### PR TITLE
Handle case where sfdx binary is not installed

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,6 +22,25 @@
       "preLaunchTask": "Compile"
     },
     {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch SalesforceDX Utils Tests",
+      "program": "${workspaceRoot}/packages/salesforcedx-utils-vscode/node_modules/mocha/bin/_mocha",
+      "args": [
+        "-u",
+        "tdd",
+        "--timeout",
+        "999999",
+        "--colors",
+        "--recursive",
+        "${workspaceRoot}/packages/salesforcedx-utils-vscode/out/test"
+      ],
+      "sourceMaps": true,
+      "outFiles": ["${workspaceRoot}/packages/*/out/**/*.js"],
+      "preLaunchTask": "Compile",
+      "internalConsoleOptions": "openOnSessionStart"
+    },
+    {
       "name": "Launch SalesforceDX VS Code Core Tests",
       "type": "extensionHost",
       "request": "launch",

--- a/packages/salesforcedx-utils-vscode/test/cli/commandExecutorTest.ts
+++ b/packages/salesforcedx-utils-vscode/test/cli/commandExecutorTest.ts
@@ -1,6 +1,10 @@
 import { expect } from 'chai';
 
-import { CliCommandExecutor, SfdxCommandBuilder } from '../../src/cli';
+import {
+  CliCommandExecutor,
+  CommandBuilder,
+  SfdxCommandBuilder
+} from '../../src/cli';
 
 describe('CommandExecutor tests', () => {
   describe('Handle listeners on stdout and stderr', () => {
@@ -17,7 +21,7 @@ describe('CommandExecutor tests', () => {
       const exitCode = await new Promise<string>((resolve, reject) => {
         execution.processExitSubject.subscribe(
           data => {
-            resolve(data !== null ? data.toString() : '');
+            resolve(data != undefined ? data.toString() : '');
           },
           err => {
             reject(err);
@@ -45,7 +49,7 @@ describe('CommandExecutor tests', () => {
       const exitCode = await new Promise<string>((resolve, reject) => {
         execution.processExitSubject.subscribe(
           data => {
-            resolve(data !== null ? data.toString() : '');
+            resolve(data != undefined ? data.toString() : '');
           },
           err => {
             reject(err);
@@ -56,6 +60,28 @@ describe('CommandExecutor tests', () => {
       expect(exitCode).to.not.equal('0');
       expect(stdout).to.contain('');
       expect(stderr).to.contain('Error: Unexpected flag --unknown');
+    });
+  });
+
+  describe('Handle listeners on error', () => {
+    it('Should relay error event', async () => {
+      const execution = new CliCommandExecutor(
+        new CommandBuilder('bogus').build(),
+        {}
+      ).execute();
+
+      const errorData = await new Promise<string>((resolve, reject) => {
+        execution.processErrorSubject.subscribe(
+          data => {
+            resolve(data != undefined ? data.toString() : '');
+          },
+          err => {
+            reject(err);
+          }
+        );
+      });
+
+      expect(errorData).to.equal('Error: spawn bogus ENOENT');
     });
   });
 });

--- a/packages/salesforcedx-vscode-apex/src/language-server.ts
+++ b/packages/salesforcedx-vscode-apex/src/language-server.ts
@@ -1,14 +1,14 @@
-import * as vscode from 'vscode';
 import * as child_process from 'child_process';
-import * as path from 'path';
 import * as net from 'net';
+import * as path from 'path';
 import * as portFinder from 'portfinder';
-import * as requirements from './requirements';
+import * as vscode from 'vscode';
 import {
   LanguageClient,
   LanguageClientOptions,
   StreamInfo
 } from 'vscode-languageclient';
+import * as requirements from './requirements';
 
 const UBER_JAR_NAME = 'apex-jorje-lsp.jar';
 const JDWP_DEBUG_PORT = 2739;

--- a/packages/salesforcedx-vscode-apex/src/requirements.ts
+++ b/packages/salesforcedx-vscode-apex/src/requirements.ts
@@ -1,8 +1,8 @@
 // From https://github.com/redhat-developer/vscode-java
 // Original version licensed under the Eclipse Public License (EPL)
 
-import { workspace } from 'vscode';
 import * as cp from 'child_process';
+import { workspace } from 'vscode';
 
 import pathExists = require('path-exists');
 

--- a/packages/salesforcedx-vscode-core/src/channels/channelService.ts
+++ b/packages/salesforcedx-vscode-core/src/channels/channelService.ts
@@ -37,10 +37,26 @@ export class ChannelService {
     execution.processExitSubject.subscribe(data => {
       this.channel.append(execution.command.toString());
       this.channel.append(' ');
-      if (data !== null) {
+      if (data != undefined) {
         this.channel.appendLine(
           localize('channel_end_with_exit_code', data.toString())
         );
+      } else {
+        this.channel.appendLine(localize('channel_end'));
+      }
+    });
+
+    execution.processErrorSubject.subscribe(data => {
+      this.channel.append(execution.command.toString());
+      this.channel.append(' ');
+      if (data != undefined) {
+        this.channel.appendLine(
+          localize('channel_end_with_error', data.toString())
+        );
+
+        if (/sfdx.*ENOENT/.test(data.message)) {
+          this.channel.appendLine(localize('channel_end_with_sfdx_not_found'));
+        }
       } else {
         this.channel.appendLine(localize('channel_end'));
       }

--- a/packages/salesforcedx-vscode-core/src/commands/forceApexTestRun.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexTestRun.ts
@@ -1,9 +1,9 @@
-import * as path from 'path';
-import * as vscode from 'vscode';
 import {
   CliCommandExecutor,
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import * as path from 'path';
+import * as vscode from 'vscode';
 import { channelService } from '../channels';
 import { notificationService } from '../notifications';
 import { CancellableStatusBar, taskViewService } from '../statuses';

--- a/packages/salesforcedx-vscode-core/src/commands/forceAuthWebLogin.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceAuthWebLogin.ts
@@ -1,8 +1,8 @@
-import * as vscode from 'vscode';
 import {
   CliCommandExecutor,
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import * as vscode from 'vscode';
 import { channelService } from '../channels';
 import { notificationService } from '../notifications';
 import { CancellableStatusBar, taskViewService } from '../statuses';

--- a/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
@@ -1,9 +1,9 @@
-import * as path from 'path';
-import * as vscode from 'vscode';
 import {
   CliCommandExecutor,
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import * as path from 'path';
+import * as vscode from 'vscode';
 import { channelService } from '../channels';
 import { notificationService } from '../notifications';
 import { CancellableStatusBar, taskViewService } from '../statuses';

--- a/packages/salesforcedx-vscode-core/src/commands/forceOrgOpen.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceOrgOpen.ts
@@ -1,8 +1,8 @@
-import * as vscode from 'vscode';
 import {
   CliCommandExecutor,
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import * as vscode from 'vscode';
 import { channelService } from '../channels';
 import { notificationService } from '../notifications';
 import { CancellableStatusBar, taskViewService } from '../statuses';

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourcePull.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourcePull.ts
@@ -1,8 +1,8 @@
-import * as vscode from 'vscode';
 import {
   CliCommandExecutor,
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import * as vscode from 'vscode';
 import { channelService } from '../channels';
 import { notificationService } from '../notifications';
 import { CancellableStatusBar, taskViewService } from '../statuses';

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourcePush.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourcePush.ts
@@ -1,8 +1,8 @@
-import * as vscode from 'vscode';
 import {
   CliCommandExecutor,
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import * as vscode from 'vscode';
 import { channelService } from '../channels';
 import { notificationService } from '../notifications';
 import { CancellableStatusBar, taskViewService } from '../statuses';

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceStatus.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceStatus.ts
@@ -1,8 +1,8 @@
-import * as vscode from 'vscode';
 import {
   CliCommandExecutor,
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import * as vscode from 'vscode';
 import { channelService } from '../channels';
 import { notificationService } from '../notifications';
 import { CancellableStatusBar, taskViewService } from '../statuses';

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -1,7 +1,5 @@
 import * as vscode from 'vscode';
 
-import * as scratchOrgDecorator from './scratch-org-decorator';
-import { CANCEL_EXECUTION_COMMAND, cancelCommandExecution } from './statuses';
 import {
   forceApexTestRun,
   forceAuthWebLogin,
@@ -12,6 +10,8 @@ import {
   forceSourceStatus,
   forceTaskStop
 } from './commands';
+import * as scratchOrgDecorator from './scratch-org-decorator';
+import { CANCEL_EXECUTION_COMMAND, cancelCommandExecution } from './statuses';
 import { taskViewService } from './statuses';
 
 function registerCommands(): vscode.Disposable {

--- a/packages/salesforcedx-vscode-core/src/messages/index.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/index.ts
@@ -47,6 +47,9 @@ const messages: Messages = {
     channel_name: 'SalesforceDX CLI',
     channel_starting_message: 'Starting ',
     channel_end_with_exit_code: 'ended with exit code %s',
+    channel_end_with_sfdx_not_found:
+      'The SFDX CLI is not installed. Install it from https://developer.salesforce.com/tools/sfdxcli',
+    channel_end_with_error: 'ended with error %s',
     channel_end: 'ended',
 
     notification_successful_execution_message: 'Successfully executed %s',

--- a/packages/salesforcedx-vscode-core/src/scratch-org-decorator.ts
+++ b/packages/salesforcedx-vscode-core/src/scratch-org-decorator.ts
@@ -1,6 +1,6 @@
-import { window, workspace, StatusBarItem, StatusBarAlignment } from 'vscode';
-import * as path from 'path';
 import * as fs from 'fs';
+import * as path from 'path';
+import { StatusBarAlignment, StatusBarItem, window, workspace } from 'vscode';
 
 const CONFIG_FILE = path.join(workspace.rootPath!, '.sfdx/sfdx-config.json');
 

--- a/packages/salesforcedx-vscode-core/src/statuses/statusBar.ts
+++ b/packages/salesforcedx-vscode-core/src/statuses/statusBar.ts
@@ -1,10 +1,10 @@
+import { CommandExecution } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import {
   CancellationTokenSource,
-  StatusBarItem,
   StatusBarAlignment,
+  StatusBarItem,
   window
 } from 'vscode';
-import { CommandExecution } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import { localize } from '../../src/messages';
 
 export const CANCEL_EXECUTION_COMMAND = 'internal.cancel.execution.command';
@@ -51,6 +51,12 @@ export class CancellableStatusBar {
     }
     statusTimer = setInterval(() => cycleStatusBarText(statusBarItem), 1000);
     execution.processExitSubject.subscribe(data => {
+      if (statusTimer) {
+        clearInterval(statusTimer);
+      }
+      resetStatusBarItem();
+    });
+    execution.processErrorSubject.subscribe(data => {
       if (statusTimer) {
         clearInterval(statusTimer);
       }

--- a/packages/salesforcedx-vscode-core/src/statuses/taskView.ts
+++ b/packages/salesforcedx-vscode-core/src/statuses/taskView.ts
@@ -1,3 +1,4 @@
+import { CommandExecution } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import {
   CancellationTokenSource,
   Event,
@@ -6,7 +7,6 @@ import {
   TreeItem,
   TreeItemCollapsibleState
 } from 'vscode';
-import { CommandExecution } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import { localize } from '../messages';
 
 export class TaskViewService implements TreeDataProvider<Task> {
@@ -105,6 +105,9 @@ export class Task extends TreeItem {
 
   public monitor() {
     this.execution.processExitSubject.subscribe(data => {
+      this.taskViewProvider.removeTask(this);
+    });
+    this.execution.processErrorSubject.subscribe(data => {
       this.taskViewProvider.removeTask(this);
     });
   }

--- a/packages/salesforcedx-vscode-core/test/statuses/statusBar.test.ts
+++ b/packages/salesforcedx-vscode-core/test/statuses/statusBar.test.ts
@@ -1,22 +1,22 @@
 // tslint:disable:no-unused-expression
 
+import {
+  CliCommandExecutor,
+  CommandExecution,
+  SfdxCommandBuilder
+} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import { expect } from 'chai';
 import { CancellationTokenSource, StatusBarItem } from 'vscode';
-import {
-  SfdxCommandBuilder,
-  CliCommandExecutor,
-  CommandExecution
-} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import { localize } from '../../src/messages';
 import {
   CANCEL_EXECUTION_COMMAND,
-  CancellableStatusBar,
   cancelCommandExecution,
+  CancellableStatusBar,
   cancellationTokenSource,
   cycleStatusBarText,
   statusBarItem,
   statusTimer
 } from '../../src/statuses/statusBar';
-import { localize } from '../../src/messages';
 
 describe('Status Bar', () => {
   let tokenSource: CancellationTokenSource;

--- a/packages/salesforcedx-vscode-core/test/statuses/taskView.test.ts
+++ b/packages/salesforcedx-vscode-core/test/statuses/taskView.test.ts
@@ -1,14 +1,15 @@
 // tslint:disable:no-unused-expression
 
-import { stub } from 'sinon';
-import { expect } from 'chai';
-import { CancellationTokenSource } from 'vscode';
 import {
-  SfdxCommandBuilder,
-  CliCommandExecutor
+  CliCommandExecutor,
+  CommandBuilder,
+  SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
-import { Task, TaskViewService } from '../../src/statuses/taskView';
+import { expect } from 'chai';
+import { stub } from 'sinon';
+import { CancellationTokenSource } from 'vscode';
 import { localize } from '../../src/messages';
+import { Task, TaskViewService } from '../../src/statuses/taskView';
 
 describe('Task View', () => {
   describe('Task View Provider', () => {
@@ -123,6 +124,25 @@ describe('Task View', () => {
       const taskViewService = new TaskViewService();
       const execution = new CliCommandExecutor(
         new SfdxCommandBuilder().withArg('force').withArg('--help').build(),
+        {}
+      ).execute();
+      taskViewService.addCommandExecution(execution);
+
+      expect(taskViewService.getChildren()).to.have.lengthOf(1);
+
+      await new Promise((resolve, reject) => {
+        taskViewService.onDidChangeTreeData(e => {
+          resolve(e);
+        });
+      });
+
+      expect(taskViewService.getChildren()).to.have.lengthOf(0);
+    });
+
+    it('Should remove itself from Task View if erroneous', async () => {
+      const taskViewService = new TaskViewService();
+      const execution = new CliCommandExecutor(
+        new CommandBuilder('sfdx_').build(),
         {}
       ).execute();
       taskViewService.addCommandExecution(execution);

--- a/packages/salesforcedx-vscode-lightning/test/fileAssociations.test.ts
+++ b/packages/salesforcedx-vscode-lightning/test/fileAssociations.test.ts
@@ -1,5 +1,5 @@
-import * as vscode from 'vscode';
 import { expect } from 'chai';
+import * as vscode from 'vscode';
 
 const PERFECT_MATCH = 10;
 

--- a/packages/salesforcedx-vscode-visualforce/test/fileAssociations.test.ts
+++ b/packages/salesforcedx-vscode-visualforce/test/fileAssociations.test.ts
@@ -1,5 +1,5 @@
-import * as vscode from 'vscode';
 import { expect } from 'chai';
+import * as vscode from 'vscode';
 
 const PERFECT_MATCH = 10;
 

--- a/tslint.json
+++ b/tslint.json
@@ -1,106 +1,83 @@
 // From https://github.com/palantir/tslint/blob/master/docs/sample.tslint.json
 {
-    "rules": {
-        "class-name": true,
-        "curly": true,
-        "forin": true,
-        "jsdoc-format": true,
-        "label-position": true,
-        "member-access": true,
-        "new-parens": true,
-        "no-any": false,
-        "no-arg": true,
-        "no-bitwise": true,
-        "no-conditional-assignment": true,
-        "no-consecutive-blank-lines": false,
-        "no-console": [
-            true,
-            "debug",
-            "info",
-            "time",
-            "timeEnd",
-            "trace"
-        ],
-        "no-construct": true,
-        "no-debugger": true,
-        "no-duplicate-variable": true,
-        "no-empty": true,
-        "no-eval": true,
-        "no-inferrable-types": [
-            true,
-            "ignore-params"
-        ],
-        "no-internal-module": true,
-        "no-invalid-this": [
-            true,
-            "check-function-in-method"
-        ],
-        "no-shadowed-variable": true,
-        "no-switch-case-fall-through": true,
-        "no-trailing-whitespace": true,
-        "no-unused-expression": true,
-        "no-unused-variable": true,
-        "no-var-keyword": true,
-        "no-var-requires": true,
-        "one-line": [
-            true,
-            "check-open-brace",
-            "check-catch",
-            "check-else",
-            "check-finally",
-            "check-whitespace"
-        ],
-        "prefer-const": [
-            true,
-            {
-                "destructuring": "all"
-            }
-        ],
-        "quotemark": [
-            true,
-            "single",
-            "avoid-escape"
-        ],
-        "semicolon": [
-            true,
-            "always"
-        ],
-        "triple-equals": [
-            true,
-            "allow-null-check",
-            "allow-undefined-check"
-        ],
-        "typedef-whitespace": [
-            true,
-            {
-                "call-signature": "nospace",
-                "index-signature": "nospace",
-                "parameter": "nospace",
-                "property-declaration": "nospace",
-                "variable-declaration": "nospace"
-            },
-            {
-                "call-signature": "space",
-                "index-signature": "space",
-                "parameter": "space",
-                "property-declaration": "space",
-                "variable-declaration": "space"
-            }
-        ],
-        "use-isnan": true,
-        "variable-name": [
-            true,
-            "check-format",
-            "allow-leading-underscore",
-            "ban-keywords"
-        ],
-        "whitespace": [
-            true,
-            "check-branch",
-            "check-decl",
-            "check-operator",
-            "check-separator",
-            "check-type"
-        ]
-    }
+  "rules": {
+    "class-name": true,
+    "curly": true,
+    "forin": true,
+    "jsdoc-format": true,
+    "label-position": true,
+    "member-access": true,
+    "new-parens": true,
+    "no-any": false,
+    "no-arg": true,
+    "no-bitwise": true,
+    "no-conditional-assignment": true,
+    "no-consecutive-blank-lines": false,
+    "no-console": [true, "debug", "info", "time", "timeEnd", "trace"],
+    "no-construct": true,
+    "no-debugger": true,
+    "no-duplicate-variable": true,
+    "no-empty": true,
+    "no-eval": true,
+    "no-inferrable-types": [true, "ignore-params"],
+    "no-internal-module": true,
+    "no-invalid-this": [true, "check-function-in-method"],
+    "no-shadowed-variable": true,
+    "no-switch-case-fall-through": true,
+    "no-trailing-whitespace": true,
+    "no-unused-expression": true,
+    "no-unused-variable": true,
+    "no-var-keyword": true,
+    "no-var-requires": true,
+    "one-line": [
+      true,
+      "check-open-brace",
+      "check-catch",
+      "check-else",
+      "check-finally",
+      "check-whitespace"
+    ],
+    "ordered-imports": [true],
+    "prefer-const": [
+      true,
+      {
+        "destructuring": "all"
+      }
+    ],
+    "quotemark": [true, "single", "avoid-escape"],
+    "semicolon": [true, "always"],
+    "triple-equals": [true, "allow-null-check", "allow-undefined-check"],
+    "typedef-whitespace": [
+      true,
+      {
+        "call-signature": "nospace",
+        "index-signature": "nospace",
+        "parameter": "nospace",
+        "property-declaration": "nospace",
+        "variable-declaration": "nospace"
+      },
+      {
+        "call-signature": "space",
+        "index-signature": "space",
+        "parameter": "space",
+        "property-declaration": "space",
+        "variable-declaration": "space"
+      }
+    ],
+    "use-isnan": true,
+    "variable-name": [
+      true,
+      "check-format",
+      "allow-leading-underscore",
+      "ban-keywords"
+    ],
+    "whitespace": [
+      true,
+      "check-branch",
+      "check-decl",
+      "check-operator",
+      "check-separator",
+      "check-type"
+    ]
+  }
 }


### PR DESCRIPTION
### What does this PR do?

Handles the case where the SFDX binary is not installed. 

Running a command and failing is different from not being able to run a command. The first is captured in the 'exit' event. The latter is captured in the 'error' event. See https://nodejs.org/api/child_process.html#child_process_class_childprocess for more information.

### What issues does this PR fix or reference?

@W-4146476@