### PR TITLE
Add custom qna attribute to package.json

### DIFF
--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -3,6 +3,7 @@
   "name": "salesforcedx-vscode-apex-debugger",
   "displayName": "Apex Debugger for Visual Studio Code",
   "description": "Provides debugging support for the Apex programming language",
+  "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",
   "icon": "images/icon.png",
   "galleryBanner": {
     "color": "#ECECEC",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -3,6 +3,7 @@
   "name": "salesforcedx-vscode-apex",
   "displayName": "Apex Code Editor for Visual Studio Code",
   "description": "Provides code-completion for the Apex programming language",
+  "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",
   "icon": "images/icon.png",
   "galleryBanner": {
     "color": "#ECECEC",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -3,6 +3,7 @@
   "name": "salesforcedx-vscode-core",
   "displayName": "SFDX CLI integration for Visual Studio Code",
   "description": "Provides integration with the SFDX CLI",
+  "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",
   "icon": "images/icon.png",
   "galleryBanner": {
     "color": "#ECECEC",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -3,6 +3,7 @@
   "name": "salesforcedx-vscode-lightning",
   "displayName": "Lightning Code Editor for Visual Studio Code",
   "description": "Provides syntax highlighting for Lightning framework",
+  "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",
   "icon": "images/icon.png",
   "galleryBanner": {
     "color": "#ECECEC",

--- a/packages/salesforcedx-vscode-visualforce/package.json
+++ b/packages/salesforcedx-vscode-visualforce/package.json
@@ -3,6 +3,7 @@
   "name": "salesforcedx-vscode-visualforce",
   "displayName": "Visualforce Code Editor for Visual Studio Code",
   "description": "Provides syntax highlighting for Visualforce framework",
+  "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",
   "icon": "images/icon.png",
   "galleryBanner": {
     "color": "#ECECEC",

--- a/packages/salesforcedx-vscode/package.json
+++ b/packages/salesforcedx-vscode/package.json
@@ -3,6 +3,7 @@
   "name": "salesforcedx-vscode",
   "displayName": "Visual Studio Code Extension Pack for Salesforce DX",
   "description": "Collection of extensions for Salesforce DX",
+  "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",
   "icon": "images/icon.png",
   "galleryBanner": {
     "color": "#ECECEC",


### PR DESCRIPTION
### What does this PR do?

This disables the default QnA on the marketplace and allows us to redirect to the GitHub page. This helps prevent yet another QnA site (we already have success community, GitHub issues, etc)

This uses a unpublished attribute in vscode-vsce. See https://github.com/Microsoft/vscode-vsce/blob/f27aa315121e3761f11691db9e129aa8cd276e26/src/package.ts#L155

### What issues does this PR fix or reference?

None. Small change.
