### PR TITLE
Transform URI on Windows prior to sending over

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/index.ts
@@ -7,7 +7,7 @@
 
 import * as vscode from 'vscode';
 import { APEX_LANGUAGE_SERVER_CHANNEL } from './channel';
-import * as languageServer from './language-server';
+import * as languageServer from './languageServer';
 
 export function activate(context: vscode.ExtensionContext) {
   APEX_LANGUAGE_SERVER_CHANNEL.appendLine(

--- a/packages/salesforcedx-vscode-apex/src/languageServer.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageServer.ts
@@ -114,6 +114,21 @@ function startedInDebugMode(): boolean {
   return false;
 }
 
+// See https://github.com/Microsoft/vscode-languageserver-node/issues/105
+export function code2ProtocolConverter(value: vscode.Uri) {
+  if (/^win32/.test(process.platform)) {
+    // The *first* : is also being encoded which is not the standard for URI on Windows
+    // Here we transform it back to the standard way
+    return value.toString().replace('%3A', ':');
+  } else {
+    return value.toString();
+  }
+}
+
+function protocol2CodeConverter(value: string) {
+  return vscode.Uri.parse(value);
+}
+
 export function createLanguageServer(
   context: vscode.ExtensionContext
 ): LanguageClient {
@@ -127,6 +142,10 @@ export function createLanguageServer(
         vscode.workspace.createFileSystemWatcher('**/*.trigger'), // Apex triggers
         vscode.workspace.createFileSystemWatcher('**/sfdx-project.json') // SFDX workspace configuration file
       ]
+    },
+    uriConverters: {
+      code2Protocol: code2ProtocolConverter,
+      protocol2Code: protocol2CodeConverter
     }
   };
 

--- a/packages/salesforcedx-vscode-apex/test/languageServer.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/languageServer.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+// tslint:disable:no-unused-expression
+
+import { expect } from 'chai';
+import { Uri } from 'vscode';
+import { code2ProtocolConverter } from '../src/languageServer';
+
+describe('Apex Language Server Client', () => {
+  describe('Should properly handle sending URI to server on Windows', () => {
+    let originalPlatform: PropertyDescriptor;
+
+    before(() => {
+      originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+    });
+
+    after(() => {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    });
+
+    it('Should only replace first :', () => {
+      const actual = code2ProtocolConverter(
+        Uri.parse('file:///c%3A/path/to/file/with%20%3A%20in%20name')
+      );
+      expect(actual).to.be.eql(
+        'file:///c:/path/to/file/with%20%3A%20in%20name'
+      );
+    });
+  });
+
+  describe('Should properly handle sending URI to server on *nix', () => {
+    let originalPlatform: PropertyDescriptor;
+
+    before(() => {
+      originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+    });
+
+    after(() => {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    });
+
+    it('Should not replace first :', () => {
+      const actual = code2ProtocolConverter(
+        Uri.parse('file:///path/to/file/with%20%3A%20in%20name')
+      );
+      expect(actual).to.be.eql('file:///path/to/file/with%20%3A%20in%20name');
+    });
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Due to https://github.com/Microsoft/vscode-languageserver-node/issues/105 the URI that is being sent to the Apex Language Server protocol does not conform to the standard. As such, the Apex Language Server is  confused on what to invalidate. This simple pre-transformation will fix the encoding to match the standard (and what Java expects).

### What issues does this PR fix or reference?

@W-4192006@
