### PR TITLE
Change image URLs to use raw.githubusercontent.com

### DIFF
--- a/packages/salesforcedx-vscode-apex/README.md
+++ b/packages/salesforcedx-vscode-apex/README.md
@@ -11,17 +11,17 @@ Currently, Visual Studio Code extensions are not signed or verified on the Micro
 
 ## View Code-Completion Suggestions
 To see code-completion suggestions, press Ctrl+space when you’re working in a `.cls` or `.trigger` file. To navigate between the suggestions, use the arrow keys. To auto-complete a suggestion from the list, press Enter.  
-![Animation showing code completion of a System.debug() statement](https://github.com/forcedotcom/salesforcedx-vscode/blob/develop/packages/salesforcedx-vscode-apex/images/apex_completion.gif)
+![Animation showing code completion of a System.debug() statement](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-apex/images/apex_completion.gif)
 
 ## Check Syntax Errors in Your Code
 If you leave out a `;`, `}`, or `)`, the syntax error is marked with a red squiggly line in the editor.  
 
 The Problems view in the bottom pane also lists the syntax errors. Double-click the problem to go to the source file.  
-![Problems view, showing a missing semicolon in an Apex class](https://github.com/forcedotcom/salesforcedx-vscode/blob/develop/packages/salesforcedx-vscode-apex/images/apex_problems.png)
+![Problems view, showing a missing semicolon in an Apex class](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-apex/images/apex_problems.png)
 
 ## View an Outline of Your Apex Class or Trigger
 The Apex outline view shows the structure of the Apex class or trigger that’s open in the editor. For a list of the symbols in your file, press Cmd+Shift+O (macOS) or Ctrl+Shift+O (Windows or Linux). To jump to one of the symbols, select it in the list.  
-![Outline view, showing the symbols in an Apex class](https://github.com/forcedotcom/salesforcedx-vscode/blob/develop/packages/salesforcedx-vscode-apex/images/apex_outline.png)
+![Outline view, showing the symbols in an Apex class](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-apex/images/apex_outline.png)
 
 ## Monitor Apex Language Server Output
 The Apex Language Server is an implementation of the [Language Server Protocol](https://github.com/Microsoft/language-server-protocol) 3.0 specification. The Language Server Protocol allows a tool (in this case, VS Code) to communicate with a language smartness provider (the server). VS Code uses the Apex Language Server to show outlines of Apex classes and triggers, code-completion suggestions, and syntactic errors. To see all diagnostic information from the Apex Language Server, select **View** > **Output**, then choose **Apex Language Server** from the dropdown menu. The diagnostic information gives you insights into the progress of the language server and shows the problems  encountered.  

--- a/packages/salesforcedx-vscode-core/README.md
+++ b/packages/salesforcedx-vscode-core/README.md
@@ -11,21 +11,21 @@ Currently, Visual Studio Code extensions are not signed or verified on the Micro
 
 ## Run Salesforce CLI Commands
 To run a command from the Salesforce Development Tools for Visual Studio Code extensions, press Cmd+Shift+P (macOS) or Ctrl+Shift+P (Windows or Linux) and type **SFDX** in the command palette.  
-![Command palette, filtered to show SFDX commands](https://github.com/forcedotcom/salesforcedx-vscode/blob/develop/packages/salesforcedx-vscode-core/images/sfdx_commands.png)
+![Command palette, filtered to show SFDX commands](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-core/images/sfdx_commands.png)
 
 When a command finishes running (due to success, failure, or cancellation), a notification displays at the top of the window.  
-![Notification that source was successfully pushed to a scratch org](https://github.com/forcedotcom/salesforcedx-vscode/blob/develop/packages/salesforcedx-vscode-core/images/command_success_notification.png)
+![Notification that source was successfully pushed to a scratch org](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-core/images/command_success_notification.png)
 
 To see the output of the commands that you run, select **View** > **Output**, and then select **Salesforce DX CLI** from the dropdown menu. Alternatively, click **Show** in the completion notification.  
-![Output view, showing the results of an Apex test run](https://github.com/forcedotcom/salesforcedx-vscode/blob/develop/packages/salesforcedx-vscode-core/images/output_view.png)
+![Output view, showing the results of an Apex test run](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-core/images/output_view.png)
 
 ## View Your Active Scratch Org
 A badge in the footer shows your current default scratch org. It uses the org’s auto-generated username or the alias that you chose for the org.  
-![Username for default scratch org, displayed in footer](https://github.com/forcedotcom/salesforcedx-vscode/blob/develop/packages/salesforcedx-vscode-core/images/active_scratch_org.png)
+![Username for default scratch org, displayed in footer](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-core/images/active_scratch_org.png)
 
 ## View Your Running Tasks
 To check your running tasks, expand the Running Tasks view in the Explorer.  
-![Running Tasks view, showing that Apex tests are running](https://github.com/forcedotcom/salesforcedx-vscode/blob/develop/packages/salesforcedx-vscode-core/images/running_tasks.png)
+![Running Tasks view, showing that Apex tests are running](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-core/images/running_tasks.png)
 
 ## Resources
 * Trailhead: [Get Started with Salesforce DX](https://trailhead.salesforce.com/trails/sfdx_get_started)

--- a/packages/salesforcedx-vscode-lightning/README.md
+++ b/packages/salesforcedx-vscode-lightning/README.md
@@ -14,18 +14,18 @@ Currently, Visual Studio Code extensions are not signed or verified on the Micro
    * HTML portions
    * Embedded CSS and JavaScript portions  
    
-   ![Colored syntax highlighting in a .js file from a Lightning bundle](https://github.com/forcedotcom/salesforcedx-vscode/blob/develop/packages/salesforcedx-vscode-lightning/images/lightning_syntax.png)
+   ![Colored syntax highlighting in a .js file from a Lightning bundle](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-lightning/images/lightning_syntax.png)
 
 * Code completion
    * HTML tags
    * CSS
    * JavaScript  
    
-   ![Code-completion options in a .js file from a Lightning bundle](https://github.com/forcedotcom/salesforcedx-vscode/blob/develop/packages/salesforcedx-vscode-lightning/images/lightning_completion.png)
+   ![Code-completion options in a .js file from a Lightning bundle](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-lightning/images/lightning_completion.png)
 
 * Outline view  
 
-   ![List of symbols in a .js file from a Lightning bundle](https://github.com/forcedotcom/salesforcedx-vscode/blob/develop/packages/salesforcedx-vscode-lightning/images/lightning_outline.png)
+   ![List of symbols in a .js file from a Lightning bundle](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-lightning/images/lightning_outline.png)
 
 ## Resources
 * Trailhead: [Get Started with Salesforce DX](https://trailhead.salesforce.com/trails/sfdx_get_started)

--- a/packages/salesforcedx-vscode-visualforce/README.md
+++ b/packages/salesforcedx-vscode-visualforce/README.md
@@ -14,18 +14,18 @@ Currently, Visual Studio Code extensions are not signed or verified on the Micro
    * HTML portions
    * Embedded CSS and JavaScript portions  
    
-   ![Colored syntax highlighting in a .page file](https://github.com/forcedotcom/salesforcedx-vscode/blob/develop/packages/salesforcedx-vscode-visualforce/images/visualforce_syntax.png)
+   ![Colored syntax highlighting in a .page file](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-visualforce/images/visualforce_syntax.png)
 
 * Code completion
    * HTML tags
    * CSS
    * JavaScript  
    
-   ![Code-completion options in a .page file](https://github.com/forcedotcom/salesforcedx-vscode/blob/develop/packages/salesforcedx-vscode-visualforce/images/visualforce_completion.png)
+   ![Code-completion options in a .page file](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-visualforce/images/visualforce_completion.png)
 
 * Outline view  
 
-   ![List of symbols in a .page file](https://github.com/forcedotcom/salesforcedx-vscode/blob/develop/packages/salesforcedx-vscode-visualforce/images/visualforce_outline.png)
+   ![List of symbols in a .page file](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-visualforce/images/visualforce_outline.png)
 
 ## Resources
 * Trailhead: [Get Started with Salesforce DX](https://trailhead.salesforce.com/trails/sfdx_get_started)

--- a/packages/salesforcedx-vscode/README.md
+++ b/packages/salesforcedx-vscode/README.md
@@ -11,7 +11,7 @@ This release contains a beta version of Salesforce Development Tools for Visual 
 Currently, Visual Studio Code extensions are not signed or verified on the Microsoft Visual Studio Code Marketplace. Salesforce provides the Secure Hash Algorithm (SHA) of each extension that we publish. Please consult [Manually Verify the salesforcedx-vscode Extensions’ Authenticity](https://developer.salesforce.com/media/vscode/SHA256.md) to learn how to verify the extensions.  
 
 ---
-![GIF showing Apex code completion, pushing source to a scratch org, and running Apex tests](https://github.com/forcedotcom/salesforcedx-vscode/blob/develop/packages/salesforcedx-vscode/images/overview.gif)  
+![GIF showing Apex code completion, pushing source to a scratch org, and running Apex tests](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode/images/overview.gif)  
 
 ### Extensions Included  
 To use Salesforce Development Tools for Visual Studio Code, install all the extensions in this bundle.


### PR DESCRIPTION
### What does this PR do?
Updates image URLs to use `raw.githubusercontent.com` instead of `github.com` and to remove `/blob`, so that images will load properly in the VS Code Marketplace.

### What issues does this PR fix or reference?
@W-4166826@