### PR TITLE
Add await for test

### DIFF
--- a/packages/salesforcedx-vscode-lightning/test/fileAssociations.test.ts
+++ b/packages/salesforcedx-vscode-lightning/test/fileAssociations.test.ts
@@ -21,30 +21,30 @@ async function matchExtensionAsHtml(extension: string) {
 
 describe('Lightning file association', () => {
   it('Should support .app association', async () => {
-    matchExtensionAsHtml('.app');
+    await matchExtensionAsHtml('.app');
   });
 
   it('Should support .cmp association', async () => {
-    matchExtensionAsHtml('.cmp');
+    await matchExtensionAsHtml('.cmp');
   });
 
   it('Should support .design association', async () => {
-    matchExtensionAsHtml('.design');
+    await matchExtensionAsHtml('.design');
   });
 
   it('Should support .evt association', async () => {
-    matchExtensionAsHtml('.evt');
+    await matchExtensionAsHtml('.evt');
   });
 
   it('Should support.intf association', async () => {
-    matchExtensionAsHtml('.intf');
+    await matchExtensionAsHtml('.intf');
   });
 
   it('Should support .auradoc association', async () => {
-    matchExtensionAsHtml('.auradoc');
+    await matchExtensionAsHtml('.auradoc');
   });
 
   it('Should support .tokens association', async () => {
-    matchExtensionAsHtml('.tokens');
+    await matchExtensionAsHtml('.tokens');
   });
 });

--- a/packages/salesforcedx-vscode-visualforce/test/fileAssociations.test.ts
+++ b/packages/salesforcedx-vscode-visualforce/test/fileAssociations.test.ts
@@ -21,10 +21,10 @@ async function matchExtensionAsHtml(extension: string) {
 
 describe('Visualforce file association', () => {
   it('Should support .page association', async () => {
-    matchExtensionAsHtml('.page');
+    await matchExtensionAsHtml('.page');
   });
 
   it('Should support .component association', async () => {
-    matchExtensionAsHtml('.component');
+    await matchExtensionAsHtml('.component');
   });
 });


### PR DESCRIPTION
### What does this PR do?

For these tests to detect pass/failure on the command line, you need to be sure to add the `await`. 

I did not notice the missing `await` since I usually run them from VS Code's debug menu which will fail tests on unhandled promised rejections.

But, for CI, we need the `await`.

I verified that there was no regression and that is a test issue.
