### PR TITLE
Adds a framework for command precondition-checking, parameter gathering, and execution

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/predicates/predicate.ts
+++ b/packages/salesforcedx-utils-vscode/src/predicates/predicate.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+// This file is meant to mimics the functionality of Predicate and Predicates from Google Guava.
+// Expand as necessary.
+
+export interface Predicate<T> {
+  apply(item: T): PredicateResponse;
+}
+export class PredicateResponse {
+  public result: boolean;
+  public message: string;
+
+  private constructor(result: boolean, message: string) {
+    this.result = result;
+    this.message = message;
+  }
+
+  public static of(result: boolean, message: string): PredicateResponse {
+    return new PredicateResponse(result, message);
+  }
+
+  public static true(): PredicateResponse {
+    return new PredicateResponse(true, '');
+  }
+
+  public static false(): PredicateResponse {
+    return new PredicateResponse(false, 'GENERAL ERROR');
+  }
+}

--- a/packages/salesforcedx-utils-vscode/src/predicates/predicate.ts
+++ b/packages/salesforcedx-utils-vscode/src/predicates/predicate.ts
@@ -11,6 +11,7 @@
 export interface Predicate<T> {
   apply(item: T): PredicateResponse;
 }
+
 export class PredicateResponse {
   public result: boolean;
   public message: string;

--- a/packages/salesforcedx-vscode-core/src/commands/commands.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/commands.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  CliCommandExecutor,
+  Command
+} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { channelService } from '../channels';
+import { notificationService } from '../notifications';
+import { isSfdxProjectOpened } from '../predicates';
+import { CancellableStatusBar, taskViewService } from '../statuses';
+
+// Precondition checking
+////////////////////////
+export interface PreconditionChecker {
+  check(): boolean;
+}
+
+export class SfdxWorkspaceChecker implements PreconditionChecker {
+  public check(): boolean {
+    const result = isSfdxProjectOpened.apply(vscode.workspace);
+    if (!result.result) {
+      notificationService.showErrorMessage(result.message);
+      return false;
+    }
+    return true;
+  }
+}
+
+// Input gathering
+//////////////////
+export interface ContinueResponse<T> {
+  type: 'CONTINUE';
+  data: T;
+}
+
+export interface CancelResponse {
+  type: 'CANCEL';
+}
+
+export interface ParametersGatherer<T> {
+  gather(): Promise<CancelResponse | ContinueResponse<T>>;
+}
+
+export class EmptyParametersGatherer implements ParametersGatherer<{}> {
+  public async gather(): Promise<CancelResponse | ContinueResponse<{}>> {
+    return { type: 'CONTINUE', data: {} };
+  }
+}
+
+export type FileSelection = { file: string };
+export class FileSelector implements ParametersGatherer<FileSelection> {
+  private readonly include: string;
+  private readonly exclude?: string;
+  private readonly maxResults?: number;
+
+  constructor(include: string, exclude?: string, maxResults?: number) {
+    this.include = include;
+    this.exclude = exclude;
+    this.maxResults = maxResults;
+  }
+
+  public async gather(): Promise<
+    CancelResponse | ContinueResponse<FileSelection>
+  > {
+    const files = await vscode.workspace.findFiles(
+      this.include,
+      this.exclude,
+      this.maxResults
+    );
+    const fileItems = files.map(file => {
+      return {
+        label: path.basename(file.toString()),
+        description: file.fsPath
+      };
+    });
+    const selection = await vscode.window.showQuickPick(fileItems);
+    return selection
+      ? { type: 'CONTINUE', data: { file: selection.description.toString() } }
+      : { type: 'CANCEL' };
+  }
+}
+
+// Command Execution
+////////////////////
+export interface CommandletExecutor<T> {
+  execute(response: ContinueResponse<T>): void;
+}
+
+// Common
+
+export abstract class SfdxCommandletExecutor<T>
+  implements CommandletExecutor<T> {
+  public execute(response: ContinueResponse<T>): void {
+    const cancellationTokenSource = new vscode.CancellationTokenSource();
+    const cancellationToken = cancellationTokenSource.token;
+
+    const execution = new CliCommandExecutor(this.build(response.data), {
+      cwd: vscode.workspace.rootPath
+    }).execute(cancellationToken);
+
+    channelService.streamCommandOutput(execution);
+    notificationService.reportCommandExecutionStatus(
+      execution,
+      cancellationToken
+    );
+    CancellableStatusBar.show(execution, cancellationTokenSource);
+    taskViewService.addCommandExecution(execution, cancellationTokenSource);
+  }
+
+  public abstract build(data: T): Command;
+}
+
+export class SfdxCommandlet<T> {
+  private readonly checker: PreconditionChecker;
+  private readonly gatherer: ParametersGatherer<T>;
+  private readonly executor: CommandletExecutor<T>;
+
+  constructor(
+    checker: PreconditionChecker,
+    gatherer: ParametersGatherer<T>,
+    executor: CommandletExecutor<T>
+  ) {
+    this.checker = checker;
+    this.gatherer = gatherer;
+    this.executor = executor;
+  }
+
+  public async run(): Promise<void> {
+    if (this.checker.check()) {
+      const inputs = await this.gatherer.gather();
+
+      switch (inputs.type) {
+        case 'CONTINUE':
+          return this.executor.execute(inputs);
+        case 'CANCEL':
+          return;
+      }
+    }
+  }
+}

--- a/packages/salesforcedx-vscode-core/src/commands/forceAuthWebLogin.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceAuthWebLogin.ts
@@ -6,35 +6,38 @@
  */
 
 import {
-  CliCommandExecutor,
+  Command,
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
-import * as vscode from 'vscode';
-import { channelService } from '../channels';
 import { nls } from '../messages';
-import { notificationService } from '../notifications';
-import { CancellableStatusBar, taskViewService } from '../statuses';
+import {
+  EmptyParametersGatherer,
+  SfdxCommandlet,
+  SfdxCommandletExecutor,
+  SfdxWorkspaceChecker
+} from './commands';
 
-export function forceAuthWebLogin() {
-  const cancellationTokenSource = new vscode.CancellationTokenSource();
-  const cancellationToken = cancellationTokenSource.token;
-
-  const execution = new CliCommandExecutor(
-    new SfdxCommandBuilder()
+class ForceAuthWebLoginExecutor extends SfdxCommandletExecutor<{}> {
+  public build(data: {}): Command {
+    return new SfdxCommandBuilder()
       .withDescription(
         nls.localize('force_auth_web_login_authorize_dev_hub_text')
       )
       .withArg('force:auth:web:login')
       .withArg('--setdefaultdevhubusername')
-      .build(),
-    { cwd: vscode.workspace.rootPath }
-  ).execute(cancellationTokenSource.token);
+      .build();
+  }
+}
 
-  channelService.streamCommandOutput(execution);
-  notificationService.reportCommandExecutionStatus(
-    execution,
-    cancellationToken
-  );
-  CancellableStatusBar.show(execution, cancellationTokenSource);
-  taskViewService.addCommandExecution(execution);
+const workspaceChecker = new SfdxWorkspaceChecker();
+const parameterGatherer = new EmptyParametersGatherer();
+const executor = new ForceAuthWebLoginExecutor();
+const commandlet = new SfdxCommandlet(
+  workspaceChecker,
+  parameterGatherer,
+  executor
+);
+
+export function forceAuthWebLogin() {
+  commandlet.run();
 }

--- a/packages/salesforcedx-vscode-core/src/commands/forceOrgOpen.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceOrgOpen.ts
@@ -6,32 +6,35 @@
  */
 
 import {
-  CliCommandExecutor,
+  Command,
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
-import * as vscode from 'vscode';
-import { channelService } from '../channels';
 import { nls } from '../messages';
-import { notificationService } from '../notifications';
-import { CancellableStatusBar, taskViewService } from '../statuses';
+import {
+  EmptyParametersGatherer,
+  SfdxCommandlet,
+  SfdxCommandletExecutor,
+  SfdxWorkspaceChecker
+} from './commands';
 
-export function forceOrgOpen() {
-  const cancellationTokenSource = new vscode.CancellationTokenSource();
-  const cancellationToken = cancellationTokenSource.token;
-
-  const execution = new CliCommandExecutor(
-    new SfdxCommandBuilder()
+class ForceOrgOpenExecutor extends SfdxCommandletExecutor<{}> {
+  public build(data: {}): Command {
+    return new SfdxCommandBuilder()
       .withDescription(nls.localize('force_org_open_default_scratch_org_text'))
       .withArg('force:org:open')
-      .build(),
-    { cwd: vscode.workspace.rootPath }
-  ).execute(cancellationToken);
+      .build();
+  }
+}
 
-  channelService.streamCommandOutput(execution);
-  notificationService.reportCommandExecutionStatus(
-    execution,
-    cancellationToken
-  );
-  CancellableStatusBar.show(execution, cancellationTokenSource);
-  taskViewService.addCommandExecution(execution, cancellationTokenSource);
+const workspaceChecker = new SfdxWorkspaceChecker();
+const parameterGatherer = new EmptyParametersGatherer();
+const executor = new ForceOrgOpenExecutor();
+const commandlet = new SfdxCommandlet(
+  workspaceChecker,
+  parameterGatherer,
+  executor
+);
+
+export function forceOrgOpen() {
+  commandlet.run();
 }

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourcePull.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourcePull.ts
@@ -6,34 +6,37 @@
  */
 
 import {
-  CliCommandExecutor,
+  Command,
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
-import * as vscode from 'vscode';
-import { channelService } from '../channels';
 import { nls } from '../messages';
-import { notificationService } from '../notifications';
-import { CancellableStatusBar, taskViewService } from '../statuses';
+import {
+  EmptyParametersGatherer,
+  SfdxCommandlet,
+  SfdxCommandletExecutor,
+  SfdxWorkspaceChecker
+} from './commands';
 
-export function forceSourcePull() {
-  const cancellationTokenSource = new vscode.CancellationTokenSource();
-  const cancellationToken = cancellationTokenSource.token;
-
-  const execution = new CliCommandExecutor(
-    new SfdxCommandBuilder()
+class ForceSourcePullExecutor extends SfdxCommandletExecutor<{}> {
+  public build(data: {}): Command {
+    return new SfdxCommandBuilder()
       .withDescription(
         nls.localize('force_source_pull_default_scratch_org_text')
       )
       .withArg('force:source:pull')
-      .build(),
-    { cwd: vscode.workspace.rootPath }
-  ).execute(cancellationToken);
+      .build();
+  }
+}
 
-  channelService.streamCommandOutput(execution);
-  notificationService.reportCommandExecutionStatus(
-    execution,
-    cancellationToken
-  );
-  CancellableStatusBar.show(execution, cancellationTokenSource);
-  taskViewService.addCommandExecution(execution, cancellationTokenSource);
+const workspaceChecker = new SfdxWorkspaceChecker();
+const parameterGatherer = new EmptyParametersGatherer();
+const executor = new ForceSourcePullExecutor();
+const commandlet = new SfdxCommandlet(
+  workspaceChecker,
+  parameterGatherer,
+  executor
+);
+
+export function forceSourcePull() {
+  commandlet.run();
 }

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceStatus.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceStatus.ts
@@ -6,32 +6,35 @@
  */
 
 import {
-  CliCommandExecutor,
+  Command,
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
-import * as vscode from 'vscode';
-import { channelService } from '../channels';
 import { nls } from '../messages';
-import { notificationService } from '../notifications';
-import { CancellableStatusBar, taskViewService } from '../statuses';
+import {
+  EmptyParametersGatherer,
+  SfdxCommandlet,
+  SfdxCommandletExecutor,
+  SfdxWorkspaceChecker
+} from './commands';
 
-export function forceSourceStatus() {
-  const cancellationTokenSource = new vscode.CancellationTokenSource();
-  const cancellationToken = cancellationTokenSource.token;
-
-  const execution = new CliCommandExecutor(
-    new SfdxCommandBuilder()
+class ForceSourceStatusExecutor extends SfdxCommandletExecutor<{}> {
+  public build(data: {}): Command {
+    return new SfdxCommandBuilder()
       .withDescription(nls.localize('force_source_status_text'))
       .withArg('force:source:status')
-      .build(),
-    { cwd: vscode.workspace.rootPath }
-  ).execute(cancellationToken);
+      .build();
+  }
+}
 
-  channelService.streamCommandOutput(execution);
-  notificationService.reportCommandExecutionStatus(
-    execution,
-    cancellationToken
-  );
-  CancellableStatusBar.show(execution, cancellationTokenSource);
-  taskViewService.addCommandExecution(execution, cancellationTokenSource);
+const workspaceChecker = new SfdxWorkspaceChecker();
+const parameterGatherer = new EmptyParametersGatherer();
+const executor = new ForceSourceStatusExecutor();
+const commandlet = new SfdxCommandlet(
+  workspaceChecker,
+  parameterGatherer,
+  executor
+);
+
+export function forceSourceStatus() {
+  commandlet.run();
 }

--- a/packages/salesforcedx-vscode-core/src/constants.ts
+++ b/packages/salesforcedx-vscode-core/src/constants.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+export const SFDX_PROJECT_FILE = 'sfdx-project.json';

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -29,6 +29,11 @@ export const messages = {
   notification_unsuccessful_execution_text: '%s failed to run',
   notification_show_button_text: 'Show',
 
+  predicates_no_folder_opened_text:
+    'No folder opened. Open a Salesforce DX project in VS Code.',
+  predicates_no_sfdx_project_found_text:
+    'No sfdx-project.json found in the root directory of your open project. Open a Salesforce DX project in VS Code.',
+
   task_view_running_message: '[Running] %s',
 
   status_bar_text: `$(x) %s`,
@@ -50,5 +55,8 @@ export const messages = {
   force_source_status_text:
     'View All Changes (Local and in Default Scratch Org)',
 
-  force_apex_test_run_text: 'SFDX: Invoke Apex Tests...'
+  force_apex_test_run_text: 'SFDX: Invoke Apex Tests...',
+  force_apex_test_run_all_test_label: 'All tests',
+  force_apex_test_run_all_tests_desription_text:
+    'Runs all tests in the current project'
 };

--- a/packages/salesforcedx-vscode-core/src/notifications/notificationService.ts
+++ b/packages/salesforcedx-vscode-core/src/notifications/notificationService.ts
@@ -11,6 +11,9 @@ import * as vscode from 'vscode';
 import { DEFAULT_SFDX_CHANNEL } from '../channels';
 import { nls } from '../messages';
 
+/**
+ * A centralized location for all notification functionalities.
+ */
 export class NotificationService {
   private readonly channel: vscode.OutputChannel;
   private static instance: NotificationService;
@@ -24,6 +27,30 @@ export class NotificationService {
       NotificationService.instance = new NotificationService(channel);
     }
     return NotificationService.instance;
+  }
+
+  // Prefer these over directly calling the vscode.show* functions
+  // We can expand these to be facades that gather analytics of failures.
+
+  public showErrorMessage(
+    message: string,
+    ...items: string[]
+  ): Thenable<string | undefined> {
+    return vscode.window.showErrorMessage(message, ...items);
+  }
+
+  public showInformationMessage(
+    message: string,
+    ...items: string[]
+  ): Thenable<string | undefined> {
+    return vscode.window.showInformationMessage(message, ...items);
+  }
+
+  public showWarningMessage(
+    message: string,
+    ...items: string[]
+  ): Thenable<string | undefined> {
+    return vscode.window.showWarningMessage(message, ...items);
   }
 
   public reportCommandExecutionStatus(
@@ -50,7 +77,7 @@ export class NotificationService {
     observable.subscribe(async data => {
       if (data != undefined && data.toString() === '0') {
         const showButtonText = nls.localize('notification_show_button_text');
-        const selection = await vscode.window.showInformationMessage(
+        const selection = await this.showInformationMessage(
           nls.localize('notification_successful_execution_text', executionName),
           showButtonText
         );
@@ -59,12 +86,12 @@ export class NotificationService {
         }
       } else {
         if (cancellationToken && cancellationToken.isCancellationRequested) {
-          vscode.window.showWarningMessage(
+          this.showWarningMessage(
             nls.localize('notification_canceled_execution_text', executionName)
           );
           this.channel.show();
         } else {
-          vscode.window.showErrorMessage(
+          this.showErrorMessage(
             nls.localize(
               'notification_unsuccessful_execution_text',
               executionName
@@ -81,7 +108,7 @@ export class NotificationService {
     observable: Observable<Error | undefined>
   ) {
     observable.subscribe(async data => {
-      vscode.window.showErrorMessage(
+      this.showErrorMessage(
         nls.localize('notification_unsuccessful_execution_text', executionName)
       );
       this.channel.show();

--- a/packages/salesforcedx-vscode-core/src/predicates/index.ts
+++ b/packages/salesforcedx-vscode-core/src/predicates/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { IsSfdxProjectOpened } from './salesforcePredicates';
+
+export const isSfdxProjectOpened = new IsSfdxProjectOpened();

--- a/packages/salesforcedx-vscode-core/src/predicates/salesforcePredicates.ts
+++ b/packages/salesforcedx-vscode-core/src/predicates/salesforcePredicates.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  Predicate,
+  PredicateResponse
+} from '@salesforce/salesforcedx-utils-vscode/out/src/predicates/predicate';
+import * as fs from 'fs';
+import * as path from 'path';
+import { workspace } from 'vscode';
+import { SFDX_PROJECT_FILE } from '../constants';
+import { nls } from '../messages';
+
+export class IsSfdxProjectOpened implements Predicate<typeof workspace> {
+  public apply(item: typeof workspace): PredicateResponse {
+    if (!workspace.rootPath) {
+      return PredicateResponse.of(
+        false,
+        nls.localize('predicates_no_folder_opened_text')
+      );
+    } else if (
+      !fs.existsSync(path.join(workspace.rootPath, SFDX_PROJECT_FILE))
+    ) {
+      return PredicateResponse.of(
+        false,
+        nls.localize('predicates_no_sfdx_project_found_text')
+      );
+    } else {
+      return PredicateResponse.true();
+    }
+  }
+}

--- a/packages/salesforcedx-vscode-core/test/commands/commands.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/commands.test.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from 'chai';
+import {
+  CancelResponse,
+  CommandletExecutor,
+  ContinueResponse,
+  EmptyParametersGatherer,
+  ParametersGatherer,
+  SfdxCommandlet
+} from '../../src/commands/commands';
+
+// tslint:disable:no-unused-expression
+describe('Command Utilities', () => {
+  describe('EmptyParametersGatherer', () => {
+    it('Should always return continue with empty object as data', async () => {
+      const gatherer = new EmptyParametersGatherer();
+      const response = await gatherer.gather();
+      expect(response.type).to.be.eql('CONTINUE');
+
+      const continueResponse = response as ContinueResponse<{}>;
+      expect(continueResponse.data).to.be.eql({});
+    });
+  });
+
+  describe('SfdxCommandlet', () => {
+    it('Should not proceed if checker fails', async () => {
+      const commandlet = new SfdxCommandlet(
+        new class {
+          public check(): boolean {
+            return false;
+          }
+        }(),
+        new class implements ParametersGatherer<{}> {
+          public async gather(): Promise<
+            CancelResponse | ContinueResponse<{}>
+          > {
+            throw new Error('This should not be called');
+          }
+        }(),
+        new class implements CommandletExecutor<{}> {
+          public execute(response: ContinueResponse<{}>): void {
+            throw new Error('This should not be called');
+          }
+        }()
+      );
+
+      await commandlet.run();
+    });
+
+    it('Should not call executor if gatherer is CANCEL', async () => {
+      const commandlet = new SfdxCommandlet(
+        new class {
+          public check(): boolean {
+            return true;
+          }
+        }(),
+        new class implements ParametersGatherer<{}> {
+          public async gather(): Promise<
+            CancelResponse | ContinueResponse<{}>
+          > {
+            return { type: 'CANCEL' };
+          }
+        }(),
+        new class implements CommandletExecutor<{}> {
+          public execute(response: ContinueResponse<{}>): void {
+            throw new Error('This should not be called');
+          }
+        }()
+      );
+
+      await commandlet.run();
+    });
+
+    it('Should call executor if gatherer is CONTINUE', async () => {
+      let executed = false;
+      const commandlet = new SfdxCommandlet(
+        new class {
+          public check(): boolean {
+            return true;
+          }
+        }(),
+        new class implements ParametersGatherer<{}> {
+          public async gather(): Promise<
+            CancelResponse | ContinueResponse<{}>
+          > {
+            return { type: 'CONTINUE', data: {} };
+          }
+        }(),
+        new class implements CommandletExecutor<{}> {
+          public execute(response: ContinueResponse<{}>): void {
+            executed = true;
+          }
+        }()
+      );
+
+      await commandlet.run();
+
+      expect(executed).to.be.true;
+    });
+  });
+});

--- a/packages/salesforcedx-vscode-core/test/predicates/index.test.ts
+++ b/packages/salesforcedx-vscode-core/test/predicates/index.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+import { SinonStub, stub } from 'sinon';
+import { workspace } from 'vscode';
+import { SFDX_PROJECT_FILE } from '../../src/constants';
+import { nls } from '../../src/messages';
+import { isSfdxProjectOpened } from '../../src/predicates';
+
+// tslint:disable:no-unused-expression
+describe('SFDX project predicate', () => {
+  let mExistsSync: SinonStub;
+
+  beforeEach(() => {
+    mExistsSync = stub(fs, 'existsSync');
+    mExistsSync.resetBehavior();
+  });
+
+  afterEach(() => mExistsSync.restore());
+
+  it('Should fail predicate with message when sfdx-project.json is missing', () => {
+    mExistsSync
+      .withArgs(path.join(workspace.rootPath!, SFDX_PROJECT_FILE))
+      .returns(false);
+
+    const response = isSfdxProjectOpened.apply(workspace);
+    expect(response.result).to.be.false;
+    expect(response.message).to.eql(
+      nls.localize('predicates_no_sfdx_project_found_text')
+    );
+  });
+
+  it('Should pass predicate when sfdx-project.json is present', () => {
+    mExistsSync
+      .withArgs(path.join(workspace.rootPath!, SFDX_PROJECT_FILE))
+      .returns(true);
+
+    const response = isSfdxProjectOpened.apply(workspace);
+    expect(response.result).to.be.true;
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Adds a framework for command precondition-checking, parameter gathering, and execution. What triggered this was that we needed to check if the `vscode.workspace.root` is defined and that the root workspace has a sfdx-project.json.

As part of that refactoring, I introduced a framework for composing all the different stages together.

Also, added a less aggressive filter on -scratch-def.json so that it looks for
those file through out the workspace.

@W-4175532, W-4192163@



### What issues does this PR fix or reference?
