### PR TITLE
Look under config folder (and its nested folders) for -scratch-def.json

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
@@ -38,7 +38,7 @@ class ForceOrgCreateExecutor extends SfdxCommandletExecutor<FileSelection> {
 }
 
 const workspaceChecker = new SfdxWorkspaceChecker();
-const parameterGatherer = new FileSelector('**/*-scratch-def.json');
+const parameterGatherer = new FileSelector('config/**/*-scratch-def.json');
 
 export function forceOrgCreate() {
   const commandlet = new SfdxCommandlet(


### PR DESCRIPTION
### What does this PR do?

We will assume that all config files will reside under the top-level config folder (or its children folders)

![look_only_in_config](https://user-images.githubusercontent.com/54414/29037745-d56165be-7b59-11e7-82c5-6f030383c86e.gif)

### What issues does this PR fix or reference?

@W-4192163@

