### PR TITLE
Authenticate CI with DevHub

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,6 +24,7 @@ install:
   - SET PATH=%APPVEYOR_BUILD_FOLDER%\sfdx\bin;%PATH%
   - sfdx update
   - npm install -g codecov 
+  # the JWT key should be stored base 64 encoded in AppVeyor settings
   - ps: "[System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($env:SFDX_CI_DEVHUB_JWTKEY)) | Out-File -Encoding \"ASCII\" devhub.key"
   - sfdx force:auth:jwt:grant --clientid %SFDX_CI_DEVHUB_CLIENTID% --username %SFDX_CI_DEVHUB_USERNAME% --jwtkeyfile devhub.key --setdefaultdevhubusername --setalias devhub
   - del devhub.key

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,6 +24,10 @@ install:
   - SET PATH=%APPVEYOR_BUILD_FOLDER%\sfdx\bin;%PATH%
   - sfdx update
   - npm install -g codecov 
+  - ps: "[System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($env:SFDX_CI_DEVHUB_JWTKEY)) | Out-File -Encoding \"ASCII\" devhub.key"
+  - sfdx force:auth:jwt:grant --clientid %SFDX_CI_DEVHUB_CLIENTID% --username %SFDX_CI_DEVHUB_USERNAME% --jwtkeyfile devhub.key --setdefaultdevhubusername --setalias devhub
+  - del devhub.key
+
 
 build_script:
   - npm run compile

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ jspm_packages/
 
 # Eclipse
 .project
+
+# no keys
+*.key

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ before_install:
       sfdx update
     fi
   - |
+    # the key should be stored in Travis Repository Setting, wrapped in quotes and newlines replaced with \n
     echo -e $SFDX_CI_DEVHUB_JWTKEY > devhub.key
     sfdx force:auth:jwt:grant --clientid $SFDX_CI_DEVHUB_CLIENTID --username $SFDX_CI_DEVHUB_USERNAME --jwtkeyfile devhub.key --setdefaultdevhubusername --setalias devhub
     rm devhub.key

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,11 @@ before_install:
       sudo installer -pkg sfdx-osx.pkg -target /
       sfdx update
     fi
+  - |
+    echo -e $SFDX_CI_DEVHUB_JWTKEY > devhub.key
+    sfdx force:auth:jwt:grant --clientid $SFDX_CI_DEVHUB_CLIENTID --username $SFDX_CI_DEVHUB_USERNAME --jwtkeyfile devhub.key --setdefaultdevhubusername --setalias devhub
+    rm devhub.key
+
 
 install:
   - npm install


### PR DESCRIPTION
This authenticates Travis and AppVeyor with our DevHub for CI testing. The org will be set as default devhub and will also get the alias "devhub" to be used by integration tests.

