### PR TITLE
Fix windows path normalization

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -21,9 +21,7 @@
   "engines": {
     "vscode": "^1.13.0"
   },
-  "categories": [
-    "Other"
-  ],
+  "categories": ["Other"],
   "dependencies": {
     "glob": "^7.1.2",
     "@salesforce/salesforcedx-utils-vscode": "40.5.1",
@@ -55,9 +53,7 @@
     "postinstall": "node ./node_modules/vscode/bin/install",
     "test": "node ./node_modules/vscode/bin/test"
   },
-  "activationEvents": [
-    "workspaceContains:sfdx-project.json"
-  ],
+  "activationEvents": ["workspaceContains:sfdx-project.json"],
   "main": "./out/src",
   "contributes": {
     "views": {
@@ -78,7 +74,7 @@
       "explorer/context": [
         {
           "command": "sfdx.force.apex.class.create",
-          "when": "explorerResourceIsFolder"
+          "when": "explorerResourceIsFolder && sfdx:project_opened"
         }
       ],
       "commandPalette": [

--- a/packages/salesforcedx-vscode-core/src/commands/forceApexClassCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexClassCreate.ts
@@ -80,24 +80,16 @@ class SelectDirPath implements ParametersGatherer<{ outputdir: string }> {
     const rootPath = vscode.workspace.rootPath;
     let outputdir;
     if (rootPath) {
-      const normalizedRoot = path.normalize(rootPath);
-      if (this.explorerDir) {
-        if (process.platform === 'win32') {
-          outputdir = path.normalize(this.explorerDir.substr(1));
-        } else {
-          outputdir = path.normalize(this.explorerDir);
-        }
-      } else {
-        const relativeDir = await vscode.window.showQuickPick(
-          this.globDirs(rootPath, 'classes'),
-          <vscode.QuickPickOptions>{
-            placeHolder: nls.localize('force_apex_class_create_enter_dir_name')
-          }
-        );
-        if (relativeDir) {
-          outputdir = path.join(normalizedRoot, relativeDir);
-        }
-      }
+      outputdir = this.explorerDir
+        ? this.explorerDir
+        : await vscode.window.showQuickPick(
+            this.globDirs(rootPath, 'classes'),
+            <vscode.QuickPickOptions>{
+              placeHolder: nls.localize(
+                'force_apex_class_create_enter_dir_name'
+              )
+            }
+          );
     }
     return outputdir
       ? { type: 'CONTINUE', data: { outputdir } }

--- a/packages/salesforcedx-vscode-core/src/commands/forceApexClassCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexClassCreate.ts
@@ -48,8 +48,8 @@ class SelectFileName implements ParametersGatherer<{ fileName: string }> {
 class SelectDirPath implements ParametersGatherer<{ outputdir: string }> {
   private explorerDir: string | undefined;
 
-  public constructor(explorerDir?: { path: string }) {
-    this.explorerDir = explorerDir ? explorerDir.path : explorerDir;
+  public constructor(explorerDir?: { fsPath: string }) {
+    this.explorerDir = explorerDir ? explorerDir.fsPath : explorerDir;
   }
 
   public globDirs(srcPath: string, priorityKeyword?: string): string[] {

--- a/packages/salesforcedx-vscode-core/src/commands/forceApexClassCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexClassCreate.ts
@@ -48,7 +48,7 @@ class SelectFileName implements ParametersGatherer<{ fileName: string }> {
 class SelectDirPath implements ParametersGatherer<{ outputdir: string }> {
   private explorerDir: string | undefined;
 
-  public constructor(explorerDir?: { fsPath: string }) {
+  public constructor(explorerDir?: vscode.Uri) {
     this.explorerDir = explorerDir ? explorerDir.fsPath : explorerDir;
   }
 


### PR DESCRIPTION
### What does this PR do?
Address an issue where on windows, the path being returned from a context menu in the explorer has an extra '\\' appended before the drive
i.e. \c:\path\to\directory
### What issues does this PR fix or reference?
@W-4197613@