### PR TITLE
change absolute explorer dir path to relative path

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceApexClassCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexClassCreate.ts
@@ -81,7 +81,7 @@ class SelectDirPath implements ParametersGatherer<{ outputdir: string }> {
     let outputdir;
     if (rootPath) {
       outputdir = this.explorerDir
-        ? this.explorerDir
+        ? path.relative(rootPath, this.explorerDir)
         : await vscode.window.showQuickPick(
             this.globDirs(rootPath, 'classes'),
             <vscode.QuickPickOptions>{
@@ -127,6 +127,7 @@ class ForceApexClassCreateExecutor extends SfdxCommandletExecutor<
         vscode.workspace
           .openTextDocument(
             path.join(
+              vscode.workspace.rootPath,
               response.data.outputdir,
               response.data.fileName + APEX_FILE_EXTENSION
             )


### PR DESCRIPTION
### What does this PR do?
Gatherer should pass directory's relative path to command builder and then reconstruct the absolute path to open the file later.
### What issues does this PR fix or reference?
@W-4197613@