### PR TITLE
Added missing engines definition / removed main key

### DIFF
--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -7,7 +7,7 @@
   "license": "BSD-3-Clause",
   "categories": [
     "Other"
-  ],
+    ],
   "dependencies": {
     "rxjs": "^5.4.1",
     "tree-kill": "^1.1.0"
@@ -29,6 +29,9 @@
     "source-map-support": "^0.4.15",
     "typescript": "2.4.0"
   },
+  "engines": {
+    "vscode": "^1.15.0"
+  },
   "scripts": {
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
@@ -42,6 +45,5 @@
       "text-summary",
       "lcov"
     ]
-  },
-  "main": "./out/src/"
+  }
 }

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -7,7 +7,7 @@
   "license": "BSD-3-Clause",
   "categories": [
     "Other"
-    ],
+  ],
   "dependencies": {
     "rxjs": "^5.4.1",
     "tree-kill": "^1.1.0"

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -30,7 +30,7 @@
     "typescript": "2.4.0"
   },
   "engines": {
-    "vscode": "^1.15.0"
+    "vscode": "^1.13.0"
   },
   "scripts": {
     "compile": "tsc -p ./",


### PR DESCRIPTION
### What does this PR do?

This PR adds the 'engines' key to the package.json of salesforcedx-utils-vscode. It also removes the 'main' key in the package.json.

### What issues does this PR fix or reference?

Fixes #68 