### PR TITLE
Support packaging and publishing with Node 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:without-system-tests": "lerna run test --ignore system-tests --concurrency 1",
     "test:system-tests": "lerna run test --scope system-tests --concurrency 1",
     "coverage:system-tests": "lerna run coverage --scope system-tests --concurrency 1",
-    "vscode:package": "lerna run vscode:package --concurrency 1",
+    "vscode:package": "lerna exec --scope @salesforce/salesforcedx-* -- npm prune --production && lerna run vscode:package --concurrency 1",
     "vscode:sha256": "lerna run vscode:sha256 --concurrency 1",
     "vscode:publish": "lerna run vscode:publish --concurrency 1",
     "watch": "lerna run --parallel watch"

--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -31,7 +31,6 @@
     "vscode-debugadapter-testsupport": "1.22.0"
   },
   "scripts": {
-    "vscode:package": "npm prune --production",
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",

--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -8,9 +8,7 @@
   "engines": {
     "vscode": "^1.15.0"
   },
-  "categories": [
-    "Debuggers"
-  ],
+  "categories": ["Debuggers"],
   "dependencies": {
     "@salesforce/salesforcedx-utils-vscode": "40.7.0",
     "faye": "1.1.2",
@@ -33,6 +31,7 @@
     "vscode-debugadapter-testsupport": "1.22.0"
   },
   "scripts": {
+    "vscode:package": "npm prune --production",
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
@@ -40,9 +39,6 @@
     "test": "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test"
   },
   "nyc": {
-    "reporter": [
-      "text-summary",
-      "lcov"
-    ]
+    "reporter": ["text-summary", "lcov"]
   }
 }

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -5,9 +5,7 @@
   "version": "40.7.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
-  "categories": [
-    "Other"
-  ],
+  "categories": ["Other"],
   "dependencies": {
     "rxjs": "^5.4.1",
     "tree-kill": "^1.1.0"
@@ -33,6 +31,7 @@
     "vscode": "^1.13.0"
   },
   "scripts": {
+    "vscode:package": "npm prune --production",
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
@@ -41,9 +40,6 @@
     "coverage": "./node_modules/.bin/nyc npm test"
   },
   "nyc": {
-    "reporter": [
-      "text-summary",
-      "lcov"
-    ]
+    "reporter": ["text-summary", "lcov"]
   }
 }

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -15,9 +15,7 @@
   "engines": {
     "vscode": "^1.15.0"
   },
-  "categories": [
-    "Debuggers"
-  ],
+  "categories": ["Debuggers"],
   "dependencies": {
     "@salesforce/salesforcedx-apex-debugger": "40.7.0"
   },
@@ -52,9 +50,7 @@
         "label": "Apex Debugger",
         "program": "./node_modules/@salesforce/salesforcedx-apex-debugger/out/src/adapter/apexDebug.js",
         "runtime": "node",
-        "languages": [
-          "apex"
-        ],
+        "languages": ["apex"],
         "configurationSnippets": [
           {
             "label": "%launch_snippet_label_text%",
@@ -73,9 +69,7 @@
         "configurationAttributes": {
           "launch": {
             "properties": {
-              "required": [
-                "sfdxProject"
-              ],
+              "required": ["sfdxProject"],
               "userIdFilter": {
                 "type": "string",
                 "description": "%user_id_filter_text%",

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -12,6 +12,15 @@ shell.set('+v');
  * 2. The script is running in the right branch (e.g., release/vxx.y.z)
  */
 
+// Checks that you are running this with Node v7.9.0
+const nodeVersion = shell.exec('node -v', { silent: true });
+if (!nodeVersion.includes('v7.9.0')) {
+  console.log(
+    'You do not have the right version of node. We require version 7.9.0'
+  );
+  exit(-1);
+}
+
 // Checks that you have access to our bucket on AWS
 const awsExitCode = shell.exec(
   'aws s3 ls s3://dfc-data-production/media/vscode/SHA256.md',

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -12,11 +12,13 @@ shell.set('+v');
  * 2. The script is running in the right branch (e.g., release/vxx.y.z)
  */
 
-// Checks that you are running this with Node v7.9.0
-const nodeVersion = shell.exec('node -v', { silent: true });
-if (!nodeVersion.includes('v7.9.0')) {
+// Checks that you are running this with Node v7.9.0 and above
+const [version, major, minor, patch] = process.version.match(
+  /^v(\d+)\.?(\d+)\.?(\*|\d+)$/
+);
+if (!major !== 7 && !(minor >= 9)) {
   console.log(
-    'You do not have the right version of node. We require version 7.9.0'
+    'You do not have the right version of node. We require version 7.9.0 and above (but not Node 8, yet).'
   );
   exit(-1);
 }

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -16,7 +16,7 @@ shell.set('+v');
 const [version, major, minor, patch] = process.version.match(
   /^v(\d+)\.?(\d+)\.?(\*|\d+)$/
 );
-if (!major !== 7 && !(minor >= 9)) {
+if (major !== 7 || minor < 9) {
   console.log(
     'You do not have the right version of node. We require version 7.9.0 and above (but not Node 8, yet).'
   );


### PR DESCRIPTION
### What does this PR do?

Trying to package the extensions with Node 7 doesn't work. 

1. git clone git@github.com:forcedotcom/salesforcedx-vscode.git
2. cd into salesforcedx-vscode
3. npm run install
4. npm run compile
5. npm run vscode:package

**Expected**: 
Should work like it did with Node 6.

**Actual**:
```
vscode-debugadapter-testsupport@1.22.0 node_modules/vscode-debugadapter-testsupport
lerna ERR! vscode:package Errored while running script in 'salesforcedx-vscode-apex'
lerna ERR! execute Error: Command failed: npm run vscode:package
lerna ERR! execute Executing prepublish script 'npm run vscode:prepublish'...
lerna ERR! execute Error: Command failed: npm list --production --parseable --depth=99999
lerna ERR! execute npm ERR! extraneous: @types/node@6.0.88 /Users/nchen/Development/Node/salesforcedx-vscode/packages/salesforcedx-vscode-apex/node_modules/@salesforce/salesforcedx-utils-vscode/node_modules/@types/node
lerna ERR! execute npm ERR! extraneous: istanbul@0.4.5 /Users/nchen/Development/Node/salesforcedx-vscode/packages/salesforcedx-vscode-apex/node_modules/@salesforce/salesforcedx-utils-vscode/node_modules/istanbul
```

### How does this PR resolve that?

It does the pruning manually first on the leaf nodes. Basically, this is building up the dependency tree manually for now.

### What issues does this PR fix or reference?

@W-4264167@
