### PR TITLE
Reformat with prettier after lerna publish (release/v40.8.0 branch) 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "devDependencies": {
-    "lerna": "2.0.0",
     "istanbul": "1.1.0-alpha.1",
+    "lerna": "2.0.0",
+    "prettier": "1.6.0",
     "remap-istanbul": "^0.9.5",
     "shx": "0.2.2",
     "tslint": "5.5.0",
@@ -16,10 +17,13 @@
     "lint": "lerna run lint",
     "publish": "node scripts/publish.js",
     "test": "lerna run test --concurrency 1",
-    "test:without-system-tests": "lerna run test --ignore system-tests --concurrency 1",
+    "test:without-system-tests":
+      "lerna run test --ignore system-tests --concurrency 1",
     "test:system-tests": "lerna run test --scope system-tests --concurrency 1",
-    "coverage:system-tests": "lerna run coverage --scope system-tests --concurrency 1",
-    "vscode:package": "lerna exec --scope @salesforce/salesforcedx-* -- npm prune --production && lerna run vscode:package --concurrency 1",
+    "coverage:system-tests":
+      "lerna run coverage --scope system-tests --concurrency 1",
+    "vscode:package":
+      "lerna exec --scope @salesforce/salesforcedx-* -- npm prune --production && lerna run vscode:package --concurrency 1",
     "vscode:sha256": "lerna run vscode:sha256 --concurrency 1",
     "vscode:publish": "lerna run vscode:publish --concurrency 1",
     "watch": "lerna run --parallel watch"

--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -34,8 +34,10 @@
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
-    "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
-    "test": "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test"
+    "clean":
+      "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
+    "test":
+      "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test"
   },
   "nyc": {
     "reporter": ["text-summary", "lcov"]

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@salesforce/salesforcedx-utils-vscode",
   "displayName": "SFDX Utilities for VS Code",
-  "description": "Provides utilies to interface the SFDX libraries with VS Code",
+  "description":
+    "Provides utilies to interface the SFDX libraries with VS Code",
   "version": "40.7.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
@@ -35,8 +36,10 @@
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
-    "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
-    "test": "./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test",
+    "clean":
+      "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
+    "test":
+      "./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test",
     "coverage": "./node_modules/.bin/nyc npm test"
   },
   "nyc": {

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -30,7 +30,8 @@
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
-    "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
+    "clean":
+      "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
     "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "activationEvents": [
@@ -48,7 +49,8 @@
       {
         "type": "apex",
         "label": "Apex Debugger",
-        "program": "./node_modules/@salesforce/salesforcedx-apex-debugger/out/src/adapter/apexDebug.js",
+        "program":
+          "./node_modules/@salesforce/salesforcedx-apex-debugger/out/src/adapter/apexDebug.js",
         "runtime": "node",
         "languages": ["apex"],
         "configurationSnippets": [

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -2,7 +2,8 @@
   "preview": true,
   "name": "salesforcedx-vscode-apex",
   "displayName": "Apex Code Editor for Visual Studio Code",
-  "description": "Provides code-editing features for the Apex programming language",
+  "description":
+    "Provides code-editing features for the Apex programming language",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",
   "bugs": {
     "url": "https://github.com/forcedotcom/salesforcedx-vscode/issues"
@@ -21,9 +22,7 @@
   "engines": {
     "vscode": "^1.13.0"
   },
-  "categories": [
-    "Languages"
-  ],
+  "categories": ["Languages"],
   "devDependencies": {
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
@@ -43,13 +42,12 @@
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
-    "clean": "shx rm -rf node_modules && cd out && node ../../../scripts/clean-all-but-jar.js && shx rm -rf coverage && shx rm -rf .nyc_output",
+    "clean":
+      "shx rm -rf node_modules && cd out && node ../../../scripts/clean-all-but-jar.js && shx rm -rf coverage && shx rm -rf .nyc_output",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "test": "node ./node_modules/vscode/bin/test"
   },
-  "activationEvents": [
-    "workspaceContains:sfdx-project.json"
-  ],
+  "activationEvents": ["workspaceContains:sfdx-project.json"],
   "main": "./out/src",
   "contributes": {
     "configuration": {
@@ -57,10 +55,7 @@
       "title": "%configuration_title%",
       "properties": {
         "salesforcedx-vscode-apex.java.home": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "default": null,
           "description": "%java_home_description%"
         }
@@ -69,14 +64,8 @@
     "languages": [
       {
         "id": "apex",
-        "aliases": [
-          "Apex",
-          "apex"
-        ],
-        "extensions": [
-          ".cls",
-          ".trigger"
-        ],
+        "aliases": ["Apex", "apex"],
+        "extensions": [".cls", ".trigger"],
         "configuration": "./syntaxes/apex.configuration.json"
       }
     ],

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -50,9 +50,11 @@
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
-    "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
+    "clean":
+      "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
     "postinstall": "node ./node_modules/vscode/bin/install",
-    "test": "cross-env CODE_TESTS_WORKSPACE='../system-tests/assets/sfdx-simple' node ./node_modules/vscode/bin/test"
+    "test":
+      "cross-env CODE_TESTS_WORKSPACE='../system-tests/assets/sfdx-simple' node ./node_modules/vscode/bin/test"
   },
   "activationEvents": ["workspaceContains:sfdx-project.json"],
   "main": "./out/src",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -21,9 +21,7 @@
   "engines": {
     "vscode": "^1.13.0"
   },
-  "categories": [
-    "Languages"
-  ],
+  "categories": ["Languages"],
   "devDependencies": {
     "@salesforce/salesforcedx-utils-vscode": "40.7.0",
     "@types/chai": "^4.0.0",
@@ -44,7 +42,8 @@
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
-    "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
+    "clean":
+      "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "test": "node ./node_modules/vscode/bin/test"
   },

--- a/packages/salesforcedx-vscode-visualforce/package.json
+++ b/packages/salesforcedx-vscode-visualforce/package.json
@@ -21,9 +21,7 @@
   "engines": {
     "vscode": "^1.13.0"
   },
-  "categories": [
-    "Languages"
-  ],
+  "categories": ["Languages"],
   "devDependencies": {
     "@salesforce/salesforcedx-utils-vscode": "40.7.0",
     "@types/chai": "^4.0.0",
@@ -44,7 +42,8 @@
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
-    "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
+    "clean":
+      "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "test": "node ./node_modules/vscode/bin/test"
   },
@@ -52,10 +51,7 @@
     "languages": [
       {
         "id": "html",
-        "extensions": [
-          ".page",
-          ".component"
-        ]
+        "extensions": [".page", ".component"]
       }
     ]
   }

--- a/packages/salesforcedx-vscode/package.json
+++ b/packages/salesforcedx-vscode/package.json
@@ -2,7 +2,8 @@
   "preview": true,
   "name": "salesforcedx-vscode",
   "displayName": "Visual Studio Code Extension Pack for Salesforce DX",
-  "description": "Collection of extensions for the Salesforce DX development flow",
+  "description":
+    "Collection of extensions for the Salesforce DX development flow",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",
   "bugs": {
     "url": "https://github.com/forcedotcom/salesforcedx-vscode/issues"
@@ -27,9 +28,7 @@
     "vscode:sha256": "node ../../scripts/generate-sha256.js >> ../../SHA256",
     "vscode:publish": "node ../../scripts/publish-vsix.js"
   },
-  "categories": [
-    "Extension Packs"
-  ],
+  "categories": ["Extension Packs"],
   "extensionDependencies": [
     "salesforce.salesforcedx-vscode-apex",
     "salesforce.salesforcedx-vscode-core",

--- a/packages/system-tests/package.json
+++ b/packages/system-tests/package.json
@@ -34,11 +34,14 @@
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
-    "clean": "shx rm -rf .vscode-test && shx rm -rf node_modules && shx rm -rf out",
+    "clean":
+      "shx rm -rf .vscode-test && shx rm -rf node_modules && shx rm -rf out",
     "postinstall": "node ./node_modules/vscode/bin/install",
-    "pretest": "npm run compile && node ../../scripts/download-vscode-for-system-tests",
+    "pretest":
+      "npm run compile && node ../../scripts/download-vscode-for-system-tests",
     "test": "node out/src/main.js",
-    "coverage": "npm run pretest && node ../../scripts/instrument-salesforcedx-vscode-extensions && cross-env COLLECT_COVERAGE=1 npm run test && node ../../scripts/remap-coverage"
+    "coverage":
+      "npm run pretest && node ../../scripts/instrument-salesforcedx-vscode-extensions && cross-env COLLECT_COVERAGE=1 npm run test && node ../../scripts/remap-coverage"
   },
   "activationEvents": ["*"],
   "main": "./out/src"

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -69,6 +69,9 @@ if (nextVersion) {
   );
 }
 
+// Reformat with prettier since lerna changes the formatting in package.json
+shell.exec('./scripts/reformat-with-prettier.js');
+
 // Generate the .vsix files
 shell.exec(`npm run vscode:package`);
 

--- a/scripts/reformat-with-prettier.js
+++ b/scripts/reformat-with-prettier.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const shell = require('shelljs');
+
+const prettierExecutable = path.join(
+  __dirname,
+  '..',
+  'node_modules',
+  '.bin',
+  'prettier'
+);
+
+shell.exec(
+  `${prettierExecutable} --single-quote --write "packages/salesforcedx-*/package.json"`,
+  {
+    cwd: path.join(__dirname, '..')
+  }
+);


### PR DESCRIPTION
### What does this PR do?

When we use lerna --publish, it rewrites package.json and destroys the formatting from prettier. This restores the formatting.

I'm going to have to make a similar change in the develop branch to keep all the formatting consistent.

### What issues does this PR fix or reference?

None.
