### PR TITLE
Remove unnecessary check for number of files created in e2e tests

### DIFF
--- a/packages/system-tests/scenarios/scaffolding.test.ts
+++ b/packages/system-tests/scenarios/scaffolding.test.ts
@@ -16,7 +16,6 @@ import {
 } from '../src/spectron/application';
 
 const TITLE = 'Scaffolding Commands Tests';
-const NUM_FILES_CREATED_LIGHTNING_APP_EVT = 6;
 
 const WORKSPACE_PATH = path.join(
   createWorkspace(path.join(process.cwd(), 'assets', 'sfdx-simple')),
@@ -149,11 +148,6 @@ describe('Scaffolding commands', () => {
     if (lightningAppTab) {
       await common.closeTab();
     }
-
-    await app.command('workbench.action.quickOpen');
-    await common.type(fileName);
-    const elCount = await common.getQuickOpenElements();
-    expect(elCount).to.equal(NUM_FILES_CREATED_LIGHTNING_APP_EVT);
   });
 
   it('Should create Lightning component', async () => {
@@ -181,11 +175,6 @@ describe('Scaffolding commands', () => {
     if (lightningComponentTab) {
       await common.closeTab();
     }
-
-    await app.command('workbench.action.quickOpen');
-    await common.type(fileName);
-    const elCount = await common.getQuickOpenElements();
-    expect(elCount).to.equal(NUM_FILES_CREATED_LIGHTNING_APP_EVT);
   });
 
   it('Should create Lightning event', async () => {
@@ -213,11 +202,6 @@ describe('Scaffolding commands', () => {
     if (lightningEventTab) {
       await common.closeTab();
     }
-
-    await app.command('workbench.action.quickOpen');
-    await common.type(fileName);
-    const elCount = await common.getQuickOpenElements();
-    expect(elCount).to.equal(2);
   });
 
   it('Should create Lightning interface', async () => {
@@ -245,10 +229,5 @@ describe('Scaffolding commands', () => {
     if (lightningInterfaceTab) {
       await common.closeTab();
     }
-
-    await app.command('workbench.action.quickOpen');
-    await common.type(fileName);
-    const elCount = await common.getQuickOpenElements();
-    expect(elCount).to.equal(2);
   });
 });


### PR DESCRIPTION
### What does this PR do?
Removes part of integration tests verifying that the number of files created is correct. This would be an issue that the CLI command should test and handle.
### What issues does this PR fix or reference?
@W-4271774@
