### PR TITLE
Add GoToDefinition feature

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -28,9 +28,11 @@
     "@types/mocha": "2.2.38",
     "@types/node": "^6.0.40",
     "@types/path-exists": "^1.0.29",
+    "@types/shelljs": "^0.7.4",
     "chai": "^4.0.2",
     "mocha": "3.2.0",
     "nyc": "^11.0.2",
+    "shelljs": "^0.7.8",
     "typescript": "2.4.0",
     "vscode": "1.1.2"
   },

--- a/packages/salesforcedx-vscode-apex/test/index.ts
+++ b/packages/salesforcedx-vscode-apex/test/index.ts
@@ -12,7 +12,8 @@ const testRunner = require('@salesforce/salesforcedx-utils-vscode/out/src/test/t
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
 testRunner.configure({
   ui: 'bdd', // the TDD UI is being used in extension.test.ts (suite, test, etc.)
-  useColors: true // colored output from test results
+  useColors: true, // colored output from test results
+  timeout: 360000
 });
 
 module.exports = testRunner;

--- a/packages/salesforcedx-vscode-apex/test/requirements.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/requirements.test.ts
@@ -8,10 +8,21 @@
 // tslint:disable:no-unused-expression
 
 import { expect } from 'chai';
+import * as path from 'path';
+import * as shell from 'shelljs';
 import { workspace } from 'vscode';
 import { JAVA_HOME_KEY } from '../src/requirements';
 
 describe('Java Requirements Test', () => {
+  it('The jar should be signed', () => {
+    const apexJarPath = path.join(__dirname, '..', 'apex-jorje-lsp.jar');
+    expect(
+      shell
+        .exec(`jarsigner -verify ${apexJarPath}`)
+        .stdout.includes('jar verified')
+    ).to.be.true;
+  });
+
   it('Should have java.home section', () => {
     const config = workspace.getConfiguration();
     expect(config.has(JAVA_HOME_KEY)).to.be.true;


### PR DESCRIPTION
### What does this PR do?

Adds GoToDefinition feature for the current fie. Limited to the following:

- fields
- properties
- local variables
- params

Others will come later. The goal is to get this in incrementally.

![gotodefinitionsymbolsinfile](https://user-images.githubusercontent.com/54414/29945701-25ffd5cc-8e57-11e7-81fd-cf44b2b7417b.gif)


### What issues does this PR fix or reference?

@W-4248232, W-4276176@

