### PR TITLE
Handle SystemWarning event

### DIFF
--- a/packages/salesforcedx-apex-debugger/src/constants.ts
+++ b/packages/salesforcedx-apex-debugger/src/constants.ts
@@ -6,3 +6,6 @@
  */
 
 export const DEFAULT_STREAMING_TIMEOUT = 14400;
+export const GET_LINE_BREAKPOINT_INFO_EVENT = 'getLineBreakpointInfo';
+export const SHOW_MESSAGE_EVENT = 'showMessage';
+export const LINE_BREAKPOINT_INFO_REQUEST = 'lineBreakpointInfo';

--- a/packages/salesforcedx-apex-debugger/src/index.ts
+++ b/packages/salesforcedx-apex-debugger/src/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+export * from './constants';
+
+export enum VscodeDebuggerMessageType {
+  Info,
+  Warning,
+  Error
+}
+
+export interface VscodeDebuggerMessage {
+  type: VscodeDebuggerMessageType;
+  message: string;
+}


### PR DESCRIPTION
### What does this PR do?
The debug adapter handles Apex Debugger SystemWarning event by logging the description to debug console and handing it off to salesforcedx-vscode-apex-debugger to also show in a top level notification.

![warningfromdebugadapter](https://user-images.githubusercontent.com/7286437/29987853-fdc4d24c-8f1e-11e7-8ab5-4fb34ffdf294.png)

### What issues does this PR fix or reference?
@W-4178985@