### PR TITLE
Fix error messages with starting & stopping debugger session

### DIFF
--- a/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
+++ b/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
@@ -462,14 +462,15 @@ export class ApexDebug extends DebugSession {
       response.success = false;
       const errorObj = JSON.parse(error);
       if (errorObj && errorObj.message) {
+        const errorMessage: string = errorObj.message;
         if (
-          errorObj.message.indexOf(
+          errorMessage.includes(
             'entity type cannot be inserted: Apex Debugger Session'
-          ) !== -1
+          )
         ) {
           response.message = nls.localize('session_no_entity_access_text');
         } else {
-          response.message = errorObj.message;
+          response.message = errorMessage;
         }
         if (errorObj.action) {
           this.errorToDebugConsole(

--- a/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
+++ b/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
@@ -462,7 +462,15 @@ export class ApexDebug extends DebugSession {
       response.success = false;
       const errorObj = JSON.parse(error);
       if (errorObj && errorObj.message) {
-        response.message = errorObj.message;
+        if (
+          errorObj.message.indexOf(
+            'entity type cannot be inserted: Apex Debugger Session'
+          ) !== -1
+        ) {
+          response.message = nls.localize('session_no_entity_access_text');
+        } else {
+          response.message = errorObj.message;
+        }
         if (errorObj.action) {
           this.errorToDebugConsole(
             `${nls.localize(
@@ -628,7 +636,15 @@ export class ApexDebug extends DebugSession {
   }
 
   private handleSessionTerminated(message: DebuggerMessage): void {
-    this.errorToDebugConsole(message.sobject.Description);
+    if (message.sobject.Description) {
+      this.errorToDebugConsole(message.sobject.Description);
+      this.sendEvent(
+        new Event(SHOW_MESSAGE_EVENT, {
+          type: VscodeDebuggerMessageType.Error,
+          message: message.sobject.Description
+        } as VscodeDebuggerMessage)
+      );
+    }
     this.mySessionService.forceStop();
     this.sendEvent(new TerminatedEvent());
   }

--- a/packages/salesforcedx-apex-debugger/src/messages/i18n.ts
+++ b/packages/salesforcedx-apex-debugger/src/messages/i18n.ts
@@ -19,6 +19,8 @@ export const messages = {
   command_error_help_text: 'Command returned the following error',
   session_language_server_error_text:
     'Apex language server could not provide information about valid breakpoints.',
+  session_no_entity_access_text:
+    "Either your org or user doesn't have the permission to debug Apex.",
   session_started_text: 'Apex Debugger session started with ID %s.',
   session_terminated_text: 'Apex Debugger session terminated with ID %s.',
   streaming_connected_text: 'Connected to Streaming API channel %s.',


### PR DESCRIPTION
### What does this PR do?
When an Apex Debugger session is terminated outside of VS Code, we handle a SessionTerminated event by printing the event description to debug console. Now, we also show an error top-level notification:
![sessionterminatednotification](https://user-images.githubusercontent.com/7286437/30137014-4d546ed0-9316-11e7-9c27-a097c684e9de.png)

When the scratch org or user does not have Debug Apex perm, we show an error top-level notification that suggests they need both org and user perms. We cannot use "sfdx force:schema:sobject" commands to individually detect for org & user perm. The command sobject:list will return ApexDebuggerSession with & without Debug Apex org perm because its org access is only restricted to AuthorApex. The command sobject:describe on ApexDebuggerSession will return the same thing with & without Debug Apex org perm.
![noaccesstoapexdebuggersessionobject](https://user-images.githubusercontent.com/7286437/30137103-ad7ec49a-9316-11e7-864d-536d5d04f870.png)

### What issues does this PR fix or reference?
@W-4241196, W-4241210@
