### PR TITLE
Log Apex Debugger event SystemInfo

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -100,7 +100,7 @@ See this
 [guide](https://www.atlassian.com/git/tutorials/comparing-workflows#gitflow-workflow)
 from Atlassian on the flow. These steps are manual because you might encounter merge conflicts.
 
-1. `git push tags` to push the tags to GitHub.
+1. `git push --tags` to push the tags to GitHub.
 1. `git checkout master`
 1. `git pull` to get the latest changes (there shouldn't be any since you are
    the person releasing).

--- a/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
+++ b/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
@@ -592,6 +592,10 @@ export class ApexDebug extends DebugSession {
         this.handleSystemGack(message);
         break;
       }
+      case ApexDebuggerEventType.SystemInfo: {
+        this.handleSystemInfo(message);
+        break;
+      }
       case ApexDebuggerEventType.SystemWarning: {
         this.handleSystemWarning(message);
         break;
@@ -736,6 +740,10 @@ export class ApexDebug extends DebugSession {
         } as VscodeDebuggerMessage)
       );
     }
+  }
+
+  private handleSystemInfo(message: DebuggerMessage): void {
+    this.logEvent(message);
   }
 
   private handleSystemWarning(message: DebuggerMessage): void {

--- a/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebug.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebug.test.ts
@@ -1543,5 +1543,21 @@ describe('Debugger adapter - unit', () => {
       expect(adapter.getEvents().length).to.equal(1);
       expect(adapter.getEvents()[0].event).to.equal('output');
     });
+
+    it('[SystemInfo] - Should log event', () => {
+      const message: DebuggerMessage = {
+        event: {} as StreamingEvent,
+        sobject: {
+          SessionId: '123',
+          Type: 'SystemInfo',
+          Description: 'Request will not be debugged'
+        }
+      };
+
+      adapter.handleEvent(message);
+
+      expect(adapter.getEvents().length).to.equal(1);
+      expect(adapter.getEvents()[0].event).to.equal('output');
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Apex Debugger event SystemInfo only has a value in its description field. It tells the client whether a request matched their session's userId/request/entryPoint filter. It can get pretty noisy so I'm just logging it in the debug console instead of also showing a top-level notification.

![systeminfoevent](https://user-images.githubusercontent.com/7286437/30186966-9bb60acc-93dc-11e7-8327-4cad7701f092.png)

### What issues does this PR fix or reference?
@W-4179008@