### PR TITLE
[DO NOT MERGE] Add a simple SFDX: SObject Describe Account Command for testing

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -172,6 +172,10 @@
         {
           "command": "sfdx.force.lightning.interface.create",
           "when": "sfdx:project_opened"
+        },
+        {
+          "command": "sfdx.force.sobject.describe.account",
+          "when": "sfdx:project_opened"
         }
       ]
     },
@@ -243,6 +247,10 @@
       {
         "command": "sfdx.force.lightning.interface.create",
         "title": "%force_lightning_interface_create_text%"
+      },
+      {
+        "command": "sfdx.force.sobject.describe.account",
+        "title": "SFDX: SObject Describe Account"
       }
     ]
   }

--- a/packages/salesforcedx-vscode-core/src/commands/commands.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/commands.ts
@@ -203,7 +203,12 @@ export abstract class SfdxCommandletExecutor<T>
     const cancellationToken = cancellationTokenSource.token;
 
     const execution = new CliCommandExecutor(this.build(response.data), {
-      cwd: vscode.workspace.rootPath
+      cwd: vscode.workspace.rootPath,
+      stdio: [
+        'pipe',
+        'pipe', // fs.openSync(path.join(vscode.workspace.rootPath!, 'stdout.txt'), 'w'),
+        'pipe'
+      ]
     }).execute(cancellationToken);
 
     channelService.streamCommandOutput(execution);

--- a/packages/salesforcedx-vscode-core/src/commands/forceSObjectDescribeAccount.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSObjectDescribeAccount.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  Command,
+  SfdxCommandBuilder
+} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import {
+  EmptyParametersGatherer,
+  SfdxCommandlet,
+  SfdxCommandletExecutor,
+  SfdxWorkspaceChecker
+} from './commands';
+
+class ForceSObjectDescribeAccountExecutor extends SfdxCommandletExecutor<{}> {
+  public build(data: {}): Command {
+    return new SfdxCommandBuilder()
+      .withDescription('force:schema:sobject:describe')
+      .withArg('force:schema:sobject:describe')
+      .withFlag('-s', 'Account')
+      .build();
+  }
+}
+
+const workspaceChecker = new SfdxWorkspaceChecker();
+const parameterGatherer = new EmptyParametersGatherer();
+const executor = new ForceSObjectDescribeAccountExecutor();
+const commandlet = new SfdxCommandlet(
+  workspaceChecker,
+  parameterGatherer,
+  executor
+);
+
+export function forceSObjectDescribeAccount() {
+  commandlet.run();
+}

--- a/packages/salesforcedx-vscode-core/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/index.ts
@@ -22,3 +22,4 @@ export {
 export { forceLightningComponentCreate } from './forceLightningComponentCreate';
 export { forceLightningEventCreate } from './forceLightningEventCreate';
 export { forceLightningInterfaceCreate } from './forceLightningInterfaceCreate';
+export { forceSObjectDescribeAccount } from './forceSObjectDescribeAccount';

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -17,6 +17,7 @@ import {
   forceLightningInterfaceCreate,
   forceOrgCreate,
   forceOrgOpen,
+  forceSObjectDescribeAccount,
   forceSourcePull,
   forceSourcePush,
   forceSourceStatus,
@@ -100,6 +101,10 @@ function registerCommands(): vscode.Disposable {
     'sfdx.force.lightning.interface.create',
     forceLightningInterfaceCreate
   );
+  const forceSObjectDescribeAccountCmd = vscode.commands.registerCommand(
+    'sfdx.force.sobject.describe.account',
+    forceSObjectDescribeAccount
+  );
 
   // Internal commands
   const internalCancelCommandExecution = vscode.commands.registerCommand(
@@ -123,6 +128,7 @@ function registerCommands(): vscode.Disposable {
     forceLightningComponentCreateCmd,
     forceLightningEventCreateCmd,
     forceLightningInterfaceCreateCmd,
+    forceSObjectDescribeAccountCmd,
     forceSourceStatusLocalCmd,
     forceSourceStatusRemoteCmd,
     internalCancelCommandExecution


### PR DESCRIPTION
### What does this PR do?

Adds a simple top-level command that is used to fetch the result of a describe call.

This is meant to illustrate the problem that for large data from the CLI, the results could be truncated. Now, **before anyone is alarmed**, this only happens under very special circumstances and doesn't affect any of the commands that we have in the released version of our extensions:

![stdout-truncated](https://user-images.githubusercontent.com/54414/30382257-884b8cfc-9853-11e7-8dca-9c67b383f486.gif)


1. This seems to be on OS X.
1. This only seems to happen when you use `child_process.spawn` and are using the `process.stdout.on('data',....)` events.

This might be related to 
* https://github.com/nodejs/node/issues/6379
* https://github.com/nodejs/node/issues/2360 

where we might need to change the SFDX CLI to call `process.stdout._handle.setBlocking(true)`

However, having an interactive top-level command that reproduces this issue makes it easier for us to debug this on different platforms.

### What issues does this PR fix or reference?

This PR is meant to serve as an easy way for us to debug this and discuss solutions with traceability.
