### PR TITLE
Update breakpoint reconcile strategy

### DIFF
--- a/packages/salesforcedx-apex-debugger/src/core/breakpointService.ts
+++ b/packages/salesforcedx-apex-debugger/src/core/breakpointService.ts
@@ -273,5 +273,7 @@ export class BreakpointService {
 
   public clearSavedBreakpoints(): void {
     this.breakpointCache.clear();
+    this.breakpointAddQueue.clear();
+    this.breakpointDeleteQueue.clear();
   }
 }

--- a/packages/salesforcedx-apex-debugger/src/core/breakpointService.ts
+++ b/packages/salesforcedx-apex-debugger/src/core/breakpointService.ts
@@ -136,7 +136,7 @@ export class BreakpointService {
         .withArg('--usetoolingapi')
         .withArg('--json')
         .build(),
-      { cwd: projectPath }
+      { cwd: projectPath, env: RequestService.getEnvVars() }
     ).execute();
 
     const cmdOutput = new CommandOutput();
@@ -181,7 +181,7 @@ export class BreakpointService {
         .withArg('--usetoolingapi')
         .withArg('--json')
         .build(),
-      { cwd: projectPath }
+      { cwd: projectPath, env: RequestService.getEnvVars() }
     ).execute();
     const cmdOutput = new CommandOutput();
     const result = await cmdOutput.getCmdResult(execution);

--- a/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebug.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebug.test.ts
@@ -397,8 +397,8 @@ describe('Debugger adapter - unit', () => {
   describe('Line breakpoint request', () => {
     let breakpointReconcileSpy: sinon.SinonStub;
     let breakpointGetSpy: sinon.SinonSpy;
-    let breakpointGetTyperefSpy: sinon.SinonStub;
-    let breakpointCreateSpy: sinon.SinonStub;
+    let breakpointGetTyperefSpy: sinon.SinonSpy;
+    let breakpointCreateSpy: sinon.SinonSpy;
     let breakpointCacheSpy: sinon.SinonSpy;
     let sessionIdSpy: sinon.SinonStub;
 
@@ -412,6 +412,14 @@ describe('Debugger adapter - unit', () => {
       breakpointGetSpy = sinon.spy(
         BreakpointService.prototype,
         'getBreakpointsFor'
+      );
+      breakpointGetTyperefSpy = sinon.spy(
+        BreakpointService.prototype,
+        'getTyperefFor'
+      );
+      breakpointCreateSpy = sinon.spy(
+        BreakpointService.prototype,
+        'createLineBreakpoint'
       );
       breakpointCacheSpy = sinon.spy(
         BreakpointService.prototype,
@@ -446,13 +454,7 @@ describe('Debugger adapter - unit', () => {
       const bpLines = [1, 2];
       breakpointReconcileSpy = sinon
         .stub(BreakpointService.prototype, 'reconcileBreakpoints')
-        .returns(Promise.resolve(bpLines));
-      breakpointGetTyperefSpy = sinon
-        .stub(BreakpointService.prototype, 'getTyperefFor')
-        .returns('namespace/foo$inner');
-      breakpointCreateSpy = sinon
-        .stub(BreakpointService.prototype, 'createLineBreakpoint')
-        .returns(breakpointId);
+        .returns(Promise.resolve(new Set().add(1)));
       adapter.setSfdxProject('someProjectPath');
 
       await adapter.setBreakPointsReq(
@@ -468,108 +470,21 @@ describe('Debugger adapter - unit', () => {
       expect(breakpointReconcileSpy.calledOnce).to.equal(true);
       expect(breakpointReconcileSpy.getCall(0).args).to.deep.equal([
         'someProjectPath',
-        '07aFAKE',
         'file:///foo.cls',
+        '07aFAKE',
         bpLines
       ]);
-      expect(breakpointGetSpy.calledOnce).to.equal(true);
-      expect(breakpointGetSpy.getCall(0).args).to.have.same.members([
-        'file:///foo.cls'
-      ]);
-      expect(breakpointGetTyperefSpy.calledTwice).to.equal(true);
-      expect(breakpointCreateSpy.calledTwice).to.equal(true);
-      expect(breakpointCacheSpy.calledTwice).to.equal(true);
-
-      for (let i = 0; i < bpLines.length; i++) {
-        expect(breakpointGetTyperefSpy.getCall(i).args).to.have.same.members([
-          'file:///foo.cls',
-          bpLines[i]
-        ]);
-        expect(breakpointCreateSpy.getCall(i).args).to.have.same.members([
-          'someProjectPath',
-          '07aFAKE',
-          'namespace/foo$inner',
-          bpLines[i]
-        ]);
-        expect(breakpointCacheSpy.getCall(i).args).to.have.same.members([
-          'file:///foo.cls',
-          bpLines[i],
-          '07bFAKE'
-        ]);
-      }
-
-      const expectedResp = {
-        success: true,
-        body: {
-          breakpoints: [
-            {
-              verified: true,
-              source: {
-                path: 'foo.cls'
-              },
-              line: 1
-            },
-            {
-              verified: true,
-              source: {
-                path: 'foo.cls'
-              },
-              line: 2
-            }
-          ]
-        }
-      } as DebugProtocol.SetBreakpointsResponse;
-      expect(adapter.getResponse(0)).to.deep.equal(expectedResp);
-    });
-
-    it('Should not create breakpoint', async () => {
-      const bpLines = [1, 2];
-      breakpointReconcileSpy = sinon
-        .stub(BreakpointService.prototype, 'reconcileBreakpoints')
-        .returns(Promise.resolve(bpLines));
-      breakpointGetTyperefSpy = sinon
-        .stub(BreakpointService.prototype, 'getTyperefFor')
-        .returns('');
-      breakpointCreateSpy = sinon.stub(
-        BreakpointService.prototype,
-        'createLineBreakpoint'
-      );
-      adapter.setSfdxProject('someProjectPath');
-
-      await adapter.setBreakPointsReq(
-        {} as DebugProtocol.SetBreakpointsResponse,
-        {
-          source: {
-            path: 'foo.cls'
-          },
-          lines: bpLines
-        }
-      );
-
-      expect(breakpointReconcileSpy.calledOnce).to.equal(true);
-      expect(breakpointReconcileSpy.getCall(0).args).to.deep.equal([
-        'someProjectPath',
-        '07aFAKE',
-        'file:///foo.cls',
-        bpLines
-      ]);
-      expect(breakpointGetTyperefSpy.calledTwice).to.equal(true);
+      expect(breakpointGetSpy.called).to.equal(false);
+      expect(breakpointGetTyperefSpy.called).to.equal(false);
       expect(breakpointCreateSpy.called).to.equal(false);
       expect(breakpointCacheSpy.called).to.equal(false);
 
-      for (let i = 0; i < bpLines.length; i++) {
-        expect(breakpointGetTyperefSpy.getCall(i).args).to.have.same.members([
-          'file:///foo.cls',
-          bpLines[i]
-        ]);
-      }
-
       const expectedResp = {
         success: true,
         body: {
           breakpoints: [
             {
-              verified: false,
+              verified: true,
               source: {
                 path: 'foo.cls'
               },
@@ -588,15 +503,39 @@ describe('Debugger adapter - unit', () => {
       expect(adapter.getResponse(0)).to.deep.equal(expectedResp);
     });
 
-    it('Should output error', async () => {
+    it('Should not create breakpoint without source argument', async () => {
       const bpLines = [1, 2];
       breakpointReconcileSpy = sinon
         .stub(BreakpointService.prototype, 'reconcileBreakpoints')
-        .returns(
-          Promise.reject(
-            '{"message":"There was an error", "action":"Try again"}'
-          )
-        );
+        .returns(Promise.resolve(bpLines));
+      adapter.setSfdxProject('someProjectPath');
+
+      await adapter.setBreakPointsReq(
+        {} as DebugProtocol.SetBreakpointsResponse,
+        {
+          source: {
+            path: undefined
+          },
+          lines: bpLines
+        }
+      );
+
+      expect(breakpointReconcileSpy.called).to.equal(false);
+      expect(breakpointGetTyperefSpy.called).to.equal(false);
+      expect(breakpointCreateSpy.called).to.equal(false);
+      expect(breakpointCacheSpy.called).to.equal(false);
+
+      const expectedResp = {
+        success: true
+      } as DebugProtocol.SetBreakpointsResponse;
+      expect(adapter.getResponse(0)).to.deep.equal(expectedResp);
+    });
+
+    it('Should not create breakpoint without lines argument', async () => {
+      const bpLines = [1, 2];
+      breakpointReconcileSpy = sinon
+        .stub(BreakpointService.prototype, 'reconcileBreakpoints')
+        .returns(Promise.resolve(bpLines));
       adapter.setSfdxProject('someProjectPath');
 
       await adapter.setBreakPointsReq(
@@ -605,23 +544,19 @@ describe('Debugger adapter - unit', () => {
           source: {
             path: 'foo.cls'
           },
-          lines: bpLines
+          lines: undefined
         }
       );
 
-      expect(breakpointReconcileSpy.calledOnce).to.equal(true);
-      expect(breakpointReconcileSpy.getCall(0).args).to.deep.equal([
-        'someProjectPath',
-        '07aFAKE',
-        'file:///foo.cls',
-        bpLines
-      ]);
-      expect(adapter.getResponse(0).success).to.equal(false);
-      expect(adapter.getResponse(0).message).to.equal('There was an error');
-      expect(adapter.getEvents()[0].event).to.equal('output');
-      expect(
-        (adapter.getEvents()[0] as OutputEvent).body.output
-      ).to.have.string('Try again');
+      expect(breakpointReconcileSpy.called).to.equal(false);
+      expect(breakpointGetTyperefSpy.called).to.equal(false);
+      expect(breakpointCreateSpy.called).to.equal(false);
+      expect(breakpointCacheSpy.called).to.equal(false);
+
+      const expectedResp = {
+        success: true
+      } as DebugProtocol.SetBreakpointsResponse;
+      expect(adapter.getResponse(0)).to.deep.equal(expectedResp);
     });
   });
 

--- a/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebug.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebug.test.ts
@@ -450,7 +450,6 @@ describe('Debugger adapter - unit', () => {
     });
 
     it('Should create breakpoint', async () => {
-      const breakpointId = '07bFAKE';
       const bpLines = [1, 2];
       breakpointReconcileSpy = sinon
         .stub(BreakpointService.prototype, 'reconcileBreakpoints')

--- a/packages/salesforcedx-apex-debugger/test/unit/core/breakpointService.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/core/breakpointService.test.ts
@@ -5,10 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import {
-  CommandOutput,
-  SfdxCommandBuilder
-} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import { SfdxCommandBuilder } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import {


### PR DESCRIPTION
### What does this PR do?
If you enable breakpoints on lines 1, 2, 3, VS Code sends three requests to the adapter. Request 1 wants a breakpoint on line 1. Request 2 wants breakpoints on lines 1 & 2. Request 3 wants breakpoints on lines 1, 2, & 3. 

Each breakpoint request is not handled individually from start to finish. Due to nodejs event loop, a breakpoint request will be put aside when it spawns an SFDX CLI process to add/delete breakpoint. The next breakpoint request will start getting handled. 

We also need to watch out for when we delete & add quickly, and vice versa. For example, if you click on line 1 to delete, then click it again to add, the first request will kick off a breakpoint delete with the CLI. The second request starts getting handled, but the adapter already has line 1 in its cache because the delete operation hasn't finished yet, so the adapter thought the add was a no-op.

That means the breakpoint service needs to remove duplicates, reconcile the client's list of breakpoints vs. cached breakpoints to know which to add and delete, and also reconcile with in-flight breakpoint operations.

### What issues does this PR fix or reference?
@W-4336889@