### PR TITLE
Fix debugger capabilities and stop command

### DIFF
--- a/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
+++ b/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
@@ -424,7 +424,19 @@ export class ApexDebug extends DebugSession {
           );
         }
         this.initializedResponse.body = {
-          supportsDelayedStackTraceLoading: false
+          supportsCompletionsRequest: false,
+          supportsConditionalBreakpoints: false,
+          supportsDelayedStackTraceLoading: false,
+          supportsEvaluateForHovers: false,
+          supportsExceptionInfoRequest: false,
+          supportsExceptionOptions: false,
+          supportsFunctionBreakpoints: false,
+          supportsHitConditionalBreakpoints: false,
+          supportsLoadedSourcesRequest: false,
+          supportsRestartFrame: false,
+          supportsSetVariable: false,
+          supportsStepBack: false,
+          supportsStepInTargetsRequest: false
         };
         this.initializedResponse.success = true;
         this.sendResponse(this.initializedResponse);

--- a/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebug.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebug.test.ts
@@ -964,7 +964,19 @@ describe('Debugger adapter - unit', () => {
         success: true,
         type: 'response',
         body: {
-          supportsDelayedStackTraceLoading: false
+          supportsCompletionsRequest: false,
+          supportsConditionalBreakpoints: false,
+          supportsDelayedStackTraceLoading: false,
+          supportsEvaluateForHovers: false,
+          supportsExceptionInfoRequest: false,
+          supportsExceptionOptions: false,
+          supportsFunctionBreakpoints: false,
+          supportsHitConditionalBreakpoints: false,
+          supportsLoadedSourcesRequest: false,
+          supportsRestartFrame: false,
+          supportsSetVariable: false,
+          supportsStepBack: false,
+          supportsStepInTargetsRequest: false
         }
       } as DebugProtocol.InitializeResponse;
 

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -104,10 +104,6 @@
         {
           "command": "sfdx.force.lightning.interface.create",
           "when": "explorerResourceIsFolder && sfdx:project_opened"
-        },
-        {
-          "command": "sfdx.force.debugger.stop",
-          "when": "explorerResourceIsFolder && sfdx:project_opened"
         }
       ],
       "commandPalette": [
@@ -196,7 +192,6 @@
           "when": "sfdx:project_opened"
         },
         {
-
           "command": "sfdx.force.alias.list",
           "when": "sfdx:project_opened"
         },

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -90,5 +90,8 @@ export const messages = {
   force_alias_list_text: 'SFDX: List All Aliases',
   force_org_display_default_text:
     'SFDX: Display Org Details for Default Scratch Org',
-  force_org_display_username_text: 'SFDX: Display Org Details...'
+  force_org_display_username_text: 'SFDX: Display Org Details...',
+  force_debugger_query_session_text: 'query for Apex Debugger session',
+  force_debugger_stop_text: 'SFDX: Stop Apex Debugger Session',
+  force_debugger_stop_none_found_text: 'No Apex Debugger session found.'
 };


### PR DESCRIPTION
### What does this PR do?
Disable debugger capabilities that we don't support. Remove Apex Debugger stop command from right-click menu in the project explorer. Clean up the notifications from the stop command.

### What issues does this PR fix or reference?
@W-4337014, W-4331254@