### PR TITLE
Debugger whitelist

### DIFF
--- a/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
+++ b/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
@@ -61,8 +61,8 @@ import os = require('os');
 
 export interface LaunchRequestArguments
   extends DebugProtocol.LaunchRequestArguments {
-  userIdFilter?: string;
-  requestTypeFilter?: string;
+  userIdFilter?: string[];
+  requestTypeFilter?: string[];
   entryPointFilter?: string;
   sfdxProject: string;
 }
@@ -134,9 +134,9 @@ export class ApexDebug extends DebugSession {
 
       const sessionId = await this.mySessionService
         .forProject(args.sfdxProject)
-        .withUserFilter(args.userIdFilter)
+        .withUserFilter(this.stringifyLaunchArg(args.userIdFilter))
         .withEntryFilter(args.entryPointFilter)
-        .withRequestFilter(args.requestTypeFilter)
+        .withRequestFilter(this.stringifyLaunchArg(args.requestTypeFilter))
         .start();
       if (this.mySessionService.isConnected()) {
         response.success = true;
@@ -710,7 +710,7 @@ export class ApexDebug extends DebugSession {
     if (threadId !== undefined) {
       this.logEvent(message);
       const stoppedEvent: DebugProtocol.StoppedEvent = new StoppedEvent(
-        message.sobject.BreakpointId ? 'breakpoint' : 'step',
+        '',
         threadId
       );
       this.sendEvent(stoppedEvent);
@@ -743,6 +743,13 @@ export class ApexDebug extends DebugSession {
         } as VscodeDebuggerMessage)
       );
     }
+  }
+
+  private stringifyLaunchArg(arg?: string[]): string {
+    if (arg && arg.length > 0) {
+      return Array.from(new Set(arg)).join(',');
+    }
+    return '';
   }
 }
 

--- a/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
+++ b/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
@@ -134,9 +134,9 @@ export class ApexDebug extends DebugSession {
 
       const sessionId = await this.mySessionService
         .forProject(args.sfdxProject)
-        .withUserFilter(this.stringifyLaunchArg(args.userIdFilter))
+        .withUserFilter(this.toCommaSeparatedString(args.userIdFilter))
         .withEntryFilter(args.entryPointFilter)
-        .withRequestFilter(this.stringifyLaunchArg(args.requestTypeFilter))
+        .withRequestFilter(this.toCommaSeparatedString(args.requestTypeFilter))
         .start();
       if (this.mySessionService.isConnected()) {
         response.success = true;
@@ -745,7 +745,7 @@ export class ApexDebug extends DebugSession {
     }
   }
 
-  private stringifyLaunchArg(arg?: string[]): string {
+  public toCommaSeparatedString(arg?: string[]): string {
     if (arg && arg.length > 0) {
       return Array.from(new Set(arg)).join(',');
     }

--- a/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebug.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebug.test.ts
@@ -176,9 +176,13 @@ describe('Debugger adapter - unit', () => {
       };
       args = {
         sfdxProject: 'project',
-        userIdFilter: 'user',
+        userIdFilter: ['005FAKE1', '005FAKE2', '005FAKE1'],
         entryPointFilter: 'entry',
-        requestTypeFilter: 'request'
+        requestTypeFilter: [
+          'RUN_TESTS_SYNCHRONOUS',
+          'EXECUTE_ANONYMOUS',
+          'RUN_TESTS_SYNCHRONOUS'
+        ]
       };
     });
 
@@ -218,6 +222,18 @@ describe('Debugger adapter - unit', () => {
         (adapter.getEvents()[0] as OutputEvent).body.output
       ).to.have.string(nls.localize('session_started_text', sessionId));
       expect(adapter.getEvents()[1].event).to.equal('initialized');
+      expect(sessionUserFilterSpy.calledOnce).to.equal(true);
+      expect(sessionEntryFilterSpy.calledOnce).to.equal(true);
+      expect(sessionRequestFilterSpy.calledOnce).to.equal(true);
+      expect(sessionUserFilterSpy.getCall(0).args).to.have.same.members([
+        '005FAKE1,005FAKE2'
+      ]);
+      expect(sessionEntryFilterSpy.getCall(0).args).to.have.same.members([
+        'entry'
+      ]);
+      expect(sessionRequestFilterSpy.getCall(0).args).to.have.same.members([
+        'RUN_TESTS_SYNCHRONOUS,EXECUTE_ANONYMOUS'
+      ]);
     });
 
     it('Should not launch if ApexDebuggerSession object is not accessible', async () => {
@@ -1406,7 +1422,7 @@ describe('Debugger adapter - unit', () => {
       const stoppedEvent = adapter.getEvents()[1] as StoppedEvent;
       expect(stoppedEvent.body).to.deep.equal({
         threadId: 1,
-        reason: 'breakpoint'
+        reason: ''
       });
       expect(markEventProcessedSpy.calledOnce).to.equal(true);
       expect(markEventProcessedSpy.getCall(0).args).to.have.same.members([
@@ -1433,7 +1449,7 @@ describe('Debugger adapter - unit', () => {
       expect(adapter.getEvents()[0].event).to.equal('output');
       expect(adapter.getEvents()[1].event).to.equal('stopped');
       const threadEvent = adapter.getEvents()[1] as StoppedEvent;
-      expect(threadEvent.body.reason).to.equal('step');
+      expect(threadEvent.body.reason).to.equal('');
       expect(threadEvent.body.threadId).to.equal(1);
     });
 

--- a/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebug.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebug.test.ts
@@ -308,6 +308,14 @@ describe('Debugger adapter - unit', () => {
       );
       expect(adapter.getEvents().length).to.equal(0);
     });
+
+    it('Should return empty string with null launch array', () => {
+      expect(adapter.toCommaSeparatedString()).to.equal('');
+    });
+
+    it('Should return empty string with empty launch array', () => {
+      expect(adapter.toCommaSeparatedString([])).to.equal('');
+    });
   });
 
   describe('Disconnect', () => {

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -76,14 +76,39 @@
             "properties": {
               "required": ["sfdxProject"],
               "userIdFilter": {
-                "type": "string",
+                "type": "array",
                 "description": "%user_id_filter_text%",
-                "default": ""
+                "default": [],
+                "items": {
+                  "type": "string"
+                }
               },
               "requestTypeFilter": {
-                "type": "string",
+                "type": "array",
                 "description": "%request_type_filter_text%",
-                "default": ""
+                "default": "",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "BATCH_APEX",
+                    "EXECUTE_ANONYMOUS",
+                    "FUTURE",
+                    "INBOUND_EMAIL_SERVICE",
+                    "INVOCABLE_ACTION",
+                    "LIGHTNING",
+                    "QUEUEABLE",
+                    "QUICK_ACTION",
+                    "REMOTE_ACTION",
+                    "REST",
+                    "RUN_TESTS_ASYNCHRONOUS",
+                    "RUN_TESTS_SYNCHRONOUS",
+                    "RUN_TESTS_DEPLOY",
+                    "SCHEDULED",
+                    "SOAP",
+                    "SYNCHRONOUS",
+                    "VISUALFORCE"
+                  ]
+                }
               },
               "entryPointFilter": {
                 "type": "string",

--- a/packages/salesforcedx-vscode-apex-debugger/package.nls.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.nls.json
@@ -1,9 +1,13 @@
 {
-  "user_id_filter_text": "A comma-separated list of user IDs with requests whitelisted for debugging",
-  "request_type_filter_text": "A comma-separated list of ApexRequesType values whitelisted for debugging",
-  "entry_point_filter_text": "A regular expression matching entry points whitelisted for debugging",
+  "user_id_filter_text":
+    "A list of user IDs with requests whitelisted for debugging",
+  "request_type_filter_text":
+    "A list of Apex request types whitelisted for debugging",
+  "entry_point_filter_text":
+    "A regular expression matching entry points whitelisted for debugging",
   "sfdx_project_text": "Location of SFDX project",
   "launch_snippet_label_text": "Apex Debugger: Launch",
-  "launch_snippet_description_text": "A new configuration for launching Apex Debugger",
+  "launch_snippet_description_text":
+    "A new configuration for launching Apex Debugger",
   "launch_snippet_name": "Launch Apex Debugger"
 }


### PR DESCRIPTION
### What does this PR do?
Change UserIdFilter into an array so user doesn't have to type commas. Change RequestTypeFilter into an array and suggest possible values. 

![requesttypefiltersuggestion](https://user-images.githubusercontent.com/7286437/30941165-fb250064-a398-11e7-8009-d31022507686.png)

Also, remove the stopped event reason so it defaults to just "Paused" in the callstack.

![callstackpaused](https://user-images.githubusercontent.com/7286437/30941233-46523610-a399-11e7-805c-3357fd56b015.png)

### What issues does this PR fix or reference?
@W-4314787, W-4314153@