### PR TITLE
Rene/sfdx soql query

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/test/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/test/index.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+// tslint:disable-next-line:no-var-requires
+// tslint:disable-next-line:variable-name
+import Mocha = require('mocha');
+
+// You can directly control Mocha options by uncommenting the following lines
+// See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
+
+const mocha = new Mocha({
+  ui: 'bdd',
+  timeout: 100000
+});
+mocha.useColors(true);
+
+module.exports = mocha;

--- a/packages/salesforcedx-utils-vscode/src/test/orgUtils.ts
+++ b/packages/salesforcedx-utils-vscode/src/test/orgUtils.ts
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { CliCommandExecutor, CommandOutput, SfdxCommandBuilder } from '../cli';
+import childProcess = require('child_process');
+import * as path from 'path';
+import * as util from 'util';
+
+// Used only for CI purposes. Must call delete if you call create
+export async function createSFDXProject(projectName: string): Promise<void> {
+  const execution = new CliCommandExecutor(
+    new SfdxCommandBuilder()
+      .withArg('force:project:create')
+      .withFlag('--projectname', projectName)
+      .withJson()
+      .build(),
+    { cwd: process.cwd() }
+  ).execute();
+  const cmdOutput = new CommandOutput();
+  await cmdOutput.getCmdResult(execution);
+  return Promise.resolve();
+}
+
+export async function createScratchOrg(projectName: string): Promise<string> {
+  const scratchDefFilePath = path.join(
+    process.cwd(),
+    projectName,
+    'config',
+    'project-scratch-def.json'
+  );
+  const execution = new CliCommandExecutor(
+    new SfdxCommandBuilder()
+      .withArg('force:org:create')
+      .withFlag('--definitionfile', `${scratchDefFilePath}`)
+      .withArg('--setdefaultusername')
+      .withJson()
+      .build(),
+    { cwd: path.join(process.cwd(), projectName) }
+  ).execute();
+  const cmdOutput = new CommandOutput();
+  const result = await cmdOutput.getCmdResult(execution);
+  const username = JSON.parse(result).result.username;
+  return Promise.resolve(username);
+}
+
+export async function deleteScratchOrg(
+  projectName: string,
+  username: string
+): Promise<string> {
+  const execution = new CliCommandExecutor(
+    new SfdxCommandBuilder()
+      .withArg('force:org:delete')
+      .withFlag('--targetusername', username)
+      .withArg('--noprompt')
+      .withJson()
+      .build(),
+    { cwd: path.join(process.cwd(), projectName) }
+  ).execute();
+  const cmdOutput = new CommandOutput();
+  const result = await cmdOutput.getCmdResult(execution);
+  return Promise.resolve(result);
+}
+
+export async function pushSource(
+  sourceFolder: string,
+  projectName: string,
+  username: string
+): Promise<string> {
+  const targetFolder = path.join(
+    process.cwd(),
+    projectName,
+    'force-app',
+    'main',
+    'default'
+  );
+  childProcess.execSync('cp -R ' + sourceFolder + ' ' + targetFolder);
+  const execution = new CliCommandExecutor(
+    new SfdxCommandBuilder()
+      .withArg('force:source:push')
+      .withFlag('--targetusername', username)
+      .withJson()
+      .build(),
+    { cwd: path.join(process.cwd(), projectName) }
+  ).execute();
+  const cmdOutput = new CommandOutput();
+  const result = await cmdOutput.getCmdResult(execution);
+  const source = JSON.parse(result).result.pushedSource;
+  return Promise.resolve(source);
+}
+
+export async function pullSource(
+  projectName: string,
+  username: string
+): Promise<string> {
+  const execution = new CliCommandExecutor(
+    new SfdxCommandBuilder()
+      .withArg('force:source:pull')
+      .withFlag('--targetusername', username)
+      .withJson()
+      .build(),
+    { cwd: path.join(process.cwd(), projectName) }
+  ).execute();
+  const cmdOutput = new CommandOutput();
+  const result = await cmdOutput.getCmdResult(execution);
+  const source = JSON.parse(result).result.pushedSource;
+  return Promise.resolve(source);
+}
+
+export async function createPermissionSet(
+  permissionSetName: string,
+  username: string
+): Promise<string> {
+  const execution = new CliCommandExecutor(
+    new SfdxCommandBuilder()
+      .withArg('force:data:record:create')
+      .withFlag('--sobjecttype', 'PermissionSet')
+      .withFlag('--targetusername', username)
+      .withFlag(
+        '--values',
+        'Name=' + permissionSetName + " Label='Give FLS Read'"
+      )
+      .withJson()
+      .build(),
+    { cwd: process.cwd() }
+  ).execute();
+  const cmdOutput = new CommandOutput();
+  const result = await cmdOutput.getCmdResult(execution);
+  const permissionSetId = JSON.parse(result).result.id as string;
+  return Promise.resolve(permissionSetId);
+}
+
+export async function createFieldPermissions(
+  permissionSetId: string,
+  sobjectType: string,
+  fieldName: string,
+  username: string
+): Promise<void> {
+  const execution = new CliCommandExecutor(
+    new SfdxCommandBuilder()
+      .withArg('force:data:record:create')
+      .withFlag('--sobjecttype', 'FieldPermissions')
+      .withFlag('--targetusername', username)
+      .withFlag(
+        '--values',
+        util.format(
+          'ParentId=%s SobjectType=%s Field=%s PermissionsRead=true',
+          permissionSetId,
+          sobjectType,
+          fieldName
+        )
+      )
+      .withJson()
+      .build(),
+    { cwd: process.cwd() }
+  ).execute();
+  const cmdOutput = new CommandOutput();
+  await cmdOutput.getCmdResult(execution);
+  return Promise.resolve();
+}
+
+export async function assignPermissionSet(
+  permissionSetName: string,
+  username: string
+): Promise<void> {
+  const execution = new CliCommandExecutor(
+    new SfdxCommandBuilder()
+      .withArg('force:user:permset:assign')
+      .withFlag('--permsetname', permissionSetName)
+      .withFlag('--targetusername', username)
+      .withJson()
+      .build(),
+    { cwd: process.cwd() }
+  ).execute();
+  const cmdOutput = new CommandOutput();
+  await cmdOutput.getCmdResult(execution);
+  return Promise.resolve();
+}

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -206,6 +206,14 @@
         {
           "command": "sfdx.force.internal.refreshsobjects",
           "when": "config.sfdx.refreshSObjects.enabled"
+        },
+        {
+          "command": "sfdx.force.data.soql.query.input",
+          "when": "sfdx:project_opened && !editorHasSelection"
+        },
+        {
+          "command": "sfdx.force.data.soql.query.selection",
+          "when": "sfdx:project_opened && editorHasSelection"
         }
       ]
     },
@@ -309,6 +317,14 @@
       {
         "command": "sfdx.force.internal.refreshsobjects",
         "title": "%force_refresh_sobjects%"
+      },
+      {
+        "command": "sfdx.force.data.soql.query.input",
+        "title": "%force_data_soql_query_input_text%"
+      },
+      {
+        "command": "sfdx.force.data.soql.query.selection",
+        "title": "%force_data_soql_query_selection_text%"
       }
     ]
   }

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -34,5 +34,8 @@
   "force_org_display_default_text":
     "SFDX: Display Org Details for Default Scratch Org",
   "force_org_display_username_text": "SFDX: Display Org Details...",
-  "force_refresh_sobjects": "SFDX: Refresh SObject Definitions"
+  "force_refresh_sobjects": "SFDX: Refresh SObject Definitions",
+  "force_data_soql_query_input_text": "SFDX: Execute SOQL Query...",
+  "force_data_soql_query_selection_text":
+    "SFDX: Execute SOQL Query with Currently Selected Text"
 }

--- a/packages/salesforcedx-vscode-core/src/commands/forceDataSoqlQuery.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceDataSoqlQuery.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  Command,
+  SfdxCommandBuilder
+} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import * as vscode from 'vscode';
+import { nls } from '../messages';
+import {
+  CancelResponse,
+  ContinueResponse,
+  ParametersGatherer,
+  SfdxCommandlet,
+  SfdxCommandletExecutor,
+  SfdxWorkspaceChecker
+} from './commands';
+
+class ForceDataSoqlQueryExecutor extends SfdxCommandletExecutor<{}> {
+  public build(data: QueryInput): Command {
+    return new SfdxCommandBuilder()
+      .withDescription(nls.localize('force_data_soql_query_input_text'))
+      .withArg('force:data:soql:query')
+      .withFlag('--query', `${data.input}`)
+      .build();
+  }
+}
+
+export type QueryInput = {
+  input: string;
+};
+
+export class GetQueryInput implements ParametersGatherer<{ input: string }> {
+  public async gather(): Promise<
+    CancelResponse | ContinueResponse<{ input: string }>
+  > {
+    const editor = await vscode.window.activeTextEditor;
+
+    let input;
+
+    if (!editor) {
+      const userInputOptions = <vscode.InputBoxOptions>{
+        prompt: nls.localize('parameter_gatherer_enter_soql_query')
+      };
+      input = await vscode.window.showInputBox(userInputOptions);
+    } else {
+      const document = editor.document;
+      if (editor.selection.isEmpty) {
+        const userInputOptions = <vscode.InputBoxOptions>{
+          prompt: nls.localize('parameter_gatherer_enter_soql_query')
+        };
+        input = await vscode.window.showInputBox(userInputOptions);
+      } else {
+        input = document.getText(editor.selection);
+      }
+    }
+
+    input = input!.replace('[', '').replace(']', '');
+    return input ? { type: 'CONTINUE', data: { input } } : { type: 'CANCEL' };
+  }
+}
+
+const workspaceChecker = new SfdxWorkspaceChecker();
+
+export async function forceDataSoqlQuery(explorerDir?: any) {
+  const parameterGatherer = new GetQueryInput();
+  const commandlet = new SfdxCommandlet(
+    workspaceChecker,
+    parameterGatherer,
+    new ForceDataSoqlQueryExecutor()
+  );
+  commandlet.run();
+}

--- a/packages/salesforcedx-vscode-core/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/index.ts
@@ -7,6 +7,7 @@
 
 export { forceAuthWebLogin } from './forceAuthWebLogin';
 export { forceApexTestRun } from './forceApexTestRun';
+export { forceDataSoqlQuery } from './forceDataSoqlQuery';
 export { forceOrgCreate } from './forceOrgCreate';
 export { forceOrgOpen } from './forceOrgOpen';
 export { forceSourcePull } from './forceSourcePull';

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -13,6 +13,7 @@ import {
   forceApexTestRun,
   forceAuthWebLogin,
   forceConfigList,
+  forceDataSoqlQuery,
   forceDebuggerStop,
   forceGenerateFauxClassesCreate,
   forceLightningAppCreate,
@@ -137,6 +138,14 @@ function registerCommands(): vscode.Disposable {
     forceOrgDisplay,
     { flag: '--targetusername' }
   );
+  const forceDataSoqlQueryInputCmd = vscode.commands.registerCommand(
+    'sfdx.force.data.soql.query.input',
+    forceDataSoqlQuery
+  );
+  const forceDataSoqlQuerySelectionCmd = vscode.commands.registerCommand(
+    'sfdx.force.data.soql.query.selection',
+    forceDataSoqlQuery
+  );
 
   const forceGenerateFauxClassesCmd = vscode.commands.registerCommand(
     'sfdx.force.internal.refreshsobjects',
@@ -152,6 +161,8 @@ function registerCommands(): vscode.Disposable {
   return vscode.Disposable.from(
     forceApexTestRunCmd,
     forceAuthWebLoginCmd,
+    forceDataSoqlQueryInputCmd,
+    forceDataSoqlQuerySelectionCmd,
     forceOrgCreateCmd,
     forceOrgOpenCmd,
     forceSourcePullCmd,

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -91,5 +91,9 @@ export const messages = {
   force_org_display_username_text: 'SFDX: Display Org Details...',
   force_debugger_query_session_text: 'query for Apex Debugger session',
   force_debugger_stop_text: 'SFDX: Stop Apex Debugger Session',
-  force_debugger_stop_none_found_text: 'No Apex Debugger session found.'
+  force_debugger_stop_none_found_text: 'No Apex Debugger session found.',
+  force_data_soql_query_input_text: 'SFDX: Execute SOQL Query...',
+  force_data_soql_query_selection_text:
+    'SFDX: Execute SOQL Query with Currently Selected Text',
+  parameter_gatherer_enter_soql_query: 'Enter the SOQL query'
 };

--- a/packages/system-tests/package.json
+++ b/packages/system-tests/package.json
@@ -9,6 +9,7 @@
     "vscode": "^1.13.0"
   },
   "devDependencies": {
+    "@salesforce/salesforcedx-utils-vscode": "^40.10.0",
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
     "@types/node": "^6.0.40",
@@ -34,13 +35,14 @@
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
-    "clean": "shx rm -rf .vscode-test && shx rm -rf node_modules && shx rm -rf out",
+    "clean":
+      "shx rm -rf .vscode-test && shx rm -rf node_modules && shx rm -rf out",
     "postinstall": "node ./node_modules/vscode/bin/install",
-    "pretest": "npm run compile && node ../../scripts/download-vscode-for-system-tests",
+    "pretest":
+      "npm run compile && node ../../scripts/download-vscode-for-system-tests",
     "test": "node out/src/main.js",
-    "coverage": "npm run pretest && node ../../scripts/instrument-salesforcedx-vscode-extensions && cross-env COLLECT_COVERAGE=1 npm run test && node ../../scripts/remap-coverage"
+    "coverage":
+      "npm run pretest && node ../../scripts/instrument-salesforcedx-vscode-extensions && cross-env COLLECT_COVERAGE=1 npm run test && node ../../scripts/remap-coverage"
   },
-  "activationEvents": [
-    "*"
-  ]
+  "activationEvents": ["*"]
 }

--- a/packages/system-tests/scenarios/forceSoqlQueryUi.test.ts
+++ b/packages/system-tests/scenarios/forceSoqlQueryUi.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+// tslint:disable:no-unused-expression
+import * as util from '@salesforce/salesforcedx-utils-vscode/out/src/test/orgUtils';
+import { expect } from 'chai';
+import * as path from 'path';
+import { CommonActions } from '../src/areas/common';
+import { removeWorkspace } from '../src/helpers/workspace';
+import {
+  SpectronApplication,
+  VSCODE_BINARY_PATH
+} from '../src/spectron/application';
+
+const TITLE = 'force:soql:query UI commands Tests';
+const PROJECT_NAME = `project_${new Date().getTime()}`;
+
+describe(TITLE, () => {
+  let app: SpectronApplication;
+  let common: CommonActions;
+
+  const PROJECT_DIR = path.join(process.cwd(), PROJECT_NAME);
+
+  let username: string;
+
+  before(async () => {
+    await util.createSFDXProject(PROJECT_NAME);
+    username = await util.createScratchOrg(PROJECT_NAME);
+  });
+
+  after(async () => {
+    await util.deleteScratchOrg(PROJECT_NAME, username);
+    await removeWorkspace(PROJECT_DIR);
+  });
+
+  beforeEach(async () => {
+    app = new SpectronApplication(VSCODE_BINARY_PATH, TITLE, 2, [PROJECT_DIR]);
+    common = new CommonActions(app);
+
+    await app.start();
+    await app.wait();
+  });
+
+  afterEach(async () => {
+    return await app.stop();
+  });
+
+  it('Should execute SOQL query from input box', async () => {
+    // Invoke SFDX: Execute SOQL Query command by name
+    await app.command('workbench.action.quickOpen');
+    await common.type('>SFDX: Execute SOQL Query...');
+    await app.client.keys(['NULL', 'Enter', 'NULL'], false);
+    await app.wait();
+
+    const query = `SELECT Id, Name FROM Account`;
+
+    // Enter SOQL query
+    await common.type(query);
+    await app.client.keys(['NULL', 'Enter', 'NULL'], false);
+    await app.wait();
+
+    const successNotification = await common.getMessageNotification();
+    expect(successNotification).to.equal(
+      'SFDX: Execute SOQL Query... successfully ran'
+    );
+  });
+
+  it('Should execute SOQL query with current selection', async () => {
+    // Enter SOQL query in active editor
+    const query = `SELECT Id, Name FROM Account`;
+    await common.type(query);
+    await app.wait();
+
+    // Select all text in the current window
+    await app.client.keys(['Meta', 'a', 'NULL'], false);
+
+    // Invoke SFDX: Execute SOQL Query command by name
+    await app.command('workbench.action.quickOpen');
+    await common.type('>SFDX: Execute SOQL Query with Currently Selected Text');
+    await app.client.keys(['NULL', 'Enter', 'NULL'], false);
+    await app.wait();
+
+    const successNotification = await common.getMessageNotification();
+    expect(successNotification).to.equal(
+      'SFDX: Execute SOQL Query... successfully ran'
+    );
+  });
+});

--- a/packages/system-tests/scenarios/forceSoqlQueryUi.test.ts
+++ b/packages/system-tests/scenarios/forceSoqlQueryUi.test.ts
@@ -30,14 +30,6 @@ describe(TITLE, () => {
   before(async () => {
     await util.createSFDXProject(PROJECT_NAME);
     username = await util.createScratchOrg(PROJECT_NAME);
-  });
-
-  after(async () => {
-    await util.deleteScratchOrg(PROJECT_NAME, username);
-    await removeWorkspace(PROJECT_DIR);
-  });
-
-  beforeEach(async () => {
     app = new SpectronApplication(VSCODE_BINARY_PATH, TITLE, 2, [PROJECT_DIR]);
     common = new CommonActions(app);
 
@@ -45,8 +37,10 @@ describe(TITLE, () => {
     await app.wait();
   });
 
-  afterEach(async () => {
-    return await app.stop();
+  after(async () => {
+    await app.stop();
+    await util.deleteScratchOrg(PROJECT_NAME, username);
+    await removeWorkspace(PROJECT_DIR);
   });
 
   it('Should execute SOQL query from input box', async () => {

--- a/packages/system-tests/scenarios/forceSoqlQueryUi.test.ts
+++ b/packages/system-tests/scenarios/forceSoqlQueryUi.test.ts
@@ -70,6 +70,10 @@ describe(TITLE, () => {
   });
 
   it('Should execute SOQL query with current selection', async () => {
+    // Open new untitled file
+    await app.command('workbench.action.files.newUntitledFile');
+    await app.wait();
+
     // Enter SOQL query in active editor
     const query = `SELECT Id, Name FROM Account`;
     await common.type(query);

--- a/packages/system-tests/scenarios/forceSoqlQueryUi.test.ts
+++ b/packages/system-tests/scenarios/forceSoqlQueryUi.test.ts
@@ -63,10 +63,12 @@ describe(TITLE, () => {
     await app.client.keys(['NULL', 'Enter', 'NULL'], false);
     await app.wait();
 
-    const successNotification = await common.getMessageNotification();
-    expect(successNotification).to.equal(
-      'SFDX: Execute SOQL Query... successfully ran'
-    );
+    const consoleHtml = await common.getConsoleHtml();
+    for (let i = 0; i < consoleHtml.length; i++) {
+      if (consoleHtml[i].indexOf('xit&nbsp;code') > 0) {
+        expect(consoleHtml[i]).to.contain('exit&nbsp;code&nbsp;0');
+      }
+    }
   });
 
   it('Should execute SOQL query with current selection', async () => {
@@ -88,9 +90,11 @@ describe(TITLE, () => {
     await app.client.keys(['NULL', 'Enter', 'NULL'], false);
     await app.wait();
 
-    const successNotification = await common.getMessageNotification();
-    expect(successNotification).to.equal(
-      'SFDX: Execute SOQL Query... successfully ran'
-    );
+    const consoleHtml = await common.getConsoleHtml();
+    for (let i = 0; i < consoleHtml.length; i++) {
+      if (consoleHtml[i].indexOf('xit&nbsp;code') > 0) {
+        expect(consoleHtml[i]).to.contain('exit&nbsp;code&nbsp;0');
+      }
+    }
   });
 });

--- a/packages/system-tests/scenarios/forceSoqlQueryUi.test.ts
+++ b/packages/system-tests/scenarios/forceSoqlQueryUi.test.ts
@@ -76,7 +76,7 @@ describe(TITLE, () => {
     await app.wait();
 
     // Select all text in the current window
-    await app.client.keys(['Meta', 'a', 'NULL'], false);
+    await app.command('editor.action.selectAll');
 
     // Invoke SFDX: Execute SOQL Query command by name
     await app.command('workbench.action.quickOpen');

--- a/packages/system-tests/scenarios/scaffolding.test.ts
+++ b/packages/system-tests/scenarios/scaffolding.test.ts
@@ -26,7 +26,7 @@ describe('Scaffolding commands', () => {
   let app: SpectronApplication;
   let common: CommonActions;
 
-  beforeEach(async () => {
+  before(async () => {
     app = new SpectronApplication(VSCODE_BINARY_PATH, TITLE, 2, [
       WORKSPACE_PATH
     ]);
@@ -36,7 +36,7 @@ describe('Scaffolding commands', () => {
     await app.wait();
   });
 
-  afterEach(async () => {
+  after(async () => {
     return await app.stop();
   });
 

--- a/packages/system-tests/src/areas/common.ts
+++ b/packages/system-tests/src/areas/common.ts
@@ -70,12 +70,12 @@ export class CommonActions {
     );
   }
 
-  public async getMessageNotification(): Promise<any> {
-    const notification = `span[class="message-left-side"]`;
-    const el = await this.spectron.client.element(notification);
+  public async getConsoleHtml(): Promise<any> {
+    const htmlTag = `div[class="view-lines"]`;
+    const el = await this.spectron.client.element(htmlTag);
     if (el.status === 0) {
-      const text = this.spectron.client.getText(notification);
-      return text;
+      const html = await this.spectron.client.getHTML(htmlTag);
+      return html;
     }
     return undefined;
   }

--- a/packages/system-tests/src/areas/common.ts
+++ b/packages/system-tests/src/areas/common.ts
@@ -70,6 +70,16 @@ export class CommonActions {
     );
   }
 
+  public async getMessageNotification(): Promise<any> {
+    const notification = `span[class="message-left-side"]`;
+    const el = await this.spectron.client.element(notification);
+    if (el.status === 0) {
+      const text = this.spectron.client.getText(notification);
+      return text;
+    }
+    return undefined;
+  }
+
   public async openFirstMatchFile(fileName: string): Promise<any> {
     await this.openQuickOpen();
     await this.type(fileName);

--- a/packages/system-tests/src/helpers/workspace.ts
+++ b/packages/system-tests/src/helpers/workspace.ts
@@ -7,7 +7,7 @@
  */
 
 import * as path from 'path';
-import { cp, mkdir, tempdir } from 'shelljs';
+import { cp, mkdir, rm, tempdir } from 'shelljs';
 
 export function createWorkspace(assetToSeedPath: string): string {
   const tmpDir = tempdir();
@@ -16,4 +16,8 @@ export function createWorkspace(assetToSeedPath: string): string {
   mkdir('-p', workspacePath);
   cp('-R', assetToSeedPath, workspacePath);
   return path.join(workspacePath);
+}
+
+export function removeWorkspace(pathToRemove: string) {
+  rm('-rf', pathToRemove);
 }


### PR DESCRIPTION
### What does this PR do?

Implements UI for sfdx force:data:soql:query

Option 1:
User has no editor open or no text selected => a VS code input is used to gather user input

Option 2:
User has text selected => selected text is used as SOQL query

E2E tests are implemented.

In addition the utils class from @chowwinston's faux package has been moved to the utils-vscode package.

### What issues does this PR fix or reference?

Fixes #65