### PR TITLE
Fix null field showing up in generated SObject faux classes

### DIFF
--- a/packages/salesforcedx-sobjects-faux-generator/test/fauxgeneratortest.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/fauxgeneratortest.ts
@@ -123,7 +123,7 @@ describe('generate relationship tests', function() {
     );
     expect(fs.existsSync(classPath));
     const classText = fs.readFileSync(classPath, 'utf8');
-    expect(classText).to.include('Case RelatedCase;');
+    expect(classText).to.include('List<Case> RelatedCase;');
   });
 
   // seems odd, but this can happen due to the childRelationships that don't have a relationshipName
@@ -152,5 +152,28 @@ describe('generate relationship tests', function() {
     const classText = fs.readFileSync(classPath, 'utf8');
     expect(classText).to.include('List<Case> Reference;');
     expect(classText).to.not.include('Account Reference');
+  });
+
+  it('faux class generator should handle relationships missing the relationshipName', async function(): Promise<
+    void
+  > {
+    const childRelation1 =
+      '{"childSObject": "Account", "field": "ReferenceId", "relationshipName": null}';
+    const field1 =
+      '{"name": "FooId", "type": "string", "referenceTo": ["Account"], "relationshipName": null}';
+    const header = '{ "name": "Custom__c",  "childRelationships": [';
+    const fieldHeader = '"fields": [';
+    const sobject1 = `${header}${childRelation1}],${fieldHeader}${field1}]}`;
+    const sobjectFolder = './';
+    const gen: FauxClassGenerator = new FauxClassGenerator();
+    classPath = await gen.generateFauxClass(
+      sobjectFolder,
+      JSON.parse(sobject1)
+    );
+    expect(fs.existsSync(classPath));
+    const classText = fs.readFileSync(classPath, 'utf8');
+    expect(classText).to.not.include('null');
+    expect(classText).to.include('Account Foo');
+    expect(classText).to.include('List<Account> Reference');
   });
 });

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -39,7 +39,7 @@
     "clean":
       "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
     "test":
-      "./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test --reporter mocha-multi-reporters",
+      "./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test --reporter mocha-multi-reporters --timeout 5000",
     "coverage": "./node_modules/.bin/nyc npm test"
   },
   "nyc": {

--- a/packages/salesforcedx-vscode-core/test/index.ts
+++ b/packages/salesforcedx-vscode-core/test/index.ts
@@ -24,7 +24,8 @@ const testRunner = require('@salesforce/salesforcedx-utils-vscode/out/src/test/t
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
 testRunner.configure({
   ui: 'bdd', // the TDD UI is being used in extension.test.ts (suite, test, etc.)
-  useColors: true // colored output from test results
+  useColors: true, // colored output from test results
+  timeout: 5000
 });
 
 module.exports = testRunner;


### PR DESCRIPTION
### What does this PR do?
When fields are generated in the SObject faux class, there were situations
where the relationshipName was not always specified.  In that case, there is
a field/childRelationship name that usually ends in “Id”.
This fix uses that name if the relationshipName is missing and strips off the “Id”.
This is consistent with what Apex and IlluminatedCloud expect and do.

### What issues does this PR fix or reference?
Resolves: @W-4344749@




