### PR TITLE
Add alias prompt and unit tests

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/commands.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/commands.ts
@@ -207,9 +207,9 @@ export class SelectFileName
   public async gather(): Promise<
     CancelResponse | ContinueResponse<{ fileName: string }>
   > {
-    const fileNameInputOptions = <vscode.InputBoxOptions>{
+    const fileNameInputOptions = {
       prompt: nls.localize('parameter_gatherer_enter_file_name')
-    };
+    } as vscode.InputBoxOptions;
     const fileName = await vscode.window.showInputBox(fileNameInputOptions);
     return fileName
       ? { type: 'CONTINUE', data: { fileName } }
@@ -296,9 +296,9 @@ export class SelectUsername
   public async gather(): Promise<
     CancelResponse | ContinueResponse<{ username: string }>
   > {
-    const usernameInputOptions = <vscode.InputBoxOptions>{
+    const usernameInputOptions = {
       prompt: nls.localize('parameter_gatherer_enter_username_name')
-    };
+    } as vscode.InputBoxOptions;
     const username = await vscode.window.showInputBox(usernameInputOptions);
     return username
       ? { type: 'CONTINUE', data: { username } }

--- a/packages/salesforcedx-vscode-core/src/commands/forceDataSoqlQuery.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceDataSoqlQuery.ts
@@ -43,16 +43,16 @@ export class GetQueryInput implements ParametersGatherer<{ input: string }> {
     let input;
 
     if (!editor) {
-      const userInputOptions = <vscode.InputBoxOptions>{
+      const userInputOptions = {
         prompt: nls.localize('parameter_gatherer_enter_soql_query')
-      };
+      } as vscode.InputBoxOptions;
       input = await vscode.window.showInputBox(userInputOptions);
     } else {
       const document = editor.document;
       if (editor.selection.isEmpty) {
-        const userInputOptions = <vscode.InputBoxOptions>{
+        const userInputOptions = {
           prompt: nls.localize('parameter_gatherer_enter_soql_query')
-        };
+        } as vscode.InputBoxOptions;
         input = await vscode.window.showInputBox(userInputOptions);
       } else {
         input = document.getText(editor.selection);

--- a/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
@@ -26,9 +26,9 @@ import {
 
 export const DEFAULT_ALIAS = 'scratchOrg';
 export class ForceOrgCreateExecutor extends SfdxCommandletExecutor<
-  FileSelection & Alias
+  AliasAndFileSelection
 > {
-  public build(data: FileSelection & Alias): Command {
+  public build(data: AliasAndFileSelection): Command {
     const selectionPath = path.relative(
       vscode.workspace.rootPath!, // this is safe because of workspaceChecker
       data.file
@@ -47,9 +47,9 @@ export class ForceOrgCreateExecutor extends SfdxCommandletExecutor<
 
 export class AliasGatherer implements ParametersGatherer<Alias> {
   public async gather(): Promise<CancelResponse | ContinueResponse<Alias>> {
-    const aliasInputOptions = <vscode.InputBoxOptions>{
+    const aliasInputOptions = {
       prompt: nls.localize('parameter_gatherer_enter_alias_name')
-    };
+    } as vscode.InputBoxOptions;
     const alias = await vscode.window.showInputBox(aliasInputOptions);
     // Hitting enter with no alias will default the alias to 'scratchOrg'
     if (alias === undefined) {
@@ -64,9 +64,11 @@ export interface Alias {
   alias: string;
 }
 
+export type AliasAndFileSelection = Alias & FileSelection;
+
 const workspaceChecker = new SfdxWorkspaceChecker();
 const parameterGatherer = new CompositeParametersGatherer<
-  FileSelection & Alias
+  AliasAndFileSelection
 >(new FileSelector('config/**/*-scratch-def.json'), new AliasGatherer());
 
 export function forceOrgCreate() {

--- a/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
@@ -13,15 +13,22 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { nls } from '../messages';
 import {
+  CancelResponse,
+  CompositeParametersGatherer,
+  ContinueResponse,
   FileSelection,
   FileSelector,
+  ParametersGatherer,
   SfdxCommandlet,
   SfdxCommandletExecutor,
   SfdxWorkspaceChecker
 } from './commands';
 
-class ForceOrgCreateExecutor extends SfdxCommandletExecutor<FileSelection> {
-  public build(data: FileSelection): Command {
+export const DEFAULT_ALIAS = 'scratchOrg';
+export class ForceOrgCreateExecutor extends SfdxCommandletExecutor<
+  FileSelection & Alias
+> {
+  public build(data: FileSelection & Alias): Command {
     const selectionPath = path.relative(
       vscode.workspace.rootPath!, // this is safe because of workspaceChecker
       data.file
@@ -32,13 +39,35 @@ class ForceOrgCreateExecutor extends SfdxCommandletExecutor<FileSelection> {
       )
       .withArg('force:org:create')
       .withFlag('-f', `${selectionPath}`)
+      .withFlag('--setalias', data.alias)
       .withArg('--setdefaultusername')
       .build();
   }
 }
 
+export class AliasGatherer implements ParametersGatherer<Alias> {
+  public async gather(): Promise<CancelResponse | ContinueResponse<Alias>> {
+    const aliasInputOptions = <vscode.InputBoxOptions>{
+      prompt: nls.localize('parameter_gatherer_enter_alias_name')
+    };
+    const alias = await vscode.window.showInputBox(aliasInputOptions);
+    // Hitting enter with no alias will default the alias to 'scratchOrg'
+    if (alias === undefined) {
+      return { type: 'CANCEL' };
+    }
+    return alias === ''
+      ? { type: 'CONTINUE', data: { alias: DEFAULT_ALIAS } }
+      : { type: 'CONTINUE', data: { alias } };
+  }
+}
+export interface Alias {
+  alias: string;
+}
+
 const workspaceChecker = new SfdxWorkspaceChecker();
-const parameterGatherer = new FileSelector('config/**/*-scratch-def.json');
+const parameterGatherer = new CompositeParametersGatherer<
+  FileSelection & Alias
+>(new FileSelector('config/**/*-scratch-def.json'), new AliasGatherer());
 
 export function forceOrgCreate() {
   const commandlet = new SfdxCommandlet(

--- a/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
@@ -24,7 +24,7 @@ import {
   SfdxWorkspaceChecker
 } from './commands';
 
-export const DEFAULT_ALIAS = 'scratchOrg';
+export const DEFAULT_ALIAS = 'vscodeScratchOrg';
 export class ForceOrgCreateExecutor extends SfdxCommandletExecutor<
   AliasAndFileSelection
 > {
@@ -51,7 +51,7 @@ export class AliasGatherer implements ParametersGatherer<Alias> {
       prompt: nls.localize('parameter_gatherer_enter_alias_name')
     } as vscode.InputBoxOptions;
     const alias = await vscode.window.showInputBox(aliasInputOptions);
-    // Hitting enter with no alias will default the alias to 'scratchOrg'
+    // Hitting enter with no alias will default the alias to 'vscodeScratchOrg'
     if (alias === undefined) {
       return { type: 'CANCEL' };
     }

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -45,6 +45,7 @@ export const messages = {
   parameter_gatherer_enter_dir_name:
     'Enter desired directory (Press Enter to confirm or Esc to cancel)',
   parameter_gatherer_enter_username_name: 'Enter target username',
+  parameter_gatherer_enter_alias_name: 'Enter an alias',
 
   force_org_create_default_scratch_org_text:
     'SFDX: Create a Default Scratch Org...',

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -45,7 +45,7 @@ export const messages = {
   parameter_gatherer_enter_dir_name:
     'Enter desired directory (Press Enter to confirm or Esc to cancel)',
   parameter_gatherer_enter_username_name: 'Enter target username',
-  parameter_gatherer_enter_alias_name: 'Enter an alias',
+  parameter_gatherer_enter_alias_name: 'Enter a scratch org alias',
 
   force_org_create_default_scratch_org_text:
     'SFDX: Create a Default Scratch Org...',

--- a/packages/salesforcedx-vscode-core/test/commands/forceOrgCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceOrgCreate.test.ts
@@ -5,7 +5,6 @@ import * as vscode from 'vscode';
 import {
   AliasGatherer,
   DEFAULT_ALIAS,
-  forceOrgCreate,
   ForceOrgCreateExecutor
 } from '../../src/commands/forceOrgCreate';
 import { nls } from '../../src/messages';

--- a/packages/salesforcedx-vscode-core/test/commands/forceOrgCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceOrgCreate.test.ts
@@ -1,0 +1,77 @@
+import { expect } from 'chai';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import {
+  AliasGatherer,
+  DEFAULT_ALIAS,
+  forceOrgCreate,
+  ForceOrgCreateExecutor
+} from '../../src/commands/forceOrgCreate';
+import { nls } from '../../src/messages';
+
+// tslint:disable:no-unused-expression
+describe('Force Org Create', () => {
+  describe('Alias Gatherer', () => {
+    const TEST_ALIAS = 'testAlias';
+    let inputBoxSpy: sinon.SinonStub;
+
+    before(() => {
+      inputBoxSpy = sinon.stub(vscode.window, 'showInputBox');
+      inputBoxSpy.onCall(0).returns(undefined);
+      inputBoxSpy.onCall(1).returns('');
+      inputBoxSpy.onCall(2).returns(TEST_ALIAS);
+    });
+
+    after(() => {
+      inputBoxSpy.restore();
+    });
+
+    it('Should return cancel if alias is undefined', async () => {
+      const gatherer = new AliasGatherer();
+      const response = await gatherer.gather();
+      expect(inputBoxSpy.calledOnce).to.be.true;
+      expect(response.type).to.equal('CANCEL');
+    });
+
+    it('Should return Continue with default alias if user input is empty string', async () => {
+      const gatherer = new AliasGatherer();
+      const response = await gatherer.gather();
+      expect(inputBoxSpy.calledTwice).to.be.true;
+      if (response.type === 'CONTINUE') {
+        expect(response.data.alias).to.equal(DEFAULT_ALIAS);
+      } else {
+        expect.fail('Response should be of type ContinueResponse');
+      }
+    });
+
+    it('Should return Continue with inputted alias if user input is not undefined or empty', async () => {
+      const gatherer = new AliasGatherer();
+      const response = await gatherer.gather();
+      expect(inputBoxSpy.calledThrice).to.be.true;
+      if (response.type === 'CONTINUE') {
+        expect(response.data.alias).to.equal(TEST_ALIAS);
+      } else {
+        expect.fail('Response should be of type ContinueResponse');
+      }
+    });
+  });
+
+  describe('Org Create Builder', () => {
+    it('Should build the org create command', async () => {
+      const CONFIG_FILE = 'configFile.txt';
+      const TEST_ALIAS = 'testAlias';
+      const forceOrgCreateBuilder = new ForceOrgCreateExecutor();
+      const createCommand = forceOrgCreateBuilder.build({
+        file: path.join(vscode.workspace.rootPath!, CONFIG_FILE),
+        alias: TEST_ALIAS
+      });
+      expect(createCommand.toCommand()).to.equal(
+        `sfdx force:org:create -f ${CONFIG_FILE} --setalias ${TEST_ALIAS} --setdefaultusername`
+      );
+      expect(createCommand.description).to.equal(
+        nls.localize('force_org_create_default_scratch_org_text')
+      );
+    });
+  });
+});

--- a/packages/system-tests/package.json
+++ b/packages/system-tests/package.json
@@ -15,7 +15,7 @@
     "@types/node": "^6.0.40",
     "@types/rimraf": "0.0.28",
     "@types/shelljs": "^0.7.4",
-    "@types/webdriverio": "^4.6.1",
+    "@types/webdriverio": "4.6.1",
     "chai": "^4.0.2",
     "cross-env": "5.0.4",
     "decache": "^4.1.0",


### PR DESCRIPTION
### What does this PR do?
Add alias prompt for force:org:create. The prompt will set the alias inputted by the user with the --setalias flag on the command. If user hits Enter with no alias inputted, the alias will be set to "scratchOrg" by default. If user hits Escape to cancel out, the command should not execute.
### What issues does this PR fix or reference?
@W-4345929@