### PR TITLE
Notify the user of Refresh command status

### DIFF
--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -30,7 +30,7 @@
     "nyc": "^11.0.2",
     "sinon": "^2.3.6",
     "typescript": "2.4.0",
-    "vscode": "1.1.4"
+    "vscode": "1.1.5"
   },
   "scripts": {
     "vscode:package": "npm prune --production",

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -29,8 +29,7 @@
     "mock-spawn": "0.2.6",
     "nyc": "^11.0.2",
     "sinon": "^2.3.6",
-    "typescript": "2.4.0",
-    "vscode": "1.1.5"
+    "typescript": "2.4.0"
   },
   "scripts": {
     "vscode:package": "npm prune --production",

--- a/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
@@ -27,6 +27,7 @@ export interface CancellationToken {
 
 export const SUCCESS_CODE = '0';
 export const FAILURE_CODE = '1';
+const SFDX_PROJECT_FILE = 'sfdx-project.json';
 export class FauxClassGenerator {
   private emitter: EventEmitter;
   private cancellationToken: CancellationToken | undefined;
@@ -97,6 +98,14 @@ export class FauxClassGenerator {
       this.SOBJECTS_DIR
     );
 
+    if (
+      !fs.existsSync(projectPath) ||
+      !fs.existsSync(path.join(projectPath, SFDX_PROJECT_FILE))
+    ) {
+      return this.errorExit(
+        nls.localize('no_generate_if_not_in_project', sobjectsFolderPath)
+      );
+    }
     this.cleanupSObjectFolders(sobjectsFolderPath);
 
     const describe = new SObjectDescribe();

--- a/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
@@ -4,14 +4,13 @@
 * Licensed under the BSD 3-Clause license.
 * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 */
+import { SFDX_PROJECT_FILE } from '@salesforce/salesforcedx-utils-vscode/out/src';
 import { LocalCommandExecution } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
-
 import { EventEmitter } from 'events';
 import * as fs from 'fs';
 import { EOL } from 'os';
 import * as path from 'path';
 import { mkdir, rm } from 'shelljs';
-
 import {
   ChildRelationship,
   Field,
@@ -25,18 +24,15 @@ export interface CancellationToken {
   isCancellationRequested: boolean;
 }
 
-export const SUCCESS_CODE = '0';
-export const FAILURE_CODE = '1';
-const SFDX_PROJECT_FILE = 'sfdx-project.json';
+const SFDX_DIR = '.sfdx';
+const TOOLS_DIR = 'tools';
+const SOBJECTS_DIR = 'sobjects';
+const STANDARDOBJECTS_DIR = 'standardObjects';
+const CUSTOMOBJECTS_DIR = 'customObjects';
+
 export class FauxClassGenerator {
   private emitter: EventEmitter;
   private cancellationToken: CancellationToken | undefined;
-
-  private SFDX_DIR = '.sfdx';
-  private TOOLS_DIR = 'tools';
-  private SOBJECTS_DIR = 'sobjects';
-  private STANDARDOBJECTS_DIR = 'standardObjects';
-  private CUSTOMOBJECTS_DIR = 'customObjects';
 
   // the empty string is used to represent the need for a special case
   // usually multiple fields with specialized names
@@ -77,14 +73,26 @@ export class FauxClassGenerator {
   }
 
   private errorExit(errorMessage: string): Promise<string> {
-    this.emitter.emit(LocalCommandExecution.STDERR_EVENT, errorMessage);
-    this.emitter.emit(LocalCommandExecution.ERROR_EVENT, '1');
-    return Promise.reject(`${FAILURE_CODE} - ${errorMessage}`);
+    this.emitter.emit(LocalCommandExecution.STDERR_EVENT, `${errorMessage}\n`);
+    this.emitter.emit(
+      LocalCommandExecution.ERROR_EVENT,
+      new Error(errorMessage)
+    );
+    this.emitter.emit(
+      LocalCommandExecution.EXIT_EVENT,
+      LocalCommandExecution.FAILURE_CODE
+    );
+    return Promise.reject(
+      `${LocalCommandExecution.FAILURE_CODE.toString()} - ${errorMessage}`
+    );
   }
 
   private successExit(): Promise<string> {
-    this.emitter.emit(LocalCommandExecution.EXIT_EVENT, '0');
-    return Promise.resolve(SUCCESS_CODE);
+    this.emitter.emit(
+      LocalCommandExecution.EXIT_EVENT,
+      LocalCommandExecution.SUCCESS_CODE
+    );
+    return Promise.resolve(LocalCommandExecution.SUCCESS_CODE.toString());
   }
 
   public async generate(
@@ -93,9 +101,17 @@ export class FauxClassGenerator {
   ): Promise<string> {
     const sobjectsFolderPath = path.join(
       projectPath,
-      this.SFDX_DIR,
-      this.TOOLS_DIR,
-      this.SOBJECTS_DIR
+      SFDX_DIR,
+      TOOLS_DIR,
+      SOBJECTS_DIR
+    );
+    const standardSObjectsFolderPath = path.join(
+      sobjectsFolderPath,
+      STANDARDOBJECTS_DIR
+    );
+    const customSObjectsFolderPath = path.join(
+      sobjectsFolderPath,
+      CUSTOMOBJECTS_DIR
     );
 
     if (
@@ -151,19 +167,16 @@ export class FauxClassGenerator {
 
     this.logFetchedObjects(standardSObjects, customSObjects);
 
-    const standardResult = this.generateFauxClasses(
-      standardSObjects,
-      path.join(sobjectsFolderPath, this.STANDARDOBJECTS_DIR)
-    );
-    if (standardResult) {
-      return this.errorExit(standardResult);
+    try {
+      this.generateFauxClasses(standardSObjects, standardSObjectsFolderPath);
+    } catch (exc) {
+      return this.errorExit(exc);
     }
-    const customResult = this.generateFauxClasses(
-      customSObjects,
-      path.join(sobjectsFolderPath, this.CUSTOMOBJECTS_DIR)
-    );
-    if (customResult) {
-      return this.errorExit(customResult);
+
+    try {
+      this.generateFauxClasses(customSObjects, customSObjectsFolderPath);
+    } catch (exc) {
+      return this.errorExit(exc);
     }
 
     return this.successExit();
@@ -223,23 +236,19 @@ export class FauxClassGenerator {
     return decls;
   }
 
-  private static fieldName(decl: string) {
+  private static fieldName(decl: string): string {
     return decl.substr(decl.indexOf(' ') + 1);
   }
 
-  private generateFauxClasses(
-    sobjects: SObject[],
-    targetFolder: string
-  ): string {
+  private generateFauxClasses(sobjects: SObject[], targetFolder: string): void {
     if (!this.createIfNeededOutputFolder(targetFolder)) {
-      return nls.localize('no_sobject_output_folder_text', targetFolder);
+      throw nls.localize('no_sobject_output_folder_text', targetFolder);
     }
     for (const sobject of sobjects) {
       if (sobject.name) {
         this.generateFauxClass(targetFolder, sobject);
       }
     }
-    return '';
   }
 
   // VisibleForTesting
@@ -341,29 +350,20 @@ export class FauxClassGenerator {
     }
   }
 
+  private logSObjects(sobjectKind: string, fetchedLength: number) {
+    if (fetchedLength > 0) {
+      this.emitter.emit(
+        LocalCommandExecution.STDOUT_EVENT,
+        nls.localize('fetched_sobjects_length_text', fetchedLength, sobjectKind)
+      );
+    }
+  }
+
   private logFetchedObjects(
     standardSObjects: SObject[],
     customSObjects: SObject[]
   ) {
-    if (standardSObjects.length > 0) {
-      this.emitter.emit(
-        LocalCommandExecution.STDOUT_EVENT,
-        nls.localize(
-          'fetched_sobjects_length_text',
-          standardSObjects.length,
-          'Standard'
-        )
-      );
-    }
-    if (customSObjects.length > 0) {
-      this.emitter.emit(
-        LocalCommandExecution.STDOUT_EVENT,
-        nls.localize(
-          'fetched_sobjects_length_text',
-          customSObjects.length,
-          'Custom'
-        )
-      );
-    }
+    this.logSObjects('Standard', standardSObjects.length);
+    this.logSObjects('Custom', customSObjects.length);
   }
 }

--- a/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
@@ -169,14 +169,14 @@ export class FauxClassGenerator {
 
     try {
       this.generateFauxClasses(standardSObjects, standardSObjectsFolderPath);
-    } catch (exc) {
-      return this.errorExit(exc);
+    } catch (e) {
+      return this.errorExit(e);
     }
 
     try {
       this.generateFauxClasses(customSObjects, customSObjectsFolderPath);
-    } catch (exc) {
-      return this.errorExit(exc);
+    } catch (e) {
+      return this.errorExit(e);
     }
 
     return this.successExit();

--- a/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
@@ -157,7 +157,6 @@ export class FauxClassGenerator {
     }
 
     for (let i = 0; i < fetchedSObjects.length; i++) {
-      console.log(fetchedSObjects[i].name);
       if (fetchedSObjects[i].custom) {
         customSObjects.push(fetchedSObjects[i]);
       } else {

--- a/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
@@ -24,9 +24,12 @@ import { nls } from '../messages';
 export interface CancellationToken {
   isCancellationRequested: boolean;
 }
+
+export const SUCCESS_CODE = '0';
+export const FAILURE_CODE = '1';
 export class FauxClassGenerator {
   private emitter: EventEmitter;
-  private cancellationToken: CancellationToken;
+  private cancellationToken: CancellationToken | undefined;
 
   private SFDX_DIR = '.sfdx';
   private TOOLS_DIR = 'tools';
@@ -67,7 +70,7 @@ export class FauxClassGenerator {
     ['complexvalue', 'Object']
   ]);
 
-  constructor(emitter: EventEmitter, cancellationToken: CancellationToken) {
+  constructor(emitter: EventEmitter, cancellationToken?: CancellationToken) {
     this.emitter = emitter;
     this.cancellationToken = cancellationToken;
   }
@@ -75,12 +78,12 @@ export class FauxClassGenerator {
   private errorExit(errorMessage: string): Promise<string> {
     this.emitter.emit(LocalCommandExecution.STDERR_EVENT, errorMessage);
     this.emitter.emit(LocalCommandExecution.ERROR_EVENT, '1');
-    return Promise.reject(errorMessage);
+    return Promise.reject(`${FAILURE_CODE} - ${errorMessage}`);
   }
 
-  private successExit(successMessage: string): Promise<string> {
+  private successExit(): Promise<string> {
     this.emitter.emit(LocalCommandExecution.EXIT_EVENT, '0');
-    return Promise.resolve(successMessage);
+    return Promise.resolve(SUCCESS_CODE);
   }
 
   public async generate(
@@ -154,7 +157,7 @@ export class FauxClassGenerator {
       return this.errorExit(customResult);
     }
 
-    return this.successExit('');
+    return this.successExit();
   }
 
   private stripId(name: string): string {

--- a/packages/salesforcedx-sobjects-faux-generator/src/messages/i18n.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/messages/i18n.ts
@@ -16,11 +16,11 @@
  * If ommitted, we will assume _message.
  */
 export const messages = {
-  faux_generation_cancelled_text: 'Faux class generation cancelled.',
+  faux_generation_cancelled_text: 'Faux class generation cancelled',
   failure_fetching_sobjects_list_text:
-    'Failure fetching list of SObjects from org %s.',
-  failure_in_sobject_describe_text: 'Failure performing SObject describe %s.',
-  no_sobject_output_folder_text: 'No output folder available %s.',
+    'Failure fetching list of SObjects from org %s',
+  failure_in_sobject_describe_text: 'Failure performing SObject describe %s',
+  no_sobject_output_folder_text: 'No output folder available %s',
   fetched_sobjects_length_text:
     'Fetched %s %s SObjects from default scratch org\n',
   no_generate_if_not_in_project:

--- a/packages/salesforcedx-sobjects-faux-generator/src/messages/i18n.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/messages/i18n.ts
@@ -22,5 +22,7 @@ export const messages = {
   failure_in_sobject_describe_text: 'Failure performing SObject describe %s.',
   no_sobject_output_folder_text: 'No output folder available %s.',
   fetched_sobjects_length_text:
-    'Fetched %s %s SObjects from default scratch org\n'
+    'Fetched %s %s SObjects from default scratch org\n',
+  no_generate_if_not_in_project:
+    'Unable to generate faux classes for SObjects when not in an SFDX project %s'
 };

--- a/packages/salesforcedx-sobjects-faux-generator/src/messages/i18n.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/messages/i18n.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * Conventions:
+ * _message: is for unformatted text that will be shown as-is to
+ * the user.
+ * _text: is for text that will appear in the UI, possibly with
+ * decorations, e.g., $(x) uses the https://octicons.github.com/ and should not
+ * be localized
+ *
+ * If ommitted, we will assume _message.
+ */
+export const messages = {
+  faux_generation_cancelled_text: 'Faux class generation cancelled.',
+  failure_fetching_sobjects_list_text:
+    'Failure fetching list of SObjects from org %s.',
+  failure_in_sobject_describe_text: 'Failure performing SObject describe %s.',
+  no_sobject_output_folder_text: 'No output folder available %s.',
+  fetched_sobjects_length_text:
+    'Fetched %s %s SObjects from default scratch org\n'
+};

--- a/packages/salesforcedx-sobjects-faux-generator/src/messages/i18n.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/messages/i18n.ts
@@ -16,13 +16,14 @@
  * If ommitted, we will assume _message.
  */
 export const messages = {
-  faux_generation_cancelled_text: 'Faux class generation cancelled',
+  faux_generation_cancelled_text: 'Faux class generation canceled',
   failure_fetching_sobjects_list_text:
-    'Failure fetching list of SObjects from org %s',
-  failure_in_sobject_describe_text: 'Failure performing SObject describe %s',
-  no_sobject_output_folder_text: 'No output folder available %s',
+    'Failure fetching list of sObjects from org %s',
+  failure_in_sobject_describe_text: 'Failure performing sObject describe %s',
+  no_sobject_output_folder_text:
+    'No output folder available %s.  Please create this folder and refresh again',
   fetched_sobjects_length_text:
-    'Fetched %s %s SObjects from default scratch org\n',
+    'Fetched %s %s sObjects from default scratch org\n',
   no_generate_if_not_in_project:
-    'Unable to generate faux classes for SObjects when not in an SFDX project %s'
+    'Unable to generate faux classes for sObjects when not in an SFDX project %s'
 };

--- a/packages/salesforcedx-sobjects-faux-generator/src/messages/index.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/messages/index.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  BASE_FILE_EXTENSION,
+  BASE_FILE_NAME,
+  Config,
+  DEFAULT_LOCALE,
+  Localization,
+  Message
+} from '@salesforce/salesforcedx-utils-vscode/out/src/i18n';
+
+function loadMessageBundle(config?: Config): Message {
+  function resolveFileName(locale: string): string {
+    return locale === DEFAULT_LOCALE
+      ? `${BASE_FILE_NAME}.${BASE_FILE_EXTENSION}`
+      : `${BASE_FILE_NAME}.${locale}.${BASE_FILE_EXTENSION}`;
+  }
+
+  const base = new Message(
+    require(`./${resolveFileName(DEFAULT_LOCALE)}`).messages
+  );
+
+  if (config && config.locale && config.locale !== DEFAULT_LOCALE) {
+    try {
+      const layer = new Message(
+        require(`./${resolveFileName(config.locale)}`).messages,
+        base
+      );
+      return layer;
+    } catch (e) {
+      console.error(`Cannot find ${config.locale}, defaulting to en`);
+      return base;
+    }
+  } else {
+    return base;
+  }
+}
+
+export const nls = new Localization(
+  loadMessageBundle(JSON.parse(process.env.VSCODE_NLS_CONFIG))
+);

--- a/packages/salesforcedx-sobjects-faux-generator/test/fauxClassGenerator.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/fauxClassGenerator.test.ts
@@ -1,8 +1,21 @@
 import * as chai from 'chai';
+import { EventEmitter } from 'events';
 import * as fs from 'fs';
-import { FauxClassGenerator } from '../src/generator/fauxClassGenerator';
+import {
+  CancellationToken,
+  FauxClassGenerator
+} from '../src/generator/fauxClassGenerator';
 
 const expect = chai.expect;
+
+class CancellationTokenSource {
+  public token: CancellationToken;
+}
+
+function getGenerator(): FauxClassGenerator {
+  const emitter: EventEmitter = new EventEmitter();
+  return new FauxClassGenerator(emitter, new CancellationTokenSource().token);
+}
 
 describe('SObject faux class generator', function() {
   let classPath = '';
@@ -44,7 +57,7 @@ describe('SObject faux class generator', function() {
     const sobject1 = `${fieldsHeader}${fieldsString}${closeHeader}`;
 
     const sobjectFolder = process.cwd();
-    const gen: FauxClassGenerator = new FauxClassGenerator();
+    const gen = getGenerator();
     classPath = await gen.generateFauxClass(
       sobjectFolder,
       JSON.parse(sobject1)
@@ -84,7 +97,7 @@ describe('SObject faux class generator', function() {
     const sobject1 = `${fieldsHeader}${fieldsString}${closeHeader}`;
 
     const sobjectFolder = process.cwd();
-    const gen: FauxClassGenerator = new FauxClassGenerator();
+    const gen = getGenerator();
     classPath = await gen.generateFauxClass(
       sobjectFolder,
       JSON.parse(sobject1)
@@ -110,7 +123,7 @@ describe('SObject faux class generator', function() {
       relation1 +
       ' ], "childRelationships": [] }';
     const sobjectFolder = process.cwd();
-    const gen: FauxClassGenerator = new FauxClassGenerator();
+    const gen = getGenerator();
     classPath = await gen.generateFauxClass(
       sobjectFolder,
       JSON.parse(sobject1)
@@ -134,7 +147,7 @@ describe('SObject faux class generator', function() {
       childRelation1 +
       '] }';
     const sobjectFolder = process.cwd();
-    const gen: FauxClassGenerator = new FauxClassGenerator();
+    const gen = getGenerator();
     classPath = await gen.generateFauxClass(
       sobjectFolder,
       JSON.parse(sobject1)
@@ -152,7 +165,7 @@ describe('SObject faux class generator', function() {
       childRelation1 +
       '] }';
     const sobjectFolder = process.cwd();
-    const gen: FauxClassGenerator = new FauxClassGenerator();
+    const gen = getGenerator();
     classPath = await gen.generateFauxClass(
       sobjectFolder,
       JSON.parse(sobject1)
@@ -177,7 +190,7 @@ describe('SObject faux class generator', function() {
       childRelation1 +
       '] }';
     const sobjectFolder = process.cwd();
-    const gen: FauxClassGenerator = new FauxClassGenerator();
+    const gen = getGenerator();
     classPath = await gen.generateFauxClass(
       sobjectFolder,
       JSON.parse(sobject1)
@@ -197,7 +210,7 @@ describe('SObject faux class generator', function() {
     const fieldHeader = '"fields": [';
     const sobject1 = `${header}${childRelation1}],${fieldHeader}${field1}]}`;
     const sobjectFolder = process.cwd();
-    const gen: FauxClassGenerator = new FauxClassGenerator();
+    const gen = getGenerator();
     classPath = await gen.generateFauxClass(
       sobjectFolder,
       JSON.parse(sobject1)
@@ -216,7 +229,7 @@ describe('SObject faux class generator', function() {
     const fieldHeader = '"fields": [';
     const sobject1 = `${header},${fieldHeader}${field1}]}`;
     const sobjectFolder = process.cwd();
-    const gen: FauxClassGenerator = new FauxClassGenerator();
+    const gen = getGenerator();
     classPath = await gen.generateFauxClass(
       sobjectFolder,
       JSON.parse(sobject1)
@@ -242,7 +255,7 @@ describe('SObject faux class generator', function() {
       '{"name": "StringField", "type": "string", "referenceTo": []}';
     const sobject1 = `${header}${field1},${field2}]}`;
     const sobjectFolder = process.cwd();
-    const gen: FauxClassGenerator = new FauxClassGenerator();
+    const gen = getGenerator();
     classPath = await gen.generateFauxClass(
       sobjectFolder,
       JSON.parse(sobject1)
@@ -261,7 +274,7 @@ describe('SObject faux class generator', function() {
       '{"name": "StringField", "type": "string", "referenceTo": []}';
     const sobject1 = `${header}${field1},${field2}]}`;
     const sobjectFolder = process.cwd();
-    const gen: FauxClassGenerator = new FauxClassGenerator();
+    const gen = getGenerator();
     classPath = await gen.generateFauxClass(
       sobjectFolder,
       JSON.parse(sobject1)
@@ -284,7 +297,7 @@ describe('SObject faux class generator', function() {
     const sobject1 = `${fieldsHeader}${fieldsString}${closeHeader}`;
 
     const sobjectFolder = process.cwd();
-    const gen: FauxClassGenerator = new FauxClassGenerator();
+    const gen = getGenerator();
     classPath = await gen.generateFauxClass(
       sobjectFolder,
       JSON.parse(sobject1)

--- a/packages/salesforcedx-sobjects-faux-generator/test/fauxClassGenerator.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/fauxClassGenerator.test.ts
@@ -1,29 +1,17 @@
 import * as chai from 'chai';
 import { EventEmitter } from 'events';
 import * as fs from 'fs';
-import {
-  CancellationToken,
-  FauxClassGenerator
-} from '../src/generator/fauxClassGenerator';
+import { FauxClassGenerator } from '../src/generator/fauxClassGenerator';
 
 const expect = chai.expect;
 
-class CancellationTokenSource {
-  public token: CancellationToken;
-}
-
 describe('SObject faux class generator', function() {
   let classPath = '';
-  let cancellationTokenSource: CancellationTokenSource;
 
   function getGenerator(): FauxClassGenerator {
     const emitter: EventEmitter = new EventEmitter();
-    return new FauxClassGenerator(emitter, cancellationTokenSource.token);
+    return new FauxClassGenerator(emitter);
   }
-
-  beforeEach(() => {
-    cancellationTokenSource = new CancellationTokenSource();
-  });
 
   afterEach(() => {
     if (classPath) {

--- a/packages/salesforcedx-sobjects-faux-generator/test/fauxClassGenerator.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/fauxClassGenerator.test.ts
@@ -12,13 +12,18 @@ class CancellationTokenSource {
   public token: CancellationToken;
 }
 
-function getGenerator(): FauxClassGenerator {
-  const emitter: EventEmitter = new EventEmitter();
-  return new FauxClassGenerator(emitter, new CancellationTokenSource().token);
-}
-
 describe('SObject faux class generator', function() {
   let classPath = '';
+  let cancellationTokenSource: CancellationTokenSource;
+
+  function getGenerator(): FauxClassGenerator {
+    const emitter: EventEmitter = new EventEmitter();
+    return new FauxClassGenerator(emitter, cancellationTokenSource.token);
+  }
+
+  beforeEach(() => {
+    cancellationTokenSource = new CancellationTokenSource();
+  });
 
   afterEach(() => {
     if (classPath) {

--- a/packages/salesforcedx-sobjects-faux-generator/test/integration/fauxGenerate.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/integration/fauxGenerate.test.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { LocalCommandExecution } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import rimraf = require('rimraf');
+import { expect } from 'chai';
+import { EventEmitter } from 'events';
+import * as path from 'path';
+import { SObjectCategory } from '../../src/describe';
+import {
+  //CancellationToken,
+  FAILURE_CODE,
+  FauxClassGenerator,
+  SUCCESS_CODE
+} from '../../src/generator/fauxClassGenerator';
+import { nls } from '../../src/messages';
+import * as util from './integrationTestUtil';
+
+// The CustomObjects are all identical in terms of fields, just different ones to test batch
+// and multiple objects for testing describeGlobal
+const PROJECT_NAME = `project_${new Date().getTime()}`;
+const CUSTOM_OBJECT_NAME = 'MyCustomObject__c';
+const CUSTOM_OBJECT2 = 'MyCustomObject2__c';
+const CUSTOM_OBJECT3 = 'MyCustomObject3__c';
+const CUSTOM_FIELD_FULLNAME = CUSTOM_OBJECT_NAME + '.MyCustomField__c';
+const SIMPLE_OBJECT_SOURCE_FOLDER = 'simpleObjectAndField';
+
+// tslint:disable:no-unused-expression
+describe('Generate faux classes for SObjects', function() {
+  // tslint:disable-next-line:no-invalid-this
+  this.timeout(180000);
+  let username: string;
+
+  //let cancellationTokenSource: CancellationTokenSource;
+  let projectPath: string;
+  let emitter: EventEmitter;
+
+  function getGenerator(): FauxClassGenerator {
+    //return new FauxClassGenerator(emitter, cancellationTokenSource.token);
+    return new FauxClassGenerator(emitter);
+  }
+
+  before(async function() {
+    const customFields: util.CustomFieldInfo[] = [
+      new util.CustomFieldInfo(CUSTOM_OBJECT_NAME, [CUSTOM_FIELD_FULLNAME]),
+      new util.CustomFieldInfo(CUSTOM_OBJECT2, [CUSTOM_FIELD_FULLNAME]),
+      new util.CustomFieldInfo(CUSTOM_OBJECT3, [CUSTOM_FIELD_FULLNAME])
+    ];
+
+    //cancellationTokenSource = new CancellationTokenSource();
+
+    username = await util.initializeProject(
+      PROJECT_NAME,
+      SIMPLE_OBJECT_SOURCE_FOLDER,
+      customFields
+    );
+
+    projectPath = path.join(process.cwd(), PROJECT_NAME);
+    emitter = new EventEmitter();
+  });
+
+  after(function() {
+    rimraf.sync(projectPath);
+    projectPath = '';
+  });
+
+  // commented out until the ability to reference vscode.CancellationTokenSource is solved
+  /*
+  it('Should be cancellable', async () => {
+    const generator = getGenerator();
+    cancellationTokenSource.cancel();
+    try {
+      const result = await generator.generate(projectPath, SObjectCategory.ALL);
+      expect.fail(result, 'undefined', 'generator should have thrown an error');
+    } catch (e) {
+      expect(e).to.be(nls.localize('faux_generation_cancelled_text'));
+    }
+  });
+  */
+
+  it('Should fail if outside a project', async () => {
+    const generator = getGenerator();
+    const INVALID_PROJECT_NAME = 'outsideproject';
+    projectPath = path.join(process.cwd(), INVALID_PROJECT_NAME);
+    try {
+      const result = await generator.generate(projectPath, SObjectCategory.ALL);
+      expect.fail(result, 'undefined', 'generator should have thrown an error');
+    } catch (e) {
+      expect(e).to.contain(FAILURE_CODE);
+      expect(e).to.contain(nls.localize('failure_fetching_sobjects_list_text'));
+    }
+  });
+
+  /*
+  it('Should emit an error event on failure', async () => {
+
+  });
+
+  it('Should emit message to stderr on failure', async () => {
+
+  });
+
+  it('Should emit an exit event with code 0 on success', async () => {
+
+  });
+  */
+
+  it('Should log the number of created faux classes on success', async () => {
+    const generator = getGenerator();
+    let stdoutInfo = '';
+    emitter.addListener(LocalCommandExecution.STDOUT_EVENT, (data: string) => {
+      stdoutInfo = data;
+    });
+    try {
+      // only fetch the custom objects to keep the execution time short
+      const result = await generator.generate(
+        projectPath,
+        SObjectCategory.CUSTOM
+      );
+      expect(result).to.be(SUCCESS_CODE);
+      expect(stdoutInfo).to.contain(
+        nls.localize('fetched_sobjects_length_text', 3, 'Custom')
+      );
+    } catch (e) {
+      expect.fail(e, 'undefined', 'generator should not have thrown an error');
+    }
+  });
+});

--- a/packages/salesforcedx-sobjects-faux-generator/test/integration/fauxGenerate.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/integration/fauxGenerate.test.ts
@@ -14,7 +14,6 @@ import { renameSync } from 'fs';
 import * as path from 'path';
 import { SObjectCategory } from '../../src/describe';
 import {
-  CancellationToken,
   FAILURE_CODE,
   FauxClassGenerator,
   SUCCESS_CODE

--- a/packages/salesforcedx-sobjects-faux-generator/test/integration/integrationTestUtil.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/integration/integrationTestUtil.ts
@@ -63,7 +63,7 @@ export async function deleteScratchOrg(userName: string): Promise<void> {
     { cwd: process.cwd() }
   ).execute();
   const cmdOutput = new CommandOutput();
-  const result = await cmdOutput.getCmdResult(execution);
+  await cmdOutput.getCmdResult(execution);
   return Promise.resolve();
 }
 

--- a/packages/salesforcedx-sobjects-faux-generator/test/integration/integrationTestUtil.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/integration/integrationTestUtil.ts
@@ -10,6 +10,7 @@ import {
   CommandOutput,
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import { CancellationToken } from '../../src/generator/fauxClassGenerator';
 import childProcess = require('child_process');
 import * as path from 'path';
 import * as util from 'util';
@@ -40,6 +41,7 @@ export async function createScratchOrg(projectName: string): Promise<string> {
     new SfdxCommandBuilder()
       .withArg('force:org:create')
       .withFlag('--definitionfile', scratchDefFilePath)
+      .withArg('--setdefaultusername')
       .withJson()
       .build(),
     { cwd: path.join(process.cwd(), projectName) }
@@ -194,4 +196,22 @@ export async function initializeProject(
   await assignPermissionSet(permSetName, username);
 
   return username;
+}
+
+// Added to be able to test cancellation of FauxClassGenerator.generate
+// mimic of vscode but shouldn't depend on vscode in this package
+
+class StandardCancellationToken implements CancellationToken {
+  public isCancellationRequested = false;
+}
+export class CancellationTokenSource {
+  public token: CancellationToken = new StandardCancellationToken();
+
+  public cancel(): void {
+    this.token.isCancellationRequested = true;
+  }
+
+  public dispose(): void {
+    this.cancel();
+  }
 }

--- a/packages/salesforcedx-sobjects-faux-generator/test/integration/integrationTestUtil.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/integration/integrationTestUtil.ts
@@ -52,6 +52,21 @@ export async function createScratchOrg(projectName: string): Promise<string> {
   return Promise.resolve(username);
 }
 
+export async function deleteScratchOrg(userName: string): Promise<void> {
+  const execution = new CliCommandExecutor(
+    new SfdxCommandBuilder()
+      .withArg('force:org:delete')
+      .withFlag('--targetusername', userName)
+      .withArg('--noprompt')
+      .withJson()
+      .build(),
+    { cwd: process.cwd() }
+  ).execute();
+  const cmdOutput = new CommandOutput();
+  const result = await cmdOutput.getCmdResult(execution);
+  return Promise.resolve();
+}
+
 export async function push(
   sourceFolder: string,
   projectName: string,

--- a/packages/salesforcedx-sobjects-faux-generator/test/integration/sObjectDescribe.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/integration/sObjectDescribe.test.ts
@@ -53,7 +53,10 @@ describe('Fetch sObjects', function() {
     );
   });
 
-  after(function() {
+  after(async function() {
+    if (username) {
+      await util.deleteScratchOrg(username);
+    }
     const projectPath = path.join(process.cwd(), PROJECT_NAME);
     rimraf.sync(projectPath);
   });

--- a/packages/salesforcedx-sobjects-faux-generator/test/integration/sObjectDescribe.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/integration/sObjectDescribe.test.ts
@@ -20,14 +20,8 @@ const PROJECT_NAME = `project_${new Date().getTime()}`;
 const CUSTOM_OBJECT_NAME = 'MyCustomObject__c';
 const CUSTOM_OBJECT2 = 'MyCustomObject2__c';
 const CUSTOM_OBJECT3 = 'MyCustomObject3__c';
-const CUSTOM_FIELD_FULLNAME = CUSTOM_OBJECT_NAME + '.MyCustomField__c';
-const SIMPLE_OBJECT_DIR = path.join(
-  'test',
-  'integration',
-  'config',
-  'simpleObjectAndField',
-  'objects'
-);
+const CUSTOM_FIELDNAME = 'MyCustomField__c';
+const SIMPLE_OBJECT_SOURCE_FOLDER = 'simpleObjectAndField';
 
 const sobjectdescribe = new SObjectDescribe();
 const MIN_CUSTOMOBJECT_NUM_FIELDS = 9;
@@ -40,32 +34,23 @@ describe('Fetch sObjects', function() {
   let username: string;
 
   before(async function() {
-    await util.createSFDXProject(PROJECT_NAME);
-    username = await util.createScratchOrg(PROJECT_NAME);
+    const customFields: util.CustomFieldInfo[] = [
+      new util.CustomFieldInfo(CUSTOM_OBJECT_NAME, [
+        `${CUSTOM_OBJECT_NAME}.${CUSTOM_FIELDNAME}`
+      ]),
+      new util.CustomFieldInfo(CUSTOM_OBJECT2, [
+        `${CUSTOM_OBJECT2}.${CUSTOM_FIELDNAME}`
+      ]),
+      new util.CustomFieldInfo(CUSTOM_OBJECT3, [
+        `${CUSTOM_OBJECT3}.${CUSTOM_FIELDNAME}`
+      ])
+    ];
 
-    const sourceFolder = path.join(
-      __dirname,
-      '..',
-      '..',
-      '..',
-      SIMPLE_OBJECT_DIR
+    username = await util.initializeProject(
+      PROJECT_NAME,
+      SIMPLE_OBJECT_SOURCE_FOLDER,
+      customFields
     );
-    await util.push(sourceFolder, PROJECT_NAME, username);
-
-    const permSetName = 'AllowRead';
-    const permissionSetId = await util.createPermissionSet(
-      permSetName,
-      username
-    );
-
-    await util.createFieldPermissions(
-      permissionSetId,
-      CUSTOM_OBJECT_NAME,
-      CUSTOM_FIELD_FULLNAME,
-      username
-    );
-
-    await util.assignPermissionSet(permSetName, username);
   });
 
   after(function() {

--- a/packages/salesforcedx-sobjects-faux-generator/test/integration/sObjectDescribe.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/integration/sObjectDescribe.test.ts
@@ -18,8 +18,8 @@ import * as util from './integrationTestUtil';
 // and multiple objects for testing describeGlobal
 const PROJECT_NAME = `project_${new Date().getTime()}`;
 const CUSTOM_OBJECT_NAME = 'MyCustomObject__c';
-const CUSTOM_OBJECT2 = 'MyCustomObject2__c';
-const CUSTOM_OBJECT3 = 'MyCustomObject3__c';
+const CUSTOM_OBJECT2_NAME = 'MyCustomObject2__c';
+const CUSTOM_OBJECT3_NAME = 'MyCustomObject3__c';
 const CUSTOM_FIELDNAME = 'MyCustomField__c';
 const SIMPLE_OBJECT_SOURCE_FOLDER = 'simpleObjectAndField';
 
@@ -38,11 +38,11 @@ describe('Fetch sObjects', function() {
       new util.CustomFieldInfo(CUSTOM_OBJECT_NAME, [
         `${CUSTOM_OBJECT_NAME}.${CUSTOM_FIELDNAME}`
       ]),
-      new util.CustomFieldInfo(CUSTOM_OBJECT2, [
-        `${CUSTOM_OBJECT2}.${CUSTOM_FIELDNAME}`
+      new util.CustomFieldInfo(CUSTOM_OBJECT2_NAME, [
+        `${CUSTOM_OBJECT2_NAME}.${CUSTOM_FIELDNAME}`
       ]),
-      new util.CustomFieldInfo(CUSTOM_OBJECT3, [
-        `${CUSTOM_OBJECT3}.${CUSTOM_FIELDNAME}`
+      new util.CustomFieldInfo(CUSTOM_OBJECT3_NAME, [
+        `${CUSTOM_OBJECT3_NAME}.${CUSTOM_FIELDNAME}`
       ])
     ];
 
@@ -59,7 +59,7 @@ describe('Fetch sObjects', function() {
   });
 
   it('Should be able to call describeGlobal', async function() {
-    const objs = [CUSTOM_OBJECT_NAME, CUSTOM_OBJECT2, CUSTOM_OBJECT3];
+    const objs = [CUSTOM_OBJECT_NAME, CUSTOM_OBJECT2_NAME, CUSTOM_OBJECT3_NAME];
     const cmdOutput = await sobjectdescribe.describeGlobal(
       process.cwd(),
       SObjectCategory.CUSTOM,
@@ -95,7 +95,7 @@ describe('Fetch sObjects', function() {
   it('Should be able to call describeSObjectBatch on custom objects', async function() {
     const cmdOutput = await sobjectdescribe.describeSObjectBatch(
       process.cwd(),
-      [CUSTOM_OBJECT_NAME, CUSTOM_OBJECT2, CUSTOM_OBJECT3],
+      [CUSTOM_OBJECT_NAME, CUSTOM_OBJECT2_NAME, CUSTOM_OBJECT3_NAME],
       0,
       username
     );
@@ -105,11 +105,11 @@ describe('Fetch sObjects', function() {
     const customField = cmdOutput[0].fields[cmdOutput[0].fields.length - 1];
     expect(customField.name).to.be.equal('MyCustomField__c');
 
-    expect(cmdOutput[1].name).to.be.equal(CUSTOM_OBJECT2);
+    expect(cmdOutput[1].name).to.be.equal(CUSTOM_OBJECT2_NAME);
     expect(cmdOutput[1].custom).to.be.true;
     expect(cmdOutput[1].fields.length).to.be.least(MIN_CUSTOMOBJECT_NUM_FIELDS);
 
-    expect(cmdOutput[2].name).to.be.equal(CUSTOM_OBJECT3);
+    expect(cmdOutput[2].name).to.be.equal(CUSTOM_OBJECT3_NAME);
   });
 
   it('Should be able to call describeSObject on standard object', async function() {

--- a/packages/salesforcedx-utils-vscode/src/cli/commandExecutor.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/commandExecutor.ts
@@ -35,7 +35,11 @@ export class CliCommandExecutor {
       this.command.args,
       this.options
     );
-    return new CommandExecution(this.command, childProcess, cancellationToken);
+    return new CliCommandExecution(
+      this.command,
+      childProcess,
+      cancellationToken
+    );
   }
 }
 
@@ -45,7 +49,16 @@ export class CliCommandExecutor {
  * If we ever use a different executor, this class should be refactored and abstracted
  * to take an event emitter/observable instead of child_proces.
  */
-export class CommandExecution {
+export interface CommandExecution {
+  readonly command: Command;
+  readonly cancellationToken?: CancellationToken;
+  readonly processExitSubject: Observable<number | undefined>;
+  readonly processErrorSubject: Observable<Error | undefined>;
+  readonly stdoutSubject: Observable<Buffer | string>;
+  readonly stderrSubject: Observable<Buffer | string>;
+}
+
+export class CliCommandExecution implements CommandExecution {
   public readonly command: Command;
   public readonly cancellationToken?: CancellationToken;
   public readonly processExitSubject: Observable<number | undefined>;

--- a/packages/salesforcedx-utils-vscode/src/cli/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/index.ts
@@ -15,5 +15,10 @@ export interface Command {
 }
 
 export { CommandBuilder, SfdxCommandBuilder } from './commandBuilder';
-export { CliCommandExecutor, CommandExecution } from './commandExecutor';
+export {
+  CliCommandExecutor,
+  CliCommandExecution,
+  CommandExecution
+} from './commandExecutor';
 export { CommandOutput } from './commandOutput';
+export { LocalCommandExecution } from './localCommandExecutor';

--- a/packages/salesforcedx-utils-vscode/src/cli/localCommandExecutor.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/localCommandExecutor.ts
@@ -1,0 +1,41 @@
+import { EventEmitter } from 'events';
+import 'rxjs/add/observable/fromEvent';
+import { Command } from '.';
+import { CancellationToken, CommandExecution } from './commandExecutor';
+
+import { Observable } from 'rxjs/Observable';
+
+export class LocalCommandExecution implements CommandExecution {
+  public readonly command: Command;
+  public readonly cancellationToken?: CancellationToken;
+  public readonly processExitSubject: Observable<number | undefined>;
+  public readonly processErrorSubject: Observable<Error | undefined>;
+  public readonly stdoutSubject: Observable<Buffer | string>;
+  public readonly stderrSubject: Observable<Buffer | string>;
+
+  public cmdEmitter: EventEmitter = new EventEmitter();
+  public static readonly EXIT_EVENT = 'exitEvent';
+  public static readonly ERROR_EVENT = 'errorEvent';
+  public static readonly STDOUT_EVENT = 'stdoutEvent';
+  public static readonly STDERR_EVENT = 'stderrEvent';
+
+  constructor(command: Command) {
+    this.command = command;
+    this.processExitSubject = Observable.fromEvent(
+      this.cmdEmitter,
+      LocalCommandExecution.EXIT_EVENT
+    );
+    this.processErrorSubject = Observable.fromEvent(
+      this.cmdEmitter,
+      LocalCommandExecution.ERROR_EVENT
+    );
+    this.stdoutSubject = Observable.fromEvent(
+      this.cmdEmitter,
+      LocalCommandExecution.STDOUT_EVENT
+    );
+    this.stderrSubject = Observable.fromEvent(
+      this.cmdEmitter,
+      LocalCommandExecution.STDERR_EVENT
+    );
+  }
+}

--- a/packages/salesforcedx-utils-vscode/src/cli/localCommandExecutor.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/localCommandExecutor.ts
@@ -1,9 +1,8 @@
 import { EventEmitter } from 'events';
 import 'rxjs/add/observable/fromEvent';
+import { Observable } from 'rxjs/Observable';
 import { Command } from '.';
 import { CancellationToken, CommandExecution } from './commandExecutor';
-
-import { Observable } from 'rxjs/Observable';
 
 export class LocalCommandExecution implements CommandExecution {
   public readonly command: Command;
@@ -13,29 +12,33 @@ export class LocalCommandExecution implements CommandExecution {
   public readonly stdoutSubject: Observable<Buffer | string>;
   public readonly stderrSubject: Observable<Buffer | string>;
 
+  // NOTE: ERROR_EVENT is NOT named 'error' because that causes the EventEmitter to actually
+  // throw an exception IF there is no listener
   public cmdEmitter: EventEmitter = new EventEmitter();
   public static readonly EXIT_EVENT = 'exitEvent';
   public static readonly ERROR_EVENT = 'errorEvent';
   public static readonly STDOUT_EVENT = 'stdoutEvent';
   public static readonly STDERR_EVENT = 'stderrEvent';
+  public static readonly SUCCESS_CODE = 0;
+  public static readonly FAILURE_CODE = 1;
 
   constructor(command: Command) {
     this.command = command;
     this.processExitSubject = Observable.fromEvent(
       this.cmdEmitter,
       LocalCommandExecution.EXIT_EVENT
-    );
+    ) as Observable<number>;
     this.processErrorSubject = Observable.fromEvent(
       this.cmdEmitter,
       LocalCommandExecution.ERROR_EVENT
-    );
+    ) as Observable<Error>;
     this.stdoutSubject = Observable.fromEvent(
       this.cmdEmitter,
       LocalCommandExecution.STDOUT_EVENT
-    );
+    ) as Observable<string>;
     this.stderrSubject = Observable.fromEvent(
       this.cmdEmitter,
       LocalCommandExecution.STDERR_EVENT
-    );
+    ) as Observable<string>;
   }
 }

--- a/packages/salesforcedx-utils-vscode/src/constants.ts
+++ b/packages/salesforcedx-utils-vscode/src/constants.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+export const SFDX_PROJECT_FILE = 'sfdx-project.json';

--- a/packages/salesforcedx-utils-vscode/src/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/index.ts
@@ -1,0 +1,1 @@
+export { SFDX_PROJECT_FILE } from './constants';

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -323,7 +323,7 @@
       },
       {
         "command": "sfdx.force.internal.refreshsobjects",
-        "title": "%force_refresh_sobjects%"
+        "title": "%force_sobjects_refresh%"
       },
       {
         "command": "sfdx.force.data.soql.query.input",

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -34,7 +34,7 @@
   "force_org_display_default_text":
     "SFDX: Display Org Details for Default Scratch Org",
   "force_org_display_username_text": "SFDX: Display Org Details...",
-  "force_refresh_sobjects": "SFDX: Refresh SObject Definitions",
+  "force_sobjects_refresh": "SFDX: Refresh SObject Definitions",
   "force_data_soql_query_input_text": "SFDX: Execute SOQL Query...",
   "force_data_soql_query_selection_text":
     "SFDX: Execute SOQL Query with Currently Selected Text",

--- a/packages/salesforcedx-vscode-core/src/channels/channelService.ts
+++ b/packages/salesforcedx-vscode-core/src/channels/channelService.ts
@@ -61,7 +61,7 @@ export class ChannelService {
       this.channel.append(' ');
       if (data != undefined) {
         this.channel.appendLine(
-          nls.localize('channel_end_with_error', data.toString())
+          nls.localize('channel_end_with_error', data.message)
         );
 
         if (/sfdx.*ENOENT/.test(data.message)) {

--- a/packages/salesforcedx-vscode-core/src/commands/forceGenerateFauxClasses.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceGenerateFauxClasses.ts
@@ -25,8 +25,8 @@ import {
 class ForceGenerateFauxClassesExecutor extends SfdxCommandletExecutor<{}> {
   public build(data: {}): Command {
     return new SfdxCommandBuilder()
-      .withDescription(nls.localize('force_refresh_sobjects'))
-      .withArg('refresh sObject definitions')
+      .withDescription(nls.localize('force_sobjects_refresh'))
+      .withArg('sobject definitions refresh')
       .build();
   }
 
@@ -38,7 +38,7 @@ class ForceGenerateFauxClassesExecutor extends SfdxCommandletExecutor<{}> {
 
     this.attachExecution(execution, cancellationTokenSource, cancellationToken);
 
-    const projectPath: string = <string>vscode.workspace.rootPath;
+    const projectPath: string = vscode.workspace.rootPath as string;
     const gen: FauxClassGenerator = new FauxClassGenerator(
       execution.cmdEmitter,
       cancellationToken

--- a/packages/salesforcedx-vscode-core/src/commands/forceGenerateFauxClasses.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceGenerateFauxClasses.ts
@@ -9,6 +9,8 @@ import { SObjectCategory } from '@salesforce/salesforcedx-sobjects-faux-generato
 import { FauxClassGenerator } from '@salesforce/salesforcedx-sobjects-faux-generator/out/src/generator';
 import {
   Command,
+  CommandExecution,
+  LocalCommandExecution,
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import * as vscode from 'vscode';
@@ -25,16 +27,30 @@ class ForceGenerateFauxClassesExecutor extends SfdxCommandletExecutor<{}> {
   public build(data: {}): Command {
     return new SfdxCommandBuilder()
       .withDescription(nls.localize('force_refresh_sobjects'))
+      .withArg('refresh sObject definitions')
       .build();
   }
 
   public async execute(response: ContinueResponse<{}>): Promise<void> {
+    const cancellationTokenSource = new vscode.CancellationTokenSource();
+    const cancellationToken = cancellationTokenSource.token;
+
+    const execution = new LocalCommandExecution(this.build(response.data));
+
+    this.attachExecution(execution, cancellationTokenSource, cancellationToken);
+
     const projectPath: string = <string>vscode.workspace.rootPath;
-    const gen: FauxClassGenerator = new FauxClassGenerator();
+    const gen: FauxClassGenerator = new FauxClassGenerator(
+      execution.cmdEmitter,
+      cancellationToken
+    );
+
     try {
       await gen.generate(projectPath, SObjectCategory.ALL);
+      execution.cmdEmitter.emit(LocalCommandExecution.EXIT_EVENT, '0');
     } catch (e) {
-      console.log(e);
+      execution.cmdEmitter.emit(LocalCommandExecution.STDERR_EVENT, e);
+      execution.cmdEmitter.emit(LocalCommandExecution.ERROR_EVENT, '1');
     }
     return;
   }

--- a/packages/salesforcedx-vscode-core/src/commands/forceGenerateFauxClasses.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceGenerateFauxClasses.ts
@@ -46,11 +46,10 @@ class ForceGenerateFauxClassesExecutor extends SfdxCommandletExecutor<{}> {
     );
 
     try {
-      await gen.generate(projectPath, SObjectCategory.ALL);
-      execution.cmdEmitter.emit(LocalCommandExecution.EXIT_EVENT, '0');
+      const result = await gen.generate(projectPath, SObjectCategory.ALL);
+      console.log('Generate success ' + result);
     } catch (e) {
-      execution.cmdEmitter.emit(LocalCommandExecution.STDERR_EVENT, e);
-      execution.cmdEmitter.emit(LocalCommandExecution.ERROR_EVENT, '1');
+      console.log('Generate error ' + e);
     }
     return;
   }

--- a/packages/salesforcedx-vscode-core/src/commands/forceGenerateFauxClasses.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceGenerateFauxClasses.ts
@@ -9,7 +9,6 @@ import { SObjectCategory } from '@salesforce/salesforcedx-sobjects-faux-generato
 import { FauxClassGenerator } from '@salesforce/salesforcedx-sobjects-faux-generator/out/src/generator';
 import {
   Command,
-  CommandExecution,
   LocalCommandExecution,
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -101,5 +101,5 @@ export const messages = {
     'SFDX: Execute Anonymous Apex with Editor Contents',
   force_apex_execute_selection_text:
     'SFDX: Execute Anonymous Apex with Currently Selected Text',
-  force_refresh_sobjects: 'SFDX: Refresh SObject Definitions'
+  force_sobjects_refresh: 'SFDX: Refresh SObject Definitions'
 };

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -100,5 +100,6 @@ export const messages = {
   force_apex_execute_document_text:
     'SFDX: Execute Anonymous Apex with Editor Contents',
   force_apex_execute_selection_text:
-    'SFDX: Execute Anonymous Apex with Currently Selected Text'
+    'SFDX: Execute Anonymous Apex with Currently Selected Text',
+  force_refresh_sobjects: 'SFDX: Refresh SObject Definitions'
 };


### PR DESCRIPTION
Convert the ForceGenerateFauxClassesExecutor (command) and FauxClassGenerator to properly utilize the support in SfdxCommandLetExecutor to hook into notification, cancellation, and status bar.  This involves creating a LocalCommandExecution to feed the observables from an emitter (exit, error, stdout, stderr). 
Cancellation is checked before each batch of SObject describes is done - as these are the long operations in FauxClassGenerator.
Added fauxGenerateTest for integration tests of the generate() call.
More cleanup of the testing in general to ensure that scratch orgs are deleted, etc.

@W-4358436@
