### PR TITLE
Lock stacktraceRequest. Fix default type of requestTypeFilter.

### DIFF
--- a/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
+++ b/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
@@ -745,9 +745,16 @@ export class ApexDebug extends LoggingDebugSession {
 
     const requestId = this.requestThreads.get(args.threadId)!;
     try {
-      const stateResponse = await this.myRequestService.execute(
-        new StateCommand(requestId)
-      );
+      const stateResponse = await this.lock.acquire('stacktrace', async () => {
+        this.log(
+          TRACE_CATEGORY_VARIABLES,
+          `stackTraceRequest: args threadId=${args.threadId} startFrame=${args.startFrame} levels=${args.levels}`
+        );
+        const responseString = await this.myRequestService.execute(
+          new StateCommand(requestId)
+        );
+        return Promise.resolve(responseString);
+      });
       const stateRespObj: DebuggerResponse = JSON.parse(stateResponse);
       const clientFrames: StackFrame[] = [];
       if (this.hasStackFrames(stateRespObj)) {

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -110,7 +110,7 @@
               "requestTypeFilter": {
                 "type": "array",
                 "description": "%request_type_filter_text%",
-                "default": "",
+                "default": [],
                 "items": {
                   "type": "string",
                   "enum": [


### PR DESCRIPTION
### What does this PR do?
The adapter sends one stopped event to VS Code when we've hit a breakpoint or finished stepping. VS Code sends a stackTraceRequest as a result of that stopped event. Then, for some reason, their tree api refreshes the callstack view which again sends a stackTraceRequest. As a result, our adapter fires off two state requests. If the timing is very close, apex debugger engine could still be processing the first request and cannot evaluate the state again. So, we're locking the stackTraceRequest to process one at a time.

Also, make default type of requestTypeFilter from string to array.

### What issues does this PR fix or reference?
@W-4380397, W-4380128@