### PR TITLE
Use V6 with the latest installers

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,7 +11,7 @@ skip_branch_with_pr: true
 platform: x64
 
 environment:
-  SFDX_URL_WINDOWS: https://cli-assets.heroku.com/branches/alpha/5.99.1-128ffd6/sfdx-v5.99.1-128ffd6-windows-amd64.tar.xz
+  SFDX_URL_WINDOWS: https://developer.salesforce.com/media/salesforce-cli/sfdx-v5.99.1-d7efd75-windows-amd64.tar.xz
   SFDX_AUTOUPDATE_DISABLE: true
   SFDX_DOMAIN_RETRY: 300
 
@@ -22,7 +22,7 @@ install:
   - 7z x sfdx-windows-amd64.tar.xz
   - 7z x sfdx-windows-amd64.tar
   - SET PATH=%APPVEYOR_BUILD_FOLDER%\sfdx\bin;%PATH%
-  - sfdx update alpha
+  - sfdx update
   - npm install -g codecov 
   # the JWT key should be stored base 64 encoded in AppVeyor settings
   - ps: "[System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($env:SFDX_CI_DEVHUB_JWTKEY)) | Out-File -Encoding \"ASCII\" C:\\projects\\devhub.key"

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
       wget -qO- $SFDX_URL_LINUX | tar xJf -
       "./sfdx/install"
       export PATH=./sfdx/$(pwd):$PATH
-      sfdx update alpha
+      sfdx update
       export SFDX_CI_KEY_LOCATION=/home/travis/devhub.key
     fi
   - |
@@ -55,7 +55,7 @@ before_install:
       echo Installing SFDX CLI macOS
       wget -q $SFDX_URL_OSX
       sudo installer -pkg sfdx-osx.pkg -target /
-      sfdx update alpha
+      sfdx update
       export SFDX_CI_KEY_LOCATION=/Users/travis/devhub.key
     fi
   - |

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -39,7 +39,7 @@
     "clean":
       "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
     "test":
-      "./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test --reporter mocha-multi-reporters --timeout 5000",
+      "./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test --reporter mocha-multi-reporters --timeout 20000",
     "coverage": "./node_modules/.bin/nyc npm test"
   },
   "nyc": {

--- a/packages/salesforcedx-vscode-core/test/index.ts
+++ b/packages/salesforcedx-vscode-core/test/index.ts
@@ -25,7 +25,7 @@ const testRunner = require('@salesforce/salesforcedx-utils-vscode/out/src/test/t
 testRunner.configure({
   ui: 'bdd', // the TDD UI is being used in extension.test.ts (suite, test, etc.)
   useColors: true, // colored output from test results
-  timeout: 5000
+  timeout: 20000
 });
 
 module.exports = testRunner;


### PR DESCRIPTION
### What does this PR do?

The installers are now all at v5.9.9.x and we no longer need to use `sfdx update alpha`. Changing the CI jobs to reflect that.

### What issues does this PR fix or reference?

None. Normal CI tasks.