### PR TITLE
Add client identifier to debugger REST calls

### DIFF
--- a/packages/salesforcedx-apex-debugger/src/commands/requestService.ts
+++ b/packages/salesforcedx-apex-debugger/src/commands/requestService.ts
@@ -6,7 +6,7 @@
  */
 
 import { configure, xhr, XHROptions, XHRResponse } from 'request-light';
-import { DEFAULT_CONNECTION_TIMEOUT_MS } from '../constants';
+import { CLIENT_ID, DEFAULT_CONNECTION_TIMEOUT_MS } from '../constants';
 import { BaseCommand } from './baseCommand';
 
 export class RequestService {
@@ -105,7 +105,8 @@ export class RequestService {
         Authorization: `OAuth ${this.accessToken}`,
         'Content-Length': requestBody
           ? Buffer.byteLength(requestBody, 'utf-8')
-          : 0
+          : 0,
+        clientid: CLIENT_ID
       },
       data: requestBody
     };

--- a/packages/salesforcedx-apex-debugger/src/commands/requestService.ts
+++ b/packages/salesforcedx-apex-debugger/src/commands/requestService.ts
@@ -106,7 +106,7 @@ export class RequestService {
         'Content-Length': requestBody
           ? Buffer.byteLength(requestBody, 'utf-8')
           : 0,
-        clientid: CLIENT_ID
+        'Sforce-Call-Options': `client=${CLIENT_ID}`
       },
       data: requestBody
     };

--- a/packages/salesforcedx-apex-debugger/src/constants.ts
+++ b/packages/salesforcedx-apex-debugger/src/constants.ts
@@ -14,3 +14,4 @@ export const GET_WORKSPACE_SETTINGS_EVENT = 'getWorkspaceSettings';
 export const LINE_BREAKPOINT_INFO_REQUEST = 'lineBreakpointInfo';
 export const HOTSWAP_REQUEST = 'hotswap';
 export const WORKSPACE_SETTINGS_REQUEST = 'workspaceSettings';
+export const CLIENT_ID = 'sfdx-vscode';

--- a/packages/salesforcedx-apex-debugger/test/unit/commands/baseCommand.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/commands/baseCommand.test.ts
@@ -11,7 +11,10 @@ import * as sinon from 'sinon';
 import { BaseCommand } from '../../../src/commands/baseCommand';
 import { DebuggerRequest } from '../../../src/commands/protocol';
 import { RequestService } from '../../../src/commands/requestService';
-import { DEFAULT_CONNECTION_TIMEOUT_MS } from '../../../src/constants';
+import {
+  CLIENT_ID,
+  DEFAULT_CONNECTION_TIMEOUT_MS
+} from '../../../src/constants';
 
 class DummyCommand extends BaseCommand {
   public constructor(
@@ -22,6 +25,16 @@ class DummyCommand extends BaseCommand {
   ) {
     super(commandName, debuggedRequestId, queryString, request);
   }
+}
+
+export function getDefaultHeaders(contentLength: number): any {
+  return {
+    'Content-Type': 'application/json;charset=utf-8',
+    Accept: 'application/json',
+    Authorization: `OAuth 123`,
+    'Content-Length': contentLength,
+    clientid: CLIENT_ID
+  };
 }
 
 describe('Base command', () => {
@@ -50,12 +63,7 @@ describe('Base command', () => {
       type: 'POST',
       url: 'https://www.salesforce.com/services/debug/v41.0/dummy/07cFAKE',
       timeout: DEFAULT_CONNECTION_TIMEOUT_MS,
-      headers: {
-        'Content-Type': 'application/json;charset=utf-8',
-        Accept: 'application/json',
-        Authorization: `OAuth 123`,
-        'Content-Length': 0
-      },
+      headers: getDefaultHeaders(0),
       data: undefined
     };
 
@@ -80,12 +88,7 @@ describe('Base command', () => {
       url:
         'https://www.salesforce.com/services/debug/v41.0/dummy2/07cFAKE?param=whoops',
       timeout: DEFAULT_CONNECTION_TIMEOUT_MS,
-      headers: {
-        'Content-Type': 'application/json;charset=utf-8',
-        Accept: 'application/json',
-        Authorization: `OAuth 123`,
-        'Content-Length': 0
-      },
+      headers: getDefaultHeaders(0),
       data: undefined
     };
 
@@ -119,12 +122,7 @@ describe('Base command', () => {
       url:
         'https://www.salesforce.com/services/debug/v41.0/dummy2/07cFAKE?param=whoops',
       timeout: DEFAULT_CONNECTION_TIMEOUT_MS,
-      headers: {
-        'Content-Type': 'application/json;charset=utf-8',
-        Accept: 'application/json',
-        Authorization: `OAuth 123`,
-        'Content-Length': Buffer.byteLength(requestBody, 'utf-8')
-      },
+      headers: getDefaultHeaders(Buffer.byteLength(requestBody, 'utf-8')),
       data: requestBody
     };
 

--- a/packages/salesforcedx-apex-debugger/test/unit/commands/baseCommand.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/commands/baseCommand.test.ts
@@ -33,7 +33,7 @@ export function getDefaultHeaders(contentLength: number): any {
     Accept: 'application/json',
     Authorization: `OAuth 123`,
     'Content-Length': contentLength,
-    clientid: CLIENT_ID
+    'Sforce-Call-Options': `client=${CLIENT_ID}`
   };
 }
 

--- a/packages/salesforcedx-apex-debugger/test/unit/commands/frameCommand.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/commands/frameCommand.test.ts
@@ -10,6 +10,7 @@ import { XHROptions, XHRResponse } from 'request-light';
 import * as sinon from 'sinon';
 import { FrameCommand, RequestService } from '../../../src/commands';
 import { DEFAULT_CONNECTION_TIMEOUT_MS } from '../../../src/constants';
+import { getDefaultHeaders } from './baseCommand.test';
 
 describe('Frame command', () => {
   let sendRequestSpy: sinon.SinonStub;
@@ -37,12 +38,7 @@ describe('Frame command', () => {
       url:
         'https://www.salesforce.com/services/debug/v41.0/frame/07cFAKE?stackFrame=1',
       timeout: DEFAULT_CONNECTION_TIMEOUT_MS,
-      headers: {
-        'Content-Type': 'application/json;charset=utf-8',
-        Accept: 'application/json',
-        Authorization: `OAuth 123`,
-        'Content-Length': 0
-      },
+      headers: getDefaultHeaders(0),
       data: undefined
     };
 

--- a/packages/salesforcedx-apex-debugger/test/unit/commands/referencesCommand.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/commands/referencesCommand.test.ts
@@ -10,6 +10,7 @@ import { XHROptions, XHRResponse } from 'request-light';
 import * as sinon from 'sinon';
 import { ReferencesCommand, RequestService } from '../../../src/commands';
 import { DEFAULT_CONNECTION_TIMEOUT_MS } from '../../../src/constants';
+import { getDefaultHeaders } from './baseCommand.test';
 
 describe('References command', () => {
   let sendRequestSpy: sinon.SinonStub;
@@ -41,12 +42,7 @@ describe('References command', () => {
       type: 'POST',
       url: 'https://www.salesforce.com/services/debug/v41.0/references/07cFAKE',
       timeout: DEFAULT_CONNECTION_TIMEOUT_MS,
-      headers: {
-        'Content-Type': 'application/json;charset=utf-8',
-        Accept: 'application/json',
-        Authorization: `OAuth 123`,
-        'Content-Length': Buffer.byteLength(requestBody, 'utf-8')
-      },
+      headers: getDefaultHeaders(Buffer.byteLength(requestBody, 'utf-8')),
       data: requestBody
     };
 

--- a/packages/salesforcedx-apex-debugger/test/unit/commands/runCommand.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/commands/runCommand.test.ts
@@ -10,6 +10,7 @@ import { XHROptions, XHRResponse } from 'request-light';
 import * as sinon from 'sinon';
 import { RequestService, RunCommand } from '../../../src/commands';
 import { DEFAULT_CONNECTION_TIMEOUT_MS } from '../../../src/constants';
+import { getDefaultHeaders } from './baseCommand.test';
 
 describe('Run command', () => {
   let sendRequestSpy: sinon.SinonStub;
@@ -36,12 +37,7 @@ describe('Run command', () => {
       type: 'POST',
       url: 'https://www.salesforce.com/services/debug/v41.0/run/07cFAKE',
       timeout: DEFAULT_CONNECTION_TIMEOUT_MS,
-      headers: {
-        'Content-Type': 'application/json;charset=utf-8',
-        Accept: 'application/json',
-        Authorization: `OAuth 123`,
-        'Content-Length': 0
-      },
+      headers: getDefaultHeaders(0),
       data: undefined
     };
 

--- a/packages/salesforcedx-apex-debugger/test/unit/commands/stateCommand.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/commands/stateCommand.test.ts
@@ -10,6 +10,7 @@ import { XHROptions, XHRResponse } from 'request-light';
 import * as sinon from 'sinon';
 import { RequestService, StateCommand } from '../../../src/commands';
 import { DEFAULT_CONNECTION_TIMEOUT_MS } from '../../../src/constants';
+import { getDefaultHeaders } from './baseCommand.test';
 
 describe('State command', () => {
   let sendRequestSpy: sinon.SinonStub;
@@ -36,12 +37,7 @@ describe('State command', () => {
       type: 'POST',
       url: 'https://www.salesforce.com/services/debug/v41.0/state/07cFAKE',
       timeout: DEFAULT_CONNECTION_TIMEOUT_MS,
-      headers: {
-        'Content-Type': 'application/json;charset=utf-8',
-        Accept: 'application/json',
-        Authorization: `OAuth 123`,
-        'Content-Length': 0
-      },
+      headers: getDefaultHeaders(0),
       data: undefined
     };
 

--- a/packages/salesforcedx-apex-debugger/test/unit/commands/stepCommands.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/commands/stepCommands.test.ts
@@ -15,6 +15,7 @@ import {
   StepOverCommand
 } from '../../../src/commands';
 import { DEFAULT_CONNECTION_TIMEOUT_MS } from '../../../src/constants';
+import { getDefaultHeaders } from './baseCommand.test';
 
 describe('Step commands', () => {
   let sendRequestSpy: sinon.SinonStub;
@@ -41,12 +42,7 @@ describe('Step commands', () => {
       url:
         'https://www.salesforce.com/services/debug/v41.0/step/07cFAKE?type=into',
       timeout: DEFAULT_CONNECTION_TIMEOUT_MS,
-      headers: {
-        'Content-Type': 'application/json;charset=utf-8',
-        Accept: 'application/json',
-        Authorization: `OAuth 123`,
-        'Content-Length': 0
-      },
+      headers: getDefaultHeaders(0),
       data: undefined
     };
 
@@ -68,12 +64,7 @@ describe('Step commands', () => {
       url:
         'https://www.salesforce.com/services/debug/v41.0/step/07cFAKE?type=out',
       timeout: DEFAULT_CONNECTION_TIMEOUT_MS,
-      headers: {
-        'Content-Type': 'application/json;charset=utf-8',
-        Accept: 'application/json',
-        Authorization: `OAuth 123`,
-        'Content-Length': 0
-      },
+      headers: getDefaultHeaders(0),
       data: undefined
     };
 
@@ -95,12 +86,7 @@ describe('Step commands', () => {
       url:
         'https://www.salesforce.com/services/debug/v41.0/step/07cFAKE?type=over',
       timeout: DEFAULT_CONNECTION_TIMEOUT_MS,
-      headers: {
-        'Content-Type': 'application/json;charset=utf-8',
-        Accept: 'application/json',
-        Authorization: `OAuth 123`,
-        'Content-Length': 0
-      },
+      headers: getDefaultHeaders(0),
       data: undefined
     };
 


### PR DESCRIPTION
### What does this PR do?
Add a client ID in RequestService following the spec in https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/headers_calloptions.htm.

### What issues does this PR fix or reference?
@W-4395263@
