### PR TITLE
Allow osx build to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ node_js:
 
 cache:
   directories:
-    - node_modules
     - $HOME/.npm
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,10 @@ before_install:
       sleep 3;
       # install CLI
       echo Installing SFDX CLI Linux
-      wget -qO- $SFDX_URL_LINUX | tar xJf -
+      travis_retry wget -qO- $SFDX_URL_LINUX | tar xJf -
       "./sfdx/install"
       export PATH=./sfdx/$(pwd):$PATH
-      sfdx update
+      travis_retry sfdx update
       export SFDX_CI_KEY_LOCATION=/home/travis/devhub.key
     fi
   - |
@@ -57,9 +57,9 @@ before_install:
       rvm get stable
       # install CLI
       echo Installing SFDX CLI macOS
-      wget -q $SFDX_URL_OSX
+      travis_retry wget -q $SFDX_URL_OSX
       sudo installer -pkg sfdx-osx.pkg -target /
-      sfdx update
+      travis_retry sfdx update
       export SFDX_CI_KEY_LOCATION=/Users/travis/devhub.key
     fi
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ notifications:
   email: false
 
 matrix:
+  allow_failures:
+    - os: osx
   fast_finish: true
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,8 +67,8 @@ before_install:
     curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
 
 install:
-  - npm install
-  - npm install -g codecov 
+  - travis_retry npm install
+  - travis_retry npm install -g codecov 
 
 script:
   - npm run compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: required
 
 node_js:
   - "7"
+  - "8"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,8 +77,8 @@ script:
   - npm run lint
   - |
     if [[ $TRAVIS_OS_NAME == "linux" ]]; then
-      npm run test:without-system-tests
-      npm run coverage:system-tests
+      travis_wait 30 npm run test:without-system-tests
+      travis_wait 30 npm run coverage:system-tests
     fi
   - |
     if [[ $TRAVIS_OS_NAME == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ script:
     if [[ $TRAVIS_OS_NAME == "osx" ]]; then
       # Due to slowness of OS X on Travis
       # https://github.com/travis-ci/travis-ci/issues/6095
-      npm run test:without-system-tests
+      travis_wait 30 npm run test:without-system-tests
     fi
   - codecov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ os:
   - linux
   - osx
 
+osx_image: xcode9
+
 addons:
   apt:
     packages:


### PR DESCRIPTION
### What does this PR do?
Allows OSX builds to fail without blocking a PR
### What issues does this PR fix or reference?
Tests on mac builds have been flakey and don't usually catch errors that the linux build do not catch. Let's make them optional to pass so flakiness does not block a PR.