### PR TITLE
Rename settings from 'Salesforce DX' to 'Salesforce'

### DIFF
--- a/packages/salesforcedx-vscode-apex-debugger/package.nls.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.nls.json
@@ -12,7 +12,7 @@
   "launch_snippet_name": "Launch Apex Debugger",
   "trace_text":
     "Produce diagnostic output. Instead of setting this to true you can list one or more selectors separated with commas. The 'all' selector enables very detailed output. Other selectors are 'protocol', 'variables', 'launch'",
-  "configuration_title": "Salesforce DX Apex Debugger Configuration",
+  "configuration_title": "Salesforce Apex Debugger Configuration",
   "connection_timeout_ms_description":
     "Connection timeout for Apex Debugger API requests (in milliseconds)."
 }

--- a/packages/salesforcedx-vscode-apex/package.nls.json
+++ b/packages/salesforcedx-vscode-apex/package.nls.json
@@ -1,4 +1,5 @@
 {
-  "configuration_title": "Salesforce DX Apex Configuration",
-  "java_home_description": "Specifies the folder path to the Java 8 runtime used to launch the Apex Language Server (for example, /Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home)."
+  "configuration_title": "Salesforce Apex Configuration",
+  "java_home_description":
+    "Specifies the folder path to the Java 8 runtime used to launch the Apex Language Server (for example, /Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home)."
 }

--- a/packages/salesforcedx-vscode-visualforce/package.json
+++ b/packages/salesforcedx-vscode-visualforce/package.json
@@ -73,7 +73,7 @@
     ],
     "configuration": {
       "type": "object",
-      "title": "Salesforce DX Visualforce Configuration",
+      "title": "%configuration.title%",
       "properties": {
         "visualforce.format.enable": {
           "type": "boolean",

--- a/packages/salesforcedx-vscode-visualforce/package.nls.json
+++ b/packages/salesforcedx-vscode-visualforce/package.nls.json
@@ -1,4 +1,5 @@
 {
+  "configuration.title": "Salesforce Visualforce Configuration",
   "visualforce.format.enable.desc":
     "Enable/disable default Visualforce formatter",
   "visualforce.format.wrapLineLength.desc":


### PR DESCRIPTION
### What does this PR do?

Rename the configuration titles to use the more general "Salesforce" term instead of "Salesforce DX".

### What issues does this PR fix or reference?

@W-4401094@