### PR TITLE
Debugger requires 1.17 so the extension pack should also require 1.17

### DIFF
--- a/packages/salesforcedx-slds-linter/package.json
+++ b/packages/salesforcedx-slds-linter/package.json
@@ -7,7 +7,7 @@
   "license": "BSD-3-Clause",
   "categories": ["Other"],
   "engines": {
-    "vscode": "^1.13.0"
+    "vscode": "^1.17.0"
   },
   "devDependencies": {
     "@types/chai": "^4.0.0",

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -7,7 +7,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.15.0"
+    "vscode": "^1.17.0"
   },
   "dependencies": {
     "@salesforce/salesforcedx-utils-vscode": "41.4.0",

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -31,7 +31,7 @@
     "shelljs": "^0.7.8"
   },
   "engines": {
-    "vscode": "^1.13.0"
+    "vscode": "^1.17.0"
   },
   "scripts": {
     "vscode:package": "npm prune --production",

--- a/packages/salesforcedx-visualforce-language-server/package.json
+++ b/packages/salesforcedx-visualforce-language-server/package.json
@@ -5,7 +5,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.15.0"
+    "vscode": "^1.17.0"
   },
   "dependencies": {
     "@salesforce/salesforcedx-visualforce-markup-language-server": "41.4.0",

--- a/packages/salesforcedx-visualforce-markup-language-server/package.json
+++ b/packages/salesforcedx-visualforce-markup-language-server/package.json
@@ -5,7 +5,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.15.0"
+    "vscode": "^1.17.0"
   },
   "activationEvents": ["onView:never"],
   "main": "./out/src/htmlLanguageService.js",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -19,7 +19,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.13.0"
+    "vscode": "^1.17.0"
   },
   "categories": ["Languages"],
   "devDependencies": {

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -18,7 +18,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.13.0"
+    "vscode": "^1.17.0"
   },
   "categories": ["Other"],
   "dependencies": {

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -18,7 +18,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.13.0"
+    "vscode": "^1.17.0"
   },
   "categories": ["Languages"],
   "dependencies": {

--- a/packages/salesforcedx-vscode-visualforce/package.json
+++ b/packages/salesforcedx-vscode-visualforce/package.json
@@ -18,7 +18,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.15.0"
+    "vscode": "^1.17.0"
   },
   "categories": ["Languages"],
   "dependencies": {

--- a/packages/salesforcedx-vscode/package.json
+++ b/packages/salesforcedx-vscode/package.json
@@ -19,7 +19,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.13.0"
+    "vscode": "^1.17.0"
   },
   "scripts": {
     "vscode:prepublish": "npm prune --production",

--- a/packages/system-tests/package.json
+++ b/packages/system-tests/package.json
@@ -6,7 +6,7 @@
   "license": "BSD-3-Clause",
   "main": "./out/src",
   "engines": {
-    "vscode": "^1.13.0"
+    "vscode": "^1.17.0"
   },
   "devDependencies": {
     "@salesforce/salesforcedx-utils-vscode": "41.4.0",


### PR DESCRIPTION
### What does this PR do?
Once they install the pack, vscode prevents them from uninstalling the pack's dependencies, so they won't be able to remove the debugger extension. By bumping the pack's vscode version, the error message should be about the pack's required version instead of a specific dependency.

### What issues does this PR fix or reference?
