### PR TITLE
Ruth/update prereq docs

### DIFF
--- a/packages/salesforcedx-vscode-apex/README.md
+++ b/packages/salesforcedx-vscode-apex/README.md
@@ -3,6 +3,14 @@ View outlines of Apex classes and triggers, see code-completion suggestions, and
 
 For best results, use this extension with the other extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) bundle.  
 
+###  Prerequisites
+Before you set up this extension, make sure that you have these essentials.
+
+* **Java 8 Platform, Standard Edition Development Kit**  
+  Some features in Salesforce Extensions for VS Code depend upon the Java 8 Platform, Standard Edition Development Kit (JDK).  
+  If you don’t already have the JDK installed, install the latest version of the Java 8 JDK from [Java SE Development Kit 8 Downloads](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).  
+* **[Visual Studio Code](https://code.visualstudio.com/download) v1.17 or later**  
+
 ## View Code-Completion Suggestions
 To see code-completion suggestions, press Ctrl+space when you’re working in a `.cls` or `.trigger` file. To navigate between the suggestions, use the arrow keys. To auto-complete a suggestion from the list, press Enter.  
 ![Animation showing code completion of a System.debug() statement](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-apex/images/apex_completion.gif)

--- a/packages/salesforcedx-vscode-core/README.md
+++ b/packages/salesforcedx-vscode-core/README.md
@@ -3,6 +3,14 @@ This extension enables VS Code to use the Salesforce CLI to interact with your s
 
 For best results, use this extension with the other extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) bundle.  
 
+##  Prerequisites
+Before you set up this extension, make sure that you have these essentials.
+
+* **Salesforce CLI and a Salesforce DX project**  
+  Before you use Salesforce Extensions for VS Code, [set up the Salesforce CLI](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup) and [create a Salesforce DX project](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_workspace_setup.htm).  
+  Open your Salesforce DX project in a directory that contains an `sfdx-project.json` file. Otherwise, some features don’t work.  
+* **[Visual Studio Code](https://code.visualstudio.com/download) v1.17 or later**  
+
 ## Run Salesforce CLI Commands
 To run a command from Salesforce Extensions for VS Code, press Cmd+Shift+P (macOS) or Ctrl+Shift+P (Windows or Linux) and type **SFDX** in the command palette.  
 ![Command palette, filtered to show SFDX commands](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-core/images/sfdx_commands.png)

--- a/packages/salesforcedx-vscode-lightning/README.md
+++ b/packages/salesforcedx-vscode-lightning/README.md
@@ -3,6 +3,9 @@ This extension uses the default HTML language server from VS Code to provide syn
 
 For best results, use this extension with the other extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) bundle.  
 
+##  Prerequisites
+Before you set up this extension, make sure that you have [Visual Studio Code](https://code.visualstudio.com/download) v1.17 or later.  
+
 ## Features Provided by This Extension
 * Syntax highlighting in some sections of various files (`.page`, `.component`, `.app`, and so on)
    * HTML portions

--- a/packages/salesforcedx-vscode-visualforce/README.md
+++ b/packages/salesforcedx-vscode-visualforce/README.md
@@ -3,6 +3,9 @@ This extension uses the Visualforce Language Server and VS Code’s default HTML
 
 For best results, use this extension with the other extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) bundle.  
 
+##  Prerequisites
+Before you set up this extension, make sure that you have [Visual Studio Code](https://code.visualstudio.com/download) v1.17 or later.  
+
 ## Features Provided by This Extension
 * Code completion (invoke using Ctrl+Space)
    * Standard Visualforce components (tags and attributes), with Salesforce documentation

--- a/packages/salesforcedx-vscode/README.md
+++ b/packages/salesforcedx-vscode/README.md
@@ -6,6 +6,17 @@ This extension bundle includes tools for developing on the Salesforce platform u
 
 ![GIF showing Apex code completion, pushing source to a scratch org, and running Apex tests](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode/images/overview.gif)  
 
+###  Prerequisites
+Before you set up Salesforce Extensions for VS Code, make sure that you have these essentials.
+
+* **Salesforce CLI and a Salesforce DX project**  
+  Before you use Salesforce Extensions for VS Code, [set up the Salesforce CLI](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup) and [create a Salesforce DX project](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_workspace_setup.htm).  
+  Open your Salesforce DX project in a directory that contains an `sfdx-project.json` file. Otherwise, some features don’t work.  
+* **Java 8 Platform, Standard Edition Development Kit**  
+  Some features in Salesforce Extensions for VS Code depend upon the Java 8 Platform, Standard Edition Development Kit (JDK).  
+  If you don’t already have the JDK installed, install the latest version of the Java 8 JDK from [Java SE Development Kit 8 Downloads](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).  
+* **[Visual Studio Code](https://code.visualstudio.com/download) v1.17 or later**  
+
 ### Documentation for Included Extensions  
 To use Salesforce Extensions for VS Code, install all the extensions in this extension pack. Each extension has its own documentation.
 * [salesforcedx-vscode-core](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-core)  
@@ -18,14 +29,9 @@ To use Salesforce Extensions for VS Code, install all the extensions in this ext
    This extension supports Lightning component bundles. It uses the HTML language server from VS Code.
 * [salesforcedx-vscode-visualforce](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-visualforce)  
    This extension supports Visualforce pages and components. It uses the HTML language server from VS Code.  
-   
-### Get Started with Salesforce Extensions for VS Code
-Before you use Salesforce Extensions for VS Code, [set up the Salesforce CLI](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup) and [create a Salesforce DX project](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_workspace_setup.htm). 
-
-Open your Salesforce DX project in a directory that contains an `sfdx-project.json` file. Otherwise, some features don’t work. 
 
 For tips and tricks for working with Salesforce Extensions for VS Code, visit our [GitHub wiki](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Tips-and-Tricks).  
-
+   
 ### Report Issues on GitHub
 To report issues with Salesforce Extensions for VS Code, visit us on [GitHub](https://github.com/forcedotcom/salesforcedx-vscode).  
 


### PR DESCRIPTION
### What does this PR do?
* Adds JDK 8 as a prereq for salesforcedx-vscode and salesforcedx-vscode-apex
* Adds VS Code v1.17 as a prerequisite for all extensions except for salesforcedx-vscode-apex-debugger, which it was already listed as a prereq for
* Reorganizes README for salesforcedx-vscode to move prereqs to the beginning, explicitly label the prereqs as such, and move the link to the tips-and-tricks doc into the section about docs

### What issues does this PR fix or reference?
Issue #100, @W-4408180@