### PR TITLE
Update displayName for extension pack

### DIFF
--- a/packages/salesforcedx-vscode/package.json
+++ b/packages/salesforcedx-vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforcedx-vscode",
-  "displayName": "Visual Studio Code Extension Pack for Salesforce DX",
+  "displayName": "Salesforce Extensions for VS Code",
   "description":
     "Collection of extensions for the Salesforce DX development flow",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",


### PR DESCRIPTION
### What does this PR do?
Changes name that displays in VS Code Marketplace to the official name of the extension pack.

### What issues does this PR fix or reference?
@W-4420480@