### PR TITLE
Default timeout if debugger cannot get line breakpoint info in that time

### DIFF
--- a/packages/salesforcedx-apex-debugger/src/constants.ts
+++ b/packages/salesforcedx-apex-debugger/src/constants.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+export const DEFAULT_INITIALIZE_TIMEOUT_MS = 10000;
 export const DEFAULT_STREAMING_TIMEOUT_MS = 14400;
 export const DEFAULT_CONNECTION_TIMEOUT_MS = 20000;
 export const DEFAULT_LOCK_TIMEOUT_MS = 10000;


### PR DESCRIPTION
### What does this PR do?
The debugger adapter asks for line breakpoint info from Apex language server. When the adapter receives the info, it would send an initialized response to vs code so the rest of the debugger launch sequence can proceed. VS Code used to show the debugger controls while launching so if the line breakpoint info takes too long, the user could simply stop the launch. It seems those controls are no longer shown, so if the launch is stuck because of the language server, the user cannot terminate the launch. This change is to use setTimeout to check the status of line breakpoint info after a specified timeout.

### What issues does this PR fix or reference?
@W-4428718@