### PR TITLE
Remove keybinding fetching and use local bindings from test_data

### DIFF
--- a/packages/system-tests/src/main.ts
+++ b/packages/system-tests/src/main.ts
@@ -10,7 +10,6 @@
 
 import * as child_process from 'child_process';
 import * as fs from 'fs';
-import * as https from 'https';
 import * as path from 'path';
 
 const tempFolder = 'test_data';

--- a/packages/system-tests/src/main.ts
+++ b/packages/system-tests/src/main.ts
@@ -62,52 +62,6 @@ process.env.VSCODE_BINARY_PATH =
     ? darwinExecutable
     : process.platform === 'win32' ? windowsExecutable : linuxExecutable;
 
-// KEYBINDINGS
-//////////////
-
-function getKeybindings(location: string): Promise<any> {
-  let os = process.platform.toString();
-  if (os === 'darwin') {
-    os = 'osx';
-  } else if (os === 'win32') {
-    os = 'win';
-  }
-
-  const hostname = 'raw.githubusercontent.com';
-  const keybindingsPath = `/Microsoft/vscode-docs/master/scripts/keybindings/doc.keybindings.${os}.json`;
-
-  console.log(`Fetching keybindings from ${path}...`);
-
-  return new Promise((resolve, reject) => {
-    https
-      .get({ hostname: hostname, path: keybindingsPath }, res => {
-        if (res.statusCode !== 200) {
-          reject(
-            `Failed to obtain key bindings with response code: ${res.statusCode}`
-          );
-        }
-
-        const buffer: Buffer[] = [];
-        res.on('data', chunk => {
-          if (chunk instanceof Buffer) {
-            buffer.push(chunk);
-          } else {
-            buffer.push(new Buffer(chunk));
-          }
-        });
-        res.on('end', () => {
-          fs.writeFile(location, Buffer.concat(buffer), 'utf8', () => {
-            console.log('Keybindings were successfully fetched.');
-            resolve();
-          });
-        });
-      })
-      .on('error', e => {
-        reject(`Failed to obtain key bindings with an error: ${e}`);
-      });
-  });
-}
-
 // SPECTRON MOCHA RUNNER
 ////////////////////////
 
@@ -151,9 +105,7 @@ function runTests(): void {
 ///////
 
 function main() {
-  const promises: Promise<any>[] = [];
-  promises.push(getKeybindings(`${tempFolder}/keybindings.json`));
-  Promise.all(promises).then(() => runTests());
+  runTests();
 }
 
 main();

--- a/packages/system-tests/src/spectron/application.ts
+++ b/packages/system-tests/src/spectron/application.ts
@@ -111,9 +111,23 @@ export class SpectronApplication {
     );
   }
 
+  private getKeybindingPlatform(): string {
+    switch (process.platform) {
+      case 'darwin':
+        return 'osx';
+      case 'win32':
+        return 'win';
+      default:
+        return process.platform;
+    }
+  }
+
   private retrieveKeybindings() {
     fs.readFile(
-      path.join(process.cwd(), `test_data/keybindings.json`),
+      path.join(
+        process.cwd(),
+        `test_data/keybindings.${this.getKeybindingPlatform()}.json`
+      ),
       'utf8',
       (err, data) => {
         if (err) {

--- a/packages/system-tests/test_data/keybindings.linux.json
+++ b/packages/system-tests/test_data/keybindings.linux.json
@@ -1,0 +1,1628 @@
+[
+  {
+    "key": "escape escape",
+    "command": "workbench.action.exitZenMode",
+    "when": "inZenMode"
+  },
+  {
+    "key": "shift+escape",
+    "command": "closeReferenceSearchEditor",
+    "when": "inReferenceSearchEditor && !config.editor.stablePeek"
+  },
+  {
+    "key": "escape",
+    "command": "closeReferenceSearchEditor",
+    "when": "inReferenceSearchEditor && !config.editor.stablePeek"
+  },
+  {
+    "key": "shift+escape",
+    "command": "cancelSelection",
+    "when": "editorHasSelection && editorTextFocus"
+  },
+  {
+    "key": "escape",
+    "command": "cancelSelection",
+    "when": "editorHasSelection && editorTextFocus"
+  },
+  {
+    "key": "ctrl+end",
+    "command": "cursorBottom",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+shift+end",
+    "command": "cursorBottomSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "down",
+    "command": "cursorDown",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+down",
+    "command": "cursorDownSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "end",
+    "command": "cursorEnd",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+end",
+    "command": "cursorEndSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "home",
+    "command": "cursorHome",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+home",
+    "command": "cursorHomeSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "left",
+    "command": "cursorLeft",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+left",
+    "command": "cursorLeftSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "pagedown",
+    "command": "cursorPageDown",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+pagedown",
+    "command": "cursorPageDownSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "pageup",
+    "command": "cursorPageUp",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+pageup",
+    "command": "cursorPageUpSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "right",
+    "command": "cursorRight",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+right",
+    "command": "cursorRightSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+home",
+    "command": "cursorTop",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+shift+home",
+    "command": "cursorTopSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "up",
+    "command": "cursorUp",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+up",
+    "command": "cursorUpSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+backspace",
+    "command": "deleteLeft",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "backspace",
+    "command": "deleteLeft",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "delete",
+    "command": "deleteRight",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  { "key": "ctrl+a", "command": "editor.action.selectAll" },
+  {
+    "key": "ctrl+i",
+    "command": "expandLineSelection",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+tab",
+    "command": "outdent",
+    "when": "editorTextFocus && !editorReadonly && !editorTabMovesFocus"
+  },
+  {
+    "key": "ctrl+shift+z",
+    "command": "redo",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+y",
+    "command": "redo",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+down",
+    "command": "scrollLineDown",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+up",
+    "command": "scrollLineUp",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "alt+pagedown",
+    "command": "scrollPageDown",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "alt+pageup",
+    "command": "scrollPageUp",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "tab",
+    "command": "tab",
+    "when": "editorTextFocus && !editorReadonly && !editorTabMovesFocus"
+  },
+  {
+    "key": "ctrl+z",
+    "command": "undo",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "shift+escape",
+    "command": "removeSecondaryCursors",
+    "when": "editorHasMultipleSelections && editorTextFocus"
+  },
+  {
+    "key": "escape",
+    "command": "removeSecondaryCursors",
+    "when": "editorHasMultipleSelections && editorTextFocus"
+  },
+  {
+    "key": "right",
+    "command": "repl.action.acceptSuggestion",
+    "when": "editorTextFocus && inDebugRepl && suggestWidgetVisible"
+  },
+  {
+    "key": "down",
+    "command": "repl.action.historyNext",
+    "when": "editorTextFocus && inDebugRepl && onLastDebugReplLine"
+  },
+  {
+    "key": "up",
+    "command": "repl.action.historyPrevious",
+    "when": "editorTextFocus && inDebugRepl && onFirsteDebugReplLine"
+  },
+  { "key": "ctrl+f", "command": "actions.find" },
+  {
+    "key": "ctrl+u",
+    "command": "cursorUndo",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+right",
+    "command": "cursorWordEndRight",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+shift+right",
+    "command": "cursorWordEndRightSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+left",
+    "command": "cursorWordStartLeft",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+shift+left",
+    "command": "cursorWordStartLeftSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+backspace",
+    "command": "deleteWordLeft",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+delete",
+    "command": "deleteWordRight",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+k ctrl+c",
+    "command": "editor.action.addCommentLine",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+d",
+    "command": "editor.action.addSelectionToNextFindMatch",
+    "when": "editorFocus"
+  },
+  {
+    "key": "ctrl+shift+a",
+    "command": "editor.action.blockComment",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+f2",
+    "command": "editor.action.changeAll",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+c",
+    "command": "editor.action.clipboardCopyAction",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+x",
+    "command": "editor.action.clipboardCutAction",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+v",
+    "command": "editor.action.clipboardPasteAction",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+/",
+    "command": "editor.action.commentLine",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+shift+alt+down",
+    "command": "editor.action.copyLinesDownAction",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+shift+alt+up",
+    "command": "editor.action.copyLinesUpAction",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+k ctrl+k",
+    "command": "editor.action.defineKeybinding",
+    "when": "editorTextFocus && !editorReadonly && editorLangId == 'json'"
+  },
+  {
+    "key": "ctrl+shift+k",
+    "command": "editor.action.deleteLines",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "f7",
+    "command": "editor.action.diffReview.next",
+    "when": "isInDiffEditor"
+  },
+  {
+    "key": "shift+f7",
+    "command": "editor.action.diffReview.prev",
+    "when": "isInDiffEditor"
+  },
+  {
+    "key": "ctrl+f",
+    "command": "editor.action.extensioneditor.hidefind",
+    "when": "extensionEditorWebviewFocus"
+  },
+  {
+    "key": "alt+down",
+    "command": "editor.action.extensioneditor.showNextFindTerm",
+    "when": "extensionEditorFindWidgetInputFocused"
+  },
+  {
+    "key": "alt+up",
+    "command": "editor.action.extensioneditor.showPreviousFindTerm",
+    "when": "extensionEditorFindWidgetInputFocused"
+  },
+  {
+    "key": "ctrl+f",
+    "command": "editor.action.extensioneditor.showfind",
+    "when": "extensionEditorWebviewFocus"
+  },
+  {
+    "key": "ctrl+shift+i",
+    "command": "editor.action.formatDocument",
+    "when":
+      "editorHasDocumentFormattingProvider && editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+k ctrl+f",
+    "command": "editor.action.formatSelection",
+    "when":
+      "editorHasDocumentSelectionFormattingProvider && editorHasSelection && editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "f12",
+    "command": "editor.action.goToDeclaration",
+    "when":
+      "editorHasDefinitionProvider && editorTextFocus && !isInEmbeddedEditor"
+  },
+  {
+    "key": "ctrl+f12",
+    "command": "editor.action.goToImplementation",
+    "when":
+      "editorHasImplementationProvider && editorTextFocus && !isInEmbeddedEditor"
+  },
+  {
+    "key": "ctrl+shift+.",
+    "command": "editor.action.inPlaceReplace.down",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+shift+[IntlBackslash]",
+    "command": "editor.action.inPlaceReplace.down",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+shift+,",
+    "command": "editor.action.inPlaceReplace.up",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+[IntlBackslash]",
+    "command": "editor.action.inPlaceReplace.up",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+]",
+    "command": "editor.action.indentLines",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+shift+up",
+    "command": "editor.action.insertCursorAbove",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+alt+up",
+    "command": "editor.action.insertCursorAbove",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+alt+i",
+    "command": "editor.action.insertCursorAtEndOfEachLineSelected",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+shift+down",
+    "command": "editor.action.insertCursorBelow",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+alt+down",
+    "command": "editor.action.insertCursorBelow",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+enter",
+    "command": "editor.action.insertLineAfter",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+shift+enter",
+    "command": "editor.action.insertLineBefore",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+shift+\\",
+    "command": "editor.action.jumpToBracket",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "f8",
+    "command": "editor.action.marker.next",
+    "when": "editorFocus && !editorReadonly"
+  },
+  {
+    "key": "shift+f8",
+    "command": "editor.action.marker.prev",
+    "when": "editorFocus && !editorReadonly"
+  },
+  {
+    "key": "alt+down",
+    "command": "editor.action.moveLinesDownAction",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "alt+up",
+    "command": "editor.action.moveLinesUpAction",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+k ctrl+d",
+    "command": "editor.action.moveSelectionToNextFindMatch",
+    "when": "editorFocus"
+  },
+  {
+    "key": "f3",
+    "command": "editor.action.nextMatchFindAction",
+    "when": "editorFocus"
+  },
+  {
+    "key": "ctrl+f3",
+    "command": "editor.action.nextSelectionMatchFindAction",
+    "when": "editorFocus"
+  },
+  {
+    "key": "ctrl+k f12",
+    "command": "editor.action.openDeclarationToTheSide",
+    "when":
+      "editorHasDefinitionProvider && editorTextFocus && !isInEmbeddedEditor"
+  },
+  {
+    "key": "ctrl+[",
+    "command": "editor.action.outdentLines",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+shift+f12",
+    "command": "editor.action.peekImplementation",
+    "when":
+      "editorHasImplementationProvider && editorTextFocus && !isInEmbeddedEditor"
+  },
+  {
+    "key": "ctrl+shift+f10",
+    "command": "editor.action.previewDeclaration",
+    "when":
+      "editorHasDefinitionProvider && editorTextFocus && !inReferenceSearchEditor && !isInEmbeddedEditor"
+  },
+  {
+    "key": "shift+f3",
+    "command": "editor.action.previousMatchFindAction",
+    "when": "editorFocus"
+  },
+  {
+    "key": "ctrl+shift+f3",
+    "command": "editor.action.previousSelectionMatchFindAction",
+    "when": "editorFocus"
+  },
+  {
+    "key": "ctrl+.",
+    "command": "editor.action.quickFix",
+    "when": "editorHasCodeActionsProvider && editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "shift+f12",
+    "command": "editor.action.referenceSearch.trigger",
+    "when":
+      "editorHasReferenceProvider && editorTextFocus && !inReferenceSearchEditor && !isInEmbeddedEditor"
+  },
+  {
+    "key": "ctrl+k ctrl+u",
+    "command": "editor.action.removeCommentLine",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "f2",
+    "command": "editor.action.rename",
+    "when": "editorHasRenameProvider && editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+shift+l",
+    "command": "editor.action.selectHighlights",
+    "when": "editorFocus"
+  },
+  {
+    "key": "alt+f1",
+    "command": "editor.action.showAccessibilityHelp",
+    "when": "editorFocus"
+  },
+  {
+    "key": "shift+f10",
+    "command": "editor.action.showContextMenu",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+i",
+    "command": "editor.action.showHover",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+alt+right",
+    "command": "editor.action.smartSelect.grow",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+alt+left",
+    "command": "editor.action.smartSelect.shrink",
+    "when": "editorTextFocus"
+  },
+  { "key": "ctrl+h", "command": "editor.action.startFindReplaceAction" },
+  { "key": "ctrl+m", "command": "editor.action.toggleTabFocusMode" },
+  { "key": "alt+z", "command": "editor.action.toggleWordWrap" },
+  {
+    "key": "ctrl+shift+space",
+    "command": "editor.action.triggerParameterHints",
+    "when": "editorHasSignatureHelpProvider && editorTextFocus"
+  },
+  {
+    "key": "ctrl+space",
+    "command": "editor.action.triggerSuggest",
+    "when":
+      "editorHasCompletionItemProvider && editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+k ctrl+x",
+    "command": "editor.action.trimTrailingWhitespace",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "escape",
+    "command": "editor.action.webvieweditor.hideFind",
+    "when": "webviewEditorFocus && webviewFindWidgetVisible"
+  },
+  {
+    "key": "ctrl+f",
+    "command": "editor.action.webvieweditor.showFind",
+    "when": "webviewEditorFocus"
+  },
+  {
+    "key": "alt+down",
+    "command": "editor.action.webvieweditor.showNextFindTerm",
+    "when": "webviewEditorFindWidgetInputFocused"
+  },
+  {
+    "key": "alt+up",
+    "command": "editor.action.webvieweditor.showPreviousFindTerm",
+    "when": "webviewEditorFindWidgetInputFocused"
+  },
+  {
+    "key": "ctrl+k ctrl+i",
+    "command": "editor.debug.action.showDebugHover",
+    "when": "editorTextFocus && inDebugMode"
+  },
+  {
+    "key": "f9",
+    "command": "editor.debug.action.toggleBreakpoint",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+f9",
+    "command": "editor.debug.action.toggleColumnBreakpoint",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "tab",
+    "command": "editor.emmet.action.expandAbbreviation",
+    "when":
+      "config.emmet.triggerExpansionOnTab && editorTextFocus && !editorReadonly && !editorTabMovesFocus"
+  },
+  {
+    "key": "ctrl+shift+[",
+    "command": "editor.fold",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+0",
+    "command": "editor.foldAll",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+1",
+    "command": "editor.foldLevel1",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+2",
+    "command": "editor.foldLevel2",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+3",
+    "command": "editor.foldLevel3",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+4",
+    "command": "editor.foldLevel4",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+5",
+    "command": "editor.foldLevel5",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+6",
+    "command": "editor.foldLevel6",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+7",
+    "command": "editor.foldLevel7",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+8",
+    "command": "editor.foldLevel8",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+9",
+    "command": "editor.foldLevel9",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+[",
+    "command": "editor.foldRecursively",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+shift+]",
+    "command": "editor.unfold",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+j",
+    "command": "editor.unfoldAll",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+]",
+    "command": "editor.unfoldRecursively",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "tab",
+    "command": "insertSnippet",
+    "when":
+      "config.editor.tabCompletion && editorTextFocus && hasSnippetCompletions && !editorTabMovesFocus && !inSnippetMode"
+  },
+  {
+    "key": "enter",
+    "command": "repl.action.acceptInput",
+    "when": "editorTextFocus && inDebugRepl"
+  },
+  {
+    "key": "escape",
+    "command": "settings.action.clearSearchResults",
+    "when": "inSettingsSearch"
+  },
+  {
+    "key": "enter",
+    "command": "settings.action.focusNextSetting",
+    "when": "inSettingsSearch"
+  },
+  {
+    "key": "shift+enter",
+    "command": "settings.action.focusPreviousSetting",
+    "when": "inSettingsSearch"
+  },
+  {
+    "key": "down",
+    "command": "settings.action.focusSettingsFile",
+    "when": "inSettingsSearch"
+  },
+  {
+    "key": "ctrl+f",
+    "command": "settings.action.search",
+    "when": "inSettingsEditor"
+  },
+  {
+    "key": "shift+escape",
+    "command": "closeFindWidget",
+    "when": "editorFocus && findWidgetVisible"
+  },
+  {
+    "key": "escape",
+    "command": "closeFindWidget",
+    "when": "editorFocus && findWidgetVisible"
+  },
+  {
+    "key": "ctrl+alt+enter",
+    "command": "editor.action.replaceAll",
+    "when": "editorFocus && findWidgetVisible"
+  },
+  {
+    "key": "ctrl+shift+1",
+    "command": "editor.action.replaceOne",
+    "when": "editorFocus && findWidgetVisible"
+  },
+  {
+    "key": "alt+enter",
+    "command": "editor.action.selectAllMatches",
+    "when": "editorFocus && findWidgetVisible"
+  },
+  {
+    "key": "alt+down",
+    "command": "find.history.showNext",
+    "when": "editorFocus && findInputFocussed && findWidgetVisible"
+  },
+  {
+    "key": "alt+up",
+    "command": "find.history.showPrevious",
+    "when": "editorFocus && findInputFocussed && findWidgetVisible"
+  },
+  {
+    "key": "alt+c",
+    "command": "toggleFindCaseSensitive",
+    "when": "editorFocus"
+  },
+  {
+    "key": "alt+l",
+    "command": "toggleFindInSelection",
+    "when": "editorFocus"
+  },
+  {
+    "key": "alt+r",
+    "command": "toggleFindRegex",
+    "when": "editorFocus"
+  },
+  {
+    "key": "alt+w",
+    "command": "toggleFindWholeWord",
+    "when": "editorFocus"
+  },
+  {
+    "key": "shift+escape",
+    "command": "closeBreakpointWidget",
+    "when": "breakpointWidgetVisible && editorFocus"
+  },
+  {
+    "key": "escape",
+    "command": "closeBreakpointWidget",
+    "when": "breakpointWidgetVisible && editorFocus"
+  },
+  {
+    "key": "tab",
+    "command": "jumpToNextSnippetPlaceholder",
+    "when": "editorTextFocus && hasNextTabstop && inSnippetMode"
+  },
+  {
+    "key": "shift+tab",
+    "command": "jumpToPrevSnippetPlaceholder",
+    "when": "editorTextFocus && hasPrevTabstop && inSnippetMode"
+  },
+  {
+    "key": "escape",
+    "command": "leaveEditorMessage",
+    "when": "messageVisible"
+  },
+  {
+    "key": "shift+escape",
+    "command": "leaveSnippet",
+    "when": "editorTextFocus && inSnippetMode"
+  },
+  {
+    "key": "escape",
+    "command": "leaveSnippet",
+    "when": "editorTextFocus && inSnippetMode"
+  },
+  {
+    "key": "shift+escape",
+    "command": "closeMarkersNavigation",
+    "when": "editorFocus && markersNavigationVisible"
+  },
+  {
+    "key": "escape",
+    "command": "closeMarkersNavigation",
+    "when": "editorFocus && markersNavigationVisible"
+  },
+  {
+    "key": "shift+escape",
+    "command": "closeReferenceSearch",
+    "when": "referenceSearchVisible && !config.editor.stablePeek"
+  },
+  {
+    "key": "escape",
+    "command": "closeReferenceSearch",
+    "when": "referenceSearchVisible && !config.editor.stablePeek"
+  },
+  {
+    "key": "shift+escape",
+    "command": "closeParameterHints",
+    "when": "editorTextFocus && parameterHintsVisible"
+  },
+  {
+    "key": "escape",
+    "command": "closeParameterHints",
+    "when": "editorTextFocus && parameterHintsVisible"
+  },
+  {
+    "key": "alt+down",
+    "command": "showNextParameterHint",
+    "when":
+      "editorTextFocus && parameterHintsMultipleSignatures && parameterHintsVisible"
+  },
+  {
+    "key": "down",
+    "command": "showNextParameterHint",
+    "when":
+      "editorTextFocus && parameterHintsMultipleSignatures && parameterHintsVisible"
+  },
+  {
+    "key": "alt+up",
+    "command": "showPrevParameterHint",
+    "when":
+      "editorTextFocus && parameterHintsMultipleSignatures && parameterHintsVisible"
+  },
+  {
+    "key": "up",
+    "command": "showPrevParameterHint",
+    "when":
+      "editorTextFocus && parameterHintsMultipleSignatures && parameterHintsVisible"
+  },
+  {
+    "key": "tab",
+    "command": "acceptSelectedSuggestion",
+    "when": "editorTextFocus && suggestWidgetVisible"
+  },
+  {
+    "key": "enter",
+    "command": "acceptSelectedSuggestionOnEnter",
+    "when":
+      "acceptSuggestionOnEnter && editorTextFocus && suggestWidgetVisible && suggestionMakesTextEdit"
+  },
+  {
+    "key": "shift+escape",
+    "command": "hideSuggestWidget",
+    "when": "editorTextFocus && suggestWidgetVisible"
+  },
+  {
+    "key": "escape",
+    "command": "hideSuggestWidget",
+    "when": "editorTextFocus && suggestWidgetVisible"
+  },
+  {
+    "key": "ctrl+pagedown",
+    "command": "selectNextPageSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "pagedown",
+    "command": "selectNextPageSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "ctrl+down",
+    "command": "selectNextSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "down",
+    "command": "selectNextSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "ctrl+pageup",
+    "command": "selectPrevPageSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "pageup",
+    "command": "selectPrevPageSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "ctrl+up",
+    "command": "selectPrevSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "up",
+    "command": "selectPrevSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "ctrl+space",
+    "command": "toggleSuggestionDetails",
+    "when": "editorTextFocus && suggestWidgetVisible"
+  },
+  {
+    "key": "ctrl+alt+space",
+    "command": "toggleSuggestionFocus",
+    "when": "editorTextFocus && suggestWidgetVisible"
+  },
+  {
+    "key": "enter",
+    "command": "acceptRenameInput",
+    "when": "editorFocus && renameInputVisible"
+  },
+  {
+    "key": "shift+escape",
+    "command": "cancelRenameInput",
+    "when": "editorFocus && renameInputVisible"
+  },
+  {
+    "key": "escape",
+    "command": "cancelRenameInput",
+    "when": "editorFocus && renameInputVisible"
+  },
+  {
+    "key": "shift+escape",
+    "command": "closeAccessibilityHelp",
+    "when": "accessibilityHelpWidgetVisible && editorFocus"
+  },
+  {
+    "key": "escape",
+    "command": "closeAccessibilityHelp",
+    "when": "accessibilityHelpWidgetVisible && editorFocus"
+  },
+  {
+    "key": "escape",
+    "command": "closeReplaceInFilesWidget",
+    "when": "replaceInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "delete",
+    "command": "debug.removeBreakpoint",
+    "when": "breakpointsFocused"
+  },
+  {
+    "key": "delete",
+    "command": "debug.removeWatchExpression",
+    "when": "watchExpressionsFocused"
+  },
+  {
+    "key": "escape",
+    "command": "keybindings.editor.clearSearchResults",
+    "when": "inKeybindings && inKeybindingsSearch"
+  },
+  {
+    "key": "ctrl+c",
+    "command": "keybindings.editor.copyKeybindingEntry",
+    "when": "inKeybindings && keybindingFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+k",
+    "command": "keybindings.editor.defineKeybinding",
+    "when": "inKeybindings && keybindingFocus"
+  },
+  {
+    "key": "down",
+    "command": "keybindings.editor.focusKeybindings",
+    "when": "inKeybindings && inKeybindingsSearch"
+  },
+  {
+    "key": "delete",
+    "command": "keybindings.editor.removeKeybinding",
+    "when": "inKeybindings && keybindingFocus"
+  },
+  {
+    "key": "ctrl+f",
+    "command": "keybindings.editor.searchKeybindings",
+    "when": "inKeybindings && keybindingFocus"
+  },
+  {
+    "key": "escape",
+    "command": "list.clear",
+    "when": "listFocus"
+  },
+  {
+    "key": "left",
+    "command": "list.collapse",
+    "when": "listFocus"
+  },
+  {
+    "key": "right",
+    "command": "list.expand",
+    "when": "listFocus"
+  },
+  {
+    "key": "down",
+    "command": "list.focusDown",
+    "when": "listFocus"
+  },
+  {
+    "key": "home",
+    "command": "list.focusFirst",
+    "when": "listFocus"
+  },
+  {
+    "key": "end",
+    "command": "list.focusLast",
+    "when": "listFocus"
+  },
+  {
+    "key": "pagedown",
+    "command": "list.focusPageDown",
+    "when": "listFocus"
+  },
+  {
+    "key": "pageup",
+    "command": "list.focusPageUp",
+    "when": "listFocus"
+  },
+  {
+    "key": "up",
+    "command": "list.focusUp",
+    "when": "listFocus"
+  },
+  {
+    "key": "ctrl+enter",
+    "command": "list.select",
+    "when": "listFocus"
+  },
+  {
+    "key": "enter",
+    "command": "list.select",
+    "when": "listFocus"
+  },
+  {
+    "key": "space",
+    "command": "list.toggleExpand",
+    "when": "listFocus"
+  },
+  {
+    "key": "ctrl+enter",
+    "command": "problems.action.openToSide",
+    "when": "problemFocus"
+  },
+  {
+    "key": "escape",
+    "command": "search.action.cancel",
+    "when": "listFocus && searchViewletVisible"
+  },
+  {
+    "key": "ctrl+shift+f",
+    "command": "search.action.focusActiveEditor",
+    "when": "searchInputBoxFocus && searchViewletVisible"
+  },
+  { "key": "f4", "command": "search.action.focusNextSearchResult" },
+  { "key": "shift+f4", "command": "search.action.focusPreviousSearchResult" },
+  {
+    "key": "up",
+    "command": "search.action.focusSearchFromResults",
+    "when": "firstMatchFocus && searchViewletVisible"
+  },
+  {
+    "key": "ctrl+enter",
+    "command": "search.action.openResultToSide",
+    "when": "fileMatchOrMatchFocus && searchViewletVisible"
+  },
+  {
+    "key": "delete",
+    "command": "search.action.remove",
+    "when": "fileMatchOrMatchFocus && searchViewletVisible"
+  },
+  {
+    "key": "ctrl+shift+1",
+    "command": "search.action.replace",
+    "when": "matchFocus && replaceActive && searchViewletVisible"
+  },
+  {
+    "key": "ctrl+alt+enter",
+    "command": "search.action.replaceAll",
+    "when": "replaceActive && searchViewletVisible && !findWidgetVisible"
+  },
+  {
+    "key": "ctrl+shift+enter",
+    "command": "search.action.replaceAllInFile",
+    "when": "fileMatchFocus && replaceActive && searchViewletVisible"
+  },
+  {
+    "key": "down",
+    "command": "search.focus.nextInputBox",
+    "when": "inputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "up",
+    "command": "search.focus.previousInputBox",
+    "when": "inputBoxFocus && searchViewletVisible && !searchInputBoxFocus"
+  },
+  {
+    "key": "alt+down",
+    "command": "search.history.showNext",
+    "when": "searchInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "alt+down",
+    "command": "search.history.showNextExcludePattern",
+    "when": "patternExcludesInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "alt+down",
+    "command": "search.history.showNextIncludePattern",
+    "when": "patternIncludesInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "alt+up",
+    "command": "search.history.showPrevious",
+    "when": "searchInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "alt+up",
+    "command": "search.history.showPreviousExcludePattern",
+    "when": "patternExcludesInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "alt+up",
+    "command": "search.history.showPreviousIncludePattern",
+    "when": "patternIncludesInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "alt+c",
+    "command": "toggleSearchCaseSensitive",
+    "when": "searchInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "alt+r",
+    "command": "toggleSearchRegex",
+    "when": "searchInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "alt+w",
+    "command": "toggleSearchWholeWord",
+    "when": "searchInputBoxFocus && searchViewletVisible"
+  },
+  { "key": "ctrl+w", "command": "workbench.action.closeActiveEditor" },
+  { "key": "ctrl+k ctrl+w", "command": "workbench.action.closeAllEditors" },
+  { "key": "ctrl+k w", "command": "workbench.action.closeEditorsInGroup" },
+  { "key": "ctrl+k f", "command": "workbench.action.closeFolder" },
+  {
+    "key": "shift+escape",
+    "command": "workbench.action.closeMessages",
+    "when": "globalMessageVisible"
+  },
+  {
+    "key": "escape",
+    "command": "workbench.action.closeMessages",
+    "when": "globalMessageVisible"
+  },
+  {
+    "key": "shift+escape",
+    "command": "workbench.action.closeQuickOpen",
+    "when": "inQuickOpen"
+  },
+  {
+    "key": "escape",
+    "command": "workbench.action.closeQuickOpen",
+    "when": "inQuickOpen"
+  },
+  { "key": "ctrl+k u", "command": "workbench.action.closeUnmodifiedEditors" },
+  { "key": "ctrl+shift+w", "command": "workbench.action.closeWindow" },
+  {
+    "key": "ctrl+w",
+    "command": "workbench.action.closeWindow",
+    "when": "!editorIsOpen"
+  },
+  {
+    "key": "f5",
+    "command": "workbench.action.debug.continue",
+    "when": "inDebugMode"
+  },
+  {
+    "key": "f6",
+    "command": "workbench.action.debug.pause",
+    "when": "inDebugMode"
+  },
+  {
+    "key": "ctrl+shift+f5",
+    "command": "workbench.action.debug.restart",
+    "when": "inDebugMode"
+  },
+  {
+    "key": "ctrl+f5",
+    "command": "workbench.action.debug.run",
+    "when": "!inDebugMode"
+  },
+  {
+    "key": "f5",
+    "command": "workbench.action.debug.start",
+    "when": "!inDebugMode"
+  },
+  {
+    "key": "shift+f11",
+    "command": "workbench.action.debug.stepOut",
+    "when": "inDebugMode"
+  },
+  {
+    "key": "f10",
+    "command": "workbench.action.debug.stepOver",
+    "when": "inDebugMode"
+  },
+  {
+    "key": "shift+f5",
+    "command": "workbench.action.debug.stop",
+    "when": "inDebugMode"
+  },
+  {
+    "key": "ctrl+k m",
+    "command": "workbench.action.editor.changeLanguageMode"
+  },
+  {
+    "key": "ctrl+k p",
+    "command": "workbench.action.files.copyPathOfActiveFile"
+  },
+  { "key": "ctrl+n", "command": "workbench.action.files.newUntitledFile" },
+  { "key": "ctrl+o", "command": "workbench.action.files.openFile" },
+  { "key": "ctrl+k ctrl+o", "command": "workbench.action.files.openFolder" },
+  {
+    "key": "ctrl+k r",
+    "command": "workbench.action.files.revealActiveFileInWindows"
+  },
+  { "key": "ctrl+s", "command": "workbench.action.files.save" },
+  { "key": "ctrl+shift+s", "command": "workbench.action.files.saveAs" },
+  {
+    "key": "ctrl+k o",
+    "command": "workbench.action.files.showOpenedFileInNewWindow"
+  },
+  {
+    "key": "ctrl+shift+f",
+    "command": "workbench.action.findInFiles",
+    "when": "!searchInputBoxFocus"
+  },
+  { "key": "ctrl+1", "command": "workbench.action.focusFirstEditorGroup" },
+  { "key": "ctrl+k ctrl+right", "command": "workbench.action.focusNextGroup" },
+  {
+    "key": "ctrl+k ctrl+left",
+    "command": "workbench.action.focusPreviousGroup"
+  },
+  { "key": "ctrl+2", "command": "workbench.action.focusSecondEditorGroup" },
+  { "key": "ctrl+0", "command": "workbench.action.focusSideBar" },
+  { "key": "ctrl+3", "command": "workbench.action.focusThirdEditorGroup" },
+  { "key": "ctrl+g", "command": "workbench.action.gotoLine" },
+  { "key": "ctrl+shift+o", "command": "workbench.action.gotoSymbol" },
+  {
+    "key": "escape",
+    "command": "workbench.action.hideInterfaceOverview",
+    "when": "interfaceOverviewVisible"
+  },
+  {
+    "key": "down",
+    "command": "workbench.action.interactivePlayground.arrowDown",
+    "when": "interactivePlaygroundFocus && !editorTextFocus"
+  },
+  {
+    "key": "up",
+    "command": "workbench.action.interactivePlayground.arrowUp",
+    "when": "interactivePlaygroundFocus && !editorTextFocus"
+  },
+  {
+    "key": "ctrl+c",
+    "command": "problems.action.copy",
+    "when": "problemFocus"
+  },
+  {
+    "key": "pagedown",
+    "command": "workbench.action.interactivePlayground.pageDown",
+    "when": "interactivePlaygroundFocus && !editorTextFocus"
+  },
+  {
+    "key": "pageup",
+    "command": "workbench.action.interactivePlayground.pageUp",
+    "when": "interactivePlaygroundFocus && !editorTextFocus"
+  },
+  { "key": "ctrl+k enter", "command": "workbench.action.keepEditor" },
+  {
+    "key": "ctrl+k ctrl+r",
+    "command": "workbench.action.keybindingsReference"
+  },
+  {
+    "key": "ctrl+k left",
+    "command": "workbench.action.moveActiveEditorGroupLeft"
+  },
+  {
+    "key": "ctrl+k right",
+    "command": "workbench.action.moveActiveEditorGroupRight"
+  },
+  {
+    "key": "ctrl+shift+pageup",
+    "command": "workbench.action.moveEditorLeftInGroup"
+  },
+  {
+    "key": "ctrl+shift+pagedown",
+    "command": "workbench.action.moveEditorRightInGroup"
+  },
+  {
+    "key": "ctrl+alt+right",
+    "command": "workbench.action.moveEditorToNextGroup"
+  },
+  {
+    "key": "ctrl+alt+left",
+    "command": "workbench.action.moveEditorToPreviousGroup"
+  },
+  { "key": "ctrl+alt+-", "command": "workbench.action.navigateBack" },
+  { "key": "ctrl+shift+-", "command": "workbench.action.navigateForward" },
+  { "key": "ctrl+shift+n", "command": "workbench.action.newWindow" },
+  { "key": "ctrl+pagedown", "command": "workbench.action.nextEditor" },
+  { "key": "alt+1", "command": "workbench.action.openEditorAtIndex1" },
+  { "key": "alt+2", "command": "workbench.action.openEditorAtIndex2" },
+  { "key": "alt+3", "command": "workbench.action.openEditorAtIndex3" },
+  { "key": "alt+4", "command": "workbench.action.openEditorAtIndex4" },
+  { "key": "alt+5", "command": "workbench.action.openEditorAtIndex5" },
+  { "key": "alt+6", "command": "workbench.action.openEditorAtIndex6" },
+  { "key": "alt+7", "command": "workbench.action.openEditorAtIndex7" },
+  { "key": "alt+8", "command": "workbench.action.openEditorAtIndex8" },
+  { "key": "alt+9", "command": "workbench.action.openEditorAtIndex9" },
+  {
+    "key": "ctrl+k ctrl+s",
+    "command": "workbench.action.openGlobalKeybindings"
+  },
+  { "key": "ctrl+,", "command": "workbench.action.openGlobalSettings" },
+  { "key": "alt+0", "command": "workbench.action.openLastEditorInGroup" },
+  {
+    "key": "ctrl+tab",
+    "command": "workbench.action.openNextRecentlyUsedEditorInGroup"
+  },
+  {
+    "key": "ctrl+shift+tab",
+    "command": "workbench.action.openPreviousRecentlyUsedEditorInGroup"
+  },
+  { "key": "ctrl+r", "command": "workbench.action.openRecent" },
+  { "key": "ctrl+k ctrl+h", "command": "workbench.action.output.toggleOutput" },
+  { "key": "ctrl+pageup", "command": "workbench.action.previousEditor" },
+  { "key": "ctrl+e", "command": "workbench.action.quickOpen" },
+  { "key": "ctrl+p", "command": "workbench.action.quickOpen" },
+  { "key": "ctrl+q", "command": "workbench.action.quit" },
+  { "key": "ctrl+shift+t", "command": "workbench.action.reopenClosedEditor" },
+  { "key": "ctrl+shift+h", "command": "workbench.action.replaceInFiles" },
+  {
+    "key": "ctrl+shift+j",
+    "command": "workbench.action.search.toggleQueryDetails",
+    "when": "searchViewletVisible"
+  },
+  { "key": "ctrl+k ctrl+t", "command": "workbench.action.selectTheme" },
+  { "key": "ctrl+k ctrl+p", "command": "workbench.action.showAllEditors" },
+  { "key": "ctrl+t", "command": "workbench.action.showAllSymbols" },
+  { "key": "f1", "command": "workbench.action.showCommands" },
+  { "key": "ctrl+shift+p", "command": "workbench.action.showCommands" },
+  { "key": "ctrl+\\", "command": "workbench.action.splitEditor" },
+  { "key": "ctrl+shift+b", "command": "workbench.action.tasks.build" },
+  {
+    "key": "ctrl+shift+c",
+    "command": "workbench.action.terminal.copySelection",
+    "when": "terminalFocus && terminalTextSelected"
+  },
+  {
+    "key": "ctrl+backspace",
+    "command": "workbench.action.terminal.deleteWordLeft",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "ctrl+delete",
+    "command": "workbench.action.terminal.deleteWordRight",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "alt+down",
+    "command": "workbench.action.terminal.findWidget.history.showNext",
+    "when": "terminalFindWidgetInputFocused && terminalFindWidgetVisible"
+  },
+  {
+    "key": "alt+up",
+    "command": "workbench.action.terminal.findWidget.history.showPrevious",
+    "when": "terminalFindWidgetInputFocused && terminalFindWidgetVisible"
+  },
+  {
+    "key": "ctrl+f",
+    "command": "workbench.action.terminal.focusFindWidget",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "shift+escape",
+    "command": "workbench.action.terminal.hideFindWidget",
+    "when": "terminalFindWidgetVisible && terminalFocus"
+  },
+  {
+    "key": "escape",
+    "command": "workbench.action.terminal.hideFindWidget",
+    "when": "terminalFindWidgetVisible && terminalFocus"
+  },
+  { "key": "ctrl+shift+`", "command": "workbench.action.terminal.new" },
+  {
+    "key": "ctrl+shift+c",
+    "command": "workbench.action.terminal.openNativeConsole",
+    "when": "!terminalFocus"
+  },
+  {
+    "key": "ctrl+shift+v",
+    "command": "workbench.action.terminal.paste",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "ctrl+shift+down",
+    "command": "workbench.action.terminal.scrollDown",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "shift+pagedown",
+    "command": "workbench.action.terminal.scrollDownPage",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "shift+end",
+    "command": "workbench.action.terminal.scrollToBottom",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "shift+home",
+    "command": "workbench.action.terminal.scrollToTop",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "ctrl+shift+up",
+    "command": "workbench.action.terminal.scrollUp",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "shift+pageup",
+    "command": "workbench.action.terminal.scrollUpPage",
+    "when": "terminalFocus"
+  },
+  { "key": "ctrl+`", "command": "workbench.action.terminal.toggleTerminal" },
+  {
+    "key": "shift+alt+1",
+    "command": "workbench.action.toggleEditorGroupLayout"
+  },
+  { "key": "f11", "command": "workbench.action.toggleFullScreen" },
+  { "key": "ctrl+j", "command": "workbench.action.togglePanel" },
+  { "key": "ctrl+b", "command": "workbench.action.toggleSidebarVisibility" },
+  { "key": "ctrl+k z", "command": "workbench.action.toggleZenMode" },
+  { "key": "ctrl+numpad_add", "command": "workbench.action.zoomIn" },
+  { "key": "ctrl+shift+=", "command": "workbench.action.zoomIn" },
+  { "key": "ctrl+=", "command": "workbench.action.zoomIn" },
+  { "key": "ctrl+numpad_subtract", "command": "workbench.action.zoomOut" },
+  { "key": "ctrl+-", "command": "workbench.action.zoomOut" },
+  { "key": "ctrl+numpad0", "command": "workbench.action.zoomReset" },
+  { "key": "ctrl+shift+m", "command": "workbench.actions.view.problems" },
+  { "key": "ctrl+shift+y", "command": "workbench.debug.action.toggleRepl" },
+  {
+    "key": "ctrl+k ctrl+m",
+    "command": "workbench.extensions.action.showRecommendedKeymapExtensions"
+  },
+  { "key": "ctrl+k d", "command": "workbench.files.action.compareWithSaved" },
+  {
+    "key": "ctrl+k e",
+    "command": "workbench.files.action.focusOpenEditorsView"
+  },
+  { "key": "ctrl+shift+d", "command": "workbench.view.debug" },
+  { "key": "ctrl+shift+e", "command": "workbench.view.explorer" },
+  { "key": "ctrl+shift+x", "command": "workbench.view.extensions" },
+  { "key": "ctrl+shift+g", "command": "workbench.view.scm" },
+  {
+    "key": "ctrl+shift+f",
+    "command": "workbench.view.search",
+    "when": "!searchViewletVisible"
+  },
+  {
+    "key": "f11",
+    "command": "workbench.action.debug.stepInto",
+    "when": "inDebugMode"
+  },
+  {
+    "key": "f2",
+    "command": "debug.renameWatchExpression",
+    "when": "watchExpressionsFocused"
+  },
+  {
+    "key": "f2",
+    "command": "debug.setVariable",
+    "when": "variablesFocused"
+  },
+  {
+    "key": "space",
+    "command": "debug.toggleBreakpoint",
+    "when": "breakpointsFocused"
+  },
+  {
+    "key": "ctrl+alt+c",
+    "command": "copyFilePath",
+    "when": "explorerViewletFocus && explorerViewletVisible"
+  },
+  {
+    "key": "shift+delete",
+    "command": "deleteFile",
+    "when": "explorerViewletVisible && filesExplorerFocus"
+  },
+  {
+    "key": "ctrl+enter",
+    "command": "explorer.openToSide",
+    "when": "explorerViewletFocus && explorerViewletVisible"
+  },
+  {
+    "key": "ctrl+c",
+    "command": "filesExplorer.copy",
+    "when": "explorerViewletVisible && filesExplorerFocus"
+  },
+  {
+    "key": "ctrl+v",
+    "command": "filesExplorer.paste",
+    "when": "explorerViewletVisible && filesExplorerFocus"
+  },
+  {
+    "key": "delete",
+    "command": "moveFileToTrash",
+    "when": "explorerViewletVisible && filesExplorerFocus"
+  },
+  {
+    "key": "f2",
+    "command": "renameFile",
+    "when": "explorerViewletVisible && filesExplorerFocus"
+  },
+  {
+    "key": "ctrl+alt+r",
+    "command": "revealFileInOS",
+    "when": "explorerViewletFocus && explorerViewletVisible"
+  },
+  {
+    "key": "ctrl+tab",
+    "command": "workbench.action.quickOpenNavigateNextInEditorPicker",
+    "when": "inEditorsPicker && inQuickOpen"
+  },
+  {
+    "key": "ctrl+e",
+    "command": "workbench.action.quickOpenNavigateNextInFilePicker",
+    "when": "inFilesPicker && inQuickOpen"
+  },
+  {
+    "key": "ctrl+p",
+    "command": "workbench.action.quickOpenNavigateNextInFilePicker",
+    "when": "inFilesPicker && inQuickOpen"
+  },
+  {
+    "key": "ctrl+r",
+    "command": "workbench.action.quickOpenNavigateNextInRecentFilesPicker",
+    "when": "inQuickOpen && inRecentFilesPicker"
+  },
+  {
+    "key": "ctrl+shift+tab",
+    "command": "workbench.action.quickOpenNavigatePreviousInEditorPicker",
+    "when": "inEditorsPicker && inQuickOpen"
+  },
+  {
+    "key": "ctrl+shift+e",
+    "command": "workbench.action.quickOpenNavigatePreviousInFilePicker",
+    "when": "inFilesPicker && inQuickOpen"
+  },
+  {
+    "key": "ctrl+shift+p",
+    "command": "workbench.action.quickOpenNavigatePreviousInFilePicker",
+    "when": "inFilesPicker && inQuickOpen"
+  },
+  {
+    "key": "ctrl+shift+r",
+    "command": "workbench.action.quickOpenNavigatePreviousInRecentFilesPicker",
+    "when": "inQuickOpen && inRecentFilesPicker"
+  },
+  {
+    "key": "ctrl+f4",
+    "command": "extension.node-debug.pickLoadedScript",
+    "when": "debugType == 'node'"
+  },
+  {
+    "key": "ctrl+f4",
+    "command": "extension.node-debug.pickLoadedScript",
+    "when": "debugType == 'node2'"
+  },
+  {
+    "key": "ctrl+shift+v",
+    "command": "markdown.showPreview",
+    "when": "editorLangId == 'markdown'"
+  },
+  {
+    "key": "ctrl+k v",
+    "command": "markdown.showPreviewToSide",
+    "when": "editorLangId == 'markdown'"
+  }
+]

--- a/packages/system-tests/test_data/keybindings.osx.json
+++ b/packages/system-tests/test_data/keybindings.osx.json
@@ -1,0 +1,1793 @@
+[
+  {
+    "key": "escape escape",
+    "command": "workbench.action.exitZenMode",
+    "when": "inZenMode"
+  },
+  {
+    "key": "shift+escape",
+    "command": "closeReferenceSearchEditor",
+    "when": "inReferenceSearchEditor && !config.editor.stablePeek"
+  },
+  {
+    "key": "escape",
+    "command": "closeReferenceSearchEditor",
+    "when": "inReferenceSearchEditor && !config.editor.stablePeek"
+  },
+  {
+    "key": "shift+escape",
+    "command": "cancelSelection",
+    "when": "editorHasSelection && editorTextFocus"
+  },
+  {
+    "key": "escape",
+    "command": "cancelSelection",
+    "when": "editorHasSelection && editorTextFocus"
+  },
+  {
+    "key": "cmd+down",
+    "command": "cursorBottom",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+cmd+down",
+    "command": "cursorBottomSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+alt+cmd+down",
+    "command": "cursorColumnSelectDown",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+alt+cmd+left",
+    "command": "cursorColumnSelectLeft",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+alt+cmd+pagedown",
+    "command": "cursorColumnSelectPageDown",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+alt+cmd+pageup",
+    "command": "cursorColumnSelectPageUp",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+alt+cmd+right",
+    "command": "cursorColumnSelectRight",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+alt+cmd+up",
+    "command": "cursorColumnSelectUp",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+n",
+    "command": "cursorDown",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "down",
+    "command": "cursorDown",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+down",
+    "command": "cursorDownSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "cmd+right",
+    "command": "cursorEnd",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "end",
+    "command": "cursorEnd",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+cmd+right",
+    "command": "cursorEndSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+end",
+    "command": "cursorEndSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "cmd+left",
+    "command": "cursorHome",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "home",
+    "command": "cursorHome",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+cmd+left",
+    "command": "cursorHomeSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+home",
+    "command": "cursorHomeSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+b",
+    "command": "cursorLeft",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "left",
+    "command": "cursorLeft",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+left",
+    "command": "cursorLeftSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+e",
+    "command": "cursorLineEnd",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+a",
+    "command": "cursorLineStart",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "pagedown",
+    "command": "cursorPageDown",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+pagedown",
+    "command": "cursorPageDownSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "pageup",
+    "command": "cursorPageUp",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+pageup",
+    "command": "cursorPageUpSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+f",
+    "command": "cursorRight",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "right",
+    "command": "cursorRight",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+right",
+    "command": "cursorRightSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "cmd+up",
+    "command": "cursorTop",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+cmd+up",
+    "command": "cursorTopSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+p",
+    "command": "cursorUp",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "up",
+    "command": "cursorUp",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+up",
+    "command": "cursorUpSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+backspace",
+    "command": "deleteLeft",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+h",
+    "command": "deleteLeft",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "shift+backspace",
+    "command": "deleteLeft",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "backspace",
+    "command": "deleteLeft",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+delete",
+    "command": "deleteRight",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+d",
+    "command": "deleteRight",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "delete",
+    "command": "deleteRight",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  { "key": "cmd+a", "command": "editor.action.selectAll" },
+  {
+    "key": "cmd+i",
+    "command": "expandLineSelection",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+o",
+    "command": "lineBreakInsert",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "shift+tab",
+    "command": "outdent",
+    "when": "editorTextFocus && !editorReadonly && !editorTabMovesFocus"
+  },
+  {
+    "key": "shift+cmd+z",
+    "command": "redo",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+pagedown",
+    "command": "scrollLineDown",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+pageup",
+    "command": "scrollLineUp",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "cmd+pagedown",
+    "command": "scrollPageDown",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "cmd+pageup",
+    "command": "scrollPageUp",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "tab",
+    "command": "tab",
+    "when": "editorTextFocus && !editorReadonly && !editorTabMovesFocus"
+  },
+  {
+    "key": "cmd+z",
+    "command": "undo",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "shift+escape",
+    "command": "removeSecondaryCursors",
+    "when": "editorHasMultipleSelections && editorTextFocus"
+  },
+  {
+    "key": "escape",
+    "command": "removeSecondaryCursors",
+    "when": "editorHasMultipleSelections && editorTextFocus"
+  },
+  {
+    "key": "right",
+    "command": "repl.action.acceptSuggestion",
+    "when": "editorTextFocus && inDebugRepl && suggestWidgetVisible"
+  },
+  {
+    "key": "down",
+    "command": "repl.action.historyNext",
+    "when": "editorTextFocus && inDebugRepl && onLastDebugReplLine"
+  },
+  {
+    "key": "up",
+    "command": "repl.action.historyPrevious",
+    "when": "editorTextFocus && inDebugRepl && onFirsteDebugReplLine"
+  },
+  { "key": "cmd+e", "command": "actions.find" },
+  { "key": "cmd+f", "command": "actions.find" },
+  {
+    "key": "cmd+u",
+    "command": "cursorUndo",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "alt+right",
+    "command": "cursorWordEndRight",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+alt+right",
+    "command": "cursorWordEndRightSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "alt+left",
+    "command": "cursorWordStartLeft",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+alt+left",
+    "command": "cursorWordStartLeftSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "cmd+backspace",
+    "command": "deleteAllLeft",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "cmd+delete",
+    "command": "deleteAllRight",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+k",
+    "command": "deleteAllRight",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "alt+backspace",
+    "command": "deleteWordLeft",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "alt+delete",
+    "command": "deleteWordRight",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "cmd+k cmd+c",
+    "command": "editor.action.addCommentLine",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "cmd+d",
+    "command": "editor.action.addSelectionToNextFindMatch",
+    "when": "editorFocus"
+  },
+  {
+    "key": "shift+alt+a",
+    "command": "editor.action.blockComment",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "cmd+f2",
+    "command": "editor.action.changeAll",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "cmd+c",
+    "command": "editor.action.clipboardCopyAction",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "cmd+x",
+    "command": "editor.action.clipboardCutAction",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "cmd+v",
+    "command": "editor.action.clipboardPasteAction",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "cmd+/",
+    "command": "editor.action.commentLine",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "shift+alt+down",
+    "command": "editor.action.copyLinesDownAction",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "shift+alt+up",
+    "command": "editor.action.copyLinesUpAction",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "cmd+k cmd+k",
+    "command": "editor.action.defineKeybinding",
+    "when": "editorTextFocus && !editorReadonly && editorLangId == 'json'"
+  },
+  {
+    "key": "shift+cmd+k",
+    "command": "editor.action.deleteLines",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "f7",
+    "command": "editor.action.diffReview.next",
+    "when": "isInDiffEditor"
+  },
+  {
+    "key": "shift+f7",
+    "command": "editor.action.diffReview.prev",
+    "when": "isInDiffEditor"
+  },
+  {
+    "key": "cmd+f",
+    "command": "editor.action.extensioneditor.hidefind",
+    "when": "extensionEditorWebviewFocus"
+  },
+  {
+    "key": "alt+down",
+    "command": "editor.action.extensioneditor.showNextFindTerm",
+    "when": "extensionEditorFindWidgetInputFocused"
+  },
+  {
+    "key": "alt+up",
+    "command": "editor.action.extensioneditor.showPreviousFindTerm",
+    "when": "extensionEditorFindWidgetInputFocused"
+  },
+  {
+    "key": "cmd+f",
+    "command": "editor.action.extensioneditor.showfind",
+    "when": "extensionEditorWebviewFocus"
+  },
+  {
+    "key": "shift+alt+f",
+    "command": "editor.action.formatDocument",
+    "when":
+      "editorHasDocumentFormattingProvider && editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "cmd+k cmd+f",
+    "command": "editor.action.formatSelection",
+    "when":
+      "editorHasDocumentSelectionFormattingProvider && editorHasSelection && editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "f12",
+    "command": "editor.action.goToDeclaration",
+    "when":
+      "editorHasDefinitionProvider && editorTextFocus && !isInEmbeddedEditor"
+  },
+  {
+    "key": "cmd+f12",
+    "command": "editor.action.goToImplementation",
+    "when":
+      "editorHasImplementationProvider && editorTextFocus && !isInEmbeddedEditor"
+  },
+  {
+    "key": "shift+cmd+.",
+    "command": "editor.action.inPlaceReplace.down",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "shift+cmd+,",
+    "command": "editor.action.inPlaceReplace.up",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "cmd+]",
+    "command": "editor.action.indentLines",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "alt+cmd+up",
+    "command": "editor.action.insertCursorAbove",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+alt+i",
+    "command": "editor.action.insertCursorAtEndOfEachLineSelected",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "alt+cmd+down",
+    "command": "editor.action.insertCursorBelow",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "cmd+enter",
+    "command": "editor.action.insertLineAfter",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "shift+cmd+enter",
+    "command": "editor.action.insertLineBefore",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+j",
+    "command": "editor.action.joinLines",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "shift+cmd+\\",
+    "command": "editor.action.jumpToBracket",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "f8",
+    "command": "editor.action.marker.next",
+    "when": "editorFocus && !editorReadonly"
+  },
+  {
+    "key": "shift+f8",
+    "command": "editor.action.marker.prev",
+    "when": "editorFocus && !editorReadonly"
+  },
+  {
+    "key": "alt+down",
+    "command": "editor.action.moveLinesDownAction",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "alt+up",
+    "command": "editor.action.moveLinesUpAction",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "cmd+k cmd+d",
+    "command": "editor.action.moveSelectionToNextFindMatch",
+    "when": "editorFocus"
+  },
+  {
+    "key": "f3",
+    "command": "editor.action.nextMatchFindAction",
+    "when": "editorFocus"
+  },
+  {
+    "key": "cmd+g",
+    "command": "editor.action.nextMatchFindAction",
+    "when": "editorFocus"
+  },
+  {
+    "key": "cmd+f3",
+    "command": "editor.action.nextSelectionMatchFindAction",
+    "when": "editorFocus"
+  },
+  {
+    "key": "cmd+k f12",
+    "command": "editor.action.openDeclarationToTheSide",
+    "when":
+      "editorHasDefinitionProvider && editorTextFocus && !isInEmbeddedEditor"
+  },
+  {
+    "key": "cmd+[",
+    "command": "editor.action.outdentLines",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "shift+cmd+f12",
+    "command": "editor.action.peekImplementation",
+    "when":
+      "editorHasImplementationProvider && editorTextFocus && !isInEmbeddedEditor"
+  },
+  {
+    "key": "alt+f12",
+    "command": "editor.action.previewDeclaration",
+    "when":
+      "editorHasDefinitionProvider && editorTextFocus && !inReferenceSearchEditor && !isInEmbeddedEditor"
+  },
+  {
+    "key": "shift+f3",
+    "command": "editor.action.previousMatchFindAction",
+    "when": "editorFocus"
+  },
+  {
+    "key": "shift+cmd+g",
+    "command": "editor.action.previousMatchFindAction",
+    "when": "editorFocus"
+  },
+  {
+    "key": "shift+cmd+f3",
+    "command": "editor.action.previousSelectionMatchFindAction",
+    "when": "editorFocus"
+  },
+  {
+    "key": "cmd+.",
+    "command": "editor.action.quickFix",
+    "when": "editorHasCodeActionsProvider && editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "shift+f12",
+    "command": "editor.action.referenceSearch.trigger",
+    "when":
+      "editorHasReferenceProvider && editorTextFocus && !inReferenceSearchEditor && !isInEmbeddedEditor"
+  },
+  {
+    "key": "cmd+k cmd+u",
+    "command": "editor.action.removeCommentLine",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "f2",
+    "command": "editor.action.rename",
+    "when": "editorHasRenameProvider && editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "shift+cmd+l",
+    "command": "editor.action.selectHighlights",
+    "when": "editorFocus"
+  },
+  {
+    "key": "alt+f1",
+    "command": "editor.action.showAccessibilityHelp",
+    "when": "editorFocus"
+  },
+  {
+    "key": "shift+f10",
+    "command": "editor.action.showContextMenu",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "cmd+k cmd+i",
+    "command": "editor.action.showHover",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+shift+cmd+right",
+    "command": "editor.action.smartSelect.grow",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+shift+cmd+left",
+    "command": "editor.action.smartSelect.shrink",
+    "when": "editorTextFocus"
+  },
+  { "key": "alt+cmd+f", "command": "editor.action.startFindReplaceAction" },
+  { "key": "ctrl+shift+m", "command": "editor.action.toggleTabFocusMode" },
+  { "key": "alt+z", "command": "editor.action.toggleWordWrap" },
+  {
+    "key": "ctrl+t",
+    "command": "editor.action.transposeLetters",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "shift+cmd+space",
+    "command": "editor.action.triggerParameterHints",
+    "when": "editorHasSignatureHelpProvider && editorTextFocus"
+  },
+  {
+    "key": "ctrl+space",
+    "command": "editor.action.triggerSuggest",
+    "when":
+      "editorHasCompletionItemProvider && editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "cmd+k cmd+x",
+    "command": "editor.action.trimTrailingWhitespace",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "escape",
+    "command": "editor.action.webvieweditor.hideFind",
+    "when": "webviewEditorFocus && webviewFindWidgetVisible"
+  },
+  {
+    "key": "cmd+f",
+    "command": "editor.action.webvieweditor.showFind",
+    "when": "webviewEditorFocus"
+  },
+  {
+    "key": "alt+down",
+    "command": "editor.action.webvieweditor.showNextFindTerm",
+    "when": "webviewEditorFindWidgetInputFocused"
+  },
+  {
+    "key": "alt+up",
+    "command": "editor.action.webvieweditor.showPreviousFindTerm",
+    "when": "webviewEditorFindWidgetInputFocused"
+  },
+  {
+    "key": "cmd+k cmd+i",
+    "command": "editor.debug.action.showDebugHover",
+    "when": "editorTextFocus && inDebugMode"
+  },
+  {
+    "key": "f9",
+    "command": "editor.debug.action.toggleBreakpoint",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+f9",
+    "command": "editor.debug.action.toggleColumnBreakpoint",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "tab",
+    "command": "editor.emmet.action.expandAbbreviation",
+    "when":
+      "config.emmet.triggerExpansionOnTab && editorTextFocus && !editorReadonly && !editorTabMovesFocus"
+  },
+  {
+    "key": "alt+cmd+[",
+    "command": "editor.fold",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "cmd+k cmd+0",
+    "command": "editor.foldAll",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "cmd+k cmd+1",
+    "command": "editor.foldLevel1",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "cmd+k cmd+2",
+    "command": "editor.foldLevel2",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "cmd+k cmd+3",
+    "command": "editor.foldLevel3",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "cmd+k cmd+4",
+    "command": "editor.foldLevel4",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "cmd+k cmd+5",
+    "command": "editor.foldLevel5",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "cmd+k cmd+6",
+    "command": "editor.foldLevel6",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "cmd+k cmd+7",
+    "command": "editor.foldLevel7",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "cmd+k cmd+8",
+    "command": "editor.foldLevel8",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "cmd+k cmd+9",
+    "command": "editor.foldLevel9",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "cmd+k cmd+[",
+    "command": "editor.foldRecursively",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "alt+cmd+]",
+    "command": "editor.unfold",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "cmd+k cmd+j",
+    "command": "editor.unfoldAll",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "cmd+k cmd+]",
+    "command": "editor.unfoldRecursively",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "tab",
+    "command": "insertSnippet",
+    "when":
+      "config.editor.tabCompletion && editorTextFocus && hasSnippetCompletions && !editorTabMovesFocus && !inSnippetMode"
+  },
+  {
+    "key": "enter",
+    "command": "repl.action.acceptInput",
+    "when": "editorTextFocus && inDebugRepl"
+  },
+  {
+    "key": "escape",
+    "command": "settings.action.clearSearchResults",
+    "when": "inSettingsSearch"
+  },
+  {
+    "key": "enter",
+    "command": "settings.action.focusNextSetting",
+    "when": "inSettingsSearch"
+  },
+  {
+    "key": "shift+enter",
+    "command": "settings.action.focusPreviousSetting",
+    "when": "inSettingsSearch"
+  },
+  {
+    "key": "down",
+    "command": "settings.action.focusSettingsFile",
+    "when": "inSettingsSearch"
+  },
+  {
+    "key": "cmd+f",
+    "command": "settings.action.search",
+    "when": "inSettingsEditor"
+  },
+  {
+    "key": "shift+escape",
+    "command": "closeFindWidget",
+    "when": "editorFocus && findWidgetVisible"
+  },
+  {
+    "key": "escape",
+    "command": "closeFindWidget",
+    "when": "editorFocus && findWidgetVisible"
+  },
+  {
+    "key": "alt+cmd+enter",
+    "command": "editor.action.replaceAll",
+    "when": "editorFocus && findWidgetVisible"
+  },
+  {
+    "key": "shift+cmd+1",
+    "command": "editor.action.replaceOne",
+    "when": "editorFocus && findWidgetVisible"
+  },
+  {
+    "key": "alt+enter",
+    "command": "editor.action.selectAllMatches",
+    "when": "editorFocus && findWidgetVisible"
+  },
+  {
+    "key": "alt+down",
+    "command": "find.history.showNext",
+    "when": "editorFocus && findInputFocussed && findWidgetVisible"
+  },
+  {
+    "key": "alt+up",
+    "command": "find.history.showPrevious",
+    "when": "editorFocus && findInputFocussed && findWidgetVisible"
+  },
+  {
+    "key": "alt+cmd+c",
+    "command": "toggleFindCaseSensitive",
+    "when": "editorFocus"
+  },
+  {
+    "key": "alt+cmd+l",
+    "command": "toggleFindInSelection",
+    "when": "editorFocus"
+  },
+  {
+    "key": "alt+cmd+r",
+    "command": "toggleFindRegex",
+    "when": "editorFocus"
+  },
+  {
+    "key": "alt+cmd+w",
+    "command": "toggleFindWholeWord",
+    "when": "editorFocus"
+  },
+  {
+    "key": "shift+escape",
+    "command": "closeBreakpointWidget",
+    "when": "breakpointWidgetVisible && editorFocus"
+  },
+  {
+    "key": "escape",
+    "command": "closeBreakpointWidget",
+    "when": "breakpointWidgetVisible && editorFocus"
+  },
+  {
+    "key": "tab",
+    "command": "jumpToNextSnippetPlaceholder",
+    "when": "editorTextFocus && hasNextTabstop && inSnippetMode"
+  },
+  {
+    "key": "shift+tab",
+    "command": "jumpToPrevSnippetPlaceholder",
+    "when": "editorTextFocus && hasPrevTabstop && inSnippetMode"
+  },
+  {
+    "key": "escape",
+    "command": "leaveEditorMessage",
+    "when": "messageVisible"
+  },
+  {
+    "key": "shift+escape",
+    "command": "leaveSnippet",
+    "when": "editorTextFocus && inSnippetMode"
+  },
+  {
+    "key": "escape",
+    "command": "leaveSnippet",
+    "when": "editorTextFocus && inSnippetMode"
+  },
+  {
+    "key": "shift+escape",
+    "command": "closeMarkersNavigation",
+    "when": "editorFocus && markersNavigationVisible"
+  },
+  {
+    "key": "escape",
+    "command": "closeMarkersNavigation",
+    "when": "editorFocus && markersNavigationVisible"
+  },
+  {
+    "key": "shift+escape",
+    "command": "closeReferenceSearch",
+    "when": "referenceSearchVisible && !config.editor.stablePeek"
+  },
+  {
+    "key": "escape",
+    "command": "closeReferenceSearch",
+    "when": "referenceSearchVisible && !config.editor.stablePeek"
+  },
+  {
+    "key": "shift+escape",
+    "command": "closeParameterHints",
+    "when": "editorTextFocus && parameterHintsVisible"
+  },
+  {
+    "key": "escape",
+    "command": "closeParameterHints",
+    "when": "editorTextFocus && parameterHintsVisible"
+  },
+  {
+    "key": "ctrl+n",
+    "command": "showNextParameterHint",
+    "when":
+      "editorTextFocus && parameterHintsMultipleSignatures && parameterHintsVisible"
+  },
+  {
+    "key": "alt+down",
+    "command": "showNextParameterHint",
+    "when":
+      "editorTextFocus && parameterHintsMultipleSignatures && parameterHintsVisible"
+  },
+  {
+    "key": "down",
+    "command": "showNextParameterHint",
+    "when":
+      "editorTextFocus && parameterHintsMultipleSignatures && parameterHintsVisible"
+  },
+  {
+    "key": "ctrl+p",
+    "command": "showPrevParameterHint",
+    "when":
+      "editorTextFocus && parameterHintsMultipleSignatures && parameterHintsVisible"
+  },
+  {
+    "key": "alt+up",
+    "command": "showPrevParameterHint",
+    "when":
+      "editorTextFocus && parameterHintsMultipleSignatures && parameterHintsVisible"
+  },
+  {
+    "key": "up",
+    "command": "showPrevParameterHint",
+    "when":
+      "editorTextFocus && parameterHintsMultipleSignatures && parameterHintsVisible"
+  },
+  {
+    "key": "tab",
+    "command": "acceptSelectedSuggestion",
+    "when": "editorTextFocus && suggestWidgetVisible"
+  },
+  {
+    "key": "enter",
+    "command": "acceptSelectedSuggestionOnEnter",
+    "when":
+      "acceptSuggestionOnEnter && editorTextFocus && suggestWidgetVisible && suggestionMakesTextEdit"
+  },
+  {
+    "key": "shift+escape",
+    "command": "hideSuggestWidget",
+    "when": "editorTextFocus && suggestWidgetVisible"
+  },
+  {
+    "key": "escape",
+    "command": "hideSuggestWidget",
+    "when": "editorTextFocus && suggestWidgetVisible"
+  },
+  {
+    "key": "cmd+pagedown",
+    "command": "selectNextPageSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "pagedown",
+    "command": "selectNextPageSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "ctrl+n",
+    "command": "selectNextSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "cmd+down",
+    "command": "selectNextSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "down",
+    "command": "selectNextSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "cmd+pageup",
+    "command": "selectPrevPageSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "pageup",
+    "command": "selectPrevPageSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "ctrl+p",
+    "command": "selectPrevSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "cmd+up",
+    "command": "selectPrevSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "up",
+    "command": "selectPrevSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "ctrl+space",
+    "command": "toggleSuggestionDetails",
+    "when": "editorTextFocus && suggestWidgetVisible"
+  },
+  {
+    "key": "ctrl+alt+space",
+    "command": "toggleSuggestionFocus",
+    "when": "editorTextFocus && suggestWidgetVisible"
+  },
+  {
+    "key": "enter",
+    "command": "acceptRenameInput",
+    "when": "editorFocus && renameInputVisible"
+  },
+  {
+    "key": "shift+escape",
+    "command": "cancelRenameInput",
+    "when": "editorFocus && renameInputVisible"
+  },
+  {
+    "key": "escape",
+    "command": "cancelRenameInput",
+    "when": "editorFocus && renameInputVisible"
+  },
+  {
+    "key": "shift+escape",
+    "command": "closeAccessibilityHelp",
+    "when": "accessibilityHelpWidgetVisible && editorFocus"
+  },
+  {
+    "key": "escape",
+    "command": "closeAccessibilityHelp",
+    "when": "accessibilityHelpWidgetVisible && editorFocus"
+  },
+  {
+    "key": "escape",
+    "command": "closeReplaceInFilesWidget",
+    "when": "replaceInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "cmd+backspace",
+    "command": "debug.removeBreakpoint",
+    "when": "breakpointsFocused"
+  },
+  {
+    "key": "cmd+backspace",
+    "command": "debug.removeWatchExpression",
+    "when": "watchExpressionsFocused"
+  },
+  {
+    "key": "escape",
+    "command": "keybindings.editor.clearSearchResults",
+    "when": "inKeybindings && inKeybindingsSearch"
+  },
+  {
+    "key": "cmd+c",
+    "command": "keybindings.editor.copyKeybindingEntry",
+    "when": "inKeybindings && keybindingFocus"
+  },
+  {
+    "key": "cmd+k cmd+k",
+    "command": "keybindings.editor.defineKeybinding",
+    "when": "inKeybindings && keybindingFocus"
+  },
+  {
+    "key": "down",
+    "command": "keybindings.editor.focusKeybindings",
+    "when": "inKeybindings && inKeybindingsSearch"
+  },
+  {
+    "key": "cmd+k cmd+backspace",
+    "command": "keybindings.editor.removeKeybinding",
+    "when": "inKeybindings && keybindingFocus"
+  },
+  {
+    "key": "cmd+f",
+    "command": "keybindings.editor.searchKeybindings",
+    "when": "inKeybindings && keybindingFocus"
+  },
+  {
+    "key": "escape",
+    "command": "list.clear",
+    "when": "listFocus"
+  },
+  {
+    "key": "cmd+up",
+    "command": "list.collapse",
+    "when": "listFocus"
+  },
+  {
+    "key": "left",
+    "command": "list.collapse",
+    "when": "listFocus"
+  },
+  {
+    "key": "right",
+    "command": "list.expand",
+    "when": "listFocus"
+  },
+  {
+    "key": "ctrl+n",
+    "command": "list.focusDown",
+    "when": "listFocus"
+  },
+  {
+    "key": "down",
+    "command": "list.focusDown",
+    "when": "listFocus"
+  },
+  {
+    "key": "home",
+    "command": "list.focusFirst",
+    "when": "listFocus"
+  },
+  {
+    "key": "end",
+    "command": "list.focusLast",
+    "when": "listFocus"
+  },
+  {
+    "key": "pagedown",
+    "command": "list.focusPageDown",
+    "when": "listFocus"
+  },
+  {
+    "key": "pageup",
+    "command": "list.focusPageUp",
+    "when": "listFocus"
+  },
+  {
+    "key": "ctrl+p",
+    "command": "list.focusUp",
+    "when": "listFocus"
+  },
+  {
+    "key": "up",
+    "command": "list.focusUp",
+    "when": "listFocus"
+  },
+  {
+    "key": "cmd+down",
+    "command": "list.select",
+    "when": "listFocus"
+  },
+  {
+    "key": "cmd+enter",
+    "command": "list.select",
+    "when": "listFocus"
+  },
+  {
+    "key": "enter",
+    "command": "list.select",
+    "when": "listFocus"
+  },
+  {
+    "key": "space",
+    "command": "list.toggleExpand",
+    "when": "listFocus"
+  },
+  {
+    "key": "ctrl+enter",
+    "command": "problems.action.openToSide",
+    "when": "problemFocus"
+  },
+  {
+    "key": "escape",
+    "command": "search.action.cancel",
+    "when": "listFocus && searchViewletVisible"
+  },
+  {
+    "key": "shift+cmd+f",
+    "command": "search.action.focusActiveEditor",
+    "when": "searchInputBoxFocus && searchViewletVisible"
+  },
+  { "key": "f4", "command": "search.action.focusNextSearchResult" },
+  { "key": "shift+f4", "command": "search.action.focusPreviousSearchResult" },
+  {
+    "key": "up",
+    "command": "search.action.focusSearchFromResults",
+    "when": "firstMatchFocus && searchViewletVisible"
+  },
+  {
+    "key": "ctrl+enter",
+    "command": "search.action.openResultToSide",
+    "when": "fileMatchOrMatchFocus && searchViewletVisible"
+  },
+  {
+    "key": "cmd+backspace",
+    "command": "search.action.remove",
+    "when": "fileMatchOrMatchFocus && searchViewletVisible"
+  },
+  {
+    "key": "shift+cmd+1",
+    "command": "search.action.replace",
+    "when": "matchFocus && replaceActive && searchViewletVisible"
+  },
+  {
+    "key": "alt+cmd+enter",
+    "command": "search.action.replaceAll",
+    "when": "replaceActive && searchViewletVisible && !findWidgetVisible"
+  },
+  {
+    "key": "shift+cmd+enter",
+    "command": "search.action.replaceAllInFile",
+    "when": "fileMatchFocus && replaceActive && searchViewletVisible"
+  },
+  {
+    "key": "down",
+    "command": "search.focus.nextInputBox",
+    "when": "inputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "up",
+    "command": "search.focus.previousInputBox",
+    "when": "inputBoxFocus && searchViewletVisible && !searchInputBoxFocus"
+  },
+  {
+    "key": "alt+down",
+    "command": "search.history.showNext",
+    "when": "searchInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "alt+down",
+    "command": "search.history.showNextExcludePattern",
+    "when": "patternExcludesInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "alt+down",
+    "command": "search.history.showNextIncludePattern",
+    "when": "patternIncludesInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "alt+up",
+    "command": "search.history.showPrevious",
+    "when": "searchInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "alt+up",
+    "command": "search.history.showPreviousExcludePattern",
+    "when": "patternExcludesInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "alt+up",
+    "command": "search.history.showPreviousIncludePattern",
+    "when": "patternIncludesInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "alt+cmd+c",
+    "command": "toggleSearchCaseSensitive",
+    "when": "searchInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "alt+cmd+r",
+    "command": "toggleSearchRegex",
+    "when": "searchInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "alt+cmd+w",
+    "command": "toggleSearchWholeWord",
+    "when": "searchInputBoxFocus && searchViewletVisible"
+  },
+  { "key": "cmd+w", "command": "workbench.action.closeActiveEditor" },
+  { "key": "cmd+k cmd+w", "command": "workbench.action.closeAllEditors" },
+  { "key": "cmd+k w", "command": "workbench.action.closeEditorsInGroup" },
+  { "key": "cmd+k f", "command": "workbench.action.closeFolder" },
+  {
+    "key": "shift+escape",
+    "command": "workbench.action.closeMessages",
+    "when": "globalMessageVisible"
+  },
+  {
+    "key": "escape",
+    "command": "workbench.action.closeMessages",
+    "when": "globalMessageVisible"
+  },
+  { "key": "alt+cmd+t", "command": "workbench.action.closeOtherEditors" },
+  {
+    "key": "shift+escape",
+    "command": "workbench.action.closeQuickOpen",
+    "when": "inQuickOpen"
+  },
+  {
+    "key": "escape",
+    "command": "workbench.action.closeQuickOpen",
+    "when": "inQuickOpen"
+  },
+  { "key": "cmd+k u", "command": "workbench.action.closeUnmodifiedEditors" },
+  {
+    "key": "cmd+w",
+    "command": "workbench.action.closeWindow",
+    "when": "!editorIsOpen"
+  },
+  { "key": "shift+cmd+w", "command": "workbench.action.closeWindow" },
+  {
+    "key": "f5",
+    "command": "workbench.action.debug.continue",
+    "when": "inDebugMode"
+  },
+  {
+    "key": "f6",
+    "command": "workbench.action.debug.pause",
+    "when": "inDebugMode"
+  },
+  {
+    "key": "shift+cmd+f5",
+    "command": "workbench.action.debug.restart",
+    "when": "inDebugMode"
+  },
+  {
+    "key": "cmd+f5",
+    "command": "workbench.action.debug.run",
+    "when": "!inDebugMode"
+  },
+  {
+    "key": "f5",
+    "command": "workbench.action.debug.start",
+    "when": "!inDebugMode"
+  },
+  {
+    "key": "shift+f11",
+    "command": "workbench.action.debug.stepOut",
+    "when": "inDebugMode"
+  },
+  {
+    "key": "f10",
+    "command": "workbench.action.debug.stepOver",
+    "when": "inDebugMode"
+  },
+  {
+    "key": "shift+f5",
+    "command": "workbench.action.debug.stop",
+    "when": "inDebugMode"
+  },
+  { "key": "cmd+k m", "command": "workbench.action.editor.changeLanguageMode" },
+  {
+    "key": "cmd+k p",
+    "command": "workbench.action.files.copyPathOfActiveFile"
+  },
+  { "key": "cmd+n", "command": "workbench.action.files.newUntitledFile" },
+  { "key": "cmd+o", "command": "workbench.action.files.openFileFolder" },
+  {
+    "key": "cmd+k r",
+    "command": "workbench.action.files.revealActiveFileInWindows"
+  },
+  { "key": "cmd+s", "command": "workbench.action.files.save" },
+  { "key": "alt+cmd+s", "command": "workbench.action.files.saveAll" },
+  { "key": "shift+cmd+s", "command": "workbench.action.files.saveAs" },
+  {
+    "key": "cmd+k o",
+    "command": "workbench.action.files.showOpenedFileInNewWindow"
+  },
+  {
+    "key": "shift+cmd+f",
+    "command": "workbench.action.findInFiles",
+    "when": "!searchInputBoxFocus"
+  },
+  { "key": "cmd+1", "command": "workbench.action.focusFirstEditorGroup" },
+  { "key": "cmd+k cmd+right", "command": "workbench.action.focusNextGroup" },
+  { "key": "cmd+k cmd+left", "command": "workbench.action.focusPreviousGroup" },
+  { "key": "cmd+2", "command": "workbench.action.focusSecondEditorGroup" },
+  { "key": "cmd+0", "command": "workbench.action.focusSideBar" },
+  { "key": "cmd+3", "command": "workbench.action.focusThirdEditorGroup" },
+  { "key": "ctrl+g", "command": "workbench.action.gotoLine" },
+  { "key": "shift+cmd+o", "command": "workbench.action.gotoSymbol" },
+  {
+    "key": "escape",
+    "command": "workbench.action.hideInterfaceOverview",
+    "when": "interfaceOverviewVisible"
+  },
+  {
+    "key": "down",
+    "command": "workbench.action.interactivePlayground.arrowDown",
+    "when": "interactivePlaygroundFocus && !editorTextFocus"
+  },
+  {
+    "key": "up",
+    "command": "workbench.action.interactivePlayground.arrowUp",
+    "when": "interactivePlaygroundFocus && !editorTextFocus"
+  },
+  {
+    "key": "pagedown",
+    "command": "workbench.action.interactivePlayground.pageDown",
+    "when": "interactivePlaygroundFocus && !editorTextFocus"
+  },
+  {
+    "key": "pageup",
+    "command": "workbench.action.interactivePlayground.pageUp",
+    "when": "interactivePlaygroundFocus && !editorTextFocus"
+  },
+  { "key": "cmd+k enter", "command": "workbench.action.keepEditor" },
+  { "key": "cmd+k cmd+r", "command": "workbench.action.keybindingsReference" },
+  {
+    "key": "cmd+k left",
+    "command": "workbench.action.moveActiveEditorGroupLeft"
+  },
+  {
+    "key": "cmd+k right",
+    "command": "workbench.action.moveActiveEditorGroupRight"
+  },
+  {
+    "key": "cmd+k shift+cmd+left",
+    "command": "workbench.action.moveEditorLeftInGroup"
+  },
+  {
+    "key": "cmd+k shift+cmd+right",
+    "command": "workbench.action.moveEditorRightInGroup"
+  },
+  {
+    "key": "ctrl+cmd+right",
+    "command": "workbench.action.moveEditorToNextGroup"
+  },
+  {
+    "key": "ctrl+cmd+left",
+    "command": "workbench.action.moveEditorToPreviousGroup"
+  },
+  { "key": "ctrl+-", "command": "workbench.action.navigateBack" },
+  { "key": "ctrl+shift+-", "command": "workbench.action.navigateForward" },
+  { "key": "shift+cmd+n", "command": "workbench.action.newWindow" },
+  { "key": "shift+cmd+]", "command": "workbench.action.nextEditor" },
+  { "key": "alt+cmd+right", "command": "workbench.action.nextEditor" },
+  { "key": "ctrl+1", "command": "workbench.action.openEditorAtIndex1" },
+  { "key": "ctrl+2", "command": "workbench.action.openEditorAtIndex2" },
+  { "key": "ctrl+3", "command": "workbench.action.openEditorAtIndex3" },
+  { "key": "ctrl+4", "command": "workbench.action.openEditorAtIndex4" },
+  { "key": "ctrl+5", "command": "workbench.action.openEditorAtIndex5" },
+  { "key": "ctrl+6", "command": "workbench.action.openEditorAtIndex6" },
+  { "key": "ctrl+7", "command": "workbench.action.openEditorAtIndex7" },
+  { "key": "ctrl+8", "command": "workbench.action.openEditorAtIndex8" },
+  { "key": "ctrl+9", "command": "workbench.action.openEditorAtIndex9" },
+  { "key": "cmd+k cmd+s", "command": "workbench.action.openGlobalKeybindings" },
+  { "key": "cmd+,", "command": "workbench.action.openGlobalSettings" },
+  { "key": "ctrl+0", "command": "workbench.action.openLastEditorInGroup" },
+  {
+    "key": "ctrl+tab",
+    "command": "workbench.action.openNextRecentlyUsedEditorInGroup"
+  },
+  {
+    "key": "ctrl+shift+tab",
+    "command": "workbench.action.openPreviousRecentlyUsedEditorInGroup"
+  },
+  { "key": "ctrl+r", "command": "workbench.action.openRecent" },
+  { "key": "shift+cmd+u", "command": "workbench.action.output.toggleOutput" },
+  { "key": "shift+cmd+[", "command": "workbench.action.previousEditor" },
+  { "key": "alt+cmd+left", "command": "workbench.action.previousEditor" },
+  { "key": "cmd+p", "command": "workbench.action.quickOpen" },
+  { "key": "ctrl+q", "command": "workbench.action.quickOpenView" },
+  { "key": "cmd+q", "command": "workbench.action.quit" },
+  { "key": "shift+cmd+t", "command": "workbench.action.reopenClosedEditor" },
+  { "key": "shift+cmd+h", "command": "workbench.action.replaceInFiles" },
+  {
+    "key": "shift+cmd+j",
+    "command": "workbench.action.search.toggleQueryDetails",
+    "when": "searchViewletVisible"
+  },
+  { "key": "cmd+k cmd+t", "command": "workbench.action.selectTheme" },
+  { "key": "alt+cmd+tab", "command": "workbench.action.showAllEditors" },
+  { "key": "cmd+t", "command": "workbench.action.showAllSymbols" },
+  { "key": "f1", "command": "workbench.action.showCommands" },
+  { "key": "shift+cmd+p", "command": "workbench.action.showCommands" },
+  { "key": "cmd+\\", "command": "workbench.action.splitEditor" },
+  { "key": "ctrl+w", "command": "workbench.action.switchWindow" },
+  { "key": "shift+cmd+b", "command": "workbench.action.tasks.build" },
+  {
+    "key": "cmd+c",
+    "command": "workbench.action.terminal.copySelection",
+    "when": "terminalFocus && terminalTextSelected"
+  },
+  {
+    "key": "alt+backspace",
+    "command": "workbench.action.terminal.deleteWordLeft",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "alt+delete",
+    "command": "workbench.action.terminal.deleteWordRight",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "alt+down",
+    "command": "workbench.action.terminal.findWidget.history.showNext",
+    "when": "terminalFindWidgetInputFocused && terminalFindWidgetVisible"
+  },
+  {
+    "key": "alt+up",
+    "command": "workbench.action.terminal.findWidget.history.showPrevious",
+    "when": "terminalFindWidgetInputFocused && terminalFindWidgetVisible"
+  },
+  {
+    "key": "cmd+f",
+    "command": "workbench.action.terminal.focusFindWidget",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "shift+escape",
+    "command": "workbench.action.terminal.hideFindWidget",
+    "when": "terminalFindWidgetVisible && terminalFocus"
+  },
+  {
+    "key": "escape",
+    "command": "workbench.action.terminal.hideFindWidget",
+    "when": "terminalFindWidgetVisible && terminalFocus"
+  },
+  { "key": "ctrl+shift+`", "command": "workbench.action.terminal.new" },
+  {
+    "key": "cmd+c",
+    "command": "problems.action.copy",
+    "when": "problemFocus"
+  },
+  {
+    "key": "shift+cmd+c",
+    "command": "workbench.action.terminal.openNativeConsole",
+    "when": "!terminalFocus"
+  },
+  {
+    "key": "cmd+down",
+    "command": "workbench.action.terminal.scrollDown",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "pagedown",
+    "command": "workbench.action.terminal.scrollDownPage",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "cmd+end",
+    "command": "workbench.action.terminal.scrollToBottom",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "cmd+home",
+    "command": "workbench.action.terminal.scrollToTop",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "cmd+up",
+    "command": "workbench.action.terminal.scrollUp",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "pageup",
+    "command": "workbench.action.terminal.scrollUpPage",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "cmd+a",
+    "command": "workbench.action.terminal.selectAll",
+    "when": "terminalFocus"
+  },
+  { "key": "ctrl+`", "command": "workbench.action.terminal.toggleTerminal" },
+  { "key": "alt+cmd+1", "command": "workbench.action.toggleEditorGroupLayout" },
+  { "key": "ctrl+cmd+f", "command": "workbench.action.toggleFullScreen" },
+  { "key": "cmd+j", "command": "workbench.action.togglePanel" },
+  { "key": "cmd+b", "command": "workbench.action.toggleSidebarVisibility" },
+  { "key": "cmd+k z", "command": "workbench.action.toggleZenMode" },
+  { "key": "cmd+numpad_add", "command": "workbench.action.zoomIn" },
+  { "key": "shift+cmd+=", "command": "workbench.action.zoomIn" },
+  { "key": "cmd+=", "command": "workbench.action.zoomIn" },
+  { "key": "cmd+numpad_subtract", "command": "workbench.action.zoomOut" },
+  { "key": "shift+cmd+-", "command": "workbench.action.zoomOut" },
+  { "key": "cmd+-", "command": "workbench.action.zoomOut" },
+  { "key": "cmd+numpad0", "command": "workbench.action.zoomReset" },
+  { "key": "shift+cmd+m", "command": "workbench.actions.view.problems" },
+  { "key": "shift+cmd+y", "command": "workbench.debug.action.toggleRepl" },
+  {
+    "key": "cmd+k cmd+m",
+    "command": "workbench.extensions.action.showRecommendedKeymapExtensions"
+  },
+  { "key": "cmd+k d", "command": "workbench.files.action.compareWithSaved" },
+  {
+    "key": "cmd+k e",
+    "command": "workbench.files.action.focusOpenEditorsView"
+  },
+  { "key": "shift+cmd+d", "command": "workbench.view.debug" },
+  { "key": "shift+cmd+e", "command": "workbench.view.explorer" },
+  { "key": "shift+cmd+x", "command": "workbench.view.extensions" },
+  { "key": "ctrl+shift+g", "command": "workbench.view.scm" },
+  {
+    "key": "shift+cmd+f",
+    "command": "workbench.view.search",
+    "when": "!searchViewletVisible"
+  },
+  {
+    "key": "f11",
+    "command": "workbench.action.debug.stepInto",
+    "when": "inDebugMode"
+  },
+  {
+    "key": "cmd+k",
+    "command": "workbench.action.terminal.clear",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "enter",
+    "command": "debug.renameWatchExpression",
+    "when": "watchExpressionsFocused"
+  },
+  {
+    "key": "enter",
+    "command": "debug.setVariable",
+    "when": "variablesFocused"
+  },
+  {
+    "key": "space",
+    "command": "debug.toggleBreakpoint",
+    "when": "breakpointsFocused"
+  },
+  {
+    "key": "alt+cmd+c",
+    "command": "copyFilePath",
+    "when": "explorerViewletFocus && explorerViewletVisible"
+  },
+  {
+    "key": "alt+cmd+backspace",
+    "command": "deleteFile",
+    "when": "explorerViewletVisible && filesExplorerFocus"
+  },
+  {
+    "key": "ctrl+enter",
+    "command": "explorer.openToSide",
+    "when": "explorerViewletFocus && explorerViewletVisible"
+  },
+  {
+    "key": "cmd+c",
+    "command": "filesExplorer.copy",
+    "when": "explorerViewletVisible && filesExplorerFocus"
+  },
+  {
+    "key": "cmd+v",
+    "command": "filesExplorer.paste",
+    "when": "explorerViewletVisible && filesExplorerFocus"
+  },
+  {
+    "key": "cmd+backspace",
+    "command": "moveFileToTrash",
+    "when": "explorerViewletVisible && filesExplorerFocus"
+  },
+  {
+    "key": "enter",
+    "command": "renameFile",
+    "when": "explorerViewletVisible && filesExplorerFocus"
+  },
+  {
+    "key": "alt+cmd+r",
+    "command": "revealFileInOS",
+    "when": "explorerViewletFocus && explorerViewletVisible"
+  },
+  {
+    "key": "ctrl+tab",
+    "command": "workbench.action.quickOpenNavigateNextInEditorPicker",
+    "when": "inEditorsPicker && inQuickOpen"
+  },
+  {
+    "key": "cmd+p",
+    "command": "workbench.action.quickOpenNavigateNextInFilePicker",
+    "when": "inFilesPicker && inQuickOpen"
+  },
+  {
+    "key": "ctrl+r",
+    "command": "workbench.action.quickOpenNavigateNextInRecentFilesPicker",
+    "when": "inQuickOpen && inRecentFilesPicker"
+  },
+  {
+    "key": "ctrl+q",
+    "command": "workbench.action.quickOpenNavigateNextInViewPicker",
+    "when": "inQuickOpen && inViewsPicker"
+  },
+  {
+    "key": "ctrl+shift+tab",
+    "command": "workbench.action.quickOpenNavigatePreviousInEditorPicker",
+    "when": "inEditorsPicker && inQuickOpen"
+  },
+  {
+    "key": "shift+cmd+p",
+    "command": "workbench.action.quickOpenNavigatePreviousInFilePicker",
+    "when": "inFilesPicker && inQuickOpen"
+  },
+  {
+    "key": "ctrl+shift+r",
+    "command": "workbench.action.quickOpenNavigatePreviousInRecentFilesPicker",
+    "when": "inQuickOpen && inRecentFilesPicker"
+  },
+  {
+    "key": "ctrl+shift+q",
+    "command": "workbench.action.quickOpenNavigatePreviousInViewPicker",
+    "when": "inQuickOpen && inViewsPicker"
+  },
+  {
+    "key": "ctrl+n",
+    "command": "workbench.action.quickOpenSelectNext",
+    "when": "inQuickOpen"
+  },
+  {
+    "key": "ctrl+p",
+    "command": "workbench.action.quickOpenSelectPrevious",
+    "when": "inQuickOpen"
+  },
+  {
+    "key": "cmd+f4",
+    "command": "extension.node-debug.pickLoadedScript",
+    "when": "debugType == 'node'"
+  },
+  {
+    "key": "cmd+f4",
+    "command": "extension.node-debug.pickLoadedScript",
+    "when": "debugType == 'node2'"
+  },
+  {
+    "key": "shift+cmd+v",
+    "command": "markdown.showPreview",
+    "when": "editorLangId == 'markdown'"
+  },
+  {
+    "key": "cmd+k v",
+    "command": "markdown.showPreviewToSide",
+    "when": "editorLangId == 'markdown'"
+  }
+]

--- a/packages/system-tests/test_data/keybindings.win.json
+++ b/packages/system-tests/test_data/keybindings.win.json
@@ -1,0 +1,1681 @@
+[
+  {
+    "key": "escape escape",
+    "command": "workbench.action.exitZenMode",
+    "when": "inZenMode"
+  },
+  {
+    "key": "shift+escape",
+    "command": "closeReferenceSearchEditor",
+    "when": "inReferenceSearchEditor && !config.editor.stablePeek"
+  },
+  {
+    "key": "escape",
+    "command": "closeReferenceSearchEditor",
+    "when": "inReferenceSearchEditor && !config.editor.stablePeek"
+  },
+  {
+    "key": "shift+escape",
+    "command": "cancelSelection",
+    "when": "editorHasSelection && editorTextFocus"
+  },
+  {
+    "key": "escape",
+    "command": "cancelSelection",
+    "when": "editorHasSelection && editorTextFocus"
+  },
+  {
+    "key": "ctrl+end",
+    "command": "cursorBottom",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+shift+end",
+    "command": "cursorBottomSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+shift+alt+down",
+    "command": "cursorColumnSelectDown",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+shift+alt+left",
+    "command": "cursorColumnSelectLeft",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+shift+alt+pagedown",
+    "command": "cursorColumnSelectPageDown",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+shift+alt+pageup",
+    "command": "cursorColumnSelectPageUp",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+shift+alt+right",
+    "command": "cursorColumnSelectRight",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+shift+alt+up",
+    "command": "cursorColumnSelectUp",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "down",
+    "command": "cursorDown",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+shift+down",
+    "command": "cursorDownSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+down",
+    "command": "cursorDownSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "end",
+    "command": "cursorEnd",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+end",
+    "command": "cursorEndSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "home",
+    "command": "cursorHome",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+home",
+    "command": "cursorHomeSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "left",
+    "command": "cursorLeft",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+left",
+    "command": "cursorLeftSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "pagedown",
+    "command": "cursorPageDown",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+pagedown",
+    "command": "cursorPageDownSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "pageup",
+    "command": "cursorPageUp",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+pageup",
+    "command": "cursorPageUpSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "right",
+    "command": "cursorRight",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+right",
+    "command": "cursorRightSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+home",
+    "command": "cursorTop",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+shift+home",
+    "command": "cursorTopSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "up",
+    "command": "cursorUp",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+shift+up",
+    "command": "cursorUpSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+up",
+    "command": "cursorUpSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+backspace",
+    "command": "deleteLeft",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "backspace",
+    "command": "deleteLeft",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "delete",
+    "command": "deleteRight",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  { "key": "ctrl+a", "command": "editor.action.selectAll" },
+  {
+    "key": "ctrl+i",
+    "command": "expandLineSelection",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+tab",
+    "command": "outdent",
+    "when": "editorTextFocus && !editorReadonly && !editorTabMovesFocus"
+  },
+  {
+    "key": "ctrl+shift+z",
+    "command": "redo",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+y",
+    "command": "redo",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+down",
+    "command": "scrollLineDown",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+up",
+    "command": "scrollLineUp",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "alt+pagedown",
+    "command": "scrollPageDown",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "alt+pageup",
+    "command": "scrollPageUp",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "tab",
+    "command": "tab",
+    "when": "editorTextFocus && !editorReadonly && !editorTabMovesFocus"
+  },
+  {
+    "key": "ctrl+z",
+    "command": "undo",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "shift+escape",
+    "command": "removeSecondaryCursors",
+    "when": "editorHasMultipleSelections && editorTextFocus"
+  },
+  {
+    "key": "escape",
+    "command": "removeSecondaryCursors",
+    "when": "editorHasMultipleSelections && editorTextFocus"
+  },
+  {
+    "key": "right",
+    "command": "repl.action.acceptSuggestion",
+    "when": "editorTextFocus && inDebugRepl && suggestWidgetVisible"
+  },
+  {
+    "key": "down",
+    "command": "repl.action.historyNext",
+    "when": "editorTextFocus && inDebugRepl && onLastDebugReplLine"
+  },
+  {
+    "key": "up",
+    "command": "repl.action.historyPrevious",
+    "when": "editorTextFocus && inDebugRepl && onFirsteDebugReplLine"
+  },
+  { "key": "ctrl+f", "command": "actions.find" },
+  {
+    "key": "ctrl+u",
+    "command": "cursorUndo",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+right",
+    "command": "cursorWordEndRight",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+shift+right",
+    "command": "cursorWordEndRightSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+left",
+    "command": "cursorWordStartLeft",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+shift+left",
+    "command": "cursorWordStartLeftSelect",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+backspace",
+    "command": "deleteWordLeft",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+delete",
+    "command": "deleteWordRight",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+k ctrl+c",
+    "command": "editor.action.addCommentLine",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+d",
+    "command": "editor.action.addSelectionToNextFindMatch",
+    "when": "editorFocus"
+  },
+  {
+    "key": "shift+alt+a",
+    "command": "editor.action.blockComment",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+f2",
+    "command": "editor.action.changeAll",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+insert",
+    "command": "editor.action.clipboardCopyAction",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+c",
+    "command": "editor.action.clipboardCopyAction",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+delete",
+    "command": "editor.action.clipboardCutAction",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+x",
+    "command": "editor.action.clipboardCutAction",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "shift+insert",
+    "command": "editor.action.clipboardPasteAction",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+v",
+    "command": "editor.action.clipboardPasteAction",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+/",
+    "command": "editor.action.commentLine",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "shift+alt+down",
+    "command": "editor.action.copyLinesDownAction",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "shift+alt+up",
+    "command": "editor.action.copyLinesUpAction",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+k ctrl+k",
+    "command": "editor.action.defineKeybinding",
+    "when": "editorTextFocus && !editorReadonly && editorLangId == 'json'"
+  },
+  {
+    "key": "ctrl+shift+k",
+    "command": "editor.action.deleteLines",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "f7",
+    "command": "editor.action.diffReview.next",
+    "when": "isInDiffEditor"
+  },
+  {
+    "key": "shift+f7",
+    "command": "editor.action.diffReview.prev",
+    "when": "isInDiffEditor"
+  },
+  {
+    "key": "ctrl+f",
+    "command": "editor.action.extensioneditor.hidefind",
+    "when": "extensionEditorWebviewFocus"
+  },
+  {
+    "key": "alt+down",
+    "command": "editor.action.extensioneditor.showNextFindTerm",
+    "when": "extensionEditorFindWidgetInputFocused"
+  },
+  {
+    "key": "alt+up",
+    "command": "editor.action.extensioneditor.showPreviousFindTerm",
+    "when": "extensionEditorFindWidgetInputFocused"
+  },
+  {
+    "key": "ctrl+f",
+    "command": "editor.action.extensioneditor.showfind",
+    "when": "extensionEditorWebviewFocus"
+  },
+  {
+    "key": "shift+alt+f",
+    "command": "editor.action.formatDocument",
+    "when":
+      "editorHasDocumentFormattingProvider && editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+k ctrl+f",
+    "command": "editor.action.formatSelection",
+    "when":
+      "editorHasDocumentSelectionFormattingProvider && editorHasSelection && editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "f12",
+    "command": "editor.action.goToDeclaration",
+    "when":
+      "editorHasDefinitionProvider && editorTextFocus && !isInEmbeddedEditor"
+  },
+  {
+    "key": "ctrl+f12",
+    "command": "editor.action.goToImplementation",
+    "when":
+      "editorHasImplementationProvider && editorTextFocus && !isInEmbeddedEditor"
+  },
+  {
+    "key": "ctrl+shift+.",
+    "command": "editor.action.inPlaceReplace.down",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+shift+,",
+    "command": "editor.action.inPlaceReplace.up",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+]",
+    "command": "editor.action.indentLines",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+alt+up",
+    "command": "editor.action.insertCursorAbove",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+alt+i",
+    "command": "editor.action.insertCursorAtEndOfEachLineSelected",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+alt+down",
+    "command": "editor.action.insertCursorBelow",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+enter",
+    "command": "editor.action.insertLineAfter",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+shift+enter",
+    "command": "editor.action.insertLineBefore",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+shift+\\",
+    "command": "editor.action.jumpToBracket",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "f8",
+    "command": "editor.action.marker.next",
+    "when": "editorFocus && !editorReadonly"
+  },
+  {
+    "key": "shift+f8",
+    "command": "editor.action.marker.prev",
+    "when": "editorFocus && !editorReadonly"
+  },
+  {
+    "key": "alt+down",
+    "command": "editor.action.moveLinesDownAction",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "alt+up",
+    "command": "editor.action.moveLinesUpAction",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+k ctrl+d",
+    "command": "editor.action.moveSelectionToNextFindMatch",
+    "when": "editorFocus"
+  },
+  {
+    "key": "f3",
+    "command": "editor.action.nextMatchFindAction",
+    "when": "editorFocus"
+  },
+  {
+    "key": "ctrl+f3",
+    "command": "editor.action.nextSelectionMatchFindAction",
+    "when": "editorFocus"
+  },
+  {
+    "key": "ctrl+k f12",
+    "command": "editor.action.openDeclarationToTheSide",
+    "when":
+      "editorHasDefinitionProvider && editorTextFocus && !isInEmbeddedEditor"
+  },
+  {
+    "key": "ctrl+[",
+    "command": "editor.action.outdentLines",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+shift+f12",
+    "command": "editor.action.peekImplementation",
+    "when":
+      "editorHasImplementationProvider && editorTextFocus && !isInEmbeddedEditor"
+  },
+  {
+    "key": "alt+f12",
+    "command": "editor.action.previewDeclaration",
+    "when":
+      "editorHasDefinitionProvider && editorTextFocus && !inReferenceSearchEditor && !isInEmbeddedEditor"
+  },
+  {
+    "key": "shift+f3",
+    "command": "editor.action.previousMatchFindAction",
+    "when": "editorFocus"
+  },
+  {
+    "key": "ctrl+shift+f3",
+    "command": "editor.action.previousSelectionMatchFindAction",
+    "when": "editorFocus"
+  },
+  {
+    "key": "ctrl+.",
+    "command": "editor.action.quickFix",
+    "when": "editorHasCodeActionsProvider && editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "shift+f12",
+    "command": "editor.action.referenceSearch.trigger",
+    "when":
+      "editorHasReferenceProvider && editorTextFocus && !inReferenceSearchEditor && !isInEmbeddedEditor"
+  },
+  {
+    "key": "ctrl+k ctrl+u",
+    "command": "editor.action.removeCommentLine",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "f2",
+    "command": "editor.action.rename",
+    "when": "editorHasRenameProvider && editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+shift+l",
+    "command": "editor.action.selectHighlights",
+    "when": "editorFocus"
+  },
+  {
+    "key": "alt+f1",
+    "command": "editor.action.showAccessibilityHelp",
+    "when": "editorFocus"
+  },
+  {
+    "key": "shift+f10",
+    "command": "editor.action.showContextMenu",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+i",
+    "command": "editor.action.showHover",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+alt+right",
+    "command": "editor.action.smartSelect.grow",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+alt+left",
+    "command": "editor.action.smartSelect.shrink",
+    "when": "editorTextFocus"
+  },
+  { "key": "ctrl+h", "command": "editor.action.startFindReplaceAction" },
+  { "key": "ctrl+m", "command": "editor.action.toggleTabFocusMode" },
+  { "key": "alt+z", "command": "editor.action.toggleWordWrap" },
+  {
+    "key": "ctrl+shift+space",
+    "command": "editor.action.triggerParameterHints",
+    "when": "editorHasSignatureHelpProvider && editorTextFocus"
+  },
+  {
+    "key": "ctrl+space",
+    "command": "editor.action.triggerSuggest",
+    "when":
+      "editorHasCompletionItemProvider && editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "ctrl+k ctrl+x",
+    "command": "editor.action.trimTrailingWhitespace",
+    "when": "editorTextFocus && !editorReadonly"
+  },
+  {
+    "key": "escape",
+    "command": "editor.action.webvieweditor.hideFind",
+    "when": "webviewEditorFocus && webviewFindWidgetVisible"
+  },
+  {
+    "key": "ctrl+f",
+    "command": "editor.action.webvieweditor.showFind",
+    "when": "webviewEditorFocus"
+  },
+  {
+    "key": "alt+down",
+    "command": "editor.action.webvieweditor.showNextFindTerm",
+    "when": "webviewEditorFindWidgetInputFocused"
+  },
+  {
+    "key": "alt+up",
+    "command": "editor.action.webvieweditor.showPreviousFindTerm",
+    "when": "webviewEditorFindWidgetInputFocused"
+  },
+  {
+    "key": "ctrl+k ctrl+i",
+    "command": "editor.debug.action.showDebugHover",
+    "when": "editorTextFocus && inDebugMode"
+  },
+  {
+    "key": "f9",
+    "command": "editor.debug.action.toggleBreakpoint",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "shift+f9",
+    "command": "editor.debug.action.toggleColumnBreakpoint",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "tab",
+    "command": "editor.emmet.action.expandAbbreviation",
+    "when":
+      "config.emmet.triggerExpansionOnTab && editorTextFocus && !editorReadonly && !editorTabMovesFocus"
+  },
+  {
+    "key": "ctrl+shift+[",
+    "command": "editor.fold",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+0",
+    "command": "editor.foldAll",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+1",
+    "command": "editor.foldLevel1",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+2",
+    "command": "editor.foldLevel2",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+3",
+    "command": "editor.foldLevel3",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+4",
+    "command": "editor.foldLevel4",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+5",
+    "command": "editor.foldLevel5",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+6",
+    "command": "editor.foldLevel6",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+7",
+    "command": "editor.foldLevel7",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+8",
+    "command": "editor.foldLevel8",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+9",
+    "command": "editor.foldLevel9",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+[",
+    "command": "editor.foldRecursively",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+shift+]",
+    "command": "editor.unfold",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+j",
+    "command": "editor.unfoldAll",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+]",
+    "command": "editor.unfoldRecursively",
+    "when": "editorTextFocus"
+  },
+  {
+    "key": "tab",
+    "command": "insertSnippet",
+    "when":
+      "config.editor.tabCompletion && editorTextFocus && hasSnippetCompletions && !editorTabMovesFocus && !inSnippetMode"
+  },
+  {
+    "key": "enter",
+    "command": "repl.action.acceptInput",
+    "when": "editorTextFocus && inDebugRepl"
+  },
+  {
+    "key": "escape",
+    "command": "settings.action.clearSearchResults",
+    "when": "inSettingsSearch"
+  },
+  {
+    "key": "enter",
+    "command": "settings.action.focusNextSetting",
+    "when": "inSettingsSearch"
+  },
+  {
+    "key": "shift+enter",
+    "command": "settings.action.focusPreviousSetting",
+    "when": "inSettingsSearch"
+  },
+  {
+    "key": "down",
+    "command": "settings.action.focusSettingsFile",
+    "when": "inSettingsSearch"
+  },
+  {
+    "key": "ctrl+f",
+    "command": "settings.action.search",
+    "when": "inSettingsEditor"
+  },
+  {
+    "key": "shift+escape",
+    "command": "closeFindWidget",
+    "when": "editorFocus && findWidgetVisible"
+  },
+  {
+    "key": "escape",
+    "command": "closeFindWidget",
+    "when": "editorFocus && findWidgetVisible"
+  },
+  {
+    "key": "ctrl+alt+enter",
+    "command": "editor.action.replaceAll",
+    "when": "editorFocus && findWidgetVisible"
+  },
+  {
+    "key": "ctrl+shift+1",
+    "command": "editor.action.replaceOne",
+    "when": "editorFocus && findWidgetVisible"
+  },
+  {
+    "key": "alt+enter",
+    "command": "editor.action.selectAllMatches",
+    "when": "editorFocus && findWidgetVisible"
+  },
+  {
+    "key": "alt+down",
+    "command": "find.history.showNext",
+    "when": "editorFocus && findInputFocussed && findWidgetVisible"
+  },
+  {
+    "key": "alt+up",
+    "command": "find.history.showPrevious",
+    "when": "editorFocus && findInputFocussed && findWidgetVisible"
+  },
+  {
+    "key": "alt+c",
+    "command": "toggleFindCaseSensitive",
+    "when": "editorFocus"
+  },
+  {
+    "key": "alt+l",
+    "command": "toggleFindInSelection",
+    "when": "editorFocus"
+  },
+  {
+    "key": "alt+r",
+    "command": "toggleFindRegex",
+    "when": "editorFocus"
+  },
+  {
+    "key": "alt+w",
+    "command": "toggleFindWholeWord",
+    "when": "editorFocus"
+  },
+  {
+    "key": "shift+escape",
+    "command": "closeBreakpointWidget",
+    "when": "breakpointWidgetVisible && editorFocus"
+  },
+  {
+    "key": "escape",
+    "command": "closeBreakpointWidget",
+    "when": "breakpointWidgetVisible && editorFocus"
+  },
+  {
+    "key": "tab",
+    "command": "jumpToNextSnippetPlaceholder",
+    "when": "editorTextFocus && hasNextTabstop && inSnippetMode"
+  },
+  {
+    "key": "shift+tab",
+    "command": "jumpToPrevSnippetPlaceholder",
+    "when": "editorTextFocus && hasPrevTabstop && inSnippetMode"
+  },
+  {
+    "key": "escape",
+    "command": "leaveEditorMessage",
+    "when": "messageVisible"
+  },
+  {
+    "key": "shift+escape",
+    "command": "leaveSnippet",
+    "when": "editorTextFocus && inSnippetMode"
+  },
+  {
+    "key": "escape",
+    "command": "leaveSnippet",
+    "when": "editorTextFocus && inSnippetMode"
+  },
+  {
+    "key": "shift+escape",
+    "command": "closeMarkersNavigation",
+    "when": "editorFocus && markersNavigationVisible"
+  },
+  {
+    "key": "escape",
+    "command": "closeMarkersNavigation",
+    "when": "editorFocus && markersNavigationVisible"
+  },
+  {
+    "key": "shift+escape",
+    "command": "closeReferenceSearch",
+    "when": "referenceSearchVisible && !config.editor.stablePeek"
+  },
+  {
+    "key": "escape",
+    "command": "closeReferenceSearch",
+    "when": "referenceSearchVisible && !config.editor.stablePeek"
+  },
+  {
+    "key": "shift+escape",
+    "command": "closeParameterHints",
+    "when": "editorTextFocus && parameterHintsVisible"
+  },
+  {
+    "key": "escape",
+    "command": "closeParameterHints",
+    "when": "editorTextFocus && parameterHintsVisible"
+  },
+  {
+    "key": "alt+down",
+    "command": "showNextParameterHint",
+    "when":
+      "editorTextFocus && parameterHintsMultipleSignatures && parameterHintsVisible"
+  },
+  {
+    "key": "down",
+    "command": "showNextParameterHint",
+    "when":
+      "editorTextFocus && parameterHintsMultipleSignatures && parameterHintsVisible"
+  },
+  {
+    "key": "alt+up",
+    "command": "showPrevParameterHint",
+    "when":
+      "editorTextFocus && parameterHintsMultipleSignatures && parameterHintsVisible"
+  },
+  {
+    "key": "up",
+    "command": "showPrevParameterHint",
+    "when":
+      "editorTextFocus && parameterHintsMultipleSignatures && parameterHintsVisible"
+  },
+  {
+    "key": "tab",
+    "command": "acceptSelectedSuggestion",
+    "when": "editorTextFocus && suggestWidgetVisible"
+  },
+  {
+    "key": "enter",
+    "command": "acceptSelectedSuggestionOnEnter",
+    "when":
+      "acceptSuggestionOnEnter && editorTextFocus && suggestWidgetVisible && suggestionMakesTextEdit"
+  },
+  {
+    "key": "shift+escape",
+    "command": "hideSuggestWidget",
+    "when": "editorTextFocus && suggestWidgetVisible"
+  },
+  {
+    "key": "escape",
+    "command": "hideSuggestWidget",
+    "when": "editorTextFocus && suggestWidgetVisible"
+  },
+  {
+    "key": "ctrl+pagedown",
+    "command": "selectNextPageSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "pagedown",
+    "command": "selectNextPageSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "ctrl+down",
+    "command": "selectNextSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "down",
+    "command": "selectNextSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "ctrl+pageup",
+    "command": "selectPrevPageSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "pageup",
+    "command": "selectPrevPageSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "ctrl+up",
+    "command": "selectPrevSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "up",
+    "command": "selectPrevSuggestion",
+    "when":
+      "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
+  },
+  {
+    "key": "ctrl+space",
+    "command": "toggleSuggestionDetails",
+    "when": "editorTextFocus && suggestWidgetVisible"
+  },
+  {
+    "key": "ctrl+alt+space",
+    "command": "toggleSuggestionFocus",
+    "when": "editorTextFocus && suggestWidgetVisible"
+  },
+  {
+    "key": "enter",
+    "command": "acceptRenameInput",
+    "when": "editorFocus && renameInputVisible"
+  },
+  {
+    "key": "shift+escape",
+    "command": "cancelRenameInput",
+    "when": "editorFocus && renameInputVisible"
+  },
+  {
+    "key": "escape",
+    "command": "cancelRenameInput",
+    "when": "editorFocus && renameInputVisible"
+  },
+  {
+    "key": "shift+escape",
+    "command": "closeAccessibilityHelp",
+    "when": "accessibilityHelpWidgetVisible && editorFocus"
+  },
+  {
+    "key": "escape",
+    "command": "closeAccessibilityHelp",
+    "when": "accessibilityHelpWidgetVisible && editorFocus"
+  },
+  {
+    "key": "escape",
+    "command": "closeReplaceInFilesWidget",
+    "when": "replaceInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "delete",
+    "command": "debug.removeBreakpoint",
+    "when": "breakpointsFocused"
+  },
+  {
+    "key": "delete",
+    "command": "debug.removeWatchExpression",
+    "when": "watchExpressionsFocused"
+  },
+  {
+    "key": "escape",
+    "command": "keybindings.editor.clearSearchResults",
+    "when": "inKeybindings && inKeybindingsSearch"
+  },
+  {
+    "key": "ctrl+c",
+    "command": "keybindings.editor.copyKeybindingEntry",
+    "when": "inKeybindings && keybindingFocus"
+  },
+  {
+    "key": "ctrl+k ctrl+k",
+    "command": "keybindings.editor.defineKeybinding",
+    "when": "inKeybindings && keybindingFocus"
+  },
+  {
+    "key": "down",
+    "command": "keybindings.editor.focusKeybindings",
+    "when": "inKeybindings && inKeybindingsSearch"
+  },
+  {
+    "key": "delete",
+    "command": "keybindings.editor.removeKeybinding",
+    "when": "inKeybindings && keybindingFocus"
+  },
+  {
+    "key": "ctrl+f",
+    "command": "keybindings.editor.searchKeybindings",
+    "when": "inKeybindings && keybindingFocus"
+  },
+  {
+    "key": "escape",
+    "command": "list.clear",
+    "when": "listFocus"
+  },
+  {
+    "key": "left",
+    "command": "list.collapse",
+    "when": "listFocus"
+  },
+  {
+    "key": "right",
+    "command": "list.expand",
+    "when": "listFocus"
+  },
+  {
+    "key": "down",
+    "command": "list.focusDown",
+    "when": "listFocus"
+  },
+  {
+    "key": "home",
+    "command": "list.focusFirst",
+    "when": "listFocus"
+  },
+  {
+    "key": "end",
+    "command": "list.focusLast",
+    "when": "listFocus"
+  },
+  {
+    "key": "pagedown",
+    "command": "list.focusPageDown",
+    "when": "listFocus"
+  },
+  {
+    "key": "pageup",
+    "command": "list.focusPageUp",
+    "when": "listFocus"
+  },
+  {
+    "key": "up",
+    "command": "list.focusUp",
+    "when": "listFocus"
+  },
+  {
+    "key": "ctrl+enter",
+    "command": "list.select",
+    "when": "listFocus"
+  },
+  {
+    "key": "enter",
+    "command": "list.select",
+    "when": "listFocus"
+  },
+  {
+    "key": "space",
+    "command": "list.toggleExpand",
+    "when": "listFocus"
+  },
+  {
+    "key": "ctrl+enter",
+    "command": "problems.action.openToSide",
+    "when": "problemFocus"
+  },
+  {
+    "key": "escape",
+    "command": "search.action.cancel",
+    "when": "listFocus && searchViewletVisible"
+  },
+  {
+    "key": "ctrl+shift+f",
+    "command": "search.action.focusActiveEditor",
+    "when": "searchInputBoxFocus && searchViewletVisible"
+  },
+  { "key": "f4", "command": "search.action.focusNextSearchResult" },
+  { "key": "shift+f4", "command": "search.action.focusPreviousSearchResult" },
+  {
+    "key": "up",
+    "command": "search.action.focusSearchFromResults",
+    "when": "firstMatchFocus && searchViewletVisible"
+  },
+  {
+    "key": "ctrl+enter",
+    "command": "search.action.openResultToSide",
+    "when": "fileMatchOrMatchFocus && searchViewletVisible"
+  },
+  {
+    "key": "delete",
+    "command": "search.action.remove",
+    "when": "fileMatchOrMatchFocus && searchViewletVisible"
+  },
+  {
+    "key": "ctrl+shift+1",
+    "command": "search.action.replace",
+    "when": "matchFocus && replaceActive && searchViewletVisible"
+  },
+  {
+    "key": "ctrl+alt+enter",
+    "command": "search.action.replaceAll",
+    "when": "replaceActive && searchViewletVisible && !findWidgetVisible"
+  },
+  {
+    "key": "ctrl+shift+enter",
+    "command": "search.action.replaceAllInFile",
+    "when": "fileMatchFocus && replaceActive && searchViewletVisible"
+  },
+  {
+    "key": "down",
+    "command": "search.focus.nextInputBox",
+    "when": "inputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "up",
+    "command": "search.focus.previousInputBox",
+    "when": "inputBoxFocus && searchViewletVisible && !searchInputBoxFocus"
+  },
+  {
+    "key": "alt+down",
+    "command": "search.history.showNext",
+    "when": "searchInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "alt+down",
+    "command": "search.history.showNextExcludePattern",
+    "when": "patternExcludesInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "alt+down",
+    "command": "search.history.showNextIncludePattern",
+    "when": "patternIncludesInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "alt+up",
+    "command": "search.history.showPrevious",
+    "when": "searchInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "alt+up",
+    "command": "search.history.showPreviousExcludePattern",
+    "when": "patternExcludesInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "alt+up",
+    "command": "search.history.showPreviousIncludePattern",
+    "when": "patternIncludesInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "alt+c",
+    "command": "toggleSearchCaseSensitive",
+    "when": "searchInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "alt+r",
+    "command": "toggleSearchRegex",
+    "when": "searchInputBoxFocus && searchViewletVisible"
+  },
+  {
+    "key": "alt+w",
+    "command": "toggleSearchWholeWord",
+    "when": "searchInputBoxFocus && searchViewletVisible"
+  },
+  { "key": "ctrl+w", "command": "workbench.action.closeActiveEditor" },
+  { "key": "ctrl+f4", "command": "workbench.action.closeActiveEditor" },
+  { "key": "ctrl+k ctrl+w", "command": "workbench.action.closeAllEditors" },
+  { "key": "ctrl+k w", "command": "workbench.action.closeEditorsInGroup" },
+  { "key": "ctrl+k f", "command": "workbench.action.closeFolder" },
+  {
+    "key": "shift+escape",
+    "command": "workbench.action.closeMessages",
+    "when": "globalMessageVisible"
+  },
+  {
+    "key": "escape",
+    "command": "workbench.action.closeMessages",
+    "when": "globalMessageVisible"
+  },
+  {
+    "key": "shift+escape",
+    "command": "workbench.action.closeQuickOpen",
+    "when": "inQuickOpen"
+  },
+  {
+    "key": "escape",
+    "command": "workbench.action.closeQuickOpen",
+    "when": "inQuickOpen"
+  },
+  {
+    "key": "ctrl+c",
+    "command": "problems.action.copy",
+    "when": "problemFocus"
+  },
+  { "key": "ctrl+k u", "command": "workbench.action.closeUnmodifiedEditors" },
+  { "key": "ctrl+shift+w", "command": "workbench.action.closeWindow" },
+  {
+    "key": "ctrl+w",
+    "command": "workbench.action.closeWindow",
+    "when": "!editorIsOpen"
+  },
+  {
+    "key": "f5",
+    "command": "workbench.action.debug.continue",
+    "when": "inDebugMode"
+  },
+  {
+    "key": "f6",
+    "command": "workbench.action.debug.pause",
+    "when": "inDebugMode"
+  },
+  {
+    "key": "ctrl+shift+f5",
+    "command": "workbench.action.debug.restart",
+    "when": "inDebugMode"
+  },
+  {
+    "key": "ctrl+f5",
+    "command": "workbench.action.debug.run",
+    "when": "!inDebugMode"
+  },
+  {
+    "key": "f5",
+    "command": "workbench.action.debug.start",
+    "when": "!inDebugMode"
+  },
+  {
+    "key": "shift+f11",
+    "command": "workbench.action.debug.stepOut",
+    "when": "inDebugMode"
+  },
+  {
+    "key": "f10",
+    "command": "workbench.action.debug.stepOver",
+    "when": "inDebugMode"
+  },
+  {
+    "key": "shift+f5",
+    "command": "workbench.action.debug.stop",
+    "when": "inDebugMode"
+  },
+  {
+    "key": "ctrl+k m",
+    "command": "workbench.action.editor.changeLanguageMode"
+  },
+  {
+    "key": "ctrl+k p",
+    "command": "workbench.action.files.copyPathOfActiveFile"
+  },
+  { "key": "ctrl+n", "command": "workbench.action.files.newUntitledFile" },
+  { "key": "ctrl+o", "command": "workbench.action.files.openFile" },
+  { "key": "ctrl+k ctrl+o", "command": "workbench.action.files.openFolder" },
+  {
+    "key": "ctrl+k r",
+    "command": "workbench.action.files.revealActiveFileInWindows"
+  },
+  { "key": "ctrl+s", "command": "workbench.action.files.save" },
+  { "key": "ctrl+k s", "command": "workbench.action.files.saveAll" },
+  { "key": "ctrl+shift+s", "command": "workbench.action.files.saveAs" },
+  {
+    "key": "ctrl+k o",
+    "command": "workbench.action.files.showOpenedFileInNewWindow"
+  },
+  {
+    "key": "ctrl+shift+f",
+    "command": "workbench.action.findInFiles",
+    "when": "!searchInputBoxFocus"
+  },
+  { "key": "ctrl+1", "command": "workbench.action.focusFirstEditorGroup" },
+  { "key": "ctrl+k ctrl+right", "command": "workbench.action.focusNextGroup" },
+  {
+    "key": "ctrl+k ctrl+left",
+    "command": "workbench.action.focusPreviousGroup"
+  },
+  { "key": "ctrl+2", "command": "workbench.action.focusSecondEditorGroup" },
+  { "key": "ctrl+0", "command": "workbench.action.focusSideBar" },
+  { "key": "ctrl+3", "command": "workbench.action.focusThirdEditorGroup" },
+  { "key": "ctrl+g", "command": "workbench.action.gotoLine" },
+  { "key": "ctrl+shift+o", "command": "workbench.action.gotoSymbol" },
+  {
+    "key": "escape",
+    "command": "workbench.action.hideInterfaceOverview",
+    "when": "interfaceOverviewVisible"
+  },
+  {
+    "key": "down",
+    "command": "workbench.action.interactivePlayground.arrowDown",
+    "when": "interactivePlaygroundFocus && !editorTextFocus"
+  },
+  {
+    "key": "up",
+    "command": "workbench.action.interactivePlayground.arrowUp",
+    "when": "interactivePlaygroundFocus && !editorTextFocus"
+  },
+  {
+    "key": "pagedown",
+    "command": "workbench.action.interactivePlayground.pageDown",
+    "when": "interactivePlaygroundFocus && !editorTextFocus"
+  },
+  {
+    "key": "pageup",
+    "command": "workbench.action.interactivePlayground.pageUp",
+    "when": "interactivePlaygroundFocus && !editorTextFocus"
+  },
+  { "key": "ctrl+k enter", "command": "workbench.action.keepEditor" },
+  {
+    "key": "ctrl+k ctrl+r",
+    "command": "workbench.action.keybindingsReference"
+  },
+  {
+    "key": "ctrl+k left",
+    "command": "workbench.action.moveActiveEditorGroupLeft"
+  },
+  {
+    "key": "ctrl+k right",
+    "command": "workbench.action.moveActiveEditorGroupRight"
+  },
+  {
+    "key": "ctrl+shift+pageup",
+    "command": "workbench.action.moveEditorLeftInGroup"
+  },
+  {
+    "key": "ctrl+shift+pagedown",
+    "command": "workbench.action.moveEditorRightInGroup"
+  },
+  {
+    "key": "ctrl+alt+right",
+    "command": "workbench.action.moveEditorToNextGroup"
+  },
+  {
+    "key": "ctrl+alt+left",
+    "command": "workbench.action.moveEditorToPreviousGroup"
+  },
+  { "key": "alt+left", "command": "workbench.action.navigateBack" },
+  { "key": "alt+right", "command": "workbench.action.navigateForward" },
+  { "key": "ctrl+shift+n", "command": "workbench.action.newWindow" },
+  { "key": "ctrl+pagedown", "command": "workbench.action.nextEditor" },
+  { "key": "alt+1", "command": "workbench.action.openEditorAtIndex1" },
+  { "key": "alt+2", "command": "workbench.action.openEditorAtIndex2" },
+  { "key": "alt+3", "command": "workbench.action.openEditorAtIndex3" },
+  { "key": "alt+4", "command": "workbench.action.openEditorAtIndex4" },
+  { "key": "alt+5", "command": "workbench.action.openEditorAtIndex5" },
+  { "key": "alt+6", "command": "workbench.action.openEditorAtIndex6" },
+  { "key": "alt+7", "command": "workbench.action.openEditorAtIndex7" },
+  { "key": "alt+8", "command": "workbench.action.openEditorAtIndex8" },
+  { "key": "alt+9", "command": "workbench.action.openEditorAtIndex9" },
+  {
+    "key": "ctrl+k ctrl+s",
+    "command": "workbench.action.openGlobalKeybindings"
+  },
+  { "key": "ctrl+,", "command": "workbench.action.openGlobalSettings" },
+  { "key": "alt+0", "command": "workbench.action.openLastEditorInGroup" },
+  {
+    "key": "ctrl+tab",
+    "command": "workbench.action.openNextRecentlyUsedEditorInGroup"
+  },
+  {
+    "key": "ctrl+shift+tab",
+    "command": "workbench.action.openPreviousRecentlyUsedEditorInGroup"
+  },
+  { "key": "ctrl+r", "command": "workbench.action.openRecent" },
+  { "key": "ctrl+shift+u", "command": "workbench.action.output.toggleOutput" },
+  { "key": "ctrl+pageup", "command": "workbench.action.previousEditor" },
+  { "key": "ctrl+e", "command": "workbench.action.quickOpen" },
+  { "key": "ctrl+p", "command": "workbench.action.quickOpen" },
+  { "key": "ctrl+q", "command": "workbench.action.quickOpenView" },
+  { "key": "ctrl+shift+t", "command": "workbench.action.reopenClosedEditor" },
+  { "key": "ctrl+shift+h", "command": "workbench.action.replaceInFiles" },
+  {
+    "key": "ctrl+shift+j",
+    "command": "workbench.action.search.toggleQueryDetails",
+    "when": "searchViewletVisible"
+  },
+  { "key": "ctrl+k ctrl+t", "command": "workbench.action.selectTheme" },
+  { "key": "ctrl+k ctrl+p", "command": "workbench.action.showAllEditors" },
+  { "key": "ctrl+t", "command": "workbench.action.showAllSymbols" },
+  { "key": "f1", "command": "workbench.action.showCommands" },
+  { "key": "ctrl+shift+p", "command": "workbench.action.showCommands" },
+  { "key": "ctrl+\\", "command": "workbench.action.splitEditor" },
+  { "key": "ctrl+shift+b", "command": "workbench.action.tasks.build" },
+  {
+    "key": "ctrl+c",
+    "command": "workbench.action.terminal.copySelection",
+    "when": "terminalFocus && terminalTextSelected"
+  },
+  {
+    "key": "ctrl+backspace",
+    "command": "workbench.action.terminal.deleteWordLeft",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "ctrl+delete",
+    "command": "workbench.action.terminal.deleteWordRight",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "alt+down",
+    "command": "workbench.action.terminal.findWidget.history.showNext",
+    "when": "terminalFindWidgetInputFocused && terminalFindWidgetVisible"
+  },
+  {
+    "key": "alt+up",
+    "command": "workbench.action.terminal.findWidget.history.showPrevious",
+    "when": "terminalFindWidgetInputFocused && terminalFindWidgetVisible"
+  },
+  {
+    "key": "ctrl+f",
+    "command": "workbench.action.terminal.focusFindWidget",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "shift+escape",
+    "command": "workbench.action.terminal.hideFindWidget",
+    "when": "terminalFindWidgetVisible && terminalFocus"
+  },
+  {
+    "key": "escape",
+    "command": "workbench.action.terminal.hideFindWidget",
+    "when": "terminalFindWidgetVisible && terminalFocus"
+  },
+  { "key": "ctrl+shift+`", "command": "workbench.action.terminal.new" },
+  {
+    "key": "ctrl+shift+c",
+    "command": "workbench.action.terminal.openNativeConsole",
+    "when": "!terminalFocus"
+  },
+  {
+    "key": "ctrl+v",
+    "command": "workbench.action.terminal.paste",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "ctrl+down",
+    "command": "workbench.action.terminal.scrollDown",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "shift+pagedown",
+    "command": "workbench.action.terminal.scrollDownPage",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "ctrl+end",
+    "command": "workbench.action.terminal.scrollToBottom",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "ctrl+home",
+    "command": "workbench.action.terminal.scrollToTop",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "ctrl+up",
+    "command": "workbench.action.terminal.scrollUp",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "shift+pageup",
+    "command": "workbench.action.terminal.scrollUpPage",
+    "when": "terminalFocus"
+  },
+  { "key": "ctrl+`", "command": "workbench.action.terminal.toggleTerminal" },
+  {
+    "key": "shift+alt+1",
+    "command": "workbench.action.toggleEditorGroupLayout"
+  },
+  { "key": "f11", "command": "workbench.action.toggleFullScreen" },
+  { "key": "ctrl+j", "command": "workbench.action.togglePanel" },
+  { "key": "ctrl+b", "command": "workbench.action.toggleSidebarVisibility" },
+  { "key": "ctrl+k z", "command": "workbench.action.toggleZenMode" },
+  { "key": "ctrl+numpad_add", "command": "workbench.action.zoomIn" },
+  { "key": "ctrl+shift+=", "command": "workbench.action.zoomIn" },
+  { "key": "ctrl+=", "command": "workbench.action.zoomIn" },
+  { "key": "ctrl+numpad_subtract", "command": "workbench.action.zoomOut" },
+  { "key": "ctrl+shift+-", "command": "workbench.action.zoomOut" },
+  { "key": "ctrl+-", "command": "workbench.action.zoomOut" },
+  { "key": "ctrl+numpad0", "command": "workbench.action.zoomReset" },
+  { "key": "ctrl+shift+m", "command": "workbench.actions.view.problems" },
+  { "key": "ctrl+shift+y", "command": "workbench.debug.action.toggleRepl" },
+  {
+    "key": "ctrl+k ctrl+m",
+    "command": "workbench.extensions.action.showRecommendedKeymapExtensions"
+  },
+  { "key": "ctrl+k d", "command": "workbench.files.action.compareWithSaved" },
+  {
+    "key": "ctrl+k e",
+    "command": "workbench.files.action.focusOpenEditorsView"
+  },
+  { "key": "ctrl+shift+d", "command": "workbench.view.debug" },
+  { "key": "ctrl+shift+e", "command": "workbench.view.explorer" },
+  { "key": "ctrl+shift+x", "command": "workbench.view.extensions" },
+  { "key": "ctrl+shift+g", "command": "workbench.view.scm" },
+  {
+    "key": "ctrl+shift+f",
+    "command": "workbench.view.search",
+    "when": "!searchViewletVisible"
+  },
+  {
+    "key": "f11",
+    "command": "workbench.action.debug.stepInto",
+    "when": "inDebugMode"
+  },
+  {
+    "key": "ctrl+k",
+    "command": "workbench.action.terminal.clear",
+    "when": "terminalFocus"
+  },
+  {
+    "key": "f2",
+    "command": "debug.renameWatchExpression",
+    "when": "watchExpressionsFocused"
+  },
+  {
+    "key": "f2",
+    "command": "debug.setVariable",
+    "when": "variablesFocused"
+  },
+  {
+    "key": "space",
+    "command": "debug.toggleBreakpoint",
+    "when": "breakpointsFocused"
+  },
+  {
+    "key": "shift+alt+c",
+    "command": "copyFilePath",
+    "when": "explorerViewletFocus && explorerViewletVisible"
+  },
+  {
+    "key": "shift+delete",
+    "command": "deleteFile",
+    "when": "explorerViewletVisible && filesExplorerFocus"
+  },
+  {
+    "key": "ctrl+enter",
+    "command": "explorer.openToSide",
+    "when": "explorerViewletFocus && explorerViewletVisible"
+  },
+  {
+    "key": "ctrl+c",
+    "command": "filesExplorer.copy",
+    "when": "explorerViewletVisible && filesExplorerFocus"
+  },
+  {
+    "key": "ctrl+v",
+    "command": "filesExplorer.paste",
+    "when": "explorerViewletVisible && filesExplorerFocus"
+  },
+  {
+    "key": "delete",
+    "command": "moveFileToTrash",
+    "when": "explorerViewletVisible && filesExplorerFocus"
+  },
+  {
+    "key": "f2",
+    "command": "renameFile",
+    "when": "explorerViewletVisible && filesExplorerFocus"
+  },
+  {
+    "key": "shift+alt+r",
+    "command": "revealFileInOS",
+    "when": "explorerViewletFocus && explorerViewletVisible"
+  },
+  {
+    "key": "ctrl+tab",
+    "command": "workbench.action.quickOpenNavigateNextInEditorPicker",
+    "when": "inEditorsPicker && inQuickOpen"
+  },
+  {
+    "key": "ctrl+e",
+    "command": "workbench.action.quickOpenNavigateNextInFilePicker",
+    "when": "inFilesPicker && inQuickOpen"
+  },
+  {
+    "key": "ctrl+p",
+    "command": "workbench.action.quickOpenNavigateNextInFilePicker",
+    "when": "inFilesPicker && inQuickOpen"
+  },
+  {
+    "key": "ctrl+r",
+    "command": "workbench.action.quickOpenNavigateNextInRecentFilesPicker",
+    "when": "inQuickOpen && inRecentFilesPicker"
+  },
+  {
+    "key": "ctrl+q",
+    "command": "workbench.action.quickOpenNavigateNextInViewPicker",
+    "when": "inQuickOpen && inViewsPicker"
+  },
+  {
+    "key": "ctrl+shift+tab",
+    "command": "workbench.action.quickOpenNavigatePreviousInEditorPicker",
+    "when": "inEditorsPicker && inQuickOpen"
+  },
+  {
+    "key": "ctrl+shift+e",
+    "command": "workbench.action.quickOpenNavigatePreviousInFilePicker",
+    "when": "inFilesPicker && inQuickOpen"
+  },
+  {
+    "key": "ctrl+shift+p",
+    "command": "workbench.action.quickOpenNavigatePreviousInFilePicker",
+    "when": "inFilesPicker && inQuickOpen"
+  },
+  {
+    "key": "ctrl+shift+r",
+    "command": "workbench.action.quickOpenNavigatePreviousInRecentFilesPicker",
+    "when": "inQuickOpen && inRecentFilesPicker"
+  },
+  {
+    "key": "ctrl+shift+q",
+    "command": "workbench.action.quickOpenNavigatePreviousInViewPicker",
+    "when": "inQuickOpen && inViewsPicker"
+  },
+  {
+    "key": "ctrl+f4",
+    "command": "extension.node-debug.pickLoadedScript",
+    "when": "debugType == 'node'"
+  },
+  {
+    "key": "ctrl+f4",
+    "command": "extension.node-debug.pickLoadedScript",
+    "when": "debugType == 'node2'"
+  },
+  {
+    "key": "ctrl+shift+v",
+    "command": "markdown.showPreview",
+    "when": "editorLangId == 'markdown'"
+  },
+  {
+    "key": "ctrl+k v",
+    "command": "markdown.showPreviewToSide",
+    "when": "editorLangId == 'markdown'"
+  }
+]


### PR DESCRIPTION
### What does this PR do?
Add platform keybinding json files to our test_data directory and read the bindings from them directly.
### What issues does this PR fix or reference?
Autobuilds failing because keybinding retrieval is broken. Used to pull them from vscode-docs but they removed the files in https://github.com/Microsoft/vscode-docs/pull/1229