### PR TITLE
Fix debugger launch sequence

### DIFF
--- a/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebug.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebug.test.ts
@@ -77,21 +77,6 @@ describe('Debugger adapter - unit', () => {
     let response: DebugProtocol.InitializeResponse;
     let args: DebugProtocol.InitializeRequestArguments;
     let clock: sinon.SinonFakeTimers;
-    const initializedResponseBody = {
-      supportsCompletionsRequest: false,
-      supportsConditionalBreakpoints: false,
-      supportsDelayedStackTraceLoading: false,
-      supportsEvaluateForHovers: false,
-      supportsExceptionInfoRequest: false,
-      supportsExceptionOptions: false,
-      supportsFunctionBreakpoints: false,
-      supportsHitConditionalBreakpoints: false,
-      supportsLoadedSourcesRequest: false,
-      supportsRestartFrame: false,
-      supportsSetVariable: false,
-      supportsStepBack: false,
-      supportsStepInTargetsRequest: false
-    };
 
     beforeEach(() => {
       adapter = new ApexDebugForTest(


### PR DESCRIPTION
### What does this PR do?
I reverted some changes made in https://github.com/forcedotcom/salesforcedx-vscode/pull/194. How it used to work before that PR:
1. VS Code asks the adapter to initialize.
1. The adapter asks apex extension for line breakpoint info.
1. When the adapter gets them (could take however long), it sends an initialized response to VS Code so it can continue the launch. 

https://github.com/forcedotcom/salesforcedx-vscode/pull/194 replaced that sequence with a setTimeout so after the default timeout, the adapter checks if it has received line breakpoint info. If yes, send an initialized response to continue the launch. If not, send error message. It ensured we error out with a message if it takes too long. However, in the case where line breakpoint info is received before the timeout, we don't check until that setTimeout is triggered. So, the happy path always takes however long the default timeout is.

I'm reverting back to the old sequence while keeping the setTimeout to just check if it does not already have line breakpoint info.

### What issues does this PR fix or reference?
@W-4428718@