### PR TITLE
Remove hardcoded path in keybinding retrieval

### DIFF
--- a/packages/system-tests/src/spectron/application.ts
+++ b/packages/system-tests/src/spectron/application.ts
@@ -126,7 +126,8 @@ export class SpectronApplication {
     fs.readFile(
       path.join(
         process.cwd(),
-        `test_data/keybindings.${this.getKeybindingPlatform()}.json`
+        'test_data',
+        `keybindings.${this.getKeybindingPlatform()}.json`
       ),
       'utf8',
       (err, data) => {


### PR DESCRIPTION
### What does this PR do?
Removes hardcoded path in keybinding retrieval
### What issues does this PR fix or reference?
While path.join does normalize path segments, it would be safer not to have it hardcoded