### PR TITLE
Run single apex test with synchronous option

### DIFF
--- a/packages/salesforcedx-vscode-core/test/commands/commands.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/commands.test.ts
@@ -30,7 +30,7 @@ import { notificationService } from '../../src/notifications';
 // tslint:disable:no-unused-expression
 describe('Command Utilities', () => {
   const WORKSPACE_NAME = 'sfdx-simple';
-  const SFDX_SIMPLE_NUM_OF_DIRS = 13;
+  const SFDX_SIMPLE_NUM_OF_DIRS = 14;
   describe('EmptyParametersGatherer', () => {
     it('Should always return continue with empty object as data', async () => {
       const gatherer = new EmptyParametersGatherer();

--- a/packages/salesforcedx-vscode-core/test/commands/forceApexTestRun.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceApexTestRun.test.ts
@@ -1,0 +1,103 @@
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import {
+  ApexTestQuickPickItem,
+  ForceApexTestRunExecutor,
+  TestsSelector,
+  TestType
+} from '../../src/commands/forceApexTestRun';
+import { nls } from '../../src/messages';
+
+describe('Force Apex Test Run', () => {
+  describe('Command builder', () => {
+    const builder = new ForceApexTestRunExecutor();
+
+    it('Should build command for test suite', () => {
+      const command = builder.build({
+        label: 'MySuite',
+        description: '',
+        type: TestType.Suite
+      });
+
+      expect(command.toCommand()).to.equal(
+        'sfdx force:apex:test:run --suitenames MySuite --resultformat human'
+      );
+      expect(command.description).to.equal(
+        nls.localize('force_apex_test_run_text')
+      );
+    });
+
+    it('Should build command for single class', () => {
+      const command = builder.build({
+        label: 'MyTestClass',
+        description: '',
+        type: TestType.Class
+      });
+
+      expect(command.toCommand()).to.equal(
+        'sfdx force:apex:test:run --classnames MyTestClass --resultformat human --synchronous'
+      );
+      expect(command.description).to.equal(
+        nls.localize('force_apex_test_run_text')
+      );
+    });
+
+    it('Should build command for all tests', () => {
+      const command = builder.build({
+        label: nls.localize('force_apex_test_run_all_test_label'),
+        description: nls.localize(
+          'force_apex_test_run_all_tests_desription_text'
+        ),
+        type: TestType.All
+      });
+
+      expect(command.toCommand()).to.equal(
+        'sfdx force:apex:test:run --resultformat human'
+      );
+      expect(command.description).to.equal(
+        nls.localize('force_apex_test_run_text')
+      );
+    });
+  });
+
+  describe('Tests selector', () => {
+    let quickPickStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      quickPickStub = sinon.stub(vscode.window, 'showQuickPick').returns({
+        label: nls.localize('force_apex_test_run_all_test_label'),
+        description: nls.localize(
+          'force_apex_test_run_all_tests_desription_text'
+        ),
+        type: TestType.All
+      });
+    });
+
+    afterEach(() => {
+      quickPickStub.restore();
+    });
+
+    it('Should have test suite and class', async () => {
+      const gatherer = new TestsSelector();
+      const result = await gatherer.gather();
+
+      expect(result.type).to.equal('CONTINUE');
+      expect(quickPickStub.getCall(0).args.length).to.equal(1);
+      const fileItems: ApexTestQuickPickItem[] = quickPickStub.getCall(0)
+        .args[0];
+      expect(fileItems.length).to.equal(3);
+      expect(fileItems[0].label).to.equal('DemoSuite');
+      expect(fileItems[0].type).to.equal(TestType.Suite);
+      expect(fileItems[1].label).to.equal('DemoControllerTests');
+      expect(fileItems[1].type).to.equal(TestType.Class);
+      expect(fileItems[2].label).to.equal(
+        nls.localize('force_apex_test_run_all_test_label')
+      );
+      expect(fileItems[2].description).to.equal(
+        nls.localize('force_apex_test_run_all_tests_desription_text')
+      );
+      expect(fileItems[2].type).to.equal(TestType.All);
+    });
+  });
+});

--- a/packages/system-tests/assets/sfdx-simple/force-app/test/default/testSuites/DemoSuite.testSuite-meta.xml
+++ b/packages/system-tests/assets/sfdx-simple/force-app/test/default/testSuites/DemoSuite.testSuite-meta.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTestSuite xmlns="http://soap.sforce.com/2006/04/metadata">
+    <testClassName>DemoControllerTests</testClassName>
+</ApexTestSuite>


### PR DESCRIPTION
### What does this PR do?
This adds the ability to run force:apex:test:run command with a single Apex class. The command always executes with --synchronous option so the test is debuggable.

![debugapextest](https://user-images.githubusercontent.com/7286437/32354206-f3290892-bfe5-11e7-9207-175410457dad.gif)


### What issues does this PR fix or reference?
@W-4337479@