### PR TITLE
Exception breakpoints

### DIFF
--- a/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
+++ b/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
@@ -26,6 +26,7 @@ import {
   Variable
 } from 'vscode-debugadapter';
 import { DebugProtocol } from 'vscode-debugprotocol';
+import { ExceptionBreakpointInfo } from '../breakpoints/exceptionBreakpoint';
 import {
   LineBreakpointInfo,
   LineBreakpointsInTyperef
@@ -50,6 +51,7 @@ import {
 import {
   DEFAULT_INITIALIZE_TIMEOUT_MS,
   DEFAULT_LOCK_TIMEOUT_MS,
+  EXCEPTION_BREAKPOINT_REQUEST,
   GET_LINE_BREAKPOINT_INFO_EVENT,
   GET_WORKSPACE_SETTINGS_EVENT,
   HOTSWAP_REQUEST,
@@ -95,6 +97,10 @@ export interface LaunchRequestArguments
   requestTypeFilter?: string[];
   entryPointFilter?: string;
   sfdxProject: string;
+}
+
+export interface SetExceptionBreakpointsArguments {
+  exceptionInfo: ExceptionBreakpointInfo;
 }
 
 export class ApexDebugStackFrameInfo {
@@ -716,6 +722,13 @@ export class ApexDebug extends LoggingDebugSession {
     this.sendResponse(response);
   }
 
+  protected setExceptionBreakpointRequest(
+    response: DebugProtocol.Response,
+    args: SetExceptionBreakpointsArguments
+  ): void {
+    response.success = true;
+  }
+
   protected async continueRequest(
     response: DebugProtocol.ContinueResponse,
     args: DebugProtocol.ContinueArguments
@@ -976,6 +989,12 @@ export class ApexDebug extends LoggingDebugSession {
         this.myRequestService.proxyAuthorization = workspaceSettings.proxyAuth;
         this.myRequestService.connectionTimeoutMs =
           workspaceSettings.connectionTimeoutMs;
+        break;
+      case EXCEPTION_BREAKPOINT_REQUEST:
+        const requestArgs: SetExceptionBreakpointsArguments = args;
+        if (requestArgs) {
+          this.setExceptionBreakpointRequest(response, requestArgs);
+        }
         break;
       default:
         break;

--- a/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
+++ b/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
@@ -51,6 +51,8 @@ import {
 import {
   DEFAULT_INITIALIZE_TIMEOUT_MS,
   DEFAULT_LOCK_TIMEOUT_MS,
+  EXCEPTION_BREAKPOINT_BREAK_MODE_ALWAYS,
+  EXCEPTION_BREAKPOINT_BREAK_MODE_NEVER,
   EXCEPTION_BREAKPOINT_REQUEST,
   GET_LINE_BREAKPOINT_INFO_EVENT,
   GET_WORKSPACE_SETTINGS_EVENT,
@@ -996,6 +998,27 @@ export class ApexDebug extends LoggingDebugSession {
                 requestArgs.exceptionInfo
               );
             });
+            if (
+              requestArgs.exceptionInfo.breakMode ===
+              EXCEPTION_BREAKPOINT_BREAK_MODE_ALWAYS
+            ) {
+              this.printToDebugConsole(
+                nls.localize(
+                  'created_exception_breakpoint_text',
+                  requestArgs.exceptionInfo.label
+                )
+              );
+            } else if (
+              requestArgs.exceptionInfo.breakMode ===
+              EXCEPTION_BREAKPOINT_BREAK_MODE_NEVER
+            ) {
+              this.printToDebugConsole(
+                nls.localize(
+                  'removed_exception_breakpoint_text',
+                  requestArgs.exceptionInfo.label
+                )
+              );
+            }
           } catch (error) {
             response.success = false;
             this.log(

--- a/packages/salesforcedx-apex-debugger/src/breakpoints/exceptionBreakpoint.ts
+++ b/packages/salesforcedx-apex-debugger/src/breakpoints/exceptionBreakpoint.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+export interface ExceptionBreakpointInfo {
+  label: string;
+  typeref: string;
+  breakMode: string;
+  uri?: string;
+}

--- a/packages/salesforcedx-apex-debugger/src/constants.ts
+++ b/packages/salesforcedx-apex-debugger/src/constants.ts
@@ -17,4 +17,6 @@ export const HOTSWAP_REQUEST = 'hotswap';
 export const WORKSPACE_SETTINGS_REQUEST = 'workspaceSettings';
 export const EXCEPTION_BREAKPOINT_REQUEST = 'exceptionBreakpoint';
 export const LIST_EXCEPTION_BREAKPOINTS_REQUEST = 'listExceptionBreakpoints';
+export const EXCEPTION_BREAKPOINT_BREAK_MODE_ALWAYS = 'always';
+export const EXCEPTION_BREAKPOINT_BREAK_MODE_NEVER = 'never';
 export const CLIENT_ID = 'sfdx-vscode';

--- a/packages/salesforcedx-apex-debugger/src/constants.ts
+++ b/packages/salesforcedx-apex-debugger/src/constants.ts
@@ -15,4 +15,5 @@ export const GET_WORKSPACE_SETTINGS_EVENT = 'getWorkspaceSettings';
 export const LINE_BREAKPOINT_INFO_REQUEST = 'lineBreakpointInfo';
 export const HOTSWAP_REQUEST = 'hotswap';
 export const WORKSPACE_SETTINGS_REQUEST = 'workspaceSettings';
+export const EXCEPTION_BREAKPOINT_REQUEST = 'exceptionBreakpoint';
 export const CLIENT_ID = 'sfdx-vscode';

--- a/packages/salesforcedx-apex-debugger/src/constants.ts
+++ b/packages/salesforcedx-apex-debugger/src/constants.ts
@@ -16,4 +16,5 @@ export const LINE_BREAKPOINT_INFO_REQUEST = 'lineBreakpointInfo';
 export const HOTSWAP_REQUEST = 'hotswap';
 export const WORKSPACE_SETTINGS_REQUEST = 'workspaceSettings';
 export const EXCEPTION_BREAKPOINT_REQUEST = 'exceptionBreakpoint';
+export const LIST_EXCEPTION_BREAKPOINTS_REQUEST = 'listExceptionBreakpoints';
 export const CLIENT_ID = 'sfdx-vscode';

--- a/packages/salesforcedx-apex-debugger/src/core/breakpointService.ts
+++ b/packages/salesforcedx-apex-debugger/src/core/breakpointService.ts
@@ -284,5 +284,6 @@ export class BreakpointService {
 
   public clearSavedBreakpoints(): void {
     this.lineBreakpointCache.clear();
+    this.exceptionBreakpointCache.clear();
   }
 }

--- a/packages/salesforcedx-apex-debugger/src/index.ts
+++ b/packages/salesforcedx-apex-debugger/src/index.ts
@@ -6,6 +6,7 @@
  */
 
 export * from './constants';
+export { SetExceptionBreakpointsArguments } from './adapter/apexDebug';
 
 export enum VscodeDebuggerMessageType {
   Info,

--- a/packages/salesforcedx-apex-debugger/src/messages/i18n.ts
+++ b/packages/salesforcedx-apex-debugger/src/messages/i18n.ts
@@ -30,5 +30,7 @@ export const messages = {
   streaming_handshake_timeout_text:
     'Streaming API handshake failed due to a socket timeout. Check your connection and try again.',
   hotswap_warn_text:
-    "You can't modify Apex classes or triggers during an Apex Debugger session. Save your changes after you're done debugging."
+    "You can't modify Apex classes or triggers during an Apex Debugger session. Save your changes after you're done debugging.",
+  created_exception_breakpoint_text: 'Created exception breakpoint for %s.',
+  removed_exception_breakpoint_text: 'Removed exception breakpoint for %s'
 };

--- a/packages/salesforcedx-apex-debugger/src/messages/i18n.ts
+++ b/packages/salesforcedx-apex-debugger/src/messages/i18n.ts
@@ -32,5 +32,5 @@ export const messages = {
   hotswap_warn_text:
     "You can't modify Apex classes or triggers during an Apex Debugger session. Save your changes after you're done debugging.",
   created_exception_breakpoint_text: 'Created exception breakpoint for %s.',
-  removed_exception_breakpoint_text: 'Removed exception breakpoint for %s'
+  removed_exception_breakpoint_text: 'Removed exception breakpoint for %s.'
 };

--- a/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebug.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebug.test.ts
@@ -629,7 +629,7 @@ describe('Debugger adapter - unit', () => {
       );
       breakpointCacheSpy = sinon.spy(
         BreakpointService.prototype,
-        'cacheBreakpoint'
+        'cacheLineBreakpoint'
       );
       sessionIdSpy = sinon
         .stub(SessionService.prototype, 'getSessionId')
@@ -660,7 +660,7 @@ describe('Debugger adapter - unit', () => {
     it('Should create breakpoint', async () => {
       const bpLines = [1, 2];
       breakpointReconcileSpy = sinon
-        .stub(BreakpointService.prototype, 'reconcileBreakpoints')
+        .stub(BreakpointService.prototype, 'reconcileLineBreakpoints')
         .returns(Promise.resolve(new Set().add(1)));
       adapter.setSfdxProject('someProjectPath');
 
@@ -715,7 +715,7 @@ describe('Debugger adapter - unit', () => {
     it('Should not create breakpoint without source argument', async () => {
       const bpLines = [1, 2];
       breakpointReconcileSpy = sinon
-        .stub(BreakpointService.prototype, 'reconcileBreakpoints')
+        .stub(BreakpointService.prototype, 'reconcileLineBreakpoints')
         .returns(Promise.resolve(bpLines));
       adapter.setSfdxProject('someProjectPath');
 
@@ -743,7 +743,7 @@ describe('Debugger adapter - unit', () => {
     it('Should not create breakpoint without lines argument', async () => {
       const bpLines = [1, 2];
       breakpointReconcileSpy = sinon
-        .stub(BreakpointService.prototype, 'reconcileBreakpoints')
+        .stub(BreakpointService.prototype, 'reconcileLineBreakpoints')
         .returns(Promise.resolve(bpLines));
       adapter.setSfdxProject('someProjectPath');
 

--- a/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebugForTest.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebugForTest.ts
@@ -131,11 +131,11 @@ export class ApexDebugForTest extends ApexDebug {
     return super.stackTraceRequest(response, args);
   }
 
-  public customRequest(
+  public async customRequest(
     command: string,
     response: DebugProtocol.Response,
     args: any
-  ): void {
+  ): Promise<void> {
     return super.customRequest(command, response, args);
   }
 

--- a/packages/salesforcedx-apex-debugger/test/unit/core/breakpointService.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/core/breakpointService.test.ts
@@ -105,33 +105,33 @@ describe('Debugger breakpoint service', () => {
         { line: 3, breakpointId: '07bFAKE3' }
       ]);
 
-      service.cacheBreakpoint('file:///foo.cls', 1, '07bFAKE1');
-      service.cacheBreakpoint('file:///foo.cls', 2, '07bFAKE2');
-      service.cacheBreakpoint('file:///bar.cls', 3, '07bFAKE3');
+      service.cacheLineBreakpoint('file:///foo.cls', 1, '07bFAKE1');
+      service.cacheLineBreakpoint('file:///foo.cls', 2, '07bFAKE2');
+      service.cacheLineBreakpoint('file:///bar.cls', 3, '07bFAKE3');
 
-      expect(service.getBreakpointCache()).to.deep.equal(expectedCache);
+      expect(service.getLineBreakpointCache()).to.deep.equal(expectedCache);
     });
 
     it('Should clear cached breakpoints', () => {
-      service.cacheBreakpoint('file:///foo.cls', 1, '07bFAKE1');
+      service.cacheLineBreakpoint('file:///foo.cls', 1, '07bFAKE1');
 
       service.clearSavedBreakpoints();
 
-      expect(service.getBreakpointCache().size).to.equal(0);
+      expect(service.getLineBreakpointCache().size).to.equal(0);
     });
 
     it('Should find existing breakpoints', () => {
-      service.cacheBreakpoint('file:///foo.cls', 1, '07bFAKE1');
-      service.cacheBreakpoint('file:///foo.cls', 2, '07bFAKE2');
-      service.cacheBreakpoint('file:///bar.cls', 3, '07bFAKE3');
+      service.cacheLineBreakpoint('file:///foo.cls', 1, '07bFAKE1');
+      service.cacheLineBreakpoint('file:///foo.cls', 2, '07bFAKE2');
+      service.cacheLineBreakpoint('file:///bar.cls', 3, '07bFAKE3');
 
       const savedBreakpoints = service.getBreakpointsFor('file:///foo.cls');
       expect(savedBreakpoints).to.have.all.keys([1, 2]);
     });
 
     it('Should not find existing breakpoints', () => {
-      service.cacheBreakpoint('file:///foo.cls', 1, '07bFAKE1');
-      service.cacheBreakpoint('file:///foo.cls', 2, '07bFAKE2');
+      service.cacheLineBreakpoint('file:///foo.cls', 1, '07bFAKE1');
+      service.cacheLineBreakpoint('file:///foo.cls', 2, '07bFAKE2');
 
       const savedBreakpoints = service.getBreakpointsFor('file:///bar.cls');
       expect(savedBreakpoints.size).to.equal(0);
@@ -273,7 +273,7 @@ describe('Debugger breakpoint service', () => {
     it('Should delete successfully', async () => {
       mySpawn.setDefault(mySpawn.simple(0, '{"result":{"id":"07bFAKE"}}'));
 
-      const cmdOutput = await service.deleteLineBreakpoint(
+      const cmdOutput = await service.deleteBreakpoint(
         'someProjectPath',
         '07bFAKE'
       );
@@ -301,7 +301,7 @@ describe('Debugger breakpoint service', () => {
       mySpawn.setDefault(mySpawn.simple(0, '{"result":{"id":"FAKE"}}'));
 
       try {
-        await service.deleteLineBreakpoint('someProjectPath', '07bFAKE');
+        await service.deleteBreakpoint('someProjectPath', '07bFAKE');
         expect.fail('Should have failed');
       } catch (error) {
         expect(error).to.equal('{"result":{"id":"FAKE"}}');
@@ -312,7 +312,7 @@ describe('Debugger breakpoint service', () => {
       mySpawn.setDefault(mySpawn.simple(0, '{"result":{"notid":"FAKE"}}'));
 
       try {
-        await service.deleteLineBreakpoint('someProjectPath', '07bFAKE');
+        await service.deleteBreakpoint('someProjectPath', '07bFAKE');
         expect.fail('Should have failed');
       } catch (error) {
         expect(error).to.equal('{"result":{"notid":"FAKE"}}');
@@ -329,7 +329,7 @@ describe('Debugger breakpoint service', () => {
       );
 
       try {
-        await service.deleteLineBreakpoint('someProjectPath', '07bFAKE');
+        await service.deleteBreakpoint('someProjectPath', '07bFAKE');
         expect.fail('Should have failed');
       } catch (error) {
         expect(error).to.equal(
@@ -346,10 +346,10 @@ describe('Debugger breakpoint service', () => {
 
     beforeEach(() => {
       service = new BreakpointService();
-      service.cacheBreakpoint('file:///foo.cls', 3, '07bFAKE3');
-      service.cacheBreakpoint('file:///foo.cls', 4, '07bFAKE4');
-      service.cacheBreakpoint('file:///foo.cls', 5, '07bFAKE5');
-      service.cacheBreakpoint('file:///bar.cls', 1, '07bFAKE6');
+      service.cacheLineBreakpoint('file:///foo.cls', 3, '07bFAKE3');
+      service.cacheLineBreakpoint('file:///foo.cls', 4, '07bFAKE4');
+      service.cacheLineBreakpoint('file:///foo.cls', 5, '07bFAKE5');
+      service.cacheLineBreakpoint('file:///bar.cls', 1, '07bFAKE6');
     });
 
     afterEach(() => {
@@ -375,7 +375,7 @@ describe('Debugger breakpoint service', () => {
         .onSecondCall()
         .returns(Promise.resolve('07bFAKE2'));
       deleteLineBreakpointSpy = sinon
-        .stub(BreakpointService.prototype, 'deleteLineBreakpoint')
+        .stub(BreakpointService.prototype, 'deleteBreakpoint')
         .onFirstCall()
         .returns(Promise.resolve('07bFAKE4'))
         .onSecondCall()
@@ -390,7 +390,7 @@ describe('Debugger breakpoint service', () => {
         { line: 1, breakpointId: '07bFAKE6' }
       ]);
 
-      const bpsToCreate = await service.reconcileBreakpoints(
+      const bpsToCreate = await service.reconcileLineBreakpoints(
         'someProjectPath',
         'file:///foo.cls',
         '07aFAKE',
@@ -420,7 +420,7 @@ describe('Debugger breakpoint service', () => {
         'someProjectPath',
         '07bFAKE4'
       ]);
-      expect(service.getBreakpointCache()).to.deep.equal(expectedCache);
+      expect(service.getLineBreakpointCache()).to.deep.equal(expectedCache);
     });
 
     it('Should not create breakpoints without known typeref', async () => {
@@ -432,7 +432,7 @@ describe('Debugger breakpoint service', () => {
         'createLineBreakpoint'
       );
       deleteLineBreakpointSpy = sinon
-        .stub(BreakpointService.prototype, 'deleteLineBreakpoint')
+        .stub(BreakpointService.prototype, 'deleteBreakpoint')
         .onFirstCall()
         .returns(Promise.resolve('07bFAKE4'))
         .onSecondCall()
@@ -445,7 +445,7 @@ describe('Debugger breakpoint service', () => {
         { line: 1, breakpointId: '07bFAKE6' }
       ]);
 
-      const bpsToCreate = await service.reconcileBreakpoints(
+      const bpsToCreate = await service.reconcileLineBreakpoints(
         'someProjectPath',
         'file:///foo.cls',
         '07aFAKE',
@@ -463,7 +463,7 @@ describe('Debugger breakpoint service', () => {
         'someProjectPath',
         '07bFAKE4'
       ]);
-      expect(service.getBreakpointCache()).to.deep.equal(expectedCache);
+      expect(service.getLineBreakpointCache()).to.deep.equal(expectedCache);
     });
   });
 });

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -159,8 +159,7 @@
     "menus": {
       "commandPalette": [
         {
-          "command": "sfdx.debug.exception.breakpoint",
-          "when": "apex_debug_start"
+          "command": "sfdx.debug.exception.breakpoint"
         }
       ]
     },

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -22,7 +22,8 @@
   },
   "categories": ["Debuggers"],
   "dependencies": {
-    "@salesforce/salesforcedx-apex-debugger": "41.8.1"
+    "@salesforce/salesforcedx-apex-debugger": "41.8.1",
+    "vscode-debugprotocol": "1.24.0"
   },
   "devDependencies": {
     "@salesforce/salesforcedx-utils-vscode": "41.8.1",
@@ -152,6 +153,19 @@
             }
           }
         }
+      }
+    ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "sfdx.debug.exception.breakpoint"
+        }
+      ]
+    },
+    "commands": [
+      {
+        "command": "sfdx.debug.exception.breakpoint",
+        "title": "%exception_breakpoint_command_text%"
       }
     ]
   }

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -22,14 +22,15 @@
   },
   "categories": ["Debuggers"],
   "dependencies": {
+    "@salesforce/salesforcedx-utils-vscode": "41.8.1",
     "@salesforce/salesforcedx-apex-debugger": "41.8.1",
     "vscode-debugprotocol": "1.24.0"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-utils-vscode": "41.8.1",
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
     "@types/sinon": "^2.3.2",
+    "@types/node": "^6.0.40",
     "chai": "^4.0.2",
     "mocha": "3.2.0",
     "sinon": "^2.3.6",
@@ -158,7 +159,8 @@
     "menus": {
       "commandPalette": [
         {
-          "command": "sfdx.debug.exception.breakpoint"
+          "command": "sfdx.debug.exception.breakpoint",
+          "when": "apex_debug_start"
         }
       ]
     },

--- a/packages/salesforcedx-vscode-apex-debugger/package.nls.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.nls.json
@@ -14,5 +14,6 @@
     "Produce diagnostic output. Instead of setting this to true you can list one or more selectors separated with commas. The 'all' selector enables very detailed output. Other selectors are 'protocol', 'variables', 'launch'",
   "configuration_title": "Salesforce Apex Debugger Configuration",
   "connection_timeout_ms_description":
-    "Connection timeout for Apex Debugger API requests (in milliseconds)."
+    "Connection timeout for Apex Debugger API requests (in milliseconds).",
+  "exception_breakpoint_command_text": "Apex Debug: Configure Exceptions"
 }

--- a/packages/salesforcedx-vscode-apex-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-debugger/src/index.ts
@@ -146,7 +146,7 @@ export async function configureExceptionBreakpoint(): Promise<void> {
     const enabledExceptionBreakpoints = await vscode.debug.activeDebugSession.customRequest(
       LIST_EXCEPTION_BREAKPOINTS_REQUEST
     );
-    const processedBreakpointInfos = reconcileExceptionBreakpoints(
+    const processedBreakpointInfos = mergeExceptionBreakpointInfos(
       exceptionBreakpointInfos,
       enabledExceptionBreakpoints
     );
@@ -181,7 +181,7 @@ export async function configureExceptionBreakpoint(): Promise<void> {
   }
 }
 
-export function reconcileExceptionBreakpoints(
+export function mergeExceptionBreakpointInfos(
   breakpointInfos: ExceptionBreakpointItem[],
   enabledBreakpoints: any
 ): ExceptionBreakpointItem[] {

--- a/packages/salesforcedx-vscode-apex-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-debugger/src/index.ts
@@ -136,7 +136,7 @@ const EXCEPTION_BREAK_MODES: BreakModeItem[] = [
   }
 ];
 
-export async function configureExceptionBreakpoint(): Promise<void> {
+async function configureExceptionBreakpoint(): Promise<void> {
   const sfdxApex = vscode.extensions.getExtension(
     'salesforce.salesforcedx-vscode-apex'
   );

--- a/packages/salesforcedx-vscode-apex-debugger/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-apex-debugger/src/messages/i18n.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * Conventions:
+ * _message: is for unformatted text that will be shown as-is to
+ * the user.
+ * _text: is for text that will appear in the UI, possibly with
+ * decorations, e.g., $(x) uses the https://octicons.github.com/ and should not
+ * be localized
+ *
+ * If ommitted, we will assume _message.
+ */
+export const messages = {
+  select_exception_text: 'Select an exception',
+  select_break_option_text: 'Select break option',
+  always_break_text: 'Always break',
+  never_break_text: 'Never break'
+};

--- a/packages/salesforcedx-vscode-apex-debugger/src/messages/index.ts
+++ b/packages/salesforcedx-vscode-apex-debugger/src/messages/index.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  BASE_FILE_EXTENSION,
+  BASE_FILE_NAME,
+  Config,
+  DEFAULT_LOCALE,
+  Localization,
+  Message
+} from '@salesforce/salesforcedx-utils-vscode/out/src/i18n';
+
+function loadMessageBundle(config?: Config): Message {
+  function resolveFileName(locale: string): string {
+    return locale === DEFAULT_LOCALE
+      ? `${BASE_FILE_NAME}.${BASE_FILE_EXTENSION}`
+      : `${BASE_FILE_NAME}.${locale}.${BASE_FILE_EXTENSION}`;
+  }
+
+  const base = new Message(
+    require(`./${resolveFileName(DEFAULT_LOCALE)}`).messages
+  );
+
+  if (config && config.locale && config.locale !== DEFAULT_LOCALE) {
+    try {
+      const layer = new Message(
+        require(`./${resolveFileName(config.locale)}`).messages,
+        base
+      );
+      return layer;
+    } catch (e) {
+      console.error(`Cannot find ${config.locale}, defaulting to en`);
+      return base;
+    }
+  } else {
+    return base;
+  }
+}
+
+export const nls = new Localization(
+  loadMessageBundle(JSON.parse(process.env.VSCODE_NLS_CONFIG))
+);

--- a/packages/salesforcedx-vscode-apex-debugger/test/index.test.ts
+++ b/packages/salesforcedx-vscode-apex-debugger/test/index.test.ts
@@ -1,6 +1,15 @@
+import {
+  EXCEPTION_BREAKPOINT_BREAK_MODE_ALWAYS,
+  EXCEPTION_BREAKPOINT_BREAK_MODE_NEVER
+} from '@salesforce/salesforcedx-apex-debugger/out/src';
 import { expect } from 'chai';
 import * as vscode from 'vscode';
-import { ApexDebuggerConfigurationProvider } from '../src/index';
+import {
+  ApexDebuggerConfigurationProvider,
+  ExceptionBreakpointItem,
+  mergeExceptionBreakpointInfos
+} from '../src/index';
+import { nls } from '../src/messages';
 
 describe('Extension Setup', () => {
   describe('Configuration provider', () => {
@@ -47,6 +56,99 @@ describe('Extension Setup', () => {
       const configs = provider.provideDebugConfigurations(undefined);
 
       expect(configs).to.deep.equal([expectedConfig]);
+    });
+  });
+
+  describe('Exception breakpoint', () => {
+    describe('Merge breakpoint infos', () => {
+      let breakpointInfos: ExceptionBreakpointItem[] = [];
+
+      beforeEach(() => {
+        breakpointInfos = [
+          {
+            typeref: 'barexception',
+            label: 'barexception',
+            uri: 'file:///barexception.cls',
+            breakMode: EXCEPTION_BREAKPOINT_BREAK_MODE_NEVER,
+            description: ''
+          },
+          {
+            typeref: 'fooexception',
+            label: 'fooexception',
+            uri: 'file:///fooexception.cls',
+            breakMode: EXCEPTION_BREAKPOINT_BREAK_MODE_NEVER,
+            description: ''
+          },
+          {
+            typeref: 'com/salesforce/api/exception/NullPointerException',
+            label: 'System.NullPointerException',
+            breakMode: EXCEPTION_BREAKPOINT_BREAK_MODE_NEVER,
+            description: ''
+          }
+        ];
+      });
+      it('Should order breakpoints by enabled first', () => {
+        const enabledBreakpoints = {
+          typerefs: ['com/salesforce/api/exception/NullPointerException']
+        };
+
+        const exceptionBreakpointQuickPicks = mergeExceptionBreakpointInfos(
+          breakpointInfos,
+          enabledBreakpoints
+        );
+
+        expect(exceptionBreakpointQuickPicks.length).to.equal(3);
+        expect(exceptionBreakpointQuickPicks[0].typeref).to.equal(
+          'com/salesforce/api/exception/NullPointerException'
+        );
+        expect(exceptionBreakpointQuickPicks[0].breakMode).to.equal(
+          EXCEPTION_BREAKPOINT_BREAK_MODE_ALWAYS
+        );
+        expect(exceptionBreakpointQuickPicks[0].description).to.equal(
+          `$(stop) ${nls.localize('always_break_text')}`
+        );
+        expect(exceptionBreakpointQuickPicks[1].typeref).to.equal(
+          'barexception'
+        );
+        expect(exceptionBreakpointQuickPicks[1].breakMode).to.equal(
+          EXCEPTION_BREAKPOINT_BREAK_MODE_NEVER
+        );
+        expect(exceptionBreakpointQuickPicks[2].typeref).to.equal(
+          'fooexception'
+        );
+        expect(exceptionBreakpointQuickPicks[2].breakMode).to.equal(
+          EXCEPTION_BREAKPOINT_BREAK_MODE_NEVER
+        );
+      });
+
+      it('Should not modify breakpoint infos if there is no enabled breakpoints', () => {
+        const exceptionBreakpointQuickPicks = mergeExceptionBreakpointInfos(
+          breakpointInfos,
+          undefined
+        );
+
+        expect(exceptionBreakpointQuickPicks).to.deep.equal(breakpointInfos);
+      });
+
+      it('Should not modify breakpoint infos if enabled breakpoints has undefined typerefs', () => {
+        const exceptionBreakpointQuickPicks = mergeExceptionBreakpointInfos(
+          breakpointInfos,
+          {}
+        );
+
+        expect(exceptionBreakpointQuickPicks).to.deep.equal(breakpointInfos);
+      });
+
+      it('Should not modify breakpoint infos if enabled breakpoints has empty typerefs', () => {
+        const exceptionBreakpointQuickPicks = mergeExceptionBreakpointInfos(
+          breakpointInfos,
+          {
+            typerefs: []
+          }
+        );
+
+        expect(exceptionBreakpointQuickPicks).to.deep.equal(breakpointInfos);
+      });
     });
   });
 });

--- a/packages/salesforcedx-vscode-apex-debugger/test/index.test.ts
+++ b/packages/salesforcedx-vscode-apex-debugger/test/index.test.ts
@@ -7,7 +7,9 @@ import * as vscode from 'vscode';
 import {
   ApexDebuggerConfigurationProvider,
   ExceptionBreakpointItem,
-  mergeExceptionBreakpointInfos
+  getExceptionBreakpointCache,
+  mergeExceptionBreakpointInfos,
+  updateExceptionBreakpointCache
 } from '../src/index';
 import { nls } from '../src/messages';
 
@@ -88,13 +90,9 @@ describe('Extension Setup', () => {
         ];
       });
       it('Should order breakpoints by enabled first', () => {
-        const enabledBreakpoints = {
-          typerefs: ['com/salesforce/api/exception/NullPointerException']
-        };
-
         const exceptionBreakpointQuickPicks = mergeExceptionBreakpointInfos(
           breakpointInfos,
-          enabledBreakpoints
+          ['com/salesforce/api/exception/NullPointerException']
         );
 
         expect(exceptionBreakpointQuickPicks.length).to.equal(3);
@@ -121,33 +119,97 @@ describe('Extension Setup', () => {
         );
       });
 
-      it('Should not modify breakpoint infos if there is no enabled breakpoints', () => {
-        const exceptionBreakpointQuickPicks = mergeExceptionBreakpointInfos(
-          breakpointInfos,
-          undefined
-        );
-
-        expect(exceptionBreakpointQuickPicks).to.deep.equal(breakpointInfos);
-      });
-
-      it('Should not modify breakpoint infos if enabled breakpoints has undefined typerefs', () => {
-        const exceptionBreakpointQuickPicks = mergeExceptionBreakpointInfos(
-          breakpointInfos,
-          {}
-        );
-
-        expect(exceptionBreakpointQuickPicks).to.deep.equal(breakpointInfos);
-      });
-
       it('Should not modify breakpoint infos if enabled breakpoints has empty typerefs', () => {
         const exceptionBreakpointQuickPicks = mergeExceptionBreakpointInfos(
           breakpointInfos,
-          {
-            typerefs: []
-          }
+          []
         );
 
         expect(exceptionBreakpointQuickPicks).to.deep.equal(breakpointInfos);
+      });
+    });
+
+    describe('Update cache', () => {
+      beforeEach(() => {
+        getExceptionBreakpointCache().clear();
+      });
+
+      it('Should add new breakpoint', () => {
+        updateExceptionBreakpointCache({
+          typeref: 'barexception',
+          label: 'barexception',
+          uri: 'file:///barexception.cls',
+          breakMode: EXCEPTION_BREAKPOINT_BREAK_MODE_ALWAYS,
+          description: ''
+        });
+
+        expect(getExceptionBreakpointCache().size).to.equal(1);
+      });
+
+      it('Should not add existing breakpoint', () => {
+        updateExceptionBreakpointCache({
+          typeref: 'barexception',
+          label: 'barexception',
+          uri: 'file:///barexception.cls',
+          breakMode: EXCEPTION_BREAKPOINT_BREAK_MODE_ALWAYS,
+          description: ''
+        });
+
+        expect(getExceptionBreakpointCache().size).to.equal(1);
+
+        updateExceptionBreakpointCache({
+          typeref: 'barexception',
+          label: 'barexception',
+          uri: 'file:///barexception.cls',
+          breakMode: EXCEPTION_BREAKPOINT_BREAK_MODE_ALWAYS,
+          description: ''
+        });
+
+        expect(getExceptionBreakpointCache().size).to.equal(1);
+      });
+
+      it('Should remove existing breakpoint', () => {
+        updateExceptionBreakpointCache({
+          typeref: 'barexception',
+          label: 'barexception',
+          uri: 'file:///barexception.cls',
+          breakMode: EXCEPTION_BREAKPOINT_BREAK_MODE_ALWAYS,
+          description: ''
+        });
+
+        expect(getExceptionBreakpointCache().size).to.equal(1);
+
+        updateExceptionBreakpointCache({
+          typeref: 'barexception',
+          label: 'barexception',
+          uri: 'file:///barexception.cls',
+          breakMode: EXCEPTION_BREAKPOINT_BREAK_MODE_NEVER,
+          description: ''
+        });
+
+        expect(getExceptionBreakpointCache().size).to.equal(0);
+      });
+
+      it('Should not remove nonexisting breakpoint', () => {
+        updateExceptionBreakpointCache({
+          typeref: 'barexception',
+          label: 'barexception',
+          uri: 'file:///barexception.cls',
+          breakMode: EXCEPTION_BREAKPOINT_BREAK_MODE_ALWAYS,
+          description: ''
+        });
+
+        expect(getExceptionBreakpointCache().size).to.equal(1);
+
+        updateExceptionBreakpointCache({
+          typeref: 'fooexception',
+          label: 'fooexception',
+          uri: 'file:///fooexception.cls',
+          breakMode: EXCEPTION_BREAKPOINT_BREAK_MODE_NEVER,
+          description: ''
+        });
+
+        expect(getExceptionBreakpointCache().size).to.equal(1);
       });
     });
   });

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -76,19 +76,6 @@
         "scopeName": "source.apex",
         "path": "./syntaxes/apex.tmLanguage"
       }
-    ],
-    "menus": {
-      "commandPalette": [
-        {
-          "command": "sfdx.debug.exception.breakpoint"
-        }
-      ]
-    },
-    "commands": [
-      {
-        "command": "sfdx.debug.exception.breakpoint",
-        "title": "Apex Debug: Get Exception Breakpoint Info"
-      }
     ]
   },
   "dependencies": {

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -76,6 +76,19 @@
         "scopeName": "source.apex",
         "path": "./syntaxes/apex.tmLanguage"
       }
+    ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "sfdx.debug.exception.breakpoint"
+        }
+      ]
+    },
+    "commands": [
+      {
+        "command": "sfdx.debug.exception.breakpoint",
+        "title": "Apex Debug: Get Exception Breakpoint Info"
+      }
     ]
   },
   "dependencies": {

--- a/packages/salesforcedx-vscode-apex/src/constants.ts
+++ b/packages/salesforcedx-vscode-apex/src/constants.ts
@@ -6,3 +6,4 @@
  */
 
 export const DEBUGGER_LINE_BREAKPOINTS = 'debugger/lineBreakpoints';
+export const DEBUGGER_EXCEPTION_BREAKPOINTS = 'debugger/exceptionBreakpoints';

--- a/packages/salesforcedx-vscode-apex/src/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/index.ts
@@ -7,7 +7,10 @@
 
 import * as vscode from 'vscode';
 import { LanguageClient } from 'vscode-languageclient';
-import { DEBUGGER_LINE_BREAKPOINTS } from './constants';
+import {
+  DEBUGGER_EXCEPTION_BREAKPOINTS,
+  DEBUGGER_LINE_BREAKPOINTS
+} from './constants';
 import * as languageServer from './languageServer';
 
 let languageClient: LanguageClient | undefined;
@@ -16,6 +19,12 @@ export async function activate(context: vscode.ExtensionContext) {
   languageClient = await languageServer.createLanguageServer(context);
   const handle = languageClient.start();
   context.subscriptions.push(handle);
+
+  const getExceptionBreakpointInfoCmd = vscode.commands.registerCommand(
+    'sfdx.debug.exception.breakpoint',
+    getExceptionBreakpointInfo
+  );
+  context.subscriptions.push(getExceptionBreakpointInfoCmd);
 
   const exportedApi = {
     getLineBreakpointInfo
@@ -27,6 +36,14 @@ async function getLineBreakpointInfo(): Promise<{}> {
   let response = {};
   if (languageClient) {
     response = await languageClient.sendRequest(DEBUGGER_LINE_BREAKPOINTS);
+  }
+  return Promise.resolve(response);
+}
+
+async function getExceptionBreakpointInfo(): Promise<{}> {
+  let response = {};
+  if (languageClient) {
+    response = await languageClient.sendRequest(DEBUGGER_EXCEPTION_BREAKPOINTS);
   }
   return Promise.resolve(response);
 }

--- a/packages/salesforcedx-vscode-apex/src/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/index.ts
@@ -20,14 +20,9 @@ export async function activate(context: vscode.ExtensionContext) {
   const handle = languageClient.start();
   context.subscriptions.push(handle);
 
-  const getExceptionBreakpointInfoCmd = vscode.commands.registerCommand(
-    'sfdx.debug.exception.breakpoint',
-    getExceptionBreakpointInfo
-  );
-  context.subscriptions.push(getExceptionBreakpointInfoCmd);
-
   const exportedApi = {
-    getLineBreakpointInfo
+    getLineBreakpointInfo,
+    getExceptionBreakpointInfo
   };
   return exportedApi;
 }


### PR DESCRIPTION
### What does this PR do?
![exceptionbreakpoint](https://user-images.githubusercontent.com/7286437/32924517-d960f980-caf1-11e7-9dc8-275f2afbbf1b.gif)

This change allows a debugging user to add/remove exception breakpoints for System and user-defined exception types. The list of exception types are acquired from Apex language server. Configuring an exception breakpoint is done through the command palette.

**Typical UX Flow**
1. Open SFDX project in VS Code with Salesforce extensions installed
1. Start Apex Debugger session
1. Open command palette
1. Select `Apex Debug: Configure Exceptions`
1. Select an exception type
1. Select whether to always break (add breakpoint) or never break (remove breakpoint)
1. Wait until a log line in Debug Console verifies the breakpoint has been configured
1. Trigger the Apex exception 

**Notes**
- Exception types in the command palette are listed alphabetically.
- Enabled exception breakpoints will be shown at the top of the list of exception types in the command palette. They will have a description that says "Always break" with a built-in VS Code icon from https://octicons.github.com/icon/stop/.
- `Apex Debug: Configure Exceptions` command is also available without an active debugger session. If the user tries to add an exception breakpoint without an active session, we automatically mark it as enabled and save it to be added when we detect a new debugger session. 
- packages/salesforcedx-vscode-apex/out/apex-jorje-lsp.jar is signed.

### What issues does this PR fix or reference?
@W-4179085@