### PR TITLE
Prevent repeats of Refresh SObject while running

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceGenerateFauxClasses.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceGenerateFauxClasses.ts
@@ -23,6 +23,7 @@ import {
 } from './commands';
 
 class ForceGenerateFauxClassesExecutor extends SfdxCommandletExecutor<{}> {
+  private static isActive = false;
   public build(data: {}): Command {
     return new SfdxCommandBuilder()
       .withDescription(nls.localize('force_sobjects_refresh'))
@@ -31,6 +32,13 @@ class ForceGenerateFauxClassesExecutor extends SfdxCommandletExecutor<{}> {
   }
 
   public async execute(response: ContinueResponse<{}>): Promise<void> {
+    if (ForceGenerateFauxClassesExecutor.isActive) {
+      vscode.window.showErrorMessage(
+        nls.localize('no_refresh_if_currently_active')
+      );
+      return;
+    }
+    ForceGenerateFauxClassesExecutor.isActive = true;
     const cancellationTokenSource = new vscode.CancellationTokenSource();
     const cancellationToken = cancellationTokenSource.token;
 
@@ -50,6 +58,7 @@ class ForceGenerateFauxClassesExecutor extends SfdxCommandletExecutor<{}> {
     } catch (e) {
       console.log('Generate error ' + e);
     }
+    ForceGenerateFauxClassesExecutor.isActive = false;
     return;
   }
 }

--- a/packages/salesforcedx-vscode-core/src/commands/forceGenerateFauxClasses.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceGenerateFauxClasses.ts
@@ -34,7 +34,7 @@ class ForceGenerateFauxClassesExecutor extends SfdxCommandletExecutor<{}> {
   public async execute(response: ContinueResponse<{}>): Promise<void> {
     if (ForceGenerateFauxClassesExecutor.isActive) {
       vscode.window.showErrorMessage(
-        nls.localize('no_refresh_if_currently_active')
+        nls.localize('force_sobjects_no_refresh_if_already_active_error_text')
       );
       return;
     }

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -107,5 +107,7 @@ export const messages = {
   force_sobjects_refresh: 'SFDX: Refresh SObject Definitions',
   force_project_create_text: 'SFDX: Create Project',
   force_project_create_open_dialog_create_label: 'Create Project',
-  force_apex_trigger_create_text: 'SFDX: Create Apex Trigger'
+  force_apex_trigger_create_text: 'SFDX: Create Apex Trigger',
+  no_refresh_if_currently_active:
+    'Refresh is already active.  Cancel the existing task if there is a need to restart'
 };

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -108,6 +108,6 @@ export const messages = {
   force_project_create_text: 'SFDX: Create Project',
   force_project_create_open_dialog_create_label: 'Create Project',
   force_apex_trigger_create_text: 'SFDX: Create Apex Trigger',
-  no_refresh_if_currently_active:
-    'Refresh is already active.  Cancel the existing task if there is a need to restart'
+  force_sobjects_no_refresh_if_already_active_error_text:
+    'A refresh of your sObject definitions is already underway. If you need to restart the process, cancel the running task.'
 };

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -105,9 +105,9 @@ export const messages = {
   force_apex_execute_selection_text:
     'SFDX: Execute Anonymous Apex with Currently Selected Text',
   force_sobjects_refresh: 'SFDX: Refresh SObject Definitions',
+  force_sobjects_no_refresh_if_already_active_error_text:
+    'A refresh of your sObject definitions is already underway. If you need to restart the process, cancel the running task.',
   force_project_create_text: 'SFDX: Create Project',
   force_project_create_open_dialog_create_label: 'Create Project',
-  force_apex_trigger_create_text: 'SFDX: Create Apex Trigger',
-  force_sobjects_no_refresh_if_already_active_error_text:
-    'A refresh of your sObject definitions is already underway. If you need to restart the process, cancel the running task.'
+  force_apex_trigger_create_text: 'SFDX: Create Apex Trigger'
 };


### PR DESCRIPTION
The Refresh SObject Definitions command can take a few seconds.
If the user hits the command again while running, it will do the command
all over again when the first one ends - not intended behavior.
Add checks and a warning message to the command forceGenerateFauxClasses.ts
to disallow multiple invocations at the same time.

@W-4471720@
