### PR TITLE
Add an explanatory comment to the generated SObject faux classes

### DIFF
--- a/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
@@ -328,22 +328,14 @@ export class FauxClassGenerator {
       }
     );
 
-    const headerComment = `\/\/ This file is generated as an Apex representation of the
-\/\/     corresponding sObject and its fields.
-\/\/ This read-only file is used by the Apex Language Server to
-\/\/     provide code smartness, and is deleted each time you
-\/\/     refresh your sObject definitions.
-\/\/ To edit your sObjects and their fields, edit the corresponding
-\/\/     .object-meta.xml and .field-meta.xml files.
-
-`;
-
     const indentAndModifier = '    global ';
     const classDeclaration = `global class ${className} {${EOL}`;
     const declarationLines = declarations.join(`;${EOL}${indentAndModifier}`);
     const classConstructor = `${indentAndModifier}${className} () ${EOL}    {${EOL}    }${EOL}`;
 
-    const generatedClass = `${headerComment}${classDeclaration}${indentAndModifier}${declarationLines};${EOL}${EOL}${classConstructor}}`;
+    const generatedClass = `${nls.localize(
+      'class_header_generated_comment'
+    )}${classDeclaration}${indentAndModifier}${declarationLines};${EOL}${EOL}${classConstructor}}`;
 
     return generatedClass;
   }

--- a/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
@@ -264,8 +264,9 @@ export class FauxClassGenerator {
       fs.mkdirSync(folderPath);
     }
     const fauxClassPath = path.join(folderPath, sobject.name + '.cls');
-    fs.writeFileSync(fauxClassPath, this.generateFauxClassText(sobject));
-
+    fs.writeFileSync(fauxClassPath, this.generateFauxClassText(sobject), {
+      mode: 0o444
+    });
     return fauxClassPath;
   }
 
@@ -327,12 +328,22 @@ export class FauxClassGenerator {
       }
     );
 
+    const headerComment = `\/\/ This file is generated as an Apex representation of the
+\/\/     corresponding sObject and its fields.
+\/\/ This read-only file is used by the Apex Language Server to
+\/\/     provide code smartness, and is deleted each time you
+\/\/     refresh your sObject definitions.
+\/\/ To edit your sObjects and their fields, edit the corresponding
+\/\/     .object-meta.xml and .field-meta.xml files.
+
+`;
+
     const indentAndModifier = '    global ';
     const classDeclaration = `global class ${className} {${EOL}`;
     const declarationLines = declarations.join(`;${EOL}${indentAndModifier}`);
     const classConstructor = `${indentAndModifier}${className} () ${EOL}    {${EOL}    }${EOL}`;
 
-    const generatedClass = `${classDeclaration}${indentAndModifier}${declarationLines};${EOL}${EOL}${classConstructor}}`;
+    const generatedClass = `${headerComment}${classDeclaration}${indentAndModifier}${declarationLines};${EOL}${EOL}${classConstructor}}`;
 
     return generatedClass;
   }

--- a/packages/salesforcedx-sobjects-faux-generator/src/messages/i18n.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/messages/i18n.ts
@@ -25,5 +25,14 @@ export const messages = {
   fetched_sobjects_length_text:
     'Fetched %s %s sObjects from default scratch org\n',
   no_generate_if_not_in_project:
-    'Unable to generate faux classes for sObjects when not in an SFDX project %s'
+    'Unable to generate faux classes for sObjects when not in an SFDX project %s',
+  class_header_generated_comment: `\/\/ This file is generated as an Apex representation of the
+\/\/     corresponding sObject and its fields.
+\/\/ This read-only file is used by the Apex Language Server to
+\/\/     provide code smartness, and is deleted each time you
+\/\/     refresh your sObject definitions.
+\/\/ To edit your sObjects and their fields, edit the corresponding
+\/\/     .object-meta.xml and .field-meta.xml files.
+
+`
 };

--- a/packages/salesforcedx-sobjects-faux-generator/test/fauxClassGenerator.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/fauxClassGenerator.test.ts
@@ -24,6 +24,43 @@ describe('SObject faux class generator', function() {
     }
   });
 
+  it('Should generate a faux class with a proper header comment', async () => {
+    const fieldsHeader = '{ "name": "Custom__c", "fields": [ ';
+    const closeHeader = ' ], "childRelationships": [] }';
+
+    const sobject1 = `${fieldsHeader}${closeHeader}`;
+
+    const sobjectFolder = process.cwd();
+    const gen = getGenerator();
+    classPath = await gen.generateFauxClass(
+      sobjectFolder,
+      JSON.parse(sobject1)
+    );
+    expect(fs.existsSync(classPath));
+    const classText = fs.readFileSync(classPath, 'utf8');
+    expect(classText).to.include(
+      '// This file is generated as an Apex representation'
+    );
+  });
+
+  it('Should generate a faux class as read-only', async () => {
+    const fieldsHeader = '{ "name": "Custom__c", "fields": [ ';
+    const closeHeader = ' ], "childRelationships": [] }';
+
+    const sobject1 = `${fieldsHeader}${closeHeader}`;
+
+    const sobjectFolder = process.cwd();
+    const gen = getGenerator();
+    classPath = await gen.generateFauxClass(
+      sobjectFolder,
+      JSON.parse(sobject1)
+    );
+    expect(fs.existsSync(classPath));
+    const stat = fs.lstatSync(classPath);
+    const expectedMode = parseInt('100444', 8);
+    expect(stat.mode).to.equal(expectedMode);
+  });
+
   it('Should generate a faux class with all types of fields that can be in custom SObjects', async () => {
     const fieldsHeader = '{ "name": "Custom__c", "fields": [ ';
     const closeHeader = ' ], "childRelationships": [] }';

--- a/packages/salesforcedx-sobjects-faux-generator/test/fauxClassGenerator.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/fauxClassGenerator.test.ts
@@ -2,6 +2,7 @@ import * as chai from 'chai';
 import { EventEmitter } from 'events';
 import * as fs from 'fs';
 import { FauxClassGenerator } from '../src/generator/fauxClassGenerator';
+import { nls } from '../src/messages';
 
 const expect = chai.expect;
 
@@ -39,7 +40,7 @@ describe('SObject faux class generator', function() {
     expect(fs.existsSync(classPath));
     const classText = fs.readFileSync(classPath, 'utf8');
     expect(classText).to.include(
-      '// This file is generated as an Apex representation'
+      nls.localize('class_header_generated_comment')
     );
   });
 


### PR DESCRIPTION
…lasses

The generated faux classes are intended for use by the Apex Language Server
and for viewing by a developer.   They are not to be edited and an explanatory
comment about being generated is added.

The generation is also changed to make the generated files read-only.

@W-4477572@
