### PR TITLE
Add Integration Tests and Unit Tests to framework

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -263,6 +263,50 @@
         "${workspaceRoot}/packages/salesforcedx-sobjects-faux-generator/out/test/**/*.js"
       ],
       "preLaunchTask": "Compile"
+    },
+    {
+      "name": "Launch SObject Generator Unit Tests",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceRoot}/packages/salesforcedx-sobjects-faux-generator",
+      "program":
+        "${workspaceRoot}/packages/salesforcedx-sobjects-faux-generator/node_modules/mocha/bin/_mocha",
+      "args": [
+        "-u",
+        "tdd",
+        "--timeout",
+        "100000",
+        "--colors",
+        "--recursive",
+        "${workspaceRoot}/packages/salesforcedx-sobjects-faux-generator/out/test/unit"
+      ],
+      "sourceMaps": true,
+      "outFiles": [
+        "${workspaceRoot}/packages/salesforcedx-sobjects-faux-generator/out/test/**/*.js"
+      ],
+      "preLaunchTask": "Compile"
+    },
+    {
+      "name": "Launch SObject Generator Integration Tests",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceRoot}/packages/salesforcedx-sobjects-faux-generator",
+      "program":
+        "${workspaceRoot}/packages/salesforcedx-sobjects-faux-generator/node_modules/mocha/bin/_mocha",
+      "args": [
+        "-u",
+        "tdd",
+        "--timeout",
+        "100000",
+        "--colors",
+        "--recursive",
+        "${workspaceRoot}/packages/salesforcedx-sobjects-faux-generator/out/test/integration"
+      ],
+      "sourceMaps": true,
+      "outFiles": [
+        "${workspaceRoot}/packages/salesforcedx-sobjects-faux-generator/out/test/**/*.js"
+      ],
+      "preLaunchTask": "Compile"
     }
   ],
   "compounds": [

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -18,7 +18,7 @@ We have several modules that do not have any dependencies on VS Code. For
 instance, the salesforce-apex-debugger and salesforce-utils-vscode modules. You
 would write such tests using Mocha and Chai as you normally would for NPM modules.
 
-## VS Code Integration Tests
+## VS Code Tests
 
 VS Code provides its own special way to run tests that require access to the
 extension development host. Basically, it launches your test in another instance
@@ -105,6 +105,23 @@ for more information.
 See this
 [repository](https://github.com/Microsoft/vscode-extension-vscode/blob/master/bin/test)
 for the actual vscode/bin/test source.
+
+## Integration Tests that require the Salesforce server
+
+There are tests that require integration with the Salesforce server and expect default DevHub and prior authentication.
+These show up in several packages.   These tests are put under test/integration and named in the standard .test.ts pattern.  The
+package.json should have an entry like `"test:integration": "node ./node_modules/vscode/bin/test/integration"`.
+
+These can be run in the same way from the CLI using `npm run test:integration`.   Running npm run test will also run these.
+
+## Unit Tests
+A module can also have an entry like `"test:unit": "node ./node_modules/vscode/bin/test/unit"`.   This is used for pure unit
+tests and for VS Code based tests discussed above.    It is a good pattern to have an entry of `"test:unit": "node ./node_modules/vscode/bin/test"` in the package.json for modules that don't have separate integration tests.   
+
+These can be run using `npm run test:unit` for quick testing that doesn't require the scratch org and server.
+
+Modules that have separate unit & integration tests can provide top level launch configurations for running those tests as well.  
+See the examples in launch.json for Apex Debugger configurations.
 
 # System Tests with Spectron
 

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -108,20 +108,29 @@ for the actual vscode/bin/test source.
 
 ## Integration Tests that require the Salesforce server
 
-There are tests that require integration with the Salesforce server.  These tests require prior authentication to have occurred and a default devhub to be set.
-These show up in several packages.   These tests are put under test/integration and named in the standard .test.ts pattern.  The
-package.json should have an entry like `"test:integration": "node ./node_modules/vscode/bin/test/integration"`.
+There are tests that require integration with the Salesforce server. These tests
+require prior authentication to have occurred and a default devhub to be set.
+These show up in several packages. These tests are put under test/integration
+and named in the standard .test.ts pattern.  The package.json should have an
+entry like `"test:integration": "node
+./node_modules/vscode/bin/test/integration"`.
 
-These can be run in the same way from the CLI using `npm run test:integration`.   Running `npm run test` will also run these.
+These can be run in the same way from the CLI using `npm run test:integration`.
+Running `npm run test` will also run these.
 
 ## Unit Tests
-A module can also have an entry like `"test:unit": "node ./node_modules/vscode/bin/test/unit"`.   This is used for pure unit
-tests and for VS Code based tests discussed above.    It is a good pattern to have an entry of `"test:unit": "node ./node_modules/vscode/bin/test"` in the package.json for modules that don't have separate integration tests.   
+A module can also have an entry like `"test:unit": "node
+./node_modules/vscode/bin/test/unit"`. This is used for pure unit tests and for
+VS Code based tests discussed above. It is a good pattern to have an entry of
+`"test:unit": "node ./node_modules/vscode/bin/test"` in the package.json for
+modules that don't have separate integration tests.   
 
-These can be run using `npm run test:unit` for quick testing that doesn't require the scratch org and server.
+These can be run using `npm run test:unit` for quick testing that doesn't
+require the scratch org and server.
 
-Modules that have separate unit & integration tests can provide top level launch configurations for running those tests as well.  
-See the examples in launch.json for Apex Debugger configurations.
+Modules that have separate unit & integration tests can provide top level launch
+configurations for running those tests as well. See the examples in launch.json
+for Apex Debugger configurations.
 
 # System Tests with Spectron
 

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -108,11 +108,11 @@ for the actual vscode/bin/test source.
 
 ## Integration Tests that require the Salesforce server
 
-There are tests that require integration with the Salesforce server and expect default DevHub and prior authentication.
+There are tests that require integration with the Salesforce server.  These tests require prior authentication to have occurred and a default devhub to be set.
 These show up in several packages.   These tests are put under test/integration and named in the standard .test.ts pattern.  The
 package.json should have an entry like `"test:integration": "node ./node_modules/vscode/bin/test/integration"`.
 
-These can be run in the same way from the CLI using `npm run test:integration`.   Running npm run test will also run these.
+These can be run in the same way from the CLI using `npm run test:integration`.   Running `npm run test` will also run these.
 
 ## Unit Tests
 A module can also have an entry like `"test:unit": "node ./node_modules/vscode/bin/test/unit"`.   This is used for pure unit

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "lint": "lerna run lint",
     "publish": "node scripts/publish.js",
     "test": "lerna run test --concurrency 1 --stream",
+    "test:unit": "lerna run test:unit --concurrency 1 --stream",
+    "test:integration": "lerna run test:integration --concurrency 1 --stream",
     "test:without-system-tests":
       "lerna run test --ignore system-tests --concurrency 1 --stream",
     "test:system-tests":

--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -47,7 +47,7 @@
       "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test --reporter mocha-multi-reporters",
     "test:unit":
       "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test/unit --reporter mocha-multi-reporters",
-    "test:system-tests":
+    "test:integration":
       "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test/integration --reporter mocha-multi-reporters"
   },
   "nyc": {

--- a/packages/salesforcedx-slds-linter/package.json
+++ b/packages/salesforcedx-slds-linter/package.json
@@ -36,7 +36,8 @@
     "watch": "tsc -watch -p .",
     "clean": "shx rm -rf node_modules",
     "postinstall": "node ./node_modules/vscode/bin/install",
-    "test": "node ./node_modules/vscode/bin/test"
+    "test": "node ./node_modules/vscode/bin/test",
+    "test:unit": "node ./node_modules/vscode/bin/test"
   },
   "nyc": {
     "reporter": ["text-summary", "lcov"]

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -38,7 +38,11 @@
     "watch": "tsc -watch -p .",
     "clean": "shx rm -rf node_modules && shx rm -rf out",
     "test":
-      "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test"
+      "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test",
+    "test:unit":
+      "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test/unit",
+    "test:integration":
+      "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test/integration"
   },
   "nyc": {
     "reporter": ["text-summary", "lcov"]

--- a/packages/salesforcedx-sobjects-faux-generator/test/unit/fauxClassGenerator.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/unit/fauxClassGenerator.test.ts
@@ -1,8 +1,8 @@
 import * as chai from 'chai';
 import { EventEmitter } from 'events';
 import * as fs from 'fs';
-import { FauxClassGenerator } from '../src/generator/fauxClassGenerator';
-import { nls } from '../src/messages';
+import { FauxClassGenerator } from '../../src/generator/fauxClassGenerator';
+import { nls } from '../../src/messages';
 
 const expect = chai.expect;
 

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -42,6 +42,8 @@
       "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
     "test":
       "./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test --reporter mocha-multi-reporters --timeout 20000",
+    "test:unit":
+      "./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test --reporter mocha-multi-reporters --timeout 20000",
     "coverage": "./node_modules/.bin/nyc npm test"
   },
   "nyc": {

--- a/packages/salesforcedx-visualforce-language-server/package.json
+++ b/packages/salesforcedx-visualforce-language-server/package.json
@@ -37,6 +37,8 @@
     "clean":
       "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
     "test":
+      "./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test",
+    "test:unit":
       "./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test"
   },
   "nyc": {

--- a/packages/salesforcedx-visualforce-markup-language-server/package.json
+++ b/packages/salesforcedx-visualforce-markup-language-server/package.json
@@ -38,6 +38,8 @@
     "clean":
       "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
     "test":
+      "./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test",
+    "test:unit":
       "./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test"
   },
   "nyc": {

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -50,7 +50,8 @@
     "clean":
       "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
     "postinstall": "node ./node_modules/vscode/bin/install",
-    "test": "node ./node_modules/vscode/bin/test"
+    "test": "node ./node_modules/vscode/bin/test",
+    "test:unit": "node ./node_modules/vscode/bin/test"
   },
   "activationEvents": ["onDebug", "workspaceContains:sfdx-project.json"],
   "main": "./out/src",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -46,7 +46,8 @@
     "clean":
       "shx rm -rf node_modules && cd out && node ../../../scripts/clean-all-but-jar.js && shx rm -rf coverage && shx rm -rf .nyc_output",
     "postinstall": "node ./node_modules/vscode/bin/install",
-    "test": "node ./node_modules/vscode/bin/test"
+    "test": "node ./node_modules/vscode/bin/test",
+    "test:unit": "node ./node_modules/vscode/bin/test"
   },
   "activationEvents": ["workspaceContains:sfdx-project.json"],
   "main": "./out/src",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -55,6 +55,8 @@
       "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "test":
+      "cross-env CODE_TESTS_WORKSPACE='../system-tests/assets/sfdx-simple' node ./node_modules/vscode/bin/test",
+    "test:unit":
       "cross-env CODE_TESTS_WORKSPACE='../system-tests/assets/sfdx-simple' node ./node_modules/vscode/bin/test"
   },
   "activationEvents": [

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -49,6 +49,8 @@
       "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "test":
+      "cross-env CODE_TESTS_WORKSPACE='../system-tests/assets/sfdx-simple' node ./node_modules/vscode/bin/test",
+    "test:unit":
       "cross-env CODE_TESTS_WORKSPACE='../system-tests/assets/sfdx-simple' node ./node_modules/vscode/bin/test"
   },
   "activationEvents": ["workspaceContains:sfdx-project.json"],

--- a/packages/salesforcedx-vscode-visualforce/package.json
+++ b/packages/salesforcedx-vscode-visualforce/package.json
@@ -51,7 +51,8 @@
     "clean":
       "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
     "postinstall": "node ./node_modules/vscode/bin/install",
-    "test": "node ./node_modules/vscode/bin/test"
+    "test": "node ./node_modules/vscode/bin/test",
+    "test:unit": "node ./node_modules/vscode/bin/test"
   },
   "activationEvents": ["workspaceContains:sfdx-project.json"],
   "main": "./out/src/extension",


### PR DESCRIPTION
Add Integration Tests and Unit Tests to framework  …
There are a few tests in salesforcedx-apex-debugger and
salesforcedx-sobjects-faux-generator that require authentication
and create a scratch org.
These are turned into test:integration tests.
Also a test:unit set is created - tests that don’t require
the core server/scratch orgs and are not end-to-end system-tests

@W-4402142@