### PR TITLE
Add trigger:create; mention VF lang svr in ext pack README

### DIFF
--- a/packages/salesforcedx-vscode-core/README.md
+++ b/packages/salesforcedx-vscode-core/README.md
@@ -27,6 +27,7 @@ These Salesforce CLI commands are available:
 * `force:apex:execute`: **SFDX: Execute Anonymous Apex with Currently Selected Text**
 * `force:apex:execute --apexcodefile`: **SFDX: Execute Anonymous Apex with Editor Contents**
 * `force:apex:test:run --resultformat human ...`: **SFDX: Invoke Apex Tests...**
+* `force:apex:trigger:create ...`: **SFDX: Create Apex Trigger**
 * `force:auth:web:login --setdefaultdevhubusername`: **SFDX: Authorize a Dev Hub**
 * `force:config:list`: **SFDX: List All Config Variables**
 * `force:data:soql:query`: **SFDX: Execute SOQL Query with Currently Selected Text**

--- a/packages/salesforcedx-vscode/README.md
+++ b/packages/salesforcedx-vscode/README.md
@@ -28,7 +28,7 @@ To use Salesforce Extensions for VS Code, install all the extensions in this ext
 * [salesforcedx-vscode-lightning](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-lightning)  
    This extension supports Lightning component bundles. It uses the HTML language server from VS Code.
 * [salesforcedx-vscode-visualforce](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-visualforce)  
-   This extension supports Visualforce pages and components. It uses the HTML language server from VS Code.  
+   This extension supports Visualforce pages and components. It uses the Visualforce Language Server and the HTML language server from VS Code.  
 
 For tips and tricks for working with Salesforce Extensions for VS Code, visit our [GitHub wiki](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Tips-and-Tricks).  
    


### PR DESCRIPTION
### What does this PR do?
* Adds `force:apex:trigger:create` to list of commands supported in salesforcedx-vscode-core
* Mentions Visualforce Language Server in the extension pack's README

### What issues does this PR fix or reference?
@W-4470502@