### PR TITLE
Add visual indication for exception being paused on

### DIFF
--- a/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
+++ b/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
@@ -63,7 +63,9 @@ import {
   HOTSWAP_REQUEST,
   LINE_BREAKPOINT_INFO_REQUEST,
   LIST_EXCEPTION_BREAKPOINTS_REQUEST,
+  SALESFORCE_EXCEPTION_PREFIX,
   SHOW_MESSAGE_EVENT,
+  TRIGGER_EXCEPTION_PREFIX,
   WORKSPACE_SETTINGS_REQUEST
 } from '../constants';
 import {
@@ -1734,8 +1736,8 @@ export class ApexDebug extends LoggingDebugSession {
             // typerefs for exceptions will change based on whether they are custom,
             // defined as an inner class, defined in a trigger, or in a namespaced org
             reason = key
-              .replace('com/salesforce/api/exception/', '')
-              .replace('__sfdc_trigger/', '')
+              .replace(SALESFORCE_EXCEPTION_PREFIX, '')
+              .replace(TRIGGER_EXCEPTION_PREFIX, '')
               .replace('$', '.')
               .replace('/', '.');
           }

--- a/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
+++ b/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
@@ -1702,7 +1702,7 @@ export class ApexDebug extends LoggingDebugSession {
     this.sendEvent(new TerminatedEvent());
   }
 
-  private async handleStopped(message: DebuggerMessage): Promise<void> {
+  private handleStopped(message: DebuggerMessage): void {
     const threadId = this.getThreadIdFromRequestId(message.sobject.RequestId);
 
     if (threadId !== undefined) {
@@ -1731,9 +1731,13 @@ export class ApexDebug extends LoggingDebugSession {
         > = this.myBreakpointService.getExceptionBreakpointCache();
         cache.forEach((value, key) => {
           if (value === message.sobject.BreakpointId) {
-            if (key.indexOf('Exception') !== -1) {
-              reason = key.substring(key.lastIndexOf('/') + 1);
-            }
+            // typerefs for exceptions will change based on whether they are custom,
+            // defined as an inner class, defined in a trigger, or in a namespaced org
+            reason = key
+              .replace('com/salesforce/api/exception/', '')
+              .replace('__sfdc_trigger/', '')
+              .replace('$', '.')
+              .replace('/', '.');
           }
         });
       }

--- a/packages/salesforcedx-apex-debugger/src/constants.ts
+++ b/packages/salesforcedx-apex-debugger/src/constants.ts
@@ -24,3 +24,5 @@ export const LIST_EXCEPTION_BREAKPOINTS_REQUEST = 'listExceptionBreakpoints';
 export const EXCEPTION_BREAKPOINT_BREAK_MODE_ALWAYS = 'always';
 export const EXCEPTION_BREAKPOINT_BREAK_MODE_NEVER = 'never';
 export const CLIENT_ID = 'sfdx-vscode';
+export const SALESFORCE_EXCEPTION_PREFIX = 'com/salesforce/api/exception/';
+export const TRIGGER_EXCEPTION_PREFIX = '__sfdc_trigger/';

--- a/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebug.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebug.test.ts
@@ -52,7 +52,9 @@ import {
   HOTSWAP_REQUEST,
   LINE_BREAKPOINT_INFO_REQUEST,
   LIST_EXCEPTION_BREAKPOINTS_REQUEST,
+  SALESFORCE_EXCEPTION_PREFIX,
   SHOW_MESSAGE_EVENT,
+  TRIGGER_EXCEPTION_PREFIX,
   WORKSPACE_SETTINGS_REQUEST
 } from '../../../src/constants';
 import {
@@ -1748,10 +1750,13 @@ describe('Debugger adapter - unit', () => {
     let markEventProcessedSpy: sinon.SinonSpy;
     let getExceptionBreakpointCacheSpy: sinon.SinonStub;
     const knownExceptionBreakpoints: Map<string, string> = new Map([
-      ['com/salesforce/api/exception/AssertException', '07bFAKE1'],
+      [`${SALESFORCE_EXCEPTION_PREFIX}AssertException`, '07bFAKE1'],
       ['namespace/fooexception', '07bFAKE2'],
       ['namespace/MyClass$InnerException', '07bFAKE3'],
-      ['__sfdc_trigger/namespace/MyTrigger$InnerException', '07bFAKE4']
+      [
+        `${TRIGGER_EXCEPTION_PREFIX}namespace/MyTrigger$InnerException`,
+        '07bFAKE4'
+      ]
     ]);
 
     beforeEach(() => {

--- a/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebug.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebug.test.ts
@@ -1746,8 +1746,18 @@ describe('Debugger adapter - unit', () => {
     let sessionStopSpy: sinon.SinonSpy;
     let eventProcessedSpy: sinon.SinonStub;
     let markEventProcessedSpy: sinon.SinonSpy;
+    let getExceptionBreakpointCacheSpy: sinon.SinonStub;
+    const knownExceptionBreakpoints: Map<string, string> = new Map([
+      ['com/salesforce/api/exception/AssertException', '07bFAKE1'],
+      ['namespace/fooexception', '07bFAKE2'],
+      ['namespace/MyClass$InnerException', '07bFAKE3'],
+      ['__sfdc_trigger/namespace/MyTrigger$InnerException', '07bFAKE4']
+    ]);
 
     beforeEach(() => {
+      getExceptionBreakpointCacheSpy = sinon
+        .stub(BreakpointService.prototype, 'getExceptionBreakpointCache')
+        .returns(knownExceptionBreakpoints);
       adapter = new ApexDebugForTest(
         new SessionService(),
         new StreamingService(),
@@ -1776,6 +1786,7 @@ describe('Debugger adapter - unit', () => {
       sessionStopSpy.restore();
       eventProcessedSpy.restore();
       markEventProcessedSpy.restore();
+      getExceptionBreakpointCacheSpy.restore();
     });
 
     it('[SessionTerminated] - Should stop session service', () => {
@@ -2033,6 +2044,94 @@ describe('Debugger adapter - unit', () => {
       expect(adapter.getVariableContainerReferenceByApexId().has(0)).to.equal(
         false
       );
+    });
+
+    it('[Stopped] - Should display exception type when stopped on exception breakpoint', () => {
+      const message: DebuggerMessage = {
+        event: {
+          replayId: 0
+        } as StreamingEvent,
+        sobject: {
+          SessionId: '07aFAKE',
+          Type: 'Stopped',
+          RequestId: '07cFAKE',
+          BreakpointId: '07bFAKE1'
+        }
+      };
+      adapter.addRequestThread('07cFAKE');
+      adapter.handleEvent(message);
+
+      const stoppedEvent = adapter.getEvents()[1] as StoppedEvent;
+      expect(stoppedEvent.body).to.deep.equal({
+        threadId: 1,
+        reason: 'AssertException'
+      });
+    });
+
+    it('[Stopped] - Should display exception for namespaced orgs', () => {
+      const message: DebuggerMessage = {
+        event: {
+          replayId: 0
+        } as StreamingEvent,
+        sobject: {
+          SessionId: '07aFAKE',
+          Type: 'Stopped',
+          RequestId: '07cFAKE',
+          BreakpointId: '07bFAKE2'
+        }
+      };
+      adapter.addRequestThread('07cFAKE');
+      adapter.handleEvent(message);
+
+      const stoppedEvent = adapter.getEvents()[1] as StoppedEvent;
+      expect(stoppedEvent.body).to.deep.equal({
+        threadId: 1,
+        reason: 'namespace.fooexception'
+      });
+    });
+
+    it('[Stopped] - Should display exception for namespaced org with exception as inner class', () => {
+      const message: DebuggerMessage = {
+        event: {
+          replayId: 0
+        } as StreamingEvent,
+        sobject: {
+          SessionId: '07aFAKE',
+          Type: 'Stopped',
+          RequestId: '07cFAKE',
+          BreakpointId: '07bFAKE3'
+        }
+      };
+      adapter.addRequestThread('07cFAKE');
+      adapter.handleEvent(message);
+
+      const stoppedEvent = adapter.getEvents()[1] as StoppedEvent;
+      expect(stoppedEvent.body).to.deep.equal({
+        threadId: 1,
+        reason: 'namespace.MyClass.InnerException'
+      });
+    });
+
+    it('[Stopped] - Should display exception for namespaced org with exception as inner class in a trigger', () => {
+      const message: DebuggerMessage = {
+        event: {
+          replayId: 0
+        } as StreamingEvent,
+        sobject: {
+          SessionId: '07aFAKE',
+          Type: 'Stopped',
+          RequestId: '07cFAKE',
+          BreakpointId: '07bFAKE4'
+        }
+      };
+      adapter.addRequestThread('07cFAKE');
+      adapter.handleEvent(message);
+
+      const stoppedEvent = adapter.getEvents()[1] as StoppedEvent;
+      expect(stoppedEvent.body).to.deep.equal({
+        threadId: 1,
+        reason: 'namespace.MyTrigger.InnerException'
+      });
     });
 
     it('[Stopped] - Should send stepping stopped event', () => {


### PR DESCRIPTION
### What does this PR do?
Add a visual indicator telling the user what exception the user is paused on
![image](https://user-images.githubusercontent.com/4503716/34275699-119c8138-e664-11e7-9f4b-7be05ef5257b.png)

### What issues does this PR fix or reference?
@W-4518683@