### PR TITLE
Upgrade to TypeScript 2.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "remap-istanbul": "^0.9.5",
     "shx": "0.2.2",
     "tslint": "5.5.0",
-    "typescript": "2.4.0",
+    "typescript": "2.6.2",
     "vsce": "1.29.0"
   },
   "scripts": {

--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -32,7 +32,7 @@
     "mock-spawn": "0.2.6",
     "nyc": "^11.0.2",
     "sinon": "^2.3.6",
-    "typescript": "2.4.0",
+    "typescript": "2.6.2",
     "vscode": "1.1.10",
     "vscode-debugadapter-testsupport": "1.24.0"
   },

--- a/packages/salesforcedx-slds-linter/package.json
+++ b/packages/salesforcedx-slds-linter/package.json
@@ -26,7 +26,7 @@
     "remap-istanbul": "^0.9.5",
     "sinon": "^2.3.6",
     "source-map-support": "^0.4.15",
-    "typescript": "2.4.0",
+    "typescript": "2.6.2",
     "vscode": "1.1.10"
   },
   "scripts": {

--- a/packages/salesforcedx-slds-linter/src/server/index.ts
+++ b/packages/salesforcedx-slds-linter/src/server/index.ts
@@ -30,9 +30,7 @@ documents.listen(connection);
 
 // After the server has started the client sends an initialize request. The server receives
 // in the passed params the rootPath of the workspace plus the client capabilities.
-let workspaceRoot: string | undefined | null;
 connection.onInitialize((params): InitializeResult => {
-  workspaceRoot = params.rootPath;
   return {
     capabilities: {
       // Tell the client that the server works in FULL text document sync mode
@@ -45,26 +43,39 @@ connection.onInitialize((params): InitializeResult => {
 // The content of a text document has changed. This event is emitted
 // when the text document first opened or when its content has changed.
 documents.onDidChangeContent(change => {
-  validateTextDocument(change.document.getText(), change.document.uri, connection);
+  validateTextDocument(
+    change.document.getText(),
+    change.document.uri,
+    connection
+  );
 });
 
 documents.onDidOpen(change => {
-  validateTextDocument(change.document.getText(), change.document.uri, connection);
+  validateTextDocument(
+    change.document.getText(),
+    change.document.uri,
+    connection
+  );
 });
 
 // The settings have changed. Is send on server activation
 // as well.
 connection.onDidChangeConfiguration(change => {
   // Revalidate any open text documents
-  documents.all().forEach(doc => validateTextDocument(doc.getText(), doc.uri, connection));
+  documents
+    .all()
+    .forEach(doc => validateTextDocument(doc.getText(), doc.uri, connection));
 });
 
 let activeDiagnostics: Diagnostic[] = [];
 
-export function validateTextDocument(textDocument: String, uri: string, conn: any): void {
+export function validateTextDocument(
+  textDocument: String,
+  uri: string,
+  conn: any
+): void {
   activeDiagnostics = [];
   const lines = textDocument.split(/\r?\n/g);
-  let problems = 0;
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     const found = line.match(/slds\S*--[A-Za-z0-9_-]+/g) || [];
@@ -74,7 +85,6 @@ export function validateTextDocument(textDocument: String, uri: string, conn: an
       if (index >= 0) {
         const foundStringLength = match.length;
         const fixedString = match.replace('--', '_');
-        problems++;
         const diagnostic = <Diagnostic>{
           code: `0${fixedString}`,
           severity: DiagnosticSeverity.Warning,
@@ -82,10 +92,11 @@ export function validateTextDocument(textDocument: String, uri: string, conn: an
             start: { line: i, character: index },
             end: { line: i, character: index + foundStringLength }
           },
-          message: nls.localize('deprecated_class_name', line.substr(
-            index,
-            foundStringLength
-          ), fixedString),
+          message: nls.localize(
+            'deprecated_class_name',
+            line.substr(index, foundStringLength),
+            fixedString
+          ),
           source: 'slds'
         };
         activeDiagnostics.push(diagnostic);
@@ -184,7 +195,6 @@ function sameCodeActions(result: Command[], uri: string, problem: string) {
             codeMessage = nls.localize('fix_same_default');
           }
         }
-
       }
     }
     result.push(

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -29,7 +29,7 @@
     "mock-spawn": "0.2.6",
     "nyc": "^11.0.2",
     "sinon": "^2.3.6",
-    "typescript": "2.4.0"
+    "typescript": "2.6.2"
   },
   "scripts": {
     "vscode:package": "npm prune --production",

--- a/packages/salesforcedx-sobjects-faux-generator/test/integration/fauxGenerate.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/integration/fauxGenerate.test.ts
@@ -99,7 +99,6 @@ describe('Generate faux classes for SObjects', function() {
   });
 
   it('Should emit an error event on failure', async () => {
-    let result = '';
     let errorMessage = '';
     let exitCode: number = LocalCommandExecution.SUCCESS_CODE;
     let rejectOutput = '';
@@ -112,7 +111,7 @@ describe('Generate faux classes for SObjects', function() {
     });
     invalidateProject(projectPath);
     try {
-      result = await generator.generate(projectPath, SObjectCategory.CUSTOM);
+      await generator.generate(projectPath, SObjectCategory.CUSTOM);
     } catch (e) {
       rejectOutput = e;
     } finally {
@@ -128,7 +127,6 @@ describe('Generate faux classes for SObjects', function() {
   });
 
   it('Should emit message to stderr on failure', async () => {
-    let result = '';
     let stderrInfo = '';
     let rejectOutput = '';
     const generator = getGenerator();
@@ -137,7 +135,7 @@ describe('Generate faux classes for SObjects', function() {
     });
     invalidateProject(projectPath);
     try {
-      result = await generator.generate(projectPath, SObjectCategory.CUSTOM);
+      await generator.generate(projectPath, SObjectCategory.CUSTOM);
     } catch (e) {
       rejectOutput = e;
     } finally {

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -28,7 +28,7 @@
     "remap-istanbul": "^0.9.5",
     "shelljs": "^0.7.8",
     "source-map-support": "^0.4.15",
-    "typescript": "2.4.0"
+    "typescript": "2.6.2"
   },
   "engines": {
     "vscode": "^1.17.0"

--- a/packages/salesforcedx-visualforce-language-server/package.json
+++ b/packages/salesforcedx-visualforce-language-server/package.json
@@ -27,7 +27,7 @@
     "remap-istanbul": "^0.9.5",
     "shx": "0.2.2",
     "source-map-support": "^0.4.15",
-    "typescript": "2.4.0"
+    "typescript": "2.6.2"
   },
   "scripts": {
     "vscode:package": "npm prune --production",

--- a/packages/salesforcedx-visualforce-language-server/src/modes/javascriptMode.ts
+++ b/packages/salesforcedx-visualforce-language-server/src/modes/javascriptMode.ts
@@ -133,7 +133,8 @@ export function getJavascriptMode(
       const offset = currentTextDocument.offsetAt(position);
       const completions = jsLanguageService.getCompletionsAtPosition(
         FILE_NAME,
-        offset
+        offset,
+        { includeExternalModuleExports: false }
       );
       if (!completions) {
         return { isIncomplete: false, items: [] };
@@ -167,7 +168,9 @@ export function getJavascriptMode(
       const details = jsLanguageService.getCompletionEntryDetails(
         FILE_NAME,
         item.data.offset,
-        item.label
+        item.label,
+        undefined,
+        undefined
       );
       if (details) {
         item.detail = ts.displayPartsToString(details.displayParts);

--- a/packages/salesforcedx-visualforce-language-server/src/utils/edits.ts
+++ b/packages/salesforcedx-visualforce-language-server/src/utils/edits.ts
@@ -15,7 +15,6 @@ export function applyEdits(document: TextDocument, edits: TextEdit[]): string {
     }
     return startDiff;
   });
-  let lastOffset = text.length;
   sortedEdits.forEach(e => {
     const startOffset = document.offsetAt(e.range.start);
     const endOffset = document.offsetAt(e.range.end);
@@ -23,7 +22,6 @@ export function applyEdits(document: TextDocument, edits: TextEdit[]): string {
       text.substring(0, startOffset) +
       e.newText +
       text.substring(endOffset, text.length);
-    lastOffset = startOffset;
   });
   return text;
 }

--- a/packages/salesforcedx-visualforce-markup-language-server/package.json
+++ b/packages/salesforcedx-visualforce-markup-language-server/package.json
@@ -23,7 +23,7 @@
     "remap-istanbul": "^0.9.5",
     "shx": "0.2.2",
     "source-map-support": "^0.4.15",
-    "typescript": "2.4.0"
+    "typescript": "2.6.2"
   },
   "dependencies": {
     "vscode-languageserver-types": "^3.3.0",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -32,7 +32,7 @@
     "mocha": "3.2.0",
     "nyc": "^11.0.2",
     "shelljs": "^0.7.8",
-    "typescript": "2.4.0",
+    "typescript": "2.6.2",
     "vscode": "1.1.10"
   },
   "scripts": {

--- a/packages/salesforcedx-vscode-apex/test/languageServer.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/languageServer.test.ts
@@ -16,10 +16,7 @@ describe('Apex Language Server Client', () => {
     let originalPlatform: PropertyDescriptor;
 
     before(() => {
-      originalPlatform = Object.getOwnPropertyDescriptor(
-        process,
-        'platform'
-      ) as PropertyDescriptor;
+      originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!;
       Object.defineProperty(process, 'platform', { value: 'win32' });
     });
 
@@ -41,10 +38,7 @@ describe('Apex Language Server Client', () => {
     let originalPlatform: PropertyDescriptor;
 
     before(() => {
-      originalPlatform = Object.getOwnPropertyDescriptor(
-        process,
-        'platform'
-      ) as PropertyDescriptor;
+      originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!;
       Object.defineProperty(process, 'platform', { value: 'darwin' });
     });
 

--- a/packages/salesforcedx-vscode-apex/test/languageServer.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/languageServer.test.ts
@@ -16,7 +16,10 @@ describe('Apex Language Server Client', () => {
     let originalPlatform: PropertyDescriptor;
 
     before(() => {
-      originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+      originalPlatform = Object.getOwnPropertyDescriptor(
+        process,
+        'platform'
+      ) as PropertyDescriptor;
       Object.defineProperty(process, 'platform', { value: 'win32' });
     });
 
@@ -38,7 +41,10 @@ describe('Apex Language Server Client', () => {
     let originalPlatform: PropertyDescriptor;
 
     before(() => {
-      originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+      originalPlatform = Object.getOwnPropertyDescriptor(
+        process,
+        'platform'
+      ) as PropertyDescriptor;
       Object.defineProperty(process, 'platform', { value: 'darwin' });
     });
 

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -40,7 +40,7 @@
     "mock-spawn": "0.2.6",
     "nyc": "^11.0.2",
     "sinon": "^2.3.6",
-    "typescript": "2.4.0",
+    "typescript": "2.6.2",
     "vscode": "1.1.10"
   },
   "scripts": {

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -34,7 +34,7 @@
     "cross-env": "^5.0.5",
     "mocha": "3.2.0",
     "sinon": "^2.3.6",
-    "typescript": "2.4.0",
+    "typescript": "2.6.2",
     "vscode": "1.1.10"
   },
   "scripts": {

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -35,7 +35,7 @@
     "cross-env": "^5.0.5",
     "mocha": "3.2.0",
     "sinon": "^2.3.6",
-    "typescript": "2.4.0",
+    "typescript": "2.6.2",
     "vscode": "1.1.8"
   },
   "extensionDependencies": ["dbaeumer.vscode-eslint"],

--- a/packages/salesforcedx-vscode-visualforce/package.json
+++ b/packages/salesforcedx-vscode-visualforce/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@salesforce/salesforcedx-visualforce-language-server": "41.12.0",
     "@salesforce/salesforcedx-visualforce-markup-language-server": "41.12.0",
-    "typescript": "2.4.0",
+    "typescript": "2.6.2",
     "vscode-languageclient": "3.4.2",
     "vscode-languageserver-protocol": "3.4.2",
     "vscode-languageserver-types": "3.4.0"

--- a/packages/system-tests/assets/sfdx-simple/.vscode/settings.json
+++ b/packages/system-tests/assets/sfdx-simple/.vscode/settings.json
@@ -1,3 +1,12 @@
 {
-  "extensions.autoUpdate": false
+  "extensions.autoUpdate": false,
+  "terminal.integrated.env.osx": {
+    "SFDX_SET_CLIENT_IDS": "sfdx-vscode"
+  },
+  "terminal.integrated.env.linux": {
+    "SFDX_SET_CLIENT_IDS": "sfdx-vscode"
+  },
+  "terminal.integrated.env.windows": {
+    "SFDX_SET_CLIENT_IDS": "sfdx-vscode"
+  }
 }

--- a/packages/system-tests/package.json
+++ b/packages/system-tests/package.json
@@ -30,20 +30,21 @@
     "shelljs": "^0.7.8",
     "source-map-support": "^0.4.15",
     "spectron": "^3.7.2",
-    "typescript": "2.4.0",
+    "typescript": "2.6.2",
     "vscode": "1.1.10"
   },
   "scripts": {
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
-    "clean": "shx rm -rf .vscode-test && shx rm -rf node_modules && shx rm -rf out",
+    "clean":
+      "shx rm -rf .vscode-test && shx rm -rf node_modules && shx rm -rf out",
     "postinstall": "node ./node_modules/vscode/bin/install",
-    "pretest": "npm run compile && node ../../scripts/download-vscode-for-system-tests",
+    "pretest":
+      "npm run compile && node ../../scripts/download-vscode-for-system-tests",
     "test": "node out/src/main.js",
-    "coverage": "npm run pretest && node ../../scripts/instrument-salesforcedx-vscode-extensions && cross-env COLLECT_COVERAGE=1 npm run test && node ../../scripts/remap-coverage"
+    "coverage":
+      "npm run pretest && node ../../scripts/instrument-salesforcedx-vscode-extensions && cross-env COLLECT_COVERAGE=1 npm run test && node ../../scripts/remap-coverage"
   },
-  "activationEvents": [
-    "*"
-  ]
+  "activationEvents": ["*"]
 }


### PR DESCRIPTION
### What does this PR do?

Switch salesforcedx-vscode over to use TypeScript 2.6 instead of TypeScript 2.4. 

TypeScript 2.6 was released in October so it’s stable now. See https://blogs.msdn.microsoft.com/typescript/2017/10/31/announcing-typescript-2-6/

### What issues does this PR fix or reference?

None. This is an engineering commit.
