### PR TITLE
Update docs for v41.16.0

### DIFF
--- a/packages/salesforcedx-vscode-apex-debugger/README.md
+++ b/packages/salesforcedx-vscode-apex-debugger/README.md
@@ -63,11 +63,11 @@ To start a debugging session, from the configuration dropdown menu at the top of
 While a debugging session is in progress, any synchronous activity that runs a line of code with a breakpoint causes execution to halt at the breakpoint. While execution is paused, you can inspect the call stack and see the current values of your variables. You can also step through your code, using the Debug actions pane that appears at the top of the editor while a debugging session is in progress, and watch those values change. You can debug up to two threads at a time. For more information, see [Debugging](https://code.visualstudio.com/docs/editor/debugging) in the Visual Studio Code docs.
 
 ## Set Exception Breakpoints
-To make the Apex Debugger halt execution when an exception is thrown during a debugging session, set breakpoints on exceptions. When an exception breakpoint is hit, the debugger pauses on the line of code that caused the exception.
+To make the Apex Debugger halt execution when an exception is thrown during a debugging session, set breakpoints on exceptions. When an exception breakpoint is hit, the debugger pauses on the line of code that caused the exception. The Call Stack panel in the Debug view shows the name of the exception.  
 
 To set an exception breakpoint, press Cmd+Shift+P (macOS) or Ctrl+Shift+P (Windows or Linux) to open the command palette, then select **Apex Debug: Configure Exceptions**. The list of available exceptions includes the [exceptions in the `System` namespace](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_exception_methods.htm) and the Apex classes in your project that extend `Exception`. Select an exception from the list, and then select **Always break**. 
 
-To see your exception breakpoints, run **Apex Debug: Configure Exceptions**. The top of the list shows the exception classes that have active breakpoints, labeled `Always break`. To remove an exception breakpoint, select an exception from the list and then select **Never break**.
+To see your exception breakpoints, run **Apex Debug: Configure Exceptions**. The top of the list shows the exception classes that have active breakpoints, labeled `Always break`. To remove an exception breakpoint, select an exception from the list and then select **Never break**.  
 
 When you close VS Code, all your exception breakpoints are removed. (Your line breakpoints, however, remain.)
 

--- a/packages/salesforcedx-vscode-apex/README.md
+++ b/packages/salesforcedx-vscode-apex/README.md
@@ -20,18 +20,18 @@ To see code-completion suggestions, press Ctrl+space when you’re working in a 
 ## View or Jump to Definitions
 You can preview, view, or go to definitions of:  
 * Apex  
+  * classes (from within extending classes)  
+  * constructors  
+  * interfaces (from within implementing classes)  
   * methods  
   * properties  
-  * constructors  
-  * local variables  
-  * class variables  
+  * variables (local and class variables)  
 * standard objects  
+  * fields (standard and custom fields)
   * object definitions
-  * standard fields  
-  * custom fields  
 * custom objects
+  * fields  
   * object definitions  
-  * custom fields  
 
 (See the "Enable Code Smartness for SObjects" section of this README for information on working with standard and custom objects.)
 

--- a/packages/salesforcedx-vscode-apex/README.md
+++ b/packages/salesforcedx-vscode-apex/README.md
@@ -20,9 +20,9 @@ To see code-completion suggestions, press Ctrl+space when you’re working in a 
 ## View or Jump to Definitions
 You can preview, view, or go to definitions of:  
 * Apex  
-  * classes (from within extending classes)  
+  * classes (from definitions of extending classes)  
   * constructors  
-  * interfaces (from within implementing classes)  
+  * interfaces (from definitions of implementing classes)  
   * methods  
   * properties  
   * variables (local and class variables)  


### PR DESCRIPTION
### What does this PR do?
* salesforcedx-vscode-apex README:  
    * Adds classes and interfaces to list of Apex items whose definitions you can visit (https://github.com/forcedotcom/salesforcedx-vscode/pull/247)  
    * Alphabetizes items in lists of items whose definitions you can visit
* salesforcedx-vscode-apex-debugger README: Adds mention that call stack shows paused-on exception (https://github.com/forcedotcom/salesforcedx-vscode/pull/240)

### What issues does this PR fix or reference?
@W-4605866@