### PR TITLE
Add extension setting to control showing cli success messages via inf…

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -368,7 +368,14 @@
     ],
     "configuration": {
       "type": "object",
-      "title": "%feature_previews_title%"
+      "title": "%feature_previews_title%",
+      "properties": {
+        "salesforcedx-vscode-core.show-cli-success-msg": {
+          "type": ["boolean"],
+          "default": true,
+          "description": "%show_cli_success_msg_description%"
+        }
+      }
     }
   }
 }

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -44,5 +44,7 @@
     "SFDX: Execute Anonymous Apex with Currently Selected Text",
   "feature_previews_title": "Salesforce Feature Previews",
   "force_project_create_text": "SFDX: Create Project",
-  "force_apex_trigger_create_text": "SFDX: Create Apex Trigger"
+  "force_apex_trigger_create_text": "SFDX: Create Apex Trigger",
+  "show_cli_success_msg_description":
+    "Specifies whether the SFDX CLI messages executed via vscode will show as information messages (true) or as status bar messages (false)."
 }

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -46,5 +46,5 @@
   "force_project_create_text": "SFDX: Create Project",
   "force_apex_trigger_create_text": "SFDX: Create Apex Trigger",
   "show_cli_success_msg_description":
-    "Specifies whether the SFDX CLI messages executed via vscode will show as information messages (true) or as status bar messages (false)."
+    "Specifies whether status messages for Salesforce CLI commands run using the VS Code command palette will appear as pop-up information messages (true) or as status bar messages (false)."
 }

--- a/packages/salesforcedx-vscode-core/src/constants.ts
+++ b/packages/salesforcedx-vscode-core/src/constants.ts
@@ -13,3 +13,6 @@ export const TERMINAL_INTEGRATED_ENVS = [
   'terminal.integrated.env.linux',
   'terminal.integrated.env.windows'
 ];
+export const SFDX_CORE_CONFIGURATION_NAME = 'salesforcedx-vscode-core';
+export const STATUS_BAR_MSG_TIMEOUT_MS = 5000;
+export const SHOW_CLI_SUCCESS_INFO_MSG = 'show-cli-success-msg';

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -28,6 +28,7 @@ export const messages = {
   notification_canceled_execution_text: '%s was canceled',
   notification_unsuccessful_execution_text: '%s failed to run',
   notification_show_button_text: 'Show',
+  notification_show_in_status_bar_button_text: 'Show Only in Status Bar',
 
   predicates_no_folder_opened_text:
     'No folder opened. Open a Salesforce DX project in VS Code.',

--- a/packages/salesforcedx-vscode-core/src/notifications/notificationService.ts
+++ b/packages/salesforcedx-vscode-core/src/notifications/notificationService.ts
@@ -11,7 +11,7 @@ import * as vscode from 'vscode';
 import { DEFAULT_SFDX_CHANNEL } from '../channels';
 import { STATUS_BAR_MSG_TIMEOUT_MS } from '../constants';
 import { nls } from '../messages';
-import { SfdxCoreSettings } from '../sfdxCoreSettings';
+import { sfdxCoreSettings } from '../settings';
 
 /**
  * A centralized location for all notification functionalities.
@@ -76,7 +76,6 @@ export class NotificationService {
     observable: Observable<number | undefined>,
     cancellationToken?: vscode.CancellationToken
   ) {
-    const sfdxCoreSettings = SfdxCoreSettings.getInstance();
     observable.subscribe(async data => {
       if (data != undefined && data.toString() === '0') {
         const message = nls.localize(

--- a/packages/salesforcedx-vscode-core/src/settings/index.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { SfdxCoreSettings } from './sfdxCoreSettings';
+
+export const sfdxCoreSettings = SfdxCoreSettings.getInstance();

--- a/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
@@ -9,7 +9,7 @@ import * as vscode from 'vscode';
 import {
   SFDX_CORE_CONFIGURATION_NAME,
   SHOW_CLI_SUCCESS_INFO_MSG
-} from './constants';
+} from '../constants';
 /**
  * A centralized location for interacting with sfdx-core settings.
  */

--- a/packages/salesforcedx-vscode-core/src/sfdxCoreSettings.ts
+++ b/packages/salesforcedx-vscode-core/src/sfdxCoreSettings.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as vscode from 'vscode';
+import {
+  SFDX_CORE_CONFIGURATION_NAME,
+  SHOW_CLI_SUCCESS_INFO_MSG
+} from './constants';
+/**
+ * A centralized location for interacting with sfdx-core settings.
+ */
+export class SfdxCoreSettings {
+  private static instance: SfdxCoreSettings;
+
+  public static getInstance() {
+    if (!SfdxCoreSettings.instance) {
+      SfdxCoreSettings.instance = new SfdxCoreSettings();
+    }
+    return SfdxCoreSettings.instance;
+  }
+
+  /**
+   * Get the configuration for a sfdx-core
+   */
+  public getConfiguration(): vscode.WorkspaceConfiguration {
+    return vscode.workspace.getConfiguration(SFDX_CORE_CONFIGURATION_NAME);
+  }
+
+  public getShowCLISuccessMsg(): boolean {
+    return this.getConfigValue<boolean>(SHOW_CLI_SUCCESS_INFO_MSG, true);
+  }
+
+  public async updateShowCLISuccessMsg(value: boolean) {
+    await this.setConfigValue(SHOW_CLI_SUCCESS_INFO_MSG, value);
+  }
+
+  private getConfigValue<T>(key: string, defaultValue: T): T {
+    return this.getConfiguration().get<T>(key, defaultValue);
+  }
+
+  private async setConfigValue(key: string, value: any) {
+    await this.getConfiguration().update(key, value);
+  }
+}

--- a/packages/salesforcedx-vscode-core/test/notifications/index.test.ts
+++ b/packages/salesforcedx-vscode-core/test/notifications/index.test.ts
@@ -11,7 +11,7 @@ import { CancellationTokenSource, window } from 'vscode';
 import { DEFAULT_SFDX_CHANNEL } from '../../src/channels/channelService';
 import { nls } from '../../src/messages';
 import { NotificationService } from '../../src/notifications/notificationService';
-import { SfdxCoreSettings } from '../../src/sfdxCoreSettings';
+import { SfdxCoreSettings } from '../../src/settings/sfdxCoreSettings';
 
 const SHOW_BUTTON_TEXT = nls.localize('notification_show_button_text');
 const SHOW_ONLY_STATUS_BAR_BUTTON_TEXT = nls.localize(


### PR DESCRIPTION
…ormation messages or status bar. @W-4440104@.

### What does this PR do?
Adds setting to control showing successful message as information messages or as status bar messages.
### What issues does this PR fix or reference?
Addresses giving the user control on how certain messages are shown.