### PR TITLE
Update the way we publish

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -31,8 +31,7 @@ It is possible to run each step manually as illustrated below.
 
 ### Prerequisite
 
-* Lerna is properly installed (`npm install -g lerna@2.0.0`).
-* shelljs is properly installed (`npm install -g shelljs`).
+* Lerna is properly installed (`npm install -g lerna@2.4.0`).
 * You have a clean workspace. You can use `git clean -xfd` to get to a pristine
   stage.
 * All tests have been run prior to publishing. We don't run the tests during the
@@ -43,9 +42,9 @@ It is possible to run each step manually as illustrated below.
 
 1. `npm install` to install all the dependencies and to symlink interdependent local modules.
 1. `npm run compile` to compile all the TypeScript files.
-1. `lerna publish ...` will increment the version in the individual package.json
-   to prepare for publication. **This also commits the changes to git and adds a
-   tag.**
+1. `lerna publish ...` (see scripts/publish.js for the full command) will
+   increment the version in the individual package.json to prepare for
+   publication. **This also commits the changes to git and adds a tag.**
 1. `npm run vscode:package` packages _each_ extension as a .vsix.
 
 **At this stage, it is possible to share the .vsix directly for manual installation.**

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -25,6 +25,11 @@ The files under scripts use [shelljs/shx](https://github.com/shelljs/shx) and
 [shelljs/shelljs](https://github.com/shelljs/shelljs) to write scripts in a
 portable manner across platforms.
 
+1. `git checkout -t origin release/vxx.yy.zz`
+1. `npm install`
+1. `export SALESFORCEDX_VSCODE_VERSION=xx.yy.zz` (must match the branch version)
+1. `scripts/publish.js`
+
 It is possible to run each step manually as illustrated below.
 
 ## Packaging as .vsix
@@ -32,8 +37,6 @@ It is possible to run each step manually as illustrated below.
 ### Prerequisite
 
 * Lerna is properly installed (`npm install -g lerna@2.4.0`).
-* You have a clean workspace. You can use `git clean -xfd` to get to a pristine
-  stage.
 * All tests have been run prior to publishing. We don't run the tests during the
   publishing cycle since it generates artifacts that we do not want to include
   in the packaged extensions.

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
     "vsce": "1.29.0"
   },
   "scripts": {
-    "postinstall": "lerna bootstrap -- --no-package-lock && node scripts/reformat-with-prettier",
-    "bootstrap": "lerna bootstrap -- --no-package-lock && node scripts/reformat-with-prettier",
+    "postinstall":
+      "lerna bootstrap -- --no-package-lock && node scripts/reformat-with-prettier",
+    "bootstrap":
+      "lerna bootstrap -- --no-package-lock && node scripts/reformat-with-prettier",
     "clean": "lerna run clean",
     "compile": "lerna run --stream compile",
     "lint": "lerna run lint",
@@ -21,14 +23,19 @@
     "test": "lerna run test --concurrency 1 --stream",
     "test:unit": "lerna run test:unit --concurrency 1 --stream",
     "test:integration": "lerna run test:integration --concurrency 1 --stream",
-    "test:without-system-tests": "lerna run test --ignore system-tests --concurrency 1 --stream",
-    "test:system-tests": "lerna run test --scope system-tests --concurrency 1 --stream",
-    "coverage:system-tests": "lerna run coverage --scope system-tests --concurrency 1 --stream",
-    "vscode:package": "lerna exec --scope @salesforce/salesforcedx-* -- npm prune --production && lerna run vscode:package --concurrency 1",
+    "test:without-system-tests":
+      "lerna run test --ignore system-tests --concurrency 1 --stream",
+    "test:system-tests":
+      "lerna run test --scope system-tests --concurrency 1 --stream",
+    "coverage:system-tests":
+      "lerna run coverage --scope system-tests --concurrency 1 --stream",
+    "vscode:package":
+      "lerna exec --scope @salesforce/salesforcedx-* -- npm prune --production && lerna run vscode:package --concurrency 1 && node scripts/reformat-with-prettier",
     "vscode:sha256": "lerna run vscode:sha256 --concurrency 1",
     "vscode:publish": "lerna run vscode:publish --concurrency 1",
     "watch": "lerna run --parallel watch",
-    "eslint-check": "eslint --print-config .eslintrc.json | eslint-config-prettier-check"
+    "eslint-check":
+      "eslint --print-config .eslintrc.json | eslint-config-prettier-check"
   },
   "repository": {
     "type": "git",

--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -8,9 +8,7 @@
   "engines": {
     "vscode": "^1.17.0"
   },
-  "categories": [
-    "Debuggers"
-  ],
+  "categories": ["Debuggers"],
   "dependencies": {
     "@salesforce/salesforcedx-utils-vscode": "41.17.0",
     "async-lock": "1.0.0",
@@ -42,15 +40,16 @@
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
-    "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
-    "test": "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test --reporter mocha-multi-reporters",
-    "test:unit": "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test/unit --reporter mocha-multi-reporters",
-    "test:integration": "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test/integration --reporter mocha-multi-reporters"
+    "clean":
+      "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
+    "test":
+      "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test --reporter mocha-multi-reporters",
+    "test:unit":
+      "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test/unit --reporter mocha-multi-reporters",
+    "test:integration":
+      "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test/integration --reporter mocha-multi-reporters"
   },
   "nyc": {
-    "reporter": [
-      "text-summary",
-      "lcov"
-    ]
+    "reporter": ["text-summary", "lcov"]
   }
 }

--- a/packages/salesforcedx-slds-linter/package.json
+++ b/packages/salesforcedx-slds-linter/package.json
@@ -5,9 +5,7 @@
   "version": "41.17.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
-  "categories": [
-    "Other"
-  ],
+  "categories": ["Other"],
   "engines": {
     "vscode": "^1.17.0"
   },
@@ -41,10 +39,7 @@
     "test:unit": "node ./node_modules/vscode/bin/test"
   },
   "nyc": {
-    "reporter": [
-      "text-summary",
-      "lcov"
-    ]
+    "reporter": ["text-summary", "lcov"]
   },
   "dependencies": {
     "@salesforce/salesforcedx-utils-vscode": "41.17.0",

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@salesforce/salesforcedx-sobjects-faux-generator",
   "displayName": "Salesforce SObject Faux Generator",
-  "description": "Fetches sobjects and generates their faux apex class to be used for Apex Language Server",
+  "description":
+    "Fetches sobjects and generates their faux apex class to be used for Apex Language Server",
   "version": "41.17.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
@@ -35,14 +36,14 @@
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
     "clean": "shx rm -rf node_modules && shx rm -rf out",
-    "test": "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test",
-    "test:unit": "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test/unit",
-    "test:integration": "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test/integration"
+    "test":
+      "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test",
+    "test:unit":
+      "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test/unit",
+    "test:integration":
+      "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test/integration"
   },
   "nyc": {
-    "reporter": [
-      "text-summary",
-      "lcov"
-    ]
+    "reporter": ["text-summary", "lcov"]
   }
 }

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -1,13 +1,12 @@
 {
   "name": "@salesforce/salesforcedx-utils-vscode",
   "displayName": "SFDX Utilities for VS Code",
-  "description": "Provides utilies to interface the SFDX libraries with VS Code",
+  "description":
+    "Provides utilies to interface the SFDX libraries with VS Code",
   "version": "41.17.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
-  "categories": [
-    "Other"
-  ],
+  "categories": ["Other"],
   "dependencies": {
     "rxjs": "^5.4.1",
     "tree-kill": "^1.1.0"
@@ -38,15 +37,15 @@
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
-    "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
-    "test": "./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test --reporter mocha-multi-reporters --timeout 20000",
-    "test:unit": "./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test --reporter mocha-multi-reporters --timeout 20000",
+    "clean":
+      "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
+    "test":
+      "./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test --reporter mocha-multi-reporters --timeout 20000",
+    "test:unit":
+      "./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test --reporter mocha-multi-reporters --timeout 20000",
     "coverage": "./node_modules/.bin/nyc npm test"
   },
   "nyc": {
-    "reporter": [
-      "text-summary",
-      "lcov"
-    ]
+    "reporter": ["text-summary", "lcov"]
   }
 }

--- a/packages/salesforcedx-visualforce-language-server/package.json
+++ b/packages/salesforcedx-visualforce-language-server/package.json
@@ -33,14 +33,14 @@
     "compile": "tsc -p ./ && shx cp -R test/fixtures out/test",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
-    "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
-    "test": "./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test",
-    "test:unit": "./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test"
+    "clean":
+      "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
+    "test":
+      "./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test",
+    "test:unit":
+      "./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test"
   },
   "nyc": {
-    "reporter": [
-      "text-summary",
-      "lcov"
-    ]
+    "reporter": ["text-summary", "lcov"]
   }
 }

--- a/packages/salesforcedx-visualforce-markup-language-server/package.json
+++ b/packages/salesforcedx-visualforce-markup-language-server/package.json
@@ -7,9 +7,7 @@
   "engines": {
     "vscode": "^1.17.0"
   },
-  "activationEvents": [
-    "onView:never"
-  ],
+  "activationEvents": ["onView:never"],
   "main": "./out/src/htmlLanguageService.js",
   "typings": "./out/src/htmlLanguageService",
   "devDependencies": {
@@ -36,14 +34,14 @@
     "compile": "tsc -p ./ && shx cp src/beautify/beautify-* out/src/beautify",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
-    "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
-    "test": "./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test",
-    "test:unit": "./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test"
+    "clean":
+      "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
+    "test":
+      "./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test",
+    "test:unit":
+      "./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test"
   },
   "nyc": {
-    "reporter": [
-      "text-summary",
-      "lcov"
-    ]
+    "reporter": ["text-summary", "lcov"]
   }
 }

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -20,9 +20,7 @@
   "engines": {
     "vscode": "^1.17.0"
   },
-  "categories": [
-    "Debuggers"
-  ],
+  "categories": ["Debuggers"],
   "dependencies": {
     "@salesforce/salesforcedx-apex-debugger": "41.17.0",
     "vscode-debugprotocol": "1.24.0"
@@ -49,15 +47,13 @@
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
-    "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
+    "clean":
+      "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "test": "node ./node_modules/vscode/bin/test",
     "test:unit": "node ./node_modules/vscode/bin/test"
   },
-  "activationEvents": [
-    "onDebug",
-    "workspaceContains:sfdx-project.json"
-  ],
+  "activationEvents": ["onDebug", "workspaceContains:sfdx-project.json"],
   "main": "./out/src",
   "contributes": {
     "breakpoints": [
@@ -82,11 +78,10 @@
       {
         "type": "apex",
         "label": "Apex Debugger",
-        "program": "./node_modules/@salesforce/salesforcedx-apex-debugger/out/src/adapter/apexDebug.js",
+        "program":
+          "./node_modules/@salesforce/salesforcedx-apex-debugger/out/src/adapter/apexDebug.js",
         "runtime": "node",
-        "languages": [
-          "apex"
-        ],
+        "languages": ["apex"],
         "configurationSnippets": [
           {
             "label": "%launch_snippet_label_text%",
@@ -105,9 +100,7 @@
         "configurationAttributes": {
           "launch": {
             "properties": {
-              "required": [
-                "sfdxProject"
-              ],
+              "required": ["sfdxProject"],
               "userIdFilter": {
                 "type": "array",
                 "description": "%user_id_filter_text%",
@@ -154,10 +147,7 @@
                 "default": "${workspaceRoot}"
               },
               "trace": {
-                "type": [
-                  "boolean",
-                  "string"
-                ],
+                "type": ["boolean", "string"],
                 "description": "%trace_text%",
                 "default": false
               }

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -1,7 +1,8 @@
 {
   "name": "salesforcedx-vscode-apex",
   "displayName": "Apex Code Editor for Visual Studio Code",
-  "description": "Provides code-editing features for the Apex programming language",
+  "description":
+    "Provides code-editing features for the Apex programming language",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",
   "bugs": {
     "url": "https://github.com/forcedotcom/salesforcedx-vscode/issues"
@@ -20,9 +21,7 @@
   "engines": {
     "vscode": "^1.17.0"
   },
-  "categories": [
-    "Languages"
-  ],
+  "categories": ["Languages"],
   "devDependencies": {
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
@@ -44,14 +43,13 @@
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
-    "clean": "shx rm -rf node_modules && cd out && node ../../../scripts/clean-all-but-jar.js && shx rm -rf coverage && shx rm -rf .nyc_output",
+    "clean":
+      "shx rm -rf node_modules && cd out && node ../../../scripts/clean-all-but-jar.js && shx rm -rf coverage && shx rm -rf .nyc_output",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "test": "node ./node_modules/vscode/bin/test",
     "test:unit": "node ./node_modules/vscode/bin/test"
   },
-  "activationEvents": [
-    "workspaceContains:sfdx-project.json"
-  ],
+  "activationEvents": ["workspaceContains:sfdx-project.json"],
   "main": "./out/src",
   "contributes": {
     "configuration": {
@@ -59,10 +57,7 @@
       "title": "%configuration_title%",
       "properties": {
         "salesforcedx-vscode-apex.java.home": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "default": null,
           "description": "%java_home_description%"
         }
@@ -71,14 +66,8 @@
     "languages": [
       {
         "id": "apex",
-        "aliases": [
-          "Apex",
-          "apex"
-        ],
-        "extensions": [
-          ".cls",
-          ".trigger"
-        ],
+        "aliases": ["Apex", "apex"],
+        "extensions": [".cls", ".trigger"],
         "configuration": "./syntaxes/apex.configuration.json"
       }
     ],

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -20,9 +20,7 @@
   "engines": {
     "vscode": "^1.17.0"
   },
-  "categories": [
-    "Other"
-  ],
+  "categories": ["Other"],
   "dependencies": {
     "@salesforce/salesforcedx-sobjects-faux-generator": "41.17.0",
     "@salesforce/salesforcedx-utils-vscode": "41.17.0",
@@ -53,10 +51,13 @@
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
-    "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
+    "clean":
+      "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
     "postinstall": "node ./node_modules/vscode/bin/install",
-    "test": "cross-env CODE_TESTS_WORKSPACE='../system-tests/assets/sfdx-simple' node ./node_modules/vscode/bin/test",
-    "test:unit": "cross-env CODE_TESTS_WORKSPACE='../system-tests/assets/sfdx-simple' node ./node_modules/vscode/bin/test"
+    "test":
+      "cross-env CODE_TESTS_WORKSPACE='../system-tests/assets/sfdx-simple' node ./node_modules/vscode/bin/test",
+    "test:unit":
+      "cross-env CODE_TESTS_WORKSPACE='../system-tests/assets/sfdx-simple' node ./node_modules/vscode/bin/test"
   },
   "activationEvents": [
     "workspaceContains:sfdx-project.json",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -20,9 +20,7 @@
   "engines": {
     "vscode": "^1.17.0"
   },
-  "categories": [
-    "Languages"
-  ],
+  "categories": ["Languages"],
   "dependencies": {
     "@salesforce/salesforcedx-slds-linter": "41.17.0"
   },
@@ -47,14 +45,15 @@
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
-    "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
+    "clean":
+      "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
     "postinstall": "node ./node_modules/vscode/bin/install",
-    "test": "cross-env CODE_TESTS_WORKSPACE='../system-tests/assets/sfdx-simple' node ./node_modules/vscode/bin/test",
-    "test:unit": "cross-env CODE_TESTS_WORKSPACE='../system-tests/assets/sfdx-simple' node ./node_modules/vscode/bin/test"
+    "test":
+      "cross-env CODE_TESTS_WORKSPACE='../system-tests/assets/sfdx-simple' node ./node_modules/vscode/bin/test",
+    "test:unit":
+      "cross-env CODE_TESTS_WORKSPACE='../system-tests/assets/sfdx-simple' node ./node_modules/vscode/bin/test"
   },
-  "activationEvents": [
-    "workspaceContains:sfdx-project.json"
-  ],
+  "activationEvents": ["workspaceContains:sfdx-project.json"],
   "main": "./out/src",
   "contributes": {
     "languages": [

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -20,9 +20,7 @@
   "engines": {
     "vscode": "^1.17.0"
   },
-  "categories": [
-    "Languages"
-  ],
+  "categories": ["Languages"],
   "dependencies": {
     "lwc-language-server": "0.14.1",
     "vscode-languageclient": "3.5.0"
@@ -40,19 +38,19 @@
     "typescript": "2.6.2",
     "vscode": "1.1.8"
   },
-  "extensionDependencies": [
-    "dbaeumer.vscode-eslint"
-  ],
+  "extensionDependencies": ["dbaeumer.vscode-eslint"],
   "scripts": {
     "vscode:prepublish": "npm prune --production",
     "vscode:package": "vsce package",
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
-    "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
+    "clean":
+      "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "pretest": "node ../../scripts/download-vscode-for-system-tests",
-    "test": "node ../../scripts/install-vsix-dependencies dbaeumer.vscode-eslint && node ../../scripts/run-test-with-top-level-extensions"
+    "test":
+      "node ../../scripts/install-vsix-dependencies dbaeumer.vscode-eslint && node ../../scripts/run-test-with-top-level-extensions"
   },
   "activationEvents": [
     "workspaceContains:package.json",

--- a/packages/salesforcedx-vscode-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-replay-debugger/package.json
@@ -20,9 +20,7 @@
   "engines": {
     "vscode": "^1.19.0"
   },
-  "categories": [
-    "Debuggers"
-  ],
+  "categories": ["Debuggers"],
   "dependencies": {
     "@salesforce/salesforcedx-utils-vscode": "41.17.0",
     "vscode-debugadapter": "1.25.0",
@@ -54,10 +52,13 @@
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
-    "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
+    "clean":
+      "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
     "postinstall": "node ./node_modules/vscode/bin/install",
-    "test": "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test --reporter mocha-multi-reporters",
-    "test:unit": "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test/unit --reporter mocha-multi-reporters"
+    "test":
+      "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test --reporter mocha-multi-reporters",
+    "test:unit":
+      "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test/unit --reporter mocha-multi-reporters"
   },
   "activationEvents": [
     "onDebug",
@@ -76,9 +77,7 @@
         "label": "Apex Replay Debugger",
         "program": "./out/src/adapter/apexReplayDebug.js",
         "runtime": "node",
-        "languages": [
-          "apex"
-        ],
+        "languages": ["apex"],
         "variables": {
           "AskForLogFileName": "extension.replay-debugger.getLogFileName"
         },
@@ -99,9 +98,7 @@
         "configurationAttributes": {
           "launch": {
             "properties": {
-              "required": [
-                "logFile"
-              ],
+              "required": ["logFile"],
               "logFile": {
                 "type": "string",
                 "description": "%logfile_text%",
@@ -124,9 +121,6 @@
     ]
   },
   "nyc": {
-    "reporter": [
-      "text-summary",
-      "lcov"
-    ]
+    "reporter": ["text-summary", "lcov"]
   }
 }

--- a/packages/salesforcedx-vscode-visualforce/package.json
+++ b/packages/salesforcedx-vscode-visualforce/package.json
@@ -20,9 +20,7 @@
   "engines": {
     "vscode": "^1.17.0"
   },
-  "categories": [
-    "Languages"
-  ],
+  "categories": ["Languages"],
   "dependencies": {
     "@salesforce/salesforcedx-visualforce-language-server": "41.17.0",
     "@salesforce/salesforcedx-visualforce-markup-language-server": "41.17.0",
@@ -50,27 +48,20 @@
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
-    "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
+    "clean":
+      "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "test": "node ./node_modules/vscode/bin/test",
     "test:unit": "node ./node_modules/vscode/bin/test"
   },
-  "activationEvents": [
-    "workspaceContains:sfdx-project.json"
-  ],
+  "activationEvents": ["workspaceContains:sfdx-project.json"],
   "main": "./out/src/extension",
   "contributes": {
     "languages": [
       {
         "id": "visualforce",
-        "aliases": [
-          "Visualforce",
-          "visualforce"
-        ],
-        "extensions": [
-          ".page",
-          ".component"
-        ],
+        "aliases": ["Visualforce", "visualforce"],
+        "extensions": [".page", ".component"],
         "configuration": "./syntaxes/visualforce.configuration.json"
       }
     ],
@@ -102,19 +93,13 @@
           "description": "%visualforce.format.wrapLineLength.desc%"
         },
         "visualforce.format.unformatted": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "scope": "resource",
           "default": "",
           "description": "%visualforce.format.unformatted.desc%"
         },
         "visualforce.format.contentUnformatted": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "scope": "resource",
           "default": "pre,code,textarea",
           "description": "%visualforce.format.contentUnformatted.desc%"
@@ -132,10 +117,7 @@
           "description": "%visualforce.format.preserveNewLines.desc%"
         },
         "visualforce.format.maxPreserveNewLines": {
-          "type": [
-            "number",
-            "null"
-          ],
+          "type": ["number", "null"],
           "scope": "resource",
           "default": null,
           "description": "%visualforce.format.maxPreserveNewLines.desc%"
@@ -147,10 +129,7 @@
           "description": "%visualforce.format.endWithNewline.desc%"
         },
         "visualforce.format.extraLiners": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "scope": "resource",
           "default": "head, body, /html",
           "description": "%visualforce.format.extraLiners.desc%"
@@ -159,12 +138,7 @@
           "type": "string",
           "scope": "resource",
           "default": "auto",
-          "enum": [
-            "auto",
-            "force",
-            "force-aligned",
-            "force-expand-multiline"
-          ],
+          "enum": ["auto", "force", "force-aligned", "force-expand-multiline"],
           "enumDescriptions": [
             "%visualforce.format.wrapAttributes.auto%",
             "%visualforce.format.wrapAttributes.force%",
@@ -200,11 +174,7 @@
         "visualforce.trace.server": {
           "type": "string",
           "scope": "window",
-          "enum": [
-            "off",
-            "messages",
-            "verbose"
-          ],
+          "enum": ["off", "messages", "verbose"],
           "default": "off",
           "description": "%visualforce.trace.server.desc%"
         }

--- a/packages/salesforcedx-vscode/package.json
+++ b/packages/salesforcedx-vscode/package.json
@@ -1,7 +1,8 @@
 {
   "name": "salesforcedx-vscode",
   "displayName": "Salesforce Extensions for VS Code",
-  "description": "Collection of extensions for the Salesforce DX development flow",
+  "description":
+    "Collection of extensions for the Salesforce DX development flow",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",
   "bugs": {
     "url": "https://github.com/forcedotcom/salesforcedx-vscode/issues"
@@ -26,9 +27,7 @@
     "vscode:sha256": "node ../../scripts/generate-sha256.js >> ../../SHA256",
     "vscode:publish": "node ../../scripts/publish-vsix.js"
   },
-  "categories": [
-    "Extension Packs"
-  ],
+  "categories": ["Extension Packs"],
   "extensionDependencies": [
     "salesforce.salesforcedx-vscode-apex",
     "salesforce.salesforcedx-vscode-apex-debugger",

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -84,7 +84,7 @@ if (checkTags.includes(nextVersion)) {
 }
 
 // Real-clean
-shell.exec('git clean -xfd');
+shell.exec('git clean -xfd -e node_modules');
 
 // Install and bootstrap
 shell.exec('npm install');
@@ -98,9 +98,6 @@ shell.exec('npm run compile');
 shell.exec(
   `lerna publish --force-publish --exact --repo-version ${nextVersion} --yes --skip-npm`
 );
-
-// Reformat with prettier since lerna changes the formatting in package.json
-shell.exec('./scripts/reformat-with-prettier.js');
 
 // Generate the .vsix files
 shell.exec(`npm run vscode:package`);

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -25,7 +25,7 @@ if (parseInt(major) !== 8 || parseInt(minor) < 9) {
   console.log(
     'You do not have the right version of node. We require version 8.9.0.'
   );
-  exit(-1);
+  process.exit(-1);
 }
 
 // Checks that you have access to our bucket on AWS
@@ -39,7 +39,7 @@ if (awsExitCode !== 0) {
   console.log(
     'You do not have the s3 command line installed or you do not have access to the aws s3 bucket.'
   );
-  exit(-1);
+  process.exit(-1);
 }
 
 // Checks that you have access to the salesforce publisher
@@ -48,7 +48,7 @@ if (!publishers.includes('salesforce')) {
   console.log(
     'You do not have the vsce command line installed or you do not have access to the salesforce publisher id as part of vsce.'
   );
-  exit(-1);
+  process.exit(-1);
 }
 
 // Checks that you have specified the next version as an environment variable, and that it's properly formatted.
@@ -57,7 +57,7 @@ if (!nextVersion) {
   console.log(
     'You must specify the next version of the extension by setting SALESFORCEDX_VSCODE_VERSION as an environment variable.'
   );
-  exit(-1);
+  process.exit(-1);
 } else {
   const [version, major, minor, patch] = nextVersion.match(
     /^(\d+)\.(\d+)\.(\d+)$/
@@ -70,7 +70,7 @@ if (!nextVersion) {
     console.log(
       `You must execute this script in a release branch including SALESFORCEDX_VSCODE_VERSION (e.g, release/v${nextVersion} or hotfix/v${nextVersion})`
     );
-    exit(-1);
+    process.exit(-1);
   }
 }
 
@@ -80,7 +80,7 @@ if (checkTags.includes(nextVersion)) {
   console.log(
     'There is a conflicting git tag. Reclone the repository and start fresh to avoid versioning problems.'
   );
-  exit(-1);
+  process.exit(-1);
 }
 
 // Real-clean

--- a/scripts/reformat-with-prettier.js
+++ b/scripts/reformat-with-prettier.js
@@ -12,7 +12,7 @@ const prettierExecutable = path.join(
 );
 
 shell.exec(
-  `${prettierExecutable} --single-quote --write "packages/salesforcedx-*/package.json"`,
+  `${prettierExecutable} --single-quote --write "packages/salesforcedx-*/package.json" "package.json"`,
   {
     cwd: path.join(__dirname, '..')
   }


### PR DESCRIPTION
### What does this PR do?

Node 8 makes it more difficult to `require` global libraries. So the previous way of trying to use the globally installed shelljs library doesn't work. See https://nodejs.org/api/modules.html#modules_loading_from_the_global_folders for the full resolution order.

We could make the old way work but that would require us to either install it in the $HOME directory, or mess with NODE_PATH. Neither sounds desirable.

So, instead the main changes are:

1. You do a `npm install` at the top-level. This brings in the dependencies.
1. When we do a `git clean` we ignore the top-level node_module which only contains things like shelljs, lerna, etc. These are never bundled so they don't affect the generated vsix.

### What issues does this PR fix or reference?
