### PR TITLE
Only activate for SFDX workspace

### DIFF
--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -52,11 +52,6 @@
     "test":
       "node ../../scripts/install-vsix-dependencies dbaeumer.vscode-eslint && node ../../scripts/run-test-with-top-level-extensions"
   },
-  "activationEvents": [
-    "workspaceContains:package.json",
-    "workspaceContains:sfdx-project.json",
-    "workspaceContains:workspace-user.xml",
-    "workspaceContains:modules"
-  ],
+  "activationEvents": ["workspaceContains:sfdx-project.json"],
   "main": "./out/src"
 }


### PR DESCRIPTION
### What does this PR do?

The LWC extension is activated for both local and external users. This limits it so that it only activates for SFDX users.

### What issues does this PR fix or reference?
