### PR TITLE
Print USER_DEBUG messages to console with link to source

### DIFF
--- a/packages/salesforcedx-vscode-replay-debugger/src/adapter/apexReplayDebug.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/src/adapter/apexReplayDebug.ts
@@ -360,14 +360,14 @@ export class ApexReplayDebug extends LoggingDebugSession {
 
   public printToDebugConsole(
     msg: string,
-    type = 'stdout',
+    category = 'stdout',
     sourceFile?: Source,
     sourceLine?: number
   ): void {
     if (msg && msg.length !== 0) {
       const event: DebugProtocol.OutputEvent = new OutputEvent(
         `${msg}${EOL}`,
-        type
+        category
       );
       event.body.source = sourceFile;
       event.body.line = sourceLine;

--- a/packages/salesforcedx-vscode-replay-debugger/src/adapter/apexReplayDebug.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/src/adapter/apexReplayDebug.ts
@@ -360,9 +360,9 @@ export class ApexReplayDebug extends LoggingDebugSession {
 
   public printToDebugConsole(
     msg: string,
-    category = 'stdout',
     sourceFile?: Source,
-    sourceLine?: number
+    sourceLine?: number,
+    category = 'stdout'
   ): void {
     if (msg && msg.length !== 0) {
       const event: DebugProtocol.OutputEvent = new OutputEvent(
@@ -381,7 +381,7 @@ export class ApexReplayDebug extends LoggingDebugSession {
     sourceFile?: Source,
     sourceLine?: number
   ): void {
-    this.printToDebugConsole(msg, 'console', sourceFile, sourceLine);
+    this.printToDebugConsole(msg, sourceFile, sourceLine, 'console');
   }
 
   public errorToDebugConsole(
@@ -389,7 +389,7 @@ export class ApexReplayDebug extends LoggingDebugSession {
     sourceFile?: Source,
     sourceLine?: number
   ): void {
-    this.printToDebugConsole(msg, 'stderr', sourceFile, sourceLine);
+    this.printToDebugConsole(msg, sourceFile, sourceLine, 'stderr');
   }
 
   public getBreakpointUtil(): BreakpointUtil {

--- a/packages/salesforcedx-vscode-replay-debugger/src/constants.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/src/constants.ts
@@ -16,10 +16,10 @@ export const EVENT_EXECUTE_ANONYMOUS = 'Execute Anonymous';
 export const EVENT_METHOD_ENTRY = 'METHOD_ENTRY';
 export const EVENT_METHOD_EXIT = 'METHOD_EXIT';
 export const EVENT_STATEMENT_EXECUTE = 'STATEMENT_EXECUTE';
+export const EVENT_USER_DEBUG = 'USER_DEBUG';
 export const EVENT_VF_APEX_CALL_START = 'VF_APEX_CALL_START';
 export const EVENT_VF_APEX_CALL_END = 'VF_APEX_CALL_END';
 export const EXEC_ANON_SIGNATURE = 'execute_anonymous_apex';
 export const GET_LINE_BREAKPOINT_INFO_EVENT = 'getLineBreakpointInfo';
 export const LINE_BREAKPOINT_INFO_REQUEST = 'lineBreakpointInfo';
 export const SFDC_TRIGGER = '__sfdc_trigger/';
-

--- a/packages/salesforcedx-vscode-replay-debugger/src/core/logContext.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/src/core/logContext.ts
@@ -85,6 +85,10 @@ export class LogContext {
     return this.logLinePosition;
   }
 
+  public incrementLogLinePosition(): void {
+    this.logLinePosition += 1;
+  }
+
   public getFrames(): StackFrame[] {
     return this.stackFrameInfos;
   }
@@ -151,10 +155,13 @@ export class LogContext {
     while (++this.logLinePosition < this.logLines.length) {
       const logLine = this.logLines[this.logLinePosition];
       if (logLine) {
-        if (this.session.shouldTraceLogFile()) {
+        this.setState(this.parseLogEvent(logLine));
+        if (
+          this.session.shouldTraceLogFile() &&
+          !(this.state instanceof UserDebugState)
+        ) {
           this.session.printToDebugConsole(logLine);
         }
-        this.setState(this.parseLogEvent(logLine));
         if (this.state && this.state.handle(this)) {
           break;
         }

--- a/packages/salesforcedx-vscode-replay-debugger/src/states/index.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/src/states/index.ts
@@ -9,5 +9,6 @@ export { DebugLogState } from './debugLogState';
 export { FrameEntryState } from './frameEntryState';
 export { FrameExitState } from './frameExitState';
 export { LogEntryState } from './logEntryState';
-export { StatementExecuteState } from './statementExecuteState';
 export { NoOpState } from './noOpState';
+export { StatementExecuteState } from './statementExecuteState';
+export { UserDebugState } from './userDebugState';

--- a/packages/salesforcedx-vscode-replay-debugger/src/states/userDebugState.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/src/states/userDebugState.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { EXEC_ANON_SIGNATURE } from '../constants';
+import { LogContext } from '../core/logContext';
+import { DebugLogState } from './debugLogState';
+
+export class UserDebugState implements DebugLogState {
+  private readonly line: number;
+  private readonly message: string;
+
+  constructor(fields: string[]) {
+    this.line = parseInt(fields[2]);
+    this.message = fields[fields.length - 1];
+  }
+
+  public handle(logContext: LogContext): boolean {
+    const frame = logContext.getTopFrame();
+    if (frame) {
+      logContext
+        .getSession()
+        .warnToDebugConsole(
+          this.message,
+          frame.source,
+          frame.name === EXEC_ANON_SIGNATURE
+            ? logContext.getExecAnonScriptLocationInDebugLog(this.line)
+            : this.line
+        );
+    }
+    return false;
+  }
+}

--- a/packages/salesforcedx-vscode-replay-debugger/src/states/userDebugState.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/src/states/userDebugState.ts
@@ -5,20 +5,26 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { EOL } from 'os';
 import { EXEC_ANON_SIGNATURE } from '../constants';
 import { LogContext } from '../core/logContext';
 import { DebugLogState } from './debugLogState';
 
 export class UserDebugState implements DebugLogState {
   private readonly line: number;
-  private readonly message: string;
+  private message: string;
 
   constructor(fields: string[]) {
     this.line = parseInt(fields[2]);
     this.message = fields[fields.length - 1];
   }
 
+  public getMessage(): string {
+    return this.message;
+  }
+
   public handle(logContext: LogContext): boolean {
+    this.lookAheadAndAppend(logContext);
     const frame = logContext.getTopFrame();
     if (frame) {
       logContext
@@ -32,5 +38,23 @@ export class UserDebugState implements DebugLogState {
         );
     }
     return false;
+  }
+
+  public lookAheadAndAppend(logContext: LogContext): void {
+    for (
+      let i = logContext.getLogLinePosition() + 1;
+      i < logContext.getLogLines().length;
+      i++
+    ) {
+      // Get next log line as-is (no trimming)
+      const nextLogLine = logContext.getLogLines()[i];
+      // Check if this could be a debug log event
+      if (nextLogLine.split('|').length >= 3) {
+        break;
+      }
+      // If it's not a debug log event, assume it's in the user's
+      this.message = `${this.message}${EOL}${nextLogLine}`;
+      logContext.incrementLogLinePosition();
+    }
   }
 }

--- a/packages/salesforcedx-vscode-replay-debugger/test/unit/adapter/apexReplayDebug.test.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/test/unit/adapter/apexReplayDebug.test.ts
@@ -30,7 +30,7 @@ import { nls } from '../../../src/messages';
 
 export class MockApexReplayDebug extends ApexReplayDebug {
   public setLogFile(args: LaunchRequestArguments) {
-    this.logContext = new LogContext(args, new BreakpointUtil());
+    this.logContext = new LogContext(args, this);
   }
 
   public getDefaultResponse(): DebugProtocol.Response {

--- a/packages/salesforcedx-vscode-replay-debugger/test/unit/adapter/debugConsole.test.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/test/unit/adapter/debugConsole.test.ts
@@ -41,6 +41,7 @@ describe('Debug console', () => {
 
       expect(adapter.getTraceConfig()).to.be.eql(['all']);
       expect(adapter.getTraceAllConfig()).to.be.true;
+      expect(adapter.shouldTraceLogFile()).to.be.true;
     });
 
     it('Should accept boolean false', () => {
@@ -50,6 +51,7 @@ describe('Debug console', () => {
 
       expect(adapter.getTraceConfig()).to.be.empty;
       expect(adapter.getTraceAllConfig()).to.be.false;
+      expect(adapter.shouldTraceLogFile()).to.be.false;
     });
 
     it('Should accept multiple trace categories', () => {
@@ -64,6 +66,16 @@ describe('Debug console', () => {
       ]);
       expect(adapter.getTraceAllConfig()).to.be.true;
     });
+
+    it('Should accept logfile category', () => {
+      args.trace = 'logfile';
+
+      adapter.setupLogger(args);
+
+      expect(adapter.getTraceConfig()).to.be.eql(['logfile']);
+      expect(adapter.getTraceAllConfig()).to.be.false;
+      expect(adapter.shouldTraceLogFile()).to.be.true;
+    });
   });
 
   describe('Print', () => {
@@ -74,12 +86,6 @@ describe('Debug console', () => {
 
     afterEach(() => {
       sendEventSpy.restore();
-    });
-
-    it('Should not print if message is undefined', () => {
-      adapter.printToDebugConsole(undefined);
-
-      expect(sendEventSpy.notCalled).to.be.true;
     });
 
     it('Should not print is message is empty', () => {
@@ -93,7 +99,7 @@ describe('Debug console', () => {
         logFileName,
         encodeURI(`file://${logFilePath}`)
       );
-      adapter.printToDebugConsole('test', source, 5);
+      adapter.printToDebugConsole('test', 'stdout', source, 5);
 
       expect(sendEventSpy.calledOnce).to.be.true;
       const outputEvent: DebugProtocol.OutputEvent = sendEventSpy.getCall(0)
@@ -114,12 +120,6 @@ describe('Debug console', () => {
 
     afterEach(() => {
       sendEventSpy.restore();
-    });
-
-    it('Should not warn if message is undefined', () => {
-      adapter.warnToDebugConsole(undefined);
-
-      expect(sendEventSpy.notCalled).to.be.true;
     });
 
     it('Should not warn is message is empty', () => {
@@ -147,12 +147,6 @@ describe('Debug console', () => {
 
     afterEach(() => {
       sendEventSpy.restore();
-    });
-
-    it('Should not error if message is undefined', () => {
-      adapter.errorToDebugConsole(undefined);
-
-      expect(sendEventSpy.notCalled).to.be.true;
     });
 
     it('Should not error is message is empty', () => {

--- a/packages/salesforcedx-vscode-replay-debugger/test/unit/adapter/debugConsole.test.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/test/unit/adapter/debugConsole.test.ts
@@ -99,7 +99,7 @@ describe('Debug console', () => {
         logFileName,
         encodeURI(`file://${logFilePath}`)
       );
-      adapter.printToDebugConsole('test', 'stdout', source, 5);
+      adapter.printToDebugConsole('test', source, 5, 'stdout');
 
       expect(sendEventSpy.calledOnce).to.be.true;
       const outputEvent: DebugProtocol.OutputEvent = sendEventSpy.getCall(0)

--- a/packages/salesforcedx-vscode-replay-debugger/test/unit/core/logContext.test.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/test/unit/core/logContext.test.ts
@@ -43,6 +43,8 @@ describe('LogContext', () => {
   let readLogFileStub: sinon.SinonStub;
   let parseLogEventStub: sinon.SinonStub;
   let noOpHandleStub: sinon.SinonStub;
+  let shouldTraceLogFileStub: sinon.SinonStub;
+  let printToDebugConsoleStub: sinon.SinonStub;
   const launchRequestArgs: LaunchRequestArguments = {
     logFile: '/path/foo.log',
     trace: true
@@ -52,6 +54,13 @@ describe('LogContext', () => {
     readLogFileStub = sinon
       .stub(LogContextUtil.prototype, 'readLogFile')
       .returns(['line1', 'line2']);
+    shouldTraceLogFileStub = sinon
+      .stub(ApexReplayDebug.prototype, 'shouldTraceLogFile')
+      .returns(true);
+    printToDebugConsoleStub = sinon.stub(
+      ApexReplayDebug.prototype,
+      'printToDebugConsole'
+    );
     context = new LogContext(launchRequestArgs, new ApexReplayDebug());
   });
 
@@ -63,6 +72,8 @@ describe('LogContext', () => {
     if (noOpHandleStub) {
       noOpHandleStub.restore();
     }
+    shouldTraceLogFileStub.restore();
+    printToDebugConsoleStub.restore();
   });
 
   it('Should return array of log lines', () => {
@@ -149,6 +160,7 @@ describe('LogContext', () => {
     expect(context.getLogLinePosition()).to.equal(1);
     expect(context.hasState()).to.be.true;
     expect(context.getFrames()).to.be.empty;
+    expect(printToDebugConsoleStub.calledTwice).to.be.true;
   });
 
   describe('Log event parser', () => {

--- a/packages/salesforcedx-vscode-replay-debugger/test/unit/states/frameEntryState.test.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/test/unit/states/frameEntryState.test.ts
@@ -8,8 +8,10 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { StackFrame } from 'vscode-debugadapter';
-import { LaunchRequestArguments } from '../../../src/adapter/apexReplayDebug';
-import { BreakpointUtil } from '../../../src/breakpoints';
+import {
+  ApexReplayDebug,
+  LaunchRequestArguments
+} from '../../../src/adapter/apexReplayDebug';
 import { LogContext } from '../../../src/core';
 import { FrameEntryState } from '../../../src/states';
 
@@ -35,7 +37,7 @@ describe('Frame entry event', () => {
 
   it('Should add a frame', () => {
     const state = new FrameEntryState(['signature']);
-    const context = new LogContext(launchRequestArgs, new BreakpointUtil());
+    const context = new LogContext(launchRequestArgs, new ApexReplayDebug());
     context
       .getFrames()
       .push({ id: 0, name: 'execute_anonymous_apex' } as StackFrame);

--- a/packages/salesforcedx-vscode-replay-debugger/test/unit/states/frameExitState.test.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/test/unit/states/frameExitState.test.ts
@@ -7,8 +7,10 @@
 
 import { expect } from 'chai';
 import { StackFrame } from 'vscode-debugadapter';
-import { LaunchRequestArguments } from '../../../src/adapter/apexReplayDebug';
-import { BreakpointUtil } from '../../../src/breakpoints';
+import {
+  ApexReplayDebug,
+  LaunchRequestArguments
+} from '../../../src/adapter/apexReplayDebug';
 import { LogContext } from '../../../src/core';
 import { FrameExitState } from '../../../src/states';
 
@@ -23,7 +25,7 @@ describe('Frame exit event', () => {
   };
 
   beforeEach(() => {
-    context = new LogContext(launchRequestArgs, new BreakpointUtil());
+    context = new LogContext(launchRequestArgs, new ApexReplayDebug());
   });
 
   it('Should not remove anything if there are no frames', () => {

--- a/packages/salesforcedx-vscode-replay-debugger/test/unit/states/logEntryState.test.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/test/unit/states/logEntryState.test.ts
@@ -7,8 +7,10 @@
 
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import { LaunchRequestArguments } from '../../../src/adapter/apexReplayDebug';
-import { BreakpointUtil } from '../../../src/breakpoints';
+import {
+  ApexReplayDebug,
+  LaunchRequestArguments
+} from '../../../src/adapter/apexReplayDebug';
 import { LogContext, LogContextUtil } from '../../../src/core';
 import { LogEntryState } from '../../../src/states';
 
@@ -33,7 +35,7 @@ describe('LogEntry event', () => {
         stopOnEntry: true,
         trace: true
       } as LaunchRequestArguments,
-      new BreakpointUtil()
+      new ApexReplayDebug()
     );
     const logEntry = new LogEntryState();
 

--- a/packages/salesforcedx-vscode-replay-debugger/test/unit/states/noOpState.test.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/test/unit/states/noOpState.test.ts
@@ -6,8 +6,10 @@
  */
 
 import { expect } from 'chai';
-import { LaunchRequestArguments } from '../../../src/adapter/apexReplayDebug';
-import { BreakpointUtil } from '../../../src/breakpoints';
+import {
+  ApexReplayDebug,
+  LaunchRequestArguments
+} from '../../../src/adapter/apexReplayDebug';
 import { LogContext } from '../../../src/core';
 import { NoOpState } from '../../../src/states';
 
@@ -19,7 +21,7 @@ describe('NoOp event', () => {
         logFile: '/path/foo.log',
         trace: true
       } as LaunchRequestArguments,
-      new BreakpointUtil()
+      new ApexReplayDebug()
     );
     const unsupported = new NoOpState();
 

--- a/packages/salesforcedx-vscode-replay-debugger/test/unit/states/statementExecuteState.test.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/test/unit/states/statementExecuteState.test.ts
@@ -7,8 +7,10 @@
 
 import { expect } from 'chai';
 import { StackFrame } from 'vscode-debugadapter';
-import { LaunchRequestArguments } from '../../../src/adapter/apexReplayDebug';
-import { BreakpointUtil } from '../../../src/breakpoints';
+import {
+  ApexReplayDebug,
+  LaunchRequestArguments
+} from '../../../src/adapter/apexReplayDebug';
 import { EXEC_ANON_SIGNATURE } from '../../../src/constants';
 import { LogContext } from '../../../src/core';
 import { StatementExecuteState } from '../../../src/states';
@@ -24,7 +26,7 @@ describe('Statement execute event', () => {
   };
 
   beforeEach(() => {
-    context = new LogContext(launchRequestArgs, new BreakpointUtil());
+    context = new LogContext(launchRequestArgs, new ApexReplayDebug());
   });
 
   it('Should not update frame without any frames', () => {

--- a/packages/salesforcedx-vscode-replay-debugger/test/unit/states/userDebugState.test.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/test/unit/states/userDebugState.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { expect } from 'chai';
+import { EOL } from 'os';
 import * as sinon from 'sinon';
 import { StackFrame } from 'vscode-debugadapter';
 import {
@@ -19,6 +20,7 @@ import { UserDebugState } from '../../../src/states';
 // tslint:disable:no-unused-expression
 describe('User debug event', () => {
   let warnToDebugConsoleStub: sinon.SinonStub;
+  let getLogLinesStub: sinon.SinonStub;
   let context: LogContext;
   const logFileName = 'foo.log';
   const logFilePath = `path/${logFileName}`;
@@ -33,10 +35,14 @@ describe('User debug event', () => {
       ApexReplayDebug.prototype,
       'warnToDebugConsole'
     );
+    getLogLinesStub = sinon
+      .stub(LogContext.prototype, 'getLogLines')
+      .returns(['foo', 'bar', 'timestamp|USER_DEBUG|[3]|DEBUG|Next message']);
   });
 
   afterEach(() => {
     warnToDebugConsoleStub.restore();
+    getLogLinesStub.restore();
   });
 
   it('Should not print without any frames', () => {
@@ -71,7 +77,7 @@ describe('User debug event', () => {
     expect(state.handle(context)).to.be.false;
     expect(warnToDebugConsoleStub.calledOnce).to.be.true;
     expect(warnToDebugConsoleStub.getCall(0).args).to.have.same.members([
-      'Hello',
+      `Hello${EOL}foo${EOL}bar`,
       frame.source,
       5
     ]);
@@ -94,7 +100,7 @@ describe('User debug event', () => {
     expect(state.handle(context)).to.be.false;
     expect(warnToDebugConsoleStub.calledOnce).to.be.true;
     expect(warnToDebugConsoleStub.getCall(0).args).to.have.same.members([
-      'Hello',
+      `Hello${EOL}foo${EOL}bar`,
       frame.source,
       2
     ]);

--- a/packages/salesforcedx-vscode-replay-debugger/test/unit/states/userDebugState.test.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/test/unit/states/userDebugState.test.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { StackFrame } from 'vscode-debugadapter';
+import {
+  ApexReplayDebug,
+  LaunchRequestArguments
+} from '../../../src/adapter/apexReplayDebug';
+import { EXEC_ANON_SIGNATURE } from '../../../src/constants';
+import { LogContext } from '../../../src/core';
+import { UserDebugState } from '../../../src/states';
+
+// tslint:disable:no-unused-expression
+describe('User debug event', () => {
+  let warnToDebugConsoleStub: sinon.SinonStub;
+  let context: LogContext;
+  const logFileName = 'foo.log';
+  const logFilePath = `path/${logFileName}`;
+  const launchRequestArgs: LaunchRequestArguments = {
+    logFile: logFilePath,
+    trace: true
+  };
+
+  beforeEach(() => {
+    context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+    warnToDebugConsoleStub = sinon.stub(
+      ApexReplayDebug.prototype,
+      'warnToDebugConsole'
+    );
+  });
+
+  afterEach(() => {
+    warnToDebugConsoleStub.restore();
+  });
+
+  it('Should not print without any frames', () => {
+    const state = new UserDebugState([
+      'timestamp',
+      'USER_DEBUG',
+      '2',
+      'DEBUG',
+      'Hello'
+    ]);
+
+    expect(state.handle(context)).to.be.false;
+    expect(context.getFrames()).to.be.empty;
+    expect(warnToDebugConsoleStub.called).to.be.false;
+  });
+
+  it('Should link to anonymous specific frame', () => {
+    const frame = {
+      name: EXEC_ANON_SIGNATURE,
+      source: { name: 'foo.log' }
+    } as StackFrame;
+    context.getFrames().push(frame);
+    context.getExecAnonScriptMapping().set(2, 5);
+    const state = new UserDebugState([
+      'timestamp',
+      'USER_DEBUG',
+      '2',
+      'DEBUG',
+      'Hello'
+    ]);
+
+    expect(state.handle(context)).to.be.false;
+    expect(warnToDebugConsoleStub.calledOnce).to.be.true;
+    expect(warnToDebugConsoleStub.getCall(0).args).to.have.same.members([
+      'Hello',
+      frame.source,
+      5
+    ]);
+  });
+
+  it('Should use line number in log line', () => {
+    const frame = {
+      name: 'foo',
+      source: { name: 'foo.cls' }
+    } as StackFrame;
+    context.getFrames().push(frame);
+    const state = new UserDebugState([
+      'timestamp',
+      'USER_DEBUG',
+      '2',
+      'DEBUG',
+      'Hello'
+    ]);
+
+    expect(state.handle(context)).to.be.false;
+    expect(warnToDebugConsoleStub.calledOnce).to.be.true;
+    expect(warnToDebugConsoleStub.getCall(0).args).to.have.same.members([
+      'Hello',
+      frame.source,
+      2
+    ]);
+  });
+});


### PR DESCRIPTION
### What does this PR do?
![userdebug](https://user-images.githubusercontent.com/7286437/35694645-d20ddde8-0736-11e8-97a8-8e455223cc59.gif)

When it detects `USER_DEBUG` log event, it will:
- Send a `DebugProtocol.OutputEvent` to VS Code with `DebugProtocol.Source`, line number, and `DebugProtocol.OutputEvent.body.category`.
- `DebugProtocol.Source` is always the source of the topmost frame (if any) because the execution in debug log is linear.
- Line number is from the `USER_DEBUG` log line.
- `DebugProtocol.OutputEvent.body.category` is "console" so the color is orange.


**Up for discussion**:
- If the user configures their launch config to print debug log lines as they are parsed, they see:

![image](https://user-images.githubusercontent.com/7286437/35695146-85dbf386-0738-11e8-943f-20a1fea3fae9.png)

### What issues does this PR fix or reference?
@ W-4549446@