### PR TITLE
Refactor frame states to use a single base class so any frame name mo…

### DIFF
--- a/packages/salesforcedx-vscode-replay-debugger/src/states/frameEntryState.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/src/states/frameEntryState.ts
@@ -8,21 +8,13 @@
 import { basename } from 'path';
 import { Source, StackFrame } from 'vscode-debugadapter';
 import Uri from 'vscode-uri';
-import { SFDC_TRIGGER } from '../constants';
 import { LogContext } from '../core/logContext';
 import { DebugLogState } from './debugLogState';
+import { FrameState } from './frameState';
 
-export class FrameEntryState implements DebugLogState {
-  private readonly signature: string;
-  private readonly frameName: string;
-
+export class FrameEntryState extends FrameState implements DebugLogState {
   constructor(fields: string[]) {
-    this.signature = fields[fields.length - 1];
-    if (this.signature.startsWith(SFDC_TRIGGER)) {
-      this.frameName = this.signature.substring(SFDC_TRIGGER.length);
-    } else {
-      this.frameName = this.signature;
-    }
+    super(fields);
   }
 
   public handle(logContext: LogContext): boolean {

--- a/packages/salesforcedx-vscode-replay-debugger/src/states/frameExitState.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/src/states/frameExitState.ts
@@ -7,12 +7,11 @@
 
 import { LogContext } from '../core/logContext';
 import { DebugLogState } from './debugLogState';
+import { FrameState } from './frameState';
 
-export class FrameExitState implements DebugLogState {
-  private readonly signature: string;
-
+export class FrameExitState extends FrameState implements DebugLogState {
   constructor(fields: string[]) {
-    this.signature = fields[fields.length - 1];
+    super(fields);
   }
 
   public handle(logContext: LogContext): boolean {
@@ -21,8 +20,8 @@ export class FrameExitState implements DebugLogState {
       if (topFrame) {
         logContext.getFrames().pop();
         if (
-          topFrame.name === this.signature ||
-          topFrame.name.startsWith(this.signature)
+          topFrame.name === this.frameName ||
+          topFrame.name.startsWith(this.frameName)
         ) {
           break;
         }

--- a/packages/salesforcedx-vscode-replay-debugger/src/states/frameState.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/src/states/frameState.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
 import { SFDC_TRIGGER } from '../constants';
 
 export class FrameState {

--- a/packages/salesforcedx-vscode-replay-debugger/src/states/frameState.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/src/states/frameState.ts
@@ -1,0 +1,15 @@
+import { SFDC_TRIGGER } from '../constants';
+
+export class FrameState {
+  protected readonly signature: string;
+  protected readonly frameName: string;
+
+  constructor(fields: string[]) {
+    this.signature = fields[fields.length - 1];
+    if (this.signature.startsWith(SFDC_TRIGGER)) {
+      this.frameName = this.signature.substring(SFDC_TRIGGER.length);
+    } else {
+      this.frameName = this.signature;
+    }
+  }
+}


### PR DESCRIPTION
…difications only have to be done in one place

### What does this PR do?
Refactor frame states to use a single base class so any frame name modifications only have to be done in one place. Instead of frameEntryState and frameExitState both having constructors that would need to manipulate the frame name, create a base class they can extend and put the logic in there. With this change, any logic to set or manipulate the frame name, only has to be made in once place.

### What issues does this PR fix or reference?
@W-4672633@