### PR TITLE
Remove setting declaration

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -407,11 +407,6 @@
           "type": ["boolean"],
           "default": true,
           "description": "%show_cli_success_msg_description%"
-        },
-        "salesforcedx-vscode-core.isv-debugger.enabled": {
-          "type": "boolean",
-          "default": false,
-          "description": "%isv_debugger_enabled_description%"
         }
       }
     }

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -53,7 +53,5 @@
     "SFDX: Turn off Apex Debug Log for Replay Debugger",
 
   "isv_bootstrap_command_text":
-    "SFDX: Create and Set Up Project for ISV Debugging",
-  "isv_debugger_enabled_description":
-    "Set to true to enable a feature preview of the ISV Debugger."
+    "SFDX: Create and Set Up Project for ISV Debugging"
 }


### PR DESCRIPTION
### What issues does this PR fix or reference?
This should hide the ISV enablement setting from the VS Code marketplace.