### PR TITLE
Don't fail for missing labels

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/i18n/localization.ts
+++ b/packages/salesforcedx-utils-vscode/src/i18n/localization.ts
@@ -55,26 +55,29 @@ export class Message implements LocalizationProvider {
   }
 
   public localize(label: string, ...args: any[]): string {
-    const possibleLabel = this.getLabel(label);
+    let possibleLabel = this.getLabel(label);
 
     if (!possibleLabel) {
-      throw new Error("Message '" + label + "' doesn't exist");
+      console.warn(`Missing label for key: ${label}`);
+      possibleLabel = `!!! MISSING LABEL !!! ${label}`;
+      if (args.length >= 1) {
+        args.forEach(arg => {
+          possibleLabel += ` (${arg})`;
+        });
+      }
+      return possibleLabel;
     }
 
     if (args.length >= 1) {
       const expectedNumArgs = possibleLabel.split('%s').length - 1;
       if (args.length !== expectedNumArgs) {
-        throw new Error(
-          'Wrong number of args for message: ' +
-            label +
-            '\nExpect ' +
-            expectedNumArgs +
-            ' got ' +
-            args.length
+        // just log it, we might want to hide some in some languges on purpose
+        console.log(
+          `Arguments do not match for label '${label}', got ${args.length} but want ${expectedNumArgs}`
         );
       }
 
-      args.unshift(this.messages[label]);
+      args.unshift(possibleLabel);
       return util.format.apply(util, args);
     }
 

--- a/packages/salesforcedx-utils-vscode/test/i18n/localizationTest.ts
+++ b/packages/salesforcedx-utils-vscode/test/i18n/localizationTest.ts
@@ -70,9 +70,16 @@ describe('Localization tests', () => {
     expect(nls.localize('key_2')).to.be.equals('Bye');
   });
 
-  it('Should error if arg counts do no match', () => {
+  it('Should not fail if a key is missing in default locale', () => {
     const nls = new Localization(loadMessageBundle());
-    expect(() => nls.localize('key_3')).to.throw();
+    expect(nls.localize('non_existent_key')).to.be.equals(
+      '!!! MISSING LABEL !!! non_existent_key'
+    );
+  });
+
+  it('Should not error if arg counts do no match', () => {
+    const nls = new Localization(loadMessageBundle());
+    expect(() => nls.localize('key_3')).to.not.throw();
   });
 
   it('Should perform substitution in default locale if args >=1', () => {
@@ -84,6 +91,13 @@ describe('Localization tests', () => {
     const nls = new Localization(loadMessageBundle({ locale: 'ja' }));
     expect(nls.localize('key_3_with_args', 'John')).to.be.equals(
       'こんにちは Johnさん'
+    );
+  });
+
+  it('Should append args for missing label', () => {
+    const nls = new Localization(loadMessageBundle());
+    expect(nls.localize('non_existent_key', 'John')).to.be.equals(
+      '!!! MISSING LABEL !!! non_existent_key (John)'
     );
   });
 });


### PR DESCRIPTION
### What does this PR do?
Instead of throwing an error when a label is missing, a dummy text is returned.

This improves the development flow. It support a prototyping first approach with having all labels in place. Without that change, all labels have to exist first before one is able to use them. With this change a !!! MISSING LABEL !!! label_key is printed instead of failing with an error. 

This allows postponing the task of finalizing labels till when the code is ready. Additionally it improves error handling by presenting missing labels prominently in the UI. Depending on the code location, a thrown error might go by unrecognized.

### What issues does this PR fix or reference?
n/a