### PR TITLE
Use LWC 0.16.4

### DIFF
--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -24,7 +24,7 @@
   "categories": ["Languages"],
   "dependencies": {
     "@salesforce/salesforcedx-utils-vscode": "41.18.0",
-    "lwc-language-server": "0.16.3",
+    "lwc-language-server": "0.16.4",
     "vscode-languageclient": "3.5.0",
     "eslint": "4.16.0",
     "eslint-plugin-lwc": "0.3.2",


### PR DESCRIPTION
### What does this PR do?

Use 0.16.4 of the language server.

The UI tests for this PR will still fail. That's because VS Code 1.20 (latest one) just released some changes in the way we access the elements. This is a test issue and we have manually verified the scenarios and things are working.

### What issues does this PR fix or reference?