### PR TITLE
Source link support for test failures

### DIFF
--- a/packages/salesforcedx-vscode-core/README.md
+++ b/packages/salesforcedx-vscode-core/README.md
@@ -26,7 +26,7 @@ These Salesforce CLI commands are available:
 * `force:apex:class:create ...`: **SFDX: Create Apex Class**
 * `force:apex:execute`: **SFDX: Execute Anonymous Apex with Currently Selected Text**
 * `force:apex:execute --apexcodefile`: **SFDX: Execute Anonymous Apex with Editor Contents**
-* `force:apex:test:run ...`: **SFDX: Invoke Apex Tests...**
+* `force:apex:test:run --resultformat human ...`: **SFDX: Invoke Apex Tests...**
 * `force:apex:trigger:create ...`: **SFDX: Create Apex Trigger**
 * `force:auth:web:login --setdefaultdevhubusername`: **SFDX: Authorize a Dev Hub**
 * `force:config:list`: **SFDX: List All Config Variables**

--- a/packages/salesforcedx-vscode-core/README.md
+++ b/packages/salesforcedx-vscode-core/README.md
@@ -26,7 +26,7 @@ These Salesforce CLI commands are available:
 * `force:apex:class:create ...`: **SFDX: Create Apex Class**
 * `force:apex:execute`: **SFDX: Execute Anonymous Apex with Currently Selected Text**
 * `force:apex:execute --apexcodefile`: **SFDX: Execute Anonymous Apex with Editor Contents**
-* `force:apex:test:run --resultformat human ...`: **SFDX: Invoke Apex Tests...**
+* `force:apex:test:run ...`: **SFDX: Invoke Apex Tests...**
 * `force:apex:trigger:create ...`: **SFDX: Create Apex Trigger**
 * `force:auth:web:login --setdefaultdevhubusername`: **SFDX: Authorize a Dev Hub**
 * `force:config:list`: **SFDX: List All Config Variables**

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -169,14 +169,6 @@
           "when": "sfdx:project_opened"
         },
         {
-          "command": "sfdx.force.apex.test.class.run",
-          "when": "sfdx:project_opened"
-        },
-        {
-          "command": "sfdx.force.apex.test.method.run",
-          "when": "sfdx:project_opened"
-        },
-        {
           "command": "sfdx.force.task.stop",
           "when": "sfdx:project_opened"
         },
@@ -266,6 +258,14 @@
         {
           "command": "sfdx.debug.isv.bootstrap",
           "when": "config.salesforcedx-vscode-core.isv-debugger.enabled"
+        },
+        {
+          "command": "sfdx.force.apex.test.class.run",
+          "when": "sfdx:has_cached_test_class"
+        },
+        {
+          "command": "sfdx.force.apex.test.method.run",
+          "when": "sfdx:has_cached_test_method"
         }
       ]
     },

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -261,11 +261,11 @@
         },
         {
           "command": "sfdx.force.apex.test.class.run",
-          "when": "sfdx:has_cached_test_class"
+          "when": "sfdx:project_opened && sfdx:has_cached_test_class"
         },
         {
           "command": "sfdx.force.apex.test.method.run",
-          "when": "sfdx:has_cached_test_method"
+          "when": "sfdx:project_opened && sfdx:has_cached_test_method"
         }
       ]
     },

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -169,7 +169,11 @@
           "when": "sfdx:project_opened"
         },
         {
-          "command": "sfdx.force.apex.test.run.codeAction",
+          "command": "sfdx.force.apex.test.class.run",
+          "when": "sfdx:project_opened"
+        },
+        {
+          "command": "sfdx.force.apex.test.method.run",
           "when": "sfdx:project_opened"
         },
         {
@@ -309,6 +313,14 @@
       {
         "command": "sfdx.force.apex.test.run",
         "title": "%force_apex_test_run_text%"
+      },
+      {
+        "command": "sfdx.force.apex.test.class.run",
+        "title": "%force_apex_test_run_class_text%"
+      },
+      {
+        "command": "sfdx.force.apex.test.method.run",
+        "title": "%force_apex_test_run_method_text%"
       },
       {
         "command": "sfdx.force.task.stop",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -260,12 +260,20 @@
           "when": "config.salesforcedx-vscode-core.isv-debugger.enabled"
         },
         {
-          "command": "sfdx.force.apex.test.class.run",
+          "command": "sfdx.force.apex.test.last.class.run",
           "when": "sfdx:project_opened && sfdx:has_cached_test_class"
         },
         {
-          "command": "sfdx.force.apex.test.method.run",
+          "command": "sfdx.force.apex.test.last.method.run",
           "when": "sfdx:project_opened && sfdx:has_cached_test_method"
+        },
+        {
+          "command": "sfdx.force.apex.test.class.run",
+          "when": "false"
+        },
+        {
+          "command": "sfdx.force.apex.test.method.run",
+          "when": "false"
         }
       ]
     },
@@ -315,12 +323,20 @@
         "title": "%force_apex_test_run_text%"
       },
       {
+        "command": "sfdx.force.apex.test.last.class.run",
+        "title": "%force_apex_test_last_class_run_text%"
+      },
+      {
+        "command": "sfdx.force.apex.test.last.method.run",
+        "title": "%force_apex_test_last_method_run_text%"
+      },
+      {
         "command": "sfdx.force.apex.test.class.run",
-        "title": "%force_apex_test_run_class_text%"
+        "title": "%force_apex_test_class_run_text%"
       },
       {
         "command": "sfdx.force.apex.test.method.run",
-        "title": "%force_apex_test_run_method_text%"
+        "title": "%force_apex_test_method_run_text%"
       },
       {
         "command": "sfdx.force.task.stop",

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -19,9 +19,9 @@
   "force_apex_test_class_run_text": "SFDX: Invoke Apex Test Class",
   "force_apex_test_method_run_text": "SFDX: Invoke Apex Test Method",
   "force_apex_test_last_class_run_text":
-    "SFDX: Re-Run Last Executed Test Class",
+    "SFDX: Re-Run Last Invoked Apex Test Class",
   "force_apex_test_last_method_run_text":
-    "SFDX: Re-Run Last Executed Test Method",
+    "SFDX: Re-Run Last Invoked Apex Test Method",
   "cancel_sfdx_command_text": "SFDX: Cancel Active Command",
   "force_apex_class_create_text": "SFDX: Create Apex Class",
   "force_visualforce_component_create_text":

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -16,8 +16,12 @@
   "force_source_status_text":
     "SFDX: View All Changes (Local and in Default Scratch Org)",
   "force_apex_test_run_text": "SFDX: Invoke Apex Tests...",
-  "force_apex_test_run_class_text": "SFDX: Invoke Last Executed Test Class",
-  "force_apex_test_run_method_text": "SFDX: Invoke Last Executed Test Method",
+  "force_apex_test_class_run_text": "SFDX: Invoke Apex Test Class",
+  "force_apex_test_method_run_text": "SFDX: Invoke Apex Test Method",
+  "force_apex_test_last_class_run_text":
+    "SFDX: Re-Run Last Executed Test Class",
+  "force_apex_test_last_method_run_text":
+    "SFDX: Re-Run Last Executed Test Method",
   "cancel_sfdx_command_text": "SFDX: Cancel Active Command",
   "force_apex_class_create_text": "SFDX: Create Apex Class",
   "force_visualforce_component_create_text":

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -17,7 +17,7 @@
     "SFDX: View All Changes (Local and in Default Scratch Org)",
   "force_apex_test_run_text": "SFDX: Invoke Apex Tests...",
   "force_apex_test_run_class_text": "SFDX: Invoke Last Executed Test Class",
-  "force_apex_test_run_method_text": "SFDX: Invoke Last Execute Test Method",
+  "force_apex_test_run_method_text": "SFDX: Invoke Last Executed Test Method",
   "cancel_sfdx_command_text": "SFDX: Cancel Active Command",
   "force_apex_class_create_text": "SFDX: Create Apex Class",
   "force_visualforce_component_create_text":

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -16,6 +16,8 @@
   "force_source_status_text":
     "SFDX: View All Changes (Local and in Default Scratch Org)",
   "force_apex_test_run_text": "SFDX: Invoke Apex Tests...",
+  "force_apex_test_run_class_text": "SFDX: Invoke All Apex Tests in Class",
+  "force_apex_test_run_method_text": "SFDX: Invoke Apex Test Method",
   "cancel_sfdx_command_text": "SFDX: Cancel Active Command",
   "force_apex_class_create_text": "SFDX: Create Apex Class",
   "force_visualforce_component_create_text":

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -16,8 +16,8 @@
   "force_source_status_text":
     "SFDX: View All Changes (Local and in Default Scratch Org)",
   "force_apex_test_run_text": "SFDX: Invoke Apex Tests...",
-  "force_apex_test_run_class_text": "SFDX: Invoke All Apex Tests in Class",
-  "force_apex_test_run_method_text": "SFDX: Invoke Apex Test Method",
+  "force_apex_test_run_class_text": "SFDX: Invoke Last Executed Test Class",
+  "force_apex_test_run_method_text": "SFDX: Invoke Last Execute Test Method",
   "cancel_sfdx_command_text": "SFDX: Cancel Active Command",
   "force_apex_class_create_text": "SFDX: Create Apex Class",
   "force_visualforce_component_create_text":

--- a/packages/salesforcedx-vscode-core/src/commands/forceApexTestRun.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexTestRun.ts
@@ -90,7 +90,7 @@ export class ForceApexTestRunExecutor extends SfdxCommandletExecutor<
         .withDescription(nls.localize('force_apex_test_run_text'))
         .withArg('force:apex:test:run')
         .withFlag('--suitenames', `${data.label}`)
-        .withFlag('--resultformat', 'ide')
+        .withFlag('--resultformat', 'human')
         .withFlag('--loglevel', 'error')
         .build();
     } else if (data.type === TestType.Class) {
@@ -98,15 +98,15 @@ export class ForceApexTestRunExecutor extends SfdxCommandletExecutor<
         .withDescription(nls.localize('force_apex_test_run_text'))
         .withArg('force:apex:test:run')
         .withFlag('--classnames', `${data.label}`)
-        .withFlag('--resultformat', 'ide')
-        .withFlag('--loglevel', 'error')
+        .withFlag('--resultformat', 'human')
         .withArg('--synchronous')
+        .withFlag('--loglevel', 'error')
         .build();
     } else {
       return new SfdxCommandBuilder()
         .withDescription(nls.localize('force_apex_test_run_text'))
         .withArg('force:apex:test:run')
-        .withFlag('--resultformat', 'ide')
+        .withFlag('--resultformat', 'human')
         .withFlag('--loglevel', 'error')
         .build();
     }

--- a/packages/salesforcedx-vscode-core/src/commands/forceApexTestRun.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexTestRun.ts
@@ -90,21 +90,24 @@ export class ForceApexTestRunExecutor extends SfdxCommandletExecutor<
         .withDescription(nls.localize('force_apex_test_run_text'))
         .withArg('force:apex:test:run')
         .withFlag('--suitenames', `${data.label}`)
-        .withFlag('--resultformat', 'human')
+        .withFlag('--resultformat', 'ide')
+        .withFlag('--loglevel', 'error')
         .build();
     } else if (data.type === TestType.Class) {
       return new SfdxCommandBuilder()
         .withDescription(nls.localize('force_apex_test_run_text'))
         .withArg('force:apex:test:run')
         .withFlag('--classnames', `${data.label}`)
-        .withFlag('--resultformat', 'human')
+        .withFlag('--resultformat', 'ide')
+        .withFlag('--loglevel', 'error')
         .withArg('--synchronous')
         .build();
     } else {
       return new SfdxCommandBuilder()
         .withDescription(nls.localize('force_apex_test_run_text'))
         .withArg('force:apex:test:run')
-        .withFlag('--resultformat', 'human')
+        .withFlag('--resultformat', 'ide')
+        .withFlag('--loglevel', 'error')
         .build();
     }
   }

--- a/packages/salesforcedx-vscode-core/src/commands/forceApexTestRunCodeAction.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexTestRunCodeAction.ts
@@ -10,6 +10,7 @@ import {
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import { nls } from '../messages';
+import { notificationService } from '../notifications';
 import {
   EmptyParametersGatherer,
   SfdxCommandlet,
@@ -17,6 +18,43 @@ import {
   SfdxWorkspaceChecker
 } from './commands';
 
+function isEmpty(value: string): boolean {
+  return !value || value.length === 0;
+}
+
+function isNotEmpty(value: string): boolean {
+  return !isEmpty(value);
+}
+
+// cache last test class and test method values to
+// enable re-running w/o command context via built-in LRU
+class ForceApexTestRunCache {
+  public lastClassTestParam: string;
+  public lastMethodTestParam: string;
+  private static instance: ForceApexTestRunCache;
+
+  public static getInstance() {
+    if (!ForceApexTestRunCache.instance) {
+      ForceApexTestRunCache.instance = new ForceApexTestRunCache();
+    }
+    return ForceApexTestRunCache.instance;
+  }
+
+  public constructor() {
+    this.lastClassTestParam = '';
+    this.lastMethodTestParam = '';
+  }
+
+  public hasCachedClassTestParam() {
+    return isNotEmpty(this.lastClassTestParam);
+  }
+
+  public hasCachedMethodTestParam() {
+    return isNotEmpty(this.lastMethodTestParam);
+  }
+}
+
+// build force:apex:test:run w/ given test class or test method
 export class ForceApexTestRunCodeActionExecutor extends SfdxCommandletExecutor<{}> {
   private test: string;
 
@@ -32,18 +70,84 @@ export class ForceApexTestRunCodeActionExecutor extends SfdxCommandletExecutor<{
       )
       .withArg('force:apex:test:run')
       .withFlag('--tests', this.test)
-      .withFlag('--resultformat', 'ide')
+      .withFlag('--resultformat', 'human')
       .withArg('--synchronous')
       .withFlag('--loglevel', 'error')
       .build();
   }
 }
 
-export function forceApexTestRunCodeAction(test: string) {
+function forceApexTestRunCodeAction(test: string) {
   const commandlet = new SfdxCommandlet(
     new SfdxWorkspaceChecker(),
     new EmptyParametersGatherer(),
     new ForceApexTestRunCodeActionExecutor(test)
   );
   commandlet.run();
+}
+
+//   T E S T   C L A S S
+
+// evaluate test class param: if not provided, apply cached value
+// exported for testability
+export function resolveTestClassParam(testClass: string): string {
+  const testCache = ForceApexTestRunCache.getInstance();
+  if (isEmpty(testClass)) {
+    // value not provided for re-run invocations
+    // apply cached value, if available
+    if (testCache.hasCachedClassTestParam()) {
+      testClass = testCache.lastClassTestParam;
+    }
+  } else {
+    testCache.lastClassTestParam = testClass;
+  }
+
+  return testClass;
+}
+
+// invokes apex test run on all tests in a class
+export function forceApexTestClassRunCodeAction(testClass: string) {
+  testClass = resolveTestClassParam(testClass);
+  if (isEmpty(testClass)) {
+    // test param not provided: show error and terminate
+    notificationService.showErrorMessage(
+      nls.localize('force_apex_test_run_codeAction_no_class_test_param_text')
+    );
+    return;
+  }
+
+  forceApexTestRunCodeAction(testClass);
+}
+
+//   T E S T   M E T H O D
+
+// evaluate test method param: if not provided, apply cached value
+// exported for testability
+export function resolveTestMethodParam(testMethod: string): string {
+  const testCache = ForceApexTestRunCache.getInstance();
+  if (isEmpty(testMethod)) {
+    // value not provided for re-run invocations
+    // apply cached value, if available
+    if (testCache.hasCachedMethodTestParam()) {
+      testMethod = testCache.lastMethodTestParam;
+    }
+  } else {
+    testCache.lastMethodTestParam = testMethod;
+  }
+
+  return testMethod;
+}
+
+// invokes apex test run on a test method
+export function forceApexTestMethodRunCodeAction(testMethod: string) {
+  testMethod = resolveTestMethodParam(testMethod);
+  if (isEmpty(testMethod)) {
+    // test param not provided: show error and terminate
+    notificationService.showErrorMessage(
+      nls.localize('force_apex_test_run_codeAction_no_method_test_param_text')
+    );
+    return;
+  }
+
+  forceApexTestRunCodeAction(testMethod);
 }

--- a/packages/salesforcedx-vscode-core/src/commands/forceApexTestRunCodeAction.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexTestRunCodeAction.ts
@@ -54,7 +54,7 @@ class ForceApexTestRunCacheService {
   }
 }
 
-export const forceApexTestRunCacheService = ForceApexTestRunCacheService.getInstance();
+const forceApexTestRunCacheService = ForceApexTestRunCacheService.getInstance();
 
 // build force:apex:test:run w/ given test class or test method
 export class ForceApexTestRunCodeActionExecutor extends SfdxCommandletExecutor<{}> {

--- a/packages/salesforcedx-vscode-core/src/commands/forceApexTestRunCodeAction.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexTestRunCodeAction.ts
@@ -92,17 +92,18 @@ function forceApexTestRunCodeAction(test: string) {
 //   T E S T   C L A S S
 
 // redirects to run-all-tests cmd
-export function forceApexTestClassRunCodeActionDelegate(testClass: string) {
+export async function forceApexTestClassRunCodeActionDelegate(
+  testClass: string
+) {
   // enable then run 'last executed' command so command
   // added to 'recently used'
-  vscode.commands
-    .executeCommand('setContext', 'sfdx:has_cached_test_class', true)
-    .then(() =>
-      vscode.commands.executeCommand(
-        'sfdx.force.apex.test.class.run',
-        testClass
-      )
-    );
+  await vscode.commands.executeCommand(
+    'setContext',
+    'sfdx:has_cached_test_class',
+    true
+  );
+
+  vscode.commands.executeCommand('sfdx.force.apex.test.class.run', testClass);
 }
 
 // evaluate test class param: if not provided, apply cached value
@@ -138,17 +139,18 @@ export function forceApexTestClassRunCodeAction(testClass: string) {
 //   T E S T   M E T H O D
 
 // redirects to run-test-method cmd
-export function forceApexTestMethodRunCodeActionDelegate(testMethod: string) {
+export async function forceApexTestMethodRunCodeActionDelegate(
+  testMethod: string
+) {
   // enable then run 'last executed' command so command
   // added to 'recently used'
-  vscode.commands
-    .executeCommand('setContext', 'sfdx:has_cached_test_method', true)
-    .then(() =>
-      vscode.commands.executeCommand(
-        'sfdx.force.apex.test.method.run',
-        testMethod
-      )
-    );
+  await vscode.commands.executeCommand(
+    'setContext',
+    'sfdx:has_cached_test_method',
+    true
+  );
+
+  vscode.commands.executeCommand('sfdx.force.apex.test.method.run', testMethod);
 }
 
 // evaluate test method param: if not provided, apply cached value

--- a/packages/salesforcedx-vscode-core/src/commands/forceApexTestRunCodeAction.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexTestRunCodeAction.ts
@@ -9,6 +9,7 @@ import {
   Command,
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import * as vscode from 'vscode';
 import { nls } from '../messages';
 import { notificationService } from '../notifications';
 import {
@@ -90,6 +91,20 @@ function forceApexTestRunCodeAction(test: string) {
 
 //   T E S T   C L A S S
 
+// redirects to run-all-tests cmd
+export function forceApexTestClassRunCodeActionDelegate(testClass: string) {
+  // enable then run 'last executed' command so command
+  // added to 'recently used'
+  vscode.commands
+    .executeCommand('setContext', 'sfdx:has_cached_test_class', true)
+    .then(() =>
+      vscode.commands.executeCommand(
+        'sfdx.force.apex.test.class.run',
+        testClass
+      )
+    );
+}
+
 // evaluate test class param: if not provided, apply cached value
 // exported for testability
 export function resolveTestClassParam(testClass: string): string {
@@ -121,6 +136,20 @@ export function forceApexTestClassRunCodeAction(testClass: string) {
 }
 
 //   T E S T   M E T H O D
+
+// redirects to run-test-method cmd
+export function forceApexTestMethodRunCodeActionDelegate(testMethod: string) {
+  // enable then run 'last executed' command so command
+  // added to 'recently used'
+  vscode.commands
+    .executeCommand('setContext', 'sfdx:has_cached_test_method', true)
+    .then(() =>
+      vscode.commands.executeCommand(
+        'sfdx.force.apex.test.method.run',
+        testMethod
+      )
+    );
+}
 
 // evaluate test method param: if not provided, apply cached value
 // exported for testability

--- a/packages/salesforcedx-vscode-core/src/commands/forceApexTestRunCodeAction.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexTestRunCodeAction.ts
@@ -28,16 +28,16 @@ function isNotEmpty(value: string): boolean {
 
 // cache last test class and test method values to
 // enable re-running w/o command context via built-in LRU
-class ForceApexTestRunCache {
+class ForceApexTestRunCacheService {
   public lastClassTestParam: string;
   public lastMethodTestParam: string;
-  private static instance: ForceApexTestRunCache;
+  private static instance: ForceApexTestRunCacheService;
 
   public static getInstance() {
-    if (!ForceApexTestRunCache.instance) {
-      ForceApexTestRunCache.instance = new ForceApexTestRunCache();
+    if (!ForceApexTestRunCacheService.instance) {
+      ForceApexTestRunCacheService.instance = new ForceApexTestRunCacheService();
     }
-    return ForceApexTestRunCache.instance;
+    return ForceApexTestRunCacheService.instance;
   }
 
   public constructor() {
@@ -53,6 +53,8 @@ class ForceApexTestRunCache {
     return isNotEmpty(this.lastMethodTestParam);
   }
 }
+
+export const forceApexTestRunCacheService = ForceApexTestRunCacheService.getInstance();
 
 // build force:apex:test:run w/ given test class or test method
 export class ForceApexTestRunCodeActionExecutor extends SfdxCommandletExecutor<{}> {
@@ -91,15 +93,14 @@ function forceApexTestRunCodeAction(test: string) {
 // evaluate test class param: if not provided, apply cached value
 // exported for testability
 export function resolveTestClassParam(testClass: string): string {
-  const testCache = ForceApexTestRunCache.getInstance();
   if (isEmpty(testClass)) {
     // value not provided for re-run invocations
     // apply cached value, if available
-    if (testCache.hasCachedClassTestParam()) {
-      testClass = testCache.lastClassTestParam;
+    if (forceApexTestRunCacheService.hasCachedClassTestParam()) {
+      testClass = forceApexTestRunCacheService.lastClassTestParam;
     }
   } else {
-    testCache.lastClassTestParam = testClass;
+    forceApexTestRunCacheService.lastClassTestParam = testClass;
   }
 
   return testClass;
@@ -124,15 +125,14 @@ export function forceApexTestClassRunCodeAction(testClass: string) {
 // evaluate test method param: if not provided, apply cached value
 // exported for testability
 export function resolveTestMethodParam(testMethod: string): string {
-  const testCache = ForceApexTestRunCache.getInstance();
   if (isEmpty(testMethod)) {
     // value not provided for re-run invocations
     // apply cached value, if available
-    if (testCache.hasCachedMethodTestParam()) {
-      testMethod = testCache.lastMethodTestParam;
+    if (forceApexTestRunCacheService.hasCachedMethodTestParam()) {
+      testMethod = forceApexTestRunCacheService.lastMethodTestParam;
     }
   } else {
-    testCache.lastMethodTestParam = testMethod;
+    forceApexTestRunCacheService.lastMethodTestParam = testMethod;
   }
 
   return testMethod;

--- a/packages/salesforcedx-vscode-core/src/commands/forceApexTestRunCodeAction.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexTestRunCodeAction.ts
@@ -32,8 +32,9 @@ export class ForceApexTestRunCodeActionExecutor extends SfdxCommandletExecutor<{
       )
       .withArg('force:apex:test:run')
       .withFlag('--tests', this.test)
-      .withFlag('--resultformat', 'human')
+      .withFlag('--resultformat', 'ide')
       .withArg('--synchronous')
+      .withFlag('--loglevel', 'error')
       .build();
   }
 }

--- a/packages/salesforcedx-vscode-core/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/index.ts
@@ -16,7 +16,10 @@ export {
 export { forceApexExecute } from './forceApexExecute';
 export { forceAuthWebLogin } from './forceAuthWebLogin';
 export { forceApexTestRun } from './forceApexTestRun';
-export { forceApexTestRunCodeAction } from './forceApexTestRunCodeAction';
+export {
+  forceApexTestClassRunCodeAction,
+  forceApexTestMethodRunCodeAction
+} from './forceApexTestRunCodeAction';
 export { forceDataSoqlQuery } from './forceDataSoqlQuery';
 export { forceOrgCreate } from './forceOrgCreate';
 export { forceOrgOpen } from './forceOrgOpen';

--- a/packages/salesforcedx-vscode-core/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/index.ts
@@ -18,7 +18,9 @@ export { forceAuthWebLogin } from './forceAuthWebLogin';
 export { forceApexTestRun } from './forceApexTestRun';
 export {
   forceApexTestClassRunCodeAction,
-  forceApexTestMethodRunCodeAction
+  forceApexTestClassRunCodeActionDelegate,
+  forceApexTestMethodRunCodeAction,
+  forceApexTestMethodRunCodeActionDelegate
 } from './forceApexTestRunCodeAction';
 export { forceDataSoqlQuery } from './forceDataSoqlQuery';
 export { forceOrgCreate } from './forceOrgCreate';

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -14,7 +14,9 @@ import {
   forceApexClassCreate,
   forceApexExecute,
   forceApexTestClassRunCodeAction,
+  forceApexTestClassRunCodeActionDelegate,
   forceApexTestMethodRunCodeAction,
+  forceApexTestMethodRunCodeActionDelegate,
   forceApexTestRun,
   forceApexTriggerCreate,
   forceAuthWebLogin,
@@ -107,9 +109,17 @@ function registerCommands(): vscode.Disposable {
     'sfdx.force.apex.test.run',
     forceApexTestRun
   );
+  const forceApexTestClassRunDelegateCmd = vscode.commands.registerCommand(
+    'sfdx.force.apex.test.class.run.delegate',
+    forceApexTestClassRunCodeActionDelegate
+  );
   const forceApexTestClassRunCmd = vscode.commands.registerCommand(
     'sfdx.force.apex.test.class.run',
     forceApexTestClassRunCodeAction
+  );
+  const forceApexTestMethodRunDelegateCmd = vscode.commands.registerCommand(
+    'sfdx.force.apex.test.method.run.delegate',
+    forceApexTestMethodRunCodeActionDelegate
   );
   const forceApexTestMethodRunCmd = vscode.commands.registerCommand(
     'sfdx.force.apex.test.method.run',
@@ -230,7 +240,9 @@ function registerCommands(): vscode.Disposable {
     forceApexExecuteSelectionCmd,
     forceApexTestRunCmd,
     forceApexTestClassRunCmd,
+    forceApexTestClassRunDelegateCmd,
     forceApexTestMethodRunCmd,
+    forceApexTestMethodRunDelegateCmd,
     forceAuthWebLoginCmd,
     forceDataSoqlQueryInputCmd,
     forceDataSoqlQuerySelectionCmd,

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -13,8 +13,9 @@ import {
   forceAliasList,
   forceApexClassCreate,
   forceApexExecute,
+  forceApexTestClassRunCodeAction,
+  forceApexTestMethodRunCodeAction,
   forceApexTestRun,
-  forceApexTestRunCodeAction,
   forceApexTriggerCreate,
   forceAuthWebLogin,
   forceConfigList,
@@ -106,9 +107,13 @@ function registerCommands(): vscode.Disposable {
     'sfdx.force.apex.test.run',
     forceApexTestRun
   );
-  const forceApexTestRunCodeActionCmd = vscode.commands.registerCommand(
-    'sfdx.force.apex.test.run.codeAction',
-    forceApexTestRunCodeAction
+  const forceApexTestClassRunCmd = vscode.commands.registerCommand(
+    'sfdx.force.apex.test.class.run',
+    forceApexTestClassRunCodeAction
+  );
+  const forceApexTestMethodRunCmd = vscode.commands.registerCommand(
+    'sfdx.force.apex.test.method.run',
+    forceApexTestMethodRunCodeAction
   );
   const forceTaskStopCmd = vscode.commands.registerCommand(
     'sfdx.force.task.stop',
@@ -224,7 +229,8 @@ function registerCommands(): vscode.Disposable {
     forceApexExecuteDocumentCmd,
     forceApexExecuteSelectionCmd,
     forceApexTestRunCmd,
-    forceApexTestRunCodeActionCmd,
+    forceApexTestClassRunCmd,
+    forceApexTestMethodRunCmd,
     forceAuthWebLoginCmd,
     forceDataSoqlQueryInputCmd,
     forceDataSoqlQuerySelectionCmd,

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -113,6 +113,10 @@ function registerCommands(): vscode.Disposable {
     'sfdx.force.apex.test.class.run.delegate',
     forceApexTestClassRunCodeActionDelegate
   );
+  const forceApexTestLastClassRunCmd = vscode.commands.registerCommand(
+    'sfdx.force.apex.test.last.class.run',
+    forceApexTestClassRunCodeAction
+  );
   const forceApexTestClassRunCmd = vscode.commands.registerCommand(
     'sfdx.force.apex.test.class.run',
     forceApexTestClassRunCodeAction
@@ -120,6 +124,10 @@ function registerCommands(): vscode.Disposable {
   const forceApexTestMethodRunDelegateCmd = vscode.commands.registerCommand(
     'sfdx.force.apex.test.method.run.delegate',
     forceApexTestMethodRunCodeActionDelegate
+  );
+  const forceApexTestLastMethodRunCmd = vscode.commands.registerCommand(
+    'sfdx.force.apex.test.last.method.run',
+    forceApexTestMethodRunCodeAction
   );
   const forceApexTestMethodRunCmd = vscode.commands.registerCommand(
     'sfdx.force.apex.test.method.run',
@@ -239,8 +247,10 @@ function registerCommands(): vscode.Disposable {
     forceApexExecuteDocumentCmd,
     forceApexExecuteSelectionCmd,
     forceApexTestRunCmd,
+    forceApexTestLastClassRunCmd,
     forceApexTestClassRunCmd,
     forceApexTestClassRunDelegateCmd,
+    forceApexTestLastMethodRunCmd,
     forceApexTestMethodRunCmd,
     forceApexTestMethodRunDelegateCmd,
     forceAuthWebLoginCmd,

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -76,8 +76,8 @@ export const messages = {
   force_apex_test_run_all_tests_description_text:
     'Runs all tests in the current project',
 
-  force_apex_test_run_class_text: 'SFDX: Invoke All Apex Tests in Class',
-  force_apex_test_run_method_text: 'SFDX: Invoke Apex Test Method',
+  force_apex_test_run_class_text: 'SFDX: Invoke Last Executed Test Class',
+  force_apex_test_run_method_text: 'SFDX: Invoke Last Execute Test Method',
   force_apex_test_run_codeAction_description_text: 'Run Apex test(s)',
   force_apex_test_run_codeAction_no_class_test_param_text:
     'Test class not provided. Run the code action on a class annotated with @isTest.',

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -77,7 +77,7 @@ export const messages = {
     'Runs all tests in the current project',
 
   force_apex_test_run_class_text: 'SFDX: Invoke Last Executed Test Class',
-  force_apex_test_run_method_text: 'SFDX: Invoke Last Execute Test Method',
+  force_apex_test_run_method_text: 'SFDX: Invoke Last Executed Test Method',
   force_apex_test_run_codeAction_description_text: 'Run Apex test(s)',
   force_apex_test_run_codeAction_no_class_test_param_text:
     'Test class not provided. Run the code action on a class annotated with @isTest.',

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -80,9 +80,9 @@ export const messages = {
   force_apex_test_run_method_text: 'SFDX: Invoke Apex Test Method',
   force_apex_test_run_codeAction_description_text: 'Run Apex test(s)',
   force_apex_test_run_codeAction_no_class_test_param_text:
-    'Test class not provided.  Please run Apex test code action on a test class.',
+    'Test class not provided. Run the code action on a class annotated with @isTest.',
   force_apex_test_run_codeAction_no_method_test_param_text:
-    'Test method not provided.  Please run Apex test code action on a test method.',
+    'Test method not provided. Run the code action on a method annotated with @isTest or testMethod.',
 
   force_apex_class_create_text: 'SFDX: Create Apex Class',
   force_visualforce_component_create_text: 'SFDX: Create Visualforce Component',

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -76,7 +76,13 @@ export const messages = {
   force_apex_test_run_all_tests_description_text:
     'Runs all tests in the current project',
 
+  force_apex_test_run_class_text: 'SFDX: Invoke All Apex Tests in Class',
+  force_apex_test_run_method_text: 'SFDX: Invoke Apex Test Method',
   force_apex_test_run_codeAction_description_text: 'Run Apex test(s)',
+  force_apex_test_run_codeAction_no_class_test_param_text:
+    'Test class not provided.  Please run Apex test code action on a test class.',
+  force_apex_test_run_codeAction_no_method_test_param_text:
+    'Test method not provided.  Please run Apex test code action on a test method.',
 
   force_apex_class_create_text: 'SFDX: Create Apex Class',
   force_visualforce_component_create_text: 'SFDX: Create Visualforce Component',

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -76,8 +76,6 @@ export const messages = {
   force_apex_test_run_all_tests_description_text:
     'Runs all tests in the current project',
 
-  force_apex_test_run_class_text: 'SFDX: Invoke Last Executed Test Class',
-  force_apex_test_run_method_text: 'SFDX: Invoke Last Executed Test Method',
   force_apex_test_run_codeAction_description_text: 'Run Apex test(s)',
   force_apex_test_run_codeAction_no_class_test_param_text:
     'Test class not provided. Run the code action on a class annotated with @isTest.',

--- a/packages/salesforcedx-vscode-core/test/commands/forceApexTestRun.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceApexTestRun.test.ts
@@ -21,7 +21,7 @@ describe('Force Apex Test Run', () => {
       });
 
       expect(command.toCommand()).to.equal(
-        'sfdx force:apex:test:run --suitenames MySuite --resultformat human'
+        'sfdx force:apex:test:run --suitenames MySuite --resultformat ide --loglevel error'
       );
       expect(command.description).to.equal(
         nls.localize('force_apex_test_run_text')
@@ -36,7 +36,7 @@ describe('Force Apex Test Run', () => {
       });
 
       expect(command.toCommand()).to.equal(
-        'sfdx force:apex:test:run --classnames MyTestClass --resultformat human --synchronous'
+        'sfdx force:apex:test:run --classnames MyTestClass --resultformat ide --synchronous --loglevel error'
       );
       expect(command.description).to.equal(
         nls.localize('force_apex_test_run_text')
@@ -53,7 +53,7 @@ describe('Force Apex Test Run', () => {
       });
 
       expect(command.toCommand()).to.equal(
-        'sfdx force:apex:test:run --resultformat human'
+        'sfdx force:apex:test:run --resultformat ide --loglevel error'
       );
       expect(command.description).to.equal(
         nls.localize('force_apex_test_run_text')

--- a/packages/salesforcedx-vscode-core/test/commands/forceApexTestRun.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceApexTestRun.test.ts
@@ -21,7 +21,7 @@ describe('Force Apex Test Run', () => {
       });
 
       expect(command.toCommand()).to.equal(
-        'sfdx force:apex:test:run --suitenames MySuite --resultformat ide --loglevel error'
+        'sfdx force:apex:test:run --suitenames MySuite --resultformat human --loglevel error'
       );
       expect(command.description).to.equal(
         nls.localize('force_apex_test_run_text')
@@ -36,7 +36,7 @@ describe('Force Apex Test Run', () => {
       });
 
       expect(command.toCommand()).to.equal(
-        'sfdx force:apex:test:run --classnames MyTestClass --resultformat ide --synchronous --loglevel error'
+        'sfdx force:apex:test:run --classnames MyTestClass --resultformat human --synchronous --loglevel error'
       );
       expect(command.description).to.equal(
         nls.localize('force_apex_test_run_text')
@@ -53,7 +53,7 @@ describe('Force Apex Test Run', () => {
       });
 
       expect(command.toCommand()).to.equal(
-        'sfdx force:apex:test:run --resultformat ide --loglevel error'
+        'sfdx force:apex:test:run --resultformat human --loglevel error'
       );
       expect(command.description).to.equal(
         nls.localize('force_apex_test_run_text')

--- a/packages/salesforcedx-vscode-core/test/commands/forceApexTestRunCodeAction.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceApexTestRunCodeAction.test.ts
@@ -10,7 +10,7 @@ describe('Force Apex Test Run - Code Action', () => {
       const command = builder.build({});
 
       expect(command.toCommand()).to.equal(
-        `sfdx force:apex:test:run --tests ${testClass} --resultformat human --synchronous`
+        `sfdx force:apex:test:run --tests ${testClass} --resultformat ide --synchronous --loglevel error`
       );
     });
   });
@@ -23,7 +23,7 @@ describe('Force Apex Test Run - Code Action', () => {
       const command = builder.build({});
 
       expect(command.toCommand()).to.equal(
-        `sfdx force:apex:test:run --tests ${testMethod} --resultformat human --synchronous`
+        `sfdx force:apex:test:run --tests ${testMethod} --resultformat ide --synchronous --loglevel error`
       );
     });
   });

--- a/packages/salesforcedx-vscode-core/test/commands/forceApexTestRunCodeAction.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceApexTestRunCodeAction.test.ts
@@ -1,5 +1,14 @@
 import { expect } from 'chai';
-import { ForceApexTestRunCodeActionExecutor } from '../../src/commands/forceApexTestRunCodeAction';
+import {
+  ForceApexTestRunCodeActionExecutor,
+  resolveTestClassParam,
+  resolveTestMethodParam
+} from '../../src/commands/forceApexTestRunCodeAction';
+
+// return undefined: used to get around strict checks
+function getUndefined(): any {
+  return undefined;
+}
 
 describe('Force Apex Test Run - Code Action', () => {
   describe('Command builder - Test Class', () => {
@@ -10,7 +19,7 @@ describe('Force Apex Test Run - Code Action', () => {
       const command = builder.build({});
 
       expect(command.toCommand()).to.equal(
-        `sfdx force:apex:test:run --tests ${testClass} --resultformat ide --synchronous --loglevel error`
+        `sfdx force:apex:test:run --tests ${testClass} --resultformat human --synchronous --loglevel error`
       );
     });
   });
@@ -23,8 +32,56 @@ describe('Force Apex Test Run - Code Action', () => {
       const command = builder.build({});
 
       expect(command.toCommand()).to.equal(
-        `sfdx force:apex:test:run --tests ${testMethod} --resultformat ide --synchronous --loglevel error`
+        `sfdx force:apex:test:run --tests ${testMethod} --resultformat human --synchronous --loglevel error`
       );
+    });
+  });
+
+  describe('Cached Test Class', () => {
+    const testClass = 'MyTests';
+    const testClass2 = 'MyTests2';
+    it('Should return cached value', () => {
+      let resolvedTestClass = resolveTestClassParam(getUndefined());
+      expect(resolvedTestClass).to.equal(undefined);
+
+      resolvedTestClass = resolveTestClassParam(testClass);
+      expect(resolvedTestClass).to.equal(testClass);
+
+      resolvedTestClass = resolveTestClassParam('');
+      expect(resolvedTestClass).to.equal(testClass);
+
+      resolvedTestClass = resolveTestClassParam(getUndefined());
+      expect(resolvedTestClass).to.equal(testClass);
+
+      resolvedTestClass = resolveTestClassParam(testClass2);
+      expect(resolvedTestClass).to.equal(testClass2);
+
+      resolvedTestClass = resolveTestClassParam('');
+      expect(resolvedTestClass).to.equal(testClass2);
+    });
+  });
+
+  describe('Cached Test Method', () => {
+    const testMethod = 'MyTests.testMe';
+    const testMethod2 = 'MyTests.testMe2';
+    it('Should return cached value', () => {
+      let resolvedTestMethod = resolveTestMethodParam(getUndefined());
+      expect(resolvedTestMethod).to.equal(undefined);
+
+      resolvedTestMethod = resolveTestMethodParam(testMethod);
+      expect(resolvedTestMethod).to.equal(testMethod);
+
+      resolvedTestMethod = resolveTestMethodParam('');
+      expect(resolvedTestMethod).to.equal(testMethod);
+
+      resolvedTestMethod = resolveTestMethodParam(getUndefined());
+      expect(resolvedTestMethod).to.equal(testMethod);
+
+      resolvedTestMethod = resolveTestMethodParam(testMethod2);
+      expect(resolvedTestMethod).to.equal(testMethod2);
+
+      resolvedTestMethod = resolveTestMethodParam('');
+      expect(resolvedTestMethod).to.equal(testMethod2);
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Invoke `force:apex:test:run` w/ `--resultformat human` to include source link to stacktraces.

Also:
- `force:apex:test:run` invoked w/ `--loglevel error` to avoid distracting warning messages.
- Support for re-running Apex test class and test method code actions via "Recently Used".

This PR requires `force-com-toolbelt` PR #1837.

### What issues does this PR fix or reference?

@W-4709572@
