### PR TITLE
Access preference using scoped resource style

### DIFF
--- a/packages/salesforcedx-vscode-lwc/src/index.ts
+++ b/packages/salesforcedx-vscode-lwc/src/index.ts
@@ -73,7 +73,10 @@ export async function activate(context: vscode.ExtensionContext) {
   if (workspaceType === lwcLanguageServer.WorkspaceType.SFDX) {
     await populateEslintSettingIfNecessary(
       context,
-      vscode.workspace.getConfiguration()
+      vscode.workspace.getConfiguration(
+        '',
+        vscode.workspace.workspaceFolders[0].uri
+      )
     );
   }
 

--- a/packages/salesforcedx-vscode-lwc/test/index.ts
+++ b/packages/salesforcedx-vscode-lwc/test/index.ts
@@ -12,7 +12,8 @@ const testRunner = require('@salesforce/salesforcedx-utils-vscode/out/src/test/t
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
 testRunner.configure({
   ui: 'bdd', // the TDD UI is being used in extension.test.ts (suite, test, etc.)
-  useColors: true // colored output from test results
+  useColors: true, // colored output from test results
+  timeout: 10000
 });
 
 module.exports = testRunner;


### PR DESCRIPTION
### What does this PR do?

Removes error of the form 

```
[Extension Host] [salesforce.salesforcedx-vscode-lwc] Accessing a resource scoped configuration without providing a resource is not expected. To get the effective value for 'eslint.nodePath';, provide the URI of a resource or 'null' for any resource. (at e._validateConfigurationAccess (/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:511:635))
```

### What issues does this PR fix or reference?

@W-4650780@
