### PR TITLE
Add .vscodeignore to debugger packages

### DIFF
--- a/packages/salesforcedx-vscode-apex-debugger/.vscodeignore
+++ b/packages/salesforcedx-vscode-apex-debugger/.vscodeignore
@@ -1,0 +1,8 @@
+.vscode/**
+.vscode-test/**
+out/test/**
+test/**
+src/**
+**/*.map
+.gitignore
+tsconfig.json

--- a/packages/salesforcedx-vscode-replay-debugger/.vscodeignore
+++ b/packages/salesforcedx-vscode-replay-debugger/.vscodeignore
@@ -1,0 +1,8 @@
+.vscode/**
+.vscode-test/**
+out/test/**
+test/**
+src/**
+**/*.map
+.gitignore
+tsconfig.json


### PR DESCRIPTION
### What does this PR do?

Add .vscodeignore to debugger packages so that we don't accidentally package the .vscode binaries for test. This can help prevent unnecessary bloat.

### What issues does this PR fix or reference?

Small tech debt.
