### PR TITLE
Disable external sharing model

### DIFF
--- a/packages/salesforcedx-sobjects-faux-generator/test/integration/config/simpleObjectAndField/objects/MyCustomObject2__c/MyCustomObject2__c.object-meta.xml
+++ b/packages/salesforcedx-sobjects-faux-generator/test/integration/config/simpleObjectAndField/objects/MyCustomObject2__c/MyCustomObject2__c.object-meta.xml
@@ -52,7 +52,6 @@
     <enableSearch>false</enableSearch>
     <enableSharing>true</enableSharing>
     <enableStreamingApi>true</enableStreamingApi>
-    <externalSharingModel>ReadWrite</externalSharingModel>
     <label>MyCustomObject</label>
     <nameField>
         <label>MyCustomObject Name</label>

--- a/packages/salesforcedx-sobjects-faux-generator/test/integration/config/simpleObjectAndField/objects/MyCustomObject3__c/MyCustomObject3__c.object-meta.xml
+++ b/packages/salesforcedx-sobjects-faux-generator/test/integration/config/simpleObjectAndField/objects/MyCustomObject3__c/MyCustomObject3__c.object-meta.xml
@@ -52,7 +52,6 @@
     <enableSearch>false</enableSearch>
     <enableSharing>true</enableSharing>
     <enableStreamingApi>true</enableStreamingApi>
-    <externalSharingModel>ReadWrite</externalSharingModel>
     <label>MyCustomObject</label>
     <nameField>
         <label>MyCustomObject Name</label>

--- a/packages/salesforcedx-sobjects-faux-generator/test/integration/config/simpleObjectAndField/objects/MyCustomObject__c/MyCustomObject__c.object-meta.xml
+++ b/packages/salesforcedx-sobjects-faux-generator/test/integration/config/simpleObjectAndField/objects/MyCustomObject__c/MyCustomObject__c.object-meta.xml
@@ -52,7 +52,6 @@
     <enableSearch>false</enableSearch>
     <enableSharing>true</enableSharing>
     <enableStreamingApi>true</enableStreamingApi>
-    <externalSharingModel>ReadWrite</externalSharingModel>
     <label>MyCustomObject</label>
     <nameField>
         <label>MyCustomObject Name</label>


### PR DESCRIPTION
### What does this PR do?

Disable the external sharing model attribute in the test custom objects. We now disable the external sharing model in scratch orgs. See https://success.salesforce.com/_ui/core/chatter/groups/GroupProfilePage?g=0F93A000000HTp1&fId=0D53A00003SQizw for more information.

### What issues does this PR fix or reference?

Backport from develop to make tests pass in release.
