### PR TITLE
Peg language server versions

### DIFF
--- a/packages/salesforcedx-slds-linter/package.json
+++ b/packages/salesforcedx-slds-linter/package.json
@@ -43,7 +43,9 @@
   },
   "dependencies": {
     "@salesforce/salesforcedx-utils-vscode": "42.5.0",
-    "vscode-languageclient": "3.3.0",
-    "vscode-languageserver": "^3.3.0"
+    "vscode-languageclient": "3.5.0",
+    "vscode-languageserver": "3.5.0",
+    "vscode-languageserver-protocol": "3.5.0",
+    "vscode-languageserver-types": "3.5.0"
   }
 }

--- a/packages/salesforcedx-visualforce-markup-language-server/package.json
+++ b/packages/salesforcedx-visualforce-markup-language-server/package.json
@@ -26,7 +26,7 @@
     "typescript": "2.6.2"
   },
   "dependencies": {
-    "vscode-languageserver-types": "^3.3.0",
+    "vscode-languageserver-types": "3.4.0",
     "vscode-nls": "^2.0.2",
     "vscode-uri": "^1.0.1"
   },

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -84,6 +84,7 @@
     "expand-home-dir": "0.0.3",
     "find-java-home": "0.2.0",
     "path-exists": "3.0.0",
-    "vscode-languageclient": "3.3.0"
+    "vscode-languageclient": "3.5.0",
+    "vscode-languageserver-protocol": "3.5.0"
   }
 }

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -29,7 +29,10 @@
     "eslint-plugin-lwc": "0.3.2",
     "lwc-language-server": "0.16.4",
     "rxjs": "^5.4.1",
-    "vscode-languageclient": "3.5.0"
+    "vscode-languageclient": "3.3.0",
+    "vscode-languageserver": "3.3.0",
+    "vscode-languageserver-protocol": "3.5.0",
+    "vscode-languageserver-types": "3.5.0"
   },
   "devDependencies": {
     "@types/chai": "^4.0.0",


### PR DESCRIPTION
### What does this PR do?
 
Pegs the server versions to avoid https://github.com/Microsoft/vscode-languageserver-node/issues/317

We have a special dependency on version 3.4.x for the visualforce branch because of our use of the proposed color provider. 

The rest have been updated to v3.5.x

### What issues does this PR fix or reference?

Fixes the build.
