### PR TITLE
[WIP] Do not bundle all the vscode-languageserver/clients/types/protocol

### DIFF
--- a/packages/salesforcedx-slds-linter/package.json
+++ b/packages/salesforcedx-slds-linter/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@salesforce/salesforcedx-utils-vscode": "42.5.0",
-    "vscode-languageclient": "3.3.0",
-    "vscode-languageserver": "^3.3.0"
+    "vscode-languageclient": "3.5.0",
+    "vscode-languageserver": "3.5.0"
   }
 }

--- a/packages/salesforcedx-slds-linter/package.json
+++ b/packages/salesforcedx-slds-linter/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@salesforce/salesforcedx-utils-vscode": "42.5.0",
-    "vscode-languageclient": "3.5.0",
-    "vscode-languageserver": "3.5.0"
+    "vscode-languageclient": "3.5.1",
+    "vscode-languageserver": "3.5.1"
   }
 }

--- a/packages/salesforcedx-slds-linter/package.json
+++ b/packages/salesforcedx-slds-linter/package.json
@@ -43,9 +43,7 @@
   },
   "dependencies": {
     "@salesforce/salesforcedx-utils-vscode": "42.5.0",
-    "vscode-languageclient": "3.5.0",
-    "vscode-languageserver": "3.5.0",
-    "vscode-languageserver-protocol": "3.5.0",
-    "vscode-languageserver-types": "3.5.0"
+    "vscode-languageclient": "3.3.0",
+    "vscode-languageserver": "^3.3.0"
   }
 }

--- a/packages/salesforcedx-visualforce-markup-language-server/package.json
+++ b/packages/salesforcedx-visualforce-markup-language-server/package.json
@@ -26,7 +26,7 @@
     "typescript": "2.6.2"
   },
   "dependencies": {
-    "vscode-languageserver-types": "^3.3.0",
+    "vscode-languageserver-types": "3.4.0",
     "vscode-nls": "^2.0.2",
     "vscode-uri": "^1.0.1"
   },

--- a/packages/salesforcedx-visualforce-markup-language-server/package.json
+++ b/packages/salesforcedx-visualforce-markup-language-server/package.json
@@ -26,7 +26,7 @@
     "typescript": "2.6.2"
   },
   "dependencies": {
-    "vscode-languageserver-types": "3.4.0",
+    "vscode-languageserver-types": "^3.3.0",
     "vscode-nls": "^2.0.2",
     "vscode-uri": "^1.0.1"
   },

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -84,6 +84,6 @@
     "expand-home-dir": "0.0.3",
     "find-java-home": "0.2.0",
     "path-exists": "3.0.0",
-    "vscode-languageclient": "3.3.0"
+    "vscode-languageclient": "3.5.0"
   }
 }

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -84,6 +84,6 @@
     "expand-home-dir": "0.0.3",
     "find-java-home": "0.2.0",
     "path-exists": "3.0.0",
-    "vscode-languageclient": "3.5.0"
+    "vscode-languageclient": "3.5.1"
   }
 }

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -84,7 +84,6 @@
     "expand-home-dir": "0.0.3",
     "find-java-home": "0.2.0",
     "path-exists": "3.0.0",
-    "vscode-languageclient": "3.5.0",
-    "vscode-languageserver-protocol": "3.5.0"
+    "vscode-languageclient": "3.3.0"
   }
 }

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -29,10 +29,7 @@
     "eslint-plugin-lwc": "0.3.2",
     "lwc-language-server": "0.16.4",
     "rxjs": "^5.4.1",
-    "vscode-languageclient": "3.3.0",
-    "vscode-languageserver": "3.3.0",
-    "vscode-languageserver-protocol": "3.5.0",
-    "vscode-languageserver-types": "3.5.0"
+    "vscode-languageclient": "3.5.0"
   },
   "devDependencies": {
     "@types/chai": "^4.0.0",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -29,7 +29,7 @@
     "eslint-plugin-lwc": "0.3.2",
     "lwc-language-server": "0.16.4",
     "rxjs": "^5.4.1",
-    "vscode-languageclient": "3.5.0"
+    "vscode-languageclient": "3.5.1"
   },
   "devDependencies": {
     "@types/chai": "^4.0.0",


### PR DESCRIPTION
### What does this PR do?

A fix has been made upstream from Microsoft that will rectify #332. We don't need to bundle all the versions of it, which would help make our .vsix leaner.

### What issues does this PR fix or reference?

Build issues.