### PR TITLE
Add demo mode for VS Code

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/test/testrunner.ts
+++ b/packages/salesforcedx-utils-vscode/src/test/testrunner.ts
@@ -78,7 +78,6 @@ function run(testsRoot: any, clb: any): any {
     try {
       // Fill into Mocha
       files.forEach((f): Mocha => {
-        console.log(`Adding test script: ${f}`);
         return mocha.addFile(paths.join(testsRoot, f));
       });
       // Run the tests

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -134,6 +134,10 @@
           "when": "sfdx:project_opened"
         },
         {
+          "command": "sfdx.force.auth.logout.all",
+          "when": "sfdx:project_opened"
+        },
+        {
           "command": "sfdx.force.org.create",
           "when": "sfdx:project_opened"
         },
@@ -290,6 +294,10 @@
       {
         "command": "sfdx.force.auth.web.login",
         "title": "%force_auth_web_login_authorize_dev_hub_text%"
+      },
+      {
+        "command": "sfdx.force.auth.logout.all",
+        "title": "%force_auth_logout_all_text%"
       },
       {
         "command": "sfdx.force.org.create",

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -2,6 +2,7 @@
   "running_tasks_title_text": "Running Tasks",
 
   "force_auth_web_login_authorize_dev_hub_text": "SFDX: Authorize a Dev Hub",
+  "force_auth_logout_all_text": "SFDX: Log Out from All Authorized Orgs",
   "force_org_create_default_scratch_org_text":
     "SFDX: Create a Default Scratch Org...",
   "force_org_open_default_scratch_org_text": "SFDX: Open Default Scratch Org",

--- a/packages/salesforcedx-vscode-core/src/commands/commands.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/commands.ts
@@ -291,7 +291,7 @@ export class SelectUsername
 
 export class DemoModePromptGatherer implements ParametersGatherer<{}> {
   private readonly LOGOUT_RESPONSE = 'Cancel';
-  private readonly DO_NOT_LOGOUT_RESPONSE = 'Continue';
+  private readonly DO_NOT_LOGOUT_RESPONSE = 'Authorize Org';
   private readonly prompt: string;
 
   public constructor() {

--- a/packages/salesforcedx-vscode-core/src/commands/commands.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/commands.ts
@@ -289,6 +289,28 @@ export class SelectUsername
   }
 }
 
+export class DemoModePromptGatherer implements ParametersGatherer<{}> {
+  private readonly LOGOUT_RESPONSE = 'Cancel';
+  private readonly DO_NOT_LOGOUT_RESPONSE = 'Continue';
+  private readonly prompt: string;
+
+  public constructor() {
+    this.prompt = nls.localize('demo_mode_prompt');
+  }
+
+  public async gather(): Promise<CancelResponse | ContinueResponse<{}>> {
+    const response = await vscode.window.showInformationMessage(
+      this.prompt,
+      this.DO_NOT_LOGOUT_RESPONSE,
+      this.LOGOUT_RESPONSE
+    );
+
+    return response && response === this.LOGOUT_RESPONSE
+      ? { type: 'CONTINUE', data: {} }
+      : { type: 'CANCEL' };
+  }
+}
+
 // Command Execution
 ////////////////////
 export interface CommandletExecutor<T> {

--- a/packages/salesforcedx-vscode-core/src/commands/commands.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/commands.ts
@@ -317,13 +317,19 @@ export interface CommandletExecutor<T> {
 
 export abstract class SfdxCommandletExecutor<T>
   implements CommandletExecutor<T> {
+  protected showChannelOutput = true;
+
   protected attachExecution(
     execution: CommandExecution,
     cancellationTokenSource: vscode.CancellationTokenSource,
     cancellationToken: vscode.CancellationToken
   ) {
     channelService.streamCommandOutput(execution);
-    channelService.showChannelOutput();
+
+    if (this.showChannelOutput) {
+      channelService.showChannelOutput();
+    }
+
     notificationService.reportCommandExecutionStatus(
       execution,
       cancellationToken

--- a/packages/salesforcedx-vscode-core/src/commands/commands.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/commands.ts
@@ -292,11 +292,7 @@ export class SelectUsername
 export class DemoModePromptGatherer implements ParametersGatherer<{}> {
   private readonly LOGOUT_RESPONSE = 'Cancel';
   private readonly DO_NOT_LOGOUT_RESPONSE = 'Authorize Org';
-  private readonly prompt: string;
-
-  public constructor() {
-    this.prompt = nls.localize('demo_mode_prompt');
-  }
+  private readonly prompt = nls.localize('demo_mode_prompt');
 
   public async gather(): Promise<CancelResponse | ContinueResponse<{}>> {
     const response = await vscode.window.showInformationMessage(

--- a/packages/salesforcedx-vscode-core/src/commands/forceAuthLogout.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceAuthLogout.ts
@@ -18,6 +18,12 @@ import {
 } from './commands';
 
 export class ForceAuthLogoutAll extends SfdxCommandletExecutor<{}> {
+  public static withoutShowingChannel(): ForceAuthLogoutAll {
+    const instance = new ForceAuthLogoutAll();
+    instance.showChannelOutput = false;
+    return instance;
+  }
+
   public build(data: {}): Command {
     return new SfdxCommandBuilder()
       .withDescription(nls.localize('force_auth_logout_all_text'))

--- a/packages/salesforcedx-vscode-core/src/commands/forceAuthLogout.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceAuthLogout.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  Command,
+  SfdxCommandBuilder
+} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import { nls } from '../messages';
+import {
+  EmptyParametersGatherer,
+  SfdxCommandlet,
+  SfdxCommandletExecutor,
+  SfdxWorkspaceChecker
+} from './commands';
+
+export class ForceAuthLogoutAll extends SfdxCommandletExecutor<{}> {
+  public build(data: {}): Command {
+    return new SfdxCommandBuilder()
+      .withDescription(nls.localize('force_auth_logout_all_text'))
+      .withArg('force:auth:logout')
+      .withArg('--all')
+      .withArg('--noprompt')
+      .build();
+  }
+}
+
+const workspaceChecker = new SfdxWorkspaceChecker();
+const parameterGatherer = new EmptyParametersGatherer();
+const executor = new ForceAuthLogoutAll();
+const commandlet = new SfdxCommandlet(
+  workspaceChecker,
+  parameterGatherer,
+  executor
+);
+
+export function forceAuthLogoutAll() {
+  commandlet.run();
+}

--- a/packages/salesforcedx-vscode-core/src/commands/forceAuthWebLogin.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceAuthWebLogin.ts
@@ -71,13 +71,19 @@ export class ForceAuthWebDemoModeLoginExecutor extends SfdxCommandletExecutor<{}
     CancellableStatusBar.show(execution, cancellationTokenSource);
     taskViewService.addCommandExecution(execution, cancellationTokenSource);
 
-    const cmdOutput = new CommandOutput();
-    const result = await cmdOutput.getCmdResult(execution);
-
-    if (isProdOrg(JSON.parse(result))) {
-      promptLogOutForProdOrg();
+    try {
+      const result = await new CommandOutput().getCmdResult(execution);
+      if (isProdOrg(JSON.parse(result))) {
+        promptLogOutForProdOrg();
+      } else {
+        notificationService.showSuccessfulExecution(
+          execution.command.toString()
+        );
+      }
+      return Promise.resolve();
+    } catch (err) {
+      return Promise.reject(err);
     }
-    return Promise.resolve();
   }
 }
 
@@ -85,7 +91,7 @@ export function promptLogOutForProdOrg() {
   new SfdxCommandlet(
     new SfdxWorkspaceChecker(),
     new DemoModePromptGatherer(),
-    new ForceAuthLogoutAll()
+    ForceAuthLogoutAll.withoutShowingChannel()
   ).run();
 }
 

--- a/packages/salesforcedx-vscode-core/src/commands/forceAuthWebLogin.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceAuthWebLogin.ts
@@ -9,13 +9,25 @@ import {
   Command,
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import { CliCommandExecutor } from '@salesforce/salesforcedx-utils-vscode/out/src/cli/commandExecutor';
+import { CommandOutput } from '@salesforce/salesforcedx-utils-vscode/out/src/cli/commandOutput';
+import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types/index';
+import { Observable } from 'rxjs/Observable';
+import { CancellationToken, CancellationTokenSource, workspace } from 'vscode';
+import { channelService } from '../channels/index';
 import { nls } from '../messages';
+import { isDemoMode, isTrialOrg } from '../modes/demo-mode';
+import { notificationService } from '../notifications/index';
+import { taskViewService } from '../statuses/index';
+import { CancellableStatusBar } from '../statuses/statusBar';
 import {
+  DemoModePromptGatherer,
   EmptyParametersGatherer,
   SfdxCommandlet,
   SfdxCommandletExecutor,
   SfdxWorkspaceChecker
 } from './commands';
+import { ForceAuthLogoutAll } from './forceAuthLogout';
 
 class ForceAuthWebLoginExecutor extends SfdxCommandletExecutor<{}> {
   public build(data: {}): Command {
@@ -29,14 +41,72 @@ class ForceAuthWebLoginExecutor extends SfdxCommandletExecutor<{}> {
   }
 }
 
+class ForceAuthWebDemoModeLoginExecutor extends SfdxCommandletExecutor<{}> {
+  public build(data: {}): Command {
+    return new SfdxCommandBuilder()
+      .withDescription(
+        nls.localize('force_auth_web_login_authorize_dev_hub_text')
+      )
+      .withArg('force:auth:web:login')
+      .withArg('--noprompt')
+      .withArg('--json')
+      .withArg('--setdefaultdevhubusername')
+      .build();
+  }
+
+  public async execute(response: ContinueResponse<{}>): Promise<void> {
+    const cancellationTokenSource = new CancellationTokenSource();
+    const cancellationToken = cancellationTokenSource.token;
+
+    const execution = new CliCommandExecutor(this.build({}), {
+      cwd: workspace.rootPath
+    }).execute(cancellationToken);
+
+    notificationService.reportExecutionError(
+      execution.command.toString(),
+      (execution.stderrSubject as any) as Observable<Error | undefined>
+    );
+
+    channelService.streamCommandOutput(execution);
+    CancellableStatusBar.show(execution, cancellationTokenSource);
+    taskViewService.addCommandExecution(execution, cancellationTokenSource);
+
+    const cmdOutput = new CommandOutput();
+    const result = await cmdOutput.getCmdResult(execution);
+
+    if (isTrialOrg(JSON.parse(result))) {
+      promptLogOutForDemoMode();
+    }
+    return Promise.resolve();
+  }
+}
+
+export function promptLogOutForDemoMode() {
+  new SfdxCommandlet(
+    new SfdxWorkspaceChecker(),
+    new DemoModePromptGatherer(),
+    new ForceAuthLogoutAll()
+  ).run();
+}
+
 const workspaceChecker = new SfdxWorkspaceChecker();
 const parameterGatherer = new EmptyParametersGatherer();
-const executor = new ForceAuthWebLoginExecutor();
-const commandlet = new SfdxCommandlet(
-  workspaceChecker,
-  parameterGatherer,
-  executor
-);
+
+let commandlet: SfdxCommandlet<{}>;
+
+if (isDemoMode()) {
+  commandlet = new SfdxCommandlet(
+    workspaceChecker,
+    parameterGatherer,
+    new ForceAuthWebDemoModeLoginExecutor()
+  );
+} else {
+  commandlet = new SfdxCommandlet(
+    workspaceChecker,
+    parameterGatherer,
+    new ForceAuthWebLoginExecutor()
+  );
+}
 
 export function forceAuthWebLogin() {
   commandlet.run();

--- a/packages/salesforcedx-vscode-core/src/commands/forceStopApexDebugLogging.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceStopApexDebugLogging.ts
@@ -18,8 +18,8 @@ import {
 } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import * as vscode from 'vscode';
 import { developerLogTraceFlag } from '.';
+import { hideTraceFlagExpiration } from '../decorators';
 import { nls } from '../messages';
-import { hideTraceFlagExpiration } from '../traceflag-time-decorator';
 import {
   SfdxCommandlet,
   SfdxCommandletExecutor,

--- a/packages/salesforcedx-vscode-core/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/index.ts
@@ -46,7 +46,11 @@ export { forceOrgDisplay } from './forceOrgDisplay';
 export { forceProjectCreate } from './forceProjectCreate';
 export { forceApexTriggerCreate } from './forceApexTriggerCreate';
 export { forceStartApexDebugLogging } from './forceStartApexDebugLogging';
-export { forceStopApexDebugLogging } from './forceStopApexDebugLogging';
+export {
+  forceStopApexDebugLogging,
+  restoreDebugLevels
+} from './forceStopApexDebugLogging';
 export { forceApexLogGet } from './forceApexLogGet';
+export { forceAuthLogoutAll } from './forceAuthLogout';
 import { DeveloperLogTraceFlag } from '../traceflag/developerLogTraceFlag';
 export const developerLogTraceFlag = DeveloperLogTraceFlag.getInstance();

--- a/packages/salesforcedx-vscode-core/src/decorators/demo-mode-decorator.ts
+++ b/packages/salesforcedx-vscode-core/src/decorators/demo-mode-decorator.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { StatusBarAlignment, StatusBarItem, window } from 'vscode';
+import { nls } from '../../src/messages';
+
+let demoModeStatusBar: StatusBarItem;
+
+export function showDemoMode() {
+  if (!demoModeStatusBar) {
+    demoModeStatusBar = window.createStatusBarItem(
+      StatusBarAlignment.Right,
+      50
+    );
+    demoModeStatusBar.text = nls.localize('demo_mode_status_text');
+    demoModeStatusBar.tooltip = nls.localize('demo_mode_status_tooltip');
+    demoModeStatusBar.show();
+  }
+}

--- a/packages/salesforcedx-vscode-core/src/decorators/index.ts
+++ b/packages/salesforcedx-vscode-core/src/decorators/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+export { showDemoMode } from './demo-mode-decorator';
+export { monitorOrgConfigChanges, showOrg } from './scratch-org-decorator';
+export {
+  disposeTraceFlagExpiration,
+  hideTraceFlagExpiration,
+  showTraceFlagExpiration
+} from './traceflag-time-decorator';

--- a/packages/salesforcedx-vscode-core/src/decorators/scratch-org-decorator.ts
+++ b/packages/salesforcedx-vscode-core/src/decorators/scratch-org-decorator.ts
@@ -25,7 +25,7 @@ export function showOrg() {
   displayDefaultUserName(CONFIG_FILE);
 }
 
-export function monitorConfigChanges() {
+export function monitorOrgConfigChanges() {
   const watcher = workspace.createFileSystemWatcher(CONFIG_FILE);
   watcher.onDidChange(uri => {
     displayDefaultUserName(uri.fsPath);

--- a/packages/salesforcedx-vscode-core/src/decorators/traceflag-time-decorator.ts
+++ b/packages/salesforcedx-vscode-core/src/decorators/traceflag-time-decorator.ts
@@ -7,8 +7,8 @@
 
 import * as moment from 'moment';
 import { StatusBarAlignment, StatusBarItem, window } from 'vscode';
-import { APEX_CODE_DEBUG_LEVEL } from './constants';
-import { nls } from './messages';
+import { APEX_CODE_DEBUG_LEVEL } from './../constants';
+import { nls } from './../messages';
 
 let statusBarItem: StatusBarItem;
 

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -392,10 +392,5 @@ export function deactivate(): Promise<void> {
   console.log('SFDX CLI Extension Deactivated');
 
   decorators.disposeTraceFlagExpiration();
-
-  if (isDemoMode()) {
-    forceAuthLogoutAll();
-  }
-
   return restoreDebugLevels();
 }

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -20,6 +20,7 @@ import {
   forceApexTestMethodRunCodeActionDelegate,
   forceApexTestRun,
   forceApexTriggerCreate,
+  forceAuthLogoutAll,
   forceAuthWebLogin,
   forceConfigList,
   forceDataSoqlQuery,
@@ -41,24 +42,24 @@ import {
   forceTaskStop,
   forceVisualforceComponentCreate,
   forceVisualforcePageCreate,
+  restoreDebugLevels,
   SelectFileName,
   SelectStrictDirPath,
   SfdxCommandlet,
   SfdxCommandletExecutor,
   SfdxWorkspaceChecker
 } from './commands';
-import { restoreDebugLevels } from './commands/forceStopApexDebugLogging';
 import { isvDebugBootstrap } from './commands/isvdebugging/bootstrapCmd';
 import {
   CLIENT_ID,
   SFDX_CLIENT_ENV_VAR,
   TERMINAL_INTEGRATED_ENVS
 } from './constants';
+import * as decorators from './decorators';
+import { isDemoMode } from './modes/demo-mode';
 import { notificationService } from './notifications';
-import * as scratchOrgDecorator from './scratch-org-decorator';
 import { CANCEL_EXECUTION_COMMAND, cancelCommandExecution } from './statuses';
 import { CancellableStatusBar, taskViewService } from './statuses';
-import { disposeTraceFlagExpiration } from './traceflag-time-decorator';
 
 function registerCommands(): vscode.Disposable {
   // Customer-facing commands
@@ -357,8 +358,13 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Scratch Org Decorator
   if (vscode.workspace.rootPath) {
-    scratchOrgDecorator.showOrg();
-    scratchOrgDecorator.monitorConfigChanges();
+    decorators.showOrg();
+    decorators.monitorOrgConfigChanges();
+  }
+
+  // Demo mode Decorator
+  if (vscode.workspace.rootPath && isDemoMode()) {
+    decorators.showDemoMode();
   }
 
   const api: any = {
@@ -379,6 +385,12 @@ export async function activate(context: vscode.ExtensionContext) {
 
 export function deactivate(): Promise<void> {
   console.log('SFDX CLI Extension Deactivated');
-  disposeTraceFlagExpiration();
+
+  decorators.disposeTraceFlagExpiration();
+
+  if (isDemoMode()) {
+    forceAuthLogoutAll();
+  }
+
   return restoreDebugLevels();
 }

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -67,6 +67,10 @@ function registerCommands(): vscode.Disposable {
     'sfdx.force.auth.web.login',
     forceAuthWebLogin
   );
+  const forceAuthLogoutAllCmd = vscode.commands.registerCommand(
+    'sfdx.force.auth.logout.all',
+    forceAuthLogoutAll
+  );
   const forceOrgCreateCmd = vscode.commands.registerCommand(
     'sfdx.force.org.create',
     forceOrgCreate
@@ -261,6 +265,7 @@ function registerCommands(): vscode.Disposable {
     forceApexTestMethodRunCmd,
     forceApexTestMethodRunDelegateCmd,
     forceAuthWebLoginCmd,
+    forceAuthLogoutAllCmd,
     forceDataSoqlQueryInputCmd,
     forceDataSoqlQuerySelectionCmd,
     forceOrgCreateCmd,

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -155,5 +155,13 @@ export const messages = {
   error_creating_packagexml: 'Error creating package.xml. %s',
   error_extracting_org_source: 'Error extracting downloaded Apex source. %s',
   error_extracting_packages: 'Error extracting packages: %s',
-  error_updating_sfdx_project: 'Error updating sfdx-project.json: %s'
+  error_updating_sfdx_project: 'Error updating sfdx-project.json: %s',
+
+  demo_mode_status_text: `$(gist-secret) SFDX DEMO`,
+  demo_mode_status_tooltip:
+    'You are running the SFDX VS Code extensions in demo mode. You will be prompted if you are connecting to production orgs.',
+  demo_mode_prompt:
+    'Authenticating against a business or production org is not recommended on a demo or shared machine. Continue authenticating or cancel?',
+
+  force_auth_logout_all_text: 'SFDX: Log Out from All Authorized Orgs'
 };

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -159,9 +159,9 @@ export const messages = {
 
   demo_mode_status_text: `$(gist-secret) SFDX DEMO`,
   demo_mode_status_tooltip:
-    'You are running the SFDX VS Code extensions in demo mode. You will be prompted if you are connecting to production orgs.',
+    'You are running Salesforce Extensions for VS Code in demo mode. You will be prompted for confirmation when connecting to production orgs.',
   demo_mode_prompt:
-    'Authenticating against a business or production org is not recommended on a demo or shared machine. Continue authenticating or cancel?',
+    'Authorizing a business or production org is not recommended on a demo or shared machine. If you continue with the authentication, be sure to run "sfdx force:auth:logout --targetusername --noprompt" when you\'re done using the org. Are you sure you want to authorize this org?',
 
   force_auth_logout_all_text: 'SFDX: Log Out from All Authorized Orgs'
 };

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -161,7 +161,7 @@ export const messages = {
   demo_mode_status_tooltip:
     'You are running Salesforce Extensions for VS Code in demo mode. You will be prompted for confirmation when connecting to production orgs.',
   demo_mode_prompt:
-    'Authorizing a business or production org is not recommended on a demo or shared machine. If you continue with the authentication, be sure to run "sfdx force:auth:logout --targetusername --noprompt" when you\'re done using the org. Are you sure you want to authorize this org?',
+    'Authorizing a business or production org is not recommended on a demo or shared machine. If you continue with the authentication, be sure to run "SFDX: Log Out from All Authorized Orgs" when you\'re done using this org.',
 
   force_auth_logout_all_text: 'SFDX: Log Out from All Authorized Orgs'
 };

--- a/packages/salesforcedx-vscode-core/src/modes/demo-mode.ts
+++ b/packages/salesforcedx-vscode-core/src/modes/demo-mode.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+export function isDemoMode() {
+  return process.env.SFDX_ENV ? process.env.SFDX_ENV === 'DEMO' : false;
+}
+
+export type authResponse = {
+  orgId: string;
+  username: string;
+  accessToken?: string;
+  instanceUrl?: string;
+  refreshToken?: string;
+  loginUrl?: string;
+  clientId?: string;
+  trialExpirationDate?: string;
+  clientSecret?: string;
+};
+
+export function isTrialOrg(response: { status: number; result: authResponse }) {
+  return response.result.trialExpirationDate ? false : true;
+}

--- a/packages/salesforcedx-vscode-core/src/modes/demo-mode.ts
+++ b/packages/salesforcedx-vscode-core/src/modes/demo-mode.ts
@@ -17,10 +17,10 @@ export type authResponse = {
   refreshToken?: string;
   loginUrl?: string;
   clientId?: string;
-  trialExpirationDate?: string;
+  trialExpirationDate?: string | null;
   clientSecret?: string;
 };
 
-export function isTrialOrg(response: { status: number; result: authResponse }) {
+export function isProdOrg(response: { status: number; result: authResponse }) {
   return response.result.trialExpirationDate ? false : true;
 }

--- a/packages/salesforcedx-vscode-core/src/modes/index.ts
+++ b/packages/salesforcedx-vscode-core/src/modes/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+export { isDemoMode, isTrialOrg } from './demo-mode';

--- a/packages/salesforcedx-vscode-core/src/modes/index.ts
+++ b/packages/salesforcedx-vscode-core/src/modes/index.ts
@@ -5,4 +5,4 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export { isDemoMode, isTrialOrg } from './demo-mode';
+export { isDemoMode, isProdOrg } from './demo-mode';

--- a/packages/salesforcedx-vscode-core/src/notifications/notificationService.ts
+++ b/packages/salesforcedx-vscode-core/src/notifications/notificationService.ts
@@ -78,46 +78,55 @@ export class NotificationService {
   ) {
     observable.subscribe(async data => {
       if (data != undefined && data.toString() === '0') {
-        const message = nls.localize(
-          'notification_successful_execution_text',
-          executionName
-        );
-        if (sfdxCoreSettings.getShowCLISuccessMsg()) {
-          const showButtonText = nls.localize('notification_show_button_text');
-          const showOnlyStatusBarButtonText = nls.localize(
-            'notification_show_in_status_bar_button_text'
-          );
-          const selection = await this.showInformationMessage(
-            message,
-            showButtonText,
-            showOnlyStatusBarButtonText
-          );
-          if (selection && selection === showButtonText) {
-            this.channel.show();
-          }
-          if (selection && selection === showOnlyStatusBarButtonText) {
-            sfdxCoreSettings.updateShowCLISuccessMsg(false);
-          }
-        } else {
-          vscode.window.setStatusBarMessage(message, STATUS_BAR_MSG_TIMEOUT_MS);
-        }
+        await this.showSuccessfulExecution(executionName);
       } else {
         if (cancellationToken && cancellationToken.isCancellationRequested) {
-          this.showWarningMessage(
-            nls.localize('notification_canceled_execution_text', executionName)
-          );
-          this.channel.show();
+          this.showCanceledExecution(executionName);
         } else {
-          this.showErrorMessage(
-            nls.localize(
-              'notification_unsuccessful_execution_text',
-              executionName
-            )
-          );
-          this.channel.show();
+          this.showFailedExecution(executionName);
         }
       }
     });
+  }
+
+  private showFailedExecution(executionName: string) {
+    this.showErrorMessage(
+      nls.localize('notification_unsuccessful_execution_text', executionName)
+    );
+    this.channel.show();
+  }
+
+  private showCanceledExecution(executionName: string) {
+    this.showWarningMessage(
+      nls.localize('notification_canceled_execution_text', executionName)
+    );
+    this.channel.show();
+  }
+
+  public async showSuccessfulExecution(executionName: string) {
+    const message = nls.localize(
+      'notification_successful_execution_text',
+      executionName
+    );
+    if (sfdxCoreSettings.getShowCLISuccessMsg()) {
+      const showButtonText = nls.localize('notification_show_button_text');
+      const showOnlyStatusBarButtonText = nls.localize(
+        'notification_show_in_status_bar_button_text'
+      );
+      const selection = await this.showInformationMessage(
+        message,
+        showButtonText,
+        showOnlyStatusBarButtonText
+      );
+      if (selection && selection === showButtonText) {
+        this.channel.show();
+      }
+      if (selection && selection === showOnlyStatusBarButtonText) {
+        sfdxCoreSettings.updateShowCLISuccessMsg(false);
+      }
+    } else {
+      vscode.window.setStatusBarMessage(message, STATUS_BAR_MSG_TIMEOUT_MS);
+    }
   }
 
   public reportExecutionError(

--- a/packages/salesforcedx-vscode-core/src/traceflag/developerLogTraceFlag.ts
+++ b/packages/salesforcedx-vscode-core/src/traceflag/developerLogTraceFlag.ts
@@ -6,7 +6,7 @@
  */
 
 import { APEX_CODE_DEBUG_LEVEL, VISUALFORCE_DEBUG_LEVEL } from '../constants';
-import { showTraceFlagExpiration } from '../traceflag-time-decorator';
+import { showTraceFlagExpiration } from '../decorators';
 
 export class DeveloperLogTraceFlag {
   private static instance: DeveloperLogTraceFlag;

--- a/packages/salesforcedx-vscode-core/test/commands/commands.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/commands.test.ts
@@ -18,6 +18,7 @@ import * as vscode from 'vscode';
 import {
   CommandletExecutor,
   CompositeParametersGatherer,
+  DemoModePromptGatherer,
   EmptyParametersGatherer,
   EmptyPostChecker,
   FilePathExistsChecker,
@@ -231,7 +232,6 @@ describe('Command Utilities', () => {
         const dirList: string[] = dirPathGatherer.globDirs(
           vscode.workspace.rootPath
         );
-        console.log(`Found dirs: ${dirList}`);
         expect(dirList[0]).to.not.contain(WORKSPACE_NAME);
         expect(dirList.length).to.equal(SFDX_SIMPLE_NUM_OF_DIRS);
       });
@@ -503,6 +503,38 @@ describe('Command Utilities', () => {
         sinon.assert.called(warningSpy);
         expect(response.type).to.equal('CANCEL');
       });
+    });
+  });
+
+  // Due to the way the prompt is phrased
+  // CONTINUE means that we will execute the forceLogoutAll command
+  // CANCEL means that we will not execute the forceLogoutAll command
+  describe('DemoModePrompGatherer', () => {
+    let showInformationMessageStub: sinon.SinonStub;
+
+    before(() => {
+      showInformationMessageStub = sinon.stub(
+        vscode.window,
+        'showInformationMessage'
+      );
+    });
+
+    after(() => {
+      sinon.restore(vscode.window);
+    });
+
+    it('Should return CONTINUE if message is Cancel', async () => {
+      showInformationMessageStub.onFirstCall().returns('Cancel');
+      const gatherer = new DemoModePromptGatherer();
+      const result = await gatherer.gather();
+      expect(result.type).to.equal('CONTINUE');
+      expect((result as ContinueResponse<{}>).data!).to.eql({});
+    });
+    it('Should return CANCEL if message is Authorize Org', async () => {
+      showInformationMessageStub.onFirstCall().returns('Cancel');
+      const gatherer = new DemoModePromptGatherer();
+      const result = await gatherer.gather();
+      expect(result.type).to.equal('CANCEL');
     });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/commands/forceApexTestRun.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceApexTestRun.test.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';

--- a/packages/salesforcedx-vscode-core/test/commands/forceApexTestRunCodeAction.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceApexTestRunCodeAction.test.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
 import { expect } from 'chai';
 import {
   ForceApexTestRunCodeActionExecutor,

--- a/packages/salesforcedx-vscode-core/test/commands/forceAuthLogout.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceAuthLogout.test.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from 'chai';
+import { ForceAuthLogoutAll } from '../../src/commands/forceAuthLogout';
+import { nls } from '../../src/messages';
+
+// tslint:disable:no-unused-expression
+describe('Force Auth Logout All', () => {
+  it('Should build the auth logout all command', async () => {
+    const authLogoutAll = new ForceAuthLogoutAll();
+    const authLogoutAllCommand = authLogoutAll.build({});
+    expect(authLogoutAllCommand.toCommand()).to.equal(
+      'sfdx force:auth:logout --all --noprompt'
+    );
+    expect(authLogoutAllCommand.description).to.equal(
+      nls.localize('force_auth_logout_all_text')
+    );
+  });
+});

--- a/packages/salesforcedx-vscode-core/test/commands/forceAuthWebLogin.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceAuthWebLogin.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from 'chai';
+import {
+  createExecutor,
+  ForceAuthWebDemoModeLoginExecutor,
+  ForceAuthWebLoginExecutor
+} from '../../src/commands/forceAuthWebLogin';
+import { nls } from '../../src/messages';
+
+// tslint:disable:no-unused-expression
+describe('Force Auth Web Login', () => {
+  it('Should build the auth web login command', async () => {
+    const authWebLogin = new ForceAuthWebLoginExecutor();
+    const authWebLoginCommand = authWebLogin.build({});
+    expect(authWebLoginCommand.toCommand()).to.equal(
+      'sfdx force:auth:web:login --setdefaultdevhubusername'
+    );
+    expect(authWebLoginCommand.description).to.equal(
+      nls.localize('force_auth_web_login_authorize_dev_hub_text')
+    );
+  });
+});
+
+describe('Force Auth Web Login for Demo  Mode', () => {
+  it('Should build the auth web login command', async () => {
+    const authWebLogin = new ForceAuthWebDemoModeLoginExecutor();
+    const authWebLoginCommand = authWebLogin.build({});
+    expect(authWebLoginCommand.toCommand()).to.equal(
+      'sfdx force:auth:web:login --setdefaultdevhubusername --noprompt --json'
+    );
+    expect(authWebLoginCommand.description).to.equal(
+      nls.localize('force_auth_web_login_authorize_dev_hub_text')
+    );
+  });
+});
+
+describe('Command chosen is based on results of isDemoMode()', () => {
+  let originalValue: any;
+
+  beforeEach(() => {
+    originalValue = process.env.SFDX_ENV;
+  });
+
+  afterEach(() => {
+    process.env.SFXD_ENV = originalValue;
+  });
+
+  it('Should use ForceAuthWebDemoModeLoginExecutor if demo mode is true', () => {
+    process.env.SFDX_ENV = 'DEMO';
+    expect(createExecutor() instanceof ForceAuthWebDemoModeLoginExecutor).to.be
+      .true;
+  });
+
+  it('Should use ForceAuthWebLoginExecutor if demo mode is false', () => {
+    process.env.SFDX_ENV = '';
+    expect(createExecutor() instanceof ForceAuthWebLoginExecutor).to.be.true;
+  });
+});

--- a/packages/salesforcedx-vscode-core/test/commands/forceOrgCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceOrgCreate.test.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
 import { expect } from 'chai';
 import * as path from 'path';
 import * as sinon from 'sinon';

--- a/packages/salesforcedx-vscode-core/test/commands/forceProjectCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceProjectCreate.test.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import { expect } from 'chai';
 import * as path from 'path';

--- a/packages/salesforcedx-vscode-core/test/modes/index.test.ts
+++ b/packages/salesforcedx-vscode-core/test/modes/index.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from 'chai';
+import * as vscode from 'vscode';
+import { isDemoMode, isProdOrg } from '../../src/modes/demo-mode';
+
+// tslint:disable:no-unused-expression
+describe('Demo Mode Utils', () => {
+  describe('isDemoMode', () => {
+    let originalValue: any;
+
+    beforeEach(() => {
+      originalValue = process.env.SFDX_ENV;
+    });
+
+    afterEach(() => {
+      process.env.SFXD_ENV = originalValue;
+    });
+
+    it('Should report demo mode if SFDX_ENV === DEMO', () => {
+      process.env.SFDX_ENV = 'DEMO';
+      expect(isDemoMode()).to.be.true;
+    });
+
+    it('Should not report demo mode if SFDX_ENV !== DEMO', () => {
+      process.env.SFDX_ENV = 'SOMETHING_ELSE';
+      expect(isDemoMode()).to.be.false;
+    });
+  });
+
+  describe('isProdOrg', () => {
+    it('Should report trial org if trialExpirationDate is a date string', () => {
+      expect(
+        isProdOrg({
+          status: 0,
+          result: {
+            orgId: '00D_BOGUS',
+            username: '005_BOGUS',
+            trialExpirationDate: '2021-08-08T23:59:59.000+0000'
+          }
+        })
+      ).to.be.false;
+    });
+
+    it('Should not report trial org if trialExpirationDate is undefined', () => {
+      expect(
+        isProdOrg({
+          status: 0,
+          result: {
+            orgId: '00D_BOGUS',
+            username: '005_BOGUS'
+          }
+        })
+      ).to.be.true;
+    });
+
+    it('Should not report trial org if trialExpirationDate is null', () => {
+      expect(
+        isProdOrg({
+          status: 0,
+          result: {
+            orgId: '00D_BOGUS',
+            username: '005_BOGUS',
+            trialExpirationDate: null
+          }
+        })
+      ).to.be.true;
+    });
+  });
+});

--- a/packages/salesforcedx-vscode-core/test/modes/index.test.ts
+++ b/packages/salesforcedx-vscode-core/test/modes/index.test.ts
@@ -33,7 +33,7 @@ describe('Demo Mode Utils', () => {
   });
 
   describe('isProdOrg', () => {
-    it('Should report trial org if trialExpirationDate is a date string', () => {
+    it('Should not be a prod org if trialExpirationDate is a date string', () => {
       expect(
         isProdOrg({
           status: 0,
@@ -46,7 +46,7 @@ describe('Demo Mode Utils', () => {
       ).to.be.false;
     });
 
-    it('Should not report trial org if trialExpirationDate is undefined', () => {
+    it('Should be a prod org if trialExpirationDate is undefined', () => {
       expect(
         isProdOrg({
           status: 0,
@@ -58,7 +58,7 @@ describe('Demo Mode Utils', () => {
       ).to.be.true;
     });
 
-    it('Should not report trial org if trialExpirationDate is null', () => {
+    it('Should be a prod org if trialExpirationDate is null', () => {
       expect(
         isProdOrg({
           status: 0,

--- a/packages/salesforcedx-vscode-core/test/modes/index.test.ts
+++ b/packages/salesforcedx-vscode-core/test/modes/index.test.ts
@@ -6,7 +6,6 @@
  */
 
 import { expect } from 'chai';
-import * as vscode from 'vscode';
 import { isDemoMode, isProdOrg } from '../../src/modes/demo-mode';
 
 // tslint:disable:no-unused-expression

--- a/packages/salesforcedx-vscode-core/test/traceflag/DeveloperLogTraceFlag.test.ts
+++ b/packages/salesforcedx-vscode-core/test/traceflag/DeveloperLogTraceFlag.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { expect } from 'chai';
-import { developerLogTraceFlag } from '../src/commands';
+import { developerLogTraceFlag } from '../../src/commands';
 
 // tslint:disable:no-unused-expression
 describe('Force Start Apex Debug Logging', () => {


### PR DESCRIPTION
### What does this PR do?

Supports demo mode from the CLI. If we detect that SFDX_ENV is set to DEMO we activate demo mode, which does two things:

1. Shows the status bar item at the bottom right corner.
2. If the user authenticates against a non-trial org, we warn the user and ask if she wants to proceed.

### What issues does this PR fix or reference?

@W-4714447@
