### PR TITLE
Run npm lint before push

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "devDependencies": {
+    "ajv": "6.1.1",
     "eslint": "4.13.1",
     "eslint-config-prettier": "2.9.0",
+    "husky": "^0.14.3",
     "istanbul": "1.1.0-alpha.1",
     "lerna": "2.4.0",
     "prettier": "1.6.0",
@@ -9,7 +11,6 @@
     "shx": "0.2.2",
     "tslint": "5.5.0",
     "typescript": "2.6.2",
-    "ajv": "6.1.1",
     "vsce": "^1.36.3"
   },
   "scripts": {
@@ -21,6 +22,7 @@
     "compile": "lerna run --stream compile",
     "lint": "lerna run lint",
     "publish": "node scripts/publish.js",
+    "prepush": "npm run lint",
     "test": "lerna run test --concurrency 1 --stream",
     "test:unit": "lerna run test:unit --concurrency 1 --stream",
     "test:integration": "lerna run test:integration --concurrency 1 --stream",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "ajv": "6.1.1",
     "eslint": "4.13.1",
     "eslint-config-prettier": "2.9.0",
-    "husky": "^0.14.3",
+    "husky": "0.14.3",
     "istanbul": "1.1.0-alpha.1",
     "lerna": "2.4.0",
     "prettier": "1.6.0",


### PR DESCRIPTION
### What does this PR do?

I've noticed that a lot of times (myself included) that we have pushed to GitHub without first running `npm run lint`. Instead of trying to force everyone to remember to do so, I've automated it using [husky](https://www.npmjs.com/package/husky).

So, now when you do a `npm install` it will set up everything for you.

Now, when you do a `git push` it will run lint first for you.
If for some reason you want to bypass this, you can always do `git push --no-verify` to skip all the hooks.

### What issues does this PR fix or reference?

Code health.
