### PR TITLE
Update docs for v42.7.0

### DIFF
--- a/packages/salesforcedx-vscode-apex-debugger/README.md
+++ b/packages/salesforcedx-vscode-apex-debugger/README.md
@@ -153,7 +153,7 @@ These entry points aren’t supported:
 * _[Apex Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode)_
 * _Force.com IDE Developer Guide_: [Explore a Simple Debugging Puzzle](https://developer.salesforce.com/docs/atlas.en-us.eclipse.meta/eclipse/debugger_puzzle_parent.htm)
 * GitHub: [salesforcedx-vscode-apex-debugger](https://github.com/forcedotcom/salesforcedx-vscode/tree/develop/packages/salesforcedx-vscode-apex-debugger)
-* GitHub Wiki for salesforcedx-vscode: [Apex Debugger](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Apex-Debugger)  
+* GitHub wiki for salesforcedx-vscode: [Apex Debugger](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Apex-Debugger)  
 
 ---
 Currently, Visual Studio Code extensions are not signed or verified on the Microsoft Visual Studio Code Marketplace. Salesforce provides the Secure Hash Algorithm (SHA) of each extension that we publish. Consult [Manually Verify the salesforcedx-vscode Extensions’ Authenticity](https://developer.salesforce.com/media/vscode/SHA256.md) to learn how to verify the extensions.  

--- a/packages/salesforcedx-vscode-apex-debugger/README.md
+++ b/packages/salesforcedx-vscode-apex-debugger/README.md
@@ -153,6 +153,7 @@ These entry points aren’t supported:
 * _[Apex Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode)_
 * _Force.com IDE Developer Guide_: [Explore a Simple Debugging Puzzle](https://developer.salesforce.com/docs/atlas.en-us.eclipse.meta/eclipse/debugger_puzzle_parent.htm)
 * GitHub: [salesforcedx-vscode-apex-debugger](https://github.com/forcedotcom/salesforcedx-vscode/tree/develop/packages/salesforcedx-vscode-apex-debugger)
+* GitHub Wiki for salesforcedx-vscode: [Apex Debugger](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Apex-Debugger)  
 
 ---
 Currently, Visual Studio Code extensions are not signed or verified on the Microsoft Visual Studio Code Marketplace. Salesforce provides the Secure Hash Algorithm (SHA) of each extension that we publish. Consult [Manually Verify the salesforcedx-vscode Extensions’ Authenticity](https://developer.salesforce.com/media/vscode/SHA256.md) to learn how to verify the extensions.  

--- a/packages/salesforcedx-vscode-apex/README.md
+++ b/packages/salesforcedx-vscode-apex/README.md
@@ -19,19 +19,19 @@ To see code-completion suggestions, press Ctrl+space when you’re working in a 
 
 ## View or Jump to Definitions
 You can preview, view, or go to definitions of:  
-* Apex  
-  * classes (from definitions of extending classes)  
-  * constructors  
-  * interfaces (from definitions of implementing classes)  
-  * methods  
-  * properties  
-  * variables (local and class variables)  
-* standard objects  
-  * fields (standard and custom fields)
-  * object definitions
-* custom objects
-  * fields  
-  * object definitions  
+* User-defined Apex  
+  * Classes (from definitions of extending classes)  
+  * Constructors  
+  * Interfaces (from definitions of implementing classes)  
+  * Methods  
+  * Properties  
+  * Variables (local and class variables)  
+* Standard objects  
+  * Fields (standard and custom fields)
+  * Object definitions
+* Custom objects
+  * Fields  
+  * Object definitions  
 
 (See the "Enable Code Smartness for SObjects" section of this README for information on working with standard and custom objects.)
 
@@ -43,10 +43,13 @@ To jump to the location of a definition, right-click the item and select **Go to
 ![Previewing, viewing, and jumping to a definition](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-apex/images/apex_go_to_definition.gif)
 
 ## Find All References to Types
-You can find all references to:
-* Apex class variables
-* Apex properties
-* User-defined Apex classes, enums, interfaces, and methods
+You can find all references to user-defined Apex:  
+* Classes  
+* Class variables  
+* Enums  
+* Interfaces  
+* Methods  
+* Properties  
 
 To find references to an item, right-click the item and select **Find All References**, or press Shift+F12.
 
@@ -82,6 +85,7 @@ If you’re not seeing the Apex completion suggestions that you expect, your Ape
 * Dreamforce ’17 Session Video: [Building Powerful Tooling For All IDEs Through Language Servers](https://www.salesforce.com/video/1765282/)
 * GitHub: [Language Server Protocol](https://github.com/Microsoft/language-server-protocol)
 * GitHub: [salesforcedx-vscode-apex](https://github.com/forcedotcom/salesforcedx-vscode/tree/develop/packages/salesforcedx-vscode-apex)
+* GitHub Wiki for salesforcedx-vscode: [Apex Language Server](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Apex-Language-Server)
 
 ---
 Currently, Visual Studio Code extensions are not signed or verified on the Microsoft Visual Studio Code Marketplace. Salesforce provides the Secure Hash Algorithm (SHA) of each extension that we publish. Consult [Manually Verify the salesforcedx-vscode Extensions’ Authenticity](https://developer.salesforce.com/media/vscode/SHA256.md) to learn how to verify the extensions.    

--- a/packages/salesforcedx-vscode-apex/README.md
+++ b/packages/salesforcedx-vscode-apex/README.md
@@ -42,7 +42,7 @@ To view a definition, right-click the item and select **Peek Definition**, or pr
 To jump to the location of a definition, right-click the item and select **Go to Definition**, or press F12.  
 ![Previewing, viewing, and jumping to a definition](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-apex/images/apex_go_to_definition.gif)
 
-## Find All References to Types
+## Find All References
 You can find all references to user-defined Apex:  
 * Classes  
 * Class variables  
@@ -82,10 +82,10 @@ If you’re not seeing the Apex completion suggestions that you expect, your Ape
 * Trailhead: [Get Started with Salesforce DX](https://trailhead.salesforce.com/trails/sfdx_get_started)
 * _[Salesforce DX Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev)_
 * _[Apex Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode)_
-* Dreamforce ’17 Session Video: [Building Powerful Tooling For All IDEs Through Language Servers](https://www.salesforce.com/video/1765282/)
+* Dreamforce ’17 session video: [Building Powerful Tooling For All IDEs Through Language Servers](https://www.salesforce.com/video/1765282/)
 * GitHub: [Language Server Protocol](https://github.com/Microsoft/language-server-protocol)
 * GitHub: [salesforcedx-vscode-apex](https://github.com/forcedotcom/salesforcedx-vscode/tree/develop/packages/salesforcedx-vscode-apex)
-* GitHub Wiki for salesforcedx-vscode: [Apex Language Server](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Apex-Language-Server)
+* GitHub wiki for salesforcedx-vscode: [Apex Language Server](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Apex-Language-Server)
 
 ---
 Currently, Visual Studio Code extensions are not signed or verified on the Microsoft Visual Studio Code Marketplace. Salesforce provides the Secure Hash Algorithm (SHA) of each extension that we publish. Consult [Manually Verify the salesforcedx-vscode Extensions’ Authenticity](https://developer.salesforce.com/media/vscode/SHA256.md) to learn how to verify the extensions.    

--- a/packages/salesforcedx-vscode-core/README.md
+++ b/packages/salesforcedx-vscode-core/README.md
@@ -75,9 +75,9 @@ To edit your workspace settings, select **Code** > **Preferences** > **Settings*
 To stop Salesforce CLI success messages from showing as pop-up information messages, click **Show Only in Status Bar** in a success message. This button overrides the `salesforcedx-vscode-core.show-cli-success-msg` value in your Default Settings. It changes the Workspace Settings value to `false`. Setting this value to `false` makes the success messages appear in the status bar (in VS Code’s footer) instead of as information messages. If you decide that you liked the information messages after all, change the value back to `true`.   
 
 ## Activate Demo Mode
-If you’re setting up a machine that will be used to give demos at a conference (or otherwise used by people you don’t know), set up demo mode. When in demo mode, VS Code warns users who authorize business or production orgs of the potential security risks of using these orgs on shared machines.  
+If you’re setting up a machine to use for demos at a conference (or for other public use), set up demo mode. When in demo mode, VS Code warns users who authorize business or production orgs of the potential security risks of using these orgs on shared machines.  
 
-To activate demo mode, add an environment variable called `DEMO` and set its value to `true`.  
+To activate demo mode, add an environment variable called `SFDX_ENV` and set its value to `DEMO`: `SFDX_ENV=DEMO`.  
 
 When you’re done with your event, run **SFDX: Log Out from All Authorized Orgs**.  
 

--- a/packages/salesforcedx-vscode-core/README.md
+++ b/packages/salesforcedx-vscode-core/README.md
@@ -29,6 +29,7 @@ These Salesforce CLI commands are available:
 * `force:apex:log:get ...`: **SFDX: Get Apex Debug Logs...**
 * `force:apex:test:run --resultformat human ...`: **SFDX: Invoke Apex Tests...**
 * `force:apex:trigger:create ...`: **SFDX: Create Apex Trigger**
+* `force:auth:logout --all --noprompt`: **SFDX: Log Out from All Authorized Orgs**
 * `force:auth:web:login --setdefaultdevhubusername`: **SFDX: Authorize a Dev Hub**
 * `force:config:list`: **SFDX: List All Config Variables**
 * `force:data:soql:query`: **SFDX: Execute SOQL Query with Currently Selected Text**
@@ -72,6 +73,13 @@ After you run Apex tests, two new commands are available in the command palette:
 To edit your workspace settings, select **Code** > **Preferences** > **Settings** (macOS) or **File** > **Preferences** > **Settings** (Windows and Linux).  
 
 To stop Salesforce CLI success messages from showing as pop-up information messages, click **Show Only in Status Bar** in a success message. This button overrides the `salesforcedx-vscode-core.show-cli-success-msg` value in your Default Settings. It changes the Workspace Settings value to `false`. Setting this value to `false` makes the success messages appear in the status bar (in VS Code’s footer) instead of as information messages. If you decide that you liked the information messages after all, change the value back to `true`.   
+
+## Activate Demo Mode
+If you’re setting up a machine that will be used to give demos at a conference (or otherwise used by people you don’t know), set up demo mode. When in demo mode, VS Code warns users who authorize business or production orgs of the potential security risks of using these orgs on shared machines.  
+
+To activate demo mode, add an environment variable called `DEMO` and set its value to `true`.  
+
+When you’re done with your event, run **SFDX: Log Out from All Authorized Orgs**.  
 
 ## Resources
 * Trailhead: [Get Started with Salesforce DX](https://trailhead.salesforce.com/trails/sfdx_get_started)

--- a/packages/salesforcedx-vscode/README.md
+++ b/packages/salesforcedx-vscode/README.md
@@ -41,7 +41,9 @@ To report issues with Salesforce Extensions for VS Code, visit us on [GitHub](ht
 * _[Salesforce DX Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev)_
 * Dreamforce ’17 Session Video: [Getting Started In VS Code With Salesforce DX](https://www.salesforce.com/video/1768045/)
 * Dreamforce ’17 Session Video: [Visual Studio Code for Eclipse Users](https://www.salesforce.com/video/1774284/)
-* GitHub: [salesforcedx-vscode](https://github.com/forcedotcom/salesforcedx-vscode)
+* GitHub: [salesforcedx-vscode](https://github.com/forcedotcom/salesforcedx-vscode)  
+* GitHub Wiki for salesforcedx-vscode: [Tips and Tricks](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Tips-and-Tricks)
+* GitHub Wiki for salesforcedx-vscode: [Troubleshooting](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Troubleshooting)
 
 ---
 Currently, Visual Studio Code extensions are not signed or verified on the Microsoft Visual Studio Code Marketplace. Salesforce provides the Secure Hash Algorithm (SHA) of each extension that we publish. Consult [Manually Verify the salesforcedx-vscode Extensions’ Authenticity](https://developer.salesforce.com/media/vscode/SHA256.md) to learn how to verify the extensions.  

--- a/packages/salesforcedx-vscode/README.md
+++ b/packages/salesforcedx-vscode/README.md
@@ -42,8 +42,8 @@ To report issues with Salesforce Extensions for VS Code, visit us on [GitHub](ht
 * Dreamforce ’17 Session Video: [Getting Started In VS Code With Salesforce DX](https://www.salesforce.com/video/1768045/)
 * Dreamforce ’17 Session Video: [Visual Studio Code for Eclipse Users](https://www.salesforce.com/video/1774284/)
 * GitHub: [salesforcedx-vscode](https://github.com/forcedotcom/salesforcedx-vscode)  
-* GitHub Wiki for salesforcedx-vscode: [Tips and Tricks](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Tips-and-Tricks)
-* GitHub Wiki for salesforcedx-vscode: [Troubleshooting](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Troubleshooting)
+* GitHub wiki for salesforcedx-vscode: [Tips and Tricks](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Tips-and-Tricks)
+* GitHub wiki for salesforcedx-vscode: [Troubleshooting](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Troubleshooting)
 
 ---
 Currently, Visual Studio Code extensions are not signed or verified on the Microsoft Visual Studio Code Marketplace. Salesforce provides the Secure Hash Algorithm (SHA) of each extension that we publish. Consult [Manually Verify the salesforcedx-vscode Extensions’ Authenticity](https://developer.salesforce.com/media/vscode/SHA256.md) to learn how to verify the extensions.  


### PR DESCRIPTION
### What does this PR do?
* Adds links to wiki pages from Resources lists
* Clarifies that Go To Definition works only for user-defined Apex types (and updates capitalization of related list items to comply with style standards)
* Adds info about demo mode to README for salesforcedx-vscode-core

### What issues does this PR fix or reference?
https://github.com/forcedotcom/salesforcedx-vscode/pull/347
https://github.com/forcedotcom/salesforcedx-vscode/pull/335