### PR TITLE
Remove unused variable

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceAuthWebLogin.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceAuthWebLogin.ts
@@ -13,7 +13,7 @@ import { CliCommandExecutor } from '@salesforce/salesforcedx-utils-vscode/out/sr
 import { CommandOutput } from '@salesforce/salesforcedx-utils-vscode/out/src/cli/commandOutput';
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types/index';
 import { Observable } from 'rxjs/Observable';
-import { CancellationToken, CancellationTokenSource, workspace } from 'vscode';
+import { CancellationTokenSource, workspace } from 'vscode';
 import { channelService } from '../channels/index';
 import { nls } from '../messages';
 import { isDemoMode, isProdOrg } from '../modes/demo-mode';


### PR DESCRIPTION
### What does this PR do?
Removes an unused variable on forceAuthWebLogin to fix a lint error.

### What issues does this PR fix or reference?
During release tasks we got a lint error:
salesforcedx-vscode/packages/salesforcedx-vscode-core/src/commands/forceAuthWebLogin.ts[16, 10]: 'CancellationToken' is declared but its value is never read.
