### PR TITLE
Bump version for vscode debugger modules to use their uri to path fixes

### DIFF
--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -14,8 +14,8 @@
     "async-lock": "1.0.0",
     "faye": "1.1.2",
     "request-light": "0.2.1",
-    "vscode-debugadapter": "1.24.0",
-    "vscode-debugprotocol": "1.24.0"
+    "vscode-debugadapter": "1.28.0",
+    "vscode-debugprotocol": "1.28.0"
   },
   "devDependencies": {
     "@types/async-lock": "0.0.20",
@@ -34,7 +34,7 @@
     "sinon": "^2.3.6",
     "typescript": "2.6.2",
     "vscode": "1.1.10",
-    "vscode-debugadapter-testsupport": "1.24.0"
+    "vscode-debugadapter-testsupport": "1.28.0"
   },
   "scripts": {
     "compile": "tsc -p ./",

--- a/packages/salesforcedx-apex-debugger/test/integration/adapter.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/integration/adapter.test.ts
@@ -14,9 +14,9 @@ import * as util from '@salesforce/salesforcedx-utils-vscode/out/src/test/orgUti
 import { expect } from 'chai';
 import * as path from 'path';
 import * as rimraf from 'rimraf';
-import * as Url from 'url';
 import { DebugClient } from 'vscode-debugadapter-testsupport';
 import { DebugProtocol } from 'vscode-debugprotocol';
+import Uri from 'vscode-uri';
 import { LaunchRequestArguments } from '../../src/adapter/apexDebug';
 import { LineBreakpointInfo } from '../../src/breakpoints/lineBreakpoint';
 import { LINE_BREAKPOINT_INFO_REQUEST } from '../../src/constants';
@@ -55,9 +55,12 @@ describe('Interactive debugger adapter - integration', function() {
     await util.createSFDXProject(PROJECT_NAME);
     // Create scratch org with Debug Apex enabled
     util.addFeatureToScratchOrgConfig(PROJECT_NAME, 'DebugApex');
-    apexClassUri = util.pathToUri(
+    apexClassUri = Uri.file(
       `${projectPath}/force-app/main/default/classes/BasicVariables.cls`
-    );
+    ).toString();
+    if (process.platform === 'win32') {
+      apexClassUri = apexClassUri.replace('%3A', ':');
+    }
     console.log(`apexClassUri: ${apexClassUri}`);
     LINE_BREAKPOINT_INFO.push({
       uri: apexClassUri,
@@ -135,7 +138,7 @@ describe('Interactive debugger adapter - integration', function() {
     expect(launchResponse.success).to.equal(true);
     try {
       // Add breakpoint
-      const apexClassPath = Url.parse(apexClassUri).pathname;
+      const apexClassPath = Uri.parse(apexClassUri).fsPath;
       console.log(`apexClassPath: ${apexClassPath}`);
       const addBreakpointsResponse = await dc.setBreakpointsRequest({
         source: {

--- a/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebug.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebug.test.ts
@@ -16,6 +16,7 @@ import {
   ThreadEvent
 } from 'vscode-debugadapter';
 import { DebugProtocol } from 'vscode-debugprotocol';
+import Uri from 'vscode-uri';
 import {
   ApexDebugStackFrameInfo,
   ApexVariable,
@@ -1136,9 +1137,10 @@ describe('Interactive debugger adapter - unit', () => {
             '{"stateResponse":{"state":{"stack":{"stackFrame":[{"typeRef":"FooDebug","fullName":"FooDebug.test()","lineNumber":1,"frameNumber":0},{"typeRef":"BarDebug","fullName":"BarDebug.test()","lineNumber":2,"frameNumber":1}]}}}}'
           )
         );
+      const fileUri = 'file:///foo.cls';
       sourcePathSpy = sinon
         .stub(BreakpointService.prototype, 'getSourcePathFromTyperef')
-        .returns('file:///foo.cls');
+        .returns(fileUri);
 
       await adapter.stackTraceRequest(
         {} as DebugProtocol.StackTraceResponse,
@@ -1159,7 +1161,7 @@ describe('Interactive debugger adapter - unit', () => {
         new StackFrame(
           1000,
           'FooDebug.test()',
-          new Source('foo.cls', '/foo.cls'),
+          new Source('foo.cls', Uri.parse(fileUri).fsPath),
           1,
           0
         )
@@ -1168,7 +1170,7 @@ describe('Interactive debugger adapter - unit', () => {
         new StackFrame(
           1001,
           'BarDebug.test()',
-          new Source('foo.cls', '/foo.cls'),
+          new Source('foo.cls', Uri.parse(fileUri).fsPath),
           2,
           0
         )
@@ -1609,15 +1611,16 @@ describe('Interactive debugger adapter - unit', () => {
       LineBreakpointsInTyperef[]
     > = new Map();
     const typerefMapping: Map<string, string> = new Map();
-    lineNumberMapping.set('file:///foo.cls', [
+    const fooUri = 'file:///foo.cls';
+    lineNumberMapping.set(fooUri, [
       { typeref: 'foo', lines: [1, 2] },
       { typeref: 'foo$inner', lines: [3, 4] }
     ]);
     lineNumberMapping.set('file:///bar.cls', [
       { typeref: 'bar', lines: [3, 4] }
     ]);
-    typerefMapping.set('foo', 'file:///foo.cls');
-    typerefMapping.set('foo$inner', 'file:///foo.cls');
+    typerefMapping.set('foo', fooUri);
+    typerefMapping.set('foo$inner', fooUri);
     typerefMapping.set('bar', 'file:///bar.cls');
 
     beforeEach(() => {
@@ -1690,7 +1693,7 @@ describe('Interactive debugger adapter - unit', () => {
           .sobject.Line} | ${msg.sobject.Description} |${os.EOL}${msg.sobject
           .Stacktrace}`
       );
-      expect(outputEvent.body.source!.path).to.equal('/foo.cls');
+      expect(outputEvent.body.source!.path).to.equal(Uri.parse(fooUri).fsPath);
       expect(outputEvent.body.line).to.equal(4);
     });
   });

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -23,7 +23,7 @@
   "categories": ["Debuggers"],
   "dependencies": {
     "@salesforce/salesforcedx-apex-debugger": "42.8.0",
-    "vscode-debugprotocol": "1.24.0"
+    "vscode-debugprotocol": "1.28.0"
   },
   "devDependencies": {
     "@types/chai": "^4.0.0",


### PR DESCRIPTION
### What does this PR do?
This allows interactive debugger to work on Windows when there's spaces in the project's path

<img width="1440" alt="screen shot 2018-03-30 at 3 56 43 pm" src="https://user-images.githubusercontent.com/7286437/38157316-c5050d2a-343a-11e8-9e19-c9088c5678c3.png">

### What issues does this PR fix or reference?
@W-4709469@