### PR TITLE
Fix getting the uri for a signature with inner class

### DIFF
--- a/packages/salesforcedx-apex-debugger/test/integration/config/variables/source/permissionsets/DebugApex.permissionset-meta.xml
+++ b/packages/salesforcedx-apex-debugger/test/integration/config/variables/source/permissionsets/DebugApex.permissionset-meta.xml
@@ -585,6 +585,10 @@
     </userPermissions>
     <userPermissions>
         <enabled>true</enabled>
+        <name>ModifyMetadata</name>
+    </userPermissions>
+    <userPermissions>
+        <enabled>true</enabled>
         <name>RunReports</name>
     </userPermissions>
     <userPermissions>

--- a/packages/salesforcedx-vscode-replay-debugger/adaptertest/unit/core/logContext.test.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/adaptertest/unit/core/logContext.test.ts
@@ -328,7 +328,9 @@ describe('LogContext', () => {
 
     it('Should return URI for inner class', () => {
       expect(
-        context.getUriFromSignature('namespace.Foo.Bar(Integer)')
+        context.getUriFromSignature(
+          'namespace.Foo.Bar(namespace.Foo.Bar, String, Map<String,String>, List<String>)'
+        )
       ).to.equal('/path/foo.cls');
     });
 

--- a/packages/salesforcedx-vscode-replay-debugger/src/core/logContext.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/src/core/logContext.ts
@@ -165,7 +165,10 @@ export class LogContext {
       return this.getLogFilePath();
     }
     const processedSignature = signature.endsWith(')')
-      ? signature.substring(0, signature.lastIndexOf('.'))
+      ? signature.substring(
+          0,
+          signature.substring(0, signature.indexOf('(')).lastIndexOf('.')
+        )
       : signature;
     const typerefMapping = this.session.getBreakpointUtil().getTyperefMapping();
     let uri = '';


### PR DESCRIPTION
### What does this PR do?
Sample signature is `BotController.findMatchingHandlerIfPossible(BotController.HandlerMapping, String, Map<String,String>, List<String>)`, so we need to remove the params then the method name.

### What issues does this PR fix or reference?
@W-4852805@