### PR TITLE
Untar to sfdx folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,8 @@ before_install:
       sleep 3
       # install CLI
       echo Installing SFDX CLI Linux
-      travis_retry wget -qO- $SFDX_URL_LINUX | tar xJf -
+      mkdir sfdx
+      travis_retry wget -qO- https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz | tar xJf - -C sfdx --strip-components=1
       "./sfdx/install"
       export PATH=./sfdx/$(pwd):$PATH
       travis_retry sfdx update


### PR DESCRIPTION
### What does this PR do?

The https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz now untars to a directory that contains the version number. So we need to handle this differently.

### What issues does this PR fix or reference?

Build issues on Travis on Linux.