### PR TITLE
Update to remove checkpoint from VS Code if it fails to create

### DIFF
--- a/packages/salesforcedx-vscode-replay-debugger/src/breakpoints/checkpointService.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/src/breakpoints/checkpointService.ts
@@ -232,9 +232,9 @@ export class CheckpointService implements TreeDataProvider<BaseNode> {
     // is a plain string. It'll cause the parsing to fail.
     if (errorString) {
       try {
-        const result = <ApexExecutionOverlayFailureResult[]>JSON.parse(
+        const result = JSON.parse(
           errorString
-        );
+        ) as ApexExecutionOverlayFailureResult[];
         // If the node is a dupe, then delete it and recreate it. If the failure reason
         // was something else that we don't handle then just set the command result.
         if (result[0].errorCode === DUPLICATE_VALUE && recreateIfDupe) {

--- a/packages/salesforcedx-vscode-replay-debugger/src/breakpoints/checkpointService.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/src/breakpoints/checkpointService.ts
@@ -228,29 +228,37 @@ export class CheckpointService implements TreeDataProvider<BaseNode> {
     // If that's the case then pase the Id out, delete it and recreate it.
     // Fun fact: the result is an array of 1 item
     // "[{"message":"duplicate value found: ScopeId duplicates value on record with id: 1doxx00000000Pn","errorCode":"DUPLICATE_VALUE","fields":[]}]"
+    // Fun fact #2: The result message can also be an outright failure string. For example if we can't connnect up to the AppServer then the result
+    // is a plain string. It'll cause the parsing to fail.
     if (errorString) {
-      const result = <ApexExecutionOverlayFailureResult[]>JSON.parse(
-        errorString
-      );
-      // If the node is a dupe, then delete it and recreate it. If the failure reason
-      // was something else that we don't handle then just set the command result.
-      if (result[0].errorCode === DUPLICATE_VALUE && recreateIfDupe) {
-        // parse the record ID from the result[0].message, call remove and then call add again
-        const duplicateId = result[0].message
-          .substr(result[0].message.lastIndexOf(':') + 1)
-          .trim();
-        // set the id to the duplicate id and call the delete to nuke the record,
-        // then call the delete again with the recreation flag unset
-        theNode.setActionCommandResult(duplicateId, undefined);
-        await this.executeRemoveApexExecutionOverlayActionCommand(theNode);
-        // clear out the action command result
-        theNode.setActionCommandResult(undefined, undefined);
-        await this.executeCreateApexExecutionOverlayActionCommand(
-          theNode,
-          false /* recreateIfDupe */
+      try {
+        const result = <ApexExecutionOverlayFailureResult[]>JSON.parse(
+          errorString
         );
-      } else {
-        theNode.setActionCommandResult(undefined, result[0].message);
+        // If the node is a dupe, then delete it and recreate it. If the failure reason
+        // was something else that we don't handle then just set the command result.
+        if (result[0].errorCode === DUPLICATE_VALUE && recreateIfDupe) {
+          // parse the record ID from the result[0].message, call remove and then call add again
+          const duplicateId = result[0].message
+            .substr(result[0].message.lastIndexOf(':') + 1)
+            .trim();
+          // set the id to the duplicate id and call the delete to nuke the record,
+          // then call the delete again with the recreation flag unset
+          theNode.setActionCommandResult(duplicateId, undefined);
+          await this.executeRemoveApexExecutionOverlayActionCommand(theNode);
+          // clear out the action command result
+          theNode.setActionCommandResult(undefined, undefined);
+          await this.executeCreateApexExecutionOverlayActionCommand(
+            theNode,
+            false /* recreateIfDupe */
+          );
+        } else {
+          theNode.setActionCommandResult(undefined, result[0].message);
+        }
+      } catch {
+        // If the JSON parse fails then the message was actually just a string returned.
+        // This can happen when the connection is lost and we try to execute a command.
+        theNode.setActionCommandResult(undefined, errorString);
       }
     }
   }
@@ -275,7 +283,7 @@ export class CheckpointService implements TreeDataProvider<BaseNode> {
         });
       if (errorString) {
         vscode.window.showErrorMessage(
-          nls.localize('cannot_delete_existing_checkpoint')
+          nls.localize('cannot_delete_existing_checkpoint') + ': ' + errorString
         );
       }
     }
@@ -322,7 +330,7 @@ export class CheckpointService implements TreeDataProvider<BaseNode> {
               // that was returned from the AppServer.
               if (deleteError) {
                 vscode.window.showErrorMessage(
-                  nls.localize('cannot_delete_existing_overlay_action')
+                  nls.localize('cannot_delete_existing_overlay_action') + ': ' + deleteError
                 );
                 return false;
               }
@@ -584,6 +592,7 @@ export async function processBreakpointChangedForCheckpoints(
         );
         const errorMessage = theNode.getActionCommandFailureMessage();
         if (errorMessage) {
+          breakpointsToRemove.push(bp);
           vscode.window.showErrorMessage(
             nls.localize('unable_to_create_checkpoint') +
               ' Error: ' +

--- a/packages/salesforcedx-vscode-replay-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/src/index.ts
@@ -147,9 +147,7 @@ async function retrieveLineBreakpointInfo(): Promise<boolean> {
     } else {
       const lineBpInfo = await sfdxApex.exports.getLineBreakpointInfo();
       if (lineBpInfo && lineBpInfo.length > 0) {
-        vscode.window.showInformationMessage(
-          nls.localize('line_breakpoint_information_success')
-        );
+        console.log(nls.localize('line_breakpoint_information_success'));
         breakpointUtil.createMappingsFromLineBreakpointInfo(lineBpInfo);
         return true;
       } else {


### PR DESCRIPTION
### What does this PR do?
1. Update to remove the checkpoint correctly if it fails to create.
2. The result message from the checkpoint create can actually result in a message that is not a ApexExecutionOverlayFailureResult but, is instead, is just a string. This can happen in the case where maybe the user loses network connectivity and can't connect to the appserver. The message returned in that case is just a string. If we're unable to parse the error message as an ApexExecutionOverlayFailureResult then just give the error string as the error message.
3. Last but not least, instead of showInformationMessage when we retrieve the breakpoint information, just print it to the console like the other informational messages.


### What issues does this PR fix or reference?
@W-4719064@