### PR TITLE
Handle both sfdx.cmd and sfdx.exe on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,7 +11,6 @@ skip_branch_with_pr: true
 platform: x64
 
 environment:
-  SFDX_URL_WINDOWS: https://developer.salesforce.com/media/salesforce-cli/sfdx-cli/channels/stable/sfdx-cli-v6.11.0-9a1ef8794d-windows-x64.tar.xz
   SFDX_AUTOUPDATE_DISABLE: true
   SFDX_DOMAIN_RETRY: 300
 
@@ -21,10 +20,7 @@ install:
   - curl -fsSL -o sfdx-windows-amd64.tar.xz %SFDX_URL_WINDOWS%
   - 7z x sfdx-windows-amd64.tar.xz
   - 7z x sfdx-windows-amd64.tar
-  - ps: $env:Path += ";" + (Get-ChildItem -Filter "sfdx-cli-*" -Directory).Fullname + "\bin"
-  - ps: echo $env:Path
-  - echo %PATH%
-  - sfdx -h
+  - npm install -g sfdx-cli
   - npm install -g codecov 
   # the JWT key should be stored base 64 encoded in AppVeyor settings
   - ps: "[System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($env:SFDX_CI_DEVHUB_JWTKEY)) | Out-File -Encoding \"ASCII\" C:\\projects\\devhub.key"
@@ -73,6 +69,6 @@ artifacts:
   - path: '**\*.vsix'
 
 on_finish:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   - del C:\projects\devhub.key
+  - codecov --disable=gcov
  

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,9 +15,6 @@ environment:
   SFDX_AUTOUPDATE_DISABLE: true
   SFDX_DOMAIN_RETRY: 300
 
-init:
-  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-
 install:
   - ps: Install-Product node 8 x64
   - appveyor-retry npm install
@@ -78,4 +75,5 @@ artifacts:
 on_finish:
   - del C:\projects\devhub.key
   - codecov --disable=gcov
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
  

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -73,7 +73,6 @@ artifacts:
   - path: '**\*.vsix'
 
 on_finish:
-  - del C:\projects\devhub.key
-  - codecov --disable=gcov
   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  - del C:\projects\devhub.key
  

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,6 +23,8 @@ install:
   - 7z x sfdx-windows-amd64.tar
   - ps: $env:Path += ";" + (Get-ChildItem -Filter "sfdx-cli-*" -Directory).Fullname + "\bin"
   - ps: echo $env:Path
+  - echo %PATH%
+  - sfdx -h
   - npm install -g codecov 
   # the JWT key should be stored base 64 encoded in AppVeyor settings
   - ps: "[System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($env:SFDX_CI_DEVHUB_JWTKEY)) | Out-File -Encoding \"ASCII\" C:\\projects\\devhub.key"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,7 +11,7 @@ skip_branch_with_pr: true
 platform: x64
 
 environment:
-  SFDX_URL_WINDOWS: https://developer.salesforce.com/media/salesforce-cli/sfdx-v5.99.1-d7efd75-windows-amd64.tar.xz
+  SFDX_URL_WINDOWS: https://developer.salesforce.com/media/salesforce-cli/sfdx-cli/channels/stable/sfdx-cli-v6.11.0-9a1ef8794d-windows-x64.tar.xz
   SFDX_AUTOUPDATE_DISABLE: true
   SFDX_DOMAIN_RETRY: 300
 
@@ -21,8 +21,8 @@ install:
   - curl -fsSL -o sfdx-windows-amd64.tar.xz %SFDX_URL_WINDOWS%
   - 7z x sfdx-windows-amd64.tar.xz
   - 7z x sfdx-windows-amd64.tar
-  - SET PATH=%APPVEYOR_BUILD_FOLDER%\sfdx\bin;%PATH%
-  - sfdx update
+  - ps: $env:Path += ";" + (Get-ChildItem -Filter "sfdx-cli-*" -Directory).Fullname + "\bin"
+  - ps: echo $env:Path
   - npm install -g codecov 
   # the JWT key should be stored base 64 encoded in AppVeyor settings
   - ps: "[System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($env:SFDX_CI_DEVHUB_JWTKEY)) | Out-File -Encoding \"ASCII\" C:\\projects\\devhub.key"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,6 +15,9 @@ environment:
   SFDX_AUTOUPDATE_DISABLE: true
   SFDX_DOMAIN_RETRY: 300
 
+init:
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
 install:
   - ps: Install-Product node 8 x64
   - appveyor-retry npm install

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,9 +17,6 @@ environment:
 install:
   - ps: Install-Product node 8 x64
   - appveyor-retry npm install
-  - curl -fsSL -o sfdx-windows-amd64.tar.xz %SFDX_URL_WINDOWS%
-  - 7z x sfdx-windows-amd64.tar.xz
-  - 7z x sfdx-windows-amd64.tar
   - npm install -g sfdx-cli
   - npm install -g codecov 
   # the JWT key should be stored base 64 encoded in AppVeyor settings

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
     "vsce": "^1.36.3"
   },
   "scripts": {
-    "postinstall": "lerna bootstrap -- --no-package-lock && node scripts/reformat-with-prettier",
-    "bootstrap": "lerna bootstrap -- --no-package-lock && node scripts/reformat-with-prettier",
+    "postinstall":
+      "lerna bootstrap -- --no-package-lock && node scripts/reformat-with-prettier",
+    "bootstrap":
+      "lerna bootstrap -- --no-package-lock && node scripts/reformat-with-prettier",
     "clean": "lerna run clean",
     "compile": "lerna run --stream compile",
     "lint": "lerna run lint",
@@ -24,14 +26,19 @@
     "test": "lerna run test --concurrency 1 --stream",
     "test:unit": "lerna run test:unit --concurrency 1 --stream",
     "test:integration": "lerna run test:integration --concurrency 1 --stream",
-    "test:without-system-tests": "lerna run test --ignore system-tests --concurrency 1 --stream",
-    "test:system-tests": "lerna run test --scope system-tests --concurrency 1 --stream",
-    "coverage:system-tests": "lerna run coverage --scope system-tests --concurrency 1 --stream",
-    "vscode:package": "lerna exec --scope @salesforce/salesforcedx-* -- npm prune --production && lerna run vscode:package --concurrency 1 && node scripts/reformat-with-prettier",
+    "test:without-system-tests":
+      "lerna run test --ignore system-tests --concurrency 1 --stream",
+    "test:system-tests":
+      "lerna run test --scope system-tests --concurrency 1 --stream",
+    "coverage:system-tests":
+      "lerna run coverage --scope system-tests --concurrency 1 --stream",
+    "vscode:package":
+      "lerna exec --scope @salesforce/salesforcedx-* -- npm prune --production && lerna run vscode:package --concurrency 1 && node scripts/reformat-with-prettier",
     "vscode:sha256": "lerna run vscode:sha256 --concurrency 1",
     "vscode:publish": "lerna run vscode:publish --concurrency 1",
     "watch": "lerna run --parallel watch",
-    "eslint-check": "eslint --print-config .eslintrc.json | eslint-config-prettier-check",
+    "eslint-check":
+      "eslint --print-config .eslintrc.json | eslint-config-prettier-check",
     "reformat": "node scripts/reformat-with-prettier.js"
   },
   "repository": {

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@salesforce/salesforcedx-sobjects-faux-generator",
   "displayName": "Salesforce SObject Faux Generator",
-  "description": "Fetches sobjects and generates their faux apex class to be used for Apex Language Server",
+  "description":
+    "Fetches sobjects and generates their faux apex class to be used for Apex Language Server",
   "version": "42.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
@@ -13,8 +14,7 @@
     "request-light": "0.2.1",
     "rxjs": "^5.4.1",
     "shelljs": "0.7.8",
-    "tree-kill": "^1.1.0",
-    "which": "1.3.0"
+    "tree-kill": "^1.1.0"
   },
   "devDependencies": {
     "@types/chai": "^4.0.0",
@@ -36,14 +36,14 @@
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
     "clean": "shx rm -rf node_modules && shx rm -rf out",
-    "test": "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test",
-    "test:unit": "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test/unit",
-    "test:integration": "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test/integration"
+    "test":
+      "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test",
+    "test:unit":
+      "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test/unit",
+    "test:integration":
+      "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test/integration"
   },
   "nyc": {
-    "reporter": [
-      "text-summary",
-      "lcov"
-    ]
+    "reporter": ["text-summary", "lcov"]
   }
 }

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@salesforce/salesforcedx-sobjects-faux-generator",
   "displayName": "Salesforce SObject Faux Generator",
-  "description":
-    "Fetches sobjects and generates their faux apex class to be used for Apex Language Server",
+  "description": "Fetches sobjects and generates their faux apex class to be used for Apex Language Server",
   "version": "42.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
@@ -14,7 +13,8 @@
     "request-light": "0.2.1",
     "rxjs": "^5.4.1",
     "shelljs": "0.7.8",
-    "tree-kill": "^1.1.0"
+    "tree-kill": "^1.1.0",
+    "which": "1.3.0"
   },
   "devDependencies": {
     "@types/chai": "^4.0.0",
@@ -36,14 +36,14 @@
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
     "clean": "shx rm -rf node_modules && shx rm -rf out",
-    "test":
-      "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test",
-    "test:unit":
-      "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test/unit",
-    "test:integration":
-      "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test/integration"
+    "test": "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test",
+    "test:unit": "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test/unit",
+    "test:integration": "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test/integration"
   },
   "nyc": {
-    "reporter": ["text-summary", "lcov"]
+    "reporter": [
+      "text-summary",
+      "lcov"
+    ]
   }
 }

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@salesforce/salesforcedx-utils-vscode": "42.11.0",
+    "cross-spawn": "6.0.5",
     "request-light": "0.2.1",
     "rxjs": "^5.4.1",
     "shelljs": "0.7.8",

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -9,7 +9,8 @@
   "categories": ["Other"],
   "dependencies": {
     "rxjs": "^5.4.1",
-    "tree-kill": "^1.1.0"
+    "tree-kill": "^1.1.0",
+    "which": "1.3.0"
   },
   "devDependencies": {
     "@types/chai": "^4.0.0",
@@ -17,6 +18,7 @@
     "@types/mocha": "^2.2.38",
     "@types/node": "^6.0.40",
     "@types/shelljs": "^0.7.4",
+    "@types/which": "1.3.1",
     "chai": "^4.0.2",
     "decache": "^4.1.0",
     "glob": "^7.1.2",

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -8,17 +8,17 @@
   "license": "BSD-3-Clause",
   "categories": ["Other"],
   "dependencies": {
+    "cross-spawn": "6.0.5",
     "rxjs": "^5.4.1",
-    "tree-kill": "^1.1.0",
-    "which": "1.3.0"
+    "tree-kill": "^1.1.0"
   },
   "devDependencies": {
     "@types/chai": "^4.0.0",
+    "@types/cross-spawn": "6.0.0",
     "@types/glob": "^5.0.30",
     "@types/mocha": "^2.2.38",
     "@types/node": "^6.0.40",
     "@types/shelljs": "^0.7.4",
-    "@types/which": "1.3.1",
     "chai": "^4.0.2",
     "decache": "^4.1.0",
     "glob": "^7.1.2",

--- a/packages/salesforcedx-utils-vscode/src/cli/commandExecutor.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/commandExecutor.ts
@@ -5,15 +5,14 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { ChildProcess, spawn, SpawnOptions } from 'child_process';
+import { ChildProcess, SpawnOptions } from 'child_process';
+import * as cross_spawn from 'cross-spawn';
 import * as os from 'os';
-import * as path from 'path';
 import 'rxjs/add/observable/fromEvent';
 import 'rxjs/add/observable/interval';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 import { Subscription } from 'rxjs/Subscription';
-import * as which from 'which';
 
 // tslint:disable-next-line:no-var-requires
 const kill = require('tree-kill');
@@ -31,25 +30,10 @@ export class CliCommandExecutor {
   public constructor(command: Command, options: SpawnOptions) {
     this.command = command;
     this.options = options;
-
-    if (/^win32/.test(process.platform) && command.command === 'sfdx') {
-      this.normalizeSfdxCommand();
-    }
-  }
-
-  // The new installers for Salesforce CLI no longer produces a .exe on Windows
-  // So we need to normalize the calling mechanisms to support both old and new executions
-  private normalizeSfdxCommand(): void {
-    const basename = path.basename(which.sync('sfdx'));
-
-    // https://nodejs.org/api/child_process.html#child_process_spawning_bat_and_cmd_files_on_windows
-    if (/sfdx.cmd/i.test(basename)) {
-      this.options.shell = true;
-    }
   }
 
   public execute(cancellationToken?: CancellationToken): CommandExecution {
-    const childProcess = spawn(
+    const childProcess = cross_spawn(
       this.command.command,
       this.command.args,
       this.options

--- a/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
@@ -18,7 +18,7 @@ import {
   ParametersGatherer
 } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import * as AdmZip from 'adm-zip';
-import { ExecOptions } from 'child_process';
+import { SpawnOptions } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as querystring from 'querystring';
@@ -434,7 +434,7 @@ export class IsvDebugBootstrapExecutor extends SfdxCommandletExecutor<{}> {
 
   public async executeCommand(
     command: Command,
-    options: ExecOptions,
+    options: SpawnOptions,
     cancellationTokenSource: vscode.CancellationTokenSource,
     cancellationToken: vscode.CancellationToken
   ): Promise<string> {


### PR DESCRIPTION
### What does this PR do?

The new Salesforce CLI installers no longer produce a sfdx.exe. Instead it produces a sfdx.cmd. When using a .cmd on Windows, we need a different way to launch this. See https://nodejs.org/api/child_process.html#child_process_spawning_bat_and_cmd_files_on_windows

We also need to make sure that we use the old way for customers who are still on the older installers, which are still on sfdx.exe

### What issues does this PR fix or reference?

@W-4914336@
Resolves #383 

