### PR TITLE
Disable UI tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,6 @@ script:
   - |
     if [[ $TRAVIS_OS_NAME == "linux" ]]; then
       travis_wait 30 npm run test:without-system-tests
-      travis_wait 30 npm run coverage:system-tests
     fi
   - |
     if [[ $TRAVIS_OS_NAME == "osx" ]]; then


### PR DESCRIPTION
### What does this PR do?

Travis is not able to run the end-to-end UI tests.
These tests pass on Window (appveyor build) and they work.
This is a test issue or an issue with Travis.

I'm commenting them out for now since we are looking to move away from Travis to CircelCI. We still have UI test coverage from Appveyor which is more reliable.

### What issues does this PR fix or reference?

Maintenance
