### PR TITLE
Replay Debugger Bug Fixes

### DIFF
--- a/packages/salesforcedx-vscode-replay-debugger/src/breakpoints/checkpointService.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/src/breakpoints/checkpointService.ts
@@ -517,7 +517,7 @@ export async function processBreakpointChangedForCheckpoints(
     ) {
       if (bp instanceof vscode.SourceBreakpoint) {
         await checkpointService.deleteCheckpointNode(
-          bp.location.uri.toString(false /* skipEncoding */),
+          code2ProtocolConverter(bp.location.uri),
           bp.location.range.start.line + 1 // need to add 1 since the lines are 0 based
         );
       }
@@ -538,7 +538,7 @@ export async function processBreakpointChangedForCheckpoints(
         continue;
       }
       if (bp instanceof vscode.SourceBreakpoint) {
-        const uri = bp.location.uri.toString(false /* skipEncoding */);
+        const uri = code2ProtocolConverter(bp.location.uri);
         const lineNumber = bp.location.range.start.line + 1; // need to add 1 since the lines are 0 based
         if (breakpointUtil.canSetLineBreakpoint(uri, lineNumber)) {
           const typeRef = breakpointUtil.getTopLevelTyperefForUri(uri);
@@ -577,5 +577,16 @@ export async function processBreakpointChangedForCheckpoints(
       vscode.window.showErrorMessage(nls.localize('up_to_five_checkpoints'));
     }
     vscode.debug.removeBreakpoints(breakpointsToRemove);
+  }
+}
+
+// See https://github.com/Microsoft/vscode-languageserver-node/issues/105
+function code2ProtocolConverter(value: vscode.Uri) {
+  if (/^win32/.test(process.platform)) {
+    // The *first* : is also being encoded which is not the standard for URI on Windows
+    // Here we transform it back to the standard way
+    return value.toString().replace('%3A', ':');
+  } else {
+    return value.toString();
   }
 }

--- a/packages/salesforcedx-vscode-replay-debugger/src/constants.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/src/constants.ts
@@ -24,6 +24,7 @@ export const EVENT_VF_APEX_CALL_END = 'VF_APEX_CALL_END';
 export const EVENT_VARIABLE_SCOPE_BEGIN = 'VARIABLE_SCOPE_BEGIN';
 export const EVENT_VARIABLE_ASSIGNMENT = 'VARIABLE_ASSIGNMENT';
 export const EXEC_ANON_SIGNATURE = 'execute_anonymous_apex';
+export const FIELD_INTEGRITY_EXCEPTION = 'FIELD_INTEGRITY_EXCEPTION';
 export const GET_LINE_BREAKPOINT_INFO_EVENT = 'getLineBreakpointInfo';
 export const LINE_BREAKPOINT_INFO_REQUEST = 'lineBreakpointInfo';
 export const MAX_ALLOWED_CHECKPOINTS = 5;

--- a/packages/salesforcedx-vscode-replay-debugger/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/src/messages/i18n.ts
@@ -26,6 +26,10 @@ export const messages = {
   incorrect_log_levels_text:
     'The log must be generated with log categories Apex code at the FINEST level and Visualforce at the FINER level.',
   up_to_five_checkpoints: 'You can set up to five checkpoints.',
+  checkpoints_can_only_be_on_valid_apex_source:
+    'Checkpoints can be set only on a valid line of Apex source.',
+  local_source_is_out_of_sync_with_the_server:
+    "The local source is out of sync with the server. Push any changes you've made locally to your org, and pull any changes you've made in the org into your local project.",
   // These strings are going to be re-worked to become better, Salesforce appropriate, error messages.
   cannot_determine_workspace:
     'Unable to determine workspace folders for workspace',


### PR DESCRIPTION
### What does this PR do?
There are 3 bug fixes here.
W-4919185 - The checkpoint result was useful for diagnostics when doing the initial work on the feature. Because we're not creating the checkpoint if there's a failure (we remove it) it's far less useful. Move the checkpoint result onto the CheckpointNode instead of making it its own CheckpointInfoNode.

W-4919352 - The difference in behavior is due to not checking canSetLineBreakpoint before passing things off to the appserver. Once that check is in place if the user tries to create a checkpoint on an invalid line it'll give them an error "Checkpoints can be set only on a valid line of Apex source." 
![checkpointinvalidlineerror](https://user-images.githubusercontent.com/13556087/39207071-e1e382f0-47b3-11e8-834b-83ef35484b9c.png)

W-4919978 - This error message is "confusing" if you're not getting in from SFDX after passing in an invalid typeRef to create a checkpoint from the command line. When in VS Code, if the error code from the AppServer is FIELD_INTEGRITY_EXCEPTION that means that the source is out of sync with the server. Translate the error to something more user friendly for VS Code "The local source is out of sync with the server. Push any changes you've made locally to your org, and pull any changes you've made in the org into your local project."
![sourceoutofsync](https://user-images.githubusercontent.com/13556087/39207090-ee7172fc-47b3-11e8-8507-bc9071a816d0.png)

W-4920046 - W-4920046 - This fails on Windows because of this VS Code issue: https://github.com/Microsoft/vscode-languageserver-node/issues/105. I'm pretty much stealing this function from https://github.com/forcedotcom/salesforcedx-vscode/blob/develop/packages/salesforcedx-vscode-lwc/src/index.ts#L107 which fixes the issue. I've already tested this on a Windows VM and on Linux.

### What issues does this PR fix or reference?
@W-4919185, @W-4919352@ @W-4919978@ @W-4920046@