### PR TITLE
Update Apex Language Server link to point to wiki

### DIFF
--- a/packages/salesforcedx-vscode-apex/README.md
+++ b/packages/salesforcedx-vscode-apex/README.md
@@ -1,5 +1,5 @@
 # salesforcedx-vscode-apex
-View outlines of Apex classes and triggers, see code-completion suggestions, and find syntactic errors in your code. This extension is powered by the [Apex Language Server](https://developer.salesforce.com/docs/atlas.en-us.sfdx_ide2.meta/sfdx_ide2/sfdx_ide2_build_app_apex_language_server_protocol.htm).
+View outlines of Apex classes and triggers, see code-completion suggestions, and find syntactic errors in your code. This extension is powered by the [Apex Language Server](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Apex-Language-Server).
 
 For best results, use this extension with the other extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) bundle.  
 


### PR DESCRIPTION
### What does this PR do?
Formerly, this link pointed to the IDE2 docs. Now it points to this repo's wiki. I looked at the (now-retired) doc that we previously pointed to, and it didn't really contain useful info that's not already in the wiki.

### What issues does this PR fix or reference?
@W-4682014@