### PR TITLE
Ignore warnings and CLI update messages when using --json

### DIFF
--- a/packages/salesforcedx-apex-debugger/src/core/breakpointService.ts
+++ b/packages/salesforcedx-apex-debugger/src/core/breakpointService.ts
@@ -123,7 +123,7 @@ export class BreakpointService {
           `SessionId='${sessionId}' FileName='${typeref}' Line=${line} IsEnabled='true' Type='Line'`
         )
         .withArg('--usetoolingapi')
-        .withArg('--json')
+        .withJson()
         .build(),
       { cwd: projectPath, env: this.requestService.getEnvVars() }
     ).execute();
@@ -152,7 +152,7 @@ export class BreakpointService {
         .withFlag('--sobjecttype', 'ApexDebuggerBreakpoint')
         .withFlag('--sobjectid', breakpointId)
         .withArg('--usetoolingapi')
-        .withArg('--json')
+        .withJson()
         .build(),
       { cwd: projectPath, env: this.requestService.getEnvVars() }
     ).execute();
@@ -239,7 +239,7 @@ export class BreakpointService {
           `SessionId='${sessionId}' FileName='${typeref}' IsEnabled='true' Type='Exception'`
         )
         .withArg('--usetoolingapi')
-        .withArg('--json')
+        .withJson()
         .build(),
       { cwd: projectPath, env: this.requestService.getEnvVars() }
     ).execute();

--- a/packages/salesforcedx-apex-debugger/src/core/sessionService.ts
+++ b/packages/salesforcedx-apex-debugger/src/core/sessionService.ts
@@ -68,7 +68,7 @@ export class SessionService {
             .entryFilter}' RequestTypeFilter='${this.requestFilter}'`
         )
         .withArg('--usetoolingapi')
-        .withArg('--json')
+        .withJson()
         .build(),
       {
         cwd: this.project,
@@ -102,7 +102,7 @@ export class SessionService {
         .withFlag('--sobjectid', this.sessionId)
         .withFlag('--values', "Status='Detach'")
         .withArg('--usetoolingapi')
-        .withArg('--json')
+        .withJson()
         .build(),
       { cwd: this.project, env: this.requestService.getEnvVars() }
     ).execute();

--- a/packages/salesforcedx-apex-debugger/test/unit/core/breakpointService.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/core/breakpointService.test.ts
@@ -145,6 +145,7 @@ describe('Debugger breakpoint service', () => {
     let origSpawn: any, mySpawn: any;
     let cmdWithArgSpy: sinon.SinonSpy;
     let cmdWithFlagSpy: sinon.SinonSpy;
+    let cmdWithJsonSpy: sinon.SinonSpy;
     let cmdBuildSpy: sinon.SinonSpy;
 
     beforeEach(() => {
@@ -154,6 +155,7 @@ describe('Debugger breakpoint service', () => {
       childProcess.spawn = mySpawn;
       cmdWithArgSpy = sinon.spy(SfdxCommandBuilder.prototype, 'withArg');
       cmdWithFlagSpy = sinon.spy(SfdxCommandBuilder.prototype, 'withFlag');
+      cmdWithJsonSpy = sinon.spy(SfdxCommandBuilder.prototype, 'withJson');
       cmdBuildSpy = sinon.spy(SfdxCommandBuilder.prototype, 'build');
     });
 
@@ -161,6 +163,7 @@ describe('Debugger breakpoint service', () => {
       childProcess.spawn = origSpawn;
       cmdWithArgSpy.restore();
       cmdWithFlagSpy.restore();
+      cmdWithJsonSpy.restore();
       cmdBuildSpy.restore();
     });
 
@@ -189,7 +192,7 @@ describe('Debugger breakpoint service', () => {
       expect(cmdWithArgSpy.getCall(1).args).to.have.same.members([
         '--usetoolingapi'
       ]);
-      expect(cmdWithArgSpy.getCall(2).args).to.have.same.members(['--json']);
+      expect(cmdWithJsonSpy.calledOnce).to.equal(true);
       expect(cmdBuildSpy.calledOnce).to.equal(true);
     });
 
@@ -254,6 +257,7 @@ describe('Debugger breakpoint service', () => {
     let origSpawn: any, mySpawn: any;
     let cmdWithArgSpy: sinon.SinonSpy;
     let cmdWithFlagSpy: sinon.SinonSpy;
+    let cmdWithJsonSpy: sinon.SinonSpy;
     let cmdBuildSpy: sinon.SinonSpy;
 
     beforeEach(() => {
@@ -263,6 +267,7 @@ describe('Debugger breakpoint service', () => {
       childProcess.spawn = mySpawn;
       cmdWithArgSpy = sinon.spy(SfdxCommandBuilder.prototype, 'withArg');
       cmdWithFlagSpy = sinon.spy(SfdxCommandBuilder.prototype, 'withFlag');
+      cmdWithJsonSpy = sinon.spy(SfdxCommandBuilder.prototype, 'withJson');
       cmdBuildSpy = sinon.spy(SfdxCommandBuilder.prototype, 'build');
     });
 
@@ -270,6 +275,7 @@ describe('Debugger breakpoint service', () => {
       childProcess.spawn = origSpawn;
       cmdWithArgSpy.restore();
       cmdWithFlagSpy.restore();
+      cmdWithJsonSpy.restore();
       cmdBuildSpy.restore();
     });
 
@@ -297,7 +303,7 @@ describe('Debugger breakpoint service', () => {
       expect(cmdWithArgSpy.getCall(1).args).to.have.same.members([
         '--usetoolingapi'
       ]);
-      expect(cmdWithArgSpy.getCall(2).args).to.have.same.members(['--json']);
+      expect(cmdWithJsonSpy.calledOnce).to.equal(true);
       expect(cmdBuildSpy.calledOnce).to.equal(true);
     });
   });
@@ -306,6 +312,7 @@ describe('Debugger breakpoint service', () => {
     let origSpawn: any, mySpawn: any;
     let cmdWithArgSpy: sinon.SinonSpy;
     let cmdWithFlagSpy: sinon.SinonSpy;
+    let cmdWithJsonSpy: sinon.SinonSpy;
     let cmdBuildSpy: sinon.SinonSpy;
 
     beforeEach(() => {
@@ -315,6 +322,7 @@ describe('Debugger breakpoint service', () => {
       childProcess.spawn = mySpawn;
       cmdWithArgSpy = sinon.spy(SfdxCommandBuilder.prototype, 'withArg');
       cmdWithFlagSpy = sinon.spy(SfdxCommandBuilder.prototype, 'withFlag');
+      cmdWithJsonSpy = sinon.spy(SfdxCommandBuilder.prototype, 'withJson');
       cmdBuildSpy = sinon.spy(SfdxCommandBuilder.prototype, 'build');
     });
 
@@ -322,6 +330,7 @@ describe('Debugger breakpoint service', () => {
       childProcess.spawn = origSpawn;
       cmdWithArgSpy.restore();
       cmdWithFlagSpy.restore();
+      cmdWithJsonSpy.restore();
       cmdBuildSpy.restore();
     });
 
@@ -348,7 +357,7 @@ describe('Debugger breakpoint service', () => {
       expect(cmdWithArgSpy.getCall(1).args).to.have.same.members([
         '--usetoolingapi'
       ]);
-      expect(cmdWithArgSpy.getCall(2).args).to.have.same.members(['--json']);
+      expect(cmdWithJsonSpy.calledOnce).to.equal(true);
       expect(cmdBuildSpy.calledOnce).to.equal(true);
     });
 

--- a/packages/salesforcedx-apex-debugger/test/unit/core/sessionService.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/core/sessionService.test.ts
@@ -34,6 +34,7 @@ describe('Debugger session service', () => {
     let origSpawn: any, mySpawn: any;
     let cmdWithArgSpy: sinon.SinonSpy;
     let cmdWithFlagSpy: sinon.SinonSpy;
+    let cmdWithJsonSpy: sinon.SinonSpy;
     let cmdBuildSpy: sinon.SinonSpy;
 
     beforeEach(() => {
@@ -42,6 +43,7 @@ describe('Debugger session service', () => {
       childProcess.spawn = mySpawn;
       cmdWithArgSpy = sinon.spy(SfdxCommandBuilder.prototype, 'withArg');
       cmdWithFlagSpy = sinon.spy(SfdxCommandBuilder.prototype, 'withFlag');
+      cmdWithJsonSpy = sinon.spy(SfdxCommandBuilder.prototype, 'withJson');
       cmdBuildSpy = sinon.spy(SfdxCommandBuilder.prototype, 'build');
     });
 
@@ -49,6 +51,7 @@ describe('Debugger session service', () => {
       childProcess.spawn = origSpawn;
       cmdWithArgSpy.restore();
       cmdWithFlagSpy.restore();
+      cmdWithJsonSpy.restore();
       cmdBuildSpy.restore();
     });
 
@@ -86,7 +89,7 @@ describe('Debugger session service', () => {
       expect(cmdWithArgSpy.getCall(1).args).to.have.same.members([
         '--usetoolingapi'
       ]);
-      expect(cmdWithArgSpy.getCall(2).args).to.have.same.members(['--json']);
+      expect(cmdWithJsonSpy.calledOnce).to.equal(true);
       expect(cmdBuildSpy.calledOnce).to.equal(true);
     });
 
@@ -147,6 +150,7 @@ describe('Debugger session service', () => {
     let origSpawn: any, mySpawn: any;
     let cmdWithArgSpy: sinon.SinonSpy;
     let cmdWithFlagSpy: sinon.SinonSpy;
+    let cmdWithJsonSpy: sinon.SinonSpy;
     let cmdBuildSpy: sinon.SinonSpy;
 
     beforeEach(() => {
@@ -155,6 +159,7 @@ describe('Debugger session service', () => {
       childProcess.spawn = mySpawn;
       cmdWithArgSpy = sinon.spy(SfdxCommandBuilder.prototype, 'withArg');
       cmdWithFlagSpy = sinon.spy(SfdxCommandBuilder.prototype, 'withFlag');
+      cmdWithJsonSpy = sinon.spy(SfdxCommandBuilder.prototype, 'withJson');
       cmdBuildSpy = sinon.spy(SfdxCommandBuilder.prototype, 'build');
     });
 
@@ -162,6 +167,7 @@ describe('Debugger session service', () => {
       childProcess.spawn = origSpawn;
       cmdWithArgSpy.restore();
       cmdWithFlagSpy.restore();
+      cmdWithJsonSpy.restore();
       cmdBuildSpy.restore();
     });
 
@@ -181,6 +187,7 @@ describe('Debugger session service', () => {
       await service.start();
       cmdWithArgSpy.reset();
       cmdWithFlagSpy.reset();
+      cmdWithJsonSpy.reset();
       cmdBuildSpy.reset();
       await service.stop();
 
@@ -202,7 +209,7 @@ describe('Debugger session service', () => {
       expect(cmdWithArgSpy.getCall(1).args).to.have.same.members([
         '--usetoolingapi'
       ]);
-      expect(cmdWithArgSpy.getCall(2).args).to.have.same.members(['--json']);
+      expect(cmdWithJsonSpy.calledOnce).to.equal(true);
       expect(cmdBuildSpy.calledOnce).to.equal(true);
     });
 

--- a/packages/salesforcedx-utils-vscode/src/cli/commandBuilder.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/commandBuilder.ts
@@ -42,7 +42,11 @@ export class CommandBuilder {
   }
 
   public withArg(arg: string): CommandBuilder {
-    this.args.push(arg);
+    if (arg === '--json') {
+      this.withJson();
+    } else {
+      this.args.push(arg);
+    }
     return this;
   }
 
@@ -53,6 +57,7 @@ export class CommandBuilder {
 
   public withJson(): CommandBuilder {
     this.args.push('--json');
+    this.args.push('--loglevel', 'fatal');
     return this;
   }
 

--- a/packages/salesforcedx-utils-vscode/src/cli/commandOutput.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/commandOutput.ts
@@ -8,14 +8,15 @@
 import { CommandExecution } from './commandExecutor';
 
 export class CommandOutput {
-  private buffer = '';
+  private stdoutBuffer = '';
+  private stderrBuffer = '';
 
   public async getCmdResult(execution: CommandExecution): Promise<string> {
     execution.stdoutSubject.subscribe(realData => {
-      this.buffer += realData.toString();
+      this.stdoutBuffer += realData.toString();
     });
     execution.stderrSubject.subscribe(realData => {
-      this.buffer += realData.toString();
+      this.stderrBuffer += realData.toString();
     });
 
     return new Promise<
@@ -23,9 +24,9 @@ export class CommandOutput {
     >((resolve: (result: string) => void, reject: (reason: string) => void) => {
       execution.processExitSubject.subscribe(data => {
         if (data != undefined && data.toString() === '0') {
-          return resolve(this.buffer);
+          return resolve(this.stdoutBuffer);
         } else {
-          reject(this.buffer);
+          reject(this.stderrBuffer);
         }
       });
     });

--- a/packages/salesforcedx-utils-vscode/src/cli/forceConfigGet.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/forceConfigGet.ts
@@ -18,7 +18,7 @@ export class ForceConfigGet {
     keys.forEach(key => commandBuilder.withArg(key));
 
     const execution = new CliCommandExecutor(
-      commandBuilder.withArg('--json').build(),
+      commandBuilder.withJson().build(),
       {
         cwd: projectPath
       }

--- a/packages/salesforcedx-utils-vscode/src/cli/forceOrgDisplay.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/forceOrgDisplay.ts
@@ -29,8 +29,7 @@ export class ForceOrgDisplay {
     const execution = new CliCommandExecutor(
       new SfdxCommandBuilder()
         .withArg('force:org:display')
-        .withArg('--json')
-        .withFlag('--loglevel', 'fatal')
+        .withJson()
         .build(),
       { cwd: projectPath }
     ).execute();

--- a/packages/salesforcedx-utils-vscode/test/cli/commandBuilderTest.ts
+++ b/packages/salesforcedx-utils-vscode/test/cli/commandBuilderTest.ts
@@ -30,7 +30,7 @@ describe('CommandBuilder tests', () => {
       const actual = new CommandBuilder('sfdx').withJson().build();
 
       expect(actual.command).to.equal('sfdx');
-      expect(actual.args).to.eql(['--json']);
+      expect(actual.args).to.eql(['--json', '--loglevel', 'fatal']);
     });
 
     it('Should store the command arg', () => {

--- a/packages/salesforcedx-utils-vscode/test/cli/forceConfigGet.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/cli/forceConfigGet.test.ts
@@ -14,7 +14,9 @@ describe('force:config:get', () => {
   const mockSpawn = require('mock-spawn');
   let command: ForceConfigGet;
   let origSpawn: any, mySpawn: any;
-  let cmdWithArgSpy: sinon.SinonSpy, cmdBuildSpy: sinon.SinonSpy;
+  let cmdWithArgSpy: sinon.SinonSpy,
+    cmdJsonSpy: sinon.SinonSpy,
+    cmdBuildSpy: sinon.SinonSpy;
 
   beforeEach(() => {
     command = new ForceConfigGet();
@@ -22,12 +24,14 @@ describe('force:config:get', () => {
     mySpawn = mockSpawn();
     childProcess.spawn = mySpawn;
     cmdWithArgSpy = sinon.spy(SfdxCommandBuilder.prototype, 'withArg');
+    cmdJsonSpy = sinon.spy(SfdxCommandBuilder.prototype, 'withJson');
     cmdBuildSpy = sinon.spy(SfdxCommandBuilder.prototype, 'build');
   });
 
   afterEach(() => {
     childProcess.spawn = origSpawn;
     cmdWithArgSpy.restore();
+    cmdJsonSpy.restore();
     cmdBuildSpy.restore();
   });
 
@@ -43,13 +47,13 @@ describe('force:config:get', () => {
 
     expect(cmdOutput.get('key1')).to.equal('val1');
     expect(cmdOutput.get('key2')).to.equal('val2');
-    expect(cmdWithArgSpy.callCount).to.equal(4);
+    expect(cmdWithArgSpy.callCount).to.equal(3);
     expect(cmdWithArgSpy.getCall(0).args).to.have.same.members([
       'force:config:get'
     ]);
     expect(cmdWithArgSpy.getCall(1).args).to.have.same.members(['key1']);
     expect(cmdWithArgSpy.getCall(2).args).to.have.same.members(['key2']);
-    expect(cmdWithArgSpy.getCall(3).args).to.have.same.members(['--json']);
+    expect(cmdJsonSpy.calledOnce).to.equal(true);
     expect(cmdBuildSpy.calledOnce).to.equal(true);
   });
 

--- a/packages/salesforcedx-utils-vscode/test/cli/forceOrgDisplay.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/cli/forceOrgDisplay.test.ts
@@ -14,7 +14,9 @@ describe('force:org:display', () => {
   const mockSpawn = require('mock-spawn');
   let command: ForceOrgDisplay;
   let origSpawn: any, mySpawn: any;
-  let cmdWithArgSpy: sinon.SinonSpy, cmdBuildSpy: sinon.SinonSpy;
+  let cmdWithArgSpy: sinon.SinonSpy,
+    cmdWithJsonSpy: sinon.SinonSpy,
+    cmdBuildSpy: sinon.SinonSpy;
 
   beforeEach(() => {
     command = new ForceOrgDisplay();
@@ -22,12 +24,14 @@ describe('force:org:display', () => {
     mySpawn = mockSpawn();
     childProcess.spawn = mySpawn;
     cmdWithArgSpy = sinon.spy(SfdxCommandBuilder.prototype, 'withArg');
+    cmdWithJsonSpy = sinon.spy(SfdxCommandBuilder.prototype, 'withJson');
     cmdBuildSpy = sinon.spy(SfdxCommandBuilder.prototype, 'build');
   });
 
   afterEach(() => {
     childProcess.spawn = origSpawn;
     cmdWithArgSpy.restore();
+    cmdWithJsonSpy.restore();
     cmdBuildSpy.restore();
   });
 
@@ -53,11 +57,11 @@ describe('force:org:display', () => {
     const cmdOutput: OrgInfo = await command.getOrgInfo('foo');
 
     expect(cmdOutput).to.deep.equal(orgInfo);
-    expect(cmdWithArgSpy.calledTwice).to.equal(true);
+    expect(cmdWithArgSpy.calledOnce).to.equal(true);
     expect(cmdWithArgSpy.getCall(0).args).to.have.same.members([
       'force:org:display'
     ]);
-    expect(cmdWithArgSpy.getCall(1).args).to.have.same.members(['--json']);
+    expect(cmdWithJsonSpy.calledOnce).to.equal(true);
     expect(cmdBuildSpy.calledOnce).to.equal(true);
   });
 

--- a/packages/salesforcedx-vscode-core/src/commands/forceApexLogGet.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexLogGet.ts
@@ -41,7 +41,7 @@ export class ForceApexLogGetExecutor extends SfdxCommandletExecutor<
       .withDescription(nls.localize('force_apex_log_get_text'))
       .withArg('force:apex:log:get')
       .withFlag('--logid', data.id)
-      .withArg('--json')
+      .withJson()
       .build();
   }
 
@@ -159,7 +159,7 @@ export class ForceApexLogList {
       new SfdxCommandBuilder()
         .withDescription(nls.localize('force_apex_log_list_text'))
         .withArg('force:apex:log:list')
-        .withArg('--json')
+        .withJson()
         .build(),
       { cwd: vscode.workspace.workspaceFolders![0].uri.fsPath }
     ).execute();

--- a/packages/salesforcedx-vscode-core/src/commands/forceAuthWebLogin.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceAuthWebLogin.ts
@@ -50,7 +50,7 @@ export class ForceAuthWebDemoModeLoginExecutor extends SfdxCommandletExecutor<{}
       .withArg('force:auth:web:login')
       .withArg('--setdefaultdevhubusername')
       .withArg('--noprompt')
-      .withArg('--json')
+      .withJson()
       .build();
   }
 

--- a/packages/salesforcedx-vscode-core/src/commands/forceDebuggerStop.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceDebuggerStop.ts
@@ -80,7 +80,7 @@ export class StopActiveDebuggerSessionExecutor extends SfdxCommandletExecutor<{}
         "SELECT Id FROM ApexDebuggerSession WHERE Status = 'Active' LIMIT 1"
       )
       .withArg('--usetoolingapi')
-      .withArg('--json')
+      .withJson()
       .build();
   }
 

--- a/packages/salesforcedx-vscode-core/src/commands/forceStartApexDebugLogging.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceStartApexDebugLogging.ts
@@ -107,8 +107,7 @@ export async function getUserId(projectPath: string): Promise<string> {
   const execution = new CliCommandExecutor(
     new SfdxCommandBuilder()
       .withArg('force:user:display')
-      .withFlag('--loglevel', 'fatal')
-      .withArg('--json')
+      .withJson()
       .build(),
     { cwd: projectPath }
   ).execute();
@@ -134,7 +133,7 @@ export class CreateDebugLevel extends SfdxCommandletExecutor<{}> {
           .developerName} apexcode=${APEX_CODE_DEBUG_LEVEL} visualforce=${VISUALFORCE_DEBUG_LEVEL}`
       )
       .withArg('--usetoolingapi')
-      .withArg('--json')
+      .withJson()
       .build();
   }
 }
@@ -161,7 +160,7 @@ export class CreateTraceFlag extends SfdxCommandletExecutor<{}> {
           .toUTCString()}`
       )
       .withArg('--usetoolingapi')
-      .withArg('--json')
+      .withJson()
       .build();
   }
 }
@@ -177,7 +176,7 @@ export class UpdateDebugLevelsExecutor extends SfdxCommandletExecutor<{}> {
         `ApexCode=${APEX_CODE_DEBUG_LEVEL} Visualforce=${VISUALFORCE_DEBUG_LEVEL}`
       )
       .withArg('--usetoolingapi')
-      .withArg('--json')
+      .withJson()
       .build();
   }
 }
@@ -197,7 +196,7 @@ export class UpdateTraceFlagsExecutor extends SfdxCommandletExecutor<{}> {
           .toUTCString()}'`
       )
       .withArg('--usetoolingapi')
-      .withArg('--json')
+      .withJson()
       .build();
   }
 }
@@ -215,7 +214,7 @@ export class ForceQueryTraceFlag extends SfdxCommandletExecutor<{}> {
         "SELECT id, logtype, startdate, expirationdate, debuglevelid, debuglevel.apexcode, debuglevel.visualforce FROM TraceFlag WHERE logtype='DEVELOPER_LOG'"
       )
       .withArg('--usetoolingapi')
-      .withArg('--json')
+      .withJson()
       .build();
   }
 }

--- a/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
@@ -105,7 +105,7 @@ export class IsvDebugBootstrapExecutor extends SfdxCommandletExecutor<{}> {
       .withArg('force:data:soql:query')
       .withFlag('--query', 'SELECT NamespacePrefix FROM Organization LIMIT 1')
       .withFlag('--targetusername', data.sessionId)
-      .withArg(`--json`)
+      .withJson()
       .build();
   }
 
@@ -162,7 +162,7 @@ export class IsvDebugBootstrapExecutor extends SfdxCommandletExecutor<{}> {
       )
       .withArg('force:package:installed:list')
       .withFlag('--targetusername', data.sessionId)
-      .withArg('--json')
+      .withJson()
       .build();
   }
 

--- a/packages/salesforcedx-vscode-core/test/commands/forceApexLogGet.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceApexLogGet.test.ts
@@ -80,7 +80,7 @@ describe('Force Apex Log Get Logging', () => {
       nls.localize('force_apex_log_get_text')
     );
     expect(startLoggingCmd.toCommand()).to.equal(
-      `sfdx force:apex:log:get --logid ${LOG_ID} --json`
+      `sfdx force:apex:log:get --logid ${LOG_ID} --json --loglevel fatal`
     );
   });
 

--- a/packages/salesforcedx-vscode-core/test/commands/forceAuthWebLogin.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceAuthWebLogin.test.ts
@@ -32,7 +32,7 @@ describe('Force Auth Web Login for Demo  Mode', () => {
     const authWebLogin = new ForceAuthWebDemoModeLoginExecutor();
     const authWebLoginCommand = authWebLogin.build({});
     expect(authWebLoginCommand.toCommand()).to.equal(
-      'sfdx force:auth:web:login --setdefaultdevhubusername --noprompt --json'
+      'sfdx force:auth:web:login --setdefaultdevhubusername --noprompt --json --loglevel fatal'
     );
     expect(authWebLoginCommand.description).to.equal(
       nls.localize('force_auth_web_login_authorize_dev_hub_text')

--- a/packages/salesforcedx-vscode-core/test/commands/forceDebuggerStop.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceDebuggerStop.test.ts
@@ -66,7 +66,7 @@ describe('Debugger stop command', () => {
       const command = executor.build({});
 
       expect(command.toCommand()).to.equal(
-        "sfdx force:data:soql:query --query SELECT Id FROM ApexDebuggerSession WHERE Status = 'Active' LIMIT 1 --usetoolingapi --json"
+        "sfdx force:data:soql:query --query SELECT Id FROM ApexDebuggerSession WHERE Status = 'Active' LIMIT 1 --usetoolingapi --json --loglevel fatal"
       );
       expect(command.description).to.equal(
         nls.localize('force_debugger_query_session_text')

--- a/packages/salesforcedx-vscode-core/test/commands/forceStartApexDebugLogging.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceStartApexDebugLogging.test.ts
@@ -67,7 +67,7 @@ describe('Force Start Apex Debug Logging', () => {
     const queryTraceFlagsExecutor = new ForceQueryTraceFlag();
     const updateTraceFlagCmd = queryTraceFlagsExecutor.build();
     expect(updateTraceFlagCmd.toCommand()).to.equal(
-      `sfdx force:data:soql:query --query SELECT id, logtype, startdate, expirationdate, debuglevelid, debuglevel.apexcode, debuglevel.visualforce FROM TraceFlag WHERE logtype='DEVELOPER_LOG' --usetoolingapi --json`
+      `sfdx force:data:soql:query --query SELECT id, logtype, startdate, expirationdate, debuglevelid, debuglevel.apexcode, debuglevel.visualforce FROM TraceFlag WHERE logtype='DEVELOPER_LOG' --usetoolingapi --json --loglevel fatal`
     );
   });
 
@@ -75,7 +75,7 @@ describe('Force Start Apex Debug Logging', () => {
     const updateTraceFlagsExecutor = new UpdateTraceFlagsExecutor();
     const updateTraceFlagCmd = updateTraceFlagsExecutor.build();
     expect(updateTraceFlagCmd.toCommand()).to.equal(
-      `sfdx force:data:record:update --sobjecttype TraceFlag --sobjectid ${fakeTraceFlagId} --values StartDate='${startDate.toUTCString()}' ExpirationDate='${endDate.toUTCString()}' --usetoolingapi --json`
+      `sfdx force:data:record:update --sobjecttype TraceFlag --sobjectid ${fakeTraceFlagId} --values StartDate='${startDate.toUTCString()}' ExpirationDate='${endDate.toUTCString()}' --usetoolingapi --json --loglevel fatal`
     );
   });
 
@@ -83,7 +83,7 @@ describe('Force Start Apex Debug Logging', () => {
     const updateDebugLevelsExecutor = new UpdateDebugLevelsExecutor();
     const updateDebugLevelCmd = updateDebugLevelsExecutor.build();
     expect(updateDebugLevelCmd.toCommand()).to.equal(
-      `sfdx force:data:record:update --sobjecttype DebugLevel --sobjectid ${fakeDebugLevelId} --values ApexCode=${APEX_CODE_DEBUG_LEVEL} Visualforce=${VISUALFORCE_DEBUG_LEVEL} --usetoolingapi --json`
+      `sfdx force:data:record:update --sobjecttype DebugLevel --sobjectid ${fakeDebugLevelId} --values ApexCode=${APEX_CODE_DEBUG_LEVEL} Visualforce=${VISUALFORCE_DEBUG_LEVEL} --usetoolingapi --json --loglevel fatal`
     );
   });
 
@@ -91,7 +91,7 @@ describe('Force Start Apex Debug Logging', () => {
     const createTraceFlagExecutor = new CreateTraceFlag('testUserId');
     const createTraceFlagCmd = createTraceFlagExecutor.build();
     expect(createTraceFlagCmd.toCommand()).to.equal(
-      `sfdx force:data:record:create --sobjecttype TraceFlag --values tracedentityid='testUserId' logtype=developer_log debuglevelid=${fakeDebugLevelId} StartDate='${startDate.toUTCString()}' ExpirationDate='${endDate.toUTCString()} --usetoolingapi --json`
+      `sfdx force:data:record:create --sobjecttype TraceFlag --values tracedentityid='testUserId' logtype=developer_log debuglevelid=${fakeDebugLevelId} StartDate='${startDate.toUTCString()}' ExpirationDate='${endDate.toUTCString()} --usetoolingapi --json --loglevel fatal`
     );
   });
 
@@ -99,7 +99,7 @@ describe('Force Start Apex Debug Logging', () => {
     const createDebugLevelExecutor = new CreateDebugLevel();
     const createDebugLevelCmd = createDebugLevelExecutor.build();
     expect(createDebugLevelCmd.toCommand()).to.equal(
-      `sfdx force:data:record:create --sobjecttype DebugLevel --values developername=${createDebugLevelExecutor.developerName} MasterLabel=${createDebugLevelExecutor.developerName} apexcode=${APEX_CODE_DEBUG_LEVEL} visualforce=${VISUALFORCE_DEBUG_LEVEL} --usetoolingapi --json`
+      `sfdx force:data:record:create --sobjecttype DebugLevel --values developername=${createDebugLevelExecutor.developerName} MasterLabel=${createDebugLevelExecutor.developerName} apexcode=${APEX_CODE_DEBUG_LEVEL} visualforce=${VISUALFORCE_DEBUG_LEVEL} --usetoolingapi --json --loglevel fatal`
     );
   });
 });

--- a/packages/salesforcedx-vscode-core/test/commands/isvdebugger/bootstrapCmd.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/isvdebugger/bootstrapCmd.test.ts
@@ -171,7 +171,7 @@ describe('ISV Debugging Project Bootstrap Command', () => {
         }
       );
       expect(command.toCommand()).to.equal(
-        `sfdx force:data:soql:query --query SELECT NamespacePrefix FROM Organization LIMIT 1 --targetusername ${SESSION_ID} --json`
+        `sfdx force:data:soql:query --query SELECT NamespacePrefix FROM Organization LIMIT 1 --targetusername ${SESSION_ID} --json --loglevel fatal`
       );
       expect(command.description).to.equal(
         nls.localize(
@@ -241,7 +241,7 @@ describe('ISV Debugging Project Bootstrap Command', () => {
         projectUri: PROJECT_DIR[0].fsPath
       });
       expect(command.toCommand()).to.equal(
-        `sfdx force:package:installed:list --targetusername ${SESSION_ID} --json`
+        `sfdx force:package:installed:list --targetusername ${SESSION_ID} --json --loglevel fatal`
       );
       expect(command.description).to.equal(
         nls.localize('isv_debug_bootstrap_step5_list_installed_packages')

--- a/packages/salesforcedx-vscode-lwc-next/package.json
+++ b/packages/salesforcedx-vscode-lwc-next/package.json
@@ -41,7 +41,7 @@
     "mocha": "3.2.0",
     "sinon": "^2.3.6",
     "typescript": "2.6.2",
-    "vscode": "1.1.8"
+    "vscode": "1.1.10"
   },
   "extensionDependencies": [
     "dbaeumer.vscode-eslint",

--- a/packages/salesforcedx-vscode-lwc-next/test/eslint.test.ts
+++ b/packages/salesforcedx-vscode-lwc-next/test/eslint.test.ts
@@ -5,15 +5,11 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+/* tslint:disable:no-unused-expression */
 import { expect } from 'chai';
 import { stub } from 'sinon';
-import {
-  ExtensionContext,
-  extensions,
-  workspace,
-  WorkspaceConfiguration
-} from 'vscode';
-import { ESLINT_NODEPATH_CONFIG, LWC_EXTENSION_NAME } from '../src/constants';
+import { ExtensionContext, WorkspaceConfiguration } from 'vscode';
+import { LWC_EXTENSION_NAME } from '../src/constants';
 import { populateEslintSettingIfNecessary } from '../src/index';
 
 describe('LWC ESlint Unit Tests', () => {

--- a/packages/salesforcedx-vscode-lwc-next/test/eslint.test.ts
+++ b/packages/salesforcedx-vscode-lwc-next/test/eslint.test.ts
@@ -16,24 +16,6 @@ import {
 import { ESLINT_NODEPATH_CONFIG, LWC_EXTENSION_NAME } from '../src/constants';
 import { populateEslintSettingIfNecessary } from '../src/index';
 
-// tslint:disable:no-unused-expression
-describe('LWC ESlint Integration Tests', () => {
-  before(async () => {
-    const extension = extensions.getExtension(
-      `salesforce.${LWC_EXTENSION_NAME}`
-    );
-    if (extension && !extension.isActive) {
-      await extension.activate();
-    }
-  });
-
-  it('Should configure eslint.nodePath on sfdx-simple', () => {
-    expect(
-      workspace.getConfiguration().get<string>(ESLINT_NODEPATH_CONFIG)
-    ).to.contain(LWC_EXTENSION_NAME);
-  });
-});
-
 describe('LWC ESlint Unit Tests', () => {
   const mContext = {
     asAbsolutePath: () => {

--- a/packages/salesforcedx-vscode-lwc-next/test/index.ts
+++ b/packages/salesforcedx-vscode-lwc-next/test/index.ts
@@ -12,8 +12,7 @@ const testRunner = require('@salesforce/salesforcedx-utils-vscode/out/src/test/t
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
 testRunner.configure({
   ui: 'bdd', // the TDD UI is being used in extension.test.ts (suite, test, etc.)
-  useColors: true, // colored output from test results
-  timeout: 10000
+  useColors: true // colored output from test results
 });
 
 module.exports = testRunner;

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -41,7 +41,7 @@
     "mocha": "3.2.0",
     "sinon": "^2.3.6",
     "typescript": "2.6.2",
-    "vscode": "1.1.8"
+    "vscode": "1.1.10"
   },
   "extensionDependencies": [
     "dbaeumer.vscode-eslint",

--- a/packages/salesforcedx-vscode-lwc/test/eslint.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/eslint.test.ts
@@ -5,34 +5,12 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+/* tslint:disable:no-unused-expression */
 import { expect } from 'chai';
 import { stub } from 'sinon';
-import {
-  ExtensionContext,
-  extensions,
-  workspace,
-  WorkspaceConfiguration
-} from 'vscode';
-import { ESLINT_NODEPATH_CONFIG, LWC_EXTENSION_NAME } from '../src/constants';
+import { ExtensionContext, WorkspaceConfiguration } from 'vscode';
+import { LWC_EXTENSION_NAME } from '../src/constants';
 import { populateEslintSettingIfNecessary } from '../src/index';
-
-// tslint:disable:no-unused-expression
-describe('LWC ESlint Integration Tests', () => {
-  before(async () => {
-    const extension = extensions.getExtension(
-      `salesforce.${LWC_EXTENSION_NAME}`
-    );
-    if (extension && !extension.isActive) {
-      await extension.activate();
-    }
-  });
-
-  it('Should configure eslint.nodePath on sfdx-simple', () => {
-    expect(
-      workspace.getConfiguration().get<string>(ESLINT_NODEPATH_CONFIG)
-    ).to.contain(LWC_EXTENSION_NAME);
-  });
-});
 
 describe('LWC ESlint Unit Tests', () => {
   const mContext = {

--- a/packages/salesforcedx-vscode-lwc/test/index.ts
+++ b/packages/salesforcedx-vscode-lwc/test/index.ts
@@ -12,8 +12,7 @@ const testRunner = require('@salesforce/salesforcedx-utils-vscode/out/src/test/t
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
 testRunner.configure({
   ui: 'bdd', // the TDD UI is being used in extension.test.ts (suite, test, etc.)
-  useColors: true, // colored output from test results
-  timeout: 10000
+  useColors: true // colored output from test results
 });
 
 module.exports = testRunner;


### PR DESCRIPTION
### What does this PR do?
This change standardizes CLI calls that need --json to use `CommandBuilder.withJson()`. In `withJson()`, it will append `--loglevel fatal` to ignore warnings from CLI so we avoid getting multiple JSON objects.

Additionally, CLI outputs messages when it's updating to the latest version. When this happens with a command that needs --json, the messages are in human-readable format and it cannot be supressed with `--loglevel fatal`. You would see something like this:

```
sfdx-cli: Updating to ...
{ ... the JSON we care about ... }
```

The update messages actually go to stderr, so the fix is to ignore stderr.

### What issues does this PR fix or reference?
@W-4485495@