### PR TITLE
VSCode engine version update and status bar

### DIFF
--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -6,7 +6,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.17.0"
+    "vscode": "^1.22.0"
   },
   "categories": ["Debuggers"],
   "dependencies": {

--- a/packages/salesforcedx-slds-linter/package.json
+++ b/packages/salesforcedx-slds-linter/package.json
@@ -7,7 +7,7 @@
   "license": "BSD-3-Clause",
   "categories": ["Other"],
   "engines": {
-    "vscode": "^1.17.0"
+    "vscode": "^1.22.0"
   },
   "devDependencies": {
     "@types/chai": "^4.0.0",

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -7,7 +7,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.17.0"
+    "vscode": "^1.22.0"
   },
   "dependencies": {
     "@salesforce/salesforcedx-utils-vscode": "42.14.0",

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -37,7 +37,7 @@
     "typescript": "2.6.2"
   },
   "engines": {
-    "vscode": "^1.17.0"
+    "vscode": "^1.22.0"
   },
   "scripts": {
     "compile": "tsc -p ./",

--- a/packages/salesforcedx-visualforce-language-server/package.json
+++ b/packages/salesforcedx-visualforce-language-server/package.json
@@ -5,7 +5,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.17.0"
+    "vscode": "^1.22.0"
   },
   "dependencies": {
     "@salesforce/salesforcedx-visualforce-markup-language-server": "42.14.0",

--- a/packages/salesforcedx-visualforce-markup-language-server/package.json
+++ b/packages/salesforcedx-visualforce-markup-language-server/package.json
@@ -5,7 +5,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.17.0"
+    "vscode": "^1.22.0"
   },
   "activationEvents": ["onView:never"],
   "main": "./out/src/htmlLanguageService.js",

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -18,7 +18,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.17.0"
+    "vscode": "^1.22.0"
   },
   "categories": ["Debuggers"],
   "dependencies": {

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -19,7 +19,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.17.0"
+    "vscode": "^1.22.0"
   },
   "categories": ["Languages"],
   "devDependencies": {

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -18,7 +18,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.17.0"
+    "vscode": "^1.22.0"
   },
   "categories": ["Other"],
   "dependencies": {

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -18,7 +18,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.17.0"
+    "vscode": "^1.22.0"
   },
   "categories": ["Languages"],
   "dependencies": {

--- a/packages/salesforcedx-vscode-lwc-next/package.json
+++ b/packages/salesforcedx-vscode-lwc-next/package.json
@@ -19,7 +19,7 @@
   "preview": true,
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.17.0"
+    "vscode": "^1.22.0"
   },
   "categories": ["Languages"],
   "dependencies": {

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -19,7 +19,7 @@
   "preview": true,
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.17.0"
+    "vscode": "^1.22.0"
   },
   "categories": ["Languages"],
   "dependencies": {

--- a/packages/salesforcedx-vscode-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-replay-debugger/package.json
@@ -18,7 +18,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.21.0"
+    "vscode": "^1.22.0"
   },
   "categories": ["Debuggers"],
   "dependencies": {

--- a/packages/salesforcedx-vscode-replay-debugger/src/commands/batchDeleteExistingOverlayActionsCommand.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/src/commands/batchDeleteExistingOverlayActionsCommand.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
 import { BaseCommand } from '@salesforce/salesforcedx-utils-vscode/out/src/requestService';
 import { RestHttpMethodEnum } from '@salesforce/salesforcedx-utils-vscode/out/src/requestService';
 

--- a/packages/salesforcedx-vscode-replay-debugger/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/src/messages/i18n.ts
@@ -33,6 +33,7 @@ export const messages = {
     "The local source is out of sync with the server. Push any changes you've made locally to your org, and pull any changes you've made in the org into your local project.",
   checkpoints_successfully_uploaded:
     'All checkpoints have been successfully uploaded to the server.',
+  creating_checkpoints_progress_window_message: 'Creating checkpoints',
   // These strings are going to be re-worked to become better, Salesforce appropriate, error messages.
   cannot_determine_workspace:
     'Unable to determine workspace folders for workspace',

--- a/packages/salesforcedx-vscode-replay-debugger/test/unit/commands/batchDeleteExistingOverlayActionsCommand.test.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/test/unit/commands/batchDeleteExistingOverlayActionsCommand.test.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
 import {
   RequestService,
   RestHttpMethodEnum

--- a/packages/salesforcedx-vscode/package.json
+++ b/packages/salesforcedx-vscode/package.json
@@ -19,7 +19,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.17.0"
+    "vscode": "^1.22.0"
   },
   "scripts": {
     "vscode:prepublish": "npm prune --production",


### PR DESCRIPTION
### What does this PR do?
1. Update the **engine** version the vscode to 1.22. For the replay debugger extension this was necessary to get access to the progress window which is only in 1.22. All of the other extensions except for salesforcedx-vscode-visualforce were updated. For salesforcedx-vscode-visualforce there will be a work item since that appears to be more involved.
2. Add a progress window that'll show progress the user creates checkpoints (either through the command or through the button on the checkpoints view).
3. Prevent another checkpoint update if one is already in progress. 
4. Add the missing copyright to the batchDeleteExeistingOverlayActionCommand* files.

### What issues does this PR fix or reference?
@W-4979514@ @W-4979533@