### PR TITLE
Bump vscode-debug dependencies to 1.28

### DIFF
--- a/packages/salesforcedx-vscode-replay-debugger/adaptertest/unit/breakpoints/breakpointUtil.test.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/adaptertest/unit/breakpoints/breakpointUtil.test.ts
@@ -43,7 +43,7 @@ describe('Breakpoint utilities', () => {
 
     expect(util.canSetLineBreakpoint('file:///foo.cls', 1)).to.be.true;
     expect(util.canSetLineBreakpoint('file:///foo.cls', 2)).to.be.false;
-    expect(util.canSetLineBreakpoint('file:///bar.cls', 1));
+    expect(util.canSetLineBreakpoint('file:///bar.cls', 1)).to.be.false;
   });
 
   it('Should return top level typeRef for URI', () => {

--- a/packages/salesforcedx-vscode-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-replay-debugger/package.json
@@ -24,8 +24,8 @@
   "dependencies": {
     "@salesforce/salesforcedx-utils-vscode": "42.15.0",
     "request-light": "0.2.1",
-    "vscode-debugadapter": "1.25.0",
-    "vscode-debugprotocol": "1.25.0",
+    "vscode-debugadapter": "1.28.0",
+    "vscode-debugprotocol": "1.28.0",
     "vscode-uri": "1.0.1"
   },
   "devDependencies": {
@@ -42,7 +42,7 @@
     "sinon": "^2.3.6",
     "typescript": "2.6.2",
     "vscode": "1.1.10",
-    "vscode-debugadapter-testsupport": "1.25.0"
+    "vscode-debugadapter-testsupport": "1.28.0"
   },
   "extensionDependencies": [
     "salesforce.salesforcedx-vscode-apex",

--- a/packages/salesforcedx-vscode-replay-debugger/src/adapter/apexReplayDebug.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/src/adapter/apexReplayDebug.ts
@@ -404,14 +404,14 @@ export class ApexReplayDebug extends LoggingDebugSession {
   ): void {
     response.body = { breakpoints: [] };
     if (args.source.path && args.breakpoints) {
+      const uri = this.convertClientPathToDebugger(args.source.path);
       this.log(
         TRACE_CATEGORY_BREAKPOINTS,
         `setBreakPointsRequest: path=${args.source
-          .path} lines=${breakpointUtil.returnLinesForLoggingFromBreakpointArgs(
+          .path} uri=${uri} lines=${breakpointUtil.returnLinesForLoggingFromBreakpointArgs(
           args.breakpoints
         )}`
       );
-      const uri = this.convertClientPathToDebugger(args.source.path);
       this.breakpoints.set(uri, []);
       for (const bp of args.breakpoints) {
         const isVerified = breakpointUtil.canSetLineBreakpoint(

--- a/packages/salesforcedx-vscode-replay-debugger/src/breakpoints/breakpointUtil.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/src/breakpoints/breakpointUtil.ts
@@ -6,11 +6,11 @@
  */
 
 import { DebugProtocol } from 'vscode-debugprotocol';
+import { LineBreakpointInfo } from '.';
 export class BreakpointUtil {
   private static instance: BreakpointUtil;
   private lineNumberMapping: Map<string, number[]> = new Map();
   private typerefMapping: Map<string, string> = new Map();
-  private rawLineBPInfo: any | undefined;
 
   public setValidLines(
     lineNumberMapping: Map<string, number[]>,
@@ -50,17 +50,14 @@ export class BreakpointUtil {
     );
   }
 
-  public getRawLineBPInfo(): any | undefined {
-    return this.rawLineBPInfo;
-  }
-
-  public createMappingsFromLineBreakpointInfo(lineBpInfo: any): void {
+  public createMappingsFromLineBreakpointInfo(
+    lineBpInfo: LineBreakpointInfo[]
+  ): void {
     // clear out any existing mapping
     this.lineNumberMapping.clear();
     this.typerefMapping.clear();
 
     // set the mapping from the source line info
-    this.rawLineBPInfo = lineBpInfo;
     for (const info of lineBpInfo) {
       if (!this.lineNumberMapping.has(info.uri)) {
         this.lineNumberMapping.set(info.uri, []);


### PR DESCRIPTION
### What does this PR do?
Replay Debugger's VS Code dependency was bumped to 1.21 to detect breakpoint changes without an active debugger session. However, from 1.21 and above, VS Code changed their `DebugProtocol.SetBreakpointsArguments.source.path`. It used to give lower case Windows drive (e.g. c:\foo.cls). But now it gives C:\foo.cls.

That path is converted to a URI that is then validated against language server. The language server returns lower case Windows drive, so the upgrade to 1.21 broke the validation. Changing vscode-debugadapter version to 1.28 makes sure the debugger extension converts that path to the same URI provided by language server.

### What issues does this PR fix or reference?
@W-4995585@