### PR TITLE
Remember the last open log folder for log picker

### DIFF
--- a/packages/salesforcedx-vscode-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-replay-debugger/package.json
@@ -23,6 +23,7 @@
   "categories": ["Debuggers"],
   "dependencies": {
     "@salesforce/salesforcedx-utils-vscode": "42.16.0",
+    "path-exists": "3.0.0",
     "request-light": "0.2.1",
     "vscode-debugadapter": "1.28.0",
     "vscode-debugprotocol": "1.28.0",
@@ -32,6 +33,7 @@
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
     "@types/node": "^6.0.40",
+    "@types/path-exists": "^1.0.29",
     "@types/sinon": "^2.3.2",
     "chai": "^4.0.2",
     "cross-env": "5.0.4",

--- a/packages/salesforcedx-vscode-replay-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-replay-debugger/src/index.ts
@@ -6,6 +6,7 @@
  */
 
 import * as path from 'path';
+import * as pathExists from 'path-exists';
 import * as vscode from 'vscode';
 import { DebugConfigurationProvider } from './adapter/debugConfigurationProvider';
 import { breakpointUtil } from './breakpoints';
@@ -21,7 +22,6 @@ import {
   LINE_BREAKPOINT_INFO_REQUEST
 } from './constants';
 import { nls } from './messages';
-import pathExists = require('path-exists');
 let lastOpenedLogFolder: string | undefined;
 
 function registerCommands(): vscode.Disposable {


### PR DESCRIPTION
### What does this PR do?
There are a couple of things here
1. If the user has previously loaded a log to debug, save that path off. If the user starts a new debug session and is prompted to load a log then the getLogFileName will use that path as the default, if it still exists.
2. If the user has used the SFDX command to download logs, they'll downloaded to the .sfdx/tools/debug/logs sub-directory of the current workspace. If that directory exists and there's no previously loaded log folder, then we'll use that. Otherwise we'll stick with the .sfdx which was the previous default.

### What issues does this PR fix or reference?
@W-4995493@