### PR TITLE
Use new location of VS Code executable for test

### DIFF
--- a/packages/system-tests/src/main.ts
+++ b/packages/system-tests/src/main.ts
@@ -15,11 +15,14 @@ import * as path from 'path';
 // VS CODE BINARY LOCATER
 /////////////////////////
 
-const testRunFolder = '.vscode-test';
-const testRunFolderAbsolute = path.join(process.cwd(), testRunFolder);
-
 const version = process.env.CODE_VERSION || '*';
 const isInsiders = version === 'insiders';
+
+const testRunFolder = path.join(
+  '.vscode-test',
+  isInsiders ? 'insiders' : 'stable'
+);
+const testRunFolderAbsolute = path.join(process.cwd(), testRunFolder);
 
 let windowsExecutable;
 let darwinExecutable;

--- a/scripts/install-vsix-dependencies.js
+++ b/scripts/install-vsix-dependencies.js
@@ -4,11 +4,14 @@ const path = require('path');
 const shell = require('shelljs');
 
 // Installs a list of extensions passed on the command line
+var version = process.env.CODE_VERSION || '*';
+var isInsiders = version === 'insiders';
 
-const testRunFolder = '.vscode-test';
+const testRunFolder = path.join(
+  '.vscode-test',
+  isInsiders ? 'insiders' : 'stable'
+);
 const testRunFolderAbsolute = path.join(process.cwd(), testRunFolder);
-
-const version = process.env.CODE_VERSION || '*';
 
 const downloadPlatform =
   process.platform === 'darwin'


### PR DESCRIPTION
### What does this PR do?

Use the new location for VS Code executables.

See https://github.com/Microsoft/vscode-extension-vscode/commit/43a8268ef8075ddec04f901f8bc03f3b5d172351#diff-f900621cc6a1719b5473baf0191f297b

### What issues does this PR fix or reference?

Build failures for integration tests.
