### PR TITLE
Do not inherit global env during Bootstrap

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
@@ -490,7 +490,8 @@ export class IsvDebugBootstrapExecutor extends SfdxCommandletExecutor<{}> {
     cancellationTokenSource: vscode.CancellationTokenSource,
     cancellationToken: vscode.CancellationToken
   ): Promise<string> {
-    const execution = new CliCommandExecutor(command, options).execute(
+    // do not inherit global env because we are setting our own auth
+    const execution = new CliCommandExecutor(command, options, false).execute(
       cancellationToken
     );
 


### PR DESCRIPTION
### What does this PR do?
Ensure that the global environment is skipped during bootstrap command. This prevents inheritance of global auth variables from a previous (old) session.

### What issues does this PR fix or reference?
@W-4998734@