### PR TITLE
Add command to debug last used log

### DIFF
--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -106,6 +106,10 @@
         {
           "command": "sfdx.launch.replay.debugger.logfile",
           "when": "sfdx:project_opened && editorLangId == 'apexlog'"
+        },
+        {
+          "command": "sfdx.launch.replay.debugger.last.logfile",
+          "when": "sfdx:project_opened && !inDebugMode"
         }
       ],
       "view/title": [
@@ -152,6 +156,10 @@
       {
         "command": "sfdx.launch.replay.debugger.logfile",
         "title": "%launch_from_log_file%"
+      },
+      {
+        "command": "sfdx.launch.replay.debugger.last.logfile",
+        "title": "%launch_from_last_log_file%"
       }
     ],
     "views": {

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.nls.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.nls.json
@@ -5,6 +5,8 @@
     "A new configuration for launching Apex Replay Debugger",
   "launch_snippet_name": "Launch Apex Replay Debugger",
   "launch_from_log_file": "SFDX: Launch Apex Replay Debugger with Current File",
+  "launch_from_last_log_file":
+    "SFDX: Launch Apex Replay Debugger with Last Log File",
   "logfile_text":
     "Path to an Apex Debug Log file (*.log) in the workspace folder.",
   "stop_on_entry_text":

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/launchFromLogFile.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/launchFromLogFile.ts
@@ -8,7 +8,7 @@
 import * as vscode from 'vscode';
 import { DebugConfigurationProvider } from '../adapter/debugConfigurationProvider';
 
-export function launchFromLogFile(editorUri: vscode.Uri) {
+export function launchFromLogFile(logFile?: string) {
   if (
     !vscode.debug.activeDebugSession &&
     vscode.workspace.workspaceFolders &&
@@ -16,7 +16,7 @@ export function launchFromLogFile(editorUri: vscode.Uri) {
   ) {
     vscode.debug.startDebugging(
       vscode.workspace.workspaceFolders[0],
-      DebugConfigurationProvider.getConfig(editorUri.fsPath)
+      DebugConfigurationProvider.getConfig(logFile)
     );
   }
 }

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/constants.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/constants.ts
@@ -26,6 +26,8 @@ export const EXEC_ANON_SIGNATURE = 'execute_anonymous_apex';
 export const FIELD_INTEGRITY_EXCEPTION = 'FIELD_INTEGRITY_EXCEPTION';
 export const INVALID_CROSS_REFERENCE_KEY = 'INVALID_CROSS_REFERENCE_KEY';
 export const GET_LINE_BREAKPOINT_INFO_EVENT = 'getLineBreakpointInfo';
+export const LAST_OPENED_LOG_FOLDER_KEY = 'LAST_OPENED_LOG_FOLDER_KEY';
+export const LAST_OPENED_LOG_KEY = 'LAST_OPENED_LOG_KEY';
 export const LINE_BREAKPOINT_INFO_REQUEST = 'lineBreakpointInfo';
 export const OVERLAY_ACTION_DELETE_URL =
   'services/data/v43.0/tooling/sobjects/ApexExecutionOverlayAction/';

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
@@ -23,7 +23,9 @@ import {
   LINE_BREAKPOINT_INFO_REQUEST
 } from './constants';
 import { nls } from './messages';
-let lastOpenedLogFolder: string | undefined;
+let extContext: vscode.ExtensionContext;
+const LAST_OPENED_LOG_KEY = 'LAST_OPENED_LOG_KEY';
+const LAST_OPENED_LOG_FOLDER_KEY = 'LAST_OPENED_LOG_FOLDER_KEY';
 
 export enum VSCodeWindowTypeEnum {
   Error = 1,
@@ -44,7 +46,14 @@ function registerCommands(): vscode.Disposable {
         defaultUri: getDialogStartingPath()
       });
       if (fileUris && fileUris.length === 1) {
-        lastOpenedLogFolder = path.dirname(fileUris[0].fsPath);
+        extContext.workspaceState.update(
+          LAST_OPENED_LOG_KEY,
+          fileUris[0].fsPath
+        );
+        extContext.workspaceState.update(
+          LAST_OPENED_LOG_FOLDER_KEY,
+          path.dirname(fileUris[0].fsPath)
+        );
         return fileUris[0].fsPath;
       }
     }
@@ -52,16 +61,38 @@ function registerCommands(): vscode.Disposable {
   const launchFromLogFileCmd = vscode.commands.registerCommand(
     'sfdx.launch.replay.debugger.logfile',
     editorUri => {
+      let logFile: string | undefined;
       if (!editorUri) {
         const editor = vscode.window.activeTextEditor;
         if (editor) {
           editorUri = editor.document.uri;
         }
       }
-      return launchFromLogFile(editorUri);
+      if (editorUri) {
+        logFile = editorUri.fsPath;
+        extContext.workspaceState.update(LAST_OPENED_LOG_KEY, editorUri.fsPath);
+        extContext.workspaceState.update(
+          LAST_OPENED_LOG_FOLDER_KEY,
+          path.dirname(editorUri.fsPath)
+        );
+      }
+      return launchFromLogFile(logFile);
     }
   );
-  return vscode.Disposable.from(promptForLogCmd, launchFromLogFileCmd);
+  const launchFromLastLogFileCmd = vscode.commands.registerCommand(
+    'sfdx.launch.replay.debugger.last.logfile',
+    lastLogFileUri => {
+      const lastOpenedLog = extContext.workspaceState.get<string>(
+        LAST_OPENED_LOG_KEY
+      );
+      return launchFromLogFile(lastOpenedLog);
+    }
+  );
+  return vscode.Disposable.from(
+    promptForLogCmd,
+    launchFromLogFileCmd,
+    launchFromLastLogFileCmd
+  );
 }
 
 function registerDebugHandlers(checkpointsEnabled: boolean): vscode.Disposable {
@@ -109,6 +140,8 @@ function registerDebugHandlers(checkpointsEnabled: boolean): vscode.Disposable {
 
 export async function activate(context: vscode.ExtensionContext) {
   console.log('Apex Replay Debugger Extension Activated');
+
+  extContext = context;
 
   // registerCommands needs the checkpoint configuration
   const config = vscode.workspace.getConfiguration();
@@ -162,6 +195,9 @@ function getDialogStartingPath(): vscode.Uri | undefined {
   ) {
     // If the user has already selected a document through getLogFileName then
     // use that path if it still exists.
+    const lastOpenedLogFolder = extContext.workspaceState.get<string>(
+      LAST_OPENED_LOG_FOLDER_KEY
+    );
     if (lastOpenedLogFolder && pathExists.sync(lastOpenedLogFolder)) {
       return vscode.Uri.file(lastOpenedLogFolder);
     }

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
@@ -20,12 +20,12 @@ import { launchFromLogFile } from './commands/launchFromLogFile';
 import {
   DEBUGGER_TYPE,
   GET_LINE_BREAKPOINT_INFO_EVENT,
+  LAST_OPENED_LOG_FOLDER_KEY,
+  LAST_OPENED_LOG_KEY,
   LINE_BREAKPOINT_INFO_REQUEST
 } from './constants';
 import { nls } from './messages';
 let extContext: vscode.ExtensionContext;
-const LAST_OPENED_LOG_KEY = 'LAST_OPENED_LOG_KEY';
-const LAST_OPENED_LOG_FOLDER_KEY = 'LAST_OPENED_LOG_FOLDER_KEY';
 
 export enum VSCodeWindowTypeEnum {
   Error = 1,
@@ -46,14 +46,7 @@ function registerCommands(): vscode.Disposable {
         defaultUri: getDialogStartingPath()
       });
       if (fileUris && fileUris.length === 1) {
-        extContext.workspaceState.update(
-          LAST_OPENED_LOG_KEY,
-          fileUris[0].fsPath
-        );
-        extContext.workspaceState.update(
-          LAST_OPENED_LOG_FOLDER_KEY,
-          path.dirname(fileUris[0].fsPath)
-        );
+        updateLastOpened(extContext, fileUris[0].fsPath);
         return fileUris[0].fsPath;
       }
     }
@@ -70,11 +63,7 @@ function registerCommands(): vscode.Disposable {
       }
       if (editorUri) {
         logFile = editorUri.fsPath;
-        extContext.workspaceState.update(LAST_OPENED_LOG_KEY, editorUri.fsPath);
-        extContext.workspaceState.update(
-          LAST_OPENED_LOG_FOLDER_KEY,
-          path.dirname(editorUri.fsPath)
-        );
+        updateLastOpened(extContext, editorUri.fsPath);
       }
       return launchFromLogFile(logFile);
     }
@@ -92,6 +81,17 @@ function registerCommands(): vscode.Disposable {
     promptForLogCmd,
     launchFromLogFileCmd,
     launchFromLastLogFileCmd
+  );
+}
+
+export function updateLastOpened(
+  extensionContext: vscode.ExtensionContext,
+  logPath: string
+) {
+  extensionContext.workspaceState.update(LAST_OPENED_LOG_KEY, logPath);
+  extensionContext.workspaceState.update(
+    LAST_OPENED_LOG_FOLDER_KEY,
+    path.dirname(logPath)
   );
 }
 

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/unit/adapter/debugConfigurationProvider.test.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/unit/adapter/debugConfigurationProvider.test.ts
@@ -9,7 +9,13 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import { DebugConfigurationProvider } from '../../../src/adapter/debugConfigurationProvider';
-import { DEBUGGER_LAUNCH_TYPE, DEBUGGER_TYPE } from '../../../src/constants';
+import {
+  DEBUGGER_LAUNCH_TYPE,
+  DEBUGGER_TYPE,
+  LAST_OPENED_LOG_FOLDER_KEY,
+  LAST_OPENED_LOG_KEY
+} from '../../../src/constants';
+import { updateLastOpened } from '../../../src/index';
 import { nls } from '../../../src/messages';
 
 // tslint:disable:no-unused-expression
@@ -102,5 +108,32 @@ describe('Configuration provider', () => {
     });
 
     expect(config).to.deep.equal(expectedConfig);
+  });
+});
+
+describe('extension context log path tests', () => {
+  const mementoKeys: string[] = [];
+  const mementoValues: string[] = [];
+  const mContext = {
+    workspaceState: {
+      update: (key: string, value: any) => {
+        mementoKeys.push(key);
+        mementoValues.push(value as string);
+      }
+    }
+  };
+  it('Should update the extension context', () => {
+    updateLastOpened(
+      (mContext as any) as vscode.ExtensionContext,
+      '/foo/bar/logfilename.log'
+    );
+    expect(mementoKeys).to.have.same.members([
+      `${LAST_OPENED_LOG_KEY}`,
+      `${LAST_OPENED_LOG_FOLDER_KEY}`
+    ]);
+    expect(mementoValues).to.have.same.members([
+      '/foo/bar/logfilename.log',
+      '/foo/bar'
+    ]);
   });
 });


### PR DESCRIPTION
### What does this PR do?
Added the command "SFDX: Launch Apex Replay Debugger with Last Log File" which will start a new debugging session with the last log debugged. Note: This command is only available if there isn't an active debug session. The reason for this is that the Restart Debugging command (through the menu option or through the button on the debug panel) will already restart the session with the same parameters. 

As part of this fix, store the last debugged log and the last debugged log directory in the workspaceState Memento. This will persist both variables for the workspace similar to the way breakpoints are persisted which is to say if you were to unload/reload the same project we'd still have the last log and last log directory if they were previously set (otherwise we'd prompt).

Also, fixed an issue with SFDX: Launch Apex Replay Debugger with Current File where it didn't update the last debugged log/directory. (The scenario: Debug Log A through the normal means. Open up Log B through the Open File menu and select to debug with current file. Stop debugging and then debug with last log file and instead of opening up B again it would open up A and start debugging). 


### What issues does this PR fix or reference?
@W-5001363@