### PR TITLE
Make lwc-next the current version of lwc

### DIFF
--- a/packages/salesforcedx-vscode-lwc-next/package.json
+++ b/packages/salesforcedx-vscode-lwc-next/package.json
@@ -27,7 +27,7 @@
     "ajv": "^6.1.1",
     "eslint": "4.16.0",
     "eslint-plugin-lwc": "0.3.2",
-    "lwc-language-server": "1.4.0",
+    "lwc-language-server": "1.5.0",
     "rxjs": "^5.4.1",
     "vscode-languageclient": "3.5.1"
   },

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -27,7 +27,7 @@
     "ajv": "^6.1.1",
     "eslint": "4.16.0",
     "eslint-plugin-lwc": "0.3.2",
-    "lwc-language-server": "0.16.4",
+    "lwc-language-server": "1.4.0",
     "rxjs": "^5.4.1",
     "vscode-languageclient": "3.5.1"
   },

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -27,7 +27,7 @@
     "ajv": "^6.1.1",
     "eslint": "4.16.0",
     "eslint-plugin-lwc": "0.3.2",
-    "lwc-language-server": "1.4.0",
+    "lwc-language-server": "1.5.0",
     "rxjs": "^5.4.1",
     "vscode-languageclient": "3.5.1"
   },

--- a/packages/salesforcedx-vscode-lwc/package.nls.json
+++ b/packages/salesforcedx-vscode-lwc/package.nls.json
@@ -1,3 +1,3 @@
 {
-  "force_lightning_lwc_create_text": "SFDX: Create LWC Bundle"
+  "force_lightning_lwc_create_text": "SFDX: Create Lightning Web Component"
 }

--- a/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcCreate.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcCreate.ts
@@ -78,8 +78,9 @@ class ForceLightningLwcCreateExecutor extends (SfdxCommandletExecutor as {
   public build(data: DirFileNameSelection): Command {
     return new SfdxCommandBuilder()
       .withDescription(nls.localize('force_lightning_lwc_create_text'))
-      .withArg('force:lightning:lwc:create')
-      .withFlag('--lwcname', data.fileName)
+      .withArg('force:lightning:component:create')
+      .withFlag('--type', 'web')
+      .withFlag('--componentname', data.fileName)
       .withFlag('--outputdir', data.outputdir)
       .build();
   }

--- a/packages/salesforcedx-vscode-lwc/src/index.ts
+++ b/packages/salesforcedx-vscode-lwc/src/index.ts
@@ -143,7 +143,9 @@ function startLWCLanguageServer(
         ),
         vscode.workspace.createFileSystemWatcher(
           '**/lightningcomponents/*/*.js'
-        )
+        ),
+        // need to watch for directory deletions as no events are created for contents or deleted directories
+        vscode.workspace.createFileSystemWatcher('**/', true, true, false)
       ]
     },
     uriConverters: {

--- a/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
@@ -19,10 +19,10 @@ export const messages = {
   salesforcedx_vscode_core_not_installed_text:
     'salesforce.salesforcedx-vscode-lwc failed to activate. Ensure that you have the latest version of salesforce.salesforcedx-vscode-core installed and activated',
 
-  force_lightning_lwc_create_text: 'SFDX: Create LWC Bundle',
+  force_lightning_lwc_create_text: 'SFDX: Create Lightning Web Component',
 
   warning_prompt_lightning_bundle_overwrite:
-    'An LWC bundle with the specified path already exists in your workspace. Do you want to overwrite any existing files in this bundle?',
+    'A Lightning Web Component with the specified path already exists in your workspace. Do you want to overwrite any existing files in this bundle?',
   warning_prompt_overwrite_confirm: 'Overwrite',
   warning_prompt_overwrite_cancel: 'Cancel'
 };


### PR DESCRIPTION
### What does this PR do?

The main changes are:

1. The command to call the way we scaffold a new component (requires new version of the Salesforce CLI)
2. The version of the language server that we are using

### What issues does this PR fix or reference?

@W-5028685@