### PR TITLE
Bump vscode dependency to 1.23

### DIFF
--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -6,7 +6,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.22.0"
+    "vscode": "^1.23.0"
   },
   "categories": ["Debuggers"],
   "dependencies": {

--- a/packages/salesforcedx-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-apex-replay-debugger/package.json
@@ -7,7 +7,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.22.0"
+    "vscode": "^1.23.0"
   },
   "categories": ["Debuggers"],
   "dependencies": {

--- a/packages/salesforcedx-slds-linter/package.json
+++ b/packages/salesforcedx-slds-linter/package.json
@@ -7,7 +7,7 @@
   "license": "BSD-3-Clause",
   "categories": ["Other"],
   "engines": {
-    "vscode": "^1.22.0"
+    "vscode": "^1.23.0"
   },
   "devDependencies": {
     "@types/chai": "^4.0.0",

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -7,7 +7,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.22.0"
+    "vscode": "^1.23.0"
   },
   "dependencies": {
     "@salesforce/salesforcedx-utils-vscode": "42.18.0",

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -37,7 +37,7 @@
     "typescript": "2.6.2"
   },
   "engines": {
-    "vscode": "^1.22.0"
+    "vscode": "^1.23.0"
   },
   "scripts": {
     "compile": "tsc -p ./",

--- a/packages/salesforcedx-visualforce-language-server/package.json
+++ b/packages/salesforcedx-visualforce-language-server/package.json
@@ -5,7 +5,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.22.0"
+    "vscode": "^1.23.0"
   },
   "dependencies": {
     "@salesforce/salesforcedx-visualforce-markup-language-server": "42.18.0",

--- a/packages/salesforcedx-visualforce-markup-language-server/package.json
+++ b/packages/salesforcedx-visualforce-markup-language-server/package.json
@@ -5,7 +5,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.22.0"
+    "vscode": "^1.23.0"
   },
   "activationEvents": ["onView:never"],
   "main": "./out/src/htmlLanguageService.js",

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -18,7 +18,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.22.0"
+    "vscode": "^1.23.0"
   },
   "categories": ["Debuggers"],
   "dependencies": {

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -18,7 +18,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.22.0"
+    "vscode": "^1.23.0"
   },
   "categories": ["Debuggers"],
   "dependencies": {

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -19,7 +19,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.22.0"
+    "vscode": "^1.23.0"
   },
   "categories": ["Languages"],
   "devDependencies": {

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -18,7 +18,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.22.0"
+    "vscode": "^1.23.0"
   },
   "categories": ["Other"],
   "dependencies": {

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -18,7 +18,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.22.0"
+    "vscode": "^1.23.0"
   },
   "categories": ["Languages"],
   "dependencies": {

--- a/packages/salesforcedx-vscode-lwc-next/package.json
+++ b/packages/salesforcedx-vscode-lwc-next/package.json
@@ -19,7 +19,7 @@
   "preview": true,
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.22.0"
+    "vscode": "^1.23.0"
   },
   "categories": ["Languages"],
   "dependencies": {

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -19,7 +19,7 @@
   "preview": true,
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.22.0"
+    "vscode": "^1.23.0"
   },
   "categories": ["Languages"],
   "dependencies": {

--- a/packages/salesforcedx-vscode/package.json
+++ b/packages/salesforcedx-vscode/package.json
@@ -19,7 +19,7 @@
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
-    "vscode": "^1.22.0"
+    "vscode": "^1.23.0"
   },
   "scripts": {
     "vscode:prepublish": "npm prune --production",


### PR DESCRIPTION
### What does this PR do?

Webview Panels in VS Code are only available in version 1.23 and higher.
To support custom UI we need to be able to use webview panels.

I separated this from #451 to make it clearer than this is a version bump.

### What issues does this PR fix or reference?

@W-5013822@
