### PR TITLE
Send InitializedEvent when LogContext is ready

### DIFF
--- a/packages/salesforcedx-apex-replay-debugger/src/adapter/apexReplayDebug.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/adapter/apexReplayDebug.ts
@@ -191,12 +191,14 @@ export class ApexReplayDebug extends LoggingDebugSession {
   ): void {
     response.success = false;
     this.setupLogger(args);
-
     this.log(
       TRACE_CATEGORY_LAUNCH,
       `launchRequest: args=${JSON.stringify(args)}`
     );
+
     this.logContext = new LogContext(args, this);
+    this.sendEvent(new InitializedEvent());
+
     if (!this.logContext.hasLogLines()) {
       response.message = nls.localize('no_log_file_text');
       this.sendResponse(response);
@@ -490,7 +492,6 @@ export class ApexReplayDebug extends LoggingDebugSession {
           };
           this.initializedResponse.success = true;
           this.sendResponse(this.initializedResponse);
-          this.sendEvent(new InitializedEvent());
           break;
         }
     }

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/apexReplayDebug.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/apexReplayDebug.test.ts
@@ -103,6 +103,7 @@ describe('Replay debugger adapter - unit', () => {
 
   describe('Launch', () => {
     let sendResponseSpy: sinon.SinonSpy;
+    let sendEventSpy: sinon.SinonSpy;
     let response: DebugProtocol.LaunchResponse;
     let args: LaunchRequestArguments;
     let hasLogLinesStub: sinon.SinonStub;
@@ -119,6 +120,7 @@ describe('Replay debugger adapter - unit', () => {
         trace: false
       };
       sendResponseSpy = sinon.spy(ApexReplayDebug.prototype, 'sendResponse');
+      sendEventSpy = sinon.spy(ApexReplayDebug.prototype, 'sendEvent');
       readLogFileStub = sinon
         .stub(LogContextUtil.prototype, 'readLogFile')
         .returns(['line1', 'line2']);
@@ -130,6 +132,7 @@ describe('Replay debugger adapter - unit', () => {
 
     afterEach(() => {
       sendResponseSpy.restore();
+      sendEventSpy.restore();
       hasLogLinesStub.restore();
       meetsLogLevelRequirementsStub.restore();
       readLogFileStub.restore();
@@ -169,6 +172,10 @@ describe('Replay debugger adapter - unit', () => {
       expect(hasLogLinesStub.calledOnce).to.be.true;
       expect(meetsLogLevelRequirementsStub.calledOnce).to.be.true;
       expect(sendResponseSpy.calledOnce).to.be.true;
+      expect(sendEventSpy.calledOnce).to.be.true;
+      expect(sendEventSpy.getCall(0).args[0]).to.be.instanceof(
+        InitializedEvent
+      );
       const actualResponse: DebugProtocol.LaunchResponse = sendResponseSpy.getCall(
         0
       ).args[0];
@@ -759,7 +766,6 @@ describe('Replay debugger adapter - unit', () => {
   describe('Custom request', () => {
     describe('Line breakpoint info', () => {
       let sendResponseSpy: sinon.SinonSpy;
-      let sendEventSpy: sinon.SinonSpy;
       let createMappingsFromLineBreakpointInfo: sinon.SinonSpy;
       const initializedResponse = {
         success: true,
@@ -788,7 +794,6 @@ describe('Replay debugger adapter - unit', () => {
           {} as DebugProtocol.InitializeRequestArguments
         );
         sendResponseSpy = sinon.spy(ApexReplayDebug.prototype, 'sendResponse');
-        sendEventSpy = sinon.spy(ApexReplayDebug.prototype, 'sendEvent');
         createMappingsFromLineBreakpointInfo = sinon.spy(
           BreakpointUtil.prototype,
           'createMappingsFromLineBreakpointInfo'
@@ -797,7 +802,6 @@ describe('Replay debugger adapter - unit', () => {
 
       afterEach(() => {
         sendResponseSpy.restore();
-        sendEventSpy.restore();
         createMappingsFromLineBreakpointInfo.restore();
       });
 
@@ -815,10 +819,6 @@ describe('Replay debugger adapter - unit', () => {
         ).args[0];
         expect(actualResponse.success).to.be.true;
         expect(actualResponse).to.deep.equal(initializedResponse);
-        expect(sendEventSpy.calledOnce).to.be.true;
-        expect(sendEventSpy.getCall(0).args[0]).to.be.instanceof(
-          InitializedEvent
-        );
       });
 
       it('Should handle empty line breakpoint info', () => {
@@ -835,10 +835,6 @@ describe('Replay debugger adapter - unit', () => {
         ).args[0];
         expect(actualResponse.success).to.be.true;
         expect(actualResponse).to.deep.equal(initializedResponse);
-        expect(sendEventSpy.calledOnce).to.be.true;
-        expect(sendEventSpy.getCall(0).args[0]).to.be.instanceof(
-          InitializedEvent
-        );
       });
 
       it('Should save line number mapping', () => {
@@ -868,10 +864,6 @@ describe('Replay debugger adapter - unit', () => {
         ).args[0];
         expect(actualResponse.success).to.be.true;
         expect(actualResponse).to.deep.equal(initializedResponse);
-        expect(sendEventSpy.calledOnce).to.be.true;
-        expect(sendEventSpy.getCall(0).args[0]).to.be.instanceof(
-          InitializedEvent
-        );
         // Verify that the line number mapping is the expected line number mapping
         expect(breakpointUtil.getLineNumberMapping()).to.deep.eq(
           expectedLineNumberMapping


### PR DESCRIPTION
### What does this PR do?
With a Live Share session enabled, the ordering of requests/events doesn't appear to be consistent. Live Share team is still looking into it; their suggestion is to fix our `InitializedEvent`. The issue did expose a flaw in when the replay debugger sends an `InitializedEvent` to VS Code. It should do it after `LogContext` is initialized because it's actually ready for breakpoints and etc.

![untitled](https://user-images.githubusercontent.com/7286437/40851270-c791da42-657b-11e8-9c18-a60b216f497a.png)

### What issues does this PR fix or reference?
@W-5013801@