### PR TITLE
Add an event listener for the creation of the sfdx-config file

### DIFF
--- a/packages/salesforcedx-vscode-core/src/decorators/scratch-org-decorator.ts
+++ b/packages/salesforcedx-vscode-core/src/decorators/scratch-org-decorator.ts
@@ -30,6 +30,9 @@ export function monitorOrgConfigChanges() {
   watcher.onDidChange(uri => {
     displayDefaultUserName(uri.fsPath);
   });
+  watcher.onDidCreate(uri => {
+    displayDefaultUserName(uri.fsPath);
+  });
 }
 
 function displayDefaultUserName(configPath: string) {


### PR DESCRIPTION
### What does this PR do?
This pr adds an event listener to detect the creation of the config file where the default scratch org is specified. That event is used to update the scratch org shortcut in the vscode status bar. 

### What issues does this PR fix or reference?
W-4959520: The scratch org shortcut was not showing up in the vscode status bar in cases where the <workspace-dir>/.sfdx/sfdx-config.json was created after the creation of the scratch org. This is because we only had an event listener listening to updates made to the sfdx-config.json file, and no event listener detecting the creation of the file. 