### PR TITLE
Mark apex replay debugger as preview

### DIFF
--- a/packages/salesforcedx-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-apex-replay-debugger/package.json
@@ -5,6 +5,7 @@
     "Implements the VS Code Debug Protocol for the Apex Replay Debugger",
   "version": "42.18.0",
   "publisher": "salesforce",
+  "preview": true,
   "license": "BSD-3-Clause",
   "engines": {
     "vscode": "^1.23.0"


### PR DESCRIPTION
### What does this PR do?

Apex Replay Debugger is open beta in Summer '18. We should use `preview: true` as documented at https://code.visualstudio.com/docs/extensionAPI/extension-manifest

### What issues does this PR fix or reference?

@W-5001732@
