### PR TITLE
Add an extra quickPick for the api type (REST vs. Tooling API)

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceDataSoqlQuery.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceDataSoqlQuery.ts
@@ -17,7 +17,6 @@ import {
 import * as vscode from 'vscode';
 import { nls } from '../messages';
 import {
-  CompositeParametersGatherer,
   SfdxCommandlet,
   SfdxCommandletExecutor,
   SfdxWorkspaceChecker

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -171,6 +171,9 @@ export const messages = {
   demo_mode_prompt:
     'Authorizing a business or production org is not recommended on a demo or shared machine. If you continue with the authentication, be sure to run "SFDX: Log Out from All Authorized Orgs" when you\'re done using this org.',
   force_auth_logout_all_text: 'SFDX: Log Out from All Authorized Orgs',
-
-  manifest_editor_title_message: 'Manifest Editor'
+  manifest_editor_title_message: 'Manifest Editor',
+  REST_API: 'REST API',
+  tooling_API: 'Tooling API',
+  REST_API_description: 'The Salesforce REST API',
+  tooling_API_description: 'The Salesforce Tooling API'
 };

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -174,6 +174,6 @@ export const messages = {
   manifest_editor_title_message: 'Manifest Editor',
   REST_API: 'REST API',
   tooling_API: 'Tooling API',
-  REST_API_description: 'The Salesforce REST API',
-  tooling_API_description: 'The Salesforce Tooling API'
+  REST_API_description: 'Execute the query with REST API',
+  tooling_API_description: 'Execute the query with Tooling API'
 };

--- a/packages/system-tests/scenarios/forceSoqlQueryUi.test.ts
+++ b/packages/system-tests/scenarios/forceSoqlQueryUi.test.ts
@@ -57,6 +57,11 @@ describe(TITLE, () => {
     await app.client.keys(['NULL', 'Enter', 'NULL'], false);
     await app.wait();
 
+    // Select REST API
+    await common.type('REST API');
+    await app.client.keys(['NULL', 'Enter', 'NULL'], false);
+    await app.wait();
+
     const consoleHtml = await common.getConsoleOutput();
     // tslint:disable-next-line:prefer-for-of
     for (let i = 0; i < consoleHtml.length; i++) {
@@ -82,6 +87,39 @@ describe(TITLE, () => {
     // Invoke SFDX: Execute SOQL Query command by name
     await app.command('workbench.action.quickOpen');
     await common.type('>SFDX: Execute SOQL Query with Currently Selected Text');
+    await app.client.keys(['NULL', 'Enter', 'NULL'], false);
+    await app.wait();
+
+    // Select REST API
+    await common.type('REST API');
+    await app.client.keys(['NULL', 'Enter', 'NULL'], false);
+    await app.wait();
+
+    const consoleHtml = await common.getConsoleOutput();
+    // tslint:disable-next-line:prefer-for-of
+    for (let i = 0; i < consoleHtml.length; i++) {
+      if (consoleHtml[i].indexOf('exit code') > 0) {
+        expect(consoleHtml[i]).to.contain('exit code 0');
+      }
+    }
+  });
+
+  it('Should execute SOQL query against the Tooling API', async () => {
+    // Invoke SFDX: Execute SOQL Query command by name
+    await app.command('workbench.action.quickOpen');
+    await common.type('>SFDX: Execute SOQL Query...');
+    await app.client.keys(['NULL', 'Enter', 'NULL'], false);
+    await app.wait();
+
+    const query = `SELECT Id FROM ApexClassMember`;
+
+    // Enter SOQL query
+    await common.type(query);
+    await app.client.keys(['NULL', 'Enter', 'NULL'], false);
+    await app.wait();
+
+    // Select Tooling API
+    await common.type('Tooling API');
     await app.client.keys(['NULL', 'Enter', 'NULL'], false);
     await app.wait();
 


### PR DESCRIPTION
### What does this PR do?
Adds an extra dropdown for the user to select whether they want to query the "REST API" or "Tooling API". 

### What issues does this PR fix or reference?
W-4365988: Needs a way to be able to specify --usetoolingapi flag for SOQL query