### PR TITLE
Fix capitalization of package display name

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforcedx-vscode-core",
-  "displayName": "Salesforce CLI integration for Visual Studio Code",
+  "displayName": "Salesforce CLI Integration for Visual Studio Code",
   "description": "Provides integration with the Salesforce CLI",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",
   "bugs": {


### PR DESCRIPTION
### What does this PR do?
Fix capitalization of "Integration" in salesforcedx-vscode-core package's display name.

### What issues does this PR fix or reference?
Per https://github.com/forcedotcom/salesforcedx-vscode/pull/463#discussion_r193571519