### PR TITLE
Turn on Synk monitoring on each build for new vulnerabilities

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,6 @@ jobs:
        - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
        - run: npm install
-       - run: npm run synk:monitor
        - run: npm run compile
        - run: npm run vscode:package
        - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
        - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
        - run: npm install
+       - run: npm run synk:monitor
        - run: npm run compile
        - run: npm run vscode:package
        - run:

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "synk:test":
       "lerna exec --bail=false --ignore salesforcedx-vscode -- snyk test --severity-threshold=medium --show-vulnerable-paths=false",
     "synk:monitor":
-      "lerna exec --bail=false --ignore salesforcedx-vscode -- snyk monitor --severity-threshold=medium --show-vulnerable-paths=false",
+      "lerna exec --bail=false --ignore salesforcedx-vscode -- snyk monitor --severity-threshold=medium --show-vulnerable-paths=false --org=salesforce",
     "start-webview": "npm run start --prefix=packages/salesforcedx-webview-ui",
     "build-webview": "npm run build --prefix=packages/salesforcedx-webview-ui",
     "test-webview": "npm run test --prefix=packages/salesforcedx-webview-ui",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "synk:test":
       "lerna exec --bail=false --ignore salesforcedx-vscode -- snyk test --severity-threshold=medium --show-vulnerable-paths=false",
     "synk:monitor":
-      "lerna exec --bail=false --ignore salesforcedx-vscode -- snyk monitor --severity-threshold=medium --show-vulnerable-paths=false --org=salesforce",
+      "lerna exec --bail=false --ignore salesforcedx-vscode -- snyk monitor --severity-threshold=medium --show-vulnerable-paths=false --org=vazexqi",
     "start-webview": "npm run start --prefix=packages/salesforcedx-webview-ui",
     "build-webview": "npm run build --prefix=packages/salesforcedx-webview-ui",
     "test-webview": "npm run test --prefix=packages/salesforcedx-webview-ui",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prettier": "1.6.0",
     "remap-istanbul": "^0.9.5",
     "shx": "0.2.2",
+    "snyk": "^1.82.1",
     "tslint": "5.5.0",
     "typescript": "2.6.2",
     "vsce": "^1.36.3"
@@ -42,6 +43,10 @@
     "eslint-check":
       "eslint --print-config .eslintrc.json | eslint-config-prettier-check",
     "reformat": "node scripts/reformat-with-prettier.js",
+    "synk:test":
+      "lerna exec --bail=false --ignore salesforcedx-vscode -- snyk test --severity-threshold=medium --show-vulnerable-paths=false",
+    "synk:monitor":
+      "lerna exec --bail=false --ignore salesforcedx-vscode -- snyk monitor --severity-threshold=medium --show-vulnerable-paths=false",
     "start-webview": "npm run start --prefix=packages/salesforcedx-webview-ui",
     "build-webview": "npm run build --prefix=packages/salesforcedx-webview-ui",
     "test-webview": "npm run test --prefix=packages/salesforcedx-webview-ui",


### PR DESCRIPTION
### What does this PR do?

Turn on Synk monitoring on each build for new vulnerabilities. This will run [`snyk monitor`](https://snyk.io/docs/using-snyk#monitor) and upload the results to https://snyk.io/org/vazexqi for now. I've already enquired about a global one for forcedotcom.

This will continuously update the security checks on each build (and, if no builds happen, it's set to check each day).

I've added @lcampos and @DatGuyJonathan as admins to https://snyk.io/org/vazexqi for now.

### What issues does this PR fix or reference?

Trust.