### PR TITLE
Add a setting flag for retrieving coverage when running Apex unit tests

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -475,7 +475,7 @@
             "boolean"
           ],
           "default": false,
-          "description": "%retrieve_test_code_coverage_text"
+          "description": "%retrieve_test_code_coverage_text%"
         }
       }
     }

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -20,9 +20,7 @@
   "engines": {
     "vscode": "^1.23.0"
   },
-  "categories": [
-    "Other"
-  ],
+  "categories": ["Other"],
   "dependencies": {
     "@salesforce/salesforcedx-sobjects-faux-generator": "43.3.0",
     "@salesforce/salesforcedx-utils-vscode": "43.3.0",
@@ -60,10 +58,13 @@
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
-    "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
+    "clean":
+      "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
     "postinstall": "node ./node_modules/vscode/bin/install",
-    "test": "cross-env CODE_TESTS_WORKSPACE='../system-tests/assets/sfdx-simple' node ./node_modules/vscode/bin/test",
-    "test:unit": "cross-env CODE_TESTS_WORKSPACE='../system-tests/assets/sfdx-simple' node ./node_modules/vscode/bin/test"
+    "test":
+      "cross-env CODE_TESTS_WORKSPACE='../system-tests/assets/sfdx-simple' node ./node_modules/vscode/bin/test",
+    "test:unit":
+      "cross-env CODE_TESTS_WORKSPACE='../system-tests/assets/sfdx-simple' node ./node_modules/vscode/bin/test"
   },
   "activationEvents": [
     "workspaceContains:sfdx-project.json",
@@ -90,35 +91,43 @@
       "explorer/context": [
         {
           "command": "sfdx.force.apex.class.create",
-          "when": "explorerResourceIsFolder && resourceFilename != aura && resourceFilename != lightningcomponents && sfdx:project_opened"
+          "when":
+            "explorerResourceIsFolder && resourceFilename != aura && resourceFilename != lightningcomponents && sfdx:project_opened"
         },
         {
           "command": "sfdx.force.visualforce.component.create",
-          "when": "explorerResourceIsFolder && resourceFilename != aura && resourceFilename != lightningcomponents && sfdx:project_opened"
+          "when":
+            "explorerResourceIsFolder && resourceFilename != aura && resourceFilename != lightningcomponents && sfdx:project_opened"
         },
         {
           "command": "sfdx.force.visualforce.page.create",
-          "when": "explorerResourceIsFolder && resourceFilename != aura && resourceFilename != lightningcomponents && sfdx:project_opened"
+          "when":
+            "explorerResourceIsFolder && resourceFilename != aura && resourceFilename != lightningcomponents && sfdx:project_opened"
         },
         {
           "command": "sfdx.force.lightning.app.create",
-          "when": "explorerResourceIsFolder && resourceFilename == aura && sfdx:project_opened"
+          "when":
+            "explorerResourceIsFolder && resourceFilename == aura && sfdx:project_opened"
         },
         {
           "command": "sfdx.force.lightning.component.create",
-          "when": "explorerResourceIsFolder && resourceFilename == aura && sfdx:project_opened"
+          "when":
+            "explorerResourceIsFolder && resourceFilename == aura && sfdx:project_opened"
         },
         {
           "command": "sfdx.force.lightning.event.create",
-          "when": "explorerResourceIsFolder && resourceFilename == aura && sfdx:project_opened"
+          "when":
+            "explorerResourceIsFolder && resourceFilename == aura && sfdx:project_opened"
         },
         {
           "command": "sfdx.force.lightning.interface.create",
-          "when": "explorerResourceIsFolder && resourceFilename == aura && sfdx:project_opened"
+          "when":
+            "explorerResourceIsFolder && resourceFilename == aura && sfdx:project_opened"
         },
         {
           "command": "sfdx.force.apex.trigger.create",
-          "when": "explorerResourceIsFolder && resourceFilename != aura && resourceFilename != lightningcomponents && sfdx:project_opened"
+          "when":
+            "explorerResourceIsFolder && resourceFilename != aura && resourceFilename != lightningcomponents && sfdx:project_opened"
         }
       ],
       "commandPalette": [
@@ -282,7 +291,8 @@
         },
         {
           "command": "sfdx.force.manifest.editor.show",
-          "when": "sfdx:project_opened && config.salesforcedx-vscode-core.show_experimental_webviews"
+          "when":
+            "sfdx:project_opened && config.salesforcedx-vscode-core.show_experimental_webviews"
         }
       ]
     },
@@ -457,23 +467,17 @@
       "title": "%feature_previews_title%",
       "properties": {
         "salesforcedx-vscode-core.show-cli-success-msg": {
-          "type": [
-            "boolean"
-          ],
+          "type": ["boolean"],
           "default": true,
           "description": "%show_cli_success_msg_description%"
         },
         "salesforcedx-vscode-core.show_experimental_webviews": {
-          "type": [
-            "boolean"
-          ],
+          "type": ["boolean"],
           "default": false,
           "description": "%show_experimental_webviews_description%"
         },
         "salesforcedx-vscode-core.retrieve-test-code-coverage": {
-          "type": [
-            "boolean"
-          ],
+          "type": ["boolean"],
           "default": false,
           "description": "%retrieve_test_code_coverage_text%"
         }

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -20,7 +20,9 @@
   "engines": {
     "vscode": "^1.23.0"
   },
-  "categories": ["Other"],
+  "categories": [
+    "Other"
+  ],
   "dependencies": {
     "@salesforce/salesforcedx-sobjects-faux-generator": "43.3.0",
     "@salesforce/salesforcedx-utils-vscode": "43.3.0",
@@ -58,13 +60,10 @@
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
-    "clean":
-      "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
+    "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
     "postinstall": "node ./node_modules/vscode/bin/install",
-    "test":
-      "cross-env CODE_TESTS_WORKSPACE='../system-tests/assets/sfdx-simple' node ./node_modules/vscode/bin/test",
-    "test:unit":
-      "cross-env CODE_TESTS_WORKSPACE='../system-tests/assets/sfdx-simple' node ./node_modules/vscode/bin/test"
+    "test": "cross-env CODE_TESTS_WORKSPACE='../system-tests/assets/sfdx-simple' node ./node_modules/vscode/bin/test",
+    "test:unit": "cross-env CODE_TESTS_WORKSPACE='../system-tests/assets/sfdx-simple' node ./node_modules/vscode/bin/test"
   },
   "activationEvents": [
     "workspaceContains:sfdx-project.json",
@@ -91,43 +90,35 @@
       "explorer/context": [
         {
           "command": "sfdx.force.apex.class.create",
-          "when":
-            "explorerResourceIsFolder && resourceFilename != aura && resourceFilename != lightningcomponents && sfdx:project_opened"
+          "when": "explorerResourceIsFolder && resourceFilename != aura && resourceFilename != lightningcomponents && sfdx:project_opened"
         },
         {
           "command": "sfdx.force.visualforce.component.create",
-          "when":
-            "explorerResourceIsFolder && resourceFilename != aura && resourceFilename != lightningcomponents && sfdx:project_opened"
+          "when": "explorerResourceIsFolder && resourceFilename != aura && resourceFilename != lightningcomponents && sfdx:project_opened"
         },
         {
           "command": "sfdx.force.visualforce.page.create",
-          "when":
-            "explorerResourceIsFolder && resourceFilename != aura && resourceFilename != lightningcomponents && sfdx:project_opened"
+          "when": "explorerResourceIsFolder && resourceFilename != aura && resourceFilename != lightningcomponents && sfdx:project_opened"
         },
         {
           "command": "sfdx.force.lightning.app.create",
-          "when":
-            "explorerResourceIsFolder && resourceFilename == aura && sfdx:project_opened"
+          "when": "explorerResourceIsFolder && resourceFilename == aura && sfdx:project_opened"
         },
         {
           "command": "sfdx.force.lightning.component.create",
-          "when":
-            "explorerResourceIsFolder && resourceFilename == aura && sfdx:project_opened"
+          "when": "explorerResourceIsFolder && resourceFilename == aura && sfdx:project_opened"
         },
         {
           "command": "sfdx.force.lightning.event.create",
-          "when":
-            "explorerResourceIsFolder && resourceFilename == aura && sfdx:project_opened"
+          "when": "explorerResourceIsFolder && resourceFilename == aura && sfdx:project_opened"
         },
         {
           "command": "sfdx.force.lightning.interface.create",
-          "when":
-            "explorerResourceIsFolder && resourceFilename == aura && sfdx:project_opened"
+          "when": "explorerResourceIsFolder && resourceFilename == aura && sfdx:project_opened"
         },
         {
           "command": "sfdx.force.apex.trigger.create",
-          "when":
-            "explorerResourceIsFolder && resourceFilename != aura && resourceFilename != lightningcomponents && sfdx:project_opened"
+          "when": "explorerResourceIsFolder && resourceFilename != aura && resourceFilename != lightningcomponents && sfdx:project_opened"
         }
       ],
       "commandPalette": [
@@ -291,8 +282,7 @@
         },
         {
           "command": "sfdx.force.manifest.editor.show",
-          "when":
-            "sfdx:project_opened && config.salesforcedx-vscode-core.show_experimental_webviews"
+          "when": "sfdx:project_opened && config.salesforcedx-vscode-core.show_experimental_webviews"
         }
       ]
     },
@@ -467,14 +457,25 @@
       "title": "%feature_previews_title%",
       "properties": {
         "salesforcedx-vscode-core.show-cli-success-msg": {
-          "type": ["boolean"],
+          "type": [
+            "boolean"
+          ],
           "default": true,
           "description": "%show_cli_success_msg_description%"
         },
         "salesforcedx-vscode-core.show_experimental_webviews": {
-          "type": ["boolean"],
+          "type": [
+            "boolean"
+          ],
           "default": false,
           "description": "%show_experimental_webviews_description%"
+        },
+        "salesforcedx-vscode-core.retrieve-test-code-coverage": {
+          "type": [
+            "boolean"
+          ],
+          "default": false,
+          "description": "%retrieve_test_code_coverage_text"
         }
       }
     }

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -67,7 +67,7 @@
     "SFDX: Show Package Manifest Editor (Experimental)",
   "show_experimental_webviews_description":
     "Specifies whether the commands for the experimental webviews are available to the user.",
-    
+
   "retrieve_test_code_coverage_text":
-    "Determines whether code coverage should be retrieved/calculated when running Apex test classes/suites."
+    "Specifies whether code coverage results are calculated and retrieved when you run Apex tests."
 }

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -66,5 +66,8 @@
   "force_manifest_editor_show_text":
     "SFDX: Show Package Manifest Editor (Experimental)",
   "show_experimental_webviews_description":
-    "Specifies whether the commands for the experimental webviews are available to the user."
+    "Specifies whether the commands for the experimental webviews are available to the user.",
+    
+  "retrieve_test_code_coverage_text":
+    "Determines whether code coverage should be retrieved/calculated when running Apex test classes/suites."
 }

--- a/packages/salesforcedx-vscode-core/src/commands/forceApexTestRun.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexTestRun.ts
@@ -25,7 +25,6 @@ import {
   SfdxWorkspaceChecker
 } from './commands';
 
-
 export enum TestType {
   All,
   Suite,

--- a/packages/salesforcedx-vscode-core/src/commands/forceApexTestRun.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexTestRun.ts
@@ -18,12 +18,13 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { nls } from '../messages';
-import { SfdxCoreSettings } from '../settings/sfdxCoreSettings';
+import { sfdxCoreSettings } from '../settings';
 import {
   SfdxCommandlet,
   SfdxCommandletExecutor,
   SfdxWorkspaceChecker
 } from './commands';
+
 
 export enum TestType {
   All,
@@ -83,14 +84,14 @@ export class TestsSelector
 }
 
 export class ForceApexTestRunCommandFactory {
-  private _data: ApexTestQuickPickItem;
-  private _getCodeCoverage: boolean;
+  private data: ApexTestQuickPickItem;
+  private getCodeCoverage: boolean;
   private builder: SfdxCommandBuilder = new SfdxCommandBuilder();
   private testRunExecutorCommand: Command;
 
   constructor(data: ApexTestQuickPickItem, getCodeCoverage: boolean) {
-    this._data = data;
-    this._getCodeCoverage = getCodeCoverage;
+    this.data = data;
+    this.getCodeCoverage = getCodeCoverage;
   }
 
   public constructExecutorCommand(): Command {
@@ -98,21 +99,21 @@ export class ForceApexTestRunCommandFactory {
       .withDescription(nls.localize('force_apex_test_run_text'))
       .withArg('force:apex:test:run');
 
-    switch (this._data.type) {
+    switch (this.data.type) {
       case TestType.Suite:
         this.builder = this.builder
-          .withFlag('--suitenames', `${this._data.label}`);
+          .withFlag('--suitenames', `${this.data.label}`);
         break;
       case TestType.Class:
         this.builder = this.builder
-          .withFlag('--classnames', `${this._data.label}`)
+          .withFlag('--classnames', `${this.data.label}`)
           .withArg('--synchronous');
         break;
       default:
         break;
     }
 
-    if (this._getCodeCoverage) {
+    if (this.getCodeCoverage) {
       this.builder = this.builder
         .withArg('--codecoverage');
     }
@@ -131,8 +132,9 @@ export class ForceApexTestRunExecutor extends SfdxCommandletExecutor<
   ApexTestQuickPickItem
   > {
   public build(data: ApexTestQuickPickItem): Command {
-    const getCodeCoverage: boolean = SfdxCoreSettings.getInstance()
-      .getConfiguration().get('retrieve-test-code-coverage') as boolean;
+    const getCodeCoverage: boolean = sfdxCoreSettings
+      .getConfiguration()
+      .get('retrieve-test-code-coverage') as boolean;
     const factory: ForceApexTestRunCommandFactory = new ForceApexTestRunCommandFactory(data, getCodeCoverage);
     return factory.constructExecutorCommand();
   }

--- a/packages/salesforcedx-vscode-core/src/commands/forceApexTestRun.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexTestRun.ts
@@ -18,6 +18,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { nls } from '../messages';
+import { SfdxCoreSettings } from '../settings/sfdxCoreSettings';
 import {
   SfdxCommandlet,
   SfdxCommandletExecutor,
@@ -38,7 +39,7 @@ export class TestsSelector
   implements ParametersGatherer<ApexTestQuickPickItem> {
   public async gather(): Promise<
     CancelResponse | ContinueResponse<ApexTestQuickPickItem>
-  > {
+    > {
     const testSuites = await vscode.workspace.findFiles(
       '**/*.testSuite-meta.xml'
     );
@@ -81,35 +82,59 @@ export class TestsSelector
   }
 }
 
+export class ForceApexTestRunCommandFactory {
+  private _data: ApexTestQuickPickItem;
+  private _getCodeCoverage: boolean;
+  private builder: SfdxCommandBuilder = new SfdxCommandBuilder();
+  private testRunExecutorCommand: Command;
+
+  constructor(data: ApexTestQuickPickItem, getCodeCoverage: boolean) {
+    this._data = data;
+    this._getCodeCoverage = getCodeCoverage;
+  }
+
+  public constructExecutorCommand(): Command {
+    this.builder = this.builder
+      .withDescription(nls.localize('force_apex_test_run_text'))
+      .withArg('force:apex:test:run');
+
+    switch (this._data.type) {
+      case TestType.Suite:
+        this.builder = this.builder
+          .withFlag('--suitenames', `${this._data.label}`);
+        break;
+      case TestType.Class:
+        this.builder = this.builder
+          .withFlag('--classnames', `${this._data.label}`);
+        break;
+      default:
+        break;
+    }
+
+    if (this._getCodeCoverage) {
+      this.builder = this.builder
+        .withArg('--codecoverage');
+    }
+
+    this.builder = this.builder
+      .withFlag('--resultformat', 'human')
+      .withArg('--synchronous')
+      .withFlag('--loglevel', 'error');
+
+    this.testRunExecutorCommand = this.builder.build();
+    return this.testRunExecutorCommand;
+  }
+
+}
+
 export class ForceApexTestRunExecutor extends SfdxCommandletExecutor<
   ApexTestQuickPickItem
-> {
+  > {
   public build(data: ApexTestQuickPickItem): Command {
-    if (data.type === TestType.Suite) {
-      return new SfdxCommandBuilder()
-        .withDescription(nls.localize('force_apex_test_run_text'))
-        .withArg('force:apex:test:run')
-        .withFlag('--suitenames', `${data.label}`)
-        .withFlag('--resultformat', 'human')
-        .withFlag('--loglevel', 'error')
-        .build();
-    } else if (data.type === TestType.Class) {
-      return new SfdxCommandBuilder()
-        .withDescription(nls.localize('force_apex_test_run_text'))
-        .withArg('force:apex:test:run')
-        .withFlag('--classnames', `${data.label}`)
-        .withFlag('--resultformat', 'human')
-        .withArg('--synchronous')
-        .withFlag('--loglevel', 'error')
-        .build();
-    } else {
-      return new SfdxCommandBuilder()
-        .withDescription(nls.localize('force_apex_test_run_text'))
-        .withArg('force:apex:test:run')
-        .withFlag('--resultformat', 'human')
-        .withFlag('--loglevel', 'error')
-        .build();
-    }
+    const getCodeCoverage: boolean = SfdxCoreSettings.getInstance()
+      .getConfiguration().get('retrieve-test-code-coverage') as boolean;
+    const factory: ForceApexTestRunCommandFactory = new ForceApexTestRunCommandFactory(data, getCodeCoverage);
+    return factory.constructExecutorCommand();
   }
 }
 

--- a/packages/salesforcedx-vscode-core/src/commands/forceApexTestRun.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexTestRun.ts
@@ -105,7 +105,8 @@ export class ForceApexTestRunCommandFactory {
         break;
       case TestType.Class:
         this.builder = this.builder
-          .withFlag('--classnames', `${this._data.label}`);
+          .withFlag('--classnames', `${this._data.label}`)
+          .withArg('--synchronous');
         break;
       default:
         break;
@@ -118,7 +119,6 @@ export class ForceApexTestRunCommandFactory {
 
     this.builder = this.builder
       .withFlag('--resultformat', 'human')
-      .withArg('--synchronous')
       .withFlag('--loglevel', 'error');
 
     this.testRunExecutorCommand = this.builder.build();

--- a/packages/salesforcedx-vscode-core/src/commands/forceApexTestRunCodeAction.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexTestRunCodeAction.ts
@@ -12,6 +12,7 @@ import {
 import * as vscode from 'vscode';
 import { nls } from '../messages';
 import { notificationService } from '../notifications';
+import { SfdxCoreSettings } from '../settings/sfdxCoreSettings';
 import {
   EmptyParametersGatherer,
   SfdxCommandlet,
@@ -60,14 +61,17 @@ const forceApexTestRunCacheService = ForceApexTestRunCacheService.getInstance();
 // build force:apex:test:run w/ given test class or test method
 export class ForceApexTestRunCodeActionExecutor extends SfdxCommandletExecutor<{}> {
   private test: string;
+  private shouldGetCodeCoverage: boolean = false;
+  private builder: SfdxCommandBuilder = new SfdxCommandBuilder();
 
-  public constructor(test: string) {
+  public constructor(test: string, shouldGetCodeCoverage: boolean) {
     super();
     this.test = test || '';
+    this.shouldGetCodeCoverage = shouldGetCodeCoverage;
   }
 
   public build(data: {}): Command {
-    return new SfdxCommandBuilder()
+    this.builder = this.builder
       .withDescription(
         nls.localize('force_apex_test_run_codeAction_description_text')
       )
@@ -75,16 +79,23 @@ export class ForceApexTestRunCodeActionExecutor extends SfdxCommandletExecutor<{
       .withFlag('--tests', this.test)
       .withFlag('--resultformat', 'human')
       .withArg('--synchronous')
-      .withFlag('--loglevel', 'error')
-      .build();
+      .withFlag('--loglevel', 'error');
+
+    if (this.shouldGetCodeCoverage) {
+      this.builder = this.builder.withArg('--codecoverage');
+    }
+
+    return this.builder.build();
   }
 }
 
 async function forceApexTestRunCodeAction(test: string) {
+  const getCodeCoverage: boolean = SfdxCoreSettings.getInstance()
+    .getConfiguration().get('retrieve-test-code-coverage') as boolean;
   const commandlet = new SfdxCommandlet(
     new SfdxWorkspaceChecker(),
     new EmptyParametersGatherer(),
-    new ForceApexTestRunCodeActionExecutor(test)
+    new ForceApexTestRunCodeActionExecutor(test, getCodeCoverage)
   );
   await commandlet.run();
 }

--- a/packages/salesforcedx-vscode-core/src/commands/forceApexTestRunCodeAction.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexTestRunCodeAction.ts
@@ -12,7 +12,7 @@ import {
 import * as vscode from 'vscode';
 import { nls } from '../messages';
 import { notificationService } from '../notifications';
-import { SfdxCoreSettings } from '../settings/sfdxCoreSettings';
+import { sfdxCoreSettings } from '../settings';
 import {
   EmptyParametersGatherer,
   SfdxCommandlet,
@@ -90,8 +90,9 @@ export class ForceApexTestRunCodeActionExecutor extends SfdxCommandletExecutor<{
 }
 
 async function forceApexTestRunCodeAction(test: string) {
-  const getCodeCoverage: boolean = SfdxCoreSettings.getInstance()
-    .getConfiguration().get('retrieve-test-code-coverage') as boolean;
+  const getCodeCoverage: boolean = sfdxCoreSettings
+    .getConfiguration()
+    .get('retrieve-test-code-coverage') as boolean;
   const commandlet = new SfdxCommandlet(
     new SfdxWorkspaceChecker(),
     new EmptyParametersGatherer(),

--- a/packages/salesforcedx-vscode-core/test/channels/index.test.ts
+++ b/packages/salesforcedx-vscode-core/test/channels/index.test.ts
@@ -76,7 +76,9 @@ describe('Channel', () => {
           resolve();
         });
       });
-      expect(mChannel.value).to.contain('Usage: sfdx force');
+      expect(mChannel.value).to.contain(
+        'sfdx force: [-v] [--json] [--loglevel <string>]'
+      );
       expect(mChannel.value).to.contain('ended with exit code 0');
     });
 

--- a/packages/salesforcedx-vscode-core/test/commands/forceApexTestRun.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceApexTestRun.test.ts
@@ -43,7 +43,7 @@ describe('Force Apex Test Run', () => {
       });
 
       expect(command.toCommand()).to.equal(
-        'sfdx force:apex:test:run --classnames MyTestClass --resultformat human --synchronous --loglevel error'
+        'sfdx force:apex:test:run --classnames MyTestClass --synchronous --resultformat human --loglevel error'
       );
       expect(command.description).to.equal(
         nls.localize('force_apex_test_run_text')
@@ -70,7 +70,6 @@ describe('Force Apex Test Run', () => {
 
   describe('Tests selector', () => {
     let quickPickStub: sinon.SinonStub;
-
     beforeEach(() => {
       quickPickStub = sinon.stub(vscode.window, 'showQuickPick').returns({
         label: nls.localize('force_apex_test_run_all_test_label'),

--- a/packages/salesforcedx-vscode-core/test/commands/forceApexTestRunCodeAction.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceApexTestRunCodeAction.test.ts
@@ -20,7 +20,7 @@ function getUndefined(): any {
 describe('Force Apex Test Run - Code Action', () => {
   describe('Command builder - Test Class', () => {
     const testClass = 'MyTests';
-    const builder = new ForceApexTestRunCodeActionExecutor(testClass);
+    const builder = new ForceApexTestRunCodeActionExecutor(testClass, false);
 
     it('Should build command for single test class', () => {
       const command = builder.build({});
@@ -31,15 +31,41 @@ describe('Force Apex Test Run - Code Action', () => {
     });
   });
 
+  describe('Command builder - Test Class with Coverage', () => {
+    const testClass = 'MyTests';
+    const builder = new ForceApexTestRunCodeActionExecutor(testClass, true);
+
+    it('Should build command for single test class with code coverage', () => {
+      const command = builder.build({});
+
+      expect(command.toCommand()).to.equal(
+        `sfdx force:apex:test:run --tests ${testClass} --resultformat human --synchronous --loglevel error --codecoverage`
+      );
+    });
+  });
+
   describe('Command builder - Test Method', () => {
     const testMethod = 'MyTests.testMe';
-    const builder = new ForceApexTestRunCodeActionExecutor(testMethod);
+    const builder = new ForceApexTestRunCodeActionExecutor(testMethod, false);
 
     it('Should build command for single test method', () => {
       const command = builder.build({});
 
       expect(command.toCommand()).to.equal(
         `sfdx force:apex:test:run --tests ${testMethod} --resultformat human --synchronous --loglevel error`
+      );
+    });
+  });
+
+  describe('Command builder - Test Method with Coverage', () => {
+    const testMethod = 'MyTests.testMe';
+    const builder = new ForceApexTestRunCodeActionExecutor(testMethod, true);
+
+    it('Should build command for single test method with code coverage', () => {
+      const command = builder.build({});
+
+      expect(command.toCommand()).to.equal(
+        `sfdx force:apex:test:run --tests ${testMethod} --resultformat human --synchronous --loglevel error --codecoverage`
       );
     });
   });


### PR DESCRIPTION
### What does this PR do?
Adds a configuration flag indicating whether code coverage should be retrieved when running Apex Unit Tests (@vazexqi  - this is a replacement for the previous pull request - this one is cleaner without all of the messy history).

### What issues does this PR fix or reference?
#473