### PR TITLE
Wrap environment setup for isv debugger in a try-catch

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
@@ -656,14 +656,14 @@ export async function setupGlobalDefaultUserIsvAuth() {
         ENV_SFDX_INSTANCE_URL,
         isvDebuggerUrl
       );
-      console.log(
-        'Configured SFDX_DEFAULTUSERNAME and SFDX_INSTANCE_URL for ISV Project Authentication'
-      );
       // enable ISV project
       vscode.commands.executeCommand(
         'setContext',
         'sfdx:isv_debug_project',
         true
+      );
+      console.log(
+        `Configured ${ENV_SFDX_DEFAULTUSERNAME} and ${ENV_SFDX_INSTANCE_URL} for ISV Project Authentication`
       );
       return;
     } else {
@@ -673,10 +673,14 @@ export async function setupGlobalDefaultUserIsvAuth() {
         'sfdx:isv_debug_project',
         false
       );
+      console.log('Project is not for ISV Debugger');
     }
   }
 
   // reset any auth
   GlobalCliEnvironment.environmentVariables.delete(ENV_SFDX_DEFAULTUSERNAME);
   GlobalCliEnvironment.environmentVariables.delete(ENV_SFDX_INSTANCE_URL);
+  console.log(
+    `Deleted environment variables ${ENV_SFDX_DEFAULTUSERNAME} and ${ENV_SFDX_INSTANCE_URL}`
+  );
 }

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -5,8 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { ConfigurationTarget } from 'vscode';
 import * as vscode from 'vscode';
+import { ConfigurationTarget } from 'vscode';
 import { channelService } from './channels';
 import {
   CompositeParametersGatherer,

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -374,11 +374,13 @@ export async function activate(context: vscode.ExtensionContext) {
     sfdxApexDebuggerExtension && sfdxApexDebuggerExtension.id
   );
   if (sfdxApexDebuggerExtension && sfdxApexDebuggerExtension.id) {
+    console.log('Setting up ISV Debugger environment variables');
     // register watcher for ISV authentication and setup default user for CLI
     // this is done in core because it shares access to GlobalCliEnvironment with the commands
     // (VS Code does not seem to allow sharing npm modules between extensions)
     try {
       context.subscriptions.push(registerIsvAuthWatcher());
+      console.log('Configured file watcher for **/.sfdx/sfdx-config.json');
       await setupGlobalDefaultUserIsvAuth();
     } catch (e) {
       console.error(e);

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -5,8 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import * as vscode from 'vscode';
 import { ConfigurationTarget } from 'vscode';
+import * as vscode from 'vscode';
 import { channelService } from './channels';
 import {
   CompositeParametersGatherer,
@@ -60,6 +60,7 @@ import {
   TERMINAL_INTEGRATED_ENVS
 } from './constants';
 import * as decorators from './decorators';
+import { nls } from './messages';
 import { isDemoMode } from './modes/demo-mode';
 import { notificationService } from './notifications';
 import { CANCEL_EXECUTION_COMMAND, cancelCommandExecution } from './statuses';
@@ -376,8 +377,15 @@ export async function activate(context: vscode.ExtensionContext) {
     // register watcher for ISV authentication and setup default user for CLI
     // this is done in core because it shares access to GlobalCliEnvironment with the commands
     // (VS Code does not seem to allow sharing npm modules between extensions)
-    context.subscriptions.push(registerIsvAuthWatcher());
-    await setupGlobalDefaultUserIsvAuth();
+    try {
+      context.subscriptions.push(registerIsvAuthWatcher());
+      await setupGlobalDefaultUserIsvAuth();
+    } catch (e) {
+      console.error(e);
+      vscode.window.showWarningMessage(
+        nls.localize('isv_debug_config_environment_error')
+      );
+    }
   }
 
   // Commands

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -152,7 +152,7 @@ export const messages = {
   isv_debug_bootstrap_open_project:
     'Opening project in new Visual Studio Code window',
   isv_debug_config_environment_error:
-    'There was a problem configuring the environment for ISV Customer Debugger. Some features may not work. See VS Code Developer Tools and Salesforce CLI logs for details.',
+    'Salesforce Extensions for VS Code encountered a problem while configuring your environment. Some features might not work. For details, click Help > Toggle Developer Tools or check the Salesforce CLI logs in ~/.sfdx/sfdx.log.',
 
   force_apex_log_get_text: 'SFDX: Get Apex Debug Logs...',
   force_apex_log_get_no_logs_text: 'No Apex debug logs were found',

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -151,6 +151,8 @@ export const messages = {
   isv_debug_bootstrap_generate_launchjson: 'Creating launch configuration',
   isv_debug_bootstrap_open_project:
     'Opening project in new Visual Studio Code window',
+  isv_debug_config_environment_error:
+    'There was a problem configuring the environment for ISV Customer Debugger. Some features may not work. See VS Code Developer Tools and Salesforce CLI logs for details.',
 
   force_apex_log_get_text: 'SFDX: Get Apex Debug Logs...',
   force_apex_log_get_no_logs_text: 'No Apex debug logs were found',


### PR DESCRIPTION
### What does this PR do?
salesforcedx-vscode-core does some environment setup for ISV Debugger. The setup allows SFDX commands to work in an ISV Debugger project. If there's an exception during the setup, it prevents salesforcedx-vscode-core extension to activate, therefore other extensions that depend on it also fail to activate.

So, this just catches the error, outputs it to a console in VS Code Developer Tools, and tells the user there was a problem with the setup. If there's an error, the user can still start and use the isv debugger, but SFDX commands won't work.

### What issues does this PR fix or reference?
@W-5093261@