### PR TITLE
Specify document selector

### DIFF
--- a/packages/salesforcedx-visualforce-language-server/src/visualforceServer.ts
+++ b/packages/salesforcedx-visualforce-language-server/src/visualforceServer.ts
@@ -200,7 +200,7 @@ connection.onDidChangeConfiguration(change => {
     if (enableFormatter) {
       if (!formatterRegistration) {
         const documentSelector: DocumentSelector = [
-          { language: 'visualforce' }
+          { language: 'visualforce', scheme: 'file' }
         ];
         formatterRegistration = connection.client.register(
           DocumentRangeFormattingRequest.type,

--- a/packages/salesforcedx-vscode-apex/src/languageServer.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageServer.ts
@@ -116,7 +116,7 @@ export async function createLanguageServer(
 ): Promise<LanguageClient> {
   const clientOptions: LanguageClientOptions = {
     // Register the server for Apex documents
-    documentSelector: ['apex'],
+    documentSelector: [{ language: 'apex', scheme: 'file' }],
     synchronize: {
       configurationSection: 'apex',
       fileEvents: [

--- a/packages/salesforcedx-vscode-lwc-next/src/index.ts
+++ b/packages/salesforcedx-vscode-lwc-next/src/index.ts
@@ -127,7 +127,10 @@ function startLWCLanguageServer(
     }
   };
   const clientOptions: LanguageClientOptions = {
-    documentSelector: ['html', 'javascript'],
+    documentSelector: [
+      { language: 'html', scheme: 'file' },
+      { language: 'javascript', scheme: 'file' }
+    ],
     synchronize: {
       fileEvents: [
         vscode.workspace.createFileSystemWatcher('**/*.resource'),

--- a/packages/salesforcedx-vscode-lwc/src/index.ts
+++ b/packages/salesforcedx-vscode-lwc/src/index.ts
@@ -134,7 +134,10 @@ function startLWCLanguageServer(
     }
   };
   const clientOptions: LanguageClientOptions = {
-    documentSelector: ['html', 'javascript'],
+    documentSelector: [
+      { language: 'html', scheme: 'file' },
+      { language: 'javascript', scheme: 'file' }
+    ],
     synchronize: {
       fileEvents: [
         vscode.workspace.createFileSystemWatcher('**/*.resource'),

--- a/packages/salesforcedx-vscode-visualforce/src/extension.ts
+++ b/packages/salesforcedx-vscode-visualforce/src/extension.ts
@@ -73,7 +73,12 @@ export function activate(context: ExtensionContext) {
     }
   };
 
-  const documentSelector = ['visualforce'];
+  const documentSelector = [
+    {
+      language: 'visualforce',
+      scheme: 'file'
+    }
+  ];
   const embeddedLanguages = { css: true, javascript: true };
 
   // Options to control the language client


### PR DESCRIPTION
### What does this PR do?

Specify a document selector for Apex, Visualforce, and LWC. This follows best practice principles from https://code.visualstudio.com/docs/extensionAPI/document-selectors. 

Currently a warning only occurs when you are running from Code Insiders with debugging turned on but this is good to fix.

### What issues does this PR fix or reference?

@W-5035486@
