### PR TITLE
Added notice to github bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -4,17 +4,25 @@ about: Create a report to help us improve
 
 ---
 
+<!--
+NOTICE: While GitHub is the preferred channel for reporting issues/feedback, this is not a mechanism for receiving support under any agreement or SLA. If you require immediate assistance, please use official support channels.
+-->
+
 ### Summary
+
 _Short summary of what is going on or to provide context_.
 
 ### Steps To Reproduce:
-1. This is step 1.
-1. This is step 2. All steps should start with '1.'
+
+1.  This is step 1.
+1.  This is step 2. All steps should start with '1.'
 
 ### Expected result
+
 _Describe what should have happened_.
 
 ### Actual result
+
 _Describe what actually happened instead_.
 
 ### Additional information


### PR DESCRIPTION
### What does this PR do?
Adds a notice about github not being an official support channel.

### What issues does this PR fix or reference?
N/A
