### PR TITLE
Add SFDX: Create Change-set-based Project command

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -255,6 +255,11 @@
           "command": "sfdx.force.project.create"
         },
         {
+          "command": "sfdx.force.create.change.set.based",
+          "when":
+            "config.salesforcedx-vscode-core.change_set_based_tools.enabled"
+        },
+        {
           "command": "sfdx.force.apex.trigger.create",
           "when": "sfdx:project_opened"
         },
@@ -292,7 +297,7 @@
         {
           "command": "sfdx.force.manifest.editor.show",
           "when":
-            "sfdx:project_opened && config.salesforcedx-vscode-core.show_experimental_webviews"
+            "sfdx:project_opened && config.salesforcedx-vscode-core.change_set_based_tools.enabled"
         }
       ]
     },
@@ -438,6 +443,10 @@
         "title": "%force_project_create_text%"
       },
       {
+        "command": "sfdx.force.create.change.set.based",
+        "title": "%force_project_create_change_set_based_text%"
+      },
+      {
         "command": "sfdx.force.apex.trigger.create",
         "title": "%force_apex_trigger_create_text%"
       },
@@ -471,10 +480,10 @@
           "default": true,
           "description": "%show_cli_success_msg_description%"
         },
-        "salesforcedx-vscode-core.show_experimental_webviews": {
+        "salesforcedx-vscode-core.change_set_based_tools.enabled": {
           "type": ["boolean"],
           "default": false,
-          "description": "%show_experimental_webviews_description%"
+          "description": "%change_set_based_tools.enabled_description%"
         },
         "salesforcedx-vscode-core.retrieve-test-code-coverage": {
           "type": ["boolean"],

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -51,6 +51,8 @@
     "SFDX: Execute Anonymous Apex with Currently Selected Text",
   "feature_previews_title": "Salesforce Feature Previews",
   "force_project_create_text": "SFDX: Create Project",
+  "force_project_create_change_set_based_text":
+    "SFDX: Create Change-set-based Project",
   "force_apex_trigger_create_text": "SFDX: Create Apex Trigger",
   "show_cli_success_msg_description":
     "Specifies whether status messages for Salesforce CLI commands run using the VS Code command palette will appear as pop-up information messages (true) or as status bar messages (false).",
@@ -63,11 +65,10 @@
     "SFDX: Create and Set Up Project for ISV Debugging",
   "force_apex_log_get_text": "SFDX: Get Apex Debug Logs...",
 
-  "force_manifest_editor_show_text":
-    "SFDX: Show Package Manifest Editor (Experimental)",
-  "show_experimental_webviews_description":
-    "Specifies whether the commands for the experimental webviews are available to the user.",
-
   "retrieve_test_code_coverage_text":
-    "Specifies whether code coverage results are calculated and retrieved when you run Apex tests."
+    "Specifies whether code coverage results are calculated and retrieved when you run Apex tests.",
+
+  "change_set_based_tools.enabled_description":
+    "Specifies whether the commands for change-set-based development are available to the user.",
+  "force_manifest_editor_show_text": "SFDX: Show Package Manifest Editor"
 }

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -52,7 +52,7 @@
   "feature_previews_title": "Salesforce Feature Previews",
   "force_project_create_text": "SFDX: Create Project",
   "force_project_create_change_set_based_text":
-    "SFDX: Create Change-set-based Project",
+    "SFDX: Create Change-Set-Based Project",
   "force_apex_trigger_create_text": "SFDX: Create Apex Trigger",
   "show_cli_success_msg_description":
     "Specifies whether status messages for Salesforce CLI commands run using the VS Code command palette will appear as pop-up information messages (true) or as status bar messages (false).",

--- a/packages/salesforcedx-vscode-core/src/commands/forceProjectCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceProjectCreate.ts
@@ -31,14 +31,32 @@ import {
   SfdxCommandletExecutor
 } from './commands';
 
-export class ForceProjectCreateExecutor extends SfdxCommandletExecutor<{}> {
+type forceProjectCreateOptions = {
+  isChangeSetBasedProject: boolean;
+};
+
+export class ForceProjectCreateExecutor extends SfdxCommandletExecutor<
+  ProjectNameAndPath
+> {
+  private readonly options: forceProjectCreateOptions;
+
+  public constructor(options = { isChangeSetBasedProject: false }) {
+    super();
+    this.options = options;
+  }
+
   public build(data: ProjectNameAndPath): Command {
-    return new SfdxCommandBuilder()
+    const builder = new SfdxCommandBuilder()
       .withDescription(nls.localize('force_project_create_text'))
       .withArg('force:project:create')
       .withFlag('--projectname', data.projectName)
-      .withFlag('--outputdir', data.projectUri)
-      .build();
+      .withFlag('--outputdir', data.projectUri);
+
+    if (this.options.isChangeSetBasedProject) {
+      builder.withArg('--manifest');
+    }
+
+    return builder.build();
   }
 
   public execute(response: ContinueResponse<ProjectNameAndPath>): void {
@@ -154,14 +172,22 @@ const parameterGatherer = new CompositeParametersGatherer(
 );
 const pathExistsChecker = new PathExistsChecker();
 
-const executor = new ForceProjectCreateExecutor();
-const commandlet = new SfdxCommandlet(
+const sfdxProjectCreateCommandlet = new SfdxCommandlet(
   workspaceChecker,
   parameterGatherer,
-  executor,
+  new ForceProjectCreateExecutor(),
   pathExistsChecker
 );
+export async function forceSfdxProjectCreate() {
+  await sfdxProjectCreateCommandlet.run();
+}
 
-export async function forceProjectCreate() {
-  await commandlet.run();
+const changeSetProjectCreateCommandlet = new SfdxCommandlet(
+  workspaceChecker,
+  parameterGatherer,
+  new ForceProjectCreateExecutor({ isChangeSetBasedProject: true }),
+  pathExistsChecker
+);
+export async function forceChangeSetProjectCreate() {
+  await changeSetProjectCreateCommandlet.run();
 }

--- a/packages/salesforcedx-vscode-core/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/index.ts
@@ -43,7 +43,10 @@ export { forceDebuggerStop } from './forceDebuggerStop';
 export { forceConfigList } from './forceConfigList';
 export { forceAliasList } from './forceAliasList';
 export { forceOrgDisplay } from './forceOrgDisplay';
-export { forceProjectCreate } from './forceProjectCreate';
+export {
+  forceSfdxProjectCreate,
+  forceChangeSetProjectCreate
+} from './forceProjectCreate';
 export { forceApexTriggerCreate } from './forceApexTriggerCreate';
 export { forceStartApexDebugLogging } from './forceStartApexDebugLogging';
 export {

--- a/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
@@ -555,7 +555,7 @@ export class EnterForceIdeUri implements ParametersGatherer<ForceIdeUri> {
     }
 
     return null; // all good
-  }
+  };
 
   public forceIdUrl?: ForceIdeUri;
   public async gather(): Promise<

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -6,8 +6,8 @@
  */
 
 import * as path from 'path';
-import * as vscode from 'vscode';
 import { ConfigurationTarget } from 'vscode';
+import * as vscode from 'vscode';
 import { channelService } from './channels';
 import {
   CompositeParametersGatherer,
@@ -23,6 +23,7 @@ import {
   forceApexTriggerCreate,
   forceAuthLogoutAll,
   forceAuthWebLogin,
+  forceChangeSetProjectCreate,
   forceConfigList,
   forceDataSoqlQuery,
   forceDebuggerStop,
@@ -34,7 +35,7 @@ import {
   forceOrgCreate,
   forceOrgDisplay,
   forceOrgOpen,
-  forceProjectCreate,
+  forceSfdxProjectCreate,
   forceSourcePull,
   forceSourcePush,
   forceSourceStatus,
@@ -229,7 +230,12 @@ function registerCommands(
 
   const forceProjectCreateCmd = vscode.commands.registerCommand(
     'sfdx.force.project.create',
-    forceProjectCreate
+    forceSfdxProjectCreate
+  );
+
+  const forceChangeSetBasedProjectCreateCmd = vscode.commands.registerCommand(
+    'sfdx.force.create.change.set.based',
+    forceChangeSetProjectCreate
   );
 
   const forceApexTriggerCreateCmd = vscode.commands.registerCommand(
@@ -306,6 +312,7 @@ function registerCommands(
     forceOrgDisplayUsernameCmd,
     forceGenerateFauxClassesCmd,
     forceProjectCreateCmd,
+    forceChangeSetBasedProjectCreateCmd,
     forceApexTriggerCreateCmd,
     forceStartApexDebugLoggingCmd,
     forceStopApexDebugLoggingCmd,

--- a/packages/salesforcedx-vscode-core/test/commands/commands.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/commands.test.ts
@@ -520,7 +520,7 @@ describe('Command Utilities', () => {
     });
 
     after(() => {
-      sinon.restore(vscode.window);
+      showInformationMessageStub.restore();
     });
 
     it('Should return CONTINUE if message is Cancel', async () => {

--- a/packages/salesforcedx-vscode-core/test/commands/forceProjectCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceProjectCreate.test.ts
@@ -172,5 +172,22 @@ describe('Force Project Create', () => {
         nls.localize('force_project_create_text')
       );
     });
+
+    it('Should build the project create command for change-set-based projects', async () => {
+      const forceProjectCreateBuilder = new ForceProjectCreateExecutor({
+        isChangeSetBasedProject: true
+      });
+      const createCommand = forceProjectCreateBuilder.build({
+        projectName: PROJECT_NAME,
+        projectUri: PROJECT_DIR[0].fsPath
+      });
+      expect(createCommand.toCommand()).to.equal(
+        `sfdx force:project:create --projectname ${PROJECT_NAME} --outputdir ${PROJECT_DIR[0]
+          .fsPath} --manifest`
+      );
+      expect(createCommand.description).to.equal(
+        nls.localize('force_project_create_text')
+      );
+    });
   });
 });

--- a/packages/system-tests/src/spectron/client.ts
+++ b/packages/system-tests/src/spectron/client.ts
@@ -186,7 +186,7 @@ export class SpectronClient {
     const XTERM_SELECTOR = `${PANEL_SELECTOR} .terminal-wrapper`;
     return await this.spectron.client.selectorExecute(XTERM_SELECTOR, div => {
       const xterm = ((Array.isArray(div) ? div[0] : div) as any).xterm;
-      const buffer = xterm.buffer;
+      const buffer = xterm._core.buffer;
       const lines: string[] = [];
       for (let i = 0; i < buffer.lines.length; i++) {
         lines.push(buffer.translateBufferLineToString(i, true));

--- a/tslint.json
+++ b/tslint.json
@@ -5,6 +5,7 @@
     "no-any": false,
     "quotemark": [true, "single", "avoid-escape"],
     "member-ordering": false,
-    "no-string-based-set-timeout": false
+    "no-string-based-set-timeout": false,
+    "semicolon": [true, "always", "ignore-bound-class-methods"]
   }
 }


### PR DESCRIPTION
### What does this PR do?

Adds a command that calls out to the Salesforce CLI to generate a manifest for working with non-scratch orgs. For those curious about this feature, it requires the latest version (unpublished) of the Salesforce CLI to work.

### What issues does this PR fix or reference?

@W-5070910@
