### PR TITLE
Add SFDX: Authenticate an Org

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -138,7 +138,7 @@
         {
           "command": "sfdx.force.auth.web.login",
           "when":
-            "config.salesforcedx-vscode-core.change_set_based_tools.enabled"
+            "sfdx:project_opened && config.salesforcedx-vscode-core.change_set_based_tools.enabled"
         },
         {
           "command": "sfdx.force.auth.logout.all",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -132,8 +132,13 @@
       ],
       "commandPalette": [
         {
-          "command": "sfdx.force.auth.web.login",
+          "command": "sfdx.force.auth.dev.hub",
           "when": "sfdx:project_opened"
+        },
+        {
+          "command": "sfdx.force.auth.web.login",
+          "when":
+            "config.salesforcedx-vscode-core.change_set_based_tools.enabled"
         },
         {
           "command": "sfdx.force.auth.logout.all",
@@ -298,8 +303,12 @@
     },
     "commands": [
       {
-        "command": "sfdx.force.auth.web.login",
+        "command": "sfdx.force.auth.dev.hub",
         "title": "%force_auth_web_login_authorize_dev_hub_text%"
+      },
+      {
+        "command": "sfdx.force.auth.web.login",
+        "title": "%force_auth_web_login_authorize_org_text%"
       },
       {
         "command": "sfdx.force.auth.logout.all",

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -1,74 +1,50 @@
 {
   "running_tasks_title_text": "Running Tasks",
-
   "force_auth_web_login_authorize_dev_hub_text": "SFDX: Authorize a Dev Hub",
+  "force_auth_web_login_authorize_org_text": "SFDX: Authorize an Org",
   "force_auth_logout_all_text": "SFDX: Log Out from All Authorized Orgs",
-  "force_org_create_default_scratch_org_text":
-    "SFDX: Create a Default Scratch Org...",
+  "force_org_create_default_scratch_org_text": "SFDX: Create a Default Scratch Org...",
   "force_org_open_default_scratch_org_text": "SFDX: Open Default Scratch Org",
-  "force_source_pull_default_scratch_org_text":
-    "SFDX: Pull Source from Default Scratch Org",
-  "force_source_pull_force_default_scratch_org_text":
-    "SFDX: Pull Source from Default Scratch Org and Override Conflicts",
-  "force_source_push_default_scratch_org_text":
-    "SFDX: Push Source to Default Scratch Org",
-  "force_source_push_force_default_scratch_org_text":
-    "SFDX: Push Source to Default Scratch Org and Override Conflicts",
-  "force_source_status_text":
-    "SFDX: View All Changes (Local and in Default Scratch Org)",
+  "force_source_pull_default_scratch_org_text": "SFDX: Pull Source from Default Scratch Org",
+  "force_source_pull_force_default_scratch_org_text": "SFDX: Pull Source from Default Scratch Org and Override Conflicts",
+  "force_source_push_default_scratch_org_text": "SFDX: Push Source to Default Scratch Org",
+  "force_source_push_force_default_scratch_org_text": "SFDX: Push Source to Default Scratch Org and Override Conflicts",
+  "force_source_status_text": "SFDX: View All Changes (Local and in Default Scratch Org)",
   "force_apex_test_run_text": "SFDX: Invoke Apex Tests...",
   "force_apex_test_class_run_text": "SFDX: Invoke Apex Test Class",
   "force_apex_test_method_run_text": "SFDX: Invoke Apex Test Method",
-  "force_apex_test_last_class_run_text":
-    "SFDX: Re-Run Last Invoked Apex Test Class",
-  "force_apex_test_last_method_run_text":
-    "SFDX: Re-Run Last Invoked Apex Test Method",
+  "force_apex_test_last_class_run_text": "SFDX: Re-Run Last Invoked Apex Test Class",
+  "force_apex_test_last_method_run_text": "SFDX: Re-Run Last Invoked Apex Test Method",
   "cancel_sfdx_command_text": "SFDX: Cancel Active Command",
   "force_apex_class_create_text": "SFDX: Create Apex Class",
-  "force_visualforce_component_create_text":
-    "SFDX: Create Visualforce Component",
+  "force_visualforce_component_create_text": "SFDX: Create Visualforce Component",
   "force_visualforce_page_create_text": "SFDX: Create Visualforce Page",
   "force_lightning_app_create_text": "SFDX: Create Lightning App",
   "force_lightning_component_create_text": "SFDX: Create Lightning Component",
   "force_lightning_event_create_text": "SFDX: Create Lightning Event",
   "force_lightning_interface_create_text": "SFDX: Create Lightning Interface",
   "force_source_status_local_text": "SFDX: View Local Changes",
-  "force_source_status_remote_text":
-    "SFDX: View Changes in Default Scratch Org",
+  "force_source_status_remote_text": "SFDX: View Changes in Default Scratch Org",
   "force_debugger_stop_text": "SFDX: Stop Apex Debugger Session",
   "force_config_list_text": "SFDX: List All Config Variables",
   "force_alias_list_text": "SFDX: List All Aliases",
-  "force_org_display_default_text":
-    "SFDX: Display Org Details for Default Scratch Org",
+  "force_org_display_default_text": "SFDX: Display Org Details for Default Scratch Org",
   "force_org_display_username_text": "SFDX: Display Org Details...",
   "force_sobjects_refresh": "SFDX: Refresh SObject Definitions",
   "force_data_soql_query_input_text": "SFDX: Execute SOQL Query...",
-  "force_data_soql_query_selection_text":
-    "SFDX: Execute SOQL Query with Currently Selected Text",
-  "force_apex_execute_document_text":
-    "SFDX: Execute Anonymous Apex with Editor Contents",
-  "force_apex_execute_selection_text":
-    "SFDX: Execute Anonymous Apex with Currently Selected Text",
+  "force_data_soql_query_selection_text": "SFDX: Execute SOQL Query with Currently Selected Text",
+  "force_apex_execute_document_text": "SFDX: Execute Anonymous Apex with Editor Contents",
+  "force_apex_execute_selection_text": "SFDX: Execute Anonymous Apex with Currently Selected Text",
   "feature_previews_title": "Salesforce Feature Previews",
   "force_project_create_text": "SFDX: Create Project",
-  "force_project_create_change_set_based_text":
-    "SFDX: Create Change-Set-Based Project",
+  "force_project_create_change_set_based_text": "SFDX: Create Change-Set-Based Project",
   "force_apex_trigger_create_text": "SFDX: Create Apex Trigger",
-  "show_cli_success_msg_description":
-    "Specifies whether status messages for Salesforce CLI commands run using the VS Code command palette will appear as pop-up information messages (true) or as status bar messages (false).",
-  "force_start_apex_debug_logging":
-    "SFDX: Turn On Apex Debug Log for Replay Debugger",
-  "force_stop_apex_debug_logging":
-    "SFDX: Turn Off Apex Debug Log for Replay Debugger",
-
-  "isv_bootstrap_command_text":
-    "SFDX: Create and Set Up Project for ISV Debugging",
+  "show_cli_success_msg_description": "Specifies whether status messages for Salesforce CLI commands run using the VS Code command palette will appear as pop-up information messages (true) or as status bar messages (false).",
+  "force_start_apex_debug_logging": "SFDX: Turn On Apex Debug Log for Replay Debugger",
+  "force_stop_apex_debug_logging": "SFDX: Turn Off Apex Debug Log for Replay Debugger",
+  "isv_bootstrap_command_text": "SFDX: Create and Set Up Project for ISV Debugging",
   "force_apex_log_get_text": "SFDX: Get Apex Debug Logs...",
-
-  "retrieve_test_code_coverage_text":
-    "Specifies whether code coverage results are calculated and retrieved when you run Apex tests.",
-
-  "change_set_based_tools.enabled_description":
-    "Specifies whether the commands for change-set-based development are available to the user.",
+  "retrieve_test_code_coverage_text": "Specifies whether code coverage results are calculated and retrieved when you run Apex tests.",
+  "change_set_based_tools.enabled_description": "Specifies whether the commands for change-set-based development are available to the user.",
   "force_manifest_editor_show_text": "SFDX: Show Package Manifest Editor"
 }

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -3,48 +3,69 @@
   "force_auth_web_login_authorize_dev_hub_text": "SFDX: Authorize a Dev Hub",
   "force_auth_web_login_authorize_org_text": "SFDX: Authorize an Org",
   "force_auth_logout_all_text": "SFDX: Log Out from All Authorized Orgs",
-  "force_org_create_default_scratch_org_text": "SFDX: Create a Default Scratch Org...",
+  "force_org_create_default_scratch_org_text":
+    "SFDX: Create a Default Scratch Org...",
   "force_org_open_default_scratch_org_text": "SFDX: Open Default Scratch Org",
-  "force_source_pull_default_scratch_org_text": "SFDX: Pull Source from Default Scratch Org",
-  "force_source_pull_force_default_scratch_org_text": "SFDX: Pull Source from Default Scratch Org and Override Conflicts",
-  "force_source_push_default_scratch_org_text": "SFDX: Push Source to Default Scratch Org",
-  "force_source_push_force_default_scratch_org_text": "SFDX: Push Source to Default Scratch Org and Override Conflicts",
-  "force_source_status_text": "SFDX: View All Changes (Local and in Default Scratch Org)",
+  "force_source_pull_default_scratch_org_text":
+    "SFDX: Pull Source from Default Scratch Org",
+  "force_source_pull_force_default_scratch_org_text":
+    "SFDX: Pull Source from Default Scratch Org and Override Conflicts",
+  "force_source_push_default_scratch_org_text":
+    "SFDX: Push Source to Default Scratch Org",
+  "force_source_push_force_default_scratch_org_text":
+    "SFDX: Push Source to Default Scratch Org and Override Conflicts",
+  "force_source_status_text":
+    "SFDX: View All Changes (Local and in Default Scratch Org)",
   "force_apex_test_run_text": "SFDX: Invoke Apex Tests...",
   "force_apex_test_class_run_text": "SFDX: Invoke Apex Test Class",
   "force_apex_test_method_run_text": "SFDX: Invoke Apex Test Method",
-  "force_apex_test_last_class_run_text": "SFDX: Re-Run Last Invoked Apex Test Class",
-  "force_apex_test_last_method_run_text": "SFDX: Re-Run Last Invoked Apex Test Method",
+  "force_apex_test_last_class_run_text":
+    "SFDX: Re-Run Last Invoked Apex Test Class",
+  "force_apex_test_last_method_run_text":
+    "SFDX: Re-Run Last Invoked Apex Test Method",
   "cancel_sfdx_command_text": "SFDX: Cancel Active Command",
   "force_apex_class_create_text": "SFDX: Create Apex Class",
-  "force_visualforce_component_create_text": "SFDX: Create Visualforce Component",
+  "force_visualforce_component_create_text":
+    "SFDX: Create Visualforce Component",
   "force_visualforce_page_create_text": "SFDX: Create Visualforce Page",
   "force_lightning_app_create_text": "SFDX: Create Lightning App",
   "force_lightning_component_create_text": "SFDX: Create Lightning Component",
   "force_lightning_event_create_text": "SFDX: Create Lightning Event",
   "force_lightning_interface_create_text": "SFDX: Create Lightning Interface",
   "force_source_status_local_text": "SFDX: View Local Changes",
-  "force_source_status_remote_text": "SFDX: View Changes in Default Scratch Org",
+  "force_source_status_remote_text":
+    "SFDX: View Changes in Default Scratch Org",
   "force_debugger_stop_text": "SFDX: Stop Apex Debugger Session",
   "force_config_list_text": "SFDX: List All Config Variables",
   "force_alias_list_text": "SFDX: List All Aliases",
-  "force_org_display_default_text": "SFDX: Display Org Details for Default Scratch Org",
+  "force_org_display_default_text":
+    "SFDX: Display Org Details for Default Scratch Org",
   "force_org_display_username_text": "SFDX: Display Org Details...",
   "force_sobjects_refresh": "SFDX: Refresh SObject Definitions",
   "force_data_soql_query_input_text": "SFDX: Execute SOQL Query...",
-  "force_data_soql_query_selection_text": "SFDX: Execute SOQL Query with Currently Selected Text",
-  "force_apex_execute_document_text": "SFDX: Execute Anonymous Apex with Editor Contents",
-  "force_apex_execute_selection_text": "SFDX: Execute Anonymous Apex with Currently Selected Text",
+  "force_data_soql_query_selection_text":
+    "SFDX: Execute SOQL Query with Currently Selected Text",
+  "force_apex_execute_document_text":
+    "SFDX: Execute Anonymous Apex with Editor Contents",
+  "force_apex_execute_selection_text":
+    "SFDX: Execute Anonymous Apex with Currently Selected Text",
   "feature_previews_title": "Salesforce Feature Previews",
   "force_project_create_text": "SFDX: Create Project",
-  "force_project_create_change_set_based_text": "SFDX: Create Change-Set-Based Project",
+  "force_project_create_change_set_based_text":
+    "SFDX: Create Change-Set-Based Project",
   "force_apex_trigger_create_text": "SFDX: Create Apex Trigger",
-  "show_cli_success_msg_description": "Specifies whether status messages for Salesforce CLI commands run using the VS Code command palette will appear as pop-up information messages (true) or as status bar messages (false).",
-  "force_start_apex_debug_logging": "SFDX: Turn On Apex Debug Log for Replay Debugger",
-  "force_stop_apex_debug_logging": "SFDX: Turn Off Apex Debug Log for Replay Debugger",
-  "isv_bootstrap_command_text": "SFDX: Create and Set Up Project for ISV Debugging",
+  "show_cli_success_msg_description":
+    "Specifies whether status messages for Salesforce CLI commands run using the VS Code command palette will appear as pop-up information messages (true) or as status bar messages (false).",
+  "force_start_apex_debug_logging":
+    "SFDX: Turn On Apex Debug Log for Replay Debugger",
+  "force_stop_apex_debug_logging":
+    "SFDX: Turn Off Apex Debug Log for Replay Debugger",
+  "isv_bootstrap_command_text":
+    "SFDX: Create and Set Up Project for ISV Debugging",
   "force_apex_log_get_text": "SFDX: Get Apex Debug Logs...",
-  "retrieve_test_code_coverage_text": "Specifies whether code coverage results are calculated and retrieved when you run Apex tests.",
-  "change_set_based_tools.enabled_description": "Specifies whether the commands for change-set-based development are available to the user.",
+  "retrieve_test_code_coverage_text":
+    "Specifies whether code coverage results are calculated and retrieved when you run Apex tests.",
+  "change_set_based_tools.enabled_description":
+    "Specifies whether the commands for change-set-based development are available to the user.",
   "force_manifest_editor_show_text": "SFDX: Show Package Manifest Editor"
 }

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -1,5 +1,6 @@
 {
   "running_tasks_title_text": "Running Tasks",
+
   "force_auth_web_login_authorize_dev_hub_text": "SFDX: Authorize a Dev Hub",
   "force_auth_web_login_authorize_org_text": "SFDX: Authorize an Org",
   "force_auth_logout_all_text": "SFDX: Log Out from All Authorized Orgs",
@@ -60,11 +61,14 @@
     "SFDX: Turn On Apex Debug Log for Replay Debugger",
   "force_stop_apex_debug_logging":
     "SFDX: Turn Off Apex Debug Log for Replay Debugger",
+
   "isv_bootstrap_command_text":
     "SFDX: Create and Set Up Project for ISV Debugging",
   "force_apex_log_get_text": "SFDX: Get Apex Debug Logs...",
+
   "retrieve_test_code_coverage_text":
     "Specifies whether code coverage results are calculated and retrieved when you run Apex tests.",
+
   "change_set_based_tools.enabled_description":
     "Specifies whether the commands for change-set-based development are available to the user.",
   "force_manifest_editor_show_text": "SFDX: Show Package Manifest Editor"

--- a/packages/salesforcedx-vscode-core/src/commands/forceAuthDevHub.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceAuthDevHub.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  Command,
+  SfdxCommandBuilder
+} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+
+import {
+  EmptyParametersGatherer,
+  SfdxCommandlet,
+  SfdxCommandletExecutor,
+  SfdxWorkspaceChecker
+} from './commands';
+import { ForceAuthDemoModeExecutor } from './forceAuthWebLogin';
+
+import { nls } from '../messages';
+import { isDemoMode } from '../modes/demo-mode';
+
+export class ForceAuthDevHubExecutor extends SfdxCommandletExecutor<{}> {
+  public build(data: {}): Command {
+    return new SfdxCommandBuilder()
+      .withDescription(
+        nls.localize('force_auth_web_login_authorize_dev_hub_text')
+      )
+      .withArg('force:auth:web:login')
+      .withArg('--setdefaultdevhubusername')
+      .build();
+  }
+}
+
+export class ForceAuthDevHubDemoModeExecutor extends ForceAuthDemoModeExecutor<{}> {
+  public build(data: {}): Command {
+    return new SfdxCommandBuilder()
+      .withDescription(
+        nls.localize('force_auth_web_login_authorize_dev_hub_text')
+      )
+      .withArg('force:auth:web:login')
+      .withArg('--setdefaultdevhubusername')
+      .withArg('--noprompt')
+      .withJson()
+      .build();
+  }
+}
+
+const workspaceChecker = new SfdxWorkspaceChecker();
+const parameterGatherer = new EmptyParametersGatherer();
+
+export function createExecutor(): SfdxCommandletExecutor<{}> {
+  return isDemoMode()
+    ? new ForceAuthDevHubDemoModeExecutor()
+    : new ForceAuthDevHubExecutor();
+}
+
+export async function forceAuthDevHub() {
+  const commandlet = new SfdxCommandlet(
+    workspaceChecker,
+    parameterGatherer,
+    createExecutor()
+  );
+  await commandlet.run();
+}

--- a/packages/salesforcedx-vscode-core/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/index.ts
@@ -15,6 +15,7 @@ export {
 } from './commands';
 export { forceApexExecute } from './forceApexExecute';
 export { forceAuthWebLogin } from './forceAuthWebLogin';
+export { forceAuthDevHub } from './forceAuthDevHub';
 export { forceApexTestRun } from './forceApexTestRun';
 export {
   forceApexTestClassRunCodeAction,

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
@@ -21,6 +22,7 @@ import {
   forceApexTestMethodRunCodeActionDelegate,
   forceApexTestRun,
   forceApexTriggerCreate,
+  forceAuthDevHub,
   forceAuthLogoutAll,
   forceAuthWebLogin,
   forceChangeSetProjectCreate,
@@ -75,6 +77,10 @@ function registerCommands(
   const forceAuthWebLoginCmd = vscode.commands.registerCommand(
     'sfdx.force.auth.web.login',
     forceAuthWebLogin
+  );
+  const forceAuthDevHubCmd = vscode.commands.registerCommand(
+    'sfdx.force.auth.dev.hub',
+    forceAuthDevHub
   );
   const forceAuthLogoutAllCmd = vscode.commands.registerCommand(
     'sfdx.force.auth.logout.all',
@@ -279,6 +285,7 @@ function registerCommands(
     forceApexTestMethodRunCmd,
     forceApexTestMethodRunDelegateCmd,
     forceAuthWebLoginCmd,
+    forceAuthDevHubCmd,
     forceAuthLogoutAllCmd,
     forceDataSoqlQueryInputCmd,
     forceDataSoqlQuerySelectionCmd,

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -41,6 +41,7 @@ export const messages = {
   status_bar_tooltip: 'Click to cancel the command',
 
   force_auth_web_login_authorize_dev_hub_text: 'SFDX: Authorize a Dev Hub',
+  force_auth_web_login_authorize_org_text: 'SFDX: Authorize an Org',
 
   parameter_gatherer_enter_file_name: 'Enter desired filename',
   parameter_gatherer_enter_dir_name:

--- a/packages/salesforcedx-vscode-core/test/commands/forceAuthDevHub.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceAuthDevHub.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from 'chai';
+import {
+  createExecutor,
+  ForceAuthDevHubDemoModeExecutor,
+  ForceAuthDevHubExecutor
+} from '../../src/commands/forceAuthDevHub';
+import { nls } from '../../src/messages';
+
+// tslint:disable:no-unused-expression
+describe('Force Auth Web Login for Dev Hub', () => {
+  it('Should build the auth web login command', async () => {
+    const authWebLogin = new ForceAuthDevHubExecutor();
+    const authWebLoginCommand = authWebLogin.build({});
+    expect(authWebLoginCommand.toCommand()).to.equal(
+      'sfdx force:auth:web:login --setdefaultdevhubusername'
+    );
+    expect(authWebLoginCommand.description).to.equal(
+      nls.localize('force_auth_web_login_authorize_dev_hub_text')
+    );
+  });
+});
+
+describe('Force Auth Web Login For Dev Hub in Demo  Mode', () => {
+  it('Should build the auth web login command', async () => {
+    const authWebLogin = new ForceAuthDevHubDemoModeExecutor();
+    const authWebLoginCommand = authWebLogin.build({});
+    expect(authWebLoginCommand.toCommand()).to.equal(
+      'sfdx force:auth:web:login --setdefaultdevhubusername --noprompt --json --loglevel fatal'
+    );
+    expect(authWebLoginCommand.description).to.equal(
+      nls.localize('force_auth_web_login_authorize_dev_hub_text')
+    );
+  });
+});
+
+describe('Command chosen is based on results of isDemoMode()', () => {
+  let originalValue: any;
+
+  beforeEach(() => {
+    originalValue = process.env.SFDX_ENV;
+  });
+
+  afterEach(() => {
+    process.env.SFXD_ENV = originalValue;
+  });
+
+  it('Should use ForceAuthDevHubDemoModeExecutor if demo mode is true', () => {
+    process.env.SFDX_ENV = 'DEMO';
+    expect(createExecutor() instanceof ForceAuthDevHubDemoModeExecutor).to.be
+      .true;
+  });
+
+  it('Should use ForceAuthDevHubExecutor if demo mode is false', () => {
+    process.env.SFDX_ENV = '';
+    expect(createExecutor() instanceof ForceAuthDevHubExecutor).to.be.true;
+  });
+});

--- a/packages/salesforcedx-vscode-core/test/commands/forceAuthWebLogin.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceAuthWebLogin.test.ts
@@ -6,37 +6,87 @@
  */
 
 import { expect } from 'chai';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
 import {
+  AliasGatherer,
   createExecutor,
-  ForceAuthWebDemoModeLoginExecutor,
+  DEFAULT_ALIAS,
+  ForceAuthWebLoginDemoModeExecutor,
   ForceAuthWebLoginExecutor
 } from '../../src/commands/forceAuthWebLogin';
 import { nls } from '../../src/messages';
+
+const TEST_ALIAS = 'testAlias';
 
 // tslint:disable:no-unused-expression
 describe('Force Auth Web Login', () => {
   it('Should build the auth web login command', async () => {
     const authWebLogin = new ForceAuthWebLoginExecutor();
-    const authWebLoginCommand = authWebLogin.build({});
+    const authWebLoginCommand = authWebLogin.build({ alias: TEST_ALIAS });
     expect(authWebLoginCommand.toCommand()).to.equal(
-      'sfdx force:auth:web:login --setdefaultdevhubusername'
+      `sfdx force:auth:web:login --setalias ${TEST_ALIAS} --setdefaultusername`
     );
     expect(authWebLoginCommand.description).to.equal(
-      nls.localize('force_auth_web_login_authorize_dev_hub_text')
+      nls.localize('force_auth_web_login_authorize_org_text')
     );
   });
 });
 
-describe('Force Auth Web Login for Demo  Mode', () => {
+describe('Force Auth Web Login in Demo  Mode', () => {
   it('Should build the auth web login command', async () => {
-    const authWebLogin = new ForceAuthWebDemoModeLoginExecutor();
-    const authWebLoginCommand = authWebLogin.build({});
+    const authWebLogin = new ForceAuthWebLoginDemoModeExecutor();
+    const authWebLoginCommand = authWebLogin.build({ alias: TEST_ALIAS });
     expect(authWebLoginCommand.toCommand()).to.equal(
-      'sfdx force:auth:web:login --setdefaultdevhubusername --noprompt --json --loglevel fatal'
+      `sfdx force:auth:web:login --setalias ${TEST_ALIAS} --setdefaultusername --noprompt --json --loglevel fatal`
     );
     expect(authWebLoginCommand.description).to.equal(
-      nls.localize('force_auth_web_login_authorize_dev_hub_text')
+      nls.localize('force_auth_web_login_authorize_org_text')
     );
+  });
+});
+
+describe('Alias Gatherer', () => {
+  let inputBoxSpy: sinon.SinonStub;
+
+  before(() => {
+    inputBoxSpy = sinon.stub(vscode.window, 'showInputBox');
+    inputBoxSpy.onCall(0).returns(undefined);
+    inputBoxSpy.onCall(1).returns('');
+    inputBoxSpy.onCall(2).returns(TEST_ALIAS);
+  });
+
+  after(() => {
+    inputBoxSpy.restore();
+  });
+
+  it('Should return cancel if alias is undefined', async () => {
+    const gatherer = new AliasGatherer();
+    const response = await gatherer.gather();
+    expect(inputBoxSpy.calledOnce).to.be.true;
+    expect(response.type).to.equal('CANCEL');
+  });
+
+  it('Should return Continue with default alias if user input is empty string', async () => {
+    const gatherer = new AliasGatherer();
+    const response = await gatherer.gather();
+    expect(inputBoxSpy.calledTwice).to.be.true;
+    if (response.type === 'CONTINUE') {
+      expect(response.data.alias).to.equal(DEFAULT_ALIAS);
+    } else {
+      expect.fail('Response should be of type ContinueResponse');
+    }
+  });
+
+  it('Should return Continue with inputted alias if user input is not undefined or empty', async () => {
+    const gatherer = new AliasGatherer();
+    const response = await gatherer.gather();
+    expect(inputBoxSpy.calledThrice).to.be.true;
+    if (response.type === 'CONTINUE') {
+      expect(response.data.alias).to.equal(TEST_ALIAS);
+    } else {
+      expect.fail('Response should be of type ContinueResponse');
+    }
   });
 });
 
@@ -51,13 +101,13 @@ describe('Command chosen is based on results of isDemoMode()', () => {
     process.env.SFXD_ENV = originalValue;
   });
 
-  it('Should use ForceAuthWebDemoModeLoginExecutor if demo mode is true', () => {
+  it('Should use ForceAuthDevHubDemoModeExecutor if demo mode is true', () => {
     process.env.SFDX_ENV = 'DEMO';
-    expect(createExecutor() instanceof ForceAuthWebDemoModeLoginExecutor).to.be
+    expect(createExecutor() instanceof ForceAuthWebLoginDemoModeExecutor).to.be
       .true;
   });
 
-  it('Should use ForceAuthWebLoginExecutor if demo mode is false', () => {
+  it('Should use ForceAuthDevHubExecutor if demo mode is false', () => {
     process.env.SFDX_ENV = '';
     expect(createExecutor() instanceof ForceAuthWebLoginExecutor).to.be.true;
   });


### PR DESCRIPTION
Renamed the existing forceAuthWebLogin to forceAuthDevHub so that
forceAuthWebLogin could be repurposed for the `SFDX: Authorize an Org` 
command.

### What does this PR do?
* Adds a new command that authenticates an org and sets it as the 
default username
* Supports demo mode, similar to the existing command `SFDX: Authorize a Dev Hub`
* Hides the new command behind the `salesforcedx-vscode-core.change_set_based_tools.enabled` perm


### What issues does this PR fix or reference?
For change set development, users should be able to authorize their production and 
sandbox orgs.
@W-5070919@