### PR TITLE
Generate a default export for the type definitions

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/languageServer.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageServer.ts
@@ -35,23 +35,31 @@ async function createServer(
     );
     let args: string[];
     if (DEBUG) {
-      args = [
-        '-cp',
-        uberJar,
+      args = ['-cp', uberJar];
+
+      if (!shouldUseNewLwcFeatures()) {
+        args.push('-Dlwc.scoped.apex=false');
+      }
+
+      args.push(
         '-Ddebug.internal.errors=true',
         '-Ddebug.semantic.errors=false',
         '-Dtrace.protocol=false',
         `-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${JDWP_DEBUG_PORT},quiet=y`,
         APEX_LANGUAGE_SERVER_MAIN
-      ];
+      );
     } else {
-      args = [
-        '-cp',
-        uberJar,
+      args = ['-cp', uberJar];
+
+      if (!shouldUseNewLwcFeatures()) {
+        args.push('-Dlwc.scoped.use=false');
+      }
+
+      args.push(
         '-Ddebug.internal.errors=true',
         '-Ddebug.semantic.errors=false',
         APEX_LANGUAGE_SERVER_MAIN
-      ];
+      );
     }
 
     return {
@@ -94,6 +102,17 @@ function startedInDebugMode(): boolean {
     );
   }
   return false;
+}
+
+/**
+ * This is a temporary function that is just used to gate LWC features.
+ * This is to be removed when LWC goes GA.
+ */
+function shouldUseNewLwcFeatures(): boolean {
+  const isLwcNext = vscode.extensions.getExtension(
+    'salesforce.salesforcedx-vscode-lwc-next'
+  );
+  return isLwcNext ? true : false;
 }
 
 // See https://github.com/Microsoft/vscode-languageserver-node/issues/105

--- a/packages/salesforcedx-vscode-lwc-next/package.json
+++ b/packages/salesforcedx-vscode-lwc-next/package.json
@@ -27,7 +27,7 @@
     "ajv": "^6.1.1",
     "eslint": "4.16.0",
     "eslint-plugin-lwc": "0.4.0",
-    "lwc-language-server": "1.6.2",
+    "lwc-language-server": "1.6.3",
     "rxjs": "^5.4.1",
     "vscode-languageclient": "3.5.1"
   },

--- a/packages/salesforcedx-vscode-lwc-next/package.json
+++ b/packages/salesforcedx-vscode-lwc-next/package.json
@@ -27,7 +27,7 @@
     "ajv": "^6.1.1",
     "eslint": "4.16.0",
     "eslint-plugin-lwc": "0.4.0",
-    "lwc-language-server": "1.6.0",
+    "lwc-language-server": "1.6.1",
     "rxjs": "^5.4.1",
     "vscode-languageclient": "3.5.1"
   },

--- a/packages/salesforcedx-vscode-lwc-next/package.json
+++ b/packages/salesforcedx-vscode-lwc-next/package.json
@@ -27,7 +27,7 @@
     "ajv": "^6.1.1",
     "eslint": "4.16.0",
     "eslint-plugin-lwc": "0.4.0",
-    "lwc-language-server": "1.6.1",
+    "lwc-language-server": "1.6.2",
     "rxjs": "^5.4.1",
     "vscode-languageclient": "3.5.1"
   },

--- a/packages/salesforcedx-vscode-lwc-next/package.json
+++ b/packages/salesforcedx-vscode-lwc-next/package.json
@@ -26,8 +26,8 @@
     "@salesforce/salesforcedx-utils-vscode": "43.6.0",
     "ajv": "^6.1.1",
     "eslint": "4.16.0",
-    "eslint-plugin-lwc": "0.3.2",
-    "lwc-language-server": "1.5.1",
+    "eslint-plugin-lwc": "0.4.0",
+    "lwc-language-server": "1.6.0",
     "rxjs": "^5.4.1",
     "vscode-languageclient": "3.5.1"
   },


### PR DESCRIPTION
### What does this PR do?

When lwc-next is not installed, use the old type definitions, i.e., @apex/MyClass.MyMethod.
If lwc-next is installed, use the new type definitions, i.e, @salesforce/apex/MyClass.MyMethod

### What issues does this PR fix or reference?

@W-4987185@
