### PR TITLE
Add 'SFDX: Deploy Source to Org' command

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -92,7 +92,12 @@
         {
           "command": "sfdx.force.source.retrieve.current.file",
           "when":
-            "sfdx:project_opened && config.salesforcedx-vscode-core.change_set_based_tools.enabled"
+            "sfdx:project_opened && sfdx:is_change_set_workspace && config.salesforcedx-vscode-core.change_set_based_tools.enabled"
+        },
+        {
+          "command": "sfdx.force.source.deploy.current.file",
+          "when":
+            "sfdx:project_opened && sfdx:is_change_set_workspace && config.salesforcedx-vscode-core.change_set_based_tools.enabled"
         }
       ],
       "explorer/context": [
@@ -139,7 +144,12 @@
         {
           "command": "sfdx.force.source.retrieve",
           "when":
-            "sfdx:project_opened && config.salesforcedx-vscode-core.change_set_based_tools.enabled"
+            "sfdx:project_opened && sfdx:is_change_set_workspace && config.salesforcedx-vscode-core.change_set_based_tools.enabled"
+        },
+        {
+          "command": "sfdx.force.source.deploy",
+          "when":
+            "sfdx:project_opened && sfdx:is_change_set_workspace && config.salesforcedx-vscode-core.change_set_based_tools.enabled"
         }
       ],
       "commandPalette": [
@@ -316,7 +326,15 @@
           "when": "false"
         },
         {
+          "command": "sfdx.force.source.deploy",
+          "when": "false"
+        },
+        {
           "command": "sfdx.force.source.retrieve.current.file",
+          "when": "false"
+        },
+        {
+          "command": "sfdx.force.source.deploy.current.file",
           "when": "false"
         }
       ]
@@ -497,6 +515,14 @@
       {
         "command": "sfdx.force.source.retrieve.current.file",
         "title": "%force_source_retrieve_this_source_file_text%"
+      },
+      {
+        "command": "sfdx.force.source.deploy",
+        "title": "%force_source_deploy_text%"
+      },
+      {
+        "command": "sfdx.force.source.deploy.current.file",
+        "title": "%force_source_deploy_this_source_file_text%"
       }
     ],
     "configuration": {

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -74,5 +74,8 @@
   "force_manifest_editor_show_text": "SFDX: Show Package Manifest Editor",
   "force_source_retrieve_text": "SFDX: Retrieve Source from Org",
   "force_source_retrieve_this_source_file_text":
-    "SFDX: Retrieve This Source File from Org"
+    "SFDX: Retrieve This Source File from Org",
+  "force_source_deploy_text": "SFDX: Deploy Source to Org",
+  "force_source_deploy_this_source_file_text":
+    "SFDX: Deploy This Source File to Org"
 }

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploy.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploy.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  Command,
+  SfdxCommandBuilder
+} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import { nls } from '../messages';
+import {
+  SfdxCommandlet,
+  SfdxCommandletExecutor,
+  SfdxWorkspaceChecker
+} from './commands';
+import {
+  FileType,
+  ManifestOrSourcePathGatherer,
+  SelectedPath
+} from './forceSourceRetrieve';
+
+export class ForceSourceDeployExecutor extends SfdxCommandletExecutor<
+  SelectedPath
+> {
+  public build(data: SelectedPath): Command {
+    const commandBuilder = new SfdxCommandBuilder()
+      .withDescription(nls.localize('force_source_deploy_text'))
+      .withArg('force:source:deploy');
+    if (data.type === FileType.Manifest) {
+      commandBuilder.withFlag('--manifest', data.filePath);
+    } else {
+      commandBuilder.withFlag('--sourcepath', data.filePath);
+    }
+    return commandBuilder.build();
+  }
+}
+
+const workspaceChecker = new SfdxWorkspaceChecker();
+
+export async function forceSourceDeploy(explorerPath: any) {
+  const commandlet = new SfdxCommandlet(
+    workspaceChecker,
+    new ManifestOrSourcePathGatherer(explorerPath),
+    new ForceSourceDeployExecutor()
+  );
+  await commandlet.run();
+}

--- a/packages/salesforcedx-vscode-core/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/index.ts
@@ -26,6 +26,7 @@ export {
 export { forceDataSoqlQuery } from './forceDataSoqlQuery';
 export { forceOrgCreate } from './forceOrgCreate';
 export { forceOrgOpen } from './forceOrgOpen';
+export { forceSourceDeploy } from './forceSourceDeploy';
 export { forceSourcePull } from './forceSourcePull';
 export { forceSourcePush } from './forceSourcePush';
 export { forceSourceRetrieve } from './forceSourceRetrieve';

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
+import * as fs from 'fs';
 import * as path from 'path';
 import { ConfigurationTarget } from 'vscode';
 import * as vscode from 'vscode';
@@ -37,6 +37,7 @@ import {
   forceOrgDisplay,
   forceOrgOpen,
   forceSfdxProjectCreate,
+  forceSourceDeploy,
   forceSourcePull,
   forceSourcePush,
   forceSourceRetrieve,
@@ -92,6 +93,10 @@ function registerCommands(
   const forceOrgOpenCmd = vscode.commands.registerCommand(
     'sfdx.force.org.open',
     forceOrgOpen
+  );
+  const forceSourceDeployCmd = vscode.commands.registerCommand(
+    'sfdx.force.source.deploy',
+    forceSourceDeploy
   );
   const forceSourcePullCmd = vscode.commands.registerCommand(
     'sfdx.force.source.pull',
@@ -292,6 +297,7 @@ function registerCommands(
     forceDataSoqlQuerySelectionCmd,
     forceOrgCreateCmd,
     forceOrgOpenCmd,
+    forceSourceDeployCmd,
     forceSourcePullCmd,
     forceSourcePullForceCmd,
     forceSourcePushCmd,
@@ -345,6 +351,14 @@ export async function activate(context: vscode.ExtensionContext) {
     sfdxProjectOpened = files && files.length > 0;
   }
 
+  let isChangeSetWorkspace = false;
+  if (vscode.workspace.workspaceFolders) {
+    const manifestDirExists = fs.existsSync(
+      path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, 'manifest')
+    );
+    isChangeSetWorkspace = manifestDirExists;
+  }
+
   let replayDebuggerExtensionInstalled = false;
   if (
     vscode.extensions.getExtension(
@@ -373,6 +387,12 @@ export async function activate(context: vscode.ExtensionContext) {
     'setContext',
     'sfdx:project_opened',
     sfdxProjectOpened
+  );
+
+  vscode.commands.executeCommand(
+    'setContext',
+    'sfdx:is_change_set_workspace',
+    isChangeSetWorkspace
   );
 
   const sfdxApexDebuggerExtension = vscode.extensions.getExtension(

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -73,7 +73,9 @@ export const messages = {
   force_source_push_force_default_scratch_org_text:
     'SFDX: Push Source to Default Scratch Org and Override Conflicts',
 
+  force_source_deploy_text: 'SFDX: Deploy Source to Org',
   force_source_retrieve_text: 'SFDX: Retrieve Source from Org',
+
   force_source_status_text:
     'View All Changes (Local and in Default Scratch Org)',
 

--- a/packages/salesforcedx-vscode-core/test/commands/forceSourceDeploy.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceSourceDeploy.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from 'chai';
+import * as path from 'path';
+
+import { ForceSourceDeployExecutor } from './../../src/commands/forceSourceDeploy';
+import { FileType } from './../../src/commands/forceSourceRetrieve';
+
+import { nls } from '../../src/messages';
+
+describe('Force Source Deploy with Manifest Option', () => {
+  it('Should build the source deploy command', () => {
+    const manifestPath = path.join('path', 'to', 'manifest', 'package.xml');
+    const sourceDeploy = new ForceSourceDeployExecutor();
+    const sourceDeployCommand = sourceDeploy.build({
+      filePath: manifestPath,
+      type: FileType.Manifest
+    });
+    expect(sourceDeployCommand.toCommand()).to.equal(
+      `sfdx force:source:deploy --manifest ${manifestPath}`
+    );
+    expect(sourceDeployCommand.description).to.equal(
+      nls.localize('force_source_deploy_text')
+    );
+  });
+});
+
+describe('Force Source Deploy with Sourcepath Option', () => {
+  it('Should build the source deploy command', () => {
+    const sourcePath = path.join('path', 'to', 'sourceFile');
+    const sourceDeploy = new ForceSourceDeployExecutor();
+    const sourceDeployCommand = sourceDeploy.build({
+      filePath: sourcePath,
+      type: FileType.Source
+    });
+    expect(sourceDeployCommand.toCommand()).to.equal(
+      `sfdx force:source:deploy --sourcepath ${sourcePath}`
+    );
+    expect(sourceDeployCommand.description).to.equal(
+      nls.localize('force_source_deploy_text')
+    );
+  });
+});


### PR DESCRIPTION
### What does this PR do?
* Adds a new 'SFDX: Deploy Source to Org' command that deploys source for a given
manifest file or source path in the workspace

* Hides the source deploy and retrieve commands behind an additional check that the user is in a change-set-based project

### What issues does this PR fix or reference?
@W-5070947@

