### PR TITLE
Explain how to retrieve code coverage results

### DIFF
--- a/packages/salesforcedx-vscode-core/README.md
+++ b/packages/salesforcedx-vscode-core/README.md
@@ -69,7 +69,7 @@ Results from your test run display in the Output panel. The Failures section of 
 
 After you run Apex tests, two new commands are available in the command palette: **SFDX: Re-Run Last Invoked Apex Test Class** and **SFDX: Re-Run Last Invoked Apex Test Method**.  
 
-To retrieve code coverage results when you run Apex tests, edit your workplace settings and set `salesforcedx-vscode-core.retrieve-test-code-coverage` to `true`.  
+To retrieve code coverage results when you run Apex tests, edit your workspace settings and set `salesforcedx-vscode-core.retrieve-test-code-coverage` to `true`.  
 
 ## Edit Your Workspace Settings
 To edit your workspace settings, select **Code** > **Preferences** > **Settings** (macOS) or **File** > **Preferences** > **Settings** (Windows and Linux).  

--- a/packages/salesforcedx-vscode-core/README.md
+++ b/packages/salesforcedx-vscode-core/README.md
@@ -69,6 +69,8 @@ Results from your test run display in the Output panel. The Failures section of 
 
 After you run Apex tests, two new commands are available in the command palette: **SFDX: Re-Run Last Invoked Apex Test Class** and **SFDX: Re-Run Last Invoked Apex Test Method**.  
 
+To retrieve code coverage results when you run Apex tests, edit your workplace settings and set `salesforcedx-vscode-core.retrieve-test-code-coverage` to `true`.  
+
 ## Edit Your Workspace Settings
 To edit your workspace settings, select **Code** > **Preferences** > **Settings** (macOS) or **File** > **Preferences** > **Settings** (Windows and Linux).  
 


### PR DESCRIPTION
### What does this PR do?
Updates doc to explain how to retrieve Apex code coverage results when running tests. We previously added this info to the change log but not to the doc.

### What issues does this PR fix or reference?
@W-5083565@
https://github.com/forcedotcom/salesforcedx-vscode/pull/482