### PR TITLE
First update for Trigger context vars in heapdumps

### DIFF
--- a/packages/salesforcedx-apex-replay-debugger/src/adapter/apexReplayDebug.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/adapter/apexReplayDebug.ts
@@ -373,10 +373,8 @@ export class ApexReplayDebug extends LoggingDebugSession {
         false
       )
     );
-    // JRS
     // Right now, globals are only going to exist if there's a heapdump and the frame
-    // source is a trigger. Not sure if this is the correct way to do this but we'll
-    // see
+    // source is a trigger.
     if (heapDumpId && this.logContext.isRunningApexTrigger()) {
       scopes.push(
         new Scope(

--- a/packages/salesforcedx-apex-replay-debugger/src/adapter/apexReplayDebug.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/adapter/apexReplayDebug.ts
@@ -82,12 +82,14 @@ export class ApexDebugStackFrameInfo {
   public readonly signature: string;
   public statics: Map<string, VariableContainer>;
   public locals: Map<string, VariableContainer>;
+  public globals: Map<string, VariableContainer>;
 
   public constructor(frameNumber: number, signature: string) {
     this.frameNumber = frameNumber;
     this.signature = signature;
     this.statics = new Map<string, VariableContainer>();
     this.locals = new Map<string, VariableContainer>();
+    this.globals = new Map<string, VariableContainer>();
   }
 
   public copy(): ApexDebugStackFrameInfo {
@@ -104,7 +106,8 @@ export class ApexDebugStackFrameInfo {
 
 export enum SCOPE_TYPES {
   LOCAL = 'local',
-  STATIC = 'static'
+  STATIC = 'static',
+  GLOBAL = 'global'
 }
 
 export abstract class VariableContainer {
@@ -370,6 +373,21 @@ export class ApexReplayDebug extends LoggingDebugSession {
         false
       )
     );
+    // JRS
+    // Right now, globals are only going to exist if there's a heapdump and the frame
+    // source is a trigger. Not sure if this is the correct way to do this but we'll
+    // see
+    if (heapDumpId && this.logContext.isRunningApexTrigger()) {
+      scopes.push(
+        new Scope(
+          'Global',
+          this.logContext
+            .getVariableHandler()
+            .create(new ScopeContainer(SCOPE_TYPES.GLOBAL, frameInfo.globals)),
+          false
+        )
+      );
+    }
     response.body = { scopes };
     this.sendResponse(response);
   }

--- a/packages/salesforcedx-apex-replay-debugger/src/constants.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/constants.ts
@@ -41,3 +41,4 @@ export const OVERLAY_ACTION_DELETE_URL =
 export const QUERY_URL = 'services/data/v43.0/tooling/query';
 export const MAX_ALLOWED_CHECKPOINTS = 5;
 export const SFDC_TRIGGER = '__sfdc_trigger/';
+export const EXTENT_TRIGGER_PREFIX = 'Trigger.';

--- a/packages/salesforcedx-apex-replay-debugger/src/core/heapDumpService.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/core/heapDumpService.ts
@@ -10,10 +10,11 @@ import { ApexVariableContainer } from '../adapter/apexReplayDebug';
 import {
   ApexExecutionOverlayResultCommandSuccess,
   HeapDumpCollectionTypeDefinition,
+  HeapDumpExtents,
   HeapDumpExtentValue,
   HeapDumpExtentValueEntry
 } from '../commands/apexExecutionOverlayResultCommand';
-import { ADDRESS_PREFIX } from '../constants';
+import { ADDRESS_PREFIX, EXTENT_TRIGGER_PREFIX } from '../constants';
 import { LogContext } from './logContext';
 
 export class HeapDumpService {
@@ -124,6 +125,59 @@ export class HeapDumpService {
           }
         }
       }
+      // Create the trigger context variables in the global context. Unlike locals or statics
+      // the global variable container should be empty and these variables are created from
+      // scratch instead of updating existing variables.
+      if (this.logContext.isRunningApexTrigger()) {
+        for (const outerExtent of heapdumpResult.HeapDump.extents) {
+          if (this.isTriggerExtent(outerExtent)) {
+            // The trigger context variables are going to be immediate children of the outerExtent.
+            for (const innerExtent of outerExtent.extent) {
+              // All of the symbols are going to start with the trigger prefix and will be exclusive
+              // to trigger context varables. It's worth noting that any local variables or statics
+              // within the triggger will be under "this" and won't get picked up there.
+              if (innerExtent.symbols && innerExtent.symbols.length > 0) {
+                for (const symName of innerExtent.symbols) {
+                  if (symName && symName.startsWith(EXTENT_TRIGGER_PREFIX)) {
+                    // Update the type mapping if necessary
+                    if (!variableTypes.has(symName)) {
+                      variableTypes.set(symName, outerExtent.typeName);
+                    }
+                    // Create the variable container
+                    frameInfo.globals.set(
+                      symName,
+                      new ApexVariableContainer(
+                        symName,
+                        '',
+                        outerExtent.typeName
+                      )
+                    );
+                    const globalVar = frameInfo.globals.get(
+                      symName
+                    ) as ApexVariableContainer;
+                    // Setting the variableref needs to get done in order for VS Code to be able to
+                    // expand list/map variables. The reason this isn't done for booleans is that it
+                    // would end up creating a collapsible variable with no value, just the arrow to
+                    // expand or collapse which is incorrect.
+                    if (outerExtent.typeName !== 'Boolean') {
+                      globalVar.variablesRef = this.logContext
+                        .getVariableHandler()
+                        .create(globalVar);
+                    }
+                    this.updateContainer(
+                      globalVar,
+                      innerExtent.value,
+                      extentToRevisit,
+                      referenceToRevisit,
+                      variableTypes
+                    );
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 
@@ -170,7 +224,7 @@ export class HeapDumpService {
     referenceToRevisit: Map<string, ApexVariableContainer>,
     variableTypes: Map<string, string>
   ): void {
-    if (heapDumpExtentValue.value) {
+    if (typeof heapDumpExtentValue.value !== 'undefined') {
       this.updateContainerWithExtentValue(
         varContainer,
         heapDumpExtentValue.value,
@@ -231,7 +285,7 @@ export class HeapDumpService {
     extentEntry: HeapDumpExtentValueEntry[] | undefined,
     type?: string
   ): void {
-    if (extentValue) {
+    if (typeof extentValue !== 'undefined') {
       this.updateContainerWithExtentValue(varContainer, extentValue, type);
     } else if (extentEntry) {
       for (const extentValueEntry of extentEntry) {
@@ -242,13 +296,16 @@ export class HeapDumpService {
             extentValueEntry.value.entry
           );
         }
-        varContainer.variables.forEach((value, key) => {
+        if (varContainer.variables.has(extentValueEntry.keyDisplayValue)) {
+          const value = varContainer.variables.get(
+            extentValueEntry.keyDisplayValue
+          ) as ApexVariableContainer;
           this.updateContainerWithExtentValueOrEntry(
             value as ApexVariableContainer,
             extentValue,
             extentEntry
           );
-        });
+        }
       }
     }
   }
@@ -319,5 +376,20 @@ export class HeapDumpService {
     extentValueEntry: HeapDumpExtentValueEntry
   ) {
     return varContainer.name === extentValueEntry.keyDisplayValue;
+  }
+
+  public isTriggerExtent(outerExtent: HeapDumpExtents) {
+    if (
+      (outerExtent.typeName === 'Boolean' ||
+        outerExtent.typeName.startsWith('List') ||
+        outerExtent.typeName.startsWith('Map')) &&
+      (outerExtent.count > 0 &&
+        outerExtent.extent[0].symbols !== null &&
+        outerExtent.extent[0].symbols!.length > 0 &&
+        outerExtent.extent[0].symbols![0].startsWith(EXTENT_TRIGGER_PREFIX))
+    ) {
+      return true;
+    }
+    return false;
   }
 }

--- a/packages/salesforcedx-apex-replay-debugger/src/core/heapDumpService.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/core/heapDumpService.ts
@@ -381,8 +381,8 @@ export class HeapDumpService {
   public isTriggerExtent(outerExtent: HeapDumpExtents) {
     if (
       (outerExtent.typeName === 'Boolean' ||
-        outerExtent.typeName.startsWith('List') ||
-        outerExtent.typeName.startsWith('Map')) &&
+        outerExtent.typeName.startsWith('List<') ||
+        outerExtent.typeName.startsWith('Map<')) &&
       (outerExtent.count > 0 &&
         outerExtent.extent[0].symbols !== null &&
         outerExtent.extent[0].symbols!.length > 0 &&

--- a/packages/salesforcedx-apex-replay-debugger/src/core/logContext.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/core/logContext.ts
@@ -158,6 +158,18 @@ export class LogContext {
     }
   }
 
+  public isRunningApexTrigger(): boolean {
+    const topFrame = this.getTopFrame();
+    if (
+      topFrame &&
+      topFrame.source &&
+      topFrame.source.name.toLowerCase().endsWith('.trigger')
+    ) {
+      return true;
+    }
+    return false;
+  }
+
   public copyStateForHeapDump(): void {
     this.backupStackFrameInfos = JSON.parse(
       JSON.stringify(this.stackFrameInfos)

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/apexReplayDebugVariablesHandling.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/apexReplayDebugVariablesHandling.test.ts
@@ -9,6 +9,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { Source, StackFrame } from 'vscode-debugadapter';
 import { DebugProtocol } from 'vscode-debugprotocol';
+import { EXTENT_TRIGGER_PREFIX } from '../../../src';
 import {
   ApexDebugStackFrameInfo,
   ApexReplayDebug,
@@ -27,6 +28,7 @@ import { ApexHeapDump, LogContext } from '../../../src/core';
 import { Handles } from '../../../src/core/handles';
 import { HeapDumpService } from '../../../src/core/heapDumpService';
 import { MockApexReplayDebug } from './apexReplayDebug.test';
+import { createHeapDumpResultForTriggers } from './heapDumpTestUtil';
 
 // tslint:disable:no-unused-expression
 describe('Replay debugger adapter variable handling - unit', () => {
@@ -804,6 +806,203 @@ describe('Replay debugger adapter variable handling - unit', () => {
             extentValueEntry
           )
         ).to.be.false;
+      });
+    });
+
+    describe('heapDumpTriggerContextVariables', () => {
+      let getTopFrameStub: sinon.SinonStub;
+      let getHeapDumpForThisLocationStub: sinon.SinonStub;
+      let getFrameHandlerStub: sinon.SinonStub;
+      let getRefsMapStub: sinon.SinonStub;
+      let getStaticVariablesClassMapStub: sinon.SinonStub;
+      let isRunningApexTriggerStub: sinon.SinonStub;
+      let getVariableHandlerStub: sinon.SinonStub;
+      let variableHandler: Handles<VariableContainer>;
+
+      const topFrame: StackFrame = {
+        id: 0,
+        name: 'Foo.cls',
+        line: 10,
+        column: 0,
+        source: new Source('Foo.trigger', '/path/Foo.trigger')
+      };
+      let frameHandler: Handles<ApexDebugStackFrameInfo>;
+      let refsMap: Map<string, ApexVariableContainer>;
+      let staticVariablesClassMap: Map<string, Map<string, VariableContainer>>;
+
+      beforeEach(() => {
+        adapter = new MockApexReplayDebug();
+        adapter.setLogFile(launchRequestArgs);
+        frameHandler = new Handles<ApexDebugStackFrameInfo>();
+        refsMap = new Map<string, ApexVariableContainer>();
+        staticVariablesClassMap = new Map<
+          string,
+          Map<string, ApexVariableContainer>
+        >();
+        getTopFrameStub = sinon
+          .stub(LogContext.prototype, 'getTopFrame')
+          .returns(topFrame);
+        getFrameHandlerStub = sinon
+          .stub(LogContext.prototype, 'getFrameHandler')
+          .returns(frameHandler);
+        getRefsMapStub = sinon
+          .stub(LogContext.prototype, 'getRefsMap')
+          .returns(refsMap);
+        getStaticVariablesClassMapStub = sinon
+          .stub(LogContext.prototype, 'getStaticVariablesClassMap')
+          .returns(staticVariablesClassMap);
+        variableHandler = new Handles<VariableContainer>();
+        isRunningApexTriggerStub = sinon.stub(
+          LogContext.prototype,
+          'isRunningApexTrigger'
+        );
+      });
+
+      afterEach(() => {
+        getTopFrameStub.restore();
+        getHeapDumpForThisLocationStub.restore();
+        getFrameHandlerStub.restore();
+        getRefsMapStub.restore();
+        getStaticVariablesClassMapStub.restore();
+        if (isRunningApexTriggerStub) {
+          isRunningApexTriggerStub.restore();
+        }
+        if (getVariableHandlerStub) {
+          getVariableHandlerStub.restore();
+        }
+      });
+
+      it('Should not create global trigger variables if not processing a trigger heapdump', () => {
+        const heapdump = createHeapDumpResultForTriggers();
+
+        getHeapDumpForThisLocationStub = sinon
+          .stub(LogContext.prototype, 'getHeapDumpForThisLocation')
+          .returns(heapdump);
+
+        getVariableHandlerStub = sinon
+          .stub(LogContext.prototype, 'getVariableHandler')
+          .returns(variableHandler);
+
+        // In this test we're not running a trigger
+        isRunningApexTriggerStub.returns(false);
+
+        const frameInfo = new ApexDebugStackFrameInfo(0, 'Foo');
+        const id = frameHandler.create(frameInfo);
+        topFrame.id = id;
+
+        // There should be no globals before the heap dump processing
+        expect(frameInfo.globals.size).to.eq(0);
+
+        heapDumpService.replaceVariablesWithHeapDump();
+
+        // There should be no gloabs after the heap dump processing
+        expect(frameInfo.globals.size).to.eq(0);
+      });
+
+      it('Should create trigger variables if processing a trigger heapdump', () => {
+        const heapdump = createHeapDumpResultForTriggers();
+
+        getHeapDumpForThisLocationStub = sinon
+          .stub(LogContext.prototype, 'getHeapDumpForThisLocation')
+          .returns(heapdump);
+
+        getVariableHandlerStub = sinon
+          .stub(LogContext.prototype, 'getVariableHandler')
+          .returns(variableHandler);
+
+        // In this test we are running a trigger
+        isRunningApexTriggerStub.returns(true);
+
+        const frameInfo = new ApexDebugStackFrameInfo(0, 'Foo');
+        const id = frameHandler.create(frameInfo);
+        topFrame.id = id;
+
+        // There should be no globals before the heap dump processing
+        expect(frameInfo.globals.size).to.eq(0);
+
+        heapDumpService.replaceVariablesWithHeapDump();
+
+        // There should be 8 globals after the heap dump processing
+        // 6 Trigger.is* boolean values
+        // 1 Trigger.new - List
+        // 1 Trigger.newmap - Map
+        expect(frameInfo.globals.size).to.eq(8);
+        // Verify the false Trigger booleans
+        expect(
+          (frameInfo.globals.get(
+            EXTENT_TRIGGER_PREFIX + 'isbefore'
+          ) as ApexVariableContainer).value
+        ).to.eq('false');
+        expect(
+          (frameInfo.globals.get(
+            EXTENT_TRIGGER_PREFIX + 'isdelete'
+          ) as ApexVariableContainer).value
+        ).to.eq('false');
+        expect(
+          (frameInfo.globals.get(
+            EXTENT_TRIGGER_PREFIX + 'isundelete'
+          ) as ApexVariableContainer).value
+        ).to.eq('false');
+        expect(
+          (frameInfo.globals.get(
+            EXTENT_TRIGGER_PREFIX + 'isupdate'
+          ) as ApexVariableContainer).value
+        ).to.eq('false');
+        // Verify the True Trigger booleans
+        expect(
+          (frameInfo.globals.get(
+            EXTENT_TRIGGER_PREFIX + 'isafter'
+          ) as ApexVariableContainer).value
+        ).to.eq('true');
+        expect(
+          (frameInfo.globals.get(
+            EXTENT_TRIGGER_PREFIX + 'isinsert'
+          ) as ApexVariableContainer).value
+        ).to.eq('true');
+
+        // Verify the Trigger.new map
+        const triggerNew = frameInfo.globals.get(
+          EXTENT_TRIGGER_PREFIX + 'new'
+        ) as ApexVariableContainer;
+        expect(triggerNew.type).to.be.eq('List<Account>');
+        // The variablesRef should be set as part of the variable processing. 0 is
+        // the default, if the reference is set it'll be greater than 0
+        expect(triggerNew.variablesRef).to.be.greaterThan(0);
+        // There should be 3 items in the Trigger.new list
+        expect(triggerNew.variables.size).to.be.eq(3);
+        // Verify the entries in the array
+        expect(
+          (triggerNew.variables.get('0') as ApexVariableContainer).value
+        ).to.eq("'0x5f163c72'");
+        expect(
+          (triggerNew.variables.get('1') as ApexVariableContainer).value
+        ).to.eq("'0xf1fabe'");
+        expect(
+          (triggerNew.variables.get('2') as ApexVariableContainer).value
+        ).to.eq("'0x76e9852b'");
+
+        // Verify the Trigger.newmap which is a Map<Id,Account>
+        const triggerNewmap = frameInfo.globals.get(
+          EXTENT_TRIGGER_PREFIX + 'newmap'
+        ) as ApexVariableContainer;
+        expect(triggerNewmap.type).to.be.eq('Map<Id,Account>');
+        // The variablesRef should be set as part of the variable processing. 0 is
+        // the default, if the reference is set it'll be greater than 0
+        expect(triggerNewmap.variablesRef).to.be.greaterThan(0);
+        expect(triggerNewmap.variables.size).to.be.eq(3);
+        // Verify the key/value pairs in the map
+        expect(
+          (triggerNewmap.variables.get('0x5c288675') as ApexVariableContainer)
+            .value
+        ).to.be.eq('0x5f163c72');
+        expect(
+          (triggerNewmap.variables.get('0x5db01cb1') as ApexVariableContainer)
+            .value
+        ).to.be.eq('0xf1fabe');
+        expect(
+          (triggerNewmap.variables.get('0x1872dffb') as ApexVariableContainer)
+            .value
+        ).to.be.eq('0x76e9852b');
       });
     });
   });

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/heapDumpTestUtil.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/heapDumpTestUtil.ts
@@ -1,0 +1,412 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { ApexExecutionOverlayResultCommandSuccess } from '../../../src/commands/apexExecutionOverlayResultCommand';
+import { ApexHeapDump } from '../../../src/core';
+
+// Rather than duplicate a large heapdump in multiple places just have a common function return it. The
+// heap dump for triggers is ends up bring pretty large but there are only 3 Account records in here.
+// This method contains the elements necessary to test the Trigger variables in the heapdump.
+export function createHeapDumpResultForTriggers(): ApexHeapDump {
+  // This particular heapdump was taken after an insert. The Trigger booleans for isafter and isinsert will
+  // be true. isbefore, isdelete, isundelete and isupdate will be false. The Trigger.new and Trigger.newmap
+  // will both be populated with 3 Account objects.
+  const heapdump = new ApexHeapDump('some ID', 'Foo', '', 10);
+  heapdump.setOverlaySuccessResult({
+    HeapDump: {
+      extents: [
+        {
+          collectionType: null,
+          count: 3,
+          definition: [{}],
+          extent: [
+            {
+              address: '0x5f163c72',
+              size: 0,
+              symbols: null,
+              value: {
+                entry: [
+                  {
+                    keyDisplayValue: 'LastModifiedDate',
+                    value: {
+                      value: 'Mon Jul 30 15:02:51 GMT 2018'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'IsDeleted',
+                    value: {
+                      value: 'false'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'CleanStatus',
+                    value: {
+                      value: 'Pending'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'OwnerId',
+                    value: {
+                      value: '005xx000001Uta8AAC'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'CreatedById',
+                    value: {
+                      value: '005xx000001Uta8AAC'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'CreatedDate',
+                    value: {
+                      value: 'Mon Jul 30 15:02:51 GMT 2018'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'Id',
+                    value: {
+                      value: '001xx000003Dv3YAAS'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'LastModifiedById',
+                    value: {
+                      value: '005xx000001Uta8AAC'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'SystemModstamp',
+                    value: {
+                      value: 'Mon Jul 30 15:02:51 GMT 2018'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'Name',
+                    value: {
+                      value: 'okToDelete0'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'AccountNumber',
+                    value: {
+                      value: 'xxx'
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              address: '0xf1fabe',
+              size: 0,
+              symbols: null,
+              value: {
+                entry: [
+                  {
+                    keyDisplayValue: 'LastModifiedDate',
+                    value: {
+                      value: 'Mon Jul 30 15:02:51 GMT 2018'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'IsDeleted',
+                    value: {
+                      value: 'false'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'CleanStatus',
+                    value: {
+                      value: 'Pending'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'OwnerId',
+                    value: {
+                      value: '005xx000001Uta8AAC'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'CreatedById',
+                    value: {
+                      value: '005xx000001Uta8AAC'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'CreatedDate',
+                    value: {
+                      value: 'Mon Jul 30 15:02:51 GMT 2018'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'Id',
+                    value: {
+                      value: '001xx000003Dv3ZAAS'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'LastModifiedById',
+                    value: {
+                      value: '005xx000001Uta8AAC'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'SystemModstamp',
+                    value: {
+                      value: 'Mon Jul 30 15:02:51 GMT 2018'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'Name',
+                    value: {
+                      value: 'okToDelete1'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'AccountNumber',
+                    value: {
+                      value: 'xxx'
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              address: '0x76e9852b',
+              size: 0,
+              symbols: null,
+              value: {
+                entry: [
+                  {
+                    keyDisplayValue: 'LastModifiedDate',
+                    value: {
+                      value: 'Mon Jul 30 15:02:51 GMT 2018'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'IsDeleted',
+                    value: {
+                      value: 'false'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'CleanStatus',
+                    value: {
+                      value: 'Pending'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'OwnerId',
+                    value: {
+                      value: '005xx000001Uta8AAC'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'CreatedById',
+                    value: {
+                      value: '005xx000001Uta8AAC'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'CreatedDate',
+                    value: {
+                      value: 'Mon Jul 30 15:02:51 GMT 2018'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'Id',
+                    value: {
+                      value: '001xx000003Dv3aAAC'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'LastModifiedById',
+                    value: {
+                      value: '005xx000001Uta8AAC'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'SystemModstamp',
+                    value: {
+                      value: 'Mon Jul 30 15:02:51 GMT 2018'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'Name',
+                    value: {
+                      value: 'okToDelete2'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'AccountNumber',
+                    value: {
+                      value: 'xxx'
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          totalSize: 0,
+          typeName: 'Account'
+        },
+        {
+          collectionType: 'Account',
+          count: 1,
+          definition: [],
+          extent: [
+            {
+              address: '0x7ac2777',
+              size: 16,
+              symbols: ['Trigger.new'],
+              value: {
+                value: [
+                  {
+                    value: '0x5f163c72'
+                  },
+                  {
+                    value: '0xf1fabe'
+                  },
+                  {
+                    value: '0x76e9852b'
+                  }
+                ]
+              }
+            }
+          ],
+          totalSize: 16,
+          typeName: 'List<Account>'
+        },
+        {
+          collectionType: 'Account',
+          count: 1,
+          definition: [],
+          extent: [
+            {
+              address: '0x4266fa43',
+              size: 16,
+              symbols: ['Trigger.newmap'],
+              value: {
+                entry: [
+                  {
+                    keyDisplayValue: '0x5c288675',
+                    value: {
+                      value: '0x5f163c72'
+                    }
+                  },
+                  {
+                    keyDisplayValue: '0x5db01cb1',
+                    value: {
+                      value: '0xf1fabe'
+                    }
+                  },
+                  {
+                    keyDisplayValue: '0x1872dffb',
+                    value: {
+                      value: '0x76e9852b'
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          totalSize: 16,
+          typeName: 'Map<Id,Account>'
+        },
+        {
+          collectionType: null,
+          count: 2,
+          definition: [
+            {
+              name: 'value',
+              type: 'Boolean'
+            }
+          ],
+          extent: [
+            {
+              address: '0x10954bcf',
+              size: 5,
+              symbols: [
+                'Trigger.isbefore',
+                'Trigger.isdelete',
+                'Trigger.isundelete',
+                'Trigger.isupdate'
+              ],
+              value: {
+                value: false
+              }
+            },
+            {
+              address: '0x63903543',
+              size: 5,
+              symbols: ['Trigger.isafter', 'Trigger.isinsert'],
+              value: {
+                value: true
+              }
+            }
+          ],
+          totalSize: 10,
+          typeName: 'Boolean'
+        },
+        {
+          collectionType: null,
+          count: 5,
+          definition: [
+            {
+              name: 'stringValue',
+              type: 'char[]'
+            }
+          ],
+          extent: [
+            {
+              address: '0x72488407',
+              size: 15,
+              symbols: null,
+              value: {
+                value: 'currentinstance'
+              }
+            },
+            {
+              address: '0x5f87e37c',
+              size: 10,
+              symbols: null,
+              value: {
+                value: 'targettype'
+              }
+            },
+            {
+              address: '0x5c288675',
+              size: 18,
+              symbols: null,
+              value: {
+                value: '001xx000003Dv3YAAS'
+              }
+            },
+            {
+              address: '0x5db01cb1',
+              size: 18,
+              symbols: null,
+              value: {
+                value: '001xx000003Dv3ZAAS'
+              }
+            },
+            {
+              address: '0x1872dffb',
+              size: 18,
+              symbols: null,
+              value: {
+                value: '001xx000003Dv3aAAC'
+              }
+            }
+          ],
+          totalSize: 79,
+          typeName: 'String'
+        }
+      ]
+    }
+  } as ApexExecutionOverlayResultCommandSuccess);
+  return heapdump;
+}


### PR DESCRIPTION
### What does this PR do?
This is the matching VS Code side changes for adding the Trigger context variables to the heap dump. Like the live debugger these variables show up under the Global variables. 

It's probably worth adding here that collections are not displayed correctly as of yet. That's the next bug I'm working on.


![triggercontext](https://user-images.githubusercontent.com/13556087/43475337-47e84e80-94aa-11e8-80d8-d9e66f5a06dc.png)


### What issues does this PR fix or reference?
@W-5186304@