### PR TITLE
Activate Extension on 'SFDX: Create a Change-Set-Based Project' Command

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -69,6 +69,7 @@
   "activationEvents": [
     "workspaceContains:sfdx-project.json",
     "onCommand:sfdx.force.project.create",
+    "onCommand:sfdx.force.create.change.set.based",
     "onCommand:sfdx.debug.isv.bootstrap"
   ],
   "main": "./out/src",


### PR DESCRIPTION
### What does this PR do?

Extensions are activated lazily in VS Code. As a result, we need to
provide the context in which the extension should be activated. Our
extension is usually activated by the presence of the sfdx-project.json
file, but since the 'SFDX: Create a Change-Set-Based Project' command
can be called from outside of an sfdx project, the command should
be added to the list of events that activate the extension.

### What issues does this PR fix or reference?
@W-5231415@