### PR TITLE
Update dependencies to bundle vscode telemetry

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -30,7 +30,8 @@
     "moment": "2.20.1",
     "rxjs": "^5.4.1",
     "sanitize-filename": "^1.6.1",
-    "shelljs": "^0.8.1"
+    "shelljs": "^0.8.1",
+    "vscode-extension-telemetry": "0.0.17"
   },
   "devDependencies": {
     "@types/adm-zip": "^0.4.31",
@@ -49,8 +50,7 @@
     "nyc": "^11.0.2",
     "sinon": "^2.3.6",
     "typescript": "2.6.2",
-    "vscode": "1.1.17",
-    "vscode-extension-telemetry": "0.0.17"
+    "vscode": "1.1.17"
   },
   "scripts": {
     "vscode:prepublish": "npm prune --production",


### PR DESCRIPTION
### What does this PR do?
Move vscode-extension-telemetry from devDependencies to dependencies since it's not being included in vsix files.

### What issues does this PR fix or reference?
It fixes a bundling issue with telemetry on vsix @W-5066473@