### PR TITLE
Create uri with 'file' scheme for use with 'vscode.openFolder'

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceProjectCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceProjectCreate.ts
@@ -71,7 +71,7 @@ export class ForceProjectCreateExecutor extends SfdxCommandletExecutor<
       if (data !== undefined && data.toString() === '0') {
         await vscode.commands.executeCommand(
           'vscode.openFolder',
-          vscode.Uri.parse(
+          vscode.Uri.file(
             path.join(response.data.projectUri, response.data.projectName)
           )
         );

--- a/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
@@ -494,7 +494,7 @@ export class IsvDebugBootstrapExecutor extends SfdxCommandletExecutor<{}> {
     channelService.appendLine(nls.localize('isv_debug_bootstrap_open_project'));
     await vscode.commands.executeCommand(
       'vscode.openFolder',
-      vscode.Uri.parse(projectPath)
+      vscode.Uri.file(projectPath)
     );
   }
 


### PR DESCRIPTION
### What does this PR do?

Creates a uri with the 'file' scheme to be passed to `vscode.openFolder`. Without specifying the scheme, we see the following error:

![screen shot 2018-08-06 at 9 42 14 am](https://user-images.githubusercontent.com/1639375/43744530-a6215374-9997-11e8-8721-7ac2873ac460.png)



### What issues does this PR fix or reference?
@W-5296710@
https://github.com/Microsoft/vscode/issues/55891#issuecomment-410799312