### PR TITLE
Update telemetry dependency for all extensions

### DIFF
--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -23,7 +23,8 @@
   "categories": ["Debuggers"],
   "dependencies": {
     "@salesforce/salesforcedx-apex-debugger": "43.10.0",
-    "vscode-debugprotocol": "1.28.0"
+    "vscode-debugprotocol": "1.28.0",
+    "vscode-extension-telemetry": "0.0.17"
   },
   "devDependencies": {
     "@types/chai": "^4.0.0",
@@ -34,8 +35,7 @@
     "cross-env": "^5.0.5",
     "mocha": "3.2.0",
     "sinon": "^2.3.6",
-    "vscode": "1.1.17",
-    "vscode-extension-telemetry": "0.0.17"
+    "vscode": "1.1.17"
   },
   "extensionDependencies": [
     "salesforce.salesforcedx-vscode-apex",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -25,7 +25,8 @@
     "@salesforce/salesforcedx-apex-replay-debugger": "43.10.0",
     "async-lock": "1.0.0",
     "path-exists": "3.0.0",
-    "request-light": "0.2.1"
+    "request-light": "0.2.1",
+    "vscode-extension-telemetry": "0.0.17"
   },
   "devDependencies": {
     "@types/async-lock": "0.0.20",
@@ -38,8 +39,7 @@
     "cross-env": "^5.0.5",
     "mocha": "3.2.0",
     "sinon": "^2.3.6",
-    "vscode": "1.1.17",
-    "vscode-extension-telemetry": "0.0.17"
+    "vscode": "1.1.17"
   },
   "extensionDependencies": [
     "salesforce.salesforcedx-vscode-apex",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -36,8 +36,7 @@
     "sinon": "^2.3.6",
     "shelljs": "^0.7.8",
     "typescript": "2.6.2",
-    "vscode": "1.1.17",
-    "vscode-extension-telemetry": "0.0.17"
+    "vscode": "1.1.17"
   },
   "extensionDependencies": ["salesforce.salesforcedx-vscode-core"],
   "scripts": {
@@ -97,6 +96,7 @@
     "expand-home-dir": "0.0.3",
     "find-java-home": "0.2.0",
     "path-exists": "3.0.0",
+    "vscode-extension-telemetry": "0.0.17",
     "vscode-languageclient": "3.5.1"
   }
 }

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -22,7 +22,8 @@
   },
   "categories": ["Programming Languages"],
   "dependencies": {
-    "@salesforce/salesforcedx-slds-linter": "43.10.0"
+    "@salesforce/salesforcedx-slds-linter": "43.10.0",
+    "vscode-extension-telemetry": "0.0.17"
   },
   "devDependencies": {
     "@salesforce/salesforcedx-utils-vscode": "43.10.0",
@@ -35,8 +36,7 @@
     "mocha": "3.2.0",
     "sinon": "^2.3.6",
     "typescript": "2.6.2",
-    "vscode": "1.1.17",
-    "vscode-extension-telemetry": "0.0.17"
+    "vscode": "1.1.17"
   },
   "extensionDependencies": ["salesforce.salesforcedx-vscode-core"],
   "scripts": {

--- a/packages/salesforcedx-vscode-lwc-next/package.json
+++ b/packages/salesforcedx-vscode-lwc-next/package.json
@@ -29,6 +29,7 @@
     "eslint-plugin-lwc": "0.4.0",
     "lwc-language-server": "1.6.4",
     "rxjs": "^5.4.1",
+    "vscode-extension-telemetry": "0.0.17",
     "vscode-languageclient": "3.5.1"
   },
   "devDependencies": {
@@ -41,8 +42,7 @@
     "mocha": "3.2.0",
     "sinon": "^2.3.6",
     "typescript": "2.6.2",
-    "vscode": "1.1.17",
-    "vscode-extension-telemetry": "0.0.17"
+    "vscode": "1.1.17"
   },
   "extensionDependencies": [
     "dbaeumer.vscode-eslint",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -29,6 +29,7 @@
     "eslint-plugin-lwc": "0.3.2",
     "lwc-language-server": "1.5.1",
     "rxjs": "^5.4.1",
+    "vscode-extension-telemetry": "0.0.17",
     "vscode-languageclient": "3.5.1"
   },
   "devDependencies": {
@@ -41,8 +42,7 @@
     "mocha": "3.2.0",
     "sinon": "^2.3.6",
     "typescript": "2.6.2",
-    "vscode": "1.1.17",
-    "vscode-extension-telemetry": "0.0.17"
+    "vscode": "1.1.17"
   },
   "extensionDependencies": [
     "dbaeumer.vscode-eslint",

--- a/packages/salesforcedx-vscode-visualforce/package.json
+++ b/packages/salesforcedx-vscode-visualforce/package.json
@@ -25,6 +25,7 @@
     "@salesforce/salesforcedx-visualforce-language-server": "43.10.0",
     "@salesforce/salesforcedx-visualforce-markup-language-server": "43.10.0",
     "typescript": "2.6.2",
+    "vscode-extension-telemetry": "0.0.17",
     "vscode-languageclient": "3.4.2",
     "vscode-languageserver-protocol": "3.4.2",
     "vscode-languageserver-types": "3.4.0"
@@ -39,8 +40,7 @@
     "cross-env": "^5.0.5",
     "mocha": "3.2.0",
     "sinon": "^2.3.6",
-    "vscode": "1.1.17",
-    "vscode-extension-telemetry": "0.0.17"
+    "vscode": "1.1.17"
   },
   "extensionDependencies": ["salesforce.salesforcedx-vscode-core"],
   "scripts": {


### PR DESCRIPTION
### What does this PR do?
It makes sure that vscode-extension-telemetry dependency is included in the vsix for all extensions which are now depending on core to load it.

### What issues does this PR fix or reference?
@W-5307674@