### PR TITLE
Update node types to version 8.0.0

### DIFF
--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -21,7 +21,7 @@
     "@types/async-lock": "0.0.20",
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
-    "@types/node": "8.0.0",
+    "@types/node": "8.9.3",
     "@types/rimraf": "^2.0.2",
     "@types/sinon": "^2.3.2",
     "chai": "^4.0.2",

--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -21,7 +21,7 @@
     "@types/async-lock": "0.0.20",
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
-    "@types/node": "^6.0.40",
+    "@types/node": "8.0.0",
     "@types/rimraf": "^2.0.2",
     "@types/sinon": "^2.3.2",
     "chai": "^4.0.2",

--- a/packages/salesforcedx-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-apex-replay-debugger/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
-    "@types/node": "^6.0.40",
+    "@types/node": "8.0.0",
     "@types/sinon": "^2.3.2",
     "chai": "^4.0.2",
     "cross-env": "5.0.4",

--- a/packages/salesforcedx-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-apex-replay-debugger/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
-    "@types/node": "8.0.0",
+    "@types/node": "8.9.3",
     "@types/sinon": "^2.3.2",
     "chai": "^4.0.2",
     "cross-env": "5.0.4",

--- a/packages/salesforcedx-apex-replay-debugger/test/integration/goldFileUtil.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/integration/goldFileUtil.ts
@@ -29,7 +29,9 @@ export class GoldFileUtil {
   }
 
   public close(): void {
-    fs.writeFileSync(this.goldFilePath, this.golds.join('\n'), 'utf-8');
+    fs.writeFileSync(this.goldFilePath, this.golds.join('\n'), {
+      encoding: 'utf8'
+    });
   }
 
   public async assertTopState(

--- a/packages/salesforcedx-slds-linter/package.json
+++ b/packages/salesforcedx-slds-linter/package.json
@@ -13,7 +13,7 @@
     "@types/chai": "^4.0.0",
     "@types/glob": "^5.0.30",
     "@types/mocha": "^2.2.38",
-    "@types/node": "8.0.0",
+    "@types/node": "8.9.3",
     "@types/sinon": "^2.3.2",
     "chai": "^4.0.2",
     "decache": "^4.1.0",

--- a/packages/salesforcedx-slds-linter/package.json
+++ b/packages/salesforcedx-slds-linter/package.json
@@ -13,7 +13,7 @@
     "@types/chai": "^4.0.0",
     "@types/glob": "^5.0.30",
     "@types/mocha": "^2.2.38",
-    "@types/node": "^6.0.40",
+    "@types/node": "8.0.0",
     "@types/sinon": "^2.3.2",
     "chai": "^4.0.2",
     "decache": "^4.1.0",

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
-    "@types/node": "8.0.0",
+    "@types/node": "8.9.3",
     "@types/rimraf": "^2.0.2",
     "@types/shelljs": "0.7.4",
     "@types/sinon": "^2.3.2",

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
-    "@types/node": "^6.0.40",
+    "@types/node": "8.0.0",
     "@types/rimraf": "^2.0.2",
     "@types/shelljs": "0.7.4",
     "@types/sinon": "^2.3.2",

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -17,7 +17,7 @@
     "@types/cross-spawn": "6.0.0",
     "@types/glob": "^5.0.30",
     "@types/mocha": "^2.2.38",
-    "@types/node": "8.0.0",
+    "@types/node": "8.9.3",
     "@types/shelljs": "^0.7.4",
     "@types/sinon": "^2.3.2",
     "chai": "^4.0.2",

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -17,7 +17,7 @@
     "@types/cross-spawn": "6.0.0",
     "@types/glob": "^5.0.30",
     "@types/mocha": "^2.2.38",
-    "@types/node": "^6.0.40",
+    "@types/node": "8.0.0",
     "@types/shelljs": "^0.7.4",
     "@types/sinon": "^2.3.2",
     "chai": "^4.0.2",

--- a/packages/salesforcedx-utils-vscode/src/test/orgUtils.ts
+++ b/packages/salesforcedx-utils-vscode/src/test/orgUtils.ts
@@ -197,11 +197,9 @@ export function addFeatureToScratchOrgConfig(
     featuresList += feature;
     config.features = featuresList;
   }
-  fs.writeFileSync(
-    scratchDefFilePath,
-    JSON.stringify(config, null, '\t'),
-    'utf8'
-  );
+  fs.writeFileSync(scratchDefFilePath, JSON.stringify(config, null, '\t'), {
+    encoding: 'utf8'
+  });
 }
 
 export function pathToUri(str: string): string {

--- a/packages/salesforcedx-visualforce-language-server/package.json
+++ b/packages/salesforcedx-visualforce-language-server/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^2.2.38",
-    "@types/node": "8.0.0",
+    "@types/node": "8.9.3",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
     "mocha-junit-reporter": "^1.13.0",

--- a/packages/salesforcedx-visualforce-language-server/package.json
+++ b/packages/salesforcedx-visualforce-language-server/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^2.2.38",
-    "@types/node": "^6.0.40",
+    "@types/node": "8.0.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
     "mocha-junit-reporter": "^1.13.0",

--- a/packages/salesforcedx-visualforce-markup-language-server/package.json
+++ b/packages/salesforcedx-visualforce-markup-language-server/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@types/chai": "^4.0.0",
     "@types/mocha": "^2.2.38",
-    "@types/node": "8.0.0",
+    "@types/node": "8.9.3",
     "chai": "^4.0.2",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",

--- a/packages/salesforcedx-visualforce-markup-language-server/package.json
+++ b/packages/salesforcedx-visualforce-markup-language-server/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@types/chai": "^4.0.0",
     "@types/mocha": "^2.2.38",
-    "@types/node": "^6.0.40",
+    "@types/node": "8.0.0",
     "chai": "^4.0.2",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
-    "@types/node": "^6.0.40",
+    "@types/node": "8.0.0",
     "@types/sinon": "^2.3.2",
     "chai": "^4.0.2",
     "cross-env": "^5.0.5",

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
-    "@types/node": "8.0.0",
+    "@types/node": "8.9.3",
     "@types/sinon": "^2.3.2",
     "chai": "^4.0.2",
     "cross-env": "^5.0.5",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -32,7 +32,7 @@
     "@types/async-lock": "0.0.20",
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
-    "@types/node": "^6.0.40",
+    "@types/node": "8.0.0",
     "@types/path-exists": "^1.0.29",
     "@types/sinon": "^2.3.2",
     "chai": "^4.0.2",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -32,7 +32,7 @@
     "@types/async-lock": "0.0.20",
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
-    "@types/node": "8.0.0",
+    "@types/node": "8.9.3",
     "@types/path-exists": "^1.0.29",
     "@types/sinon": "^2.3.2",
     "chai": "^4.0.2",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
-    "@types/node": "8.0.0",
+    "@types/node": "8.9.3",
     "@types/path-exists": "^1.0.29",
     "@types/shelljs": "^0.7.4",
     "@types/sinon": "^2.3.2",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
-    "@types/node": "^6.0.40",
+    "@types/node": "8.0.0",
     "@types/path-exists": "^1.0.29",
     "@types/shelljs": "^0.7.4",
     "@types/sinon": "^2.3.2",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -38,7 +38,7 @@
     "@types/chai": "^4.0.0",
     "@types/glob": "^5.0.30",
     "@types/mocha": "2.2.38",
-    "@types/node": "^7.0.0",
+    "@types/node": "8.0.0",
     "@types/path-exists": "^1.0.29",
     "@types/sanitize-filename": "^1.1.28",
     "@types/shelljs": "^0.7.8",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -38,7 +38,7 @@
     "@types/chai": "^4.0.0",
     "@types/glob": "^5.0.30",
     "@types/mocha": "2.2.38",
-    "@types/node": "8.0.0",
+    "@types/node": "8.9.3",
     "@types/path-exists": "^1.0.29",
     "@types/sanitize-filename": "^1.1.28",
     "@types/shelljs": "^0.7.8",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -29,7 +29,7 @@
     "@salesforce/salesforcedx-utils-vscode": "43.12.0",
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
-    "@types/node": "^6.0.40",
+    "@types/node": "8.0.0",
     "@types/sinon": "^2.3.2",
     "chai": "^4.0.2",
     "cross-env": "^5.0.5",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -29,7 +29,7 @@
     "@salesforce/salesforcedx-utils-vscode": "43.12.0",
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
-    "@types/node": "8.0.0",
+    "@types/node": "8.9.3",
     "@types/sinon": "^2.3.2",
     "chai": "^4.0.2",
     "cross-env": "^5.0.5",

--- a/packages/salesforcedx-vscode-lwc-next/package.json
+++ b/packages/salesforcedx-vscode-lwc-next/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
-    "@types/node": "8.0.0",
+    "@types/node": "8.9.3",
     "@types/sinon": "^2.3.2",
     "chai": "^4.0.2",
     "cross-env": "^5.0.5",

--- a/packages/salesforcedx-vscode-lwc-next/package.json
+++ b/packages/salesforcedx-vscode-lwc-next/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
-    "@types/node": "^6.0.40",
+    "@types/node": "8.0.0",
     "@types/sinon": "^2.3.2",
     "chai": "^4.0.2",
     "cross-env": "^5.0.5",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
-    "@types/node": "8.0.0",
+    "@types/node": "8.9.3",
     "@types/sinon": "^2.3.2",
     "chai": "^4.0.2",
     "cross-env": "^5.0.5",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
-    "@types/node": "^6.0.40",
+    "@types/node": "8.0.0",
     "@types/sinon": "^2.3.2",
     "chai": "^4.0.2",
     "cross-env": "^5.0.5",

--- a/packages/salesforcedx-vscode-visualforce/package.json
+++ b/packages/salesforcedx-vscode-visualforce/package.json
@@ -34,7 +34,7 @@
     "@salesforce/salesforcedx-utils-vscode": "43.12.0",
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
-    "@types/node": "^6.0.40",
+    "@types/node": "8.0.0",
     "@types/sinon": "^2.3.2",
     "chai": "^4.0.2",
     "cross-env": "^5.0.5",

--- a/packages/salesforcedx-vscode-visualforce/package.json
+++ b/packages/salesforcedx-vscode-visualforce/package.json
@@ -34,7 +34,7 @@
     "@salesforce/salesforcedx-utils-vscode": "43.12.0",
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
-    "@types/node": "8.0.0",
+    "@types/node": "8.9.3",
     "@types/sinon": "^2.3.2",
     "chai": "^4.0.2",
     "cross-env": "^5.0.5",

--- a/packages/system-tests/package.json
+++ b/packages/system-tests/package.json
@@ -13,7 +13,7 @@
     "@types/chai": "^4.0.0",
     "@types/mkdirp": "0.5.2",
     "@types/mocha": "2.2.38",
-    "@types/node": "^6.0.40",
+    "@types/node": "8.0.0",
     "@types/rimraf": "0.0.28",
     "@types/shelljs": "^0.7.4",
     "@types/webdriverio": "4.6.1",

--- a/packages/system-tests/package.json
+++ b/packages/system-tests/package.json
@@ -13,7 +13,7 @@
     "@types/chai": "^4.0.0",
     "@types/mkdirp": "0.5.2",
     "@types/mocha": "2.2.38",
-    "@types/node": "8.0.0",
+    "@types/node": "8.9.3",
     "@types/rimraf": "0.0.28",
     "@types/shelljs": "^0.7.4",
     "@types/webdriverio": "4.6.1",
@@ -39,12 +39,13 @@
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
-    "clean": "shx rm -rf .vscode-test && shx rm -rf node_modules && shx rm -rf out",
+    "clean":
+      "shx rm -rf .vscode-test && shx rm -rf node_modules && shx rm -rf out",
     "postinstall": "node ./node_modules/vscode/bin/install",
-    "pretest": "npm run compile && node ../../scripts/download-vscode-for-system-tests",
-    "coverage": "npm run pretest && node ../../scripts/instrument-salesforcedx-vscode-extensions && cross-env COLLECT_COVERAGE=1 npm run test && node ../../scripts/remap-coverage"
+    "pretest":
+      "npm run compile && node ../../scripts/download-vscode-for-system-tests",
+    "coverage":
+      "npm run pretest && node ../../scripts/instrument-salesforcedx-vscode-extensions && cross-env COLLECT_COVERAGE=1 npm run test && node ../../scripts/remap-coverage"
   },
-  "activationEvents": [
-    "*"
-  ]
+  "activationEvents": ["*"]
 }


### PR DESCRIPTION
### What does this PR do?
Updates node types to 8.0.0 now that vscode has updated to a newer electron version (https://code.visualstudio.com/updates/v1_26#_nodejs-update)

### What issues does this PR fix or reference?
Comments on PR #555 