### PR TITLE
Selectively show apex test view

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -70,7 +70,8 @@
       "test": [
         {
           "id": "sfdx.force.test.view",
-          "name": "%test_view_name%"
+          "name": "%test_view_name%",
+          "when": "sfdx:project_opened"
         }
       ]
     },


### PR DESCRIPTION
### What does this PR do?

The Apex Test View should only show up when you have an SFDX project opened. Without this fix, the Apex Test View shows up for all projects.

### What issues does this PR fix or reference?

@W-5296138@
