### PR TITLE
Fix vscode-lightning test failure

### DIFF
--- a/packages/salesforcedx-vscode-lightning/test/deprecatedClassName.test.ts
+++ b/packages/salesforcedx-vscode-lightning/test/deprecatedClassName.test.ts
@@ -26,14 +26,18 @@ describe('SLDS Deprecated Class Name', () => {
     }
   });
 
-  it('Should create SFDX fix deprecated class command', async () => {
-    if (coreExtension && !coreExtension.isActive) {
-      await coreExtension.activate();
-    }
+  it('coreExtension activation', async () => {
+    await coreExtension.activate();
+    expect(coreExtension.isActive);
+  });
 
-    if (lightningExtension && !lightningExtension.isActive) {
-      await lightningExtension.activate();
-    }
+  it('lightningExtension activation', async () => {
+    await lightningExtension.activate();
+    expect(lightningExtension.isActive);
+  });
+
+  it('Should create SFDX fix deprecated class command', async () => {
+    expect(lightningExtension.isActive);
 
     res = await vscode.workspace.findFiles(
       path.join('**', 'DemoComponent.cmp')

--- a/packages/salesforcedx-vscode-lightning/test/deprecatedClassName.test.ts
+++ b/packages/salesforcedx-vscode-lightning/test/deprecatedClassName.test.ts
@@ -26,7 +26,9 @@ describe('SLDS Deprecated Class Name', () => {
     }
   });
 
-  it('coreExtension activation', async () => {
+  it('coreExtension activation', async function() {
+    // tslint:disable-next-line:no-invalid-this
+    this.timeout(0);
     await coreExtension.activate();
     expect(coreExtension.isActive);
   });

--- a/packages/salesforcedx-vscode-lightning/test/deprecatedClassName.test.ts
+++ b/packages/salesforcedx-vscode-lightning/test/deprecatedClassName.test.ts
@@ -11,10 +11,15 @@ import * as vscode from 'vscode';
 
 describe('SLDS Deprecated Class Name', () => {
   let res: vscode.Uri[];
+  let coreExtension: vscode.Extension<any>;
   let lightningExtension: vscode.Extension<any>;
 
   before(async () => {
     if (vscode.workspace.rootPath) {
+      coreExtension = vscode.extensions.getExtension(
+        'salesforce.salesforcedx-vscode-core'
+      ) as vscode.Extension<any>;
+
       lightningExtension = vscode.extensions.getExtension(
         'salesforce.salesforcedx-vscode-lightning'
       ) as vscode.Extension<any>;
@@ -22,9 +27,14 @@ describe('SLDS Deprecated Class Name', () => {
   });
 
   it('Should create SFDX fix deprecated class command', async () => {
+    if (coreExtension && !coreExtension.isActive) {
+      await coreExtension.activate();
+    }
+
     if (lightningExtension && !lightningExtension.isActive) {
       await lightningExtension.activate();
     }
+
     res = await vscode.workspace.findFiles(
       path.join('**', 'DemoComponent.cmp')
     );

--- a/packages/salesforcedx-vscode-lightning/test/deprecatedClassName.test.ts
+++ b/packages/salesforcedx-vscode-lightning/test/deprecatedClassName.test.ts
@@ -28,7 +28,7 @@ describe('SLDS Deprecated Class Name', () => {
 
   it('coreExtension activation', async function() {
     // tslint:disable-next-line:no-invalid-this
-    this.timeout(0);
+    this.timeout(10000);
     await coreExtension.activate();
     expect(coreExtension.isActive);
   });


### PR DESCRIPTION
### What does this PR do?
Updates tests in vscode-lightning extension that were failing. Root cause of the failure is an increase in the time it takes to activate salesforcedx-vscode-core extension.

### What issues does this PR fix or reference?
