### PR TITLE
Change default scratch alias to folder name

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
@@ -50,17 +50,27 @@ export class ForceOrgCreateExecutor extends SfdxCommandletExecutor<
 
 export class AliasGatherer implements ParametersGatherer<Alias> {
   public async gather(): Promise<CancelResponse | ContinueResponse<Alias>> {
+    let defaultAlias = DEFAULT_ALIAS;
+    if (
+      vscode.workspace.workspaceFolders &&
+      vscode.workspace.workspaceFolders[0]
+    ) {
+      defaultAlias = vscode.workspace.workspaceFolders[0].name.replace(
+        /\W/g /* Replace all non-alphanumeric characters */,
+        ''
+      );
+    }
     const aliasInputOptions = {
       prompt: nls.localize('parameter_gatherer_enter_alias_name'),
-      placeHolder: DEFAULT_ALIAS
+      placeHolder: defaultAlias
     } as vscode.InputBoxOptions;
     const alias = await vscode.window.showInputBox(aliasInputOptions);
-    // Hitting enter with no alias will default the alias to 'vscodeScratchOrg'
+    // Hitting enter with no alias will use the value of `defaultAlias`
     if (alias === undefined) {
       return { type: 'CANCEL' };
     }
     return alias === ''
-      ? { type: 'CONTINUE', data: { alias: DEFAULT_ALIAS } }
+      ? { type: 'CONTINUE', data: { alias: defaultAlias } }
       : { type: 'CONTINUE', data: { alias } };
   }
 }

--- a/packages/salesforcedx-vscode-core/test/commands/forceOrgCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceOrgCreate.test.ts
@@ -11,7 +11,6 @@ import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import {
   AliasGatherer,
-  DEFAULT_ALIAS,
   ForceOrgCreateExecutor
 } from '../../src/commands/forceOrgCreate';
 import { nls } from '../../src/messages';
@@ -20,6 +19,7 @@ import { nls } from '../../src/messages';
 describe('Force Org Create', () => {
   describe('Alias Gatherer', () => {
     const TEST_ALIAS = 'testAlias';
+    const TEST_WORKSPACE = 'sfdxsimple'; // FYI: This test uses the workspace created by the system tests to run
     let inputBoxSpy: sinon.SinonStub;
 
     before(() => {
@@ -45,7 +45,7 @@ describe('Force Org Create', () => {
       const response = await gatherer.gather();
       expect(inputBoxSpy.calledTwice).to.be.true;
       if (response.type === 'CONTINUE') {
-        expect(response.data.alias).to.equal(DEFAULT_ALIAS);
+        expect(response.data.alias).to.equal(TEST_WORKSPACE);
       } else {
         expect.fail('Response should be of type ContinueResponse');
       }


### PR DESCRIPTION
### What does this PR do?
Changes the default alias name to be the folder name rather than the hard-coded string.

This is from the intern, I am just submitting it since his internship ended.

### What issues does this PR fix or reference?
