### PR TITLE
Updated debugger package.json to prevent activation in non sfdx project

### DIFF
--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -55,7 +55,10 @@
     "test": "node ../../scripts/run-test-with-top-level-extensions",
     "test:unit": "node ../../scripts/run-test-with-top-level-extensions"
   },
-  "activationEvents": ["onDebug", "workspaceContains:sfdx-project.json"],
+  "activationEvents": [
+    "onDebugResolve:apex",
+    "workspaceContains:sfdx-project.json"
+  ],
   "main": "./out/src",
   "contributes": {
     "breakpoints": [

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -60,7 +60,7 @@
     "test:unit": "node ../../scripts/run-test-with-top-level-extensions"
   },
   "activationEvents": [
-    "onDebug",
+    "onDebugResolve:apex",
     "onCommand:extension.replay-debugger.getLogFileName",
     "workspaceContains:sfdx-project.json"
   ],


### PR DESCRIPTION
### What does this PR do?
Updated the package.json for apex debugger and replay debugger to activate when 'apex' is specified.

I checked to see that apex debugger and replay debugger do not get activated and .sfdx folder is not created in non-sfdx projects. Checked to make sure debuggers are still getting activated in sfdx projects. (I'm not sure if this should be tested for something else as well.)

### What issues does this PR fix or reference?
W-4629156