### PR TITLE
Fix lightning component syntax highlighting issues

### DIFF
--- a/packages/salesforcedx-vscode-lightning/OSSREADME.json
+++ b/packages/salesforcedx-vscode-lightning/OSSREADME.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "microsoft/vscode",
+    "license": "MIT",
+    "licenseDetail": [
+      "MIT License",
+      "",
+      "Copyright (c) 2015 - present Microsoft Corporation",
+      "",
+      "Permission is hereby granted, free of charge, to any person obtaining a copy",
+      "of this software and associated documentation files (the \"Software\"), to deal",
+      "in the Software without restriction, including without limitation the rights",
+      "to use, copy, modify, merge, publish, distribute, sublicense, and/or sell",
+      "copies of the Software, and to permit persons to whom the Software is",
+      "furnished to do so, subject to the following conditions:",
+      "",
+      "The above copyright notice and this permission notice shall be included in all",
+      "copies or substantial portions of the Software.",
+      "",
+      "THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR",
+      "IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,",
+      "FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE",
+      "AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER",
+      "LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,",
+      "OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+    ],
+    "version": "1.26.0",
+    "repositoryURL": "https://github.com/Microsoft/vscode"
+  }
+]

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -69,6 +69,13 @@
           ".tokens"
         ]
       }
+    ],
+    "grammars": [
+      {
+        "language": "html",
+        "scopeName": "text.html.basic",
+        "path": "./syntaxes/html.tmLanguage.json"
+      }
     ]
   }
 }

--- a/packages/salesforcedx-vscode-lightning/syntaxes/html.tmLanguage.json
+++ b/packages/salesforcedx-vscode-lightning/syntaxes/html.tmLanguage.json
@@ -1,0 +1,746 @@
+{
+  "information_for_contributors": [
+    "This file has been converted from https://github.com/textmate/html.tmbundle/blob/master/Syntaxes/HTML.plist",
+    "If you want to provide a fix or improvement, please create a pull request against the original repository.",
+    "Once accepted there, we are happy to receive an update request."
+  ],
+  "version":
+    "https://github.com/textmate/html.tmbundle/commit/a723f08ebd49c67c22aca08dd8f17d0bf836ec93",
+  "name": "HTML",
+  "scopeName": "text.html.basic",
+  "injections": {
+    "R:text.html - (comment.block, text.html source)": {
+      "comment": "Use R: to ensure this matches after any other injections.",
+      "patterns": [
+        {
+          "match": "<",
+          "name": "invalid.illegal.bad-angle-bracket.html"
+        }
+      ]
+    }
+  },
+  "patterns": [
+    {
+      "begin": "(<)([a-zA-Z][a-zA-Z0-9:-]*)(?=[^>]*></\\2>)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.html"
+        },
+        "2": {
+          "name": "entity.name.tag.html"
+        }
+      },
+      "end": "(>(<)/)(\\2)(>)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.html"
+        },
+        "2": {
+          "name": "meta.scope.between-tag-pair.html"
+        },
+        "3": {
+          "name": "entity.name.tag.html"
+        },
+        "4": {
+          "name": "punctuation.definition.tag.html"
+        }
+      },
+      "name": "meta.tag.any.html",
+      "patterns": [
+        {
+          "include": "#tag-stuff"
+        }
+      ]
+    },
+    {
+      "begin": "(<\\?)(xml)",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.tag.html"
+        },
+        "2": {
+          "name": "entity.name.tag.xml.html"
+        }
+      },
+      "end": "(\\?>)",
+      "name": "meta.tag.preprocessor.xml.html",
+      "patterns": [
+        {
+          "include": "#tag-generic-attribute"
+        },
+        {
+          "include": "#string-double-quoted"
+        },
+        {
+          "include": "#string-single-quoted"
+        }
+      ]
+    },
+    {
+      "begin": "<!--",
+      "captures": {
+        "0": {
+          "name": "punctuation.definition.comment.html"
+        }
+      },
+      "end": "--\\s*>",
+      "name": "comment.block.html",
+      "patterns": [
+        {
+          "match": "--",
+          "name": "invalid.illegal.bad-comments-or-CDATA.html"
+        },
+        {
+          "include": "#embedded-code"
+        }
+      ]
+    },
+    {
+      "begin": "<!",
+      "captures": {
+        "0": {
+          "name": "punctuation.definition.tag.html"
+        }
+      },
+      "end": ">",
+      "name": "meta.tag.sgml.html",
+      "patterns": [
+        {
+          "begin": "(?i:DOCTYPE)",
+          "captures": {
+            "1": {
+              "name": "entity.name.tag.doctype.html"
+            }
+          },
+          "end": "(?=>)",
+          "name": "meta.tag.sgml.doctype.html",
+          "patterns": [
+            {
+              "match": "\"[^\">]*\"",
+              "name": "string.quoted.double.doctype.identifiers-and-DTDs.html"
+            }
+          ]
+        },
+        {
+          "begin": "\\[CDATA\\[",
+          "end": "]](?=>)",
+          "name": "constant.other.inline-data.html"
+        },
+        {
+          "match": "(\\s*)(?!--|>)\\S(\\s*)",
+          "name": "invalid.illegal.bad-comments-or-CDATA.html"
+        }
+      ]
+    },
+    {
+      "include": "#embedded-code"
+    },
+    {
+      "begin": "(^[ \\t]+)?(?=<(?i:style))",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.whitespace.embedded.leading.html"
+        }
+      },
+      "end": "(?!\\G)([ \\t]*$\\n?)?",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.whitespace.embedded.trailing.html"
+        }
+      },
+      "patterns": [
+        {
+          "begin": "(<)((?i:style))\\b",
+          "beginCaptures": {
+            "0": {
+              "name": "meta.tag.metadata.style.html"
+            },
+            "1": {
+              "name": "punctuation.definition.tag.begin.html"
+            },
+            "2": {
+              "name": "entity.name.tag.html"
+            }
+          },
+          "end": "(/>)|((<)/)((?i:style))(>)",
+          "endCaptures": {
+            "0": {
+              "name": "meta.tag.metadata.style.html"
+            },
+            "1": {
+              "name": "punctuation.definition.tag.end.html"
+            },
+            "2": {
+              "name": "punctuation.definition.tag.begin.html"
+            },
+            "3": {
+              "name": "source.css"
+            },
+            "4": {
+              "name": "entity.name.tag.html"
+            },
+            "5": {
+              "name": "punctuation.definition.tag.end.html"
+            }
+          },
+          "name": "meta.embedded.block.html",
+          "patterns": [
+            {
+              "begin": "\\G",
+              "captures": {
+                "1": {
+                  "name": "punctuation.definition.tag.end.html"
+                }
+              },
+              "end": "(?=/>)|(>)",
+              "name": "meta.tag.metadata.style.html",
+              "patterns": [
+                {
+                  "include": "#tag-stuff"
+                }
+              ]
+            },
+            {
+              "begin": "(?!\\G)",
+              "end": "(?=</(?i:style))",
+              "name": "source.css",
+              "patterns": [
+                {
+                  "include": "#embedded-code"
+                },
+                {
+                  "include": "source.css"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "begin": "(^[ \\t]+)?(?=<(?i:script))",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.whitespace.embedded.leading.html"
+        }
+      },
+      "end": "(?!\\G)([ \\t]*$\\n?)?",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.whitespace.embedded.trailing.html"
+        }
+      },
+      "patterns": [
+        {
+          "begin": "(<)((?i:script))\\b",
+          "beginCaptures": {
+            "0": {
+              "name": "meta.tag.metadata.script.html"
+            },
+            "1": {
+              "name": "punctuation.definition.tag.begin.html"
+            },
+            "2": {
+              "name": "entity.name.tag.html"
+            }
+          },
+          "end": "(/>)|(/)((?i:script))(>)",
+          "endCaptures": {
+            "0": {
+              "name": "meta.tag.metadata.script.html"
+            },
+            "1": {
+              "name": "punctuation.definition.tag.end.html"
+            },
+            "2": {
+              "name": "punctuation.definition.tag.begin.html"
+            },
+            "3": {
+              "name": "entity.name.tag.html"
+            },
+            "4": {
+              "name": "punctuation.definition.tag.end.html"
+            }
+          },
+          "name": "meta.embedded.block.html",
+          "patterns": [
+            {
+              "begin": "\\G",
+              "end": "(?=/>|/)",
+              "patterns": [
+                {
+                  "begin": "(>)",
+                  "beginCaptures": {
+                    "0": {
+                      "name": "meta.tag.metadata.script.html"
+                    },
+                    "1": {
+                      "name": "punctuation.definition.tag.end.html"
+                    }
+                  },
+                  "end": "((<))(?=/(?i:script))",
+                  "endCaptures": {
+                    "0": {
+                      "name": "meta.tag.metadata.script.html"
+                    },
+                    "1": {
+                      "name": "punctuation.definition.tag.begin.html"
+                    },
+                    "2": {
+                      "name": "source.js"
+                    }
+                  },
+                  "patterns": [
+                    {
+                      "begin": "\\G",
+                      "end": "(?=</(?i:script))",
+                      "name": "source.js",
+                      "patterns": [
+                        {
+                          "begin": "(^[ \\t]+)?(?=//)",
+                          "beginCaptures": {
+                            "1": {
+                              "name":
+                                "punctuation.whitespace.comment.leading.js"
+                            }
+                          },
+                          "end": "(?!\\G)",
+                          "patterns": [
+                            {
+                              "begin": "//",
+                              "beginCaptures": {
+                                "0": {
+                                  "name": "punctuation.definition.comment.js"
+                                }
+                              },
+                              "end": "(?=</script)|\\n",
+                              "name": "comment.line.double-slash.js"
+                            }
+                          ]
+                        },
+                        {
+                          "begin": "/\\*",
+                          "captures": {
+                            "0": {
+                              "name": "punctuation.definition.comment.js"
+                            }
+                          },
+                          "end": "\\*/|(?=</script)",
+                          "name": "comment.block.js"
+                        },
+                        {
+                          "include": "source.js"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "begin": "\\G",
+                  "end":
+                    "(?i:(?=/?>|type(?=[\\s=])(?!\\s*=\\s*('|\"|)(text/(javascript|ecmascript|babel)|application/((x-)?javascript|ecmascript|babel)|module)[\\s\"'>])))",
+                  "name": "meta.tag.metadata.script.html",
+                  "patterns": [
+                    {
+                      "include": "#tag-stuff"
+                    }
+                  ]
+                },
+                {
+                  "begin":
+                    "(?=(?i:type\\s*=\\s*('|\"|)(text/(x-handlebars|(x-(handlebars-)?|ng-)?template|html)[\\s\"'>])))",
+                  "end": "((<))(?=/(?i:script))",
+                  "endCaptures": {
+                    "0": {
+                      "name": "meta.tag.metadata.script.html"
+                    },
+                    "1": {
+                      "name": "punctuation.definition.tag.begin.html"
+                    },
+                    "2": {
+                      "name": "text.html.basic"
+                    }
+                  },
+                  "patterns": [
+                    {
+                      "begin": "\\G",
+                      "end": "(>)|(?=/>)",
+                      "endCaptures": {
+                        "1": {
+                          "name": "punctuation.definition.tag.end.html"
+                        }
+                      },
+                      "name": "meta.tag.metadata.script.html",
+                      "patterns": [
+                        {
+                          "include": "#tag-stuff"
+                        }
+                      ]
+                    },
+                    {
+                      "begin": "(?!\\G)",
+                      "end": "(?=</(?i:script))",
+                      "name": "text.html.basic",
+                      "patterns": [
+                        {
+                          "include": "text.html.basic"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "begin": "(?=(?i:type))",
+                  "end": "(<)(?=/(?i:script))",
+                  "endCaptures": {
+                    "0": {
+                      "name": "meta.tag.metadata.script.html"
+                    },
+                    "1": {
+                      "name": "punctuation.definition.tag.begin.html"
+                    }
+                  },
+                  "patterns": [
+                    {
+                      "begin": "\\G",
+                      "end": "(>)|(?=/>)",
+                      "endCaptures": {
+                        "1": {
+                          "name": "punctuation.definition.tag.end.html"
+                        }
+                      },
+                      "name": "meta.tag.metadata.script.html",
+                      "patterns": [
+                        {
+                          "include": "#tag-stuff"
+                        }
+                      ]
+                    },
+                    {
+                      "begin": "(?!\\G)",
+                      "end": "(?=</(?i:script))",
+                      "name": "source.unknown"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "begin": "(</?)((?i:body|head|html)\\b)",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.tag.html"
+        },
+        "2": {
+          "name": "entity.name.tag.structure.any.html"
+        }
+      },
+      "end": "(>)",
+      "name": "meta.tag.structure.any.html",
+      "patterns": [
+        {
+          "include": "#tag-stuff"
+        }
+      ]
+    },
+    {
+      "begin":
+        "(</?)((?i:address|blockquote|dd|div|section|article|aside|header|footer|nav|menu|dl|dt|fieldset|form|frame|frameset|h1|h2|h3|h4|h5|h6|iframe|noframes|object|ol|p|ul|applet|center|dir|hr|pre)\\b)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.begin.html"
+        },
+        "2": {
+          "name": "entity.name.tag.block.any.html"
+        }
+      },
+      "end": "(>)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.end.html"
+        }
+      },
+      "name": "meta.tag.block.any.html",
+      "patterns": [
+        {
+          "include": "#tag-stuff"
+        }
+      ]
+    },
+    {
+      "begin":
+        "(</?)((?i:a|abbr|acronym|area|b|base|basefont|bdo|big|br|button|caption|cite|code|col|colgroup|del|dfn|em|font|head|html|i|img|input|ins|isindex|kbd|label|legend|li|link|map|meta|noscript|optgroup|option|param|q|s|samp|script|select|small|span|strike|strong|style|sub|sup|table|tbody|td|textarea|tfoot|th|thead|title|tr|tt|u|var)\\b(?!-))",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.begin.html"
+        },
+        "2": {
+          "name": "entity.name.tag.inline.any.html"
+        }
+      },
+      "end": "((?: ?/)?>)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.end.html"
+        }
+      },
+      "name": "meta.tag.inline.any.html",
+      "patterns": [
+        {
+          "include": "#tag-stuff"
+        }
+      ]
+    },
+    {
+      "begin": "(</?)([a-zA-Z][a-zA-Z0-9:-]*)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.begin.html"
+        },
+        "2": {
+          "name": "entity.name.tag.other.html"
+        }
+      },
+      "end": "(/?>)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.end.html"
+        }
+      },
+      "name": "meta.tag.other.html",
+      "patterns": [
+        {
+          "include": "#tag-stuff"
+        }
+      ]
+    },
+    {
+      "include": "#entities"
+    },
+    {
+      "match": "<>",
+      "name": "invalid.illegal.incomplete.html"
+    }
+  ],
+  "repository": {
+    "embedded-code": {
+      "patterns": [
+        {
+          "include": "#smarty"
+        },
+        {
+          "include": "#python"
+        }
+      ]
+    },
+    "entities": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.entity.html"
+            },
+            "3": {
+              "name": "punctuation.definition.entity.html"
+            }
+          },
+          "match": "(&)([a-zA-Z0-9]+|#[0-9]+|#[xX][0-9a-fA-F]+)(;)",
+          "name": "constant.character.entity.html"
+        },
+        {
+          "match": "&",
+          "name": "invalid.illegal.bad-ampersand.html"
+        }
+      ]
+    },
+    "python": {
+      "begin": "(?:^\\s*)<\\?python(?!.*\\?>)",
+      "end": "\\?>(?:\\s*$\\n)?",
+      "name": "source.python.embedded.html",
+      "patterns": [
+        {
+          "include": "source.python"
+        }
+      ]
+    },
+    "smarty": {
+      "patterns": [
+        {
+          "begin": "(\\{(literal)\\})",
+          "captures": {
+            "1": {
+              "name": "source.smarty.embedded.html"
+            },
+            "2": {
+              "name": "support.function.built-in.smarty"
+            }
+          },
+          "end": "(\\{/(literal)\\})"
+        },
+        {
+          "begin": "{{|{",
+          "disabled": 1,
+          "end": "}}|}",
+          "name": "source.smarty.embedded.html",
+          "patterns": [
+            {
+              "include": "source.smarty"
+            }
+          ]
+        }
+      ]
+    },
+    "string-double-quoted": {
+      "begin": "\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.html"
+        }
+      },
+      "end": "\"",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.html"
+        }
+      },
+      "name": "string.quoted.double.html",
+      "patterns": [
+        {
+          "include": "#embedded-code"
+        },
+        {
+          "include": "#entities"
+        }
+      ]
+    },
+    "string-single-quoted": {
+      "begin": "'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.html"
+        }
+      },
+      "end": "'",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.html"
+        }
+      },
+      "name": "string.quoted.single.html",
+      "patterns": [
+        {
+          "include": "#embedded-code"
+        },
+        {
+          "include": "#entities"
+        }
+      ]
+    },
+    "tag-generic-attribute": {
+      "match": "(?<=[^=])\\b([a-zA-Z0-9:-]+)",
+      "name": "entity.other.attribute-name.html"
+    },
+    "tag-id-attribute": {
+      "begin": "\\b(id)\\b\\s*(=)",
+      "captures": {
+        "1": {
+          "name": "entity.other.attribute-name.id.html"
+        },
+        "2": {
+          "name": "punctuation.separator.key-value.html"
+        }
+      },
+      "end": "(?!\\G)(?<='|\"|[^\\s<>/])",
+      "name": "meta.attribute-with-value.id.html",
+      "patterns": [
+        {
+          "begin": "\"",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.html"
+            }
+          },
+          "contentName": "meta.toc-list.id.html",
+          "end": "\"",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.html"
+            }
+          },
+          "name": "string.quoted.double.html",
+          "patterns": [
+            {
+              "include": "#embedded-code"
+            },
+            {
+              "include": "#entities"
+            }
+          ]
+        },
+        {
+          "begin": "'",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.html"
+            }
+          },
+          "contentName": "meta.toc-list.id.html",
+          "end": "'",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.html"
+            }
+          },
+          "name": "string.quoted.single.html",
+          "patterns": [
+            {
+              "include": "#embedded-code"
+            },
+            {
+              "include": "#entities"
+            }
+          ]
+        },
+        {
+          "captures": {
+            "0": {
+              "name": "meta.toc-list.id.html"
+            }
+          },
+          "match": "(?<==)(?:[^\\s<>/'\"]|/(?!>))+",
+          "name": "string.unquoted.html"
+        }
+      ]
+    },
+    "tag-stuff": {
+      "patterns": [
+        {
+          "include": "#tag-id-attribute"
+        },
+        {
+          "include": "#tag-generic-attribute"
+        },
+        {
+          "include": "#string-double-quoted"
+        },
+        {
+          "include": "#string-single-quoted"
+        },
+        {
+          "include": "#embedded-code"
+        },
+        {
+          "include": "#unquoted-attribute"
+        }
+      ]
+    },
+    "unquoted-attribute": {
+      "match": "(?<==)(?:[^\\s<>/'\"]|/(?!>))+",
+      "name": "string.unquoted.html"
+    }
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Forks the previous version of the html syntax file (https://github.com/textmate/html.tmbundle) and includes it as part of the lightning extension.

### What issues does this PR fix or reference?
#573 