### PR TITLE
Track Apex LSP startup time, errors and apex extension startup time

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/languageServer.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageServer.ts
@@ -15,6 +15,7 @@ import {
 } from 'vscode-languageclient';
 import { nls } from './messages';
 import * as requirements from './requirements';
+import { telemetryService } from './telemetry';
 
 const UBER_JAR_NAME = 'apex-jorje-lsp.jar';
 const JDWP_DEBUG_PORT = 2739;
@@ -72,6 +73,7 @@ async function createServer(
     };
   } catch (err) {
     vscode.window.showErrorMessage(err);
+    telemetryService.sendApexLSPError(err);
     throw err;
   }
 }

--- a/packages/salesforcedx-vscode-apex/src/telemetry/telemetry.ts
+++ b/packages/salesforcedx-vscode-apex/src/telemetry/telemetry.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import * as util from 'util';
 import TelemetryReporter from 'vscode-extension-telemetry';
 
 const EXTENSION_NAME = 'salesforcedx-vscode-apex';
@@ -32,10 +33,12 @@ export class TelemetryService {
     this.reporter = reporter;
   }
 
-  public sendExtensionActivationEvent(): void {
+  public sendExtensionActivationEvent(hrstart: [number, number]): void {
     if (this.reporter !== undefined && this.isTelemetryEnabled) {
+      const startupTime = this.getEndHRTime(hrstart);
       this.reporter.sendTelemetryEvent('activationEvent', {
-        extensionName: EXTENSION_NAME
+        extensionName: EXTENSION_NAME,
+        startupTime
       });
     }
   }
@@ -55,5 +58,29 @@ export class TelemetryService {
         commandName
       });
     }
+  }
+
+  public sendApexLSPActivationEvent(hrstart: [number, number]): void {
+    if (this.reporter !== undefined && this.isTelemetryEnabled) {
+      const startupTime = this.getEndHRTime(hrstart);
+      this.reporter.sendTelemetryEvent('apexLSPStartup', {
+        extensionName: EXTENSION_NAME,
+        startupTime
+      });
+    }
+  }
+
+  public sendApexLSPError(errorMsg: string): void {
+    if (this.reporter !== undefined && this.isTelemetryEnabled) {
+      this.reporter.sendTelemetryEvent('apexLSPError', {
+        extensionName: EXTENSION_NAME,
+        errorMsg
+      });
+    }
+  }
+
+  private getEndHRTime(hrstart: [number, number]): string {
+    const hrend = process.hrtime(hrstart);
+    return util.format('%ds %dms', hrend[0], hrend[1] / 1000000);
   }
 }

--- a/packages/salesforcedx-vscode-apex/test/unit/telemetry/telemetry.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/unit/telemetry/telemetry.test.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { assert, SinonStub, stub } from 'sinon';
+import { assert, match, SinonStub, stub } from 'sinon';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import { TelemetryService } from '../../../src/telemetry/telemetry';
 
@@ -26,7 +26,7 @@ describe('Telemetry', () => {
     const telemetryService = TelemetryService.getInstance();
     telemetryService.initializeService(reporter, true);
 
-    telemetryService.sendExtensionActivationEvent();
+    telemetryService.sendExtensionActivationEvent([0, 678]);
     assert.calledOnce(sendEvent);
   });
 
@@ -56,13 +56,14 @@ describe('Telemetry', () => {
     const telemetryService = TelemetryService.getInstance();
     telemetryService.initializeService(reporter, true);
 
-    telemetryService.sendExtensionActivationEvent();
+    telemetryService.sendExtensionActivationEvent([1, 700]);
     assert.calledOnce(sendEvent);
 
     const expectedData = {
-      extensionName: 'salesforcedx-vscode-apex'
+      extensionName: 'salesforcedx-vscode-apex',
+      startupTime: match.string
     };
-    assert.calledWith(sendEvent, 'activationEvent', expectedData);
+    assert.calledWith(sendEvent, 'activationEvent', match(expectedData));
   });
 
   it('Should send correct data format on sendExtensionDeactivationEvent', async () => {
@@ -76,5 +77,33 @@ describe('Telemetry', () => {
       extensionName: 'salesforcedx-vscode-apex'
     };
     assert.calledWith(sendEvent, 'deactivationEvent', expectedData);
+  });
+
+  it('Should send correct data format on sendApexLSPActivationEvent', async () => {
+    const telemetryService = TelemetryService.getInstance();
+    telemetryService.initializeService(reporter, true);
+
+    telemetryService.sendApexLSPActivationEvent([0, 50]);
+    assert.calledOnce(sendEvent);
+
+    const expectedData = {
+      extensionName: 'salesforcedx-vscode-apex',
+      startupTime: match.string
+    };
+    assert.calledWith(sendEvent, 'apexLSPStartup', match(expectedData));
+  });
+
+  it('Should send correct data format on sendApexLSPError', async () => {
+    const telemetryService = TelemetryService.getInstance();
+    telemetryService.initializeService(reporter, true);
+    const errorMsg = 'NullPointerException on Apex LSP';
+    telemetryService.sendApexLSPError(errorMsg);
+    assert.calledOnce(sendEvent);
+
+    const expectedData = {
+      extensionName: 'salesforcedx-vscode-apex',
+      errorMsg
+    };
+    assert.calledWith(sendEvent, 'apexLSPError', expectedData);
   });
 });


### PR DESCRIPTION
### What does this PR do?
Adds apex extension activation time, Apex LSP errors and startup time to insights.

### What issues does this PR fix or reference?
@W-4883803@