### PR TITLE
SFDX: Turn On Apex Debug Log for Replay Debugger throws an error for non-scratch orgs

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceStartApexDebugLogging.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceStartApexDebugLogging.ts
@@ -26,10 +26,7 @@ import {
   SfdxWorkspaceChecker
 } from './commands';
 
-import {
-  getDefaultUsernameOrAlias,
-  getUsername
-} from '../context';
+import { getDefaultUsernameOrAlias, getUsername } from '../context';
 import { telemetryService } from '../telemetry';
 import { developerLogTraceFlag } from './';
 
@@ -110,9 +107,12 @@ export class ForceStartApexDebugLoggingExecutor extends SfdxCommandletExecutor<{
 export async function getUserId(projectPath: string): Promise<string> {
   const defaultUsernameOrAlias = await getDefaultUsernameOrAlias();
   const username = await getUsername(defaultUsernameOrAlias!);
-  const execution = new CliCommandExecutor(new ForceQueryUser(username).build(), {
-    cwd: projectPath
-  }).execute();
+  const execution = new CliCommandExecutor(
+    new ForceQueryUser(username).build(),
+    {
+      cwd: projectPath
+    }
+  ).execute();
   telemetryService.sendCommandEvent(execution.command.logName);
   const cmdOutput = new CommandOutput();
   const result = await cmdOutput.getCmdResult(execution);
@@ -132,7 +132,6 @@ export class ForceQueryUser extends SfdxCommandletExecutor<{}> {
   }
   public build(): Command {
     return new SfdxCommandBuilder()
-      .withDescription(nls.localize('force_start_apex_debug_logging'))
       .withArg('force:data:soql:query')
       .withFlag(
         '--query',
@@ -178,10 +177,10 @@ export class CreateTraceFlag extends SfdxCommandletExecutor<{}> {
         '--values',
         `tracedentityid='${this
           .userId}' logtype=developer_log debuglevelid=${developerLogTraceFlag.getDebugLevelId()} StartDate='${developerLogTraceFlag
-            .getStartDate()
-            .toUTCString()}' ExpirationDate='${developerLogTraceFlag
-              .getExpirationDate()
-              .toUTCString()}`
+          .getStartDate()
+          .toUTCString()}' ExpirationDate='${developerLogTraceFlag
+          .getExpirationDate()
+          .toUTCString()}`
       )
       .withArg('--usetoolingapi')
       .withJson()
@@ -220,8 +219,8 @@ export class UpdateTraceFlagsExecutor extends SfdxCommandletExecutor<{}> {
         `StartDate='${developerLogTraceFlag
           .getStartDate()
           .toUTCString()}' ExpirationDate='${developerLogTraceFlag
-            .getExpirationDate()
-            .toUTCString()}'`
+          .getExpirationDate()
+          .toUTCString()}'`
       )
       .withArg('--usetoolingapi')
       .withJson()

--- a/packages/salesforcedx-vscode-core/src/commands/forceStartApexDebugLogging.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceStartApexDebugLogging.ts
@@ -29,7 +29,6 @@ import {
 import {
   getDefaultUsernameOrAlias,
   getUsername,
-  isAScratchOrg
 } from '../context';
 import { telemetryService } from '../telemetry';
 import { developerLogTraceFlag } from './';
@@ -113,49 +112,20 @@ export async function getUserId(projectPath: string): Promise<string> {
   const defaultUsernameIsSet = typeof defaultUsernameOrAlias !== 'undefined';
   if (defaultUsernameIsSet) {
     const username = await getUsername(defaultUsernameOrAlias!);
-    let isScratchOrg = false;
-    try {
-      isScratchOrg = await isAScratchOrg(username);
-    } catch (e) {
-      // If the info for the default username cannot be found,
-      // we will treat it like it is not a scratch org
-      if (e.name !== 'NamedOrgNotFound') {
-        throw e;
-      }
-    }
-    let execution;
-    if (isScratchOrg) {
-      execution = new CliCommandExecutor(new ForceUserDisplay().build(), {
-        cwd: projectPath
-      }).execute();
-    } else {
-      execution = new CliCommandExecutor(new ForceQueryUser(username).build(), {
-        cwd: projectPath
-      }).execute();
-    }
+    const execution = new CliCommandExecutor(new ForceQueryUser(username).build(), {
+      cwd: projectPath
+    }).execute();
     telemetryService.sendCommandEvent(execution.command.logName);
     const cmdOutput = new CommandOutput();
     const result = await cmdOutput.getCmdResult(execution);
     try {
-      const orgInfo = isScratchOrg
-        ? JSON.parse(result).result.id
-        : JSON.parse(result).result.records[0].Id;
+      const orgInfo = JSON.parse(result).result.records[0].Id;
       return Promise.resolve(orgInfo);
     } catch (e) {
       return Promise.reject(result);
     }
   } else {
     throw new Error(nls.localize('no_default_username_found_error'));
-  }
-}
-
-class ForceUserDisplay extends SfdxCommandletExecutor<{}> {
-  public build(): Command {
-    return new SfdxCommandBuilder()
-      .withArg('force:user:display')
-      .withJson()
-      .withLogName('force_user_display')
-      .build();
   }
 }
 
@@ -213,10 +183,10 @@ export class CreateTraceFlag extends SfdxCommandletExecutor<{}> {
         '--values',
         `tracedentityid='${this
           .userId}' logtype=developer_log debuglevelid=${developerLogTraceFlag.getDebugLevelId()} StartDate='${developerLogTraceFlag
-          .getStartDate()
-          .toUTCString()}' ExpirationDate='${developerLogTraceFlag
-          .getExpirationDate()
-          .toUTCString()}`
+            .getStartDate()
+            .toUTCString()}' ExpirationDate='${developerLogTraceFlag
+              .getExpirationDate()
+              .toUTCString()}`
       )
       .withArg('--usetoolingapi')
       .withJson()
@@ -255,8 +225,8 @@ export class UpdateTraceFlagsExecutor extends SfdxCommandletExecutor<{}> {
         `StartDate='${developerLogTraceFlag
           .getStartDate()
           .toUTCString()}' ExpirationDate='${developerLogTraceFlag
-          .getExpirationDate()
-          .toUTCString()}'`
+            .getExpirationDate()
+            .toUTCString()}'`
       )
       .withArg('--usetoolingapi')
       .withJson()

--- a/packages/salesforcedx-vscode-core/src/commands/forceStartApexDebugLogging.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceStartApexDebugLogging.ts
@@ -28,7 +28,7 @@ import {
 
 import {
   getDefaultUsernameOrAlias,
-  getUsername,
+  getUsername
 } from '../context';
 import { telemetryService } from '../telemetry';
 import { developerLogTraceFlag } from './';
@@ -109,27 +109,22 @@ export class ForceStartApexDebugLoggingExecutor extends SfdxCommandletExecutor<{
 
 export async function getUserId(projectPath: string): Promise<string> {
   const defaultUsernameOrAlias = await getDefaultUsernameOrAlias();
-  const defaultUsernameIsSet = typeof defaultUsernameOrAlias !== 'undefined';
-  if (defaultUsernameIsSet) {
-    const username = await getUsername(defaultUsernameOrAlias!);
-    const execution = new CliCommandExecutor(new ForceQueryUser(username).build(), {
-      cwd: projectPath
-    }).execute();
-    telemetryService.sendCommandEvent(execution.command.logName);
-    const cmdOutput = new CommandOutput();
-    const result = await cmdOutput.getCmdResult(execution);
-    try {
-      const orgInfo = JSON.parse(result).result.records[0].Id;
-      return Promise.resolve(orgInfo);
-    } catch (e) {
-      return Promise.reject(result);
-    }
-  } else {
-    throw new Error(nls.localize('no_default_username_found_error'));
+  const username = await getUsername(defaultUsernameOrAlias!);
+  const execution = new CliCommandExecutor(new ForceQueryUser(username).build(), {
+    cwd: projectPath
+  }).execute();
+  telemetryService.sendCommandEvent(execution.command.logName);
+  const cmdOutput = new CommandOutput();
+  const result = await cmdOutput.getCmdResult(execution);
+  try {
+    const orgInfo = JSON.parse(result).result.records[0].Id;
+    return Promise.resolve(orgInfo);
+  } catch (e) {
+    return Promise.reject(result);
   }
 }
 
-class ForceQueryUser extends SfdxCommandletExecutor<{}> {
+export class ForceQueryUser extends SfdxCommandletExecutor<{}> {
   private username: string;
   public constructor(username: string) {
     super();

--- a/packages/salesforcedx-vscode-core/src/context/index.ts
+++ b/packages/salesforcedx-vscode-core/src/context/index.ts
@@ -7,7 +7,6 @@
 export {
   getDefaultUsernameOrAlias,
   getUsername,
-  isAScratchOrg,
   registerDefaultUsernameWatcher,
   setupWorkspaceOrgType
 } from './workspaceOrgType';

--- a/packages/salesforcedx-vscode-core/src/context/index.ts
+++ b/packages/salesforcedx-vscode-core/src/context/index.ts
@@ -5,6 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 export {
+  getDefaultUsernameOrAlias,
+  getUsername,
+  isAScratchOrg,
   registerDefaultUsernameWatcher,
   setupWorkspaceOrgType
 } from './workspaceOrgType';

--- a/packages/salesforcedx-vscode-core/src/context/workspaceOrgType.ts
+++ b/packages/salesforcedx-vscode-core/src/context/workspaceOrgType.ts
@@ -34,7 +34,7 @@ export async function setupWorkspaceOrgType() {
   setDefaultUsernameHasNoChangeTracking(defaultUsernameIsSet && !isScratchOrg);
 }
 
-export async function isAScratchOrg(username: string): Promise<boolean> {
+async function isAScratchOrg(username: string): Promise<boolean> {
   const authInfo = await AuthInfo.create(username);
   const authInfoFields = authInfo.getFields();
   return Promise.resolve(typeof authInfoFields.devHubUsername !== 'undefined');

--- a/packages/salesforcedx-vscode-core/src/context/workspaceOrgType.ts
+++ b/packages/salesforcedx-vscode-core/src/context/workspaceOrgType.ts
@@ -34,7 +34,7 @@ export async function setupWorkspaceOrgType() {
   setDefaultUsernameHasNoChangeTracking(defaultUsernameIsSet && !isScratchOrg);
 }
 
-async function isAScratchOrg(username: string): Promise<boolean> {
+export async function isAScratchOrg(username: string): Promise<boolean> {
   const authInfo = await AuthInfo.create(username);
   const authInfoFields = authInfo.getFields();
   return Promise.resolve(typeof authInfoFields.devHubUsername !== 'undefined');
@@ -44,7 +44,7 @@ async function isAScratchOrg(username: string): Promise<boolean> {
  * Returns the non-aliased username
  * @param usernameOrAlias
  */
-async function getUsername(usernameOrAlias: string): Promise<string> {
+export async function getUsername(usernameOrAlias: string): Promise<string> {
   const username = await Aliases.fetch(usernameOrAlias);
   if (username) {
     return Promise.resolve(username);
@@ -68,7 +68,7 @@ function setDefaultUsernameHasNoChangeTracking(val: boolean) {
   );
 }
 
-async function getDefaultUsernameOrAlias(): Promise<string | undefined> {
+export async function getDefaultUsernameOrAlias(): Promise<string | undefined> {
   if (
     vscode.workspace.workspaceFolders instanceof Array &&
     vscode.workspace.workspaceFolders.length > 0

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -192,5 +192,6 @@ export const messages = {
   tooling_API_description: 'Execute the query with Tooling API',
   telemetry_legal_dialog_message:
     'You agree that Salesforce Extensions for VS Code may collect usage information, user environment, and crash reports for product improvements. Learn how to [opt out](%s).',
-  telemetry_legal_dialog_button_text: 'Read more'
+  telemetry_legal_dialog_button_text: 'Read more',
+  no_default_username_found_error: 'No defaultusername found'
 };

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -192,6 +192,5 @@ export const messages = {
   tooling_API_description: 'Execute the query with Tooling API',
   telemetry_legal_dialog_message:
     'You agree that Salesforce Extensions for VS Code may collect usage information, user environment, and crash reports for product improvements. Learn how to [opt out](%s).',
-  telemetry_legal_dialog_button_text: 'Read more',
-  no_default_username_found_error: 'No defaultusername found'
+  telemetry_legal_dialog_button_text: 'Read more'
 };

--- a/packages/salesforcedx-vscode-core/test/commands/forceStartApexDebugLogging.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceStartApexDebugLogging.test.ts
@@ -11,9 +11,9 @@ import { developerLogTraceFlag } from '../../src/commands';
 import {
   CreateDebugLevel,
   CreateTraceFlag,
-  ForceStartApexDebugLoggingExecutor,
   ForceQueryTraceFlag,
   ForceQueryUser,
+  ForceStartApexDebugLoggingExecutor,
   UpdateDebugLevelsExecutor,
   UpdateTraceFlagsExecutor
 } from '../../src/commands/forceStartApexDebugLogging';

--- a/packages/salesforcedx-vscode-core/test/commands/forceStartApexDebugLogging.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceStartApexDebugLogging.test.ts
@@ -11,8 +11,9 @@ import { developerLogTraceFlag } from '../../src/commands';
 import {
   CreateDebugLevel,
   CreateTraceFlag,
-  ForceQueryTraceFlag,
   ForceStartApexDebugLoggingExecutor,
+  ForceQueryTraceFlag,
+  ForceQueryUser,
   UpdateDebugLevelsExecutor,
   UpdateTraceFlagsExecutor
 } from '../../src/commands/forceStartApexDebugLogging';
@@ -100,6 +101,15 @@ describe('Force Start Apex Debug Logging', () => {
     const createDebugLevelCmd = createDebugLevelExecutor.build();
     expect(createDebugLevelCmd.toCommand()).to.equal(
       `sfdx force:data:record:create --sobjecttype DebugLevel --values developername=${createDebugLevelExecutor.developerName} MasterLabel=${createDebugLevelExecutor.developerName} apexcode=${APEX_CODE_DEBUG_LEVEL} visualforce=${VISUALFORCE_DEBUG_LEVEL} --usetoolingapi --json --loglevel fatal`
+    );
+  });
+
+  it('Should build the user id query command', async () => {
+    const testUser = 'user@test.org';
+    const forceQueryUserExecutor = new ForceQueryUser(testUser);
+    const forceQueryUserCmd = forceQueryUserExecutor.build();
+    expect(forceQueryUserCmd.toCommand()).to.equal(
+      `sfdx force:data:soql:query --query SELECT id FROM User WHERE username='${testUser}' --json --loglevel fatal`
     );
   });
 });

--- a/packages/salesforcedx-vscode-core/test/context/workspaceOrgType.test.ts
+++ b/packages/salesforcedx-vscode-core/test/context/workspaceOrgType.test.ts
@@ -34,13 +34,13 @@ describe('getUsername', () => {
 });
 
 describe('getDefaultUsernameOrAlias', () => {
-  it('returns the defaultusername when the username is set', async () => {
+  it('returns undefined when no defaultusername is set', async () => {
     const getConfigStub = getGetConfigStub(new Map());
     expect(await getDefaultUsernameOrAlias()).to.be.undefined;
     getConfigStub.restore();
   });
 
-  it('returns undefined when no defaultusername is set', async () => {
+  it('returns the defaultusername when the username is set', async () => {
     const username = 'test@org.com';
     const getConfigStub = getGetConfigStub(
       new Map([['defaultusername', username]])

--- a/packages/salesforcedx-vscode-core/test/context/workspaceOrgType.test.ts
+++ b/packages/salesforcedx-vscode-core/test/context/workspaceOrgType.test.ts
@@ -11,7 +11,44 @@ import * as vscode from 'vscode';
 
 import { Aliases, AuthInfo } from '@salesforce/core';
 import { ForceConfigGet } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
-import { setupWorkspaceOrgType } from '../../src/context';
+import {
+  getDefaultUsernameOrAlias,
+  getUsername,
+  setupWorkspaceOrgType
+} from '../../src/context';
+
+describe('getUsername', () => {
+  it('should return the username when given a username', async () => {
+    const username = 'test@org.com';
+    const aliasesStub = getAliasesFetchStub(undefined);
+    expect(await getUsername(username)).to.equal(username);
+    aliasesStub.restore();
+  });
+
+  it('should return the username when given an alias', async () => {
+    const username = 'test@org.com';
+    const aliasesStub = getAliasesFetchStub(username);
+    expect(await getUsername('orgAlias')).to.equal(username);
+    aliasesStub.restore();
+  });
+});
+
+describe('getDefaultUsernameOrAlias', () => {
+  it('returns the defaultusername when the username is set', async () => {
+    const getConfigStub = getGetConfigStub(new Map());
+    expect(await getDefaultUsernameOrAlias()).to.be.undefined;
+    getConfigStub.restore();
+  });
+
+  it('returns undefined when no defaultusername is set', async () => {
+    const username = 'test@org.com';
+    const getConfigStub = getGetConfigStub(
+      new Map([['defaultusername', username]])
+    );
+    expect(await getDefaultUsernameOrAlias()).to.equal(username);
+    getConfigStub.restore();
+  });
+});
 
 describe('setupWorkspaceOrgType', () => {
   it('should set both sfdx:default_username_has_change_tracking and sfdx:default_username_has_no_change_tracking contexts to false', async () => {


### PR DESCRIPTION
### What does this PR do?
This pr changes the `SFDX: Turn On Apex Debug Log for Replay Debugger` command to query orgs directly for the user's id so that we can use the command against non-scratch orgs. Previously, the command was using the `sfdx force:org:display` to get the user id of an org, but this command throws an error when called against non-scratch orgs. 

### What issues does this PR fix or reference?
@W-5461537@
