### PR TITLE
Fix for circular references

### DIFF
--- a/packages/salesforcedx-apex-replay-debugger/src/core/heapDumpService.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/core/heapDumpService.ts
@@ -338,7 +338,7 @@ export class HeapDumpService {
   //   2: '3'
   private createStringFromVarContainer(
     varContainer: ApexVariableContainer,
-    visitedMap: Map<string, null>
+    visitedSet: Set<string>
   ): string {
     // If the varContainer isn't a reference or is a string references
     if (
@@ -350,10 +350,10 @@ export class HeapDumpService {
 
     // If the varContainer is a ref and it's already been visited then return the string
     if (varContainer.ref) {
-      if (visitedMap.has(varContainer.ref)) {
+      if (visitedSet.has(varContainer.ref)) {
         return 'already output';
       } else {
-        visitedMap.set(varContainer.ref, null);
+        visitedSet.add(varContainer.ref);
       }
     }
     let returnString = '';
@@ -380,7 +380,7 @@ export class HeapDumpService {
           // if this is also a ref then create the string from that
           returnString += this.createStringFromVarContainer(
             valueAsApexVar,
-            visitedMap
+            visitedSet
           );
         } else {
           // otherwise get the name/value from the variable
@@ -393,7 +393,7 @@ export class HeapDumpService {
       returnString += isListOrSet ? ')' : '}';
     } finally {
       if (varContainer.ref) {
-        visitedMap.delete(varContainer.ref);
+        visitedSet.delete(varContainer.ref);
       }
     }
     return returnString;
@@ -609,7 +609,7 @@ export class HeapDumpService {
     if (!hasInnerRefs) {
       refContainer.value = this.createStringFromVarContainer(
         refContainer,
-        new Map<string, null>()
+        new Set<string>()
       );
     }
   }
@@ -784,7 +784,7 @@ export class HeapDumpService {
         }
         namedVarContainer.value = this.createStringFromVarContainer(
           namedVarContainer,
-          new Map<string, null>()
+          new Set<string>()
         );
       }
 
@@ -800,7 +800,7 @@ export class HeapDumpService {
           const varContainer = element as ApexVariableContainer;
           varContainer.value = this.createStringFromVarContainer(
             varContainer,
-            new Map<string, null>()
+            new Set<string>()
           );
         });
       }

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/apexReplayDebugVariablesHandling.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/apexReplayDebugVariablesHandling.test.ts
@@ -311,36 +311,26 @@ describe('Replay debugger adapter variable handling - unit', () => {
       });
 
       it('Should not create string refs if there are not any in the heapdump', () => {
-        // Create the heap dump and pass the overlay result into createStringRefsFromHeapdump
-        // Verify with that the ref's map is empty
         const heapdump = createHeapDumpWithNoStringTypes();
         heapDumpService.createStringRefsFromHeapdump(
           heapdump.getOverlaySuccessResult()!
         );
-        // There should be no strings in the refsMap
         expect(refsMap.size).to.be.eq(0);
       });
 
       it('Should only create string refs if there are not any in the heapdump', () => {
-        // Create the heap dump and pass the overlay result into createStringRefsFromHeapdump
-        // Verify with that the ref's map is empty
         const heapdump = createHeapDumpWithNoStringTypes();
         heapDumpService.createStringRefsFromHeapdump(
           heapdump.getOverlaySuccessResult()!
         );
-        // There should be no strings in the refsMap
         expect(refsMap.size).to.be.eq(0);
       });
 
       it('Should create string refs if there are any in the heapdump', () => {
-        // Create the heap dump and pass the overlay result into createStringRefsFromHeapdump
-        // Verify with that the ref's map is empty.
         const heapdump = createHeapDumpWithStrings();
         heapDumpService.createStringRefsFromHeapdump(
           heapdump.getOverlaySuccessResult()!
         );
-        // There should be 2 strings in the refsMap, verify their values which should
-        // contain quotes
         expect(refsMap.size).to.be.eq(2);
         let tempStringVar = refsMap.get('0x47a32f5b') as ApexVariableContainer;
         expect(tempStringVar.value).to.be.eq(
@@ -351,7 +341,6 @@ describe('Replay debugger adapter variable handling - unit', () => {
       });
 
       it('Should not follow reference chain when creating leaf variables except strings', () => {
-        // Create a heapdump
         const heapdump = createHeapDumpWithNestedRefs();
         getHeapDumpForThisLocationStub = sinon
           .stub(LogContext.prototype, 'getHeapDumpForThisLocation')
@@ -364,8 +353,6 @@ describe('Replay debugger adapter variable handling - unit', () => {
         expect(updateLeafReferenceContainerSpy.called).to.be.true;
         // with no local, static or global variables to update this shouldn't be called
         expect(createVariableFromReferenceSpy.called).to.be.false;
-
-        // there should be 4 references in the map, 2 strings and 2 objects
         expect(refsMap.size).to.be.eq(4);
 
         // NonStaticClassWithVariablesToInspect has an inner class of the same type.
@@ -400,10 +387,9 @@ describe('Replay debugger adapter variable handling - unit', () => {
           'innerVariable'
         ) as ApexVariableContainer;
         expect(innerApexRefVar.ref).to.be.eq('0x55260a7a');
-        // There should be no children on the inner variable since it's a reference
         expect(innerApexRefVar.variables.size).to.be.eq(0);
 
-        // Verify there is an entry in the ref's for the inner var, verify everything is set on it
+        // Verify there is an entry in the ref's for the inner var
         tempApexVar = refsMap.get('0x55260a7a') as ApexVariableContainer;
         expect(tempApexVar.variables.size).to.be.eq(7);
         expect(
@@ -433,13 +419,11 @@ describe('Replay debugger adapter variable handling - unit', () => {
       });
 
       it('Should follow reference chain when creating instance variables from references', () => {
-        // Create the heapdump
         const heapdump = createHeapDumpWithNestedRefs();
         getHeapDumpForThisLocationStub = sinon
           .stub(LogContext.prototype, 'getHeapDumpForThisLocation')
           .returns(heapdump);
 
-        // Create a ref variable to update
         const localRefVariable = new ApexVariableContainer(
           'foo',
           '',
@@ -449,10 +433,8 @@ describe('Replay debugger adapter variable handling - unit', () => {
         const id = frameHandler.create(frameInfo);
         topFrame.id = id;
         frameInfo.locals.set(localRefVariable.name, localRefVariable);
-        // Update it with the heap dump
         heapDumpService.replaceVariablesWithHeapDump();
 
-        // Verify the variable was updated
         const updatedLocRefVariable = frameInfo.locals.get(
           localRefVariable.name
         ) as ApexVariableContainer;
@@ -489,14 +471,14 @@ describe('Replay debugger adapter variable handling - unit', () => {
         ).to.be.eq(
           "'This is a longer string that will certainly get truncated until we hit a checkpoint and inspect it_extra'"
         );
-        // Get the innerVariable from the updatedLocRefVariable which should be fully populated
+
         const innerApexRefVar = updatedLocRefVariable.variables.get(
           'innerVariable'
         ) as ApexVariableContainer;
         expect(innerApexRefVar.ref).to.be.eq('0x55260a7a');
+
         // The innerVariable should have 7 children (no further references), verify everything has been set correctly
         expect(innerApexRefVar.variables.size).to.be.eq(7);
-
         expect(
           (innerApexRefVar.variables.get('MyBoolean') as ApexVariableContainer)
             .value
@@ -573,7 +555,6 @@ describe('Replay debugger adapter variable handling - unit', () => {
         expect(createStringRefsFromHeapdumpSpy.calledOnce).to.be.true;
         expect(updateLeafReferenceContainerSpy.calledOnce).to.be.false;
         expect(createVariableFromReferenceSpy.calledOnce).to.be.false;
-        // The variable should have been updated and have a value of 5
         const updatedNonRefVariable = frameInfo.locals.get(
           nonRefVariable.name
         ) as ApexVariableContainer;
@@ -631,7 +612,6 @@ describe('Replay debugger adapter variable handling - unit', () => {
         expect(createStringRefsFromHeapdumpSpy.calledOnce).to.be.true;
         expect(updateLeafReferenceContainerSpy.calledOnce).to.be.false;
         expect(createVariableFromReferenceSpy.calledOnce).to.be.false;
-        // The variable should have been updated and have a value of 5
         const updatedNonRefVariable = frameInfo.statics.get(
           nonRefVariable.name
         ) as ApexVariableContainer;
@@ -639,13 +619,11 @@ describe('Replay debugger adapter variable handling - unit', () => {
       });
 
       it('Should correctly deal with circular references and variable values', () => {
-        // Create the heapdump
         const heapdump = createHeapDumpWithCircularRefs();
         getHeapDumpForThisLocationStub = sinon
           .stub(LogContext.prototype, 'getHeapDumpForThisLocation')
           .returns(heapdump);
 
-        // Create a ref variable to update
         const localRefVariable = new ApexVariableContainer(
           'cf1',
           '',
@@ -656,7 +634,6 @@ describe('Replay debugger adapter variable handling - unit', () => {
         const id = frameHandler.create(frameInfo);
         topFrame.id = id;
         frameInfo.locals.set(localRefVariable.name, localRefVariable);
-        // Update it with the heap dump
         heapDumpService.replaceVariablesWithHeapDump();
 
         // Verify the variable was updated and that there is a cicular reference that
@@ -671,10 +648,8 @@ describe('Replay debugger adapter variable handling - unit', () => {
         const updatedLocRefVariable = frameInfo.locals.get(
           localRefVariable.name
         ) as ApexVariableContainer;
-        // Verify the variable's value has been set
         expect(updatedLocRefVariable.value).to.be.eq(expectedVariableValue);
 
-        // There should be 2 children, 1 list named cfList and 1 integer named someInt
         expect(updatedLocRefVariable.variables.size).to.be.eq(2);
         expect(
           (updatedLocRefVariable.variables.get(
@@ -685,18 +660,13 @@ describe('Replay debugger adapter variable handling - unit', () => {
           'cfList'
         ) as ApexVariableContainer;
 
-        // Verify the value is set correctly and there's exactly 1 item
-        // in the list
         expect(listChildVar.value).to.be.eq(expectedListVarValue);
         expect(listChildVar.variables.size).to.be.eq(1);
 
-        // There should be 1 child item on the list and it should have the same
-        // value as cf1, expectedVariableValue.
         const listElementVar = listChildVar.variables.get(
           '0'
         ) as ApexVariableContainer;
         expect(listElementVar.value).to.be.eq(expectedVariableValue);
-        // Lastly, verify that it's list has the same value as cfList, expectedListVarValue
         expect(
           (listElementVar.variables.get('cfList') as ApexVariableContainer)
             .value
@@ -778,19 +748,14 @@ describe('Replay debugger adapter variable handling - unit', () => {
           .stub(LogContext.prototype, 'getVariableHandler')
           .returns(variableHandler);
 
-        // In this test we're not running a trigger
         isRunningApexTriggerStub.returns(false);
 
         const frameInfo = new ApexDebugStackFrameInfo(0, 'Foo');
         const id = frameHandler.create(frameInfo);
         topFrame.id = id;
 
-        // There should be no globals before the heap dump processing
         expect(frameInfo.globals.size).to.eq(0);
-
         heapDumpService.replaceVariablesWithHeapDump();
-
-        // There should be no globals after the heap dump processing
         expect(frameInfo.globals.size).to.eq(0);
       });
 
@@ -805,16 +770,13 @@ describe('Replay debugger adapter variable handling - unit', () => {
           .stub(LogContext.prototype, 'getVariableHandler')
           .returns(variableHandler);
 
-        // In this test we are running a trigger
         isRunningApexTriggerStub.returns(true);
 
         const frameInfo = new ApexDebugStackFrameInfo(0, 'Foo');
         const id = frameHandler.create(frameInfo);
         topFrame.id = id;
 
-        // There should be no globals before the heap dump processing
         expect(frameInfo.globals.size).to.eq(0);
-
         heapDumpService.replaceVariablesWithHeapDump();
 
         // There should be 8 globals after the heap dump processing
@@ -822,7 +784,6 @@ describe('Replay debugger adapter variable handling - unit', () => {
         // 1 Trigger.new - List
         // 1 Trigger.newmap - Map
         expect(frameInfo.globals.size).to.eq(8);
-        // Verify the false Trigger booleans
         expect(
           (frameInfo.globals.get(
             EXTENT_TRIGGER_PREFIX + 'isbefore'
@@ -843,7 +804,6 @@ describe('Replay debugger adapter variable handling - unit', () => {
             EXTENT_TRIGGER_PREFIX + 'isupdate'
           ) as ApexVariableContainer).value
         ).to.eq('false');
-        // Verify the True Trigger booleans
         expect(
           (frameInfo.globals.get(
             EXTENT_TRIGGER_PREFIX + 'isafter'
@@ -855,7 +815,6 @@ describe('Replay debugger adapter variable handling - unit', () => {
           ) as ApexVariableContainer).value
         ).to.eq('true');
 
-        // Verify the Trigger.new map
         const triggerNew = frameInfo.globals.get(
           EXTENT_TRIGGER_PREFIX + 'new'
         ) as ApexVariableContainer;
@@ -863,9 +822,7 @@ describe('Replay debugger adapter variable handling - unit', () => {
         // The variablesRef should be set as part of the variable processing. 0 is
         // the default, if the reference is set it'll be greater than 0
         expect(triggerNew.variablesRef).to.be.greaterThan(0);
-        // There should be 3 items in the Trigger.new list
         expect(triggerNew.variables.size).to.be.eq(3);
-        // Verify the entries in the array
         expect(
           (triggerNew.variables.get('0') as ApexVariableContainer).ref
         ).to.eq('0x5f163c72');
@@ -876,13 +833,10 @@ describe('Replay debugger adapter variable handling - unit', () => {
           (triggerNew.variables.get('2') as ApexVariableContainer).ref
         ).to.eq('0x76e9852b');
 
-        // Verify the Trigger.newmap which is a Map<Id,Account>
         const triggerNewmap = frameInfo.globals.get(
           EXTENT_TRIGGER_PREFIX + 'newmap'
         ) as ApexVariableContainer;
         expect(triggerNewmap.type).to.be.eq('Map<Id,Account>');
-        // The variablesRef should be set as part of the variable processing. 0 is
-        // the default, if the reference is set it'll be greater than 0
         expect(triggerNewmap.variablesRef).to.be.greaterThan(0);
         expect(triggerNewmap.variables.size).to.be.eq(3);
         // Verify the key/value pairs in the map

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/apexReplayDebugVariablesHandling.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/apexReplayDebugVariablesHandling.test.ts
@@ -351,7 +351,6 @@ describe('Replay debugger adapter variable handling - unit', () => {
         heapDumpService.replaceVariablesWithHeapDump();
         expect(createStringRefsFromHeapdumpSpy.called).to.be.true;
         expect(updateLeafReferenceContainerSpy.called).to.be.true;
-        // with no local, static or global variables to update this shouldn't be called
         expect(createVariableFromReferenceSpy.called).to.be.false;
         expect(refsMap.size).to.be.eq(4);
 
@@ -389,7 +388,6 @@ describe('Replay debugger adapter variable handling - unit', () => {
         expect(innerApexRefVar.ref).to.be.eq('0x55260a7a');
         expect(innerApexRefVar.variables.size).to.be.eq(0);
 
-        // Verify there is an entry in the ref's for the inner var
         tempApexVar = refsMap.get('0x55260a7a') as ApexVariableContainer;
         expect(tempApexVar.variables.size).to.be.eq(7);
         expect(
@@ -477,7 +475,6 @@ describe('Replay debugger adapter variable handling - unit', () => {
         ) as ApexVariableContainer;
         expect(innerApexRefVar.ref).to.be.eq('0x55260a7a');
 
-        // The innerVariable should have 7 children (no further references), verify everything has been set correctly
         expect(innerApexRefVar.variables.size).to.be.eq(7);
         expect(
           (innerApexRefVar.variables.get('MyBoolean') as ApexVariableContainer)
@@ -561,8 +558,6 @@ describe('Replay debugger adapter variable handling - unit', () => {
         expect(updatedNonRefVariable.value).to.be.eq('5');
       });
 
-      // Variables, whether local, static or trigger all use the same code
-      // to update. Having this in there for statics is just for sanity
       it('Should update a non-reference static variable', () => {
         const heapdump = new ApexHeapDump('some ID', 'Foo', '', 10);
         heapdump.setOverlaySuccessResult({
@@ -779,10 +774,6 @@ describe('Replay debugger adapter variable handling - unit', () => {
         expect(frameInfo.globals.size).to.eq(0);
         heapDumpService.replaceVariablesWithHeapDump();
 
-        // There should be 8 globals after the heap dump processing
-        // 6 Trigger.is* boolean values
-        // 1 Trigger.new - List
-        // 1 Trigger.newmap - Map
         expect(frameInfo.globals.size).to.eq(8);
         expect(
           (frameInfo.globals.get(
@@ -819,8 +810,6 @@ describe('Replay debugger adapter variable handling - unit', () => {
           EXTENT_TRIGGER_PREFIX + 'new'
         ) as ApexVariableContainer;
         expect(triggerNew.type).to.be.eq('List<Account>');
-        // The variablesRef should be set as part of the variable processing. 0 is
-        // the default, if the reference is set it'll be greater than 0
         expect(triggerNew.variablesRef).to.be.greaterThan(0);
         expect(triggerNew.variables.size).to.be.eq(3);
         expect(
@@ -839,9 +828,7 @@ describe('Replay debugger adapter variable handling - unit', () => {
         expect(triggerNewmap.type).to.be.eq('Map<Id,Account>');
         expect(triggerNewmap.variablesRef).to.be.greaterThan(0);
         expect(triggerNewmap.variables.size).to.be.eq(3);
-        // Verify the key/value pairs in the map
-        // There should be a key name with the type of Id and value sane as the kvp name
-        // There should be a value of type Account whose ref is the account ref
+
         let tempKeyValPairApexVar = triggerNewmap.variables.get(
           'key0_value0'
         ) as ApexVariableContainer;

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/heapDumpTestUtil.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/heapDumpTestUtil.ts
@@ -836,3 +836,78 @@ export function createHeapDumpWithNestedRefs(): ApexHeapDump {
   } as ApexExecutionOverlayResultCommandSuccess);
   return heapdump;
 }
+
+// Partial heapdump with a circular reference
+export function createHeapDumpWithCircularRefs(): ApexHeapDump {
+  const heapdump = new ApexHeapDump('some ID', 'Foo', '', 10);
+  heapdump.setOverlaySuccessResult({
+    HeapDump: {
+      className: 'CircularRefTest',
+      extents: [
+        {
+          collectionType: null,
+          count: 1,
+          definition: [
+            {
+              name: 'cfList',
+              type: 'List<CircularReference>'
+            },
+            {
+              name: 'someInt',
+              type: 'Integer'
+            }
+          ],
+          extent: [
+            {
+              address: '0x717304ef',
+              isStatic: false,
+              size: 12,
+              symbols: ['cf1'],
+              value: {
+                entry: [
+                  {
+                    keyDisplayValue: 'cfList',
+                    value: {
+                      value: '0x614edc98'
+                    }
+                  },
+                  {
+                    keyDisplayValue: 'someInt',
+                    value: {
+                      value: 5
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          totalSize: 12,
+          typeName: 'CircularReference'
+        },
+        {
+          collectionType: 'CircularReference',
+          count: 1,
+          definition: [],
+          extent: [
+            {
+              address: '0x614edc98',
+              isStatic: false,
+              size: 8,
+              symbols: null,
+              value: {
+                value: [
+                  {
+                    value: '0x717304ef'
+                  }
+                ]
+              }
+            }
+          ],
+          totalSize: 8,
+          typeName: 'List<CircularReference>'
+        }
+      ]
+    }
+  } as ApexExecutionOverlayResultCommandSuccess);
+  return heapdump;
+}


### PR DESCRIPTION
### What does this PR do?
There was an issue where circular references weren't being hooked up correctly. This was causing the value of the name/value pair displayed in VS Code to display the wrong thing. Initially I'd opted stop hooking things up when there was a circular reference but this ended leaving a dangling reference. This also caused the value, when it was computed, to be incorrect as well. Right now, with the way it's hooked up it'll mimic the live debugger which is to say that you can just open up the variables until rapture. There is a slight difference in the replay debugger vs live debugger here. The live debugger does something special when it encounters a circular reference and puts it in braces (see picture) instead of keeping it in the same list/variable format as non-recusive references.
![livedebuggercircref](https://user-images.githubusercontent.com/13556087/46500848-b185cf00-c7d8-11e8-917b-a8fa52fb491c.png)

The replay-debugger keeps the live debugging format but still identifies the circular dependency. Mainly because the code to special case and add braces would be painful to deal with (the live debugger has a bit more leniency when dealing with variables since it doesn't have to compute the values from heap dump extent entries.
![replaydebuggercircref](https://user-images.githubusercontent.com/13556087/46501164-8b146380-c7d9-11e8-8067-a9dc7eafe260.png)

### What issues does this PR fix or reference?
@W-5491876@