### PR TITLE
Fix log variable processing for object properties and parameters

### DIFF
--- a/packages/salesforcedx-apex-replay-debugger/src/states/variableAssignmentState.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/states/variableAssignmentState.ts
@@ -47,7 +47,6 @@ export class VariableAssignmentState implements DebugLogState {
         // If the className is 'this' that means the variable being split was
         // this.<something>. We need to check the className for 'this' otherwise
         // a propery on 'this' would get incorrectly processed as a local variable.
-        // It'll correclty fall into the local variable
       } else if (className !== 'this' && frameInfo.locals.has(varName)) {
         map = frameInfo.locals;
         container = map.get(varName) as ApexVariableContainer;

--- a/packages/salesforcedx-apex-replay-debugger/src/states/variableAssignmentState.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/states/variableAssignmentState.ts
@@ -44,7 +44,11 @@ export class VariableAssignmentState implements DebugLogState {
       if (logContext.getStaticVariablesClassMap().has(className)) {
         map = logContext.getStaticVariablesClassMap().get(className)!;
         container = map.get(varName)! as ApexVariableContainer;
-      } else if (frameInfo.locals.has(varName)) {
+        // If the className is 'this' that means the variable being split was
+        // this.<something>. We need to check the className for 'this' otherwise
+        // a propery on 'this' would get incorrectly processed as a local variable.
+        // It'll correclty fall into the local variable
+      } else if (className !== 'this' && frameInfo.locals.has(varName)) {
         map = frameInfo.locals;
         container = map.get(varName) as ApexVariableContainer;
         // if the variable we're given is a child variable, then it will come in the format of this.varName

--- a/packages/salesforcedx-apex-replay-debugger/test/integration/config/logs/recursive.gold
+++ b/packages/salesforcedx-apex-replay-debugger/test/integration/config/logs/recursive.gold
@@ -34,7 +34,7 @@
   {
     "name": "myClass",
     "value": "",
-    "variablesReference": 1005,
+    "variablesReference": 1003,
     "type": "B.MyInnerClassB",
     "evaluateName": ""
   },
@@ -205,14 +205,14 @@
   {
     "name": "this",
     "value": "",
-    "variablesReference": 1050,
+    "variablesReference": 1022,
     "type": "A",
     "evaluateName": ""
   },
   {
     "name": "myB",
     "value": "",
-    "variablesReference": 1051,
+    "variablesReference": 1023,
     "type": "B",
     "evaluateName": ""
   },
@@ -261,7 +261,7 @@
   {
     "name": "enumVar",
     "value": "",
-    "variablesReference": 1054,
+    "variablesReference": 1027,
     "type": "A.Season",
     "evaluateName": ""
   },
@@ -306,7 +306,7 @@
   {
     "name": "myClass",
     "value": "",
-    "variablesReference": 1031,
+    "variablesReference": 1015,
     "type": "A.MyInnerClassA",
     "evaluateName": ""
   },
@@ -379,14 +379,14 @@
   {
     "name": "myB",
     "value": "",
-    "variablesReference": 1027,
+    "variablesReference": 1013,
     "type": "B",
     "evaluateName": ""
   },
   {
     "name": "myA",
     "value": "",
-    "variablesReference": 1059,
+    "variablesReference": 1032,
     "type": "A",
     "evaluateName": ""
   }


### PR DESCRIPTION
### What does this PR do?
There was an issue with log variable processing that happened when the object had properties with the same names as method parameters. If a class had myInteger is a property and a method on that class had myInteger as a parameter, the processing would get confused. Take the following log line segment:
VARIABLE_ASSIGNMENT|[6]|this.myInteger|1|0x759bccda
Instead of processing the variable assignment on "this.myInteger" what ended up happening is that the variable myInteger, which is the parameter, would end up getting processed. Because the log line has a reference, which points back to 'this', we ended up with a myInteger that expanded with all of this' properties. 
![incorrectvariableassignments](https://user-images.githubusercontent.com/13556087/46555122-30d9d800-c897-11e8-98e7-d4cf4ab24fb0.png)

The fix was relatively simple, before pulling the local variable, look to see if processing 'this'.
![withfix](https://user-images.githubusercontent.com/13556087/46555152-4949f280-c897-11e8-8aa2-052090a6c404.png)

The goldfile test actually contains the same inner class code that @lcampos was running when he hit this. As it turns the scenario is in the goldfile since we're no longer needlessly creating the extra variableRefs, those needed to be updated. I'd ended up creating a project with these classes and debugged it locally to verify correctness of these changes. There were quite a few superfluous variableRef's being created that shouldn't have been.  

### What issues does this PR fix or reference?
@W-5497724@