### PR TITLE
Disable system tests from running in appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,7 +41,7 @@ test_script:
       "Running npm run test:without-system-tests..."
       "--------------------------------------------"
       npm run test:without-system-tests
-      npm run coverage:system-tests
+      #npm run coverage:system-tests
       npm run aggregateJUnit
       junit-merge -d junit-aggregate -o junit-aggregate.xml
       $NpmTestsExitCode = $LastExitCode


### PR DESCRIPTION
### What does this PR do?
Disables running system test in appveyor builds. This is being done to unblock  PRs from getting merged while we work on a fix for the appveyor builds.

### What issues does this PR fix or reference?
