### PR TITLE
[WIP] Refactor replay debugger initialize

### DIFF
--- a/packages/salesforcedx-apex-replay-debugger/src/adapter/apexReplayDebug.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/adapter/apexReplayDebug.ts
@@ -222,14 +222,37 @@ export class ApexReplayDebug extends LoggingDebugSession {
     args: DebugProtocol.InitializeRequestArguments
   ): void {
     this.initializedResponse = response;
-    this.sendEvent(new Event(GET_LINE_BREAKPOINT_INFO_EVENT));
+    // this.sendEvent(new InitializedEvent());
+    this.initializedResponse.body = {
+      supportsConfigurationDoneRequest: true,
+      supportsCompletionsRequest: false,
+      supportsConditionalBreakpoints: true,
+      supportsDelayedStackTraceLoading: false,
+      supportsEvaluateForHovers: false,
+      supportsExceptionInfoRequest: false,
+      supportsExceptionOptions: false,
+      supportsFunctionBreakpoints: false,
+      supportsHitConditionalBreakpoints: false,
+      supportsLoadedSourcesRequest: false,
+      supportsRestartFrame: false,
+      supportsSetVariable: false,
+      supportsStepBack: false,
+      supportsStepInTargetsRequest: false
+    };
+    this.initializedResponse.success = true;
+    this.sendResponse(this.initializedResponse);
+    // this.sendEvent(new Event(GET_LINE_BREAKPOINT_INFO_EVENT));
   }
 
   public async launchRequest(
     response: DebugProtocol.LaunchResponse,
     args: LaunchRequestArguments
   ): Promise<void> {
+    this.sendEvent(new Event(GET_LINE_BREAKPOINT_INFO_EVENT));
     response.success = false;
+    console.log('----------------');
+    console.log('launchRequest');
+    console.log('----------------');
     this.setupLogger(args);
     this.log(
       TRACE_CATEGORY_LAUNCH,
@@ -568,7 +591,7 @@ export class ApexReplayDebug extends LoggingDebugSession {
           );
           this.sendResponse(this.initializedResponse);
         }
-        if (this.initializedResponse) {
+      /* if (this.initializedResponse) {
           this.initializedResponse.body = {
             supportsConfigurationDoneRequest: true,
             supportsCompletionsRequest: false,
@@ -588,7 +611,7 @@ export class ApexReplayDebug extends LoggingDebugSession {
           this.initializedResponse.success = true;
           this.sendResponse(this.initializedResponse);
           break;
-        }
+        } */
     }
     this.sendResponse(response);
   }

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/apexReplayDebug.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/apexReplayDebug.test.ts
@@ -21,15 +21,9 @@ import {
   ApexReplayDebug,
   LaunchRequestArguments
 } from '../../../src/adapter/apexReplayDebug';
-import {
-  breakpointUtil,
-  BreakpointUtil,
-  LineBreakpointEventArgs,
-  LineBreakpointInfo
-} from '../../../src/breakpoints';
+import { BreakpointUtil } from '../../../src/breakpoints';
 import {
   DEFAULT_INITIALIZE_TIMEOUT_MS,
-  LINE_BREAKPOINT_INFO_REQUEST,
   SEND_METRIC_LAUNCH_EVENT
 } from '../../../src/constants';
 import { LogContext, LogContextUtil } from '../../../src/core';
@@ -914,7 +908,7 @@ describe('Replay debugger adapter - unit', () => {
       ]);
     });
   });
-
+  /*
   describe('Custom request', () => {
     describe('Line breakpoint info', () => {
       let sendResponseSpy: sinon.SinonSpy;
@@ -1033,5 +1027,5 @@ describe('Replay debugger adapter - unit', () => {
         expect(adapter.getProjectPath()).to.equal(projectPathArg);
       });
     });
-  });
+  }); */
 });

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
@@ -10,6 +10,8 @@ import {
   DEBUGGER_LAUNCH_TYPE,
   DEBUGGER_TYPE
 } from '@salesforce/salesforcedx-apex-replay-debugger/out/src/constants';
+import * as fs from 'fs';
+import * as path from 'path';
 import * as vscode from 'vscode';
 import { nls } from '../messages';
 
@@ -49,31 +51,30 @@ export class DebugConfigurationProvider
       config.trace = true;
     }
 
-    const sfdxApex = vscode.extensions.getExtension(
-      'salesforce.salesforcedx-vscode-apex'
-    );
-    if (sfdxApex && sfdxApex.exports) {
-      const lineBpInfo = sfdxApex.exports.getLineBreakpointInfo();
-      let fsPath: string | undefined;
-      if (
-        vscode.workspace.workspaceFolders &&
-        vscode.workspace.workspaceFolders[0]
-      ) {
-        fsPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
-      }
-      /* const config = vscode.workspace.getConfiguration();
-      const checkpointsEnabled = config.get(
-        'salesforcedx-vscode-apex-replay-debugger-checkpoints.enabled',
-        false
-      ); */
+    // TODO: move everything below this to salesforce-vscode-apex module
+    let fsPath: string | undefined;
+    if (
+      vscode.workspace.workspaceFolders &&
+      vscode.workspace.workspaceFolders[0]
+    ) {
+      fsPath = path.join(
+        vscode.workspace.workspaceFolders[0].uri.fsPath,
+        '.sfdx',
+        'tools',
+        'projectBreakpoints.json'
+      );
+
+      const testResultOutput = fs.readFileSync(fsPath, 'utf8');
+      const lineBpInfo = JSON.parse(testResultOutput);
+
       const returnArgs: LineBreakpointEventArgs = {
         lineBreakpointInfo: lineBpInfo,
-        // for the moment always send undefined if checkpoints aren't enabled.
-        projectPath: fsPath !== null ? fsPath : undefined
+        projectPath: vscode.workspace.workspaceFolders[0].uri.fsPath
       };
-
+      // END TODO
       config.__privateData = returnArgs;
     }
+
     return config;
   }
 }

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
@@ -5,13 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { LineBreakpointEventArgs } from '@salesforce/salesforcedx-apex-replay-debugger/out/src/breakpoints';
 import {
   DEBUGGER_LAUNCH_TYPE,
   DEBUGGER_TYPE
 } from '@salesforce/salesforcedx-apex-replay-debugger/out/src/constants';
-import * as fs from 'fs';
-import * as path from 'path';
 import * as vscode from 'vscode';
 import { nls } from '../messages';
 
@@ -43,6 +40,7 @@ export class DebugConfigurationProvider
     config.name = config.name || nls.localize('config_name_text');
     config.type = config.type || DEBUGGER_TYPE;
     config.request = config.request || DEBUGGER_LAUNCH_TYPE;
+    config.projectBreakpointFilePath = '${command:sfdx.updateBreakpoint}';
     config.logFile = config.logFile || '${command:AskForLogFileName}';
     if (config.stopOnEntry === undefined) {
       config.stopOnEntry = true;
@@ -50,29 +48,11 @@ export class DebugConfigurationProvider
     if (config.trace === undefined) {
       config.trace = true;
     }
-
-    // TODO: move everything below this to salesforce-vscode-apex module
-    let fsPath: string | undefined;
     if (
       vscode.workspace.workspaceFolders &&
       vscode.workspace.workspaceFolders[0]
     ) {
-      fsPath = path.join(
-        vscode.workspace.workspaceFolders[0].uri.fsPath,
-        '.sfdx',
-        'tools',
-        'projectBreakpoints.json'
-      );
-
-      const testResultOutput = fs.readFileSync(fsPath, 'utf8');
-      const lineBpInfo = JSON.parse(testResultOutput);
-
-      const returnArgs: LineBreakpointEventArgs = {
-        lineBreakpointInfo: lineBpInfo,
-        projectPath: vscode.workspace.workspaceFolders[0].uri.fsPath
-      };
-      // END TODO
-      config.__privateData = returnArgs;
+      config.projectPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
     }
 
     return config;

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { LineBreakpointEventArgs } from '@salesforce/salesforcedx-apex-replay-debugger/out/src/breakpoints';
 import {
   DEBUGGER_LAUNCH_TYPE,
   DEBUGGER_TYPE
@@ -46,6 +47,32 @@ export class DebugConfigurationProvider
     }
     if (config.trace === undefined) {
       config.trace = true;
+    }
+
+    const sfdxApex = vscode.extensions.getExtension(
+      'salesforce.salesforcedx-vscode-apex'
+    );
+    if (sfdxApex && sfdxApex.exports) {
+      const lineBpInfo = sfdxApex.exports.getLineBreakpointInfo();
+      let fsPath: string | undefined;
+      if (
+        vscode.workspace.workspaceFolders &&
+        vscode.workspace.workspaceFolders[0]
+      ) {
+        fsPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
+      }
+      /* const config = vscode.workspace.getConfiguration();
+      const checkpointsEnabled = config.get(
+        'salesforcedx-vscode-apex-replay-debugger-checkpoints.enabled',
+        false
+      ); */
+      const returnArgs: LineBreakpointEventArgs = {
+        lineBreakpointInfo: lineBpInfo,
+        // for the moment always send undefined if checkpoints aren't enabled.
+        projectPath: fsPath !== null ? fsPath : undefined
+      };
+
+      config.__privateData = returnArgs;
     }
     return config;
   }

--- a/packages/salesforcedx-vscode-apex/src/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/index.ts
@@ -60,6 +60,13 @@ export async function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(await registerTestView(testOutlineProvider));
 
+  const updateBreakpointCmd = vscode.commands.registerCommand(
+    'sfdx.updateBreakpoint',
+    updateProjectLineBreakpointFile
+  );
+
+  context.subscriptions.push(updateBreakpointCmd);
+
   const exportedApi = {
     getLineBreakpointInfo,
     getExceptionBreakpointInfo,
@@ -69,6 +76,34 @@ export async function activate(context: vscode.ExtensionContext) {
 
   telemetryService.sendExtensionActivationEvent(extensionHRStart);
   return exportedApi;
+}
+
+async function updateProjectLineBreakpointFile() {
+  const lineBpInfo = await getLineBreakpointInfo();
+
+  if (
+    vscode.workspace.workspaceFolders &&
+    vscode.workspace.workspaceFolders[0]
+  ) {
+    const folderPath = path.join(
+      vscode.workspace.workspaceFolders[0].uri.fsPath,
+      '.sfdx',
+      'tools'
+    );
+
+    const myJsonString = JSON.stringify(lineBpInfo);
+    console.log(myJsonString);
+    if (!fs.existsSync(folderPath)) {
+      fs.mkdirSync(folderPath);
+    }
+    const projectBreakpointPath = path.join(
+      folderPath,
+      'projectBreakpoints.json'
+    );
+    fs.writeFileSync(projectBreakpointPath, myJsonString);
+    return projectBreakpointPath;
+  }
+  return '';
 }
 
 async function registerTestView(


### PR DESCRIPTION
### What does this PR do?
It removes the event that gets information from Apex LSP on replay debugger initializeRequest phase. This is replaced by an internal command that is triggered on resolveDebugConfiguration method (executes before debugger initializeRequest). The new command creates a file that contains all the information needed from Apex LSP and returns the file path. The result (file path) is then sent to launchRequest which parses the data for breakpoint validations and file navigation in later phases of the debugger.

I decided on this approach because the information from Apex LSP is used for breakpoint validation and file navigation once the debugger has started; replacing this would mean a big refactor on our debugger implementation. I also tested using a file watcher that would create a file with this data on any local update to apex code but that showed performance issues when testing with big projects (1000+ apex files).

This is an early review, still need to do clean up and update the tests but I wanted to get your opinions on this approach early on.

### What issues does this PR fix or reference?
@W-5402619@