### PR TITLE
Refactor replay debugger config on initialize

### DIFF
--- a/packages/salesforcedx-apex-replay-debugger/src/adapter/apexReplayDebug.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/adapter/apexReplayDebug.ts
@@ -23,7 +23,7 @@ import {
 } from 'vscode-debugadapter';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { MetricError, MetricLaunch } from '..';
-import { breakpointUtil, LineBreakpointEventArgs } from '../breakpoints';
+import { breakpointUtil, LineBreakpointInfo } from '../breakpoints';
 import {
   SEND_METRIC_ERROR_EVENT,
   SEND_METRIC_LAUNCH_EVENT
@@ -57,7 +57,8 @@ export interface LaunchRequestArguments
   logFile: string;
   stopOnEntry?: boolean | true;
   trace?: boolean | string;
-  lineBreakpointInfo?: any;
+  lineBreakpointInfo?: LineBreakpointInfo[];
+  projectPath: string | undefined;
 }
 
 export class ApexVariable extends Variable {
@@ -248,14 +249,12 @@ export class ApexReplayDebug extends LoggingDebugSession {
     let lineBreakpointInfoAvailable = false;
     if (args && args.lineBreakpointInfo) {
       lineBreakpointInfoAvailable = true;
-      const lineBreakpointEventArgs = args.lineBreakpointInfo as LineBreakpointEventArgs;
       breakpointUtil.createMappingsFromLineBreakpointInfo(
-        lineBreakpointEventArgs.lineBreakpointInfo
+        args.lineBreakpointInfo
       );
-      this.projectPath = lineBreakpointEventArgs.projectPath;
       delete args.lineBreakpointInfo;
     }
-
+    this.projectPath = args.projectPath;
     response.success = false;
     this.setupLogger(args);
     this.log(

--- a/packages/salesforcedx-apex-replay-debugger/src/adapter/apexReplayDebug.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/adapter/apexReplayDebug.ts
@@ -222,14 +222,37 @@ export class ApexReplayDebug extends LoggingDebugSession {
     args: DebugProtocol.InitializeRequestArguments
   ): void {
     this.initializedResponse = response;
-    this.sendEvent(new Event(GET_LINE_BREAKPOINT_INFO_EVENT));
+    // this.sendEvent(new InitializedEvent());
+    this.initializedResponse.body = {
+      supportsConfigurationDoneRequest: true,
+      supportsCompletionsRequest: false,
+      supportsConditionalBreakpoints: true,
+      supportsDelayedStackTraceLoading: false,
+      supportsEvaluateForHovers: false,
+      supportsExceptionInfoRequest: false,
+      supportsExceptionOptions: false,
+      supportsFunctionBreakpoints: false,
+      supportsHitConditionalBreakpoints: false,
+      supportsLoadedSourcesRequest: false,
+      supportsRestartFrame: false,
+      supportsSetVariable: false,
+      supportsStepBack: false,
+      supportsStepInTargetsRequest: false
+    };
+    this.initializedResponse.success = true;
+    this.sendResponse(this.initializedResponse);
+    // this.sendEvent(new Event(GET_LINE_BREAKPOINT_INFO_EVENT));
   }
 
   public async launchRequest(
     response: DebugProtocol.LaunchResponse,
     args: LaunchRequestArguments
   ): Promise<void> {
+    this.sendEvent(new Event(GET_LINE_BREAKPOINT_INFO_EVENT));
     response.success = false;
+    console.log('----------------');
+    console.log('launchRequest');
+    console.log('----------------');
     this.setupLogger(args);
     this.log(
       TRACE_CATEGORY_LAUNCH,
@@ -568,7 +591,7 @@ export class ApexReplayDebug extends LoggingDebugSession {
           );
           this.sendResponse(this.initializedResponse);
         }
-        if (this.initializedResponse) {
+      /* if (this.initializedResponse) {
           this.initializedResponse.body = {
             supportsConfigurationDoneRequest: true,
             supportsCompletionsRequest: false,
@@ -588,7 +611,7 @@ export class ApexReplayDebug extends LoggingDebugSession {
           this.initializedResponse.success = true;
           this.sendResponse(this.initializedResponse);
           break;
-        }
+        } */
     }
     this.sendResponse(response);
   }

--- a/packages/salesforcedx-apex-replay-debugger/src/breakpoints/index.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/breakpoints/index.ts
@@ -13,8 +13,3 @@ export interface LineBreakpointInfo {
 export { BreakpointUtil } from './breakpointUtil';
 import { BreakpointUtil } from './breakpointUtil';
 export const breakpointUtil = BreakpointUtil.getInstance();
-
-export interface LineBreakpointEventArgs {
-  lineBreakpointInfo: LineBreakpointInfo[];
-  projectPath: string | undefined;
-}

--- a/packages/salesforcedx-apex-replay-debugger/src/constants.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/constants.ts
@@ -34,7 +34,6 @@ export const SEND_METRIC_ERROR_EVENT = 'sendMetricError';
 export const SEND_METRIC_LAUNCH_EVENT = 'sendMetricLaunch';
 export const LAST_OPENED_LOG_FOLDER_KEY = 'LAST_OPENED_LOG_FOLDER_KEY';
 export const LAST_OPENED_LOG_KEY = 'LAST_OPENED_LOG_KEY';
-export const LINE_BREAKPOINT_INFO_REQUEST = 'lineBreakpointInfo';
 export const LIVESHARE_DEBUG_TYPE_REQUEST = 'debugType';
 export const SOBJECTS_URL = 'services/data/v43.0/tooling/sobjects';
 export const COMPOSITE_BATCH_URL =

--- a/packages/salesforcedx-apex-replay-debugger/test/integration/adapter.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/integration/adapter.test.ts
@@ -18,7 +18,6 @@ import {
   LineBreakpointEventArgs,
   LineBreakpointInfo
 } from '../../src/breakpoints';
-import { LINE_BREAKPOINT_INFO_REQUEST } from '../../src/constants';
 import { GoldFileUtil } from './goldFileUtil';
 
 const PROJECT_NAME = `project_${new Date().getTime()}`;
@@ -121,13 +120,12 @@ describe('Replay debugger adapter - integration', function() {
       projectPath: undefined
     };
 
-    await dc.customRequest(LINE_BREAKPOINT_INFO_REQUEST, returnArgs);
-
     const launchResponse = await dc.launchRequest({
       sfdxProject: projectPath,
       logFile: logFilePath,
       stopOnEntry: true,
-      trace: true
+      trace: true,
+      lineBreakpointInfo: returnArgs
     } as LaunchRequestArguments);
     expect(launchResponse.success).to.equal(true);
 
@@ -224,13 +222,12 @@ describe('Replay debugger adapter - integration', function() {
       projectPath: undefined
     };
 
-    await dc.customRequest(LINE_BREAKPOINT_INFO_REQUEST, returnArgs);
-
     const launchResponse = await dc.launchRequest({
       sfdxProject: projectPath,
       logFile: logFilePath,
       stopOnEntry: true,
-      trace: true
+      trace: true,
+      lineBreakpointInfo: returnArgs
     } as LaunchRequestArguments);
     expect(launchResponse.success).to.equal(true);
 

--- a/packages/salesforcedx-apex-replay-debugger/test/integration/adapter.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/integration/adapter.test.ts
@@ -14,10 +14,7 @@ import {
   ApexReplayDebug,
   LaunchRequestArguments
 } from '../../src/adapter/apexReplayDebug';
-import {
-  LineBreakpointEventArgs,
-  LineBreakpointInfo
-} from '../../src/breakpoints';
+import { LineBreakpointInfo } from '../../src/breakpoints';
 import { GoldFileUtil } from './goldFileUtil';
 
 const PROJECT_NAME = `project_${new Date().getTime()}`;
@@ -115,17 +112,14 @@ describe('Replay debugger adapter - integration', function() {
       dc,
       path.join(LOG_FOLDER, `${testName}.gold`)
     );
-    const returnArgs: LineBreakpointEventArgs = {
-      lineBreakpointInfo: lineBpInfo,
-      projectPath: undefined
-    };
 
     const launchResponse = await dc.launchRequest({
       sfdxProject: projectPath,
       logFile: logFilePath,
       stopOnEntry: true,
       trace: true,
-      lineBreakpointInfo: returnArgs
+      lineBreakpointInfo: lineBpInfo,
+      projectPath: undefined
     } as LaunchRequestArguments);
     expect(launchResponse.success).to.equal(true);
 
@@ -217,17 +211,13 @@ describe('Replay debugger adapter - integration', function() {
       path.join(LOG_FOLDER, `${testName}.gold`)
     );
 
-    const returnArgs: LineBreakpointEventArgs = {
-      lineBreakpointInfo: lineBpInfo,
-      projectPath: undefined
-    };
-
     const launchResponse = await dc.launchRequest({
       sfdxProject: projectPath,
       logFile: logFilePath,
       stopOnEntry: true,
       trace: true,
-      lineBreakpointInfo: returnArgs
+      lineBreakpointInfo: lineBpInfo,
+      projectPath: undefined
     } as LaunchRequestArguments);
     expect(launchResponse.success).to.equal(true);
 

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/apexReplayDebug.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/apexReplayDebug.test.ts
@@ -973,8 +973,8 @@ describe('Replay debugger adapter - unit', () => {
         createMappingsFromLineBreakpointInfo.restore();
       });
 
-      it('Should handle undefined args', () => {
-        adapter.launchRequest(
+      it('Should handle undefined args', async () => {
+        await adapter.launchRequest(
           initializedResponse,
           {} as LaunchRequestArguments
         );
@@ -984,7 +984,7 @@ describe('Replay debugger adapter - unit', () => {
         );
       });
 
-      it('Should handle empty line breakpoint info', () => {
+      it('Should handle empty line breakpoint info', async () => {
         const returnArgs: LineBreakpointEventArgs = {
           lineBreakpointInfo: [],
           projectPath: undefined
@@ -994,7 +994,7 @@ describe('Replay debugger adapter - unit', () => {
           logFile: 'someTestLogFile.log'
         };
 
-        adapter.launchRequest(
+        await adapter.launchRequest(
           initializedResponse,
           config as LaunchRequestArguments
         );
@@ -1008,7 +1008,7 @@ describe('Replay debugger adapter - unit', () => {
         expect(adapter.getProjectPath()).to.equal(undefined);
       });
 
-      it('Should save line number mapping', () => {
+      it('Should save line number mapping', async () => {
         const info: LineBreakpointInfo[] = [
           { uri: 'file:///foo.cls', typeref: 'foo', lines: [1, 2, 3] },
           { uri: 'file:///foo.cls', typeref: 'foo$inner', lines: [4, 5, 6] },
@@ -1028,7 +1028,7 @@ describe('Replay debugger adapter - unit', () => {
           lineBreakpointInfo: returnArgs,
           logFile: 'someTestLogFile.log'
         };
-        adapter.launchRequest(
+        await adapter.launchRequest(
           initializedResponse,
           config as LaunchRequestArguments
         );

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/apexReplayDebug.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/apexReplayDebug.test.ts
@@ -21,15 +21,9 @@ import {
   ApexReplayDebug,
   LaunchRequestArguments
 } from '../../../src/adapter/apexReplayDebug';
-import {
-  breakpointUtil,
-  BreakpointUtil,
-  LineBreakpointEventArgs,
-  LineBreakpointInfo
-} from '../../../src/breakpoints';
+import { BreakpointUtil } from '../../../src/breakpoints';
 import {
   DEFAULT_INITIALIZE_TIMEOUT_MS,
-  LINE_BREAKPOINT_INFO_REQUEST,
   SEND_METRIC_LAUNCH_EVENT
 } from '../../../src/constants';
 import { LogContext, LogContextUtil } from '../../../src/core';
@@ -914,7 +908,7 @@ describe('Replay debugger adapter - unit', () => {
       ]);
     });
   });
-
+  /*
   describe('Custom request', () => {
     describe('Line breakpoint info', () => {
       let sendResponseSpy: sinon.SinonSpy;
@@ -1033,5 +1027,5 @@ describe('Replay debugger adapter - unit', () => {
         expect(adapter.getProjectPath()).to.equal(projectPathArg);
       });
     });
-  });
+  }); */
 });

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/apexReplayDebug.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/apexReplayDebug.test.ts
@@ -24,7 +24,6 @@ import {
 import {
   breakpointUtil,
   BreakpointUtil,
-  LineBreakpointEventArgs,
   LineBreakpointInfo
 } from '../../../src/breakpoints';
 import {
@@ -81,6 +80,7 @@ describe('Replay debugger adapter - unit', () => {
   let adapter: MockApexReplayDebug;
   const logFileName = 'foo.log';
   const logFilePath = `path/${logFileName}`;
+  const projectPath = 'path/project';
 
   describe('Initialize', () => {
     let sendResponseSpy: sinon.SinonSpy;
@@ -132,10 +132,6 @@ describe('Replay debugger adapter - unit', () => {
       typeref: 'StaticVarsA',
       lines: [9, 10, 13]
     });
-    const lineBreakpointInfoArgs: LineBreakpointEventArgs = {
-      lineBreakpointInfo: lineBpInfo,
-      projectPath: 'some/file/path'
-    };
 
     beforeEach(() => {
       adapter = new MockApexReplayDebug();
@@ -143,7 +139,8 @@ describe('Replay debugger adapter - unit', () => {
       args = {
         logFile: logFilePath,
         stopOnEntry: true,
-        trace: false
+        trace: false,
+        projectPath
       };
       sendResponseSpy = sinon.spy(ApexReplayDebug.prototype, 'sendResponse');
       sendEventSpy = sinon.spy(ApexReplayDebug.prototype, 'sendEvent');
@@ -250,7 +247,7 @@ describe('Replay debugger adapter - unit', () => {
         .stub(LogContext.prototype, 'meetsLogLevelRequirements')
         .returns(true);
 
-      args.lineBreakpointInfo = lineBreakpointInfoArgs;
+      args.lineBreakpointInfo = lineBpInfo;
       await adapter.launchRequest(response, args);
 
       expect(hasLogLinesStub.calledOnce).to.be.true;
@@ -300,7 +297,7 @@ describe('Replay debugger adapter - unit', () => {
         .stub(LogContext.prototype, 'fetchOverlayResultsForApexHeapDumps')
         .returns(true);
 
-      args.lineBreakpointInfo = lineBreakpointInfoArgs;
+      args.lineBreakpointInfo = lineBpInfo;
       await adapter.launchRequest(response, args);
 
       expect(hasLogLinesStub.calledOnce).to.be.true;
@@ -324,7 +321,7 @@ describe('Replay debugger adapter - unit', () => {
         .stub(LogContext.prototype, 'fetchOverlayResultsForApexHeapDumps')
         .returns(true);
 
-      args.lineBreakpointInfo = lineBreakpointInfoArgs;
+      args.lineBreakpointInfo = lineBpInfo;
       await adapter.launchRequest(response, args);
 
       expect(hasLogLinesStub.calledOnce).to.be.true;
@@ -347,7 +344,7 @@ describe('Replay debugger adapter - unit', () => {
         .stub(LogContext.prototype, 'fetchOverlayResultsForApexHeapDumps')
         .returns(false);
 
-      args.lineBreakpointInfo = lineBreakpointInfoArgs;
+      args.lineBreakpointInfo = lineBpInfo;
       await adapter.launchRequest(response, args);
 
       expect(hasLogLinesStub.calledOnce).to.be.true;
@@ -381,7 +378,8 @@ describe('Replay debugger adapter - unit', () => {
     const args: DebugProtocol.ConfigurationDoneArguments = {};
     const launchRequestArgs: LaunchRequestArguments = {
       logFile: logFilePath,
-      trace: true
+      trace: true,
+      projectPath
     };
 
     beforeEach(() => {
@@ -476,7 +474,8 @@ describe('Replay debugger adapter - unit', () => {
     let readLogFileStub: sinon.SinonStub;
     const launchRequestArgs: LaunchRequestArguments = {
       logFile: logFilePath,
-      trace: true
+      trace: true,
+      projectPath
     };
 
     beforeEach(() => {
@@ -518,7 +517,8 @@ describe('Replay debugger adapter - unit', () => {
     let getFramesStub: sinon.SinonStub;
     const launchRequestArgs: LaunchRequestArguments = {
       logFile: logFilePath,
-      trace: true
+      trace: true,
+      projectPath
     };
     const sampleStackFrames: StackFrame[] = [
       {
@@ -585,7 +585,8 @@ describe('Replay debugger adapter - unit', () => {
     let args: DebugProtocol.ContinueArguments;
     const launchRequestArgs: LaunchRequestArguments = {
       logFile: logFilePath,
-      trace: true
+      trace: true,
+      projectPath
     };
 
     beforeEach(() => {
@@ -797,7 +798,8 @@ describe('Replay debugger adapter - unit', () => {
     let args: DebugProtocol.SetBreakpointsArguments;
     const launchRequestArgs: LaunchRequestArguments = {
       logFile: logFilePath,
-      trace: true
+      trace: true,
+      projectPath
     };
 
     beforeEach(() => {
@@ -985,13 +987,10 @@ describe('Replay debugger adapter - unit', () => {
       });
 
       it('Should handle empty line breakpoint info', async () => {
-        const returnArgs: LineBreakpointEventArgs = {
-          lineBreakpointInfo: [],
-          projectPath: undefined
-        };
         const config = {
-          lineBreakpointInfo: returnArgs,
-          logFile: 'someTestLogFile.log'
+          lineBreakpointInfo: [],
+          logFile: 'someTestLogFile.log',
+          projectPath: undefined
         };
 
         await adapter.launchRequest(
@@ -1020,12 +1019,9 @@ describe('Replay debugger adapter - unit', () => {
         expectedLineNumberMapping.set('file:///bar.cls', [1, 2, 3, 4, 5, 6]);
         const projectPathArg = 'some path';
 
-        const returnArgs: LineBreakpointEventArgs = {
-          lineBreakpointInfo: info,
-          projectPath: projectPathArg
-        };
         const config = {
-          lineBreakpointInfo: returnArgs,
+          lineBreakpointInfo: info,
+          projectPath: projectPathArg,
           logFile: 'someTestLogFile.log'
         };
         await adapter.launchRequest(

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/apexReplayDebugVariablesHandling.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/apexReplayDebugVariablesHandling.test.ts
@@ -37,9 +37,11 @@ describe('Replay debugger adapter variable handling - unit', () => {
   let sendResponseSpy: sinon.SinonSpy;
   const logFileName = 'foo.log';
   const logFilePath = `path/${logFileName}`;
+  const projectPath = undefined;
   const launchRequestArgs: LaunchRequestArguments = {
     logFile: logFilePath,
-    trace: true
+    trace: true,
+    projectPath
   };
 
   describe('Scopes request', () => {

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/debugConsole.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/debugConsole.test.ts
@@ -24,13 +24,15 @@ describe('Debug console', () => {
 
   describe('Logger', () => {
     let args: LaunchRequestArguments = {
-      logFile: logFilePath
+      logFile: logFilePath,
+      projectPath: undefined
     };
 
     beforeEach(() => {
       adapter = new MockApexReplayDebug();
       args = {
-        logFile: logFilePath
+        logFile: logFilePath,
+        projectPath: undefined
       };
     });
 

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/core/logContext.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/core/logContext.test.ts
@@ -52,7 +52,8 @@ describe('LogContext', () => {
   let revertStateAfterHeapDumpSpy: sinon.SinonSpy;
   const launchRequestArgs: LaunchRequestArguments = {
     logFile: '/path/foo.log',
-    trace: true
+    trace: true,
+    projectPath: 'path/project'
   };
 
   beforeEach(() => {

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/states/frameEntryState.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/states/frameEntryState.test.ts
@@ -26,7 +26,8 @@ describe('Frame entry event', () => {
   const uriFromSignature = 'file:///path/foo.cls';
   const launchRequestArgs: LaunchRequestArguments = {
     logFile: logFilePath,
-    trace: true
+    trace: true,
+    projectPath: undefined
   };
   let map: Map<string, Map<string, ApexVariable>>;
 

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/states/frameExitState.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/states/frameExitState.test.ts
@@ -21,7 +21,8 @@ describe('Frame exit event', () => {
   const logFilePath = `path/${logFileName}`;
   const launchRequestArgs: LaunchRequestArguments = {
     logFile: logFilePath,
-    trace: true
+    trace: true,
+    projectPath: undefined
   };
 
   beforeEach(() => {

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/states/statementExecuteState.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/states/statementExecuteState.test.ts
@@ -22,7 +22,8 @@ describe('Statement execute event', () => {
   const logFilePath = `path/${logFileName}`;
   const launchRequestArgs: LaunchRequestArguments = {
     logFile: logFilePath,
-    trace: true
+    trace: true,
+    projectPath: undefined
   };
 
   beforeEach(() => {

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/states/userDebugState.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/states/userDebugState.test.ts
@@ -26,7 +26,8 @@ describe('User debug event', () => {
   const logFilePath = `path/${logFileName}`;
   const launchRequestArgs: LaunchRequestArguments = {
     logFile: logFilePath,
-    trace: true
+    trace: true,
+    projectPath: undefined
   };
 
   beforeEach(() => {

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/states/variableAssignmentState.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/states/variableAssignmentState.test.ts
@@ -30,7 +30,8 @@ describe('Variable assignment event', () => {
   const uriFromSignature = 'file:///path/foo.cls';
   const launchRequestArgs: LaunchRequestArguments = {
     logFile: logFilePath,
-    trace: true
+    trace: true,
+    projectPath: undefined
   };
   describe('Primitive assignment', () => {
     const STATIC_PRIMITIVE_VARIABLE_SCOPE_BEGIN =
@@ -78,10 +79,9 @@ describe('Variable assignment event', () => {
         'staticInteger'
       );
       expect(
-        context
-          .getStaticVariablesClassMap()
-          .get('signature')!
-          .get('staticInteger')
+        context.getStaticVariablesClassMap().get('signature')!.get(
+          'staticInteger'
+        )
       ).to.include({
         name: 'staticInteger',
         value: 'null'
@@ -92,10 +92,9 @@ describe('Variable assignment event', () => {
         'staticInteger'
       );
       expect(
-        context
-          .getStaticVariablesClassMap()
-          .get('signature')!
-          .get('staticInteger')
+        context.getStaticVariablesClassMap().get('signature')!.get(
+          'staticInteger'
+        )
       ).to.include({
         name: 'staticInteger',
         value: '5'

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/states/variableBeginState.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/states/variableBeginState.test.ts
@@ -26,7 +26,8 @@ describe('Variable begin scope event', () => {
   const uriFromSignature = 'file:///path/foo.cls';
   const launchRequestArgs: LaunchRequestArguments = {
     logFile: logFilePath,
-    trace: true
+    trace: true,
+    projectPath: undefined
   };
   const STATIC_VARIABLE_LOG_LINE =
     'fakeTime|VARIABLE_SCOPE_BEGIN|[38]|fakeClass.staticInteger|Integer|false|true';

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -90,13 +90,11 @@
       "commandPalette": [
         {
           "command": "sfdx.create.checkpoints",
-          "when":
-            "sfdx:project_opened && sfdx:replay_debugger_checkpoints_enabled"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sfdx.toggle.checkpoint",
-          "when":
-            "sfdx:project_opened && sfdx:replay_debugger_checkpoints_enabled && editorLangId == 'apex'"
+          "when": "sfdx:project_opened && editorLangId == 'apex'"
         },
         {
           "command": "sfdx.launch.replay.debugger.logfile",
@@ -110,8 +108,7 @@
       "view/title": [
         {
           "command": "sfdx.create.checkpoints",
-          "when":
-            "view == sfdx.force.view.checkpoint && sfdx:project_opened && sfdx:replay_debugger_checkpoints_enabled",
+          "when": "view == sfdx.force.view.checkpoint && sfdx:project_opened",
           "group": "navigation"
         }
       ],
@@ -141,8 +138,7 @@
           "light": "images/light/cloud-upload.svg",
           "dark": "images/dark/cloud-upload.svg"
         },
-        "when":
-          "sfdx:project_opened && sfdx:replay_debugger_checkpoints_enabled"
+        "when": "sfdx:project_opened"
       },
       {
         "command": "sfdx.launch.replay.debugger.logfile",
@@ -158,8 +154,7 @@
         {
           "id": "sfdx.force.view.checkpoint",
           "name": "%view_checkpoints%",
-          "when":
-            "sfdx:project_opened && sfdx:replay_debugger_checkpoints_enabled"
+          "when": "sfdx:project_opened"
         }
       ]
     },
@@ -211,17 +206,6 @@
           }
         }
       }
-    ],
-    "configuration": {
-      "type": "object",
-      "title": "%replay-debugger_checkpoint_configuration_title%",
-      "properties": {
-        "salesforcedx-vscode-apex-replay-debugger-checkpoints.enabled": {
-          "type": "boolean",
-          "default": true,
-          "description": "%replay-debugger_checkpoints_enabled%"
-        }
-      }
-    }
+    ]
   }
 }

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.nls.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.nls.json
@@ -13,9 +13,6 @@
     "Stop the debugger after launching. If false, the debugger will run until it hits a breakpoint.",
   "trace_text":
     "Produce diagnostic output. You can set this to true, false, or one or more selectors separated with commas. Selectors include 'all' (very detailed output; the equivalent of true), 'protocol', 'logfile', 'launch', 'breakpoints'.",
-  "replay-debugger_checkpoint_configuration_title":
-    "Replay Debugger Checkpoint Configuration",
-  "replay-debugger_checkpoints_enabled": "Replay Debugger Checkpoints Enabled",
   "sfdx_update_checkpoints_in_org": "SFDX: Update Checkpoints in Org",
   "sfdx_toggle_checkpoint": "SFDX: Toggle Checkpoint"
 }

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
@@ -10,6 +10,8 @@ import {
   DEBUGGER_LAUNCH_TYPE,
   DEBUGGER_TYPE
 } from '@salesforce/salesforcedx-apex-replay-debugger/out/src/constants';
+import * as fs from 'fs';
+import * as path from 'path';
 import * as vscode from 'vscode';
 import { nls } from '../messages';
 
@@ -49,31 +51,30 @@ export class DebugConfigurationProvider
       config.trace = true;
     }
 
-    const sfdxApex = vscode.extensions.getExtension(
-      'salesforce.salesforcedx-vscode-apex'
-    );
-    if (sfdxApex && sfdxApex.exports) {
-      const lineBpInfo = sfdxApex.exports.getLineBreakpointInfo();
-      let fsPath: string | undefined;
-      if (
-        vscode.workspace.workspaceFolders &&
-        vscode.workspace.workspaceFolders[0]
-      ) {
-        fsPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
-      }
-      /* const config = vscode.workspace.getConfiguration();
-      const checkpointsEnabled = config.get(
-        'salesforcedx-vscode-apex-replay-debugger-checkpoints.enabled',
-        false
-      ); */
+    // TODO: move everything below this to salesforce-vscode-apex module
+    let fsPath: string | undefined;
+    if (
+      vscode.workspace.workspaceFolders &&
+      vscode.workspace.workspaceFolders[0]
+    ) {
+      fsPath = path.join(
+        vscode.workspace.workspaceFolders[0].uri.fsPath,
+        '.sfdx',
+        'tools',
+        'projectBreakpoints.json'
+      );
+
+      const testResultOutput = fs.readFileSync(fsPath, 'utf8');
+      const lineBpInfo = JSON.parse(testResultOutput);
+
       const returnArgs: LineBreakpointEventArgs = {
         lineBreakpointInfo: lineBpInfo,
-        // for the moment always send undefined if checkpoints aren't enabled.
-        projectPath: fsPath !== null ? fsPath : undefined
+        projectPath: vscode.workspace.workspaceFolders[0].uri.fsPath
       };
-
+      // END TODO
       config.__privateData = returnArgs;
     }
+
     return config;
   }
 }

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
@@ -38,21 +38,17 @@ export class DebugConfigurationProvider
     config: vscode.DebugConfiguration,
     token?: vscode.CancellationToken
   ): vscode.ProviderResult<vscode.DebugConfiguration> {
-    return this.asyncDebugConfig(folder, config).catch(err => {
-      return vscode.window
-        .showErrorMessage(err.message, { modal: true })
-        .then(_ => undefined); // abort launch
+    return this.asyncDebugConfig(config).catch(async err => {
+      return vscode.window.showErrorMessage(err.message).then(x => undefined);
     });
   }
 
   private async asyncDebugConfig(
-    folder: vscode.WorkspaceFolder | undefined,
     config: vscode.DebugConfiguration
   ): Promise<vscode.DebugConfiguration | undefined> {
     config.name = config.name || nls.localize('config_name_text');
     config.type = config.type || DEBUGGER_TYPE;
     config.request = config.request || DEBUGGER_LAUNCH_TYPE;
-    // config.projectBreakpointFilePath = '${command:sfdx.updateBreakpoint}';
     config.logFile = config.logFile || '${command:AskForLogFileName}';
     if (config.stopOnEntry === undefined) {
       config.stopOnEntry = true;

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
@@ -5,13 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { LineBreakpointEventArgs } from '@salesforce/salesforcedx-apex-replay-debugger/out/src/breakpoints';
 import {
   DEBUGGER_LAUNCH_TYPE,
   DEBUGGER_TYPE
 } from '@salesforce/salesforcedx-apex-replay-debugger/out/src/constants';
-import * as fs from 'fs';
-import * as path from 'path';
 import * as vscode from 'vscode';
 import { nls } from '../messages';
 
@@ -43,6 +40,7 @@ export class DebugConfigurationProvider
     config.name = config.name || nls.localize('config_name_text');
     config.type = config.type || DEBUGGER_TYPE;
     config.request = config.request || DEBUGGER_LAUNCH_TYPE;
+    config.projectBreakpointFilePath = '${command:sfdx.updateBreakpoint}';
     config.logFile = config.logFile || '${command:AskForLogFileName}';
     if (config.stopOnEntry === undefined) {
       config.stopOnEntry = true;
@@ -50,29 +48,11 @@ export class DebugConfigurationProvider
     if (config.trace === undefined) {
       config.trace = true;
     }
-
-    // TODO: move everything below this to salesforce-vscode-apex module
-    let fsPath: string | undefined;
     if (
       vscode.workspace.workspaceFolders &&
       vscode.workspace.workspaceFolders[0]
     ) {
-      fsPath = path.join(
-        vscode.workspace.workspaceFolders[0].uri.fsPath,
-        '.sfdx',
-        'tools',
-        'projectBreakpoints.json'
-      );
-
-      const testResultOutput = fs.readFileSync(fsPath, 'utf8');
-      const lineBpInfo = JSON.parse(testResultOutput);
-
-      const returnArgs: LineBreakpointEventArgs = {
-        lineBreakpointInfo: lineBpInfo,
-        projectPath: vscode.workspace.workspaceFolders[0].uri.fsPath
-      };
-      // END TODO
-      config.__privateData = returnArgs;
+      config.projectPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
     }
 
     return config;

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
@@ -5,7 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { LineBreakpointEventArgs } from '@salesforce/salesforcedx-apex-replay-debugger/out/src/breakpoints';
 import {
   DEBUGGER_LAUNCH_TYPE,
   DEBUGGER_TYPE
@@ -57,26 +56,19 @@ export class DebugConfigurationProvider
       config.trace = true;
     }
 
+    if (
+      vscode.workspace &&
+      vscode.workspace.workspaceFolders &&
+      vscode.workspace.workspaceFolders[0]
+    ) {
+      config.projectPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
+    }
+
     const sfdxApex = vscode.extensions.getExtension(
       'salesforce.salesforcedx-vscode-apex'
     );
-
     if (sfdxApex && sfdxApex.exports) {
-      const lineBpInfo = await sfdxApex.exports.getLineBreakpointInfo();
-      let fsPath: string | undefined;
-      if (
-        vscode.workspace &&
-        vscode.workspace.workspaceFolders &&
-        vscode.workspace.workspaceFolders[0]
-      ) {
-        fsPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
-      }
-
-      const returnArgs: LineBreakpointEventArgs = {
-        lineBreakpointInfo: lineBpInfo,
-        projectPath: fsPath
-      };
-      config.lineBreakpointInfo = returnArgs;
+      config.lineBreakpointInfo = await sfdxApex.exports.getLineBreakpointInfo();
     }
 
     return config;

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { LineBreakpointEventArgs } from '@salesforce/salesforcedx-apex-replay-debugger/out/src/breakpoints';
 import {
   DEBUGGER_LAUNCH_TYPE,
   DEBUGGER_TYPE
@@ -46,6 +47,32 @@ export class DebugConfigurationProvider
     }
     if (config.trace === undefined) {
       config.trace = true;
+    }
+
+    const sfdxApex = vscode.extensions.getExtension(
+      'salesforce.salesforcedx-vscode-apex'
+    );
+    if (sfdxApex && sfdxApex.exports) {
+      const lineBpInfo = sfdxApex.exports.getLineBreakpointInfo();
+      let fsPath: string | undefined;
+      if (
+        vscode.workspace.workspaceFolders &&
+        vscode.workspace.workspaceFolders[0]
+      ) {
+        fsPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
+      }
+      /* const config = vscode.workspace.getConfiguration();
+      const checkpointsEnabled = config.get(
+        'salesforcedx-vscode-apex-replay-debugger-checkpoints.enabled',
+        false
+      ); */
+      const returnArgs: LineBreakpointEventArgs = {
+        lineBreakpointInfo: lineBpInfo,
+        // for the moment always send undefined if checkpoints aren't enabled.
+        projectPath: fsPath !== null ? fsPath : undefined
+      };
+
+      config.__privateData = returnArgs;
     }
     return config;
   }

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/unit/adapter/MockJorje.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/unit/adapter/MockJorje.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+export class MockJorje {
+  constructor() {}
+  public getLineBreakpointInfo(): Promise<{}> {
+    const response = [
+      {
+        uri: '/force-app/main/default/classes/A.cls',
+        typeref: 'A',
+        lines: [2, 5, 6, 7]
+      }
+    ];
+    return Promise.resolve(response);
+  }
+}

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/unit/adapter/debugConfigurationProvider.test.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/unit/adapter/debugConfigurationProvider.test.ts
@@ -68,8 +68,8 @@ describe('Configuration provider', () => {
     const config = DebugConfigurationProvider.getConfig('/path/foo.cls');
     expect(config).to.deep.equal(expectedConfig);
   });
-
-  it('Should fill in empty attributes in the config', () => {
+  /*
+  it('Should fill in empty attributes in the config', ()=> {
     const expectedConfig = {
       name: nls.localize('config_name_text'),
       type: DEBUGGER_TYPE,
@@ -108,7 +108,7 @@ describe('Configuration provider', () => {
     });
 
     expect(config).to.deep.equal(expectedConfig);
-  });
+  }); */
 });
 
 describe('extension context log path tests', () => {

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/unit/adapter/debugConfigurationProvider.test.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/unit/adapter/debugConfigurationProvider.test.ts
@@ -13,30 +13,42 @@ import {
 } from '@salesforce/salesforcedx-apex-replay-debugger/out/src/constants';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import * as vscode from 'vscode';
+import {
+  DebugConfiguration,
+  ExtensionContext,
+  extensions,
+  Uri,
+  WorkspaceFolder
+} from 'vscode';
 import { DebugConfigurationProvider } from '../../../src/adapter/debugConfigurationProvider';
 import { updateLastOpened } from '../../../src/index';
 import { nls } from '../../../src/messages';
+import { MockJorje } from './MockJorje';
 
 // tslint:disable:no-unused-expression
 describe('Configuration provider', () => {
   let provider: DebugConfigurationProvider;
   let getConfigSpy: sinon.SinonSpy;
-  const folder: vscode.WorkspaceFolder = {
+  const folder: WorkspaceFolder = {
     name: 'myWorkspaceFolder',
     index: 0,
     uri: {
       fsPath: '/foo'
-    } as vscode.Uri
+    } as Uri
   };
+  let mockApexJorje: sinon.SinonStub;
 
   beforeEach(() => {
     provider = new DebugConfigurationProvider();
     getConfigSpy = sinon.spy(DebugConfigurationProvider, 'getConfig');
+    mockApexJorje = sinon
+      .stub(extensions, 'getExtension')
+      .returns({ exports: new MockJorje() });
   });
 
   afterEach(() => {
     getConfigSpy.restore();
+    mockApexJorje.restore();
   });
 
   it('Should provide default config', () => {
@@ -47,7 +59,7 @@ describe('Configuration provider', () => {
       logFile: '${command:AskForLogFileName}',
       stopOnEntry: true,
       trace: true
-    } as vscode.DebugConfiguration;
+    } as DebugConfiguration;
 
     const configs = provider.provideDebugConfigurations(folder);
 
@@ -63,42 +75,43 @@ describe('Configuration provider', () => {
       logFile: '/path/foo.cls',
       stopOnEntry: true,
       trace: true
-    } as vscode.DebugConfiguration;
+    } as DebugConfiguration;
 
     const config = DebugConfigurationProvider.getConfig('/path/foo.cls');
     expect(config).to.deep.equal(expectedConfig);
   });
-  /*
-  it('Should fill in empty attributes in the config', ()=> {
-    const expectedConfig = {
-      name: nls.localize('config_name_text'),
-      type: DEBUGGER_TYPE,
-      request: DEBUGGER_LAUNCH_TYPE,
-      logFile: '${command:AskForLogFileName}',
-      stopOnEntry: true,
-      trace: true
-    } as vscode.DebugConfiguration;
 
-    const config = provider.resolveDebugConfiguration(folder, {
+  it('Should fill in empty attributes in the config', async () => {
+    const config = await provider.resolveDebugConfiguration(folder, {
       name: '',
       type: '',
       request: ''
     });
 
-    expect(config).to.deep.equal(expectedConfig);
+    if (config) {
+      expect(config.name).to.equals(nls.localize('config_name_text'));
+      expect(config.type).to.equals(DEBUGGER_TYPE);
+      expect(config.request).to.equals(DEBUGGER_LAUNCH_TYPE);
+      expect(config.logFile).to.equals('${command:AskForLogFileName}');
+      expect(config.stopOnEntry).to.equals(true);
+      expect(config.trace).to.equals(true);
+      expect(config.projectPath).to.not.equals(undefined);
+      expect(config.lineBreakpointInfo).to.deep.equals([
+        {
+          uri: '/force-app/main/default/classes/A.cls',
+          typeref: 'A',
+          lines: [2, 5, 6, 7]
+        }
+      ]);
+    } else {
+      expect.fail(
+        'Did not get configuration information from resolveDebugConfiguration'
+      );
+    }
   });
 
-  it('Should not modify existing config', () => {
-    const expectedConfig = {
-      name: 'sampleName',
-      type: 'sampleType',
-      request: 'sampleConfigType',
-      logFile: 'foo.log',
-      stopOnEntry: false,
-      trace: false
-    } as vscode.DebugConfiguration;
-
-    const config = provider.resolveDebugConfiguration(folder, {
+  it('Should not modify existing config', async () => {
+    const config = await provider.resolveDebugConfiguration(folder, {
       name: 'sampleName',
       type: 'sampleType',
       request: 'sampleConfigType',
@@ -107,8 +120,27 @@ describe('Configuration provider', () => {
       trace: false
     });
 
-    expect(config).to.deep.equal(expectedConfig);
-  }); */
+    if (config) {
+      expect(config.name).to.equals('sampleName');
+      expect(config.type).to.equals('sampleType');
+      expect(config.request).to.equals('sampleConfigType');
+      expect(config.logFile).to.equals('foo.log');
+      expect(config.stopOnEntry).to.equals(false);
+      expect(config.trace).to.equals(false);
+      expect(config.projectPath).to.not.equals(undefined);
+      expect(config.lineBreakpointInfo).to.deep.equals([
+        {
+          uri: '/force-app/main/default/classes/A.cls',
+          typeref: 'A',
+          lines: [2, 5, 6, 7]
+        }
+      ]);
+    } else {
+      expect.fail(
+        'Did not get configuration information from resolveDebugConfiguration'
+      );
+    }
+  });
 });
 
 describe('extension context log path tests', () => {
@@ -125,7 +157,7 @@ describe('extension context log path tests', () => {
 
   it('Should update the extension context', () => {
     updateLastOpened(
-      (mContext as any) as vscode.ExtensionContext,
+      (mContext as any) as ExtensionContext,
       '/foo/bar/logfilename.log'
     );
     expect(mementoKeys).to.have.same.members([

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/unit/checkpoints/checkpointService.test.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/unit/checkpoints/checkpointService.test.ts
@@ -27,13 +27,6 @@ import {
 } from '../../../src/breakpoints/checkpointService';
 
 describe('Checkpoint Service - unit', () => {
-  if (!checkpointsEnabled()) {
-    console.log(
-      'Checkpoints are not enabled, skipping CheckpointService tests'
-    );
-    return;
-  }
-
   const breakpointId = '6c1d848c-fake-4c2c-8b90-5fabe1740da4';
   const breakpointEnabled = true;
   const actionObjectId = '1doxx000000FAKE';
@@ -167,13 +160,6 @@ describe('Checkpoint Service - unit', () => {
 
 // Verify that the vscode.debug.onDidChangeBreakpoints cal
 describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', () => {
-  if (!checkpointsEnabled()) {
-    console.log(
-      'Checkpoints not enabled, skipping Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints'
-    );
-    return;
-  }
-
   // constant empty list
   const bpEmpty: vscode.Breakpoint[] = [];
 
@@ -607,13 +593,6 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
 //  3. if the logMessage isn't empty and doesn't start with 'select' then it is treated as ActionScriptEnum.Apex
 // IsDumpingHeap defaults to true, there's currently no way to reset this.
 describe('Checkpoint parsing from SourceBreakpoint', () => {
-  if (!checkpointsEnabled()) {
-    console.log(
-      'Checkpoints not enabled, skipping Checkpoint parsing from SourceBreakpoint'
-    );
-    return;
-  }
-
   const uriInput = 'file:///bar.cls';
   const lineInput = 5;
 
@@ -703,13 +682,6 @@ describe('Checkpoint parsing from SourceBreakpoint', () => {
 });
 
 describe('Verify SFDX Toggle Checkpoint callback, sfdxToggleCheckpoint', () => {
-  if (!checkpointsEnabled()) {
-    console.log(
-      'Checkpoints not enabled, skipping Verify SFDX Toggle Checkpoint callback, sfdxToggleCheckpoint'
-    );
-    return;
-  }
-
   const cpService = require('../../../src/breakpoints/checkpointService');
 
   const breakpointEnabled = true;
@@ -929,13 +901,4 @@ function clearOutCheckpoints() {
       );
     }
   }
-}
-
-function checkpointsEnabled(): boolean {
-  const config = vscode.workspace.getConfiguration();
-  const enabled = config.get(
-    'salesforcedx-vscode-apex-replay-debugger-checkpoints.enabled',
-    false
-  );
-  return enabled;
 }

--- a/packages/salesforcedx-vscode-apex/src/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/index.ts
@@ -60,13 +60,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(await registerTestView(testOutlineProvider));
 
-  const updateBreakpointCmd = vscode.commands.registerCommand(
-    'sfdx.updateBreakpoint',
-    updateProjectLineBreakpointFile
-  );
-
-  context.subscriptions.push(updateBreakpointCmd);
-
   const exportedApi = {
     getLineBreakpointInfo,
     getExceptionBreakpointInfo,
@@ -76,34 +69,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
   telemetryService.sendExtensionActivationEvent(extensionHRStart);
   return exportedApi;
-}
-
-async function updateProjectLineBreakpointFile() {
-  const lineBpInfo = await getLineBreakpointInfo();
-
-  if (
-    vscode.workspace.workspaceFolders &&
-    vscode.workspace.workspaceFolders[0]
-  ) {
-    const folderPath = path.join(
-      vscode.workspace.workspaceFolders[0].uri.fsPath,
-      '.sfdx',
-      'tools'
-    );
-
-    const myJsonString = JSON.stringify(lineBpInfo);
-    console.log(myJsonString);
-    if (!fs.existsSync(folderPath)) {
-      fs.mkdirSync(folderPath);
-    }
-    const projectBreakpointPath = path.join(
-      folderPath,
-      'projectBreakpoints.json'
-    );
-    fs.writeFileSync(projectBreakpointPath, myJsonString);
-    return projectBreakpointPath;
-  }
-  return '';
 }
 
 async function registerTestView(

--- a/packages/salesforcedx-vscode-apex/src/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/index.ts
@@ -60,6 +60,13 @@ export async function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(await registerTestView(testOutlineProvider));
 
+  const updateBreakpointCmd = vscode.commands.registerCommand(
+    'sfdx.updateBreakpoint',
+    updateProjectLineBreakpointFile
+  );
+
+  context.subscriptions.push(updateBreakpointCmd);
+
   const exportedApi = {
     getLineBreakpointInfo,
     getExceptionBreakpointInfo,
@@ -69,6 +76,34 @@ export async function activate(context: vscode.ExtensionContext) {
 
   telemetryService.sendExtensionActivationEvent(extensionHRStart);
   return exportedApi;
+}
+
+async function updateProjectLineBreakpointFile() {
+  const lineBpInfo = await getLineBreakpointInfo();
+
+  if (
+    vscode.workspace.workspaceFolders &&
+    vscode.workspace.workspaceFolders[0]
+  ) {
+    const folderPath = path.join(
+      vscode.workspace.workspaceFolders[0].uri.fsPath,
+      '.sfdx',
+      'tools'
+    );
+
+    const myJsonString = JSON.stringify(lineBpInfo);
+    console.log(myJsonString);
+    if (!fs.existsSync(folderPath)) {
+      fs.mkdirSync(folderPath);
+    }
+    const projectBreakpointPath = path.join(
+      folderPath,
+      'projectBreakpoints.json'
+    );
+    fs.writeFileSync(projectBreakpointPath, myJsonString);
+    return projectBreakpointPath;
+  }
+  return '';
 }
 
 async function registerTestView(


### PR DESCRIPTION
### What does this PR do?
Refactors the way the replay debugger configuration is received on initialize. Changing from an event that set line breakpoint information on initialize phase to updating resolveDebugConfiguration to be asynchronous and pass the line breakpoint information as parameters to the debug protocol.

Note: This also includes removing the checkpoint setting.

### What issues does this PR fix or reference?
@W-5402619@