### PR TITLE
Updated package names and readmes

### DIFF
--- a/packages/salesforcedx-vscode-apex-debugger/README.md
+++ b/packages/salesforcedx-vscode-apex-debugger/README.md
@@ -1,62 +1,66 @@
-# Apex Debugger for Visual Studio Code
+# Apex Interactive Debugger for Visual Studio Code
+
 This extension enables VS Code to use the real-time Apex Debugger with your scratch orgs and to use ISV Customer Debugger with your subscribers’ sandbox orgs.
 
-For best results, use this extension with the other extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) bundle.  
+For best results, use this extension with the other extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) bundle.
 
-![GIF showing starting a debugging session, hitting a breakpoint, stepping through code, and examining values](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-apex-debugger/images/apex_debugger.gif)  
+![GIF showing starting a debugging session, hitting a breakpoint, stepping through code, and examining values](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-apex-debugger/images/apex_debugger.gif)
 
 ## Prerequisites
+
 Before you set up the Apex Debugger, make sure that you have these essentials.
 
-* At least one available Apex Debugger session in your Dev Hub org (not needed for ISV customer debugging)
-    * One Apex Debugger session is included with Performance Edition and Unlimited Edition orgs.
-    * To purchase Apex Debugger sessions for Enterprise Edition orgs, or to purchase more sessions for orgs that already have allocated sessions, contact Salesforce.
-    * If your production org has access to the Apex Debugger, you can check how many sessions are available on the Apex Debugger page in Setup.
-* For ISV customer debugging: a License Management Org (LMO) that has login access to a subscriber’s sandbox org
-* [Salesforce CLI](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_install_cli.htm) v41.1.0 or later
-* [Visual Studio Code](https://code.visualstudio.com/download) v1.26 or later
-* The latest versions of the [salesforcedx-vscode-core](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-core) and [salesforcedx-vscode-apex](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-apex) extensions (We suggest that you install all extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) extension pack.)
+- At least one available Apex Debugger session in your Dev Hub org (not needed for ISV customer debugging)
+  - One Apex Debugger session is included with Performance Edition and Unlimited Edition orgs.
+  - To purchase Apex Debugger sessions for Enterprise Edition orgs, or to purchase more sessions for orgs that already have allocated sessions, contact Salesforce.
+  - If your production org has access to the Apex Debugger, you can check how many sessions are available on the Apex Debugger page in Setup.
+- For ISV customer debugging: a License Management Org (LMO) that has login access to a subscriber’s sandbox org
+- [Salesforce CLI](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_install_cli.htm) v41.1.0 or later
+- [Visual Studio Code](https://code.visualstudio.com/download) v1.26 or later
+- The latest versions of the [salesforcedx-vscode-core](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-core) and [salesforcedx-vscode-apex](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-apex) extensions (We suggest that you install all extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) extension pack.)
 
 ## Set Up the Apex Debugger
+
 The first time that you use the Apex Debugger in VS Code, complete these setup steps.
 
 1. Add the `DebugApex` feature to the scratch org definition files for all the types of scratch orgs that you plan to debug:  
-  `"features": "DebugApex"`
-1. In VS Code, run **SFDX: Create a Default Scratch Org**. 
+   `"features": "DebugApex"`
+1. In VS Code, run **SFDX: Create a Default Scratch Org**.
 1. Choose a scratch org definition file that includes the `DebugApex` feature.
-1. When your scratch org is ready, assign permissions for the Apex Debugger to the org’s admin user.  
-    1. In VS Code, run **SFDX: Open Default Org**.
-    1. In your browser, from Setup, enter `Permission Sets` in the Quick Find box, then select **Permission Sets**.
-    1. Click **New**.
-    1. Give the permission set a name that you can remember, such as `Debug Apex`.
-    1. In the “Select the type of users who will use this permission set” section, choose **None** from the User License dropdown list. Choosing None lets you assign the permission set to more than one type of user.
-    1. Save your changes.
-    1. Click **System Permissions**.
-    1. Click **Edit**.
-    1. Enable **Debug Apex**. The other permissions that Debug Apex requires are added automatically.
-    1. Save your changes.
-    1. Click **Manage Assignments**.
-    1. Click **Add Assignments**.
-    1. Select the users to whom you want to assign the permission set, and then click **Assign**.
-    1. Click **Done**.
+1. When your scratch org is ready, assign permissions for the Apex Debugger to the org’s admin user.
+   1. In VS Code, run **SFDX: Open Default Org**.
+   1. In your browser, from Setup, enter `Permission Sets` in the Quick Find box, then select **Permission Sets**.
+   1. Click **New**.
+   1. Give the permission set a name that you can remember, such as `Debug Apex`.
+   1. In the “Select the type of users who will use this permission set” section, choose **None** from the User License dropdown list. Choosing None lets you assign the permission set to more than one type of user.
+   1. Save your changes.
+   1. Click **System Permissions**.
+   1. Click **Edit**.
+   1. Enable **Debug Apex**. The other permissions that Debug Apex requires are added automatically.
+   1. Save your changes.
+   1. Click **Manage Assignments**.
+   1. Click **Add Assignments**.
+   1. Select the users to whom you want to assign the permission set, and then click **Assign**.
+   1. Click **Done**.
 1. **Optional**: In VS Code, run **SFDX: Pull Source from Default Scratch Org**. Then, add your new permission set to your source control repository. If you have a copy of the permission set in your Salesforce DX project, you can assign permissions to scratch org users by running `sfdx force:user:permset:assign -n Your_Perm_Set_Name`.
 1. In VS Code, create a launch configuration for the Apex Debugger.
-    1. To open the Debug view, in the VS Code Activity Bar, click the bug icon (hover text: Debug).
-    1. To create a `launch.json` file, click the gear icon (hover text: Configure or Fix launch.json) and then select **Apex Debugger**. (If you’ve already created this file, clicking the gear icon opens the file.)
-    1. Within the `"configurations"` array, add a `"Launch Apex Debugger"` configuration. The minimum information it should contain:
-        ```
-        "configurations": [
-            {
-                "name": "Launch Apex Debugger",
-                "type": "apex",
-                "request": "launch",
-                "sfdxProject": "${workspaceRoot}"
-            }
-        ]
-        ```
-    1. Save your `launch.json` file. Each project needs only one `launch.json` file, even if you work with multiple scratch orgs. This file lives in the project’s `.vscode` directory.
+   1. To open the Debug view, in the VS Code Activity Bar, click the bug icon (hover text: Debug).
+   1. To create a `launch.json` file, click the gear icon (hover text: Configure or Fix launch.json) and then select **Apex Debugger**. (If you’ve already created this file, clicking the gear icon opens the file.)
+   1. Within the `"configurations"` array, add a `"Launch Apex Debugger"` configuration. The minimum information it should contain:
+      ```
+      "configurations": [
+          {
+              "name": "Launch Apex Debugger",
+              "type": "apex",
+              "request": "launch",
+              "sfdxProject": "${workspaceRoot}"
+          }
+      ]
+      ```
+   1. Save your `launch.json` file. Each project needs only one `launch.json` file, even if you work with multiple scratch orgs. This file lives in the project’s `.vscode` directory.
 
 ## Debug Your Code
+
 Nice job! You’ve set up the Apex Debugger. Now, set breakpoints and start a debugging session. Then, debug your code.
 
 To set a line breakpoint, open a `.cls` or `.trigger` file and click the column to the left of the line numbers. Active breakpoints are red. Inactive breakpoints are grey. You can see a list of your breakpoints in the Breakpoints panel of the Debug view.
@@ -66,18 +70,21 @@ To start a debugging session, from the configuration dropdown menu at the top of
 While a debugging session is in progress, any synchronous activity that runs a line of code with a breakpoint causes execution to halt at the breakpoint. While execution is paused, you can inspect the call stack and see the current values of your variables. You can also step through your code, using the Debug actions pane that appears at the top of the editor while a debugging session is in progress, and watch those values change. You can debug up to two threads at a time. For more information, see [Debugging](https://code.visualstudio.com/docs/editor/debugging) in the Visual Studio Code docs.
 
 ## Set Exception Breakpoints
-To make the Apex Debugger halt execution when an exception is thrown during a debugging session, set breakpoints on exceptions. When an exception breakpoint is hit, the debugger pauses on the line of code that caused the exception. The Call Stack panel in the Debug view shows the name of the exception.  
 
-To set an exception breakpoint, press Cmd+Shift+P (macOS) or Ctrl+Shift+P (Windows or Linux) to open the command palette, then select **Apex Debug: Configure Exceptions**. The list of available exceptions includes the [exceptions in the `System` namespace](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_exception_methods.htm) and the Apex classes in your project that extend `Exception`. Select an exception from the list, and then select **Always break**. 
+To make the Apex Debugger halt execution when an exception is thrown during a debugging session, set breakpoints on exceptions. When an exception breakpoint is hit, the debugger pauses on the line of code that caused the exception. The Call Stack panel in the Debug view shows the name of the exception.
 
-To see your exception breakpoints, run **Apex Debug: Configure Exceptions**. The top of the list shows the exception classes that have active breakpoints, labeled `Always break`. To remove an exception breakpoint, select an exception from the list and then select **Never break**.  
+To set an exception breakpoint, press Cmd+Shift+P (macOS) or Ctrl+Shift+P (Windows or Linux) to open the command palette, then select **Apex Debug: Configure Exceptions**. The list of available exceptions includes the [exceptions in the `System` namespace](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_exception_methods.htm) and the Apex classes in your project that extend `Exception`. Select an exception from the list, and then select **Always break**.
+
+To see your exception breakpoints, run **Apex Debug: Configure Exceptions**. The top of the list shows the exception classes that have active breakpoints, labeled `Always break`. To remove an exception breakpoint, select an exception from the list and then select **Never break**.
 
 When you close VS Code, all your exception breakpoints are removed. (Your line breakpoints, however, remain.)
 
 ## Whitelist Users and Request Types
+
 To filter which requests are debugged, edit your `launch.json` file to set up whitelisting. (The `launch.json` file lives in your project’s `.vscode` directory.) If you don’t use whitelisting, all events in your org trigger debugging during a debugging session. Whitelist users or request types to focus only on the events that are relevant to the problem you’re debugging.
 
-Add filters to the `"Launch Apex Debugger"` configuration:  
+Add filters to the `"Launch Apex Debugger"` configuration:
+
 ```
     "configurations": [
         {
@@ -98,7 +105,7 @@ To filter by entry point, enter a regular expression as the value for `"entryPoi
 
 ## ISV Customer Debugger
 
-The ISV Customer Debugger covers a gap in what you can do with the Apex Debugger. As an ISV, you can debug your own code. As a subscriber, you can debug your own code. However, because of the protections against seeing managed code, subscribers can’t debug ISV code in their orgs. With the ISV Customer Debugger, an ISV can work with a subscriber to debug issues specific to the subscriber’s org. 
+The ISV Customer Debugger covers a gap in what you can do with the Apex Debugger. As an ISV, you can debug your own code. As a subscriber, you can debug your own code. However, because of the protections against seeing managed code, subscribers can’t debug ISV code in their orgs. With the ISV Customer Debugger, an ISV can work with a subscriber to debug issues specific to the subscriber’s org.
 
 An ISV can reproduce issues in the specific environment, so problems can be diagnosed more quickly. You can debug only sandbox orgs.
 
@@ -115,7 +122,7 @@ The ISV Customer Debugger is part of the `salesforcedx-vscode-apex-debugger` ext
 1. When directed, either accept the default project name or enter a name for your debugging project, and press Enter.
 1. Choose a location to store the project, and click **Create Project**.
 1. Wait for the project generation process to finish. VS Code retrieves your packaged metadata, your subscriber's metadata, and skeleton classes for other packages in the org, converts them to source format, and creates a Salesforce DX project. VS Code also creates a launch configuration (`launch.json` file) for the project. This process can take a long time, especially for orgs that contain lots of metadata, so feel free to leave it running and check back later. You can monitor the progress in the output panel at the bottom of VS Code. To show the output panel, select **View** > **Output**, then select **Salesforce CLI** from the dropdown menu in the corner of the Output tab.  
-When the project is ready, VS Code opens it for you in a new window.
+   When the project is ready, VS Code opens it for you in a new window.
 1. In the new window, from the Explorer view, open an Apex class or trigger that you want to set breakpoints in.
 1. To set a breakpoint, click the gutter to the left of the line numbers.
 1. Switch to the Debug view.
@@ -123,7 +130,7 @@ When the project is ready, VS Code opens it for you in a new window.
 
 ### Debug Your Subscriber’s Org
 
-With one noteworthy exception, debugging a subscriber’s org works the same way that debugging other orgs does. The exception: You can’t break on Apex events triggered by other users in the org. Only the Login As user can trigger Apex breakpoint hit events. 
+With one noteworthy exception, debugging a subscriber’s org works the same way that debugging other orgs does. The exception: You can’t break on Apex events triggered by other users in the org. Only the Login As user can trigger Apex breakpoint hit events.
 
 See the rest of this README for information about the Apex Debugger. For general information about debugging in VS Code, see [Debugging](https://code.visualstudio.com/docs/editor/debugging) in the Visual Studio Code docs.
 
@@ -136,76 +143,86 @@ If your session expires, start a new session from Setup using all the same steps
 The code from your subscriber’s org is your subscriber’s intellectual property. We advise against keeping it around after you’re done debugging. Delete the entire project from the location where you stored it during the setup process. Never store your subscriber’s metadata in your version control system. When you start a new debugging session later, VS Code downloads the metadata for you again.
 
 ## Considerations
+
 Keep these limitations and known issues in mind when working with the Apex Debugger.
 
 ### General Considerations
-* If you edit Apex classes while a debugging session is in progress, your breakpoints might not match your debugging output after you save your changes.  
 
-* Your debugging session is orphaned when you close VS Code before stopping your session. If you have an orphaned session, you can’t start a new session. To stop your active session, in VS Code, run **SFDX: Stop Apex Debugger Session**. To manage your Dev Hub’s Apex Debugger sessions, go to Apex Debugger in Setup.  
+- If you edit Apex classes while a debugging session is in progress, your breakpoints might not match your debugging output after you save your changes.
 
-* Eval functionality isn’t available.  
+- Your debugging session is orphaned when you close VS Code before stopping your session. If you have an orphaned session, you can’t start a new session. To stop your active session, in VS Code, run **SFDX: Stop Apex Debugger Session**. To manage your Dev Hub’s Apex Debugger sessions, go to Apex Debugger in Setup.
 
-* Hot swapping isn’t permitted. These actions kill your debugging session:
-    * Installing or uninstalling a package
-    * Saving changes that cause your org’s metadata to recompile  
-        ___
-        You can’t save changes to these items during a debugging session:
-        * Apex classes or triggers
-        * Visualforce pages or components
-        * Lightning resources
-        * Permissions or preferences
-        * Custom fields or custom objects  
-        ___
+- Eval functionality isn’t available.
+
+- Hot swapping isn’t permitted. These actions kill your debugging session:
+  - Installing or uninstalling a package
+  - Saving changes that cause your org’s metadata to recompile
+    ***
+    You can’t save changes to these items during a debugging session:
+    - Apex classes or triggers
+    - Visualforce pages or components
+    - Lightning resources
+    - Permissions or preferences
+    - Custom fields or custom objects
+    ***
 
 ### Considerations for Entry Points
+
 These entry points aren’t supported:
-* Asynchronously executed code, including asynchronous tests  
-    ___
-    **Tip**: Code that’s between a pair of `startTest` and `stopTest` methods can run synchronously. To debug your asynchronous functionality, use these methods within your tests.  
-    ___
-* Batch, Queueable, and Scheduled Apex
-* Inbound email
-* Code with the `@future` annotation  
+
+- Asynchronously executed code, including asynchronous tests
+  ***
+  **Tip**: Code that’s between a pair of `startTest` and `stopTest` methods can run synchronously. To debug your asynchronous functionality, use these methods within your tests.
+  ***
+- Batch, Queueable, and Scheduled Apex
+- Inbound email
+- Code with the `@future` annotation
 
 ### Considerations for Breakpoints
-* You can’t set conditional breakpoints.
-* Breakpoints set on a `get` or `set` method must be within the method’s body.
-* You can’t set breakpoints in or step through Execute Anonymous blocks. However, when you hit a breakpoint using Execute Anonymous, we show your Execute Anonymous frame in the stack. To view your Execute Anonymous code’s variables, click this line in the stack.  
+
+- You can’t set conditional breakpoints.
+- Breakpoints set on a `get` or `set` method must be within the method’s body.
+- You can’t set breakpoints in or step through Execute Anonymous blocks. However, when you hit a breakpoint using Execute Anonymous, we show your Execute Anonymous frame in the stack. To view your Execute Anonymous code’s variables, click this line in the stack.
 
 ### Considerations for Variables
-* You can’t watch variables.
-* Variable inspection in dynamic Visualforce and Lightning components isn’t supported.
-* You can’t drill into the instance variables of Apex library objects. To view these objects’ contents, use their `toString` methods.
-* Variables declared within a loop are visible outside of the loop.
-* Drill into variables to see their children’s values. For example, if you run the query `[SELECT Id, ContactId, Contact.accountId, Contact.Account.ownerId FROM Case]`, your results are nested as follows.
-    ```
-    Case
-    --> Contact
-    -----> contactId
-    -----> Account
-    --------> accountId
-    --------> ownerId
-    ```
-* When you perform a SOQL query for variables from the EntityDefinition table, your results include the `durableId` even if you don’t explicitly `SELECT` that variable.
+
+- You can’t watch variables.
+- Variable inspection in dynamic Visualforce and Lightning components isn’t supported.
+- You can’t drill into the instance variables of Apex library objects. To view these objects’ contents, use their `toString` methods.
+- Variables declared within a loop are visible outside of the loop.
+- Drill into variables to see their children’s values. For example, if you run the query `[SELECT Id, ContactId, Contact.accountId, Contact.Account.ownerId FROM Case]`, your results are nested as follows.
+  ```
+  Case
+  --> Contact
+  -----> contactId
+  -----> Account
+  --------> accountId
+  --------> ownerId
+  ```
+- When you perform a SOQL query for variables from the EntityDefinition table, your results include the `durableId` even if you don’t explicitly `SELECT` that variable.
 
 ### ISV Customer Debugger Considerations
-* You can debug only sandbox orgs.
-* You can debug only one customer at a time. However, if you purchase Apex Debugger licenses, you can debug multiple customers at once. An Apex Debugger license also lets you debug in your sandboxes and scratch orgs.
-* When you click Return to subscriber overview, your debugging session terminates. Stay logged in to your subscriber’s org while you debug, and return to your LMO only when you’re done debugging.
+
+- You can debug only sandbox orgs.
+- You can debug only one customer at a time. However, if you purchase Apex Debugger licenses, you can debug multiple customers at once. An Apex Debugger license also lets you debug in your sandboxes and scratch orgs.
+- When you click Return to subscriber overview, your debugging session terminates. Stay logged in to your subscriber’s org while you debug, and return to your LMO only when you’re done debugging.
 
 ## Bugs and Feedback
+
 To report issues with Salesforce Extensions for VS Code, open a [bug on GitHub](https://github.com/forcedotcom/salesforcedx-vscode/issues/new?template=Bug_report.md). If you would like to suggest a feature, create a [feature request on Github](https://github.com/forcedotcom/salesforcedx-vscode/issues/new?template=Feature_request.md).
 
 ## Resources
-* Visual Studio Code Docs: [Debugging](https://code.visualstudio.com/docs/editor/debugging)
-* Trailhead: [Get Started with Salesforce DX](https://trailhead.salesforce.com/trails/sfdx_get_started)
-* _[Salesforce DX Setup Guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup)_
-* _[Apex Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode)_
-* _Force.com IDE Developer Guide_: [Explore a Simple Debugging Puzzle](https://developer.salesforce.com/docs/atlas.en-us.eclipse.meta/eclipse/debugger_puzzle_parent.htm)
-* GitHub: [salesforcedx-vscode-apex-debugger](https://github.com/forcedotcom/salesforcedx-vscode/tree/develop/packages/salesforcedx-vscode-apex-debugger)
-* GitHub wiki for salesforcedx-vscode: [Apex Debugger](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Apex-Debugger)  
+
+- Visual Studio Code Docs: [Debugging](https://code.visualstudio.com/docs/editor/debugging)
+- Trailhead: [Get Started with Salesforce DX](https://trailhead.salesforce.com/trails/sfdx_get_started)
+- _[Salesforce DX Setup Guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup)_
+- _[Apex Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode)_
+- _Force.com IDE Developer Guide_: [Explore a Simple Debugging Puzzle](https://developer.salesforce.com/docs/atlas.en-us.eclipse.meta/eclipse/debugger_puzzle_parent.htm)
+- GitHub: [salesforcedx-vscode-apex-debugger](https://github.com/forcedotcom/salesforcedx-vscode/tree/develop/packages/salesforcedx-vscode-apex-debugger)
+- GitHub wiki for salesforcedx-vscode: [Apex Debugger](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Apex-Debugger)
 
 ---
-Currently, Visual Studio Code extensions are not signed or verified on the Microsoft Visual Studio Code Marketplace. Salesforce provides the Secure Hash Algorithm (SHA) of each extension that we publish. Consult [Manually Verify the salesforcedx-vscode Extensions’ Authenticity](https://developer.salesforce.com/media/vscode/SHA256.md) to learn how to verify the extensions.  
+
+Currently, Visual Studio Code extensions are not signed or verified on the Microsoft Visual Studio Code Marketplace. Salesforce provides the Secure Hash Algorithm (SHA) of each extension that we publish. Consult [Manually Verify the salesforcedx-vscode Extensions’ Authenticity](https://developer.salesforce.com/media/vscode/SHA256.md) to learn how to verify the extensions.
 
 ---

--- a/packages/salesforcedx-vscode-apex-debugger/README.md
+++ b/packages/salesforcedx-vscode-apex-debugger/README.md
@@ -2,7 +2,7 @@
 
 This extension enables VS Code to use the real-time Apex Debugger with your scratch orgs and to use ISV Customer Debugger with your subscribers’ sandbox orgs.
 
-For best results, use this extension with the other extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) bundle.
+**For best results, do not install this extension directly. Install the complete [Salesforce Extension Pack] (https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) instead.**
 
 ![GIF showing starting a debugging session, hitting a breakpoint, stepping through code, and examining values](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-apex-debugger/images/apex_debugger.gif)
 

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforcedx-vscode-apex-debugger",
-  "displayName": "Apex Debugger for Visual Studio Code",
+  "displayName": "Apex Interactive Debugger",
   "description": "Provides debugging support for the Apex programming language",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",
   "bugs": {

--- a/packages/salesforcedx-vscode-apex-replay-debugger/README.md
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/README.md
@@ -1,33 +1,38 @@
 # Apex Replay Debugger for Visual Studio Code
+
 Apex Replay Debugger simulates a live debugging session using a debug log that is a recording of all interactions in a transaction. You no longer need to parse through thousands of log lines manually. Instead, Apex Replay Debugger presents the logged information similarly to an interactive debugger, so you can debug your Apex code. The debugging process is a repetition of editing your Apex code, pushing or deploying the code to your org, reproducing the buggy scenario, downloading the resulting debug log, and launching Apex Replay Debugger with that debug log.
 
 ## Prerequisites
+
 Before you set up Apex Replay Debugger, make sure that you have these essentials.
 
-* **Salesforce CLI**  
-  Before you use Salesforce Extensions for VS Code, [set up Salesforce CLI](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup). 
-* **A Salesforce DX project**  
+- **Salesforce CLI**  
+  Before you use Salesforce Extensions for VS Code, [set up Salesforce CLI](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup).
+- **A Salesforce DX project**  
   See [Project Setup](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_workspace_setup.htm) in the _Salesforce DX Developer Guide_ for details.
-* **An active default org, or a local copy of a debug log from the org whose up-to-date source is in your Salesforce DX project**
-  1. To create a scratch org, you need a Dev Hub. To set up your production org as a Dev Hub, see [Enable Dev Hub in Your Org](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_enable_devhub.htm) in the _Salesforce DX Setup Guide_.  
-  1. To authorize your Dev Hub, open VS Code’s command palette (Cmd+Shift+P on macOS, or Ctrl+Shift+P on Windows or Linux) and run **SFDX: Authorize a Dev Hub**.  
+- **An active default org, or a local copy of a debug log from the org whose up-to-date source is in your Salesforce DX project**
+  1. To create a scratch org, you need a Dev Hub. To set up your production org as a Dev Hub, see [Enable Dev Hub in Your Org](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_enable_devhub.htm) in the _Salesforce DX Setup Guide_.
+  1. To authorize your Dev Hub, open VS Code’s command palette (Cmd+Shift+P on macOS, or Ctrl+Shift+P on Windows or Linux) and run **SFDX: Authorize a Dev Hub**.
   1. To create a default scratch org, run **SFDX: Create a Default Scratch Org**. Then, run **SFDX: Push Source to Default Scratch Org**. For more information, see [Scratch Orgs](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_scratch_orgs.htm) in the _Salesforce DX Developer Guide_.
-* **[Visual Studio Code](https://code.visualstudio.com/download) v1.26 or later**  
-* **The latest version of the [salesforcedx-vscode-core](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-core) and [salesforcedx-vscode-apex](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-apex) extensions**  
-We suggest that you install all extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) extension pack.
-* **View All Data**  
-To view, retain, and delete debug logs and to set checkpoints, you need the View All Data user permission.
+- **[Visual Studio Code](https://code.visualstudio.com/download) v1.26 or later**
+- **The latest version of the [salesforcedx-vscode-core](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-core) and [salesforcedx-vscode-apex](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-apex) extensions**  
+  We suggest that you install all extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) extension pack.
+- **View All Data**  
+  To view, retain, and delete debug logs and to set checkpoints, you need the View All Data user permission.
 
 ## Set Up Apex Replay Debugger
+
 The first time that you use Apex Replay Debugger, create a launch configuration. Then, each time that you debug an issue, set up an Apex Replay Debugger session.
 
 ### Create a Launch Configuration
+
 To create a launch configuration for Apex Replay Debugger, create or update your project’s `.vscode/launch.json` file.
 
 1. Open your Salesforce DX project in VS Code.
 1. If your Salesforce DX project doesn’t already contain a JSON file with the file path `.vscode/launch.json`, create the file (and, if necessary, the folder).
 1. Open your `.vscode/launch.json` file.
-1. Add a configuration named `Launch Apex Replay Debugger`.  
+1. Add a configuration named `Launch Apex Replay Debugger`.
+
 ```
 {
   // Use IntelliSense to learn about possible attributes.
@@ -51,19 +56,20 @@ To create a launch configuration for Apex Replay Debugger, create or update your
 
 Before you generate a debug log for replay debugging, set breakpoints and checkpoints.
 
-1. To set line breakpoints, open a `.cls` or `.trigger` file and click the column to the left of the line numbers.
-1. For more information than line breakpoints provide, add checkpoints. You can set up to five checkpoints to get heap dumps when lines of code run. All local variables, static variables, and trigger context variables have better information at checkpoints. Trigger context variables don’t exist in logs and are available only at checkpoint locations.  
-In Visual Studio Code, a checkpoint is a type of breakpoint. Checkpoints function like breakpoints while replay debugging from a log. Set up and upload your checkpoints before you start an Apex Replay Debugger session.  
-    1. Set checkpoints on up to five lines in Apex classes or triggers.  
-        1. Click the line of code where you want to set the checkpoint.  
-        1. Open the command palette (press Cmd+Shift+P on macOS or Ctrl+Shift+P on Windows or Linux).  
-        1. Run **SFDX: Toggle Checkpoint**.  
+1.  To set line breakpoints, open a `.cls` or `.trigger` file and click the column to the left of the line numbers.
+1.  For more information than line breakpoints provide, add checkpoints. You can set up to five checkpoints to get heap dumps when lines of code run. All local variables, static variables, and trigger context variables have better information at checkpoints. Trigger context variables don’t exist in logs and are available only at checkpoint locations.  
+    In Visual Studio Code, a checkpoint is a type of breakpoint. Checkpoints function like breakpoints while replay debugging from a log. Set up and upload your checkpoints before you start an Apex Replay Debugger session.
 
-        - Or, right-click in the gutter to the left of the line numbers, select **Add Conditional Breakpoint** | **Expression**, and set the expression to `Checkpoint`.  
+    1.  Set checkpoints on up to five lines in Apex classes or triggers.
+    1.  Click the line of code where you want to set the checkpoint.
+    1.  Open the command palette (press Cmd+Shift+P on macOS or Ctrl+Shift+P on Windows or Linux).
+    1.  Run **SFDX: Toggle Checkpoint**.
 
-        - Or, to convert an existing breakpoint into a checkpoint, right-click the breakpoint, and select **Edit Breakpoint** | **Expression**. Set the expression to `Checkpoint`.  
+            - Or, right-click in the gutter to the left of the line numbers, select **Add Conditional Breakpoint** | **Expression**, and set the expression to `Checkpoint`.
 
-    1. To upload your checkpoints to your org to collect heap dump information, open the command palette, and run **SFDX: Update Checkpoints in Org**.
+            - Or, to convert an existing breakpoint into a checkpoint, right-click the breakpoint, and select **Edit Breakpoint** | **Expression**. Set the expression to `Checkpoint`.
+
+        1. To upload your checkpoints to your org to collect heap dump information, open the command palette, and run **SFDX: Update Checkpoints in Org**.
 
 ### Set Up an Apex Replay Debugger Session for a Scratch Org or a Default Development Org
 
@@ -71,10 +77,10 @@ If you’re debugging an issue in a scratch org, or in a sandbox or DE org that 
 
 1. To enable logging, from VS Code, open the command palette (Cmd+Shift+P on macOS, or Ctrl+Shift+P on Windows or Linux) and run **SFDX: Turn On Apex Debug Log for Replay Debugger**.
 1. Reproduce the scenario you want to debug. You can do this by:
-    * Running **SFDX: Invoke Apex Tests**
-    * Running **SFDX: Execute Anonymous Apex with Currently Selected Text**
-    * Running **SFDX: Execute Anonymous Apex with Editor Contents**
-    * Executing manual steps in your org in a web browser 
+   - Running **SFDX: Invoke Apex Tests**
+   - Running **SFDX: Execute Anonymous Apex with Currently Selected Text**
+   - Running **SFDX: Execute Anonymous Apex with Editor Contents**
+   - Executing manual steps in your org in a web browser
 1. To get a list of debug logs in your org, run **SFDX: Get Apex Debug Logs**.
 1. Click the log that you want to replay. The log downloads and opens in VS Code.
 1. Run **SFDX: Launch Apex Replay Debugger with Current File**.
@@ -84,7 +90,7 @@ If you’re debugging an issue in a scratch org, or in a sandbox or DE org that 
 If you’re not using a scratch org or an org that you’ve set as your default org for development in VS Code, download a debug log from your org before you start debugging. Open that log in VS Code and then start a debugging session.
 
 1. In VS Code, open the debug log that you want to analyze. The log must be generated with a log level of `FINER` or `FINEST` for `VISUALFORCE` and a log level of `FINEST` for `APEX_CODE`.
-1. Run **SFDX: Launch Apex Replay Debugger with Current File**.  
+1. Run **SFDX: Launch Apex Replay Debugger with Current File**.
 
 TIP: If your log file is part of your Salesforce DX project, you don’t need to open the log file and then run a separate command. Instead, you can find a log file in the Explorer view, right-click it, and select **Launch Apex Replay Debugger with Current File**.
 
@@ -95,10 +101,11 @@ Replay your debug log and inspect your variables’ values.
 1. To switch to VS Code’s Debug view, click the bug icon on the left edge of the window.
 1. To replay the code execution that was logged in your debug log until you hit your first breakpoint, click the green play icon in the Debug actions pane at the top of the editor.
 1. Step through your code and examine the states of your variables in the VARIABLES section of the Debug view. For details, see [Debugging](https://code.visualstudio.com/docs/editor/debugging) in the Visual Studio Code docs.  
-As you step through your code during a debugging session, Apex Replay Debugger provides details about your variables from heap dumps on lines where you set checkpoints.  
+   As you step through your code during a debugging session, Apex Replay Debugger provides details about your variables from heap dumps on lines where you set checkpoints.
 1. When you’ve stepped through all the logged events, the debugging session ends. If you want to start again at the beginning of the log, run **SFDX: Launch Apex Replay Debugger with Last Log File**.
 
 ## Considerations
+
 Keep these considerations and known issues in mind when working with Apex Replay Debugger.
 
 - You can use this debugger only in your orgs. ISV customer debugging is unavailable in Apex Replay Debugger. To debug customers’ orgs, use [ISV Customer Debugger](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-apex-debugger).
@@ -112,11 +119,12 @@ Keep these considerations and known issues in mind when working with Apex Replay
 - Modifying a collection does not update the collection variable in the VARIABLES section of the Debug view.
 - You can’t set method or conditional breakpoints.
 - You can’t evaluate or watch variables or expressions in the Debug view’s WATCH section.
-- While debugging, right-clicking a variable in the VARIABLES section of the Debug view and selecting **Copy Value** works properly. However, **Copy as Expression** and **Add to Watch** don’t work as expected. 
+- While debugging, right-clicking a variable in the VARIABLES section of the Debug view and selecting **Copy Value** works properly. However, **Copy as Expression** and **Add to Watch** don’t work as expected.
   - **Copy as Expression** functions like Copy Value: It copies the variable’s value instead of copying the full variable name.
   - **Add to Watch** copies the variable’s value into the WATCH section, but because we don’t evaluate variables in this section you see only `<VariableValue>:<VariableValue>`.
 
 ## Bugs and Feedback
+
 To report issues with Salesforce Extensions for VS Code, open a [bug on GitHub](https://github.com/forcedotcom/salesforcedx-vscode/issues/new?template=Bug_report.md). If you would like to suggest a feature, create a [feature request on Github](https://github.com/forcedotcom/salesforcedx-vscode/issues/new?template=Feature_request.md).
 
 ## Resources
@@ -126,6 +134,7 @@ To report issues with Salesforce Extensions for VS Code, open a [bug on GitHub](
 - _Apex Developer Guide_: [Trigger Context Variables](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_triggers_context_variables.htm)
 
 ---
-Currently, Visual Studio Code extensions are not signed or verified on the Microsoft Visual Studio Code Marketplace. Salesforce provides the Secure Hash Algorithm (SHA) of each extension that we publish. Consult [Manually Verify the salesforcedx-vscode Extensions’ Authenticity](https://developer.salesforce.com/media/vscode/SHA256.md) to learn how to verify the extensions.  
+
+Currently, Visual Studio Code extensions are not signed or verified on the Microsoft Visual Studio Code Marketplace. Salesforce provides the Secure Hash Algorithm (SHA) of each extension that we publish. Consult [Manually Verify the salesforcedx-vscode Extensions’ Authenticity](https://developer.salesforce.com/media/vscode/SHA256.md) to learn how to verify the extensions.
 
 ---

--- a/packages/salesforcedx-vscode-apex-replay-debugger/README.md
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/README.md
@@ -2,6 +2,8 @@
 
 Apex Replay Debugger simulates a live debugging session using a debug log that is a recording of all interactions in a transaction. You no longer need to parse through thousands of log lines manually. Instead, Apex Replay Debugger presents the logged information similarly to an interactive debugger, so you can debug your Apex code. The debugging process is a repetition of editing your Apex code, pushing or deploying the code to your org, reproducing the buggy scenario, downloading the resulting debug log, and launching Apex Replay Debugger with that debug log.
 
+**For best results, do not install this extension directly. Install the complete [Salesforce Extension Pack] (https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) instead.**
+
 ## Prerequisites
 
 Before you set up Apex Replay Debugger, make sure that you have these essentials.

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforcedx-vscode-apex-replay-debugger",
-  "displayName": "Apex Replay Debugger for Visual Studio Code",
+  "displayName": "Apex Replay Debugger",
   "description": "Replay Apex execution from Apex Debug Log",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",
   "bugs": {

--- a/packages/salesforcedx-vscode-apex/README.md
+++ b/packages/salesforcedx-vscode-apex/README.md
@@ -2,7 +2,7 @@
 
 View outlines of Apex classes and triggers, see code-completion suggestions, and find syntactic errors in your code. This extension is powered by the [Apex Language Server](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Apex-Language-Server).
 
-**For best results,  do not install this extension directly. Install the complete [Salesforce Extension Pack] (https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) instead.
+**For best results, do not install this extension directly. Install the complete [Salesforce Extension Pack] (https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) instead.**
 
 ## Prerequisites
 

--- a/packages/salesforcedx-vscode-apex/README.md
+++ b/packages/salesforcedx-vscode-apex/README.md
@@ -2,7 +2,7 @@
 
 View outlines of Apex classes and triggers, see code-completion suggestions, and find syntactic errors in your code. This extension is powered by the [Apex Language Server](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Apex-Language-Server).
 
-For best results, use this extension with the other extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) bundle.
+**For best results,  do not install this extension directly. Install the complete [Salesforce Extension Pack] (https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) instead.
 
 ## Prerequisites
 

--- a/packages/salesforcedx-vscode-apex/README.md
+++ b/packages/salesforcedx-vscode-apex/README.md
@@ -1,44 +1,50 @@
-# Apex Code Editor for Visual Studio Code
+# Apex for Visual Studio Code
+
 View outlines of Apex classes and triggers, see code-completion suggestions, and find syntactic errors in your code. This extension is powered by the [Apex Language Server](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Apex-Language-Server).
 
-For best results, use this extension with the other extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) bundle.  
+For best results, use this extension with the other extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) bundle.
 
-##  Prerequisites
+## Prerequisites
+
 Before you set up this extension, make sure that you have these essentials.
 
-* **Java 8 Platform, Standard Edition Development Kit**  
+- **Java 8 Platform, Standard Edition Development Kit**  
   Some features in Salesforce Extensions for VS Code depend upon the Java 8 Platform, Standard Edition Development Kit (JDK).  
-  If you don’t already have the JDK installed, install the latest version of the Java 8 JDK from [Java SE Development Kit 8 Downloads](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).  
-* **[Visual Studio Code](https://code.visualstudio.com/download) v1.26 or later**  
-* **[Salesforce Extensions for VS Code](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode)**  
+  If you don’t already have the JDK installed, install the latest version of the Java 8 JDK from [Java SE Development Kit 8 Downloads](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
+- **[Visual Studio Code](https://code.visualstudio.com/download) v1.26 or later**
+- **[Salesforce Extensions for VS Code](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode)**  
   Code smartness for sObjects in Apex code is powered by the [salesforcedx-vscode-core](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-core) extension. We suggest that you install all extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) extension pack.
 
 ## View Code-Completion Suggestions
+
 To see code-completion suggestions, press Ctrl+space when you’re working in a `.cls` or `.trigger` file. To navigate between the suggestions, use the arrow keys. To auto-complete a suggestion from the list, press Enter.  
 ![Animation showing code completion of a System.debug() statement](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-apex/images/apex_completion.gif)
 
 ## Insert Code Snippets
+
 To see available Apex code snippets when you’re working in a `.cls` or `.trigger` file, run **Insert Snippet**. Snippets are available for class and interface definitions, a variety of statements, and much more. These code snippets are also available as code-completion suggestions.
 
 ## View or Jump to Definitions
-You can preview, view, or go to definitions of:  
-* User-defined Apex  
-  * Classes (from definitions of extending classes)  
-  * Constructors  
-  * Interfaces (from definitions of implementing classes)  
-  * Methods  
-  * Properties  
-  * Variables (local and class variables)  
-* Standard objects  
-  * Fields (standard and custom fields)
-  * Object definitions
-* Custom objects
-  * Fields  
-  * Object definitions  
+
+You can preview, view, or go to definitions of:
+
+- User-defined Apex
+  - Classes (from definitions of extending classes)
+  - Constructors
+  - Interfaces (from definitions of implementing classes)
+  - Methods
+  - Properties
+  - Variables (local and class variables)
+- Standard objects
+  - Fields (standard and custom fields)
+  - Object definitions
+- Custom objects
+  - Fields
+  - Object definitions
 
 (See the "Enable Code Smartness for SObjects" section of this README for information on working with standard and custom objects.)
 
-To preview a definition, hold down Cmd (macOS) or Ctrl (Windows or Linux) and hover over the item whose definition you want to see.  
+To preview a definition, hold down Cmd (macOS) or Ctrl (Windows or Linux) and hover over the item whose definition you want to see.
 
 To view a definition, right-click the item and select **Peek Definition**, or press Alt+F12.
 
@@ -46,54 +52,64 @@ To jump to the location of a definition, right-click the item and select **Go to
 ![Previewing, viewing, and jumping to a definition](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-apex/images/apex_go_to_definition.gif)
 
 ## Find All References
-You can find all references to user-defined Apex:  
-* Classes  
-* Class variables  
-* Enums  
-* Interfaces  
-* Methods  
-* Properties  
+
+You can find all references to user-defined Apex:
+
+- Classes
+- Class variables
+- Enums
+- Interfaces
+- Methods
+- Properties
 
 To find references to an item, right-click the item and select **Find All References**, or press Shift+F12.
 
 ## Check Syntax Errors in Your Code
-If you leave out a `;`, `}`, or `)`, the syntax error is marked with a red squiggly line in the editor.  
+
+If you leave out a `;`, `}`, or `)`, the syntax error is marked with a red squiggly line in the editor.
 
 The Problems view in the bottom pane also lists the syntax errors. Double-click the problem to go to the source file.  
 ![Problems view, showing a missing semicolon in an Apex class](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-apex/images/apex_problems.png)
 
 ## View an Outline of Your Apex Class or Trigger
+
 The Apex outline view shows the structure of the Apex class or trigger that’s open in the editor. For a list of the symbols in your file, press Cmd+Shift+O (macOS) or Ctrl+Shift+O (Windows or Linux). To jump to one of the symbols, select it in the list.  
 ![Outline view, showing the symbols in an Apex class](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-apex/images/apex_outline.png)
 
 ## Enable Code Smartness for SObjects
-To activate this extension’s code smartness features for standard and custom objects and their fields, including for custom fields on standard objects, press Cmd+Shift+P (macOS) or Ctrl+Shift+P (Windows or Linux), and then select **SFDX: Refresh SObject Definitions** from the command palette. 
 
-When you refresh your sObject definitions, VS Code uses your default org to generate faux Apex classes. These faux classes represent the standard and custom objects that the admin user has access to for your default scratch org, or the logged-in user of your sandbox or DE org. The classes are stored in a hidden directory on your local workstation. Don’t edit the faux classes! They are deleted and regenerated each time that you refresh your sObject definitions. To modify your sObjects, either modify the objects’ `.object-meta.xml` and `.field-meta.xml` files (and then run **SFDX: Push Source to Default Scratch Org** or **SFDX: Deploy Source to Org**), or make changes declaratively in your org (and then run **SFDX: Pull Source from Default Scratch Org** or **SFDX: Retrieve Source from Org**). Your user doesn’t automatically gain access to new custom objects, so be sure to assign new permissions to the user as necessary. To assign permissions from the command line, run `sfdx force:user:permset:assign -n YourPermSetName`. 
+To activate this extension’s code smartness features for standard and custom objects and their fields, including for custom fields on standard objects, press Cmd+Shift+P (macOS) or Ctrl+Shift+P (Windows or Linux), and then select **SFDX: Refresh SObject Definitions** from the command palette.
 
-After you add or edit standard or custom objects or their fields, be sure to rerun **SFDX: Refresh SObject Definitions**.  
+When you refresh your sObject definitions, VS Code uses your default org to generate faux Apex classes. These faux classes represent the standard and custom objects that the admin user has access to for your default scratch org, or the logged-in user of your sandbox or DE org. The classes are stored in a hidden directory on your local workstation. Don’t edit the faux classes! They are deleted and regenerated each time that you refresh your sObject definitions. To modify your sObjects, either modify the objects’ `.object-meta.xml` and `.field-meta.xml` files (and then run **SFDX: Push Source to Default Scratch Org** or **SFDX: Deploy Source to Org**), or make changes declaratively in your org (and then run **SFDX: Pull Source from Default Scratch Org** or **SFDX: Retrieve Source from Org**). Your user doesn’t automatically gain access to new custom objects, so be sure to assign new permissions to the user as necessary. To assign permissions from the command line, run `sfdx force:user:permset:assign -n YourPermSetName`.
+
+After you add or edit standard or custom objects or their fields, be sure to rerun **SFDX: Refresh SObject Definitions**.
 
 ## Monitor Apex Language Server Output
-The Apex Language Server is an implementation of the [Language Server Protocol](https://github.com/Microsoft/language-server-protocol) 3.0 specification. The Language Server Protocol allows a tool (in this case, VS Code) to communicate with a language smartness provider (the server). VS Code uses the Apex Language Server to show outlines of Apex classes and triggers, code-completion suggestions, and syntactic errors. To see all diagnostic information from the Apex Language Server, select **View** > **Output**, then choose **Apex Language Server** from the dropdown menu. The diagnostic information gives you insights into the progress of the language server and shows the problems  encountered.  
+
+The Apex Language Server is an implementation of the [Language Server Protocol](https://github.com/Microsoft/language-server-protocol) 3.0 specification. The Language Server Protocol allows a tool (in this case, VS Code) to communicate with a language smartness provider (the server). VS Code uses the Apex Language Server to show outlines of Apex classes and triggers, code-completion suggestions, and syntactic errors. To see all diagnostic information from the Apex Language Server, select **View** > **Output**, then choose **Apex Language Server** from the dropdown menu. The diagnostic information gives you insights into the progress of the language server and shows the problems encountered.
 
 ## Troubleshooting
-Salesforce Extensions for VS Code functions properly only if the root directory of your open project contains an `sfdx-project.json` file.  
+
+Salesforce Extensions for VS Code functions properly only if the root directory of your open project contains an `sfdx-project.json` file.
 
 If you’re not seeing the Apex completion suggestions that you expect, your Apex database might need to be rebuilt. Quit VS Code, and then delete the `.sfdx/tools/apex.db` file from your project. Then relaunch VS Code, and open an Apex class or trigger. The Apex database rebuilds within about 5 seconds (up to 30 seconds for very large code bases).
 
 ## Bugs and Feedback
+
 To report issues with Salesforce Extensions for VS Code, open a [bug on GitHub](https://github.com/forcedotcom/salesforcedx-vscode/issues/new?template=Bug_report.md). If you would like to suggest a feature, create a [feature request on Github](https://github.com/forcedotcom/salesforcedx-vscode/issues/new?template=Feature_request.md).
 
 ## Resources
-* Trailhead: [Get Started with Salesforce DX](https://trailhead.salesforce.com/trails/sfdx_get_started)
-* _[Salesforce DX Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev)_
-* _[Apex Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode)_
-* Dreamforce ’17 session video: [Building Powerful Tooling For All IDEs Through Language Servers](https://www.salesforce.com/video/1765282/)
-* GitHub: [Language Server Protocol](https://github.com/Microsoft/language-server-protocol)
-* GitHub: [salesforcedx-vscode-apex](https://github.com/forcedotcom/salesforcedx-vscode/tree/develop/packages/salesforcedx-vscode-apex)
-* GitHub wiki for salesforcedx-vscode: [Apex Language Server](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Apex-Language-Server)
+
+- Trailhead: [Get Started with Salesforce DX](https://trailhead.salesforce.com/trails/sfdx_get_started)
+- _[Salesforce DX Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev)_
+- _[Apex Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode)_
+- Dreamforce ’17 session video: [Building Powerful Tooling For All IDEs Through Language Servers](https://www.salesforce.com/video/1765282/)
+- GitHub: [Language Server Protocol](https://github.com/Microsoft/language-server-protocol)
+- GitHub: [salesforcedx-vscode-apex](https://github.com/forcedotcom/salesforcedx-vscode/tree/develop/packages/salesforcedx-vscode-apex)
+- GitHub wiki for salesforcedx-vscode: [Apex Language Server](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Apex-Language-Server)
 
 ---
-Currently, Visual Studio Code extensions are not signed or verified on the Microsoft Visual Studio Code Marketplace. Salesforce provides the Secure Hash Algorithm (SHA) of each extension that we publish. Consult [Manually Verify the salesforcedx-vscode Extensions’ Authenticity](https://developer.salesforce.com/media/vscode/SHA256.md) to learn how to verify the extensions.    
+
+Currently, Visual Studio Code extensions are not signed or verified on the Microsoft Visual Studio Code Marketplace. Salesforce provides the Secure Hash Algorithm (SHA) of each extension that we publish. Consult [Manually Verify the salesforcedx-vscode Extensions’ Authenticity](https://developer.salesforce.com/media/vscode/SHA256.md) to learn how to verify the extensions.
 
 ---

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforcedx-vscode-apex",
-  "displayName": "Apex Code Editor for Visual Studio Code",
+  "displayName": "Apex",
   "description":
     "Provides code-editing features for the Apex programming language",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",

--- a/packages/salesforcedx-vscode-core/README.md
+++ b/packages/salesforcedx-vscode-core/README.md
@@ -1,38 +1,45 @@
 # Salesforce CLI Integration for Visual Studio Code
-This extension enables VS Code to use the Salesforce CLI to interact with your orgs.  
 
-For best results, use this extension with the other extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) bundle.  
+This extension enables VS Code to use the Salesforce CLI to interact with your orgs.
 
-##  Prerequisites
+For best results, use this extension with the other extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) bundle.
+
+## Prerequisites
+
 Before you set up this extension, make sure that you have these essentials.
 
-* **Salesforce CLI**  
-  Before you use Salesforce Extensions for VS Code, [set up the Salesforce CLI](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup).  
-* **A Salesforce DX project**
+- **Salesforce CLI**  
+  Before you use Salesforce Extensions for VS Code, [set up the Salesforce CLI](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup).
+- **A Salesforce DX project**
   Open your Salesforce DX project in a directory that contains an `sfdx-project.json` file. Otherwise, some features don’t work.  
-  If you don't already have a Salesforce DX project, create one with the **SFDX: Create Project** command (for development against scratch orgs) or the **SFDX: Create Project with Manifest** command (for development against sandboxes or DE orgs). Or, see [create a Salesforce DX project](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_workspace_setup.htm) for information about setting up a project using Salesforce CLI.  
-* **[Visual Studio Code](https://code.visualstudio.com/download) v1.26 or later**  
+  If you don't already have a Salesforce DX project, create one with the **SFDX: Create Project** command (for development against scratch orgs) or the **SFDX: Create Project with Manifest** command (for development against sandboxes or DE orgs). Or, see [create a Salesforce DX project](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_workspace_setup.htm) for information about setting up a project using Salesforce CLI.
+- **[Visual Studio Code](https://code.visualstudio.com/download) v1.26 or later**
 
-## Set Up a Default Scratch Org  
+## Set Up a Default Scratch Org
+
 To access the Visual Studio Code command palette, press Cmd+Shift+P (macOS) or Ctrl+Shift+P (Windows or Linux). To create a scratch org and set it as your default org for development, run **SFDX: Authorize a Dev Hub** and then **SFDX: Create a Default Scratch Org**. Then, to push the source in your project to the scratch org, run **SFDX: Push Source to Default Scratch Org**. To open the org in your browser, run **SFDX: Open Default Org**. After you make changes in the Salesforce user interface, to pull those changes to your local project, run **SFDX: Pull Source from Default Scratch Org**.
 
 ## Develop Against Any Org in Visual Studio Code (Beta)
+
 Connect to a sandbox or Developer Edition (DE) org to retrieve and deploy source from Visual Studio Code. You can connect to non-source-tracked orgs (orgs other than scratch orgs) in Salesforce Extensions for VS Code v44 and later.
 
 ---
+
 As a beta feature, the ability to use VS Code with sandbox and production orgs is a preview and isn’t part of the “Services” under your master subscription agreement with Salesforce. Use this feature at your sole discretion, and make your purchase decisions only on the basis of generally available products and features. Salesforce doesn’t guarantee general availability of this feature within any particular time frame or at all, and we can discontinue it at any time. This feature is for evaluation purposes only, not for production use. It’s offered as is and isn’t supported, and Salesforce has no liability for any harm or damage arising out of or in connection with it. All restrictions, Salesforce reservation of rights, obligations concerning the Services, and terms for related Non-Salesforce Applications and Content apply equally to your use of this feature. You can provide feedback and suggestions for this functionality in the [Issues section](https://github.com/forcedotcom/salesforcedx-vscode/issues) of the salesforcedx-vscode repository on GitHub.
 
 ---
 
 To access the Visual Studio Code command palette, press Cmd+Shift+P (macOS) or Ctrl+Shift+P (Windows or Linux). Then run these commands as needed.
-- To log in to a sandbox or a DE org and set that org as the default org for your project, run **SFDX: Authorize an Org**.  
 
-    NOTE: Before you authorize a sandbox org, edit your `sfdx-project.json` file and set your `sfdcLoginUrl` value to `https://test.salesforce.com`:  
-    ```
-    "sfdcLoginUrl": "https://test.salesforce.com"
-    ```
+- To log in to a sandbox or a DE org and set that org as the default org for your project, run **SFDX: Authorize an Org**.
 
-- To generate a project with a manifest (with a `package.xml` file) to develop against orgs without source tracking (orgs that aren’t scratch orgs), run **SFDX: Create Project with Manifest**.  
+  NOTE: Before you authorize a sandbox org, edit your `sfdx-project.json` file and set your `sfdcLoginUrl` value to `https://test.salesforce.com`:
+
+  ```
+  "sfdcLoginUrl": "https://test.salesforce.com"
+  ```
+
+- To generate a project with a manifest (with a `package.xml` file) to develop against orgs without source tracking (orgs that aren’t scratch orgs), run **SFDX: Create Project with Manifest**.
 
 To retrieve source from an org without source tracking (from an org that’s not a scratch org), right-click a manifest, a source file, or a directory in the Visual Studio Code explorer. Select **SFDX: Retrieve Source from Org**. Or, right-click a file that’s open in the editor, and select **SFDX: Retrieve This Source File from Org**.
 
@@ -45,10 +52,12 @@ CAUTION: Deploying source to an org overwrites the metadata in your org with you
 To delete source from your project and from your non-source-tracked org, right-click a manifest, a source file, or a directory in the Visual Studio Code explorer. Select **SFDX: Delete from Project and Org**. Or, right-click a file that’s open in the editor, and select **SFDX: Delete This from Project and Org**.
 
 ## View Your Default Org
+
 A badge in the footer shows your default development org. It uses the org’s auto-generated username or the alias that you chose for the org. To open the org in your browser, click this badge.  
 ![Username for default scratch org, displayed in footer](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-core/images/active_scratch_org.png)
 
 ## Run Salesforce CLI Commands
+
 To run a command from Salesforce Extensions for VS Code, press Cmd+Shift+P (macOS) or Ctrl+Shift+P (Windows or Linux) and type **SFDX** in the command palette.  
 ![Command palette, filtered to show SFDX commands](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-core/images/sfdx_commands.png)
 
@@ -56,95 +65,104 @@ When a command finishes running (due to success, failure, or cancellation), a no
 ![Notification that source was successfully pushed to a scratch org](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-core/images/command_success_notification.png)
 
 To see the output of the commands that you run, select **View** > **Output**, and then select **Salesforce CLI** from the dropdown menu. Alternatively, click **Show** in the completion notification.  
-![Output view, showing the results of an Apex test run](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-core/images/output_view.png)  
+![Output view, showing the results of an Apex test run](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-core/images/output_view.png)
 
 These Salesforce CLI commands are available:
-* `force:alias:list`: **SFDX: List All Aliases**
-* `force:apex:class:create ...`: **SFDX: Create Apex Class**
-* `force:apex:execute`: **SFDX: Execute Anonymous Apex with Currently Selected Text**
-* `force:apex:execute --apexcodefile`: **SFDX: Execute Anonymous Apex with Editor Contents**
-* `force:apex:log:get ...`: **SFDX: Get Apex Debug Logs...**
-* `force:apex:test:run --resultformat human ...`: **SFDX: Invoke Apex Tests...**
-* `force:apex:trigger:create ...`: **SFDX: Create Apex Trigger**
-* `force:auth:logout --all --noprompt`: **SFDX: Log Out from All Authorized Orgs**
-* `force:auth:web:login --setdefaultdevhubusername`: **SFDX: Authorize a Dev Hub**
-* `force:config:list`: **SFDX: List All Config Variables**
-* `force:data:soql:query`: **SFDX: Execute SOQL Query with Currently Selected Text**
-* `force:data:soql:query ...`: **SFDX: Execute SOQL Query...**
-* `force:lightning:app:create ...`: **SFDX: Create Lightning App**
-* `force:lightning:component:create ...`: **SFDX: Create Lightning Component**
-* `force:lightning:event:create ...`: **SFDX: Create Lightning Event**
-* `force:lightning:interface:create ...`: **SFDX: Create Lightning Interface**
-* `force:org:create --setdefaultusername ...`: **SFDX: Create a Default Scratch Org**
-* `force:org:display`: **SFDX: Display Org Details for Default Scratch Org**
-* `force:org:display --targetusername ...`: **SFDX: Display Org Details...**
-* `force:org:open`: **SFDX: Open Default Org**
-* `force:project:create ...`: **SFDX: Create Project**
-* `force:project:create --manifest ...`: **SFDX: Create Project with Manifest**
-* `force:source:delete`: **SFDX: Delete from Project and Org** (beta)
-* `force:source:deploy`: **SFDX: Deploy Source to Org** (beta)
-* `force:source:pull`: **SFDX: Pull Source from Default Scratch Org**
-* `force:source:pull --forceoverwrite`: **SFDX: Pull Source from Default Scratch Org and Override Conflicts**
-* `force:source:push`: **SFDX: Push Source to Default Scratch Org**
-* `force:source:push --forceoverwrite`: **SFDX: Push Source to Default Scratch Org and Override Conflicts**
-* `force:source:retrieve`: **SFDX: Retrieve Source from Org** (beta)
-* `force:source:status`: **SFDX: View All Changes (Local and in Default Scratch Org)**
-* `force:source:status --local`: **SFDX: View Local Changes**
-* `force:source:status --remote`: **SFDX: View Changes in Default Scratch Org**
-* `force:visualforce:component:create ...`: **SFDX: Create Visualforce Component**
-* `force:visualforce:page:create ...`: **SFDX: Create Visualforce Page**
+
+- `force:alias:list`: **SFDX: List All Aliases**
+- `force:apex:class:create ...`: **SFDX: Create Apex Class**
+- `force:apex:execute`: **SFDX: Execute Anonymous Apex with Currently Selected Text**
+- `force:apex:execute --apexcodefile`: **SFDX: Execute Anonymous Apex with Editor Contents**
+- `force:apex:log:get ...`: **SFDX: Get Apex Debug Logs...**
+- `force:apex:test:run --resultformat human ...`: **SFDX: Invoke Apex Tests...**
+- `force:apex:trigger:create ...`: **SFDX: Create Apex Trigger**
+- `force:auth:logout --all --noprompt`: **SFDX: Log Out from All Authorized Orgs**
+- `force:auth:web:login --setdefaultdevhubusername`: **SFDX: Authorize a Dev Hub**
+- `force:config:list`: **SFDX: List All Config Variables**
+- `force:data:soql:query`: **SFDX: Execute SOQL Query with Currently Selected Text**
+- `force:data:soql:query ...`: **SFDX: Execute SOQL Query...**
+- `force:lightning:app:create ...`: **SFDX: Create Lightning App**
+- `force:lightning:component:create ...`: **SFDX: Create Lightning Component**
+- `force:lightning:event:create ...`: **SFDX: Create Lightning Event**
+- `force:lightning:interface:create ...`: **SFDX: Create Lightning Interface**
+- `force:org:create --setdefaultusername ...`: **SFDX: Create a Default Scratch Org**
+- `force:org:display`: **SFDX: Display Org Details for Default Scratch Org**
+- `force:org:display --targetusername ...`: **SFDX: Display Org Details...**
+- `force:org:open`: **SFDX: Open Default Org**
+- `force:project:create ...`: **SFDX: Create Project**
+- `force:project:create --manifest ...`: **SFDX: Create Project with Manifest**
+- `force:source:delete`: **SFDX: Delete from Project and Org** (beta)
+- `force:source:deploy`: **SFDX: Deploy Source to Org** (beta)
+- `force:source:pull`: **SFDX: Pull Source from Default Scratch Org**
+- `force:source:pull --forceoverwrite`: **SFDX: Pull Source from Default Scratch Org and Override Conflicts**
+- `force:source:push`: **SFDX: Push Source to Default Scratch Org**
+- `force:source:push --forceoverwrite`: **SFDX: Push Source to Default Scratch Org and Override Conflicts**
+- `force:source:retrieve`: **SFDX: Retrieve Source from Org** (beta)
+- `force:source:status`: **SFDX: View All Changes (Local and in Default Scratch Org)**
+- `force:source:status --local`: **SFDX: View Local Changes**
+- `force:source:status --remote`: **SFDX: View Changes in Default Scratch Org**
+- `force:visualforce:component:create ...`: **SFDX: Create Visualforce Component**
+- `force:visualforce:page:create ...`: **SFDX: Create Visualforce Page**
 
 ## View Your Running Tasks
+
 To check your running tasks, expand the Running Tasks view in the Explorer.  
 ![Running Tasks view, showing that Apex tests are running](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-core/images/running_tasks.png)
 
-## Apex Tests  
+## Apex Tests
+
 You can run Apex tests from within a file or from the Apex Tests sidebar. The sidebar provides other useful features for working with your tests.
 
 ### Explore Your Apex Tests
 
-The Apex Tests sidebar provides several features. Here, you can see all your Apex tests at a glance. You can run one test method, the test methods in one class, or all your tests. You can view the results of your last test run. And you can jump from those results to the corresponding lines in your code. To access this sidebar, click the beaker icon (hover text: Test) in the view bar on the left side of the VS Code window. (If you don’t see this icon, make sure that the project you have open in VS Code contains an `sfdx-project.json` file in its root directory.)  
+The Apex Tests sidebar provides several features. Here, you can see all your Apex tests at a glance. You can run one test method, the test methods in one class, or all your tests. You can view the results of your last test run. And you can jump from those results to the corresponding lines in your code. To access this sidebar, click the beaker icon (hover text: Test) in the view bar on the left side of the VS Code window. (If you don’t see this icon, make sure that the project you have open in VS Code contains an `sfdx-project.json` file in its root directory.)
 
-To run selected tests, in the Apex Tests view, hover over the name of a test method or class to reveal a play icon. Click the play icon (hover text: Run Single Test) to run a test method or all the methods in a class. To run all your tests, click the larger play icon at the top of the Apex Tests view (hover text: Run Tests).  
+To run selected tests, in the Apex Tests view, hover over the name of a test method or class to reveal a play icon. Click the play icon (hover text: Run Single Test) to run a test method or all the methods in a class. To run all your tests, click the larger play icon at the top of the Apex Tests view (hover text: Run Tests).
 
 After you run tests, the blue icons next to your classes and methods change to green icons (for passing tests) or red icons (for failing tests). To see details about your test runs, hover over the name of a test class in the sidebar.
 
-To jump to the definition of a test class, a test method that passed, or a method that you haven’t run yet, click its name in the sidebar. If you click the name of a failed test method, you jump to the assert statement that failed.  
+To jump to the definition of a test class, a test method that passed, or a method that you haven’t run yet, click its name in the sidebar. If you click the name of a failed test method, you jump to the assert statement that failed.
 
-To clear your test results, click the refresh icon at the top of the sidebar (hover text: Refresh Tests).  
+To clear your test results, click the refresh icon at the top of the sidebar (hover text: Refresh Tests).
 
 ### Run Apex Tests from Within a File
+
 To run Apex tests, in your `.cls` file, click **Run Test** or **Run All Tests** above the definition of an Apex test method or class.  
 ![Running Apex tests using the Run Test and Run All Tests code lenses](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-core/images/apex_test_run.gif)
 
-Results from your test run display in the Output panel. The Failures section of the output lists stack traces for failed tests. To navigate to the line of code that caused a failure, press Cmd (macOS) or Ctrl (Windows and Linux) and click that stack trace.  
+Results from your test run display in the Output panel. The Failures section of the output lists stack traces for failed tests. To navigate to the line of code that caused a failure, press Cmd (macOS) or Ctrl (Windows and Linux) and click that stack trace.
 
-After you run Apex tests, two new commands are available in the command palette: **SFDX: Re-Run Last Invoked Apex Test Class** and **SFDX: Re-Run Last Invoked Apex Test Method**. 
+After you run Apex tests, two new commands are available in the command palette: **SFDX: Re-Run Last Invoked Apex Test Class** and **SFDX: Re-Run Last Invoked Apex Test Method**.
 
-To retrieve code coverage results when you run Apex tests, edit your workspace settings and set `salesforcedx-vscode-core.retrieve-test-code-coverage` to `true`.  
+To retrieve code coverage results when you run Apex tests, edit your workspace settings and set `salesforcedx-vscode-core.retrieve-test-code-coverage` to `true`.
 
 ## Edit Your Workspace Settings
-To edit your workspace settings, select **Code** > **Preferences** > **Settings** (macOS) or **File** > **Preferences** > **Settings** (Windows and Linux).  
 
-To stop Salesforce CLI success messages from showing as pop-up information messages, click **Show Only in Status Bar** in a success message. This button overrides the `salesforcedx-vscode-core.show-cli-success-msg` value in your Default Settings. It changes the Workspace Settings value to `false`. Setting this value to `false` makes the success messages appear in the status bar (in VS Code’s footer) instead of as information messages. If you decide that you liked the information messages after all, change the value back to `true`.   
+To edit your workspace settings, select **Code** > **Preferences** > **Settings** (macOS) or **File** > **Preferences** > **Settings** (Windows and Linux).
+
+To stop Salesforce CLI success messages from showing as pop-up information messages, click **Show Only in Status Bar** in a success message. This button overrides the `salesforcedx-vscode-core.show-cli-success-msg` value in your Default Settings. It changes the Workspace Settings value to `false`. Setting this value to `false` makes the success messages appear in the status bar (in VS Code’s footer) instead of as information messages. If you decide that you liked the information messages after all, change the value back to `true`.
 
 ## Activate Demo Mode
-If you’re setting up a machine to use for demos at a conference (or for other public use), set up demo mode. When in demo mode, VS Code warns users who authorize business or production orgs of the potential security risks of using these orgs on shared machines.  
 
-To activate demo mode, add an environment variable called `SFDX_ENV` and set its value to `DEMO`: `SFDX_ENV=DEMO`.  
+If you’re setting up a machine to use for demos at a conference (or for other public use), set up demo mode. When in demo mode, VS Code warns users who authorize business or production orgs of the potential security risks of using these orgs on shared machines.
 
-When you’re done with your event, run **SFDX: Log Out from All Authorized Orgs**.  
+To activate demo mode, add an environment variable called `SFDX_ENV` and set its value to `DEMO`: `SFDX_ENV=DEMO`.
+
+When you’re done with your event, run **SFDX: Log Out from All Authorized Orgs**.
 
 ## Bugs and Feedback
+
 To report issues with Salesforce Extensions for VS Code, open a [bug on GitHub](https://github.com/forcedotcom/salesforcedx-vscode/issues/new?template=Bug_report.md). If you would like to suggest a feature, create a [feature request on Github](https://github.com/forcedotcom/salesforcedx-vscode/issues/new?template=Feature_request.md).
 
 ## Resources
-* Trailhead: [Get Started with Salesforce DX](https://trailhead.salesforce.com/trails/sfdx_get_started)
-* _[Salesforce DX Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev)_
-* _[Salesforce CLI Command Reference](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference)_
-* GitHub: [salesforcedx-vscode-core](https://github.com/forcedotcom/salesforcedx-vscode/tree/develop/packages/salesforcedx-vscode-core)
+
+- Trailhead: [Get Started with Salesforce DX](https://trailhead.salesforce.com/trails/sfdx_get_started)
+- _[Salesforce DX Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev)_
+- _[Salesforce CLI Command Reference](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference)_
+- GitHub: [salesforcedx-vscode-core](https://github.com/forcedotcom/salesforcedx-vscode/tree/develop/packages/salesforcedx-vscode-core)
 
 ---
-Currently, Visual Studio Code extensions are not signed or verified on the Microsoft Visual Studio Code Marketplace. Salesforce provides the Secure Hash Algorithm (SHA) of each extension that we publish. Consult [Manually Verify the salesforcedx-vscode Extensions’ Authenticity](https://developer.salesforce.com/media/vscode/SHA256.md) to learn how to verify the extensions.    
+
+Currently, Visual Studio Code extensions are not signed or verified on the Microsoft Visual Studio Code Marketplace. Salesforce provides the Secure Hash Algorithm (SHA) of each extension that we publish. Consult [Manually Verify the salesforcedx-vscode Extensions’ Authenticity](https://developer.salesforce.com/media/vscode/SHA256.md) to learn how to verify the extensions.
 
 ---

--- a/packages/salesforcedx-vscode-core/README.md
+++ b/packages/salesforcedx-vscode-core/README.md
@@ -2,7 +2,7 @@
 
 This extension enables VS Code to use the Salesforce CLI to interact with your orgs.
 
-For best results, use this extension with the other extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) bundle.
+**For best results, do not install this extension directly. Install the complete [Salesforce Extension Pack] (https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) instead.**
 
 ## Prerequisites
 

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforcedx-vscode-core",
-  "displayName": "CLI Integration",
+  "displayName": "Salesforce CLI Integration",
   "description": "Provides integration with the Salesforce CLI",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",
   "bugs": {

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforcedx-vscode-core",
-  "displayName": "Salesforce CLI Integration for Visual Studio Code",
+  "displayName": "Salesforce CLI Integration",
   "description": "Provides integration with the Salesforce CLI",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",
   "bugs": {

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforcedx-vscode-core",
-  "displayName": "Salesforce CLI Integration",
+  "displayName": "CLI Integration",
   "description": "Provides integration with the Salesforce CLI",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",
   "bugs": {

--- a/packages/salesforcedx-vscode-lightning/README.md
+++ b/packages/salesforcedx-vscode-lightning/README.md
@@ -2,7 +2,7 @@
 
 This extension uses the default HTML language server from VS Code to provide syntax highlighting, code completion, an outline view of your files, and a Salesforce Lightning Design System (SLDS) linter.
 
-For best results, use this extension with the other extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) bundle.
+**For best results, do not install this extension directly. Install the complete [Salesforce Extension Pack] (https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) instead.**
 
 ## Prerequisites
 

--- a/packages/salesforcedx-vscode-lightning/README.md
+++ b/packages/salesforcedx-vscode-lightning/README.md
@@ -1,47 +1,56 @@
-# Lightning Component Code Editor for Visual Studio Code
+# Lightning Component Framework for Visual Studio Code
+
 This extension uses the default HTML language server from VS Code to provide syntax highlighting, code completion, an outline view of your files, and a Salesforce Lightning Design System (SLDS) linter.
 
-For best results, use this extension with the other extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) bundle.  
+For best results, use this extension with the other extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) bundle.
 
-##  Prerequisites
-Before you set up this extension, make sure that you have [Visual Studio Code](https://code.visualstudio.com/download) v1.26 or later.  
+## Prerequisites
+
+Before you set up this extension, make sure that you have [Visual Studio Code](https://code.visualstudio.com/download) v1.26 or later.
 
 ## Features Provided by This Extension
-* Syntax highlighting in some sections of various files (`.page`, `.component`, `.app`, and so on)
-   * HTML portions
-   * Embedded CSS and JavaScript portions  
 
-   ![Colored syntax highlighting in a .js file from a Lightning bundle](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-lightning/images/lightning_syntax.png)
+- Syntax highlighting in some sections of various files (`.page`, `.component`, `.app`, and so on)
 
-* Code completion (invoke using Ctrl+Space)
-   * HTML tags
-   * CSS
-   * JavaScript  
+  - HTML portions
+  - Embedded CSS and JavaScript portions
 
-   ![Code-completion options in a .js file from a Lightning bundle](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-lightning/images/lightning_completion.png)
+  ![Colored syntax highlighting in a .js file from a Lightning bundle](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-lightning/images/lightning_syntax.png)
 
-* Outline view (invoke using Cmd+Shift+O on macOS, or Ctrl+Shift+O on Windows and Linux)
+- Code completion (invoke using Ctrl+Space)
 
-   ![List of symbols in a .js file from a Lightning bundle](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-lightning/images/lightning_outline.png)
+  - HTML tags
+  - CSS
+  - JavaScript
 
-* Salesforce Lightning Design System Linter
-   * Detects deprecated BEM syntax (`--`) for Salesforce Lightning Design System class names in HTML files
-   * Warning message displays on hover
-   * Code actions are available on click
-   Note: The linter won't run if SLDS is included as a static resource in your project.
+  ![Code-completion options in a .js file from a Lightning bundle](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-lightning/images/lightning_completion.png)
 
-   ![SLDS Linter detecting deprecated '--' class name syntax](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-lightning/images/lightning_slds.png)
+- Outline view (invoke using Cmd+Shift+O on macOS, or Ctrl+Shift+O on Windows and Linux)
+
+  ![List of symbols in a .js file from a Lightning bundle](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-lightning/images/lightning_outline.png)
+
+- Salesforce Lightning Design System Linter
+
+  - Detects deprecated BEM syntax (`--`) for Salesforce Lightning Design System class names in HTML files
+  - Warning message displays on hover
+  - Code actions are available on click
+    Note: The linter won't run if SLDS is included as a static resource in your project.
+
+  ![SLDS Linter detecting deprecated '--' class name syntax](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-lightning/images/lightning_slds.png)
 
 ## Bugs and Feedback
+
 To report issues with Salesforce Extensions for VS Code, open a [bug on GitHub](https://github.com/forcedotcom/salesforcedx-vscode/issues/new?template=Bug_report.md). If you would like to suggest a feature, create a [feature request on Github](https://github.com/forcedotcom/salesforcedx-vscode/issues/new?template=Feature_request.md).
 
 ## Resources
-* Trailhead: [Get Started with Salesforce DX](https://trailhead.salesforce.com/trails/sfdx_get_started)
-* _[Salesforce DX Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev)_
-* _[Lightning Components Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.lightning.meta/lightning)_
-* GitHub: [salesforcedx-vscode-lightning](https://github.com/forcedotcom/salesforcedx-vscode/tree/develop/packages/salesforcedx-vscode-lightning)
+
+- Trailhead: [Get Started with Salesforce DX](https://trailhead.salesforce.com/trails/sfdx_get_started)
+- _[Salesforce DX Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev)_
+- _[Lightning Components Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.lightning.meta/lightning)_
+- GitHub: [salesforcedx-vscode-lightning](https://github.com/forcedotcom/salesforcedx-vscode/tree/develop/packages/salesforcedx-vscode-lightning)
 
 ---
-Currently, Visual Studio Code extensions are not signed or verified on the Microsoft Visual Studio Code Marketplace. Salesforce provides the Secure Hash Algorithm (SHA) of each extension that we publish. Consult [Manually Verify the salesforcedx-vscode Extensions’ Authenticity](https://developer.salesforce.com/media/vscode/SHA256.md) to learn how to verify the extensions.    
+
+Currently, Visual Studio Code extensions are not signed or verified on the Microsoft Visual Studio Code Marketplace. Salesforce provides the Secure Hash Algorithm (SHA) of each extension that we publish. Consult [Manually Verify the salesforcedx-vscode Extensions’ Authenticity](https://developer.salesforce.com/media/vscode/SHA256.md) to learn how to verify the extensions.
 
 ---

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforcedx-vscode-lightning",
-  "displayName": "Lightning Component Code Editor for Visual Studio Code",
+  "displayName": "Lightning Component Framework",
   "description": "Provides syntax highlighting for Lightning components",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",
   "bugs": {

--- a/packages/salesforcedx-vscode-lwc-next/README.md
+++ b/packages/salesforcedx-vscode-lwc-next/README.md
@@ -1,6 +1,6 @@
-# salesforcedx-vscode-lwc-next
+# LWC (next) for Visual Studio Code
 
-This is a preview of a work in progress implementation of the salesforcedx-vscode-lwc-next extension. It is published to enable early feedback and testing. 
+This is a preview of a work in progress implementation of the salesforcedx-vscode-lwc-next extension. It is published to enable early feedback and testing.
 
 Install either this version (if you have been granted early access) or the salesforcedx-vscode-lwc-next version. Do not install both.
 

--- a/packages/salesforcedx-vscode-lwc-next/package.json
+++ b/packages/salesforcedx-vscode-lwc-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforcedx-vscode-lwc-next",
-  "displayName": "LWC Code Editor for Visual Studio Code",
+  "displayName": "LWC",
   "description": "Provides code-editing features for LWC",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",
   "bugs": {

--- a/packages/salesforcedx-vscode-lwc/README.md
+++ b/packages/salesforcedx-vscode-lwc/README.md
@@ -1,4 +1,4 @@
-# salesforcedx-vscode-lwc
+# LWC for Visual Studio Code
 
 salesforce-vscode-lwc is part of a private pilot for testing new features. We are not accepting pilot enrollments at this time. This extension will not work unless you are part of the pilot.
 

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforcedx-vscode-lwc",
-  "displayName": "LWC Code Editor for Visual Studio Code",
+  "displayName": "LWC",
   "description": "Provides code-editing features for LWC",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",
   "bugs": {

--- a/packages/salesforcedx-vscode-visualforce/README.md
+++ b/packages/salesforcedx-vscode-visualforce/README.md
@@ -2,7 +2,7 @@
 
 This extension uses the Visualforce Language Server and VS Code’s default HTML language server to provide syntax highlighting, code completion, and an outline view of your files.
 
-For best results, use this extension with the other extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) bundle.
+**For best results, do not install this extension directly. Install the complete [Salesforce Extension Pack] (https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) instead.**
 
 ## Prerequisites
 

--- a/packages/salesforcedx-vscode-visualforce/README.md
+++ b/packages/salesforcedx-vscode-visualforce/README.md
@@ -1,42 +1,50 @@
-# Visualforce Code Editor for Visual Studio Code
+# Visualforce for Visual Studio Code
+
 This extension uses the Visualforce Language Server and VS Code’s default HTML language server to provide syntax highlighting, code completion, and an outline view of your files.
 
-For best results, use this extension with the other extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) bundle.  
+For best results, use this extension with the other extensions in the [salesforcedx-vscode](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) bundle.
 
-##  Prerequisites
-Before you set up this extension, make sure that you have [Visual Studio Code](https://code.visualstudio.com/download) v1.26 or later.  
+## Prerequisites
+
+Before you set up this extension, make sure that you have [Visual Studio Code](https://code.visualstudio.com/download) v1.26 or later.
 
 ## Features Provided by This Extension
-* Code completion (invoke using Ctrl+Space)
-   * Standard Visualforce components (tags and attributes), with Salesforce documentation
-   * HTML tags
-   * CSS
-   * JavaScript  
-   
-   ![Code-completion options and associated documentation in a .page file](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-visualforce/images/visualforce_completion.png)
 
-* Syntax highlighting in some sections of various files (`.page`, `.component`, `.app`, and so on)
-   * HTML portions
-   * Embedded CSS and JavaScript portions  
-   
-   ![Colored syntax highlighting in a .page file](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-visualforce/images/visualforce_syntax.png)
+- Code completion (invoke using Ctrl+Space)
 
-* Outline view (invoke using Cmd+Shift+O on macOS, or Ctrl+Shift+O on Windows and Linux)
+  - Standard Visualforce components (tags and attributes), with Salesforce documentation
+  - HTML tags
+  - CSS
+  - JavaScript
 
-   ![List of symbols in a .page file](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-visualforce/images/visualforce_outline.png)
+  ![Code-completion options and associated documentation in a .page file](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-visualforce/images/visualforce_completion.png)
+
+- Syntax highlighting in some sections of various files (`.page`, `.component`, `.app`, and so on)
+
+  - HTML portions
+  - Embedded CSS and JavaScript portions
+
+  ![Colored syntax highlighting in a .page file](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-visualforce/images/visualforce_syntax.png)
+
+- Outline view (invoke using Cmd+Shift+O on macOS, or Ctrl+Shift+O on Windows and Linux)
+
+  ![List of symbols in a .page file](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-visualforce/images/visualforce_outline.png)
 
 ## Bugs and Feedback
+
 To report issues with Salesforce Extensions for VS Code, open a [bug on GitHub](https://github.com/forcedotcom/salesforcedx-vscode/issues/new?template=Bug_report.md). If you would like to suggest a feature, create a [feature request on Github](https://github.com/forcedotcom/salesforcedx-vscode/issues/new?template=Feature_request.md).
 
 ## Resources
-* Trailhead: [Get Started with Salesforce DX](https://trailhead.salesforce.com/trails/sfdx_get_started)
-* _[Salesforce DX Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev)_
-* _[Visualforce Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.pages.meta/pages)_
-* Dreamforce ’17 Session Video: [Building Powerful Tooling For All IDEs Through Language Servers](https://www.salesforce.com/video/1765282/)
-* GitHub: [Language Server Protocol](https://github.com/Microsoft/language-server-protocol)
-* GitHub: [salesforcedx-vscode-visualforce](https://github.com/forcedotcom/salesforcedx-vscode/tree/develop/packages/salesforcedx-vscode-visualforce)
+
+- Trailhead: [Get Started with Salesforce DX](https://trailhead.salesforce.com/trails/sfdx_get_started)
+- _[Salesforce DX Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev)_
+- _[Visualforce Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.pages.meta/pages)_
+- Dreamforce ’17 Session Video: [Building Powerful Tooling For All IDEs Through Language Servers](https://www.salesforce.com/video/1765282/)
+- GitHub: [Language Server Protocol](https://github.com/Microsoft/language-server-protocol)
+- GitHub: [salesforcedx-vscode-visualforce](https://github.com/forcedotcom/salesforcedx-vscode/tree/develop/packages/salesforcedx-vscode-visualforce)
 
 ---
-Currently, Visual Studio Code extensions are not signed or verified on the Microsoft Visual Studio Code Marketplace. Salesforce provides the Secure Hash Algorithm (SHA) of each extension that we publish. Consult [Manually Verify the salesforcedx-vscode Extensions’ Authenticity](https://developer.salesforce.com/media/vscode/SHA256.md) to learn how to verify the extensions.   
+
+Currently, Visual Studio Code extensions are not signed or verified on the Microsoft Visual Studio Code Marketplace. Salesforce provides the Secure Hash Algorithm (SHA) of each extension that we publish. Consult [Manually Verify the salesforcedx-vscode Extensions’ Authenticity](https://developer.salesforce.com/media/vscode/SHA256.md) to learn how to verify the extensions.
 
 ---

--- a/packages/salesforcedx-vscode-visualforce/package.json
+++ b/packages/salesforcedx-vscode-visualforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforcedx-vscode-visualforce",
-  "displayName": "Visualforce Code Editor for Visual Studio Code",
+  "displayName": "Visualforce",
   "description": "Provides syntax highlighting for the Visualforce framework",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",
   "bugs": {

--- a/packages/salesforcedx-vscode/README.md
+++ b/packages/salesforcedx-vscode/README.md
@@ -1,6 +1,6 @@
 # Salesforce Extensions for Visual Studio Code
 
-This extension bundle includes tools for developing on the Salesforce platform in the lightweight, extensible VS Code editor. These tools provide features for working with development orgs (scratch orgs, sandboxes, and DE orgs), Apex, Lightning components, and Visualforce.
+This extension pack includes tools for developing on the Salesforce platform in the lightweight, extensible VS Code editor. These tools provide features for working with development orgs (scratch orgs, sandboxes, and DE orgs), Apex, Lightning components, and Visualforce.
 
 ![GIF showing Apex code completion, pushing source to a scratch org, and running Apex tests](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode/images/overview.gif)
 
@@ -18,38 +18,50 @@ Before you set up Salesforce Extensions for VS Code, make sure that you have the
   If you don’t already have the JDK installed, install the latest version of the Java 8 JDK from [Java SE Development Kit 8 Downloads](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
 - **[Visual Studio Code](https://code.visualstudio.com/download) v1.26 or later**
 
-## Documentation for Included Extensions
+## Documentation & Resources
 
-To use Salesforce Extensions for VS Code, install all the extensions in this extension pack. Each extension has its own documentation.
+Documentation for each extension as well as additional resources are listed below.
 
-- [salesforcedx-vscode-core](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-core)  
+### Extension Documentation
+
+- [Salesforce CLI Integration](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-core)  
    This extension interacts with Salesforce CLI to provide core functionality.
-- [salesforcedx-vscode-apex](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-apex)  
+- [Apex](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-apex)  
    This extension uses the Apex Language Server to provide features such as syntax highlighting and code completion.
-- [salesforcedx-vscode-apex-debugger](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-apex-debugger)  
+- [Apex Interactive Debugger](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-apex-debugger)  
    This extension enables VS Code to use the real-time Apex Debugger with your scratch orgs or to use ISV Customer Debugger for your subscribers’ orgs.
-- [salesforcedx-vscode-apex-replay-debugger](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-apex-replay-debugger)  
+- [Apex Replay Debugger](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-apex-replay-debugger)  
    This extension enables VS Code to replay Apex execution from Apex debug logs.
-- [salesforcedx-vscode-lightning](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-lightning)  
+- [Lighting Component Framework](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-lightning)  
    This extension supports Lightning component bundles. It uses the HTML language server from VS Code.
-- [salesforcedx-vscode-visualforce](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-visualforce)  
+- [Visualforce](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-visualforce)  
    This extension supports Visualforce pages and components. It uses the Visualforce Language Server and the HTML language server from VS Code.
 
-For tips and tricks for working with Salesforce Extensions for VS Code, visit our [GitHub wiki](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Tips-and-Tricks).
+### Additional Documentation
+
+- Trailhead: [Get Started with Salesforce DX](https://trailhead.salesforce.com/trails/sfdx_get_started)
+- Tutorial: [Develop Against Any Org](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Develop-Against-Any-Org-in-Visual-Studio-Code)
+- Tutorial: [Migrate From Forcecom IDE to Visual Studio Code](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Migrate-From-Forcecom-IDE-to-Visual-Studio-Code)
+- [Tips and Tricks](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Tips-and-Tricks)
+- [Troubleshooting](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Troubleshooting)
+- [Salesforce DX Setup Guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup)
+- [Salesforce DX Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev)
+- [Recommended Extension](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Recommended-Extensions)
+
+### Dreamforce Session Videos
+
+- [Salesforce Development with Visual Studio Code](https://www.youtube.com/watch?v=lQ-ZpCRKYM0)
+- [Be An Efficient Salesforce Developer with VS Code](https://www.youtube.com/watch?v=hw9LBvjo4PQ)
+- [Moving to Visual Studio Code for Force.com IDE Developers](https://www.youtube.com/watch?v=J-9ILFRqcwg)
+
+### Open Source
+
+- [Roadmap](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Roadmap)
+- [Github Repository](https://github.com/forcedotcom/salesforcedx-vscode)
 
 ## Bugs and Feedback
 
 To report issues with Salesforce Extensions for VS Code, open a [bug on GitHub](https://github.com/forcedotcom/salesforcedx-vscode/issues/new?template=Bug_report.md). If you would like to suggest a feature, create a [feature request on Github](https://github.com/forcedotcom/salesforcedx-vscode/issues/new?template=Feature_request.md).
-
-## Resources
-
-- Trailhead: [Get Started with Salesforce DX](https://trailhead.salesforce.com/trails/sfdx_get_started)
-- _[Salesforce DX Setup Guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup)_
-- _[Salesforce DX Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev)_
-- Dreamforce ’18 Session Video: [Be An Efficient Salesforce Developer with VS Code](https://www.youtube.com/watch?v=hw9LBvjo4PQ)
-- GitHub: [salesforcedx-vscode](https://github.com/forcedotcom/salesforcedx-vscode)
-- GitHub wiki for salesforcedx-vscode: [Tips and Tricks](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Tips-and-Tricks)
-- GitHub wiki for salesforcedx-vscode: [Troubleshooting](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Troubleshooting)
 
 ---
 

--- a/packages/salesforcedx-vscode/package.json
+++ b/packages/salesforcedx-vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "salesforcedx-vscode",
-  "displayName": "Salesforce Extensions Pack",
+  "displayName": "Salesforce",
   "description":
-    "Collection of extensions for the Salesforce DX development flow",
+    "Extensions for developing on the Salesforce Platform",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",
   "bugs": {
     "url": "https://github.com/forcedotcom/salesforcedx-vscode/issues"

--- a/packages/salesforcedx-vscode/package.json
+++ b/packages/salesforcedx-vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforcedx-vscode",
-  "displayName": "Salesforce Extensions for VS Code",
+  "displayName": "Salesforce Extensions Pack",
   "description":
     "Collection of extensions for the Salesforce DX development flow",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",


### PR DESCRIPTION
### What does this PR do?
Updates the extension names and titles in the readmes to be in line with what other extensions on the Marketplace use.

The second goal of this is to help people find the right extension. Currently, we are seeing higher numbers of downloads on some of the individual extension rather than the extension pack. My hope is this clarification in naming will ensure that when users search "Salesforce" they will find the extension pack as the most likely option.
