### PR TITLE
Renaming Salesforce Extension

### DIFF
--- a/packages/salesforcedx-vscode-apex-debugger/README.md
+++ b/packages/salesforcedx-vscode-apex-debugger/README.md
@@ -2,7 +2,7 @@
 
 This extension enables VS Code to use the real-time Apex Debugger with your scratch orgs and to use ISV Customer Debugger with your subscribers’ sandbox orgs.
 
-**For best results, do not install this extension directly. Install the complete [Salesforce Extension Pack] (https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) instead.**
+**For best results, do not install this extension directly. Install the complete [Salesforce Extension Pack](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) instead.**
 
 ![GIF showing starting a debugging session, hitting a breakpoint, stepping through code, and examining values](https://raw.githubusercontent.com/forcedotcom/salesforcedx-vscode/develop/packages/salesforcedx-vscode-apex-debugger/images/apex_debugger.gif)
 

--- a/packages/salesforcedx-vscode-apex-replay-debugger/README.md
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/README.md
@@ -2,7 +2,7 @@
 
 Apex Replay Debugger simulates a live debugging session using a debug log that is a recording of all interactions in a transaction. You no longer need to parse through thousands of log lines manually. Instead, Apex Replay Debugger presents the logged information similarly to an interactive debugger, so you can debug your Apex code. The debugging process is a repetition of editing your Apex code, pushing or deploying the code to your org, reproducing the buggy scenario, downloading the resulting debug log, and launching Apex Replay Debugger with that debug log.
 
-**For best results, do not install this extension directly. Install the complete [Salesforce Extension Pack] (https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) instead.**
+**For best results, do not install this extension directly. Install the complete [Salesforce Extension Pack](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) instead.**
 
 ## Prerequisites
 

--- a/packages/salesforcedx-vscode-apex/README.md
+++ b/packages/salesforcedx-vscode-apex/README.md
@@ -2,7 +2,7 @@
 
 View outlines of Apex classes and triggers, see code-completion suggestions, and find syntactic errors in your code. This extension is powered by the [Apex Language Server](https://github.com/forcedotcom/salesforcedx-vscode/wiki/Apex-Language-Server).
 
-**For best results, do not install this extension directly. Install the complete [Salesforce Extension Pack] (https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) instead.**
+**For best results, do not install this extension directly. Install the complete [Salesforce Extension Pack](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) instead.**
 
 ## Prerequisites
 

--- a/packages/salesforcedx-vscode-core/README.md
+++ b/packages/salesforcedx-vscode-core/README.md
@@ -2,7 +2,7 @@
 
 This extension enables VS Code to use the Salesforce CLI to interact with your orgs.
 
-**For best results, do not install this extension directly. Install the complete [Salesforce Extension Pack] (https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) instead.**
+**For best results, do not install this extension directly. Install the complete [Salesforce Extension Pack](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) instead.**
 
 ## Prerequisites
 

--- a/packages/salesforcedx-vscode-lightning/README.md
+++ b/packages/salesforcedx-vscode-lightning/README.md
@@ -2,7 +2,7 @@
 
 This extension uses the default HTML language server from VS Code to provide syntax highlighting, code completion, an outline view of your files, and a Salesforce Lightning Design System (SLDS) linter.
 
-**For best results, do not install this extension directly. Install the complete [Salesforce Extension Pack] (https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) instead.**
+**For best results, do not install this extension directly. Install the complete [Salesforce Extension Pack](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) instead.**
 
 ## Prerequisites
 

--- a/packages/salesforcedx-vscode-visualforce/README.md
+++ b/packages/salesforcedx-vscode-visualforce/README.md
@@ -2,7 +2,7 @@
 
 This extension uses the Visualforce Language Server and VS Code’s default HTML language server to provide syntax highlighting, code completion, and an outline view of your files.
 
-**For best results, do not install this extension directly. Install the complete [Salesforce Extension Pack] (https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) instead.**
+**For best results, do not install this extension directly. Install the complete [Salesforce Extension Pack](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode) instead.**
 
 ## Prerequisites
 

--- a/packages/salesforcedx-vscode/package.json
+++ b/packages/salesforcedx-vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforcedx-vscode",
-  "displayName": "Salesforce",
+  "displayName": "Salesforce Extension Pack",
   "description": "Extensions for developing on the Salesforce Platform",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",
   "bugs": {


### PR DESCRIPTION
Renames Salesforce Extension to Salesforce Extension Pack to be consistent with other extension packs.

Also, fixes an extra space that broke the link on the readmes.