### PR TITLE
Remove trailing slash on instanceURL

### DIFF
--- a/packages/salesforcedx-apex-debugger/src/core/streamingService.ts
+++ b/packages/salesforcedx-apex-debugger/src/core/streamingService.ts
@@ -77,7 +77,11 @@ export class StreamingService {
     systemEventClientInfo: StreamingClientInfo,
     userEventClientInfo: StreamingClientInfo
   ): Promise<boolean> {
-    const urlElements = [requestService.instanceUrl, 'cometd', this.apiVersion];
+    const urlElements = [
+      this.removeTrailingSlashURL(requestService.instanceUrl),
+      'cometd',
+      this.apiVersion
+    ];
     const streamUrl = urlElements.join('/');
 
     this.systemEventClient = new StreamingClient(
@@ -94,6 +98,10 @@ export class StreamingService {
     await this.systemEventClient.subscribe();
     await this.userEventClient.subscribe();
     return Promise.resolve(this.isReady());
+  }
+
+  private removeTrailingSlashURL(instanceUrl: string) {
+    return instanceUrl ? instanceUrl.replace(/\/+$/, '') : '';
   }
 
   public disconnect(): void {


### PR DESCRIPTION
### What does this PR do?
In Windows, we experience issues initializing the Apex Interactive Debugger because the url we build to connect to the Streaming API has an additional slash, making it an invalid url. The changes here strip the trailing slash of the host url.

Moved PR #751 to be part of release v44.7.0

### What issues does this PR fix or reference?
#722, @W-5622038@