### PR TITLE
Fix SFDX: Turn on Apex Debug Log for Replay Debugger

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceStartApexDebugLogging.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceStartApexDebugLogging.ts
@@ -235,7 +235,7 @@ export class ForceQueryTraceFlag extends SfdxCommandletExecutor<{}> {
       .withArg('force:data:soql:query')
       .withFlag(
         '--query',
-        "SELECT id, logtype, startdate, expirationdate, debuglevelid, debuglevel.apexcode, debuglevel.visualforce FROM TraceFlag WHERE logtype='DEVELOPER_LOG'"
+        "SELECT id, logtype, startdate, expirationdate, debuglevelid, debuglevel.apexcode, debuglevel.visualforce FROM TraceFlag WHERE logtype='DEVELOPER_LOG' and debuglevelid != null"
       )
       .withArg('--usetoolingapi')
       .withJson()

--- a/packages/salesforcedx-vscode-core/test/commands/forceStartApexDebugLogging.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceStartApexDebugLogging.test.ts
@@ -68,7 +68,7 @@ describe('Force Start Apex Debug Logging', () => {
     const queryTraceFlagsExecutor = new ForceQueryTraceFlag();
     const updateTraceFlagCmd = queryTraceFlagsExecutor.build();
     expect(updateTraceFlagCmd.toCommand()).to.equal(
-      `sfdx force:data:soql:query --query SELECT id, logtype, startdate, expirationdate, debuglevelid, debuglevel.apexcode, debuglevel.visualforce FROM TraceFlag WHERE logtype='DEVELOPER_LOG' --usetoolingapi --json --loglevel fatal`
+      `sfdx force:data:soql:query --query SELECT id, logtype, startdate, expirationdate, debuglevelid, debuglevel.apexcode, debuglevel.visualforce FROM TraceFlag WHERE logtype='DEVELOPER_LOG' and debuglevelid != null --usetoolingapi --json --loglevel fatal`
     );
   });
 


### PR DESCRIPTION
### What does this PR do?
Adds a null check for debugLevelId to the 'WHERE' clause in our TraceFlag query so that we do not try to update nonexistent DebugLevels


### What issues does this PR fix or reference?
https://github.com/forcedotcom/salesforcedx-vscode/issues/761#issuecomment-440046451