### PR TITLE
Show better error message for SFDX: Turn On Apex Debug Log for Replay Debugger when updating a trace flag that is missing a debug level

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceStartApexDebugLogging.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceStartApexDebugLogging.ts
@@ -66,6 +66,14 @@ export class ForceStartApexDebugLoggingExecutor extends SfdxCommandletExecutor<{
           traceflag.ExpirationDate,
           traceflag.DebugLevelId
         );
+        if (!developerLogTraceFlag.isValidDebugLevelId()) {
+          throw new Error(
+            nls.localize(
+              'invalid_debug_level_id_error',
+              developerLogTraceFlag.getTraceFlagId()
+            )
+          );
+        }
         await this.subExecute(new UpdateDebugLevelsExecutor().build());
 
         if (!developerLogTraceFlag.isValidDateLength()) {

--- a/packages/salesforcedx-vscode-core/src/commands/forceStartApexDebugLogging.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceStartApexDebugLogging.ts
@@ -67,12 +67,7 @@ export class ForceStartApexDebugLoggingExecutor extends SfdxCommandletExecutor<{
           traceflag.DebugLevelId
         );
         if (!developerLogTraceFlag.isValidDebugLevelId()) {
-          throw new Error(
-            nls.localize(
-              'invalid_debug_level_id_error',
-              developerLogTraceFlag.getTraceFlagId()
-            )
-          );
+          throw new Error(nls.localize('invalid_debug_level_id_error'));
         }
         await this.subExecute(new UpdateDebugLevelsExecutor().build());
 

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -192,5 +192,8 @@ export const messages = {
   tooling_API_description: 'Execute the query with Tooling API',
   telemetry_legal_dialog_message:
     'You agree that Salesforce Extensions for VS Code may collect usage information, user environment, and crash reports for product improvements. Learn how to [opt out](%s).',
-  telemetry_legal_dialog_button_text: 'Read more'
+  telemetry_legal_dialog_button_text: 'Read more',
+
+  invalid_debug_level_id_error:
+    "You have an invalid trace flag in your org. Please delete the trace flag with Id: %s and any others that are missing an associated Debug Level before running this command again. You can find trace flags that are missing debug levels by running the soql query: 'SELECT Id FROM TraceFlag WHERE debuglevelid = null' or visiting the Debug Logs page in your org's Setup UI."
 };

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -195,5 +195,5 @@ export const messages = {
   telemetry_legal_dialog_button_text: 'Read more',
 
   invalid_debug_level_id_error:
-    "You have an invalid trace flag in your org. Please delete the trace flag with Id: %s and any others that are missing an associated Debug Level before running this command again. You can find trace flags that are missing debug levels by running the soql query: 'SELECT Id FROM TraceFlag WHERE debuglevelid = null' or visiting the Debug Logs page in your org's Setup UI."
+    'At least one trace flag in your org doesn\'t have an associated debug level. Before you run this command again, run "sfdx force:data:soql:query -t -q "SELECT Id FROM TraceFlag WHERE DebugLevelId = null"". Then, to delete each invalid trace flag, run "sfdx force:data:record:delete -t -s TraceFlag -i 7tfxxxxxxxxxxxxxxx", replacing 7tfxxxxxxxxxxxxxxx with the ID of each trace flag without a debug level.'
 };

--- a/packages/salesforcedx-vscode-core/src/traceflag/developerLogTraceFlag.ts
+++ b/packages/salesforcedx-vscode-core/src/traceflag/developerLogTraceFlag.ts
@@ -11,7 +11,7 @@ export class DeveloperLogTraceFlag {
   private static instance: DeveloperLogTraceFlag;
   private active: boolean;
   private traceflagId: string | undefined;
-  private debugLevelId: string | undefined;
+  private debugLevelId: string | undefined | null;
   private startDate: Date;
   private expirationDate: Date;
 
@@ -35,7 +35,7 @@ export class DeveloperLogTraceFlag {
     id: string,
     startDate: string,
     expirationDate: string,
-    debugLevelId: string
+    debugLevelId: string | null
   ) {
     this.traceflagId = id;
     this.startDate = new Date(startDate);
@@ -44,7 +44,7 @@ export class DeveloperLogTraceFlag {
     this.active = true;
   }
 
-  public setDebugLevelId(debugLevelId: string) {
+  public setDebugLevelId(debugLevelId: string | undefined | null) {
     this.debugLevelId = debugLevelId;
   }
 
@@ -58,7 +58,7 @@ export class DeveloperLogTraceFlag {
   }
 
   public isValidDebugLevelId() {
-    return this.debugLevelId !== null;
+    return this.debugLevelId != null;
   }
 
   public isValidDateLength() {

--- a/packages/salesforcedx-vscode-core/src/traceflag/developerLogTraceFlag.ts
+++ b/packages/salesforcedx-vscode-core/src/traceflag/developerLogTraceFlag.ts
@@ -58,7 +58,11 @@ export class DeveloperLogTraceFlag {
   }
 
   public isValidDebugLevelId() {
-    return this.debugLevelId != null;
+    return (
+      this.debugLevelId !== null &&
+      this.debugLevelId !== undefined &&
+      this.debugLevelId !== ''
+    );
   }
 
   public isValidDateLength() {

--- a/packages/salesforcedx-vscode-core/src/traceflag/developerLogTraceFlag.ts
+++ b/packages/salesforcedx-vscode-core/src/traceflag/developerLogTraceFlag.ts
@@ -57,6 +57,10 @@ export class DeveloperLogTraceFlag {
     showTraceFlagExpiration(this.getExpirationDate());
   }
 
+  public isValidDebugLevelId() {
+    return this.debugLevelId !== null;
+  }
+
   public isValidDateLength() {
     const currDate = new Date().valueOf();
     return (

--- a/packages/salesforcedx-vscode-core/test/traceflag/DeveloperLogTraceFlag.test.ts
+++ b/packages/salesforcedx-vscode-core/test/traceflag/DeveloperLogTraceFlag.test.ts
@@ -36,4 +36,21 @@ describe('Force Start Apex Debug Logging', () => {
       );
     });
   });
+
+  describe('Validating debuglevelid', () => {
+    it('Should return true if debuglevelid exists', () => {
+      developerLogTraceFlag.setDebugLevelId('fakeDebugLevelId');
+      expect(developerLogTraceFlag.isValidDebugLevelId()).to.be.true;
+    });
+
+    it('Should return false if debuglevelid is null', () => {
+      developerLogTraceFlag.setDebugLevelId(null);
+      expect(developerLogTraceFlag.isValidDebugLevelId()).to.be.false;
+    });
+
+    it('Should return false if debuglevelid is undefined', () => {
+      developerLogTraceFlag.setDebugLevelId(undefined);
+      expect(developerLogTraceFlag.isValidDebugLevelId()).to.be.false;
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?
This PR changes the `SFDX: Turn On Apex Debug Log for Replay Debugger` command to throw an error when the query for trace flags returns a trace flag with a null debugLevelId. 

### What issues does this PR fix or reference?
https://github.com/forcedotcom/salesforcedx-vscode/issues/761

`SFDX: Turn On Apex Debug Log for Replay Debugger` first queries TraceFlag for any existing DEVELOPER_LOG type logs. If it finds any existing trace flags, it will take the first one from query results, and it will update that trace flag's associated DebugLevel. 

If the trace flag has no associated DebugLevel, then the command is currently returning the error referenced by the issue above. Since trace flags without Debug Levels are now considered invalid, the fix in this pr will notify the user to delete the invalid trace flags with a helpful error message. 