### PR TITLE
Set the Duration of a Scratch Org

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
@@ -43,7 +43,7 @@ export class ForceOrgCreateExecutor extends SfdxCommandletExecutor<
       .withArg('force:org:create')
       .withFlag('-f', `${selectionPath}`)
       .withFlag('--setalias', data.alias)
-      .withFlag('-d', data.expirationDays)
+      .withFlag('--durationdays', data.expirationDays)
       .withArg('--setdefaultusername')
       .withLogName('force_org_create_default_scratch_org')
       .build();

--- a/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
@@ -87,7 +87,6 @@ export class AliasGatherer implements ParametersGatherer<Alias> {
     ) {
       scratchOrgExpirationInDays = defaultExpirationdate;
     }
-    // return params;
     return {
       type: 'CONTINUE',
       data: {

--- a/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
@@ -85,7 +85,6 @@ export class AliasGatherer implements ParametersGatherer<Alias> {
       return { type: 'CANCEL' };
     }
     if (
-      scratchOrgExpirationInDays !== undefined &&
       !Number.isNaN(Number.parseInt(scratchOrgExpirationInDays)) &&
       Number.parseInt(scratchOrgExpirationInDays) >= 1 &&
       Number.parseInt(scratchOrgExpirationInDays) <= 30

--- a/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
@@ -71,7 +71,7 @@ export class AliasGatherer implements ParametersGatherer<Alias> {
       prompt: nls.localize(
         'parameter_gatherer_enter_scratch_org_expiration_days'
       ),
-      placeHolder: defaultExpirationdate.toString()
+      placeHolder: defaultExpirationdate
     } as vscode.InputBoxOptions;
     const alias = await vscode.window.showInputBox(aliasInputOptions);
     // Hitting enter with no alias will use the value of `defaultAlias`

--- a/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
@@ -27,7 +27,7 @@ import {
 } from './commands';
 
 export const DEFAULT_ALIAS = 'vscodeScratchOrg';
-export const DEFAULT_EXPIRATION_DATE = 7;
+export const DEFAULT_EXPIRATION_DATE = '7';
 export class ForceOrgCreateExecutor extends SfdxCommandletExecutor<
   AliasAndFileSelection
 > {
@@ -68,33 +68,38 @@ export class AliasGatherer implements ParametersGatherer<Alias> {
       placeHolder: defaultAlias
     } as vscode.InputBoxOptions;
     const expirationDays = {
-      prompt: nls.localize('parameter_gatherer_enter_alias_name'),
+      prompt: nls.localize(
+        'parameter_gatherer_enter_scratch_org_expiration_days'
+      ),
       placeHolder: defaultExpirationdate.toString()
     } as vscode.InputBoxOptions;
     const alias = await vscode.window.showInputBox(aliasInputOptions);
-    const scratchOrgExpirationInDays = await vscode.window.showInputBox(
+    let scratchOrgExpirationInDays = await vscode.window.showInputBox(
       expirationDays
     );
     // Hitting enter with no alias will use the value of `defaultAlias`
     if (alias === undefined) {
       return { type: 'CANCEL' };
     }
+    if (
+      scratchOrgExpirationInDays === undefined ||
+      scratchOrgExpirationInDays === ''
+    ) {
+      scratchOrgExpirationInDays = defaultExpirationdate;
+    }
     // return params;
     return {
       type: 'CONTINUE',
       data: {
         alias: alias === '' ? defaultAlias : alias,
-        expirationDays:
-          scratchOrgExpirationInDays === ''
-            ? defaultExpirationdate
-            : scratchOrgExpirationInDays
+        expirationDays: scratchOrgExpirationInDays
       }
     };
   }
 }
 export interface Alias {
   alias: string;
-  expirationDays: number;
+  expirationDays: string;
 }
 
 export type AliasAndFileSelection = Alias & FileSelection;

--- a/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
@@ -27,7 +27,7 @@ import {
 } from './commands';
 
 export const DEFAULT_ALIAS = 'vscodeScratchOrg';
-export const DEFAULT_EXPIRATION_DATE = '7';
+export const DEFAULT_EXPIRATION_DAYS = '7';
 export class ForceOrgCreateExecutor extends SfdxCommandletExecutor<
   AliasAndFileSelection
 > {
@@ -52,7 +52,7 @@ export class ForceOrgCreateExecutor extends SfdxCommandletExecutor<
 
 export class AliasGatherer implements ParametersGatherer<Alias> {
   public async gather(): Promise<CancelResponse | ContinueResponse<Alias>> {
-    const defaultExpirationdate = DEFAULT_EXPIRATION_DATE;
+    const defaultExpirationdate = DEFAULT_EXPIRATION_DAYS;
     let defaultAlias = DEFAULT_ALIAS;
     if (
       vscode.workspace.workspaceFolders &&

--- a/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
@@ -81,11 +81,20 @@ export class AliasGatherer implements ParametersGatherer<Alias> {
     let scratchOrgExpirationInDays = await vscode.window.showInputBox(
       expirationDays
     );
+    if (scratchOrgExpirationInDays === undefined) {
+      return { type: 'CANCEL' };
+    }
     if (
-      scratchOrgExpirationInDays === undefined ||
-      scratchOrgExpirationInDays === ''
+      scratchOrgExpirationInDays !== undefined &&
+      !Number.isNaN(Number.parseInt(scratchOrgExpirationInDays)) &&
+      Number.parseInt(scratchOrgExpirationInDays) >= 1 &&
+      Number.parseInt(scratchOrgExpirationInDays) <= 30
     ) {
-      scratchOrgExpirationInDays = defaultExpirationdate;
+      scratchOrgExpirationInDays = Number.parseInt(
+        scratchOrgExpirationInDays
+      ).toString();
+    } else {
+      scratchOrgExpirationInDays = DEFAULT_EXPIRATION_DAYS;
     }
     return {
       type: 'CONTINUE',

--- a/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
@@ -81,19 +81,22 @@ export class AliasGatherer implements ParametersGatherer<Alias> {
     let scratchOrgExpirationInDays = await vscode.window.showInputBox(
       expirationDays
     );
-    if (scratchOrgExpirationInDays === undefined) {
-      return { type: 'CANCEL' };
-    }
     if (
-      !Number.isNaN(Number.parseInt(scratchOrgExpirationInDays)) &&
-      Number.parseInt(scratchOrgExpirationInDays) >= 1 &&
-      Number.parseInt(scratchOrgExpirationInDays) <= 30
+      scratchOrgExpirationInDays === undefined ||
+      !Number.isSafeInteger(Number.parseInt(scratchOrgExpirationInDays))
     ) {
-      scratchOrgExpirationInDays = Number.parseInt(
-        scratchOrgExpirationInDays
-      ).toString();
+      return { type: 'CANCEL' };
     } else {
-      scratchOrgExpirationInDays = DEFAULT_EXPIRATION_DAYS;
+      if (
+        Number.parseInt(scratchOrgExpirationInDays) < 1 ||
+        Number.parseInt(scratchOrgExpirationInDays) > 30
+      ) {
+        scratchOrgExpirationInDays = DEFAULT_EXPIRATION_DAYS;
+      } else {
+        scratchOrgExpirationInDays = Number.parseInt(
+          scratchOrgExpirationInDays
+        ).toString();
+      }
     }
     return {
       type: 'CONTINUE',

--- a/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
@@ -74,13 +74,13 @@ export class AliasGatherer implements ParametersGatherer<Alias> {
       placeHolder: defaultExpirationdate.toString()
     } as vscode.InputBoxOptions;
     const alias = await vscode.window.showInputBox(aliasInputOptions);
-    let scratchOrgExpirationInDays = await vscode.window.showInputBox(
-      expirationDays
-    );
     // Hitting enter with no alias will use the value of `defaultAlias`
     if (alias === undefined) {
       return { type: 'CANCEL' };
     }
+    let scratchOrgExpirationInDays = await vscode.window.showInputBox(
+      expirationDays
+    );
     if (
       scratchOrgExpirationInDays === undefined ||
       scratchOrgExpirationInDays === ''

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -51,6 +51,8 @@ export const messages = {
   parameter_gatherer_enter_username_name: 'Enter target username',
   parameter_gatherer_enter_alias_name:
     'Enter an org alias or use default alias',
+  parameter_gatherer_enter_scratch_org_expiration_days:
+    'Enter the expiration days for the scratch org',
   parameter_gatherer_enter_project_name: 'Enter project name',
   parameter_gatherer_paste_forceide_url: 'Paste forceide:// URL from Setup',
   parameter_gatherer_paste_forceide_url_placeholder:

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -52,7 +52,7 @@ export const messages = {
   parameter_gatherer_enter_alias_name:
     'Enter an org alias or use default alias',
   parameter_gatherer_enter_scratch_org_expiration_days:
-    'Enter the expiration days for the scratch org',
+    'Enter the number of days (1–30) until scratch org expiration or use the default value',
   parameter_gatherer_enter_project_name: 'Enter project name',
   parameter_gatherer_paste_forceide_url: 'Paste forceide:// URL from Setup',
   parameter_gatherer_paste_forceide_url_placeholder:

--- a/packages/salesforcedx-vscode-core/test/commands/forceOrgCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceOrgCreate.test.ts
@@ -26,8 +26,12 @@ describe('Force Org Create', () => {
     before(() => {
       inputBoxSpy = sinon.stub(vscode.window, 'showInputBox');
       inputBoxSpy.onCall(0).returns(undefined);
+
       inputBoxSpy.onCall(1).returns('');
-      inputBoxSpy.onCall(2).returns(TEST_ALIAS);
+      inputBoxSpy.onCall(2).returns('');
+
+      inputBoxSpy.onCall(3).returns(TEST_ALIAS);
+      inputBoxSpy.onCall(4).returns('8');
     });
 
     after(() => {
@@ -37,14 +41,16 @@ describe('Force Org Create', () => {
     it('Should return cancel if alias is undefined', async () => {
       const gatherer = new AliasGatherer();
       const response = await gatherer.gather();
-      expect(inputBoxSpy.calledOnce).to.be.true;
+      // expect(inputBoxSpy.calledOnce).to.be.true;
+      expect(inputBoxSpy.callCount).to.equal(1);
       expect(response.type).to.equal('CANCEL');
     });
 
     it('Should return Continue with default alias if user input is empty string', async () => {
       const gatherer = new AliasGatherer();
       const response = await gatherer.gather();
-      expect(inputBoxSpy.calledTwice).to.be.true;
+      // expect(inputBoxSpy.calledTwice).to.be.true;
+      expect(inputBoxSpy.callCount).to.equal(3);
       if (response.type === 'CONTINUE') {
         expect(response.data.alias).to.equal(TEST_WORKSPACE);
         expect(response.data.expirationDays).to.equal(TEST_ORG_EXPIRATION_DAYS);
@@ -56,10 +62,12 @@ describe('Force Org Create', () => {
     it('Should return Continue with inputted alias if user input is not undefined or empty', async () => {
       const gatherer = new AliasGatherer();
       const response = await gatherer.gather();
-      expect(inputBoxSpy.calledThrice).to.be.true;
+      // expect(inputBoxSpy.calledThrice).to.be.true;
+      expect(inputBoxSpy.callCount).to.equal(5);
+      expect(response.type).to.equal('CONTINUE');
       if (response.type === 'CONTINUE') {
         expect(response.data.alias).to.equal(TEST_ALIAS);
-        expect(response.data.expirationDays).to.equal(TEST_ORG_EXPIRATION_DAYS);
+        expect(response.data.expirationDays).to.equal('8');
       } else {
         expect.fail('Response should be of type ContinueResponse');
       }
@@ -78,7 +86,7 @@ describe('Force Org Create', () => {
         expirationDays: TEST_ORG_EXPIRATION_DAYS
       });
       expect(createCommand.toCommand()).to.equal(
-        `sfdx force:org:create -f ${CONFIG_FILE} --setalias ${TEST_ALIAS} --setdefaultusername`
+        `sfdx force:org:create -f ${CONFIG_FILE} --setalias ${TEST_ALIAS} -d ${TEST_ORG_EXPIRATION_DAYS} --setdefaultusername`
       );
       expect(createCommand.description).to.equal(
         nls.localize('force_org_create_default_scratch_org_text')

--- a/packages/salesforcedx-vscode-core/test/commands/forceOrgCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceOrgCreate.test.ts
@@ -18,10 +18,14 @@ import { nls } from '../../src/messages';
 // tslint:disable:no-unused-expression
 describe('Force Org Create', () => {
   describe('Alias Gatherer', () => {
+    const EVENT_CANCEL = 'CANCEL';
+    const EVENT_CONTINUE = 'CONTINUE';
     const TEST_ALIAS = 'testAlias';
     const TEST_WORKSPACE = 'sfdxsimple'; // FYI: This test uses the workspace created by the system tests to run
     const TEST_ORG_EXPIRATION_DAYS = '7';
     const TEST_ORG_EXPIRATION_DAYS_PLUS_ONE_DAY = '8';
+    const TEST_ORG_EXPIRATION_DAYS_INPUT_FLOAT = '8.2';
+    const TEST_ORG_EXPIRATION_DAYS_INPUT_INVALID_RANGE = '31';
     let inputBoxSpy: sinon.SinonStub;
 
     before(() => {
@@ -33,6 +37,17 @@ describe('Force Org Create', () => {
 
       inputBoxSpy.onCall(3).returns(TEST_ALIAS);
       inputBoxSpy.onCall(4).returns(TEST_ORG_EXPIRATION_DAYS_PLUS_ONE_DAY);
+
+      inputBoxSpy.onCall(5).returns(TEST_ALIAS);
+      inputBoxSpy.onCall(6).returns(TEST_ORG_EXPIRATION_DAYS_INPUT_FLOAT);
+
+      inputBoxSpy.onCall(7).returns(TEST_ALIAS);
+      inputBoxSpy.onCall(8).returns(undefined);
+
+      inputBoxSpy.onCall(9).returns(TEST_ALIAS);
+      inputBoxSpy
+        .onCall(10)
+        .returns(TEST_ORG_EXPIRATION_DAYS_INPUT_INVALID_RANGE);
     });
 
     after(() => {
@@ -43,14 +58,14 @@ describe('Force Org Create', () => {
       const gatherer = new AliasGatherer();
       const response = await gatherer.gather();
       expect(inputBoxSpy.callCount).to.equal(1);
-      expect(response.type).to.equal('CANCEL');
+      expect(response.type).to.equal(EVENT_CANCEL);
     });
 
     it('Should return Continue with default alias if user input is empty string', async () => {
       const gatherer = new AliasGatherer();
       const response = await gatherer.gather();
       expect(inputBoxSpy.callCount).to.equal(3);
-      if (response.type === 'CONTINUE') {
+      if (response.type === EVENT_CONTINUE) {
         expect(response.data.alias).to.equal(TEST_WORKSPACE);
         expect(response.data.expirationDays).to.equal(TEST_ORG_EXPIRATION_DAYS);
       } else {
@@ -62,12 +77,45 @@ describe('Force Org Create', () => {
       const gatherer = new AliasGatherer();
       const response = await gatherer.gather();
       expect(inputBoxSpy.callCount).to.equal(5);
-      expect(response.type).to.equal('CONTINUE');
-      if (response.type === 'CONTINUE') {
+      expect(response.type).to.equal(EVENT_CONTINUE);
+      if (response.type === EVENT_CONTINUE) {
         expect(response.data.alias).to.equal(TEST_ALIAS);
         expect(response.data.expirationDays).to.equal(
           TEST_ORG_EXPIRATION_DAYS_PLUS_ONE_DAY
         );
+      } else {
+        expect.fail('Response should be of type ContinueResponse');
+      }
+    });
+
+    it('Should return Continue with default alias and the expiration date the user inputted as float, but converted to the integer', async () => {
+      const gatherer = new AliasGatherer();
+      const response = await gatherer.gather();
+      expect(inputBoxSpy.callCount).to.equal(7);
+      if (response.type === EVENT_CONTINUE) {
+        expect(response.data.alias).to.equal(TEST_ALIAS);
+        expect(response.data.expirationDays).to.equal(
+          Number.parseInt(TEST_ORG_EXPIRATION_DAYS_INPUT_FLOAT).toString()
+        );
+      } else {
+        expect.fail('Response should be of type ContinueResponse');
+      }
+    });
+
+    it('Should return Cancel since the user canceled (pressed ESC) the process when defining the expiration for the scratch org', async () => {
+      const gatherer = new AliasGatherer();
+      const response = await gatherer.gather();
+      expect(inputBoxSpy.callCount).to.equal(9);
+      expect(response.type).to.equal(EVENT_CANCEL);
+    });
+
+    it('Should return Continue with default alias and the default expiration date, since the user inputted an invalid integer as expiration date', async () => {
+      const gatherer = new AliasGatherer();
+      const response = await gatherer.gather();
+      expect(inputBoxSpy.callCount).to.equal(11);
+      if (response.type === EVENT_CONTINUE) {
+        expect(response.data.alias).to.equal(TEST_ALIAS);
+        expect(response.data.expirationDays).to.equal(TEST_ORG_EXPIRATION_DAYS);
       } else {
         expect.fail('Response should be of type ContinueResponse');
       }
@@ -86,7 +134,7 @@ describe('Force Org Create', () => {
         expirationDays: TEST_ORG_EXPIRATION_DAYS
       });
       expect(createCommand.toCommand()).to.equal(
-        `sfdx force:org:create -f ${CONFIG_FILE} --setalias ${TEST_ALIAS} -d ${TEST_ORG_EXPIRATION_DAYS} --setdefaultusername`
+        `sfdx force:org:create -f ${CONFIG_FILE} --setalias ${TEST_ALIAS} --durationdays ${TEST_ORG_EXPIRATION_DAYS} --setdefaultusername`
       );
       expect(createCommand.description).to.equal(
         nls.localize('force_org_create_default_scratch_org_text')

--- a/packages/salesforcedx-vscode-core/test/commands/forceOrgCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceOrgCreate.test.ts
@@ -21,6 +21,7 @@ describe('Force Org Create', () => {
     const TEST_ALIAS = 'testAlias';
     const TEST_WORKSPACE = 'sfdxsimple'; // FYI: This test uses the workspace created by the system tests to run
     const TEST_ORG_EXPIRATION_DAYS = '7';
+    const TEST_ORG_EXPIRATION_DAYS_PLUS_ONE_DAY = '8';
     let inputBoxSpy: sinon.SinonStub;
 
     before(() => {
@@ -31,7 +32,7 @@ describe('Force Org Create', () => {
       inputBoxSpy.onCall(2).returns('');
 
       inputBoxSpy.onCall(3).returns(TEST_ALIAS);
-      inputBoxSpy.onCall(4).returns('8');
+      inputBoxSpy.onCall(4).returns(TEST_ORG_EXPIRATION_DAYS_PLUS_ONE_DAY);
     });
 
     after(() => {
@@ -41,7 +42,6 @@ describe('Force Org Create', () => {
     it('Should return cancel if alias is undefined', async () => {
       const gatherer = new AliasGatherer();
       const response = await gatherer.gather();
-      // expect(inputBoxSpy.calledOnce).to.be.true;
       expect(inputBoxSpy.callCount).to.equal(1);
       expect(response.type).to.equal('CANCEL');
     });
@@ -49,7 +49,6 @@ describe('Force Org Create', () => {
     it('Should return Continue with default alias if user input is empty string', async () => {
       const gatherer = new AliasGatherer();
       const response = await gatherer.gather();
-      // expect(inputBoxSpy.calledTwice).to.be.true;
       expect(inputBoxSpy.callCount).to.equal(3);
       if (response.type === 'CONTINUE') {
         expect(response.data.alias).to.equal(TEST_WORKSPACE);
@@ -62,12 +61,13 @@ describe('Force Org Create', () => {
     it('Should return Continue with inputted alias if user input is not undefined or empty', async () => {
       const gatherer = new AliasGatherer();
       const response = await gatherer.gather();
-      // expect(inputBoxSpy.calledThrice).to.be.true;
       expect(inputBoxSpy.callCount).to.equal(5);
       expect(response.type).to.equal('CONTINUE');
       if (response.type === 'CONTINUE') {
         expect(response.data.alias).to.equal(TEST_ALIAS);
-        expect(response.data.expirationDays).to.equal('8');
+        expect(response.data.expirationDays).to.equal(
+          TEST_ORG_EXPIRATION_DAYS_PLUS_ONE_DAY
+        );
       } else {
         expect.fail('Response should be of type ContinueResponse');
       }

--- a/packages/salesforcedx-vscode-core/test/commands/forceOrgCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceOrgCreate.test.ts
@@ -20,6 +20,7 @@ describe('Force Org Create', () => {
   describe('Alias Gatherer', () => {
     const TEST_ALIAS = 'testAlias';
     const TEST_WORKSPACE = 'sfdxsimple'; // FYI: This test uses the workspace created by the system tests to run
+    const TEST_ORG_EXPIRATION_DAYS = '7';
     let inputBoxSpy: sinon.SinonStub;
 
     before(() => {
@@ -46,6 +47,7 @@ describe('Force Org Create', () => {
       expect(inputBoxSpy.calledTwice).to.be.true;
       if (response.type === 'CONTINUE') {
         expect(response.data.alias).to.equal(TEST_WORKSPACE);
+        expect(response.data.expirationDays).to.equal(TEST_ORG_EXPIRATION_DAYS);
       } else {
         expect.fail('Response should be of type ContinueResponse');
       }
@@ -57,6 +59,7 @@ describe('Force Org Create', () => {
       expect(inputBoxSpy.calledThrice).to.be.true;
       if (response.type === 'CONTINUE') {
         expect(response.data.alias).to.equal(TEST_ALIAS);
+        expect(response.data.expirationDays).to.equal(TEST_ORG_EXPIRATION_DAYS);
       } else {
         expect.fail('Response should be of type ContinueResponse');
       }
@@ -67,10 +70,12 @@ describe('Force Org Create', () => {
     it('Should build the org create command', async () => {
       const CONFIG_FILE = 'configFile.txt';
       const TEST_ALIAS = 'testAlias';
+      const TEST_ORG_EXPIRATION_DAYS = '7';
       const forceOrgCreateBuilder = new ForceOrgCreateExecutor();
       const createCommand = forceOrgCreateBuilder.build({
         file: path.join(vscode.workspace.rootPath!, CONFIG_FILE),
-        alias: TEST_ALIAS
+        alias: TEST_ALIAS,
+        expirationDays: TEST_ORG_EXPIRATION_DAYS
       });
       expect(createCommand.toCommand()).to.equal(
         `sfdx force:org:create -f ${CONFIG_FILE} --setalias ${TEST_ALIAS} --setdefaultusername`


### PR DESCRIPTION
### What does this PR do?

This adds another inputBox to the process of creating a scratch org, right after specifying the org's alias. It allows the user to specify the expiration days for the scratch org (other than just using the default 7 every time).

### What issues does this PR fix or reference?

It addresses #768.