### PR TITLE
Sort Tests (by Test Class Name)

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/views/testOutlineProvider.ts
+++ b/packages/salesforcedx-vscode-apex/src/views/testOutlineProvider.ts
@@ -118,30 +118,32 @@ export class ApexTestOutlineProvider
     }
     this.rootNode.children = new Array<TestNode>();
     if (this.apexTestInfo) {
-      this.apexTestInfo.forEach(test => {
-        let apexGroup = this.apexTestMap.get(
-          test.definingType
-        ) as ApexTestGroupNode;
-        if (!apexGroup) {
-          const groupLocation = new vscode.Location(
-            test.location.uri,
-            APEX_GROUP_RANGE
-          );
-          apexGroup = new ApexTestGroupNode(test.definingType, groupLocation);
-          this.apexTestMap.set(test.definingType, apexGroup);
-        }
-        const apexTest = new ApexTestNode(test.methodName, test.location);
-        apexTest.name = apexGroup.label + '.' + apexTest.label;
-        this.apexTestMap.set(apexTest.name, apexTest);
-        apexGroup.children.push(apexTest);
-        if (
-          this.rootNode &&
-          !(this.rootNode.children.indexOf(apexGroup) >= 0)
-        ) {
-          this.rootNode.children.push(apexGroup);
-        }
-        this.testStrings.add(apexGroup.name);
-      });
+      this.apexTestInfo
+        .sort((a, b) => a.definingType.localeCompare(b.definingType))
+        .forEach(test => {
+          let apexGroup = this.apexTestMap.get(
+            test.definingType
+          ) as ApexTestGroupNode;
+          if (!apexGroup) {
+            const groupLocation = new vscode.Location(
+              test.location.uri,
+              APEX_GROUP_RANGE
+            );
+            apexGroup = new ApexTestGroupNode(test.definingType, groupLocation);
+            this.apexTestMap.set(test.definingType, apexGroup);
+          }
+          const apexTest = new ApexTestNode(test.methodName, test.location);
+          apexTest.name = apexGroup.label + '.' + apexTest.label;
+          this.apexTestMap.set(apexTest.name, apexTest);
+          apexGroup.children.push(apexTest);
+          if (
+            this.rootNode &&
+            !(this.rootNode.children.indexOf(apexGroup) >= 0)
+          ) {
+            this.rootNode.children.push(apexGroup);
+          }
+          this.testStrings.add(apexGroup.name);
+        });
     }
     return this.rootNode;
   }


### PR DESCRIPTION
### What does this PR do?
This PR will sort tests alphabetically, so that on orgs with many test classes, you can easily find the one you're looking for.
Turn this:
![image](https://user-images.githubusercontent.com/1755213/49154418-a2268c00-f318-11e8-89e5-842023a7e57a.png)

Into this:
![image](https://user-images.githubusercontent.com/1755213/49154384-8f13bc00-f318-11e8-95fc-f14c4dea2346.png)

Unfortunately, the diff contains a whole lot more than what I've actually changed (just added the `sort`) due to prettier re-formatting the code.

### What issues does this PR fix or reference?
Might be considered related to #605, though it doesn't add any searching/filtering.