### PR TITLE
Jsuplizio/manifestations

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieve.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
@@ -56,11 +57,68 @@ export class ManifestOrSourcePathGatherer
       // corresponding to the explorer path when we begin supporting multiple workspace folders
       const workspaceRootPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
       const manifestPath = path.join(workspaceRootPath, 'manifest');
-      const isManifestFile = this.explorerPath.includes(manifestPath);
-      const type = isManifestFile ? FileType.Manifest : FileType.Source;
-      return { type: 'CONTINUE', data: { filePath: this.explorerPath, type } };
+      const isManifest = this.explorerPath.includes(manifestPath);
+      const type = isManifest ? FileType.Manifest : FileType.Source;
+
+      // If the type is manifest check whether or not the user selected an actual
+      // file or just the manifest directory. If the user selected the manifest
+      // directory then check that directory for manifest files. If there's only
+      // one manifest file then use it, if there none or more than one then give
+      // them a file select dialog and make them select one.
+      if (isManifest) {
+        let manifestFile = this.explorerPath;
+        const stat = fs.lstatSync(manifestFile);
+        if (stat.isDirectory()) {
+          const manifestFileList = this.getManifestFiles(manifestFile);
+          if (manifestFileList.length === 1) {
+            manifestFile = manifestFileList[0];
+          } else {
+            const localizedFilterButtonText = nls.localize(
+              'select_manifest_filter_button_text'
+            );
+            const fileUris = await vscode.window.showOpenDialog({
+              canSelectFiles: true,
+              canSelectFolders: false,
+              canSelectMany: false,
+              openLabel: nls.localize('select_manifest_file_button_text'),
+              filters: { localizedFilterButtonText: ['xml'] },
+              defaultUri: vscode.Uri.file(manifestFile)
+            });
+            if (fileUris && fileUris.length === 1) {
+              manifestFile = fileUris[0].fsPath;
+            } else {
+              return { type: 'CANCEL' };
+            }
+          }
+        }
+        return {
+          type: 'CONTINUE',
+          data: { filePath: manifestFile, type }
+        };
+      } else {
+        return {
+          type: 'CONTINUE',
+          data: { filePath: this.explorerPath, type }
+        };
+      }
     }
     return { type: 'CANCEL' };
+  }
+
+  private getManifestFiles(manifestDir: string): string[] {
+    const manifestFileExtension = '.xml';
+    const manifestFiles: string[] = [];
+    const files = fs.readdirSync(manifestDir);
+    files.forEach(rawFile => {
+      const fileName = path.join(manifestDir, rawFile);
+      const stat = fs.lstatSync(fileName);
+      if (!stat.isDirectory()) {
+        if (path.extname(fileName).toLowerCase() === manifestFileExtension) {
+          manifestFiles.push(fileName);
+        }
+      }
+    });
+    return manifestFiles;
   }
 }
 

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieve.ts
@@ -81,7 +81,7 @@ export class ManifestOrSourcePathGatherer
               canSelectFolders: false,
               canSelectMany: false,
               openLabel: nls.localize('select_manifest_file_button_text'),
-              filters: { localizedFilterButtonText: ['xml'] },
+              filters: { [localizedFilterButtonText]: ['xml'] },
               defaultUri: vscode.Uri.file(manifestFile)
             });
             if (fileUris && fileUris.length === 1) {

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -82,6 +82,8 @@ export const messages = {
     'Deleting source files deletes the files from your computer and removes the corresponding metadata from your default org. Are you sure you want to delete this source from your project and your org?',
   confirm_delete_source_button_text: 'Delete Source',
   cancel_delete_source_button_text: 'Cancel',
+  select_manifest_file_button_text: 'Select Manifest File',
+  select_manifest_filter_button_text: 'Manifest',
 
   force_source_status_text:
     'View All Changes (Local and in Default Scratch Org)',

--- a/packages/salesforcedx-vscode-core/test/commands/forceSourceRetrieve.test.ts
+++ b/packages/salesforcedx-vscode-core/test/commands/forceSourceRetrieve.test.ts
@@ -6,7 +6,9 @@
  */
 
 import { expect } from 'chai';
+import * as fs from 'fs';
 import * as path from 'path';
+import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 
 import {
@@ -51,7 +53,7 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
   });
 });
 
-describe('Manifest or Sourcepath Gatherer', () => {
+describe('Sourcepath Gatherer', () => {
   it("Should return an object of type 'Source'", async () => {
     if (
       vscode.workspace.workspaceFolders &&
@@ -70,23 +72,261 @@ describe('Manifest or Sourcepath Gatherer', () => {
       expect.fail('The workspace root path was undefined');
     }
   });
+});
 
-  it("Should return an object of type 'Manifest'", async () => {
+describe('Manifest Gatherer', () => {
+  let showOpenDialogStub: sinon.SinonStub;
+  before(() => {
+    if (
+      vscode.workspace.workspaceFolders &&
+      vscode.workspace.workspaceFolders[0]
+    ) {
+      const manifestDir = path.join(
+        vscode.workspace.workspaceFolders[0].uri.fsPath,
+        'manifest'
+      );
+      if (!fs.existsSync(manifestDir)) {
+        fs.mkdirSync(manifestDir);
+      }
+    } else {
+      expect.fail('The workspace root path was undefined');
+    }
+  });
+
+  after(() => {
+    if (
+      vscode.workspace.workspaceFolders &&
+      vscode.workspace.workspaceFolders[0]
+    ) {
+      const manifestDir = path.join(
+        vscode.workspace.workspaceFolders[0].uri.fsPath,
+        'manifest'
+      );
+      if (fs.existsSync(manifestDir)) {
+        fs.rmdirSync(manifestDir);
+      }
+    }
+  });
+
+  beforeEach(() => {
+    showOpenDialogStub = sinon.stub(vscode.window, 'showOpenDialog');
+  });
+  afterEach(() => {
+    showOpenDialogStub.restore();
+    if (
+      vscode.workspace.workspaceFolders &&
+      vscode.workspace.workspaceFolders[0]
+    ) {
+      const manifestDir = path.join(
+        vscode.workspace.workspaceFolders[0].uri.fsPath,
+        'manifest'
+      );
+      if (fs.existsSync(manifestDir)) {
+        fs.readdirSync(manifestDir).forEach(file => {
+          const fileWithPath = path.join(manifestDir, file);
+          fs.unlinkSync(fileWithPath);
+        });
+      }
+    }
+  });
+
+  it("Should return an object of type 'Manifest' with full path to manifest file ", async () => {
     if (
       vscode.workspace.workspaceFolders &&
       vscode.workspace.workspaceFolders[0]
     ) {
       const workspaceRootPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
       const manifestPath = {
-        fsPath: path.join(workspaceRootPath, 'manifest', 'file')
+        fsPath: path.join(workspaceRootPath, 'manifest', 'project.xml')
       };
+      fs.writeFileSync(manifestPath.fsPath, '');
       const gatherer = new ManifestOrSourcePathGatherer(manifestPath);
       const response = await gatherer.gather();
       if (response.type === 'CONTINUE') {
         expect(response.data.type).to.equal(FileType.Manifest);
         expect(response.data.filePath).to.equal(manifestPath.fsPath);
+        expect(showOpenDialogStub.calledOnce).to.eq(false);
       } else {
         expect.fail('Response should be of type ContinueResponse');
+      }
+    } else {
+      expect.fail('The workspace root path was undefined');
+    }
+  });
+
+  it("Should return an object of type 'Manifest' from manifest directory path containing a single manifest ", async () => {
+    if (
+      vscode.workspace.workspaceFolders &&
+      vscode.workspace.workspaceFolders[0]
+    ) {
+      const workspaceRootPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
+      const manifestPath = {
+        fsPath: path.join(workspaceRootPath, 'manifest')
+      };
+      const manifestXmlFileWithPath = path.join(
+        workspaceRootPath,
+        'manifest',
+        'project.xml'
+      );
+      fs.writeFileSync(manifestXmlFileWithPath, '');
+      const gatherer = new ManifestOrSourcePathGatherer(manifestPath);
+      const response = await gatherer.gather();
+      if (response.type === 'CONTINUE') {
+        expect(response.data.type).to.equal(FileType.Manifest);
+        expect(response.data.filePath).to.equal(manifestXmlFileWithPath);
+        expect(showOpenDialogStub.calledOnce).to.eq(false);
+      } else {
+        expect.fail('Response should be of type ContinueResponse');
+      }
+    } else {
+      expect.fail('The workspace root path was undefined');
+    }
+  });
+
+  it("Should return an object of type 'Manifest' from manifest directory path containing a single manifest ", async () => {
+    if (
+      vscode.workspace.workspaceFolders &&
+      vscode.workspace.workspaceFolders[0]
+    ) {
+      const workspaceRootPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
+      const manifestPath = {
+        fsPath: path.join(workspaceRootPath, 'manifest')
+      };
+      const manifestXmlFileWithPath = path.join(
+        workspaceRootPath,
+        'manifest',
+        'project.xml'
+      );
+      fs.writeFileSync(manifestXmlFileWithPath, '');
+      const gatherer = new ManifestOrSourcePathGatherer(manifestPath);
+      const response = await gatherer.gather();
+      if (response.type === 'CONTINUE') {
+        expect(response.data.type).to.equal(FileType.Manifest);
+        expect(response.data.filePath).to.equal(manifestXmlFileWithPath);
+        expect(showOpenDialogStub.calledOnce).to.eq(false);
+      } else {
+        expect.fail('Response should be of type ContinueResponse');
+      }
+    } else {
+      expect.fail('The workspace root path was undefined');
+    }
+  });
+
+  it("Should return an object of type 'Manifest' from manifest directory path containing a single manifest file ", async () => {
+    if (
+      vscode.workspace.workspaceFolders &&
+      vscode.workspace.workspaceFolders[0]
+    ) {
+      const workspaceRootPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
+      const manifestPath = {
+        fsPath: path.join(workspaceRootPath, 'manifest')
+      };
+      const manifestXmlFileWithPath = path.join(
+        workspaceRootPath,
+        'manifest',
+        'project.xml'
+      );
+      fs.writeFileSync(manifestXmlFileWithPath, '');
+      const gatherer = new ManifestOrSourcePathGatherer(manifestPath);
+      const response = await gatherer.gather();
+      if (response.type === 'CONTINUE') {
+        expect(response.data.type).to.equal(FileType.Manifest);
+        expect(response.data.filePath).to.equal(manifestXmlFileWithPath);
+        expect(showOpenDialogStub.calledOnce).to.eq(false);
+      } else {
+        expect.fail('Response should be of type ContinueResponse');
+      }
+    } else {
+      expect.fail('The workspace root path was undefined');
+    }
+  });
+
+  it('Should make the user choose a manifest file if there are more than one in the manifest directory ', async () => {
+    if (
+      vscode.workspace.workspaceFolders &&
+      vscode.workspace.workspaceFolders[0]
+    ) {
+      const workspaceRootPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
+      const manifestPath = {
+        fsPath: path.join(workspaceRootPath, 'manifest')
+      };
+      const manifestXmlFileWithPath = path.join(
+        workspaceRootPath,
+        'manifest',
+        'project.xml'
+      );
+      fs.writeFileSync(manifestXmlFileWithPath, '');
+      const manifestXmlFileWithPath2 = path.join(
+        workspaceRootPath,
+        'manifest',
+        'project2.xml'
+      );
+      fs.writeFileSync(manifestXmlFileWithPath2, '');
+      showOpenDialogStub.resolves([{ fsPath: manifestXmlFileWithPath2 }]);
+      const gatherer = new ManifestOrSourcePathGatherer(manifestPath);
+      const response = await gatherer.gather();
+      if (response.type === 'CONTINUE') {
+        expect(response.data.type).to.equal(FileType.Manifest);
+        expect(response.data.filePath).to.equal(manifestXmlFileWithPath2);
+        expect(showOpenDialogStub.calledOnce).to.eq(true);
+      } else {
+        expect.fail('Response should be of type ContinueResponse');
+      }
+    } else {
+      expect.fail('The workspace root path was undefined');
+    }
+  });
+
+  it('Should open a select dialog if there are no manifest files in the directory ', async () => {
+    if (
+      vscode.workspace.workspaceFolders &&
+      vscode.workspace.workspaceFolders[0]
+    ) {
+      const workspaceRootPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
+      const manifestPath = {
+        fsPath: path.join(workspaceRootPath, 'manifest')
+      };
+      showOpenDialogStub.resolves(undefined);
+      const gatherer = new ManifestOrSourcePathGatherer(manifestPath);
+      const response = await gatherer.gather();
+      if (response.type === 'CANCEL') {
+        expect(showOpenDialogStub.calledOnce).to.eq(true);
+      } else {
+        expect.fail('Response should be of type CancelResponse');
+      }
+    } else {
+      expect.fail('The workspace root path was undefined');
+    }
+  });
+
+  it('Should cancel request if there are multiple manifest files and user selects cancel ', async () => {
+    if (
+      vscode.workspace.workspaceFolders &&
+      vscode.workspace.workspaceFolders[0]
+    ) {
+      const workspaceRootPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
+      const manifestPath = {
+        fsPath: path.join(workspaceRootPath, 'manifest')
+      };
+      const manifestXmlFileWithPath = path.join(
+        workspaceRootPath,
+        'manifest',
+        'project.xml'
+      );
+      fs.writeFileSync(manifestXmlFileWithPath, '');
+      const manifestXmlFileWithPath2 = path.join(
+        workspaceRootPath,
+        'manifest',
+        'project2.xml'
+      );
+      fs.writeFileSync(manifestXmlFileWithPath2, '');
+      showOpenDialogStub.resolves(undefined);
+      const gatherer = new ManifestOrSourcePathGatherer(manifestPath);
+      const response = await gatherer.gather();
+      if (response.type === 'CANCEL') {
+        expect(showOpenDialogStub.calledOnce).to.eq(true);
+      } else {
+        expect.fail('Response should be of type CancelResponse');
       }
     } else {
       expect.fail('The workspace root path was undefined');


### PR DESCRIPTION
### What does this PR do?
The "SFDX: Retrieve/Deploy Source from Org" calls the underlying CLI "sfdx force:source:retrieve" with --manifest or --sourcepath depending on where the command was invoked from. Right clicking on the project's manifest directory and running the command will attempt to run the underlying command with the --manifest option on the directory which will outright fail.

With these changes I check if the type is manifest and, if so, check if the input "file" is actually a manifest file or the manifest directory. If the input is the manifest directory and there's only one .xml file I'll use that but if there are multiple files I'll pop up a showOpenDialog and allow the user to pick one or cancel. If the user picks one the command will continue as normal. If the user hits cancel instead of choosing a file then the command gets canceled and doesn't run. I've attached a screenshot of the open dialog and  it's worth noting that both the "Select Manifest File" and the "Manifest" filter dropdown will both get localized.
![manifestfileselect](https://user-images.githubusercontent.com/13556087/49185715-6fc85f00-f317-11e8-9e59-e42224af75c8.png)

### What issues does this PR fix or reference?
@W-5230669@