### PR TITLE
Adding timestamps to command executions in output…

### DIFF
--- a/packages/salesforcedx-vscode-core/src/channels/channelService.ts
+++ b/packages/salesforcedx-vscode-core/src/channels/channelService.ts
@@ -44,10 +44,14 @@ export class ChannelService {
     this.channel.appendLine(execution.command.toString());
     this.channel.appendLine('');
 
-    this.channel.appendLine(execution.command.toCommand());
+    this.channel.appendLine(
+      this.getExecutionTime() + ' ' + execution.command.toCommand()
+    );
 
     execution.processExitSubject.subscribe(data => {
-      this.channel.append(execution.command.toCommand());
+      this.channel.append(
+        this.getExecutionTime() + ' ' + execution.command.toCommand()
+      );
       this.channel.append(' ');
       if (data !== undefined) {
         this.channel.appendLine(
@@ -60,7 +64,9 @@ export class ChannelService {
     });
 
     execution.processErrorSubject.subscribe(data => {
-      this.channel.append(execution.command.toCommand());
+      this.channel.append(
+        this.getExecutionTime() + ' ' + execution.command.toCommand()
+      );
       this.channel.append(' ');
       if (data !== undefined) {
         this.channel.appendLine(
@@ -77,6 +83,19 @@ export class ChannelService {
       }
       this.channel.appendLine('');
     });
+  }
+
+  private getExecutionTime() {
+    const d = new Date();
+    const hr = this.ensureDoubleDigits(d.getHours());
+    const mins = this.ensureDoubleDigits(d.getMinutes());
+    const sec = this.ensureDoubleDigits(d.getSeconds());
+    const milli = d.getMilliseconds();
+    return `${hr}:${mins}:${sec}.${milli}`;
+  }
+
+  private ensureDoubleDigits(num: number) {
+    return num < 10 ? `0${num.toString()}` : num.toString();
   }
 
   public showChannelOutput() {


### PR DESCRIPTION
… view

### What does this PR do?
Adds timestamps to every sfdx command execution that's being printed in the Output panel.

As the title suggests, this is a work in progress cause I want to run the automation and see if I missed any test failures and get feedback.

### What issues does this PR fix or reference?
#759 

<img width="738" alt="timestamp_preview_highlight" src="https://user-images.githubusercontent.com/1041842/49197795-22fb7d00-f345-11e8-8677-a4b06c70f714.png">

