### PR TITLE
Sort Tests (by Test Class Name)

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/views/testOutlineProvider.ts
+++ b/packages/salesforcedx-vscode-apex/src/views/testOutlineProvider.ts
@@ -118,30 +118,32 @@ export class ApexTestOutlineProvider
     }
     this.rootNode.children = new Array<TestNode>();
     if (this.apexTestInfo) {
-      this.apexTestInfo.forEach(test => {
-        let apexGroup = this.apexTestMap.get(
-          test.definingType
-        ) as ApexTestGroupNode;
-        if (!apexGroup) {
-          const groupLocation = new vscode.Location(
-            test.location.uri,
-            APEX_GROUP_RANGE
-          );
-          apexGroup = new ApexTestGroupNode(test.definingType, groupLocation);
-          this.apexTestMap.set(test.definingType, apexGroup);
-        }
-        const apexTest = new ApexTestNode(test.methodName, test.location);
-        apexTest.name = apexGroup.label + '.' + apexTest.label;
-        this.apexTestMap.set(apexTest.name, apexTest);
-        apexGroup.children.push(apexTest);
-        if (
-          this.rootNode &&
-          !(this.rootNode.children.indexOf(apexGroup) >= 0)
-        ) {
-          this.rootNode.children.push(apexGroup);
-        }
-        this.testStrings.add(apexGroup.name);
-      });
+      this.apexTestInfo
+        .sort((a, b) => a.definingType.localeCompare(b.definingType))
+        .forEach(test => {
+          let apexGroup = this.apexTestMap.get(
+            test.definingType
+          ) as ApexTestGroupNode;
+          if (!apexGroup) {
+            const groupLocation = new vscode.Location(
+              test.location.uri,
+              APEX_GROUP_RANGE
+            );
+            apexGroup = new ApexTestGroupNode(test.definingType, groupLocation);
+            this.apexTestMap.set(test.definingType, apexGroup);
+          }
+          const apexTest = new ApexTestNode(test.methodName, test.location);
+          apexTest.name = apexGroup.label + '.' + apexTest.label;
+          this.apexTestMap.set(apexTest.name, apexTest);
+          apexGroup.children.push(apexTest);
+          if (
+            this.rootNode &&
+            !(this.rootNode.children.indexOf(apexGroup) >= 0)
+          ) {
+            this.rootNode.children.push(apexGroup);
+          }
+          this.testStrings.add(apexGroup.name);
+        });
     }
     return this.rootNode;
   }


### PR DESCRIPTION
### What does this PR do?
Rebase and run the automation for the changes sent in PR #776 

This PR will sort tests alphabetically, so that on orgs with many test classes, you can easily find the one you're looking for.
Turn this:
![image](https://user-images.githubusercontent.com/1041842/49253113-b7fc8580-f3da-11e8-9173-1265a351339b.png)

Into this:
![image](https://user-images.githubusercontent.com/1041842/49253131-c0ed5700-f3da-11e8-9e48-bf6d9b59e292.png)


Unfortunately, the diff contains a whole lot more than what I've actually changed (just added the sort) due to prettier re-formatting the code.

### What issues does this PR fix or reference?
Might be considered related to #605, though it doesn't add any searching/filtering.
@W-5652397@