### PR TITLE
[WIP] Easy Deploy on Save

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -23,7 +23,7 @@
   },
   "categories": ["Other"],
   "dependencies": {
-    "@salesforce/core": "0.18.2",
+    "@salesforce/core": "0.23.1",
     "@salesforce/salesforcedx-sobjects-faux-generator": "44.8.0",
     "@salesforce/salesforcedx-utils-vscode": "44.8.0",
     "adm-zip": "0.4.7",
@@ -50,7 +50,7 @@
     "mock-spawn": "0.2.6",
     "nyc": "^11.0.2",
     "sinon": "^2.3.6",
-    "typescript": "2.6.2",
+    "typescript": "2.9.1",
     "vscode": "1.1.17"
   },
   "scripts": {

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -158,7 +158,7 @@
             "sfdx:project_opened && sfdx:default_username_has_no_change_tracking"
         },
         {
-          "command": "sfdx.force.source.deploy",
+          "command": "sfdx.force.source.deploy.manifest.or.source.path",
           "when":
             "sfdx:project_opened && sfdx:default_username_has_no_change_tracking"
         },
@@ -346,7 +346,7 @@
           "when": "false"
         },
         {
-          "command": "sfdx.force.source.deploy",
+          "command": "sfdx.force.source.deploy.manifest.or.source.path",
           "when": "false"
         },
         {
@@ -545,7 +545,7 @@
         "title": "%force_source_retrieve_this_source_text%"
       },
       {
-        "command": "sfdx.force.source.deploy",
+        "command": "sfdx.force.source.deploy.manifest.or.source.path",
         "title": "%force_source_deploy_text%"
       },
       {

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -577,6 +577,11 @@
           "type": ["boolean"],
           "default": true,
           "description": "%telemetry_enabled_description%"
+        },
+        "salesforcedx-vscode-core.push-or-deploy-on-save.enabled": {
+          "type": ["boolean"],
+          "default": false,
+          "description": "%push_or_deploy_on_save_enabled_description%"
         }
       }
     },

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -69,6 +69,8 @@
     "Specifies whether code coverage results are calculated and retrieved when you run Apex tests.",
   "telemetry_enabled_description":
     "Specifies whether to enable Salesforce telemetry. Even when enabled, still abides by the overall `telemetry.enableTelemetry` vscode setting.",
+  "push_or_deploy_on_save_enabled_description":
+    "Specifies whether or not to automatically synchronize source changes to your org when a local source file is saved.",
   "force_manifest_editor_show_text": "SFDX: Show Package Manifest Editor",
   "force_source_retrieve_text": "SFDX: Retrieve Source from Org",
   "force_source_retrieve_this_source_text":

--- a/packages/salesforcedx-vscode-core/src/commands/forceApexTestRun.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexTestRun.ts
@@ -86,7 +86,7 @@ export class ForceApexTestRunCommandFactory {
   private data: ApexTestQuickPickItem;
   private getCodeCoverage: boolean;
   private builder: SfdxCommandBuilder = new SfdxCommandBuilder();
-  private testRunExecutorCommand: Command;
+  private testRunExecutorCommand: Command | undefined;
 
   constructor(data: ApexTestQuickPickItem, getCodeCoverage: boolean) {
     this.data = data;

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploy.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploy.ts
@@ -117,7 +117,7 @@ export class MultipleSourcePathsGatherer
 
 const workspaceChecker = new SfdxWorkspaceChecker();
 
-export async function forceSourceDeployMultiplePaths(uris: vscode.Uri[]) {
+export async function forceSourceDeployMultipleSourcePaths(uris: vscode.Uri[]) {
   const commandlet = new SfdxCommandlet(
     workspaceChecker,
     new MultipleSourcePathsGatherer(uris),

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploy.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploy.ts
@@ -126,7 +126,9 @@ export async function forceSourceDeployMultipleSourcePaths(uris: vscode.Uri[]) {
   await commandlet.run();
 }
 
-export async function forceSourceDeploy(explorerPath: vscode.Uri) {
+export async function forceSourceDeployManifestOrSourcePath(
+  explorerPath: vscode.Uri
+) {
   const commandlet = new SfdxCommandlet(
     workspaceChecker,
     new ManifestOrSourcePathGatherer(explorerPath),

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploy.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploy.ts
@@ -100,7 +100,8 @@ export class ForceSourceDeployExecutor extends SfdxCommandletExecutor<
   }
 }
 
-export class SourcePathsGatherer implements ParametersGatherer<SelectedPath> {
+export class MultipleSourcePathsGatherer
+  implements ParametersGatherer<SelectedPath> {
   private uris: vscode.Uri[];
   public constructor(uris: vscode.Uri[]) {
     this.uris = uris;
@@ -119,7 +120,7 @@ const workspaceChecker = new SfdxWorkspaceChecker();
 export async function forceSourceDeployMultiplePaths(uris: vscode.Uri[]) {
   const commandlet = new SfdxCommandlet(
     workspaceChecker,
-    new SourcePathsGatherer(uris),
+    new MultipleSourcePathsGatherer(uris),
     new ForceSourceDeployExecutor()
   );
   await commandlet.run();

--- a/packages/salesforcedx-vscode-core/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/index.ts
@@ -30,7 +30,7 @@ export { forceOrgCreate } from './forceOrgCreate';
 export { forceOrgOpen } from './forceOrgOpen';
 export { forceSourceDelete } from './forceSourceDelete';
 export {
-  forceSourceDeploy,
+  forceSourceDeployManifestOrSourcePath,
   forceSourceDeployMultipleSourcePaths
 } from './forceSourceDeploy';
 export { forceSourcePull } from './forceSourcePull';

--- a/packages/salesforcedx-vscode-core/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/index.ts
@@ -31,7 +31,7 @@ export { forceOrgOpen } from './forceOrgOpen';
 export { forceSourceDelete } from './forceSourceDelete';
 export {
   forceSourceDeploy,
-  forceSourceDeployMultiplePaths
+  forceSourceDeployMultipleSourcePaths
 } from './forceSourceDeploy';
 export { forceSourcePull } from './forceSourcePull';
 export { forceSourcePush } from './forceSourcePush';

--- a/packages/salesforcedx-vscode-core/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/index.ts
@@ -29,7 +29,10 @@ export { forceDataSoqlQuery } from './forceDataSoqlQuery';
 export { forceOrgCreate } from './forceOrgCreate';
 export { forceOrgOpen } from './forceOrgOpen';
 export { forceSourceDelete } from './forceSourceDelete';
-export { forceSourceDeploy } from './forceSourceDeploy';
+export {
+  forceSourceDeploy,
+  forceSourceDeployMultiplePaths
+} from './forceSourceDeploy';
 export { forceSourcePull } from './forceSourcePull';
 export { forceSourcePush } from './forceSourcePush';
 export { forceSourceRetrieve } from './forceSourceRetrieve';

--- a/packages/salesforcedx-vscode-core/src/constants.ts
+++ b/packages/salesforcedx-vscode-core/src/constants.ts
@@ -21,3 +21,4 @@ export const VISUALFORCE_DEBUG_LEVEL = 'FINER';
 export const TELEMETRY_ENABLED = 'telemetry.enabled';
 export const TELEMETRY_OPT_OUT_LINK =
   'https://github.com/forcedotcom/salesforcedx-vscode/wiki/Telemetry';
+export const PUSH_OR_DEPLOY_ON_SAVE_ENABLED = 'push-or-deploy-on-save.enabled';

--- a/packages/salesforcedx-vscode-core/src/context/index.ts
+++ b/packages/salesforcedx-vscode-core/src/context/index.ts
@@ -7,6 +7,7 @@
 export {
   getDefaultUsernameOrAlias,
   getUsername,
+  isAScratchOrg,
   registerDefaultUsernameWatcher,
   setupWorkspaceOrgType
 } from './workspaceOrgType';

--- a/packages/salesforcedx-vscode-core/src/context/index.ts
+++ b/packages/salesforcedx-vscode-core/src/context/index.ts
@@ -7,7 +7,8 @@
 export {
   getDefaultUsernameOrAlias,
   getUsername,
-  isAScratchOrg,
+  getWorkspaceOrgType,
+  OrgType,
   registerDefaultUsernameWatcher,
   setupWorkspaceOrgType
 } from './workspaceOrgType';

--- a/packages/salesforcedx-vscode-core/src/context/workspaceOrgType.ts
+++ b/packages/salesforcedx-vscode-core/src/context/workspaceOrgType.ts
@@ -34,7 +34,7 @@ export async function setupWorkspaceOrgType() {
   setDefaultUsernameHasNoChangeTracking(defaultUsernameIsSet && !isScratchOrg);
 }
 
-async function isAScratchOrg(username: string): Promise<boolean> {
+export async function isAScratchOrg(username: string): Promise<boolean> {
   const authInfo = await AuthInfo.create(username);
   const authInfoFields = authInfo.getFields();
   return Promise.resolve(typeof authInfoFields.devHubUsername !== 'undefined');

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -39,7 +39,7 @@ import {
   forceProjectWithManifestCreate,
   forceSfdxProjectCreate,
   forceSourceDelete,
-  forceSourceDeploy,
+  forceSourceDeployManifestOrSourcePath,
   forceSourceDeployMultipleSourcePaths,
   forceSourcePull,
   forceSourcePush,
@@ -111,13 +111,13 @@ function registerCommands(
     'sfdx.force.source.delete.current.file',
     forceSourceDelete
   );
-  const forceSourceDeployCmd = vscode.commands.registerCommand(
-    'sfdx.force.source.deploy',
-    forceSourceDeploy
+  const forceSourceDeployManifestOrSourcePathCmd = vscode.commands.registerCommand(
+    'sfdx.force.source.deploy.manifest.or.source.path',
+    forceSourceDeployManifestOrSourcePath
   );
   const forceSourceDeployCurrentFileCmd = vscode.commands.registerCommand(
     'sfdx.force.source.deploy.current.file',
-    forceSourceDeploy
+    forceSourceDeployManifestOrSourcePath
   );
   const forceSourceDeployMultipleSourcePathsCmd = vscode.commands.registerCommand(
     'sfdx.force.source.deploy.multiple.source.paths',
@@ -324,7 +324,7 @@ function registerCommands(
     forceOrgOpenCmd,
     forceSourceDeleteCmd,
     forceSourceDeleteCurrentFileCmd,
-    forceSourceDeployCmd,
+    forceSourceDeployManifestOrSourcePathCmd,
     forceSourceDeployCurrentFileCmd,
     forceSourceDeployMultipleSourcePathsCmd,
     forceSourcePullCmd,

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -40,7 +40,7 @@ import {
   forceSfdxProjectCreate,
   forceSourceDelete,
   forceSourceDeploy,
-  forceSourceDeployMultiplePaths,
+  forceSourceDeployMultipleSourcePaths,
   forceSourcePull,
   forceSourcePush,
   forceSourceRetrieve,
@@ -119,9 +119,9 @@ function registerCommands(
     'sfdx.force.source.deploy.current.file',
     forceSourceDeploy
   );
-  const forceSourceDeployMultiplePathsCmd = vscode.commands.registerCommand(
-    'sfdx.force.source.deploy.multiple.paths',
-    forceSourceDeployMultiplePaths
+  const forceSourceDeployMultipleSourcePathsCmd = vscode.commands.registerCommand(
+    'sfdx.force.source.deploy.multiple.source.paths',
+    forceSourceDeployMultipleSourcePaths
   );
   const forceSourcePullCmd = vscode.commands.registerCommand(
     'sfdx.force.source.pull',
@@ -326,7 +326,7 @@ function registerCommands(
     forceSourceDeleteCurrentFileCmd,
     forceSourceDeployCmd,
     forceSourceDeployCurrentFileCmd,
-    forceSourceDeployMultiplePathsCmd,
+    forceSourceDeployMultipleSourcePathsCmd,
     forceSourcePullCmd,
     forceSourcePullForceCmd,
     forceSourcePushCmd,

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -74,6 +74,7 @@ import * as decorators from './decorators';
 import { nls } from './messages';
 import { isDemoMode } from './modes/demo-mode';
 import { notificationService, ProgressNotification } from './notifications';
+import { registerPushOrDeployOnSave } from './settings';
 import { taskViewService } from './statuses';
 import { telemetryService } from './telemetry';
 
@@ -451,6 +452,8 @@ export async function activate(context: vscode.ExtensionContext) {
   await setupWorkspaceOrgType();
   registerDefaultUsernameWatcher(context);
 
+  // Register filewatcher for push or deploy on save
+  await registerPushOrDeployOnSave();
   // Commands
   const commands = registerCommands(context);
   context.subscriptions.push(commands);

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -40,6 +40,7 @@ import {
   forceSfdxProjectCreate,
   forceSourceDelete,
   forceSourceDeploy,
+  forceSourceDeployMultiplePaths,
   forceSourcePull,
   forceSourcePush,
   forceSourceRetrieve,
@@ -117,6 +118,10 @@ function registerCommands(
   const forceSourceDeployCurrentFileCmd = vscode.commands.registerCommand(
     'sfdx.force.source.deploy.current.file',
     forceSourceDeploy
+  );
+  const forceSourceDeployMultiplePathsCmd = vscode.commands.registerCommand(
+    'sfdx.force.source.deploy.multiple.paths',
+    forceSourceDeployMultiplePaths
   );
   const forceSourcePullCmd = vscode.commands.registerCommand(
     'sfdx.force.source.pull',
@@ -321,6 +326,7 @@ function registerCommands(
     forceSourceDeleteCurrentFileCmd,
     forceSourceDeployCmd,
     forceSourceDeployCurrentFileCmd,
+    forceSourceDeployMultiplePathsCmd,
     forceSourcePullCmd,
     forceSourcePullForceCmd,
     forceSourcePushCmd,

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -192,5 +192,9 @@ export const messages = {
   tooling_API_description: 'Execute the query with Tooling API',
   telemetry_legal_dialog_message:
     'You agree that Salesforce Extensions for VS Code may collect usage information, user environment, and crash reports for product improvements. Learn how to [opt out](%s).',
-  telemetry_legal_dialog_button_text: 'Read more'
+  telemetry_legal_dialog_button_text: 'Read more',
+  error_fetching_auth_info_text:
+    'Error fetching the info for your defaultusername. Please re-auth into your org and manually push or deploy your change again.',
+  error_change_not_deleted_text:
+    'Unfortunately, automatic deployment of deletes is not supported. If you would like to deploy the source that you just deleted, please undo your last deletion and delete your source using the SFDX: Delete Source from Project and Org command'
 };

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -196,7 +196,7 @@ export const messages = {
   invalid_debug_level_id_error:
     'At least one trace flag in your org doesn\'t have an associated debug level. Before you run this command again, run "sfdx force:data:soql:query -t -q "SELECT Id FROM TraceFlag WHERE DebugLevelId = null"". Then, to delete each invalid trace flag, run "sfdx force:data:record:delete -t -s TraceFlag -i 7tfxxxxxxxxxxxxxxx", replacing 7tfxxxxxxxxxxxxxxx with the ID of each trace flag without a debug level.',
   error_fetching_auth_info_text:
-    'Error fetching the info for your defaultusername. Please re-auth into your org and manually push or deploy your change again.',
+    'Error fetching the info for your defaultusername. Your last change was not deployed to your org. Please re-auth into your org and manually push or deploy your change again.',
   error_change_not_deleted_text:
     'Unfortunately, automatic deployment of deletes is not supported. If you would like to deploy the source that you just deleted, please undo your last deletion and delete your source using the SFDX: Delete Source from Project and Org command'
 };

--- a/packages/salesforcedx-vscode-core/src/settings/index.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/index.ts
@@ -8,3 +8,4 @@
 import { SfdxCoreSettings } from './sfdxCoreSettings';
 
 export const sfdxCoreSettings = SfdxCoreSettings.getInstance();
+export { registerPushOrDeployOnSave } from './pushOrDeployOnSave';

--- a/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
@@ -4,6 +4,7 @@ import {
   getUsername,
   isAScratchOrg
 } from '../context';
+import { notificationService } from '../notifications';
 import { sfdxCoreSettings } from '../settings';
 
 import * as vscode from 'vscode';
@@ -65,15 +66,20 @@ export async function registerPushOrDeployOnSave() {
         clearTimeout(deletedFilesTimeout);
 
         deletedFilesTimeout = setTimeout(async () => {
-          const orgType = await getOrgType();
+          let orgType;
+          try {
+            orgType = await getOrgType();
+          } catch (e) {
+            console.log(e);
+          }
+
           if (orgType === OrgType.SourceTrackedOrg) {
             vscode.commands.executeCommand('sfdx.force.source.push');
             deletedFiles = [];
           }
 
           if (orgType === OrgType.NonSourceTrackedOrg) {
-            console.log(`deleted files: ${deletedFiles}`);
-            vscode.commands.executeCommand('sfdx.force.source.delete', uri);
+            notificationService.showErrorMessage('Use the Delete Command Plz');
             deletedFiles = [];
           }
         });

--- a/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
@@ -1,0 +1,16 @@
+import { SfdxProject } from '@salesforce/core';
+
+import * as vscode from 'vscode';
+
+export async function registerPushOrDeployOnSave() {
+  if (
+    vscode.workspace.workspaceFolders &&
+    vscode.workspace.workspaceFolders.length > 0
+  ) {
+    const project = await SfdxProject.resolve(
+      vscode.workspace.workspaceFolders[0].uri.fsPath
+    );
+    const projectJson = await project.resolveProjectConfig();
+    console.log(projectJson);
+  }
+}

--- a/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
@@ -82,7 +82,7 @@ async function pushOrDeploy(
         );
       } else if (fileEventType === FileEventType.Change) {
         vscode.commands.executeCommand(
-          'sfdx.force.source.deploy',
+          'sfdx.force.source.deploy.manifest.or.source.path',
           filesToDeploy![0]
         );
       } else if (fileEventType === FileEventType.Delete) {

--- a/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
@@ -40,7 +40,10 @@ export async function registerPushOrDeployOnSave() {
 
           if (orgType === OrgType.NonSourceTrackedOrg) {
             console.log(`created files: ${createdFiles}`);
-            vscode.commands.executeCommand('sfdx.force.source.deploy', uri);
+            vscode.commands.executeCommand(
+              'sfdx.force.source.deploy.multiple.paths',
+              createdFiles
+            );
             createdFiles = [];
           }
         }, 1000);

--- a/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
@@ -77,7 +77,7 @@ async function pushOrDeploy(
     if (orgType === OrgType.NonSourceTracked) {
       if (fileEventType === FileEventType.Create) {
         vscode.commands.executeCommand(
-          'sfdx.force.source.deploy.multiple.paths',
+          'sfdx.force.source.deploy.multiple.source.paths',
           filesToDeploy!.slice(0)
         );
       } else if (fileEventType === FileEventType.Change) {

--- a/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
@@ -1,16 +1,108 @@
 import { SfdxProject } from '@salesforce/core';
+import {
+  getDefaultUsernameOrAlias,
+  getUsername,
+  isAScratchOrg
+} from '../context';
+import { sfdxCoreSettings } from '../settings';
 
 import * as vscode from 'vscode';
 
+interface SfdxProjectJson {
+  packageDirectories: [PackageDirectory];
+}
+
+interface PackageDirectory {
+  path: string;
+  default?: boolean;
+}
+
 export async function registerPushOrDeployOnSave() {
+  if (sfdxCoreSettings.getPushOrDeployOnSaveEnabled()) {
+    const fileSystemWatcher = await createFileSystemWatcher();
+    if (fileSystemWatcher) {
+      fileSystemWatcher.onDidCreate(async uri => {
+        const orgType = await getOrgType();
+        if (orgType === OrgType.SourceTrackedOrg) {
+          vscode.commands.executeCommand('sfdx.force.source.push');
+        }
+
+        if (orgType === OrgType.NonSourceTrackedOrg) {
+          // Collect all source additions within a few seconds and deploy all at once
+          vscode.commands.executeCommand('sfdx.force.source.deploy', uri);
+        }
+      });
+
+      fileSystemWatcher.onDidChange(async uri => {
+        const orgType = await getOrgType();
+        if (orgType === OrgType.SourceTrackedOrg) {
+          vscode.commands.executeCommand('sfdx.force.source.push');
+        }
+
+        if (orgType === OrgType.NonSourceTrackedOrg) {
+          vscode.commands.executeCommand('sfdx.force.source.deploy', uri);
+        }
+      });
+
+      fileSystemWatcher.onDidDelete(async uri => {
+        const orgType = await getOrgType();
+        if (orgType === OrgType.SourceTrackedOrg) {
+          vscode.commands.executeCommand('sfdx.force.source.push');
+        }
+
+        if (orgType === OrgType.NonSourceTrackedOrg) {
+          vscode.commands.executeCommand('sfdx.force.source.delete', uri);
+        }
+      });
+    }
+  }
+}
+
+enum OrgType {
+  SourceTrackedOrg,
+  NonSourceTrackedOrg,
+  NoOrgSet
+}
+
+async function getOrgType(): Promise<OrgType> {
+  const defaultUsernameOrAlias = await getDefaultUsernameOrAlias();
+  const defaultUsernameIsSet = typeof defaultUsernameOrAlias !== 'undefined';
+  let isScratchOrg = false;
+  if (defaultUsernameIsSet) {
+    const username = await getUsername(defaultUsernameOrAlias!);
+    try {
+      isScratchOrg = await isAScratchOrg(username);
+    } catch (e) {
+      throw new Error('Error finding default org type, please re-auth');
+    }
+
+    if (defaultUsernameIsSet && isScratchOrg) {
+      return Promise.resolve(OrgType.SourceTrackedOrg);
+    }
+
+    if (defaultUsernameIsSet && !isScratchOrg) {
+      return Promise.resolve(OrgType.NonSourceTrackedOrg);
+    }
+  }
+  return Promise.resolve(OrgType.NoOrgSet);
+}
+
+async function createFileSystemWatcher(): Promise<vscode.FileSystemWatcher | null> {
   if (
     vscode.workspace.workspaceFolders &&
     vscode.workspace.workspaceFolders.length > 0
   ) {
-    const project = await SfdxProject.resolve(
-      vscode.workspace.workspaceFolders[0].uri.fsPath
+    const projectPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
+    const project = await SfdxProject.resolve(projectPath);
+    const projectJson = (await project.resolveProjectConfig()) as SfdxProjectJson;
+    const packageDirectoryPaths = projectJson.packageDirectories.map(
+      packageDir => packageDir.path
     );
-    const projectJson = await project.resolveProjectConfig();
-    console.log(projectJson);
+    const globString = `${projectPath}/{${packageDirectoryPaths.join(',')}}/**`;
+    const fileSystemWatcher = vscode.workspace.createFileSystemWatcher(
+      globString
+    );
+    return Promise.resolve(fileSystemWatcher);
   }
+  return Promise.resolve(null);
 }

--- a/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
@@ -50,7 +50,13 @@ export async function registerPushOrDeployOnSave() {
             createdFiles = [];
           } catch (e) {
             createdFiles = [];
-            notificationService.showErrorMessage(e.message);
+            if (e.name === 'NamedOrgNotFound') {
+              notificationService.showErrorMessage(
+                nls.localize('error_fetching_auth_info_text')
+              );
+            } else {
+              notificationService.showErrorMessage(e);
+            }
           }
         }, WAIT_TIME_IN_MS);
       });
@@ -66,7 +72,13 @@ export async function registerPushOrDeployOnSave() {
             vscode.commands.executeCommand('sfdx.force.source.deploy', uri);
           }
         } catch (e) {
-          notificationService.showErrorMessage(e.message);
+          if (e.name === 'NamedOrgNotFound') {
+            notificationService.showErrorMessage(
+              nls.localize('error_fetching_auth_info_text')
+            );
+          } else {
+            notificationService.showErrorMessage(e);
+          }
         }
       });
 
@@ -83,13 +95,19 @@ export async function registerPushOrDeployOnSave() {
 
             if (orgType === OrgType.NonSourceTrackedOrg) {
               notificationService.showErrorMessage(
-                'Use the Delete Command Plz'
+                nls.localize('error_change_not_deleted_text')
               );
             }
             deletedFiles = [];
           } catch (e) {
             deletedFiles = [];
-            notificationService.showErrorMessage(e.message);
+            if (e.name === 'NamedOrgNotFound') {
+              notificationService.showErrorMessage(
+                nls.localize('error_fetching_auth_info_text')
+              );
+            } else {
+              notificationService.showErrorMessage(e);
+            }
           }
         }, WAIT_TIME_IN_MS);
       });
@@ -112,7 +130,7 @@ async function getOrgType(): Promise<OrgType> {
     try {
       isScratchOrg = await isAScratchOrg(username);
     } catch (e) {
-      throw new Error('Error finding default org type, please re-auth');
+      throw e;
     }
 
     if (defaultUsernameIsSet && isScratchOrg) {

--- a/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
@@ -7,6 +7,7 @@
 
 import * as vscode from 'vscode';
 import {
+  PUSH_OR_DEPLOY_ON_SAVE_ENABLED,
   SFDX_CORE_CONFIGURATION_NAME,
   SHOW_CLI_SUCCESS_INFO_MSG,
   TELEMETRY_ENABLED
@@ -47,6 +48,10 @@ export class SfdxCoreSettings {
 
   public async updateShowCLISuccessMsg(value: boolean) {
     await this.setConfigValue(SHOW_CLI_SUCCESS_INFO_MSG, value);
+  }
+
+  public getPushOrDeployOnSaveEnabled(): boolean {
+    return this.getConfigValue<boolean>(PUSH_OR_DEPLOY_ON_SAVE_ENABLED, false);
   }
 
   private getConfigValue<T>(key: string, defaultValue: T): T {

--- a/packages/salesforcedx-vscode-core/src/statuses/taskView.ts
+++ b/packages/salesforcedx-vscode-core/src/statuses/taskView.ts
@@ -88,8 +88,8 @@ export class TaskViewService implements TreeDataProvider<Task> {
 }
 
 export class Task extends TreeItem {
-  public readonly label: string;
-  public readonly collapsibleState: TreeItemCollapsibleState;
+  public readonly label: string | undefined;
+  public readonly collapsibleState: TreeItemCollapsibleState | undefined;
 
   private readonly taskViewProvider: TaskViewService;
   private readonly execution: CommandExecution;

--- a/packages/salesforcedx-vscode-core/test/telemetry/MockContext.ts
+++ b/packages/salesforcedx-vscode-core/test/telemetry/MockContext.ts
@@ -29,6 +29,7 @@ class MockMemento implements Memento {
 export class MockContext implements ExtensionContext {
   constructor(mm: boolean) {
     this.globalState = new MockMemento(mm);
+    this.workspaceState = new MockMemento(mm);
   }
   public subscriptions: Array<{ dispose(): any }> = [];
   public workspaceState: Memento;


### PR DESCRIPTION
I'd like to get feedback on my implementation approach for Easy Deploy on Save in case my current approach requires major changes.

### What does this PR do?
* Adds a workspace configuration called `salesforcedx-vscode-core.push-or-deploy-on-save.enabled` that is set to `false` by default
* Works in both scratch orgs and non-scratch orgs

Still left to do:
* Update @salesforce/core package to the latest version (in this PR it has been bumped from 0.18.2 to 0.23.1, but the latest version available in npm is 0.24.8)
* Update typescript in all repo packages
* Add testing
* Test on OS's other than Mac
* Test out the alternative way to batch created/deleted files for a single deploy/push; Right now, whenever I detect a create/delete, I extend the wait time by 1 second. When the wait time of 1 second has passed without detecting any additional creates/deletes, then I initiate a single deploy/push

### What issues does this PR fix or reference?
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000005wp9BIAQ/view