### PR TITLE
Avoid screenshots on every word being typed

### DIFF
--- a/packages/system-tests/src/areas/common.ts
+++ b/packages/system-tests/src/areas/common.ts
@@ -105,7 +105,7 @@ export class CommonActions {
 
         const toType = textSplit[i + 1] ? `${textSplit[i]} ` : textSplit[i];
         await spectron.client.keys(toType, false);
-        await spectron.client.keys(['NULL']);
+        await spectron.client.keys(['NULL'], false);
         await type(i + 1);
       }
 


### PR DESCRIPTION
### What does this PR do?
Saves us 50% (or more) of the old execution time for system tests. Below is the comparison using our longest running test.

Before this: 
- Should execute anonymous apex from current editor : exec time = 2 min 21 sec (avg)

After this: 
- Should execute anonymous apex from current editor : exec time = 56 sec 599 ms (avg)

### What issues does this PR fix or reference?
