### PR TITLE
Update right click menu label based on test status

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -95,8 +95,13 @@
           "when": "view == sfdx.force.test.view"
         },
         {
+          "command": "sfdx.force.test.view.runClassTests",
+          "when": "view == sfdx.force.test.view && viewItem == apexTestGroup",
+          "group": "inline"
+        },
+        {
           "command": "sfdx.force.test.view.runSingleTest",
-          "when": "view == sfdx.force.test.view",
+          "when": "view == sfdx.force.test.view && viewItem == apexTest",
           "group": "inline"
         }
       ]
@@ -124,6 +129,14 @@
         "icon": {
           "light": "resources/light/document/notRun.svg",
           "dark": "resources/dark/document/notRun.svg"
+        }
+      },
+      {
+        "command": "sfdx.force.test.view.runClassTests",
+        "title": "%run_tests_title%",
+        "icon": {
+          "light": "resources/light/play-side.svg",
+          "dark": "resources/dark/play-side.svg"
         }
       },
       {

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -92,16 +92,23 @@
       "view/item/context": [
         {
           "command": "sfdx.force.test.view.showError",
-          "when": "view == sfdx.force.test.view"
+          "when":
+            "view == sfdx.force.test.view && viewItem =~ /(apexTest|apexTestGroup)_Fail/"
+        },
+        {
+          "command": "sfdx.force.test.view.showDefinition",
+          "when":
+            "view == sfdx.force.test.view && viewItem =~ /(apexTest|apexTestGroup)(_Pass|_Skip|\\b)/"
         },
         {
           "command": "sfdx.force.test.view.runClassTests",
-          "when": "view == sfdx.force.test.view && viewItem == apexTestGroup",
+          "when": "view == sfdx.force.test.view && viewItem =~ /apexTestGroup/",
           "group": "inline"
         },
         {
           "command": "sfdx.force.test.view.runSingleTest",
-          "when": "view == sfdx.force.test.view && viewItem == apexTest",
+          "when":
+            "view == sfdx.force.test.view && viewItem =~ /(apexTest)(_.*|\\b)/",
           "group": "inline"
         }
       ]
@@ -126,6 +133,14 @@
       {
         "command": "sfdx.force.test.view.showError",
         "title": "%show_error_title%",
+        "icon": {
+          "light": "resources/light/document/notRun.svg",
+          "dark": "resources/dark/document/notRun.svg"
+        }
+      },
+      {
+        "command": "sfdx.force.test.view.showDefinition",
+        "title": "%show_definition_title%",
         "icon": {
           "light": "resources/light/document/notRun.svg",
           "dark": "resources/dark/document/notRun.svg"

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -96,7 +96,7 @@
             "view == sfdx.force.test.view && viewItem =~ /(apexTest|apexTestGroup)_Fail/"
         },
         {
-          "command": "sfdx.force.test.view.showDefinition",
+          "command": "sfdx.force.test.view.goToDefinition",
           "when":
             "view == sfdx.force.test.view && viewItem =~ /(apexTest|apexTestGroup)(_Pass|_Skip|\\b)/"
         },
@@ -139,8 +139,8 @@
         }
       },
       {
-        "command": "sfdx.force.test.view.showDefinition",
-        "title": "%show_definition_title%",
+        "command": "sfdx.force.test.view.goToDefinition",
+        "title": "%go_to_definition_title%",
         "icon": {
           "light": "resources/light/document/notRun.svg",
           "dark": "resources/dark/document/notRun.svg"

--- a/packages/salesforcedx-vscode-apex/package.nls.json
+++ b/packages/salesforcedx-vscode-apex/package.nls.json
@@ -6,6 +6,7 @@
   "refresh_test_title": "Refresh Tests",
   "run_single_test_title": "Run Single Test",
   "show_error_title": "Display Error",
+  "show_definition_title": "Go to Definition",
   "java_home_description":
     "Specifies the folder path to the Java 8 runtime used to launch the Apex Language Server (for example, /Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home).",
   "apex_rename_description":

--- a/packages/salesforcedx-vscode-apex/package.nls.json
+++ b/packages/salesforcedx-vscode-apex/package.nls.json
@@ -6,7 +6,7 @@
   "refresh_test_title": "Refresh Tests",
   "run_single_test_title": "Run Single Test",
   "show_error_title": "Display Error",
-  "show_definition_title": "Go to Definition",
+  "go_to_definition_title": "Go to Definition",
   "java_home_description":
     "Specifies the folder path to the Java 8 runtime used to launch the Apex Language Server (for example, /Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home).",
   "apex_rename_description":

--- a/packages/salesforcedx-vscode-apex/src/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/index.ts
@@ -98,11 +98,18 @@ async function registerTestView(
       testRunner.showErrorMessage(test)
     )
   );
+  // Run Class Tests command
+  testViewItems.push(
+    vscode.commands.registerCommand(
+      'sfdx.force.test.view.runClassTests',
+      test => testRunner.runTestOrTestClass(test)
+    )
+  );
   // Run Single Test command
   testViewItems.push(
     vscode.commands.registerCommand(
       'sfdx.force.test.view.runSingleTest',
-      test => testRunner.runSingleTest(test)
+      test => testRunner.runTestOrTestClass(test)
     )
   );
   // Refresh Test View command

--- a/packages/salesforcedx-vscode-apex/src/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/index.ts
@@ -101,7 +101,7 @@ async function registerTestView(
   // Show Definition command
   testViewItems.push(
     vscode.commands.registerCommand(
-      'sfdx.force.test.view.showDefinition',
+      'sfdx.force.test.view.goToDefinition',
       test => testRunner.showErrorMessage(test)
     )
   );

--- a/packages/salesforcedx-vscode-apex/src/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/index.ts
@@ -98,6 +98,13 @@ async function registerTestView(
       testRunner.showErrorMessage(test)
     )
   );
+  // Show Definition command
+  testViewItems.push(
+    vscode.commands.registerCommand(
+      'sfdx.force.test.view.showDefinition',
+      test => testRunner.showErrorMessage(test)
+    )
+  );
   // Run Class Tests command
   testViewItems.push(
     vscode.commands.registerCommand(

--- a/packages/salesforcedx-vscode-apex/src/views/testOutlineProvider.ts
+++ b/packages/salesforcedx-vscode-apex/src/views/testOutlineProvider.ts
@@ -180,7 +180,7 @@ export class ApexTestOutlineProvider
       ) as ApexTestNode;
       if (apexTest) {
         apexTest.outcome = testResult.Outcome;
-        apexTest.updateIcon();
+        apexTest.updateOutcome();
         if (testResult.Outcome === 'Fail') {
           apexTest.errorMessage = testResult.Message;
           apexTest.stackTrace = testResult.StackTrace;
@@ -226,7 +226,7 @@ export abstract class TestNode extends vscode.TreeItem {
     return this.description;
   }
 
-  public updateIcon(outcome: string) {
+  public updateOutcome(outcome: string) {
     if (outcome === 'Pass') {
       // Passed Test
       this.iconPath = {
@@ -246,6 +246,9 @@ export abstract class TestNode extends vscode.TreeItem {
         dark: DARK_ORANGE_BUTTON
       };
     }
+
+    const contextValue = this.contextValue.split('_');
+    this.contextValue = `${contextValue}_${outcome}`;
   }
 
   public abstract contextValue: string;
@@ -278,19 +281,19 @@ export class ApexTestGroupNode extends TestNode {
 
     if (this.passing + this.failing + this.skipping === this.children.length) {
       if (this.failing !== 0) {
-        this.updateIcon('Fail');
+        this.updateOutcome('Fail');
       } else {
-        this.updateIcon('Pass');
+        this.updateOutcome('Pass');
       }
     }
   }
 
-  public updateIcon(outcome: string) {
-    super.updateIcon(outcome);
+  public updateOutcome(outcome: string) {
+    super.updateOutcome(outcome);
     if (outcome === 'Pass') {
       this.children.forEach(child => {
         // Update all the children as well
-        child.updateIcon(outcome);
+        child.updateOutcome(outcome);
       });
     }
   }
@@ -305,8 +308,8 @@ export class ApexTestNode extends TestNode {
     super(label, vscode.TreeItemCollapsibleState.None, location);
   }
 
-  public updateIcon() {
-    super.updateIcon(this.outcome);
+  public updateOutcome() {
+    super.updateOutcome(this.outcome);
     if (this.outcome === 'Pass') {
       this.errorMessage = '';
     }

--- a/packages/salesforcedx-vscode-apex/src/views/testOutlineProvider.ts
+++ b/packages/salesforcedx-vscode-apex/src/views/testOutlineProvider.ts
@@ -247,8 +247,8 @@ export abstract class TestNode extends vscode.TreeItem {
       };
     }
 
-    const contextValue = this.contextValue.split('_');
-    this.contextValue = `${contextValue}_${outcome}`;
+    const nodeType = this.contextValue.split('_')[0];
+    this.contextValue = `${nodeType}_${outcome}`;
   }
 
   public abstract contextValue: string;

--- a/packages/salesforcedx-vscode-apex/src/views/testRunner.ts
+++ b/packages/salesforcedx-vscode-apex/src/views/testRunner.ts
@@ -78,14 +78,6 @@ export class ApexTestRunner {
     }
   }
 
-  // public goToPosition(test: TestNode, position: vscode.Range | number) {
-  //   if (test.location) {
-  //     vscode.window.showTextDocument(test.location.uri).then(() => {
-  //       this.eventsEmitter.emit('sfdx:update_selection', position);
-  //     });
-  //   }
-  // }
-
   public updateSelection(index: vscode.Range | number) {
     const editor = vscode.window.activeTextEditor;
     if (editor) {

--- a/packages/salesforcedx-vscode-apex/src/views/testRunner.ts
+++ b/packages/salesforcedx-vscode-apex/src/views/testRunner.ts
@@ -70,18 +70,9 @@ export class ApexTestRunner {
         channelService.showChannelOutput();
       }
     }
-<<<<<<< HEAD
 
     if (testNode.location) {
       vscode.window.showTextDocument(testNode.location.uri).then(() => {
-=======
-    this.goToPosition(testNode, position);
-  }
-
-  public goToPosition(test: TestNode, position: vscode.Range | number) {
-    if (test.location) {
-      vscode.window.showTextDocument(test.location.uri).then(() => {
->>>>>>> e2b4d324a0f86d148b284ee152ffa067a75d32ee
         this.eventsEmitter.emit('sfdx:update_selection', position);
       });
     }

--- a/packages/salesforcedx-vscode-apex/src/views/testRunner.ts
+++ b/packages/salesforcedx-vscode-apex/src/views/testRunner.ts
@@ -28,9 +28,13 @@ const SfdxWorkspaceChecker = sfdxCoreExports.SfdxWorkspaceChecker;
 const channelService = sfdxCoreExports.channelService;
 export class ApexTestRunner {
   private testOutline: ApexTestOutlineProvider;
-  private eventsEmitter = new events.EventEmitter();
-  constructor(testOutline: ApexTestOutlineProvider) {
+  private eventsEmitter: events.EventEmitter;
+  constructor(
+    testOutline: ApexTestOutlineProvider,
+    eventsEmitter?: events.EventEmitter
+  ) {
     this.testOutline = testOutline;
+    this.eventsEmitter = eventsEmitter || new events.EventEmitter();
     this.eventsEmitter.on('sfdx:update_selection', this.updateSelection);
   }
 
@@ -66,12 +70,21 @@ export class ApexTestRunner {
         channelService.showChannelOutput();
       }
     }
+
     if (testNode.location) {
       vscode.window.showTextDocument(testNode.location.uri).then(() => {
         this.eventsEmitter.emit('sfdx:update_selection', position);
       });
     }
   }
+
+  // public goToPosition(test: TestNode, position: vscode.Range | number) {
+  //   if (test.location) {
+  //     vscode.window.showTextDocument(test.location.uri).then(() => {
+  //       this.eventsEmitter.emit('sfdx:update_selection', position);
+  //     });
+  //   }
+  // }
 
   public updateSelection(index: vscode.Range | number) {
     const editor = vscode.window.activeTextEditor;

--- a/packages/salesforcedx-vscode-apex/src/views/testRunner.ts
+++ b/packages/salesforcedx-vscode-apex/src/views/testRunner.ts
@@ -98,7 +98,7 @@ export class ApexTestRunner {
     }
   }
 
-  public async runSingleTest(test: TestNode) {
+  public async runTestOrTestClass(test: TestNode) {
     await this.testOutline.refresh();
     const tmpFolder = this.getTempFolder();
     const builder = new ReadableApexTestRunExecutor(

--- a/packages/salesforcedx-vscode-apex/test/views/testJSONOutputs.ts
+++ b/packages/salesforcedx-vscode-apex/test/views/testJSONOutputs.ts
@@ -69,8 +69,8 @@ const testResultsMultipleFiles = [
     MethodName: 'test1',
     Outcome: 'Fail',
     RunTime: 1,
-    Message: '',
-    StackTrace: '',
+    Message: 'System.AssertException: Assertion Failed',
+    StackTrace: 'Class.fakeClass.test1: line 40, column 1',
     FullName: 'file0.test1'
   },
   {
@@ -114,8 +114,8 @@ const testResultsMultipleFiles = [
     MethodName: 'test6',
     Outcome: 'Fail',
     RunTime: 1,
-    Message: '',
-    StackTrace: '',
+    Message: 'System.AssertException: Assertion Failed',
+    StackTrace: 'Class.fakeClass.test6: line 22, column 1',
     FullName: 'file3.test6'
   },
   {

--- a/packages/salesforcedx-vscode-apex/test/views/testOutline.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/views/testOutline.test.ts
@@ -17,7 +17,8 @@ import { ApexTestMethod } from '../../src/views/lspConverter';
 import {
   ApexTestGroupNode,
   ApexTestNode,
-  ApexTestOutlineProvider
+  ApexTestOutlineProvider,
+  TestNode
 } from '../../src/views/testOutlineProvider';
 import { ApexTestRunner } from '../../src/views/testRunner';
 import {

--- a/packages/system-tests/src/areas/common.ts
+++ b/packages/system-tests/src/areas/common.ts
@@ -105,7 +105,7 @@ export class CommonActions {
 
         const toType = textSplit[i + 1] ? `${textSplit[i]} ` : textSplit[i];
         await spectron.client.keys(toType, false);
-        await spectron.client.keys(['NULL']);
+        await spectron.client.keys(['NULL'], false);
         await type(i + 1);
       }
 


### PR DESCRIPTION
Looking for some feedback on how I went about this. Also noticed there aren't any tests for the functionality of going to the error/definition, I'll work on that as well.

### What does this PR do?
When right clicking on a test that hasn't run, passed, or is skipped, the menu option now says "Go to Definition" instead of "Display Error", the latter which is shown only when the test has failed. 

### What issues does this PR fix or reference?
W-5368845