### PR TITLE
Resolve from main NPM repository

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://npm.lwcjs.org/


### PR DESCRIPTION
### What does this PR do?

No longer use npm.lwcjs.org as the NPM repository.

### What issues does this PR fix or reference?

Clean up.