### PR TITLE
fix typo in url and change http to https

### DIFF
--- a/packages/salesforcedx-vscode-lwc/README.md
+++ b/packages/salesforcedx-vscode-lwc/README.md
@@ -42,7 +42,7 @@ To report issues with Salesforce Extensions for VS Code, open a [bug on GitHub](
 
 ## Resources
 
-- Doc: [Lightning Web Components Developer Guide](http://developer.salesfore.com/docs/component-library/documentation/lwc) (available after December 17th)
+- Doc: [Lightning Web Components Developer Guide](https://developer.salesforce.com/docs/component-library/documentation/lwc) (available after December 17th)
 - Trailhead: [Lightning Web Components Quick Start](https://trailhead.salesforce.com/content/learn/projects/quick-start-lightning-web-components/)
 - Trailhead: [Get Started with Salesforce DX](https://trailhead.salesforce.com/trails/sfdx_get_started)
 - Doc: [Salesforce DX Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev)


### PR DESCRIPTION
### What does this PR do?
Changed the link to use https not http and also found a typo in the link (salesforce was missing the 'c').

### What issues does this PR fix or reference?
@W-5699220@