### PR TITLE
Fix Syntax hightlighting for manifest XML files

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -630,6 +630,13 @@
         "aliases": ["ForceSourceManifest", "forcesourcemanifest"],
         "filenamePatterns": ["**/manifest/**/*.xml"]
       }
+    ],
+    "grammars": [
+      {
+        "language": "forcesourcemanifest",
+        "scopeName": "manifest.text.xml",
+        "path": "./syntaxes/manifestXML.tmLanguage.json"
+      }
     ]
   }
 }

--- a/packages/salesforcedx-vscode-core/syntaxes/manifestXML.tmLanguage.json
+++ b/packages/salesforcedx-vscode-core/syntaxes/manifestXML.tmLanguage.json
@@ -1,0 +1,14 @@
+{
+  "information_for_contributors": [
+    "There's nothing special going on here in regards to Manifest XML formatting. The forcesourcemanifest language",
+    "declaration is there to provide a finer granularity for when several commands are available and nothing else.",
+    "This file just includes the standard XML formatting file."
+  ],
+  "name": "Manifest XML",
+  "scopeName": "manifest.text.xml",
+  "patterns": [
+    {
+      "include": "text.xml"
+    }
+  ]
+}


### PR DESCRIPTION
### What does this PR do?
When I'd made the changes to create the "language" for limiting when certain manifest commands are available I'd inadvertently caused the manifest xml files to lose syntax highlighting. This change adds the correct grammar and syntax files to the package.json. The language file is just a pass through as there's nothing special about the syntax for the manifest XML at this time.

### What issues does this PR fix or reference?
@W-5698186@