### PR TITLE
Boxfoot/execute soql selection multiline

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceDataSoqlQuery.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceDataSoqlQuery.ts
@@ -63,7 +63,7 @@ export class GetQueryAndApiInputs
         query = document.getText(editor.selection);
       }
     }
-    query = query!.replace('[', '').replace(']', '').replace('\n', ' ');
+    query = query!.replace('[', '').replace(']', '').replace(/(\r\n|\n)/g, " ");
 
     if (!query) {
       return { type: 'CANCEL' };

--- a/packages/salesforcedx-vscode-core/src/commands/forceDataSoqlQuery.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceDataSoqlQuery.ts
@@ -63,7 +63,7 @@ export class GetQueryAndApiInputs
         query = document.getText(editor.selection);
       }
     }
-    query = query!.replace('[', '').replace(']', '').replace(/(\r\n|\n)/g, " ");
+    query = query!.replace('[', '').replace(']', '').replace(/(\r\n|\n)/g, ' ');
 
     if (!query) {
       return { type: 'CANCEL' };

--- a/packages/salesforcedx-vscode-core/src/commands/forceDataSoqlQuery.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceDataSoqlQuery.ts
@@ -63,7 +63,7 @@ export class GetQueryAndApiInputs
         query = document.getText(editor.selection);
       }
     }
-    query = query!.replace('[', '').replace(']', '');
+    query = query!.replace('[', '').replace(']', '').replace('\n', ' ');
 
     if (!query) {
       return { type: 'CANCEL' };

--- a/packages/system-tests/scenarios/forceSoqlQueryUi.test.ts
+++ b/packages/system-tests/scenarios/forceSoqlQueryUi.test.ts
@@ -77,7 +77,7 @@ describe(TITLE, () => {
     await app.wait();
 
     // Enter SOQL query in active editor
-    const query = `SELECT Id, Name FROM Account`;
+    const query = 'SELECT Id, Name\nFROM Account';
     await common.type(query);
     await app.wait();
 


### PR DESCRIPTION
### What does this PR do?
Branch created out of PR #832 to run all internal automation. Allows selecting a multiline query when using the "Execute SOQL query with selected text" command.

### What issues does this PR fix or reference?
#816 