### PR TITLE
Move typescript to dependency from devDependency

### DIFF
--- a/packages/salesforcedx-visualforce-language-server/package.json
+++ b/packages/salesforcedx-visualforce-language-server/package.json
@@ -14,7 +14,8 @@
     "vscode-languageserver-protocol": "3.4.2",
     "vscode-languageserver-types": "3.4.0",
     "vscode-nls": "2.0.2",
-    "vscode-uri": "1.0.1"
+    "vscode-uri": "1.0.1",
+    "typescript": "3.1.6"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.38",
@@ -26,8 +27,7 @@
     "nyc": "^11.0.2",
     "remap-istanbul": "^0.9.5",
     "shx": "0.2.2",
-    "source-map-support": "^0.4.15",
-    "typescript": "3.1.6"
+    "source-map-support": "^0.4.15"
   },
   "scripts": {
     "compile": "tsc -p ./ && shx cp -R test/fixtures out/test",


### PR DESCRIPTION
### What does this PR do?
Makes typescript a dependency of the salesforcedx-visualforce-language-server package rather than a devDependency, since the typescript module is required in the javascriptMode.ts file. 

### What issues does this PR fix or reference?
This change to move typescript from a dependency to devDependency caused an error when activating our Visualforce Language Server extension https://github.com/forcedotcom/salesforcedx-vscode/pull/793/files#diff-0138c82fb9a6a54a14d9a4cdb8cb6f5aR43. This change moves typescript back to being a dependency, but specifically in our salesforcedx-visualforce-language-server package since that is the package where typescript is required in the code. 

Same change as: https://github.com/forcedotcom/salesforcedx-vscode/pull/861