### PR TITLE
Handle cli errors when loading workspace context

### DIFF
--- a/packages/salesforcedx-vscode-core/src/context/workspaceOrgType.ts
+++ b/packages/salesforcedx-vscode-core/src/context/workspaceOrgType.ts
@@ -37,7 +37,7 @@ export async function setupWorkspaceOrgType() {
     setDefaultUsernameHasChangeTracking(orgType === OrgType.SourceTracked);
     setDefaultUsernameHasNoChangeTracking(orgType === OrgType.NonSourceTracked);
   } catch (e) {
-    telemetryService.sendError(e.message);
+    telemetryService.sendErrorEvent(e.message, e.stack);
     switch (e.name) {
       case 'NamedOrgNotFound':
         // If the info for a default username cannot be found,

--- a/packages/salesforcedx-vscode-core/src/context/workspaceOrgType.ts
+++ b/packages/salesforcedx-vscode-core/src/context/workspaceOrgType.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 import { ForceConfigGet } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
-import { nls } from '../../src/messages';
+import { telemetryService } from '../telemetry';
 
 export enum OrgType {
   SourceTracked,
@@ -37,6 +37,7 @@ export async function setupWorkspaceOrgType() {
     setDefaultUsernameHasChangeTracking(orgType === OrgType.SourceTracked);
     setDefaultUsernameHasNoChangeTracking(orgType === OrgType.NonSourceTracked);
   } catch (e) {
+    telemetryService.sendError(e.message);
     switch (e.name) {
       case 'NamedOrgNotFound':
         // If the info for a default username cannot be found,
@@ -49,7 +50,8 @@ export async function setupWorkspaceOrgType() {
         setDefaultUsernameHasNoChangeTracking(false);
         break;
       default:
-        throw e;
+        setDefaultUsernameHasChangeTracking(true);
+        setDefaultUsernameHasNoChangeTracking(true);
     }
   }
 }
@@ -64,6 +66,7 @@ async function isAScratchOrg(username: string): Promise<boolean> {
   } catch (e) {
     // If the info for a username cannot be found,
     // then the name of the exception will be 'NamedOrgNotFound'
+    telemetryService.sendError(e.message);
     throw e;
   }
 }

--- a/packages/salesforcedx-vscode-core/src/telemetry/telemetry.ts
+++ b/packages/salesforcedx-vscode-core/src/telemetry/telemetry.ts
@@ -147,6 +147,16 @@ export class TelemetryService {
     }
   }
 
+  public sendErrorEvent(errorMsg: string, callstack: string): void {
+    if (this.reporter !== undefined && this.isTelemetryEnabled) {
+      this.reporter.sendTelemetryEvent('error', {
+        extensionName: EXTENSION_NAME,
+        errorMessage: errorMsg,
+        errorStack: callstack
+      });
+    }
+  }
+
   public dispose(): void {
     if (this.reporter !== undefined) {
       this.reporter.dispose().catch(err => console.log(err));

--- a/packages/salesforcedx-vscode-core/test/context/workspaceOrgType.test.ts
+++ b/packages/salesforcedx-vscode-core/test/context/workspaceOrgType.test.ts
@@ -266,7 +266,6 @@ describe('setupWorkspaceOrgType', () => {
     const getConfigStub = getGetConfigStub(
       new Map([['defaultusername', username]])
     );
-    expect(await getDefaultUsernameOrAlias()).to.equal(username);
 
     const error = new Error();
     error.name = 'GenericKeychainServiceError';
@@ -274,17 +273,21 @@ describe('setupWorkspaceOrgType', () => {
       'GenericKeychainServiceError: The service and acount specified in key.json do not match the version of the toolbelt ...';
     const authInfoStub = sinon.stub(AuthInfo, 'create').throws(error);
 
-    await setupWorkspaceOrgType();
+    try {
+      expect(await getDefaultUsernameOrAlias()).to.equal(username);
 
-    expect(aliasesSpy.called).to.be.false;
-    expect(executeCommandStub.calledTwice).to.be.true;
-    expectDefaultUsernameHasChangeTracking(true, executeCommandStub);
-    expectDefaultUsernameHasNoChangeTracking(true, executeCommandStub);
+      await setupWorkspaceOrgType();
 
-    getConfigStub.restore();
-    aliasesSpy.restore();
-    executeCommandStub.restore();
-    authInfoStub.restore();
+      expect(aliasesSpy.called).to.be.true;
+      expect(executeCommandStub.calledTwice).to.be.true;
+      expectDefaultUsernameHasChangeTracking(true, executeCommandStub);
+      expectDefaultUsernameHasNoChangeTracking(true, executeCommandStub);
+    } finally {
+      getConfigStub.restore();
+      aliasesSpy.restore();
+      executeCommandStub.restore();
+      authInfoStub.restore();
+    }
   });
 });
 

--- a/packages/salesforcedx-vscode-core/test/context/workspaceOrgType.test.ts
+++ b/packages/salesforcedx-vscode-core/test/context/workspaceOrgType.test.ts
@@ -258,21 +258,28 @@ describe('setupWorkspaceOrgType', () => {
     executeCommandStub.restore();
   });
 
-  it('should set both sfdx:default_username_has_change_tracking and sfdx:default_username_has_no_change_tracking contexts to false for cli config error', async () => {
-    const getConfigStub = getGetConfigStub(new Map());
+  it('should set both sfdx:default_username_has_change_tracking and sfdx:default_username_has_no_change_tracking contexts to true for cli config error', async () => {
     const aliasesSpy = sinon.spy(Aliases, 'fetch');
     const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
 
+    const username = 'test@org.com';
+    const getConfigStub = getGetConfigStub(
+      new Map([['defaultusername', username]])
+    );
+    expect(await getDefaultUsernameOrAlias()).to.equal(username);
+
     const error = new Error();
     error.name = 'GenericKeychainServiceError';
+    error.stack =
+      'GenericKeychainServiceError: The service and acount specified in key.json do not match the version of the toolbelt ...';
     const authInfoStub = sinon.stub(AuthInfo, 'create').throws(error);
 
     await setupWorkspaceOrgType();
 
     expect(aliasesSpy.called).to.be.false;
     expect(executeCommandStub.calledTwice).to.be.true;
-    expectDefaultUsernameHasChangeTracking(false, executeCommandStub);
-    expectDefaultUsernameHasNoChangeTracking(false, executeCommandStub);
+    expectDefaultUsernameHasChangeTracking(true, executeCommandStub);
+    expectDefaultUsernameHasNoChangeTracking(true, executeCommandStub);
 
     getConfigStub.restore();
     aliasesSpy.restore();

--- a/packages/salesforcedx-vscode-core/test/context/workspaceOrgType.test.ts
+++ b/packages/salesforcedx-vscode-core/test/context/workspaceOrgType.test.ts
@@ -134,6 +134,35 @@ describe('getWorkspaceOrgType', () => {
       authInfoStub.restore();
     }
   });
+
+  it('throws an error when the cli has no configuration', async () => {
+    const getConfigStub = getGetConfigStub(
+      new Map([['defaultusername', 'testUsername']])
+    );
+    const aliasesStub = getAliasesFetchStub('test@org.com');
+
+    const error = new Error();
+    error.name = 'GenericKeychainServiceError';
+    error.stack =
+      'GenericKeychainServiceError: The service and acount specified in key.json do not match the version of the toolbelt ...';
+    const authInfoStub = sinon.stub(AuthInfo, 'create').throws(error);
+
+    let errorWasThrown = false;
+    try {
+      await getWorkspaceOrgType();
+    } catch (error) {
+      errorWasThrown = true;
+      expect(error.name).to.equal('GenericKeychainServiceError');
+      expect(error.stack).to.equal(
+        'GenericKeychainServiceError: The service and acount specified in key.json do not match the version of the toolbelt ...'
+      );
+    } finally {
+      expect(errorWasThrown).to.be.true;
+      getConfigStub.restore();
+      aliasesStub.restore();
+      authInfoStub.restore();
+    }
+  });
 });
 
 describe('setupWorkspaceOrgType', () => {
@@ -227,6 +256,28 @@ describe('setupWorkspaceOrgType', () => {
     aliasesStub.restore();
     authInfoCreateStub.restore();
     executeCommandStub.restore();
+  });
+
+  it('should set both sfdx:default_username_has_change_tracking and sfdx:default_username_has_no_change_tracking contexts to false for cli config error', async () => {
+    const getConfigStub = getGetConfigStub(new Map());
+    const aliasesSpy = sinon.spy(Aliases, 'fetch');
+    const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
+
+    const error = new Error();
+    error.name = 'GenericKeychainServiceError';
+    const authInfoStub = sinon.stub(AuthInfo, 'create').throws(error);
+
+    await setupWorkspaceOrgType();
+
+    expect(aliasesSpy.called).to.be.false;
+    expect(executeCommandStub.calledTwice).to.be.true;
+    expectDefaultUsernameHasChangeTracking(false, executeCommandStub);
+    expectDefaultUsernameHasNoChangeTracking(false, executeCommandStub);
+
+    getConfigStub.restore();
+    aliasesSpy.restore();
+    executeCommandStub.restore();
+    authInfoStub.restore();
   });
 });
 


### PR DESCRIPTION
### What does this PR do?
Fixes current salesforce-vscode-core issue during activation when the cli throws errors like `GenericKeychainServiceError: The service and acount specified in key.json do not match the version of the toolbelt ...`

### What issues does this PR fix or reference?
#742 , [W-5767373](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000005jRQwIAM/view)