### PR TITLE
Refactor to enable “strictPropertyInitialization" typescript rule

### DIFF
--- a/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
+++ b/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
@@ -123,10 +123,10 @@ export interface SetExceptionBreakpointsArguments {
 export class ApexDebugStackFrameInfo {
   public readonly requestId: string;
   public readonly frameNumber: number;
-  public globals: Value[];
-  public statics: Value[];
-  public locals: LocalValue[];
-  public references: Reference[];
+  public globals: Value[] = [];
+  public statics: Value[] = [];
+  public locals: LocalValue[] = [];
+  public references: Reference[] = [];
   constructor(requestId: string, frameNumber: number) {
     this.requestId = requestId;
     this.frameNumber = frameNumber;
@@ -528,10 +528,10 @@ export class MapTupleContainer implements VariableContainer {
 
 export class ApexDebug extends LoggingDebugSession {
   protected myRequestService = new RequestService();
-  protected mySessionService: SessionService;
-  protected myBreakpointService: BreakpointService;
+  protected mySessionService!: SessionService;
+  protected myBreakpointService!: BreakpointService;
   protected myStreamingService = StreamingService.getInstance();
-  protected sfdxProject: string;
+  protected sfdxProject: string = '';
   protected requestThreads: Map<number, string>;
   protected threadId: number;
 
@@ -540,7 +540,7 @@ export class ApexDebug extends LoggingDebugSession {
   protected variableContainerReferenceByApexId = new Map<number, number>();
 
   private static LINEBREAK = `${os.EOL}`;
-  private initializedResponse: DebugProtocol.InitializeResponse;
+  private initializedResponse: DebugProtocol.InitializeResponse | undefined;
 
   private trace: string[] | undefined;
   private traceAll = false;

--- a/packages/salesforcedx-apex-debugger/src/core/sessionService.ts
+++ b/packages/salesforcedx-apex-debugger/src/core/sessionService.ts
@@ -99,7 +99,7 @@ export class SessionService {
       new SfdxCommandBuilder()
         .withArg('force:data:record:update')
         .withFlag('--sobjecttype', 'ApexDebuggerSession')
-        .withFlag('--sobjectid', this.sessionId || '')
+        .withFlag('--sobjectid', this.sessionId)
         .withFlag('--values', "Status='Detach'")
         .withArg('--usetoolingapi')
         .withJson()

--- a/packages/salesforcedx-apex-debugger/src/core/sessionService.ts
+++ b/packages/salesforcedx-apex-debugger/src/core/sessionService.ts
@@ -13,11 +13,11 @@ import {
 import { RequestService } from '@salesforce/salesforcedx-utils-vscode/out/src/requestService';
 
 export class SessionService {
-  private userFilter: string;
-  private requestFilter: string;
-  private entryFilter: string;
-  private project: string;
-  private sessionId: string;
+  private userFilter: string = '';
+  private requestFilter: string = '';
+  private entryFilter: string = '';
+  private project: string = '';
+  private sessionId: string = '';
   private connected = false;
   private readonly requestService: RequestService;
 
@@ -99,7 +99,7 @@ export class SessionService {
       new SfdxCommandBuilder()
         .withArg('force:data:record:update')
         .withFlag('--sobjecttype', 'ApexDebuggerSession')
-        .withFlag('--sobjectid', this.sessionId)
+        .withFlag('--sobjectid', this.sessionId || '')
         .withFlag('--values', "Status='Detach'")
         .withArg('--usetoolingapi')
         .withJson()

--- a/packages/salesforcedx-apex-debugger/src/core/streamingClient.ts
+++ b/packages/salesforcedx-apex-debugger/src/core/streamingClient.ts
@@ -69,12 +69,12 @@ export class StreamingClientInfo {
 }
 
 export class StreamingClientInfoBuilder {
-  public channel: string;
-  public timeout: number;
-  public errorHandler: (reason: string) => void;
-  public connectedHandler: () => void;
-  public disconnectedHandler: () => void;
-  public messageHandler: (message: any) => void;
+  public channel: string = '';
+  public timeout: number = DEFAULT_STREAMING_TIMEOUT_MS;
+  public errorHandler: (reason: string) => void = () => {};
+  public connectedHandler: () => void = () => {};
+  public disconnectedHandler: () => void = () => {};
+  public messageHandler: (message: any) => void = () => {};
 
   public forChannel(channel: string): StreamingClientInfoBuilder {
     this.channel = channel;

--- a/packages/salesforcedx-apex-debugger/src/core/streamingService.ts
+++ b/packages/salesforcedx-apex-debugger/src/core/streamingService.ts
@@ -18,8 +18,8 @@ export class StreamingService {
   public static DEFAULT_TIMEOUT = 14400;
   private static instance: StreamingService;
   private readonly apiVersion = '41.0';
-  private systemEventClient: StreamingClient;
-  private userEventClient: StreamingClient;
+  private systemEventClient!: StreamingClient;
+  private userEventClient!: StreamingClient;
 
   public static getInstance() {
     if (!StreamingService.instance) {
@@ -100,7 +100,7 @@ export class StreamingService {
     return Promise.resolve(this.isReady());
   }
 
-  private removeTrailingSlashURL(instanceUrl: string) {
+  private removeTrailingSlashURL(instanceUrl = '') {
     return instanceUrl ? instanceUrl.replace(/\/+$/, '') : '';
   }
 

--- a/packages/salesforcedx-apex-debugger/src/core/streamingService.ts
+++ b/packages/salesforcedx-apex-debugger/src/core/streamingService.ts
@@ -100,7 +100,7 @@ export class StreamingService {
     return Promise.resolve(this.isReady());
   }
 
-  private removeTrailingSlashURL(instanceUrl = '') {
+  private removeTrailingSlashURL(instanceUrl: string | undefined) {
     return instanceUrl ? instanceUrl.replace(/\/+$/, '') : '';
   }
 

--- a/packages/salesforcedx-apex-debugger/test/unit/core/sessionService.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/core/sessionService.test.ts
@@ -142,7 +142,7 @@ describe('Debugger session service', () => {
           '{"message":"There was an error", "action":"Try again"}'
         );
         expect(service.isConnected()).to.equal(false);
-        expect(service.getSessionId()).to.an('undefined');
+        expect(service.getSessionId()).to.equal('');
       }
     });
   });
@@ -224,7 +224,7 @@ describe('Debugger session service', () => {
       } catch (error) {
         expect(error).to.equal('{"result":{"id":"FAKE"}}');
         expect(service.isConnected()).to.equal(true);
-        expect(service.getSessionId()).to.an('undefined');
+        expect(service.getSessionId()).to.equal('');
       }
     });
 
@@ -237,7 +237,7 @@ describe('Debugger session service', () => {
       } catch (error) {
         expect(error).to.equal('{"result":{"notid":"FAKE"}}');
         expect(service.isConnected()).to.equal(true);
-        expect(service.getSessionId()).to.an('undefined');
+        expect(service.getSessionId()).to.equal('');
       }
     });
 
@@ -258,7 +258,7 @@ describe('Debugger session service', () => {
           '{"message":"There was an error", "action":"Try again"}'
         );
         expect(service.isConnected()).to.equal(false);
-        expect(service.getSessionId()).to.an('undefined');
+        expect(service.getSessionId()).to.equal('');
       }
     });
 

--- a/packages/salesforcedx-apex-debugger/tsconfig.json
+++ b/packages/salesforcedx-apex-debugger/tsconfig.json
@@ -10,8 +10,7 @@
     "rootDir": ".",
     "outDir": "out",
     "preserveConstEnums": true,
-    "strict": true,
-    "strictPropertyInitialization": true
+    "strict": true
   },
   "exclude": ["node_modules", ".vscode-test", "out"]
 }

--- a/packages/salesforcedx-apex-debugger/tsconfig.json
+++ b/packages/salesforcedx-apex-debugger/tsconfig.json
@@ -11,7 +11,7 @@
     "outDir": "out",
     "preserveConstEnums": true,
     "strict": true,
-    "strictPropertyInitialization": false
+    "strictPropertyInitialization": true
   },
   "exclude": ["node_modules", ".vscode-test", "out"]
 }

--- a/packages/salesforcedx-apex-replay-debugger/src/adapter/apexReplayDebug.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/adapter/apexReplayDebug.ts
@@ -203,11 +203,11 @@ export class ScopeContainer extends VariableContainer {
 
 export class ApexReplayDebug extends LoggingDebugSession {
   public static THREAD_ID = 1;
-  protected logContext: LogContext;
-  protected heapDumpService: HeapDumpService;
+  protected logContext!: LogContext;
+  protected heapDumpService!: HeapDumpService;
   protected trace: string[] = [];
   protected traceAll = false;
-  private initializedResponse: DebugProtocol.InitializeResponse;
+  private initializedResponse!: DebugProtocol.InitializeResponse;
   protected breakpoints: Map<string, number[]> = new Map();
   protected projectPath: string | undefined;
 

--- a/packages/salesforcedx-apex-replay-debugger/tsconfig.json
+++ b/packages/salesforcedx-apex-replay-debugger/tsconfig.json
@@ -10,8 +10,7 @@
     "rootDir": ".",
     "outDir": "out",
     "preserveConstEnums": true,
-    "strict": true,
-    "strictPropertyInitialization": true
+    "strict": true
   },
   "exclude": ["node_modules", ".vscode-test", "out"]
 }

--- a/packages/salesforcedx-apex-replay-debugger/tsconfig.json
+++ b/packages/salesforcedx-apex-replay-debugger/tsconfig.json
@@ -11,7 +11,7 @@
     "outDir": "out",
     "preserveConstEnums": true,
     "strict": true,
-    "strictPropertyInitialization": false
+    "strictPropertyInitialization": true
   },
   "exclude": ["node_modules", ".vscode-test", "out"]
 }

--- a/packages/salesforcedx-sobjects-faux-generator/src/describe/sObjectDescribe.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/describe/sObjectDescribe.ts
@@ -171,8 +171,8 @@ type SubResponse = { statusCode: number; result: SObject };
 type BatchResponse = { hasErrors: boolean; results: SubResponse[] };
 
 export class SObjectDescribe {
-  private accessToken: string;
-  private instanceUrl: string;
+  private accessToken: string | undefined;
+  private instanceUrl: string | undefined;
   private readonly servicesPath: string = 'services/data';
   // the targetVersion should be consistent with the Cli even if only using REST calls
   private targetVersion = '';

--- a/packages/salesforcedx-sobjects-faux-generator/tsconfig.json
+++ b/packages/salesforcedx-sobjects-faux-generator/tsconfig.json
@@ -10,8 +10,7 @@
     "rootDir": ".",
     "outDir": "out",
     "preserveConstEnums": true,
-    "strict": true,
-    "strictPropertyInitialization": true
+    "strict": true
   },
   "exclude": ["node_modules", "out"]
 }

--- a/packages/salesforcedx-sobjects-faux-generator/tsconfig.json
+++ b/packages/salesforcedx-sobjects-faux-generator/tsconfig.json
@@ -11,7 +11,7 @@
     "outDir": "out",
     "preserveConstEnums": true,
     "strict": true,
-    "strictPropertyInitialization": false
+    "strictPropertyInitialization": true
   },
   "exclude": ["node_modules", "out"]
 }

--- a/packages/salesforcedx-utils-vscode/src/requestService/requestService.ts
+++ b/packages/salesforcedx-utils-vscode/src/requestService/requestService.ts
@@ -25,12 +25,12 @@ export enum RestHttpMethodEnum {
 }
 
 export class RequestService {
-  private _instanceUrl: string;
-  private _accessToken: string;
-  private _proxyUrl: string;
-  private _proxyStrictSSL: boolean;
-  private _proxyAuthorization: string;
-  private _connectionTimeoutMs: number;
+  private _instanceUrl: string | undefined;
+  private _accessToken: string = '';
+  private _proxyUrl: string | undefined;
+  private _proxyStrictSSL: boolean = false;
+  private _proxyAuthorization: string = '';
+  private _connectionTimeoutMs: number = DEFAULT_CONNECTION_TIMEOUT_MS;
 
   public getEnvVars(): any {
     const envVars = Object.assign({}, process.env);
@@ -50,11 +50,11 @@ export class RequestService {
     return envVars;
   }
 
-  public get instanceUrl(): string {
+  public get instanceUrl(): string | undefined {
     return this._instanceUrl;
   }
 
-  public set instanceUrl(instanceUrl: string) {
+  public set instanceUrl(instanceUrl: string | undefined) {
     this._instanceUrl = instanceUrl;
   }
 
@@ -66,11 +66,11 @@ export class RequestService {
     this._accessToken = accessToken;
   }
 
-  public get proxyUrl(): string {
+  public get proxyUrl(): string | undefined {
     return this._proxyUrl;
   }
 
-  public set proxyUrl(proxyUrl: string) {
+  public set proxyUrl(proxyUrl: string | undefined) {
     this._proxyUrl = proxyUrl;
   }
 
@@ -104,7 +104,7 @@ export class RequestService {
     restHttpMethodEnum: RestHttpMethodEnum = RestHttpMethodEnum.Post
   ): Promise<string> {
     if (this.proxyUrl) {
-      configure(this._proxyUrl, this._proxyStrictSSL);
+      configure(this._proxyUrl || '', this._proxyStrictSSL);
     }
     const urlElements = [this.instanceUrl, command.getCommandUrl()];
     const requestUrl =

--- a/packages/salesforcedx-utils-vscode/tsconfig.json
+++ b/packages/salesforcedx-utils-vscode/tsconfig.json
@@ -10,8 +10,7 @@
     "rootDir": ".",
     "outDir": "out",
     "preserveConstEnums": true,
-    "strict": true,
-    "strictPropertyInitialization": true
+    "strict": true
   },
   "exclude": ["node_modules", "out"]
 }

--- a/packages/salesforcedx-utils-vscode/tsconfig.json
+++ b/packages/salesforcedx-utils-vscode/tsconfig.json
@@ -11,7 +11,7 @@
     "outDir": "out",
     "preserveConstEnums": true,
     "strict": true,
-    "strictPropertyInitialization": false
+    "strictPropertyInitialization": true
   },
   "exclude": ["node_modules", "out"]
 }

--- a/packages/salesforcedx-visualforce-language-server/tsconfig.json
+++ b/packages/salesforcedx-visualforce-language-server/tsconfig.json
@@ -8,8 +8,7 @@
     "moduleResolution": "node",
     "rootDir": ".",
     "outDir": "out",
-    "preserveConstEnums": true,
-    "strictPropertyInitialization": false
+    "preserveConstEnums": true
   },
   "exclude": ["node_modules", ".vscode-test", "out"]
 }

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/breakpoints/checkpointService.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/breakpoints/checkpointService.ts
@@ -78,7 +78,7 @@ export class CheckpointService implements TreeDataProvider<BaseNode> {
     BaseNode | undefined
   > = new EventEmitter<BaseNode | undefined>();
   private myRequestService: RequestService;
-  private orgInfo: OrgInfo;
+  private orgInfo!: OrgInfo;
   private sfdxProject: string | null = null;
 
   public readonly onDidChangeTreeData: Event<BaseNode | undefined> = this

--- a/packages/salesforcedx-vscode-apex-replay-debugger/tsconfig.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/tsconfig.json
@@ -10,8 +10,7 @@
     "rootDir": ".",
     "outDir": "out",
     "preserveConstEnums": true,
-    "strict": true,
-    "strictPropertyInitialization": true
+    "strict": true
   },
   "exclude": ["node_modules", ".vscode-test", "out"]
 }

--- a/packages/salesforcedx-vscode-apex-replay-debugger/tsconfig.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/tsconfig.json
@@ -11,7 +11,7 @@
     "outDir": "out",
     "preserveConstEnums": true,
     "strict": true,
-    "strictPropertyInitialization": false
+    "strictPropertyInitialization": true
   },
   "exclude": ["node_modules", ".vscode-test", "out"]
 }

--- a/packages/salesforcedx-vscode-core/src/commands/forceApexTestRun.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexTestRun.ts
@@ -87,7 +87,7 @@ export class ForceApexTestRunCommandFactory {
   private data: ApexTestQuickPickItem;
   private getCodeCoverage: boolean;
   private builder: SfdxCommandBuilder = new SfdxCommandBuilder();
-  private testRunExecutorCommand: Command;
+  private testRunExecutorCommand!: Command;
   private outputToJson: string;
 
   constructor(

--- a/packages/salesforcedx-vscode-core/src/statuses/taskView.ts
+++ b/packages/salesforcedx-vscode-core/src/statuses/taskView.ts
@@ -88,9 +88,6 @@ export class TaskViewService implements TreeDataProvider<Task> {
 }
 
 export class Task extends TreeItem {
-  public readonly label: string;
-  public readonly collapsibleState: TreeItemCollapsibleState;
-
   private readonly taskViewProvider: TaskViewService;
   private readonly execution: CommandExecution;
   private readonly cancellationTokenSource?: CancellationTokenSource;

--- a/packages/salesforcedx-vscode-core/test/telemetry/MockContext.ts
+++ b/packages/salesforcedx-vscode-core/test/telemetry/MockContext.ts
@@ -31,7 +31,7 @@ export class MockContext implements ExtensionContext {
     this.globalState = new MockMemento(mm);
   }
   public subscriptions: Array<{ dispose(): any }> = [];
-  public workspaceState: Memento;
+  public workspaceState!: Memento;
   public globalState: Memento;
   public extensionPath: string = 'myExtensionPath';
   public asAbsolutePath(relativePath: string): string {

--- a/packages/salesforcedx-vscode-core/tsconfig.json
+++ b/packages/salesforcedx-vscode-core/tsconfig.json
@@ -10,8 +10,7 @@
     "rootDir": ".",
     "outDir": "out",
     "preserveConstEnums": true,
-    "strict": true,
-    "strictPropertyInitialization": true
+    "strict": true
   },
   "exclude": ["node_modules", ".vscode-test", "out"]
 }

--- a/packages/salesforcedx-vscode-core/tsconfig.json
+++ b/packages/salesforcedx-vscode-core/tsconfig.json
@@ -11,7 +11,7 @@
     "outDir": "out",
     "preserveConstEnums": true,
     "strict": true,
-    "strictPropertyInitialization": false
+    "strictPropertyInitialization": true
   },
   "exclude": ["node_modules", ".vscode-test", "out"]
 }

--- a/packages/system-tests/assets/sfdx-simple/.vscode/settings.json
+++ b/packages/system-tests/assets/sfdx-simple/.vscode/settings.json
@@ -1,3 +1,12 @@
 {
-  "extensions.autoUpdate": false
+  "extensions.autoUpdate": false,
+  "terminal.integrated.env.osx": {
+    "SFDX_SET_CLIENT_IDS": "sfdx-vscode"
+  },
+  "terminal.integrated.env.linux": {
+    "SFDX_SET_CLIENT_IDS": "sfdx-vscode"
+  },
+  "terminal.integrated.env.windows": {
+    "SFDX_SET_CLIENT_IDS": "sfdx-vscode"
+  }
 }

--- a/packages/system-tests/assets/sfdx-simple/.vscode/settings.json
+++ b/packages/system-tests/assets/sfdx-simple/.vscode/settings.json
@@ -1,12 +1,3 @@
 {
-  "extensions.autoUpdate": false,
-  "terminal.integrated.env.osx": {
-    "SFDX_SET_CLIENT_IDS": "sfdx-vscode"
-  },
-  "terminal.integrated.env.linux": {
-    "SFDX_SET_CLIENT_IDS": "sfdx-vscode"
-  },
-  "terminal.integrated.env.windows": {
-    "SFDX_SET_CLIENT_IDS": "sfdx-vscode"
-  }
+  "extensions.autoUpdate": false
 }


### PR DESCRIPTION
### What does this PR do?

After the upgrade to TypeScript 3, the strictPropertyInitialization flag had to be disabled.  This PR enables that flag, and attempts to fix the issues in the source code.

* set tsconfig compiler flag ```strictPropertyInitialization:true```
* initialize the variable depending on how it was used.  
    * If it was string or boolean and seemed to be harmless, I initialized it to empty string or false.  
    * If it had logic that checked for undefined I modify it’s type with ``` string | undefined ```.  
    * For more complex object or service I had to use the definite assignment assertion (!).

Each of these approaches was described here: 
https://blog.mariusschulz.com/2018/05/20/typescript-2-7-strict-property-initialization

### What issues does this PR fix or reference?

Resolves: W-5676805
See: W-5552627, https://github.com/forcedotcom/salesforcedx-vscode/pull/793
