### PR TITLE
Refactor to enable no-floating-promises typescript rule

### DIFF
--- a/packages/salesforcedx-apex-debugger/test/integration/adapter.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/integration/adapter.test.ts
@@ -115,7 +115,7 @@ describe.skip('Interactive debugger adapter - integration', function() {
     }
     rimraf.sync(projectPath);
     if (dc) {
-      dc.stop();
+      await dc.stop();
     }
   });
 

--- a/packages/salesforcedx-apex-replay-debugger/test/integration/adapter.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/integration/adapter.test.ts
@@ -148,9 +148,8 @@ describe('Replay debugger adapter - integration', function() {
         classBPath,
         classBValidLines
       );
-
-      await dc.configurationDoneRequest({});
-
+      // tslint:disable-next-line:no-floating-promises
+      dc.configurationDoneRequest({});
       // Verify stopped on the first line of debug log
       const stackTraceResponse = await dc.assertStoppedLocation('entry', {
         path: logFilePath,
@@ -234,7 +233,8 @@ describe('Replay debugger adapter - integration', function() {
         classStaticVarsAValidLines
       );
 
-      await dc.configurationDoneRequest({});
+      // tslint:disable-next-line:no-floating-promises
+      dc.configurationDoneRequest({});
 
       // Verify stopped on the first line of debug log
       const stackTraceResponse = await dc.assertStoppedLocation('entry', {
@@ -251,6 +251,7 @@ describe('Replay debugger adapter - integration', function() {
         classStaticVarsAPath,
         classStaticVarsAValidLines[0]
       );
+
     } finally {
       const disconnectResponse = await dc.disconnectRequest({});
       expect(disconnectResponse.success).to.equal(true);

--- a/packages/salesforcedx-apex-replay-debugger/test/integration/adapter.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/integration/adapter.test.ts
@@ -56,7 +56,7 @@ describe('Replay debugger adapter - integration', function() {
 
   after(async () => {
     if (dc) {
-      dc.stop();
+      await dc.stop();
     }
   });
 
@@ -149,7 +149,7 @@ describe('Replay debugger adapter - integration', function() {
         classBValidLines
       );
 
-      dc.configurationDoneRequest({});
+      await dc.configurationDoneRequest({});
 
       // Verify stopped on the first line of debug log
       const stackTraceResponse = await dc.assertStoppedLocation('entry', {
@@ -234,7 +234,7 @@ describe('Replay debugger adapter - integration', function() {
         classStaticVarsAValidLines
       );
 
-      dc.configurationDoneRequest({});
+      await dc.configurationDoneRequest({});
 
       // Verify stopped on the first line of debug log
       const stackTraceResponse = await dc.assertStoppedLocation('entry', {

--- a/packages/salesforcedx-vscode-apex-debugger/test/vscode-integration/telemetry/telemetry.test.ts
+++ b/packages/salesforcedx-vscode-apex-debugger/test/vscode-integration/telemetry/telemetry.test.ts
@@ -17,9 +17,9 @@ describe('Telemetry', () => {
     sendEvent = stub(reporter, 'sendTelemetryEvent');
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     sendEvent.restore();
-    reporter.dispose();
+    await reporter.dispose();
   });
 
   it('Should send telemetry data', async () => {

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/vscode-integration/telemetry/telemetry.test.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/vscode-integration/telemetry/telemetry.test.ts
@@ -17,9 +17,9 @@ describe('Telemetry', () => {
     sendEvent = stub(reporter, 'sendTelemetryEvent');
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     sendEvent.restore();
-    reporter.dispose();
+    await reporter.dispose();
   });
 
   it('Should send telemetry data', async () => {

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/telemetry/telemetry.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/telemetry/telemetry.test.ts
@@ -17,9 +17,9 @@ describe('Telemetry', () => {
     sendEvent = stub(reporter, 'sendTelemetryEvent');
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     sendEvent.restore();
-    reporter.dispose();
+    await reporter.dispose();
   });
 
   it('Should send telemetry data', async () => {

--- a/packages/salesforcedx-vscode-lightning/test/vscode-integration/telemetry/telemetry.test.ts
+++ b/packages/salesforcedx-vscode-lightning/test/vscode-integration/telemetry/telemetry.test.ts
@@ -21,9 +21,9 @@ describe('Telemetry', () => {
     sendEvent = stub(reporter, 'sendTelemetryEvent');
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     sendEvent.restore();
-    reporter.dispose();
+    await reporter.dispose();
   });
 
   it('Should send telemetry data', async () => {

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/telemetry/telemetry.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/telemetry/telemetry.test.ts
@@ -17,9 +17,9 @@ describe('Telemetry', () => {
     sendEvent = stub(reporter, 'sendTelemetryEvent');
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     sendEvent.restore();
-    reporter.dispose();
+    await reporter.dispose();
   });
 
   it('Should send telemetry data', async () => {

--- a/packages/salesforcedx-vscode-visualforce/src/extension.ts
+++ b/packages/salesforcedx-vscode-visualforce/src/extension.ts
@@ -106,7 +106,7 @@ export async function activate(context: ExtensionContext) {
 
   let disposable = client.start();
   toDispose.push(disposable);
-  client.onReady().then(() => {
+  await client.onReady().then(() => {
     disposable = languages.registerColorProvider(documentSelector, {
       provideDocumentColors(
         document: TextDocument

--- a/packages/salesforcedx-vscode-visualforce/src/extension.ts
+++ b/packages/salesforcedx-vscode-visualforce/src/extension.ts
@@ -106,79 +106,86 @@ export async function activate(context: ExtensionContext) {
 
   let disposable = client.start();
   toDispose.push(disposable);
-  await client.onReady().then(() => {
-    disposable = languages.registerColorProvider(documentSelector, {
-      provideDocumentColors(
-        document: TextDocument
-      ): Thenable<ColorInformation[]> {
-        const params: DocumentColorParams = {
-          textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(
-            document
-          )
-        };
-        return client
-          .sendRequest(DocumentColorRequest.type, params)
-          .then(symbols => {
-            return symbols.map(symbol => {
-              const range = client.protocol2CodeConverter.asRange(symbol.range);
-              const color = new Color(
-                symbol.color.red,
-                symbol.color.green,
-                symbol.color.blue,
-                symbol.color.alpha
-              );
-              return new ColorInformation(range, color);
-            });
-          });
-      },
-      provideColorPresentations(
-        document: TextDocument,
-        colorInfo: ColorInformation
-      ): Thenable<ColorPresentation[]> {
-        const params: ColorPresentationParams = {
-          textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(
-            document
-          ),
-          colorInfo: {
-            range: client.code2ProtocolConverter.asRange(colorInfo.range),
-            color: colorInfo.color
-          }
-        };
-        return client
-          .sendRequest(ColorPresentationRequest.type, params)
-          .then(presentations => {
-            return presentations.map(p => {
-              const presentation = new ColorPresentation(p.label);
-              presentation.textEdit =
-                p.textEdit &&
-                client.protocol2CodeConverter.asTextEdit(p.textEdit);
-              presentation.additionalTextEdits =
-                p.additionalTextEdits &&
-                client.protocol2CodeConverter.asTextEdits(
-                  p.additionalTextEdits
+  client
+    .onReady()
+    .then(() => {
+      disposable = languages.registerColorProvider(documentSelector, {
+        provideDocumentColors(
+          document: TextDocument
+        ): Thenable<ColorInformation[]> {
+          const params: DocumentColorParams = {
+            textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(
+              document
+            )
+          };
+          return client
+            .sendRequest(DocumentColorRequest.type, params)
+            .then(symbols => {
+              return symbols.map(symbol => {
+                const range = client.protocol2CodeConverter.asRange(
+                  symbol.range
                 );
-              return presentation;
+                const color = new Color(
+                  symbol.color.red,
+                  symbol.color.green,
+                  symbol.color.blue,
+                  symbol.color.alpha
+                );
+                return new ColorInformation(range, color);
+              });
             });
-          });
-      }
-    });
-    toDispose.push(disposable);
+        },
+        provideColorPresentations(
+          document: TextDocument,
+          colorInfo: ColorInformation
+        ): Thenable<ColorPresentation[]> {
+          const params: ColorPresentationParams = {
+            textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(
+              document
+            ),
+            colorInfo: {
+              range: client.code2ProtocolConverter.asRange(colorInfo.range),
+              color: colorInfo.color
+            }
+          };
+          return client
+            .sendRequest(ColorPresentationRequest.type, params)
+            .then(presentations => {
+              return presentations.map(p => {
+                const presentation = new ColorPresentation(p.label);
+                presentation.textEdit =
+                  p.textEdit &&
+                  client.protocol2CodeConverter.asTextEdit(p.textEdit);
+                presentation.additionalTextEdits =
+                  p.additionalTextEdits &&
+                  client.protocol2CodeConverter.asTextEdits(
+                    p.additionalTextEdits
+                  );
+                return presentation;
+              });
+            });
+        }
+      });
+      toDispose.push(disposable);
 
-    const tagRequestor = (document: TextDocument, position: Position) => {
-      const param = client.code2ProtocolConverter.asTextDocumentPositionParams(
-        document,
-        position
+      const tagRequestor = (document: TextDocument, position: Position) => {
+        const param = client.code2ProtocolConverter.asTextDocumentPositionParams(
+          document,
+          position
+        );
+        return client.sendRequest(TagCloseRequest.type, param);
+      };
+      disposable = activateTagClosing(
+        tagRequestor,
+        { visualforce: true },
+        'visualforce.autoClosingTags'
       );
-      return client.sendRequest(TagCloseRequest.type, param);
-    };
-    disposable = activateTagClosing(
-      tagRequestor,
-      { visualforce: true },
-      'visualforce.autoClosingTags'
-    );
-    toDispose.push(disposable);
-  });
-
+      toDispose.push(disposable);
+    })
+    .catch(err => {
+      // Handled by clients
+      telemetryService.sendExtensionActivationEvent(err);
+    });
   languages.setLanguageConfiguration('visualforce', {
     indentationRules: {
       increaseIndentPattern: /<(?!\?|(?:area|base|br|col|frame|hr|html|img|input|link|meta|param)\b|[^>]*\/>)([-_\.A-Za-z0-9]+)(?=\s|>)\b[^>]*>(?!.*<\/\1>)|<!--(?!.*-->)|\{[^}"']*$/,

--- a/packages/salesforcedx-vscode-visualforce/test/vscode-integration/telemetry/telemetry.test.ts
+++ b/packages/salesforcedx-vscode-visualforce/test/vscode-integration/telemetry/telemetry.test.ts
@@ -17,9 +17,9 @@ describe('Telemetry', () => {
     sendEvent = stub(reporter, 'sendTelemetryEvent');
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     sendEvent.restore();
-    reporter.dispose();
+    await reporter.dispose();
   });
 
   it('Should send telemetry data', async () => {

--- a/tslint.json
+++ b/tslint.json
@@ -7,6 +7,6 @@
     "member-ordering": false,
     "no-string-based-set-timeout": false,
     "semicolon": [true, "always", "ignore-bound-class-methods"],
-    "no-floating-promises": false
+    "no-floating-promises": true
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -6,7 +6,6 @@
     "quotemark": [true, "single", "avoid-escape"],
     "member-ordering": false,
     "no-string-based-set-timeout": false,
-    "semicolon": [true, "always", "ignore-bound-class-methods"],
-    "no-floating-promises": true
+    "semicolon": [true, "always", "ignore-bound-class-methods"]
   }
 }


### PR DESCRIPTION
### What does this PR do?
- removes "no-floating-promises" key in tslint.json. TSlint should check this by default
- adds await to functions throughout the project that are flagged by tslint
- ignores 2 linter issues that should not have been flagged 

### What issues does this PR fix or reference?
W-5676815 - Refactor non-debugger vscode extensions to conform to "no-floating-promises" tslint rule