### PR TITLE
Fix debug log filename being set to '07Lxxxxxxxxxxxxxxx_Invalid date.…

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceApexLogGet.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexLogGet.ts
@@ -116,6 +116,7 @@ export type ApexDebugLogObject = {
 
 interface ApexDebugLogItem extends vscode.QuickPickItem {
   id: string;
+  startTime: string;
 }
 
 export class LogFileSelector
@@ -131,6 +132,9 @@ export class LogFileSelector
         return {
           id: logInfo.Id,
           label: icon + logInfo.LogUser.Name + ' - ' + logInfo.Operation,
+          startTime: moment(new Date(logInfo.StartTime)).format(
+            'M/DD/YYYY, h:mm:s a'
+          ),
           detail:
             moment(new Date(logInfo.StartTime)).format('M/DD/YYYY, h:mm:s a') +
             ' - ' +
@@ -146,7 +150,7 @@ export class LogFileSelector
       if (logItem) {
         return {
           type: 'CONTINUE',
-          data: { id: logItem.id, startTime: logItem.detail! }
+          data: { id: logItem.id, startTime: logItem.startTime! }
         };
       }
     } else {


### PR DESCRIPTION
…log'

### What does this PR do?
Fixes the Debug Log filename containing `Invalid date` as part of it. This was introduced was part of the fix to enrich the Debug Log list data.

### What issues does this PR fix or reference?
@W-5714727@