### PR TITLE
Split Apex and Anon Apex languages

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -184,13 +184,25 @@
       {
         "id": "apex",
         "aliases": ["Apex", "apex"],
-        "extensions": [".cls", ".trigger", ".apex"],
+        "extensions": [".cls", ".trigger"],
+        "configuration": "./syntaxes/apex.configuration.json"
+      },
+      {
+        "id": "apex-anon",
+        "aliases": ["Anonymous Apex"],
+        "extensions": [".apex"],
         "configuration": "./syntaxes/apex.configuration.json"
       }
     ],
     "grammars": [
       {
         "language": "apex",
+        "scopeName": "source.apex",
+        "path":
+          "./node_modules/@salesforce/apex-tmlanguage/grammars/apex.tmLanguage"
+      },
+      {
+        "language": "apex-anon",
         "scopeName": "source.apex",
         "path":
           "./node_modules/@salesforce/apex-tmlanguage/grammars/apex.tmLanguage"


### PR DESCRIPTION
### What does this PR do?
Splits apex (`.cls` and `.trigger` files) from anon apex (`.apex` files) so that the `.apex` files only get the grammar and not the language server - which doesn't work on anon apex anyway.

### What issues does this PR fix or reference?
Part of #929 
