### PR TITLE
Clear errors in problem view until next deploy finishes

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploy.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploy.ts
@@ -15,12 +15,6 @@ import { handleDiagnosticErrors } from '../diagnostics';
 import { telemetryService } from '../telemetry';
 import { SfdxCommandletExecutor } from './commands';
 
-vscode.workspace.onDidChangeTextDocument(e => {
-  if (ForceSourceDeployExecutor.errorCollection.has(e.document.uri)) {
-    ForceSourceDeployExecutor.errorCollection.delete(e.document.uri);
-  }
-});
-
 export abstract class ForceSourceDeployExecutor extends SfdxCommandletExecutor<
   string
 > {
@@ -65,6 +59,8 @@ export abstract class ForceSourceDeployExecutor extends SfdxCommandletExecutor<
             'Error while creating diagnostics for vscode problem view.'
           );
         }
+      } else {
+        ForceSourceDeployExecutor.errorCollection.clear();
       }
     });
 


### PR DESCRIPTION
### What does this PR do?
Clears source:deploy errors until the next deploy is triggered. This allows users to keep the errors around until everything is addressed.

### What issues does this PR fix or reference?
#771 , @W-5641403@