### PR TITLE
Fix 'manifests' vs. 'manifest' and one other typo

### DIFF
--- a/docs/articles/user-guide/org-development-model.md
+++ b/docs/articles/user-guide/org-development-model.md
@@ -24,9 +24,9 @@ After you select a login URL and give your project a name, your browser opens an
 
 ## The Manifest (`package.xml`) File
 
-If you are connected to a sandbox, DE org, or Trailhead Playground, the easiest way to retrieve all the metadata you want to work with from your org is by using a `package.xml` file. If you don’t already have one, update the provided file, or create a `package.xml` file in the `manifests` directory.
+If you are connected to a sandbox, DE org, or Trailhead Playground, the easiest way to retrieve all the metadata you want to work with from your org is by using a `package.xml` file. If you don’t already have one, update the provided file, or create a `package.xml` file in the `manifest` directory.
 
-Add the various metadata types you want to retrieve to this file. For information about the `package.xml` file, see in [Sample package.xml Manifest Files](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/manifest_samples.htm) in the _Metadata API Developer Guide_.
+Add the various metadata types you want to retrieve to this file. For information about the `package.xml` file, see [Sample package.xml Manifest Files](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/manifest_samples.htm) in the _Metadata API Developer Guide_.
 
 After you [retrieve your source](#retrieve-source), your project structure looks something like this.
 
@@ -44,7 +44,7 @@ your-app
 |           ├── aura
 |           ├── classes
 |           └── objects
-└── manifests
+└── manifest
     └── package.xml
 ```
 


### PR DESCRIPTION
When creating a new project with manifest, the directory created is called 'manifest', not 'manifests', and the right-click commands on package.xml will not work if the directory is called 'manifests'. Also removed a stray "in" before the link to Metadata API docs.

### What does this PR do?

*Docs changes only, to one article*. 
Replaces two instances of 'manifests' with 'manifest' in the Org Development Model article.
Removes awkward 'in' before Metadata API docs link.

### What issues does this PR fix or reference?
