### PR TITLE
Fix extensions failing to activate when sfdx cli is missing

### DIFF
--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -14,7 +14,7 @@
     "path-exists": "3.0.0",
     "request-light": "0.2.1",
     "rxjs": "^5.4.1",
-    "shelljs": "0.7.8",
+    "shelljs": "0.8.3",
     "tree-kill": "^1.1.0"
   },
   "devDependencies": {

--- a/packages/salesforcedx-vscode-apex-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-debugger/src/index.ts
@@ -268,23 +268,25 @@ export async function activate(context: vscode.ExtensionContext) {
     )
   );
 
-  console.log('Setting up ISV Debugger environment variables');
-  // register watcher for ISV authentication and setup default user for CLI
-  // this is done in core because it shares access to GlobalCliEnvironment with the commands
-  // (VS Code does not seem to allow sharing npm modules between extensions)
-  try {
-    registerIsvAuthWatcher(context);
-    console.log('Configured file watcher for .sfdx/sfdx-config.json');
-    await setupGlobalDefaultUserIsvAuth();
-  } catch (e) {
-    console.error(e);
-    vscode.window.showWarningMessage(
-      nls.localize('isv_debug_config_environment_error')
-    );
-  }
-
-  // Telemetry
   if (sfdxCoreExtension && sfdxCoreExtension.exports) {
+    if (sfdxCoreExtension.exports.isCLIInstalled()) {
+      console.log('Setting up ISV Debugger environment variables');
+      // register watcher for ISV authentication and setup default user for CLI
+      // this is done in core because it shares access to GlobalCliEnvironment with the commands
+      // (VS Code does not seem to allow sharing npm modules between extensions)
+      try {
+        registerIsvAuthWatcher(context);
+        console.log('Configured file watcher for .sfdx/sfdx-config.json');
+        await setupGlobalDefaultUserIsvAuth();
+      } catch (e) {
+        console.error(e);
+        vscode.window.showWarningMessage(
+          nls.localize('isv_debug_config_environment_error')
+        );
+      }
+    }
+
+    // Telemetry
     sfdxCoreExtension.exports.telemetryService.showTelemetryMessage();
 
     telemetryService.initializeService(

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -29,7 +29,7 @@
     "expand-home-dir": "0.0.3",
     "find-java-home": "0.2.0",
     "path-exists": "3.0.0",
-    "shelljs": "^0.8.1",
+    "shelljs": "0.8.3",
     "vscode-extension-telemetry": "0.0.17",
     "vscode-languageclient": "5.1.1"
   },

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -34,7 +34,7 @@
     "moment": "2.20.1",
     "rxjs": "^5.4.1",
     "sanitize-filename": "^1.6.1",
-    "shelljs": "^0.8.1"
+    "shelljs": "0.8.3"
   },
   "devDependencies": {
     "@types/adm-zip": "^0.4.31",

--- a/packages/salesforcedx-vscode-core/src/constants.ts
+++ b/packages/salesforcedx-vscode-core/src/constants.ts
@@ -25,3 +25,5 @@ export const PUSH_OR_DEPLOY_ON_SAVE_ENABLED = 'push-or-deploy-on-save.enabled';
 export const RETRIEVE_TEST_CODE_COVERAGE = 'retrieve-test-code-coverage';
 export const ENABLE_SOBJECT_REFRESH_ON_STARTUP =
   'enable-sobject-refresh-on-startup';
+export const SFDX_CLI_DOWNLOAD_LINK =
+  'https://developer.salesforce.com/tools/sfdxcli';

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -437,6 +437,7 @@ export async function activate(context: vscode.ExtensionContext) {
     await showDefaultOrg();
   } else {
     showCLINotInstalledMessage();
+    telemetryService.sendError('Salesforce CLI is not installed');
   }
 
   // Register filewatcher for push or deploy on save
@@ -485,7 +486,8 @@ export async function activate(context: vscode.ExtensionContext) {
     notificationService,
     taskViewService,
     telemetryService,
-    getUserId
+    getUserId,
+    isCLIInstalled
   };
 
   telemetryService.sendExtensionActivationEvent(extensionHRStart);

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -80,6 +80,7 @@ import { registerPushOrDeployOnSave, sfdxCoreSettings } from './settings';
 import { SfdxProjectPath } from './sfdxProject';
 import { taskViewService } from './statuses';
 import { telemetryService } from './telemetry';
+import { isCLIInstalled, showCLINotInstalledMessage } from './util';
 
 function registerCommands(
   extensionContext: vscode.ExtensionContext
@@ -384,7 +385,6 @@ function registerCommands(
 }
 
 export async function activate(context: vscode.ExtensionContext) {
-  console.log('SFDX CLI Extension Activated');
   const extensionHRStart = process.hrtime();
   // Telemetry
   const machineId =
@@ -429,11 +429,15 @@ export async function activate(context: vscode.ExtensionContext) {
     sfdxProjectOpened
   );
 
-  // Set context for defaultusername org
-  await setupWorkspaceOrgType();
-  registerDefaultUsernameWatcher(context);
+  if (isCLIInstalled()) {
+    // Set context for defaultusername org
+    await setupWorkspaceOrgType();
+    registerDefaultUsernameWatcher(context);
 
-  await showDefaultOrg();
+    await showDefaultOrg();
+  } else {
+    showCLINotInstalledMessage();
+  }
 
   // Register filewatcher for push or deploy on save
   await registerPushOrDeployOnSave();
@@ -485,6 +489,7 @@ export async function activate(context: vscode.ExtensionContext) {
   };
 
   telemetryService.sendExtensionActivationEvent(extensionHRStart);
+  console.log('SFDX CLI Extension Activated');
   return api;
 }
 

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -20,7 +20,7 @@ export const messages = {
   channel_starting_message: 'Starting ',
   channel_end_with_exit_code: 'ended with exit code %s',
   channel_end_with_sfdx_not_found:
-    'The Salesforce CLI is not installed. Install it from https://developer.salesforce.com/tools/sfdxcli',
+    'Salesforce CLI is not installed. Install it from https://developer.salesforce.com/tools/sfdxcli',
   channel_end_with_error: 'ended with error %s',
   channel_end: 'ended',
 
@@ -225,7 +225,7 @@ export const messages = {
   error_parsing_sfdx_project_file:
     "Couldn't parse sfdx-project.json file (%s). Parse error: %s",
   sfdx_cli_not_found:
-    'The Salesforce CLI is not installed. Install it from [%s](%s)',
+    'Salesforce CLI is not installed. Install it from [%s](%s)',
   table_header_errors: 'ERRORS',
   table_header_project_path: 'PROJECT PATH',
   table_header_type: 'TYPE',

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -224,6 +224,8 @@ export const messages = {
   force_config_set_org_text: 'SFDX: Set a Default Org',
   error_parsing_sfdx_project_file:
     "Couldn't parse sfdx-project.json file (%s). Parse error: %s",
+  sfdx_cli_not_found:
+    'The Salesforce CLI is not installed. Install it from [%s](%s)',
   table_header_errors: 'ERRORS',
   table_header_project_path: 'PROJECT PATH',
   table_header_type: 'TYPE',

--- a/packages/salesforcedx-vscode-core/src/util/cliConfiguration.ts
+++ b/packages/salesforcedx-vscode-core/src/util/cliConfiguration.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { which } from 'shelljs';
+import { window } from 'vscode';
+import { SFDX_CLI_DOWNLOAD_LINK } from '../constants';
+import { nls } from '../messages';
+
+export function isCLIInstalled(): boolean {
+  let isInstalled = false;
+  try {
+    if (which('sfdx')) {
+      isInstalled = true;
+    }
+  } catch (e) {
+    console.error('An error happened while looking for sfdx cli', e);
+  }
+  return isInstalled;
+}
+
+export function showCLINotInstalledMessage() {
+  const showMessage = nls.localize(
+    'sfdx_cli_not_found',
+    SFDX_CLI_DOWNLOAD_LINK,
+    SFDX_CLI_DOWNLOAD_LINK
+  );
+  window.showWarningMessage(showMessage);
+}

--- a/packages/salesforcedx-vscode-core/src/util/index.ts
+++ b/packages/salesforcedx-vscode-core/src/util/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { OrgAuthInfo } from './authInfo';
+export { isCLIInstalled, showCLINotInstalledMessage } from './cliConfiguration';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/util/cliConfiguration.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/util/cliConfiguration.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from 'chai';
+import * as shelljs from 'shelljs';
+import { assert, SinonStub, stub } from 'sinon';
+import { window } from 'vscode';
+import { isCLIInstalled, showCLINotInstalledMessage } from '../../../src/util';
+
+describe('SFDX CLI Configuration utility', () => {
+  describe('isCLIInstalled', () => {
+    let whichStub: SinonStub;
+
+    beforeEach(() => {
+      whichStub = stub(shelljs, 'which');
+    });
+
+    afterEach(() => {
+      whichStub.restore();
+    });
+
+    it('Should return false if sfdx cli path is not found', () => {
+      whichStub.withArgs('sfdx').returns('');
+
+      const response = isCLIInstalled();
+      expect(response).equal(false);
+    });
+
+    it('Should return true if sfdx cli path is found', () => {
+      whichStub.withArgs('sfdx').returns('Users/some/path/sfdx/cli');
+
+      const response = isCLIInstalled();
+      expect(response).equal(true);
+    });
+
+    it('Should return false if sfdx cli path query throwns an exception', () => {
+      whichStub
+        .withArgs('sfdx')
+        .throws(new Error('some exception while querying system path'));
+
+      const response = isCLIInstalled();
+      expect(response).equal(false);
+    });
+  });
+
+  describe('showCLINotInstalledMessage', () => {
+    let mShowWarning: SinonStub;
+
+    beforeEach(() => {
+      mShowWarning = stub(window, 'showWarningMessage').returns(
+        Promise.resolve(null)
+      );
+    });
+
+    afterEach(() => {
+      mShowWarning.restore();
+    });
+
+    it('Should show cli install info message', async () => {
+      showCLINotInstalledMessage();
+      assert.calledOnce(mShowWarning);
+    });
+  });
+});

--- a/packages/system-tests/package.json
+++ b/packages/system-tests/package.json
@@ -29,7 +29,7 @@
     "mocha-multi-reporters": "^1.1.4",
     "remap-istanbul": "^0.9.5",
     "rimraf": "^2.6.1",
-    "shelljs": "^0.7.8",
+    "shelljs": "0.8.3",
     "source-map-support": "^0.4.15",
     "spectron": "^3.7.2",
     "typescript": "3.1.6",


### PR DESCRIPTION
### What does this PR do?
Fixes core extension not getting activated when the salesforce cli is not installed or can't be found, which currently causes all the other extensions to fail.
With the new behavior, we check if the cli is installed before executing cli commands during extension activation. If the cli is not installed, a warning message is surfaced to the user pointing them to where they can download the cli.

![cli_not_installed_message](https://user-images.githubusercontent.com/1041842/53450356-df122580-39d0-11e9-8f8b-d090b74892c8.png)

### What issues does this PR fix or reference?
