### PR TITLE
Push or Deploy on Save shouldn't require reloading VS Code

### DIFF
--- a/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
@@ -18,27 +18,25 @@ import * as vscode from 'vscode';
 const WAIT_TIME_IN_MS = 4500;
 
 export async function registerPushOrDeployOnSave() {
-  if (sfdxCoreSettings.getPushOrDeployOnSaveEnabled()) {
-    const savedFiles: Set<vscode.Uri> = new Set();
-    let savedFilesTimeout: NodeJS.Timer;
-    vscode.workspace.onDidSaveTextDocument(
-      async (textDocument: vscode.TextDocument) => {
-        if (
-          sfdxCoreSettings.getPushOrDeployOnSaveEnabled() &&
-          !(await ignorePath(textDocument.uri))
-        ) {
-          savedFiles.add(textDocument.uri);
-          clearTimeout(savedFilesTimeout);
+  const savedFiles: Set<vscode.Uri> = new Set();
+  let savedFilesTimeout: NodeJS.Timer;
+  vscode.workspace.onDidSaveTextDocument(
+    async (textDocument: vscode.TextDocument) => {
+      if (
+        sfdxCoreSettings.getPushOrDeployOnSaveEnabled() &&
+        !(await ignorePath(textDocument.uri))
+      ) {
+        savedFiles.add(textDocument.uri);
+        clearTimeout(savedFilesTimeout);
 
-          savedFilesTimeout = setTimeout(async () => {
-            const files = Array.from(savedFiles);
-            savedFiles.clear();
-            await pushOrDeploy(files);
-          }, WAIT_TIME_IN_MS);
-        }
+        savedFilesTimeout = setTimeout(async () => {
+          const files = Array.from(savedFiles);
+          savedFiles.clear();
+          await pushOrDeploy(files);
+        }, WAIT_TIME_IN_MS);
       }
-    );
-  }
+    }
+  );
 }
 
 export async function pushOrDeploy(filesToDeploy: vscode.Uri[]): Promise<void> {


### PR DESCRIPTION
### What does this PR do?
Right now if a user enables "push-or-deploy-on-save.enabled" they'll have to reload VS Code for the setting to take effect. The reason for this was because of the way registerPushOrDeployOnSave was implemented. At the time we didn't know what the exact performance impact of the onDidSaveTextDocument listener and wanted the ability to be able to turn it off, just in case. My change doesn't actually change any functionality except that we're registering the vscode.workspace.onDidSaveTextDocument() listener regardless of whether the user has the setting enabled or not. The user can now enable/disable the setting without having to reload VS Code for it to take effect.

### What issues does this PR fix or reference?
@W-5896670@