### PR TITLE
Update icons used by colorizer statusbar

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/codecoverage/statusBarToggle.ts
+++ b/packages/salesforcedx-vscode-apex/src/codecoverage/statusBarToggle.ts
@@ -11,8 +11,8 @@ import { nls } from '../messages';
 export class StatusBarToggle implements Disposable {
   private static readonly toggleCodeCovCommand =
     'sfdx.force.apex.toggle.colorizer';
-  private static readonly showIcon = '$(tasklist)';
-  private static readonly hideIcon = '$(three-bars)';
+  private static readonly showIcon = '$(three-bars)';
+  private static readonly hideIcon = '$(tasklist)';
   private static readonly toolTip = nls.localize(
     'colorizer_statusbar_hover_text'
   );


### PR DESCRIPTION
### What does this PR do?
Updates the icons used by the colorizer status bar. The change now makes sure that the icon displayed is the one that reflects the current status of the feature (On/Off).

### What issues does this PR fix or reference?
W-5951754