### PR TITLE
Bump Lerna from 2.4.0 to 3.13.1

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,8 +1,4 @@
 {
-  "lerna": "2.0.0",
-  "packages": [
-    "packages/*",
-    "docs"
-  ],
+  "packages": ["packages/*", "docs"],
   "version": "45.7.0"
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "eslint-config-prettier": "2.9.0",
     "husky": "1.3.1",
     "istanbul": "1.1.0-alpha.1",
-    "lerna": "2.4.0",
+    "lerna": "3.13.1",
     "prettier": "1.16.4",
     "remap-istanbul": "^0.9.5",
     "shx": "0.2.2",


### PR DESCRIPTION
### What does this PR do?
This PR bumps the version of Lerna that we are using from 2.4.0 to 3.13.1
### What issues does this PR fix or reference?
W-5917685
