### PR TITLE
Output panel shouldn't steal focus

### DIFF
--- a/packages/salesforcedx-vscode-core/src/channels/channelService.ts
+++ b/packages/salesforcedx-vscode-core/src/channels/channelService.ts
@@ -99,7 +99,7 @@ export class ChannelService {
   }
 
   public showChannelOutput() {
-    this.channel.show();
+    this.channel.show(true);
   }
 
   public appendLine(text: string) {

--- a/packages/salesforcedx-vscode-core/src/notifications/notificationService.ts
+++ b/packages/salesforcedx-vscode-core/src/notifications/notificationService.ts
@@ -142,6 +142,7 @@ export class NotificationService {
       this.showChannelOutput();
     });
   }
+
   private showChannelOutput() {
     this.channel.show(true);
   }

--- a/packages/salesforcedx-vscode-core/src/notifications/notificationService.ts
+++ b/packages/salesforcedx-vscode-core/src/notifications/notificationService.ts
@@ -95,14 +95,14 @@ export class NotificationService {
     this.showErrorMessage(
       nls.localize('notification_unsuccessful_execution_text', executionName)
     );
-    this.channel.show();
+    this.showChannelOutput();
   }
 
   private showCanceledExecution(executionName: string) {
     this.showWarningMessage(
       nls.localize('notification_canceled_execution_text', executionName)
     );
-    this.channel.show();
+    this.showChannelOutput();
   }
 
   public async showSuccessfulExecution(executionName: string) {
@@ -121,7 +121,7 @@ export class NotificationService {
         showOnlyStatusBarButtonText
       );
       if (selection && selection === showButtonText) {
-        this.channel.show();
+        this.showChannelOutput();
       }
       if (selection && selection === showOnlyStatusBarButtonText) {
         await sfdxCoreSettings.updateShowCLISuccessMsg(false);
@@ -139,7 +139,10 @@ export class NotificationService {
       this.showErrorMessage(
         nls.localize('notification_unsuccessful_execution_text', executionName)
       );
-      this.channel.show();
+      this.showChannelOutput();
     });
+  }
+  private showChannelOutput() {
+    this.channel.show(true);
   }
 }


### PR DESCRIPTION
### What does this PR do?
Commands writing to the output channel were stealing focus. For some command this was happening twice, once during the initial execution and then a second time during the results reporting. The solution here was actually quite simple, OutputChannel.show takes an optional boolean parameter that, when set to true, preserves the focus.

The widgets/commands that were stealing focus:
The notificationService - would steal focus reporting command results (success, fail or cancel)
Apex test runner - would steal focus when reporting a test failure
Apex replay debugger - would steal focus when writing errors to the output window
SfdxCommandletExecutor - would steal focus for any command if showChannelOutput was set (defaults to true)
forceDebuggerStop - would steal focus when stopping the debugger session
forceGenerateFauxClasses - would steal focus when showChannelOutput was set
The base class for deploy/retrieve commands - would steal focus when a command was executed and then, because of the notification service, would steal focus a second time reporting command results. Additionallly forceSourceRetrieveSourcePath would steal focus on precondition errors and pushOrDeployOnSave would steal focus if an exception was thrown during push or deploy
Apex debugger bootstrap command - Executes several commands during isvDebugging setup/attach which all show channel output

### What issues does this PR fix or reference?
@W-5896263@