### PR TITLE
update request-light to 0.2.4

### DIFF
--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -15,7 +15,7 @@
     "@salesforce/salesforcedx-utils-vscode": "45.8.0",
     "async-lock": "1.0.0",
     "faye": "1.1.2",
-    "request-light": "0.2.1",
+    "request-light": "0.2.4",
     "vscode-debugadapter": "1.28.0",
     "vscode-debugprotocol": "1.28.0"
   },

--- a/packages/salesforcedx-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-apex-replay-debugger/package.json
@@ -29,7 +29,7 @@
     "mocha-junit-reporter": "^1.13.0",
     "mocha-multi-reporters": "^1.1.4",
     "nyc": "^13",
-    "request-light": "0.2.1",
+    "request-light": "0.2.4",
     "sinon": "^2.3.6",
     "typescript": "3.1.6",
     "vscode": "1.1.17",

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -12,7 +12,7 @@
     "@salesforce/salesforcedx-utils-vscode": "45.8.0",
     "cross-spawn": "6.0.5",
     "path-exists": "3.0.0",
-    "request-light": "0.2.1",
+    "request-light": "0.2.4",
     "rxjs": "^5.4.1",
     "shelljs": "0.8.3",
     "tree-kill": "^1.1.0"

--- a/packages/salesforcedx-test-utils-vscode/package.json
+++ b/packages/salesforcedx-test-utils-vscode/package.json
@@ -29,7 +29,7 @@
     "mock-spawn": "0.2.6",
     "nyc": "^11.0.2",
     "remap-istanbul": "^0.9.5",
-    "request-light": "0.2.1",
+    "request-light": "0.2.4",
     "sinon": "^2.3.6",
     "source-map-support": "^0.4.15",
     "typescript": "3.1.6"

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -34,7 +34,7 @@
     "mock-spawn": "0.2.6",
     "nyc": "^13",
     "remap-istanbul": "^0.9.5",
-    "request-light": "0.2.1",
+    "request-light": "0.2.4",
     "sinon": "^2.3.6",
     "source-map-support": "^0.4.15",
     "typescript": "3.1.6"

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -27,7 +27,7 @@
     "@salesforce/salesforcedx-apex-replay-debugger": "45.8.0",
     "async-lock": "1.0.0",
     "path-exists": "3.0.0",
-    "request-light": "0.2.1",
+    "request-light": "0.2.4",
     "vscode-extension-telemetry": "0.0.17"
   },
   "devDependencies": {


### PR DESCRIPTION
### What does this PR do?
Version 0.2.1 of request-light has a dependency on a version of http-proxy-agent which contains a security vulnerability. request-light to 0.2.4 uses an updated version of http-proxy-agent in which this vulnerability has been fixed.

### What issues does this PR fix or reference?
@W-5997778@