### PR TITLE
update Lightning LSPs to 2.1.0 / add new activation logic

### DIFF
--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -142,7 +142,7 @@
             "autodetect",
             "off"
           ],
-          "enumDescription": [
+          "enumDescriptions": [
             "%activation_mode_always_on%",
             "%activation_mode_autodetect%",
             "%activation_mode_off%"

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -104,7 +104,7 @@
         {
           "id": "salesforce-lightning-components",
           "name": "%lightning_explorer_name%",
-          "when": "config.salesforcedx-vscode-lightning.show-lightning-explorer"
+          "when": "config.salesforcedx-vscode-lightning.showLightningExplorer"
         }
       ]
     },
@@ -128,7 +128,7 @@
       "type": "object",
       "title": "%lightning_preferences%",
       "properties": {
-        "salesforcedx-vscode-lightning.show-lightning-explorer": {
+        "salesforcedx-vscode-lightning.showLightningExplorer": {
           "type": "boolean",
           "scope": "window",
           "default": false,

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -28,7 +28,7 @@
     "aura-language-server": "2.1.0",
     "change-case": "^3.1.0",
     "lightning-lsp-common": "2.1.0",
-    "open": "^6.0.0",
+    "open": "6.0.0",
     "vscode-extension-telemetry": "0.0.17",
     "vscode-languageclient": "^3.5.1"
   },
@@ -37,7 +37,7 @@
     "@types/chai": "^4.0.0",
     "@types/mocha": "2.2.38",
     "@types/node": "8.9.3",
-    "@types/open": "^6.0.0",
+    "@types/open": "6.0.0",
     "@types/sinon": "^2.3.2",
     "chai": "^4.0.2",
     "cross-env": "5.2.0",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -46,9 +46,6 @@
     "typescript": "3.1.6",
     "vscode": "1.1.17"
   },
-  "extensionDependencies": [
-    "salesforce.salesforcedx-vscode-core"
-  ],
   "scripts": {
     "vscode:prepublish": "npm prune --production",
     "vscode:package": "vsce package",
@@ -64,8 +61,11 @@
     "test:vscode-insiders-integration": "cross-env CODE_VERSION=insiders npm run test:vscode-integration"
   },
   "activationEvents": [
+    "onLanguage:html",
+    "onLanguage:javascript",
     "workspaceContains:sfdx-project.json",
-    "workspaceContains:**/core/workspace-user.xml"
+    "workspaceContains:**/workspace-user.xml",
+    "onView:salesforce-lightning-explorer"
   ],
   "main": "./out/src",
   "contributes": {
@@ -133,6 +133,21 @@
           "scope": "window",
           "default": false,
           "description": "%show_lightning_explorer_description%"
+        },
+        "salesforcedx-vscode-lightning.activationMode": {
+          "type": "string",
+          "description": "%activation_mode_description%",
+          "enum": [
+            "always",
+            "autodetect",
+            "off"
+          ],
+          "enumDescription": [
+            "Always on",
+            "Only activate when a valid SFDX workspace",
+            "Always off"
+          ],
+          "default": "autodetect"
         }
       }
     }

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -126,7 +126,7 @@
     ],
     "configuration": {
       "type": "object",
-      "title": "%feature_previews_title%",
+      "title": "%lightning_preferences%",
       "properties": {
         "salesforcedx-vscode-lightning.show-lightning-explorer": {
           "type": "boolean",
@@ -143,9 +143,9 @@
             "off"
           ],
           "enumDescription": [
-            "Always on",
-            "Only activate when a valid SFDX workspace",
-            "Always off"
+            "%activation_mode_always_on%",
+            "%activation_mode_autodetect%",
+            "%activation_mode_off%"
           ],
           "default": "autodetect"
         }

--- a/packages/salesforcedx-vscode-lightning/package.nls.json
+++ b/packages/salesforcedx-vscode-lightning/package.nls.json
@@ -1,7 +1,9 @@
 {
   "lightning_open_component_title": "SFDX: Open Lightning Component",
   "lightning_explorer_title": "Lightning Explorer",
-  "feature_previews_title": "Salesforce Feature Previews",
+  "feature_previews_title": "Salesforce Lightning ",
   "lightning_explorer_name": "Lightning Components",
-  "show_lightning_explorer_description": "Show the lightning explorer view"
+  "show_lightning_explorer_description": "Show the lightning explorer view",
+  "debug_mode_description": "Activate debug mode",
+  "activation_mode_description": "When the language server should be activated"
 }

--- a/packages/salesforcedx-vscode-lightning/package.nls.json
+++ b/packages/salesforcedx-vscode-lightning/package.nls.json
@@ -1,9 +1,11 @@
 {
   "lightning_open_component_title": "SFDX: Open Lightning Component",
   "lightning_explorer_title": "Lightning Explorer",
-  "feature_previews_title": "Salesforce Lightning ",
+  "lightning_preferences": "Salesforce Lightning",
   "lightning_explorer_name": "Lightning Components",
-  "show_lightning_explorer_description": "Show the lightning explorer view",
-  "debug_mode_description": "Activate debug mode",
-  "activation_mode_description": "When the language server should be activated"
+  "show_lightning_explorer_description": "Preview Feature: Show the Lightning Explorer View",
+  "activation_mode_description": "Configures when the Aura and LWC language servers (LSPs) should be active (requires restart)",
+  "activation_mode_always_on": "Lighning LSPs will always be activate, regardless of vscode workspace structure",
+  "activation_mode_autodetect": "Lighning LSPs will only become active if a valid vscode workspace is detected",
+  "activation_mode_off": "Lighning LSPs will never be activated"
 }

--- a/packages/salesforcedx-vscode-lightning/src/dxsupport/waitForDX.ts
+++ b/packages/salesforcedx-vscode-lightning/src/dxsupport/waitForDX.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import * as vscode from 'vscode';
+
+let wait: Promise<vscode.Extension<any>>;
+
+export async function waitForDX(activate: boolean = false) {
+  if (!wait) {
+    wait = new Promise((resolve, reject) => {
+      // 120 seconds from now
+      const expires = new Date().getTime() + 1000 * 120;
+      const dosetup = () => {
+        let success = false;
+        try {
+          const coreDependency = vscode.extensions.getExtension(
+            'salesforce.salesforcedx-vscode-core'
+          );
+          if (coreDependency && !coreDependency.isActive && activate) {
+            return coreDependency.activate().then(api => {
+              resolve(
+                vscode.extensions.getExtension(
+                  'salesforce.salesforcedx-vscode-core'
+                )
+              );
+            });
+          }
+          if (coreDependency && coreDependency.exports) {
+            success = true;
+            resolve(coreDependency);
+          }
+        } catch (ignore) {
+          // ignore
+        }
+        if (!success) {
+          if (new Date().getTime() > expires) {
+            const msg =
+              'salesforce.salesforcedx-vscode-core not installed or activated, some features unavailable';
+            console.log(msg);
+            reject(msg);
+          } else {
+            setTimeout(dosetup, 100);
+          }
+        }
+      };
+      setTimeout(dosetup, 100);
+    });
+  }
+  return wait;
+}

--- a/packages/salesforcedx-vscode-lightning/src/index.ts
+++ b/packages/salesforcedx-vscode-lightning/src/index.ts
@@ -11,7 +11,6 @@ import * as path from 'path';
 import {
   commands,
   ExtensionContext,
-  extensions,
   ProgressLocation,
   Uri,
   window,
@@ -69,27 +68,22 @@ export async function activate(context: ExtensionContext) {
   }
 
   // 3) If activationMode is autodetect or always, check workspaceType before startup
-  let workspaceType;
-  if (checkActivationMode('autodetect') || checkActivationMode('always')) {
-    workspaceType = lspCommon.detectWorkspaceType(
-      workspace.workspaceFolders[0].uri.fsPath
-    );
-    const sfdxWorkspace = workspaceType === WorkspaceType.SFDX;
+  const workspaceType = lspCommon.detectWorkspaceType(
+    workspace.workspaceFolders[0].uri.fsPath
+  );
 
-    // Check if we have a valid project structure
-    if (!lspCommon.isLWC(workspaceType)) {
-      // If activationMode === autodetect and we don't have a valid workspace type, exit
-      if (checkActivationMode('autodetect')) {
-        console.log(
-          'Aura LSP - autodetect did not find a valid project structure, exiting....'
-        );
-        console.log('WorkspaceType detected: ' + workspaceType);
-        return;
-      }
-      // If activationMode === always, ignore workspace type and continue activating
-    }
+  // Check if we have a valid project structure
+  if (checkActivationMode('autodetect') && !lspCommon.isLWC(workspaceType)) {
+    // If activationMode === autodetect and we don't have a valid workspace type, exit
+    console.log(
+      'Aura LSP - autodetect did not find a valid project structure, exiting....'
+    );
+    console.log('WorkspaceType detected: ' + workspaceType);
+    return;
   }
-  // 4) If we get here, we either passed autodetect validation or activationMode == alwayson
+  // If activationMode === always, ignore workspace type and continue activating
+
+  // 4) If we get here, we either passed autodetect validation or activationMode == always
   console.log('Aura Components Extension Activated');
   console.log('WorkspaceType detected: ' + workspaceType);
 

--- a/packages/salesforcedx-vscode-lightning/src/index.ts
+++ b/packages/salesforcedx-vscode-lightning/src/index.ts
@@ -17,7 +17,6 @@ import {
   window,
   workspace
 } from 'vscode';
-import * as vscode from 'vscode';
 import {
   LanguageClient,
   LanguageClientOptions,
@@ -48,7 +47,7 @@ function protocol2CodeConverter(value: string): Uri {
 
 function checkActivationMode(mode: string): boolean {
   return (
-    vscode.workspace
+    workspace
       .getConfiguration('salesforcedx-vscode-lightning')
       .get('activationMode') === mode
   );
@@ -64,7 +63,7 @@ export async function activate(context: ExtensionContext) {
   }
 
   // 2) if we have no workspace folders, exit
-  if (!vscode.workspace.workspaceFolders) {
+  if (!workspace.workspaceFolders) {
     console.log('No workspace, exiting extension');
     return;
   }
@@ -73,7 +72,7 @@ export async function activate(context: ExtensionContext) {
   let workspaceType;
   if (checkActivationMode('autodetect') || checkActivationMode('always')) {
     workspaceType = lspCommon.detectWorkspaceType(
-      vscode.workspace.workspaceFolders[0].uri.fsPath
+      workspace.workspaceFolders[0].uri.fsPath
     );
     const sfdxWorkspace = workspaceType === WorkspaceType.SFDX;
 

--- a/packages/salesforcedx-vscode-lightning/src/index.ts
+++ b/packages/salesforcedx-vscode-lightning/src/index.ts
@@ -184,5 +184,5 @@ function reportIndexing(indexingPromise: Promise<void>) {
 
 export function deactivate() {
   console.log('Aura Components Extension Deactivated');
-  telemetryService.sendExtensionDeactivationEvent();
+  telemetryService.sendExtensionDeactivationEvent().catch();
 }

--- a/packages/salesforcedx-vscode-lightning/src/index.ts
+++ b/packages/salesforcedx-vscode-lightning/src/index.ts
@@ -5,6 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { shared as lspCommon } from 'lightning-lsp-common';
+import { WorkspaceType } from 'lightning-lsp-common/lib/shared';
 import * as path from 'path';
 import {
   commands,
@@ -44,21 +46,63 @@ function protocol2CodeConverter(value: string): Uri {
   return Uri.parse(value);
 }
 
-export async function activate(context: ExtensionContext) {
-  if (
+function checkActivationMode(mode: string): boolean {
+  return (
     vscode.workspace
       .getConfiguration('salesforcedx-vscode-lightning')
-      .get('activationMode') === 'off'
-  ) {
-    console.log(
-      'Aura Components Extension deactivated - setting is turned off'
-    );
+      .get('activationMode') === mode
+  );
+}
+
+export async function activate(context: ExtensionContext) {
+  const extensionHRStart = process.hrtime();
+  // Run our auto detection routine before we activate
+  // 1) If activationMode is off, don't startup no matter what
+  if (checkActivationMode('off')) {
+    console.log('Aura Language Server activationMode set to off, exiting...');
     return;
   }
 
-  console.log('Aura Components Extension Activated');
-  const extensionHRStart = process.hrtime();
+  // 2) if we have no workspace folders, exit
+  if (!vscode.workspace.workspaceFolders) {
+    console.log('No workspace, exiting extension');
+    return;
+  }
 
+  // 3) If activationMode is autodetect or always, check workspaceType before startup
+  let workspaceType;
+  if (checkActivationMode('autodetect') || checkActivationMode('always')) {
+    workspaceType = lspCommon.detectWorkspaceType(
+      vscode.workspace.workspaceFolders[0].uri.fsPath
+    );
+    const sfdxWorkspace = workspaceType === WorkspaceType.SFDX;
+
+    // Check if we have a valid project structure
+    if (!lspCommon.isLWC(workspaceType)) {
+      // If activationMode === autodetect and we don't have a valid workspace type, exit
+      if (checkActivationMode('autodetect')) {
+        console.log(
+          'Aura LSP - autodetect did not find a valid project structure, exiting....'
+        );
+        console.log('WorkspaceType detected: ' + workspaceType);
+        return;
+      }
+      // If activationMode === always, ignore workspace type and continue activating
+    }
+  }
+  // 4) If we get here, we either passed autodetect validation or activationMode == alwayson
+  console.log('Aura Components Extension Activated');
+  console.log('WorkspaceType detected: ' + workspaceType);
+
+  // Start the Aura Language Server
+  startAuraLanguageServer(context);
+
+  // Notify telemetry that our extension is now active
+  telemetryService.sendExtensionActivationEvent(extensionHRStart).catch();
+}
+
+function startAuraLanguageServer(context: vscode.ExtensionContext) {
+  // Setup the language server
   const serverModule = context.asAbsolutePath(
     path.join('node_modules', 'aura-language-server', 'lib', 'server.js')
   );
@@ -79,6 +123,7 @@ export async function activate(context: ExtensionContext) {
     }
   };
 
+  // Setup our fileSystemWatchers
   const clientOptions: LanguageClientOptions = {
     outputChannelName: nls.localize('channel_name'),
     documentSelector: [
@@ -128,13 +173,16 @@ export async function activate(context: ExtensionContext) {
     serverOptions,
     clientOptions
   );
-  // UI customizations
+
+  // Add Quick Open command
   context.subscriptions.push(
     commands.registerCommand(
       'salesforce-lightning-quickopen',
       createQuickOpenCommand(client)
     )
   );
+
+  // Add Lightning Explorer data provider
   const componentProvider = new ComponentTreeProvider(client, context);
   window.registerTreeDataProvider(
     'salesforce-lightning-components',
@@ -149,11 +197,12 @@ export async function activate(context: ExtensionContext) {
     })
     .catch();
 
-  // do this last
+  // Start the language server
   client.start();
-  context.subscriptions.push(this.client);
 
-  telemetryService.sendExtensionActivationEvent(extensionHRStart).catch();
+  // Push the disposable to the context's subscriptions so that the
+  // client can be deactivated on extension deactivation
+  context.subscriptions.push(this.client);
 }
 
 let indexingResolve: any;

--- a/packages/salesforcedx-vscode-lightning/src/index.ts
+++ b/packages/salesforcedx-vscode-lightning/src/index.ts
@@ -95,13 +95,7 @@ export async function activate(context: ExtensionContext) {
   console.log('WorkspaceType detected: ' + workspaceType);
 
   // Start the Aura Language Server
-  startAuraLanguageServer(context);
 
-  // Notify telemetry that our extension is now active
-  telemetryService.sendExtensionActivationEvent(extensionHRStart).catch();
-}
-
-function startAuraLanguageServer(context: vscode.ExtensionContext) {
   // Setup the language server
   const serverModule = context.asAbsolutePath(
     path.join('node_modules', 'aura-language-server', 'lib', 'server.js')
@@ -203,6 +197,9 @@ function startAuraLanguageServer(context: vscode.ExtensionContext) {
   // Push the disposable to the context's subscriptions so that the
   // client can be deactivated on extension deactivation
   context.subscriptions.push(this.client);
+
+  // Notify telemetry that our extension is now active
+  telemetryService.sendExtensionActivationEvent(extensionHRStart).catch();
 }
 
 let indexingResolve: any;

--- a/packages/salesforcedx-vscode-lightning/src/index.ts
+++ b/packages/salesforcedx-vscode-lightning/src/index.ts
@@ -15,6 +15,7 @@ import {
   window,
   workspace
 } from 'vscode';
+import * as vscode from 'vscode';
 import {
   LanguageClient,
   LanguageClientOptions,
@@ -44,6 +45,17 @@ function protocol2CodeConverter(value: string): Uri {
 }
 
 export async function activate(context: ExtensionContext) {
+  if (
+    vscode.workspace
+      .getConfiguration('salesforcedx-vscode-lightning')
+      .get('activationMode') === 'off'
+  ) {
+    console.log(
+      'Aura Components Extension deactivated - setting is turned off'
+    );
+    return;
+  }
+
   console.log('Aura Components Extension Activated');
   const extensionHRStart = process.hrtime();
 
@@ -52,8 +64,9 @@ export async function activate(context: ExtensionContext) {
   );
 
   // The debug options for the server
-  const debugOptions = { execArgv: ['--nolazy', '--inspect=6020'] };
-  // let debugOptions = { };
+  const debugOptions = {
+    execArgv: ['--nolazy', '--inspect-brk=6020']
+  };
 
   // If the extension is launched in debug mode then the debug server options are used
   // Otherwise the run options are used
@@ -140,21 +153,7 @@ export async function activate(context: ExtensionContext) {
   client.start();
   context.subscriptions.push(this.client);
 
-  const sfdxCoreExtension = extensions.getExtension(
-    'salesforce.salesforcedx-vscode-core'
-  );
-
-  // Telemetry
-  if (sfdxCoreExtension && sfdxCoreExtension.exports) {
-    sfdxCoreExtension.exports.telemetryService.showTelemetryMessage();
-
-    telemetryService.initializeService(
-      sfdxCoreExtension.exports.telemetryService.getReporter(),
-      sfdxCoreExtension.exports.telemetryService.isTelemetryEnabled()
-    );
-  }
-
-  telemetryService.sendExtensionActivationEvent(extensionHRStart);
+  telemetryService.sendExtensionActivationEvent(extensionHRStart).catch();
 }
 
 let indexingResolve: any;

--- a/packages/salesforcedx-vscode-lightning/src/telemetry/telemetry.ts
+++ b/packages/salesforcedx-vscode-lightning/src/telemetry/telemetry.ts
@@ -95,6 +95,6 @@ export class TelemetryService {
 
   private getEndHRTime(hrstart: [number, number]): string {
     const hrend = process.hrtime(hrstart);
-    return util.format('%ds %dms', hrend[0], hrend[1] / 1000000);
+    return util.format('%d%d', hrend[0], hrend[1] / 1000000);
   }
 }

--- a/packages/salesforcedx-vscode-lightning/src/telemetry/telemetry.ts
+++ b/packages/salesforcedx-vscode-lightning/src/telemetry/telemetry.ts
@@ -1,12 +1,15 @@
 /*
- * Copyright (c) 2018, salesforce.com, inc.
+ * Copyright (c) 2019, salesforce.com, inc.
  * All rights reserved.
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
 import * as util from 'util';
+import * as vscode from 'vscode';
 import TelemetryReporter from 'vscode-extension-telemetry';
+import { telemetryService } from '.';
+import { waitForDX } from '../dxsupport/waitForDX';
 
 const EXTENSION_NAME = 'salesforcedx-vscode-lightning';
 
@@ -14,6 +17,7 @@ export class TelemetryService {
   private static instance: TelemetryService;
   private reporter: TelemetryReporter | undefined;
   private isTelemetryEnabled: boolean;
+  private setup: Promise<TelemetryService | undefined> | undefined;
 
   constructor() {
     this.isTelemetryEnabled = false;
@@ -26,6 +30,29 @@ export class TelemetryService {
     return TelemetryService.instance;
   }
 
+  public async setupVSCodeTelemetry() {
+    // if its already set up
+    if (this.reporter) {
+      return Promise.resolve(telemetryService);
+    }
+    if (!this.setup) {
+      this.setup = waitForDX(true)
+        .then((coreDependency: vscode.Extension<any>) => {
+          coreDependency.exports.telemetryService.showTelemetryMessage();
+
+          telemetryService.initializeService(
+            coreDependency.exports.telemetryService.getReporter(),
+            coreDependency.exports.telemetryService.isTelemetryEnabled()
+          );
+          return telemetryService;
+        })
+        .catch(err => {
+          return undefined;
+        });
+    }
+    return this.setup;
+  }
+
   public initializeService(
     reporter: TelemetryReporter,
     isTelemetryEnabled: boolean
@@ -34,7 +61,10 @@ export class TelemetryService {
     this.reporter = reporter;
   }
 
-  public sendExtensionActivationEvent(hrstart: [number, number]): void {
+  public async sendExtensionActivationEvent(
+    hrstart: [number, number]
+  ): Promise<void> {
+    await this.setupVSCodeTelemetry();
     if (this.reporter !== undefined && this.isTelemetryEnabled) {
       const startupTime = this.getEndHRTime(hrstart);
       this.reporter.sendTelemetryEvent('activationEvent', {
@@ -44,7 +74,8 @@ export class TelemetryService {
     }
   }
 
-  public sendExtensionDeactivationEvent(): void {
+  public async sendExtensionDeactivationEvent(): Promise<void> {
+    await this.setupVSCodeTelemetry();
     if (this.reporter !== undefined && this.isTelemetryEnabled) {
       this.reporter.sendTelemetryEvent('deactivationEvent', {
         extensionName: EXTENSION_NAME
@@ -52,8 +83,18 @@ export class TelemetryService {
     }
   }
 
+  public async sendCommandEvent(commandName?: string): Promise<void> {
+    await this.setupVSCodeTelemetry();
+    if (this.reporter !== undefined && this.isTelemetryEnabled && commandName) {
+      this.reporter.sendTelemetryEvent('commandExecution', {
+        extensionName: EXTENSION_NAME,
+        commandName
+      });
+    }
+  }
+
   private getEndHRTime(hrstart: [number, number]): string {
     const hrend = process.hrtime(hrstart);
-    return util.format('%d%d', hrend[0], hrend[1] / 1000000);
+    return util.format('%ds %dms', hrend[0], hrend[1] / 1000000);
   }
 }

--- a/packages/salesforcedx-vscode-lightning/src/views/component-tree-provider.ts
+++ b/packages/salesforcedx-vscode-lightning/src/views/component-tree-provider.ts
@@ -37,7 +37,7 @@ const tagsCleared: NotificationType<void, void> = new NotificationType<
   void
 >('salesforce/tagsCleared');
 
-let loadNamespacesPromise: Promise<Map<string, LwcNode>>;
+let loadNamespacesPromise: Promise<Map<string, LwcNode>> | null;
 
 async function loadNamespaces(client: LanguageClient) {
   if (!loadNamespacesPromise) {
@@ -189,7 +189,9 @@ export class ComponentTreeProvider implements TreeDataProvider<LwcNode> {
 
   public async getChildren(node?: LwcNode): Promise<LwcNode[]> {
     if (node) {
-      const sorted = node.children.sort((a, b) => (a.label < b.label ? -1 : 1));
+      const sorted = node.children.sort((a, b) =>
+        (a.label || '') < (b.label || '') ? -1 : 1
+      );
       return Promise.resolve(sorted);
     } else {
       return [...(await loadNamespaces(this.client)).values()];

--- a/packages/salesforcedx-vscode-lightning/test/vscode-integration/telemetry/telemetry.test.ts
+++ b/packages/salesforcedx-vscode-lightning/test/vscode-integration/telemetry/telemetry.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, salesforce.com, inc.
+ * Copyright (c) 2019, salesforce.com, inc.
  * All rights reserved.
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
@@ -14,7 +14,7 @@ describe('Telemetry', () => {
 
   beforeEach(() => {
     reporter = new TelemetryReporter(
-      'salesforcedx-vscode',
+      'salesforcedx-vscode-lightning',
       'v1',
       'test87349-0'
     );
@@ -30,7 +30,7 @@ describe('Telemetry', () => {
     const telemetryService = TelemetryService.getInstance();
     telemetryService.initializeService(reporter, true);
 
-    telemetryService.sendExtensionActivationEvent([0, 600]);
+    await telemetryService.sendExtensionActivationEvent([0, 600]);
     assert.calledOnce(sendEvent);
   });
 
@@ -38,7 +38,7 @@ describe('Telemetry', () => {
     const telemetryService = TelemetryService.getInstance();
     telemetryService.initializeService(reporter, false);
 
-    telemetryService.sendExtensionActivationEvent([0, 700]);
+    await telemetryService.sendExtensionActivationEvent([0, 700]);
     assert.notCalled(sendEvent);
   });
 
@@ -46,7 +46,7 @@ describe('Telemetry', () => {
     const telemetryService = TelemetryService.getInstance();
     telemetryService.initializeService(reporter, true);
 
-    telemetryService.sendExtensionActivationEvent([0, 800]);
+    await telemetryService.sendExtensionActivationEvent([0, 800]);
     assert.calledOnce(sendEvent);
 
     const expectedData = {
@@ -60,7 +60,7 @@ describe('Telemetry', () => {
     const telemetryService = TelemetryService.getInstance();
     telemetryService.initializeService(reporter, true);
 
-    telemetryService.sendExtensionDeactivationEvent();
+    await telemetryService.sendExtensionDeactivationEvent();
     assert.calledOnce(sendEvent);
 
     const expectedData = {

--- a/packages/salesforcedx-vscode-lightning/tsconfig.json
+++ b/packages/salesforcedx-vscode-lightning/tsconfig.json
@@ -10,7 +10,8 @@
     "noImplicitAny": true,
     "rootDir": ".",
     "outDir": "out",
-    "preserveConstEnums": true
+    "preserveConstEnums": true,
+    "strict": true
   },
   "exclude": ["node_modules", ".vscode-test", "out"]
 }

--- a/packages/salesforcedx-vscode-lightning/tsconfig.json
+++ b/packages/salesforcedx-vscode-lightning/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "es6",
     "lib": ["dom", "es2016"],
     "sourceMap": true,
+    "declarationMap": true,
     "declaration": true,
     "moduleResolution": "node",
     "noImplicitAny": true,

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -65,8 +65,11 @@
     "test:vscode-insiders-integration": "cross-env CODE_VERSION=insiders npm run test:vscode-integration"
   },
   "activationEvents": [
+    "onLanguage:html",
+    "onLanguage:javascript",
     "workspaceContains:sfdx-project.json",
-    "workspaceContains:**/core/workspace-user.xml"
+    "workspaceContains:**/workspace-user.xml",
+    "onView:salesforce-lightning-explorer"
   ],
   "main": "./out/src",
   "contributes": {

--- a/packages/salesforcedx-vscode-lwc/src/index.ts
+++ b/packages/salesforcedx-vscode-lwc/src/index.ts
@@ -63,19 +63,17 @@ async function registerCommands(): Promise<Disposable | undefined> {
   }
 }
 
-function checkActivationMode(mode: string): boolean {
-  return (
-    workspace
-      .getConfiguration('salesforcedx-vscode-lightning')
-      .get('activationMode') === mode
-  );
+function getActivationMode(): string {
+  const config = workspace.getConfiguration('salesforcedx-vscode-lightning');
+  return config.get('activationMode') || 'autodetect'; // default to autodetect
 }
 
 export async function activate(context: ExtensionContext) {
   const extensionHRStart = process.hrtime();
+  console.log('Activation Mode: ' + getActivationMode());
   // Run our auto detection routine before we activate
   // 1) If activationMode is off, don't startup no matter what
-  if (checkActivationMode('off')) {
+  if (getActivationMode() === 'off') {
     console.log('LWC Language Server activationMode set to off, exiting...');
     return;
   }
@@ -92,7 +90,7 @@ export async function activate(context: ExtensionContext) {
   );
 
   // Check if we have a valid project structure
-  if (checkActivationMode('autodetect') && !lspCommon.isLWC(workspaceType)) {
+  if (getActivationMode() === 'autodetect' && !lspCommon.isLWC(workspaceType)) {
     // If activationMode === autodetect and we don't have a valid workspace type, exit
     console.log(
       'LWC LSP - autodetect did not find a valid project structure, exiting....'

--- a/packages/salesforcedx-vscode-lwc/src/index.ts
+++ b/packages/salesforcedx-vscode-lwc/src/index.ts
@@ -7,7 +7,15 @@
 
 import { shared as lspCommon } from 'lightning-lsp-common';
 import * as path from 'path';
-import * as vscode from 'vscode';
+import {
+  commands,
+  ConfigurationTarget,
+  Disposable,
+  ExtensionContext,
+  Uri,
+  workspace,
+  WorkspaceConfiguration
+} from 'vscode';
 import {
   LanguageClient,
   LanguageClientOptions,
@@ -21,7 +29,7 @@ import { waitForDX } from './dxsupport/waitForDX';
 import { telemetryService } from './telemetry';
 
 // See https://github.com/Microsoft/vscode-languageserver-node/issues/105
-export function code2ProtocolConverter(value: vscode.Uri) {
+export function code2ProtocolConverter(value: Uri) {
   if (/^win32/.test(process.platform)) {
     // The *first* : is also being encoded which is not the standard for URI on Windows
     // Here we transform it back to the standard way
@@ -32,10 +40,10 @@ export function code2ProtocolConverter(value: vscode.Uri) {
 }
 
 function protocol2CodeConverter(value: string) {
-  return vscode.Uri.parse(value);
+  return Uri.parse(value);
 }
 
-async function registerCommands(): Promise<vscode.Disposable | undefined> {
+async function registerCommands(): Promise<Disposable | undefined> {
   try {
     await waitForDX(true);
     const {
@@ -43,12 +51,12 @@ async function registerCommands(): Promise<vscode.Disposable | undefined> {
     } = require('./commands/forceLightningLwcCreate');
 
     // Customer-facing commands
-    const forceLightningLwcCreateCmd = vscode.commands.registerCommand(
+    const forceLightningLwcCreateCmd = commands.registerCommand(
       'sfdx.force.lightning.lwc.create',
       forceLightningLwcCreate
     );
 
-    return vscode.Disposable.from(forceLightningLwcCreateCmd);
+    return Disposable.from(forceLightningLwcCreateCmd);
   } catch (ignore) {
     // ignore
     return undefined;
@@ -57,13 +65,13 @@ async function registerCommands(): Promise<vscode.Disposable | undefined> {
 
 function checkActivationMode(mode: string): boolean {
   return (
-    vscode.workspace
+    workspace
       .getConfiguration('salesforcedx-vscode-lightning')
       .get('activationMode') === mode
   );
 }
 
-export async function activate(context: vscode.ExtensionContext) {
+export async function activate(context: ExtensionContext) {
   const extensionHRStart = process.hrtime();
   // Run our auto detection routine before we activate
   // 1) If activationMode is off, don't startup no matter what
@@ -73,30 +81,27 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   // 2) if we have no workspace folders, exit
-  if (!vscode.workspace.workspaceFolders) {
+  if (!workspace.workspaceFolders) {
     console.log('No workspace, exiting extension');
     return;
   }
 
   // 3) If activationMode is autodetect or always, check workspaceType before startup
   const workspaceType = lspCommon.detectWorkspaceType(
-    vscode.workspace.workspaceFolders[0].uri.fsPath
+  	workspace.workspaceFolders[0].uri.fsPath
   );
 
-    // Check if we have a valid project structure
-    if (!lspCommon.isLWC(workspaceType)) {
-      // If activationMode === autodetect and we don't have a valid workspace type, exit
-      if (checkActivationMode('autodetect')) {
-        console.log(
-          'LWC LSP - autodetect did not find a valid project structure, exiting....'
-        );
-        console.log('WorkspaceType detected: ' + workspaceType);
-        return;
-      }
-      // If activationMode === always, ignore workspace type and continue activating
-    }
+  // Check if we have a valid project structure
+  if (checkActivationMode('autodetect') && !lspCommon.isLWC(workspaceType)) {
+    // If activationMode === autodetect and we don't have a valid workspace type, exit
+    console.log(
+      'LWC LSP - autodetect did not find a valid project structure, exiting....'
+    );
+    console.log('WorkspaceType detected: ' + workspaceType);
+    return;
   }
-  // 4) If we get here, we either passed autodetect validation or activationMode == alwayson
+
+  // 4) If we get here, we either passed autodetect validation or activationMode == always
   console.log('Lightning Web Components Extension Activated');
   console.log('WorkspaceType detected: ' + workspaceType);
 
@@ -107,10 +112,7 @@ export async function activate(context: vscode.ExtensionContext) {
   if (workspaceType === lspCommon.WorkspaceType.SFDX) {
     await populateEslintSettingIfNecessary(
       context,
-      vscode.workspace.getConfiguration(
-        '',
-        vscode.workspace.workspaceFolders[0].uri
-      )
+      workspace.getConfiguration('', workspace.workspaceFolders[0].uri)
     );
   }
 
@@ -127,7 +129,7 @@ export async function activate(context: vscode.ExtensionContext) {
   telemetryService.sendExtensionActivationEvent(extensionHRStart).catch();
 }
 
-function startLWCLanguageServer(context: vscode.ExtensionContext) {
+function startLWCLanguageServer(context: ExtensionContext) {
   // Setup the language server
   const serverModule = context.asAbsolutePath(
     path.join('node_modules', 'lwc-language-server', 'lib', 'server.js')
@@ -150,20 +152,18 @@ function startLWCLanguageServer(context: vscode.ExtensionContext) {
     ],
     synchronize: {
       fileEvents: [
-        vscode.workspace.createFileSystemWatcher('**/*.resource'),
-        vscode.workspace.createFileSystemWatcher(
+        workspace.createFileSystemWatcher('**/*.resource'),
+        workspace.createFileSystemWatcher(
           '**/labels/CustomLabels.labels-meta.xml'
         ),
-        vscode.workspace.createFileSystemWatcher(
+        workspace.createFileSystemWatcher(
           '**/staticresources/*.resource-meta.xml'
         ),
-        vscode.workspace.createFileSystemWatcher(
-          '**/contentassets/*.asset-meta.xml'
-        ),
-        vscode.workspace.createFileSystemWatcher('**/lwc/*/*.js'),
-        vscode.workspace.createFileSystemWatcher('**/modules/*/*/*.js'),
+        workspace.createFileSystemWatcher('**/contentassets/*.asset-meta.xml'),
+        workspace.createFileSystemWatcher('**/lwc/*/*.js'),
+        workspace.createFileSystemWatcher('**/modules/*/*/*.js'),
         // need to watch for directory deletions as no events are created for contents or deleted directories
-        vscode.workspace.createFileSystemWatcher('**/', false, true, false)
+        workspace.createFileSystemWatcher('**/', false, true, false)
       ]
     },
     uriConverters: {
@@ -186,8 +186,8 @@ function startLWCLanguageServer(context: vscode.ExtensionContext) {
 }
 
 export async function populateEslintSettingIfNecessary(
-  context: vscode.ExtensionContext,
-  config: vscode.WorkspaceConfiguration
+  context: ExtensionContext,
+  config: WorkspaceConfiguration
 ) {
   const nodePath = config.get<string>(ESLINT_NODEPATH_CONFIG);
 
@@ -200,7 +200,7 @@ export async function populateEslintSettingIfNecessary(
     await config.update(
       ESLINT_NODEPATH_CONFIG,
       eslintModule,
-      vscode.ConfigurationTarget.Workspace
+      ConfigurationTarget.Workspace
     );
   }
 }

--- a/packages/salesforcedx-vscode-lwc/src/telemetry/telemetry.ts
+++ b/packages/salesforcedx-vscode-lwc/src/telemetry/telemetry.ts
@@ -36,7 +36,7 @@ export class TelemetryService {
       return Promise.resolve(telemetryService);
     }
     if (!this.setup) {
-      this.setup = waitForDX()
+      this.setup = waitForDX(true)
         .then((coreDependency: vscode.Extension<any>) => {
           coreDependency.exports.telemetryService.showTelemetryMessage();
 

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/telemetry/telemetry.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/telemetry/telemetry.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, salesforce.com, inc.
+ * Copyright (c) 2019, salesforce.com, inc.
  * All rights reserved.
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
@@ -13,7 +13,11 @@ describe('Telemetry', () => {
   let sendEvent: SinonStub;
 
   beforeEach(() => {
-    reporter = new TelemetryReporter('salesforcedx-vscode', 'v1', 'test345390');
+    reporter = new TelemetryReporter(
+      'salesforcedx-vscode-lwc',
+      'v1',
+      'test345390'
+    );
     sendEvent = stub(reporter, 'sendTelemetryEvent');
   });
 
@@ -50,5 +54,18 @@ describe('Telemetry', () => {
       startupTime: match.string
     };
     assert.calledWith(sendEvent, 'activationEvent', match(expectedData));
+  });
+
+  it('Should send correct data format on sendExtensionDeactivationEvent', async () => {
+    const telemetryService = TelemetryService.getInstance();
+    telemetryService.initializeService(reporter, true);
+
+    await telemetryService.sendExtensionDeactivationEvent();
+    assert.calledOnce(sendEvent);
+
+    const expectedData = {
+      extensionName: 'salesforcedx-vscode-lightning'
+    };
+    assert.calledWith(sendEvent, 'deactivationEvent', expectedData);
   });
 });

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/telemetry/telemetry.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/telemetry/telemetry.test.ts
@@ -64,7 +64,7 @@ describe('Telemetry', () => {
     assert.calledOnce(sendEvent);
 
     const expectedData = {
-      extensionName: 'salesforcedx-vscode-lightning'
+      extensionName: 'salesforcedx-vscode-lwc'
     };
     assert.calledWith(sendEvent, 'deactivationEvent', expectedData);
   });

--- a/packages/salesforcedx-vscode-lwc/tsconfig.json
+++ b/packages/salesforcedx-vscode-lwc/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "es6",
     "lib": ["dom", "es2016"],
     "sourceMap": true,
+    "declarationMap": true,
     "declaration": true,
     "moduleResolution": "node",
     "noImplicitAny": true,


### PR DESCRIPTION
### What does this PR do?
- Update the lightning lsps to 2.1.0
- Fix settings.json file being overwritten
- Async startup for aura language server
- Add vscode settings for configuring LSP activation
- Cleanup activation logic for internal and external developers
### What issues does this PR fix or reference?
#1210 