### PR TITLE
display message based upon defaultname and where it was found or not

### DIFF
--- a/packages/salesforcedx-vscode-core/src/context/workspaceOrgType.ts
+++ b/packages/salesforcedx-vscode-core/src/context/workspaceOrgType.ts
@@ -73,6 +73,6 @@ function setDefaultUsernameHasNoChangeTracking(val: boolean) {
 
 export async function getDefaultUsernameOrAlias(): Promise<string | undefined> {
   if (hasRootWorkspace()) {
-    return await OrgAuthInfo.getDefaultUsernameOrAlias();
+    return await OrgAuthInfo.getDefaultUsernameOrAlias(true);
   }
 }

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -242,6 +242,8 @@ export const messages = {
   error_no_default_devhubusername:
     'No default Dev Hub is set. Run "SFDX: Authorize a Dev Hub" to set one.',
   custom_output_directory: 'Choose a Custom Directory',
+  warning_using_global_username:
+    'No default username found in the local project config; using the global default username. Run "SFDX: Authorize an Org" to set the username for the local project config.',
   apex_class_message_name: 'Apex Class',
   apex_trigger_message_name: 'Apex Trigger',
   visualforce_component_message_name: 'Visualforce Component',

--- a/packages/salesforcedx-vscode-core/src/orgBrowser/orgMetadata.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/orgMetadata.ts
@@ -90,7 +90,9 @@ export async function forceDescribeMetadata(outputPath?: string) {
 export async function getMetadataTypesPath(): Promise<string | undefined> {
   if (hasRootWorkspace()) {
     const workspaceRootPath = getRootWorkspacePath();
-    const defaultUsernameOrAlias = await OrgAuthInfo.getDefaultUsernameOrAlias();
+    const defaultUsernameOrAlias = await OrgAuthInfo.getDefaultUsernameOrAlias(
+      false
+    );
     const defaultUsernameIsSet = typeof defaultUsernameOrAlias !== 'undefined';
 
     if (defaultUsernameIsSet) {

--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -38,7 +38,9 @@ export class OrgList implements vscode.Disposable {
   public async displayDefaultUsername() {
     let defaultUsernameorAlias: string | undefined;
     if (hasRootWorkspace()) {
-      defaultUsernameorAlias = await OrgAuthInfo.getDefaultUsernameOrAlias();
+      defaultUsernameorAlias = await OrgAuthInfo.getDefaultUsernameOrAlias(
+        false
+      );
     }
     if (defaultUsernameorAlias) {
       this.statusBarItem.text = `$(plug) ${defaultUsernameorAlias}`;

--- a/packages/salesforcedx-vscode-core/src/util/authInfo.ts
+++ b/packages/salesforcedx-vscode-core/src/util/authInfo.ts
@@ -4,60 +4,53 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import {
-  Aliases,
-  AuthInfo,
-  ConfigAggregator,
-  ConfigFile
-} from '@salesforce/core';
-import * as path from 'path';
+import { Aliases, AuthInfo } from '@salesforce/core';
+import { isUndefined } from 'util';
+import { channelService } from '../channels';
 import { nls } from '../messages';
-import { getRootWorkspacePath } from './index';
+import { notificationService } from '../notifications';
+import { ConfigSource, ConfigUtil } from './index';
+
+const defaultUserNameKey = 'defaultusername';
+const defaultDevHubUserNameKey = 'defaultdevhubusername';
 export class OrgAuthInfo {
   public static async getDefaultUsernameOrAlias(): Promise<string | undefined> {
-    try {
-      const rootPath = getRootWorkspacePath();
-      const myLocalConfig = await ConfigFile.create({
-        isGlobal: false,
-        rootFolder: path.join(rootPath, '.sfdx'),
-        filename: 'sfdx-config.json'
-      });
-      const localDefault = myLocalConfig.get('defaultusername');
-      return JSON.stringify(localDefault).replace(/\"/g, '');
-    } catch {
-      await this.getGlobalDefaults('defaultusername');
-    }
-  }
-
-  private static async getGlobalDefaults(usernameType: string) {
-    try {
-      const aggregator = await ConfigAggregator.create();
-      const globalDefault = aggregator.getPropertyValue(usernameType);
-      return JSON.stringify(globalDefault).replace(/\"/g, '');
-    } catch {
-      if (usernameType === 'defaultusername') {
-        console.error(nls.localize('error_no_default_username'));
-      } else {
-        console.error(nls.localize('error_ no_default_devhubusername'));
+    const defaultUserName = await ConfigUtil.getConfigValue(defaultUserNameKey);
+    if (isUndefined(defaultUserName)) {
+      displayMessage(
+        nls.localize('error_no_default_username'),
+        true,
+        VSCodeWindowTypeEnum.Informational
+      );
+      return undefined;
+    } else {
+      const configSource = await ConfigUtil.getConfigSource(defaultUserNameKey);
+      if (configSource === ConfigSource.Global) {
+        displayMessage(
+          nls.localize('warning_using_global_username'),
+          true,
+          VSCodeWindowTypeEnum.Warning
+        );
       }
     }
+    return JSON.stringify(defaultUserName).replace(/\"/g, '');
   }
 
   public static async getDefaultDevHubUsernameOrAlias(): Promise<
     string | undefined
   > {
-    try {
-      const rootPath = getRootWorkspacePath();
-      const myLocalConfig = await ConfigFile.create({
-        isGlobal: false,
-        rootFolder: path.join(rootPath, '.sfdx'),
-        filename: 'sfdx-config.json'
-      });
-      const localDefault = myLocalConfig.get('defaultdevhubusername');
-      return JSON.stringify(localDefault).replace(/\"/g, '');
-    } catch {
-      await this.getGlobalDefaults('defaultdevhubusername');
+    const defaultDevHubUserName = await ConfigUtil.getConfigValue(
+      defaultDevHubUserNameKey
+    );
+    if (isUndefined(defaultDevHubUserName)) {
+      displayMessage(
+        nls.localize('error_no_default_devhubusername'),
+        true,
+        VSCodeWindowTypeEnum.Error
+      );
+      return undefined;
     }
+    return JSON.stringify(defaultDevHubUserName).replace(/\"/g, '');
   }
 
   public static async getUsername(usernameOrAlias: string): Promise<string> {
@@ -77,6 +70,36 @@ export class OrgAuthInfo {
       );
     } catch (e) {
       throw e;
+    }
+  }
+}
+
+enum VSCodeWindowTypeEnum {
+  Error = 1,
+  Informational = 2,
+  Warning = 3
+}
+function displayMessage(
+  output: string,
+  showVSCodeWindow?: boolean,
+  vsCodeWindowType?: VSCodeWindowTypeEnum
+) {
+  channelService.appendLine(output);
+  channelService.showChannelOutput();
+  if (showVSCodeWindow && vsCodeWindowType) {
+    switch (vsCodeWindowType) {
+      case VSCodeWindowTypeEnum.Error: {
+        notificationService.showErrorMessage(output);
+        break;
+      }
+      case VSCodeWindowTypeEnum.Informational: {
+        notificationService.showInformationMessage(output);
+        break;
+      }
+      case VSCodeWindowTypeEnum.Warning: {
+        notificationService.showWarningMessage(output);
+        break;
+      }
     }
   }
 }

--- a/packages/salesforcedx-vscode-core/src/util/configUtil.ts
+++ b/packages/salesforcedx-vscode-core/src/util/configUtil.ts
@@ -7,6 +7,7 @@
 import { ConfigAggregator, ConfigFile, ConfigValue } from '@salesforce/core';
 import * as path from 'path';
 import { isNullOrUndefined, isUndefined } from 'util';
+import { telemetryService } from '../telemetry';
 import { getRootWorkspacePath } from './index';
 
 export enum ConfigSource {
@@ -49,7 +50,13 @@ export class ConfigUtil {
         if (!isNullOrUndefined(localValue)) {
           return localValue;
         }
-      } catch {}
+      } catch (err) {
+        telemetryService.sendErrorEvent(
+          'Unexpected error in ConfigUtil.getConfigValue local',
+          err
+        );
+        return undefined;
+      }
     }
     if (isUndefined(source) || source === ConfigSource.Global) {
       try {
@@ -58,7 +65,13 @@ export class ConfigUtil {
         if (!isNullOrUndefined(globalValue)) {
           return globalValue;
         }
-      } catch {}
+      } catch (err) {
+        telemetryService.sendErrorEvent(
+          'Unexpected error in ConfigUtil.getConfigValue global',
+          err
+        );
+        return undefined;
+      }
     }
     return undefined;
   }

--- a/packages/salesforcedx-vscode-core/src/util/configUtil.ts
+++ b/packages/salesforcedx-vscode-core/src/util/configUtil.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { ConfigAggregator, ConfigFile, ConfigValue } from '@salesforce/core';
+import * as path from 'path';
+import { isNullOrUndefined, isUndefined } from 'util';
+import { getRootWorkspacePath } from './index';
+
+export enum ConfigSource {
+  Local,
+  Global,
+  None
+}
+
+// This class should be reworked or removed once the ConfigAggregator correctly checks
+// local as well as global configs. It's also worth noting that ConfigAggregator, according
+// to its docs checks local, global and environment and, for our purposes, environment may
+// not be viable.
+
+// Given a configuration key, check the local then the global configs for the value and return
+// the appropriate ConfigSource for the location or None if the value doesn't exist in either.
+export class ConfigUtil {
+  public static async getConfigSource(key: string): Promise<ConfigSource> {
+    let value = await ConfigUtil.getConfigValue(key, ConfigSource.Local);
+    if (!isNullOrUndefined(value)) {
+      return ConfigSource.Local;
+    }
+    value = await ConfigUtil.getConfigValue(key, ConfigSource.Global);
+    if (!isNullOrUndefined(value)) {
+      return ConfigSource.Global;
+    }
+    return ConfigSource.None;
+  }
+
+  // Given a configuration key check the local then the global configs for the value returning
+  // the value if it exists or undefined otherwise. If the optional source argument if set to Local
+  // or Global then it will only check the appropriate config for the value.
+  public static async getConfigValue(
+    key: string,
+    source?: ConfigSource.Global | ConfigSource.Local
+  ): Promise<ConfigValue | undefined> {
+    if (isUndefined(source) || source === ConfigSource.Local) {
+      try {
+        const rootPath = getRootWorkspacePath();
+        const myLocalConfig = await ConfigFile.create({
+          isGlobal: false,
+          rootFolder: path.join(rootPath, '.sfdx'),
+          filename: 'sfdx-config.json'
+        });
+        const localValue = myLocalConfig.get(key);
+        if (!isNullOrUndefined(localValue)) {
+          return localValue;
+        }
+      } catch {}
+    }
+    if (isUndefined(source) || source === ConfigSource.Global) {
+      try {
+        const aggregator = await ConfigAggregator.create();
+        const globalValue = aggregator.getPropertyValue(key);
+        if (!isNullOrUndefined(globalValue)) {
+          return globalValue;
+        }
+      } catch {}
+    }
+    return undefined;
+  }
+}

--- a/packages/salesforcedx-vscode-core/src/util/configUtil.ts
+++ b/packages/salesforcedx-vscode-core/src/util/configUtil.ts
@@ -20,8 +20,6 @@ export enum ConfigSource {
 // to its docs checks local, global and environment and, for our purposes, environment may
 // not be viable.
 
-// Given a configuration key, check the local then the global configs for the value and return
-// the appropriate ConfigSource for the location or None if the value doesn't exist in either.
 export class ConfigUtil {
   public static async getConfigSource(key: string): Promise<ConfigSource> {
     let value = await ConfigUtil.getConfigValue(key, ConfigSource.Local);
@@ -35,9 +33,6 @@ export class ConfigUtil {
     return ConfigSource.None;
   }
 
-  // Given a configuration key check the local then the global configs for the value returning
-  // the value if it exists or undefined otherwise. If the optional source argument if set to Local
-  // or Global then it will only check the appropriate config for the value.
   public static async getConfigValue(
     key: string,
     source?: ConfigSource.Global | ConfigSource.Local

--- a/packages/salesforcedx-vscode-core/src/util/index.ts
+++ b/packages/salesforcedx-vscode-core/src/util/index.ts
@@ -12,3 +12,4 @@ export {
   hasRootWorkspace
 } from './rootWorkspace';
 export { isCLIInstalled, showCLINotInstalledMessage } from './cliConfiguration';
+export { ConfigSource, ConfigUtil } from './configUtil';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/util/configUtil.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/util/configUtil.test.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { ConfigSource, ConfigUtil } from '../../../src/util';
+
+describe('getConfigSource', () => {
+  let getConfigValueStub: sinon.SinonStub;
+  beforeEach(() => {
+    getConfigValueStub = sinon.stub(ConfigUtil, 'getConfigValue');
+  });
+  afterEach(() => {
+    getConfigValueStub.restore();
+  });
+  it('should return ConfigSource.Local if the key/value is in the local config', async () => {
+    getConfigValueStub.onCall(0).returns('someValue');
+    const configSource = await ConfigUtil.getConfigSource('key');
+    expect(configSource).to.be.eq(ConfigSource.Local);
+  });
+  it('should return ConfigSource.Global if the key/value is in the global config', async () => {
+    getConfigValueStub.onCall(0).returns(undefined);
+    getConfigValueStub.onCall(1).returns('someValue');
+    const configSource = await ConfigUtil.getConfigSource('key');
+    expect(configSource).to.be.eq(ConfigSource.Global);
+  });
+  it('should return ConfigSource.None if the key/value is in the global config', async () => {
+    getConfigValueStub.onCall(0).returns(undefined);
+    getConfigValueStub.onCall(1).returns(undefined);
+    const configSource = await ConfigUtil.getConfigSource('key');
+    expect(configSource).to.be.eq(ConfigSource.None);
+  });
+});

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/util/configUtil.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/util/configUtil.test.ts
@@ -27,7 +27,7 @@ describe('getConfigSource', () => {
     const configSource = await ConfigUtil.getConfigSource('key');
     expect(configSource).to.be.eq(ConfigSource.Global);
   });
-  it('should return ConfigSource.None if the key/value is in the global config', async () => {
+  it('should return ConfigSource.None if the key/value is not in the local or global config', async () => {
     getConfigValueStub.onCall(0).returns(undefined);
     getConfigValueStub.onCall(1).returns(undefined);
     const configSource = await ConfigUtil.getConfigSource('key');


### PR DESCRIPTION
### What does this PR do?
Display a message when the user does not have a defaultusername set for the current project OR if the defaultusername is being pulled from the global config instead of the local project config.

If there is no defaultusername in the local or global configs we were already displaying a message to the debug console I just added that message as an informational popup. That message will be displayed if the user create a new project or loads a project that has not authenticated yet.

If the defaultusername is pulled from the global config we will now display a warning message (console and popup) with instructions to authorize an org.

As part of this I refactored the config code out of the OrgAuthInfo class into its own class, ConfigUtil. The fact is, the CLI's ConfigAggregator class should do exactly what ConfigUtil does but it's currently broken and doesn't fetch anything other than the global config.

The informational message
![InformationNoDefaultOrg](https://user-images.githubusercontent.com/13556087/56054553-01a39800-5d0c-11e9-8b14-62b7677e9907.png)

The warning message
![GlobalConfigWarning](https://user-images.githubusercontent.com/13556087/56054567-08320f80-5d0c-11e9-95a1-567f3a11eeac.png)

### What issues does this PR fix or reference?
@W-5856821@