### PR TITLE
Filter existing traceflag to the specific user the cli authenticated …

### DIFF
--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceStartApexDebugLogging.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceStartApexDebugLogging.test.ts
@@ -66,9 +66,9 @@ describe('Force Start Apex Debug Logging', () => {
 
   it('Should build the traceflag query command for logging', async () => {
     const queryTraceFlagsExecutor = new ForceQueryTraceFlag();
-    const updateTraceFlagCmd = queryTraceFlagsExecutor.build();
+    const updateTraceFlagCmd = queryTraceFlagsExecutor.build('005x00000000123');
     expect(updateTraceFlagCmd.toCommand()).to.equal(
-      `sfdx force:data:soql:query --query SELECT id, logtype, startdate, expirationdate, debuglevelid, debuglevel.apexcode, debuglevel.visualforce FROM TraceFlag WHERE logtype='DEVELOPER_LOG' --usetoolingapi --json --loglevel fatal`
+      `sfdx force:data:soql:query --query SELECT id, logtype, startdate, expirationdate, debuglevelid, debuglevel.apexcode, debuglevel.visualforce FROM TraceFlag WHERE logtype='DEVELOPER_LOG' AND TracedEntityId='005x00000000123' --usetoolingapi --json --loglevel fatal`
     );
   });
 


### PR DESCRIPTION
…with

### What does this PR do?
Fixes the issue where the Replay debugger uses an existing TraceFlag that is not assigned to the user the Salesforce CLI authenticated with.

### What issues does this PR fix or reference?
Issues #1285 & #1280 
@W-6081465@