### PR TITLE
[Org Browser] Lazy loading for metadata components

### DIFF
--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -61,7 +61,6 @@ import * as decorators from './decorators';
 import { isDemoMode } from './modes/demo-mode';
 import { notificationService, ProgressNotification } from './notifications';
 import { MetadataOutlineProvider } from './orgBrowser';
-import { forceListMetadata } from './orgBrowser';
 import { OrgList } from './orgPicker';
 import { registerPushOrDeployOnSave, sfdxCoreSettings } from './settings';
 import { taskViewService } from './statuses';

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -419,7 +419,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Register filewatcher for push or deploy on save
   await registerPushOrDeployOnSave();
-  await forceListMetadata('ApexClass', 'a.jha@appexchange.com.full8');
   // Commands
   const commands = registerCommands(context);
   context.subscriptions.push(commands);

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -61,6 +61,7 @@ import * as decorators from './decorators';
 import { isDemoMode } from './modes/demo-mode';
 import { notificationService, ProgressNotification } from './notifications';
 import { MetadataOutlineProvider } from './orgBrowser';
+import { forceListMetadata } from './orgBrowser';
 import { OrgList } from './orgPicker';
 import { registerPushOrDeployOnSave, sfdxCoreSettings } from './settings';
 import { taskViewService } from './statuses';
@@ -418,7 +419,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Register filewatcher for push or deploy on save
   await registerPushOrDeployOnSave();
-
+  await forceListMetadata('ApexClass', 'a.jha@appexchange.com.full8');
   // Commands
   const commands = registerCommands(context);
   context.subscriptions.push(commands);

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -250,5 +250,6 @@ export const messages = {
   visualforce_page_message_name: 'Visualforce Page',
   aura_bundle_message_name: 'Aura Bundle',
   lwc_message_name: 'Lightning Web Component',
-  force_lightning_lwc_create_text: 'SFDX: Create Lightning Web Component'
+  force_lightning_lwc_create_text: 'SFDX: Create Lightning Web Component',
+  force_list_metadata_text: 'SFDX: List Metadata'
 };

--- a/packages/salesforcedx-vscode-core/src/orgBrowser/index.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/index.ts
@@ -8,8 +8,14 @@ export {
   onUsernameChange,
   forceDescribeMetadata,
   ForceDescribeMetadataExecutor,
-  getMetadataTypesPath,
+  getTypesPath,
   buildTypesList
-} from './orgMetadata';
+} from './metadataType';
 export { MetadataOutlineProvider } from './metadataOutlineProvider';
 export { BrowserNode, NodeType } from './nodeTypes';
+export {
+  buildComponentsList,
+  forceListMetadata,
+  ForceListMetadataExecutor,
+  getComponentsPath
+} from './metadataCmp';

--- a/packages/salesforcedx-vscode-core/src/orgBrowser/index.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/index.ts
@@ -15,6 +15,7 @@ export { MetadataOutlineProvider } from './metadataOutlineProvider';
 export { BrowserNode, NodeType } from './nodeTypes';
 export {
   buildComponentsList,
+  folderTypes,
   forceListMetadata,
   ForceListMetadataExecutor,
   getComponentsPath

--- a/packages/salesforcedx-vscode-core/src/orgBrowser/metadataCmp.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/metadataCmp.ts
@@ -45,13 +45,22 @@ export class ForceListMetadataExecutor extends SfdxCommandletExecutor<string> {
   }
 
   public build(data: {}): Command {
-    return new SfdxCommandBuilder()
+    let builder = new SfdxCommandBuilder()
       .withArg('force:mdapi:listmetadata')
       .withFlag('-m', this.metadataType)
       .withFlag('-u', this.defaultUsernameOrAlias)
       .withFlag('-f', this.outputPath)
-      .withJson()
-      .build();
+      .withJson();
+
+    if (
+      this.metadataType === 'Dashboard' ||
+      this.metadataType === 'Report' ||
+      this.metadataType === 'EmailTemplate' ||
+      this.metadataType === 'Document'
+    ) {
+      builder = builder.withFlag('--folder', 'unfiled$public');
+    }
+    return builder.build();
   }
 
   public execute(response: ContinueResponse<string>): void {

--- a/packages/salesforcedx-vscode-core/src/orgBrowser/metadataCmp.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/metadataCmp.ts
@@ -113,6 +113,16 @@ export async function getComponentsPath(
     try {
       const workspaceRootPath = getRootWorkspacePath();
       const username = await OrgAuthInfo.getUsername(defaultUsernameOrAlias);
+
+      if (isNullOrUndefined(username)) {
+        const err = nls.localize('error_no_default_username');
+        telemetryService.sendErrorEvent(
+          'Undefined username on metadataCmp.getComponentsPath',
+          err
+        );
+        throw new Error(err);
+      }
+
       const componentsPath = path.join(
         workspaceRootPath,
         '.sfdx',

--- a/packages/salesforcedx-vscode-core/src/orgBrowser/metadataCmp.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/metadataCmp.ts
@@ -28,6 +28,7 @@ import { taskViewService } from '../statuses';
 import { telemetryService } from '../telemetry';
 import { getRootWorkspacePath, hasRootWorkspace, OrgAuthInfo } from '../util';
 
+export const folderTypes = new Set(['EmailTemplate', 'Reports']);
 export class ForceListMetadataExecutor extends SfdxCommandletExecutor<string> {
   private metadataType: string;
   private outputPath: string;
@@ -46,18 +47,14 @@ export class ForceListMetadataExecutor extends SfdxCommandletExecutor<string> {
 
   public build(data: {}): Command {
     let builder = new SfdxCommandBuilder()
+      .withDescription(nls.localize('force_list_metadata_text'))
       .withArg('force:mdapi:listmetadata')
       .withFlag('-m', this.metadataType)
       .withFlag('-u', this.defaultUsernameOrAlias)
       .withFlag('-f', this.outputPath)
       .withJson();
 
-    if (
-      this.metadataType === 'Dashboard' ||
-      this.metadataType === 'Report' ||
-      this.metadataType === 'EmailTemplate' ||
-      this.metadataType === 'Document'
-    ) {
+    if (folderTypes.has(this.metadataType)) {
       builder = builder.withFlag('--folder', 'unfiled$public');
     }
     return builder.build();
@@ -155,6 +152,7 @@ export function buildComponentsList(
     );
     return metaComponents;
   } catch (e) {
-    throw e;
+    telemetryService.sendError(e);
+    throw new Error(e);
   }
 }

--- a/packages/salesforcedx-vscode-core/src/orgBrowser/metadataType.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/metadataType.ts
@@ -102,7 +102,7 @@ export async function getTypesPath(): Promise<string | undefined> {
   if (isNullOrUndefined(defaultUsernameOrAlias)) {
     const err = nls.localize('error_no_default_username');
     telemetryService.sendErrorEvent(
-      'Undefined username or alias on orgMetadata.getMetadataTypesPath',
+      'Undefined username or alias on orgMetadata.getTypesPath',
       err
     );
     throw new Error(err);
@@ -113,7 +113,7 @@ export async function getTypesPath(): Promise<string | undefined> {
   if (isNullOrUndefined(username)) {
     const err = nls.localize('error_no_default_username');
     telemetryService.sendErrorEvent(
-      'Undefined username on orgMetadata.getMetadataTypesPath',
+      'Undefined username on orgMetadata.getTypesPath',
       err
     );
     throw new Error(err);

--- a/packages/salesforcedx-vscode-core/src/orgBrowser/metadataType.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/metadataType.ts
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  CliCommandExecutor,
+  Command,
+  SfdxCommandBuilder
+} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
+import * as fs from 'fs';
+import * as path from 'path';
+import { Observable } from 'rxjs/Observable';
+import { isNullOrUndefined } from 'util';
+import * as vscode from 'vscode';
+import { channelService } from '../channels';
+import {
+  EmptyParametersGatherer,
+  SfdxCommandlet,
+  SfdxCommandletExecutor,
+  SfdxWorkspaceChecker
+} from '../commands';
+import { nls } from '../messages';
+import { notificationService, ProgressNotification } from '../notifications';
+import { taskViewService } from '../statuses';
+import { telemetryService } from '../telemetry';
+import { getRootWorkspacePath, hasRootWorkspace, OrgAuthInfo } from '../util';
+
+export class ForceDescribeMetadataExecutor extends SfdxCommandletExecutor<
+  string
+> {
+  private outputPath: string;
+
+  public constructor(outputPath: string) {
+    super();
+    this.outputPath = outputPath;
+  }
+
+  public build(data: {}): Command {
+    return new SfdxCommandBuilder()
+      .withArg('force:mdapi:describemetadata')
+      .withJson()
+      .withFlag('-f', this.outputPath)
+      .withLogName('force_describe_metadata')
+      .build();
+  }
+
+  public execute(response: ContinueResponse<string>): void {
+    const startTime = process.hrtime();
+    const cancellationTokenSource = new vscode.CancellationTokenSource();
+    const cancellationToken = cancellationTokenSource.token;
+
+    const execution = new CliCommandExecutor(this.build(response.data), {
+      cwd: getRootWorkspacePath()
+    }).execute(cancellationToken);
+
+    execution.processExitSubject.subscribe(async data => {
+      this.logMetric(execution.command.logName, startTime);
+      buildTypesList(this.outputPath);
+    });
+    notificationService.reportExecutionError(
+      execution.command.toString(),
+      (execution.stderrSubject as any) as Observable<Error | undefined>
+    );
+    channelService.streamCommandOutput(execution);
+    ProgressNotification.show(execution, cancellationTokenSource);
+    taskViewService.addCommandExecution(execution, cancellationTokenSource);
+  }
+}
+
+const workspaceChecker = new SfdxWorkspaceChecker();
+const parameterGatherer = new EmptyParametersGatherer();
+
+export async function forceDescribeMetadata(outputPath?: string) {
+  if (isNullOrUndefined(outputPath)) {
+    outputPath = await getTypesPath();
+  }
+  const describeExecutor = new ForceDescribeMetadataExecutor(outputPath!);
+  const commandlet = new SfdxCommandlet(
+    workspaceChecker,
+    parameterGatherer,
+    describeExecutor
+  );
+  await commandlet.run();
+}
+
+export async function getTypesPath(): Promise<string | undefined> {
+  if (!hasRootWorkspace()) {
+    const err = nls.localize('cannot_determine_workspace');
+    telemetryService.sendError(err);
+    throw new Error(err);
+  }
+
+  const workspaceRootPath = getRootWorkspacePath();
+  const defaultUsernameOrAlias = await OrgAuthInfo.getDefaultUsernameOrAlias(
+    false
+  );
+
+  if (isNullOrUndefined(defaultUsernameOrAlias)) {
+    const err = nls.localize('error_no_default_username');
+    telemetryService.sendErrorEvent(
+      'Undefined username or alias on orgMetadata.getMetadataTypesPath',
+      err
+    );
+    throw new Error(err);
+  }
+
+  const username = await OrgAuthInfo.getUsername(defaultUsernameOrAlias);
+
+  if (isNullOrUndefined(username)) {
+    const err = nls.localize('error_no_default_username');
+    telemetryService.sendErrorEvent(
+      'Undefined username on orgMetadata.getMetadataTypesPath',
+      err
+    );
+    throw new Error(err);
+  }
+
+  const metadataTypesPath = path.join(
+    workspaceRootPath,
+    '.sfdx',
+    'orgs',
+    username,
+    'metadata',
+    'metadataTypes.json'
+  );
+  return metadataTypesPath;
+}
+
+export type MetadataObject = {
+  directoryName: string;
+  inFolder: boolean;
+  metaFile: boolean;
+  suffix: string;
+  xmlName: string;
+};
+
+export function buildTypesList(metadataTypesPath: string): string[] {
+  try {
+    const fileData = JSON.parse(fs.readFileSync(metadataTypesPath, 'utf8'));
+    const metadataObjects = fileData.metadataObjects as MetadataObject[];
+    const metadataTypes = [];
+    for (const metadataObject of metadataObjects) {
+      if (!isNullOrUndefined(metadataObject.xmlName)) {
+        metadataTypes.push(metadataObject.xmlName);
+      }
+    }
+    telemetryService.sendEventData('Metadata Types Quantity', undefined, {
+      metadataTypes: metadataTypes.length
+    });
+    return metadataTypes;
+  } catch (e) {
+    throw e;
+  }
+}
+
+export async function onUsernameChange() {
+  const metadataTypesPath = await getTypesPath();
+  if (
+    !isNullOrUndefined(metadataTypesPath) &&
+    !fs.existsSync(metadataTypesPath)
+  ) {
+    await forceDescribeMetadata(metadataTypesPath);
+  }
+}

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+import { SinonStub, stub } from 'sinon';
+import { isNullOrUndefined } from 'util';
+import {
+  buildComponentsList,
+  ForceListMetadataExecutor,
+  getComponentsPath
+} from '../../../src/orgBrowser';
+import { getRootWorkspacePath, OrgAuthInfo } from '../../../src/util';
+
+describe('Force List Metadata', () => {
+  it('Should build list metadata command', async () => {
+    const outputPath = 'outputPath';
+    const metadataType = 'ApexClass';
+    const defaultUsername = 'test-username1@example.com';
+    const forceListMetadataExec = new ForceListMetadataExecutor(
+      metadataType,
+      outputPath,
+      defaultUsername
+    );
+    const forceDescribeMetadataCmd = forceListMetadataExec.build({});
+    expect(forceDescribeMetadataCmd.toCommand()).to.equal(
+      `sfdx force:mdapi:listmetadata -m ${metadataType} -u ${defaultUsername} -f ${outputPath} --json --loglevel fatal`
+    );
+  });
+});
+
+// tslint:disable:no-unused-expression
+describe('get metadata components path', () => {
+  let getUsernameStub: SinonStub;
+  const rootWorkspacePath = getRootWorkspacePath();
+  beforeEach(() => {
+    getUsernameStub = stub(OrgAuthInfo, 'getUsername');
+  });
+  afterEach(() => {
+    getUsernameStub.restore();
+  });
+
+  it('should return the path for a given username and metadata type', async () => {
+    getUsernameStub.returns('test-username1@example.com');
+    const metadataType = 'Apex Class';
+    const alias = 'test user 1';
+    const filePath = path.join(
+      rootWorkspacePath,
+      '.sfdx',
+      'orgs',
+      'test-username1@example.com',
+      'metadata',
+      metadataType + '.json'
+    );
+    expect(await getComponentsPath(metadataType, alias)).to.equal(filePath);
+  });
+});
+
+describe('build metadata components list', () => {
+  let readFileStub: SinonStub;
+  beforeEach(() => {
+    readFileStub = stub(fs, 'readFileSync');
+  });
+  afterEach(() => {
+    readFileStub.restore();
+  });
+  it('should return a list of fullNames when given a list of metadata components', async () => {
+    const componentsPath = 'metadataComponentsPath';
+    const metadataType = 'ApexClass';
+    const fileData = JSON.stringify([
+      { fullName: 'fakeName1', suffix: 'fakeSuffix1' },
+      { fullName: 'fakeName2', suffix: 'fakeSuffix2' }
+    ]);
+    readFileStub.returns(fileData);
+    const fullNames = buildComponentsList(componentsPath, metadataType);
+    if (!isNullOrUndefined(fullNames)) {
+      expect(fullNames[0]).to.equal('fakeName1');
+      expect(fullNames[1]).to.equal('fakeName2');
+    }
+  });
+  it('should throw an error if the file does not exist yet', async () => {
+    const metadataTypesPath = 'invalidPath';
+    const metadataType = 'ApexClass';
+    let errorWasThrown = false;
+    try {
+      buildComponentsList(metadataTypesPath, metadataType);
+    } catch (e) {
+      errorWasThrown = true;
+    } finally {
+      expect(errorWasThrown).to.be.true;
+    }
+  });
+});

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
@@ -32,6 +32,21 @@ describe('Force List Metadata', () => {
       `sfdx force:mdapi:listmetadata -m ${metadataType} -u ${defaultUsername} -f ${outputPath} --json --loglevel fatal`
     );
   });
+
+  it('Should build list metadata command with folder arg', async () => {
+    const outputPath = 'outputPath';
+    const metadataType = 'Report';
+    const defaultUsername = 'test-username1@example.com';
+    const forceListMetadataExec = new ForceListMetadataExecutor(
+      metadataType,
+      outputPath,
+      defaultUsername
+    );
+    const forceDescribeMetadataCmd = forceListMetadataExec.build({});
+    expect(forceDescribeMetadataCmd.toCommand()).to.equal(
+      `sfdx force:mdapi:listmetadata -m ${metadataType} -u ${defaultUsername} -f ${outputPath} --json --loglevel fatal --folder unfiled$public`
+    );
+  });
 });
 
 // tslint:disable:no-unused-expression

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
@@ -12,6 +12,7 @@ import { SinonStub, stub } from 'sinon';
 import { isNullOrUndefined } from 'util';
 import {
   buildComponentsList,
+  folderTypes,
   ForceListMetadataExecutor,
   getComponentsPath
 } from '../../../src/orgBrowser';
@@ -35,17 +36,18 @@ describe('Force List Metadata', () => {
 
   it('Should build list metadata command with folder arg', async () => {
     const outputPath = 'outputPath';
-    const metadataType = 'Report';
     const defaultUsername = 'test-username1@example.com';
-    const forceListMetadataExec = new ForceListMetadataExecutor(
-      metadataType,
-      outputPath,
-      defaultUsername
-    );
-    const forceDescribeMetadataCmd = forceListMetadataExec.build({});
-    expect(forceDescribeMetadataCmd.toCommand()).to.equal(
-      `sfdx force:mdapi:listmetadata -m ${metadataType} -u ${defaultUsername} -f ${outputPath} --json --loglevel fatal --folder unfiled$public`
-    );
+    for (const type of folderTypes) {
+      const forceListMetadataExec = new ForceListMetadataExecutor(
+        type,
+        outputPath,
+        defaultUsername
+      );
+      const forceDescribeMetadataCmd = forceListMetadataExec.build({});
+      expect(forceDescribeMetadataCmd.toCommand()).to.equal(
+        `sfdx force:mdapi:listmetadata -m ${type} -u ${defaultUsername} -f ${outputPath} --json --loglevel fatal --folder unfiled$public`
+      );
+    }
   });
 });
 

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataType.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataType.test.ts
@@ -32,7 +32,7 @@ describe('Force Describe Metadata', () => {
 });
 
 // tslint:disable:no-unused-expression
-describe('getMetadataTypesPath', () => {
+describe('get metadata types path', () => {
   let getDefaultUsernameStub: SinonStub;
   let getUsernameStub: SinonStub;
   const rootWorkspacePath = getRootWorkspacePath();

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataType.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataType.test.ts
@@ -14,13 +14,9 @@ import { nls } from '../../../src/messages';
 import {
   buildTypesList,
   ForceDescribeMetadataExecutor,
-  getMetadataTypesPath
+  getTypesPath
 } from '../../../src/orgBrowser';
-import {
-  getRootWorkspacePath,
-  hasRootWorkspace,
-  OrgAuthInfo
-} from '../../../src/util';
+import { getRootWorkspacePath, OrgAuthInfo } from '../../../src/util';
 
 describe('Force Describe Metadata', () => {
   it('Should build describe metadata command', async () => {
@@ -60,14 +56,14 @@ describe('getMetadataTypesPath', () => {
       'metadata',
       'metadataTypes.json'
     );
-    expect(await getMetadataTypesPath()).to.equal(filePath);
+    expect(await getTypesPath()).to.equal(filePath);
   });
 
   it('should throw an error if default username is not set', async () => {
     getDefaultUsernameStub.returns(undefined);
     let errorWasThrown = false;
     try {
-      await getMetadataTypesPath();
+      await getTypesPath();
     } catch (e) {
       errorWasThrown = true;
       expect(e.message).to.equal(nls.localize('error_no_default_username'));


### PR DESCRIPTION
### What does this PR do?
This PR does the groundwork for retrieving metadata component information for a given metadata type. For types that support folders, we are only fetching the components in the top level public folders at this point.

### What issues does this PR fix or reference?
@W-5980323@