### PR TITLE
Update activation logic for default username information

### DIFF
--- a/packages/salesforcedx-vscode-core/src/context/workspaceOrgType.ts
+++ b/packages/salesforcedx-vscode-core/src/context/workspaceOrgType.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { isNullOrUndefined } from 'util';
 import * as vscode from 'vscode';
 import { telemetryService } from '../telemetry';
 import { hasRootWorkspace, OrgAuthInfo } from '../util';
@@ -13,11 +14,10 @@ export enum OrgType {
   NonSourceTracked
 }
 
-export async function getWorkspaceOrgType(): Promise<OrgType> {
-  const defaultUsernameOrAlias = await getDefaultUsernameOrAlias();
-  const defaultUsernameIsSet = typeof defaultUsernameOrAlias !== 'undefined';
-
-  if (defaultUsernameIsSet) {
+export async function getWorkspaceOrgType(
+  defaultUsernameOrAlias?: string
+): Promise<OrgType> {
+  if (!isNullOrUndefined(defaultUsernameOrAlias)) {
     const username = await OrgAuthInfo.getUsername(defaultUsernameOrAlias!);
     const isScratchOrg = await OrgAuthInfo.isAScratchOrg(username).catch(err =>
       telemetryService.sendError(err)
@@ -30,9 +30,9 @@ export async function getWorkspaceOrgType(): Promise<OrgType> {
   throw e;
 }
 
-export async function setupWorkspaceOrgType() {
+export async function setupWorkspaceOrgType(defaultUsernameOrAlias?: string) {
   try {
-    const orgType = await getWorkspaceOrgType();
+    const orgType = await getWorkspaceOrgType(defaultUsernameOrAlias);
     setDefaultUsernameHasChangeTracking(orgType === OrgType.SourceTracked);
     setDefaultUsernameHasNoChangeTracking(orgType === OrgType.NonSourceTracked);
   } catch (e) {

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -352,10 +352,12 @@ function registerOrgPickerCommands(orgList: OrgList): vscode.Disposable {
 }
 
 async function setupOrgBrowser(
-  extensionContext: vscode.ExtensionContext
+  extensionContext: vscode.ExtensionContext,
+  defaultUsernameOrAlias?: string
 ): Promise<void> {
-  const metadataTreeProvider = new MetadataOutlineProvider();
-  await metadataTreeProvider.getDefaultUsernameOrAlias();
+  const metadataTreeProvider = new MetadataOutlineProvider(
+    defaultUsernameOrAlias
+  );
   const metadataProvider = vscode.window.registerTreeDataProvider(
     'metadata',
     metadataTreeProvider
@@ -405,14 +407,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // register org picker commands and set up filewatcher for defaultusername
   const orgList = new OrgList();
-<<<<<<< HEAD
-  await orgList.displayDefaultUsername();
-  context.subscriptions.push(registerOrgPickerCommands(orgList));
-  // await setupOrgBrowser(context);
-=======
   await orgList.displayDefaultUsername(defaultUsernameorAlias);
-  context.subscriptions.push(registerOrgPickerCommands(context, orgList));
->>>>>>> Changes for default username & activation
+  context.subscriptions.push(registerOrgPickerCommands(orgList));
+  // await setupOrgBrowser(context, defaultUsernameorAlias);
 
   vscode.commands.executeCommand('setContext', 'sfdx:display_tree_view', false);
   if (isCLIInstalled()) {

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -398,16 +398,26 @@ export async function activate(context: vscode.ExtensionContext) {
     sfdxProjectOpened
   );
 
+  let defaultUsernameorAlias: string | undefined;
+  if (hasRootWorkspace()) {
+    defaultUsernameorAlias = await OrgAuthInfo.getDefaultUsernameOrAlias(false);
+  }
+
   // register org picker commands and set up filewatcher for defaultusername
   const orgList = new OrgList();
+<<<<<<< HEAD
   await orgList.displayDefaultUsername();
   context.subscriptions.push(registerOrgPickerCommands(orgList));
   // await setupOrgBrowser(context);
+=======
+  await orgList.displayDefaultUsername(defaultUsernameorAlias);
+  context.subscriptions.push(registerOrgPickerCommands(context, orgList));
+>>>>>>> Changes for default username & activation
 
   vscode.commands.executeCommand('setContext', 'sfdx:display_tree_view', false);
   if (isCLIInstalled()) {
     // Set context for defaultusername org
-    await setupWorkspaceOrgType();
+    await setupWorkspaceOrgType(defaultUsernameorAlias);
     await orgList.registerDefaultUsernameWatcher(context);
   } else {
     showCLINotInstalledMessage();

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -407,7 +407,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // register org picker commands and set up filewatcher for defaultusername
   const orgList = new OrgList();
-  await orgList.displayDefaultUsername(defaultUsernameorAlias);
+  orgList.displayDefaultUsername(defaultUsernameorAlias);
   context.subscriptions.push(registerOrgPickerCommands(orgList));
   // await setupOrgBrowser(context, defaultUsernameorAlias);
 

--- a/packages/salesforcedx-vscode-core/src/orgBrowser/metadataOutlineProvider.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/metadataOutlineProvider.ts
@@ -20,10 +20,14 @@ export class MetadataOutlineProvider
     BrowserNode | undefined
   > = this.internalOnDidChangeTreeData.event;
 
-  constructor() {}
+  constructor(defaultOrg?: string) {
+    this.defaultOrg = defaultOrg;
+  }
 
-  public async refresh(): Promise<void> {
-    await this.getDefaultUsernameOrAlias();
+  public async refresh(defaultOrg?: string): Promise<void> {
+    if (!isNullOrUndefined(defaultOrg)) {
+      this.defaultOrg = defaultOrg;
+    }
     this.internalOnDidChangeTreeData.fire();
   }
 

--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -35,14 +35,8 @@ export class OrgList implements vscode.Disposable {
     this.statusBarItem.show();
   }
 
-  public async displayDefaultUsername() {
-    let defaultUsernameorAlias: string | undefined;
-    if (hasRootWorkspace()) {
-      defaultUsernameorAlias = await OrgAuthInfo.getDefaultUsernameOrAlias(
-        false
-      );
-    }
-    if (defaultUsernameorAlias) {
+  public async displayDefaultUsername(defaultUsernameorAlias?: string) {
+    if (!isNullOrUndefined(defaultUsernameorAlias)) {
       this.statusBarItem.text = `$(plug) ${defaultUsernameorAlias}`;
     } else {
       this.statusBarItem.text = nls.localize('missing_default_org');
@@ -177,8 +171,14 @@ export class OrgList implements vscode.Disposable {
   }
 
   public async onSfdxConfigEvent() {
-    await setupWorkspaceOrgType();
-    await this.displayDefaultUsername();
+    let defaultUsernameorAlias: string | undefined;
+    if (hasRootWorkspace()) {
+      defaultUsernameorAlias = await OrgAuthInfo.getDefaultUsernameOrAlias(
+        false
+      );
+    }
+    await setupWorkspaceOrgType(defaultUsernameorAlias);
+    await this.displayDefaultUsername(defaultUsernameorAlias);
   }
 
   public registerDefaultUsernameWatcher(context: vscode.ExtensionContext) {

--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -35,7 +35,7 @@ export class OrgList implements vscode.Disposable {
     this.statusBarItem.show();
   }
 
-  public async displayDefaultUsername(defaultUsernameorAlias?: string) {
+  public displayDefaultUsername(defaultUsernameorAlias?: string) {
     if (!isNullOrUndefined(defaultUsernameorAlias)) {
       this.statusBarItem.text = `$(plug) ${defaultUsernameorAlias}`;
     } else {
@@ -178,7 +178,7 @@ export class OrgList implements vscode.Disposable {
       );
     }
     await setupWorkspaceOrgType(defaultUsernameorAlias);
-    await this.displayDefaultUsername(defaultUsernameorAlias);
+    this.displayDefaultUsername(defaultUsernameorAlias);
   }
 
   public registerDefaultUsernameWatcher(context: vscode.ExtensionContext) {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/context/workspaceOrgType.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/context/workspaceOrgType.test.ts
@@ -167,7 +167,7 @@ describe('setupWorkspaceOrgType', () => {
     const aliasesSpy = sinon.spy(Aliases, 'fetch');
     const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
 
-    await setupWorkspaceOrgType(undefined);
+    await setupWorkspaceOrgType(defaultUsername);
 
     expect(aliasesSpy.called).to.be.false;
     expect(executeCommandStub.calledTwice).to.be.true;
@@ -180,9 +180,9 @@ describe('setupWorkspaceOrgType', () => {
   });
 
   it('should set both sfdx:default_username_has_change_tracking and sfdx:default_username_has_no_change_tracking contexts to true', async () => {
-    const getConfigStub = getDefaultUsernameStub('testUsername');
+    // const getConfigStub = getDefaultUsernameStub('testUsername');
     const aliasesStub = getAliasesFetchStub('test@org.com');
-
+    const defaultUsername = 'test@org.com';
     const error = new Error();
     error.name = 'NamedOrgNotFound';
     const orgAuthInfoStub = sinon
@@ -190,29 +190,30 @@ describe('setupWorkspaceOrgType', () => {
       .throws(error);
     const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
 
-    await setupWorkspaceOrgType();
+    await setupWorkspaceOrgType(defaultUsername);
 
     expect(executeCommandStub.calledTwice).to.be.true;
     expectDefaultUsernameHasChangeTracking(true, executeCommandStub);
     expectDefaultUsernameHasNoChangeTracking(true, executeCommandStub);
 
-    getConfigStub.restore();
+    // getConfigStub.restore();
     aliasesStub.restore();
     orgAuthInfoStub.restore();
     executeCommandStub.restore();
   });
 
   it('should set sfdx:default_username_has_change_tracking to true, and sfdx:default_username_has_no_change_tracking to false', async () => {
-    const getConfigStub = getDefaultUsernameStub('scratchOrgAlias');
+    // const getConfigStub = getDefaultUsernameStub('scratchOrgAlias');
     const aliasesStub = getAliasesFetchStub('scratch@org.com');
     const authInfoCreateStub = getAuthInfoCreateStub({
       getFields: () => ({
         devHubUsername: 'dev@hub.com'
       })
     });
+    const defaultUsername = 'scratchOrgAlias';
     const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
 
-    await setupWorkspaceOrgType();
+    await setupWorkspaceOrgType(defaultUsername);
 
     expect(authInfoCreateStub.getCall(0).args[0]).to.eql({
       username: 'scratch@org.com'
@@ -221,21 +222,21 @@ describe('setupWorkspaceOrgType', () => {
     expectDefaultUsernameHasChangeTracking(true, executeCommandStub);
     expectDefaultUsernameHasNoChangeTracking(false, executeCommandStub);
 
-    getConfigStub.restore();
+    // getConfigStub.restore();
     aliasesStub.restore();
     authInfoCreateStub.restore();
     executeCommandStub.restore();
   });
 
   it('should set sfdx:default_username_has_change_tracking to false, and sfdx:default_username_has_no_change_tracking to true', async () => {
-    const getConfigStub = getDefaultUsernameStub('sandbox@org.com');
+    // const getConfigStub = getDefaultUsernameStub('sandbox@org.com');
     const aliasesStub = getAliasesFetchStub(undefined);
     const authInfoCreateStub = getAuthInfoCreateStub({
       getFields: () => ({})
     });
     const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
-
-    await setupWorkspaceOrgType();
+    const defaultUsername = 'sandbox@org.com';
+    await setupWorkspaceOrgType(defaultUsername);
 
     expect(authInfoCreateStub.getCall(0).args[0]).to.eql({
       username: 'sandbox@org.com'
@@ -244,7 +245,7 @@ describe('setupWorkspaceOrgType', () => {
     expectDefaultUsernameHasChangeTracking(false, executeCommandStub);
     expectDefaultUsernameHasNoChangeTracking(true, executeCommandStub);
 
-    getConfigStub.restore();
+    // getConfigStub.restore();
     aliasesStub.restore();
     authInfoCreateStub.restore();
     executeCommandStub.restore();
@@ -255,7 +256,7 @@ describe('setupWorkspaceOrgType', () => {
     const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
 
     const username = 'test@org.com';
-    const getConfigStub = getDefaultUsernameStub(username);
+    // const getConfigStub = getDefaultUsernameStub(username);
 
     const error = new Error();
     error.name = 'GenericKeychainServiceError';
@@ -266,16 +267,16 @@ describe('setupWorkspaceOrgType', () => {
       .throws(error);
 
     try {
-      expect(await getDefaultUsernameOrAlias()).to.equal(username);
+      // expect(await getDefaultUsernameOrAlias()).to.equal(username);
 
-      await setupWorkspaceOrgType();
+      await setupWorkspaceOrgType(username);
 
       expect(aliasesSpy.called).to.be.true;
       expect(executeCommandStub.calledTwice).to.be.true;
       expectDefaultUsernameHasChangeTracking(true, executeCommandStub);
       expectDefaultUsernameHasNoChangeTracking(true, executeCommandStub);
     } finally {
-      getConfigStub.restore();
+      // getConfigStub.restore();
       aliasesSpy.restore();
       executeCommandStub.restore();
       orgAuthInfoStub.restore();

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/context/workspaceOrgType.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/context/workspaceOrgType.test.ts
@@ -51,7 +51,6 @@ describe('getDefaultUsernameOrAlias', () => {
 
 describe('getWorkspaceOrgType', () => {
   it('returns the source-tracked org type', async () => {
-    // const getConfigStub = getDefaultUsernameStub('scratchOrgAlias');
     const defaultUsername = 'scratchOrgAlias';
     const aliasesStub = getAliasesFetchStub('scratch@org.com');
     const authInfoCreateStub = getAuthInfoCreateStub({
@@ -64,13 +63,11 @@ describe('getWorkspaceOrgType', () => {
 
     expect(orgType).to.equal(OrgType.SourceTracked);
 
-    // getConfigStub.restore();
     aliasesStub.restore();
     authInfoCreateStub.restore();
   });
 
   it('returns the non-source-tracked org type', async () => {
-    // const getConfigStub = getDefaultUsernameStub('sandbox@org.com');
     const defaultUsername = 'sandbox@org.com';
     const aliasesStub = getAliasesFetchStub(undefined);
     const authInfoCreateStub = getAuthInfoCreateStub({
@@ -83,31 +80,27 @@ describe('getWorkspaceOrgType', () => {
       username: 'sandbox@org.com'
     });
 
-    // getConfigStub.restore();
     aliasesStub.restore();
     authInfoCreateStub.restore();
   });
 
   it('throws an error when no defaultusername is set', async () => {
-    // const getConfigStub = getDefaultUsernameStub(undefined);
     const aliasesSpy = sinon.spy(Aliases, 'fetch');
     const defaultUsername = undefined;
     let errorWasThrown = false;
     try {
-      await getWorkspaceOrgType(undefined);
+      await getWorkspaceOrgType(defaultUsername);
     } catch (error) {
       errorWasThrown = true;
       expect(error.name).to.equal('NoDefaultusernameSet');
     } finally {
       expect(aliasesSpy.called).to.be.false;
       expect(errorWasThrown).to.be.true;
-      // getConfigStub.restore();
       aliasesSpy.restore();
     }
   });
 
   it('throws an error when the info cannot be found for the defaultusername', async () => {
-    // const getConfigStub = getDefaultUsernameStub('testUsername');
     const aliasesStub = getAliasesFetchStub('test@org.com');
     const defaultUsername = 'testUsername';
     const error = new Error();
@@ -124,14 +117,12 @@ describe('getWorkspaceOrgType', () => {
       expect(error.name).to.equal('NamedOrgNotFound');
     } finally {
       expect(errorWasThrown).to.be.true;
-      // getConfigStub.restore();
       aliasesStub.restore();
       orgAuthInfoStub.restore();
     }
   });
 
   it('throws an error when the cli has no configuration', async () => {
-    // const getConfigStub = getDefaultUsernameStub('testUsername');
     const aliasesStub = getAliasesFetchStub('test@org.com');
     const defaultUsername = 'testUsername';
     const error = new Error();
@@ -153,7 +144,6 @@ describe('getWorkspaceOrgType', () => {
       );
     } finally {
       expect(errorWasThrown).to.be.true;
-      // getConfigStub.restore();
       aliasesStub.restore();
       orgAuthInfoStub.restore();
     }
@@ -162,7 +152,6 @@ describe('getWorkspaceOrgType', () => {
 
 describe('setupWorkspaceOrgType', () => {
   it('should set both sfdx:default_username_has_change_tracking and sfdx:default_username_has_no_change_tracking contexts to false', async () => {
-    // const getConfigStub = getDefaultUsernameStub(undefined);
     const defaultUsername = undefined;
     const aliasesSpy = sinon.spy(Aliases, 'fetch');
     const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
@@ -174,13 +163,11 @@ describe('setupWorkspaceOrgType', () => {
     expectDefaultUsernameHasChangeTracking(false, executeCommandStub);
     expectDefaultUsernameHasNoChangeTracking(false, executeCommandStub);
 
-    // getConfigStub.restore();
     aliasesSpy.restore();
     executeCommandStub.restore();
   });
 
   it('should set both sfdx:default_username_has_change_tracking and sfdx:default_username_has_no_change_tracking contexts to true', async () => {
-    // const getConfigStub = getDefaultUsernameStub('testUsername');
     const aliasesStub = getAliasesFetchStub('test@org.com');
     const defaultUsername = 'test@org.com';
     const error = new Error();
@@ -196,14 +183,12 @@ describe('setupWorkspaceOrgType', () => {
     expectDefaultUsernameHasChangeTracking(true, executeCommandStub);
     expectDefaultUsernameHasNoChangeTracking(true, executeCommandStub);
 
-    // getConfigStub.restore();
     aliasesStub.restore();
     orgAuthInfoStub.restore();
     executeCommandStub.restore();
   });
 
   it('should set sfdx:default_username_has_change_tracking to true, and sfdx:default_username_has_no_change_tracking to false', async () => {
-    // const getConfigStub = getDefaultUsernameStub('scratchOrgAlias');
     const aliasesStub = getAliasesFetchStub('scratch@org.com');
     const authInfoCreateStub = getAuthInfoCreateStub({
       getFields: () => ({
@@ -222,14 +207,12 @@ describe('setupWorkspaceOrgType', () => {
     expectDefaultUsernameHasChangeTracking(true, executeCommandStub);
     expectDefaultUsernameHasNoChangeTracking(false, executeCommandStub);
 
-    // getConfigStub.restore();
     aliasesStub.restore();
     authInfoCreateStub.restore();
     executeCommandStub.restore();
   });
 
   it('should set sfdx:default_username_has_change_tracking to false, and sfdx:default_username_has_no_change_tracking to true', async () => {
-    // const getConfigStub = getDefaultUsernameStub('sandbox@org.com');
     const aliasesStub = getAliasesFetchStub(undefined);
     const authInfoCreateStub = getAuthInfoCreateStub({
       getFields: () => ({})
@@ -245,7 +228,6 @@ describe('setupWorkspaceOrgType', () => {
     expectDefaultUsernameHasChangeTracking(false, executeCommandStub);
     expectDefaultUsernameHasNoChangeTracking(true, executeCommandStub);
 
-    // getConfigStub.restore();
     aliasesStub.restore();
     authInfoCreateStub.restore();
     executeCommandStub.restore();
@@ -256,7 +238,6 @@ describe('setupWorkspaceOrgType', () => {
     const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
 
     const username = 'test@org.com';
-    // const getConfigStub = getDefaultUsernameStub(username);
 
     const error = new Error();
     error.name = 'GenericKeychainServiceError';
@@ -267,8 +248,6 @@ describe('setupWorkspaceOrgType', () => {
       .throws(error);
 
     try {
-      // expect(await getDefaultUsernameOrAlias()).to.equal(username);
-
       await setupWorkspaceOrgType(username);
 
       expect(aliasesSpy.called).to.be.true;
@@ -276,7 +255,6 @@ describe('setupWorkspaceOrgType', () => {
       expectDefaultUsernameHasChangeTracking(true, executeCommandStub);
       expectDefaultUsernameHasNoChangeTracking(true, executeCommandStub);
     } finally {
-      // getConfigStub.restore();
       aliasesSpy.restore();
       executeCommandStub.restore();
       orgAuthInfoStub.restore();

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/context/workspaceOrgType.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/context/workspaceOrgType.test.ts
@@ -51,7 +51,8 @@ describe('getDefaultUsernameOrAlias', () => {
 
 describe('getWorkspaceOrgType', () => {
   it('returns the source-tracked org type', async () => {
-    const getConfigStub = getDefaultUsernameStub('scratchOrgAlias');
+    // const getConfigStub = getDefaultUsernameStub('scratchOrgAlias');
+    const defaultUsername = 'scratchOrgAlias';
     const aliasesStub = getAliasesFetchStub('scratch@org.com');
     const authInfoCreateStub = getAuthInfoCreateStub({
       getFields: () => ({
@@ -59,55 +60,56 @@ describe('getWorkspaceOrgType', () => {
       })
     });
 
-    const orgType = await getWorkspaceOrgType();
+    const orgType = await getWorkspaceOrgType(defaultUsername);
 
     expect(orgType).to.equal(OrgType.SourceTracked);
 
-    getConfigStub.restore();
+    // getConfigStub.restore();
     aliasesStub.restore();
     authInfoCreateStub.restore();
   });
 
   it('returns the non-source-tracked org type', async () => {
-    const getConfigStub = getDefaultUsernameStub('sandbox@org.com');
+    // const getConfigStub = getDefaultUsernameStub('sandbox@org.com');
+    const defaultUsername = 'sandbox@org.com';
     const aliasesStub = getAliasesFetchStub(undefined);
     const authInfoCreateStub = getAuthInfoCreateStub({
       getFields: () => ({})
     });
-    const orgType = await getWorkspaceOrgType();
+    const orgType = await getWorkspaceOrgType(defaultUsername);
 
     expect(orgType).to.equal(OrgType.NonSourceTracked);
     expect(authInfoCreateStub.getCall(0).args[0]).to.eql({
       username: 'sandbox@org.com'
     });
 
-    getConfigStub.restore();
+    // getConfigStub.restore();
     aliasesStub.restore();
     authInfoCreateStub.restore();
   });
 
   it('throws an error when no defaultusername is set', async () => {
-    const getConfigStub = getDefaultUsernameStub(undefined);
+    // const getConfigStub = getDefaultUsernameStub(undefined);
     const aliasesSpy = sinon.spy(Aliases, 'fetch');
-
+    const defaultUsername = undefined;
     let errorWasThrown = false;
     try {
-      await getWorkspaceOrgType();
+      await getWorkspaceOrgType(undefined);
     } catch (error) {
       errorWasThrown = true;
       expect(error.name).to.equal('NoDefaultusernameSet');
     } finally {
       expect(aliasesSpy.called).to.be.false;
       expect(errorWasThrown).to.be.true;
-      getConfigStub.restore();
+      // getConfigStub.restore();
       aliasesSpy.restore();
     }
   });
 
   it('throws an error when the info cannot be found for the defaultusername', async () => {
-    const getConfigStub = getDefaultUsernameStub('testUsername');
+    // const getConfigStub = getDefaultUsernameStub('testUsername');
     const aliasesStub = getAliasesFetchStub('test@org.com');
-
+    const defaultUsername = 'testUsername';
     const error = new Error();
     error.name = 'NamedOrgNotFound';
     const orgAuthInfoStub = sinon
@@ -116,22 +118,22 @@ describe('getWorkspaceOrgType', () => {
 
     let errorWasThrown = false;
     try {
-      await getWorkspaceOrgType();
+      await getWorkspaceOrgType(defaultUsername);
     } catch (error) {
       errorWasThrown = true;
       expect(error.name).to.equal('NamedOrgNotFound');
     } finally {
       expect(errorWasThrown).to.be.true;
-      getConfigStub.restore();
+      // getConfigStub.restore();
       aliasesStub.restore();
       orgAuthInfoStub.restore();
     }
   });
 
   it('throws an error when the cli has no configuration', async () => {
-    const getConfigStub = getDefaultUsernameStub('testUsername');
+    // const getConfigStub = getDefaultUsernameStub('testUsername');
     const aliasesStub = getAliasesFetchStub('test@org.com');
-
+    const defaultUsername = 'testUsername';
     const error = new Error();
     error.name = 'GenericKeychainServiceError';
     error.stack =
@@ -142,7 +144,7 @@ describe('getWorkspaceOrgType', () => {
 
     let errorWasThrown = false;
     try {
-      await getWorkspaceOrgType();
+      await getWorkspaceOrgType(defaultUsername);
     } catch (error) {
       errorWasThrown = true;
       expect(error.name).to.equal('GenericKeychainServiceError');
@@ -151,7 +153,7 @@ describe('getWorkspaceOrgType', () => {
       );
     } finally {
       expect(errorWasThrown).to.be.true;
-      getConfigStub.restore();
+      // getConfigStub.restore();
       aliasesStub.restore();
       orgAuthInfoStub.restore();
     }
@@ -160,18 +162,19 @@ describe('getWorkspaceOrgType', () => {
 
 describe('setupWorkspaceOrgType', () => {
   it('should set both sfdx:default_username_has_change_tracking and sfdx:default_username_has_no_change_tracking contexts to false', async () => {
-    const getConfigStub = getDefaultUsernameStub(undefined);
+    // const getConfigStub = getDefaultUsernameStub(undefined);
+    const defaultUsername = undefined;
     const aliasesSpy = sinon.spy(Aliases, 'fetch');
     const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
 
-    await setupWorkspaceOrgType();
+    await setupWorkspaceOrgType(undefined);
 
     expect(aliasesSpy.called).to.be.false;
     expect(executeCommandStub.calledTwice).to.be.true;
     expectDefaultUsernameHasChangeTracking(false, executeCommandStub);
     expectDefaultUsernameHasNoChangeTracking(false, executeCommandStub);
 
-    getConfigStub.restore();
+    // getConfigStub.restore();
     aliasesSpy.restore();
     executeCommandStub.restore();
   });


### PR DESCRIPTION
### What does this PR do?
This PR updates the activation logic for the org picker, org browser, and workspace org type to only collect default username information once.

### What issues does this PR fix or reference?
