### PR TITLE
remove -brk option from debug options

### DIFF
--- a/packages/salesforcedx-vscode-lightning/src/index.ts
+++ b/packages/salesforcedx-vscode-lightning/src/index.ts
@@ -93,7 +93,7 @@ export async function activate(context: ExtensionContext) {
 
   // The debug options for the server
   const debugOptions = {
-    execArgv: ['--nolazy', '--inspect-brk=6020']
+    execArgv: ['--nolazy', '--inspect=6020']
   };
 
   // If the extension is launched in debug mode then the debug server options are used

--- a/packages/salesforcedx-vscode-lwc/src/index.ts
+++ b/packages/salesforcedx-vscode-lwc/src/index.ts
@@ -100,7 +100,7 @@ function startLWCLanguageServer(context: ExtensionContext) {
   const serverModule = context.asAbsolutePath(
     path.join('node_modules', 'lwc-language-server', 'lib', 'server.js')
   );
-  const debugOptions = { execArgv: ['--nolazy', '--inspect-brk=6009'] };
+  const debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] };
   // If the extension is launched in debug mode then the debug server options are used
   // Otherwise the run options are used
   const serverOptions: ServerOptions = {


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where launching in debug mode can cause CPU to spike to 100%
