### PR TITLE
Fix issue with context not being properly updated when creating scrat…

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceStartApexDebugLogging.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceStartApexDebugLogging.ts
@@ -118,14 +118,20 @@ export async function getUserId(projectPath: string): Promise<string> {
   const defaultUsernameOrAlias = await getDefaultUsernameOrAlias();
   if (isNullOrUndefined(defaultUsernameOrAlias)) {
     const err = nls.localize('error_no_default_username');
-    telemetryService.sendError(err);
+    telemetryService.sendErrorEvent(
+      'Undefined username or alias when starting Apex Replay Debugger',
+      err
+    );
     throw new Error(err);
   }
 
   const username = await OrgAuthInfo.getUsername(defaultUsernameOrAlias);
   if (isNullOrUndefined(username)) {
     const err = nls.localize('error_no_default_username');
-    telemetryService.sendError(err);
+    telemetryService.sendErrorEvent(
+      'Undefined username when starting Apex Replay Debugger',
+      err
+    );
     throw new Error(err);
   }
 

--- a/packages/salesforcedx-vscode-core/src/commands/forceStartApexDebugLogging.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceStartApexDebugLogging.ts
@@ -27,6 +27,7 @@ import {
   SfdxWorkspaceChecker
 } from './commands';
 
+import { isNullOrUndefined } from 'util';
 import { getDefaultUsernameOrAlias } from '../context';
 import { telemetryService } from '../telemetry';
 import { developerLogTraceFlag } from './';
@@ -115,7 +116,19 @@ export class ForceStartApexDebugLoggingExecutor extends SfdxCommandletExecutor<{
 
 export async function getUserId(projectPath: string): Promise<string> {
   const defaultUsernameOrAlias = await getDefaultUsernameOrAlias();
-  const username = await OrgAuthInfo.getUsername(defaultUsernameOrAlias!);
+  if (isNullOrUndefined(defaultUsernameOrAlias)) {
+    const err = nls.localize('error_no_default_username');
+    telemetryService.sendError(err);
+    throw new Error(err);
+  }
+
+  const username = await OrgAuthInfo.getUsername(defaultUsernameOrAlias);
+  if (isNullOrUndefined(username)) {
+    const err = nls.localize('error_no_default_username');
+    telemetryService.sendError(err);
+    throw new Error(err);
+  }
+
   const execution = new CliCommandExecutor(
     new ForceQueryUser(username).build(),
     {

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -56,12 +56,7 @@ import {
 } from './commands';
 import { getUserId } from './commands/forceStartApexDebugLogging';
 import { isvDebugBootstrap } from './commands/isvdebugging/bootstrapCmd';
-import {
-  getDefaultUsernameOrAlias,
-  getWorkspaceOrgType,
-  OrgType,
-  setupWorkspaceOrgType
-} from './context';
+import { getDefaultUsernameOrAlias, setupWorkspaceOrgType } from './context';
 import * as decorators from './decorators';
 import { isDemoMode } from './modes/demo-mode';
 import { notificationService, ProgressNotification } from './notifications';

--- a/packages/salesforcedx-vscode-core/src/orgBrowser/orgMetadata.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/orgMetadata.ts
@@ -101,7 +101,10 @@ export async function getMetadataTypesPath(): Promise<string | undefined> {
 
   if (isNullOrUndefined(defaultUsernameOrAlias)) {
     const err = nls.localize('error_no_default_username');
-    telemetryService.sendError(err);
+    telemetryService.sendErrorEvent(
+      'Undefined username or alias on orgMetadata.getMetadataTypesPath',
+      err
+    );
     throw new Error(err);
   }
 
@@ -109,7 +112,10 @@ export async function getMetadataTypesPath(): Promise<string | undefined> {
 
   if (isNullOrUndefined(username)) {
     const err = nls.localize('error_no_default_username');
-    telemetryService.sendError(err);
+    telemetryService.sendErrorEvent(
+      'Undefined username on orgMetadata.getMetadataTypesPath',
+      err
+    );
     throw new Error(err);
   }
 

--- a/packages/salesforcedx-vscode-core/src/orgBrowser/orgMetadata.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/orgMetadata.ts
@@ -88,34 +88,40 @@ export async function forceDescribeMetadata(outputPath?: string) {
 }
 
 export async function getMetadataTypesPath(): Promise<string | undefined> {
-  if (hasRootWorkspace()) {
-    const workspaceRootPath = getRootWorkspacePath();
-    const defaultUsernameOrAlias = await OrgAuthInfo.getDefaultUsernameOrAlias(
-      false
-    );
-    const defaultUsernameIsSet = typeof defaultUsernameOrAlias !== 'undefined';
-
-    if (defaultUsernameIsSet) {
-      const username = await OrgAuthInfo.getUsername(defaultUsernameOrAlias!);
-      const metadataTypesPath = path.join(
-        workspaceRootPath,
-        '.sfdx',
-        'orgs',
-        username,
-        'metadata',
-        'metadataTypes.json'
-      );
-      return metadataTypesPath;
-    } else {
-      const err = nls.localize('error_no_default_username');
-      telemetryService.sendError(err);
-      throw new Error(err);
-    }
-  } else {
+  if (!hasRootWorkspace()) {
     const err = nls.localize('cannot_determine_workspace');
     telemetryService.sendError(err);
     throw new Error(err);
   }
+
+  const workspaceRootPath = getRootWorkspacePath();
+  const defaultUsernameOrAlias = await OrgAuthInfo.getDefaultUsernameOrAlias(
+    false
+  );
+
+  if (isNullOrUndefined(defaultUsernameOrAlias)) {
+    const err = nls.localize('error_no_default_username');
+    telemetryService.sendError(err);
+    throw new Error(err);
+  }
+
+  const username = await OrgAuthInfo.getUsername(defaultUsernameOrAlias);
+
+  if (isNullOrUndefined(username)) {
+    const err = nls.localize('error_no_default_username');
+    telemetryService.sendError(err);
+    throw new Error(err);
+  }
+
+  const metadataTypesPath = path.join(
+    workspaceRootPath,
+    '.sfdx',
+    'orgs',
+    username,
+    'metadata',
+    'metadataTypes.json'
+  );
+  return metadataTypesPath;
 }
 
 export type MetadataObject = {

--- a/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
@@ -14,6 +14,7 @@ import { SfdxPackageDirectories } from '../sfdxProject';
 
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { hasRootWorkspace, OrgAuthInfo } from '../util';
 
 const WAIT_TIME_IN_MS = 4500;
 
@@ -41,7 +42,13 @@ export async function registerPushOrDeployOnSave() {
 
 export async function pushOrDeploy(filesToDeploy: vscode.Uri[]): Promise<void> {
   try {
-    const orgType = await getWorkspaceOrgType();
+    let defaultUsernameorAlias: string | undefined;
+    if (hasRootWorkspace()) {
+      defaultUsernameorAlias = await OrgAuthInfo.getDefaultUsernameOrAlias(
+        false
+      );
+    }
+    const orgType = await getWorkspaceOrgType(defaultUsernameorAlias);
     if (orgType === OrgType.SourceTracked) {
       vscode.commands.executeCommand('sfdx.force.source.push');
     } else {

--- a/packages/salesforcedx-vscode-core/src/util/authInfo.ts
+++ b/packages/salesforcedx-vscode-core/src/util/authInfo.ts
@@ -78,12 +78,11 @@ export class OrgAuthInfo {
     }
   }
 
-  public static async getUsername(usernameOrAlias: string): Promise<string> {
+  public static async getUsername(
+    usernameOrAlias: string
+  ): Promise<string | undefined> {
     const username = await Aliases.fetch(usernameOrAlias);
-    if (username) {
-      return Promise.resolve(username);
-    }
-    return Promise.resolve(usernameOrAlias);
+    return Promise.resolve(username);
   }
 
   public static async isAScratchOrg(username: string): Promise<boolean> {
@@ -104,6 +103,7 @@ enum VSCodeWindowTypeEnum {
   Informational = 2,
   Warning = 3
 }
+
 function displayMessage(
   output: string,
   enableWarning?: boolean,

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/context/workspaceOrgType.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/context/workspaceOrgType.test.ts
@@ -22,7 +22,7 @@ describe('getUsername', () => {
   it('should return the username when given a username', async () => {
     const username = 'test@org.com';
     const aliasesStub = getAliasesFetchStub(undefined);
-    expect(await OrgAuthInfo.getUsername(username)).to.equal(username);
+    expect(await OrgAuthInfo.getUsername(username)).to.equal(undefined);
     aliasesStub.restore();
   });
 
@@ -77,7 +77,7 @@ describe('getWorkspaceOrgType', () => {
 
     expect(orgType).to.equal(OrgType.NonSourceTracked);
     expect(authInfoCreateStub.getCall(0).args[0]).to.eql({
-      username: 'sandbox@org.com'
+      username: undefined
     });
 
     aliasesStub.restore();
@@ -222,7 +222,7 @@ describe('setupWorkspaceOrgType', () => {
     await setupWorkspaceOrgType(defaultUsername);
 
     expect(authInfoCreateStub.getCall(0).args[0]).to.eql({
-      username: 'sandbox@org.com'
+      username: undefined
     });
     expect(executeCommandStub.calledTwice).to.be.true;
     expectDefaultUsernameHasChangeTracking(false, executeCommandStub);

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/context/workspaceOrgType.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/context/workspaceOrgType.test.ts
@@ -19,7 +19,7 @@ import {
 import { OrgAuthInfo } from '../../../src/util';
 
 describe('getUsername', () => {
-  it('should return the username when given a username', async () => {
+  it('should return the undefined when given an invalid username', async () => {
     const username = 'test@org.com';
     const aliasesStub = getAliasesFetchStub(undefined);
     expect(await OrgAuthInfo.getUsername(username)).to.equal(undefined);

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgPicker/orgList.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgPicker/orgList.test.ts
@@ -53,6 +53,7 @@ describe('getAuthInfoObjects', () => {
     listAuthFilesStub.restore();
     readFileStub.restore();
   });
+
   it('should return null when no auth files are present', async () => {
     const orgList = new OrgList();
     const listAuthFilesStub = getAuthInfoListAuthFilesStub(null);
@@ -60,6 +61,7 @@ describe('getAuthInfoObjects', () => {
     expect(authInfoObjects).to.equal(null);
     listAuthFilesStub.restore();
   });
+
   const getAuthInfoListAuthFilesStub = (returnValue: any) =>
     sinon
       .stub(AuthInfo, 'listAllAuthFiles')
@@ -68,22 +70,28 @@ describe('getAuthInfoObjects', () => {
 
 describe('Filter Authorization Info', async () => {
   let defaultDevHubStub: sinon.SinonStub;
+  let getUsernameStub: sinon.SinonStub;
   let aliasCreateStub: sinon.SinonStub;
   let aliasKeysStub: sinon.SinonStub;
   const orgList = new OrgList();
+
   beforeEach(() => {
     defaultDevHubStub = sinon.stub(
       OrgAuthInfo,
       'getDefaultDevHubUsernameOrAlias'
     );
+    getUsernameStub = sinon.stub(OrgAuthInfo, 'getUsername');
     aliasCreateStub = sinon.stub(Aliases, 'create');
     aliasKeysStub = sinon.stub(Aliases.prototype, 'getKeysByValue');
   });
+
   afterEach(() => {
     defaultDevHubStub.restore();
+    getUsernameStub.restore();
     aliasCreateStub.restore();
     aliasKeysStub.restore();
   });
+
   it('should filter the list for users other than admins when scratchadminusername field is present', async () => {
     const authInfoObjects: FileInfo[] = [
       JSON.parse(
@@ -129,6 +137,7 @@ describe('Filter Authorization Info', async () => {
       )
     ];
     defaultDevHubStub.returns('test-devhub1@gmail.com');
+    getUsernameStub.returns('test-devhub1@gmail.com');
     aliasCreateStub.returns(Aliases.prototype);
     aliasKeysStub.returns([]);
     const authList = await orgList.filterAuthInfo(authInfoObjects);


### PR DESCRIPTION
…ch orgs

### What does this PR do?
Refactor needed to address the issue where command context is not properly update when creating scratch orgs. 
Root cause: because of the latest perf updates we've shipped, we are running a bit faster than how the cli sets scratch auth context. This causes us not to receive enough information to set the correct context used to control visibility of some commands (e.g. Push/Pull & Deploy/Retrieve).

### What issues does this PR fix or reference?
Issue #1196, @W-5988233@