### PR TITLE
Bp/org picker msgs

### DIFF
--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -165,12 +165,6 @@ export class OrgList implements vscode.Disposable {
     }
   }
 
-  public async getDefaultUsernameOrAlias() {
-    if (hasRootWorkspace()) {
-      return OrgAuthInfo.getDefaultDevHubUsernameOrAlias(false);
-    }
-  }
-
   public async getDefaultDevHubUsernameorAlias(): Promise<string | undefined> {
     if (hasRootWorkspace()) {
       return OrgAuthInfo.getDefaultDevHubUsernameOrAlias(false);

--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -109,15 +109,20 @@ export class OrgList implements vscode.Disposable {
 
   public async setDefaultOrg(): Promise<CancelResponse | ContinueResponse<{}>> {
     let quickPickList = [
-      '$(plus) ' + nls.localize('force_auth_web_login_authorize_org_text'),
-      '$(plus) ' + nls.localize('force_org_create_default_scratch_org_text')
+      '$(plus) ' + nls.localize('force_auth_web_login_authorize_org_text')
     ];
+
     const defaultDevHubUsernameorAlias = await this.getDefaultDevHubUsernameorAlias();
     if (isNullOrUndefined(defaultDevHubUsernameorAlias)) {
       quickPickList.push(
         '$(plus) ' + nls.localize('force_auth_web_login_authorize_dev_hub_text')
       );
+    } else {
+      quickPickList.push(
+        '$(plus) ' + nls.localize('force_org_create_default_scratch_org_text')
+      );
     }
+
     const authInfoList = await this.updateOrgList();
     if (!isNullOrUndefined(authInfoList)) {
       quickPickList = quickPickList.concat(authInfoList);
@@ -160,9 +165,15 @@ export class OrgList implements vscode.Disposable {
     }
   }
 
+  public async getDefaultUsernameOrAlias() {
+    if (hasRootWorkspace()) {
+      return OrgAuthInfo.getDefaultDevHubUsernameOrAlias(false);
+    }
+  }
+
   public async getDefaultDevHubUsernameorAlias(): Promise<string | undefined> {
     if (hasRootWorkspace()) {
-      return OrgAuthInfo.getDefaultDevHubUsernameOrAlias();
+      return OrgAuthInfo.getDefaultDevHubUsernameOrAlias(false);
     }
   }
 

--- a/packages/salesforcedx-vscode-core/src/util/authInfo.ts
+++ b/packages/salesforcedx-vscode-core/src/util/authInfo.ts
@@ -52,9 +52,9 @@ export class OrgAuthInfo {
     }
   }
 
-  public static async getDefaultDevHubUsernameOrAlias(): Promise<
-    string | undefined
-  > {
+  public static async getDefaultDevHubUsernameOrAlias(
+    enableWarning: boolean
+  ): Promise<string | undefined> {
     try {
       const defaultDevHubUserName = await ConfigUtil.getConfigValue(
         defaultDevHubUserNameKey
@@ -62,7 +62,7 @@ export class OrgAuthInfo {
       if (isUndefined(defaultDevHubUserName)) {
         displayMessage(
           nls.localize('error_no_default_devhubusername'),
-          true,
+          enableWarning,
           VSCodeWindowTypeEnum.Error
         );
         return undefined;

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgPicker/orgList.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgPicker/orgList.test.ts
@@ -167,6 +167,7 @@ describe('Set Default Org', () => {
   let defaultDevHubStub: sinon.SinonStub;
   let orgListStub: sinon.SinonStub;
   let quickPickStub: sinon.SinonStub;
+  let executeCommandStub: sinon.SinonStub;
   const orgsList = [
     'alias - test-username1@gmail.com',
     'test-username2@gmail.com'
@@ -180,19 +181,21 @@ describe('Set Default Org', () => {
     );
     orgListStub = sinon.stub(OrgList.prototype, 'updateOrgList');
     quickPickStub = sinon.stub(vscode.window, 'showQuickPick');
+    executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
+  });
+
+  afterEach(() => {
+    orgListStub.restore();
+    quickPickStub.restore();
+    defaultDevHubStub.restore();
+    executeCommandStub.restore();
   });
 
   it('should return Cancel if selection is undefined', async () => {
-    try {
-      orgListStub.returns(orgsList);
-      quickPickStub.returns(undefined);
-      const response = await orgList.setDefaultOrg();
-      expect(response.type).to.equal('CANCEL');
-    } finally {
-      orgListStub.restore();
-      quickPickStub.restore();
-      defaultDevHubStub.restore();
-    }
+    orgListStub.returns(orgsList);
+    quickPickStub.returns(undefined);
+    const response = await orgList.setDefaultOrg();
+    expect(response.type).to.equal('CANCEL');
   });
 
   it('should return Continue and call force:auth:web:login command if SFDX: Authorize an Org is selected', async () => {
@@ -200,18 +203,11 @@ describe('Set Default Org', () => {
     quickPickStub.returns(
       '$(plus) ' + nls.localize('force_auth_web_login_authorize_org_text')
     );
-    const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
-    try {
-      const response = await orgList.setDefaultOrg();
-      expect(response.type).to.equal('CONTINUE');
-      const commandResult = expect(
-        executeCommandStub.calledWith('sfdx.force.auth.web.login')
-      ).to.be.true;
-    } finally {
-      orgListStub.restore();
-      quickPickStub.restore();
-      executeCommandStub.restore();
-    }
+    const response = await orgList.setDefaultOrg();
+    expect(response.type).to.equal('CONTINUE');
+    const commandResult = expect(
+      executeCommandStub.calledWith('sfdx.force.auth.web.login')
+    ).to.be.true;
   });
 
   it('should return Continue and call force:org:create command if SFDX: Create a Default Scratch Org is selected', async () => {
@@ -219,18 +215,11 @@ describe('Set Default Org', () => {
     quickPickStub.returns(
       '$(plus) ' + nls.localize('force_org_create_default_scratch_org_text')
     );
-    const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
-    try {
-      const response = await orgList.setDefaultOrg();
-      expect(response.type).to.equal('CONTINUE');
-      const commandResult = expect(
-        executeCommandStub.calledWith('sfdx.force.org.create')
-      ).to.be.true;
-    } finally {
-      orgListStub.restore();
-      quickPickStub.restore();
-      executeCommandStub.restore();
-    }
+    const response = await orgList.setDefaultOrg();
+    expect(response.type).to.equal('CONTINUE');
+    const commandResult = expect(
+      executeCommandStub.calledWith('sfdx.force.org.create')
+    ).to.be.true;
   });
 
   it('should return Continue and call force:auth:dev:hub command if SFDX: Authorize a Dev Hub is selected', async () => {
@@ -238,45 +227,35 @@ describe('Set Default Org', () => {
     quickPickStub.returns(
       '$(plus) ' + nls.localize('force_auth_web_login_authorize_dev_hub_text')
     );
-    const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
-    try {
-      const response = await orgList.setDefaultOrg();
-      expect(response.type).to.equal('CONTINUE');
-      const commandResult = expect(
-        executeCommandStub.calledWith('sfdx.force.auth.dev.hub')
-      ).to.be.true;
-    } finally {
-      orgListStub.restore();
-      quickPickStub.restore();
-      executeCommandStub.restore();
-    }
+    const response = await orgList.setDefaultOrg();
+    expect(response.type).to.equal('CONTINUE');
+    const commandResult = expect(
+      executeCommandStub.calledWith('sfdx.force.auth.dev.hub')
+    ).to.be.true;
   });
 
   it('should return Continue and call force:config:set command if a username/alias is selected', async () => {
     orgListStub.returns(orgsList);
     quickPickStub.returns('$(plus)' + orgsList[0].split(' ', 1));
-    const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
-    try {
-      const response = await orgList.setDefaultOrg();
-      expect(response.type).to.equal('CONTINUE');
-      const commandResult = expect(
-        executeCommandStub.calledWith('sfdx.force.config.set')
-      ).to.be.true;
-    } finally {
-      orgListStub.restore();
-      quickPickStub.restore();
-      executeCommandStub.restore();
-    }
+    const response = await orgList.setDefaultOrg();
+    expect(response.type).to.equal('CONTINUE');
+    const commandResult = expect(
+      executeCommandStub.calledWith('sfdx.force.config.set')
+    ).to.be.true;
   });
 
-  it('should show appropriate commands depending on whether or not a default dev hub is set', async () => {
-    defaultDevHubStub.returns(undefined);
-    const response = await orgList.setDefaultOrg();
-    expect(
-      quickPickStub.calledWith([
-        '$(plus) ' + nls.localize('force_auth_web_login_authorize_org_text'),
-        '$(plus) ' + nls.localize('force_auth_web_login_authorize_dev_hub_text')
-      ])
-    );
+  it('should show appropriate commands depending on whether a dev hub is set or not', async () => {
+    defaultDevHubStub.onCall(0).returns(undefined);
+    defaultDevHubStub.onCall(1).returns('test@test.test');
+    let response = await orgList.setDefaultOrg();
+    response = await orgList.setDefaultOrg();
+    expect(quickPickStub.getCall(0).args[0]).to.eql([
+      '$(plus) ' + nls.localize('force_auth_web_login_authorize_org_text'),
+      '$(plus) ' + nls.localize('force_auth_web_login_authorize_dev_hub_text')
+    ]);
+    expect(quickPickStub.getCall(1).args[0]).to.eql([
+      '$(plus) ' + nls.localize('force_auth_web_login_authorize_org_text'),
+      '$(plus) ' + nls.localize('force_org_create_default_scratch_org_text')
+    ]);
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgPicker/orgList.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgPicker/orgList.test.ts
@@ -164,6 +164,7 @@ describe('Filter Authorization Info', async () => {
 });
 
 describe('Set Default Org', () => {
+  let defaultDevHubStub: sinon.SinonStub;
   let orgListStub: sinon.SinonStub;
   let quickPickStub: sinon.SinonStub;
   const orgsList = [
@@ -173,6 +174,10 @@ describe('Set Default Org', () => {
   const orgList = new OrgList();
 
   beforeEach(() => {
+    defaultDevHubStub = sinon.stub(
+      OrgAuthInfo,
+      'getDefaultDevHubUsernameOrAlias'
+    );
     orgListStub = sinon.stub(OrgList.prototype, 'updateOrgList');
     quickPickStub = sinon.stub(vscode.window, 'showQuickPick');
   });
@@ -186,6 +191,7 @@ describe('Set Default Org', () => {
     } finally {
       orgListStub.restore();
       quickPickStub.restore();
+      defaultDevHubStub.restore();
     }
   });
 
@@ -261,5 +267,16 @@ describe('Set Default Org', () => {
       quickPickStub.restore();
       executeCommandStub.restore();
     }
+  });
+
+  it('should show appropriate commands depending on whether or not a default dev hub is set', async () => {
+    defaultDevHubStub.returns(undefined);
+    const response = await orgList.setDefaultOrg();
+    expect(
+      quickPickStub.calledWith([
+        '$(plus) ' + nls.localize('force_auth_web_login_authorize_org_text'),
+        '$(plus) ' + nls.localize('force_auth_web_login_authorize_dev_hub_text')
+      ])
+    );
   });
 });


### PR DESCRIPTION
### What does this PR do?

Removes warning message when opening the org picker that a default dev hub is not set. Every time the list was opened the message was written twice in the output console and a notification pops up. Also only show option for creating a scratch org if we have a dev hub set, or if we don't have a dev hub set show the option to authorize one.

### What issues does this PR fix or reference?

W-6104719