### PR TITLE
Show all the org auth/creation options in picker regardless of auth status

### DIFF
--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -109,19 +109,10 @@ export class OrgList implements vscode.Disposable {
 
   public async setDefaultOrg(): Promise<CancelResponse | ContinueResponse<{}>> {
     let quickPickList = [
-      '$(plus) ' + nls.localize('force_auth_web_login_authorize_org_text')
+      '$(plus) ' + nls.localize('force_auth_web_login_authorize_org_text'),
+      '$(plus) ' + nls.localize('force_auth_web_login_authorize_dev_hub_text'),
+      '$(plus) ' + nls.localize('force_org_create_default_scratch_org_text')
     ];
-
-    const defaultDevHubUsernameorAlias = await this.getDefaultDevHubUsernameorAlias();
-    if (isNullOrUndefined(defaultDevHubUsernameorAlias)) {
-      quickPickList.push(
-        '$(plus) ' + nls.localize('force_auth_web_login_authorize_dev_hub_text')
-      );
-    } else {
-      quickPickList.push(
-        '$(plus) ' + nls.localize('force_org_create_default_scratch_org_text')
-      );
-    }
 
     const authInfoList = await this.updateOrgList();
     if (!isNullOrUndefined(authInfoList)) {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgPicker/orgList.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgPicker/orgList.test.ts
@@ -173,7 +173,6 @@ describe('Filter Authorization Info', async () => {
 });
 
 describe('Set Default Org', () => {
-  let defaultDevHubStub: sinon.SinonStub;
   let orgListStub: sinon.SinonStub;
   let quickPickStub: sinon.SinonStub;
   let executeCommandStub: sinon.SinonStub;
@@ -184,10 +183,6 @@ describe('Set Default Org', () => {
   const orgList = new OrgList();
 
   beforeEach(() => {
-    defaultDevHubStub = sinon.stub(
-      OrgAuthInfo,
-      'getDefaultDevHubUsernameOrAlias'
-    );
     orgListStub = sinon.stub(OrgList.prototype, 'updateOrgList');
     quickPickStub = sinon.stub(vscode.window, 'showQuickPick');
     executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
@@ -196,7 +191,6 @@ describe('Set Default Org', () => {
   afterEach(() => {
     orgListStub.restore();
     quickPickStub.restore();
-    defaultDevHubStub.restore();
     executeCommandStub.restore();
   });
 
@@ -251,20 +245,5 @@ describe('Set Default Org', () => {
     const commandResult = expect(
       executeCommandStub.calledWith('sfdx.force.config.set')
     ).to.be.true;
-  });
-
-  it('should show appropriate commands depending on whether a dev hub is set or not', async () => {
-    defaultDevHubStub.onCall(0).returns(undefined);
-    defaultDevHubStub.onCall(1).returns('test@test.test');
-    let response = await orgList.setDefaultOrg();
-    response = await orgList.setDefaultOrg();
-    expect(quickPickStub.getCall(0).args[0]).to.eql([
-      '$(plus) ' + nls.localize('force_auth_web_login_authorize_org_text'),
-      '$(plus) ' + nls.localize('force_auth_web_login_authorize_dev_hub_text')
-    ]);
-    expect(quickPickStub.getCall(1).args[0]).to.eql([
-      '$(plus) ' + nls.localize('force_auth_web_login_authorize_org_text'),
-      '$(plus) ' + nls.localize('force_org_create_default_scratch_org_text')
-    ]);
   });
 });


### PR DESCRIPTION
### What does this PR do?

Show all the org auth/creation options in the org picker.

### What issues does this PR fix or reference?

W-6143678