### PR TITLE
Fix for default dev hub username in org picker and test fix

### DIFF
--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -73,9 +73,10 @@ export class OrgList implements vscode.Disposable {
 
     const defaultDevHubUsernameorAlias = await this.getDefaultDevHubUsernameorAlias();
     if (defaultDevHubUsernameorAlias) {
-      const defaultDevHubUsername = await OrgAuthInfo.getUsername(
-        defaultDevHubUsernameorAlias
-      );
+      const defaultDevHubUsername =
+        (await OrgAuthInfo.getUsername(defaultDevHubUsernameorAlias)) ||
+        defaultDevHubUsernameorAlias;
+
       authInfoObjects = authInfoObjects.filter(
         fileData =>
           isNullOrUndefined(fileData.devHubUsername) ||

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/channels/index.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/channels/index.test.ts
@@ -79,7 +79,7 @@ describe('Channel', () => {
       });
       expect(mChannel.value).to.contain('Starting sfdx force --help');
       expect(mChannel.value).to.contain(
-        'USAGE\n  $ sfdx force [--json] [--loglevel trace|debug|info|warn|error|fatal]'
+        'USAGE\n  $ sfdx force [--json] [--loglevel \n  trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]'
       );
       expect(mChannel.value).to.contain('ended with exit code 0');
     });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgPicker/orgList.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgPicker/orgList.test.ts
@@ -119,7 +119,7 @@ describe('Filter Authorization Info', async () => {
     expect(authList[0]).to.equal('test-username2@gmail.com');
   });
 
-  it('should filter the list to only show scratch orgs associated with current default dev hub', async () => {
+  it('should filter the list to only show scratch orgs associated with current default dev hub without an alias', async () => {
     const authInfoObjects: FileInfo[] = [
       JSON.parse(
         JSON.stringify({
@@ -137,6 +137,31 @@ describe('Filter Authorization Info', async () => {
       )
     ];
     defaultDevHubStub.returns('test-devhub1@gmail.com');
+    getUsernameStub.returns(undefined);
+    aliasCreateStub.returns(Aliases.prototype);
+    aliasKeysStub.returns([]);
+    const authList = await orgList.filterAuthInfo(authInfoObjects);
+    expect(authList[0]).to.equal('test-scratchorg1@gmail.com');
+  });
+
+  it('should filter the list to only show scratch orgs associated with current default dev hub with an alias', async () => {
+    const authInfoObjects: FileInfo[] = [
+      JSON.parse(
+        JSON.stringify({
+          orgId: '000',
+          username: 'test-scratchorg1@gmail.com',
+          devHubUsername: 'test-devhub1@gmail.com'
+        })
+      ),
+      JSON.parse(
+        JSON.stringify({
+          orgId: '111',
+          username: 'test-scratchorg2@gmail.com',
+          devHubUsername: 'test-devhub2@gmail.com'
+        })
+      )
+    ];
+    defaultDevHubStub.returns('dev hub alias');
     getUsernameStub.returns('test-devhub1@gmail.com');
     aliasCreateStub.returns(Aliases.prototype);
     aliasKeysStub.returns([]);


### PR DESCRIPTION
### What does this PR do?
This PR allows for scratch orgs associated with the default dev hub username to be displayed even when the default dev hub has no alias set. Also includes a test fix due to the new version of the CLI.

### What issues does this PR fix or reference?
W-6155361