### PR TITLE
Bundling changes for vf extension

### DIFF
--- a/packages/salesforcedx-vscode-visualforce/.vscodeignore
+++ b/packages/salesforcedx-vscode-visualforce/.vscodeignore
@@ -6,8 +6,36 @@ src/**
 **/*.map
 .gitignore
 tsconfig.json
+images/**
+!images/VSCodeVisualforce.png
+typings/**
 
 # salesforcedx-visualforce-language-server files to ignore
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/bin/*
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/lib/cs/*
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/lib/de/*
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/lib/es/*
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/lib/fr/*
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/lib/it/*
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/lib/ja/*
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/lib/ko/*
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/lib/pl/*
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/lib/pt-br/*
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/lib/ru/*
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/lib/tr/*
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/lib/zh-cn/*
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/lib/zh-tw/*
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/lib/protocol.d.ts
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/lib/tsc.js
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/lib/tsserver.js
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/lib/tsserverlibrary.js
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/lib/tsserverlibrary.d.ts
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/lib/typescript.d.ts
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/lib/typescriptServices.d.ts
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/lib/typescriptServices.js
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/lib/typesMap.json
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/lib/typingsInstaller.js
+node_modules/@salesforce/salesforcedx-visualforce-language-server/node_modules/typescript/lib/watchGuard.js
 node_modules/@salesforce/salesforcedx-visualforce-language-server/src/**
 node_modules/@salesforce/salesforcedx-visualforce-language-server/test/**
 node_modules/@salesforce/salesforcedx-visualforce-language-server/.vscode


### PR DESCRIPTION
### What does this PR do?
Update how we import typescript & how we bundle it when creating the visualforce extension. This change will allow us to decrease the size of the visualforce extension from 9MB to 2.5MB

FYI: this is a similar strategy to what VSCode is doing when bundling extensions that rely on `typescript` e.g. Javascript https://github.com/microsoft/vscode/blob/master/extensions/postinstall.js

### What issues does this PR fix or reference?
@W-6330667@