### PR TITLE
Remove dirty doc check for deploy on save and add telemetry

### DIFF
--- a/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
@@ -47,7 +47,6 @@ export class DeployQueue {
   }
 
   public async enqueue(document: vscode.Uri) {
-    telemetryService.sendEventData('deployOnSaveEnqueue');
     this.queue.add(document);
     await this.wait();
     await this.doDeploy();
@@ -141,7 +140,9 @@ function displayError(message: string) {
   notificationService.showErrorMessage(message);
   channelService.appendLine(message);
   channelService.showChannelOutput();
-  telemetryService.sendError(`DeployOnSaveError: ${message}`);
+  telemetryService.sendError(
+    `DeployOnSaveError: Documents were queued but a deployment was not triggered`
+  );
 }
 
 async function ignorePath(uri: vscode.Uri) {

--- a/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
@@ -15,6 +15,7 @@ import { SfdxPackageDirectories } from '../sfdxProject';
 import * as path from 'path';
 import { setTimeout } from 'timers';
 import * as vscode from 'vscode';
+import { telemetryService } from '../telemetry';
 import { hasRootWorkspace, OrgAuthInfo } from '../util';
 
 export class DeployQueue {
@@ -25,6 +26,7 @@ export class DeployQueue {
   private readonly queue = new Set<vscode.Uri>();
   private timer: NodeJS.Timer | undefined;
   private locked = false;
+  private deployWaitStart?: [number, number];
 
   private constructor() {}
 
@@ -45,6 +47,7 @@ export class DeployQueue {
   }
 
   public async enqueue(document: vscode.Uri) {
+    telemetryService.sendEventData('deployOnSaveEnqueue');
     this.queue.add(document);
     await this.wait();
     await this.doDeploy();
@@ -86,6 +89,20 @@ export class DeployQueue {
             toDeploy
           );
         }
+
+        telemetryService.sendEventData(
+          'deployOnSave',
+          {
+            deployType: orgType === OrgType.SourceTracked ? 'Push' : 'Deploy'
+          },
+          {
+            documentsToDeploy: toDeploy.length,
+            waitTimeForLastDeploy: this.deployWaitStart
+              ? parseFloat(telemetryService.getEndHRTime(this.deployWaitStart))
+              : 0
+          }
+        );
+        this.deployWaitStart = undefined;
       } catch (e) {
         switch (e.name) {
           case 'NamedOrgNotFound':
@@ -100,31 +117,21 @@ export class DeployQueue {
             displayError(e.message);
         }
         this.locked = false;
+        this.deployWaitStart = undefined;
       }
+    } else if (this.locked && !this.deployWaitStart) {
+      this.deployWaitStart = process.hrtime();
     }
   }
 }
 
 export async function registerPushOrDeployOnSave() {
-  const dirtyDocs = new Set<vscode.Uri>();
-  vscode.workspace.onWillSaveTextDocument(
-    (e: vscode.TextDocumentWillSaveEvent) => {
-      if (
-        sfdxCoreSettings.getPushOrDeployOnSaveEnabled() &&
-        e.document.isDirty
-      ) {
-        dirtyDocs.add(e.document.uri);
-      }
-    }
-  );
   vscode.workspace.onDidSaveTextDocument(
     async (textDocument: vscode.TextDocument) => {
       if (
         sfdxCoreSettings.getPushOrDeployOnSaveEnabled() &&
-        !(await ignorePath(textDocument.uri)) &&
-        dirtyDocs.has(textDocument.uri)
+        !(await ignorePath(textDocument.uri))
       ) {
-        dirtyDocs.delete(textDocument.uri);
         await DeployQueue.get().enqueue(textDocument.uri);
       }
     }
@@ -135,6 +142,7 @@ function displayError(message: string) {
   notificationService.showErrorMessage(message);
   channelService.appendLine(message);
   channelService.showChannelOutput();
+  telemetryService.sendError(`DeployOnSaveError: ${message}`);
 }
 
 async function ignorePath(uri: vscode.Uri) {

--- a/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
@@ -102,7 +102,6 @@ export class DeployQueue {
               : 0
           }
         );
-        this.deployWaitStart = undefined;
       } catch (e) {
         switch (e.name) {
           case 'NamedOrgNotFound':
@@ -117,8 +116,8 @@ export class DeployQueue {
             displayError(e.message);
         }
         this.locked = false;
-        this.deployWaitStart = undefined;
       }
+      this.deployWaitStart = undefined;
     } else if (this.locked && !this.deployWaitStart) {
       this.deployWaitStart = process.hrtime();
     }

--- a/packages/salesforcedx-vscode-core/src/telemetry/telemetry.ts
+++ b/packages/salesforcedx-vscode-core/src/telemetry/telemetry.ts
@@ -190,8 +190,8 @@ export class TelemetryService {
     }
   }
 
-  private getEndHRTime(hrstart: [number, number]): string {
+  public getEndHRTime(hrstart: [number, number]): string {
     const hrend = process.hrtime(hrstart);
-    return util.format('%d%d', hrend[0], hrend[1] / 1000000);
+    return util.format('%d.%d', hrend[0], Math.round(hrend[1] / 1000000));
   }
 }

--- a/packages/salesforcedx-vscode-core/src/telemetry/telemetry.ts
+++ b/packages/salesforcedx-vscode-core/src/telemetry/telemetry.ts
@@ -192,6 +192,6 @@ export class TelemetryService {
 
   public getEndHRTime(hrstart: [number, number]): string {
     const hrend = process.hrtime(hrstart);
-    return util.format('%d.%d', hrend[0], Math.round(hrend[1] / 1000000));
+    return util.format('%d%d', hrend[0], hrend[1] / 1000000);
   }
 }


### PR DESCRIPTION
### What does this PR do?

We're suspecting the way the listeners are set up to determine what documents are dirty before kicking of a deploy is problematic for some users. This removes the check for a dirty document before kicking off a deploy and will do so whether or not the file actually changed when a user saves it. To help further investigate, telemetry data is being added. 

### What issues does this PR fix or reference?

W-6330470
#1451 