### PR TITLE
Don’t show "no code coverage" warning when viewing a testclass

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/codecoverage/colorizer.ts
+++ b/packages/salesforcedx-vscode-apex/src/codecoverage/colorizer.ts
@@ -157,10 +157,17 @@ export class CodeCoverage {
             covItem.name === getApexMemberName(editor.document.uri.fsPath)
         );
 
-        if (!codeCovItem) {
+        const isTestclass = editor.document
+          .getText()
+          .toLowerCase()
+          .includes('@istest');
+
+        if (!codeCovItem && !isTestclass) {
           throw new Error(
             nls.localize('colorizer_no_code_coverage_current_file')
           );
+        } else if (!codeCovItem) {
+          return;
         }
 
         for (const key in codeCovItem.lines) {


### PR DESCRIPTION
### What does this PR do?
Minor tweak regarding the display of the _No code coverage information was found for this file [...]_ warning when viewing test classes.
Now, the warning is only displayed in case `@istest` is not included inside the opened file.

### What issues does this PR fix or reference?
No reference, just a minor nuisance I happen to run into a lot, always drawing my attention to the warning when switching editor tabs.