### PR TITLE
Settings should not require editing JSON for simple primitive types

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -229,16 +229,12 @@
           "description": "%java_home_description%"
         },
         "salesforcedx-vscode-apex.enable-semantic-errors": {
-          "type": [
-            "boolean"
-          ],
+          "type": "boolean",
           "default": false,
           "description": "%apex_semantic_errors_description%"
         },
         "salesforcedx-vscode-apex.enable-sobject-refresh-on-startup": {
-          "type": [
-            "boolean"
-          ],
+          "type": "boolean",
           "default": false,
           "description": "%enable_sobject_refresh_on_startup_description%"
         }

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -673,44 +673,32 @@
       "title": "%feature_previews_title%",
       "properties": {
         "salesforcedx-vscode-core.show-cli-success-msg": {
-          "type": [
-            "boolean"
-          ],
+          "type": "boolean",
           "default": true,
           "description": "%show_cli_success_msg_description%"
         },
         "salesforcedx-vscode-core.retrieve-test-code-coverage": {
-          "type": [
-            "boolean"
-          ],
+          "type": "boolean",
           "default": false,
           "description": "%retrieve_test_code_coverage_text%"
         },
         "salesforcedx-vscode-core.telemetry.enabled": {
-          "type": [
-            "boolean"
-          ],
+          "type": "boolean",
           "default": true,
           "description": "%telemetry_enabled_description%"
         },
         "salesforcedx-vscode-core.push-or-deploy-on-save.enabled": {
-          "type": [
-            "boolean"
-          ],
+          "type": "boolean",
           "default": false,
           "description": "%push_or_deploy_on_save_enabled_description%"
         },
         "salesforcedx-vscode-core.internal-development": {
-          "type": [
-            "boolean"
-          ],
+          "type": "boolean",
           "default": false,
           "description": "%internal_dev_description%"
         },
         "salesforcedx-vscode-core.show-org-browser": {
-          "type": [
-            "boolean"
-          ],
+          "type": "boolean",
           "default": false
         }
       }


### PR DESCRIPTION
Simple primitive settings were changed to primitives instead of arrays

resolves forcedotcom/salesforcedx-vscode#1494

### What does this PR do?
Updates simple primitive settings to allow editing in the UI instead of editing JSON.

### What issues does this PR fix or reference?
#1494
