### PR TITLE
Remove regex that evaluates defaultusername

### DIFF
--- a/packages/salesforcedx-vscode-core/src/context/workspaceOrgType.ts
+++ b/packages/salesforcedx-vscode-core/src/context/workspaceOrgType.ts
@@ -23,15 +23,11 @@ export async function getWorkspaceOrgType(
     throw e;
   }
 
-  const email = /^\w+([\.$-]*\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/.test(
-    defaultUsernameOrAlias
-  );
-  const isUsername = email ? true : false;
   const username = await OrgAuthInfo.getUsername(defaultUsernameOrAlias);
 
   if (isNullOrUndefined(username)) {
     telemetryService.sendError(
-      `workspaceOrgType.getWorkspaceOrgType ran into an undefined username. Username email format = ${isUsername}`
+      'workspaceOrgType.getWorkspaceOrgType ran into an undefined username.'
     );
   }
 


### PR DESCRIPTION
### What does this PR do?
Removes a regex that was exclusively used for telemetry purposes. A long enough string would cause the evaluation to error and crash initialization of the core extension.
e.g. defaultUsername = usernameThatDoesntExistAndHasAnIncreadiblyLongLongName

### What issues does this PR fix or reference?
@W-6411742@