### PR TITLE
"Apex Debug: Configure Exceptions" command is visible in non-sfdx projects

### DIFF
--- a/docs/articles-jp/apex/interactive-debugger.md
+++ b/docs/articles-jp/apex/interactive-debugger.md
@@ -69,9 +69,9 @@ VS Code で初めて Apex デバッガを使用するときは、次の設定手
 
 デバッグセッション中に例外が発生した場合に、Apex デバッガの実行を停止するには、例外にブレークポイントを設定します。例外ブレークポイントに達すると、例外の原因となったコード行でデバッガが一時停止します。[Debug \(デバッグ\)] ビューの [Call Stack \(コールスタック\)] パネルに、例外の名前が表示されます。
 
-例外ブレークポイントを設定するには、Ctrl+Shift+P キー \(Windows、Linux\) または Cmd+Shift+P キー \(macOS\) を押してコマンドパレットを開き、**[Apex Debug: Configure Exceptions \(Apex デバッグ: 例外を設定\)]** を選択します。使用可能な例外のリストに、[exceptions in the `System` namespace](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_exception_methods.htm) と、`Exception` を拡張するプロジェクトの Apex クラスが表示されます。リストから例外を選択して、**[Always break \(常に中断\)]** をクリックします。
+例外ブレークポイントを設定するには、Ctrl+Shift+P キー \(Windows、Linux\) または Cmd+Shift+P キー \(macOS\) を押してコマンドパレットを開き、**[SFDX: Configure Apex Debug Exceptions \(Apex デバッグ: 例外を設定\)]** を選択します。使用可能な例外のリストに、[exceptions in the `System` namespace](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_exception_methods.htm) と、`Exception` を拡張するプロジェクトの Apex クラスが表示されます。リストから例外を選択して、**[Always break \(常に中断\)]** をクリックします。
 
-例外ブレークポイントを表示するには、**[Apex Debug: Configure Exceptions \(Apex デバッグ: 例外を設定\)]** を実行します。リストの上部に、有効なブレークポイントのある例外クラスが示され、`Always break` と表示されます。例外ブレークポイントを削除するには、リストから例外を選択して、**[Never break \(中断しない\)]** を選択します。
+例外ブレークポイントを表示するには、**[SFDX: Configure Apex Debug Exceptions \(Apex デバッグ: 例外を設定\)]** を実行します。リストの上部に、有効なブレークポイントのある例外クラスが示され、`Always break` と表示されます。例外ブレークポイントを削除するには、リストから例外を選択して、**[Never break \(中断しない\)]** を選択します。
 
 VS Code を閉じると、すべての例外ブレークポイントが削除されます\(ただし、行ブレークポイントは維持されます\)。
 

--- a/docs/articles/apex/interactive-debugger.md
+++ b/docs/articles/apex/interactive-debugger.md
@@ -69,9 +69,9 @@ While a debugging session is in progress, any synchronous activity that runs a l
 
 To make Apex Debugger halt execution when an exception is thrown during a debugging session, set breakpoints on exceptions. When an exception breakpoint is hit, the debugger pauses on the line of code that caused the exception. The Call Stack panel in the Debug view shows the name of the exception.
 
-To set an exception breakpoint, press Ctrl+Shift+P (Windows or Linux) or Cmd+Shift+P (macOS) to open the command palette, then select **Apex Debug: Configure Exceptions**. The list of available exceptions includes the [exceptions in the `System` namespace](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_exception_methods.htm) and the Apex classes in your project that extend `Exception`. Select an exception from the list, and then select **Always break**.
+To set an exception breakpoint, press Ctrl+Shift+P (Windows or Linux) or Cmd+Shift+P (macOS) to open the command palette, then select **SFDX: Configure Apex Debug Exceptions**. The list of available exceptions includes the [exceptions in the `System` namespace](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_exception_methods.htm) and the Apex classes in your project that extend `Exception`. Select an exception from the list, and then select **Always break**.
 
-To see your exception breakpoints, run **Apex Debug: Configure Exceptions**. The top of the list shows the exception classes that have active breakpoints, labeled `Always break`. To remove an exception breakpoint, select an exception from the list and then select **Never break**.
+To see your exception breakpoints, run **SFDX: Configure Apex Debug Exceptions**. The top of the list shows the exception classes that have active breakpoints, labeled `Always break`. To remove an exception breakpoint, select an exception from the list and then select **Never break**.
 
 When you close VS Code, all your exception breakpoints are removed. (Your line breakpoints, however, remain.)
 

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -181,7 +181,8 @@
     "menus": {
       "commandPalette": [
         {
-          "command": "sfdx.debug.exception.breakpoint"
+          "command": "sfdx.debug.exception.breakpoint",
+          "when": "sfdx:project_opened"
         }
       ]
     },

--- a/packages/salesforcedx-vscode-apex-debugger/package.nls.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.nls.json
@@ -9,6 +9,6 @@
   "trace_text": "Produce diagnostic output. You can set this to true, false, or one or more selectors separated with commas. Selectors include 'all' (very detailed output; the equivalent of true), 'protocol', 'variables', 'launch', 'breakpoints' and 'streaming'.",
   "configuration_title": "Salesforce Apex Debugger Configuration",
   "connection_timeout_ms_description": "Connection timeout for Apex Debugger API requests (in milliseconds).",
-  "exception_breakpoint_command_text": "Apex Debug: Configure Exceptions",
+  "exception_breakpoint_command_text": "SFDX: Configure Apex Debug Exceptions",
   "connect_type_text": "Connection Type"
 }


### PR DESCRIPTION
### What does this PR do?

fixed visibility bug; added prefix to palette command text



### What issues does this PR fix or reference?
@W-6197646@
