### PR TITLE
Change test placeholders for security

### DIFF
--- a/packages/salesforcedx-utils-vscode/test/unit/cli/orgOpenContainerResultParser.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/unit/cli/orgOpenContainerResultParser.test.ts
@@ -23,6 +23,7 @@ describe('force:org:open container parser', () => {
       username: 'test@example.com'
     }
   };
+
   it('should parse success info successfully', () => {
     const parser = new OrgOpenContainerResultParser(
       JSON.stringify(orgOpenSuccessResult)

--- a/packages/salesforcedx-utils-vscode/test/unit/cli/orgOpenContainerResultParser.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/unit/cli/orgOpenContainerResultParser.test.ts
@@ -15,16 +15,15 @@ import {
 
 // tslint:disable:no-unused-expression
 describe('force:org:open container parser', () => {
+  const orgOpenSuccessResult: OrgOpenSuccessResult = {
+    status: 0,
+    result: {
+      orgId: '00Dxx0000000123',
+      url: 'www.example.com',
+      username: 'test@example.com'
+    }
+  };
   it('should parse success info successfully', () => {
-    const orgOpenSuccessResult: OrgOpenSuccessResult = {
-      status: 0,
-      result: {
-        orgId: '00Dxx0000000123',
-        url: 'www.openMeUpScotty.com',
-        username: 'krirk@enterprise.com'
-      }
-    };
-
     const parser = new OrgOpenContainerResultParser(
       JSON.stringify(orgOpenSuccessResult)
     );
@@ -70,16 +69,6 @@ describe('force:org:open container parser', () => {
   });
 
   it('Should parse success info successfully when provided along other info', () => {
-    //
-    const orgOpenSuccessResult: OrgOpenSuccessResult = {
-      status: 0,
-      result: {
-        orgId: '00Dxx0000000123',
-        url: 'www.openMeUpScotty.com',
-        username: 'krirk@enterprise.com'
-      }
-    };
-
     const parser = new OrgOpenContainerResultParser(
       `Warning: sfdx-cli update available from 7.7.0 to 7.14.0.${EOL} sfdx force:org:open --json --loglevel fatal ${EOL}
       ${JSON.stringify(

--- a/packages/salesforcedx-utils-vscode/test/unit/cli/orgOpenContainerResultParser.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/unit/cli/orgOpenContainerResultParser.test.ts
@@ -40,6 +40,7 @@ describe('force:org:open container parser', () => {
       orgOpenSuccessResult.result.username
     );
   });
+
   it('should parse error info successfully', () => {
     const orgOpenErrorResult: OrgOpenErrorResult = {
       status: 1,


### PR DESCRIPTION
### What does this PR do?
Change the test mock URLs to `www.example.com` for security purposes.
Nate Totten has reminded me that the only safe URL to use are reserved ones such as `example.com, net, org` to avoid an accidental visit to a malware site.

More info can be found here: https://www.iana.org/domains/reserved
### What issues does this PR fix or reference?
This is not related to specific work item.