### PR TITLE
Resolve test failures in forceListMetadata and forceDescribeMetadata commands

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/cli/commandExecutor.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/commandExecutor.ts
@@ -69,7 +69,7 @@ export class CliCommandExecutor {
       : options;
   }
 
-  public execute(cancellationToken?: CancellationToken): CommandExecution {
+  public execute(cancellationToken?: CancellationToken): CliCommandExecution {
     const childProcess = cross_spawn(
       this.command.command,
       this.command.args,

--- a/packages/salesforcedx-utils-vscode/src/cli/commandExecutor.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/commandExecutor.ts
@@ -69,7 +69,7 @@ export class CliCommandExecutor {
       : options;
   }
 
-  public execute(cancellationToken?: CancellationToken): CliCommandExecution {
+  public execute(cancellationToken?: CancellationToken): CommandExecution {
     const childProcess = cross_spawn(
       this.command.command,
       this.command.args,

--- a/packages/salesforcedx-vscode-core/src/commands/forceDescribeMetadata.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceDescribeMetadata.ts
@@ -33,35 +33,24 @@ export class ForceDescribeMetadataExecutor extends SfdxCommandletExecutor<
       .build();
   }
 
-  public attachLogging(
-    execution: CliCommandExecution,
-    startTime: [number, number]
-  ) {
+  public execute(): CliCommandExecution {
+    const startTime = process.hrtime();
+    const execution = new CliCommandExecutor(this.build({}), {
+      cwd: getRootWorkspacePath()
+    }).execute();
+
     execution.processExitSubject.subscribe(() => {
       this.logMetric(execution.command.logName, startTime);
     });
+    return execution;
   }
 }
 
 export async function forceDescribeMetadata(
   outputFolder: string
 ): Promise<string> {
-  const startTime = process.hrtime();
   const forceDescribeMetadataExecutor = new ForceDescribeMetadataExecutor();
-  const execution = new CliCommandExecutor(
-    forceDescribeMetadataExecutor.build({}),
-    { cwd: getRootWorkspacePath() }
-  ).execute();
-
-  execution.processExitSubject.subscribe(() => {
-    forceDescribeMetadataExecutor.logMetric(
-      execution.command.logName,
-      startTime
-    );
-  });
-
-  // forceDescribeMetadataExecutor.attachLogging(execution, startTime);
-
+  const execution = forceDescribeMetadataExecutor.execute();
   if (!fs.existsSync(outputFolder)) {
     mkdir('-p', outputFolder);
   }

--- a/packages/salesforcedx-vscode-core/src/commands/forceDescribeMetadata.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceDescribeMetadata.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  CliCommandExecution,
   CliCommandExecutor,
   Command,
   CommandOutput,
@@ -31,6 +32,15 @@ export class ForceDescribeMetadataExecutor extends SfdxCommandletExecutor<
       .withLogName('force_mdapi_describemetadata')
       .build();
   }
+
+  public attachLogging(
+    execution: CliCommandExecution,
+    startTime: [number, number]
+  ) {
+    execution.processExitSubject.subscribe(() => {
+      this.logMetric(execution.command.logName, startTime);
+    });
+  }
 }
 
 export async function forceDescribeMetadata(
@@ -49,6 +59,8 @@ export async function forceDescribeMetadata(
       startTime
     );
   });
+
+  // forceDescribeMetadataExecutor.attachLogging(execution, startTime);
 
   if (!fs.existsSync(outputFolder)) {
     mkdir('-p', outputFolder);

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceDescribeMetadata.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceDescribeMetadata.test.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { Observable } from '@salesforce/salesforcedx-utils-vscode/node_modules/rxjs/Observable';
 import {
   CliCommandExecution,
   CliCommandExecutor,
@@ -26,19 +27,17 @@ describe('Force Describe Metadata', () => {
       `sfdx force:mdapi:describemetadata --json --loglevel fatal`
     );
   });
-  // skipped because of an issue stubbing a property
-  xit('Should write a file with metadata describe output', async () => {
-    const subscribeStub = sinon
-      .stub(
-        CliCommandExecutor.prototype.execute().processExitSubject,
-        'subscribe'
-      )
-      .callsFake(() => {});
 
-    const commandStub = sinon.stub(CliCommandExecutor.prototype, 'execute');
-    const testStub = sinon
-      .stub(CliCommandExecution.prototype, 'command')
-      .returns({ logName: 'log' });
+  it('Should write a file with metadata describe output', async () => {
+    /*const loggingStub = sinon.stub(
+      ForceDescribeMetadataExecutor.prototype,
+      'attachLogging'
+    );*/
+    const execStub = sinon.stub(CliCommandExecutor.prototype, 'execute');
+    const processStub = sinon.stub(
+      CliCommandExecution.prototype,
+      'processExitSubject'
+    );
 
     const writeFileStub = sinon.stub(fs, 'writeFileSync');
 
@@ -54,8 +53,8 @@ describe('Force Describe Metadata', () => {
 
     writeFileStub.restore();
     cmdOutputStub.restore();
-    subscribeStub.restore();
-    commandStub.restore();
-    testStub.restore();
+    // loggingStub.restore();
+    execStub.restore();
+    processStub.restore();
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceDescribeMetadata.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceDescribeMetadata.test.ts
@@ -29,16 +29,10 @@ describe('Force Describe Metadata', () => {
   });
 
   it('Should write a file with metadata describe output', async () => {
-    /*const loggingStub = sinon.stub(
+    const execStub = sinon.stub(
       ForceDescribeMetadataExecutor.prototype,
-      'attachLogging'
-    );*/
-    const execStub = sinon.stub(CliCommandExecutor.prototype, 'execute');
-    const processStub = sinon.stub(
-      CliCommandExecution.prototype,
-      'processExitSubject'
+      'execute'
     );
-
     const writeFileStub = sinon.stub(fs, 'writeFileSync');
 
     const outputFolder = '/test/folder/';
@@ -53,8 +47,6 @@ describe('Force Describe Metadata', () => {
 
     writeFileStub.restore();
     cmdOutputStub.restore();
-    // loggingStub.restore();
     execStub.restore();
-    processStub.restore();
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceDescribeMetadata.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceDescribeMetadata.test.ts
@@ -4,12 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { Observable } from '@salesforce/salesforcedx-utils-vscode/node_modules/rxjs/Observable';
-import {
-  CliCommandExecution,
-  CliCommandExecutor,
-  CommandOutput
-} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import { CommandOutput } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import { expect } from 'chai';
 import * as fs from 'fs';
 import * as sinon from 'sinon';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceListMetadata.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceListMetadata.test.ts
@@ -4,10 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import {
-  CliCommandExecutor,
-  CommandOutput
-} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import { CommandOutput } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import { expect } from 'chai';
 import * as fs from 'fs';
 import * as sinon from 'sinon';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceListMetadata.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceListMetadata.test.ts
@@ -44,8 +44,8 @@ describe('Force List Metadata', () => {
       `sfdx force:mdapi:listmetadata -m ${metadataType} -u ${defaultUsername} --json --loglevel fatal --folder ${folder}`
     );
   });
-  // skipped because of an issue stubbing a property
-  xit('Should write a file with metadata list output', async () => {
+
+  it('Should write a file with metadata list output', async () => {
     const outputFolder = '/test/folder/';
     const metadataType = 'ApexClass';
     const defaultUsername = 'test-username1@example.com';
@@ -54,7 +54,7 @@ describe('Force List Metadata', () => {
     const cmdOutputStub = sinon
       .stub(CommandOutput.prototype, 'getCmdResult')
       .returns(resultData);
-    const cliExecStub = sinon.stub(CliCommandExecutor.prototype, 'execute');
+    const execStub = sinon.stub(ForceListMetadataExecutor.prototype, 'execute');
     const result = await forceListMetadata(
       metadataType,
       defaultUsername,
@@ -64,6 +64,6 @@ describe('Force List Metadata', () => {
     expect(result).to.equal(resultData);
     writeFileStub.restore();
     cmdOutputStub.restore();
-    cliExecStub.restore();
+    execStub.restore();
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
@@ -4,17 +4,14 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import {
-  CliCommandExecutor,
-  CommandOutput
-} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
-import { fail } from 'assert';
+import { CommandOutput } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import { expect } from 'chai';
 import * as fs from 'fs';
 import * as path from 'path';
 import { SinonStub, stub } from 'sinon';
 import { isNullOrUndefined } from 'util';
-import { ComponentUtils, TypeUtils } from '../../../src/orgBrowser';
+import { ForceListMetadataExecutor } from '../../../src/commands';
+import { ComponentUtils } from '../../../src/orgBrowser';
 import { getRootWorkspacePath, OrgAuthInfo } from '../../../src/util';
 
 // tslint:disable:no-unused-expression
@@ -179,7 +176,7 @@ describe('load metadata component data', () => {
     getUsernameStub = stub(OrgAuthInfo, 'getUsername').returns(undefined);
     fileExistsStub = stub(fs, 'existsSync');
     buildComponentsStub = stub(ComponentUtils.prototype, 'buildComponentsList');
-    cliCommandStub = stub(CliCommandExecutor.prototype, 'execute');
+    cliCommandStub = stub(ForceListMetadataExecutor.prototype, 'execute');
     cmdOutputStub = stub(CommandOutput.prototype, 'getCmdResult');
     writeFileStub = stub(fs, 'writeFileSync');
     getComponentsPathStub = stub(
@@ -197,8 +194,8 @@ describe('load metadata component data', () => {
     writeFileStub.restore();
     getComponentsPathStub.restore();
   });
-  // skipped because of an issue stubbing a property
-  xit('should load metadata components through cli command if file does not exist', async () => {
+
+  it('should load metadata components through cli command if file does not exist', async () => {
     fileExistsStub.returns(false);
     const fileData = JSON.stringify({
       status: 0,
@@ -221,8 +218,8 @@ describe('load metadata component data', () => {
     expect(buildComponentsStub.calledWith(metadataType, undefined, filePath)).to
       .be.true;
   });
-  // skipped because of an issue stubbing a property
-  xit('should load components through cli if file exists and force is set to true', async () => {
+
+  it('should load components through cli if file exists and force is set to true', async () => {
     fileExistsStub.returns(true);
     await cmpUtil.loadComponents(defaultOrg, metadataType, undefined, true);
     expect(cmdOutputStub.calledOnce).to.be.true;

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
@@ -163,7 +163,7 @@ describe('load metadata component data', () => {
   let getUsernameStub: SinonStub;
   let fileExistsStub: SinonStub;
   let buildComponentsStub: SinonStub;
-  let cliCommandStub: SinonStub;
+  let execStub: SinonStub;
   let cmdOutputStub: SinonStub;
   let writeFileStub: SinonStub;
   let getComponentsPathStub: SinonStub;
@@ -176,7 +176,7 @@ describe('load metadata component data', () => {
     getUsernameStub = stub(OrgAuthInfo, 'getUsername').returns(undefined);
     fileExistsStub = stub(fs, 'existsSync');
     buildComponentsStub = stub(ComponentUtils.prototype, 'buildComponentsList');
-    cliCommandStub = stub(ForceListMetadataExecutor.prototype, 'execute');
+    execStub = stub(ForceListMetadataExecutor.prototype, 'execute');
     cmdOutputStub = stub(CommandOutput.prototype, 'getCmdResult');
     writeFileStub = stub(fs, 'writeFileSync');
     getComponentsPathStub = stub(
@@ -189,7 +189,7 @@ describe('load metadata component data', () => {
     getUsernameStub.restore();
     fileExistsStub.restore();
     buildComponentsStub.restore();
-    cliCommandStub.restore();
+    execStub.restore();
     cmdOutputStub.restore();
     writeFileStub.restore();
     getComponentsPathStub.restore();

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataType.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataType.test.ts
@@ -5,7 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {
-  CliCommandExecution,
   CliCommandExecutor,
   CommandOutput
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
@@ -14,6 +13,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { SinonStub, stub } from 'sinon';
 import { isNullOrUndefined } from 'util';
+import { ForceDescribeMetadataExecutor } from '../../../src/commands';
 import { TypeUtils } from '../../../src/orgBrowser';
 import { getRootWorkspacePath, OrgAuthInfo } from '../../../src/util';
 
@@ -119,7 +119,7 @@ describe('load metadata types data', () => {
     getUsernameStub = stub(OrgAuthInfo, 'getUsername').returns(undefined);
     fileExistsStub = stub(fs, 'existsSync');
     buildTypesStub = stub(TypeUtils.prototype, 'buildTypesList');
-    cliCommandStub = stub(CliCommandExecutor.prototype, 'execute');
+    cliCommandStub = stub(ForceDescribeMetadataExecutor.prototype, 'execute');
     cmdOutputStub = stub(CommandOutput.prototype, 'getCmdResult');
     writeFileStub = stub(fs, 'writeFileSync');
     getTypesFolderStub = stub(TypeUtils.prototype, 'getTypesFolder').returns(
@@ -136,8 +136,8 @@ describe('load metadata types data', () => {
     writeFileStub.restore();
     getTypesFolderStub.restore();
   });
-  // skipped because of an issue stubbing a property
-  xit('should load metadata types through cli command if file does not exist', async () => {
+
+  it('should load metadata types through cli command if file does not exist', async () => {
     fileExistsStub.returns(false);
     const executionStub = stub(
       CliCommandExecutor.prototype.execute().processExitSubject,
@@ -166,8 +166,8 @@ describe('load metadata types data', () => {
     expect(cmdOutputStub.called).to.equal(false);
     expect(buildTypesStub.calledWith(undefined, filePath)).to.be.true;
   });
-  // skipped because of an issue stubbing a property
-  xit('should load metadata types through cli if file exists and force is set to true', async () => {
+
+  it('should load metadata types through cli if file exists and force is set to true', async () => {
     fileExistsStub.returns(true);
     await typeUtil.loadTypes(defaultOrg, true);
     expect(cmdOutputStub.calledOnce).to.be.true;

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataType.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataType.test.ts
@@ -4,10 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import {
-  CliCommandExecutor,
-  CommandOutput
-} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import { CommandOutput } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import { expect } from 'chai';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -107,7 +104,7 @@ describe('load metadata types data', () => {
   let getUsernameStub: SinonStub;
   let fileExistsStub: SinonStub;
   let buildTypesStub: SinonStub;
-  let cliCommandStub: SinonStub;
+  let execStub: SinonStub;
   let cmdOutputStub: SinonStub;
   let writeFileStub: SinonStub;
   let getTypesFolderStub: SinonStub;
@@ -119,7 +116,7 @@ describe('load metadata types data', () => {
     getUsernameStub = stub(OrgAuthInfo, 'getUsername').returns(undefined);
     fileExistsStub = stub(fs, 'existsSync');
     buildTypesStub = stub(TypeUtils.prototype, 'buildTypesList');
-    cliCommandStub = stub(ForceDescribeMetadataExecutor.prototype, 'execute');
+    execStub = stub(ForceDescribeMetadataExecutor.prototype, 'execute');
     cmdOutputStub = stub(CommandOutput.prototype, 'getCmdResult');
     writeFileStub = stub(fs, 'writeFileSync');
     getTypesFolderStub = stub(TypeUtils.prototype, 'getTypesFolder').returns(
@@ -131,7 +128,7 @@ describe('load metadata types data', () => {
     getUsernameStub.restore();
     fileExistsStub.restore();
     buildTypesStub.restore();
-    cliCommandStub.restore();
+    execStub.restore();
     cmdOutputStub.restore();
     writeFileStub.restore();
     getTypesFolderStub.restore();
@@ -139,10 +136,6 @@ describe('load metadata types data', () => {
 
   it('should load metadata types through cli command if file does not exist', async () => {
     fileExistsStub.returns(false);
-    const executionStub = stub(
-      CliCommandExecutor.prototype.execute().processExitSubject,
-      'subscribe'
-    );
     const fileData = JSON.stringify({
       status: 0,
       result: {
@@ -156,7 +149,6 @@ describe('load metadata types data', () => {
     const components = await typeUtil.loadTypes(defaultOrg);
     expect(cmdOutputStub.called).to.equal(true);
     expect(buildTypesStub.calledWith(fileData, undefined)).to.be.true;
-    executionStub.restore();
   });
 
   it('should load metadata types from file if file exists', async () => {


### PR DESCRIPTION
### What does this PR do?
This PR resolves test failures with the forceListMetadata and forceDescribeMetadata commands. The code has been refactored to follow the pattern used by other commands by overriding the execute command and returning the execution. This also addresses the problem with mocking the observable property on the `execution.processExitSubject`.

### What issues does this PR fix or reference?
@W-6418018@