### PR TITLE
update auth web login and auth dev hub to conditionally use device lo…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ packages/dbaeumer*
 
 # Netlify
 .netlify
+
+# Vscode History Extension
+.history

--- a/packages/salesforcedx-vscode-core/src/commands/forceAuthDevHub.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceAuthDevHub.ts
@@ -10,6 +10,7 @@ import {
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 
+import { isSFDXContainerMode } from '../util';
 import {
   EmptyParametersGatherer,
   SfdxCommandlet,
@@ -23,14 +24,18 @@ import { isDemoMode } from '../modes/demo-mode';
 
 export class ForceAuthDevHubExecutor extends SfdxCommandletExecutor<{}> {
   public build(data: {}): Command {
-    return new SfdxCommandBuilder()
-      .withDescription(
-        nls.localize('force_auth_web_login_authorize_dev_hub_text')
-      )
-      .withArg('force:auth:web:login')
-      .withArg('--setdefaultdevhubusername')
-      .withLogName('force_auth_dev_hub')
-      .build();
+    const command = new SfdxCommandBuilder().withDescription(
+      nls.localize('force_auth_web_login_authorize_dev_hub_text')
+    );
+    if (isSFDXContainerMode()) {
+      command
+        .withArg('force:auth:device:login')
+        .withLogName('force_auth_device_dev_hub');
+    } else {
+      command.withArg('force:auth:web:login').withLogName('force_auth_dev_hub');
+    }
+    command.withArg('--setdefaultdevhubusername');
+    return command.build();
   }
 }
 

--- a/packages/salesforcedx-vscode-core/src/commands/forceAuthWebLogin.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceAuthWebLogin.ts
@@ -29,7 +29,7 @@ import {
 } from '../notifications/index';
 import { SfdxProjectConfig } from '../sfdxProject';
 import { taskViewService } from '../statuses/index';
-import { getRootWorkspacePath } from '../util';
+import { getRootWorkspacePath, isSFDXContainerMode } from '../util';
 import {
   DemoModePromptGatherer,
   SfdxCommandlet,
@@ -46,17 +46,25 @@ export class ForceAuthWebLoginExecutor extends SfdxCommandletExecutor<
   AuthParams
 > {
   public build(data: AuthParams): Command {
-    return new SfdxCommandBuilder()
-      .withDescription(nls.localize('force_auth_web_login_authorize_org_text'))
-      .withArg('force:auth:web:login')
+    const command = new SfdxCommandBuilder().withDescription(
+      nls.localize('force_auth_web_login_authorize_org_text')
+    );
+    if (isSFDXContainerMode()) {
+      command
+        .withArg('force:auth:device:login')
+        .withLogName('force_auth_device_login');
+    } else {
+      command
+        .withArg('force:auth:web:login')
+        .withLogName('force_auth_web_login');
+    }
+    command
       .withFlag('--setalias', data.alias)
       .withFlag('--instanceurl', data.loginUrl)
-      .withArg('--setdefaultusername')
-      .withLogName('force_auth_web_login')
-      .build();
+      .withArg('--setdefaultusername');
+    return command.build();
   }
 }
-
 export abstract class ForceAuthDemoModeExecutor<
   T
 > extends SfdxCommandletExecutor<T> {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceOrgOpen.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceOrgOpen.test.ts
@@ -38,17 +38,13 @@ describe('Force Org Open', () => {
   });
 
   describe('Executor is chosen based on environment', () => {
-    let originalEnvValue: string;
-
-    beforeEach(() => {
-      originalEnvValue = process.env.SFDX_CONTAINER_MODE as string;
-    });
-
     afterEach(() => {
-      process.env.SFDX_CONTAINER_MODE = originalEnvValue;
+      delete process.env.SFDX_CONTAINER_MODE;
     });
-
     it('should use ForceOrgOpenExecutor if container mode is not defined', () => {
+      expect(getExecutor()).to.be.instanceOf(ForceOrgOpenExecutor);
+    });
+    it('should use ForceOrgOpenExecutor if container mode is empty', () => {
       process.env.SFDX_CONTAINER_MODE = '';
       expect(getExecutor()).to.be.instanceOf(ForceOrgOpenExecutor);
     });


### PR DESCRIPTION
This PR changes how Authorize A Dev Hub and Authorize An Org behave when running in Docker ( or any environment with SFDX_CONTAINER_MODE set ).  Those commands will now generate force:auth:device:login instead of force:auth:web:login.  For most users there will be no change.  But for VSCode Remote Development, they will now be able to authenticate using Salesforce OAuth 2 Device Flow.

### What does this PR do?
This PR enables support for VSCode Remote Development in a container.  It aligns with recent changes to the sfdx CLI to make this new force:auth:device:login command available.

### What issues does this PR fix or reference?
@W-6351129@