### PR TITLE
Add CustomObject to bundle types for path checker

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveCmp.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveCmp.ts
@@ -62,7 +62,8 @@ const BUNDLE_TYPES = new Set([
   'AuraDefinitionBundle',
   'LightningComponentBundle',
   'WaveTemplateBundle',
-  'ExperienceBundle'
+  'ExperienceBundle',
+  'CustomObject'
 ]);
 
 export function generateSuffix(


### PR DESCRIPTION
### What does this PR do?

CustomObject components are in a bundle like format in a local workspace, so we should add them to the set for FilePathExistsChecker.

### What issues does this PR fix or reference?

W-6463163