### PR TITLE
Fix not being able to retrieve standard objects in org browser

### DIFF
--- a/packages/salesforcedx-vscode-core/src/orgBrowser/metadataCmp.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/metadataCmp.ts
@@ -58,11 +58,12 @@ export class ComponentUtils {
       if (!isNullOrUndefined(cmpArray)) {
         cmpArray = cmpArray instanceof Array ? cmpArray : [cmpArray];
         for (const cmp of cmpArray) {
+          const { fullName, manageableState } = cmp;
           if (
-            !isNullOrUndefined(cmp.fullName) &&
-            cmp.manageableState === 'unmanaged'
+            !isNullOrUndefined(fullName) &&
+            (!manageableState || manageableState === 'unmanaged')
           ) {
-            components.push(cmp.fullName);
+            components.push(fullName);
           }
         }
       }

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
@@ -129,7 +129,7 @@ describe('build metadata components list', () => {
     }
   });
 
-  it('should only return unmanaged components', async () => {
+  it('should return components only with "unmanaged" manageableState', async () => {
     const type = 'ApexClass';
     const states = [
       'unmanaged',
@@ -155,6 +155,23 @@ describe('build metadata components list', () => {
 
     expect(fullNames.length).to.equal(1);
     expect(fullNames[0]).to.equal('fakeName0');
+  });
+
+  it('should return components with no manageableState', async () => {
+    const type = 'CustomObject';
+    const fileData = {
+      status: 0,
+      result: [{ fullName: 'fakeName', type }]
+    };
+
+    const fullNames = cmpUtil.buildComponentsList(
+      type,
+      JSON.stringify(fileData),
+      undefined
+    );
+
+    expect(fullNames.length).to.equal(1);
+    expect(fullNames[0]).to.equal('fakeName');
   });
 });
 

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
@@ -129,7 +129,7 @@ describe('build metadata components list', () => {
     }
   });
 
-  it('should return components only with "unmanaged" manageableState', async () => {
+  it('should only return "unmanaged" components if they have a manageableState', async () => {
     const type = 'ApexClass';
     const states = [
       'unmanaged',


### PR DESCRIPTION
### What does this PR do?

Due to how we were filtering components based on their manageability, we were accidentally omitting standard objects from appearing under CustomObjects. This fixes the filtering condition.

### What issues does this PR fix or reference?
#1542 
W-6467588