### PR TITLE
Remove use of momentjs

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/date/format.ts
+++ b/packages/salesforcedx-utils-vscode/src/date/format.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+export function getYYYYMMddHHmmssDateFormat(localUTCDate: Date): string {
+  const month2Digit = makeDoubleDigit(localUTCDate.getMonth() + 1);
+  const date2Digit = makeDoubleDigit(localUTCDate.getDate());
+  const hour2Digit = makeDoubleDigit(localUTCDate.getHours());
+  const mins2Digit = makeDoubleDigit(localUTCDate.getMinutes());
+  const sec2Digit = makeDoubleDigit(localUTCDate.getSeconds());
+
+  return `${localUTCDate.getFullYear()}${month2Digit}${date2Digit}${hour2Digit}${mins2Digit}${sec2Digit}`;
+}
+
+export function makeDoubleDigit(currentDigit: number): string {
+  return ('0' + currentDigit).slice(-2);
+}
+
+export const optionYYYYMMddHHmmss = {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit'
+};
+
+export const optionHHmm = {
+  hour: '2-digit',
+  minute: '2-digit'
+};
+
+export const optionMMddYYYY = {
+  month: '2-digit',
+  day: '2-digit',
+  year: 'numeric'
+};

--- a/packages/salesforcedx-utils-vscode/src/date/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/date/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+export {
+  getYYYYMMddHHmmssDateFormat,
+  makeDoubleDigit,
+  optionHHmm,
+  optionMMddYYYY,
+  optionYYYYMMddHHmmss
+} from './format';

--- a/packages/salesforcedx-utils-vscode/test/unit/date/format.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/unit/date/format.test.ts
@@ -21,7 +21,7 @@ describe('Date format utility', () => {
     expect(doubleDigit).to.equal('09');
   });
 
-  it('Should return a the same two character string when provided a double digit number', () => {
+  it('Should return the same two character string when provided with a double digit number', () => {
     const singleDigit = 13;
     const doubleDigit = makeDoubleDigit(singleDigit);
     expect(doubleDigit).to.equal('13');

--- a/packages/salesforcedx-utils-vscode/test/unit/date/format.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/unit/date/format.test.ts
@@ -30,7 +30,8 @@ describe('Date format utility', () => {
   it('Should return a YYYYMMddHHmmss formatted string', () => {
     const utcString = '2019-09-10T04:34:28+0000';
     const result = getYYYYMMddHHmmssDateFormat(new Date(utcString));
-    expect(result).to.equal('20190909213428');
+    expect(result.startsWith('2019')).to.equal(true);
+    expect(result.length).to.equal(14);
   });
 
   it('Should return a YYYYMMddHHmmss formatted string when using optionYYYYMMddHHmmss', () => {
@@ -42,7 +43,8 @@ describe('Date format utility', () => {
       optionYYYYMMddHHmmss
     );
 
-    expect(localDateFormatted).to.equal('09/09/2019, 9:34:28 PM');
+    const dateTimeFormatRegex = /([0-9]{2})(\/)([0-9]{2})(\/)([0-9]{4})(\,)\s([0-9])(:)([0-9]{2})(:)([0-9]{2})\s(AM|PM)/;
+    expect(dateTimeFormatRegex.test(localDateFormatted)).to.equal(true);
   });
 
   it('Should return a HHmm formatted string when using optionHHmm', () => {
@@ -54,7 +56,8 @@ describe('Date format utility', () => {
       optionHHmm
     );
 
-    expect(localTimeFormatted).to.equal('9:34 PM');
+    const timeFormatRegex = /([0-9])(:)([0-9]{2})\s(AM|PM)/;
+    expect(timeFormatRegex.test(localTimeFormatted)).to.equal(true);
   });
 
   it('Should return a optionMMddYYYY formatted string when using optionMMddYYYY', () => {
@@ -66,6 +69,7 @@ describe('Date format utility', () => {
       optionMMddYYYY
     );
 
-    expect(localDateFormatted).to.equal('09/09/2019');
+    const dateTimeFormatRegex = /([0-9]{2})(\/)([0-9]{2})(\/)([0-9]{4})/;
+    expect(dateTimeFormatRegex.test(localDateFormatted)).to.equal(true);
   });
 });

--- a/packages/salesforcedx-utils-vscode/test/unit/date/format.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/unit/date/format.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from 'chai';
+import {
+  getYYYYMMddHHmmssDateFormat,
+  makeDoubleDigit,
+  optionHHmm,
+  optionMMddYYYY,
+  optionYYYYMMddHHmmss
+} from '../../../src/date';
+
+describe('Date format utility', () => {
+  it('Should return a string with two characters, zero being the first character', () => {
+    const singleDigit = 9;
+    const doubleDigit = makeDoubleDigit(singleDigit);
+    expect(doubleDigit).to.equal('09');
+  });
+
+  it('Should return a the same two character string when provided a double digit number', () => {
+    const singleDigit = 13;
+    const doubleDigit = makeDoubleDigit(singleDigit);
+    expect(doubleDigit).to.equal('13');
+  });
+
+  it('Should return a YYYYMMddHHmmss formatted string', () => {
+    const utcString = '2019-09-10T04:34:28+0000';
+    const result = getYYYYMMddHHmmssDateFormat(new Date(utcString));
+    expect(result).to.equal('20190909213428');
+  });
+
+  it('Should return a YYYYMMddHHmmss formatted string when using optionYYYYMMddHHmmss', () => {
+    const utcString = '2019-09-10T04:34:28+0000';
+
+    const localUTCDate = new Date(utcString);
+    const localDateFormatted = localUTCDate.toLocaleDateString(
+      'en-US',
+      optionYYYYMMddHHmmss
+    );
+
+    expect(localDateFormatted).to.equal('09/09/2019, 9:34:28 PM');
+  });
+
+  it('Should return a HHmm formatted string when using optionHHmm', () => {
+    const utcString = '2019-09-10T04:34:28+0000';
+
+    const localUTCDate = new Date(utcString);
+    const localTimeFormatted = localUTCDate.toLocaleTimeString(
+      'en-US',
+      optionHHmm
+    );
+
+    expect(localTimeFormatted).to.equal('9:34 PM');
+  });
+
+  it('Should return a optionMMddYYYY formatted string when using optionMMddYYYY', () => {
+    const utcString = '2019-09-10T04:34:28+0000';
+
+    const localUTCDate = new Date(utcString);
+    const localDateFormatted = localUTCDate.toLocaleDateString(
+      'en-US',
+      optionMMddYYYY
+    );
+
+    expect(localDateFormatted).to.equal('09/09/2019');
+  });
+});

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -30,7 +30,6 @@
     "adm-zip": "0.4.13",
     "applicationinsights": "1.0.6",
     "glob": "^7.1.2",
-    "moment": "2.20.1",
     "rxjs": "^5.4.1",
     "sanitize-filename": "^1.6.1",
     "shelljs": "0.8.3"

--- a/packages/salesforcedx-vscode-core/src/commands/forceApexLogGet.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexLogGet.ts
@@ -12,6 +12,10 @@ import {
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import {
+  getYYYYMMddHHmmssDateFormat,
+  optionYYYYMMddHHmmss
+} from '@salesforce/salesforcedx-utils-vscode/out/src/date';
+import {
   CancelResponse,
   ContinueResponse,
   ParametersGatherer
@@ -89,30 +93,14 @@ export class ForceApexLogGetExecutor extends SfdxCommandletExecutor<
         mkdir('-p', logDir);
       }
 
-      const utcDate = response.data.startTime; // 2019-09-10T04:34:28+0000
-      const localDate = new Date(utcDate);
-      const date = getLogDateFormat(localDate);
-
+      const localUTCDate = new Date(response.data.startTime);
+      const date = getYYYYMMddHHmmssDateFormat(localUTCDate);
       const logPath = path.join(logDir, `${response.data.id}_${date}.log`);
       fs.writeFileSync(logPath, resultJson.result.log);
       const document = await vscode.workspace.openTextDocument(logPath);
       vscode.window.showTextDocument(document);
     }
   }
-}
-
-function getLogDateFormat(localDate: Date): string {
-  const month2Digit = makeDoubleDigit(localDate.getMonth() + 1);
-  const date2Digit = makeDoubleDigit(localDate.getDate());
-  const hour2Digit = makeDoubleDigit(localDate.getHours());
-  const mins2Digit = makeDoubleDigit(localDate.getMinutes());
-  const sec2Digit = makeDoubleDigit(localDate.getSeconds());
-
-  return `${localDate.getFullYear()}${month2Digit}${date2Digit}${hour2Digit}${mins2Digit}${sec2Digit}`;
-}
-
-function makeDoubleDigit(currentDigit: number): string {
-  return ('0' + currentDigit).slice(-2);
 }
 
 export type ApexDebugLogIdStartTime = {
@@ -149,22 +137,10 @@ export class LogFileSelector
     if (logInfos.length > 0) {
       const logItems = logInfos.map(logInfo => {
         const icon = '$(file-text) ';
-
-        const utcDate = logInfo.StartTime; // 2019-09-10T04:34:28+0000
-        const localDate = new Date(utcDate);
-
-        const options = {
-          year: 'numeric',
-          month: '2-digit',
-          day: '2-digit',
-          hour: '2-digit',
-          minute: '2-digit',
-          second: '2-digit'
-        };
-
-        const localDateFormatted = localDate.toLocaleDateString(
+        const localUTCDate = new Date(logInfo.StartTime);
+        const localDateFormatted = localUTCDate.toLocaleDateString(
           undefined,
-          options
+          optionYYYYMMddHHmmss
         );
 
         return {

--- a/packages/salesforcedx-vscode-core/src/decorators/traceflag-time-decorator.ts
+++ b/packages/salesforcedx-vscode-core/src/decorators/traceflag-time-decorator.ts
@@ -5,7 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import * as moment from 'moment';
 import { StatusBarAlignment, StatusBarItem, window } from 'vscode';
 import { APEX_CODE_DEBUG_LEVEL } from './../constants';
 import { nls } from './../messages';
@@ -16,16 +15,27 @@ export function showTraceFlagExpiration(expirationDate: Date) {
   if (!statusBarItem) {
     statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left, 40);
   }
+
   statusBarItem.text = nls.localize(
     'force_apex_debug_log_status_bar_text',
-    moment(expirationDate).format('LT')
+    expirationDate.toLocaleTimeString(undefined, {
+      hour: '2-digit',
+      minute: '2-digit'
+    })
   );
 
   statusBarItem.tooltip = nls.localize(
     'force_apex_debug_log_status_bar_hover_text',
     APEX_CODE_DEBUG_LEVEL,
-    moment(expirationDate).format('LT'),
-    moment(expirationDate).format('l')
+    expirationDate.toLocaleTimeString(undefined, {
+      hour: '2-digit',
+      minute: '2-digit'
+    }),
+    expirationDate.toLocaleDateString(undefined, {
+      month: '2-digit',
+      day: '2-digit',
+      year: 'numeric'
+    })
   );
   statusBarItem.show();
 }

--- a/packages/salesforcedx-vscode-core/src/decorators/traceflag-time-decorator.ts
+++ b/packages/salesforcedx-vscode-core/src/decorators/traceflag-time-decorator.ts
@@ -5,6 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import {
+  optionHHmm,
+  optionMMddYYYY
+} from '@salesforce/salesforcedx-utils-vscode/out/src/date';
 import { StatusBarAlignment, StatusBarItem, window } from 'vscode';
 import { APEX_CODE_DEBUG_LEVEL } from './../constants';
 import { nls } from './../messages';
@@ -18,24 +22,14 @@ export function showTraceFlagExpiration(expirationDate: Date) {
 
   statusBarItem.text = nls.localize(
     'force_apex_debug_log_status_bar_text',
-    expirationDate.toLocaleTimeString(undefined, {
-      hour: '2-digit',
-      minute: '2-digit'
-    })
+    expirationDate.toLocaleTimeString(undefined, optionHHmm)
   );
 
   statusBarItem.tooltip = nls.localize(
     'force_apex_debug_log_status_bar_hover_text',
     APEX_CODE_DEBUG_LEVEL,
-    expirationDate.toLocaleTimeString(undefined, {
-      hour: '2-digit',
-      minute: '2-digit'
-    }),
-    expirationDate.toLocaleDateString(undefined, {
-      month: '2-digit',
-      day: '2-digit',
-      year: 'numeric'
-    })
+    expirationDate.toLocaleTimeString(undefined, optionHHmm),
+    expirationDate.toLocaleDateString(undefined, optionMMddYYYY)
   );
   statusBarItem.show();
 }


### PR DESCRIPTION
### What does this PR do?
This PR replaces momentjs by using the native locale methods and other date formatting utilities. This is part of the changes needed to reduce the size of the extensions. By removing momentjs, we remove a dependency on a module that is not tree-shakeable.

### What issues does this PR fix or reference?
@W-6587405@