### PR TITLE
Add missing @salesforce/core dependency

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -25,6 +25,7 @@
   ],
   "dependencies": {
     "@salesforce/apex-tmlanguage": "1.2.0",
+    "@salesforce/core": "2.0.1",
     "@salesforce/salesforcedx-sobjects-faux-generator": "46.15.0",
     "@salesforce/salesforcedx-utils-vscode": "46.15.0",
     "expand-home-dir": "0.0.3",


### PR DESCRIPTION
### What does this PR do?
Updates the dependencies in the apex extension to address a limitation with lerna not bundling dependencies that are 2 or more levels deep for local modules.

### What issues does this PR fix or reference?
#1671 , @W-6597872@