### PR TITLE
Refresh component list before retrieving metadata

### DIFF
--- a/docs/articles/user-guide/org-browser.md
+++ b/docs/articles/user-guide/org-browser.md
@@ -43,6 +43,6 @@ You can also retrieve multiple components from the default org by clicking the r
 
 ![Overwrite components](../../images/overwrite-prompt.png)
 
-When the CLI retrieves components by a metadata type, the Org Browser needs an up-to-date list of all of the components to be retrieved. This is so the extensions can accurately check the local workspace for existing components.
+When the CLI retrieves components by a metadata type, the Org Browser needs an up-to-date list of all of the components to be retrieved. Therefore, the Org Browser will automatically refresh the component list before retrieving by a type. This is so the extensions can accurately check the local workspace for existing components.
 
 > Because of the asynchronous nature of the Metadata API, there exists the possibility for a simultaneous deploy and retrieve to enter a race condition. This could result in retrieving unexpected components. Keep this in mind if there are deploys happening while using the Org Browser.

--- a/docs/articles/user-guide/org-browser.md
+++ b/docs/articles/user-guide/org-browser.md
@@ -42,3 +42,7 @@ You can retrieve a component to your local project by clicking the retrieve butt
 You can also retrieve multiple components from the default org by clicking the retrieve button next to the metadata type. If retrieving a component overwrites it, you'll be prompted to select how to proceed.
 
 ![Overwrite components](../../images/overwrite-prompt.png)
+
+When the CLI retrieves components by a metadata type, the Org Browser needs an up-to-date list of all of the components to be retrieved. This is so the extensions can accurately check the local workspace for existing components.
+
+> Because of the asynchronous nature of the Metadata API, there exists the possibility for a simultaneous deploy and retrieve to enter a race condition. This could result in retrieving unexpected components. Keep this in mind if there are deploys happening while using the Org Browser.

--- a/docs/articles/user-guide/org-browser.md
+++ b/docs/articles/user-guide/org-browser.md
@@ -43,6 +43,6 @@ You can also retrieve multiple components from the default org by clicking the r
 
 ![Overwrite components](../../images/overwrite-prompt.png)
 
-When the CLI retrieves components by a metadata type, the Org Browser needs an up-to-date list of all of the components to be retrieved. Therefore, the Org Browser will automatically refresh the component list before retrieving by a type. This is so the extensions can accurately check the local workspace for existing components.
+When you retrieve components for a metadata type, the Org Browser automatically refreshes the component list for the selected type and then retrieves them. This ensures that the extensions accurately check the local workspace for existing components.
 
-> Because of the asynchronous nature of the Metadata API, there exists the possibility for a simultaneous deploy and retrieve to enter a race condition. This could result in retrieving unexpected components. Keep this in mind if there are deploys happening while using the Org Browser.
+> Because of the asynchronous nature of the Metadata API calls, a simultaneous deploy and retrieve could potentially lead to a race condition. To prevent retrieving unexpected components, be mindful of using the Org Browser while a deploy operation is in progress.

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveMetadata/describers.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveMetadata/describers.ts
@@ -7,7 +7,7 @@
 import { LocalComponent } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import { join } from 'path';
 import { RetrieveDescriber } from '.';
-import { BrowserNode, OrgBrowser } from '../../orgBrowser';
+import { BrowserNode, orgBrowser } from '../../orgBrowser';
 import { SfdxPackageDirectories } from '../../sfdxProject';
 
 abstract class NodeDescriber implements RetrieveDescriber {
@@ -53,7 +53,7 @@ class TypeNodeDescriber extends NodeDescriber {
   }
 
   public async gatherOutputLocations(): Promise<LocalComponent[]> {
-    await OrgBrowser.get().refreshAndExpand(this.node);
+    await orgBrowser.refreshAndExpand(this.node);
     const components = [];
     for (const child of this.node.children!) {
       components.push(...(await this.buildOutput(child)));

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveMetadata/describers.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveMetadata/describers.ts
@@ -7,7 +7,7 @@
 import { LocalComponent } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import { join } from 'path';
 import { RetrieveDescriber } from '.';
-import { BrowserNode } from '../../orgBrowser';
+import { BrowserNode, OrgBrowser } from '../../orgBrowser';
 import { SfdxPackageDirectories } from '../../sfdxProject';
 
 abstract class NodeDescriber implements RetrieveDescriber {
@@ -53,6 +53,7 @@ class TypeNodeDescriber extends NodeDescriber {
   }
 
   public async gatherOutputLocations(): Promise<LocalComponent[]> {
+    await OrgBrowser.get().refreshAndExpand(this.node);
     const components = [];
     for (const child of this.node.children!) {
       components.push(...(await this.buildOutput(child)));

--- a/packages/salesforcedx-vscode-core/src/commands/util/postconditionCheckers.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/postconditionCheckers.ts
@@ -119,7 +119,7 @@ export class OverwriteComponentPrompt
       metadataSuffix = info.suffix;
     } else {
       notificationService.showErrorMessage(
-        'Error checking workspace for existing components'
+        nls.localize('error_overwrite_prompt')
       );
       telemetryService.sendException(
         'OverwriteComponentPromptException',

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -67,7 +67,7 @@ import { getDefaultUsernameOrAlias, setupWorkspaceOrgType } from './context';
 import * as decorators from './decorators';
 import { isDemoMode } from './modes/demo-mode';
 import { notificationService, ProgressNotification } from './notifications';
-import { MetadataOutlineProvider } from './orgBrowser';
+import { OrgBrowser } from './orgBrowser';
 import { OrgList } from './orgPicker';
 import { registerPushOrDeployOnSave, sfdxCoreSettings } from './settings';
 import { taskViewService } from './statuses';
@@ -403,32 +403,22 @@ function registerOrgPickerCommands(orgList: OrgList): vscode.Disposable {
 }
 
 async function setupOrgBrowser(
-  extensionContext: vscode.ExtensionContext,
-  defaultUsernameOrAlias?: string
+  extensionContext: vscode.ExtensionContext
 ): Promise<void> {
-  const metadataProvider = new MetadataOutlineProvider(defaultUsernameOrAlias);
-
-  const treeView = vscode.window.createTreeView('metadata', {
-    treeDataProvider: metadataProvider
-  });
-
-  treeView.onDidChangeVisibility(async () => {
-    if (treeView.visible) {
-      await metadataProvider.onViewChange();
-    }
-  });
+  const browser = OrgBrowser.get();
+  await browser.init(extensionContext);
 
   vscode.commands.registerCommand(
     'sfdx.force.metadata.view.type.refresh',
     async node => {
-      await metadataProvider.refresh(node);
+      await browser.refreshAndExpand(node);
     }
   );
 
   vscode.commands.registerCommand(
     'sfdx.force.metadata.view.component.refresh',
     async node => {
-      await metadataProvider.refresh(node);
+      await browser.refreshAndExpand(node);
     }
   );
 
@@ -438,7 +428,6 @@ async function setupOrgBrowser(
       await forceSourceRetrieveCmp(trigger);
     }
   );
-  extensionContext.subscriptions.push(treeView);
 }
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -525,7 +514,7 @@ export async function activate(context: vscode.ExtensionContext) {
   orgList.displayDefaultUsername(defaultUsernameorAlias);
   context.subscriptions.push(registerOrgPickerCommands(orgList));
 
-  await setupOrgBrowser(context, defaultUsernameorAlias);
+  await setupOrgBrowser(context);
   if (isCLIInstalled()) {
     // Set context for defaultusername org
     await setupWorkspaceOrgType(defaultUsernameorAlias);

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -67,7 +67,7 @@ import { getDefaultUsernameOrAlias, setupWorkspaceOrgType } from './context';
 import * as decorators from './decorators';
 import { isDemoMode } from './modes/demo-mode';
 import { notificationService, ProgressNotification } from './notifications';
-import { OrgBrowser } from './orgBrowser';
+import { orgBrowser } from './orgBrowser';
 import { OrgList } from './orgPicker';
 import { registerPushOrDeployOnSave, sfdxCoreSettings } from './settings';
 import { taskViewService } from './statuses';
@@ -405,20 +405,19 @@ function registerOrgPickerCommands(orgList: OrgList): vscode.Disposable {
 async function setupOrgBrowser(
   extensionContext: vscode.ExtensionContext
 ): Promise<void> {
-  const browser = OrgBrowser.get();
-  await browser.init(extensionContext);
+  await orgBrowser.init(extensionContext);
 
   vscode.commands.registerCommand(
     'sfdx.force.metadata.view.type.refresh',
     async node => {
-      await browser.refreshAndExpand(node);
+      await orgBrowser.refreshAndExpand(node);
     }
   );
 
   vscode.commands.registerCommand(
     'sfdx.force.metadata.view.component.refresh',
     async node => {
-      await browser.refreshAndExpand(node);
+      await orgBrowser.refreshAndExpand(node);
     }
   );
 

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -273,6 +273,8 @@ export const messages = {
   error_fetching_metadata: 'Error fetching metadata for org.',
   error_org_browser_text:
     'Run "SFDX: Authorize an Org" to authorize your org again.',
+  error_org_browser_init: 'Org Browser has not been initialized',
+  error_overwrite_prompt: 'Error checking workspace for existing components',
   force_list_metadata: 'SFDX: Force List Metadata',
 
   AccessControlPolicy: 'Access Control Policies',

--- a/packages/salesforcedx-vscode-core/src/orgBrowser/browser.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/browser.ts
@@ -19,7 +19,7 @@ export class OrgBrowser {
 
   private constructor() {}
 
-  public static get(): OrgBrowser {
+  public static getInstance(): OrgBrowser {
     if (!this.instance) {
       this.instance = new OrgBrowser();
     }

--- a/packages/salesforcedx-vscode-core/src/orgBrowser/browser.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/browser.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { ExtensionContext, TreeView, window } from 'vscode';
+import { nls } from '../messages';
+import { BrowserNode, MetadataOutlineProvider } from '../orgBrowser';
+import { telemetryService } from '../telemetry';
+import { OrgAuthInfo } from '../util';
+
+export class OrgBrowser {
+  private static VIEW_ID = 'metadata';
+  private static instance: OrgBrowser;
+
+  private _treeView?: TreeView<BrowserNode>;
+  private _dataProvider?: MetadataOutlineProvider;
+
+  private constructor() {}
+
+  public static get(): OrgBrowser {
+    if (!this.instance) {
+      this.instance = new OrgBrowser();
+    }
+    return this.instance;
+  }
+
+  get treeView() {
+    if (this._treeView) {
+      return this._treeView;
+    }
+    throw this.initError();
+  }
+
+  get dataProvider() {
+    if (this._dataProvider) {
+      return this._dataProvider;
+    }
+    throw this.initError();
+  }
+
+  public async init(extensionContext: ExtensionContext) {
+    const username = await OrgAuthInfo.getDefaultUsernameOrAlias(false);
+    this._dataProvider = new MetadataOutlineProvider(username);
+    this._treeView = window.createTreeView(OrgBrowser.VIEW_ID, {
+      treeDataProvider: this._dataProvider
+    });
+    this._treeView.onDidChangeVisibility(() => async () => {
+      if (this.treeView.visible) {
+        await this.dataProvider.onViewChange();
+      }
+    });
+    extensionContext.subscriptions.push(this._treeView);
+  }
+
+  public async refreshAndExpand(node: BrowserNode) {
+    await this.dataProvider.refresh(node);
+    await this.treeView.reveal(node, { expand: true });
+  }
+
+  private initError() {
+    const message = nls.localize('error_org_browser_init');
+    telemetryService.sendException('OrgBrowserException', message);
+    return new Error(message);
+  }
+}

--- a/packages/salesforcedx-vscode-core/src/orgBrowser/index.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/index.ts
@@ -8,3 +8,4 @@ export { TypeUtils, MetadataObject } from './metadataType';
 export { MetadataOutlineProvider } from './metadataOutlineProvider';
 export { BrowserNode, NodeType } from './nodeTypes';
 export { ComponentUtils } from './metadataCmp';
+export { OrgBrowser } from './browser';

--- a/packages/salesforcedx-vscode-core/src/orgBrowser/index.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/index.ts
@@ -8,4 +8,5 @@ export { TypeUtils, MetadataObject } from './metadataType';
 export { MetadataOutlineProvider } from './metadataOutlineProvider';
 export { BrowserNode, NodeType } from './nodeTypes';
 export { ComponentUtils } from './metadataCmp';
-export { OrgBrowser } from './browser';
+import { OrgBrowser } from './browser';
+export const orgBrowser = OrgBrowser.getInstance();

--- a/packages/salesforcedx-vscode-core/src/orgBrowser/metadataOutlineProvider.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/metadataOutlineProvider.ts
@@ -4,7 +4,10 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { extractJsonObject, isNullOrUndefined } from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
+import {
+  extractJsonObject,
+  isNullOrUndefined
+} from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import * as vscode from 'vscode';
 import { nls } from '../messages';
 import { hasRootWorkspace, OrgAuthInfo } from '../util';
@@ -53,6 +56,10 @@ export class MetadataOutlineProvider
 
   public getTreeItem(element: BrowserNode): vscode.TreeItem {
     return element;
+  }
+
+  public getParent(element: BrowserNode) {
+    return element.parent;
   }
 
   public async getChildren(element?: BrowserNode): Promise<BrowserNode[]> {
@@ -138,7 +145,6 @@ export class MetadataOutlineProvider
 
 export function parseErrors(error: string | any): Error {
   try {
-
     const errMsg = typeof error === 'string' ? error : error.message;
     const e = extractJsonObject(errMsg);
 

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveMetadata/describers.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveMetadata/describers.test.ts
@@ -9,7 +9,7 @@ import { expect } from 'chai';
 import { normalize } from 'path';
 import { sandbox, SinonStub } from 'sinon';
 import { RetrieveDescriberFactory } from '../../../../src/commands/forceSourceRetrieveMetadata';
-import { BrowserNode, NodeType, OrgBrowser } from '../../../../src/orgBrowser';
+import { BrowserNode, NodeType, orgBrowser } from '../../../../src/orgBrowser';
 import { SfdxPackageDirectories } from '../../../../src/sfdxProject';
 
 const env = sandbox.create();
@@ -32,9 +32,7 @@ describe('Retrieve Metadata Describers', () => {
     packageStub = env
       .stub(SfdxPackageDirectories, 'getPackageDirectoryPaths')
       .returns(['p1', 'p2']);
-    refreshStub = env
-      .stub(OrgBrowser.prototype, 'refreshAndExpand')
-      .callsFake(() => '');
+    refreshStub = env.stub(orgBrowser, 'refreshAndExpand').callsFake(() => '');
   });
 
   afterEach(() => env.restore());


### PR DESCRIPTION
### What does this PR do?

Refresh the component list before kicking off a multi-retrieve triggered by a metadata type BrowserNode. 

### What issues does this PR fix or reference?

W-6633366