### PR TITLE
Remove analytics option from project create

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceProjectCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceProjectCreate.ts
@@ -33,8 +33,7 @@ import {
 
 export enum projectTemplateEnum {
   standard = 'standard',
-  empty = 'empty',
-  analytics = 'analytics'
+  empty = 'empty'
 }
 
 type forceProjectCreateOptions = {
@@ -144,10 +143,6 @@ export class SelectProjectTemplate
       new ProjectTemplateItem(
         projectTemplateEnum.empty,
         'force_project_create_empty_template'
-      ),
-      new ProjectTemplateItem(
-        projectTemplateEnum.analytics,
-        'force_project_create_analytics_template'
       )
     ];
 

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceProjectCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceProjectCreate.test.ts
@@ -14,10 +14,8 @@ import {
   ForceProjectCreateExecutor,
   PathExistsChecker,
   ProjectNameAndPathAndTemplate,
-  ProjectTemplateItem,
   SelectProjectFolder,
-  SelectProjectName,
-  SelectProjectTemplate
+  SelectProjectName
 } from '../../../src/commands/forceProjectCreate';
 import { projectTemplateEnum } from '../../../src/commands/forceProjectCreate';
 import { nls } from '../../../src/messages';
@@ -29,7 +27,7 @@ describe('Force Project Create', () => {
   const WORKSPACE_PATH = path.join(getRootWorkspacePath(), '..');
   const PROJECT_DIR: vscode.Uri[] = [vscode.Uri.parse(WORKSPACE_PATH)];
 
-  describe('SelectProjectTemplate Gatherer', () => {
+  /* describe('SelectProjectTemplate Gatherer', () => {
     let quickPickSpy: sinon.SinonStub;
 
     before(() => {
@@ -76,7 +74,7 @@ describe('Force Project Create', () => {
         expect.fail('Response should be of type ContinueResponse');
       }
     });
-  });
+  }); */
 
   describe('SelectProjectName Gatherer', () => {
     let inputBoxSpy: sinon.SinonStub;
@@ -236,7 +234,7 @@ describe('Force Project Create', () => {
         nls.localize('force_project_create_text')
       );
     });
-
+    /*
     it('Should build the analytics project create command', async () => {
       const forceProjectCreateBuilder = new ForceProjectCreateExecutor();
       const createCommand = forceProjectCreateBuilder.build({
@@ -271,7 +269,7 @@ describe('Force Project Create', () => {
       expect(createCommand.description).to.equal(
         nls.localize('force_project_create_text')
       );
-    });
+    }); */
 
     it('Should build the project with manifest create command', async () => {
       const forceProjectCreateBuilder = new ForceProjectCreateExecutor({


### PR DESCRIPTION
### What does this PR do?
Removes the analytics option from project create since the cli piece will not go out in the next release.

### What issues does this PR fix or reference?
