### PR TITLE
Port CircleCI cache key change to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
+          key: dependency-cache-v2-{{ checksum "package.json" }}
       - run: npm install
       # Setup an NODE_ENV to production mode before compiling.
       - run:


### PR DESCRIPTION
(cherry picked from commit fc2f1c1446e82ed4dea90593438b3a925444a3a4)

### What does this PR do?

Port CircleCI cache key change to master

### What issues does this PR fix or reference?
