### PR TITLE
Ensure valid session when fetching SObject definitions 

### DIFF
--- a/packages/salesforcedx-sobjects-faux-generator/src/describe/sObjectDescribe.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/describe/sObjectDescribe.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthInfo } from '@salesforce/core';
+import { Org } from '@salesforce/core';
 import {
   CliCommandExecution,
   CliCommandExecutor,
@@ -264,7 +264,6 @@ export class SObjectDescribe {
 
   public buildXHROptions(types: string[], nextToProcess: number): XHROptions {
     const batchRequest = this.buildBatchRequestBody(types, nextToProcess);
-
     return {
       type: 'POST',
       url: this.buildBatchRequestURL(),
@@ -319,10 +318,11 @@ export class SObjectDescribe {
   public async getConnectionData(projectPath: string) {
     try {
       const username = await ConfigUtil.getUsername(projectPath);
-      const authInfo = await AuthInfo.create({ username });
-      const opts = authInfo.getConnectionOptions();
-      this.accessToken = opts.accessToken;
-      this.instanceUrl = opts.instanceUrl;
+      const org = await Org.create({ aliasOrUsername: username });
+      await org.refreshAuth();
+      const { accessToken, instanceUrl } = org.getConnection();
+      this.accessToken = accessToken;
+      this.instanceUrl = instanceUrl;
     } catch (err) {
       const error = new Error();
       error.name = 'Authentication Error';

--- a/packages/salesforcedx-sobjects-faux-generator/test/integration/fauxGenerate.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/integration/fauxGenerate.test.ts
@@ -26,6 +26,10 @@ import { CancellationTokenSource } from './integrationTestUtil';
 import { mockDescribeResponse } from './mockData';
 
 const PROJECT_NAME = `project_${new Date().getTime()}`;
+const CONNECTION_DATA = {
+  accessToken: '00Dxx000thisIsATestToken',
+  instanceUrl: 'https://na1.salesforce.com'
+};
 
 // tslint:disable:no-unused-expression
 describe('Generate faux classes for SObjects', () => {
@@ -156,18 +160,11 @@ describe('Generate faux classes for SObjects', () => {
     beforeEach(() => {
       getUsername = stub(ConfigUtil, 'getUsername').returns('test@example.com');
       authInfo = stub(AuthInfo, 'create').returns({
-        getConnectionOptions() {
-          return {
-            accessToken: '00Dxx000thisIsATestToken',
-            instanceUrl: 'https://na1.salesforce.com'
-          };
-        }
+        getConnectionOptions: () => CONNECTION_DATA
       });
-      connection = stub(Org.prototype, 'getConnection');
-      connection.returns({
-        accessToken: '00Dxx000thisIsATestToken',
-        instanceUrl: 'https://na1.salesforce.com'
-      });
+      connection = stub(Org.prototype, 'getConnection').returns(
+        CONNECTION_DATA
+      );
       xhrMock = stub(SObjectDescribe.prototype, 'runRequest');
       fsExistSyncStub = stub(fs, 'existsSync').returns(true);
       refreshAuth = stub(Org.prototype, 'refreshAuth');

--- a/packages/salesforcedx-sobjects-faux-generator/test/integration/fauxGenerate.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/integration/fauxGenerate.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthInfo } from '@salesforce/core';
+import { AuthInfo, Org } from '@salesforce/core';
 import { LocalCommandExecution } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import { fail } from 'assert';
 import { expect } from 'chai';
@@ -150,6 +150,8 @@ describe('Generate faux classes for SObjects', () => {
     let getUsername: SinonStub;
     let authInfo: SinonStub;
     let xhrMock: SinonStub;
+    let connection: SinonStub;
+    let refreshAuth: SinonStub;
 
     beforeEach(() => {
       getUsername = stub(ConfigUtil, 'getUsername').returns('test@example.com');
@@ -161,8 +163,14 @@ describe('Generate faux classes for SObjects', () => {
           };
         }
       });
+      connection = stub(Org.prototype, 'getConnection');
+      connection.returns({
+        accessToken: '00Dxx000thisIsATestToken',
+        instanceUrl: 'https://na1.salesforce.com'
+      });
       xhrMock = stub(SObjectDescribe.prototype, 'runRequest');
       fsExistSyncStub = stub(fs, 'existsSync').returns(true);
+      refreshAuth = stub(Org.prototype, 'refreshAuth');
     });
 
     afterEach(() => {
@@ -170,6 +178,8 @@ describe('Generate faux classes for SObjects', () => {
       getUsername.restore();
       authInfo.restore();
       xhrMock.restore();
+      connection.restore();
+      refreshAuth.restore();
     });
 
     it('Should emit an exit event with code success code 0 on success', async () => {

--- a/packages/salesforcedx-sobjects-faux-generator/test/integration/sObjectDescribe.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/integration/sObjectDescribe.test.ts
@@ -20,6 +20,10 @@ import {
 import { mockDescribeResponse } from './mockData';
 
 const sobjectdescribe = new SObjectDescribe();
+const CONNECTION_DATA = {
+  accessToken: '00Dxx000thisIsATestToken',
+  instanceUrl: 'https://na1.salesforce.com'
+};
 
 // tslint:disable:no-unused-expression
 describe('Fetch sObjects', () => {
@@ -30,19 +34,11 @@ describe('Fetch sObjects', () => {
   let refreshAuth: SinonStub;
 
   beforeEach(() => {
-    authInfo = stub(AuthInfo, 'create');
-    authInfo.returns({
-      getConnectionOptions: () => ({
-        accessToken: '00Dxx000thisIsATestToken',
-        instanceUrl: 'https://na1.salesforce.com'
-      })
+    authInfo = stub(AuthInfo, 'create').returns({
+      getConnectionOptions: () => CONNECTION_DATA
     });
     getUsername = stub(ConfigUtil, 'getUsername').returns('test@example.com');
-    connection = stub(Org.prototype, 'getConnection');
-    connection.returns({
-      accessToken: '00Dxx000thisIsATestToken',
-      instanceUrl: 'https://na1.salesforce.com'
-    });
+    connection = stub(Org.prototype, 'getConnection').returns(CONNECTION_DATA);
     refreshAuth = stub(Org.prototype, 'refreshAuth');
     xhrMock = stub(SObjectDescribe.prototype, 'runRequest');
   });


### PR DESCRIPTION
### What does this PR do?

Ensures there is a valid session token before fetching SObject definitions from the default org.

### What issues does this PR fix or reference?

W-6803122, #1702 
