### PR TITLE
Fix to display correct org name/alias in org browser

### DIFF
--- a/packages/salesforcedx-vscode-core/src/orgBrowser/browser.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/browser.ts
@@ -46,7 +46,7 @@ export class OrgBrowser {
     this._treeView = window.createTreeView(OrgBrowser.VIEW_ID, {
       treeDataProvider: this._dataProvider
     });
-    this._treeView.onDidChangeVisibility(() => async () => {
+    this._treeView.onDidChangeVisibility(async () => {
       if (this.treeView.visible) {
         await this.dataProvider.onViewChange();
       }


### PR DESCRIPTION
### What does this PR do?
This PR fixes a bug with displaying the correct org name/alias in the org browser. The bug had to do with how the visibility event was being registered.

### What issues does this PR fix or reference?
@W-6767384@, #1761 