### PR TITLE
removed legacy prettier setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,5 @@
   "typescript.tsdk": "./node_modules/typescript/lib",
   "editor.tabSize": 2,
   "editor.formatOnSave": true,
-  "prettier.singleQuote": true,
   "rewrap.wrappingColumn": 80
 }


### PR DESCRIPTION
### What does this PR do?
Removed legacy prettier setting that is no longer used in prettier vscode 3.0

### What issues does this PR fix or reference?
