### PR TITLE
Changelog for v47.11.0

### DIFF
--- a/packages/salesforcedx-vscode/CHANGELOG.md
+++ b/packages/salesforcedx-vscode/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 #### docs
 
-- Fix a variety of broken doc links ([PR #1846](https://github.com/forcedotcom/salesforcedx-vscode/pull/1846), [Issue #1825](https://github.com/forcedotcom/salesforcedx-vscode/issues/1825), [Issue #1821](https://github.com/forcedotcom/salesforcedx-vscode/issues/1821), [Issue #1777](https://github.com/forcedotcom/salesforcedx-vscode/issues/1777))
+- Fix links in various doc sections ([PR #1846](https://github.com/forcedotcom/salesforcedx-vscode/pull/1846), [Issue #1825](https://github.com/forcedotcom/salesforcedx-vscode/issues/1825), [Issue #1821](https://github.com/forcedotcom/salesforcedx-vscode/issues/1821), [Issue #1777](https://github.com/forcedotcom/salesforcedx-vscode/issues/1777))
 
-- Fix broken links on [Development Models](https://developer.salesforce.com/tools/vscode/en/user-guide/development-models) and [Default Org](https://developer.salesforce.com/tools/vscode/en/user-guide/default-org) pages ([PR #1844](https://github.com/forcedotcom/salesforcedx-vscode/pull/1844))—Contribution by [@Lafexlos](https://github.com/Lafexlos)
+- Fix broken links in [Development Models](https://developer.salesforce.com/tools/vscode/en/user-guide/development-models) and [Default Org](https://developer.salesforce.com/tools/vscode/en/user-guide/default-org) pages ([PR #1844](https://github.com/forcedotcom/salesforcedx-vscode/pull/1844))—Contribution by [@Lafexlos](https://github.com/Lafexlos)
 
 ## Added
 

--- a/packages/salesforcedx-vscode/CHANGELOG.md
+++ b/packages/salesforcedx-vscode/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 47.11.0 - December 18th, 2019
+
+## Fixed
+
+#### docs
+
+- Fix a variety of broken doc links ([PR #1846](https://github.com/forcedotcom/salesforcedx-vscode/pull/1846), [Issue #1825](https://github.com/forcedotcom/salesforcedx-vscode/issues/1825), [Issue #1821](https://github.com/forcedotcom/salesforcedx-vscode/issues/1821), [Issue #1777](https://github.com/forcedotcom/salesforcedx-vscode/issues/1777))
+
+- Fix broken links on [Development Models](https://developer.salesforce.com/tools/vscode/en/user-guide/development-models) and [Default Org](https://developer.salesforce.com/tools/vscode/en/user-guide/default-org) pages ([PR #1844](https://github.com/forcedotcom/salesforcedx-vscode/pull/1844))—Contribution by [@Lafexlos](https://github.com/Lafexlos)
+
+## Added
+
+#### docs
+
+- Update header and footer to match Salesforce developer site ([PR #1814](https://github.com/forcedotcom/salesforcedx-vscode/pull/1814))
+
 # 47.10.0 - December 12, 2019
 
 ## Fixed


### PR DESCRIPTION
### What does this PR do?

Changelog for v47.11.0. The release only contains doc changes and will not be released to the marketplace.