### PR TITLE
Disable focusing the Output panel when running deploy, org picker, or…

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployCommand.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployCommand.ts
@@ -50,7 +50,6 @@ export abstract class BaseDeployExecutor extends SfdxCommandletExecutor<
     }).execute(cancellationToken);
 
     channelService.streamCommandStartStop(execution);
-    channelService.showChannelOutput();
 
     let stdOut = '';
     execution.stdoutSubject.subscribe(realData => {
@@ -63,6 +62,7 @@ export abstract class BaseDeployExecutor extends SfdxCommandletExecutor<
         const deployParser = new ForceDeployResultParser(stdOut);
         const errors = deployParser.getErrors();
         if (errors && !deployParser.hasConflicts()) {
+          channelService.showChannelOutput();
           handleDiagnosticErrors(
             errors,
             workspacePath,

--- a/packages/salesforcedx-vscode-core/src/commands/forceAuthDevHub.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceAuthDevHub.ts
@@ -33,6 +33,8 @@ import { ConfigSource, OrgAuthInfo } from '../util/index';
 import { ForceAuthDemoModeExecutor } from './forceAuthWebLogin';
 
 export class ForceAuthDevHubExecutor extends SfdxCommandletExecutor<{}> {
+  protected showChannelOutput = false;
+
   public build(data: {}): Command {
     const command = new SfdxCommandBuilder().withDescription(
       nls.localize('force_auth_web_login_authorize_dev_hub_text')

--- a/packages/salesforcedx-vscode-core/src/commands/forceAuthWebLogin.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceAuthWebLogin.ts
@@ -45,6 +45,8 @@ export const SANDBOX_URL = 'https://test.salesforce.com';
 export class ForceAuthWebLoginExecutor extends SfdxCommandletExecutor<
   AuthParams
 > {
+  protected showChannelOutput = false;
+
   public build(data: AuthParams): Command {
     const command = new SfdxCommandBuilder().withDescription(
       nls.localize('force_auth_web_login_authorize_org_text')
@@ -65,6 +67,7 @@ export class ForceAuthWebLoginExecutor extends SfdxCommandletExecutor<
     return command.build();
   }
 }
+
 export abstract class ForceAuthDemoModeExecutor<
   T
 > extends SfdxCommandletExecutor<T> {

--- a/packages/salesforcedx-vscode-core/src/commands/forceConfigSet.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceConfigSet.ts
@@ -18,6 +18,7 @@ import {
 
 export class ForceConfigSetExecutor extends SfdxCommandletExecutor<{}> {
   private usernameOrAlias: string;
+  protected showChannelOutput = false;
 
   public constructor(usernameOrAlias: string) {
     super();

--- a/packages/salesforcedx-vscode-core/src/commands/forceOrgOpen.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceOrgOpen.ts
@@ -101,6 +101,7 @@ export class ForceOrgOpenContainerExecutor extends SfdxCommandletExecutor<{}> {
 }
 
 export class ForceOrgOpenExecutor extends SfdxCommandletExecutor<{}> {
+  protected showChannelOutput = false;
   public build(data: {}): Command {
     return new SfdxCommandBuilder()
       .withDescription(nls.localize('force_org_open_default_scratch_org_text'))

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDiff.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDiff.ts
@@ -48,7 +48,6 @@ export class ForceSourceDiffExecutor extends SfdxCommandletExecutor<string> {
     }).execute(cancellationToken);
 
     channelService.streamCommandStartStop(execution);
-    channelService.showChannelOutput();
 
     let stdOut = '';
     execution.stdoutSubject.subscribe(realData => {
@@ -106,10 +105,12 @@ export async function handleDiffResponse(
       );
     } else if (diffParserError) {
       channelService.appendLine(diffParserError.message);
+      channelService.showChannelOutput();
     }
   } catch (e) {
     notificationService.showErrorMessage(e.message);
     channelService.appendLine(e.message);
+    channelService.showChannelOutput();
     telemetryService.sendException(e.name, e.message);
   }
 }


### PR DESCRIPTION
…g auth and file diff

### What does this PR do?
This PR disables opening the Output panel when running the following commands:
SFDX: Deploy ...
SFDX: Push ...
SFDX: Open Default Org
SFDX: Authorize an Org
SFDX: Authorize a Dev Hub
SFDX: Diff File Against Org

### What issues does this PR fix or reference?
#1806, @W-7099802@