### PR TITLE
Allow spaces in scratch org alias creation

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/helpers/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/index.ts
@@ -6,4 +6,4 @@
  */
 
 export { isNullOrUndefined, extractJsonObject } from './utils';
-export { isAlphaNumString, isInteger, isIntegerInRange } from './validations';
+export { isAlphaNumString, isInteger, isIntegerInRange, isAlphaNumSpaceString } from './validations';

--- a/packages/salesforcedx-utils-vscode/src/helpers/validations.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/validations.ts
@@ -25,7 +25,7 @@ export function isIntegerInRange(
 }
 
 export function isAlphaNumString(value: string | undefined): boolean {
-  return value !== undefined && !/\W/.test(value);
+  return value !== undefined && value !== '' && !/\W/.test(value);
 }
 
 export function isAlphaNumSpaceString(value: string | undefined): boolean {

--- a/packages/salesforcedx-utils-vscode/src/helpers/validations.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/validations.ts
@@ -27,3 +27,7 @@ export function isIntegerInRange(
 export function isAlphaNumString(value: string | undefined): boolean {
   return value !== undefined && !/\W/.test(value);
 }
+
+export function isAlphaNumSpaceString(value: string | undefined): boolean {
+  return value !== undefined && /^\w+( *\w*)*$/.test(value);
+}

--- a/packages/salesforcedx-utils-vscode/test/unit/helpers/validations.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/unit/helpers/validations.test.ts
@@ -19,6 +19,11 @@ describe('Input Box Validations', () => {
       expect(res).to.equal(false);
     });
 
+    it('Should return false if value is empty', async () => {
+      const res = isInteger('');
+      expect(res).to.equal(false);
+    });
+
     it('Should return false if value is a float', async () => {
       const res = isInteger('1.37');
       expect(res).to.equal(false);
@@ -38,6 +43,11 @@ describe('Input Box Validations', () => {
   describe('isIntegerInRange', () => {
     it('Should return false if value is undefined', async () => {
       const res = isIntegerInRange(undefined, [1, 3]);
+      expect(res).to.equal(false);
+    });
+
+    it('Should return false if value is empty', async () => {
+      const res = isIntegerInRange('', [1, 3]);
       expect(res).to.equal(false);
     });
 
@@ -83,6 +93,11 @@ describe('Input Box Validations', () => {
       expect(res).to.equal(false);
     });
 
+    it('Should return false if value is empty', async () => {
+      const res = isAlphaNumString('');
+      expect(res).to.equal(false);
+    });
+
     it('Should return false if value contains non alphanumeric characters', async () => {
       const res = isAlphaNumString('my scratch org');
       expect(res).to.equal(false);
@@ -102,6 +117,11 @@ describe('Input Box Validations', () => {
   describe('isAlphaNumSpaceString', () => {
     it('Should return false if value is undefined', async () => {
       const res = isAlphaNumSpaceString(undefined);
+      expect(res).to.equal(false);
+    });
+
+    it('Should return false if value is empty', async () => {
+      const res = isAlphaNumSpaceString('');
       expect(res).to.equal(false);
     });
 

--- a/packages/salesforcedx-utils-vscode/test/unit/helpers/validations.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/unit/helpers/validations.test.ts
@@ -6,6 +6,7 @@
  */
 import { expect } from 'chai';
 import {
+  isAlphaNumSpaceString,
   isAlphaNumString,
   isInteger,
   isIntegerInRange
@@ -94,6 +95,28 @@ describe('Input Box Validations', () => {
 
     it('Should return true if value has only alphanumeric characters and underscores', async () => {
       const res = isAlphaNumString('scratch_123');
+      expect(res).to.equal(true);
+    });
+  });
+
+  describe('isAlphaNumSpaceString', () => {
+    it('Should return false if value is undefined', async () => {
+      const res = isAlphaNumSpaceString(undefined);
+      expect(res).to.equal(false);
+    });
+
+    it('Should return false if value contains non alphanumeric and space characters', async () => {
+      const res = isAlphaNumSpaceString('my-scratch-org!');
+      expect(res).to.equal(false);
+    });
+
+    it('Should return true if value has only numeric characters', async () => {
+      const res = isAlphaNumSpaceString('123');
+      expect(res).to.equal(true);
+    });
+
+    it('Should return true if value has only underscores, spaces, and alphanumeric characters', async () => {
+      const res = isAlphaNumSpaceString('scratch_123 4 5 6');
       expect(res).to.equal(true);
     });
   });

--- a/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceOrgCreate.ts
@@ -13,7 +13,7 @@ import {
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import {
-  isAlphaNumString,
+  isAlphaNumSpaceString,
   isIntegerInRange
 } from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import {
@@ -50,7 +50,7 @@ export const DEFAULT_EXPIRATION_DAYS = '7';
 
 export class ForceOrgCreateExecutor extends SfdxCommandletExecutor<
   AliasAndFileSelection
-> {
+  > {
   public build(data: AliasAndFileSelection): Command {
     const selectionPath = path.relative(
       getRootWorkspacePath(), // this is safe because of workspaceChecker
@@ -138,7 +138,7 @@ export class AliasGatherer implements ParametersGatherer<Alias> {
       prompt: nls.localize('parameter_gatherer_enter_alias_name'),
       placeHolder: defaultAlias,
       validateInput: value => {
-        return isAlphaNumString(value)
+        return isAlphaNumSpaceString(value)
           ? null
           : nls.localize('error_invalid_org_alias');
       }

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -277,7 +277,7 @@ export const messages = {
   error_auth_token: 'Error refreshing authentication token.',
   error_no_org_found: 'No org authorization info found.',
   error_invalid_org_alias:
-    'Alias can only contain underscores and alphanumeric characters',
+    'Alias can only contain underscores, spaces and alphanumeric characters',
   error_invalid_expiration_days: 'Number of days should be between 1 and 30',
   error_fetching_metadata: 'Error fetching metadata for org.',
   error_org_browser_text:

--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -131,24 +131,24 @@ export class OrgList implements vscode.Disposable {
     switch (selection) {
       case '$(plus) ' +
         nls.localize('force_auth_web_login_authorize_org_text'): {
-        vscode.commands.executeCommand('sfdx.force.auth.web.login');
-        return {
-          type: 'CONTINUE',
-          data: {}
-        };
-      }
+          vscode.commands.executeCommand('sfdx.force.auth.web.login');
+          return {
+            type: 'CONTINUE',
+            data: {}
+          };
+        }
       case '$(plus) ' +
         nls.localize('force_auth_web_login_authorize_dev_hub_text'): {
-        vscode.commands.executeCommand('sfdx.force.auth.dev.hub');
-        return { type: 'CONTINUE', data: {} };
-      }
+          vscode.commands.executeCommand('sfdx.force.auth.dev.hub');
+          return { type: 'CONTINUE', data: {} };
+        }
       case '$(plus) ' +
         nls.localize('force_org_create_default_scratch_org_text'): {
-        vscode.commands.executeCommand('sfdx.force.org.create');
-        return { type: 'CONTINUE', data: {} };
-      }
+          vscode.commands.executeCommand('sfdx.force.org.create');
+          return { type: 'CONTINUE', data: {} };
+        }
       default: {
-        const usernameOrAlias = selection.split(' ', 1);
+        const usernameOrAlias = selection.split(' - ', 1);
         vscode.commands.executeCommand(
           'sfdx.force.config.set',
           usernameOrAlias


### PR DESCRIPTION
### What does this PR do?
1) Allow spaces in alias names during scratch org creation.
2) Slight modification for retrieving alias names via the OrgList.

### What issues does this PR fix or reference?
@W-6009445@