### PR TITLE
@W-6876798 Update extensions to use vscode-test

### DIFF
--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -27,6 +27,7 @@
     "@types/node": "8.9.3",
     "@types/rimraf": "^2.0.2",
     "@types/sinon": "^2.3.2",
+    "@types/vscode": "^1.32.0",
     "chai": "^4.0.2",
     "cross-env": "5.2.0",
     "mocha": "3.2.0",
@@ -36,8 +37,8 @@
     "nyc": "^13",
     "sinon": "^2.3.6",
     "typescript": "3.1.6",
-    "vscode": "1.1.17",
-    "vscode-debugadapter-testsupport": "1.28.0"
+    "vscode-debugadapter-testsupport": "1.28.0",
+    "vscode-test": "^1.3.0"
   },
   "scripts": {
     "compile": "tsc -p ./",

--- a/packages/salesforcedx-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-apex-replay-debugger/package.json
@@ -23,6 +23,7 @@
     "@types/mocha": "2.2.38",
     "@types/node": "8.9.3",
     "@types/sinon": "^2.3.2",
+    "@types/vscode": "^1.32.0",
     "chai": "^4.0.2",
     "cross-env": "5.2.0",
     "mocha": "3.2.0",
@@ -32,8 +33,8 @@
     "request-light": "0.2.4",
     "sinon": "^2.3.6",
     "typescript": "3.1.6",
-    "vscode": "1.1.17",
-    "vscode-debugadapter-testsupport": "1.28.0"
+    "vscode-debugadapter-testsupport": "1.28.0",
+    "vscode-test": "^1.3.0"
   },
   "scripts": {
     "compile": "tsc -p ./",

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -24,6 +24,7 @@
     "@types/path-exists": "^1.0.29",
     "@types/shelljs": "0.7.9",
     "@types/sinon": "^2.3.2",
+    "@types/vscode": "^1.32.0",
     "chai": "^4.0.2",
     "decache": "^4.1.0",
     "glob": "^7.1.2",
@@ -37,7 +38,8 @@
     "request-light": "0.2.4",
     "sinon": "^2.3.6",
     "source-map-support": "^0.4.15",
-    "typescript": "3.1.6"
+    "typescript": "3.1.6",
+    "vscode-test": "^1.3.0"
   },
   "engines": {
     "vscode": "^1.32.0"

--- a/packages/salesforcedx-visualforce-language-server/package.json
+++ b/packages/salesforcedx-visualforce-language-server/package.json
@@ -20,13 +20,15 @@
   "devDependencies": {
     "@types/mocha": "^2.2.38",
     "@types/node": "8.9.3",
+    "@types/vscode": "^1.32.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
     "mocha-junit-reporter": "^1.13.0",
     "mocha-multi-reporters": "^1.1.4",
     "nyc": "^13",
     "shx": "0.2.2",
-    "source-map-support": "^0.4.15"
+    "source-map-support": "^0.4.15",
+    "vscode-test": "^1.3.0"
   },
   "scripts": {
     "compile": "tsc -p ./ && shx cp -R test/unit/fixtures out/test/unit",

--- a/packages/salesforcedx-visualforce-markup-language-server/package.json
+++ b/packages/salesforcedx-visualforce-markup-language-server/package.json
@@ -16,6 +16,7 @@
     "@types/chai": "^4.0.0",
     "@types/mocha": "^2.2.38",
     "@types/node": "8.9.3",
+    "@types/vscode": "^1.32.0",
     "chai": "^4.0.2",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
@@ -24,7 +25,8 @@
     "nyc": "^13",
     "shx": "0.2.2",
     "source-map-support": "^0.4.15",
-    "typescript": "3.1.6"
+    "typescript": "3.1.6",
+    "vscode-test": "^1.3.0"
   },
   "dependencies": {
     "vscode-languageserver-types": "3.4.0",

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -34,11 +34,12 @@
     "@types/mocha": "2.2.38",
     "@types/node": "8.9.3",
     "@types/sinon": "^2.3.2",
+    "@types/vscode": "^1.32.0",
     "chai": "^4.0.2",
     "cross-env": "5.2.0",
     "mocha": "3.2.0",
     "sinon": "^2.3.6",
-    "vscode": "1.1.17"
+    "vscode-test": "^1.3.0"
   },
   "extensionDependencies": [
     "salesforce.salesforcedx-vscode-apex",
@@ -53,7 +54,6 @@
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
     "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
-    "postinstall": "node ./node_modules/vscode/bin/install",
     "test": "npm run test:vscode-integration",
     "test:vscode-integration": "node ../../scripts/run-vscode-integration-tests-with-top-level-extensions",
     "test:vscode-insiders-integration": "cross-env CODE_VERSION=insiders npm run test:vscode-integration"

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -38,11 +38,12 @@
     "@types/node": "8.9.3",
     "@types/path-exists": "^1.0.29",
     "@types/sinon": "^2.3.2",
+    "@types/vscode": "^1.32.0",
     "chai": "^4.0.2",
     "cross-env": "5.2.0",
     "mocha": "3.2.0",
     "sinon": "^2.3.6",
-    "vscode": "1.1.17"
+    "vscode-test": "^1.3.0"
   },
   "extensionDependencies": [
     "salesforce.salesforcedx-vscode-apex",
@@ -57,7 +58,6 @@
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
     "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
-    "postinstall": "node ./node_modules/vscode/bin/install",
     "test": "npm run test:vscode-integration",
     "test:vscode-integration": "node ../../scripts/run-vscode-integration-tests",
     "test:vscode-insiders-integration": "cross-env CODE_VERSION=insiders npm run test:vscode-integration"

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -43,13 +43,14 @@
     "@types/path-exists": "^1.0.29",
     "@types/shelljs": "^0.7.8",
     "@types/sinon": "^2.3.2",
+    "@types/vscode": "^1.32.0",
     "chai": "^4.0.2",
     "cross-env": "5.2.0",
     "mocha": "3.2.0",
     "sinon": "^2.3.6",
     "typescript": "3.1.6",
-    "vscode": "1.1.17",
-    "vscode-extension-telemetry": "0.0.17"
+    "vscode-extension-telemetry": "0.0.17",
+    "vscode-test": "^1.3.0"
   },
   "extensionDependencies": [
     "salesforce.salesforcedx-vscode-core"
@@ -63,7 +64,6 @@
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
     "clean": "shx rm -rf node_modules && cd out && node ../../../scripts/clean-all-but-jar.js && shx rm -rf coverage && shx rm -rf .nyc_output",
-    "postinstall": "node ./node_modules/vscode/bin/install",
     "test": "npm run test:vscode-integration",
     "test:vscode-integration": "node ../../scripts/run-vscode-integration-tests-with-top-level-extensions",
     "test:vscode-insiders-integration": "cross-env CODE_VERSION=insiders npm run test:vscode-integration"

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -44,13 +44,14 @@
     "@types/sanitize-filename": "^1.1.28",
     "@types/shelljs": "^0.7.8",
     "@types/sinon": "^2.3.2",
+    "@types/vscode": "^1.32.0",
     "chai": "^4.0.2",
     "cross-env": "5.2.0",
     "mocha": "3.2.0",
     "mock-spawn": "0.2.6",
     "sinon": "^2.3.6",
     "typescript": "3.1.6",
-    "vscode": "1.1.17"
+    "vscode-test": "^1.3.0"
   },
   "scripts": {
     "vscode:prepublish": "npm prune --production",
@@ -61,7 +62,6 @@
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
     "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
-    "postinstall": "node ./node_modules/vscode/bin/install",
     "test": "npm run test:vscode-integration",
     "test:vscode-integration": "cross-env CODE_TESTS_WORKSPACE='../system-tests/assets/sfdx-simple' node ../../scripts/run-vscode-integration-tests",
     "test:vscode-insiders-integration": "cross-env CODE_VERSION=insiders npm run test:vscode-integration"

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "@salesforce/salesforcedx-utils-vscode": "47.10.0",
     "aura-language-server": "2.2.2",
-    "lwc-language-server": "2.2.4",
     "change-case": "^3.1.0",
     "lightning-lsp-common": "2.2.2",
     "lwc-language-server": "2.2.4",
@@ -42,13 +41,14 @@
     "@types/node": "8.9.3",
     "@types/open": "6.0.0",
     "@types/sinon": "^2.3.2",
+    "@types/vscode": "^1.32.0",
     "@types/which": "^1.3.1",
     "chai": "^4.0.2",
     "cross-env": "5.2.0",
     "mocha": "3.2.0",
     "sinon": "^2.3.6",
     "typescript": "3.1.6",
-    "vscode": "1.1.17"
+    "vscode-test": "^1.3.0"
   },
   "scripts": {
     "vscode:prepublish": "npm prune --production",
@@ -59,7 +59,6 @@
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
     "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
-    "postinstall": "node ./node_modules/vscode/bin/install",
     "test": "npm run test:vscode-integration",
     "test:vscode-integration": "node ../../scripts/run-vscode-integration-tests-with-top-level-extensions",
     "test:vscode-insiders-integration": "cross-env CODE_VERSION=insiders npm run test:vscode-integration"

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -46,6 +46,7 @@
     "@types/node": "8.9.3",
     "@types/sinon": "^2.3.2",
     "@types/uuid": "^3.4.5",
+    "@types/vscode": "^1.32.0",
     "@types/which": "^1.3.1",
     "chai": "^4.0.2",
     "cross-env": "5.2.0",
@@ -55,7 +56,7 @@
     "nyc": "^13",
     "sinon": "^2.3.6",
     "typescript": "3.1.6",
-    "vscode": "1.1.17",
+    "vscode-test": "^1.3.0",
     "vscode-uri": "^1.0.8"
   },
   "extensionDependencies": [
@@ -71,7 +72,6 @@
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
     "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
-    "postinstall": "node ./node_modules/vscode/bin/install",
     "test": "npm run test:unit && npm run test:vscode-integration",
     "test:unit": "./node_modules/.bin/cross-env VSCODE_NLS_CONFIG={} ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --recursive out/test/unit --reporter mocha-multi-reporters --reporter-options configFile=../../config/mochaUnitTestsConfig.json",
     "test:vscode-integration": "node ../../scripts/install-vsix-dependencies dbaeumer.vscode-eslint && node ../../scripts/run-vscode-integration-tests-with-top-level-extensions",

--- a/packages/salesforcedx-vscode-visualforce/package.json
+++ b/packages/salesforcedx-vscode-visualforce/package.json
@@ -37,12 +37,13 @@
     "@types/mocha": "2.2.38",
     "@types/node": "8.9.3",
     "@types/sinon": "^2.3.2",
+    "@types/vscode": "^1.32.0",
     "chai": "^4.0.2",
     "cross-env": "5.2.0",
     "mocha": "3.2.0",
     "sinon": "^2.3.6",
     "typescript": "3.1.6",
-    "vscode": "1.1.17"
+    "vscode-test": "^1.3.0"
   },
   "extensionDependencies": [
     "salesforce.salesforcedx-vscode-core"
@@ -56,7 +57,6 @@
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
     "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
-    "postinstall": "node ./node_modules/vscode/bin/install",
     "test": "npm run test:vscode-integration",
     "test:vscode-integration": "node ../../scripts/run-vscode-integration-tests-with-top-level-extensions",
     "test:vscode-insiders-integration": "cross-env CODE_VERSION=insiders npm run test:vscode-integration"

--- a/packages/system-tests/package.json
+++ b/packages/system-tests/package.json
@@ -17,6 +17,7 @@
     "@types/node": "8.9.3",
     "@types/rimraf": "0.0.28",
     "@types/shelljs": "^0.7.4",
+    "@types/vscode": "^1.32.0",
     "@types/webdriverio": "4.6.1",
     "chai": "^4.0.2",
     "cross-env": "5.2.0",
@@ -34,14 +35,13 @@
     "source-map-support": "^0.4.15",
     "spectron": "5.0.0",
     "typescript": "3.1.6",
-    "vscode": "1.1.17"
+    "vscode-test": "^1.3.0"
   },
   "scripts": {
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
     "watch": "tsc -watch -p .",
     "clean": "shx rm -rf .vscode-test && shx rm -rf node_modules && shx rm -rf out",
-    "postinstall": "node ./node_modules/vscode/bin/install",
     "pretest": "npm run compile && node ../../scripts/download-vscode-for-system-tests",
     "test": "node ../../scripts/install-vsix-dependencies dbaeumer.vscode-eslint && node out/src/main.js",
     "test:vscode-insiders-system-tests": "cross-env CODE_VERSION=insiders npm run pretest && node ../../scripts/install-vsix-dependencies dbaeumer.vscode-eslint && CODE_VERSION=insiders node out/src/main.js",


### PR DESCRIPTION
### What does this PR do?
The vscode team has split up the vscode package into 2, with a new one (vscode-test) being specific for test usage. We should update our repository to use it since it provides some updates to the api's we use for testing.

Removes the 'vscode' dependency and adds 'vscode-test'. Also adds the types and removes the postinstall command as described in the migration steps here:
https://code.visualstudio.com/api/working-with-extensions/testing-extension#migrating-from-vscode

### What issues does this PR fix or reference?
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000007d9DjIAI/view

