### PR TITLE
Fix telemetry error data on apex activation

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/index.ts
@@ -92,7 +92,12 @@ export async function activate(context: vscode.ExtensionContext) {
             if (sobjectRefreshStartup) {
               initSObjectDefinitions(
                 vscode.workspace.workspaceFolders![0].uri.fsPath
-              ).catch(e => telemetryService.sendErrorEvent(e.message, e.stack));
+              ).catch(e =>
+                telemetryService.sendErrorEvent({
+                  message: e.message,
+                  stack: e.stack
+                })
+              );
             }
 
             await testOutlineProvider.refresh();


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where upon failure of syncing sobject definitions, we were sending the error data in an unreadable format. This was occurring because we were accidentally sending the stack trace as `additional data` instead of as part of the error object.

### What issues does this PR fix or reference?
@W-7144699@