### PR TITLE
feat: set envar for cli logging

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/cli/commandExecutor.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/commandExecutor.ts
@@ -67,6 +67,7 @@ export class CliCommandExecutor {
           GlobalCliEnvironment.environmentVariables
         )
       : options;
+    this.options.env.SFDX_TOOL = 'salesforce-vscode-extensions';
   }
 
   public execute(cancellationToken?: CancellationToken): CliCommandExecution {


### PR DESCRIPTION
### What does this PR do?
Set SFDX_TOOL on all CLI commands invoked by vscode extensions. The CLI will record that envar to appinsights so we can see what percentage of commands are invoked by vscode.

### What issues does this PR fix or reference?
@W-7162538@