### PR TITLE
Log vscode.env.uiKind as common telemetry property

### DIFF
--- a/packages/salesforcedx-vscode-core/src/telemetry/telemetryReporter.ts
+++ b/packages/salesforcedx-vscode-core/src/telemetry/telemetryReporter.ts
@@ -130,6 +130,10 @@ export default class TelemetryReporter extends vscode.Disposable {
       commonProperties['common.vscodemachineid'] = vscode.env.machineId;
       commonProperties['common.vscodesessionid'] = vscode.env.sessionId;
       commonProperties['common.vscodeversion'] = vscode.version;
+      if (vscode.env.uiKind) {
+        commonProperties['common.vscodeuikind'] =
+          vscode.UIKind[vscode.env.uiKind];
+      }
     }
     return commonProperties;
   }


### PR DESCRIPTION
### What does this PR do?
Logs the `vscode.env.uiKind` (current values are either "Desktop" or "Web") as a common telemetry property. This way we can filter in AppInsights based on whether a telemetry event comes from the Desktop client or Web client.

### What issues does this PR fix or reference?
W-6984859