### PR TITLE
Update apex-tmlanguage dependency

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -24,7 +24,7 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/apex-tmlanguage": "1.2.0",
+    "@salesforce/apex-tmlanguage": "1.3.0",
     "@salesforce/core": "2.0.1",
     "@salesforce/salesforcedx-sobjects-faux-generator": "47.17.1",
     "@salesforce/salesforcedx-utils-vscode": "47.17.1",


### PR DESCRIPTION
### What does this PR do?
Updates the apex-tmlanguage dependency to get the latest syntax highlighting updates. Below is a list of updates.
- SOQL when clause highlighting
- Switch statements with multiple string clauses
- JavaDoc support
- Missing apex class highlighting

### What issues does this PR fix or reference?
@W-6532166@, @W-7210864@, @W-5973555@, 

### Functionality Before
SOQL
![Screen Shot 2020-02-12 at 3 28 26 PM](https://user-images.githubusercontent.com/1041842/74387118-8f2c9a00-4dac-11ea-9fec-9e7d84ef0945.png)

JavaDoc
![javadoc-before](https://user-images.githubusercontent.com/1041842/74386037-d9604c00-4da9-11ea-89fd-c19cde074758.png)

Apex keyword
![system-class-before](https://user-images.githubusercontent.com/1041842/74386060-e715d180-4da9-11ea-9f1f-292ed5ab5a27.png)

Strings on switch
![switch-string-before](https://user-images.githubusercontent.com/1041842/74386142-162c4300-4daa-11ea-91eb-344eaf1f7328.png)

### Functionality After
SOQL
![Screen Shot 2020-02-12 at 3 27 40 PM](https://user-images.githubusercontent.com/1041842/74387135-98b60200-4dac-11ea-9e72-96e8b67cc3e0.png)

JavaDoc
![javadoc-after](https://user-images.githubusercontent.com/1041842/74386054-e2511d80-4da9-11ea-8c9a-0f310b476f62.png)

Apex keyword
![system-class-after](https://user-images.githubusercontent.com/1041842/74386108-00b71900-4daa-11ea-9bca-7b576aa9295b.png)

Strings on switch
![Screen Shot 2020-02-12 at 3 09 17 PM](https://user-images.githubusercontent.com/1041842/74386168-27754f80-4daa-11ea-904c-35e47b818413.png)



