### PR TITLE
[W-7241114] Add GitHub Action to upgrade language servers

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -1,0 +1,32 @@
+name: Check Dependencies
+
+on:
+  schedule:
+    - cron: '00 0 * * *'
+
+jobs:
+  check-language-servers:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package:
+          - salesforcedx-vscode-lwc
+          - salesforcedx-vscode-lightning
+    steps:
+      - uses: actions/checkout@master
+      - name: set remote url
+        run: git remote set-url --push origin https://$GITHUB_ACTOR:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
+      - name: package-update
+        uses: taichi/actions-package-update@master
+        env:
+          AUTHOR_EMAIL: actions@github.com
+          AUTHOR_NAME: github-actions
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXECUTE: true
+          BRANCH_PREFIX: ${{ matrix.package }}/
+          COMMIT_MESSAGE: Upgrade Langauge Servers for ${{ matrix.package }}
+        with:
+          args: >-
+            -u
+            --packageFile packages/${{ matrix.package }}/package.json
+            @salesforce/aura-language-server,@salesforce/lwc-language-server,@salesforce/lightning-lsp-common


### PR DESCRIPTION
### What does this PR do?
Adds a GitHub Action that checks daily for language server updates and opens a PR per extension(lwc or lightning) to upgrade if necessary. 

### What issues does this PR fix or reference?
@W-7241114@

### Functionality Before
Dependabot would open a PR for each individual dependency, but this would not work when multiple dependencies needed to be updated in the same PR.

### Functionality After
Upgrade PRs for grouped language server packages per extension