### PR TITLE
Handle scenarios where global envs should be ignored in CLICommandExecutor

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/cli/commandExecutor.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/commandExecutor.ts
@@ -67,7 +67,9 @@ export class CliCommandExecutor {
           GlobalCliEnvironment.environmentVariables
         )
       : options;
-    this.options.env.SFDX_TOOL = 'salesforce-vscode-extensions';
+    if (this.options && this.options.env) {
+      this.options.env.SFDX_TOOL = 'salesforce-vscode-extensions';
+    }
   }
 
   public execute(cancellationToken?: CancellationToken): CliCommandExecution {

--- a/packages/salesforcedx-utils-vscode/src/cli/commandExecutor.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/commandExecutor.ts
@@ -43,6 +43,11 @@ export class CliCommandExecutor {
       env[key] = value;
     });
 
+    // telemetry header
+    if (env) {
+      env.SFDX_TOOL = 'salesforce-vscode-extensions';
+    }
+
     // then specific environment from Spawn Options
     if (typeof options.env !== 'undefined') {
       Object.assign(env, options.env);
@@ -67,9 +72,6 @@ export class CliCommandExecutor {
           GlobalCliEnvironment.environmentVariables
         )
       : options;
-    if (this.options && this.options.env) {
-      this.options.env.SFDX_TOOL = 'salesforce-vscode-extensions';
-    }
   }
 
   public execute(cancellationToken?: CancellationToken): CliCommandExecution {


### PR DESCRIPTION
### What does this PR do?
Updates the assignment of SFDX_TOOL in scenarios where env variables need to be ignored. This fixes the current issues with ISV Debugger.

### What issues does this PR fix or reference?
#2013 , @W-7256523@