### PR TITLE
removed beta setup requirements

### DIFF
--- a/docs/_articles/en/user-guide/detect-conflicts.md
+++ b/docs/_articles/en/user-guide/detect-conflicts.md
@@ -5,16 +5,7 @@ lang: en
 
 Whenever you retrieve or deploy source to keep the local project and your default org in sync, the operation could detect conflicts. If conflicts are not detected, the retrieve or deploy operation is completed. If conflicts are detected, the retrieve or deploy operation can be cancelled. The resource files that caused the conflict and the CLI command to overwrite the conflict is displayed in the Output panel. You can enable the conflict detection feature only in non-scratch orgs.
 
-> NOTICE: The conflict detection feature is currently in beta. If you have any issues or feedback, [open a GitHub issue](./en/bugs-and-feedback).
-
-Because the conflict detection feature is in beta, you must enable the feature:
-
-1. Select **File** > **Preferences** > **Settings** (Windows or Linux) or **Code** > **Preferences** > **Settings** (macOS).
-1. Under Salesforce Feature Previews, select Detect Conflicts At Sync.
-
-You can also enter conflict detection in the search box to find the feature and then enable it.
-
-In this beta release, we have enabled conflict detection for the **SFDX: Retrieve Source in Manifest from Org** and **SFDX: Deploy Source in Manifest to Org** commands only. All manifest files that exists both in the org and in the local environment are checked for conflicts; files that don’t exist in both are not checked.
+All manifest files that exists both in the org and in the local environment are checked for conflicts; files that don’t exist in both are not checked.
 
 ![Prompt for conflict detection](./images/DetectConflict_prompt.png)
 


### PR DESCRIPTION
since the feature is no longer in beta, the extra setup steps are not required, so I removed them from the document.

### What does this PR do?
Removed extra setup steps that are not required since this is no longer in beta

### What issues does this PR fix or reference?


### Functionality Before
Users were directed to locate and check a box that no longer exists in VS Code

### Functionality After
Users are no longer directed to check a box that doesn't exist
