### PR TITLE
Update publish-vsix.js to use the global vsce module

### DIFF
--- a/scripts/publish-vsix.js
+++ b/scripts/publish-vsix.js
@@ -12,16 +12,15 @@ if (!vsix.length) {
   shell.exit(1);
 }
 
-const vsce = '../../node_modules/.bin/vsce';
 const VSCE_PERSONAL_ACCESS_TOKEN = process.env['VSCE_PERSONAL_ACCESS_TOKEN'];
 let vscePublish = '';
 if (VSCE_PERSONAL_ACCESS_TOKEN) {
   vscePublish = shell.exec(
-    `${vsce} publish --pat ${VSCE_PERSONAL_ACCESS_TOKEN} --packagePath ${vsix}`
+    `vsce publish --pat ${VSCE_PERSONAL_ACCESS_TOKEN} --packagePath ${vsix}`
   );
 } else {
   // Assume that one has already been configured
-  vscePublish = shell.exec(`${vsce} publish --packagePath ${vsix}`);
+  vscePublish = shell.exec(`vsce publish --packagePath ${vsix}`);
 }
 
 // Check that publishing extension was successful.


### PR DESCRIPTION
### What does this PR do?
Updates publish-vsix.js script to use the global vsce module instead of hardcoding the path to a locally installed one. 

### What issues does this PR fix or reference?
@W-7298800@
