### PR TITLE
Prevent lwc and lightning extensions activating in non-Salesforce projects

### DIFF
--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -68,8 +68,6 @@
     "test:vscode-insiders-integration": "cross-env CODE_VERSION=insiders npm run test:vscode-integration"
   },
   "activationEvents": [
-    "onLanguage:html",
-    "onLanguage:javascript",
     "workspaceContains:sfdx-project.json",
     "workspaceContains:**/workspace-user.xml",
     "onView:salesforce-lightning-explorer"

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -81,8 +81,6 @@
     "test:vscode-insiders-integration": "cross-env CODE_VERSION=insiders npm run test:vscode-integration"
   },
   "activationEvents": [
-    "onLanguage:html",
-    "onLanguage:javascript",
     "workspaceContains:sfdx-project.json",
     "workspaceContains:**/workspace-user.xml",
     "onView:salesforce-lightning-explorer",


### PR DESCRIPTION
### What does this PR do?
These changes will prevent LWC & Lightning extensions activating in non-Salesforce projects which cause the salesforce-core extension to activate and throw errors.

This addresses issues #1988 and #2065 

### What issues does this PR fix or reference?

