### PR TITLE
Missing/misconfigured label for Apex Interactive Debugger

### DIFF
--- a/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
+++ b/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
@@ -13,6 +13,7 @@ import {
   ForceConfigGet,
   ForceOrgDisplay
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import { extractJsonObject } from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import { RequestService } from '@salesforce/salesforcedx-utils-vscode/out/src/requestService';
 import * as AsyncLock from 'async-lock';
 import { basename } from 'path';
@@ -1505,7 +1506,7 @@ export class ApexDebug extends LoggingDebugSession {
     }
     try {
       response.success = false;
-      const errorObj = JSON.parse(error);
+      const errorObj = extractJsonObject(error);
       if (errorObj && errorObj.message) {
         const errorMessage: string = errorObj.message;
         if (
@@ -1525,11 +1526,14 @@ export class ApexDebug extends LoggingDebugSession {
           );
         }
       } else {
+        response.message = nls.localize('unexpected_error_help_text');
         this.errorToDebugConsole(
           `${nls.localize('command_error_help_text')}:${os.EOL}${error}`
         );
       }
     } catch (e) {
+      response.message =
+        response.message || nls.localize('unexpected_error_help_text');
       this.errorToDebugConsole(
         `${nls.localize('command_error_help_text')}:${os.EOL}${error}`
       );

--- a/packages/salesforcedx-apex-debugger/src/messages/i18n.ts
+++ b/packages/salesforcedx-apex-debugger/src/messages/i18n.ts
@@ -40,5 +40,5 @@ export const messages = {
   invalid_isv_project_config:
     'Your project configuration is invalid or incomplete for ISV debugging. Return to the Apex Debugger page in Setup, start a new partner debugging session, and try again.',
   unexpected_error_help_text:
-    'There was an unexpected error launching your debugger session. Please check the debug console for more detailed information.'
+    'An unexpected error occurred while launching the debugger session. Refer to the Debug Console for details.'
 };

--- a/packages/salesforcedx-apex-debugger/src/messages/i18n.ts
+++ b/packages/salesforcedx-apex-debugger/src/messages/i18n.ts
@@ -38,5 +38,7 @@ export const messages = {
   idle_terminated_text:
     'Your debugger session is being terminated because it has been idle for %s minutes.',
   invalid_isv_project_config:
-    'Your project configuration is invalid or incomplete for ISV debugging. Return to the Apex Debugger page in Setup, start a new partner debugging session, and try again.'
+    'Your project configuration is invalid or incomplete for ISV debugging. Return to the Apex Debugger page in Setup, start a new partner debugging session, and try again.',
+  unexpected_error_help_text:
+    'There was an unexpected error launching your debugger session. Please check the debug console for more detailed information.'
 };

--- a/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebug.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/adapter/apexDebug.test.ts
@@ -1568,6 +1568,7 @@ describe('Interactive debugger adapter - unit', () => {
 
   describe('Logging', () => {
     let breakpointService: BreakpointService;
+    let response: DebugProtocol.Response;
     const lineNumberMapping: Map<
       string,
       LineBreakpointsInTyperef[]
@@ -1587,6 +1588,13 @@ describe('Interactive debugger adapter - unit', () => {
 
     beforeEach(() => {
       adapter = new ApexDebugForTest(new RequestService());
+      response = {
+        command: '',
+        success: true,
+        request_seq: 0,
+        seq: 0,
+        type: 'response'
+      };
       breakpointService = adapter.getBreakpointService();
       breakpointService.setValidLines(lineNumberMapping, typerefMapping);
     });
@@ -1595,6 +1603,13 @@ describe('Interactive debugger adapter - unit', () => {
       adapter.tryToParseSfdxError({} as DebugProtocol.Response);
 
       expect(adapter.getEvents().length).to.equal(0);
+    });
+
+    it('Should not log error without an error message', () => {
+      adapter.tryToParseSfdxError(response, {});
+      expect(response.message).to.equal(
+        nls.localize('unexpected_error_help_text')
+      );
     });
 
     it('Should error to console with unexpected error schema', () => {


### PR DESCRIPTION
### What does this PR do?
This PR addresses the missing label issue with the Apex Interactive Debugger. It handles an issue with the json parsing of the error object and displays a default error message if an unexpected error is thrown.

### What issues does this PR fix or reference?
#2005 , @W-7287990@

### Functionality Before
![image](https://user-images.githubusercontent.com/21326913/76816659-01363b80-67be-11ea-9aca-65c3fd2243f8.png)

### Functionality After
<img width="421" alt="Screen Shot 2020-03-16 at 2 17 45 PM" src="https://user-images.githubusercontent.com/21326913/76816627-f085c580-67bd-11ea-87fe-70cbb25897fd.png">
<img width="919" alt="Screen Shot 2020-03-16 at 2 17 58 PM" src="https://user-images.githubusercontent.com/21326913/76816635-f2e81f80-67bd-11ea-98f9-c986be501bd8.png">
