### PR TITLE
Hide Apex test sidebar commands from showing in Command Palette

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -144,6 +144,30 @@
         {
           "command": "sfdx.force.internal.refreshsobjects",
           "when": "sfdx:project_opened"
+        },
+        {
+          "command": "sfdx.force.test.view.runClassTests",
+          "when": "false"
+        },
+        {
+          "command": "sfdx.force.test.view.runSingleTest",
+          "when": "false"
+        },
+        {
+          "command": "sfdx.force.test.view.goToDefinition",
+          "when": "false"
+        },
+        {
+          "command": "sfdx.force.test.view.showError",
+          "when": "false"
+        },
+        {
+          "command": "sfdx.force.test.view.run",
+          "when": "false"
+        },
+        {
+          "command": "sfdx.force.test.view.refresh",
+          "when": "false"
         }
       ]
     },


### PR DESCRIPTION
### What does this PR do?
Hide Apex Test sidebar commands from showing in Command Palette. This is needed since these commands cannot run successfully from the Command Palette.

### What issues does this PR fix or reference?
#2088 , @W-7353790@