### PR TITLE
Perf changes for source retrieve

### DIFF
--- a/docs/_articles/en/user-guide/perf-enhancements.md
+++ b/docs/_articles/en/user-guide/perf-enhancements.md
@@ -14,7 +14,7 @@ To enable this beta feature:
 1. Select **File** > **Preferences** > **Settings** (Windows or Linux) or **Code** > **Preferences** > **Settings** (macOS).
 1. Under Salesforce Feature Previews, select Experimental: Deploy Retrieve.
 
-In this beta release, performance enhancements are effective when you run the **SFDX: Deploy this Source to Org** command with these metadata types:
+In this beta release, performance enhancements are effective when you run the **SFDX: Deploy This Source to Org** and **SFDX: Retrieve This Source from Org** command with these metadata types:
 
 - Apex Class
 - Apex Trigger

--- a/docs/_articles/en/user-guide/perf-enhancements.md
+++ b/docs/_articles/en/user-guide/perf-enhancements.md
@@ -20,3 +20,4 @@ In this beta release, performance enhancements are effective when you run the **
 - Apex Trigger
 - Visualforce Component
 - Visualforce Page
+- Lightning Components

--- a/docs/_articles/ja/user-guide/perf-enhancements.md
+++ b/docs/_articles/ja/user-guide/perf-enhancements.md
@@ -14,7 +14,7 @@ To enable this beta feature:
 1. Select **File** > **Preferences** > **Settings** (Windows or Linux) or **Code** > **Preferences** > **Settings** (macOS).
 1. Under Salesforce Feature Previews, select Experimental: Deploy Retrieve.
 
-In this beta release, performance enhancements are effective when you run the **SFDX: Deploy this Source to Org** command with these metadata types:
+In this beta release, performance enhancements are effective when you run the **SFDX: Deploy This Source to Org** and **SFDX: Retrieve This Source from Org** command with these metadata types:
 
 - Apex Class
 - Apex Trigger

--- a/docs/_articles/ja/user-guide/perf-enhancements.md
+++ b/docs/_articles/ja/user-guide/perf-enhancements.md
@@ -20,3 +20,4 @@ In this beta release, performance enhancements are effective when you run the **
 - Apex Trigger
 - Visualforce Component
 - Visualforce Page
+- Lightning Components

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploySourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploySourcePath.ts
@@ -108,9 +108,9 @@ export function useBetaRetrieve(explorerPath: vscode.Uri[]): boolean {
   if (explorerPath.length > 1) {
     return false;
   }
-  // const filePath = explorerPath[0].fsPath;
+  const filePath = explorerPath[0].fsPath;
   const betaDeployRetrieve = sfdxCoreSettings.getBetaDeployRetrieve();
-  const supportedType = true; /*
+  const supportedType =
     path.extname(filePath) === APEX_CLASS_EXTENSION ||
     filePath.includes(`${APEX_CLASS_EXTENSION}-meta.xml`) ||
     (path.extname(filePath) === APEX_TRIGGER_EXTENSION ||
@@ -118,7 +118,7 @@ export function useBetaRetrieve(explorerPath: vscode.Uri[]): boolean {
     (path.extname(filePath) === VISUALFORCE_COMPONENT_EXTENSION ||
       filePath.includes(`${VISUALFORCE_COMPONENT_EXTENSION}-meta.xml`)) ||
     (path.extname(filePath) === VISUALFORCE_PAGE_EXTENSION ||
-      filePath.includes(`${VISUALFORCE_PAGE_EXTENSION}-meta.xml`));*/
+      filePath.includes(`${VISUALFORCE_PAGE_EXTENSION}-meta.xml`));
   return betaDeployRetrieve && supportedType;
 }
 

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploySourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploySourcePath.ts
@@ -108,9 +108,9 @@ export function useBetaRetrieve(explorerPath: vscode.Uri[]): boolean {
   if (explorerPath.length > 1) {
     return false;
   }
-  const filePath = explorerPath[0].fsPath;
+  // const filePath = explorerPath[0].fsPath;
   const betaDeployRetrieve = sfdxCoreSettings.getBetaDeployRetrieve();
-  const supportedType =
+  const supportedType = true; /*
     path.extname(filePath) === APEX_CLASS_EXTENSION ||
     filePath.includes(`${APEX_CLASS_EXTENSION}-meta.xml`) ||
     (path.extname(filePath) === APEX_TRIGGER_EXTENSION ||
@@ -118,7 +118,7 @@ export function useBetaRetrieve(explorerPath: vscode.Uri[]): boolean {
     (path.extname(filePath) === VISUALFORCE_COMPONENT_EXTENSION ||
       filePath.includes(`${VISUALFORCE_COMPONENT_EXTENSION}-meta.xml`)) ||
     (path.extname(filePath) === VISUALFORCE_PAGE_EXTENSION ||
-      filePath.includes(`${VISUALFORCE_PAGE_EXTENSION}-meta.xml`));
+      filePath.includes(`${VISUALFORCE_PAGE_EXTENSION}-meta.xml`));*/
   return betaDeployRetrieve && supportedType;
 }
 

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveSourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveSourcePath.ts
@@ -22,7 +22,12 @@ import { notificationService } from '../notifications';
 import { sfdxCoreSettings } from '../settings';
 import { SfdxPackageDirectories } from '../sfdxProject';
 import { telemetryService } from '../telemetry';
-import { APEX_CLASS_EXTENSION } from './templates/metadataTypeConstants';
+import {
+  APEX_CLASS_EXTENSION,
+  APEX_TRIGGER_EXTENSION,
+  VISUALFORCE_COMPONENT_EXTENSION,
+  VISUALFORCE_PAGE_EXTENSION
+} from './templates/metadataTypeConstants';
 import {
   FilePathGatherer,
   SfdxCommandlet,
@@ -117,7 +122,13 @@ function useBetaRetrieve(explorerPath: vscode.Uri): boolean {
   const betaDeployRetrieve = sfdxCoreSettings.getBetaDeployRetrieve();
   const supportedType =
     path.extname(filePath) === APEX_CLASS_EXTENSION ||
-    filePath.includes(`${APEX_CLASS_EXTENSION}-meta.xml`);
+    filePath.includes(`${APEX_CLASS_EXTENSION}-meta.xml`) ||
+    (path.extname(filePath) === APEX_TRIGGER_EXTENSION ||
+      filePath.includes(`${APEX_TRIGGER_EXTENSION}-meta.xml`)) ||
+    (path.extname(filePath) === VISUALFORCE_COMPONENT_EXTENSION ||
+      filePath.includes(`${VISUALFORCE_COMPONENT_EXTENSION}-meta.xml`)) ||
+    (path.extname(filePath) === VISUALFORCE_PAGE_EXTENSION ||
+      filePath.includes(`${VISUALFORCE_PAGE_EXTENSION}-meta.xml`));
   const multipleSourcePaths = filePath.includes(',');
   return betaDeployRetrieve && supportedType && !multipleSourcePaths;
 }
@@ -142,8 +153,7 @@ export class LibraryRetrieveSourcePathExecutor extends LibraryCommandletExecutor
         this.sourceClient.tooling.retrieveWithPaths
       );
       const retrieveOpts = {
-        paths: [response.data],
-        output: 'wa'
+        paths: [response.data]
       };
       await this.sourceClient.tooling.retrieveWithPaths(retrieveOpts);
       this.logMetric();

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveSourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveSourcePath.ts
@@ -117,20 +117,15 @@ export async function forceSourceRetrieveSourcePath(explorerPath: vscode.Uri) {
 
 // this supported types logic is temporary until we have a way of generating the metadata type from the path
 // once we have the metadata type we can check to see if it is a toolingsupportedtype from that util
-function useBetaRetrieve(explorerPath: vscode.Uri): boolean {
+export function useBetaRetrieve(explorerPath: vscode.Uri): boolean {
   const filePath = explorerPath.fsPath;
   const betaDeployRetrieve = sfdxCoreSettings.getBetaDeployRetrieve();
   const supportedType =
     path.extname(filePath) === APEX_CLASS_EXTENSION ||
-    filePath.includes(`${APEX_CLASS_EXTENSION}-meta.xml`) ||
-    (path.extname(filePath) === APEX_TRIGGER_EXTENSION ||
-      filePath.includes(`${APEX_TRIGGER_EXTENSION}-meta.xml`)) ||
-    (path.extname(filePath) === VISUALFORCE_COMPONENT_EXTENSION ||
-      filePath.includes(`${VISUALFORCE_COMPONENT_EXTENSION}-meta.xml`)) ||
-    (path.extname(filePath) === VISUALFORCE_PAGE_EXTENSION ||
-      filePath.includes(`${VISUALFORCE_PAGE_EXTENSION}-meta.xml`));
-  const multipleSourcePaths = filePath.includes(',');
-  return betaDeployRetrieve && supportedType && !multipleSourcePaths;
+    path.extname(filePath) === APEX_TRIGGER_EXTENSION ||
+    path.extname(filePath) === VISUALFORCE_COMPONENT_EXTENSION ||
+    path.extname(filePath) === VISUALFORCE_PAGE_EXTENSION;
+  return betaDeployRetrieve && supportedType;
 }
 
 export class LibraryRetrieveSourcePathExecutor extends LibraryCommandletExecutor<

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveSourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveSourcePath.ts
@@ -26,10 +26,10 @@ import { telemetryService } from '../telemetry';
 import {
   APEX_CLASS_EXTENSION,
   APEX_TRIGGER_EXTENSION,
-  VISUALFORCE_COMPONENT_EXTENSION,
-  VISUALFORCE_PAGE_EXTENSION,
   AURA_DIRECTORY,
-  LWC_DIRECTORY
+  LWC_DIRECTORY,
+  VISUALFORCE_COMPONENT_EXTENSION,
+  VISUALFORCE_PAGE_EXTENSION
 } from './templates/metadataTypeConstants';
 import {
   FilePathGatherer,

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveSourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveSourcePath.ts
@@ -118,13 +118,17 @@ export async function forceSourceRetrieveSourcePath(explorerPath: vscode.Uri) {
 // this supported types logic is temporary until we have a way of generating the metadata type from the path
 // once we have the metadata type we can check to see if it is a toolingsupportedtype from that util
 export function useBetaRetrieve(explorerPath: vscode.Uri): boolean {
-  const filePath = explorerPath.fsPath;
+  // const filePath = explorerPath.fsPath;
   const betaDeployRetrieve = sfdxCoreSettings.getBetaDeployRetrieve();
-  const supportedType =
+  const supportedType = true; /*
     path.extname(filePath) === APEX_CLASS_EXTENSION ||
-    path.extname(filePath) === APEX_TRIGGER_EXTENSION ||
-    path.extname(filePath) === VISUALFORCE_COMPONENT_EXTENSION ||
-    path.extname(filePath) === VISUALFORCE_PAGE_EXTENSION;
+    filePath.includes(`${APEX_CLASS_EXTENSION}-meta.xml`) ||
+    (path.extname(filePath) === APEX_TRIGGER_EXTENSION ||
+      filePath.includes(`${APEX_TRIGGER_EXTENSION}-meta.xml`)) ||
+    (path.extname(filePath) === VISUALFORCE_COMPONENT_EXTENSION ||
+      filePath.includes(`${VISUALFORCE_COMPONENT_EXTENSION}-meta.xml`)) ||
+    (path.extname(filePath) === VISUALFORCE_PAGE_EXTENSION ||
+      filePath.includes(`${VISUALFORCE_PAGE_EXTENSION}-meta.xml`)); */
   return betaDeployRetrieve && supportedType;
 }
 

--- a/packages/salesforcedx-vscode-core/src/commands/util/libraryCommandlet.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/libraryCommandlet.ts
@@ -67,7 +67,7 @@ export abstract class LibraryCommandletExecutor<T>
         }
       );
 
-      channelService.appendLine('Library result =>' + JSON.stringify(result));
+      channelService.appendLine(outputRetrieveTable(result));
       channelService.showCommandWithTimestamp(`Finished ${commandName}`);
       await notificationService.showSuccessfulExecution(commandName);
       return result;

--- a/packages/salesforcedx-vscode-core/src/commands/util/libraryCommandlet.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/libraryCommandlet.ts
@@ -7,11 +7,11 @@
 
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import {
+  ApiResult,
   DeployResult,
   DeployStatusEnum,
   SourceClient
 } from '@salesforce/source-deploy-retrieve';
-import { ApiResult } from '@salesforce/source-deploy-retrieve/lib/client/client';
 import { languages, ProgressLocation, window } from 'vscode';
 import { channelService } from '../../channels';
 import { handleLibraryDiagnostics } from '../../diagnostics/diagnostics';

--- a/packages/salesforcedx-vscode-core/src/commands/util/libraryCommandlet.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/libraryCommandlet.ts
@@ -20,8 +20,8 @@ import { notificationService } from '../../notifications';
 import { TelemetryData, telemetryService } from '../../telemetry';
 import { OrgAuthInfo } from '../../util';
 import { LibraryDeployResultParser } from './libraryDeployResultParser';
-import { CommandletExecutor } from './sfdxCommandlet';
 import { outputRetrieveTable } from './retrieveParser';
+import { CommandletExecutor } from './sfdxCommandlet';
 
 export abstract class LibraryCommandletExecutor<T>
   implements CommandletExecutor<T> {

--- a/packages/salesforcedx-vscode-core/src/commands/util/libraryCommandlet.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/libraryCommandlet.ts
@@ -21,6 +21,7 @@ import { TelemetryData, telemetryService } from '../../telemetry';
 import { OrgAuthInfo } from '../../util';
 import { LibraryDeployResultParser } from './libraryDeployResultParser';
 import { CommandletExecutor } from './sfdxCommandlet';
+import { outputRetrieveTable } from './retrieveParser';
 
 export abstract class LibraryCommandletExecutor<T>
   implements CommandletExecutor<T> {

--- a/packages/salesforcedx-vscode-core/src/commands/util/retrieveParser.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/retrieveParser.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  Row,
+  Table
+} from '@salesforce/salesforcedx-utils-vscode/out/src/output';
+import { ApiResult } from '@salesforce/source-deploy-retrieve';
+import { nls } from '../../messages';
+import { telemetryService } from '../../telemetry';
+
+export function outputRetrieveTable(retrieveResult: ApiResult) {
+  if (retrieveResult.components.length === 0) {
+    return retrieveResult.message
+      ? retrieveResult.message
+      : nls.localize(
+          'lib_retrieve_result_parse_error',
+          JSON.stringify(retrieveResult)
+        );
+  }
+
+  let outputResult: string;
+  const table = new Table();
+  const title = nls.localize('lib_retrieve_result_title');
+  const resultRows = [] as Row[];
+  try {
+    retrieveResult.components.forEach(item => {
+      // rows for source files
+      item.sources.forEach(sourceItem => {
+        resultRows.push({
+          fullName: item.fullName,
+          type: item.type.name,
+          filePath: sourceItem
+        });
+      });
+      // row for xml
+      resultRows.push({
+        fullName: item.fullName,
+        type: item.type.name,
+        filePath: item.xml
+      });
+    });
+
+    outputResult = table.createTable(
+      resultRows,
+      [
+        { key: 'fullName', label: nls.localize('table_header_full_name') },
+        { key: 'type', label: nls.localize('table_header_type') },
+        {
+          key: 'filePath',
+          label: nls.localize('table_header_project_path')
+        }
+      ],
+      title
+    );
+  } catch (e) {
+    telemetryService.sendException(
+      'force_source_retrieve_with_sourcepath_beta_result_format',
+      e.message
+    );
+    outputResult = nls.localize(
+      'lib_retrieve_result_parse_error',
+      JSON.stringify(retrieveResult)
+    );
+  }
+  return outputResult;
+}

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -517,5 +517,8 @@ export const messages = {
   beta_tapi_mdcontainer_error: 'Unexpected error creating metadata container',
   beta_tapi_membertype_error: 'Unexpected error creating %s member',
   beta_tapi_car_error: 'Unexpected error creating container async request',
-  beta_tapi_queue_status: 'The deploy is still in the Queue'
+  beta_tapi_queue_status: 'The deploy is still in the Queue',
+  lib_retrieve_result_title: 'Retrieved Source',
+  lib_retrieve_result_parse_error:
+    'Not able to parse current results. Raw result: %s'
 };

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveSourcePath.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveSourcePath.test.ts
@@ -10,6 +10,7 @@ import {
   ContinueResponse
 } from '@salesforce/salesforcedx-utils-vscode/out/src/types/index';
 import { expect } from 'chai';
+import * as fs from 'fs';
 import * as path from 'path';
 import { createSandbox, SinonSandbox, SinonStub, stub } from 'sinon';
 import { Uri } from 'vscode';
@@ -120,6 +121,11 @@ describe('Force Source Retrieve with Sourcepath Beta', () => {
 
   beforeEach(() => {
     sandboxStub = createSandbox();
+    sandboxStub.stub(fs, 'statSync').returns({
+      isDirectory() {
+        return false;
+      }
+    } as fs.Stats);
   });
 
   afterEach(() => {
@@ -203,6 +209,42 @@ describe('Force Source Retrieve with Sourcepath Beta', () => {
       .stub(SfdxCoreSettings.prototype, 'getBetaDeployRetrieve')
       .returns(false);
     const uriOne = Uri.parse('file:///bar.component');
+    const cmpProcessing = useBetaRetrieve(uriOne);
+    expect(cmpProcessing).to.equal(false);
+  });
+
+  it('Should return true for Aura Component URI when beta configuration is enabled', () => {
+    sandboxStub
+      .stub(SfdxCoreSettings.prototype, 'getBetaDeployRetrieve')
+      .returns(true);
+    const uriOne = Uri.parse('file:///project/aura/myCmp/bar.cmp');
+    const cmpProcessing = useBetaRetrieve(uriOne);
+    expect(cmpProcessing).to.equal(true);
+  });
+
+  it('Should return false for Aura Component URI when beta configuration is disabled', () => {
+    sandboxStub
+      .stub(SfdxCoreSettings.prototype, 'getBetaDeployRetrieve')
+      .returns(false);
+    const uriOne = Uri.parse('file:///project/aura/myCmp/bar.cmp');
+    const cmpProcessing = useBetaRetrieve(uriOne);
+    expect(cmpProcessing).to.equal(false);
+  });
+
+  it('Should return true for LWC Component URI when beta configuration is enabled', () => {
+    sandboxStub
+      .stub(SfdxCoreSettings.prototype, 'getBetaDeployRetrieve')
+      .returns(true);
+    const uriOne = Uri.parse('file:///project/lwc/myCmp/bar.js');
+    const cmpProcessing = useBetaRetrieve(uriOne);
+    expect(cmpProcessing).to.equal(true);
+  });
+
+  it('Should return false for LWC Component URI when beta configuration is disabled', () => {
+    sandboxStub
+      .stub(SfdxCoreSettings.prototype, 'getBetaDeployRetrieve')
+      .returns(false);
+    const uriOne = Uri.parse('file:///project/lwc/myCmp/bar.js');
     const cmpProcessing = useBetaRetrieve(uriOne);
     expect(cmpProcessing).to.equal(false);
   });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveSourcePath.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveSourcePath.test.ts
@@ -128,8 +128,61 @@ describe('Force Source Retrieve with Sourcepath Beta', () => {
       suffix: 'cls'
     },
     fullName: 'myTestClass',
-    xml: path.join('file', 'path', 'myTestClass.cls-meta.xml'),
-    sources: [path.join('file', 'path', 'myTestClass.cls')]
+    xml: path.join('file', 'path', 'classes', 'myTestClass.cls-meta.xml'),
+    sources: [path.join('file', 'path', 'classes', 'myTestClass.cls')]
+  };
+  const apexTriggerMDComponent: MetadataComponent = {
+    type: {
+      name: 'ApexTrigger',
+      directoryName: 'triggers',
+      inFolder: false,
+      suffix: 'trigger'
+    },
+    fullName: 'accTrigger',
+    xml: path.join('file', 'path', 'triggers', 'accTrigger.trigger-meta.xml'),
+    sources: [path.join('file', 'path', 'triggers', 'accTrigger.trigger')]
+  };
+  const pageMDComponent: MetadataComponent = {
+    type: {
+      name: 'ApexPage',
+      directoryName: 'pages',
+      inFolder: false,
+      suffix: 'page'
+    },
+    fullName: 'myPage',
+    xml: path.join('file', 'path', 'pages', 'myPage.page-meta.xml'),
+    sources: [path.join('file', 'path', 'pages', 'myPage.page')]
+  };
+  const vfComponentMDComponent: MetadataComponent = {
+    type: {
+      name: 'ApexComponent',
+      directoryName: 'components',
+      inFolder: false,
+      suffix: 'component'
+    },
+    fullName: 'myPage',
+    xml: path.join('file', 'path', 'components', 'VFCmp.component-meta.xml'),
+    sources: [path.join('file', 'path', 'components', 'VFCmp.component')]
+  };
+  const auraMDComponent: MetadataComponent = {
+    type: {
+      name: 'AuraDefinitionBundle',
+      directoryName: 'aura',
+      inFolder: false
+    },
+    fullName: 'testApp',
+    xml: path.join('file', 'path', 'aura', 'testApp.app-meta.xml'),
+    sources: [path.join('file', 'path', 'aura', 'testApp.app')]
+  };
+  const lwcMDComponent: MetadataComponent = {
+    type: {
+      name: 'LightningComponentBundle',
+      directoryName: 'lwc',
+      inFolder: false
+    },
+    fullName: 'testCmp',
+    xml: path.join('file', 'path', 'lwc', 'testCmp', 'testCmp.js-meta.xml'),
+    sources: [path.join('file', 'path', 'lwc', 'testCmp', 'testCmp.js')]
   };
 
   beforeEach(() => {
@@ -148,7 +201,18 @@ describe('Force Source Retrieve with Sourcepath Beta', () => {
     sandboxStub
       .stub(SfdxCoreSettings.prototype, 'getBetaDeployRetrieve')
       .returns(true);
-    mockRegistry.returns([]);
+    mockRegistry.returns([
+      {
+        type: {
+          name: 'Layout',
+          directoryName: 'layouts',
+          inFolder: false
+        },
+        fullName: 'Obj Layout',
+        xml: path.join('file', 'path', 'layouts', 'Obj Layout.layout-meta.xml'),
+        sources: [path.join('file', 'path', 'layouts', 'Obj Layout.layout')]
+      }
+    ]);
     const uriOne = Uri.parse('file:///bar.html');
     const fileProcessing = useBetaRetrieve(uriOne);
     expect(fileProcessing).to.equal(false);
@@ -159,7 +223,7 @@ describe('Force Source Retrieve with Sourcepath Beta', () => {
       .stub(SfdxCoreSettings.prototype, 'getBetaDeployRetrieve')
       .returns(true);
     mockRegistry.returns([apexClassMDComponent]);
-    const uriOne = Uri.parse('file:///file/path/myTestClass.cls');
+    const uriOne = Uri.parse('file:///file/path/classes/myTestClass.cls');
     const apexClassProcessing = useBetaRetrieve(uriOne);
     expect(apexClassProcessing).to.equal(true);
   });
@@ -169,7 +233,7 @@ describe('Force Source Retrieve with Sourcepath Beta', () => {
       .stub(SfdxCoreSettings.prototype, 'getBetaDeployRetrieve')
       .returns(false);
     mockRegistry.returns([apexClassMDComponent]);
-    const uriOne = Uri.parse('file:///file/path/myTestClass.cls');
+    const uriOne = Uri.parse('file:///file/path/classes/myTestClass.cls');
     const apexClassProcessing = useBetaRetrieve(uriOne);
     expect(apexClassProcessing).to.equal(false);
   });
@@ -178,7 +242,8 @@ describe('Force Source Retrieve with Sourcepath Beta', () => {
     sandboxStub
       .stub(SfdxCoreSettings.prototype, 'getBetaDeployRetrieve')
       .returns(true);
-    const uriOne = Uri.parse('file:///bar.trigger');
+    mockRegistry.returns([apexTriggerMDComponent]);
+    const uriOne = Uri.parse('file:///file/path/triggers/accTrigger.trigger');
     const triggerProcessing = useBetaRetrieve(uriOne);
     expect(triggerProcessing).to.equal(true);
   });
@@ -187,7 +252,8 @@ describe('Force Source Retrieve with Sourcepath Beta', () => {
     sandboxStub
       .stub(SfdxCoreSettings.prototype, 'getBetaDeployRetrieve')
       .returns(false);
-    const uriOne = Uri.parse('file:///bar.trigger');
+    mockRegistry.returns([apexTriggerMDComponent]);
+    const uriOne = Uri.parse('file:///file/path/triggers/accTrigger.trigger');
     const triggerProcessing = useBetaRetrieve(uriOne);
     expect(triggerProcessing).to.equal(false);
   });
@@ -196,7 +262,8 @@ describe('Force Source Retrieve with Sourcepath Beta', () => {
     sandboxStub
       .stub(SfdxCoreSettings.prototype, 'getBetaDeployRetrieve')
       .returns(true);
-    const uriOne = Uri.parse('file:///bar.page');
+    mockRegistry.returns([pageMDComponent]);
+    const uriOne = Uri.parse('file:///file/path/pages/myPage.page');
     const pageProcessing = useBetaRetrieve(uriOne);
     expect(pageProcessing).to.equal(true);
   });
@@ -205,7 +272,8 @@ describe('Force Source Retrieve with Sourcepath Beta', () => {
     sandboxStub
       .stub(SfdxCoreSettings.prototype, 'getBetaDeployRetrieve')
       .returns(false);
-    const uriOne = Uri.parse('file:///bar.page');
+    mockRegistry.returns([pageMDComponent]);
+    const uriOne = Uri.parse('file:///file/path/pages/myPage.page');
     const pageProcessing = useBetaRetrieve(uriOne);
     expect(pageProcessing).to.equal(false);
   });
@@ -214,7 +282,8 @@ describe('Force Source Retrieve with Sourcepath Beta', () => {
     sandboxStub
       .stub(SfdxCoreSettings.prototype, 'getBetaDeployRetrieve')
       .returns(true);
-    const uriOne = Uri.parse('file:///bar.component');
+    mockRegistry.returns([vfComponentMDComponent]);
+    const uriOne = Uri.parse('file:///file/path/components/VFCmp.component');
     const cmpProcessing = useBetaRetrieve(uriOne);
     expect(cmpProcessing).to.equal(true);
   });
@@ -223,7 +292,8 @@ describe('Force Source Retrieve with Sourcepath Beta', () => {
     sandboxStub
       .stub(SfdxCoreSettings.prototype, 'getBetaDeployRetrieve')
       .returns(false);
-    const uriOne = Uri.parse('file:///bar.component');
+    mockRegistry.returns([vfComponentMDComponent]);
+    const uriOne = Uri.parse('file:///file/path/components/VFCmp.component');
     const cmpProcessing = useBetaRetrieve(uriOne);
     expect(cmpProcessing).to.equal(false);
   });
@@ -232,7 +302,8 @@ describe('Force Source Retrieve with Sourcepath Beta', () => {
     sandboxStub
       .stub(SfdxCoreSettings.prototype, 'getBetaDeployRetrieve')
       .returns(true);
-    const uriOne = Uri.parse('file:///project/aura/myCmp/bar.cmp');
+    mockRegistry.returns([auraMDComponent]);
+    const uriOne = Uri.parse('file:///file/path/aura/testApp.app');
     const cmpProcessing = useBetaRetrieve(uriOne);
     expect(cmpProcessing).to.equal(true);
   });
@@ -241,7 +312,8 @@ describe('Force Source Retrieve with Sourcepath Beta', () => {
     sandboxStub
       .stub(SfdxCoreSettings.prototype, 'getBetaDeployRetrieve')
       .returns(false);
-    const uriOne = Uri.parse('file:///project/aura/myCmp/bar.cmp');
+    mockRegistry.returns([auraMDComponent]);
+    const uriOne = Uri.parse('file:///file/path/aura/testApp.app');
     const cmpProcessing = useBetaRetrieve(uriOne);
     expect(cmpProcessing).to.equal(false);
   });
@@ -250,7 +322,8 @@ describe('Force Source Retrieve with Sourcepath Beta', () => {
     sandboxStub
       .stub(SfdxCoreSettings.prototype, 'getBetaDeployRetrieve')
       .returns(true);
-    const uriOne = Uri.parse('file:///project/lwc/myCmp/bar.js');
+    mockRegistry.returns([lwcMDComponent]);
+    const uriOne = Uri.parse('file:///file/path/lwc/testCmp/testCmp.js');
     const cmpProcessing = useBetaRetrieve(uriOne);
     expect(cmpProcessing).to.equal(true);
   });
@@ -259,7 +332,8 @@ describe('Force Source Retrieve with Sourcepath Beta', () => {
     sandboxStub
       .stub(SfdxCoreSettings.prototype, 'getBetaDeployRetrieve')
       .returns(false);
-    const uriOne = Uri.parse('file:///project/lwc/myCmp/bar.js');
+    mockRegistry.returns([lwcMDComponent]);
+    const uriOne = Uri.parse('file:///file/path/lwc/testCmp/testCmp.js');
     const cmpProcessing = useBetaRetrieve(uriOne);
     expect(cmpProcessing).to.equal(false);
   });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/retrieveParser.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/retrieveParser.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { ApiResult } from '@salesforce/source-deploy-retrieve';
+import { expect } from 'chai';
+import { outputRetrieveTable } from '../../../../src/commands/util/retrieveParser';
+import { nls } from '../../../../src/messages';
+
+describe('retrieveParser', () => {
+  it('Should handle an ApiResult with no components and no message', () => {
+    const emptyResult = {
+      success: true,
+      components: []
+    } as ApiResult;
+
+    const parsedResult = outputRetrieveTable(emptyResult);
+    expect(parsedResult).to.equal(
+      nls.localize(
+        'lib_retrieve_result_parse_error',
+        JSON.stringify({ success: true, components: [] })
+      )
+    );
+  });
+
+  it('Should handle an ApiResult with no components but with message', () => {
+    const emptyResult = {
+      success: true,
+      components: [],
+      message: 'Message from library'
+    } as ApiResult;
+
+    const parsedResult = outputRetrieveTable(emptyResult);
+    expect(parsedResult).to.equal('Message from library');
+  });
+
+  it('Should handle an fully formed ApiResult', () => {
+    const successfulResult = {
+      success: true,
+      components: [
+        {
+          fullName: 'MyTestClass',
+          xml: 'some/path/MyTestClass.cls-meta.xml',
+          type: {
+            name: 'ApexClass',
+            directoryName: 'classes',
+            inFolder: false
+          },
+          sources: ['some/path/MyTestClass.cls']
+        }
+      ],
+      message: 'Message from library'
+    } as ApiResult;
+
+    const parsedResult = outputRetrieveTable(successfulResult);
+
+    let expectedResult = '=== Retrieved Source\n';
+    expectedResult +=
+      'FULL NAME    TYPE       PROJECT PATH                      \n';
+    expectedResult +=
+      '───────────  ─────────  ──────────────────────────────────\n';
+    expectedResult +=
+      'MyTestClass  ApexClass  some/path/MyTestClass.cls         \n';
+    expectedResult +=
+      'MyTestClass  ApexClass  some/path/MyTestClass.cls-meta.xml\n';
+
+    expect(parsedResult).to.equal(expectedResult);
+  });
+
+  it('Should handle a malformed ApiResult', () => {
+    const apiResultWithOutType = {
+      success: true,
+      components: [
+        {
+          fullName: 'MyTestClass',
+          xml: 'some/path/MyTestClass.cls-meta.xml',
+          sources: ['some/path/MyTestClass.cls']
+        }
+      ],
+      message: 'Message from library'
+    } as ApiResult;
+
+    const parsedResult = outputRetrieveTable(apiResultWithOutType);
+
+    expect(parsedResult).to.equal(
+      nls.localize(
+        'lib_retrieve_result_parse_error',
+        JSON.stringify(apiResultWithOutType)
+      )
+    );
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Here's an early version of how consuming the new retrieve library endpoint will look like. These changes include a new small wrapper that will handle calling channelservice, notificationservice, showing the progress of the execution, etc.

### What issues does this PR fix or reference?
@W-7500391@

### Functionality Before/After
![retrieve_beta](https://user-images.githubusercontent.com/1041842/77712636-9a6d0b00-6f91-11ea-8bbf-fd797f19527f.gif)
