### PR TITLE
Changes to Launch Config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -153,6 +153,29 @@
       "internalConsoleOptions": "openOnSessionStart"
     },
     {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Tests - Lightning - Unit Tests",
+      "program": "${workspaceFolder}/packages/salesforcedx-vscode-lightning/node_modules/mocha/bin/_mocha",
+      "args": [
+        "--timeout",
+        "999999",
+        "--colors",
+        "--recursive",
+        "${workspaceFolder}/packages/salesforcedx-vscode-lightning/out/test/unit"
+      ],
+      "sourceMaps": true,
+      "smartStep": true,
+      "outFiles": ["${workspaceFolder}/packages/*/out/**/*.js"],
+      "sourceMapPathOverrides": {
+        "../../../test/unit/": "${workspaceFolder}/packages/salesforcedx-vscode-lightning/out/test/unit/*",
+        "webpack:///salesforcedx-utils-vscode/./*": "${workspaceFolder}/packages/salesforcedx-utils-vscode/*",
+        "webpack:///*": "*"
+      },
+      "preLaunchTask": "Compile",
+      "internalConsoleOptions": "openOnSessionStart"
+    },
+    {
       "name": "Launch Tests - Lightning - VSCode Integration Tests",
       "type": "extensionHost",
       "request": "launch",
@@ -169,6 +192,29 @@
       "sourceMapPathOverrides": {
         "../../../test/vscode-integration": "${workspaceFolder}/packages/salesforcedx-vscode-lightning/out/test/vscode-integration/*",
         "../../../../test/vscode-integration": "${workspaceFolder}/packages/salesforcedx-vscode-lightning/out/test/vscode-integration/*",
+        "webpack:///salesforcedx-utils-vscode/./*": "${workspaceFolder}/packages/salesforcedx-utils-vscode/*",
+        "webpack:///*": "*"
+      },
+      "preLaunchTask": "Compile",
+      "internalConsoleOptions": "openOnSessionStart"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Tests - LWC - Unit Tests",
+      "program": "${workspaceFolder}/packages/salesforcedx-vscode-lwc/node_modules/mocha/bin/_mocha",
+      "args": [
+        "--timeout",
+        "999999",
+        "--colors",
+        "--recursive",
+        "${workspaceFolder}/packages/salesforcedx-vscode-lwc/out/test/unit"
+      ],
+      "sourceMaps": true,
+      "smartStep": true,
+      "outFiles": ["${workspaceFolder}/packages/*/out/**/*.js"],
+      "sourceMapPathOverrides": {
+        "../../../test/unit/": "${workspaceFolder}/packages/salesforcedx-vscode-lwc/out/test/unit/*",
         "webpack:///salesforcedx-utils-vscode/./*": "${workspaceFolder}/packages/salesforcedx-utils-vscode/*",
         "webpack:///*": "*"
       },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,9 +8,7 @@
       "name": "Attach to Process (Legacy Protocol)",
       "port": 5858,
       "sourceMaps": true,
-      "outFiles": [
-        "${workspaceFolder}/packages/*/out/**/*.js"
-      ]
+      "outFiles": ["${workspaceFolder}/packages/*/out/**/*.js"]
     },
     {
       "type": "node",
@@ -19,24 +17,18 @@
       "name": "Attach to Process (Inspector Protocol)",
       "port": 9229,
       "sourceMaps": true,
-      "outFiles": [
-        "${workspaceFolder}/packages/*/out/**/*.js"
-      ]
+      "outFiles": ["${workspaceFolder}/packages/*/out/**/*.js"]
     },
     {
       "name": "Launch Extensions",
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
-      "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}/packages"
-      ],
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}/packages"],
       "stopOnEntry": false,
       "sourceMaps": true,
       "smartStep": true,
-      "outFiles": [
-        "${workspaceFolder}/packages/*/out/src/**/*.js"
-      ],
+      "outFiles": ["${workspaceFolder}/packages/*/out/src/**/*.js"],
       "sourceMapPathOverrides": {
         "webpack:///salesforcedx-utils-vscode/./*": "${workspaceFolder}/packages/salesforcedx-utils-vscode/*",
         "webpack:///salesforcedx-sobjects-faux-generator/./*": "${workspaceFolder}/packages/salesforcedx-sobjects-faux-generator/*",
@@ -49,15 +41,11 @@
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
-      "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}/packages"
-      ],
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}/packages"],
       "stopOnEntry": false,
       "sourceMaps": true,
       "smartStep": true,
-      "outFiles": [
-        "${workspaceFolder}/packages/*/out/src/**/*.js"
-      ],
+      "outFiles": ["${workspaceFolder}/packages/*/out/src/**/*.js"],
       "sourceMapPathOverrides": {
         "webpack:///salesforcedx-utils-vscode/./*": "${workspaceFolder}/packages/salesforcedx-utils-vscode/*",
         "webpack:///*": "*"
@@ -69,14 +57,10 @@
       "request": "launch",
       "cwd": "${workspaceFolder}",
       "program": "${workspaceFolder}/packages/salesforcedx-apex-debugger/out/src/adapter/apexDebug.js",
-      "args": [
-        "--server=4711"
-      ],
+      "args": ["--server=4711"],
       "sourceMaps": true,
       "smartStep": true,
-      "outFiles": [
-        "${workspaceFolder}/packages/*/out/src/**/*.js"
-      ],
+      "outFiles": ["${workspaceFolder}/packages/*/out/src/**/*.js"],
       "sourceMapPathOverrides": {
         "webpack:///salesforcedx-utils-vscode/./*": "${workspaceFolder}/packages/salesforcedx-utils-vscode/*",
         "webpack:///*": "*"
@@ -99,9 +83,7 @@
       ],
       "sourceMaps": true,
       "smartStep": true,
-      "outFiles": [
-        "${workspaceFolder}/packages/*/out/**/*.js"
-      ],
+      "outFiles": ["${workspaceFolder}/packages/*/out/**/*.js"],
       "sourceMapPathOverrides": {
         "webpack:///salesforcedx-utils-vscode/./*": "${workspaceFolder}/packages/salesforcedx-utils-vscode/*",
         "webpack:///*": "*"
@@ -122,9 +104,7 @@
       "stopOnEntry": false,
       "sourceMaps": true,
       "smartStep": true,
-      "outFiles": [
-        "${workspaceFolder}/packages/*/out/**/*.js"
-      ],
+      "outFiles": ["${workspaceFolder}/packages/*/out/**/*.js"],
       "sourceMapPathOverrides": {
         "../../../../test/vscode-integration": "${workspaceFolder}/packages/salesforcedx-vscode-core/out/test/vscode-integration/*",
         "webpack:///salesforcedx-utils-vscode/./*": "${workspaceFolder}/packages/salesforcedx-utils-vscode/*",
@@ -146,9 +126,7 @@
       "stopOnEntry": false,
       "sourceMaps": true,
       "smartStep": true,
-      "outFiles": [
-        "${workspaceFolder}/packages/*/out/**/*.js"
-      ],
+      "outFiles": ["${workspaceFolder}/packages/*/out/**/*.js"],
       "sourceMapPathOverrides": {
         "../../../test/vscode-integration": "${workspaceFolder}/packages/salesforcedx-vscode-apex/out/test/vscode-integration/*",
         "../../../../test/vscode-integration": "${workspaceFolder}/packages/salesforcedx-vscode-apex/out/test/vscode-integration/*",
@@ -156,54 +134,6 @@
         "webpack:///*": "*"
       },
       "preLaunchTask": "Compile",
-      "internalConsoleOptions": "openOnSessionStart"
-    },
-    {
-      "name": "Launch Lightning Tests",
-      "type": "extensionHost",
-      "request": "launch",
-      "runtimeExecutable": "${execPath}",
-      "args": [
-        "${workspaceFolder}/packages/system-tests/assets/sfdx-simple",
-        "--extensionDevelopmentPath=${workspaceFolder}/packages",
-        "--extensionTestsPath=${workspaceFolder}/packages/salesforcedx-vscode-lightning/out/test/vscode-integration"
-      ],
-      "stopOnEntry": false,
-      "sourceMaps": true,
-      "smartStep": true,
-      "outFiles": [
-        "${workspaceFolder}/packages/*/out/**/*.js"
-      ],
-      "sourceMapPathOverrides": {
-        "../../../test/vscode-integration": "${workspaceFolder}/packages/salesforcedx-vscode-lightning/out/test/vscode-integration/*",
-        "../../../../test/vscode-integration": "${workspaceFolder}/packages/salesforcedx-vscode-lightning/out/test/vscode-integration/*",
-        "webpack:///salesforcedx-utils-vscode/./*": "${workspaceFolder}/packages/salesforcedx-utils-vscode/*",
-        "webpack:///*": "*"
-      },
-      "internalConsoleOptions": "openOnSessionStart"
-    },
-    {
-      "name": "Launch LWC Tests",
-      "type": "extensionHost",
-      "request": "launch",
-      "runtimeExecutable": "${execPath}",
-      "args": [
-        "${workspaceFolder}/packages/system-tests/assets/lwc-recipes",
-        "--extensionDevelopmentPath=${workspaceFolder}/packages",
-        "--extensionTestsPath=${workspaceFolder}/packages/salesforcedx-vscode-lwc/out/test/vscode-integration"
-      ],
-      "stopOnEntry": false,
-      "sourceMaps": true,
-      "smartStep": true,
-      "outFiles": [
-        "${workspaceFolder}/packages/*/out/**/*.js"
-      ],
-      "sourceMapPathOverrides": {
-        "../../../test/vscode-integration": "${workspaceFolder}/packages/salesforcedx-vscode-lwc/out/test/vscode-integration/*",
-        "../../../../test/vscode-integration": "${workspaceFolder}/packages/salesforcedx-vscode-lwc/out/test/vscode-integration/*",
-        "webpack:///salesforcedx-utils-vscode/./*": "${workspaceFolder}/packages/salesforcedx-utils-vscode/*",
-        "webpack:///*": "*"
-      },
       "internalConsoleOptions": "openOnSessionStart"
     },
     {
@@ -219,9 +149,7 @@
       "stopOnEntry": false,
       "sourceMaps": true,
       "smartStep": true,
-      "outFiles": [
-        "${workspaceFolder}/packages/*/out/**/*.js"
-      ],
+      "outFiles": ["${workspaceFolder}/packages/*/out/**/*.js"],
       "sourceMapPathOverrides": {
         "../../../test/vscode-integration": "${workspaceFolder}/packages/salesforcedx-vscode-lightning/out/test/vscode-integration/*",
         "../../../../test/vscode-integration": "${workspaceFolder}/packages/salesforcedx-vscode-lightning/out/test/vscode-integration/*",
@@ -244,9 +172,7 @@
       "stopOnEntry": false,
       "sourceMaps": true,
       "smartStep": true,
-      "outFiles": [
-        "${workspaceFolder}/packages/*/out/**/*.js"
-      ],
+      "outFiles": ["${workspaceFolder}/packages/*/out/**/*.js"],
       "sourceMapPathOverrides": {
         "../../../test/vscode-integration": "${workspaceFolder}/packages/salesforcedx-vscode-lwc/out/test/vscode-integration/*",
         "../../../../test/vscode-integration": "${workspaceFolder}/packages/salesforcedx-vscode-lwc/out/test/vscode-integration/*",
@@ -268,9 +194,7 @@
       "stopOnEntry": false,
       "sourceMaps": true,
       "smartStep": true,
-      "outFiles": [
-        "${workspaceFolder}/packages/*/out/**/*.js"
-      ],
+      "outFiles": ["${workspaceFolder}/packages/*/out/**/*.js"],
       "sourceMapPathOverrides": {
         "../../../test/vscode-integration": "${workspaceFolder}/packages/salesforcedx-vscode-visualforce/out/test/vscode-integration/*",
         "../../../../test/vscode-integration": "${workspaceFolder}/packages/salesforcedx-vscode-visualforce/out/test/vscode-integration/*",
@@ -294,9 +218,7 @@
       ],
       "sourceMaps": true,
       "smartStep": true,
-      "outFiles": [
-        "${workspaceFolder}/packages/*/out/**/*.js"
-      ],
+      "outFiles": ["${workspaceFolder}/packages/*/out/**/*.js"],
       "sourceMapPathOverrides": {
         "../../../test/unit/": "${workspaceFolder}/packages/salesforcedx-visualforce-language-server/out/test/unit/*",
         "webpack:///salesforcedx-utils-vscode/./*": "${workspaceFolder}/packages/salesforcedx-utils-vscode/*",
@@ -319,9 +241,7 @@
       ],
       "sourceMaps": true,
       "smartStep": true,
-      "outFiles": [
-        "${workspaceFolder}/packages/*/out/**/*.js"
-      ],
+      "outFiles": ["${workspaceFolder}/packages/*/out/**/*.js"],
       "sourceMapPathOverrides": {
         "../../../test/unit/": "${workspaceFolder}/packages/salesforcedx-visualforce-markup-language-server/out/test/unit/*",
         "webpack:///salesforcedx-utils-vscode/./*": "${workspaceFolder}/packages/salesforcedx-utils-vscode/*",
@@ -357,9 +277,7 @@
       },
       "preLaunchTask": "Compile",
       "internalConsoleOptions": "openOnSessionStart",
-      "skipFiles": [
-        "<node_internals>/**"
-      ] // https://github.com/nodejs/node/issues/15464#issuecomment-332723120
+      "skipFiles": ["<node_internals>/**"] // https://github.com/nodejs/node/issues/15464#issuecomment-332723120
     },
     {
       "name": "Launch Apex Debugger Adapter Integration Tests",
@@ -388,9 +306,7 @@
       },
       "preLaunchTask": "Compile",
       "internalConsoleOptions": "openOnSessionStart",
-      "skipFiles": [
-        "<node_internals>/**"
-      ] // https://github.com/nodejs/node/issues/15464#issuecomment-332723120
+      "skipFiles": ["<node_internals>/**"] // https://github.com/nodejs/node/issues/15464#issuecomment-332723120
     },
     {
       "name": "Launch Apex Debugger Extension VSCode-Integration Tests",
@@ -404,9 +320,7 @@
       "stopOnEntry": false,
       "sourceMaps": true,
       "smartStep": true,
-      "outFiles": [
-        "${workspaceFolder}/packages/*/out/**/*.js"
-      ],
+      "outFiles": ["${workspaceFolder}/packages/*/out/**/*.js"],
       "sourceMapPathOverrides": {
         "../../../test/vscode-integration/": "${workspaceFolder}/packages/salesforcedx-vscode-apex-debugger/out/test/vscode-integration/*",
         "../../../../test/vscode-integration/": "${workspaceFolder}/packages/salesforcedx-vscode-apex-debugger/out/test/vscode-integration/*",
@@ -433,9 +347,7 @@
       ],
       "sourceMaps": true,
       "smartStep": true,
-      "outFiles": [
-        "${workspaceFolder}/packages/*/out/**/*.js"
-      ],
+      "outFiles": ["${workspaceFolder}/packages/*/out/**/*.js"],
       "sourceMapPathOverrides": {
         "webpack:///salesforcedx-sobjects-faux-generator/../salesforcedx-utils-vscode/*": "${workspaceFolder}/packages/salesforcedx-utils-vscode/*",
         "webpack:///salesforcedx-sobjects-faux-generator/./*": "${workspaceFolder}/packages/salesforcedx-sobjects-faux-generator/*",
@@ -461,9 +373,7 @@
       ],
       "sourceMaps": true,
       "smartStep": true,
-      "outFiles": [
-        "${workspaceFolder}/packages/*/out/**/*.js"
-      ],
+      "outFiles": ["${workspaceFolder}/packages/*/out/**/*.js"],
       "sourceMapPathOverrides": {
         "webpack:///salesforcedx-sobjects-faux-generator/../salesforcedx-utils-vscode/*": "${workspaceFolder}/packages/salesforcedx-utils-vscode/*",
         "webpack:///salesforcedx-sobjects-faux-generator/./*": "${workspaceFolder}/packages/salesforcedx-sobjects-faux-generator/*",
@@ -478,14 +388,10 @@
       "request": "launch",
       "cwd": "${workspaceFolder}",
       "program": "${workspaceFolder}/packages/salesforcedx-apex-replay-debugger/out/src/adapter/apexReplayDebug.js",
-      "args": [
-        "--server=4712"
-      ],
+      "args": ["--server=4712"],
       "sourceMaps": true,
       "smartStep": true,
-      "outFiles": [
-        "${workspaceFolder}/packages/*/out/src/**/*.js"
-      ],
+      "outFiles": ["${workspaceFolder}/packages/*/out/src/**/*.js"],
       "sourceMapPathOverrides": {
         "webpack:///salesforcedx-utils-vscode/./*": "${workspaceFolder}/packages/salesforcedx-utils-vscode/*",
         "webpack:///*": "*"
@@ -519,9 +425,7 @@
       },
       "preLaunchTask": "Compile",
       "internalConsoleOptions": "openOnSessionStart",
-      "skipFiles": [
-        "<node_internals>/**"
-      ] // https://github.com/nodejs/node/issues/15464#issuecomment-332723120
+      "skipFiles": ["<node_internals>/**"] // https://github.com/nodejs/node/issues/15464#issuecomment-332723120
     },
     {
       "name": "Launch Replay Debugger Adapter Integration Tests",
@@ -550,9 +454,7 @@
       },
       "preLaunchTask": "Compile",
       "internalConsoleOptions": "openOnSessionStart",
-      "skipFiles": [
-        "<node_internals>/**"
-      ] // https://github.com/nodejs/node/issues/15464#issuecomment-332723120
+      "skipFiles": ["<node_internals>/**"] // https://github.com/nodejs/node/issues/15464#issuecomment-332723120
     },
     {
       "name": "Launch Replay Debugger Extension VSCode-Integration Tests",
@@ -566,9 +468,7 @@
       "stopOnEntry": false,
       "sourceMaps": true,
       "smartStep": true,
-      "outFiles": [
-        "${workspaceFolder}/packages/*/out/**/*.js"
-      ],
+      "outFiles": ["${workspaceFolder}/packages/*/out/**/*.js"],
       "sourceMapPathOverrides": {
         "../../../test/vscode-integration/": "${workspaceFolder}packages/salesforcedx-vscode-apex-replay-debugger/out/test/vscode-integration/*",
         "../../../../test/vscode-integration/": "${workspaceFolder}packages/salesforcedx-vscode-apex-replay-debugger/out/test/vscode-integration/*",
@@ -582,17 +482,11 @@
   "compounds": [
     {
       "name": "Launch Extensions + Apex Debug adapter",
-      "configurations": [
-        "Launch Extensions",
-        "Launch Apex Debug adapter"
-      ]
+      "configurations": ["Launch Extensions", "Launch Apex Debug adapter"]
     },
     {
       "name": "Launch Extensions + Replay Debugger adapter",
-      "configurations": [
-        "Launch Extensions",
-        "Launch Replay Debugger adapter"
-      ]
+      "configurations": ["Launch Extensions", "Launch Replay Debugger adapter"]
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -68,9 +68,25 @@
       "preLaunchTask": "Compile"
     },
     {
+      "name": "Launch Replay Debugger adapter",
       "type": "node",
       "request": "launch",
-      "name": "Launch Salesforce DX Utils Unit Tests",
+      "cwd": "${workspaceFolder}",
+      "program": "${workspaceFolder}/packages/salesforcedx-apex-replay-debugger/out/src/adapter/apexReplayDebug.js",
+      "args": ["--server=4712"],
+      "sourceMaps": true,
+      "smartStep": true,
+      "outFiles": ["${workspaceFolder}/packages/*/out/src/**/*.js"],
+      "sourceMapPathOverrides": {
+        "webpack:///salesforcedx-utils-vscode/./*": "${workspaceFolder}/packages/salesforcedx-utils-vscode/*",
+        "webpack:///*": "*"
+      },
+      "preLaunchTask": "Compile"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Tests - Utils - Unit Tests",
       "program": "${workspaceFolder}/packages/salesforcedx-utils-vscode/node_modules/mocha/bin/_mocha",
       "args": [
         "-u",
@@ -92,7 +108,7 @@
       "internalConsoleOptions": "openOnSessionStart"
     },
     {
-      "name": "Launch Salesforce DX VS Code Core VSCode-Integration Tests",
+      "name": "Launch Tests - Core - VSCode Integration Tests",
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
@@ -114,7 +130,7 @@
       "internalConsoleOptions": "openOnSessionStart"
     },
     {
-      "name": "Launch Salesforce DX VS Code Apex VSCode-Integration Tests",
+      "name": "Launch Tests - Apex - VSCode Integration Tests",
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
@@ -137,7 +153,7 @@
       "internalConsoleOptions": "openOnSessionStart"
     },
     {
-      "name": "Launch Salesforce DX VS Code Lightning VSCode-Integration Tests",
+      "name": "Launch Tests - Lightning - VSCode Integration Tests",
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
@@ -160,7 +176,7 @@
       "internalConsoleOptions": "openOnSessionStart"
     },
     {
-      "name": "Launch Salesforce DX VS Code LWC VSCode-Integration Tests",
+      "name": "Launch Tests - LWC - VSCode Integration Tests",
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
@@ -183,7 +199,7 @@
       "internalConsoleOptions": "openOnSessionStart"
     },
     {
-      "name": "Launch Salesforce DX VS Code Visualforce VSCode-Integration Tests",
+      "name": "Launch Tests - Visualforce - VSCode Integration Tests",
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
@@ -207,7 +223,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Launch Salesforce DX Visualforce Language Server Unit Tests",
+      "name": "Launch Tests - Visualforce Language Server - Unit Tests",
       "program": "${workspaceFolder}/packages/salesforcedx-visualforce-language-server/node_modules/mocha/bin/_mocha",
       "args": [
         "--timeout",
@@ -230,7 +246,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Launch Salesforce DX Visualforce Markup Language Server Unit Tests",
+      "name": "Launch Tests - Visualforce Markup Language Server - Unit Tests",
       "program": "${workspaceFolder}/packages/salesforcedx-visualforce-markup-language-server/node_modules/mocha/bin/_mocha",
       "args": [
         "--timeout",
@@ -251,7 +267,7 @@
       "internalConsoleOptions": "openOnSessionStart"
     },
     {
-      "name": "Launch Apex Debugger Adapter Unit Tests",
+      "name": "Launch Tests - Apex Debugger - Unit Tests",
       "type": "node",
       "request": "launch",
       "cwd": "${workspaceFolder}/packages/salesforcedx-apex-debugger",
@@ -280,7 +296,7 @@
       "skipFiles": ["<node_internals>/**"] // https://github.com/nodejs/node/issues/15464#issuecomment-332723120
     },
     {
-      "name": "Launch Apex Debugger Adapter Integration Tests",
+      "name": "Launch Tests - Apex Debugger - Integration Tests",
       "type": "node",
       "request": "launch",
       "cwd": "${workspaceFolder}/packages/salesforcedx-apex-debugger",
@@ -309,7 +325,7 @@
       "skipFiles": ["<node_internals>/**"] // https://github.com/nodejs/node/issues/15464#issuecomment-332723120
     },
     {
-      "name": "Launch Apex Debugger Extension VSCode-Integration Tests",
+      "name": "Launch Tests - Apex Debugger - VSCode Integration Tests",
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
@@ -331,7 +347,7 @@
       "internalConsoleOptions": "openOnSessionStart"
     },
     {
-      "name": "Launch SObject Generator Unit Tests",
+      "name": "Launch Tests - SObject Faux Generator - Unit Tests",
       "type": "node",
       "request": "launch",
       "cwd": "${workspaceFolder}/packages/salesforcedx-sobjects-faux-generator",
@@ -357,7 +373,7 @@
       "internalConsoleOptions": "openOnSessionStart"
     },
     {
-      "name": "Launch SObject Generator Integration Tests",
+      "name": "Launch Tests - SObject Faux Generator - Integration Tests",
       "type": "node",
       "request": "launch",
       "cwd": "${workspaceFolder}/packages/salesforcedx-sobjects-faux-generator",
@@ -383,23 +399,7 @@
       "internalConsoleOptions": "openOnSessionStart"
     },
     {
-      "name": "Launch Replay Debugger adapter",
-      "type": "node",
-      "request": "launch",
-      "cwd": "${workspaceFolder}",
-      "program": "${workspaceFolder}/packages/salesforcedx-apex-replay-debugger/out/src/adapter/apexReplayDebug.js",
-      "args": ["--server=4712"],
-      "sourceMaps": true,
-      "smartStep": true,
-      "outFiles": ["${workspaceFolder}/packages/*/out/src/**/*.js"],
-      "sourceMapPathOverrides": {
-        "webpack:///salesforcedx-utils-vscode/./*": "${workspaceFolder}/packages/salesforcedx-utils-vscode/*",
-        "webpack:///*": "*"
-      },
-      "preLaunchTask": "Compile"
-    },
-    {
-      "name": "Launch Replay Debugger Adapter Unit Tests",
+      "name": "Launch Tests - Replay Debugger - Unit Tests",
       "type": "node",
       "request": "launch",
       "cwd": "${workspaceFolder}/packages/salesforcedx-apex-replay-debugger",
@@ -428,7 +428,7 @@
       "skipFiles": ["<node_internals>/**"] // https://github.com/nodejs/node/issues/15464#issuecomment-332723120
     },
     {
-      "name": "Launch Replay Debugger Adapter Integration Tests",
+      "name": "Launch Tests - Replay Debugger - Integration Tests",
       "type": "node",
       "request": "launch",
       "cwd": "${workspaceFolder}/packages/salesforcedx-apex-replay-debugger",
@@ -457,7 +457,7 @@
       "skipFiles": ["<node_internals>/**"] // https://github.com/nodejs/node/issues/15464#issuecomment-332723120
     },
     {
-      "name": "Launch Replay Debugger Extension VSCode-Integration Tests",
+      "name": "Launch Tests - Replay Debugger - VSCode Integration Tests",
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",


### PR DESCRIPTION
### What does this PR do?
1. Removes duplicate configs for Lightning and LWC Integration Tests.
2. Adds config for running Lightning and LWC Unit Tests.
3. Renamed configs for easier recognition of Test configs.
4. Reordered Replay Debugger config so all Test configs were together.

### Functionality Before
![Screen Shot 2020-04-17 at 8 26 49 AM](https://user-images.githubusercontent.com/45604118/79585675-5e5b3080-808d-11ea-8282-4a1af824286b.png)

### Functionality After
![Screen Shot 2020-04-17 at 9 25 49 AM](https://user-images.githubusercontent.com/45604118/79585749-7a5ed200-808d-11ea-8785-b1ccdeb48037.png)