### PR TITLE
Fix for serverStarted check

### DIFF
--- a/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcStart.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcStart.ts
@@ -116,13 +116,18 @@ export class ForceLightningLwcStartExecutor extends SfdxCommandletExecutor<{}> {
 
     execution.stderrSubject.subscribe(async data => {
       if (data && data.toString().includes('Server start up failed')) {
-        this.handleErrors(cancellationToken, serverHandler, 1);
+        this.handleErrors(cancellationToken, serverHandler, serverStarted, 1);
         progress.complete();
       }
     });
 
     execution.processExitSubject.subscribe(async exitCode => {
-      this.handleErrors(cancellationToken, serverHandler, exitCode);
+      this.handleErrors(
+        cancellationToken,
+        serverHandler,
+        serverStarted,
+        exitCode
+      );
     });
 
     notificationService.reportExecutionError(
@@ -141,10 +146,11 @@ export class ForceLightningLwcStartExecutor extends SfdxCommandletExecutor<{}> {
   private handleErrors(
     cancellationToken: vscode.CancellationToken,
     serverHandler: ServerHandler,
+    serverStarted: boolean,
     exitCode: number | null | undefined
   ) {
     DevServerService.instance.clearServerHandler(serverHandler);
-    if (!this.serverStarted && !cancellationToken.isCancellationRequested) {
+    if (!serverStarted && !cancellationToken.isCancellationRequested) {
       let message = nls.localize('force_lightning_lwc_start_failed');
 
       // TODO proper exit codes in lwc-dev-server for address in use, auth/org error, etc.

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcStart.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcStart.test.ts
@@ -261,6 +261,19 @@ describe('forceLightningLwcStart', () => {
         );
       });
 
+      it('shows no error when server is stopping', () => {
+        const executor = new ForceLightningLwcStartExecutor();
+        const fakeExecution = new FakeExecution(executor.build());
+        cliCommandExecutorStub.returns(fakeExecution);
+
+        executor.execute({ type: 'CONTINUE', data: {} });
+        fakeExecution.stdoutSubject.next('Server up');
+        fakeExecution.processExitSubject.next(0);
+
+        sinon.assert.notCalled(notificationServiceStubs.showErrorMessageStub);
+        sinon.assert.notCalled(channelServiceStubs.appendLineStub);
+      });
+
       it('shows an error message when the process exists before server startup', () => {
         const executor = new ForceLightningLwcStartExecutor();
         const fakeExecution = new FakeExecution(executor.build());

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcStop.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcStop.test.ts
@@ -6,17 +6,46 @@
  */
 
 import * as sinon from 'sinon';
+import * as vscode from 'vscode';
 import { forceLightningLwcStop } from '../../../src/commands/forceLightningLwcStop';
 import { DevServerService } from '../../../src/service/devServerService';
+import { nls } from '../../../src/messages';
+
+const sfdxCoreExports = vscode.extensions.getExtension(
+  'salesforce.salesforcedx-vscode-core'
+)!.exports;
+const {
+  channelService,
+  notificationService
+} = sfdxCoreExports;
 
 describe('forceLightningLwcStop', () => {
   let sandbox: sinon.SinonSandbox;
   let devService: DevServerService;
+  let channelServiceStubs: { [key: string]: sinon.SinonStub };
+  let notificationServiceStubs: { [key: string]: sinon.SinonStub };
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     devService = new DevServerService();
     sandbox.stub(DevServerService, 'instance').get(() => devService);
+
+    channelServiceStubs = {};
+    notificationServiceStubs = {};
+
+    channelServiceStubs.appendLineStub = sandbox.stub(
+      channelService,
+      'appendLine'
+    );
+
+    notificationServiceStubs.showSuccessfulExecutionStub = sandbox.stub(
+      notificationService,
+      'showSuccessfulExecution'
+    );
+    notificationServiceStubs.showErrorMessageStub = sandbox.stub(
+      notificationService,
+      'showErrorMessage'
+    );
   });
 
   afterEach(() => {
@@ -31,5 +60,27 @@ describe('forceLightningLwcStop', () => {
 
     await forceLightningLwcStop();
     sinon.assert.calledOnce(stopStub);
+  });
+
+  it('shows successful server stop', async () => {
+    let devServiceStub = sinon.createStubInstance(DevServerService);
+    devServiceStub.isServerHandlerRegistered.returns(true);
+    sandbox.stub(DevServerService, 'instance').get(() => devServiceStub);
+
+    await forceLightningLwcStop();
+
+    sinon.assert.notCalled(notificationServiceStubs.showErrorMessageStub);
+
+    sinon.assert.calledOnce(channelServiceStubs.appendLineStub);
+    sinon.assert.calledWith(
+      channelServiceStubs.appendLineStub,
+      sinon.match(nls.localize('force_lightning_lwc_stop_in_progress'))
+    );
+
+    sinon.assert.calledOnce(notificationServiceStubs.showSuccessfulExecutionStub);
+    sinon.assert.calledWith(
+      notificationServiceStubs.showSuccessfulExecutionStub,
+      sinon.match(nls.localize('force_lightning_lwc_stop_text'))
+    );
   });
 });


### PR DESCRIPTION
### What does this PR do?
Fix for regression caused by initial PR. When stopping the local development server, the user would be presented with errors that they should not see.

### What issues does this PR fix or reference?
@W-7462993@

### Functionality Before
![stop_errors](https://user-images.githubusercontent.com/45604118/80966390-ae4a2f00-8dd1-11ea-8e37-7da8ef1f4075.gif)