### PR TITLE
Add check for server address already in use

### DIFF
--- a/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcStart.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcStart.ts
@@ -121,7 +121,7 @@ export class ForceLightningLwcStartExecutor extends SfdxCommandletExecutor<{}> {
         if (data.toString().includes('Server start up failed')) {
           errorCode = 1;
         }
-        if (data.toString().includes('EADDRINUSE: address already in use')) {
+        if (data.toString().includes('EADDRINUSE')) {
           errorCode = 98;
         }
         if (errorCode !== -1) {

--- a/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
@@ -22,7 +22,7 @@ export const messages = {
   force_lightning_lwc_start_not_found:
     'To run this command, first install the @salesforce/lwc-dev-server plugin. For more info, see [https://developer.salesforce.com/docs/component-library/documentation/lwc/lwc.get_started_local_dev](https://developer.salesforce.com/docs/component-library/documentation/lwc/lwc.get_started_local_dev).',
   force_lightning_lwc_start_addr_in_use:
-    'The local development server could not start because the address is already in use. To resolve either: \n1) Stop the local dev server if it is running in another instance.\n or 2) Change the default port [Configuration for Projects (Optional)](https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.get_started_local_dev_setup).\n or 3) Kill the process running on the specified port.',
+    "The local development server couldn't start as the address is already in use. To resolve, do one of these\n 1) Stop the local dev server running on any another instance.\n or 2) Change the default port [Configuration for Projects (Optional)](https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.get_started_local_dev_setup).\n 3) Kill the process running on the specified port.",
   force_lightning_lwc_start_failed:
     'The local development server was not able to start.',
   force_lightning_lwc_start_exited:

--- a/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
@@ -22,7 +22,7 @@ export const messages = {
   force_lightning_lwc_start_not_found:
     'To run this command, first install the @salesforce/lwc-dev-server plugin. For more info, see [https://developer.salesforce.com/docs/component-library/documentation/lwc/lwc.get_started_local_dev](https://developer.salesforce.com/docs/component-library/documentation/lwc/lwc.get_started_local_dev).',
   force_lightning_lwc_start_addr_in_use:
-    'The local development server could not start because the address is already in use. To resolve: \n1) Stop the local dev server if it is running in another instance.\n2) Change the default port [Configuration for Projects (Optional)](https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.get_started_local_dev_setup).\n3) Kill the process running on the specified port.',
+    'The local development server could not start because the address is already in use. To resolve either: \n1) Stop the local dev server if it is running in another instance.\n or 2) Change the default port [Configuration for Projects (Optional)](https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.get_started_local_dev_setup).\n or 3) Kill the process running on the specified port.',
   force_lightning_lwc_start_failed:
     'The local development server was not able to start.',
   force_lightning_lwc_start_exited:

--- a/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
@@ -21,6 +21,8 @@ export const messages = {
   force_lightning_lwc_start_text: 'SFDX: Start Local Development Server',
   force_lightning_lwc_start_not_found:
     'To run this command, first install the @salesforce/lwc-dev-server plugin. For more info, see [https://developer.salesforce.com/docs/component-library/documentation/lwc/lwc.get_started_local_dev](https://developer.salesforce.com/docs/component-library/documentation/lwc/lwc.get_started_local_dev).',
+  force_lightning_lwc_start_addr_in_use:
+    'The local development server could not start because the address is already in use. Please kill the process running on the specified port and try again.',
   force_lightning_lwc_start_failed:
     'The local development server was not able to start.',
   force_lightning_lwc_start_exited:

--- a/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
@@ -22,7 +22,7 @@ export const messages = {
   force_lightning_lwc_start_not_found:
     'To run this command, first install the @salesforce/lwc-dev-server plugin. For more info, see [https://developer.salesforce.com/docs/component-library/documentation/lwc/lwc.get_started_local_dev](https://developer.salesforce.com/docs/component-library/documentation/lwc/lwc.get_started_local_dev).',
   force_lightning_lwc_start_addr_in_use:
-    'The local development server could not start because the address is already in use. Please kill the process running on the specified port and try again.',
+    'The local development server could not start because the address is already in use. To resolve: \n1) Stop the local dev server if it is running in another instance.\n2) Change the default port [Configuration for Projects (Optional)](https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.get_started_local_dev_setup).\n3) Kill the process running on the specified port.',
   force_lightning_lwc_start_failed:
     'The local development server was not able to start.',
   force_lightning_lwc_start_exited:

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcStart.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcStart.test.ts
@@ -261,6 +261,29 @@ describe('forceLightningLwcStart', () => {
         );
       });
 
+      it('shows an error when the address is already in use', () => {
+        const executor = new ForceLightningLwcStartExecutor();
+        const fakeExecution = new FakeExecution(executor.build());
+        cliCommandExecutorStub.returns(fakeExecution);
+
+        executor.execute({ type: 'CONTINUE', data: {} });
+        fakeExecution.processExitSubject.next(98);
+
+        const commandName = nls.localize(`force_lightning_lwc_start_text`);
+
+        sinon.assert.calledTwice(notificationServiceStubs.showErrorMessageStub);
+        sinon.assert.calledWith(
+          notificationServiceStubs.showErrorMessageStub,
+          sinon.match(nls.localize('command_failure', commandName))
+        );
+
+        sinon.assert.calledOnce(channelServiceStubs.appendLineStub);
+        sinon.assert.calledWith(
+          channelServiceStubs.appendLineStub,
+          sinon.match(nls.localize('force_lightning_lwc_start_addr_in_use'))
+        );
+      });
+
       it('shows no error when server is stopping', () => {
         const executor = new ForceLightningLwcStartExecutor();
         const fakeExecution = new FakeExecution(executor.build());


### PR DESCRIPTION
### What does this PR do?
Adds a check for the error text 'EADDRINUSE: address already in use'. When this happens, we will call the error handling logic with exit code 98.

### What issues does this PR fix or reference?
@W-7148356@
