### PR TITLE
Honor CLI telemetry disablement setting

### DIFF
--- a/contributing/telemetry.md
+++ b/contributing/telemetry.md
@@ -6,6 +6,8 @@ Similar to what vscode does, we are reporting on certain events that happen in t
 
 All extensions leverage the telemetryService in `salesforce-vscode-core` extension in order to send data. The service in `salesforce-vscode-core` is resposible of showing an information message to users and properly initializing the service for other extensions in this repository to leverage. In the same line as vscode, we provide the user an opt out mechanism. We check that user settings `telemetry.enableTelemetry` and `salesforcedx-vscode-core.telemetry.enabled` are enabled before initializing the service.
 
+Additionally, if telemetry is disabled for the Salesforce CLI via the `disableTelemetry` configuration setting, or the `SFDX_DISABLE_TELEMETRY` environment variable, the telemetryService will not send data.
+
 ## Adding telemetry to an extension
 
 - Add [vscode-extension-telemetry](https://github.com/Microsoft/vscode-extension-telemetry#readme) as a devDependency

--- a/contributing/telemetry.md
+++ b/contributing/telemetry.md
@@ -4,9 +4,9 @@ Similar to what vscode does, we are reporting on certain events that happen in t
 
 ## How it works
 
-All extensions leverage the telemetryService in `salesforce-vscode-core` extension in order to send data. The service in `salesforce-vscode-core` is resposible of showing an information message to users and properly initializing the service for other extensions in this repository to leverage. In the same line as vscode, we provide the user an opt out mechanism. We check that user settings `telemetry.enableTelemetry` and `salesforcedx-vscode-core.telemetry.enabled` are enabled before initializing the service.
+All extensions leverage the telemetryService in `salesforce-vscode-core` extension in order to send data. The service in `salesforce-vscode-core` is responsible for showing an information message to users and properly initializing the service for other extensions in this repository to leverage. Similar to VSCode, we provide the user an opt out mechanism. We check that user settings `telemetry.enableTelemetry` and `salesforcedx-vscode-core.telemetry.enabled` are enabled before initializing the service.
 
-Additionally, if telemetry is disabled for the Salesforce CLI via the `disableTelemetry` configuration setting, or the `SFDX_DISABLE_TELEMETRY` environment variable, the telemetryService will not send data.
+Additionally, if telemetry is disabled for Salesforce CLI using the `disableTelemetry` configuration setting or the `SFDX_DISABLE_TELEMETRY` environment variable, the telemetryService doesn't send data.
 
 ## Adding telemetry to an extension
 

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@salesforce/salesforcedx-test-utils-vscode": "48.14.0",
+    "@salesforce/ts-sinon": "^1.0.0",
     "@types/adm-zip": "^0.4.31",
     "@types/chai": "^4.0.0",
     "@types/glob": "^5.0.30",

--- a/packages/salesforcedx-vscode-core/src/constants.ts
+++ b/packages/salesforcedx-vscode-core/src/constants.ts
@@ -14,6 +14,8 @@ export const SHOW_CLI_SUCCESS_INFO_MSG = 'show-cli-success-msg';
 export const APEX_CODE_DEBUG_LEVEL = 'FINEST';
 export const VISUALFORCE_DEBUG_LEVEL = 'FINER';
 export const TELEMETRY_ENABLED = 'telemetry.enabled';
+export const SFDX_CONFIG_DISABLE_TELEMETRY = 'disableTelemetry';
+export const ENV_SFDX_DISABLE_TELEMETRY = 'SFDX_DISABLE_TELEMETRY';
 export const INTERNAL_DEVELOPMENT_FLAG = 'internal-development';
 export const TELEMETRY_OPT_OUT_LINK =
   'https://forcedotcom.github.io/salesforcedx-vscode/articles/faq/telemetry';

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -77,8 +77,10 @@ import { registerPushOrDeployOnSave, sfdxCoreSettings } from './settings';
 import { taskViewService } from './statuses';
 import { telemetryService } from './telemetry';
 import {
+  getRootWorkspacePath,
   hasRootWorkspace,
   isCLIInstalled,
+  isCLITelemetryAllowed,
   showCLINotInstalledMessage
 } from './util';
 import { OrgAuthInfo } from './util/authInfo';
@@ -441,9 +443,12 @@ async function setupOrgBrowser(
 export async function activate(context: vscode.ExtensionContext) {
   const extensionHRStart = process.hrtime();
   // Telemetry
+  const isCliTelemetryAllowed = await isCLITelemetryAllowed(
+    getRootWorkspacePath()
+  );
   const machineId =
     vscode && vscode.env ? vscode.env.machineId : 'someValue.machineId';
-  telemetryService.initializeService(context, machineId);
+  telemetryService.initializeService(context, machineId, isCliTelemetryAllowed);
   telemetryService.showTelemetryMessage();
 
   // Task View

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -442,13 +442,9 @@ async function setupOrgBrowser(
 
 export async function activate(context: vscode.ExtensionContext) {
   const extensionHRStart = process.hrtime();
-  // Telemetry
-  const isCliTelemetryAllowed = await isCLITelemetryAllowed(
-    getRootWorkspacePath()
-  );
   const machineId =
     vscode && vscode.env ? vscode.env.machineId : 'someValue.machineId';
-  telemetryService.initializeService(context, machineId, isCliTelemetryAllowed);
+  await telemetryService.initializeService(context, machineId);
   telemetryService.showTelemetryMessage();
 
   // Task View

--- a/packages/salesforcedx-vscode-core/src/telemetry/telemetry.ts
+++ b/packages/salesforcedx-vscode-core/src/telemetry/telemetry.ts
@@ -6,11 +6,12 @@
  */
 
 import * as util from 'util';
-import vscode = require('vscode');
 import { TELEMETRY_OPT_OUT_LINK } from '../constants';
 import { nls } from '../messages';
 import { sfdxCoreSettings } from '../settings';
+import { disableCLITelemetry } from '../util';
 import TelemetryReporter from './telemetryReporter';
+import vscode = require('vscode');
 
 const TELEMETRY_GLOBAL_VALUE = 'sfdxTelemetryMessage';
 const EXTENSION_NAME = 'salesforcedx-vscode-core';
@@ -30,6 +31,7 @@ export class TelemetryService {
   private static instance: TelemetryService;
   private context: vscode.ExtensionContext | undefined;
   private reporter: TelemetryReporter | undefined;
+  private cliAllowsTelemetry: boolean = true;
 
   public static getInstance() {
     if (!TelemetryService.instance) {
@@ -40,9 +42,11 @@ export class TelemetryService {
 
   public initializeService(
     context: vscode.ExtensionContext,
-    machineId: string
+    machineId: string,
+    cliAllowsTelemetry: boolean = true
   ): void {
     this.context = context;
+    this.cliAllowsTelemetry = cliAllowsTelemetry;
     const isDevMode = machineId === 'someValue.machineId';
     // TelemetryReporter is not initialized if user has disabled telemetry setting.
     if (
@@ -62,6 +66,8 @@ export class TelemetryService {
       );
       this.context.subscriptions.push(this.reporter);
     }
+
+    this.setCliTelemetryEnabled(this.isTelemetryEnabled() && !isDevMode);
   }
 
   public getReporter(): TelemetryReporter | undefined {
@@ -69,7 +75,7 @@ export class TelemetryService {
   }
 
   public isTelemetryEnabled(): boolean {
-    return sfdxCoreSettings.getTelemetryEnabled();
+    return sfdxCoreSettings.getTelemetryEnabled() && this.cliAllowsTelemetry;
   }
 
   private getHasTelemetryMessageBeenShown(): boolean {
@@ -185,5 +191,11 @@ export class TelemetryService {
   public getEndHRTime(hrstart: [number, number]): string {
     const hrend = process.hrtime(hrstart);
     return util.format('%d%d', hrend[0], hrend[1] / 1000000);
+  }
+
+  public setCliTelemetryEnabled(isEnabled: boolean) {
+    if (!isEnabled) {
+      disableCLITelemetry();
+    }
   }
 }

--- a/packages/salesforcedx-vscode-core/src/telemetry/telemetry.ts
+++ b/packages/salesforcedx-vscode-core/src/telemetry/telemetry.ts
@@ -70,7 +70,7 @@ export class TelemetryService {
       this.context.subscriptions.push(this.reporter);
     }
 
-    this.setCliTelemetryEnabled(this.isTelemetryEnabled() && !isDevMode);
+    this.setCliTelemetryEnabled(this.isTelemetryEnabled());
   }
 
   public getReporter(): TelemetryReporter | undefined {

--- a/packages/salesforcedx-vscode-core/src/telemetry/telemetry.ts
+++ b/packages/salesforcedx-vscode-core/src/telemetry/telemetry.ts
@@ -9,7 +9,11 @@ import * as util from 'util';
 import { TELEMETRY_OPT_OUT_LINK } from '../constants';
 import { nls } from '../messages';
 import { sfdxCoreSettings } from '../settings';
-import { disableCLITelemetry } from '../util';
+import {
+  disableCLITelemetry,
+  getRootWorkspacePath,
+  isCLITelemetryAllowed
+} from '../util';
 import TelemetryReporter from './telemetryReporter';
 import vscode = require('vscode');
 
@@ -40,13 +44,12 @@ export class TelemetryService {
     return TelemetryService.instance;
   }
 
-  public initializeService(
+  public async initializeService(
     context: vscode.ExtensionContext,
-    machineId: string,
-    cliAllowsTelemetry: boolean = true
-  ): void {
+    machineId: string
+  ): Promise<void> {
     this.context = context;
-    this.cliAllowsTelemetry = cliAllowsTelemetry;
+    this.cliAllowsTelemetry = await this.checkCliTelemetry();
     const isDevMode = machineId === 'someValue.machineId';
     // TelemetryReporter is not initialized if user has disabled telemetry setting.
     if (
@@ -191,6 +194,10 @@ export class TelemetryService {
   public getEndHRTime(hrstart: [number, number]): string {
     const hrend = process.hrtime(hrstart);
     return util.format('%d%d', hrend[0], hrend[1] / 1000000);
+  }
+
+  public async checkCliTelemetry(): Promise<boolean> {
+    return await isCLITelemetryAllowed(getRootWorkspacePath());
   }
 
   public setCliTelemetryEnabled(isEnabled: boolean) {

--- a/packages/salesforcedx-vscode-core/src/util/cliConfiguration.ts
+++ b/packages/salesforcedx-vscode-core/src/util/cliConfiguration.ts
@@ -58,10 +58,8 @@ export async function isCLITelemetryAllowed(
       projectPath,
       SFDX_CONFIG_DISABLE_TELEMETRY
     );
-    const disabledConfig =
-      forceConfig.get(SFDX_CONFIG_DISABLE_TELEMETRY) || 'false';
-    const isDisabled = disabledConfig === 'true' ? true : false;
-    return !isDisabled;
+    const disabledConfig = forceConfig.get(SFDX_CONFIG_DISABLE_TELEMETRY) || '';
+    return disabledConfig !== 'true';
   }
   return true;
 }

--- a/packages/salesforcedx-vscode-core/src/util/cliConfiguration.ts
+++ b/packages/salesforcedx-vscode-core/src/util/cliConfiguration.ts
@@ -5,9 +5,17 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import {
+  ForceConfigGet,
+  GlobalCliEnvironment
+} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import { which } from 'shelljs';
 import { window } from 'vscode';
-import { SFDX_CLI_DOWNLOAD_LINK } from '../constants';
+import {
+  ENV_SFDX_DISABLE_TELEMETRY,
+  SFDX_CLI_DOWNLOAD_LINK,
+  SFDX_CONFIG_DISABLE_TELEMETRY
+} from '../constants';
 import { nls } from '../messages';
 
 export function isCLIInstalled(): boolean {
@@ -33,4 +41,27 @@ export function showCLINotInstalledMessage() {
 
 export function isSFDXContainerMode(): boolean {
   return process.env.SFDX_CONTAINER_MODE ? true : false;
+}
+
+export function disableCLITelemetry() {
+  GlobalCliEnvironment.environmentVariables.set(
+    ENV_SFDX_DISABLE_TELEMETRY,
+    'true'
+  );
+}
+
+export async function isCLITelemetryAllowed(
+  projectPath: string
+): Promise<boolean> {
+  if (isCLIInstalled()) {
+    const forceConfig = await new ForceConfigGet().getConfig(
+      projectPath,
+      SFDX_CONFIG_DISABLE_TELEMETRY
+    );
+    const disabledConfig =
+      forceConfig.get(SFDX_CONFIG_DISABLE_TELEMETRY) || 'false';
+    const isDisabled = disabledConfig === 'true' ? true : false;
+    return !isDisabled;
+  }
+  return true;
 }

--- a/packages/salesforcedx-vscode-core/src/util/index.ts
+++ b/packages/salesforcedx-vscode-core/src/util/index.ts
@@ -7,13 +7,15 @@
 
 export { OrgAuthInfo } from './authInfo';
 export {
+  disableCLITelemetry,
+  isCLIInstalled,
+  isCLITelemetryAllowed,
+  isSFDXContainerMode,
+  showCLINotInstalledMessage
+} from './cliConfiguration';
+export { ConfigSource, ConfigUtil } from './configUtil';
+export {
   getRootWorkspace,
   getRootWorkspacePath,
   hasRootWorkspace
 } from './rootWorkspace';
-export {
-  isCLIInstalled,
-  showCLINotInstalledMessage,
-  isSFDXContainerMode
-} from './cliConfiguration';
-export { ConfigSource, ConfigUtil } from './configUtil';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/telemetry/index.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/telemetry/index.test.ts
@@ -55,7 +55,7 @@ describe('Telemetry', () => {
 
       const telemetryReporter = telemetryService.getReporter();
       expect(typeof telemetryReporter).to.be.eql('undefined');
-      expect(teleStub.firstCall.args).to.eql([false]);
+      expect(teleStub.firstCall.args).to.eql([true]);
     });
 
     it('Should show telemetry info message', async () => {
@@ -72,7 +72,7 @@ describe('Telemetry', () => {
 
       telemetryService.showTelemetryMessage();
       assert.calledOnce(mShowInformation);
-      expect(teleStub.firstCall.args).to.eql([false]);
+      expect(teleStub.firstCall.args).to.eql([true]);
     });
 
     it('Should not show telemetry info message', async () => {
@@ -89,7 +89,7 @@ describe('Telemetry', () => {
 
       telemetryService.showTelemetryMessage();
       assert.notCalled(mShowInformation);
-      expect(teleStub.firstCall.args).to.eql([false]);
+      expect(teleStub.firstCall.args).to.eql([true]);
     });
 
     it('Should disable CLI telemetry', async () => {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/telemetry/index.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/telemetry/index.test.ts
@@ -21,6 +21,7 @@ describe('Telemetry', () => {
   let reporter: SinonStub;
   let exceptionEvent: SinonStub;
   let teleStub: SinonStub;
+  let cliStub: SinonStub;
 
   describe('in dev mode', () => {
     beforeEach(() => {
@@ -32,19 +33,25 @@ describe('Telemetry', () => {
         'getTelemetryEnabled'
       ).returns(true);
       teleStub = stub(telemetryService, 'setCliTelemetryEnabled');
+      cliStub = stub(telemetryService, 'checkCliTelemetry');
+      cliStub.returns(true);
     });
 
     afterEach(() => {
       mShowInformation.restore();
       settings.restore();
       teleStub.restore();
+      cliStub.restore();
     });
 
     it('Should not initialize telemetry reporter', async () => {
       // create vscode extensionContext
       mockContext = new MockContext(true);
 
-      telemetryService.initializeService(mockContext, 'someValue.machineId');
+      await telemetryService.initializeService(
+        mockContext,
+        'someValue.machineId'
+      );
 
       const telemetryReporter = telemetryService.getReporter();
       expect(typeof telemetryReporter).to.be.eql('undefined');
@@ -55,7 +62,10 @@ describe('Telemetry', () => {
       // create vscode extensionContext in which telemetry msg has never been previously shown
       mockContext = new MockContext(false);
 
-      telemetryService.initializeService(mockContext, 'someValue.machineId');
+      await telemetryService.initializeService(
+        mockContext,
+        'someValue.machineId'
+      );
 
       const telemetryEnabled = telemetryService.isTelemetryEnabled();
       expect(telemetryEnabled).to.be.eql(true);
@@ -69,7 +79,10 @@ describe('Telemetry', () => {
       // create vscode extensionContext in which telemetry msg has been previously shown
       mockContext = new MockContext(true);
 
-      telemetryService.initializeService(mockContext, 'someValue.machineId');
+      await telemetryService.initializeService(
+        mockContext,
+        'someValue.machineId'
+      );
 
       const telemetryEnabled = telemetryService.isTelemetryEnabled();
       expect(telemetryEnabled).to.be.eql(true);
@@ -82,10 +95,10 @@ describe('Telemetry', () => {
     it('Should disable CLI telemetry', async () => {
       mockContext = new MockContext(true);
 
-      telemetryService.initializeService(
+      cliStub.returns(false);
+      await telemetryService.initializeService(
         mockContext,
-        'someValue.machineId',
-        false
+        'someValue.machineId'
       );
 
       expect(teleStub.firstCall.args).to.eql([false]);
@@ -104,6 +117,8 @@ describe('Telemetry', () => {
       reporter = stub(TelemetryReporter.prototype, 'sendTelemetryEvent');
       exceptionEvent = stub(TelemetryReporter.prototype, 'sendExceptionEvent');
       teleStub = stub(telemetryService, 'setCliTelemetryEnabled');
+      cliStub = stub(telemetryService, 'checkCliTelemetry');
+      cliStub.returns(true);
     });
 
     afterEach(() => {
@@ -112,13 +127,14 @@ describe('Telemetry', () => {
       reporter.restore();
       exceptionEvent.restore();
       teleStub.restore();
+      cliStub.restore();
     });
 
     it('Should show telemetry info message', async () => {
       // create vscode extensionContext in which telemetry msg has never been previously shown
       mockContext = new MockContext(false);
 
-      telemetryService.initializeService(mockContext, machineId);
+      await telemetryService.initializeService(mockContext, machineId);
 
       const telemetryEnabled = telemetryService.isTelemetryEnabled();
       expect(telemetryEnabled).to.be.eql(true);
@@ -132,7 +148,7 @@ describe('Telemetry', () => {
       // create vscode extensionContext in which telemetry msg has been previously shown
       mockContext = new MockContext(true);
 
-      telemetryService.initializeService(mockContext, machineId);
+      await telemetryService.initializeService(mockContext, machineId);
 
       const telemetryEnabled = telemetryService.isTelemetryEnabled();
       expect(telemetryEnabled).to.be.eql(true);
@@ -146,7 +162,7 @@ describe('Telemetry', () => {
       // create vscode extensionContext in which telemetry msg has been previously shown
       mockContext = new MockContext(true);
 
-      telemetryService.initializeService(mockContext, machineId);
+      await telemetryService.initializeService(mockContext, machineId);
 
       telemetryService.sendExtensionActivationEvent([0, 678]);
       assert.calledOnce(reporter);
@@ -163,7 +179,7 @@ describe('Telemetry', () => {
         'getTelemetryEnabled'
       ).returns(false);
 
-      telemetryService.initializeService(mockContext, machineId);
+      await telemetryService.initializeService(mockContext, machineId);
 
       const telemetryEnabled = telemetryService.isTelemetryEnabled();
       expect(telemetryEnabled).to.be.eql(false);
@@ -177,7 +193,7 @@ describe('Telemetry', () => {
       // create vscode extensionContext
       mockContext = new MockContext(true);
 
-      telemetryService.initializeService(mockContext, machineId);
+      await telemetryService.initializeService(mockContext, machineId);
 
       telemetryService.sendExtensionActivationEvent([0, 678]);
       assert.calledOnce(reporter);
@@ -194,7 +210,7 @@ describe('Telemetry', () => {
       // create vscode extensionContext
       mockContext = new MockContext(true);
 
-      telemetryService.initializeService(mockContext, machineId);
+      await telemetryService.initializeService(mockContext, machineId);
 
       telemetryService.sendExtensionDeactivationEvent();
       assert.calledOnce(reporter);
@@ -210,7 +226,7 @@ describe('Telemetry', () => {
       // create vscode extensionContext
       mockContext = new MockContext(true);
 
-      telemetryService.initializeService(mockContext, machineId);
+      await telemetryService.initializeService(mockContext, machineId);
 
       telemetryService.sendCommandEvent('create_apex_class_command', [0, 678]);
       assert.calledOnce(reporter);
@@ -228,7 +244,7 @@ describe('Telemetry', () => {
       // create vscode extensionContext
       mockContext = new MockContext(true);
 
-      telemetryService.initializeService(mockContext, machineId);
+      await telemetryService.initializeService(mockContext, machineId);
       const additionalData = {
         dirType: 'testDirectoryType',
         secondParam: 'value'
@@ -255,7 +271,7 @@ describe('Telemetry', () => {
     it('should send correct data format on sendEventData', async () => {
       mockContext = new MockContext(true);
 
-      telemetryService.initializeService(mockContext, machineId);
+      await telemetryService.initializeService(mockContext, machineId);
 
       const eventName = 'eventName';
       const property = { property: 'property for event' };
@@ -270,7 +286,7 @@ describe('Telemetry', () => {
       // create vscode extensionContext
       mockContext = new MockContext(true);
 
-      telemetryService.initializeService(mockContext, machineId);
+      await telemetryService.initializeService(mockContext, machineId);
 
       telemetryService.sendException(
         'error_name',
@@ -289,7 +305,8 @@ describe('Telemetry', () => {
       // create vscode extensionContext
       mockContext = new MockContext(true);
 
-      telemetryService.initializeService(mockContext, machineId, false);
+      cliStub.returns(false);
+      await telemetryService.initializeService(mockContext, machineId);
 
       const telemetryEnabled = telemetryService.isTelemetryEnabled();
       expect(telemetryEnabled).to.be.eql(false);

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/util/cliConfiguration.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/util/cliConfiguration.test.ts
@@ -5,11 +5,24 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import {
+  ForceConfigGet,
+  GlobalCliEnvironment
+} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import { expect } from 'chai';
 import * as shelljs from 'shelljs';
 import { assert, SinonStub, stub } from 'sinon';
 import { window } from 'vscode';
-import { isCLIInstalled, showCLINotInstalledMessage } from '../../../src/util';
+import {
+  ENV_SFDX_DISABLE_TELEMETRY,
+  SFDX_CONFIG_DISABLE_TELEMETRY
+} from '../../../src/constants';
+import {
+  disableCLITelemetry,
+  isCLIInstalled,
+  isCLITelemetryAllowed,
+  showCLINotInstalledMessage
+} from '../../../src/util';
 
 describe('SFDX CLI Configuration utility', () => {
   describe('isCLIInstalled', () => {
@@ -63,6 +76,71 @@ describe('SFDX CLI Configuration utility', () => {
     it('Should show cli install info message', async () => {
       showCLINotInstalledMessage();
       assert.calledOnce(mShowWarning);
+    });
+  });
+
+  describe('CLI Telemetry', () => {
+    let whichStub: SinonStub;
+    let configGetSpy: SinonStub;
+    let cliEnvSpy: SinonStub;
+
+    beforeEach(() => {
+      whichStub = stub(shelljs, 'which');
+      cliEnvSpy = stub(GlobalCliEnvironment.environmentVariables, 'set');
+      configGetSpy = stub(ForceConfigGet.prototype, 'getConfig').returns(
+        {} as Map<string, string>
+      );
+    });
+
+    afterEach(() => {
+      whichStub.restore();
+      cliEnvSpy.restore();
+      configGetSpy.restore();
+    });
+
+    it('Should return true if cli is not installed', async () => {
+      whichStub.withArgs('sfdx').returns('');
+
+      const response = await isCLITelemetryAllowed('');
+      expect(response).equal(true);
+    });
+
+    it('Should return false if telemetry is disabled', async () => {
+      whichStub.withArgs('sfdx').returns('Users/some/path/sfdx/cli');
+
+      const config = new Map<string, string>();
+      config.set(SFDX_CONFIG_DISABLE_TELEMETRY, 'false');
+      configGetSpy.returns(config);
+
+      const response = await isCLITelemetryAllowed('');
+      expect(response).equal(true);
+    });
+
+    it('Should return true if telementry setting is undefined', async () => {
+      whichStub.withArgs('sfdx').returns('Users/some/path/sfdx/cli');
+      configGetSpy.returns(new Map<string, string>());
+
+      const response = await isCLITelemetryAllowed('');
+      expect(response).equal(true);
+    });
+
+    it('Should return true if telementry setting is enabled', async () => {
+      whichStub.withArgs('sfdx').returns('Users/some/path/sfdx/cli');
+
+      const config = new Map<string, string>();
+      config.set(SFDX_CONFIG_DISABLE_TELEMETRY, 'false');
+      configGetSpy.returns(config);
+
+      const response = await isCLITelemetryAllowed('');
+      expect(response).equal(true);
+    });
+
+    it('Should set an environment variable', async () => {
+      disableCLITelemetry();
+      expect(cliEnvSpy.firstCall.args).to.eql([
+        ENV_SFDX_DISABLE_TELEMETRY,
+        'true'
+      ]);
     });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/util/cliConfiguration.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/util/cliConfiguration.test.ts
@@ -102,18 +102,18 @@ describe('SFDX CLI Configuration utility', () => {
       whichStub.withArgs('sfdx').returns('');
 
       const response = await isCLITelemetryAllowed('');
-      expect(response).equal(true);
+      expect(response).to.equal(true);
     });
 
-    it('Should return false if telemetry is disabled', async () => {
+    it('Should return false if telemetry setting is disabled', async () => {
       whichStub.withArgs('sfdx').returns('Users/some/path/sfdx/cli');
 
       const config = new Map<string, string>();
-      config.set(SFDX_CONFIG_DISABLE_TELEMETRY, 'false');
+      config.set(SFDX_CONFIG_DISABLE_TELEMETRY, 'true');
       configGetSpy.returns(config);
 
       const response = await isCLITelemetryAllowed('');
-      expect(response).equal(true);
+      expect(response).to.equal(false);
     });
 
     it('Should return true if telementry setting is undefined', async () => {
@@ -121,7 +121,7 @@ describe('SFDX CLI Configuration utility', () => {
       configGetSpy.returns(new Map<string, string>());
 
       const response = await isCLITelemetryAllowed('');
-      expect(response).equal(true);
+      expect(response).to.equal(true);
     });
 
     it('Should return true if telementry setting is enabled', async () => {
@@ -132,7 +132,7 @@ describe('SFDX CLI Configuration utility', () => {
       configGetSpy.returns(config);
 
       const response = await isCLITelemetryAllowed('');
-      expect(response).equal(true);
+      expect(response).to.equal(true);
     });
 
     it('Should set an environment variable', async () => {


### PR DESCRIPTION
### What does this PR do?
- Honor CLI telemetry setting for extension telemetry
- Disable telemetry for spawned CLI functionality when extension telemetry is disabled

### What issues does this PR fix or reference?
@W-7263491@

### Functionality Before
Even when telemetry is opted-out in the extension telemetry is still enabled for any spawned CLI functionality. Extension did not honor the CLI disablement setting.

### Functionality After
Opting out of extension telemetry will disable telemetry for any spawned CLI functionality. Disabling CLI telemetry will disable extension telemetry.
