### PR TITLE
Show the Salesforce CLI channel output when executing auth commands in a container

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceAuthDevHub.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceAuthDevHub.ts
@@ -33,7 +33,7 @@ import { ConfigSource, OrgAuthInfo } from '../util/index';
 import { ForceAuthDemoModeExecutor } from './forceAuthWebLogin';
 
 export class ForceAuthDevHubExecutor extends SfdxCommandletExecutor<{}> {
-  protected showChannelOutput = false;
+  protected showChannelOutput = isSFDXContainerMode();
 
   public build(data: {}): Command {
     const command = new SfdxCommandBuilder().withDescription(

--- a/packages/salesforcedx-vscode-core/src/commands/forceAuthWebLogin.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceAuthWebLogin.ts
@@ -45,7 +45,7 @@ export const SANDBOX_URL = 'https://test.salesforce.com';
 export class ForceAuthWebLoginExecutor extends SfdxCommandletExecutor<
   AuthParams
 > {
-  protected showChannelOutput = false;
+  protected showChannelOutput = isSFDXContainerMode();
 
   public build(data: AuthParams): Command {
     const command = new SfdxCommandBuilder().withDescription(

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceAuthDevHub.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceAuthDevHub.test.ts
@@ -18,6 +18,12 @@ import { DEFAULT_DEV_HUB_USERNAME_KEY } from '../../../src/constants';
 import { nls } from '../../../src/messages';
 import { ConfigSource, OrgAuthInfo } from '../../../src/util/index';
 
+class TestForceAuthDevHubExecutor extends ForceAuthDevHubExecutor {
+  public getShowChannelOutput() {
+    return this.showChannelOutput;
+  }
+}
+
 // tslint:disable:no-unused-expression
 describe('Force Auth Web Login for Dev Hub', () => {
   it('Should build the auth web login command', async () => {
@@ -152,6 +158,13 @@ describe('Force Auth Dev Hub is based on environment variables', () => {
   describe('in container mode', () => {
     afterEach(() => {
       delete process.env.SFDX_CONTAINER_MODE;
+    });
+    it('Should expose the output channel when in container mode', () => {
+      const notContainerMode = new TestForceAuthDevHubExecutor();
+      expect(notContainerMode.getShowChannelOutput()).to.be.false;
+      process.env.SFDX_CONTAINER_MODE = 'true';
+      const containerMode = new TestForceAuthDevHubExecutor();
+      expect(containerMode.getShowChannelOutput()).to.be.true;
     });
     it('Should use force:auth:web:login when container mode is not defined', () => {
       const authWebLogin = new ForceAuthDevHubExecutor();

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceAuthWebLogin.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceAuthWebLogin.test.ts
@@ -24,6 +24,12 @@ import { nls } from '../../../src/messages';
 const TEST_ALIAS = 'testAlias';
 const TEST_URL = 'https://my.testdomain.salesforce.com';
 
+class TestForceAuthWebLoginExecutor extends ForceAuthWebLoginExecutor {
+  public getShowChannelOutput() {
+    return this.showChannelOutput;
+  }
+}
+
 // tslint:disable:no-unused-expression
 describe('Force Auth Web Login', () => {
   it('Should build the auth web login command', async () => {
@@ -233,6 +239,13 @@ describe('Force Auth Web Login is based on environment variables', () => {
   describe('in container mode', () => {
     afterEach(() => {
       delete process.env.SFDX_CONTAINER_MODE;
+    });
+    it('Should expose the output channel when in container mode', () => {
+      const notContainerMode = new TestForceAuthWebLoginExecutor();
+      expect(notContainerMode.getShowChannelOutput()).to.be.false;
+      process.env.SFDX_CONTAINER_MODE = 'true';
+      const containerMode = new TestForceAuthWebLoginExecutor();
+      expect(containerMode.getShowChannelOutput()).to.be.true;
     });
     it('Should use force:auth:web:login when container mode is not defined', () => {
       const authWebLogin = new ForceAuthWebLoginExecutor();


### PR DESCRIPTION
### What does this PR do?
This PR flips the showChannelOutput boolean based on the environment variable SFDX_CONTAINER_MODE.  When the extensions are running in a container, like visual studio remote development in docker, where the browser is not available to the sfdx cli, the user can see the instructions to manually launch the browser to a url with a token.

### Functionality Before
I need to manually switch to the output channel
![auth-devhub-vsonline](https://user-images.githubusercontent.com/599418/81838193-09330300-9503-11ea-9c1e-2ad240cc78b4.gif)

### Functionality After
The command automatically shows the output channel
![hub-auth-device](https://user-images.githubusercontent.com/599418/81838269-21a31d80-9503-11ea-89bf-f6ad52a66569.gif)

### What issues does this PR fix or reference?
#2195, @W-7491069@

