### PR TITLE
Fix preview component in windows @W-7387219@

### DIFF
--- a/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcPreview.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcPreview.ts
@@ -39,7 +39,7 @@ export async function forceLightningLwcPreview(sourceUri: vscode.Uri) {
     return;
   }
 
-  const resourcePath = sourceUri.path;
+  const resourcePath = sourceUri.fsPath;
   if (!resourcePath) {
     const message = nls.localize(
       'force_lightning_lwc_preview_file_undefined',

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcPreview.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcPreview.test.ts
@@ -68,6 +68,28 @@ describe('forceLightningLwcPreview', () => {
     });
   }
 
+  it('exists sync called with correct path', async () => {
+    devServiceStub.isServerHandlerRegistered.returns(true);
+    const sourceUri = URI.file(mockLwcFilePath);
+    mockFileExists(mockLwcFilePath);
+
+    lstatSyncStub.returns({
+      isDirectory() {
+        return false;
+      }
+    } as fs.Stats);
+
+    await forceLightningLwcPreview(sourceUri);
+
+    sinon.assert.calledOnce(existsSyncStub);
+    sinon.assert.calledWith(
+      existsSyncStub,
+      /^win32/.test(process.platform)
+        ? 'C:\\project\\force-app\\main\\default\\lwc\\foo\\foo.js'
+        : '/var/project/force-app/main/default/lwc/foo/foo.js'
+    );
+  });
+
   it('calls openBrowser with the correct url for files', async () => {
     devServiceStub.isServerHandlerRegistered.returns(true);
     const sourceUri = URI.file(mockLwcFilePath);
@@ -129,7 +151,7 @@ describe('forceLightningLwcPreview', () => {
   it('shows an error when source path is not recognized as an lwc module file', async () => {
     devServiceStub.isServerHandlerRegistered.returns(true);
 
-    const notLwcModulePath = path.join('/foo');
+    const notLwcModulePath = path.join(root, 'foo');
     const sourceUri = URI.file(notLwcModulePath);
     mockFileExists(notLwcModulePath);
 
@@ -144,7 +166,10 @@ describe('forceLightningLwcPreview', () => {
     sinon.assert.calledWith(
       showErrorMessageStub,
       sinon.match(
-        nls.localize(`force_lightning_lwc_preview_unsupported`, '/foo')
+        nls.localize(
+          `force_lightning_lwc_preview_unsupported`,
+          /^win32/.test(process.platform) ? 'C:\\foo' : '/var/foo'
+        )
       )
     );
   });
@@ -152,7 +177,7 @@ describe('forceLightningLwcPreview', () => {
   it('shows an error when source path does not exist', async () => {
     devServiceStub.isServerHandlerRegistered.returns(true);
 
-    const nonExistentPath = path.join('/foo');
+    const nonExistentPath = path.join(root, 'foo');
     const sourceUri = URI.file(nonExistentPath);
 
     existsSyncStub.returns(false);
@@ -162,7 +187,10 @@ describe('forceLightningLwcPreview', () => {
     sinon.assert.calledWith(
       showErrorMessageStub,
       sinon.match(
-        nls.localize(`force_lightning_lwc_preview_file_nonexist`, '/foo')
+        nls.localize(
+          `force_lightning_lwc_preview_file_nonexist`,
+          /^win32/.test(process.platform) ? 'C:\\foo' : '/var/foo'
+        )
       )
     );
   });

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcPreview.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcPreview.test.ts
@@ -60,7 +60,10 @@ describe('forceLightningLwcPreview', () => {
 
   function mockFileExists(mockPath: string) {
     existsSyncStub.callsFake(fsPath => {
-      if (path.normalize(fsPath.toString()) === path.normalize(mockPath)) {
+      if (
+        path.normalize(fsPath.toString()).toLowerCase() ===
+        path.normalize(mockPath).toLowerCase()
+      ) {
         return true;
       } else {
         return false;
@@ -85,7 +88,7 @@ describe('forceLightningLwcPreview', () => {
     sinon.assert.calledWith(
       existsSyncStub,
       /^win32/.test(process.platform)
-        ? 'C:\\project\\force-app\\main\\default\\lwc\\foo\\foo.js'
+        ? 'c:\\project\\force-app\\main\\default\\lwc\\foo\\foo.js'
         : '/var/project/force-app/main/default/lwc/foo/foo.js'
     );
   });
@@ -168,7 +171,7 @@ describe('forceLightningLwcPreview', () => {
       sinon.match(
         nls.localize(
           `force_lightning_lwc_preview_unsupported`,
-          /^win32/.test(process.platform) ? 'C:\\foo' : '/var/foo'
+          /^win32/.test(process.platform) ? 'c:\\foo' : '/var/foo'
         )
       )
     );
@@ -189,7 +192,7 @@ describe('forceLightningLwcPreview', () => {
       sinon.match(
         nls.localize(
           `force_lightning_lwc_preview_file_nonexist`,
-          /^win32/.test(process.platform) ? 'C:\\foo' : '/var/foo'
+          /^win32/.test(process.platform) ? 'c:\\foo' : '/var/foo'
         )
       )
     );


### PR DESCRIPTION
### What does this PR do?
Fixes "SFDX: Preview Component Locally" in Windows

### What issues does this PR fix or reference?
Fixes #1903, @W-7387219@

### Functionality Before
It is throwing an error - SFDX: Preview Component Locally failed to run. Can't find the Lightning Web Components module in. Check that the module exists. 

### Functionality After
It should preview the Lightning web component using local development server 
