### PR TITLE
Add wait option for force:apex:test:run

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/commands/forceApexTestRunCodeAction.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceApexTestRunCodeAction.ts
@@ -30,7 +30,7 @@ export class ForceApexTestRunCodeActionExecutor extends SfdxCommandletExecutor<{
   protected shouldGetCodeCoverage: boolean = false;
   protected builder: SfdxCommandBuilder = new SfdxCommandBuilder();
   private outputToJson: string;
-  protected waitTime: number = 10;
+  protected waitTime: number = 0;
 
   public constructor(
     test: string,

--- a/packages/salesforcedx-vscode-apex/src/commands/forceApexTestRunCodeAction.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceApexTestRunCodeAction.ts
@@ -30,16 +30,19 @@ export class ForceApexTestRunCodeActionExecutor extends SfdxCommandletExecutor<{
   protected shouldGetCodeCoverage: boolean = false;
   protected builder: SfdxCommandBuilder = new SfdxCommandBuilder();
   private outputToJson: string;
+  protected waitTime: number = 10;
 
   public constructor(
     test: string,
     shouldGetCodeCoverage: boolean,
-    outputToJson: string
+    outputToJson: string,
+    waitTime: number
   ) {
     super();
     this.test = test || '';
     this.shouldGetCodeCoverage = shouldGetCodeCoverage;
     this.outputToJson = outputToJson;
+    this.waitTime = waitTime;
   }
 
   public build(data: {}): Command {
@@ -54,6 +57,10 @@ export class ForceApexTestRunCodeActionExecutor extends SfdxCommandletExecutor<{
       .withFlag('--loglevel', 'error')
       .withLogName('force_apex_test_run_code_action');
 
+    if (this.waitTime !== 0) {
+      this.builder = this.builder.withFlag('--wait', this.waitTime.toString());
+    }
+
     if (this.shouldGetCodeCoverage) {
       this.builder = this.builder.withArg('--codecoverage');
     }
@@ -65,10 +72,16 @@ export class ForceApexTestRunCodeActionExecutor extends SfdxCommandletExecutor<{
 async function forceApexTestRunCodeAction(test: string) {
   const getCodeCoverage = sfdxCoreSettings.getRetrieveTestCodeCoverage();
   const outputToJson = getTempFolder();
+  const waitTime = sfdxCoreSettings.getRetrieveTestWaitTime();
   const commandlet = new SfdxCommandlet(
     new SfdxWorkspaceChecker(),
     new EmptyParametersGatherer(),
-    new ForceApexTestRunCodeActionExecutor(test, getCodeCoverage, outputToJson)
+    new ForceApexTestRunCodeActionExecutor(
+      test,
+      getCodeCoverage,
+      outputToJson,
+      waitTime
+    )
   );
   await commandlet.run();
 }

--- a/packages/salesforcedx-vscode-apex/src/views/readableApexTestRunExecutor.ts
+++ b/packages/salesforcedx-vscode-apex/src/views/readableApexTestRunExecutor.ts
@@ -14,17 +14,25 @@ import { ForceApexTestRunCodeActionExecutor } from '../commands';
 import { nls } from '../messages';
 
 export class ReadableApexTestRunExecutor extends (ForceApexTestRunCodeActionExecutor as {
-  new (test: string, shouldGetCodeCoverage: boolean): any;
+  new (
+    test: string,
+    shouldGetCodeCoverage: boolean,
+    outputToJson: string,
+    waitTime: number
+  ): any;
 }) {
   private outputToJson: string;
+  private waitTime: number;
 
   public constructor(
     tests: string[],
     shouldGetCodeCoverage: boolean,
-    outputToJson: string
+    outputToJson: string,
+    waitTime: number
   ) {
-    super(tests.join(','), shouldGetCodeCoverage);
+    super(tests.join(','), shouldGetCodeCoverage, outputToJson, waitTime);
     this.outputToJson = outputToJson;
+    this.waitTime = waitTime;
   }
 
   public build(data: {}): Command {
@@ -35,6 +43,10 @@ export class ReadableApexTestRunExecutor extends (ForceApexTestRunCodeActionExec
       .withFlag('--resultformat', 'human')
       .withFlag('--outputdir', this.outputToJson)
       .withFlag('--loglevel', 'error');
+
+    if (this.waitTime !== 0) {
+      this.builder = this.builder.withFlag('--wait', this.waitTime.toString());
+    }
 
     if (this.shouldGetCodeCoverage) {
       this.builder = this.builder.withArg('--codecoverage');

--- a/packages/salesforcedx-vscode-apex/src/views/testRunner.ts
+++ b/packages/salesforcedx-vscode-apex/src/views/testRunner.ts
@@ -134,6 +134,7 @@ export class ApexTestRunner {
     }
 
     const tmpFolder = this.getTempFolder();
+    const waittime = 0;
     const getCodeCoverage = sfdxCoreSettings.getRetrieveTestCodeCoverage();
     if (testRunType === TestRunType.Class) {
       await forceApexTestRunCacheService.setCachedClassTestParam(tests[0]);
@@ -143,7 +144,8 @@ export class ApexTestRunner {
     const builder = new ReadableApexTestRunExecutor(
       tests,
       getCodeCoverage,
-      tmpFolder
+      tmpFolder,
+      waittime
     );
     const commandlet = new SfdxCommandlet(
       new SfdxWorkspaceChecker(),

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceApexTestRunCodeAction.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceApexTestRunCodeAction.test.ts
@@ -21,10 +21,12 @@ describe('Force Apex Test Run - Code Action', () => {
   describe('Command builder - Test Class', () => {
     const testClass = 'MyTests';
     const outputToJson = 'outputToJson';
+    const waitTime = 0;
     const builder = new ForceApexTestRunCodeActionExecutor(
       testClass,
       false,
-      outputToJson
+      outputToJson,
+      waitTime
     );
 
     it('Should build command for single test class', () => {
@@ -39,10 +41,12 @@ describe('Force Apex Test Run - Code Action', () => {
   describe('Command builder - Test Class with Coverage', () => {
     const testClass = 'MyTests';
     const outputToJson = 'outputToJson';
+    const waitTime = 0;
     const builder = new ForceApexTestRunCodeActionExecutor(
       testClass,
       true,
-      outputToJson
+      outputToJson,
+      waitTime
     );
 
     it('Should build command for single test class with code coverage', () => {
@@ -57,10 +61,12 @@ describe('Force Apex Test Run - Code Action', () => {
   describe('Command builder - Test Method', () => {
     const testMethod = 'MyTests.testMe';
     const outputToJson = 'outputToJson';
+    const waitTime = 0;
     const builder = new ForceApexTestRunCodeActionExecutor(
       testMethod,
       false,
-      outputToJson
+      outputToJson,
+      waitTime
     );
 
     it('Should build command for single test method', () => {
@@ -75,10 +81,12 @@ describe('Force Apex Test Run - Code Action', () => {
   describe('Command builder - Test Method with Coverage', () => {
     const testMethod = 'MyTests.testMe';
     const outputToJson = 'outputToJson';
+    const waitTime = 0;
     const builder = new ForceApexTestRunCodeActionExecutor(
       testMethod,
       true,
-      outputToJson
+      outputToJson,
+      waitTime
     );
 
     it('Should build command for single test method with code coverage', () => {
@@ -86,6 +94,46 @@ describe('Force Apex Test Run - Code Action', () => {
 
       expect(command.toCommand()).to.equal(
         `sfdx force:apex:test:run --tests ${testMethod} --resultformat human --outputdir outputToJson --loglevel error --codecoverage`
+      );
+    });
+  });
+
+  describe('Command builder - Test Method with WAit', () => {
+    const testMethod = 'MyTests.testMe';
+    const outputToJson = 'outputToJson';
+    const waitTime = 8;
+    const builder = new ForceApexTestRunCodeActionExecutor(
+      testMethod,
+      false,
+      outputToJson,
+      waitTime
+    );
+
+    it('Should build command for single test method with wait', () => {
+      const command = builder.build({});
+
+      expect(command.toCommand()).to.equal(
+        `sfdx force:apex:test:run --tests ${testMethod} --resultformat human --outputdir outputToJson --loglevel error --wait 8`
+      );
+    });
+  });
+
+  describe('Command builder - Test Method with Coverage with wait', () => {
+    const testMethod = 'MyTests.testMe';
+    const outputToJson = 'outputToJson';
+    const waitTime = 9;
+    const builder = new ForceApexTestRunCodeActionExecutor(
+      testMethod,
+      true,
+      outputToJson,
+      waitTime
+    );
+
+    it('Should build command for single test method with code coverage with wait', () => {
+      const command = builder.build({});
+
+      expect(command.toCommand()).to.equal(
+        `sfdx force:apex:test:run --tests ${testMethod} --resultformat human --outputdir outputToJson --loglevel error --wait 9 --codecoverage`
       );
     });
   });

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/views/readableApexTestRunExecutor.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/views/readableApexTestRunExecutor.test.ts
@@ -12,10 +12,12 @@ describe('Apex Test Run - Sidebar', () => {
   describe('Command builder - Test Class', () => {
     const testClass = ['MyTests'];
     const outputToJson = 'outputToJson';
+    const waitTime = 0;
     const builder = new ReadableApexTestRunExecutor(
       testClass,
       false,
-      outputToJson
+      outputToJson,
+      waitTime
     );
 
     it('Should build command for single test class', () => {
@@ -30,10 +32,12 @@ describe('Apex Test Run - Sidebar', () => {
   describe('Command builder - Test Class with Coverage', () => {
     const testClass = ['MyTests'];
     const outputToJson = 'outputToJson';
+    const waitTime = 0;
     const builder = new ReadableApexTestRunExecutor(
       testClass,
       true,
-      outputToJson
+      outputToJson,
+      waitTime
     );
 
     it('Should build command for single test class with code coverage', () => {
@@ -48,10 +52,12 @@ describe('Apex Test Run - Sidebar', () => {
   describe('Command builder - Test Method', () => {
     const testMethod = ['MyTests.testMe'];
     const outputToJson = 'outputToJson';
+    const waitTime = 0;
     const builder = new ReadableApexTestRunExecutor(
       testMethod,
       false,
-      outputToJson
+      outputToJson,
+      waitTime
     );
 
     it('Should build command for single test method', () => {
@@ -66,10 +72,12 @@ describe('Apex Test Run - Sidebar', () => {
   describe('Command builder - Test Method with Coverage', () => {
     const testMethod = ['MyTests.testMe'];
     const outputToJson = 'outputToJson';
+    const waitTime = 0;
     const builder = new ReadableApexTestRunExecutor(
       testMethod,
       true,
-      outputToJson
+      outputToJson,
+      waitTime
     );
 
     it('Should build command for single test method with code coverage', () => {
@@ -77,6 +85,46 @@ describe('Apex Test Run - Sidebar', () => {
 
       expect(command.toCommand()).to.equal(
         `sfdx force:apex:test:run --tests ${testMethod} --resultformat human --outputdir outputToJson --loglevel error --codecoverage`
+      );
+    });
+  });
+
+  describe('Command builder - Test Class With Wait', () => {
+    const testClass = ['MyTests'];
+    const outputToJson = 'outputToJson';
+    const waitTime = 4;
+    const builder = new ReadableApexTestRunExecutor(
+      testClass,
+      false,
+      outputToJson,
+      waitTime
+    );
+
+    it('Should build command for single test class with wait', () => {
+      const command = builder.build({});
+
+      expect(command.toCommand()).to.equal(
+        `sfdx force:apex:test:run --tests ${testClass} --resultformat human --outputdir outputToJson --loglevel error --wait 4`
+      );
+    });
+  });
+
+  describe('Command builder - Test Class with Coverage and Wait', () => {
+    const testClass = ['MyTests'];
+    const outputToJson = 'outputToJson';
+    const waitTime = 7;
+    const builder = new ReadableApexTestRunExecutor(
+      testClass,
+      true,
+      outputToJson,
+      waitTime
+    );
+
+    it('Should build command for single test class with code coverage and wait', () => {
+      const command = builder.build({});
+
+      expect(command.toCommand()).to.equal(
+        `sfdx force:apex:test:run --tests ${testClass} --resultformat human --outputdir outputToJson --loglevel error --wait 7 --codecoverage`
       );
     });
   });

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -766,6 +766,14 @@
           "default": false,
           "description": "%retrieve_test_code_coverage_text%"
         },
+        "salesforcedx-vscode-core.retrieve-test-wait-time": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "default": 0,
+          "description": "%retrieve_test_wait_time_text%"
+        },
         "salesforcedx-vscode-core.telemetry.enabled": {
           "type": "boolean",
           "default": true,

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -41,6 +41,7 @@
   "isv_bootstrap_command_text": "SFDX: Create and Set Up Project for ISV Debugging",
   "force_apex_log_get_text": "SFDX: Get Apex Debug Logs...",
   "retrieve_test_code_coverage_text": "Specifies whether code coverage results are calculated and retrieved when you run Apex tests.",
+  "retrieve_test_wait_time_text": "Sets the number of minutes to wait for the test execution to complete. (< 2 uses system default)",
   "telemetry_enabled_description": "Specifies whether to enable Salesforce telemetry. Even when enabled, still abides by the overall `telemetry.enableTelemetry` vscode setting.",
   "push_or_deploy_on_save_enabled_description": "Specifies whether or not to automatically run force:source:push (for source-tracked orgs) or force:source:deploy (for non-source-tracked orgs) when a local source file is saved.",
   "conflict_detection_enabled_description": "Specifies whether to enable conflict detection for metadata operations (force:source:deploy with manifest, force:source:retrieve with manifest) for non source-tracked orgs.",

--- a/packages/salesforcedx-vscode-core/src/commands/forceApexTestRun.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexTestRun.ts
@@ -90,15 +90,18 @@ export class ForceApexTestRunCommandFactory {
   private builder: SfdxCommandBuilder = new SfdxCommandBuilder();
   private testRunExecutorCommand!: Command;
   private outputToJson: string;
+  private waitTime: number;
 
   constructor(
     data: ApexTestQuickPickItem,
     getCodeCoverage: boolean,
-    outputToJson: string
+    outputToJson: string,
+    waitTime: number
   ) {
     this.data = data;
     this.getCodeCoverage = getCodeCoverage;
     this.outputToJson = outputToJson;
+    this.waitTime = waitTime;
   }
 
   public constructExecutorCommand(): Command {
@@ -133,6 +136,10 @@ export class ForceApexTestRunCommandFactory {
       .withFlag('--outputdir', this.outputToJson)
       .withFlag('--loglevel', 'error');
 
+    if (this.waitTime !== 0) {
+      this.builder = this.builder.withFlag('--wait', this.waitTime.toString());
+    }
+
     this.testRunExecutorCommand = this.builder.build();
     return this.testRunExecutorCommand;
   }
@@ -156,10 +163,12 @@ export class ForceApexTestRunExecutor extends SfdxCommandletExecutor<
   public build(data: ApexTestQuickPickItem): Command {
     const getCodeCoverage = sfdxCoreSettings.getRetrieveTestCodeCoverage();
     const outputToJson = getTempFolder();
+    const waitTime = sfdxCoreSettings.getRetrieveTestWaitTime();
     const factory: ForceApexTestRunCommandFactory = new ForceApexTestRunCommandFactory(
       data,
       getCodeCoverage,
-      outputToJson
+      outputToJson,
+      waitTime
     );
     return factory.constructExecutorCommand();
   }

--- a/packages/salesforcedx-vscode-core/src/constants.ts
+++ b/packages/salesforcedx-vscode-core/src/constants.ts
@@ -19,6 +19,7 @@ export const TELEMETRY_OPT_OUT_LINK =
   'https://forcedotcom.github.io/salesforcedx-vscode/articles/faq/telemetry';
 export const PUSH_OR_DEPLOY_ON_SAVE_ENABLED = 'push-or-deploy-on-save.enabled';
 export const RETRIEVE_TEST_CODE_COVERAGE = 'retrieve-test-code-coverage';
+export const RETRIEVE_TEST_WAIT_TIME = 'retrieve-test-wait-time';
 export const SFDX_CLI_DOWNLOAD_LINK =
   'https://developer.salesforce.com/tools/sfdxcli';
 export const DEFAULT_USERNAME_KEY = 'defaultusername';

--- a/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
@@ -12,6 +12,7 @@ import {
   INTERNAL_DEVELOPMENT_FLAG,
   PUSH_OR_DEPLOY_ON_SAVE_ENABLED,
   RETRIEVE_TEST_CODE_COVERAGE,
+  RETRIEVE_TEST_WAIT_TIME,
   SFDX_CORE_CONFIGURATION_NAME,
   SHOW_CLI_SUCCESS_INFO_MSG,
   TELEMETRY_ENABLED
@@ -60,6 +61,14 @@ export class SfdxCoreSettings {
 
   public getRetrieveTestCodeCoverage(): boolean {
     return this.getConfigValue(RETRIEVE_TEST_CODE_COVERAGE, false);
+  }
+
+  public getRetrieveTestWaitTime(): number {
+    // value can't be less than 2, so change to 0 which uses CLI defaults
+    if (this.getConfigValue(RETRIEVE_TEST_WAIT_TIME, 0) < 2) {
+      return 0;
+    }
+    return this.getConfigValue(RETRIEVE_TEST_WAIT_TIME, 0);
   }
 
   public getInternalDev(): boolean {


### PR DESCRIPTION
### What does this PR do?
Add support for the wait option on the force:apex:test:run cli command, when the force:apex:test:run command is invoked from the extension.

### What issues does this PR fix or reference?
#1823 

### Functionality Before
The default value for "--wait" was always used because no wait value was able to be specified for the force:apex:test:run command. 

### Functionality After
Provides a new feature setting to define the --wait value for the force:apex:test:run command.
If the value provided is less than 2, the value is ignored and the --wait option IS NOT added to the force:apex:test:run command.  If the value provided is 2 or greater, then the --wait option IS added to the force:apex:test:run command.  
