### PR TITLE
Fix for getting execution errors from the CLI

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/cli/commandOutput.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/commandOutput.ts
@@ -25,7 +25,7 @@ export class CommandOutput {
           if (data !== undefined && data.toString() === '0') {
             return resolve(this.stdoutBuffer);
           } else {
-            reject(this.stderrBuffer);
+            return reject(this.stderrBuffer || this.stdoutBuffer);
           }
         });
       }


### PR DESCRIPTION
### What does this PR do?
Makes sure we return error info from a CLI execution. Old versions of the CLI used to return error info in stdError but newer versions return it in stdOut.

### What issues does this PR fix or reference?
@W-7287990@, #2160 , #2005 
