### PR TITLE
Removing the issue creation for Feature label

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -25,7 +25,7 @@
     "area:xml": "a1aB0000000BPyKIAW"
   },
   "issueTypeLabels": {
-    "type:feature": "USER STORY",
+    "type:feature": "",
     "type:bug": "BUG P3",
     "type:security": "BUG P2",
     "type:feedback": "",


### PR DESCRIPTION
No longer created Gus issues for the 'type:feature' label.  These user stories will be crafted outside of GH.

### What does this PR do?
Remove the mapping for the 'type:feature' label so that it stops creating Gus User Stories

### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @<Insert GUS WI>@

### Functionality Before
User story created for the 'feature' label

### Functionality After
No Gus WI created for the 'feature' label
