### PR TITLE
Add guard for unsupported cli telemetry setting

### DIFF
--- a/contributing/telemetry.md
+++ b/contributing/telemetry.md
@@ -6,6 +6,8 @@ Similar to what vscode does, we are reporting on certain events that happen in t
 
 All extensions leverage the telemetryService in `salesforce-vscode-core` extension in order to send data. The service in `salesforce-vscode-core` is responsible for showing an information message to users and properly initializing the service for other extensions in this repository to leverage. Similar to VSCode, we provide the user an opt out mechanism. We check that user settings `telemetry.enableTelemetry` and `salesforcedx-vscode-core.telemetry.enabled` are enabled before initializing the service.
 
+Additionally, if telemetry is disabled for Salesforce CLI using the `disableTelemetry` configuration setting or the `SFDX_DISABLE_TELEMETRY` environment variable, the telemetryService doesn't send data.
+
 ## Adding telemetry to an extension
 
 - Add [vscode-extension-telemetry](https://github.com/Microsoft/vscode-extension-telemetry#readme) as a devDependency

--- a/packages/salesforcedx-vscode-core/src/util/cliConfiguration.ts
+++ b/packages/salesforcedx-vscode-core/src/util/cliConfiguration.ts
@@ -53,13 +53,18 @@ export function disableCLITelemetry() {
 export async function isCLITelemetryAllowed(
   projectPath: string
 ): Promise<boolean> {
-  // if (isCLIInstalled()) {
-  //   const forceConfig = await new ForceConfigGet().getConfig(
-  //     projectPath,
-  //     SFDX_CONFIG_DISABLE_TELEMETRY
-  //   );
-  //   const disabledConfig = forceConfig.get(SFDX_CONFIG_DISABLE_TELEMETRY) || '';
-  //   return disabledConfig !== 'true';
-  // }
+  if (isCLIInstalled()) {
+    try {
+      const forceConfig = await new ForceConfigGet().getConfig(
+        projectPath,
+        SFDX_CONFIG_DISABLE_TELEMETRY
+      );
+      const disabledConfig =
+        forceConfig.get(SFDX_CONFIG_DISABLE_TELEMETRY) || '';
+      return disabledConfig !== 'true';
+    } catch (e) {
+      console.log('Error checking cli settings: ' + e);
+    }
+  }
   return true;
 }

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/util/cliConfiguration.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/util/cliConfiguration.test.ts
@@ -105,7 +105,7 @@ describe('SFDX CLI Configuration utility', () => {
       expect(response).to.equal(true);
     });
 
-    it.skip('Should return false if telemetry setting is disabled', async () => {
+    it('Should return false if telemetry setting is disabled', async () => {
       whichStub.withArgs('sfdx').returns('Users/some/path/sfdx/cli');
 
       const config = new Map<string, string>();
@@ -116,7 +116,7 @@ describe('SFDX CLI Configuration utility', () => {
       expect(response).to.equal(false);
     });
 
-    it('Should return true if telementry setting is undefined', async () => {
+    it('Should return true if telemetry setting is undefined', async () => {
       whichStub.withArgs('sfdx').returns('Users/some/path/sfdx/cli');
       configGetSpy.returns(new Map<string, string>());
 
@@ -124,12 +124,21 @@ describe('SFDX CLI Configuration utility', () => {
       expect(response).to.equal(true);
     });
 
-    it('Should return true if telementry setting is enabled', async () => {
+    it('Should return true if telemetry setting is enabled', async () => {
       whichStub.withArgs('sfdx').returns('Users/some/path/sfdx/cli');
 
       const config = new Map<string, string>();
       config.set(SFDX_CONFIG_DISABLE_TELEMETRY, 'false');
       configGetSpy.returns(config);
+
+      const response = await isCLITelemetryAllowed('');
+      expect(response).to.equal(true);
+    });
+
+    it("Should return true if CLI doesn't support telemetry setting", async () => {
+      whichStub.withArgs('sfdx').returns('Users/some/path/sfdx/cli');
+
+      configGetSpy.throws('NoSetting');
 
       const response = await isCLITelemetryAllowed('');
       expect(response).to.equal(true);


### PR DESCRIPTION
### What does this PR do?
Guards the check for _disableTelemetry_, which is unsupported by earlier versions of Salesforce CLI

### What issues does this PR fix or reference?
@W-7605599@
