### PR TITLE
Add preference for completion statistics

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -269,7 +269,7 @@
           "default": false,
           "description": "%enable_sobject_refresh_on_startup_description%"
         },
-        "salesforcedx-vscode-apex.enable-completion-statistics": {
+        "salesforcedx-vscode-apex.advanced.enable-completion-statistics": {
           "type": "boolean",
           "default": false,
           "description": "%apex_completion_statistics_description%"

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -268,11 +268,6 @@
           "type": "boolean",
           "default": false,
           "description": "%enable_sobject_refresh_on_startup_description%"
-        },
-        "salesforcedx-vscode-apex.advanced.enable-completion-statistics": {
-          "type": "boolean",
-          "default": false,
-          "description": "%apex_completion_statistics_description%"
         }
       }
     },

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -268,6 +268,11 @@
           "type": "boolean",
           "default": false,
           "description": "%enable_sobject_refresh_on_startup_description%"
+        },
+        "salesforcedx-vscode-apex.enable-completion-statistics": {
+          "type": "boolean",
+          "default": false,
+          "description": "%apex_completion_statistics_description%"
         }
       }
     },

--- a/packages/salesforcedx-vscode-apex/package.nls.json
+++ b/packages/salesforcedx-vscode-apex/package.nls.json
@@ -8,7 +8,7 @@
   "show_error_title": "Display Error",
   "go_to_definition_title": "Go to Definition",
   "java_home_description": "Specifies the folder path to the Java 8 or Java 11 runtime used to launch the Apex Language Server (for example, /Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home).",
-  "java_memory_description": "Specifies the amount of memory allocation to the Apex Language Server in MB or null to use the default value.",
+  "java_memory_description": "Specifies the amount of memory allocation to the Apex Language Server in MB, or null to use the system default value.",
   "apex_semantic_errors_description": "Allow Apex Language Server to surface semantic errors",
   "apex_completion_statistics_description": "List statistics for Apex completions",
   "force_apex_test_last_class_run_text": "SFDX: Re-Run Last Run Apex Test Class",

--- a/packages/salesforcedx-vscode-apex/package.nls.json
+++ b/packages/salesforcedx-vscode-apex/package.nls.json
@@ -10,7 +10,7 @@
   "java_home_description": "Specifies the folder path to the Java 8 or Java 11 runtime used to launch the Apex Language Server (for example, /Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home).",
   "java_memory_description": "Specifies the amount of memory allocation to the Apex Language Server in MB or null to use the default value.",
   "apex_semantic_errors_description": "Allow Apex Language Server to surface semantic errors",
-  "apex_completion_statistics_description": "List statistics for Apex Completions",
+  "apex_completion_statistics_description": "List statistics for Apex completions",
   "force_apex_test_last_class_run_text": "SFDX: Re-Run Last Run Apex Test Class",
   "force_apex_test_last_method_run_text": "SFDX: Re-Run Last Run Apex Test Method",
   "force_apex_test_class_run_text": "SFDX: Run Apex Test Class",

--- a/packages/salesforcedx-vscode-apex/package.nls.json
+++ b/packages/salesforcedx-vscode-apex/package.nls.json
@@ -10,6 +10,7 @@
   "java_home_description": "Specifies the folder path to the Java 8 or Java 11 runtime used to launch the Apex Language Server (for example, /Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home).",
   "java_memory_description": "Specifies the amount of memory allocation to the Apex Language Server in MB or null to use the default value.",
   "apex_semantic_errors_description": "Allow Apex Language Server to surface semantic errors",
+  "apex_completion_statistics_description": "List statistics for Apex Completions",
   "force_apex_test_last_class_run_text": "SFDX: Re-Run Last Run Apex Test Class",
   "force_apex_test_last_method_run_text": "SFDX: Re-Run Last Run Apex Test Method",
   "force_apex_test_class_run_text": "SFDX: Run Apex Test Class",

--- a/packages/salesforcedx-vscode-apex/package.nls.json
+++ b/packages/salesforcedx-vscode-apex/package.nls.json
@@ -10,7 +10,6 @@
   "java_home_description": "Specifies the folder path to the Java 8 or Java 11 runtime used to launch the Apex Language Server (for example, /Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home).",
   "java_memory_description": "Specifies the amount of memory allocation to the Apex Language Server in MB, or null to use the system default value.",
   "apex_semantic_errors_description": "Allow Apex Language Server to surface semantic errors",
-  "apex_completion_statistics_description": "List statistics for Apex completions",
   "force_apex_test_last_class_run_text": "SFDX: Re-Run Last Run Apex Test Class",
   "force_apex_test_last_method_run_text": "SFDX: Re-Run Last Run Apex Test Method",
   "force_apex_test_class_run_text": "SFDX: Run Apex Test Class",

--- a/packages/salesforcedx-vscode-apex/src/languageServer.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageServer.ts
@@ -38,12 +38,16 @@ async function createServer(
     const enableSemanticErrors: boolean = vscode.workspace
       .getConfiguration()
       .get<boolean>('salesforcedx-vscode-apex.enable-semantic-errors', false);
+    const enableCompletionStatistics: boolean = vscode.workspace
+      .getConfiguration()
+      .get<boolean>('salesforcedx-vscode-apex.enable-completion-statistics', false);
 
     const args: string[] = [
       '-cp',
       uberJar,
       '-Ddebug.internal.errors=true',
-      `-Ddebug.semantic.errors=${enableSemanticErrors}`
+      `-Ddebug.semantic.errors=${enableSemanticErrors}`,
+      `-Ddebug.completion.statistics=${enableCompletionStatistics}`
     ];
 
     if (jvmMaxHeap) {

--- a/packages/salesforcedx-vscode-apex/src/languageServer.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageServer.ts
@@ -40,7 +40,10 @@ async function createServer(
       .get<boolean>('salesforcedx-vscode-apex.enable-semantic-errors', false);
     const enableCompletionStatistics: boolean = vscode.workspace
       .getConfiguration()
-      .get<boolean>('salesforcedx-vscode-apex.enable-completion-statistics', false);
+      .get<boolean>(
+        'salesforcedx-vscode-apex.advanced.enable-completion-statistics',
+        false
+      );
 
     const args: string[] = [
       '-cp',


### PR DESCRIPTION
### What does this PR do?
Adds a configurable preference to pass to the Apex LSP for printing completion statistics.

### To Enable
Add the following value to the settings.json:
`"salesforcedx-vscode-apex.advanced.enable-completion-statistics": "true"`

### What issues does this PR fix or reference?
@W-7637588@
