### PR TITLE
Open LWC preview component using the new path and correct port @W-7665177@

### DIFF
--- a/docs/_articles/en/user-guide/vscode-commands.md
+++ b/docs/_articles/en/user-guide/vscode-commands.md
@@ -179,6 +179,9 @@ Read on to learn about the commands available in Salesforce Extension for VS Cod
 - **SFDX: Create Aura Interface**
   - Creates an Aura interface with the specified name in the default directory `force-app/main/default/aura`.
   - Executes the CLI command `force:lightning:interface:create`
+- **SFDX: Create Lightning Web Component Test**
+  - Creates a test for the specified Lightning web component.
+  - Executes the CLI command `force:lightning:lwc:test:create`
 
 ### Visualforce
 

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -458,6 +458,10 @@
           "when": "sfdx:project_opened"
         },
         {
+          "command": "sfdx.force.lightning.lwc.test.create",
+          "when": "sfdx:project_opened"
+        },
+        {
           "command": "sfdx.internal.lightning.lwc.create",
           "when": "false"
         },
@@ -711,6 +715,10 @@
       {
         "command": "sfdx.force.lightning.lwc.create",
         "title": "%force_lightning_lwc_create_text%"
+      },
+      {
+        "command": "sfdx.force.lightning.lwc.test.create",
+        "title": "%force_lightning_lwc_test_create_text%"
       },
       {
         "command": "sfdx.internal.lightning.lwc.create",

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -20,6 +20,7 @@
   "force_lightning_event_create_text": "SFDX: Create Aura Event",
   "force_lightning_interface_create_text": "SFDX: Create Aura Interface",
   "force_lightning_lwc_create_text": "SFDX: Create Lightning Web Component",
+  "force_lightning_lwc_test_create_text": "SFDX: Create Lightning Web Component Test",
   "force_source_status_local_text": "SFDX: View Local Changes",
   "force_source_status_remote_text": "SFDX: View Changes in Default Scratch Org",
   "force_debugger_stop_text": "SFDX: Stop Apex Debugger Session",

--- a/packages/salesforcedx-vscode-core/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/index.ts
@@ -37,6 +37,7 @@ export {
   forceLightningEventCreate,
   forceLightningInterfaceCreate,
   forceLightningLwcCreate,
+  forceLightningLwcTestCreate,
   forceVisualforceComponentCreate,
   forceVisualforcePageCreate
 } from './templates';

--- a/packages/salesforcedx-vscode-core/src/commands/templates/forceLightningLwcTestCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/forceLightningLwcTestCreate.ts
@@ -1,0 +1,58 @@
+import {
+  Command,
+  SfdxCommandBuilder
+} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import { DirFileNameSelection } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
+import { LocalComponent } from '@salesforce/salesforcedx-utils-vscode/src/types';
+import * as path from 'path';
+import { nls } from '../../messages';
+import { getRootWorkspacePath } from '../../util';
+import {
+  CompositeParametersGatherer,
+  PathStrategyFactory,
+  SfdxCommandlet,
+  SfdxWorkspaceChecker,
+  SourcePathStrategy
+} from '../util';
+import { MetadataTypeGatherer } from '../util';
+import { SelectLwcComponentDir } from '../util/parameterGatherers';
+import { OverwriteComponentPrompt } from '../util/postconditionCheckers';
+import { BaseTemplateCommand } from './baseTemplateCommand';
+import { LWC_DIRECTORY, LWC_TYPE } from './metadataTypeConstants';
+
+export class ForceLightningLwcTestCreateExecutor extends BaseTemplateCommand {
+  constructor() {
+    super(LWC_TYPE);
+  }
+
+  public build(data: DirFileNameSelection): Command {
+    const builder = new SfdxCommandBuilder()
+      .withDescription(nls.localize('force_lightning_lwc_test_create_text'))
+      .withArg('force:lightning:lwc:test:create')
+      .withFlag(
+        '--filepath',
+        path.join(getRootWorkspacePath(), data.outputdir, data.fileName + '.js')
+      )
+      .withLogName('force_lightning_web_component_test_create');
+    return builder.build();
+  }
+
+  public getSourcePathStrategy(): SourcePathStrategy {
+    return PathStrategyFactory.createLwcTestStrategy();
+  }
+}
+
+const filePathGatherer = new SelectLwcComponentDir();
+const metadataTypeGatherer = new MetadataTypeGatherer(LWC_TYPE);
+export async function forceLightningLwcTestCreate() {
+  const commandlet = new SfdxCommandlet(
+    new SfdxWorkspaceChecker(),
+    new CompositeParametersGatherer<LocalComponent>(
+      metadataTypeGatherer,
+      filePathGatherer
+    ),
+    new ForceLightningLwcTestCreateExecutor(),
+    new OverwriteComponentPrompt()
+  );
+  await commandlet.run();
+}

--- a/packages/salesforcedx-vscode-core/src/commands/templates/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/index.ts
@@ -2,6 +2,7 @@ export {
   forceLightningLwcCreate,
   forceInternalLightningLwcCreate
 } from './forceLightningLwcCreate';
+export { forceLightningLwcTestCreate } from './forceLightningLwcTestCreate';
 export {
   forceLightningAppCreate,
   forceInternalLightningAppCreate

--- a/packages/salesforcedx-vscode-core/src/commands/util/sourcePathStrategies.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/sourcePathStrategies.ts
@@ -38,6 +38,16 @@ class WaveTemplateBundlePathStrategy implements SourcePathStrategy {
   }
 }
 
+class LwcTestPathStrategy implements SourcePathStrategy {
+  public getPathToSource(
+    dirPath: string,
+    fileName: string,
+    fileExt: string
+  ): string {
+    return join(dirPath, '__tests__', `${fileName}.test${fileExt}`);
+  }
+}
+
 export interface SourcePathStrategy {
   getPathToSource(dirPath: string, fileName: string, fileExt: string): string;
 }
@@ -45,6 +55,10 @@ export interface SourcePathStrategy {
 export class PathStrategyFactory {
   public static createDefaultStrategy(): DefaultPathStrategy {
     return new DefaultPathStrategy();
+  }
+
+  public static createLwcTestStrategy(): LwcTestPathStrategy {
+    return new LwcTestPathStrategy();
   }
 
   public static createBundleStrategy(): BundlePathStrategy {

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -31,6 +31,7 @@ import {
   forceLightningEventCreate,
   forceLightningInterfaceCreate,
   forceLightningLwcCreate,
+  forceLightningLwcTestCreate,
   forceOrgCreate,
   forceOrgDisplay,
   forceOrgOpen,
@@ -228,6 +229,11 @@ function registerCommands(
     forceLightningLwcCreate
   );
 
+  const forceLightningLwcTestCreateCmd = vscode.commands.registerCommand(
+    'sfdx.force.lightning.lwc.test.create',
+    forceLightningLwcTestCreate
+  );
+
   const forceDebuggerStopCmd = vscode.commands.registerCommand(
     'sfdx.force.debugger.stop',
     forceDebuggerStop
@@ -350,6 +356,7 @@ function registerCommands(
     forceLightningEventCreateCmd,
     forceLightningInterfaceCreateCmd,
     forceLightningLwcCreateCmd,
+    forceLightningLwcTestCreateCmd,
     forceSourceStatusLocalCmd,
     forceSourceStatusRemoteCmd,
     forceDebuggerStopCmd,

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -52,6 +52,8 @@ export const messages = {
   parameter_gatherer_enter_file_name: 'Enter desired filename',
   parameter_gatherer_enter_dir_name:
     'Enter desired directory (Press Enter to confirm or Esc to cancel)',
+  parameter_gatherer_enter_lwc_name:
+    'Enter desired Lightning Web Component (Press Enter to confirm or Esc to cancel)',
   parameter_gatherer_enter_username_name: 'Enter target username',
   parameter_gatherer_enter_alias_name:
     'Enter an org alias or use the default alias',
@@ -278,6 +280,8 @@ export const messages = {
   aura_bundle_message_name: 'Aura Bundle',
   lwc_message_name: 'Lightning Web Component',
   force_lightning_lwc_create_text: 'SFDX: Create Lightning Web Component',
+  force_lightning_lwc_test_create_text:
+    'SFDX: Create Lightning Web Component Test',
   empty_components: 'No components available',
   error_auth_token: 'Error refreshing authentication token.',
   error_no_org_found: 'No org authorization info found.',

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceLightningLWCCreateTest.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceLightningLWCCreateTest.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from 'chai';
+import * as path from 'path';
+import { SinonStub, stub } from 'sinon';
+import { ForceLightningLwcTestCreateExecutor } from '../../../../src/commands/templates/forceLightningLwcTestCreate';
+import { nls } from '../../../../src/messages';
+import { SfdxCoreSettings } from '../../../../src/settings/sfdxCoreSettings';
+import { getRootWorkspacePath } from '../../../../src/util';
+
+describe('Force Lightning Web Component Test Create', () => {
+  it('Should build the Lightning Web Component Test create command', async () => {
+    const lightningLWCTestCreate = new ForceLightningLwcTestCreateExecutor();
+    const outputDirPath = path.join('force-app', 'main', 'default', 'lwc');
+    const fileName = 'testing';
+    const lwcCreateTestCommand = lightningLWCTestCreate.build({
+      fileName,
+      outputdir: path.join(outputDirPath, 'testing')
+    });
+    const fullFilepath = path.join(
+      getRootWorkspacePath(),
+      outputDirPath,
+      'testing',
+      fileName + '.js'
+    );
+
+    if (fullFilepath) {
+      expect(lwcCreateTestCommand.toCommand()).to.equal(
+        `sfdx force:lightning:lwc:test:create --filepath ${fullFilepath}`
+      );
+      expect(lwcCreateTestCommand.description).to.equal(
+        nls.localize('force_lightning_lwc_test_create_text')
+      );
+      expect(lightningLWCTestCreate.getDefaultDirectory()).to.equal('lwc');
+      expect(lightningLWCTestCreate.getFileExtension()).to.equal('.js');
+      expect(
+        lightningLWCTestCreate
+          .getSourcePathStrategy()
+          .getPathToSource(path.join(outputDirPath, 'testing'), fileName, '.js')
+      ).to.equal(
+        path.join(outputDirPath, fileName, '__tests__', `${fileName}.test.js`)
+      );
+    }
+  });
+});

--- a/packages/salesforcedx-vscode-lwc/src/commands/commandConstants.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/commandConstants.ts
@@ -6,4 +6,5 @@
  */
 
 export const DEV_SERVER_BASE_URL = 'http://localhost:3333';
-export const DEV_SERVER_PREVIEW_ROUTE = `${DEV_SERVER_BASE_URL}/lwc/preview`;
+export const DEV_SERVER_PREVIEW_ROUTE = 'preview';
+export const SERVER_INFO_REGEX = '(http://localhost):(d*)/?(.*)';

--- a/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcOpen.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcOpen.ts
@@ -8,7 +8,6 @@
 import * as vscode from 'vscode';
 import { nls } from '../messages';
 import { DevServerService } from '../service/devServerService';
-import { DEV_SERVER_BASE_URL } from './commandConstants';
 import { openBrowser, showError } from './commandUtils';
 
 const sfdxCoreExports = vscode.extensions.getExtension(
@@ -24,7 +23,7 @@ export async function forceLightningLwcOpen() {
 
   if (DevServerService.instance.isServerHandlerRegistered()) {
     try {
-      await openBrowser(DEV_SERVER_BASE_URL);
+      await openBrowser(DevServerService.instance.getBaseUrl());
       telemetryService.sendCommandEvent(logName, startTime);
     } catch (e) {
       showError(e, logName, commandName);

--- a/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcPreview.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcPreview.ts
@@ -145,7 +145,7 @@ export async function forceLightningLwcPreview(sourceUri: vscode.Uri) {
   const fullUrl = `${DEV_SERVER_PREVIEW_ROUTE}/${componentName}`;
   // Preform existing desktop behavior if mobile is not enabled.
   if (!isMobileEnabled()) {
-    await startServer(true, fullUrl, startTime);
+    await startServer(true, componentName, startTime);
     return;
   }
 
@@ -161,7 +161,7 @@ export async function forceLightningLwcPreview(sourceUri: vscode.Uri) {
  */
 async function startServer(
   isDesktop: boolean,
-  fullUrl: string,
+  componentName: string,
   startTime: [number, number]
 ) {
   if (!DevServerService.instance.isServerHandlerRegistered()) {
@@ -170,7 +170,7 @@ async function startServer(
     const parameterGatherer = new EmptyParametersGatherer();
     const executor = new ForceLightningLwcStartExecutor({
       openBrowser: isDesktop,
-      fullUrl
+      componentName
     });
 
     const commandlet = new SfdxCommandlet(
@@ -183,6 +183,7 @@ async function startServer(
     telemetryService.sendCommandEvent(logName, startTime);
   } else if (isDesktop) {
     try {
+      const fullUrl = `${DevServerService.instance.getBaseUrl()}/${DEV_SERVER_PREVIEW_ROUTE}/${componentName}`;
       await openBrowser(fullUrl);
       telemetryService.sendCommandEvent(logName, startTime);
     } catch (e) {
@@ -195,12 +196,10 @@ async function startServer(
  * Prompts the user to select a platform to preview the LWC on. Android and iOS
  * are handled by the @salesforce/lwc-dev-mobile sfdx package.
  *
- * @param fullUrl lwc url
  * @param startTime start time of the preview command
  * @param componentName name of the lwc
  */
 async function selectPlatformAndExecute(
-  fullUrl: string,
   startTime: [number, number],
   componentName: string
 ) {
@@ -216,7 +215,7 @@ async function selectPlatformAndExecute(
 
   const isDesktop = platformSelection.id === PreviewPlatformType.Desktop;
   if (isDesktop) {
-    await startServer(true, fullUrl, startTime);
+    await startServer(true, componentName, startTime);
     return;
   }
 
@@ -251,7 +250,7 @@ async function selectPlatformAndExecute(
     );
     return;
   }
-  await startServer(false, fullUrl, startTime);
+  await startServer(false, componentName, startTime);
 
   // New target device entered
   if (targetName !== '') {

--- a/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcPreview.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcPreview.ts
@@ -149,7 +149,7 @@ export async function forceLightningLwcPreview(sourceUri: vscode.Uri) {
     return;
   }
 
-  await selectPlatformAndExecute(fullUrl, startTime, componentName);
+  await selectPlatformAndExecute(startTime, componentName);
 }
 
 /**

--- a/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcStart.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcStart.ts
@@ -122,7 +122,9 @@ export class ForceLightningLwcStartExecutor extends SfdxCommandletExecutor<{}> {
           .match('(https?://localhost):(d*)/?(.*)')![0];
 
         if (this.options.openBrowser) {
-          await openBrowser(this.options.fullUrl || DEV_SERVER_BASE_URL);
+          await openBrowser(
+            urlFromResponse || this.options.fullUrl || DEV_SERVER_BASE_URL
+          );
         }
 
         this.logMetric(execution.command.logName, startTime);

--- a/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcStart.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcStart.ts
@@ -15,7 +15,10 @@ import { Subject } from 'rxjs/Subject';
 import * as vscode from 'vscode';
 import { nls } from '../messages';
 import { DevServerService, ServerHandler } from '../service/devServerService';
-import { DEV_SERVER_BASE_URL } from './commandConstants';
+import {
+  DEV_SERVER_PREVIEW_ROUTE,
+  SERVER_INFO_REGEX
+} from './commandConstants';
 import { openBrowser, showError } from './commandUtils';
 
 const sfdxCoreExports = vscode.extensions.getExtension(
@@ -49,7 +52,7 @@ export interface ForceLightningLwcStartOptions {
   /** whether to automatically open the browser after server start */
   openBrowser: boolean;
   /** complete url of the page to open in the browser */
-  fullUrl?: string;
+  componentName?: string;
 }
 
 export class ForceLightningLwcStartExecutor extends SfdxCommandletExecutor<{}> {
@@ -117,13 +120,20 @@ export class ForceLightningLwcStartExecutor extends SfdxCommandletExecutor<{}> {
         progress.complete();
         taskViewService.removeTask(task);
         notificationService.showSuccessfulExecution(executionName);
-        const urlFromResponse = data!
-          .toString()!
-          .match('(https?://localhost):(d*)/?(.*)')![0];
+
+        if (data!.toString()!.match(SERVER_INFO_REGEX)) {
+          DevServerService.instance.setBaseUrl(
+            data!.toString()!.match(SERVER_INFO_REGEX)![0]
+          );
+        }
 
         if (this.options.openBrowser) {
           await openBrowser(
-            urlFromResponse || this.options.fullUrl || DEV_SERVER_BASE_URL
+            this.options.componentName
+              ? `${DevServerService.instance.getBaseUrl()}/${DEV_SERVER_PREVIEW_ROUTE}/${
+                  this.options.componentName
+                }`
+              : DevServerService.instance.getBaseUrl()
           );
         }
 
@@ -228,7 +238,7 @@ export async function forceLightningLwcStart() {
       restartOption
     );
     if (response === openBrowserOption) {
-      await openBrowser(DEV_SERVER_BASE_URL);
+      await openBrowser(DevServerService.instance.getBaseUrl());
       return;
     } else if (response === restartOption) {
       channelService.appendLine(

--- a/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcStart.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcStart.ts
@@ -117,6 +117,9 @@ export class ForceLightningLwcStartExecutor extends SfdxCommandletExecutor<{}> {
         progress.complete();
         taskViewService.removeTask(task);
         notificationService.showSuccessfulExecution(executionName);
+        const urlFromResponse = data!
+          .toString()!
+          .match('(https?://localhost):(d*)/?(.*)')![0];
 
         if (this.options.openBrowser) {
           await openBrowser(this.options.fullUrl || DEV_SERVER_BASE_URL);

--- a/packages/salesforcedx-vscode-lwc/src/service/devServerService.ts
+++ b/packages/salesforcedx-vscode-lwc/src/service/devServerService.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
+import { DEV_SERVER_BASE_URL } from '../commands/commandConstants';
 export interface ServerHandler {
   stop(): Promise<void>;
 }
@@ -20,6 +20,7 @@ export class DevServerService {
   }
 
   private handlers: Set<ServerHandler> = new Set();
+  private baseUrl: string = DEV_SERVER_BASE_URL;
 
   public isServerHandlerRegistered() {
     return this.handlers.size > 0;
@@ -48,5 +49,13 @@ export class DevServerService {
     } else {
       console.log('lwc dev server was not running');
     }
+  }
+
+  public getBaseUrl(): string {
+    return this.baseUrl;
+  }
+
+  public setBaseUrl(url: string) {
+    this.baseUrl = url;
   }
 }

--- a/packages/salesforcedx-vscode-lwc/test/unit/commands/commandConstants.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/unit/commands/commandConstants.test.ts
@@ -10,10 +10,4 @@ describe('force:lightning:lwc:start constants', () => {
       expect(DEV_SERVER_BASE_URL).to.include('localhost');
     });
   });
-
-  describe('preview route', () => {
-    it('should include the base url', async () => {
-      expect(DEV_SERVER_PREVIEW_ROUTE).to.include(DEV_SERVER_BASE_URL);
-    });
-  });
 });

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcOpen.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcOpen.test.ts
@@ -31,6 +31,7 @@ describe('forceLightningLwcOpen', () => {
 
   it('calls openBrowser when a server is already running', async () => {
     devServiceStub.isServerHandlerRegistered.returns(true);
+    devServiceStub.getBaseUrl.returns(DEV_SERVER_BASE_URL);
 
     await forceLightningLwcOpen();
 

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcPreview.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcPreview.test.ts
@@ -22,7 +22,10 @@ import * as sinon from 'sinon';
 import { SinonSandbox, SinonStub } from 'sinon';
 import * as vscode from 'vscode';
 import URI from 'vscode-uri';
-import { DEV_SERVER_PREVIEW_ROUTE } from '../../../src/commands/commandConstants';
+import {
+  DEV_SERVER_PREVIEW_ROUTE,
+  DEV_SERVER_BASE_URL
+} from '../../../src/commands/commandConstants';
 import * as commandUtils from '../../../src/commands/commandUtils';
 import {
   forceLightningLwcPreview,
@@ -288,6 +291,8 @@ describe('forceLightningLwcPreview', () => {
   it('calls openBrowser with the correct url for files', async () => {
     getConfigurationStub.returns(new MockWorkspace(false, false));
     devServiceStub.isServerHandlerRegistered.returns(true);
+    devServiceStub.getBaseUrl.returns(DEV_SERVER_BASE_URL);
+    const sourceUri = URI.file(mockLwcFilePath);
     mockFileExists(mockLwcFilePath);
 
     existsSyncStub.returns(true);
@@ -302,7 +307,7 @@ describe('forceLightningLwcPreview', () => {
     sinon.assert.calledOnce(openBrowserStub);
     sinon.assert.calledWith(
       openBrowserStub,
-      sinon.match(`${DEV_SERVER_PREVIEW_ROUTE}/c/foo`)
+      sinon.match(`${DEV_SERVER_BASE_URL}/${DEV_SERVER_PREVIEW_ROUTE}/c/foo`)
     );
   });
 

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcStart.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcStart.test.ts
@@ -227,10 +227,15 @@ describe('forceLightningLwcStart', () => {
         const executor = new ForceLightningLwcStartExecutor();
         const fakeExecution = new FakeExecution(executor.build());
         cliCommandExecutorStub.returns(fakeExecution);
+        devServiceStub.getBaseUrl.returns('http://localhost:3333');
 
         executor.execute({ type: 'CONTINUE', data: {} });
-        fakeExecution.stdoutSubject.next('Server up');
+        fakeExecution.stdoutSubject.next('Server up http://localhost:3333');
 
+        sinon.assert.calledWith(
+          devServiceStub.setBaseUrl,
+          sinon.match('http://localhost:3333')
+        );
         sinon.assert.calledOnce(openBrowserStub);
         sinon.assert.calledWith(
           openBrowserStub,
@@ -242,16 +247,43 @@ describe('forceLightningLwcStart', () => {
         const executor = new ForceLightningLwcStartExecutor();
         const fakeExecution = new FakeExecution(executor.build());
         cliCommandExecutorStub.returns(fakeExecution);
+        devServiceStub.getBaseUrl.returns('http://localhost:3332');
 
         executor.execute({ type: 'CONTINUE', data: {} });
         fakeExecution.stdoutSubject.next(
           'Some details here\n Server up on http://localhost:3332 something\n More details here'
         );
 
+        sinon.assert.calledWith(
+          devServiceStub.setBaseUrl,
+          sinon.match('http://localhost:3332')
+        );
         sinon.assert.calledOnce(openBrowserStub);
         sinon.assert.calledWith(
           openBrowserStub,
           sinon.match('http://localhost:3332')
+        );
+      });
+
+      it('opens the browser with default url when Server up message contains no url', () => {
+        const executor = new ForceLightningLwcStartExecutor();
+        const fakeExecution = new FakeExecution(executor.build());
+        cliCommandExecutorStub.returns(fakeExecution);
+        devServiceStub.getBaseUrl.returns(DEV_SERVER_BASE_URL);
+
+        executor.execute({ type: 'CONTINUE', data: {} });
+        fakeExecution.stdoutSubject.next(
+          'Some details here\n Server up on -no valid url here- \n More details here'
+        );
+
+        sinon.assert.neverCalledWith(
+          devServiceStub.setBaseUrl,
+          sinon.match('http://localhost:3333')
+        );
+        sinon.assert.calledOnce(openBrowserStub);
+        sinon.assert.calledWith(
+          openBrowserStub,
+          sinon.match('http://localhost:3333')
         );
       });
 

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcStart.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcStart.test.ts
@@ -238,6 +238,23 @@ describe('forceLightningLwcStart', () => {
         );
       });
 
+      it('opens the browser at the correct port once server is started', () => {
+        const executor = new ForceLightningLwcStartExecutor();
+        const fakeExecution = new FakeExecution(executor.build());
+        cliCommandExecutorStub.returns(fakeExecution);
+
+        executor.execute({ type: 'CONTINUE', data: {} });
+        fakeExecution.stdoutSubject.next(
+          'Some details here\n Server up on http://localhost:3332 something\n More details here'
+        );
+
+        sinon.assert.calledOnce(openBrowserStub);
+        sinon.assert.calledWith(
+          openBrowserStub,
+          sinon.match('http://localhost:3332')
+        );
+      });
+
       it('shows an error when the plugin is not installed', () => {
         const executor = new ForceLightningLwcStartExecutor();
         const fakeExecution = new FakeExecution(executor.build());


### PR DESCRIPTION
### What does this PR do?
Open LWC preview component using the new path and correct port.
Start Server at the correct port by parsing the Server response.

### What issues does this PR fix or reference?
@W-7665177@

### Functionality Before
Preview used to open in url like http://localhost:3333/lwc/preview/c/hello
Always defaulted to port 3333 - for both preview and server start.

### Functionality After
Preview used to open in url like http://localhost:3333/preview/c/hello
Both preview and server start open browser in the correct port.
