### PR TITLE
Release v48.20.0 - Set vscode devDependencies to 1.1.36

### DIFF
--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -42,7 +42,7 @@
     "cross-env": "5.2.0",
     "mocha": "^5",
     "sinon": "^7.3.1",
-    "vscode": "^1.1.36"
+    "vscode": "1.1.36"
   },
   "extensionDependencies": [
     "salesforce.salesforcedx-vscode-apex",


### PR DESCRIPTION
### What does this PR do?
Set salesforcedx-vscode-apex-replay-debugger vscode devDependencies to 1.1.36