### PR TITLE
Migrate to vscode-test

### DIFF
--- a/contributing/tests.md
+++ b/contributing/tests.md
@@ -118,12 +118,12 @@ such as .npmignore and .vscodeignore)
 
 There are some optional environment variables to configure the test runner:
 
-| Name                   | Description                                                                                    |
-| ---------------------- | ---------------------------------------------------------------------------------------------- |
-| `CODE_VERSION`         | Version of VS Code to run the tests against (e.g. `0.10.10`)                                   |
-| `CODE_TESTS_PATH`      | Location of the tests to execute (default is `process.cwd()/out/test` or `process.cwd()/test`) |
-| `CODE_EXTENSIONS_PATH` | Location of the extensions to load (default is `proces.cwd()`)                                 |
-| `CODE_TESTS_WORKSPACE` | Location of a workspace to open for the test instance (default is CODE_TESTS_PATH)             |
+| Name                   | Description                                                  |
+| ---------------------- | ------------------------------------------------------------ |
+| `CODE_VERSION`         | Version of VS Code to run the tests against (e.g. `0.10.10`) |
+| `CODE_TESTS_PATH`      | Location of the tests to execute                             |
+| `CODE_EXTENSIONS_PATH` | Location of the extensions to load                           |
+| `CODE_TESTS_WORKSPACE` | Location of a workspace to open for the test instance        |
 
 If you are running this from the top-level root folder, you can issue `npm run test:without-system-tests`.
 
@@ -132,8 +132,8 @@ See VS Code's doc
 for more information.
 
 See this
-[repository](https://github.com/Microsoft/vscode-extension-vscode/blob/master/bin/test)
-for the actual vscode/bin/test source.
+[repository](https://github.com/microsoft/vscode-test)
+for the actual `vscode-test` source.
 
 ### Running the tests against VS Code Insiders
 
@@ -146,16 +146,16 @@ There are tests that require integration with the Salesforce server. These tests
 require prior authentication to have occurred and a default devhub to be set.
 These show up in several packages. These tests are put under test/integration
 and named in the standard .test.ts pattern. The package.json should have an
-entry like `"test:integration": "node ./node_modules/vscode/bin/test/integration"`.
+entry like `"test:integration": "cross-env VSCODE_NLS_CONFIG={} ./node_modules/nyc/bin/nyc.js ./node_modules/mocha/bin/_mocha --recursive out/test/integration"`.
 
 These can be run in the same way from the CLI using `npm run test:integration`.
 Running `npm run test` will also run these.
 
 ## Unit Tests
 
-A module can also have an entry like `"test:unit": "node ./node_modules/vscode/bin/test/unit"`. This is used for pure unit tests and for
-VS Code based tests discussed above. It is a good pattern to have an entry of
-`"test:unit": "node ./node_modules/vscode/bin/test"` in the package.json for
+A module can also have an entry like `"test:unit": "node ./node_modules/nyc/bin/nyc.js ./node_modules/mocha/bin/_mocha --recursive out/test/unit"`.
+This is used for pure unit tests and for VS Code based tests discussed above.
+It is a good pattern to have an entry of `"test:unit"` in the package.json for
 modules that don't have separate integration tests.
 
 These can be run using `npm run test:unit` for quick testing that doesn't

--- a/contributing/tests.md
+++ b/contributing/tests.md
@@ -121,7 +121,6 @@ There are some optional environment variables to configure the test runner:
 | Name                   | Description                                                                                    |
 | ---------------------- | ---------------------------------------------------------------------------------------------- |
 | `CODE_VERSION`         | Version of VS Code to run the tests against (e.g. `0.10.10`)                                   |
-| `CODE_DOWNLOAD_URL`    | Full URL of a VS Code drop to use for running tests against                                    |
 | `CODE_TESTS_PATH`      | Location of the tests to execute (default is `process.cwd()/out/test` or `process.cwd()/test`) |
 | `CODE_EXTENSIONS_PATH` | Location of the extensions to load (default is `proces.cwd()`)                                 |
 | `CODE_TESTS_WORKSPACE` | Location of a workspace to open for the test instance (default is CODE_TESTS_PATH)             |

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "tslint": "5.5.0",
     "typescript": "3.1.6",
     "vsce": "1.62.0",
-    "vscode-test": "^1.3.0",
+    "vscode-test": "^1.4.0",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.5"
   },

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -57,7 +57,6 @@
     "ts-sinon": "^1.0.25",
     "typescript": "3.1.6",
     "vscode": "^1.1.36",
-    "vscode-test": "^1.3.0",
     "vscode-uri": "^1.0.8"
   },
   "extensionDependencies": [

--- a/scripts/run-tests-with-recipes.js
+++ b/scripts/run-tests-with-recipes.js
@@ -1,36 +1,18 @@
 #!/usr/bin/env node
 
 const path = require('path');
-const { runTests } = require('vscode-test');
+const { runIntegrationTests } = require('./vscode-integration-testrunner');
 
-function main() {
-  try {
-    const cwd = process.cwd();
-    const extensionDevelopmentPath = path.join(__dirname, '..', 'packages');
-    const testWorkspace = path.join(
-      __dirname,
-      '..',
-      'packages',
-      'system-tests',
-      'assets',
-      'lwc-recipes'
-    );
-    const extensionTestsPath = path.join(
-      cwd,
-      'out',
-      'test',
-      'vscode-integration'
-    );
-    runTests({
-      extensionDevelopmentPath,
-      extensionTestsPath,
-      launchArgs: [testWorkspace]
-    });
-  } catch (error) {
-    console.error('Test run failed with error:', error);
-    console.log('Tests exist with error code: 1 when a test fails.');
-    process.exit(1);
-  }
-}
-
-main();
+const cwd = process.cwd();
+runIntegrationTests({
+  extensionDevelopmentPath: path.join(__dirname, '..', 'packages'),
+  extensionTestsPath: path.join(cwd, 'out', 'test', 'vscode-integration'),
+  testWorkspace: path.join(
+    __dirname,
+    '..',
+    'packages',
+    'system-tests',
+    'assets',
+    'lwc-recipes'
+  )
+});

--- a/scripts/run-tests-with-recipes.js
+++ b/scripts/run-tests-with-recipes.js
@@ -5,6 +5,7 @@ const { runTests } = require('vscode-test');
 
 function main() {
   try {
+    const cwd = process.cwd();
     const extensionDevelopmentPath = path.join(__dirname, '..', 'packages');
     const testWorkspace = path.join(
       __dirname,

--- a/scripts/run-tests-with-recipes.js
+++ b/scripts/run-tests-with-recipes.js
@@ -1,29 +1,35 @@
 #!/usr/bin/env node
 
-const shell = require('shelljs');
-shell.set('-e');
-shell.set('+v');
-
 const path = require('path');
-const cwd = process.cwd();
+const { runTests } = require('vscode-test');
 
-// Executes the test, using the top-level packages as the CODE_EXTENSIONS_PATH
-try {
-  const CODE_EXTENSIONS_PATH = path.join(__dirname, '..', 'packages');
-  const CODE_TESTS_WORKSPACE = path.join(
-    __dirname,
-    '..',
-    'packages',
-    'system-tests',
-    'assets',
-    'lwc-recipes'
-  );
-  const CODE_TESTS_PATH = path.join(cwd, 'out', 'test', 'vscode-integration');
-
-  shell.exec(
-    `cross-env CODE_EXTENSIONS_PATH='${CODE_EXTENSIONS_PATH}' CODE_TESTS_WORKSPACE='${CODE_TESTS_WORKSPACE}' CODE_TESTS_PATH='${CODE_TESTS_PATH}' node ./node_modules/vscode/bin/test`
-  );
-} catch (e) {
-  console.error('Test run failed with error:', shell.error());
-  console.log('Tests exist with error code: 1 when a test fails.');
+function main() {
+  try {
+    const extensionDevelopmentPath = path.join(__dirname, '..', 'packages');
+    const testWorkspace = path.join(
+      __dirname,
+      '..',
+      'packages',
+      'system-tests',
+      'assets',
+      'lwc-recipes'
+    );
+    const extensionTestsPath = path.join(
+      cwd,
+      'out',
+      'test',
+      'vscode-integration'
+    );
+    runTests({
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [testWorkspace]
+    });
+  } catch (error) {
+    console.error('Test run failed with error:', error);
+    console.log('Tests exist with error code: 1 when a test fails.');
+    process.exit(1);
+  }
 }
+
+main();

--- a/scripts/run-vscode-integration-tests-with-top-level-extensions.js
+++ b/scripts/run-vscode-integration-tests-with-top-level-extensions.js
@@ -1,36 +1,18 @@
 #!/usr/bin/env node
 
 const path = require('path');
-const { runTests } = require('vscode-test');
+const { runIntegrationTests } = require('./vscode-integration-testrunner');
 
-function main() {
-  try {
-    const cwd = process.cwd();
-    const extensionDevelopmentPath = path.join(__dirname, '..', 'packages');
-    const testWorkspace = path.join(
-      __dirname,
-      '..',
-      'packages',
-      'system-tests',
-      'assets',
-      'sfdx-simple'
-    );
-    const extensionTestsPath = path.join(
-      cwd,
-      'out',
-      'test',
-      'vscode-integration'
-    );
-    runTests({
-      extensionDevelopmentPath,
-      extensionTestsPath,
-      launchArgs: [testWorkspace]
-    });
-  } catch (error) {
-    console.error('Test run failed with error:', error);
-    console.log('Tests exist with error code: 1 when a test fails.');
-    process.exit(1);
-  }
-}
-
-main();
+const cwd = process.cwd();
+runIntegrationTests({
+  extensionDevelopmentPath: path.join(__dirname, '..', 'packages'),
+  extensionTestsPath: path.join(cwd, 'out', 'test', 'vscode-integration'),
+  testWorkspace: path.join(
+    __dirname,
+    '..',
+    'packages',
+    'system-tests',
+    'assets',
+    'sfdx-simple'
+  )
+});

--- a/scripts/run-vscode-integration-tests-with-top-level-extensions.js
+++ b/scripts/run-vscode-integration-tests-with-top-level-extensions.js
@@ -1,29 +1,35 @@
 #!/usr/bin/env node
 
-const shell = require('shelljs');
-shell.set('-e');
-shell.set('+v');
-
 const path = require('path');
-const cwd = process.cwd();
+const { runTests } = require('vscode-test');
 
-// Executes the test, using the top-level packages as the CODE_EXTENSIONS_PATH
-try {
-  const CODE_EXTENSIONS_PATH = path.join(__dirname, '..', 'packages');
-  const CODE_TESTS_WORKSPACE = path.join(
-    __dirname,
-    '..',
-    'packages',
-    'system-tests',
-    'assets',
-    'sfdx-simple'
-  );
-  const CODE_TESTS_PATH = path.join(cwd, 'out', 'test', 'vscode-integration');
-
-  shell.exec(
-    `cross-env CODE_EXTENSIONS_PATH='${CODE_EXTENSIONS_PATH}' CODE_TESTS_WORKSPACE='${CODE_TESTS_WORKSPACE}' CODE_TESTS_PATH='${CODE_TESTS_PATH}' node ./node_modules/vscode/bin/test`
-  );
-} catch (e) {
-  console.error('Test run failed with error:', shell.error());
-  console.log('Tests exist with error code: 1 when a test fails.');
+function main() {
+  try {
+    const extensionDevelopmentPath = path.join(__dirname, '..', 'packages');
+    const testWorkspace = path.join(
+      __dirname,
+      '..',
+      'packages',
+      'system-tests',
+      'assets',
+      'sfdx-simple'
+    );
+    const extensionTestsPath = path.join(
+      cwd,
+      'out',
+      'test',
+      'vscode-integration'
+    );
+    runTests({
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [testWorkspace]
+    });
+  } catch (error) {
+    console.error('Test run failed with error:', error);
+    console.log('Tests exist with error code: 1 when a test fails.');
+    process.exit(1);
+  }
 }
+
+main();

--- a/scripts/run-vscode-integration-tests-with-top-level-extensions.js
+++ b/scripts/run-vscode-integration-tests-with-top-level-extensions.js
@@ -5,6 +5,7 @@ const { runTests } = require('vscode-test');
 
 function main() {
   try {
+    const cwd = process.cwd();
     const extensionDevelopmentPath = path.join(__dirname, '..', 'packages');
     const testWorkspace = path.join(
       __dirname,

--- a/scripts/run-vscode-integration-tests.js
+++ b/scripts/run-vscode-integration-tests.js
@@ -6,5 +6,6 @@ const { runIntegrationTests } = require('./vscode-integration-testrunner');
 const cwd = process.cwd();
 runIntegrationTests({
   extensionDevelopmentPath: cwd,
-  extensionTestsPath: path.join(cwd, 'out', 'test', 'vscode-integration')
+  extensionTestsPath: path.join(cwd, 'out', 'test', 'vscode-integration'),
+  testWorkspace: path.join(cwd, 'out', 'test', 'vscode-integration')
 });

--- a/scripts/run-vscode-integration-tests.js
+++ b/scripts/run-vscode-integration-tests.js
@@ -1,18 +1,38 @@
 #!/usr/bin/env node
 
-const shell = require('shelljs');
-shell.set('-e');
-shell.set('+v');
-
 const path = require('path');
-const cwd = process.cwd();
+const { runTests } = require('vscode-test');
 
-// Executes the tests in the out/test/vscode-integration directory
-shell.exec(
-  `cross-env CODE_TESTS_PATH='${path.join(
-    cwd,
-    'out',
-    'test',
-    'vscode-integration'
-  )}' node ./node_modules/vscode/bin/test`
-);
+function main() {
+  try {
+    const {
+      CODE_VERSION,
+      CODE_TESTS_PATH,
+      CODE_EXTENSIONS_PATH,
+      CODE_TESTS_WORKSPACE
+    } = process.env;
+
+    const cwd = process.cwd();
+    const version = CODE_VERSION;
+    const extensionDevelopmentPath = CODE_EXTENSIONS_PATH
+      ? CODE_EXTENSIONS_PATH
+      : cwd;
+    const extensionTestsPath = CODE_TESTS_PATH
+      ? CODE_TESTS_PATH
+      : path.join(cwd, 'out', 'test', 'vscode-integration');
+    const testWorkspace = CODE_TESTS_WORKSPACE;
+    const launchArgs = testWorkspace ? [testWorkspace] : undefined;
+    runTests({
+      version,
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs
+    });
+  } catch (error) {
+    console.error('Test run failed with error:', error);
+    console.log('Tests exist with error code: 1 when a test fails.');
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/run-vscode-integration-tests.js
+++ b/scripts/run-vscode-integration-tests.js
@@ -1,38 +1,10 @@
 #!/usr/bin/env node
 
 const path = require('path');
-const { runTests } = require('vscode-test');
+const { runIntegrationTests } = require('./vscode-integration-testrunner');
 
-function main() {
-  try {
-    const {
-      CODE_VERSION,
-      CODE_TESTS_PATH,
-      CODE_EXTENSIONS_PATH,
-      CODE_TESTS_WORKSPACE
-    } = process.env;
-
-    const cwd = process.cwd();
-    const version = CODE_VERSION;
-    const extensionDevelopmentPath = CODE_EXTENSIONS_PATH
-      ? CODE_EXTENSIONS_PATH
-      : cwd;
-    const extensionTestsPath = CODE_TESTS_PATH
-      ? CODE_TESTS_PATH
-      : path.join(cwd, 'out', 'test', 'vscode-integration');
-    const testWorkspace = CODE_TESTS_WORKSPACE;
-    const launchArgs = testWorkspace ? [testWorkspace] : undefined;
-    runTests({
-      version,
-      extensionDevelopmentPath,
-      extensionTestsPath,
-      launchArgs
-    });
-  } catch (error) {
-    console.error('Test run failed with error:', error);
-    console.log('Tests exist with error code: 1 when a test fails.');
-    process.exit(1);
-  }
-}
-
-main();
+const cwd = process.cwd();
+runIntegrationTests({
+  extensionDevelopmentPath: cwd,
+  extensionTestsPath: path.join(cwd, 'out', 'test', 'vscode-integration')
+});

--- a/scripts/vscode-integration-testrunner.js
+++ b/scripts/vscode-integration-testrunner.js
@@ -23,18 +23,12 @@ function runIntegrationTests({
       CODE_TESTS_WORKSPACE
     } = process.env;
 
-    const _version = CODE_VERSION ? CODE_VERSION : version;
-    console.log(JSON.stringify(_version, null, 2));
-    const _extensionDevelopmentPath = CODE_EXTENSIONS_PATH
-      ? CODE_EXTENSIONS_PATH
-      : extensionDevelopmentPath;
-    const _extensionTestsPath = CODE_TESTS_PATH
-      ? CODE_TESTS_PATH
-      : extensionTestsPath;
-    const _testWorkspace = CODE_TESTS_WORKSPACE
-      ? CODE_TESTS_WORKSPACE
-      : testWorkspace;
-    const launchArgs = _testWorkspace ? [_testWorkspace] : undefined;
+    const _version = CODE_VERSION || version;
+    const _extensionDevelopmentPath =
+      CODE_EXTENSIONS_PATH || extensionDevelopmentPath;
+    const _extensionTestsPath = CODE_TESTS_PATH || extensionTestsPath;
+    const _testWorkspace = CODE_TESTS_WORKSPACE || testWorkspace;
+    const launchArgs = _testWorkspace && [_testWorkspace];
     runTests({
       version: _version,
       extensionDevelopmentPath: _extensionDevelopmentPath,

--- a/scripts/vscode-integration-testrunner.js
+++ b/scripts/vscode-integration-testrunner.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+const { runTests } = require('vscode-test');
+
+/**
+ * A wrapper utlity for running VS Code integration tests. If a correspondent env variable is specified,
+ * it will override the parameters passed in.
+ * @param {string} version Version of VS Code to run the tests against
+ * @param {string} extensionDevelopmentPath Location of the extensions to load
+ * @param {string} extensionTestsPath Location of the tests to execute
+ * @param {string} testWorkspace Location of a workspace to open for the test instance
+ */
+function runIntegrationTests({
+  version,
+  extensionDevelopmentPath,
+  extensionTestsPath,
+  testWorkspace
+}) {
+  try {
+    const {
+      CODE_VERSION,
+      CODE_TESTS_PATH,
+      CODE_EXTENSIONS_PATH,
+      CODE_TESTS_WORKSPACE
+    } = process.env;
+
+    const _version = CODE_VERSION ? CODE_VERSION : version;
+    console.log(JSON.stringify(_version, null, 2));
+    const _extensionDevelopmentPath = CODE_EXTENSIONS_PATH
+      ? CODE_EXTENSIONS_PATH
+      : extensionDevelopmentPath;
+    const _extensionTestsPath = CODE_TESTS_PATH
+      ? CODE_TESTS_PATH
+      : extensionTestsPath;
+    const _testWorkspace = CODE_TESTS_WORKSPACE
+      ? CODE_TESTS_WORKSPACE
+      : testWorkspace;
+    const launchArgs = _testWorkspace ? [_testWorkspace] : undefined;
+    runTests({
+      version: _version,
+      extensionDevelopmentPath: _extensionDevelopmentPath,
+      extensionTestsPath: _extensionTestsPath,
+      launchArgs
+    });
+  } catch (error) {
+    console.error('Test run failed with error:', error);
+    console.log('Tests exist with error code: 1 when a test fails.');
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  runIntegrationTests
+};


### PR DESCRIPTION
### What does this PR do?
Update `vscode-test` to `^1.4.0`. (Note: We were originally using `vscode-test` to download VS code, but not to launch tests.)

Update test scripts to use `runTests` from `vscode-test` module: (npm scripts  test:vscode-integration invoke the test scripts)

* `scripts/run-vscode-integration-tests-with-top-level-extensions.js`
* `scripts/run-tests-with-recipes.js`
* `scripts/run-vscode-integration-tests.js`

Update docs:

* Update Running through the CLI section to deprecate `CODE_DOWNLOAD_URL`.
* Remove mentions of vscode/bin/test

### What issues does this PR fix or reference?
@W-7742828@

### Functionality Before
We use `vscode` module for VS Code integration tests.

### Functionality After
We don't use `vscode` module for VS Code integration tests.
