### PR TITLE
Expose LWC stop watching all tests

### DIFF
--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -239,6 +239,10 @@
         {
           "command": "sfdx.force.lightning.lwc.test.editorTitle.stopWatching",
           "when": "sfdx:lwc_jest_file_focused"
+        },
+        {
+          "command": "sfdx.force.lightning.lwc.test.stopWatchingAllTests",
+          "when": "sfdx:project_opened || sfdx:internal_dev"
         }
       ]
     },
@@ -342,6 +346,10 @@
           "light": "resources/light/stopWatching.svg",
           "dark": "resources/dark/stopWatching.svg"
         }
+      },
+      {
+        "command": "sfdx.force.lightning.lwc.test.stopWatchingAllTests",
+        "title": "%force_lightning_lwc_test_stop_watching_all_tests_text%"
       }
     ],
     "configuration": {

--- a/packages/salesforcedx-vscode-lwc/package.nls.json
+++ b/packages/salesforcedx-vscode-lwc/package.nls.json
@@ -15,6 +15,7 @@
   "force_lightning_lwc_test_debug_current_file_text": "SFDX: Debug Current Lightning Web Component Test File",
   "force_lightning_lwc_test_start_watching_text": "SFDX: Start Watching Lightning Web Component Test",
   "force_lightning_lwc_test_stop_watching_text": "SFDX: Stop Watching Lightning Web Component Test",
+  "force_lightning_lwc_test_stop_watching_all_tests_text": "SFDX: Stop Watching All Lightning Web Component Tests",
   "force_lightning_lwc_preferences": "Salesforce Lightning Web Components",
   "force_lightning_lwc_remember_device_description": "Remember most recently used mobile device target.",
   "force_lightning_lwc_mobile_log_level": "Log level used when calling SFDX Preview on Mobile command."

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/commands/forceLwcTestWatchAction.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/commands/forceLwcTestWatchAction.ts
@@ -20,7 +20,7 @@ import { isLwcJestTest } from '../utils';
  * It will kick off a VS Code task to execute the test runner in watch mode,
  * so that on file changes to the test file or the code related to the test file,
  * it will re-run the tests.
- * @param data providded by test watch commands (or test explorer potentially in the future)
+ * @param data provided by test watch commands (or test explorer potentially in the future)
  */
 export async function forceLwcTestStartWatching(data: {
   testExecutionInfo: TestExecutionInfo;
@@ -29,6 +29,11 @@ export async function forceLwcTestStartWatching(data: {
   await testWatcher.watchTest(testExecutionInfo);
 }
 
+/**
+ * Stop watching tests using the provided test execution info.
+ * It will terminate the test watch task matched by the test URI.
+ * @param data provided by test watch commands
+ */
 export async function forceLwcTestStopWatching(data: {
   testExecutionInfo: TestExecutionInfo;
 }) {
@@ -36,6 +41,10 @@ export async function forceLwcTestStopWatching(data: {
   testWatcher.stopWatchingTest(testExecutionInfo);
 }
 
+/**
+ * Stop watching all tests.
+ * It will terminate all test watch tasks.
+ */
 export function forceLwcTestStopWatchingAllTests() {
   testWatcher.stopWatchingAllTests();
 }

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/commands/forceLwcTestWatchAction.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/commands/forceLwcTestWatchAction.ts
@@ -36,6 +36,10 @@ export async function forceLwcTestStopWatching(data: {
   testWatcher.stopWatchingTest(testExecutionInfo);
 }
 
+export function forceLwcTestStopWatchingAllTests() {
+  testWatcher.stopWatchingAllTests();
+}
+
 /**
  * Start watching the test of currently focused editor
  */

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/commands/index.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/commands/index.ts
@@ -23,6 +23,7 @@ import {
 } from './forceLwcTestRunAction';
 import {
   forceLwcTestStartWatchingCurrentFile,
+  forceLwcTestStopWatchingAllTests,
   forceLwcTestStopWatchingCurrentFile
 } from './forceLwcTestWatchAction';
 
@@ -77,6 +78,10 @@ export function registerCommands(
     'sfdx.force.lightning.lwc.test.editorTitle.stopWatching',
     forceLwcTestStopWatchingCurrentFile
   );
+  const forceLwcTestStopWatchingAllTestsCmd = commands.registerCommand(
+    'sfdx.force.lightning.lwc.test.stopWatchingAllTests',
+    forceLwcTestStopWatchingAllTests
+  );
   const startDebugSessionDisposable = vscode.debug.onDidStartDebugSession(
     handleDidStartDebugSession
   );
@@ -95,6 +100,7 @@ export function registerCommands(
     forceLwcTestEditorTitleDebugCmd,
     forceLwcTestEditorTitleStartWatchingCmd,
     forceLwcTestEditorTitleStopWatchingCmd,
+    forceLwcTestStopWatchingAllTestsCmd,
     startDebugSessionDisposable,
     stopDebugSessionDisposable
   );

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/testRunner/testWatcher.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/testRunner/testWatcher.ts
@@ -38,6 +38,7 @@ class TestWatcher {
         });
         this.watchedTests.set(fsPath, sfdxTask);
         this.setWatchingContext(testUri);
+        return sfdxTask;
       }
     } catch (error) {
       console.error(error);

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/commands/forceLwcTestWatchAction.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/commands/forceLwcTestWatchAction.test.ts
@@ -9,6 +9,7 @@ import {
   forceLwcTestStartWatching,
   forceLwcTestStartWatchingCurrentFile,
   forceLwcTestStopWatching,
+  forceLwcTestStopWatchingAllTests,
   forceLwcTestStopWatchingCurrentFile
 } from '../../../../src/testSupport/commands/forceLwcTestWatchAction';
 import { testWatcher } from '../../../../src/testSupport/testRunner/testWatcher';
@@ -45,6 +46,23 @@ describe('Force LWC Test Watch Action', () => {
     expect(testWatcher.isWatchingTest(mockTestFileInfo.testUri)).to.equal(true);
     await forceLwcTestStopWatching({ testExecutionInfo: mockTestFileInfo });
     expect(testWatcher.isWatchingTest(mockTestFileInfo.testUri)).to.equal(
+      false
+    );
+  });
+
+  it('Should stop watching all tests', async () => {
+    const mockTestFileInfo2 = createMockTestFileInfo('mockTest2.test.js');
+    await forceLwcTestStartWatching({ testExecutionInfo: mockTestFileInfo });
+    await forceLwcTestStartWatching({ testExecutionInfo: mockTestFileInfo2 });
+    expect(testWatcher.isWatchingTest(mockTestFileInfo.testUri)).to.equal(true);
+    expect(testWatcher.isWatchingTest(mockTestFileInfo2.testUri)).to.equal(
+      true
+    );
+    forceLwcTestStopWatchingAllTests();
+    expect(testWatcher.isWatchingTest(mockTestFileInfo.testUri)).to.equal(
+      false
+    );
+    expect(testWatcher.isWatchingTest(mockTestFileInfo2.testUri)).to.equal(
       false
     );
   });

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/commands/forceLwcTestWatchAction.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/commands/forceLwcTestWatchAction.test.ts
@@ -67,6 +67,10 @@ describe('Force LWC Test Watch Action', () => {
     );
   });
 
+  it('Stop watching all tests should not throw if no tests are being watched', async () => {
+    expect(forceLwcTestStopWatchingAllTests).to.not.throw();
+  });
+
   it('Should start and stop watching current file', async () => {
     mockActiveTextEditorUri(mockTestFileInfo.testUri);
     await forceLwcTestStartWatchingCurrentFile();

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/mocks/index.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/mocks/index.ts
@@ -26,7 +26,7 @@ let sfdxTaskExecuteStub: SinonStub<[], Promise<SfdxTask>>;
 let activeTextEditorStub: SinonStub<any[], any>;
 let getTempFolderStub: SinonStub<[string, string], string>;
 let watchTestResultsStub: SinonStub<[string], void>;
-export function createMockTestFileInfo() {
+export function createMockTestFileInfo(mockTestFile = 'mockTest.test.js') {
   const mockDirectory = path.join(
     vscode.workspace.workspaceFolders![0].uri.fsPath,
     'force-app',
@@ -36,7 +36,6 @@ export function createMockTestFileInfo() {
     '__tests__'
   );
 
-  const mockTestFile = 'mockTest.test.js';
   const mockTestFilePath = path.join(mockDirectory, mockTestFile);
   const testExecutionInfo: TestFileInfo = {
     kind: TestInfoKind.TEST_FILE,

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/testRunner/testWatcher.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/testRunner/testWatcher.test.ts
@@ -15,6 +15,7 @@ import {
   unmockGetLwcTestRunnerExecutable,
   unmockSfdxTaskExecute
 } from '../mocks';
+import { expect } from 'chai';
 
 describe('Test Watcher', () => {
   describe('Telemetry for watching tests', () => {
@@ -38,6 +39,22 @@ describe('Test Watcher', () => {
       telemetryStub.restore();
       unmockSfdxTaskExecute();
       unmockGetLwcTestRunnerExecutable();
+    });
+
+    it('Should remove test from tests being watched on ending watch task', async () => {
+      const testExecutionInfo = createMockTestFileInfo();
+      const task = await testWatcher.watchTest(testExecutionInfo);
+      expect(testWatcher.isWatchingTest(testExecutionInfo.testUri)).to.equal(
+        true
+      );
+      // For test purpose, simulate ending watch task by notifyEndTask
+      task!.notifyEndTask();
+      expect(testWatcher.isWatchingTest(testExecutionInfo.testUri)).to.equal(
+        false
+      );
+
+      // Terminate and clean up task
+      task!.terminate();
     });
 
     it('Should send telemetry for watching tests', async () => {


### PR DESCRIPTION
### What does this PR do?
Expose LWC stop watching all tests

### What issues does this PR fix or reference?
@W-7752733@

### Functionality Before
Stop watching all tests is not exposed in the commands.

### Functionality After
Stop watching all tests is exposed in the commands.

<img width="622" alt="Screen Shot 2020-06-26 at 5 22 54 PM" src="https://user-images.githubusercontent.com/679275/85910158-3fd28d80-b7d2-11ea-9f17-db5df70d033e.png">

