### PR TITLE
Add unlocked package support to Org Browser @W-7765801@

### DIFF
--- a/packages/salesforcedx-vscode-core/src/orgBrowser/metadataCmp.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/metadataCmp.ts
@@ -12,6 +12,13 @@ import { nls } from '../messages';
 import { telemetryService } from '../telemetry';
 import { getRootWorkspacePath, hasRootWorkspace, OrgAuthInfo } from '../util';
 
+const validManageableStates = new Set([
+  'unmanaged',
+  'installedEditable',
+  'deprecatedEditable',
+  undefined // not part of a package
+]);
+
 export class ComponentUtils {
   public async getComponentsPath(
     metadataType: string,
@@ -59,7 +66,7 @@ export class ComponentUtils {
           const { fullName, manageableState } = cmp;
           if (
             !isNullOrUndefined(fullName) &&
-            (!manageableState || manageableState === 'unmanaged')
+            validManageableStates.has(manageableState)
           ) {
             components.push(fullName);
           }

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
@@ -129,10 +129,9 @@ describe('build metadata components list', () => {
     }
   });
 
-  it('should only return "unmanaged" components if they have a manageableState', async () => {
+  it('should not return components if they are uneditable', async () => {
     const type = 'ApexClass';
     const states = [
-      'unmanaged',
       'installed',
       'released',
       'deleted',
@@ -153,26 +152,34 @@ describe('build metadata components list', () => {
       undefined
     );
 
-    expect(fullNames.length).to.equal(1);
-    expect(fullNames[0]).to.equal('fakeName0');
+    expect(fullNames.length).to.equal(0);
   });
 
-  it('should return components with no manageableState', async () => {
+  it('should return components that are editable', () => {
     const type = 'CustomObject';
+    const validStates = [
+      'unmanaged',
+      'deprecatedEditable',
+      'installedEditable',
+      undefined // unpackaged component
+    ];
+
     const fileData = {
       status: 0,
-      result: [{ fullName: 'fakeName', type }]
+      result: validStates.map((s, i) => ({
+        fullName: `fakeName${i}`,
+        type,
+        manageableState: s
+      }))
     };
-
     const fullNames = cmpUtil.buildComponentsList(
       type,
       JSON.stringify(fileData),
       undefined
     );
 
-    expect(fullNames.length).to.equal(1);
-    expect(fullNames[0]).to.equal('fakeName');
-  });
+    expect(fullNames).to.deep.equal(['fakeName0', 'fakeName1', 'fakeName2', 'fakeName3'])
+  })
 });
 
 describe('load metadata component data', () => {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
@@ -131,7 +131,7 @@ describe('build metadata components list', () => {
 
   it('should not return components if they are uneditable', async () => {
     const type = 'ApexClass';
-    const states = ['installed', 'released', 'deleted', 'deprecated'];
+    const states = ['installed', 'released', 'deleted', 'deprecated', 'beta'];
     const fileData = {
       status: 0,
       result: states.map((s, i) => ({

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
@@ -131,12 +131,7 @@ describe('build metadata components list', () => {
 
   it('should not return components if they are uneditable', async () => {
     const type = 'ApexClass';
-    const states = [
-      'installed',
-      'released',
-      'deleted',
-      'depricated'
-    ];
+    const states = ['installed', 'released', 'deleted', 'depricated'];
     const fileData = {
       status: 0,
       result: states.map((s, i) => ({
@@ -178,8 +173,13 @@ describe('build metadata components list', () => {
       undefined
     );
 
-    expect(fullNames).to.deep.equal(['fakeName0', 'fakeName1', 'fakeName2', 'fakeName3'])
-  })
+    expect(fullNames).to.deep.equal([
+      'fakeName0',
+      'fakeName1',
+      'fakeName2',
+      'fakeName3'
+    ]);
+  });
 });
 
 describe('load metadata component data', () => {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
@@ -131,7 +131,7 @@ describe('build metadata components list', () => {
 
   it('should not return components if they are uneditable', async () => {
     const type = 'ApexClass';
-    const states = ['installed', 'released', 'deleted', 'depricated'];
+    const states = ['installed', 'released', 'deleted', 'deprecated'];
     const fileData = {
       status: 0,
       result: states.map((s, i) => ({


### PR DESCRIPTION
### What does this PR do?

Updates the Org Browser to allow viewing and retrieving components belonging to an unlocked package.

### What issues does this PR fix or reference?
#2204, @W-7765801@

### Functionality Before
![before](https://user-images.githubusercontent.com/10779873/86188462-92be8480-baf3-11ea-93b7-b12999a9c073.png)

### Functionality After
![after](https://user-images.githubusercontent.com/10779873/86188466-9520de80-baf3-11ea-819f-2bce68bb8ac5.png)
