### PR TITLE
Lock Snyk version 1.358.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prettier": "1.16.4",
     "remap-istanbul": "^0.9.5",
     "shx": "0.2.2",
-    "snyk": "^1.82.1",
+    "snyk": "1.358.0",
     "ts-loader": "5.4.5",
     "tslint": "5.5.0",
     "typescript": "3.1.6",


### PR DESCRIPTION
### What does this PR do?

Lock Snyk version 1.358.0 since the previous version introduced a regression that causes the extensions to not compile in development mode.