### PR TITLE
Core activation perf changes

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/cli/forceConfigGet.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/forceConfigGet.ts
@@ -8,7 +8,10 @@
 import { SfdxCommandBuilder } from './commandBuilder';
 import { CliCommandExecutor } from './commandExecutor';
 import { CommandOutput } from './commandOutput';
-
+/**
+ * @deprecated
+ * NOTE: This code is deprecated in favor of using ConfigUtil.ts
+ */
 export class ForceConfigGet {
   public async getConfig(
     projectPath: string,

--- a/packages/salesforcedx-vscode-apex/src/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/index.ts
@@ -256,7 +256,8 @@ async function registerTestView(
 
 export async function getApexClassFiles(): Promise<vscode.Uri[]> {
   const jsonProject = (await vscode.workspace.findFiles(
-    '**/sfdx-project.json'
+    '**/sfdx-project.json',
+    '**/node_modules/**'
   ))[0];
   const innerText = fs.readFileSync(jsonProject.path);
   const jsonObject = JSON.parse(innerText.toString());
@@ -265,7 +266,10 @@ export async function getApexClassFiles(): Promise<vscode.Uri[]> {
   const allClasses = new Array<vscode.Uri>();
   for (const packageDirectory of packageDirectories) {
     const pattern = path.join(packageDirectory.path, '**/*.cls');
-    const apexClassFiles = await vscode.workspace.findFiles(pattern);
+    const apexClassFiles = await vscode.workspace.findFiles(
+      pattern,
+      '**/node_modules/**'
+    );
     allClasses.push(...apexClassFiles);
   }
   return allClasses;

--- a/packages/salesforcedx-vscode-core/src/channels/channelService.ts
+++ b/packages/salesforcedx-vscode-core/src/channels/channelService.ts
@@ -64,13 +64,13 @@ export class ChannelService {
 
       this.channel.append(' ');
       if (data !== undefined) {
-        this.channel.appendLine(
-          nls.localize('channel_end_with_error', data.message)
-        );
-
         if (/sfdx.*ENOENT/.test(data.message)) {
           this.channel.appendLine(
             nls.localize('channel_end_with_sfdx_not_found')
+          );
+        } else {
+          this.channel.appendLine(
+            nls.localize('channel_end_with_error', data.message)
           );
         }
       } else {

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import * as util from 'util';
+
 import * as vscode from 'vscode';
 import { channelService } from './channels';
 import {
@@ -583,13 +583,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   telemetryService.sendExtensionActivationEvent(extensionHRStart);
   console.log('SFDX CLI Extension Activated');
-  console.log('CLI activation ==> ', getEndHRTime(extensionHRStart));
   return api;
-}
-
-function getEndHRTime(hrstart: [number, number]): number {
-  const hrend = process.hrtime(hrstart);
-  return Number(util.format('%d%d', hrend[0], hrend[1] / 1000000));
 }
 
 export function deactivate(): Promise<void> {

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import * as util from 'util';
 import * as vscode from 'vscode';
 import { channelService } from './channels';
 import {
@@ -78,13 +79,7 @@ import { OrgList } from './orgPicker';
 import { registerPushOrDeployOnSave, sfdxCoreSettings } from './settings';
 import { taskViewService } from './statuses';
 import { telemetryService } from './telemetry';
-import {
-  getRootWorkspacePath,
-  hasRootWorkspace,
-  isCLIInstalled,
-  isCLITelemetryAllowed,
-  showCLINotInstalledMessage
-} from './util';
+import { hasRootWorkspace, isCLIInstalled } from './util';
 import { OrgAuthInfo } from './util/authInfo';
 
 function registerCommands(
@@ -497,14 +492,6 @@ export async function activate(context: vscode.ExtensionContext) {
       telemetryService
     };
 
-    if (!isCLIInstalled()) {
-      showCLINotInstalledMessage();
-      telemetryService.sendException(
-        'core_internal_no_cli',
-        'Salesforce CLI is not installed, internal dev mode'
-      );
-    }
-
     telemetryService.sendExtensionActivationEvent(extensionHRStart);
     console.log('SFDX CLI Extension Activated (internal dev mode)');
     return internalApi;
@@ -513,10 +500,13 @@ export async function activate(context: vscode.ExtensionContext) {
   // Context
   let sfdxProjectOpened = false;
   if (hasRootWorkspace()) {
-    const files = await vscode.workspace.findFiles('**/sfdx-project.json');
+    const files = await vscode.workspace.findFiles(
+      '**/sfdx-project.json',
+      '**/{node_modules,out}/**'
+    );
     sfdxProjectOpened = files && files.length > 0;
   }
-
+  // TODO: move this and the replay debugger commands to the apex extension
   let replayDebuggerExtensionInstalled = false;
   if (
     vscode.extensions.getExtension(
@@ -549,17 +539,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
   await setupOrgBrowser(context);
   await setupConflictView(context);
-  if (isCLIInstalled()) {
-    // Set context for defaultusername org
-    await setupWorkspaceOrgType(defaultUsernameorAlias);
-    await orgList.registerDefaultUsernameWatcher(context);
-  } else {
-    showCLINotInstalledMessage();
-    telemetryService.sendException(
-      'core_no_cli',
-      'Salesforce CLI is not installed'
-    );
-  }
+  // Set context for defaultusername org
+  await setupWorkspaceOrgType(defaultUsernameorAlias);
+  await orgList.registerDefaultUsernameWatcher(context);
 
   // Register filewatcher for push or deploy on save
   await registerPushOrDeployOnSave();
@@ -572,11 +554,11 @@ export async function activate(context: vscode.ExtensionContext) {
   if (hasRootWorkspace()) {
     decorators.showOrg();
     decorators.monitorOrgConfigChanges();
-  }
 
-  // Demo mode Decorator
-  if (hasRootWorkspace() && isDemoMode()) {
-    decorators.showDemoMode();
+    // Demo mode Decorator
+    if (isDemoMode()) {
+      decorators.showDemoMode();
+    }
   }
 
   const api: any = {
@@ -601,7 +583,13 @@ export async function activate(context: vscode.ExtensionContext) {
 
   telemetryService.sendExtensionActivationEvent(extensionHRStart);
   console.log('SFDX CLI Extension Activated');
+  console.log('CLI activation ==> ', getEndHRTime(extensionHRStart));
   return api;
+}
+
+function getEndHRTime(hrstart: [number, number]): number {
+  const hrend = process.hrtime(hrstart);
+  return Number(util.format('%d%d', hrend[0], hrend[1] / 1000000));
 }
 
 export function deactivate(): Promise<void> {

--- a/packages/salesforcedx-vscode-core/src/telemetry/telemetry.ts
+++ b/packages/salesforcedx-vscode-core/src/telemetry/telemetry.ts
@@ -216,7 +216,7 @@ export class TelemetryService {
   }
 
   public async checkCliTelemetry(): Promise<boolean> {
-    return await isCLITelemetryAllowed(getRootWorkspacePath());
+    return await isCLITelemetryAllowed();
   }
 
   public setCliTelemetryEnabled(isEnabled: boolean) {

--- a/packages/salesforcedx-vscode-core/src/util/cliConfiguration.ts
+++ b/packages/salesforcedx-vscode-core/src/util/cliConfiguration.ts
@@ -17,6 +17,7 @@ import {
   SFDX_CONFIG_DISABLE_TELEMETRY
 } from '../constants';
 import { nls } from '../messages';
+import { ConfigUtil } from '.';
 
 export function isCLIInstalled(): boolean {
   let isInstalled = false;
@@ -53,18 +54,12 @@ export function disableCLITelemetry() {
 export async function isCLITelemetryAllowed(
   projectPath: string
 ): Promise<boolean> {
-  if (isCLIInstalled()) {
-    try {
-      const forceConfig = await new ForceConfigGet().getConfig(
-        projectPath,
-        SFDX_CONFIG_DISABLE_TELEMETRY
-      );
-      const disabledConfig =
-        forceConfig.get(SFDX_CONFIG_DISABLE_TELEMETRY) || '';
-      return disabledConfig !== 'true';
-    } catch (e) {
-      console.log('Error checking cli settings: ' + e);
-    }
+  try {
+    const disabledConfig =
+      (await ConfigUtil.getConfigValue(SFDX_CONFIG_DISABLE_TELEMETRY)) || '';
+    return disabledConfig !== 'true';
+  } catch (e) {
+    console.log('Error checking cli settings: ' + e);
   }
   return true;
 }

--- a/packages/salesforcedx-vscode-core/src/util/cliConfiguration.ts
+++ b/packages/salesforcedx-vscode-core/src/util/cliConfiguration.ts
@@ -5,19 +5,16 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import {
-  ForceConfigGet,
-  GlobalCliEnvironment
-} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import { GlobalCliEnvironment } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import { which } from 'shelljs';
 import { window } from 'vscode';
+import { ConfigUtil } from '.';
 import {
   ENV_SFDX_DISABLE_TELEMETRY,
   SFDX_CLI_DOWNLOAD_LINK,
   SFDX_CONFIG_DISABLE_TELEMETRY
 } from '../constants';
 import { nls } from '../messages';
-import { ConfigUtil } from '.';
 
 export function isCLIInstalled(): boolean {
   let isInstalled = false;
@@ -51,9 +48,7 @@ export function disableCLITelemetry() {
   );
 }
 
-export async function isCLITelemetryAllowed(
-  projectPath: string
-): Promise<boolean> {
+export async function isCLITelemetryAllowed(): Promise<boolean> {
   try {
     const disabledConfig =
       (await ConfigUtil.getConfigValue(SFDX_CONFIG_DISABLE_TELEMETRY)) || '';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceAuthDevHub.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceAuthDevHub.test.ts
@@ -140,7 +140,7 @@ describe('Force Auth Dev Hub is based on environment variables', () => {
     });
 
     afterEach(() => {
-      process.env.SFXD_ENV = originalValue;
+      process.env.SFDX_ENV = originalValue;
     });
 
     it('Should use ForceAuthDevHubDemoModeExecutor if demo mode is true', () => {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceAuthWebLogin.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceAuthWebLogin.test.ts
@@ -221,7 +221,7 @@ describe('Force Auth Web Login is based on environment variables', () => {
     });
 
     afterEach(() => {
-      process.env.SFXD_ENV = originalValue;
+      process.env.SFDX_ENV = originalValue;
     });
 
     it('Should use ForceAuthDevHubDemoModeExecutor if demo mode is true', () => {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/betaDeployRetrieve.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/betaDeployRetrieve.test.ts
@@ -12,8 +12,7 @@ import {
 import { MetadataComponent } from '@salesforce/source-deploy-retrieve/lib/types';
 import { expect } from 'chai';
 import * as path from 'path';
-import { createSandbox, SinonSandbox, SinonStub } from 'sinon';
-import { Uri } from 'vscode';
+import { createSandbox, SinonSandbox } from 'sinon';
 import * as vscode from 'vscode';
 import {
   createComponentCount,

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/modes/index.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/modes/index.test.ts
@@ -18,7 +18,7 @@ describe('Demo Mode Utils', () => {
     });
 
     afterEach(() => {
-      process.env.SFXD_ENV = originalValue;
+      process.env.SFDX_ENV = originalValue;
     });
 
     it('Should report demo mode if SFDX_ENV === DEMO', () => {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/util/cliConfiguration.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/util/cliConfiguration.test.ts
@@ -5,19 +5,17 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import {
-  ForceConfigGet,
-  GlobalCliEnvironment
-} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import { GlobalCliEnvironment } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import { expect } from 'chai';
 import * as shelljs from 'shelljs';
-import { assert, SinonStub, stub } from 'sinon';
+import { assert, createSandbox, SinonSandbox, SinonStub, stub } from 'sinon';
 import { window } from 'vscode';
 import {
   ENV_SFDX_DISABLE_TELEMETRY,
   SFDX_CONFIG_DISABLE_TELEMETRY
 } from '../../../src/constants';
 import {
+  ConfigUtil,
   disableCLITelemetry,
   isCLIInstalled,
   isCLITelemetryAllowed,
@@ -25,15 +23,17 @@ import {
 } from '../../../src/util';
 
 describe('SFDX CLI Configuration utility', () => {
+  let sandboxStub: SinonSandbox;
   describe('isCLIInstalled', () => {
     let whichStub: SinonStub;
 
     beforeEach(() => {
-      whichStub = stub(shelljs, 'which');
+      sandboxStub = createSandbox();
+      whichStub = sandboxStub.stub(shelljs, 'which');
     });
 
     afterEach(() => {
-      whichStub.restore();
+      sandboxStub.restore();
     });
 
     it('Should return false if sfdx cli path is not found', () => {
@@ -64,13 +64,14 @@ describe('SFDX CLI Configuration utility', () => {
     let mShowWarning: SinonStub;
 
     beforeEach(() => {
-      mShowWarning = stub(window, 'showWarningMessage').returns(
-        Promise.resolve(null)
-      );
+      sandboxStub = createSandbox();
+      mShowWarning = sandboxStub
+        .stub(window, 'showWarningMessage')
+        .returns(Promise.resolve(null));
     });
 
     afterEach(() => {
-      mShowWarning.restore();
+      sandboxStub.restore();
     });
 
     it('Should show cli install info message', async () => {
@@ -80,71 +81,61 @@ describe('SFDX CLI Configuration utility', () => {
   });
 
   describe('CLI Telemetry', () => {
-    let whichStub: SinonStub;
-    let configGetSpy: SinonStub;
-    let cliEnvSpy: SinonStub;
+    let getConfigValueStub: SinonStub;
 
     beforeEach(() => {
-      whichStub = stub(shelljs, 'which');
-      cliEnvSpy = stub(GlobalCliEnvironment.environmentVariables, 'set');
-      configGetSpy = stub(ForceConfigGet.prototype, 'getConfig').returns(
-        {} as Map<string, string>
-      );
+      sandboxStub = createSandbox();
+      getConfigValueStub = sandboxStub.stub(ConfigUtil, 'getConfigValue');
     });
 
     afterEach(() => {
-      whichStub.restore();
-      cliEnvSpy.restore();
-      configGetSpy.restore();
+      sandboxStub.restore();
     });
 
     it('Should return true if cli is not installed', async () => {
-      whichStub.withArgs('sfdx').returns('');
+      getConfigValueStub.withArgs(SFDX_CONFIG_DISABLE_TELEMETRY).returns('');
 
       const response = await isCLITelemetryAllowed();
       expect(response).to.equal(true);
     });
 
     it('Should return false if telemetry setting is disabled', async () => {
-      whichStub.withArgs('sfdx').returns('Users/some/path/sfdx/cli');
-
-      const config = new Map<string, string>();
-      config.set(SFDX_CONFIG_DISABLE_TELEMETRY, 'true');
-      configGetSpy.returns(config);
+      getConfigValueStub
+        .withArgs(SFDX_CONFIG_DISABLE_TELEMETRY)
+        .returns('true');
 
       const response = await isCLITelemetryAllowed();
       expect(response).to.equal(false);
     });
 
     it('Should return true if telemetry setting is undefined', async () => {
-      whichStub.withArgs('sfdx').returns('Users/some/path/sfdx/cli');
-      configGetSpy.returns(new Map<string, string>());
+      getConfigValueStub.withArgs(SFDX_CONFIG_DISABLE_TELEMETRY).returns('');
 
       const response = await isCLITelemetryAllowed();
       expect(response).to.equal(true);
     });
 
     it('Should return true if telemetry setting is enabled', async () => {
-      whichStub.withArgs('sfdx').returns('Users/some/path/sfdx/cli');
-
-      const config = new Map<string, string>();
-      config.set(SFDX_CONFIG_DISABLE_TELEMETRY, 'false');
-      configGetSpy.returns(config);
+      getConfigValueStub
+        .withArgs(SFDX_CONFIG_DISABLE_TELEMETRY)
+        .returns('false');
 
       const response = await isCLITelemetryAllowed();
       expect(response).to.equal(true);
     });
 
     it("Should return true if CLI doesn't support telemetry setting", async () => {
-      whichStub.withArgs('sfdx').returns('Users/some/path/sfdx/cli');
-
-      configGetSpy.throws('NoSetting');
+      getConfigValueStub.withArgs(SFDX_CONFIG_DISABLE_TELEMETRY).returns('');
 
       const response = await isCLITelemetryAllowed();
       expect(response).to.equal(true);
     });
 
     it('Should set an environment variable', async () => {
+      const cliEnvSpy = sandboxStub.stub(
+        GlobalCliEnvironment.environmentVariables,
+        'set'
+      );
       disableCLITelemetry();
       expect(cliEnvSpy.firstCall.args).to.eql([
         ENV_SFDX_DISABLE_TELEMETRY,

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/util/cliConfiguration.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/util/cliConfiguration.test.ts
@@ -101,7 +101,7 @@ describe('SFDX CLI Configuration utility', () => {
     it('Should return true if cli is not installed', async () => {
       whichStub.withArgs('sfdx').returns('');
 
-      const response = await isCLITelemetryAllowed('');
+      const response = await isCLITelemetryAllowed();
       expect(response).to.equal(true);
     });
 
@@ -112,7 +112,7 @@ describe('SFDX CLI Configuration utility', () => {
       config.set(SFDX_CONFIG_DISABLE_TELEMETRY, 'true');
       configGetSpy.returns(config);
 
-      const response = await isCLITelemetryAllowed('');
+      const response = await isCLITelemetryAllowed();
       expect(response).to.equal(false);
     });
 
@@ -120,7 +120,7 @@ describe('SFDX CLI Configuration utility', () => {
       whichStub.withArgs('sfdx').returns('Users/some/path/sfdx/cli');
       configGetSpy.returns(new Map<string, string>());
 
-      const response = await isCLITelemetryAllowed('');
+      const response = await isCLITelemetryAllowed();
       expect(response).to.equal(true);
     });
 
@@ -131,7 +131,7 @@ describe('SFDX CLI Configuration utility', () => {
       config.set(SFDX_CONFIG_DISABLE_TELEMETRY, 'false');
       configGetSpy.returns(config);
 
-      const response = await isCLITelemetryAllowed('');
+      const response = await isCLITelemetryAllowed();
       expect(response).to.equal(true);
     });
 
@@ -140,7 +140,7 @@ describe('SFDX CLI Configuration utility', () => {
 
       configGetSpy.throws('NoSetting');
 
-      const response = await isCLITelemetryAllowed('');
+      const response = await isCLITelemetryAllowed();
       expect(response).to.equal(true);
     });
 

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/util/configUtil.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/util/configUtil.test.ts
@@ -5,16 +5,18 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { expect } from 'chai';
-import * as sinon from 'sinon';
+import { createSandbox, SinonSandbox, SinonStub } from 'sinon';
 import { ConfigSource, ConfigUtil } from '../../../src/util';
 
 describe('getConfigSource', () => {
-  let getConfigValueStub: sinon.SinonStub;
+  let sandboxStub: SinonSandbox;
+  let getConfigValueStub: SinonStub;
   beforeEach(() => {
-    getConfigValueStub = sinon.stub(ConfigUtil, 'getConfigValue');
+    sandboxStub = createSandbox();
+    getConfigValueStub = sandboxStub.stub(ConfigUtil, 'getConfigValue');
   });
   afterEach(() => {
-    getConfigValueStub.restore();
+    sandboxStub.restore();
   });
   it('should return ConfigSource.Local if the key/value is in the local config', async () => {
     getConfigValueStub.onCall(0).returns('someValue');

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/testIndexer/lwcTestIndexer.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/testIndexer/lwcTestIndexer.ts
@@ -201,7 +201,8 @@ class LwcTestIndexer implements Indexer, vscode.Disposable {
   private async indexAllTestFiles(): Promise<TestFileInfo[]> {
     // TODO, infer package directory from sfdx project json
     const lwcJestTestFiles = await vscode.workspace.findFiles(
-      LWC_TEST_GLOB_PATTERN
+      LWC_TEST_GLOB_PATTERN,
+      '**/node_modules/**'
     );
     const allTestFileInfo = lwcJestTestFiles.map(lwcJestTestFile => {
       const { fsPath } = lwcJestTestFile;


### PR DESCRIPTION
### What does this PR do?
Removes the CLI checks done during core activation, adds ignoring `node_modules` in globs used for searching files and updates telemetry checks to use `@salesforce/core` libraries

### What issues does this PR fix or reference?
#2295 
