### PR TITLE
Support for new JavaScript debugger in VS Code 1.47.0

### DIFF
--- a/packages/salesforcedx-vscode-lwc/src/testSupport/commands/forceLwcTestDebugAction.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/commands/forceLwcTestDebugAction.ts
@@ -42,6 +42,7 @@ export function getDebugConfiguration(
     cwd,
     runtimeExecutable: command,
     args,
+    resolveSourceMapLocations: ['**', '!**/node_modules/**'],
     console: 'integratedTerminal',
     internalConsoleOptions: 'openOnSessionStart',
     port: 9229,

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/workspace/getCliArgsFromJestArgs.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/workspace/getCliArgsFromJestArgs.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { workspace } from 'vscode';
 import { TestRunType } from '../testRunner/testRunner';
 
 /**
@@ -16,7 +17,12 @@ export function getCliArgsFromJestArgs(
   testRunType: TestRunType
 ) {
   const cliArgs = ['--', ...jestArgs];
-  if (testRunType === TestRunType.DEBUG) {
+
+  const usePreviewJavaScriptDebugger = workspace
+    .getConfiguration('debug')
+    .get('javascript.usePreview');
+
+  if (testRunType === TestRunType.DEBUG && !usePreviewJavaScriptDebugger) {
     cliArgs.unshift('--debug');
   }
   return cliArgs;

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/commands/forceLwcTestDebugAction.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/commands/forceLwcTestDebugAction.test.ts
@@ -62,10 +62,6 @@ describe('Force LWC Test Debug - Code Action', () => {
     [(string | undefined)?, ([number, number] | undefined)?, any?, any?],
     Promise<void>
   >;
-  let getConfigurationStub: SinonStub<
-    [string?, (vscode.Uri | null)?],
-    vscode.WorkspaceConfiguration
-  >;
   const mockUuid = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
   beforeEach(() => {
     uuidStub = stub(uuid, 'v4');
@@ -87,7 +83,6 @@ describe('Force LWC Test Debug - Code Action', () => {
     processHrtimeStub.restore();
     telemetryStub.restore();
     getLwcTestRunnerExecutableStub.restore();
-    getConfigurationStub.restore();
   });
 
   const root = /^win32/.test(process.platform) ? 'C:\\' : '/var';

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/commands/forceLwcTestDebugAction.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/commands/forceLwcTestDebugAction.test.ts
@@ -62,6 +62,10 @@ describe('Force LWC Test Debug - Code Action', () => {
     [(string | undefined)?, ([number, number] | undefined)?, any?, any?],
     Promise<void>
   >;
+  let getConfigurationStub: SinonStub<
+    [string?, (vscode.Uri | null)?],
+    vscode.WorkspaceConfiguration
+  >;
   const mockUuid = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
   beforeEach(() => {
     uuidStub = stub(uuid, 'v4');
@@ -83,6 +87,7 @@ describe('Force LWC Test Debug - Code Action', () => {
     processHrtimeStub.restore();
     telemetryStub.restore();
     getLwcTestRunnerExecutableStub.restore();
+    getConfigurationStub.restore();
   });
 
   const root = /^win32/.test(process.platform) ? 'C:\\' : '/var';
@@ -111,18 +116,19 @@ describe('Force LWC Test Debug - Code Action', () => {
     testUri,
     testName
   };
-  const command = lwcTestExecutablePath;
-  const args = [
-    '--debug',
-    '--',
-    '--runTestsByPath',
-    /^win32/.test(process.platform) ? testRelativePath : testFsPath,
-    '--testNamePattern',
-    '"mockTestName"'
-  ];
-  const cwd = sfdxProjectPath;
 
   describe('Debug Configuration', () => {
+    const command = lwcTestExecutablePath;
+    const args = [
+      '--debug',
+      '--',
+      '--runTestsByPath',
+      /^win32/.test(process.platform) ? testRelativePath : testFsPath,
+      '--testNamePattern',
+      '"mockTestName"'
+    ];
+    const cwd = sfdxProjectPath;
+
     it('Should generate debug configuration for single test case', () => {
       const debugConfiguration = getDebugConfiguration(command, args, cwd);
       expect(debugConfiguration).to.deep.equal({
@@ -133,15 +139,14 @@ describe('Force LWC Test Debug - Code Action', () => {
         cwd: sfdxProjectPath,
         runtimeExecutable: lwcTestExecutablePath,
         args,
+        resolveSourceMapLocations: ['**', '!**/node_modules/**'],
         console: 'integratedTerminal',
         internalConsoleOptions: 'openOnSessionStart',
         port: 9229,
         disableOptimisticBPs: true
       });
     });
-  });
 
-  describe('Debug Test Case', () => {
     it('Should send telemetry for debug test case', async () => {
       getLwcTestRunnerExecutableStub.returns(lwcTestExecutablePath);
       const mockExecutionTime: [number, number] = [123, 456];
@@ -189,7 +194,6 @@ describe('Force LWC Test Debug - Code Action', () => {
       const expectedCwd = vscode.workspace.workspaceFolders![0].uri.fsPath;
       assert.calledWith(debugStub, vscode.workspace.workspaceFolders![0], {
         args: [
-          '--debug',
           '--',
           '--json',
           '--outputFile',
@@ -207,6 +211,7 @@ describe('Force LWC Test Debug - Code Action', () => {
             ? path.relative(expectedCwd, mockTestFileInfo.testUri.fsPath)
             : mockTestFileInfo.testUri.fsPath
         ],
+        resolveSourceMapLocations: ['**', '!**/node_modules/**'],
         console: 'integratedTerminal',
         cwd: expectedCwd,
         disableOptimisticBPs: true,
@@ -226,7 +231,6 @@ describe('Force LWC Test Debug - Code Action', () => {
       const expectedCwd = vscode.workspace.workspaceFolders![0].uri.fsPath;
       assert.calledWith(debugStub, vscode.workspace.workspaceFolders![0], {
         args: [
-          '--debug',
           '--',
           '--json',
           '--outputFile',
@@ -244,6 +248,7 @@ describe('Force LWC Test Debug - Code Action', () => {
             ? path.relative(expectedCwd, mockTestFileInfo.testUri.fsPath)
             : mockTestFileInfo.testUri.fsPath
         ],
+        resolveSourceMapLocations: ['**', '!**/node_modules/**'],
         console: 'integratedTerminal',
         cwd: expectedCwd,
         disableOptimisticBPs: true,

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/mocks/index.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/mocks/index.ts
@@ -19,6 +19,12 @@ import {
   TestInfoKind,
   TestType
 } from '../../../../src/testSupport/types';
+import {
+  mockPreviewJavaScriptDebugger,
+  unmockPreviewJavaScriptDebugger
+} from './vscodeConfiguration';
+
+export { mockPreviewJavaScriptDebugger, unmockPreviewJavaScriptDebugger };
 
 let existsSyncStub: SinonStub<[fs.PathLike], boolean>;
 let whichSyncStub: SinonStub<[string], fs.PathLike>;

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/mocks/vscodeConfiguration.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/mocks/vscodeConfiguration.ts
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
 import * as vscode from 'vscode';
 import { workspace, Uri, WorkspaceConfiguration } from 'vscode';
 import { SinonStub, stub } from 'sinon';

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/mocks/vscodeConfiguration.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/mocks/vscodeConfiguration.ts
@@ -1,3 +1,4 @@
+import * as vscode from 'vscode';
 import { workspace, Uri, WorkspaceConfiguration } from 'vscode';
 import { SinonStub, stub } from 'sinon';
 
@@ -5,7 +6,7 @@ let getConfigurationStub: SinonStub<
   [string?, (Uri | null)?],
   WorkspaceConfiguration
 >;
-let mockBaseConfiguration = {
+const mockBaseConfiguration = {
   has(section: string) {
     return true;
   },
@@ -14,22 +15,22 @@ let mockBaseConfiguration = {
   },
   async update(section: string, value: any) {}
 };
+const mockDebugConfigurationJson: { [index: string]: any } = {};
+const mockDebugConfiguration: WorkspaceConfiguration = {
+  ...mockBaseConfiguration,
+  get(section: string) {
+    return mockDebugConfigurationJson[section];
+  }
+};
 
 /**
  * Mock "debug.javascript.usePreview" value
  * @param enabled is configuration enabled
  */
-export function mockPreviewJavaScriptDebugger(enabled: boolean = true) {
-  if (!getConfigurationStub) {
-    getConfigurationStub = stub(workspace, 'getConfiguration');
-  }
-  const mockConfiguration: WorkspaceConfiguration = {
-    ...mockBaseConfiguration,
-    get(section: string) {
-      if (section === 'javascript.usePreview') return enabled;
-    }
-  };
-  getConfigurationStub.returns(mockConfiguration);
+export function mockPreviewJavaScriptDebugger(enabled: boolean) {
+  getConfigurationStub = stub(workspace, 'getConfiguration');
+  mockDebugConfigurationJson['javascript.usePreview'] = enabled;
+  getConfigurationStub.returns(mockDebugConfiguration);
 }
 
 export function unmockPreviewJavaScriptDebugger() {

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/mocks/vscodeConfiguration.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/mocks/vscodeConfiguration.ts
@@ -1,0 +1,37 @@
+import { workspace, Uri, WorkspaceConfiguration } from 'vscode';
+import { SinonStub, stub } from 'sinon';
+
+let getConfigurationStub: SinonStub<
+  [string?, (Uri | null)?],
+  WorkspaceConfiguration
+>;
+let mockBaseConfiguration = {
+  has(section: string) {
+    return true;
+  },
+  inspect(section: string) {
+    return undefined;
+  },
+  async update(section: string, value: any) {}
+};
+
+/**
+ * Mock "debug.javascript.usePreview" value
+ * @param enabled is configuration enabled
+ */
+export function mockPreviewJavaScriptDebugger(enabled: boolean = true) {
+  if (!getConfigurationStub) {
+    getConfigurationStub = stub(workspace, 'getConfiguration');
+  }
+  const mockConfiguration: WorkspaceConfiguration = {
+    ...mockBaseConfiguration,
+    get(section: string) {
+      if (section === 'javascript.usePreview') return enabled;
+    }
+  };
+  getConfigurationStub.returns(mockConfiguration);
+}
+
+export function unmockPreviewJavaScriptDebugger() {
+  getConfigurationStub.restore();
+}

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/workspace/getCliArgsFromJestArgs.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/workspace/getCliArgsFromJestArgs.test.ts
@@ -22,26 +22,25 @@ describe('getCliArgsFromJestArgs Unit Tests', () => {
     'mockTestPath'
   ];
 
-  beforeEach(() => {
-    mockPreviewJavaScriptDebugger(true);
-  });
   afterEach(() => {
     unmockPreviewJavaScriptDebugger();
   });
 
   it('Should return Cli args for run mode', () => {
+    mockPreviewJavaScriptDebugger(true);
     const cliArgs = getCliArgsFromJestArgs(mockJestArgs, TestRunType.RUN);
     const expectedCliArgs = ['--', ...mockJestArgs];
     expect(cliArgs).to.eql(expectedCliArgs);
   });
 
   it('Should return Cli args for watch mode', () => {
+    mockPreviewJavaScriptDebugger(true);
     const cliArgs = getCliArgsFromJestArgs(mockJestArgs, TestRunType.WATCH);
     const expectedCliArgs = ['--', ...mockJestArgs];
     expect(cliArgs).to.eql(expectedCliArgs);
   });
 
-  it('Should return Cli args for debug mode', () => {
+  it('Should return Cli args for debug mode if not using preview JavaScript debugger', () => {
     mockPreviewJavaScriptDebugger(false);
     const cliArgs = getCliArgsFromJestArgs(mockJestArgs, TestRunType.DEBUG);
     const expectedCliArgs = ['--debug', '--', ...mockJestArgs];

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/workspace/getCliArgsFromJestArgs.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/workspace/getCliArgsFromJestArgs.test.ts
@@ -5,12 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { expect } from 'chai';
-import { shared as lspCommon } from '@salesforce/lightning-lsp-common';
 import { SinonStub, stub } from 'sinon';
-import {
-  getCliArgsFromJestArgs,
-  workspaceService
-} from '../../../../src/testSupport/workspace';
+import { workspace, Uri, WorkspaceConfiguration } from 'vscode';
+import { getCliArgsFromJestArgs } from '../../../../src/testSupport/workspace';
 import { TestRunType } from '../../../../src/testSupport/testRunner/testRunner';
 
 describe('getCliArgsFromJestArgs Unit Tests', () => {
@@ -22,86 +19,69 @@ describe('getCliArgsFromJestArgs Unit Tests', () => {
     '--runTestsByPath',
     'mockTestPath'
   ];
-  let getCurrentWorkspaceTypeStub: SinonStub<[], lspCommon.WorkspaceType>;
+  let getConfigurationStub: SinonStub<
+    [string?, (Uri | null)?],
+    WorkspaceConfiguration
+  >;
+  let mockBaseConfiguration = {
+    has(section: string) {
+      return true;
+    },
+    inspect(section: string) {
+      return undefined;
+    },
+    async update(section: string, value: any) {}
+  };
+  let mockPreviewJavaScriptDebuggerEnabledConfiguration: WorkspaceConfiguration = {
+    ...mockBaseConfiguration,
+    get(section: string) {
+      if (section === 'javascript.usePreview') return true;
+    }
+  };
+  let mockPreviewJavaScriptDebuggerDisabledConfiguration: WorkspaceConfiguration = {
+    ...mockBaseConfiguration,
+    get(section: string) {
+      if (section === 'javascript.usePreview') return false;
+    }
+  };
+
   beforeEach(() => {
-    getCurrentWorkspaceTypeStub = stub(
-      workspaceService,
-      'getCurrentWorkspaceType'
+    getConfigurationStub = stub(workspace, 'getConfiguration');
+    getConfigurationStub.returns(
+      mockPreviewJavaScriptDebuggerEnabledConfiguration
     );
   });
   afterEach(() => {
-    getCurrentWorkspaceTypeStub.restore();
+    getConfigurationStub.restore();
   });
 
-  describe('SFDX Workspace', () => {
-    beforeEach(() => {
-      getCurrentWorkspaceTypeStub.returns(lspCommon.WorkspaceType.SFDX);
-    });
-
-    it('Should return Cli args for run mode', () => {
-      const cliArgs = getCliArgsFromJestArgs(mockJestArgs, TestRunType.RUN);
-      const expectedCliArgs = ['--', ...mockJestArgs];
-      expect(cliArgs).to.eql(expectedCliArgs);
-    });
-
-    it('Should return Cli args for watch mode', () => {
-      const cliArgs = getCliArgsFromJestArgs(mockJestArgs, TestRunType.WATCH);
-      const expectedCliArgs = ['--', ...mockJestArgs];
-      expect(cliArgs).to.eql(expectedCliArgs);
-    });
-
-    it('Should return Cli args for debug mode', () => {
-      const cliArgs = getCliArgsFromJestArgs(mockJestArgs, TestRunType.DEBUG);
-      const expectedCliArgs = ['--debug', '--', ...mockJestArgs];
-      expect(cliArgs).to.eql(expectedCliArgs);
-    });
+  it('Should return Cli args for run mode', () => {
+    const cliArgs = getCliArgsFromJestArgs(mockJestArgs, TestRunType.RUN);
+    const expectedCliArgs = ['--', ...mockJestArgs];
+    expect(cliArgs).to.eql(expectedCliArgs);
   });
 
-  describe('Internal Dev Workspace', () => {
-    beforeEach(() => {
-      getCurrentWorkspaceTypeStub.returns(lspCommon.WorkspaceType.CORE_PARTIAL);
-    });
-
-    it('Should return Cli args for run mode', () => {
-      const cliArgs = getCliArgsFromJestArgs(mockJestArgs, TestRunType.RUN);
-      const expectedCliArgs = ['--', ...mockJestArgs];
-      expect(cliArgs).to.eql(expectedCliArgs);
-    });
-
-    it('Should return Cli args for watch mode', () => {
-      const cliArgs = getCliArgsFromJestArgs(mockJestArgs, TestRunType.WATCH);
-      const expectedCliArgs = ['--', ...mockJestArgs];
-      expect(cliArgs).to.eql(expectedCliArgs);
-    });
-
-    it('Should return Cli args for debug mode', () => {
-      const cliArgs = getCliArgsFromJestArgs(mockJestArgs, TestRunType.DEBUG);
-      const expectedCliArgs = ['--debug', '--', ...mockJestArgs];
-      expect(cliArgs).to.eql(expectedCliArgs);
-    });
+  it('Should return Cli args for watch mode', () => {
+    const cliArgs = getCliArgsFromJestArgs(mockJestArgs, TestRunType.WATCH);
+    const expectedCliArgs = ['--', ...mockJestArgs];
+    expect(cliArgs).to.eql(expectedCliArgs);
   });
 
-  describe('Unknown Workspace', () => {
-    beforeEach(() => {
-      getCurrentWorkspaceTypeStub.returns(lspCommon.WorkspaceType.UNKNOWN);
-    });
+  it('Should return Cli args for debug mode', () => {
+    getConfigurationStub.returns(
+      mockPreviewJavaScriptDebuggerDisabledConfiguration
+    );
+    const cliArgs = getCliArgsFromJestArgs(mockJestArgs, TestRunType.DEBUG);
+    const expectedCliArgs = ['--debug', '--', ...mockJestArgs];
+    expect(cliArgs).to.eql(expectedCliArgs);
+  });
 
-    it('Should return Cli args for run mode', () => {
-      const cliArgs = getCliArgsFromJestArgs(mockJestArgs, TestRunType.RUN);
-      const expectedCliArgs = ['--', ...mockJestArgs];
-      expect(cliArgs).to.eql(expectedCliArgs);
-    });
-
-    it('Should return Cli args for watch mode', () => {
-      const cliArgs = getCliArgsFromJestArgs(mockJestArgs, TestRunType.WATCH);
-      const expectedCliArgs = ['--', ...mockJestArgs];
-      expect(cliArgs).to.eql(expectedCliArgs);
-    });
-
-    it('Should return Cli args for debug mode', () => {
-      const cliArgs = getCliArgsFromJestArgs(mockJestArgs, TestRunType.DEBUG);
-      const expectedCliArgs = ['--debug', '--', ...mockJestArgs];
-      expect(cliArgs).to.eql(expectedCliArgs);
-    });
+  it('Should return Cli args for debug mode if using preview JavaScript debugger', () => {
+    getConfigurationStub.returns(
+      mockPreviewJavaScriptDebuggerEnabledConfiguration
+    );
+    const cliArgs = getCliArgsFromJestArgs(mockJestArgs, TestRunType.DEBUG);
+    const expectedCliArgs = ['--', ...mockJestArgs];
+    expect(cliArgs).to.eql(expectedCliArgs);
   });
 });


### PR DESCRIPTION
### What does this PR do?
Fixes LWC test debugging in VS Code 1.47.0, which introduced [new JavaScript debugger](https://github.com/microsoft/vscode-js-debug) by default on 07/10/2020 

### What issues does this PR fix or reference?
@W-7771814@

### Functionality Before
Debugging LWC tests doesn't work if `"debug.javascript.usePreview"` VS Code setting is set to true (default value) in VS Code 1.47.0

### Functionality After
Debugging LWC tests works if `"debug.javascript.usePreview"` VS Code setting is set to true (default value) in VS Code 1.47.0
