### PR TITLE
Update typescript to 3.7.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ parameters:
     default: false
   cache-version:
     type: string
-    default: 'dependency-cache-v3-'
+    default: 'dependency-cache-v4-'
 
 commands:
   compile:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "snyk": "1.358.0",
     "ts-loader": "5.4.5",
     "tslint": "5.5.0",
-    "typescript": "3.9.6",
+    "typescript": "3.7.5",
     "vsce": "1.62.0",
     "vscode-test": "^1.4.0",
     "webpack": "4.30.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "snyk": "1.358.0",
     "ts-loader": "5.4.5",
     "tslint": "5.5.0",
-    "typescript": "3.1.6",
+    "typescript": "3.9.6",
     "vsce": "1.62.0",
     "vscode-test": "^1.4.0",
     "webpack": "4.30.0",

--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -35,7 +35,7 @@
     "mock-spawn": "0.2.6",
     "nyc": "^13",
     "sinon": "^7.3.1",
-    "typescript": "3.1.6",
+    "typescript": "3.9.6",
     "vscode-debugadapter-testsupport": "1.28.0"
   },
   "scripts": {

--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -35,7 +35,7 @@
     "mock-spawn": "0.2.6",
     "nyc": "^13",
     "sinon": "^7.3.1",
-    "typescript": "3.9.6",
+    "typescript": "3.7.5",
     "vscode-debugadapter-testsupport": "1.28.0"
   },
   "scripts": {

--- a/packages/salesforcedx-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-apex-replay-debugger/package.json
@@ -31,7 +31,7 @@
     "nyc": "^13",
     "request-light": "0.2.4",
     "sinon": "^7.3.1",
-    "typescript": "3.1.6",
+    "typescript": "3.9.6",
     "vscode-debugadapter-testsupport": "1.28.0"
   },
   "scripts": {

--- a/packages/salesforcedx-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-apex-replay-debugger/package.json
@@ -31,7 +31,7 @@
     "nyc": "^13",
     "request-light": "0.2.4",
     "sinon": "^7.3.1",
-    "typescript": "3.9.6",
+    "typescript": "3.7.5",
     "vscode-debugadapter-testsupport": "1.28.0"
   },
   "scripts": {

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -35,7 +35,7 @@
     "mock-spawn": "0.2.6",
     "nyc": "^13",
     "sinon": "^7.3.1",
-    "typescript": "3.1.6"
+    "typescript": "3.9.6"
   },
   "scripts": {
     "compile": "webpack",

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@salesforce/core": "2.5.1",
-    "@salesforce/kit": "1.2.2",
+    "@salesforce/kit": "^1.2.3",
     "@salesforce/salesforcedx-utils-vscode": "49.0.0",
     "cross-spawn": "6.0.5",
     "path-exists": "3.0.0",

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -35,7 +35,7 @@
     "mock-spawn": "0.2.6",
     "nyc": "^13",
     "sinon": "^7.3.1",
-    "typescript": "3.9.6"
+    "typescript": "3.7.5"
   },
   "scripts": {
     "compile": "webpack",

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@salesforce/core": "2.5.1",
-    "@salesforce/kit": "^1.2.3",
     "@salesforce/salesforcedx-utils-vscode": "49.0.0",
     "cross-spawn": "6.0.5",
     "path-exists": "3.0.0",

--- a/packages/salesforcedx-test-utils-vscode/package.json
+++ b/packages/salesforcedx-test-utils-vscode/package.json
@@ -32,7 +32,7 @@
     "request-light": "0.2.4",
     "sinon": "^7.3.1",
     "source-map-support": "^0.4.15",
-    "typescript": "3.1.6"
+    "typescript": "3.9.6"
   },
   "engines": {
     "vscode": "^1.40.0"

--- a/packages/salesforcedx-test-utils-vscode/package.json
+++ b/packages/salesforcedx-test-utils-vscode/package.json
@@ -32,7 +32,7 @@
     "request-light": "0.2.4",
     "sinon": "^7.3.1",
     "source-map-support": "^0.4.15",
-    "typescript": "3.9.6"
+    "typescript": "3.7.5"
   },
   "engines": {
     "vscode": "^1.40.0"

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -31,7 +31,7 @@
     "nyc": "^13",
     "request-light": "0.2.4",
     "sinon": "^7.3.1",
-    "typescript": "3.9.6"
+    "typescript": "3.7.5"
   },
   "engines": {
     "vscode": "^1.40.0"

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -31,7 +31,7 @@
     "nyc": "^13",
     "request-light": "0.2.4",
     "sinon": "^7.3.1",
-    "typescript": "3.1.6"
+    "typescript": "3.9.6"
   },
   "engines": {
     "vscode": "^1.40.0"

--- a/packages/salesforcedx-utils-vscode/src/i18n/localization.ts
+++ b/packages/salesforcedx-utils-vscode/src/i18n/localization.ts
@@ -71,7 +71,7 @@ export class Message implements LocalizationProvider {
       }
 
       args.unshift(possibleLabel);
-      return util.format.apply(util, args);
+      return util.format.apply(util, args as [any, ...any[]]);
     }
 
     return possibleLabel;

--- a/packages/salesforcedx-visualforce-language-server/package.json
+++ b/packages/salesforcedx-visualforce-language-server/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@salesforce/salesforcedx-visualforce-markup-language-server": "49.0.0",
-    "typescript": "3.9.6",
+    "typescript": "3.7.5",
     "vscode-css-languageservice": "2.1.9",
     "vscode-languageserver": "5.2.1",
     "vscode-languageserver-protocol": "3.14.1",

--- a/packages/salesforcedx-visualforce-language-server/package.json
+++ b/packages/salesforcedx-visualforce-language-server/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@salesforce/salesforcedx-visualforce-markup-language-server": "49.0.0",
-    "typescript": "3.1.6",
+    "typescript": "3.9.6",
     "vscode-css-languageservice": "2.1.9",
     "vscode-languageserver": "5.2.1",
     "vscode-languageserver-protocol": "3.14.1",

--- a/packages/salesforcedx-visualforce-markup-language-server/package.json
+++ b/packages/salesforcedx-visualforce-markup-language-server/package.json
@@ -22,7 +22,7 @@
     "mocha-multi-reporters": "^1.1.7",
     "nyc": "^13",
     "shx": "0.2.2",
-    "typescript": "3.9.6"
+    "typescript": "3.7.5"
   },
   "dependencies": {
     "vscode-languageserver-types": "3.4.0",

--- a/packages/salesforcedx-visualforce-markup-language-server/package.json
+++ b/packages/salesforcedx-visualforce-markup-language-server/package.json
@@ -22,7 +22,7 @@
     "mocha-multi-reporters": "^1.1.7",
     "nyc": "^13",
     "shx": "0.2.2",
-    "typescript": "3.1.6"
+    "typescript": "3.9.6"
   },
   "dependencies": {
     "vscode-languageserver-types": "3.4.0",

--- a/packages/salesforcedx-visualforce-markup-language-server/src/utils/paths.ts
+++ b/packages/salesforcedx-visualforce-markup-language-server/src/utils/paths.ts
@@ -47,14 +47,14 @@ export function extname(path: string): string {
   return idx ? path.substring(~idx) : '';
 }
 
-export const join: (...parts: string[]) => string = () => {
+export const join: (...parts: string[]) => string = (...parts) => {
   // Not using a function with var-args because of how TS compiles
   // them to JS - it would result in 2*n runtime cost instead
   // of 1*n, where n is parts.length.
 
   let value = '';
-  for (let i = 0; i < arguments.length; i++) {
-    const part = arguments[i];
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
     if (i > 0) {
       // add the separater between two parts unless
       // there already is one

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "@salesforce/apex-tmlanguage": "1.3.0",
     "@salesforce/core": "2.5.1",
-    "@salesforce/kit": "^1.2.3",
     "@salesforce/salesforcedx-sobjects-faux-generator": "49.0.0",
     "@salesforce/salesforcedx-utils-vscode": "49.0.0",
     "expand-home-dir": "0.0.3",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -49,7 +49,7 @@
     "cross-env": "5.2.0",
     "mocha": "^5",
     "sinon": "^7.3.1",
-    "typescript": "3.1.6",
+    "typescript": "3.9.6",
     "vscode-extension-telemetry": "0.0.17"
   },
   "extensionDependencies": [

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -49,7 +49,7 @@
     "cross-env": "5.2.0",
     "mocha": "^5",
     "sinon": "^7.3.1",
-    "typescript": "3.9.6",
+    "typescript": "3.7.5",
     "vscode-extension-telemetry": "0.0.17"
   },
   "extensionDependencies": [

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@salesforce/apex-tmlanguage": "1.3.0",
     "@salesforce/core": "2.5.1",
-    "@salesforce/kit": "1.2.2",
+    "@salesforce/kit": "^1.2.3",
     "@salesforce/salesforcedx-sobjects-faux-generator": "49.0.0",
     "@salesforce/salesforcedx-utils-vscode": "49.0.0",
     "expand-home-dir": "0.0.3",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "@salesforce/core": "2.5.1",
-    "@salesforce/kit": "1.2.2",
+    "@salesforce/kit": "^1.2.3",
     "@salesforce/salesforcedx-utils-vscode": "49.0.0",
     "@salesforce/source-deploy-retrieve": "1.0.15",
     "adm-zip": "0.4.13",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -26,7 +26,6 @@
   ],
   "dependencies": {
     "@salesforce/core": "2.5.1",
-    "@salesforce/kit": "^1.2.3",
     "@salesforce/salesforcedx-utils-vscode": "49.0.0",
     "@salesforce/source-deploy-retrieve": "1.0.15",
     "@salesforce/apex-node": "0.0.2",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -57,7 +57,7 @@
     "mock-spawn": "0.2.6",
     "nyc": "^13",
     "sinon": "^7.3.1",
-    "typescript": "3.1.6"
+    "typescript": "3.9.6"
   },
   "scripts": {
     "vscode:prepublish": "npm prune --production",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -57,7 +57,7 @@
     "mock-spawn": "0.2.6",
     "nyc": "^13",
     "sinon": "^7.3.1",
-    "typescript": "3.9.6"
+    "typescript": "3.7.5"
   },
   "scripts": {
     "vscode:prepublish": "npm prune --production",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -47,7 +47,7 @@
     "mocha-multi-reporters": "^1.1.7",
     "nyc": "^13",
     "sinon": "^7.3.1",
-    "typescript": "3.1.6"
+    "typescript": "3.9.6"
   },
   "scripts": {
     "vscode:prepublish": "npm prune --production",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -47,7 +47,7 @@
     "mocha-multi-reporters": "^1.1.7",
     "nyc": "^13",
     "sinon": "^7.3.1",
-    "typescript": "3.9.6"
+    "typescript": "3.7.5"
   },
   "scripts": {
     "vscode:prepublish": "npm prune --production",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -56,7 +56,7 @@
     "sinon": "^7.3.1",
     "sinon-chai": "^3.4.0",
     "ts-sinon": "^1.0.25",
-    "typescript": "3.1.6",
+    "typescript": "3.9.6",
     "vscode-uri": "^1.0.8"
   },
   "extensionDependencies": [

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -56,7 +56,7 @@
     "sinon": "^7.3.1",
     "sinon-chai": "^3.4.0",
     "ts-sinon": "^1.0.25",
-    "typescript": "3.9.6",
+    "typescript": "3.7.5",
     "vscode-uri": "^1.0.8"
   },
   "extensionDependencies": [

--- a/packages/salesforcedx-vscode-visualforce/package.json
+++ b/packages/salesforcedx-vscode-visualforce/package.json
@@ -42,7 +42,7 @@
     "cross-env": "5.2.0",
     "mocha": "^5",
     "sinon": "^7.3.1",
-    "typescript": "3.1.6"
+    "typescript": "3.9.6"
   },
   "extensionDependencies": [
     "salesforce.salesforcedx-vscode-core"

--- a/packages/salesforcedx-vscode-visualforce/package.json
+++ b/packages/salesforcedx-vscode-visualforce/package.json
@@ -42,7 +42,7 @@
     "cross-env": "5.2.0",
     "mocha": "^5",
     "sinon": "^7.3.1",
-    "typescript": "3.9.6"
+    "typescript": "3.7.5"
   },
   "extensionDependencies": [
     "salesforce.salesforcedx-vscode-core"

--- a/packages/system-tests/package.json
+++ b/packages/system-tests/package.json
@@ -33,7 +33,7 @@
     "rimraf": "^2.6.1",
     "shelljs": "0.8.3",
     "spectron": "9.0.0",
-    "typescript": "3.1.6"
+    "typescript": "3.9.6"
   },
   "scripts": {
     "compile": "tsc -p ./",

--- a/packages/system-tests/package.json
+++ b/packages/system-tests/package.json
@@ -33,7 +33,7 @@
     "rimraf": "^2.6.1",
     "shelljs": "0.8.3",
     "spectron": "9.0.0",
-    "typescript": "3.9.6"
+    "typescript": "3.7.5"
   },
   "scripts": {
     "compile": "tsc -p ./",

--- a/packages/system-tests/src/spectron/application.ts
+++ b/packages/system-tests/src/spectron/application.ts
@@ -273,7 +273,7 @@ export class SpectronApplication {
       if (wdioDeprecationWarning.test(message)) {
         return;
       }
-      warn.apply(console, arguments);
+      warn.apply(console, Array.from(arguments) as [any?, ...any[]]);
     };
   }
 }


### PR DESCRIPTION
### What does this PR do?
- Update TypeScript version to `3.7.5`.
Version number comes from the stable release tag of the engine version we are using (1.40) in vscode repo. The [commit](https://github.com/microsoft/vscode/blob/86405ea23e3937316009fc27c9361deee66ffbf5/package.json#L135) uses TypeScript version `3.7.1-rc`.
- Remove `@salesforce/kit` dependency, which was a hack to stick to the older `@salesforce/kit` version

### What issues does this PR fix or reference?
@W-7823323@