### PR TITLE
Show list of available devices for LWC Preview

### DIFF
--- a/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
@@ -84,6 +84,9 @@ export const messages = {
   force_lightning_lwc_ios_failure: "Failed to start iOS Simulator '%s'.",
   force_lightning_lwc_android_start: "Starting Android Emulator '%s'.",
   force_lightning_lwc_ios_start: "Starting iOS Simulator '%s'.",
+  force_lightning_lwc_preview_create_virtual_device_label: "New...",
+  force_lightning_lwc_preview_create_virtual_device_detail: "Create a Virtual Device",
+  force_lightning_lwc_preview_select_virtual_device: "Select a Virtual Device...",
   force_lightning_lwc_preview_desktop_label: 'Use Desktop Browser',
   force_lightning_lwc_preview_desktop_description:
     'Preview component on desktop browser'


### PR DESCRIPTION
### What does this PR do?
Adds the feature to show a list of available/compatible devices for LWC Preview command and allows the user to pick a device from the list.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/lwc-dev-mobile/issues/21

### Functionality Before
The user was presented with an input box and they had to type in the name of the device manually.

### Functionality After
The user is presented with a quick pick with a list of available/compatible devices and the user can pick one from the list.
