### PR TITLE
Show list of available devices for LWC Preview

### DIFF
--- a/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcPreview.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcPreview.ts
@@ -262,10 +262,12 @@ async function selectPlatformAndExecute(
   let targetName: string | undefined;
 
   try {
-    const result = await deviceListOutput.getCmdResult(deviceListExecution);
-    const jsonString = result.substring(result.indexOf('{'));
-    const json = JSON.parse(jsonString);
-    const devices = json.result as any[];
+    const result: string = await deviceListOutput.getCmdResult(
+      deviceListExecution
+    );
+    const jsonString: string = result.substring(result.indexOf('{'));
+    const json: any = JSON.parse(jsonString);
+    const devices: any[] = json.result as any[];
 
     devices.forEach(device => {
       const label = isAndroid ? device.displayName : device.name;

--- a/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcPreview.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcPreview.ts
@@ -43,6 +43,23 @@ export const enum PlatformName {
   iOS = 'iOS'
 }
 
+export interface IOSSimulatorDevice {
+  name: string;
+  udid: string;
+  state: string;
+  runtimeId: string;
+  isAvailable: boolean;
+}
+
+export interface AndroidVirtualDevice {
+  name: string;
+  displayName: string;
+  deviceName: string;
+  path: string;
+  target: string;
+  api: string;
+}
+
 interface PreviewQuickPickItem extends vscode.QuickPickItem {
   label: string;
   detail: string;
@@ -265,17 +282,26 @@ async function selectPlatformAndExecute(
     const result: string = await deviceListOutput.getCmdResult(
       deviceListExecution
     );
-    const jsonString: string = result.substring(result.indexOf('{'));
-    const json: any = JSON.parse(jsonString);
-    const devices: any[] = json.result as any[];
 
-    devices.forEach(device => {
-      const label = isAndroid ? device.displayName : device.name;
-      const detail = isAndroid
-        ? `${device.target}, ${device.api}`
-        : device.runtimeId;
-      options.push({ label, detail });
-    });
+    const jsonString: string = result.substring(result.indexOf('{'));
+
+    if (isAndroid) {
+      const devices: AndroidVirtualDevice[] = JSON.parse(jsonString)
+        .result as AndroidVirtualDevice[];
+      devices.forEach(device => {
+        const label: string = device.displayName;
+        const detail: string = `${device.target}, ${device.api}`;
+        options.push({ label, detail });
+      });
+    } else {
+      const devices: IOSSimulatorDevice[] = JSON.parse(jsonString)
+        .result as IOSSimulatorDevice[];
+      devices.forEach(device => {
+        const label: string = device.name;
+        const detail: string = device.runtimeId;
+        options.push({ label, detail });
+      });
+    }
   } catch (e) {
     // If device enumeration fails due to exit code 127
     // (i.e. lwc on mobile sfdx plugin is not installed)

--- a/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
@@ -84,9 +84,11 @@ export const messages = {
   force_lightning_lwc_ios_failure: "Failed to start iOS Simulator '%s'.",
   force_lightning_lwc_android_start: "Starting Android Emulator '%s'.",
   force_lightning_lwc_ios_start: "Starting iOS Simulator '%s'.",
-  force_lightning_lwc_preview_create_virtual_device_label: "New...",
-  force_lightning_lwc_preview_create_virtual_device_detail: "Create a Virtual Device",
-  force_lightning_lwc_preview_select_virtual_device: "Select a Virtual Device...",
+  force_lightning_lwc_preview_create_virtual_device_label: 'New...',
+  force_lightning_lwc_preview_create_virtual_device_detail:
+    'Create a Virtual Device',
+  force_lightning_lwc_preview_select_virtual_device:
+    'Select a Virtual Device...',
   force_lightning_lwc_preview_desktop_label: 'Use Desktop Browser',
   force_lightning_lwc_preview_desktop_description:
     'Preview component on desktop browser'

--- a/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
@@ -84,6 +84,9 @@ export const messages = {
   force_lightning_lwc_ios_failure: "Failed to start iOS Simulator '%s'.",
   force_lightning_lwc_android_start: "Starting Android Emulator '%s'.",
   force_lightning_lwc_ios_start: "Starting iOS Simulator '%s'.",
+  force_lightning_lwc_preview_create_virtual_device_label: "New...",
+  force_lightning_lwc_preview_create_virtual_device_detail: "Create a Virtual Device",
+  force_lightning_lwc_preview_select_virtual_device: "Select a Virtual Device...",
   force_lightning_lwc_preview_desktop_label: 'Use Desktop Browser',
   force_lightning_lwc_preview_desktop_description:
     'Preview component on desktop browser'

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcPreview.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcPreview.test.ts
@@ -915,27 +915,23 @@ describe('forceLightningLwcPreview', () => {
     showQuickPickStub.resolves(androidQuickPick);
     showInputBoxStub.resolves('');
 
-    await forceLightningLwcPreview(mockLwcFilePathUri);
-    mockExecution.processExitSubject.next(127);
-
-    sinon.assert.calledTwice(mobileExecutorStub); // device list + preview
-    sinon.assert.calledWith(
-      showErrorMessageStub,
-      sinon.match(
-        nls.localize(
-          'force_lightning_lwc_android_failure',
-          androidQuickPick.defaultTargetName
-        )
-      )
+    commandOutputStub.returns(
+      Promise.reject(`${sfdxDeviceListCommand} is not a sfdx command.`)
     );
+
+    await forceLightningLwcPreview(mockLwcFilePathUri);
+
+    sinon.assert.calledOnce(mobileExecutorStub); // device list only
+
     sinon.assert.calledWith(
       showErrorMessageStub,
       sinon.match(nls.localize('force_lightning_lwc_no_mobile_plugin'))
     );
-    sinon.assert.calledOnce(streamCommandOutputSpy);
-    expect(successInfoMessageSpy.callCount).to.equal(0);
 
-    sinon.assert.calledTwice(appendLineSpy);
+    sinon.assert.notCalled(streamCommandOutputSpy);
+    sinon.assert.notCalled(successInfoMessageSpy);
+
+    sinon.assert.calledOnce(appendLineSpy);
     expect(
       appendLineSpy.calledWith(
         nls.localize('force_lightning_lwc_no_mobile_plugin')

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcPreview.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcPreview.test.ts
@@ -102,17 +102,6 @@ const androidDeviceListJson = `
   }
 `;
 
-const createDeviceLabelText = nls.localize(
-  'force_lightning_lwc_preview_create_virtual_device_label'
-);
-const createDeviceDetailText = nls.localize(
-  'force_lightning_lwc_preview_create_virtual_device_detail'
-);
-const createNewDeviceOption: vscode.QuickPickItem = {
-  label: createDeviceLabelText,
-  detail: createDeviceDetailText
-};
-
 describe('forceLightningLwcPreview', () => {
   let sandbox: SinonSandbox;
   let devServiceStub: any;
@@ -1066,6 +1055,15 @@ describe('forceLightningLwcPreview', () => {
   });
 
   async function doNewDeviceQuickPickTest(isAndroid: Boolean) {
+    const createNewDeviceOption: vscode.QuickPickItem = {
+      label: nls.localize(
+        'force_lightning_lwc_preview_create_virtual_device_label'
+      ),
+      detail: nls.localize(
+        'force_lightning_lwc_preview_create_virtual_device_detail'
+      )
+    };
+
     const deviceName = isAndroid ? 'androidtestname' : 'iostestname';
     const platform = isAndroid ? PlatformName.Android : PlatformName.iOS;
     devServiceStub.isServerHandlerRegistered.returns(true);


### PR DESCRIPTION
### What does this PR do?
Adds the feature to show a list of available/compatible devices for LWC Preview command and allows the user to pick a device from the list.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/lwc-dev-mobile/issues/21

### Functionality Before
The user was presented with an input box and they had to type in the name of the device manually.

### Functionality After
The user is presented with a quick pick with a list of available/compatible devices and the user can pick one from the list.
