### PR TITLE
Remove skip ci from sha update message

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,7 @@ commands:
           name: 'Adding the SHA256 to git.'
           command: |
             git add SHA256.md
-            git commit -m "[skip ci] Updated SHA256"
+            git commit -m "Updated SHA256 v${RELEASE_VERSION}"
 
   build-artifacts:
     description: 'Building and archiving extension artifacts.'


### PR DESCRIPTION
### What does this PR do?
Updates the SHA commit message during publishing to remove [skip ci]. This is not needed anymore since we've now moved to using parameters to kick off publishing.
