### PR TITLE
Show list of available devices for LWC Preview

### DIFF
--- a/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcPreview.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcPreview.ts
@@ -43,7 +43,7 @@ export const enum PlatformName {
   iOS = 'iOS'
 }
 
-export interface IOSSimulatorDevice {
+interface IOSSimulatorDevice {
   name: string;
   udid: string;
   state: string;
@@ -51,7 +51,7 @@ export interface IOSSimulatorDevice {
   isAvailable: boolean;
 }
 
-export interface AndroidVirtualDevice {
+interface AndroidVirtualDevice {
   name: string;
   displayName: string;
   deviceName: string;

--- a/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
@@ -84,6 +84,11 @@ export const messages = {
   force_lightning_lwc_ios_failure: "Failed to start iOS Simulator '%s'.",
   force_lightning_lwc_android_start: "Starting Android Emulator '%s'.",
   force_lightning_lwc_ios_start: "Starting iOS Simulator '%s'.",
+  force_lightning_lwc_preview_create_virtual_device_label: 'New...',
+  force_lightning_lwc_preview_create_virtual_device_detail:
+    'Create a Virtual Device',
+  force_lightning_lwc_preview_select_virtual_device:
+    'Select a Virtual Device...',
   force_lightning_lwc_preview_desktop_label: 'Use Desktop Browser',
   force_lightning_lwc_preview_desktop_description:
     'Preview component on desktop browser'

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcPreview.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcPreview.test.ts
@@ -6,13 +6,14 @@
  */
 
 import {
+  CliCommandExecution,
   CliCommandExecutor,
   Command,
   CommandBuilder,
   CommandExecution,
+  CommandOutput,
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
-import { CliCommandExecution } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import { CancellationToken } from '@salesforce/salesforcedx-utils-vscode/out/src/cli/commandExecutor';
 import { expect } from 'chai';
 import * as fs from 'fs';
@@ -40,11 +41,66 @@ const sfdxCoreExports = vscode.extensions.getExtension(
   'salesforce.salesforcedx-vscode-core'
 )!.exports;
 const { channelService, SfdxCommandlet, notificationService } = sfdxCoreExports;
+const sfdxDeviceListCommand = 'force:lightning:local:device:list';
 const sfdxMobilePreviewCommand = 'force:lightning:lwc:preview';
 const rememberDeviceKey = 'preview.rememberDevice';
 const logLevelKey = 'preview.logLevel';
 const defaultLogLevel = 'warn';
 const androidSuccessString = 'Launching... Opening Browser';
+
+const iOSPickedDevice: vscode.QuickPickItem = {
+  label: 'iPhone 8',
+  detail: 'iOS 13.3'
+};
+const iOSDeviceListJson = `
+  {
+    "status":0,
+    "result":[
+      {
+          "name":"iPhone 8",
+          "udid":"6CC16032-2671-4BD2-8FF1-0E314945010C",
+          "state":"Shutdown",
+          "runtimeId":"iOS 13.3",
+          "isAvailable":true
+      },
+      {
+          "name":"LWCSimulator",
+          "udid":"09D522C8-DC85-4259-AD15-15D36672D2EA",
+          "state":"Shutdown",
+          "runtimeId":"iOS 13.3",
+          "isAvailable":true
+      }
+    ]
+  }
+`;
+
+const androidPickedDevice: vscode.QuickPickItem = {
+  label: 'emu2',
+  detail: 'Default Android System Image'
+};
+const androidDeviceListJson = `
+  {
+    "status":0,
+    "result":[
+      {
+          "name":"emu2",
+          "displayName":"emu2",
+          "deviceName":"pixel",
+          "path":"/Users/maliroteh/.android/avd/emu2.avd",
+          "target":"Default Android System Image",
+          "api":"API 29"
+      },
+      {
+          "name":"Pixel_API_29",
+          "displayName":"Pixel API 29",
+          "deviceName":"pixel",
+          "path":"/Users/maliroteh/.android/avd/Pixel_API_29.avd",
+          "target":"Google APIs",
+          "api":"API 29"
+      }
+    ]
+  }
+`;
 
 describe('forceLightningLwcPreview', () => {
   let sandbox: SinonSandbox;
@@ -93,6 +149,7 @@ describe('forceLightningLwcPreview', () => {
     [(CancellationToken | undefined)?],
     CliCommandExecution | MockExecution
   >;
+  let commandOutputStub: sinon.SinonStub<[CommandExecution], Promise<string>>;
   let mockExecution: MockExecution;
   let showWarningMessageSpy: sinon.SinonSpy<any, any>;
   let successInfoMessageSpy: sinon.SinonSpy<any, any>;
@@ -218,6 +275,8 @@ describe('forceLightningLwcPreview', () => {
     mockExecution = new MockExecution(new SfdxCommandBuilder().build());
     mobileExecutorStub = sinon.stub(CliCommandExecutor.prototype, 'execute');
     mobileExecutorStub.returns(mockExecution);
+    commandOutputStub = sinon.stub(CommandOutput.prototype, 'getCmdResult');
+    commandOutputStub.returns(Promise.resolve('{}'));
     showWarningMessageSpy = sandbox.spy(vscode.window, 'showWarningMessage');
     successInfoMessageSpy = sandbox.spy(
       vscode.window,
@@ -237,6 +296,7 @@ describe('forceLightningLwcPreview', () => {
     showWarningMessageSpy.restore();
     successInfoMessageSpy.restore();
     mobileExecutorStub.restore();
+    commandOutputStub.restore();
     streamCommandOutputSpy.restore();
     appendLineSpy.restore();
   });
@@ -353,48 +413,16 @@ describe('forceLightningLwcPreview', () => {
   });
 
   it('starts the server if it is not running when Android selected', async () => {
-    devServiceStub.isServerHandlerRegistered.returns(false);
-    mockFileExists(mockLwcFilePath);
-    existsSyncStub.returns(true);
-    lstatSyncStub.returns({
-      isDirectory() {
-        return false;
-      }
-    } as fs.Stats);
-    getConfigurationStub.returns(new MockWorkspace(false));
-    getGlobalStoreStub.returns(new MockMemento());
-    showQuickPickStub.resolves(androidQuickPick);
-    showInputBoxStub.resolves('');
-    const commandletStub = sandbox.stub(SfdxCommandlet.prototype, 'run');
-    await forceLightningLwcPreview(mockLwcFilePathUri);
-    mockExecution.stdoutSubject.next(androidSuccessString);
-    sinon.assert.calledOnce(showQuickPickStub);
-    sinon.assert.calledOnce(showInputBoxStub);
-    sinon.assert.calledOnce(commandletStub);
-    expect(cmdWithArgSpy.callCount).to.equal(1);
-    expect(cmdWithArgSpy.getCall(0).args[0]).equals(sfdxMobilePreviewCommand);
-    expect(cmdWithFlagSpy.callCount).to.equal(4);
-    expect(cmdWithFlagSpy.getCall(0).args).to.have.same.members([
-      '-p',
-      PlatformName.Android
-    ]);
-    expect(cmdWithFlagSpy.getCall(1).args).to.have.same.members([
-      '-t',
-      'SFDXEmulator'
-    ]);
-    expect(cmdWithFlagSpy.getCall(2).args).to.have.same.members([
-      '-n',
-      'c/foo'
-    ]);
-    expect(cmdWithFlagSpy.getCall(3).args).to.have.same.members([
-      '--loglevel',
-      'warn'
-    ]);
-    sinon.assert.calledOnce(mobileExecutorStub);
-    expect(successInfoMessageSpy.callCount).to.equal(1);
+    await doStartServerTest(true);
   });
 
   it('starts the server if it is not running when iOS selected', async () => {
+    await doStartServerTest(false);
+  });
+
+  async function doStartServerTest(isAndroid: Boolean) {
+    const platform = isAndroid ? PlatformName.Android : PlatformName.iOS;
+    const deviceName = isAndroid ? 'SFDXEmulator' : 'SFDXSimulator';
     devServiceStub.isServerHandlerRegistered.returns(false);
     mockFileExists(mockLwcFilePath);
     existsSyncStub.returns(true);
@@ -405,37 +433,54 @@ describe('forceLightningLwcPreview', () => {
     } as fs.Stats);
     getConfigurationStub.returns(new MockWorkspace(false));
     getGlobalStoreStub.returns(new MockMemento());
-    showQuickPickStub.resolves(iOSQuickPick);
+    showQuickPickStub.resolves(isAndroid ? androidQuickPick : iOSQuickPick);
     showInputBoxStub.resolves('');
     const commandletStub = sandbox.stub(SfdxCommandlet.prototype, 'run');
     await forceLightningLwcPreview(mockLwcFilePathUri);
-    mockExecution.processExitSubject.next(0);
+
+    if (isAndroid) {
+      mockExecution.stdoutSubject.next(androidSuccessString);
+    } else {
+      mockExecution.processExitSubject.next(0);
+    }
 
     sinon.assert.calledOnce(showQuickPickStub);
     sinon.assert.calledOnce(showInputBoxStub);
     sinon.assert.calledOnce(commandletStub);
-    expect(cmdWithArgSpy.callCount).to.equal(1);
-    expect(cmdWithArgSpy.getCall(0).args[0]).equals(sfdxMobilePreviewCommand);
-    expect(cmdWithFlagSpy.callCount).to.equal(4);
+    expect(cmdWithArgSpy.callCount).to.equal(2);
+    expect(cmdWithArgSpy.getCall(0).args[0]).equals(sfdxDeviceListCommand);
+    expect(cmdWithArgSpy.getCall(1).args[0]).equals(sfdxMobilePreviewCommand);
+    expect(cmdWithFlagSpy.callCount).to.equal(5);
     expect(cmdWithFlagSpy.getCall(0).args).to.have.same.members([
       '-p',
-      PlatformName.iOS
+      platform
     ]);
     expect(cmdWithFlagSpy.getCall(1).args).to.have.same.members([
-      '-t',
-      'SFDXSimulator'
+      '-p',
+      platform
     ]);
     expect(cmdWithFlagSpy.getCall(2).args).to.have.same.members([
+      '-t',
+      deviceName
+    ]);
+    expect(cmdWithFlagSpy.getCall(3).args).to.have.same.members([
       '-n',
       'c/foo'
     ]);
-    expect(cmdWithFlagSpy.getCall(3).args).to.have.same.members([
+    expect(cmdWithFlagSpy.getCall(4).args).to.have.same.members([
       '--loglevel',
       'warn'
     ]);
-    sinon.assert.calledOnce(mobileExecutorStub);
+    sinon.assert.calledTwice(mobileExecutorStub); // device list + preview
     expect(successInfoMessageSpy.callCount).to.equal(1);
-  });
+    expect(
+      successInfoMessageSpy.calledWith(
+        isAndroid
+          ? nls.localize('force_lightning_lwc_android_start', deviceName)
+          : nls.localize('force_lightning_lwc_ios_start', deviceName)
+      )
+    );
+  }
 
   it('shows an error when source path is not recognized as an lwc module file', async () => {
     devServiceStub.isServerHandlerRegistered.returns(true);
@@ -521,26 +566,31 @@ describe('forceLightningLwcPreview', () => {
 
     sinon.assert.calledOnce(showQuickPickStub);
     sinon.assert.calledOnce(showInputBoxStub);
-    expect(cmdWithArgSpy.callCount).to.equal(1);
-    expect(cmdWithArgSpy.getCall(0).args[0]).equals(sfdxMobilePreviewCommand);
-    expect(cmdWithFlagSpy.callCount).to.equal(4);
+    expect(cmdWithArgSpy.callCount).to.equal(2);
+    expect(cmdWithArgSpy.getCall(0).args[0]).equals(sfdxDeviceListCommand);
+    expect(cmdWithArgSpy.getCall(1).args[0]).equals(sfdxMobilePreviewCommand);
+    expect(cmdWithFlagSpy.callCount).to.equal(5);
     expect(cmdWithFlagSpy.getCall(0).args).to.have.same.members([
       '-p',
       PlatformName.Android
     ]);
     expect(cmdWithFlagSpy.getCall(1).args).to.have.same.members([
+      '-p',
+      PlatformName.Android
+    ]);
+    expect(cmdWithFlagSpy.getCall(2).args).to.have.same.members([
       '-t',
       'SFDXEmulator'
     ]);
-    expect(cmdWithFlagSpy.getCall(2).args).to.have.same.members([
+    expect(cmdWithFlagSpy.getCall(3).args).to.have.same.members([
       '-n',
       'c/foo'
     ]);
-    expect(cmdWithFlagSpy.getCall(3).args).to.have.same.members([
+    expect(cmdWithFlagSpy.getCall(4).args).to.have.same.members([
       '--loglevel',
       'warn'
     ]);
-    sinon.assert.calledOnce(mobileExecutorStub);
+    sinon.assert.calledTwice(mobileExecutorStub); // device list + preview
     expect(successInfoMessageSpy.callCount).to.equal(1);
   });
 
@@ -562,26 +612,31 @@ describe('forceLightningLwcPreview', () => {
 
     sinon.assert.calledOnce(showQuickPickStub);
     sinon.assert.calledOnce(showInputBoxStub);
-    expect(cmdWithArgSpy.callCount).to.equal(1);
-    expect(cmdWithArgSpy.getCall(0).args[0]).equals(sfdxMobilePreviewCommand);
-    expect(cmdWithFlagSpy.callCount).to.equal(4);
+    expect(cmdWithArgSpy.callCount).to.equal(2);
+    expect(cmdWithArgSpy.getCall(0).args[0]).equals(sfdxDeviceListCommand);
+    expect(cmdWithArgSpy.getCall(1).args[0]).equals(sfdxMobilePreviewCommand);
+    expect(cmdWithFlagSpy.callCount).to.equal(5);
     expect(cmdWithFlagSpy.getCall(0).args).to.have.same.members([
       '-p',
       PlatformName.iOS
     ]);
     expect(cmdWithFlagSpy.getCall(1).args).to.have.same.members([
+      '-p',
+      PlatformName.iOS
+    ]);
+    expect(cmdWithFlagSpy.getCall(2).args).to.have.same.members([
       '-t',
       'SFDXSimulator'
     ]);
-    expect(cmdWithFlagSpy.getCall(2).args).to.have.same.members([
+    expect(cmdWithFlagSpy.getCall(3).args).to.have.same.members([
       '-n',
       'c/foo'
     ]);
-    expect(cmdWithFlagSpy.getCall(3).args).to.have.same.members([
+    expect(cmdWithFlagSpy.getCall(4).args).to.have.same.members([
       '--loglevel',
       'warn'
     ]);
-    sinon.assert.calledOnce(mobileExecutorStub);
+    sinon.assert.calledTwice(mobileExecutorStub); // device list + preview
     expect(successInfoMessageSpy.callCount).to.equal(1);
   });
 
@@ -636,7 +691,16 @@ describe('forceLightningLwcPreview', () => {
   });
 
   it('calls SFDX preview with specified Android device name', async () => {
-    const deviceName = 'androidtestname';
+    await doSpecifiedDeviceTest(true);
+  });
+
+  it('calls SFDX preview with specified iOS device name', async () => {
+    await doSpecifiedDeviceTest(false);
+  });
+
+  async function doSpecifiedDeviceTest(isAndroid: Boolean) {
+    const deviceName = isAndroid ? 'androidtestname' : 'iostestname';
+    const platform = isAndroid ? PlatformName.Android : PlatformName.iOS;
     devServiceStub.isServerHandlerRegistered.returns(true);
     mockFileExists(mockLwcFileDirectory);
     existsSyncStub.returns(true);
@@ -648,107 +712,50 @@ describe('forceLightningLwcPreview', () => {
 
     getConfigurationStub.returns(new MockWorkspace(false));
     getGlobalStoreStub.returns(new MockMemento());
-    showQuickPickStub.resolves(androidQuickPick);
+    showQuickPickStub.resolves(isAndroid ? androidQuickPick : iOSQuickPick);
     showInputBoxStub.resolves(deviceName);
+
     await forceLightningLwcPreview(mockLwcFileDirectoryUri);
-    mockExecution.stdoutSubject.next(androidSuccessString);
+    if (isAndroid) {
+      mockExecution.stdoutSubject.next(androidSuccessString);
+    } else {
+      mockExecution.processExitSubject.next(0);
+    }
 
     sinon.assert.calledOnce(showQuickPickStub);
     sinon.assert.calledOnce(showInputBoxStub);
     expect(cmdWithFlagSpy.getCall(0).args).to.have.same.members([
       '-p',
-      PlatformName.Android
+      platform
     ]);
     expect(cmdWithFlagSpy.getCall(1).args).to.have.same.members([
-      '-t',
-      deviceName
-    ]);
-    sinon.assert.calledOnce(mobileExecutorStub);
-    expect(successInfoMessageSpy.callCount).to.equal(1);
-    expect(
-      successInfoMessageSpy.calledWith(
-        nls.localize('force_lightning_lwc_android_start', deviceName)
-      )
-    );
-  });
-
-  it('calls SFDX preview with specified iOS device name', async () => {
-    const deviceName = 'iostestname';
-    mockFileExists(mockLwcFilePath);
-    existsSyncStub.returns(true);
-    lstatSyncStub.returns({
-      isDirectory() {
-        return true;
-      }
-    } as fs.Stats);
-
-    devServiceStub.isServerHandlerRegistered.returns(true);
-    getConfigurationStub.returns(new MockWorkspace(false));
-    getGlobalStoreStub.returns(new MockMemento());
-    showQuickPickStub.resolves(iOSQuickPick);
-    showInputBoxStub.resolves(deviceName);
-    await forceLightningLwcPreview(mockLwcFilePathUri);
-    mockExecution.processExitSubject.next(0);
-
-    sinon.assert.calledOnce(showQuickPickStub);
-    sinon.assert.calledOnce(showInputBoxStub);
-    expect(cmdWithFlagSpy.getCall(0).args).to.have.same.members([
       '-p',
-      PlatformName.iOS
+      platform
     ]);
-    expect(cmdWithFlagSpy.getCall(1).args).to.have.same.members([
+    expect(cmdWithFlagSpy.getCall(2).args).to.have.same.members([
       '-t',
       deviceName
     ]);
-    sinon.assert.calledOnce(mobileExecutorStub);
+    sinon.assert.calledTwice(mobileExecutorStub); // device list + preview
     expect(successInfoMessageSpy.callCount).to.equal(1);
     expect(
       successInfoMessageSpy.calledWith(
-        nls.localize('force_lightning_lwc_ios_start', deviceName)
+        isAndroid
+          ? nls.localize('force_lightning_lwc_android_start', deviceName)
+          : nls.localize('force_lightning_lwc_ios_start', deviceName)
       )
     );
-  });
+  }
 
   it('calls SFDX preview with remembered Android device name', async () => {
-    devServiceStub.isServerHandlerRegistered.returns(true);
-    mockFileExists(mockLwcFilePath);
-    existsSyncStub.returns(true);
-    lstatSyncStub.returns({
-      isDirectory() {
-        return true;
-      }
-    } as fs.Stats);
-
-    getConfigurationStub.returns(new MockWorkspace(true));
-    getGlobalStoreStub.returns(new MockMemento());
-    showQuickPickStub.resolves(androidQuickPick);
-    showInputBoxStub.resolves('');
-    await forceLightningLwcPreview(mockLwcFilePathUri);
-    mockExecution.stdoutSubject.next(androidSuccessString);
-
-    sinon.assert.calledOnce(showQuickPickStub);
-    sinon.assert.calledOnce(showInputBoxStub);
-    expect(cmdWithFlagSpy.getCall(0).args).to.have.same.members([
-      '-p',
-      PlatformName.Android
-    ]);
-    expect(cmdWithFlagSpy.getCall(1).args).to.have.same.members([
-      '-t',
-      rememberedAndroidDevice
-    ]);
-    sinon.assert.calledOnce(mobileExecutorStub);
-    expect(successInfoMessageSpy.callCount).to.equal(1);
-    expect(
-      successInfoMessageSpy.calledWith(
-        nls.localize(
-          'force_lightning_lwc_android_start',
-          rememberedAndroidDevice
-        )
-      )
-    );
+    await doRememberedDeviceTest(true);
   });
 
   it('calls SFDX preview with remembered iOS device name', async () => {
+    await doRememberedDeviceTest(false);
+  });
+
+  async function doRememberedDeviceTest(isAndroid: Boolean) {
     devServiceStub.isServerHandlerRegistered.returns(true);
     mockFileExists(mockLwcFilePath);
     existsSyncStub.returns(true);
@@ -760,31 +767,56 @@ describe('forceLightningLwcPreview', () => {
 
     getConfigurationStub.returns(new MockWorkspace(true));
     getGlobalStoreStub.returns(new MockMemento());
-    showQuickPickStub.resolves(iOSQuickPick);
+    showQuickPickStub.resolves(isAndroid ? androidQuickPick : iOSQuickPick);
     showInputBoxStub.resolves('');
     await forceLightningLwcPreview(mockLwcFilePathUri);
-    mockExecution.processExitSubject.next(0);
+
+    if (isAndroid) {
+      mockExecution.stdoutSubject.next(androidSuccessString);
+    } else {
+      mockExecution.processExitSubject.next(0);
+    }
 
     sinon.assert.calledOnce(showQuickPickStub);
     sinon.assert.calledOnce(showInputBoxStub);
+
+    const platform = isAndroid ? PlatformName.Android : PlatformName.iOS;
+    const deviceName = isAndroid
+      ? rememberedAndroidDevice
+      : rememberediOSDevice;
+
     expect(cmdWithFlagSpy.getCall(0).args).to.have.same.members([
       '-p',
-      PlatformName.iOS
+      platform
     ]);
     expect(cmdWithFlagSpy.getCall(1).args).to.have.same.members([
-      '-t',
-      rememberediOSDevice
+      '-p',
+      platform
     ]);
-    sinon.assert.calledOnce(mobileExecutorStub);
+    expect(cmdWithFlagSpy.getCall(2).args).to.have.same.members([
+      '-t',
+      deviceName
+    ]);
+    sinon.assert.calledTwice(mobileExecutorStub); // device list + preview
     expect(successInfoMessageSpy.callCount).to.equal(1);
     expect(
       successInfoMessageSpy.calledWith(
-        nls.localize('force_lightning_lwc_android_start', rememberediOSDevice)
+        isAndroid
+          ? nls.localize('force_lightning_lwc_android_start', deviceName)
+          : nls.localize('force_lightning_lwc_ios_start', deviceName)
       )
     );
-  });
+  }
 
   it('shows warning when you cancel Android device name input', async () => {
+    await doCancelledExecutionTest(true);
+  });
+
+  it('shows warning when you cancel iOS device name input', async () => {
+    await doCancelledExecutionTest(false);
+  });
+
+  async function doCancelledExecutionTest(isAndroid: Boolean) {
     mockFileExists(mockLwcFilePath);
     existsSyncStub.returns(true);
     lstatSyncStub.returns({
@@ -795,84 +827,32 @@ describe('forceLightningLwcPreview', () => {
 
     getConfigurationStub.returns(new MockWorkspace(true));
     getGlobalStoreStub.returns(new MockMemento());
-    showQuickPickStub.resolves(androidQuickPick);
+    showQuickPickStub.resolves(isAndroid ? androidQuickPick : iOSQuickPick);
     // This simulates the user hitting the escape key to cancel input.
     showInputBoxStub.resolves(undefined);
     await forceLightningLwcPreview(mockLwcFilePathUri);
 
     sinon.assert.calledOnce(showQuickPickStub);
     sinon.assert.calledOnce(showInputBoxStub);
-    expect(cmdWithArgSpy.callCount).to.equal(0);
-    expect(cmdWithFlagSpy.callCount).to.equal(0);
-    sinon.assert.notCalled(mobileExecutorStub);
+    expect(cmdWithArgSpy.callCount).to.equal(1);
+    expect(cmdWithFlagSpy.callCount).to.equal(1);
+    sinon.assert.calledOnce(mobileExecutorStub); // device list only (no preview)
     expect(
       showWarningMessageSpy.calledWith(
         nls.localize('force_lightning_lwc_android_device_cancelled')
       )
     );
-  });
-
-  it('shows warning when you cancel iOS device name input', async () => {
-    mockFileExists(mockLwcFilePath);
-    existsSyncStub.returns(true);
-    lstatSyncStub.returns({
-      isDirectory() {
-        return true;
-      }
-    } as fs.Stats);
-
-    getConfigurationStub.returns(new MockWorkspace(true));
-    getGlobalStoreStub.returns(new MockMemento());
-    showQuickPickStub.resolves(iOSQuickPick);
-    // This simulates the user hitting the escape key to cancel input.
-    showInputBoxStub.resolves(undefined);
-    await forceLightningLwcPreview(mockLwcFilePathUri);
-
-    sinon.assert.calledOnce(showQuickPickStub);
-    sinon.assert.calledOnce(showInputBoxStub);
-    expect(cmdWithArgSpy.callCount).to.equal(0);
-    expect(cmdWithFlagSpy.callCount).to.equal(0);
-    sinon.assert.notCalled(mobileExecutorStub);
-    expect(
-      showWarningMessageSpy.calledWith(
-        nls.localize('force_lightning_lwc_ios_device_cancelled')
-      )
-    );
-  });
+  }
 
   it('shows error in console when Android SFDX execution fails', async () => {
-    devServiceStub.isServerHandlerRegistered.returns(true);
-    mockFileExists(mockLwcFilePath);
-    existsSyncStub.returns(true);
-    lstatSyncStub.returns({
-      isDirectory() {
-        return false;
-      }
-    } as fs.Stats);
-
-    getConfigurationStub.returns(new MockWorkspace(false));
-    getGlobalStoreStub.returns(new MockMemento());
-    showQuickPickStub.resolves(androidQuickPick);
-    showInputBoxStub.resolves('');
-    await forceLightningLwcPreview(mockLwcFilePathUri);
-    mockExecution.processExitSubject.next(1);
-
-    sinon.assert.calledOnce(mobileExecutorStub);
-    sinon.assert.calledTwice(showErrorMessageStub);
-    sinon.assert.calledWith(
-      showErrorMessageStub,
-      sinon.match(
-        nls.localize(
-          'force_lightning_lwc_android_failure',
-          androidQuickPick.defaultTargetName
-        )
-      )
-    );
-    sinon.assert.calledOnce(streamCommandOutputSpy);
-    expect(successInfoMessageSpy.callCount).to.equal(0);
+    await doFailedExecutionTest(true);
   });
 
   it('shows error in console when iOS SFDX execution fails', async () => {
+    await doFailedExecutionTest(false);
+  });
+
+  async function doFailedExecutionTest(isAndroid: Boolean) {
     devServiceStub.isServerHandlerRegistered.returns(true);
     mockFileExists(mockLwcFilePath);
     existsSyncStub.returns(true);
@@ -884,25 +864,30 @@ describe('forceLightningLwcPreview', () => {
 
     getConfigurationStub.returns(new MockWorkspace(false));
     getGlobalStoreStub.returns(new MockMemento());
-    showQuickPickStub.resolves(iOSQuickPick);
+    showQuickPickStub.resolves(isAndroid ? androidQuickPick : iOSQuickPick);
     showInputBoxStub.resolves('');
     await forceLightningLwcPreview(mockLwcFilePathUri);
     mockExecution.processExitSubject.next(1);
 
-    sinon.assert.calledOnce(mobileExecutorStub);
+    sinon.assert.calledTwice(mobileExecutorStub); // device list + preview
     sinon.assert.calledTwice(showErrorMessageStub);
     sinon.assert.calledWith(
       showErrorMessageStub,
       sinon.match(
-        nls.localize(
-          'force_lightning_lwc_ios_failure',
-          iOSQuickPick.defaultTargetName
-        )
+        isAndroid
+          ? nls.localize(
+              'force_lightning_lwc_android_failure',
+              androidQuickPick.defaultTargetName
+            )
+          : nls.localize(
+              'force_lightning_lwc_ios_failure',
+              iOSQuickPick.defaultTargetName
+            )
       )
     );
     sinon.assert.calledOnce(streamCommandOutputSpy);
     expect(successInfoMessageSpy.callCount).to.equal(0);
-  });
+  }
 
   it('shows install message if sfdx plugin is not installed', async () => {
     devServiceStub.isServerHandlerRegistered.returns(true);
@@ -919,27 +904,23 @@ describe('forceLightningLwcPreview', () => {
     showQuickPickStub.resolves(androidQuickPick);
     showInputBoxStub.resolves('');
 
-    await forceLightningLwcPreview(mockLwcFilePathUri);
-    mockExecution.processExitSubject.next(127);
-
-    sinon.assert.calledOnce(mobileExecutorStub);
-    sinon.assert.calledWith(
-      showErrorMessageStub,
-      sinon.match(
-        nls.localize(
-          'force_lightning_lwc_android_failure',
-          androidQuickPick.defaultTargetName
-        )
-      )
+    commandOutputStub.returns(
+      Promise.reject(`${sfdxDeviceListCommand} is not a sfdx command.`)
     );
+
+    await forceLightningLwcPreview(mockLwcFilePathUri);
+
+    sinon.assert.calledOnce(mobileExecutorStub); // device list only
+
     sinon.assert.calledWith(
       showErrorMessageStub,
       sinon.match(nls.localize('force_lightning_lwc_no_mobile_plugin'))
     );
-    sinon.assert.calledOnce(streamCommandOutputSpy);
-    expect(successInfoMessageSpy.callCount).to.equal(0);
 
-    sinon.assert.calledTwice(appendLineSpy);
+    sinon.assert.notCalled(streamCommandOutputSpy);
+    sinon.assert.notCalled(successInfoMessageSpy);
+
+    sinon.assert.calledOnce(appendLineSpy);
     expect(
       appendLineSpy.calledWith(
         nls.localize('force_lightning_lwc_no_mobile_plugin')
@@ -966,26 +947,178 @@ describe('forceLightningLwcPreview', () => {
 
     sinon.assert.calledOnce(showQuickPickStub);
     sinon.assert.calledOnce(showInputBoxStub);
-    expect(cmdWithArgSpy.callCount).to.equal(1);
-    expect(cmdWithArgSpy.getCall(0).args[0]).equals(sfdxMobilePreviewCommand);
-    expect(cmdWithFlagSpy.callCount).to.equal(4);
+    expect(cmdWithArgSpy.callCount).to.equal(2);
+    expect(cmdWithArgSpy.getCall(0).args[0]).equals(sfdxDeviceListCommand);
+    expect(cmdWithArgSpy.getCall(1).args[0]).equals(sfdxMobilePreviewCommand);
+    expect(cmdWithFlagSpy.callCount).to.equal(5);
     expect(cmdWithFlagSpy.getCall(0).args).to.have.same.members([
       '-p',
       PlatformName.Android
     ]);
     expect(cmdWithFlagSpy.getCall(1).args).to.have.same.members([
+      '-p',
+      PlatformName.Android
+    ]);
+    expect(cmdWithFlagSpy.getCall(2).args).to.have.same.members([
       '-t',
       'SFDXEmulator'
     ]);
-    expect(cmdWithFlagSpy.getCall(2).args).to.have.same.members([
+    expect(cmdWithFlagSpy.getCall(3).args).to.have.same.members([
       '-n',
       'c/foo'
     ]);
-    expect(cmdWithFlagSpy.getCall(3).args).to.have.same.members([
+    expect(cmdWithFlagSpy.getCall(4).args).to.have.same.members([
       '--loglevel',
       'debug'
     ]);
-    sinon.assert.calledOnce(mobileExecutorStub);
+    sinon.assert.calledTwice(mobileExecutorStub); // device list + preview
     expect(successInfoMessageSpy.callCount).to.equal(1);
   });
+
+  it('Shows device pick list for Android devices', async () => {
+    await doDeviceListQuickPickTest(true);
+  });
+
+  it('Shows device pick list for iOS devices', async () => {
+    await doDeviceListQuickPickTest(false);
+  });
+
+  async function doDeviceListQuickPickTest(isAndroid: Boolean) {
+    devServiceStub.isServerHandlerRegistered.returns(true);
+    mockFileExists(mockLwcFileDirectory);
+    existsSyncStub.returns(true);
+    lstatSyncStub.returns({
+      isDirectory() {
+        return true;
+      }
+    } as fs.Stats);
+
+    getConfigurationStub.returns(new MockWorkspace(false));
+    getGlobalStoreStub.returns(new MockMemento());
+    showQuickPickStub
+      .onFirstCall()
+      .resolves(isAndroid ? androidQuickPick : iOSQuickPick);
+    showQuickPickStub
+      .onSecondCall()
+      .resolves(isAndroid ? androidPickedDevice : iOSPickedDevice);
+    commandOutputStub.returns(
+      Promise.resolve(isAndroid ? androidDeviceListJson : iOSDeviceListJson)
+    );
+
+    await forceLightningLwcPreview(mockLwcFileDirectoryUri);
+
+    if (isAndroid) {
+      mockExecution.stdoutSubject.next(androidSuccessString);
+    } else {
+      mockExecution.processExitSubject.next(0);
+    }
+
+    sinon.assert.calledTwice(showQuickPickStub); // platform + device list
+    sinon.assert.notCalled(showInputBoxStub);
+
+    const platform = isAndroid ? PlatformName.Android : PlatformName.iOS;
+    const deviceName = isAndroid
+      ? androidPickedDevice.label
+      : iOSPickedDevice.label;
+
+    expect(cmdWithFlagSpy.getCall(0).args).to.have.same.members([
+      '-p',
+      platform
+    ]);
+    expect(cmdWithFlagSpy.getCall(1).args).to.have.same.members([
+      '-p',
+      platform
+    ]);
+    expect(cmdWithFlagSpy.getCall(2).args).to.have.same.members([
+      '-t',
+      deviceName
+    ]);
+
+    sinon.assert.calledTwice(mobileExecutorStub); // device list + preview
+
+    expect(successInfoMessageSpy.callCount).to.equal(1);
+    expect(
+      successInfoMessageSpy.calledWith(
+        isAndroid
+          ? nls.localize('force_lightning_lwc_android_start', deviceName)
+          : nls.localize('force_lightning_lwc_ios_start', deviceName)
+      )
+    );
+  }
+
+  it('Shows input box when choosing New from device pick list for Android devices', async () => {
+    await doNewDeviceQuickPickTest(true);
+  });
+
+  it('Shows input box when choosing New from device pick list for iOS devices', async () => {
+    await doNewDeviceQuickPickTest(false);
+  });
+
+  async function doNewDeviceQuickPickTest(isAndroid: Boolean) {
+    const createNewDeviceOption: vscode.QuickPickItem = {
+      label: nls.localize(
+        'force_lightning_lwc_preview_create_virtual_device_label'
+      ),
+      detail: nls.localize(
+        'force_lightning_lwc_preview_create_virtual_device_detail'
+      )
+    };
+
+    const deviceName = isAndroid ? 'androidtestname' : 'iostestname';
+    const platform = isAndroid ? PlatformName.Android : PlatformName.iOS;
+    devServiceStub.isServerHandlerRegistered.returns(true);
+    mockFileExists(mockLwcFileDirectory);
+    existsSyncStub.returns(true);
+    lstatSyncStub.returns({
+      isDirectory() {
+        return true;
+      }
+    } as fs.Stats);
+
+    getConfigurationStub.returns(new MockWorkspace(false));
+    getGlobalStoreStub.returns(new MockMemento());
+    showQuickPickStub
+      .onFirstCall()
+      .resolves(isAndroid ? androidQuickPick : iOSQuickPick);
+    showQuickPickStub.onSecondCall().resolves(createNewDeviceOption);
+    showInputBoxStub.resolves(deviceName);
+    commandOutputStub.returns(
+      Promise.resolve(isAndroid ? androidDeviceListJson : iOSDeviceListJson)
+    );
+
+    await forceLightningLwcPreview(mockLwcFileDirectoryUri);
+
+    if (isAndroid) {
+      mockExecution.stdoutSubject.next(androidSuccessString);
+    } else {
+      mockExecution.processExitSubject.next(0);
+    }
+
+    sinon.assert.calledTwice(showQuickPickStub); // platform + device list
+    sinon.assert.calledOnce(showInputBoxStub);
+
+    expect(cmdWithFlagSpy.getCall(0).args).to.have.same.members([
+      '-p',
+      platform
+    ]);
+    expect(cmdWithFlagSpy.getCall(1).args).to.have.same.members([
+      '-p',
+      platform
+    ]);
+    expect(cmdWithFlagSpy.getCall(2).args).to.have.same.members([
+      '-t',
+      deviceName
+    ]);
+
+    sinon.assert.calledTwice(mobileExecutorStub); // device list + preview
+
+    expect(successInfoMessageSpy.callCount).to.equal(1);
+    expect(
+      successInfoMessageSpy.calledWith(
+        isAndroid
+          ? nls.localize('force_lightning_lwc_android_start', deviceName)
+          : nls.localize('force_lightning_lwc_ios_start', deviceName)
+      )
+    );
+  }
 });


### PR DESCRIPTION
### What does this PR do?
Adds the feature to show a list of available/compatible devices for LWC Preview command and allows the user to pick a device from the list.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/lwc-dev-mobile/issues/21

### Functionality Before
The user was presented with an input box and they had to type in the name of the device manually.

### Functionality After
The user is presented with a quick pick with a list of available/compatible devices and the user can pick one from the list.
