### PR TITLE
Execute anonymous apex if file is not saved

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceApexExecute.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexExecute.ts
@@ -109,10 +109,14 @@ export class AnonApexGatherer
       }
 
       const document = editor.document;
-      if (!editor.selection.isEmpty) {
+      if (!editor.selection.isEmpty || !fs.existsSync(document.uri.fsPath)) {
         return {
           type: 'CONTINUE',
-          data: { apexCode: document.getText(editor.selection) }
+          data: {
+            apexCode: !editor.selection.isEmpty
+              ? document.getText(editor.selection)
+              : document.getText()
+          }
         };
       }
 

--- a/packages/salesforcedx-vscode-core/src/commands/forceApexExecute.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceApexExecute.ts
@@ -109,7 +109,7 @@ export class AnonApexGatherer
       }
 
       const document = editor.document;
-      if (!editor.selection.isEmpty || !fs.existsSync(document.uri.fsPath)) {
+      if (!editor.selection.isEmpty || document.isUntitled) {
         return {
           type: 'CONTINUE',
           data: {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceApexExecute.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceApexExecute.test.ts
@@ -41,11 +41,12 @@ describe('AnonApexGatherer', async () => {
     );
     const mockActiveTextEditor = {
       document: {
-        uri: { fsPath: fileName }
+        uri: { fsPath: fileName },
+        isUntitled: false
       },
       selection: { isEmpty: true }
     };
-    sb.stub(fs, 'existsSync').returns(true);
+
     sb.stub(vscode.window, 'activeTextEditor').get(() => {
       return mockActiveTextEditor;
     });
@@ -68,14 +69,14 @@ describe('AnonApexGatherer', async () => {
     const mockActiveTextEditor = {
       document: {
         uri: { fsPath: fileName },
-        getText: () => text
+        getText: () => text,
+        isUntitled: true
       },
       selection: { isEmpty: true, text: 'System.assert(false);' }
     };
     sb.stub(vscode.window, 'activeTextEditor').get(() => {
       return mockActiveTextEditor;
     });
-    sb.stub(fs, 'existsSync').returns(false);
 
     const fileNameGatherer = new AnonApexGatherer();
     const result = (await fileNameGatherer.gather()) as ContinueResponse<{
@@ -87,7 +88,8 @@ describe('AnonApexGatherer', async () => {
   it(`should return the currently highlighted 'selection' to execute anonymous apex`, async () => {
     const mockActiveTextEditor = {
       document: {
-        getText: (doc: { isEmpty: boolean; text: string }) => doc.text
+        getText: (doc: { isEmpty: boolean; text: string }) => doc.text,
+        isUntitled: true
       },
       selection: { isEmpty: false, text: 'System.assert(true);' }
     };

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceApexExecute.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceApexExecute.test.ts
@@ -6,7 +6,6 @@
  */
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import { expect } from 'chai';
-import * as fs from 'fs';
 import * as path from 'path';
 import { createSandbox, SinonSandbox, SinonSpy, SinonStub } from 'sinon';
 import * as vscode from 'vscode';


### PR DESCRIPTION
### What does this PR do?
This PR addresses the issue where an error is thrown if the user tries to run `SFDX: Execute Anonymous Apex with Editor Contents` when the file has not been saved yet.

### What issues does this PR fix or reference?
#2369, @W-7860461@

