### PR TITLE
Fix snippets for Assertions

### DIFF
--- a/packages/salesforcedx-vscode-apex/snippets/apex.json
+++ b/packages/salesforcedx-vscode-apex/snippets/apex.json
@@ -40,33 +40,33 @@
         ],
         "description": "System.assert(false, message);"
     },
-    "System Assert Equal": {
+    "System Assert Equals": {
         "prefix": "sysasseq",
         "body": [
-            "System.assertEqual(${1:expected}, ${2:actual});"
+            "System.assertEquals(${1:expected}, ${2:actual});"
         ],
-        "description": "System.assertEqual(expected, actual);"
+        "description": "System.assertEquals(expected, actual);"
     },
-    "System Assert not Equal": {
+    "System Assert not Equals": {
         "prefix": "sysassnoteq",
         "body": [
-            "System.assertNotEqual(${1:expected}, ${2:actual});"
+            "System.assertNotEquals(${1:expected}, ${2:actual});"
         ],
-        "description": "System.assertNotEqual(expected, actual);"
+        "description": "System.assertNotEquals(expected, actual);"
     },
     "System Assert null": {
         "prefix": "sysassnull",
         "body": [
-            "System.assertEqual(null, ${1:actual});"
+            "System.assertEquals(null, ${1:actual});"
         ],
-        "description": "System.assertEqual(null, actual);"
+        "description": "System.assertEquals(null, actual);"
     },
     "System Assert Not Null": {
         "prefix": "sysassnotnull",
         "body": [
-            "System.assertNotEqual(null, ${1:actual});"
+            "System.assertNotEquals(null, ${1:actual});"
         ],
-        "description": "System.assertNotEqual(null, actual);"
+        "description": "System.assertNotEquals(null, actual);"
     },
     "DescribeFieldResult": {
         "prefix": "dfr",


### PR DESCRIPTION
### What does this PR do?
Added missing "s" in assertion snippets as per documentation of system method.
https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_methods_system_system.htm

### Functionality Before
Snippets were resolved to "System.AssertEqual" and "System.AssertNotEqual" which gives error: method do not exists.

### Functionality After
Snippets are now resolved to "System.AssertEquals" and "System.AssertNotEquals" which are correct method names as per documentation of System class.
