### PR TITLE
@W-7904975@ Do not show SObject refresh pop up when a project does not have a defaultusername

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/commands/forceGenerateFauxClasses.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceGenerateFauxClasses.ts
@@ -190,7 +190,12 @@ export async function forceGenerateFauxClassesCreate(
 export async function initSObjectDefinitions(projectPath: string) {
   const hasDefaultUsernameSet =
     (await getDefaultUsernameOrAlias()) !== undefined;
-  initSObjectDefinitionsWithUserName(projectPath, hasDefaultUsernameSet);
+  initSObjectDefinitionsWithUserName(projectPath, hasDefaultUsernameSet).catch(e =>
+    telemetryService.sendErrorEvent({
+      message: e.message,
+      stack: e.stack
+    })
+  );
 }
 
 export async function initSObjectDefinitionsWithUserName(projectPath: string, hasDefaultUsernameSet: boolean) {

--- a/packages/salesforcedx-vscode-apex/src/commands/forceGenerateFauxClasses.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceGenerateFauxClasses.ts
@@ -190,6 +190,10 @@ export async function forceGenerateFauxClassesCreate(
 export async function initSObjectDefinitions(projectPath: string) {
   const hasDefaultUsernameSet =
     (await getDefaultUsernameOrAlias()) !== undefined;
+  initSObjectDefinitionsWithUserName(projectPath, hasDefaultUsernameSet);
+}
+
+export async function initSObjectDefinitionsWithUserName(projectPath: string, hasDefaultUsernameSet: boolean) {
   if (projectPath && hasDefaultUsernameSet) {
     const sobjectFolder = getSObjectsDirectory(projectPath);
     if (!fs.existsSync(sobjectFolder)) {
@@ -210,7 +214,9 @@ function getSObjectsDirectory(projectPath: string) {
 }
 
 export async function checkSObjectsAndRefresh(projectPath: string) {
-  if (projectPath) {
+  const hasDefaultUsernameSet =
+    await getDefaultUsernameOrAlias();
+  if (projectPath && hasDefaultUsernameSet) {
     if (!fs.existsSync(getSObjectsDirectory(projectPath))) {
       telemetryService.sendEventData('sObjectRefreshNotification',
         { type: 'No SObjects' },
@@ -222,7 +228,7 @@ export async function checkSObjectsAndRefresh(projectPath: string) {
         telemetryService.sendEventData('sObjectRefreshNotification',
           { type: 'Requested Refresh' },
           undefined);
-        initSObjectDefinitions(projectPath).catch(e =>
+        initSObjectDefinitionsWithUserName(projectPath, hasDefaultUsernameSet).catch(e =>
           telemetryService.sendErrorEvent({
             message: e.message,
             stack: e.stack

--- a/packages/salesforcedx-vscode-apex/src/commands/forceGenerateFauxClasses.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceGenerateFauxClasses.ts
@@ -187,19 +187,21 @@ export async function forceGenerateFauxClassesCreate(
   await commandlet.run();
 }
 
-export async function initSObjectDefinitions(projectPath: string) {
+export async function verifyUsernameAndInitSObjectDefinitions(projectPath: string) {
   const hasDefaultUsernameSet =
     (await getDefaultUsernameOrAlias()) !== undefined;
-  initSObjectDefinitionsWithUserName(projectPath, hasDefaultUsernameSet).catch(e =>
-    telemetryService.sendErrorEvent({
-      message: e.message,
-      stack: e.stack
-    })
-  );
+  if (hasDefaultUsernameSet) {
+    initSObjectDefinitions(projectPath).catch(e =>
+      telemetryService.sendErrorEvent({
+        message: e.message,
+        stack: e.stack
+      })
+    );
+  }
 }
 
-export async function initSObjectDefinitionsWithUserName(projectPath: string, hasDefaultUsernameSet: boolean) {
-  if (projectPath && hasDefaultUsernameSet) {
+export async function initSObjectDefinitions(projectPath: string) {
+  if (projectPath) {
     const sobjectFolder = getSObjectsDirectory(projectPath);
     if (!fs.existsSync(sobjectFolder)) {
       forceGenerateFauxClassesCreate(SObjectRefreshSource.Startup).catch(e => {
@@ -233,7 +235,7 @@ export async function checkSObjectsAndRefresh(projectPath: string) {
         telemetryService.sendEventData('sObjectRefreshNotification',
           { type: 'Requested Refresh' },
           undefined);
-        initSObjectDefinitionsWithUserName(projectPath, hasDefaultUsernameSet).catch(e =>
+        initSObjectDefinitions(projectPath).catch(e =>
           telemetryService.sendErrorEvent({
             message: e.message,
             stack: e.stack

--- a/packages/salesforcedx-vscode-apex/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/index.ts
@@ -12,4 +12,4 @@ export {
   forceApexTestMethodRunCodeActionDelegate,
   ForceApexTestRunCodeActionExecutor
 } from './forceApexTestRunCodeAction';
-export { checkSObjectsAndRefresh, forceGenerateFauxClassesCreate, initSObjectDefinitions } from './forceGenerateFauxClasses';
+export { checkSObjectsAndRefresh, forceGenerateFauxClassesCreate, verifyUsernameAndInitSObjectDefinitions as initSObjectDefinitions } from './forceGenerateFauxClasses';

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceGenerateFauxClasses.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceGenerateFauxClasses.test.ts
@@ -25,9 +25,9 @@ import { ProgressLocation } from 'vscode';
 import {
   checkSObjectsAndRefresh,
   ForceGenerateFauxClassesExecutor,
-  initSObjectDefinitions,
   RefreshSelection,
-  SObjectRefreshGatherer
+  SObjectRefreshGatherer,
+  verifyUsernameAndInitSObjectDefinitions
 } from '../../../src/commands/forceGenerateFauxClasses';
 import * as forceGenerateFauxClasses from '../../../src/commands/forceGenerateFauxClasses';
 import { nls } from '../../../src/messages';
@@ -71,7 +71,7 @@ describe('ForceGenerateFauxClasses', () => {
       existsSyncStub.returns(false);
       getUsernameStub.returns(new Map([['defaultusername', 'Sample']]));
 
-      await initSObjectDefinitions(projectPath);
+      await verifyUsernameAndInitSObjectDefinitions(projectPath);
 
       expect(existsSyncStub.calledWith(sobjectsPath)).to.be.true;
       expect(commandletSpy.calledOnce).to.be.true;
@@ -86,7 +86,7 @@ describe('ForceGenerateFauxClasses', () => {
       existsSyncStub.returns(true);
       getUsernameStub.returns('Sample');
 
-      await initSObjectDefinitions(projectPath);
+      await verifyUsernameAndInitSObjectDefinitions(projectPath);
 
       expect(existsSyncStub.calledWith(sobjectsPath)).to.be.true;
       expect(commandletSpy.notCalled).to.be.true;
@@ -96,7 +96,7 @@ describe('ForceGenerateFauxClasses', () => {
       existsSyncStub.returns(false);
       getUsernameStub.returns(undefined);
 
-      await initSObjectDefinitions(projectPath);
+      await verifyUsernameAndInitSObjectDefinitions(projectPath);
 
       expect(commandletSpy.notCalled).to.be.true;
     });

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceGenerateFauxClasses.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceGenerateFauxClasses.test.ts
@@ -105,6 +105,7 @@ describe('ForceGenerateFauxClasses', () => {
   describe('checkSObjectsAndRefresh', () => {
     let existsSyncStub: sinon.SinonStub;
     let notificationStub: sinon.SinonStub;
+    let getUsernameStub: sinon.SinonStub;
 
     const projectPath = path.join('sample', 'path');
     const sobjectsPath = path.join(
@@ -117,16 +118,19 @@ describe('ForceGenerateFauxClasses', () => {
     beforeEach(() => {
       existsSyncStub = sinon.stub(fs, 'existsSync');
       notificationStub = sinon.stub(notificationService, 'showInformationMessage');
+      getUsernameStub = sinon.stub(OrgAuthInfo, 'getDefaultUsernameOrAlias');
     });
 
     afterEach(() => {
       existsSyncStub.restore();
       notificationStub.restore();
+      getUsernameStub.restore();
     });
 
     it('Should call notification service when sobjects already exist', async () => {
       existsSyncStub.returns(false);
       notificationStub.returns('Run SFDX: Refresh SObject Definitions now');
+      getUsernameStub.returns(new Map([['defaultusername', 'Sample']]));
 
       await checkSObjectsAndRefresh(projectPath);
 
@@ -137,10 +141,20 @@ describe('ForceGenerateFauxClasses', () => {
     it('Should not call notification service when sobjects already exist', async () => {
       existsSyncStub.returns(true);
       notificationStub.returns('Run SFDX: Refresh SObject Definitions now');
+      getUsernameStub.returns(new Map([['defaultusername', 'Sample']]));
 
       await checkSObjectsAndRefresh(projectPath);
 
       expect(existsSyncStub.calledWith(sobjectsPath)).to.be.true;
+      expect(notificationStub.notCalled).to.be.true;
+    });
+
+    it('Should not call notification service when username not set', async () => {
+      notificationStub.returns('Run SFDX: Refresh SObject Definitions now');
+      getUsernameStub.returns(undefined);
+
+      await checkSObjectsAndRefresh(projectPath);
+
       expect(notificationStub.notCalled).to.be.true;
     });
   });


### PR DESCRIPTION
### What does this PR do?
Checks if an org has been authorized before showing a pop up to refresh sobjects

### What issues does this PR fix or reference?
@W-7904975@

### Functionality Before
![Screen Shot 2020-07-20 at 2 34 46 PM](https://user-images.githubusercontent.com/58611665/89310089-19054380-d629-11ea-914e-1572f593b431.png)


### Functionality After
The pop up to refresh sobject is not shown if no org is authorized.
