### PR TITLE
SOQL Language Client (replaces #2395)

### DIFF
--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -19,7 +19,9 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/soql-builder-ui": "0.0.2"
+    "@salesforce/soql-builder-ui": "0.0.2",
+    "@salesforce/soql-language-server": "0.1.0",
+    "vscode-languageclient": "^6.1.3"
   },
   "devDependencies": {
     "@types/node": "12.0.12",
@@ -39,7 +41,8 @@
     "vscode:package": "vsce package"
   },
   "activationEvents": [
-    "onCustomEditor:soqlCustom.soql"
+    "onCustomEditor:soqlCustom.soql",
+    "onLanguage:soql"
   ],
   "main": "./out/src",
   "contributes": {
@@ -53,6 +56,18 @@
           }
         ],
         "priority": "default"
+      }
+    ],
+    "languages": [
+      {
+        "id": "soql",
+        "aliases": [
+          "soql",
+          "SOQL"
+        ],
+        "extensions": [
+          ".soql"
+        ]
       }
     ]
   }

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "@salesforce/soql-builder-ui": "0.0.2",
-    "@salesforce/soql-language-server": "0.1.0",
+    "@salesforce/soql-language-server": "0.2.1",
     "vscode-languageclient": "^6.1.3"
   },
   "devDependencies": {

--- a/packages/salesforcedx-vscode-soql/src/client/client.ts
+++ b/packages/salesforcedx-vscode-soql/src/client/client.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as path from 'path';
+import { ExtensionContext, workspace } from 'vscode';
+
+import {
+  LanguageClient,
+  LanguageClientOptions,
+  ServerOptions,
+  TransportKind
+} from 'vscode-languageclient';
+
+let client: LanguageClient;
+
+export function startLanguageClient(context: ExtensionContext) {
+  // path to language server module
+  const serverModule = context.asAbsolutePath(
+    path.join(
+      'node_modules',
+      '@salesforce',
+      'soql-language-server',
+      'lib',
+      'server.js'
+    )
+  );
+  const debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] };
+
+  // provide for different run/debug modes
+  const serverOptions: ServerOptions = {
+    run: { module: serverModule, transport: TransportKind.ipc },
+    debug: {
+      module: serverModule,
+      transport: TransportKind.ipc,
+      options: debugOptions
+    }
+  };
+
+  const clientOptions: LanguageClientOptions = {
+    documentSelector: [{ scheme: 'file', language: 'soql' }],
+    synchronize: {
+      configurationSection: 'soql',
+      fileEvents: workspace.createFileSystemWatcher('**/.soql')
+    }
+  };
+
+  // Create the language client and start the client.
+  client = new LanguageClient(
+    'soql-language-server',
+    'SOQL Language Server',
+    serverOptions,
+    clientOptions
+  );
+
+  // Start the client. This will also launch the server
+  client.start();
+}
+
+export function stopLanguageClient(): Thenable<void> | undefined {
+  if (!client) {
+    return undefined;
+  }
+  return client.stop();
+}

--- a/packages/salesforcedx-vscode-soql/src/client/client.ts
+++ b/packages/salesforcedx-vscode-soql/src/client/client.ts
@@ -44,7 +44,7 @@ export function startLanguageClient(context: ExtensionContext) {
     documentSelector: [{ scheme: 'file', language: 'soql' }],
     synchronize: {
       configurationSection: 'soql',
-      fileEvents: workspace.createFileSystemWatcher('**/.soql')
+      fileEvents: workspace.createFileSystemWatcher('**/*.soql')
     }
   };
 

--- a/packages/salesforcedx-vscode-soql/src/index.ts
+++ b/packages/salesforcedx-vscode-soql/src/index.ts
@@ -6,9 +6,15 @@
  */
 
 import * as vscode from 'vscode';
+import { startLanguageClient, stopLanguageClient } from './client/client';
 import { SOQLEditorProvider } from './editor/soqlEditorProvider';
 
 export function activate(context: vscode.ExtensionContext) {
   console.log('SOQL Extension Activated');
   context.subscriptions.push(SOQLEditorProvider.register(context));
+  startLanguageClient(context);
+}
+
+export function deactivate(): Thenable<void> | undefined {
+  return stopLanguageClient();
 }


### PR DESCRIPTION
### What does this PR do?
This PR implements a SOQL language client to connect with the SOQL language server.

### What issues does this PR fix or reference?
@W-7904819@

### Functionality Before
Functions in the text editor for SOQL files is provided by the Apex language server.

### Functionality After
Functions in the text editor for SOQL files is provided by the SOQL language server.

### Notes
- Since the SOQL extension is not ready to release, the .soql extension support for the Apex language server is not removed. It will be at a later time.
- CI did not work on https://github.com/forcedotcom/salesforcedx-vscode/pull/2395 since that PR was from a fork and not a feature branch.