### PR TITLE
ISV Debugger - Clear project prior to new creation (@W-5620191)

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
@@ -250,6 +250,9 @@ export class IsvDebugBootstrapExecutor extends SfdxCommandletExecutor<{}> {
       this.relativeInstalledPackagesPath
     );
 
+    // remove any previous project at this path location
+    shell.rm('-rf', projectPath);
+
     // 1: create project
     await this.executeCommand(
       this.buildCreateProjectCommand(response.data),
@@ -265,6 +268,8 @@ export class IsvDebugBootstrapExecutor extends SfdxCommandletExecutor<{}> {
       cancellationTokenSource,
       cancellationToken
     );
+
+    console.log('It got here at least');
 
     // 2b: update sfdx-project.json with namespace
     const orgNamespaceInfoResponseJson = await this.executeCommand(
@@ -383,6 +388,9 @@ export class IsvDebugBootstrapExecutor extends SfdxCommandletExecutor<{}> {
     try {
       const packagesTempPath = path.join(projectMetadataTempPath, 'packages');
       shell.mkdir('-p', packagesTempPath);
+
+      // Remove any previous installed packages at this location.
+      // shell.rm('-rf', projectInstalledPackagesPath);
       shell.mkdir('-p', projectInstalledPackagesPath);
       const zip = new AdmZip(
         path.join(projectMetadataTempPath, 'unpackaged.zip')

--- a/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
@@ -269,8 +269,6 @@ export class IsvDebugBootstrapExecutor extends SfdxCommandletExecutor<{}> {
       cancellationToken
     );
 
-    console.log('It got here at least');
-
     // 2b: update sfdx-project.json with namespace
     const orgNamespaceInfoResponseJson = await this.executeCommand(
       this.buildQueryForOrgNamespacePrefixCommand(response.data),
@@ -388,9 +386,6 @@ export class IsvDebugBootstrapExecutor extends SfdxCommandletExecutor<{}> {
     try {
       const packagesTempPath = path.join(projectMetadataTempPath, 'packages');
       shell.mkdir('-p', packagesTempPath);
-
-      // Remove any previous installed packages at this location.
-      // shell.rm('-rf', projectInstalledPackagesPath);
       shell.mkdir('-p', projectInstalledPackagesPath);
       const zip = new AdmZip(
         path.join(projectMetadataTempPath, 'unpackaged.zip')

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -202,8 +202,7 @@ export const messages = {
     'SFDX: ISV Debugger Setup, Step 7 of 7: Converting package: %s',
   isv_debug_bootstrap_processing_package: 'Processing package: %s',
   isv_debug_bootstrap_generate_launchjson: 'Creating launch configuration',
-  isv_debug_bootstrap_open_project:
-    'Opening project in new Visual Studio Code window',
+  isv_debug_bootstrap_open_project: 'Opening project in Visual Studio Code',
 
   force_apex_log_get_text: 'SFDX: Get Apex Debug Logs...',
   force_apex_log_get_no_logs_text: 'No Apex debug logs were found',

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/isvdebugger/bootstrapCmd.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/isvdebugger/bootstrapCmd.test.ts
@@ -19,7 +19,7 @@ import { getRootWorkspacePath } from '../../../../src/util';
 describe('ISV Debugging Project Bootstrap Command', () => {
   const LOGIN_URL = 'a.b.c';
   const SESSION_ID = '0x123';
-  const PROJECT_NAME = 'sfdx-simple';
+  const PROJECT_NAME = 'sfdx-simple-test';
   const WORKSPACE_PATH = path.join(getRootWorkspacePath(), '..');
   const PROJECT_DIR: vscode.Uri[] = [vscode.Uri.parse(WORKSPACE_PATH)];
 
@@ -376,6 +376,10 @@ describe('ISV Debugging Project Bootstrap Command', () => {
         projectPath,
         executor.relativeMetdataTempPath
       );
+      const projectInstalledPackagesPath = path.join(
+        projectPath,
+        executor.relativeInstalledPackagesPath
+      );
 
       // fake namespace query
       executeCommandSpy
@@ -416,16 +420,9 @@ describe('ISV Debugging Project Bootstrap Command', () => {
         zip.writeZip(path.join(projectMetadataTempPath, 'unpackaged.zip'));
       });
 
-      // fake package metadate convert
+      // fake package metadata convert
       executeCommandSpy.onCall(7).callsFake(() => {
-        shell.mkdir(
-          '-p',
-          path.join(
-            projectPath,
-            executor.relativeInstalledPackagesPath,
-            'mypackage'
-          )
-        );
+        shell.mkdir('-p', path.join(projectInstalledPackagesPath, 'mypackage'));
       });
 
       const input = {
@@ -446,6 +443,18 @@ describe('ISV Debugging Project Bootstrap Command', () => {
         fs.existsSync(path.join(projectPath, '.vscode', 'launch.json')),
         'there must be a launch.json file'
       ).to.equal(true);
+
+      // expect(
+      //   fs.existsSync(path.join(projectInstalledPackagesPath, 'mypackage')),
+      //   'installed packages folder should be present'
+      // ).to.equal(true);
+
+      // const dirInfo = fs.readdirSync(projectInstalledPackagesPath);
+      // // there should be only one package in the installed-packages folder
+      // expect(
+      //   dirInfo.length,
+      //   `There should only be one package installed at ${projectInstalledPackagesPath}`
+      // ).to.equal(1);
 
       // any temp files should be gone
       expect(


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with the ISV Debugger that leaves stale unmanaged source and installed packages. Upon creation of the ISV project, we will remove the current project after prompting the user with an overwrite prompt.

### What issues does this PR fix or reference?
@W-5620191@

### Functionality Before
_This screen recording shows an old 'Subscriber' project being overwritten by a new 'Subscriber' project with the ISV Debugger. Upon completion, there are still old installed-packages at `.sfdx/tools/installed-packages`, along with old unmanaged source code in `force-app/main/default/classes`._
![debugger_before_editted](https://user-images.githubusercontent.com/45604118/89840193-db268480-db2c-11ea-9bf9-e7a93db598fb.gif)

### Functionality After
_This screen recording shows an old 'Subscriber' project being completely overwritten by the new 'Subscriber' project. Only the new installed-packages are seen in `.sfdx/tools/installed-packages` and old unmanaged source code is no longer present._
![debugging_after_edited](https://user-images.githubusercontent.com/45604118/89840366-4e2ffb00-db2d-11ea-9c0a-e504c62880cd.gif)