### PR TITLE
@W-7905048@ Refresh ignores sobjects ending with Share, History, Feed and Event

### DIFF
--- a/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
@@ -215,10 +215,8 @@ export class FauxClassGenerator {
 
   // VisibleForTesting
   public isRequiredSObject(sobject: string): boolean {
-    if (sobject.endsWith('Share') || sobject.endsWith('History') || sobject.endsWith('Feed') || sobject.endsWith('Event')) {
-      return false;
-    }
-    return true;
+    // Ignore all sobjects that end with Share or History or Feed or Event
+    return !/Share$|History$|Feed$|Event$/.test(sobject);
   }
 
   // VisibleForTesting

--- a/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
@@ -94,7 +94,7 @@ export class FauxClassGenerator {
   private static fieldDeclToString(decl: FieldDeclaration): string {
     return `${FauxClassGenerator.commentToString(decl.comment)}${INDENT}${
       decl.modifier
-    } ${decl.type} ${decl.name};`;
+      } ${decl.type} ${decl.name};`;
   }
 
   // VisibleForTesting
@@ -102,9 +102,9 @@ export class FauxClassGenerator {
     // for some reasons if the comment is on a single line the help context shows the last '*/'
     return comment
       ? `${INDENT}/* ${comment.replace(
-          /(\/\*+\/)|(\/\*+)|(\*+\/)/g,
-          ''
-        )}${EOL}${INDENT}*/${EOL}`
+        /(\/\*+\/)|(\/\*+)|(\*+\/)/g,
+        ''
+      )}${EOL}${INDENT}*/${EOL}`
       : '';
   }
 
@@ -163,8 +163,9 @@ export class FauxClassGenerator {
         err.stack
       );
     }
+    const filteredSObjects = sobjects.filter(this.isRequiredSObject);
     let j = 0;
-    while (j < sobjects.length) {
+    while (j < filteredSObjects.length) {
       try {
         if (
           this.cancellationToken &&
@@ -173,7 +174,7 @@ export class FauxClassGenerator {
           return this.cancelExit();
         }
         fetchedSObjects = fetchedSObjects.concat(
-          await describe.describeSObjectBatch(projectPath, sobjects, j)
+          await describe.describeSObjectBatch(projectPath, filteredSObjects, j)
         );
         j = fetchedSObjects.length;
       } catch (errorMessage) {
@@ -210,6 +211,14 @@ export class FauxClassGenerator {
     }
 
     return this.successExit();
+  }
+
+  // VisibleForTesting
+  public isRequiredSObject(sobject: string): boolean {
+    if (sobject.endsWith('Share') || sobject.endsWith('History') || sobject.endsWith('Feed') || sobject.endsWith('Event')) {
+      return false;
+    }
+    return true;
   }
 
   // VisibleForTesting

--- a/packages/salesforcedx-sobjects-faux-generator/test/unit/fauxClassGenerator.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/unit/fauxClassGenerator.test.ts
@@ -432,5 +432,13 @@ describe('SObject faux class generator', () => {
       expect(!fs.existsSync(customFolder));
       expect(!fs.existsSync(standardFolder));
     });
+
+    it('Should remove sobjects ending with Share, History, Feed, Event', () => {
+      const sobjects: string[] = ['xShare', 'Sharex', 'yHistory', 'xFeed', 'xFeedy', 'zEvent'];
+      const output = sobjects.filter(gen.isRequiredSObject);
+      expect(output.length).to.equal(2);
+      expect(output).to.contain('Sharex');
+      expect(output).to.contain('xFeedy');
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Refresh ignores sobjects ending with Share, History, Feed and Event

### What issues does this PR fix or reference?
@W-7905048@

### Functionality Before
All sobjects definitions are fetched ( about 568)

### Functionality After
SObjects ending with Share, History, Feed and Event are filtered out while refreshing SObjects either at the project loading or when "Refresh SObject Definition" command is run (386 sobjects in all).