### PR TITLE
Update java-setup.md Advanced setup

### DIFF
--- a/docs/_articles/en/getting-started/java-setup.md
+++ b/docs/_articles/en/getting-started/java-setup.md
@@ -126,6 +126,6 @@ By default, a JVM allocates up to one fourth of the system's physical memory to 
 
 ```json
 {
-  "salesforcedx-vscode-apex.java.memory": "4096"
+  "salesforcedx-vscode-apex.java.memory": 4096
 }
 ```


### PR DESCRIPTION

### What does this PR do?
Fix the exemple on the Advanced Setup for setting up Java.
The type required for the setting "salesforcedx-vscode-apex.java.memory" is integer, not string.
The example have been updated accordingly.

### Functionality Before
Example in [Advanced Setup](https://developer.salesforce.com/tools/vscode/en/getting-started/java-setup/#advanced-setup) is using string.
![image](https://user-images.githubusercontent.com/32196400/90622613-a34acb80-e215-11ea-8fd2-d91d7b3f250e.png)


### Functionality After
Example in Advanced Setup is using integer as required.