### PR TITLE
Use @salesforce/templates library for template creation

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -29,6 +29,7 @@
     "@salesforce/core": "2.5.1",
     "@salesforce/salesforcedx-utils-vscode": "49.6.0",
     "@salesforce/source-deploy-retrieve": "1.0.18",
+    "@salesforce/templates": "49.4.3",
     "adm-zip": "0.4.13",
     "applicationinsights": "1.0.7",
     "glob": "^7.1.2",
@@ -39,7 +40,6 @@
   },
   "devDependencies": {
     "@salesforce/salesforcedx-test-utils-vscode": "49.6.0",
-    "@salesforce/templates": "49.4.3",
     "@salesforce/ts-sinon": "^1.0.0",
     "@types/adm-zip": "^0.4.31",
     "@types/chai": "^4.0.0",
@@ -50,6 +50,7 @@
     "@types/shelljs": "^0.7.8",
     "@types/sinon": "^2.3.2",
     "@types/vscode": "1.40.0",
+    "@types/yeoman-assert": "^3.1.1",
     "chai": "^4.0.2",
     "cross-env": "5.2.0",
     "mocha": "^5",
@@ -58,7 +59,8 @@
     "mock-spawn": "0.2.6",
     "nyc": "^13",
     "sinon": "^7.3.1",
-    "typescript": "3.7.5"
+    "typescript": "3.7.5",
+    "yeoman-assert": "^3.1.1"
   },
   "scripts": {
     "vscode:prepublish": "npm prune --production",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -29,7 +29,7 @@
     "@salesforce/core": "2.5.1",
     "@salesforce/salesforcedx-utils-vscode": "49.6.0",
     "@salesforce/source-deploy-retrieve": "1.0.18",
-    "@salesforce/templates": "49.4.3",
+    "@salesforce/templates": "49.4.4",
     "adm-zip": "0.4.13",
     "applicationinsights": "1.0.7",
     "glob": "^7.1.2",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@salesforce/salesforcedx-test-utils-vscode": "49.6.0",
+    "@salesforce/templates": "49.4.3",
     "@salesforce/ts-sinon": "^1.0.0",
     "@types/adm-zip": "^0.4.31",
     "@types/chai": "^4.0.0",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -813,7 +813,7 @@
         },
         "salesforcedx-vscode-core.experimental.useTemplatesLibrary": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "%experimental_templates_library_description%"
         }
       }

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -808,6 +808,11 @@
           "type": "boolean",
           "default": true,
           "description": "%experimental_apex_library_description%"
+        },
+        "salesforcedx-vscode-core.experimental.useTemplatesLibrary": {
+          "type": "boolean",
+          "default": false,
+          "description": "%experimental_templates_library_description%"
         }
       }
     },

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -64,5 +64,6 @@
   "force_diff_against_org": "SFDX: Diff File Against Org",
   "force_analytics_template_create_text": "SFDX: Create Sample Analytics Template",
   "experimental_deploy_retrieve_description": "Enable performance enhancements to the deploy/retrieve experience.",
-  "experimental_apex_library_description": "Use Apex Library for Apex CLI commands"
+  "experimental_apex_library_description": "Use Apex Library for Apex CLI commands",
+  "experimental_templates_library_description": "Use Templates Library for Templates CLI commands"
 }

--- a/packages/salesforcedx-vscode-core/src/commands/templates/forceAnalyticsTemplateCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/forceAnalyticsTemplateCreate.ts
@@ -36,7 +36,7 @@ import {
 } from './metadataTypeConstants';
 
 export class LibraryForceAnalyticsTemplateCreateExecutor extends LibraryBaseTemplateCommand<
-  DirFileNameSelection
+  TemplateAndDir
 > {
   public executionName = nls.localize('force_analytics_template_create_text');
   public telemetryName = 'force_analytics_template_create';
@@ -45,10 +45,10 @@ export class LibraryForceAnalyticsTemplateCreateExecutor extends LibraryBaseTemp
   public getFileExtension(): string {
     return '.json';
   }
-  public getOutputFileName(data: DirFileNameSelection) {
+  public getOutputFileName(data: TemplateAndDir) {
     return data.fileName;
   }
-  public constructTemplateOptions(data: DirFileNameSelection) {
+  public constructTemplateOptions(data: TemplateAndDir) {
     const templateOptions: AnalyticsTemplateOptions = {
       outputdir: data.outputdir,
       templatename: data.fileName

--- a/packages/salesforcedx-vscode-core/src/commands/templates/forceApexClassCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/forceApexClassCreate.ts
@@ -14,6 +14,7 @@ import {
 import { DirFileNameSelection } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import { LocalComponent } from '@salesforce/salesforcedx-utils-vscode/src/types';
 import { nls } from '../../messages';
+import { sfdxCoreSettings } from '../../settings';
 import {
   CompositeParametersGatherer,
   MetadataTypeGatherer,
@@ -70,7 +71,9 @@ const outputDirGatherer = new SelectOutputDir(APEX_CLASS_DIRECTORY);
 const metadataTypeGatherer = new MetadataTypeGatherer(APEX_CLASS_TYPE);
 
 export async function forceApexClassCreate() {
-  const libraryExecutor = new LibraryForceApexClassCreateExecutor();
+  const createTemplateExecutor = sfdxCoreSettings.getTemplatesLibrary()
+    ? new LibraryForceApexClassCreateExecutor()
+    : new ForceApexClassCreateExecutor();
   const commandlet = new SfdxCommandlet(
     new SfdxWorkspaceChecker(),
     new CompositeParametersGatherer<LocalComponent>(
@@ -78,7 +81,7 @@ export async function forceApexClassCreate() {
       fileNameGatherer,
       outputDirGatherer
     ),
-    libraryExecutor, // new ForceApexClassCreateExecutor(),
+    createTemplateExecutor,
     new OverwriteComponentPrompt()
   );
   await commandlet.run();

--- a/packages/salesforcedx-vscode-core/src/commands/templates/forceApexClassCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/forceApexClassCreate.ts
@@ -25,9 +25,8 @@ import {
 } from '../util';
 import { OverwriteComponentPrompt } from '../util/postconditionCheckers';
 import { BaseTemplateCommand } from './baseTemplateCommand';
-import { APEX_CLASS_DIRECTORY, APEX_CLASS_TYPE } from './metadataTypeConstants';
-
 import { LibraryBaseTemplateCommand } from './libraryBaseTemplateCommand';
+import { APEX_CLASS_DIRECTORY, APEX_CLASS_TYPE } from './metadataTypeConstants';
 
 export class LibraryForceApexClassCreateExecutor extends LibraryBaseTemplateCommand<
   DirFileNameSelection

--- a/packages/salesforcedx-vscode-core/src/commands/templates/forceApexClassCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/forceApexClassCreate.ts
@@ -5,6 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { ApexClassOptions, TemplateType } from '@salesforce/templates';
+
 import {
   Command,
   SfdxCommandBuilder
@@ -23,6 +25,28 @@ import {
 import { OverwriteComponentPrompt } from '../util/postconditionCheckers';
 import { BaseTemplateCommand } from './baseTemplateCommand';
 import { APEX_CLASS_DIRECTORY, APEX_CLASS_TYPE } from './metadataTypeConstants';
+
+import { LibraryBaseTemplateCommand } from './libraryBaseTemplateCommand';
+
+export class LibraryForceApexClassCreateExecutor extends LibraryBaseTemplateCommand<
+  DirFileNameSelection
+> {
+  public executionName = nls.localize('force_apex_class_create_text');
+  public telemetryName = 'force_apex_class_create';
+  public metadataTypeName = APEX_CLASS_TYPE;
+  public templateType = TemplateType.ApexClass;
+  public getOutputFileName(data: DirFileNameSelection) {
+    return data.fileName;
+  }
+  public constructTemplateOptions(data: DirFileNameSelection) {
+    const templateOptions: ApexClassOptions = {
+      template: 'DefaultApexClass',
+      classname: data.fileName,
+      outputdir: data.outputdir
+    };
+    return templateOptions;
+  }
+}
 
 export class ForceApexClassCreateExecutor extends BaseTemplateCommand {
   constructor() {
@@ -46,6 +70,7 @@ const outputDirGatherer = new SelectOutputDir(APEX_CLASS_DIRECTORY);
 const metadataTypeGatherer = new MetadataTypeGatherer(APEX_CLASS_TYPE);
 
 export async function forceApexClassCreate() {
+  const libraryExecutor = new LibraryForceApexClassCreateExecutor();
   const commandlet = new SfdxCommandlet(
     new SfdxWorkspaceChecker(),
     new CompositeParametersGatherer<LocalComponent>(
@@ -53,7 +78,7 @@ export async function forceApexClassCreate() {
       fileNameGatherer,
       outputDirGatherer
     ),
-    new ForceApexClassCreateExecutor(),
+    libraryExecutor, // new ForceApexClassCreateExecutor(),
     new OverwriteComponentPrompt()
   );
   await commandlet.run();

--- a/packages/salesforcedx-vscode-core/src/commands/templates/forceLightningInterfaceCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/forceLightningInterfaceCreate.ts
@@ -5,6 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { LightningInterfaceOptions, TemplateType } from '@salesforce/templates';
+import { LibraryBaseTemplateCommand } from './libraryBaseTemplateCommand';
+
 import {
   Command,
   SfdxCommandBuilder
@@ -33,6 +36,31 @@ import {
   AURA_INTERFACE_EXTENSION,
   AURA_TYPE
 } from './metadataTypeConstants';
+
+export class LibraryForceLightningInterfaceCreateExecutor extends LibraryBaseTemplateCommand<
+  DirFileNameSelection
+> {
+  public executionName = nls.localize('force_lightning_interface_create_text');
+  public telemetryName = 'force_lightning_interface_create';
+  public metadataTypeName = AURA_TYPE;
+  public templateType = TemplateType.LightningInterface;
+  public getOutputFileName(data: DirFileNameSelection) {
+    return data.fileName;
+  }
+  public getFileExtension() {
+    return AURA_INTERFACE_EXTENSION;
+  }
+  public constructTemplateOptions(data: DirFileNameSelection) {
+    const internal = sfdxCoreSettings.getInternalDev();
+    const templateOptions: LightningInterfaceOptions = {
+      outputdir: data.outputdir,
+      interfacename: data.fileName,
+      template: 'DefaultLightningIntf',
+      internal
+    };
+    return templateOptions;
+  }
+}
 
 export class ForceLightningInterfaceCreateExecutor extends BaseTemplateCommand {
   constructor() {
@@ -64,6 +92,9 @@ const outputDirGatherer = new SelectOutputDir(AURA_DIRECTORY, true);
 const metadataTypeGatherer = new MetadataTypeGatherer(AURA_TYPE);
 
 export async function forceLightningInterfaceCreate() {
+  const createTemplateExecutor = sfdxCoreSettings.getTemplatesLibrary()
+    ? new LibraryForceLightningInterfaceCreateExecutor()
+    : new ForceLightningInterfaceCreateExecutor();
   const commandlet = new SfdxCommandlet(
     new SfdxWorkspaceChecker(),
     new CompositeParametersGatherer<LocalComponent>(
@@ -71,20 +102,23 @@ export async function forceLightningInterfaceCreate() {
       fileNameGatherer,
       outputDirGatherer
     ),
-    new ForceLightningInterfaceCreateExecutor(),
+    createTemplateExecutor,
     new OverwriteComponentPrompt()
   );
   await commandlet.run();
 }
 
 export async function forceInternalLightningInterfaceCreate(sourceUri: Uri) {
+  const createTemplateExecutor = sfdxCoreSettings.getTemplatesLibrary()
+    ? new LibraryForceLightningInterfaceCreateExecutor()
+    : new ForceLightningInterfaceCreateExecutor();
   const commandlet = new SfdxCommandlet(
     new InternalDevWorkspaceChecker(),
     new CompositeParametersGatherer(
       fileNameGatherer,
       new FileInternalPathGatherer(sourceUri)
     ),
-    new ForceLightningInterfaceCreateExecutor()
+    createTemplateExecutor
   );
   await commandlet.run();
 }

--- a/packages/salesforcedx-vscode-core/src/commands/templates/libraryBaseTemplateCommand.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/libraryBaseTemplateCommand.ts
@@ -116,6 +116,10 @@ export abstract class LibraryBaseTemplateCommand<T>
           output: result.rawOutput
         };
       } catch (error) {
+        telemetryService.sendException(
+          'force_template_create_library',
+          error.message
+        );
         return {
           error
         };

--- a/packages/salesforcedx-vscode-core/src/commands/templates/libraryBaseTemplateCommand.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/libraryBaseTemplateCommand.ts
@@ -179,7 +179,8 @@ export abstract class LibraryBaseTemplateCommand<T>
   }
 
   private getPathToSource(outputDir: string, fileName: string): string {
-    const sourceDirectory = path.join(getRootWorkspacePath(), outputDir);
+    // outputDir from library is an absolute path
+    const sourceDirectory = outputDir;
     return this.getSourcePathStrategy().getPathToSource(
       sourceDirectory,
       fileName,

--- a/packages/salesforcedx-vscode-core/src/commands/templates/libraryBaseTemplateCommand.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/libraryBaseTemplateCommand.ts
@@ -1,0 +1,160 @@
+import {
+  TemplateOptions,
+  TemplateService,
+  TemplateType
+} from '@salesforce/templates';
+import {
+  CommandletExecutor,
+  SelectOutputDir,
+  SourcePathStrategy
+} from '../util';
+
+import { channelService } from '../../channels';
+import { notificationService } from '../../notifications';
+import {
+  getRootWorkspacePath,
+  hasRootWorkspace,
+  MetadataDictionary,
+  MetadataInfo
+} from '../../util';
+
+import {
+  CancelResponse,
+  ContinueResponse,
+  DirFileNameSelection,
+  ParametersGatherer
+} from '@salesforce/salesforcedx-utils-vscode/out/src/types';
+
+import * as path from 'path';
+import { ProgressLocation, window, workspace } from 'vscode';
+
+interface ExecutionResult {
+  output?: string;
+  error?: Error;
+}
+
+function wrapExecute(
+  commandName: string,
+  telemetryName: string,
+  fn: (...args: any[]) => Promise<ExecutionResult>
+) {
+  return async (...args: any[]) => {
+    channelService.showCommandWithTimestamp(`Starting ${commandName}`);
+    const result = await window.withProgress(
+      {
+        title: commandName,
+        location: ProgressLocation.Notification
+      },
+      async () => {
+        return await fn.call(null, ...args);
+      }
+    );
+    if (result.output) {
+      channelService.appendLine(result.output);
+      channelService.showCommandWithTimestamp(`Finished ${commandName}`);
+      notificationService.showSuccessfulExecution(commandName).catch(() => {
+        // ignore
+      });
+    }
+    if (result.error) {
+      notificationService.showFailedExecution(commandName);
+    }
+  };
+}
+
+export abstract class LibraryBaseTemplateCommand<T>
+  implements CommandletExecutor<T> {
+  private _metadataType: MetadataInfo | undefined;
+  protected showChannelOutput = true;
+  protected startTime: [number, number] | undefined;
+
+  public abstract get executionName(): string;
+  public abstract get telemetryName(): string;
+  public abstract get metadataTypeName(): string;
+  public abstract get templateType(): TemplateType;
+  public abstract constructTemplateOptions(data: T): TemplateOptions;
+  public abstract getOutputFileName(data: T): string;
+
+  private get metadataType(): MetadataInfo {
+    if (this._metadataType) {
+      return this._metadataType;
+    }
+    const type = this.metadataTypeName;
+    const info = MetadataDictionary.getInfo(type);
+    if (!info) {
+      throw new Error(`Unrecognized metadata type ${type}`);
+    }
+    this._metadataType = info;
+    return info;
+  }
+
+  public async execute(response: ContinueResponse<T>): Promise<void> {
+    await wrapExecute(this.executionName, this.telemetryName, async () => {
+      try {
+        const templateOptions = this.constructTemplateOptions(response.data);
+        const result = await this.createTemplate(
+          this.templateType,
+          templateOptions
+        );
+        const fileName = this.getOutputFileName(response.data);
+        await this.openCreatedDocument(result.outputDir, fileName);
+        return {
+          output: result.rawOutput
+        };
+      } catch (error) {
+        return {
+          error
+        };
+      }
+    })();
+  }
+
+  private async createTemplate(
+    templateType: TemplateType,
+    templateOptions: TemplateOptions
+  ) {
+    const cwd = getRootWorkspacePath();
+    const templateService = TemplateService.getInstance(cwd);
+    return await templateService.create(templateType, templateOptions);
+  }
+
+  private async openCreatedDocument(outputdir: string, fileName: string) {
+    if (hasRootWorkspace()) {
+      const document = await workspace.openTextDocument(
+        this.getPathToSource(outputdir, fileName)
+      );
+      window.showTextDocument(document);
+    }
+  }
+
+  private identifyDirType(outputDirectory: string): string {
+    const defaultDirectoryPath = path.join(
+      SelectOutputDir.defaultOutput,
+      this.getDefaultDirectory()
+    );
+    return outputDirectory.endsWith(defaultDirectoryPath)
+      ? 'defaultDir'
+      : 'customDir';
+  }
+
+  private getPathToSource(outputDir: string, fileName: string): string {
+    const sourceDirectory = path.join(getRootWorkspacePath(), outputDir);
+    return this.getSourcePathStrategy().getPathToSource(
+      sourceDirectory,
+      fileName,
+      this.getFileExtension()
+    );
+  }
+
+  public getSourcePathStrategy(): SourcePathStrategy {
+    return this.metadataType.pathStrategy;
+  }
+
+  public getFileExtension(): string {
+    return `.${this.metadataType.suffix}`;
+  }
+
+  public getDefaultDirectory(): string {
+    return this.metadataType.directory;
+  }
+}

--- a/packages/salesforcedx-vscode-core/src/commands/templates/libraryBaseTemplateCommand.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/libraryBaseTemplateCommand.ts
@@ -27,21 +27,21 @@ import {
   MetadataInfo
 } from '../../util';
 
-import {
-  CancelResponse,
-  ContinueResponse,
-  DirFileNameSelection,
-  ParametersGatherer
-} from '@salesforce/salesforcedx-utils-vscode/out/src/types';
+import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 
 import * as path from 'path';
-import { commands, ProgressLocation, Uri, window, workspace } from 'vscode';
+import { ProgressLocation, window, workspace } from 'vscode';
 
 interface ExecutionResult {
   output?: string;
   error?: Error;
 }
 
+/**
+ * Warpping function exeuction with VS Code interface, such as Output channel and progress
+ * @param commandName command name
+ * @param fn function to execute
+ */
 function wrapExecute(
   commandName: string,
   fn: (...args: any[]) => Promise<ExecutionResult>
@@ -71,14 +71,30 @@ function wrapExecute(
   };
 }
 
+/**
+ * Base class for all template commands
+ */
 export abstract class LibraryBaseTemplateCommand<T>
   implements CommandletExecutor<T> {
   private _metadataType: MetadataInfo | undefined;
   protected showChannelOutput = true;
 
+  /**
+   * Command name
+   */
   public abstract get executionName(): string;
+  /**
+   * Command telemetry name
+   */
   public abstract get telemetryName(): string;
+  /**
+   * Template type
+   */
   public abstract get templateType(): TemplateType;
+  /**
+   * Construct template creation options from user input
+   * @param data data from Continue response
+   */
   public abstract constructTemplateOptions(data: T): TemplateOptions;
 
   public async execute(response: ContinueResponse<T>): Promise<void> {
@@ -134,6 +150,12 @@ export abstract class LibraryBaseTemplateCommand<T>
    * or getSourcePathStrategy/getFileExtension/getDefaultDirectory.
    */
   public metadataTypeName: string = '';
+  /**
+   * Locate output file name from user input.
+   * We use this function to determine the file name to open,
+   * after template creation completes.
+   * @param data data from ContinueResponse
+   */
   public abstract getOutputFileName(data: T): string;
 
   private get metadataType(): MetadataInfo | undefined {

--- a/packages/salesforcedx-vscode-core/src/commands/templates/libraryBaseTemplateCommand.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/libraryBaseTemplateCommand.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
 import {
   TemplateOptions,
   TemplateService,

--- a/packages/salesforcedx-vscode-core/src/constants.ts
+++ b/packages/salesforcedx-vscode-core/src/constants.ts
@@ -31,3 +31,4 @@ export const SFDX_CORE_CONFIGURATION_NAME = 'salesforcedx-vscode-core';
 export const SHOW_CLI_SUCCESS_INFO_MSG = 'show-cli-success-msg';
 export const TELEMETRY_ENABLED = 'telemetry.enabled';
 export const USE_APEX_LIBRARY = 'experimental.useApexLibrary';
+export const USE_TEMPLATES_LIBRARY = 'experimental.useTemplatesLibrary';

--- a/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
@@ -15,7 +15,8 @@ import {
   SFDX_CORE_CONFIGURATION_NAME,
   SHOW_CLI_SUCCESS_INFO_MSG,
   TELEMETRY_ENABLED,
-  USE_APEX_LIBRARY
+  USE_APEX_LIBRARY,
+  USE_TEMPLATES_LIBRARY
 } from '../constants';
 /**
  * A centralized location for interacting with sfdx-core settings.
@@ -77,6 +78,10 @@ export class SfdxCoreSettings {
 
   public getApexLibrary(): boolean {
     return this.getConfigValue(USE_APEX_LIBRARY, true);
+  }
+
+  public getTemplatesLibrary(): boolean {
+    return this.getConfigValue(USE_TEMPLATES_LIBRARY, true);
   }
 
   private getConfigValue<T>(key: string, defaultValue: T): T {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceProjectCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceProjectCreate.test.ts
@@ -30,7 +30,6 @@ import { nls } from '../../../src/messages';
 import { notificationService } from '../../../src/notifications';
 import { SfdxCoreSettings } from '../../../src/settings/sfdxCoreSettings';
 import { getRootWorkspacePath } from '../../../src/util';
-import Sinon = require('sinon');
 
 // tslint:disable:no-unused-expression
 describe('Force Project Create', () => {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceAnalyticsTemplateCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceAnalyticsTemplateCreate.test.ts
@@ -7,53 +7,152 @@
 
 import { expect } from 'chai';
 import * as path from 'path';
+import * as shell from 'shelljs';
 import { SinonStub, stub } from 'sinon';
-import { ForceAnalyticsTemplateCreateExecutor } from '../../../../src/commands/templates/forceAnalyticsTemplateCreate';
+import * as vscode from 'vscode';
+import * as assert from 'yeoman-assert';
+import { channelService } from '../../../../src/channels';
+import {
+  forceAnalyticsTemplateCreate,
+  ForceAnalyticsTemplateCreateExecutor
+} from '../../../../src/commands/templates/forceAnalyticsTemplateCreate';
 import { nls } from '../../../../src/messages';
+import { notificationService } from '../../../../src/notifications';
 import { SfdxCoreSettings } from '../../../../src/settings/sfdxCoreSettings';
+import { getRootWorkspacePath } from '../../../../src/util';
 
 // tslint:disable:no-unused-expression
 describe('Force Analytics Template Create', () => {
-  let settings: SinonStub;
+  describe('Command', () => {
+    let settings: SinonStub;
 
-  beforeEach(() => {
-    settings = stub(SfdxCoreSettings.prototype, 'getInternalDev');
-  });
-
-  afterEach(() => {
-    settings.restore();
-  });
-
-  it('Should build the analytics template create command', async () => {
-    settings.returns(false);
-    const waveTemplateCreate = new ForceAnalyticsTemplateCreateExecutor();
-    const outputDirPath = path.join(
-      'force-app',
-      'main',
-      'default',
-      'waveTemplates'
-    );
-    const sampleTemplateName = 'analyticsTemplate';
-
-    const waveTemplateCreateCommand = waveTemplateCreate.build({
-      outputdir: outputDirPath,
-      fileName: sampleTemplateName
+    beforeEach(() => {
+      settings = stub(SfdxCoreSettings.prototype, 'getInternalDev');
     });
-    expect(waveTemplateCreateCommand.toCommand()).to.equal(
-      `sfdx force:analytics:template:create --outputdir ${outputDirPath} --templatename ${sampleTemplateName}`
-    );
-    expect(waveTemplateCreateCommand.description).to.equal(
-      nls.localize('force_analytics_template_create_text')
-    );
-    expect(waveTemplateCreate.getDefaultDirectory()).to.equal('waveTemplates');
-    expect(
-      waveTemplateCreate.sourcePathStrategy.getPathToSource(
-        outputDirPath,
-        sampleTemplateName,
-        '.json'
-      )
-    ).to.equal(
-      path.join(outputDirPath, sampleTemplateName, 'template-info.json')
-    );
+
+    afterEach(() => {
+      settings.restore();
+    });
+
+    it('Should build the analytics template create command', async () => {
+      settings.returns(false);
+      const waveTemplateCreate = new ForceAnalyticsTemplateCreateExecutor();
+      const outputDirPath = path.join(
+        'force-app',
+        'main',
+        'default',
+        'waveTemplates'
+      );
+      const sampleTemplateName = 'analyticsTemplate';
+
+      const waveTemplateCreateCommand = waveTemplateCreate.build({
+        outputdir: outputDirPath,
+        fileName: sampleTemplateName
+      });
+      expect(waveTemplateCreateCommand.toCommand()).to.equal(
+        `sfdx force:analytics:template:create --outputdir ${outputDirPath} --templatename ${sampleTemplateName}`
+      );
+      expect(waveTemplateCreateCommand.description).to.equal(
+        nls.localize('force_analytics_template_create_text')
+      );
+      expect(waveTemplateCreate.getDefaultDirectory()).to.equal(
+        'waveTemplates'
+      );
+      expect(
+        waveTemplateCreate.sourcePathStrategy.getPathToSource(
+          outputDirPath,
+          sampleTemplateName,
+          '.json'
+        )
+      ).to.equal(
+        path.join(outputDirPath, sampleTemplateName, 'template-info.json')
+      );
+    });
+  });
+
+  describe('Library Create', () => {
+    let settings: SinonStub;
+    let showInputBoxStub: SinonStub;
+    let quickPickStub: SinonStub;
+    let appendLineStub: SinonStub;
+    let showSuccessfulExecutionStub: SinonStub;
+    let showFailedExecutionStub: SinonStub;
+
+    beforeEach(() => {
+      // mock experimental setting
+      settings = stub(SfdxCoreSettings.prototype, 'getTemplatesLibrary');
+      settings.returns(true);
+      showInputBoxStub = stub(vscode.window, 'showInputBox');
+      quickPickStub = stub(vscode.window, 'showQuickPick');
+      appendLineStub = stub(channelService, 'appendLine');
+      showSuccessfulExecutionStub = stub(
+        notificationService,
+        'showSuccessfulExecution'
+      );
+      showSuccessfulExecutionStub.returns(Promise.resolve());
+      showFailedExecutionStub = stub(
+        notificationService,
+        'showFailedExecution'
+      );
+    });
+
+    afterEach(() => {
+      settings.restore();
+      showInputBoxStub.restore();
+      quickPickStub.restore();
+      showSuccessfulExecutionStub.restore();
+      showFailedExecutionStub.restore();
+      appendLineStub.restore();
+    });
+
+    it('Should create Analytics Template', async () => {
+      // arrange
+      const outputPath = 'force-app/main/default/waveTemplates';
+      const templateInfoJsonPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'TestWave',
+        'template-info.json'
+      );
+      const templateFolderJsonPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'TestWave',
+        'folder.json'
+      );
+      const templateDashboardPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'TestWave/dashboards',
+        'TestWaveDashboard.json'
+      );
+      shell.rm(
+        '-rf',
+        path.join(getRootWorkspacePath(), outputPath, 'TestWave')
+      );
+      assert.noFile([
+        templateInfoJsonPath,
+        templateFolderJsonPath,
+        templateDashboardPath
+      ]);
+      showInputBoxStub.returns('TestWave');
+      quickPickStub.returns(outputPath);
+
+      // act
+      await forceAnalyticsTemplateCreate();
+
+      // assert
+      assert.file([
+        templateInfoJsonPath,
+        templateFolderJsonPath,
+        templateDashboardPath
+      ]);
+      assert.fileContent(templateInfoJsonPath, '"label": "TestWave"');
+      assert.fileContent(templateFolderJsonPath, '"name": "TestWave"');
+      assert.fileContent(
+        templateDashboardPath,
+        '"name": "TestWaveDashboard_tp"'
+      );
+    });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceAnalyticsTemplateCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceAnalyticsTemplateCreate.test.ts
@@ -153,6 +153,9 @@ describe('Force Analytics Template Create', () => {
         templateDashboardPath,
         '"name": "TestWaveDashboard_tp"'
       );
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath));
     });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceApexClassCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceApexClassCreate.test.ts
@@ -9,6 +9,7 @@ import { expect } from 'chai';
 import * as path from 'path';
 import * as shell from 'shelljs';
 import { SinonStub, stub } from 'sinon';
+import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import * as assert from 'yeoman-assert';
 import { channelService } from '../../../../src/channels';
@@ -60,6 +61,7 @@ describe('Force Apex Class Create', () => {
     let appendLineStub: SinonStub;
     let showSuccessfulExecutionStub: SinonStub;
     let showFailedExecutionStub: SinonStub;
+    let openTextDocumentStub: SinonStub;
 
     beforeEach(() => {
       // mock experimental setting
@@ -77,6 +79,7 @@ describe('Force Apex Class Create', () => {
         notificationService,
         'showFailedExecution'
       );
+      openTextDocumentStub = stub(vscode.workspace, 'openTextDocument');
     });
 
     afterEach(() => {
@@ -86,6 +89,7 @@ describe('Force Apex Class Create', () => {
       showSuccessfulExecutionStub.restore();
       showFailedExecutionStub.restore();
       appendLineStub.restore();
+      openTextDocumentStub.restore();
     });
 
     it('Should create Apex Class', async () => {
@@ -124,6 +128,8 @@ describe('Force Apex Class Create', () => {
     <status>Active</status>
 </ApexClass>`
       );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, apexClassPath);
     });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceApexClassCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceApexClassCreate.test.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { TemplateService } from '@salesforce/templates';
 import { expect } from 'chai';
 import * as path from 'path';
 import * as shell from 'shelljs';
@@ -115,6 +116,7 @@ describe('Force Apex Class Create', () => {
       await forceApexClassCreate();
 
       // assert
+      const defaultApiVersion = TemplateService.getDefaultApiVersion();
       assert.file([apexClassPath, apexClassMetaPath]);
       assert.fileContent(
         apexClassPath,
@@ -124,7 +126,7 @@ describe('Force Apex Class Create', () => {
         apexClassMetaPath,
         `<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>${defaultApiVersion}</apiVersion>
     <status>Active</status>
 </ApexClass>`
       );

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceApexClassCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceApexClassCreate.test.ts
@@ -7,31 +7,122 @@
 
 import { expect } from 'chai';
 import * as path from 'path';
-import { ForceApexClassCreateExecutor } from '../../../../src/commands/templates/forceApexClassCreate';
+import * as shell from 'shelljs';
+import { SinonStub, stub } from 'sinon';
+import * as vscode from 'vscode';
+import * as assert from 'yeoman-assert';
+import { channelService } from '../../../../src/channels';
+import {
+  forceApexClassCreate,
+  ForceApexClassCreateExecutor
+} from '../../../../src/commands/templates/forceApexClassCreate';
 import { nls } from '../../../../src/messages';
+import { notificationService } from '../../../../src/notifications';
+import { SfdxCoreSettings } from '../../../../src/settings/sfdxCoreSettings';
+import { getRootWorkspacePath } from '../../../../src/util';
 
 // tslint:disable:no-unused-expression
 describe('Force Apex Class Create', () => {
-  it('Should build the apex class create command', async () => {
-    const classCreate = new ForceApexClassCreateExecutor();
-    const outputDirPath = path.join('force-app', 'main', 'default', 'classes');
-    const fileName = 'myClass';
-    const classCreateCommand = classCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Command', () => {
+    it('Should build the apex class create command', async () => {
+      const classCreate = new ForceApexClassCreateExecutor();
+      const outputDirPath = path.join(
+        'force-app',
+        'main',
+        'default',
+        'classes'
+      );
+      const fileName = 'myClass';
+      const classCreateCommand = classCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(classCreateCommand.toCommand()).to.equal(
+        `sfdx force:apex:class:create --classname ${fileName} --template DefaultApexClass --outputdir ${outputDirPath}`
+      );
+      expect(classCreateCommand.description).to.equal(
+        nls.localize('force_apex_class_create_text')
+      );
+      expect(classCreate.getDefaultDirectory()).to.equal('classes');
+      expect(classCreate.getFileExtension()).to.equal('.cls');
+      expect(
+        classCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.cls')
+      ).to.equal(path.join(outputDirPath, `${fileName}.cls`));
     });
-    expect(classCreateCommand.toCommand()).to.equal(
-      `sfdx force:apex:class:create --classname ${fileName} --template DefaultApexClass --outputdir ${outputDirPath}`
-    );
-    expect(classCreateCommand.description).to.equal(
-      nls.localize('force_apex_class_create_text')
-    );
-    expect(classCreate.getDefaultDirectory()).to.equal('classes');
-    expect(classCreate.getFileExtension()).to.equal('.cls');
-    expect(
-      classCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.cls')
-    ).to.equal(path.join(outputDirPath, `${fileName}.cls`));
+  });
+
+  describe('Library Create', () => {
+    let settings: SinonStub;
+    let showInputBoxStub: SinonStub;
+    let quickPickStub: SinonStub;
+    let appendLineStub: SinonStub;
+    let showSuccessfulExecutionStub: SinonStub;
+    let showFailedExecutionStub: SinonStub;
+
+    beforeEach(() => {
+      // mock experimental setting
+      settings = stub(SfdxCoreSettings.prototype, 'getTemplatesLibrary');
+      settings.returns(true);
+      showInputBoxStub = stub(vscode.window, 'showInputBox');
+      quickPickStub = stub(vscode.window, 'showQuickPick');
+      appendLineStub = stub(channelService, 'appendLine');
+      showSuccessfulExecutionStub = stub(
+        notificationService,
+        'showSuccessfulExecution'
+      );
+      showSuccessfulExecutionStub.returns(Promise.resolve());
+      showFailedExecutionStub = stub(
+        notificationService,
+        'showFailedExecution'
+      );
+    });
+
+    afterEach(() => {
+      settings.restore();
+      showInputBoxStub.restore();
+      quickPickStub.restore();
+      showSuccessfulExecutionStub.restore();
+      showFailedExecutionStub.restore();
+      appendLineStub.restore();
+    });
+
+    it('Should create Apex Class', async () => {
+      // arrange
+      showInputBoxStub.returns('TestApexClass');
+      quickPickStub.returns('force-app/main/default/classes');
+      const apexClassPath = path.join(
+        getRootWorkspacePath(),
+        'force-app/main/default/classes',
+        'TestApexClass.cls'
+      );
+      const apexClassMetaPath = path.join(
+        getRootWorkspacePath(),
+        'force-app/main/default/classes',
+        'TestApexClass.cls-meta.xml'
+      );
+      shell.rm('-f', apexClassPath);
+      shell.rm('-f', apexClassMetaPath);
+      assert.noFile([apexClassPath, apexClassMetaPath]);
+
+      // act
+      await forceApexClassCreate();
+
+      // assert
+      assert.file([apexClassPath, apexClassMetaPath]);
+      assert.fileContent(
+        apexClassPath,
+        'public with sharing class TestApexClass'
+      );
+      assert.fileContent(
+        apexClassMetaPath,
+        `<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>49.0</apiVersion>
+    <status>Active</status>
+</ApexClass>`
+      );
+    });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceApexClassCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceApexClassCreate.test.ts
@@ -90,21 +90,22 @@ describe('Force Apex Class Create', () => {
 
     it('Should create Apex Class', async () => {
       // arrange
-      showInputBoxStub.returns('TestApexClass');
-      quickPickStub.returns('force-app/main/default/classes');
+      const outputPath = 'force-app/main/default/classes';
       const apexClassPath = path.join(
         getRootWorkspacePath(),
-        'force-app/main/default/classes',
+        outputPath,
         'TestApexClass.cls'
       );
       const apexClassMetaPath = path.join(
         getRootWorkspacePath(),
-        'force-app/main/default/classes',
+        outputPath,
         'TestApexClass.cls-meta.xml'
       );
       shell.rm('-f', apexClassPath);
       shell.rm('-f', apexClassMetaPath);
       assert.noFile([apexClassPath, apexClassMetaPath]);
+      showInputBoxStub.returns('TestApexClass');
+      quickPickStub.returns(outputPath);
 
       // act
       await forceApexClassCreate();

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceApexTriggerCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceApexTriggerCreate.test.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { TemplateService } from '@salesforce/templates';
 import { expect } from 'chai';
 import * as path from 'path';
 import * as shell from 'shelljs';
@@ -111,6 +112,7 @@ describe('Force Apex Trigger Create', () => {
       await forceApexTriggerCreate();
 
       // assert
+      const defaultApiVersion = TemplateService.getDefaultApiVersion();
       assert.file([apexTriggerPath, apexTriggerMetaPath]);
       assert.fileContent(
         apexTriggerPath,
@@ -122,7 +124,7 @@ describe('Force Apex Trigger Create', () => {
         apexTriggerMetaPath,
         `<?xml version='1.0' encoding='UTF-8'?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>49.0</apiVersion>
+  <apiVersion>${defaultApiVersion}</apiVersion>
   <status>Active</status>
 </ApexTrigger>`
       );

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceApexTriggerCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceApexTriggerCreate.test.ts
@@ -7,31 +7,125 @@
 
 import { expect } from 'chai';
 import * as path from 'path';
-import { ForceApexTriggerCreateExecutor } from '../../../../src/commands/templates/forceApexTriggerCreate';
+import * as shell from 'shelljs';
+import { SinonStub, stub } from 'sinon';
+import * as vscode from 'vscode';
+import * as assert from 'yeoman-assert';
+import { channelService } from '../../../../src/channels';
+import {
+  forceApexTriggerCreate,
+  ForceApexTriggerCreateExecutor
+} from '../../../../src/commands/templates/forceApexTriggerCreate';
 import { nls } from '../../../../src/messages';
+import { notificationService } from '../../../../src/notifications';
+import { SfdxCoreSettings } from '../../../../src/settings/sfdxCoreSettings';
+import { getRootWorkspacePath } from '../../../../src/util';
 
 // tslint:disable:no-unused-expression
 describe('Force Apex Trigger Create', () => {
-  it('Should build the apex trigger create command', async () => {
-    const triggerCreate = new ForceApexTriggerCreateExecutor();
-    const outputDirPath = path.join('force-app', 'main', 'default', 'triggers');
-    const fileName = 'myTrigger';
-    const triggerCreateCommand = triggerCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Command', () => {
+    it('Should build the apex trigger create command', async () => {
+      const triggerCreate = new ForceApexTriggerCreateExecutor();
+      const outputDirPath = path.join(
+        'force-app',
+        'main',
+        'default',
+        'triggers'
+      );
+      const fileName = 'myTrigger';
+      const triggerCreateCommand = triggerCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(triggerCreateCommand.toCommand()).to.equal(
+        `sfdx force:apex:trigger:create --triggername ${fileName} --outputdir ${outputDirPath}`
+      );
+      expect(triggerCreateCommand.description).to.equal(
+        nls.localize('force_apex_trigger_create_text')
+      );
+      expect(triggerCreate.getDefaultDirectory()).to.equal('triggers');
+      expect(triggerCreate.getFileExtension()).to.equal('.trigger');
+      expect(
+        triggerCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.trigger')
+      ).to.equal(path.join(outputDirPath, `${fileName}.trigger`));
     });
-    expect(triggerCreateCommand.toCommand()).to.equal(
-      `sfdx force:apex:trigger:create --triggername ${fileName} --outputdir ${outputDirPath}`
-    );
-    expect(triggerCreateCommand.description).to.equal(
-      nls.localize('force_apex_trigger_create_text')
-    );
-    expect(triggerCreate.getDefaultDirectory()).to.equal('triggers');
-    expect(triggerCreate.getFileExtension()).to.equal('.trigger');
-    expect(
-      triggerCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.trigger')
-    ).to.equal(path.join(outputDirPath, `${fileName}.trigger`));
+  });
+
+  describe('Library Create', () => {
+    let settings: SinonStub;
+    let showInputBoxStub: SinonStub;
+    let quickPickStub: SinonStub;
+    let appendLineStub: SinonStub;
+    let showSuccessfulExecutionStub: SinonStub;
+    let showFailedExecutionStub: SinonStub;
+
+    beforeEach(() => {
+      // mock experimental setting
+      settings = stub(SfdxCoreSettings.prototype, 'getTemplatesLibrary');
+      settings.returns(true);
+      showInputBoxStub = stub(vscode.window, 'showInputBox');
+      quickPickStub = stub(vscode.window, 'showQuickPick');
+      appendLineStub = stub(channelService, 'appendLine');
+      showSuccessfulExecutionStub = stub(
+        notificationService,
+        'showSuccessfulExecution'
+      );
+      showSuccessfulExecutionStub.returns(Promise.resolve());
+      showFailedExecutionStub = stub(
+        notificationService,
+        'showFailedExecution'
+      );
+    });
+
+    afterEach(() => {
+      settings.restore();
+      showInputBoxStub.restore();
+      quickPickStub.restore();
+      showSuccessfulExecutionStub.restore();
+      showFailedExecutionStub.restore();
+      appendLineStub.restore();
+    });
+
+    it('Should create Apex Class', async () => {
+      // arrange
+      const outputPath = 'force-app/main/default/classes';
+      const apexTriggerPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'TestApexTrigger.trigger'
+      );
+      const apexTriggerMetaPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'TestApexTrigger.trigger-meta.xml'
+      );
+      shell.rm('-f', apexTriggerPath);
+      shell.rm('-f', apexTriggerMetaPath);
+      assert.noFile([apexTriggerPath, apexTriggerMetaPath]);
+      showInputBoxStub.returns('TestApexTrigger');
+      quickPickStub.returns(outputPath);
+
+      // act
+      await forceApexTriggerCreate();
+
+      // assert
+      assert.file([apexTriggerPath, apexTriggerMetaPath]);
+      assert.fileContent(
+        apexTriggerPath,
+        `trigger TestApexTrigger on SOBJECT (before insert) {
+
+}`
+      );
+      assert.fileContent(
+        apexTriggerMetaPath,
+        `<?xml version='1.0' encoding='UTF-8'?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>49.0</apiVersion>
+  <status>Active</status>
+</ApexTrigger>`
+      );
+    });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceLightningAppCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceLightningAppCreate.test.ts
@@ -7,68 +7,234 @@
 
 import { expect } from 'chai';
 import * as path from 'path';
+import * as shell from 'shelljs';
 import { SinonStub, stub } from 'sinon';
-import { ForceLightningAppCreateExecutor } from '../../../../src/commands/templates/forceLightningAppCreate';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import * as assert from 'yeoman-assert';
+import { channelService } from '../../../../src/channels';
+import {
+  forceInternalLightningAppCreate,
+  forceLightningAppCreate,
+  ForceLightningAppCreateExecutor
+} from '../../../../src/commands/templates/forceLightningAppCreate';
 import { nls } from '../../../../src/messages';
+import { notificationService } from '../../../../src/notifications';
 import { SfdxCoreSettings } from '../../../../src/settings/sfdxCoreSettings';
+import { getRootWorkspacePath } from '../../../../src/util';
 
 // tslint:disable:no-unused-expression
 describe('Force Lightning App Create', () => {
-  let settings: SinonStub;
+  let getInternalDevStub: SinonStub;
 
   beforeEach(() => {
-    settings = stub(SfdxCoreSettings.prototype, 'getInternalDev');
+    getInternalDevStub = stub(SfdxCoreSettings.prototype, 'getInternalDev');
   });
 
   afterEach(() => {
-    settings.restore();
+    getInternalDevStub.restore();
   });
 
-  it('Should build the lightning app create command', async () => {
-    settings.returns(false);
-    const lightningAppCreate = new ForceLightningAppCreateExecutor();
-    const outputDirPath = path.join('force-app', 'main', 'default', 'aura');
-    const fileName = 'lightningApp';
-    const lightningAppCreateCommand = lightningAppCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Commands', () => {
+    it('Should build the lightning app create command', async () => {
+      getInternalDevStub.returns(false);
+      const lightningAppCreate = new ForceLightningAppCreateExecutor();
+      const outputDirPath = path.join('force-app', 'main', 'default', 'aura');
+      const fileName = 'lightningApp';
+      const lightningAppCreateCommand = lightningAppCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(lightningAppCreateCommand.toCommand()).to.equal(
+        `sfdx force:lightning:app:create --appname ${fileName} --outputdir ${outputDirPath}`
+      );
+      expect(lightningAppCreateCommand.description).to.equal(
+        nls.localize('force_lightning_app_create_text')
+      );
+      expect(lightningAppCreate.getDefaultDirectory()).to.equal('aura');
+      expect(lightningAppCreate.getFileExtension()).to.equal('.app');
+      expect(
+        lightningAppCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.app')
+      ).to.equal(path.join(outputDirPath, fileName, `${fileName}.app`));
     });
-    expect(lightningAppCreateCommand.toCommand()).to.equal(
-      `sfdx force:lightning:app:create --appname ${fileName} --outputdir ${outputDirPath}`
-    );
-    expect(lightningAppCreateCommand.description).to.equal(
-      nls.localize('force_lightning_app_create_text')
-    );
-    expect(lightningAppCreate.getDefaultDirectory()).to.equal('aura');
-    expect(lightningAppCreate.getFileExtension()).to.equal('.app');
-    expect(
-      lightningAppCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.app')
-    ).to.equal(path.join(outputDirPath, fileName, `${fileName}.app`));
+
+    it('Should build the internal lightning app create command', async () => {
+      getInternalDevStub.returns(true);
+      const lightningAppCreate = new ForceLightningAppCreateExecutor();
+      const outputDirPath = path.join('non-dx', 'dir', 'components', 'ns');
+      const fileName = 'lightningInternalApp';
+      const lightningAppCreateCommand = lightningAppCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(lightningAppCreateCommand.toCommand()).to.equal(
+        `sfdx force:lightning:app:create --appname ${fileName} --outputdir ${outputDirPath} --internal`
+      );
+      expect(lightningAppCreateCommand.description).to.equal(
+        nls.localize('force_lightning_app_create_text')
+      );
+      expect(lightningAppCreate.getDefaultDirectory()).to.equal('aura');
+      expect(lightningAppCreate.getFileExtension()).to.equal('.app');
+      expect(
+        lightningAppCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.app')
+      ).to.equal(path.join(outputDirPath, fileName, `${fileName}.app`));
+    });
   });
 
-  it('Should build the internal lightning app create command', async () => {
-    settings.returns(true);
-    const lightningAppCreate = new ForceLightningAppCreateExecutor();
-    const outputDirPath = path.join('non-dx', 'dir', 'components', 'ns');
-    const fileName = 'lightningInternalApp';
-    const lightningAppCreateCommand = lightningAppCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Library Create', () => {
+    let getTemplatesLibraryStub: SinonStub;
+    let showInputBoxStub: SinonStub;
+    let quickPickStub: SinonStub;
+    let appendLineStub: SinonStub;
+    let showSuccessfulExecutionStub: SinonStub;
+    let showFailedExecutionStub: SinonStub;
+    let openTextDocumentStub: SinonStub;
+
+    beforeEach(() => {
+      // mock experimental setting
+      getTemplatesLibraryStub = stub(
+        SfdxCoreSettings.prototype,
+        'getTemplatesLibrary'
+      );
+      getTemplatesLibraryStub.returns(true);
+      showInputBoxStub = stub(vscode.window, 'showInputBox');
+      quickPickStub = stub(vscode.window, 'showQuickPick');
+      appendLineStub = stub(channelService, 'appendLine');
+      showSuccessfulExecutionStub = stub(
+        notificationService,
+        'showSuccessfulExecution'
+      );
+      showSuccessfulExecutionStub.returns(Promise.resolve());
+      showFailedExecutionStub = stub(
+        notificationService,
+        'showFailedExecution'
+      );
+      openTextDocumentStub = stub(vscode.workspace, 'openTextDocument');
     });
-    expect(lightningAppCreateCommand.toCommand()).to.equal(
-      `sfdx force:lightning:app:create --appname ${fileName} --outputdir ${outputDirPath} --internal`
-    );
-    expect(lightningAppCreateCommand.description).to.equal(
-      nls.localize('force_lightning_app_create_text')
-    );
-    expect(lightningAppCreate.getDefaultDirectory()).to.equal('aura');
-    expect(lightningAppCreate.getFileExtension()).to.equal('.app');
-    expect(
-      lightningAppCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.app')
-    ).to.equal(path.join(outputDirPath, fileName, `${fileName}.app`));
+
+    afterEach(() => {
+      getTemplatesLibraryStub.restore();
+      showInputBoxStub.restore();
+      quickPickStub.restore();
+      showSuccessfulExecutionStub.restore();
+      showFailedExecutionStub.restore();
+      appendLineStub.restore();
+      openTextDocumentStub.restore();
+    });
+
+    it('Should create Aura App', async () => {
+      // arrange
+      getInternalDevStub.returns(false);
+      const outputPath = 'force-app/main/default/aura';
+      const auraAppPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'testApp',
+        'testApp.app'
+      );
+      const auraAppMetaPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'testApp',
+        'testApp.app-meta.xml'
+      );
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, 'testApp'));
+      assert.noFile([auraAppPath, auraAppMetaPath]);
+      showInputBoxStub.returns('testApp');
+      quickPickStub.returns(outputPath);
+
+      // act
+      await forceLightningAppCreate();
+
+      // assert
+      const suffixarray = [
+        '.app',
+        '.app-meta.xml',
+        '.auradoc',
+        '.css',
+        'Controller.js',
+        'Helper.js',
+        'Renderer.js',
+        '.svg'
+      ];
+      for (const suffix of suffixarray) {
+        assert.file(
+          path.join(
+            getRootWorkspacePath(),
+            outputPath,
+            'testApp',
+            `testApp${suffix}`
+          )
+        );
+      }
+      assert.fileContent(
+        auraAppPath,
+        '<aura:application>\n\n</aura:application>'
+      );
+      assert.fileContent(
+        auraAppMetaPath,
+        `<AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">`
+      );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, auraAppPath);
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, 'testApp'));
+    });
+
+    it('Should create internal Aura App', async () => {
+      // arrange
+      getInternalDevStub.returns(true);
+      const outputPath = 'force-app/main/default/aura';
+      const auraAppPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'testApp',
+        'testApp.app'
+      );
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, 'testApp'));
+      assert.noFile([auraAppPath]);
+      showInputBoxStub.returns('testApp');
+
+      // act
+      shell.mkdir('-p', path.join(getRootWorkspacePath(), outputPath));
+      await forceInternalLightningAppCreate(
+        vscode.Uri.file(path.join(getRootWorkspacePath(), outputPath))
+      );
+
+      // assert
+      const suffixarray = [
+        '.app',
+        '.auradoc',
+        '.css',
+        'Controller.js',
+        'Helper.js',
+        'Renderer.js',
+        '.svg'
+      ];
+      for (const suffix of suffixarray) {
+        assert.file(
+          path.join(
+            getRootWorkspacePath(),
+            outputPath,
+            'testApp',
+            `testApp${suffix}`
+          )
+        );
+      }
+      assert.fileContent(
+        auraAppPath,
+        '<aura:application>\n\n</aura:application>'
+      );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, auraAppPath);
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, 'testApp'));
+    });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceLightningComponentCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceLightningComponentCreate.test.ts
@@ -7,68 +7,239 @@
 
 import { expect } from 'chai';
 import * as path from 'path';
+import * as shell from 'shelljs';
 import { SinonStub, stub } from 'sinon';
-import { ForceLightningComponentCreateExecutor } from '../../../../src/commands/templates/forceLightningComponentCreate';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import * as assert from 'yeoman-assert';
+import { channelService } from '../../../../src/channels';
+import {
+  forceInternalLightningComponentCreate,
+  forceLightningComponentCreate,
+  ForceLightningComponentCreateExecutor
+} from '../../../../src/commands/templates/forceLightningComponentCreate';
 import { nls } from '../../../../src/messages';
+import { notificationService } from '../../../../src/notifications';
 import { SfdxCoreSettings } from '../../../../src/settings/sfdxCoreSettings';
+import { getRootWorkspacePath } from '../../../../src/util';
 
 // tslint:disable:no-unused-expression
 describe('Force Lightning Component Create', () => {
-  let settings: SinonStub;
+  let getInternalDevStub: SinonStub;
 
   beforeEach(() => {
-    settings = stub(SfdxCoreSettings.prototype, 'getInternalDev');
+    getInternalDevStub = stub(SfdxCoreSettings.prototype, 'getInternalDev');
   });
 
   afterEach(() => {
-    settings.restore();
+    getInternalDevStub.restore();
   });
 
-  it('Should build the Lightning Component create command', async () => {
-    settings.returns(false);
-    const lightningCmpCreate = new ForceLightningComponentCreateExecutor();
-    const outputDirPath = path.join('force-app', 'main', 'default', 'aura');
-    const fileName = 'myAuraCmp';
-    const lwcCreateCommand = lightningCmpCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Commands', () => {
+    it('Should build the Lightning Component create command', async () => {
+      getInternalDevStub.returns(false);
+      const lightningCmpCreate = new ForceLightningComponentCreateExecutor();
+      const outputDirPath = path.join('force-app', 'main', 'default', 'aura');
+      const fileName = 'myAuraCmp';
+      const lwcCreateCommand = lightningCmpCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(lwcCreateCommand.toCommand()).to.equal(
+        `sfdx force:lightning:component:create --componentname ${fileName} --outputdir ${outputDirPath}`
+      );
+      expect(lwcCreateCommand.description).to.equal(
+        nls.localize('force_lightning_component_create_text')
+      );
+      expect(lightningCmpCreate.getDefaultDirectory()).to.equal('aura');
+      expect(lightningCmpCreate.getFileExtension()).to.equal('.cmp');
+      expect(
+        lightningCmpCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.cmp')
+      ).to.equal(path.join(outputDirPath, fileName, `${fileName}.cmp`));
     });
-    expect(lwcCreateCommand.toCommand()).to.equal(
-      `sfdx force:lightning:component:create --componentname ${fileName} --outputdir ${outputDirPath}`
-    );
-    expect(lwcCreateCommand.description).to.equal(
-      nls.localize('force_lightning_component_create_text')
-    );
-    expect(lightningCmpCreate.getDefaultDirectory()).to.equal('aura');
-    expect(lightningCmpCreate.getFileExtension()).to.equal('.cmp');
-    expect(
-      lightningCmpCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.cmp')
-    ).to.equal(path.join(outputDirPath, fileName, `${fileName}.cmp`));
+
+    it('Should build the internal Lightning Component create command', async () => {
+      getInternalDevStub.returns(true);
+      const lightningCmpCreate = new ForceLightningComponentCreateExecutor();
+      const outputDirPath = path.join('non-dx', 'dir', 'components', 'ns');
+      const fileName = 'internalCmp';
+      const lwcCreateCommand = lightningCmpCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(lwcCreateCommand.toCommand()).to.equal(
+        `sfdx force:lightning:component:create --componentname ${fileName} --outputdir ${outputDirPath} --internal`
+      );
+      expect(lwcCreateCommand.description).to.equal(
+        nls.localize('force_lightning_component_create_text')
+      );
+      expect(lightningCmpCreate.getDefaultDirectory()).to.equal('aura');
+      expect(lightningCmpCreate.getFileExtension()).to.equal('.cmp');
+      expect(
+        lightningCmpCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.cmp')
+      ).to.equal(path.join(outputDirPath, fileName, `${fileName}.cmp`));
+    });
   });
 
-  it('Should build the internal Lightning Component create command', async () => {
-    settings.returns(true);
-    const lightningCmpCreate = new ForceLightningComponentCreateExecutor();
-    const outputDirPath = path.join('non-dx', 'dir', 'components', 'ns');
-    const fileName = 'internalCmp';
-    const lwcCreateCommand = lightningCmpCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Library Create', () => {
+    let getTemplatesLibraryStub: SinonStub;
+    let showInputBoxStub: SinonStub;
+    let quickPickStub: SinonStub;
+    let appendLineStub: SinonStub;
+    let showSuccessfulExecutionStub: SinonStub;
+    let showFailedExecutionStub: SinonStub;
+    let openTextDocumentStub: SinonStub;
+
+    beforeEach(() => {
+      // mock experimental setting
+      getTemplatesLibraryStub = stub(
+        SfdxCoreSettings.prototype,
+        'getTemplatesLibrary'
+      );
+      getTemplatesLibraryStub.returns(true);
+      showInputBoxStub = stub(vscode.window, 'showInputBox');
+      quickPickStub = stub(vscode.window, 'showQuickPick');
+      appendLineStub = stub(channelService, 'appendLine');
+      showSuccessfulExecutionStub = stub(
+        notificationService,
+        'showSuccessfulExecution'
+      );
+      showSuccessfulExecutionStub.returns(Promise.resolve());
+      showFailedExecutionStub = stub(
+        notificationService,
+        'showFailedExecution'
+      );
+      openTextDocumentStub = stub(vscode.workspace, 'openTextDocument');
     });
-    expect(lwcCreateCommand.toCommand()).to.equal(
-      `sfdx force:lightning:component:create --componentname ${fileName} --outputdir ${outputDirPath} --internal`
-    );
-    expect(lwcCreateCommand.description).to.equal(
-      nls.localize('force_lightning_component_create_text')
-    );
-    expect(lightningCmpCreate.getDefaultDirectory()).to.equal('aura');
-    expect(lightningCmpCreate.getFileExtension()).to.equal('.cmp');
-    expect(
-      lightningCmpCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.cmp')
-    ).to.equal(path.join(outputDirPath, fileName, `${fileName}.cmp`));
+
+    afterEach(() => {
+      getTemplatesLibraryStub.restore();
+      showInputBoxStub.restore();
+      quickPickStub.restore();
+      showSuccessfulExecutionStub.restore();
+      showFailedExecutionStub.restore();
+      appendLineStub.restore();
+      openTextDocumentStub.restore();
+    });
+
+    it('Should create Aura Component', async () => {
+      // arrange
+      getInternalDevStub.returns(false);
+      const fileName = 'testComponent';
+      const outputPath = 'force-app/main/default/aura';
+      const auraComponentPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'testComponent',
+        'testComponent.cmp'
+      );
+      const auraComponentMetaPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'testComponent',
+        'testComponent.cmp-meta.xml'
+      );
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+      assert.noFile([auraComponentPath, auraComponentMetaPath]);
+      showInputBoxStub.returns(fileName);
+      quickPickStub.returns(outputPath);
+
+      // act
+      await forceLightningComponentCreate();
+
+      // assert
+      const suffixarray = [
+        '.cmp',
+        '.cmp-meta.xml',
+        '.auradoc',
+        '.css',
+        'Controller.js',
+        'Helper.js',
+        'Renderer.js',
+        '.svg',
+        '.design'
+      ];
+      for (const suffix of suffixarray) {
+        assert.file(
+          path.join(
+            getRootWorkspacePath(),
+            outputPath,
+            fileName,
+            `${fileName}${suffix}`
+          )
+        );
+      }
+      assert.fileContent(
+        auraComponentPath,
+        '<aura:component>\n\n</aura:component>'
+      );
+      assert.fileContent(
+        auraComponentMetaPath,
+        `<AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">`
+      );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, auraComponentPath);
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+    });
+
+    it('Should create internal Aura Component', async () => {
+      // arrange
+      getInternalDevStub.returns(true);
+      const fileName = 'testComponent';
+      const outputPath = 'force-app/main/default/aura';
+      const auraComponentPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'testComponent',
+        'testComponent.cmp'
+      );
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+      assert.noFile([auraComponentPath]);
+      showInputBoxStub.returns(fileName);
+      quickPickStub.returns(outputPath);
+
+      // act
+      shell.mkdir('-p', path.join(getRootWorkspacePath(), outputPath));
+      await forceInternalLightningComponentCreate(
+        vscode.Uri.file(path.join(getRootWorkspacePath(), outputPath))
+      );
+
+      // assert
+      const suffixarray = [
+        '.cmp',
+        '.auradoc',
+        '.css',
+        'Controller.js',
+        'Helper.js',
+        'Renderer.js',
+        '.svg',
+        '.design'
+      ];
+      for (const suffix of suffixarray) {
+        assert.file(
+          path.join(
+            getRootWorkspacePath(),
+            outputPath,
+            fileName,
+            `${fileName}${suffix}`
+          )
+        );
+      }
+      assert.fileContent(
+        auraComponentPath,
+        '<aura:component>\n\n</aura:component>'
+      );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, auraComponentPath);
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+    });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceLightningEventCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceLightningEventCreate.test.ts
@@ -4,71 +4,208 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
+import { TemplateService } from '@salesforce/templates';
 import { expect } from 'chai';
 import * as path from 'path';
+import * as shell from 'shelljs';
 import { SinonStub, stub } from 'sinon';
-import { ForceLightningEventCreateExecutor } from '../../../../src/commands/templates/forceLightningEventCreate';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import * as assert from 'yeoman-assert';
+import { channelService } from '../../../../src/channels';
+import {
+  forceInternalLightningEventCreate,
+  forceLightningEventCreate,
+  ForceLightningEventCreateExecutor
+} from '../../../../src/commands/templates/forceLightningEventCreate';
 import { nls } from '../../../../src/messages';
+import { notificationService } from '../../../../src/notifications';
 import { SfdxCoreSettings } from '../../../../src/settings/sfdxCoreSettings';
+import { getRootWorkspacePath } from '../../../../src/util';
 
 // tslint:disable:no-unused-expression
 describe('Force Lightning Event Create', () => {
-  let settings: SinonStub;
+  let getInternalDevStub: SinonStub;
 
   beforeEach(() => {
-    settings = stub(SfdxCoreSettings.prototype, 'getInternalDev');
+    getInternalDevStub = stub(SfdxCoreSettings.prototype, 'getInternalDev');
   });
 
   afterEach(() => {
-    settings.restore();
+    getInternalDevStub.restore();
   });
 
-  it('Should build the Lightning Event create command', async () => {
-    settings.returns(false);
-    const lightningEventCreate = new ForceLightningEventCreateExecutor();
-    const outputDirPath = path.join('force-app', 'main', 'default', 'aura');
-    const fileName = 'myAuraEvent';
-    const lwcCreateCommand = lightningEventCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Commands', () => {
+    it('Should build the Lightning Event create command', async () => {
+      getInternalDevStub.returns(false);
+      const lightningEventCreate = new ForceLightningEventCreateExecutor();
+      const outputDirPath = path.join('force-app', 'main', 'default', 'aura');
+      const fileName = 'myAuraEvent';
+      const lwcCreateCommand = lightningEventCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(lwcCreateCommand.toCommand()).to.equal(
+        `sfdx force:lightning:event:create --eventname ${fileName} --outputdir ${outputDirPath}`
+      );
+      expect(lwcCreateCommand.description).to.equal(
+        nls.localize('force_lightning_event_create_text')
+      );
+      expect(lightningEventCreate.getDefaultDirectory()).to.equal('aura');
+      expect(lightningEventCreate.getFileExtension()).to.equal('.evt');
+      expect(
+        lightningEventCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.evt')
+      ).to.equal(path.join(outputDirPath, fileName, `${fileName}.evt`));
     });
-    expect(lwcCreateCommand.toCommand()).to.equal(
-      `sfdx force:lightning:event:create --eventname ${fileName} --outputdir ${outputDirPath}`
-    );
-    expect(lwcCreateCommand.description).to.equal(
-      nls.localize('force_lightning_event_create_text')
-    );
-    expect(lightningEventCreate.getDefaultDirectory()).to.equal('aura');
-    expect(lightningEventCreate.getFileExtension()).to.equal('.evt');
-    expect(
-      lightningEventCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.evt')
-    ).to.equal(path.join(outputDirPath, fileName, `${fileName}.evt`));
+
+    it('Should build the internal Lightning Event create command', async () => {
+      getInternalDevStub.returns(true);
+      const lightningEventCreate = new ForceLightningEventCreateExecutor();
+      const outputDirPath = path.join('non-dx', 'dir', 'components', 'ns');
+      const fileName = 'internalEvent';
+      const lwcCreateCommand = lightningEventCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(lwcCreateCommand.toCommand()).to.equal(
+        `sfdx force:lightning:event:create --eventname ${fileName} --outputdir ${outputDirPath} --internal`
+      );
+      expect(lwcCreateCommand.description).to.equal(
+        nls.localize('force_lightning_event_create_text')
+      );
+      expect(lightningEventCreate.getDefaultDirectory()).to.equal('aura');
+      expect(lightningEventCreate.getFileExtension()).to.equal('.evt');
+      expect(
+        lightningEventCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.evt')
+      ).to.equal(path.join(outputDirPath, fileName, `${fileName}.evt`));
+    });
   });
 
-  it('Should build the internal Lightning Event create command', async () => {
-    settings.returns(true);
-    const lightningEventCreate = new ForceLightningEventCreateExecutor();
-    const outputDirPath = path.join('non-dx', 'dir', 'components', 'ns');
-    const fileName = 'internalEvent';
-    const lwcCreateCommand = lightningEventCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Library Create', () => {
+    let getTemplatesLibraryStub: SinonStub;
+    let showInputBoxStub: SinonStub;
+    let quickPickStub: SinonStub;
+    let appendLineStub: SinonStub;
+    let showSuccessfulExecutionStub: SinonStub;
+    let showFailedExecutionStub: SinonStub;
+    let openTextDocumentStub: SinonStub;
+
+    beforeEach(() => {
+      // mock experimental setting
+      getTemplatesLibraryStub = stub(
+        SfdxCoreSettings.prototype,
+        'getTemplatesLibrary'
+      );
+      getTemplatesLibraryStub.returns(true);
+      showInputBoxStub = stub(vscode.window, 'showInputBox');
+      quickPickStub = stub(vscode.window, 'showQuickPick');
+      appendLineStub = stub(channelService, 'appendLine');
+      showSuccessfulExecutionStub = stub(
+        notificationService,
+        'showSuccessfulExecution'
+      );
+      showSuccessfulExecutionStub.returns(Promise.resolve());
+      showFailedExecutionStub = stub(
+        notificationService,
+        'showFailedExecution'
+      );
+      openTextDocumentStub = stub(vscode.workspace, 'openTextDocument');
     });
-    expect(lwcCreateCommand.toCommand()).to.equal(
-      `sfdx force:lightning:event:create --eventname ${fileName} --outputdir ${outputDirPath} --internal`
-    );
-    expect(lwcCreateCommand.description).to.equal(
-      nls.localize('force_lightning_event_create_text')
-    );
-    expect(lightningEventCreate.getDefaultDirectory()).to.equal('aura');
-    expect(lightningEventCreate.getFileExtension()).to.equal('.evt');
-    expect(
-      lightningEventCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.evt')
-    ).to.equal(path.join(outputDirPath, fileName, `${fileName}.evt`));
+
+    afterEach(() => {
+      getTemplatesLibraryStub.restore();
+      showInputBoxStub.restore();
+      quickPickStub.restore();
+      showSuccessfulExecutionStub.restore();
+      showFailedExecutionStub.restore();
+      appendLineStub.restore();
+      openTextDocumentStub.restore();
+    });
+
+    it('Should create Aura Event', async () => {
+      // arrange
+      getInternalDevStub.returns(false);
+      const fileName = 'testEvent';
+      const outputPath = 'force-app/main/default/aura';
+      const auraEventPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        fileName,
+        'testEvent.evt'
+      );
+      const auraEventMetaPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        fileName,
+        'testEvent.evt-meta.xml'
+      );
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+      assert.noFile([auraEventPath, auraEventMetaPath]);
+      showInputBoxStub.returns(fileName);
+      quickPickStub.returns(outputPath);
+
+      // act
+      await forceLightningEventCreate();
+
+      // assert
+      const defaultApiVersion = TemplateService.getDefaultApiVersion();
+      assert.file([auraEventPath, auraEventMetaPath]);
+      assert.fileContent(
+        auraEventPath,
+        '<aura:event type="APPLICATION" description="Event template"/>'
+      );
+      assert.fileContent(
+        auraEventMetaPath,
+        `<?xml version="1.0" encoding="UTF-8"?>
+<AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>${defaultApiVersion}</apiVersion>
+    <description>A Lightning Event Bundle</description>
+</AuraDefinitionBundle>`
+      );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, auraEventPath);
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+    });
+
+    it('Should create internal Aura Event', async () => {
+      // arrange
+      getInternalDevStub.returns(true);
+      const fileName = 'testEvent';
+      const outputPath = 'force-app/main/default/aura';
+      const auraEventPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        fileName,
+        'testEvent.evt'
+      );
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+      assert.noFile([auraEventPath]);
+      showInputBoxStub.returns(fileName);
+      quickPickStub.returns(outputPath);
+
+      // act
+      shell.mkdir('-p', path.join(getRootWorkspacePath(), outputPath));
+      await forceInternalLightningEventCreate(
+        vscode.Uri.file(path.join(getRootWorkspacePath(), outputPath))
+      );
+
+      // assert
+      assert.file([auraEventPath]);
+      assert.fileContent(
+        auraEventPath,
+        '<aura:event type="APPLICATION" description="Event template"/>'
+      );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, auraEventPath);
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+    });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceLightningInterfaceCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceLightningInterfaceCreate.test.ts
@@ -4,71 +4,212 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
+import { TemplateService } from '@salesforce/templates';
 import { expect } from 'chai';
 import * as path from 'path';
+import * as shell from 'shelljs';
+import * as sinon from 'sinon';
 import { SinonStub, stub } from 'sinon';
-import { ForceLightningInterfaceCreateExecutor } from '../../../../src/commands/templates/forceLightningInterfaceCreate';
+import * as vscode from 'vscode';
+import * as assert from 'yeoman-assert';
+import { channelService } from '../../../../src/channels';
+import {
+  forceInternalLightningInterfaceCreate,
+  forceLightningInterfaceCreate,
+  ForceLightningInterfaceCreateExecutor
+} from '../../../../src/commands/templates/forceLightningInterfaceCreate';
 import { nls } from '../../../../src/messages';
+import { notificationService } from '../../../../src/notifications';
 import { SfdxCoreSettings } from '../../../../src/settings/sfdxCoreSettings';
+import { getRootWorkspacePath } from '../../../../src/util';
 
 // tslint:disable:no-unused-expression
 describe('Force Lightning Interface Create', () => {
-  let settings: SinonStub;
+  let getInternalDevStub: SinonStub;
 
   beforeEach(() => {
-    settings = stub(SfdxCoreSettings.prototype, 'getInternalDev');
+    getInternalDevStub = stub(SfdxCoreSettings.prototype, 'getInternalDev');
   });
 
   afterEach(() => {
-    settings.restore();
+    getInternalDevStub.restore();
   });
 
-  it('Should build the Lightning Interface create command', async () => {
-    settings.returns(false);
-    const lightningInterfaceCreate = new ForceLightningInterfaceCreateExecutor();
-    const outputDirPath = path.join('force-app', 'main', 'default', 'aura');
-    const fileName = 'myAuraInterface';
-    const lwcCreateCommand = lightningInterfaceCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Commands', () => {
+    it('Should build the Lightning Interface create command', async () => {
+      getInternalDevStub.returns(false);
+      const lightningInterfaceCreate = new ForceLightningInterfaceCreateExecutor();
+      const outputDirPath = path.join('force-app', 'main', 'default', 'aura');
+      const fileName = 'myAuraInterface';
+      const lwcCreateCommand = lightningInterfaceCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(lwcCreateCommand.toCommand()).to.equal(
+        `sfdx force:lightning:interface:create --interfacename ${fileName} --outputdir ${outputDirPath}`
+      );
+      expect(lwcCreateCommand.description).to.equal(
+        nls.localize('force_lightning_interface_create_text')
+      );
+      expect(lightningInterfaceCreate.getDefaultDirectory()).to.equal('aura');
+      expect(lightningInterfaceCreate.getFileExtension()).to.equal('.intf');
+      expect(
+        lightningInterfaceCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.intf')
+      ).to.equal(path.join(outputDirPath, fileName, `${fileName}.intf`));
     });
-    expect(lwcCreateCommand.toCommand()).to.equal(
-      `sfdx force:lightning:interface:create --interfacename ${fileName} --outputdir ${outputDirPath}`
-    );
-    expect(lwcCreateCommand.description).to.equal(
-      nls.localize('force_lightning_interface_create_text')
-    );
-    expect(lightningInterfaceCreate.getDefaultDirectory()).to.equal('aura');
-    expect(lightningInterfaceCreate.getFileExtension()).to.equal('.intf');
-    expect(
-      lightningInterfaceCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.intf')
-    ).to.equal(path.join(outputDirPath, fileName, `${fileName}.intf`));
+
+    it('Should build the internal Lightning Interface create command', async () => {
+      getInternalDevStub.returns(true);
+      const lightningInterfaceCreate = new ForceLightningInterfaceCreateExecutor();
+      const outputDirPath = path.join('non-dx', 'dir', 'components', 'ns');
+      const fileName = 'internalInterface';
+      const lwcCreateCommand = lightningInterfaceCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(lwcCreateCommand.toCommand()).to.equal(
+        `sfdx force:lightning:interface:create --interfacename ${fileName} --outputdir ${outputDirPath} --internal`
+      );
+      expect(lwcCreateCommand.description).to.equal(
+        nls.localize('force_lightning_interface_create_text')
+      );
+      expect(lightningInterfaceCreate.getDefaultDirectory()).to.equal('aura');
+      expect(lightningInterfaceCreate.getFileExtension()).to.equal('.intf');
+      expect(
+        lightningInterfaceCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.intf')
+      ).to.equal(path.join(outputDirPath, fileName, `${fileName}.intf`));
+    });
   });
 
-  it('Should build the internal Lightning Interface create command', async () => {
-    settings.returns(true);
-    const lightningInterfaceCreate = new ForceLightningInterfaceCreateExecutor();
-    const outputDirPath = path.join('non-dx', 'dir', 'components', 'ns');
-    const fileName = 'internalInterface';
-    const lwcCreateCommand = lightningInterfaceCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Library Create', () => {
+    let getTemplatesLibraryStub: SinonStub;
+    let showInputBoxStub: SinonStub;
+    let quickPickStub: SinonStub;
+    let appendLineStub: SinonStub;
+    let showSuccessfulExecutionStub: SinonStub;
+    let showFailedExecutionStub: SinonStub;
+    let openTextDocumentStub: SinonStub;
+
+    beforeEach(() => {
+      // mock experimental setting
+      getTemplatesLibraryStub = stub(
+        SfdxCoreSettings.prototype,
+        'getTemplatesLibrary'
+      );
+      getTemplatesLibraryStub.returns(true);
+      showInputBoxStub = stub(vscode.window, 'showInputBox');
+      quickPickStub = stub(vscode.window, 'showQuickPick');
+      appendLineStub = stub(channelService, 'appendLine');
+      showSuccessfulExecutionStub = stub(
+        notificationService,
+        'showSuccessfulExecution'
+      );
+      showSuccessfulExecutionStub.returns(Promise.resolve());
+      showFailedExecutionStub = stub(
+        notificationService,
+        'showFailedExecution'
+      );
+      openTextDocumentStub = stub(vscode.workspace, 'openTextDocument');
     });
-    expect(lwcCreateCommand.toCommand()).to.equal(
-      `sfdx force:lightning:interface:create --interfacename ${fileName} --outputdir ${outputDirPath} --internal`
-    );
-    expect(lwcCreateCommand.description).to.equal(
-      nls.localize('force_lightning_interface_create_text')
-    );
-    expect(lightningInterfaceCreate.getDefaultDirectory()).to.equal('aura');
-    expect(lightningInterfaceCreate.getFileExtension()).to.equal('.intf');
-    expect(
-      lightningInterfaceCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.intf')
-    ).to.equal(path.join(outputDirPath, fileName, `${fileName}.intf`));
+
+    afterEach(() => {
+      getTemplatesLibraryStub.restore();
+      showInputBoxStub.restore();
+      quickPickStub.restore();
+      showSuccessfulExecutionStub.restore();
+      showFailedExecutionStub.restore();
+      appendLineStub.restore();
+      openTextDocumentStub.restore();
+    });
+
+    it('Should create Aura Interface', async () => {
+      // arrange
+      getInternalDevStub.returns(false);
+      const fileName = 'testInterface';
+      const outputPath = 'force-app/main/default/aura';
+      const auraInterfacePath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        fileName,
+        'testInterface.intf'
+      );
+      const auraInterfaceMetaPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        fileName,
+        'testInterface.intf-meta.xml'
+      );
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+      assert.noFile([auraInterfacePath, auraInterfaceMetaPath]);
+      showInputBoxStub.returns(fileName);
+      quickPickStub.returns(outputPath);
+
+      // act
+      await forceLightningInterfaceCreate();
+
+      // assert
+      const defaultApiVersion = TemplateService.getDefaultApiVersion();
+      assert.file([auraInterfacePath, auraInterfaceMetaPath]);
+      assert.fileContent(
+        auraInterfacePath,
+        `<aura:interface description="Interface template">
+  <aura:attribute name="example" type="String" default="" description="An example attribute."/>
+</aura:interface>`
+      );
+      assert.fileContent(
+        auraInterfaceMetaPath,
+        `<?xml version="1.0" encoding="UTF-8"?>
+<AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>${defaultApiVersion}</apiVersion>
+    <description>A Lightning Interface Bundle</description>
+</AuraDefinitionBundle>`
+      );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, auraInterfacePath);
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+    });
+
+    it('Should create internal Aura Interface', async () => {
+      // arrange
+      getInternalDevStub.returns(true);
+      const fileName = 'testInterface';
+      const outputPath = 'force-app/main/default/aura';
+      const auraInterfacePath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        fileName,
+        'testInterface.intf'
+      );
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+      assert.noFile([auraInterfacePath]);
+      showInputBoxStub.returns(fileName);
+      quickPickStub.returns(outputPath);
+
+      // act
+      shell.mkdir('-p', path.join(getRootWorkspacePath(), outputPath));
+      await forceInternalLightningInterfaceCreate(
+        vscode.Uri.file(path.join(getRootWorkspacePath(), outputPath))
+      );
+
+      // assert
+      assert.file([auraInterfacePath]);
+      assert.fileContent(
+        auraInterfacePath,
+        `<aura:interface description="Interface template">
+  <aura:attribute name="example" type="String" default="" description="An example attribute."/>
+</aura:interface>`
+      );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, auraInterfacePath);
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+    });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceLightningLWCCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceLightningLWCCreate.test.ts
@@ -4,71 +4,226 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
+import { TemplateService } from '@salesforce/templates';
 import { expect } from 'chai';
 import * as path from 'path';
+import * as shell from 'shelljs';
+import * as sinon from 'sinon';
 import { SinonStub, stub } from 'sinon';
-import { ForceLightningLwcCreateExecutor } from '../../../../src/commands/templates';
+import * as vscode from 'vscode';
+import * as assert from 'yeoman-assert';
+import { channelService } from '../../../../src/channels';
+import {
+  forceInternalLightningLwcCreate,
+  forceLightningLwcCreate,
+  ForceLightningLwcCreateExecutor
+} from '../../../../src/commands/templates';
 import { nls } from '../../../../src/messages';
+import { notificationService } from '../../../../src/notifications';
 import { SfdxCoreSettings } from '../../../../src/settings/sfdxCoreSettings';
+import { getRootWorkspacePath } from '../../../../src/util';
 
 // tslint:disable:no-unused-expression
 describe('Force Lightning Web Component Create', () => {
-  let settings: SinonStub;
+  let getInternalDevStub: SinonStub;
 
   beforeEach(() => {
-    settings = stub(SfdxCoreSettings.prototype, 'getInternalDev');
+    getInternalDevStub = stub(SfdxCoreSettings.prototype, 'getInternalDev');
   });
 
   afterEach(() => {
-    settings.restore();
+    getInternalDevStub.restore();
   });
 
-  it('Should build the Lightning Web Component create command', async () => {
-    settings.returns(false);
-    const lightningLWCCreate = new ForceLightningLwcCreateExecutor();
-    const outputDirPath = path.join('force-app', 'main', 'default', 'lwc');
-    const fileName = 'myLWC';
-    const lwcCreateCommand = lightningLWCCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Commands', () => {
+    it('Should build the Lightning Web Component create command', async () => {
+      getInternalDevStub.returns(false);
+      const lightningLWCCreate = new ForceLightningLwcCreateExecutor();
+      const outputDirPath = path.join('force-app', 'main', 'default', 'lwc');
+      const fileName = 'myLWC';
+      const lwcCreateCommand = lightningLWCCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(lwcCreateCommand.toCommand()).to.equal(
+        `sfdx force:lightning:component:create --type lwc --componentname ${fileName} --outputdir ${outputDirPath}`
+      );
+      expect(lwcCreateCommand.description).to.equal(
+        nls.localize('force_lightning_lwc_create_text')
+      );
+      expect(lightningLWCCreate.getDefaultDirectory()).to.equal('lwc');
+      expect(lightningLWCCreate.getFileExtension()).to.equal('.js');
+      expect(
+        lightningLWCCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.js')
+      ).to.equal(path.join(outputDirPath, fileName, `${fileName}.js`));
     });
-    expect(lwcCreateCommand.toCommand()).to.equal(
-      `sfdx force:lightning:component:create --type lwc --componentname ${fileName} --outputdir ${outputDirPath}`
-    );
-    expect(lwcCreateCommand.description).to.equal(
-      nls.localize('force_lightning_lwc_create_text')
-    );
-    expect(lightningLWCCreate.getDefaultDirectory()).to.equal('lwc');
-    expect(lightningLWCCreate.getFileExtension()).to.equal('.js');
-    expect(
-      lightningLWCCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.js')
-    ).to.equal(path.join(outputDirPath, fileName, `${fileName}.js`));
+
+    it('Should build the internal Lightning Web Component create command', async () => {
+      getInternalDevStub.returns(true);
+      const lightningLWCCreate = new ForceLightningLwcCreateExecutor();
+      const outputDirPath = path.join('non-dx', 'dir', 'components', 'ns');
+      const fileName = 'internalLWC';
+      const lwcCreateCommand = lightningLWCCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(lwcCreateCommand.toCommand()).to.equal(
+        `sfdx force:lightning:component:create --type lwc --componentname ${fileName} --outputdir ${outputDirPath} --internal`
+      );
+      expect(lwcCreateCommand.description).to.equal(
+        nls.localize('force_lightning_lwc_create_text')
+      );
+      expect(lightningLWCCreate.getDefaultDirectory()).to.equal('lwc');
+      expect(lightningLWCCreate.getFileExtension()).to.equal('.js');
+      expect(
+        lightningLWCCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.js')
+      ).to.equal(path.join(outputDirPath, fileName, `${fileName}.js`));
+    });
   });
 
-  it('Should build the internal Lightning Web Component create command', async () => {
-    settings.returns(true);
-    const lightningLWCCreate = new ForceLightningLwcCreateExecutor();
-    const outputDirPath = path.join('non-dx', 'dir', 'components', 'ns');
-    const fileName = 'internalLWC';
-    const lwcCreateCommand = lightningLWCCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Library Create', () => {
+    let getTemplatesLibraryStub: SinonStub;
+    let showInputBoxStub: SinonStub;
+    let quickPickStub: SinonStub;
+    let appendLineStub: SinonStub;
+    let showSuccessfulExecutionStub: SinonStub;
+    let showFailedExecutionStub: SinonStub;
+    let openTextDocumentStub: SinonStub;
+
+    beforeEach(() => {
+      // mock experimental setting
+      getTemplatesLibraryStub = stub(
+        SfdxCoreSettings.prototype,
+        'getTemplatesLibrary'
+      );
+      getTemplatesLibraryStub.returns(true);
+      showInputBoxStub = stub(vscode.window, 'showInputBox');
+      quickPickStub = stub(vscode.window, 'showQuickPick');
+      appendLineStub = stub(channelService, 'appendLine');
+      showSuccessfulExecutionStub = stub(
+        notificationService,
+        'showSuccessfulExecution'
+      );
+      showSuccessfulExecutionStub.returns(Promise.resolve());
+      showFailedExecutionStub = stub(
+        notificationService,
+        'showFailedExecution'
+      );
+      openTextDocumentStub = stub(vscode.workspace, 'openTextDocument');
     });
-    expect(lwcCreateCommand.toCommand()).to.equal(
-      `sfdx force:lightning:component:create --type lwc --componentname ${fileName} --outputdir ${outputDirPath} --internal`
-    );
-    expect(lwcCreateCommand.description).to.equal(
-      nls.localize('force_lightning_lwc_create_text')
-    );
-    expect(lightningLWCCreate.getDefaultDirectory()).to.equal('lwc');
-    expect(lightningLWCCreate.getFileExtension()).to.equal('.js');
-    expect(
-      lightningLWCCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.js')
-    ).to.equal(path.join(outputDirPath, fileName, `${fileName}.js`));
+
+    afterEach(() => {
+      getTemplatesLibraryStub.restore();
+      showInputBoxStub.restore();
+      quickPickStub.restore();
+      showSuccessfulExecutionStub.restore();
+      showFailedExecutionStub.restore();
+      appendLineStub.restore();
+      openTextDocumentStub.restore();
+    });
+
+    it('Should create LWC Component', async () => {
+      // arrange
+      getInternalDevStub.returns(false);
+      const fileName = 'testLwc';
+      const outputPath = 'force-app/main/default/lwc';
+      const lwcHtmlPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        fileName,
+        'testLwc.html'
+      );
+      const lwcJsPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        fileName,
+        'testLwc.js'
+      );
+      const lwcJsMetaPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        fileName,
+        'testLwc.js-meta.xml'
+      );
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+      assert.noFile([lwcHtmlPath, lwcJsPath, lwcJsMetaPath]);
+      showInputBoxStub.returns(fileName);
+      quickPickStub.returns(outputPath);
+
+      // act
+      await forceLightningLwcCreate();
+
+      // assert
+      const defaultApiVersion = TemplateService.getDefaultApiVersion();
+      assert.file([lwcHtmlPath, lwcJsPath, lwcJsMetaPath]);
+      assert.fileContent(lwcHtmlPath, `<template>\n    \n</template>`);
+      assert.fileContent(
+        lwcJsPath,
+        `import { LightningElement } from 'lwc';
+
+export default class TestLwc extends LightningElement {}`
+      );
+      assert.fileContent(
+        lwcJsMetaPath,
+        `<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>${defaultApiVersion}</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>`
+      );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, lwcJsPath);
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+    });
+
+    it('Should create internal LWC Component', async () => {
+      // arrange
+      getInternalDevStub.returns(true);
+      const fileName = 'testLwc';
+      const outputPath = 'force-app/main/default/lwc';
+      const lwcHtmlPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        fileName,
+        'testLwc.html'
+      );
+      const lwcJsPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        fileName,
+        'testLwc.js'
+      );
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+      assert.noFile([lwcHtmlPath, lwcJsPath]);
+      showInputBoxStub.returns(fileName);
+      quickPickStub.returns(outputPath);
+
+      // act
+      shell.mkdir('-p', path.join(getRootWorkspacePath(), outputPath));
+      await forceInternalLightningLwcCreate(
+        vscode.Uri.file(path.join(getRootWorkspacePath(), outputPath))
+      );
+
+      // assert
+      assert.file([lwcHtmlPath, lwcJsPath]);
+      assert.fileContent(lwcHtmlPath, `<template>\n    \n</template>`);
+      assert.fileContent(
+        lwcJsPath,
+        `import { LightningElement } from 'lwc';
+
+export default class TestLwc extends LightningElement {}`
+      );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, lwcJsPath);
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+    });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceVisualforceComponentCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceVisualforceComponentCreate.test.ts
@@ -4,39 +4,144 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
+import { TemplateService } from '@salesforce/templates';
 import { expect } from 'chai';
 import * as path from 'path';
-import { ForceVisualForceComponentCreateExecutor } from '../../../../src/commands/templates';
+import * as shell from 'shelljs';
+import * as sinon from 'sinon';
+import { SinonStub, stub } from 'sinon';
+import * as vscode from 'vscode';
+import * as assert from 'yeoman-assert';
+import { channelService } from '../../../../src/channels';
+import {
+  forceVisualforceComponentCreate,
+  ForceVisualForceComponentCreateExecutor
+} from '../../../../src/commands/templates';
 import { nls } from '../../../../src/messages';
+import { notificationService } from '../../../../src/notifications';
+import { SfdxCoreSettings } from '../../../../src/settings/sfdxCoreSettings';
+import { getRootWorkspacePath } from '../../../../src/util';
 
 // tslint:disable:no-unused-expression
 describe('Force Visualforce Component Create', () => {
-  it('Should build the Visualforce component create command', async () => {
-    const visualforceCmpCreate = new ForceVisualForceComponentCreateExecutor();
-    const outputDirPath = path.join(
-      'force-app',
-      'main',
-      'default',
-      'components'
-    );
-    const fileName = 'myVFCmp';
-    const vfCmpCreateCommand = visualforceCmpCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Commands', () => {
+    it('Should build the Visualforce component create command', async () => {
+      const visualforceCmpCreate = new ForceVisualForceComponentCreateExecutor();
+      const outputDirPath = path.join(
+        'force-app',
+        'main',
+        'default',
+        'components'
+      );
+      const fileName = 'myVFCmp';
+      const vfCmpCreateCommand = visualforceCmpCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(vfCmpCreateCommand.toCommand()).to.equal(
+        `sfdx force:visualforce:component:create --componentname ${fileName} --label ${fileName} --outputdir ${outputDirPath}`
+      );
+      expect(vfCmpCreateCommand.description).to.equal(
+        nls.localize('force_visualforce_component_create_text')
+      );
+      expect(visualforceCmpCreate.getDefaultDirectory()).to.equal('components');
+      expect(visualforceCmpCreate.getFileExtension()).to.equal('.component');
+      expect(
+        visualforceCmpCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.component')
+      ).to.equal(path.join(outputDirPath, `${fileName}.component`));
     });
-    expect(vfCmpCreateCommand.toCommand()).to.equal(
-      `sfdx force:visualforce:component:create --componentname ${fileName} --label ${fileName} --outputdir ${outputDirPath}`
-    );
-    expect(vfCmpCreateCommand.description).to.equal(
-      nls.localize('force_visualforce_component_create_text')
-    );
-    expect(visualforceCmpCreate.getDefaultDirectory()).to.equal('components');
-    expect(visualforceCmpCreate.getFileExtension()).to.equal('.component');
-    expect(
-      visualforceCmpCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.component')
-    ).to.equal(path.join(outputDirPath, `${fileName}.component`));
+  });
+
+  describe('Library Create', () => {
+    let getTemplatesLibraryStub: SinonStub;
+    let showInputBoxStub: SinonStub;
+    let quickPickStub: SinonStub;
+    let appendLineStub: SinonStub;
+    let showSuccessfulExecutionStub: SinonStub;
+    let showFailedExecutionStub: SinonStub;
+    let openTextDocumentStub: SinonStub;
+
+    beforeEach(() => {
+      // mock experimental setting
+      getTemplatesLibraryStub = stub(
+        SfdxCoreSettings.prototype,
+        'getTemplatesLibrary'
+      );
+      getTemplatesLibraryStub.returns(true);
+      showInputBoxStub = stub(vscode.window, 'showInputBox');
+      quickPickStub = stub(vscode.window, 'showQuickPick');
+      appendLineStub = stub(channelService, 'appendLine');
+      showSuccessfulExecutionStub = stub(
+        notificationService,
+        'showSuccessfulExecution'
+      );
+      showSuccessfulExecutionStub.returns(Promise.resolve());
+      showFailedExecutionStub = stub(
+        notificationService,
+        'showFailedExecution'
+      );
+      openTextDocumentStub = stub(vscode.workspace, 'openTextDocument');
+    });
+
+    afterEach(() => {
+      getTemplatesLibraryStub.restore();
+      showInputBoxStub.restore();
+      quickPickStub.restore();
+      showSuccessfulExecutionStub.restore();
+      showFailedExecutionStub.restore();
+      appendLineStub.restore();
+      openTextDocumentStub.restore();
+    });
+
+    it('Should create Visualforce Component', async () => {
+      // arrange
+      const fileName = 'testVFCmp';
+      const outputPath = 'force-app/main/default/components';
+      const vfCmpPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'testVFCmp.component'
+      );
+      const vfCmpMetaPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'testVFCmp.component-meta.xml'
+      );
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath));
+      assert.noFile([vfCmpPath, vfCmpMetaPath]);
+      showInputBoxStub.returns(fileName);
+      quickPickStub.returns(outputPath);
+
+      // act
+      await forceVisualforceComponentCreate();
+
+      // assert
+      const defaultApiVersion = TemplateService.getDefaultApiVersion();
+      assert.file([vfCmpPath, vfCmpMetaPath]);
+      assert.fileContent(
+        vfCmpPath,
+        `<apex:component>
+<!-- Begin Default Content REMOVE THIS -->
+<h1>Congratulations</h1>
+This is your new Component
+<!-- End Default Content REMOVE THIS -->
+</apex:component>`
+      );
+      assert.fileContent(
+        vfCmpMetaPath,
+        `<?xml version="1.0" encoding="UTF-8"?>
+<ApexComponent xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>${defaultApiVersion}</apiVersion>
+    <label>testVFCmp</label>
+</ApexComponent>`
+      );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, vfCmpPath);
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath));
+    });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceVisualforcePageCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceVisualforcePageCreate.test.ts
@@ -4,34 +4,139 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
+import { TemplateService } from '@salesforce/templates';
 import { expect } from 'chai';
 import * as path from 'path';
-import { ForceVisualForcePageCreateExecutor } from '../../../../src/commands/templates';
+import * as shell from 'shelljs';
+import * as sinon from 'sinon';
+import { SinonStub, stub } from 'sinon';
+import * as vscode from 'vscode';
+import * as assert from 'yeoman-assert';
+import { channelService } from '../../../../src/channels';
+import {
+  forceVisualforcePageCreate,
+  ForceVisualForcePageCreateExecutor
+} from '../../../../src/commands/templates';
 import { nls } from '../../../../src/messages';
+import { notificationService } from '../../../../src/notifications';
+import { SfdxCoreSettings } from '../../../../src/settings/sfdxCoreSettings';
+import { getRootWorkspacePath } from '../../../../src/util';
 
 // tslint:disable:no-unused-expression
 describe('Force Visualforce Page Create', () => {
-  it('Should build the Visualforce page create command', async () => {
-    const visualforcePageCreate = new ForceVisualForcePageCreateExecutor();
-    const outputDirPath = path.join('force-app', 'main', 'default', 'pages');
-    const fileName = 'myVFPage';
-    const vfPageCreateCommand = visualforcePageCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Commands', () => {
+    it('Should build the Visualforce page create command', async () => {
+      const visualforcePageCreate = new ForceVisualForcePageCreateExecutor();
+      const outputDirPath = path.join('force-app', 'main', 'default', 'pages');
+      const fileName = 'myVFPage';
+      const vfPageCreateCommand = visualforcePageCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(vfPageCreateCommand.toCommand()).to.equal(
+        `sfdx force:visualforce:page:create --pagename ${fileName} --label ${fileName} --outputdir ${outputDirPath}`
+      );
+      expect(vfPageCreateCommand.description).to.equal(
+        nls.localize('force_visualforce_page_create_text')
+      );
+      expect(visualforcePageCreate.getDefaultDirectory()).to.equal('pages');
+      expect(visualforcePageCreate.getFileExtension()).to.equal('.page');
+      expect(
+        visualforcePageCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.page')
+      ).to.equal(path.join(outputDirPath, `${fileName}.page`));
     });
-    expect(vfPageCreateCommand.toCommand()).to.equal(
-      `sfdx force:visualforce:page:create --pagename ${fileName} --label ${fileName} --outputdir ${outputDirPath}`
-    );
-    expect(vfPageCreateCommand.description).to.equal(
-      nls.localize('force_visualforce_page_create_text')
-    );
-    expect(visualforcePageCreate.getDefaultDirectory()).to.equal('pages');
-    expect(visualforcePageCreate.getFileExtension()).to.equal('.page');
-    expect(
-      visualforcePageCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.page')
-    ).to.equal(path.join(outputDirPath, `${fileName}.page`));
+  });
+
+  describe('Library Create', () => {
+    let getTemplatesLibraryStub: SinonStub;
+    let showInputBoxStub: SinonStub;
+    let quickPickStub: SinonStub;
+    let appendLineStub: SinonStub;
+    let showSuccessfulExecutionStub: SinonStub;
+    let showFailedExecutionStub: SinonStub;
+    let openTextDocumentStub: SinonStub;
+
+    beforeEach(() => {
+      // mock experimental setting
+      getTemplatesLibraryStub = stub(
+        SfdxCoreSettings.prototype,
+        'getTemplatesLibrary'
+      );
+      getTemplatesLibraryStub.returns(true);
+      showInputBoxStub = stub(vscode.window, 'showInputBox');
+      quickPickStub = stub(vscode.window, 'showQuickPick');
+      appendLineStub = stub(channelService, 'appendLine');
+      showSuccessfulExecutionStub = stub(
+        notificationService,
+        'showSuccessfulExecution'
+      );
+      showSuccessfulExecutionStub.returns(Promise.resolve());
+      showFailedExecutionStub = stub(
+        notificationService,
+        'showFailedExecution'
+      );
+      openTextDocumentStub = stub(vscode.workspace, 'openTextDocument');
+    });
+
+    afterEach(() => {
+      getTemplatesLibraryStub.restore();
+      showInputBoxStub.restore();
+      quickPickStub.restore();
+      showSuccessfulExecutionStub.restore();
+      showFailedExecutionStub.restore();
+      appendLineStub.restore();
+      openTextDocumentStub.restore();
+    });
+
+    it('Should create Visualforce Component', async () => {
+      // arrange
+      const fileName = 'testVFPage';
+      const outputPath = 'force-app/main/default/components';
+      const vfPagePath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'testVFPage.page'
+      );
+      const vfPageMetaPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'testVFPage.page-meta.xml'
+      );
+      shell.rm('-f', path.join(vfPagePath));
+      shell.rm('-f', path.join(vfPageMetaPath));
+      assert.noFile([vfPagePath, vfPageMetaPath]);
+      showInputBoxStub.returns(fileName);
+      quickPickStub.returns(outputPath);
+
+      // act
+      await forceVisualforcePageCreate();
+
+      // assert
+      const defaultApiVersion = TemplateService.getDefaultApiVersion();
+      assert.file([vfPagePath, vfPageMetaPath]);
+      assert.fileContent(
+        vfPagePath,
+        `<apex:page>
+<!-- Begin Default Content REMOVE THIS -->
+<h1>Congratulations</h1>
+This is your new Page
+<!-- End Default Content REMOVE THIS -->
+</apex:page>`
+      );
+      assert.fileContent(
+        vfPageMetaPath,
+        `<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata"> \n    <apiVersion>${defaultApiVersion}</apiVersion>
+    <label>testVFPage</label>
+</ApexPage>`
+      );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, vfPagePath);
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath));
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Use `@salesforce/templates` library for creating templates. This functionality is behind the flag `salesforcedx-vscode-core.experimental.useTemplatesLibrary`

- Analytics
- Apex Class
- Apex Trigger
- Project

See remaining templates in #2437 (for an easier review)
- Lightning App
- Lightning Component
- Lightning Event
- Lightning Interface
- Lightning LWC
- Visualforce Component
- Visualforce Page

### What issues does this PR fix or reference?
@W-7747009@

### Functionality Before
![apex-class-cli](https://user-images.githubusercontent.com/679275/90719973-84c2ef80-e26a-11ea-843a-b2bd236f52ce.gif)

### Functionality After
We should cancel the progress bar :) task is finished before it knows
![apex-class-library](https://user-images.githubusercontent.com/679275/90720016-9c01dd00-e26a-11ea-8924-9ed4dfded38d.gif)

Measurement:
```
ApexClassCreate Elapsed: 4205.001875013113 
ApexClassCreate Elapsed: 2854.296660989523 
ApexClassCreate Elapsed: 2824.861781001091 
ApexClassCreate Elapsed: 2846.4673389792442 
ApexClassCreate Elapsed: 2850.0102190077305

ApexClassCreate (Library) Elapsed: 601.2615059912205 
ApexClassCreate (Library) Elapsed: 35.476530998945236 
ApexClassCreate (Library) Elapsed: 24.221484005451202 
ApexClassCreate (Library) Elapsed: 26.848446995019913 
ApexClassCreate (Library) Elapsed: 24.462306022644043
```
- 600% faster first run
- 10148% faster subsequent runs in the same session (with the optimization for multiple runs in library API)