### PR TITLE
Use @salesforce/templates library (Remaining templates)

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/templates/forceLightningInterfaceCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/forceLightningInterfaceCreate.ts
@@ -5,6 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { LightningInterfaceOptions, TemplateType } from '@salesforce/templates';
+import { LibraryBaseTemplateCommand } from './libraryBaseTemplateCommand';
+
 import {
   Command,
   SfdxCommandBuilder
@@ -33,6 +36,31 @@ import {
   AURA_INTERFACE_EXTENSION,
   AURA_TYPE
 } from './metadataTypeConstants';
+
+export class LibraryForceLightningInterfaceCreateExecutor extends LibraryBaseTemplateCommand<
+  DirFileNameSelection
+> {
+  public executionName = nls.localize('force_lightning_interface_create_text');
+  public telemetryName = 'force_lightning_interface_create';
+  public metadataTypeName = AURA_TYPE;
+  public templateType = TemplateType.LightningInterface;
+  public getOutputFileName(data: DirFileNameSelection) {
+    return data.fileName;
+  }
+  public getFileExtension() {
+    return AURA_INTERFACE_EXTENSION;
+  }
+  public constructTemplateOptions(data: DirFileNameSelection) {
+    const internal = sfdxCoreSettings.getInternalDev();
+    const templateOptions: LightningInterfaceOptions = {
+      outputdir: data.outputdir,
+      interfacename: data.fileName,
+      template: 'DefaultLightningIntf',
+      internal
+    };
+    return templateOptions;
+  }
+}
 
 export class ForceLightningInterfaceCreateExecutor extends BaseTemplateCommand {
   constructor() {
@@ -64,6 +92,9 @@ const outputDirGatherer = new SelectOutputDir(AURA_DIRECTORY, true);
 const metadataTypeGatherer = new MetadataTypeGatherer(AURA_TYPE);
 
 export async function forceLightningInterfaceCreate() {
+  const createTemplateExecutor = sfdxCoreSettings.getTemplatesLibrary()
+    ? new LibraryForceLightningInterfaceCreateExecutor()
+    : new ForceLightningInterfaceCreateExecutor();
   const commandlet = new SfdxCommandlet(
     new SfdxWorkspaceChecker(),
     new CompositeParametersGatherer<LocalComponent>(
@@ -71,20 +102,23 @@ export async function forceLightningInterfaceCreate() {
       fileNameGatherer,
       outputDirGatherer
     ),
-    new ForceLightningInterfaceCreateExecutor(),
+    createTemplateExecutor,
     new OverwriteComponentPrompt()
   );
   await commandlet.run();
 }
 
 export async function forceInternalLightningInterfaceCreate(sourceUri: Uri) {
+  const createTemplateExecutor = sfdxCoreSettings.getTemplatesLibrary()
+    ? new LibraryForceLightningInterfaceCreateExecutor()
+    : new ForceLightningInterfaceCreateExecutor();
   const commandlet = new SfdxCommandlet(
     new InternalDevWorkspaceChecker(),
     new CompositeParametersGatherer(
       fileNameGatherer,
       new FileInternalPathGatherer(sourceUri)
     ),
-    new ForceLightningInterfaceCreateExecutor()
+    createTemplateExecutor
   );
   await commandlet.run();
 }

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceLightningAppCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceLightningAppCreate.test.ts
@@ -7,68 +7,234 @@
 
 import { expect } from 'chai';
 import * as path from 'path';
+import * as shell from 'shelljs';
 import { SinonStub, stub } from 'sinon';
-import { ForceLightningAppCreateExecutor } from '../../../../src/commands/templates/forceLightningAppCreate';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import * as assert from 'yeoman-assert';
+import { channelService } from '../../../../src/channels';
+import {
+  forceInternalLightningAppCreate,
+  forceLightningAppCreate,
+  ForceLightningAppCreateExecutor
+} from '../../../../src/commands/templates/forceLightningAppCreate';
 import { nls } from '../../../../src/messages';
+import { notificationService } from '../../../../src/notifications';
 import { SfdxCoreSettings } from '../../../../src/settings/sfdxCoreSettings';
+import { getRootWorkspacePath } from '../../../../src/util';
 
 // tslint:disable:no-unused-expression
 describe('Force Lightning App Create', () => {
-  let settings: SinonStub;
+  let getInternalDevStub: SinonStub;
 
   beforeEach(() => {
-    settings = stub(SfdxCoreSettings.prototype, 'getInternalDev');
+    getInternalDevStub = stub(SfdxCoreSettings.prototype, 'getInternalDev');
   });
 
   afterEach(() => {
-    settings.restore();
+    getInternalDevStub.restore();
   });
 
-  it('Should build the lightning app create command', async () => {
-    settings.returns(false);
-    const lightningAppCreate = new ForceLightningAppCreateExecutor();
-    const outputDirPath = path.join('force-app', 'main', 'default', 'aura');
-    const fileName = 'lightningApp';
-    const lightningAppCreateCommand = lightningAppCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Commands', () => {
+    it('Should build the lightning app create command', async () => {
+      getInternalDevStub.returns(false);
+      const lightningAppCreate = new ForceLightningAppCreateExecutor();
+      const outputDirPath = path.join('force-app', 'main', 'default', 'aura');
+      const fileName = 'lightningApp';
+      const lightningAppCreateCommand = lightningAppCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(lightningAppCreateCommand.toCommand()).to.equal(
+        `sfdx force:lightning:app:create --appname ${fileName} --outputdir ${outputDirPath}`
+      );
+      expect(lightningAppCreateCommand.description).to.equal(
+        nls.localize('force_lightning_app_create_text')
+      );
+      expect(lightningAppCreate.getDefaultDirectory()).to.equal('aura');
+      expect(lightningAppCreate.getFileExtension()).to.equal('.app');
+      expect(
+        lightningAppCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.app')
+      ).to.equal(path.join(outputDirPath, fileName, `${fileName}.app`));
     });
-    expect(lightningAppCreateCommand.toCommand()).to.equal(
-      `sfdx force:lightning:app:create --appname ${fileName} --outputdir ${outputDirPath}`
-    );
-    expect(lightningAppCreateCommand.description).to.equal(
-      nls.localize('force_lightning_app_create_text')
-    );
-    expect(lightningAppCreate.getDefaultDirectory()).to.equal('aura');
-    expect(lightningAppCreate.getFileExtension()).to.equal('.app');
-    expect(
-      lightningAppCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.app')
-    ).to.equal(path.join(outputDirPath, fileName, `${fileName}.app`));
+
+    it('Should build the internal lightning app create command', async () => {
+      getInternalDevStub.returns(true);
+      const lightningAppCreate = new ForceLightningAppCreateExecutor();
+      const outputDirPath = path.join('non-dx', 'dir', 'components', 'ns');
+      const fileName = 'lightningInternalApp';
+      const lightningAppCreateCommand = lightningAppCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(lightningAppCreateCommand.toCommand()).to.equal(
+        `sfdx force:lightning:app:create --appname ${fileName} --outputdir ${outputDirPath} --internal`
+      );
+      expect(lightningAppCreateCommand.description).to.equal(
+        nls.localize('force_lightning_app_create_text')
+      );
+      expect(lightningAppCreate.getDefaultDirectory()).to.equal('aura');
+      expect(lightningAppCreate.getFileExtension()).to.equal('.app');
+      expect(
+        lightningAppCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.app')
+      ).to.equal(path.join(outputDirPath, fileName, `${fileName}.app`));
+    });
   });
 
-  it('Should build the internal lightning app create command', async () => {
-    settings.returns(true);
-    const lightningAppCreate = new ForceLightningAppCreateExecutor();
-    const outputDirPath = path.join('non-dx', 'dir', 'components', 'ns');
-    const fileName = 'lightningInternalApp';
-    const lightningAppCreateCommand = lightningAppCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Library Create', () => {
+    let getTemplatesLibraryStub: SinonStub;
+    let showInputBoxStub: SinonStub;
+    let quickPickStub: SinonStub;
+    let appendLineStub: SinonStub;
+    let showSuccessfulExecutionStub: SinonStub;
+    let showFailedExecutionStub: SinonStub;
+    let openTextDocumentStub: SinonStub;
+
+    beforeEach(() => {
+      // mock experimental setting
+      getTemplatesLibraryStub = stub(
+        SfdxCoreSettings.prototype,
+        'getTemplatesLibrary'
+      );
+      getTemplatesLibraryStub.returns(true);
+      showInputBoxStub = stub(vscode.window, 'showInputBox');
+      quickPickStub = stub(vscode.window, 'showQuickPick');
+      appendLineStub = stub(channelService, 'appendLine');
+      showSuccessfulExecutionStub = stub(
+        notificationService,
+        'showSuccessfulExecution'
+      );
+      showSuccessfulExecutionStub.returns(Promise.resolve());
+      showFailedExecutionStub = stub(
+        notificationService,
+        'showFailedExecution'
+      );
+      openTextDocumentStub = stub(vscode.workspace, 'openTextDocument');
     });
-    expect(lightningAppCreateCommand.toCommand()).to.equal(
-      `sfdx force:lightning:app:create --appname ${fileName} --outputdir ${outputDirPath} --internal`
-    );
-    expect(lightningAppCreateCommand.description).to.equal(
-      nls.localize('force_lightning_app_create_text')
-    );
-    expect(lightningAppCreate.getDefaultDirectory()).to.equal('aura');
-    expect(lightningAppCreate.getFileExtension()).to.equal('.app');
-    expect(
-      lightningAppCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.app')
-    ).to.equal(path.join(outputDirPath, fileName, `${fileName}.app`));
+
+    afterEach(() => {
+      getTemplatesLibraryStub.restore();
+      showInputBoxStub.restore();
+      quickPickStub.restore();
+      showSuccessfulExecutionStub.restore();
+      showFailedExecutionStub.restore();
+      appendLineStub.restore();
+      openTextDocumentStub.restore();
+    });
+
+    it('Should create Aura App', async () => {
+      // arrange
+      getInternalDevStub.returns(false);
+      const outputPath = 'force-app/main/default/aura';
+      const auraAppPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'testApp',
+        'testApp.app'
+      );
+      const auraAppMetaPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'testApp',
+        'testApp.app-meta.xml'
+      );
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, 'testApp'));
+      assert.noFile([auraAppPath, auraAppMetaPath]);
+      showInputBoxStub.returns('testApp');
+      quickPickStub.returns(outputPath);
+
+      // act
+      await forceLightningAppCreate();
+
+      // assert
+      const suffixarray = [
+        '.app',
+        '.app-meta.xml',
+        '.auradoc',
+        '.css',
+        'Controller.js',
+        'Helper.js',
+        'Renderer.js',
+        '.svg'
+      ];
+      for (const suffix of suffixarray) {
+        assert.file(
+          path.join(
+            getRootWorkspacePath(),
+            outputPath,
+            'testApp',
+            `testApp${suffix}`
+          )
+        );
+      }
+      assert.fileContent(
+        auraAppPath,
+        '<aura:application>\n\n</aura:application>'
+      );
+      assert.fileContent(
+        auraAppMetaPath,
+        `<AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">`
+      );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, auraAppPath);
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, 'testApp'));
+    });
+
+    it('Should create internal Aura App', async () => {
+      // arrange
+      getInternalDevStub.returns(true);
+      const outputPath = 'force-app/main/default/aura';
+      const auraAppPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'testApp',
+        'testApp.app'
+      );
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, 'testApp'));
+      assert.noFile([auraAppPath]);
+      showInputBoxStub.returns('testApp');
+
+      // act
+      shell.mkdir('-p', path.join(getRootWorkspacePath(), outputPath));
+      await forceInternalLightningAppCreate(
+        vscode.Uri.file(path.join(getRootWorkspacePath(), outputPath))
+      );
+
+      // assert
+      const suffixarray = [
+        '.app',
+        '.auradoc',
+        '.css',
+        'Controller.js',
+        'Helper.js',
+        'Renderer.js',
+        '.svg'
+      ];
+      for (const suffix of suffixarray) {
+        assert.file(
+          path.join(
+            getRootWorkspacePath(),
+            outputPath,
+            'testApp',
+            `testApp${suffix}`
+          )
+        );
+      }
+      assert.fileContent(
+        auraAppPath,
+        '<aura:application>\n\n</aura:application>'
+      );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, auraAppPath);
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, 'testApp'));
+    });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceLightningComponentCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceLightningComponentCreate.test.ts
@@ -7,68 +7,239 @@
 
 import { expect } from 'chai';
 import * as path from 'path';
+import * as shell from 'shelljs';
 import { SinonStub, stub } from 'sinon';
-import { ForceLightningComponentCreateExecutor } from '../../../../src/commands/templates/forceLightningComponentCreate';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import * as assert from 'yeoman-assert';
+import { channelService } from '../../../../src/channels';
+import {
+  forceInternalLightningComponentCreate,
+  forceLightningComponentCreate,
+  ForceLightningComponentCreateExecutor
+} from '../../../../src/commands/templates/forceLightningComponentCreate';
 import { nls } from '../../../../src/messages';
+import { notificationService } from '../../../../src/notifications';
 import { SfdxCoreSettings } from '../../../../src/settings/sfdxCoreSettings';
+import { getRootWorkspacePath } from '../../../../src/util';
 
 // tslint:disable:no-unused-expression
 describe('Force Lightning Component Create', () => {
-  let settings: SinonStub;
+  let getInternalDevStub: SinonStub;
 
   beforeEach(() => {
-    settings = stub(SfdxCoreSettings.prototype, 'getInternalDev');
+    getInternalDevStub = stub(SfdxCoreSettings.prototype, 'getInternalDev');
   });
 
   afterEach(() => {
-    settings.restore();
+    getInternalDevStub.restore();
   });
 
-  it('Should build the Lightning Component create command', async () => {
-    settings.returns(false);
-    const lightningCmpCreate = new ForceLightningComponentCreateExecutor();
-    const outputDirPath = path.join('force-app', 'main', 'default', 'aura');
-    const fileName = 'myAuraCmp';
-    const lwcCreateCommand = lightningCmpCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Commands', () => {
+    it('Should build the Lightning Component create command', async () => {
+      getInternalDevStub.returns(false);
+      const lightningCmpCreate = new ForceLightningComponentCreateExecutor();
+      const outputDirPath = path.join('force-app', 'main', 'default', 'aura');
+      const fileName = 'myAuraCmp';
+      const lwcCreateCommand = lightningCmpCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(lwcCreateCommand.toCommand()).to.equal(
+        `sfdx force:lightning:component:create --componentname ${fileName} --outputdir ${outputDirPath}`
+      );
+      expect(lwcCreateCommand.description).to.equal(
+        nls.localize('force_lightning_component_create_text')
+      );
+      expect(lightningCmpCreate.getDefaultDirectory()).to.equal('aura');
+      expect(lightningCmpCreate.getFileExtension()).to.equal('.cmp');
+      expect(
+        lightningCmpCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.cmp')
+      ).to.equal(path.join(outputDirPath, fileName, `${fileName}.cmp`));
     });
-    expect(lwcCreateCommand.toCommand()).to.equal(
-      `sfdx force:lightning:component:create --componentname ${fileName} --outputdir ${outputDirPath}`
-    );
-    expect(lwcCreateCommand.description).to.equal(
-      nls.localize('force_lightning_component_create_text')
-    );
-    expect(lightningCmpCreate.getDefaultDirectory()).to.equal('aura');
-    expect(lightningCmpCreate.getFileExtension()).to.equal('.cmp');
-    expect(
-      lightningCmpCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.cmp')
-    ).to.equal(path.join(outputDirPath, fileName, `${fileName}.cmp`));
+
+    it('Should build the internal Lightning Component create command', async () => {
+      getInternalDevStub.returns(true);
+      const lightningCmpCreate = new ForceLightningComponentCreateExecutor();
+      const outputDirPath = path.join('non-dx', 'dir', 'components', 'ns');
+      const fileName = 'internalCmp';
+      const lwcCreateCommand = lightningCmpCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(lwcCreateCommand.toCommand()).to.equal(
+        `sfdx force:lightning:component:create --componentname ${fileName} --outputdir ${outputDirPath} --internal`
+      );
+      expect(lwcCreateCommand.description).to.equal(
+        nls.localize('force_lightning_component_create_text')
+      );
+      expect(lightningCmpCreate.getDefaultDirectory()).to.equal('aura');
+      expect(lightningCmpCreate.getFileExtension()).to.equal('.cmp');
+      expect(
+        lightningCmpCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.cmp')
+      ).to.equal(path.join(outputDirPath, fileName, `${fileName}.cmp`));
+    });
   });
 
-  it('Should build the internal Lightning Component create command', async () => {
-    settings.returns(true);
-    const lightningCmpCreate = new ForceLightningComponentCreateExecutor();
-    const outputDirPath = path.join('non-dx', 'dir', 'components', 'ns');
-    const fileName = 'internalCmp';
-    const lwcCreateCommand = lightningCmpCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Library Create', () => {
+    let getTemplatesLibraryStub: SinonStub;
+    let showInputBoxStub: SinonStub;
+    let quickPickStub: SinonStub;
+    let appendLineStub: SinonStub;
+    let showSuccessfulExecutionStub: SinonStub;
+    let showFailedExecutionStub: SinonStub;
+    let openTextDocumentStub: SinonStub;
+
+    beforeEach(() => {
+      // mock experimental setting
+      getTemplatesLibraryStub = stub(
+        SfdxCoreSettings.prototype,
+        'getTemplatesLibrary'
+      );
+      getTemplatesLibraryStub.returns(true);
+      showInputBoxStub = stub(vscode.window, 'showInputBox');
+      quickPickStub = stub(vscode.window, 'showQuickPick');
+      appendLineStub = stub(channelService, 'appendLine');
+      showSuccessfulExecutionStub = stub(
+        notificationService,
+        'showSuccessfulExecution'
+      );
+      showSuccessfulExecutionStub.returns(Promise.resolve());
+      showFailedExecutionStub = stub(
+        notificationService,
+        'showFailedExecution'
+      );
+      openTextDocumentStub = stub(vscode.workspace, 'openTextDocument');
     });
-    expect(lwcCreateCommand.toCommand()).to.equal(
-      `sfdx force:lightning:component:create --componentname ${fileName} --outputdir ${outputDirPath} --internal`
-    );
-    expect(lwcCreateCommand.description).to.equal(
-      nls.localize('force_lightning_component_create_text')
-    );
-    expect(lightningCmpCreate.getDefaultDirectory()).to.equal('aura');
-    expect(lightningCmpCreate.getFileExtension()).to.equal('.cmp');
-    expect(
-      lightningCmpCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.cmp')
-    ).to.equal(path.join(outputDirPath, fileName, `${fileName}.cmp`));
+
+    afterEach(() => {
+      getTemplatesLibraryStub.restore();
+      showInputBoxStub.restore();
+      quickPickStub.restore();
+      showSuccessfulExecutionStub.restore();
+      showFailedExecutionStub.restore();
+      appendLineStub.restore();
+      openTextDocumentStub.restore();
+    });
+
+    it('Should create Aura Component', async () => {
+      // arrange
+      getInternalDevStub.returns(false);
+      const fileName = 'testComponent';
+      const outputPath = 'force-app/main/default/aura';
+      const auraComponentPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'testComponent',
+        'testComponent.cmp'
+      );
+      const auraComponentMetaPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'testComponent',
+        'testComponent.cmp-meta.xml'
+      );
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+      assert.noFile([auraComponentPath, auraComponentMetaPath]);
+      showInputBoxStub.returns(fileName);
+      quickPickStub.returns(outputPath);
+
+      // act
+      await forceLightningComponentCreate();
+
+      // assert
+      const suffixarray = [
+        '.cmp',
+        '.cmp-meta.xml',
+        '.auradoc',
+        '.css',
+        'Controller.js',
+        'Helper.js',
+        'Renderer.js',
+        '.svg',
+        '.design'
+      ];
+      for (const suffix of suffixarray) {
+        assert.file(
+          path.join(
+            getRootWorkspacePath(),
+            outputPath,
+            fileName,
+            `${fileName}${suffix}`
+          )
+        );
+      }
+      assert.fileContent(
+        auraComponentPath,
+        '<aura:component>\n\n</aura:component>'
+      );
+      assert.fileContent(
+        auraComponentMetaPath,
+        `<AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">`
+      );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, auraComponentPath);
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+    });
+
+    it('Should create internal Aura Component', async () => {
+      // arrange
+      getInternalDevStub.returns(true);
+      const fileName = 'testComponent';
+      const outputPath = 'force-app/main/default/aura';
+      const auraComponentPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'testComponent',
+        'testComponent.cmp'
+      );
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+      assert.noFile([auraComponentPath]);
+      showInputBoxStub.returns(fileName);
+      quickPickStub.returns(outputPath);
+
+      // act
+      shell.mkdir('-p', path.join(getRootWorkspacePath(), outputPath));
+      await forceInternalLightningComponentCreate(
+        vscode.Uri.file(path.join(getRootWorkspacePath(), outputPath))
+      );
+
+      // assert
+      const suffixarray = [
+        '.cmp',
+        '.auradoc',
+        '.css',
+        'Controller.js',
+        'Helper.js',
+        'Renderer.js',
+        '.svg',
+        '.design'
+      ];
+      for (const suffix of suffixarray) {
+        assert.file(
+          path.join(
+            getRootWorkspacePath(),
+            outputPath,
+            fileName,
+            `${fileName}${suffix}`
+          )
+        );
+      }
+      assert.fileContent(
+        auraComponentPath,
+        '<aura:component>\n\n</aura:component>'
+      );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, auraComponentPath);
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+    });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceLightningEventCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceLightningEventCreate.test.ts
@@ -4,71 +4,208 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
+import { TemplateService } from '@salesforce/templates';
 import { expect } from 'chai';
 import * as path from 'path';
+import * as shell from 'shelljs';
 import { SinonStub, stub } from 'sinon';
-import { ForceLightningEventCreateExecutor } from '../../../../src/commands/templates/forceLightningEventCreate';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import * as assert from 'yeoman-assert';
+import { channelService } from '../../../../src/channels';
+import {
+  forceInternalLightningEventCreate,
+  forceLightningEventCreate,
+  ForceLightningEventCreateExecutor
+} from '../../../../src/commands/templates/forceLightningEventCreate';
 import { nls } from '../../../../src/messages';
+import { notificationService } from '../../../../src/notifications';
 import { SfdxCoreSettings } from '../../../../src/settings/sfdxCoreSettings';
+import { getRootWorkspacePath } from '../../../../src/util';
 
 // tslint:disable:no-unused-expression
 describe('Force Lightning Event Create', () => {
-  let settings: SinonStub;
+  let getInternalDevStub: SinonStub;
 
   beforeEach(() => {
-    settings = stub(SfdxCoreSettings.prototype, 'getInternalDev');
+    getInternalDevStub = stub(SfdxCoreSettings.prototype, 'getInternalDev');
   });
 
   afterEach(() => {
-    settings.restore();
+    getInternalDevStub.restore();
   });
 
-  it('Should build the Lightning Event create command', async () => {
-    settings.returns(false);
-    const lightningEventCreate = new ForceLightningEventCreateExecutor();
-    const outputDirPath = path.join('force-app', 'main', 'default', 'aura');
-    const fileName = 'myAuraEvent';
-    const lwcCreateCommand = lightningEventCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Commands', () => {
+    it('Should build the Lightning Event create command', async () => {
+      getInternalDevStub.returns(false);
+      const lightningEventCreate = new ForceLightningEventCreateExecutor();
+      const outputDirPath = path.join('force-app', 'main', 'default', 'aura');
+      const fileName = 'myAuraEvent';
+      const lwcCreateCommand = lightningEventCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(lwcCreateCommand.toCommand()).to.equal(
+        `sfdx force:lightning:event:create --eventname ${fileName} --outputdir ${outputDirPath}`
+      );
+      expect(lwcCreateCommand.description).to.equal(
+        nls.localize('force_lightning_event_create_text')
+      );
+      expect(lightningEventCreate.getDefaultDirectory()).to.equal('aura');
+      expect(lightningEventCreate.getFileExtension()).to.equal('.evt');
+      expect(
+        lightningEventCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.evt')
+      ).to.equal(path.join(outputDirPath, fileName, `${fileName}.evt`));
     });
-    expect(lwcCreateCommand.toCommand()).to.equal(
-      `sfdx force:lightning:event:create --eventname ${fileName} --outputdir ${outputDirPath}`
-    );
-    expect(lwcCreateCommand.description).to.equal(
-      nls.localize('force_lightning_event_create_text')
-    );
-    expect(lightningEventCreate.getDefaultDirectory()).to.equal('aura');
-    expect(lightningEventCreate.getFileExtension()).to.equal('.evt');
-    expect(
-      lightningEventCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.evt')
-    ).to.equal(path.join(outputDirPath, fileName, `${fileName}.evt`));
+
+    it('Should build the internal Lightning Event create command', async () => {
+      getInternalDevStub.returns(true);
+      const lightningEventCreate = new ForceLightningEventCreateExecutor();
+      const outputDirPath = path.join('non-dx', 'dir', 'components', 'ns');
+      const fileName = 'internalEvent';
+      const lwcCreateCommand = lightningEventCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(lwcCreateCommand.toCommand()).to.equal(
+        `sfdx force:lightning:event:create --eventname ${fileName} --outputdir ${outputDirPath} --internal`
+      );
+      expect(lwcCreateCommand.description).to.equal(
+        nls.localize('force_lightning_event_create_text')
+      );
+      expect(lightningEventCreate.getDefaultDirectory()).to.equal('aura');
+      expect(lightningEventCreate.getFileExtension()).to.equal('.evt');
+      expect(
+        lightningEventCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.evt')
+      ).to.equal(path.join(outputDirPath, fileName, `${fileName}.evt`));
+    });
   });
 
-  it('Should build the internal Lightning Event create command', async () => {
-    settings.returns(true);
-    const lightningEventCreate = new ForceLightningEventCreateExecutor();
-    const outputDirPath = path.join('non-dx', 'dir', 'components', 'ns');
-    const fileName = 'internalEvent';
-    const lwcCreateCommand = lightningEventCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Library Create', () => {
+    let getTemplatesLibraryStub: SinonStub;
+    let showInputBoxStub: SinonStub;
+    let quickPickStub: SinonStub;
+    let appendLineStub: SinonStub;
+    let showSuccessfulExecutionStub: SinonStub;
+    let showFailedExecutionStub: SinonStub;
+    let openTextDocumentStub: SinonStub;
+
+    beforeEach(() => {
+      // mock experimental setting
+      getTemplatesLibraryStub = stub(
+        SfdxCoreSettings.prototype,
+        'getTemplatesLibrary'
+      );
+      getTemplatesLibraryStub.returns(true);
+      showInputBoxStub = stub(vscode.window, 'showInputBox');
+      quickPickStub = stub(vscode.window, 'showQuickPick');
+      appendLineStub = stub(channelService, 'appendLine');
+      showSuccessfulExecutionStub = stub(
+        notificationService,
+        'showSuccessfulExecution'
+      );
+      showSuccessfulExecutionStub.returns(Promise.resolve());
+      showFailedExecutionStub = stub(
+        notificationService,
+        'showFailedExecution'
+      );
+      openTextDocumentStub = stub(vscode.workspace, 'openTextDocument');
     });
-    expect(lwcCreateCommand.toCommand()).to.equal(
-      `sfdx force:lightning:event:create --eventname ${fileName} --outputdir ${outputDirPath} --internal`
-    );
-    expect(lwcCreateCommand.description).to.equal(
-      nls.localize('force_lightning_event_create_text')
-    );
-    expect(lightningEventCreate.getDefaultDirectory()).to.equal('aura');
-    expect(lightningEventCreate.getFileExtension()).to.equal('.evt');
-    expect(
-      lightningEventCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.evt')
-    ).to.equal(path.join(outputDirPath, fileName, `${fileName}.evt`));
+
+    afterEach(() => {
+      getTemplatesLibraryStub.restore();
+      showInputBoxStub.restore();
+      quickPickStub.restore();
+      showSuccessfulExecutionStub.restore();
+      showFailedExecutionStub.restore();
+      appendLineStub.restore();
+      openTextDocumentStub.restore();
+    });
+
+    it('Should create Aura Event', async () => {
+      // arrange
+      getInternalDevStub.returns(false);
+      const fileName = 'testEvent';
+      const outputPath = 'force-app/main/default/aura';
+      const auraEventPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        fileName,
+        'testEvent.evt'
+      );
+      const auraEventMetaPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        fileName,
+        'testEvent.evt-meta.xml'
+      );
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+      assert.noFile([auraEventPath, auraEventMetaPath]);
+      showInputBoxStub.returns(fileName);
+      quickPickStub.returns(outputPath);
+
+      // act
+      await forceLightningEventCreate();
+
+      // assert
+      const defaultApiVersion = TemplateService.getDefaultApiVersion();
+      assert.file([auraEventPath, auraEventMetaPath]);
+      assert.fileContent(
+        auraEventPath,
+        '<aura:event type="APPLICATION" description="Event template"/>'
+      );
+      assert.fileContent(
+        auraEventMetaPath,
+        `<?xml version="1.0" encoding="UTF-8"?>
+<AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>${defaultApiVersion}</apiVersion>
+    <description>A Lightning Event Bundle</description>
+</AuraDefinitionBundle>`
+      );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, auraEventPath);
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+    });
+
+    it('Should create internal Aura Event', async () => {
+      // arrange
+      getInternalDevStub.returns(true);
+      const fileName = 'testEvent';
+      const outputPath = 'force-app/main/default/aura';
+      const auraEventPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        fileName,
+        'testEvent.evt'
+      );
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+      assert.noFile([auraEventPath]);
+      showInputBoxStub.returns(fileName);
+      quickPickStub.returns(outputPath);
+
+      // act
+      shell.mkdir('-p', path.join(getRootWorkspacePath(), outputPath));
+      await forceInternalLightningEventCreate(
+        vscode.Uri.file(path.join(getRootWorkspacePath(), outputPath))
+      );
+
+      // assert
+      assert.file([auraEventPath]);
+      assert.fileContent(
+        auraEventPath,
+        '<aura:event type="APPLICATION" description="Event template"/>'
+      );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, auraEventPath);
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+    });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceLightningInterfaceCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceLightningInterfaceCreate.test.ts
@@ -4,71 +4,212 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
+import { TemplateService } from '@salesforce/templates';
 import { expect } from 'chai';
 import * as path from 'path';
+import * as shell from 'shelljs';
+import * as sinon from 'sinon';
 import { SinonStub, stub } from 'sinon';
-import { ForceLightningInterfaceCreateExecutor } from '../../../../src/commands/templates/forceLightningInterfaceCreate';
+import * as vscode from 'vscode';
+import * as assert from 'yeoman-assert';
+import { channelService } from '../../../../src/channels';
+import {
+  forceInternalLightningInterfaceCreate,
+  forceLightningInterfaceCreate,
+  ForceLightningInterfaceCreateExecutor
+} from '../../../../src/commands/templates/forceLightningInterfaceCreate';
 import { nls } from '../../../../src/messages';
+import { notificationService } from '../../../../src/notifications';
 import { SfdxCoreSettings } from '../../../../src/settings/sfdxCoreSettings';
+import { getRootWorkspacePath } from '../../../../src/util';
 
 // tslint:disable:no-unused-expression
 describe('Force Lightning Interface Create', () => {
-  let settings: SinonStub;
+  let getInternalDevStub: SinonStub;
 
   beforeEach(() => {
-    settings = stub(SfdxCoreSettings.prototype, 'getInternalDev');
+    getInternalDevStub = stub(SfdxCoreSettings.prototype, 'getInternalDev');
   });
 
   afterEach(() => {
-    settings.restore();
+    getInternalDevStub.restore();
   });
 
-  it('Should build the Lightning Interface create command', async () => {
-    settings.returns(false);
-    const lightningInterfaceCreate = new ForceLightningInterfaceCreateExecutor();
-    const outputDirPath = path.join('force-app', 'main', 'default', 'aura');
-    const fileName = 'myAuraInterface';
-    const lwcCreateCommand = lightningInterfaceCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Commands', () => {
+    it('Should build the Lightning Interface create command', async () => {
+      getInternalDevStub.returns(false);
+      const lightningInterfaceCreate = new ForceLightningInterfaceCreateExecutor();
+      const outputDirPath = path.join('force-app', 'main', 'default', 'aura');
+      const fileName = 'myAuraInterface';
+      const lwcCreateCommand = lightningInterfaceCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(lwcCreateCommand.toCommand()).to.equal(
+        `sfdx force:lightning:interface:create --interfacename ${fileName} --outputdir ${outputDirPath}`
+      );
+      expect(lwcCreateCommand.description).to.equal(
+        nls.localize('force_lightning_interface_create_text')
+      );
+      expect(lightningInterfaceCreate.getDefaultDirectory()).to.equal('aura');
+      expect(lightningInterfaceCreate.getFileExtension()).to.equal('.intf');
+      expect(
+        lightningInterfaceCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.intf')
+      ).to.equal(path.join(outputDirPath, fileName, `${fileName}.intf`));
     });
-    expect(lwcCreateCommand.toCommand()).to.equal(
-      `sfdx force:lightning:interface:create --interfacename ${fileName} --outputdir ${outputDirPath}`
-    );
-    expect(lwcCreateCommand.description).to.equal(
-      nls.localize('force_lightning_interface_create_text')
-    );
-    expect(lightningInterfaceCreate.getDefaultDirectory()).to.equal('aura');
-    expect(lightningInterfaceCreate.getFileExtension()).to.equal('.intf');
-    expect(
-      lightningInterfaceCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.intf')
-    ).to.equal(path.join(outputDirPath, fileName, `${fileName}.intf`));
+
+    it('Should build the internal Lightning Interface create command', async () => {
+      getInternalDevStub.returns(true);
+      const lightningInterfaceCreate = new ForceLightningInterfaceCreateExecutor();
+      const outputDirPath = path.join('non-dx', 'dir', 'components', 'ns');
+      const fileName = 'internalInterface';
+      const lwcCreateCommand = lightningInterfaceCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(lwcCreateCommand.toCommand()).to.equal(
+        `sfdx force:lightning:interface:create --interfacename ${fileName} --outputdir ${outputDirPath} --internal`
+      );
+      expect(lwcCreateCommand.description).to.equal(
+        nls.localize('force_lightning_interface_create_text')
+      );
+      expect(lightningInterfaceCreate.getDefaultDirectory()).to.equal('aura');
+      expect(lightningInterfaceCreate.getFileExtension()).to.equal('.intf');
+      expect(
+        lightningInterfaceCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.intf')
+      ).to.equal(path.join(outputDirPath, fileName, `${fileName}.intf`));
+    });
   });
 
-  it('Should build the internal Lightning Interface create command', async () => {
-    settings.returns(true);
-    const lightningInterfaceCreate = new ForceLightningInterfaceCreateExecutor();
-    const outputDirPath = path.join('non-dx', 'dir', 'components', 'ns');
-    const fileName = 'internalInterface';
-    const lwcCreateCommand = lightningInterfaceCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Library Create', () => {
+    let getTemplatesLibraryStub: SinonStub;
+    let showInputBoxStub: SinonStub;
+    let quickPickStub: SinonStub;
+    let appendLineStub: SinonStub;
+    let showSuccessfulExecutionStub: SinonStub;
+    let showFailedExecutionStub: SinonStub;
+    let openTextDocumentStub: SinonStub;
+
+    beforeEach(() => {
+      // mock experimental setting
+      getTemplatesLibraryStub = stub(
+        SfdxCoreSettings.prototype,
+        'getTemplatesLibrary'
+      );
+      getTemplatesLibraryStub.returns(true);
+      showInputBoxStub = stub(vscode.window, 'showInputBox');
+      quickPickStub = stub(vscode.window, 'showQuickPick');
+      appendLineStub = stub(channelService, 'appendLine');
+      showSuccessfulExecutionStub = stub(
+        notificationService,
+        'showSuccessfulExecution'
+      );
+      showSuccessfulExecutionStub.returns(Promise.resolve());
+      showFailedExecutionStub = stub(
+        notificationService,
+        'showFailedExecution'
+      );
+      openTextDocumentStub = stub(vscode.workspace, 'openTextDocument');
     });
-    expect(lwcCreateCommand.toCommand()).to.equal(
-      `sfdx force:lightning:interface:create --interfacename ${fileName} --outputdir ${outputDirPath} --internal`
-    );
-    expect(lwcCreateCommand.description).to.equal(
-      nls.localize('force_lightning_interface_create_text')
-    );
-    expect(lightningInterfaceCreate.getDefaultDirectory()).to.equal('aura');
-    expect(lightningInterfaceCreate.getFileExtension()).to.equal('.intf');
-    expect(
-      lightningInterfaceCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.intf')
-    ).to.equal(path.join(outputDirPath, fileName, `${fileName}.intf`));
+
+    afterEach(() => {
+      getTemplatesLibraryStub.restore();
+      showInputBoxStub.restore();
+      quickPickStub.restore();
+      showSuccessfulExecutionStub.restore();
+      showFailedExecutionStub.restore();
+      appendLineStub.restore();
+      openTextDocumentStub.restore();
+    });
+
+    it('Should create Aura Interface', async () => {
+      // arrange
+      getInternalDevStub.returns(false);
+      const fileName = 'testInterface';
+      const outputPath = 'force-app/main/default/aura';
+      const auraInterfacePath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        fileName,
+        'testInterface.intf'
+      );
+      const auraInterfaceMetaPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        fileName,
+        'testInterface.intf-meta.xml'
+      );
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+      assert.noFile([auraInterfacePath, auraInterfaceMetaPath]);
+      showInputBoxStub.returns(fileName);
+      quickPickStub.returns(outputPath);
+
+      // act
+      await forceLightningInterfaceCreate();
+
+      // assert
+      const defaultApiVersion = TemplateService.getDefaultApiVersion();
+      assert.file([auraInterfacePath, auraInterfaceMetaPath]);
+      assert.fileContent(
+        auraInterfacePath,
+        `<aura:interface description="Interface template">
+  <aura:attribute name="example" type="String" default="" description="An example attribute."/>
+</aura:interface>`
+      );
+      assert.fileContent(
+        auraInterfaceMetaPath,
+        `<?xml version="1.0" encoding="UTF-8"?>
+<AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>${defaultApiVersion}</apiVersion>
+    <description>A Lightning Interface Bundle</description>
+</AuraDefinitionBundle>`
+      );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, auraInterfacePath);
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+    });
+
+    it('Should create internal Aura Interface', async () => {
+      // arrange
+      getInternalDevStub.returns(true);
+      const fileName = 'testInterface';
+      const outputPath = 'force-app/main/default/aura';
+      const auraInterfacePath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        fileName,
+        'testInterface.intf'
+      );
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+      assert.noFile([auraInterfacePath]);
+      showInputBoxStub.returns(fileName);
+      quickPickStub.returns(outputPath);
+
+      // act
+      shell.mkdir('-p', path.join(getRootWorkspacePath(), outputPath));
+      await forceInternalLightningInterfaceCreate(
+        vscode.Uri.file(path.join(getRootWorkspacePath(), outputPath))
+      );
+
+      // assert
+      assert.file([auraInterfacePath]);
+      assert.fileContent(
+        auraInterfacePath,
+        `<aura:interface description="Interface template">
+  <aura:attribute name="example" type="String" default="" description="An example attribute."/>
+</aura:interface>`
+      );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, auraInterfacePath);
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+    });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceLightningLWCCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceLightningLWCCreate.test.ts
@@ -4,71 +4,226 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
+import { TemplateService } from '@salesforce/templates';
 import { expect } from 'chai';
 import * as path from 'path';
+import * as shell from 'shelljs';
+import * as sinon from 'sinon';
 import { SinonStub, stub } from 'sinon';
-import { ForceLightningLwcCreateExecutor } from '../../../../src/commands/templates';
+import * as vscode from 'vscode';
+import * as assert from 'yeoman-assert';
+import { channelService } from '../../../../src/channels';
+import {
+  forceInternalLightningLwcCreate,
+  forceLightningLwcCreate,
+  ForceLightningLwcCreateExecutor
+} from '../../../../src/commands/templates';
 import { nls } from '../../../../src/messages';
+import { notificationService } from '../../../../src/notifications';
 import { SfdxCoreSettings } from '../../../../src/settings/sfdxCoreSettings';
+import { getRootWorkspacePath } from '../../../../src/util';
 
 // tslint:disable:no-unused-expression
 describe('Force Lightning Web Component Create', () => {
-  let settings: SinonStub;
+  let getInternalDevStub: SinonStub;
 
   beforeEach(() => {
-    settings = stub(SfdxCoreSettings.prototype, 'getInternalDev');
+    getInternalDevStub = stub(SfdxCoreSettings.prototype, 'getInternalDev');
   });
 
   afterEach(() => {
-    settings.restore();
+    getInternalDevStub.restore();
   });
 
-  it('Should build the Lightning Web Component create command', async () => {
-    settings.returns(false);
-    const lightningLWCCreate = new ForceLightningLwcCreateExecutor();
-    const outputDirPath = path.join('force-app', 'main', 'default', 'lwc');
-    const fileName = 'myLWC';
-    const lwcCreateCommand = lightningLWCCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Commands', () => {
+    it('Should build the Lightning Web Component create command', async () => {
+      getInternalDevStub.returns(false);
+      const lightningLWCCreate = new ForceLightningLwcCreateExecutor();
+      const outputDirPath = path.join('force-app', 'main', 'default', 'lwc');
+      const fileName = 'myLWC';
+      const lwcCreateCommand = lightningLWCCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(lwcCreateCommand.toCommand()).to.equal(
+        `sfdx force:lightning:component:create --type lwc --componentname ${fileName} --outputdir ${outputDirPath}`
+      );
+      expect(lwcCreateCommand.description).to.equal(
+        nls.localize('force_lightning_lwc_create_text')
+      );
+      expect(lightningLWCCreate.getDefaultDirectory()).to.equal('lwc');
+      expect(lightningLWCCreate.getFileExtension()).to.equal('.js');
+      expect(
+        lightningLWCCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.js')
+      ).to.equal(path.join(outputDirPath, fileName, `${fileName}.js`));
     });
-    expect(lwcCreateCommand.toCommand()).to.equal(
-      `sfdx force:lightning:component:create --type lwc --componentname ${fileName} --outputdir ${outputDirPath}`
-    );
-    expect(lwcCreateCommand.description).to.equal(
-      nls.localize('force_lightning_lwc_create_text')
-    );
-    expect(lightningLWCCreate.getDefaultDirectory()).to.equal('lwc');
-    expect(lightningLWCCreate.getFileExtension()).to.equal('.js');
-    expect(
-      lightningLWCCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.js')
-    ).to.equal(path.join(outputDirPath, fileName, `${fileName}.js`));
+
+    it('Should build the internal Lightning Web Component create command', async () => {
+      getInternalDevStub.returns(true);
+      const lightningLWCCreate = new ForceLightningLwcCreateExecutor();
+      const outputDirPath = path.join('non-dx', 'dir', 'components', 'ns');
+      const fileName = 'internalLWC';
+      const lwcCreateCommand = lightningLWCCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(lwcCreateCommand.toCommand()).to.equal(
+        `sfdx force:lightning:component:create --type lwc --componentname ${fileName} --outputdir ${outputDirPath} --internal`
+      );
+      expect(lwcCreateCommand.description).to.equal(
+        nls.localize('force_lightning_lwc_create_text')
+      );
+      expect(lightningLWCCreate.getDefaultDirectory()).to.equal('lwc');
+      expect(lightningLWCCreate.getFileExtension()).to.equal('.js');
+      expect(
+        lightningLWCCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.js')
+      ).to.equal(path.join(outputDirPath, fileName, `${fileName}.js`));
+    });
   });
 
-  it('Should build the internal Lightning Web Component create command', async () => {
-    settings.returns(true);
-    const lightningLWCCreate = new ForceLightningLwcCreateExecutor();
-    const outputDirPath = path.join('non-dx', 'dir', 'components', 'ns');
-    const fileName = 'internalLWC';
-    const lwcCreateCommand = lightningLWCCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Library Create', () => {
+    let getTemplatesLibraryStub: SinonStub;
+    let showInputBoxStub: SinonStub;
+    let quickPickStub: SinonStub;
+    let appendLineStub: SinonStub;
+    let showSuccessfulExecutionStub: SinonStub;
+    let showFailedExecutionStub: SinonStub;
+    let openTextDocumentStub: SinonStub;
+
+    beforeEach(() => {
+      // mock experimental setting
+      getTemplatesLibraryStub = stub(
+        SfdxCoreSettings.prototype,
+        'getTemplatesLibrary'
+      );
+      getTemplatesLibraryStub.returns(true);
+      showInputBoxStub = stub(vscode.window, 'showInputBox');
+      quickPickStub = stub(vscode.window, 'showQuickPick');
+      appendLineStub = stub(channelService, 'appendLine');
+      showSuccessfulExecutionStub = stub(
+        notificationService,
+        'showSuccessfulExecution'
+      );
+      showSuccessfulExecutionStub.returns(Promise.resolve());
+      showFailedExecutionStub = stub(
+        notificationService,
+        'showFailedExecution'
+      );
+      openTextDocumentStub = stub(vscode.workspace, 'openTextDocument');
     });
-    expect(lwcCreateCommand.toCommand()).to.equal(
-      `sfdx force:lightning:component:create --type lwc --componentname ${fileName} --outputdir ${outputDirPath} --internal`
-    );
-    expect(lwcCreateCommand.description).to.equal(
-      nls.localize('force_lightning_lwc_create_text')
-    );
-    expect(lightningLWCCreate.getDefaultDirectory()).to.equal('lwc');
-    expect(lightningLWCCreate.getFileExtension()).to.equal('.js');
-    expect(
-      lightningLWCCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.js')
-    ).to.equal(path.join(outputDirPath, fileName, `${fileName}.js`));
+
+    afterEach(() => {
+      getTemplatesLibraryStub.restore();
+      showInputBoxStub.restore();
+      quickPickStub.restore();
+      showSuccessfulExecutionStub.restore();
+      showFailedExecutionStub.restore();
+      appendLineStub.restore();
+      openTextDocumentStub.restore();
+    });
+
+    it('Should create LWC Component', async () => {
+      // arrange
+      getInternalDevStub.returns(false);
+      const fileName = 'testLwc';
+      const outputPath = 'force-app/main/default/lwc';
+      const lwcHtmlPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        fileName,
+        'testLwc.html'
+      );
+      const lwcJsPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        fileName,
+        'testLwc.js'
+      );
+      const lwcJsMetaPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        fileName,
+        'testLwc.js-meta.xml'
+      );
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+      assert.noFile([lwcHtmlPath, lwcJsPath, lwcJsMetaPath]);
+      showInputBoxStub.returns(fileName);
+      quickPickStub.returns(outputPath);
+
+      // act
+      await forceLightningLwcCreate();
+
+      // assert
+      const defaultApiVersion = TemplateService.getDefaultApiVersion();
+      assert.file([lwcHtmlPath, lwcJsPath, lwcJsMetaPath]);
+      assert.fileContent(lwcHtmlPath, `<template>\n    \n</template>`);
+      assert.fileContent(
+        lwcJsPath,
+        `import { LightningElement } from 'lwc';
+
+export default class TestLwc extends LightningElement {}`
+      );
+      assert.fileContent(
+        lwcJsMetaPath,
+        `<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>${defaultApiVersion}</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>`
+      );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, lwcJsPath);
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+    });
+
+    it('Should create internal LWC Component', async () => {
+      // arrange
+      getInternalDevStub.returns(true);
+      const fileName = 'testLwc';
+      const outputPath = 'force-app/main/default/lwc';
+      const lwcHtmlPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        fileName,
+        'testLwc.html'
+      );
+      const lwcJsPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        fileName,
+        'testLwc.js'
+      );
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+      assert.noFile([lwcHtmlPath, lwcJsPath]);
+      showInputBoxStub.returns(fileName);
+      quickPickStub.returns(outputPath);
+
+      // act
+      shell.mkdir('-p', path.join(getRootWorkspacePath(), outputPath));
+      await forceInternalLightningLwcCreate(
+        vscode.Uri.file(path.join(getRootWorkspacePath(), outputPath))
+      );
+
+      // assert
+      assert.file([lwcHtmlPath, lwcJsPath]);
+      assert.fileContent(lwcHtmlPath, `<template>\n    \n</template>`);
+      assert.fileContent(
+        lwcJsPath,
+        `import { LightningElement } from 'lwc';
+
+export default class TestLwc extends LightningElement {}`
+      );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, lwcJsPath);
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath, fileName));
+    });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceVisualforceComponentCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceVisualforceComponentCreate.test.ts
@@ -4,39 +4,144 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
+import { TemplateService } from '@salesforce/templates';
 import { expect } from 'chai';
 import * as path from 'path';
-import { ForceVisualForceComponentCreateExecutor } from '../../../../src/commands/templates';
+import * as shell from 'shelljs';
+import * as sinon from 'sinon';
+import { SinonStub, stub } from 'sinon';
+import * as vscode from 'vscode';
+import * as assert from 'yeoman-assert';
+import { channelService } from '../../../../src/channels';
+import {
+  forceVisualforceComponentCreate,
+  ForceVisualForceComponentCreateExecutor
+} from '../../../../src/commands/templates';
 import { nls } from '../../../../src/messages';
+import { notificationService } from '../../../../src/notifications';
+import { SfdxCoreSettings } from '../../../../src/settings/sfdxCoreSettings';
+import { getRootWorkspacePath } from '../../../../src/util';
 
 // tslint:disable:no-unused-expression
 describe('Force Visualforce Component Create', () => {
-  it('Should build the Visualforce component create command', async () => {
-    const visualforceCmpCreate = new ForceVisualForceComponentCreateExecutor();
-    const outputDirPath = path.join(
-      'force-app',
-      'main',
-      'default',
-      'components'
-    );
-    const fileName = 'myVFCmp';
-    const vfCmpCreateCommand = visualforceCmpCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Commands', () => {
+    it('Should build the Visualforce component create command', async () => {
+      const visualforceCmpCreate = new ForceVisualForceComponentCreateExecutor();
+      const outputDirPath = path.join(
+        'force-app',
+        'main',
+        'default',
+        'components'
+      );
+      const fileName = 'myVFCmp';
+      const vfCmpCreateCommand = visualforceCmpCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(vfCmpCreateCommand.toCommand()).to.equal(
+        `sfdx force:visualforce:component:create --componentname ${fileName} --label ${fileName} --outputdir ${outputDirPath}`
+      );
+      expect(vfCmpCreateCommand.description).to.equal(
+        nls.localize('force_visualforce_component_create_text')
+      );
+      expect(visualforceCmpCreate.getDefaultDirectory()).to.equal('components');
+      expect(visualforceCmpCreate.getFileExtension()).to.equal('.component');
+      expect(
+        visualforceCmpCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.component')
+      ).to.equal(path.join(outputDirPath, `${fileName}.component`));
     });
-    expect(vfCmpCreateCommand.toCommand()).to.equal(
-      `sfdx force:visualforce:component:create --componentname ${fileName} --label ${fileName} --outputdir ${outputDirPath}`
-    );
-    expect(vfCmpCreateCommand.description).to.equal(
-      nls.localize('force_visualforce_component_create_text')
-    );
-    expect(visualforceCmpCreate.getDefaultDirectory()).to.equal('components');
-    expect(visualforceCmpCreate.getFileExtension()).to.equal('.component');
-    expect(
-      visualforceCmpCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.component')
-    ).to.equal(path.join(outputDirPath, `${fileName}.component`));
+  });
+
+  describe('Library Create', () => {
+    let getTemplatesLibraryStub: SinonStub;
+    let showInputBoxStub: SinonStub;
+    let quickPickStub: SinonStub;
+    let appendLineStub: SinonStub;
+    let showSuccessfulExecutionStub: SinonStub;
+    let showFailedExecutionStub: SinonStub;
+    let openTextDocumentStub: SinonStub;
+
+    beforeEach(() => {
+      // mock experimental setting
+      getTemplatesLibraryStub = stub(
+        SfdxCoreSettings.prototype,
+        'getTemplatesLibrary'
+      );
+      getTemplatesLibraryStub.returns(true);
+      showInputBoxStub = stub(vscode.window, 'showInputBox');
+      quickPickStub = stub(vscode.window, 'showQuickPick');
+      appendLineStub = stub(channelService, 'appendLine');
+      showSuccessfulExecutionStub = stub(
+        notificationService,
+        'showSuccessfulExecution'
+      );
+      showSuccessfulExecutionStub.returns(Promise.resolve());
+      showFailedExecutionStub = stub(
+        notificationService,
+        'showFailedExecution'
+      );
+      openTextDocumentStub = stub(vscode.workspace, 'openTextDocument');
+    });
+
+    afterEach(() => {
+      getTemplatesLibraryStub.restore();
+      showInputBoxStub.restore();
+      quickPickStub.restore();
+      showSuccessfulExecutionStub.restore();
+      showFailedExecutionStub.restore();
+      appendLineStub.restore();
+      openTextDocumentStub.restore();
+    });
+
+    it('Should create Visualforce Component', async () => {
+      // arrange
+      const fileName = 'testVFCmp';
+      const outputPath = 'force-app/main/default/components';
+      const vfCmpPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'testVFCmp.component'
+      );
+      const vfCmpMetaPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'testVFCmp.component-meta.xml'
+      );
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath));
+      assert.noFile([vfCmpPath, vfCmpMetaPath]);
+      showInputBoxStub.returns(fileName);
+      quickPickStub.returns(outputPath);
+
+      // act
+      await forceVisualforceComponentCreate();
+
+      // assert
+      const defaultApiVersion = TemplateService.getDefaultApiVersion();
+      assert.file([vfCmpPath, vfCmpMetaPath]);
+      assert.fileContent(
+        vfCmpPath,
+        `<apex:component>
+<!-- Begin Default Content REMOVE THIS -->
+<h1>Congratulations</h1>
+This is your new Component
+<!-- End Default Content REMOVE THIS -->
+</apex:component>`
+      );
+      assert.fileContent(
+        vfCmpMetaPath,
+        `<?xml version="1.0" encoding="UTF-8"?>
+<ApexComponent xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>${defaultApiVersion}</apiVersion>
+    <label>testVFCmp</label>
+</ApexComponent>`
+      );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, vfCmpPath);
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath));
+    });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceVisualforcePageCreate.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/forceVisualforcePageCreate.test.ts
@@ -4,34 +4,139 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
+import { TemplateService } from '@salesforce/templates';
 import { expect } from 'chai';
 import * as path from 'path';
-import { ForceVisualForcePageCreateExecutor } from '../../../../src/commands/templates';
+import * as shell from 'shelljs';
+import * as sinon from 'sinon';
+import { SinonStub, stub } from 'sinon';
+import * as vscode from 'vscode';
+import * as assert from 'yeoman-assert';
+import { channelService } from '../../../../src/channels';
+import {
+  forceVisualforcePageCreate,
+  ForceVisualForcePageCreateExecutor
+} from '../../../../src/commands/templates';
 import { nls } from '../../../../src/messages';
+import { notificationService } from '../../../../src/notifications';
+import { SfdxCoreSettings } from '../../../../src/settings/sfdxCoreSettings';
+import { getRootWorkspacePath } from '../../../../src/util';
 
 // tslint:disable:no-unused-expression
 describe('Force Visualforce Page Create', () => {
-  it('Should build the Visualforce page create command', async () => {
-    const visualforcePageCreate = new ForceVisualForcePageCreateExecutor();
-    const outputDirPath = path.join('force-app', 'main', 'default', 'pages');
-    const fileName = 'myVFPage';
-    const vfPageCreateCommand = visualforcePageCreate.build({
-      fileName,
-      outputdir: outputDirPath
+  describe('Commands', () => {
+    it('Should build the Visualforce page create command', async () => {
+      const visualforcePageCreate = new ForceVisualForcePageCreateExecutor();
+      const outputDirPath = path.join('force-app', 'main', 'default', 'pages');
+      const fileName = 'myVFPage';
+      const vfPageCreateCommand = visualforcePageCreate.build({
+        fileName,
+        outputdir: outputDirPath
+      });
+      expect(vfPageCreateCommand.toCommand()).to.equal(
+        `sfdx force:visualforce:page:create --pagename ${fileName} --label ${fileName} --outputdir ${outputDirPath}`
+      );
+      expect(vfPageCreateCommand.description).to.equal(
+        nls.localize('force_visualforce_page_create_text')
+      );
+      expect(visualforcePageCreate.getDefaultDirectory()).to.equal('pages');
+      expect(visualforcePageCreate.getFileExtension()).to.equal('.page');
+      expect(
+        visualforcePageCreate
+          .getSourcePathStrategy()
+          .getPathToSource(outputDirPath, fileName, '.page')
+      ).to.equal(path.join(outputDirPath, `${fileName}.page`));
     });
-    expect(vfPageCreateCommand.toCommand()).to.equal(
-      `sfdx force:visualforce:page:create --pagename ${fileName} --label ${fileName} --outputdir ${outputDirPath}`
-    );
-    expect(vfPageCreateCommand.description).to.equal(
-      nls.localize('force_visualforce_page_create_text')
-    );
-    expect(visualforcePageCreate.getDefaultDirectory()).to.equal('pages');
-    expect(visualforcePageCreate.getFileExtension()).to.equal('.page');
-    expect(
-      visualforcePageCreate
-        .getSourcePathStrategy()
-        .getPathToSource(outputDirPath, fileName, '.page')
-    ).to.equal(path.join(outputDirPath, `${fileName}.page`));
+  });
+
+  describe('Library Create', () => {
+    let getTemplatesLibraryStub: SinonStub;
+    let showInputBoxStub: SinonStub;
+    let quickPickStub: SinonStub;
+    let appendLineStub: SinonStub;
+    let showSuccessfulExecutionStub: SinonStub;
+    let showFailedExecutionStub: SinonStub;
+    let openTextDocumentStub: SinonStub;
+
+    beforeEach(() => {
+      // mock experimental setting
+      getTemplatesLibraryStub = stub(
+        SfdxCoreSettings.prototype,
+        'getTemplatesLibrary'
+      );
+      getTemplatesLibraryStub.returns(true);
+      showInputBoxStub = stub(vscode.window, 'showInputBox');
+      quickPickStub = stub(vscode.window, 'showQuickPick');
+      appendLineStub = stub(channelService, 'appendLine');
+      showSuccessfulExecutionStub = stub(
+        notificationService,
+        'showSuccessfulExecution'
+      );
+      showSuccessfulExecutionStub.returns(Promise.resolve());
+      showFailedExecutionStub = stub(
+        notificationService,
+        'showFailedExecution'
+      );
+      openTextDocumentStub = stub(vscode.workspace, 'openTextDocument');
+    });
+
+    afterEach(() => {
+      getTemplatesLibraryStub.restore();
+      showInputBoxStub.restore();
+      quickPickStub.restore();
+      showSuccessfulExecutionStub.restore();
+      showFailedExecutionStub.restore();
+      appendLineStub.restore();
+      openTextDocumentStub.restore();
+    });
+
+    it('Should create Visualforce Component', async () => {
+      // arrange
+      const fileName = 'testVFPage';
+      const outputPath = 'force-app/main/default/components';
+      const vfPagePath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'testVFPage.page'
+      );
+      const vfPageMetaPath = path.join(
+        getRootWorkspacePath(),
+        outputPath,
+        'testVFPage.page-meta.xml'
+      );
+      shell.rm('-f', path.join(vfPagePath));
+      shell.rm('-f', path.join(vfPageMetaPath));
+      assert.noFile([vfPagePath, vfPageMetaPath]);
+      showInputBoxStub.returns(fileName);
+      quickPickStub.returns(outputPath);
+
+      // act
+      await forceVisualforcePageCreate();
+
+      // assert
+      const defaultApiVersion = TemplateService.getDefaultApiVersion();
+      assert.file([vfPagePath, vfPageMetaPath]);
+      assert.fileContent(
+        vfPagePath,
+        `<apex:page>
+<!-- Begin Default Content REMOVE THIS -->
+<h1>Congratulations</h1>
+This is your new Page
+<!-- End Default Content REMOVE THIS -->
+</apex:page>`
+      );
+      assert.fileContent(
+        vfPageMetaPath,
+        `<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata"> \n    <apiVersion>${defaultApiVersion}</apiVersion>
+    <label>testVFPage</label>
+</ApexPage>`
+      );
+      sinon.assert.calledOnce(openTextDocumentStub);
+      sinon.assert.calledWith(openTextDocumentStub, vfPagePath);
+
+      // clean up
+      shell.rm('-rf', path.join(getRootWorkspacePath(), outputPath));
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Use `@salesforce/templates` library for creating templates. Follow up of #2428
- Lightning App
- Lightning Component
- Lightning Event
- Lightning Interface
- Lightning LWC
- Visualforce Component
- Visualforce Page

### What issues does this PR fix or reference?
@W-7747009@
