### PR TITLE
Make Refresh SObject Definitions more resilient when handling expired access tokens 

### DIFF
--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -13,12 +13,12 @@
     "@salesforce/salesforcedx-utils-vscode": "49.6.0",
     "cross-spawn": "6.0.5",
     "path-exists": "3.0.0",
-    "request-light": "0.2.4",
     "rxjs": "^5.4.1",
     "shelljs": "0.8.3",
     "tree-kill": "^1.1.0"
   },
   "devDependencies": {
+    "@salesforce/ts-types": "^1.4.2",
     "@types/chai": "^4.0.0",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -18,7 +18,6 @@
     "tree-kill": "^1.1.0"
   },
   "devDependencies": {
-    "@salesforce/ts-types": "^1.4.2",
     "@types/chai": "^4.0.0",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",

--- a/packages/salesforcedx-sobjects-faux-generator/src/describe/sObjectDescribe.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/describe/sObjectDescribe.ts
@@ -14,7 +14,6 @@ import {
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import { extractJsonObject } from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
-import { JsonMap } from '@salesforce/ts-types';
 import { CLIENT_ID } from '../constants';
 
 export interface SObject {
@@ -264,8 +263,8 @@ export class SObjectDescribe {
     return batchRequest;
   }
 
-  public async runRequest(batchRequest: BatchRequest): Promise<JsonMap> {
-    return this.connection.requestRaw({
+  public async runRequest(batchRequest: BatchRequest): Promise<BatchResponse> {
+    return (this.connection.request({
       method: 'POST',
       url: this.buildBatchRequestURL(),
       body: JSON.stringify(batchRequest),
@@ -273,7 +272,7 @@ export class SObjectDescribe {
         'User-Agent': 'salesforcedx-extension',
         'Sforce-Call-Options': `client=${CLIENT_ID}`
       }
-    });
+    }) as unknown) as BatchResponse;
   }
 
   public async describeSObjectBatch(
@@ -282,10 +281,7 @@ export class SObjectDescribe {
   ): Promise<SObject[]> {
     try {
       const batchRequest = this.buildBatchRequestBody(types, nextToProcess);
-      const response = await this.runRequest(batchRequest);
-      const batchResponse = JSON.parse(
-        response.body as string
-      ) as BatchResponse;
+      const batchResponse = await this.runRequest(batchRequest);
       const fetchedObjects: SObject[] = [];
       let i = nextToProcess;
       for (const sr of batchResponse.results) {

--- a/packages/salesforcedx-sobjects-faux-generator/src/describe/sObjectDescribe.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/describe/sObjectDescribe.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Org } from '@salesforce/core';
+import { Connection } from '@salesforce/core';
 import {
   CliCommandExecution,
   CliCommandExecutor,
@@ -14,9 +14,8 @@ import {
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import { extractJsonObject } from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
-import { xhr, XHROptions, XHRResponse } from 'request-light';
+import { JsonMap } from '@salesforce/ts-types';
 import { CLIENT_ID } from '../constants';
-import { ConfigUtil } from './configUtil';
 
 export interface SObject {
   actionOverrides: any[];
@@ -191,14 +190,17 @@ export class ForceListSObjectSchemaExecutor {
 }
 
 export class SObjectDescribe {
-  private accessToken?: string;
-  private instanceUrl?: string;
+  private connection: Connection;
   private readonly servicesPath: string = 'services/data';
   // the targetVersion should be consistent with the Cli even if only using REST calls
   private readonly targetVersion = '46.0';
   private readonly versionPrefix = 'v';
   private readonly sobjectsPart: string = 'sobjects';
   private readonly batchPart: string = 'composite/batch';
+
+  constructor(connection: Connection) {
+    this.connection = connection;
+  }
 
   public async describeGlobal(
     projectPath: string,
@@ -233,7 +235,7 @@ export class SObjectDescribe {
 
   public buildBatchRequestURL(): string {
     const batchUrlElements = [
-      this.instanceUrl,
+      this.connection.instanceUrl,
       this.servicesPath,
       this.getVersion(),
       this.batchPart
@@ -262,55 +264,28 @@ export class SObjectDescribe {
     return batchRequest;
   }
 
-  public buildXHROptions(types: string[], nextToProcess: number): XHROptions {
-    const batchRequest = this.buildBatchRequestBody(types, nextToProcess);
-    return {
-      type: 'POST',
+  public async runRequest(batchRequest: BatchRequest): Promise<JsonMap> {
+    return this.connection.requestRaw({
+      method: 'POST',
       url: this.buildBatchRequestURL(),
+      body: JSON.stringify(batchRequest),
       headers: {
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-        Authorization: `OAuth ${this.accessToken}`,
         'User-Agent': 'salesforcedx-extension',
         'Sforce-Call-Options': `client=${CLIENT_ID}`
-      },
-      data: JSON.stringify(batchRequest)
-    } as XHROptions;
-  }
-
-  public async runRequest(options: XHROptions): Promise<XHRResponse> {
-    return xhr(options);
+      }
+    });
   }
 
   public async describeSObjectBatch(
-    projectPath: string,
     types: string[],
     nextToProcess: number
   ): Promise<SObject[]> {
     try {
-      const org = await Org.create({
-        aliasOrUsername: await ConfigUtil.getUsername(projectPath)
-      });
-
-      if (!this.accessToken || !this.instanceUrl) {
-        await this.getConnectionData(org);
-      }
-
-      let response: XHRResponse;
-      let options: XHROptions;
-      try {
-        options = this.buildXHROptions(types, nextToProcess);
-        response = await this.runRequest(options);
-      } catch (e) {
-        if (e.status !== 401) {
-          throw e;
-        }
-        await this.getConnectionData(org, true);
-        options = this.buildXHROptions(types, nextToProcess);
-        response = await this.runRequest(options);
-      }
-
-      const batchResponse = JSON.parse(response.responseText) as BatchResponse;
+      const batchRequest = this.buildBatchRequestBody(types, nextToProcess);
+      const response = await this.runRequest(batchRequest);
+      const batchResponse = JSON.parse(
+        response.body as string
+      ) as BatchResponse;
       const fetchedObjects: SObject[] = [];
       let i = nextToProcess;
       for (const sr of batchResponse.results) {
@@ -324,20 +299,11 @@ export class SObjectDescribe {
       }
       return Promise.resolve(fetchedObjects);
     } catch (error) {
-      const errorMsg = error.hasOwnProperty('responseText')
-        ? error.responseText
+      const errorMsg = error.hasOwnProperty('body')
+        ? error.body
         : error.message;
       return Promise.reject(errorMsg);
     }
-  }
-
-  public async getConnectionData(org: Org, withRefresh?: boolean) {
-    if (withRefresh) {
-      await org.refreshAuth();
-    }
-    const { accessToken, instanceUrl } = org.getConnection();
-    this.accessToken = accessToken;
-    this.instanceUrl = instanceUrl;
   }
 
   public getVersion(): string {

--- a/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
@@ -96,7 +96,7 @@ export class FauxClassGenerator {
   private static fieldDeclToString(decl: FieldDeclaration): string {
     return `${FauxClassGenerator.commentToString(decl.comment)}${INDENT}${
       decl.modifier
-      } ${decl.type} ${decl.name};`;
+    } ${decl.type} ${decl.name};`;
   }
 
   // VisibleForTesting
@@ -104,9 +104,9 @@ export class FauxClassGenerator {
     // for some reasons if the comment is on a single line the help context shows the last '*/'
     return comment
       ? `${INDENT}/* ${comment.replace(
-        /(\/\*+\/)|(\/\*+)|(\*+\/)/g,
-        ''
-      )}${EOL}${INDENT}*/${EOL}`
+          /(\/\*+\/)|(\/\*+)|(\*+\/)/g,
+          ''
+        )}${EOL}${INDENT}*/${EOL}`
       : '';
   }
 

--- a/packages/salesforcedx-sobjects-faux-generator/test/integration/fauxGenerate.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/integration/fauxGenerate.test.ts
@@ -153,22 +153,15 @@ describe('Generate faux classes for SObjects', () => {
   describe('Check results', () => {
     beforeEach(() => {
       env.stub(fs, 'existsSync').returns(true);
+      env.stub(Connection.prototype, 'request').resolves(mockDescribeResponse);
+      env.stub(FauxClassGenerator.prototype, 'generateFauxClass');
+      env
+        .stub(SObjectDescribe.prototype, 'describeGlobal')
+        .returns(['ApexPageInfo']);
     });
 
     it('Should emit an exit event with code success code 0 on success', async () => {
       let exitCode = LocalCommandExecution.FAILURE_CODE;
-      env
-        .stub(SObjectDescribe.prototype, 'describeGlobal')
-        .returns(['ApexPageInfo']);
-
-      env.stub(Connection.prototype, 'requestRaw').returns(
-        Promise.resolve({
-          status: 200,
-          body: JSON.stringify(mockDescribeResponse)
-        })
-      );
-
-      env.stub(FauxClassGenerator.prototype, 'generateFauxClass');
 
       const generator = getGenerator();
       emitter.addListener(LocalCommandExecution.EXIT_EVENT, (data: number) => {
@@ -195,18 +188,6 @@ describe('Generate faux classes for SObjects', () => {
         }
       );
 
-      env
-        .stub(SObjectDescribe.prototype, 'describeGlobal')
-        .returns(['ApexPageInfo']);
-
-      env.stub(Connection.prototype, 'requestRaw').returns(
-        Promise.resolve({
-          status: 200,
-          body: JSON.stringify(mockDescribeResponse)
-        })
-      );
-
-      env.stub(FauxClassGenerator.prototype, 'generateFauxClass');
       result = await generator.generate(
         projectPath,
         SObjectCategory.CUSTOM,

--- a/packages/salesforcedx-sobjects-faux-generator/test/integration/sObjectDescribe.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/integration/sObjectDescribe.test.ts
@@ -5,13 +5,12 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthInfo, Org } from '@salesforce/core';
+import { AuthInfo, Connection } from '@salesforce/core';
 import { CommandOutput } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import { fail } from 'assert';
 import { expect } from 'chai';
-import { XHRResponse } from 'request-light';
-import { SinonStub, stub } from 'sinon';
-import { ConfigUtil } from '../../src/describe/configUtil';
+import { connect } from 'http2';
+import { createSandbox, SinonStub, stub } from 'sinon';
 import {
   ForceListSObjectSchemaExecutor,
   SObjectCategory,
@@ -19,37 +18,31 @@ import {
 } from '../../src/describe/sObjectDescribe';
 import { mockDescribeResponse } from './mockData';
 
-const sobjectdescribe = new SObjectDescribe();
 const CONNECTION_DATA = {
   accessToken: '00Dxx000thisIsATestToken',
   instanceUrl: 'https://na1.salesforce.com'
 };
 
+const env = createSandbox();
+
 // tslint:disable:no-unused-expression
 describe('Fetch sObjects', () => {
-  let getUsername: SinonStub;
-  let connection: SinonStub;
-  let xhrMock: SinonStub;
-  let authInfo: SinonStub;
-  let refreshAuth: SinonStub;
+  let connection: Connection;
+  let sobjectdescribe: SObjectDescribe;
 
-  beforeEach(() => {
-    authInfo = stub(AuthInfo, 'create').returns({
+  beforeEach(async () => {
+    env.stub(AuthInfo, 'create').returns({
       getConnectionOptions: () => CONNECTION_DATA
     });
-    getUsername = stub(ConfigUtil, 'getUsername').returns('test@example.com');
-    connection = stub(Org.prototype, 'getConnection').returns(CONNECTION_DATA);
-    refreshAuth = stub(Org.prototype, 'refreshAuth');
-    xhrMock = stub(SObjectDescribe.prototype, 'runRequest');
+    connection = await Connection.create({
+      authInfo: await AuthInfo.create({
+        username: 'test@example.com'
+      })
+    });
+    sobjectdescribe = new SObjectDescribe(connection);
   });
 
-  afterEach(() => {
-    getUsername.restore();
-    connection.restore();
-    xhrMock.restore();
-    authInfo.restore();
-    refreshAuth.restore();
-  });
+  afterEach(() => env.restore());
 
   it('Should build the schema sobject list command', async () => {
     const sobjectType = 'all';
@@ -86,32 +79,9 @@ describe('Fetch sObjects', () => {
   });
 
   it('Should build the batch request url', async () => {
-    const org = await Org.create({ aliasOrUsername: 'test@example.com' });
-    await sobjectdescribe.getConnectionData(org);
     expect(sobjectdescribe.buildBatchRequestURL()).to.equal(
       'https://na1.salesforce.com/services/data/v46.0/composite/batch'
     );
-  });
-
-  it('Should ensure valid session token', async () => {
-    const sobjectTypes = ['object1', 'object2', 'object3'];
-    xhrMock.onFirstCall().throws({ status: 401 });
-    xhrMock
-      .onSecondCall()
-      .returns({ responseText: JSON.stringify(mockDescribeResponse) });
-    refreshAuth.callsFake(() => {
-      connection.returns({
-        accessToken: 'another-test-token',
-        instanceUrl: 'https://na1.salesforce.com'
-      });
-    });
-    await sobjectdescribe.describeSObjectBatch(
-      'test/project/uri',
-      sobjectTypes,
-      0
-    );
-    const opts = sobjectdescribe.buildXHROptions(sobjectTypes, 0);
-    expect(opts.headers.Authorization).to.equal('OAuth another-test-token');
   });
 
   it('Should build the api version', () => {
@@ -131,9 +101,7 @@ describe('Fetch sObjects', () => {
     expect(requestBody).to.deep.equals(testBatchReq);
   });
 
-  it('Should create the correct xhr options', async () => {
-    const org = await Org.create({ aliasOrUsername: 'test@example.com' });
-    const sobjectTypes = ['object1', 'object2', 'object3'];
+  it('Should create the correct request options', async () => {
     const testBatchReq = {
       batchRequests: [
         { method: 'GET', url: 'v46.0/sobjects/object1/describe' },
@@ -141,40 +109,31 @@ describe('Fetch sObjects', () => {
         { method: 'GET', url: 'v46.0/sobjects/object3/describe' }
       ]
     };
-    await sobjectdescribe.getConnectionData(org);
-    const xhrOptions = sobjectdescribe.buildXHROptions(sobjectTypes, 0);
-    expect(xhrOptions).to.not.be.empty;
-    expect(xhrOptions.type).to.be.equal('POST');
-    expect(xhrOptions.url).to.be.equal(
-      'https://na1.salesforce.com/services/data/v46.0/composite/batch'
-    );
-    expect(xhrOptions.headers).to.deep.equal({
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-      Authorization: 'OAuth 00Dxx000thisIsATestToken',
-      'User-Agent': 'salesforcedx-extension',
-      'Sforce-Call-Options': 'client=sfdx-vscode'
+    const requestStub = env.stub(connection, 'requestRaw');
+    await sobjectdescribe.runRequest(testBatchReq);
+    expect(requestStub.firstCall.args[0]).to.deep.equal({
+      method: 'POST',
+      url: `${connection.instanceUrl}/services/data/v46.0/composite/batch`,
+      body: JSON.stringify(testBatchReq),
+      headers: {
+        'User-Agent': 'salesforcedx-extension',
+        'Sforce-Call-Options': `client=sfdx-vscode`
+      }
     });
-    expect(xhrOptions.data).to.be.equal(JSON.stringify(testBatchReq));
   });
 
   it('Should return sobjects when calling describeSObjectBatch', async () => {
     const sobjectTypes = ['ApexPageInfo'];
-    xhrMock.returns(
-      Promise.resolve({
-        status: 200,
-        responseText: JSON.stringify(mockDescribeResponse)
-      } as XHRResponse)
-    );
+    env.stub(connection, 'requestRaw').resolves({
+      status: 200,
+      body: JSON.stringify(mockDescribeResponse)
+    });
 
     const batchResponse = await sobjectdescribe.describeSObjectBatch(
-      'test/project/uri',
       sobjectTypes,
       0
     );
 
-    expect(xhrMock.calledOnce).to.equal(true);
-    expect(batchResponse).to.be.an('array');
     expect(batchResponse.length).to.be.equal(1);
     expect(batchResponse[0]).to.deep.equal(
       mockDescribeResponse.results[0].result
@@ -183,42 +142,31 @@ describe('Fetch sObjects', () => {
 
   it('Should throw error when response errors out', async () => {
     const sobjectTypes = ['ApexPageInfo'];
-    xhrMock.returns(
+    env.stub(connection, 'requestRaw').returns(
       Promise.reject({
         status: 400,
-        responseText: 'Unexpected error'
-      } as XHRResponse)
+        body: 'Unexpected error'
+      })
     );
 
     try {
-      await sobjectdescribe.describeSObjectBatch(
-        'test/project/uri',
-        sobjectTypes,
-        0
-      );
+      await sobjectdescribe.describeSObjectBatch(sobjectTypes, 0);
       fail('An error was expected');
     } catch (err) {
       expect(err).to.be.equal('Unexpected error');
     }
-
-    expect(xhrMock.calledOnce).to.equal(true);
   });
 
-  it('Should throw error when authentication errors out', async () => {
-    const sobjectdescribeException = new SObjectDescribe();
-    const sobjectTypes = ['ApexPageInfo'];
-    authInfo.throws(new Error('Unexpected error in Auth phase'));
+  // it('Should throw error when authentication errors out', async () => {
+  //   const sobjectTypes = ['ApexPageInfo'];
+  //   authInfo.throws(new Error('Unexpected error in Auth phase'));
 
-    try {
-      await sobjectdescribeException.describeSObjectBatch(
-        'test/project/uri',
-        sobjectTypes,
-        0
-      );
-      fail('An error was expected');
-    } catch (err) {
-      expect(err).to.be.equal('Unexpected error in Auth phase');
-    }
-    expect(authInfo.called).to.equal(true);
-  });
+  //   try {
+  //     await sobjectdescribe.describeSObjectBatch(sobjectTypes, 0);
+  //     fail('An error was expected');
+  //   } catch (err) {
+  //     expect(err).to.be.equal('Unexpected error in Auth phase');
+  //   }
+  //   expect(authInfo.called).to.equal(true);
+  // });
 });

--- a/packages/salesforcedx-sobjects-faux-generator/test/integration/sObjectDescribe.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/integration/sObjectDescribe.test.ts
@@ -108,7 +108,7 @@ describe('Fetch sObjects', () => {
         { method: 'GET', url: 'v46.0/sobjects/object3/describe' }
       ]
     };
-    const requestStub = env.stub(connection, 'requestRaw');
+    const requestStub = env.stub(connection, 'request');
     await sobjectdescribe.runRequest(testBatchReq);
     expect(requestStub.firstCall.args[0]).to.deep.equal({
       method: 'POST',
@@ -123,10 +123,7 @@ describe('Fetch sObjects', () => {
 
   it('Should return sobjects when calling describeSObjectBatch', async () => {
     const sobjectTypes = ['ApexPageInfo'];
-    env.stub(connection, 'requestRaw').resolves({
-      status: 200,
-      body: JSON.stringify(mockDescribeResponse)
-    });
+    env.stub(connection, 'request').resolves(mockDescribeResponse);
 
     const batchResponse = await sobjectdescribe.describeSObjectBatch(
       sobjectTypes,
@@ -141,12 +138,10 @@ describe('Fetch sObjects', () => {
 
   it('Should throw error when response errors out', async () => {
     const sobjectTypes = ['ApexPageInfo'];
-    env.stub(connection, 'requestRaw').returns(
-      Promise.reject({
-        status: 400,
-        body: 'Unexpected error'
-      })
-    );
+    env.stub(connection, 'request').rejects({
+      status: 400,
+      body: 'Unexpected error'
+    });
 
     try {
       await sobjectdescribe.describeSObjectBatch(sobjectTypes, 0);

--- a/packages/salesforcedx-sobjects-faux-generator/test/integration/sObjectDescribe.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/integration/sObjectDescribe.test.ts
@@ -9,8 +9,7 @@ import { AuthInfo, Connection } from '@salesforce/core';
 import { CommandOutput } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import { fail } from 'assert';
 import { expect } from 'chai';
-import { connect } from 'http2';
-import { createSandbox, SinonStub, stub } from 'sinon';
+import { createSandbox, stub } from 'sinon';
 import {
   ForceListSObjectSchemaExecutor,
   SObjectCategory,
@@ -156,17 +155,4 @@ describe('Fetch sObjects', () => {
       expect(err).to.be.equal('Unexpected error');
     }
   });
-
-  // it('Should throw error when authentication errors out', async () => {
-  //   const sobjectTypes = ['ApexPageInfo'];
-  //   authInfo.throws(new Error('Unexpected error in Auth phase'));
-
-  //   try {
-  //     await sobjectdescribe.describeSObjectBatch(sobjectTypes, 0);
-  //     fail('An error was expected');
-  //   } catch (err) {
-  //     expect(err).to.be.equal('Unexpected error in Auth phase');
-  //   }
-  //   expect(authInfo.called).to.equal(true);
-  // });
 });


### PR DESCRIPTION
### What does this PR do?

Update the Refresh SObject Definitions command to use an sfdx-core connection when making the sObject describe request. A core connection will automatically take care of refreshing an access token, reducing the chances of the command failing due to authentication issues.

### What issues does this PR fix or reference?

@W-7709580@
