### PR TITLE
fix: create minimal sobject refresh on activation

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,5 +78,8 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
+  },
+  "volta": {
+    "node": "12.4.0"
   }
 }

--- a/packages/salesforcedx-sobjects-faux-generator/src/index.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/index.ts
@@ -4,4 +4,10 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-export { CLIENT_ID, SFDX_DIR, SOBJECTS_DIR, TOOLS_DIR } from './constants';
+export {
+  CLIENT_ID,
+  SFDX_DIR,
+  SOBJECTS_DIR,
+  TOOLS_DIR,
+  STANDARDOBJECTS_DIR
+} from './constants';


### PR DESCRIPTION
### What does this PR do?
New type of sobject refresh that gets the definition of a reduced set of SObjects. This is meant to be used through the activation message. Reducing the amount of sobject definitions helps avoid the performance spikes seen lately while still allowing the user to have a better apex lang server experience.

NOTE: i'm still working on updating the test but the changes are ready to start getting feedback

### What issues does this PR fix or reference?
#2410 , @W-8027533@

