### PR TITLE
feat: Delete & clean scratch orgs

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -656,6 +656,14 @@
         "title": "%force_alias_list_text%"
       },
       {
+        "command": "sfdx.force.org.delete.default",
+        "title": "%force_org_delete_default_text%"
+      },
+      {
+        "command": "sfdx.force.org.delete.username",
+        "title": "%force_org_delete_username_text%"
+      },
+      {
         "command": "sfdx.force.org.display.default",
         "title": "%force_org_display_default_text%"
       },

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -664,6 +664,10 @@
         "title": "%force_org_display_username_text%"
       },
       {
+        "command": "sfdx.force.org.list.clean",
+        "title": "%force_org_list_clean_text%"
+      },
+      {
         "command": "sfdx.force.data.soql.query.input",
         "title": "%force_data_soql_query_input_text%"
       },

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -26,6 +26,8 @@
   "force_debugger_stop_text": "SFDX: Stop Apex Debugger Session",
   "force_config_list_text": "SFDX: List All Config Variables",
   "force_alias_list_text": "SFDX: List All Aliases",
+  "force_org_delete_default_text": "SFDX: Delete Default Org",
+  "force_org_delete_username_text": "SFDX: Delete Org...",
   "force_org_display_default_text": "SFDX: Display Org Details for Default Org",
   "force_org_display_username_text": "SFDX: Display Org Details...",
   "force_org_list_clean_text": "SFDX: Remove All Expired Orgs",

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -28,6 +28,7 @@
   "force_alias_list_text": "SFDX: List All Aliases",
   "force_org_display_default_text": "SFDX: Display Org Details for Default Org",
   "force_org_display_username_text": "SFDX: Display Org Details...",
+  "force_org_list_clean_text": "SFDX: Remove All Expired Orgs",
   "force_data_soql_query_input_text": "SFDX: Execute SOQL Query...",
   "force_data_soql_query_selection_text": "SFDX: Execute SOQL Query with Currently Selected Text",
   "force_apex_execute_document_text": "SFDX: Execute Anonymous Apex with Editor Contents",

--- a/packages/salesforcedx-vscode-core/src/commands/forceOrgDelete.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceOrgDelete.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  Command,
+  SfdxCommandBuilder
+} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import { nls } from '../messages';
+import {
+  CompositeParametersGatherer,
+  FlagParameter,
+  PromptConfirmGatherer,
+  SelectUsername,
+  SfdxCommandlet,
+  SfdxCommandletExecutor,
+  SfdxWorkspaceChecker
+} from './util';
+
+export class ForceOrgDeleteExecutor extends SfdxCommandletExecutor<{}> {
+  private flag: string | undefined;
+
+  public constructor(flag?: string) {
+    super();
+    this.flag = flag;
+  }
+
+  public build(data: { choice?: string; username?: string }): Command {
+    const builder = new SfdxCommandBuilder()
+      .withDescription(nls.localize('force_org_delete_default_text'))
+      .withArg('force:org:delete')
+      .withArg('--noprompt')
+      .withLogName('force_org_delete_default');
+
+    if (this.flag === '--targetusername' && data.username) {
+      builder
+        .withDescription(nls.localize('force_org_delete_username_text'))
+        .withFlag(this.flag, data.username);
+    }
+    return builder.build();
+  }
+}
+
+const workspaceChecker = new SfdxWorkspaceChecker();
+
+export async function forceOrgDelete(this: FlagParameter<string>) {
+  // tslint:disable-next-line:no-invalid-this
+  const flag = this ? this.flag : undefined;
+
+  const parameterGatherer = flag
+    ? new CompositeParametersGatherer(
+        new SelectUsername(),
+        new PromptConfirmGatherer()
+      )
+    : new PromptConfirmGatherer();
+
+  const executor = new ForceOrgDeleteExecutor(flag);
+  const commandlet = new SfdxCommandlet(
+    workspaceChecker,
+    parameterGatherer,
+    executor
+  );
+  await commandlet.run();
+}

--- a/packages/salesforcedx-vscode-core/src/commands/forceOrgList.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceOrgList.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
 import {
   Command,
   SfdxCommandBuilder

--- a/packages/salesforcedx-vscode-core/src/commands/forceOrgList.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceOrgList.ts
@@ -1,0 +1,36 @@
+import {
+  Command,
+  SfdxCommandBuilder
+} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import { nls } from '../messages';
+import {
+  PromptConfirmGatherer,
+  SfdxCommandlet,
+  SfdxCommandletExecutor,
+  SfdxWorkspaceChecker
+} from './util';
+
+export class ForceOrgListExecutor extends SfdxCommandletExecutor<{}> {
+  public build(data: { choice?: string }): Command {
+    return new SfdxCommandBuilder()
+      .withDescription(nls.localize('force_org_list_clean_text'))
+      .withArg('force:org:list')
+      .withArg('--clean')
+      .withArg('--noprompt')
+      .withLogName('force_org_list_clean')
+      .build();
+  }
+}
+
+const workspaceChecker = new SfdxWorkspaceChecker();
+
+export async function forceOrgList() {
+  const parameterGatherer = new PromptConfirmGatherer();
+  const executor = new ForceOrgListExecutor();
+  const commandlet = new SfdxCommandlet(
+    workspaceChecker,
+    parameterGatherer,
+    executor
+  );
+  await commandlet.run();
+}

--- a/packages/salesforcedx-vscode-core/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/index.ts
@@ -162,6 +162,7 @@ export {
   ForceSourceDiffExecutor,
   handleDiffResponse
 } from './forceSourceDiff';
+export { forceOrgList } from './forceOrgList';
 export { BaseDeployExecutor } from './baseDeployCommand';
 export { forceFunctionCreate } from './templates/forceFunctionCreate';
 export {

--- a/packages/salesforcedx-vscode-core/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/index.ts
@@ -163,6 +163,7 @@ export {
   handleDiffResponse
 } from './forceSourceDiff';
 export { forceOrgList } from './forceOrgList';
+export { forceOrgDelete } from './forceOrgDelete';
 export { BaseDeployExecutor } from './baseDeployCommand';
 export { forceFunctionCreate } from './templates/forceFunctionCreate';
 export {

--- a/packages/salesforcedx-vscode-core/src/commands/util/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/index.ts
@@ -18,6 +18,7 @@ export {
   FileSelector,
   FilePathGatherer,
   MetadataTypeGatherer,
+  PromptConfirmGatherer,
   SelectOutputDir,
   SelectFileName,
   SelectUsername

--- a/packages/salesforcedx-vscode-core/src/commands/util/parameterGatherers.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/parameterGatherers.ts
@@ -340,3 +340,23 @@ export class MetadataTypeGatherer extends SimpleGatherer<{ type: string }> {
     super({ type: metadataType });
   }
 }
+
+export class PromptConfirmGatherer
+  implements ParametersGatherer<{ choice: string }> {
+  public async gather(): Promise<
+    CancelResponse | ContinueResponse<{ choice: string }>
+  > {
+    const confirmOpt = nls.localize('parameter_gatherer_prompt_confirm_option');
+    const cancelOpt = nls.localize('parameter_gatherer_prompt_cancel_option');
+    const choice = await this.showMenu([confirmOpt, cancelOpt]);
+    return confirmOpt === choice
+      ? { type: 'CONTINUE', data: { choice } }
+      : { type: 'CANCEL' };
+  }
+
+  public async showMenu(options: string[]): Promise<string | undefined> {
+    return await vscode.window.showQuickPick(options, {
+      placeHolder: nls.localize('parameter_gatherer_prompt_confirm_placeholder')
+    } as vscode.QuickPickOptions);
+  }
+}

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -38,6 +38,7 @@ import {
   forceLightningLwcTestCreate,
   forceOrgCreate,
   forceOrgDisplay,
+  forceOrgList,
   forceOrgOpen,
   forcePackageInstall,
   forceProjectWithManifestCreate,
@@ -253,6 +254,10 @@ function registerCommands(
     'sfdx.force.org.display.username',
     forceOrgDisplay,
     { flag: '--targetusername' }
+  );
+  const forceOrgListCleanCmd = vscode.commands.registerCommand(
+    'sfdx.force.org.list.clean',
+    forceOrgList
   );
   const forceDataSoqlQueryInputCmd = vscode.commands.registerCommand(
     'sfdx.force.data.soql.query.input',

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -37,6 +37,7 @@ import {
   forceLightningLwcCreate,
   forceLightningLwcTestCreate,
   forceOrgCreate,
+  forceOrgDelete,
   forceOrgDisplay,
   forceOrgList,
   forceOrgOpen,
@@ -245,6 +246,15 @@ function registerCommands(
   const forceAliasListCmd = vscode.commands.registerCommand(
     'sfdx.force.alias.list',
     forceAliasList
+  );
+  const forceOrgDeleteDefaultCmd = vscode.commands.registerCommand(
+    'sfdx.force.org.delete.default',
+    forceOrgDelete
+  );
+  const forceOrgDeleteUsernameCmd = vscode.commands.registerCommand(
+    'sfdx.force.org.delete.username',
+    forceOrgDelete,
+    { flag: '--targetusername' }
   );
   const forceOrgDisplayDefaultCmd = vscode.commands.registerCommand(
     'sfdx.force.org.display.default',

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -162,6 +162,8 @@ export const messages = {
   warning_prompt_other_not_shown: '...%s other components not shown\n',
   force_config_list_text: 'SFDX: List All Config Variables',
   force_alias_list_text: 'SFDX: List All Aliases',
+  force_org_delete_default_text: 'SFDX: Delete Default Org',
+  force_org_delete_username_text: 'SFDX: Delete Org...',
   force_org_display_default_text: 'SFDX: Display Org Details for Default Org',
   force_org_display_username_text: 'SFDX: Display Org Details...',
   force_org_list_clean_text: 'SFDX: Remove All Expired Orgs',

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -75,7 +75,6 @@ export const messages = {
   parameter_gatherer_invalid_forceide_url:
     "The forceide:// URL is invalid. From your subscriber's org, copy and paste the forceide:// URL shown on the Apex Debugger page in Setup.",
   parameter_gatherer_enter_function: 'Enter function details',
-
   parameter_gatherer_prompt_confirm_option: 'yes',
   parameter_gatherer_prompt_cancel_option: 'no',
   parameter_gatherer_prompt_confirm_placeholder: 'Confirm the operation?',

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -567,6 +567,5 @@ export const messages = {
   package_id_gatherer_placeholder: '04t...',
   force_function_enter_function: 'Enter a name for the function',
   force_function_enter_language: 'Select a language for your function',
-  force_function_pull_dependencies_error:
-    "%s. Make sure you have NodeJS installed (https://nodejs.org/) and then run 'npm install' to install dependencies from package.json"
+  force_function_pull_dependencies_error: "%s. Make sure you have NodeJS installed (https://nodejs.org/) and then run 'npm install' to install dependencies from package.json"
 };

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -76,6 +76,10 @@ export const messages = {
     "The forceide:// URL is invalid. From your subscriber's org, copy and paste the forceide:// URL shown on the Apex Debugger page in Setup.",
   parameter_gatherer_enter_function: 'Enter function details',
 
+  parameter_gatherer_prompt_confirm_option: 'yes',
+  parameter_gatherer_prompt_cancel_option: 'no',
+  parameter_gatherer_prompt_confirm_placeholder: 'Confirm the operation?',
+
   force_org_create_default_scratch_org_text:
     'SFDX: Create a Default Scratch Org...',
   force_org_create_result_parsing_error:
@@ -160,6 +164,7 @@ export const messages = {
   force_alias_list_text: 'SFDX: List All Aliases',
   force_org_display_default_text: 'SFDX: Display Org Details for Default Org',
   force_org_display_username_text: 'SFDX: Display Org Details...',
+  force_org_list_clean_text: 'SFDX: Remove All Expired Orgs',
   force_debugger_query_session_text: 'query for Apex Debugger session',
   force_debugger_stop_text: 'SFDX: Stop Apex Debugger Session',
   force_debugger_stop_none_found_text: 'No Apex Debugger session found.',
@@ -561,5 +566,6 @@ export const messages = {
   package_id_gatherer_placeholder: '04t...',
   force_function_enter_function: 'Enter a name for the function',
   force_function_enter_language: 'Select a language for your function',
-  force_function_pull_dependencies_error: "%s. Make sure you have NodeJS installed (https://nodejs.org/) and then run 'npm install' to install dependencies from package.json"
+  force_function_pull_dependencies_error:
+    "%s. Make sure you have NodeJS installed (https://nodejs.org/) and then run 'npm install' to install dependencies from package.json"
 };

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceOrgDelete.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceOrgDelete.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { expect } from 'chai';
+import { ForceOrgDeleteExecutor } from '../../../src/commands/forceOrgDelete';
+import { nls } from '../../../src/messages';
+
+describe('Force Org Delete', () => {
+  it('Should build the delete command with no flag', async () => {
+    const forceOrgDelete = new ForceOrgDeleteExecutor();
+    const deleteCommand = forceOrgDelete.build({});
+    expect(deleteCommand.toCommand()).to.equal(
+      'sfdx force:org:delete --noprompt'
+    );
+    expect(deleteCommand.description).to.equal(
+      nls.localize('force_org_delete_default_text')
+    );
+  });
+
+  it('Should build the delete command with targetusername flag', async () => {
+    const forceOrgDelete = new ForceOrgDeleteExecutor('--targetusername');
+    const deleteCommand = forceOrgDelete.build({ username: 'test' });
+    expect(deleteCommand.toCommand()).to.equal(
+      'sfdx force:org:delete --noprompt --targetusername test'
+    );
+    expect(deleteCommand.description).to.equal(
+      nls.localize('force_org_delete_username_text')
+    );
+  });
+});

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceOrgList.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceOrgList.test.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
 import { expect } from 'chai';
 import { ForceOrgListExecutor } from '../../../src/commands/forceOrgList';
 import { nls } from '../../../src/messages';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceOrgList.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceOrgList.test.ts
@@ -1,0 +1,16 @@
+import { expect } from 'chai';
+import { ForceOrgListExecutor } from '../../../src/commands/forceOrgList';
+import { nls } from '../../../src/messages';
+
+describe('Force Org List', () => {
+  it('Should build the list command with --clean option', async () => {
+    const forceOrgList = new ForceOrgListExecutor();
+    const listCommand = forceOrgList.build({});
+    expect(listCommand.toCommand()).to.equal(
+      'sfdx force:org:list --clean --noprompt'
+    );
+    expect(listCommand.description).to.equal(
+      nls.localize('force_org_list_clean_text')
+    );
+  });
+});

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/parameterGatherers.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/parameterGatherers.test.ts
@@ -31,7 +31,11 @@ import {
   SfdxCommandlet,
   SimpleGatherer
 } from '../../../../src/commands/util';
-import { SelectLwcComponentDir } from '../../../../src/commands/util/parameterGatherers';
+import {
+  PromptConfirmGatherer,
+  SelectLwcComponentDir
+} from '../../../../src/commands/util/parameterGatherers';
+import { nls } from '../../../../src/messages';
 import { SfdxPackageDirectories } from '../../../../src/sfdxProject';
 import { getRootWorkspacePath } from '../../../../src/util';
 
@@ -368,6 +372,33 @@ describe('Parameter Gatherers', () => {
       expect(response).to.eql({
         type: 'CONTINUE',
         data: input
+      });
+    });
+  });
+
+  describe('PromptConfirmGatherer', () => {
+    it('Should return CONTINUE if confirmation to proceed is positive', async () => {
+      const promptConfirm = new PromptConfirmGatherer();
+      const showMenuStub = sinon.stub(promptConfirm, 'showMenu');
+      const choice = nls.localize('prompt_confirm_option');
+      showMenuStub.onFirstCall().returns(choice);
+      const response = await promptConfirm.gather();
+      expect(response).to.eql({
+        type: 'CONTINUE',
+        data: {
+          choice
+        }
+      });
+    });
+
+    it('Should return CANCEL if confirmation to proceed is negative', async () => {
+      const promptConfirm = new PromptConfirmGatherer();
+      const showMenuStub = sinon.stub(promptConfirm, 'showMenu');
+      const choice = nls.localize('prompt_cancel_option');
+      showMenuStub.onFirstCall().returns(choice);
+      const response = await promptConfirm.gather();
+      expect(response).to.eql({
+        type: 'CANCEL'
       });
     });
   });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/parameterGatherers.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/parameterGatherers.test.ts
@@ -380,7 +380,7 @@ describe('Parameter Gatherers', () => {
     it('Should return CONTINUE if confirmation to proceed is positive', async () => {
       const promptConfirm = new PromptConfirmGatherer();
       const showMenuStub = sinon.stub(promptConfirm, 'showMenu');
-      const choice = nls.localize('prompt_confirm_option');
+      const choice = nls.localize('parameter_gatherer_prompt_confirm_option');
       showMenuStub.onFirstCall().returns(choice);
       const response = await promptConfirm.gather();
       expect(response).to.eql({
@@ -394,7 +394,7 @@ describe('Parameter Gatherers', () => {
     it('Should return CANCEL if confirmation to proceed is negative', async () => {
       const promptConfirm = new PromptConfirmGatherer();
       const showMenuStub = sinon.stub(promptConfirm, 'showMenu');
-      const choice = nls.localize('prompt_cancel_option');
+      const choice = nls.localize('parameter_gatherer_prompt_cancel_option');
       showMenuStub.onFirstCall().returns(choice);
       const response = await promptConfirm.gather();
       expect(response).to.eql({


### PR DESCRIPTION
### What does this PR do?
Add three new Command Palette entries to:
- Remove all expired Scratch Orgs, by running the `sfdx force:org:list --clean` CLI command
- Delete the default Org, by running the `sfdx force:org:delete` CLI command
- Delete a specific Org, by running the `sfdx force:org:delete -u test` CLI command

### What issues does this PR fix or reference?
#945 

### Functionality After
<img width="605" alt="Screenshot 2020-09-10 at 15 30 11" src="https://user-images.githubusercontent.com/8080936/92737190-37263800-f37b-11ea-9fd4-63d378bbaf1c.png">

<img width="606" alt="Screenshot 2020-09-10 at 15 30 45" src="https://user-images.githubusercontent.com/8080936/92737251-43aa9080-f37b-11ea-9143-27524879a9ea.png">

