### PR TITLE
chore(soql): add missing type for mkdirp

### DIFF
--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -32,6 +32,7 @@
     "@salesforce/ts-sinon": "1.2.2",
     "@types/chai": "^4.0.0",
     "@types/debounce": "^1.2.0",
+    "@types/mkdirp": "^1.0.1",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",
     "@types/sinon": "^2.3.2",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -32,7 +32,7 @@
     "@salesforce/ts-sinon": "1.2.2",
     "@types/chai": "^4.0.0",
     "@types/debounce": "^1.2.0",
-    "@types/mkdirp": "^1.0.1",
+    "@types/mkdirp": "0.5.2",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",
     "@types/sinon": "^2.3.2",


### PR DESCRIPTION
### What does this PR do?
This fixes the compile error:

```salesforcedx-vscode-soql: node_modules/@salesforce/core/lib/util/fs.d.ts(4,28): error TS7016: Could not find a declaration file for module 'mkdirp'. '/Users/tcromer/workspace/vscode/salesforcedx-vscode/packages/salesforcedx-vscode-soql/node_modules/mkdirp/index.js'```

This appears to be a downstream dependency from us as we don't use this module directly.

### What issues does this PR fix or reference?

### Functionality After
Compile and Lint pass.
