### PR TITLE
chore: update change log generator to utilize the recent commitizen rule sets (@W-8115261@)

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -131,7 +131,7 @@
     {
       "id": "releaseOverride",
       "type": "promptString",
-      "description": "Enter the release number or leave blank to run with the current branch's release number."
+      "description": "Release Version: Leave blank to grab the latest release, or provide the release manually (Ex 49.11.0)"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "label": "Create Change Log",
       "command": "./scripts/change-log-generator.js",
       "type": "shell",
-      "args": ["-v", "${input:verboseOutput}", "-r", "${input:releaseOverride}"]
+      "args": ["${input:verboseOutput}", "-r", "${input:releaseOverride}"]
     },
     {
       "label": "Lint",
@@ -124,9 +124,9 @@
     {
       "id": "verboseOutput",
       "type": "pickString",
-      "description": "Output verbose logging?",
-      "options": ["Yes", "No"],
-      "default": "Yes"
+      "description": "Output verbose logging? Select -v for verbose, and blank for quiet.",
+      "options": ["", "-v"],
+      "default": "-v"
     },
     {
       "id": "releaseOverride",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -80,6 +80,12 @@
       "args": ["${input:circleCiId}"]
     },
     {
+      "label": "Create Change Log",
+      "command": "./scripts/change-log-generator.js",
+      "type": "shell",
+      "args": ["-v", "${input:verboseOutput}", "-r", "${input:releaseOverride}"]
+    },
+    {
       "label": "Lint",
       "command": "npm",
       "type": "shell",
@@ -114,6 +120,18 @@
       "id": "circleCiId",
       "type": "promptString",
       "description": "CircleCi Token"
+    },
+    {
+      "id": "verboseOutput",
+      "type": "pickString",
+      "description": "Output verbose logging?",
+      "options": ["Yes", "No"],
+      "default": "Yes"
+    },
+    {
+      "id": "releaseOverride",
+      "type": "promptString",
+      "description": "Enter the release number or leave blank to run with the current branch's release number."
     }
   ]
 }

--- a/scripts/change-log-generator.js
+++ b/scripts/change-log-generator.js
@@ -132,7 +132,7 @@ function getCommits(releaseBranch, previousBranch) {
   if (ADD_VERBOSE_LOGGING) {
     console.log(
       '\nStep 3: Determine differences between current release branch and previous release branch.' +
-        '\nCommits:'
+      '\nCommits:'
     );
   }
   var commits = shell
@@ -202,7 +202,7 @@ function getFilesChanged(commitNumber) {
 
 function getPackageHeaders(filesChanged) {
   var packageHeaders = new Set();
-  filesChanged.split(',').forEach(function(filePath) {
+  filesChanged.split(',').forEach(function (filePath) {
     var packageName = getPackageName(filePath);
     if (packageName) {
       packageHeaders.add(packageName);
@@ -229,7 +229,7 @@ function getPackageName(filePath) {
 function filterPackageNames(packageHeaders) {
   var filteredHeaders = new Set(packageHeaders);
   if (packageHeaders.has('salesforcedx-vscode-core')) {
-    packageHeaders.forEach(function(packageName) {
+    packageHeaders.forEach(function (packageName) {
       if (packageName != 'salesforcedx-vscode-core' && packageName != 'docs') {
         filteredHeaders.delete(packageName);
       }
@@ -241,7 +241,7 @@ function filterPackageNames(packageHeaders) {
 function filterExistingPREntries(parsedCommits) {
   var currentChangeLog = fs.readFileSync(CHANGE_LOG_PATH);
   var filteredResults = [];
-  parsedCommits.forEach(function(map) {
+  parsedCommits.forEach(function (map) {
     if (!currentChangeLog.includes('PR #' + map[PR_NUM])) {
       filteredResults.push(map);
     } else if (ADD_VERBOSE_LOGGING) {
@@ -258,8 +258,8 @@ function filterExistingPREntries(parsedCommits) {
 function getMessagesGroupedByPackage(parsedCommits) {
   var groupedMessages = {};
   var sortedMessages = {};
-  parsedCommits.forEach(function(map) {
-    map[PACKAGES].forEach(function(packageName) {
+  parsedCommits.forEach(function (map) {
+    map[PACKAGES].forEach(function (packageName) {
       var key = generateKey(packageName, map[TYPE]);
       if (key) {
         groupedMessages[key] = groupedMessages[key] || [];
@@ -271,7 +271,7 @@ function getMessagesGroupedByPackage(parsedCommits) {
   });
   Object.keys(groupedMessages)
     .sort()
-    .forEach(function(key) {
+    .forEach(function (key) {
       sortedMessages[key] = groupedMessages[key];
     });
   if (ADD_VERBOSE_LOGGING) {
@@ -302,17 +302,8 @@ function generateKey(packageName, type) {
   if (typesToIgnore.includes(type)) {
     return '';
   }
-  var key = packageName;
-  if (type) {
-    if (type == 'feat') {
-      key = 'Added|' + packageName;
-    } else {
-      key = 'Fixed|' + packageName;
-    }
-  } else {
-    key = 'Fixed|' + packageName; // If no type is specified, assume this is a fix.
-  }
-  return key;
+  const keyPrefix = type === 'feat' ? 'Added' : 'Fixed';
+  return `${keyPrefix}|${packageName}`;
 }
 
 function getChangeLogText(releaseBranch, groupedMessages) {
@@ -321,15 +312,14 @@ function getChangeLogText(releaseBranch, groupedMessages) {
     releaseBranch.toString().replace('origin/release/v', '')
   );
   var lastType = '';
-  Object.keys(groupedMessages).forEach(function(typeAndPackageName) {
-    var type = typeAndPackageName.split('|')[0];
-    var packageName = typeAndPackageName.split('|')[1];
+  Object.keys(groupedMessages).forEach(function (typeAndPackageName) {
+    var [type, packageName] = typeAndPackageName.split('|');
     if (!lastType || lastType != type) {
       changeLogText += util.format(TYPE_HEADER, type);
       lastType = type;
     }
     changeLogText += util.format(SECTION_HEADER, packageName);
-    groupedMessages[typeAndPackageName].forEach(function(message) {
+    groupedMessages[typeAndPackageName].forEach(function (message) {
       changeLogText += message;
     });
   });

--- a/scripts/change-log-generator.js
+++ b/scripts/change-log-generator.js
@@ -346,7 +346,9 @@ function writeChangeLog(textToInsert) {
 }
 
 function writeAdditionalInfo() {
-  console.log('\nStep 6: Write results to the change log.');
+  if (ADD_VERBOSE_LOGGING) {
+    console.log('\nStep 6: Write results to the change log.');
+  }
   console.log('Change log written to: ' + CHANGE_LOG_PATH);
   console.log('\nNext Steps:');
   console.log("  1) Remove entries that shouldn't be included in the release.");
@@ -364,7 +366,7 @@ let ADD_VERBOSE_LOGGING = process.argv.indexOf('-v') > -1 ? true : false;
 var releaseBranch = getReleaseBranch();
 var previousBranch = getPreviousReleaseBranch(releaseBranch);
 console.log(util.format(RELEASE_MESSAGE, releaseBranch, previousBranch));
-getNewChangeLogBranch(releaseBranch);
+// getNewChangeLogBranch(releaseBranch);
 
 var parsedCommits = parseCommits(getCommits(releaseBranch, previousBranch));
 var groupedMessages = getMessagesGroupedByPackage(parsedCommits);

--- a/scripts/change-log-generator.js
+++ b/scripts/change-log-generator.js
@@ -243,6 +243,7 @@ function filterExistingPREntries(parsedCommits) {
  */
 function getMessagesGroupedByPackage(parsedCommits) {
   var groupedMessages = {};
+  var sortedMessages = {};
   parsedCommits.forEach(function(map) {
     map[PACKAGES].forEach(function(packageName) {
       var key = generateKey(packageName, map[TYPE]);
@@ -258,7 +259,16 @@ function getMessagesGroupedByPackage(parsedCommits) {
     console.log('\nMessages grouped by package:');
     console.log(groupedMessages);
   }
-  return groupedMessages;
+  Object.keys(groupedMessages)
+    .sort()
+    .forEach(function(key) {
+      sortedMessages[key] = groupedMessages[key];
+    });
+  if (ADD_VERBOSE_LOGGING) {
+    console.log('\nSorted messages:');
+    console.log(sortedMessages);
+  }
+  return sortedMessages;
 }
 
 /**
@@ -299,6 +309,7 @@ function getChangeLogText(releaseBranch, groupedMessages) {
     LOG_HEADER,
     releaseBranch.toString().replace('origin/release/v', '')
   );
+  // TODO - want to sort the keys of the map. Right now Fixed/Added are in different places.
   Object.keys(groupedMessages).forEach(function(packageName) {
     changeLogText += util.format(SECTION_HEADER, packageName);
     groupedMessages[packageName].forEach(function(message) {

--- a/scripts/change-log-generator.js
+++ b/scripts/change-log-generator.js
@@ -53,7 +53,7 @@ const PR_ALREADY_EXISTS_ERROR =
   'Filtered PR number %s. An entry already exists in the changelog.';
 
 // Commit Map Keys
-const PR_NUM = 'PR NUM';
+const PR_NUM = 'PR_NUM';
 const COMMIT = 'COMMIT';
 const TYPE = 'TYPE';
 const MESSAGE = 'MESSAGE';
@@ -64,7 +64,7 @@ const PACKAGES = 'PACKAGES';
 const RELEASE_REGEX = new RegExp(/^origin\/release\/v\d{2}\.\d{1,2}\.\d/);
 const PR_REGEX = new RegExp(/(\(#\d+\))/);
 const COMMIT_REGEX = new RegExp(/^([\da-zA-Z]+)/);
-const TYPE_REGEX = new RegExp(/([a-zA-Z]+):/);
+const TYPE_REGEX = new RegExp(/([a-zA-Z]+(?:\([a-zA-Z]+\))?):/);
 
 /**
  * Checks if the user has provided a release branch override. If they

--- a/scripts/change-log-generator.js
+++ b/scripts/change-log-generator.js
@@ -366,7 +366,7 @@ let ADD_VERBOSE_LOGGING = process.argv.indexOf('-v') > -1 ? true : false;
 var releaseBranch = getReleaseBranch();
 var previousBranch = getPreviousReleaseBranch(releaseBranch);
 console.log(util.format(RELEASE_MESSAGE, releaseBranch, previousBranch));
-// getNewChangeLogBranch(releaseBranch);
+getNewChangeLogBranch(releaseBranch);
 
 var parsedCommits = parseCommits(getCommits(releaseBranch, previousBranch));
 var groupedMessages = getMessagesGroupedByPackage(parsedCommits);

--- a/scripts/change-log-generator.js
+++ b/scripts/change-log-generator.js
@@ -162,7 +162,8 @@ function buildMapFromCommit(commit) {
         map[TYPE] = type[1];
         message = message.replace(type[0], '');
       }
-      map[MESSAGE] = message.trim();
+      message = message.trim();
+      map[MESSAGE] = message.charAt(0).toUpperCase() + message.slice(1);
       map[FILES_CHANGED] = getFilesChanged(map[COMMIT]);
       map[PACKAGES] = getPackageHeaders(map[FILES_CHANGED]);
     }

--- a/scripts/change-log-generator.js
+++ b/scripts/change-log-generator.js
@@ -44,8 +44,7 @@ const CHANGE_LOG_BRANCH = 'changeLog-v';
 // Text Values
 const RELEASE_MESSAGE = 'Using Release Branch: %s\nPrevious Release Branch: %s';
 const LOG_HEADER = '# %s - Month DD, YYYY\n';
-const ADDED_HEADER = '\n\n## Added\n';
-const FIXED_HEADER = '\n## Fixed\n';
+const TYPE_HEADER = '\n## %s\n';
 const SECTION_HEADER = '\n#### %s\n';
 const MESSAGE_FORMAT =
   '\n- %s ([PR #%s](https://github.com/forcedotcom/salesforcedx-vscode/pull/%s))\n';
@@ -255,17 +254,13 @@ function getMessagesGroupedByPackage(parsedCommits) {
       }
     });
   });
-  if (ADD_VERBOSE_LOGGING) {
-    console.log('\nMessages grouped by package:');
-    console.log(groupedMessages);
-  }
   Object.keys(groupedMessages)
     .sort()
     .forEach(function(key) {
       sortedMessages[key] = groupedMessages[key];
     });
   if (ADD_VERBOSE_LOGGING) {
-    console.log('\nSorted messages:');
+    console.log('\nSorted messages by package name and type:');
     console.log(sortedMessages);
   }
   return sortedMessages;
@@ -309,10 +304,16 @@ function getChangeLogText(releaseBranch, groupedMessages) {
     LOG_HEADER,
     releaseBranch.toString().replace('origin/release/v', '')
   );
-  // TODO - want to sort the keys of the map. Right now Fixed/Added are in different places.
-  Object.keys(groupedMessages).forEach(function(packageName) {
+  var lastType = '';
+  Object.keys(groupedMessages).forEach(function(typeAndPackageName) {
+    var type = typeAndPackageName.split('|')[0];
+    var packageName = typeAndPackageName.split('|')[1];
+    if (!lastType || lastType != type) {
+      changeLogText += util.format(TYPE_HEADER, type);
+      lastType = type;
+    }
     changeLogText += util.format(SECTION_HEADER, packageName);
-    groupedMessages[packageName].forEach(function(message) {
+    groupedMessages[typeAndPackageName].forEach(function(message) {
       changeLogText += message;
     });
   });

--- a/scripts/change-log-generator.js
+++ b/scripts/change-log-generator.js
@@ -43,9 +43,9 @@ const CHANGE_LOG_BRANCH = 'changeLog-v';
 
 // Text Values
 const RELEASE_MESSAGE = 'Using Release Branch: %s\nPrevious Release Branch: %s';
-const LOG_HEADER =
-  '# %s - (INSERT RELEASE DATE [Month Day, Year])\n' +
-  '\n## Fixed\nMOVE ENTRIES FROM BELOW\n\n## Added\nMOVE ENTRIES FROM BELOW\n';
+const LOG_HEADER = '# %s - Month DD, YYYY\n';
+const FIXED_HEADER = '\n## Fixed\n';
+const ADDED_HEADER = '\n\n## Added\n';
 const SECTION_HEADER = '\n#### %s\n';
 const MESSAGE_FORMAT =
   '\n- %s ([PR #%s](https://github.com/forcedotcom/salesforcedx-vscode/pull/%s))\n';
@@ -71,7 +71,7 @@ const COMMIT_REGEX = new RegExp(/^([\da-zA-Z]+)/);
 function getReleaseBranch() {
   var releaseIndex = process.argv.indexOf('-r');
   var releaseBranch =
-    releaseIndex > -1
+    releaseIndex > -1 && process.argv[releaseIndex + 1]
       ? 'origin/release/v' + process.argv[releaseIndex + 1]
       : getReleaseBranches()[0];
   validateReleaseBranch(releaseBranch);


### PR DESCRIPTION
### What does this PR do?
1. Adds a task for calling the change log generator with the param options that the script accepts.
1. Adds the ability to automatically add commits following the new commitizen format into the Added/Fixed sections of the change log.
1. Adds the ability to automatically filter out certain commitizen types that are not customer facing. Currently the types to ignore include: chore, style, refactor, test, build, ci, and revert.
1. Adds clarity to the steps the change log generator is taking.

### What issues does this PR fix or reference?
@W-8115261@

### Functionality Before
Old change log results, along with verbose output from the script.
[CLG_OldChangeLog.txt](https://github.com/forcedotcom/salesforcedx-vscode/files/5269758/CLG_OldChangeLog.txt)
[CLG_VerboseResults.txt](https://github.com/forcedotcom/salesforcedx-vscode/files/5269759/CLG_VerboseResults.txt)

### Functionality After
New change log results, along with verbose output from the script.
[CLG_New_ChangelogResults.txt](https://github.com/forcedotcom/salesforcedx-vscode/files/5269766/CLG_New_ChangelogResults.txt)
[CLG_New_VerboseOutput.txt](https://github.com/forcedotcom/salesforcedx-vscode/files/5269767/CLG_New_VerboseOutput.txt). [Note that this result does not list Step 2 for changing the branch - this was commented out for testing purposes]