### PR TITLE
Lock down soql-builder-ui and soql-language-server versons while we iterate

### DIFF
--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -23,9 +23,7 @@
     "@salesforce/soql-builder-ui": "0.0.4",
     "@salesforce/soql-language-server": "^0.2.1",
     "debounce": "^1.2.0",
-    "immutable": "^3.8.2",
     "jsforce": "^1.10.0",
-    "rxjs": "^6.6.3",
     "vscode-extension-telemetry": "^0.1.6",
     "vscode-languageclient": "^6.1.3"
   },

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@salesforce/core": "^2.12.1",
     "@salesforce/soql-builder-ui": "0.0.4",
-    "@salesforce/soql-language-server": "^0.2.1",
+    "@salesforce/soql-language-server": "0.2.1",
     "debounce": "^1.2.0",
     "jsforce": "^1.10.0",
     "vscode-extension-telemetry": "^0.1.6",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -20,10 +20,12 @@
   ],
   "dependencies": {
     "@salesforce/core": "^2.12.1",
-    "@salesforce/soql-builder-ui": "^0.0.4",
+    "@salesforce/soql-builder-ui": "0.0.4",
     "@salesforce/soql-language-server": "^0.2.1",
     "debounce": "^1.2.0",
+    "immutable": "^3.8.2",
     "jsforce": "^1.10.0",
+    "rxjs": "^6.6.3",
     "vscode-extension-telemetry": "^0.1.6",
     "vscode-languageclient": "^6.1.3"
   },


### PR DESCRIPTION
### What does this PR do?
This PR will lock down the version of soql-builder-ui to version 0.0.4 and soql-language-server to 0.2.1.  This will prevent any unintended breakage to this repo while we are iterating quickly, moving things around, and **generally being quite volatile**.  

### What issues does this PR fix or reference?
None, it's a task.