### PR TITLE
test: fix core test suite not running due to WorkspaceContext initialization

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/util/apexLibraryExecutor.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/apexLibraryExecutor.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import { languages, ProgressLocation, window } from 'vscode';
 import * as vscode from 'vscode';
 import { channelService } from '../../channels';
-import { WorkspaceContext } from '../../context';
+import { workspaceContext } from '../../context';
 import { handleApexLibraryDiagnostics } from '../../diagnostics';
 import { notificationService } from '../../notifications';
 import { formatExecuteResult } from './apexLibraryResultFormatter';
@@ -29,7 +29,7 @@ export abstract class ApexLibraryExecutor extends LibraryCommandletExecutor<{}> 
   ): Promise<void> {
     this.executionName = execName;
     this.telemetryName = telemetryLogName;
-    const conn = await WorkspaceContext.get().getConnection();
+    const conn = await workspaceContext.getConnection();
     this.createService(conn);
   }
 

--- a/packages/salesforcedx-vscode-core/src/commands/util/deployRetrieveLibraryExecutor.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/deployRetrieveLibraryExecutor.ts
@@ -7,7 +7,7 @@
 import { ApiResult, SourceClient } from '@salesforce/source-deploy-retrieve';
 import { languages, ProgressLocation, window } from 'vscode';
 import { channelService } from '../../channels';
-import { WorkspaceContext } from '../../context';
+import { workspaceContext } from '../../context';
 import { notificationService } from '../../notifications';
 import { LibraryCommandletExecutor } from './libraryCommandlet';
 import { outputRetrieveTable } from './retrieveParser';
@@ -27,7 +27,7 @@ export class DeployRetrieveLibraryExecutor extends LibraryCommandletExecutor<
   ): Promise<void> {
     this.executionName = execName;
     this.telemetryName = telemetryLogName;
-    const conn = await WorkspaceContext.get().getConnection();
+    const conn = await workspaceContext.getConnection();
     this.sourceClient = new SourceClient(conn);
   }
 

--- a/packages/salesforcedx-vscode-core/src/context/index.ts
+++ b/packages/salesforcedx-vscode-core/src/context/index.ts
@@ -11,4 +11,6 @@ export {
   OrgType,
   setupWorkspaceOrgType
 } from './workspaceOrgType';
-export { WorkspaceContext, OrgInfo } from './workspaceContext';
+export { OrgInfo } from './workspaceContext';
+import { WorkspaceContext } from './workspaceContext';
+export const workspaceContext = WorkspaceContext.getInstance();

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -77,7 +77,7 @@ import {
 } from './commands/util';
 import { registerConflictView, setupConflictView } from './conflict';
 import { getDefaultUsernameOrAlias, setupWorkspaceOrgType } from './context';
-import { WorkspaceContext } from './context';
+import { workspaceContext } from './context';
 import * as decorators from './decorators';
 import { isDemoMode } from './modes/demo-mode';
 import { notificationService, ProgressNotification } from './notifications';
@@ -579,7 +579,7 @@ export async function activate(context: vscode.ExtensionContext) {
     sfdxProjectOpened
   );
 
-  await WorkspaceContext.initialize(context);
+  await workspaceContext.initialize(context);
 
   // register org picker commands
   const orgList = new OrgList();

--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -13,7 +13,7 @@ import { readFileSync } from 'fs';
 import * as path from 'path';
 import { isNullOrUndefined } from 'util';
 import * as vscode from 'vscode';
-import { OrgInfo, WorkspaceContext } from '../context';
+import { OrgInfo, workspaceContext } from '../context';
 import { nls } from '../messages';
 import { hasRootWorkspace, OrgAuthInfo } from '../util';
 
@@ -36,10 +36,10 @@ export class OrgList implements vscode.Disposable {
     this.statusBarItem.tooltip = nls.localize('status_bar_org_picker_tooltip');
     this.statusBarItem.show();
 
-    WorkspaceContext.get().onOrgChange((orgInfo: OrgInfo) =>
+    workspaceContext.onOrgChange((orgInfo: OrgInfo) =>
       this.displayDefaultUsername(orgInfo.alias || orgInfo.username)
     );
-    const { username, alias } = WorkspaceContext.get();
+    const { username, alias } = workspaceContext;
     this.displayDefaultUsername(alias || username);
   }
 

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDeploySourcePath.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDeploySourcePath.test.ts
@@ -16,7 +16,7 @@ import {
   ForceSourceDeploySourcePathExecutor,
   LibraryDeploySourcePathExecutor
 } from '../../../src/commands';
-import { WorkspaceContext } from '../../../src/context';
+import { workspaceContext } from '../../../src/context';
 import { nls } from '../../../src/messages';
 import { SfdxProjectConfig } from '../../../src/sfdxProject';
 import { OrgAuthInfo } from '../../../src/util';
@@ -67,7 +67,7 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
       sb.stub(OrgAuthInfo, 'getDefaultUsernameOrAlias').returns(
         testData.username
       );
-      sb.stub(WorkspaceContext.get(), 'getConnection').returns(mockConnection);
+      sb.stub(workspaceContext, 'getConnection').returns(mockConnection);
       const getNamespace = sb
         .stub(SfdxProjectConfig, 'getValue')
         .returns('diFf');

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveSourcePath.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveSourcePath.test.ts
@@ -21,7 +21,7 @@ import {
   LibraryRetrieveSourcePathExecutor,
   SourcePathChecker
 } from '../../../src/commands';
-import { WorkspaceContext } from '../../../src/context';
+import { workspaceContext } from '../../../src/context';
 import { nls } from '../../../src/messages';
 import { notificationService } from '../../../src/notifications';
 import {
@@ -152,7 +152,7 @@ describe('Source Retrieve Beta', () => {
     sb.stub(OrgAuthInfo, 'getDefaultUsernameOrAlias').returns(
       testData.username
     );
-    sb.stub(WorkspaceContext.get(), 'getConnection').returns(mockConnection);
+    sb.stub(workspaceContext, 'getConnection').returns(mockConnection);
     const getNamespace = sb.stub(SfdxProjectConfig, 'getValue').returns('diFf');
     const getComponentsStub = sb.stub(
       RegistryAccess.prototype,

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/apexLibraryExecutor.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/apexLibraryExecutor.test.ts
@@ -19,7 +19,7 @@ import {
   SfdxCommandlet
 } from '../../../../src/commands/util';
 import { ApexLibraryExecutor } from '../../../../src/commands/util';
-import { WorkspaceContext } from '../../../../src/context';
+import { workspaceContext } from '../../../../src/context';
 import { nls } from '../../../../src/messages';
 
 // tslint:disable:no-unused-expression
@@ -85,7 +85,7 @@ describe('ApexLibraryExecutor', () => {
 
   it('Should create connection on build phase', async () => {
     const orgAuthConnMock = sb
-      .stub(WorkspaceContext.get(), 'getConnection')
+      .stub(workspaceContext, 'getConnection')
       .returns(mockConnection);
 
     const commandlet = new class extends ApexLibraryExecutor {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/deployRetrieveLibraryExecutor.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/deployRetrieveLibraryExecutor.test.ts
@@ -98,7 +98,7 @@ describe('DeployRetrieveLibraryExecutor', () => {
       .stub(OrgAuthInfo, 'getDefaultUsernameOrAlias')
       .returns(undefined);
     // @ts-ignore just need subscriptions in extension context
-    workspaceContext.initialize({ subscriptions: [] });
+    await workspaceContext.initialize({ subscriptions: [] });
     const commandlet = new class extends DeployRetrieveLibraryExecutor {
       public async execute(response: ContinueResponse<{}>): Promise<void> {}
     }();

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/deployRetrieveLibraryExecutor.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/deployRetrieveLibraryExecutor.test.ts
@@ -20,7 +20,7 @@ import {
   SfdxCommandlet
 } from '../../../../src/commands/util';
 import { DeployRetrieveLibraryExecutor } from '../../../../src/commands/util/deployRetrieveLibraryExecutor';
-import { WorkspaceContext } from '../../../../src/context';
+import { workspaceContext } from '../../../../src/context';
 import { nls } from '../../../../src/messages';
 import { OrgAuthInfo } from '../../../../src/util';
 
@@ -83,7 +83,7 @@ describe('DeployRetrieveLibraryExecutor', () => {
 
   it('Should create connection on build phase', async () => {
     const getConnectionStub = sb
-      .stub(WorkspaceContext.get(), 'getConnection')
+      .stub(workspaceContext, 'getConnection')
       .returns(mockConnection);
     const commandlet = new class extends DeployRetrieveLibraryExecutor {
       public async execute(response: ContinueResponse<{}>): Promise<void> {}
@@ -97,6 +97,8 @@ describe('DeployRetrieveLibraryExecutor', () => {
     const orgAuthMock = sb
       .stub(OrgAuthInfo, 'getDefaultUsernameOrAlias')
       .returns(undefined);
+    // @ts-ignore just need subscriptions in extension context
+    workspaceContext.initialize({ subscriptions: [] });
     const commandlet = new class extends DeployRetrieveLibraryExecutor {
       public async execute(response: ContinueResponse<{}>): Promise<void> {}
     }();


### PR DESCRIPTION
### What does this PR do?

The test suite doesn't wait for extension activation to initialize, so when it was trying to access the instance of WorkspaceContext on start up it didn't run the suite at all since an error was thrown. This caused false positives in the autobuilds.