### PR TITLE
Mzeuli/fix property get undefined

### DIFF
--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -76,7 +76,7 @@ import {
   SfdxWorkspaceChecker
 } from './commands/util';
 import { registerConflictView, setupConflictView } from './conflict';
-import { getDefaultUsernameOrAlias, setupWorkspaceOrgType } from './context';
+import { getDefaultUsernameOrAlias } from './context';
 import { workspaceContext } from './context';
 import * as decorators from './decorators';
 import { isDemoMode } from './modes/demo-mode';
@@ -87,7 +87,7 @@ import { isSfdxProjectOpened } from './predicates';
 import { registerPushOrDeployOnSave, sfdxCoreSettings } from './settings';
 import { taskViewService } from './statuses';
 import { telemetryService } from './telemetry';
-import { hasRootWorkspace, isCLIInstalled } from './util';
+import { isCLIInstalled } from './util';
 import { OrgAuthInfo } from './util/authInfo';
 
 function registerCommands(
@@ -378,6 +378,9 @@ function registerCommands(
     forceFunctionStopCmd,
     forceOrgCreateCmd,
     forceOrgOpenCmd,
+    forceOrgDeleteDefaultCmd,
+    forceOrgDeleteUsernameCmd,
+    forceOrgListCleanCmd,
     forceSourceDeleteCmd,
     forceSourceDeleteCurrentFileCmd,
     forceSourceDeployCurrentSourceFileCmd,

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -83,6 +83,7 @@ import { isDemoMode } from './modes/demo-mode';
 import { notificationService, ProgressNotification } from './notifications';
 import { orgBrowser } from './orgBrowser';
 import { OrgList } from './orgPicker';
+import { isSfdxProjectOpened } from './predicates';
 import { registerPushOrDeployOnSave, sfdxCoreSettings } from './settings';
 import { taskViewService } from './statuses';
 import { telemetryService } from './telemetry';
@@ -550,14 +551,8 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   // Context
-  let sfdxProjectOpened = false;
-  if (hasRootWorkspace()) {
-    const files = await vscode.workspace.findFiles(
-      '**/sfdx-project.json',
-      '**/{node_modules,out}/**'
-    );
-    sfdxProjectOpened = files && files.length > 0;
-  }
+  const sfdxProjectOpened = isSfdxProjectOpened.apply(vscode.workspace).result;
+
   // TODO: move this and the replay debugger commands to the apex extension
   let replayDebuggerExtensionInstalled = false;
   if (
@@ -579,24 +574,19 @@ export async function activate(context: vscode.ExtensionContext) {
     sfdxProjectOpened
   );
 
-  await workspaceContext.initialize(context);
+  if (sfdxProjectOpened) {
+    await workspaceContext.initialize(context);
 
-  // register org picker commands
-  const orgList = new OrgList();
-  context.subscriptions.push(registerOrgPickerCommands(orgList));
+    // register org picker commands
+    const orgList = new OrgList();
+    context.subscriptions.push(registerOrgPickerCommands(orgList));
 
-  await setupOrgBrowser(context);
-  await setupConflictView(context);
+    await setupOrgBrowser(context);
+    await setupConflictView(context);
 
-  // Register filewatcher for push or deploy on save
-  await registerPushOrDeployOnSave();
-  // Commands
-  const commands = registerCommands(context);
-  context.subscriptions.push(commands);
-  context.subscriptions.push(registerConflictView());
+    // Register filewatcher for push or deploy on save
 
-  // Scratch Org Decorator
-  if (hasRootWorkspace()) {
+    await registerPushOrDeployOnSave();
     decorators.showOrg();
     decorators.monitorOrgConfigChanges();
 
@@ -605,6 +595,11 @@ export async function activate(context: vscode.ExtensionContext) {
       decorators.showDemoMode();
     }
   }
+
+  // Commands
+  const commands = registerCommands(context);
+  context.subscriptions.push(commands);
+  context.subscriptions.push(registerConflictView());
 
   const api: any = {
     channelService,


### PR DESCRIPTION
### What does this PR do?
Port of PR #2547 

Prevents the _core_ extension to initialise certain features when a non-Salesforce project is opened.

For reason beyond my comprehension the _salesforcedx-vscode-core_ extension gets activated even when there isn't a _sfdx-project.json_ file in the project folder.

It seems that this _workspaceContains_ clause is ignored:
```json
"activationEvents": [
    "workspaceContains:sfdx-project.json",
    "onCommand:sfdx.force.project.create",
    "onCommand:sfdx.force.project.with.manifest.create",
    "onCommand:sfdx.debug.isv.bootstrap"
  ],
```

When the _core_ extension activates then this code runs:
```ts
if (hasRootWorkspace()) {
    const files = await vscode.workspace.findFiles(
      '**/sfdx-project.json',
      '**/{node_modules,out}/**'
    );
    sfdxProjectOpened = files && files.length > 0;
  }
```

Which cause the extension's commands and features like _registerPushOrDeployOnSave_, _orgPicker_ to be enabled also for non-Salesforce project. It's sufficient to have the `node_modules` folder.

The _core_ extension now relies on the predicate _IsSfdxProjectOpen_ in order to activate Salesforce specific features.


### What issues does this PR fix or reference?
@W-8084765@, #2429