### PR TITLE
fix: store artifacts before pushing to marketplace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -430,10 +430,10 @@ jobs:
       - compile
       - package-extensions
       - updating-sha-for-publish
+      - stage-and-store-artifacts
       - run:
           name: 'Publishing to the VS Code Marketplace.'
           command: npm run vscode:publish
-      - stage-and-store-artifacts
       - run:
           name: 'Create git tag (e.g. v48.1.0) & push changes back to main branch'
           command: |


### PR DESCRIPTION
### What does this PR do?
Update the publish job so we store the generated artifacts (vsix files) before publishing to the marketplace. This will help in scenarios where publishing fails because of a connection issue but some of the artifacts were successfully published.

### What issues does this PR fix or reference?
@W-8257686@
