### PR TITLE
Rename 'Local dev server' commands

### DIFF
--- a/packages/salesforcedx-vscode-lwc/package.nls.json
+++ b/packages/salesforcedx-vscode-lwc/package.nls.json
@@ -1,6 +1,6 @@
 {
-  "force_lightning_lwc_start_text": "SFDX: Start LWC Code Preview server",
-  "force_lightning_lwc_stop_text": "SFDX: Stop LWC Code Preview server",
+  "force_lightning_lwc_start_text": "SFDX: Start LWC Code Preview Server",
+  "force_lightning_lwc_stop_text": "SFDX: Stop LWC Code Preview Server",
   "force_lightning_lwc_open_text": "SFDX: Open Code Preview Home",
   "force_lightning_lwc_preview_text": "SFDX: Preview Component",
   "force_lightning_lwc_test_view_name": "LWC Tests",

--- a/packages/salesforcedx-vscode-lwc/package.nls.json
+++ b/packages/salesforcedx-vscode-lwc/package.nls.json
@@ -1,8 +1,8 @@
 {
-  "force_lightning_lwc_start_text": "SFDX: Start Local Development Server",
-  "force_lightning_lwc_stop_text": "SFDX: Stop Local Development Server",
-  "force_lightning_lwc_open_text": "SFDX: Open Local Development Server",
-  "force_lightning_lwc_preview_text": "SFDX: Preview Component Locally",
+  "force_lightning_lwc_start_text": "SFDX: Start Component Preview",
+  "force_lightning_lwc_stop_text": "SFDX: Stop Component Preview",
+  "force_lightning_lwc_open_text": "SFDX: Open Component Preview",
+  "force_lightning_lwc_preview_text": "SFDX: Preview Component",
   "force_lightning_lwc_test_view_name": "LWC Tests",
   "force_lightning_lwc_test_run_all_tests_text": "SFDX: Run All Lightning Web Component Tests",
   "force_lightning_lwc_test_refresh_test_explorer_text": "SFDX: Refresh Lightning Web Component Test Explorer",

--- a/packages/salesforcedx-vscode-lwc/package.nls.json
+++ b/packages/salesforcedx-vscode-lwc/package.nls.json
@@ -1,7 +1,7 @@
 {
-  "force_lightning_lwc_start_text": "SFDX: Start Component Preview",
-  "force_lightning_lwc_stop_text": "SFDX: Stop Component Preview",
-  "force_lightning_lwc_open_text": "SFDX: Open Component Preview",
+  "force_lightning_lwc_start_text": "SFDX: Start LWC Code Preview server",
+  "force_lightning_lwc_stop_text": "SFDX: Stop LWC Code Preview server",
+  "force_lightning_lwc_open_text": "SFDX: Open Code Preview Home",
   "force_lightning_lwc_preview_text": "SFDX: Preview Component",
   "force_lightning_lwc_test_view_name": "LWC Tests",
   "force_lightning_lwc_test_run_all_tests_text": "SFDX: Run All Lightning Web Component Tests",

--- a/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
@@ -18,7 +18,7 @@
 export const messages = {
   command_failure: '%s failed to run.',
   command_canceled: '%s was canceled.',
-  force_lightning_lwc_start_text: 'SFDX: Start LWC Code Preview server',
+  force_lightning_lwc_start_text: 'SFDX: Start LWC Code Preview Server',
   force_lightning_lwc_start_not_found:
     'To run this command, install the @salesforce/lwc-dev-server plugin. For more info, see [https://developer.salesforce.com/docs/component-library/documentation/lwc/lwc.get_started_local_dev](https://developer.salesforce.com/docs/component-library/documentation/lwc/lwc.get_started_local_dev).',
   force_lightning_lwc_start_addr_in_use:
@@ -31,10 +31,10 @@ export const messages = {
     'The local development server exited unexpectedly with code %s.',
   force_lightning_lwc_start_already_running:
     'The local development server is already running.',
-  force_lightning_lwc_stop_text: 'SFDX: Stop LWC Code Preview server',
+  force_lightning_lwc_stop_text: 'SFDX: Stop LWC Code Preview Server',
   force_lightning_lwc_stop_not_running:
     'The local development server is not running.',
-  force_lightning_lwc_stop_in_progress: 'Stopping local development server',
+  force_lightning_lwc_stop_in_progress: 'Stopping local development Server',
   force_lightning_lwc_preview_text: 'SFDX: Preview Component Locally',
   force_lightning_lwc_preview_file_undefined:
     "Can't find the Lightning Web Components module. Check that %s is the correct file path.",

--- a/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
@@ -34,7 +34,7 @@ export const messages = {
   force_lightning_lwc_stop_text: 'SFDX: Stop LWC Code Preview Server',
   force_lightning_lwc_stop_not_running:
     'The local development server is not running.',
-  force_lightning_lwc_stop_in_progress: 'Stopping local development Server',
+  force_lightning_lwc_stop_in_progress: 'Stopping LWC Code Preview Server',
   force_lightning_lwc_preview_text: 'SFDX: Preview Component Locally',
   force_lightning_lwc_preview_file_undefined:
     "Can't find the Lightning Web Components module. Check that %s is the correct file path.",

--- a/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
@@ -18,7 +18,7 @@
 export const messages = {
   command_failure: '%s failed to run.',
   command_canceled: '%s was canceled.',
-  force_lightning_lwc_start_text: 'SFDX: Start Local Development Server',
+  force_lightning_lwc_start_text: 'SFDX: Start LWC Code Preview server',
   force_lightning_lwc_start_not_found:
     'To run this command, install the @salesforce/lwc-dev-server plugin. For more info, see [https://developer.salesforce.com/docs/component-library/documentation/lwc/lwc.get_started_local_dev](https://developer.salesforce.com/docs/component-library/documentation/lwc/lwc.get_started_local_dev).',
   force_lightning_lwc_start_addr_in_use:
@@ -31,7 +31,7 @@ export const messages = {
     'The local development server exited unexpectedly with code %s.',
   force_lightning_lwc_start_already_running:
     'The local development server is already running.',
-  force_lightning_lwc_stop_text: 'SFDX: Stop Local Development Server',
+  force_lightning_lwc_stop_text: 'SFDX: Stop LWC Code Preview server',
   force_lightning_lwc_stop_not_running:
     'The local development server is not running.',
   force_lightning_lwc_stop_in_progress: 'Stopping local development server',
@@ -43,7 +43,7 @@ export const messages = {
   force_lightning_lwc_preview_unsupported:
     "Something's not right with the filepath. The local development server doesn't recognize the Lightning Web Components module '%s.'",
   force_lightning_lwc_open_text:
-    'SFDX: Open Local Development Server in Browser',
+    'SFDX: Open Code Preview Home',
   prompt_option_open_browser: 'Open Browser',
   prompt_option_restart: 'Restart',
   force_lwc_test_run_description_text: 'Run LWC test(s)',

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/commandUtils.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/commandUtils.test.ts
@@ -26,7 +26,7 @@ describe('command utilities', () => {
       showError(
         new Error('test error message'),
         'force_lightning_lwc_start_test',
-        'SFDX: Start Local Development Server'
+        'SFDX: Start LWC Code Preview server'
       );
 
       sinon.assert.calledOnce(spy);
@@ -45,13 +45,13 @@ describe('command utilities', () => {
       showError(
         new Error('test error message'),
         'force_lightning_lwc_start_test',
-        'SFDX: Start Local Development Server'
+        'SFDX: Start LWC Code Preview server'
       );
 
       sinon.assert.calledTwice(spy);
       sinon.assert.calledWith(
         spy,
-        sinon.match('SFDX: Start Local Development Server')
+        sinon.match('SFDX: Start LWC Code Preview server')
       );
 
       spy.restore();
@@ -63,7 +63,7 @@ describe('command utilities', () => {
       showError(
         new Error('test error message'),
         'force_lightning_lwc_start_test',
-        'SFDX: Start Local Development Server'
+        'SFDX: Start LWC Code Preview server'
       );
 
       sinon.assert.calledOnce(spy);
@@ -78,7 +78,7 @@ describe('command utilities', () => {
       showError(
         new Error('test error message'),
         'force_lightning_lwc_start_test',
-        'SFDX: Start Local Development Server'
+        'SFDX: Start LWC Code Preview server'
       );
 
       sinon.assert.calledOnce(spy);

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/commandUtils.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/commandUtils.test.ts
@@ -23,7 +23,7 @@ describe('command utilities', () => {
       showError(
         new Error('test error message'),
         'force_lightning_lwc_start_test',
-        'SFDX: Start LWC Code Preview server'
+        'SFDX: Start LWC Code Preview Server'
       );
 
       sinon.assert.calledOnce(spy);
@@ -42,13 +42,13 @@ describe('command utilities', () => {
       showError(
         new Error('test error message'),
         'force_lightning_lwc_start_test',
-        'SFDX: Start LWC Code Preview server'
+        'SFDX: Start LWC Code Preview Server'
       );
 
       sinon.assert.calledTwice(spy);
       sinon.assert.calledWith(
         spy,
-        sinon.match('SFDX: Start LWC Code Preview server')
+        sinon.match('SFDX: Start LWC Code Preview Server')
       );
 
       spy.restore();
@@ -60,7 +60,7 @@ describe('command utilities', () => {
       showError(
         new Error('test error message'),
         'force_lightning_lwc_start_test',
-        'SFDX: Start LWC Code Preview server'
+        'SFDX: Start LWC Code Preview Server'
       );
 
       sinon.assert.calledOnce(spy);
@@ -75,7 +75,7 @@ describe('command utilities', () => {
       showError(
         new Error('test error message'),
         'force_lightning_lwc_start_test',
-        'SFDX: Start LWC Code Preview server'
+        'SFDX: Start LWC Code Preview Server'
       );
 
       sinon.assert.calledOnce(spy);


### PR DESCRIPTION
### What does this PR do?
This PR is renaming 'Local development server' with 'Component Preview'

### What issues does this PR fix or reference?
 @W-8247907@
