### PR TITLE
fix: clear deploy diagnostics

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployCommand.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployCommand.ts
@@ -76,6 +76,7 @@ export abstract class BaseDeployExecutor extends SfdxCommandletExecutor<
       this.logMetric(execution.command.logName, startTime, properties);
 
       try {
+        BaseDeployExecutor.errorCollection.clear();
         if (stdOut) {
           const deployParser = new ForceDeployResultParser(stdOut);
           const errors = deployParser.getErrors();
@@ -87,12 +88,11 @@ export abstract class BaseDeployExecutor extends SfdxCommandletExecutor<
               execFilePathOrPaths,
               BaseDeployExecutor.errorCollection
             );
-          } else {
-            BaseDeployExecutor.errorCollection.clear();
           }
           this.outputResult(deployParser);
         }
       } catch (e) {
+        BaseDeployExecutor.errorCollection.clear();
         if (e.name !== 'DeployParserFail') {
           e.message =
             'Error while creating diagnostics for vscode problem view.';

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploySourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploySourcePath.ts
@@ -138,9 +138,6 @@ export class LibraryDeploySourcePathExecutor extends LibraryCommandletExecutor<
 > {
   protected executionName = 'Deploy (Beta)';
   protected logName = 'force_source_deploy_with_sourcepath_beta';
-  /* private diagnostics = vscode.languages.createDiagnosticCollection(
-    'deploy-errors'
-  ); */
 
   public async run(
     response: ContinueResponse<string | string[]>

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploySourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploySourcePath.ts
@@ -138,9 +138,9 @@ export class LibraryDeploySourcePathExecutor extends LibraryCommandletExecutor<
 > {
   protected executionName = 'Deploy (Beta)';
   protected logName = 'force_source_deploy_with_sourcepath_beta';
-  private diagnostics = vscode.languages.createDiagnosticCollection(
+  /* private diagnostics = vscode.languages.createDiagnosticCollection(
     'deploy-errors'
-  );
+  ); */
 
   public async run(
     response: ContinueResponse<string | string[]>
@@ -161,18 +161,17 @@ export class LibraryDeploySourcePathExecutor extends LibraryCommandletExecutor<
       const parser = new LibraryDeployResultParser(result);
       const outputResult = parser.resultParser(result);
       channelService.appendLine(outputResult);
-
+      BaseDeployExecutor.errorCollection.clear();
       if (
         result.status === DeployStatus.Succeeded ||
         result.status === ToolingDeployStatus.Completed
       ) {
-        this.diagnostics.clear();
         return true;
       }
 
       handleDeployRetrieveLibraryDiagnostics(
         result,
-        this.diagnostics
+        BaseDeployExecutor.errorCollection
       );
 
       return false;


### PR DESCRIPTION
### What does this PR do?
Fixes different issues with clearing diagnostics for deploy operations:
- Clear diagnostics before parsing deploy results
- Clear diagnostics in case there was an error parsing deploy results
- Use the same diagnostics collection between CLI and Library implementation so diagnostics can be cleared correctly regardless of which path created the diagnostics

### What issues does this PR fix or reference?
#2608, @W-8266770@
