### PR TITLE
chore: add additional slack messages for post publish steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -443,6 +443,14 @@ jobs:
       - sfchangecase/update:
           location: REPO_LOCATION
           release: GUS_RELEASE
+      - slack/notify:
+          channel: 'pdt_releases'
+          color: '#9bcd9b'
+          message: 'VSCode Extensions v${RELEASE_VERSION} have been published to the marketplace'
+      - slack/notify:
+          channel: 'pdt_releases'
+          color: '#9bcd9b'
+          message: 'VSCode Extensions v${RELEASE_VERSION} Post Publish - Merging main into develop'
       - run:
           name: 'Merge changes from main back into develop'
           command: |
@@ -453,7 +461,7 @@ jobs:
       - slack/notify:
           channel: 'pdt_releases'
           color: '#9bcd9b'
-          message: 'VSCode Extensions v${RELEASE_VERSION} have been published to the marketplace'
+          message: 'VSCode Extensions v${RELEASE_VERSION} Post Publish - Succeeded'
       - slack/status:
           channel: 'pdt_releases'
           fail_only: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -456,7 +456,7 @@ jobs:
           command: |
             git checkout develop
             git pull
-            git merge main
+            git merge main --commit --no-edit
             git push origin develop
       - slack/notify:
           channel: 'pdt_releases'


### PR DESCRIPTION
### What does this PR do?
In order to clarify when there is a post merge issue vs. a publishing issue, this change adds additional messaging to the slack output.

### What issues does this PR fix or reference?
@W-8290541@
