### PR TITLE
feat(soql): soql grammar moved to apex-tmlanguage repo

### DIFF
--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -20,6 +20,7 @@
     "Programming Languages"
   ],
   "dependencies": {
+    "@salesforce/apex-tmlanguage": "1.5.0",
     "@salesforce/core": "2.12.1",
     "@salesforce/soql-builder-ui": "0.0.21",
     "@salesforce/soql-data-view": "0.0.5",
@@ -102,7 +103,7 @@
       {
         "language": "soql",
         "scopeName": "source.soql",
-        "path": "./node_modules/@salesforce/soql-tmlanguage/grammars/soql.tmLanguage.json"
+        "path": "./node_modules/@salesforce/apex-tmlanguage/grammars/soql.tmLanguage"
       }
     ]
   }


### PR DESCRIPTION
### What does this PR do?

Read soql TextMate grammar file from `apex-tmlanguage` package (instead of `soql-tmlanguage`).

### What issues does this PR fix or reference?
@W-8179607@

