### PR TITLE
feat(soql): only activate with sfdx project

### DIFF
--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -70,8 +70,7 @@
     "vscode:package": "vsce package"
   },
   "activationEvents": [
-    "onCustomEditor:soqlCustom.soql",
-    "onLanguage:soql"
+    "workspaceContains:sfdx-project.json"
   ],
   "main": "./out/src",
   "contributes": {
@@ -84,7 +83,7 @@
             "filenamePattern": "*.soql"
           }
         ],
-        "priority": "default"
+        "priority": "option"
       }
     ],
     "languages": [


### PR DESCRIPTION
### What does this PR do?
This PR will activate the SOQL extension only if there is a `sfdx-project.json` present in the workspace, just like the rest of the Salesforce extensions. This PR will also change the priority of our custom editor to `option`, that means that when a user clicks on a `.soql` file they will see the text document by default and have to take extra steps to see the SOQL Builder UI.

### What issues does this PR fix or reference?
@W-8253044@

### Functionality Before
SOQL Extension would activate and open any time a user clicks on a .soql file

### Functionality After
The SOQL Extension will only activate if there is an `sfdx-project.json` in the root of the workspace. The users will also see the text document by default instead of the builder UI.
