### PR TITLE
fix: debug log list in descending order

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -25,7 +25,7 @@
     "Other"
   ],
   "dependencies": {
-    "@salesforce/apex-node": "0.1.2",
+    "@salesforce/apex-node": "0.1.4",
     "@salesforce/core": "2.11.0",
     "@salesforce/salesforcedx-utils-vscode": "50.4.0",
     "@salesforce/schemas": "^1",


### PR DESCRIPTION
### What does this PR do?
Fixes the order in which debug log list is returned.

### What issues does this PR fix or reference?
@W-8331099@, #2698

### Before
<img width="614" alt="log-list-before" src="https://user-images.githubusercontent.com/1041842/98309654-d92f5e80-1f7f-11eb-872e-77f82cff3118.png">

### After 
<img width="618" alt="log-list-after" src="https://user-images.githubusercontent.com/1041842/98309666-e0566c80-1f7f-11eb-8a0f-dd278e77d971.png">


