### PR TITLE
chore: update post publish job for merging (@W-8290541)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,6 +128,7 @@ commands:
             git config credential.helper 'cache --timeout=<< parameters.cache_timeout >>'
             git config user.email "<< parameters.gh_email >>"
             git config user.name "<< parameters.gh_username >>"
+            git config --global pull.rebase true
 
   install:
     description: 'Installing dependencies'
@@ -455,7 +456,7 @@ jobs:
           name: 'Merge changes from main back into develop'
           command: |
             git checkout develop
-            git pull --rebase
+            git pull
             git merge main --commit --no-edit
             git push origin develop
       - slack/notify:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -449,8 +449,8 @@ jobs:
           message: 'VSCode Extensions v${RELEASE_VERSION} have been published to the marketplace'
       - slack/notify:
           channel: 'pdt_releases'
-          color: '#9bcd9b'
-          message: 'VSCode Extensions v${RELEASE_VERSION} Post Publish - Merging main into develop'
+          color: '#FFDEAD'
+          message: 'VSCode Extensions v${RELEASE_VERSION} Post Publish - Starting merge of main into develop'
       - run:
           name: 'Merge changes from main back into develop'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -455,7 +455,7 @@ jobs:
           name: 'Merge changes from main back into develop'
           command: |
             git checkout develop
-            git pull
+            git pull --rebase
             git merge main --commit --no-edit
             git push origin develop
       - slack/notify:


### PR DESCRIPTION
### What does this PR do?
1. Changes color for start of the merge of main back into develop. This is to help indicate that it is in progress.
1. Added suggestion from CircleCi support to resolve the error:

> error: Terminal is dumb, but EDITOR unset
> Not committing merge; use 'git commit' to complete the merge.
> 

### What issues does this PR fix or reference?
@W-8290541@

Example Failure:
https://app.circleci.com/pipelines/github/forcedotcom/salesforcedx-vscode/2842/workflows/d69adcc2-687a-418f-8bf6-1c26014d0b73/jobs/14623