### PR TITLE
JHork: Show api error when running query

### DIFF
--- a/packages/salesforcedx-vscode-soql/src/editor/queryRunner.ts
+++ b/packages/salesforcedx-vscode-soql/src/editor/queryRunner.ts
@@ -24,10 +24,7 @@ export class QueryRunner {
       };
       return cleanQueryData;
     } catch (error) {
-      // TODO: i18n
-      vscode.window.showErrorMessage(
-        `Your query contains invalid or incomplete syntax. Fix the syntax errors and try again.`
-      );
+      vscode.window.showErrorMessage(`${error.name}:  ${error.message}`);
       throw error;
     }
   }


### PR DESCRIPTION
### What does this PR do?
This PR will surface the error `name` and `message` returned by the REST API to the user when running an soql query.

There is a plan to address the root cause of some errors, such as showing fields that can not be queried, or to display the errors in a prettier way post beta.

This PR will provide a better UX to help address issues [52](https://github.com/forcedotcom/soql-tooling/issues/52), [82](https://github.com/forcedotcom/soql-tooling/issues/82), [83](https://github.com/forcedotcom/soql-tooling/issues/83), [86](https://github.com/forcedotcom/soql-tooling/issues/86) in the forcedotcom/soql-tooling repo.

### What issues does this PR fix or reference?
@W-8393352@

### Functionality Before

![image](https://user-images.githubusercontent.com/25188632/99123754-128a4e80-25be-11eb-9ac6-7bc48983c8fb.png)


### Functionality After
Issues [86](https://github.com/forcedotcom/soql-tooling/issues/86) and [52](https://github.com/forcedotcom/soql-tooling/issues/52):
<img width="1761" alt="Screen Shot 2020-11-13 at 1 42 08 PM" src="https://user-images.githubusercontent.com/25188632/99123784-203fd400-25be-11eb-8318-994cdcc92111.png">

Issue [82](https://github.com/forcedotcom/soql-tooling/issues/82)
<img width="1761" alt="Screen Shot 2020-11-13 at 1 41 07 PM" src="https://user-images.githubusercontent.com/25188632/99123921-685ef680-25be-11eb-960c-c74cd6d9e8e2.png">

Issue [83](https://github.com/forcedotcom/soql-tooling/issues/83)
<img width="1761" alt="Screen Shot 2020-11-13 at 2 44 42 PM" src="https://user-images.githubusercontent.com/25188632/99124135-d73c4f80-25be-11eb-9b76-462741b41ce0.png">

