### PR TITLE
Remote SOQL Errors - Language Client Part

### DIFF
--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -38,7 +38,7 @@
     "@salesforce/salesforcedx-utils-vscode": "50.8.0",
     "@salesforce/soql-builder-ui": "0.0.23",
     "@salesforce/soql-data-view": "0.0.7",
-    "@salesforce/soql-language-server": "0.2.7",
+    "@salesforce/soql-language-server": "0.2.8",
     "debounce": "^1.2.0",
     "jsforce": "^1.10.0",
     "papaparse": "^5.3.0",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -43,7 +43,8 @@
     "jsforce": "^1.10.0",
     "papaparse": "^5.3.0",
     "vscode-extension-telemetry": "^0.1.6",
-    "vscode-languageclient": "^6.1.3"
+    "vscode-languageclient": "6.1.3",
+    "vscode-languageserver-protocol": "3.15.3"
   },
   "devDependencies": {
     "@salesforce/salesforcedx-test-utils-vscode": "50.8.0",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -38,7 +38,7 @@
     "@salesforce/salesforcedx-utils-vscode": "50.8.0",
     "@salesforce/soql-builder-ui": "0.0.23",
     "@salesforce/soql-data-view": "0.0.7",
-    "@salesforce/soql-language-server": "0.2.8",
+    "@salesforce/soql-language-server": "0.2.9",
     "debounce": "^1.2.0",
     "jsforce": "^1.10.0",
     "papaparse": "^5.3.0",

--- a/packages/salesforcedx-vscode-soql/src/client/client.ts
+++ b/packages/salesforcedx-vscode-soql/src/client/client.ts
@@ -27,7 +27,7 @@ const workspaceContext = sfdxCoreExtension?.exports?.workspaceContext;
 let client: LanguageClient;
 
 export function clearDiagnostics(): void {
-  client.diagnostics?.clear();
+  client?.diagnostics?.clear();
 }
 
 export async function startLanguageClient(

--- a/packages/salesforcedx-vscode-soql/src/client/client.ts
+++ b/packages/salesforcedx-vscode-soql/src/client/client.ts
@@ -75,23 +75,25 @@ export async function startLanguageClient(
   // Start the client. This will also launch the server
   client.start();
 
-  await client.onReady().then(() => {
-    client.onRequest(RequestTypes.RunQuery, async (queryText: string) => {
-      try {
-        const conn = await workspaceContext.getConnection();
-        const queryData = await new QueryRunner(conn).runQuery(queryText, {
-          showErrors: false
-        });
-        return { result: queryData };
-      } catch (e) {
-        const error = {
+  await client.onReady();
+  client.onRequest(RequestTypes.RunQuery, async (queryText: string) => {
+    try {
+      const conn = await workspaceContext.getConnection();
+      const queryData = await new QueryRunner(conn).runQuery(queryText, {
+        showErrors: false
+      });
+      return { result: queryData };
+    } catch (e) {
+      // NOTE: The return value must be serializable, for JSON-RPC.
+      // Thus we cannot include the exception object as-is
+      return {
+        error: {
           name: e.name,
           errorCode: e.errorCode,
           message: e.message
-        };
-        return { error };
-      }
-    });
+        }
+      };
+    }
   });
 }
 

--- a/packages/salesforcedx-vscode-soql/src/editor/queryRunner.ts
+++ b/packages/salesforcedx-vscode-soql/src/editor/queryRunner.ts
@@ -13,7 +13,10 @@ import * as vscode from 'vscode';
 export class QueryRunner {
   constructor(private connection: Connection) {}
 
-  public async runQuery(queryText: string): Promise<QueryResult<JsonMap>> {
+  public async runQuery(
+    queryText: string,
+    options = { showErrors: true }
+  ): Promise<QueryResult<JsonMap>> {
     try {
       const rawQueryData = (await this.connection.query(
         queryText
@@ -24,7 +27,10 @@ export class QueryRunner {
       };
       return cleanQueryData;
     } catch (error) {
-      vscode.window.showErrorMessage(`${error.name}:  ${error.message}`);
+      // TODO: i18n
+      if (options.showErrors) {
+        vscode.window.showErrorMessage(`${error.message}`);
+      }
       throw error;
     }
   }

--- a/packages/salesforcedx-vscode-soql/src/index.ts
+++ b/packages/salesforcedx-vscode-soql/src/index.ts
@@ -11,12 +11,14 @@ import { SOQLEditorProvider } from './editor/soqlEditorProvider';
 import { QueryDataViewService } from './queryDataView/queryDataViewService';
 import { startTelemetry, stopTelemetry } from './telemetry';
 
-export function activate(context: vscode.ExtensionContext): void {
+export async function activate(
+  context: vscode.ExtensionContext
+): Promise<void> {
   console.log('SOQL Extension Activated');
   const extensionHRStart = process.hrtime();
   context.subscriptions.push(SOQLEditorProvider.register(context));
   QueryDataViewService.register(context);
-  startLanguageClient(context);
+  await startLanguageClient(context);
   startTelemetry(context, extensionHRStart).catch();
 }
 

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/client/client.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/client/client.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from 'chai';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import { extensions, languages, Uri, window, workspace } from 'vscode';
+import { clearDiagnostics } from '../../../src/client/client';
+import { QueryRunner } from '../../../src/editor/queryRunner';
+
+async function sleep(ms: number = 0) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function waitUntil(predicate: () => boolean) {
+  return new Promise(async resolve => {
+    let notFound = true;
+    while (notFound) {
+      await sleep(0);
+      notFound = !predicate();
+    }
+    resolve();
+  });
+}
+
+describe('SOQL language client', () => {
+  let sandbox: sinon.SinonSandbox;
+  let workspacePath: string;
+  let soqlFileUri: Uri;
+  const encoder = new TextEncoder();
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    workspacePath = workspace.workspaceFolders![0].uri.fsPath;
+    soqlFileUri = Uri.file(path.join(workspacePath, 'test.soql'));
+    const ext = extensions.getExtension('salesforce.salesforcedx-vscode-soql')!;
+    await ext.activate();
+    clearDiagnostics();
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+    await workspace.fs.delete(soqlFileUri);
+  });
+
+  it('should show diagnostics for syntax error', async () => {
+    await workspace.fs.writeFile(
+      soqlFileUri,
+      encoder.encode(`
+      SELECT Id
+      FRM Account
+    `)
+    );
+    await window.showTextDocument(soqlFileUri);
+
+    const diagnostics = languages.getDiagnostics(soqlFileUri);
+    expect(diagnostics)
+      .to.be.an('array')
+      .to.have.lengthOf(1);
+    expect(diagnostics[0].message).to.equal(`missing 'from' at 'Account'`);
+  });
+
+  it('should create diagnostics based off of limit 0 execute error results', async () => {
+    const expectedError = `SELECT Ids FROM ACCOUNT\nERROR at Row:1:Column:8\nSome error at 'Ids'`;
+    await workspace.fs.writeFile(
+      soqlFileUri,
+      encoder.encode(`
+      SELECT Ids
+      FROM Account
+    `)
+    );
+    sinon.stub(QueryRunner.prototype, 'runQuery').callsFake(async () => {
+      throw {
+        name: 'INVALID_FIELD',
+        errorCode: 'INVALID_FIELD',
+        message: expectedError
+      };
+    });
+
+    await window.showTextDocument(soqlFileUri);
+
+    await waitUntil(() => {
+      return languages.getDiagnostics(soqlFileUri).length > 0;
+    });
+    const diagnostics = languages.getDiagnostics(soqlFileUri);
+    expect(diagnostics)
+      .to.be.an('array')
+      .to.have.lengthOf(1);
+    expect(diagnostics[0].message).to.equal(expectedError);
+    expect(diagnostics[0].range.start.line).to.equal(0, 'range start line');
+    expect(diagnostics[0].range.start.character).to.equal(
+      7,
+      'range start char'
+    );
+    expect(diagnostics[0].range.end.line).to.equal(0, 'range end line');
+    expect(diagnostics[0].range.end.character).to.equal(10, 'range end char');
+  });
+});

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/client/client.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/client/client.test.ts
@@ -26,7 +26,7 @@ async function sleep(ms: number = 0) {
 }
 
 function waitUntil(predicate: () => boolean) {
-  return new Promise(async resolve => {
+  return new Promise<void>(async resolve => {
     let notFound = true;
     let tries = 5;
     while (notFound || tries-- > 0) {


### PR DESCRIPTION
[W-7977000](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07B0000008ULb1IAG)

Dependent on https://github.com/forcedotcom/soql-tooling/pull/93

### What does this PR do?

Handles `runQuery` requests from the SOQL language server. This will run the query unmodified and return the result to the LS. The LS may then validate and add diagnostic messages.
