### PR TITLE
Updated Git2Gus to assign WI to SOQLBuilder product tag (web tools) instead of SOQL (dev tools)

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -20,7 +20,7 @@
     "area:aura": "a1aB0000000MRAzIAO",
     "area:lwc": "a1aB0000000Bn8tIAC",
     "area:slds": "a1aB000000005G3IAI",
-    "area:soql": "a1aB000000005G3IAI",
+    "area:soql": "a1aB0000000YKFSIA4",
     "area:visualforce": "a1aB0000000BPyKIAW",
     "area:xml": "a1aB0000000BPyKIAW"
   },


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @<Insert GUS WI>@

### Functionality Before
<insert gif and/or summary>

### Functionality After
<insert gif and/or summary>
