### PR TITLE
docs: add license note for interactive debugger

### DIFF
--- a/docs/_articles/en/apex/interactive-debugger.md
+++ b/docs/_articles/en/apex/interactive-debugger.md
@@ -18,7 +18,7 @@ To debug subscribers’ sandbox orgs, use [ISV Customer Debugger](./en/apex/isv-
 
 The first time that you use Apex Debugger in VS Code, complete these setup steps.
 
-Note: You can use the default license provided to License Management orgs only with the [ISV Customer Debugger](./en/apex/isv-debugger) to debug subscriber orgs. If you don't have an Apex Debugger license, use the [Replay Debugger](./en/apex/isv-debugger).
+Note: You can use the default license provided to License Management orgs only with the [ISV Customer Debugger](./en/apex/isv-debugger) to debug subscriber orgs. If you don't have an [Apex Debugger license](https://help.salesforce.com/articleView?id=000314082&type=1&mode=1), use the [Replay Debugger](./en/apex/isv-debugger).
 
 1. Add the `DebugApex` feature to the scratch org definition files for all the types of scratch orgs that you plan to debug:  
    `"features": "DebugApex"`

--- a/docs/_articles/en/apex/interactive-debugger.md
+++ b/docs/_articles/en/apex/interactive-debugger.md
@@ -18,7 +18,7 @@ To debug subscribers’ sandbox orgs, use [ISV Customer Debugger](./en/apex/isv-
 
 The first time that you use Apex Debugger in VS Code, complete these setup steps.
 
-Note that you will need to have the appropriate debugger license. The default license provided to License Management orgs can only be used with the [ISV Customer Debugger](./en/apex/isv-debugger) to debug Subscriber orgs. If you do not have the appropriate license, please consider using the [Replay Debugger](./en/apex/isv-debugger).
+Note: You can use the default license provided to License Management orgs only with the [ISV Customer Debugger](./en/apex/isv-debugger) to debug subscriber orgs. If you don't have an Apex Debugger license, use the [Replay Debugger](./en/apex/isv-debugger).
 
 1. Add the `DebugApex` feature to the scratch org definition files for all the types of scratch orgs that you plan to debug:  
    `"features": "DebugApex"`

--- a/docs/_articles/en/apex/interactive-debugger.md
+++ b/docs/_articles/en/apex/interactive-debugger.md
@@ -18,6 +18,8 @@ To debug subscribers’ sandbox orgs, use [ISV Customer Debugger](./en/apex/isv-
 
 The first time that you use Apex Debugger in VS Code, complete these setup steps.
 
+Note that you will need to have the appropriate debugger license. The default license provided to License Management orgs can only be used with the [ISV Customer Debugger](./en/apex/isv-debugger) to debug Subscriber orgs. If you do not have the appropriate license, please consider using the [Replay Debugger](./en/apex/isv-debugger).
+
 1. Add the `DebugApex` feature to the scratch org definition files for all the types of scratch orgs that you plan to debug:  
    `"features": "DebugApex"`
 1. In VS Code, run **SFDX: Create a Default Scratch Org**.


### PR DESCRIPTION
### What does this PR do?
Updates the Interactive Debugger documentation with additional information about licenses provided to LMOs. The default license provided to LMOs can only be used with the ISV Debugger to debug a Subscriber org.

### What issues does this PR fix or reference?
#2737, @W-8493955@