### PR TITLE
chore: add git clean to clean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "circleci:artifacts": "node scripts/download-vsix-from-circleci.js",
     "commit-init": "commitizen init cz-conventional-changelog --save-dev --save-exact --force",
     "commit": "git-cz",
-    "clean": "lerna run clean",
+    "clean": "lerna run clean && git clean -xfd",
     "compile": "lerna run --stream compile",
     "lint": "lerna run lint",
     "publish": "node scripts/publish-circleci.js",


### PR DESCRIPTION
### What does this PR do?
Adds `git clean -xfd` to the clean script.