### PR TITLE
Remove unused code from generated extensions (vsix)

### DIFF
--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -9,7 +9,7 @@
     "vscode": "^1.46.0"
   },
   "dependencies": {
-    "@salesforce/core": "2.5.1",
+    "@salesforce/core": "2.11.0",
     "@salesforce/salesforcedx-utils-vscode": "50.6.0",
     "cross-spawn": "6.0.5",
     "path-exists": "3.0.0",

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -9,7 +9,7 @@
     "vscode": "^1.46.0"
   },
   "dependencies": {
-    "@salesforce/core": "2.11.0",
+    "@salesforce/core": "2.9.0",
     "@salesforce/salesforcedx-utils-vscode": "50.6.0",
     "cross-spawn": "6.0.5",
     "path-exists": "3.0.0",

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -10,7 +10,7 @@
     "Other"
   ],
   "dependencies": {
-    "@salesforce/core": "2.9.0",
+    "@salesforce/core": "2.11.0",
     "applicationinsights": "1.0.7",
     "cross-spawn": "6.0.5",
     "path-exists": "3.0.0",

--- a/packages/salesforcedx-vscode-apex/.vscodeignore
+++ b/packages/salesforcedx-vscode-apex/.vscodeignore
@@ -30,3 +30,15 @@ node_modules/@salesforce/salesforcedx-sobjects-faux-generator/package-lock.json
 node_modules/@salesforce/salesforcedx-sobjects-faux-generator/tsconfig.json
 node_modules/@salesforce/salesforcedx-sobjects-faux-generator/webpack.config.js
 node_modules/@salesforce/salesforcedx-sobjects-faux-generator/out/test/**
+
+# ignore unused jsforce code
+node_modules/jsforce/test/**
+node_modules/jsforce/build/**
+
+# ignore unused sfdx-faye code
+node_modules/sfdx-faye/examples/**
+node_modules/sfdx-faye/site/**
+node_modules/sfdx-faye/spec/**
+
+# ignore unused dayjs code
+node_modules/dayjs/esm/**

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "@salesforce/apex-tmlanguage": "1.4.0",
-    "@salesforce/core": "2.5.1",
+    "@salesforce/core": "2.11.0",
     "@salesforce/salesforcedx-sobjects-faux-generator": "50.6.0",
     "@salesforce/salesforcedx-utils-vscode": "50.6.0",
     "expand-home-dir": "0.0.3",

--- a/packages/salesforcedx-vscode-core/.vscodeignore
+++ b/packages/salesforcedx-vscode-core/.vscodeignore
@@ -17,3 +17,17 @@ node_modules/@salesforce/salesforcedx-utils-vscode/package-lock.json
 node_modules/@salesforce/salesforcedx-utils-vscode/tsconfig.json
 node_modules/@salesforce/salesforcedx-utils-vscode/webpack.config.js
 node_modules/@salesforce/salesforcedx-utils-vscode/out/test/**
+
+# ignore unused rxjs code 
+node_modules/rxjs/src/**
+node_modules/rxjs/bundles/**
+node_modules/rxjs/_esm5/**
+node_modules/rxjs/_esm2015/**
+node_modules/inquirer/node_modules/rxjs/src/**
+node_modules/inquirer/node_modules/rxjs/bundles/**
+node_modules/inquirer/node_modules/rxjs/_esm5/**
+node_modules/inquirer/node_modules/rxjs/_esm2015/**
+
+# ignore unused jsforce code
+node_modules/jsforce/test/**
+node_modules/jsforce/build/**

--- a/packages/salesforcedx-vscode-core/.vscodeignore
+++ b/packages/salesforcedx-vscode-core/.vscodeignore
@@ -31,3 +31,11 @@ node_modules/inquirer/node_modules/rxjs/_esm2015/**
 # ignore unused jsforce code
 node_modules/jsforce/test/**
 node_modules/jsforce/build/**
+
+# ignore unused sfdx-faye code
+node_modules/sfdx-faye/examples/**
+node_modules/sfdx-faye/site/**
+node_modules/sfdx-faye/spec/**
+
+# ignore unused dayjs code
+node_modules/dayjs/esm/**

--- a/packages/salesforcedx-vscode-lightning/.vscodeignore
+++ b/packages/salesforcedx-vscode-lightning/.vscodeignore
@@ -17,3 +17,15 @@ node_modules/@salesforce/salesforcedx-utils-vscode/package-lock.json
 node_modules/@salesforce/salesforcedx-utils-vscode/tsconfig.json
 node_modules/@salesforce/salesforcedx-utils-vscode/webpack.config.js
 node_modules/@salesforce/salesforcedx-utils-vscode/out/test/**
+
+# ignore unused jsforce code
+node_modules/jsforce/test/**
+node_modules/jsforce/build/**
+
+# ignore unused sfdx-faye code
+node_modules/sfdx-faye/examples/**
+node_modules/sfdx-faye/site/**
+node_modules/sfdx-faye/spec/**
+
+# ignore unused dayjs code
+node_modules/dayjs/esm/**

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "@salesforce/aura-language-server": "3.0.11",
-    "@salesforce/core": "2.9.0",
+    "@salesforce/core": "2.11.0",
     "@salesforce/lightning-lsp-common": "3.0.11",
     "@salesforce/lwc-language-server": "3.0.11",
     "@salesforce/salesforcedx-utils-vscode": "50.6.0",

--- a/packages/salesforcedx-vscode-lwc/.vscodeignore
+++ b/packages/salesforcedx-vscode-lwc/.vscodeignore
@@ -17,3 +17,21 @@ node_modules/@salesforce/salesforcedx-utils-vscode/package-lock.json
 node_modules/@salesforce/salesforcedx-utils-vscode/tsconfig.json
 node_modules/@salesforce/salesforcedx-utils-vscode/webpack.config.js
 node_modules/@salesforce/salesforcedx-utils-vscode/out/test/**
+
+# ignore unused rxjs code 
+node_modules/rxjs/src/**
+node_modules/rxjs/bundles/**
+node_modules/rxjs/_esm5/**
+node_modules/rxjs/_esm2015/**
+
+# ignore unused jsforce code
+node_modules/jsforce/test/**
+node_modules/jsforce/build/**
+
+# ignore unused sfdx-faye code
+node_modules/sfdx-faye/examples/**
+node_modules/sfdx-faye/site/**
+node_modules/sfdx-faye/spec/**
+
+# ignore unused dayjs code
+node_modules/dayjs/esm/**

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -25,7 +25,7 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/core": "2.9.0",
+    "@salesforce/core": "2.11.0",
     "@salesforce/eslint-config-lwc": "0.3.0",
     "@salesforce/lightning-lsp-common": "3.0.11",
     "@salesforce/lwc-language-server": "3.0.11",


### PR DESCRIPTION
### What does this PR do?
Remove unused code from being part of the generated vsix files specific to the core, apex, lightning and lwc extensions.
- Remove unused code installed by `@salesforce/core`
- Remove unused code installed by `rxjs`
- Update to the same version of `@salesforce/core` (except for the salesforcedx-sobject-faux-generator module)

| extension        | Old size           | New size  |
| ------------- |:-------------:| -----:|
| salesforcedx-vscode-core     | 14.2 MB | 10 MB |
| salesforcedx-vscode-apex      | 24 MB      |   22 MB|
| salesforcedx-vscode-lightning | 23.3 MB      |    21.6 MB |
| salesforcedx-vscode-lwc | 44.1 MB      |    41 MB |

### What issues does this PR fix or reference?
@W-7870137@