### PR TITLE
Dehru/soql error telemetry

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployCommand.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployCommand.ts
@@ -24,7 +24,7 @@ import { nls } from '../messages';
 import { notificationService, ProgressNotification } from '../notifications';
 import { DeployQueue } from '../settings/pushOrDeployOnSave';
 import { taskViewService } from '../statuses';
-import { telemetryService } from '../telemetry';
+import { TelemetryBuilder, telemetryService } from '../telemetry';
 import { getRootWorkspacePath } from '../util';
 import { createComponentCount } from './util/betaDeployRetrieve';
 import { SfdxCommandletExecutor } from './util/sfdxCommandlet';
@@ -60,20 +60,23 @@ export abstract class BaseDeployExecutor extends SfdxCommandletExecutor<
     });
 
     execution.processExitSubject.subscribe(async exitCode => {
-      let properties;
+      const telemetry = new TelemetryBuilder();
+
       try {
-        const ws = ComponentSet.fromSource(execFilePathOrPaths);
-        const metadataCount = JSON.stringify(createComponentCount([...ws]));
-        properties = { metadataCount };
-        // registry does not handle multiple paths. only log component count for single paths
+        const components = new ComponentSet();
+        for (const fsPath of execFilePathOrPaths.split(',')) {
+          components.resolveSourceComponents(fsPath);
+        }
+        const metadataCount = JSON.stringify(createComponentCount(components));
+        telemetry.addProperty('metadataCount', metadataCount);
       } catch (e) {
         telemetryService.sendException(
           e.name,
           'error detecting deploy components'
         );
       }
-      this.logMetric(execution.command.logName, startTime, properties);
 
+      let success = false;
       try {
         BaseDeployExecutor.errorCollection.clear();
         if (stdOut) {
@@ -87,6 +90,8 @@ export abstract class BaseDeployExecutor extends SfdxCommandletExecutor<
               execFilePathOrPaths,
               BaseDeployExecutor.errorCollection
             );
+          } else {
+            success = true;
           }
           this.outputResult(deployParser);
         }
@@ -99,6 +104,8 @@ export abstract class BaseDeployExecutor extends SfdxCommandletExecutor<
         telemetryService.sendException(e.name, e.message);
         console.error(e.message);
       }
+      telemetry.addProperty('success', String(success));
+      this.logMetric(execution.command.logName, startTime, telemetry.build().properties);
       await DeployQueue.get().unlock();
     });
 

--- a/packages/salesforcedx-vscode-soql/src/commonUtils.ts
+++ b/packages/salesforcedx-vscode-soql/src/commonUtils.ts
@@ -36,11 +36,11 @@ export function showError(kind: string, err: string): void {
 export async function trackError(kind: string, err: string): Promise<void> {
   try {
     await telemetryService.sendException(
-      `soql-error-${kind.toLocaleLowerCase()}`,
+      `soql_error_${kind.toLocaleLowerCase()}`,
       err
     );
   } catch (err) {
-    channelService.appendLine(`soql-error-telemetry:  ${err.toString()}`);
+    channelService.appendLine(`soql_error_telemetry:  ${err.toString()}`);
   }
 }
 

--- a/packages/salesforcedx-vscode-soql/src/commonUtils.ts
+++ b/packages/salesforcedx-vscode-soql/src/commonUtils.ts
@@ -6,23 +6,48 @@
  */
 
 import * as path from 'path';
-import { TextDocument, workspace, WorkspaceFolder } from 'vscode';
+import * as vscode from 'vscode';
+import { channelService } from './channel';
+import { telemetryService } from './telemetry';
 
-export function getDocumentName(document: TextDocument): string {
+export function getDocumentName(document: vscode.TextDocument): string {
   const documentPath = document.uri.fsPath;
   return path.basename(documentPath) || '';
 }
 
-function hasRootWorkspace(ws: typeof workspace = workspace) {
+function hasRootWorkspace(ws: typeof vscode.workspace = vscode.workspace) {
   return ws && ws.workspaceFolders && ws.workspaceFolders.length > 0;
 }
 
-function getRootWorkspace(): WorkspaceFolder {
+function getRootWorkspace(): vscode.WorkspaceFolder {
   return hasRootWorkspace()
-    ? workspace.workspaceFolders![0]
-    : ({} as WorkspaceFolder);
+    ? (vscode.workspace.workspaceFolders as vscode.WorkspaceFolder[])[0]
+    : ({} as vscode.WorkspaceFolder);
 }
 
 export function getRootWorkspacePath(): string {
   return getRootWorkspace().uri ? getRootWorkspace().uri.fsPath : '';
+}
+
+export function showError(kind: string, err: string): void {
+  vscode.window.showErrorMessage(`${kind}:  ${err}`);
+}
+
+export async function trackError(kind: string, err: string): Promise<void> {
+  try {
+    await telemetryService.sendException(
+      `soql-error-${kind.toLocaleLowerCase()}`,
+      err
+    );
+  } catch (err) {
+    channelService.appendLine(`soql-error-telemetry:  ${err.toString()}`);
+  }
+}
+
+export async function showAndTrackError(
+  kind: string,
+  err: string
+): Promise<void> {
+  showError(kind, err);
+  await trackError(kind, err);
 }

--- a/packages/salesforcedx-vscode-soql/src/editor/queryRunner.ts
+++ b/packages/salesforcedx-vscode-soql/src/editor/queryRunner.ts
@@ -8,25 +8,19 @@
 import { Connection } from '@salesforce/core';
 import { JsonMap } from '@salesforce/ts-types';
 import { QueryResult } from 'jsforce';
-import * as vscode from 'vscode';
 
 export class QueryRunner {
   constructor(private connection: Connection) {}
 
   public async runQuery(queryText: string): Promise<QueryResult<JsonMap>> {
-    try {
-      const rawQueryData = (await this.connection.query(
-        queryText
-      )) as QueryResult<JsonMap>;
-      const cleanQueryData = {
-        ...rawQueryData,
-        records: this.flattenQueryRecords(rawQueryData.records)
-      };
-      return cleanQueryData;
-    } catch (error) {
-      vscode.window.showErrorMessage(`${error.name}:  ${error.message}`);
-      throw error;
-    }
+    const rawQueryData = (await this.connection.query(
+      queryText
+    )) as QueryResult<JsonMap>;
+    const cleanQueryData = {
+      ...rawQueryData,
+      records: this.flattenQueryRecords(rawQueryData.records)
+    };
+    return cleanQueryData;
   }
   /*
   As query complexity grows

--- a/packages/salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts
+++ b/packages/salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts
@@ -175,21 +175,19 @@ export class SOQLEditorInstance {
       }
       case MessageType.UI_TELEMETRY: {
         const { unsupported, errors } = e.payload as TelemetryModelJson;
-        if (errors && errors.length) {
+        if (errors) {
           trackError('syntax_error', JSON.stringify(e.payload)).catch(
             console.error
           );
         }
-        if (unsupported && unsupported.length) {
+        if (unsupported) {
           // no need to duplicate.  unsupported and errors often both present
-          if (!errors || !errors.length) {
+          if (!errors) {
             trackError('syntax_unsupported', JSON.stringify(e.payload)).catch(
               console.error
             );
           }
-          channelService.appendLine(
-            `This syntax is not yet supported: ${unsupported.join(', ')}`
-          );
+          channelService.appendLine(`This syntax is not yet supported.`);
         }
         break;
       }

--- a/packages/salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts
+++ b/packages/salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts
@@ -176,16 +176,14 @@ export class SOQLEditorInstance {
       case MessageType.UI_TELEMETRY: {
         const { unsupported, errors } = e.payload as TelemetryModelJson;
         if (errors && errors.length) {
-          trackError('syntax-error', JSON.stringify(e.payload)).catch(err => {
-            channelService.appendLine(
-              `Unable to send telemetry because of ${err}.`
-            );
-          });
+          trackError('syntax_error', JSON.stringify(e.payload)).catch(
+            console.error
+          );
         }
         if (unsupported && unsupported.length) {
-          // no need to duplicate.  unsupported and errors often duplicate
+          // no need to duplicate.  unsupported and errors often both present
           if (!errors || !errors.length) {
-            trackError('syntax-unsupported', JSON.stringify(e.payload)).catch(
+            trackError('syntax_unsupported', JSON.stringify(e.payload)).catch(
               console.error
             );
           }
@@ -225,7 +223,7 @@ export class SOQLEditorInstance {
       default: {
         const message = `message type ${e.type} is not supported`;
         channelService.appendLine(message);
-        trackError('message-handler', message).catch(console.error);
+        trackError('message_handler', message).catch(console.error);
       }
     }
   }
@@ -260,7 +258,7 @@ export class SOQLEditorInstance {
     return withSFConnection(async conn => {
       conn.describeGlobal$((err, describeGlobalResult) => {
         if (err) {
-          showAndTrackError('retrieve-sobjects', err.toString()).catch(
+          showAndTrackError('retrieve_sobjects', err.toString()).catch(
             console.error
           );
         }
@@ -277,7 +275,7 @@ export class SOQLEditorInstance {
     return withSFConnection(async conn => {
       conn.describe$(sobjectName, (err, sobject) => {
         if (err) {
-          showAndTrackError('retrieve-sobject', err.toString()).catch(
+          showAndTrackError('retrieve_sobject', err.toString()).catch(
             console.error
           );
         }

--- a/packages/salesforcedx-vscode-soql/src/messages/index.ts
+++ b/packages/salesforcedx-vscode-soql/src/messages/index.ts
@@ -46,7 +46,7 @@ function loadMessageBundle(config?: Config): Message {
 export const nls = new Localization(
   loadMessageBundle(
     process.env.VSCODE_NLS_CONFIG
-      ? JSON.parse(process.env.VSCODE_NLS_CONFIG!)
+      ? JSON.parse(process.env.VSCODE_NLS_CONFIG as string)
       : undefined
   )
 );

--- a/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataFileService.ts
+++ b/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataFileService.ts
@@ -10,7 +10,7 @@ import * as fs from 'fs';
 import { QueryResult } from 'jsforce';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { getRootWorkspacePath } from '../commonUtils';
+import { getRootWorkspacePath, trackError } from '../commonUtils';
 import { QUERY_RESULTS_DIR_NAME, QUERY_RESULTS_DIR_PATH } from '../constants';
 import {
   CsvDataProvider,
@@ -83,10 +83,11 @@ export class QueryDataFileService {
   }
 
   private showFileInExplorer(targetPath: string) {
-    vscode.commands.executeCommand(
-      'revealInExplorer',
-      vscode.Uri.file(targetPath)
-    );
+    vscode.commands
+      .executeCommand('revealInExplorer', vscode.Uri.file(targetPath))
+      .then(undefined, async (err: string) => {
+        trackError('data-view-show-file', err);
+      });
   }
 
   private showSaveSuccessMessage(savedFileName: string) {

--- a/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataFileService.ts
+++ b/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataFileService.ts
@@ -86,7 +86,7 @@ export class QueryDataFileService {
     vscode.commands
       .executeCommand('revealInExplorer', vscode.Uri.file(targetPath))
       .then(undefined, async (err: string) => {
-        trackError('data-view-show-file', err);
+        trackError('data_view_show_file', err);
       });
   }
 

--- a/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataViewService.ts
+++ b/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataViewService.ts
@@ -129,7 +129,7 @@ export class QueryDataViewService {
       default:
         showAndTrackError(
           'data_view_message_type',
-          `Dataview unable to handle message type: ${type}`
+          `Error: ${type}. This is an unknown error.  Open an issue: https://github.com/forcedotcom/soql-tooling/issues/new/choose.`
         );
         break;
     }

--- a/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataViewService.ts
+++ b/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataViewService.ts
@@ -57,7 +57,7 @@ export class QueryDataViewService {
         documentName: getDocumentName(this.document)
       })
       .then(undefined, async (err: string) => {
-        showAndTrackError('data-view-postmessage', err);
+        showAndTrackError('data_view_postmessage', err);
       });
   }
 
@@ -128,7 +128,7 @@ export class QueryDataViewService {
         break;
       default:
         showAndTrackError(
-          'message-type',
+          'data_view_message_type',
           `Dataview unable to handle message type: ${type}`
         );
         break;
@@ -144,7 +144,7 @@ export class QueryDataViewService {
       );
       fileService.save();
     } catch (err) {
-      trackError('data-view-save', err);
+      trackError('data_view_save', err);
     }
   }
 

--- a/packages/salesforcedx-vscode-soql/src/telemetry/index.ts
+++ b/packages/salesforcedx-vscode-soql/src/telemetry/index.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { TelemetryService } from '@salesforce/salesforcedx-utils-vscode/out/src/telemetry';
+import { JsonMap } from '@salesforce/ts-types';
 import * as vscode from 'vscode';
 
 export const telemetryService = TelemetryService.getInstance();
@@ -26,4 +27,12 @@ export async function startTelemetry(
 
 export async function stopTelemetry(): Promise<void> {
   await telemetryService.sendExtensionDeactivationEvent();
+}
+
+export interface TelemetryModelJson extends JsonMap {
+  fields: number;
+  orderBy: number;
+  limit: number;
+  errors: JsonMap[];
+  unsupported: string[];
 }

--- a/packages/salesforcedx-vscode-soql/src/telemetry/index.ts
+++ b/packages/salesforcedx-vscode-soql/src/telemetry/index.ts
@@ -33,6 +33,6 @@ export interface TelemetryModelJson extends JsonMap {
   fields: number;
   orderBy: number;
   limit: number;
-  errors: JsonMap[];
-  unsupported: string[];
+  errors: number;
+  unsupported: number;
 }

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/commomUtils.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/commomUtils.test.ts
@@ -6,15 +6,19 @@
  */
 
 import { expect } from 'chai';
+import * as sinon from 'sinon';
 import * as vscode from 'vscode';
-import { getDocumentName } from '../../src/commonUtils';
+import { getDocumentName, showAndTrackError } from '../../src/commonUtils';
 import { MockTextDocumentProvider } from './testUtilities';
+import { telemetryService } from '../../src/telemetry';
 
 describe('Common SOQL Builder Utilities', () => {
   let mockTextDocument: vscode.TextDocument;
   let docProviderDisposable: vscode.Disposable;
+  let sandbox: sinon.SinonSandbox;
 
   beforeEach(async () => {
+    sandbox = sinon.createSandbox();
     docProviderDisposable = vscode.workspace.registerTextDocumentContentProvider(
       'sfdc-test',
       new MockTextDocumentProvider()
@@ -26,10 +30,32 @@ describe('Common SOQL Builder Utilities', () => {
 
   afterEach(() => {
     docProviderDisposable.dispose();
+    sandbox.restore();
   });
 
   it('gets the document name form path', () => {
     const documentName = getDocumentName(mockTextDocument);
     expect(documentName).equals('mocksoql.soql');
+  });
+
+  it('display and track error with correct telemetry namespace', async () => {
+    const telemetryServiceStub = sandbox
+      .stub(telemetryService, 'sendException')
+      .resolves();
+    const windowErrorMessageStub = sandbox.stub(
+      vscode.window,
+      'showErrorMessage'
+    );
+
+    const errorNamespace = 'test-me';
+    const errorDetails = 'this is a test error';
+    await showAndTrackError(errorNamespace, errorDetails);
+
+    expect(telemetryServiceStub.callCount).to.equal(1);
+    expect(telemetryServiceStub.getCall(0).args[0]).to.equal(
+      `soql-error-${errorNamespace}`
+    );
+    expect(telemetryServiceStub.getCall(0).args[1]).to.equal(errorDetails);
+    expect(windowErrorMessageStub.callCount).to.equal(1);
   });
 });

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/commomUtils.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/commomUtils.test.ts
@@ -53,7 +53,7 @@ describe('Common SOQL Builder Utilities', () => {
 
     expect(telemetryServiceStub.callCount).to.equal(1);
     expect(telemetryServiceStub.getCall(0).args[0]).to.equal(
-      `soql-error-${errorNamespace}`
+      `soql_error_${errorNamespace}`
     );
     expect(telemetryServiceStub.getCall(0).args[1]).to.equal(errorDetails);
     expect(windowErrorMessageStub.callCount).to.equal(1);

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/editor/soqlEditorInstance.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/editor/soqlEditorInstance.test.ts
@@ -177,7 +177,7 @@ describe('SoqlEditorInstance should', () => {
     });
     return Promise.resolve().then(() => {
       expect(trackErrorSpy.callCount).to.equal(1);
-      expect(trackErrorSpy.getCall(0).args[0]).to.equal('syntax-error');
+      expect(trackErrorSpy.getCall(0).args[0]).to.equal('syntax_error');
     });
   });
 
@@ -189,7 +189,7 @@ describe('SoqlEditorInstance should', () => {
     });
     return Promise.resolve().then(() => {
       expect(trackErrorSpy.callCount).to.equal(1);
-      expect(trackErrorSpy.getCall(0).args[0]).to.equal('syntax-unsupported');
+      expect(trackErrorSpy.getCall(0).args[0]).to.equal('syntax_unsupported');
     });
   });
 
@@ -201,7 +201,7 @@ describe('SoqlEditorInstance should', () => {
     });
     return Promise.resolve().then(() => {
       expect(trackErrorSpy.callCount).to.equal(1);
-      expect(trackErrorSpy.getCall(0).args[0]).to.equal('syntax-error');
+      expect(trackErrorSpy.getCall(0).args[0]).to.equal('syntax_error');
     });
   });
 });

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/editor/soqlEditorInstance.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/editor/soqlEditorInstance.test.ts
@@ -173,7 +173,7 @@ describe('SoqlEditorInstance should', () => {
     const trackErrorSpy = sandbox.spy(commonUtils, 'trackError');
     instance.sendEvent({
       type: MessageType.UI_TELEMETRY,
-      payload: { errors: ['an example error'] }
+      payload: { errors: 1 }
     });
     return Promise.resolve().then(() => {
       expect(trackErrorSpy.callCount).to.equal(1);
@@ -185,7 +185,7 @@ describe('SoqlEditorInstance should', () => {
     const trackErrorSpy = sandbox.spy(commonUtils, 'trackError');
     instance.sendEvent({
       type: MessageType.UI_TELEMETRY,
-      payload: { unsupported: ['WHERE'] }
+      payload: { unsupported: 1 }
     });
     return Promise.resolve().then(() => {
       expect(trackErrorSpy.callCount).to.equal(1);
@@ -197,7 +197,7 @@ describe('SoqlEditorInstance should', () => {
     const trackErrorSpy = sandbox.spy(commonUtils, 'trackError');
     instance.sendEvent({
       type: MessageType.UI_TELEMETRY,
-      payload: { unsupported: ['WHERE'], errors: ['an example error'] }
+      payload: { unsupported: 1, errors: 1 }
     });
     return Promise.resolve().then(() => {
       expect(trackErrorSpy.callCount).to.equal(1);

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/editor/soqlEditorInstance.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/editor/soqlEditorInstance.test.ts
@@ -171,13 +171,15 @@ describe('SoqlEditorInstance should', () => {
 
   it('handles telemetry events and tracks when there are errors', async () => {
     const trackErrorSpy = sandbox.spy(commonUtils, 'trackError');
-    instance.sendEvent({
+    const telemetryEvent = {
       type: MessageType.UI_TELEMETRY,
       payload: { errors: 1 }
-    });
+    };
+    instance.sendEvent(telemetryEvent);
     return Promise.resolve().then(() => {
       expect(trackErrorSpy.callCount).to.equal(1);
       expect(trackErrorSpy.getCall(0).args[0]).to.equal('syntax_error');
+      expect(JSON.parse(trackErrorSpy.getCall(0).args[1]).errors).to.equal(1);
     });
   });
 
@@ -190,6 +192,22 @@ describe('SoqlEditorInstance should', () => {
     return Promise.resolve().then(() => {
       expect(trackErrorSpy.callCount).to.equal(1);
       expect(trackErrorSpy.getCall(0).args[0]).to.equal('syntax_unsupported');
+    });
+  });
+
+  it('handles telemetry errors and unsupported properties as numbers AND arrays', async () => {
+    const trackErrorSpy = sandbox.spy(commonUtils, 'trackError');
+    const telemetryEvent = {
+      type: MessageType.UI_TELEMETRY,
+      payload: { unsupported: ['WHERE 1 = 1'], errors: ['WHERE Pickles'] }
+    };
+    instance.sendEvent(telemetryEvent);
+    return Promise.resolve().then(() => {
+      expect(trackErrorSpy.callCount).to.equal(1);
+      expect(trackErrorSpy.getCall(0).args[0]).to.equal('syntax_error');
+      expect(trackErrorSpy.getCall(0).args[1]).contains(
+        telemetryEvent.payload.errors[0]
+      );
     });
   });
 

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/queryDataView/queryDataViewService.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/queryDataView/queryDataViewService.test.ts
@@ -11,6 +11,7 @@ import { QueryResult } from 'jsforce';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import { getDocumentName } from '../../../src/commonUtils';
+import * as commonUtils from '../../../src/commonUtils';
 import {
   FileFormat,
   QueryDataFileService
@@ -97,5 +98,35 @@ describe('Query Data View Service', () => {
     const postMessageArgs = saveRecordsSpy.args[0][0];
     expect(postMessageArgs).to.eql(FileFormat.CSV);
     expect(fileServiceStub.callCount).equal(1);
+  });
+
+  it('should track error via telemetry if event type is not handled', () => {
+    const trackSpy = sandbox.spy(commonUtils, 'showAndTrackError');
+    const dataViewService = new TestQueryDataViewService(
+      mockSubscription,
+      queryRecords,
+      mockTextDocument
+    );
+    dataViewService.createOrShowWebView();
+    dataViewService.sendEvent({ type: 'unsupported', format: FileFormat.CSV });
+    expect(trackSpy.callCount).to.equal(1);
+  });
+
+  it('should display error when save fails', () => {
+    const trackSpy = sandbox.spy(commonUtils, 'trackError');
+    const dataViewService = new TestQueryDataViewService(
+      mockSubscription,
+      queryRecords,
+      mockTextDocument
+    );
+    const fileServiceStub = sandbox
+      .stub(QueryDataFileService.prototype, 'save')
+      .throws();
+    QueryDataViewService.extensionPath = '';
+    sandbox.stub(vscode.window, 'createWebviewPanel').returns(mockWebviewPanel);
+    dataViewService.createOrShowWebView();
+    dataViewService.sendEvent({ type: 'save_records', format: FileFormat.CSV });
+    expect(fileServiceStub.callCount).equal(1);
+    expect(trackSpy.callCount).to.equal(1);
   });
 });

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/testUtilities.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/testUtilities.ts
@@ -26,8 +26,13 @@ import {
 
 export interface MockConnection {
   authInfo: object;
-  describeGlobal$: (callback: (err: Error | undefined, resp: any) => void) => void;
-  describe$: (name: string, callback: (err: Error | undefined, resp: any) => void) => void;
+  describeGlobal$: (
+    callback: (err: Error | undefined, resp: any) => void
+  ) => void;
+  describe$: (
+    name: string,
+    callback: (err: Error | undefined, resp: any) => void
+  ) => void;
   query: () => Promise<QueryResult<JsonMap>>;
 }
 
@@ -74,8 +79,12 @@ export function getMockConnection(
   const mockAuthInfo = { test: 'test' };
   const mockConnection = {
     authInfo: mockAuthInfo,
-    describeGlobal$: (callback: (err: Error | undefined, resp: any) => void) => callback(undefined, mockDescribeGlobalResponse),
-    describe$: (name: string, callback: (err: Error | undefined, resp: any) => void) => callback(undefined, mockSObject),
+    describeGlobal$: (callback: (err: Error | undefined, resp: any) => void) =>
+      callback(undefined, mockDescribeGlobalResponse),
+    describe$: (
+      name: string,
+      callback: (err: Error | undefined, resp: any) => void
+    ) => callback(undefined, mockSObject),
     query: () => Promise.resolve(mockQueryData)
   };
 
@@ -118,6 +127,10 @@ export class TestSoqlEditorInstance extends SOQLEditorInstance {
 
   public openQueryDataView(queryData: QueryResult<JsonMap>) {
     super.openQueryDataView(queryData);
+  }
+
+  public sendMessageToUi(type: string, payload: any) {
+    super.sendMessageToUi(type, payload);
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
This PR attempts to capture the various errors ( some could be quite rare and catastrophic! ) and send them to telemetry as exceptions.  It also displays a select few of these errors to the user as either a channel log message or an actual vscode error poptart.  I used my own discretion as to when a pop-tart message was important.

### What issues does this PR fix or reference?
@W-8086238@

### Functionality Before
Previously only activation event was tracked for telemetry

### Functionality After
The following are examples of the telemetry data related to soql syntax errors sent as exeptions to the vscode_appinsights resource on azure.  I think in the future, we can expose some more of the syntax that caused the error, but we need to scrub any possible user protected data.

<img width="707" alt="Screen Shot 2020-12-07 at 10 08 58 PM" src="https://user-images.githubusercontent.com/599418/101442864-62b4b200-38d9-11eb-9b95-de4083e6a172.png">

Soql Extension channel message to the user appear on some exceptions where appropriate.  

Also, I added a channel message for unsupported syntax.
<img width="440" alt="Screen Shot 2020-12-07 at 10 00 52 PM" src="https://user-images.githubusercontent.com/599418/101442888-6e07dd80-38d9-11eb-8b26-71a22f3327d6.png">


