### PR TITLE
feat(soql): new query command

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -173,6 +173,29 @@
       "internalConsoleOptions": "openOnSessionStart"
     },
     {
+      "name": "Launch Tests - SOQL - VSCode Integration Tests",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "${workspaceFolder}/packages/system-tests/assets/sfdx-simple",
+        "--extensionDevelopmentPath=${workspaceFolder}/packages",
+        "--extensionTestsPath=${workspaceFolder}/packages/salesforcedx-vscode-soql/out/test/vscode-integration"
+      ],
+      "stopOnEntry": false,
+      "sourceMaps": true,
+      "smartStep": true,
+      "outFiles": ["${workspaceFolder}/packages/*/out/**/*.js"],
+      "sourceMapPathOverrides": {
+        "../../../../test/vscode-integration": "${workspaceFolder}/packages/salesforcedx-vscode-soql/out/test/vscode-integration/*",
+        "webpack:///salesforcedx-utils-vscode/./*": "${workspaceFolder}/packages/salesforcedx-utils-vscode/*",
+        "webpack:///salesforcedx-sobjects-faux-generator/./*": "${workspaceFolder}/packages/salesforcedx-sobjects-faux-generator/*",
+        "webpack:///*": "*"
+      },
+      "preLaunchTask": "Compile",
+      "internalConsoleOptions": "openOnSessionStart"
+    },
+    {
       "name": "Launch Tests - Apex - VSCode Integration Tests",
       "type": "extensionHost",
       "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -189,7 +189,6 @@
       "sourceMapPathOverrides": {
         "../../../../test/vscode-integration": "${workspaceFolder}/packages/salesforcedx-vscode-soql/out/test/vscode-integration/*",
         "webpack:///salesforcedx-utils-vscode/./*": "${workspaceFolder}/packages/salesforcedx-utils-vscode/*",
-        "webpack:///salesforcedx-sobjects-faux-generator/./*": "${workspaceFolder}/packages/salesforcedx-sobjects-faux-generator/*",
         "webpack:///*": "*"
       },
       "preLaunchTask": "Compile",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -125,7 +125,7 @@
     "commands": [
       {
         "command": "soql.builder.open.new",
-        "title": "SOQL: New Query"
+        "title": "SOQL: Create Query in SOQL Builder"
       }
     ],
     "menus": {

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -93,7 +93,7 @@
   "contributes": {
     "customEditors": [
       {
-        "viewType": "soqlCustom.soql",
+        "viewType": "%soqlCustom_soql%",
         "displayName": "SOQL Builder",
         "selector": [
           {
@@ -125,7 +125,7 @@
     "commands": [
       {
         "command": "soql.builder.open.new",
-        "title": "SOQL: Create Query in SOQL Builder"
+        "title": "%soql_builder_open_new%"
       }
     ],
     "menus": {

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -121,6 +121,20 @@
         "scopeName": "source.soql",
         "path": "./node_modules/@salesforce/apex-tmlanguage/grammars/soql.tmLanguage"
       }
-    ]
+    ],
+    "commands": [
+      {
+        "command": "soql.builder.open.new",
+        "title": "SOQL: New Query"
+      }
+    ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "soql.builder.open.new",
+          "when": "sfdx:project_opened"
+        }
+      ]
+    }
   }
 }

--- a/packages/salesforcedx-vscode-soql/package.nls.json
+++ b/packages/salesforcedx-vscode-soql/package.nls.json
@@ -1,0 +1,4 @@
+{
+  "soqlCustom_soql": "SOQL Builder",
+  "soql_builder_open_new": "SFDX: Create Query in SOQL Builder"
+}

--- a/packages/salesforcedx-vscode-soql/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-soql/src/commands/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+export { soqlOpenNew } from './soqlFileCreate';

--- a/packages/salesforcedx-vscode-soql/src/commands/soqlFileCreate.ts
+++ b/packages/salesforcedx-vscode-soql/src/commands/soqlFileCreate.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { EDITOR_VIEW_TYPE } from '../constants';
+import { telemetryService } from '../telemetry';
+
+export async function soqlOpenNew() {
+  telemetryService.sendCommandEvent('soql_builder_open_new', process.hrtime());
+
+  if (vscode.workspace) {
+    // create untitled file
+    const newFileUri = vscode.Uri.file(
+      path.join(vscode.workspace.rootPath!, 'untitled.soql')
+    ).with({ scheme: 'untitled' });
+    await vscode.workspace.openTextDocument(newFileUri);
+
+    // open with SOQL builder
+    vscode.commands.executeCommand(
+      'vscode.openWith',
+      newFileUri,
+      EDITOR_VIEW_TYPE
+    );
+  }
+}

--- a/packages/salesforcedx-vscode-soql/src/commands/soqlFileCreate.ts
+++ b/packages/salesforcedx-vscode-soql/src/commands/soqlFileCreate.ts
@@ -15,15 +15,15 @@ export async function soqlOpenNew() {
 
   if (vscode.workspace) {
     // create untitled file
-    const newFileUri = vscode.Uri.file(
-      path.join(vscode.workspace.rootPath!, 'untitled.soql')
-    ).with({ scheme: 'untitled' });
-    await vscode.workspace.openTextDocument(newFileUri);
+    const doc = await vscode.workspace.openTextDocument({
+      language: 'soql',
+      content: ''
+    });
 
     // open with SOQL builder
     vscode.commands.executeCommand(
       'vscode.openWith',
-      newFileUri,
+      doc.uri,
       EDITOR_VIEW_TYPE
     );
   }

--- a/packages/salesforcedx-vscode-soql/src/index.ts
+++ b/packages/salesforcedx-vscode-soql/src/index.ts
@@ -7,6 +7,7 @@
 
 import * as vscode from 'vscode';
 import { startLanguageClient, stopLanguageClient } from './client/client';
+import { soqlOpenNew } from './commands';
 import { SOQLEditorProvider } from './editor/soqlEditorProvider';
 import { QueryDataViewService } from './queryDataView/queryDataViewService';
 import { startTelemetry, stopTelemetry } from './telemetry';
@@ -16,6 +17,13 @@ export function activate(context: vscode.ExtensionContext): void {
   const extensionHRStart = process.hrtime();
   context.subscriptions.push(SOQLEditorProvider.register(context));
   QueryDataViewService.register(context);
+
+  const soqlOpenNewCommand = vscode.commands.registerCommand(
+    'soql.builder.open.new',
+    soqlOpenNew
+  );
+  context.subscriptions.push(soqlOpenNewCommand);
+
   startLanguageClient(context);
   startTelemetry(context, extensionHRStart).catch();
 }

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/commands/soqlFileCreate.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/commands/soqlFileCreate.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from 'chai';
+import { SinonSandbox, createSandbox, SinonStub } from 'sinon';
+import * as vscode from 'vscode';
+import { soqlOpenNew } from '../../../src/commands/soqlFileCreate';
+import { telemetryService } from '../../../src/telemetry';
+
+describe('soqlOpenNew should', () => {
+  let sb: SinonSandbox;
+  let telemetryStub: SinonStub;
+  let editorOpened: SinonStub;
+
+  beforeEach(() => {
+    sb = createSandbox();
+    telemetryStub = sb.stub(telemetryService, 'sendCommandEvent');
+    editorOpened = sb.stub();
+    vscode.workspace.onDidOpenTextDocument(editorOpened);
+  });
+
+  afterEach(async () => {
+    sb.restore();
+  });
+
+  it('sends telemetry and opens editor when invoked', async () => {
+    await soqlOpenNew();
+
+    expect(telemetryStub.called).is.true;
+    expect(editorOpened.called).is.true;
+  });
+
+});


### PR DESCRIPTION
### What does this PR do?
This PR implements the command "SOQL: New Query", which opens an untitled, unsaved, empty query in the SOQL Builder.  This command is enabled in the command palette when an SFDX project is open.

### What issues does this PR fix or reference?
@W-8516491@

### Functionality Before
User must create .soql file, then "Open With" SOQL Builder to open a new query in the SOQL Builder.

### Functionality After
User uses command "SOQL: New Query" to open a new query in the SOQL Builder.
![createquery](https://user-images.githubusercontent.com/55159130/101947797-04c8e880-3bbf-11eb-8c8a-f864184f7ec6.gif)
