### PR TITLE
fix: downgrade vscode-languageclient to ^5.2.1

### DIFF
--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -43,7 +43,8 @@
     "jsforce": "^1.10.0",
     "papaparse": "^5.3.0",
     "vscode-extension-telemetry": "^0.1.6",
-    "vscode-languageclient": "^5.2.1"
+    "vscode-languageclient": "6.1.3",
+    "vscode-languageserver-protocol": "3.15.3"
   },
   "devDependencies": {
     "@salesforce/salesforcedx-test-utils-vscode": "50.8.0",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -43,7 +43,7 @@
     "jsforce": "^1.10.0",
     "papaparse": "^5.3.0",
     "vscode-extension-telemetry": "^0.1.6",
-    "vscode-languageclient": "^6.1.3"
+    "vscode-languageclient": "^5.2.1"
   },
   "devDependencies": {
     "@salesforce/salesforcedx-test-utils-vscode": "50.8.0",


### PR DESCRIPTION
### What does this PR do?

Downgrades vscode-languageclient to ^5.2.1 in salesforcedx-vscode-soql