### PR TITLE
docs: add cache information for code preview

### DIFF
--- a/docs/_articles/en/codepreview/set-up-lwc-code-preview.md
+++ b/docs/_articles/en/codepreview/set-up-lwc-code-preview.md
@@ -12,6 +12,19 @@ Run this command from a command-line interface.
 ```
 sfdx plugins:install @salesforce/lwc-dev-server
 ```
+
 > **Troubleshooting Tip:** Due to a known issue, it's likely you'll see several errors when you install the plug-in. Run `sfdx plugins --core` to see if the plug-in is installed. If yes, try to start the Code Preview server. If successful, you're good to proceed.
 
 After you select **SFDX: Preview Component**, the Command Palette displays a list of preview options. You can choose to preview your component in the desktop browser or in a virtual mobile device (iOS or Android). Mobile previews require additional setup. See [Preview Lightning Web Components on Mobile](https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.mobile_extensions) in the _Lightning Web Components Dev Guide_.
+
+## Recommended Settings
+
+**Disable Browser Cache**  
+If you would like to see changes made to your static resources in real time (file additions and deletions to your `/staticresources/` folder), please disable the web browser cache when working with LWC Code Preview.
+
+For some examples of how to disable the web browser cache, please see...
+
+- Chrome: https://www.technipages.com/google-chrome-how-to-completely-disable-cache
+- Safari: https://www.technipages.com/apple-safari-completely-disable-cache
+
+Another work around is to make changes to one of the .js or .html files within your component, which will recompile and cache your new static resources to the browser.

--- a/docs/_articles/en/codepreview/set-up-lwc-code-preview.md
+++ b/docs/_articles/en/codepreview/set-up-lwc-code-preview.md
@@ -28,3 +28,5 @@ For some examples of how to disable the web browser cache, see:
 - Safari: https://www.technipages.com/apple-safari-completely-disable-cache
 
 Another workaround is to make changes to one of the `.js` or `.html` files within your component, which recompiles and caches your new static resources to the browser.
+
+> **Warning:** Disabling the browser cache may cause slowness for other websites and services. It is advisable to recheck this cache setting when no longer working within LWC Code Preview.

--- a/docs/_articles/en/codepreview/set-up-lwc-code-preview.md
+++ b/docs/_articles/en/codepreview/set-up-lwc-code-preview.md
@@ -20,7 +20,7 @@ After you select **SFDX: Preview Component**, the Command Palette displays a lis
 ## Recommended Settings
 
 **Disable Browser Cache**  
-If you would like to see changes made to your static resources in real time (file additions and deletions to your `/staticresources/` folder), please disable the web browser cache when working with LWC Code Preview.
+If you would like to see changes made to your static resources in real time, please disable the web browser cache when working with LWC Code Preview.
 
 For some examples of how to disable the web browser cache, please see...
 

--- a/docs/_articles/en/codepreview/set-up-lwc-code-preview.md
+++ b/docs/_articles/en/codepreview/set-up-lwc-code-preview.md
@@ -20,11 +20,11 @@ After you select **SFDX: Preview Component**, the Command Palette displays a lis
 ## Recommended Settings
 
 **Disable Browser Cache**  
-If you would like to see changes made to your static resources in real time, please disable the web browser cache when working with LWC Code Preview.
+To see changes made to your static resources in real time, disable the web browser cache when working with LWC Code Preview.
 
-For some examples of how to disable the web browser cache, please see...
+For some examples of how to disable the web browser cache, see:
 
 - Chrome: https://www.technipages.com/google-chrome-how-to-completely-disable-cache
 - Safari: https://www.technipages.com/apple-safari-completely-disable-cache
 
-Another work around is to make changes to one of the .js or .html files within your component, which will recompile and cache your new static resources to the browser.
+Another workaround is to make changes to one of the `.js` or `.html` files within your component, which recompiles and caches your new static resources to the browser.

--- a/docs/_articles/ja/codepreview/set-up-lwc-code-preview.md
+++ b/docs/_articles/ja/codepreview/set-up-lwc-code-preview.md
@@ -12,6 +12,19 @@ Run this command from a command-line interface.
 ```
 sfdx plugins:install @salesforce/lwc-dev-server
 ```
+
 > **Troubleshooting Tip:** Due to a known issue, it's likely you'll see several errors when you install the plug-in. Run `sfdx plugins --core` to see if the plug-in is installed. If yes, try to start the Code Preview server. If successful, you're good to proceed.
 
 After you select **SFDX: Preview Component**, the Command Palette displays a list of preview options. You can choose to preview your component in the desktop browser or in a virtual mobile device (iOS or Android). Mobile previews require additional setup. See [Preview Lightning Web Components on Mobile](https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.mobile_extensions) in the _Lightning Web Components Dev Guide_.
+
+## Recommended Settings
+
+**Disable Browser Cache**  
+If you would like to see changes made to your static resources in real time (file additions and deletions to your `/staticresources/` folder), please disable the web browser cache when working with LWC Code Preview.
+
+For some examples of how to disable the web browser cache, please see...
+
+- Chrome: https://www.technipages.com/google-chrome-how-to-completely-disable-cache
+- Safari: https://www.technipages.com/apple-safari-completely-disable-cache
+
+Another work around is to make changes to one of the .js or .html files within your component, which will recompile and cache your new static resources to the browser.

--- a/docs/_articles/ja/codepreview/set-up-lwc-code-preview.md
+++ b/docs/_articles/ja/codepreview/set-up-lwc-code-preview.md
@@ -28,3 +28,5 @@ For some examples of how to disable the web browser cache, see:
 - Safari: https://www.technipages.com/apple-safari-completely-disable-cache
 
 Another workaround is to make changes to one of the `.js` or `.html` files within your component, which recompiles and caches your new static resources to the browser.
+
+> **Warning:** Disabling the browser cache may cause slowness for other websites and services. It is advisable to recheck this cache setting when no longer working within LWC Code Preview.

--- a/docs/_articles/ja/codepreview/set-up-lwc-code-preview.md
+++ b/docs/_articles/ja/codepreview/set-up-lwc-code-preview.md
@@ -20,7 +20,7 @@ After you select **SFDX: Preview Component**, the Command Palette displays a lis
 ## Recommended Settings
 
 **Disable Browser Cache**  
-If you would like to see changes made to your static resources in real time (file additions and deletions to your `/staticresources/` folder), please disable the web browser cache when working with LWC Code Preview.
+If you would like to see changes made to your static resources in real time, please disable the web browser cache when working with LWC Code Preview.
 
 For some examples of how to disable the web browser cache, please see...
 

--- a/docs/_articles/ja/codepreview/set-up-lwc-code-preview.md
+++ b/docs/_articles/ja/codepreview/set-up-lwc-code-preview.md
@@ -20,11 +20,11 @@ After you select **SFDX: Preview Component**, the Command Palette displays a lis
 ## Recommended Settings
 
 **Disable Browser Cache**  
-If you would like to see changes made to your static resources in real time, please disable the web browser cache when working with LWC Code Preview.
+To see changes made to your static resources in real time, disable the web browser cache when working with LWC Code Preview.
 
-For some examples of how to disable the web browser cache, please see...
+For some examples of how to disable the web browser cache, see:
 
 - Chrome: https://www.technipages.com/google-chrome-how-to-completely-disable-cache
 - Safari: https://www.technipages.com/apple-safari-completely-disable-cache
 
-Another work around is to make changes to one of the .js or .html files within your component, which will recompile and cache your new static resources to the browser.
+Another workaround is to make changes to one of the `.js` or `.html` files within your component, which recompiles and caches your new static resources to the browser.


### PR DESCRIPTION
### What does this PR do?
Adds documentation for disabling the browser cache for code preview. Also adds a workaround tip for those that do not want to disable the cache.

### What issues does this PR fix or reference?
@W-8247036@
