### PR TITLE
test: Increase hover test timeout to 10000

### DIFF
--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/hover.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/hover.test.ts
@@ -30,7 +30,7 @@ describe('LWC Hovers', () => {
   let client: LanguageClient;
 
   before(async function() {
-    this.timeout(5000);
+    this.timeout(10000);
     // creating a new client so that we can wait on its ready status before the
     // tests begin. set the timeout at the suite level to give the client some time
     // to get ready


### PR DESCRIPTION
### What does this PR do?

Adds more padding to the timeout for the lwc hover tests to allow the language client to initialize. If we find ourselves increasing this timeout more and more, we should reconsider doing something more drastic with the test.
