### PR TITLE
SOQL Code completion on WHERE clause

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "50.10.0",
+  "version": "50.11.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "docs",
     "packages/*"
   ],
-  "version": "50.10.0"
+  "version": "50.11.0"
 }

--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -2,7 +2,7 @@
   "name": "@salesforce/salesforcedx-apex-debugger",
   "displayName": "Apex Debugger Adapter",
   "description": "Implements the VS Code Debug Protocol for the Apex Debugger",
-  "version": "50.10.0",
+  "version": "50.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -12,7 +12,7 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-utils-vscode": "50.10.0",
+    "@salesforce/salesforcedx-utils-vscode": "50.11.0",
     "async-lock": "1.0.0",
     "faye": "1.1.2",
     "request-light": "0.2.4",
@@ -20,7 +20,7 @@
     "vscode-debugprotocol": "1.28.0"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "50.10.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "50.11.0",
     "@types/async-lock": "0.0.20",
     "@types/chai": "^4.0.0",
     "@types/mocha": "^5",

--- a/packages/salesforcedx-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-apex-replay-debugger/package.json
@@ -2,7 +2,7 @@
   "name": "@salesforce/salesforcedx-apex-replay-debugger",
   "displayName": "Apex Replay Debug Adapter",
   "description": "Implements the VS Code Debug Protocol for the Apex Replay Debugger",
-  "version": "50.10.0",
+  "version": "50.11.0",
   "publisher": "salesforce",
   "preview": true,
   "license": "BSD-3-Clause",
@@ -13,7 +13,7 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-utils-vscode": "50.10.0",
+    "@salesforce/salesforcedx-utils-vscode": "50.11.0",
     "vscode-debugadapter": "1.28.0",
     "vscode-debugprotocol": "1.28.0",
     "vscode-uri": "1.0.1"

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -2,7 +2,7 @@
   "name": "@salesforce/salesforcedx-sobjects-faux-generator",
   "displayName": "Salesforce SObject Faux Generator",
   "description": "Fetches sobjects and generates their faux apex class to be used for Apex Language Server",
-  "version": "50.10.0",
+  "version": "50.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@salesforce/core": "2.9.0",
-    "@salesforce/salesforcedx-utils-vscode": "50.10.0",
+    "@salesforce/salesforcedx-utils-vscode": "50.11.0",
     "cross-spawn": "6.0.5",
     "path-exists": "3.0.0",
     "rxjs": "^5.4.1",

--- a/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
@@ -189,7 +189,9 @@ export class FauxClassGenerator {
         err.stack
       );
     }
-    const filteredSObjects = sobjects.filter(this.isRequiredSObject);
+
+    const filteredSObjects = this.filterSObjects(sobjects, type, source);
+
     let j = 0;
     while (j < filteredSObjects.length) {
       try {
@@ -316,7 +318,23 @@ export class FauxClassGenerator {
   }
 
   // VisibleForTesting
-  public isRequiredSObject(sobject: string): boolean {
+  public filterSObjects(
+    sobjects: string[],
+    category: SObjectCategory,
+    source: SObjectRefreshSource
+  ): string[] {
+    if (
+      category === SObjectCategory.ALL &&
+      source === SObjectRefreshSource.Manual
+    ) {
+      // manually run by the user, does not exclude any sObjects
+      return sobjects;
+    }
+    // in all other cases we clean up the list
+    return sobjects.filter(this.isRequiredSObject);
+  }
+
+  private isRequiredSObject(sobject: string): boolean {
     // Ignore all sobjects that end with Share or History or Feed or Event
     return !/Share$|History$|Feed$|.+Event$/.test(sobject);
   }
@@ -514,17 +532,13 @@ export class FauxClassGenerator {
   ): string {
     // sort, but filter out duplicates
     // which can happen due to childRelationships w/o a relationshipName
-    declarations.sort(
-      (first, second): number => {
-        return first.name || first.type > second.name || second.type ? 1 : -1;
-      }
-    );
+    declarations.sort((first, second): number => {
+      return first.name || first.type > second.name || second.type ? 1 : -1;
+    });
 
-    declarations = declarations.filter(
-      (value, index, array): boolean => {
-        return !index || value.name !== array[index - 1].name;
-      }
-    );
+    declarations = declarations.filter((value, index, array): boolean => {
+      return !index || value.name !== array[index - 1].name;
+    });
 
     const classDeclaration = `${MODIFIER} class ${className} {${EOL}`;
     const declarationLines = declarations

--- a/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
@@ -318,7 +318,7 @@ export class FauxClassGenerator {
   // VisibleForTesting
   public isRequiredSObject(sobject: string): boolean {
     // Ignore all sobjects that end with Share or History or Feed or Event
-    return !/Share$|History$|Feed$|Event$/.test(sobject);
+    return !/Share$|History$|Feed$|.+Event$/.test(sobject);
   }
 
   // VisibleForTesting

--- a/packages/salesforcedx-sobjects-faux-generator/test/unit/fauxClassGenerator.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/unit/fauxClassGenerator.test.ts
@@ -16,7 +16,8 @@ import { CUSTOMOBJECTS_DIR, STANDARDOBJECTS_DIR } from '../../src/constants';
 import { SObjectCategory } from '../../src/describe';
 import {
   FauxClassGenerator,
-  INDENT
+  INDENT,
+  SObjectRefreshSource
 } from '../../src/generator/fauxClassGenerator';
 import { nls } from '../../src/messages';
 import { customSObject } from './sObjectMockData';
@@ -432,14 +433,70 @@ describe('SObject faux class generator', () => {
       expect(!fs.existsSync(customFolder));
       expect(!fs.existsSync(standardFolder));
     });
+  });
 
-    it('Should remove sobjects ending with Share, History, Feed, Event', () => {
-      const sobjects: string[] = ['xShare', 'Sharex', 'yHistory', 'xFeed', 'xFeedy', 'zEvent', 'Event'];
-      const output = sobjects.filter(gen.isRequiredSObject);
-      expect(output.length).to.equal(3);
-      expect(output).to.contain('Sharex');
-      expect(output).to.contain('xFeedy');
-      expect(output).to.contain('Event');
+  describe('SObjects Filter', () => {
+    const gen = getGenerator();
+    // sobjects to filter
+    const sobjects: string[] = [
+      'xShare',
+      'Sharex',
+      'yHistory',
+      'xFeed',
+      'xFeedy',
+      'zEvent',
+      'Event'
+    ];
+    // expected result when filtered
+    const expectedFilteredSObjects: string[] = ['Sharex', 'xFeedy', 'Event'];
+    describe('When source is Startup', () => {
+      const source = SObjectRefreshSource.Startup;
+      it('Should remove sobjects ending with Share, History, Feed, Event', () => {
+        const output = gen.filterSObjects(
+          sobjects,
+          SObjectCategory.ALL,
+          source
+        );
+        expect(output).to.deep.equal(expectedFilteredSObjects);
+      });
+    });
+    describe('When source is StartupMin', () => {
+      const source = SObjectRefreshSource.StartupMin;
+      it('Should remove sobjects ending with Share, History, Feed, Event', () => {
+        const output = gen.filterSObjects(
+          sobjects,
+          SObjectCategory.ALL,
+          source
+        );
+        expect(output).to.deep.equal(expectedFilteredSObjects);
+      });
+    });
+    describe('When source is Manual', () => {
+      const source = SObjectRefreshSource.Manual;
+      it('Should remove sobjects ending with Share, History, Feed, Event if category is CUSTOM', () => {
+        const output = gen.filterSObjects(
+          sobjects,
+          SObjectCategory.CUSTOM,
+          source
+        );
+        expect(output).to.deep.equal(expectedFilteredSObjects);
+      });
+      it('Should remove sobjects ending with Share, History, Feed, Event if category is STANDARD', () => {
+        const output = gen.filterSObjects(
+          sobjects,
+          SObjectCategory.STANDARD,
+          source
+        );
+        expect(output).to.deep.equal(expectedFilteredSObjects);
+      });
+      it('Should NOT remove sobjects ending with Share, History, Feed, Event if category is ALL', () => {
+        const output = gen.filterSObjects(
+          sobjects,
+          SObjectCategory.ALL,
+          source
+        );
+        expect(output).to.equal(sobjects);
+      });
     });
   });
 });

--- a/packages/salesforcedx-sobjects-faux-generator/test/unit/fauxClassGenerator.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/unit/fauxClassGenerator.test.ts
@@ -434,11 +434,12 @@ describe('SObject faux class generator', () => {
     });
 
     it('Should remove sobjects ending with Share, History, Feed, Event', () => {
-      const sobjects: string[] = ['xShare', 'Sharex', 'yHistory', 'xFeed', 'xFeedy', 'zEvent'];
+      const sobjects: string[] = ['xShare', 'Sharex', 'yHistory', 'xFeed', 'xFeedy', 'zEvent', 'Event'];
       const output = sobjects.filter(gen.isRequiredSObject);
-      expect(output.length).to.equal(2);
+      expect(output.length).to.equal(3);
       expect(output).to.contain('Sharex');
       expect(output).to.contain('xFeedy');
+      expect(output).to.contain('Event');
     });
   });
 });

--- a/packages/salesforcedx-test-utils-vscode/package.json
+++ b/packages/salesforcedx-test-utils-vscode/package.json
@@ -2,14 +2,14 @@
   "name": "@salesforce/salesforcedx-test-utils-vscode",
   "displayName": "SFDX Test Utilities for VS Code",
   "description": "Provides test utilities to interface the SFDX libraries with VS Code",
-  "version": "50.10.0",
+  "version": "50.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "categories": [
     "Other"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-utils-vscode": "50.10.0",
+    "@salesforce/salesforcedx-utils-vscode": "50.11.0",
     "shelljs": "0.8.3"
   },
   "devDependencies": {

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "SFDX Utilities for VS Code",
   "description": "Provides utilities to interface the SFDX libraries with VS Code",
   "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
-  "version": "50.10.0",
+  "version": "50.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "categories": [

--- a/packages/salesforcedx-visualforce-language-server/package.json
+++ b/packages/salesforcedx-visualforce-language-server/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@salesforce/salesforcedx-visualforce-language-server",
   "description": "Visualforce language server",
-  "version": "50.10.0",
+  "version": "50.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
     "vscode": "^1.46.0"
   },
   "dependencies": {
-    "@salesforce/salesforcedx-visualforce-markup-language-server": "50.10.0",
+    "@salesforce/salesforcedx-visualforce-markup-language-server": "50.11.0",
     "typescript": "3.7.5",
     "vscode-css-languageservice": "2.1.9",
     "vscode-languageserver": "5.2.1",

--- a/packages/salesforcedx-visualforce-markup-language-server/package.json
+++ b/packages/salesforcedx-visualforce-markup-language-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/salesforcedx-visualforce-markup-language-server",
   "description": "Language service for Visualforce Markup",
-  "version": "50.10.0",
+  "version": "50.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "50.10.0",
+  "version": "50.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -24,12 +24,12 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-apex-debugger": "50.10.0",
+    "@salesforce/salesforcedx-apex-debugger": "50.11.0",
     "vscode-debugprotocol": "1.28.0",
     "vscode-extension-telemetry": "0.0.17"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "50.10.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "50.11.0",
     "@types/chai": "^4.0.0",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "50.10.0",
+  "version": "50.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -24,14 +24,14 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-apex-replay-debugger": "50.10.0",
+    "@salesforce/salesforcedx-apex-replay-debugger": "50.11.0",
     "async-lock": "1.0.0",
     "path-exists": "3.0.0",
     "request-light": "0.2.4",
     "vscode-extension-telemetry": "0.0.17"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "50.10.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "50.11.0",
     "@types/async-lock": "0.0.20",
     "@types/chai": "^4.0.0",
     "@types/mocha": "^5",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "50.10.0",
+  "version": "50.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -26,8 +26,8 @@
   "dependencies": {
     "@salesforce/apex-tmlanguage": "1.4.0",
     "@salesforce/core": "2.11.0",
-    "@salesforce/salesforcedx-sobjects-faux-generator": "50.10.0",
-    "@salesforce/salesforcedx-utils-vscode": "50.10.0",
+    "@salesforce/salesforcedx-sobjects-faux-generator": "50.11.0",
+    "@salesforce/salesforcedx-utils-vscode": "50.11.0",
     "expand-home-dir": "0.0.3",
     "find-java-home": "0.2.0",
     "path-exists": "3.0.0",
@@ -36,7 +36,7 @@
     "vscode-languageclient": "5.1.1"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "50.10.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "50.11.0",
     "@types/chai": "^4.0.0",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -15,7 +15,7 @@
     "theme": "light"
   },
   "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
-  "version": "50.10.0",
+  "version": "50.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -27,7 +27,7 @@
   "dependencies": {
     "@salesforce/apex-node": "0.1.4",
     "@salesforce/core": "2.11.0",
-    "@salesforce/salesforcedx-utils-vscode": "50.10.0",
+    "@salesforce/salesforcedx-utils-vscode": "50.11.0",
     "@salesforce/schemas": "^1",
     "@salesforce/source-deploy-retrieve": "1.1.14",
     "@salesforce/templates": "50.1.0",
@@ -41,7 +41,7 @@
     "xmldom-sfdx-encoding": "0.1.29"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "50.10.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "50.11.0",
     "@salesforce/ts-sinon": "^1.0.0",
     "@types/adm-zip": "^0.4.31",
     "@types/chai": "^4.0.0",

--- a/packages/salesforcedx-vscode-expanded/package.json
+++ b/packages/salesforcedx-vscode-expanded/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "50.10.0",
+  "version": "50.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -15,7 +15,7 @@
     "theme": "light"
   },
   "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
-  "version": "50.10.0",
+  "version": "50.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -29,13 +29,13 @@
     "@salesforce/core": "2.11.0",
     "@salesforce/lightning-lsp-common": "3.0.12",
     "@salesforce/lwc-language-server": "3.0.12",
-    "@salesforce/salesforcedx-utils-vscode": "50.10.0",
+    "@salesforce/salesforcedx-utils-vscode": "50.11.0",
     "applicationinsights": "1.0.7",
     "vscode-extension-telemetry": "0.0.17",
     "vscode-languageclient": "^5.2.1"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "50.10.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "50.11.0",
     "@types/chai": "^4.0.0",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -15,7 +15,7 @@
     "theme": "light"
   },
   "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
-  "version": "50.10.0",
+  "version": "50.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -29,7 +29,7 @@
     "@salesforce/eslint-config-lwc": "0.3.0",
     "@salesforce/lightning-lsp-common": "3.0.12",
     "@salesforce/lwc-language-server": "3.0.12",
-    "@salesforce/salesforcedx-utils-vscode": "50.10.0",
+    "@salesforce/salesforcedx-utils-vscode": "50.11.0",
     "ajv": "^6.1.1",
     "applicationinsights": "1.0.7",
     "eslint": "5.0.0",
@@ -42,7 +42,7 @@
     "vscode-languageclient": "^5.2.1"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "50.10.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "50.11.0",
     "@types/chai": "^4.0.0",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/hover.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/hover.test.ts
@@ -30,7 +30,7 @@ describe('LWC Hovers', () => {
   let client: LanguageClient;
 
   before(async function() {
-    this.timeout(5000);
+    this.timeout(10000);
     // creating a new client so that we can wait on its ready status before the
     // tests begin. set the timeout at the suite level to give the client some time
     // to get ready

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/forcedotcom/salesforcedx-vscode"
   },
   "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
-  "version": "50.10.0",
+  "version": "50.11.0",
   "preview": true,
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
@@ -35,7 +35,7 @@
   "dependencies": {
     "@salesforce/apex-tmlanguage": "1.5.0",
     "@salesforce/core": "^2.15.2",
-    "@salesforce/salesforcedx-utils-vscode": "50.10.0",
+    "@salesforce/salesforcedx-utils-vscode": "50.11.0",
     "@salesforce/soql-builder-ui": "0.0.23",
     "@salesforce/soql-data-view": "0.0.7",
     "@salesforce/soql-language-server": "0.2.9",
@@ -47,7 +47,7 @@
     "vscode-languageserver-protocol": "3.15.3"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "50.10.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "50.11.0",
     "@salesforce/ts-sinon": "1.2.2",
     "@types/chai": "^4.0.0",
     "@types/debounce": "^1.2.0",

--- a/packages/salesforcedx-vscode-visualforce/package.json
+++ b/packages/salesforcedx-vscode-visualforce/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "50.10.0",
+  "version": "50.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -24,15 +24,15 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-visualforce-language-server": "50.10.0",
-    "@salesforce/salesforcedx-visualforce-markup-language-server": "50.10.0",
+    "@salesforce/salesforcedx-visualforce-language-server": "50.11.0",
+    "@salesforce/salesforcedx-visualforce-markup-language-server": "50.11.0",
     "vscode-extension-telemetry": "0.0.17",
     "vscode-languageclient": "5.2.1",
     "vscode-languageserver-protocol": "3.14.1",
     "vscode-languageserver-types": "3.14.0"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "50.10.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "50.11.0",
     "@types/chai": "^4.0.0",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",

--- a/packages/salesforcedx-vscode/package.json
+++ b/packages/salesforcedx-vscode/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "50.10.0",
+  "version": "50.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {

--- a/packages/system-tests/package.json
+++ b/packages/system-tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "system-tests",
   "description": "System tests for Salesforce DX Extensions for VS Code",
-  "version": "50.10.0",
+  "version": "50.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "main": "./out/src",
@@ -9,8 +9,8 @@
     "vscode": "^1.46.0"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "50.10.0",
-    "@salesforce/salesforcedx-utils-vscode": "50.10.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "50.11.0",
+    "@salesforce/salesforcedx-utils-vscode": "50.11.0",
     "@types/chai": "^4.0.0",
     "@types/mkdirp": "0.5.2",
     "@types/mocha": "^5",


### PR DESCRIPTION
### What does this PR do?

Code completion of WHERE clause expressions
    
  * Complete operators based on type of field
  * Complete literal values based on type of field
  * Show type name (and icon) on completion items for fields
  * Offer NULL as a completion value only if field is nillable
    
Also: refactoring of "placeholder" completion items: receive JSON data instead
of parseable values inside item label string.

### What issues does this PR fix or reference?
@W-8597428@

See also: https://github.com/forcedotcom/soql-tooling/pull/112

### Functionality Before
n/a

### Functionality After
https://user-images.githubusercontent.com/152839/103246284-b139f700-4941-11eb-9228-2a56fc06dd87.mov
