### PR TITLE
SOQL code-completion on WHERE clause expressions

### DIFF
--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -38,7 +38,7 @@
     "@salesforce/salesforcedx-utils-vscode": "50.13.0",
     "@salesforce/soql-builder-ui": "0.0.23",
     "@salesforce/soql-data-view": "0.0.7",
-    "@salesforce/soql-language-server": "0.2.9",
+    "@salesforce/soql-language-server": "0.3.2",
     "debounce": "^1.2.0",
     "jsforce": "^1.10.0",
     "papaparse": "^5.3.0",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -56,7 +56,7 @@
     "@types/mocha": "^5",
     "@types/node": "12.0.12",
     "@types/papaparse": "^5.2.3",
-    "@types/sinon": "^2.3.2",
+    "@types/sinon": "7.5.2",
     "@types/vscode": "1.46.0",
     "@typescript-eslint/eslint-plugin": "^3.7.1",
     "@typescript-eslint/parser": "^3.7.1",
@@ -67,7 +67,7 @@
     "eslint-plugin-jsdoc": "^30.0.3",
     "eslint-plugin-prettier": "^3.1.4",
     "mocha": "^5",
-    "sinon": "^7.3.1",
+    "sinon": "7.5.0",
     "typescript": "3.7.5"
   },
   "scripts": {

--- a/packages/salesforcedx-vscode-soql/src/client/codeCompletion.ts
+++ b/packages/salesforcedx-vscode-soql/src/client/codeCompletion.ts
@@ -5,12 +5,13 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { CompletionItemKind } from 'vscode';
+import { CompletionItemKind, SnippetString } from 'vscode';
 import ProtocolCompletionItem from 'vscode-languageclient/lib/protocolCompletionItem';
 import { retrieveSObject, retrieveSObjects } from '../sfdx';
 
 import { Middleware } from 'vscode-languageclient';
-import { FieldType } from 'jsforce';
+
+const EXPANDABLE_ITEM_PATTERN = /__([A-Z_]+)/;
 
 export const middleware: Middleware = {
   // The SOQL LSP server may include special completion items as "placeholders" for
@@ -26,39 +27,76 @@ export const middleware: Middleware = {
       token
     )) as ProtocolCompletionItem[];
 
-    return expandPlaceholders(items);
+    return expandPlaceholders(await filterByContext(items));
   }
 };
 
-const expandableItemPattern = /__([A-Z_]+)(:(\w+(,\w+)*))?/;
+interface SoqlItemContext {
+  sobjectName: string;
+  fieldName?: string;
+  notNillable?: boolean;
+}
+
+async function filterByContext(
+  items: ProtocolCompletionItem[]
+): Promise<ProtocolCompletionItem[]> {
+  const filteredItems: ProtocolCompletionItem[] = [];
+
+  for (const item of items) {
+    if (
+      !EXPANDABLE_ITEM_PATTERN.test(item.label) &&
+      item?.data?.soqlContext?.sobjectName
+    ) {
+      const objMetadata = await retrieveSObject(
+        item.data.soqlContext.sobjectName
+      );
+      const fieldMeta = objMetadata.fields.find(
+        field => field.name === item.data.soqlContext.fieldName
+      );
+      if (fieldMeta && !operatorsByType[fieldMeta.type].includes(item.label)) {
+        continue;
+      }
+    }
+
+    filteredItems.push(item);
+  }
+
+  return filteredItems;
+}
+
 async function expandPlaceholders(
   items: ProtocolCompletionItem[]
 ): Promise<ProtocolCompletionItem[]> {
   const expandedItems = [...items];
 
-  items.forEach(async (item, index) => {
-    const m = item.label.match(expandableItemPattern);
-    if (m) {
-      const command = m[1];
-      const args = m[3] ? m[3].split(',') : [];
+  for (const [index, item] of items.entries()) {
+    const parsedCommand = item.label.match(EXPANDABLE_ITEM_PATTERN);
+    if (parsedCommand) {
+      const commandName = parsedCommand[1];
 
-      const handler = expandFunctions[command];
+      const handler = expandFunctions[commandName];
       if (!handler) {
-        console.log(`Unknown SOQL completion command ${command}!`);
+        console.log(`Unknown SOQL completion command ${commandName}!`);
       }
 
-      expandedItems.splice(index, 1, ...(await handler(args)));
+      expandedItems.splice(
+        index,
+        1,
+        ...(await handler(item?.data?.soqlContext))
+      );
     }
-  });
+  }
 
   return expandedItems;
 }
 
 const expandFunctions: {
-  [key: string]: (args: string[]) => Promise<ProtocolCompletionItem[]>;
+  [key: string]: (
+    soqlContext?: SoqlItemContext
+  ) => Promise<ProtocolCompletionItem[]>;
 } = {
   SOBJECTS_PLACEHOLDER: async (
-    args: string[]
+    soqlContext?: SoqlItemContext
   ): Promise<ProtocolCompletionItem[]> => {
     try {
       const sobjectItems = (await retrieveSObjects()).map(objName => {
@@ -66,6 +104,7 @@ const expandFunctions: {
         item.kind = CompletionItemKind.Class;
         return item;
       });
+
       return sobjectItems;
     } catch (metadataErrors) {
       return [];
@@ -73,19 +112,31 @@ const expandFunctions: {
   },
 
   SOBJECT_FIELDS_PLACEHOLDER: async (
-    args: string[]
+    soqlContext?: SoqlItemContext
   ): Promise<ProtocolCompletionItem[]> => {
-    try {
-      const objMetadata = await retrieveSObject(args[0]);
-      const sobjectFields = objMetadata.fields.reduce((fieldItems, field) => {
-        fieldItems.push(newFieldCompletionItem(field.name, field.name));
+    if (!soqlContext?.sobjectName) {
+      console.log('SOBJECT_FIELDS_PLACEHOLDER missing `sobjectName`!');
+      return [];
+    }
 
+    try {
+      const objMetadata = await retrieveSObject(soqlContext.sobjectName);
+      const sobjectFields = objMetadata.fields.reduce((fieldItems, field) => {
+        fieldItems.push(
+          newCompletionItem(
+            field.name,
+            field.name,
+            CompletionItemKind.Field,
+            field.type
+          )
+        );
         if (field.relationshipName) {
           fieldItems.push(
-            newFieldCompletionItem(
-              `${field.relationshipName} \(${field.referenceTo}\)`,
+            newCompletionItem(
+              `${field.relationshipName}`,
               field.relationshipName + '.',
-              CompletionItemKind.Class
+              CompletionItemKind.Class,
+              'Ref. to ' + field.referenceTo
             )
           );
         }
@@ -96,16 +147,126 @@ const expandFunctions: {
     } catch (metadataError) {
       return [];
     }
+  },
+  LITERAL_VALUES_FOR_FIELD: async (
+    soqlContext?: SoqlItemContext
+  ): Promise<ProtocolCompletionItem[]> => {
+    let items: ProtocolCompletionItem[] = [];
+
+    if (!soqlContext?.sobjectName || !soqlContext?.fieldName) {
+      console.log('LITERAL_VALUES_FOR_FIELD missing `sobjectName/fieldName`!');
+      return [];
+    }
+
+    try {
+      const objMetadata = await retrieveSObject(soqlContext.sobjectName);
+      const nillables = objMetadata.fields
+        // .filter(field => field.nillable)
+        .map(f => ({ name: f.name, type: f.type, nillable: f.nillable }));
+      if (nillables) {
+        // debugger;
+        console.log('for debugging');
+      }
+      const fieldMeta = objMetadata.fields.find(
+        field => field.name === soqlContext.fieldName
+      );
+      if (fieldMeta) {
+        if (
+          ['picklist', 'multipicklist'].includes(fieldMeta.type) &&
+          fieldMeta?.picklistValues
+        ) {
+          items = items.concat(
+            fieldMeta.picklistValues
+              .filter(v => v.active)
+              .map(v =>
+                newCompletionItem(
+                  v.value,
+                  "'" + v.value + "'",
+                  CompletionItemKind.Value
+                )
+              )
+          );
+        } else if (fieldMeta.type === 'boolean') {
+          items.push(
+            newCompletionItem('TRUE', 'TRUE', CompletionItemKind.Value)
+          );
+          items.push(
+            newCompletionItem('FALSE', 'FALSE', CompletionItemKind.Value)
+          );
+        } else if (fieldMeta.type === 'date') {
+          items.push(
+            newCompletionItem(
+              'YYYY-MM-DD',
+              '${1:${CURRENT_YEAR}}-${2:${CURRENT_MONTH}}-${3:${CURRENT_DATE}}$0',
+              CompletionItemKind.Snippet
+            )
+          );
+        } else if (fieldMeta.type === 'datetime') {
+          items.push(
+            newCompletionItem(
+              'YYYY-MM-DDThh:mm:ssZ',
+              '${1:${CURRENT_YEAR}}-${2:${CURRENT_MONTH}}-${3:${CURRENT_DATE}}T${4:${CURRENT_HOUR}}:${5:${CURRENT_MINUTE}}:${6:${CURRENT_SECOND}}Z$0',
+              CompletionItemKind.Snippet
+            )
+          );
+        }
+
+        if (fieldMeta.nillable && !soqlContext.notNillable) {
+          items.push(
+            newCompletionItem('NULL', 'NULL', CompletionItemKind.Keyword)
+          );
+        }
+      }
+
+      return items;
+    } catch (metadataError) {
+      return [];
+    }
   }
 };
 
-function newFieldCompletionItem(
+// All types allow equality operators
+// Here we list the extra operators supported on each type
+const operatorsByType: { [key: string]: string[] } = {
+  address: [],
+  anyType: ['<', '<=', '>=', '>'],
+  base64: [],
+  boolean: [],
+  combobox: [],
+  complexvalue: ['<', '<=', '>=', '>'],
+  currency: ['<', '<=', '>=', '>'],
+  date: ['<', '<=', '>=', '>'],
+  datetime: ['<', '<=', '>=', '>'],
+  double: ['<', '<=', '>=', '>'],
+  email: [],
+  encryptedstring: [],
+  int: ['<', '<=', '>=', '>'],
+  id: [],
+  location: [],
+  percent: ['<', '<=', '>=', '>'],
+  phone: [],
+  picklist: [],
+  multipicklist: ['INCLUDES(', 'EXCLUDES('],
+  reference: [],
+  string: ['<', '<=', '>=', '>', 'LIKE'],
+  textarea: ['<', '<=', '>=', '>', 'LIKE'],
+  time: ['<', '<=', '>=', '>', 'LIKE'],
+  url: ['<', '<=', '>=', '>']
+};
+
+function newCompletionItem(
   label: string,
   insertText?: string,
-  kind: CompletionItemKind = CompletionItemKind.Field
+  kind: CompletionItemKind = CompletionItemKind.Field,
+  detail?: string
 ): ProtocolCompletionItem {
   const item = new ProtocolCompletionItem(label);
   item.kind = kind;
-  item.insertText = insertText;
+  item.insertText =
+    kind === CompletionItemKind.Snippet
+      ? new SnippetString(insertText)
+      : insertText;
+  item.detail = detail;
+
   return item;
 }

--- a/packages/salesforcedx-vscode-soql/src/index.ts
+++ b/packages/salesforcedx-vscode-soql/src/index.ts
@@ -10,7 +10,7 @@ import { startLanguageClient, stopLanguageClient } from './client/client';
 import { soqlBuilderToggle, soqlOpenNew } from './commands';
 import { SOQLEditorProvider } from './editor/soqlEditorProvider';
 import { QueryDataViewService } from './queryDataView/queryDataViewService';
-import { workspaceContext } from './sfdx';
+import { workspaceContext, channelService } from './sfdx';
 import { startTelemetry, stopTelemetry } from './telemetry';
 
 export async function activate(context: vscode.ExtensionContext): Promise<any> {
@@ -29,7 +29,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
   await startLanguageClient(context);
   startTelemetry(context, extensionHRStart).catch();
   console.log('SOQL Extension Activated');
-  return { workspaceContext };
+  return { workspaceContext, channelService };
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/client/client.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/client/client.test.ts
@@ -8,6 +8,8 @@
 import { expect } from 'chai';
 import * as path from 'path';
 import * as sinon from 'sinon';
+import { stubInterface } from '@salesforce/ts-sinon';
+
 import {
   extensions,
   languages,
@@ -15,14 +17,16 @@ import {
   Uri,
   window,
   workspace,
+  WorkspaceConfiguration,
   commands
 } from 'vscode';
 import { clearDiagnostics } from '../../../src/client/client';
-import { stubMockConnection, MockConnection } from '../testUtilities';
+import { stubMockConnection } from '../testUtilities';
 import {
   SOQL_CONFIGURATION_NAME,
   SOQL_VALIDATION_CONFIG
 } from '../../../src/constants';
+import { Connection } from 'jsforce';
 
 async function sleep(ms: number = 0) {
   return new Promise(resolve => {
@@ -43,7 +47,7 @@ describe('SOQL language client', () => {
   let sandbox: sinon.SinonSandbox;
   let soqlFileUri: Uri;
   let textEditor: TextEditor;
-  let mockConnection: MockConnection;
+  let mockConnection: Connection;
   let soqlExtension: any;
 
   beforeEach(async () => {
@@ -187,9 +191,9 @@ function stubSOQLExtensionConfiguration(
   configValues: { [key: string]: any },
   extension: any
 ) {
-  const mockConfiguration = {
+  const mockConfiguration = stubInterface<WorkspaceConfiguration>(sandbox, {
     get: (key: string) => configValues[key]
-  };
+  });
 
   expect(
     Object.keys(extension.packageJSON.contributes.configuration.properties)

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/client/client.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/client/client.test.ts
@@ -26,7 +26,7 @@ import {
   SOQL_CONFIGURATION_NAME,
   SOQL_VALIDATION_CONFIG
 } from '../../../src/constants';
-import { Connection } from 'jsforce';
+import { Connection } from '@salesforce/core';
 
 async function sleep(ms: number = 0) {
   return new Promise(resolve => {

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/client/completion.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/client/completion.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { expect } from 'chai';
-import { Connection } from 'jsforce';
+import { Connection } from '@salesforce/core';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/commands/soqlBuilderToggle.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/commands/soqlBuilderToggle.test.ts
@@ -19,8 +19,11 @@ describe('soqlBuilderToggle should', () => {
 
   beforeEach(() => {
     sb = createSandbox();
-    telemetryStub = sb.stub(telemetryService, 'sendCommandEvent');
-    executeCommandSpy = sb.spy(vscode.commands, 'executeCommand');
+    telemetryStub = sb.stub(telemetryService, 'sendCommandEvent') as SinonStub;
+    executeCommandSpy = (sb.spy(
+      vscode.commands,
+      'executeCommand'
+    ) as unknown) as SinonSpy;
   });
 
   afterEach(async () => {

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/commands/soqlFileCreate.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/commands/soqlFileCreate.test.ts
@@ -20,10 +20,13 @@ describe('soqlOpenNew should', () => {
 
   beforeEach(() => {
     sb = createSandbox();
-    telemetryStub = sb.stub(telemetryService, 'sendCommandEvent');
+    telemetryStub = sb.stub(telemetryService, 'sendCommandEvent') as SinonStub;
     editorOpened = sb.stub();
     vscode.workspace.onDidOpenTextDocument(editorOpened);
-    executeCommandSpy = sb.spy(vscode.commands, 'executeCommand');
+    executeCommandSpy = (sb.spy(
+      vscode.commands,
+      'executeCommand'
+    ) as unknown) as SinonSpy;
   });
 
   afterEach(async () => {

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/editor/queryRunner.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/editor/queryRunner.test.ts
@@ -6,16 +6,13 @@
  */
 
 import { expect } from 'chai';
+import { Connection } from 'jsforce';
 import * as sinon from 'sinon';
 import { QueryRunner } from '../../../src/editor/queryRunner';
-import {
-  getMockConnection,
-  MockConnection,
-  mockQueryText
-} from '../testUtilities';
+import { getMockConnection, mockQueryText } from '../testUtilities';
 
 describe('Query Runner Should', () => {
-  let mockConnection: MockConnection;
+  let mockConnection: Connection;
   let sandbox: sinon.SinonSandbox;
 
   beforeEach(() => {

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/editor/queryRunner.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/editor/queryRunner.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { expect } from 'chai';
-import { Connection } from 'jsforce';
+import { Connection } from '@salesforce/core';
 import * as sinon from 'sinon';
 import { QueryRunner } from '../../../src/editor/queryRunner';
 import { getMockConnection, mockQueryText } from '../testUtilities';

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/editor/soqlEditorInstance.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/editor/soqlEditorInstance.test.ts
@@ -11,15 +11,12 @@ import * as vscode from 'vscode';
 import * as commonUtils from '../../../src/commonUtils';
 import { MessageType } from '../../../src/editor/soqlEditorInstance';
 import {
-  MockConnection,
   mockSObject,
   MockTextDocumentProvider,
-  stubMockConnection,
   TestSoqlEditorInstance
 } from '../testUtilities';
 
 describe('SoqlEditorInstance should', () => {
-  let mockConnection: MockConnection;
   let mockWebviewPanel: vscode.WebviewPanel;
   let docProviderDisposable: vscode.Disposable;
   let mockTextDocument: vscode.TextDocument;
@@ -45,7 +42,6 @@ describe('SoqlEditorInstance should', () => {
 
   beforeEach(async () => {
     sandbox = sinon.createSandbox();
-    mockConnection = stubMockConnection(sandbox);
     docProviderDisposable = vscode.workspace.registerTextDocumentContentProvider(
       'sfdc-test',
       new MockTextDocumentProvider()

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/testUtilities.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/testUtilities.ts
@@ -91,6 +91,7 @@ export const mockSObjects = [
         label: 'Account ID',
         custom: false,
         groupable: true,
+        nillable: false,
         relationshipName: null,
         sortable: true,
         type: 'id',
@@ -104,9 +105,71 @@ export const mockSObjects = [
         label: 'Account Name',
         name: 'Name',
         nameField: true,
+        nillable: false,
         sortable: true,
         type: 'string',
         updateable: true
+      },
+      {
+        aggregatable: true,
+        custom: false,
+        filterable: true,
+        groupable: true,
+        label: 'Billing City',
+        name: 'BillingCity',
+        nameField: false,
+        nillable: true,
+        sortable: true,
+        type: 'string',
+        updateable: true
+      },
+      {
+        aggregatable: false,
+        calculated: false,
+        custom: false,
+        defaultValue: false,
+        filterable: true,
+        groupable: true,
+        label: 'Deleted',
+        name: 'IsDeleted',
+        nameField: false,
+        nillable: false,
+        sortable: true,
+        type: 'boolean',
+        unique: false,
+        updateable: false
+      },
+      {
+        aggregatable: false,
+        calculated: false,
+        custom: false,
+        defaultValue: false,
+        filterable: true,
+        groupable: true,
+        label: 'LastActivityDate',
+        name: 'LastActivityDate',
+        nameField: false,
+        nillable: false,
+        sortable: true,
+        type: 'date',
+        unique: false,
+        updateable: false
+      },
+      {
+        aggregatable: false,
+        calculated: false,
+        custom: false,
+        defaultValue: false,
+        filterable: true,
+        groupable: true,
+        label: 'CreatedDate',
+        name: 'CreatedDate',
+        nameField: false,
+        nillable: false,
+        sortable: true,
+        type: 'datetime',
+        unique: false,
+        updateable: false
       }
     ]
   },
@@ -145,6 +208,68 @@ export const mockSObjects = [
         referenceTo: ['Account'],
         relationshipName: 'Account',
         type: 'reference'
+      },
+      {
+        aggregatable: false,
+        calculated: false,
+        custom: false,
+        defaultValue: false,
+        filterable: true,
+        groupable: true,
+        label: 'Deleted',
+        name: 'IsDeleted',
+        nameField: false,
+        nillable: false,
+        sortable: true,
+        type: 'boolean',
+        unique: false,
+        updateable: false
+      }
+    ]
+  },
+  {
+    name: 'QuickText',
+    fields: [
+      {
+        aggregatable: false,
+        defaultValue: 'Email',
+        filterable: true,
+        groupable: false,
+        label: 'Channel',
+        name: 'Channel',
+        nillable: true,
+        picklistValues: [
+          {
+            active: true,
+            defaultValue: true,
+            label: 'Email',
+            validFor: null,
+            value: 'Email'
+          },
+          {
+            active: true,
+            defaultValue: false,
+            label: 'Portal',
+            validFor: null,
+            value: 'Portal'
+          },
+          {
+            active: true,
+            defaultValue: false,
+            label: 'Phone',
+            validFor: null,
+            value: 'Phone'
+          },
+          {
+            active: false,
+            label: 'INACTIVE',
+            value: 'INACTIVE'
+          }
+        ],
+        sortable: false,
+        type: 'multipicklist',
+        unique: false,
+        updateable: true
       }
     ]
   }


### PR DESCRIPTION
### What does this PR do?

Code completion of WHERE clause expressions
    
  * Complete operators based on type of field
  * Complete literal values based on type of field
  * Show type name (and icon) on completion items for fields
  * Offer NULL as a completion value only if field is nillable
    
Also: refactoring of "placeholder" completion items: receive JSON data instead
of parseable values inside item label string.

### What issues does this PR fix or reference?
@W-8597428@

Related LSP-server PR: https://github.com/forcedotcom/soql-tooling/pull/112

### Functionality Before
n/a

### Functionality After
https://user-images.githubusercontent.com/152839/103246284-b139f700-4941-11eb-9228-2a56fc06dd87.mov

https://user-images.githubusercontent.com/152839/103816838-60fb1d00-5044-11eb-9c42-8336da6bb86b.mov
