### PR TITLE
bug: fix bug causing soql builder does not show (#2827)

### DIFF
--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -94,7 +94,7 @@
   "contributes": {
     "customEditors": [
       {
-        "viewType": "%soqlCustom_soql%",
+        "viewType": "soqlCustom.soql",
         "displayName": "SOQL Builder",
         "selector": [
           {

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/commands/soqlFileCreate.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/commands/soqlFileCreate.test.ts
@@ -6,21 +6,24 @@
  */
 
 import { expect } from 'chai';
-import { SinonSandbox, createSandbox, SinonStub } from 'sinon';
+import { SinonSandbox, createSandbox, SinonSpy, SinonStub } from 'sinon';
 import * as vscode from 'vscode';
 import { soqlOpenNew } from '../../../src/commands/soqlFileCreate';
+import { EDITOR_VIEW_TYPE } from '../../../src/constants';
 import { telemetryService } from '../../../src/telemetry';
 
 describe('soqlOpenNew should', () => {
   let sb: SinonSandbox;
   let telemetryStub: SinonStub;
   let editorOpened: SinonStub;
+  let executeCommandSpy: SinonSpy;
 
   beforeEach(() => {
     sb = createSandbox();
     telemetryStub = sb.stub(telemetryService, 'sendCommandEvent');
     editorOpened = sb.stub();
     vscode.workspace.onDidOpenTextDocument(editorOpened);
+    executeCommandSpy = sb.spy(vscode.commands, 'executeCommand');
   });
 
   afterEach(async () => {
@@ -32,6 +35,6 @@ describe('soqlOpenNew should', () => {
 
     expect(telemetryStub.called).is.true;
     expect(editorOpened.called).is.true;
+    expect(executeCommandSpy.getCall(0).args[2]).contains(EDITOR_VIEW_TYPE);
   });
-
 });


### PR DESCRIPTION
### What does this PR do?
This is a cherry-pick of commit b3c64e78bd0159abd86a1b15c022169d5ed2b0f3 from develop to fix a bug where soql builder ui does not render because the viewType is incorrect.

### What issues does this PR fix or reference?
Soql Builder not rendered.

### Functionality Before

<img width="1064" alt="Screen Shot 2021-01-05 at 3 10 09 PM" src="https://user-images.githubusercontent.com/599418/103705427-3c317780-4f68-11eb-95f1-e4a95eee5371.png">

### Functionality After

<img width="1097" alt="Screen Shot 2021-01-05 at 3 07 38 PM" src="https://user-images.githubusercontent.com/599418/103705501-5ec39080-4f68-11eb-887f-36c45bdedb5d.png">

