### PR TITLE
fix(soql): disable remote query checks. Make it an experimental option

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -595,29 +595,6 @@
       },
       "preLaunchTask": "Compile",
       "internalConsoleOptions": "openOnSessionStart"
-    },
-    {
-      "name": "Launch Tests - SOQL - VSCode Integration Tests",
-      "type": "extensionHost",
-      "request": "launch",
-      "runtimeExecutable": "${execPath}",
-      "args": [
-        "${workspaceFolder}/packages/system-tests/assets/sfdx-simple",
-        "--extensionDevelopmentPath=${workspaceFolder}/packages",
-        "--extensionTestsPath=${workspaceFolder}/packages/salesforcedx-vscode-soql/out/test/vscode-integration"
-      ],
-      "stopOnEntry": false,
-      "sourceMaps": true,
-      "smartStep": true,
-      "outFiles": ["${workspaceFolder}/packages/*/out/**/*.js"],
-      "sourceMapPathOverrides": {
-        "../../../test/vscode-integration": "${workspaceFolder}/packages/salesforcedx-vscode-soql/out/test/vscode-integration/*",
-        "../../../../test/vscode-integration": "${workspaceFolder}/packages/salesforcedx-vscode-soql/out/test/vscode-integration/*",
-        "webpack:///salesforcedx-utils-vscode/./*": "${workspaceFolder}/packages/salesforcedx-utils-vscode/*",
-        "webpack:///*": "*"
-      },
-      "preLaunchTask": "Compile",
-      "internalConsoleOptions": "openOnSessionStart"
     }
   ],
   "compounds": [

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -143,6 +143,17 @@
           "group": "navigation"
         }
       ]
+    },
+    "configuration": {
+      "type": "object",
+      "title": "%configuration_title%",
+      "properties": {
+        "salesforcedx-vscode-soql.experimental.validateQueries": {
+          "type": "boolean",
+          "default": false,
+          "description": "%soql_validation_flag%"
+        }
+      }
     }
   }
 }

--- a/packages/salesforcedx-vscode-soql/package.nls.json
+++ b/packages/salesforcedx-vscode-soql/package.nls.json
@@ -1,5 +1,7 @@
 {
+  "configuration_title": "Salesforce SOQL Configuration",
   "soqlCustom_soql": "SOQL Builder",
   "soql_builder_open_new": "SFDX: Create Query in SOQL Builder",
-  "soql_builder_toggle": "Toggle SOQL Builder"
+  "soql_builder_toggle": "Toggle SOQL Builder",
+  "soql_validation_flag": "Use REST API to validate SOQL queries and to identify errors."
 }

--- a/packages/salesforcedx-vscode-soql/src/client/client.ts
+++ b/packages/salesforcedx-vscode-soql/src/client/client.ts
@@ -69,7 +69,6 @@ export async function startLanguageClient(
   // Start the client. This will also launch the server
   client.start();
   await client.onReady();
-
   client = queryValidation.afterStart(client);
 }
 

--- a/packages/salesforcedx-vscode-soql/src/client/client.ts
+++ b/packages/salesforcedx-vscode-soql/src/client/client.ts
@@ -4,13 +4,10 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
-import {
-  QueryValidationFeature,
-  RequestTypes
-} from '@salesforce/soql-language-server';
 import * as path from 'path';
-import { CompletionItemKind, ExtensionContext, workspace } from 'vscode';
+import { ExtensionContext, workspace } from 'vscode';
+import * as queryValidation from './queryValidation';
+import * as codeCompletion from './codeCompletion';
 
 import {
   LanguageClient,
@@ -18,10 +15,6 @@ import {
   ServerOptions,
   TransportKind
 } from 'vscode-languageclient';
-import { QueryRunner } from '../editor/queryRunner';
-
-import ProtocolCompletionItem from 'vscode-languageclient/lib/protocolCompletionItem';
-import { retrieveSObject, retrieveSObjects, withSFConnection } from '../sfdx';
 
 let client: LanguageClient;
 
@@ -60,28 +53,7 @@ export async function startLanguageClient(
       configurationSection: 'soql',
       fileEvents: workspace.createFileSystemWatcher('**/*.soql')
     },
-    middleware: {
-      // The SOQL LSP server may include special completion items as "placeholders" for
-      // the client to expand with information from the users' default Salesforce Org.
-      // We do that here as middleware, transforming the server response before passing
-      // it up to VSCode.
-      provideCompletionItem: async (
-        document,
-        position,
-        context,
-        token,
-        next
-      ) => {
-        const items = (await next(
-          document,
-          position,
-          context,
-          token
-        )) as ProtocolCompletionItem[];
-
-        return expandPlaceholders(items);
-      }
-    }
+    middleware: codeCompletion.middleware
   };
 
   // Create the language client and start the client.
@@ -91,32 +63,14 @@ export async function startLanguageClient(
     serverOptions,
     clientOptions
   );
-  client.registerFeature(new QueryValidationFeature());
+
+  client = queryValidation.init(client);
 
   // Start the client. This will also launch the server
   client.start();
-
   await client.onReady();
-  client.onRequest(RequestTypes.RunQuery, async (queryText: string) => {
-    try {
-      return await withSFConnection(async conn => {
-        const queryData = await new QueryRunner(conn).runQuery(queryText, {
-          showErrors: false
-        });
-        return { result: queryData };
-      });
-    } catch (e) {
-      // NOTE: The return value must be serializable, for JSON-RPC.
-      // Thus we cannot include the exception object as-is
-      return {
-        error: {
-          name: e.name,
-          errorCode: e.errorCode,
-          message: e.message
-        }
-      };
-    }
-  });
+
+  client = queryValidation.afterStart(client);
 }
 
 export function stopLanguageClient(): Thenable<void> | undefined {
@@ -124,74 +78,4 @@ export function stopLanguageClient(): Thenable<void> | undefined {
     return undefined;
   }
   return client.stop();
-}
-
-async function expandPlaceholders(
-  completionItems: ProtocolCompletionItem[]
-): Promise<ProtocolCompletionItem[]> {
-  // Expand SObject names
-  const sobjectsIdx = completionItems.findIndex(
-    item => item.label === '__SOBJECTS_PLACEHOLDER'
-  );
-  if (sobjectsIdx >= 0) {
-    try {
-      const sobjectItems = (await retrieveSObjects()).map(objName => {
-        const item = new ProtocolCompletionItem(objName);
-        item.kind = CompletionItemKind.Class;
-        return item;
-      });
-      completionItems.splice(sobjectsIdx, 1, ...sobjectItems);
-    } catch (metadataErrors) {
-      completionItems.splice(sobjectsIdx, 1);
-    }
-  }
-
-  //  Expand SObject fields
-  const SOBJECT_FIELDS_PLACEHOLDER = /__SOBJECT_FIELDS_PLACEHOLDER:(\w+)/;
-  const sobjectFieldsIdx = completionItems.findIndex(item =>
-    SOBJECT_FIELDS_PLACEHOLDER.test(item.label)
-  );
-  if (sobjectFieldsIdx >= 0) {
-    const parsedCommand = completionItems[sobjectFieldsIdx].label.match(
-      SOBJECT_FIELDS_PLACEHOLDER
-    );
-
-    if (parsedCommand) {
-      const objName = parsedCommand[1];
-      try {
-        const objMetadata = await retrieveSObject(objName);
-        const sobjectFields = objMetadata.fields.reduce((fieldItems, field) => {
-          fieldItems.push(newFieldCompletionItem(field.name));
-
-          if (field.relationshipName) {
-            fieldItems.push(
-              newFieldCompletionItem(
-                `${field.relationshipName} \(${field.referenceTo}\)`,
-                CompletionItemKind.Class,
-                field.relationshipName + '.'
-              )
-            );
-          }
-
-          return fieldItems;
-        }, [] as ProtocolCompletionItem[]);
-        completionItems.splice(sobjectFieldsIdx, 1, ...sobjectFields);
-      } catch (metadataError) {
-        completionItems.splice(sobjectFieldsIdx, 1);
-      }
-    }
-  }
-
-  return completionItems;
-}
-
-function newFieldCompletionItem(
-  label: string,
-  kind: CompletionItemKind = CompletionItemKind.Field,
-  insertText?: string
-): ProtocolCompletionItem {
-  const item = new ProtocolCompletionItem(label);
-  item.kind = kind;
-  item.insertText = insertText;
-  return item;
 }

--- a/packages/salesforcedx-vscode-soql/src/client/codeCompletion.ts
+++ b/packages/salesforcedx-vscode-soql/src/client/codeCompletion.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { CompletionItemKind } from 'vscode';
+import ProtocolCompletionItem from 'vscode-languageclient/lib/protocolCompletionItem';
+import { retrieveSObject, retrieveSObjects } from '../sfdx';
+
+import { Middleware } from 'vscode-languageclient';
+import { FieldType } from 'jsforce';
+
+export const middleware: Middleware = {
+  // The SOQL LSP server may include special completion items as "placeholders" for
+  // the client to expand with information from the users' default Salesforce Org.
+  // We do that here as middleware, transforming the server response before passing
+  // it up to VSCode.
+
+  provideCompletionItem: async (document, position, context, token, next) => {
+    const items = (await next(
+      document,
+      position,
+      context,
+      token
+    )) as ProtocolCompletionItem[];
+
+    return expandPlaceholders(items);
+  }
+};
+
+const expandableItemPattern = /__([A-Z_]+)(:(\w+(,\w+)*))?/;
+async function expandPlaceholders(
+  items: ProtocolCompletionItem[]
+): Promise<ProtocolCompletionItem[]> {
+  const expandedItems = [...items];
+
+  items.forEach(async (item, index) => {
+    const m = item.label.match(expandableItemPattern);
+    if (m) {
+      const command = m[1];
+      const args = m[3] ? m[3].split(',') : [];
+
+      const handler = expandFunctions[command];
+      if (!handler) {
+        console.log(`Unknown SOQL completion command ${command}!`);
+      }
+
+      expandedItems.splice(index, 1, ...(await handler(args)));
+    }
+  });
+
+  return expandedItems;
+}
+
+const expandFunctions: {
+  [key: string]: (args: string[]) => Promise<ProtocolCompletionItem[]>;
+} = {
+  SOBJECTS_PLACEHOLDER: async (
+    args: string[]
+  ): Promise<ProtocolCompletionItem[]> => {
+    try {
+      const sobjectItems = (await retrieveSObjects()).map(objName => {
+        const item = new ProtocolCompletionItem(objName);
+        item.kind = CompletionItemKind.Class;
+        return item;
+      });
+      return sobjectItems;
+    } catch (metadataErrors) {
+      return [];
+    }
+  },
+
+  SOBJECT_FIELDS_PLACEHOLDER: async (
+    args: string[]
+  ): Promise<ProtocolCompletionItem[]> => {
+    try {
+      const objMetadata = await retrieveSObject(args[0]);
+      const sobjectFields = objMetadata.fields.reduce((fieldItems, field) => {
+        fieldItems.push(newFieldCompletionItem(field.name, field.name));
+
+        if (field.relationshipName) {
+          fieldItems.push(
+            newFieldCompletionItem(
+              `${field.relationshipName} \(${field.referenceTo}\)`,
+              field.relationshipName + '.',
+              CompletionItemKind.Class
+            )
+          );
+        }
+
+        return fieldItems;
+      }, [] as ProtocolCompletionItem[]);
+      return sobjectFields;
+    } catch (metadataError) {
+      return [];
+    }
+  }
+};
+
+function newFieldCompletionItem(
+  label: string,
+  insertText?: string,
+  kind: CompletionItemKind = CompletionItemKind.Field
+): ProtocolCompletionItem {
+  const item = new ProtocolCompletionItem(label);
+  item.kind = kind;
+  item.insertText = insertText;
+  return item;
+}

--- a/packages/salesforcedx-vscode-soql/src/client/queryValidation.ts
+++ b/packages/salesforcedx-vscode-soql/src/client/queryValidation.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {
+  QueryValidationFeature,
+  RequestTypes
+} from '@salesforce/soql-language-server';
+import { LanguageClient } from 'vscode-languageclient';
+import { QueryRunner } from '../editor/queryRunner';
+import { withSFConnection } from '../sfdx';
+
+export function init(client: LanguageClient): LanguageClient {
+  client.registerFeature(new QueryValidationFeature());
+  return client;
+}
+export function afterStart(client: LanguageClient): LanguageClient {
+  client.onRequest(RequestTypes.RunQuery, async (queryText: string) => {
+    try {
+      return await withSFConnection(async conn => {
+        const queryData = await new QueryRunner(conn).runQuery(queryText, {
+          showErrors: false
+        });
+        return { result: queryData };
+      });
+    } catch (e) {
+      // NOTE: The return value must be serializable, for JSON-RPC.
+      // Thus we cannot include the exception object as-is
+      return {
+        error: {
+          name: e.name,
+          errorCode: e.errorCode,
+          message: e.message
+        }
+      };
+    }
+  });
+
+  return client;
+}

--- a/packages/salesforcedx-vscode-soql/src/constants.ts
+++ b/packages/salesforcedx-vscode-soql/src/constants.ts
@@ -56,3 +56,7 @@ export const QUERY_RESULTS_DIR_PATH = path.join(
 );
 export const DATA_CSV_EXT = 'csv';
 export const DATA_JSON_EXT = 'json';
+
+/* ==== SOQL Extension ==== */
+export const SOQL_CONFIGURATION_NAME = 'salesforcedx-vscode-soql';
+export const SOQL_VALIDATION_CONFIG = 'experimental.validateQueries';

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/client/completion.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/client/completion.test.ts
@@ -8,7 +8,7 @@ import { expect } from 'chai';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
-import { extensions, Position, Uri, workspace } from 'vscode';
+import { extensions, Position, Uri, workspace, commands } from 'vscode';
 import { stubMockConnection, MockConnection } from '../testUtilities';
 
 let doc: vscode.TextDocument;
@@ -21,13 +21,17 @@ let mockConnection: MockConnection;
 describe('Should do completion', async () => {
   beforeEach(async () => {
     workspacePath = workspace.workspaceFolders![0].uri.fsPath;
-    soqlFileUri = Uri.file(path.join(workspacePath, 'test.soql'));
+    soqlFileUri = Uri.file(
+      path.join(workspacePath, `test_${generateRandomInt()}.soql`)
+    );
     sandbox = sinon.createSandbox();
     mockConnection = stubMockConnection(sandbox);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     sandbox.restore();
+    commands.executeCommand('workbench.action.closeActiveEditor');
+    await workspace.fs.delete(soqlFileUri);
   });
 
   testCompletion('|', [
@@ -136,4 +140,8 @@ function getCursorPosition(text: string, cursorChar: string): Position {
     if (column >= 0) return new Position(line, column);
   }
   throw new Error(`Cursor ${cursorChar} not found in ${text} !`);
+}
+
+function generateRandomInt() {
+  return Math.floor(Math.random() * Math.floor(Number.MAX_SAFE_INTEGER));
 }

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/testUtilities.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/testUtilities.ts
@@ -93,6 +93,7 @@ export const mockSObjects = [
         groupable: true,
         relationshipName: null,
         sortable: true,
+        type: 'id',
         updateable: false
       },
       {


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
@W-8611581@

### Functionality Before
SOQL editor would always call the remote API to validate queries

### Functionality After
This "experimental" feature is now disabled by default. Added new configuration option for the user to enable it.


https://user-images.githubusercontent.com/152839/103817675-e501d480-5045-11eb-8f54-36ac25cec8b3.mov


