### PR TITLE
refactor: copy library commandlet to utils module

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/commands/commandletExecutors.ts
+++ b/packages/salesforcedx-utils-vscode/src/commands/commandletExecutors.ts
@@ -5,7 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import * as vscode from 'vscode';
-import { notificationService, ProgressNotification } from './index';
 import { CliCommandExecutor, Command, CommandExecution } from '../cli';
 import {
   Measurements,
@@ -18,6 +17,7 @@ import { nls } from '../messages';
 import { ContinueResponse } from '../types';
 import { getRootWorkspacePath } from '../workspaces';
 import { ChannelService } from './channelService';
+import { notificationService, ProgressNotification } from './index';
 
 export interface FlagParameter<T> {
   flag: T;

--- a/packages/salesforcedx-utils-vscode/src/commands/commandletExecutors.ts
+++ b/packages/salesforcedx-utils-vscode/src/commands/commandletExecutors.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import * as vscode from 'vscode';
+import { notificationService, ProgressNotification } from '.';
+import { CliCommandExecutor, Command, CommandExecution } from '../cli';
+import {
+  Measurements,
+  Properties,
+  TelemetryBuilder,
+  TelemetryData,
+  TelemetryService
+} from '../index';
+import { nls } from '../messages';
+import { ContinueResponse } from '../types';
+import { getRootWorkspacePath } from '../workspaces';
+import { ChannelService } from './channelService';
+
+export interface FlagParameter<T> {
+  flag: T;
+}
+
+export interface CommandletExecutor<T> {
+  execute(response: ContinueResponse<T>): void;
+  readonly onDidFinishExecution?: vscode.Event<[number, number]>;
+}
+
+export abstract class SfdxCommandletExecutor<T>
+  implements CommandletExecutor<T> {
+  protected showChannelOutput = true;
+  protected executionCwd = getRootWorkspacePath();
+  protected onDidFinishExecutionEventEmitter = new vscode.EventEmitter<
+    [number, number]
+  >();
+  public readonly onDidFinishExecution: vscode.Event<[number, number]> = this
+    .onDidFinishExecutionEventEmitter.event;
+
+  protected attachExecution(
+    execution: CommandExecution,
+    cancellationTokenSource: vscode.CancellationTokenSource,
+    cancellationToken: vscode.CancellationToken
+  ) {
+    notificationService.reportCommandExecutionStatus(
+      execution,
+      cancellationToken
+    );
+    ProgressNotification.show(execution, cancellationTokenSource);
+  }
+
+  public logMetric(
+    logName: string | undefined,
+    hrstart: [number, number],
+    properties?: Properties,
+    measurements?: Measurements
+  ) {
+    TelemetryService.getInstance()
+      .sendCommandEvent(logName, hrstart, properties, measurements)
+      .catch();
+  }
+
+  public execute(response: ContinueResponse<T>): void {
+    const startTime = process.hrtime();
+    const cancellationTokenSource = new vscode.CancellationTokenSource();
+    const cancellationToken = cancellationTokenSource.token;
+    const execution = new CliCommandExecutor(this.build(response.data), {
+      cwd: this.executionCwd,
+      env: { SFDX_JSON_TO_STDOUT: 'true' }
+    }).execute(cancellationToken);
+
+    let output = '';
+    execution.stdoutSubject.subscribe(realData => {
+      output += realData.toString();
+    });
+
+    execution.processExitSubject.subscribe(exitCode => {
+      const telemetryData = this.getTelemetryData(
+        exitCode === 0,
+        response,
+        output
+      );
+      let properties;
+      let measurements;
+      if (telemetryData) {
+        properties = telemetryData.properties;
+        measurements = telemetryData.measurements;
+      }
+      this.logMetric(
+        execution.command.logName,
+        startTime,
+        properties,
+        measurements
+      );
+      this.onDidFinishExecutionEventEmitter.fire(startTime);
+    });
+    this.attachExecution(execution, cancellationTokenSource, cancellationToken);
+  }
+
+  protected getTelemetryData(
+    success: boolean,
+    response: ContinueResponse<T>,
+    output: string
+  ): TelemetryData | undefined {
+    return;
+  }
+
+  public abstract build(data: T): Command;
+}
+
+export abstract class LibraryCommandletExecutor<T>
+  implements CommandletExecutor<T> {
+  /**
+   * Command name visible to user while executing.
+   */
+  protected abstract readonly executionName: string;
+  /**
+   * Command name for logging purposes such as telemetry
+   */
+  protected abstract readonly logName: string;
+  /**
+   * Output channel to report execution status to.
+   */
+  protected abstract readonly outputChannel: vscode.OutputChannel;
+  protected readonly telemetry = new TelemetryBuilder();
+
+  /**
+   * Core logic of the command.
+   *
+   * @param response Data from the parameter gathering step.
+   * @returns Whether or not the execution was a success
+   */
+  protected abstract run(response: ContinueResponse<T>): Promise<boolean>;
+
+  public async execute(response: ContinueResponse<T>): Promise<void> {
+    const startTime = process.hrtime();
+    const channelService = new ChannelService(this.outputChannel);
+    const telemetryService = TelemetryService.getInstance();
+
+    channelService.showCommandWithTimestamp(
+      `${nls.localize('channel_starting_message')}${this.executionName}\n`
+    );
+
+    try {
+      const success = await vscode.window.withProgress(
+        {
+          title: nls.localize('progress_notification_text', this.executionName),
+          location: vscode.ProgressLocation.Notification
+        },
+        () => this.run(response)
+      );
+      channelService.showCommandWithTimestamp(
+        `${nls.localize('channel_end')} ${this.executionName}`
+      );
+      if (success) {
+        notificationService
+          .showSuccessfulExecution(this.executionName)
+          .catch(e => console.error(e));
+      } else {
+        notificationService.showFailedExecution(this.executionName);
+      }
+      this.telemetry.addProperty('success', String(success));
+      const { properties, measurements } = this.telemetry.build();
+      await telemetryService.sendCommandEvent(
+        this.logName,
+        startTime,
+        properties,
+        measurements
+      );
+    } catch (e) {
+      await telemetryService.sendException(e.name, e.message);
+      notificationService.showFailedExecution(this.executionName);
+      channelService.appendLine(e.message);
+      channelService.showChannelOutput();
+    }
+  }
+}

--- a/packages/salesforcedx-utils-vscode/src/commands/commandletExecutors.ts
+++ b/packages/salesforcedx-utils-vscode/src/commands/commandletExecutors.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import * as vscode from 'vscode';
-import { notificationService, ProgressNotification } from '.';
+import { notificationService, ProgressNotification } from './index';
 import { CliCommandExecutor, Command, CommandExecution } from '../cli';
 import {
   Measurements,

--- a/packages/salesforcedx-utils-vscode/src/commands/sfdxCommandlet.ts
+++ b/packages/salesforcedx-utils-vscode/src/commands/sfdxCommandlet.ts
@@ -5,112 +5,14 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import * as vscode from 'vscode';
-import { CliCommandExecutor, Command, CommandExecution } from '../cli';
 import {
-  Measurements,
-  Properties,
-  TelemetryData,
-  TelemetryService
-} from '../index';
-import {
-  ContinueResponse,
   ParametersGatherer,
   PostconditionChecker,
   PreconditionChecker
 } from '../types';
-import { getRootWorkspacePath } from '../workspaces';
-import { notificationService, ProgressNotification } from './index';
+import { CommandletExecutor } from './commandletExecutors';
+import { notificationService } from './index';
 import { EmptyPostChecker } from './postconditionCheckers';
-
-export interface FlagParameter<T> {
-  flag: T;
-}
-
-export interface CommandletExecutor<T> {
-  execute(response: ContinueResponse<T>): void;
-  readonly onDidFinishExecution?: vscode.Event<[number, number]>;
-}
-
-export abstract class SfdxCommandletExecutor<T>
-  implements CommandletExecutor<T> {
-  protected showChannelOutput = true;
-  protected executionCwd = getRootWorkspacePath();
-  protected onDidFinishExecutionEventEmitter = new vscode.EventEmitter<
-    [number, number]
-  >();
-  public readonly onDidFinishExecution: vscode.Event<[number, number]> = this
-    .onDidFinishExecutionEventEmitter.event;
-
-  protected attachExecution(
-    execution: CommandExecution,
-    cancellationTokenSource: vscode.CancellationTokenSource,
-    cancellationToken: vscode.CancellationToken
-  ) {
-    notificationService.reportCommandExecutionStatus(
-      execution,
-      cancellationToken
-    );
-    ProgressNotification.show(execution, cancellationTokenSource);
-  }
-
-  public logMetric(
-    logName: string | undefined,
-    hrstart: [number, number],
-    properties?: Properties,
-    measurements?: Measurements
-  ) {
-    TelemetryService.getInstance()
-      .sendCommandEvent(logName, hrstart, properties, measurements)
-      .catch();
-  }
-
-  public execute(response: ContinueResponse<T>): void {
-    const startTime = process.hrtime();
-    const cancellationTokenSource = new vscode.CancellationTokenSource();
-    const cancellationToken = cancellationTokenSource.token;
-    const execution = new CliCommandExecutor(this.build(response.data), {
-      cwd: this.executionCwd,
-      env: { SFDX_JSON_TO_STDOUT: 'true' }
-    }).execute(cancellationToken);
-
-    let output = '';
-    execution.stdoutSubject.subscribe(realData => {
-      output += realData.toString();
-    });
-
-    execution.processExitSubject.subscribe(exitCode => {
-      const telemetryData = this.getTelemetryData(
-        exitCode === 0,
-        response,
-        output
-      );
-      let properties;
-      let measurements;
-      if (telemetryData) {
-        properties = telemetryData.properties;
-        measurements = telemetryData.measurements;
-      }
-      this.logMetric(
-        execution.command.logName,
-        startTime,
-        properties,
-        measurements
-      );
-      this.onDidFinishExecutionEventEmitter.fire(startTime);
-    });
-    this.attachExecution(execution, cancellationTokenSource, cancellationToken);
-  }
-
-  protected getTelemetryData(
-    success: boolean,
-    response: ContinueResponse<T>,
-    output: string
-  ): TelemetryData | undefined {
-    return;
-  }
-
-  public abstract build(data: T): Command;
-}
 
 export class SfdxCommandlet<T> {
   private readonly prechecker: PreconditionChecker;

--- a/packages/salesforcedx-utils-vscode/src/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/index.ts
@@ -16,10 +16,9 @@ export {
 } from './commands/preconditionCheckers';
 export {
   CommandletExecutor,
-  SfdxCommandlet,
   SfdxCommandletExecutor
-} from './commands/sfdxCommandlet';
-
+} from './commands/commandletExecutors';
+export { SfdxCommandlet } from './commands/sfdxCommandlet';
 export {
   TelemetryService,
   TelemetryBuilder,

--- a/scripts/aggregate-junit-xml.js
+++ b/scripts/aggregate-junit-xml.js
@@ -3,26 +3,26 @@
 /*
  * Asserts JUnit test results were generated from a test run with the specified
  * test categories and aggregates them into a directory.
- * 
- * 
+ *
+ *
  * e.g. with the following structure:
- * 
+ *
  * packages/salesforcecx-vscode-lwc/test/unit
  * packages/salesforcecx-vscode-lwc/test/vscode-integration
- * 
+ *
  * these files will be asserted to exist:
- * 
+ *
  * packages/salesforcedx-vscode-lwc/junit-custom-unitTests.xml
  * packages/salesforcedx-vscode-lwc/junit-custom-vscodeIntegrationTests.xml
- * 
+ *
  * and then are copied into a top-level directory called junit-aggregate.'
- * 
- * 
+ *
+ *
  * Valid categories: unit, integration, vscode-integration
- * 
+ *
  * By default, all categories will be tested. To only process specific
  * categories, call the script with desired categories separated by a space.
- * 
+ *
  * e.g. node aggregate-junit-xml.js integration vscode-integration
  */
 
@@ -35,10 +35,10 @@ const packagesDir = path.join(cwd, 'packages');
 const aggregateDir = path.join(cwd, 'junit-aggregate');
 const categoryToFile = {
   'vscode-integration': 'junit-custom-vscodeIntegrationTests.xml',
-  'integration': 'junit-custom-integrationTests.xml',
-  'unit': 'junit-custom-unitTests.xml',
-  'system': 'junit-custom.xml',
-}
+  integration: 'junit-custom-integrationTests.xml',
+  unit: 'junit-custom-unitTests.xml',
+  system: 'junit-custom.xml'
+};
 
 // process all test categories if none are specified in arguments
 let flags = new Set(process.argv.slice(2));
@@ -52,10 +52,10 @@ if (!fs.existsSync(aggregateDir)) {
 
 const missingResults = {
   'vscode-integration': [],
-  'integration': [],
-  'unit': [],
-  'system': []
-}
+  integration: [],
+  unit: [],
+  system: []
+};
 
 for (const entry of fs.readdirSync(packagesDir)) {
   const packagePath = path.join(packagesDir, entry);
@@ -67,11 +67,18 @@ for (const entry of fs.readdirSync(packagesDir)) {
         // if package test directory has a test category that matches the
         // category input, copy the junit results to the aggregate folder
         if (flags.has(`--${testEntry}`)) {
-          const junitFilePath = path.join(packagePath, categoryToFile[testEntry]);
+          const junitFilePath = path.join(
+            packagePath,
+            categoryToFile[testEntry]
+          );
           if (fs.existsSync(junitFilePath)) {
             shell.cp(
               junitFilePath,
-              path.join(cwd, 'junit-aggregate', `${entry}-${categoryToFile[testEntry]}`)
+              path.join(
+                cwd,
+                'junit-aggregate',
+                `${entry}-${categoryToFile[testEntry]}`
+              )
             );
           } else {
             missingResults[testEntry].push(entry);
@@ -90,16 +97,22 @@ for (const [testType, pkgs] of Object.entries(missingResults)) {
     if (!missingMessage) {
       missingMessage = 'Missing junit results for the following packages:\n';
     }
-    missingMessage += `\n* ${testType}:`
-    missingMessage = pkgs.reduce((previous, current) => `${previous}\n\t- ${current}`, missingMessage);
+    missingMessage += `\n* ${testType}:`;
+    missingMessage = pkgs.reduce(
+      (previous, current) => `${previous}\n\t- ${current}`,
+      missingMessage
+    );
   }
 }
 
 if (missingMessage) {
-  missingMessage += '\n\nPossible Issues:\n\n'
-  missingMessage += "1) Tests in the expected suite categories haven't run yet (unit, integration, etc.).\n";
-  missingMessage += '2) An unexpected test runner or reporter failure while running tests. Sometimes extension activation issues or issues in the tests can silently fail.\n';
+  missingMessage += '\n\nPossible Issues:\n\n';
+  missingMessage +=
+    "1) Tests in the expected suite categories haven't run yet (unit, integration, etc.).\n";
+  missingMessage +=
+    '2) An unexpected test runner or reporter failure while running tests. Sometimes extension activation issues or issues in the tests can silently fail.\n';
   missingMessage += '3) Test run configuration is improperly set up.\n';
+  missingMessage += '4) Circular imports.\n';
   console.error(missingMessage);
   process.exit(1);
 }


### PR DESCRIPTION
### What does this PR do?

Simply copies the library commandlet to the utils module. Commands have not been changed to use this version yet because there are other things that need to be updated first. E.g. the utils version of the telemetry service needs to be used in the extensions packages first, otherwise telemetry will stop working.

### What issues does this PR fix or reference?
@W-8659966@