### PR TITLE
fix: do not show toggle command in palette

### DIFF
--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -134,6 +134,10 @@
         {
           "command": "soql.builder.open.new",
           "when": "sfdx:project_opened"
+        },
+        {
+          "command": "soql.builder.toggle",
+          "when": "false"
         }
       ],
       "editor/title": [


### PR DESCRIPTION
### What does this PR do?

The command to toggle between Soql Builder and Soql Editor has snuck into the Command Palette, even though it is not explicitly mentioned that it contributes to the command palette.  Fortunately, it's an easy fix.

### What issues does this PR fix or reference?
@W-8728692@

### Functionality Before
<img width="737" alt="Screen Shot 2021-01-15 at 12 42 48 PM" src="https://user-images.githubusercontent.com/599418/104772218-4efa3800-5730-11eb-956b-746e4f3437e9.png">

### Functionality After
<img width="665" alt="Screen Shot 2021-01-15 at 12 41 05 PM" src="https://user-images.githubusercontent.com/599418/104772242-591c3680-5730-11eb-9745-e581e785e438.png">
