### PR TITLE
fix: workspaceContext initialization across apex & replay-debugger packages

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/context/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/context/index.ts
@@ -4,7 +4,4 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
-import { WorkspaceContextUtil } from './workspaceContextUtil';
-export const workspaceContext = WorkspaceContextUtil.getInstance();
 export { OrgInfo, WorkspaceContextUtil } from './workspaceContextUtil';

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/quickLaunch.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/quickLaunch.ts
@@ -13,10 +13,10 @@ import {
 } from '@salesforce/apex-node/lib/src/tests/types';
 import { Connection } from '@salesforce/core';
 import { notificationService } from '@salesforce/salesforcedx-utils-vscode/out/src/commands';
-import { workspaceContext } from '@salesforce/salesforcedx-utils-vscode/out/src/context';
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { workspaceContext } from '../context';
 import { nls } from '../messages';
 import { getLogDirPath } from '../utils';
 import { launchFromLogFile } from './launchFromLogFile';

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/context/index.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/context/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { WorkspaceContext } from './workspaceContext';
+export const workspaceContext = WorkspaceContext.getInstance();

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/context/workspaceContext.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/context/workspaceContext.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Connection } from '@salesforce/core';
+import { WorkspaceContextUtil } from '@salesforce/salesforcedx-utils-vscode/out/src/context';
+import * as vscode from 'vscode';
+
+export class WorkspaceContext {
+  protected static instance?: WorkspaceContext;
+
+  public async initialize(context: vscode.ExtensionContext) {
+    await WorkspaceContextUtil.getInstance().initialize(context);
+  }
+
+  public static getInstance(forceNew = false): WorkspaceContext {
+    if (!this.instance || forceNew) {
+      this.instance = new WorkspaceContext();
+    }
+    return this.instance;
+  }
+
+  public async getConnection(): Promise<Connection> {
+    return await WorkspaceContextUtil.getInstance().getConnection();
+  }
+}

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
@@ -31,6 +31,7 @@ import {
 } from './breakpoints/checkpointService';
 import { launchFromLogFile } from './commands/launchFromLogFile';
 import { setupAndDebugTests } from './commands/quickLaunch';
+import { workspaceContext } from './context';
 import { nls } from './messages';
 import { telemetryService } from './telemetry';
 let extContext: vscode.ExtensionContext;
@@ -176,6 +177,9 @@ export async function activate(context: vscode.ExtensionContext) {
   const breakpointsSub = vscode.debug.onDidChangeBreakpoints(
     processBreakpointChangedForCheckpoints
   );
+
+  // Workspace Context
+  await workspaceContext.initialize(context);
 
   // Debug Tests command
   const debugTests = vscode.commands.registerCommand(

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/vscode-integration/commands/quickLaunch.test.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/vscode-integration/commands/quickLaunch.test.ts
@@ -10,7 +10,6 @@ import { TestResult } from '@salesforce/apex-node/lib/src/tests/types';
 import { AuthInfo, ConfigAggregator, Connection } from '@salesforce/core';
 import { MockTestOrgData, testSetup } from '@salesforce/core/lib/testSetup';
 import { notificationService } from '@salesforce/salesforcedx-utils-vscode/out/src/commands';
-import { workspaceContext } from '@salesforce/salesforcedx-utils-vscode/out/src/context';
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import { expect } from 'chai';
 import * as path from 'path';
@@ -18,6 +17,7 @@ import { createSandbox, SinonSandbox, SinonStub } from 'sinon';
 import * as launcher from '../../../src/commands/launchFromLogFile';
 import { TestDebuggerExecutor } from '../../../src/commands/quickLaunch';
 import { TraceFlags } from '../../../src/commands/traceFlags';
+import { workspaceContext } from '../../../src/context';
 import { nls } from '../../../src/messages';
 import * as utils from '../../../src/utils';
 

--- a/packages/salesforcedx-vscode-apex/src/commands/forceApexTestRunCodeAction.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceApexTestRunCodeAction.ts
@@ -16,7 +16,7 @@ import {
   TestRunner
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import { notificationService } from '@salesforce/salesforcedx-utils-vscode/out/src/commands';
-import { workspaceContext } from '@salesforce/salesforcedx-utils-vscode/out/src/context';
+import { WorkspaceContextUtil } from '@salesforce/salesforcedx-utils-vscode/out/src/context';
 import * as vscode from 'vscode';
 import { nls } from '../messages';
 import { forceApexTestRunCacheService, isEmpty } from '../testRunCache';
@@ -70,7 +70,7 @@ export class ApexLibraryTestRunExecutor extends LibraryCommandletExecutor<{
   }
 
   protected async run(): Promise<boolean> {
-    const connection = await workspaceContext.getConnection();
+    const connection = await WorkspaceContextUtil.getInstance().getConnection();
     const testService = new TestService(connection);
     const result = await testService.runTestAsynchronous(
       {

--- a/packages/salesforcedx-vscode-apex/src/commands/forceApexTestRunCodeAction.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceApexTestRunCodeAction.ts
@@ -32,6 +32,7 @@ const SfdxCommandletExecutor = sfdxCoreExports.SfdxCommandletExecutor;
 const LibraryCommandletExecutor = sfdxCoreExports.LibraryCommandletExecutor;
 const channelService = sfdxCoreExports.channelService;
 
+const workspaceContext = WorkspaceContextUtil.getInstance();
 export class ApexLibraryTestRunExecutor extends LibraryCommandletExecutor<{
   outputDir: string;
   tests: string[];
@@ -70,7 +71,7 @@ export class ApexLibraryTestRunExecutor extends LibraryCommandletExecutor<{
   }
 
   protected async run(): Promise<boolean> {
-    const connection = await WorkspaceContextUtil.getInstance().getConnection();
+    const connection = await workspaceContext.getConnection();
     const testService = new TestService(connection);
     const result = await testService.runTestAsynchronous(
       {

--- a/packages/salesforcedx-vscode-apex/src/commands/forceApexTestRunCodeAction.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceApexTestRunCodeAction.ts
@@ -16,8 +16,8 @@ import {
   TestRunner
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import { notificationService } from '@salesforce/salesforcedx-utils-vscode/out/src/commands';
-import { WorkspaceContextUtil } from '@salesforce/salesforcedx-utils-vscode/out/src/context';
 import * as vscode from 'vscode';
+import { workspaceContext } from '../context';
 import { nls } from '../messages';
 import { forceApexTestRunCacheService, isEmpty } from '../testRunCache';
 
@@ -32,7 +32,6 @@ const SfdxCommandletExecutor = sfdxCoreExports.SfdxCommandletExecutor;
 const LibraryCommandletExecutor = sfdxCoreExports.LibraryCommandletExecutor;
 const channelService = sfdxCoreExports.channelService;
 
-const workspaceContext = WorkspaceContextUtil.getInstance();
 export class ApexLibraryTestRunExecutor extends LibraryCommandletExecutor<{
   outputDir: string;
   tests: string[];

--- a/packages/salesforcedx-vscode-apex/src/context/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/context/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { WorkspaceContext } from './workspaceContext';
+export const workspaceContext = WorkspaceContext.getInstance();

--- a/packages/salesforcedx-vscode-apex/src/context/workspaceContext.ts
+++ b/packages/salesforcedx-vscode-apex/src/context/workspaceContext.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Connection } from '@salesforce/core';
+import { WorkspaceContextUtil } from '@salesforce/salesforcedx-utils-vscode/out/src/context';
+import * as vscode from 'vscode';
+
+export class WorkspaceContext {
+  protected static instance?: WorkspaceContext;
+
+  public async initialize(context: vscode.ExtensionContext) {
+    await WorkspaceContextUtil.getInstance().initialize(context);
+  }
+
+  public static getInstance(forceNew = false): WorkspaceContext {
+    if (!this.instance || forceNew) {
+      this.instance = new WorkspaceContext();
+    }
+    return this.instance;
+  }
+
+  public async getConnection(): Promise<Connection> {
+    return await WorkspaceContextUtil.getInstance().getConnection();
+  }
+}

--- a/packages/salesforcedx-vscode-apex/src/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/index.ts
@@ -6,7 +6,6 @@
  */
 
 import { TestRunner } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
-import { WorkspaceContextUtil } from '@salesforce/salesforcedx-utils-vscode/out/src/context';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { LanguageClient } from 'vscode-languageclient/lib/main';
@@ -26,6 +25,7 @@ import {
   ENABLE_SOBJECT_REFRESH_ON_STARTUP,
   SFDX_APEX_CONFIGURATION_NAME
 } from './constants';
+import { workspaceContext } from './context';
 import {
   ClientStatus,
   enableJavaDocSymbols,
@@ -70,7 +70,7 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   // Workspace Context
-  await WorkspaceContextUtil.getInstance().initialize(context);
+  await workspaceContext.initialize(context);
 
   // Telemetry
   telemetryService.initializeService(

--- a/packages/salesforcedx-vscode-apex/src/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { TestRunner } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import { WorkspaceContextUtil } from '@salesforce/salesforcedx-utils-vscode/out/src/context';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { LanguageClient } from 'vscode-languageclient/lib/main';
@@ -67,6 +68,9 @@ export async function activate(context: vscode.ExtensionContext) {
   } else {
     throw new Error(nls.localize('cannot_determine_workspace'));
   }
+
+  // Workspace Context
+  await WorkspaceContextUtil.getInstance().initialize(context);
 
   // Telemetry
   telemetryService.initializeService(

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceApexTestRunCodeAction.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceApexTestRunCodeAction.test.ts
@@ -6,7 +6,6 @@
  */
 
 import { TestLevel, TestService } from '@salesforce/apex-node';
-import { workspaceContext } from '@salesforce/salesforcedx-utils-vscode/out/src/context';
 import { expect } from 'chai';
 import { createSandbox, SinonSandbox, SinonStub } from 'sinon';
 import { extensions } from 'vscode';
@@ -18,6 +17,7 @@ import {
   resolveTestClassParam,
   resolveTestMethodParam
 } from '../../../src/commands/forceApexTestRunCodeAction';
+import { workspaceContext } from '../../../src/context';
 
 const sfdxCoreExports = extensions.getExtension(
   'salesforce.salesforcedx-vscode-core'


### PR DESCRIPTION
### What does this PR do?
This PR changes how we are initializing the workspaceContext service in the apex and replay-debugger packages. This fixes an issue where 'Run Test' and 'Debug & Run Test' were not picking up the default org when the project was opened for the first time.

### What issues does this PR fix or reference?
@W-8732172@