### PR TITLE
fix: add aiKey to apex package

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -14,6 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
+  "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
   "version": "50.14.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
### What does this PR do?
Follow up to #2877 - adds the app insights key to the Apex package.json. Because of the recent telemetry changes, the extension will not activate without this 

### What issues does this PR fix or reference?
@W-8720933@
