### PR TITLE
chore: add ability to ignore packages for the change log generator

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,10 +10,7 @@
         "focus": false,
         "panel": "shared"
       },
-      "args": [
-        "run",
-        "bootstrap"
-      ],
+      "args": ["run", "bootstrap"],
       "isBackground": false
     },
     {
@@ -24,10 +21,7 @@
         "focus": false,
         "panel": "shared"
       },
-      "args": [
-        "run",
-        "clean"
-      ],
+      "args": ["run", "clean"],
       "isBackground": false
     },
     {
@@ -38,10 +32,7 @@
         "focus": true,
         "panel": "shared"
       },
-      "args": [
-        "run",
-        "commit"
-      ],
+      "args": ["run", "commit"],
       "isBackground": false
     },
     {
@@ -52,10 +43,7 @@
         "focus": false,
         "panel": "shared"
       },
-      "args": [
-        "run",
-        "commit-init"
-      ],
+      "args": ["run", "commit-init"],
       "isBackground": false
     },
     {
@@ -70,10 +58,7 @@
         "focus": false,
         "panel": "dedicated"
       },
-      "args": [
-        "run",
-        "compile"
-      ],
+      "args": ["run", "compile"],
       "isBackground": false,
       "problemMatcher": {
         "owner": "typescript",
@@ -92,9 +77,7 @@
       "label": "Create Release Branch",
       "command": "./scripts/create-release-branch-workflow.sh",
       "type": "shell",
-      "args": [
-        "${input:circleCiId}"
-      ]
+      "args": ["${input:circleCiId}"]
     },
     {
       "label": "Create Change Log",
@@ -103,7 +86,9 @@
       "args": [
         "${input:verboseOutput}",
         "-r",
-        "${input:releaseOverride}"
+        "${input:releaseOverride}",
+        "-i",
+        "${input:packagesToIgnore}"
       ]
     },
     {
@@ -114,28 +99,20 @@
         "focus": false,
         "panel": "dedicated"
       },
-      "args": [
-        "run",
-        "lint"
-      ],
+      "args": ["run", "lint"],
       "isBackground": false
     },
     {
       "label": "Launch Pre-Publish Steps",
       "command": "./scripts/pre-publish-workflow.sh",
       "type": "shell",
-      "args": [
-        "${input:circleCiId}",
-        "${input:releaseBranch}"
-      ]
+      "args": ["${input:circleCiId}", "${input:releaseBranch}"]
     },
     {
       "label": "Publish Extensions",
       "command": "./scripts/publish-workflow.sh",
       "type": "shell",
-      "args": [
-        "${input:circleCiId}"
-      ]
+      "args": ["${input:circleCiId}"]
     },
     {
       "label": "Watch",
@@ -145,10 +122,7 @@
         "focus": false,
         "panel": "dedicated"
       },
-      "args": [
-        "run",
-        "watch"
-      ],
+      "args": ["run", "watch"],
       "isBackground": false,
       "problemMatcher": "$tsc-watch"
     }
@@ -160,13 +134,16 @@
       "description": "CircleCi Token"
     },
     {
+      "id": "packagesToIgnore",
+      "type": "promptString",
+      "description": "Packages To Ignore: These are packages that are not to be included in the change log (Ex package1,package2)",
+      "default": "salesforcedx-vscode-soql"
+    },
+    {
       "id": "verboseOutput",
       "type": "pickString",
       "description": "Output verbose logging? Select -v for verbose, and blank for quiet.",
-      "options": [
-        "",
-        "-v"
-      ],
+      "options": ["", "-v"],
       "default": "-v"
     },
     {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -85,10 +85,10 @@
       "type": "shell",
       "args": [
         "${input:verboseOutput}",
-        "-r",
-        "${input:releaseOverride}",
         "-i",
-        "${input:packagesToIgnore}"
+        "${input:packagesToIgnore}",
+        "-r",
+        "${input:releaseOverride}"
       ]
     },
     {

--- a/scripts/change-log-generator.js
+++ b/scripts/change-log-generator.js
@@ -10,7 +10,6 @@
  * 1. External contributions
  * 2. Duplicates (ex file changes made in both salesforcedx-apex-debugger and salesforcedx-apex-replay-debugger)
  * 3. Non-salesforce package contributions aside from doc updates
- * 4. Adding vs. Fixed vs. Ignore in change log
  *
  * Overriding Default Values:
  * 1. Override the release. Example: npm run build-change-log -- -r 46.7.0

--- a/scripts/change-log-generator.js
+++ b/scripts/change-log-generator.js
@@ -14,7 +14,7 @@
  * Overriding Default Values:
  * 1. Override the release. Example: npm run build-change-log -- -r 46.7.0
  * 2. Add verbose logging. Example: npm run build-change-log -- -v
- * 3. Package list to ignore (comma separated without spaces) npm run build-change-log --i package1,package2,package3
+ * 3. Package list to ignore (comma separated list) npm run build-change-log --i package1,package2,package3
  */
 
 const process = require('process');

--- a/scripts/change-log-generator.js
+++ b/scripts/change-log-generator.js
@@ -14,6 +14,7 @@
  * Overriding Default Values:
  * 1. Override the release. Example: npm run build-change-log -- -r 46.7.0
  * 2. Add verbose logging. Example: npm run build-change-log -- -v
+ * 3. Package list to ignore (comma separated without spaces) npm run build-change-log --i package1,package2,package3
  */
 
 const process = require('process');
@@ -42,6 +43,16 @@ const TYPE = 'TYPE';
 const MESSAGE = 'MESSAGE';
 const FILES_CHANGED = 'FILES_CHANGED';
 const PACKAGES = 'PACKAGES';
+
+const typesToIgnore = [
+  'chore',
+  'style',
+  'refactor',
+  'test',
+  'build',
+  'ci',
+  'revert'
+];
 
 /**
  * Checks if the user has provided a release branch override. If they
@@ -281,16 +292,10 @@ function getMessagesGroupedByPackage(parsedCommits) {
  * If we have a type that should be ignored, return an empty key.
  */
 function generateKey(packageName, type) {
-  const typesToIgnore = [
-    'chore',
-    'style',
-    'refactor',
-    'test',
-    'build',
-    'ci',
-    'revert'
-  ];
-  if (typesToIgnore.includes(type)) {
+  if (
+    typesToIgnore.includes(type) ||
+    PACKAGES_TO_IGNORE.includes(packageName)
+  ) {
     return '';
   }
   const keyPrefix = type === 'feat' ? 'Added' : 'Fixed';
@@ -353,6 +358,11 @@ function writeAdditionalInfo() {
 console.log("Starting script 'change-log-generator'\n");
 
 let ADD_VERBOSE_LOGGING = process.argv.indexOf('-v') > -1 ? true : false;
+let PACKAGES_TO_IGNORE =
+  process.argv.indexOf('-i') > -1
+    ? process.argv[process.argv.indexOf('-i') + 1]
+    : '';
+
 const releaseBranch = getReleaseBranch();
 const previousBranch = getPreviousReleaseBranch(releaseBranch);
 console.log(util.format(RELEASE_MESSAGE, releaseBranch, previousBranch));


### PR DESCRIPTION
### What does this PR do?
Adds a configurable param that can be passed to the change log generator that contains a list of packages to ignore when generating the change log. This approach allows for future instances where we do not want to include changes from a certain package. It also allows the PWT team to still use this automation within their own change log.

### What issues does this PR fix or reference?
@W-8778016@

### Functionality Before
```
# 50.14.0 - Month DD, YYYY

## Added

#### salesforcedx-vscode-core

- Remove channelService from core extension ([PR #2853](https://github.com/forcedotcom/salesforcedx-vscode/pull/2853))

#### salesforcedx-vscode-soql

- Do not emit message from custom editor to webview if soql has not changed ([PR #2818](https://github.com/forcedotcom/salesforcedx-vscode/pull/2818))

## Fixed

#### salesforcedx-vscode-soql

- Do not show toggle command in palette ([PR #2867](https://github.com/forcedotcom/salesforcedx-vscode/pull/2867))

- Disable remote query checks. Make it an experimental option ([PR #2847](https://github.com/forcedotcom/salesforcedx-vscode/pull/2847))

- Revert auto-publish of SOQL extension  (#2859) ([PR #2843](https://github.com/forcedotcom/salesforcedx-vscode/pull/2843))

- Fix local test environment ([PR #2857](https://github.com/forcedotcom/salesforcedx-vscode/pull/2857))
```

### Functionality After
```
# 50.14.0 - Month DD, YYYY

## Added

#### salesforcedx-vscode-core

- Remove channelService from core extension ([PR #2853](https://github.com/forcedotcom/salesforcedx-vscode/pull/2853))

```