### PR TITLE
Fast way to find your Java path on the MAC OS.

### DIFF
--- a/docs/_articles/en/getting-started/java-setup.md
+++ b/docs/_articles/en/getting-started/java-setup.md
@@ -27,6 +27,8 @@ Inside Visual Studio Code, you will need to set the `salesforcedx-vscode-apex.ja
 
 MacOS:
 
+It is worth using the command 'Which Java' to find the correct path to your Java_Home.
+
 ```json
 {
   "salesforcedx-vscode-apex.java.home": "/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home"


### PR DESCRIPTION
I wasted a lot of time using the suggested paths, and could even see them in my Mac Finder app.  However, after much Googling the terminal command that found me, my true Java_Home was 'Which Java', cutting and pasting this path into my VSC settings overcame the settings error I kept receiving when selecting an Apex class.

### What does this PR do?

### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @<Insert GUS WI>@

### Functionality Before
<insert gif and/or summary>

### Functionality After
<insert gif and/or summary>
