### PR TITLE
fix: missing telemetry method

### DIFF
--- a/packages/salesforcedx-vscode-apex-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-debugger/src/index.ts
@@ -17,7 +17,7 @@ import {
   SetExceptionBreakpointsArguments,
   SHOW_MESSAGE_EVENT,
   VscodeDebuggerMessage,
-  VscodeDebuggerMessageType
+  VscodeDebuggerMessageType,
 } from '@salesforce/salesforcedx-apex-debugger/out/src';
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -47,7 +47,7 @@ export async function getDebuggerType(
 
 function registerCommands(): vscode.Disposable {
   const customEventHandler = vscode.debug.onDidReceiveDebugSessionCustomEvent(
-    async event => {
+    async (event) => {
       if (event && event.session) {
         const type = await getDebuggerType(event.session);
         if (type === DEBUGGER_TYPE && event.event === SHOW_MESSAGE_EVENT) {
@@ -76,10 +76,10 @@ function registerCommands(): vscode.Disposable {
     'sfdx.debug.exception.breakpoint',
     configureExceptionBreakpoint
   );
-  const startSessionHandler = vscode.debug.onDidStartDebugSession(session => {
-    cachedExceptionBreakpoints.forEach(breakpoint => {
+  const startSessionHandler = vscode.debug.onDidStartDebugSession((session) => {
+    cachedExceptionBreakpoints.forEach((breakpoint) => {
       const args: SetExceptionBreakpointsArguments = {
-        exceptionInfo: breakpoint
+        exceptionInfo: breakpoint,
       };
       session.customRequest(EXCEPTION_BREAKPOINT_REQUEST, args);
     });
@@ -106,13 +106,13 @@ const EXCEPTION_BREAK_MODES: BreakModeItem[] = [
   {
     label: nls.localize('always_break_text'),
     description: '',
-    breakMode: EXCEPTION_BREAKPOINT_BREAK_MODE_ALWAYS
+    breakMode: EXCEPTION_BREAKPOINT_BREAK_MODE_ALWAYS,
   },
   {
     label: nls.localize('never_break_text'),
     description: '',
-    breakMode: EXCEPTION_BREAKPOINT_BREAK_MODE_NEVER
-  }
+    breakMode: EXCEPTION_BREAKPOINT_BREAK_MODE_NEVER,
+  },
 ];
 
 async function configureExceptionBreakpoint(): Promise<void> {
@@ -141,7 +141,7 @@ async function configureExceptionBreakpoint(): Promise<void> {
     );
     const selectExceptionOptions: vscode.QuickPickOptions = {
       placeHolder: nls.localize('select_exception_text'),
-      matchOnDescription: true
+      matchOnDescription: true,
     };
     const selectedException = await vscode.window.showQuickPick(
       processedBreakpointInfos,
@@ -150,7 +150,7 @@ async function configureExceptionBreakpoint(): Promise<void> {
     if (selectedException) {
       const selectBreakModeOptions: vscode.QuickPickOptions = {
         placeHolder: nls.localize('select_break_option_text'),
-        matchOnDescription: true
+        matchOnDescription: true,
       };
       const selectedBreakMode = await vscode.window.showQuickPick(
         EXCEPTION_BREAK_MODES,
@@ -159,7 +159,7 @@ async function configureExceptionBreakpoint(): Promise<void> {
       if (selectedBreakMode) {
         selectedException.breakMode = selectedBreakMode.breakMode;
         const args: SetExceptionBreakpointsArguments = {
-          exceptionInfo: selectedException
+          exceptionInfo: selectedException,
         };
         if (vscode.debug.activeDebugSession) {
           await vscode.debug.activeDebugSession.customRequest(
@@ -221,13 +221,13 @@ export function getExceptionBreakpointCache(): Map<
 
 function registerFileWatchers(): vscode.Disposable {
   const clsWatcher = vscode.workspace.createFileSystemWatcher('**/*.cls');
-  clsWatcher.onDidChange(uri => notifyDebuggerSessionFileChanged());
-  clsWatcher.onDidCreate(uri => notifyDebuggerSessionFileChanged());
-  clsWatcher.onDidDelete(uri => notifyDebuggerSessionFileChanged());
+  clsWatcher.onDidChange((uri) => notifyDebuggerSessionFileChanged());
+  clsWatcher.onDidCreate((uri) => notifyDebuggerSessionFileChanged());
+  clsWatcher.onDidDelete((uri) => notifyDebuggerSessionFileChanged());
   const trgWatcher = vscode.workspace.createFileSystemWatcher('**/*.trigger');
-  trgWatcher.onDidChange(uri => notifyDebuggerSessionFileChanged());
-  trgWatcher.onDidCreate(uri => notifyDebuggerSessionFileChanged());
-  trgWatcher.onDidDelete(uri => notifyDebuggerSessionFileChanged());
+  trgWatcher.onDidChange((uri) => notifyDebuggerSessionFileChanged());
+  trgWatcher.onDidCreate((uri) => notifyDebuggerSessionFileChanged());
+  trgWatcher.onDidDelete((uri) => notifyDebuggerSessionFileChanged());
   return vscode.Disposable.from(clsWatcher, trgWatcher);
 }
 
@@ -248,9 +248,9 @@ function registerIsvAuthWatcher(context: vscode.ExtensionContext) {
       'sfdx-config.json'
     );
     const isvAuthWatcher = vscode.workspace.createFileSystemWatcher(configPath);
-    isvAuthWatcher.onDidChange(uri => setupGlobalDefaultUserIsvAuth());
-    isvAuthWatcher.onDidCreate(uri => setupGlobalDefaultUserIsvAuth());
-    isvAuthWatcher.onDidDelete(uri => setupGlobalDefaultUserIsvAuth());
+    isvAuthWatcher.onDidChange((uri) => setupGlobalDefaultUserIsvAuth());
+    isvAuthWatcher.onDidCreate((uri) => setupGlobalDefaultUserIsvAuth());
+    isvAuthWatcher.onDidDelete((uri) => setupGlobalDefaultUserIsvAuth());
     context.subscriptions.push(isvAuthWatcher);
   }
 }
@@ -287,8 +287,6 @@ export async function activate(context: vscode.ExtensionContext) {
     }
 
     // Telemetry
-    sfdxCoreExtension.exports.telemetryService.showTelemetryMessage();
-
     telemetryService.initializeService(
       sfdxCoreExtension.exports.telemetryService.getReporter(),
       sfdxCoreExtension.exports.telemetryService.isTelemetryEnabled()

--- a/packages/salesforcedx-vscode-apex-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-debugger/src/index.ts
@@ -17,7 +17,7 @@ import {
   SetExceptionBreakpointsArguments,
   SHOW_MESSAGE_EVENT,
   VscodeDebuggerMessage,
-  VscodeDebuggerMessageType,
+  VscodeDebuggerMessageType
 } from '@salesforce/salesforcedx-apex-debugger/out/src';
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -47,7 +47,7 @@ export async function getDebuggerType(
 
 function registerCommands(): vscode.Disposable {
   const customEventHandler = vscode.debug.onDidReceiveDebugSessionCustomEvent(
-    async (event) => {
+    async event => {
       if (event && event.session) {
         const type = await getDebuggerType(event.session);
         if (type === DEBUGGER_TYPE && event.event === SHOW_MESSAGE_EVENT) {
@@ -76,10 +76,10 @@ function registerCommands(): vscode.Disposable {
     'sfdx.debug.exception.breakpoint',
     configureExceptionBreakpoint
   );
-  const startSessionHandler = vscode.debug.onDidStartDebugSession((session) => {
-    cachedExceptionBreakpoints.forEach((breakpoint) => {
+  const startSessionHandler = vscode.debug.onDidStartDebugSession(session => {
+    cachedExceptionBreakpoints.forEach(breakpoint => {
       const args: SetExceptionBreakpointsArguments = {
-        exceptionInfo: breakpoint,
+        exceptionInfo: breakpoint
       };
       session.customRequest(EXCEPTION_BREAKPOINT_REQUEST, args);
     });
@@ -106,13 +106,13 @@ const EXCEPTION_BREAK_MODES: BreakModeItem[] = [
   {
     label: nls.localize('always_break_text'),
     description: '',
-    breakMode: EXCEPTION_BREAKPOINT_BREAK_MODE_ALWAYS,
+    breakMode: EXCEPTION_BREAKPOINT_BREAK_MODE_ALWAYS
   },
   {
     label: nls.localize('never_break_text'),
     description: '',
-    breakMode: EXCEPTION_BREAKPOINT_BREAK_MODE_NEVER,
-  },
+    breakMode: EXCEPTION_BREAKPOINT_BREAK_MODE_NEVER
+  }
 ];
 
 async function configureExceptionBreakpoint(): Promise<void> {
@@ -141,7 +141,7 @@ async function configureExceptionBreakpoint(): Promise<void> {
     );
     const selectExceptionOptions: vscode.QuickPickOptions = {
       placeHolder: nls.localize('select_exception_text'),
-      matchOnDescription: true,
+      matchOnDescription: true
     };
     const selectedException = await vscode.window.showQuickPick(
       processedBreakpointInfos,
@@ -150,7 +150,7 @@ async function configureExceptionBreakpoint(): Promise<void> {
     if (selectedException) {
       const selectBreakModeOptions: vscode.QuickPickOptions = {
         placeHolder: nls.localize('select_break_option_text'),
-        matchOnDescription: true,
+        matchOnDescription: true
       };
       const selectedBreakMode = await vscode.window.showQuickPick(
         EXCEPTION_BREAK_MODES,
@@ -159,7 +159,7 @@ async function configureExceptionBreakpoint(): Promise<void> {
       if (selectedBreakMode) {
         selectedException.breakMode = selectedBreakMode.breakMode;
         const args: SetExceptionBreakpointsArguments = {
-          exceptionInfo: selectedException,
+          exceptionInfo: selectedException
         };
         if (vscode.debug.activeDebugSession) {
           await vscode.debug.activeDebugSession.customRequest(
@@ -221,13 +221,13 @@ export function getExceptionBreakpointCache(): Map<
 
 function registerFileWatchers(): vscode.Disposable {
   const clsWatcher = vscode.workspace.createFileSystemWatcher('**/*.cls');
-  clsWatcher.onDidChange((uri) => notifyDebuggerSessionFileChanged());
-  clsWatcher.onDidCreate((uri) => notifyDebuggerSessionFileChanged());
-  clsWatcher.onDidDelete((uri) => notifyDebuggerSessionFileChanged());
+  clsWatcher.onDidChange(uri => notifyDebuggerSessionFileChanged());
+  clsWatcher.onDidCreate(uri => notifyDebuggerSessionFileChanged());
+  clsWatcher.onDidDelete(uri => notifyDebuggerSessionFileChanged());
   const trgWatcher = vscode.workspace.createFileSystemWatcher('**/*.trigger');
-  trgWatcher.onDidChange((uri) => notifyDebuggerSessionFileChanged());
-  trgWatcher.onDidCreate((uri) => notifyDebuggerSessionFileChanged());
-  trgWatcher.onDidDelete((uri) => notifyDebuggerSessionFileChanged());
+  trgWatcher.onDidChange(uri => notifyDebuggerSessionFileChanged());
+  trgWatcher.onDidCreate(uri => notifyDebuggerSessionFileChanged());
+  trgWatcher.onDidDelete(uri => notifyDebuggerSessionFileChanged());
   return vscode.Disposable.from(clsWatcher, trgWatcher);
 }
 
@@ -248,9 +248,9 @@ function registerIsvAuthWatcher(context: vscode.ExtensionContext) {
       'sfdx-config.json'
     );
     const isvAuthWatcher = vscode.workspace.createFileSystemWatcher(configPath);
-    isvAuthWatcher.onDidChange((uri) => setupGlobalDefaultUserIsvAuth());
-    isvAuthWatcher.onDidCreate((uri) => setupGlobalDefaultUserIsvAuth());
-    isvAuthWatcher.onDidDelete((uri) => setupGlobalDefaultUserIsvAuth());
+    isvAuthWatcher.onDidChange(uri => setupGlobalDefaultUserIsvAuth());
+    isvAuthWatcher.onDidCreate(uri => setupGlobalDefaultUserIsvAuth());
+    isvAuthWatcher.onDidDelete(uri => setupGlobalDefaultUserIsvAuth());
     context.subscriptions.push(isvAuthWatcher);
   }
 }

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
@@ -7,7 +7,7 @@
 
 import {
   MetricError,
-  MetricLaunch,
+  MetricLaunch
 } from '@salesforce/salesforcedx-apex-replay-debugger/out/src';
 import { breakpointUtil } from '@salesforce/salesforcedx-apex-replay-debugger/out/src/breakpoints';
 import {
@@ -17,7 +17,7 @@ import {
   LIVESHARE_DEBUG_TYPE_REQUEST,
   LIVESHARE_DEBUGGER_TYPE,
   SEND_METRIC_ERROR_EVENT,
-  SEND_METRIC_LAUNCH_EVENT,
+  SEND_METRIC_LAUNCH_EVENT
 } from '@salesforce/salesforcedx-apex-replay-debugger/out/src/constants';
 import * as path from 'path';
 import * as pathExists from 'path-exists';
@@ -27,7 +27,7 @@ import {
   checkpointService,
   processBreakpointChangedForCheckpoints,
   sfdxCreateCheckpoints,
-  sfdxToggleCheckpoint,
+  sfdxToggleCheckpoint
 } from './breakpoints/checkpointService';
 import { launchFromLogFile } from './commands/launchFromLogFile';
 import { setupAndDebugTests } from './commands/quickLaunch';
@@ -39,7 +39,7 @@ let extContext: vscode.ExtensionContext;
 export enum VSCodeWindowTypeEnum {
   Error = 1,
   Informational = 2,
-  Warning = 3,
+  Warning = 3
 }
 
 const sfdxCoreExtension = vscode.extensions.getExtension(
@@ -49,14 +49,14 @@ const sfdxCoreExtension = vscode.extensions.getExtension(
 function registerCommands(): vscode.Disposable {
   const promptForLogCmd = vscode.commands.registerCommand(
     'extension.replay-debugger.getLogFileName',
-    async (config) => {
+    async config => {
       const fileUris:
         | vscode.Uri[]
         | undefined = await vscode.window.showOpenDialog({
         canSelectFiles: true,
         canSelectFolders: false,
         canSelectMany: false,
-        defaultUri: getDialogStartingPath(),
+        defaultUri: getDialogStartingPath()
       });
       if (fileUris && fileUris.length === 1) {
         updateLastOpened(extContext, fileUris[0].fsPath);
@@ -66,7 +66,7 @@ function registerCommands(): vscode.Disposable {
   );
   const launchFromLogFileCmd = vscode.commands.registerCommand(
     'sfdx.launch.replay.debugger.logfile',
-    (editorUri) => {
+    editorUri => {
       let logFile: string | undefined;
       if (!editorUri) {
         const editor = vscode.window.activeTextEditor;
@@ -83,7 +83,7 @@ function registerCommands(): vscode.Disposable {
   );
   const launchFromLastLogFileCmd = vscode.commands.registerCommand(
     'sfdx.launch.replay.debugger.last.logfile',
-    (lastLogFileUri) => {
+    lastLogFileUri => {
       const lastOpenedLog = extContext.workspaceState.get<string>(
         LAST_OPENED_LOG_KEY
       );
@@ -132,7 +132,7 @@ export async function getDebuggerType(
 
 function registerDebugHandlers(): vscode.Disposable {
   const customEventHandler = vscode.debug.onDidReceiveDebugSessionCustomEvent(
-    async (event) => {
+    async event => {
       if (event && event.session) {
         const type = await getDebuggerType(event.session);
         if (type !== DEBUGGER_TYPE) {
@@ -184,7 +184,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Debug Tests command
   const debugTests = vscode.commands.registerCommand(
     'sfdx.force.test.view.debugTests',
-    async (test) => {
+    async test => {
       await setupAndDebugTests(test.name);
     }
   );
@@ -192,7 +192,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Debug Single Test command
   const debugTest = vscode.commands.registerCommand(
     'sfdx.force.test.view.debugSingleTest',
-    async (test) => {
+    async test => {
       const name = test.name.split('.');
       await setupAndDebugTests(name[0], name[1]);
     }
@@ -311,7 +311,7 @@ export async function retrieveLineBreakpointInfo(): Promise<boolean> {
 }
 
 function imposeSlightDelay(ms = 0) {
-  return new Promise((r) => setTimeout(r, ms));
+  return new Promise(r => setTimeout(r, ms));
 }
 
 export function writeToDebuggerOutputWindow(

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
@@ -7,7 +7,7 @@
 
 import {
   MetricError,
-  MetricLaunch
+  MetricLaunch,
 } from '@salesforce/salesforcedx-apex-replay-debugger/out/src';
 import { breakpointUtil } from '@salesforce/salesforcedx-apex-replay-debugger/out/src/breakpoints';
 import {
@@ -17,7 +17,7 @@ import {
   LIVESHARE_DEBUG_TYPE_REQUEST,
   LIVESHARE_DEBUGGER_TYPE,
   SEND_METRIC_ERROR_EVENT,
-  SEND_METRIC_LAUNCH_EVENT
+  SEND_METRIC_LAUNCH_EVENT,
 } from '@salesforce/salesforcedx-apex-replay-debugger/out/src/constants';
 import * as path from 'path';
 import * as pathExists from 'path-exists';
@@ -27,7 +27,7 @@ import {
   checkpointService,
   processBreakpointChangedForCheckpoints,
   sfdxCreateCheckpoints,
-  sfdxToggleCheckpoint
+  sfdxToggleCheckpoint,
 } from './breakpoints/checkpointService';
 import { launchFromLogFile } from './commands/launchFromLogFile';
 import { setupAndDebugTests } from './commands/quickLaunch';
@@ -39,7 +39,7 @@ let extContext: vscode.ExtensionContext;
 export enum VSCodeWindowTypeEnum {
   Error = 1,
   Informational = 2,
-  Warning = 3
+  Warning = 3,
 }
 
 const sfdxCoreExtension = vscode.extensions.getExtension(
@@ -49,14 +49,14 @@ const sfdxCoreExtension = vscode.extensions.getExtension(
 function registerCommands(): vscode.Disposable {
   const promptForLogCmd = vscode.commands.registerCommand(
     'extension.replay-debugger.getLogFileName',
-    async config => {
+    async (config) => {
       const fileUris:
         | vscode.Uri[]
         | undefined = await vscode.window.showOpenDialog({
         canSelectFiles: true,
         canSelectFolders: false,
         canSelectMany: false,
-        defaultUri: getDialogStartingPath()
+        defaultUri: getDialogStartingPath(),
       });
       if (fileUris && fileUris.length === 1) {
         updateLastOpened(extContext, fileUris[0].fsPath);
@@ -66,7 +66,7 @@ function registerCommands(): vscode.Disposable {
   );
   const launchFromLogFileCmd = vscode.commands.registerCommand(
     'sfdx.launch.replay.debugger.logfile',
-    editorUri => {
+    (editorUri) => {
       let logFile: string | undefined;
       if (!editorUri) {
         const editor = vscode.window.activeTextEditor;
@@ -83,7 +83,7 @@ function registerCommands(): vscode.Disposable {
   );
   const launchFromLastLogFileCmd = vscode.commands.registerCommand(
     'sfdx.launch.replay.debugger.last.logfile',
-    lastLogFileUri => {
+    (lastLogFileUri) => {
       const lastOpenedLog = extContext.workspaceState.get<string>(
         LAST_OPENED_LOG_KEY
       );
@@ -132,7 +132,7 @@ export async function getDebuggerType(
 
 function registerDebugHandlers(): vscode.Disposable {
   const customEventHandler = vscode.debug.onDidReceiveDebugSessionCustomEvent(
-    async event => {
+    async (event) => {
       if (event && event.session) {
         const type = await getDebuggerType(event.session);
         if (type !== DEBUGGER_TYPE) {
@@ -184,7 +184,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Debug Tests command
   const debugTests = vscode.commands.registerCommand(
     'sfdx.force.test.view.debugTests',
-    async test => {
+    async (test) => {
       await setupAndDebugTests(test.name);
     }
   );
@@ -192,7 +192,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Debug Single Test command
   const debugTest = vscode.commands.registerCommand(
     'sfdx.force.test.view.debugSingleTest',
-    async test => {
+    async (test) => {
       const name = test.name.split('.');
       await setupAndDebugTests(name[0], name[1]);
     }
@@ -210,8 +210,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Telemetry
   if (sfdxCoreExtension && sfdxCoreExtension.exports) {
-    sfdxCoreExtension.exports.telemetryService.showTelemetryMessage();
-
     telemetryService.initializeService(
       sfdxCoreExtension.exports.telemetryService.getReporter(),
       sfdxCoreExtension.exports.telemetryService.isTelemetryEnabled()
@@ -313,7 +311,7 @@ export async function retrieveLineBreakpointInfo(): Promise<boolean> {
 }
 
 function imposeSlightDelay(ms = 0) {
-  return new Promise(r => setTimeout(r, ms));
+  return new Promise((r) => setTimeout(r, ms));
 }
 
 export function writeToDebuggerOutputWindow(

--- a/packages/salesforcedx-vscode-visualforce/src/extension.ts
+++ b/packages/salesforcedx-vscode-visualforce/src/extension.ts
@@ -16,7 +16,7 @@ import {
   languages,
   Position,
   Range,
-  TextDocument,
+  TextDocument
 } from 'vscode';
 import {
   BaseLanguageClient,
@@ -25,7 +25,7 @@ import {
   RequestType,
   ServerOptions,
   TextDocumentPositionParams,
-  TransportKind,
+  TransportKind
 } from 'vscode-languageclient';
 import { EMPTY_ELEMENTS } from './htmlEmptyTagsShared';
 import { activateTagClosing } from './tagClosing';
@@ -35,7 +35,7 @@ import {
   ColorPresentationParams,
   ColorPresentationRequest,
   DocumentColorParams,
-  DocumentColorRequest,
+  DocumentColorRequest
 } from 'vscode-languageserver-protocol';
 import { telemetryService } from './telemetry';
 
@@ -74,15 +74,15 @@ export async function activate(context: ExtensionContext) {
     debug: {
       module: serverModule,
       transport: TransportKind.ipc,
-      options: debugOptions,
-    },
+      options: debugOptions
+    }
   };
 
   const documentSelector = [
     {
       language: 'visualforce',
-      scheme: 'file',
-    },
+      scheme: 'file'
+    }
   ];
   const embeddedLanguages = { css: true, javascript: true };
 
@@ -90,11 +90,11 @@ export async function activate(context: ExtensionContext) {
   const clientOptions: LanguageClientOptions = {
     documentSelector,
     synchronize: {
-      configurationSection: ['visualforce', 'css', 'javascript'], // the settings to synchronize
+      configurationSection: ['visualforce', 'css', 'javascript'] // the settings to synchronize
     },
     initializationOptions: {
-      embeddedLanguages,
-    },
+      embeddedLanguages
+    }
   };
 
   // Create the language client and start the client.
@@ -118,12 +118,12 @@ export async function activate(context: ExtensionContext) {
           const params: DocumentColorParams = {
             textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(
               document
-            ),
+            )
           };
           return client
             .sendRequest(DocumentColorRequest.type, params)
-            .then((symbols) => {
-              return symbols.map((symbol) => {
+            .then(symbols => {
+              return symbols.map(symbol => {
                 const range = client.protocol2CodeConverter.asRange(
                   symbol.range
                 );
@@ -146,12 +146,12 @@ export async function activate(context: ExtensionContext) {
               colorContext.document
             ),
             range: client.code2ProtocolConverter.asRange(colorContext.range),
-            color,
+            color
           };
           return client
             .sendRequest(ColorPresentationRequest.type, params)
-            .then((presentations) => {
-              return presentations.map((p) => {
+            .then(presentations => {
+              return presentations.map(p => {
                 const presentation = new ColorPresentation(p.label);
                 presentation.textEdit =
                   p.textEdit &&
@@ -164,7 +164,7 @@ export async function activate(context: ExtensionContext) {
                 return presentation;
               });
             });
-        },
+        }
       });
       toDispose.push(disposable);
 
@@ -182,14 +182,14 @@ export async function activate(context: ExtensionContext) {
       );
       toDispose.push(disposable);
     })
-    .catch((err) => {
+    .catch(err => {
       // Handled by clients
       telemetryService.sendExtensionActivationEvent(err);
     });
   languages.setLanguageConfiguration('visualforce', {
     indentationRules: {
       increaseIndentPattern: /<(?!\?|(?:area|base|br|col|frame|hr|html|img|input|link|meta|param)\b|[^>]*\/>)([-_\.A-Za-z0-9]+)(?=\s|>)\b[^>]*>(?!.*<\/\1>)|<!--(?!.*-->)|\{[^}"']*$/,
-      decreaseIndentPattern: /^\s*(<\/(?!html)[-_\.A-Za-z0-9]+\b[^>]*>|-->|\})/,
+      decreaseIndentPattern: /^\s*(<\/(?!html)[-_\.A-Za-z0-9]+\b[^>]*>|-->|\})/
     },
     wordPattern: /(-?\d*\.\d\w*)|([^\`\~\!\@\$\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\s]+)/g,
     onEnterRules: [
@@ -201,7 +201,7 @@ export async function activate(context: ExtensionContext) {
           'i'
         ),
         afterText: /^<\/([_:\w][_:\w-.\d]*)\s*>$/i,
-        action: { indentAction: IndentAction.IndentOutdent },
+        action: { indentAction: IndentAction.IndentOutdent }
       },
       {
         beforeText: new RegExp(
@@ -210,9 +210,9 @@ export async function activate(context: ExtensionContext) {
           )}))(\\w[\\w\\d]*)([^/>]*(?!/)>)[^<]*$`,
           'i'
         ),
-        action: { indentAction: IndentAction.Indent },
-      },
-    ],
+        action: { indentAction: IndentAction.Indent }
+      }
+    ]
   });
 
   languages.setLanguageConfiguration('handlebars', {
@@ -226,7 +226,7 @@ export async function activate(context: ExtensionContext) {
           'i'
         ),
         afterText: /^<\/([_:\w][_:\w-.\d]*)\s*>$/i,
-        action: { indentAction: IndentAction.IndentOutdent },
+        action: { indentAction: IndentAction.IndentOutdent }
       },
       {
         beforeText: new RegExp(
@@ -235,9 +235,9 @@ export async function activate(context: ExtensionContext) {
           )}))(\\w[\\w\\d]*)([^/>]*(?!/)>)[^<]*$`,
           'i'
         ),
-        action: { indentAction: IndentAction.Indent },
-      },
-    ],
+        action: { indentAction: IndentAction.Indent }
+      }
+    ]
   });
 
   languages.setLanguageConfiguration('razor', {
@@ -251,7 +251,7 @@ export async function activate(context: ExtensionContext) {
           'i'
         ),
         afterText: /^<\/([_:\w][_:\w-.\d]*)\s*>$/i,
-        action: { indentAction: IndentAction.IndentOutdent },
+        action: { indentAction: IndentAction.IndentOutdent }
       },
       {
         beforeText: new RegExp(
@@ -260,9 +260,9 @@ export async function activate(context: ExtensionContext) {
           )}))(\\w[\\w\\d]*)([^/>]*(?!/)>)[^<]*$`,
           'i'
         ),
-        action: { indentAction: IndentAction.Indent },
-      },
-    ],
+        action: { indentAction: IndentAction.Indent }
+      }
+    ]
   });
 
   // Telemetry

--- a/packages/salesforcedx-vscode-visualforce/src/extension.ts
+++ b/packages/salesforcedx-vscode-visualforce/src/extension.ts
@@ -16,7 +16,7 @@ import {
   languages,
   Position,
   Range,
-  TextDocument
+  TextDocument,
 } from 'vscode';
 import {
   BaseLanguageClient,
@@ -25,7 +25,7 @@ import {
   RequestType,
   ServerOptions,
   TextDocumentPositionParams,
-  TransportKind
+  TransportKind,
 } from 'vscode-languageclient';
 import { EMPTY_ELEMENTS } from './htmlEmptyTagsShared';
 import { activateTagClosing } from './tagClosing';
@@ -35,7 +35,7 @@ import {
   ColorPresentationParams,
   ColorPresentationRequest,
   DocumentColorParams,
-  DocumentColorRequest
+  DocumentColorRequest,
 } from 'vscode-languageserver-protocol';
 import { telemetryService } from './telemetry';
 
@@ -74,15 +74,15 @@ export async function activate(context: ExtensionContext) {
     debug: {
       module: serverModule,
       transport: TransportKind.ipc,
-      options: debugOptions
-    }
+      options: debugOptions,
+    },
   };
 
   const documentSelector = [
     {
       language: 'visualforce',
-      scheme: 'file'
-    }
+      scheme: 'file',
+    },
   ];
   const embeddedLanguages = { css: true, javascript: true };
 
@@ -90,11 +90,11 @@ export async function activate(context: ExtensionContext) {
   const clientOptions: LanguageClientOptions = {
     documentSelector,
     synchronize: {
-      configurationSection: ['visualforce', 'css', 'javascript'] // the settings to synchronize
+      configurationSection: ['visualforce', 'css', 'javascript'], // the settings to synchronize
     },
     initializationOptions: {
-      embeddedLanguages
-    }
+      embeddedLanguages,
+    },
   };
 
   // Create the language client and start the client.
@@ -118,12 +118,12 @@ export async function activate(context: ExtensionContext) {
           const params: DocumentColorParams = {
             textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(
               document
-            )
+            ),
           };
           return client
             .sendRequest(DocumentColorRequest.type, params)
-            .then(symbols => {
-              return symbols.map(symbol => {
+            .then((symbols) => {
+              return symbols.map((symbol) => {
                 const range = client.protocol2CodeConverter.asRange(
                   symbol.range
                 );
@@ -146,12 +146,12 @@ export async function activate(context: ExtensionContext) {
               colorContext.document
             ),
             range: client.code2ProtocolConverter.asRange(colorContext.range),
-            color
+            color,
           };
           return client
             .sendRequest(ColorPresentationRequest.type, params)
-            .then(presentations => {
-              return presentations.map(p => {
+            .then((presentations) => {
+              return presentations.map((p) => {
                 const presentation = new ColorPresentation(p.label);
                 presentation.textEdit =
                   p.textEdit &&
@@ -164,7 +164,7 @@ export async function activate(context: ExtensionContext) {
                 return presentation;
               });
             });
-        }
+        },
       });
       toDispose.push(disposable);
 
@@ -182,14 +182,14 @@ export async function activate(context: ExtensionContext) {
       );
       toDispose.push(disposable);
     })
-    .catch(err => {
+    .catch((err) => {
       // Handled by clients
       telemetryService.sendExtensionActivationEvent(err);
     });
   languages.setLanguageConfiguration('visualforce', {
     indentationRules: {
       increaseIndentPattern: /<(?!\?|(?:area|base|br|col|frame|hr|html|img|input|link|meta|param)\b|[^>]*\/>)([-_\.A-Za-z0-9]+)(?=\s|>)\b[^>]*>(?!.*<\/\1>)|<!--(?!.*-->)|\{[^}"']*$/,
-      decreaseIndentPattern: /^\s*(<\/(?!html)[-_\.A-Za-z0-9]+\b[^>]*>|-->|\})/
+      decreaseIndentPattern: /^\s*(<\/(?!html)[-_\.A-Za-z0-9]+\b[^>]*>|-->|\})/,
     },
     wordPattern: /(-?\d*\.\d\w*)|([^\`\~\!\@\$\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\s]+)/g,
     onEnterRules: [
@@ -201,7 +201,7 @@ export async function activate(context: ExtensionContext) {
           'i'
         ),
         afterText: /^<\/([_:\w][_:\w-.\d]*)\s*>$/i,
-        action: { indentAction: IndentAction.IndentOutdent }
+        action: { indentAction: IndentAction.IndentOutdent },
       },
       {
         beforeText: new RegExp(
@@ -210,9 +210,9 @@ export async function activate(context: ExtensionContext) {
           )}))(\\w[\\w\\d]*)([^/>]*(?!/)>)[^<]*$`,
           'i'
         ),
-        action: { indentAction: IndentAction.Indent }
-      }
-    ]
+        action: { indentAction: IndentAction.Indent },
+      },
+    ],
   });
 
   languages.setLanguageConfiguration('handlebars', {
@@ -226,7 +226,7 @@ export async function activate(context: ExtensionContext) {
           'i'
         ),
         afterText: /^<\/([_:\w][_:\w-.\d]*)\s*>$/i,
-        action: { indentAction: IndentAction.IndentOutdent }
+        action: { indentAction: IndentAction.IndentOutdent },
       },
       {
         beforeText: new RegExp(
@@ -235,9 +235,9 @@ export async function activate(context: ExtensionContext) {
           )}))(\\w[\\w\\d]*)([^/>]*(?!/)>)[^<]*$`,
           'i'
         ),
-        action: { indentAction: IndentAction.Indent }
-      }
-    ]
+        action: { indentAction: IndentAction.Indent },
+      },
+    ],
   });
 
   languages.setLanguageConfiguration('razor', {
@@ -251,7 +251,7 @@ export async function activate(context: ExtensionContext) {
           'i'
         ),
         afterText: /^<\/([_:\w][_:\w-.\d]*)\s*>$/i,
-        action: { indentAction: IndentAction.IndentOutdent }
+        action: { indentAction: IndentAction.IndentOutdent },
       },
       {
         beforeText: new RegExp(
@@ -260,9 +260,9 @@ export async function activate(context: ExtensionContext) {
           )}))(\\w[\\w\\d]*)([^/>]*(?!/)>)[^<]*$`,
           'i'
         ),
-        action: { indentAction: IndentAction.Indent }
-      }
-    ]
+        action: { indentAction: IndentAction.Indent },
+      },
+    ],
   });
 
   // Telemetry
@@ -271,8 +271,6 @@ export async function activate(context: ExtensionContext) {
   );
 
   if (sfdxCoreExtension && sfdxCoreExtension.exports) {
-    sfdxCoreExtension.exports.telemetryService.showTelemetryMessage();
-
     telemetryService.initializeService(
       sfdxCoreExtension.exports.telemetryService.getReporter(),
       sfdxCoreExtension.exports.telemetryService.isTelemetryEnabled()


### PR DESCRIPTION
### What does this PR do?
Follow up to PRs #2878 & #2894. This fixes an issue on `salesforcedx-vscode-apex`, `salesforcedx-vscode-apex-replay-debugger` and `salesforcedx-vscode-visualforce` where it fails to find a now removed `showTelemetryMessage` method.

### What issues does this PR fix or reference?
@W-8792554@
