### PR TITLE
feat(soql): extract comments out of soql text before running query

### DIFF
--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -33,7 +33,7 @@
     "soql builder"
   ],
   "dependencies": {
-    "@salesforce/apex-tmlanguage": "1.5.0",
+    "@salesforce/apex-tmlanguage": "1.6.0",
     "@salesforce/core": "^2.15.2",
     "@salesforce/salesforcedx-utils-vscode": "50.16.0",
     "@salesforce/soql-builder-ui": "0.0.29",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -38,7 +38,7 @@
     "@salesforce/salesforcedx-utils-vscode": "50.16.0",
     "@salesforce/soql-builder-ui": "0.0.29",
     "@salesforce/soql-data-view": "0.0.8",
-    "@salesforce/soql-language-server": "0.3.3",
+    "@salesforce/soql-language-server": "0.3.4",
     "debounce": "^1.2.0",
     "jsforce": "^1.10.0",
     "papaparse": "^5.3.0",

--- a/packages/salesforcedx-vscode-soql/src/editor/queryRunner.ts
+++ b/packages/salesforcedx-vscode-soql/src/editor/queryRunner.ts
@@ -10,7 +10,7 @@ import { JsonMap } from '@salesforce/ts-types';
 import { QueryResult } from 'jsforce';
 import * as vscode from 'vscode';
 import { nls } from '../messages';
-
+import { parseHeaderComments } from '@salesforce/soql-language-server/lib/soqlComments';
 export class QueryRunner {
   constructor(private connection: Connection) {}
 
@@ -18,9 +18,11 @@ export class QueryRunner {
     queryText: string,
     options = { showErrors: true }
   ): Promise<QueryResult<JsonMap>> {
+    const pureSOQLText = parseHeaderComments(queryText).soqlText;
+
     try {
       const rawQueryData = (await this.connection.query(
-        queryText
+        pureSOQLText
       )) as QueryResult<JsonMap>;
       const cleanQueryData = {
         ...rawQueryData,

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/client/client.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/client/client.test.ts
@@ -114,11 +114,11 @@ describe('SOQL language client', () => {
       soqlExtension
     );
 
-    const expectedError = `SELECT Ids FROM ACCOUNT\nERROR at Row:1:Column:8\nSome error at 'Ids'`;
+    const serverError = `SELECT Ids FROM ACCOUNT\nERROR at Row:1:Column:8\nSome error at 'Ids'`;
     const querySpy = sandbox.stub(mockConnection, 'query').throws({
       name: 'INVALID_FIELD',
       errorCode: 'INVALID_FIELD',
-      message: expectedError
+      message: serverError
     });
     await window.showTextDocument(soqlFileUri);
 
@@ -145,11 +145,13 @@ describe('SOQL language client', () => {
       soqlExtension
     );
 
-    const expectedError = `SELECT Ids FROM ACCOUNT\nERROR at Row:1:Column:8\nSome error at 'Ids'`;
+    const serverError = `SELECT Ids FROM ACCOUNT\nERROR at Row:1:Column:8\nSome error at 'Ids'`;
+    const expectedError = `SELECT Ids FROM ACCOUNT\nError:\nSome error at 'Ids'`;
+
     sandbox.stub(mockConnection, 'query').throws({
       name: 'INVALID_FIELD',
       errorCode: 'INVALID_FIELD',
-      message: expectedError
+      message: serverError
     });
 
     await window.showTextDocument(soqlFileUri);

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/editor/queryRunner.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/editor/queryRunner.test.ts
@@ -44,4 +44,21 @@ describe('Query Runner Should', () => {
       expect(error.name).equal(errorName);
     }
   });
+
+  it('strip comments before passing query to connection', async () => {
+    const querySpy = sandbox.spy(mockConnection, 'query');
+    const soqlNoComments = 'SELECT Id\nFROM Account\n';
+    const soqlWithComments =
+      '// Comment line 1\n//Comment line2\n' + soqlNoComments;
+
+    const queryRunner = new QueryRunner(mockConnection);
+    const queryData = await queryRunner.runQuery(soqlWithComments);
+    queryData.records.forEach((result: {}) => {
+      expect(result).to.not.have.key('attributes');
+    });
+
+    expect(querySpy.calledOnce).to.be.true;
+    expect(querySpy.firstCall.args[0]).to.equal(soqlNoComments);
+  });
+
 });


### PR DESCRIPTION
### What does this PR do?
On SOQL Builder: when there are comments at the top of `.soql` files, strip them out before calling the "Run Query" API.

### What issues does this PR fix or reference?
@W-8611529@

### Functionality Before
![image](https://user-images.githubusercontent.com/152839/106660244-7fd6cb80-657e-11eb-9727-35b7f20e3223.png)

### Functionality After
![image](https://user-images.githubusercontent.com/152839/106660453-c3c9d080-657e-11eb-9449-cf6a7567c588.png)
