### PR TITLE
refactor: remove core extension dependency from apex extension

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -53,9 +53,6 @@
     "typescript": "3.8.3",
     "vscode-extension-telemetry": "0.0.17"
   },
-  "extensionDependencies": [
-    "salesforce.salesforcedx-vscode-core"
-  ],
   "scripts": {
     "vscode:prepublish": "npm prune --production",
     "vscode:package": "vsce package",

--- a/packages/salesforcedx-vscode-apex/src/commands/forceApexTestRunCodeAction.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceApexTestRunCodeAction.ts
@@ -11,8 +11,11 @@ import {
   TestService
 } from '@salesforce/apex-node';
 import {
+  EmptyParametersGatherer,
   LibraryCommandletExecutor,
-  SfdxCommandletExecutor
+  SfdxCommandlet,
+  SfdxCommandletExecutor,
+  SfdxWorkspaceChecker
 } from '@salesforce/salesforcedx-utils-vscode/out/src';
 import {
   Command,
@@ -26,13 +29,6 @@ import { workspaceContext } from '../context';
 import { nls } from '../messages';
 import * as settings from '../settings';
 import { forceApexTestRunCacheService, isEmpty } from '../testRunCache';
-
-const sfdxCoreExports = vscode.extensions.getExtension(
-  'salesforce.salesforcedx-vscode-core'
-)!.exports;
-const EmptyParametersGatherer = sfdxCoreExports.EmptyParametersGatherer;
-const SfdxCommandlet = sfdxCoreExports.SfdxCommandlet;
-const SfdxWorkspaceChecker = sfdxCoreExports.SfdxWorkspaceChecker;
 
 export class ApexLibraryTestRunExecutor extends LibraryCommandletExecutor<{}> {
   private tests: string[];

--- a/packages/salesforcedx-vscode-apex/src/views/testOutlineProvider.ts
+++ b/packages/salesforcedx-vscode-apex/src/views/testOutlineProvider.ts
@@ -25,18 +25,16 @@ import {
   languageClientUtils
 } from '../languageClientUtils';
 import { nls } from '../messages';
+import * as settings from '../settings';
 import { ApexTestMethod } from './lspConverter';
 import { FullTestResult } from './testDataAccessObjects';
+
 // Message
 const LOADING_MESSAGE = nls.localize('force_test_view_loading_message');
 const NO_TESTS_MESSAGE = nls.localize('force_test_view_no_tests_message');
 const NO_TESTS_DESCRIPTION = nls.localize(
   'force_test_view_no_tests_description'
 );
-const sfdxCoreExports = vscode.extensions.getExtension(
-  'salesforce.salesforcedx-vscode-core'
-)!.exports;
-const sfdxCoreSettings = sfdxCoreExports.sfdxCoreSettings;
 
 export class ApexTestOutlineProvider
   implements vscode.TreeDataProvider<TestNode> {
@@ -183,7 +181,7 @@ export class ApexTestOutlineProvider
     const testResultOutput = readFileSync(testResultFilePath, 'utf8');
     const testResultContent = JSON.parse(testResultOutput);
 
-    sfdxCoreSettings.getApexLibrary()
+    settings.useApexLibrary()
       ? this.updateTestsFromLibrary(testResultContent as TestResult)
       : this.updateTestsFromJSON(testResultContent as FullTestResult);
     this.onDidChangeTestData.fire(undefined);

--- a/packages/salesforcedx-vscode-apex/src/views/testRunner.ts
+++ b/packages/salesforcedx-vscode-apex/src/views/testRunner.ts
@@ -5,6 +5,11 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import {
+  EmptyParametersGatherer,
+  SfdxCommandlet,
+  SfdxWorkspaceChecker
+} from '@salesforce/salesforcedx-utils-vscode/out/src';
 import { TestRunner } from '@salesforce/salesforcedx-utils-vscode/out/src/cli/';
 import * as events from 'events';
 import * as vscode from 'vscode';
@@ -18,6 +23,7 @@ import {
   languageClientUtils
 } from '../languageClientUtils';
 import { nls } from '../messages';
+import * as settings from '../settings';
 import { forceApexTestRunCacheService } from '../testRunCache';
 import {
   ApexTestGroupNode,
@@ -25,14 +31,6 @@ import {
   ApexTestOutlineProvider,
   TestNode
 } from './testOutlineProvider';
-const sfdxCoreExports = vscode.extensions.getExtension(
-  'salesforce.salesforcedx-vscode-core'
-)!.exports;
-
-const EmptyParametersGatherer = sfdxCoreExports.EmptyParametersGatherer;
-const SfdxCommandlet = sfdxCoreExports.SfdxCommandlet;
-const SfdxWorkspaceChecker = sfdxCoreExports.SfdxWorkspaceChecker;
-const sfdxCoreSettings = sfdxCoreExports.sfdxCoreSettings;
 
 export enum TestRunType {
   All,
@@ -137,13 +135,13 @@ export class ApexTestRunner {
     }
 
     const tmpFolder = this.getTempFolder();
-    const getCodeCoverage = sfdxCoreSettings.getRetrieveTestCodeCoverage();
+    const getCodeCoverage = settings.retrieveTestCodeCoverage();
     if (testRunType === TestRunType.Class) {
       await forceApexTestRunCacheService.setCachedClassTestParam(tests[0]);
     } else if (testRunType === TestRunType.Method) {
       await forceApexTestRunCacheService.setCachedMethodTestParam(tests[0]);
     }
-    const executor = sfdxCoreSettings.getApexLibrary()
+    const executor = settings.useApexLibrary()
       ? new ApexLibraryTestRunExecutor(tests, tmpFolder, getCodeCoverage)
       : new ForceApexTestRunCodeActionExecutor(
           tests,

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceGenerateFauxClasses.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceGenerateFauxClasses.test.ts
@@ -16,6 +16,11 @@ import {
   FauxClassGenerator,
   SObjectRefreshSource
 } from '@salesforce/salesforcedx-sobjects-faux-generator/out/src/generator';
+import { SfdxCommandlet } from '@salesforce/salesforcedx-utils-vscode/out/src';
+import {
+  notificationService,
+  ProgressNotification
+} from '@salesforce/salesforcedx-utils-vscode/out/src/commands';
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import { expect } from 'chai';
 import * as fs from 'fs';
@@ -30,18 +35,9 @@ import {
   SObjectRefreshGatherer,
   verifyUsernameAndInitSObjectDefinitions
 } from '../../../src/commands/forceGenerateFauxClasses';
+import { workspaceContext } from '../../../src/context';
 import { nls } from '../../../src/messages';
 import { telemetryService } from '../../../src/telemetry';
-
-const sfdxCoreExports = vscode.extensions.getExtension(
-  'salesforce.salesforcedx-vscode-core'
-)!.exports;
-const {
-  OrgAuthInfo,
-  ProgressNotification,
-  SfdxCommandlet,
-  notificationService
-} = sfdxCoreExports;
 
 describe('ForceGenerateFauxClasses', () => {
   describe('initSObjectDefinitions', () => {
@@ -62,10 +58,10 @@ describe('ForceGenerateFauxClasses', () => {
     beforeEach(() => {
       sandboxStub = createSandbox();
       existsSyncStub = sandboxStub.stub(fs, 'existsSync');
-      getUsernameStub = sandboxStub.stub(
-        OrgAuthInfo,
-        'getDefaultUsernameOrAlias'
-      );
+      getUsernameStub = sandboxStub.stub();
+      sandboxStub
+        .stub(workspaceContext, 'getConnection')
+        .resolves({ getUsername: getUsernameStub });
       commandletSpy = sandboxStub.stub(SfdxCommandlet.prototype, 'run');
       notificationStub = sandboxStub.stub(
         notificationService,
@@ -134,10 +130,10 @@ describe('ForceGenerateFauxClasses', () => {
         notificationService,
         'showInformationMessage'
       );
-      getUsernameStub = sandboxStub.stub(
-        OrgAuthInfo,
-        'getDefaultUsernameOrAlias'
-      );
+      getUsernameStub = sandboxStub.stub();
+      sandboxStub
+        .stub(workspaceContext, 'getConnection')
+        .resolves({ getUsername: getUsernameStub });
     });
 
     afterEach(() => {

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceGenerateFauxClasses.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceGenerateFauxClasses.test.ts
@@ -179,7 +179,7 @@ describe('ForceGenerateFauxClasses', () => {
     let logStub: SinonStub;
     let errorStub: SinonStub;
 
-    const expectedData: any = {
+    const expectedData = {
       cancelled: false,
       standardObjects: 1,
       customObjects: 2
@@ -249,7 +249,13 @@ describe('ForceGenerateFauxClasses', () => {
     it('Should log correct information to telemetry', async () => {
       // Success
       await doExecute(SObjectRefreshSource.Startup);
-      expect(logStub.getCall(0).args[2]).to.eqls(expectedData);
+      expect(logStub.getCall(0).args[2]).to.deep.contain({
+        cancelled: 'false'
+      });
+      expect(logStub.getCall(0).args[3]).to.deep.contain({
+        standardObjects: expectedData.standardObjects,
+        customObjects: expectedData.customObjects
+      });
 
       // Error
       const error = { message: 'sample error', stack: 'sample stack' };

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/views/testOutline.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/views/testOutline.test.ts
@@ -6,6 +6,7 @@
  */
 
 // tslint:disable:no-unused-expression
+import { SfdxCommandlet } from '@salesforce/salesforcedx-utils-vscode/out/src';
 import { expect } from 'chai';
 import * as events from 'events';
 import * as fs from 'fs';
@@ -17,6 +18,7 @@ import {
   LanguageClientUtils
 } from '../../../src/languageClientUtils/languageClientUtils';
 import { nls } from '../../../src/messages';
+import * as settings from '../../../src/settings';
 import { forceApexTestRunCacheService } from '../../../src/testRunCache';
 import { ApexTestMethod } from '../../../src/views/lspConverter';
 import {
@@ -38,11 +40,6 @@ const NO_TESTS_DESCRIPTION = nls.localize(
   'force_test_view_no_tests_description'
 );
 
-const coreExports = vscode.extensions.getExtension(
-  'salesforce.salesforcedx-vscode-core'
-)!.exports;
-const sfdxCoreSettings = coreExports.sfdxCoreSettings;
-
 describe('TestView', () => {
   let testOutline: ApexTestOutlineProvider;
   const apexTestInfo: ApexTestMethod[] = generateApexTestMethod();
@@ -54,11 +51,11 @@ describe('TestView', () => {
     let settingStub: SinonStub;
 
     beforeEach(() => {
-      commandletSpy = spy(coreExports.SfdxCommandlet.prototype, 'run');
-      getCoverageStub = stub(sfdxCoreSettings, 'getRetrieveTestCodeCoverage');
+      commandletSpy = spy(SfdxCommandlet.prototype, 'run');
+      getCoverageStub = stub(settings, 'retrieveTestCodeCoverage');
       languageClientUtils = LanguageClientUtils.getInstance();
       languageClientUtils.setStatus(ClientStatus.Ready, 'Apex client is ready');
-      settingStub = stub(sfdxCoreSettings, 'getApexLibrary').returns(false);
+      settingStub = stub(settings, 'useApexLibrary').returns(false);
     });
 
     afterEach(() => {
@@ -222,7 +219,7 @@ describe('TestView', () => {
         return 'nonsense';
       });
       parseJSONStub = stub(JSON, 'parse');
-      settingStub = stub(sfdxCoreSettings, 'getApexLibrary');
+      settingStub = stub(settings, 'useApexLibrary');
     });
 
     afterEach(() => {
@@ -344,7 +341,7 @@ describe('TestView', () => {
       eventEmitterStub = stub(eventEmitter, 'emit');
       showTextDocumentStub = stub(vscode.window, 'showTextDocument');
       showTextDocumentStub.returns(Promise.resolve());
-      settingStub = stub(sfdxCoreSettings, 'getApexLibrary').returns(false);
+      settingStub = stub(settings, 'useApexLibrary').returns(false);
 
       testOutline = new ApexTestOutlineProvider(apexTestInfo);
       testOutline.updateTestResults('multipleFilesMixed');

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/views/testOutlineNamespace.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/views/testOutlineNamespace.test.ts
@@ -11,6 +11,7 @@ import * as fs from 'fs';
 import { createSandbox, SinonSandbox, SinonStub } from 'sinon';
 import * as vscode from 'vscode';
 import { APEX_GROUP_RANGE } from '../../../src/constants';
+import * as settings from '../../../src/settings';
 import { ApexTestMethod } from '../../../src/views/lspConverter';
 import {
   ApexTestGroupNode,
@@ -26,11 +27,6 @@ import {
   jsonMultipleNSFiles,
   jsonOneNSFilePass
 } from './testNamespacedOutputs';
-
-const sfdxCoreExports = vscode.extensions.getExtension(
-  'salesforce.salesforcedx-vscode-core'
-)!.exports;
-const sfdxCoreSettings = sfdxCoreExports.sfdxCoreSettings;
 
 describe('Test View with namespace', () => {
   let testOutline: ApexTestOutlineProvider;
@@ -118,7 +114,7 @@ describe('Test View with namespace', () => {
         return 'nonsense';
       });
       parseJSONStub = sb.stub(JSON, 'parse');
-      settingStub = sb.stub(sfdxCoreSettings, 'getApexLibrary').returns(false);
+      settingStub = sb.stub(settings, 'useApexLibrary').returns(false);
     });
 
     afterEach(() => {
@@ -237,7 +233,7 @@ describe('Test View with namespace', () => {
       eventEmitterStub = sb.stub(eventEmitter, 'emit');
       showTextDocumentStub = sb.stub(vscode.window, 'showTextDocument');
       showTextDocumentStub.returns(Promise.resolve());
-      sb.stub(sfdxCoreSettings, 'getApexLibrary').returns(false);
+      sb.stub(settings, 'useApexLibrary').returns(false);
 
       testOutline = new ApexTestOutlineProvider(apexNamespacedTestInfo);
       testOutline.updateTestResults('multipleFilesMixed');


### PR DESCRIPTION
### What does this PR do?

Removes the core extension dependency from the apex extension. This allows the Apex extension to start activating before the core extension finishes.

### What issues does this PR fix or reference?

@W-8659996@