### PR TITLE
fix: activate redhat XML extension only if it is version 0.14.0 @W-8852786@

### DIFF
--- a/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
@@ -100,6 +100,8 @@ export const messages = {
     'Salesforce js-meta.xml IntelliSense requires the Red Hat XML extension',
   force_lightning_lwc_deprecated_redhat_extension:
     'Salesforce js-meta.xml IntelliSense requires the Red Hat XML extension version >= 0.14.0. Upgrade the Red Hat XML extension.',
+  force_lightning_lwc_redhat_extension_regression:
+    'Salesforce js-meta.xml IntelliSense does not work with Red Hat XML extension version 0.15.0. Downgrade the Red Hat XML extension to 0.14.0.',
   force_lightning_lwc_fail_redhat_extension:
     'Failed to setup Red Hat XML extension'
 };

--- a/packages/salesforcedx-vscode-lwc/src/metasupport/metaSupport.ts
+++ b/packages/salesforcedx-vscode-lwc/src/metasupport/metaSupport.ts
@@ -80,8 +80,14 @@ export class MetaSupport {
     } else if (redHatExtension) {
       const pluginVersionNumber = redHatExtension!.packageJSON['version'];
 
-      // checks plugin version greater than 0.13.0, might need to change.
-      if (parseInt(pluginVersionNumber.split('.')[1], 10) >= 14) {
+      // checks if the installed plugin version is exactly 0.14.0
+      // 0.15.0 has a regression and 0.13.0 or earlier versions are not supported
+
+      if (parseInt(pluginVersionNumber.split('.')[1], 10) === 15) {
+        channelService.appendLine(
+          nls.localize('force_lightning_lwc_redhat_extension_regression')
+        );
+      } else if (parseInt(pluginVersionNumber.split('.')[1], 10) === 14) {
         const catalogs = this.getLocalFilePath(['js-meta-home.xml']);
         const fileAssociations = [
           {

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/metaSupport/metaSupport.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/metaSupport/metaSupport.test.ts
@@ -20,7 +20,7 @@ let mockRhExtension: any;
 let rhExtension: any;
 let appendLineSpy: sinon.SinonSpy<any, any>;
 
-describe('MetaSupport: Extension version too old', () => {
+describe('MetaSupport: Extension version supported', () => {
   beforeEach(() => {
     appendLineSpy = sinon.spy(ChannelService.prototype, 'appendLine');
   });
@@ -47,6 +47,16 @@ describe('MetaSupport: Extension version too old', () => {
     await metaSupport.getMetaSupport();
     expect(appendLineSpy).to.have.calledOnceWith(
       nls.localize('force_lightning_lwc_deprecated_redhat_extension')
+    );
+  });
+
+  it('Should post error message if XML extension is 0.15.0', async () => {
+    mockRhExtension = sandbox
+      .stub(extensions, 'getExtension')
+      .returns(new MockRedhatExtension('0.15.0'));
+    await metaSupport.getMetaSupport();
+    expect(appendLineSpy).to.have.calledOnceWith(
+      nls.localize('force_lightning_lwc_redhat_extension_regression')
     );
   });
 });


### PR DESCRIPTION
### What does this PR do?
fix: activate redhat XML extension only if it is version 0.14.0

### What issues does this PR fix or reference?
@W-8852786@

### Functionality Before
LWC Extension activation error for some users

### Functionality After
Fix for the LWC Extension activation error for some users