### PR TITLE
feat: add namespace support to test:run & debug commands

### DIFF
--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/quickLaunch.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/quickLaunch.ts
@@ -9,6 +9,7 @@ import {
   ApexTestResultData,
   SyncTestConfiguration,
   TestItem,
+  TestLevel,
   TestResult
 } from '@salesforce/apex-node/lib/src/tests/types';
 import { Connection } from '@salesforce/core';
@@ -78,21 +79,14 @@ export class QuickLaunch {
     testClass: string,
     testMethod?: string
   ): Promise<TestRunResult> {
-    const testOptions: SyncTestConfiguration = {
-      tests: [
-        {
-          className: testClass,
-          testMethods: testMethod ? [testMethod] : undefined
-        } as TestItem
-      ],
-      testLevel: 'RunSpecifiedTests'
-    };
-
     const testService = new TestService(connection);
     try {
-      const result: TestResult = await testService.runTestSynchronous(
-        testOptions
+      const payload = await testService.buildSyncPayload(
+        TestLevel.RunSpecifiedTests,
+        testMethod,
+        testClass
       );
+      const result: TestResult = await testService.runTestSynchronous(payload);
       const tests: ApexTestResultData[] = result.tests;
       if (tests.length === 0) {
         return {

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/vscode-integration/commands/quickLaunch.test.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/vscode-integration/commands/quickLaunch.test.ts
@@ -23,6 +23,7 @@ import * as utils from '../../../src/utils';
 
 const $$ = testSetup();
 
+// tslint:disable:no-unused-expression
 describe('Quick launch apex tests', () => {
   const testData = new MockTestOrgData();
   const testDebuggerExec = new TestDebuggerExecutor();

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/vscode-integration/commands/quickLaunch.test.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/vscode-integration/commands/quickLaunch.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { LogService, TestService } from '@salesforce/apex-node';
-import { TestResult } from '@salesforce/apex-node/lib/src/tests/types';
+import { TestLevel, TestResult } from '@salesforce/apex-node/lib/src/tests/types';
 import { AuthInfo, ConfigAggregator, Connection } from '@salesforce/core';
 import { MockTestOrgData, testSetup } from '@salesforce/core/lib/testSetup';
 import { notificationService } from '@salesforce/salesforcedx-utils-vscode/out/src/commands';
@@ -36,6 +36,7 @@ describe('Quick launch apex tests', () => {
   let testServiceStub: SinonStub;
   let logServiceStub: SinonStub;
   let launcherStub: SinonStub;
+  let buildPayloadStub: SinonStub;
 
   beforeEach(async () => {
     sb = createSandbox();
@@ -51,6 +52,11 @@ describe('Quick launch apex tests', () => {
       .withArgs('defaultusername')
       .returns(testData.username);
     notificationServiceStub = sb.stub(notificationService, 'showErrorMessage');
+    sb.stub(workspaceContext, 'getConnection').returns(mockConnection);
+    testServiceStub = sb
+      .stub(TestService.prototype, 'runTestSynchronous')
+      .resolves({ tests: [{ apexLogId: APEX_LOG_ID }] } as TestResult);
+    buildPayloadStub = sb.stub(TestService.prototype, 'buildSyncPayload');
   });
 
   afterEach(() => {
@@ -58,13 +64,13 @@ describe('Quick launch apex tests', () => {
   });
 
   it('should debug an entire test class', async () => {
-    sb.stub(workspaceContext, 'getConnection').returns(mockConnection);
+    buildPayloadStub.resolves({
+      tests: [{ className: 'MyClass' }],
+      testLevel: 'RunSpecifiedTests'
+    });
     traceFlagsStub = sb
       .stub(TraceFlags.prototype, 'ensureTraceFlags')
       .returns(true);
-    testServiceStub = sb
-      .stub(TestService.prototype, 'runTestSynchronous')
-      .resolves({ tests: [{ apexLogId: APEX_LOG_ID }] } as TestResult);
     sb.stub(utils, 'getLogDirPath').returns(LOG_DIR);
     logServiceStub = sb.stub(LogService.prototype, 'getLogs').resolves([]);
     launcherStub = sb.stub(launcher, 'launchFromLogFile');
@@ -82,8 +88,7 @@ describe('Quick launch apex tests', () => {
     expect(args[0]).to.eql({
       tests: [
         {
-          className: 'MyClass',
-          testMethods: undefined
+          className: 'MyClass'
         }
       ],
       testLevel: 'RunSpecifiedTests'
@@ -100,16 +105,18 @@ describe('Quick launch apex tests', () => {
     const launcherArgs = launcherStub.getCall(0).args;
     expect(launcherArgs[0]).to.equal(path.join('logs', 'abcd.log'));
     expect(launcherArgs[1]).to.equal(false);
+    expect(buildPayloadStub.called).to.be.true;
+    expect(buildPayloadStub.args[0]).to.eql([TestLevel.RunSpecifiedTests, undefined, 'MyClass']);
   });
 
   it('should debug a single test method', async () => {
-    sb.stub(workspaceContext, 'getConnection').returns(mockConnection);
+    buildPayloadStub.resolves({
+      tests: [{ className: 'MyClass', testMethods: ['testSomeCode'] }],
+      testLevel: 'RunSpecifiedTests'
+    });
     traceFlagsStub = sb
       .stub(TraceFlags.prototype, 'ensureTraceFlags')
       .returns(true);
-    testServiceStub = sb
-      .stub(TestService.prototype, 'runTestSynchronous')
-      .resolves({ tests: [{ apexLogId: APEX_LOG_ID }] } as TestResult);
     sb.stub(utils, 'getLogDirPath').returns(LOG_DIR);
     logServiceStub = sb.stub(LogService.prototype, 'getLogs').resolves([]);
     launcherStub = sb.stub(launcher, 'launchFromLogFile');
@@ -122,6 +129,8 @@ describe('Quick launch apex tests', () => {
     await testDebuggerExec.execute(response);
 
     expect(traceFlagsStub.called).to.equal(true);
+    expect(buildPayloadStub.called).to.be.true;
+    expect(buildPayloadStub.args[0]).to.eql([TestLevel.RunSpecifiedTests, 'testSomeCode', 'MyClass']);
     expect(testServiceStub.called).to.equal(true);
     const { args } = testServiceStub.getCall(0);
     expect(args[0]).to.eql({
@@ -148,13 +157,14 @@ describe('Quick launch apex tests', () => {
   });
 
   it('should debug a single test method that fails', async () => {
-    sb.stub(workspaceContext, 'getConnection').returns(mockConnection);
+    buildPayloadStub.resolves({
+      tests: [{ className: 'MyClass', testMethods: ['testSomeCode'] }],
+      testLevel: 'RunSpecifiedTests'
+    });
     traceFlagsStub = sb
       .stub(TraceFlags.prototype, 'ensureTraceFlags')
       .returns(true);
-    testServiceStub = sb
-      .stub(TestService.prototype, 'runTestSynchronous')
-      .resolves({} as TestResult);
+    testServiceStub.resolves({} as TestResult);
     sb.stub(utils, 'getLogDirPath').returns(LOG_DIR);
     logServiceStub = sb.stub(LogService.prototype, 'getLogs').resolves([]);
     launcherStub = sb.stub(launcher, 'launchFromLogFile');
@@ -167,6 +177,8 @@ describe('Quick launch apex tests', () => {
     await testDebuggerExec.execute(response);
 
     expect(traceFlagsStub.called).to.equal(true);
+    expect(buildPayloadStub.called).to.be.true;
+    expect(buildPayloadStub.args[0]).to.eql([TestLevel.RunSpecifiedTests, 'testSomeCode', 'MyClass']);
     expect(testServiceStub.called).to.equal(true);
     const { args } = testServiceStub.getCall(0);
     expect(args[0]).to.eql({
@@ -190,13 +202,14 @@ describe('Quick launch apex tests', () => {
   });
 
   it('should display an error for a missing test', async () => {
-    sb.stub(workspaceContext, 'getConnection').returns(mockConnection);
+    buildPayloadStub.resolves({
+      tests: [{ className: 'MyClass', testMethods: ['testSomeCode'] }],
+      testLevel: 'RunSpecifiedTests'
+    });
     traceFlagsStub = sb
       .stub(TraceFlags.prototype, 'ensureTraceFlags')
       .returns(true);
-    testServiceStub = sb
-      .stub(TestService.prototype, 'runTestSynchronous')
-      .resolves({ tests: [] });
+    testServiceStub.resolves({ tests: [] });
 
     const response: ContinueResponse<string[]> = {
       type: 'CONTINUE',
@@ -206,6 +219,8 @@ describe('Quick launch apex tests', () => {
     await testDebuggerExec.execute(response);
 
     expect(traceFlagsStub.called).to.equal(true);
+    expect(buildPayloadStub.called).to.be.true;
+    expect(buildPayloadStub.args[0]).to.eql([TestLevel.RunSpecifiedTests, 'testSomeCode', 'MyClass']);
     expect(testServiceStub.called).to.equal(true);
     const { args } = testServiceStub.getCall(0);
     expect(args[0]).to.eql({
@@ -226,13 +241,14 @@ describe('Quick launch apex tests', () => {
   });
 
   it('should display an error for a missing log file', async () => {
-    sb.stub(workspaceContext, 'getConnection').returns(mockConnection);
+    buildPayloadStub.resolves({
+      tests: [{ className: 'MyClass', testMethods: ['testSomeCode'] }],
+      testLevel: 'RunSpecifiedTests'
+    });
     traceFlagsStub = sb
       .stub(TraceFlags.prototype, 'ensureTraceFlags')
       .returns(true);
-    testServiceStub = sb
-      .stub(TestService.prototype, 'runTestSynchronous')
-      .resolves({ tests: [{}] });
+    testServiceStub.resolves({ tests: [{}] });
 
     const response: ContinueResponse<string[]> = {
       type: 'CONTINUE',
@@ -242,6 +258,8 @@ describe('Quick launch apex tests', () => {
     await testDebuggerExec.execute(response);
 
     expect(traceFlagsStub.called).to.equal(true);
+    expect(buildPayloadStub.called).to.be.true;
+    expect(buildPayloadStub.args[0]).to.eql([TestLevel.RunSpecifiedTests, 'testSomeCode', 'MyClass']);
     expect(testServiceStub.called).to.equal(true);
     const { args } = testServiceStub.getCall(0);
     expect(args[0]).to.eql({

--- a/packages/salesforcedx-vscode-apex/src/commands/forceApexTestRun.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceApexTestRun.ts
@@ -206,10 +206,10 @@ export class ApexLibraryTestRunExecutor extends LibraryCommandletExecutor<
 
     switch (response.data.type) {
       case TestType.Class:
-        payload = { classNames: response.data.label, testLevel };
+        payload = await testService.buildAsyncPayload(testLevel, undefined, response.data.label)
         break;
       case TestType.Suite:
-        payload = { suiteNames: response.data.label, testLevel };
+        payload = await testService.buildAsyncPayload(testLevel, undefined, undefined, response.data.label);
         break;
       default:
         payload = { testLevel: TestLevel.RunAllTestsInOrg };

--- a/packages/salesforcedx-vscode-apex/src/commands/forceApexTestRun.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceApexTestRun.ts
@@ -206,7 +206,7 @@ export class ApexLibraryTestRunExecutor extends LibraryCommandletExecutor<
 
     switch (response.data.type) {
       case TestType.Class:
-        payload = await testService.buildAsyncPayload(testLevel, undefined, response.data.label)
+        payload = await testService.buildAsyncPayload(testLevel, undefined, response.data.label);
         break;
       case TestType.Suite:
         payload = await testService.buildAsyncPayload(testLevel, undefined, undefined, response.data.label);

--- a/packages/salesforcedx-vscode-apex/src/commands/forceApexTestRunCodeAction.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceApexTestRunCodeAction.ts
@@ -79,11 +79,12 @@ export class ApexLibraryTestRunExecutor extends LibraryCommandletExecutor<{}> {
   public async run(): Promise<boolean> {
     const connection = await workspaceContext.getConnection();
     const testService = new TestService(connection);
+    const payload = await testService.buildAsyncPayload(
+      TestLevel.RunSpecifiedTests,
+      this.tests.join()
+    );
     const result = await testService.runTestAsynchronous(
-      {
-        tests: this.buildTestItem(this.tests),
-        testLevel: TestLevel.RunSpecifiedTests
-      },
+      payload,
       this.codeCoverage
     );
     await testService.writeResultFiles(
@@ -110,7 +111,7 @@ export class ApexLibraryTestRunExecutor extends LibraryCommandletExecutor<{}> {
         const components = ComponentSet.fromSource(defaultPackage);
         const testClassCmp = components
           .getSourceComponents({
-            fullName: test.apexClass.fullName,
+            fullName: test.apexClass.name,
             type: 'ApexClass'
           })
           .next().value as SourceComponent;

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceApexTestRun.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceApexTestRun.test.ts
@@ -29,6 +29,7 @@ import * as settings from '../../../src/settings';
 
 const sb = createSandbox();
 
+// tslint:disable:no-unused-expression
 describe('Force Apex Test Run', () => {
   const testResultsOutput = join('test', 'results', 'apex');
 

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceApexTestRun.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceApexTestRun.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { TestLevel, TestService } from '@salesforce/apex-node';
+import { HumanReporter, TestLevel, TestService } from '@salesforce/apex-node';
 import {
   EmptyParametersGatherer,
   SfdxWorkspaceChecker
@@ -95,21 +95,36 @@ describe('Force Apex Test Run', () => {
   });
 
   describe('Apex Library Test Run Executor', async () => {
-    let runTestStub: sinon.SinonStub;
+    let runTestStub: SinonStub;
+    let buildPayloadStub: SinonStub;
 
     beforeEach(async () => {
       retrieveCoverageStub.returns(true);
       runTestStub = sb.stub(TestService.prototype, 'runTestAsynchronous');
       sb.stub(workspaceContext, 'getConnection');
+      buildPayloadStub = sb.stub(TestService.prototype, 'buildAsyncPayload');
+      sb.stub(HumanReporter.prototype, 'format');
+      sb.stub(TestService.prototype, 'writeResultFiles');
     });
 
     it('should run test with correct parameters for specified class', async () => {
+      buildPayloadStub.resolves({
+        classNames: 'testClass',
+        testLevel: TestLevel.RunSpecifiedTests
+      });
+
       const apexLibExecutor = new ApexLibraryTestRunExecutor();
-      await apexLibExecutor.execute({
+      await apexLibExecutor.run({
         data: { type: TestType.Class, label: 'testClass' },
         type: 'CONTINUE'
       });
 
+      expect(buildPayloadStub.called).to.be.true;
+      expect(buildPayloadStub.args[0]).to.eql([
+        'RunSpecifiedTests',
+        undefined,
+        'testClass'
+      ]);
       expect(runTestStub.args[0]).to.deep.equal([
         { classNames: 'testClass', testLevel: TestLevel.RunSpecifiedTests },
         true
@@ -117,12 +132,24 @@ describe('Force Apex Test Run', () => {
     });
 
     it('should run test with correct parameters for specified suite', async () => {
+      buildPayloadStub.resolves({
+        suiteNames: 'testSuite',
+        testLevel: TestLevel.RunSpecifiedTests
+      });
+
       const apexLibExecutor = new ApexLibraryTestRunExecutor();
-      await apexLibExecutor.execute({
+      await apexLibExecutor.run({
         data: { type: TestType.Suite, label: 'testSuite' },
         type: 'CONTINUE'
       });
 
+      expect(buildPayloadStub.called).to.be.true;
+      expect(buildPayloadStub.args[0]).to.eql([
+        'RunSpecifiedTests',
+        undefined,
+        undefined,
+        'testSuite'
+      ]);
       expect(runTestStub.args[0]).to.deep.equal([
         { suiteNames: 'testSuite', testLevel: TestLevel.RunSpecifiedTests },
         true
@@ -131,7 +158,7 @@ describe('Force Apex Test Run', () => {
 
     it('should run test with correct parameters for all tests', async () => {
       const apexLibExecutor = new ApexLibraryTestRunExecutor();
-      await apexLibExecutor.execute({
+      await apexLibExecutor.run({
         data: { type: TestType.All, label: '' },
         type: 'CONTINUE'
       });
@@ -151,10 +178,7 @@ describe('Force Apex Test Run', () => {
 
     beforeEach(async () => {
       settingStub = sb.stub(settings, 'useApexLibrary');
-      apexExecutorStub = sb.spy(
-        ApexLibraryTestRunExecutor.prototype,
-        'execute'
-      );
+      apexExecutorStub = sb.spy(ApexLibraryTestRunExecutor.prototype, 'run');
       cliExecutorStub = sb.spy(ForceApexTestRunExecutor.prototype, 'execute');
       sb.stub(EmptyParametersGatherer.prototype, 'gather');
       sb.stub(SfdxWorkspaceChecker.prototype, 'check');

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/views/testJSONOutputs.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/views/testJSONOutputs.ts
@@ -52,7 +52,7 @@ export const apexLibMultipleSummary = {
 
 const apexLibClass = {
   id: 'fakeId',
-  name: 'fakeName',
+  name: 'file0',
   namespacePrefix: '',
   fullName: 'file0'
 };
@@ -180,16 +180,19 @@ export const summaryMultipleFiles = {
   userId: '1'
 };
 
-const fakeApexClass = {
-  attributes: { type: 'FakeType' },
-  Id: 'fakeId',
-  Name: 'fakeName',
-  NamespacePrefix: ''
-};
+const fakeApexClasses = [];
+for (let i = 0; i < 4; i++) {
+  fakeApexClasses.push({
+    attributes: { type: 'FakeType' },
+    Id: 'fakeId',
+    Name: `file${i}`,
+    NamespacePrefix: ''
+  });
+}
 
 const testResultsOneFile = [
   {
-    ApexClass: fakeApexClass,
+    ApexClass: fakeApexClasses[0],
     MethodName: 'test0',
     Outcome: 'Pass',
     RunTime: 1,
@@ -201,7 +204,7 @@ const testResultsOneFile = [
 
 const testResultsMultipleFiles = [
   {
-    ApexClass: fakeApexClass,
+    ApexClass: fakeApexClasses[0],
     MethodName: 'test0',
     Outcome: 'Pass',
     RunTime: 1,
@@ -210,7 +213,7 @@ const testResultsMultipleFiles = [
     FullName: 'file0.test0'
   },
   {
-    ApexClass: fakeApexClass,
+    ApexClass: fakeApexClasses[0],
     MethodName: 'test1',
     Outcome: 'Fail',
     RunTime: 1,
@@ -219,7 +222,7 @@ const testResultsMultipleFiles = [
     FullName: 'file0.test1'
   },
   {
-    ApexClass: fakeApexClass,
+    ApexClass: fakeApexClasses[1],
     MethodName: 'test2',
     Outcome: 'Pass',
     RunTime: 1,
@@ -228,7 +231,7 @@ const testResultsMultipleFiles = [
     FullName: 'file1.test2'
   },
   {
-    ApexClass: fakeApexClass,
+    ApexClass: fakeApexClasses[1],
     MethodName: 'test3',
     Outcome: 'Pass',
     RunTime: 1,
@@ -237,7 +240,7 @@ const testResultsMultipleFiles = [
     FullName: 'file1.test3'
   },
   {
-    ApexClass: fakeApexClass,
+    ApexClass: fakeApexClasses[2],
     MethodName: 'test4',
     Outcome: 'Pass',
     RunTime: 1,
@@ -246,7 +249,7 @@ const testResultsMultipleFiles = [
     FullName: 'file2.test4'
   },
   {
-    ApexClass: fakeApexClass,
+    ApexClass: fakeApexClasses[2],
     MethodName: 'test5',
     Outcome: 'Pass',
     RunTime: 1,
@@ -255,7 +258,7 @@ const testResultsMultipleFiles = [
     FullName: 'file2.test5'
   },
   {
-    ApexClass: fakeApexClass,
+    ApexClass: fakeApexClasses[3],
     MethodName: 'test6',
     Outcome: 'Fail',
     RunTime: 1,
@@ -264,7 +267,7 @@ const testResultsMultipleFiles = [
     FullName: 'file3.test6'
   },
   {
-    ApexClass: fakeApexClass,
+    ApexClass: fakeApexClasses[3],
     MethodName: 'test7',
     Outcome: 'Pass',
     RunTime: 1,

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/views/testNamespacedOutputs.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/views/testNamespacedOutputs.ts
@@ -18,7 +18,7 @@ import {
 
 const apexLibClass = {
   id: 'fakeId',
-  name: 'fakeName',
+  name: 'file0',
   namespacePrefix: 'tester',
   fullName: 'tester.file0'
 };
@@ -108,16 +108,19 @@ export const apexLibNsTestInfo = [
   { methodName: 'test2', definingType, location }
 ];
 
-const fakeApexClass = {
-  attributes: { type: 'FakeType' },
-  Id: 'fakeId',
-  Name: 'fakeName',
-  NamespacePrefix: 'tester'
-};
+const fakeApexClasses = [];
+for (let i = 0; i < 4; i++) {
+  fakeApexClasses.push({
+    attributes: { type: 'FakeType' },
+    Id: 'fakeId',
+    Name: `file${i}`,
+    NamespacePrefix: 'tester'
+  });
+}
 
 export const testResultsOneFile = [
   {
-    ApexClass: fakeApexClass,
+    ApexClass: fakeApexClasses[0],
     MethodName: 'test0',
     Outcome: 'Pass',
     RunTime: 1,
@@ -129,7 +132,7 @@ export const testResultsOneFile = [
 
 export const testResultsMultipleFiles = [
   {
-    ApexClass: fakeApexClass,
+    ApexClass: fakeApexClasses[0],
     MethodName: 'test0',
     Outcome: 'Pass',
     RunTime: 1,
@@ -138,7 +141,7 @@ export const testResultsMultipleFiles = [
     FullName: 'file0.test0'
   },
   {
-    ApexClass: fakeApexClass,
+    ApexClass: fakeApexClasses[0],
     MethodName: 'test1',
     Outcome: 'Fail',
     RunTime: 1,
@@ -147,7 +150,7 @@ export const testResultsMultipleFiles = [
     FullName: 'file0.test1'
   },
   {
-    ApexClass: fakeApexClass,
+    ApexClass: fakeApexClasses[1],
     MethodName: 'test2',
     Outcome: 'Pass',
     RunTime: 1,
@@ -156,7 +159,7 @@ export const testResultsMultipleFiles = [
     FullName: 'file1.test2'
   },
   {
-    ApexClass: fakeApexClass,
+    ApexClass: fakeApexClasses[1],
     MethodName: 'test3',
     Outcome: 'Pass',
     RunTime: 1,
@@ -165,7 +168,7 @@ export const testResultsMultipleFiles = [
     FullName: 'file1.test3'
   },
   {
-    ApexClass: fakeApexClass,
+    ApexClass: fakeApexClasses[2],
     MethodName: 'test4',
     Outcome: 'Pass',
     RunTime: 1,
@@ -174,7 +177,7 @@ export const testResultsMultipleFiles = [
     FullName: 'file2.test4'
   },
   {
-    ApexClass: fakeApexClass,
+    ApexClass: fakeApexClasses[2],
     MethodName: 'test5',
     Outcome: 'Pass',
     RunTime: 1,
@@ -183,7 +186,7 @@ export const testResultsMultipleFiles = [
     FullName: 'file2.test5'
   },
   {
-    ApexClass: fakeApexClass,
+    ApexClass: fakeApexClasses[3],
     MethodName: 'test6',
     Outcome: 'Fail',
     RunTime: 1,
@@ -192,7 +195,7 @@ export const testResultsMultipleFiles = [
     FullName: 'file3.test6'
   },
   {
-    ApexClass: fakeApexClass,
+    ApexClass: fakeApexClasses[3],
     MethodName: 'test7',
     Outcome: 'Pass',
     RunTime: 1,


### PR DESCRIPTION
### What does this PR do?
This PR consumes the functionality added by the Apex library to support namespaces. Users should now be able to run tests from a namespaced scratch org and see the results in the output & test sidebar. Fixes an issue where test runs from namespaced scratch orgs were not updating the sidebar with results.

### What issues does this PR fix or reference?
#2865, @W-8870724@