### PR TITLE
fix: handle undefined results from describe calls

### DIFF
--- a/packages/salesforcedx-sobjects-faux-generator/src/describe/sObjectDescribe.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/describe/sObjectDescribe.ts
@@ -139,6 +139,10 @@ export class SObjectDescribe {
       const batchResponse = await this.runRequest(batchRequest);
 
       const fetchedObjects: SObject[] = [];
+      if (batchResponse && batchResponse.results === undefined) {
+        return Promise.resolve(fetchedObjects);
+      }
+
       batchResponse.results.forEach((sr, i) => {
         if (sr.result instanceof Array) {
           if (sr.result[0].errorCode && sr.result[0].message) {

--- a/packages/salesforcedx-sobjects-faux-generator/test/integration/sObjectDescribe.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/integration/sObjectDescribe.test.ts
@@ -261,6 +261,19 @@ describe('Fetch sObjects', () => {
     );
   });
 
+  it('Should handle describe call returning no sobjects when calling describeSObjectBatch', async () => {
+    const sobjectTypes = ['ApexPageInfo4'];
+    env.stub(connection, 'request').resolves({
+      results: undefined
+    });
+
+    const batchResponse = await sobjectdescribe.describeSObjectBatchRequest(
+      sobjectTypes
+    );
+
+    expect(batchResponse.length).to.be.equal(0);
+  });
+
   it('Should throw error when response errors out', async () => {
     const sobjectTypes = ['ApexPageInfo'];
     env.stub(connection, 'request').rejects({

--- a/packages/salesforcedx-sobjects-faux-generator/test/integration/sObjectDescribe.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/integration/sObjectDescribe.test.ts
@@ -262,10 +262,21 @@ describe('Fetch sObjects', () => {
   });
 
   it('Should handle describe call returning no sobjects when calling describeSObjectBatch', async () => {
-    const sobjectTypes = ['ApexPageInfo4'];
+    const sobjectTypes = ['ApexPageInfo'];
     env.stub(connection, 'request').resolves({
       results: undefined
     });
+
+    const batchResponse = await sobjectdescribe.describeSObjectBatchRequest(
+      sobjectTypes
+    );
+
+    expect(batchResponse.length).to.be.equal(0);
+  });
+
+  it('Should handle empty describe calls responses when calling describeSObjectBatch', async () => {
+    const sobjectTypes = ['ApexPageInfo'];
+    env.stub(connection, 'request').resolves({});
 
     const batchResponse = await sobjectdescribe.describeSObjectBatchRequest(
       sobjectTypes


### PR DESCRIPTION
### What does this PR do?
Handles `undefined` results from sobject describe calls

### What issues does this PR fix or reference?
#3056 , @W-9007196@