### PR TITLE
feat: add cancellation to Deploy Retrieve Library commands

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
@@ -73,15 +73,6 @@ export abstract class DeployRetrieveExecutor<
         JSON.stringify(createComponentCount(components))
       );
 
-      // const operation = this.getOperation(components);
-      // if (token) {
-      //   token.onCancellationRequested(() => {
-      //     if (operation instanceof MetadataApiRetrieve || operation instanceof MetadataApiDeploy) {
-      //       operation.cancel;
-      //     }
-      //   });
-      // }
-
       result = await this.doOperation(components, token);
 
       const status = this.getStatus(result);
@@ -132,9 +123,6 @@ export abstract class DeployRetrieveExecutor<
   protected abstract getComponents(
     response: ContinueResponse<T>
   ): Promise<ComponentSet>;
-  // protected abstract getOperation(
-  //   components: ComponentSet
-  // ): Promise<DeployRetrieveOperation | undefined>;
   protected abstract doOperation(
     components: ComponentSet, token?: vscode.CancellationToken
   ): Promise<DeployRetrieveResult | undefined>;
@@ -144,16 +132,6 @@ export abstract class DeployRetrieveExecutor<
 }
 
 export abstract class DeployExecutor<T> extends DeployRetrieveExecutor<T> {
-
-  // protected async getOperation(
-  //   components: ComponentSet
-  // ): Promise<MetadataApiDeploy | undefined> {
-  //   return components
-  //     .deploy({
-  //       usernameOrConnection: await workspaceContext.getConnection()
-  //     });
-  // }
-
   protected async doOperation(
     components: ComponentSet, token: vscode.CancellationToken
   ): Promise<DeployResult | undefined> {
@@ -238,7 +216,6 @@ export abstract class DeployExecutor<T> extends DeployRetrieveExecutor<T> {
 }
 
 export abstract class RetrieveExecutor<T> extends DeployRetrieveExecutor<T> {
-
   protected async doOperation(
     components: ComponentSet, token: vscode.CancellationToken
   ): Promise<RetrieveResult | undefined> {

--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
@@ -112,8 +112,8 @@ export abstract class DeployRetrieveExecutor<
       : result?.status;
   }
 
-  protected setupCancellation(operation: DeployRetrieveOperation, token?: vscode.CancellationToken) {
-    if (token) {
+  protected setupCancellation(operation: DeployRetrieveOperation | undefined, token?: vscode.CancellationToken) {
+    if (token && operation) {
       token.onCancellationRequested(() => {
         operation.cancel();
       });

--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
@@ -4,7 +4,6 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import * as vscode from 'vscode';
 import {
   getRootWorkspacePath,
   LibraryCommandletExecutor
@@ -31,6 +30,7 @@ import {
   RequestStatus
 } from '@salesforce/source-deploy-retrieve/lib/src/client/types';
 import { join, sep } from 'path';
+import * as vscode from 'vscode';
 import { BaseDeployExecutor } from '.';
 import { channelService, OUTPUT_CHANNEL } from '../channels';
 import { TELEMETRY_METADATA_COUNT } from '../constants';

--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
@@ -115,7 +115,7 @@ export abstract class DeployRetrieveExecutor<
   protected setupCancellation(operation: DeployRetrieveOperation, token?: vscode.CancellationToken) {
     if (token) {
       token.onCancellationRequested(() => {
-        operation.cancel;
+        operation.cancel();
       });
     }
   }

--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
@@ -38,8 +38,6 @@ import { nls } from '../messages';
 import { DeployQueue } from '../settings';
 import { SfdxPackageDirectories, SfdxProjectConfig } from '../sfdxProject';
 import { createComponentCount } from './util';
-// import { Observable } from 'rxjs/Observable';
-// import { Subscription } from 'rxjs/Subscription';
 
 type RetrieveResult = MetadataApiRetrieveResult | SourceRetrieveResult;
 type DeployRetrieveResult = DeployResult | RetrieveResult;
@@ -72,20 +70,11 @@ export abstract class DeployRetrieveExecutor<
         JSON.stringify(createComponentCount(components))
       );
 
-      // let timerSubscriber: Subscription | null;
-      // if (token) {
-      //   const timer = Observable.interval(1000);
-      //   timerSubscriber = timer.subscribe(async next => {
-      //     if (token.isCancellationRequested) {
-      //       try {
-      //         // await super.killExecution();
-      //         console.log('Almost there!')
-      //       } catch (e) {
-      //         console.log(e);
-      //       }
-      //     }
-      //   });
-      // }
+      if (token) {
+        token.onCancellationRequested(() => {
+          // TODO - how do we force SDR to cancel its operation?
+        });
+      }
 
       result = await this.doOperation(components);
 
@@ -99,10 +88,6 @@ export abstract class DeployRetrieveExecutor<
       await this.postOperation(result);
     }
   }
-
-  // public async killExecution(signal: string = 'SIGKILL') {
-  //   return killPromise(this.childProcessPid, signal);
-  // }
 
   protected getRelativeProjectPath(fsPath: string = '', packageDirs: string[]) {
     let packageDirIndex;

--- a/packages/salesforcedx-vscode-core/src/commands/templates/baseTemplateCommand.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/baseTemplateCommand.ts
@@ -30,7 +30,7 @@ import {
 
 export abstract class BaseTemplateCommand extends SfdxCommandletExecutor<
   DirFileNameSelection
-> {
+  > {
   private metadataType: MetadataInfo;
 
   constructor(type: string) {
@@ -70,7 +70,7 @@ export abstract class BaseTemplateCommand extends SfdxCommandletExecutor<
       (execution.stderrSubject as any) as Observable<Error | undefined>
     );
     channelService.streamCommandOutput(execution);
-    ProgressNotification.show(execution, cancellationTokenSource);    // ADD a breakpoint!
+    ProgressNotification.show(execution, cancellationTokenSource);
     taskViewService.addCommandExecution(execution, cancellationTokenSource);
   }
 

--- a/packages/salesforcedx-vscode-core/src/commands/templates/baseTemplateCommand.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/baseTemplateCommand.ts
@@ -30,7 +30,7 @@ import {
 
 export abstract class BaseTemplateCommand extends SfdxCommandletExecutor<
   DirFileNameSelection
-  > {
+> {
   private metadataType: MetadataInfo;
 
   constructor(type: string) {
@@ -70,7 +70,7 @@ export abstract class BaseTemplateCommand extends SfdxCommandletExecutor<
       (execution.stderrSubject as any) as Observable<Error | undefined>
     );
     channelService.streamCommandOutput(execution);
-    ProgressNotification.show(execution, cancellationTokenSource);
+    ProgressNotification.show(execution, cancellationTokenSource);    // ADD a breakpoint!
     taskViewService.addCommandExecution(execution, cancellationTokenSource);
   }
 

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
@@ -205,62 +205,6 @@ describe('Base Deploy Retrieve Commands', () => {
       }
     }
 
-    class TestDeploy2 extends DeployExecutor<{}> {
-      public components: ComponentSet;
-      public getComponentsStub = sb.stub().returns(new ComponentSet());
-      public progressStub: SinonStub;
-      public cancellationStub = sb.stub();
-
-      constructor(toDeploy = new ComponentSet()) {
-        super('test', 'testlog');
-        this.components = toDeploy;
-        this.progressStub = sb.stub(vscode.window, 'withProgress').returns(
-          Promise.resolve()
-        );
-
-        // Approach2 - used by forceFunctionCreate.test.ts
-        // withProgressStub = sb.stub(vscode.window, 'withProgress');
-        // withProgressStub.callsFake((options, task) => {
-        //   task();
-        // });
-      }
-
-      protected async getComponents(
-        response: ContinueResponse<{}>
-      ): Promise<ComponentSet> {
-        return new ComponentSet([
-          new SourceComponent({
-            name: 'MyClass',
-            type: registryData.types.apexclass,
-            content: join('project', 'classes', 'MyClass.cls'),
-            xml: join('project', 'classes', 'MyClass.cls-meta.xml')
-          })
-        ]);
-      }
-      protected async setupCancellation(operation: DeployRetrieveOperation | undefined, token?: vscode.CancellationToken) {
-        return this.cancellationStub;
-      }
-    }
-
-    // TODO - Goal: I literally just want to make sure that the DeployExecutor is cancellable.
-    // it('should be cancellable', async () => {
-    //   const executor = new TestDeploy2();
-    //   const filePath = path.join('classes', 'MyClass.cls');
-
-    //   await executor.run({ data: filePath, type: 'CONTINUE' });
-
-    //   Sinon.assert.calledOnce(executor.progressStub);
-    //   Sinon.assert.calledWith(
-    //     executor.progressStub,
-    //     {
-    //       location: vscode.ProgressLocation.Window,
-    //       title: nls.localize('progress_notification_text', 'test'),
-    //       cancellable: true
-    //     },
-    //     match.any
-    //   );
-    // });
-
     it('should call setup cancellation logic', async () => {
       const executor = new TestDeploy();
       const operationSpy = Sinon.spy(executor, 'setupCancellation' as any);
@@ -269,18 +213,6 @@ describe('Base Deploy Retrieve Commands', () => {
 
       expect(operationSpy.calledOnce).to.equal(true);
     });
-
-    // TODO - Goal: Operation should be called when user cancels the command.
-    // it('should call cancel operation', async () => {
-    //   const executor = new TestDeploy();
-
-    //   // Verify operation.cancel was called from within setupCancellation.
-    //   const operationSpy = Sinon.spy(executor, 'setupCancellation' as any);
-
-    //   // How do I do this?
-
-    //   await executor.run({ data: {}, type: 'CONTINUE' });
-    // });
 
     it('should call deploy on component set', async () => {
       const executor = new TestDeploy();

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
@@ -26,7 +26,7 @@ import {
 } from '@salesforce/source-deploy-retrieve/lib/src/client/types';
 import { expect } from 'chai';
 import { basename, dirname, join, sep } from 'path';
-import { createSandbox, match, SinonStub } from 'sinon';
+import { createSandbox, SinonStub } from 'sinon';
 import Sinon = require('sinon');
 import * as vscode from 'vscode';
 import { channelService } from '../../../src/channels';
@@ -43,7 +43,6 @@ import {
   SfdxPackageDirectories,
   SfdxProjectConfig
 } from '../../../src/sfdxProject';
-import * as path from 'path';
 
 const sb = createSandbox();
 const $$ = testSetup();
@@ -248,7 +247,6 @@ describe('Base Deploy Retrieve Commands', () => {
     //   const executor = new TestDeploy2();
     //   const filePath = path.join('classes', 'MyClass.cls');
 
-
     //   await executor.run({ data: filePath, type: 'CONTINUE' });
 
     //   Sinon.assert.calledOnce(executor.progressStub);
@@ -265,7 +263,7 @@ describe('Base Deploy Retrieve Commands', () => {
 
     it('should call setup cancellation logic', async () => {
       const executor = new TestDeploy();
-      const operationSpy = Sinon.spy(executor, "setupCancellation" as any);
+      const operationSpy = Sinon.spy(executor, 'setupCancellation' as any);
 
       await executor.run({ data: {}, type: 'CONTINUE' });
 
@@ -277,7 +275,7 @@ describe('Base Deploy Retrieve Commands', () => {
     //   const executor = new TestDeploy();
 
     //   // Verify operation.cancel was called from within setupCancellation.
-    //   const operationSpy = Sinon.spy(executor, "setupCancellation" as any);
+    //   const operationSpy = Sinon.spy(executor, 'setupCancellation' as any);
 
     //   // How do I do this?
 
@@ -581,7 +579,7 @@ describe('Base Deploy Retrieve Commands', () => {
 
     it('should call setup cancellation logic', async () => {
       const executor = new TestRetrieve();
-      const operationSpy = Sinon.spy(executor, "setupCancellation" as any);
+      const operationSpy = Sinon.spy(executor, 'setupCancellation' as any);
 
       await executor.run({ data: {}, type: 'CONTINUE' });
 

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
@@ -26,7 +26,7 @@ import {
 } from '@salesforce/source-deploy-retrieve/lib/src/client/types';
 import { expect } from 'chai';
 import { basename, dirname, join, sep } from 'path';
-import { assert, createSandbox, match, SinonStub } from 'sinon';
+import { createSandbox, match, SinonStub } from 'sinon';
 import Sinon = require('sinon');
 import * as vscode from 'vscode';
 import { channelService } from '../../../src/channels';
@@ -244,23 +244,24 @@ describe('Base Deploy Retrieve Commands', () => {
     }
 
     // TODO - Goal: I literally just want to make sure that the DeployExecutor is cancellable.
-    it('should be cancellable', async () => {
-      const executor = new TestDeploy2();
-      const filePath = path.join('classes', 'MyClass.cls');
+    // it('should be cancellable', async () => {
+    //   const executor = new TestDeploy2();
+    //   const filePath = path.join('classes', 'MyClass.cls');
 
-      await executor.run({ data: filePath, type: 'CONTINUE' });
 
-      Sinon.assert.calledOnce(executor.progressStub);
-      Sinon.assert.calledWith(
-        executor.progressStub,
-        {
-          location: vscode.ProgressLocation.Window,
-          title: nls.localize('progress_notification_text', 'test'),
-          cancellable: true
-        },
-        match.any
-      );
-    });
+    //   await executor.run({ data: filePath, type: 'CONTINUE' });
+
+    //   Sinon.assert.calledOnce(executor.progressStub);
+    //   Sinon.assert.calledWith(
+    //     executor.progressStub,
+    //     {
+    //       location: vscode.ProgressLocation.Window,
+    //       title: nls.localize('progress_notification_text', 'test'),
+    //       cancellable: true
+    //     },
+    //     match.any
+    //   );
+    // });
 
     it('should call setup cancellation logic', async () => {
       const executor = new TestDeploy();
@@ -272,16 +273,16 @@ describe('Base Deploy Retrieve Commands', () => {
     });
 
     // TODO - Goal: Operation should be called when user cancels the command.
-    it('should call cancel operation', async () => {
-      const executor = new TestDeploy();
+    // it('should call cancel operation', async () => {
+    //   const executor = new TestDeploy();
 
-      // Verify operation.cancel was called from within setupCancellation.
-      const operationSpy = Sinon.spy(executor, "setupCancellation" as any);
+    //   // Verify operation.cancel was called from within setupCancellation.
+    //   const operationSpy = Sinon.spy(executor, "setupCancellation" as any);
 
-      // How do I do this?
+    //   // How do I do this?
 
-      await executor.run({ data: {}, type: 'CONTINUE' });
-    });
+    //   await executor.run({ data: {}, type: 'CONTINUE' });
+    // });
 
     it('should call deploy on component set', async () => {
       const executor = new TestDeploy();

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
@@ -26,8 +26,7 @@ import {
 } from '@salesforce/source-deploy-retrieve/lib/src/client/types';
 import { expect } from 'chai';
 import { basename, dirname, join, sep } from 'path';
-import { createSandbox, SinonStub } from 'sinon';
-import Sinon = require('sinon');
+import { createSandbox, SinonStub, spy } from 'sinon';
 import * as vscode from 'vscode';
 import { channelService } from '../../../src/channels';
 import { BaseDeployExecutor } from '../../../src/commands';
@@ -207,7 +206,7 @@ describe('Base Deploy Retrieve Commands', () => {
 
     it('should call setup cancellation logic', async () => {
       const executor = new TestDeploy();
-      const operationSpy = Sinon.spy(executor, 'setupCancellation' as any);
+      const operationSpy = spy(executor, 'setupCancellation' as any);
 
       await executor.run({ data: {}, type: 'CONTINUE' });
 
@@ -511,7 +510,7 @@ describe('Base Deploy Retrieve Commands', () => {
 
     it('should call setup cancellation logic', async () => {
       const executor = new TestRetrieve();
-      const operationSpy = Sinon.spy(executor, 'setupCancellation' as any);
+      const operationSpy = spy(executor, 'setupCancellation' as any);
 
       await executor.run({ data: {}, type: 'CONTINUE' });
 


### PR DESCRIPTION
### What does this PR do?
Adds cancellation logic for Deploy Retrieve Library commands.

### What issues does this PR fix or reference?
@W-8979870@

### Functionality Before
![Before](https://user-images.githubusercontent.com/45604118/111408317-bb46d880-869a-11eb-9d88-fd2ce08e0fc5.png)

### Functionality After
![SDR_After](https://user-images.githubusercontent.com/45604118/111408663-38724d80-869b-11eb-990e-c00b466d414b.gif)
