### PR TITLE
fix: add ability to jump to channel output via the 'Show' button

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/commands/commandletExecutors.ts
+++ b/packages/salesforcedx-utils-vscode/src/commands/commandletExecutors.ts
@@ -47,14 +47,11 @@ export abstract class SfdxCommandletExecutor<T>
         channel.showChannelOutput();
       }
     }
-    let res = notificationService.reportCommandExecutionStatus(
+    notificationService.reportCommandExecutionStatus(
       execution,
-      // channel,
+      channel,
       cancellationToken
     );
-    if (res && channel && this.showChannelOutput) {
-      channel.showChannelOutput();
-    }
     ProgressNotification.show(execution, cancellationTokenSource);
   }
 
@@ -194,12 +191,9 @@ export abstract class LibraryCommandletExecutor<T>
 
       if (!this.cancelled) {
         if (success) {
-          let res = notificationService
-            .showSuccessfulExecution(this.executionName)
+          notificationService
+            .showSuccessfulExecution(this.executionName, channelService)
             .catch(e => console.error(e));
-          if (res && this.showChannelOutput) {
-            channelService.showChannelOutput();
-          }
         } else {
           notificationService.showFailedExecution(this.executionName);
         }

--- a/packages/salesforcedx-utils-vscode/src/commands/commandletExecutors.ts
+++ b/packages/salesforcedx-utils-vscode/src/commands/commandletExecutors.ts
@@ -39,7 +39,7 @@ export abstract class SfdxCommandletExecutor<T>
     cancellationTokenSource: vscode.CancellationTokenSource,
     cancellationToken: vscode.CancellationToken
   ) {
-    let channel = undefined;
+    let channel;
     if (this.outputChannel) {
       channel = new ChannelService(this.outputChannel);
       channel.streamCommandOutput(execution);

--- a/packages/salesforcedx-utils-vscode/src/commands/commandletExecutors.ts
+++ b/packages/salesforcedx-utils-vscode/src/commands/commandletExecutors.ts
@@ -39,17 +39,22 @@ export abstract class SfdxCommandletExecutor<T>
     cancellationTokenSource: vscode.CancellationTokenSource,
     cancellationToken: vscode.CancellationToken
   ) {
+    let channel = undefined;
     if (this.outputChannel) {
-      const channel = new ChannelService(this.outputChannel);
+      channel = new ChannelService(this.outputChannel);
       channel.streamCommandOutput(execution);
       if (this.showChannelOutput) {
         channel.showChannelOutput();
       }
     }
-    notificationService.reportCommandExecutionStatus(
+    let res = notificationService.reportCommandExecutionStatus(
       execution,
+      // channel,
       cancellationToken
     );
+    if (res && channel && this.showChannelOutput) {
+      channel.showChannelOutput();
+    }
     ProgressNotification.show(execution, cancellationTokenSource);
   }
 
@@ -189,9 +194,12 @@ export abstract class LibraryCommandletExecutor<T>
 
       if (!this.cancelled) {
         if (success) {
-          notificationService
+          let res = notificationService
             .showSuccessfulExecution(this.executionName)
             .catch(e => console.error(e));
+          if (res && this.showChannelOutput) {
+            channelService.showChannelOutput();
+          }
         } else {
           notificationService.showFailedExecution(this.executionName);
         }

--- a/packages/salesforcedx-utils-vscode/test/unit/commands/notificationService.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/unit/commands/notificationService.test.ts
@@ -76,7 +76,11 @@ describe('Notifications', () => {
     observable.next(0);
 
     const notificationService = NotificationService.getInstance();
-    notificationService.reportExecutionStatus('mock command', channelService, observable);
+    notificationService.reportExecutionStatus(
+      'mock command',
+      channelService,
+      observable
+    );
 
     setTimeout(() => {
       assert.calledWith(
@@ -104,7 +108,11 @@ describe('Notifications', () => {
     observable.next(0);
 
     const notificationService = NotificationService.getInstance();
-    await notificationService.reportExecutionStatus('mock command', channelService, observable);
+    await notificationService.reportExecutionStatus(
+      'mock command',
+      channelService,
+      observable
+    );
 
     assert.calledWith(
       mShowInformation,
@@ -132,7 +140,11 @@ describe('Notifications', () => {
     observable.next(0);
 
     const notificationService = NotificationService.getInstance();
-    notificationService.reportExecutionStatus('mock command', channelService, observable);
+    notificationService.reportExecutionStatus(
+      'mock command',
+      channelService,
+      observable
+    );
 
     setTimeout(() => {
       assert.notCalled(mShow);
@@ -163,7 +175,11 @@ describe('Notifications', () => {
     observable.next(0);
 
     const notificationService = NotificationService.getInstance();
-    notificationService.reportExecutionStatus('mock command', channelService, observable);
+    notificationService.reportExecutionStatus(
+      'mock command',
+      channelService,
+      observable
+    );
 
     setTimeout(() => {
       assert.calledWith(
@@ -190,7 +206,7 @@ describe('Notifications', () => {
       'mock command',
       channelService,
       observable,
-      cancellationTokenSource.token,
+      cancellationTokenSource.token
     );
 
     cancellationTokenSource.cancel();
@@ -210,7 +226,11 @@ describe('Notifications', () => {
     observable.next(ABNORMAL_EXIT);
 
     const notificationService = NotificationService.getInstance();
-    notificationService.reportExecutionStatus('mock command', channelService, observable);
+    notificationService.reportExecutionStatus(
+      'mock command',
+      channelService,
+      observable
+    );
 
     setTimeout(() => {
       assert.notCalled(mShow);

--- a/packages/salesforcedx-vscode-core/src/commands/forceRefreshSObjects.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceRefreshSObjects.ts
@@ -124,6 +124,7 @@ export class ForceRefreshSObjectsExecutor extends SfdxCommandletExecutor<{}> {
 
     notificationService.reportCommandExecutionStatus(
       execution,
+      channelService,
       cancellationToken
     );
 

--- a/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcPreview.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcPreview.ts
@@ -559,7 +559,7 @@ async function executeMobilePreview(
       showError(new Error(message), logName, commandName);
     } else if (!isAndroid) {
       notificationService
-        .showSuccessfulExecution(previewExecution.command.toString())
+        .showSuccessfulExecution(previewExecution.command.toString(), channelService)
         .catch();
       vscode.window.showInformationMessage(
         nls.localize('force_lightning_lwc_ios_start', targetDevice)
@@ -573,7 +573,7 @@ async function executeMobilePreview(
     previewExecution.stdoutSubject.subscribe(async data => {
       if (data && data.toString().includes(androidSuccessString)) {
         notificationService
-          .showSuccessfulExecution(previewExecution.command.toString())
+          .showSuccessfulExecution(previewExecution.command.toString(), channelService)
           .catch();
         vscode.window.showInformationMessage(
           nls.localize('force_lightning_lwc_android_start', targetDevice)

--- a/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcStart.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcStart.ts
@@ -106,7 +106,7 @@ export class ForceLightningLwcStartExecutor extends SfdxCommandletExecutor<{}> {
       if (!serverStarted && data && data.toString().includes('Server up')) {
         serverStarted = true;
         progress.complete();
-        notificationService.showSuccessfulExecution(executionName).catch();
+        notificationService.showSuccessfulExecution(executionName, channelService).catch();
 
         DevServerService.instance.setBaseUrlFromDevServerUpMessage(
           data.toString()

--- a/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcStop.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcStop.ts
@@ -25,7 +25,7 @@ export async function forceLightningLwcStop() {
       );
       await DevServerService.instance.stopServer();
       notificationService
-        .showSuccessfulExecution(nls.localize('force_lightning_lwc_stop_text'))
+        .showSuccessfulExecution(nls.localize('force_lightning_lwc_stop_text'), channelService)
         .catch();
       telemetryService.sendCommandEvent(logName, startTime);
     } else {


### PR DESCRIPTION
### What does this PR do?
Adds back in functionality for jumping to the correct output channel when clicking the 'Show' button.

### What issues does this PR fix or reference?
#2987, @W-8935765@

### Functionality Before
Clicking the 'Show' button did not redirect the user to the appropriate output channel.
![OutputChannelShowBtn_Before](https://user-images.githubusercontent.com/45604118/112054512-4d2b6700-8b1b-11eb-8754-a701937f3432.gif)

### Functionality After
Clicking the 'Show' button redirects the user to the correct output channel. 
![OutputChannelShowBtn_After](https://user-images.githubusercontent.com/45604118/112054540-5583a200-8b1b-11eb-83d6-4d3efbf69bfd.gif)

### Other Notes
- This fix also applies for the Apex Plugin & Library.
- Jumping to the correct output channel upon successful completion for SDR has already been fixed by #3027.
- The text "Null Extension Description" is specific only to the dev environment. This does not impact customers.
