### PR TITLE
fix: do not show refresh success message for min sobjects @W-9042465@

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceRefreshSObjects.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceRefreshSObjects.ts
@@ -125,6 +125,7 @@ export class ForceRefreshSObjectsExecutor extends SfdxCommandletExecutor<{}> {
     if (response.data.source !== SObjectRefreshSource.StartupMin) {
       notificationService.reportCommandExecutionStatus(
         execution,
+        channelService,
         cancellationToken
       );
     }

--- a/packages/salesforcedx-vscode-core/src/commands/forceRefreshSObjects.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceRefreshSObjects.ts
@@ -122,10 +122,12 @@ export class ForceRefreshSObjectsExecutor extends SfdxCommandletExecutor<{}> {
       channelService.showChannelOutput();
     }
 
-    notificationService.reportCommandExecutionStatus(
-      execution,
-      cancellationToken
-    );
+    if (response.data.source !== SObjectRefreshSource.StartupMin) {
+      notificationService.reportCommandExecutionStatus(
+        execution,
+        cancellationToken
+      );
+    }
 
     let progressLocation = vscode.ProgressLocation.Notification;
     if (response.data.source !== SObjectRefreshSource.Manual) {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceRefreshSObjects.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceRefreshSObjects.test.ts
@@ -161,6 +161,7 @@ describe('ForceGenerateFauxClasses', () => {
     let generatorMinStub: SinonStub;
     let logStub: SinonStub;
     let errorStub: SinonStub;
+    let notificationStub: SinonStub;
 
     const expectedData = {
       cancelled: false,
@@ -182,10 +183,15 @@ describe('ForceGenerateFauxClasses', () => {
         'logMetric'
       );
       errorStub = sandboxStub.stub(telemetryService, 'sendException');
+      notificationStub = sandboxStub.stub(
+        notificationService,
+        'reportCommandExecutionStatus'
+      );
     });
 
     afterEach(() => {
       sandboxStub.restore();
+      notificationStub.restore();
     });
 
     it('Should pass response data to generator', async () => {
@@ -213,6 +219,21 @@ describe('ForceGenerateFauxClasses', () => {
       expect(progressStub.getCall(0).args[2]).to.eq(
         ProgressLocation.Notification
       );
+    });
+
+    it('Should report command execution status for Startup Refresh', async () => {
+      await doExecute(SObjectRefreshSource.Startup, SObjectCategory.STANDARD);
+      expect(notificationStub.calledOnce).to.be.true;
+    });
+
+    it('Should report command execution status for Manual Refresh', async () => {
+      await doExecute(SObjectRefreshSource.Manual, SObjectCategory.STANDARD);
+      expect(notificationStub.calledOnce).to.be.true;
+    });
+
+    it('Should not report command execution status for Startup Min Refresh', async () => {
+      await doExecute(SObjectRefreshSource.StartupMin, SObjectCategory.STANDARD);
+      expect(notificationStub.notCalled).to.be.true;
     });
 
     it('Should log correct information to telemetry', async () => {


### PR DESCRIPTION
### What does this PR do?
Does not show refresh success message for min sobjects are refreshed at startup

### What issues does this PR fix or reference?
@W-9042465@

### Functionality Before
![Screen Shot 2021-03-23 at 7 30 59 AM](https://user-images.githubusercontent.com/58611665/112162948-c5406e00-8ba9-11eb-924a-f8b0be0e6857.png)

### Functionality After
Above message not shown
