### PR TITLE
fix: update deploy and retrieve beta to use 1.1.20

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -29,7 +29,7 @@
     "@salesforce/salesforcedx-sobjects-faux-generator": "51.6.0",
     "@salesforce/salesforcedx-utils-vscode": "51.6.0",
     "@salesforce/schemas": "^1",
-    "@salesforce/source-deploy-retrieve": "1.1.19",
+    "@salesforce/source-deploy-retrieve": "1.1.20",
     "@salesforce/templates": "51.3.0",
     "adm-zip": "0.4.13",
     "applicationinsights": "1.0.7",


### PR DESCRIPTION
### What does this PR do?
Updates SDR to 1.1.20. This update changes the suffix type on the metadata file for Document metadata types. This fixes deployment issues for Document types when using a combination of the CLI and SDR Library to deploy and retrieve.

### What issues does this PR fix or reference?
@W-9043410@

See https://github.com/forcedotcom/source-deploy-retrieve/pull/263 for more information.
