### PR TITLE
Port "do not show refresh success message for min sobjects"

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceRefreshSObjects.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceRefreshSObjects.ts
@@ -122,11 +122,13 @@ export class ForceRefreshSObjectsExecutor extends SfdxCommandletExecutor<{}> {
       channelService.showChannelOutput();
     }
 
-    notificationService.reportCommandExecutionStatus(
-      execution,
-      channelService,
-      cancellationToken
-    );
+    if (response.data.source !== SObjectRefreshSource.StartupMin) {
+      notificationService.reportCommandExecutionStatus(
+        execution,
+        channelService,
+        cancellationToken
+      );
+    }
 
     let progressLocation = vscode.ProgressLocation.Notification;
     if (response.data.source !== SObjectRefreshSource.Manual) {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceRefreshSObjects.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceRefreshSObjects.test.ts
@@ -161,6 +161,7 @@ describe('ForceGenerateFauxClasses', () => {
     let generatorMinStub: SinonStub;
     let logStub: SinonStub;
     let errorStub: SinonStub;
+    let notificationStub: SinonStub;
 
     const expectedData = {
       cancelled: false,
@@ -182,10 +183,15 @@ describe('ForceGenerateFauxClasses', () => {
         'logMetric'
       );
       errorStub = sandboxStub.stub(telemetryService, 'sendException');
+      notificationStub = sandboxStub.stub(
+        notificationService,
+        'reportCommandExecutionStatus'
+      );
     });
 
     afterEach(() => {
       sandboxStub.restore();
+      notificationStub.restore();
     });
 
     it('Should pass response data to generator', async () => {
@@ -213,6 +219,21 @@ describe('ForceGenerateFauxClasses', () => {
       expect(progressStub.getCall(0).args[2]).to.eq(
         ProgressLocation.Notification
       );
+    });
+
+    it('Should report command execution status for Startup Refresh', async () => {
+      await doExecute(SObjectRefreshSource.Startup, SObjectCategory.STANDARD);
+      expect(notificationStub.calledOnce).to.be.true;
+    });
+
+    it('Should report command execution status for Manual Refresh', async () => {
+      await doExecute(SObjectRefreshSource.Manual, SObjectCategory.STANDARD);
+      expect(notificationStub.calledOnce).to.be.true;
+    });
+
+    it('Should not report command execution status for Startup Min Refresh', async () => {
+      await doExecute(SObjectRefreshSource.StartupMin, SObjectCategory.STANDARD);
+      expect(notificationStub.notCalled).to.be.true;
     });
 
     it('Should log correct information to telemetry', async () => {


### PR DESCRIPTION
### What does this PR do?
Port "do not show refresh success message for min sobjects" commit to release