### PR TITLE
docs: denote that deploy and retrieve perf enhancements are on by default

### DIFF
--- a/docs/_articles/en/user-guide/perf-enhancements.md
+++ b/docs/_articles/en/user-guide/perf-enhancements.md
@@ -21,7 +21,7 @@ This architecture change is done through a phased approach.  For both the Apex l
 |                         | Library complete	| Available to try in VS Code	| On by default in VS Code	| CLI Updated  |
 |-------------------------|:-----------------:|:---------------------------:|:-------------------------:|:------------:|
 | Apex Library	          |        ✔️          |               ✔️             |             ✔️             |              |
-| Deploy Retrieve Library |        ✔️          |               ✔️             |                           |              |
+| Deploy Retrieve Library |        ✔️          |               ✔️             |             ✔️              |              |
 	
 
 ## Setup


### PR DESCRIPTION
Update the doc page to reflect that Deploy / Retrieve library is now on be default