### PR TITLE
fix: better exception handling for type inference errors

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/helpers/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/index.ts
@@ -13,4 +13,8 @@ export {
   isAlphaNumSpaceString,
   isRecordIdFormat
 } from './validations';
-export { ensureDirectoryExists, getTestResultsFolder } from './paths';
+export {
+  ensureDirectoryExists,
+  getTestResultsFolder,
+  getRelativeProjectPath
+} from './paths';

--- a/packages/salesforcedx-utils-vscode/src/helpers/paths.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/paths.ts
@@ -28,3 +28,31 @@ export function getTestResultsFolder(vscodePath: string, testType: string) {
   ensureDirectoryExists(dirPath);
   return dirPath;
 }
+
+/**
+ * Creates a project relative path version of an absolute path.
+ *
+ * @param fsPath Absolute file path
+ * @param packageDirs Package directory paths
+ * @returns Relative path for the project
+ */
+export function getRelativeProjectPath(
+  fsPath: string = '',
+  packageDirs: string[]
+) {
+  let packageDirIndex;
+  for (let packageDir of packageDirs) {
+    if (!packageDir.startsWith(path.sep)) {
+      packageDir = path.sep + packageDir;
+    }
+    if (!packageDir.endsWith(path.sep)) {
+      packageDir = packageDir + path.sep;
+    }
+    packageDirIndex = fsPath.indexOf(packageDir);
+    if (packageDirIndex !== -1) {
+      packageDirIndex += 1;
+      break;
+    }
+  }
+  return packageDirIndex !== -1 ? fsPath.slice(packageDirIndex) : fsPath;
+}

--- a/packages/salesforcedx-utils-vscode/src/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/index.ts
@@ -36,3 +36,4 @@ export {
   getRootWorkspacePath,
   getRootWorkspaceSfdxPath
 } from './workspaces';
+export { getRelativeProjectPath } from './helpers';

--- a/packages/salesforcedx-utils-vscode/test/unit/helpers/paths.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/unit/helpers/paths.test.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 import { createSandbox, SinonStub } from 'sinon';
 import {
   ensureDirectoryExists,
+  getRelativeProjectPath,
   getTestResultsFolder
 } from '../../../src/helpers';
 
@@ -61,6 +62,32 @@ describe('paths utils', () => {
       expect(result).to.equal(
         path.join(dirPath, '.sfdx', 'tools', 'testresults', 'apex')
       );
+    });
+  });
+
+  describe('getRelativeProjectPath', () => {
+    it('should return a relative project path version of an absolute path', () => {
+      const relative = path.join('force-app', 'something', 'test');
+      const absolute = path.join(path.sep, 'path', 'to', relative);
+
+      const result = getRelativeProjectPath(absolute, [
+        'force-app',
+        'force-app-2'
+      ]);
+
+      expect(result).to.equal(relative);
+    });
+
+    it('should return the absolute path if path is not in a given package directory', () => {
+      const relative = path.join('force-app', 'something', 'test');
+      const absolute = path.join(path.sep, 'path', 'to', relative);
+
+      const result = getRelativeProjectPath(absolute, [
+        'test-app',
+        'test-app-2'
+      ]);
+
+      expect(result).to.equal(absolute);
     });
   });
 });

--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployCommand.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployCommand.ts
@@ -26,7 +26,10 @@ import { DeployQueue } from '../settings/pushOrDeployOnSave';
 import { taskViewService } from '../statuses';
 import { telemetryService } from '../telemetry';
 import { getRootWorkspacePath } from '../util';
-import { createComponentCount } from './util/betaDeployRetrieve';
+import {
+  createComponentCount,
+  formatException
+} from './util/betaDeployRetrieve';
 import { SfdxCommandletExecutor } from './util/sfdxCommandlet';
 
 export enum DeployType {
@@ -70,10 +73,8 @@ export abstract class BaseDeployExecutor extends SfdxCommandletExecutor<
         const metadataCount = JSON.stringify(createComponentCount(components));
         telemetry.addProperty(TELEMETRY_METADATA_COUNT, metadataCount);
       } catch (e) {
-        telemetryService.sendException(
-          e.name,
-          'error detecting deploy components'
-        );
+        const error = await formatException(e);
+        telemetryService.sendException(error.name, error.message);
       }
 
       let success = false;

--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
@@ -40,8 +40,7 @@ import { handleDeployDiagnostics } from '../diagnostics';
 import { nls } from '../messages';
 import { DeployQueue } from '../settings';
 import { SfdxPackageDirectories, SfdxProjectConfig } from '../sfdxProject';
-import { createComponentCount } from './util';
-import { formatException } from './util/betaDeployRetrieve';
+import { createComponentCount, formatException } from './util';
 
 type RetrieveResult = MetadataApiRetrieveResult | SourceRetrieveResult;
 type DeployRetrieveResult = DeployResult | RetrieveResult;

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDeployManifest.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDeployManifest.ts
@@ -19,17 +19,13 @@ import {
 } from '../commands/util/postconditionCheckers';
 import { nls } from '../messages';
 import { notificationService } from '../notifications';
+import { sfdxCoreSettings } from '../settings';
 import { SfdxPackageDirectories } from '../sfdxProject';
 import { telemetryService } from '../telemetry';
 import { getRootWorkspacePath } from '../util';
 import { BaseDeployExecutor, DeployType } from './baseDeployCommand';
 import { DeployExecutor } from './baseDeployRetrieve';
-import {
-  FilePathGatherer,
-  SfdxCommandlet,
-  SfdxWorkspaceChecker,
-  useBetaDeployRetrieve
-} from './util';
+import { FilePathGatherer, SfdxCommandlet, SfdxWorkspaceChecker } from './util';
 
 export class ForceSourceDeployManifestExecutor extends BaseDeployExecutor {
   public build(manifestPath: string): Command {
@@ -99,7 +95,7 @@ export async function forceSourceDeployManifest(manifestUri: vscode.Uri) {
   const commandlet = new SfdxCommandlet(
     new SfdxWorkspaceChecker(),
     new FilePathGatherer(manifestUri),
-    useBetaDeployRetrieve([])
+    sfdxCoreSettings.getBetaDeployRetrieve()
       ? new LibrarySourceDeployManifestExecutor()
       : new ForceSourceDeployManifestExecutor(),
     new ConflictDetectionChecker(messages)

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploySourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploySourcePath.ts
@@ -17,12 +17,12 @@ import * as vscode from 'vscode';
 import { channelService } from '../channels';
 import { nls } from '../messages';
 import { notificationService } from '../notifications';
+import { sfdxCoreSettings } from '../settings';
 import { telemetryService } from '../telemetry';
 import { BaseDeployExecutor, DeployType } from './baseDeployCommand';
 import { DeployExecutor } from './baseDeployRetrieve';
 import { SourcePathChecker } from './forceSourceRetrieveSourcePath';
 import { FilePathGatherer, SfdxCommandlet, SfdxWorkspaceChecker } from './util';
-import { useBetaDeployRetrieve } from './util';
 
 export class ForceSourceDeploySourcePathExecutor extends BaseDeployExecutor {
   public build(sourcePath: string): Command {
@@ -116,7 +116,7 @@ export async function forceSourceDeploySourcePath(sourceUri: vscode.Uri) {
   const commandlet = new SfdxCommandlet(
     new SfdxWorkspaceChecker(),
     new FilePathGatherer(sourceUri),
-    useBetaDeployRetrieve([sourceUri])
+    sfdxCoreSettings.getBetaDeployRetrieve()
       ? new LibraryDeploySourcePathExecutor()
       : new ForceSourceDeploySourcePathExecutor(),
     new SourcePathChecker()
@@ -125,7 +125,7 @@ export async function forceSourceDeploySourcePath(sourceUri: vscode.Uri) {
 }
 
 export async function forceSourceDeployMultipleSourcePaths(uris: vscode.Uri[]) {
-  const useBeta = useBetaDeployRetrieve(uris);
+  const useBeta = sfdxCoreSettings.getBetaDeployRetrieve();
   const commandlet = new SfdxCommandlet(
     new SfdxWorkspaceChecker(),
     useBeta

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveManifest.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveManifest.ts
@@ -19,6 +19,7 @@ import {
 } from '../commands/util/postconditionCheckers';
 import { nls } from '../messages';
 import { notificationService } from '../notifications';
+import { sfdxCoreSettings } from '../settings';
 import { SfdxPackageDirectories } from '../sfdxProject';
 import { telemetryService } from '../telemetry';
 import { getRootWorkspacePath } from '../util';
@@ -27,8 +28,7 @@ import {
   FilePathGatherer,
   SfdxCommandlet,
   SfdxCommandletExecutor,
-  SfdxWorkspaceChecker,
-  useBetaDeployRetrieve
+  SfdxWorkspaceChecker
 } from './util';
 
 export class ForceSourceRetrieveManifestExecutor extends SfdxCommandletExecutor<
@@ -101,7 +101,7 @@ export async function forceSourceRetrieveManifest(explorerPath: vscode.Uri) {
   const commandlet = new SfdxCommandlet(
     new SfdxWorkspaceChecker(),
     new FilePathGatherer(explorerPath),
-    useBetaDeployRetrieve([])
+    sfdxCoreSettings.getBetaDeployRetrieve()
       ? new LibrarySourceRetrieveManifestExecutor()
       : new ForceSourceRetrieveManifestExecutor(),
     new ConflictDetectionChecker(messages)

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveMetadata/forceSourceRetrieveCmp.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveMetadata/forceSourceRetrieveCmp.ts
@@ -27,6 +27,7 @@ import * as vscode from 'vscode';
 import { RetrieveDescriber, RetrieveMetadataTrigger } from '.';
 import { channelService } from '../../channels';
 import { nls } from '../../messages';
+import { sfdxCoreSettings } from '../../settings';
 import { SfdxPackageDirectories } from '../../sfdxProject';
 import { telemetryService } from '../../telemetry';
 import { getRootWorkspacePath, MetadataDictionary } from '../../util';
@@ -34,8 +35,7 @@ import { RetrieveExecutor } from '../baseDeployRetrieve';
 import {
   SfdxCommandlet,
   SfdxCommandletExecutor,
-  SfdxWorkspaceChecker,
-  useBetaDeployRetrieve
+  SfdxWorkspaceChecker
 } from '../util';
 import { RetrieveComponentOutputGatherer } from '../util/parameterGatherers';
 import { OverwriteComponentPrompt } from '../util/postconditionCheckers';
@@ -228,12 +228,11 @@ export async function forceSourceRetrieveCmp(
   trigger: RetrieveMetadataTrigger,
   openAfterRetrieve: boolean = false
 ) {
-  const useBeta = useBetaDeployRetrieve([]);
   const retrieveDescriber = trigger.describer();
   const commandlet = new SfdxCommandlet(
     new SfdxWorkspaceChecker(),
     new RetrieveComponentOutputGatherer(retrieveDescriber),
-    useBeta
+    sfdxCoreSettings.getBetaDeployRetrieve()
       ? new LibraryRetrieveSourcePathExecutor(openAfterRetrieve)
       : new ForceSourceRetrieveExecutor(retrieveDescriber, openAfterRetrieve),
     new OverwriteComponentPrompt()

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveSourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveSourcePath.ts
@@ -18,6 +18,7 @@ import * as vscode from 'vscode';
 import { channelService } from '../channels';
 import { nls } from '../messages';
 import { notificationService } from '../notifications';
+import { sfdxCoreSettings } from '../settings';
 import { SfdxPackageDirectories } from '../sfdxProject';
 import { telemetryService } from '../telemetry';
 import { RetrieveExecutor } from './baseDeployRetrieve';
@@ -25,8 +26,7 @@ import {
   FilePathGatherer,
   SfdxCommandlet,
   SfdxCommandletExecutor,
-  SfdxWorkspaceChecker,
-  useBetaDeployRetrieve
+  SfdxWorkspaceChecker
 } from './util';
 
 export class ForceSourceRetrieveSourcePathExecutor extends SfdxCommandletExecutor<
@@ -114,12 +114,10 @@ export async function forceSourceRetrieveSourcePath(explorerPath: vscode.Uri) {
     }
   }
 
-  const useBeta = useBetaDeployRetrieve([explorerPath]);
-
   const commandlet = new SfdxCommandlet(
     new SfdxWorkspaceChecker(),
     new FilePathGatherer(explorerPath),
-    useBeta
+    sfdxCoreSettings.getBetaDeployRetrieve()
       ? new LibraryRetrieveSourcePathExecutor()
       : new ForceSourceRetrieveSourcePathExecutor(),
     new SourcePathChecker()

--- a/packages/salesforcedx-vscode-core/src/commands/util/betaDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/betaDeployRetrieve.ts
@@ -4,7 +4,24 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { getRelativeProjectPath } from '@salesforce/salesforcedx-utils-vscode/out/src';
 import { MetadataComponent } from '@salesforce/source-deploy-retrieve';
+import { SfdxPackageDirectories } from '../../sfdxProject';
+
+export async function formatException(e: Error): Promise<Error> {
+  const formattedException = new Error('Unknown Exception');
+  formattedException.name = e.name;
+
+  if (e.name === 'TypeInferenceError') {
+    const projectPath = getRelativeProjectPath(
+      e.message.slice(0, e.message.lastIndexOf(':')),
+      await SfdxPackageDirectories.getPackageDirectoryPaths()
+    );
+    formattedException.message = `${projectPath}: Could not infer metadata type`;
+  }
+
+  return formattedException;
+}
 
 export function createComponentCount(components: Iterable<MetadataComponent>) {
   const quantities: { [type: string]: number } = {};

--- a/packages/salesforcedx-vscode-core/src/commands/util/betaDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/betaDeployRetrieve.ts
@@ -4,38 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
-import { ComponentSet, MetadataType } from '@salesforce/source-deploy-retrieve';
 import { MetadataComponent } from '@salesforce/source-deploy-retrieve';
-import * as vscode from 'vscode';
-import { sfdxCoreSettings } from '../../settings';
-
-export function useBetaDeployRetrieve(
-  uris: vscode.Uri[],
-  supportedTypes?: MetadataType[]
-): boolean {
-  const betaSettingOn = sfdxCoreSettings.getBetaDeployRetrieve();
-  if (!betaSettingOn) {
-    return false;
-  }
-
-  const ws = new ComponentSet();
-  const permittedTypeNames = new Set();
-  supportedTypes?.forEach(type => permittedTypeNames.add(type.name));
-
-  for (const { fsPath } of uris) {
-    const componentsForPath = ws.resolveSourceComponents(fsPath);
-    if (supportedTypes && componentsForPath) {
-      for (const component of componentsForPath) {
-        if (!permittedTypeNames.has(component.type.name)) {
-          return false;
-        }
-      }
-    }
-  }
-
-  return true;
-}
 
 export function createComponentCount(components: Iterable<MetadataComponent>) {
   const quantities: { [type: string]: number } = {};

--- a/packages/salesforcedx-vscode-core/src/commands/util/betaDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/betaDeployRetrieve.ts
@@ -8,6 +8,12 @@ import { getRelativeProjectPath } from '@salesforce/salesforcedx-utils-vscode/ou
 import { MetadataComponent } from '@salesforce/source-deploy-retrieve';
 import { SfdxPackageDirectories } from '../../sfdxProject';
 
+/**
+ * Reformats errors thrown by beta deploy/retrieve logic.
+ *
+ * @param e Error to reformat
+ * @returns A newly formatted error
+ */
 export async function formatException(e: Error): Promise<Error> {
   const formattedException = new Error('Unknown Exception');
   formattedException.name = e.name;

--- a/packages/salesforcedx-vscode-core/src/commands/util/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/index.ts
@@ -40,7 +40,4 @@ export {
   DevUsernameChecker,
   EmptyPreChecker
 } from './preconditionCheckers';
-export {
-  createComponentCount,
-  useBetaDeployRetrieve
-} from './betaDeployRetrieve';
+export { createComponentCount } from './betaDeployRetrieve';

--- a/packages/salesforcedx-vscode-core/src/commands/util/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/index.ts
@@ -40,4 +40,4 @@ export {
   DevUsernameChecker,
   EmptyPreChecker
 } from './preconditionCheckers';
-export { createComponentCount } from './betaDeployRetrieve';
+export { createComponentCount, formatException } from './betaDeployRetrieve';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
@@ -205,9 +205,7 @@ describe('Base Deploy Retrieve Commands', () => {
         fail('should have thrown an error');
       } catch (e) {
         expect(e.name).to.equal(testException.name);
-        expect(e.message).to.equal(
-          `Unknown exception in ${executor.constructor.name}`
-        );
+        expect(e.message).to.equal('Unknown Exception');
       }
     });
   });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/betaDeployRetrieve.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/betaDeployRetrieve.test.ts
@@ -10,10 +10,7 @@ import { SourceComponent } from '@salesforce/source-deploy-retrieve';
 import { expect } from 'chai';
 import { createSandbox, SinonStub } from 'sinon';
 import * as vscode from 'vscode';
-import {
-  createComponentCount,
-  useBetaDeployRetrieve
-} from '../../../../src/commands/util';
+import { createComponentCount } from '../../../../src/commands/util';
 import { SfdxCoreSettings } from '../../../../src/settings/sfdxCoreSettings';
 
 const env = createSandbox();
@@ -35,71 +32,6 @@ describe('Deploy/Retrieve Performance Beta Utils', () => {
       []
     )
   ];
-
-  describe('useBetaDeployRetrieve', () => {
-    let settingStub: SinonStub;
-    let registryStub: SinonStub;
-
-    const uriOne = vscode.Uri.file('classes/foo.cls');
-    const uriTwo = vscode.Uri.parse(
-      'channelLayouts/bar.channelLayout-meta.xml'
-    );
-
-    beforeEach(() => {
-      settingStub = env
-        .stub(SfdxCoreSettings.prototype, 'getBetaDeployRetrieve')
-        .returns(true);
-      const wsOne = new ComponentSet();
-      wsOne.add(testComponents[0]);
-      const wsTwo = new ComponentSet();
-      wsTwo.add(testComponents[1]);
-      registryStub = env
-        .stub(ComponentSet.prototype, 'resolveSourceComponents')
-        .withArgs(uriOne.fsPath)
-        .returns(wsOne)
-        .withArgs(uriTwo.fsPath)
-        .returns(wsTwo);
-    });
-
-    afterEach(() => {
-      env.restore();
-    });
-
-    it('should return true when beta configuration is enabled', () => {
-      expect(useBetaDeployRetrieve([uriOne])).to.equal(true);
-      expect(settingStub.calledBefore(registryStub)).to.equal(true);
-    });
-
-    it('should return false when beta configuration is disabled', () => {
-      settingStub.returns(false);
-
-      expect(useBetaDeployRetrieve([uriOne])).to.equal(false);
-      expect(registryStub.notCalled).to.equal(true);
-    });
-
-    it("should return true if a component's type is marked as supported", () => {
-      expect(
-        useBetaDeployRetrieve([uriOne], [registryData.types.apexclass])
-      ).to.equal(true);
-    });
-
-    it("should return false if a component's type is not marked as supported", () => {
-      expect(
-        useBetaDeployRetrieve([uriTwo], [registryData.types.apexclass])
-      ).to.equal(false);
-    });
-
-    it('should return as expected for multiple uris', () => {
-      const permittedTypes = [
-        registryData.types.apexclass,
-        registryData.types.channellayout
-      ];
-      expect(useBetaDeployRetrieve([uriOne, uriTwo], permittedTypes)).to.equal(
-        true
-      );
-      expect(useBetaDeployRetrieve([uriOne, uriTwo], [])).to.equal(false);
-    });
-  });
 
   describe('createComponentCount', () => {
     it('should correctly generate rows for telemetry', () => {


### PR DESCRIPTION
### What does this PR do?

Properly handles file paths when throwing TypeInfereceError exceptions. Also fixes it for when we are creating component counts in the baseDeployExecutor. 

### What issues does this PR fix or reference?

@W-9105085@