### PR TITLE
fix: retrieving all components of org browser type

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveMetadata/forceSourceRetrieveCmp.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveMetadata/forceSourceRetrieveCmp.ts
@@ -156,15 +156,18 @@ export class LibraryRetrieveSourcePathExecutor extends RetrieveExecutor<
   protected async getComponents(
     response: ContinueResponse<LocalComponent[]>
   ): Promise<ComponentSet> {
-    const filter = new ComponentSet(
+    const toRetrieve = new ComponentSet(
       response.data.map(lc => ({ fullName: lc.fileName, type: lc.type }))
     );
     const packageDirs = await SfdxPackageDirectories.getPackageDirectoryFullPaths();
-    const sourceResult = ComponentSet.fromSource({
+    const localSourceComponents = ComponentSet.fromSource({
       fsPaths: packageDirs,
-      include: filter
+      include: toRetrieve
     });
-    return sourceResult.getSourceComponents().toArray().length === 0 ? filter : sourceResult;
+    for (const component of localSourceComponents) {
+      toRetrieve.add(component);
+    }
+    return toRetrieve;
   }
 
   protected async postOperation(


### PR DESCRIPTION
### What does this PR do?

Fixes an issue retrieving all components of a type using the org browser. If there was a mixed of locally present components and remote only components, only the locally present ones were retrieved.

### What issues does this PR fix or reference?

@W-9102368@

### Functionality Before

Only locally present components were retrieved when retrieving all components of a type.

### Functionality After

Both remote components and locally present ones are retrieved.
