### PR TITLE
fix: unknown exception with deploy/retrieve

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployCommand.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployCommand.ts
@@ -27,9 +27,8 @@ import { taskViewService } from '../statuses';
 import { telemetryService } from '../telemetry';
 import { getRootWorkspacePath } from '../util';
 import {
-  createComponentCount,
-  formatException
-} from './util/betaDeployRetrieve';
+  createComponentCount, formatException
+} from './util';
 import { SfdxCommandletExecutor } from './util/sfdxCommandlet';
 
 export enum DeployType {

--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
@@ -48,7 +48,7 @@ type DeployRetrieveOperation = MetadataApiDeploy | MetadataApiRetrieve;
 
 export abstract class DeployRetrieveExecutor<
   T
-> extends LibraryCommandletExecutor<T> {
+  > extends LibraryCommandletExecutor<T> {
   protected cancellable: boolean = true;
 
   constructor(executionName: string, logName: string) {
@@ -82,7 +82,7 @@ export abstract class DeployRetrieveExecutor<
         status === RequestStatus.SucceededPartial
       );
     } catch (e) {
-      throw await formatException(e);
+      throw formatException(e);
     } finally {
       await this.postOperation(result);
     }

--- a/packages/salesforcedx-vscode-core/src/commands/util/betaDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/betaDeployRetrieve.ts
@@ -4,29 +4,17 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { getRelativeProjectPath } from '@salesforce/salesforcedx-utils-vscode/out/src';
+import { getRootWorkspacePath } from '@salesforce/salesforcedx-utils-vscode/out/src';
 import { MetadataComponent } from '@salesforce/source-deploy-retrieve';
-import { SfdxPackageDirectories } from '../../sfdxProject';
-
 /**
  * Reformats errors thrown by beta deploy/retrieve logic.
  *
  * @param e Error to reformat
  * @returns A newly formatted error
  */
-export async function formatException(e: Error): Promise<Error> {
-  const formattedException = new Error('Unknown Exception');
-  formattedException.name = e.name;
-
-  if (e.name === 'TypeInferenceError') {
-    const projectPath = getRelativeProjectPath(
-      e.message.slice(0, e.message.lastIndexOf(':')),
-      await SfdxPackageDirectories.getPackageDirectoryPaths()
-    );
-    formattedException.message = `${projectPath}: Could not infer metadata type`;
-  }
-
-  return formattedException;
+export function formatException(e: Error): Error {
+  e.message = e.message.replace(getRootWorkspacePath(), '');
+  return e;
 }
 
 export function createComponentCount(components: Iterable<MetadataComponent>) {


### PR DESCRIPTION
### What does this PR do?

Surfaces the original error instead of "Unknown Exception". While this doesn't exactly fix underlying issues if there are some, we or the user at least can triage what's going on.

### What issues does this PR fix or reference?
#3137, @W-9178716@

### Functionality Before

"Unknown Exception" message reported for any issues that are not TypeInferenceErrors

### Functionality After

Original errors are now surfaced to make triaging easier.