### PR TITLE
fix: preserve leading zeros in xml tags during deploy/retrieve

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -29,7 +29,7 @@
     "@salesforce/salesforcedx-sobjects-faux-generator": "51.11.0",
     "@salesforce/salesforcedx-utils-vscode": "51.11.0",
     "@salesforce/schemas": "^1",
-    "@salesforce/source-deploy-retrieve": "2.1.2",
+    "@salesforce/source-deploy-retrieve": "2.1.3",
     "@salesforce/templates": "51.3.0",
     "adm-zip": "0.4.13",
     "applicationinsights": "1.0.7",


### PR DESCRIPTION
### What does this PR do?

Updates to the latest version of SDR that contains the fix for preserving leading zeroes in xml tags during deploys and retrieves.

### What issues does this PR fix or reference?
#3138, @W-9118281@

### Functionality Before

Deploying and retrieving metadata with leading zeroes in xml tags were not preserved.

### Functionality After

Now they are.
