### PR TITLE
feat: cache metadata based on a project path

### DIFF
--- a/packages/salesforcedx-vscode-core/src/conflict/metadataCacheService.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/metadataCacheService.ts
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {
+  ComponentSet,
+  MetadataApiRetrieve,
+  RetrieveResult,
+  SourceComponent,
+  SourceRetrieveResult
+} from '@salesforce/source-deploy-retrieve';
+import { FileProperties } from '@salesforce/source-deploy-retrieve/lib/src/client/types';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as shell from 'shelljs';
+import * as vscode from 'vscode';
+import { RetrieveExecutor } from '../commands/baseDeployRetrieve';
+import { getRootWorkspacePath } from '../util';
+
+export interface MetadataContext {
+  baseDirectory: string;
+  commonRoot: string;
+  components: SourceComponent[];
+}
+
+export interface MetadataCacheResult {
+  selectedPath: string;
+  selectedIsDirectory: boolean;
+
+  cachePropPath?: string;
+  cache: MetadataContext;
+  project: MetadataContext;
+}
+
+export class MetadataCacheService {
+  private static CACHE_FOLDER = ['.sfdx', 'diff'];
+  private static PROPERTIES_FOLDER = ['prop'];
+  private static PROPERTIES_FILE = 'file-props.json';
+
+  private username: string;
+  private cachePath: string;
+  private componentPath?: string;
+  private sourceComponents: ComponentSet;
+
+  public constructor(username: string) {
+    this.username = username;
+    this.sourceComponents = new ComponentSet();
+    this.cachePath = this.getCachePath(username);
+  }
+
+  public initialize(componentPath: string): void {
+    this.componentPath = componentPath;
+  }
+
+  public async loadCache(
+    componentPath: string
+  ): Promise<MetadataCacheResult | undefined> {
+    this.initialize(componentPath);
+    const components = await this.getSourceComponents();
+    const operation = await this.createRetrieveOperation(components);
+    const results = await operation.start();
+    return this.processResults(results);
+  }
+
+  public async getSourceComponents(): Promise<ComponentSet> {
+    return this.componentPath
+      ? (this.sourceComponents = ComponentSet.fromSource(this.componentPath))
+      : new ComponentSet();
+  }
+
+  public async createRetrieveOperation(
+    comps?: ComponentSet
+  ): Promise<MetadataApiRetrieve> {
+    const components = comps || (await this.getSourceComponents());
+    this.clearDirectory(this.cachePath, true);
+
+    const operation = components.retrieve({
+      usernameOrConnection: this.username,
+      output: this.cachePath,
+      merge: false
+    });
+
+    return operation;
+  }
+
+  public async processResults(
+    result: RetrieveResult | SourceRetrieveResult | undefined
+  ): Promise<MetadataCacheResult | undefined> {
+    if (!result) {
+      return;
+    }
+
+    const { components, properties } = this.extractResults(result);
+    if (components.length > 0 && this.componentPath) {
+      const propsFile = this.saveProperties(properties);
+      const cacheCommon = this.findLongestCommonDir(components, this.cachePath);
+
+      const projectDir = getRootWorkspacePath();
+      const projCommon = this.findLongestCommonDir(
+        this.sourceComponents.getSourceComponents().toArray(),
+        projectDir
+      );
+
+      const isPathDirectory =
+        fs.existsSync(this.componentPath) &&
+        fs.lstatSync(this.componentPath).isDirectory();
+
+      return {
+        selectedPath: this.componentPath,
+        selectedIsDirectory: isPathDirectory,
+
+        cache: {
+          baseDirectory: this.cachePath,
+          commonRoot: cacheCommon,
+          components
+        },
+        cachePropPath: propsFile,
+
+        project: {
+          baseDirectory: projectDir,
+          commonRoot: projCommon,
+          components: this.sourceComponents.getSourceComponents().toArray()
+        }
+      };
+    }
+  }
+
+  private extractResults(
+    result: RetrieveResult | SourceRetrieveResult
+  ): { components: SourceComponent[]; properties: FileProperties[] } {
+    let components: SourceComponent[] = [];
+    const properties: FileProperties[] = [];
+
+    if (result instanceof RetrieveResult) {
+      if (Array.isArray(result.response.fileProperties)) {
+        properties.push(...result.response.fileProperties);
+      } else {
+        properties.push(result.response.fileProperties);
+      }
+      components = result.components.getSourceComponents().toArray();
+    } else {
+      result.successes?.forEach(s => {
+        if (s.properties) {
+          properties.push(s.properties);
+        }
+        components.push(s.component);
+      });
+    }
+    return { components, properties };
+  }
+
+  private findLongestCommonDir(
+    comps: SourceComponent[],
+    baseDir: string
+  ): string {
+    if (comps.length === 0) {
+      return baseDir;
+    }
+    if (comps.length === 1) {
+      return this.getRelativePath(comps[0], baseDir);
+    }
+
+    const allPaths = comps.map(c => this.getRelativePath(c, baseDir));
+    const baseline = allPaths[0];
+    let shortest = baseline.length;
+
+    for (let whichPath = 1; whichPath < allPaths.length; whichPath++) {
+      const sample = allPaths[whichPath];
+      shortest = Math.min(shortest, sample.length);
+
+      for (let comparePos = 0; comparePos < shortest; comparePos++) {
+        if (baseline[comparePos] !== sample[comparePos]) {
+          shortest = comparePos;
+          break;
+        }
+      }
+    }
+
+    return baseline.substring(0, shortest);
+  }
+
+  private saveProperties(properties: FileProperties[]): string {
+    const props = {
+      componentPath: this.componentPath,
+      fileProperties: properties
+    };
+    const propDir = this.getPropsPath();
+    const propsFile = path.join(propDir, MetadataCacheService.PROPERTIES_FILE);
+
+    fs.mkdirSync(propDir);
+    fs.writeFileSync(propsFile, JSON.stringify(props));
+    return propsFile;
+  }
+
+  private getRelativePath(comp: SourceComponent, baseDir: string): string {
+    const compPath = comp.content || comp.xml;
+    if (compPath) {
+      const compDir = path.dirname(compPath);
+      return compDir.substring(baseDir.length + path.sep.length);
+    }
+    return '';
+  }
+
+  public getCachePath(cacheKey: string): string {
+    return path.join(
+      os.tmpdir(),
+      ...MetadataCacheService.CACHE_FOLDER,
+      cacheKey
+    );
+  }
+
+  public getPropsPath(): string {
+    return path.join(this.cachePath, ...MetadataCacheService.PROPERTIES_FOLDER);
+  }
+
+  private clearDirectory(dirToRemove: string, throwErrorOnFailure: boolean) {
+    try {
+      shell.rm('-rf', dirToRemove);
+    } catch (error) {
+      if (throwErrorOnFailure) {
+        throw error;
+      }
+    }
+  }
+}
+
+export type MetadataCacheCallback = (
+  cache: MetadataCacheResult | undefined
+) => Promise<void>;
+
+export class MetadataCacheExecutor extends RetrieveExecutor<string> {
+  private cacheService: MetadataCacheService;
+  private callback: MetadataCacheCallback;
+
+  constructor(
+    username: string,
+    executionName: string,
+    logName: string,
+    callback: MetadataCacheCallback
+  ) {
+    super(executionName, logName);
+    this.callback = callback;
+    this.cacheService = new MetadataCacheService(username);
+  }
+
+  protected async getComponents(response: any): Promise<ComponentSet> {
+    this.cacheService.initialize(response.data);
+    return this.cacheService.getSourceComponents();
+  }
+
+  protected async doOperation(
+    components: ComponentSet,
+    token: vscode.CancellationToken
+  ): Promise<RetrieveResult | undefined> {
+    const operation = await this.cacheService.createRetrieveOperation(
+      components
+    );
+    this.setupCancellation(operation, token);
+    return operation.start();
+  }
+
+  protected async postOperation(
+    result: RetrieveResult | SourceRetrieveResult | undefined
+  ) {
+    const cache:
+      | MetadataCacheResult
+      | undefined = await this.cacheService.processResults(result);
+    await this.callback(cache);
+  }
+}

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/metadataCacheService.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/metadataCacheService.test.ts
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  ComponentSet,
+  MetadataApiRetrieve,
+  RetrieveResult
+} from '@salesforce/source-deploy-retrieve';
+import {
+  FileProperties,
+  MetadataApiRetrieveStatus,
+  RequestStatus
+} from '@salesforce/source-deploy-retrieve/lib/src/client/types';
+import * as AdmZip from 'adm-zip';
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as shell from 'shelljs';
+import {
+  MetadataCacheExecutor,
+  MetadataCacheResult,
+  MetadataCacheService
+} from '../../../src/conflict/metadataCacheService';
+import { stubRootWorkspace } from '../util/rootWorkspace.test-util';
+import sinon = require('sinon');
+
+describe('Metadata Cache', () => {
+  describe('Metadata Cache Executor', () => {
+    const PROJ_ROOT = path.join(
+      __dirname,
+      '..',
+      '..',
+      '..',
+      '..',
+      'test',
+      'vscode-integration',
+      'diffs'
+    );
+    const usernameOrAlias = 'admin@ut-sandbox.org';
+    const PROJECT_DIR = path.join(PROJ_ROOT, 'meta-proj');
+    let workspaceStub: sinon.SinonStub;
+    let executor: MetadataCacheExecutor;
+    let componentStub: sinon.SinonStub;
+    let operationStub: sinon.SinonStub;
+    let processStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      executor = new MetadataCacheExecutor(
+        usernameOrAlias,
+        'Source Diff',
+        'source-diff-loader',
+        handleCacheResults
+      );
+      operationStub = sinon.stub(
+        MetadataCacheService.prototype,
+        'createRetrieveOperation'
+      );
+      componentStub = sinon.stub(
+        MetadataCacheService.prototype,
+        'getSourceComponents'
+      );
+      processStub = sinon.stub(
+        MetadataCacheService.prototype,
+        'processResults'
+      );
+      workspaceStub = stubRootWorkspace(PROJECT_DIR);
+    });
+
+    afterEach(() => {
+      componentStub.restore();
+      processStub.restore();
+      operationStub.restore();
+      workspaceStub!.restore();
+      shell.rm('-rf', PROJECT_DIR);
+    });
+
+    it('Should run metadata service', async () => {
+      componentStub.resolves(new ComponentSet());
+      const mockOperation = new MetadataApiRetrieve({
+        usernameOrConnection: usernameOrAlias,
+        components: new ComponentSet(),
+        output: ''
+      });
+      const startStub = sinon.stub(mockOperation, 'start');
+      startStub.callsFake(() => {});
+      operationStub.resolves(mockOperation);
+      processStub.resolves(undefined);
+
+      await executor.run({ data: PROJECT_DIR, type: 'CONTINUE' });
+
+      expect(componentStub.callCount).to.equal(1);
+      expect(operationStub.callCount).to.equal(1);
+      expect(startStub.callCount).to.equal(1);
+      expect(processStub.callCount).to.equal(1);
+    });
+  });
+
+  describe('Metadata Cache Service', () => {
+    const PROJ_ROOT = path.join(
+      __dirname,
+      '..',
+      '..',
+      '..',
+      '..',
+      'test',
+      'vscode-integration',
+      'diffs'
+    );
+    const TEST_ASSETS_FOLDER = path.join(
+      __dirname,
+      '..',
+      '..',
+      '..',
+      '..',
+      '..',
+      'system-tests',
+      'assets'
+    );
+    const TEST_DATA_FOLDER = path.join(TEST_ASSETS_FOLDER, 'differ-testdata');
+    const usernameOrAlias = 'admin@ut-sandbox.org';
+    const PROJECT_DIR = path.join(PROJ_ROOT, 'meta-proj2');
+    let workspaceStub: sinon.SinonStub;
+    let service: MetadataCacheService;
+
+    beforeEach(() => {
+      service = new MetadataCacheService(usernameOrAlias);
+      workspaceStub = stubRootWorkspace(PROJECT_DIR);
+    });
+
+    afterEach(() => {
+      service.clearCache();
+      workspaceStub!.restore();
+      shell.rm('-rf', PROJECT_DIR);
+    });
+
+    it('Should clear cache directory', async () => {
+      const cachePath = service.getCachePath();
+      const tempFilePath = path.join(cachePath, 'TestFile.xml');
+
+      shell.mkdir('-p', cachePath);
+      shell.touch([tempFilePath]);
+
+      expect(
+        fs.existsSync(tempFilePath),
+        `folder ${tempFilePath} should exist`
+      ).to.equal(true);
+
+      const actualCachePath = service.clearCache();
+      expect(actualCachePath).to.equal(cachePath);
+
+      expect(
+        fs.existsSync(actualCachePath),
+        `folder ${actualCachePath} should not exist`
+      ).to.equal(false);
+    });
+
+    it('Should find one component', async () => {
+      const projectPath = path.join(PROJECT_DIR, 'src');
+
+      // populate project metadata
+      const projectZip = new AdmZip();
+      projectZip.addLocalFolder(TEST_DATA_FOLDER);
+      projectZip.extractAllTo(projectPath);
+
+      const componentPath = path.join(
+        projectPath,
+        'aura',
+        'PictureGalleryCard',
+        'PictureGalleryCard.cmp'
+      );
+      service.initialize(componentPath, PROJECT_DIR);
+      const components = await service.getSourceComponents();
+
+      expect(components.size).to.equal(1);
+    });
+
+    it('Should find components', async () => {
+      const projectPath = path.join(PROJECT_DIR, 'src');
+
+      // populate project metadata
+      const projectZip = new AdmZip();
+      projectZip.addLocalFolder(TEST_DATA_FOLDER);
+      projectZip.extractAllTo(projectPath);
+
+      service.initialize(projectPath, PROJECT_DIR);
+      const components = await service.getSourceComponents();
+
+      expect(components.size).to.equal(14);
+    });
+
+    it('Should return cache results', async () => {
+      const projectPath = path.join(PROJECT_DIR, 'src');
+      const cachePath = service.getCachePath();
+      const retrieveRoot = path.join('main', 'default');
+
+      // populate project metadata
+      const projectZip = new AdmZip();
+      projectZip.addLocalFolder(TEST_DATA_FOLDER);
+      projectZip.extractAllTo(projectPath);
+      projectZip.extractAllTo(path.join(cachePath, retrieveRoot));
+
+      service.initialize(projectPath, PROJECT_DIR);
+      await service.getSourceComponents();
+      const results = loadMockCache(cachePath);
+
+      const cache = await service.processResults(results);
+
+      expect(cache).to.not.equal(undefined);
+      expect(cache?.selectedPath).to.equal(projectPath);
+      expect(cache?.selectedIsDirectory).to.equal(true);
+      expect(cache?.cachePropPath).to.equal(
+        path.join(cachePath, 'prop', 'file-props.json')
+      );
+
+      expect(cache?.cache.baseDirectory).to.equal(cachePath);
+      expect(cache?.cache.commonRoot).to.equal(retrieveRoot);
+
+      expect(cache?.project.baseDirectory).to.equal(PROJECT_DIR);
+      expect(cache?.project.commonRoot).to.equal('src');
+
+      // verify contents of prop file
+      if (cache?.cachePropPath) {
+        const propObj = JSON.parse(
+          fs.readFileSync(cache?.cachePropPath, {
+            encoding: 'UTF-8'
+          })
+        );
+
+        expect(propObj.componentPath).to.equal(projectPath);
+        expect(propObj.fileProperties.length).to.equal(1);
+        const prop = propObj.fileProperties[0];
+        expect(prop.fullName).to.equal('One');
+        expect(prop.fileName).to.equal('One.cls');
+      }
+    });
+  });
+
+  async function handleCacheResults(
+    cache?: MetadataCacheResult
+  ): Promise<void> {}
+
+  function loadMockCache(cachePath: string): RetrieveResult {
+    const props: FileProperties[] = [
+      {
+        id: '1',
+        createdById: '2',
+        createdByName: 'Me',
+        createdDate: 'Today',
+        fileName: 'One.cls',
+        fullName: 'One',
+        lastModifiedById: '3',
+        lastModifiedByName: 'You',
+        lastModifiedDate: 'Tomorrow',
+        type: 'ApexClass'
+      }
+    ];
+
+    const response: MetadataApiRetrieveStatus = {
+      done: true,
+      status: RequestStatus.Succeeded,
+      success: true,
+      id: '',
+      fileProperties: props,
+      zipFile: ''
+    };
+
+    const cacheComps = ComponentSet.fromSource(cachePath);
+    const results = new RetrieveResult(response, cacheComps);
+    return results;
+  }
+});

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/directoryDiffer.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/directoryDiffer.test.ts
@@ -55,11 +55,11 @@ describe('Directory Differ', () => {
     expect(
       results.scannedLocal,
       'incorrect number of files scanned in dirOne'
-    ).to.equal(42);
+    ).to.equal(43);
     expect(
       results.scannedRemote,
       'incorrect number of files scanned in dirTwo'
-    ).to.equal(41);
+    ).to.equal(42);
   });
 
   it('Should detect text differences', () => {
@@ -91,11 +91,11 @@ describe('Directory Differ', () => {
     expect(
       results.scannedLocal,
       'incorrect number of files scanned in dirOne'
-    ).to.equal(42);
+    ).to.equal(43);
     expect(
       results.scannedRemote,
       'incorrect number of files scanned in dirTwo'
-    ).to.equal(41);
+    ).to.equal(42);
   });
 
   it('Should detect binary differences', () => {
@@ -127,10 +127,10 @@ describe('Directory Differ', () => {
     expect(
       results.scannedLocal,
       'incorrect number of files scanned in dirOne'
-    ).to.equal(42);
+    ).to.equal(43);
     expect(
       results.scannedRemote,
       'incorrect number of files scanned in dirTwo'
-    ).to.equal(41);
+    ).to.equal(42);
   });
 });

--- a/packages/system-tests/assets/differ-testdata/classes/DemoDriver.cls
+++ b/packages/system-tests/assets/differ-testdata/classes/DemoDriver.cls
@@ -1,0 +1,1 @@
+public with sharing class DemoDriver {}


### PR DESCRIPTION
### What does this PR do?

Provide an SDR based service for caching project metadata based on a project path. The service and its executor will be used in subsequent source diff and conflict detection work. The service retrieves metadata specified by a project path that may indicate a single resource, or any level of project folder. Properties of each resource are retrieved and saved to a dedicated file in the cache. Paths returned from the retrieve operation are normalized to allow difference or conflict analysis of the two folder structures.

### What issues does this PR fix or reference?
@ W-9166495@
