### PR TITLE
chore: remove tests as requirement for pre-publish workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -546,18 +546,12 @@ workflows:
           message: Pending Approval for merge of release branch into main
           channel: 'pdt_releases'
           color: '#0E1111'
-      - build-all
-      - unit-tests
-      - integration-tests
       - hold: # Requires manual approval in Circle Ci
           type: approval
       - merge-release-branch:
           e: default-executor
           context: pdt-publish-restricted-context
           requires:
-            - build-all
-            - unit-tests
-            - integration-tests
             - hold
           filters:
             branches:


### PR DESCRIPTION
### What does this PR do?
Reduces jobs required for pre-publish workflow (merging release branch into main). In order for commits to have made it this far, they would have already gone through the build-all, unit tests, and integration test checks. They should not be required again. 

Note this is a temporary measure to get around the vscode tests not always launching in circleci, and thus failing the build.
