### PR TITLE
feat: add alias prompt to authorize a devhub

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/index.ts
@@ -17,6 +17,8 @@ export {
   SANDBOX_URL
 } from './forceAuthWebLogin';
 export {
+  AuthDevHubParams,
+  AuthDevHubParamsGatherer,
   forceAuthDevHub,
   createAuthDevHubExecutor,
   ForceAuthDevHubDemoModeExecutor,

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceAuthDevHub.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceAuthDevHub.test.ts
@@ -9,14 +9,21 @@ import { ConfigFile } from '@salesforce/core';
 import { testSetup } from '@salesforce/core/lib/testSetup';
 import { expect } from 'chai';
 import { createSandbox, SinonSandbox, SinonSpy, SinonStub } from 'sinon';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
 import {
+  AuthDevHubParams,
+  AuthDevHubParamsGatherer,
   createAuthDevHubExecutor,
+  DEFAULT_ALIAS,
   ForceAuthDevHubDemoModeExecutor,
   ForceAuthDevHubExecutor
 } from '../../../src/commands';
 import { DEFAULT_DEV_HUB_USERNAME_KEY } from '../../../src/constants';
 import { nls } from '../../../src/messages';
 import { ConfigSource, OrgAuthInfo } from '../../../src/util';
+
+const TEST_ALIAS = 'testAlias';
 
 class TestForceAuthDevHubExecutor extends ForceAuthDevHubExecutor {
   public getShowChannelOutput() {
@@ -28,9 +35,11 @@ class TestForceAuthDevHubExecutor extends ForceAuthDevHubExecutor {
 describe('Force Auth Web Login for Dev Hub', () => {
   it('Should build the auth web login command', async () => {
     const authWebLogin = new ForceAuthDevHubExecutor();
-    const authWebLoginCommand = authWebLogin.build({});
+    const authWebLoginCommand = authWebLogin.build({
+      alias: TEST_ALIAS
+    });
     expect(authWebLoginCommand.toCommand()).to.equal(
-      'sfdx force:auth:web:login --setdefaultdevhubusername'
+      `sfdx force:auth:web:login --setalias ${TEST_ALIAS} --setdefaultdevhubusername`
     );
     expect(authWebLoginCommand.description).to.equal(
       nls.localize('force_auth_web_login_authorize_dev_hub_text')
@@ -121,13 +130,70 @@ describe('configureDefaultDevHubLocation on processExit of ForceAuthDevHubExecut
 describe('Force Auth Web Login For Dev Hub in Demo  Mode', () => {
   it('Should build the auth web login command', async () => {
     const authWebLogin = new ForceAuthDevHubDemoModeExecutor();
-    const authWebLoginCommand = authWebLogin.build({});
+    const authWebLoginCommand = authWebLogin.build({
+      alias: TEST_ALIAS
+    });
     expect(authWebLoginCommand.toCommand()).to.equal(
-      'sfdx force:auth:web:login --setdefaultdevhubusername --noprompt --json --loglevel fatal'
+      `sfdx force:auth:web:login --setalias ${TEST_ALIAS} --setdefaultdevhubusername --noprompt --json --loglevel fatal`
     );
     expect(authWebLoginCommand.description).to.equal(
       nls.localize('force_auth_web_login_authorize_dev_hub_text')
     );
+  });
+});
+
+describe('Auth Params Gatherer', () => {
+  let inputBoxSpy: sinon.SinonStub;
+
+  let gatherer: AuthDevHubParamsGatherer;
+
+  const setGathererBehavior = (
+    orgAlias: string | undefined
+  ) => {
+    inputBoxSpy.onCall(0).returns(orgAlias);
+  };
+
+  beforeEach(() => {
+    gatherer = new AuthDevHubParamsGatherer();
+    inputBoxSpy = sinon.stub(vscode.window, 'showInputBox');
+  });
+
+  afterEach(() => {
+    inputBoxSpy.restore();
+  });
+
+  describe('Org Alias Input', () => {
+    it('Should return Cancel if alias is undefined', async () => {
+      setGathererBehavior(undefined);
+
+      const response = await gatherer.gather();
+      expect(inputBoxSpy.calledOnce).to.be.true;
+      expect(response.type).to.equal('CANCEL');
+    });
+
+    it('Should return Continue with default alias if user input is empty string', async () => {
+      setGathererBehavior('');
+
+      const response = await gatherer.gather();
+      expect(inputBoxSpy.calledOnce).to.be.true;
+      if (response.type === 'CONTINUE') {
+        expect(response.data.alias).to.equal(DEFAULT_ALIAS);
+      } else {
+        expect.fail('Response should be of type ContinueResponse');
+      }
+    });
+
+    it('Should return Continue with inputted alias if user input is not undefined or empty', async () => {
+      setGathererBehavior(TEST_ALIAS);
+
+      const response = await gatherer.gather();
+      expect(inputBoxSpy.calledOnce).to.be.true;
+      if (response.type === 'CONTINUE') {
+        expect(response.data.alias).to.equal(TEST_ALIAS);
+      } else {
+        expect.fail('Response should be of type ContinueResponse');
+      }
+    });
   });
 });
 
@@ -170,26 +236,26 @@ describe('Force Auth Dev Hub is based on environment variables', () => {
     });
     it('Should use force:auth:web:login when container mode is not defined', () => {
       const authWebLogin = new ForceAuthDevHubExecutor();
-      const authWebLoginCommand = authWebLogin.build({});
+      const authWebLoginCommand = authWebLogin.build(({} as unknown) as AuthDevHubParams);
       expect(authWebLoginCommand.toCommand()).to.equal(
-        'sfdx force:auth:web:login --setdefaultdevhubusername'
+        'sfdx force:auth:web:login --setalias  --setdefaultdevhubusername'
       );
     });
     it('Should use force:auth:web:login when container mode is empty', () => {
       process.env.SFDX_CONTAINER_MODE = '';
       const authWebLogin = new ForceAuthDevHubExecutor();
-      const authWebLoginCommand = authWebLogin.build({});
+      const authWebLoginCommand = authWebLogin.build(({} as unknown) as AuthDevHubParams);
       expect(authWebLoginCommand.toCommand()).to.equal(
-        'sfdx force:auth:web:login --setdefaultdevhubusername'
+        'sfdx force:auth:web:login --setalias  --setdefaultdevhubusername'
       );
     });
 
     it('Should use force:auth:device:login when container mode is defined', () => {
       process.env.SFDX_CONTAINER_MODE = 'pickles';
       const authWebLogin = new ForceAuthDevHubExecutor();
-      const authWebLoginCommand = authWebLogin.build({});
+      const authWebLoginCommand = authWebLogin.build(({} as unknown) as AuthDevHubParams);
       expect(authWebLoginCommand.toCommand()).to.equal(
-        'sfdx force:auth:device:login --setdefaultdevhubusername'
+        'sfdx force:auth:device:login --setalias  --setdefaultdevhubusername'
       );
     });
   });


### PR DESCRIPTION
### What does this PR do?
Enable the user to define an alias when the command "Authorize a DevHub" runs

### What issues does this PR fix or reference?
#2278 

### Functionality Before
![Apr-29-2021 23-07-56](https://user-images.githubusercontent.com/32336365/116647363-fb5ad580-a93f-11eb-84c2-f99913bac798.gif)


### Functionality After
![Apr-29-2021 23-19-07](https://user-images.githubusercontent.com/32336365/116647913-5f31ce00-a941-11eb-98ac-81bfe847fa35.gif)
