### PR TITLE
fix: respect sfdx api version override during new deploy/retrieve

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
@@ -20,6 +20,7 @@ import {
   DeployResult,
   MetadataApiDeploy,
   MetadataApiRetrieve,
+  registry,
   RetrieveResult
 } from '@salesforce/source-deploy-retrieve';
 import {
@@ -62,10 +63,16 @@ export abstract class DeployRetrieveExecutor<
 
     try {
       const components = await this.getComponents(response);
-      const apiVersion = (await ConfigUtil.getConfigValue('apiVersion')) as
-        | string
-        | undefined;
-      components.apiVersion = apiVersion ?? components.apiVersion;
+
+      // concrete classes may have purposefully changed the api version.
+      // if there's an indication they didn't, check the SFDX configuration to see
+      // if there is an overridden api version.
+      if (components.apiVersion === registry.apiVersion) {
+        const apiVersion = (await ConfigUtil.getConfigValue('apiVersion')) as
+          | string
+          | undefined;
+        components.apiVersion = apiVersion ?? components.apiVersion;
+      }
 
       this.telemetry.addProperty(
         TELEMETRY_METADATA_COUNT,

--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {
+  ConfigUtil,
   getRelativeProjectPath,
   getRootWorkspacePath,
   LibraryCommandletExecutor
@@ -61,6 +62,10 @@ export abstract class DeployRetrieveExecutor<
 
     try {
       const components = await this.getComponents(response);
+      const apiVersion = (await ConfigUtil.getConfigValue('apiVersion')) as
+        | string
+        | undefined;
+      components.apiVersion = apiVersion ?? components.apiVersion;
 
       this.telemetry.addProperty(
         TELEMETRY_METADATA_COUNT,

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
@@ -196,7 +196,25 @@ describe('Base Deploy Retrieve Commands', () => {
       expect(components.apiVersion).to.equal(configApiVersion);
     });
 
-    it('should use the registry api version if SFDX configuration is not set', async () => {
+    it('should not override api version if getComponents set it already', async () => {
+      const executor = new TestDeployRetrieve();
+
+      const getComponentsResult = new ComponentSet();
+      getComponentsResult.apiVersion = '41.0';
+      executor.lifecycle.getComponentsStub.returns(getComponentsResult);
+
+      const configApiVersion = '45.0';
+      sb.stub(ConfigUtil, 'getConfigValue')
+        .withArgs('apiVersion')
+        .returns(configApiVersion);
+
+      await executor.run({ data: {}, type: 'CONTINUE' });
+      const components = executor.lifecycle.doOperationStub.firstCall.args[0];
+
+      expect(components.apiVersion).to.equal(getComponentsResult.apiVersion);
+    });
+
+    it('should use the registry api version by default', async () => {
       const executor = new TestDeployRetrieve();
       const registryApiVersion = registry.apiVersion;
       sb.stub(ConfigUtil, 'getConfigValue')


### PR DESCRIPTION
### What does this PR do?

Respects the overridden API version in an SFDX project when using the new deploy/retrieve logic. Note that deploying/retrieving with a manifest will always honor the version specified in the manifest - this is the CLI behavior.

### What issues does this PR fix or reference?
#3151, @W-9179305@

### Functionality Before

New deploy/retrieve logic always used the latest API version when using Org Browser or source paths.

### Functionality After

Now it only uses the latest if a version isn't overridden through SFDX configuration or with a manifest file's version.
