### PR TITLE
chore: change perms for installing change-case-management

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -445,7 +445,10 @@ jobs:
       - prepare-gus-environment-variables
       - restore_dependency_cache
       - gh-config
-      - release-management/install-change-case-mgmt
+      - run:
+          name: 'Setup gus case management'
+          command: |
+            sudo npm install -g @salesforce/change-case-management@latest
       - release-management/change-case-create
       - install
       - compile


### PR DESCRIPTION
### What does this PR do?
Due to permission issues within circleci, change to root user when installing the change case management dependency used by the npm-release-management-orb. Note that we used to use sudo for this step in the past as well. If this ends up being an unblocker, I will be reaching out to the CLI team.

### What issues does this PR fix or reference?
@W-9230973@

### Functionality Before
Errors during publishing when installing change-case-management:
https://app.circleci.com/pipelines/github/forcedotcom/salesforcedx-vscode/4667/workflows/01bd5e25-938c-468c-87ce-8ce5e9419908/jobs/20545

### Functionality After
Hopefully no errors during this step.
