### PR TITLE
chore: update change log date for v51.12.0

### DIFF
--- a/packages/salesforcedx-vscode/CHANGELOG.md
+++ b/packages/salesforcedx-vscode/CHANGELOG.md
@@ -37,7 +37,6 @@
 #### salesforcedx-vscode-core
 
 - Fix issues with the following types for deploy/retrieve library ([PR #3147](https://github.com/forcedotcom/salesforcedx-vscode/pull/3147), [Issue #3114](https://github.com/forcedotcom/salesforcedx-vscode/issues/3114), [Issue #3157](https://github.com/forcedotcom/salesforcedx-vscode/issues/3157)):
-
   - AccountRelationshipShareRule
   - TimeSheetTemplate
   - WaveDashboard

--- a/packages/salesforcedx-vscode/CHANGELOG.md
+++ b/packages/salesforcedx-vscode/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 51.12.0 - May 5, 2021
+# 51.12.0 - May 6, 2021
 
 ## Fixed
 
@@ -37,6 +37,7 @@
 #### salesforcedx-vscode-core
 
 - Fix issues with the following types for deploy/retrieve library ([PR #3147](https://github.com/forcedotcom/salesforcedx-vscode/pull/3147), [Issue #3114](https://github.com/forcedotcom/salesforcedx-vscode/issues/3114), [Issue #3157](https://github.com/forcedotcom/salesforcedx-vscode/issues/3157)):
+
   - AccountRelationshipShareRule
   - TimeSheetTemplate
   - WaveDashboard


### PR DESCRIPTION
### What does this PR do?
Updates the change log date for v51.12.0. 

Note this PR is mainly being used to pull in a new commit for the publishing process. The auth token being used by sf-change-case-management should hopefully be resolved once we can pull in a fresh commit.
