### PR TITLE
chore: add CLI_CTC context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -569,7 +569,9 @@ workflows:
           type: approval
       - publish:
           e: default-executor
-          context: pdt-publish-restricted-context
+          context:
+            - pdt-publish-restricted-context
+            - CLI_CTC
           requires:
             - build-all
             - unit-tests


### PR DESCRIPTION
### What does this PR do?
1. Adds the content CLI_CTC to our publish job. This will add the environment variable SF_CHANGE_CASE_SFDX_AUTH_URL. I am not 100% sure if our own value for SF_CHANGE_CASE_SCHEDULE_BUILD will override what's currently in CLI_CTC.
2. Removed the environment variable SF_CHANGE_CASE_SFDX_AUTH_URL from [CircleCi](https://app.circleci.com/settings/project/github/forcedotcom/salesforcedx-vscode/environment-variables?return-to=%2F). Note that previously this value ended in '.com', though I'm not sure what the actual value was.

This change should hopefully push us past some of the Change Case Management issues we have been seeing around authorization.

### What issues does this PR fix or reference?
@W-9237090@
