### PR TITLE
chore: add optional flag to attach profiler agent to apex ls

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/languageServer.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageServer.ts
@@ -63,6 +63,9 @@ async function createServer(
         '-Dtrace.protocol=false',
         `-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${JDWP_DEBUG_PORT},quiet=y`
       );
+      if (process.env.YOURKIT_PROFILER_AGENT) {
+        args.push(`-agentpath:${process.env.YOURKIT_PROFILER_AGENT}`);
+      }
     }
 
     args.push(APEX_LANGUAGE_SERVER_MAIN);


### PR DESCRIPTION
### What does this PR do?

Adds an optional flag that enables attaching the YourKit profiler agent through an environment variable. This is for internal development and debugging only.

### What issues does this PR fix or reference?

@W-9162876@
