### PR TITLE
feat: add analytics__Dashboard js-meta.xml support, and js-meta bug fixes

### DIFF
--- a/packages/salesforcedx-vscode-lwc/resources/static/js-meta.xsd
+++ b/packages/salesforcedx-vscode-lwc/resources/static/js-meta.xsd
@@ -276,6 +276,16 @@
               <xs:documentation>A datetime in ISO 8601 format. Supported only if the target is `lightning__FlowScreen`.</xs:documentation>
             </xs:annotation>
           </xs:enumeration>
+          <xs:enumeration value="Dimension">
+            <xs:annotation>
+              <xs:documentation>A dimension column from the results of the attached step. Supported only if hasStep is `true`.</xs:documentation>
+            </xs:annotation>
+          </xs:enumeration>
+          <xs:enumeration value="Measure">
+            <xs:annotation>
+              <xs:documentation>A measure column from the results of the attached step. Supported only if hasStep is `true`.</xs:documentation>
+            </xs:annotation>
+          </xs:enumeration>
         </xs:restriction>
       </xs:simpleType>
       <xs:simpleType>

--- a/packages/salesforcedx-vscode-lwc/resources/static/js-meta.xsd
+++ b/packages/salesforcedx-vscode-lwc/resources/static/js-meta.xsd
@@ -230,13 +230,84 @@
         <xs:documentation>Specifies whether the attribute is inputOnly or outputOnly. If you don’t specify the role attribute, the default value allows input and output. For example, if a property is restricted to outputOnly, users can’t set its value from a Lightning record page. Supported only if the target is lightning__FlowScreen. If you don’t set the role attribute, or if you set it to inputOnly, the property is exposed in a custom property editor. If you set it to outputOnly, the property isn’t exposed in a custom property editor.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute type="xs:string" name="type" use="required">
+    <xs:attribute type="propertyTypeAttr" name="type" use="required">
       <xs:annotation>
         <xs:documentation>The attribute’s data type. Please refer to the documentation for all supported types for different targets.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
-  <!-- property XSD-->
+  <!-- type attribute on property XSD -->
+  <xs:simpleType name="propertyTypeAttr">
+    <xs:union>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="Boolean">
+            <xs:annotation>
+              <xs:documentation>A boolean value.</xs:documentation>
+            </xs:annotation>
+          </xs:enumeration>
+          <xs:enumeration value="Integer">
+            <xs:annotation>
+              <xs:documentation>An integer value.</xs:documentation>
+            </xs:annotation>
+          </xs:enumeration>
+          <xs:enumeration value="String">
+            <xs:annotation>
+              <xs:documentation>A string value.</xs:documentation>
+            </xs:annotation>
+          </xs:enumeration>
+          <xs:enumeration value="Color">
+            <xs:annotation>
+              <xs:documentation>Displays a color selector. Use the default attribute to specify RGBA, RGB, or hex strings. Supported only if the target is `lightningCommunity__Default`.</xs:documentation>
+            </xs:annotation>
+          </xs:enumeration>
+          <xs:enumeration value="ContentReference">
+            <xs:annotation>
+              <xs:documentation>Displays a window in Experience Builder for selecting Salesforce CMS content. You can use the filter attribute to restrict the window contents to specific content types. Supported only if the target is `lightningCommunity__Default`.</xs:documentation>
+            </xs:annotation>
+          </xs:enumeration>
+          <xs:enumeration value="Date">
+            <xs:annotation>
+              <xs:documentation>A date in ISO 8601 format. Supported only if the target is `lightning__FlowScreen`.</xs:documentation>
+            </xs:annotation>
+          </xs:enumeration>
+          <xs:enumeration value="DateTime">
+            <xs:annotation>
+              <xs:documentation>A datetime in ISO 8601 format. Supported only if the target is `lightning__FlowScreen`.</xs:documentation>
+            </xs:annotation>
+          </xs:enumeration>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:pattern value="apex://.+">
+            <xs:annotation>
+              <xs:documentation>Apex class used for an Apex-defined data type. If the class is in the same namespace as the component, don’t specify a namespace. If the class is in a managed package, specify the namespace of the managed package. Supported only if the target is `lightning__FlowScreen`.</xs:documentation>
+            </xs:annotation>
+          </xs:pattern>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:pattern value="@salesforce/schema/.+">
+            <xs:annotation>
+              <xs:documentation>An object. If the object is in the same namespace as the component, don’t specify a namespace. If the object is in a managed package, specify the namespace of the managed package. Supported only if the target is `lightning__FlowScreen`.</xs:documentation>
+            </xs:annotation>
+          </xs:pattern>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:pattern value="\{.+\}">
+            <xs:annotation>
+              <xs:documentation>A reference to a named &lt; propertyType &gt; data type. Supported only if the target is `lightning__FlowScreen`.</xs:documentation>
+            </xs:annotation>
+          </xs:pattern>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <!-- propertyType XSD-->
   <xs:complexType name="propertyType">
     <xs:annotation>
       <xs:documentation>Defines a data type to extend for component properties in flow screen components. Only generic `sObject` and `sObject` collection data types can be extended. Supported only if the target is `lightning__FlowScreen`.</xs:documentation>

--- a/packages/salesforcedx-vscode-lwc/resources/static/js-meta.xsd
+++ b/packages/salesforcedx-vscode-lwc/resources/static/js-meta.xsd
@@ -190,6 +190,11 @@
         <xs:documentation>Displays as an i-bubble for the attribute in the tool.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute type="xs:string" name="filter" use="optional">
+      <xs:annotation>
+        <xs:documentation>Specifies the Salesforce CMS content types to display in the component in Experience Builder. Supported only if the target is `lightningCommunity__Default` and the type is `ContentReference`.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
     <xs:attribute type="xs:string" name="label" use="optional">
       <xs:annotation>
         <xs:documentation>Displays as a label for the attribute in the tool.</xs:documentation>
@@ -228,6 +233,32 @@
     <xs:attribute type="xs:string" name="type" use="required">
       <xs:annotation>
         <xs:documentation>The attribute’s data type. Please refer to the documentation for all supported types for different targets.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <!-- property XSD-->
+  <xs:complexType name="propertyType">
+    <xs:annotation>
+      <xs:documentation>Defines a data type to extend for component properties in flow screen components. Only generic `sObject` and `sObject` collection data types can be extended. Supported only if the target is `lightning__FlowScreen`.</xs:documentation>
+    </xs:annotation>
+    <xs:attribute type="xs:string" name="extends" use="required">
+      <xs:annotation>
+        <xs:documentation>Specifies the data type to extend for component properties.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute type="xs:string" name="description" use="optional">
+      <xs:annotation>
+        <xs:documentation>Description of the property type.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute type="xs:string" name="label" use="optional">
+      <xs:annotation>
+        <xs:documentation>Label of the property type.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute type="xs:string" name="name" use="required">
+      <xs:annotation>
+        <xs:documentation>Specifies the data type name to reference from each type attribute that is defined in a component’s property subtag.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
@@ -292,6 +323,7 @@
           <xs:annotation>
             <xs:documentation>Use a separate targetConfig for each different page type configuration.</xs:documentation>
           </xs:annotation>
+          <!-- These are really allowed to be unordered in the server, but xsd doesn't support unordered child elements with some being optional and some being unbounded -->
           <xs:sequence>
             <xs:element type="xs:boolean" name="hasStep" minOccurs="0">
               <xs:annotation>
@@ -299,7 +331,11 @@
               </xs:annotation>
             </xs:element>
             <xs:element type="objects" name="objects" minOccurs="0" />
-            <xs:element type="property" name="property" minOccurs="0" maxOccurs="unbounded" />
+            <!-- Do allow these unbounded ones to be unordered, which makes the propertyType example in the docs validate -->
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:element type="property" name="property" />
+              <xs:element type="propertyType" name="propertyType" />
+            </xs:choice>
             <xs:element type="supportedFormFactors" name="supportedFormFactors" minOccurs="0" />
           </xs:sequence>
           <xs:attribute type="xs:string" name="configurationEditor" use="optional">

--- a/packages/salesforcedx-vscode-lwc/resources/static/js-meta.xsd
+++ b/packages/salesforcedx-vscode-lwc/resources/static/js-meta.xsd
@@ -136,9 +136,8 @@
               <xs:annotation>
                 <xs:documentation>Enables a custom chat header component to be selected from Embedded Service Chat Setup. A component that imports the lightningsnapin/baseChatHeader module must specify that lightningSnapin__ChatHeader target. For more information, see the lightningsnapin/baseChatHeader documentation.</xs:documentation>
               </xs:annotation>
-
             </xs:enumeration>
-             <xs:enumeration value="lightning__RecordAction">
+            <xs:enumeration value="lightning__RecordAction">
               <xs:annotation>
                 <xs:documentation>Makes Lightning web component record action available for quick action.</xs:documentation>
               </xs:annotation>
@@ -146,6 +145,11 @@
             <xs:enumeration value="lightning__GlobalAction">
               <xs:annotation>
                 <xs:documentation>Makes Lightning web component global action available for quick action.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="analytics__Dashboard">
+              <xs:annotation>
+                <xs:documentation>Enables a component for use in Tableau CRM dashboards. This feature is currently in pilot in Spring and Summer '21 releases. If you're interested in participating in the pilot program, ask your Salesforce Account Executive.</xs:documentation>
               </xs:annotation>
             </xs:enumeration>
           </xs:restriction>
@@ -289,6 +293,11 @@
             <xs:documentation>Use a separate targetConfig for each different page type configuration.</xs:documentation>
           </xs:annotation>
           <xs:sequence>
+            <xs:element type="xs:boolean" name="hasStep" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>Specify that your component requires an attached step to function as expected. Only valid for `analytics__Dashboard` targets. When set to `true`, the Tableau CRM dashboard builder UI prompts you to attach an existing step or create a new step when creating an instance of your component. Components with an attached step have access to step-specific properties like `results` and `selection`.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
             <xs:element type="objects" name="objects" minOccurs="0" />
             <xs:element type="property" name="property" minOccurs="0" maxOccurs="unbounded" />
             <xs:element type="supportedFormFactors" name="supportedFormFactors" minOccurs="0" />

--- a/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
@@ -101,7 +101,7 @@ export const messages = {
   force_lightning_lwc_deprecated_redhat_extension:
     'Salesforce js-meta.xml IntelliSense requires the Red Hat XML extension version >= 0.14.0. Upgrade the Red Hat XML extension.',
   force_lightning_lwc_redhat_extension_regression:
-    'Salesforce js-meta.xml IntelliSense does not work with Red Hat XML extension version 0.15.0. Downgrade the Red Hat XML extension to 0.14.0.',
+    'Salesforce js-meta.xml IntelliSense does not work with Red Hat XML extension version 0.15.0. Upgrade the Red Hat XML extension.',
   force_lightning_lwc_fail_redhat_extension:
     'Failed to setup Red Hat XML extension'
 };

--- a/packages/salesforcedx-vscode-lwc/src/metasupport/metaSupport.ts
+++ b/packages/salesforcedx-vscode-lwc/src/metasupport/metaSupport.ts
@@ -80,14 +80,11 @@ export class MetaSupport {
     } else if (redHatExtension) {
       const pluginVersionNumber = redHatExtension!.packageJSON['version'];
 
-      // checks if the installed plugin version is exactly 0.14.0
+      // checks if the installed plugin version is exactly 0.14.0 or 0.16+,
       // 0.15.0 has a regression and 0.13.0 or earlier versions are not supported
-
-      if (parseInt(pluginVersionNumber.split('.')[1], 10) === 15) {
-        channelService.appendLine(
-          nls.localize('force_lightning_lwc_redhat_extension_regression')
-        );
-      } else if (parseInt(pluginVersionNumber.split('.')[1], 10) === 14) {
+      const major = parseInt(pluginVersionNumber.split('.')[0], 10);
+      const minor = parseInt(pluginVersionNumber.split('.')[1], 10);
+      if (major >= 1 || minor === 14 || minor >= 16) {
         const catalogs = this.getLocalFilePath(['js-meta-home.xml']);
         const fileAssociations = [
           {
@@ -96,6 +93,10 @@ export class MetaSupport {
           }
         ];
         await this.setupRedhatXml(catalogs, fileAssociations);
+      } else if (minor === 15) {
+        channelService.appendLine(
+          nls.localize('force_lightning_lwc_redhat_extension_regression')
+        );
       } else {
         channelService.appendLine(
           nls.localize('force_lightning_lwc_deprecated_redhat_extension')

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/metaSupport/metaSupport.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/metaSupport/metaSupport.test.ts
@@ -82,54 +82,56 @@ describe('MetaSupport: Extension not found', () => {
   });
 });
 
-describe('MetaSupport: Extension function', () => {
-  beforeEach(() => {
-    rhExtension = new MockRedhatExtension('0.14.0');
-    mockRhExtension = sandbox
-      .stub(extensions, 'getExtension')
-      .returns(rhExtension);
-  });
+['0.14.0', '0.16.0', '1.0.0'].forEach(rhExtensionVersion => {
+  describe(`MetaSupport: Extension v${rhExtensionVersion} function`, () => {
+    beforeEach(() => {
+      rhExtension = new MockRedhatExtension(rhExtensionVersion);
+      mockRhExtension = sandbox
+        .stub(extensions, 'getExtension')
+        .returns(rhExtension);
+    });
 
-  afterEach(() => {
-    sandbox.restore();
-  });
+    afterEach(() => {
+      sandbox.restore();
+    });
 
-  it('Should pass correct catalog path to XML extension', async () => {
-    await metaSupport.getMetaSupport();
+    it('Should pass correct catalog path to XML extension', async () => {
+      await metaSupport.getMetaSupport();
 
-    const catalogPaths = [
-      path.join(
+      const catalogPaths = [
+        path.join(
+          'extension',
+          'local',
+          'path',
+          'resources',
+          'static',
+          'js-meta-home.xml'
+        )
+      ];
+      assert.strictEqual(rhExtension.api.listOfCatalogs[0], catalogPaths[0]);
+    });
+
+    it('Should pass correct file association path to XML extension', async () => {
+      await metaSupport.getMetaSupport();
+
+      const systemId = path.join(
         'extension',
         'local',
         'path',
         'resources',
         'static',
-        'js-meta-home.xml'
-      )
-    ];
-    assert.strictEqual(rhExtension.api.listOfCatalogs[0], catalogPaths[0]);
-  });
+        'js-meta.xsd'
+      );
+      const pattern = '**/*js-meta.xml';
 
-  it('Should pass correct file association path to XML extension', async () => {
-    await metaSupport.getMetaSupport();
-
-    const systemId = path.join(
-      'extension',
-      'local',
-      'path',
-      'resources',
-      'static',
-      'js-meta.xsd'
-    );
-    const pattern = '**/*js-meta.xml';
-
-    assert.strictEqual(
-      rhExtension.api.listOfAssociations[0]['systemId'],
-      systemId
-    );
-    assert.strictEqual(
-      rhExtension.api.listOfAssociations[0]['pattern'],
-      pattern
-    );
+      assert.strictEqual(
+        rhExtension.api.listOfAssociations[0]['systemId'],
+        systemId
+      );
+      assert.strictEqual(
+        rhExtension.api.listOfAssociations[0]['pattern'],
+        pattern
+      );
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
This updates the js-meta.xml schema support:
- Adds `analytics__Dashboard` js-meta.xml support, for the new LWC's in analytics dashboard feature. This includes the `Dimension` and `Measure` `type`'s in `<property>`.
- Updated the js-meta.xml feature's checking of the vscode-xml extension version -- it appears that the bug that broke 0.15.0 got fixed in 0.16.0
- Adds missing fields: `<propertyType>`, `filter` on `<property>`
- Adds typing to `type` on `<property>`

### What issues does this PR fix or reference?
@W-9191640@, @W-8852786@

### Functionality Before
- You would get a schema error in the editor if you used `<target>analytics__Dashboard</target>` or used `<hasStep>` in a `<targetConfig>`.
- You didn't get code-completion for `analytics__Dashboard`, nor hover text
- You would get schema error on `<propertyType>` and `filter`.
- You got a wrong output channel message if you had 0.16.0 of vscode-xml installed, and the schema extensions for `js-meta.xml` files didn't work.

### Functionality After
That all works now.
