### PR TITLE
feat: enable conflict UI for folder diff @W-9166602@

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -212,6 +212,10 @@
           "when": "explorerResourceIsFolder && resourceFilename == classes && sfdx:project_opened"
         },
         {
+          "command": "sfdx.force.folder.diff",
+          "when": "explorerResourceIsFolder && resourceFilename =~ /applications|aura|classes|components|contentassets|flexipages|layouts|lwc|objects|pages|permissionsets|staticresources|tabs|triggers$/ && sfdx:project_opened"
+        },
+        {
           "command": "sfdx.force.analytics.template.create",
           "when": "explorerResourceIsFolder && resourceFilename == waveTemplates && sfdx:project_opened"
         },
@@ -807,6 +811,10 @@
       {
         "command": "sfdx.force.diff",
         "title": "%force_diff_against_org%"
+      },
+      {
+        "command": "sfdx.force.folder.diff",
+        "title": "%force_diff_folder_against_org%"
       },
       {
         "command": "sfdx.force.conflict.open",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -213,7 +213,7 @@
         },
         {
           "command": "sfdx.force.folder.diff",
-          "when": "explorerResourceIsFolder && resourceFilename =~ /applications|aura|classes|components|contentassets|flexipages|layouts|lwc|objects|pages|permissionsets|staticresources|tabs|triggers$/ && sfdx:project_opened"
+          "when": "explorerResourceIsFolder && sfdx:project_opened"
         },
         {
           "command": "sfdx.force.analytics.template.create",

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -62,6 +62,7 @@
   "force_source_retrieve_display_text": "Retrieve Source from Org",
   "force_source_retrieve_and_open_display_text": "Retrieve and Open Source",
   "force_diff_against_org": "SFDX: Diff File Against Org",
+  "force_diff_folder_against_org": "SFDX: Diff Folder Against Org",
   "force_analytics_template_create_text": "SFDX: Create Sample Analytics Template",
   "experimental_deploy_retrieve_description": "Use library for deploy and retrieve commands instead of the CLI",
   "force_function_create": "SFDX: Create Function",

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDiff.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDiff.ts
@@ -5,14 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { StreamingMockSubscriptionCall } from '@salesforce/core/lib/testSetup';
-import {
-  CliCommandExecutor,
-  Command,
-  DiffResultParser,
-  SfdxCommandBuilder
-} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
-import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import { SourceComponent } from '@salesforce/source-deploy-retrieve';
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -29,68 +21,6 @@ import { telemetryService } from '../telemetry';
 import { FilePathGatherer, SfdxCommandlet, SfdxWorkspaceChecker } from './util';
 
 const workspaceChecker = new SfdxWorkspaceChecker();
-
-/**
- * Perform file diff and execute VS Code diff comand to show in UI.
- * It matches the correspondent file in compoennt.
- * @param localFile local file
- * @param remoteComponent remote source component
- * @returns {Promise<void>}
- */
-async function diffFile(
-  localFile: string,
-  remoteComponent: SourceComponent
-): Promise<void> {
-  const filePart = path.basename(localFile);
-  const defaultUsernameorAlias =
-    workspaceContext.alias || workspaceContext.username;
-
-  const remoteFilePaths = remoteComponent.walkContent();
-  if (remoteComponent.xml) {
-    remoteFilePaths.push(remoteComponent.xml);
-  }
-  for (const filePath of remoteFilePaths) {
-    if (filePath.endsWith(filePart)) {
-      const remoteUri = vscode.Uri.file(filePath);
-      const localUri = vscode.Uri.file(localFile);
-
-      try {
-        await vscode.commands.executeCommand(
-          'vscode.diff',
-          remoteUri,
-          localUri,
-          nls.localize(
-            'force_source_diff_title',
-            defaultUsernameorAlias,
-            filePart,
-            filePart
-          )
-        );
-      } catch (err) {
-        notificationService.showErrorMessage(err.message);
-        channelService.appendLine(err.message);
-        channelService.showChannelOutput();
-        telemetryService.sendException(err.name, err.message);
-      }
-      return;
-    }
-  }
-}
-
-async function handleCacheResults(cache?: MetadataCacheResult): Promise<void> {
-  if (cache) {
-    if (!cache.selectedIsDirectory && cache.cache.components) {
-      // file
-      await diffFile(cache.selectedPath, cache.cache.components[0]);
-    } else {
-      // directory
-    }
-  } else {
-    const message = nls.localize('force_source_diff_remote_not_found');
-    notificationService.showErrorMessage(message);
-    throw new Error(message);
-  }
-}
 
 export async function forceSourceDiff(sourceUri?: vscode.Uri) {
   if (!sourceUri) {
@@ -161,7 +91,7 @@ export async function forceSourceFolderDiff(explorerPath: vscode.Uri) {
 export async function handleCacheResults(username: string, cache?: MetadataCacheResult): Promise<void> {
   if (cache) {
     if (!cache.selectedIsDirectory && cache.cache.components) {
-      await conflictDetectionService.diffOneFile(cache.selectedPath, cache.cache.components[0]);
+      await conflictDetectionService.diffOneFile(cache.selectedPath, cache.cache.components[0], username);
     } else if (cache.selectedIsDirectory) {
       await conflictDetectionService.diffFolder(cache, username);
     }

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDiff.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDiff.ts
@@ -20,7 +20,7 @@ import * as conflictDetectionService from '../conflict/conflictDetectionService'
 import {
   MetadataCacheExecutor,
   MetadataCacheResult
-} from '../conflict/metadataCacheService';
+} from '../conflict';
 import { workspaceContext } from '../context';
 import { nls } from '../messages';
 import { notificationService, ProgressNotification } from '../notifications';
@@ -173,7 +173,7 @@ export async function forceSourceFolderDiff(explorerPath: vscode.Uri) {
 
   const username = workspaceContext.username;
   if (!username) {
-    notificationService.showErrorMessage('No default org');
+    notificationService.showErrorMessage(nls.localize('missing_default_org'));
     return;
   }
 

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDiff.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDiff.ts
@@ -16,11 +16,11 @@ import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { channelService } from '../channels';
-import * as conflictDetectionService from '../conflict/conflictDetectionService';
 import {
   MetadataCacheExecutor,
   MetadataCacheResult
 } from '../conflict';
+import * as conflictDetectionService from '../conflict/conflictDetectionService';
 import { workspaceContext } from '../context';
 import { nls } from '../messages';
 import { notificationService, ProgressNotification } from '../notifications';

--- a/packages/salesforcedx-vscode-core/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/index.ts
@@ -143,8 +143,10 @@ export {
 export { forceSourceRetrieveCmp } from './forceSourceRetrieveMetadata';
 export {
   forceSourceDiff,
+  forceSourceFolderDiff,
   ForceSourceDiffExecutor,
-  handleDiffResponse
+  handleDiffResponse,
+  handleCacheResults
 } from './forceSourceDiff';
 export { forceOrgList } from './forceOrgList';
 export { forceOrgDelete } from './forceOrgDelete';

--- a/packages/salesforcedx-vscode-core/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/index.ts
@@ -144,8 +144,6 @@ export { forceSourceRetrieveCmp } from './forceSourceRetrieveMetadata';
 export {
   forceSourceDiff,
   forceSourceFolderDiff,
-  ForceSourceDiffExecutor,
-  handleDiffResponse,
   handleCacheResults
 } from './forceSourceDiff';
 export { forceOrgList } from './forceOrgList';

--- a/packages/salesforcedx-vscode-core/src/conflict/conflictDetectionService.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/conflictDetectionService.ts
@@ -283,7 +283,7 @@ export async function diffFolder(cache: MetadataCacheResult, username: string) {
   const diffs = differ.diff(localPath, remotePath);
 
   conflictView.visualizeDifferences(
-    'PDTDevHub - File Diffs',
+    nls.localize('force_source_diff_folder_title', username),
     username,
     true,
     diffs

--- a/packages/salesforcedx-vscode-core/src/conflict/index.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/index.ts
@@ -13,7 +13,9 @@ import { ConflictFile, ConflictNode } from './conflictNode';
 import { ConflictView } from './conflictView';
 export {
   ConflictDetectionConfig,
-  ConflictDetector
+  ConflictDetector,
+  diffFolder,
+  diffOneFile
 } from './conflictDetectionService';
 export {
   CommonDirDirectoryDiffer,
@@ -65,6 +67,6 @@ function openResource(node: ConflictNode) {
   const file = node.conflict;
   if (file) {
     const local = Uri.file(path.join(file.localPath, file.relPath));
-    window.showTextDocument(local).then(() => {});
+    window.showTextDocument(local).then(() => { });
   }
 }

--- a/packages/salesforcedx-vscode-core/src/conflict/index.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/index.ts
@@ -22,6 +22,13 @@ export {
   DirectoryDiffer,
   DirectoryDiffResults
 } from './directoryDiffer';
+export {
+  MetadataCacheCallback,
+  MetadataCacheExecutor,
+  MetadataCacheResult,
+  MetadataCacheService,
+  MetadataContext
+} from './metadataCacheService';
 export const conflictView = ConflictView.getInstance();
 export const conflictDetector = ConflictDetector.getInstance();
 

--- a/packages/salesforcedx-vscode-core/src/conflict/metadataCacheService.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/metadataCacheService.ts
@@ -241,12 +241,13 @@ export class MetadataCacheService {
 }
 
 export type MetadataCacheCallback = (
-  cache: MetadataCacheResult | undefined
+  username: string, cache: MetadataCacheResult | undefined
 ) => Promise<void>;
 
 export class MetadataCacheExecutor extends RetrieveExecutor<string> {
   private cacheService: MetadataCacheService;
   private callback: MetadataCacheCallback;
+  private username: string;
 
   constructor(
     username: string,
@@ -256,6 +257,7 @@ export class MetadataCacheExecutor extends RetrieveExecutor<string> {
   ) {
     super(executionName, logName);
     this.callback = callback;
+    this.username = username;
     this.cacheService = new MetadataCacheService(username);
   }
 
@@ -279,6 +281,6 @@ export class MetadataCacheExecutor extends RetrieveExecutor<string> {
     const cache:
       | MetadataCacheResult
       | undefined = await this.cacheService.processResults(result);
-    await this.callback(cache);
+    await this.callback(this.username, cache);
   }
 }

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -49,6 +49,7 @@ import {
   forceSourceDeployMultipleSourcePaths,
   forceSourceDeploySourcePath,
   forceSourceDiff,
+  forceSourceFolderDiff,
   forceSourcePull,
   forceSourcePush,
   forceSourceRetrieveCmp,
@@ -320,6 +321,11 @@ function registerCommands(
   const forceDiffFile = vscode.commands.registerCommand(
     'sfdx.force.diff',
     forceSourceDiff
+  );
+
+  const forceDiffFolder = vscode.commands.registerCommand(
+    'sfdx.force.folder.diff',
+    forceSourceFolderDiff
   );
 
   const forceFunctionCreateCmd = vscode.commands.registerCommand(
@@ -631,8 +637,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Refresh SObject definitions if there aren't any faux classes
   const sobjectRefreshStartup: boolean = vscode.workspace
-  .getConfiguration(SFDX_CORE_CONFIGURATION_NAME)
-  .get<boolean>(ENABLE_SOBJECT_REFRESH_ON_STARTUP, false);
+    .getConfiguration(SFDX_CORE_CONFIGURATION_NAME)
+    .get<boolean>(ENABLE_SOBJECT_REFRESH_ON_STARTUP, false);
 
   if (sobjectRefreshStartup) {
     initSObjectDefinitions(

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -564,6 +564,7 @@ export const messages = {
   force_source_diff_unsupported_type:
     'Diff for this metadata type is currently not supported',
   force_source_diff_title: '%s//%s ↔ local//%s',
+  force_source_diff_folder_title: '%s - File Diffs',
   force_source_diff_command_not_found:
     'To run this command, first install the @salesforce/sfdx-diff plugin. For more info, see [https://forcedotcom.github.io/salesforcedx-vscode/articles/user-guide/source-diff](https://forcedotcom.github.io/salesforcedx-vscode/articles/user-guide/source-diff).',
   beta_tapi_mdcontainer_error: 'Unexpected error creating metadata container',

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -589,5 +589,6 @@ export const messages = {
   force_sobjects_refresh: 'SFDX: Refresh SObject Definitions',
   sobject_refresh_all: 'All SObjects',
   sobject_refresh_custom: 'Custom SObjects',
-  sobject_refresh_standard: 'Standard SObjects'
+  sobject_refresh_standard: 'Standard SObjects',
+  force_source_diff_components_not_in_org: 'Selected components are not available in the org'
 };

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDiff.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDiff.test.ts
@@ -141,7 +141,7 @@ describe('Force Source Diff', () => {
         match.has('fsPath', localFsPath),
         nls.localize(
           'force_source_diff_title',
-          mockAlias,
+          mockUsername,
           'mockFile.cls',
           'mockFile.cls'
         )

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDiff.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDiff.test.ts
@@ -7,92 +7,139 @@
 
 import { expect } from 'chai';
 import * as path from 'path';
-import { SinonStub, stub } from 'sinon';
+import { SinonSpy, SinonStub, stub } from 'sinon';
 import { commands, Uri } from 'vscode';
 import { channelService } from '../../../src/channels';
 import {
   ForceSourceDiffExecutor,
   handleDiffResponse
 } from '../../../src/commands';
+import * as conflictCommands from '../../../src/commands';
+import * as conflictDetectionService from '../../../src/conflict/conflictDetectionService';
+import { MetadataCacheResult, MetadataContext } from '../../../src/conflict/metadataCacheService';
 import { nls } from '../../../src/messages';
 import { notificationService } from '../../../src/notifications';
+import Sinon = require('sinon');
 
-// tslint:disable:no-unused-expression
 describe('Force Source Diff', () => {
-  let appendLineStub: SinonStub;
-  let uriFileSpy: SinonStub;
-  let vscodeDiffSpy: SinonStub;
-  let notificationStub: SinonStub;
 
-  beforeEach(() => {
-    appendLineStub = stub(channelService, 'appendLine');
-    uriFileSpy = stub(Uri, 'file');
-    vscodeDiffSpy = stub(commands, 'executeCommand');
-    notificationStub = stub(notificationService, 'showErrorMessage');
+  // tslint:disable:no-unused-expression
+  describe('Force Source Diff Using Plugin', () => {
+    let appendLineStub: SinonStub;
+    let uriFileSpy: SinonStub;
+    let vscodeDiffSpy: SinonStub;
+    let notificationStub: SinonStub;
+
+    beforeEach(() => {
+      appendLineStub = stub(channelService, 'appendLine');
+      uriFileSpy = stub(Uri, 'file');
+      vscodeDiffSpy = stub(commands, 'executeCommand');
+      notificationStub = stub(notificationService, 'showErrorMessage');
+    });
+
+    afterEach(() => {
+      appendLineStub.restore();
+      uriFileSpy.restore();
+      vscodeDiffSpy.restore();
+      notificationStub.restore();
+    });
+
+    it('Should build the source diff command', () => {
+      const apexTestClassPath = path.join('path', 'to', 'apex', 'testApex.cls');
+      const sourceDiff = new ForceSourceDiffExecutor();
+      const sourceDiffCommand = sourceDiff.build(apexTestClassPath);
+      expect(sourceDiffCommand.toCommand()).to.equal(
+        `sfdx force:source:diff --sourcepath ${apexTestClassPath} --json --loglevel fatal`
+      );
+      expect(sourceDiffCommand.description).to.equal(
+        nls.localize('force_source_diff_text')
+      );
+    });
+
+    it('Should handle successful diff response', async () => {
+      const diffSuccessfulResponse = {
+        status: 0,
+        result: {
+          remote:
+            '/Users/testUser/testProject/.sfdx/orgs/user@example.com/diffCache/classes/testClass.cls',
+          local:
+            '/Users/testUser/testProject/force-app/main/default/classes/testClass.cls',
+          fileName: 'testClass.cls'
+        }
+      };
+      await handleDiffResponse(0, JSON.stringify(diffSuccessfulResponse));
+      expect(uriFileSpy.calledTwice).to.be.true;
+      expect(vscodeDiffSpy.calledOnce).to.be.true;
+      expect(vscodeDiffSpy.getCall(0).args[0]).to.equal('vscode.diff');
+    });
+
+    it('Should handle errors from diff reponse', async () => {
+      const diffErrorResponse = {
+        status: 1,
+        name: 'Error',
+        message:
+          'The path could not be found in the project. Specify a path that exists in the file system.',
+        exitCode: 1,
+        commandName: 'Diff',
+        stack:
+          'Error: The path could not be found in the project. Specify a path that exists in the file system.',
+        warnings: {}
+      };
+      await handleDiffResponse(0, JSON.stringify(diffErrorResponse));
+      expect(uriFileSpy.calledTwice).to.be.false;
+      expect(vscodeDiffSpy.calledOnce).to.be.false;
+      expect(appendLineStub.called).to.be.true;
+    });
+
+    it('Should display error message when diff plugin is not installed', async () => {
+      await handleDiffResponse(127, '');
+      expect(uriFileSpy.notCalled).to.be.true;
+      expect(vscodeDiffSpy.notCalled).to.be.true;
+      expect(appendLineStub.called).to.be.true;
+      expect(notificationStub.calledOnce).to.be.true;
+      expect(notificationStub.getCall(0).args[0]).to.equal(
+        nls.localize('force_source_diff_command_not_found')
+      );
+    });
   });
 
-  afterEach(() => {
-    appendLineStub.restore();
-    uriFileSpy.restore();
-    vscodeDiffSpy.restore();
-    notificationStub.restore();
-  });
+  describe('Force Source Folder Diff', () => {
+    let notificationStub: SinonStub;
+    let diffOneFileStub: SinonSpy;
+    let diffFolderStub: SinonSpy;
 
-  it('Should build the source diff command', () => {
-    const apexTestClassPath = path.join('path', 'to', 'apex', 'testApex.cls');
-    const sourceDiff = new ForceSourceDiffExecutor();
-    const sourceDiffCommand = sourceDiff.build(apexTestClassPath);
-    expect(sourceDiffCommand.toCommand()).to.equal(
-      `sfdx force:source:diff --sourcepath ${apexTestClassPath} --json --loglevel fatal`
-    );
-    expect(sourceDiffCommand.description).to.equal(
-      nls.localize('force_source_diff_text')
-    );
-  });
+    beforeEach(() => {
+      notificationStub = stub(notificationService, 'showErrorMessage');
+      diffOneFileStub = stub(conflictDetectionService, 'diffOneFile');
+      diffFolderStub = stub(conflictDetectionService, 'diffFolder');
+    });
 
-  it('Should handle successful diff response', async () => {
-    const diffSuccessfulResponse = {
-      status: 0,
-      result: {
-        remote:
-          '/Users/testUser/testProject/.sfdx/orgs/user@example.com/diffCache/classes/testClass.cls',
-        local:
-          '/Users/testUser/testProject/force-app/main/default/classes/testClass.cls',
-        fileName: 'testClass.cls'
-      }
-    };
-    await handleDiffResponse(0, JSON.stringify(diffSuccessfulResponse));
-    expect(uriFileSpy.calledTwice).to.be.true;
-    expect(vscodeDiffSpy.calledOnce).to.be.true;
-    expect(vscodeDiffSpy.getCall(0).args[0]).to.equal('vscode.diff');
-  });
+    afterEach(() => {
+      notificationStub.restore();
+      diffOneFileStub.restore();
+      diffFolderStub.restore();
+    });
 
-  it('Should handle errors from diff reponse', async () => {
-    const diffErrorResponse = {
-      status: 1,
-      name: 'Error',
-      message:
-        'The path could not be found in the project. Specify a path that exists in the file system.',
-      exitCode: 1,
-      commandName: 'Diff',
-      stack:
-        'Error: The path could not be found in the project. Specify a path that exists in the file system.',
-      warnings: {}
-    };
-    await handleDiffResponse(0, JSON.stringify(diffErrorResponse));
-    expect(uriFileSpy.calledTwice).to.be.false;
-    expect(vscodeDiffSpy.calledOnce).to.be.false;
-    expect(appendLineStub.called).to.be.true;
-  });
+    it('Should throw error for empty cache', async () => {
+      await conflictCommands.handleCacheResults('username', undefined);
+      expect(notificationStub.calledOnce).to.be.true;
+      expect(notificationStub.getCall(0).args[0]).to.equal(
+        nls.localize('force_source_diff_components_not_in_org')
+      );
+    });
 
-  it('Should display error message when diff plugin is not installed', async () => {
-    await handleDiffResponse(127, '');
-    expect(uriFileSpy.notCalled).to.be.true;
-    expect(vscodeDiffSpy.notCalled).to.be.true;
-    expect(appendLineStub.called).to.be.true;
-    expect(notificationStub.calledOnce).to.be.true;
-    expect(notificationStub.getCall(0).args[0]).to.equal(
-      nls.localize('force_source_diff_command_not_found')
-    );
+    it('Should diff one file', async () => {
+      const metadataCache: MetadataContext = { baseDirectory: '.', commonRoot: '.', components: [] };
+      const cacheResult: MetadataCacheResult = { selectedIsDirectory: false, selectedPath: '.', cache: metadataCache, project: metadataCache };
+      await conflictCommands.handleCacheResults('username', cacheResult);
+      expect(diffOneFileStub.calledOnce).to.be.true;
+    });
+
+    it('Should diff folder', async () => {
+      const metadataCache: MetadataContext = { baseDirectory: '.', commonRoot: '.', components: [] };
+      const cacheResult: MetadataCacheResult = { selectedIsDirectory: true, selectedPath: '.', cache: metadataCache, project: metadataCache };
+      await conflictCommands.handleCacheResults('username', cacheResult);
+      expect(diffFolderStub.calledOnce).to.be.true;
+    });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDiff.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDiff.test.ts
@@ -13,13 +13,9 @@ import * as vscode from 'vscode';
 import { commands, Uri } from 'vscode';
 import { channelService } from '../../../src/channels';
 import { forceSourceDiff } from '../../../src/commands';
-import {
-  ForceSourceDiffExecutor,
-  handleDiffResponse
-} from '../../../src/commands';
 import * as conflictCommands from '../../../src/commands';
 import * as conflictDetectionService from '../../../src/conflict/conflictDetectionService';
-import { MetadataCacheResult, MetadataContext } from '../../../src/conflict/metadataCacheService';
+import { MetadataCacheResult, MetadataCacheService, MetadataContext } from '../../../src/conflict/metadataCacheService';
 import { nls } from '../../../src/messages';
 import { notificationService } from '../../../src/notifications';
 import Sinon = require('sinon');
@@ -27,182 +23,218 @@ import {
   FilePathGatherer,
   SfdxWorkspaceChecker
 } from '../../../src/commands/util';
-import {
-  MetadataCacheResult,
-  MetadataCacheService
-} from '../../../src/conflict/metadataCacheService';
 import { workspaceContext } from '../../../src/context';
-import { nls } from '../../../src/messages';
-import { notificationService } from '../../../src/notifications';
 import { telemetryService } from '../../../src/telemetry';
 
 const sandbox = createSandbox();
 
 describe('Force Source Diff', () => {
-  const mockAlias = 'vscodeOrg';
-  const mockUsername = 'admin@ut-sandbox.org';
-  const mockFilePath = path.join(
-    '/projects/trailheadapps/lwc-recipes/force-app/main/default/classes/mockFile.cls'
-  );
-  let vscodeExecuteCommandStub: SinonStub;
-  let workspaceContextAliasStub: SinonStub;
-  let workspaceContextUsernameStub: SinonStub;
-  let workspaceCheckerStub: SinonStub;
-  let filePathGathererStub: SinonStub;
-  let componentStub: sinon.SinonStub;
-  let operationStub: sinon.SinonStub;
-  let processStub: sinon.SinonStub;
-  let notificationStub: SinonStub;
-  let channelAppendLineStub: SinonStub;
-  let channelShowChannelOutputStub: SinonStub;
-  let mockComponentWalkContentStub: SinonStub;
-  let telemetryServiceSendExceptionStub: SinonStub;
+  describe('Force Source File Diff', () => {
+    const mockAlias = 'vscodeOrg';
+    const mockUsername = 'admin@ut-sandbox.org';
+    const mockFilePath = path.join(
+      '/projects/trailheadapps/lwc-recipes/force-app/main/default/classes/mockFile.cls'
+    );
+    let vscodeExecuteCommandStub: SinonStub;
+    let workspaceContextAliasStub: SinonStub;
+    let workspaceContextUsernameStub: SinonStub;
+    let workspaceCheckerStub: SinonStub;
+    let filePathGathererStub: SinonStub;
+    let componentStub: sinon.SinonStub;
+    let operationStub: sinon.SinonStub;
+    let processStub: sinon.SinonStub;
+    let notificationStub: SinonStub;
+    let channelAppendLineStub: SinonStub;
+    let channelShowChannelOutputStub: SinonStub;
+    let mockComponentWalkContentStub: SinonStub;
+    let telemetryServiceSendExceptionStub: SinonStub;
 
-  beforeEach(() => {
-    workspaceContextUsernameStub = sandbox
-      .stub(workspaceContext, 'username')
-      .get(() => {
-        return mockUsername;
+    beforeEach(() => {
+      workspaceContextUsernameStub = sandbox
+        .stub(workspaceContext, 'username')
+        .get(() => {
+          return mockUsername;
+        });
+      workspaceContextAliasStub = sandbox
+        .stub(workspaceContext, 'alias')
+        .get(() => {
+          return mockAlias;
+        });
+      workspaceCheckerStub = sandbox.stub(
+        SfdxWorkspaceChecker.prototype,
+        'check'
+      );
+      workspaceCheckerStub.returns(true);
+      filePathGathererStub = sandbox.stub(FilePathGatherer.prototype, 'gather');
+      filePathGathererStub.returns({ type: 'CONTINUE', data: mockFilePath });
+      operationStub = sandbox.stub(
+        MetadataCacheService.prototype,
+        'createRetrieveOperation'
+      );
+      componentStub = sandbox.stub(
+        MetadataCacheService.prototype,
+        'getSourceComponents'
+      );
+      processStub = sandbox.stub(
+        MetadataCacheService.prototype,
+        'processResults'
+      );
+      mockComponentWalkContentStub = sandbox.stub(
+        SourceComponent.prototype,
+        'walkContent'
+      );
+      notificationStub = sandbox.stub(notificationService, 'showErrorMessage');
+      channelAppendLineStub = sandbox.stub(channelService, 'appendLine');
+      channelShowChannelOutputStub = sandbox.stub(
+        channelService,
+        'showChannelOutput'
+      );
+      telemetryServiceSendExceptionStub = sandbox.stub(
+        telemetryService,
+        'sendException'
+      );
+      vscodeExecuteCommandStub = sandbox.stub(commands, 'executeCommand');
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('Should execute VS Code diff command', async () => {
+      const mockSourceComponent = new SourceComponent({
+        name: 'mockFile',
+        type: {
+          id: 'ApexClass',
+          name: 'ApexClass'
+        }
       });
-    workspaceContextAliasStub = sandbox
-      .stub(workspaceContext, 'alias')
-      .get(() => {
-        return mockAlias;
-      });
-    workspaceCheckerStub = sandbox.stub(
-      SfdxWorkspaceChecker.prototype,
-      'check'
-    );
-    workspaceCheckerStub.returns(true);
-    filePathGathererStub = sandbox.stub(FilePathGatherer.prototype, 'gather');
-    filePathGathererStub.returns({ type: 'CONTINUE', data: mockFilePath });
-    operationStub = sandbox.stub(
-      MetadataCacheService.prototype,
-      'createRetrieveOperation'
-    );
-    componentStub = sandbox.stub(
-      MetadataCacheService.prototype,
-      'getSourceComponents'
-    );
-    processStub = sandbox.stub(
-      MetadataCacheService.prototype,
-      'processResults'
-    );
-    mockComponentWalkContentStub = sandbox.stub(
-      SourceComponent.prototype,
-      'walkContent'
-    );
-    notificationStub = sandbox.stub(notificationService, 'showErrorMessage');
-    channelAppendLineStub = sandbox.stub(channelService, 'appendLine');
-    channelShowChannelOutputStub = sandbox.stub(
-      channelService,
-      'showChannelOutput'
-    );
-    telemetryServiceSendExceptionStub = sandbox.stub(
-      telemetryService,
-      'sendException'
-    );
-    vscodeExecuteCommandStub = sandbox.stub(commands, 'executeCommand');
-  });
+      const mockResult: MetadataCacheResult = {
+        selectedIsDirectory: false,
+        selectedPath: mockFilePath,
+        cache: {
+          baseDirectory: path.join(`/tmp/.sfdx/diff/${mockUsername}/`),
+          commonRoot: path.join('metadataPackage_100/main/default/classes'),
+          components: [mockSourceComponent]
+        },
+        project: {
+          baseDirectory: path.join('/projects/trailheadapps/lwc-recipes'),
+          commonRoot: path.join('force-app/main/default/classes'),
+          components: []
+        }
+      };
+      const remoteFsPath = path.join(
+        mockResult.cache.baseDirectory,
+        mockResult.cache.commonRoot,
+        'mockFile.cls'
+      );
+      const localFsPath = mockFilePath;
+      mockComponentWalkContentStub.returns([remoteFsPath]);
+      processStub.returns(mockResult);
 
-  afterEach(() => {
-    sandbox.restore();
-  });
+      await forceSourceDiff(Uri.file(mockFilePath));
 
-  it('Should execute VS Code diff command', async () => {
-    const mockSourceComponent = new SourceComponent({
-      name: 'mockFile',
-      type: {
-        id: 'ApexClass',
-        name: 'ApexClass'
+      assert.calledOnce(vscodeExecuteCommandStub);
+      assert.calledWith(
+        vscodeExecuteCommandStub,
+        'vscode.diff',
+        match.has('fsPath', remoteFsPath),
+        match.has('fsPath', localFsPath),
+        nls.localize(
+          'force_source_diff_title',
+          mockAlias,
+          'mockFile.cls',
+          'mockFile.cls'
+        )
+      );
+    });
+
+    it('Should show message when remote file is not found in org', async () => {
+      processStub.returns(null);
+
+      try {
+        await forceSourceDiff(Uri.file(mockFilePath));
+      } catch (error) {
+        expect(error.message).to.be(
+          nls.localize('force_source_diff_remote_not_found')
+        );
+        assert.calledOnce(notificationStub);
+        assert.calledWith(
+          notificationStub,
+          nls.localize('force_source_diff_remote_not_found')
+        );
       }
     });
-    const mockResult: MetadataCacheResult = {
-      selectedIsDirectory: false,
-      selectedPath: mockFilePath,
-      cache: {
-        baseDirectory: path.join(`/tmp/.sfdx/diff/${mockUsername}/`),
-        commonRoot: path.join('metadataPackage_100/main/default/classes'),
-        components: [mockSourceComponent]
-      },
-      project: {
-        baseDirectory: path.join('/projects/trailheadapps/lwc-recipes'),
-        commonRoot: path.join('force-app/main/default/classes'),
-        components: []
-      }
-    };
-    const remoteFsPath = path.join(
-      mockResult.cache.baseDirectory,
-      mockResult.cache.commonRoot,
-      'mockFile.cls'
-    );
-    const localFsPath = mockFilePath;
-    mockComponentWalkContentStub.returns([remoteFsPath]);
-    processStub.returns(mockResult);
 
-    await forceSourceDiff(Uri.file(mockFilePath));
+    it('Should show message when diffing on unsupported file type', async () => {
+      const mockActiveTextEditor = {
+        document: {
+          uri: Uri.file(mockFilePath),
+          languageId: 'forcesourcemanifest'
+        }
+      };
+      sandbox.stub(vscode.window, 'activeTextEditor').get(() => {
+        return mockActiveTextEditor;
+      });
 
-    assert.calledOnce(vscodeExecuteCommandStub);
-    assert.calledWith(
-      vscodeExecuteCommandStub,
-      'vscode.diff',
-      match.has('fsPath', remoteFsPath),
-      match.has('fsPath', localFsPath),
-      nls.localize(
-        'force_source_diff_title',
-        mockAlias,
-        'mockFile.cls',
-        'mockFile.cls'
-      )
-    );
-  });
+      await forceSourceDiff();
 
-  it('Should show message when remote file is not found in org', async () => {
-    processStub.returns(null);
-
-    try {
-      await forceSourceDiff(Uri.file(mockFilePath));
-    } catch (error) {
-      expect(error.message).to.be(
-        nls.localize('force_source_diff_remote_not_found')
+      assert.calledOnce(telemetryServiceSendExceptionStub);
+      assert.calledWith(
+        telemetryServiceSendExceptionStub,
+        'unsupported_type_on_diff',
+        nls.localize('force_source_diff_unsupported_type')
       );
       assert.calledOnce(notificationStub);
       assert.calledWith(
         notificationStub,
-        nls.localize('force_source_diff_remote_not_found')
+        nls.localize('force_source_diff_unsupported_type')
       );
-    }
+      assert.calledOnce(channelAppendLineStub);
+      assert.calledWith(
+        channelAppendLineStub,
+        nls.localize('force_source_diff_unsupported_type')
+      );
+      assert.calledOnce(channelShowChannelOutputStub);
+    });
   });
 
-  it('Should show message when diffing on unsupported file type', async () => {
-    const mockActiveTextEditor = {
-      document: {
-        uri: Uri.file(mockFilePath),
-        languageId: 'forcesourcemanifest'
-      }
-    };
-    sandbox.stub(vscode.window, 'activeTextEditor').get(() => {
-      return mockActiveTextEditor;
+  describe('Force Source Folder Diff', () => {
+    let notificationStub: SinonStub;
+    let diffOneFileStub: SinonSpy;
+    let diffFolderStub: SinonSpy;
+
+    beforeEach(() => {
+      notificationStub = stub(notificationService, 'showErrorMessage');
+      diffOneFileStub = stub(conflictDetectionService, 'diffOneFile');
+      diffFolderStub = stub(conflictDetectionService, 'diffFolder');
     });
 
-    await forceSourceDiff();
+    afterEach(() => {
+      notificationStub.restore();
+      diffOneFileStub.restore();
+      diffFolderStub.restore();
+    });
 
-    assert.calledOnce(telemetryServiceSendExceptionStub);
-    assert.calledWith(
-      telemetryServiceSendExceptionStub,
-      'unsupported_type_on_diff',
-      nls.localize('force_source_diff_unsupported_type')
-    );
-    assert.calledOnce(notificationStub);
-    assert.calledWith(
-      notificationStub,
-      nls.localize('force_source_diff_unsupported_type')
-    );
-    assert.calledOnce(channelAppendLineStub);
-    assert.calledWith(
-      channelAppendLineStub,
-      nls.localize('force_source_diff_unsupported_type')
-    );
-    assert.calledOnce(channelShowChannelOutputStub);
+    it('Should throw error for empty cache', async () => {
+      await conflictCommands.handleCacheResults('username', undefined);
+      assert.calledOnce(notificationStub);
+      expect(notificationStub.getCall(0).args[0]).to.equal(
+        nls.localize('force_source_diff_components_not_in_org')
+      );
+    });
+
+    it('Should diff one file', async () => {
+      const metadataCache: MetadataContext = { baseDirectory: '.', commonRoot: '.', components: [] };
+      const cacheResult: MetadataCacheResult = { selectedIsDirectory: false, selectedPath: '.', cache: metadataCache, project: metadataCache };
+      await conflictCommands.handleCacheResults('username', cacheResult);
+      assert.calledOnce(diffOneFileStub);
+    });
+
+    it('Should diff folder', async () => {
+      const metadataCache: MetadataContext = { baseDirectory: '.', commonRoot: '.', components: [] };
+      const cacheResult: MetadataCacheResult = { selectedIsDirectory: true, selectedPath: '.', cache: metadataCache, project: metadataCache };
+      await conflictCommands.handleCacheResults('username', cacheResult);
+      assert.calledOnce(diffFolderStub);
+    });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/metadataCacheService.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/metadataCacheService.test.ts
@@ -240,6 +240,7 @@ describe('Metadata Cache', () => {
   });
 
   async function handleCacheResults(
+    username: string,
     cache?: MetadataCacheResult
   ): Promise<void> {}
 


### PR DESCRIPTION
### What does this PR do?
Enable the SFDX file diff command in vscode extensions for project folders. The command will perform a metadata diff and display the results in the Conflict Detection UI

### What issues does this PR fix or reference?
@W-9166602@

### Functionality Before
N/A

### Functionality After
![Screen Shot 2021-05-17 at 9 34 19 AM](https://user-images.githubusercontent.com/58611665/118524558-22145c80-b6f3-11eb-991f-21d9aa5d5ac4.png)
![Screen Shot 2021-05-17 at 9 34 40 AM](https://user-images.githubusercontent.com/58611665/118524572-26407a00-b6f3-11eb-979b-2a15bab54cdd.png)

