### PR TITLE
fix: use new cli for functions invoke @W-9282250@

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/functions/forceFunctionInvoke.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/functions/forceFunctionInvoke.ts
@@ -6,7 +6,7 @@
  */
 
 /**
- * Executes sfdx run:function http://localhost:8080 --payload=@functions/MyFunction/payload.json
+ * Executes sfdx run:function --url http://localhost:8080 --payload=@functions/MyFunction/payload.json
  */
 import {
   Command,

--- a/packages/salesforcedx-vscode-core/src/commands/functions/forceFunctionInvoke.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/functions/forceFunctionInvoke.ts
@@ -6,7 +6,7 @@
  */
 
 /**
- * Executes sfdx evergreen:function:invoke http://localhost:8080 --payload=@functions/MyFunction/payload.json
+ * Executes sfdx run:function http://localhost:8080 --payload=@functions/MyFunction/payload.json
  */
 import {
   Command,
@@ -28,8 +28,8 @@ export class ForceFunctionInvoke extends SfdxCommandletExecutor<string> {
   public build(payloadUri: string): Command {
     return new SfdxCommandBuilder()
       .withDescription(nls.localize('force_function_invoke_text'))
-      .withArg('evergreen:function:invoke')
-      .withArg('http://localhost:8080')
+      .withArg('run:function')
+      .withFlag('--url', 'http://localhost:8080')
       .withFlag('--payload', `@${payloadUri}`)
       .withLogName('force_function_invoke')
       .build();

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/functions/forceFunctionInvoke.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/functions/forceFunctionInvoke.test.ts
@@ -29,7 +29,7 @@ describe('Force Function Invoke', () => {
     const funcInvokeCmd = invokeFunc.build(payloadUri);
 
     expect(funcInvokeCmd.toCommand()).to.equal(
-      `sfdx evergreen:function:invoke http://localhost:8080 --payload @${payloadUri}`
+      `sfdx run:function --url http://localhost:8080 --payload @${payloadUri}`
     );
     expect(funcInvokeCmd.description).to.equal(
       nls.localize('force_function_invoke_text')


### PR DESCRIPTION
### What does this PR do?
Invoke uses new CLI + java support

### What issues does this PR fix or reference?
@W-9282250@

### Functionality Before
N/A

### Functionality After
No change in behavior