### PR TITLE
fix: update default debug port

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/functions/forceFunctionStart.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/functions/forceFunctionStart.ts
@@ -143,7 +143,7 @@ export class ForceFunctionStartExecutor extends SfdxCommandletExecutor<string> {
     );
 
     execution.stdoutSubject.subscribe(data => {
-      if (data.toString().includes('Ready to process signals')) {
+      if (data.toString().includes('Debugger running on port')) {
         progress.complete();
         taskViewService.removeTask(task);
         notificationService

--- a/packages/salesforcedx-vscode-core/src/commands/functions/types/constants.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/functions/types/constants.ts
@@ -13,7 +13,7 @@ export const FUNCTION_DEFAULT_PORT = 8080;
 /**
  * Default debug port of a locally running function
  */
-export const FUNCTION_DEFAULT_DEBUG_PORT = 9222;
+export const FUNCTION_DEFAULT_DEBUG_PORT = 9229;
 
 /**
  * Functions Payload pattern

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/functions/forceFunctionStart.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/functions/forceFunctionStart.test.ts
@@ -286,7 +286,7 @@ describe('Force Function Start', () => {
 
       await forceFunctionStart(srcUri);
 
-      mockExecution.stdoutSubject.next('Ready to process signals');
+      mockExecution.stdoutSubject.next('Debugger running on port');
       assert.calledOnce(logMetricStub);
       assert.calledWith(logMetricStub, 'force_function_start', mockStartTime);
     });


### PR DESCRIPTION
### What does this PR do?

- Update the default debug port used for functions
- Correctly identify when a function has been started

### What issues does this PR fix or reference?
@W-9282233@
