### PR TITLE
fix: invoke works when there are spaces in the path @W-9282250@

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/functions/forceFunctionInvoke.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/functions/forceFunctionInvoke.ts
@@ -30,7 +30,7 @@ export class ForceFunctionInvoke extends SfdxCommandletExecutor<string> {
       .withDescription(nls.localize('force_function_invoke_text'))
       .withArg('run:function')
       .withFlag('--url', 'http://localhost:8080')
-      .withFlag('--payload', `@${payloadUri}`)
+      .withFlag('--payload', `@'${payloadUri}'`)
       .withLogName('force_function_invoke')
       .build();
   }

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/functions/forceFunctionInvoke.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/functions/forceFunctionInvoke.test.ts
@@ -29,7 +29,7 @@ describe('Force Function Invoke', () => {
     const funcInvokeCmd = invokeFunc.build(payloadUri);
 
     expect(funcInvokeCmd.toCommand()).to.equal(
-      `sfdx run:function --url http://localhost:8080 --payload @${payloadUri}`
+      `sfdx run:function --url http://localhost:8080 --payload @'${payloadUri}'`
     );
     expect(funcInvokeCmd.description).to.equal(
       nls.localize('force_function_invoke_text')


### PR DESCRIPTION
### What does this PR do?
Invoke works when directory path to payload file has spaces

### What issues does this PR fix or reference?
@W-9282250@

### Functionality Before
Invoke would fail when payload file is in a directory path with spaces

### Functionality After
Invoke passes when payload file is in a directory path with spaces
