### PR TITLE
fix: import FileProperties from the top level

### DIFF
--- a/packages/salesforcedx-vscode-core/src/conflict/metadataCacheService.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/metadataCacheService.ts
@@ -10,7 +10,7 @@ import {
   RetrieveResult,
   SourceComponent
 } from '@salesforce/source-deploy-retrieve';
-import { FileProperties } from '@salesforce/source-deploy-retrieve/lib/src/client/types';
+import { FileProperties } from '@salesforce/source-deploy-retrieve';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';

--- a/packages/salesforcedx-vscode-core/src/conflict/persistentStorageService.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/persistentStorageService.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { FileProperties } from '@salesforce/source-deploy-retrieve/lib/src/client/types';
+import { FileProperties } from '@salesforce/source-deploy-retrieve';
 import {
   ExtensionContext,
   Memento

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/metadataCacheService.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/metadataCacheService.test.ts
@@ -7,11 +7,11 @@
 
 import {
   ComponentSet,
+  FileProperties,
   MetadataApiRetrieve,
   RetrieveResult
 } from '@salesforce/source-deploy-retrieve';
 import {
-  FileProperties,
   MetadataApiRetrieveStatus,
   RequestStatus
 } from '@salesforce/source-deploy-retrieve/lib/src/client/types';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/persistentStorageService.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/persistentStorageService.test.ts
@@ -5,19 +5,20 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { FileProperties } from '@salesforce/source-deploy-retrieve/lib/src/client/types';
+import { FileProperties } from '@salesforce/source-deploy-retrieve';
 import { expect } from 'chai';
+import { join } from 'path';
 import { PersistentStorageService } from '../../../src/conflict/persistentStorageService';
 import { MockContext } from '../telemetry/MockContext';
 
-describe('Persistant Storage Service', () => {
+describe('Persistent Storage Service', () => {
   const props: FileProperties[] = [
     {
       id: '1',
       createdById: '2',
       createdByName: 'Me',
       createdDate: 'Today',
-      fileName: 'classes/One.cls',
+      fileName: join('classes', 'One.cls'),
       fullName: 'One',
       lastModifiedById: '3',
       lastModifiedByName: 'You',
@@ -29,7 +30,7 @@ describe('Persistant Storage Service', () => {
       createdById: '2',
       createdByName: 'Me',
       createdDate: 'Yesterday',
-      fileName: 'objects/Two.object',
+      fileName: join('objects', 'Two.cls'),
       fullName: 'Two',
       lastModifiedById: '2',
       lastModifiedByName: 'Me',
@@ -46,12 +47,12 @@ describe('Persistant Storage Service', () => {
   it('Should store and retrieve file properties in Memento cache', () => {
     const cache = PersistentStorageService.getInstance();
     cache.setPropertiesForFiles(props);
-    expect(cache.getPropertiesForFile('classes/One.cls')).to.deep.equal({lastModifiedDate: 'Tomorrow'});
-    expect(cache.getPropertiesForFile('objects/Two.object')).to.deep.equal({lastModifiedDate: 'Yesterday'});
-    cache.setPropertiesForFile('classes/One.cls', undefined);
-    cache.setPropertiesForFile('objects/Two.object', undefined);
-    expect(cache.getPropertiesForFile('classes/One.cls')).to.equal(undefined);
-    expect(cache.getPropertiesForFile('objects/Two.object')).to.equal(undefined);
+    expect(cache.getPropertiesForFile(join('classes', 'One.cls'))).to.deep.equal({lastModifiedDate: 'Tomorrow'});
+    expect(cache.getPropertiesForFile(join('objects', 'Two.cls'))).to.deep.equal({lastModifiedDate: 'Yesterday'});
+    cache.setPropertiesForFile(join('classes', 'One.cls'), undefined);
+    cache.setPropertiesForFile(join('objects', 'Two.cls'), undefined);
+    expect(cache.getPropertiesForFile(join('classes', 'One.cls'))).to.equal(undefined);
+    expect(cache.getPropertiesForFile(join('objects', 'Two.cls'))).to.equal(undefined);
   });
 
 });


### PR DESCRIPTION
### What does this PR do?
This PR cleans up a few items from a previous PR. First, FileProperties used to not be able to be imported from the top level so this PR addresses that. Second, there was a typo on 'persistant'. Third, I changed the unit tests to use path.join() (I figure this is better even though it didn't really matter as they are hard-coded strings). 

### What issues does this PR fix or reference?
None that are documented, although it finishes what was started with @W-9225729@

### Functionality Before
No change in functionality

### Functionality After
No change in functionality
