### PR TITLE
feat: add org/project prefix to cache key

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDiff.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDiff.ts
@@ -37,20 +37,22 @@ export async function forceSourceDiff(sourceUri?: vscode.Uri) {
   }
 
   const defaultUsernameorAlias = workspaceContext.username;
-  if (defaultUsernameorAlias) {
-    const executor = new MetadataCacheExecutor(
-      defaultUsernameorAlias,
-      nls.localize('force_source_diff_text'),
-      'force_source_diff',
-      handleCacheResults
-    );
-    const commandlet = new SfdxCommandlet(
-      workspaceChecker,
-      new FilePathGatherer(sourceUri),
-      executor
-    );
-    await commandlet.run();
+  if (!defaultUsernameorAlias) {
+    notificationService.showErrorMessage(nls.localize('missing_default_org'));
+    return;
   }
+  const executor = new MetadataCacheExecutor(
+    defaultUsernameorAlias,
+    nls.localize('force_source_diff_text'),
+    'force_source_diff',
+    handleCacheResults
+  );
+  const commandlet = new SfdxCommandlet(
+    workspaceChecker,
+    new FilePathGatherer(sourceUri),
+    executor
+  );
+  await commandlet.run();
 }
 
 export async function forceSourceFolderDiff(explorerPath: vscode.Uri) {

--- a/packages/salesforcedx-vscode-core/src/conflict/persistentStorageService.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/persistentStorageService.ts
@@ -47,29 +47,29 @@ export class PersistentStorageService {
     this.storage.update(key, conflictFileProperties);
   }
 
-  public setPropertiesForFilesRetrieve(fileProperties: FileProperties | FileProperties[]) {
+  public setPropertiesForFilesRetrieve(org: string, project: string, fileProperties: FileProperties | FileProperties[]) {
     const fileArray = Array.isArray(fileProperties) ? fileProperties : [fileProperties];
     for (const fileProperty of fileArray) {
       this.setPropertiesForFile(
-        this.makeKey(fileProperty.type, fileProperty.fullName),
+        this.makeKey(org, project, fileProperty.type, fileProperty.fullName),
         {
           lastModifiedDate: fileProperty.lastModifiedDate
         });
     }
   }
 
-  public setPropertiesForFilesDeploy(components: ComponentSet, status: MetadataApiDeployStatus) {
+  public setPropertiesForFilesDeploy(org: string, project: string, components: ComponentSet, status: MetadataApiDeployStatus) {
     const sourceComponents = components.getSourceComponents();
     for (const comp of sourceComponents) {
       this.setPropertiesForFile(
-        this.makeKey(comp.type.name, comp.fullName),
+        this.makeKey(org, project, comp.type.name, comp.fullName),
         {
           lastModifiedDate: status.lastModifiedDate
         });
     }
   }
 
-  public makeKey(type: string, fullName: string): string {
-    return `${type}#${fullName}`;
+  public makeKey(org: string, project: string, type: string, fullName: string): string {
+    return `${org}#${project}#${type}#${fullName}`;
   }
 }

--- a/packages/salesforcedx-vscode-core/src/conflict/persistentStorageService.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/persistentStorageService.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { getRootWorkspaceSfdxPath } from '@salesforce/salesforcedx-utils-vscode/out/src';
+import { getRootWorkspacePath } from '@salesforce/salesforcedx-utils-vscode/out/src';
 import {
   ComponentSet,
   FileProperties
@@ -12,12 +12,10 @@ import {
 import { MetadataApiDeployStatus} from '@salesforce/source-deploy-retrieve/lib/src/client/types';
 import {
   ExtensionContext,
-  Memento,
-  workspace
+  Memento
 } from 'vscode';
 import { workspaceContext } from '../context';
 import { nls } from '../messages';
-import { hasRootWorkspace } from '../util';
 
 interface ConflictFileProperties {
   lastModifiedDate: string;
@@ -75,7 +73,7 @@ export class PersistentStorageService {
 
   public makeKey(type: string, fullName: string): string {
     const orgUserName = workspaceContext.username;
-    const projectPath = getRootWorkspaceSfdxPath();
+    const projectPath = getRootWorkspacePath();
     return `${orgUserName}#${projectPath}#${type}#${fullName}`;
   }
 }

--- a/packages/salesforcedx-vscode-core/src/conflict/persistentStorageService.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/persistentStorageService.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { getRootWorkspaceSfdxPath } from '@salesforce/salesforcedx-utils-vscode/out/src';
 import {
   ComponentSet,
   FileProperties
@@ -11,9 +12,12 @@ import {
 import { MetadataApiDeployStatus} from '@salesforce/source-deploy-retrieve/lib/src/client/types';
 import {
   ExtensionContext,
-  Memento
+  Memento,
+  workspace
 } from 'vscode';
+import { workspaceContext } from '../context';
 import { nls } from '../messages';
+import { hasRootWorkspace } from '../util';
 
 interface ConflictFileProperties {
   lastModifiedDate: string;
@@ -47,29 +51,31 @@ export class PersistentStorageService {
     this.storage.update(key, conflictFileProperties);
   }
 
-  public setPropertiesForFilesRetrieve(org: string, project: string, fileProperties: FileProperties | FileProperties[]) {
+  public setPropertiesForFilesRetrieve(fileProperties: FileProperties | FileProperties[]) {
     const fileArray = Array.isArray(fileProperties) ? fileProperties : [fileProperties];
     for (const fileProperty of fileArray) {
       this.setPropertiesForFile(
-        this.makeKey(org, project, fileProperty.type, fileProperty.fullName),
+        this.makeKey(fileProperty.type, fileProperty.fullName),
         {
           lastModifiedDate: fileProperty.lastModifiedDate
         });
     }
   }
 
-  public setPropertiesForFilesDeploy(org: string, project: string, components: ComponentSet, status: MetadataApiDeployStatus) {
+  public setPropertiesForFilesDeploy(components: ComponentSet, status: MetadataApiDeployStatus) {
     const sourceComponents = components.getSourceComponents();
     for (const comp of sourceComponents) {
       this.setPropertiesForFile(
-        this.makeKey(org, project, comp.type.name, comp.fullName),
+        this.makeKey(comp.type.name, comp.fullName),
         {
           lastModifiedDate: status.lastModifiedDate
         });
     }
   }
 
-  public makeKey(org: string, project: string, type: string, fullName: string): string {
-    return `${org}#${project}#${type}#${fullName}`;
+  public makeKey(type: string, fullName: string): string {
+    const orgUserName = workspaceContext.username;
+    const projectPath = getRootWorkspaceSfdxPath();
+    return `${orgUserName}#${projectPath}#${type}#${fullName}`;
   }
 }

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/persistentStorageService.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/persistentStorageService.test.ts
@@ -13,8 +13,6 @@ import { PersistentStorageService } from '../../../src/conflict/persistentStorag
 import { MockContext } from '../telemetry/MockContext';
 
 describe('Persistent Storage Service', () => {
-  const PROJECT_NAME = 'sfdx-simple';
-  const ORG_NAME = 'test-org';
   const props: FileProperties[] = [
     {
       id: '1',
@@ -85,24 +83,24 @@ describe('Persistent Storage Service', () => {
 
   it('Should store and retrieve file properties in Memento cache', () => {
     const cache = PersistentStorageService.getInstance();
-    cache.setPropertiesForFilesRetrieve(ORG_NAME, PROJECT_NAME, props);
-    expect(cache.getPropertiesForFile(cache.makeKey(ORG_NAME, PROJECT_NAME, 'ApexClass', 'One'))).to.deep.equal({lastModifiedDate: 'Tomorrow'});
-    expect(cache.getPropertiesForFile(cache.makeKey(ORG_NAME, PROJECT_NAME, 'CustomObject', 'Two'))).to.deep.equal({lastModifiedDate: 'Yesterday'});
-    cache.setPropertiesForFile(cache.makeKey(ORG_NAME, PROJECT_NAME, 'ApexClass', 'One'), undefined);
-    cache.setPropertiesForFile(cache.makeKey(ORG_NAME, PROJECT_NAME, 'CustomObject', 'Two'), undefined);
-    expect(cache.getPropertiesForFile(cache.makeKey(ORG_NAME, PROJECT_NAME, 'ApexClass', 'One'))).to.equal(undefined);
-    expect(cache.getPropertiesForFile(cache.makeKey(ORG_NAME, PROJECT_NAME, 'CustomObject', 'Two'))).to.equal(undefined);
+    cache.setPropertiesForFilesRetrieve(props);
+    expect(cache.getPropertiesForFile(cache.makeKey('ApexClass', 'One'))).to.deep.equal({lastModifiedDate: 'Tomorrow'});
+    expect(cache.getPropertiesForFile(cache.makeKey('CustomObject', 'Two'))).to.deep.equal({lastModifiedDate: 'Yesterday'});
+    cache.setPropertiesForFile(cache.makeKey('ApexClass', 'One'), undefined);
+    cache.setPropertiesForFile(cache.makeKey('CustomObject', 'Two'), undefined);
+    expect(cache.getPropertiesForFile(cache.makeKey('ApexClass', 'One'))).to.equal(undefined);
+    expect(cache.getPropertiesForFile(cache.makeKey('CustomObject', 'Two'))).to.equal(undefined);
   });
 
   it('Should set and get ConflictFileProperties in Memento cache for Deploy', () => {
     const cache = PersistentStorageService.getInstance();
-    cache.setPropertiesForFilesDeploy(ORG_NAME, PROJECT_NAME, mockDeployResult.components, mockDeployResult.response);
-    expect(cache.getPropertiesForFile(cache.makeKey(ORG_NAME, PROJECT_NAME, 'ApexClass', 'One'))).to.deep.equal({lastModifiedDate: 'Yesterday'});
-    expect(cache.getPropertiesForFile(cache.makeKey(ORG_NAME, PROJECT_NAME, 'CustomObject', 'Two'))).to.deep.equal({lastModifiedDate: 'Yesterday'});
-    cache.setPropertiesForFile(cache.makeKey(ORG_NAME, PROJECT_NAME, 'ApexClass', 'One'), undefined);
-    cache.setPropertiesForFile(cache.makeKey(ORG_NAME, PROJECT_NAME, 'CustomObject', 'Two'), undefined);
-    expect(cache.getPropertiesForFile(cache.makeKey(ORG_NAME, PROJECT_NAME, 'ApexClass', 'One'))).to.equal(undefined);
-    expect(cache.getPropertiesForFile(cache.makeKey(ORG_NAME, PROJECT_NAME, 'CustomObject', 'Two'))).to.equal(undefined);
+    cache.setPropertiesForFilesDeploy(mockDeployResult.components, mockDeployResult.response);
+    expect(cache.getPropertiesForFile(cache.makeKey('ApexClass', 'One'))).to.deep.equal({lastModifiedDate: 'Yesterday'});
+    expect(cache.getPropertiesForFile(cache.makeKey('CustomObject', 'Two'))).to.deep.equal({lastModifiedDate: 'Yesterday'});
+    cache.setPropertiesForFile(cache.makeKey('ApexClass', 'One'), undefined);
+    cache.setPropertiesForFile(cache.makeKey('CustomObject', 'Two'), undefined);
+    expect(cache.getPropertiesForFile(cache.makeKey('ApexClass', 'One'))).to.equal(undefined);
+    expect(cache.getPropertiesForFile(cache.makeKey('CustomObject', 'Two'))).to.equal(undefined);
   });
 
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/persistentStorageService.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/persistentStorageService.test.ts
@@ -81,7 +81,7 @@ describe('Persistent Storage Service', () => {
     PersistentStorageService.initialize(mockContext);
   });
 
-  it('Should store and retrieve file properties in Memento cache', () => {
+  it('Should store and retrieve file properties in Memento cache for Retrieve', () => {
     const cache = PersistentStorageService.getInstance();
     cache.setPropertiesForFilesRetrieve(props);
     expect(cache.getPropertiesForFile(cache.makeKey('ApexClass', 'One'))).to.deep.equal({lastModifiedDate: 'Tomorrow'});

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/persistentStorageService.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/persistentStorageService.test.ts
@@ -13,6 +13,8 @@ import { PersistentStorageService } from '../../../src/conflict/persistentStorag
 import { MockContext } from '../telemetry/MockContext';
 
 describe('Persistent Storage Service', () => {
+  const PROJECT_NAME = 'sfdx-simple';
+  const ORG_NAME = 'test-org';
   const props: FileProperties[] = [
     {
       id: '1',
@@ -83,24 +85,24 @@ describe('Persistent Storage Service', () => {
 
   it('Should store and retrieve file properties in Memento cache', () => {
     const cache = PersistentStorageService.getInstance();
-    cache.setPropertiesForFilesRetrieve(props);
-    expect(cache.getPropertiesForFile(cache.makeKey('ApexClass', 'One'))).to.deep.equal({lastModifiedDate: 'Tomorrow'});
-    expect(cache.getPropertiesForFile(cache.makeKey('CustomObject', 'Two'))).to.deep.equal({lastModifiedDate: 'Yesterday'});
-    cache.setPropertiesForFile(cache.makeKey('ApexClass', 'One'), undefined);
-    cache.setPropertiesForFile(cache.makeKey('CustomObject', 'Two'), undefined);
-    expect(cache.getPropertiesForFile(cache.makeKey('ApexClass', 'One'))).to.equal(undefined);
-    expect(cache.getPropertiesForFile(cache.makeKey('CustomObject', 'Two'))).to.equal(undefined);
+    cache.setPropertiesForFilesRetrieve(ORG_NAME, PROJECT_NAME, props);
+    expect(cache.getPropertiesForFile(cache.makeKey(ORG_NAME, PROJECT_NAME, 'ApexClass', 'One'))).to.deep.equal({lastModifiedDate: 'Tomorrow'});
+    expect(cache.getPropertiesForFile(cache.makeKey(ORG_NAME, PROJECT_NAME, 'CustomObject', 'Two'))).to.deep.equal({lastModifiedDate: 'Yesterday'});
+    cache.setPropertiesForFile(cache.makeKey(ORG_NAME, PROJECT_NAME, 'ApexClass', 'One'), undefined);
+    cache.setPropertiesForFile(cache.makeKey(ORG_NAME, PROJECT_NAME, 'CustomObject', 'Two'), undefined);
+    expect(cache.getPropertiesForFile(cache.makeKey(ORG_NAME, PROJECT_NAME, 'ApexClass', 'One'))).to.equal(undefined);
+    expect(cache.getPropertiesForFile(cache.makeKey(ORG_NAME, PROJECT_NAME, 'CustomObject', 'Two'))).to.equal(undefined);
   });
 
   it('Should set and get ConflictFileProperties in Memento cache for Deploy', () => {
     const cache = PersistentStorageService.getInstance();
-    cache.setPropertiesForFilesDeploy(mockDeployResult.components, mockDeployResult.response);
-    expect(cache.getPropertiesForFile(cache.makeKey('ApexClass', 'One'))).to.deep.equal({lastModifiedDate: 'Yesterday'});
-    expect(cache.getPropertiesForFile(cache.makeKey('CustomObject', 'Two'))).to.deep.equal({lastModifiedDate: 'Yesterday'});
-    cache.setPropertiesForFile(cache.makeKey('ApexClass', 'One'), undefined);
-    cache.setPropertiesForFile(cache.makeKey('CustomObject', 'Two'), undefined);
-    expect(cache.getPropertiesForFile(cache.makeKey('ApexClass', 'One'))).to.equal(undefined);
-    expect(cache.getPropertiesForFile(cache.makeKey('CustomObject', 'Two'))).to.equal(undefined);
+    cache.setPropertiesForFilesDeploy(ORG_NAME, PROJECT_NAME, mockDeployResult.components, mockDeployResult.response);
+    expect(cache.getPropertiesForFile(cache.makeKey(ORG_NAME, PROJECT_NAME, 'ApexClass', 'One'))).to.deep.equal({lastModifiedDate: 'Yesterday'});
+    expect(cache.getPropertiesForFile(cache.makeKey(ORG_NAME, PROJECT_NAME, 'CustomObject', 'Two'))).to.deep.equal({lastModifiedDate: 'Yesterday'});
+    cache.setPropertiesForFile(cache.makeKey(ORG_NAME, PROJECT_NAME, 'ApexClass', 'One'), undefined);
+    cache.setPropertiesForFile(cache.makeKey(ORG_NAME, PROJECT_NAME, 'CustomObject', 'Two'), undefined);
+    expect(cache.getPropertiesForFile(cache.makeKey(ORG_NAME, PROJECT_NAME, 'ApexClass', 'One'))).to.equal(undefined);
+    expect(cache.getPropertiesForFile(cache.makeKey(ORG_NAME, PROJECT_NAME, 'CustomObject', 'Two'))).to.equal(undefined);
   });
 
 });


### PR DESCRIPTION
### What does this PR do?
The PersistentStorageService cache is global. This PR adds an org/project prefix to every cache entry's key so that they are unique identifiers. 

### What issues does this PR fix or reference?
@[W-9456559](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000OPsiYAG/view)@

### Functionality Before
Cache key was `${type}#${fullName}`.

### Functionality After
Cache key is now `${org}#${project}#${type}#${fullName}`.