### PR TITLE
chore(tests): disable other extensions on integration tests

### DIFF
--- a/scripts/vscode-integration-testrunner.js
+++ b/scripts/vscode-integration-testrunner.js
@@ -34,6 +34,7 @@ async function runIntegrationTests({
       CODE_LOGS || path.join(process.cwd(), '..', '..', 'vscode-crash-logs');
     const launchArgs = _testWorkspace && [
       _testWorkspace,
+      '--disable-extensions',
       '--crash-reporter-directory',
       _vscodeLogDir
     ];


### PR DESCRIPTION
### What does this PR do?
When running integration tests, disable any extensions already installed in the current users' local VS Code installation.

This is to avoid possible conflicts when running tests locally. For example: if you have extra extensions for code-completion (like, Tabnine) the completion items get intermixed with the ones from our extensions, sometimes breaking our test assertions.



