### PR TITLE
Adds Java 11 path for Arch Linux installations

### DIFF
--- a/docs/_articles/en/getting-started/java-setup.md
+++ b/docs/_articles/en/getting-started/java-setup.md
@@ -43,11 +43,21 @@ Windows:
 }
 ```
 
-Linux (Pop! OS 20.04, installation via aptitude):
+### Linux
+
+Pop! OS 20.04 (installation via aptitude):
 
 ```json
 {
   "salesforcedx-vscode-apex.java.home": "/usr/lib/jvm/java-11-openjdk-amd64"
+}
+```
+
+Arch Linux (installation via AUR using package `jdk11-adoptopenjdk`):
+
+```json
+{
+  "salesforcedx-vscode-apex.java.home": "/usr/lib/jvm/java-11-adoptopenjdk",
 }
 ```
 


### PR DESCRIPTION
This PR adds the Java path for Arch Linux machines (which might prove to be useful for Arch-based installs that are more user-friendly, such as Manjaro).