### PR TITLE
feat: enable conflict detection on retrieve

### DIFF
--- a/docs/_articles/en/user-guide/detect-conflicts.md
+++ b/docs/_articles/en/user-guide/detect-conflicts.md
@@ -7,7 +7,7 @@ Whenever you retrieve or deploy source to keep the local project and your defaul
 
 If conflicts are detected, you can cancel the retrieve or deploy operation and view the differences between your local project and default org.
 
-To view the files that caused conflicts, click the Org Differences icon ({% octicon issue-opened %}) in the Activity Bar. The Org Differences: Conflicts view opens in the Side Bar and displays the list of files with conflicts. To resolve conflicts, click a file to open the diff editor and compare the remote file (to the left) with the local file (on the right). To edit a file, hover over the file name and click the open file icon.
+To view the files that caused conflicts, click the Org Differences icon ({% octicon issue-opened %}) in the Activity Bar. The Org Differences: Conflicts view opens in the Side Bar and displays the list of files with conflicts. To resolve conflicts, click a file to open the diff editor and compare the remote file (on the left) with the local file (on the right). To edit a file, hover over the file name and click the open file icon.
 
 You can also view the resource files with conflicts and the CLI command to overwrite the conflicts in the Output panel.
 
@@ -22,7 +22,7 @@ Because the conflict detection feature is in beta, you must enable the feature:
 
 You can also enter conflict detection in the search box to find the feature and then enable it.
 
-In this beta release, we have enabled conflict detection for the **SFDX: Retrieve Source in Manifest from Org** and **SFDX: Deploy Source in Manifest to Org** commands only. All manifest files that exists both in the org and in the local environment are checked for conflicts; files that don’t exist in both are not checked.
+Once enabled, conflict detection is available on all commands that deploy and retrieve source.
 
 ![Prompt for conflict detection](./images/DetectConflict_prompt.png)
 

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -46,7 +46,7 @@
   "telemetry_enabled_description": "Specifies whether to enable Salesforce telemetry. Even when enabled, still abides by the overall `telemetry.enableTelemetry` vscode setting.",
   "push_or_deploy_on_save_enabled_description": "Specifies whether or not to automatically run force:source:push (for source-tracked orgs) or force:source:deploy (for non-source-tracked orgs) when a local source file is saved.",
   "override_conflicts_on_push_description": "Specifies whether to always use --forceoverwrite when you run force:source:push on save",
-  "conflict_detection_enabled_description": "Specifies whether to enable conflict detection for metadata operations (force:source:deploy with manifest, force:source:retrieve with manifest) for non source-tracked orgs.",
+  "conflict_detection_enabled_description": "Specifies whether to enable conflict detection for metadata operations for non source-tracked orgs.",
   "conflict_detect_resolve_view": "Org Differences",
   "conflict_detect_open_file": "Open File",
   "force_manifest_editor_show_text": "SFDX: Show Package Manifest Editor",

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveManifest.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveManifest.ts
@@ -14,8 +14,8 @@ import { join } from 'path';
 import * as vscode from 'vscode';
 import { channelService } from '../channels';
 import {
-  ConflictDetectionChecker,
-  ConflictDetectionMessages
+  ConflictDetectionMessages,
+  TimestampConflictChecker
 } from '../commands/util/postconditionCheckers';
 import { nls } from '../messages';
 import { notificationService } from '../notifications';
@@ -106,7 +106,7 @@ export async function forceSourceRetrieveManifest(explorerPath: vscode.Uri) {
     sfdxCoreSettings.getBetaDeployRetrieve()
       ? new LibrarySourceRetrieveManifestExecutor()
       : new ForceSourceRetrieveManifestExecutor(),
-    new ConflictDetectionChecker(messages)
+    new TimestampConflictChecker(true, messages)
   );
   await commandlet.run();
 }

--- a/packages/salesforcedx-vscode-core/src/commands/util/postconditionCheckers.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/postconditionCheckers.ts
@@ -43,7 +43,7 @@ export class CompositePostconditionChecker<T> implements PostconditionChecker<T>
       for (const postchecker of this.postcheckers) {
         const input = await postchecker.check(inputs);
         if (input.type === 'CONTINUE') {
-          Object.keys(input.data).map(
+          Object.keys(input.data).forEach(
             key => (aggregatedData[key] = input.data[key])
           );
         } else {

--- a/packages/salesforcedx-vscode-core/src/commands/util/postconditionCheckers.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/postconditionCheckers.ts
@@ -317,7 +317,6 @@ export class ConflictDetectionChecker implements PostconditionChecker<string> {
 }
 
 export class TimestampConflictChecker implements PostconditionChecker<string> {
-
   private isManifest: boolean;
   private messages: ConflictDetectionMessages;
 
@@ -334,6 +333,13 @@ export class TimestampConflictChecker implements PostconditionChecker<string> {
     }
 
     if (inputs.type === 'CONTINUE') {
+      channelService.showChannelOutput();
+      channelService.showCommandWithTimestamp(
+        `${nls.localize('channel_starting_message')}${nls.localize(
+          'conflict_detect_execution_name'
+        )}\n`
+      );
+
       const { username } = workspaceContext;
       if (!username) {
         return {
@@ -344,9 +350,19 @@ export class TimestampConflictChecker implements PostconditionChecker<string> {
 
       const componentPath = inputs.data;
       const cacheService = new MetadataCacheService(username);
-      const result = await cacheService.loadCache(componentPath, getRootWorkspacePath(), this.isManifest);
+      const result = await cacheService.loadCache(
+        componentPath,
+        getRootWorkspacePath(),
+        this.isManifest
+      );
       const detector = new TimestampConflictDetector();
       const diffs = detector.createDiffs(result);
+
+      channelService.showCommandWithTimestamp(
+        `${nls.localize('channel_end')} ${nls.localize(
+          'conflict_detect_execution_name'
+        )}\n`
+      );
       return await this.handleConflicts(inputs.data, username, diffs);
     }
     return { type: 'CANCEL' };
@@ -377,7 +393,6 @@ export class TimestampConflictChecker implements PostconditionChecker<string> {
       results.different.forEach(file => {
         channelService.appendLine(normalize(file));
       });
-      channelService.showChannelOutput();
 
       const choice = await notificationService.showWarningModal(
         nls.localize(this.messages.warningMessageKey),

--- a/packages/salesforcedx-vscode-core/src/commands/util/postconditionCheckers.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/postconditionCheckers.ts
@@ -32,6 +32,35 @@ import { PathStrategyFactory } from './sourcePathStrategies';
 type OneOrMany = LocalComponent | LocalComponent[];
 type ContinueOrCancel = ContinueResponse<OneOrMany> | CancelResponse;
 
+export class CompositePostconditionChecker<T> implements PostconditionChecker<T> {
+  private readonly postcheckers: Array<PostconditionChecker<any>>;
+  public constructor(...postcheckers: Array<PostconditionChecker<any>>) {
+    this.postcheckers = postcheckers;
+  }
+  public async check(inputs: CancelResponse | ContinueResponse<T>): Promise<CancelResponse | ContinueResponse<T>> {
+    if (inputs.type === 'CONTINUE') {
+      const aggregatedData: any = {};
+      for (const postchecker of this.postcheckers) {
+        const input = await postchecker.check(inputs);
+        if (input.type === 'CONTINUE') {
+          Object.keys(input.data).map(
+            key => (aggregatedData[key] = input.data[key])
+          );
+        } else {
+          return {
+            type: 'CANCEL'
+          };
+        }
+      }
+      return {
+        type: 'CONTINUE',
+        data: aggregatedData
+      };
+    }
+    return inputs;
+  }
+}
+
 export class EmptyPostChecker implements PostconditionChecker<any> {
   public async check(
     inputs: ContinueResponse<any> | CancelResponse

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/postconditionCheckers.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/postconditionCheckers.test.ts
@@ -5,8 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {
+  CancelResponse,
   ContinueResponse,
-  LocalComponent
+  LocalComponent,
+  PostconditionChecker
 } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import { expect } from 'chai';
 import * as fs from 'fs';
@@ -14,13 +16,18 @@ import { join, normalize } from 'path';
 import { createSandbox, SinonSandbox, SinonStub } from 'sinon';
 import { channelService } from '../../../../src/channels';
 import {
+  CommandletExecutor,
   ConflictDetectionChecker,
   ConflictDetectionMessages,
   EmptyPostChecker,
   OverwriteComponentPrompt,
-  PathStrategyFactory
+  PathStrategyFactory,
+  SfdxCommandlet
 } from '../../../../src/commands/util';
-import { TimestampConflictChecker } from '../../../../src/commands/util/postconditionCheckers';
+import {
+  CompositePostconditionChecker,
+  TimestampConflictChecker
+} from '../../../../src/commands/util/postconditionCheckers';
 import {
   conflictDetector,
   conflictView,
@@ -31,7 +38,6 @@ import { notificationService } from '../../../../src/notifications';
 import { sfdxCoreSettings } from '../../../../src/settings';
 import { SfdxPackageDirectories } from '../../../../src/sfdxProject';
 import { getRootWorkspacePath, MetadataDictionary } from '../../../../src/util';
-
 describe('Postcondition Checkers', () => {
   let env: SinonSandbox;
   describe('EmptyPostconditionChecker', () => {
@@ -40,7 +46,6 @@ describe('Postcondition Checkers', () => {
       const response = await postChecker.check({ type: 'CANCEL' });
       expect(response.type).to.equal('CANCEL');
     });
-
     it('Should return ContinueResponse unchanged if input passed in is ContinueResponse', async () => {
       const postChecker = new EmptyPostChecker();
       const input: ContinueResponse<string> = {
@@ -54,6 +59,135 @@ describe('Postcondition Checkers', () => {
       } else {
         expect.fail('Response should be of type ContinueResponse');
       }
+    });
+  });
+
+  describe('CompositePostconditionChecker', () => {
+    it('Should return CancelResponse if input passed in is CancelResponse', async () => {
+      const postChecker = new CompositePostconditionChecker(
+        new (class implements PostconditionChecker<{}> {
+          public async check(): Promise<
+            CancelResponse | ContinueResponse<{}>
+          > {
+            throw new Error('This should not be called');
+          }
+        })()
+      );
+      const response = await postChecker.check({ type: 'CANCEL' });
+      expect(response.type).to.equal('CANCEL');
+    });
+
+    it('Should proceed to next checker if previous checker in composite checker is ContinueResponse', async () => {
+      const compositePostconditionChecker = new CompositePostconditionChecker(
+        new (class implements PostconditionChecker<{}> {
+          public async check(): Promise<
+            CancelResponse | ContinueResponse<{}>
+          > {
+            return { type: 'CONTINUE', data: {} };
+          }
+        })(),
+        new (class implements PostconditionChecker<{}> {
+          public async check(): Promise<
+            CancelResponse | ContinueResponse<{}>
+          > {
+            return { type: 'CONTINUE', data: {} };
+          }
+        })()
+      );
+
+      const response = await compositePostconditionChecker.check({ type: 'CONTINUE', data: {} });
+      expect(response.type).to.equal('CONTINUE');
+    });
+
+    it('Should not proceed to next checker if previous checker in composite checker is CancelResponse', async () => {
+      const compositePostconditionChecker = new CompositePostconditionChecker(
+        new (class implements PostconditionChecker<{}> {
+          public async check(): Promise<
+            CancelResponse | ContinueResponse<{}>
+          > {
+            return { type: 'CANCEL' };
+          }
+        })(),
+        new (class implements PostconditionChecker<{}> {
+          public async check(): Promise<
+            CancelResponse | ContinueResponse<{}>
+          > {
+            throw new Error('This should not be called');
+          }
+        })()
+      );
+
+      await compositePostconditionChecker.check({ type: 'CONTINUE', data: {} });
+    });
+
+    // tslint:disable:no-unused-expression
+    it('Should call executor if composite checker is ContinueResponse', async () => {
+      let executed = false;
+      const commandlet = new SfdxCommandlet(
+        new (class {
+          public check(): boolean {
+            return true;
+          }
+        })(),
+        new (class {
+          public async gather(): Promise<
+            CancelResponse | ContinueResponse<{}>
+          > {
+            return { type: 'CONTINUE', data: {} };
+          }
+        })(),
+        new (class implements CommandletExecutor<{}> {
+          public execute(response: ContinueResponse<{}>): void {
+            executed = true;
+          }
+        })(),
+        new CompositePostconditionChecker<{}>(
+          new (class implements PostconditionChecker<{}> {
+            public async check(): Promise<
+              CancelResponse | ContinueResponse<{}>
+            > {
+              return { type: 'CONTINUE', data: {} };
+            }
+          })()
+        )
+      );
+
+      await commandlet.run();
+
+      expect(executed).to.be.true;
+    });
+
+    it('Should not call executor if composite checker is CancelResponse', async () => {
+      const commandlet = new SfdxCommandlet(
+        new (class {
+          public check(): boolean {
+            return true;
+          }
+        })(),
+        new (class {
+          public async gather(): Promise<
+            CancelResponse | ContinueResponse<{}>
+          > {
+            return { type: 'CONTINUE', data: {} };
+          }
+        })(),
+        new (class implements CommandletExecutor<{}> {
+          public execute(response: ContinueResponse<{}>): void {
+            throw new Error('This should not be called');
+          }
+        })(),
+        new CompositePostconditionChecker<{}>(
+          new (class implements PostconditionChecker<{}> {
+            public async check(): Promise<
+              CancelResponse | ContinueResponse<{}>
+            > {
+              return { type: 'CANCEL' };
+            }
+          })()
+        )
+      );
+
+      await commandlet.run();
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
This PR enables the new conflict detection mechanism for both retrieve with manifest and retrieve from source path. For the source path side, a new helper class CompositePostconditionChecker was created. 

### What issues does this PR fix or reference?
@W-9164035@

### Functionality Before
Conflict detection was not used for retrieve from source path, the old conflict detection mechanism was used for retrieve with manifest.

### Functionality After
The new conflict detection mechanism is used for all retrieves.
