### PR TITLE
fix: remove scannedRemote and scannedLocal

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/util/postconditionCheckers.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/postconditionCheckers.ts
@@ -339,10 +339,8 @@ export class TimestampConflictChecker implements PostconditionChecker<string> {
     } else {
       channelService.appendLine(
         nls.localize(
-          'conflict_detect_conflict_header',
-          results.different.size,
-          results.scannedRemote,
-          results.scannedLocal
+          'conflict_detect_conflict_header_timestamp',
+          results.different.size
         )
       );
       results.different.forEach(file => {

--- a/packages/salesforcedx-vscode-core/src/conflict/conflictDetectionService.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/conflictDetectionService.ts
@@ -90,8 +90,8 @@ export class ConflictDetector {
 
     telemetryService.sendCommandEvent('conflict_detect', startTime, undefined, {
       conflicts: this.diffs.different.size,
-      orgFiles: this.diffs.scannedRemote,
-      localFiles: this.diffs.scannedLocal
+      orgFiles: this.diffs.scannedRemote ?? 0,
+      localFiles: this.diffs.scannedLocal ?? 0
     });
 
     return this.diffs;

--- a/packages/salesforcedx-vscode-core/src/conflict/directoryDiffer.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/directoryDiffer.ts
@@ -12,8 +12,8 @@ export interface DirectoryDiffResults {
   different: Set<string>;
   localRoot: string;
   remoteRoot: string;
-  scannedLocal: number;
-  scannedRemote: number;
+  scannedLocal?: number;
+  scannedRemote?: number;
 }
 
 export interface DirectoryDiffer {

--- a/packages/salesforcedx-vscode-core/src/conflict/timestampConflictDetector.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/timestampConflictDetector.ts
@@ -21,9 +21,7 @@ export class TimestampConflictDetector {
   private static EMPTY_DIFFS = {
     localRoot: '',
     remoteRoot: '',
-    different: new Set<string>(),
-    scannedLocal: 0,
-    scannedRemote: 0
+    different: new Set<string>()
   };
 
   constructor() {

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -554,6 +554,8 @@ export const messages = {
   conflict_detect_show_conflicts: 'Show Conflicts',
   conflict_detect_conflict_header:
     'Conflicts:\n    Found %s file(s) in conflict (scanned %s org files, %s local files):\n',
+  conflict_detect_conflict_header_timestamp:
+    'Conflicts:\n    Found %s file(s) in conflict:\n',
   conflict_detect_command_hint:
     '\nRun the following command to overwrite the conflicts:\n  %s',
   conflict_detect_no_default_username: 'No default username for this project',

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/postconditionCheckers.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/postconditionCheckers.test.ts
@@ -537,9 +537,7 @@ describe('Postcondition Checkers', () => {
           different: new Set<string>([
             'main/default/objects/Property__c/fields/Broker__c.field-meta.xml',
             'main/default/aura/auraPropertySummary/auraPropertySummaryController.js'
-          ]),
-          scannedLocal: 4,
-          scannedRemote: 6
+          ])
         } as DirectoryDiffResults;
         modalStub.returns('Cancel');
 
@@ -556,7 +554,7 @@ describe('Postcondition Checkers', () => {
         ]);
 
         expect(channelOutput).to.include.members([
-          nls.localize('conflict_detect_conflict_header', 2, 6, 4),
+          nls.localize('conflict_detect_conflict_header_timestamp', 2),
           normalize(
             'main/default/objects/Property__c/fields/Broker__c.field-meta.xml'
           ),


### PR DESCRIPTION
### What does this PR do?
With how conflict detection used to work, the number of files scanned both locally and remotely was reported to the user. The new mechanism does not operate in the same way but currently still displays those values and hardcodes them to be 0. This PR removes `scannedRemote` and `scannedLocal` from the new conflict detection mechanism code and messages.

### What issues does this PR fix or reference?
@[W-9499182](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000PEjEYAW/view)@

### Functionality Before
Hardcoded `scannedLocal` and `scannedRemote` were displayed to the user after a conflict was detected. 

### Functionality After
The new mechanism does not hardcode values of 0 for `scannedLocal` and `scannedRemote` and these fields are not displayed to the user after a conflict is detected. 
<img width="1337" alt="Screen Shot 2021-06-22 at 4 37 47 PM" src="https://user-images.githubusercontent.com/40456127/123013749-a48ade80-d379-11eb-9fc0-a8e23255ef80.png">

