### PR TITLE
perf: stops the language service output panel from stealing focus

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/languageServer.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageServer.ts
@@ -11,7 +11,8 @@ import * as vscode from 'vscode';
 import {
   Executable,
   LanguageClient,
-  LanguageClientOptions
+  LanguageClientOptions,
+  RevealOutputChannelOn
 } from 'vscode-languageclient';
 import { LSP_ERR } from './constants';
 import { soqlMiddleware } from './embeddedSoql';
@@ -165,6 +166,7 @@ export function buildClientOptions(): LanguageClientOptions {
         vscode.workspace.createFileSystemWatcher('**/sfdx-project.json') // SFDX workspace configuration file
       ]
     },
+    revealOutputChannelOn: RevealOutputChannelOn.Never,
     uriConverters: {
       code2Protocol: code2ProtocolConverter,
       protocol2Code: protocol2CodeConverter

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/languageServer.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/languageServer.test.ts
@@ -12,6 +12,9 @@ import { createSandbox } from 'sinon';
 import { Uri } from 'vscode';
 import * as vscode from 'vscode';
 import {
+  RevealOutputChannelOn
+} from 'vscode-languageclient';
+import {
   buildClientOptions,
   code2ProtocolConverter
 } from '../../src/languageServer';
@@ -91,6 +94,24 @@ describe('Apex Language Server Client', () => {
       expect(clientOptions.initializationOptions).not.to.be.undefined;
       expect(clientOptions.initializationOptions.enableEmbeddedSoqlCompletion)
         .to.be.false;
+    });
+  });
+
+  describe('Should not actively disturb user while running in the background', () => {
+    const sandbox = createSandbox();
+
+    beforeEach(() => {});
+    afterEach(() => sandbox.restore());
+
+    it('should never reveal output channel', () => {
+      sandbox
+        .stub(vscode.extensions, 'getExtension')
+        .withArgs('salesforce.salesforcedx-vscode-soql')
+        .returns({});
+
+      const clientOptions = buildClientOptions();
+
+      expect(clientOptions.revealOutputChannelOn).to.equal(RevealOutputChannelOn.Never);
     });
   });
 });


### PR DESCRIPTION
when creating the language server, sets the client options to never reveal the output channel,
preventing focus from being stolen and distracting the user during development.

fix #1429

### What does this PR do?

### What issues does this PR fix or reference?
#1429 , @W-9464384@

### Functionality Before
Language server output panel liked to steal focus.

### Functionality After
Output panel will no longer automatically be opened and receive focus.