### PR TITLE
feat: conflict detection enable deploy

### DIFF
--- a/packages/salesforcedx-sobjects-faux-generator/src/transformer/transformerFactory.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/transformer/transformerFactory.ts
@@ -76,9 +76,8 @@ export class SObjectTransformerFactory {
         generators.push(customGenerator);
       }
     }
-    // TODO Enable as part of W-8912293
-    // generators.push(new TypingGenerator());
 
+    generators.push(new TypingGenerator());
     generators.push(new SOQLMetadataGenerator(category));
 
     return new SObjectTransformer(

--- a/packages/salesforcedx-vscode-apex/src/languageServer.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageServer.ts
@@ -52,7 +52,8 @@ async function createServer(
       uberJar,
       '-Ddebug.internal.errors=true',
       `-Ddebug.semantic.errors=${enableSemanticErrors}`,
-      `-Ddebug.completion.statistics=${enableCompletionStatistics}`
+      `-Ddebug.completion.statistics=${enableCompletionStatistics}`,
+      '-Dlwc.typegeneration.disabled=true'
     ];
 
     if (jvmMaxHeap) {

--- a/packages/salesforcedx-vscode-apex/src/languageServer.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageServer.ts
@@ -11,7 +11,8 @@ import * as vscode from 'vscode';
 import {
   Executable,
   LanguageClient,
-  LanguageClientOptions
+  LanguageClientOptions,
+  RevealOutputChannelOn
 } from 'vscode-languageclient';
 import { LSP_ERR } from './constants';
 import { soqlMiddleware } from './embeddedSoql';
@@ -166,6 +167,7 @@ export function buildClientOptions(): LanguageClientOptions {
         vscode.workspace.createFileSystemWatcher('**/sfdx-project.json') // SFDX workspace configuration file
       ]
     },
+    revealOutputChannelOn: RevealOutputChannelOn.Never,
     uriConverters: {
       code2Protocol: code2ProtocolConverter,
       protocol2Code: protocol2CodeConverter

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/languageServer.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/languageServer.test.ts
@@ -12,6 +12,9 @@ import { createSandbox } from 'sinon';
 import { Uri } from 'vscode';
 import * as vscode from 'vscode';
 import {
+  RevealOutputChannelOn
+} from 'vscode-languageclient';
+import {
   buildClientOptions,
   code2ProtocolConverter
 } from '../../src/languageServer';
@@ -91,6 +94,24 @@ describe('Apex Language Server Client', () => {
       expect(clientOptions.initializationOptions).not.to.be.undefined;
       expect(clientOptions.initializationOptions.enableEmbeddedSoqlCompletion)
         .to.be.false;
+    });
+  });
+
+  describe('Should not actively disturb user while running in the background', () => {
+    const sandbox = createSandbox();
+
+    beforeEach(() => {});
+    afterEach(() => sandbox.restore());
+
+    it('should never reveal output channel', () => {
+      sandbox
+        .stub(vscode.extensions, 'getExtension')
+        .withArgs('salesforce.salesforcedx-vscode-soql')
+        .returns({});
+
+      const clientOptions = buildClientOptions();
+
+      expect(clientOptions.revealOutputChannelOn).to.equal(RevealOutputChannelOn.Never);
     });
   });
 });

--- a/packages/salesforcedx-vscode-core/src/commands/util/postconditionCheckers.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/postconditionCheckers.ts
@@ -24,7 +24,7 @@ import { TimestampConflictDetector } from '../../conflict/timestampConflictDetec
 import { workspaceContext } from '../../context';
 import { nls } from '../../messages';
 import { notificationService } from '../../notifications';
-import { sfdxCoreSettings } from '../../settings';
+import { DeployQueue, sfdxCoreSettings } from '../../settings';
 import { telemetryService } from '../../telemetry';
 import { getRootWorkspacePath, MetadataDictionary } from '../../util';
 import { PathStrategyFactory } from './sourcePathStrategies';
@@ -406,6 +406,7 @@ export class TimestampConflictChecker implements PostconditionChecker<string> {
           results
         );
 
+        await DeployQueue.get().unlock();
         return { type: 'CANCEL' };
       }
     }


### PR DESCRIPTION
What does this PR do?
This PR enables the new conflict detection mechanism for 1) deploy with manifest 2) deploy single source path and 3) deploy multiple source paths. 

What issues does this PR fix or reference?
@[W-9164037](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000BO4PYAW/view)@

Functionality Before
We had conflict detection for 1) deploy with manifest but did not have conflict detection for 2) & 3) deploy single/multiple source path. 

Functionality After
The new conflict detection mechanism is enabled for 1) deploy with manifest 2) deploy single source path and 3) deploy multiple source paths. 

manifest example: 
<img width="815" alt="Screen Shot 2021-06-25 at 9 29 52 AM" src="https://user-images.githubusercontent.com/40456127/123456649-f01ad380-d597-11eb-8743-1b2f889d255d.png">

single path example:
<img width="914" alt="Screen Shot 2021-06-25 at 9 28 09 AM" src="https://user-images.githubusercontent.com/40456127/123456676-f6a94b00-d597-11eb-87a7-2231cff6e340.png">

multiple path example (called in deploy on save): 
<img width="1083" alt="Screen Shot 2021-06-25 at 9 33 09 AM" src="https://user-images.githubusercontent.com/40456127/123457095-6cadb200-d598-11eb-850f-165cf35138eb.png">

