### PR TITLE
fix: conflict detection not working on new project

### DIFF
--- a/packages/salesforcedx-vscode-core/src/conflict/metadataCacheService.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/metadataCacheService.ts
@@ -110,7 +110,8 @@ export class MetadataCacheService {
       this.sourceComponents = this.isManifest
         ? await ComponentSet.fromManifest({
             manifestPath: this.componentPath,
-            resolveSourcePaths: packageDirs
+            resolveSourcePaths: packageDirs,
+            forceAddWildcards: true
           })
         : ComponentSet.fromSource(this.componentPath);
       return this.sourceComponents;
@@ -202,7 +203,7 @@ export class MetadataCacheService {
     baseDir: string
   ): string {
     if (comps.length === 0) {
-      return baseDir;
+      return '';
     }
     if (comps.length === 1) {
       return this.getRelativePath(comps[0], baseDir);


### PR DESCRIPTION
### What does this PR do?
Solves a bug that caused conflict detection to throw an error in a new project.

The two fixes are
1. When doing a retrieve, forceAddWildcards should be true so that the ComponentSet can be created properly. See forceSourceRetrieveManifest.ts for an example.
2. If there are no components (specifically no local components) the common root should be '' not baseDir, because the common root is defined as the relative path from baseDir.

### What issues does this PR fix or reference?
#3294, @W-9368479@

### Functionality Before
After creating a new project and running `Retrieve with Manifest` with conflict detection on, an error was triggered 'No components in the package to retrieve'

### Functionality After
Creating a new project and running `Retrieve with Manifest` with conflict detection on causes conflict detection to work as normal.
