### PR TITLE
Update bug template to ask for SF EXTENSION version

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,6 +1,10 @@
 ---
 name: Bug report
 about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
 ---
 
 <!--
@@ -32,7 +36,7 @@ _Describe what actually happened instead_.
 
 _Feel free to attach a screenshot_.
 
-**VS Code Version**:
+**Salesforce Extension Version in VS Code**:
 
 **SFDX CLI Version**:
 

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,6 +1,10 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
 ---
 
 **Is your feature request related to a problem? Please describe.**


### PR DESCRIPTION
we often have to ask a follow-up question to see which extension version they are on.  Changing the template to ask that upfront.  if we need to also know the VS Code version, we will ask in follow-ups and consider adding that to the template if we have to ask a lot