### PR TITLE
fix: add missing Experience Cloud targets

### DIFF
--- a/packages/salesforcedx-vscode-lwc/resources/static/js-meta.xsd
+++ b/packages/salesforcedx-vscode-lwc/resources/static/js-meta.xsd
@@ -112,6 +112,16 @@
                 <xs:documentation>Enables a component to be used on a Lightning community page in Experience Builder.</xs:documentation>
               </xs:annotation>
             </xs:enumeration>
+            <xs:enumeration value="lightningCommunity__Page_Layout">
+              <xs:annotation>
+                <xs:documentation>Enables a component to be used in Experience Builder as a page layout for an LWR site.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="lightningCommunity__Theme_Layout">
+              <xs:annotation>
+                <xs:documentation>Enables a component to be used in Experience Builder as a theme layout for an LWR site.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
             <xs:enumeration value="lightningCommunity__Default">
               <xs:annotation>
                 <xs:documentation>Used together with lightningCommunity__Page. Enables a component that includes configurable properties to be used on a Lightning community page in Experience Builder. When the component is selected on the page, the properties appear.</xs:documentation>


### PR DESCRIPTION
This PR adds missing Experience Cloud targets to the js-meta XML validation.

### What does this PR do?

### What issues does this PR fix or reference?
n/a

### Functionality Before
The js-meta validation is missing two Experience Cloud targets for LWR sites.

### Functionality After
The js-meta validation no longer declares the valid targets as invalid.
