### PR TITLE
fix: correct response from CompositePostconditionChecker

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/util/postconditionCheckers.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/postconditionCheckers.ts
@@ -41,21 +41,13 @@ export class CompositePostconditionChecker<T> implements PostconditionChecker<T>
     if (inputs.type === 'CONTINUE') {
       const aggregatedData: any = {};
       for (const postchecker of this.postcheckers) {
-        const input = await postchecker.check(inputs);
-        if (input.type === 'CONTINUE') {
-          Object.keys(input.data).forEach(
-            key => (aggregatedData[key] = input.data[key])
-          );
-        } else {
+        inputs = await postchecker.check(inputs);
+        if (inputs.type !== 'CONTINUE') {
           return {
             type: 'CANCEL'
           };
         }
       }
-      return {
-        type: 'CONTINUE',
-        data: aggregatedData
-      };
     }
     return inputs;
   }

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/postconditionCheckers.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/postconditionCheckers.test.ts
@@ -79,45 +79,45 @@ describe('Postcondition Checkers', () => {
 
     it('Should proceed to next checker if previous checker in composite checker is ContinueResponse', async () => {
       const compositePostconditionChecker = new CompositePostconditionChecker(
-        new (class implements PostconditionChecker<{}> {
+        new (class implements PostconditionChecker<string> {
           public async check(): Promise<
-            CancelResponse | ContinueResponse<{}>
+            CancelResponse | ContinueResponse<string>
           > {
-            return { type: 'CONTINUE', data: {} };
+            return { type: 'CONTINUE', data: 'package.xml' };
           }
         })(),
-        new (class implements PostconditionChecker<{}> {
+        new (class implements PostconditionChecker<string> {
           public async check(): Promise<
-            CancelResponse | ContinueResponse<{}>
+            CancelResponse | ContinueResponse<string>
           > {
-            return { type: 'CONTINUE', data: {} };
+            return { type: 'CONTINUE', data: 'package.xml' };
           }
         })()
       );
 
-      const response = await compositePostconditionChecker.check({ type: 'CONTINUE', data: {} });
+      const response = await compositePostconditionChecker.check({ type: 'CONTINUE', data: 'package.xml' });
       expect(response.type).to.equal('CONTINUE');
     });
 
     it('Should not proceed to next checker if previous checker in composite checker is CancelResponse', async () => {
       const compositePostconditionChecker = new CompositePostconditionChecker(
-        new (class implements PostconditionChecker<{}> {
+        new (class implements PostconditionChecker<string> {
           public async check(): Promise<
-            CancelResponse | ContinueResponse<{}>
+            CancelResponse | ContinueResponse<string>
           > {
             return { type: 'CANCEL' };
           }
         })(),
-        new (class implements PostconditionChecker<{}> {
+        new (class implements PostconditionChecker<string> {
           public async check(): Promise<
-            CancelResponse | ContinueResponse<{}>
+            CancelResponse | ContinueResponse<string>
           > {
             throw new Error('This should not be called');
           }
         })()
       );
 
-      await compositePostconditionChecker.check({ type: 'CONTINUE', data: {} });
+      await compositePostconditionChecker.check({ type: 'CONTINUE', data: 'package.xml' });
     });
 
     // tslint:disable:no-unused-expression
@@ -131,22 +131,22 @@ describe('Postcondition Checkers', () => {
         })(),
         new (class {
           public async gather(): Promise<
-            CancelResponse | ContinueResponse<{}>
+            CancelResponse | ContinueResponse<string>
           > {
-            return { type: 'CONTINUE', data: {} };
+            return { type: 'CONTINUE', data: 'package.xml' };
           }
         })(),
-        new (class implements CommandletExecutor<{}> {
-          public execute(response: ContinueResponse<{}>): void {
+        new (class implements CommandletExecutor<string> {
+          public execute(response: ContinueResponse<string>): void {
             executed = true;
           }
         })(),
-        new CompositePostconditionChecker<{}>(
-          new (class implements PostconditionChecker<{}> {
+        new CompositePostconditionChecker<string>(
+          new (class implements PostconditionChecker<string> {
             public async check(): Promise<
-              CancelResponse | ContinueResponse<{}>
+              CancelResponse | ContinueResponse<string>
             > {
-              return { type: 'CONTINUE', data: {} };
+              return { type: 'CONTINUE', data: 'package.xml' };
             }
           })()
         )
@@ -168,7 +168,7 @@ describe('Postcondition Checkers', () => {
           public async gather(): Promise<
             CancelResponse | ContinueResponse<{}>
           > {
-            return { type: 'CONTINUE', data: {} };
+            return { type: 'CONTINUE', data: 'package.xml' };
           }
         })(),
         new (class implements CommandletExecutor<{}> {


### PR DESCRIPTION
### What does this PR do?
During QA, a bug was found on deploying and retrieving with source path due to conflict detection changes. The problem went back to CompositePostconditionChecker not returning the correct data. This PR updates that class to chain the data rather than aggregate, which makes more sense for the common use case of data being file paths.

### What issues does this PR fix or reference?
@W-9164035@, @W-9164037@

### Functionality Before
Running deploy or retrieve from source path would result in the error "fsPaths is not iterable", due to incorrect data being returned from CompositePostconditionChecker. 

### Functionality After
CompositePostconditionChecker returns the correct data and there is no longer an error.
