### PR TITLE
fix: add back conflict detection progress/cancel popup

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/util/postconditionCheckers.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/postconditionCheckers.ts
@@ -24,7 +24,6 @@ import {
   conflictView,
   DirectoryDiffResults,
   MetadataCacheExecutor,
-  MetadataCacheService
 } from '../../conflict';
 import { TimestampConflictDetector } from '../../conflict/timestampConflictDetector';
 import { workspaceContext } from '../../context';

--- a/packages/salesforcedx-vscode-core/src/commands/util/postconditionCheckers.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/postconditionCheckers.ts
@@ -340,11 +340,6 @@ export class TimestampConflictChecker implements PostconditionChecker<string> {
 
     if (inputs.type === 'CONTINUE') {
       channelService.showChannelOutput();
-      channelService.showCommandWithTimestamp(
-        `${nls.localize('channel_starting_message')}${nls.localize(
-          'conflict_detect_execution_name'
-        )}\n`
-      );
 
       const { username } = workspaceContext;
       if (!username) {
@@ -354,8 +349,6 @@ export class TimestampConflictChecker implements PostconditionChecker<string> {
         };
       }
 
-      const componentPath = inputs.data;
-      const cacheService = new MetadataCacheService(username);
       const detector = new TimestampConflictDetector();
 
       const cacheExecutor = new MetadataCacheExecutor(
@@ -372,20 +365,6 @@ export class TimestampConflictChecker implements PostconditionChecker<string> {
       );
       await commandlet.run();
 
-
-      // const result = await cacheService.loadCache(
-      //   componentPath,
-      //   getRootWorkspacePath(),
-      //   this.isManifest
-      // );
-      // const detector = new TimestampConflictDetector();
-      // const diffs = detector.createDiffs(result);
-
-      channelService.showCommandWithTimestamp(
-        `${nls.localize('channel_end')} ${nls.localize(
-          'conflict_detect_execution_name'
-        )}\n`
-      );
       return await this.handleConflicts(inputs.data, username, detector.getDiffs());
     }
     return { type: 'CANCEL' };

--- a/packages/salesforcedx-vscode-core/src/conflict/timestampConflictDetector.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/timestampConflictDetector.ts
@@ -28,16 +28,20 @@ export class TimestampConflictDetector {
     this.diffs = Object.assign({}, TimestampConflictDetector.EMPTY_DIFFS);
   }
 
-  public createDiffs(
+  public getDiffs(): DirectoryDiffResults {
+    return this.diffs;
+  }
+
+  public async createDiffs(
+    username: string,
     result?: MetadataCacheResult
-  ): DirectoryDiffResults {
+  ): Promise<void> {
     if (!result) {
       throw new Error(nls.localize('conflict_detect_empty_results'));
     }
     this.createRootPaths(result);
     const components = MetadataCacheService.correlateResults(result);
     this.determineConflicts(components);
-    return this.diffs;
   }
 
   private determineConflicts(

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/timestampConflictDetector.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/timestampConflictDetector.test.ts
@@ -107,7 +107,7 @@ describe('Timestamp Conflict Detector Execution', () => {
     differStub.returns(diffResults);
     cacheStub.returns(storageResult);
 
-    const results = await executor.createDiffs(cacheResults);
+    const results = await executor.createDiffs('', cacheResults);
 
     expect(executorSpy.callCount).to.equal(1);
     expect(cacheStub.callCount).to.equal(1);
@@ -130,7 +130,7 @@ describe('Timestamp Conflict Detector Execution', () => {
       path.normalize('/a/b/c')
     ]);
 
-    expect(results.different).to.have.all.keys(
+    expect(executor.getDiffs().different).to.have.all.keys(
       path.normalize('classes/HandlerCostCenter.cls')
     );
   });
@@ -159,12 +159,12 @@ describe('Timestamp Conflict Detector Execution', () => {
       }] as FileProperties[]
     } as MetadataCacheResult;
 
-    const results = await executor.createDiffs(cacheResults);
+    const results = await executor.createDiffs('', cacheResults);
 
     expect(executorSpy.callCount).to.equal(1);
     expect(cacheStub.callCount).to.equal(0);
     expect(differStub.callCount).to.equal(0);
-    expect(results.different).to.eql(new Set<string>());
+    expect(executor.getDiffs().different).to.eql(new Set<string>());
   });
 
   it('Should not report differences if the component is only remote', async () => {
@@ -191,12 +191,12 @@ describe('Timestamp Conflict Detector Execution', () => {
       }] as FileProperties[]
     } as MetadataCacheResult;
 
-    const results = await executor.createDiffs(cacheResults);
+    const results = await executor.createDiffs('', cacheResults);
 
     expect(executorSpy.callCount).to.equal(1);
     expect(cacheStub.callCount).to.equal(0);
     expect(differStub.callCount).to.equal(0);
-    expect(results.different).to.eql(new Set<string>());
+    expect(executor.getDiffs().different).to.eql(new Set<string>());
   });
 
   it('Should not report differences if the timestamps match', async () => {
@@ -234,12 +234,12 @@ describe('Timestamp Conflict Detector Execution', () => {
 
     cacheStub.returns(storageResult);
 
-    const results = await executor.createDiffs(cacheResults);
+    const results = await executor.createDiffs('', cacheResults);
 
     expect(executorSpy.callCount).to.equal(1);
     expect(cacheStub.callCount).to.equal(1);
     expect(differStub.callCount).to.equal(0);
-    expect(results.different).to.eql(new Set<string>());
+    expect(executor.getDiffs().different).to.eql(new Set<string>());
   });
 
   it('Should not report differences if the files match', async () => {
@@ -280,7 +280,7 @@ describe('Timestamp Conflict Detector Execution', () => {
     differStub.returns(diffResults);
     cacheStub.returns(storageResult);
 
-    const results = await executor.createDiffs(cacheResults);
+    const results = await executor.createDiffs('', cacheResults);
 
     expect(executorSpy.callCount).to.equal(1);
     expect(cacheStub.callCount).to.equal(1);
@@ -303,14 +303,14 @@ describe('Timestamp Conflict Detector Execution', () => {
       path.normalize('/a/b/c')
     ]);
 
-    expect(results.different).to.eql(new Set<string>());
+    expect(executor.getDiffs().different).to.eql(new Set<string>());
   });
 
   it('Should report an error during conflict detection', async () => {
     const cacheResults = undefined;
 
     try {
-      await executor.createDiffs(cacheResults);
+      await executor.createDiffs('', cacheResults);
       fail('Failed to raise an exception during conflict detection');
     } catch (err) {
       expect(err.message).to.equal(


### PR DESCRIPTION
### What does this PR do?
This PR adds back the bottom-right progress/cancel popup for conflict detection. This is done by using the MetadataCacheExecutor class instead of the loadCache() method.

### What issues does this PR fix or reference?
@W-9545597@

### Functionality Before
The new conflict detection mechanism did not have the progress/cancel popup associated with running a command.

### Functionality After
Conflict detection now has that popup.
