### PR TITLE
fix: disable retrieve conflict detection 

### DIFF
--- a/docs/_articles/en/user-guide/detect-conflicts.md
+++ b/docs/_articles/en/user-guide/detect-conflicts.md
@@ -22,7 +22,7 @@ Because the conflict detection feature is in beta, you must enable the feature:
 
 You can also enter conflict detection in the search box to find the feature and then enable it.
 
-Once enabled, conflict detection is available on all commands that deploy and retrieve source.
+Once enabled, conflict detection is available on all commands that deploy source.
 
 ![Prompt for conflict detection](./images/DetectConflict_prompt.png)
 

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveManifest.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveManifest.ts
@@ -13,10 +13,6 @@ import { ComponentSet } from '@salesforce/source-deploy-retrieve';
 import { join } from 'path';
 import * as vscode from 'vscode';
 import { channelService } from '../channels';
-import {
-  ConflictDetectionMessages,
-  TimestampConflictChecker
-} from '../commands/util/postconditionCheckers';
 import { nls } from '../messages';
 import { notificationService } from '../notifications';
 import { sfdxCoreSettings } from '../settings';
@@ -89,24 +85,12 @@ export async function forceSourceRetrieveManifest(explorerPath: vscode.Uri) {
     }
   }
 
-  const messages: ConflictDetectionMessages = {
-    warningMessageKey: 'conflict_detect_conflicts_during_retrieve',
-    commandHint: input => {
-      return new SfdxCommandBuilder()
-        .withArg('force:source:retrieve')
-        .withFlag('--manifest', input)
-        .build()
-        .toString();
-    }
-  };
-
   const commandlet = new SfdxCommandlet(
     new SfdxWorkspaceChecker(),
     new FilePathGatherer(explorerPath),
     sfdxCoreSettings.getBetaDeployRetrieve()
       ? new LibrarySourceRetrieveManifestExecutor()
-      : new ForceSourceRetrieveManifestExecutor(),
-    new TimestampConflictChecker(true, messages)
+      : new ForceSourceRetrieveManifestExecutor()
   );
   await commandlet.run();
 }

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveSourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveSourcePath.ts
@@ -28,11 +28,6 @@ import {
   SfdxCommandletExecutor,
   SfdxWorkspaceChecker
 } from './util';
-import {
-  CompositePostconditionChecker,
-  ConflictDetectionMessages,
-  TimestampConflictChecker
-} from './util/postconditionCheckers';
 
 export class ForceSourceRetrieveSourcePathExecutor extends SfdxCommandletExecutor<
   string
@@ -119,27 +114,13 @@ export async function forceSourceRetrieveSourcePath(explorerPath: vscode.Uri) {
     }
   }
 
-  const messages: ConflictDetectionMessages = {
-    warningMessageKey: 'conflict_detect_conflicts_during_retrieve',
-    commandHint: input => {
-      return new SfdxCommandBuilder()
-        .withArg('force:source:retrieve')
-        .withFlag('--sourcepath', input)
-        .build()
-        .toString();
-    }
-  };
-
   const commandlet = new SfdxCommandlet(
     new SfdxWorkspaceChecker(),
     new FilePathGatherer(explorerPath),
     sfdxCoreSettings.getBetaDeployRetrieve()
       ? new LibraryRetrieveSourcePathExecutor()
       : new ForceSourceRetrieveSourcePathExecutor(),
-    new CompositePostconditionChecker(
-      new SourcePathChecker(),
-      new TimestampConflictChecker(false, messages)
-    )
+    new SourcePathChecker()
   );
   await commandlet.run();
 }


### PR DESCRIPTION
### What does this PR do?
This PR disables conflict detection for source path retrieve and manifest retrieve. Reasons for this decision were discussed in this [slack thread](https://platformcloud.slack.com/archives/GCDT2EVAQ/p1625172470054400). 

### What issues does this PR fix or reference?
@W-9549931@, @W-9549942@

### Functionality Before
The timestamp conflict detection mechanism was used in source path retrieve and manifest retrieve. 

### Functionality After
The timestamp conflict detection mechanism is disabled for source path retrieve and manifest retrieve. 
