### PR TITLE
fix: support child components in correlateResults

### DIFF
--- a/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/metadataCacheService.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/metadataCacheService.test.ts
@@ -321,7 +321,7 @@ describe('Metadata Cache', () => {
       type: {
         name: 'CustomField'
       }
-    }
+    };
     const cacheResults = {
       cache: {
         baseDirectory: path.normalize('/a/b'),

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/metadataCacheService.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/metadataCacheService.test.ts
@@ -322,30 +322,32 @@ describe('Metadata Cache', () => {
         name: 'CustomField'
       }
     };
-    const cacheResults = {
-      cache: {
-        baseDirectory: path.normalize('/a/b'),
-        commonRoot: 'c',
-        components: [compOne, compTwo, childComp] as SourceComponent[]
-      },
-      project: {
-        baseDirectory: path.normalize('/d'),
-        commonRoot: path.normalize('e/f'),
-        components: [compTwo, childComp, compOne] as SourceComponent[]
-      },
-      properties: [{
-        fullName: 'HandlerCostCenter',
-        lastModifiedDate: 'Today',
-        type: 'ApexClass'
-      },
-      {
-        fullName: 'Account',
-        lastModifiedDate: 'Yesterday',
-        type: 'CustomObject'
-      }] as FileProperties[]
-    } as MetadataCacheResult;
+    const fileProperties = [{
+      fullName: 'HandlerCostCenter',
+      lastModifiedDate: 'Today',
+      type: 'ApexClass'
+    },
+    {
+      fullName: 'Account',
+      lastModifiedDate: 'Yesterday',
+      type: 'CustomObject'
+    }] as FileProperties[];
 
     it('Should correlate results correctly', () => {
+      const cacheResults = {
+        cache: {
+          baseDirectory: path.normalize('/a/b'),
+          commonRoot: 'c',
+          components: [compOne, compTwo, childComp] as SourceComponent[]
+        },
+        project: {
+          baseDirectory: path.normalize('/d'),
+          commonRoot: path.normalize('e/f'),
+          components: [compTwo, childComp, compOne] as SourceComponent[]
+        },
+        properties: fileProperties
+      } as MetadataCacheResult;
+
       const components = MetadataCacheService.correlateResults(cacheResults);
 
       expect(components.length).to.equal(2);
@@ -357,6 +359,36 @@ describe('Metadata Cache', () => {
       {
         cacheComponent: compTwo,
         projectComponent: compTwo,
+        lastModifiedDate: 'Yesterday'
+      }]);
+    });
+
+    it('Should correlate results for just a child component', () => {
+      const cacheResults = {
+        cache: {
+          baseDirectory: path.normalize('/a/b'),
+          commonRoot: 'c',
+          components: [compOne, childComp] as SourceComponent[]
+        },
+        project: {
+          baseDirectory: path.normalize('/d'),
+          commonRoot: path.normalize('e/f'),
+          components: [childComp, compOne] as SourceComponent[]
+        },
+        properties: fileProperties
+      } as MetadataCacheResult;
+      
+      const components = MetadataCacheService.correlateResults(cacheResults);
+
+      expect(components.length).to.equal(2);
+      expect(components).to.have.deep.members([{
+        cacheComponent: compOne,
+        projectComponent: compOne,
+        lastModifiedDate: 'Today'
+      },
+      {
+        cacheComponent: childComp,
+        projectComponent: childComp,
         lastModifiedDate: 'Yesterday'
       }]);
     });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/metadataCacheService.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/metadataCacheService.test.ts
@@ -377,7 +377,7 @@ describe('Metadata Cache', () => {
         },
         properties: fileProperties
       } as MetadataCacheResult;
-      
+
       const components = MetadataCacheService.correlateResults(cacheResults);
 
       expect(components.length).to.equal(2);

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/metadataCacheService.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/metadataCacheService.test.ts
@@ -303,38 +303,35 @@ describe('Metadata Cache', () => {
   }
 
   describe('Static Methods', () => {
+    const compOne = {
+      fullName: 'HandlerCostCenter',
+      type: {
+        name: 'ApexClass'
+      }
+    };
+    const compTwo = {
+      fullName: 'Account',
+      type: {
+        name: 'CustomObject'
+      }
+    };
+    const childComp = {
+      fullName: 'AccountNumber',
+      parent: compTwo,
+      type: {
+        name: 'CustomField'
+      }
+    }
     const cacheResults = {
       cache: {
         baseDirectory: path.normalize('/a/b'),
         commonRoot: 'c',
-        components: [{
-          fullName: 'HandlerCostCenter',
-          type: {
-            name: 'ApexClass'
-          }
-        },
-        {
-          fullName: 'AccountController',
-          type: {
-            name: 'ApexClass'
-          }
-        }] as SourceComponent[]
+        components: [compOne, compTwo, childComp] as SourceComponent[]
       },
       project: {
         baseDirectory: path.normalize('/d'),
         commonRoot: path.normalize('e/f'),
-        components: [{
-          fullName: 'AccountController',
-          type: {
-            name: 'ApexClass'
-          }
-        },
-        {
-          fullName: 'HandlerCostCenter',
-          type: {
-            name: 'ApexClass'
-          }
-        }] as SourceComponent[]
+        components: [compTwo, childComp, compOne] as SourceComponent[]
       },
       properties: [{
         fullName: 'HandlerCostCenter',
@@ -342,9 +339,9 @@ describe('Metadata Cache', () => {
         type: 'ApexClass'
       },
       {
-        fullName: 'AccountController',
+        fullName: 'Account',
         lastModifiedDate: 'Yesterday',
-        type: 'ApexClass'
+        type: 'CustomObject'
       }] as FileProperties[]
     } as MetadataCacheResult;
 
@@ -353,34 +350,14 @@ describe('Metadata Cache', () => {
 
       expect(components.length).to.equal(2);
       expect(components).to.have.deep.members([{
-        cacheComponent: {
-          fullName: 'AccountController',
-          type: {
-            name: 'ApexClass'
-          }
-        },
-        projectComponent: {
-          fullName: 'AccountController',
-          type: {
-            name: 'ApexClass'
-          }
-        },
-        lastModifiedDate: 'Yesterday'
+        cacheComponent: compOne,
+        projectComponent: compOne,
+        lastModifiedDate: 'Today'
       },
       {
-        cacheComponent: {
-          fullName: 'HandlerCostCenter',
-          type: {
-            name: 'ApexClass'
-          }
-        },
-        projectComponent: {
-          fullName: 'HandlerCostCenter',
-          type: {
-            name: 'ApexClass'
-          }
-        },
-        lastModifiedDate: 'Today'
+        cacheComponent: compTwo,
+        projectComponent: compTwo,
+        lastModifiedDate: 'Yesterday'
       }]);
     });
   });


### PR DESCRIPTION
### What does this PR do?
This PR allows child components to work for conflict detection. Child components do not have their own FileProperties objects and thus have to use their parents'.

### What issues does this PR fix or reference?
@W-9608415@

### Functionality Before
Deploying a single or multiple child components without their corresponding parent would never be able to detect conflicts.

### Functionality After
Conflicts can be detected in child components, but they use their parents' lastModifed timestamps.

Testing this PR made me realize a piece of strange behavior for conflict detection, which is that extra conflicts can result from timestamps existing at the component level and not the file level. For example: a conflict exists in CustomField X and CustomField Y from the same CustomObject is deployed with a local change. A conflict will be detected in Y because the conflict in X caused the CustomObject's timestamps to have a disparity.
