### PR TITLE
feat: introduce 3 Apex Test Suite commands

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -157,6 +157,18 @@
           "when": "sfdx:project_opened"
         },
         {
+          "command": "sfdx.force.apex.test.suite.run",
+          "when": "sfdx:project_opened"
+        },
+        {
+          "command": "sfdx.force.apex.test.suite.create",
+          "when": "sfdx:project_opened"
+        },
+        {
+          "command": "sfdx.force.apex.test.suite.add",
+          "when": "sfdx:project_opened"
+        },
+        {
           "command": "sfdx.force.test.view.runClassTests",
           "when": "false"
         },
@@ -198,6 +210,18 @@
       {
         "command": "sfdx.force.apex.test.run",
         "title": "%force_apex_test_run_text%"
+      },
+      {
+        "command": "sfdx.force.apex.test.suite.run",
+        "title": "SFDX: Run Apex Test Suite"
+      },
+      {
+        "command": "sfdx.force.apex.test.suite.create",
+        "title": "SFDX: Create Apex Test Suite"
+      },
+      {
+        "command": "sfdx.force.apex.test.suite.add",
+        "title": "SFDX: Add Tests to Apex Test Suite"
       },
       {
         "command": "sfdx.force.test.view.run",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -213,15 +213,15 @@
       },
       {
         "command": "sfdx.force.apex.test.suite.run",
-        "title": "SFDX: Run Apex Test Suite"
+        "title": "%force_apex_test_suite_run_text%"
       },
       {
         "command": "sfdx.force.apex.test.suite.create",
-        "title": "SFDX: Create Apex Test Suite"
+        "title": "%force_apex_test_suite_create_text%"
       },
       {
         "command": "sfdx.force.apex.test.suite.add",
-        "title": "SFDX: Add Tests to Apex Test Suite"
+        "title": "%force_apex_test_suite_build_text%"
       },
       {
         "command": "sfdx.force.test.view.run",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -25,7 +25,7 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/apex-node": "0.2.2",
+    "@salesforce/apex-node": "0.2.3",
     "@salesforce/apex-tmlanguage": "1.4.0",
     "@salesforce/core": "2.23.2",
     "@salesforce/salesforcedx-utils-vscode": "52.6.0",

--- a/packages/salesforcedx-vscode-apex/package.nls.json
+++ b/packages/salesforcedx-vscode-apex/package.nls.json
@@ -17,5 +17,8 @@
   "force_apex_test_last_method_run_text": "SFDX: Re-Run Last Run Apex Test Method",
   "force_apex_test_class_run_text": "SFDX: Run Apex Test Class",
   "force_apex_test_method_run_text": "SFDX: Run Apex Test Method",
-  "force_apex_test_run_text": "SFDX: Run Apex Tests"
+  "force_apex_test_run_text": "SFDX: Run Apex Tests",
+  "force_apex_test_suite_run_text": "SFDX: Run Apex Test Suite",
+  "force_apex_test_suite_create_text": "SFDX: Create Apex Test Suite",
+  "force_apex_test_suite_build_text": "SFDX: Add Tests to Apex Test Suite"
 }

--- a/packages/salesforcedx-vscode-apex/src/commands/forceApexTestRun.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceApexTestRun.ts
@@ -155,12 +155,6 @@ export class ApexLibraryTestRunExecutor extends LibraryCommandletExecutor<
           response.data.label
         );
         break;
-      case TestType.AllLocal:
-        payload = { testLevel: TestLevel.RunLocalTests };
-        break;
-      case TestType.All:
-        payload = { testLevel: TestLevel.RunAllTestsInOrg };
-        break;
       default:
         payload = { testLevel: TestLevel.RunAllTestsInOrg };
     }

--- a/packages/salesforcedx-vscode-apex/src/commands/forceApexTestRun.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceApexTestRun.ts
@@ -155,6 +155,12 @@ export class ApexLibraryTestRunExecutor extends LibraryCommandletExecutor<
           response.data.label
         );
         break;
+      case TestType.AllLocal:
+        payload = { testLevel: TestLevel.RunLocalTests };
+        break;
+      case TestType.All:
+        payload = { testLevel: TestLevel.RunAllTestsInOrg };
+        break;
       default:
         payload = { testLevel: TestLevel.RunAllTestsInOrg };
     }

--- a/packages/salesforcedx-vscode-apex/src/commands/forceApexTestSuite.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceApexTestSuite.ts
@@ -1,24 +1,24 @@
 import { TestService } from '@salesforce/apex-node';
 import {
-  CancelResponse,
-  ContinueResponse,
-  ParametersGatherer
-} from '@salesforce/salesforcedx-utils-vscode/out/src/types';
-import {
   LibraryCommandletExecutor,
   SfdxCommandlet,
   SfdxWorkspaceChecker
 } from '@salesforce/salesforcedx-utils-vscode/out/src';
+import {
+  CancelResponse,
+  ContinueResponse,
+  ParametersGatherer
+} from '@salesforce/salesforcedx-utils-vscode/out/src/types';
+import { readFileSync } from 'fs';
+import { basename } from 'path';
+import * as vscode from 'vscode';
+import { OUTPUT_CHANNEL } from '../channels';
 import { workspaceContext } from '../context';
 import {
   ApexLibraryTestRunExecutor,
   ApexTestQuickPickItem,
   TestType
 } from './forceApexTestRun';
-import * as vscode from 'vscode';
-import { OUTPUT_CHANNEL } from '../channels';
-import { readFileSync } from 'fs';
-import { basename } from 'path';
 
 type ApexTestSuiteOptions = { suitename: string; tests: string[] };
 

--- a/packages/salesforcedx-vscode-apex/src/commands/forceApexTestSuite.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceApexTestSuite.ts
@@ -1,0 +1,196 @@
+import { TestService } from '@salesforce/apex-node';
+import {
+  CancelResponse,
+  ContinueResponse,
+  ParametersGatherer
+} from '@salesforce/salesforcedx-utils-vscode/out/src/types';
+import {
+  LibraryCommandletExecutor,
+  SfdxCommandlet,
+  SfdxWorkspaceChecker
+} from '@salesforce/salesforcedx-utils-vscode/out/src';
+import { workspaceContext } from '../context';
+import {
+  ApexLibraryTestRunExecutor,
+  ApexTestQuickPickItem,
+  TestType
+} from './forceApexTestRun';
+import * as vscode from 'vscode';
+import { OUTPUT_CHANNEL } from '../channels';
+import { readFileSync } from 'fs';
+import { basename } from 'path';
+
+type ApexTestSuiteOptions = { suitename: string; tests: string[] };
+
+async function listApexClassItems(): Promise<ApexTestQuickPickItem[]> {
+  const apexClasses = await vscode.workspace.findFiles('**/*.cls');
+  const apexClassItems: ApexTestQuickPickItem[] = [];
+
+  apexClasses.forEach(apexClass => {
+    const fileContent = readFileSync(apexClass.fsPath).toString();
+    if (fileContent && fileContent.toLowerCase().includes('@istest')) {
+      apexClassItems.push({
+        label: basename(apexClass.toString()).replace('.cls', ''),
+        description: apexClass.fsPath,
+        type: TestType.Class
+      });
+    }
+  });
+
+  return apexClassItems;
+}
+
+async function listApexTestSuiteItems(): Promise<ApexTestQuickPickItem[]> {
+  const connection = await workspaceContext.getConnection();
+  const testService = new TestService(connection);
+  const testSuites = await testService.retrieveAllSuites();
+
+  const quickPickItems = testSuites.map(testSuite => {
+    return {
+      label: testSuite.TestSuiteName,
+      // @ts-ignore
+      description: testSuite.Id,
+      type: TestType.Suite
+    };
+  });
+  return quickPickItems;
+}
+
+export class TestSuiteSelector
+  implements ParametersGatherer<ApexTestQuickPickItem> {
+  public async gather(): Promise<
+    CancelResponse | ContinueResponse<ApexTestQuickPickItem>
+  > {
+    const quickPickItems = await listApexTestSuiteItems();
+
+    const testSuiteName = (await vscode.window.showQuickPick(
+      quickPickItems
+    )) as ApexTestQuickPickItem;
+
+    return testSuiteName
+      ? { type: 'CONTINUE', data: testSuiteName }
+      : { type: 'CANCEL' };
+  }
+}
+
+export class TestSuiteBuilder
+  implements ParametersGatherer<ApexTestSuiteOptions> {
+  public async gather(): Promise<
+    CancelResponse | ContinueResponse<ApexTestSuiteOptions>
+  > {
+    const quickPickItems = await listApexTestSuiteItems();
+
+    const testSuiteName = (await vscode.window.showQuickPick(
+      quickPickItems
+    )) as ApexTestQuickPickItem;
+
+    if (testSuiteName) {
+      const apexClassItems = await listApexClassItems();
+
+      const apexClassSelection = (await vscode.window.showQuickPick(
+        apexClassItems,
+        { canPickMany: true }
+      )) as ApexTestQuickPickItem[];
+      const apexClassNames = apexClassSelection?.map(
+        selection => selection.label
+      );
+
+      return apexClassSelection
+        ? {
+            type: 'CONTINUE',
+            data: { suitename: testSuiteName.label, tests: apexClassNames }
+          }
+        : { type: 'CANCEL' };
+    }
+    return { type: 'CANCEL' };
+  }
+}
+
+export class TestSuiteCreator
+  implements ParametersGatherer<ApexTestSuiteOptions> {
+  public async gather(): Promise<
+    CancelResponse | ContinueResponse<ApexTestSuiteOptions>
+  > {
+    const testSuiteInput = {
+      prompt: 'Enter desired Apex test suite name:'
+    } as vscode.InputBoxOptions;
+    const testSuiteName = await vscode.window.showInputBox(testSuiteInput);
+
+    if (testSuiteName) {
+      const apexClassItems = await listApexClassItems();
+
+      const apexClassSelection = (await vscode.window.showQuickPick(
+        apexClassItems,
+        { canPickMany: true }
+      )) as ApexTestQuickPickItem[];
+      const apexClassNames = apexClassSelection?.map(
+        selection => selection.label
+      );
+
+      return apexClassSelection
+        ? {
+            type: 'CONTINUE',
+            data: { suitename: testSuiteName, tests: apexClassNames }
+          }
+        : { type: 'CANCEL' };
+    }
+    return { type: 'CANCEL' };
+  }
+}
+
+export class ApexLibraryTestSuiteBuilder extends LibraryCommandletExecutor<
+  ApexTestSuiteOptions
+> {
+  public static diagnostics = vscode.languages.createDiagnosticCollection(
+    'apex-errors'
+  );
+
+  constructor() {
+    super(
+      'SFDX: Build Apex Test Suite',
+      'force_apex_test_suite_build_library',
+      OUTPUT_CHANNEL
+    );
+  }
+
+  public async run(
+    response: ContinueResponse<ApexTestSuiteOptions>
+  ): Promise<boolean> {
+    const connection = await workspaceContext.getConnection();
+    const testService = new TestService(connection);
+    await testService.buildSuite(response.data.suitename, response.data.tests);
+    return true;
+  }
+}
+
+const workspaceChecker = new SfdxWorkspaceChecker();
+const testSuiteSelector = new TestSuiteSelector();
+const testSuiteCreator = new TestSuiteCreator();
+const testSuiteBuilder = new TestSuiteBuilder();
+
+export async function forceApexTestSuiteAdd() {
+  const commandlet = new SfdxCommandlet(
+    workspaceChecker,
+    testSuiteBuilder,
+    new ApexLibraryTestSuiteBuilder()
+  );
+  await commandlet.run();
+}
+
+export async function forceApexTestSuiteCreate() {
+  const commandlet = new SfdxCommandlet(
+    workspaceChecker,
+    testSuiteCreator,
+    new ApexLibraryTestSuiteBuilder()
+  );
+  await commandlet.run();
+}
+
+export async function forceApexTestSuiteRun() {
+  const commandlet = new SfdxCommandlet(
+    workspaceChecker,
+    testSuiteSelector,
+    new ApexLibraryTestRunExecutor()
+  );
+  await commandlet.run();
+}

--- a/packages/salesforcedx-vscode-apex/src/commands/forceApexTestSuite.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceApexTestSuite.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
 import { TestService } from '@salesforce/apex-node';
 import {
   LibraryCommandletExecutor,
@@ -20,7 +27,7 @@ import {
   TestType
 } from './forceApexTestRun';
 
-type ApexTestSuiteOptions = { suitename: string; tests: string[] };
+export type ApexTestSuiteOptions = { suitename: string; tests: string[] };
 
 async function listApexClassItems(): Promise<ApexTestQuickPickItem[]> {
   const apexClasses = await vscode.workspace.findFiles('**/*.cls');

--- a/packages/salesforcedx-vscode-apex/src/commands/forceApexTestSuite.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceApexTestSuite.ts
@@ -21,6 +21,7 @@ import { basename } from 'path';
 import * as vscode from 'vscode';
 import { OUTPUT_CHANNEL } from '../channels';
 import { workspaceContext } from '../context';
+import { nls } from '../messages';
 import {
   ApexLibraryTestRunExecutor,
   ApexTestQuickPickItem,
@@ -154,7 +155,7 @@ export class ApexLibraryTestSuiteBuilder extends LibraryCommandletExecutor<
 
   constructor() {
     super(
-      'SFDX: Build Apex Test Suite',
+      nls.localize('force_apex_test_suite_build_text'),
       'force_apex_test_suite_build_library',
       OUTPUT_CHANNEL
     );

--- a/packages/salesforcedx-vscode-apex/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/index.ts
@@ -17,3 +17,4 @@ export {
 export { forceApexLogGet } from './forceApexLogGet';
 export { forceApexTestRun } from './forceApexTestRun';
 export { forceApexExecute } from './forceApexExecute';
+export { forceApexTestSuiteAdd, forceApexTestSuiteCreate, forceApexTestSuiteRun } from './forceApexTestSuite';

--- a/packages/salesforcedx-vscode-apex/src/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/index.ts
@@ -19,7 +19,10 @@ import {
   forceApexTestClassRunCodeActionDelegate,
   forceApexTestMethodRunCodeAction,
   forceApexTestMethodRunCodeActionDelegate,
-  forceApexTestRun
+  forceApexTestRun,
+  forceApexTestSuiteAdd,
+  forceApexTestSuiteCreate,
+  forceApexTestSuiteRun
 } from './commands';
 import { APEX_EXTENSION_NAME, LSP_ERR } from './constants';
 import { workspaceContext } from './context';
@@ -182,6 +185,18 @@ function registerCommands(
     'sfdx.force.apex.test.method.run',
     forceApexTestMethodRunCodeAction
   );
+  const forceApexTestSuiteCreateCmd = vscode.commands.registerCommand(
+    'sfdx.force.apex.test.suite.create',
+    forceApexTestSuiteCreate
+  );
+  const forceApexTestSuiteRunCmd = vscode.commands.registerCommand(
+    'sfdx.force.apex.test.suite.run',
+    forceApexTestSuiteRun
+  );
+  const forceApexTestSuiteAddCmd = vscode.commands.registerCommand(
+    'sfdx.force.apex.test.suite.add',
+    forceApexTestSuiteAdd
+  );
   const forceApexTestRunCmd = vscode.commands.registerCommand(
     'sfdx.force.apex.test.run',
     forceApexTestRun
@@ -209,7 +224,10 @@ function registerCommands(
     forceApexTestMethodRunCmd,
     forceApexTestMethodRunDelegateCmd,
     forceApexTestRunCmd,
-    forceApexToggleColorizerCmd
+    forceApexToggleColorizerCmd,
+    forceApexTestSuiteCreateCmd,
+    forceApexTestSuiteRunCmd,
+    forceApexTestSuiteAddCmd
   );
 }
 

--- a/packages/salesforcedx-vscode-apex/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-apex/src/messages/i18n.ts
@@ -72,5 +72,6 @@ export const messages = {
   source_missing_text:
     '%s points to a missing folder. For information on how to setup the Salesforce Apex extension, see [Set Your Java Version](%s).',
   wrong_java_version_text:
-    'An unsupported Java version was detected. Download and install [Java 8](https://java.com/en/download/) or [Java 11](https://www.oracle.com/technetwork/java/javase/downloads/jdk11-downloads-5066655.html) to run the extensions. For more information, see [Set Your Java Version](%s).'
+    'An unsupported Java version was detected. Download and install [Java 8](https://java.com/en/download/) or [Java 11](https://www.oracle.com/technetwork/java/javase/downloads/jdk11-downloads-5066655.html) to run the extensions. For more information, see [Set Your Java Version](%s).',
+  force_apex_test_suite_build_text: 'SFDX: Build Apex Test Suite'
 };

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceApexTestSuite.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceApexTestSuite.test.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { TestService } from '@salesforce/apex-node';
+import { expect } from 'chai';
+import { createSandbox } from 'sinon';
+import {
+  ApexTestQuickPickItem,
+  TestType
+} from '../../../src/commands/forceApexTestRun';
+import {
+  ApexTestSuiteOptions,
+  TestSuiteBuilder,
+  TestSuiteCreator,
+  TestSuiteSelector
+} from '../../../src/commands/forceApexTestSuite';
+import { workspaceContext } from '../../../src/context';
+import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
+import * as vscode from 'vscode';
+
+describe('Test Suite Selector', async () => {
+  let quickPickStub: sinon.SinonStub;
+  let retrieveSuitesStub: sinon.SinonStub;
+  let sb = createSandbox();
+
+  beforeEach(async () => {
+    sb.stub(workspaceContext, 'getConnection');
+    quickPickStub = sb.stub(vscode.window, 'showQuickPick').returns({
+      label: 'SuiteOne',
+      type: TestType.Suite
+    });
+
+    retrieveSuitesStub = sb
+      .stub(TestService.prototype, 'retrieveAllSuites')
+      .resolves([
+        { TestSuiteName: 'SuiteOne', Id: 'xxxxxxxxxxx27343' },
+        { TestSuiteName: 'SuiteTwo', Id: 'xxxxxxxxxxx27343' }
+      ]);
+  });
+
+  afterEach(async () => {
+    sb.restore();
+  });
+
+  it('Should have two test suites', async () => {
+    const gatherer = new TestSuiteSelector();
+    const result = await gatherer.gather();
+
+    expect(result.type).to.equal('CONTINUE');
+    expect(quickPickStub.getCall(0).args.length).to.equal(1);
+    const fileItems: ApexTestQuickPickItem[] = quickPickStub.getCall(0).args[0];
+    expect(fileItems.length).to.equal(2);
+    expect(fileItems[0].label).to.equal('SuiteOne');
+    expect(fileItems[0].type).to.equal(TestType.Suite);
+    expect(fileItems[1].label).to.equal('SuiteTwo');
+    expect(fileItems[1].type).to.equal(TestType.Suite);
+  });
+
+  it('Should select suite one', async () => {
+    const gatherer = new TestSuiteSelector();
+    const result = await gatherer.gather();
+
+    expect(result.type).to.equal('CONTINUE');
+    expect((result as ContinueResponse<ApexTestQuickPickItem>).data).to.eql({
+      label: 'SuiteOne',
+      type: TestType.Suite
+    });
+  });
+});
+
+describe('Test Suite Builder', async () => {
+  let quickPickStub: sinon.SinonStub;
+  let retrieveSuitesStub: sinon.SinonStub;
+  let sb = createSandbox();
+
+  beforeEach(async () => {
+    sb.stub(workspaceContext, 'getConnection');
+    quickPickStub = sb.stub(vscode.window, 'showQuickPick').returns([
+      {
+        label: 'SuiteOne',
+        type: TestType.Suite
+      }
+    ]);
+
+    retrieveSuitesStub = sb
+      .stub(TestService.prototype, 'retrieveAllSuites')
+      .resolves([
+        { TestSuiteName: 'SuiteOne', Id: 'xxxxxxxxxxx27343' },
+        { TestSuiteName: 'SuiteTwo', Id: 'xxxxxxxxxxx27343' }
+      ]);
+  });
+
+  afterEach(async () => {
+    sb.restore();
+  });
+
+  it('Should have two test suites', async () => {
+    const gatherer = new TestSuiteBuilder();
+    const result = await gatherer.gather();
+
+    expect(result.type).to.equal('CONTINUE');
+    expect(quickPickStub.getCall(0).args.length).to.equal(1);
+    const fileItems: ApexTestQuickPickItem[] = quickPickStub.getCall(0).args[0];
+    expect(fileItems.length).to.equal(2);
+    expect(fileItems[0].label).to.equal('SuiteOne');
+    expect(fileItems[0].type).to.equal(TestType.Suite);
+    expect(fileItems[1].label).to.equal('SuiteTwo');
+    expect(fileItems[1].type).to.equal(TestType.Suite);
+  });
+
+  it('Should select suite one', async () => {
+    const gatherer = new TestSuiteBuilder();
+    const result = await gatherer.gather();
+
+    expect(result.type).to.equal('CONTINUE');
+    expect((result as ContinueResponse<ApexTestSuiteOptions>).data).to.eql({
+      suitename: undefined,
+      tests: ['SuiteOne']
+    });
+  });
+});
+
+describe('Test Suite Creator', async () => {
+  let quickPickStub: sinon.SinonStub;
+  let sb = createSandbox();
+
+  beforeEach(async () => {
+    sb.stub(workspaceContext, 'getConnection');
+    quickPickStub = sb.stub(vscode.window, 'showQuickPick').returns([
+      {
+        label: 'NewClass',
+        type: TestType.Class
+      }
+    ]);
+    sb.stub(vscode.window, 'showInputBox').resolves('NewSuite');
+  });
+
+  afterEach(async () => {
+    sb.restore();
+  });
+
+  it('Should create Test Suite and select one Apex Class', async () => {
+    const gatherer = new TestSuiteCreator();
+    const result = await gatherer.gather();
+
+    expect(result.type).to.equal('CONTINUE');
+    expect(quickPickStub.getCall(0).args.length).to.equal(2);
+    const fileItems: ApexTestQuickPickItem[] = quickPickStub.getCall(0).args[0];
+    expect(fileItems.length).to.equal(1);
+    expect(fileItems[0].label).to.equal('DemoControllerTests');
+    expect(fileItems[0].type).to.equal(TestType.Class);
+  });
+});

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceApexTestSuite.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceApexTestSuite.test.ts
@@ -6,8 +6,10 @@
  */
 
 import { TestService } from '@salesforce/apex-node';
+import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import { expect } from 'chai';
 import { createSandbox } from 'sinon';
+import * as vscode from 'vscode';
 import {
   ApexTestQuickPickItem,
   TestType
@@ -19,13 +21,12 @@ import {
   TestSuiteSelector
 } from '../../../src/commands/forceApexTestSuite';
 import { workspaceContext } from '../../../src/context';
-import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
-import * as vscode from 'vscode';
+
+const sb = createSandbox();
 
 describe('Test Suite Selector', async () => {
   let quickPickStub: sinon.SinonStub;
   let retrieveSuitesStub: sinon.SinonStub;
-  let sb = createSandbox();
 
   beforeEach(async () => {
     sb.stub(workspaceContext, 'getConnection');
@@ -75,7 +76,6 @@ describe('Test Suite Selector', async () => {
 describe('Test Suite Builder', async () => {
   let quickPickStub: sinon.SinonStub;
   let retrieveSuitesStub: sinon.SinonStub;
-  let sb = createSandbox();
 
   beforeEach(async () => {
     sb.stub(workspaceContext, 'getConnection');
@@ -126,7 +126,6 @@ describe('Test Suite Builder', async () => {
 
 describe('Test Suite Creator', async () => {
   let quickPickStub: sinon.SinonStub;
-  let sb = createSandbox();
 
   beforeEach(async () => {
     sb.stub(workspaceContext, 'getConnection');


### PR DESCRIPTION
### What does this PR do?

This PR introduces Test Suites to our command palette. It adds the following commands:

- `SFDX: Run Apex Test Suite`
   - Allows the user to choose an Apex Test Suite via quickpick. The test suite is run through the same code path as the test sidebar & the results are displayed after the test finishes running.
- `SFDX: Create Apex Test Suite`
   - User enters the name of the new Apex Test Suite & selects tests to add to the suite via a quickpick. After selection, the command is run.
- `SFDX: Add Tests to Apex Test Suite`
   - User chooses an existing Apex Test Suite and then selects tests to add to the select suite via the quickpick. After the selection, the command is run.

### What issues does this PR fix or reference?
@W-9632080@
@W-9632072@
@W-9632048@

### Functionality Before
new functionality!

### Functionality After

https://user-images.githubusercontent.com/21326913/126533374-5df40b6b-4f24-4f2f-9fbe-104bb4a5c6ae.mov


