### PR TITLE
chore: remove sfdx-diff message

### DIFF
--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ja.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ja.ts
@@ -509,8 +509,6 @@ export const messages = {
   force_source_diff_unsupported_type:
     'このメタデータ型に対する差分は現在サポートされていません。',
   force_source_diff_title: '%s//%s ↔ ローカル //%s',
-  force_source_diff_command_not_found:
-    'このコマンドの実行には、@salesforce/sfdx-diff プラグインのインストールが必要です。詳細については、[https://developer.salesforce.com/tools/vscode/jp/user-guide/source-diff/](https://developer.salesforce.com/tools/vscode/jp/user-guide/source-diff/) を参照してください。',
   package_id_validation_error:
     'Package ID should be a 15 or 18 character Id that starts with 04t',
   package_id_gatherer_placeholder: '04t...'

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -578,8 +578,6 @@ export const messages = {
     'Diff for this metadata type is currently not supported',
   force_source_diff_title: '%s//%s ↔ local//%s',
   force_source_diff_folder_title: '%s - File Diffs',
-  force_source_diff_command_not_found:
-    'To run this command, first install the @salesforce/sfdx-diff plugin. For more info, see [https://forcedotcom.github.io/salesforcedx-vscode/articles/user-guide/source-diff](https://forcedotcom.github.io/salesforcedx-vscode/articles/user-guide/source-diff).',
   beta_tapi_mdcontainer_error: 'Unexpected error creating metadata container',
   beta_tapi_membertype_error: 'Unexpected error creating %s member',
   beta_tapi_car_error: 'Unexpected error creating container async request',


### PR DESCRIPTION
### What does this PR do?
Removes an unused message that makes reference to the deprecated sfdx-diff plugin.

### What issues does this PR fix or reference?
@W-9166652@

### Functionality Before
N/A

### Functionality After
N/A
