### PR TITLE
fix: bump up functions-core version

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -25,7 +25,7 @@
     "Other"
   ],
   "dependencies": {
-    "@heroku/functions-core": "0.0.3",
+    "@heroku/functions-core": "0.0.4",
     "@salesforce/core": "2.23.2",
     "@salesforce/salesforcedx-sobjects-faux-generator": "52.5.0",
     "@salesforce/salesforcedx-utils-vscode": "52.5.0",


### PR DESCRIPTION
### What does this PR do?
Opening the packaged extension was failing due to `global-agent` being missing. This new version of functions-core moves global-agent to `dependencies` in package.json

I also think I know how we can update CI so that integration-tests can catch something like this. My theory:
When NODE_ENV is not set to production, npm i installs dependencies from both devDepdendency and dependency. In integration-tests we don't set NODE_ENV to production so it install dev dependencies and the tests run fine. I guess that when we compile and package, we are in production mode so npm i  only installs from depedencies by default

### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @<Insert GUS WI>@

### Functionality Before
<insert gif and/or summary>

### Functionality After
<insert gif and/or summary>
