### PR TITLE
fix: bump up functions-core version

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -25,7 +25,7 @@
     "Other"
   ],
   "dependencies": {
-    "@heroku/functions-core": "0.0.3",
+    "@heroku/functions-core": "0.0.4",
     "@salesforce/core": "2.23.2",
     "@salesforce/salesforcedx-sobjects-faux-generator": "52.5.0",
     "@salesforce/salesforcedx-utils-vscode": "52.5.0",


### PR DESCRIPTION
### What does this PR do?
Opening the packaged extension was failing due to global-agent being missing. This new version of functions-core moves global-agent to dependencies in package.json

### What issues does this PR fix or reference?
# #3437 @[W-9641836](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000RvHxYAK/view)@

### Functionality Before
VS Code would occasionally refuse to load due to a missing dependency on global-agent.

### Functionality After
Dependency has been relocated and VS Code loads as expected.
