### PR TITLE
fix: bump up functions-core version (#3439)

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -25,7 +25,7 @@
     "Other"
   ],
   "dependencies": {
-    "@heroku/functions-core": "0.0.3",
+    "@heroku/functions-core": "0.0.4",
     "@salesforce/core": "2.23.2",
     "@salesforce/salesforcedx-sobjects-faux-generator": "52.6.0",
     "@salesforce/salesforcedx-utils-vscode": "52.6.0",


### PR DESCRIPTION
### What does this PR do?
Adds the changes for #3439 into the release branch to prevent releasing a breaking change.