### PR TITLE
Update default-org.md

### DIFF
--- a/docs/_articles/en/user-guide/default-org.md
+++ b/docs/_articles/en/user-guide/default-org.md
@@ -9,4 +9,4 @@ To set or change the org that you’re developing against, in the VS Code footer
 
 To open your default org so that you can test your changes or use declarative tools, click the browser icon ({% octicon browser %}) in the footer. Or, open the command palette and run **SFDX: Open Default Org**.
 
-To log out of the default org run the **SDFX: Log Out from Default Org** command.
+To log out of the default org run **SDFX: Log Out from Default Org**.

--- a/docs/_articles/en/user-guide/default-org.md
+++ b/docs/_articles/en/user-guide/default-org.md
@@ -8,3 +8,5 @@ Salesforce Extensions for VS Code runs commands against the org that you’ve se
 To set or change the org that you’re developing against, in the VS Code footer, click the org’s name or the plug icon ({% octicon plug %}). Then, select a different org, or choose **SFDX: Set a Default Org** to authorize a new org. Or, open the command palette and run **SFDX: Authorize an Org** or **SFDX: Create a Default Scratch Org**.
 
 To open your default org so that you can test your changes or use declarative tools, click the browser icon ({% octicon browser %}) in the footer. Or, open the command palette and run **SFDX: Open Default Org**.
+
+To log out of the default org run the **SDFX: Log Out from Default Org** command.


### PR DESCRIPTION
Added SDFX: Log Out from Default Org to default org doc.

### What does this PR do?
Adds documentation about SDFX: Log Out from Default Org to the default org doc.
### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @<Insert GUS WI>@
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000S3qeYAC/view
The bug also included UI text review for scratch org modal. 
### Functionality Before
To command palette command to log out of default org
### Functionality After
Use  SDFX: Log Out from Default Org to log out of default org
