### PR TITLE
chore: bump SDR to 3.0.0

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -29,7 +29,7 @@
     "@salesforce/apex-tmlanguage": "1.4.0",
     "@salesforce/core": "2.23.2",
     "@salesforce/salesforcedx-utils-vscode": "52.6.0",
-    "@salesforce/source-deploy-retrieve": "2.1.5",
+    "@salesforce/source-deploy-retrieve": "3.0.0",
     "expand-home-dir": "0.0.3",
     "find-java-home": "0.2.0",
     "path-exists": "3.0.0",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -30,7 +30,7 @@
     "@salesforce/salesforcedx-sobjects-faux-generator": "52.6.0",
     "@salesforce/salesforcedx-utils-vscode": "52.6.0",
     "@salesforce/schemas": "^1",
-    "@salesforce/source-deploy-retrieve": "2.1.5",
+    "@salesforce/source-deploy-retrieve": "3.0.0",
     "@salesforce/templates": "52.0.0",
     "adm-zip": "0.4.13",
     "applicationinsights": "1.0.7",

--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
@@ -123,13 +123,13 @@ export abstract class DeployExecutor<T> extends DeployRetrieveExecutor<T> {
     components: ComponentSet,
     token: vscode.CancellationToken
   ): Promise<DeployResult | undefined> {
-    const operation = components.deploy({
+    const metadataApiDeploy = await components.deploy({
       usernameOrConnection: await workspaceContext.getConnection()
     });
 
-    this.setupCancellation(operation, token);
+    this.setupCancellation(metadataApiDeploy, token);
 
-    return operation.start();
+    return metadataApiDeploy.pollStatus();
   }
 
   protected async postOperation(
@@ -218,15 +218,15 @@ export abstract class RetrieveExecutor<T> extends DeployRetrieveExecutor<T> {
       (await SfdxPackageDirectories.getDefaultPackageDir()) ?? ''
     );
 
-    const operation = components.retrieve({
+    const metadataApiRetrieve = await components.retrieve({
       usernameOrConnection: connection,
       output: defaultOutput,
       merge: true
     });
 
-    this.setupCancellation(operation, token);
+    this.setupCancellation(metadataApiRetrieve, token);
 
-    return operation.start();
+    return metadataApiRetrieve.pollStatus();
   }
 
   protected async postOperation(

--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
@@ -100,8 +100,8 @@ export abstract class DeployRetrieveExecutor<
     token?: vscode.CancellationToken
   ) {
     if (token && operation) {
-      token.onCancellationRequested(() => {
-        operation.cancel();
+      token.onCancellationRequested(async () => {
+        await operation.cancel();
       });
     }
   }
@@ -123,13 +123,13 @@ export abstract class DeployExecutor<T> extends DeployRetrieveExecutor<T> {
     components: ComponentSet,
     token: vscode.CancellationToken
   ): Promise<DeployResult | undefined> {
-    const metadataApiDeploy = await components.deploy({
+    const operation = await components.deploy({
       usernameOrConnection: await workspaceContext.getConnection()
     });
 
-    this.setupCancellation(metadataApiDeploy, token);
+    this.setupCancellation(operation, token);
 
-    return metadataApiDeploy.pollStatus();
+    return operation.pollStatus();
   }
 
   protected async postOperation(
@@ -218,15 +218,15 @@ export abstract class RetrieveExecutor<T> extends DeployRetrieveExecutor<T> {
       (await SfdxPackageDirectories.getDefaultPackageDir()) ?? ''
     );
 
-    const metadataApiRetrieve = await components.retrieve({
+    const operation = await components.retrieve({
       usernameOrConnection: connection,
       output: defaultOutput,
       merge: true
     });
 
-    this.setupCancellation(metadataApiRetrieve, token);
+    this.setupCancellation(operation, token);
 
-    return metadataApiRetrieve.pollStatus();
+    return operation.pollStatus();
   }
 
   protected async postOperation(

--- a/packages/salesforcedx-vscode-core/src/conflict/metadataCacheService.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/metadataCacheService.ts
@@ -105,8 +105,8 @@ export class MetadataCacheService {
   ): Promise<MetadataCacheResult | undefined> {
     this.initialize(componentPath, projectPath, isManifest);
     const components = await this.getSourceComponents();
-    const operation = await this.createRetrieveOperation(components);
-    const results = await operation.start();
+    const metadataApiRetrieve = await this.createRetrieveOperation(components);
+    const results = await metadataApiRetrieve.pollStatus();
     return this.processResults(results);
   }
 
@@ -416,11 +416,11 @@ export class MetadataCacheExecutor extends RetrieveExecutor<string> {
     components: ComponentSet,
     token: vscode.CancellationToken
   ): Promise<RetrieveResult | undefined> {
-    const operation = await this.cacheService.createRetrieveOperation(
+    const metadataApiRetrieve = await this.cacheService.createRetrieveOperation(
       components
     );
-    this.setupCancellation(operation, token);
-    return operation.start();
+    this.setupCancellation(metadataApiRetrieve, token);
+    return metadataApiRetrieve.pollStatus();
   }
 
   protected async postOperation(result: RetrieveResult | undefined) {

--- a/packages/salesforcedx-vscode-core/src/conflict/metadataCacheService.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/metadataCacheService.ts
@@ -105,8 +105,8 @@ export class MetadataCacheService {
   ): Promise<MetadataCacheResult | undefined> {
     this.initialize(componentPath, projectPath, isManifest);
     const components = await this.getSourceComponents();
-    const metadataApiRetrieve = await this.createRetrieveOperation(components);
-    const results = await metadataApiRetrieve.pollStatus();
+    const operation = await this.createRetrieveOperation(components);
+    const results = await operation.pollStatus();
     return this.processResults(results);
   }
 

--- a/packages/salesforcedx-vscode-core/src/conflict/metadataCacheService.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/metadataCacheService.ts
@@ -416,11 +416,11 @@ export class MetadataCacheExecutor extends RetrieveExecutor<string> {
     components: ComponentSet,
     token: vscode.CancellationToken
   ): Promise<RetrieveResult | undefined> {
-    const metadataApiRetrieve = await this.cacheService.createRetrieveOperation(
+    const operation = await this.cacheService.createRetrieveOperation(
       components
     );
-    this.setupCancellation(metadataApiRetrieve, token);
-    return metadataApiRetrieve.pollStatus();
+    this.setupCancellation(operation, token);
+    return operation.pollStatus();
   }
 
   protected async postOperation(result: RetrieveResult | undefined) {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
@@ -250,7 +250,7 @@ describe('Base Deploy Retrieve Commands', () => {
     class TestDeploy extends DeployExecutor<{}> {
       public components: ComponentSet;
       public getComponentsStub = sb.stub().returns(new ComponentSet());
-      public startStub: SinonStub;
+      public pollStatusStub: SinonStub;
       public deployStub: SinonStub;
       public cancellationStub = sb.stub();
       public cacheSpy: SinonSpy;
@@ -258,10 +258,10 @@ describe('Base Deploy Retrieve Commands', () => {
       constructor(toDeploy = new ComponentSet()) {
         super('test', 'testlog');
         this.components = toDeploy;
-        this.startStub = sb.stub();
+        this.pollStatusStub = sb.stub();
         this.deployStub = sb
           .stub(this.components, 'deploy')
-          .returns({ start: this.startStub });
+          .returns({ pollStatus: this.pollStatusStub });
         this.cacheSpy = sb.spy(PersistentStorageService.getInstance(), 'setPropertiesForFilesDeploy');
       }
 
@@ -296,7 +296,7 @@ describe('Base Deploy Retrieve Commands', () => {
       expect(executor.deployStub.firstCall.args[0]).to.deep.equal({
         usernameOrConnection: mockConnection
       });
-      expect(executor.startStub.calledOnce).to.equal(true);
+      expect(executor.pollStatusStub.calledOnce).to.equal(true);
     });
 
     it('should store properties in metadata cache on successful deploy', async () => {
@@ -340,7 +340,7 @@ describe('Base Deploy Retrieve Commands', () => {
       const fileResponses: any[] = [];
       const cache = PersistentStorageService.getInstance();
       sb.stub(mockDeployResult, 'getFileResponses').returns(fileResponses);
-      executor.startStub.resolves(mockDeployResult);
+      executor.pollStatusStub.resolves(mockDeployResult);
 
       await executor.run({data: {}, type: 'CONTINUE' });
 
@@ -360,7 +360,7 @@ describe('Base Deploy Retrieve Commands', () => {
       );
       const fileResponses: any[] = [];
       sb.stub(mockDeployResult, 'getFileResponses').returns(fileResponses);
-      executor.startStub.resolves(mockDeployResult);
+      executor.pollStatusStub.resolves(mockDeployResult);
       const success = await executor.run({ data: {}, type: 'CONTINUE' });
 
       expect(success).to.equal(false);
@@ -406,7 +406,7 @@ describe('Base Deploy Retrieve Commands', () => {
           new ComponentSet()
         );
         sb.stub(mockDeployResult, 'getFileResponses').returns(fileResponses);
-        executor.startStub.resolves(mockDeployResult);
+        executor.pollStatusStub.resolves(mockDeployResult);
 
         const formattedRows = fileResponses.map(r => ({
           fullName: r.fullName,
@@ -443,7 +443,7 @@ describe('Base Deploy Retrieve Commands', () => {
           } as MetadataApiDeployStatus,
           new ComponentSet()
         );
-        executor.startStub.resolves(mockDeployResult);
+        executor.pollStatusStub.resolves(mockDeployResult);
 
         const failedRows = fileResponses.map(r => ({
           fullName: r.fullName,
@@ -486,7 +486,7 @@ describe('Base Deploy Retrieve Commands', () => {
           } as MetadataApiDeployStatus,
           new ComponentSet()
         );
-        executor.startStub.resolves(mockDeployResult);
+        executor.pollStatusStub.resolves(mockDeployResult);
 
         const failedRows = fileResponses.map(r => ({
           fullName: r.fullName,
@@ -555,17 +555,17 @@ describe('Base Deploy Retrieve Commands', () => {
 
     class TestRetrieve extends RetrieveExecutor<{}> {
       public components: ComponentSet;
-      public startStub: SinonStub;
+      public pollStatusStub: SinonStub;
       public retrieveStub: SinonStub;
       public cacheSpy: SinonSpy;
 
       constructor(toRetrieve = new ComponentSet()) {
         super('test', 'testlog');
         this.components = toRetrieve;
-        this.startStub = sb.stub();
+        this.pollStatusStub = sb.stub();
         this.retrieveStub = sb
           .stub(this.components, 'retrieve')
-          .returns({ start: this.startStub });
+          .returns({ pollStatus: this.pollStatusStub });
         this.cacheSpy = sb.spy(PersistentStorageService.getInstance(), 'setPropertiesForFilesRetrieve');
       }
 
@@ -618,7 +618,7 @@ describe('Base Deploy Retrieve Commands', () => {
         new ComponentSet()
       );
       const cache = PersistentStorageService.getInstance();
-      executor.startStub.resolves(mockRetrieveResult);
+      executor.pollStatusStub.resolves(mockRetrieveResult);
 
       await executor.run({data: {}, type: 'CONTINUE' });
 
@@ -637,7 +637,7 @@ describe('Base Deploy Retrieve Commands', () => {
         } as MetadataApiRetrieveStatus,
         new ComponentSet()
       );
-      executor.startStub.resolves(mockRetrieveResult);
+      executor.pollStatusStub.resolves(mockRetrieveResult);
 
       await executor.run({data: {}, type: 'CONTINUE' });
 
@@ -661,7 +661,7 @@ describe('Base Deploy Retrieve Commands', () => {
           } as MetadataApiRetrieveStatus,
           new ComponentSet()
         );
-        executor.startStub.resolves(mockRetrieveResult);
+        executor.pollStatusStub.resolves(mockRetrieveResult);
 
         const fileResponses = [
           {
@@ -715,7 +715,7 @@ describe('Base Deploy Retrieve Commands', () => {
           } as MetadataApiRetrieveStatus,
           new ComponentSet()
         );
-        executor.startStub.resolves(mockRetrieveResult);
+        executor.pollStatusStub.resolves(mockRetrieveResult);
 
         const fileResponses = [
           {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDeployManifest.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDeployManifest.test.ts
@@ -46,7 +46,7 @@ describe('Force Source Deploy Using Manifest Option', () => {
 
     let mockConnection: Connection;
     let deployStub: SinonStub;
-    let startStub: SinonStub;
+    let pollStatusStub: SinonStub;
 
     const executor = new LibrarySourceDeployManifestExecutor();
 
@@ -72,9 +72,9 @@ describe('Force Source Deploy Using Manifest Option', () => {
           resolveSourcePaths: packageDirs.map(p => path.join(getRootWorkspacePath(), p))
         })
         .returns(mockComponents);
-      startStub = env.stub();
+      pollStatusStub = env.stub();
       deployStub = env.stub(mockComponents, 'deploy').returns({
-        start: startStub
+        pollStatus: pollStatusStub
       });
     });
 
@@ -90,7 +90,7 @@ describe('Force Source Deploy Using Manifest Option', () => {
       expect(deployStub.firstCall.args[0]).to.deep.equal({
         usernameOrConnection: mockConnection
       });
-      expect(startStub.calledOnce).to.equal(true);
+      expect(pollStatusStub.calledOnce).to.equal(true);
     });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDeploySourcePath.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDeploySourcePath.test.ts
@@ -41,7 +41,7 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
     let mockConnection: Connection;
 
     let resolveStub: SinonStub;
-    let startStub: SinonStub;
+    let pollStatusStub: SinonStub;
     let deployStub: SinonStub;
 
     beforeEach(async () => {
@@ -57,12 +57,12 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
 
       resolveStub = sb.stub(MetadataResolver.prototype, 'getComponentsFromPath').returns([]);
       sb.stub(workspaceContext, 'getConnection').resolves(mockConnection);
-      startStub = sb.stub().resolves(undefined);
+      pollStatusStub = sb.stub().resolves(undefined);
       deployStub = sb
         .stub(ComponentSet.prototype, 'deploy')
         .withArgs({ usernameOrConnection: mockConnection })
         .returns({
-          start: startStub
+          pollStatus: pollStatusStub
         });
     });
 
@@ -82,7 +82,7 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
       expect(deployStub.firstCall.args[0]).to.deep.equal({
         usernameOrConnection: mockConnection
       });
-      expect(startStub.calledOnce).to.equal(true);
+      expect(pollStatusStub.calledOnce).to.equal(true);
     });
 
     it('should deploy with multiple paths', async () => {
@@ -99,7 +99,7 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
       expect(deployStub.firstCall.args[0]).to.deep.equal({
         usernameOrConnection: mockConnection
       });
-      expect(startStub.calledOnce).to.equal(true);
+      expect(pollStatusStub.calledOnce).to.equal(true);
     });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveManifest.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveManifest.test.ts
@@ -49,7 +49,7 @@ describe('Force Source Retrieve with Manifest Option', () => {
 
     let mockConnection: Connection;
     let retrieveStub: SinonStub;
-    let startStub: SinonStub;
+    let pollStatusStub: SinonStub;
 
     const executor = new LibrarySourceRetrieveManifestExecutor();
 
@@ -79,9 +79,9 @@ describe('Force Source Retrieve with Manifest Option', () => {
           forceAddWildcards: true
         })
         .returns(mockComponents);
-      startStub = env.stub();
+      pollStatusStub = env.stub();
       retrieveStub = env.stub(mockComponents, 'retrieve').returns({
-        start: startStub
+        pollStatus: pollStatusStub
       });
     });
 
@@ -99,7 +99,7 @@ describe('Force Source Retrieve with Manifest Option', () => {
         output: defaultPackagePath,
         merge: true
       });
-      expect(startStub.calledOnce).to.equal(true);
+      expect(pollStatusStub.calledOnce).to.equal(true);
     });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveMetadata/forceSourceRetrieveCmp.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveMetadata/forceSourceRetrieveCmp.test.ts
@@ -160,7 +160,7 @@ describe('Force Source Retrieve Component(s)', () => {
 
     let openTextDocumentStub: SinonStub;
     let showTextDocumentStub: SinonStub;
-    let startStub: SinonStub;
+    let pollStatusStub: SinonStub;
     let retrieveStub: SinonStub;
 
     beforeEach(async () => {
@@ -187,9 +187,9 @@ describe('Force Source Retrieve Component(s)', () => {
       sb.stub(MetadataResolver.prototype, 'getComponentsFromPath').returns([]);
       openTextDocumentStub = sb.stub(vscode.workspace, 'openTextDocument');
       showTextDocumentStub = sb.stub(vscode.window, 'showTextDocument');
-      startStub = sb.stub();
+      pollStatusStub = sb.stub();
       retrieveStub = sb.stub(ComponentSet.prototype, 'retrieve').returns({
-        start: startStub
+        pollStatus: pollStatusStub
       });
     });
 
@@ -331,7 +331,7 @@ describe('Force Source Retrieve Component(s)', () => {
         fileProperties: [],
         status: RequestStatus.Succeeded
       };
-      startStub.resolves(
+      pollStatusStub.resolves(
         new RetrieveResult(
           retrieveResponse as MetadataApiRetrieveStatus,
           componentSet

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveSourcePath.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveSourcePath.test.ts
@@ -52,7 +52,7 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
   describe('Library Executor', () => {
     let mockConnection: Connection;
     let retrieveStub: SinonStub;
-    let startStub: SinonStub;
+    let pollStatusStub: SinonStub;
 
     const defaultPackage = 'test-app';
 
@@ -70,7 +70,7 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
       sb.stub(SfdxPackageDirectories, 'getDefaultPackageDir').resolves(
         defaultPackage
       );
-      startStub = sb.stub();
+      pollStatusStub = sb.stub();
     });
 
     afterEach(() => {
@@ -93,7 +93,7 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
         .returns(toRetrieve);
       retrieveStub = sb
         .stub(toRetrieve, 'retrieve')
-        .returns({ start: startStub });
+        .returns({ pollStatus: pollStatusStub });
 
       await executor.run({ data: fsPath, type: 'CONTINUE' });
 
@@ -103,7 +103,7 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
         output: path.join(getRootWorkspacePath(), defaultPackage),
         merge: true
       });
-      expect(startStub.calledOnce).to.equal(true);
+      expect(pollStatusStub.calledOnce).to.equal(true);
     });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/metadataCacheService.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/metadataCacheService.test.ts
@@ -88,8 +88,8 @@ describe('Metadata Cache', () => {
         components: new ComponentSet(),
         output: ''
       });
-      const startStub = sinon.stub(mockOperation, 'start');
-      startStub.callsFake(() => {});
+      const pollStatusStub = sinon.stub(mockOperation, 'pollStatus');
+      pollStatusStub.callsFake(() => {});
       operationStub.resolves(mockOperation);
       processStub.resolves(undefined);
 
@@ -97,7 +97,7 @@ describe('Metadata Cache', () => {
 
       expect(componentStub.callCount).to.equal(1);
       expect(operationStub.callCount).to.equal(1);
-      expect(startStub.callCount).to.equal(1);
+      expect(pollStatusStub.callCount).to.equal(1);
       expect(processStub.callCount).to.equal(1);
     });
   });


### PR DESCRIPTION
### What does this PR do?
This PR bumps SDR to 3.0.0 and fixes a few breaking changes from [SDR #334](https://github.com/forcedotcom/source-deploy-retrieve/pull/334/) which adds support for making asynchronous metadata transfers. 

### What issues does this PR fix or reference?
SDR #334, @W-9521922@

### Functionality Before
There is no change in functionality. 

### Functionality After
There is no change in functionality. 
