### PR TITLE
feat: test constants for vscode-core

### DIFF
--- a/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/index.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+export {
+  xmlInFolder,
+  document,
+  matchingContentFile,
+  bundle,
+  mixedContentDirectory,
+  mixedContentInFolder,
+  mixedContentSingleFile,
+  decomposed,
+  nonDecomposed,
+  decomposedtoplevel
+} from './type-constants';
+export { mockRegistry, mockRegistryData } from './mockRegistry';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/mockRegistry.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/mockRegistry.ts
@@ -1,0 +1,278 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { RegistryAccess } from '@salesforce/source-deploy-retrieve';
+
+export const mockRegistryData = {
+  types: {
+    /**
+     * Metadata with no content and is contained in a folder type component
+     *
+     * e.g. Report in ReportFolder
+     */
+    xmlinfolder: {
+      id: 'xmlinfolder',
+      directoryName: 'xmlinfolders',
+      name: 'XmlInFolder',
+      suffix: 'xif',
+      folderType: 'xmlinfolderfolder'
+    },
+    /**
+     * Folder metadata type for XmlInFolder type
+     *
+     * e.g. ReportFolder for Report
+     */
+    xmlinfolderfolder: {
+      id: 'xmlinfolderfolder',
+      directoryName: 'xmlinfolders',
+      name: 'XmlInFolder',
+      suffix: 'xifFolder',
+      folderContentType: 'xmlinfolder'
+    },
+    /**
+     * Metadata with a content file that has the same suffix as the xml (minus the -meta.xml)
+     *
+     * e.g. ApexClass
+     */
+    matchingcontentfile: {
+      id: 'matchingcontentfile',
+      directoryName: 'matchingContentFiles',
+      inFolder: false,
+      name: 'MatchingContentFile',
+      suffix: 'mcf',
+      strategies: {
+        adapter: 'matchingContentFile',
+        transformer: 'standard'
+      }
+    },
+    /**
+     * Metadata with mixed content that requires replacement of the suffix.
+     *
+     * e.g. Document
+     */
+    document: {
+      id: 'document',
+      directoryName: 'documents',
+      inFolder: true,
+      name: 'Document',
+      suffix: 'document',
+      folderType: 'documentfolder',
+      strategies: {
+        adapter: 'mixedContent'
+      }
+    },
+    /**
+     * Metadata with content of any file type in a folder type component
+     *
+     * e.g. Document in DocumentFolder
+     */
+    mixedcontentinfolder: {
+      id: 'mixedcontentinfolder',
+      directoryName: 'mixedContentInFolders',
+      inFolder: true,
+      name: 'MixedContentInFolder',
+      suffix: 'mcif',
+      strictDirectoryName: true,
+      folderType: 'mciffolder',
+      strategies: {
+        adapter: 'mixedContent'
+      }
+    },
+    /**
+     * Metadata types with children that are not decomposed into separate files
+     *
+     * e.g. CustomLabels
+     */
+    nondecomposed: {
+      id: 'nondecomposedparent',
+      name: 'nondecomposedparent',
+      suffix: 'nondecomposed',
+      directoryName: 'nondecomposed',
+      inFolder: false,
+      strictDirectoryName: false,
+      children: {
+        types: {
+          nondecomposedchild: {
+            id: 'nondecomposedchild',
+            name: 'nondecomposedchild',
+            ignoreParentName: true,
+            uniqueIdElement: 'id',
+            directoryName: 'nondecomposed',
+            suffix: 'nondecomposed'
+          }
+        },
+        suffixes: {
+          nondecomposed: 'nondecomposed'
+        },
+        directories: {
+          nondecomposed: 'nondecomposed'
+        }
+      },
+      strategies: {
+        adapter: 'default',
+        transformer: 'nonDecomposed',
+        recomposition: 'startEmpty'
+      }
+    },
+    /**
+     * Metadata whose content is directory(ies) containing files of any extension
+     *
+     * e.g. ExperienceBundle
+     */
+    mixedcontentdirectory: {
+      id: 'mixedcontentdirectory',
+      directoryName: 'mixedcontentdirectories',
+      inFolder: false,
+      name: 'MixedContentDirectory',
+      strictDirectoryName: true,
+      strategies: {
+        adapter: 'mixedContent'
+      }
+    },
+    bundle: {
+      id: 'bundle',
+      directoryName: 'bundles',
+      inFolder: false,
+      name: 'Bundle',
+      strictDirectoryName: true,
+      strategies: {
+        adapter: 'bundle',
+        transformer: 'bundle'
+      }
+    },
+    mciffolder: {
+      id: 'mciffolder',
+      directoryName: 'mixedContentInFolders',
+      inFolder: false,
+      name: 'McifFolder',
+      suffix: 'mcifFolder',
+      folderContentType: 'mixedcontentinfolder'
+    },
+    decomposed: {
+      id: 'decomposed',
+      directoryName: 'decomposeds',
+      inFolder: false,
+      name: 'Decomposed',
+      suffix: 'decomposed',
+      strictDirectoryName: true,
+      children: {
+        types: {
+          x: {
+            id: 'x',
+            directoryName: 'xs',
+            name: 'X',
+            suffix: 'x'
+          },
+          y: {
+            id: 'y',
+            directoryName: 'ys',
+            name: 'Y',
+            suffix: 'y'
+          }
+        },
+        suffixes: {
+          x: 'x',
+          y: 'y'
+        },
+        directories: {
+          xs: 'x',
+          ys: 'y'
+        }
+      },
+      strategies: {
+        adapter: 'decomposed',
+        transformer: 'decomposed',
+        decomposition: 'folderPerType'
+      }
+    },
+    /**
+     * Metadata with one content of any file extension
+     *
+     * e.g. StaticResource
+     */
+    mixedcontentsinglefile: {
+      id: 'mixedcontentsinglefile',
+      directoryName: 'mixedSingleFiles',
+      inFolder: false,
+      name: 'MixedContentSingleFile',
+      suffix: 'mixedSingleFile',
+      strictDirectoryName: true,
+      strategies: {
+        adapter: 'mixedContent',
+        transformer: 'staticResource'
+      }
+    },
+    decomposedtoplevel: {
+      id: 'decomposedtoplevel',
+      directoryName: 'decomposedTopLevels',
+      inFolder: false,
+      name: 'DecomposedTopLevel',
+      suffix: 'dtl',
+      strictDirectoryName: true,
+      children: {
+        types: {
+          g: {
+            id: 'g',
+            directoryName: 'gs',
+            name: 'G',
+            suffix: 'g'
+          }
+        },
+        suffixes: {
+          g: 'g'
+        },
+        directories: {
+          gs: 'g'
+        }
+      },
+      strategies: {
+        adapter: 'decomposed',
+        transformer: 'decomposed',
+        decomposition: 'topLevel'
+      }
+    },
+    missingstrategies: {
+      id: 'missingstrategies',
+      directoryName: 'missingStrategies',
+      name: 'MissingStrategies',
+      suffix: 'ms',
+      strategies: {
+        adapter: 'thisdoesnotexist',
+        transformer: 'thisdoesnotexist'
+      }
+    }
+  },
+  suffixes: {
+    xif: 'xmlinfolder',
+    xifFolder: 'xmlinfolderfolder',
+    mcf: 'matchingcontentfile',
+    missing: 'typewithoutdef',
+    mcifFolder: 'mciffolder',
+    decomposed: 'decomposed',
+    mcif: 'mixedcontentinfolder',
+    mixedSingleFile: 'mixedcontentsinglefile',
+    dtl: 'decomposedtoplevel',
+    ms: 'missingstrategies'
+  },
+  strictDirectoryNames: {
+    mixedContentDirectories: 'mixedcontentdirectory',
+    bundles: 'bundle',
+    decomposed: 'decomposed',
+    mixedSingleFiles: 'mixedcontentsinglefile',
+    mixedContentInFolders: 'mixedcontentinfolder',
+    decomposedTopLevels: 'decomposedtoplevel'
+  },
+  childTypes: {
+    x: 'decomposed',
+    y: 'decomposed',
+    g: 'decomposedtoplevel',
+    badchildtype: 'mixedcontentsinglefile'
+  },
+  apiVersion: '52.0'
+};
+
+export const mockRegistry = new RegistryAccess(mockRegistryData);

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/type-constants/bundleConstants.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/type-constants/bundleConstants.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { SourceComponent } from '@salesforce/source-deploy-retrieve';
+import { join } from 'path';
+import { mockRegistryData } from '../mockRegistry';
+
+const type = mockRegistryData.types.bundle;
+
+export const TYPE_DIRECTORY = join('path', 'to', type.directoryName);
+const COMPONENT_NAME = 'a';
+export const CONTENT_PATH = join(TYPE_DIRECTORY, 'a');
+export const XML_NAME = `${COMPONENT_NAME}.js-meta.xml`;
+export const XML_PATH = join(CONTENT_PATH, XML_NAME);
+export const SUBTYPE_XML_PATH = join(CONTENT_PATH, 'b.z-meta.xml');
+export const SOURCE_PATHS = [
+  join(CONTENT_PATH, 'a.js'),
+  join(CONTENT_PATH, 'a.css'),
+  join(CONTENT_PATH, 'a.html')
+];
+export const COMPONENT = SourceComponent.createVirtualComponent(
+  {
+    name: 'a',
+    type,
+    xml: XML_PATH,
+    content: CONTENT_PATH
+  },
+  [
+    {
+      dirPath: TYPE_DIRECTORY,
+      children: [COMPONENT_NAME]
+    },
+    {
+      dirPath: CONTENT_PATH,
+      children: [XML_NAME, 'a.js', 'a.css', 'a.html']
+    }
+  ]
+);

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/type-constants/decomposedConstants.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/type-constants/decomposedConstants.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { SourceComponent, VirtualDirectory } from '@salesforce/source-deploy-retrieve';
+import { XML_NS_URL } from '@salesforce/source-deploy-retrieve/lib/src/common';
+import { baseName } from '@salesforce/source-deploy-retrieve/lib/src/utils';
+import { join } from 'path';
+import { mockRegistryData } from '../mockRegistry';
+
+// Constants for a decomposed type
+const type = mockRegistryData.types.decomposed;
+
+export const DECOMPOSEDS_PATH = join('path', 'to', 'decomposeds');
+export const DECOMPOSED_PATH = join(DECOMPOSEDS_PATH, 'a');
+export const DECOMPOSED_XML_NAME = 'a.decomposed-meta.xml';
+export const DECOMPOSED_XML_PATH = join(DECOMPOSED_PATH, DECOMPOSED_XML_NAME);
+export const DECOMPOSED_CHILD_XML_NAME_1 = 'z.y-meta.xml';
+export const DECOMPOSED_CHILD_XML_PATH_1 = join(DECOMPOSED_PATH, DECOMPOSED_CHILD_XML_NAME_1);
+export const DECOMPOSED_CHILD_DIR = 'xs';
+export const DECOMPOSED_CHILD_DIR_PATH = join(DECOMPOSED_PATH, DECOMPOSED_CHILD_DIR);
+export const DECOMPOSED_CHILD_XML_NAME_2 = 'w.x-meta.xml';
+export const DECOMPOSED_CHILD_XML_PATH_2 = join(
+  DECOMPOSED_CHILD_DIR_PATH,
+  DECOMPOSED_CHILD_XML_NAME_2
+);
+export const DECOMPOSED_VIRTUAL_FS: VirtualDirectory[] = [
+  {
+    dirPath: DECOMPOSED_PATH,
+    children: [
+      {
+        name: DECOMPOSED_XML_NAME,
+        data: Buffer.from(`<Decomposed xmlns="${XML_NS_URL}"><fullName>a</fullName></Decomposed>`)
+      },
+      { name: DECOMPOSED_CHILD_XML_NAME_1, data: Buffer.from('<Y><test>child1</test></Y>') },
+      DECOMPOSED_CHILD_DIR
+    ]
+  },
+  {
+    dirPath: DECOMPOSED_CHILD_DIR_PATH,
+    children: [
+      { name: DECOMPOSED_CHILD_XML_NAME_2, data: Buffer.from('<X><test>child2</test></X>') }
+    ]
+  }
+];
+export const DECOMPOSED_COMPONENT = SourceComponent.createVirtualComponent(
+  {
+    name: baseName(DECOMPOSED_XML_PATH),
+    type,
+    xml: DECOMPOSED_XML_PATH,
+    content: DECOMPOSED_PATH
+  },
+  DECOMPOSED_VIRTUAL_FS
+);
+export const DECOMPOSED_CHILD_COMPONENT_1 = SourceComponent.createVirtualComponent(
+  {
+    name: baseName(DECOMPOSED_CHILD_XML_NAME_1),
+    type: type.children.types.y,
+    xml: DECOMPOSED_CHILD_XML_PATH_1,
+    parent: DECOMPOSED_COMPONENT
+  },
+  DECOMPOSED_VIRTUAL_FS
+);
+export const DECOMPOSED_CHILD_COMPONENT_2 = SourceComponent.createVirtualComponent(
+  {
+    name: baseName(DECOMPOSED_CHILD_XML_NAME_2),
+    type: type.children.types.x,
+    xml: DECOMPOSED_CHILD_XML_PATH_2,
+    parent: DECOMPOSED_COMPONENT
+  },
+  DECOMPOSED_VIRTUAL_FS
+);

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/type-constants/decomposedTopLevelConstants.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/type-constants/decomposedTopLevelConstants.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { SourceComponent } from '@salesforce/source-deploy-retrieve';
+import { baseName } from '@salesforce/source-deploy-retrieve/lib/src/utils';
+import { join } from 'path';
+import { mockRegistryData } from '../mockRegistry';
+
+export const DECOMPOSED_TOP_LEVEL_DIR = join('path', 'to', 'decomposedTopLevels');
+export const DECOMPOSED_TOP_LEVEL_COMPONENT_PATH = join(DECOMPOSED_TOP_LEVEL_DIR, 'a');
+export const DECOMPOSED_TOP_LEVEL_XML_NAMES = ['a.dtl-meta.xml'];
+export const DECOMPOSED_TOP_LEVEL_XML_PATH = join(
+  DECOMPOSED_TOP_LEVEL_COMPONENT_PATH,
+  DECOMPOSED_TOP_LEVEL_XML_NAMES[0]
+);
+export const DECOMPOSED_TOP_LEVEL_CHILD_XML_NAMES = ['z.g-meta.xml', 'y.g-meta.xml'];
+export const DECOMPOSED_TOP_LEVEL_CHILD_XML_PATHS = DECOMPOSED_TOP_LEVEL_CHILD_XML_NAMES.map(n =>
+  join(DECOMPOSED_TOP_LEVEL_COMPONENT_PATH, n)
+);
+
+export const DECOMPOSED_VIRTUAL_FS = [
+  {
+    dirPath: DECOMPOSED_TOP_LEVEL_COMPONENT_PATH,
+    children: [
+      DECOMPOSED_TOP_LEVEL_XML_NAMES[0],
+      DECOMPOSED_TOP_LEVEL_CHILD_XML_NAMES[0],
+      DECOMPOSED_TOP_LEVEL_CHILD_XML_NAMES[1]
+    ]
+  }
+];
+
+export const DECOMPOSED_TOP_LEVEL_COMPONENT = SourceComponent.createVirtualComponent(
+  {
+    name: baseName(DECOMPOSED_TOP_LEVEL_XML_PATH),
+    type: mockRegistryData.types.decomposedtoplevel,
+    xml: DECOMPOSED_TOP_LEVEL_XML_PATH,
+    content: DECOMPOSED_TOP_LEVEL_COMPONENT_PATH
+  },
+  DECOMPOSED_VIRTUAL_FS
+);

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/type-constants/documentConstants.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/type-constants/documentConstants.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { SourceComponent } from '@salesforce/source-deploy-retrieve';
+import { META_XML_SUFFIX } from '@salesforce/source-deploy-retrieve/lib/src/common';
+import { extName } from '@salesforce/source-deploy-retrieve/lib/src/utils';
+import { join } from 'path';
+import { mockRegistryData } from '../mockRegistry';
+
+const type = mockRegistryData.types.document;
+
+export const DOCUMENTS_DIRECTORY = join('path', 'to', type.directoryName);
+export const COMPONENT_NAME = 'a';
+export const COMPONENT_SUFFIX = 'png';
+export const COMPONENT_FOLDER_NAME = 'A_Folder';
+export const COMPONENT_FOLDER_PATH = join(DOCUMENTS_DIRECTORY, COMPONENT_FOLDER_NAME);
+export const CONTENT_PATH = join(
+  DOCUMENTS_DIRECTORY,
+  COMPONENT_FOLDER_NAME,
+  COMPONENT_NAME + '.' + COMPONENT_SUFFIX
+);
+
+export const XML_NAME = COMPONENT_NAME + '.' + COMPONENT_SUFFIX + META_XML_SUFFIX;
+export const XML_PATH = join(COMPONENT_FOLDER_PATH, XML_NAME);
+// Document types are converted from the original suffix to '.document' during source conversion.
+export const CONVERTED_XML_PATH = XML_PATH.replace(extName(CONTENT_PATH), 'document');
+
+export const COMPONENT: SourceComponent = new SourceComponent({
+  name: COMPONENT_FOLDER_NAME + '/' + COMPONENT_NAME,
+  type,
+  xml: XML_PATH,
+  content: CONTENT_PATH
+});
+export const COMPONENT_MD: SourceComponent = new SourceComponent({
+  name: COMPONENT_FOLDER_NAME + '/' + COMPONENT_NAME,
+  type,
+  xml: CONVERTED_XML_PATH,
+  content: CONTENT_PATH
+});
+
+export const COMPONENT_VIRTUAL_FS = [
+  {
+    dirPath: DOCUMENTS_DIRECTORY,
+    children: [COMPONENT_FOLDER_NAME]
+  },
+  {
+    dirPath: COMPONENT_FOLDER_PATH,
+    children: [COMPONENT_NAME + '.' + COMPONENT_SUFFIX]
+  }
+];

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/type-constants/index.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/type-constants/index.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as bundle from './bundleConstants';
+import * as decomposed from './decomposedConstants';
+import * as decomposedtoplevel from './decomposedTopLevelConstants';
+import * as document from './documentConstants';
+import * as matchingContentFile from './matchingContentFileConstants';
+import * as mixedContentDirectory from './mixedContentDirectoryConstants';
+import * as mixedContentInFolder from './mixedContentInFolderConstants';
+import * as mixedContentSingleFile from './mixedContentSingleFileConstants';
+import * as nonDecomposed from './nonDecomposedConstants';
+import * as xmlInFolder from './xmlInFolderConstants';
+export {
+  xmlInFolder,
+  document,
+  matchingContentFile,
+  bundle,
+  mixedContentDirectory,
+  mixedContentInFolder,
+  mixedContentSingleFile,
+  decomposed,
+  decomposedtoplevel,
+  nonDecomposed
+};

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/type-constants/matchingContentFileConstants.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/type-constants/matchingContentFileConstants.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { SourceComponent, VirtualTreeContainer } from '@salesforce/source-deploy-retrieve';
+import { META_XML_SUFFIX } from '@salesforce/source-deploy-retrieve/lib/src/common';
+import { join } from 'path';
+import { mockRegistryData } from '../mockRegistry';
+
+// Constants for a matching content file type
+const type = mockRegistryData.types.matchingcontentfile;
+
+export const TYPE_DIRECTORY = join('path', 'to', type.directoryName);
+export const COMPONENT_NAMES = ['a', 'b'];
+export const XML_NAMES = COMPONENT_NAMES.map(name => `${name}.${type.suffix}${META_XML_SUFFIX}`);
+export const XML_PATHS = XML_NAMES.map(name => join(TYPE_DIRECTORY, name));
+export const CONTENT_NAMES = COMPONENT_NAMES.map(name => `${name}.${type.suffix}`);
+export const CONTENT_PATHS = CONTENT_NAMES.map(name => join(TYPE_DIRECTORY, name));
+
+const TREE = new VirtualTreeContainer([
+  {
+    dirPath: TYPE_DIRECTORY,
+    children: XML_NAMES.concat(CONTENT_NAMES)
+  }
+]);
+
+export const COMPONENTS = COMPONENT_NAMES.map(
+  (name, index) =>
+    new SourceComponent(
+      {
+        name,
+        type,
+        xml: XML_PATHS[index],
+        content: CONTENT_PATHS[index]
+      },
+      TREE
+    )
+);
+export const COMPONENT = COMPONENTS[0];
+
+export const CONTENT_COMPONENT = new SourceComponent({
+  name: 'a',
+  type,
+  xml: CONTENT_PATHS[0]
+});

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/type-constants/mixedContentDirectoryConstants.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/type-constants/mixedContentDirectoryConstants.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { SourceComponent } from '@salesforce/source-deploy-retrieve';
+import { basename, dirname, join } from 'path';
+import { mockRegistryData } from '../mockRegistry';
+
+// Mixed content with directory as content
+const type = mockRegistryData.types.mixedcontentdirectory;
+
+export const MIXED_CONTENT_DIRECTORY_DIR = join('path', 'to', 'mixedcontentdirectories');
+export const MIXED_CONTENT_DIRECTORY_CONTENT_PATH = join(MIXED_CONTENT_DIRECTORY_DIR, 'a');
+export const MIXED_CONTENT_DIRECTORY_XML_NAMES = ['a.mixedcontentdirectory-meta.xml'];
+export const MIXED_CONTENT_DIRECTORY_XML_PATHS = MIXED_CONTENT_DIRECTORY_XML_NAMES.map(n =>
+  join(MIXED_CONTENT_DIRECTORY_DIR, n)
+);
+export const MIXED_CONTENT_DIRECTORY_SOURCE_PATHS = [
+  join(MIXED_CONTENT_DIRECTORY_CONTENT_PATH, 'test.xyz'),
+  join(MIXED_CONTENT_DIRECTORY_CONTENT_PATH, 'b', 'test.g'),
+  join(MIXED_CONTENT_DIRECTORY_CONTENT_PATH, 'b', 'test2.w')
+];
+export const MIXED_CONTENT_DIRECTORY_COMPONENT: SourceComponent = new SourceComponent({
+  name: 'a',
+  type,
+  xml: MIXED_CONTENT_DIRECTORY_XML_PATHS[0],
+  content: MIXED_CONTENT_DIRECTORY_CONTENT_PATH
+});
+export const MIXED_CONTENT_DIRECTORY_VIRTUAL_FS = [
+  {
+    dirPath: MIXED_CONTENT_DIRECTORY_DIR,
+    children: [
+      MIXED_CONTENT_DIRECTORY_XML_NAMES[0],
+      basename(MIXED_CONTENT_DIRECTORY_CONTENT_PATH)
+    ]
+  },
+  {
+    dirPath: MIXED_CONTENT_DIRECTORY_CONTENT_PATH,
+    children: [
+      basename(MIXED_CONTENT_DIRECTORY_SOURCE_PATHS[0]),
+      basename(dirname(MIXED_CONTENT_DIRECTORY_SOURCE_PATHS[1]))
+    ]
+  },
+  {
+    dirPath: dirname(MIXED_CONTENT_DIRECTORY_SOURCE_PATHS[1]),
+    children: [
+      basename(MIXED_CONTENT_DIRECTORY_SOURCE_PATHS[1]),
+      basename(MIXED_CONTENT_DIRECTORY_SOURCE_PATHS[2])
+    ]
+  }
+];
+export const MIXED_CONTENT_DIRECTORY_VIRTUAL_FS_NO_XML = [
+  {
+    dirPath: MIXED_CONTENT_DIRECTORY_DIR,
+    children: [basename(MIXED_CONTENT_DIRECTORY_CONTENT_PATH)]
+  },
+  {
+    dirPath: MIXED_CONTENT_DIRECTORY_CONTENT_PATH,
+    children: [
+      basename(MIXED_CONTENT_DIRECTORY_SOURCE_PATHS[0]),
+      basename(dirname(MIXED_CONTENT_DIRECTORY_SOURCE_PATHS[1]))
+    ]
+  },
+  {
+    dirPath: dirname(MIXED_CONTENT_DIRECTORY_SOURCE_PATHS[1]),
+    children: [
+      basename(MIXED_CONTENT_DIRECTORY_SOURCE_PATHS[1]),
+      basename(MIXED_CONTENT_DIRECTORY_SOURCE_PATHS[2])
+    ]
+  }
+];

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/type-constants/mixedContentInFolderConstants.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/type-constants/mixedContentInFolderConstants.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { SourceComponent, VirtualTreeContainer } from '@salesforce/source-deploy-retrieve';
+import { META_XML_SUFFIX } from '@salesforce/source-deploy-retrieve/lib/src/common';
+import { basename, join } from 'path';
+import { mockRegistryData } from '../mockRegistry';
+
+const type = mockRegistryData.types.mixedcontentinfolder;
+const folderType = mockRegistryData.types.mciffolder;
+
+export const TYPE_DIRECTORY = join('path', 'to', type.directoryName);
+export const COMPONENT_FOLDER_NAME = 'A_Folder';
+export const COMPONENT_FOLDER_PATH = join(TYPE_DIRECTORY, COMPONENT_FOLDER_NAME);
+export const COMPONENT_NAMES = ['a', 'b', 'c'];
+const CONTENT_FILE_EXTS = ['x', 'y', 'z'];
+
+export const FOLDER_XML_PATH = join(
+  TYPE_DIRECTORY,
+  `${COMPONENT_FOLDER_NAME}.${folderType.suffix}${META_XML_SUFFIX}`
+);
+export const FOLDER_XML_NAME = basename(FOLDER_XML_PATH);
+export const FOLDER_XML_PATH_MD_FORMAT = join(
+  TYPE_DIRECTORY,
+  `${COMPONENT_FOLDER_NAME}${META_XML_SUFFIX}`
+);
+export const XML_PATHS = COMPONENT_NAMES.map(name =>
+  join(COMPONENT_FOLDER_PATH, `${name}.${type.suffix}${META_XML_SUFFIX}`)
+);
+export const XML_NAMES = XML_PATHS.map(path => basename(path));
+export const CONTENT_PATHS = COMPONENT_NAMES.map((name, index) =>
+  join(COMPONENT_FOLDER_PATH, `${name}.${CONTENT_FILE_EXTS[index]}`)
+);
+export const CONTENT_NAMES = CONTENT_PATHS.map(path => basename(path));
+
+const TREE = new VirtualTreeContainer([
+  {
+    dirPath: TYPE_DIRECTORY,
+    children: [COMPONENT_FOLDER_NAME, FOLDER_XML_NAME]
+  },
+  {
+    dirPath: COMPONENT_FOLDER_PATH,
+    children: XML_NAMES.concat(CONTENT_NAMES)
+  }
+]);
+export const FOLDER_COMPONENT = new SourceComponent(
+  {
+    name: COMPONENT_FOLDER_NAME,
+    type: folderType,
+    xml: FOLDER_XML_PATH
+  },
+  TREE
+);
+export const FOLDER_COMPONENT_MD_FORMAT = new SourceComponent(
+  {
+    name: COMPONENT_FOLDER_NAME,
+    type: folderType,
+    xml: FOLDER_XML_PATH_MD_FORMAT
+  },
+  TREE
+);
+export const COMPONENTS = COMPONENT_NAMES.map(
+  (name, index) =>
+    new SourceComponent(
+      {
+        name: `${COMPONENT_FOLDER_NAME}/${name}`,
+        type,
+        xml: XML_PATHS[index],
+        content: CONTENT_PATHS[index]
+      },
+      TREE
+    )
+);

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/type-constants/mixedContentSingleFileConstants.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/type-constants/mixedContentSingleFileConstants.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { SourceComponent } from '@salesforce/source-deploy-retrieve';
+import { META_XML_SUFFIX } from '@salesforce/source-deploy-retrieve/lib/src/common';
+import { join } from 'path';
+import { mockRegistryData } from '../mockRegistry';
+
+const type = mockRegistryData.types.mixedcontentsinglefile;
+
+export const TYPE_DIRECTORY = join('path', 'to', type.directoryName);
+export const COMPONENT_NAMES = ['a'];
+export const XML_NAMES = COMPONENT_NAMES.map(name => `${name}.${type.suffix}${META_XML_SUFFIX}`);
+export const XML_PATHS = XML_NAMES.map(n => join(TYPE_DIRECTORY, n));
+export const CONTENT_NAMES = COMPONENT_NAMES.map(name => `${name}.x`);
+export const CONTENT_PATHS = CONTENT_NAMES.map(n => join(TYPE_DIRECTORY, n));
+export const COMPONENT = SourceComponent.createVirtualComponent(
+  {
+    name: 'a',
+    type,
+    content: CONTENT_PATHS[0],
+    xml: XML_PATHS[0]
+  },
+  [
+    {
+      dirPath: TYPE_DIRECTORY,
+      children: XML_NAMES.concat(CONTENT_NAMES)
+    }
+  ]
+);

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/type-constants/nonDecomposedConstants.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/type-constants/nonDecomposedConstants.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { registry, SourceComponent, VirtualDirectory, VirtualTreeContainer } from '@salesforce/source-deploy-retrieve';
+import { META_XML_SUFFIX, XML_NS_KEY, XML_NS_URL } from '@salesforce/source-deploy-retrieve/lib/src/common';
+import { JsToXml } from '@salesforce/source-deploy-retrieve/lib/src/convert/streams';
+import { join } from 'path';
+import { mockRegistryData } from '../mockRegistry';
+
+// Constants for a matching content file type
+const type = mockRegistryData.types.nondecomposed;
+
+export const WORKING_DIR = join(process.cwd(), 'my-project');
+
+export const DEFAULT_DIR = join(WORKING_DIR, 'force-app');
+export const NON_DEFAULT_DIR = join(WORKING_DIR, 'my-app');
+
+export const XML_NAME = `${type.name}.${type.suffix}${META_XML_SUFFIX}`;
+
+export const COMPONENT_1_TYPE_DIR = join(DEFAULT_DIR, 'path', 'to', type.directoryName);
+export const COMPONENT_2_TYPE_DIR = join(NON_DEFAULT_DIR, type.directoryName);
+export const COMPONENT_1_XML_PATH = join(COMPONENT_1_TYPE_DIR, XML_NAME);
+export const COMPONENT_2_XML_PATH = join(COMPONENT_2_TYPE_DIR, XML_NAME);
+
+export const CHILD_1_NAME = 'Child_1';
+export const CHILD_2_NAME = 'Child_2';
+export const CHILD_3_NAME = 'Child_3';
+export const UNCLAIMED_CHILD_NAME = 'Unclaimed_Child';
+
+export const CHILD_1_XML = { id: CHILD_1_NAME, description: 'the first child' };
+export const CHILD_2_XML = { id: CHILD_2_NAME, description: 'the second child' };
+export const CHILD_3_XML = { id: CHILD_3_NAME, description: 'the third child' };
+export const UNCLAIMED_CHILD_XML = { id: UNCLAIMED_CHILD_NAME, description: 'the unclaimed child' };
+
+export const COMPONENT_1_XML = {
+  [type.name]: {
+    [XML_NS_KEY]: XML_NS_URL,
+    [type.directoryName]: [CHILD_1_XML, CHILD_2_XML]
+  }
+};
+
+export const COMPONENT_2_XML = {
+  [type.name]: {
+    [XML_NS_KEY]: XML_NS_URL,
+    [type.directoryName]: CHILD_3_XML
+  }
+};
+
+export const CLAIMED_XML_CONTENT = {
+  [type.name]: {
+    [XML_NS_KEY]: XML_NS_URL,
+    [type.directoryName]: [CHILD_1_XML, CHILD_2_XML, CHILD_3_XML]
+  }
+};
+
+export const UNCLAIMED_XML_CONTENT = {
+  [type.name]: {
+    [XML_NS_KEY]: XML_NS_URL,
+    [type.directoryName]: UNCLAIMED_CHILD_XML
+  }
+};
+
+export const FULL_XML_CONTENT = {
+  [type.name]: {
+    [XML_NS_KEY]: XML_NS_URL,
+    [type.directoryName]: [CHILD_1_XML, CHILD_2_XML, CHILD_3_XML, UNCLAIMED_CHILD_XML]
+  }
+};
+
+export const MATCHING_RULES_TYPE = registry.types.matchingrules;
+// NOTE: directory name uses the string literal rather than getting from MATCHING_RULES_TYPE
+// so it explictly shows that this matches the xml field
+export const MATCHING_RULES_TYPE_DIRECTORY_NAME = 'matchingRules';
+export const MATCHING_RULES_XML_NAME = 'Account.matchingRule-meta.xml';
+export const MATCHING_RULES_COMPONENT_DIR = join(DEFAULT_DIR, MATCHING_RULES_TYPE_DIRECTORY_NAME);
+export const MATCHING_RULES_COMPONENT_XML_PATH = join(
+  MATCHING_RULES_COMPONENT_DIR,
+  MATCHING_RULES_XML_NAME
+);
+export const MATCHING_RULES_COMPONENT_XML = {
+  MatchingRules: {
+    '@_xmlns': 'http://soap.sforce.com/2006/04/metadata',
+    matchingRules: {
+      fullName: 'My_Account_Matching_Rule',
+      booleanFilter: '1 AND 2',
+      label: 'My Account Matching Rule',
+      matchingRuleItems: [
+        {
+          blankValueBehavior: 'NullNotAllowed',
+          fieldName: 'Name',
+          matchingMethod: 'Exact'
+        },
+        {
+          blankValueBehavior: 'NullNotAllowed',
+          fieldName: 'BillingCity',
+          matchingMethod: 'Exact'
+        }
+      ],
+      ruleStatus: 'Active'
+    }
+  }
+};
+
+export const VIRTUAL_DIR: VirtualDirectory[] = [
+  { dirPath: WORKING_DIR, children: [DEFAULT_DIR, NON_DEFAULT_DIR] },
+  { dirPath: DEFAULT_DIR, children: [] },
+  { dirPath: NON_DEFAULT_DIR, children: [] },
+  {
+    dirPath: COMPONENT_1_TYPE_DIR,
+    children: [
+      { name: XML_NAME, data: Buffer.from(new JsToXml(COMPONENT_1_XML).read().toString()) }
+    ]
+  },
+  {
+    dirPath: COMPONENT_2_TYPE_DIR,
+    children: [
+      { name: XML_NAME, data: Buffer.from(new JsToXml(COMPONENT_2_XML).read().toString()) }
+    ]
+  },
+  {
+    dirPath: MATCHING_RULES_COMPONENT_DIR,
+    children: [
+      {
+        name: MATCHING_RULES_XML_NAME,
+        data: Buffer.from(new JsToXml(MATCHING_RULES_COMPONENT_XML).read().toString())
+      }
+    ]
+  }
+];
+
+export const TREE = new VirtualTreeContainer(VIRTUAL_DIR);
+
+export const COMPONENT_1 = new SourceComponent(
+  { name: type.name, type, xml: COMPONENT_1_XML_PATH },
+  TREE
+);
+
+export const COMPONENT_2 = new SourceComponent(
+  { name: type.name, type, xml: COMPONENT_2_XML_PATH },
+  TREE
+);
+
+export const MATCHING_RULES_COMPONENT = new SourceComponent(
+  {
+    name: MATCHING_RULES_TYPE.name,
+    type: MATCHING_RULES_TYPE,
+    xml: MATCHING_RULES_COMPONENT_XML_PATH
+  },
+  TREE
+);

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/type-constants/xmlInFolderConstants.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/mock/registry/type-constants/xmlInFolderConstants.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { SourceComponent } from '@salesforce/source-deploy-retrieve';
+import { META_XML_SUFFIX } from '@salesforce/source-deploy-retrieve/lib/src/common';
+import { basename, join } from 'path';
+import { mockRegistryData } from '../mockRegistry';
+
+const type = mockRegistryData.types.xmlinfolder;
+const folderType = mockRegistryData.types.xmlinfolderfolder;
+
+export const TYPE_DIRECTORY = join('path', 'to', type.directoryName);
+export const COMPONENT_FOLDER_NAME = 'A_Folder';
+export const COMPONENT_FOLDER_PATH = join(TYPE_DIRECTORY, COMPONENT_FOLDER_NAME);
+export const COMPONENT_NAMES = ['a', 'b', 'c'];
+export const XML_PATHS = COMPONENT_NAMES.map(name =>
+  join(COMPONENT_FOLDER_PATH, `${name}.${type.suffix}${META_XML_SUFFIX}`)
+);
+export const XML_NAMES = XML_PATHS.map(path => basename(path));
+export const XML_PATHS_MD_FORMAT = COMPONENT_NAMES.map(name =>
+  join(COMPONENT_FOLDER_PATH, `${name}.${type.suffix}`)
+);
+export const COMPONENTS: SourceComponent[] = COMPONENT_NAMES.map(
+  (name, index) =>
+    new SourceComponent({
+      name: `${COMPONENT_FOLDER_NAME}/${name}`,
+      type,
+      xml: XML_PATHS[index]
+    })
+);
+
+export const FOLDER_XML_PATH = join(
+  TYPE_DIRECTORY,
+  `${COMPONENT_FOLDER_NAME}.${folderType.suffix}${META_XML_SUFFIX}`
+);
+export const FOLDER_XML_NAME = basename(FOLDER_XML_PATH);
+export const FOLDER_COMPONENT = new SourceComponent({
+  name: COMPONENT_FOLDER_NAME,
+  type: folderType,
+  xml: FOLDER_XML_PATH
+});
+
+export const COMPONENTS_MD_FORMAT: SourceComponent[] = COMPONENT_NAMES.map(
+  (name, index) =>
+    new SourceComponent({
+      name: `${COMPONENT_FOLDER_NAME}/${name}`,
+      type,
+      xml: XML_PATHS_MD_FORMAT[index]
+    })
+);
+export const FOLDER_COMPONENT_MD_FORMAT = new SourceComponent({
+  name: COMPONENT_FOLDER_NAME,
+  type: folderType,
+  xml: join(TYPE_DIRECTORY, `${COMPONENT_FOLDER_NAME}${META_XML_SUFFIX}`)
+});


### PR DESCRIPTION
### What does this PR do?
This PR adds many testing constants from SDR to vscode-core. It is a proof-of-concept to demonstrate the utility of these test components on two files, baseDeployRetrieve.test.ts and forceSourceRetrieveCmp.test.ts. If the direction of this PR is approved, there are many more places where the tests could be updated, particularly for conflict detection. So far all I have done is directly replace test functionality, but the new imports could also be used to make tests more thorough (such as having more component variety than just ApexClasses). Here are some more advantages of having the test components available:

- Less code. Creating SourceComponents by hand takes effort and results in a lot of duplicated code within the tests.
- More abstraction. Tests in the past used specific examples of components (such as an ApexClass component) where now tests can use abstract categories of components (such as a MatchingContentFile component). These abstract categories exactly match with the different categories of functionality defined by SDR.
- Easier edge case testing. The components in mock/registry can be set up to account for edge cases and then easily used. For example, to test conflict detection with a child component we could now just import `decomposed.DECOMPOSED_CHILD_COMPONENT_1`.

### What issues does this PR fix or reference?
@W-9662066@

### Functionality Before and After
The tests themselves should have the same functionality before and after.
