### PR TITLE
fix: read file before calling function invoke

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/functions/forceFunctionInvoke.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/functions/forceFunctionInvoke.ts
@@ -24,6 +24,8 @@ import { FunctionService } from './functionService';
 import { runFunction } from '@heroku/functions-core';
 import { LibraryCommandletExecutor } from '@salesforce/salesforcedx-utils-vscode/out/src';
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
+import * as fs from 'fs';
+
 export class ForceFunctionInvoke extends LibraryCommandletExecutor<string> {
   constructor(debug: boolean = false) {
     super(
@@ -39,11 +41,13 @@ export class ForceFunctionInvoke extends LibraryCommandletExecutor<string> {
   public async run(response: ContinueResponse<string>): Promise<boolean> {
     const defaultUsername = await OrgAuthInfo.getDefaultUsernameOrAlias(false);
     const url = 'http://localhost:8080';
+    const data = fs.readFileSync(response.data, 'utf8');
     try {
       channelService.appendLine(`POST ${url}`);
+
       const functionResponse = await runFunction({
         url,
-        payload: `@'${response.data}'`,
+        payload: data,
         targetusername: defaultUsername
       });
       channelService.appendLine(

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/functions/forceFunctionInvoke.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/functions/forceFunctionInvoke.test.ts
@@ -32,6 +32,11 @@ import { getRootWorkspacePath, OrgAuthInfo } from '../../../../src/util';
 
 import * as library from '@heroku/functions-core';
 
+const demoPayload = {
+  id: 2345,
+  service: 'MyService'
+};
+
 describe('Force Function Invoke', () => {
   let sandbox: SinonSandbox;
   let runFunctionLibraryStub: SinonStub;
@@ -45,11 +50,14 @@ describe('Force Function Invoke', () => {
   const functionServiceStubs: {
     [key: string]: SinonStub;
   } = {};
+  let readFileSyncStub: SinonStub;
   beforeEach(() => {
     sandbox = createSandbox();
     runFunctionLibraryStub = sandbox.stub(library, 'runFunction');
     runFunctionLibraryStub.returns(Promise.resolve(true));
     functionInvokeSpy = sandbox.spy(ForceFunctionInvoke.prototype, 'run');
+    readFileSyncStub = sandbox.stub(fs, 'readFileSync');
+    readFileSyncStub.returns(demoPayload);
     notificationServiceStubs.showWarningMessageStub = sandbox.stub(
       notificationService,
       'showWarningMessage'
@@ -82,7 +90,6 @@ describe('Force Function Invoke', () => {
           'functions/demoJavaScriptFunction/payload.json'
         )
       );
-
       await forceFunctionDebugInvoke(srcUri);
       const defaultUsername = await OrgAuthInfo.getDefaultUsernameOrAlias(
         false
@@ -91,7 +98,7 @@ describe('Force Function Invoke', () => {
       assert.calledOnce(runFunctionLibraryStub);
       assert.calledWith(runFunctionLibraryStub, {
         url: 'http://localhost:8080',
-        payload: `@'${srcUri.fsPath}'`,
+        payload: demoPayload,
         targetusername: defaultUsername
       });
     });
@@ -184,7 +191,6 @@ describe('Force Function Invoke', () => {
           'functions/demoJavaScriptFunction/payload.json'
         )
       );
-
       await forceFunctionInvoke(srcUri);
       const defaultUsername = await OrgAuthInfo.getDefaultUsernameOrAlias(
         false
@@ -193,7 +199,7 @@ describe('Force Function Invoke', () => {
       assert.calledOnce(runFunctionLibraryStub);
       assert.calledWith(runFunctionLibraryStub, {
         url: 'http://localhost:8080',
-        payload: `@'${srcUri.fsPath}'`,
+        payload: demoPayload,
         targetusername: defaultUsername
       });
 


### PR DESCRIPTION
### What does this PR do?
Invoking with a payload never _actually_ worked because `runFunction` expects the payload itself, not the file path 😬 . I never caught this because I tested with functions that never required payload
### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @W-9682989@

### Functionality Before
<insert gif and/or summary>

### Functionality After
<insert gif and/or summary>
