### PR TITLE
Set sourceApiVersion for sourcepath based deploy and retrieve

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploySourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploySourcePath.ts
@@ -18,6 +18,7 @@ import { channelService } from '../channels';
 import { nls } from '../messages';
 import { notificationService } from '../notifications';
 import { sfdxCoreSettings } from '../settings';
+import { SfdxProjectConfig } from '../sfdxProject';
 import { telemetryService } from '../telemetry';
 import { BaseDeployExecutor, DeployType } from './baseDeployCommand';
 import { DeployExecutor } from './baseDeployRetrieve';
@@ -55,11 +56,14 @@ export class LibraryDeploySourcePathExecutor extends DeployExecutor<
     );
   }
 
-  protected async getComponents(
+  public async getComponents(
     response: ContinueResponse<string | string[]>
   ): Promise<ComponentSet> {
+    const sourceApiVersion = (await SfdxProjectConfig.getValue('sourceApiVersion')) as string;
     const paths = typeof response.data === 'string' ? [response.data] : response.data;
-    return ComponentSet.fromSource(paths);
+    const componentSet = ComponentSet.fromSource(paths);
+    componentSet.sourceApiVersion = sourceApiVersion;
+    return componentSet;
   }
 }
 

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveSourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveSourcePath.ts
@@ -19,7 +19,7 @@ import { channelService } from '../channels';
 import { nls } from '../messages';
 import { notificationService } from '../notifications';
 import { sfdxCoreSettings } from '../settings';
-import { SfdxPackageDirectories } from '../sfdxProject';
+import { SfdxPackageDirectories, SfdxProjectConfig } from '../sfdxProject';
 import { telemetryService } from '../telemetry';
 import { RetrieveExecutor } from './baseDeployRetrieve';
 import {
@@ -52,10 +52,13 @@ export class LibraryRetrieveSourcePathExecutor extends RetrieveExecutor<
     );
   }
 
-  protected async getComponents(
+  public async getComponents(
     response: ContinueResponse<string>
   ): Promise<ComponentSet> {
-    return ComponentSet.fromSource(response.data);
+    const sourceApiVersion = (await SfdxProjectConfig.getValue('sourceApiVersion')) as string;
+    const componentSet = ComponentSet.fromSource(response.data);
+    componentSet.sourceApiVersion = sourceApiVersion;
+    return componentSet;
   }
 }
 

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDeploySourcePath.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDeploySourcePath.test.ts
@@ -11,12 +11,15 @@ import { ComponentSet, MetadataResolver } from '@salesforce/source-deploy-retrie
 import { expect } from 'chai';
 import * as path from 'path';
 import { createSandbox, SinonStub } from 'sinon';
+import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types/index';
 import {
   ForceSourceDeploySourcePathExecutor,
   LibraryDeploySourcePathExecutor
 } from '../../../src/commands';
 import { workspaceContext } from '../../../src/context';
 import { nls } from '../../../src/messages';
+import { getRootWorkspacePath } from '../../../src/util';
+import { SfdxProjectConfig } from '../../../src/sfdxProject';
 
 const sb = createSandbox();
 const $$ = testSetup();
@@ -64,6 +67,7 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
         .returns({
           pollStatus: pollStatusStub
         });
+      sb.stub(SfdxProjectConfig, 'getValue').resolves('11.0');
     });
 
     afterEach(() => {
@@ -100,6 +104,17 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
         usernameOrConnection: mockConnection
       });
       expect(pollStatusStub.calledOnce).to.equal(true);
+    });
+
+    it('componentSet should have sourceApiVersion set', async () => {
+      const executor = new LibraryDeploySourcePathExecutor();
+      const data = path.join(getRootWorkspacePath(), 'force-app/main/default/classes/');
+      const continueResponse = {
+        type: 'CONTINUE',
+        data
+      } as ContinueResponse<string>;
+      const componentSet = executor.getComponents(continueResponse);
+      expect((await componentSet).sourceApiVersion).to.equal('11.0');
     });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDeploySourcePath.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDeploySourcePath.test.ts
@@ -7,19 +7,19 @@
 
 import { AuthInfo, Connection } from '@salesforce/core';
 import { MockTestOrgData, testSetup } from '@salesforce/core/lib/testSetup';
+import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types/index';
 import { ComponentSet, MetadataResolver } from '@salesforce/source-deploy-retrieve';
 import { expect } from 'chai';
 import * as path from 'path';
 import { createSandbox, SinonStub } from 'sinon';
-import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types/index';
 import {
   ForceSourceDeploySourcePathExecutor,
   LibraryDeploySourcePathExecutor
 } from '../../../src/commands';
 import { workspaceContext } from '../../../src/context';
 import { nls } from '../../../src/messages';
-import { getRootWorkspacePath } from '../../../src/util';
 import { SfdxProjectConfig } from '../../../src/sfdxProject';
+import { getRootWorkspacePath } from '../../../src/util';
 
 const sb = createSandbox();
 const $$ = testSetup();

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveSourcePath.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveSourcePath.test.ts
@@ -28,7 +28,7 @@ import {
 import { workspaceContext } from '../../../src/context';
 import { nls } from '../../../src/messages';
 import { notificationService } from '../../../src/notifications';
-import { SfdxPackageDirectories } from '../../../src/sfdxProject';
+import { SfdxPackageDirectories, SfdxProjectConfig } from '../../../src/sfdxProject';
 import { getRootWorkspacePath } from '../../../src/util';
 
 const sb = createSandbox();
@@ -70,6 +70,7 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
       sb.stub(SfdxPackageDirectories, 'getDefaultPackageDir').resolves(
         defaultPackage
       );
+      sb.stub(SfdxProjectConfig, 'getValue').resolves('11.0');
       pollStatusStub = sb.stub();
     });
 
@@ -104,6 +105,17 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
         merge: true
       });
       expect(pollStatusStub.calledOnce).to.equal(true);
+    });
+
+    it('componentSet has sourceApiVersion set', async () => {
+      const executor = new LibraryRetrieveSourcePathExecutor();
+      const data = path.join(getRootWorkspacePath(), 'force-app/main/default/classes/');
+      const continueResponse = {
+        type: 'CONTINUE',
+        data
+      } as ContinueResponse<string>;
+      const componentSet = executor.getComponents(continueResponse);
+      expect((await componentSet).sourceApiVersion).to.equal('11.0');
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Set sourceApiVersion for sourcepath based deploy and retrieve

### What issues does this PR fix or reference?
@W-9634598@

### Functionality Before
Source path based deploy/retrieve ignores the sourceApiVersion set in sfdx-project.json

### Functionality After
Source path based deploy/retrieve respects the sourceApiVersion set in sfdx-project.json