### PR TITLE
Xyc/fix soql build

### DIFF
--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -76,6 +76,9 @@
     "webpack": "4.30.0",
     "webpack-cli": "3.3.5"
   },
+  "overrides": {
+    "monaco-page-objects": "1.5.1"
+  },
   "scripts": {
     "build": "npm run compile",
     "compile": "tsc -p ./ && webpack",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -76,9 +76,6 @@
     "webpack": "4.30.0",
     "webpack-cli": "3.3.5"
   },
-  "overrides": {
-    "monaco-page-objects": "1.5.1"
-  },
   "scripts": {
     "build": "npm run compile",
     "compile": "tsc -p ./ && webpack",

--- a/packages/salesforcedx-vscode-soql/tsconfig.json
+++ b/packages/salesforcedx-vscode-soql/tsconfig.json
@@ -11,7 +11,8 @@
     "rootDir": ".",
     "outDir": "out",
     "preserveConstEnums": true,
-    "strict": true
+    "strict": true,
+    "skipLibCheck": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
### What does this PR do?
The extensions builds are broken because of `ts-essentials@8.1.0` has `typescript>=4.0.0` as a peer dependency. ([link](https://platformcloud.slack.com/archives/GCDT2EVAQ/p1631039502084400?thread_ts=1631026151.078200&cid=GCDT2EVAQ))
The dependency comes from monaco-page-objects, which comes from vscode-extension-tester. This fix temporarily skips checking types in libs until we can use lockfiles to pin monaco-page-objects to `1.5.1`.

FYI @dehru @jonnyhork 