### PR TITLE
fix: fix debug code lens for vscode 1.60+

### DIFF
--- a/packages/salesforcedx-vscode-lwc/src/testSupport/workspace/getCliArgsFromJestArgs.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/workspace/getCliArgsFromJestArgs.ts
@@ -22,7 +22,12 @@ export function getCliArgsFromJestArgs(
     .getConfiguration('debug')
     .get('javascript.usePreview');
 
-  if (testRunType === TestRunType.DEBUG && !usePreviewJavaScriptDebugger) {
+  // W-9883286
+  // Since VS Code 1.60, `debug.javascript.usePreview` setting is no longer available
+  if (
+    testRunType === TestRunType.DEBUG &&
+    usePreviewJavaScriptDebugger === false
+  ) {
     cliArgs.unshift('--debug');
   }
   return cliArgs;

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/mocks/vscodeConfiguration.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/mocks/vscodeConfiguration.ts
@@ -49,7 +49,7 @@ const mockDebugConfiguration: WorkspaceConfiguration = {
  * Mock "debug.javascript.usePreview" value
  * @param enabled is configuration enabled
  */
-export function mockPreviewJavaScriptDebugger(enabled: boolean) {
+export function mockPreviewJavaScriptDebugger(enabled?: boolean) {
   getConfigurationStub = stub(workspace, 'getConfiguration');
   mockDebugConfigurationJson['javascript.usePreview'] = enabled;
   getConfigurationStub.returns(mockDebugConfiguration);

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/workspace/getCliArgsFromJestArgs.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/workspace/getCliArgsFromJestArgs.test.ts
@@ -47,6 +47,13 @@ describe('getCliArgsFromJestArgs Unit Tests', () => {
     expect(cliArgs).to.eql(expectedCliArgs);
   });
 
+  it('Should return Cli args for debug mode if preview JavaScript debugger setting is not available', () => {
+    mockPreviewJavaScriptDebugger(undefined);
+    const cliArgs = getCliArgsFromJestArgs(mockJestArgs, TestRunType.DEBUG);
+    const expectedCliArgs = ['--', ...mockJestArgs];
+    expect(cliArgs).to.eql(expectedCliArgs);
+  });
+
   it('Should return Cli args for debug mode if using preview JavaScript debugger', () => {
     mockPreviewJavaScriptDebugger(true);
     const cliArgs = getCliArgsFromJestArgs(mockJestArgs, TestRunType.DEBUG);


### PR DESCRIPTION
### What does this PR do?
Fixes LWC debug code lens issue for VS Code 1.60+

### What issues does this PR fix or reference?
@W-9883286@
