### PR TITLE
feat: append or prepend site title with SEO meta data

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,6 +1,15 @@
 <html>
   <head>
-    <title>{{ page.title }}</title>
+    {% if page.url != '/' %}
+      {% if page.lang == 'en' %}
+        <title>{{ page.title }} | Salesforce for VSCode</title>
+      {% elsif page.lang == 'ja' %}
+        <title>Salesforce Developers Japan | {{ page.title }}</title>
+      {% endif %}
+    {% else %}
+      <title>{{ page.title }}</title>
+    {% endif %}
+
     <base href="{{ site.baseurl }}/" />
     {% include head.html %}
     <!-- Google Tag Manager -->


### PR DESCRIPTION
### What does this PR do?

- prepend or append SEO meta data for the title tag

### What issues does this PR fix or reference?
[W-9878507](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000005hJB7YAM/view)

### Functionality Before
title tag only contained the basic page title

### Functionality After
the title tag is prepended or appended with either a " | Salesforce for VSCode" or "Salesforce Developers Japan" string.
