### PR TITLE
fix: fix trace flag update error

### DIFF
--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/traceFlags.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/traceFlags.ts
@@ -113,7 +113,7 @@ export class TraceFlags {
   ): Promise<boolean> {
     const traceFlag = {
       Id: id,
-      StartDate: '',
+      StartDate: Date.now(),
       ExpirationDate: expirationDate.toUTCString()
     };
     const result = (await this.connection.tooling.update(
@@ -132,7 +132,7 @@ export class TraceFlags {
       tracedentityid: userId,
       logtype: 'developer_log',
       debuglevelid: debugLevelId,
-      StartDate: '',
+      StartDate: Date.now(),
       ExpirationDate: expirationDate.toUTCString()
     };
 

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/vscode-integration/commands/traceFlags.test.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/vscode-integration/commands/traceFlags.test.ts
@@ -95,7 +95,7 @@ describe('Trace Flags', () => {
     updateArgs = toolingUpdateStub.getCall(1).args;
     expect(updateArgs[0]).to.equal('TraceFlag');
     expect(updateArgs[1].Id).to.equal('1234');
-    expect(updateArgs[1].StartDate).to.equal('');
+    expect(updateArgs[1].StartDate).to.not.equal('');
     const expDate = new Date(updateArgs[1].ExpirationDate);
     expect(expDate.getTime() - currDate).to.be.greaterThan(60000 * 29);
 
@@ -143,7 +143,7 @@ describe('Trace Flags', () => {
     expect(createArgs[1].tracedentityid).to.equal(USER_ID);
     expect(createArgs[1].logtype).to.equal('developer_log');
     expect(createArgs[1].debuglevelid).to.equal('aBcDeF');
-    expect(createArgs[1].StartDate).to.equal('');
+    expect(createArgs[1].StartDate).to.not.equal('');
     const expDate = new Date(createArgs[1].ExpirationDate);
     expect(expDate.getTime() - currDate).to.be.greaterThan(60000 * 29);
   });


### PR DESCRIPTION
### What does this PR do?
There was an error with the trace flag start and end date overlapping, which is fixed by setting the start date on the trace flag when it is created and updated. This issue was [reported](https://developer.salesforce.com/forums/?id=9062I000000DIR4QAO) online, and also discovered while testing the tail log command.

### What issues does this PR fix or reference?
#

### Functionality Before
When a trace flag is updated with the replay debugger, we receive an error message: `This entity is already being traced by a trace flag with a start and expiration date that overlap this trace flag's start and expiration date.: Traced Entity ID`. To get around this error, users have to delete the trace flag and create a new one.

### Functionality After
Trace flags can be updated from the replay debugger directly.
