### PR TITLE
fix: unnecessary SDR errors

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployCommand.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployCommand.ts
@@ -15,10 +15,8 @@ import {
   Table
 } from '@salesforce/salesforcedx-utils-vscode/out/src/output';
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
-import { ComponentSet } from '@salesforce/source-deploy-retrieve';
 import * as vscode from 'vscode';
 import { channelService } from '../channels';
-import { TELEMETRY_METADATA_COUNT } from '../constants';
 import { handleDiagnosticErrors } from '../diagnostics';
 import { nls } from '../messages';
 import { notificationService, ProgressNotification } from '../notifications';
@@ -26,9 +24,6 @@ import { DeployQueue } from '../settings/pushOrDeployOnSave';
 import { taskViewService } from '../statuses';
 import { telemetryService } from '../telemetry';
 import { getRootWorkspacePath } from '../util';
-import {
-  createComponentCount, formatException
-} from './util';
 import { SfdxCommandletExecutor } from './util/sfdxCommandlet';
 
 export enum DeployType {
@@ -63,16 +58,6 @@ export abstract class BaseDeployExecutor extends SfdxCommandletExecutor<
 
     execution.processExitSubject.subscribe(async exitCode => {
       const telemetry = new TelemetryBuilder();
-
-      try {
-        const components = ComponentSet.fromSource(execFilePathOrPaths.split(','));
-        const metadataCount = JSON.stringify(createComponentCount(components));
-        telemetry.addProperty(TELEMETRY_METADATA_COUNT, metadataCount);
-      } catch (e) {
-        const error = await formatException(e);
-        telemetryService.sendException(error.name, error.message);
-      }
-
       let success = false;
       try {
         BaseDeployExecutor.errorCollection.clear();


### PR DESCRIPTION
### What does this PR do?
removed SDR from base deploy, since scratch orgs were running into errors in SDR for missing paths

### What issues does this PR fix or reference?
@W-10004893@

### Functionality Before
When pushing code to scratch orgs, error messages were being quietly logged to our telemetry.

### Functionality After
Telemetry will be cleaner, and make it easier to see real errors.
