### PR TITLE
fix: update lightning-language-server to latest version

### DIFF
--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -25,9 +25,9 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/aura-language-server": "3.0.14",
+    "@salesforce/aura-language-server": "3.1.0",
     "@salesforce/core": "2.28.0",
-    "@salesforce/lightning-lsp-common": "3.0.14",
+    "@salesforce/lightning-lsp-common": "3.1.0",
     "@salesforce/salesforcedx-utils-vscode": "53.2.0",
     "applicationinsights": "1.0.7",
     "vscode-extension-telemetry": "0.0.17",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "@salesforce/core": "2.28.0",
     "@salesforce/eslint-config-lwc": "0.3.0",
-    "@salesforce/lightning-lsp-common": "3.0.14",
-    "@salesforce/lwc-language-server": "3.0.14",
+    "@salesforce/lightning-lsp-common": "3.1.0",
+    "@salesforce/lwc-language-server": "3.1.0",
     "@salesforce/salesforcedx-utils-vscode": "53.2.0",
     "ajv": "^6.1.1",
     "applicationinsights": "1.0.7",


### PR DESCRIPTION
### What does this PR do?
Update `lightning-language-server` (and related modules) to 3.1.0 to pickup the updated wire adapter type defs.

### What issues does this PR fix or reference?
@W-9717230@

### Functionality Before
No code-complete or hover text on adapters added in forcedotcom/lightning-language-server#450

### Functionality After
Code-completion and hover texts:
<img width="661" alt="Screen Shot 2021-11-04 at 11 19 05 AM" src="https://user-images.githubusercontent.com/595444/140387998-b68436b0-06d8-4cd6-a8d6-ea001f7cf35f.png">

cc: @reidaelliott, @yijian-wang, @mblumreich 