### PR TITLE
fix: added fix for when deploy on save is enabled

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploySourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploySourcePath.ts
@@ -58,11 +58,15 @@ export const forceSourceDeploySourcePaths = async (
   // sourceUri is passed, and is the path to the first selected file, and the uris
   // array contains an array of all paths that were selected.
   //
-  // When editing a file and "Deploy This Source from Org" is executed,
-  // sourceUri is passed, but uris is undefined.
   if (!uris || uris.length < 1) {
-    uris = [];
-    uris.push(sourceUri);
+    if (Array.isArray(sourceUri)) {
+      // When "Push-or-deploy-on-save" is enabled, the first parameter
+      // passed in (sourceUri) is actually an array and not a single URI.
+      uris = sourceUri;
+    } else {
+      uris = [];
+      uris.push(sourceUri);
+    }
   }
 
   const messages: ConflictDetectionMessages = {

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveSourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveSourcePath.ts
@@ -107,14 +107,8 @@ export const forceSourceRetrieveSourcePaths = async (
   // When editing a file and "Retrieve This Source from Org" is executed,
   // sourceUri is passed, but uris is undefined.
   if (!uris || uris.length < 1) {
-    if (Array.isArray(sourceUri)) {
-      // When "Push-or-deploy-on-save" is enabled, the first parameter
-      // passed in (sourceUri) is actually an array and not a single URI.
-      uris = sourceUri;
-    } else {
-      uris = [];
-      uris.push(sourceUri);
-    }
+    uris = [];
+    uris.push(sourceUri);
   }
 
   const messages: ConflictDetectionMessages = {

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveSourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveSourcePath.ts
@@ -107,8 +107,14 @@ export const forceSourceRetrieveSourcePaths = async (
   // When editing a file and "Retrieve This Source from Org" is executed,
   // sourceUri is passed, but uris is undefined.
   if (!uris || uris.length < 1) {
-    uris = [];
-    uris.push(sourceUri);
+    if (Array.isArray(sourceUri)) {
+      // When "Push-or-deploy-on-save" is enabled, the first parameter
+      // passed in (sourceUri) is actually an array and not a single URI.
+      uris = sourceUri;
+    } else {
+      uris = [];
+      uris.push(sourceUri);
+    }
   }
 
   const messages: ConflictDetectionMessages = {


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
#https://github.com/forcedotcom/salesforcedx-vscode/issues/3655

### Functionality Before
A bug was introduced with yesterday's release.  When. one has "deploy on save" enabled, the URI passed in is coming fro VS Code, and is actually an array of URIs, which was causing a crash further downstream.

### Functionality After
`forceSourceDeploySourcePaths()` and `forceSourceRetrieveSourcePaths()` now check for the first parameter (sourceUri) and check to see if it is actually an array.
