### PR TITLE
fix: org browser folders no longer display items

### DIFF
--- a/packages/salesforcedx-vscode-core/src/orgBrowser/metadataCmp.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/metadataCmp.ts
@@ -132,9 +132,9 @@ export class ComponentUtils {
   public async fetchAndSaveSObjectFieldsProperties(
     connection: Connection,
     componentsPath: string,
-    sObjectName: string
+    folderName: string
   ): Promise<string> {
-    const describeSObjectFields = await connection.describe(sObjectName);
+    const describeSObjectFields = await connection.describe(folderName);
     const describeSObjectFieldsList = describeSObjectFields.fields;
     const result = {status: 0, result: describeSObjectFieldsList};
     const jsonResult = JSON.stringify(result, null, 2);
@@ -217,7 +217,7 @@ export class ComponentUtils {
    * @returns a list of name of metadata components
    */
   public async fetchMetadataComponents(metadataType: string, connection: Connection, componentsPath: string, folderName: string | undefined) {
-    const result = await this. fetchAndSaveMetadataComponentProperties(
+    const result = await this.fetchAndSaveMetadataComponentProperties(
       metadataType,
       connection,
       componentsPath,

--- a/packages/salesforcedx-vscode-core/src/orgBrowser/metadataCmp.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/metadataCmp.ts
@@ -173,6 +173,13 @@ export class ComponentUtils {
     return componentsList;
   }
 
+  /**
+   * Retrieves a list of all fields of the standard or custom object.
+   * @param connection instance of Connection
+   * @param componentsPath json file path of the component
+   * @param folderName name of the custom or standard object listed under Custom Objects
+   * @returns list of name of fields of the standard or custom object
+   */
   public async fetchCustomObjectsFields(connection: Connection, componentsPath: string, folderName: string) {
     const result = await this.fetchAndSaveSObjectFieldsProperties(
       connection,
@@ -187,6 +194,12 @@ export class ComponentUtils {
     return fieldList;
   }
 
+  /**
+   * Builds list of components from existing json file at the componentsPath
+   * @param metadataType name of metadata type
+   * @param componentsPath existing json file path of the component
+   * @returns list of name of metadata components
+   */
   public fetchExistingMetadataComponents(metadataType: string, componentsPath: string) {
     return this.buildComponentsList(
       metadataType,
@@ -195,6 +208,14 @@ export class ComponentUtils {
     );
   }
 
+  /**
+   * Retrieves a list of metadata components
+   * @param metadataType name of metadata component
+   * @param connection instance of connection
+   * @param componentsPath json file path of the component
+   * @param folderName name of the folders listed under metadata components like Email Templates, Documents, Dashboards or Reports
+   * @returns a list of name of metadata components
+   */
   public async fetchMetadataComponents(metadataType: string, connection: Connection, componentsPath: string, folderName: string | undefined) {
     const result = await this. fetchAndSaveMetadataComponentProperties(
       metadataType,
@@ -209,6 +230,12 @@ export class ComponentUtils {
     );
     return componentList;
   }
+
+  /**
+   * Builds a list of all fields of the standard or custom object from existing json file at the componentsPath
+   * @param componentsPath existing json file path of the component
+   * @returns a list of all fields of the standard or custom object
+   */
   public fetchExistingCustomObjectsFields(componentsPath: string) {
     return this.buildCustomObjectFieldsList(
       undefined,

--- a/packages/salesforcedx-vscode-core/src/orgBrowser/metadataCmp.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/metadataCmp.ts
@@ -130,9 +130,9 @@ export class ComponentUtils {
   }
 
   public async fetchAndSaveSObjectFieldsProperties(
-    sObjectName: string,
     connection: Connection,
-    componentsPath: string
+    componentsPath: string,
+    sObjectName: string
   ): Promise<string> {
     const describeSObjectFields = await connection.describe(sObjectName);
     const describeSObjectFieldsList = describeSObjectFields.fields;
@@ -159,9 +159,9 @@ export class ComponentUtils {
 
     if (metadataType === 'CustomObject' && folderName) {
       if (forceRefresh || !fs.existsSync(componentsPath)) {
-        componentsList = await this.fetchCustomObjectsFields(folderName, connection, componentsPath);
+        componentsList = await this.fetchCustomObjectsFields(connection, componentsPath, folderName);
       } else {
-        componentsList = this.fetchExistingCustomObjectsFields(folderName, componentsPath);
+        componentsList = this.fetchExistingCustomObjectsFields(componentsPath);
       }
     } else {
       if (forceRefresh || !fs.existsSync(componentsPath)) {
@@ -173,11 +173,11 @@ export class ComponentUtils {
     return componentsList;
   }
 
-  public async fetchCustomObjectsFields(folderName: string, connection: Connection, componentsPath: string) {
+  public async fetchCustomObjectsFields(connection: Connection, componentsPath: string, folderName: string) {
     const result = await this.fetchAndSaveSObjectFieldsProperties(
-      folderName,
       connection,
-      componentsPath
+      componentsPath,
+      folderName
     );
     const fieldList = this.buildCustomObjectFieldsList(
       result,
@@ -209,8 +209,7 @@ export class ComponentUtils {
     );
     return componentList;
   }
-// TODO: fetchExistingCustomObjectsFields requires only one parameter componentsPath and corresponding tests have to be modified
-  public fetchExistingCustomObjectsFields(folderName: string, componentsPath: string) {
+  public fetchExistingCustomObjectsFields(componentsPath: string) {
     return this.buildCustomObjectFieldsList(
       undefined,
       componentsPath

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
@@ -248,6 +248,8 @@ describe('load metadata components and custom objects fields list', () => {
   const metadataType = 'ApexClass';
   const metadataTypeCustomObject = 'CustomObject';
   const sObjectName = 'DemoCustomObject';
+  const folderName = 'DemoDashboard';
+  const metadataTypeDashboard = 'Dashboard';
   const filePath = '/test/metadata/ApexClass.json';
   const fileData = JSON.stringify({
     status: 0,
@@ -305,6 +307,23 @@ describe('load metadata components and custom objects fields list', () => {
     expect(fetchAndSaveMetadataComponentPropertiesStub.calledWith(metadataType, mockConnection, filePath)).to.be.true;
     expect(buildComponentsListStub.calledOnce).to.be.true;
     expect(buildComponentsListStub.calledWith(metadataType, fileData, undefined)).to.be.true;
+  });
+
+  it('should load metadata components listed under folders of Dashboards through sfdx-core library if file does not exist', async () => {
+    fileExistsStub.returns(false);
+    const components = await cmpUtil.loadComponents(defaultOrg, metadataTypeDashboard, folderName, undefined);
+    expect(fetchAndSaveMetadataComponentPropertiesStub.calledOnce).to.equal(true);
+    expect(fetchAndSaveMetadataComponentPropertiesStub.calledWith(metadataTypeDashboard, mockConnection, filePath, folderName)).to.be.true;
+    expect(buildComponentsListStub.calledOnce).to.be.true;
+    expect(buildComponentsListStub.calledWith(metadataTypeDashboard, fileData, undefined)).to
+      .be.true;
+  });
+
+  it('should load metadata components listed under folders of Dashboards from json file if the file exists', async () => {
+    fileExistsStub.returns(true);
+    const components = await cmpUtil.loadComponents(defaultOrg, metadataTypeDashboard, folderName, undefined);
+    expect(fetchAndSaveMetadataComponentPropertiesStub.called).to.equal(false);
+    expect(buildComponentsListStub.calledWith(metadataTypeDashboard, undefined, filePath)).to.be.true;
   });
 
   it('should load sobject fields list through sfdx-core if file does not exist', async () => {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
@@ -507,7 +507,7 @@ describe('retrieve fields data of a sobject to write in a json file designated f
 
   it('should validate that fetchAndSaveSObjectFieldsProperties() returns the correctly formatted result file', async () => {
     const sObjectFields = await cmpUtil.fetchAndSaveSObjectFieldsProperties(sObjectName, mockConnection, filePath);
-    expect(sObjectFields).to.equal(JSON.stringify(expectedfetchAndSaveSObjectFieldsPropertiesResult));
+    expect(sObjectFields).to.equal(JSON.stringify(expectedfetchAndSaveSObjectFieldsPropertiesResult, null, 2));
     expect(JSON.parse(sObjectFields).result.length).to.equal(expectedfetchAndSaveSObjectFieldsPropertiesResult.result.length);
   });
 });


### PR DESCRIPTION
### What does this PR do?
Displays the items under org browser folders like Email Templates, Dashboards, Documents and Reports.

### What issues does this PR fix or reference?
@W-10255794@

### Functionality Before
<img width="385" alt="Screen Shot 2021-12-06 at 3 25 24 PM" src="https://user-images.githubusercontent.com/72183558/144938834-fee6ef26-4eb4-41f0-b032-525ee3d4ee5c.png">

### Functionality After
<img width="392" alt="Screen Shot 2021-12-06 at 3 31 02 PM" src="https://user-images.githubusercontent.com/72183558/144939241-c59215a2-be66-4211-9eb9-1463b4584336.png">


