### PR TITLE
fix: display retrieve source button

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -154,7 +154,7 @@
         },
         {
           "command": "sfdx.force.source.retrieve.component",
-          "when": "view == metadata && viewItem =~ /(type|component)/",
+          "when": "view == metadata && viewItem =~ /(type|component|folder)/",
           "group": "inline"
         },
         {

--- a/packages/salesforcedx-vscode-core/src/orgBrowser/nodeTypes.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/nodeTypes.ts
@@ -134,6 +134,7 @@ export class BrowserNode extends vscode.TreeItem
     switch (this.type) {
       case NodeType.MetadataType:
         return RetrieveDescriberFactory.createTypeNodeDescriber(this);
+      case NodeType.Folder:
       case NodeType.MetadataComponent:
         return RetrieveDescriberFactory.createComponentNodeDescriber(this);
     }


### PR DESCRIPTION
### What does this PR do?
Provides the `Retrieve Source from Org` button for all custom objects in Org Browser
### What issues does this PR fix or reference?
@W-10304052@

### Functionality Before
<img width="438" alt="Screen Shot 2021-12-14 at 12 41 44 PM" src="https://user-images.githubusercontent.com/72183558/146076245-5a0ba37c-3dcf-45da-b0d4-ed934fed1a4f.png">

### Functionality After

<img width="441" alt="Screen Shot 2021-12-14 at 12 37 54 PM" src="https://user-images.githubusercontent.com/72183558/146075760-1bd1f929-f245-4a76-b7ab-eab6db151f06.png">

