### PR TITLE
fix: retrieve source for layout metadata type

### DIFF
--- a/packages/salesforcedx-vscode-core/src/orgBrowser/metadataCmp.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/metadataCmp.ts
@@ -12,6 +12,7 @@ import { workspaceContext } from '../context';
 import { nls } from '../messages';
 import { telemetryService } from '../telemetry';
 import { getRootWorkspacePath, hasRootWorkspace, OrgAuthInfo } from '../util';
+import { ListMetadataQuery } from 'jsforce';
 
 const validManageableStates = new Set([
   'unmanaged',
@@ -121,7 +122,10 @@ export class ComponentUtils {
     componentsPath: string,
     folderName?: string
   ): Promise<string> {
-    const metadataQuery = {folder: folderName, type: metadataType};
+    const metadataQuery: ListMetadataQuery = {type: metadataType};
+    if (folderName) {
+      metadataQuery.folder = folderName
+    }
     const metadataFileProperties = await connection.metadata.list(metadataQuery);
     const result = {status: 0, result: metadataFileProperties};
     const jsonResult = JSON.stringify(result, null, 2);


### PR DESCRIPTION
### What does this PR do?
Fix `Retrieve source from Org` command for 'Layout' metadata type
### What issues does this PR fix or reference?
@W-10317570@

### Functionality Before
Failed to run `Retrieve Source from Org`, threw error.

### Functionality After
`Retrieve Source from Org` runs successfully without error.
