### PR TITLE
chore: port 3709 to release 53.8.1

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "53.8.0",
+  "version": "53.8.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "docs",
     "packages/*"
   ],
-  "version": "53.8.0"
+  "version": "53.8.1"
 }

--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -2,7 +2,7 @@
   "name": "@salesforce/salesforcedx-apex-debugger",
   "displayName": "Apex Debugger Adapter",
   "description": "Implements the VS Code Debug Protocol for the Apex Debugger",
-  "version": "53.8.0",
+  "version": "53.8.1",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -12,7 +12,7 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-utils-vscode": "53.8.0",
+    "@salesforce/salesforcedx-utils-vscode": "53.8.1",
     "async-lock": "1.0.0",
     "faye": "1.1.2",
     "request-light": "0.2.4",
@@ -20,7 +20,7 @@
     "vscode-debugprotocol": "1.28.0"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "53.8.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "53.8.1",
     "@types/async-lock": "0.0.20",
     "@types/chai": "^4.0.0",
     "@types/mocha": "^5",

--- a/packages/salesforcedx-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-apex-replay-debugger/package.json
@@ -2,7 +2,7 @@
   "name": "@salesforce/salesforcedx-apex-replay-debugger",
   "displayName": "Apex Replay Debug Adapter",
   "description": "Implements the VS Code Debug Protocol for the Apex Replay Debugger",
-  "version": "53.8.0",
+  "version": "53.8.1",
   "publisher": "salesforce",
   "preview": true,
   "license": "BSD-3-Clause",
@@ -13,7 +13,7 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-utils-vscode": "53.8.0",
+    "@salesforce/salesforcedx-utils-vscode": "53.8.1",
     "vscode-debugadapter": "1.28.0",
     "vscode-debugprotocol": "1.28.0",
     "vscode-uri": "1.0.1"

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -2,7 +2,7 @@
   "name": "@salesforce/salesforcedx-sobjects-faux-generator",
   "displayName": "Salesforce SObject Faux Generator",
   "description": "Fetches sobjects and generates their faux apex class to be used for Apex Language Server",
-  "version": "53.8.0",
+  "version": "53.8.1",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {

--- a/packages/salesforcedx-test-utils-vscode/package.json
+++ b/packages/salesforcedx-test-utils-vscode/package.json
@@ -2,14 +2,14 @@
   "name": "@salesforce/salesforcedx-test-utils-vscode",
   "displayName": "SFDX Test Utilities for VS Code",
   "description": "Provides test utilities to interface the SFDX libraries with VS Code",
-  "version": "53.8.0",
+  "version": "53.8.1",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "categories": [
     "Other"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-utils-vscode": "53.8.0",
+    "@salesforce/salesforcedx-utils-vscode": "53.8.1",
     "shelljs": "0.8.3"
   },
   "devDependencies": {

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "SFDX Utilities for VS Code",
   "description": "Provides utilities to interface the SFDX libraries with VS Code",
   "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
-  "version": "53.8.0",
+  "version": "53.8.1",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "categories": [

--- a/packages/salesforcedx-visualforce-language-server/package.json
+++ b/packages/salesforcedx-visualforce-language-server/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@salesforce/salesforcedx-visualforce-language-server",
   "description": "Visualforce language server",
-  "version": "53.8.0",
+  "version": "53.8.1",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
     "vscode": "^1.49.3"
   },
   "dependencies": {
-    "@salesforce/salesforcedx-visualforce-markup-language-server": "53.8.0",
+    "@salesforce/salesforcedx-visualforce-markup-language-server": "53.8.1",
     "typescript": "3.8.3",
     "vscode-css-languageservice": "2.1.9",
     "vscode-languageserver": "5.2.1",

--- a/packages/salesforcedx-visualforce-markup-language-server/package.json
+++ b/packages/salesforcedx-visualforce-markup-language-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/salesforcedx-visualforce-markup-language-server",
   "description": "Language service for Visualforce Markup",
-  "version": "53.8.0",
+  "version": "53.8.1",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "53.8.0",
+  "version": "53.8.1",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -24,12 +24,12 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-apex-debugger": "53.8.0",
+    "@salesforce/salesforcedx-apex-debugger": "53.8.1",
     "vscode-debugprotocol": "1.28.0",
     "vscode-extension-telemetry": "0.0.17"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "53.8.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "53.8.1",
     "@types/chai": "^4.0.0",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "53.8.0",
+  "version": "53.8.1",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -26,15 +26,15 @@
   "dependencies": {
     "@salesforce/apex-node": "0.2.9",
     "@salesforce/core": "2.28.0",
-    "@salesforce/salesforcedx-apex-replay-debugger": "53.8.0",
-    "@salesforce/salesforcedx-utils-vscode": "53.8.0",
+    "@salesforce/salesforcedx-apex-replay-debugger": "53.8.1",
+    "@salesforce/salesforcedx-utils-vscode": "53.8.1",
     "async-lock": "1.0.0",
     "path-exists": "3.0.0",
     "request-light": "0.2.4",
     "vscode-extension-telemetry": "0.0.17"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "53.8.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "53.8.1",
     "@salesforce/ts-sinon": "1.2.2",
     "@types/async-lock": "0.0.20",
     "@types/chai": "^4.0.0",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -15,7 +15,7 @@
     "theme": "light"
   },
   "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
-  "version": "53.8.0",
+  "version": "53.8.1",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -28,7 +28,7 @@
     "@salesforce/apex-node": "0.2.9",
     "@salesforce/apex-tmlanguage": "1.4.0",
     "@salesforce/core": "2.28.0",
-    "@salesforce/salesforcedx-utils-vscode": "53.8.0",
+    "@salesforce/salesforcedx-utils-vscode": "53.8.1",
     "@salesforce/source-deploy-retrieve": "5.0.0",
     "expand-home-dir": "0.0.3",
     "find-java-home": "0.2.0",
@@ -38,7 +38,7 @@
     "vscode-languageclient": "5.1.1"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "53.8.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "53.8.1",
     "@types/chai": "^4.0.0",
     "@types/mkdirp": "0.5.2",
     "@types/mocha": "^5",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -15,7 +15,7 @@
     "theme": "light"
   },
   "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
-  "version": "53.8.0",
+  "version": "53.8.1",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -27,8 +27,8 @@
   "dependencies": {
     "@heroku/functions-core": "0.0.7",
     "@salesforce/core": "2.28.0",
-    "@salesforce/salesforcedx-sobjects-faux-generator": "53.8.0",
-    "@salesforce/salesforcedx-utils-vscode": "53.8.0",
+    "@salesforce/salesforcedx-sobjects-faux-generator": "53.8.1",
+    "@salesforce/salesforcedx-utils-vscode": "53.8.1",
     "@salesforce/schemas": "^1",
     "@salesforce/source-deploy-retrieve": "5.0.0",
     "@salesforce/templates": "52.3.0",
@@ -41,7 +41,7 @@
     "yeoman-generator": "^4.8.2"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "53.8.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "53.8.1",
     "@salesforce/ts-sinon": "^1.0.0",
     "@types/adm-zip": "^0.4.31",
     "@types/chai": "^4.0.0",

--- a/packages/salesforcedx-vscode-expanded/package.json
+++ b/packages/salesforcedx-vscode-expanded/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "53.8.0",
+  "version": "53.8.1",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -15,7 +15,7 @@
     "theme": "light"
   },
   "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
-  "version": "53.8.0",
+  "version": "53.8.1",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -28,13 +28,13 @@
     "@salesforce/aura-language-server": "3.1.0",
     "@salesforce/core": "2.28.0",
     "@salesforce/lightning-lsp-common": "3.1.0",
-    "@salesforce/salesforcedx-utils-vscode": "53.8.0",
+    "@salesforce/salesforcedx-utils-vscode": "53.8.1",
     "applicationinsights": "1.0.7",
     "vscode-extension-telemetry": "0.0.17",
     "vscode-languageclient": "^5.2.1"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "53.8.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "53.8.1",
     "@types/chai": "^4.0.0",
     "@types/mkdirp": "0.5.2",
     "@types/mocha": "^5",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -15,7 +15,7 @@
     "theme": "light"
   },
   "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
-  "version": "53.8.0",
+  "version": "53.8.1",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -29,7 +29,7 @@
     "@salesforce/eslint-config-lwc": "0.3.0",
     "@salesforce/lightning-lsp-common": "3.1.0",
     "@salesforce/lwc-language-server": "3.1.0",
-    "@salesforce/salesforcedx-utils-vscode": "53.8.0",
+    "@salesforce/salesforcedx-utils-vscode": "53.8.1",
     "ajv": "^6.1.1",
     "applicationinsights": "1.0.7",
     "eslint": "5.0.0",
@@ -42,7 +42,7 @@
     "vscode-languageclient": "^5.2.1"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "53.8.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "53.8.1",
     "@types/chai": "^4.0.0",
     "@types/mkdirp": "0.5.2",
     "@types/mocha": "^5",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/forcedotcom/salesforcedx-vscode"
   },
   "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
-  "version": "53.8.0",
+  "version": "53.8.1",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "icon": "images/VSCodeSoql.png",
@@ -41,9 +41,9 @@
     "jsforce": "^1.10.0"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-sobjects-faux-generator": "53.8.0",
-    "@salesforce/salesforcedx-test-utils-vscode": "53.8.0",
-    "@salesforce/salesforcedx-utils-vscode": "53.8.0",
+    "@salesforce/salesforcedx-sobjects-faux-generator": "53.8.1",
+    "@salesforce/salesforcedx-test-utils-vscode": "53.8.1",
+    "@salesforce/salesforcedx-utils-vscode": "53.8.1",
     "@salesforce/soql-common": "0.2.1",
     "@salesforce/ts-sinon": "1.2.2",
     "@types/chai": "^4.0.0",

--- a/packages/salesforcedx-vscode-visualforce/package.json
+++ b/packages/salesforcedx-vscode-visualforce/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "53.8.0",
+  "version": "53.8.1",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -24,15 +24,15 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-visualforce-language-server": "53.8.0",
-    "@salesforce/salesforcedx-visualforce-markup-language-server": "53.8.0",
+    "@salesforce/salesforcedx-visualforce-language-server": "53.8.1",
+    "@salesforce/salesforcedx-visualforce-markup-language-server": "53.8.1",
     "vscode-extension-telemetry": "0.0.17",
     "vscode-languageclient": "5.2.1",
     "vscode-languageserver-protocol": "3.14.1",
     "vscode-languageserver-types": "3.14.0"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "53.8.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "53.8.1",
     "@types/chai": "^4.0.0",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",

--- a/packages/salesforcedx-vscode/package.json
+++ b/packages/salesforcedx-vscode/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "53.8.0",
+  "version": "53.8.1",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {

--- a/packages/system-tests/package.json
+++ b/packages/system-tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "system-tests",
   "description": "System tests for Salesforce DX Extensions for VS Code",
-  "version": "53.8.0",
+  "version": "53.8.1",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "main": "./out/src",
@@ -9,8 +9,8 @@
     "vscode": "^1.49.3"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "53.8.0",
-    "@salesforce/salesforcedx-utils-vscode": "53.8.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "53.8.1",
+    "@salesforce/salesforcedx-utils-vscode": "53.8.1",
     "@types/chai": "^4.0.0",
     "@types/mkdirp": "0.5.2",
     "@types/mocha": "^5",


### PR DESCRIPTION
### What does this PR do?

Port changes that remove log4j classes from Apex Language Server into patch release 53.8.1