### PR TITLE
ci(dependabot): add dependabot config for updating dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -628,3 +628,19 @@ workflows:
     jobs:
       - create-release-branch:
           e: default-executor
+
+  dependabot-automerge:
+    triggers:
+      - schedule:
+          # Every hour after regular working hours (8pm-4am) specified in UTC
+          # on Thu to Fri, giving time before and after release cutoff for changes to get tested
+          # Ref: https://circleci.com/docs/2.0/workflows/#scheduling-a-workflow
+          cron: '0 4,6,8,10,12 * * 4,5'
+          filters:
+            branches:
+              only:
+                - develop
+    jobs:
+      # Merges 1 mergeable PR created by dependabot containing minor, patch updates
+      # Requires "repository" property in package.json to be a string of 'owner/repo'
+      - release-management/dependabot-automerge

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,47 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+# Notes:
+# - Use "redhat.vscode-yaml" extension for schema and config validation
+# - Must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'.
+
+version: 2
+updates:
+  # Minor, Patch updates (to be auto-merged using 'release-management/dependabot-automerge')
+  - package-ecosystem: "npm"
+    directory: "/" # Location of package manifests
+    schedule:
+      # After the weekly release branch cut-off on Monday
+      interval: "weekly"
+      day: "wednesday"
+      time: "06:00"
+      timezone: "America/Los_Angeles"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    open-pull-requests-limit: 10
+  # Major version updates (not auto-merged)
+  - package-ecosystem: "npm"
+    directory: "/" # Location of package manifests
+    target-branch: "develop"
+    schedule:
+      # Monthly after the weekly minor,patch updates have been merged
+      interval: "monthly"
+      day: "friday"
+      time: "06:00"
+      timezone: "America/Los_Angeles"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-patch"]
+    open-pull-requests-limit: 5
+  # Exclude updates to doc tools
+  # TODO: Enable after adding automated check(s) for doc generation
+  - package-ecosystem: "bundler"
+    directory: "/docs" # Location of package manifests
+    ignore:
+      - dependency-name: "*"
+    schedule:
+      interval: "monthly"

--- a/docs/_articles/en/getting-started/recommended-extensions.md
+++ b/docs/_articles/en/getting-started/recommended-extensions.md
@@ -33,7 +33,7 @@ Analyzes your JavaScript code to find issues and to help you fix them. As a part
 
 ## XML
 
-VS Code doesn’t ship with rich XML tools by default. This extension, built by Red Hat, provides language support for XML documents such as the `-meta.xml` or `package.xml` files in your VS Code project.
+VS Code doesn’t ship with rich XML tools by default. This extension, built by Red Hat, provides language support for for XML documents such as the `-meta.xml` or `package.xml` files in your VS Code project.
 
 <https://marketplace.visualstudio.com/items?itemName=redhat.vscode-xml>
 
@@ -42,5 +42,4 @@ VS Code doesn’t ship with rich XML tools by default. This extension, built by 
 The community has developed several extensions to help make Salesforce development more productive. To find these, search the [Visual Studio Code Marketplace](https://marketplace.visualstudio.com/vscode) or browse all extensions tagged [Salesforce](https://marketplace.visualstudio.com/search?term=tag%3Asalesforce&target=VSCode&category=All%20categories&sortBy=Relevance).
 
 ## Debugger for Java
-
 Java Debugger based on Java Debug Server that extends the Language Support for Java by Red Hat. It allows you to debug Java code in VSCode. Install this extension to invoke and debug Java functions.

--- a/docs/_articles/en/getting-started/recommended-extensions.md
+++ b/docs/_articles/en/getting-started/recommended-extensions.md
@@ -33,7 +33,7 @@ Analyzes your JavaScript code to find issues and to help you fix them. As a part
 
 ## XML
 
-VS Code doesn’t ship with rich XML tools by default. This extension, built by Red Hat, provides language support for for XML documents such as the `-meta.xml` or `package.xml` files in your VS Code project.
+VS Code doesn’t ship with rich XML tools by default. This extension, built by Red Hat, provides language support for XML documents such as the `-meta.xml` or `package.xml` files in your VS Code project.
 
 <https://marketplace.visualstudio.com/items?itemName=redhat.vscode-xml>
 
@@ -42,4 +42,5 @@ VS Code doesn’t ship with rich XML tools by default. This extension, built by 
 The community has developed several extensions to help make Salesforce development more productive. To find these, search the [Visual Studio Code Marketplace](https://marketplace.visualstudio.com/vscode) or browse all extensions tagged [Salesforce](https://marketplace.visualstudio.com/search?term=tag%3Asalesforce&target=VSCode&category=All%20categories&sortBy=Relevance).
 
 ## Debugger for Java
+
 Java Debugger based on Java Debug Server that extends the Language Support for Java by Red Hat. It allows you to debug Java code in VSCode. Install this extension to invoke and debug Java functions.

--- a/package.json
+++ b/package.json
@@ -64,10 +64,7 @@
     "link-lsp": "lerna exec yarn link @salesforce/aura-language-server @salesforce/lwc-language-server @salesforce/lightning-lsp-common --scope salesforcedx-vscode-lightning && lerna exec yarn link @salesforce/lwc-language-server @salesforce/lightning-lsp-common --scope salesforcedx-vscode-lwc",
     "unlink-lsp": "lerna exec yarn unlink @salesforce/aura-language-server @salesforce/lwc-language-server @salesforce/lightning-lsp-common --scope salesforcedx-vscode-lightning && lerna exec yarn unlink @salesforce/lwc-language-server @salesforce/lightning-lsp-common --scope salesforcedx-vscode-lwc"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/forcedotcom/salesforcedx-vscode.git"
-  },
+  "repository": "forcedotcom/salesforcedx-vscode",
   "license": "BSD-3-Clause",
   "dependencies": {
     "node": "12.4.0",


### PR DESCRIPTION
### What does this PR do?
* Add config to enable dependabot to create PRs for updating dependencies 
* Add scheduled automated merging of minor/patch PRs
* Replaces https://github.com/forcedotcom/salesforcedx-vscode/pull/3690

### What issues does this PR fix or reference?
@W-10247959@

### Functionality Before
* PRs to update dependencies were created manually

### Functionality After
* PRs to update dependencies are created automatically by dependabot and merged on schedule according to given config

### Discuss

- [x] Do we need to exclude any path (e.g. `/docs` or packages e.g. `@salesforce/*`, `@lwc/*` ?
- [x] Timing of opening PR (e.g. Tue following release cutoff)
- [x] Number of open PRs
- [x] Timing of PR merges (e.g. off-hours vs working hours) and number of PR merges per day
- [x] Major release PRs created against which branch