### PR TITLE
feat: add ability to remove expired orgs from the org list

### DIFF
--- a/contributing/tests.md
+++ b/contributing/tests.md
@@ -60,6 +60,18 @@ of flexibility.
 More information can be found at the doc
 [site](https://code.visualstudio.com/docs/extensions/testing-extensions).
 
+## Running Single and Exclusive Integration Tests
+
+Our integration tests provide end-to-end coverage which is useful for our
+automated builds, but running the full suite can consume a lot of time during
+development. To run one suite, compile your work, then have the \*.test.ts file
+in focus. From Run and Debug, select `Launch Current Integration Test with sfdx-simple`.
+
+To run an exclusive test, append .only to the `describe` and `it` keywords of the
+test that you wish to run. Breakpoints will also be honored when running single tests.
+
+More information on exclusive tests can be found the MochaJS doc [site](https://mochajs.org/#exclusive-tests).
+
 ### Assumptions
 
 While the test runner is highly configurable, there are certain assumptions that

--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -133,7 +133,8 @@ export class OrgList implements vscode.Disposable {
       '$(plus) ' + nls.localize('force_auth_web_login_authorize_org_text'),
       '$(plus) ' + nls.localize('force_auth_web_login_authorize_dev_hub_text'),
       '$(plus) ' + nls.localize('force_org_create_default_scratch_org_text'),
-      '$(plus) ' + nls.localize('force_auth_access_token_authorize_org_text')
+      '$(plus) ' + nls.localize('force_auth_access_token_authorize_org_text'),
+      '$(plus) ' + nls.localize('force_org_list_clean_text')
     ];
 
     const authInfoList = await this.updateOrgList();
@@ -170,6 +171,11 @@ export class OrgList implements vscode.Disposable {
       case '$(plus) ' +
         nls.localize('force_auth_access_token_authorize_org_text'): {
         vscode.commands.executeCommand('sfdx.force.auth.accessToken');
+        return { type: 'CONTINUE', data: {} };
+      }
+      case '$(plus) ' +
+        nls.localize('force_org_list_clean_text'): {
+        vscode.commands.executeCommand('sfdx.force.org.list.clean');
         return { type: 'CONTINUE', data: {} };
       }
       default: {

--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -153,10 +153,7 @@ export class OrgList implements vscode.Disposable {
       case '$(plus) ' +
         nls.localize('force_auth_web_login_authorize_org_text'): {
         vscode.commands.executeCommand('sfdx.force.auth.web.login');
-        return {
-          type: 'CONTINUE',
-          data: {}
-        };
+        return { type: 'CONTINUE', data: {} };
       }
       case '$(plus) ' +
         nls.localize('force_auth_web_login_authorize_dev_hub_text'): {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgPicker/orgList.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgPicker/orgList.test.ts
@@ -318,7 +318,7 @@ describe('Set Default Org', () => {
     ).to.be.true;
   });
 
-  it('should return Continue and call sfdx.force.auth.accessToken command if SFDX: Authorize an Org using Session ID', async () => {
+  it('should return Continue and call sfdx:force:auth:accessToken command if SFDX: Authorize an Org using Session ID', async () => {
     orgListStub.returns(orgsList);
     quickPickStub.returns(
       '$(plus) ' + nls.localize('force_auth_access_token_authorize_org_text')
@@ -327,6 +327,18 @@ describe('Set Default Org', () => {
     expect(response.type).to.equal('CONTINUE');
     const commandResult = expect(
       executeCommandStub.calledWith('sfdx.force.auth.accessToken')
+    ).to.be.true;
+  });
+
+  it('should return Continue and call force:org:list:clean command if SFDX: Remove Deleted and Expired Orgs is selected', async () => {
+    orgListStub.returns(orgsList);
+    quickPickStub.returns(
+      '$(plus) ' + nls.localize('force_org_list_clean_text')
+    );
+    const response = await orgList.setDefaultOrg();
+    expect(response.type).to.equal('CONTINUE');
+    const commandResult = expect(
+      executeCommandStub.calledWith('sfdx.force.org.list.clean')
     ).to.be.true;
   });
 


### PR DESCRIPTION
### What does this PR do?
We already had a command to remove dead scratch orgs (#2523), but that functionality isn't readily
available to users, and it can be frustrating for new users to dig it up. Meanwhile the list of
expired orgs only grows! This change surfaces that functionality in the org list directly, so users
can view the commands that interact with their orgs from one spot.

### What issues does this PR fix or reference?
@W-10351429@

### Functionality Before
The command `SFDX: Remove Deleted and Expired Orgs` was only available from the command palette.

### Functionality After
It's now easier to clean up stale orgs. 🧹