### PR TITLE
ci: add squash merge option to automerge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -643,4 +643,5 @@ workflows:
     jobs:
       # Merges 1 mergeable PR created by dependabot containing minor, patch updates
       # Requires "repository" property in package.json to be a string of 'owner/repo'
-      - release-management/dependabot-automerge
+      - release-management/dependabot-automerge:
+          merge-method: squash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,20 +23,23 @@ updates:
         update-types: ["version-update:semver-major"]
     open-pull-requests-limit: 10
   # Major version updates (not auto-merged)
-  - package-ecosystem: "npm"
-    directory: "/" # Location of package manifests
-    target-branch: "develop"
-    schedule:
-      # Monthly after the weekly minor,patch updates have been merged
-      interval: "monthly"
-      day: "friday"
-      time: "06:00"
-      timezone: "America/Los_Angeles"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          ["version-update:semver-minor", "version-update:semver-patch"]
-    open-pull-requests-limit: 5
+  # TODO: Disabled temporarily to ruleout interference of "target-branch" config
+  #   with dependabot automatic rebase of PRs. Enable and test after the workflow
+  #   for minor/patch updates is working without issues.
+  # - package-ecosystem: "npm"
+  #   directory: "/" # Location of package manifests
+  #   target-branch: "develop"
+  #   schedule:
+  #     # Monthly after the weekly minor,patch updates have been merged
+  #     interval: "monthly"
+  #     day: "friday"
+  #     time: "06:00"
+  #     timezone: "America/Los_Angeles"
+  #   ignore:
+  #     - dependency-name: "*"
+  #       update-types:
+  #         ["version-update:semver-minor", "version-update:semver-patch"]
+  #   open-pull-requests-limit: 5
   # Exclude updates to doc tools
   # TODO: Enable after adding automated check(s) for doc generation
   - package-ecosystem: "bundler"


### PR DESCRIPTION
### What does this PR do?
Modifies CI configs to
* use recently added `squash` merge option with dependabot automerge
	* 	that should fix `ERROR running dependabot:automerge: Merge commits are not allowed on this repository.`
* disable major version updates with dependabot temporarily until we have minor/patch updates working without any issues

Followup to #3714

### What issues does this PR fix or reference?
@W-10247959@
