### PR TITLE
chore: update template version

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -31,7 +31,7 @@
     "@salesforce/salesforcedx-utils-vscode": "53.14.1",
     "@salesforce/schemas": "^1",
     "@salesforce/source-deploy-retrieve": "5.0.0",
-    "@salesforce/templates": "52.3.0",
+    "@salesforce/templates": "53.1.0",
     "adm-zip": "0.4.13",
     "applicationinsights": "1.0.7",
     "glob": "^7.1.2",


### PR DESCRIPTION
What does this PR do?
Consuming new templates version so we generate templates with the source api version 53.0.

What issues does this PR fix or reference?
#3611, @W-10220491@

Functionality Before
Templates were generated with version 52.0.

Functionality After
Templates are generated with version ✨ 53.0 ✨