### PR TITLE
fix(soql): remove excess telemetry

### DIFF
--- a/packages/salesforcedx-vscode-soql/src/sfdx.ts
+++ b/packages/salesforcedx-vscode-soql/src/sfdx.ts
@@ -12,7 +12,6 @@ import * as debounce from 'debounce';
 import { DescribeSObjectResult } from 'jsforce';
 import * as vscode from 'vscode';
 import { nls } from './messages';
-import { telemetryService } from './telemetry';
 
 export const channelService = ChannelService.getInstance(
   nls.localize('soql_channel_name')
@@ -24,7 +23,6 @@ function showChannelAndErrorMessage(e: any) {
   channelService.appendLine(e);
   const message = nls.localize('error_connection');
   vscode.window.showErrorMessage(message);
-  telemetryService.sendException('soql_sf_connection_error', e.message);
 }
 
 export const debouncedShowChannelAndErrorMessage = debounce(

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/sfdx.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/sfdx.test.ts
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import * as sfdx from '../../src/sfdx';
-import { telemetryService } from '../../src/telemetry';
 
 describe('sfdx utils', () => {
   let sandbox: sinon.SinonSandbox;
@@ -17,7 +16,6 @@ describe('sfdx utils', () => {
 
   it('should display an error, channel log, and send telemetry if can not get connection to org', async () => {
     sandbox.stub(sfdx.workspaceContext, 'getConnection').throws();
-    const telemetryStub = sandbox.stub(telemetryService, 'sendException');
     const vscodeErrorMessageSpy = sandbox.spy(
       vscode.window,
       'showErrorMessage'
@@ -27,6 +25,5 @@ describe('sfdx utils', () => {
     sfdx.debouncedShowChannelAndErrorMessage.flush();
     expect(vscodeErrorMessageSpy.callCount).to.equal(1);
     expect(channelServiceSpy.callCount).to.equal(1);
-    expect(telemetryStub.callCount).to.equal(1);
   });
 });


### PR DESCRIPTION
### What does this PR do?
This PR removes a telemetry call that clutters telemetry unnecessarily.

### What issues does this PR fix or reference?
@[W-10523357](https://gus.lightning.force.com/a07EE00000kLzFqYAK)@

### Functionality Before
When SOQL tooling fails to connect to an org for any reason, telemetry logs the error.

### Functionality After
When SOQL tooling fails to connect to an org for any reason, there is no telemetry.
