### PR TITLE
chore: use context for common env variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -540,6 +540,7 @@ workflows:
     when: << pipeline.parameters.pre-publish >>
     jobs:
       - slack/approval-notification:
+          context: IEAT_keys
           message: Pending Approval for merge of release branch into main
           channel: 'pdt_releases'
           color: '#0E1111'
@@ -547,7 +548,7 @@ workflows:
           type: approval
       - merge-release-branch:
           e: default-executor
-          context: pdt-publish-restricted-context
+          context: IEAT_keys
           requires:
             - hold
           filters:
@@ -559,6 +560,7 @@ workflows:
     when: << pipeline.parameters.publish >>
     jobs:
       - slack/approval-notification:
+          context: IEAT_keys
           message: Pending Approval for Publish
           channel: 'pdt_releases'
           color: '#0E1111'
@@ -570,7 +572,7 @@ workflows:
       - publish:
           e: default-executor
           context:
-            - pdt-publish-restricted-context
+            - IEAT_keys
             - CLI_CTC
           requires:
             - build-all
@@ -586,6 +588,7 @@ workflows:
     when: << pipeline.parameters.create-release >>
     jobs:
       - slack/approval-notification:
+          context: IEAT_keys
           message: Pending Approval for Creation of Release Branch
           channel: 'pdt_releases'
           color: '#0E1111'
@@ -593,7 +596,7 @@ workflows:
           type: approval
       - create-release-branch:
           e: default-executor
-          context: pdt-publish-restricted-context
+          context: IEAT_keys
           requires:
             - hold
           filters:


### PR DESCRIPTION
### What does this PR do?
Uses context to access common environment variables across different projects

### What issues does this PR fix or reference?
 @W-10714614@

### Functionality Before
All environment variables are defined at project settings.

### Functionality After
Few common env variables are now defined in a context and remaining at project settings.
