### PR TITLE
Jb/update to java 17

### DIFF
--- a/docs/_articles/en/troubleshooting.md
+++ b/docs/_articles/en/troubleshooting.md
@@ -46,7 +46,7 @@ If the Apex Language Server didn’t activate, ensure that you've:
 
 1. Opened a Salesforce DX project that has a valid `sfdx-project.json` file.
 1. Opened the Salesforce DX project as a top-level folder.
-1. Installed Java 8 or Java 11; you’ll see a warning if neither version is installed.
+1. Installed Java 8, Java 11, or Java 17; you’ll see a warning if neither version is installed.
 
 If you’ve checked all of the above and nothing is working, check for errors in VS Code itself. In the VS Code menu bar, select **Help** > **Toggle Developer Tools**, click **Console**, and search for relevant messages.
 

--- a/packages/salesforcedx-vscode-apex/package.nls.json
+++ b/packages/salesforcedx-vscode-apex/package.nls.json
@@ -7,7 +7,7 @@
   "run_single_test_title": "Run Single Test",
   "show_error_title": "Display Error",
   "go_to_definition_title": "Go to Definition",
-  "java_home_description": "Specifies the folder path to the Java 8 or Java 11 runtime used to launch the Apex Language Server (for example, /Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home).",
+  "java_home_description": "Specifies the folder path to the Java 8, Java 11, or Java 17 runtime used to launch the Apex Language Server (for example, /Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home).",
   "java_memory_description": "Specifies the amount of memory allocation to the Apex Language Server in MB, or null to use the system default value.",
   "apex_semantic_errors_description": "Allow Apex Language Server to surface semantic errors",
   "force_anon_apex_execute_document_text": "SFDX: Execute Anonymous Apex with Editor Contents",

--- a/packages/salesforcedx-vscode-apex/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-apex/src/messages/i18n.ts
@@ -74,7 +74,7 @@ export const messages = {
   source_missing_text:
     '%s points to a missing folder. For information on how to setup the Salesforce Apex extension, see [Set Your Java Version](%s).',
   wrong_java_version_text:
-    'An unsupported Java version was detected. Download and install [Java 8](https://java.com/en/download/) or [Java 11](https://www.oracle.com/technetwork/java/javase/downloads/jdk11-downloads-5066655.html) to run the extensions. For more information, see [Set Your Java Version](%s).',
+    'An unsupported Java version was detected. Download and install [Java 8](https://java.com/en/download/), [Java 11](https://www.oracle.com/technetwork/java/javase/downloads/jdk11-downloads-5066655.html), or [Java 17](https://www.oracle.com/java/technologies/downloads/#java17) to run the extensions. For more information, see [Set Your Java Version](%s).',
   force_apex_test_suite_build_text: 'SFDX: Build Apex Test Suite',
   unable_to_locate_editor: 'You can run this command only on a source file.',
   unable_to_locate_document: 'You can run this command only on a source file.',

--- a/packages/salesforcedx-vscode-apex/src/requirements.ts
+++ b/packages/salesforcedx-vscode-apex/src/requirements.ts
@@ -99,7 +99,7 @@ function isLocal(javaHome: string): boolean {
   return !path.isAbsolute(javaHome);
 }
 
-export function checkJavaVersion(javaHome: string): Promise<any> {
+export function checkJavaVersion(javaHome: string): Promise<boolean> {
   return new Promise((resolve, reject) => {
     cp.execFile(
       javaHome + '/bin/java',

--- a/packages/salesforcedx-vscode-apex/src/requirements.ts
+++ b/packages/salesforcedx-vscode-apex/src/requirements.ts
@@ -99,7 +99,7 @@ function isLocal(javaHome: string): boolean {
   return !path.isAbsolute(javaHome);
 }
 
-function checkJavaVersion(javaHome: string): Promise<any> {
+export function checkJavaVersion(javaHome: string): Promise<any> {
   return new Promise((resolve, reject) => {
     cp.execFile(
       javaHome + '/bin/java',
@@ -108,7 +108,8 @@ function checkJavaVersion(javaHome: string): Promise<any> {
       (error, stdout, stderr) => {
         if (
           stderr.indexOf('build 1.8') < 0 &&
-          stderr.indexOf('build 11.') < 0
+          stderr.indexOf('build 11.') < 0 &&
+          stderr.indexOf('build 17.') < 0
         ) {
           reject(nls.localize('wrong_java_version_text', SET_JAVA_DOC_LINK));
         } else {

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/requirements.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/requirements.test.ts
@@ -5,15 +5,13 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-// tslint:disable:no-unused-expression
-
 import { fail } from 'assert';
 import { expect } from 'chai';
 import { createSandbox, SinonSandbox, SinonStub } from 'sinon';
 import * as vscode from 'vscode';
 import { SET_JAVA_DOC_LINK } from '../../src/constants';
 import { nls } from '../../src/messages';
-import { JAVA_HOME_KEY, resolveRequirements, checkJavaVersion } from '../../src/requirements';
+import { checkJavaVersion, JAVA_HOME_KEY, resolveRequirements } from '../../src/requirements';
 import pathExists = require('path-exists');
 import * as cp from 'child_process';
 

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/requirements.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/requirements.test.ts
@@ -49,8 +49,8 @@ describe('Java Requirements Test', () => {
     let exceptionThrown = false;
     try {
       await resolveRequirements();
-    } catch (e) {
-      expect(e).contains(localRuntime);
+    } catch (err) {
+      expect(err).contains(localRuntime);
       exceptionThrown = true;
     }
     expect(exceptionThrown).to.be.true;
@@ -65,43 +65,43 @@ describe('Java Requirements Test', () => {
 
   it('Should support Java 8', async () => {
     execFileStub.yields('', '', 'build 1.8.0');
-    checkJavaVersion('~/java_home')
-      .then(result => {
-        expect(result).to.equal(true);
-      }).catch(error => {
-        fail(`Should not have thrown when the Java version is 8.  The error was: ${error.message}`);
-      });
+    try {
+      const result = await checkJavaVersion('~/java_home');
+      expect(result).to.equal(true);
+    } catch (err) {
+      fail(`Should not have thrown when the Java version is 17.  The error was: ${err}`);
+    }
   });
 
   it('Should support Java 11', async () => {
     execFileStub.yields('', '', 'build 11.0.0');
-    checkJavaVersion('~/java_home')
-      .then(result => {
-        expect(result).to.equal(true);
-      }).catch(error => {
-        fail(`Should not have thrown when the Java version is 11.  The error was: ${error.message}`);
-      });
+    try {
+      const result = await checkJavaVersion('~/java_home');
+      expect(result).to.equal(true);
+    } catch (err) {
+      fail(`Should not have thrown when the Java version is 11.  The error was: ${err}`);
+    }
   });
 
   it('Should support Java 17', async () => {
     execFileStub.yields('', '', 'build 17.2.3');
-    checkJavaVersion('~/java_home')
-      .then(result => {
-        expect(result).to.equal(true);
-      }).catch(error => {
-        fail(`Should not have thrown when the Java version is 17.  The error was: ${error.message}`);
-      });
+    try {
+      const result = await checkJavaVersion('~/java_home');
+      expect(result).to.equal(true);
+    } catch (err) {
+      fail(`Should not have thrown when the Java version is 17.  The error was: ${err}`);
+    }
   });
 
   it('Should not support Java 20', async () => {
     execFileStub.yields('', '', 'build 20.0.0');
-    checkJavaVersion('~/java_home')
-      .then(() => {
-        fail('Should have thrown when the Java version is not supported');
-      }).catch(error => {
-        expect(error.message).to.equal(
-          nls.localize('wrong_java_version_text', SET_JAVA_DOC_LINK)
-        );
-      });
+    try {
+      await checkJavaVersion('~/java_home');
+      fail('Should have thrown when the Java version is not supported');
+    } catch (err) {
+      expect(err).to.equal(
+        nls.localize('wrong_java_version_text', SET_JAVA_DOC_LINK)
+      );
+    }
   });
 });

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/requirements.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/requirements.test.ts
@@ -7,10 +7,13 @@
 
 // tslint:disable:no-unused-expression
 
+import { fail } from 'assert';
 import { expect } from 'chai';
 import { createSandbox, SinonSandbox, SinonStub } from 'sinon';
 import * as vscode from 'vscode';
-import { JAVA_HOME_KEY, resolveRequirements } from '../../src/requirements';
+import { SET_JAVA_DOC_LINK } from '../../src/constants';
+import { nls } from '../../src/messages';
+import { JAVA_HOME_KEY, resolveRequirements, checkJavaVersion } from '../../src/requirements';
 import pathExists = require('path-exists');
 import * as cp from 'child_process';
 
@@ -60,4 +63,45 @@ describe('Java Requirements Test', () => {
     expect(requirements.java_home).contains(jdk);
   });
 
+  it('Should support Java 8', async () => {
+    execFileStub.yields('', '', 'build 1.8.0');
+    checkJavaVersion('~/java_home')
+      .then(result => {
+        expect(result).to.equal(true);
+      }).catch(error => {
+        fail(`Should not have thrown when the Java version is 8.  The error was: ${error.message}`);
+      });
+  });
+
+  it('Should support Java 11', async () => {
+    execFileStub.yields('', '', 'build 11.0.0');
+    checkJavaVersion('~/java_home')
+      .then(result => {
+        expect(result).to.equal(true);
+      }).catch(error => {
+        fail(`Should not have thrown when the Java version is 11.  The error was: ${error.message}`);
+      });
+  });
+
+  it('Should support Java 17', async () => {
+    execFileStub.yields('', '', 'build 17.2.3');
+    checkJavaVersion('~/java_home')
+      .then(result => {
+        expect(result).to.equal(true);
+      }).catch(error => {
+        fail(`Should not have thrown when the Java version is 17.  The error was: ${error.message}`);
+      });
+  });
+
+  it('Should not support Java 20', async () => {
+    execFileStub.yields('', '', 'build 20.0.0');
+    checkJavaVersion('~/java_home')
+      .then(() => {
+        fail('Should have thrown when the Java version is not supported');
+      }).catch(error => {
+        expect(error.message).to.equal(
+          nls.localize('wrong_java_version_text', SET_JAVA_DOC_LINK)
+        );
+      });
+  });
 });

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/requirements.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/requirements.test.ts
@@ -5,6 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+// tslint:disable:no-unused-expression
+
 import { fail } from 'assert';
 import { expect } from 'chai';
 import { createSandbox, SinonSandbox, SinonStub } from 'sinon';

--- a/packages/salesforcedx-vscode-expanded/README.md
+++ b/packages/salesforcedx-vscode-expanded/README.md
@@ -8,17 +8,17 @@ This extension pack includes tools for developing on the Salesforce platform in 
 
 Before you set up Salesforce Extensions for VS Code, make sure that you have these essentials.
 
-- **Salesforce CLI**  
+- **Salesforce CLI**
   Before you use Salesforce Extensions for VS Code, [set up Salesforce CLI](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup).
 - **A Salesforce DX project**
-  Open your Salesforce DX project in a directory that contains an `sfdx-project.json` file. Otherwise, some features don’t work.  
+  Open your Salesforce DX project in a directory that contains an `sfdx-project.json` file. Otherwise, some features don’t work.
   If you don't already have a Salesforce DX project, create one with the **SFDX: Create Project** command (for development against scratch orgs) or the **SFDX: Create Project with Manifest** command (for development against sandboxes or DE orgs). Or, see [create a Salesforce DX project](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_workspace_setup.htm) for information about setting up a project using Salesforce CLI.
-- **Java Platform, Standard Edition Development Kit**  
+- **Java Platform, Standard Edition Development Kit**
   Some features in Salesforce Extensions for VS Code depend upon the Java Platform, Standard Edition Development Kit (JDK). You need to have either version 8 or version 11 of the JDK installed.
 
-  If you don’t already have version 8 or 11 of the JDK installed, you can install the latest version of the Java 8 JDK from [Java SE Development Kit 8 Downloads](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) or the latest version of the Java 11 JDK from [Java SE Development Kit 11 Downloads](https://www.oracle.com/technetwork/java/javase/downloads/jdk11-downloads-5066655.html).
+  If you don’t already have version 8, 11, or 17 of the JDK installed, you can install the latest version of the Java 8 JDK from [Java SE Development Kit 8 Downloads](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html), or the latest version of the Java 11 JDK from [Java SE Development Kit 11 Downloads](https://www.oracle.com/technetwork/java/javase/downloads/jdk11-downloads-5066655.html), or Java 17 from [Java Downloads](https://www.oracle.com/java/technologies/downloads/#java17).
 
-  If you also use other versions of the JDK, set your VS Code user setting `salesforcedx-vscode-apex.java.home` to point to the location where you installed Java 8 or 11.
+  If you also use other versions of the JDK, set your VS Code user setting `salesforcedx-vscode-apex.java.home` to point to the location where you installed Java 88, 11, or 17.
 
 - **[Visual Studio Code](https://code.visualstudio.com/download) v1.26 or later**
 
@@ -39,21 +39,21 @@ To report issues with Salesforce Extensions for VS Code, open a [bug on GitHub](
 
 The Salesforce Extension Pack extension installs these extensions.
 
-- [Salesforce CLI Integration](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-core)  
+- [Salesforce CLI Integration](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-core)
    This extension (`salesforcedx-vscode-core`) interacts with Salesforce CLI to provide core functionality.
-- [Apex](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-apex)  
+- [Apex](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-apex)
    This extension (`salesforcedx-vscode-apex`) uses the Apex Language Server to provide features such as syntax highlighting and code completion.
-- [Apex Interactive Debugger](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-apex-debugger)  
+- [Apex Interactive Debugger](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-apex-debugger)
    This extension (`salesforcedx-vscode-apex-debugger`) enables VS Code to use the real-time Apex Debugger with your scratch orgs or to use ISV Customer Debugger for your subscribers’ orgs.
-- [Apex Replay Debugger](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-apex-replay-debugger)  
+- [Apex Replay Debugger](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-apex-replay-debugger)
    This extension (`salesforcedx-vscode-apex-replay-debugger`) enables VS Code to replay Apex execution from Apex debug logs.
-- [Lightning Web Components](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-lwc)  
+- [Lightning Web Components](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-lwc)
    This extension supports Lightning web component bundles. It uses the HTML language server from VS Code.
-- [Aura Components](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-lightning)  
+- [Aura Components](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-lightning)
    This extension (`salesforcedx-vscode-lightning`) supports Aura component bundles. It uses the HTML language server from VS Code.
-- [Visualforce](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-visualforce)  
+- [Visualforce](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-visualforce)
    This extension (`salesforcedx-vscode-visualforce`) supports Visualforce pages and components. It uses the Visualforce Language Server and the HTML language server from VS Code.
-- [Salesforce Lightning Design System (SLDS) Validator](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforce-vscode-slds)  
+- [Salesforce Lightning Design System (SLDS) Validator](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforce-vscode-slds)
    This extension (`salesforcedx-vscode-slds`) simplifies working with the Salesforce Lightning Design System (SLDS). It provides code completion, syntax highlighting and validation with recommended tokens and utility classes.
 
 It also includes the following community built extensions.

--- a/packages/salesforcedx-vscode-expanded/README.md
+++ b/packages/salesforcedx-vscode-expanded/README.md
@@ -16,7 +16,7 @@ Before you set up Salesforce Extensions for VS Code, make sure that you have the
 - **Java Platform, Standard Edition Development Kit**
   Some features in Salesforce Extensions for VS Code depend upon the Java Platform, Standard Edition Development Kit (JDK). You need to have either version 8 or version 11 of the JDK installed.
 
-  If you don’t already have version 8, 11, or 17 of the JDK installed, you can install the latest version of the Java 8 JDK from [Java 8 Downloads](https://www.oracle.com/java/technologies/downloads/#java8), or the latest version of the Java 11 JDK from [Java 11 Downloads](https://www.oracle.com/java/technologies/downloads/#java8), or Java 17 from [Java 17 Downloads](https://www.oracle.com/java/technologies/downloads/#java17).
+  If you don’t already have version 8, 11, or 17 of the JDK installed, you can install the latest version of the Java 8 JDK from [Java 8 Downloads](https://www.oracle.com/java/technologies/downloads/#java8), or the latest version of the Java 11 JDK from [Java 11 Downloads](https://www.oracle.com/java/technologies/downloads/#java11), or Java 17 from [Java 17 Downloads](https://www.oracle.com/java/technologies/downloads/#java17).
 
   If you also use other versions of the JDK, set your VS Code user setting `salesforcedx-vscode-apex.java.home` to point to the location where you installed Java 88, 11, or 17.
 

--- a/packages/salesforcedx-vscode-expanded/README.md
+++ b/packages/salesforcedx-vscode-expanded/README.md
@@ -16,7 +16,7 @@ Before you set up Salesforce Extensions for VS Code, make sure that you have the
 - **Java Platform, Standard Edition Development Kit**
   Some features in Salesforce Extensions for VS Code depend upon the Java Platform, Standard Edition Development Kit (JDK). You need to have either version 8 or version 11 of the JDK installed.
 
-  If you don’t already have version 8, 11, or 17 of the JDK installed, you can install the latest version of the Java 8 JDK from [Java SE Development Kit 8 Downloads](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html), or the latest version of the Java 11 JDK from [Java SE Development Kit 11 Downloads](https://www.oracle.com/technetwork/java/javase/downloads/jdk11-downloads-5066655.html), or Java 17 from [Java Downloads](https://www.oracle.com/java/technologies/downloads/#java17).
+  If you don’t already have version 8, 11, or 17 of the JDK installed, you can install the latest version of the Java 8 JDK from [Java 8 Downloads](https://www.oracle.com/java/technologies/downloads/#java8), or the latest version of the Java 11 JDK from [Java 11 Downloads](https://www.oracle.com/java/technologies/downloads/#java8), or Java 17 from [Java 17 Downloads](https://www.oracle.com/java/technologies/downloads/#java17).
 
   If you also use other versions of the JDK, set your VS Code user setting `salesforcedx-vscode-apex.java.home` to point to the location where you installed Java 88, 11, or 17.
 

--- a/packages/salesforcedx-vscode/README.md
+++ b/packages/salesforcedx-vscode/README.md
@@ -8,17 +8,17 @@ This extension pack includes tools for developing on the Salesforce platform in 
 
 Before you set up Salesforce Extensions for VS Code, make sure that you have these essentials.
 
-- **Salesforce CLI**  
+- **Salesforce CLI**
   Before you use Salesforce Extensions for VS Code, [set up Salesforce CLI](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup).
 - **A Salesforce DX project**
-  Open your Salesforce DX project in a directory that contains an `sfdx-project.json` file. Otherwise, some features don’t work.  
+  Open your Salesforce DX project in a directory that contains an `sfdx-project.json` file. Otherwise, some features don’t work.
   If you don't already have a Salesforce DX project, create one with the **SFDX: Create Project** command (for development against scratch orgs) or the **SFDX: Create Project with Manifest** command (for development against sandboxes or DE orgs). Or, see [create a Salesforce DX project](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_workspace_setup.htm) for information about setting up a project using Salesforce CLI.
-- **Java Platform, Standard Edition Development Kit**  
+- **Java Platform, Standard Edition Development Kit**
   Some features in Salesforce Extensions for VS Code depend upon the Java Platform, Standard Edition Development Kit (JDK). You need to have either version 8 or version 11 of the JDK installed.
 
-  If you don’t already have version 8 or 11 of the JDK installed, you can install the latest version of the Java 8 JDK from [Java SE Development Kit 8 Downloads](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) or the latest version of the Java 11 JDK from [Java SE Development Kit 11 Downloads](https://www.oracle.com/technetwork/java/javase/downloads/jdk11-downloads-5066655.html).
+  If you don’t already have version 8, 11, or 17 of the JDK installed, you can install the latest version of the Java 8 JDK from [Java SE Development Kit 8 Downloads](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) or the latest version of the Java 11 JDK from [Java SE Development Kit 11 Downloads](https://www.oracle.com/technetwork/java/javase/downloads/jdk11-downloads-5066655.html), or Java 17 from [Java Downloads](https://www.oracle.com/java/technologies/downloads/#java17).
 
-  If you also use other versions of the JDK, set your VS Code user setting `salesforcedx-vscode-apex.java.home` to point to the location where you installed Java 8 or 11.
+  If you also use other versions of the JDK, set your VS Code user setting `salesforcedx-vscode-apex.java.home` to point to the location where you installed Java 8, 11, or 17.
 
 - **[Visual Studio Code](https://code.visualstudio.com/download) v1.26 or later**
 
@@ -39,23 +39,23 @@ To report issues with Salesforce Extensions for VS Code, open a [bug on GitHub](
 
 The Salesforce Extension Pack extension installs these extensions.
 
-- [Salesforce CLI Integration](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-core)  
+- [Salesforce CLI Integration](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-core)
    This extension (`salesforcedx-vscode-core`) interacts with Salesforce CLI to provide core functionality.
-- [Apex](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-apex)  
+- [Apex](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-apex)
    This extension (`salesforcedx-vscode-apex`) uses the Apex Language Server to provide features such as syntax highlighting and code completion.
-- [Apex Interactive Debugger](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-apex-debugger)  
+- [Apex Interactive Debugger](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-apex-debugger)
    This extension (`salesforcedx-vscode-apex-debugger`) enables VS Code to use the real-time Apex Debugger with your scratch orgs or to use ISV Customer Debugger for your subscribers’ orgs.
-- [Apex Replay Debugger](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-apex-replay-debugger)  
+- [Apex Replay Debugger](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-apex-replay-debugger)
    This extension (`salesforcedx-vscode-apex-replay-debugger`) enables VS Code to replay Apex execution from Apex debug logs.
-- [Lightning Web Components](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-lwc)  
+- [Lightning Web Components](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-lwc)
    This extension supports Lightning web component bundles. It uses the HTML language server from VS Code.
-- [Aura Components](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-lightning)  
+- [Aura Components](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-lightning)
    This extension (`salesforcedx-vscode-lightning`) supports Aura component bundles. It uses the HTML language server from VS Code.
-- [Visualforce](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-visualforce)  
+- [Visualforce](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-visualforce)
    This extension (`salesforcedx-vscode-visualforce`) supports Visualforce pages and components. It uses the Visualforce Language Server and the HTML language server from VS Code.
-- [SOQL](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-soql)  
+- [SOQL](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-soql)
    This extension (`salesforcedx-vscode-soql`) enables you to interactively build a SOQL query via a form-based visual editor, view the query as you build, and save the output to a .csv or .json file.
-- [Salesforce Lightning Design System (SLDS) Validator](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforce-vscode-slds)  
+- [Salesforce Lightning Design System (SLDS) Validator](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforce-vscode-slds)
    This extension (`salesforcedx-vscode-slds`) simplifies working with the Salesforce Lightning Design System (SLDS). It provides code completion, syntax highlighting and validation with recommended tokens and utility classes.
 
 ---

--- a/packages/salesforcedx-vscode/README.md
+++ b/packages/salesforcedx-vscode/README.md
@@ -16,7 +16,7 @@ Before you set up Salesforce Extensions for VS Code, make sure that you have the
 - **Java Platform, Standard Edition Development Kit**
   Some features in Salesforce Extensions for VS Code depend upon the Java Platform, Standard Edition Development Kit (JDK). You need to have either version 8 or version 11 of the JDK installed.
 
-  If you don’t already have version 8, 11, or 17 of the JDK installed, you can install the latest version of the Java 8 JDK from [Java SE Development Kit 8 Downloads](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) or the latest version of the Java 11 JDK from [Java SE Development Kit 11 Downloads](https://www.oracle.com/technetwork/java/javase/downloads/jdk11-downloads-5066655.html), or Java 17 from [Java Downloads](https://www.oracle.com/java/technologies/downloads/#java17).
+  If you don’t already have version 8, 11, or 17 of the JDK installed, you can install the latest version of the Java 8 JDK from [Java 8 Downloads](https://www.oracle.com/java/technologies/downloads/#java8) or the latest version of the Java 11 JDK from [Java 11 Downloads](https://www.oracle.com/java/technologies/downloads/#java8), or Java 17 from [Java 17 Downloads](https://www.oracle.com/java/technologies/downloads/#java17).
 
   If you also use other versions of the JDK, set your VS Code user setting `salesforcedx-vscode-apex.java.home` to point to the location where you installed Java 8, 11, or 17.
 

--- a/packages/salesforcedx-vscode/README.md
+++ b/packages/salesforcedx-vscode/README.md
@@ -16,7 +16,7 @@ Before you set up Salesforce Extensions for VS Code, make sure that you have the
 - **Java Platform, Standard Edition Development Kit**
   Some features in Salesforce Extensions for VS Code depend upon the Java Platform, Standard Edition Development Kit (JDK). You need to have either version 8 or version 11 of the JDK installed.
 
-  If you don’t already have version 8, 11, or 17 of the JDK installed, you can install the latest version of the Java 8 JDK from [Java 8 Downloads](https://www.oracle.com/java/technologies/downloads/#java8) or the latest version of the Java 11 JDK from [Java 11 Downloads](https://www.oracle.com/java/technologies/downloads/#java8), or Java 17 from [Java 17 Downloads](https://www.oracle.com/java/technologies/downloads/#java17).
+  If you don’t already have version 8, 11, or 17 of the JDK installed, you can install the latest version of the Java 8 JDK from [Java 8 Downloads](https://www.oracle.com/java/technologies/downloads/#java8) or the latest version of the Java 11 JDK from [Java 11 Downloads](https://www.oracle.com/java/technologies/downloads/#java11), or Java 17 from [Java 17 Downloads](https://www.oracle.com/java/technologies/downloads/#java17).
 
   If you also use other versions of the JDK, set your VS Code user setting `salesforcedx-vscode-apex.java.home` to point to the location where you installed Java 8, 11, or 17.
 


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
#https://github.com/forcedotcom/salesforcedx-vscode/issues/3804, @W-10537442@

### Functionality Before
The VSCode extension on supported Java 8 and Java 11.  If any other major version of Java was used, the extension would display an error to the user.

### Functionality After
The extension now also supports Java 17
