### PR TITLE
chore: bump lightning language server to v3.5.0

### DIFF
--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -25,9 +25,9 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/aura-language-server": "3.1.0",
+    "@salesforce/aura-language-server": "3.5.0",
     "@salesforce/core": "2.28.0",
-    "@salesforce/lightning-lsp-common": "3.1.0",
+    "@salesforce/lightning-lsp-common": "3.5.0",
     "@salesforce/salesforcedx-utils-vscode": "54.2.0",
     "applicationinsights": "1.0.7",
     "vscode-extension-telemetry": "0.0.17",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "@salesforce/core": "2.28.0",
     "@salesforce/eslint-config-lwc": "0.3.0",
-    "@salesforce/lightning-lsp-common": "3.1.0",
-    "@salesforce/lwc-language-server": "3.1.0",
+    "@salesforce/lightning-lsp-common": "3.5.0",
+    "@salesforce/lwc-language-server": "3.5.0",
     "@salesforce/salesforcedx-utils-vscode": "54.2.0",
     "ajv": "^6.1.1",
     "applicationinsights": "1.0.7",


### PR DESCRIPTION
### What does this PR do?
Bump lightning language server to v3.5.0, which includes the following packages:

- aura-language-server": "3.5.0"
- lightning-lsp-common": "3.5.0"
- lwc-language-server": "3.5.0"

### What issues does this PR fix or reference?
@10759995@

### Functionality Before
Bracket syntax ‘{ }’ did not work in HTML files for LWCs. So users would have to go into the JS file to find the variables they need, or type them out by hand.

### Functionality After
We provide autocompletion for basic bracket syntax, including backspaces and retries.
