### PR TITLE
fix(apex and core package.json): update SDR to v5.12.3 to pick up fix for child reads

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -29,7 +29,7 @@
     "@salesforce/apex-tmlanguage": "1.4.0",
     "@salesforce/core": "^2.35.0",
     "@salesforce/salesforcedx-utils-vscode": "54.2.0",
-    "@salesforce/source-deploy-retrieve": "5.12.0",
+    "@salesforce/source-deploy-retrieve": "5.12.3",
     "expand-home-dir": "0.0.3",
     "find-java-home": "0.2.0",
     "path-exists": "3.0.0",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -30,7 +30,7 @@
     "@salesforce/salesforcedx-sobjects-faux-generator": "54.2.0",
     "@salesforce/salesforcedx-utils-vscode": "54.2.0",
     "@salesforce/schemas": "^1",
-    "@salesforce/source-deploy-retrieve": "5.12.0",
+    "@salesforce/source-deploy-retrieve": "5.12.3",
     "@salesforce/templates": "52.3.0",
     "@salesforce/ts-types": "1.5.13",
     "adm-zip": "0.4.13",


### PR DESCRIPTION
### What does this PR do?
update SDR dependency to v15.12.3 which include readFileSync fix for ZipTree. This fixes the issue where we can diff objects against the org. 

### What issues does this PR fix or reference?
@W-10159064@ @W-10120433@

### Functionality Before
Failed to retrieve diff for objects. 
Deploy source to org fails for custom objects. 

### Functionality After
Successfully diffs objects against org. 
1. Right click Account -> Select `SFDX: Diff Folder Against Org`

![Screen Shot 2022-03-03 at 1 47 32 AM](https://user-images.githubusercontent.com/76090802/156519828-5b9d842a-f009-4d53-9f17-8ca9096aa9da.png)

Deploy source to org works as expected. 
01:50:45.605 Starting SFDX: Deploy Source to Org

=== Deployed Source
STATE      FULL NAME            TYPE          PROJECT PATH                                                            
─────────  ───────────────────  ────────────  ────────────────────────────────────────────────────────────────────────
Unchanged  Order__c.Account__c  CustomField   force-app/main/default/objects/Order__c/fields/Account__c.field-meta.xml
Changed    Order__c             CustomObject  force-app/main/default/objects/Order__c/Order__c.object-meta.xml        

01:50:49.316 ended SFDX: Deploy Source to Org
