### PR TITLE
feat: add publishing to OpenVSX

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lerna": "3.13.1",
     "markdown-link-check": "^3.9.3",
     "ncp": "^2.0.0",
+    "ovsx": "0.3.0",
     "prettier": "1.19.1",
     "remap-istanbul": "^0.13.0",
     "shelljs": "0.8.5",

--- a/scripts/publish-vsix.js
+++ b/scripts/publish-vsix.js
@@ -29,3 +29,20 @@ if (vscePublish.code !== 0) {
   logger.error(`There was and error while publishing extension ${vsix}`);
   shell.exit(1);
 }
+
+const OVSX_PERSONAL_ACCESS_TOKEN = process.env['OVSX_PERSONAL_ACCESS_TOKEN'];
+let ovsxPublish = '';
+if (OVSX_PERSONAL_ACCESS_TOKEN) {
+  ovsxPublish = shell.exec(
+    `ovsx publish --pat ${OVSX_PERSONAL_ACCESS_TOKEN} --packagePath ${vsix}`
+  );
+} else {
+  // Assume that one has already been configured
+  ovsxPublish = shell.exec(`vsce publish --packagePath ${vsix}`);
+}
+
+// Check that publishing extension was successful.
+if (ovsxPublish.code !== 0) {
+  logger.error(`There was and error while publishing extension ${vsix}`);
+  shell.exit(1);
+}


### PR DESCRIPTION
### What does this PR do?
It adds automatic publishing to OpenVSX, which is just awesome!

### What issues does this PR fix or reference?

It "closes" https://github.com/forcedotcom/salesforcedx-vscode/discussions/3877, but I guess Discussions cannot be closed 😄.

### Functionality Before

Before the `scripts/publish-vsix.js` script only tackled publishing to the VS Code Marketplace using `vsce`.


### Functionality After

With this PR all of the extensions get automatically published to OpenVSX if the publishing to the MS Marketplace succeeds as well. I suppose this could be tweaked so they would run independently and the job would still fail, but it would be published wherever it can first.

## Before merging

- [ ] Update package-lock.json to add the `ovsx` dependency - my setup always wanted to convert the lockfile to v2, so I would love some input in how to approach this
- [ ] Add an `OVSX_PERSONAL_ACCESS_TOKEN` secret to CircleCI with the value obtained by following [Publishing Extensions - The OpenVSX Wiki](https://github.com/eclipse/openvsx/wiki/Publishing-Extensions) (steps 1-4)