### PR TITLE
fix: revert source-deploy-retrieve to previous version

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -29,7 +29,7 @@
     "@salesforce/apex-tmlanguage": "1.4.0",
     "@salesforce/core": "^2.35.0",
     "@salesforce/salesforcedx-utils-vscode": "54.4.0",
-    "@salesforce/source-deploy-retrieve": "5.12.3",
+    "@salesforce/source-deploy-retrieve": "5.12.2",
     "expand-home-dir": "0.0.3",
     "find-java-home": "0.2.0",
     "path-exists": "3.0.0",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -30,7 +30,7 @@
     "@salesforce/salesforcedx-sobjects-faux-generator": "54.4.0",
     "@salesforce/salesforcedx-utils-vscode": "54.4.0",
     "@salesforce/schemas": "^1",
-    "@salesforce/source-deploy-retrieve": "5.12.3",
+    "@salesforce/source-deploy-retrieve": "5.12.2",
     "@salesforce/templates": "^54.2.0",
     "@salesforce/ts-types": "1.5.13",
     "adm-zip": "0.4.13",


### PR DESCRIPTION
### What does this PR do?
Running into issue on certain systems for users with the latest version of source-deploy-retieve.
This reverts to the version prior to the latest in order to unblock those users until an alternative
can be found.

### What issues does this PR fix or reference?
#3901 

### Functionality Before
Some users are unable to run SFDX commands. 

### Functionality After
Functionality should return to normal. 
