### PR TITLE
feat: add flow for creating LWC jest debug config

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -39,8 +39,7 @@
     "jsforce": "1.11.0",
     "rxjs": "^5.4.1",
     "sanitize-filename": "^1.6.1",
-    "shelljs": "0.8.5",
-    "yeoman-generator": "^4.8.2"
+    "shelljs": "0.8.5"
   },
   "devDependencies": {
     "@salesforce/salesforcedx-test-utils-vscode": "54.4.1",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -357,6 +357,39 @@
         "title": "%force_lightning_lwc_test_stop_watching_all_tests_text%"
       }
     ],
+    "debuggers": [
+      {
+        "type": "vscode-lwc-tests",
+        "label": "%force_lightning_lwc_debugger%",
+        "languages": [
+          "javascript",
+          "typescript"
+        ],
+        "configurationSnippets": [
+          {
+            "label": "%force_lightning_lwc_debugger%",
+            "description": "%force_lightning_lwc_debugger_desc%",
+            "body": {
+              "name": "%force_lightning_lwc_debugger%",
+              "type": "node",
+              "request": "launch",
+              "program": "^\"\\${workspaceFolder}/node_modules/.bin/sfdx-lwc-jest\"",
+              "args": [
+                "--",
+                "--runInBand"
+              ],
+              "cwd": "^\"\\${workspaceFolder}\"",
+              "console": "integratedTerminal",
+              "internalConsoleOptions": "neverOpen",
+              "disableOptimisticBPs": true,
+              "windows": {
+                "program": "^\"\\${workspaceFolder}/node_modules/bin/sfdx-lwc-jest\""
+              }
+            }
+          }
+        ]
+      }
+    ],
     "configuration": {
       "type": "object",
       "title": "%force_lightning_lwc_preferences%",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -381,7 +381,7 @@
               "internalConsoleOptions": "neverOpen",
               "disableOptimisticBPs": true,
               "windows": {
-                "program": "^\"\\${workspaceFolder}/node_modules/bin/sfdx-lwc-jest\""
+                "program": "^\"\\${workspaceFolder}/node_modules/@salesforce/sfdx-lwc-jest/bin/sfdx-lwc-jest\""
               }
             }
           }

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -362,8 +362,7 @@
         "type": "vscode-lwc-tests",
         "label": "%force_lightning_lwc_debugger%",
         "languages": [
-          "javascript",
-          "typescript"
+          "javascript"
         ],
         "configurationSnippets": [
           {

--- a/packages/salesforcedx-vscode-lwc/package.nls.json
+++ b/packages/salesforcedx-vscode-lwc/package.nls.json
@@ -18,5 +18,7 @@
   "force_lightning_lwc_test_stop_watching_all_tests_text": "SFDX: Stop Watching All Lightning Web Component Tests",
   "force_lightning_lwc_preferences": "Salesforce Lightning Web Components",
   "force_lightning_lwc_remember_device_description": "Remember most recently used mobile device target.",
-  "force_lightning_lwc_mobile_log_level": "Log level used when calling SFDX Preview on Mobile command."
+  "force_lightning_lwc_mobile_log_level": "Log level used when calling SFDX Preview on Mobile command.",
+  "force_lightning_lwc_debugger": "Debug: LWC Jest Tests",
+  "force_lightning_lwc_debugger_desc": "Debug configuretion for running LWC jest tests in vscode."
 }

--- a/packages/salesforcedx-vscode-lwc/package.nls.json
+++ b/packages/salesforcedx-vscode-lwc/package.nls.json
@@ -20,5 +20,5 @@
   "force_lightning_lwc_remember_device_description": "Remember most recently used mobile device target.",
   "force_lightning_lwc_mobile_log_level": "Log level used when calling SFDX Preview on Mobile command.",
   "force_lightning_lwc_debugger": "Debug: LWC Jest Tests",
-  "force_lightning_lwc_debugger_desc": "Debug configuretion for running LWC jest tests in vscode."
+  "force_lightning_lwc_debugger_desc": "Debug configuration for running LWC jest tests in VSCode."
 }


### PR DESCRIPTION
### What does this PR do?
Add a new debugger configuration for LWC jest tests.

A few items to note that were different from how the tickets was written.
1. There is a @salesforce/lwc-jest-test module that is included in our default and analytics packages so no need to worry about verifying jest or the config existing. 
2. For an empty project with the current change the user will need to add the module from 1  in order to run the test.  

### What issues does this PR fix or reference?
@W-10536658@

### Functionality Before
No debug configuration available for LWC jest tests

### Functionality After
<img width="599" alt="Screen Shot 2022-03-15 at 12 33 44 PM" src="https://user-images.githubusercontent.com/76090802/158437435-15fe6d83-7f68-4052-b011-de6be951d16a.png">

