### PR TITLE
fix: prevent excessive autocompletion in template JS files

### DIFF
--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -25,9 +25,9 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/aura-language-server": "3.6.0",
+    "@salesforce/aura-language-server": "3.7.0",
     "@salesforce/core": "^2.35.0",
-    "@salesforce/lightning-lsp-common": "3.6.0",
+    "@salesforce/lightning-lsp-common": "3.7.0",
     "@salesforce/salesforcedx-utils-vscode": "54.4.1",
     "applicationinsights": "1.0.7",
     "vscode-extension-telemetry": "0.0.17",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "@salesforce/core": "^2.35.0",
     "@salesforce/eslint-config-lwc": "0.3.0",
-    "@salesforce/lightning-lsp-common": "3.6.0",
-    "@salesforce/lwc-language-server": "3.6.0",
+    "@salesforce/lightning-lsp-common": "3.7.0",
+    "@salesforce/lwc-language-server": "3.7.0",
     "@salesforce/salesforcedx-utils-vscode": "54.4.1",
     "ajv": "^6.1.1",
     "applicationinsights": "1.0.7",


### PR DESCRIPTION
### What does this PR do?
Bumps the lightning-language-server version to consume latest changes to prevent excessive
autocompletion in JS files with the opening of curly braces.

### What issues does this PR fix or reference?
#3902 , @W-10832653@

### Functionality Before
Autocompletion was provided for all opening curly braces in LWC JS files.

### Functionality After
Autocompletion is no longer triggered with curly braces in LWC JS files.
