### PR TITLE
chore: merge main back into develop after releasing v54.5.0

### DIFF
--- a/SHA256.md
+++ b/SHA256.md
@@ -8,7 +8,7 @@ make sure that their SHA values match the values in the list below.
    following the instructions at
    https://code.visualstudio.com/docs/editor/extension-gallery#_common-questions.
    For example, download,
-   https://salesforce.gallery.vsassets.io/_apis/public/gallery/publisher/salesforce/extension/salesforcedx-vscode-core/54.4.1/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage.
+   https://salesforce.gallery.vsassets.io/_apis/public/gallery/publisher/salesforce/extension/salesforcedx-vscode-core/54.5.0/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage.
 
 2. From a terminal, run:
 
@@ -16,16 +16,16 @@ shasum -a 256 <location_of_the_downloaded_file>
 
 3. Confirm that the SHA in your output matches the value in this list of SHAs.
 
-e956e0dc6553d8bd2b0a3d6e2955b750d82cba09e30c623ddfb4f2c329a02bbe  salesforcedx-vscode-apex-debugger-54.4.1.vsix
-0bd4e2910907acc3c37a3e9f86bdab8940d76db0b6907e2f826af8436285bf01  salesforcedx-vscode-apex-replay-debugger-54.4.1.vsix
-899510424ef3ef203b992bb5e5b416a397e734a12cc0fd9a17c56c2e18cf43ca  salesforcedx-vscode-apex-54.4.1.vsix
-f2953e0d93591912178ee132f55b151f53324c05f78e1ff76da57c68468a38ab  salesforcedx-vscode-core-54.4.1.vsix
-537419b428d5cba04f502ce2585b49d45bc569f5cfe38dd1c8e9a0ffacba521b  salesforcedx-vscode-expanded-54.4.1.vsix
-26d87bcfd57082fce816abab9a4696c30e09484141cfffd135a852e8dac71dd2  salesforcedx-vscode-lightning-54.4.1.vsix
-bc9eae99d961d17bde16d174c38f6ccb3b2f216c6b779e96a339ea40b78a3220  salesforcedx-vscode-lwc-54.4.1.vsix
-57037b424108a133ff7bdaa7977a70821241f8281d472d76817d6a8dd12bc6a2  salesforcedx-vscode-soql-54.4.1.vsix
-0dc4f49aaf004a1ada76aa843c79671fc2ac65b9f2cf578af15f263dca55dd6e  salesforcedx-vscode-visualforce-54.4.1.vsix
-668d21d06d695f9e00cd1ee04cd81cbd8a9990223808bc70bad90abb74681250  salesforcedx-vscode-54.4.1.vsix
+7c95f50166294dfb85f0ac59dfa7226b81fff688ec60b19a1862629f0c08ff17  salesforcedx-vscode-apex-debugger-54.5.0.vsix
+06be0b024e85063797b0e746f3d04327681f89f58a44c5b0e5d690828007246e  salesforcedx-vscode-apex-replay-debugger-54.5.0.vsix
+f7298477ec6083b1fe4aa9da505148999c6519a0ba80a4bde734f1e6d801d85a  salesforcedx-vscode-apex-54.5.0.vsix
+7aa29d82b80d843c3777d1bf29e7274e8b385eb6e1534a210927eeec75ef0895  salesforcedx-vscode-core-54.5.0.vsix
+83327b8753b2ec4683393a944f8313e16d89f284b1824f02dfa5c7467b38b2ff  salesforcedx-vscode-expanded-54.5.0.vsix
+2a25006fe87797b51de529c6c2e5381e34c6ec78b41cd523b18e3ec1496a853b  salesforcedx-vscode-lightning-54.5.0.vsix
+35311d7bf499c63df6f99e97ab73bb964c0f4f09fe8a64cfbba72d6bd7aae0ac  salesforcedx-vscode-lwc-54.5.0.vsix
+c186f06d00e6ac01604782656d5f1c92741c86b6c2ed7a60663798976d234655  salesforcedx-vscode-soql-54.5.0.vsix
+25e6470128ac3bfe06d2b75a9d947533c7d3475f4d143058a5cd7df40c452720  salesforcedx-vscode-visualforce-54.5.0.vsix
+a7fc45f14124f908f3b3839bbbb55bcc513043b9a58d56736b6e3405f2c00b63  salesforcedx-vscode-54.5.0.vsix
 
 
 4. Change the filename extension for the file that you downloaded from .zip to

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "54.4.1",
+  "version": "54.5.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "docs",
     "packages/*"
   ],
-  "version": "54.4.1",
+  "version": "54.5.0",
   "command": {
     "version": {
       "allowBranch": [

--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -2,7 +2,7 @@
   "name": "@salesforce/salesforcedx-apex-debugger",
   "displayName": "Apex Debugger Adapter",
   "description": "Implements the VS Code Debug Protocol for the Apex Debugger",
-  "version": "54.4.1",
+  "version": "54.5.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -12,7 +12,7 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-utils-vscode": "54.4.1",
+    "@salesforce/salesforcedx-utils-vscode": "54.5.0",
     "async-lock": "1.0.0",
     "faye": "1.1.2",
     "request-light": "0.2.4",
@@ -20,7 +20,7 @@
     "vscode-debugprotocol": "1.28.0"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "54.4.1",
+    "@salesforce/salesforcedx-test-utils-vscode": "54.5.0",
     "@types/async-lock": "0.0.20",
     "@types/chai": "^4.0.0",
     "@types/mocha": "^5",

--- a/packages/salesforcedx-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-apex-replay-debugger/package.json
@@ -2,7 +2,7 @@
   "name": "@salesforce/salesforcedx-apex-replay-debugger",
   "displayName": "Apex Replay Debug Adapter",
   "description": "Implements the VS Code Debug Protocol for the Apex Replay Debugger",
-  "version": "54.4.1",
+  "version": "54.5.0",
   "publisher": "salesforce",
   "preview": true,
   "license": "BSD-3-Clause",
@@ -13,7 +13,7 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-utils-vscode": "54.4.1",
+    "@salesforce/salesforcedx-utils-vscode": "54.5.0",
     "vscode-debugadapter": "1.28.0",
     "vscode-debugprotocol": "1.28.0",
     "vscode-uri": "1.0.1"

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -2,7 +2,7 @@
   "name": "@salesforce/salesforcedx-sobjects-faux-generator",
   "displayName": "Salesforce SObject Faux Generator",
   "description": "Fetches sobjects and generates their faux apex class to be used for Apex Language Server",
-  "version": "54.4.1",
+  "version": "54.5.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {

--- a/packages/salesforcedx-test-utils-vscode/package.json
+++ b/packages/salesforcedx-test-utils-vscode/package.json
@@ -2,14 +2,14 @@
   "name": "@salesforce/salesforcedx-test-utils-vscode",
   "displayName": "SFDX Test Utilities for VS Code",
   "description": "Provides test utilities to interface the SFDX libraries with VS Code",
-  "version": "54.4.1",
+  "version": "54.5.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "categories": [
     "Other"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-utils-vscode": "54.4.1",
+    "@salesforce/salesforcedx-utils-vscode": "54.5.0",
     "shelljs": "0.8.5"
   },
   "devDependencies": {

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "SFDX Utilities for VS Code",
   "description": "Provides utilities to interface the SFDX libraries with VS Code",
   "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
-  "version": "54.4.1",
+  "version": "54.5.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "categories": [

--- a/packages/salesforcedx-visualforce-language-server/package.json
+++ b/packages/salesforcedx-visualforce-language-server/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@salesforce/salesforcedx-visualforce-language-server",
   "description": "Visualforce language server",
-  "version": "54.4.1",
+  "version": "54.5.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
     "vscode": "^1.49.3"
   },
   "dependencies": {
-    "@salesforce/salesforcedx-visualforce-markup-language-server": "54.4.1",
+    "@salesforce/salesforcedx-visualforce-markup-language-server": "54.5.0",
     "typescript": "3.8.3",
     "vscode-css-languageservice": "2.1.9",
     "vscode-languageserver": "5.2.1",

--- a/packages/salesforcedx-visualforce-markup-language-server/package.json
+++ b/packages/salesforcedx-visualforce-markup-language-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/salesforcedx-visualforce-markup-language-server",
   "description": "Language service for Visualforce Markup",
-  "version": "54.4.1",
+  "version": "54.5.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "54.4.1",
+  "version": "54.5.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -24,12 +24,12 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-apex-debugger": "54.4.1",
+    "@salesforce/salesforcedx-apex-debugger": "54.5.0",
     "vscode-debugprotocol": "1.28.0",
     "vscode-extension-telemetry": "0.0.17"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "54.4.1",
+    "@salesforce/salesforcedx-test-utils-vscode": "54.5.0",
     "@types/chai": "^4.0.0",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "54.4.1",
+  "version": "54.5.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -26,15 +26,15 @@
   "dependencies": {
     "@salesforce/apex-node": "0.10.0",
     "@salesforce/core": "^2.35.0",
-    "@salesforce/salesforcedx-apex-replay-debugger": "54.4.1",
-    "@salesforce/salesforcedx-utils-vscode": "54.4.1",
+    "@salesforce/salesforcedx-apex-replay-debugger": "54.5.0",
+    "@salesforce/salesforcedx-utils-vscode": "54.5.0",
     "async-lock": "1.0.0",
     "path-exists": "3.0.0",
     "request-light": "0.2.4",
     "vscode-extension-telemetry": "0.0.17"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "54.4.1",
+    "@salesforce/salesforcedx-test-utils-vscode": "54.5.0",
     "@salesforce/ts-sinon": "1.3.21",
     "@types/async-lock": "0.0.20",
     "@types/chai": "^4.0.0",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -15,7 +15,7 @@
     "theme": "light"
   },
   "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
-  "version": "54.4.1",
+  "version": "54.5.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -28,7 +28,7 @@
     "@salesforce/apex-node": "0.10.0",
     "@salesforce/apex-tmlanguage": "1.4.0",
     "@salesforce/core": "^2.35.0",
-    "@salesforce/salesforcedx-utils-vscode": "54.4.1",
+    "@salesforce/salesforcedx-utils-vscode": "54.5.0",
     "@salesforce/source-deploy-retrieve": "5.12.2",
     "expand-home-dir": "0.0.3",
     "find-java-home": "0.2.0",
@@ -38,7 +38,7 @@
     "vscode-languageclient": "5.1.1"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "54.4.1",
+    "@salesforce/salesforcedx-test-utils-vscode": "54.5.0",
     "@salesforce/ts-sinon": "1.3.21",
     "@types/chai": "^4.0.0",
     "@types/mkdirp": "0.5.2",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -15,7 +15,7 @@
     "theme": "light"
   },
   "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
-  "version": "54.4.1",
+  "version": "54.5.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -27,8 +27,8 @@
   "dependencies": {
     "@heroku/functions-core": "^0.2.7",
     "@salesforce/core": "^2.35.0",
-    "@salesforce/salesforcedx-sobjects-faux-generator": "54.4.1",
-    "@salesforce/salesforcedx-utils-vscode": "54.4.1",
+    "@salesforce/salesforcedx-sobjects-faux-generator": "54.5.0",
+    "@salesforce/salesforcedx-utils-vscode": "54.5.0",
     "@salesforce/schemas": "^1",
     "@salesforce/source-deploy-retrieve": "5.12.2",
     "@salesforce/templates": "^54.2.0",
@@ -42,7 +42,7 @@
     "shelljs": "0.8.5"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "54.4.1",
+    "@salesforce/salesforcedx-test-utils-vscode": "54.5.0",
     "@salesforce/ts-sinon": "^1.0.0",
     "@types/adm-zip": "^0.4.31",
     "@types/chai": "^4.0.0",

--- a/packages/salesforcedx-vscode-expanded/package.json
+++ b/packages/salesforcedx-vscode-expanded/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "54.4.1",
+  "version": "54.5.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -15,7 +15,7 @@
     "theme": "light"
   },
   "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
-  "version": "54.4.1",
+  "version": "54.5.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -27,14 +27,14 @@
   "dependencies": {
     "@salesforce/aura-language-server": "3.7.0",
     "@salesforce/core": "^2.35.0",
+    "@salesforce/salesforcedx-utils-vscode": "54.5.0",
     "@salesforce/lightning-lsp-common": "3.7.0",
-    "@salesforce/salesforcedx-utils-vscode": "54.4.1",
     "applicationinsights": "1.0.7",
     "vscode-extension-telemetry": "0.0.17",
     "vscode-languageclient": "^5.2.1"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "54.4.1",
+    "@salesforce/salesforcedx-test-utils-vscode": "54.5.0",
     "@types/chai": "^4.0.0",
     "@types/mkdirp": "0.5.2",
     "@types/mocha": "^5",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -15,7 +15,7 @@
     "theme": "light"
   },
   "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
-  "version": "54.4.1",
+  "version": "54.5.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -29,7 +29,7 @@
     "@salesforce/eslint-config-lwc": "0.3.0",
     "@salesforce/lightning-lsp-common": "3.7.0",
     "@salesforce/lwc-language-server": "3.7.0",
-    "@salesforce/salesforcedx-utils-vscode": "54.4.1",
+    "@salesforce/salesforcedx-utils-vscode": "54.5.0",
     "ajv": "^6.1.1",
     "applicationinsights": "1.0.7",
     "eslint": "5.0.0",
@@ -42,7 +42,7 @@
     "vscode-languageclient": "^5.2.1"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "54.4.1",
+    "@salesforce/salesforcedx-test-utils-vscode": "54.5.0",
     "@types/chai": "^4.0.0",
     "@types/mkdirp": "0.5.2",
     "@types/mocha": "^5",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/forcedotcom/salesforcedx-vscode"
   },
   "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
-  "version": "54.4.1",
+  "version": "54.5.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "icon": "images/VSCodeSoql.png",
@@ -42,9 +42,9 @@
     "jsforce": "1.11.0"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-sobjects-faux-generator": "54.4.1",
-    "@salesforce/salesforcedx-test-utils-vscode": "54.4.1",
-    "@salesforce/salesforcedx-utils-vscode": "54.4.1",
+    "@salesforce/salesforcedx-sobjects-faux-generator": "54.5.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "54.5.0",
+    "@salesforce/salesforcedx-utils-vscode": "54.5.0",
     "@salesforce/soql-common": "0.2.1",
     "@salesforce/ts-sinon": "1.3.21",
     "@salesforce/ts-types": "1.5.13",

--- a/packages/salesforcedx-vscode-visualforce/package.json
+++ b/packages/salesforcedx-vscode-visualforce/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "54.4.1",
+  "version": "54.5.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -24,15 +24,15 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-visualforce-language-server": "54.4.1",
-    "@salesforce/salesforcedx-visualforce-markup-language-server": "54.4.1",
+    "@salesforce/salesforcedx-visualforce-language-server": "54.5.0",
+    "@salesforce/salesforcedx-visualforce-markup-language-server": "54.5.0",
     "vscode-extension-telemetry": "0.0.17",
     "vscode-languageclient": "5.2.1",
     "vscode-languageserver-protocol": "3.14.1",
     "vscode-languageserver-types": "3.14.0"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "54.4.1",
+    "@salesforce/salesforcedx-test-utils-vscode": "54.5.0",
     "@types/chai": "^4.0.0",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",

--- a/packages/salesforcedx-vscode/CHANGELOG.md
+++ b/packages/salesforcedx-vscode/CHANGELOG.md
@@ -1,12 +1,18 @@
-# 54.4.1 - March 10, 2022
+# v54.5.0 - March 14, 2022
 
 ## Fixed
 
 #### salesforcedx-vscode-core
-#### salesforcedx-vscode-apex
 
-- We reverted the source-deploy-retrieve library to v5.12.3 to fix the issue with using it in OSX Monterey.
+- We’ve updated the library that supports Salesforce Templates commands in VS Code so that it now uses API version 54.0 when generating new metadata from our standard templates.([PR #3749](https://github.com/forcedotcom/salesforcedx-vscode/pull/3749))
 
+# 54.4.1 - March 10, 2022
+
+## Fixed
+
+#### salesforcedx-vscode-core, salesforcedx-vscode-apex
+
+- We reverted the source-deploy-retrieve library to v5.12.2 because it was sometimes failing on OSX Monterey.
 
 # 54.4.0 - March 9, 2022
 
@@ -25,13 +31,13 @@
 - We’ve made the functionality of older versions of some commands available for you to use with your existing scratch orgs. Use these legacy commands so you don’t run into issues with their newer versions:
 
     *SFDX: Pull Source from Default Scratch Org (Legacy)*
-    
+
     *SFDX: Pull Source from Default Scratch Org and Override Conflicts (Legacy)*
-    
+
     *SFDX: Push Source to Default Scratch Org (Legacy)*
-    
+
     *SFDX: Push Source to Default Scratch Org and Override Conflicts (Legacy)*  and
-    
+
     *SFDX: View All Changes (Local and in Default Scratch Org) (Legacy)* ([PR #3839](https://github.com/forcedotcom/salesforcedx-vscode/pull/3839))
 
 #### salesforcedx-vscode-lightning & salesforcedx-vscode-lwc

--- a/packages/salesforcedx-vscode/package.json
+++ b/packages/salesforcedx-vscode/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "54.4.1",
+  "version": "54.5.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {

--- a/packages/system-tests/package.json
+++ b/packages/system-tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "system-tests",
   "description": "System tests for Salesforce DX Extensions for VS Code",
-  "version": "54.4.1",
+  "version": "54.5.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "main": "./out/src",
@@ -9,8 +9,8 @@
     "vscode": "^1.49.3"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "54.4.1",
-    "@salesforce/salesforcedx-utils-vscode": "54.4.1",
+    "@salesforce/salesforcedx-test-utils-vscode": "54.5.0",
+    "@salesforce/salesforcedx-utils-vscode": "54.5.0",
     "@types/chai": "^4.0.0",
     "@types/mkdirp": "0.5.2",
     "@types/mocha": "^5",


### PR DESCRIPTION
Merge main back into develop after releasing v54.5.0 as[ the CI job to do the same](https://app.circleci.com/pipelines/github/forcedotcom/salesforcedx-vscode/7994/workflows/d20762e8-4b13-45cd-9029-6c86cad1a38e/jobs/31222) errored due to merge conflicts.