### PR TITLE
config(git2gus): add community contribution label map to user story

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -29,7 +29,8 @@
     "type:bug": "BUG P3",
     "type:security": "BUG P2",
     "type:feedback": "",
-    "type:duplicate": ""
+    "type:duplicate": "",
+    "type:community-contrib": "USER STORY"
   },
   "defaultBuild": "offcore.tooling.54.0.0",
   "hideWorkItemUrl": "true",


### PR DESCRIPTION
### What does this PR do?
Adds a git2gus config mapping the label `type:community-contrib` to a `USER STORY`

### What issues does this PR fix or reference?
@@

### Functionality Before
No direct way to create WIs associated with community contributed PRs

### Functionality After
Git2Gus should be able to create WIs for community contributed PRs when `type:community-contrib` label is applied
