### PR TITLE
chore: changelog generator ignores dependabot PRs

### DIFF
--- a/scripts/change-log-generator-utils.js
+++ b/scripts/change-log-generator-utils.js
@@ -263,7 +263,7 @@ function filterPackageNames(packageHeaders) {
  */
 function generateKey(packageName, type, packagesToIgnore) {
   if (
-    typesToIgnore.includes(type) ||
+    typesToIgnore.some(typeToIgnore => type.startsWith(typeToIgnore)) ||
     packagesToIgnore.includes(packageName)
   ) {
     return '';


### PR DESCRIPTION
### What does this PR do?
Currently, denpendabot PRs are automatically categorized to "FIXED" field in changelog, which requires the technical writer to delete them manually. To reduce the workload for technical writer and minimize the number of commits for changing changlog, this PR makes changelog generator to ignore dependabot PRs. 

### What issues does this PR fix or reference?
@W-10959446@
