### PR TITLE
fix: changed version of types/chai to 4.3.0

### DIFF
--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@salesforce/salesforcedx-test-utils-vscode": "54.8.0",
     "@types/async-lock": "0.0.20",
-    "@types/chai": "^4.0.0",
+    "@types/chai": "4.3.0",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",
     "@types/rimraf": "^2.0.2",

--- a/packages/salesforcedx-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-apex-replay-debugger/package.json
@@ -19,7 +19,7 @@
     "vscode-uri": "1.0.1"
   },
   "devDependencies": {
-    "@types/chai": "^4.0.0",
+    "@types/chai": "4.3.0",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",
     "@types/sinon": "^2.3.7",

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -15,7 +15,7 @@
     "shelljs": "0.8.5"
   },
   "devDependencies": {
-    "@types/chai": "^4.0.0",
+    "@types/chai": "4.3.0",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",
     "@types/rimraf": "^2.0.2",

--- a/packages/salesforcedx-test-utils-vscode/package.json
+++ b/packages/salesforcedx-test-utils-vscode/package.json
@@ -13,7 +13,7 @@
     "shelljs": "0.8.5"
   },
   "devDependencies": {
-    "@types/chai": "^4.0.0",
+    "@types/chai": "4.3.0",
     "@types/glob": "^7.2.0",
     "@types/mocha": "^2.2.38",
     "@types/node": "12.0.12",

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@salesforce/ts-sinon": "1.3.21",
-    "@types/chai": "^4.0.0",
+    "@types/chai": "4.3.0",
     "@types/cross-spawn": "6.0.0",
     "@types/mkdirp": "0.5.2",
     "@types/mocha": "^5",

--- a/packages/salesforcedx-visualforce-markup-language-server/package.json
+++ b/packages/salesforcedx-visualforce-markup-language-server/package.json
@@ -13,7 +13,7 @@
   "main": "./out/src/htmlLanguageService.js",
   "typings": "./out/src/htmlLanguageService",
   "devDependencies": {
-    "@types/chai": "^4.0.0",
+    "@types/chai": "4.3.0",
     "@types/mocha": "^2.2.38",
     "@types/node": "12.0.12",
     "chai": "^4.0.2",

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@salesforce/salesforcedx-test-utils-vscode": "54.8.0",
-    "@types/chai": "^4.0.0",
+    "@types/chai": "4.3.0",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",
     "@types/sinon": "^2.3.7",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -37,7 +37,7 @@
     "@salesforce/salesforcedx-test-utils-vscode": "54.8.0",
     "@salesforce/ts-sinon": "1.3.21",
     "@types/async-lock": "0.0.20",
-    "@types/chai": "^4.0.0",
+    "@types/chai": "4.3.0",
     "@types/mkdirp": "0.5.2",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@salesforce/salesforcedx-test-utils-vscode": "54.8.0",
     "@salesforce/ts-sinon": "1.3.21",
-    "@types/chai": "^4.0.0",
+    "@types/chai": "4.3.0",
     "@types/mkdirp": "0.5.2",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -45,7 +45,7 @@
     "@salesforce/salesforcedx-test-utils-vscode": "54.8.0",
     "@salesforce/ts-sinon": "^1.0.0",
     "@types/adm-zip": "^0.4.31",
-    "@types/chai": "^4.0.0",
+    "@types/chai": "4.3.0",
     "@types/glob": "^7.2.0",
     "@types/mkdirp": "0.5.2",
     "@types/mocha": "^5",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@salesforce/salesforcedx-test-utils-vscode": "54.8.0",
-    "@types/chai": "^4.0.0",
+    "@types/chai": "4.3.0",
     "@types/mkdirp": "0.5.2",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@salesforce/salesforcedx-test-utils-vscode": "54.8.0",
-    "@types/chai": "^4.0.0",
+    "@types/chai": "4.3.0",
     "@types/mkdirp": "0.5.2",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -48,7 +48,7 @@
     "@salesforce/soql-common": "0.2.1",
     "@salesforce/ts-sinon": "1.3.21",
     "@salesforce/ts-types": "1.5.13",
-    "@types/chai": "^4.0.0",
+    "@types/chai": "4.3.0",
     "@types/debounce": "^1.2.0",
     "@types/fs-extra": "^8.1.0",
     "@types/mkdirp": "0.5.2",

--- a/packages/salesforcedx-vscode-visualforce/package.json
+++ b/packages/salesforcedx-vscode-visualforce/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@salesforce/salesforcedx-test-utils-vscode": "54.8.0",
-    "@types/chai": "^4.0.0",
+    "@types/chai": "4.3.0",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",
     "@types/sinon": "^2.3.7",

--- a/packages/system-tests/assets/sfdx-simple/functions/demoJavaScriptFunction/package.json
+++ b/packages/system-tests/assets/sfdx-simple/functions/demoJavaScriptFunction/package.json
@@ -19,7 +19,7 @@
     "@salesforce/salesforce-sdk": "^1.3.0"
   },
   "devDependencies": {
-    "@types/chai": "^4.1.7",
+    "@types/chai": "4.3.0",
     "@types/chai-as-promised": "^7.1.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.18",

--- a/packages/system-tests/package.json
+++ b/packages/system-tests/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@salesforce/salesforcedx-test-utils-vscode": "54.8.0",
     "@salesforce/salesforcedx-utils-vscode": "54.8.0",
-    "@types/chai": "^4.0.0",
+    "@types/chai": "4.3.0",
     "@types/mkdirp": "0.5.2",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",


### PR DESCRIPTION
### What does this PR do?
* pin @types/chai to 4.3.0 as 4.3.1 has introduced breaking changes

### What issues does this PR fix or reference?
@W-10994021@

### Functionality Before
Build is broken in main and multiple branches

### Functionality After
Build is fixed
