### PR TITLE
fix(404.html): update github pages 404 to redirect to docs site

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -2,6 +2,15 @@
 layout: default
 ---
 
+<script>
+  window.onload = function () {
+      // Redirect to the real documentation site if github pages url is attempted. 
+      if (window.location.href.includes("forcedotcom.github.io/salesforcedx-vscode")) {
+          window.location.href = "https://developer.salesforce.com/tools/vscode";
+      }
+  }
+</script>
+
 <style type="text/css" media="screen">
   .container {
     margin: 10px auto;

--- a/docs/README.md
+++ b/docs/README.md
@@ -103,4 +103,4 @@ When updating the `_/data/sidebar.yml` file, titles must specify both the `en` a
 ## Github Pages
 
 Previously the docs site was hosted on Github pages for the main SF VSCode extensions repository. This has been decommissioned in favor of the [doc site](https://developer.salesforce.com/tools/vscode).
-A javascript redirect has been put in place on the 404.html file to ensure we land on the documentation site when the github pages site is accessed.
+A JavaScript redirect has been put in place on the 404.html file to ensure we land on the documentation site when the github pages site is accessed.

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,6 @@
 - The `docs` folder contains content published to [Salesforce Extensions for Visual Studio Code](https://developer.salesforce.com/tools/vscode).
 - To preview the rendered doc site from a Github Pull request click "Details" against the "netlify/salesforcedx-vscode/deploy-preview — Deploy Preview ready!" check.
 
-
 ## Setup Ruby
 
 Note that the server will only work with Ruby version 2. If you install 3 (which is the current default) you will be unable to run the server.
@@ -101,6 +100,7 @@ When adding new articles, you MUST add them in both the `_articles/en` and `_art
 
 When updating the `_/data/sidebar.yml` file, titles must specify both the `en` and `ja` versions. If you are adding an new item in english simply copy the english value to the japanese value and it will be translated on the next localization pass.
 
-```
+## Github Pages
 
-```
+Previously the docs site was hosted on Github pages for the main SF VSCode extensions repository. This has been decommissioned in favor of the [doc site](https://developer.salesforce.com/tools/vscode).
+A javascript redirect has been put in place on the 404.html file to ensure we land on the documentation site when the github pages site is accessed.


### PR DESCRIPTION
### What does this PR do?
Update our 404 page in the repo to redirect to the docs site if the current url matches the github pages url. Should have zero impact on the current docs site. 

### What issues does this PR fix or reference?
@W-10817909@

### Functionality Before
Showed an incomplete 404 page when attempting to access the github pages link for the repo 
 
![Screen Shot 2022-05-03 at 2 54 36 PM](https://user-images.githubusercontent.com/76090802/166555417-016509b0-1f8e-4445-95dd-7d810cd6045d.png)


### Functionality After
Should redirect to the docs site (have to verify after merge).
