### PR TITLE
docs: fix typo

### DIFF
--- a/docs/_articles/en/apex/writing.md
+++ b/docs/_articles/en/apex/writing.md
@@ -102,4 +102,4 @@ You can execute [Anonymous Apex](https://developer.salesforce.com/docs/atlas.en-
 
 ![SFDX: Execute Anonymous Apex with Currently Selected Text](./images/apex_execute_selected.png)
 
-It is common to keep Apex code in your project for executing certain tasks. By default, a new project has a folder `scripts/apex` that contains an example `hello.apex` file. It's recommneded that you use this folder to create your anonymous Apex files using the `.apex` file extension.
+It is common to keep Apex code in your project for executing certain tasks. By default, a new project has a folder `scripts/apex` that contains an example `hello.apex` file. It's recommended that you use this folder to create your anonymous Apex files using the `.apex` file extension.


### PR DESCRIPTION
Fixes a documentation typo where two letters were swapped