### PR TITLE
fix: reverted setting to enable deploy and retrieve commands for source-tracked orgs

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -989,11 +989,6 @@
           "type": "boolean",
           "default": false,
           "description": "%enable_sobject_refresh_on_startup_description%"
-        },
-        "salesforcedx-vscode-core.enableDeployAndRetrieveForSourceTrackedOrgs": {
-          "type": "boolean",
-          "default": false,
-          "description": "%enable-deploy-and-retrieve-for-source-tracked-orgs%"
         }
       }
     },

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -54,7 +54,6 @@
   "push_or_deploy_on_save_enabled_description": "Specifies whether or not to automatically run force:source:push (for source-tracked orgs) or force:source:deploy (for non-source-tracked orgs) when a local source file is saved.",
   "override_conflicts_on_push_description": "Specifies whether to always use --forceoverwrite when you run force:source:push on save",
   "conflict_detection_enabled_description": "Specifies whether to enable conflict detection for all deploy commands executed from VS Code",
-  "enable-deploy-and-retrieve-for-source-tracked-orgs": "Specifies whether to enable the Org Browser and allow use of deploy and retrieve commands when connected to a source-tracked org.",
   "conflict_detect_resolve_view": "Org Differences",
   "conflict_detect_open_file": "Open File",
   "force_manifest_editor_show_text": "SFDX: Show Package Manifest Editor",

--- a/packages/salesforcedx-vscode-core/src/constants.ts
+++ b/packages/salesforcedx-vscode-core/src/constants.ts
@@ -37,5 +37,3 @@ export const SHOW_CLI_SUCCESS_INFO_MSG = 'show-cli-success-msg';
 export const TELEMETRY_ENABLED = 'telemetry.enabled';
 export const ENABLE_SOBJECT_REFRESH_ON_STARTUP =
   'enable-sobject-refresh-on-startup';
-export const ENABLE_DEPLOY_AND_RETRIEVE_FOR_SOURCE_TRACKED_ORGS =
-  'enableDeployAndRetrieveForSourceTrackedOrgs.enabled';

--- a/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
@@ -9,7 +9,6 @@ import * as vscode from 'vscode';
 import {
   BETA_DEPLOY_RETRIEVE,
   CONFLICT_DETECTION_ENABLED,
-  ENABLE_DEPLOY_AND_RETRIEVE_FOR_SOURCE_TRACKED_ORGS,
   INTERNAL_DEVELOPMENT_FLAG,
   PUSH_OR_DEPLOY_ON_SAVE_ENABLED,
   PUSH_OR_DEPLOY_ON_SAVE_OVERRIDE_CONFLICTS,
@@ -82,9 +81,5 @@ export class SfdxCoreSettings {
 
   private async setConfigValue(key: string, value: any) {
     await this.getConfiguration().update(key, value);
-  }
-
-  public getDeployAndRetrieveForSourceTrackedOrgsEnabled(): boolean {
-    return this.getConfigValue(ENABLE_DEPLOY_AND_RETRIEVE_FOR_SOURCE_TRACKED_ORGS, false);
   }
 }


### PR DESCRIPTION
Reverted setting to enable deploy and retrieve commands for source-tracked orgs

This reverts the work done in https://github.com/forcedotcom/salesforcedx-vscode/pull/4006/files, and will be added back in when we continue work on https://github.com/forcedotcom/salesforcedx-vscode/pull/4078