### PR TITLE
 chore: revert commit for version 54.12.0

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "54.12.0",
+  "version": "54.11.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "docs",
     "packages/*"
   ],
-  "version": "54.12.0",
+  "version": "54.11.0",
   "command": {
     "version": {
       "allowBranch": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1769,9 +1769,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@heroku/functions-core": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@heroku/functions-core/-/functions-core-0.2.8.tgz",
-      "integrity": "sha512-7SDXh4PowdqXh2lmQxDtsBYvF4CU9qU5f4PAVIlg+PHBy5eM4VobfXtwjWmdAt6ISnxDOgr/49VVvVHR8f0yOQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@heroku/functions-core/-/functions-core-0.3.1.tgz",
+      "integrity": "sha512-8/7vO3QDCAbmg/Us47jtvlAR3m2zXTD6b1ocoCFcp40SHBBCRtLgpjRpUgzgtiZgOE4zbUWEadFIZSabrEO8cQ==",
       "dependencies": {
         "@heroku-cli/color": "^1.1.14",
         "@heroku/project-descriptor": "0.0.5",
@@ -10115,7 +10115,8 @@
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
     },
     "node_modules/bn.js": {
       "version": "4.12.0",
@@ -10379,7 +10380,8 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
     },
     "node_modules/buffer-indexof-polyfill": {
       "version": "1.0.2",
@@ -10427,6 +10429,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
       "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10435,6 +10438,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-5.0.1.tgz",
       "integrity": "sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -10443,6 +10447,7 @@
       "version": "12.0.4",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
       "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
+      "dev": true,
       "dependencies": {
         "bluebird": "^3.5.5",
         "chownr": "^1.1.1",
@@ -10465,6 +10470,7 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -11090,7 +11096,8 @@
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
@@ -11688,6 +11695,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.6.0.tgz",
       "integrity": "sha512-lomjuFZKfM6MSAnV9aCZC9sc0qGbmZdfygNv+nCpqVkSKdCxCklLtd16O0EILGkImHw9ZpHkAnHaB+8Zxq5W6Q==",
+      "dev": true,
       "dependencies": {
         "strip-ansi": "^6.0.1",
         "wcwidth": "^1.0.0"
@@ -11700,6 +11708,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -11893,6 +11902,7 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
       "engines": [
         "node >= 0.8"
       ],
@@ -11907,6 +11917,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -11921,6 +11932,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -11929,6 +11941,7 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
       "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
       "dependencies": {
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
@@ -13020,6 +13033,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
       "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+      "dev": true,
       "dependencies": {
         "aproba": "^1.1.1",
         "fs-write-stream-atomic": "^1.0.8",
@@ -13032,7 +13046,8 @@
     "node_modules/copy-concurrently/node_modules/aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true
     },
     "node_modules/copy-descriptor": {
       "version": "0.1.1",
@@ -13506,7 +13521,8 @@
     "node_modules/cyclist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
-      "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
+      "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
+      "dev": true
     },
     "node_modules/cz-conventional-changelog": {
       "version": "3.3.0",
@@ -14051,6 +14067,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
       "integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -14310,6 +14327,7 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
@@ -14321,6 +14339,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -14335,6 +14354,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -15920,7 +15940,8 @@
     "node_modules/figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
-      "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw=="
+      "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
+      "dev": true
     },
     "node_modules/figures": {
       "version": "2.0.0",
@@ -16016,6 +16037,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
       "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16275,6 +16297,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
       "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
@@ -16284,6 +16307,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -16298,6 +16322,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -16365,6 +16390,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
@@ -16374,6 +16400,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -16388,6 +16415,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -16442,6 +16470,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "iferr": "^0.1.5",
@@ -16453,6 +16482,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -16467,6 +16497,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -18922,7 +18953,8 @@
     "node_modules/iferr": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
+      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+      "dev": true
     },
     "node_modules/ignore": {
       "version": "5.2.0",
@@ -19034,12 +19066,14 @@
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
     },
     "node_modules/init-package-json": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz",
       "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
+      "dev": true,
       "dependencies": {
         "glob": "^7.1.1",
         "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
@@ -19055,6 +19089,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -20330,7 +20365,8 @@
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -20401,6 +20437,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
       "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
       "dependencies": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
@@ -20805,7 +20842,8 @@
     "node_modules/lodash._getnative": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
     },
     "node_modules/lodash._isiterateecall": {
       "version": "3.0.9",
@@ -20839,7 +20877,8 @@
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
     },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
@@ -20948,7 +20987,8 @@
     "node_modules/lodash.restparam": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+      "dev": true
     },
     "node_modules/lodash.set": {
       "version": "4.3.2",
@@ -21082,6 +21122,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -21595,6 +21636,7 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
       "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -21797,6 +21839,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
       "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+      "dev": true,
       "dependencies": {
         "concat-stream": "^1.5.0",
         "duplexify": "^3.4.2",
@@ -21817,6 +21860,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -21831,6 +21875,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -21839,6 +21884,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
       "dependencies": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
@@ -22214,6 +22260,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+      "dev": true,
       "dependencies": {
         "aproba": "^1.1.1",
         "copy-concurrently": "^1.0.0",
@@ -22226,7 +22273,8 @@
     "node_modules/move-concurrently/node_modules/aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -22611,6 +22659,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.1.tgz",
       "integrity": "sha512-WH0WKGi+a4i4DUt2mHnvocex/xPLp9pYt5R6M2JdFB7pJ7Z34hveZ4nDTGTiLXCkitA9T8HFZjhinBCiVHYcWw==",
+      "dev": true,
       "dependencies": {
         "env-paths": "^2.2.0",
         "glob": "^7.1.4",
@@ -22635,6 +22684,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
       "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "dev": true,
       "dependencies": {
         "minipass": "^2.6.0"
       }
@@ -22642,12 +22692,14 @@
     "node_modules/node-gyp/node_modules/minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "node_modules/node-gyp/node_modules/minizlib": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
       "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "dev": true,
       "dependencies": {
         "minipass": "^2.9.0"
       }
@@ -22656,6 +22708,7 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -22667,6 +22720,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
       "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+      "dev": true,
       "dependencies": {
         "abbrev": "1",
         "osenv": "^0.1.4"
@@ -22679,6 +22733,7 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -22690,6 +22745,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -22709,6 +22765,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -22717,6 +22774,7 @@
       "version": "4.4.19",
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
       "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
+      "dev": true,
       "dependencies": {
         "chownr": "^1.1.4",
         "fs-minipass": "^1.2.7",
@@ -22816,6 +22874,7 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
       "dependencies": {
         "abbrev": "1"
       },
@@ -23184,6 +23243,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.5.tgz",
       "integrity": "sha512-lDLVkjfZmvmfvpvBzA4vzee9cn+Me4orq0QF8glbswJVEbIcSNWib7qGOffolysc3teCqbbPZZkzbr3GQZTL1g==",
+      "dev": true,
       "dependencies": {
         "byline": "^5.0.0",
         "graceful-fs": "^4.1.15",
@@ -23199,6 +23259,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -23212,6 +23273,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.1.tgz",
       "integrity": "sha512-qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==",
+      "dev": true,
       "dependencies": {
         "hosted-git-info": "^2.7.1",
         "osenv": "^0.1.5",
@@ -23223,6 +23285,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -23231,6 +23294,7 @@
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
       "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
+      "dev": true,
       "dependencies": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1",
@@ -23241,6 +23305,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-3.0.2.tgz",
       "integrity": "sha512-wNprTNg+X5nf+tDi+hbjdHhM4bX+mKqv6XmPh7B5eG+QY9VARfQPfCEH013H5GqfNj6ee8Ij2fg8yk0mzps1Vw==",
+      "dev": true,
       "dependencies": {
         "figgy-pudding": "^3.5.1",
         "npm-package-arg": "^6.0.0",
@@ -23251,6 +23316,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -29212,6 +29278,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.3.tgz",
       "integrity": "sha512-VdDoCwvJI4QdC6ndjpqFmoL3/+HxffFBbcJzKi5hwLLqqx3mdbedRpfZDdK0SrOSauj8X4GzBvnDZl4vTN7dOw==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -29441,6 +29508,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -29470,6 +29538,7 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "dev": true,
       "dependencies": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -29892,6 +29961,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
       "integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
+      "dev": true,
       "dependencies": {
         "cyclist": "^1.0.1",
         "inherits": "^2.0.3",
@@ -29902,6 +29972,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -29916,6 +29987,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -33314,6 +33386,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
       "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
+      "dev": true,
       "dependencies": {
         "read": "1"
       }
@@ -33329,7 +33402,8 @@
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
+      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+      "dev": true
     },
     "node_modules/protocols": {
       "version": "1.4.8",
@@ -33394,6 +33468,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+      "dev": true,
       "dependencies": {
         "duplexify": "^3.6.0",
         "inherits": "^2.0.3",
@@ -33404,6 +33479,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -33454,6 +33530,7 @@
       "version": "6.14.1",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
       "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
+      "dev": true,
       "dependencies": {
         "decode-uri-component": "^0.2.0",
         "filter-obj": "^1.1.0",
@@ -33568,6 +33645,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "dev": true,
       "dependencies": {
         "mute-stream": "~0.0.4"
       },
@@ -33579,6 +33657,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.5.tgz",
       "integrity": "sha512-v5yCqQ/7okKoZZkBQUAfTsQ3sVJtXdNfbPnI5cceppoxEVLYA3k+VtV2omkeo8MS94JCy4fSiUwlRBAwCVRPUA==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.2"
       }
@@ -33587,6 +33666,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.2.tgz",
       "integrity": "sha512-D1KmuLQr6ZSJS0tW8hf3WGpRlwszJOXZ3E8Yd/DNRaM5d+1wVRZdHlpGBLAuovjr28LbWvjpWkBHMxpRGGjzNA==",
+      "dev": true,
       "dependencies": {
         "glob": "^7.1.1",
         "json-parse-even-better-errors": "^2.3.0",
@@ -33611,6 +33691,7 @@
       "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.3.1.tgz",
       "integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
       "deprecated": "The functionality that this package provided is now in @npmcli/arborist",
+      "dev": true,
       "dependencies": {
         "read-package-json": "^2.0.0",
         "readdir-scoped-modules": "^1.0.0",
@@ -34457,6 +34538,7 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
       "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -34607,6 +34689,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+      "dev": true,
       "dependencies": {
         "aproba": "^1.1.1"
       }
@@ -34614,7 +34697,8 @@
     "node_modules/run-queue/node_modules/aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true
     },
     "node_modules/rx-lite": {
       "version": "4.0.8",
@@ -35491,6 +35575,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
       "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -35903,6 +35988,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
       "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -35960,6 +36046,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
       "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
+      "dev": true,
       "dependencies": {
         "figgy-pudding": "^3.5.1"
       }
@@ -36118,6 +36205,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
       "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
+      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "stream-shift": "^1.0.0"
@@ -36163,12 +36251,14 @@
     "node_modules/stream-shift": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "dev": true
     },
     "node_modules/strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
       "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -37700,7 +37790,8 @@
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
@@ -37744,6 +37835,7 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
       "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -37751,7 +37843,8 @@
     "node_modules/umask": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
-      "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0="
+      "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
+      "dev": true
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
@@ -38086,6 +38179,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/util-promisify/-/util-promisify-2.1.0.tgz",
       "integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
+      "dev": true,
       "dependencies": {
         "object.getownpropertydescriptors": "^2.0.3"
       }
@@ -40512,6 +40606,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
       "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
+      "dev": true,
       "dependencies": {
         "errno": "~0.1.7"
       }
@@ -40619,6 +40714,7 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
       "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
@@ -40802,6 +40898,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.4"
       }
@@ -40809,12 +40906,14 @@
     "node_modules/y18n": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true
     },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -41472,10 +41571,10 @@
     },
     "packages/salesforcedx-apex-debugger": {
       "name": "@salesforce/salesforcedx-apex-debugger",
-      "version": "54.12.0",
+      "version": "54.11.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/salesforcedx-utils-vscode": "54.12.0",
+        "@salesforce/salesforcedx-utils-vscode": "54.11.0",
         "async-lock": "1.0.0",
         "faye": "1.1.2",
         "request-light": "0.2.4",
@@ -41483,7 +41582,7 @@
         "vscode-debugprotocol": "1.28.0"
       },
       "devDependencies": {
-        "@salesforce/salesforcedx-test-utils-vscode": "54.12.0",
+        "@salesforce/salesforcedx-test-utils-vscode": "54.11.0",
         "@types/async-lock": "0.0.20",
         "@types/chai": "4.3.0",
         "@types/mocha": "^5",
@@ -41515,10 +41614,10 @@
     },
     "packages/salesforcedx-apex-replay-debugger": {
       "name": "@salesforce/salesforcedx-apex-replay-debugger",
-      "version": "54.12.0",
+      "version": "54.11.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/salesforcedx-utils-vscode": "54.12.0",
+        "@salesforce/salesforcedx-utils-vscode": "54.11.0",
         "vscode-debugadapter": "1.28.0",
         "vscode-debugprotocol": "1.28.0",
         "vscode-uri": "1.0.1"
@@ -41550,7 +41649,7 @@
     },
     "packages/salesforcedx-sobjects-faux-generator": {
       "name": "@salesforce/salesforcedx-sobjects-faux-generator",
-      "version": "54.12.0",
+      "version": "54.11.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/core": "^2.35.0",
@@ -41977,10 +42076,10 @@
     },
     "packages/salesforcedx-test-utils-vscode": {
       "name": "@salesforce/salesforcedx-test-utils-vscode",
-      "version": "54.12.0",
+      "version": "54.11.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/salesforcedx-utils-vscode": "54.12.0",
+        "@salesforce/salesforcedx-utils-vscode": "54.11.0",
         "shelljs": "0.8.5"
       },
       "devDependencies": {
@@ -45850,7 +45949,7 @@
     },
     "packages/salesforcedx-utils-vscode": {
       "name": "@salesforce/salesforcedx-utils-vscode",
-      "version": "54.12.0",
+      "version": "54.11.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/core": "^2.35.0",
@@ -45899,10 +45998,10 @@
     },
     "packages/salesforcedx-visualforce-language-server": {
       "name": "@salesforce/salesforcedx-visualforce-language-server",
-      "version": "54.12.0",
+      "version": "54.11.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/salesforcedx-visualforce-markup-language-server": "54.12.0",
+        "@salesforce/salesforcedx-visualforce-markup-language-server": "54.11.0",
         "typescript": "3.8.3",
         "vscode-css-languageservice": "2.1.9",
         "vscode-languageserver": "5.2.1",
@@ -45936,7 +46035,7 @@
     },
     "packages/salesforcedx-visualforce-markup-language-server": {
       "name": "@salesforce/salesforcedx-visualforce-markup-language-server",
-      "version": "54.12.0",
+      "version": "54.11.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "vscode-languageserver-types": "3.4.0",
@@ -45966,20 +46065,20 @@
       "dev": true
     },
     "packages/salesforcedx-vscode": {
-      "version": "54.12.0",
+      "version": "54.11.0",
       "license": "BSD-3-Clause",
       "engines": {
         "vscode": "^1.49.3"
       }
     },
     "packages/salesforcedx-vscode-apex": {
-      "version": "54.12.0",
+      "version": "54.11.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/apex-node": "0.10.0",
         "@salesforce/apex-tmlanguage": "1.4.0",
         "@salesforce/core": "^2.35.0",
-        "@salesforce/salesforcedx-utils-vscode": "54.12.0",
+        "@salesforce/salesforcedx-utils-vscode": "54.11.0",
         "@salesforce/source-deploy-retrieve": "5.12.2",
         "expand-home-dir": "0.0.3",
         "find-java-home": "0.2.0",
@@ -45989,7 +46088,7 @@
         "vscode-languageclient": "5.1.1"
       },
       "devDependencies": {
-        "@salesforce/salesforcedx-test-utils-vscode": "54.12.0",
+        "@salesforce/salesforcedx-test-utils-vscode": "54.11.0",
         "@salesforce/ts-sinon": "1.3.21",
         "@types/chai": "4.3.0",
         "@types/mkdirp": "0.5.2",
@@ -46011,15 +46110,15 @@
       }
     },
     "packages/salesforcedx-vscode-apex-debugger": {
-      "version": "54.12.0",
+      "version": "54.11.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/salesforcedx-apex-debugger": "54.12.0",
+        "@salesforce/salesforcedx-apex-debugger": "54.11.0",
         "vscode-debugprotocol": "1.28.0",
         "vscode-extension-telemetry": "0.0.17"
       },
       "devDependencies": {
-        "@salesforce/salesforcedx-test-utils-vscode": "54.12.0",
+        "@salesforce/salesforcedx-test-utils-vscode": "54.11.0",
         "@types/chai": "4.3.0",
         "@types/mocha": "^5",
         "@types/node": "12.0.12",
@@ -46035,20 +46134,20 @@
       }
     },
     "packages/salesforcedx-vscode-apex-replay-debugger": {
-      "version": "54.12.0",
+      "version": "54.11.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/apex-node": "0.10.0",
         "@salesforce/core": "^2.35.0",
-        "@salesforce/salesforcedx-apex-replay-debugger": "54.12.0",
-        "@salesforce/salesforcedx-utils-vscode": "54.12.0",
+        "@salesforce/salesforcedx-apex-replay-debugger": "54.11.0",
+        "@salesforce/salesforcedx-utils-vscode": "54.11.0",
         "async-lock": "1.0.0",
         "path-exists": "3.0.0",
         "request-light": "0.2.4",
         "vscode-extension-telemetry": "0.0.17"
       },
       "devDependencies": {
-        "@salesforce/salesforcedx-test-utils-vscode": "54.12.0",
+        "@salesforce/salesforcedx-test-utils-vscode": "54.11.0",
         "@salesforce/ts-sinon": "1.3.21",
         "@types/async-lock": "0.0.20",
         "@types/chai": "4.3.0",
@@ -46078,13 +46177,13 @@
       }
     },
     "packages/salesforcedx-vscode-core": {
-      "version": "54.12.0",
+      "version": "54.11.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@heroku/functions-core": "^0.2.7",
+        "@heroku/functions-core": "^0.3.0",
         "@salesforce/core": "^2.35.0",
-        "@salesforce/salesforcedx-sobjects-faux-generator": "54.12.0",
-        "@salesforce/salesforcedx-utils-vscode": "54.12.0",
+        "@salesforce/salesforcedx-sobjects-faux-generator": "54.11.0",
+        "@salesforce/salesforcedx-utils-vscode": "54.11.0",
         "@salesforce/schemas": "^1",
         "@salesforce/source-deploy-retrieve": "5.12.2",
         "@salesforce/templates": "^54.5.0",
@@ -46098,7 +46197,7 @@
         "shelljs": "0.8.5"
       },
       "devDependencies": {
-        "@salesforce/salesforcedx-test-utils-vscode": "54.12.0",
+        "@salesforce/salesforcedx-test-utils-vscode": "54.11.0",
         "@salesforce/ts-sinon": "^1.0.0",
         "@types/adm-zip": "^0.4.31",
         "@types/chai": "4.3.0",
@@ -46139,26 +46238,26 @@
       }
     },
     "packages/salesforcedx-vscode-expanded": {
-      "version": "54.12.0",
+      "version": "54.11.0",
       "license": "BSD-3-Clause",
       "engines": {
         "vscode": "^1.49.3"
       }
     },
     "packages/salesforcedx-vscode-lightning": {
-      "version": "54.12.0",
+      "version": "54.11.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/aura-language-server": "3.8.0",
         "@salesforce/core": "^2.35.0",
         "@salesforce/lightning-lsp-common": "3.8.0",
-        "@salesforce/salesforcedx-utils-vscode": "54.12.0",
+        "@salesforce/salesforcedx-utils-vscode": "54.11.0",
         "applicationinsights": "1.0.7",
         "vscode-extension-telemetry": "0.0.17",
         "vscode-languageclient": "^5.2.1"
       },
       "devDependencies": {
-        "@salesforce/salesforcedx-test-utils-vscode": "54.12.0",
+        "@salesforce/salesforcedx-test-utils-vscode": "54.11.0",
         "@types/chai": "4.3.0",
         "@types/mkdirp": "0.5.2",
         "@types/mocha": "^5",
@@ -46214,14 +46313,14 @@
       "dev": true
     },
     "packages/salesforcedx-vscode-lwc": {
-      "version": "54.12.0",
+      "version": "54.11.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/core": "^2.35.0",
         "@salesforce/eslint-config-lwc": "0.3.0",
         "@salesforce/lightning-lsp-common": "3.8.0",
         "@salesforce/lwc-language-server": "3.8.0",
-        "@salesforce/salesforcedx-utils-vscode": "54.12.0",
+        "@salesforce/salesforcedx-utils-vscode": "54.11.0",
         "ajv": "6.12.6",
         "applicationinsights": "1.0.7",
         "eslint": "5.0.0",
@@ -46234,7 +46333,7 @@
         "vscode-languageclient": "^5.2.1"
       },
       "devDependencies": {
-        "@salesforce/salesforcedx-test-utils-vscode": "54.12.0",
+        "@salesforce/salesforcedx-test-utils-vscode": "54.11.0",
         "@types/chai": "4.3.0",
         "@types/mkdirp": "0.5.2",
         "@types/mocha": "^5",
@@ -46579,7 +46678,7 @@
       }
     },
     "packages/salesforcedx-vscode-soql": {
-      "version": "54.12.0",
+      "version": "54.11.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/apex-tmlanguage": "1.6.0",
@@ -46592,9 +46691,9 @@
         "jsforce": "1.11.0"
       },
       "devDependencies": {
-        "@salesforce/salesforcedx-sobjects-faux-generator": "54.12.0",
-        "@salesforce/salesforcedx-test-utils-vscode": "54.12.0",
-        "@salesforce/salesforcedx-utils-vscode": "54.12.0",
+        "@salesforce/salesforcedx-sobjects-faux-generator": "54.11.0",
+        "@salesforce/salesforcedx-test-utils-vscode": "54.11.0",
+        "@salesforce/salesforcedx-utils-vscode": "54.11.0",
         "@salesforce/soql-common": "0.2.1",
         "@salesforce/ts-sinon": "1.3.21",
         "@salesforce/ts-types": "1.5.13",
@@ -47055,18 +47154,18 @@
       }
     },
     "packages/salesforcedx-vscode-visualforce": {
-      "version": "54.12.0",
+      "version": "54.11.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/salesforcedx-visualforce-language-server": "54.12.0",
-        "@salesforce/salesforcedx-visualforce-markup-language-server": "54.12.0",
+        "@salesforce/salesforcedx-visualforce-language-server": "54.11.0",
+        "@salesforce/salesforcedx-visualforce-markup-language-server": "54.11.0",
         "vscode-extension-telemetry": "0.0.17",
         "vscode-languageclient": "5.2.1",
         "vscode-languageserver-protocol": "3.14.1",
         "vscode-languageserver-types": "3.14.0"
       },
       "devDependencies": {
-        "@salesforce/salesforcedx-test-utils-vscode": "54.12.0",
+        "@salesforce/salesforcedx-test-utils-vscode": "54.11.0",
         "@types/chai": "4.3.0",
         "@types/mocha": "^5",
         "@types/node": "12.0.12",
@@ -47108,11 +47207,11 @@
       "integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A=="
     },
     "packages/system-tests": {
-      "version": "54.12.0",
+      "version": "54.11.0",
       "license": "BSD-3-Clause",
       "devDependencies": {
-        "@salesforce/salesforcedx-test-utils-vscode": "54.12.0",
-        "@salesforce/salesforcedx-utils-vscode": "54.12.0",
+        "@salesforce/salesforcedx-test-utils-vscode": "54.11.0",
+        "@salesforce/salesforcedx-utils-vscode": "54.11.0",
         "@types/chai": "4.3.0",
         "@types/mkdirp": "0.5.2",
         "@types/mocha": "^5",

--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -2,7 +2,7 @@
   "name": "@salesforce/salesforcedx-apex-debugger",
   "displayName": "Apex Debugger Adapter",
   "description": "Implements the VS Code Debug Protocol for the Apex Debugger",
-  "version": "54.12.0",
+  "version": "54.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -12,7 +12,7 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-utils-vscode": "54.12.0",
+    "@salesforce/salesforcedx-utils-vscode": "54.11.0",
     "async-lock": "1.0.0",
     "faye": "1.1.2",
     "request-light": "0.2.4",
@@ -20,7 +20,7 @@
     "vscode-debugprotocol": "1.28.0"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "54.12.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "54.11.0",
     "@types/async-lock": "0.0.20",
     "@types/chai": "4.3.0",
     "@types/mocha": "^5",

--- a/packages/salesforcedx-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-apex-replay-debugger/package.json
@@ -2,7 +2,7 @@
   "name": "@salesforce/salesforcedx-apex-replay-debugger",
   "displayName": "Apex Replay Debug Adapter",
   "description": "Implements the VS Code Debug Protocol for the Apex Replay Debugger",
-  "version": "54.12.0",
+  "version": "54.11.0",
   "publisher": "salesforce",
   "preview": true,
   "license": "BSD-3-Clause",
@@ -13,7 +13,7 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-utils-vscode": "54.12.0",
+    "@salesforce/salesforcedx-utils-vscode": "54.11.0",
     "vscode-debugadapter": "1.28.0",
     "vscode-debugprotocol": "1.28.0",
     "vscode-uri": "1.0.1"

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -2,7 +2,7 @@
   "name": "@salesforce/salesforcedx-sobjects-faux-generator",
   "displayName": "Salesforce SObject Faux Generator",
   "description": "Fetches sobjects and generates their faux apex class to be used for Apex Language Server",
-  "version": "54.12.0",
+  "version": "54.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {

--- a/packages/salesforcedx-test-utils-vscode/package.json
+++ b/packages/salesforcedx-test-utils-vscode/package.json
@@ -2,14 +2,14 @@
   "name": "@salesforce/salesforcedx-test-utils-vscode",
   "displayName": "SFDX Test Utilities for VS Code",
   "description": "Provides test utilities to interface the SFDX libraries with VS Code",
-  "version": "54.12.0",
+  "version": "54.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "categories": [
     "Other"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-utils-vscode": "54.12.0",
+    "@salesforce/salesforcedx-utils-vscode": "54.11.0",
     "shelljs": "0.8.5"
   },
   "devDependencies": {

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "SFDX Utilities for VS Code",
   "description": "Provides utilities to interface the SFDX libraries with VS Code",
   "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
-  "version": "54.12.0",
+  "version": "54.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "categories": [

--- a/packages/salesforcedx-visualforce-language-server/package.json
+++ b/packages/salesforcedx-visualforce-language-server/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@salesforce/salesforcedx-visualforce-language-server",
   "description": "Visualforce language server",
-  "version": "54.12.0",
+  "version": "54.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
     "vscode": "^1.49.3"
   },
   "dependencies": {
-    "@salesforce/salesforcedx-visualforce-markup-language-server": "54.12.0",
+    "@salesforce/salesforcedx-visualforce-markup-language-server": "54.11.0",
     "typescript": "3.8.3",
     "vscode-css-languageservice": "2.1.9",
     "vscode-languageserver": "5.2.1",

--- a/packages/salesforcedx-visualforce-markup-language-server/package.json
+++ b/packages/salesforcedx-visualforce-markup-language-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/salesforcedx-visualforce-markup-language-server",
   "description": "Language service for Visualforce Markup",
-  "version": "54.12.0",
+  "version": "54.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "54.12.0",
+  "version": "54.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -24,12 +24,12 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-apex-debugger": "54.12.0",
+    "@salesforce/salesforcedx-apex-debugger": "54.11.0",
     "vscode-debugprotocol": "1.28.0",
     "vscode-extension-telemetry": "0.0.17"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "54.12.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "54.11.0",
     "@types/chai": "4.3.0",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "54.12.0",
+  "version": "54.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -26,15 +26,15 @@
   "dependencies": {
     "@salesforce/apex-node": "0.10.0",
     "@salesforce/core": "^2.35.0",
-    "@salesforce/salesforcedx-apex-replay-debugger": "54.12.0",
-    "@salesforce/salesforcedx-utils-vscode": "54.12.0",
+    "@salesforce/salesforcedx-apex-replay-debugger": "54.11.0",
+    "@salesforce/salesforcedx-utils-vscode": "54.11.0",
     "async-lock": "1.0.0",
     "path-exists": "3.0.0",
     "request-light": "0.2.4",
     "vscode-extension-telemetry": "0.0.17"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "54.12.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "54.11.0",
     "@salesforce/ts-sinon": "1.3.21",
     "@types/async-lock": "0.0.20",
     "@types/chai": "4.3.0",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -15,7 +15,7 @@
     "theme": "light"
   },
   "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
-  "version": "54.12.0",
+  "version": "54.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -28,7 +28,7 @@
     "@salesforce/apex-node": "0.10.0",
     "@salesforce/apex-tmlanguage": "1.4.0",
     "@salesforce/core": "^2.35.0",
-    "@salesforce/salesforcedx-utils-vscode": "54.12.0",
+    "@salesforce/salesforcedx-utils-vscode": "54.11.0",
     "@salesforce/source-deploy-retrieve": "5.12.2",
     "expand-home-dir": "0.0.3",
     "find-java-home": "0.2.0",
@@ -38,7 +38,7 @@
     "vscode-languageclient": "5.1.1"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "54.12.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "54.11.0",
     "@salesforce/ts-sinon": "1.3.21",
     "@types/chai": "4.3.0",
     "@types/mkdirp": "0.5.2",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -15,7 +15,7 @@
     "theme": "light"
   },
   "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
-  "version": "54.12.0",
+  "version": "54.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -27,8 +27,8 @@
   "dependencies": {
     "@heroku/functions-core": "^0.3.0",
     "@salesforce/core": "^2.35.0",
-    "@salesforce/salesforcedx-sobjects-faux-generator": "54.12.0",
-    "@salesforce/salesforcedx-utils-vscode": "54.12.0",
+    "@salesforce/salesforcedx-sobjects-faux-generator": "54.11.0",
+    "@salesforce/salesforcedx-utils-vscode": "54.11.0",
     "@salesforce/schemas": "^1",
     "@salesforce/source-deploy-retrieve": "5.12.2",
     "@salesforce/templates": "^54.5.0",
@@ -42,7 +42,7 @@
     "shelljs": "0.8.5"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "54.12.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "54.11.0",
     "@salesforce/ts-sinon": "^1.0.0",
     "@types/adm-zip": "^0.4.31",
     "@types/chai": "4.3.0",

--- a/packages/salesforcedx-vscode-expanded/package.json
+++ b/packages/salesforcedx-vscode-expanded/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "54.12.0",
+  "version": "54.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -15,7 +15,7 @@
     "theme": "light"
   },
   "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
-  "version": "54.12.0",
+  "version": "54.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -28,13 +28,13 @@
     "@salesforce/aura-language-server": "3.8.0",
     "@salesforce/core": "^2.35.0",
     "@salesforce/lightning-lsp-common": "3.8.0",
-    "@salesforce/salesforcedx-utils-vscode": "54.12.0",
+    "@salesforce/salesforcedx-utils-vscode": "54.11.0",
     "applicationinsights": "1.0.7",
     "vscode-extension-telemetry": "0.0.17",
     "vscode-languageclient": "^5.2.1"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "54.12.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "54.11.0",
     "@types/chai": "4.3.0",
     "@types/mkdirp": "0.5.2",
     "@types/mocha": "^5",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -15,7 +15,7 @@
     "theme": "light"
   },
   "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
-  "version": "54.12.0",
+  "version": "54.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -29,7 +29,7 @@
     "@salesforce/eslint-config-lwc": "0.3.0",
     "@salesforce/lightning-lsp-common": "3.8.0",
     "@salesforce/lwc-language-server": "3.8.0",
-    "@salesforce/salesforcedx-utils-vscode": "54.12.0",
+    "@salesforce/salesforcedx-utils-vscode": "54.11.0",
     "ajv": "6.12.6",
     "applicationinsights": "1.0.7",
     "eslint": "5.0.0",
@@ -42,7 +42,7 @@
     "vscode-languageclient": "^5.2.1"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "54.12.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "54.11.0",
     "@types/chai": "4.3.0",
     "@types/mkdirp": "0.5.2",
     "@types/mocha": "^5",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/forcedotcom/salesforcedx-vscode"
   },
   "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
-  "version": "54.12.0",
+  "version": "54.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "icon": "images/VSCodeSoql.png",
@@ -42,9 +42,9 @@
     "jsforce": "1.11.0"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-sobjects-faux-generator": "54.12.0",
-    "@salesforce/salesforcedx-test-utils-vscode": "54.12.0",
-    "@salesforce/salesforcedx-utils-vscode": "54.12.0",
+    "@salesforce/salesforcedx-sobjects-faux-generator": "54.11.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "54.11.0",
+    "@salesforce/salesforcedx-utils-vscode": "54.11.0",
     "@salesforce/soql-common": "0.2.1",
     "@salesforce/ts-sinon": "1.3.21",
     "@salesforce/ts-types": "1.5.13",

--- a/packages/salesforcedx-vscode-visualforce/package.json
+++ b/packages/salesforcedx-vscode-visualforce/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "54.12.0",
+  "version": "54.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -24,15 +24,15 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-visualforce-language-server": "54.12.0",
-    "@salesforce/salesforcedx-visualforce-markup-language-server": "54.12.0",
+    "@salesforce/salesforcedx-visualforce-language-server": "54.11.0",
+    "@salesforce/salesforcedx-visualforce-markup-language-server": "54.11.0",
     "vscode-extension-telemetry": "0.0.17",
     "vscode-languageclient": "5.2.1",
     "vscode-languageserver-protocol": "3.14.1",
     "vscode-languageserver-types": "3.14.0"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "54.12.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "54.11.0",
     "@types/chai": "4.3.0",
     "@types/mocha": "^5",
     "@types/node": "12.0.12",

--- a/packages/salesforcedx-vscode/package.json
+++ b/packages/salesforcedx-vscode/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "54.12.0",
+  "version": "54.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {

--- a/packages/system-tests/package.json
+++ b/packages/system-tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "system-tests",
   "description": "System tests for Salesforce DX Extensions for VS Code",
-  "version": "54.12.0",
+  "version": "54.11.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "main": "./out/src",
@@ -9,8 +9,8 @@
     "vscode": "^1.49.3"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "54.12.0",
-    "@salesforce/salesforcedx-utils-vscode": "54.12.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "54.11.0",
+    "@salesforce/salesforcedx-utils-vscode": "54.11.0",
     "@types/chai": "4.3.0",
     "@types/mkdirp": "0.5.2",
     "@types/mocha": "^5",

--- a/scripts/change-log-generator-utils.js
+++ b/scripts/change-log-generator-utils.js
@@ -263,7 +263,7 @@ function filterPackageNames(packageHeaders) {
  */
 function generateKey(packageName, type, packagesToIgnore) {
   if (
-    typesToIgnore.some(typeToIgnore => type.startsWith(typeToIgnore)) ||
+    typesToIgnore.some(typeToIgnore => !type || type.startsWith(typeToIgnore)) ||
     packagesToIgnore.includes(packageName)
   ) {
     return '';


### PR DESCRIPTION
This reverts commit ff49172c0534bebcd9941929ff70eb3d340efe80.

### What does this PR do?
revert build commit for moving to version v54.12.0
Needed in order to verify build via circleci for release.
Update commit builder script for change log to account for bad commit messages. 


This will enable us to re-run the release script in circle to generate the next release branch and change log. 
