### PR TITLE
ci: revert dependabot max open PRs limit back to 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,9 +21,9 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-    open-pull-requests-limit: 100
+    open-pull-requests-limit: 10
     rebase-strategy: disabled
-  # Major version updates (not auto-merged)
+  # Major version updates (not to be auto-merged)
   - package-ecosystem: "npm"
     directory: "/" # Location of package manifests
     target-branch: "develop"


### PR DESCRIPTION
### What does this PR do?
- Reverts https://github.com/forcedotcom/salesforcedx-vscode/pull/3945
- Number of max open PRs by dependabot was increased for getting a figure of how many dependency updates have breaking code changes