### PR TITLE
chore: add package-lock.json change as a result of version bump to cut release script

### DIFF
--- a/scripts/create-release-branch.js
+++ b/scripts/create-release-branch.js
@@ -86,6 +86,9 @@ shell.exec(
 // Add all package.json version update changes
 shell.exec(`git add "**/package.json"`);
 
+// Add change to package lockfile that includes version bump
+shell.exec('git add package-lock.json');
+
 // Add change to lerna.json
 shell.exec('git add lerna.json');
 


### PR DESCRIPTION
### What does this PR do?
Add package-lock.json to cut release script. Required due to the addition of npm workspaces to the repo. 

### What issues does this PR fix or reference?
@W-11146084@

### Functionality Before
lock file was not included in commit pushed to develop

### Functionality After
lock file is included. 
