### PR TITLE
fix: allow for escaping lwc test create command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4605,16 +4605,15 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@lwc/engine": {
-      "version": "1.7.14",
-      "resolved": "https://registry.npmjs.org/@lwc/engine/-/engine-1.7.14.tgz",
-      "integrity": "sha512-MNql4Woh3A6x4Y2PJhQ8rRhmBX2ZvJ94wfnlKNIxMSDGijolilkey/cZtKGpefGl6URSV/JYoULofO1mCNgilQ==",
-      "deprecated": "Use @lwc/engine-dom instead"
+    "node_modules/@lwc/engine-dom": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@lwc/engine-dom/-/engine-dom-2.13.3.tgz",
+      "integrity": "sha512-f1GIJ5y1B6yfTvSF6p+zT/3aJAgxkVh0dGp6jTMAygXm6xcfHGpVsK9SXYXhpKdJUrkdGwJBzv7JjylThkqCYg=="
     },
     "node_modules/@lwc/errors": {
-      "version": "1.7.14",
-      "resolved": "https://registry.npmjs.org/@lwc/errors/-/errors-1.7.14.tgz",
-      "integrity": "sha512-jR3/DlmmOWcM3/AxqP93bjJiLaGtUHb6w1ftbtLBmgNvFg9Gl/wM3CYGi+HWb/SpU8B8BC1Q75AAClyy5SPtxw=="
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@lwc/errors/-/errors-2.13.3.tgz",
+      "integrity": "sha512-HmImrcMTg/l0CJbKjQ4ZUKsxt2l5L6perjJOZUkk/lVyAUSXInNWPGQEv9ZBwTPSTvdIOXcpT/2S+F1XwPSyMA=="
     },
     "node_modules/@lwc/eslint-plugin-lwc": {
       "version": "0.6.0",
@@ -4629,9 +4628,9 @@
       }
     },
     "node_modules/@lwc/shared": {
-      "version": "1.7.14",
-      "resolved": "https://registry.npmjs.org/@lwc/shared/-/shared-1.7.14.tgz",
-      "integrity": "sha512-Zo11Udd5DuZkqug0EWjWLxvbufa3jUmBggvvOT6uuw9kyRP7P2zdk+TsBf9WWLfNnhWM6uBhbIAjojcaBkt3hQ=="
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@lwc/shared/-/shared-2.13.3.tgz",
+      "integrity": "sha512-1AA0z+LFpxaLsufay+BpE8cIX1NJY2r5jp1kqro9hU9NG+iltDQ35bKG4uV3E/QcQ8f5Yme5lR3F1M69kExDrA=="
     },
     "node_modules/@lwc/style-compiler": {
       "version": "0.34.8",
@@ -4645,86 +4644,23 @@
       }
     },
     "node_modules/@lwc/template-compiler": {
-      "version": "1.7.14",
-      "resolved": "https://registry.npmjs.org/@lwc/template-compiler/-/template-compiler-1.7.14.tgz",
-      "integrity": "sha512-FjUGhSaGq9OcL1wj254753ZvEyPK4UzYz8jxS9UKOtm9MBJ56ivF7ABM819WntMAze/SI34mrQPN8RzFj8a7YA==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@lwc/template-compiler/-/template-compiler-2.13.3.tgz",
+      "integrity": "sha512-3wuMasZLiei2C1/wFzWav9KWUvs7wi+mSa7LbUlS+sZXbMtzXfbzLgGzzV0WDvaDquRLBsPrp/Fda/6mGnlFFA==",
       "dependencies": {
-        "@babel/generator": "~7.1.5",
-        "@babel/parser": "~7.1.5",
-        "@babel/template": "~7.1.2",
-        "@babel/traverse": "~7.1.5",
-        "@babel/types": "~7.1.5",
-        "@lwc/errors": "1.7.14",
-        "@lwc/shared": "1.7.14",
-        "acorn": "~8.0.1",
-        "esutils": "~2.0.3",
+        "@lwc/errors": "2.13.3",
+        "@lwc/shared": "2.13.3",
+        "acorn": "~8.7.1",
+        "astring": "~1.8.3",
+        "estree-walker": "~2.0.2",
         "he": "~1.2.0",
-        "parse5-with-errors": "4.0.3-beta1"
-      }
-    },
-    "node_modules/@lwc/template-compiler/node_modules/@babel/generator": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.6.tgz",
-      "integrity": "sha512-brwPBtVvdYdGxtenbQgfCdDPmtkmUBZPjUoK5SXJEBuHaA5BCubh9ly65fzXz7R6o5rA76Rs22ES8Z+HCc0YIQ==",
-      "dependencies": {
-        "@babel/types": "^7.1.6",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.17.10",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
-      }
-    },
-    "node_modules/@lwc/template-compiler/node_modules/@babel/parser": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.6.tgz",
-      "integrity": "sha512-dWP6LJm9nKT6ALaa+bnL247GHHMWir3vSlZ2+IHgHgktZQx0L3Uvq2uAWcuzIe+fujRsYWBW2q622C5UvGK9iQ==",
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@lwc/template-compiler/node_modules/@babel/template": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
-      "integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.1.2",
-        "@babel/types": "^7.1.2"
-      }
-    },
-    "node_modules/@lwc/template-compiler/node_modules/@babel/traverse": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.6.tgz",
-      "integrity": "sha512-CXedit6GpISz3sC2k2FsGCUpOhUqKdyL0lqNrImQojagnUMXf8hex4AxYFRuMkNGcvJX5QAFGzB5WJQmSv8SiQ==",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.1.6",
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.0.0",
-        "@babel/parser": "^7.1.6",
-        "@babel/types": "^7.1.6",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.10"
-      }
-    },
-    "node_modules/@lwc/template-compiler/node_modules/@babel/types": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.6.tgz",
-      "integrity": "sha512-DMiUzlY9DSjVsOylJssxLHSgj6tWM9PRFJOGW/RaOglVOK9nzTxoOMfTfRQXGUCUQ/HmlG2efwC+XqUEJ5ay4w==",
-      "dependencies": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.10",
-        "to-fast-properties": "^2.0.0"
+        "parse5": "~6.0.1"
       }
     },
     "node_modules/@lwc/template-compiler/node_modules/acorn": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.5.tgz",
-      "integrity": "sha512-v+DieK/HJkJOpFBETDJioequtc3PfxsWMaxIdIwujtF7FEV/MAyDQLlm6/zPvr7Mix07mLh6ccVwIsloceodlg==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4732,34 +4668,10 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/@lwc/template-compiler/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@lwc/template-compiler/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/@lwc/template-compiler/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+    "node_modules/@lwc/template-compiler/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
     "node_modules/@monorepo-utils/package-utils": {
       "version": "2.7.0",
@@ -5672,11 +5584,11 @@
       }
     },
     "node_modules/@salesforce/aura-language-server": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-3.8.0.tgz",
-      "integrity": "sha512-lR/wi/s9yB0u3TcuEJlIFOnZbc5ooZDyL4fgfIyDbYVfkyILCuBNstIUl5z0moXAJ6kqRXGUJNapbUccwyuE1Q==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-3.9.0.tgz",
+      "integrity": "sha512-vObJum7yZ50FuJ4Oguee+uxisfvz75nYEnpwHvRJmMAW/GUTIRUHhxw8D8iiavbaLBZQmLEP9CKD43w+em4rfg==",
       "dependencies": {
-        "@salesforce/lightning-lsp-common": "3.8.0",
+        "@salesforce/lightning-lsp-common": "3.9.0",
         "acorn": "^6.0.0",
         "acorn-loose": "^6.0.0",
         "acorn-walk": "^6.0.0",
@@ -5954,9 +5866,9 @@
       "integrity": "sha512-/ZiVwtVkmq2jWRRzgsC4SEy8m54gPaDc8e+jIfnIiR04iSeSRhYJxG+ktLSYVN2jMbVWA58HfEJSCx+73GcQCg=="
     },
     "node_modules/@salesforce/lightning-lsp-common": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-3.8.0.tgz",
-      "integrity": "sha512-viuCZkjTqw8bWkifjclIqJirQzPNEvams5Fm0PHtAB3OEgdNIW37C83NG7EXdDsYZWZcKcmDXlFjbEgf5D2riw==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-3.9.0.tgz",
+      "integrity": "sha512-mawaLz8kCvi5eX9gqYeeHsIyswZq5WRrMeszIL7ZvUlEBNFvxSajEKXrzaAns28QG7hv4Zc/bWY/czk+eKDzbQ==",
       "dependencies": {
         "decamelize": "^2.0.0",
         "deep-equal": "^1.0.1",
@@ -6001,17 +5913,17 @@
       "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
     },
     "node_modules/@salesforce/lwc-language-server": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-3.8.0.tgz",
-      "integrity": "sha512-C6Q+j4Qup/a2I11H0doNAfFt9xwsQXxIlEL954GwkQOhMCoZJ6QQoNqZOyHsNJiOj3m0rJOVNJT0rz9y/E8Jag==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-3.9.0.tgz",
+      "integrity": "sha512-dp9UqlOwlPTULan1/K9QNM7LA06H1HrsurAwzjAvd3QBPTbm74LxybeBa0Gmoue77jfLQpM1+kkzwFxi0u+2vg==",
       "dependencies": {
         "@lwc/compiler": "0.34.8",
-        "@lwc/engine": "1.7.14",
-        "@lwc/errors": "1.7.14",
-        "@lwc/template-compiler": "1.7.14",
+        "@lwc/engine-dom": "2.13.3",
+        "@lwc/errors": "2.13.3",
+        "@lwc/template-compiler": "2.13.3",
         "@salesforce/apex": "0.0.12",
         "@salesforce/label": "0.0.12",
-        "@salesforce/lightning-lsp-common": "3.8.0",
+        "@salesforce/lightning-lsp-common": "3.9.0",
         "@salesforce/resourceurl": "0.0.12",
         "@salesforce/schema": "0.0.12",
         "@salesforce/user": "0.0.12",
@@ -6363,9 +6275,9 @@
       }
     },
     "node_modules/@salesforce/templates": {
-      "version": "54.6.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-54.6.0.tgz",
-      "integrity": "sha512-zvVyKzgj/VCsiODh2ctnDbp9qV3K32g1JvNFfsatZpHd5VCruda27Pg1ecq7fiyT+cBqjTe4mrdwzl4995oIMQ==",
+      "version": "54.8.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-54.8.0.tgz",
+      "integrity": "sha512-pvrPiYP54aJGhxpUiySWE5l6bGS/f+Ww7iqThFA9gJxpR8TSDYGSk9+he6oULgkaSx4ASKIuwYXp30nLzP9fwg==",
       "dependencies": {
         "@salesforce/core": "^2.33.1",
         "got": "^11.8.2",
@@ -9280,6 +9192,14 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/astring": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.8.3.tgz",
+      "integrity": "sha512-sRpyiNrx2dEYIMmUXprS8nlpRg2Drs8m9ElX9vVEXaCB4XEAJhKfs7IcX0IwShjuOAjLR6wzIrgoptz1n19i1A==",
+      "bin": {
+        "astring": "bin/astring"
       }
     },
     "node_modules/async": {
@@ -15501,8 +15421,7 @@
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -29760,19 +29679,6 @@
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true
     },
-    "node_modules/parse5-with-errors": {
-      "version": "4.0.3-beta1",
-      "resolved": "https://registry.npmjs.org/parse5-with-errors/-/parse5-with-errors-4.0.3-beta1.tgz",
-      "integrity": "sha512-Y6IDQO1t0ZT0FuYJhoVh1W1+FS25EG1xBeQPtnX8gyQGcT4JvT3de7hCWHAOStdKW8/9cw9iS0WoFcIxjI8Ymg==",
-      "dependencies": {
-        "@types/node": "^6.0.46"
-      }
-    },
-    "node_modules/parse5-with-errors/node_modules/@types/node": {
-      "version": "6.14.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.13.tgz",
-      "integrity": "sha512-J1F0XJ/9zxlZel5ZlbeSuHW2OpabrUAqpFuC2sm2I3by8sERQ8+KCjNKUcq8QHuzpGMWiJpo9ZxeHrqrP2KzQw=="
-    },
     "node_modules/pascal-case": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
@@ -42321,7 +42227,7 @@
         "@salesforce/salesforcedx-utils-vscode": "54.14.0",
         "@salesforce/schemas": "^1",
         "@salesforce/source-deploy-retrieve": "5.12.2",
-        "@salesforce/templates": "^54.5.0",
+        "@salesforce/templates": "^54.8.0",
         "@salesforce/ts-types": "1.5.13",
         "adm-zip": "0.4.13",
         "applicationinsights": "1.0.7",
@@ -42383,9 +42289,9 @@
       "version": "54.14.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/aura-language-server": "3.8.0",
+        "@salesforce/aura-language-server": "3.9.0",
         "@salesforce/core": "^2.35.0",
-        "@salesforce/lightning-lsp-common": "3.8.0",
+        "@salesforce/lightning-lsp-common": "3.9.0",
         "@salesforce/salesforcedx-utils-vscode": "54.14.0",
         "applicationinsights": "1.0.7",
         "vscode-extension-telemetry": "0.0.17",
@@ -42453,8 +42359,8 @@
       "dependencies": {
         "@salesforce/core": "^2.35.0",
         "@salesforce/eslint-config-lwc": "0.3.0",
-        "@salesforce/lightning-lsp-common": "3.8.0",
-        "@salesforce/lwc-language-server": "3.8.0",
+        "@salesforce/lightning-lsp-common": "3.9.0",
+        "@salesforce/lwc-language-server": "3.9.0",
         "@salesforce/salesforcedx-utils-vscode": "54.14.0",
         "ajv": "6.12.6",
         "applicationinsights": "1.0.7",

--- a/packages/salesforcedx-vscode-core/src/commands/util/parameterGatherers.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/parameterGatherers.ts
@@ -201,10 +201,12 @@ export class SelectLwcComponentDir
         lwcNames,
         'parameter_gatherer_enter_lwc_name'
       );
-      const filePathToXml = namePathMap.get(chosenLwcName);
-      fileName = path.basename(filePathToXml, '.js-meta.xml');
-      // Path strategy expects a relative path to the output folder
-      outputdir = path.dirname(filePathToXml).replace(pathToPkg, packageDir);
+      if (chosenLwcName) {
+        const filePathToXml = namePathMap.get(chosenLwcName);
+        fileName = path.basename(filePathToXml, '.js-meta.xml');
+        // Path strategy expects a relative path to the output folder
+        outputdir = path.dirname(filePathToXml).replace(pathToPkg, packageDir);
+      }
     }
 
     return outputdir && fileName

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/parameterGatherers.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/parameterGatherers.test.ts
@@ -361,6 +361,46 @@ describe('Parameter Gatherers', () => {
         getLwcsStub.restore();
       }
     });
+
+    it('Should gracefully cancel if LWC is not selected', async () => {
+      const selector = new SelectLwcComponentDir();
+      const packageDirs = ['force-app'];
+      const filePath = path.join('force-app', 'main', 'default', 'lwc', 'test');
+      const component = SourceComponent.createVirtualComponent(
+        {
+          name: 'test',
+          type: registry.types.lightningcomponentbundle,
+          xml: path.join(filePath, 'test.js-meta.xml')
+        },
+        []
+      );
+      const mockComponents = new ComponentSet([component]);
+      const getPackageDirPathsStub = sinon.stub(
+        SfdxPackageDirectories,
+        'getPackageDirectoryPaths'
+      );
+      const getLwcsStub = sinon.stub(ComponentSet, 'fromSource');
+      getLwcsStub
+        .withArgs(path.join(getRootWorkspacePath(), packageDirs[0]))
+        .returns(mockComponents);
+      const showMenuStub = sinon.stub(selector, 'showMenu');
+      getPackageDirPathsStub.returns(packageDirs);
+      const dirChoice = packageDirs[0];
+      showMenuStub.onFirstCall().returns(dirChoice);
+      showMenuStub.onSecondCall().returns('');
+
+      const response = await selector.gather();
+      try {
+        //expect(showMenuStub.getCall(0).calledWith(packageDirs)).to.be.true;
+        expect(response).to.eql({
+          type: 'CANCEL'
+        });
+      } finally {
+        getPackageDirPathsStub.restore();
+        showMenuStub.restore();
+        getLwcsStub.restore();
+      }
+    });
   });
 
   describe('SimpleGatherer', () => {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/parameterGatherers.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/parameterGatherers.test.ts
@@ -391,7 +391,6 @@ describe('Parameter Gatherers', () => {
 
       const response = await selector.gather();
       try {
-        //expect(showMenuStub.getCall(0).calledWith(packageDirs)).to.be.true;
         expect(response).to.eql({
           type: 'CANCEL'
         });


### PR DESCRIPTION
### What does this PR do?
Fixed an issue where escaping from the 'Create Lightning Web Component Test' could generate an error.

### What issues does this PR fix or reference?
#3983 , @W-10915684@

### Functionality Before
When you run the command 'Create Lightning Web Component Test', select a directory, then exit out of selecting a component, you get a nasty error, shown in #3983.

### Functionality After
Escaping that command is quiet and error-message free, as it should be.
