### PR TITLE
feat: Ctrl+Space now re-trigger autocomplete within {} in HTML file

### DIFF
--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -25,9 +25,9 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/aura-language-server": "3.8.0",
+    "@salesforce/aura-language-server": "3.9.0",
     "@salesforce/core": "^2.35.0",
-    "@salesforce/lightning-lsp-common": "3.8.0",
+    "@salesforce/lightning-lsp-common": "3.9.0",
     "@salesforce/salesforcedx-utils-vscode": "54.13.0",
     "applicationinsights": "1.0.7",
     "vscode-extension-telemetry": "0.0.17",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "@salesforce/core": "^2.35.0",
     "@salesforce/eslint-config-lwc": "0.3.0",
-    "@salesforce/lightning-lsp-common": "3.8.0",
-    "@salesforce/lwc-language-server": "3.8.0",
+    "@salesforce/lightning-lsp-common": "3.9.0",
+    "@salesforce/lwc-language-server": "3.9.0",
     "@salesforce/salesforcedx-utils-vscode": "54.13.0",
     "ajv": "6.12.6",
     "applicationinsights": "1.0.7",


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
This PR reflects recent changes in lightning language server:

-  Ctrl + Space now re-trigger autocomplete within {}: [#496](https://github.com/forcedotcom/lightning-language-server/pull/496)
-  Updated `@lwc/engine` version, now it's called `@lwc/engine-dom` [#502](https://github.com/forcedotcom/lightning-language-server/pull/502)

### What issues does this PR fix or reference?
@W-1093050@

### Functionality Before
In HTML file, typing {} is the only way to trigger autocomplete for {}. 

### Functionality After
If you delete the content within {} or move your cursor away then move it back within {}, you can use Ctrl + Space to re-trigger the autocomplete. 
