### PR TITLE
feat: "SFDX: Rename Component" now guard user's input of new component name based on LWC/Aura naming rules 

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceRenameLightningComponent.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceRenameLightningComponent.ts
@@ -15,6 +15,7 @@ import * as vscode from 'vscode';
 import { OUTPUT_CHANNEL } from '../channels';
 import { nls } from '../messages';
 import { SfdxCommandlet, SfdxWorkspaceChecker } from './util';
+import { auraComponentInputGuard, lwcComponentInputGuard } from './util/inputGuard';
 
 const RENAME_LIGHTNING_COMPONENT_EXECUTOR = 'force_rename_lightning_component';
 const RENAME_INPUT_PLACEHOLDER = 'rename_component_input_placeholder';
@@ -41,8 +42,8 @@ export class RenameLwcComponentExecutor extends LibraryCommandletExecutor<Compon
     response: ContinueResponse<ComponentName>
     ): Promise<boolean> {
       const newComponentName = response.data.name?.trim();
-      // call the guard
       if (newComponentName && this.sourceFsPath) {
+        await inputGuard(this.sourceFsPath, newComponentName);
         await renameComponent(this.sourceFsPath, newComponentName);
         return true;
       }
@@ -84,19 +85,14 @@ export class GetComponentName
       : { type: 'CANCEL' };
   }
 }
-// guard input name, throw error message if it's not following the lwc naming convention
-function inputGuard(sourceFsPath: string, newName: string) {
-  //
-}
 
-// guard lwc component name
-function lwcGuard(newName: string) {
-
-}
-
-// guard aura component name
-function auraGuard(newName: string) {
-  //
+async function inputGuard(sourceFsPath: string, newName: string) {
+  const componentPath = await getComponentPath(sourceFsPath);
+  if (isLwcComponent(componentPath)) {
+    lwcComponentInputGuard(newName);
+  }else {
+    auraComponentInputGuard(newName);
+  }
 }
 
 async function renameComponent(sourceFsPath: string, newName: string) {

--- a/packages/salesforcedx-vscode-core/src/commands/forceRenameLightningComponent.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceRenameLightningComponent.ts
@@ -41,6 +41,7 @@ export class RenameLwcComponentExecutor extends LibraryCommandletExecutor<Compon
     response: ContinueResponse<ComponentName>
     ): Promise<boolean> {
       const newComponentName = response.data.name?.trim();
+      // call the guard
       if (newComponentName && this.sourceFsPath) {
         await renameComponent(this.sourceFsPath, newComponentName);
         return true;
@@ -82,6 +83,20 @@ export class GetComponentName
       ? { type: 'CONTINUE', data: { name: inputResult } }
       : { type: 'CANCEL' };
   }
+}
+// guard input name, throw error message if it's not following the lwc naming convention
+function inputGuard(sourceFsPath: string, newName: string) {
+  //
+}
+
+// guard lwc component name
+function lwcGuard(newName: string) {
+
+}
+
+// guard aura component name
+function auraGuard(newName: string) {
+  //
 }
 
 async function renameComponent(sourceFsPath: string, newName: string) {

--- a/packages/salesforcedx-vscode-core/src/commands/util/inputGuard.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/inputGuard.ts
@@ -1,0 +1,74 @@
+import { notificationService } from '@salesforce/salesforcedx-utils-vscode/out/src/commands';
+import { format } from 'util';
+import { nls } from '../../messages';
+
+const NOT_ALPHANUMERIC_OR_UNDERSCORE_ERROR = 'not_alphanumeric_or_underscore_error';
+const NOT_START_WITH_LOWERCASE_ERROR = 'not_start_with_lowercase_error';
+const HAS_WHITE_SPACE_ERROR = 'has_white_space_error';
+const END_WITH_UNDERSCORE_ERROR = 'end_with_underscore_error';
+const HAS_TWO_CONSECUTIVE_UNDERSCORES_ERROR = 'has_two_consecutive_underscores_error';
+const HAS_HYPHEN_ERROR = 'has_hyphen_error';
+
+// guard lwc component name
+export function lwcComponentInputGuard(newName: string) {
+  beginWithLowerCase(newName);
+  HasAlphanumericOrUnderscore(newName);
+  hasWhiteSpace(newName);
+  endWithUnderscore(newName);
+  hasConsecutiveUnderscores(newName);
+  hasHyphen(newName);
+}
+
+// guard aura component name
+export function auraComponentInputGuard(newName: string) {
+  //
+}
+
+function HasAlphanumericOrUnderscore(input: string) {
+  const invalidPattern = /\W/;
+  if (input.match(invalidPattern)) {
+    showErrorMessage(NOT_ALPHANUMERIC_OR_UNDERSCORE_ERROR);
+  }
+}
+
+function beginWithLowerCase(input: string) {
+  const firstChar = input.charAt(0);
+  if (!isLowerCase(firstChar)) {
+    showErrorMessage(NOT_START_WITH_LOWERCASE_ERROR);
+  }
+}
+
+function hasWhiteSpace(input: string) {
+  if (input.indexOf(' ') >= 0) {
+    showErrorMessage(HAS_WHITE_SPACE_ERROR);
+  }
+}
+
+function endWithUnderscore(input: string) {
+  const endChar = input.charAt(input.length - 1);
+  if (endChar === '_') {
+    showErrorMessage(END_WITH_UNDERSCORE_ERROR);
+  }
+}
+
+function hasConsecutiveUnderscores(input: string) {
+  if (input.indexOf('__') >= 0) {
+    showErrorMessage(HAS_TWO_CONSECUTIVE_UNDERSCORES_ERROR);
+  }
+}
+
+function hasHyphen(input: string) {
+  if (input.indexOf('-') >= 0) {
+    showErrorMessage(HAS_HYPHEN_ERROR);
+  }
+}
+
+function isLowerCase(str: string): boolean {
+  return str === str.toLowerCase() && str !== str.toUpperCase();
+}
+
+function showErrorMessage(message: string) {
+  const errorMessage = nls.localize(message);
+  notificationService.showErrorMessage(errorMessage);
+  throw new Error(format(errorMessage));
+}

--- a/packages/salesforcedx-vscode-core/src/commands/util/inputGuard.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/inputGuard.ts
@@ -4,24 +4,22 @@ import { nls } from '../../messages';
 
 const NOT_ALPHANUMERIC_OR_UNDERSCORE_ERROR = 'not_alphanumeric_or_underscore_error';
 const NOT_START_WITH_LOWERCASE_ERROR = 'not_start_with_lowercase_error';
-const HAS_WHITE_SPACE_ERROR = 'has_white_space_error';
 const END_WITH_UNDERSCORE_ERROR = 'end_with_underscore_error';
 const HAS_TWO_CONSECUTIVE_UNDERSCORES_ERROR = 'has_two_consecutive_underscores_error';
-const HAS_HYPHEN_ERROR = 'has_hyphen_error';
+const NOT_START_WITH_LETTER_ERROR = 'not_start_with_letter_error';
 
-// guard lwc component name
 export function lwcComponentInputGuard(newName: string) {
   beginWithLowerCase(newName);
   HasAlphanumericOrUnderscore(newName);
-  hasWhiteSpace(newName);
   endWithUnderscore(newName);
   hasConsecutiveUnderscores(newName);
-  hasHyphen(newName);
 }
 
-// guard aura component name
 export function auraComponentInputGuard(newName: string) {
-  //
+  beginWithLetter(newName);
+  HasAlphanumericOrUnderscore(newName);
+  endWithUnderscore(newName);
+  hasConsecutiveUnderscores(newName);
 }
 
 function HasAlphanumericOrUnderscore(input: string) {
@@ -38,9 +36,10 @@ function beginWithLowerCase(input: string) {
   }
 }
 
-function hasWhiteSpace(input: string) {
-  if (input.indexOf(' ') >= 0) {
-    showErrorMessage(HAS_WHITE_SPACE_ERROR);
+function beginWithLetter(input: string) {
+  const firstChar = input.charAt(0);
+  if (!isLetter(firstChar)) {
+    showErrorMessage(NOT_START_WITH_LETTER_ERROR);
   }
 }
 
@@ -57,18 +56,15 @@ function hasConsecutiveUnderscores(input: string) {
   }
 }
 
-function hasHyphen(input: string) {
-  if (input.indexOf('-') >= 0) {
-    showErrorMessage(HAS_HYPHEN_ERROR);
-  }
-}
-
 function isLowerCase(str: string): boolean {
   return str === str.toLowerCase() && str !== str.toUpperCase();
 }
 
+function isLetter(str: string): boolean {
+  return Boolean(str.match(/a-zA-Z]/));
+}
+
 function showErrorMessage(message: string) {
   const errorMessage = nls.localize(message);
-  notificationService.showErrorMessage(errorMessage);
   throw new Error(format(errorMessage));
 }

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -641,5 +641,11 @@ export const messages = {
     'Warning: References to the old name will not be updated. Update manually and redeploy once all changes have been made.',
   error_function_type: 'Unable to determine type of executing function.',
   error_unable_to_get_started_function:
-    'Unable to access the function in "{0}".'
+    'Unable to access the function in "{0}".',
+  not_alphanumeric_or_underscore_error: 'Component name must contain only alphanumeric or underscore characters',
+  not_start_with_lowercase_error: 'Component name must begin with a lowercase letter',
+  has_white_space_error: 'Component name can not include whitespace',
+  end_with_underscore_error: 'Component name can not end with an underscore',
+  has_two_consecutive_underscores_error: 'Component name can not contain two consecutive underscores',
+  has_hyphen_error: 'Component name can not contain a hyphen'
 };

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -644,8 +644,7 @@ export const messages = {
     'Unable to access the function in "{0}".',
   not_alphanumeric_or_underscore_error: 'Component name must contain only alphanumeric or underscore characters',
   not_start_with_lowercase_error: 'Component name must begin with a lowercase letter',
-  has_white_space_error: 'Component name can not include whitespace',
   end_with_underscore_error: 'Component name can not end with an underscore',
   has_two_consecutive_underscores_error: 'Component name can not contain two consecutive underscores',
-  has_hyphen_error: 'Component name can not contain a hyphen'
+  not_start_with_letter_error: 'Component name must begin with a letter'
 };


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Guard users' input of new component name for "SFDX: Rename Component" based on the LWC/Aura naming rules:
[1, LWC component naming rules](https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.create_components_folder) 
[2, Aura component naming rules](https://developer.salesforce.com/docs/atlas.en-us.lightning.meta/lightning/components_names.htm) 

### What issues does this PR fix or reference?
@W-10903314@, @W-10903346@

### Functionality Before
There is no restriction on new component name for "SFDX: Rename Component" command. 

### Functionality After

