### PR TITLE
chore: update jsforce to v2 in the package files

### DIFF
--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -10,8 +10,7 @@
   },
   "dependencies": {
     "@salesforce/core": "^3.13.0",
-    "@types/jsforce": "1.9.41",
-    "jsforce": "1.11.0",
+    "jsforce": "2.0.0-beta.9",
     "shelljs": "0.8.5"
   },
   "devDependencies": {

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -36,7 +36,7 @@
     "adm-zip": "0.4.13",
     "applicationinsights": "1.0.7",
     "glob": "^7.1.2",
-    "jsforce": "1.11.0",
+    "jsforce": "2.0.0-beta.9",
     "rxjs": "^5.4.1",
     "sanitize-filename": "^1.6.1",
     "shelljs": "0.8.5"

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -38,8 +38,7 @@
     "@salesforce/soql-data-view": "0.1.0",
     "@salesforce/soql-language-server": "0.7.1",
     "@salesforce/soql-model": "0.2.3",
-    "@types/jsforce": "1.9.41",
-    "jsforce": "1.11.0"
+    "jsforce": "2.0.0-beta.9"
   },
   "devDependencies": {
     "@salesforce/salesforcedx-sobjects-faux-generator": "54.12.0",


### PR DESCRIPTION
### What does this PR do?
update package.json file to jsforce 2.


TODOs: 
- will need to pull in salesforce-apex after the update [PR](https://github.com/forcedotcom/salesforcedx-apex/pull/286) has been merged. 
- Verify there are not JSForce calls that need to be updated. 
