### PR TITLE
chore: update create-release-branch script to use latest npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -514,6 +514,10 @@ jobs:
       - checkout
       - restore_dependency_cache
       - gh-config
+      - run:
+          name: 'Install latest npm'
+          shell: bash.exe
+          command: nvm install-latest-npm
       - install
       - run:
           name: Install Lerna


### PR DESCRIPTION
### What does this PR do?
Update the circleci config for the create-release-branch job to install and use the latest npm. 

### What issues does this PR fix or reference?
fix #4191

### Functionality Before
`npm install` fails with an E404 message due to the local workspaces not being in the package-lock.json file.  

### Functionality After
Running npm install will update the package-lock.json file. 
