### PR TITLE
fix: add additional context for scope of generate manifest command

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -303,7 +303,7 @@
         },
         {
           "command": "sfdx.create.manifest",
-          "when": "sfdx:project_opened"
+          "when": "resource =~ /force-app/ && sfdx:project_opened"
         },
         {
           "command": "sfdx.lightning.rename",


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Adds an additional when clause to specify where the generate manifest file command should appear.

### What issues does this PR fix or reference?
@W-10737780@

### Functionality Before
Selecting any file or folder in the project would allow you to generate a manifest file.

### Functionality After
The generate command now only appears in the package directory folder - ie. force-app directory.
