### PR TITLE
chore: bump lwc and lightning language servers to 3.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5584,11 +5584,11 @@
       }
     },
     "node_modules/@salesforce/aura-language-server": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-3.9.0.tgz",
-      "integrity": "sha512-vObJum7yZ50FuJ4Oguee+uxisfvz75nYEnpwHvRJmMAW/GUTIRUHhxw8D8iiavbaLBZQmLEP9CKD43w+em4rfg==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-3.10.0.tgz",
+      "integrity": "sha512-Q+Io3ghJplDx6kYstsrPHNDqLZGrA+47hEKrAOjC2Qn78jfrKKUGjRfDR8Y7lfMMLWE5yZw9fCNAABAGgMFmUw==",
       "dependencies": {
-        "@salesforce/lightning-lsp-common": "3.9.0",
+        "@salesforce/lightning-lsp-common": "3.10.0",
         "acorn": "^6.0.0",
         "acorn-loose": "^6.0.0",
         "acorn-walk": "^6.0.0",
@@ -5866,9 +5866,9 @@
       "integrity": "sha512-/ZiVwtVkmq2jWRRzgsC4SEy8m54gPaDc8e+jIfnIiR04iSeSRhYJxG+ktLSYVN2jMbVWA58HfEJSCx+73GcQCg=="
     },
     "node_modules/@salesforce/lightning-lsp-common": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-3.9.0.tgz",
-      "integrity": "sha512-mawaLz8kCvi5eX9gqYeeHsIyswZq5WRrMeszIL7ZvUlEBNFvxSajEKXrzaAns28QG7hv4Zc/bWY/czk+eKDzbQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-3.10.0.tgz",
+      "integrity": "sha512-p/GNA2hGvKujfIwNUDl4IAsqSgwF8GB2h31td2zYFdMZOUAsNbe/juSbafkkXyhCNSnjbrRDk24oXY0UcoTn7Q==",
       "dependencies": {
         "decamelize": "^2.0.0",
         "deep-equal": "^1.0.1",
@@ -5913,9 +5913,9 @@
       "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
     },
     "node_modules/@salesforce/lwc-language-server": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-3.9.0.tgz",
-      "integrity": "sha512-dp9UqlOwlPTULan1/K9QNM7LA06H1HrsurAwzjAvd3QBPTbm74LxybeBa0Gmoue77jfLQpM1+kkzwFxi0u+2vg==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-3.10.0.tgz",
+      "integrity": "sha512-evcCI9zA5ob613xIALzqDe/1hl8pTi+a0VnP5OaPeP5On2VwgdVr67aENqKUd9wDZvOOISK5KIDpKIH3Wmoe7A==",
       "dependencies": {
         "@lwc/compiler": "0.34.8",
         "@lwc/engine-dom": "2.13.3",
@@ -5923,7 +5923,7 @@
         "@lwc/template-compiler": "2.13.3",
         "@salesforce/apex": "0.0.12",
         "@salesforce/label": "0.0.12",
-        "@salesforce/lightning-lsp-common": "3.9.0",
+        "@salesforce/lightning-lsp-common": "3.10.0",
         "@salesforce/resourceurl": "0.0.12",
         "@salesforce/schema": "0.0.12",
         "@salesforce/user": "0.0.12",
@@ -43467,9 +43467,9 @@
       "version": "55.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/aura-language-server": "3.9.0",
+        "@salesforce/aura-language-server": "3.10.0",
         "@salesforce/core": "^2.35.0",
-        "@salesforce/lightning-lsp-common": "3.9.0",
+        "@salesforce/lightning-lsp-common": "3.10.0",
         "@salesforce/salesforcedx-utils-vscode": "55.1.0",
         "applicationinsights": "1.0.7",
         "vscode-extension-telemetry": "0.0.17",
@@ -43537,8 +43537,8 @@
       "dependencies": {
         "@salesforce/core": "^2.35.0",
         "@salesforce/eslint-config-lwc": "0.3.0",
-        "@salesforce/lightning-lsp-common": "3.9.0",
-        "@salesforce/lwc-language-server": "3.9.0",
+        "@salesforce/lightning-lsp-common": "3.10.0",
+        "@salesforce/lwc-language-server": "3.10.0",
         "@salesforce/salesforcedx-utils-vscode": "55.1.0",
         "ajv": "6.12.6",
         "applicationinsights": "1.0.7",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -25,9 +25,9 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/aura-language-server": "3.9.0",
+    "@salesforce/aura-language-server": "3.10.0",
     "@salesforce/core": "^2.35.0",
-    "@salesforce/lightning-lsp-common": "3.9.0",
+    "@salesforce/lightning-lsp-common": "3.10.0",
     "@salesforce/salesforcedx-utils-vscode": "55.1.0",
     "applicationinsights": "1.0.7",
     "vscode-extension-telemetry": "0.0.17",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "@salesforce/core": "^2.35.0",
     "@salesforce/eslint-config-lwc": "0.3.0",
-    "@salesforce/lightning-lsp-common": "3.9.0",
-    "@salesforce/lwc-language-server": "3.9.0",
+    "@salesforce/lightning-lsp-common": "3.10.0",
+    "@salesforce/lwc-language-server": "3.10.0",
     "@salesforce/salesforcedx-utils-vscode": "55.1.0",
     "ajv": "6.12.6",
     "applicationinsights": "1.0.7",


### PR DESCRIPTION
### What does this PR do?

* Bumps the version of lightning and lwc language servers to version 3.10.  The new version adds a wire adapter type for getProgramTemplates in the lightning/salesEnablementProgramApi package, and handles malformed tags quietly when components are not compiled correctly due to the outdated LWC Compiler.
