### PR TITLE
build: update the salesforcedx-schemas version to pick up the latest release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6136,9 +6136,9 @@
       "integrity": "sha512-RbZBlljl+LjMZtzFsLpE9LneX7uiWS35M0ecJGkEI6ACIV0sKH48PRbSANVko+FNyzzSkLCc2m6HvXnwiaQoTQ=="
     },
     "node_modules/@salesforce/schemas": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/schemas/-/schemas-1.1.0.tgz",
-      "integrity": "sha512-6D7DvE6nFxpLyyTnrOIbbAeCJw2r/EpinFAcMh6gU0gA/CGfSbwV/8uR3uHLYL2zCyCZLH8jJ4dZ3BzCMqc+Eg=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@salesforce/schemas/-/schemas-1.1.3.tgz",
+      "integrity": "sha512-XWohlOT2oQDqAJH00OXS3f2MGjkwZ6pr4emnnkHSQbg7UdGW0rvGpEnRKqBbDUfZ4K5YKSo9Gj216ZtaP3JLXg=="
     },
     "node_modules/@salesforce/soql-builder-ui": {
       "version": "0.2.0",


### PR DESCRIPTION
### What does this PR do?
Bumps salesforcedx-schemas to 1.1.3 -> https://github.com/forcedotcom/schemas/compare/v1.1.0...v1.1.3

### What issues does this PR fix or reference?
#4218

Functionality updated to use latest json for validation of sfdx json files
