### PR TITLE
fix: use regex to match sub-directories in when clause

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -215,7 +215,7 @@
         },
         {
           "command": "sfdx.force.apex.class.create",
-          "when": "explorerResourceIsFolder && resourceFilename == classes && sfdx:project_opened"
+          "when": "explorerResourceIsFolder && resourcePath =~ /classes/ && sfdx:project_opened"
         },
         {
           "command": "sfdx.force.folder.diff",


### PR DESCRIPTION
### What does this PR do?

This PR fixes the issue where the "Create Apex Class" option is not available in sub-directories of the `classes` directory when a user right-clicks on windows ( or control clicks on mac ).

### What issues does this PR fix or reference?
#https://github.com/forcedotcom/salesforcedx-vscode/issues/3572, @W-10288492@

### Functionality Before

https://user-images.githubusercontent.com/599418/174657434-e32a4636-8d60-4ff1-bc6a-153a3889be92.mov

### Functionality After

https://user-images.githubusercontent.com/599418/174658151-8ef486cd-9ee6-40c8-abd3-252b8ace425e.mov





