### PR TITLE
fix: fixed a bug pertaining to VS Code passing a stale file path after a file has been renamed

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/helpers/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/index.ts
@@ -5,7 +5,12 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export { isNullOrUndefined, extractJsonObject } from './utils';
+export {
+  isNullOrUndefined,
+  extractJsonObject,
+  flushFilePath,
+  flushFilePaths
+} from './utils';
 export {
   isAlphaNumString,
   isInteger,

--- a/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
@@ -35,9 +35,9 @@ export function flushFilePath(filePath: string): string {
 }
 
 export function flushFilePaths(filePaths: string[]): string[] {
-  for(let i=0; i<filePaths.length; i++) {
+  for (let i = 0; i < filePaths.length; i++) {
     filePaths[i] = flushFilePath(filePaths[i]);
-  };
+  }
 
   return filePaths;
 }

--- a/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
@@ -5,6 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import * as fs from 'fs';
+
 export function isNullOrUndefined(object: any): object is null | undefined {
   if (object === null || object === undefined) {
     return true;
@@ -14,11 +16,28 @@ export function isNullOrUndefined(object: any): object is null | undefined {
 }
 
 export function extractJsonObject(str: string): any {
-
   const jsonString = str.substring(
     str.indexOf('{'),
     str.lastIndexOf('}') + 1
   );
 
   return JSON.parse(jsonString);
+}
+
+// There's a bug in VS Code where, after a file has been renamed,
+// the URI that VS Code passes to the command is stale and is the
+// original URL.  See https://github.com/microsoft/vscode/issues/152993.
+//
+// To get around this, fs.realpathSync.native() is called to get the
+// URI with the actual file name.
+export function flushFilePath(filePath: string): string {
+  return fs.realpathSync.native(filePath);
+}
+
+export function flushFilePaths(filePaths: string[]): string[] {
+  for(let i=0; i<filePaths.length; i++) {
+    filePaths[i] = flushFilePath(filePaths[i]);
+  };
+
+  return filePaths;
 }

--- a/packages/salesforcedx-vscode-apex/src/commands/forceLaunchApexReplayDebuggerWithCurrentFile.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceLaunchApexReplayDebuggerWithCurrentFile.ts
@@ -19,6 +19,9 @@ import {
 import {
   notificationService
 } from '@salesforce/salesforcedx-utils-vscode/out/src/commands';
+import {
+  flushFilePath
+} from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import * as vscode from 'vscode';
 import { nls } from '../messages';
 import {
@@ -89,7 +92,10 @@ async function getApexTestClassName(sourceUri: vscode.Uri): Promise<string | und
   }
 
   await testOutlineProvider.refresh();
-  const testClassName = testOutlineProvider.getTestClassName(sourceUri);
+  let testClassName = testOutlineProvider.getTestClassName(sourceUri);
+  if (testClassName) {
+    testClassName = flushFilePath(testClassName);
+  }
 
   return testClassName;
 }

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceLaunchApexReplayDebuggerWithCurrentFile.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceLaunchApexReplayDebuggerWithCurrentFile.test.ts
@@ -7,6 +7,7 @@
 import { testSetup } from '@salesforce/core/lib/testSetup';
 import { SfdxCommandlet } from '@salesforce/salesforcedx-utils-vscode/out/src';
 import { notificationService } from '@salesforce/salesforcedx-utils-vscode/out/src/commands';
+import * as helpers from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import { expect } from 'chai';
 import { createSandbox, SinonSandbox } from 'sinon';
 import * as vscode from 'vscode';
@@ -138,6 +139,9 @@ describe('Force Launch Replay Debugger', () => {
       .returns(undefined);
 
     sb.stub(ApexTestOutlineProvider.prototype, 'getTestClassName')
+      .returns('foo.cls');
+
+    sb.stub(helpers, 'flushFilePath')
       .returns('foo.cls');
 
     sb.stub(SfdxCommandlet.prototype, 'run')

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDelete.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDelete.ts
@@ -11,6 +11,9 @@ import {
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import {
+  flushFilePath
+} from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
+import {
   CancelResponse,
   ContinueResponse,
   ParametersGatherer,
@@ -43,7 +46,7 @@ export class ManifestChecker implements PreconditionChecker {
   private explorerPath: string;
 
   public constructor(uri: vscode.Uri) {
-    this.explorerPath = uri.fsPath;
+    this.explorerPath = flushFilePath(uri.fsPath);
   }
 
   public check(): boolean {
@@ -70,7 +73,7 @@ export class ConfirmationAndSourcePathGatherer
   private readonly CANCEL = nls.localize('cancel_delete_source_button_text');
 
   public constructor(uri: vscode.Uri) {
-    this.explorerPath = uri.fsPath;
+    this.explorerPath = flushFilePath(uri.fsPath);
   }
 
   public async gather(): Promise<

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploySourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploySourcePath.ts
@@ -52,7 +52,7 @@ export class LibraryDeploySourcePathExecutor extends DeployExecutor<
 }
 
 export const forceSourceDeploySourcePaths = async (
-  sourceUri: vscode.Uri | vscode.Uri[] |undefined,
+  sourceUri: vscode.Uri | vscode.Uri[] | undefined,
   uris: vscode.Uri[] | undefined
 ) => {
   if (!sourceUri) {

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveSourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveSourcePath.ts
@@ -7,10 +7,10 @@
 import {
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
-import { PostconditionChecker } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import {
   CancelResponse,
-  ContinueResponse
+  ContinueResponse,
+  PostconditionChecker
 } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import { ComponentSet } from '@salesforce/source-deploy-retrieve';
 import * as vscode from 'vscode';

--- a/packages/salesforcedx-vscode-core/src/commands/util/libraryPathsGatherer.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/libraryPathsGatherer.ts
@@ -5,6 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {
+  flushFilePaths
+} from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
+import {
   ContinueResponse,
   ParametersGatherer
 } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
@@ -16,7 +19,9 @@ export class LibraryPathsGatherer implements ParametersGatherer<string[]> {
     this.uris = uris;
   }
   public async gather(): Promise<ContinueResponse<string[]>> {
-    const sourcePaths = this.uris.map(uri => uri.fsPath);
+    let sourcePaths = this.uris.map(uri => uri.fsPath);
+    sourcePaths = flushFilePaths(sourcePaths);
+
     return {
       type: 'CONTINUE',
       data: sourcePaths

--- a/packages/salesforcedx-vscode-core/src/commands/util/libraryPathsGatherer.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/libraryPathsGatherer.ts
@@ -27,7 +27,8 @@ export class LibraryPathsGatherer implements ParametersGatherer<string[]> {
     //   debugger;
     // }
 
-    let sourcePaths = this.uris.map(uri => uri.fsPath);
+    const sourcePaths = this.uris.map(uri => uri.fsPath);
+    // let sourcePaths = this.uris.map(uri => uri.fsPath);
     // sourcePaths = flushFilePaths(sourcePaths);
 
     return {

--- a/packages/salesforcedx-vscode-core/src/commands/util/libraryPathsGatherer.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/libraryPathsGatherer.ts
@@ -19,8 +19,16 @@ export class LibraryPathsGatherer implements ParametersGatherer<string[]> {
     this.uris = uris;
   }
   public async gather(): Promise<ContinueResponse<string[]>> {
+
+    // jab
+    // const sourcePaths0 = this.uris.map(uri => uri.fsPath);
+    // const sourcePaths1 = flushFilePaths(sourcePaths0);
+    // if(JSON.stringify(sourcePaths0) !== JSON.stringify(sourcePaths1)) {
+    //   debugger;
+    // }
+
     let sourcePaths = this.uris.map(uri => uri.fsPath);
-    sourcePaths = flushFilePaths(sourcePaths);
+    // sourcePaths = flushFilePaths(sourcePaths);
 
     return {
       type: 'CONTINUE',

--- a/packages/salesforcedx-vscode-core/src/commands/util/parameterGatherers.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/parameterGatherers.ts
@@ -5,6 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {
+  flushFilePath
+} from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
+import {
   CancelResponse,
   ContinueResponse,
   LocalComponent,
@@ -53,8 +56,9 @@ export class EmptyParametersGatherer implements ParametersGatherer<{}> {
 
 export class FilePathGatherer implements ParametersGatherer<string> {
   private filePath: string;
+
   public constructor(uri: vscode.Uri) {
-    this.filePath = uri.fsPath;
+    this.filePath = flushFilePath(uri.fsPath);
   }
 
   public async gather(): Promise<CancelResponse | ContinueResponse<string>> {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
@@ -138,22 +138,7 @@ describe('ConfirmationAndSourcePathGatherer', () => {
     expect(newPath, 'jab-fourth-test-on windows, and this XXX').to.equal('C:/Users/');
   });
 
-
-
   it('Should return Continue if the user chooses to proceed', async () => {
-
-    // 'C:\Users\';
-    const originalPath = 'C:\\Users\\';
-    const newPath = fs.realpathSync.native(originalPath);
-
-    // first test
-    expect(newPath, 'jab-first-test-on windows this XXX').to.equal(originalPath);
-
-    // second test
-    // expect(newPath, 'jab-second-test-on windows this XXX').to.equal(originalPath);
-
-
-
     informationMessageStub.returns(
       nls.localize('confirm_delete_source_button_text')
     );

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
@@ -117,25 +117,25 @@ describe('ConfirmationAndSourcePathGatherer', () => {
   });
 
   it('jab test1', async () => {
-    const originalPath = 'C:\\Users\\';
-    expect('C:\\Users\\', 'jab-first-test-on windows, and this XXX').to.equal(originalPath);
+    const originalPath = 'C:\\Users';
+    expect('C:\\Users', 'jab-first-test-on windows, and this XXX').to.equal(originalPath);
   });
 
   it('jab test2', async () => {
-    const originalPath = 'C:\\Users\\';
-    expect('C:/Users/', 'jab-second-test-on windows, and this XXX').to.equal(originalPath);
+    const originalPath = 'C:\\Users';
+    expect('C:/Users', 'jab-second-test-on windows, and this XXX').to.equal(originalPath);
   });
 
   it('jab test3', async () => {
-    const originalPath = 'C:\\Users\\';
+    const originalPath = 'C:\\Users';
     const newPath = fs.realpathSync.native(originalPath);
-    expect(newPath, 'jab-third-test-on windows, and this XXX').to.equal('C:\\Users\\');
+    expect(newPath, 'jab-third-test-on windows, and this XXX').to.equal('C:\\Users');
   });
 
   it('jab test4', async () => {
-    const originalPath = 'C:\\Users\\';
+    const originalPath = 'C:\\Users';
     const newPath = fs.realpathSync.native(originalPath);
-    expect(newPath, 'jab-fourth-test-on windows, and this XXX').to.equal('C:/Users/');
+    expect(newPath, 'jab-fourth-test-on windows, and this XXX').to.equal('C:/Users');
   });
 
   it('Should return Continue if the user chooses to proceed', async () => {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
@@ -53,24 +53,28 @@ describe('ManifestChecker', () => {
     );
     const manifestUri = { fsPath: manifestFilePath } as vscode.Uri;
 
-    sinon.stub(helpers, 'flushFilePath')
+    const flushFilePathStub = sinon.stub(helpers, 'flushFilePath')
       .returns(manifestFilePath);
 
     const checker = new ManifestChecker(manifestUri);
     const response = checker.check();
     expect(response).to.be.false;
+
+    flushFilePathStub.restore();
   });
 
   it('passes the check if the selected resource is not in the manifest directory', () => {
     const sourcePath = path.join(workspaceFolderPath, 'src', 'exampleFile.js');
     const sourceUri = { fsPath: sourcePath } as vscode.Uri;
 
-    sinon.stub(helpers, 'flushFilePath')
+    const flushFilePathStub = sinon.stub(helpers, 'flushFilePath')
       .returns(sourcePath);
 
     const checker = new ManifestChecker(sourceUri);
     const response = checker.check();
     expect(response).to.be.true;
+
+    flushFilePathStub.restore();
   });
 });
 
@@ -96,6 +100,9 @@ describe('ConfirmationAndSourcePathGatherer', () => {
       nls.localize('cancel_delete_source_button_text')
     );
 
+    sinon.stub(helpers, 'flushFilePath')
+      .returns(explorerPath);
+
     const gatherer = new ConfirmationAndSourcePathGatherer(explorerPath);
     const response = await gatherer.gather();
     expect(informationMessageStub.calledOnce).to.be.true;
@@ -106,6 +113,9 @@ describe('ConfirmationAndSourcePathGatherer', () => {
     informationMessageStub.returns(
       nls.localize('confirm_delete_source_button_text')
     );
+
+    sinon.stub(helpers, 'flushFilePath')
+      .returns(explorerPath);
 
     const gatherer = new ConfirmationAndSourcePathGatherer(explorerPath);
     const response = (await gatherer.gather()) as ContinueResponse<{

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
@@ -117,6 +117,19 @@ describe('ConfirmationAndSourcePathGatherer', () => {
   });
 
   it('Should return Continue if the user chooses to proceed', async () => {
+
+    // 'C:\Users\';
+    const originalPath = 'C:\\Users\\';
+    const newPath = fs.realpathSync.native(originalPath);
+
+    // first test
+    expect(newPath, 'jab-first-test-on windows this XXX').to.equal(originalPath);
+
+    // second test
+    // expect(newPath, 'jab-second-test-on windows this XXX').to.equal(originalPath);
+
+
+
     informationMessageStub.returns(
       nls.localize('confirm_delete_source_button_text')
     );
@@ -127,15 +140,6 @@ describe('ConfirmationAndSourcePathGatherer', () => {
     }>;
     expect(informationMessageStub.calledOnce).to.be.true;
     expect(response.type).to.equal('CONTINUE');
-
-    // 'C:\Users\';
-    const originalPath = 'C:\\Users\\';
-    const newPath = fs.realpathSync.native(originalPath);
-
-    // first test
-    expect(newPath, 'first test').to.equal(originalPath);
-
-
-    // expect(response.data).to.eql({ filePath: examplePath });
+    expect(response.data).to.eql({ filePath: examplePath });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
@@ -7,6 +7,7 @@
 import * as helpers from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import { expect } from 'chai';
+import * as fs from 'fs';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
@@ -126,8 +127,15 @@ describe('ConfirmationAndSourcePathGatherer', () => {
     }>;
     expect(informationMessageStub.calledOnce).to.be.true;
     expect(response.type).to.equal('CONTINUE');
-    expect(response.data).to.eql({ filePath: examplePath });
 
-    flushFilePathStub.restore();
+    // 'C:\Users\';
+    const originalPath = 'C:\\Users\\';
+    const newPath = fs.realpathSync.native(originalPath);
+
+    // first test
+    expect(newPath, 'first test').to.equal(originalPath);
+
+
+    // expect(response.data).to.eql({ filePath: examplePath });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
@@ -7,7 +7,6 @@
 import * as helpers from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import { expect } from 'chai';
-import * as fs from 'fs';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
@@ -115,28 +114,6 @@ describe('ConfirmationAndSourcePathGatherer', () => {
     expect(informationMessageStub.calledOnce).to.be.true;
     expect(response.type).to.equal('CANCEL');
   });
-
-  it('jab test1', async () => {
-    const originalPath = 'C:\\Users';
-    expect('C:\\Users', 'jab-first-test-on windows, and this XXX').to.equal(originalPath);
-  });
-
-  // it('jab test2', async () => {
-  //   const originalPath = 'C:\\Users';
-  //   expect('C:/Users', 'jab-second-test-on windows, and this XXX').to.equal(originalPath);
-  // });
-
-  it('jab test3', async () => {
-    const originalPath = 'C:\\Users';
-    const newPath = fs.realpathSync.native(originalPath);
-    expect(newPath, 'jab-third-test-on windows, and this XXX').to.equal('C:\\Users');
-  });
-
-  // it('jab test4', async () => {
-  //   const originalPath = 'C:\\Users';
-  //   const newPath = fs.realpathSync.native(originalPath);
-  //   expect(newPath, 'jab-fourth-test-on windows, and this XXX').to.equal('C:/Users');
-  // });
 
   it('Should return Continue if the user chooses to proceed', async () => {
     informationMessageStub.returns(

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
@@ -81,7 +81,7 @@ describe('ManifestChecker', () => {
 
 describe('ConfirmationAndSourcePathGatherer', () => {
   const examplePath = path.join('example', 'path');
-  const explorerPath = { fsPath: examplePath } as vscode.Uri;
+  const explorerPathUri = { fsPath: examplePath } as vscode.Uri;
 
   let informationMessageStub: sinon.SinonStub;
   let flushFilePathStub: sinon.SinonStub;
@@ -97,7 +97,7 @@ describe('ConfirmationAndSourcePathGatherer', () => {
       'flushFilePath'
     );
 
-    flushFilePathStub.returns(explorerPath);
+    flushFilePathStub.returns(examplePath);
   });
 
   afterEach(() => {
@@ -110,7 +110,7 @@ describe('ConfirmationAndSourcePathGatherer', () => {
       nls.localize('cancel_delete_source_button_text')
     );
 
-    const gatherer = new ConfirmationAndSourcePathGatherer(explorerPath);
+    const gatherer = new ConfirmationAndSourcePathGatherer(explorerPathUri);
     const response = await gatherer.gather();
     expect(informationMessageStub.calledOnce).to.be.true;
     expect(response.type).to.equal('CANCEL');
@@ -121,10 +121,10 @@ describe('ConfirmationAndSourcePathGatherer', () => {
     expect('C:\\Users', 'jab-first-test-on windows, and this XXX').to.equal(originalPath);
   });
 
-  it('jab test2', async () => {
-    const originalPath = 'C:\\Users';
-    expect('C:/Users', 'jab-second-test-on windows, and this XXX').to.equal(originalPath);
-  });
+  // it('jab test2', async () => {
+  //   const originalPath = 'C:\\Users';
+  //   expect('C:/Users', 'jab-second-test-on windows, and this XXX').to.equal(originalPath);
+  // });
 
   it('jab test3', async () => {
     const originalPath = 'C:\\Users';
@@ -132,23 +132,30 @@ describe('ConfirmationAndSourcePathGatherer', () => {
     expect(newPath, 'jab-third-test-on windows, and this XXX').to.equal('C:\\Users');
   });
 
-  it('jab test4', async () => {
-    const originalPath = 'C:\\Users';
-    const newPath = fs.realpathSync.native(originalPath);
-    expect(newPath, 'jab-fourth-test-on windows, and this XXX').to.equal('C:/Users');
-  });
+  // it('jab test4', async () => {
+  //   const originalPath = 'C:\\Users';
+  //   const newPath = fs.realpathSync.native(originalPath);
+  //   expect(newPath, 'jab-fourth-test-on windows, and this XXX').to.equal('C:/Users');
+  // });
 
   it('Should return Continue if the user chooses to proceed', async () => {
     informationMessageStub.returns(
       nls.localize('confirm_delete_source_button_text')
     );
 
-    const gatherer = new ConfirmationAndSourcePathGatherer(explorerPath);
+    const gatherer = new ConfirmationAndSourcePathGatherer(explorerPathUri);
     const response = (await gatherer.gather()) as ContinueResponse<{
       filePath: string;
     }>;
     expect(informationMessageStub.calledOnce).to.be.true;
     expect(response.type).to.equal('CONTINUE');
+
+    // jab
+    debugger;
+
     expect(response.data).to.eql({ filePath: examplePath });
+    //
+    // toEqual
+    // { filePath: examplePath }
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
@@ -83,25 +83,31 @@ describe('ConfirmationAndSourcePathGatherer', () => {
   const explorerPath = { fsPath: examplePath } as vscode.Uri;
 
   let informationMessageStub: sinon.SinonStub;
+  let flushFilePathStub: sinon.SinonStub;
 
   beforeEach(() => {
     informationMessageStub = sinon.stub(
       vscode.window,
       'showInformationMessage'
     );
+
+    flushFilePathStub = sinon.stub(
+      helpers,
+      'flushFilePath'
+    );
+
+    flushFilePathStub.returns(explorerPath);
   });
 
   afterEach(() => {
     informationMessageStub.restore();
+    flushFilePathStub.restore();
   });
 
   it('Should return cancel if the user cancels the command', async () => {
     informationMessageStub.returns(
       nls.localize('cancel_delete_source_button_text')
     );
-
-    sinon.stub(helpers, 'flushFilePath')
-      .returns(explorerPath);
 
     const gatherer = new ConfirmationAndSourcePathGatherer(explorerPath);
     const response = await gatherer.gather();
@@ -114,9 +120,6 @@ describe('ConfirmationAndSourcePathGatherer', () => {
       nls.localize('confirm_delete_source_button_text')
     );
 
-    sinon.stub(helpers, 'flushFilePath')
-      .returns(explorerPath);
-
     const gatherer = new ConfirmationAndSourcePathGatherer(explorerPath);
     const response = (await gatherer.gather()) as ContinueResponse<{
       filePath: string;
@@ -124,5 +127,7 @@ describe('ConfirmationAndSourcePathGatherer', () => {
     expect(informationMessageStub.calledOnce).to.be.true;
     expect(response.type).to.equal('CONTINUE');
     expect(response.data).to.eql({ filePath: examplePath });
+
+    flushFilePathStub.restore();
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
@@ -149,13 +149,6 @@ describe('ConfirmationAndSourcePathGatherer', () => {
     }>;
     expect(informationMessageStub.calledOnce).to.be.true;
     expect(response.type).to.equal('CONTINUE');
-
-    // jab
-    debugger;
-
     expect(response.data).to.eql({ filePath: examplePath });
-    //
-    // toEqual
-    // { filePath: examplePath }
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import * as helpers from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import { expect } from 'chai';
 import * as path from 'path';
@@ -51,6 +52,10 @@ describe('ManifestChecker', () => {
       'package.xml'
     );
     const manifestUri = { fsPath: manifestFilePath } as vscode.Uri;
+
+    sinon.stub(helpers, 'flushFilePath')
+      .returns(manifestFilePath);
+
     const checker = new ManifestChecker(manifestUri);
     const response = checker.check();
     expect(response).to.be.false;
@@ -59,6 +64,10 @@ describe('ManifestChecker', () => {
   it('passes the check if the selected resource is not in the manifest directory', () => {
     const sourcePath = path.join(workspaceFolderPath, 'src', 'exampleFile.js');
     const sourceUri = { fsPath: sourcePath } as vscode.Uri;
+
+    sinon.stub(helpers, 'flushFilePath')
+      .returns(sourcePath);
+
     const checker = new ManifestChecker(sourceUri);
     const response = checker.check();
     expect(response).to.be.true;

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
@@ -116,6 +116,30 @@ describe('ConfirmationAndSourcePathGatherer', () => {
     expect(response.type).to.equal('CANCEL');
   });
 
+  it('jab test1', async () => {
+    const originalPath = 'C:\\Users\\';
+    expect('C:\\Users\\', 'jab-first-test-on windows, and this XXX').to.equal(originalPath);
+  });
+
+  it('jab test2', async () => {
+    const originalPath = 'C:\\Users\\';
+    expect('C:/Users/', 'jab-second-test-on windows, and this XXX').to.equal(originalPath);
+  });
+
+  it('jab test3', async () => {
+    const originalPath = 'C:\\Users\\';
+    const newPath = fs.realpathSync.native(originalPath);
+    expect(newPath, 'jab-third-test-on windows, and this XXX').to.equal('C:\\Users\\');
+  });
+
+  it('jab test4', async () => {
+    const originalPath = 'C:\\Users\\';
+    const newPath = fs.realpathSync.native(originalPath);
+    expect(newPath, 'jab-fourth-test-on windows, and this XXX').to.equal('C:/Users/');
+  });
+
+
+
   it('Should return Continue if the user chooses to proceed', async () => {
 
     // 'C:\Users\';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDeploySourcePath.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDeploySourcePath.test.ts
@@ -245,7 +245,7 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
         .returns(true);
 
       sb.stub(helpers, 'flushFilePaths')
-        .returns(undefined);
+        .returns([undefined]);
 
       const getUriFromActiveEditorStub = sb
         .stub(forceSourceDeploySourcePath, 'getUriFromActiveEditor')

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDeploySourcePath.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDeploySourcePath.test.ts
@@ -7,6 +7,7 @@
 
 import { AuthInfo, Connection } from '@salesforce/core';
 import { MockTestOrgData, testSetup } from '@salesforce/core/lib/testSetup';
+import * as helpers from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types/index';
 import {
   ComponentSet,
@@ -146,9 +147,11 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
           type: 'CONTINUE',
           data: filePaths
         });
-      const isInPackageDirectoryStub = sb
-        .stub(SfdxPackageDirectories, 'isInPackageDirectory')
+      sb.stub(SfdxPackageDirectories, 'isInPackageDirectory')
         .returns(true);
+
+      sb.stub(helpers, 'flushFilePaths')
+        .returns([filePath1, filePath2, filePath3]);
 
       await forceSourceDeploySourcePath.forceSourceDeploySourcePaths(
         uris[0],
@@ -174,9 +177,12 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
           type: 'CONTINUE',
           data: filePaths
         });
-      const isInPackageDirectoryStub = sb
-        .stub(SfdxPackageDirectories, 'isInPackageDirectory')
+
+      sb.stub(SfdxPackageDirectories, 'isInPackageDirectory')
         .returns(true);
+
+      sb.stub(helpers, 'flushFilePaths')
+        .returns([filePath1]);
 
       await forceSourceDeploySourcePath.forceSourceDeploySourcePaths(
         uris[0],
@@ -202,9 +208,12 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
           type: 'CONTINUE',
           data: filePaths
         });
-      const isInPackageDirectoryStub = sb
-        .stub(SfdxPackageDirectories, 'isInPackageDirectory')
+
+      sb.stub(SfdxPackageDirectories, 'isInPackageDirectory')
         .returns(true);
+
+      sb.stub(helpers, 'flushFilePaths')
+        .returns([filePath1]);
 
       await forceSourceDeploySourcePath.forceSourceDeploySourcePaths(
         uris[0],
@@ -233,9 +242,11 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
           type: 'CONTINUE',
           data: filePaths
         });
-      const isInPackageDirectoryStub = sb
-        .stub(SfdxPackageDirectories, 'isInPackageDirectory')
+      sb.stub(SfdxPackageDirectories, 'isInPackageDirectory')
         .returns(true);
+
+      sb.stub(helpers, 'flushFilePaths')
+        .returns([filePath1]);
 
       const getUriFromActiveEditorStub = sb
         .stub(forceSourceDeploySourcePath, 'getUriFromActiveEditor')
@@ -268,9 +279,14 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
           type: 'CONTINUE',
           data: filePaths
         });
-      const isInPackageDirectoryStub = sb
-        .stub(SfdxPackageDirectories, 'isInPackageDirectory')
+      sb.stub(SfdxPackageDirectories, 'isInPackageDirectory')
         .returns(true);
+
+      sb.stub(helpers, 'flushFilePaths')
+        .returns([filePath1]);
+
+      sb.stub(forceSourceDeploySourcePath, 'getUriFromActiveEditor')
+        .returns(filePath1);
 
       await forceSourceDeploySourcePath.forceSourceDeploySourcePaths(
         sourceUri,

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDeploySourcePath.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDeploySourcePath.test.ts
@@ -151,7 +151,7 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
         .returns(true);
 
       sb.stub(helpers, 'flushFilePaths')
-        .returns([filePath1, filePath2, filePath3]);
+        .returns([uris[0].path, uris[1].path, uris[2].path]);
 
       await forceSourceDeploySourcePath.forceSourceDeploySourcePaths(
         uris[0],
@@ -182,7 +182,7 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
         .returns(true);
 
       sb.stub(helpers, 'flushFilePaths')
-        .returns([filePath1]);
+        .returns([uris[0].path]);
 
       await forceSourceDeploySourcePath.forceSourceDeploySourcePaths(
         uris[0],
@@ -213,7 +213,7 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
         .returns(true);
 
       sb.stub(helpers, 'flushFilePaths')
-        .returns([filePath1]);
+        .returns([uris[0].path]);
 
       await forceSourceDeploySourcePath.forceSourceDeploySourcePaths(
         uris[0],
@@ -236,8 +236,7 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
       const uris = undefined;
 
       const filePaths = [ filePath1 ];
-      const timestampConflictCheckerCheckStub = sb
-        .stub(TimestampConflictChecker.prototype, 'check')
+      sb.stub(TimestampConflictChecker.prototype, 'check')
         .returns({
           type: 'CONTINUE',
           data: filePaths
@@ -246,7 +245,7 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
         .returns(true);
 
       sb.stub(helpers, 'flushFilePaths')
-        .returns([filePath1]);
+        .returns(undefined);
 
       const getUriFromActiveEditorStub = sb
         .stub(forceSourceDeploySourcePath, 'getUriFromActiveEditor')
@@ -265,12 +264,12 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
 
       // When the push-or-deploy-on-save setting is on,
       // sourceUri is an array, and uris is undefined.
-      const sourceUri: vscode.Uri[] = [
+      const sourceUris: vscode.Uri[] = [
         vscode.Uri.file(filePath1)
       ];
       const uris = undefined;
 
-      const filePaths = sourceUri.map(uri => {
+      const filePaths = sourceUris.map(uri => {
         return uri.fsPath;
       });
       const timestampConflictCheckerCheckStub = sb
@@ -283,13 +282,13 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
         .returns(true);
 
       sb.stub(helpers, 'flushFilePaths')
-        .returns([filePath1]);
+        .returns([sourceUris[0].path]);
 
       sb.stub(forceSourceDeploySourcePath, 'getUriFromActiveEditor')
         .returns(filePath1);
 
       await forceSourceDeploySourcePath.forceSourceDeploySourcePaths(
-        sourceUri,
+        sourceUris,
         uris
       );
 

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDiff.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDiff.test.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import * as helpers from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import { SourceComponent } from '@salesforce/source-deploy-retrieve';
 import { expect } from 'chai';
 import * as path from 'path';
@@ -23,7 +24,6 @@ import {
 } from '../../../src/conflict/metadataCacheService';
 import { nls } from '../../../src/messages';
 import { notificationService } from '../../../src/notifications';
-import Sinon = require('sinon');
 import {
   FilePathGatherer,
   SfdxWorkspaceChecker
@@ -31,7 +31,7 @@ import {
 import { workspaceContext } from '../../../src/context';
 import { telemetryService } from '../../../src/telemetry';
 
-const sandbox = createSandbox();
+const sb = createSandbox();
 
 describe('Force Source Diff', () => {
   describe('Force Source File Diff', () => {
@@ -55,54 +55,54 @@ describe('Force Source Diff', () => {
     let telemetryServiceSendExceptionStub: SinonStub;
 
     beforeEach(() => {
-      workspaceContextUsernameStub = sandbox
+      workspaceContextUsernameStub = sb
         .stub(workspaceContext, 'username')
         .get(() => {
           return mockUsername;
         });
-      workspaceContextAliasStub = sandbox
+      workspaceContextAliasStub = sb
         .stub(workspaceContext, 'alias')
         .get(() => {
           return mockAlias;
         });
-      workspaceCheckerStub = sandbox.stub(
+      workspaceCheckerStub = sb.stub(
         SfdxWorkspaceChecker.prototype,
         'check'
       );
       workspaceCheckerStub.returns(true);
-      filePathGathererStub = sandbox.stub(FilePathGatherer.prototype, 'gather');
+      filePathGathererStub = sb.stub(FilePathGatherer.prototype, 'gather');
       filePathGathererStub.returns({ type: 'CONTINUE', data: mockFilePath });
-      operationStub = sandbox.stub(
+      operationStub = sb.stub(
         MetadataCacheService.prototype,
         'createRetrieveOperation'
       );
-      componentStub = sandbox.stub(
+      componentStub = sb.stub(
         MetadataCacheService.prototype,
         'getSourceComponents'
       );
-      processStub = sandbox.stub(
+      processStub = sb.stub(
         MetadataCacheService.prototype,
         'processResults'
       );
-      mockComponentWalkContentStub = sandbox.stub(
+      mockComponentWalkContentStub = sb.stub(
         SourceComponent.prototype,
         'walkContent'
       );
-      notificationStub = sandbox.stub(notificationService, 'showErrorMessage');
-      channelAppendLineStub = sandbox.stub(channelService, 'appendLine');
-      channelShowChannelOutputStub = sandbox.stub(
+      notificationStub = sb.stub(notificationService, 'showErrorMessage');
+      channelAppendLineStub = sb.stub(channelService, 'appendLine');
+      channelShowChannelOutputStub = sb.stub(
         channelService,
         'showChannelOutput'
       );
-      telemetryServiceSendExceptionStub = sandbox.stub(
+      telemetryServiceSendExceptionStub = sb.stub(
         telemetryService,
         'sendException'
       );
-      vscodeExecuteCommandStub = sandbox.stub(commands, 'executeCommand');
+      vscodeExecuteCommandStub = sb.stub(commands, 'executeCommand');
     });
 
     afterEach(() => {
-      sandbox.restore();
+      sb.restore();
     });
 
     it('Should execute VS Code diff command', async () => {
@@ -137,6 +137,9 @@ describe('Force Source Diff', () => {
       mockComponentWalkContentStub.returns([remoteFsPath]);
       processStub.returns(mockResult);
 
+      sb.stub(helpers, 'flushFilePath')
+        .returns(mockFilePath);
+
       await forceSourceDiff(Uri.file(mockFilePath));
 
       assert.calledOnce(vscodeExecuteCommandStub);
@@ -161,7 +164,7 @@ describe('Force Source Diff', () => {
           languageId: 'forcesourcemanifest'
         }
       };
-      sandbox.stub(vscode.window, 'activeTextEditor').get(() => {
+      sb.stub(vscode.window, 'activeTextEditor').get(() => {
         return mockActiveTextEditor;
       });
 

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDiff.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDiff.test.ts
@@ -15,6 +15,10 @@ import { commands, Uri } from 'vscode';
 import { channelService } from '../../../src/channels';
 import { forceSourceDiff } from '../../../src/commands';
 import * as conflictCommands from '../../../src/commands';
+import {
+  FilePathGatherer,
+  SfdxWorkspaceChecker
+} from '../../../src/commands/util';
 import * as differ from '../../../src/conflict/directoryDiffer';
 import {
   MetadataCacheResult,
@@ -22,13 +26,9 @@ import {
   MetadataContext,
   PathType
 } from '../../../src/conflict/metadataCacheService';
+import { workspaceContext } from '../../../src/context';
 import { nls } from '../../../src/messages';
 import { notificationService } from '../../../src/notifications';
-import {
-  FilePathGatherer,
-  SfdxWorkspaceChecker
-} from '../../../src/commands/util';
-import { workspaceContext } from '../../../src/context';
 import { telemetryService } from '../../../src/telemetry';
 
 const sb = createSandbox();

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveSourcePath.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveSourcePath.test.ts
@@ -135,7 +135,7 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
       });
 
       sb.stub(helpers, 'flushFilePaths')
-        .returns([filePath1, filePath2, filePath3]);
+        .returns([uris[0].path, uris[1].path, uris[2].path]);
 
       await forceSourceRetrieveSourcePath.forceSourceRetrieveSourcePaths(
         uris[0],
@@ -162,7 +162,7 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
       });
 
       sb.stub(helpers, 'flushFilePaths')
-        .returns([filePath1]);
+        .returns([uris[0].path]);
 
       await forceSourceRetrieveSourcePath.forceSourceRetrieveSourcePaths(
         uris[0],
@@ -189,7 +189,7 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
       });
 
       sb.stub(helpers, 'flushFilePaths')
-        .returns([filePath1]);
+        .returns([uris[0].path]);
 
       await forceSourceRetrieveSourcePath.forceSourceRetrieveSourcePaths(
         uris[0],
@@ -222,7 +222,7 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
         .returns(filePath1);
 
       sb.stub(helpers, 'flushFilePaths')
-        .returns([filePath1]);
+        .returns(undefined);
 
       await forceSourceRetrieveSourcePath.forceSourceRetrieveSourcePaths(
         sourceUri,

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveSourcePath.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveSourcePath.test.ts
@@ -7,6 +7,7 @@
 
 import { AuthInfo, Connection } from '@salesforce/core';
 import { MockTestOrgData, testSetup } from '@salesforce/core/lib/testSetup';
+import * as helpers from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import {
   CancelResponse,
   ContinueResponse
@@ -133,6 +134,9 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
         data: filePaths
       });
 
+      sb.stub(helpers, 'flushFilePaths')
+        .returns([filePath1, filePath2, filePath3]);
+
       await forceSourceRetrieveSourcePath.forceSourceRetrieveSourcePaths(
         uris[0],
         uris
@@ -156,6 +160,9 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
         type: 'CONTINUE',
         data: filePaths
       });
+
+      sb.stub(helpers, 'flushFilePaths')
+        .returns([filePath1]);
 
       await forceSourceRetrieveSourcePath.forceSourceRetrieveSourcePaths(
         uris[0],
@@ -181,6 +188,9 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
         data: filePaths
       });
 
+      sb.stub(helpers, 'flushFilePaths')
+        .returns([filePath1]);
+
       await forceSourceRetrieveSourcePath.forceSourceRetrieveSourcePaths(
         uris[0],
         undefined
@@ -202,13 +212,17 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
       const uris = undefined;
 
       const filePaths = [ filePath1 ];
-      const sourcePathCheckerCheckStub = sb.stub(
+      sb.stub(
         SourcePathChecker.prototype, 'check').returns({
         type: 'CONTINUE',
         data: filePaths
       });
 
-      const getUriFromActiveEditorStub = sb.stub(forceSourceRetrieveSourcePath, 'getUriFromActiveEditor').returns(filePath1);
+      const getUriFromActiveEditorStub = sb.stub(forceSourceRetrieveSourcePath, 'getUriFromActiveEditor')
+        .returns(filePath1);
+
+      sb.stub(helpers, 'flushFilePaths')
+        .returns([filePath1]);
 
       await forceSourceRetrieveSourcePath.forceSourceRetrieveSourcePaths(
         sourceUri,
@@ -225,6 +239,7 @@ describe('SourcePathChecker', () => {
   let sandboxStub: SinonSandbox;
   let appendLineSpy: SinonStub;
   let showErrorMessageSpy: SinonStub;
+
   beforeEach(() => {
     sandboxStub = createSandbox();
     workspacePath = getRootWorkspacePath();

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveSourcePath.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveSourcePath.test.ts
@@ -222,7 +222,7 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
         .returns(filePath1);
 
       sb.stub(helpers, 'flushFilePaths')
-        .returns(undefined);
+        .returns([undefined]);
 
       await forceSourceRetrieveSourcePath.forceSourceRetrieveSourcePaths(
         sourceUri,

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/functions/forceFunctionContainerStart.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/functions/forceFunctionContainerStart.test.ts
@@ -270,7 +270,6 @@ describe('Force Function Start Integration Tests.', () => {
       const mockStartTime = [1234, 5678];
       hrtimeStub.returns(mockStartTime);
 
-
       sb.stub(helpers, 'flushFilePath')
         .returns(srcUri.path);
 

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/functions/forceFunctionStop.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/functions/forceFunctionStop.test.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import * as library from '@heroku/functions-core';
+import * as helpers from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import * as path from 'path';
 import { assert, createSandbox, SinonSandbox, SinonStub } from 'sinon';
 import { Uri } from 'vscode';
@@ -18,7 +19,7 @@ import { telemetryService } from '../../../../src/telemetry';
 import { getRootWorkspacePath } from '../../../../src/util';
 
 describe('Force Function Stop Integration Tests', () => {
-  let sandbox: SinonSandbox;
+  let sb: SinonSandbox;
   const functionsBinaryStub: {
     [key: string]: SinonStub;
   } = {};
@@ -35,39 +36,40 @@ describe('Force Function Stop Integration Tests', () => {
     [key: string]: SinonStub;
   } = {};
   let hrtimeStub: SinonStub;
+
   beforeEach(() => {
-    sandbox = createSandbox();
-    functionsBinaryStub.cancel = sandbox.stub();
-    sandbox.stub(library, 'getFunctionsBinary').returns(functionsBinaryStub);
-    channelServiceStubs.appendLineStub = sandbox.stub(
+    sb = createSandbox();
+    functionsBinaryStub.cancel = sb.stub();
+    sb.stub(library, 'getFunctionsBinary').returns(functionsBinaryStub);
+    channelServiceStubs.appendLineStub = sb.stub(
       channelService,
       'appendLine'
     );
-    notificationServiceStubs.showSuccessfulExecutionStub = sandbox.stub(
+    notificationServiceStubs.showSuccessfulExecutionStub = sb.stub(
       notificationService,
       'showSuccessfulExecution'
     );
     notificationServiceStubs.showSuccessfulExecutionStub.returns(
       Promise.resolve()
     );
-    notificationServiceStubs.showWarningMessageStub = sandbox.stub(
+    notificationServiceStubs.showWarningMessageStub = sb.stub(
       notificationService,
       'showWarningMessage'
     );
-    telemetryServiceStubs.sendCommandEventStub = sandbox.stub(
+    telemetryServiceStubs.sendCommandEventStub = sb.stub(
       telemetryService,
       'sendCommandEvent'
     );
-    hrtimeStub = sandbox.stub(process, 'hrtime');
+    hrtimeStub = sb.stub(process, 'hrtime');
   });
 
   afterEach(() => {
-    sandbox.restore();
+    sb.restore();
   });
 
   it('Should stop function, show notification and send telemetry', async () => {
     const FUNCTION_LANGUAGE = 'node';
-    functionServiceStubs.getFunctionLanguage = sandbox.stub(
+    functionServiceStubs.getFunctionLanguage = sb.stub(
       FunctionService.prototype,
       'getFunctionLanguage'
     );
@@ -75,6 +77,9 @@ describe('Force Function Stop Integration Tests', () => {
     const srcUri = Uri.file(
       path.join(getRootWorkspacePath(), 'functions', 'demoJavaScriptFunction')
     );
+
+    sb.stub(helpers, 'flushFilePath')
+      .returns(srcUri.path);
 
     await forceFunctionContainerStartCommand(srcUri);
 
@@ -116,6 +121,9 @@ describe('Force Function Stop Integration Tests', () => {
     const srcUri = Uri.file(
       path.join(getRootWorkspacePath(), 'functions', 'demoJavaScriptFunction')
     );
+
+    sb.stub(helpers, 'flushFilePath')
+      .returns(srcUri.path);
 
     await forceFunctionContainerStartCommand(srcUri);
 

--- a/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcPreview.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcPreview.ts
@@ -17,6 +17,9 @@ import {
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import { notificationService } from '@salesforce/salesforcedx-utils-vscode/out/src/commands';
+import {
+  flushFilePath
+} from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -123,7 +126,7 @@ export async function forceLightningLwcPreview(sourceUri: vscode.Uri) {
     }
   }
 
-  const resourcePath = sourceUri.fsPath;
+  const resourcePath = flushFilePath(sourceUri.fsPath);
   if (!resourcePath) {
     const message = nls.localize(
       'force_lightning_lwc_preview_file_undefined',

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcPreview.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcPreview.test.ts
@@ -26,6 +26,11 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Subject } from 'rxjs/Subject';
 import * as sinon from 'sinon';
+
+// jab
+// import * as mocha from 'mocha';
+// import * as chai from 'chai';
+
 import { SinonSandbox, SinonStub } from 'sinon';
 import * as vscode from 'vscode';
 import URI from 'vscode-uri';
@@ -1103,6 +1108,30 @@ describe('forceLightningLwcPreview', () => {
       '-a',
       'browser'
     ]);
+
+    // jab
+    // debugger;
+    console.log('jab-test1');
+    // expect(1, 'jab-test2').to.equal(2);
+
+    // mocha.utils.
+    // chai.util.
+    // sinon.server.
+    // import * as sinon from 'sinon';
+    // import * as mocha from 'mocha';
+    // import * as chai from 'chai';
+
+    console.log('jab-test2');
+    const lhs = JSON.stringify(cmdWithFlagSpy.getCall(5).args);
+    console.log(lhs);
+
+    console.log('jab-test3');
+    const rhs = JSON.stringify([
+      '-d',
+      mockLwcFileDirectory
+    ]);
+    console.log(rhs);
+
     expect(cmdWithFlagSpy.getCall(5).args).to.have.same.members([
       '-d',
       mockLwcFileDirectory

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcPreview.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcPreview.test.ts
@@ -402,10 +402,9 @@ describe('forceLightningLwcPreview', () => {
     showQuickPickStub.resolves(desktopQuickPick);
 
     sb.stub(helpers, 'flushFilePath')
-      .returns(mockLwcFileDirectoryUri.path);
+      .returns(mockLwcFilePathUri.path);
 
     await forceLightningLwcPreview(mockLwcFilePathUri);
-
     sinon.assert.calledWith(
       devServiceStub.getComponentPreviewUrl,
       sinon.match('c/foo')
@@ -463,7 +462,7 @@ describe('forceLightningLwcPreview', () => {
     const commandletStub = sb.stub(SfdxCommandlet.prototype, 'run');
 
     sb.stub(helpers, 'flushFilePath')
-      .returns(mockLwcFileDirectoryUri.path);
+      .returns(mockLwcFilePathUri.path);
 
     await forceLightningLwcPreview(mockLwcFilePathUri);
 
@@ -496,7 +495,7 @@ describe('forceLightningLwcPreview', () => {
     const commandletStub = sb.stub(SfdxCommandlet.prototype, 'run');
 
     sb.stub(helpers, 'flushFilePath')
-      .returns(mockLwcFileDirectoryUri.path);
+      .returns(mockLwcFilePathUri.path);
 
     await forceLightningLwcPreview(mockLwcFilePathUri);
 
@@ -564,7 +563,7 @@ describe('forceLightningLwcPreview', () => {
     showQuickPickStub.resolves(desktopQuickPick);
 
     sb.stub(helpers, 'flushFilePath')
-      .returns(mockLwcFileDirectoryUri.path);
+      .returns(notLwcModulePathUri.path);
 
     await forceLightningLwcPreview(notLwcModulePathUri);
 
@@ -586,7 +585,7 @@ describe('forceLightningLwcPreview', () => {
     showQuickPickStub.resolves(desktopQuickPick);
 
     sb.stub(helpers, 'flushFilePath')
-      .returns(mockLwcFileDirectoryUri.path);
+      .returns(nonExistentPathUri.path);
 
     await forceLightningLwcPreview(nonExistentPathUri);
 
@@ -642,7 +641,7 @@ describe('forceLightningLwcPreview', () => {
     showInputBoxStub.resolves('');
 
     sb.stub(helpers, 'flushFilePath')
-      .returns(mockLwcFileDirectoryUri.path);
+      .returns(mockLwcFilePathUri.path);
 
     await forceLightningLwcPreview(mockLwcFilePathUri);
     mockExecution.stdoutSubject.next(androidSuccessString);
@@ -758,7 +757,7 @@ describe('forceLightningLwcPreview', () => {
     showInputBoxStub.resolves('test');
 
     sb.stub(helpers, 'flushFilePath')
-      .returns(mockLwcFileDirectoryUri.path);
+      .returns(notLwcModulePathUri.path);
 
     await forceLightningLwcPreview(notLwcModulePathUri);
 
@@ -784,7 +783,7 @@ describe('forceLightningLwcPreview', () => {
     showInputBoxStub.resolves(undefined);
 
     sb.stub(helpers, 'flushFilePath')
-      .returns(mockLwcFileDirectoryUri.path);
+      .returns(nonExistentPathUri.path);
 
     await forceLightningLwcPreview(nonExistentPathUri);
 
@@ -950,7 +949,7 @@ describe('forceLightningLwcPreview', () => {
     showInputBoxStub.resolves(undefined);
 
     sb.stub(helpers, 'flushFilePath')
-      .returns(mockLwcFilePath);
+      .returns(mockLwcFilePathUri.path);
 
     await forceLightningLwcPreview(mockLwcFilePathUri);
 
@@ -1147,7 +1146,7 @@ describe('forceLightningLwcPreview', () => {
     );
 
     sb.stub(helpers, 'flushFilePath')
-      .returns(mockLwcFileDirectory);
+      .returns(mockLwcFileDirectoryUri.path);
 
     await forceLightningLwcPreview(mockLwcFileDirectoryUri);
 


### PR DESCRIPTION
### What does this PR do?
There's a bug in VS Code, which Microsoft refuses to fix (see https://github.com/microsoft/vscode/issues/152993).  After a file has been renamed, if only the casing has changes (eg no characters added or removed) VS Code passes the stale path to commands.  This PR adds `flushFilePath()` and `flushFilePaths()` to fix this issue.


### What issues does this PR fix or reference?
#https://github.com/forcedotcom/salesforcedx-vscode/issues/3575, @W-10273785@

### Functionality Before
1. Rename an Apex class's file name (only changing the case of the filename), and rename it's metadata file
2. Open the file and change the name of the class to match
3. With the file open, right-click in the editor and select "SFDX : Deploy This Source to Org"
4. This results in an error in the output: "File name mismatch with class name"

### Functionality After
1-3: the same
4. This deployment succeeds 
