### PR TITLE
chore: update getting started java versions

### DIFF
--- a/docs/_articles/en/getting-started/install.md
+++ b/docs/_articles/en/getting-started/install.md
@@ -29,4 +29,4 @@ For information about installing Salesforce CLI, see the _[Salesforce DX Setup G
 
 ## Java Platform, Standard Edition Development Kit
 
-Some features in Salesforce Extensions for VS Code depend upon the Java Platform, Standard Edition Development Kit (JDK). You need to have either version 8 or version 11 of the JDK installed. See [Java Setup](./en/getting-started/java-setup) for details.
+Some features in Salesforce Extensions for VS Code depend upon the Java Platform, Standard Edition Development Kit (JDK). You need to have either version 8, 11, or 17 of the JDK installed. See [Java Setup](./en/getting-started/java-setup) for details.


### PR DESCRIPTION
### What does this PR do?
Noticed the java versions called out on the getting started doc are out of date.  Updated to include version 17. 

### What issues does this PR fix or reference?
N/A
