### PR TITLE
chore: Revert "fix: added flushFilePath() (#4240)"

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/helpers/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/index.ts
@@ -5,28 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export {
-  ensureDirectoryExists,
-  getTestResultsFolder,
-  getRelativeProjectPath,
-  fileExtensionsMatch
-} from './paths';
-
-export {
-  TraceFlags
-} from './traceFlags';
-
-export {
-  TraceFlagsRemover
-} from './traceFlagsRemover';
-
-export {
-  isNullOrUndefined,
-  extractJsonObject,
-  flushFilePath,
-  flushFilePaths
-} from './utils';
-
+export { isNullOrUndefined, extractJsonObject } from './utils';
 export {
   isAlphaNumString,
   isInteger,
@@ -34,3 +13,11 @@ export {
   isAlphaNumSpaceString,
   isRecordIdFormat
 } from './validations';
+export {
+  ensureDirectoryExists,
+  getTestResultsFolder,
+  getRelativeProjectPath,
+  fileExtensionsMatch
+} from './paths';
+export { TraceFlags } from './traceFlags';
+export { TraceFlagsRemover } from './traceFlagsRemover';

--- a/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
@@ -5,8 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import * as fs from 'fs';
-
 export function isNullOrUndefined(object: any): object is null | undefined {
   if (object === null || object === undefined) {
     return true;
@@ -16,32 +14,11 @@ export function isNullOrUndefined(object: any): object is null | undefined {
 }
 
 export function extractJsonObject(str: string): any {
+
   const jsonString = str.substring(
     str.indexOf('{'),
     str.lastIndexOf('}') + 1
   );
 
   return JSON.parse(jsonString);
-}
-
-// There's a bug in VS Code where, after a file has been renamed,
-// the URI that VS Code passes to the command is stale and is the
-// original URI.  See https://github.com/microsoft/vscode/issues/152993.
-//
-// To get around this, fs.realpathSync.native() is called to get the
-// URI with the actual file name.
-export function flushFilePath(filePath: string): string {
-  if (filePath === '') {
-    return filePath;
-  }
-
-  return fs.realpathSync.native(filePath);
-}
-
-export function flushFilePaths(filePaths: string[]): string[] {
-  for (let i = 0; i < filePaths.length; i++) {
-    filePaths[i] = flushFilePath(filePaths[i]);
-  }
-
-  return filePaths;
 }

--- a/packages/salesforcedx-utils-vscode/test/unit/helpers/utils.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/unit/helpers/utils.test.ts
@@ -7,16 +7,12 @@
  */
 
 import { expect } from 'chai';
-import * as fs from 'fs';
-import * as sinon from 'sinon';
-import {
-  extractJsonObject,
-  flushFilePath,
-  flushFilePaths
-} from '../../../src/helpers';
+import { extractJsonObject } from '../../../src/helpers';
 
-describe('extractJsonObject', () => {
+describe('getConfigSource', () => {
+
   it('should extract a JSON string from larger string and then return as an object', async () => {
+
     const exampleJsonString = JSON.stringify({ name: 'exampleName', error: 'exampleError' });
     const exampleString = `junk text <junk +text junk text ${exampleJsonString} junk text junk text junk text`;
 
@@ -24,71 +20,7 @@ describe('extractJsonObject', () => {
 
     expect(testParse.name).to.equal('exampleName');
     expect(testParse.error).to.equal('exampleError');
-  });
-});
 
-describe('flushFilePath', () => {
-  it('should call fs.realpathSync.native() to resolve a path', async () => {
-    const filePath = 'C:\\Users\\temp\\exampleFile.js';
-    const realpathSyncNativeStub = sinon.stub(
-      fs.realpathSync,
-      'native'
-    ).returns(filePath);
-
-    const result = flushFilePath(filePath);
-
-    expect(realpathSyncNativeStub.called).to.equal(true);
-    expect(realpathSyncNativeStub.calledOnce).to.equal(true);
-    expect(realpathSyncNativeStub.args[0][0]).to.equal(filePath);
-
-    realpathSyncNativeStub.restore();
   });
 
-  it('should return a path when a path is passed in', async () => {
-    const filePath = 'C:\\Users\\temp\\exampleFile.js';
-    const realpathSyncNativeStub = sinon.stub(
-      fs.realpathSync,
-      'native'
-    ).returns(filePath);
-
-    const result = flushFilePath(filePath);
-
-    expect(result).to.equal(filePath);
-
-    realpathSyncNativeStub.restore();
-  });
-
-  it('should return an empty string when an empty sting is passed in', async () => {
-    const filePath = 'C:\\Users\\temp\\exampleFile.js';
-    const realpathSyncNativeStub = sinon.stub(
-      fs.realpathSync,
-      'native'
-    ).returns('');
-
-    const result = flushFilePath(filePath);
-
-    expect(result).to.equal('');
-
-    realpathSyncNativeStub.restore();
-  });
-});
-
-describe('flushFilePaths', () => {
-  it('should return the same paths that are passed in', async () => {
-    const filePaths = [
-      'file.js',
-      'file.js',
-      'file.js'
-    ];
-    const realpathSyncNativeStub = sinon.stub(
-      fs.realpathSync,
-      'native'
-    ).returns(filePaths[0]);
-
-    const result = flushFilePaths(filePaths);
-
-    expect(result).to.equal(filePaths);
-
-    realpathSyncNativeStub.restore();
-  });
 });

--- a/packages/salesforcedx-vscode-apex/src/commands/forceLaunchApexReplayDebuggerWithCurrentFile.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceLaunchApexReplayDebuggerWithCurrentFile.ts
@@ -19,9 +19,6 @@ import {
 import {
   notificationService
 } from '@salesforce/salesforcedx-utils-vscode/out/src/commands';
-import {
-  flushFilePath
-} from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import * as vscode from 'vscode';
 import { nls } from '../messages';
 import {
@@ -92,13 +89,7 @@ async function getApexTestClassName(sourceUri: vscode.Uri): Promise<string | und
   }
 
   await testOutlineProvider.refresh();
-  let testClassName = testOutlineProvider.getTestClassName(sourceUri);
-  // This is a little bizarre.  Intellisense is reporting that getTestClassName() returns a string,
-  // but it actually it returns string | undefined.  Well, regardless, since flushFilePath() takes
-  // a string (and guards against empty strings) using the Non-null assertion operator
-  // (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html#non-null-assertion-operator)
-  // fixes the issue.
-  testClassName = flushFilePath(testClassName!);
+  const testClassName = testOutlineProvider.getTestClassName(sourceUri);
 
   return testClassName;
 }

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceLaunchApexReplayDebuggerWithCurrentFile.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceLaunchApexReplayDebuggerWithCurrentFile.test.ts
@@ -7,7 +7,6 @@
 import { testSetup } from '@salesforce/core/lib/testSetup';
 import { SfdxCommandlet } from '@salesforce/salesforcedx-utils-vscode/out/src';
 import { notificationService } from '@salesforce/salesforcedx-utils-vscode/out/src/commands';
-import * as helpers from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import { expect } from 'chai';
 import { createSandbox, SinonSandbox } from 'sinon';
 import * as vscode from 'vscode';
@@ -85,9 +84,6 @@ describe('Force Launch Replay Debugger', () => {
     sb.stub(ApexTestOutlineProvider.prototype, 'getTestClassName')
       .returns(undefined);
 
-    sb.stub(helpers, 'flushFilePath')
-      .returns(undefined);
-
     await forceLaunchApexReplayDebuggerWithCurrentFile();
 
     expect(showErrorMessageStub.called).to.equal(true);
@@ -146,9 +142,6 @@ describe('Force Launch Replay Debugger', () => {
 
     sb.stub(SfdxCommandlet.prototype, 'run')
       .returns(undefined);
-
-    sb.stub(helpers, 'flushFilePath')
-      .returns('foo.cls');
 
     const executeCommandSpy = sb.spy(vscode.commands, 'executeCommand');
 

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDelete.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDelete.ts
@@ -11,21 +11,19 @@ import {
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import {
-  flushFilePath
-} from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
-import {
   CancelResponse,
   ContinueResponse,
   ParametersGatherer,
   PreconditionChecker
 } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import * as vscode from 'vscode';
+import { SfdxCommandlet, SfdxCommandletExecutor } from './util/sfdxCommandlet';
+
 import { channelService } from '../channels';
 import { nls } from '../messages';
 import { notificationService } from '../notifications';
 import { telemetryService } from '../telemetry';
 import { getRootWorkspacePath, hasRootWorkspace } from '../util';
-import { SfdxCommandlet, SfdxCommandletExecutor } from './util/sfdxCommandlet';
 
 export class ForceSourceDeleteExecutor extends SfdxCommandletExecutor<{
   filePath: string;
@@ -45,7 +43,7 @@ export class ManifestChecker implements PreconditionChecker {
   private explorerPath: string;
 
   public constructor(uri: vscode.Uri) {
-    this.explorerPath = flushFilePath(uri.fsPath);
+    this.explorerPath = uri.fsPath;
   }
 
   public check(): boolean {
@@ -72,7 +70,7 @@ export class ConfirmationAndSourcePathGatherer
   private readonly CANCEL = nls.localize('cancel_delete_source_button_text');
 
   public constructor(uri: vscode.Uri) {
-    this.explorerPath = flushFilePath(uri.fsPath);
+    this.explorerPath = uri.fsPath;
   }
 
   public async gather(): Promise<

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploySourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploySourcePath.ts
@@ -52,7 +52,7 @@ export class LibraryDeploySourcePathExecutor extends DeployExecutor<
 }
 
 export const forceSourceDeploySourcePaths = async (
-  sourceUri: vscode.Uri | vscode.Uri[] | undefined,
+  sourceUri: vscode.Uri | vscode.Uri[] |undefined,
   uris: vscode.Uri[] | undefined
 ) => {
   if (!sourceUri) {

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveSourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveSourcePath.ts
@@ -7,10 +7,10 @@
 import {
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import { PostconditionChecker } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import {
   CancelResponse,
-  ContinueResponse,
-  PostconditionChecker
+  ContinueResponse
 } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import { ComponentSet } from '@salesforce/source-deploy-retrieve';
 import * as vscode from 'vscode';

--- a/packages/salesforcedx-vscode-core/src/commands/util/libraryPathsGatherer.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/libraryPathsGatherer.ts
@@ -5,9 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {
-  flushFilePaths
-} from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
-import {
   ContinueResponse,
   ParametersGatherer
 } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
@@ -15,18 +12,14 @@ import * as vscode from 'vscode';
 
 export class LibraryPathsGatherer implements ParametersGatherer<string[]> {
   private uris: vscode.Uri[];
-
   public constructor(uris: vscode.Uri[]) {
     this.uris = uris;
   }
-
   public async gather(): Promise<ContinueResponse<string[]>> {
     const sourcePaths = this.uris.map(uri => uri.fsPath);
-    const flushedSourcePaths = flushFilePaths(sourcePaths);
-
     return {
       type: 'CONTINUE',
-      data: flushedSourcePaths
+      data: sourcePaths
     };
   }
 }

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -13,7 +13,7 @@
  * decorations, e.g., $(x) uses the https://octicons.github.com/ and should not
  * be localized
  *
- * If omitted, we will assume _message.
+ * If ommitted, we will assume _message.
  */
 export const messages = {
   channel_name: 'Salesforce CLI',

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
@@ -4,7 +4,6 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import * as helpers from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import { expect } from 'chai';
 import * as path from 'path';
@@ -52,56 +51,35 @@ describe('ManifestChecker', () => {
       'package.xml'
     );
     const manifestUri = { fsPath: manifestFilePath } as vscode.Uri;
-
-    const flushFilePathStub = sinon.stub(helpers, 'flushFilePath')
-      .returns(manifestFilePath);
-
     const checker = new ManifestChecker(manifestUri);
     const response = checker.check();
     expect(response).to.be.false;
-
-    flushFilePathStub.restore();
   });
 
   it('passes the check if the selected resource is not in the manifest directory', () => {
     const sourcePath = path.join(workspaceFolderPath, 'src', 'exampleFile.js');
     const sourceUri = { fsPath: sourcePath } as vscode.Uri;
-
-    const flushFilePathStub = sinon.stub(helpers, 'flushFilePath')
-      .returns(sourcePath);
-
     const checker = new ManifestChecker(sourceUri);
     const response = checker.check();
     expect(response).to.be.true;
-
-    flushFilePathStub.restore();
   });
 });
 
 describe('ConfirmationAndSourcePathGatherer', () => {
   const examplePath = path.join('example', 'path');
-  const explorerPathUri = { fsPath: examplePath } as vscode.Uri;
+  const explorerPath = { fsPath: examplePath } as vscode.Uri;
 
   let informationMessageStub: sinon.SinonStub;
-  let flushFilePathStub: sinon.SinonStub;
 
   beforeEach(() => {
     informationMessageStub = sinon.stub(
       vscode.window,
       'showInformationMessage'
     );
-
-    flushFilePathStub = sinon.stub(
-      helpers,
-      'flushFilePath'
-    );
-
-    flushFilePathStub.returns(examplePath);
   });
 
   afterEach(() => {
     informationMessageStub.restore();
-    flushFilePathStub.restore();
   });
 
   it('Should return cancel if the user cancels the command', async () => {
@@ -109,7 +87,7 @@ describe('ConfirmationAndSourcePathGatherer', () => {
       nls.localize('cancel_delete_source_button_text')
     );
 
-    const gatherer = new ConfirmationAndSourcePathGatherer(explorerPathUri);
+    const gatherer = new ConfirmationAndSourcePathGatherer(explorerPath);
     const response = await gatherer.gather();
     expect(informationMessageStub.calledOnce).to.be.true;
     expect(response.type).to.equal('CANCEL');
@@ -120,7 +98,7 @@ describe('ConfirmationAndSourcePathGatherer', () => {
       nls.localize('confirm_delete_source_button_text')
     );
 
-    const gatherer = new ConfirmationAndSourcePathGatherer(explorerPathUri);
+    const gatherer = new ConfirmationAndSourcePathGatherer(explorerPath);
     const response = (await gatherer.gather()) as ContinueResponse<{
       filePath: string;
     }>;

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDeploySourcePath.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDeploySourcePath.test.ts
@@ -7,7 +7,6 @@
 
 import { AuthInfo, Connection } from '@salesforce/core';
 import { MockTestOrgData, testSetup } from '@salesforce/core/lib/testSetup';
-import * as helpers from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types/index';
 import {
   ComponentSet,
@@ -147,12 +146,9 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
           type: 'CONTINUE',
           data: filePaths
         });
-
-      sb.stub(SfdxPackageDirectories, 'isInPackageDirectory')
+      const isInPackageDirectoryStub = sb
+        .stub(SfdxPackageDirectories, 'isInPackageDirectory')
         .returns(true);
-
-      sb.stub(helpers, 'flushFilePaths')
-        .returns([path.sep + filePath1, path.sep + filePath2, path.sep + filePath3]);
 
       await forceSourceDeploySourcePath.forceSourceDeploySourcePaths(
         uris[0],
@@ -178,12 +174,9 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
           type: 'CONTINUE',
           data: filePaths
         });
-
-      sb.stub(SfdxPackageDirectories, 'isInPackageDirectory')
+      const isInPackageDirectoryStub = sb
+        .stub(SfdxPackageDirectories, 'isInPackageDirectory')
         .returns(true);
-
-      sb.stub(helpers, 'flushFilePaths')
-        .returns([path.sep + filePath1]);
 
       await forceSourceDeploySourcePath.forceSourceDeploySourcePaths(
         uris[0],
@@ -209,12 +202,9 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
           type: 'CONTINUE',
           data: filePaths
         });
-
-      sb.stub(SfdxPackageDirectories, 'isInPackageDirectory')
+      const isInPackageDirectoryStub = sb
+        .stub(SfdxPackageDirectories, 'isInPackageDirectory')
         .returns(true);
-
-      sb.stub(helpers, 'flushFilePaths')
-        .returns([path.sep + filePath1]);
 
       await forceSourceDeploySourcePath.forceSourceDeploySourcePaths(
         uris[0],
@@ -237,17 +227,15 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
       const uris = undefined;
 
       const filePaths = [ filePath1 ];
-      sb.stub(TimestampConflictChecker.prototype, 'check')
+      const timestampConflictCheckerCheckStub = sb
+        .stub(TimestampConflictChecker.prototype, 'check')
         .returns({
           type: 'CONTINUE',
           data: filePaths
         });
-
-      sb.stub(SfdxPackageDirectories, 'isInPackageDirectory')
+      const isInPackageDirectoryStub = sb
+        .stub(SfdxPackageDirectories, 'isInPackageDirectory')
         .returns(true);
-
-      sb.stub(helpers, 'flushFilePaths')
-        .returns([undefined]);
 
       const getUriFromActiveEditorStub = sb
         .stub(forceSourceDeploySourcePath, 'getUriFromActiveEditor')
@@ -266,12 +254,12 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
 
       // When the push-or-deploy-on-save setting is on,
       // sourceUri is an array, and uris is undefined.
-      const sourceUris: vscode.Uri[] = [
+      const sourceUri: vscode.Uri[] = [
         vscode.Uri.file(filePath1)
       ];
       const uris = undefined;
 
-      const filePaths = sourceUris.map(uri => {
+      const filePaths = sourceUri.map(uri => {
         return uri.fsPath;
       });
       const timestampConflictCheckerCheckStub = sb
@@ -280,15 +268,12 @@ describe('Force Source Deploy Using Sourcepath Option', () => {
           type: 'CONTINUE',
           data: filePaths
         });
-
-      sb.stub(SfdxPackageDirectories, 'isInPackageDirectory')
+      const isInPackageDirectoryStub = sb
+        .stub(SfdxPackageDirectories, 'isInPackageDirectory')
         .returns(true);
 
-      sb.stub(helpers, 'flushFilePaths')
-        .returns([path.sep + filePath1]);
-
       await forceSourceDeploySourcePath.forceSourceDeploySourcePaths(
-        sourceUris,
+        sourceUri,
         uris
       );
 

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveSourcePath.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveSourcePath.test.ts
@@ -7,7 +7,6 @@
 
 import { AuthInfo, Connection } from '@salesforce/core';
 import { MockTestOrgData, testSetup } from '@salesforce/core/lib/testSetup';
-import * as helpers from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import {
   CancelResponse,
   ContinueResponse
@@ -134,9 +133,6 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
         data: filePaths
       });
 
-      sb.stub(helpers, 'flushFilePaths')
-        .returns([path.sep + filePath1, path.sep + filePath2, path.sep + filePath3]);
-
       await forceSourceRetrieveSourcePath.forceSourceRetrieveSourcePaths(
         uris[0],
         uris
@@ -160,9 +156,6 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
         type: 'CONTINUE',
         data: filePaths
       });
-
-      sb.stub(helpers, 'flushFilePaths')
-        .returns([path.sep + filePath1]);
 
       await forceSourceRetrieveSourcePath.forceSourceRetrieveSourcePaths(
         uris[0],
@@ -188,9 +181,6 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
         data: filePaths
       });
 
-      sb.stub(helpers, 'flushFilePaths')
-        .returns([path.sep + filePath1]);
-
       await forceSourceRetrieveSourcePath.forceSourceRetrieveSourcePaths(
         uris[0],
         undefined
@@ -212,19 +202,13 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
       const uris = undefined;
 
       const filePaths = [ filePath1 ];
-      sb.stub(
+      const sourcePathCheckerCheckStub = sb.stub(
         SourcePathChecker.prototype, 'check').returns({
         type: 'CONTINUE',
         data: filePaths
       });
 
-      const getUriFromActiveEditorStub = sb.stub(
-        forceSourceRetrieveSourcePath,
-        'getUriFromActiveEditor'
-      ).returns(filePath1);
-
-      sb.stub(helpers, 'flushFilePaths')
-        .returns([undefined]);
+      const getUriFromActiveEditorStub = sb.stub(forceSourceRetrieveSourcePath, 'getUriFromActiveEditor').returns(filePath1);
 
       await forceSourceRetrieveSourcePath.forceSourceRetrieveSourcePaths(
         sourceUri,

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/functions/forceFunctionStart/ForceFunctionContainerStartExecutor.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/functions/forceFunctionStart/ForceFunctionContainerStartExecutor.test.ts
@@ -314,6 +314,10 @@ describe('ForceFunctionContainerStartExecutor unit tests', () => {
 
       assert.calledOnce(fakeDisposible.dispose);
       assert.calledTwice(localizeStub);
+      console.log('what are the args', {
+        args0: sendExceptionStub.getCalls()[0].args[0],
+        args1: sendExceptionStub.getCalls()[0].args[1]
+      });
       assert.calledWith(
         sendExceptionStub,
         'force_function_start_docker_plugin_not_installed_or_started',


### PR DESCRIPTION
### What does this PR do?
Issue reported for running deploy/retrieve on windows.  Suspect the change from PR #4240 so reverting to build and test on windows. 

### What issues does this PR fix or reference?
#4261

### Functionality Before
deploy fails on windows

### Functionality After
deploy succeeds on windows. 
