### PR TITLE
chore: fix dep issue in 55.4.1 patch publish flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5403,9 +5403,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
-      "integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA=="
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.8.0.tgz",
+      "integrity": "sha512-ydcKLs2KKcxlhpdWLzJxEBDEk/U5MUeqtqkXlrtAUXXFPs6vLl1PEGghFC/BbpleosB7iXs0Z4P2DGe7ZT5ZNg=="
     },
     "node_modules/@octokit/plugin-enterprise-rest": {
       "version": "6.0.1",
@@ -5535,11 +5535,11 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "6.34.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
-      "integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
+      "version": "6.39.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.39.0.tgz",
+      "integrity": "sha512-Mq4N9sOAYCitTsBtDdRVrBE80lIrMBhL9Jbrw0d+j96BAzlq4V+GLHFJbHokEsVvO/9tQupQdoFdgVYhD2C8UQ==",
       "dependencies": {
-        "@octokit/openapi-types": "^11.2.0"
+        "@octokit/openapi-types": "^12.7.0"
       }
     },
     "node_modules/@salesforce/apex": {
@@ -42243,6 +42243,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@heroku/functions-core": "^0.3.0",
+        "@octokit/plugin-paginate-rest": "2.21.1",
         "@salesforce/core": "^2.35.0",
         "@salesforce/salesforcedx-sobjects-faux-generator": "55.4.1",
         "@salesforce/salesforcedx-utils-vscode": "55.4.1",
@@ -42400,6 +42401,17 @@
         "@npmcli/promise-spawn": "^1.3.2",
         "node-gyp": "^8.2.0",
         "read-package-json-fast": "^2.0.1"
+      }
+    },
+    "packages/salesforcedx-vscode-core/node_modules/@octokit/plugin-paginate-rest": {
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.1.tgz",
+      "integrity": "sha512-NVNTK63yoTFp07GqISWK+uDfGH1CAPhQXS7LzsJBvaK5W+UlvG549pLZC55FK0FqANVl6q/9ra3SR5c97xF/sw==",
+      "dependencies": {
+        "@octokit/types": "^6.38.2"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=2"
       }
     },
     "packages/salesforcedx-vscode-core/node_modules/@salesforce/templates": {

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -39,7 +39,8 @@
     "jsforce": "1.11.0",
     "rxjs": "^5.4.1",
     "sanitize-filename": "^1.6.1",
-    "shelljs": "0.8.5"
+    "shelljs": "0.8.5",
+    "@octokit/plugin-paginate-rest": "2.21.1"
   },
   "devDependencies": {
     "@salesforce/salesforcedx-test-utils-vscode": "55.4.1",


### PR DESCRIPTION
### What does this PR do?
adds @octokit/plugin-paginate-rest@2.21.2 to the salesforcedx-vscode-core repo dependancies in order to avoid an issue that exists for 2.21.2.

### What issues does this PR fix or reference?
patch release
