### PR TITLE
chore: attempting to get org list working with core v3 updates

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/auth/forceAuthDevHub.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/auth/forceAuthDevHub.ts
@@ -20,16 +20,13 @@ import {
 
 import { getRootWorkspacePath } from '../../util';
 
-import { ConfigFile } from '@salesforce/core';
+import { ConfigFile, OrgConfigProperties } from '@salesforce/core';
 import { isNullOrUndefined } from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import { homedir } from 'os';
 import * as vscode from 'vscode';
 import { CLI } from '../../constants';
-import {
-  DEFAULT_DEV_HUB_USERNAME_KEY,
-  SFDX_CONFIG_FILE
-} from '../../constants';
+import { SFDX_CONFIG_FILE } from '../../constants';
 import { nls } from '../../messages';
 import { isDemoMode } from '../../modes/demo-mode';
 import { isSFDXContainerMode } from '../../util';
@@ -110,7 +107,7 @@ export class ForceAuthDevHubExecutor extends SfdxCommandletExecutor<{}> {
       filename: SFDX_CONFIG_FILE
     });
 
-    globalConfig.set(DEFAULT_DEV_HUB_USERNAME_KEY, newUsername);
+    globalConfig.set(OrgConfigProperties.TARGET_DEV_HUB, newUsername);
     await globalConfig.write();
   }
 }

--- a/packages/salesforcedx-vscode-core/src/constants.ts
+++ b/packages/salesforcedx-vscode-core/src/constants.ts
@@ -16,8 +16,6 @@ export const SFDX_CONFIG_DISABLE_TELEMETRY = 'disableTelemetry';
 export const ENV_SFDX_DISABLE_TELEMETRY = 'SFDX_DISABLE_TELEMETRY';
 export const SFDX_CLI_DOWNLOAD_LINK =
   'https://developer.salesforce.com/tools/sfdxcli';
-export const DEFAULT_USERNAME_KEY = 'target-org';
-export const DEFAULT_DEV_HUB_USERNAME_KEY = 'target-dev-hub';
 export const PKG_ID_PREFIX = '04t';
 
 export const TELEMETRY_GLOBAL_VALUE = 'sfdxTelemetryMessage';

--- a/packages/salesforcedx-vscode-core/src/constants.ts
+++ b/packages/salesforcedx-vscode-core/src/constants.ts
@@ -16,8 +16,8 @@ export const SFDX_CONFIG_DISABLE_TELEMETRY = 'disableTelemetry';
 export const ENV_SFDX_DISABLE_TELEMETRY = 'SFDX_DISABLE_TELEMETRY';
 export const SFDX_CLI_DOWNLOAD_LINK =
   'https://developer.salesforce.com/tools/sfdxcli';
-export const DEFAULT_USERNAME_KEY = 'defaultusername';
-export const DEFAULT_DEV_HUB_USERNAME_KEY = 'defaultdevhubusername';
+export const DEFAULT_USERNAME_KEY = 'target-org';
+export const DEFAULT_DEV_HUB_USERNAME_KEY = 'target-dev-hub';
 export const PKG_ID_PREFIX = '04t';
 
 export const TELEMETRY_GLOBAL_VALUE = 'sfdxTelemetryMessage';
@@ -30,7 +30,8 @@ export const BETA_DEPLOY_RETRIEVE = 'experimental.deployRetrieve';
 export const CONFLICT_DETECTION_ENABLED = 'detectConflictsAtSync';
 export const INTERNAL_DEVELOPMENT_FLAG = 'internal-development';
 export const PUSH_OR_DEPLOY_ON_SAVE_ENABLED = 'push-or-deploy-on-save.enabled';
-export const PUSH_OR_DEPLOY_ON_SAVE_OVERRIDE_CONFLICTS = 'push-or-deploy-on-save.overrideConflictsOnPush';
+export const PUSH_OR_DEPLOY_ON_SAVE_OVERRIDE_CONFLICTS =
+  'push-or-deploy-on-save.overrideConflictsOnPush';
 export const RETRIEVE_TEST_CODE_COVERAGE = 'retrieve-test-code-coverage';
 export const SFDX_CORE_CONFIGURATION_NAME = 'salesforcedx-vscode-core';
 export const SHOW_CLI_SUCCESS_INFO_MSG = 'show-cli-success-msg';

--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -43,7 +43,7 @@ export class OrgList implements vscode.Disposable {
   }
 
   public displayDefaultUsername(defaultUsernameorAlias?: string) {
-    if (!defaultUsernameorAlias) {
+    if (defaultUsernameorAlias) {
       this.statusBarItem.text = `$(plug) ${defaultUsernameorAlias}`;
     } else {
       this.statusBarItem.text = nls.localize('missing_default_org');

--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -54,25 +54,7 @@ export class OrgList implements vscode.Disposable {
     const authFilesArray = await AuthInfo.listAllAuthorizations().catch(
       err => null
     );
-
-    if (authFilesArray === null || authFilesArray.length === 0) {
-      return null;
-    }
-    const authInfoObjects: FileInfo[] = [];
-    for (const authFile of authFilesArray) {
-      try {
-        const filePath = path.join(
-          await ConfigFile.resolveRootFolder(true),
-          '.sf',
-          authFile.username
-        );
-        const fileData = readFileSync(filePath, 'utf8');
-        authInfoObjects.push(JSON.parse(fileData));
-      } catch (e) {
-        console.log(e);
-      }
-    }
-    return authInfoObjects;
+    return authFilesArray;
   }
 
   public async filterAuthInfo(authInfoObjects: FileInfo[]) {
@@ -107,7 +89,7 @@ export class OrgList implements vscode.Disposable {
         ? today >= new Date(authInfo.expirationDate)
         : false;
       let authListItem =
-        aliases.length > 0
+        aliases?.length > 0
           ? `${aliases} - ${authInfo.username}`
           : authInfo.username;
 

--- a/packages/salesforcedx-vscode-core/src/util/authInfo.ts
+++ b/packages/salesforcedx-vscode-core/src/util/authInfo.ts
@@ -4,7 +4,13 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { AuthInfo, Connection, StateAggregator } from '@salesforce/core';
+import {
+  AuthInfo,
+  ConfigAggregator,
+  Connection,
+  OrgConfigProperties,
+  StateAggregator
+} from '@salesforce/core';
 import * as vscode from 'vscode';
 import { channelService } from '../channels';
 import {
@@ -20,8 +26,9 @@ export class OrgAuthInfo {
     enableWarning: boolean
   ): Promise<string | undefined> {
     try {
-      const defaultUserName = await ConfigUtil.getConfigValue(
-        DEFAULT_USERNAME_KEY
+      const configAggregator = await ConfigAggregator.create();
+      const defaultUserName = configAggregator.getPropertyValue(
+        OrgConfigProperties.TARGET_ORG
       );
       if (defaultUserName === undefined) {
         displayMessage(

--- a/packages/salesforcedx-vscode-core/src/util/authInfo.ts
+++ b/packages/salesforcedx-vscode-core/src/util/authInfo.ts
@@ -13,10 +13,6 @@ import {
 } from '@salesforce/core';
 import * as vscode from 'vscode';
 import { channelService } from '../channels';
-import {
-  DEFAULT_DEV_HUB_USERNAME_KEY,
-  DEFAULT_USERNAME_KEY
-} from '../constants';
 import { nls } from '../messages';
 import { notificationService } from '../notifications';
 import { telemetryService } from '../telemetry';
@@ -39,7 +35,7 @@ export class OrgAuthInfo {
         return undefined;
       } else {
         const configSource = await ConfigUtil.getConfigSource(
-          DEFAULT_USERNAME_KEY
+          OrgConfigProperties.TARGET_ORG
         );
         if (configSource === ConfigSource.Global) {
           displayMessage(
@@ -69,7 +65,7 @@ export class OrgAuthInfo {
   ): Promise<string | undefined> {
     try {
       const defaultDevHubUserName = await ConfigUtil.getConfigValue(
-        DEFAULT_DEV_HUB_USERNAME_KEY,
+        OrgConfigProperties.TARGET_DEV_HUB,
         configSource
       );
       if (defaultDevHubUserName === undefined) {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/auth/forceAuthDevHub.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/auth/forceAuthDevHub.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { ConfigFile } from '@salesforce/core';
+import { ConfigFile, OrgConfigProperties } from '@salesforce/core';
 import { testSetup } from '@salesforce/core/lib/testSetup';
 import { expect } from 'chai';
 import { createSandbox, SinonSandbox, SinonSpy, SinonStub } from 'sinon';
@@ -15,7 +15,6 @@ import {
   ForceAuthDevHubDemoModeExecutor,
   ForceAuthDevHubExecutor
 } from '../../../../src/commands';
-import { DEFAULT_DEV_HUB_USERNAME_KEY } from '../../../../src/constants';
 import { nls } from '../../../../src/messages';
 import { ConfigSource, OrgAuthInfo } from '../../../../src/util';
 
@@ -112,7 +111,7 @@ describe('configureDefaultDevHubLocation on processExit of ForceAuthDevHubExecut
 
     expect(configCreateSpy.getCall(0).args[0].isGlobal).to.be.true;
     expect(
-      configSetStub.calledWith(DEFAULT_DEV_HUB_USERNAME_KEY, testUsername)
+      configSetStub.calledWith(OrgConfigProperties.TARGET_DEV_HUB, testUsername)
     ).to.equal(true);
     expect(configWriteStub.calledOnce).to.equal(true);
     expect(configSetStub.calledOnce).to.equal(true);

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/util/authInfo.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/util/authInfo.test.ts
@@ -138,8 +138,6 @@ describe('OrgAuthInfo', () => {
 
     it('should use default username/alias when invoked without argument', async () => {
       // Arrange
-      const configUtilStub = sandbox.stub(ConfigUtil, 'getConfigValue');
-      configUtilStub.returns(defaultUsername);
       sandbox
         .stub(OrgAuthInfo, 'getDefaultUsernameOrAlias')
         .returns(defaultUsername);
@@ -157,8 +155,6 @@ describe('OrgAuthInfo', () => {
       expect(
         connectionCreateStub.calledWith({ authInfo: fakeAuthInfo })
       ).to.equal(true);
-
-      configUtilStub.restore();
     });
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/util/authInfo.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/util/authInfo.test.ts
@@ -5,7 +5,12 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthInfo, Connection, StateAggregator } from '@salesforce/core';
+import {
+  AuthInfo,
+  Connection,
+  OrgConfigProperties,
+  StateAggregator
+} from '@salesforce/core';
 import { expect } from 'chai';
 import { createSandbox, SinonSandbox, SinonStub } from 'sinon';
 import * as vscode from 'vscode';
@@ -102,7 +107,6 @@ describe('OrgAuthInfo', () => {
 
   describe('getConnection', () => {
     const username = 'user@test.test';
-    const alias = 'TestOrg';
     const fakeAuthInfo = {
       authy: true
     };
@@ -132,11 +136,18 @@ describe('OrgAuthInfo', () => {
       ).to.equal(true);
     });
 
-    it('should use default username/alias when invoked without argument', async () => {
+    it.only('should use default username/alias when invoked without argument', async () => {
+      // Arrange
       const configUtilStub = sandbox.stub(ConfigUtil, 'getConfigValue');
       configUtilStub.returns(defaultUsername);
+      sandbox
+        .stub(OrgAuthInfo, 'getDefaultUsernameOrAlias')
+        .returns(defaultUsername);
 
+      // Act
       const connection = await OrgAuthInfo.getConnection();
+
+      // Assert
       expect(connection).to.equal(fakeConnection);
       expect(
         authinfoCreateStub.calledWith({

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/util/authInfo.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/util/authInfo.test.ts
@@ -136,7 +136,7 @@ describe('OrgAuthInfo', () => {
       ).to.equal(true);
     });
 
-    it.only('should use default username/alias when invoked without argument', async () => {
+    it('should use default username/alias when invoked without argument', async () => {
       // Arrange
       const configUtilStub = sandbox.stub(ConfigUtil, 'getConfigValue');
       configUtilStub.returns(defaultUsername);


### PR DESCRIPTION
VSCE will initialize successfully, and the org list should populate correctly in the command palette.    Still working on getting the set command to be handled correctly when switching default org or auth'ing an org.
