### PR TITLE
Add preference clear output channel

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/commands/channelService.ts
+++ b/packages/salesforcedx-utils-vscode/src/commands/channelService.ts
@@ -9,6 +9,7 @@ import stripAnsi from 'strip-ansi';
 import { OutputChannel, window } from 'vscode';
 import { CommandExecution } from '../cli';
 import { nls } from '../messages';
+import { SfdxSettingsService } from '../settings';
 
 export class ChannelService {
   private readonly channel: OutputChannel;
@@ -37,6 +38,9 @@ export class ChannelService {
   }
 
   public streamCommandStartStop(execution: CommandExecution) {
+    if (SfdxSettingsService.getEnableClearOutputBeforeEachCommand()) {
+        this.channel.clear();
+    }
     this.channel.append(nls.localize('channel_starting_message'));
     this.channel.appendLine(execution.command.toString());
     this.channel.appendLine('');
@@ -100,5 +104,9 @@ export class ChannelService {
 
   public appendLine(text: string) {
     this.channel.appendLine(text);
+  }
+
+  public clear() {
+    this.channel.clear();
   }
 }

--- a/packages/salesforcedx-utils-vscode/src/commands/channelService.ts
+++ b/packages/salesforcedx-utils-vscode/src/commands/channelService.ts
@@ -39,7 +39,7 @@ export class ChannelService {
 
   public streamCommandStartStop(execution: CommandExecution) {
     if (SfdxSettingsService.getEnableClearOutputBeforeEachCommand()) {
-        this.channel.clear();
+        this.clear();
     }
     this.channel.append(nls.localize('channel_starting_message'));
     this.channel.appendLine(execution.command.toString());

--- a/packages/salesforcedx-utils-vscode/src/commands/commandletExecutors.ts
+++ b/packages/salesforcedx-utils-vscode/src/commands/commandletExecutors.ts
@@ -14,6 +14,7 @@ import {
   TelemetryService
 } from '../index';
 import { nls } from '../messages';
+import { SfdxSettingsService } from '../settings';
 import { CommandletExecutor, ContinueResponse } from '../types';
 import { getRootWorkspacePath } from '../workspaces';
 import { ChannelService } from './channelService';
@@ -161,6 +162,9 @@ export abstract class LibraryCommandletExecutor<T>
     const startTime = process.hrtime();
     const channelService = new ChannelService(this.outputChannel);
     const telemetryService = TelemetryService.getInstance();
+    if (SfdxSettingsService.getEnableClearOutputBeforeEachCommand()) {
+      channelService.clear();
+    }
 
     channelService.showCommandWithTimestamp(
       `${nls.localize('channel_starting_message')}${this.executionName}\n`

--- a/packages/salesforcedx-utils-vscode/src/commands/notificationService.ts
+++ b/packages/salesforcedx-utils-vscode/src/commands/notificationService.ts
@@ -7,6 +7,7 @@
 import { Observable } from 'rxjs/Observable';
 import * as vscode from 'vscode';
 import { CommandExecution } from '../cli';
+import { SFDX_CORE_CONFIGURATION_NAME } from '../constants';
 import { nls } from '../messages';
 import { ChannelService } from './index';
 
@@ -112,7 +113,7 @@ export class NotificationService {
       executionName
     );
     const showCLISuccessMsg = vscode.workspace
-      .getConfiguration('salesforcedx-vscode-core')
+      .getConfiguration(SFDX_CORE_CONFIGURATION_NAME)
       .get<boolean>('show-cli-success-msg', true);
     if (showCLISuccessMsg) {
       const showButtonText = nls.localize('notification_show_button_text');
@@ -129,7 +130,7 @@ export class NotificationService {
           channelService.showChannelOutput();
         } else if (selection === showOnlyStatusBarButtonText) {
           await vscode.workspace
-            .getConfiguration('salesforcedx-vscode-core')
+            .getConfiguration(SFDX_CORE_CONFIGURATION_NAME)
             .update('show-cli-success-msg', false);
         }
       }

--- a/packages/salesforcedx-utils-vscode/src/commands/notificationService.ts
+++ b/packages/salesforcedx-utils-vscode/src/commands/notificationService.ts
@@ -112,7 +112,7 @@ export class NotificationService {
       'notification_successful_execution_text',
       executionName
     );
-    const coreConfigurationName = vscode.workspace.getConfiguration(SFDX_CORE_CONFIGURATION_NAME); 
+    const coreConfigurationName = vscode.workspace.getConfiguration(SFDX_CORE_CONFIGURATION_NAME);
     const showCLISuccessMsg = coreConfigurationName.get<boolean>('show-cli-success-msg', true);
     if (showCLISuccessMsg) {
       const showButtonText = nls.localize('notification_show_button_text');

--- a/packages/salesforcedx-utils-vscode/src/commands/notificationService.ts
+++ b/packages/salesforcedx-utils-vscode/src/commands/notificationService.ts
@@ -112,9 +112,8 @@ export class NotificationService {
       'notification_successful_execution_text',
       executionName
     );
-    const showCLISuccessMsg = vscode.workspace
-      .getConfiguration(SFDX_CORE_CONFIGURATION_NAME)
-      .get<boolean>('show-cli-success-msg', true);
+    const coreConfigurationName = vscode.workspace.getConfiguration(SFDX_CORE_CONFIGURATION_NAME); 
+    const showCLISuccessMsg = coreConfigurationName.get<boolean>('show-cli-success-msg', true);
     if (showCLISuccessMsg) {
       const showButtonText = nls.localize('notification_show_button_text');
       const showOnlyStatusBarButtonText = nls.localize(
@@ -129,9 +128,7 @@ export class NotificationService {
         if (selection === showButtonText && channelService) {
           channelService.showChannelOutput();
         } else if (selection === showOnlyStatusBarButtonText) {
-          await vscode.workspace
-            .getConfiguration(SFDX_CORE_CONFIGURATION_NAME)
-            .update('show-cli-success-msg', false);
+          await coreConfigurationName.update('show-cli-success-msg', false);
         }
       }
     } else {

--- a/packages/salesforcedx-utils-vscode/src/commands/sfdxCommandlet.ts
+++ b/packages/salesforcedx-utils-vscode/src/commands/sfdxCommandlet.ts
@@ -38,9 +38,6 @@ export class SfdxCommandlet<T> {
   }
 
   public async run(): Promise<void> {
-    if (SfdxSettingsService.getEnableClearOutputBeforeEachCommand()) {
-      // channelService.clear();
-    }
     if (await this.prechecker.check()) {
       let inputs = await this.gatherer.gather();
       inputs = await this.postchecker.check(inputs);

--- a/packages/salesforcedx-utils-vscode/src/commands/sfdxCommandlet.ts
+++ b/packages/salesforcedx-utils-vscode/src/commands/sfdxCommandlet.ts
@@ -5,7 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import * as vscode from 'vscode';
-import { SfdxSettingsService } from '../settings';
 import {
   CommandletExecutor,
   ParametersGatherer,

--- a/packages/salesforcedx-utils-vscode/src/commands/sfdxCommandlet.ts
+++ b/packages/salesforcedx-utils-vscode/src/commands/sfdxCommandlet.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import * as vscode from 'vscode';
+import { SfdxSettingsService } from '../settings';
 import {
   CommandletExecutor,
   ParametersGatherer,
@@ -37,6 +38,9 @@ export class SfdxCommandlet<T> {
   }
 
   public async run(): Promise<void> {
+    if (SfdxSettingsService.getEnableClearOutputBeforeEachCommand()) {
+      // channelService.clear();
+    }
     if (await this.prechecker.check()) {
       let inputs = await this.gatherer.gather();
       inputs = await this.postchecker.check(inputs);

--- a/packages/salesforcedx-utils-vscode/src/constants.ts
+++ b/packages/salesforcedx-utils-vscode/src/constants.ts
@@ -1,0 +1,2 @@
+export const ENABLE_CLEAR_OUTPUT_BEFORE_EACH_COMMAND = 'clearOutputTab';
+export const SFDX_CORE_CONFIGURATION_NAME = 'salesforcedx-vscode-core';

--- a/packages/salesforcedx-utils-vscode/src/constants.ts
+++ b/packages/salesforcedx-utils-vscode/src/constants.ts
@@ -1,2 +1,3 @@
-export const ENABLE_CLEAR_OUTPUT_BEFORE_EACH_COMMAND = 'clearOutputTab';
+export const SETTING_CLEAR_OUTPUT_TAB = 'clearOutputTab';
 export const SFDX_CORE_CONFIGURATION_NAME = 'salesforcedx-vscode-core';
+export const SFDX_CORE_EXTENSION_NAME = 'salesforcedx-vscode-core';

--- a/packages/salesforcedx-utils-vscode/src/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/index.ts
@@ -21,10 +21,10 @@ export {
 } from './commands/commandletExecutors';
 export { SfdxCommandlet } from './commands/sfdxCommandlet';
 export { ConfigSource, ConfigUtil } from './config/configUtil';
-export { 
-  SETTING_CLEAR_OUTPUT_TAB, 
-  SFDX_CORE_CONFIGURATION_NAME, 
-  SFDX_CORE_EXTENSION_NAME 
+export {
+  SETTING_CLEAR_OUTPUT_TAB,
+  SFDX_CORE_CONFIGURATION_NAME,
+  SFDX_CORE_EXTENSION_NAME
 } from './constants';
 export { OrgInfo, WorkspaceContextUtil, getLogDirPath } from './context/workspaceContextUtil';
 export {

--- a/packages/salesforcedx-utils-vscode/src/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/index.ts
@@ -21,6 +21,11 @@ export {
 } from './commands/commandletExecutors';
 export { SfdxCommandlet } from './commands/sfdxCommandlet';
 export { ConfigSource, ConfigUtil } from './config/configUtil';
+export { 
+  SETTING_CLEAR_OUTPUT_TAB, 
+  SFDX_CORE_CONFIGURATION_NAME, 
+  SFDX_CORE_EXTENSION_NAME 
+} from './constants';
 export { OrgInfo, WorkspaceContextUtil, getLogDirPath } from './context/workspaceContextUtil';
 export {
   TelemetryService,
@@ -41,4 +46,3 @@ export {
   getRootWorkspacePath,
   getRootWorkspaceSfdxPath
 } from './workspaces';
-export { SETTING_CLEAR_OUTPUT_TAB, SFDX_CORE_CONFIGURATION_NAME, SFDX_CORE_EXTENSION_NAME } from './constants';

--- a/packages/salesforcedx-utils-vscode/src/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/index.ts
@@ -41,4 +41,4 @@ export {
   getRootWorkspacePath,
   getRootWorkspaceSfdxPath
 } from './workspaces';
-export * from './constants';
+export { SETTING_CLEAR_OUTPUT_TAB, SFDX_CORE_CONFIGURATION_NAME, SFDX_CORE_EXTENSION_NAME } from './constants';

--- a/packages/salesforcedx-utils-vscode/src/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/index.ts
@@ -41,3 +41,4 @@ export {
   getRootWorkspacePath,
   getRootWorkspaceSfdxPath
 } from './workspaces';
+export * from './constants';

--- a/packages/salesforcedx-utils-vscode/src/settings/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/settings/index.ts
@@ -1,0 +1,1 @@
+export * from './sfdxSettingsService';

--- a/packages/salesforcedx-utils-vscode/src/settings/sfdxSettingsService.ts
+++ b/packages/salesforcedx-utils-vscode/src/settings/sfdxSettingsService.ts
@@ -1,0 +1,10 @@
+import * as vscode from 'vscode';
+import { ENABLE_CLEAR_OUTPUT_BEFORE_EACH_COMMAND, SFDX_CORE_CONFIGURATION_NAME } from '../constants';
+
+export class SfdxSettingsService {
+  public static getEnableClearOutputBeforeEachCommand(): boolean {
+    return vscode.workspace
+      .getConfiguration(SFDX_CORE_CONFIGURATION_NAME)
+      .get<boolean>(ENABLE_CLEAR_OUTPUT_BEFORE_EACH_COMMAND, false);
+  }
+}

--- a/packages/salesforcedx-utils-vscode/src/settings/sfdxSettingsService.ts
+++ b/packages/salesforcedx-utils-vscode/src/settings/sfdxSettingsService.ts
@@ -1,10 +1,10 @@
 import * as vscode from 'vscode';
-import { ENABLE_CLEAR_OUTPUT_BEFORE_EACH_COMMAND, SFDX_CORE_CONFIGURATION_NAME } from '../constants';
+import { SETTING_CLEAR_OUTPUT_TAB, SFDX_CORE_CONFIGURATION_NAME } from '../constants';
 
 export class SfdxSettingsService {
   public static getEnableClearOutputBeforeEachCommand(): boolean {
     return vscode.workspace
       .getConfiguration(SFDX_CORE_CONFIGURATION_NAME)
-      .get<boolean>(ENABLE_CLEAR_OUTPUT_BEFORE_EACH_COMMAND, false);
+      .get<boolean>(SETTING_CLEAR_OUTPUT_TAB, false);
   }
 }

--- a/packages/salesforcedx-utils-vscode/src/telemetry/telemetry.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/telemetry.ts
@@ -7,6 +7,7 @@
 
 import * as util from 'util';
 import { env, ExtensionContext, workspace } from 'vscode';
+import { SFDX_CORE_CONFIGURATION_NAME } from '../constants';
 import { disableCLITelemetry, isCLITelemetryAllowed } from './cliConfiguration';
 import { TelemetryReporter } from './telemetryReporter';
 
@@ -140,7 +141,7 @@ export class TelemetryService {
         .getConfiguration('telemetry')
         .get<boolean>('enableTelemetry', true) &&
       workspace
-        .getConfiguration('salesforcedx-vscode-core')
+        .getConfiguration(SFDX_CORE_CONFIGURATION_NAME)
         .get<boolean>('telemetry.enabled', true)
     );
   }

--- a/packages/salesforcedx-utils-vscode/test/unit/commands/channelService.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/unit/commands/channelService.test.ts
@@ -135,4 +135,27 @@ describe('Channel Service', () => {
     channelService.streamCommandOutput(execution);
     expect(ensureDoubleDigitsStub.called).equals(true);
   });
+
+  it('should clear channel', async () => {
+    const clearStub = sb.stub(mChannel, 'clear');
+    sb.stub(vscodeStub.window, 'createOutputChannel').returns(mChannel);
+    // @ts-ignore
+    channelService.clear();
+    expect(clearStub.called).equals(true);
+  });
+
+  it('should clear channel when streamCommandStartStop is executed', () => {
+    const clearStub = sb.stub(mChannel, 'clear');
+    sb.stub(vscodeStub.window, 'createOutputChannel').returns(mChannel);
+    const execution = new CliCommandExecutor(
+      new SfdxCommandBuilder()
+        .withArg('force')
+        .withArg('--help')
+        .build(),
+      {}
+    ).execute();
+    // @ts-ignore
+    channelService.streamCommandStartStop(execution);
+    expect(clearStub.called).equals(true);
+  });
 });

--- a/packages/salesforcedx-utils-vscode/test/unit/commands/commandletExecutor.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/unit/commands/commandletExecutor.test.ts
@@ -112,7 +112,6 @@ describe('LibraryCommandletExecutor', () => {
     expect(clearStub.called).not.to.be.true;
   });
 
-
   it('should show failed execution notification if run returns false', async () => {
     const showErrStub = sb
       .stub(vscodeStub.window, 'showErrorMessage')

--- a/packages/salesforcedx-utils-vscode/test/unit/commands/commandletExecutor.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/unit/commands/commandletExecutor.test.ts
@@ -94,6 +94,25 @@ describe('LibraryCommandletExecutor', () => {
     expect(showInfoStub.called).to.be.true;
   });
 
+  it('should clear channel output if preference set', async () => {
+    sb.stub(vscodeStub.workspace, 'getConfiguration').returns({
+      get: () => true
+    });
+    const clearStub = sb.stub(MockChannel.prototype, 'clear');
+    await executor.execute({ data: { success: false }, type: 'CONTINUE' });
+    expect(clearStub.called).to.be.true;
+  });
+
+  it('should NOT clear channel output if preference NOT set', async () => {
+    sb.stub(vscodeStub.workspace, 'getConfiguration').returns({
+      get: () => false
+    });
+    const clearStub = sb.stub(MockChannel.prototype, 'clear');
+    await executor.execute({ data: { success: false }, type: 'CONTINUE' });
+    expect(clearStub.called).not.to.be.true;
+  });
+
+
   it('should show failed execution notification if run returns false', async () => {
     const showErrStub = sb
       .stub(vscodeStub.window, 'showErrorMessage')

--- a/packages/salesforcedx-utils-vscode/test/unit/settings/sfdxSettingsService.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/unit/settings/sfdxSettingsService.test.ts
@@ -3,7 +3,7 @@ import * as proxyquire from 'proxyquire';
 import { createSandbox, SinonSandbox } from 'sinon';
 import { vscodeStub } from '../commands/mocks';
 
-const { SfdxSettings } = proxyquire.noCallThru()(
+const { SfdxSettingsService } = proxyquire.noCallThru()(
   '../../../src/settings/index',
   {
     vscode: vscodeStub
@@ -23,13 +23,13 @@ describe('SfdxSettingsService', () => {
       sb.stub(vscodeStub.workspace, 'getConfiguration').returns({
         get: () => true
       });
-      expect(SfdxSettings.getEnableClearOutputBeforeEachCommand()).equals(true);
+      expect(SfdxSettingsService.getEnableClearOutputBeforeEachCommand()).equals(true);
     });
     it('should return false if underlying configuration is false', () => {
       sb.stub(vscodeStub.workspace, 'getConfiguration').returns({
         get: () => false
       });
-      expect(SfdxSettings.getEnableClearOutputBeforeEachCommand()).equals(false);
+      expect(SfdxSettingsService.getEnableClearOutputBeforeEachCommand()).equals(false);
     });
   });
 });

--- a/packages/salesforcedx-utils-vscode/test/unit/settings/sfdxSettingsService.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/unit/settings/sfdxSettingsService.test.ts
@@ -1,0 +1,35 @@
+import { expect } from 'chai';
+import * as proxyquire from 'proxyquire';
+import { createSandbox, SinonSandbox } from 'sinon';
+import { vscodeStub } from '../commands/mocks';
+
+const { SfdxSettings } = proxyquire.noCallThru()(
+  '../../../src/settings/index',
+  {
+    vscode: vscodeStub
+  }
+);
+
+describe('SfdxSettingsService', () => {
+  let sb: SinonSandbox;
+  beforeEach(() => {
+    sb = createSandbox();
+  });
+  afterEach(() => {
+    sb.restore();
+  });
+  describe('when reading workspace preference for clearing output', () => {
+    it('should return true when underlying workspace configuration for preference', () => {
+      sb.stub(vscodeStub.workspace, 'getConfiguration').returns({
+        get: () => true
+      });
+      expect(SfdxSettings.getEnableClearOutputBeforeEachCommand()).equals(true);
+    });
+    it('should return false if underlying configuration is false', () => {
+      sb.stub(vscodeStub.workspace, 'getConfiguration').returns({
+        get: () => false
+      });
+      expect(SfdxSettings.getEnableClearOutputBeforeEachCommand()).equals(false);
+    });
+  });
+});

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/utils/settings.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/utils/settings.ts
@@ -5,10 +5,11 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { SFDX_CORE_CONFIGURATION_NAME } from '@salesforce/salesforcedx-utils-vscode/out/src';
 import * as vscode from 'vscode';
 
 export function retrieveTestCodeCoverage(): boolean {
   return vscode.workspace
-    .getConfiguration('salesforcedx-vscode-core')
+    .getConfiguration(SFDX_CORE_CONFIGURATION_NAME)
     .get<boolean>('retrieve-test-code-coverage', false);
 }

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/vscode-integration/commands/quickLaunch.test.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/vscode-integration/commands/quickLaunch.test.ts
@@ -12,7 +12,6 @@ import { MockTestOrgData, testSetup } from '@salesforce/core/lib/testSetup';
 import { notificationService } from '@salesforce/salesforcedx-utils-vscode/out/src/commands';
 import { TraceFlags } from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import * as utils from '@salesforce/salesforcedx-utils-vscode/out/src/index';
-import { SFDX_CORE_CONFIGURATION_NAME } from '@salesforce/salesforcedx-utils-vscode/out/src/index';
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import { expect } from 'chai';
 import * as path from 'path';
@@ -51,7 +50,7 @@ describe('Quick launch apex tests', () => {
     sb = createSandbox();
     settingStub = sb.stub();
     sb.stub(vscode.workspace, 'getConfiguration')
-      .withArgs(SFDX_CORE_CONFIGURATION_NAME)
+      .withArgs(utils.SFDX_CORE_CONFIGURATION_NAME)
       .returns({
         get: settingStub
     });

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/vscode-integration/commands/quickLaunch.test.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/vscode-integration/commands/quickLaunch.test.ts
@@ -12,6 +12,7 @@ import { MockTestOrgData, testSetup } from '@salesforce/core/lib/testSetup';
 import { notificationService } from '@salesforce/salesforcedx-utils-vscode/out/src/commands';
 import { TraceFlags } from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import * as utils from '@salesforce/salesforcedx-utils-vscode/out/src/index';
+import { SFDX_CORE_CONFIGURATION_NAME } from '@salesforce/salesforcedx-utils-vscode/out/src/index';
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import { expect } from 'chai';
 import * as path from 'path';
@@ -50,7 +51,7 @@ describe('Quick launch apex tests', () => {
     sb = createSandbox();
     settingStub = sb.stub();
     sb.stub(vscode.workspace, 'getConfiguration')
-      .withArgs('salesforcedx-vscode-core')
+      .withArgs(SFDX_CORE_CONFIGURATION_NAME)
       .returns({
         get: settingStub
     });

--- a/packages/salesforcedx-vscode-apex/src/settings.ts
+++ b/packages/salesforcedx-vscode-apex/src/settings.ts
@@ -5,10 +5,11 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { SFDX_CORE_CONFIGURATION_NAME } from '@salesforce/salesforcedx-utils-vscode/src';
 import * as vscode from 'vscode';
 
 export function retrieveTestCodeCoverage(): boolean {
   return vscode.workspace
-    .getConfiguration('salesforcedx-vscode-core')
+    .getConfiguration(SFDX_CORE_CONFIGURATION_NAME)
     .get<boolean>('retrieve-test-code-coverage', false);
 }

--- a/packages/salesforcedx-vscode-apex/src/settings.ts
+++ b/packages/salesforcedx-vscode-apex/src/settings.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { SFDX_CORE_CONFIGURATION_NAME } from '@salesforce/salesforcedx-utils-vscode/src';
+import { SFDX_CORE_CONFIGURATION_NAME } from '@salesforce/salesforcedx-utils-vscode/out/src';
 import * as vscode from 'vscode';
 
 export function retrieveTestCodeCoverage(): boolean {

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceApexExecute.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceApexExecute.test.ts
@@ -7,7 +7,7 @@
 import { ExecuteService } from '@salesforce/apex-node';
 import { AuthInfo, ConfigAggregator, Connection } from '@salesforce/core';
 import { MockTestOrgData, testSetup } from '@salesforce/core/lib/testSetup';
-import { getRootWorkspacePath } from '@salesforce/salesforcedx-utils-vscode/out/src';
+import { getRootWorkspacePath, SFDX_CORE_CONFIGURATION_NAME } from '@salesforce/salesforcedx-utils-vscode/out/src';
 import { ChannelService } from '@salesforce/salesforcedx-utils-vscode/out/src/commands';
 import { TraceFlags } from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
@@ -40,7 +40,7 @@ describe('Force Apex Execute', () => {
     sb = createSandbox();
     settingStub = sb.stub();
     sb.stub(vscode.workspace, 'getConfiguration')
-      .withArgs('salesforcedx-vscode-core')
+      .withArgs(SFDX_CORE_CONFIGURATION_NAME)
       .returns({
         get: settingStub
     });

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/settings.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/settings.test.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { SFDX_CORE_CONFIGURATION_NAME } from '@salesforce/salesforcedx-utils-vscode/out/src';
 import { expect } from 'chai';
 import { createSandbox, SinonStub } from 'sinon';
 import * as vscode from 'vscode';
@@ -18,7 +19,7 @@ describe('Settings', () => {
     settingStub = sandbox.stub();
     sandbox
       .stub(vscode.workspace, 'getConfiguration')
-      .withArgs('salesforcedx-vscode-core')
+      .withArgs(SFDX_CORE_CONFIGURATION_NAME)
       .returns({
         get: settingStub
       });

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -954,8 +954,13 @@
     ],
     "configuration": {
       "type": "object",
-      "title": "%feature_previews_title%",
+      "title": "%core_settings_title%",
       "properties": {
+        "salesforcedx-vscode-core.clearOutputTab": {
+          "type": "boolean",
+          "default": false,
+          "description": "%setting_clear_output_tab_description%"
+        },
         "salesforcedx-vscode-core.push-or-deploy-on-save.overrideConflictsOnPush": {
           "type": "boolean",
           "default": false,

--- a/packages/salesforcedx-vscode-core/package.nls.ja.json
+++ b/packages/salesforcedx-vscode-core/package.nls.ja.json
@@ -35,7 +35,7 @@
   "force_data_soql_query_input_text": "SFDX: SOQL クエリを実行...",
   "force_data_soql_query_selection_text": "SFDX: 現在選択されているテキストを使用して SOQL クエリを実行",
   "force_package_install_text": "SFDX: パッケージをインストール",
-  "feature_previews_title": "Salesforce 機能のプレビュー",
+  "core_settings_title": "Salesforce 機能のプレビュー",
   "force_project_create_text": "SFDX: プロジェクトを作成",
   "force_project_with_manifest_create_text": "SFDX: マニフェストファイルを使用してプロジェクトを作成",
   "force_apex_trigger_create_text": "SFDX: Apex トリガを作成",
@@ -73,5 +73,6 @@
   "force_function_debug_invoke": "SFDX: Function をデバッグ",
   "force_function_stop": "SFDX: Function を停止",
   "force_sobjects_refresh": "SFDX: SObject 定義を更新",
-  "enable_sobject_refresh_on_startup_description": "プロジェクトに sObject 定義がない場合、拡張機能が有効化される際に自動的に sObject 定義を更新するかどうかを指定します。"
+  "enable_sobject_refresh_on_startup_description": "プロジェクトに sObject 定義がない場合、拡張機能が有効化される際に自動的に sObject 定義を更新するかどうかを指定します。",
+  "setting_clear_output_tab_description": "When a new command is run, clear the output content from the previous command."
 }

--- a/packages/salesforcedx-vscode-core/package.nls.ja.json
+++ b/packages/salesforcedx-vscode-core/package.nls.ja.json
@@ -73,6 +73,5 @@
   "force_function_debug_invoke": "SFDX: Function をデバッグ",
   "force_function_stop": "SFDX: Function を停止",
   "force_sobjects_refresh": "SFDX: SObject 定義を更新",
-  "enable_sobject_refresh_on_startup_description": "プロジェクトに sObject 定義がない場合、拡張機能が有効化される際に自動的に sObject 定義を更新するかどうかを指定します。",
-  "setting_clear_output_tab_description": "When a new command is run, clear the output content from the previous command."
+  "enable_sobject_refresh_on_startup_description": "プロジェクトに sObject 定義がない場合、拡張機能が有効化される際に自動的に sObject 定義を更新するかどうかを指定します。"
 }

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -41,7 +41,7 @@
   "force_data_soql_query_input_text": "SFDX: Execute SOQL Query...",
   "force_data_soql_query_selection_text": "SFDX: Execute SOQL Query with Currently Selected Text",
   "force_package_install_text": "SFDX: Install Package",
-  "feature_previews_title": "Salesforce Feature Previews",
+  "core_settings_title": "Salesforce Core Configuration",
   "force_project_create_text": "SFDX: Create Project",
   "force_project_with_manifest_create_text": "SFDX: Create Project with Manifest",
   "force_apex_trigger_create_text": "SFDX: Create Apex Trigger",
@@ -82,5 +82,6 @@
   "force_function_stop": "SFDX: Stop Function",
   "force_sobjects_refresh": "SFDX: Refresh SObject Definitions",
   "enable_sobject_refresh_on_startup_description": "If a project has no sObject definitions, specifies whether to automatically refresh sObject definitions on extension activation (true) or not (false).",
-  "force_launch_apex_replay_debugger_with_current_file": "SFDX: Launch Apex Replay Debugger with Current File"
+  "force_launch_apex_replay_debugger_with_current_file": "SFDX: Launch Apex Replay Debugger with Current File",
+  "setting_clear_output_tab_description": "When a new command is run, clear the output content from the previous command."
 }

--- a/packages/salesforcedx-vscode-core/src/commands/util/sfdxCommandlet.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/sfdxCommandlet.ts
@@ -24,6 +24,7 @@ import * as vscode from 'vscode';
 import { EmptyPostChecker } from '.';
 import { channelService } from '../../channels';
 import { notificationService, ProgressNotification } from '../../notifications';
+import { sfdxCoreSettings } from '../../settings';
 import { taskViewService } from '../../statuses';
 import { telemetryService } from '../../telemetry';
 import { getRootWorkspacePath } from '../../util';
@@ -165,6 +166,9 @@ export class SfdxCommandlet<T> {
   }
 
   public async run(): Promise<void> {
+    if (sfdxCoreSettings.getEnableClearOutputBeforeEachCommand()) {
+      channelService.clear();
+    }
     if (await this.prechecker.check()) {
       let inputs = await this.gatherer.gather();
       inputs = await this.postchecker.check(inputs);

--- a/packages/salesforcedx-vscode-core/src/constants.ts
+++ b/packages/salesforcedx-vscode-core/src/constants.ts
@@ -32,7 +32,6 @@ export const INTERNAL_DEVELOPMENT_FLAG = 'internal-development';
 export const PUSH_OR_DEPLOY_ON_SAVE_ENABLED = 'push-or-deploy-on-save.enabled';
 export const PUSH_OR_DEPLOY_ON_SAVE_OVERRIDE_CONFLICTS = 'push-or-deploy-on-save.overrideConflictsOnPush';
 export const RETRIEVE_TEST_CODE_COVERAGE = 'retrieve-test-code-coverage';
-export const SFDX_CORE_CONFIGURATION_NAME = 'salesforcedx-vscode-core';
 export const SHOW_CLI_SUCCESS_INFO_MSG = 'show-cli-success-msg';
 export const TELEMETRY_ENABLED = 'telemetry.enabled';
 export const ENABLE_SOBJECT_REFRESH_ON_STARTUP =

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -4,8 +4,8 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import * as vscode from 'vscode';
 import { SFDX_CORE_CONFIGURATION_NAME } from '@salesforce/salesforcedx-utils-vscode/out/src';
+import * as vscode from 'vscode';
 import { channelService } from './channels';
 import {
   checkSObjectsAndRefresh,
@@ -92,7 +92,7 @@ import {
   setupConflictView
 } from './conflict';
 import {
-  ENABLE_SOBJECT_REFRESH_ON_STARTUP,
+  ENABLE_SOBJECT_REFRESH_ON_STARTUP
 } from './constants';
 import { getDefaultUsernameOrAlias } from './context';
 import { workspaceContext } from './context';

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import * as vscode from 'vscode';
+import { SFDX_CORE_CONFIGURATION_NAME } from '@salesforce/salesforcedx-utils-vscode/out/src';
 import { channelService } from './channels';
 import {
   checkSObjectsAndRefresh,
@@ -92,7 +93,6 @@ import {
 } from './conflict';
 import {
   ENABLE_SOBJECT_REFRESH_ON_STARTUP,
-  SFDX_CORE_CONFIGURATION_NAME
 } from './constants';
 import { getDefaultUsernameOrAlias } from './context';
 import { workspaceContext } from './context';

--- a/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
@@ -77,6 +77,7 @@ export class SfdxCoreSettings {
   public getEnableClearOutputBeforeEachCommand(): boolean {
     return this.getConfigValue(SETTING_CLEAR_OUTPUT_TAB, false);
   }
+  
   private getConfigValue<T>(key: string, defaultValue: T): T {
     return this.getConfiguration().get<T>(key, defaultValue);
   }

--- a/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
@@ -77,7 +77,7 @@ export class SfdxCoreSettings {
   public getEnableClearOutputBeforeEachCommand(): boolean {
     return this.getConfigValue(SETTING_CLEAR_OUTPUT_TAB, false);
   }
-  
+
   private getConfigValue<T>(key: string, defaultValue: T): T {
     return this.getConfiguration().get<T>(key, defaultValue);
   }

--- a/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
@@ -5,15 +5,14 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { SETTING_CLEAR_OUTPUT_TAB, SFDX_CORE_CONFIGURATION_NAME } from '@salesforce/salesforcedx-utils-vscode/out/src';
 import * as vscode from 'vscode';
 import {
-  BETA_DEPLOY_RETRIEVE,
   CONFLICT_DETECTION_ENABLED,
   INTERNAL_DEVELOPMENT_FLAG,
   PUSH_OR_DEPLOY_ON_SAVE_ENABLED,
   PUSH_OR_DEPLOY_ON_SAVE_OVERRIDE_CONFLICTS,
   RETRIEVE_TEST_CODE_COVERAGE,
-  SFDX_CORE_CONFIGURATION_NAME,
   SHOW_CLI_SUCCESS_INFO_MSG,
   TELEMETRY_ENABLED
 } from '../constants';
@@ -75,6 +74,9 @@ export class SfdxCoreSettings {
     return this.getConfigValue(CONFLICT_DETECTION_ENABLED, false);
   }
 
+  public getEnableClearOutputBeforeEachCommand(): boolean {
+    return this.getConfigValue(SETTING_CLEAR_OUTPUT_TAB, false);
+  }
   private getConfigValue<T>(key: string, defaultValue: T): T {
     return this.getConfiguration().get<T>(key, defaultValue);
   }

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/telemetry/index.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/telemetry/index.test.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { TelemetryReporter } from '@salesforce/salesforcedx-utils-vscode/out/src';
+import { SFDX_CORE_EXTENSION_NAME, TelemetryReporter } from '@salesforce/salesforcedx-utils-vscode/out/src';
 import { expect } from 'chai';
 import { assert, match, SinonStub, stub } from 'sinon';
 import { window } from 'vscode';
@@ -234,7 +234,7 @@ describe('Telemetry', () => {
       assert.calledOnce(reporter);
 
       const expectedProps = {
-        extensionName: 'salesforcedx-vscode-core'
+        extensionName: SFDX_CORE_EXTENSION_NAME
       };
       const expectedMeasures = match({ startupTime: match.number });
       assert.calledWith(
@@ -261,7 +261,7 @@ describe('Telemetry', () => {
       assert.calledOnce(reporter);
 
       const expectedData = {
-        extensionName: 'salesforcedx-vscode-core'
+        extensionName: SFDX_CORE_EXTENSION_NAME
       };
       assert.calledWith(reporter, 'deactivationEvent', expectedData);
       expect(teleStub.firstCall.args).to.eql([true]);
@@ -282,7 +282,7 @@ describe('Telemetry', () => {
       assert.calledOnce(reporter);
 
       const expectedProps = {
-        extensionName: 'salesforcedx-vscode-core',
+        extensionName: SFDX_CORE_EXTENSION_NAME,
         commandName: 'create_apex_class_command'
       };
       const expectedMeasures = { executionTime: match.number };
@@ -318,7 +318,7 @@ describe('Telemetry', () => {
       assert.calledOnce(reporter);
 
       const expectedProps = {
-        extensionName: 'salesforcedx-vscode-core',
+        extensionName: SFDX_CORE_EXTENSION_NAME,
         commandName: 'create_apex_class_command',
         dirType: 'testDirectoryType',
         secondParam: 'value'
@@ -357,7 +357,7 @@ describe('Telemetry', () => {
       assert.calledOnce(reporter);
 
       const expectedProps = {
-        extensionName: 'salesforcedx-vscode-core',
+        extensionName: SFDX_CORE_EXTENSION_NAME,
         commandName: 'create_apex_class_command'
       };
       const expectedMeasures = {

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/jsconfig.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/jsconfig.test.ts
@@ -27,12 +27,6 @@ describe('jsconfig Test Suite', () => {
   const configPath = path.join(lwcDir, CONFIG_FILENAME);
   let config: object;
 
-  beforeEach(async () => {
-    await createComponent(TEST_COMPONENT_NAME, lwcDir);
-    await waitForConfigUpdate(configPath);
-    config = await parseConfig(configPath);
-  });
-
   afterEach(async () => {
     if (fs.existsSync(path.join(lwcDir, TEST_COMPONENT_NAME))) {
       await workspace.fs.delete(
@@ -49,6 +43,14 @@ describe('jsconfig Test Suite', () => {
       );
       await waitForConfigUpdate(configPath);
     }
+  });
+
+  // This was moved due to a failing race condition in CircleCI Tests
+  // causing a flapping test and sporadic build failures. Do not move.
+  beforeEach(async () => {
+    await createComponent(TEST_COMPONENT_NAME, lwcDir);
+    await waitForConfigUpdate(configPath);
+    config = await parseConfig(configPath);
   });
 
   it('Should keep a generic c/* field in jsconfig after creating a new component', async () => {


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?

This PR adds a user/workspace preference and changes the preference category they display under in the preferences UI.  When set, the output channel is cleared between each common command.   There are a few commands that do not output to the channel ( Like Create Soql Query ) and those do not clear the channel.

### What issues does this PR fix or reference?
#941, @W-10288504@

### Functionality Before

Old and New Preference Shown Below

<img width="1868" alt="Screen Shot 2022-07-21 at 3 31 36 PM" src="https://user-images.githubusercontent.com/599418/180883703-2cb071f1-6a5a-480a-b52d-4e2544252462.png">

### Functionality After

https://user-images.githubusercontent.com/599418/180885264-b1a61c1b-42f8-4e73-86d2-e9d7f9238fbe.mov



