### PR TITLE
fix: updated day offset to compensate for UTC and failing test

### DIFF
--- a/packages/salesforcedx-vscode-core/test/vscode-integration/util/orgUtil.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/util/orgUtil.test.ts
@@ -150,12 +150,12 @@ describe('orgUtil tests', () => {
         .resolves([
           {
             isDevHub: false,
-            expirationDate: `${today.getFullYear()}-${today.getMonth() + 1}-${today.getDate() + 3}`,
+            expirationDate: `${today.getFullYear()}-${today.getMonth() + 1}-${today.getDate() + 2}`,
             username: 'foo'
           },
           {
             isDevHub: false,
-            expirationDate: `${today.getFullYear()}-${today.getMonth() + 1}-${today.getDate() + 4}`,
+            expirationDate: `${today.getFullYear()}-${today.getMonth() + 1}-${today.getDate() + 3}`,
             username: 'bar'
           }
         ]);


### PR DESCRIPTION
### What does this PR do?
This PR fixes a test that was failing.  The failure was due to the way JavaScript parses strings for dates, and constructs date objects.  Because of UTC offsets, the test would sometime pass, and sometimes fail.  To fix the issue, I just changed the day offset in the failing test.  No change to the actual implementation in `checkForExpiredOrgs()` was made.

### What issues does this PR fix or reference?
No logged issue, just something discussed in Slack.

### Functionality Before
The `should display multiple orgs in the output when there are several scratch orgs about to expire` test was failing.

### Functionality After
The `should display multiple orgs in the output when there are several scratch orgs about to expire` test is now passing.
No change to the actual implementation in `checkForExpiredOrgs()` was made.

