### PR TITLE
draft: fix: stop showing output tab in unnecessary circumstances

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/commands/channelService.ts
+++ b/packages/salesforcedx-utils-vscode/src/commands/channelService.ts
@@ -17,6 +17,7 @@ export class ChannelService {
 
   public constructor(channel: OutputChannel) {
     this.channel = channel;
+    this.channel.show(true);
   }
 
   public static getInstance(channelName: string) {

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/channels/index.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/channels/index.ts
@@ -5,10 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { ChannelService } from '@salesforce/salesforcedx-utils-vscode/out/src/commands';
-import * as vscode from 'vscode';
 import { nls } from '../messages';
 
-export const OUTPUT_CHANNEL = vscode.window.createOutputChannel(
+export const OUTPUT_CHANNEL = ChannelService.getInstance(
   nls.localize('channel_name')
 );
-export const channelService = new ChannelService(OUTPUT_CHANNEL);
+export const channelService = OUTPUT_CHANNEL;

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/quickLaunch.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/quickLaunch.ts
@@ -148,6 +148,9 @@ export class QuickLaunch {
 }
 
 export class TestDebuggerExecutor extends LibraryCommandletExecutor<string[]> {
+
+  protected showChannelOutput = true;
+
   constructor() {
     super(
       nls.localize('debug_test_exec_name'),

--- a/packages/salesforcedx-vscode-apex/src/channels/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/channels/index.ts
@@ -5,10 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { ChannelService } from '@salesforce/salesforcedx-utils-vscode/out/src/commands';
-import * as vscode from 'vscode';
 import { nls } from '../messages';
 
-export const OUTPUT_CHANNEL = vscode.window.createOutputChannel(
+export const OUTPUT_CHANNEL = ChannelService.getInstance(
   nls.localize('channel_name')
 );
-export const channelService = new ChannelService(OUTPUT_CHANNEL);
+export const channelService = OUTPUT_CHANNEL;

--- a/packages/salesforcedx-vscode-apex/src/commands/forceApexTestSuite.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceApexTestSuite.ts
@@ -152,6 +152,7 @@ export class ApexLibraryTestSuiteBuilder extends LibraryCommandletExecutor<
   public static diagnostics = vscode.languages.createDiagnosticCollection(
     'apex-errors'
   );
+  protected showChannelOutput = true;
 
   constructor() {
     super(

--- a/packages/salesforcedx-vscode-core/src/channels/index.ts
+++ b/packages/salesforcedx-vscode-core/src/channels/index.ts
@@ -5,10 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { ChannelService } from '@salesforce/salesforcedx-utils-vscode/out/src/commands';
-import * as vscode from 'vscode';
 import { nls } from '../messages';
 
-export const OUTPUT_CHANNEL = vscode.window.createOutputChannel(
+export const OUTPUT_CHANNEL = ChannelService.getInstance(
   nls.localize('channel_name')
 );
-export const channelService = new ChannelService(OUTPUT_CHANNEL);
+export const channelService = OUTPUT_CHANNEL;

--- a/packages/salesforcedx-vscode-core/src/commands/auth/forceAuthAccessTokenLogin.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/auth/forceAuthAccessTokenLogin.ts
@@ -21,6 +21,9 @@ import {
 export class ForceAuthAccessTokenExecutor extends LibraryCommandletExecutor<
   AccessTokenParams
 > {
+
+  protected showChannelOutput = true;
+
   constructor() {
     super(
       nls.localize('force_auth_access_token_authorize_org_text'),

--- a/packages/salesforcedx-vscode-core/src/commands/auth/forceAuthDevHub.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/auth/forceAuthDevHub.ts
@@ -54,7 +54,6 @@ export class ForceAuthDevHubContainerExecutor extends ForceAuthWebLoginContainer
 }
 
 export class ForceAuthDevHubExecutor extends SfdxCommandletExecutor<{}> {
-  protected showChannelOutput = false;
 
   public build(data: {}): Command {
     const command = new SfdxCommandBuilder().withDescription(

--- a/packages/salesforcedx-vscode-core/src/commands/auth/forceAuthLogout.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/auth/forceAuthLogout.ts
@@ -31,7 +31,6 @@ import { ScratchOrgLogoutParamsGatherer } from './authParamsGatherer';
 export class ForceAuthLogoutAll extends SfdxCommandletExecutor<{}> {
   public static withoutShowingChannel(): ForceAuthLogoutAll {
     const instance = new ForceAuthLogoutAll();
-    instance.showChannelOutput = false;
     return instance;
   }
 
@@ -60,12 +59,16 @@ export async function forceAuthLogoutAll() {
 }
 
 export class AuthLogoutDefault extends LibraryCommandletExecutor<string> {
+
+  protected showChannelOutput = true;
+
   constructor() {
     super(
       nls.localize('force_auth_logout_default_text'),
       'force_auth_logout_default',
       OUTPUT_CHANNEL
     );
+
   }
 
   public async run(

--- a/packages/salesforcedx-vscode-core/src/commands/auth/forceAuthWebLogin.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/auth/forceAuthWebLogin.ts
@@ -46,7 +46,6 @@ export interface DeviceCodeResponse {
 export class ForceAuthWebLoginContainerExecutor extends SfdxCommandletExecutor<
   AuthParams
 > {
-  protected showChannelOutput = false;
   protected deviceCodeReceived = false;
   protected stdOut = '';
 
@@ -147,7 +146,6 @@ export class ForceAuthWebLoginContainerExecutor extends SfdxCommandletExecutor<
 export class ForceAuthWebLoginExecutor extends SfdxCommandletExecutor<
   AuthParams
 > {
-  protected showChannelOutput = false;
 
   public build(data: AuthParams): Command {
     const command = new SfdxCommandBuilder().withDescription(

--- a/packages/salesforcedx-vscode-core/src/commands/forceConfigSet.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceConfigSet.ts
@@ -18,7 +18,6 @@ import {
 
 export class ForceConfigSetExecutor extends SfdxCommandletExecutor<{}> {
   private usernameOrAlias: string;
-  protected showChannelOutput = false;
 
   public constructor(usernameOrAlias: string) {
     super();

--- a/packages/salesforcedx-vscode-core/src/commands/forceCreateManifest.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceCreateManifest.ts
@@ -25,6 +25,8 @@ const MANIFEST_SAVE_PROMPT = 'manifest_input_save_prompt';
 export class ManifestCreateExecutor extends LibraryCommandletExecutor<string> {
   private sourcePaths: string[];
   private responseText: string | undefined;
+  protected showChannelOutput = true;
+
   constructor(sourcePaths: string[], responseText: string | undefined) {
     super(
       nls.localize(CREATE_MANIFEST_EXECUTOR),

--- a/packages/salesforcedx-vscode-core/src/commands/forceOrgOpen.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceOrgOpen.ts
@@ -101,7 +101,7 @@ export class ForceOrgOpenContainerExecutor extends SfdxCommandletExecutor<{}> {
 }
 
 export class ForceOrgOpenExecutor extends SfdxCommandletExecutor<{}> {
-  protected showChannelOutput = false;
+
   public build(data: {}): Command {
     return new SfdxCommandBuilder()
       .withDescription(nls.localize('force_org_open_default_scratch_org_text'))

--- a/packages/salesforcedx-vscode-core/src/commands/forceRenameLightningComponent.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceRenameLightningComponent.ts
@@ -30,6 +30,8 @@ const TEST_FOLDER = '__tests__';
 
 export class RenameLwcComponentExecutor extends LibraryCommandletExecutor<ComponentName> {
   private sourceFsPath: string;
+  protected showChannelOutput = true;
+
   constructor(sourceFsPath: string) {
     super(
       nls.localize(RENAME_LIGHTNING_COMPONENT_EXECUTOR),

--- a/packages/salesforcedx-vscode-core/src/commands/functions/forceFunctionInvoke.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/functions/forceFunctionInvoke.ts
@@ -27,6 +27,9 @@ import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/
 import * as fs from 'fs';
 
 export class ForceFunctionInvoke extends LibraryCommandletExecutor<string> {
+
+  protected showChannelOutput = true;
+
   constructor(debug: boolean = false) {
     super(
       nls.localize('force_function_invoke_text'),

--- a/packages/salesforcedx-vscode-core/src/commands/functions/forceFunctionStart/ForceFunctionStartExecutor.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/functions/forceFunctionStart/ForceFunctionStartExecutor.ts
@@ -26,6 +26,8 @@ export abstract class ForceFunctionStartExecutor extends LibraryCommandletExecut
 > {
   protected UNEXPECTED_ERROR_KEY = 'force_function_start_unexpected_error';
 
+  protected showChannelOutput = true;
+
   constructor(startMessageKey: string, logName: string) {
     super(nls.localize(startMessageKey), logName, OUTPUT_CHANNEL);
     this.cancellable = true;

--- a/packages/salesforcedx-vscode-core/src/commands/templates/forceFunctionCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/forceFunctionCreate.ts
@@ -41,6 +41,9 @@ const LOG_NAME = 'force_function_create';
 export class ForceFunctionCreateExecutor extends LibraryCommandletExecutor<
   any
 > {
+
+  protected showChannelOutput = true;
+
   constructor() {
     super(nls.localize('force_function_create_text'), LOG_NAME, OUTPUT_CHANNEL);
   }


### PR DESCRIPTION

### What does this PR do?

This PR does the following:
Stops showing the output tab in the following scenarios:
Deploy/Retrieve
Running of tests

I chose these commands for the following reason:
They are ran all of the time.
Everything you would want to know about the output of the command can already be found in the "Problems" tab in a human readable format.


The LibraryCommandletExecutor now defaults to not showing the output tab when the command is ran. The implementer must state explicitly that the output tab should show on run. I believe this is fair, since the project should be aiming for a more intuitive/readable format than just a large format of text from the CLI. 


### What issues does this PR fix or reference?
https://github.com/forcedotcom/salesforcedx-vscode/issues/3644

### Functionality Before

Whenever a test or deploy is ran, it would swap to the output tab in vscode.

### Functionality After

Whenever a test or deploy is ran, it now does not swap to the output tab in vscode. 




Notes: I still need to ensure that I have added/fixed any tests that are failing because of these changes. I just wanted to make sure that I am the right path before committing to any solution. I cannot tell how much better this would make my developer experience if just these two changes were to go through (deploy and run tests not showing output anymore)  