### PR TITLE
refactor: remove unneeded getOrgAuthorization method and related tests

### DIFF
--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -48,18 +48,6 @@ export class OrgList implements vscode.Disposable {
     }
   }
 
-  public async getOrgAuthorizations(): Promise<OrgAuthorization[] | null> {
-    const orgAuthorizations = await AuthInfo.listAllAuthorizations().catch(
-      err => null
-    );
-
-    if (orgAuthorizations === null || orgAuthorizations.length === 0) {
-      return null;
-    }
-
-    return orgAuthorizations;
-  }
-
   public async getAuthFieldsFor(username: string): Promise<AuthFields> {
     const authInfo: AuthInfo = await AuthInfo.create({
       username
@@ -114,9 +102,7 @@ export class OrgList implements vscode.Disposable {
   }
 
   public async updateOrgList() {
-    const orgAuthorizations:
-      | OrgAuthorization[]
-      | null = await this.getOrgAuthorizations();
+    const orgAuthorizations = await AuthInfo.listAllAuthorizations();
     if (!orgAuthorizations) {
       return null;
     }

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgPicker/orgList.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgPicker/orgList.test.ts
@@ -23,69 +23,13 @@ describe('orgList Tests', () => {
   });
 
   describe('getAuthInfoObjects', () => {
-    let getAuthInfoListAllAuthorizationsStub: SinonStub;
+    let authInfoListAllAuthorizationsStub: SinonStub;
 
     beforeEach(() => {
-      getAuthInfoListAllAuthorizationsStub = sandbox.stub(
+      authInfoListAllAuthorizationsStub = sandbox.stub(
         AuthInfo,
         'listAllAuthorizations'
       );
-    });
-
-    it('should return a list of FileInfo objects when given an array of file names', async () => {
-      const authFilesArray = [
-        { username: 'test-username1@example.com' },
-        { username: 'test-username2@example.com' }
-      ];
-      getAuthInfoListAllAuthorizationsStub.resolves(authFilesArray);
-      // readFileSync is used to load test files on the fly so we need to
-      // ensure we only stub calls to the fake authFiles.
-      const readFileStub = sandbox.stub(fs, 'readFileSync');
-      // Will only reurn when the arg includes the username.
-      readFileStub.withArgs(sinon.match(authFilesArray[0].username)).returns(
-        JSON.stringify({
-          orgId: '000',
-          accessToken: '000',
-          refreshToken: '000',
-          instanceUrl: '000',
-          loginUrl: '000',
-          username: 'test-username1@example.com'
-        })
-      );
-      readFileStub.withArgs(sinon.match(authFilesArray[1].username)).returns(
-        JSON.stringify({
-          orgId: '111',
-          accessToken: '111',
-          refreshToken: '111',
-          instanceUrl: '111',
-          loginUrl: '111',
-          username: 'test-username2@example.com'
-        })
-      );
-      // Call the stubbed function if not matching the above withArgs.
-      readFileStub.callThrough();
-      const orgList = new OrgList();
-
-      const orgAuthorizations = await orgList.getOrgAuthorizations();
-      if (orgAuthorizations) {
-        expect(orgAuthorizations.length).to.equal(2);
-
-        expect(orgAuthorizations[0].username).to.equal(
-          'test-username1@example.com'
-        );
-        expect(orgAuthorizations[1].username).to.equal(
-          'test-username2@example.com'
-        );
-      } else {
-        fail('Should have populated authInfoObjects');
-      }
-    });
-
-    it('should return null when no auth files are present', async () => {
-      const orgList = new OrgList();
-      getAuthInfoListAllAuthorizationsStub.resolves(null);
-      const orgAuthorizations = await orgList.getOrgAuthorizations();
-      expect(orgAuthorizations).to.equal(null);
     });
 
     describe('Filter Authorization Info', async () => {


### PR DESCRIPTION
since no longer reading from disk to generate the fileInfos but instead using
AuthInfo.listAllAuthorizations()

<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?

### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @<Insert GUS WI>@

### Functionality Before
<insert gif and/or summary>

### Functionality After
<insert gif and/or summary>
