### PR TITLE
Update _redirects

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -13,7 +13,7 @@
 /tools/vscode/en/getting-started/recommended-extensions         /tools/vscode/en/vscode-desktop/recommended-extensions    301
 /tools/vscode/en/getting-started/settings                       /tools/vscode/en/vscode-desktop/settings                  301
 /tools/vscode/en/getting-started/tips-and-tricks                /tools/vscode/en/vscode-desktop/tips-and-tricks           301
-
+/tools/vscode/en/getting-started/java-setup                     /tools/vscode/en/vscode-desktop/java-setup                301
 # Temporary Redirects for convenience
 /tools/vscode/en/                               /tools/vscode/                          302
 /tools/vscode/en/aura                           /tools/vscode/en/aura/writing           302


### PR DESCRIPTION
fixing a 404 because of the java setup file was moved.

<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?


### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @<Insert GUS WI>@

### Functionality Before
This link 404s -- https://developer.salesforce.com/tools/vscode/en/getting-started/java-setup

### Functionality After
Now redirects to https://developer.salesforce.com/tools/vscode/en/vscode-desktop/java-setup