### PR TITLE
refactor: use org api version if no user config

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
@@ -63,7 +63,7 @@ export abstract class DeployRetrieveExecutor<
 
     try {
       const components = await this.getComponents(response);
-      void this.setApiVersionOn(components);
+      await this.setApiVersionOn(components);
 
       this.telemetry.addProperty(
         TELEMETRY_METADATA_COUNT,

--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
@@ -66,7 +66,7 @@ export abstract class DeployRetrieveExecutor<
 
     try {
       const components = await this.getComponents(response);
-      this.setApiVersionOn(components);
+      await this.setApiVersionOn(components);
 
       this.telemetry.addProperty(
         TELEMETRY_METADATA_COUNT,

--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
@@ -92,10 +92,14 @@ export abstract class DeployRetrieveExecutor<
       | string
       | undefined = await ConfigUtil.getUserConfiguredApiVersion();
 
+    if (userConfiguredApiVersion) {
+      components.apiVersion = userConfiguredApiVersion;
+      return;
+    }
+
     // If no user-configured Api Version is present, then get the version from the Org.
     const orgApiVersion = await OrgAuthInfo.getOrgApiVersion();
-    components.apiVersion =
-      userConfiguredApiVersion ?? orgApiVersion ?? components.apiVersion;
+    components.apiVersion = orgApiVersion ?? components.apiVersion;
   }
 
   protected setupCancellation(

--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
@@ -93,8 +93,9 @@ export abstract class DeployRetrieveExecutor<
       | undefined = await ConfigUtil.getUserConfiguredApiVersion();
 
     // If no user-configured Api Version is present, then get the version from the Org.
+    const orgApiVersion = await OrgAuthInfo.getOrgApiVersion();
     components.apiVersion =
-      userConfiguredApiVersion ?? (await OrgAuthInfo.getOrgApiVersion());
+      userConfiguredApiVersion ?? orgApiVersion ?? components.apiVersion;
   }
 
   protected setupCancellation(

--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
@@ -63,7 +63,7 @@ export abstract class DeployRetrieveExecutor<
 
     try {
       const components = await this.getComponents(response);
-      await this.setApiVersionOn(components);
+      this.setApiVersionOn(components);
 
       this.telemetry.addProperty(
         TELEMETRY_METADATA_COUNT,

--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
@@ -63,7 +63,7 @@ export abstract class DeployRetrieveExecutor<
 
     try {
       const components = await this.getComponents(response);
-      this.setApiVersionOn(components);
+      void this.setApiVersionOn(components);
 
       this.telemetry.addProperty(
         TELEMETRY_METADATA_COUNT,

--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
@@ -36,7 +36,7 @@ import { handleDeployDiagnostics } from '../diagnostics';
 import { nls } from '../messages';
 import { DeployQueue } from '../settings';
 import { SfdxPackageDirectories } from '../sfdxProject';
-import { ConfigUtil, getDefaultDevHubUsernameOrAlias, OrgAuthInfo } from '../util';
+import { ConfigUtil, OrgAuthInfo } from '../util';
 import { createComponentCount, formatException } from './util';
 
 type DeployRetrieveResult = DeployResult | RetrieveResult;
@@ -85,13 +85,16 @@ export abstract class DeployRetrieveExecutor<
     }
   }
 
-  async setApiVersionOn(components: ComponentSet) {
+  private async setApiVersionOn(components: ComponentSet) {
     // Check the SFDX configuration to see if there is an overridden api version.
     // Project level local sfdx-config takes precedence over global sfdx-config at system level.
-    const userConfiguredApiVersion: string | undefined = await ConfigUtil.getUserConfiguredApiVersion();
-    
+    const userConfiguredApiVersion:
+      | string
+      | undefined = await ConfigUtil.getUserConfiguredApiVersion();
+
     // If no user-configured Api Version is present, then get the version from the Org.
-    components.apiVersion = userConfiguredApiVersion ?? await OrgAuthInfo.getOrgApiVersion();
+    components.apiVersion =
+      userConfiguredApiVersion ?? (await OrgAuthInfo.getOrgApiVersion());
   }
 
   protected setupCancellation(

--- a/packages/salesforcedx-vscode-core/src/util/authInfo.ts
+++ b/packages/salesforcedx-vscode-core/src/util/authInfo.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { AuthInfo, Connection, StateAggregator } from '@salesforce/core';
+import { AuthUtil } from '@salesforce/salesforcedx-utils-vscode/out/src';
 import * as vscode from 'vscode';
 import { channelService } from '../channels';
 import {
@@ -127,7 +128,15 @@ export class OrgAuthInfo {
   }
 
   public static async getOrgApiVersion() {
-    const connection = await OrgAuthInfo.getConnection();
+    const defaultUsernameOrAlias = await OrgAuthInfo.getDefaultUsernameOrAlias(
+      false
+    );
+    const username = defaultUsernameOrAlias
+      ? await AuthUtil.getInstance().getUsername(defaultUsernameOrAlias)
+      : undefined;
+    const connection = await Connection.create({
+      authInfo: await AuthInfo.create({ username })
+    });
     const apiVersion = connection.getApiVersion();
     return apiVersion;
   }

--- a/packages/salesforcedx-vscode-core/src/util/authInfo.ts
+++ b/packages/salesforcedx-vscode-core/src/util/authInfo.ts
@@ -125,6 +125,10 @@ export class OrgAuthInfo {
       authInfo: await AuthInfo.create({ username })
     });
   }
+
+  public static async getOrgApiVersion() {
+    return await (await OrgAuthInfo.getConnection()).getApiVersion();
+  }
 }
 
 enum VSCodeWindowTypeEnum {

--- a/packages/salesforcedx-vscode-core/src/util/authInfo.ts
+++ b/packages/salesforcedx-vscode-core/src/util/authInfo.ts
@@ -127,7 +127,9 @@ export class OrgAuthInfo {
   }
 
   public static async getOrgApiVersion() {
-    return await (await OrgAuthInfo.getConnection()).getApiVersion();
+    const connection = await OrgAuthInfo.getConnection();
+    const apiVersion = connection.getApiVersion();
+    return apiVersion;
   }
 }
 

--- a/packages/salesforcedx-vscode-core/src/util/authInfo.ts
+++ b/packages/salesforcedx-vscode-core/src/util/authInfo.ts
@@ -131,6 +131,9 @@ export class OrgAuthInfo {
     const defaultUsernameOrAlias = await OrgAuthInfo.getDefaultUsernameOrAlias(
       false
     );
+    if (!defaultUsernameOrAlias) {
+      return undefined;
+    }
     const username = defaultUsernameOrAlias
       ? await AuthUtil.getInstance().getUsername(defaultUsernameOrAlias)
       : undefined;

--- a/packages/salesforcedx-vscode-core/src/util/configUtil.ts
+++ b/packages/salesforcedx-vscode-core/src/util/configUtil.ts
@@ -70,4 +70,9 @@ export class ConfigUtil {
     }
     return undefined;
   }
+
+  public static async getUserConfiguredApiVersion() {
+    const apiVersion = await ConfigUtil.getConfigValue('apiVersion');
+    return apiVersion ? String(apiVersion) : undefined;
+  }
 }

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
@@ -188,12 +188,17 @@ describe('Base Deploy Retrieve Commands', () => {
       }
     });
 
-    it('should use the api version from SFDX configuration', async () => {
+    it.only('should use the api version from SFDX configuration', async () => {
       const executor = new TestDeployRetrieve();
+      //todo: stub out getOrgApiVersion instead - won't need a username and
+      // wont have to change this test file when switch to not use getConfigValue
       const configApiVersion = '30.0';
-      sb.stub(ConfigUtil, 'getConfigValue')
-        .withArgs('apiVersion')
-        .returns(configApiVersion);
+      const getUserConfiguredApiVersionStub = sb
+        .stub(executor, 'getUserConfiguredApiVersion')
+        .resolves(configApiVersion);
+      const getOrgApiVersionStub = sb
+        .stub(executor, 'getOrgApiVersion')
+        .resolves('40.0');
 
       await executor.run({ data: {}, type: 'CONTINUE' });
       const components = executor.lifecycle.doOperationStub.firstCall.args[0];

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
@@ -194,28 +194,35 @@ describe('Base Deploy Retrieve Commands', () => {
     it('should use the api version from SFDX configuration', async () => {
       const executor = new TestDeployRetrieve();
       const configApiVersion = '30.0';
-      sb.stub(ConfigUtil, 'getUserConfiguredApiVersion').resolves(
-        configApiVersion
-      );
+      const getUserConfiguredApiVersionStub = sb
+        .stub(ConfigUtil, 'getUserConfiguredApiVersion')
+        .resolves(configApiVersion);
       const getOrgApiVersionSpy = sb.spy(OrgAuthInfo, 'getOrgApiVersion');
 
       await executor.run({ data: {}, type: 'CONTINUE' });
       const components = executor.lifecycle.doOperationStub.firstCall.args[0];
 
       expect(components.apiVersion).to.equal(configApiVersion);
+      expect(getUserConfiguredApiVersionStub.calledOnce).to.equal(true);
       expect(getOrgApiVersionSpy.called).to.equal(false);
     });
 
     it('should use the api version from the Org when no User-configured api version is set', async () => {
       const executor = new TestDeployRetrieve();
       const orgApiVersion = '40.0';
-      sb.stub(ConfigUtil, 'getUserConfiguredApiVersion').resolves(undefined);
-      sb.stub(OrgAuthInfo, 'getOrgApiVersion').resolves(orgApiVersion);
+      const getUserConfiguredApiVersionStub = sb
+        .stub(ConfigUtil, 'getUserConfiguredApiVersion')
+        .resolves(undefined);
+      const getOrgApiVersionSpy = sb
+        .stub(OrgAuthInfo, 'getOrgApiVersion')
+        .resolves(orgApiVersion);
 
       await executor.run({ data: {}, type: 'CONTINUE' });
       const components = executor.lifecycle.doOperationStub.firstCall.args[0];
 
       expect(components.apiVersion).to.equal(orgApiVersion);
+      expect(getUserConfiguredApiVersionStub.calledOnce).to.equal(true);
+      expect(getOrgApiVersionSpy.calledOnce).to.equal(true);
     });
 
     it('should not override api version if getComponents set it already', async () => {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
@@ -193,8 +193,6 @@ describe('Base Deploy Retrieve Commands', () => {
 
     it('should use the api version from SFDX configuration', async () => {
       const executor = new TestDeployRetrieve();
-      //todo: stub out getOrgApiVersion instead - won't need a username and
-      // wont have to change this test file when switch to not use getConfigValue
       const configApiVersion = '30.0';
       sb.stub(ConfigUtil, 'getUserConfiguredApiVersion').resolves(
         configApiVersion

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
@@ -203,7 +203,7 @@ describe('Base Deploy Retrieve Commands', () => {
       const components = executor.lifecycle.doOperationStub.firstCall.args[0];
 
       expect(components.apiVersion).to.equal(configApiVersion);
-      expect(getOrgApiVersionSpy.called).to.be.false;
+      expect(getOrgApiVersionSpy.called).to.equal(false);
     });
 
     it('should use the api version from the Org when no User-configured api version is set', async () => {


### PR DESCRIPTION
### What does this PR do?
Uses the Api Version from the order associated with the default username when deploying components, if there is no local or global value that has been configured by the user in settings.

### What issues does this PR fix or reference?
@W-11555227@

### Functionality Before
<insert gif and/or summary>

### Functionality After
<insert gif and/or summary>
