### PR TITLE
fix: missing error label

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-apex/src/messages/i18n.ts
@@ -56,8 +56,6 @@ export const messages = {
   force_apex_test_run_codeAction_no_method_test_param_text:
     'Test method not provided. Run the code action on a method annotated with @isTest or testMethod.',
   force_apex_test_run_text: 'SFDX: Run Apex Tests',
-  force_sobjects_no_refresh_if_already_active_error_text:
-    'A refresh of your sObject definitions is already underway. If you need to restart the process, cancel the running task.',
   force_test_view_loading_message: 'Loading Apex tests ...',
   force_test_view_no_tests_message: 'No Apex Tests Found',
   force_test_view_show_error_title: 'Show Error',

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -629,6 +629,8 @@ export const messages = {
   sobject_refresh_all: 'All SObjects',
   sobject_refresh_custom: 'Custom SObjects',
   sobject_refresh_standard: 'Standard SObjects',
+  force_sobjects_no_refresh_if_already_active_error_text:
+    'A refresh of your sObject definitions is already underway. If you need to restart the process, cancel the running task.',
   force_rename_lightning_component: 'SFDX: Rename Component',
   rename_component_input_dup_error:
     'Component name is already in use in LWC or Aura',


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Moves an error message from one i18n file to another in different packages so that the message is displayed correctly 

### What issues does this PR fix or reference?
#4351, @W-11555524@

### Functionality Before
<img width="551" alt="Screen Shot 2022-08-05 at 10 27 39 AM" src="https://user-images.githubusercontent.com/60243824/183145782-d1036141-b762-4e79-934e-23ef4c0276ec.png">


### Functionality After
<img width="566" alt="Screen Shot 2022-08-05 at 10 27 04 AM" src="https://user-images.githubusercontent.com/60243824/183145813-422cc233-365a-4226-aaa4-1afe38558bb5.png">

