### PR TITLE
fix: flushFilePath() with fix for Windows

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/helpers/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/index.ts
@@ -5,14 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export { isNullOrUndefined, extractJsonObject } from './utils';
-export {
-  isAlphaNumString,
-  isInteger,
-  isIntegerInRange,
-  isAlphaNumSpaceString,
-  isRecordIdFormat
-} from './validations';
 export {
   ensureDirectoryExists,
   getTestResultsFolder,
@@ -21,3 +13,16 @@ export {
 } from './paths';
 export { TraceFlags } from './traceFlags';
 export { TraceFlagsRemover } from './traceFlagsRemover';
+export {
+  isNullOrUndefined,
+  extractJsonObject,
+  flushFilePath,
+  flushFilePaths
+} from './utils';
+export {
+  isAlphaNumString,
+  isInteger,
+  isIntegerInRange,
+  isAlphaNumSpaceString,
+  isRecordIdFormat
+} from './validations';

--- a/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
@@ -5,6 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import * as fs from 'fs';
+
 export function isNullOrUndefined(object: any): object is null | undefined {
   if (object === null || object === undefined) {
     return true;
@@ -14,11 +16,40 @@ export function isNullOrUndefined(object: any): object is null | undefined {
 }
 
 export function extractJsonObject(str: string): any {
-
-  const jsonString = str.substring(
-    str.indexOf('{'),
-    str.lastIndexOf('}') + 1
-  );
+  const jsonString = str.substring(str.indexOf('{'), str.lastIndexOf('}') + 1);
 
   return JSON.parse(jsonString);
+}
+
+// There's a bug in VS Code where, after a file has been renamed,
+// the URI that VS Code passes to the command is stale and is the
+// original URI.  See https://github.com/microsoft/vscode/issues/152993.
+//
+// To get around this, fs.realpathSync.native() is called to get the
+// URI with the actual file name.
+export function flushFilePath(filePath: string): string {
+  if (filePath === '') {
+    return filePath;
+  }
+
+  let nativePath = fs.realpathSync.native(filePath);
+  if (/^win32/.test(process.platform)) {
+    // The file path on Windows is in the form of "c:\Users\User Name\foo.cls".
+    // When called, fs.realpathSync.native() is returning the file path back as
+    // "C:\Users\User Name\foo.cls", and the capitalization of the drive letter
+    // causes problems further down stream.  To fix this, we'll use the path
+    // returned from fs.realpathSync.native() and then capitalize the first
+    // character.
+    nativePath = nativePath.charAt(0).toLowerCase() + nativePath.slice(1);
+  }
+
+  return nativePath;
+}
+
+export function flushFilePaths(filePaths: string[]): string[] {
+  for (let i = 0; i < filePaths.length; i++) {
+    filePaths[i] = flushFilePath(filePaths[i]);
+  }
+
+  return filePaths;
 }

--- a/packages/salesforcedx-utils-vscode/test/unit/helpers/utils.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/unit/helpers/utils.test.ts
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (c) 2019, salesforce.com, inc.
  * All rights reserved.
@@ -7,20 +6,99 @@
  */
 
 import { expect } from 'chai';
-import { extractJsonObject } from '../../../src/helpers';
+import * as fs from 'fs';
+import * as sinon from 'sinon';
+import {
+  extractJsonObject,
+  flushFilePath,
+  flushFilePaths
+} from '../../../src/helpers';
 
 describe('getConfigSource', () => {
-
   it('should extract a JSON string from larger string and then return as an object', async () => {
-
-    const exampleJsonString = JSON.stringify({ name: 'exampleName', error: 'exampleError' });
+    const exampleJsonString = JSON.stringify({
+      name: 'exampleName',
+      error: 'exampleError'
+    });
     const exampleString = `junk text <junk +text junk text ${exampleJsonString} junk text junk text junk text`;
 
     const testParse = extractJsonObject(exampleString);
 
     expect(testParse.name).to.equal('exampleName');
     expect(testParse.error).to.equal('exampleError');
+  });
+});
 
+describe('flushFilePath', () => {
+  it('should call fs.realpathSync.native() to resolve a path', async () => {
+    const filePath = 'C:\\Users\\temp\\exampleFile.js';
+    const realpathSyncNativeStub = sinon
+      .stub(fs.realpathSync, 'native')
+      .returns(filePath);
+
+    const result = flushFilePath(filePath);
+
+    expect(realpathSyncNativeStub.called).to.equal(true);
+    expect(realpathSyncNativeStub.calledOnce).to.equal(true);
+    expect(realpathSyncNativeStub.args[0][0]).to.equal(filePath);
+
+    realpathSyncNativeStub.restore();
   });
 
+  it('should return a path when a path is passed in', async () => {
+    const filePath = 'C:\\Users\\temp\\exampleFile.js';
+    const realpathSyncNativeStub = sinon
+      .stub(fs.realpathSync, 'native')
+      .returns(filePath);
+
+    const result = flushFilePath(filePath);
+
+    expect(result).to.equal(filePath);
+
+    realpathSyncNativeStub.restore();
+  });
+
+  it('should return an empty string when an empty sting is passed in', async () => {
+    const filePath = 'c:\\Users\\temp\\exampleFile.js';
+    const realpathSyncNativeStub = sinon
+      .stub(fs.realpathSync, 'native')
+      .returns('');
+
+    const result = flushFilePath(filePath);
+
+    expect(result).to.equal('');
+
+    realpathSyncNativeStub.restore();
+  });
+
+  it('should validate the correct path is returned when running on Windows', async () => {
+    const filePath = 'c:\\Users\\User Name\\foo.cls';
+    const realpathSyncFilePath = 'C:\\Users\\User Name\\foo.cls';
+    const realpathSyncNativeStub = sinon
+      .stub(fs.realpathSync, 'native')
+      .returns(realpathSyncFilePath);
+    const processPlatformStub = sinon.stub(process, 'platform').value('win32');
+
+    const result = flushFilePath(filePath);
+
+    expect(result).to.equal(filePath);
+
+    processPlatformStub.restore();
+    realpathSyncNativeStub.restore();
+  });
+});
+
+describe('flushFilePaths', () => {
+  it('should return the same paths that are passed in', async () => {
+    const filePaths = ['file.js', 'file.js', 'file.js'];
+    const realpathSyncNativeStub = sinon
+      .stub(fs.realpathSync, 'native')
+      .returns(filePaths[0]);
+
+    const result = flushFilePaths(filePaths);
+
+    expect(result).to.equal(filePaths);
+
+    realpathSyncNativeStub.restore();
+  });
 });

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceLaunchApexReplayDebuggerWithCurrentFile.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/forceLaunchApexReplayDebuggerWithCurrentFile.test.ts
@@ -7,6 +7,7 @@
 import { testSetup } from '@salesforce/core/lib/testSetup';
 import { SfdxCommandlet } from '@salesforce/salesforcedx-utils-vscode/out/src';
 import { notificationService } from '@salesforce/salesforcedx-utils-vscode/out/src/commands';
+import * as helpers from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import { expect } from 'chai';
 import { createSandbox, SinonSandbox } from 'sinon';
 import * as vscode from 'vscode';
@@ -28,8 +29,7 @@ describe('Force Launch Replay Debugger', () => {
   });
 
   it('should return an error when the editor is not found', async () => {
-    sb.stub(vscode.window, 'activeTextEditor')
-      .get(() => undefined);
+    sb.stub(vscode.window, 'activeTextEditor').get(() => undefined);
 
     const showErrorMessageStub = sb.stub(
       notificationService,
@@ -44,13 +44,12 @@ describe('Force Launch Replay Debugger', () => {
     ).to.equal(true);
   });
 
-  it('should return an error when the document\'s URI is not found', async () => {
-    sb.stub(vscode.window, 'activeTextEditor')
-      .get(() => ({
-        document: {
-          uri: undefined
-        }
-      }));
+  it("should return an error when the document's URI is not found", async () => {
+    sb.stub(vscode.window, 'activeTextEditor').get(() => ({
+      document: {
+        uri: undefined
+      }
+    }));
 
     const showErrorMessageStub = sb.stub(
       notificationService,
@@ -66,39 +65,41 @@ describe('Force Launch Replay Debugger', () => {
   });
 
   it('should return an error when not a log file, not an anon apex file, and not an apex test class', async () => {
-    sb.stub(vscode.window, 'activeTextEditor')
-      .get(() => ({
-        document: {
-          uri: vscode.Uri.file('foo.txt')
-        }
-      }));
+    sb.stub(vscode.window, 'activeTextEditor').get(() => ({
+      document: {
+        uri: vscode.Uri.file('foo.txt')
+      }
+    }));
 
     const showErrorMessageStub = sb.stub(
       notificationService,
       'showErrorMessage'
     );
 
-    sb.stub(ApexTestOutlineProvider.prototype, 'refresh')
-      .returns(undefined);
+    sb.stub(ApexTestOutlineProvider.prototype, 'refresh').returns(undefined);
 
-    sb.stub(ApexTestOutlineProvider.prototype, 'getTestClassName')
-      .returns(undefined);
+    sb.stub(ApexTestOutlineProvider.prototype, 'getTestClassName').returns(
+      undefined
+    );
+
+    sb.stub(helpers, 'flushFilePath').returns(undefined);
 
     await forceLaunchApexReplayDebuggerWithCurrentFile();
 
     expect(showErrorMessageStub.called).to.equal(true);
     expect(
-      showErrorMessageStub.calledWith(nls.localize('launch_apex_replay_debugger_unsupported_file'))
+      showErrorMessageStub.calledWith(
+        nls.localize('launch_apex_replay_debugger_unsupported_file')
+      )
     ).to.equal(true);
   });
 
   it('should call executeCommand() if file is a log file', async () => {
-    sb.stub(vscode.window, 'activeTextEditor')
-      .get(() => ({
-        document: {
-          uri: vscode.Uri.file('foo.log')
-        }
-      }));
+    sb.stub(vscode.window, 'activeTextEditor').get(() => ({
+      document: {
+        uri: vscode.Uri.file('foo.log')
+      }
+    }));
 
     const executeCommandSpy = sb.spy(vscode.commands, 'executeCommand');
 
@@ -111,15 +112,13 @@ describe('Force Launch Replay Debugger', () => {
   });
 
   it('should call SfdxCommandlet.run() if file is an anon apex file', async () => {
-    sb.stub(vscode.window, 'activeTextEditor')
-      .get(() => ({
-        document: {
-          uri: vscode.Uri.file('foo.apex')
-        }
-      }));
+    sb.stub(vscode.window, 'activeTextEditor').get(() => ({
+      document: {
+        uri: vscode.Uri.file('foo.apex')
+      }
+    }));
 
-    const runStub = sb.stub(SfdxCommandlet.prototype, 'run')
-      .returns(undefined);
+    const runStub = sb.stub(SfdxCommandlet.prototype, 'run').returns(undefined);
 
     await forceLaunchApexReplayDebuggerWithCurrentFile();
 
@@ -127,21 +126,21 @@ describe('Force Launch Replay Debugger', () => {
   });
 
   it('should call executeCommand if file is an apex test class', async () => {
-    sb.stub(vscode.window, 'activeTextEditor')
-      .get(() => ({
-        document: {
-          uri: vscode.Uri.file('foo.cls')
-        }
-      }));
+    sb.stub(vscode.window, 'activeTextEditor').get(() => ({
+      document: {
+        uri: vscode.Uri.file('foo.cls')
+      }
+    }));
 
-    sb.stub(ApexTestOutlineProvider.prototype, 'refresh')
-      .returns(undefined);
+    sb.stub(ApexTestOutlineProvider.prototype, 'refresh').returns(undefined);
 
-    sb.stub(ApexTestOutlineProvider.prototype, 'getTestClassName')
-      .returns('foo.cls');
+    sb.stub(ApexTestOutlineProvider.prototype, 'getTestClassName').returns(
+      'foo.cls'
+    );
 
-    sb.stub(SfdxCommandlet.prototype, 'run')
-      .returns(undefined);
+    sb.stub(SfdxCommandlet.prototype, 'run').returns(undefined);
+
+    sb.stub(helpers, 'flushFilePath').returns('foo.cls');
 
     const executeCommandSpy = sb.spy(vscode.commands, 'executeCommand');
 

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDelete.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDelete.ts
@@ -10,6 +10,7 @@ import {
   Command,
   SfdxCommandBuilder
 } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import { flushFilePath } from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import {
   CancelResponse,
   ContinueResponse,
@@ -17,13 +18,12 @@ import {
   PreconditionChecker
 } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import * as vscode from 'vscode';
-import { SfdxCommandlet, SfdxCommandletExecutor } from './util/sfdxCommandlet';
-
 import { channelService } from '../channels';
 import { nls } from '../messages';
 import { notificationService } from '../notifications';
 import { telemetryService } from '../telemetry';
 import { getRootWorkspacePath, hasRootWorkspace } from '../util';
+import { SfdxCommandlet, SfdxCommandletExecutor } from './util/sfdxCommandlet';
 
 export class ForceSourceDeleteExecutor extends SfdxCommandletExecutor<{
   filePath: string;
@@ -43,7 +43,7 @@ export class ManifestChecker implements PreconditionChecker {
   private explorerPath: string;
 
   public constructor(uri: vscode.Uri) {
-    this.explorerPath = uri.fsPath;
+    this.explorerPath = flushFilePath(uri.fsPath);
   }
 
   public check(): boolean {
@@ -70,7 +70,7 @@ export class ConfirmationAndSourcePathGatherer
   private readonly CANCEL = nls.localize('cancel_delete_source_button_text');
 
   public constructor(uri: vscode.Uri) {
-    this.explorerPath = uri.fsPath;
+    this.explorerPath = flushFilePath(uri.fsPath);
   }
 
   public async gather(): Promise<

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploySourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploySourcePath.ts
@@ -4,12 +4,8 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import {
-  SfdxCommandBuilder
-} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
-import {
-  ContinueResponse
-} from '@salesforce/salesforcedx-utils-vscode/out/src/types';
+import { SfdxCommandBuilder } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import { ComponentSet } from '@salesforce/source-deploy-retrieve';
 import * as vscode from 'vscode';
 import { channelService } from '../channels';
@@ -30,9 +26,7 @@ import {
   TimestampConflictChecker
 } from './util/postconditionCheckers';
 
-export class LibraryDeploySourcePathExecutor extends DeployExecutor<
-  string[]
-> {
+export class LibraryDeploySourcePathExecutor extends DeployExecutor<string[]> {
   constructor() {
     super(
       nls.localize('force_source_deploy_text'),
@@ -43,8 +37,11 @@ export class LibraryDeploySourcePathExecutor extends DeployExecutor<
   public async getComponents(
     response: ContinueResponse<string[]>
   ): Promise<ComponentSet> {
-    const sourceApiVersion = (await SfdxProjectConfig.getValue('sourceApiVersion')) as string;
-    const paths = typeof response.data === 'string' ? [response.data] : response.data;
+    const sourceApiVersion = (await SfdxProjectConfig.getValue(
+      'sourceApiVersion'
+    )) as string;
+    const paths =
+      typeof response.data === 'string' ? [response.data] : response.data;
     const componentSet = ComponentSet.fromSource(paths);
     componentSet.sourceApiVersion = sourceApiVersion;
     return componentSet;
@@ -52,7 +49,7 @@ export class LibraryDeploySourcePathExecutor extends DeployExecutor<
 }
 
 export const forceSourceDeploySourcePaths = async (
-  sourceUri: vscode.Uri | vscode.Uri[] |undefined,
+  sourceUri: vscode.Uri | vscode.Uri[] | undefined,
   uris: vscode.Uri[] | undefined
 ) => {
   if (!sourceUri) {

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveSourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveSourcePath.ts
@@ -4,30 +4,26 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import {
-  SfdxCommandBuilder
-} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
-import { PostconditionChecker } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
+import { SfdxCommandBuilder } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import {
   CancelResponse,
-  ContinueResponse
+  ContinueResponse,
+  PostconditionChecker
 } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import { ComponentSet } from '@salesforce/source-deploy-retrieve';
 import * as vscode from 'vscode';
-import { channelService } from '../channels';
-import { nls } from '../messages';
-import { notificationService } from '../notifications';
-import { SfdxPackageDirectories, SfdxProjectConfig } from '../sfdxProject';
-import { telemetryService } from '../telemetry';
 import { RetrieveExecutor } from './baseDeployRetrieve';
 import {
   LibraryPathsGatherer,
   SfdxCommandlet,
   SfdxWorkspaceChecker
 } from './util';
-import {
-  ConflictDetectionMessages
-} from './util/postconditionCheckers';
+import { ConflictDetectionMessages } from './util/postconditionCheckers';
+import { channelService } from '../channels';
+import { nls } from '../messages';
+import { notificationService } from '../notifications';
+import { SfdxPackageDirectories, SfdxProjectConfig } from '../sfdxProject';
+import { telemetryService } from '../telemetry';
 
 export class LibraryRetrieveSourcePathExecutor extends RetrieveExecutor<
   string[]
@@ -42,8 +38,11 @@ export class LibraryRetrieveSourcePathExecutor extends RetrieveExecutor<
   public async getComponents(
     response: ContinueResponse<string[]>
   ): Promise<ComponentSet> {
-    const sourceApiVersion = (await SfdxProjectConfig.getValue('sourceApiVersion')) as string;
-    const paths = typeof response.data === 'string' ? [response.data] : response.data;
+    const sourceApiVersion = (await SfdxProjectConfig.getValue(
+      'sourceApiVersion'
+    )) as string;
+    const paths =
+      typeof response.data === 'string' ? [response.data] : response.data;
     const componentSet = ComponentSet.fromSource(paths);
     componentSet.sourceApiVersion = sourceApiVersion;
     return componentSet;

--- a/packages/salesforcedx-vscode-core/src/commands/util/libraryPathsGatherer.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/libraryPathsGatherer.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { flushFilePaths } from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import {
   ContinueResponse,
   ParametersGatherer
@@ -12,14 +13,18 @@ import * as vscode from 'vscode';
 
 export class LibraryPathsGatherer implements ParametersGatherer<string[]> {
   private uris: vscode.Uri[];
+
   public constructor(uris: vscode.Uri[]) {
     this.uris = uris;
   }
+
   public async gather(): Promise<ContinueResponse<string[]>> {
     const sourcePaths = this.uris.map(uri => uri.fsPath);
+    const flushedSourcePaths = flushFilePaths(sourcePaths);
+
     return {
       type: 'CONTINUE',
-      data: sourcePaths
+      data: flushedSourcePaths
     };
   }
 }

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -13,7 +13,7 @@
  * decorations, e.g., $(x) uses the https://octicons.github.com/ and should not
  * be localized
  *
- * If ommitted, we will assume _message.
+ * If omitted, we will assume _message.
  */
 export const messages = {
   channel_name: 'Salesforce CLI',
@@ -646,8 +646,7 @@ export const messages = {
   error_function_type: 'Unable to determine type of executing function.',
   error_unable_to_get_started_function:
     'Unable to access the function in "{0}".',
-  pending_org_expiration_expires_on_message:
-    '%s\n(expires on %s)',
+  pending_org_expiration_expires_on_message: '%s\n(expires on %s)',
   pending_org_expiration_notification_message:
     'Warning: One or more of your orgs expire in the next %s days. For more details, review the Output panel.',
   pending_org_expiration_output_channel_message:

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceDelete.test.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import * as helpers from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import { expect } from 'chai';
 import * as path from 'path';
@@ -51,35 +52,51 @@ describe('ManifestChecker', () => {
       'package.xml'
     );
     const manifestUri = { fsPath: manifestFilePath } as vscode.Uri;
+    const flushFilePathStub = sinon
+      .stub(helpers, 'flushFilePath')
+      .returns(manifestFilePath);
     const checker = new ManifestChecker(manifestUri);
     const response = checker.check();
     expect(response).to.be.false;
+
+    flushFilePathStub.restore();
   });
 
   it('passes the check if the selected resource is not in the manifest directory', () => {
     const sourcePath = path.join(workspaceFolderPath, 'src', 'exampleFile.js');
     const sourceUri = { fsPath: sourcePath } as vscode.Uri;
+    const flushFilePathStub = sinon
+      .stub(helpers, 'flushFilePath')
+      .returns(sourcePath);
     const checker = new ManifestChecker(sourceUri);
     const response = checker.check();
     expect(response).to.be.true;
+
+    flushFilePathStub.restore();
   });
 });
 
 describe('ConfirmationAndSourcePathGatherer', () => {
   const examplePath = path.join('example', 'path');
-  const explorerPath = { fsPath: examplePath } as vscode.Uri;
+  const explorerPathUri = { fsPath: examplePath } as vscode.Uri;
 
   let informationMessageStub: sinon.SinonStub;
+  let flushFilePathStub: sinon.SinonStub;
 
   beforeEach(() => {
     informationMessageStub = sinon.stub(
       vscode.window,
       'showInformationMessage'
     );
+
+    flushFilePathStub = sinon.stub(helpers, 'flushFilePath');
+
+    flushFilePathStub.returns(examplePath);
   });
 
   afterEach(() => {
     informationMessageStub.restore();
+    flushFilePathStub.restore();
   });
 
   it('Should return cancel if the user cancels the command', async () => {
@@ -87,7 +104,7 @@ describe('ConfirmationAndSourcePathGatherer', () => {
       nls.localize('cancel_delete_source_button_text')
     );
 
-    const gatherer = new ConfirmationAndSourcePathGatherer(explorerPath);
+    const gatherer = new ConfirmationAndSourcePathGatherer(explorerPathUri);
     const response = await gatherer.gather();
     expect(informationMessageStub.calledOnce).to.be.true;
     expect(response.type).to.equal('CANCEL');
@@ -98,7 +115,7 @@ describe('ConfirmationAndSourcePathGatherer', () => {
       nls.localize('confirm_delete_source_button_text')
     );
 
-    const gatherer = new ConfirmationAndSourcePathGatherer(explorerPath);
+    const gatherer = new ConfirmationAndSourcePathGatherer(explorerPathUri);
     const response = (await gatherer.gather()) as ContinueResponse<{
       filePath: string;
     }>;

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveSourcePath.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceSourceRetrieveSourcePath.test.ts
@@ -7,6 +7,7 @@
 
 import { AuthInfo, Connection } from '@salesforce/core';
 import { MockTestOrgData, testSetup } from '@salesforce/core/lib/testSetup';
+import * as helpers from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import {
   CancelResponse,
   ContinueResponse
@@ -29,7 +30,10 @@ import * as forceSourceRetrieveSourcePath from '../../../src/commands/forceSourc
 import { workspaceContext } from '../../../src/context';
 import { nls } from '../../../src/messages';
 import { notificationService } from '../../../src/notifications';
-import { SfdxPackageDirectories, SfdxProjectConfig } from '../../../src/sfdxProject';
+import {
+  SfdxPackageDirectories,
+  SfdxProjectConfig
+} from '../../../src/sfdxProject';
 import { getRootWorkspacePath } from '../../../src/util';
 
 const sb = createSandbox();
@@ -106,7 +110,10 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
 
     it('componentSet has sourceApiVersion set', async () => {
       const executor = new LibraryRetrieveSourcePathExecutor();
-      const data = path.join(getRootWorkspacePath(), 'force-app/main/default/classes/');
+      const data = path.join(
+        getRootWorkspacePath(),
+        'force-app/main/default/classes/'
+      );
       const continueResponse = {
         type: 'CONTINUE',
         data: [data]
@@ -127,11 +134,19 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
       const filePaths = uris.map(uri => {
         return uri.fsPath;
       });
-      const sourcePathCheckerCheckStub = sb.stub(
-        SourcePathChecker.prototype, 'check').returns({
-        type: 'CONTINUE',
-        data: filePaths
-      });
+      const sourcePathCheckerCheckStub = sb
+        .stub(SourcePathChecker.prototype, 'check')
+        .returns({
+          type: 'CONTINUE',
+          data: filePaths
+        });
+      const flushFilePathsStub = sb
+        .stub(helpers, 'flushFilePaths')
+        .returns([
+          path.sep + filePath1,
+          path.sep + filePath2,
+          path.sep + filePath3
+        ]);
 
       await forceSourceRetrieveSourcePath.forceSourceRetrieveSourcePaths(
         uris[0],
@@ -139,23 +154,31 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
       );
 
       expect(sourcePathCheckerCheckStub.called).to.equal(true);
-      const continueResponse = sourcePathCheckerCheckStub.args[0][0] as ContinueResponse<string[]>;
-      expect(JSON.stringify(continueResponse.data)).to.equal(JSON.stringify(filePaths));
+      const continueResponse = sourcePathCheckerCheckStub
+        .args[0][0] as ContinueResponse<string[]>;
+      expect(JSON.stringify(continueResponse.data)).to.equal(
+        JSON.stringify(filePaths)
+      );
+
+      flushFilePathsStub.restore();
+      sourcePathCheckerCheckStub.restore();
     });
 
     it('should retrieve a single file', async () => {
       const filePath1 = path.join('classes', 'MyClass1.cls');
-      const uris = [
-        vscode.Uri.file(filePath1)
-      ];
+      const uris = [vscode.Uri.file(filePath1)];
       const filePaths = uris.map(uri => {
         return uri.fsPath;
       });
-      const sourcePathCheckerCheckStub = sb.stub(
-        SourcePathChecker.prototype, 'check').returns({
-        type: 'CONTINUE',
-        data: filePaths
-      });
+      const sourcePathCheckerCheckStub = sb
+        .stub(SourcePathChecker.prototype, 'check')
+        .returns({
+          type: 'CONTINUE',
+          data: filePaths
+        });
+      const flushFilePathsStub = sb
+        .stub(helpers, 'flushFilePaths')
+        .returns([path.sep + filePath1]);
 
       await forceSourceRetrieveSourcePath.forceSourceRetrieveSourcePaths(
         uris[0],
@@ -163,23 +186,31 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
       );
 
       expect(sourcePathCheckerCheckStub.called).to.equal(true);
-      const continueResponse = sourcePathCheckerCheckStub.args[0][0] as ContinueResponse<string[]>;
-      expect(JSON.stringify(continueResponse.data)).to.equal(JSON.stringify(filePaths));
+      const continueResponse = sourcePathCheckerCheckStub
+        .args[0][0] as ContinueResponse<string[]>;
+      expect(JSON.stringify(continueResponse.data)).to.equal(
+        JSON.stringify(filePaths)
+      );
+
+      flushFilePathsStub.restore();
+      sourcePathCheckerCheckStub.restore();
     });
 
     it('should retrieve when editing a single file and "Retrieve This Source from Org" is executed', async () => {
       const filePath1 = path.join('classes', 'MyClass1.cls');
-      const uris = [
-        vscode.Uri.file(filePath1)
-      ];
+      const uris = [vscode.Uri.file(filePath1)];
       const filePaths = uris.map(uri => {
         return uri.fsPath;
       });
-      const sourcePathCheckerCheckStub = sb.stub(
-        SourcePathChecker.prototype, 'check').returns({
-        type: 'CONTINUE',
-        data: filePaths
-      });
+      const sourcePathCheckerCheckStub = sb
+        .stub(SourcePathChecker.prototype, 'check')
+        .returns({
+          type: 'CONTINUE',
+          data: filePaths
+        });
+      const flushFilePathsStub = sb
+        .stub(helpers, 'flushFilePaths')
+        .returns([path.sep + filePath1]);
 
       await forceSourceRetrieveSourcePath.forceSourceRetrieveSourcePaths(
         uris[0],
@@ -187,8 +218,14 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
       );
 
       expect(sourcePathCheckerCheckStub.called).to.equal(true);
-      const continueResponse = sourcePathCheckerCheckStub.args[0][0] as ContinueResponse<string[]>;
-      expect(JSON.stringify(continueResponse.data)).to.equal(JSON.stringify(filePaths));
+      const continueResponse = sourcePathCheckerCheckStub
+        .args[0][0] as ContinueResponse<string[]>;
+      expect(JSON.stringify(continueResponse.data)).to.equal(
+        JSON.stringify(filePaths)
+      );
+
+      flushFilePathsStub.restore();
+      sourcePathCheckerCheckStub.restore();
     });
 
     it('should retrieve when using the command palette', async () => {
@@ -201,14 +238,19 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
       const sourceUri = undefined;
       const uris = undefined;
 
-      const filePaths = [ filePath1 ];
-      const sourcePathCheckerCheckStub = sb.stub(
-        SourcePathChecker.prototype, 'check').returns({
-        type: 'CONTINUE',
-        data: filePaths
-      });
-
-      const getUriFromActiveEditorStub = sb.stub(forceSourceRetrieveSourcePath, 'getUriFromActiveEditor').returns(filePath1);
+      const filePaths = [filePath1];
+      const sourcePathCheckerCheckStub = sb
+        .stub(SourcePathChecker.prototype, 'check')
+        .returns({
+          type: 'CONTINUE',
+          data: filePaths
+        });
+      const getUriFromActiveEditorStub = sb
+        .stub(forceSourceRetrieveSourcePath, 'getUriFromActiveEditor')
+        .returns(filePath1);
+      const flushFilePathsStub = sb
+        .stub(helpers, 'flushFilePaths')
+        .returns([undefined]);
 
       await forceSourceRetrieveSourcePath.forceSourceRetrieveSourcePaths(
         sourceUri,
@@ -216,6 +258,10 @@ describe('Force Source Retrieve with Sourcepath Option', () => {
       );
 
       expect(getUriFromActiveEditorStub.called).to.equal(true);
+
+      flushFilePathsStub.restore();
+      getUriFromActiveEditorStub.restore();
+      sourcePathCheckerCheckStub.restore();
     });
   });
 });
@@ -247,7 +293,7 @@ describe('SourcePathChecker', () => {
     const sourcePath = path.join(workspacePath, 'package');
     const continueResponse = (await pathChecker.check({
       type: 'CONTINUE',
-      data: [ sourcePath ]
+      data: [sourcePath]
     })) as ContinueResponse<string[]>;
 
     expect(isInPackageDirectoryStub.getCall(0).args[0]).to.equal(sourcePath);
@@ -264,7 +310,7 @@ describe('SourcePathChecker', () => {
     const pathChecker = new SourcePathChecker();
     const cancelResponse = (await pathChecker.check({
       type: 'CONTINUE',
-      data: [ path.join('not', 'in', 'package', 'directory') ]
+      data: [path.join('not', 'in', 'package', 'directory')]
     })) as CancelResponse;
 
     const errorMessage = nls.localize(
@@ -283,7 +329,7 @@ describe('SourcePathChecker', () => {
     const pathChecker = new SourcePathChecker();
     const cancelResponse = (await pathChecker.check({
       type: 'CONTINUE',
-      data: [ 'test/path' ]
+      data: ['test/path']
     })) as CancelResponse;
 
     const errorMessage = nls.localize(

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/functions/forceFunctionStart/ForceFunctionContainerStartExecutor.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/functions/forceFunctionStart/ForceFunctionContainerStartExecutor.test.ts
@@ -314,10 +314,6 @@ describe('ForceFunctionContainerStartExecutor unit tests', () => {
 
       assert.calledOnce(fakeDisposible.dispose);
       assert.calledTwice(localizeStub);
-      console.log('what are the args', {
-        args0: sendExceptionStub.getCalls()[0].args[0],
-        args1: sendExceptionStub.getCalls()[0].args[1]
-      });
       assert.calledWith(
         sendExceptionStub,
         'force_function_start_docker_plugin_not_installed_or_started',


### PR DESCRIPTION
### What does this PR do?
There's a bug in VS Code, which Microsoft refuses to fix (see https://github.com/microsoft/vscode/issues/152993).  After a file has been renamed, if only the casing has changes (eg no characters added or removed) VS Code passes the stale path to commands.  This PR adds `flushFilePath()` and `flushFilePaths()` to fix this issue.


### What issues does this PR fix or reference?
#https://github.com/forcedotcom/salesforcedx-vscode/issues/3575, @W-10273785@

### Functionality Before
1. Rename an Apex class's file name (only changing the case of the filename), and rename it's metadata file
2. Open the file and change the name of the class to match
3. With the file open, right-click in the editor and select "SFDX : Deploy This Source to Org"
4. This results in an error in the output: "File name mismatch with class name"

### Functionality After
1-3: the same
4. This deployment succeeds 
