### PR TITLE
chore: bump version of @salesforce/core in all packages to 3.26.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5635,16 +5635,15 @@
       }
     },
     "node_modules/@salesforce/apex-node/node_modules/@salesforce/core": {
-      "version": "3.23.3",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.23.3.tgz",
-      "integrity": "sha512-nLrvvxq1PcrPZ53ylEkCvEVsnMuJLH7SW4F5GERBLNYGxqW6aZxjtoySqsMrYoHk53vCGtycno3j3KhaIYx1FQ==",
+      "version": "3.26.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.26.1.tgz",
+      "integrity": "sha512-B2mhsiiAu9hkLAwkDu+Y5ArAtRJIx2oeqP8ofupLlSH4tohzcUmfKgCDZEk9iLC1sc5kmD1S/4DlS1QZhnNs8A==",
       "dependencies": {
         "@salesforce/bunyan": "^2.0.0",
         "@salesforce/kit": "^1.5.41",
         "@salesforce/schemas": "^1.1.0",
         "@salesforce/ts-types": "^1.5.20",
         "@types/graceful-fs": "^4.1.5",
-        "@types/mkdirp": "^1.0.2",
         "@types/semver": "^7.3.9",
         "ajv": "^8.11.0",
         "archiver": "^5.3.0",
@@ -5654,9 +5653,8 @@
         "form-data": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "js2xmlparser": "^4.0.1",
-        "jsforce": "2.0.0-beta.14",
+        "jsforce": "beta",
         "jsonwebtoken": "8.5.1",
-        "mkdirp": "1.0.4",
         "ts-retry-promise": "^0.6.0"
       }
     },
@@ -5666,14 +5664,6 @@
       "integrity": "sha512-Ov6um4CWd63EvkRavkHG0J/P9XYL55sdkDWPMr7+AIgqh5flHxDRz09/C4e9M94aX30rzJxW4TVX6EBf4Cu2BQ==",
       "dependencies": {
         "tslib": "^2.2.0"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/@types/mkdirp": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.2.tgz",
-      "integrity": "sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@salesforce/apex-node/node_modules/@types/node": {
@@ -6095,17 +6085,6 @@
       "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
       },
       "engines": {
         "node": ">=10"
@@ -7004,16 +6983,15 @@
       }
     },
     "node_modules/@salesforce/source-deploy-retrieve/node_modules/@salesforce/core": {
-      "version": "3.20.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.20.1.tgz",
-      "integrity": "sha512-lOy+qJ9YxwUmvKG9eAvnWJn1yOHvd4G/3vuvUTXugj9G8JTqUyPwKFmWgIS2FSEBWkRIhDQnEIXbgrM6/ytC4A==",
+      "version": "3.26.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.26.1.tgz",
+      "integrity": "sha512-B2mhsiiAu9hkLAwkDu+Y5ArAtRJIx2oeqP8ofupLlSH4tohzcUmfKgCDZEk9iLC1sc5kmD1S/4DlS1QZhnNs8A==",
       "dependencies": {
         "@salesforce/bunyan": "^2.0.0",
         "@salesforce/kit": "^1.5.41",
         "@salesforce/schemas": "^1.1.0",
         "@salesforce/ts-types": "^1.5.20",
         "@types/graceful-fs": "^4.1.5",
-        "@types/mkdirp": "^1.0.2",
         "@types/semver": "^7.3.9",
         "ajv": "^8.11.0",
         "archiver": "^5.3.0",
@@ -7023,9 +7001,8 @@
         "form-data": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "js2xmlparser": "^4.0.1",
-        "jsforce": "2.0.0-beta.10",
+        "jsforce": "beta",
         "jsonwebtoken": "8.5.1",
-        "mkdirp": "1.0.4",
         "ts-retry-promise": "^0.6.0"
       }
     },
@@ -7035,14 +7012,6 @@
       "integrity": "sha512-Ov6um4CWd63EvkRavkHG0J/P9XYL55sdkDWPMr7+AIgqh5flHxDRz09/C4e9M94aX30rzJxW4TVX6EBf4Cu2BQ==",
       "dependencies": {
         "tslib": "^2.2.0"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/@types/mkdirp": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.2.tgz",
-      "integrity": "sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@salesforce/source-deploy-retrieve/node_modules/@types/node": {
@@ -7367,17 +7336,6 @@
       "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
       "dependencies": {
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@salesforce/source-deploy-retrieve/node_modules/ms": {
@@ -10451,7 +10409,6 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
       "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
-      "dev": true,
       "dependencies": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
@@ -11460,8 +11417,7 @@
     "node_modules/bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-      "dev": true
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -23270,8 +23226,7 @@
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
@@ -27434,6 +27389,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -27448,16 +27404,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -27471,6 +27430,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -27486,6 +27446,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -30185,6 +30146,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openpgp": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-5.4.0.tgz",
+      "integrity": "sha512-XgQnK8SYy4Ycg9BDvrXTE4foMwME/+1EfGZWZirUU2VPzU1X3xx094fChjbP10+gUJifAcoWTsT2zAbdhFUxyg==",
+      "dependencies": {
+        "asn1.js": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/opn": {
@@ -42405,16 +42377,15 @@
       }
     },
     "packages/salesforcedx-sobjects-faux-generator/node_modules/@salesforce/core": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.23.4.tgz",
-      "integrity": "sha512-gJB2NbWjxcN0SqOy3GLyzwUytYR1bmXZvUi7r8j0Eeu2L7qJFoYBgtkXBfIk7F/urFqYd4VRlXCeJj6ZQEWImw==",
+      "version": "3.26.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.26.1.tgz",
+      "integrity": "sha512-B2mhsiiAu9hkLAwkDu+Y5ArAtRJIx2oeqP8ofupLlSH4tohzcUmfKgCDZEk9iLC1sc5kmD1S/4DlS1QZhnNs8A==",
       "dependencies": {
         "@salesforce/bunyan": "^2.0.0",
         "@salesforce/kit": "^1.5.41",
         "@salesforce/schemas": "^1.1.0",
         "@salesforce/ts-types": "^1.5.20",
         "@types/graceful-fs": "^4.1.5",
-        "@types/mkdirp": "^1.0.2",
         "@types/semver": "^7.3.9",
         "ajv": "^8.11.0",
         "archiver": "^5.3.0",
@@ -42424,9 +42395,8 @@
         "form-data": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "js2xmlparser": "^4.0.1",
-        "jsforce": "2.0.0-beta.14",
+        "jsforce": "beta",
         "jsonwebtoken": "8.5.1",
-        "mkdirp": "1.0.4",
         "ts-retry-promise": "^0.6.0"
       }
     },
@@ -42505,14 +42475,6 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
       "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
       "dev": true
-    },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/@types/mkdirp": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.2.tgz",
-      "integrity": "sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "packages/salesforcedx-sobjects-faux-generator/node_modules/@webassemblyjs/ast": {
       "version": "1.11.1",
@@ -43016,17 +42978,6 @@
       "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
       "dependencies": {
         "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "packages/salesforcedx-sobjects-faux-generator/node_modules/ms": {
@@ -43679,16 +43630,15 @@
       }
     },
     "packages/salesforcedx-utils-vscode/node_modules/@salesforce/core": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.23.4.tgz",
-      "integrity": "sha512-gJB2NbWjxcN0SqOy3GLyzwUytYR1bmXZvUi7r8j0Eeu2L7qJFoYBgtkXBfIk7F/urFqYd4VRlXCeJj6ZQEWImw==",
+      "version": "3.26.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.26.1.tgz",
+      "integrity": "sha512-B2mhsiiAu9hkLAwkDu+Y5ArAtRJIx2oeqP8ofupLlSH4tohzcUmfKgCDZEk9iLC1sc5kmD1S/4DlS1QZhnNs8A==",
       "dependencies": {
         "@salesforce/bunyan": "^2.0.0",
         "@salesforce/kit": "^1.5.41",
         "@salesforce/schemas": "^1.1.0",
         "@salesforce/ts-types": "^1.5.20",
         "@types/graceful-fs": "^4.1.5",
-        "@types/mkdirp": "^1.0.2",
         "@types/semver": "^7.3.9",
         "ajv": "^8.11.0",
         "archiver": "^5.3.0",
@@ -43698,18 +43648,9 @@
         "form-data": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "js2xmlparser": "^4.0.1",
-        "jsforce": "2.0.0-beta.14",
+        "jsforce": "beta",
         "jsonwebtoken": "8.5.1",
-        "mkdirp": "1.0.4",
         "ts-retry-promise": "^0.6.0"
-      }
-    },
-    "packages/salesforcedx-utils-vscode/node_modules/@salesforce/core/node_modules/@types/mkdirp": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.2.tgz",
-      "integrity": "sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "packages/salesforcedx-utils-vscode/node_modules/@salesforce/ts-types": {
@@ -44092,17 +44033,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "packages/salesforcedx-utils-vscode/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "packages/salesforcedx-utils-vscode/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -44439,16 +44369,15 @@
       }
     },
     "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/@salesforce/core": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.23.4.tgz",
-      "integrity": "sha512-gJB2NbWjxcN0SqOy3GLyzwUytYR1bmXZvUi7r8j0Eeu2L7qJFoYBgtkXBfIk7F/urFqYd4VRlXCeJj6ZQEWImw==",
+      "version": "3.26.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.26.1.tgz",
+      "integrity": "sha512-B2mhsiiAu9hkLAwkDu+Y5ArAtRJIx2oeqP8ofupLlSH4tohzcUmfKgCDZEk9iLC1sc5kmD1S/4DlS1QZhnNs8A==",
       "dependencies": {
         "@salesforce/bunyan": "^2.0.0",
         "@salesforce/kit": "^1.5.41",
         "@salesforce/schemas": "^1.1.0",
         "@salesforce/ts-types": "^1.5.20",
         "@types/graceful-fs": "^4.1.5",
-        "@types/mkdirp": "^1.0.2",
         "@types/semver": "^7.3.9",
         "ajv": "^8.11.0",
         "archiver": "^5.3.0",
@@ -44458,18 +44387,9 @@
         "form-data": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "js2xmlparser": "^4.0.1",
-        "jsforce": "2.0.0-beta.14",
+        "jsforce": "beta",
         "jsonwebtoken": "8.5.1",
-        "mkdirp": "1.0.4",
         "ts-retry-promise": "^0.6.0"
-      }
-    },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/@salesforce/core/node_modules/@types/mkdirp": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.2.tgz",
-      "integrity": "sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/@salesforce/ts-types": {
@@ -44804,17 +44724,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -44997,16 +44906,15 @@
       }
     },
     "packages/salesforcedx-vscode-apex/node_modules/@salesforce/core": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.23.4.tgz",
-      "integrity": "sha512-gJB2NbWjxcN0SqOy3GLyzwUytYR1bmXZvUi7r8j0Eeu2L7qJFoYBgtkXBfIk7F/urFqYd4VRlXCeJj6ZQEWImw==",
+      "version": "3.26.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.26.1.tgz",
+      "integrity": "sha512-B2mhsiiAu9hkLAwkDu+Y5ArAtRJIx2oeqP8ofupLlSH4tohzcUmfKgCDZEk9iLC1sc5kmD1S/4DlS1QZhnNs8A==",
       "dependencies": {
         "@salesforce/bunyan": "^2.0.0",
         "@salesforce/kit": "^1.5.41",
         "@salesforce/schemas": "^1.1.0",
         "@salesforce/ts-types": "^1.5.20",
         "@types/graceful-fs": "^4.1.5",
-        "@types/mkdirp": "^1.0.2",
         "@types/semver": "^7.3.9",
         "ajv": "^8.11.0",
         "archiver": "^5.3.0",
@@ -45016,18 +44924,9 @@
         "form-data": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "js2xmlparser": "^4.0.1",
-        "jsforce": "2.0.0-beta.14",
+        "jsforce": "beta",
         "jsonwebtoken": "8.5.1",
-        "mkdirp": "1.0.4",
         "ts-retry-promise": "^0.6.0"
-      }
-    },
-    "packages/salesforcedx-vscode-apex/node_modules/@salesforce/core/node_modules/@types/mkdirp": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.2.tgz",
-      "integrity": "sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "packages/salesforcedx-vscode-apex/node_modules/@salesforce/ts-types": {
@@ -45370,17 +45269,6 @@
       "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
       "dependencies": {
         "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-apex/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "packages/salesforcedx-vscode-apex/node_modules/ms": {
@@ -45769,16 +45657,15 @@
       }
     },
     "packages/salesforcedx-vscode-core/node_modules/@salesforce/core": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.23.4.tgz",
-      "integrity": "sha512-gJB2NbWjxcN0SqOy3GLyzwUytYR1bmXZvUi7r8j0Eeu2L7qJFoYBgtkXBfIk7F/urFqYd4VRlXCeJj6ZQEWImw==",
+      "version": "3.26.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.26.1.tgz",
+      "integrity": "sha512-B2mhsiiAu9hkLAwkDu+Y5ArAtRJIx2oeqP8ofupLlSH4tohzcUmfKgCDZEk9iLC1sc5kmD1S/4DlS1QZhnNs8A==",
       "dependencies": {
         "@salesforce/bunyan": "^2.0.0",
         "@salesforce/kit": "^1.5.41",
         "@salesforce/schemas": "^1.1.0",
         "@salesforce/ts-types": "^1.5.20",
         "@types/graceful-fs": "^4.1.5",
-        "@types/mkdirp": "^1.0.2",
         "@types/semver": "^7.3.9",
         "ajv": "^8.11.0",
         "archiver": "^5.3.0",
@@ -45788,9 +45675,8 @@
         "form-data": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "js2xmlparser": "^4.0.1",
-        "jsforce": "2.0.0-beta.14",
+        "jsforce": "beta",
         "jsonwebtoken": "8.5.1",
-        "mkdirp": "1.0.4",
         "ts-retry-promise": "^0.6.0"
       }
     },
@@ -45800,14 +45686,6 @@
       "integrity": "sha512-Ov6um4CWd63EvkRavkHG0J/P9XYL55sdkDWPMr7+AIgqh5flHxDRz09/C4e9M94aX30rzJxW4TVX6EBf4Cu2BQ==",
       "dependencies": {
         "tslib": "^2.2.0"
-      }
-    },
-    "packages/salesforcedx-vscode-core/node_modules/@salesforce/core/node_modules/@types/mkdirp": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.2.tgz",
-      "integrity": "sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "packages/salesforcedx-vscode-core/node_modules/@salesforce/core/node_modules/@types/node": {
@@ -47618,16 +47496,15 @@
       }
     },
     "packages/salesforcedx-vscode-lightning/node_modules/@salesforce/core": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.23.4.tgz",
-      "integrity": "sha512-gJB2NbWjxcN0SqOy3GLyzwUytYR1bmXZvUi7r8j0Eeu2L7qJFoYBgtkXBfIk7F/urFqYd4VRlXCeJj6ZQEWImw==",
+      "version": "3.26.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.26.1.tgz",
+      "integrity": "sha512-B2mhsiiAu9hkLAwkDu+Y5ArAtRJIx2oeqP8ofupLlSH4tohzcUmfKgCDZEk9iLC1sc5kmD1S/4DlS1QZhnNs8A==",
       "dependencies": {
         "@salesforce/bunyan": "^2.0.0",
         "@salesforce/kit": "^1.5.41",
         "@salesforce/schemas": "^1.1.0",
         "@salesforce/ts-types": "^1.5.20",
         "@types/graceful-fs": "^4.1.5",
-        "@types/mkdirp": "^1.0.2",
         "@types/semver": "^7.3.9",
         "ajv": "^8.11.0",
         "archiver": "^5.3.0",
@@ -47637,18 +47514,9 @@
         "form-data": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "js2xmlparser": "^4.0.1",
-        "jsforce": "2.0.0-beta.14",
+        "jsforce": "beta",
         "jsonwebtoken": "8.5.1",
-        "mkdirp": "1.0.4",
         "ts-retry-promise": "^0.6.0"
-      }
-    },
-    "packages/salesforcedx-vscode-lightning/node_modules/@salesforce/core/node_modules/@types/mkdirp": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.2.tgz",
-      "integrity": "sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "packages/salesforcedx-vscode-lightning/node_modules/@salesforce/ts-types": {
@@ -47989,17 +47857,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "packages/salesforcedx-vscode-lightning/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "packages/salesforcedx-vscode-lightning/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -48247,16 +48104,15 @@
       }
     },
     "packages/salesforcedx-vscode-lwc/node_modules/@salesforce/core": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.23.4.tgz",
-      "integrity": "sha512-gJB2NbWjxcN0SqOy3GLyzwUytYR1bmXZvUi7r8j0Eeu2L7qJFoYBgtkXBfIk7F/urFqYd4VRlXCeJj6ZQEWImw==",
+      "version": "3.26.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.26.1.tgz",
+      "integrity": "sha512-B2mhsiiAu9hkLAwkDu+Y5ArAtRJIx2oeqP8ofupLlSH4tohzcUmfKgCDZEk9iLC1sc5kmD1S/4DlS1QZhnNs8A==",
       "dependencies": {
         "@salesforce/bunyan": "^2.0.0",
         "@salesforce/kit": "^1.5.41",
         "@salesforce/schemas": "^1.1.0",
         "@salesforce/ts-types": "^1.5.20",
         "@types/graceful-fs": "^4.1.5",
-        "@types/mkdirp": "^1.0.2",
         "@types/semver": "^7.3.9",
         "ajv": "^8.11.0",
         "archiver": "^5.3.0",
@@ -48266,18 +48122,9 @@
         "form-data": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "js2xmlparser": "^4.0.1",
-        "jsforce": "2.0.0-beta.14",
+        "jsforce": "beta",
         "jsonwebtoken": "8.5.1",
-        "mkdirp": "1.0.4",
         "ts-retry-promise": "^0.6.0"
-      }
-    },
-    "packages/salesforcedx-vscode-lwc/node_modules/@salesforce/core/node_modules/@types/mkdirp": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.2.tgz",
-      "integrity": "sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "packages/salesforcedx-vscode-lwc/node_modules/@salesforce/core/node_modules/ajv": {
@@ -48293,17 +48140,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "packages/salesforcedx-vscode-lwc/node_modules/@salesforce/core/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "packages/salesforcedx-vscode-lwc/node_modules/@salesforce/eslint-config-lwc": {
@@ -49265,16 +49101,15 @@
       }
     },
     "packages/salesforcedx-vscode-soql/node_modules/@salesforce/core": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.23.4.tgz",
-      "integrity": "sha512-gJB2NbWjxcN0SqOy3GLyzwUytYR1bmXZvUi7r8j0Eeu2L7qJFoYBgtkXBfIk7F/urFqYd4VRlXCeJj6ZQEWImw==",
+      "version": "3.26.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.26.1.tgz",
+      "integrity": "sha512-B2mhsiiAu9hkLAwkDu+Y5ArAtRJIx2oeqP8ofupLlSH4tohzcUmfKgCDZEk9iLC1sc5kmD1S/4DlS1QZhnNs8A==",
       "dependencies": {
         "@salesforce/bunyan": "^2.0.0",
         "@salesforce/kit": "^1.5.41",
         "@salesforce/schemas": "^1.1.0",
         "@salesforce/ts-types": "^1.5.20",
         "@types/graceful-fs": "^4.1.5",
-        "@types/mkdirp": "^1.0.2",
         "@types/semver": "^7.3.9",
         "ajv": "^8.11.0",
         "archiver": "^5.3.0",
@@ -49284,9 +49119,8 @@
         "form-data": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "js2xmlparser": "^4.0.1",
-        "jsforce": "2.0.0-beta.14",
+        "jsforce": "beta",
         "jsonwebtoken": "8.5.1",
-        "mkdirp": "1.0.4",
         "ts-retry-promise": "^0.6.0"
       }
     },
@@ -49296,14 +49130,6 @@
       "integrity": "sha512-Ov6um4CWd63EvkRavkHG0J/P9XYL55sdkDWPMr7+AIgqh5flHxDRz09/C4e9M94aX30rzJxW4TVX6EBf4Cu2BQ==",
       "dependencies": {
         "tslib": "^2.2.0"
-      }
-    },
-    "packages/salesforcedx-vscode-soql/node_modules/@salesforce/core/node_modules/@types/mkdirp": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.2.tgz",
-      "integrity": "sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "packages/salesforcedx-vscode-soql/node_modules/@salesforce/core/node_modules/@types/node": {
@@ -49877,17 +49703,6 @@
       "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
       "dependencies": {
         "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-soql/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "packages/salesforcedx-vscode-soql/node_modules/ms": {


### PR DESCRIPTION
### What does this PR do?
Bump the version of core to the latest in order to pick up changes make for templates. 

### What issues does this PR fix or reference?

