### PR TITLE
chore: workflow fix for node version

### DIFF
--- a/.github/workflows/publish-beta-release.yml
+++ b/.github/workflows/publish-beta-release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: latest
+          node-version: '16.13.x'
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.ref }}


### PR DESCRIPTION
### What does this PR do?
- Reverts latest, since that syntax [did not work](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/2974301105).