### PR TITLE
fix: generate manifest command option in open projects

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -304,7 +304,7 @@
         },
         {
           "command": "sfdx.create.manifest",
-          "when": "resource =~ /force-app/ && sfdx:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sfdx.lightning.rename",


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
This PR reverts the changes made in [4208](https://github.com/forcedotcom/salesforcedx-vscode/pull/4208/files) PR. The project can be customized in multiple package directories and not necessarily have `force/app` folder in it. It caused more harm than gain. So reverting it.
### What issues does this PR fix or reference?
#4310

### Functionality Before
`SFDX: Generate Manifest File` option was only available within force-app directory.
### Functionality After
`SFDX: Generate Manifest File` option available on open project.