### PR TITLE
feat: add command to show debug statements only

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -135,6 +135,10 @@
           "when": "sfdx:project_opened && !editorHasSelection"
         },
         {
+          "command": "sfdx.force.anon.apex.execute.document.debug.only",
+          "when": "sfdx:project_opened && !editorHasSelection"
+        },
+        {
           "command": "sfdx.force.apex.log.get",
           "when": "sfdx:project_opened"
         },
@@ -200,6 +204,10 @@
       {
         "command": "sfdx.force.anon.apex.execute.document",
         "title": "%force_anon_apex_execute_document_text%"
+      },
+      {
+        "command": "sfdx.force.anon.apex.execute.document.debug.only",
+        "title": "%force_anon_apex_execute_document_text_debug_only%"
       },
       {
         "command": "sfdx.force.anon.apex.execute.selection",

--- a/packages/salesforcedx-vscode-apex/package.nls.json
+++ b/packages/salesforcedx-vscode-apex/package.nls.json
@@ -11,6 +11,7 @@
   "java_memory_description": "Specifies the amount of memory allocation to the Apex Language Server in MB, or null to use the system default value.",
   "apex_semantic_errors_description": "Allow Apex Language Server to surface semantic errors",
   "force_anon_apex_execute_document_text": "SFDX: Execute Anonymous Apex with Editor Contents",
+  "force_anon_apex_execute_document_text_debug_only": "SFDX: Execute Anonymous Apex with Editor Contents - Debug Statements Only",
   "force_anon_apex_execute_selection_text": "SFDX: Execute Anonymous Apex with Currently Selected Text",
   "force_apex_log_get_text": "SFDX: Get Apex Debug Logs",
   "force_apex_test_last_class_run_text": "SFDX: Re-Run Last Run Apex Test Class",

--- a/packages/salesforcedx-vscode-apex/src/commands/forceAnonApexExecute.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceAnonApexExecute.ts
@@ -179,11 +179,11 @@ export class AnonApexLibraryExecuteExecutor extends LibraryCommandletExecutor<
 
   private outputResult(response: ExecuteAnonymousResponse): void {
     let outputText = '';
-    let logs = response.logs!;
+    let log = response.logs!;
 
     if (this.isDebugStatementsOnly) {
       // Todo: QA on Windows machines to validate/verify carriage return aka '\n' works as expected
-      logs = logs
+      log = log
         .split('\n')
         .filter(line => line.includes('USER_DEBUG'))
         .join('\n');
@@ -192,7 +192,7 @@ export class AnonApexLibraryExecuteExecutor extends LibraryCommandletExecutor<
     if (response.success) {
       outputText += `${nls.localize('apex_execute_compile_success')}\n`;
       outputText += `${nls.localize('apex_execute_runtime_success')}\n`;
-      outputText += `\n${logs}`;
+      outputText += `\n${log}`;
     } else {
       const diagnostic = response.diagnostic![0];
 

--- a/packages/salesforcedx-vscode-apex/src/commands/forceAnonApexExecute.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceAnonApexExecute.ts
@@ -264,47 +264,6 @@ export class AnonApexLibraryExecuteExecutor extends LibraryCommandletExecutor<
   }
 }
 
-export class DebugLog {
-  private _log: string | undefined;
-  private _lines: string[] | undefined;
-  private userDebugEventIdentifier = 'USER_DEBUG';
-  // Todo: QA on Windows machines to validate/verify
-  // newLine aka '\n' works as expected
-  private newLineCharacter = '\n';
-
-  constructor(logOrLogLines: string | string[]) {
-    if (Array.isArray(logOrLogLines)) {
-      this._lines = logOrLogLines;
-    } else {
-      this._log = logOrLogLines;
-    }
-  }
-
-  public value(): string {
-    if (!this._log) {
-      this._log = this._lines!.join(this.newLineCharacter);
-    }
-    return this._log!;
-  }
-
-  public debugStatements(): string {
-    const userDebugStatements = this.lines(this.userDebugEventIdentifier);
-    const userDebugStatementsText = userDebugStatements.join(
-      this.newLineCharacter
-    );
-    return userDebugStatementsText;
-  }
-
-  private lines(filter?: string): string[] {
-    if (!this._lines) {
-      this._lines = this._log!.split(this.newLineCharacter);
-    }
-    return filter
-      ? this._lines.filter(line => line.includes(filter))
-      : this._lines;
-  }
-}
-
 export async function forceAnonApexExecute() {
   const commandlet = new SfdxCommandlet(
     new SfdxWorkspaceChecker(),

--- a/packages/salesforcedx-vscode-apex/src/commands/forceAnonApexExecute.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceAnonApexExecute.ts
@@ -28,6 +28,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { channelService, OUTPUT_CHANNEL } from '../channels';
 import { workspaceContext } from '../context';
+import { DebugLog } from '../domain';
 import { nls } from '../messages';
 
 interface ApexExecuteParameters {

--- a/packages/salesforcedx-vscode-apex/src/commands/forceShowDebugStatementsInOutput.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceShowDebugStatementsInOutput.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  EmptyParametersGatherer,
+  fileExtensionsMatch,
+  SfdxCommandlet,
+  SfdxCommandletExecutor,
+  SfdxWorkspaceChecker
+} from '@salesforce/salesforcedx-utils-vscode/out/src';
+import {
+  Command,
+  CommandBuilder
+} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import { notificationService } from '@salesforce/salesforcedx-utils-vscode/out/src/commands';
+import { flushFilePath } from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
+import * as vscode from 'vscode';
+import { channelService } from '../channels';
+import { nls } from '../messages';
+import { testOutlineProvider } from '../views/testOutlineProvider';
+import { DebugLog, forceAnonApexDebug } from './forceAnonApexExecute';
+
+export async function forceShowDebugStatementsInOutput() {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    notificationService.showErrorMessage(
+      nls.localize('unable_to_locate_editor')
+    );
+    return;
+  }
+
+  const debugLog = new DebugLog(editor.document.getText());
+  channelService.appendLine(debugLog.debugStatements());
+  channelService.showChannelOutput();
+  // return;
+  console.log('done!!!!');
+
+  // output:
+  // a.debugStatements();
+
+  const sourceUri = editor.document.uri;
+  if (!sourceUri) {
+    notificationService.showErrorMessage(
+      nls.localize('unable_to_locate_document')
+    );
+    return;
+  }
+
+  if (isLogFile(sourceUri)) {
+    await launchReplayDebuggerLogFile(sourceUri);
+    return;
+  }
+
+  if (isAnonymousApexFile(sourceUri)) {
+    await launchAnonymousApexReplayDebugger();
+    return;
+  }
+
+  const apexTestClassName = await getApexTestClassName(sourceUri);
+  if (apexTestClassName) {
+    await launchApexReplayDebugger(apexTestClassName);
+    return;
+  }
+
+  notificationService.showErrorMessage(
+    nls.localize('launch_apex_replay_debugger_unsupported_file')
+  );
+}
+
+function isLogFile(sourceUri: vscode.Uri): boolean {
+  return fileExtensionsMatch(sourceUri, 'log');
+}
+
+function isAnonymousApexFile(sourceUri: vscode.Uri): boolean {
+  return fileExtensionsMatch(sourceUri, 'apex');
+}
+
+async function launchReplayDebuggerLogFile(sourceUri: vscode.Uri) {
+  await vscode.commands.executeCommand('sfdx.launch.replay.debugger.logfile', {
+    fsPath: sourceUri.fsPath
+  });
+}
+
+async function getApexTestClassName(
+  sourceUri: vscode.Uri
+): Promise<string | undefined> {
+  if (!sourceUri) {
+    return undefined;
+  }
+
+  await testOutlineProvider.refresh();
+  let testClassName = testOutlineProvider.getTestClassName(sourceUri);
+  // This is a little bizarre.  Intellisense is reporting that getTestClassName() returns a string,
+  // but it actually it returns string | undefined.  Well, regardless, since flushFilePath() takes
+  // a string (and guards against empty strings) using the Non-null assertion operator
+  // (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html#non-null-assertion-operator)
+  // fixes the issue.
+  testClassName = flushFilePath(testClassName!);
+
+  return testClassName;
+}
+
+async function launchAnonymousApexReplayDebugger() {
+  const commandlet = new SfdxCommandlet(
+    new SfdxWorkspaceChecker(),
+    new EmptyParametersGatherer(),
+    new ForceAnonApexLaunchReplayDebuggerExecutor()
+  );
+  await commandlet.run();
+}
+
+async function launchApexReplayDebugger(apexTestClassName: string) {
+  // Launch using QuickLaunch (the same way the "Debug All Tests" code lens runs)
+  await vscode.commands.executeCommand('sfdx.force.test.view.debugTests', {
+    name: apexTestClassName
+  });
+}
+
+export class ForceAnonApexLaunchReplayDebuggerExecutor extends SfdxCommandletExecutor<{}> {
+  public build(): Command {
+    return new CommandBuilder(
+      nls.localize('force_launch_apex_replay_debugger_with_selected_file')
+    )
+      .withLogName('force_launch_apex_replay_debugger_with_selected_file')
+      .build();
+  }
+
+  public async execute(): Promise<void> {
+    await forceAnonApexDebug();
+  }
+}

--- a/packages/salesforcedx-vscode-apex/src/commands/forceShowDebugStatementsInOutput.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceShowDebugStatementsInOutput.ts
@@ -8,8 +8,8 @@
 import { notificationService } from '@salesforce/salesforcedx-utils-vscode/out/src/commands';
 import * as vscode from 'vscode';
 import { channelService } from '../channels';
+import { DebugLog } from '../domain';
 import { nls } from '../messages';
-import { DebugLog } from './forceAnonApexExecute';
 
 export async function forceShowDebugStatementsInOutput() {
   const editor = vscode.window.activeTextEditor;

--- a/packages/salesforcedx-vscode-apex/src/commands/forceShowDebugStatementsInOutput.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceShowDebugStatementsInOutput.ts
@@ -5,24 +5,11 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import {
-  EmptyParametersGatherer,
-  fileExtensionsMatch,
-  SfdxCommandlet,
-  SfdxCommandletExecutor,
-  SfdxWorkspaceChecker
-} from '@salesforce/salesforcedx-utils-vscode/out/src';
-import {
-  Command,
-  CommandBuilder
-} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import { notificationService } from '@salesforce/salesforcedx-utils-vscode/out/src/commands';
-import { flushFilePath } from '@salesforce/salesforcedx-utils-vscode/out/src/helpers';
 import * as vscode from 'vscode';
 import { channelService } from '../channels';
 import { nls } from '../messages';
-import { testOutlineProvider } from '../views/testOutlineProvider';
-import { DebugLog, forceAnonApexDebug } from './forceAnonApexExecute';
+import { DebugLog } from './forceAnonApexExecute';
 
 export async function forceShowDebugStatementsInOutput() {
   const editor = vscode.window.activeTextEditor;
@@ -36,100 +23,4 @@ export async function forceShowDebugStatementsInOutput() {
   const debugLog = new DebugLog(editor.document.getText());
   channelService.appendLine(debugLog.debugStatements());
   channelService.showChannelOutput();
-  // return;
-  console.log('done!!!!');
-
-  // output:
-  // a.debugStatements();
-
-  const sourceUri = editor.document.uri;
-  if (!sourceUri) {
-    notificationService.showErrorMessage(
-      nls.localize('unable_to_locate_document')
-    );
-    return;
-  }
-
-  if (isLogFile(sourceUri)) {
-    await launchReplayDebuggerLogFile(sourceUri);
-    return;
-  }
-
-  if (isAnonymousApexFile(sourceUri)) {
-    await launchAnonymousApexReplayDebugger();
-    return;
-  }
-
-  const apexTestClassName = await getApexTestClassName(sourceUri);
-  if (apexTestClassName) {
-    await launchApexReplayDebugger(apexTestClassName);
-    return;
-  }
-
-  notificationService.showErrorMessage(
-    nls.localize('launch_apex_replay_debugger_unsupported_file')
-  );
-}
-
-function isLogFile(sourceUri: vscode.Uri): boolean {
-  return fileExtensionsMatch(sourceUri, 'log');
-}
-
-function isAnonymousApexFile(sourceUri: vscode.Uri): boolean {
-  return fileExtensionsMatch(sourceUri, 'apex');
-}
-
-async function launchReplayDebuggerLogFile(sourceUri: vscode.Uri) {
-  await vscode.commands.executeCommand('sfdx.launch.replay.debugger.logfile', {
-    fsPath: sourceUri.fsPath
-  });
-}
-
-async function getApexTestClassName(
-  sourceUri: vscode.Uri
-): Promise<string | undefined> {
-  if (!sourceUri) {
-    return undefined;
-  }
-
-  await testOutlineProvider.refresh();
-  let testClassName = testOutlineProvider.getTestClassName(sourceUri);
-  // This is a little bizarre.  Intellisense is reporting that getTestClassName() returns a string,
-  // but it actually it returns string | undefined.  Well, regardless, since flushFilePath() takes
-  // a string (and guards against empty strings) using the Non-null assertion operator
-  // (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html#non-null-assertion-operator)
-  // fixes the issue.
-  testClassName = flushFilePath(testClassName!);
-
-  return testClassName;
-}
-
-async function launchAnonymousApexReplayDebugger() {
-  const commandlet = new SfdxCommandlet(
-    new SfdxWorkspaceChecker(),
-    new EmptyParametersGatherer(),
-    new ForceAnonApexLaunchReplayDebuggerExecutor()
-  );
-  await commandlet.run();
-}
-
-async function launchApexReplayDebugger(apexTestClassName: string) {
-  // Launch using QuickLaunch (the same way the "Debug All Tests" code lens runs)
-  await vscode.commands.executeCommand('sfdx.force.test.view.debugTests', {
-    name: apexTestClassName
-  });
-}
-
-export class ForceAnonApexLaunchReplayDebuggerExecutor extends SfdxCommandletExecutor<{}> {
-  public build(): Command {
-    return new CommandBuilder(
-      nls.localize('force_launch_apex_replay_debugger_with_selected_file')
-    )
-      .withLogName('force_launch_apex_replay_debugger_with_selected_file')
-      .build();
-  }
-
-  public async execute(): Promise<void> {
-    await forceAnonApexDebug();
-  }
 }

--- a/packages/salesforcedx-vscode-apex/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/index.ts
@@ -27,4 +27,3 @@ export {
   forceApexTestSuiteRun
 } from './forceApexTestSuite';
 export { forceLaunchApexReplayDebuggerWithCurrentFile } from './forceLaunchApexReplayDebuggerWithCurrentFile';
-export { forceShowDebugStatementsInOutput } from './forceShowDebugStatementsInOutput';

--- a/packages/salesforcedx-vscode-apex/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/index.ts
@@ -18,7 +18,12 @@ export { forceApexLogGet } from './forceApexLogGet';
 export { forceApexTestRun } from './forceApexTestRun';
 export {
   forceAnonApexDebug,
-  forceAnonApexExecute
+  forceAnonApexExecute,
+  forceAnonApexExecuteDebugOnly
 } from './forceAnonApexExecute';
-export { forceApexTestSuiteAdd, forceApexTestSuiteCreate, forceApexTestSuiteRun } from './forceApexTestSuite';
+export {
+  forceApexTestSuiteAdd,
+  forceApexTestSuiteCreate,
+  forceApexTestSuiteRun
+} from './forceApexTestSuite';
 export { forceLaunchApexReplayDebuggerWithCurrentFile } from './forceLaunchApexReplayDebuggerWithCurrentFile';

--- a/packages/salesforcedx-vscode-apex/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/index.ts
@@ -27,3 +27,4 @@ export {
   forceApexTestSuiteRun
 } from './forceApexTestSuite';
 export { forceLaunchApexReplayDebuggerWithCurrentFile } from './forceLaunchApexReplayDebuggerWithCurrentFile';
+export { forceShowDebugStatementsInOutput } from './forceShowDebugStatementsInOutput';

--- a/packages/salesforcedx-vscode-apex/src/domain/debugLog.ts
+++ b/packages/salesforcedx-vscode-apex/src/domain/debugLog.ts
@@ -22,7 +22,7 @@ export class DebugLog {
   }
 
   public value(): string {
-    if (!this._log) {
+    if (!this._log && this._lines && this._lines.length > 0) {
       this._log = this._lines!.join(this.newLineCharacter);
     }
     return this._log!;

--- a/packages/salesforcedx-vscode-apex/src/domain/debugLog.ts
+++ b/packages/salesforcedx-vscode-apex/src/domain/debugLog.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+export class DebugLog {
+  private _log: string | undefined;
+  private _lines: string[] | undefined;
+  private userDebugEventIdentifier = 'USER_DEBUG';
+  // Todo: QA on Windows machines to validate/verify
+  // newLine aka '\n' works as expected
+  private newLineCharacter = '\n';
+
+  constructor(logOrLogLines: string | string[]) {
+    if (Array.isArray(logOrLogLines)) {
+      this._lines = logOrLogLines;
+    } else {
+      this._log = logOrLogLines;
+    }
+  }
+
+  public value(): string {
+    if (!this._log) {
+      this._log = this._lines!.join(this.newLineCharacter);
+    }
+    return this._log!;
+  }
+
+  public debugStatements(): string {
+    const userDebugStatements = this.lines(this.userDebugEventIdentifier);
+    const userDebugStatementsText = userDebugStatements.join(
+      this.newLineCharacter
+    );
+    return userDebugStatementsText;
+  }
+
+  private lines(filter?: string): string[] {
+    if (!this._lines) {
+      this._lines = this._log!.split(this.newLineCharacter);
+    }
+    return filter
+      ? this._lines.filter(line => line.includes(filter))
+      : this._lines;
+  }
+}

--- a/packages/salesforcedx-vscode-apex/src/domain/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/domain/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+export { DebugLog } from './debugLog';

--- a/packages/salesforcedx-vscode-apex/src/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/index.ts
@@ -13,6 +13,7 @@ import { CodeCoverage, StatusBarToggle } from './codecoverage';
 import {
   forceAnonApexDebug,
   forceAnonApexExecute,
+  forceAnonApexExecuteDebugOnly,
   forceApexDebugClassRunCodeActionDelegate,
   forceApexDebugMethodRunCodeActionDelegate,
   forceApexLogGet,
@@ -72,7 +73,9 @@ export async function activate(extensionContext: vscode.ExtensionContext) {
   await workspaceContext.initialize(extensionContext);
 
   // Telemetry
-  const extensionPackage = require(extensionContext.asAbsolutePath('./package.json'));
+  const extensionPackage = require(extensionContext.asAbsolutePath(
+    './package.json'
+  ));
   await telemetryService.initializeService(
     extensionContext,
     APEX_EXTENSION_NAME,
@@ -83,7 +86,9 @@ export async function activate(extensionContext: vscode.ExtensionContext) {
   // Initialize Apex language server
   try {
     const langClientHRStart = process.hrtime();
-    languageClient = await languageServer.createLanguageServer(extensionContext);
+    languageClient = await languageServer.createLanguageServer(
+      extensionContext
+    );
     languageClientUtils.setClientInstance(languageClient);
     const handle = languageClient.start();
     languageClientUtils.setStatus(ClientStatus.Indexing, '');
@@ -219,6 +224,10 @@ function registerCommands(): vscode.Disposable {
     'sfdx.force.anon.apex.execute.document',
     forceAnonApexExecute
   );
+  const forceAnonApexExecuteDocumentDebugOnlyCmd = vscode.commands.registerCommand(
+    'sfdx.force.anon.apex.execute.document.debug.only',
+    forceAnonApexExecuteDebugOnly
+  );
   const forceAnonApexDebugDocumentCmd = vscode.commands.registerCommand(
     'sfdx.force.apex.debug.document',
     forceAnonApexDebug
@@ -239,6 +248,7 @@ function registerCommands(): vscode.Disposable {
     forceAnonApexRunDelegateCmd,
     forceAnonApexDebugDelegateCmd,
     forceAnonApexExecuteDocumentCmd,
+    forceAnonApexExecuteDocumentDebugOnlyCmd,
     forceAnonApexExecuteSelectionCmd,
     forceAnonApexDebugDocumentCmd,
     forceLaunchApexReplayDebuggerWithCurrentFileCmd,
@@ -257,8 +267,7 @@ function registerCommands(): vscode.Disposable {
   );
 }
 
-async function registerTestView(
-): Promise<vscode.Disposable> {
+async function registerTestView(): Promise<vscode.Disposable> {
   // Create TestRunner
   const testRunner = new ApexTestRunner(testOutlineProvider);
 

--- a/packages/salesforcedx-vscode-apex/src/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/index.ts
@@ -25,7 +25,8 @@ import {
   forceApexTestSuiteAdd,
   forceApexTestSuiteCreate,
   forceApexTestSuiteRun,
-  forceLaunchApexReplayDebuggerWithCurrentFile
+  forceLaunchApexReplayDebuggerWithCurrentFile,
+  forceShowDebugStatementsInOutput
 } from './commands';
 import { APEX_EXTENSION_NAME, LSP_ERR } from './constants';
 import { workspaceContext } from './context';
@@ -240,6 +241,10 @@ function registerCommands(): vscode.Disposable {
     'sfdx.force.launch.apex.replay.debugger.with.current.file',
     forceLaunchApexReplayDebuggerWithCurrentFile
   );
+  const forceShowDebugStatementsInOutputCmd = vscode.commands.registerCommand(
+    'sfdx.force.show.debug.statements.in.output',
+    forceShowDebugStatementsInOutput
+  );
 
   return vscode.Disposable.from(
     forceApexDebugClassRunDelegateCmd,
@@ -252,6 +257,7 @@ function registerCommands(): vscode.Disposable {
     forceAnonApexExecuteSelectionCmd,
     forceAnonApexDebugDocumentCmd,
     forceLaunchApexReplayDebuggerWithCurrentFileCmd,
+    forceShowDebugStatementsInOutputCmd,
     forceApexLogGetCmd,
     forceApexTestClassRunCmd,
     forceApexTestClassRunDelegateCmd,

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -203,6 +203,10 @@
         {
           "command": "sfdx.force.launch.apex.replay.debugger.with.current.file",
           "when": "sfdx:project_opened && resource =~ /.\\.(cls|apex|log)?$/"
+        },
+        {
+          "command": "sfdx.force.show.debug.statements.in.output",
+          "when": "sfdx:project_opened && resource =~ /.\\.log?$/"
         }
       ],
       "explorer/context": [
@@ -946,6 +950,10 @@
       {
         "command": "sfdx.force.launch.apex.replay.debugger.with.current.file",
         "title": "%force_launch_apex_replay_debugger_with_current_file%"
+      },
+      {
+        "command": "sfdx.force.show.debug.statements.in.output",
+        "title": "%force_show_debug_statements_in_output%"
       },
       {
         "command": "sfdx.lightning.rename",

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -83,5 +83,6 @@
   "force_sobjects_refresh": "SFDX: Refresh SObject Definitions",
   "enable_sobject_refresh_on_startup_description": "If a project has no sObject definitions, specifies whether to automatically refresh sObject definitions on extension activation (true) or not (false).",
   "force_launch_apex_replay_debugger_with_current_file": "SFDX: Launch Apex Replay Debugger with Current File",
+  "force_show_debug_statements_in_output": "SFDX: Show Debug Statements In Output",
   "setting_clear_output_tab_description": "When a new command is run, clear the output content from the previous command."
 }


### PR DESCRIPTION
### What does this PR do?
- Adds commands used to execute Anonymous Apex and show only the User Debug statements in the output, and to show only user debug statements in Output when a .log file is open in the active editor.

### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @<Insert GUS WI>@

### Functionality Before
<insert gif and/or summary>

### Functionality After
![2022-09-09_00-37-23 (2)](https://user-images.githubusercontent.com/46458081/189397918-543171a8-89bd-473f-905e-8096a4fc23b7.gif)

![2022-09-09_00-42-28 (1)](https://user-images.githubusercontent.com/46458081/189398019-b3068491-f232-4462-a92e-cf73a279ab0a.gif)





