### PR TITLE
fix: support for renaming aura event bundles

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/forceRenameLightningComponent.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceRenameLightningComponent.ts
@@ -220,7 +220,7 @@ export function isNameMatch(item: string, componentName: string, componentPath: 
   if (isLwc) {
     regularExp = new RegExp(`${componentName}\.(html|js|js-meta.xml|css|svg|test.js)`);
   } else {
-    regularExp = new RegExp(`${componentName}(((Controller|Renderer|Helper)?\.js)|(\.(cmp|app|css|design|auradoc|svg)))`);
+    regularExp = new RegExp(`${componentName}(((Controller|Renderer|Helper)?\.js)|(\.(cmp|app|css|design|auradoc|svg|evt)))`);
   }
   return Boolean(item.match(regularExp));
 }

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceRenameLightningComponent.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceRenameLightningComponent.test.ts
@@ -14,7 +14,7 @@ const auraPath = vscode.Uri.parse('/force-app/main/default/aura/');
 const lwcComponent = 'hero';
 const auraComponent = 'page';
 const itemsInHero = ['hero.css', 'hero.html', 'hero.js', 'hero.js-meta.xml', 'templateOne.html'];
-const itemsInPage = ['page.auradoc', 'page.cmp', 'page.cmp-meta.xml', 'page.css', 'page.design', 'page.svg', 'pageController.js', 'pageHelper.js', 'pageRenderer.js', 'templateOne.css'];
+const itemsInPage = ['page.auradoc', 'page.cmp', 'page.cmp-meta.xml', 'page.css', 'page.design', 'page.svg', 'pageController.js', 'pageHelper.js', 'pageRenderer.js', 'page.evt', 'page.evt-meta.xml', 'templateOne.css'];
 const testFolder = '__tests__';
 const testFiles = ['hero.test.js', 'example.test.js'];
 
@@ -286,6 +286,8 @@ describe('Force Rename Lightning Component', () => {
       expect(isNameMatch(itemsInPage[6], componentName, componentPath)).to.equal(true);
       expect(isNameMatch(itemsInPage[7], componentName, componentPath)).to.equal(true);
       expect(isNameMatch(itemsInPage[8], componentName, componentPath)).to.equal(true);
+      expect(isNameMatch(itemsInPage[9], componentName, componentPath)).to.equal(true);
+      expect(isNameMatch(itemsInPage[10], componentName, componentPath)).to.equal(true);
     });
 
     it('should return false if file type is not in LWC or Aura or file name and component name do not match', () => {


### PR DESCRIPTION
### What does this PR do?
- Adds the .evt extensions to the ones supported for aura components

### What issues does this PR fix or reference?
[@W-11786256@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000016sDxdYAE/view)

### Functionality Before
- sfdx Rename Component command doesn't work for Aura Event: only the bundle is renamed, not the files inside

### Functionality After
- sfdx Rename Component works for aura event: the bundle and the files inside end up with the new name given
