### PR TITLE
Chore: move the configAggregator to the utils package. 

### DIFF
--- a/packages/salesforcedx-sobjects-faux-generator/src/transformer/transformerFactory.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/transformer/transformerFactory.ts
@@ -50,9 +50,7 @@ export class SObjectTransformerFactory {
       retrievers.push(new MinObjectRetriever());
       generators.push(standardGenerator);
     } else {
-      const connection = await SObjectTransformerFactory.createConnection(
-        projectPath
-      );
+      const connection = await SObjectTransformerFactory.createConnection();
 
       retrievers.push(
         new OrgObjectRetriever(connection),
@@ -88,13 +86,11 @@ export class SObjectTransformerFactory {
     );
   }
 
-  public static async createConnection(
-    projectPath: string
-  ): Promise<Connection> {
+  public static async createConnection(): Promise<Connection> {
     // TODO: replace below logic with a call to a common function for getting a connection.
     const connection = await Connection.create({
       authInfo: await AuthInfo.create({
-        username: await ConfigUtil.getUsername(projectPath)
+        username: await ConfigUtil.getUsername()
       })
     });
     return connection;

--- a/packages/salesforcedx-sobjects-faux-generator/src/transformer/transformerFactory.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/transformer/transformerFactory.ts
@@ -91,6 +91,7 @@ export class SObjectTransformerFactory {
   public static async createConnection(
     projectPath: string
   ): Promise<Connection> {
+    // TODO: replace below logic with a call to a common function for getting a connection.
     const connection = await Connection.create({
       authInfo: await AuthInfo.create({
         username: await ConfigUtil.getUsername(projectPath)

--- a/packages/salesforcedx-sobjects-faux-generator/src/transformer/transformerFactory.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/transformer/transformerFactory.ts
@@ -4,8 +4,8 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { AuthInfo, Connection } from '@salesforce/core';
-import { ConfigUtil } from '@salesforce/salesforcedx-utils-vscode';
+import { Connection } from '@salesforce/core';
+import { WorkspaceContextUtil } from '@salesforce/salesforcedx-utils-vscode';
 import { EventEmitter } from 'events';
 import { SObjectSelector, SObjectShortDescription } from '../describe';
 import { FauxClassGenerator, TypingGenerator } from '../generator';
@@ -31,7 +31,6 @@ export class SObjectTransformerFactory {
   public static async create(
     emitter: EventEmitter,
     cancellationToken: CancellationToken,
-    projectPath: string,
     category: SObjectCategory,
     source: SObjectRefreshSource
   ): Promise<SObjectTransformer> {
@@ -87,12 +86,7 @@ export class SObjectTransformerFactory {
   }
 
   public static async createConnection(): Promise<Connection> {
-    // TODO: replace below logic with a call to a common function for getting a connection.
-    const connection = await Connection.create({
-      authInfo: await AuthInfo.create({
-        username: await ConfigUtil.getUsername()
-      })
-    });
+    const connection = await WorkspaceContextUtil.getInstance().getConnection();
     return connection;
   }
 }

--- a/packages/salesforcedx-utils-vscode/src/config/configUtil.ts
+++ b/packages/salesforcedx-utils-vscode/src/config/configUtil.ts
@@ -9,7 +9,8 @@ import {
   ConfigAggregator,
   ConfigFile,
   ConfigValue,
-  OrgConfigProperties
+  OrgConfigProperties,
+  StateAggregator
 } from '@salesforce/core';
 import * as path from 'path';
 import { TelemetryService } from '../telemetry/telemetry';
@@ -85,6 +86,12 @@ export class ConfigUtil {
     return undefined;
   }
 
+  /**
+   * Get the username of the currently auth'd user for the project.
+   *
+   * @param projectPath The project path for the currently SF project.
+   * @returns The username for the configured Org if it exists.
+   */
   public static async getUsername(
     projectPath: string
   ): Promise<string | undefined> {
@@ -92,7 +99,15 @@ export class ConfigUtil {
     const defaultUsernameOrAlias = configAggregator.getPropertyValue(
       OrgConfigProperties.TARGET_ORG
     );
-    return (defaultUsernameOrAlias as string) || undefined;
+    if (!defaultUsernameOrAlias) {
+      return;
+    }
+
+    const info = await StateAggregator.getInstance();
+    const username = defaultUsernameOrAlias
+      ? info.aliases.getUsername(String(defaultUsernameOrAlias))
+      : undefined;
+    return username ? String(username) : undefined;
   }
 
   private static async getConfigAggregator(

--- a/packages/salesforcedx-utils-vscode/src/config/configUtil.ts
+++ b/packages/salesforcedx-utils-vscode/src/config/configUtil.ts
@@ -90,7 +90,6 @@ export class ConfigUtil {
   /**
    * Get the username of the currently auth'd user for the project.
    *
-   * @param projectPath The project path for the currently SF project.
    * @returns The username for the configured Org if it exists.
    */
   public static async getUsername(): Promise<string | undefined> {

--- a/packages/salesforcedx-utils-vscode/src/config/configUtil.ts
+++ b/packages/salesforcedx-utils-vscode/src/config/configUtil.ts
@@ -13,6 +13,7 @@ import {
   StateAggregator
 } from '@salesforce/core';
 import * as path from 'path';
+import { ConfigAggregatorProvider } from '../providers';
 import { TelemetryService } from '../telemetry/telemetry';
 import { getRootWorkspacePath } from '../workspaces';
 
@@ -92,10 +93,8 @@ export class ConfigUtil {
    * @param projectPath The project path for the currently SF project.
    * @returns The username for the configured Org if it exists.
    */
-  public static async getUsername(
-    projectPath: string
-  ): Promise<string | undefined> {
-    const configAggregator = await ConfigUtil.getConfigAggregator(projectPath);
+  public static async getUsername(): Promise<string | undefined> {
+    const configAggregator = await ConfigAggregatorProvider.getInstance().getConfigAggregator();
     const defaultUsernameOrAlias = configAggregator.getPropertyValue(
       OrgConfigProperties.TARGET_ORG
     );
@@ -108,20 +107,5 @@ export class ConfigUtil {
       ? info.aliases.getUsername(String(defaultUsernameOrAlias))
       : undefined;
     return username ? String(username) : undefined;
-  }
-
-  private static async getConfigAggregator(
-    projectPath: string
-  ): Promise<ConfigAggregator> {
-    const origCurrentWorkingDirectory = process.cwd();
-    // Change the current working directory to the project path,
-    // so that ConfigAggregator reads the local project values
-    process.chdir(projectPath);
-    const configAggregator = await ConfigAggregator.create();
-    await configAggregator.reload();
-    // Change the current working directory back to what it was
-    // before returning
-    process.chdir(origCurrentWorkingDirectory);
-    return configAggregator;
   }
 }

--- a/packages/salesforcedx-utils-vscode/src/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/index.ts
@@ -54,3 +54,4 @@ export * from './types';
 export * from './date';
 export * from './output';
 export * from './predicates';
+export * from './providers';

--- a/packages/salesforcedx-utils-vscode/src/providers/configAggregatorProvider.ts
+++ b/packages/salesforcedx-utils-vscode/src/providers/configAggregatorProvider.ts
@@ -6,7 +6,7 @@
  */
 
 import { ConfigAggregator } from '@salesforce/core';
-import { workspaceUtils } from '../util';
+import { workspaceUtils } from '../workspaces';
 
 /*
  * The ConfigAggregatorProvider class is used to instantiate

--- a/packages/salesforcedx-utils-vscode/src/providers/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/providers/index.ts
@@ -1,0 +1,1 @@
+export { ConfigAggregatorProvider } from './configAggregatorProvider';

--- a/packages/salesforcedx-utils-vscode/src/workspaces/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/workspaces/index.ts
@@ -11,3 +11,5 @@ export {
   getRootWorkspacePath,
   getRootWorkspaceSfdxPath
 } from './rootWorkspace';
+
+export { workspaceUtils } from './workspaceUtils';

--- a/packages/salesforcedx-utils-vscode/src/workspaces/rootWorkspace.ts
+++ b/packages/salesforcedx-utils-vscode/src/workspaces/rootWorkspace.ts
@@ -9,7 +9,7 @@ import { join } from 'path';
 import { workspace, WorkspaceFolder } from 'vscode';
 import { SFDX_FOLDER } from '../types';
 
-//TODO: consolidate all of these into workspaceUtils
+// TODO: consolidate all of these into workspaceUtils
 export function hasRootWorkspace(ws: typeof workspace = workspace) {
   return ws && ws.workspaceFolders && ws.workspaceFolders.length > 0;
 }

--- a/packages/salesforcedx-utils-vscode/src/workspaces/workspaceUtils.ts
+++ b/packages/salesforcedx-utils-vscode/src/workspaces/workspaceUtils.ts
@@ -1,29 +1,28 @@
 /*
- * Copyright (c) 2020, salesforce.com, inc.
+ * Copyright (c) 2022, salesforce.com, inc.
  * All rights reserved.
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { join } from 'path';
 import { workspace, WorkspaceFolder } from 'vscode';
-import { SFDX_FOLDER } from '../types';
 
-//TODO: consolidate all of these into workspaceUtils
-export function hasRootWorkspace(ws: typeof workspace = workspace) {
+function hasRootWorkspace(ws: typeof workspace = workspace) {
   return ws && ws.workspaceFolders && ws.workspaceFolders.length > 0;
 }
 
-export function getRootWorkspace(): WorkspaceFolder {
+function getRootWorkspace(): WorkspaceFolder {
   return hasRootWorkspace()
     ? workspace.workspaceFolders![0]
     : ({} as WorkspaceFolder);
 }
 
-export function getRootWorkspacePath(): string {
+function getRootWorkspacePath(): string {
   return getRootWorkspace().uri ? getRootWorkspace().uri.fsPath : '';
 }
 
-export function getRootWorkspaceSfdxPath(): string {
-  return hasRootWorkspace() ? join(getRootWorkspacePath(), SFDX_FOLDER) : '';
-}
+export const workspaceUtils = {
+  hasRootWorkspace,
+  getRootWorkspace,
+  getRootWorkspacePath
+};

--- a/packages/salesforcedx-utils-vscode/test/unit/config/configUtil.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/unit/config/configUtil.test.ts
@@ -6,8 +6,12 @@
  */
 import { OrgConfigProperties, StateAggregator } from '@salesforce/core';
 import { expect } from 'chai';
-import { createSandbox, SinonSandbox, SinonStub, stub } from 'sinon';
-import { ConfigSource, ConfigUtil } from '../../../src';
+import { createSandbox, SinonStub, stub } from 'sinon';
+import {
+  ConfigAggregatorProvider,
+  ConfigSource,
+  ConfigUtil
+} from '../../../src';
 
 const vscodeStub = {
   commands: stub(),
@@ -64,7 +68,6 @@ describe('getConfigSource', () => {
   describe('getUsername', () => {
     const testAlias = 'aFakeAlias';
     const testUsername = 'a.f.alias@salesforce.com';
-    const fakeProjectPath = '/a/fully/qualified/fake/path';
 
     let getUserNameStub: SinonStub;
     let getPropertyValueStub: SinonStub;
@@ -78,16 +81,18 @@ describe('getConfigSource', () => {
       });
 
       getPropertyValueStub = sandbox.stub();
-      sandbox.stub(ConfigUtil as any, 'getConfigAggregator').resolves({
-        getPropertyValue: getPropertyValueStub
-      });
+      sandbox
+        .stub(ConfigAggregatorProvider.prototype, 'getConfigAggregator')
+        .resolves({
+          getPropertyValue: getPropertyValueStub
+        });
     });
 
     it('Should return the currently auth username.', async () => {
       getPropertyValueStub.returns(testAlias);
       getUserNameStub.returns(testUsername);
 
-      const username = await ConfigUtil.getUsername(fakeProjectPath);
+      const username = await ConfigUtil.getUsername();
 
       expect(username).to.equal(testUsername);
       expect(getPropertyValueStub.callCount).to.equal(1);
@@ -101,7 +106,7 @@ describe('getConfigSource', () => {
     it('Should return undefined if no username or alias is found.', async () => {
       getPropertyValueStub.returns(undefined);
 
-      const username = await ConfigUtil.getUsername(fakeProjectPath);
+      const username = await ConfigUtil.getUsername();
 
       expect(username).to.equal(undefined);
       expect(getPropertyValueStub.callCount).to.equal(1);
@@ -112,7 +117,7 @@ describe('getConfigSource', () => {
       getPropertyValueStub.returns(testAlias);
       getUserNameStub.returns(null);
 
-      const username = await ConfigUtil.getUsername(fakeProjectPath);
+      const username = await ConfigUtil.getUsername();
 
       expect(username).to.equal(undefined);
       expect(getPropertyValueStub.callCount).to.equal(1);

--- a/packages/salesforcedx-utils-vscode/test/unit/providers/configAggregatorProvider.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/unit/providers/configAggregatorProvider.test.ts
@@ -8,7 +8,7 @@ import { ConfigAggregator } from '@salesforce/core';
 import { expect } from 'chai';
 import { createSandbox, SinonStub } from 'sinon';
 import { ConfigAggregatorProvider } from '../../../src/providers/configAggregatorProvider';
-import { workspaceUtils } from '../../../src/util';
+import { workspaceUtils } from '../../../src/workspaces';
 
 const sandbox = createSandbox();
 const dummyProjectRootWorkspacePath = '/test/home/testProject';

--- a/packages/salesforcedx-vscode-core/src/commands/forceRefreshSObjects.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceRefreshSObjects.ts
@@ -149,7 +149,6 @@ export class ForceRefreshSObjectsExecutor extends SfdxCommandletExecutor<{}> {
         transformer = await SObjectTransformerFactory.create(
           execution.cmdEmitter,
           cancellationToken,
-          projectPath,
           SObjectCategory.STANDARD,
           SObjectRefreshSource.StartupMin
         );
@@ -157,7 +156,6 @@ export class ForceRefreshSObjectsExecutor extends SfdxCommandletExecutor<{}> {
         transformer = await SObjectTransformerFactory.create(
           execution.cmdEmitter,
           cancellationToken,
-          projectPath,
           response.data.category,
           response.data.source
         );

--- a/packages/salesforcedx-vscode-core/src/context/workspaceContext.ts
+++ b/packages/salesforcedx-vscode-core/src/context/workspaceContext.ts
@@ -6,12 +6,12 @@
  */
 import { Connection } from '@salesforce/core';
 import {
+  ConfigAggregatorProvider,
   OrgUserInfo,
   WorkspaceContextUtil
 } from '@salesforce/salesforcedx-utils-vscode';
 import * as vscode from 'vscode';
 import { workspaceContextUtils } from '.';
-import { ConfigAggregatorProvider } from '../providers/configAggregatorProvider';
 
 /**
  * Manages the context of a workspace during a session with an open SFDX project.

--- a/packages/salesforcedx-vscode-core/src/providers/index.ts
+++ b/packages/salesforcedx-vscode-core/src/providers/index.ts
@@ -1,0 +1,1 @@
+// export { configAggregatorProvider } from './configAggregatorProvider';

--- a/packages/salesforcedx-vscode-core/src/providers/index.ts
+++ b/packages/salesforcedx-vscode-core/src/providers/index.ts
@@ -1,1 +1,0 @@
-// export { configAggregatorProvider } from './configAggregatorProvider';

--- a/packages/salesforcedx-vscode-core/src/util/configUtil.ts
+++ b/packages/salesforcedx-vscode-core/src/util/configUtil.ts
@@ -12,7 +12,7 @@ import {
   SfConfigProperties,
   StateAggregator
 } from '@salesforce/core';
-import { ConfigAggregatorProvider } from '../providers/configAggregatorProvider';
+import { ConfigAggregatorProvider } from '@salesforce/salesforcedx-utils-vscode';
 
 export enum ConfigSource {
   Local,

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceRefreshSObjects.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/forceRefreshSObjects.test.ts
@@ -207,7 +207,7 @@ describe('ForceGenerateFauxClasses', () => {
 
     it('Should pass response data to transformer', async () => {
       await doExecute(SObjectRefreshSource.Startup, SObjectCategory.CUSTOM);
-      expect(factoryStub.firstCall.args.slice(3)).to.eql([
+      expect(factoryStub.firstCall.args.slice(2)).to.eql([
         SObjectCategory.CUSTOM,
         SObjectRefreshSource.Startup
       ]);
@@ -215,7 +215,7 @@ describe('ForceGenerateFauxClasses', () => {
 
     it('Should pass minimal response data to transformer', async () => {
       await doExecute(SObjectRefreshSource.StartupMin, SObjectCategory.CUSTOM);
-      expect(factoryStub.firstCall.args.slice(3)).to.eql([
+      expect(factoryStub.firstCall.args.slice(2)).to.eql([
         SObjectCategory.STANDARD,
         SObjectRefreshSource.StartupMin
       ]);

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/util/authInfo.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/util/authInfo.test.ts
@@ -5,26 +5,26 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import {
-  AuthInfo,
-  ConfigAggregator,
-  Connection,
-  StateAggregator
-} from '@salesforce/core';
-import { OrgConfigProperties } from '@salesforce/core/lib/exported';
+import { AuthInfo, Connection, StateAggregator } from '@salesforce/core';
 import { expect } from 'chai';
-import { createSandbox, SinonSandbox, SinonStub } from 'sinon';
+import { createSandbox, SinonStub } from 'sinon';
 import * as vscode from 'vscode';
 import { nls } from '../../../src/messages';
 import { ConfigUtil, OrgAuthInfo } from '../../../src/util';
 
 describe('OrgAuthInfo', () => {
-  let sandbox: SinonSandbox;
+  const sandbox = createSandbox();
+
   const username = 'user@test.test';
+  let getDefaultDevHubUsernameOrAliasStub: SinonStub;
 
   beforeEach(async () => {
-    sandbox = createSandbox();
+    getDefaultDevHubUsernameOrAliasStub = sandbox.stub(
+      ConfigUtil,
+      'getDefaultDevHubUsernameOrAlias'
+    );
   });
+
   afterEach(() => sandbox.restore());
 
   describe('getUsername', () => {
@@ -52,9 +52,7 @@ describe('OrgAuthInfo', () => {
 
   describe('getDefaultDevHubUsernameOrAlias', () => {
     it('should return notification if there is no dev hub set', async () => {
-      const configAggregatorStub = sandbox
-        .stub(ConfigAggregator.prototype, 'getPropertyValue')
-        .returns(undefined);
+      getDefaultDevHubUsernameOrAliasStub.resolves(undefined);
       const infoMessageStub = sandbox.stub(
         vscode.window,
         'showInformationMessage'
@@ -66,11 +64,7 @@ describe('OrgAuthInfo', () => {
     });
 
     it('should run authorize a dev hub command if button clicked', async () => {
-      const configAggregatorStub = sandbox.stub(
-        ConfigAggregator.prototype,
-        'getPropertyValue'
-      );
-      configAggregatorStub.returns(undefined);
+      getDefaultDevHubUsernameOrAliasStub.resolves(undefined);
       const showMessageStub = sandbox.stub(
         vscode.window,
         'showInformationMessage'
@@ -90,11 +84,7 @@ describe('OrgAuthInfo', () => {
     });
 
     it('should not show a message if there is a dev hub set', async () => {
-      const configAggregatorStub = sandbox.stub(
-        ConfigAggregator.prototype,
-        'getPropertyValue'
-      );
-      configAggregatorStub.returns('username');
+      getDefaultDevHubUsernameOrAliasStub.resolves('username');
       const infoMessageStub = sandbox.stub(
         vscode.window,
         'showInformationMessage'
@@ -102,10 +92,7 @@ describe('OrgAuthInfo', () => {
 
       await OrgAuthInfo.getDefaultDevHubUsernameOrAlias(true);
 
-      expect(configAggregatorStub.calledOnce).to.equal(true);
-      expect(
-        configAggregatorStub.calledWith(OrgConfigProperties.TARGET_DEV_HUB)
-      ).to.equal(true);
+      expect(getDefaultDevHubUsernameOrAliasStub.calledOnce).to.equal(true);
       expect(infoMessageStub.calledOnce).to.equal(false);
     });
   });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/util/configUtil.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/util/configUtil.test.ts
@@ -11,7 +11,7 @@ import { createSandbox, SinonStub } from 'sinon';
 import { ConfigSource, ConfigUtil } from '../../../src/util';
 
 describe('getConfigSource', () => {
-  let sandbox = createSandbox();
+  const sandbox = createSandbox();
   let getLocationStub: SinonStub;
 
   beforeEach(() => {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/util/configUtil.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/util/configUtil.test.ts
@@ -5,40 +5,38 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { ConfigAggregator } from '@salesforce/core';
+import { ConfigAggregatorProvider } from '@salesforce/salesforcedx-utils-vscode';
 import { expect } from 'chai';
-import { createSandbox, SinonSandbox, SinonStub } from 'sinon';
+import { createSandbox, SinonStub } from 'sinon';
 import { ConfigSource, ConfigUtil } from '../../../src/util';
 
 describe('getConfigSource', () => {
-  let sandboxStub: SinonSandbox;
-  let configAggregatorGetLocationStub: SinonStub;
+  let sandbox = createSandbox();
+  let getLocationStub: SinonStub;
 
   beforeEach(() => {
-    sandboxStub = createSandbox();
-    configAggregatorGetLocationStub = sandboxStub.stub(
-      ConfigAggregator.prototype,
-      'getLocation'
-    );
+    getLocationStub = sandbox.stub();
+    sandbox.stub(ConfigAggregatorProvider, 'getInstance').returns({
+      getConfigAggregator: sandbox.stub().resolves({
+        getLocation: getLocationStub
+      })
+    });
   });
   afterEach(() => {
-    sandboxStub.restore();
+    sandbox.restore();
   });
   it('should return ConfigSource.Local if the key/value is in the local config', async () => {
-    configAggregatorGetLocationStub
-      .onCall(0)
-      .returns(ConfigAggregator.Location.LOCAL);
+    getLocationStub.returns(ConfigAggregator.Location.LOCAL);
     const configSource = await ConfigUtil.getConfigSource('key');
     expect(configSource).to.be.eq(ConfigSource.Local);
   });
   it('should return ConfigSource.Global if the key/value is in the global config', async () => {
-    configAggregatorGetLocationStub
-      .onCall(0)
-      .returns(ConfigAggregator.Location.GLOBAL);
+    getLocationStub.returns(ConfigAggregator.Location.GLOBAL);
     const configSource = await ConfigUtil.getConfigSource('key');
     expect(configSource).to.be.eq(ConfigSource.Global);
   });
   it('should return ConfigSource.None if the key/value is not in the local or global config', async () => {
-    configAggregatorGetLocationStub.onCall(0).returns(undefined);
+    getLocationStub.returns(undefined);
     const configSource = await ConfigUtil.getConfigSource('key');
     expect(configSource).to.be.eq(ConfigSource.None);
   });


### PR DESCRIPTION
### What does this PR do?
This is a change to prove out having a dependency from core to the utils-vscode package. The intention is to only have classes for accessing configs in the untils package that all other extensions use to utilize.

### What issues does this PR fix or reference?
@W-11528403@

### Functionality Before
configAggragatorProvider lives in core package.
refresh sobject command will fail with error due to use of alias instead of username. 

### Functionality After
configAggragatorProvider lives in the utils package.
refresh sobject command works as expected
