### PR TITLE
fix: remove double logging from lwc language server on error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5228,11 +5228,11 @@
       }
     },
     "node_modules/@salesforce/aura-language-server": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-3.10.0.tgz",
-      "integrity": "sha512-Q+Io3ghJplDx6kYstsrPHNDqLZGrA+47hEKrAOjC2Qn78jfrKKUGjRfDR8Y7lfMMLWE5yZw9fCNAABAGgMFmUw==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-3.11.0.tgz",
+      "integrity": "sha512-KMFB7PUmvIwujjGDroPp00cM1ONFmFotwea6t8iLDDg6ur6xuLgBCrqrbvj4swapUTXIzrA3U3S4767QTVtZeg==",
       "dependencies": {
-        "@salesforce/lightning-lsp-common": "3.10.0",
+        "@salesforce/lightning-lsp-common": "3.11.0",
         "acorn": "^6.0.0",
         "acorn-loose": "^6.0.0",
         "acorn-walk": "^6.0.0",
@@ -5527,9 +5527,9 @@
       "integrity": "sha512-/ZiVwtVkmq2jWRRzgsC4SEy8m54gPaDc8e+jIfnIiR04iSeSRhYJxG+ktLSYVN2jMbVWA58HfEJSCx+73GcQCg=="
     },
     "node_modules/@salesforce/lightning-lsp-common": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-3.10.0.tgz",
-      "integrity": "sha512-p/GNA2hGvKujfIwNUDl4IAsqSgwF8GB2h31td2zYFdMZOUAsNbe/juSbafkkXyhCNSnjbrRDk24oXY0UcoTn7Q==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-3.11.0.tgz",
+      "integrity": "sha512-/2eH1C/qx2OygxLn1iH4maRINEhhcxBAXgmlMvjt21a1OTNSgzqSY/pAxTzlss0hla0Vrdtkq7q4JkPp9l0tyg==",
       "dependencies": {
         "decamelize": "^2.0.0",
         "deep-equal": "^1.0.1",
@@ -5593,9 +5593,9 @@
       "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
     },
     "node_modules/@salesforce/lwc-language-server": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-3.10.0.tgz",
-      "integrity": "sha512-evcCI9zA5ob613xIALzqDe/1hl8pTi+a0VnP5OaPeP5On2VwgdVr67aENqKUd9wDZvOOISK5KIDpKIH3Wmoe7A==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-3.11.0.tgz",
+      "integrity": "sha512-zuGwJ7acaAcz5IjPnJ71YZsv3l9HC6l1DFcxW8dA7ZM1tNoTP+MByBN8ag9PKKZbssJB7Eov5ft36BcCtLoaYw==",
       "dependencies": {
         "@lwc/compiler": "0.34.8",
         "@lwc/engine-dom": "2.13.3",
@@ -5603,7 +5603,7 @@
         "@lwc/template-compiler": "2.13.3",
         "@salesforce/apex": "0.0.12",
         "@salesforce/label": "0.0.12",
-        "@salesforce/lightning-lsp-common": "3.10.0",
+        "@salesforce/lightning-lsp-common": "3.11.0",
         "@salesforce/resourceurl": "0.0.12",
         "@salesforce/schema": "0.0.12",
         "@salesforce/user": "0.0.12",
@@ -25369,6 +25369,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -25383,16 +25384,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -25406,6 +25410,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -25421,6 +25426,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -41250,9 +41256,9 @@
       "version": "55.13.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/aura-language-server": "3.10.0",
+        "@salesforce/aura-language-server": "3.11.0",
         "@salesforce/core": "^3.23.2",
-        "@salesforce/lightning-lsp-common": "3.10.0",
+        "@salesforce/lightning-lsp-common": "3.11.0",
         "@salesforce/salesforcedx-utils-vscode": "55.13.0",
         "applicationinsights": "1.0.7",
         "vscode-extension-telemetry": "0.0.17",
@@ -41320,8 +41326,8 @@
       "dependencies": {
         "@salesforce/core": "^3.23.2",
         "@salesforce/eslint-config-lwc": "0.3.0",
-        "@salesforce/lightning-lsp-common": "3.10.0",
-        "@salesforce/lwc-language-server": "3.10.0",
+        "@salesforce/lightning-lsp-common": "3.11.0",
+        "@salesforce/lwc-language-server": "3.11.0",
         "@salesforce/salesforcedx-utils-vscode": "55.13.0",
         "ajv": "6.12.6",
         "applicationinsights": "1.0.7",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -25,9 +25,9 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/aura-language-server": "3.10.0",
+    "@salesforce/aura-language-server": "3.11.0",
     "@salesforce/core": "^3.23.2",
-    "@salesforce/lightning-lsp-common": "3.10.0",
+    "@salesforce/lightning-lsp-common": "3.11.0",
     "@salesforce/salesforcedx-utils-vscode": "55.13.0",
     "applicationinsights": "1.0.7",
     "vscode-extension-telemetry": "0.0.17",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "@salesforce/core": "^3.23.2",
     "@salesforce/eslint-config-lwc": "0.3.0",
-    "@salesforce/lightning-lsp-common": "3.10.0",
-    "@salesforce/lwc-language-server": "3.10.0",
+    "@salesforce/lightning-lsp-common": "3.11.0",
+    "@salesforce/lwc-language-server": "3.11.0",
     "@salesforce/salesforcedx-utils-vscode": "55.13.0",
     "ajv": "6.12.6",
     "applicationinsights": "1.0.7",


### PR DESCRIPTION
### What does this PR do?
This PR reflects recent changes in lightning lsp common:
- Gets rid of the double logging to the LWC Language Server Output Tab when Attribute Not Found: [#510](https://github.com/forcedotcom/lightning-language-server/pull/510)

### What issues does this PR fix or reference?
[@W-11307712@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000zN76PYAS/view)

### Functionality Before
- "Attribute x not found" was being logged twice per each cmd+click/hover when applicable

### Functionality After
- "Attribute x not found" is being logged once per each cmd+click/hover when applicable
