### PR TITLE
chore: always show login screen for device flow

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/auth/forceAuthWebLogin.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/auth/forceAuthWebLogin.ts
@@ -118,7 +118,7 @@ export class ForceAuthWebLoginContainerExecutor extends SfdxCommandletExecutor<
       const userCode = response.user_code;
 
       if (verificationUrl && userCode) {
-        authUrl = `${verificationUrl}?user_code=${userCode}`;
+        authUrl = `${verificationUrl}?user_code=${userCode}&prompt=login`;
         this.logToOutputChannel(userCode, verificationUrl);
       }
     } catch (error) {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/auth/forceAuthWebLogin.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/auth/forceAuthWebLogin.test.ts
@@ -316,6 +316,7 @@ describe('Force Auth Device Login', () => {
     expect(targetUrl).to.contain(testResponse.verification_uri);
     expect(targetUrl).to.contain(testResponse.user_code);
     expect(targetUrl).to.contain('user_code');
+    expect(targetUrl).to.contain('prompt=login');
   });
 
   it('should handle partial data from CLI stdOut', () => {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/auth/forceAuthWebLogin.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/auth/forceAuthWebLogin.test.ts
@@ -316,7 +316,7 @@ describe('Force Auth Device Login', () => {
     expect(targetUrl).to.contain(testResponse.verification_uri);
     expect(targetUrl).to.contain(testResponse.user_code);
     expect(targetUrl).to.contain('user_code');
-    expect(targetUrl).to.contain('prompt=login');
+    expect(targetUrl).to.contain('prompt%3Dlogin');
   });
 
   it('should handle partial data from CLI stdOut', () => {


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
*Problem*
When using the org login command in a containerized environment such as Code Builder, the core extension uses the device flow. When the initial device flow request returns with a verification URL, the `user_code` query parameter is appended and the URL is opened in a new tab. This is the `/connect` page. When the page form is submitted:
- If there is an active browser session to an org, the device flow with authorize the device to the org that is currently logged in.
- If not, the device flow will route the user to the login screen, where they can supply their credentials for their target org.

The first case is often an inconvenience for developers, who may want to log in to the Sandbox, DE Org,  or Dev Hub of their choice rather that whatever org is currently logged in. Even if the user clicks on the `Not you?` link, there is often no way to complete the login flow without logging out and restarting the auth flow because the `Not you?` link takes the user to the domain-specific login page of the currently logged in org, rather than the generic login page. Effectively, the user gets trapped in one org during the flow.

*Solution* 
The Winter '23 release of the core platform added a query param (`prompt=login`) to the `/connect` page to always take the user to the login page. This PR adds this query param to the verification URL during the device flow, so that the login command will avoid the trap described above.

### What issues does this PR fix or reference?
@W-11866959@

### Functionality Before
In a containerized setting:
1. Use the Authorize an org command to authorize org A. The flow auto-authorizes org A if already logged in, or takes to the user to the login page, where the user supplies credentials and subsequently authorizes org A.
2. Use the Authorize an org command to attempt to authorize org B. The device flow automatically authorizes org A. There is no recovery to authorize org B in this flow.

### Functionality After
In a containerized setting:
1. Use the Authorize an org command to authorize org A. The flow takes to the user to the login page, where the user supplies credentials to org A and subsequently authorizes org A.
2. Use the Authorize an org command to attempt to authorize org B. The flow takes to the user to the login page, where the user supplies credentials to org B and subsequently authorizes org B.

