### PR TITLE
Use Relative StateFolder Path from projectPaths for MetadataCacheService

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/helpers/paths.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/paths.ts
@@ -1,3 +1,4 @@
+import { getRootWorkspacePath } from '@salesforce/salesforcedx-utils-vscode';
 /*
  * Copyright (c) 2022, salesforce.com, inc.
  * All rights reserved.
@@ -130,13 +131,20 @@ function debugLogsFolder(): string {
 }
 
 function sfdxProjectConfig(): string {
-  const pathToSFDXProjectConfig = path.join(projectPaths.stateFolder(), SFDX_CONFIG_FILE);
+  const pathToSFDXProjectConfig = path.join(
+    projectPaths.stateFolder(),
+    SFDX_CONFIG_FILE
+  );
   return pathToSFDXProjectConfig;
 }
 
 function toolsFolder(): string {
   const pathToToolsFolder = path.join(projectPaths.stateFolder(), TOOLS);
   return pathToToolsFolder;
+}
+
+function relativeStateFolder(): string {
+  return Global.STATE_FOLDER;
 }
 
 export const projectPaths = {
@@ -148,5 +156,6 @@ export const projectPaths = {
   debugLogsFolder,
   sfdxProjectConfig,
   toolsFolder,
-  lwcTestResultsFolder
+  lwcTestResultsFolder,
+  relativeStateFolder
 };

--- a/packages/salesforcedx-vscode-core/src/conflict/metadataCacheService.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/metadataCacheService.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { projectPaths } from '@salesforce/salesforcedx-utils-vscode';
 import {
   ComponentSet,
   FileProperties,
@@ -54,8 +55,10 @@ interface RecomposedComponent {
   children: Map<string, SourceComponent>;
 }
 
+const STATE_FOLDER = projectPaths.relativeStateFolder();
+
 export class MetadataCacheService {
-  private static CACHE_FOLDER = ['.sfdx', 'diff'];
+  private static CACHE_FOLDER = [STATE_FOLDER, 'diff'];
   private static PROPERTIES_FOLDER = ['prop'];
   private static PROPERTIES_FILE = 'file-props.json';
 


### PR DESCRIPTION
### What does this PR do?
Imports the relative path to the state folder from the utils package, which imports the sfdx-core library, over referencing the '.sfdx' directory directly. 

### What issues does this PR fix or reference?
@W-11633503@

### Functionality Before
'.sfdx' directory is referenced directly.

### Functionality After
State folder is referenced using imported folder path from utils package.
