### PR TITLE
fix: update to verify path exists before chdir in configAggProvider

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/providers/configAggregatorProvider.ts
+++ b/packages/salesforcedx-utils-vscode/src/providers/configAggregatorProvider.ts
@@ -82,12 +82,14 @@ export class ConfigAggregatorProvider {
 
   private ensureCurrentDirectoryInsideProject(path: string) {
     const rootWorkspacePath = workspaceUtils.getRootWorkspacePath();
-    if (path !== rootWorkspacePath) {
+    if (rootWorkspacePath && path !== rootWorkspacePath) {
       this.changeCurrentDirectoryTo(rootWorkspacePath);
     }
   }
 
   private changeCurrentDirectoryTo(path: string) {
-    process.chdir(path);
+    if (path) {
+      process.chdir(path);
+    }
   }
 }

--- a/packages/salesforcedx-utils-vscode/test/unit/providers/configAggregatorProvider.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/unit/providers/configAggregatorProvider.test.ts
@@ -66,8 +66,8 @@ describe('ConfigAggregatorProvider', () => {
       // createConfigAggregator should change the process to the
       // root project workspace path to create the ConfigAggregator,
       // then change back to the original directory.
-      expect(changeCurrentDirectoryToStub.callCount).to.equal(2);
-      expect(changeCurrentDirectoryToStub.getCall(1).args[0]).to.equal(
+      expect(changeCurrentDirectoryToStub.callCount).to.equal(1);
+      expect(changeCurrentDirectoryToStub.getCall(0).args[0]).to.equal(
         ConfigAggregatorProvider.defaultBaseProcessDirectoryInVSCE
       );
       expect(configAggregatorCreateStub.callCount).to.equal(1);


### PR DESCRIPTION
### What does this PR do?
Update the config agg provider to not attempt to chdir when the current working directory is undefined or empty string.

### What issues does this PR fix or reference?
#4465

### Functionality Before
![Screen Shot 2022-10-26 at 11 36 10 AM](https://user-images.githubusercontent.com/76090802/198083837-2ee6fad4-4462-4cc5-a309-bfc18e23e44c.png)

### Functionality After
Successful creation of a new project from the empty project state.