### PR TITLE
fix: update bundling for core extension to exclude functions-core

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,9 @@ commands:
     steps:
       - checkout
       - restore_dependency_cache
+      - run:
+        name: 'Install npm 8.12'
+        command: sudo npm install -g npm@8.12.1
       - install
       - compile
       - package-extensions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,9 +56,7 @@ commands:
     steps:
       - checkout
       - restore_dependency_cache
-      - run:
-        name: 'Install npm 8.12'
-        command: sudo npm install -g npm@8.12.1
+      - run: sudo npm install -g npm@8.12.1
       - install
       - compile
       - package-extensions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1862,9 +1862,9 @@
       }
     },
     "node_modules/@heroku/functions-core": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@heroku/functions-core/-/functions-core-0.4.1.tgz",
-      "integrity": "sha512-ZJGke5XM1WAVXFty56VMvimpZ+/7xwOLAtLo1m0vecD13UpkyCPJScSFpGQ4d0VwyZtKc7HjNYDb7QhOrb4O+A==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@heroku/functions-core/-/functions-core-0.4.2.tgz",
+      "integrity": "sha512-LKcXleISKGPYqg8NZoyZSIWaaYPsAiKORlSGQ2FxbHn1mz16/xAwrv2mtSUVDvxTuPW0VxpO++rf1SBwX+wzKQ==",
       "dependencies": {
         "@heroku-cli/color": "^1.1.14",
         "@heroku/project-descriptor": "0.0.6",
@@ -25727,6 +25727,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -25741,16 +25742,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -25764,6 +25768,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -25779,6 +25784,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -41280,7 +41286,7 @@
       "version": "56.4.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@heroku/functions-core": "^0.4.0",
+        "@heroku/functions-core": "0.4.2",
         "@octokit/plugin-paginate-rest": "2.21.3",
         "@salesforce/core": "^3.23.2",
         "@salesforce/salesforcedx-sobjects-faux-generator": "56.4.0",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -25,7 +25,7 @@
     "Other"
   ],
   "dependencies": {
-    "@heroku/functions-core": "^0.4.0",
+    "@heroku/functions-core": "0.4.2",
     "@octokit/plugin-paginate-rest": "2.21.3",
     "@salesforce/core": "^3.23.2",
     "@salesforce/salesforcedx-sobjects-faux-generator": "56.4.0",
@@ -86,6 +86,7 @@
       "main": "dist/index.js",
       "dependencies": {
         "applicationinsights": "1.0.7",
+        "@heroku/functions-core": "0.4.2",
         "@salesforce/core": "3.30.9",
         "@salesforce/templates": "55.1.0",
         "@salesforce/source-deploy-retrieve": "6.0.4",
@@ -95,7 +96,7 @@
     }
   },
   "scripts": {
-    "bundle:extension": "esbuild ./src/index.ts  --bundle --outfile=dist/index.js --format=cjs --platform=node --external:vscode  --external:@salesforce/core --external:applicationinsights --external:shelljs --external:@salesforce/templates --external:@salesforce/source-deploy-retrieve --minify",
+    "bundle:extension": "esbuild ./src/index.ts  --bundle --outfile=dist/index.js --format=cjs --platform=node --external:vscode  --external:@salesforce/core --external:applicationinsights --external:shelljs --external:@salesforce/templates --external:@salesforce/source-deploy-retrieve --external:@heroku/functions-core --minify",
     "vscode:prepublish": "npm prune --production",
     "vscode:package": "ts-node -P ./tsconfig.json ../../scripts/vsce-bundled-extension.ts",
     "vscode:sha256": "node ../../scripts/generate-sha256.js >> ../../SHA256",

--- a/packages/salesforcedx-vscode-core/src/commands/templates/forceFunctionCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/forceFunctionCreate.ts
@@ -6,15 +6,9 @@
  */
 
 import {
-  Command,
-  SfdxCommandBuilder
-} from '@salesforce/salesforcedx-utils-vscode';
-import { LibraryCommandletExecutor } from '@salesforce/salesforcedx-utils-vscode';
-import {
   CancelResponse,
   ContinueResponse,
-  FunctionInfo,
-  ParametersGatherer
+  FunctionInfo, LibraryCommandletExecutor, ParametersGatherer
 } from '@salesforce/salesforcedx-utils-vscode';
 import * as cp from 'child_process';
 import * as path from 'path';


### PR DESCRIPTION
### What does this PR do?
Update the core extension bundling to exclude the functions-core module from bundling. 

### Testing
To test this change do the following: 
1. npm install 
2. npm run compile 
3. cd package/salesforcedx-vscode-core
4. npm run bundle:extension
5. npm run vscode:package

This will generate the `salesforcedx-vscode-core-56.4.0.vsix` extension.

To install: 
Go to whatever version of vscode you'd like to use for verifying the extension.  Uninstall add salesforce extension & reload.
Click the '...' button at the top of the extensions view and then 'install from vsix' 
select the generated vsix file 
The bundled extension should now be installed in your vscode and you can test with 
'SFDX: Create Function'


### What issues does this PR fix or reference?
fix #4531 
@W-11998949@

### Functionality Before
Create Functions command fails for all types when used from a bundled core extension.

### Functionality After
Create Function works using bundled core extension. 
