### PR TITLE
fix: update apex interactive debugger package step to include @salesforce/core

### DIFF
--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "bundle:extension": "npm run bundle:extension:build && npm run bundle:extension:copy",
     "bundle:extension:copy": "cp ../salesforcedx-apex-debugger/dist/apexdebug.js ./dist/",
-    "bundle:extension:build": "esbuild ./src/index.ts  --bundle --outfile=dist/index.js --format=cjs --platform=node --external:vscode --minify",
+    "bundle:extension:build": "esbuild ./src/index.ts  --bundle --outfile=dist/index.js --format=cjs --platform=node --external:vscode --external:@salesforce/core --minify",
     "vscode:prepublish": "npm prune --production",
     "vscode:package": "ts-node -P ./tsconfig.json ../../scripts/vsce-bundled-extension.ts",
     "vscode:sha256": "node ../../scripts/generate-sha256.js >> ../../SHA256",
@@ -83,7 +83,8 @@
     "packageUpdates": {
       "main": "dist/index.js",
       "dependencies": {
-        "applicationinsights": "1.0.7"
+        "applicationinsights": "1.0.7",
+        "@salesforce/core": "3.30.9"
       },
       "devDependencies": {}
     }


### PR DESCRIPTION
### What does this PR do?
Update the apex interactive debugger extension to exclude @salesforce/core and install it directly in the packaged extension.

This was due to updating the apex debugger to use the common code in utils for getting the config directory.  B/c it pulled in utils and utils depends on core this required a move to having core external for the extension. 

### What issues does this PR fix or reference?
#4536 @W-120117332@

### Functionality Before
apex interactive debugger failed to activate

### Functionality After
apex interactive debugger activates without issue.
