### PR TITLE
chore: update SDR version 6.0.4 to 7.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40601,7 +40601,7 @@
       "version": "56.5.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "^3.23.2",
+        "@salesforce/core": "^3.31.18",
         "@salesforce/salesforcedx-utils-vscode": "56.5.1",
         "jsforce": "2.0.0-beta.18",
         "shelljs": "0.8.5"
@@ -40903,7 +40903,7 @@
       "version": "56.5.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "^3.23.2",
+        "@salesforce/core": "^3.31.18",
         "applicationinsights": "1.0.7",
         "cross-spawn": "7.0.3",
         "rxjs": "^5.4.1",
@@ -41325,7 +41325,7 @@
       "dependencies": {
         "@salesforce/apex-node": "^1.0.0",
         "@salesforce/apex-tmlanguage": "1.4.0",
-        "@salesforce/core": "^3.23.2",
+        "@salesforce/core": "^3.31.18",
         "@salesforce/salesforcedx-utils-vscode": "56.5.1",
         "@salesforce/source-deploy-retrieve": "7.5.5",
         "expand-home-dir": "0.0.3",
@@ -41392,7 +41392,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/apex-node": "^1.0.0",
-        "@salesforce/core": "^3.23.2",
+        "@salesforce/core": "^3.31.18",
         "@salesforce/salesforcedx-apex-replay-debugger": "56.5.1",
         "@salesforce/salesforcedx-utils": "56.5.1",
         "@salesforce/salesforcedx-utils-vscode": "56.5.1",
@@ -41449,7 +41449,7 @@
       "dependencies": {
         "@heroku/functions-core": "0.4.2",
         "@octokit/plugin-paginate-rest": "2.21.3",
-        "@salesforce/core": "^3.23.2",
+        "@salesforce/core": "^3.31.18",
         "@salesforce/salesforcedx-sobjects-faux-generator": "56.5.1",
         "@salesforce/salesforcedx-utils-vscode": "56.5.1",
         "@salesforce/schemas": "^1",
@@ -41542,7 +41542,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/aura-language-server": "3.11.0",
-        "@salesforce/core": "^3.23.2",
+        "@salesforce/core": "^3.31.18",
         "@salesforce/lightning-lsp-common": "3.11.0",
         "@salesforce/salesforcedx-utils-vscode": "56.5.1",
         "applicationinsights": "1.0.7",
@@ -41609,7 +41609,7 @@
       "version": "56.5.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "^3.23.2",
+        "@salesforce/core": "^3.31.8",
         "@salesforce/eslint-config-lwc": "0.3.0",
         "@salesforce/lightning-lsp-common": "3.11.0",
         "@salesforce/lwc-language-server": "3.11.0",
@@ -42161,7 +42161,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/apex-tmlanguage": "1.6.0",
-        "@salesforce/core": "^3.23.2",
+        "@salesforce/core": "^3.31.18",
         "@salesforce/soql-builder-ui": "0.2.0",
         "@salesforce/soql-data-view": "0.1.0",
         "@salesforce/soql-language-server": "0.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5325,14 +5325,14 @@
       }
     },
     "node_modules/@salesforce/core": {
-      "version": "3.30.9",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.30.9.tgz",
-      "integrity": "sha512-dZFr2QS0joxl/FgdR+ZYhIVTEsJ7t+u02eaZCXLOqug/rzBq9xFoGPQaBboXx4CSf7k71Ox/Ty0sMSZNzkXb0A==",
+      "version": "3.31.18",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.31.18.tgz",
+      "integrity": "sha512-t2T7BzuNXdLGyAXMBHm9PtGbRvqCZQga+c3ceKKufJXW+ahQ2X8SXrOnXRzoZOt8DgTjWO3hLJmTCzC4AVgl7w==",
       "dependencies": {
         "@salesforce/bunyan": "^2.0.0",
-        "@salesforce/kit": "^1.5.41",
+        "@salesforce/kit": "^1.7.0",
         "@salesforce/schemas": "^1.1.0",
-        "@salesforce/ts-types": "^1.5.20",
+        "@salesforce/ts-types": "^1.5.21",
         "@types/graceful-fs": "^4.1.5",
         "@types/semver": "^7.3.9",
         "ajv": "^8.11.0",
@@ -5343,10 +5343,15 @@
         "form-data": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "js2xmlparser": "^4.0.1",
-        "jsforce": "beta",
+        "jsforce": "^2.0.0-beta.19",
         "jsonwebtoken": "8.5.1",
-        "ts-retry-promise": "^0.6.0"
+        "ts-retry-promise": "^0.7.0"
       }
+    },
+    "node_modules/@salesforce/core/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
     },
     "node_modules/@salesforce/core/node_modules/ajv": {
       "version": "8.11.0",
@@ -5401,6 +5406,16 @@
         "upper-case": "^2.0.2"
       }
     },
+    "node_modules/@salesforce/core/node_modules/core-js": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.0.tgz",
+      "integrity": "sha512-+DkDrhoR4Y0PxDz6rurahuB+I45OsEUv8E1maPTB6OuHRohMMcznBq9TMpdpDMm/hUPob/mJJS3PqgbHpMTQgw==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/@salesforce/core/node_modules/dot-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
@@ -5435,6 +5450,63 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/@salesforce/core/node_modules/inquirer": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.19",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.6.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@salesforce/core/node_modules/jsforce": {
+      "version": "2.0.0-beta.19",
+      "resolved": "https://registry.npmjs.org/jsforce/-/jsforce-2.0.0-beta.19.tgz",
+      "integrity": "sha512-WdF6hs7kukXNGvp/VRhu2DngldgiBBorsc2WA5us08oJGbEIPwn/itqYJWKJ+rfPXepz5JbkWQd48XHGjqmPpw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@babel/runtime-corejs3": "^7.12.5",
+        "@types/node": "^12.19.9",
+        "abort-controller": "^3.0.0",
+        "base64url": "^3.0.1",
+        "commander": "^4.0.1",
+        "core-js": "^3.6.4",
+        "csv-parse": "^4.8.2",
+        "csv-stringify": "^5.3.4",
+        "faye": "^1.4.0",
+        "form-data": "^4.0.0",
+        "fs-extra": "^8.1.0",
+        "https-proxy-agent": "^5.0.0",
+        "inquirer": "^7.0.0",
+        "multistream": "^3.1.0",
+        "node-fetch": "^2.6.1",
+        "open": "^7.0.0",
+        "regenerator-runtime": "^0.13.3",
+        "strip-ansi": "^6.0.0",
+        "xml2js": "^0.4.22"
+      },
+      "bin": {
+        "jsforce": "bin/jsforce",
+        "jsforce-gen-schema": "bin/jsforce-gen-schema"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/@salesforce/core/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -5455,6 +5527,21 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@salesforce/core/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@salesforce/core/node_modules/param-case": {
@@ -5484,6 +5571,27 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/@salesforce/core/node_modules/regenerator-runtime": {
+      "version": "0.13.10",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
+      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
+    },
+    "node_modules/@salesforce/core/node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/@salesforce/core/node_modules/rxjs/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
     "node_modules/@salesforce/core/node_modules/sentence-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
@@ -5501,6 +5609,25 @@
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@salesforce/core/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@salesforce/core/node_modules/ts-retry-promise": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/ts-retry-promise/-/ts-retry-promise-0.7.0.tgz",
+      "integrity": "sha512-x6yWZXC4BfXy4UyMweOFvbS1yJ/Y5biSz/mEPiILtJZLrqD3ZxIpzVOGGgifHHdaSe3WxzFRtsRbychI6zofOg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@salesforce/core/node_modules/tslib": {
@@ -5531,19 +5658,27 @@
       "dev": true
     },
     "node_modules/@salesforce/kit": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/kit/-/kit-1.6.1.tgz",
-      "integrity": "sha512-ZuQrzUo1jili5xl9LbJOsIra07C4FIRy5f9PLGi8lXEKGIJ2qg21VCLlREGV5tz5Qm1aYsCYW9rjQQzME1ou8Q==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/kit/-/kit-1.8.0.tgz",
+      "integrity": "sha512-Pr9CWAIzVYKZRWvM76lyhEtF3CPmVdIfgbqRD7KT/YZdbLstX3KHYBxCyx3TyWZr5qROv96n+jRIBiIFI9LGGw==",
       "dependencies": {
-        "@salesforce/ts-types": "^1.5.21",
+        "@salesforce/ts-types": "^1.7.1",
         "shx": "^0.3.3",
         "tslib": "^2.2.0"
       }
     },
+    "node_modules/@salesforce/kit/node_modules/@salesforce/ts-types": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-1.7.1.tgz",
+      "integrity": "sha512-jwZb8fYxbOmEckoJTxG2+5ZEJNJOFxmRJ/FioPnSu4IMFzpK3QbyujfqpHwLfPKHq0xlKRMx+F8QAVVKI/PA4w==",
+      "dependencies": {
+        "tslib": "^2.4.1"
+      }
+    },
     "node_modules/@salesforce/kit/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/@salesforce/label": {
       "version": "0.0.12",
@@ -5968,25 +6103,59 @@
       }
     },
     "node_modules/@salesforce/source-deploy-retrieve": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-6.0.4.tgz",
-      "integrity": "sha512-dZy7ttWPLC8P0vFbqg2dcn6pfjfHZvaEdDs9c/RiSrTPzkzPuy/trTiIBEUwzz2oK5pOUVQhAhvzeS4/QcHQMg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-7.5.5.tgz",
+      "integrity": "sha512-wRU/YB1REinffN+XWcSKBD/AOuqj+Y3IlcKpW90WPfD05f5yenY8VnUr3pm8Rm01HnbVhy3drjBmDKV3yHa4/A==",
       "dependencies": {
-        "@salesforce/core": "^3.19.0",
-        "@salesforce/kit": "^1.5.41",
-        "@salesforce/ts-types": "^1.5.20",
-        "archiver": "^5.3.0",
-        "fast-xml-parser": "^3.17.4",
-        "got": "^11.8.2",
-        "graceful-fs": "^4.2.8",
-        "ignore": "^5.1.8",
+        "@salesforce/core": "^3.31.17",
+        "@salesforce/kit": "^1.7.2",
+        "@salesforce/ts-types": "^1.7.1",
+        "archiver": "^5.3.1",
+        "fast-xml-parser": "^3.21.1",
+        "got": "^11.8.5",
+        "graceful-fs": "^4.2.10",
+        "ignore": "^5.2.0",
         "mime": "2.6.0",
-        "unzipper": "0.10.11",
-        "xmldom-sfdx-encoding": "^0.1.29"
+        "minimatch": "^5.1.0",
+        "proxy-agent": "^5.0.0",
+        "proxy-from-env": "^1.1.0",
+        "unzipper": "0.10.11"
       },
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/@salesforce/ts-types": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-1.7.1.tgz",
+      "integrity": "sha512-jwZb8fYxbOmEckoJTxG2+5ZEJNJOFxmRJ/FioPnSu4IMFzpK3QbyujfqpHwLfPKHq0xlKRMx+F8QAVVKI/PA4w==",
+      "dependencies": {
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/minimatch": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/@salesforce/templates": {
       "version": "55.1.0",
@@ -25727,6 +25896,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -25741,16 +25911,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -25764,6 +25937,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -25779,6 +25953,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -39289,14 +39464,6 @@
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
       "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg=="
     },
-    "node_modules/xmldom-sfdx-encoding": {
-      "version": "0.1.30",
-      "resolved": "https://registry.npmjs.org/xmldom-sfdx-encoding/-/xmldom-sfdx-encoding-0.1.30.tgz",
-      "integrity": "sha512-NOZCfMfwvCMBlSMBr971cnjmToNswV68A1CA3pnM0WGauo1BhWpTgSsj6Lbq8HNAI2OOdWktCSMLtaZU5wVBHA==",
-      "engines": {
-        "node": ">=0.1"
-      }
-    },
     "node_modules/xregexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
@@ -41160,7 +41327,7 @@
         "@salesforce/apex-tmlanguage": "1.4.0",
         "@salesforce/core": "^3.23.2",
         "@salesforce/salesforcedx-utils-vscode": "56.5.0",
-        "@salesforce/source-deploy-retrieve": "6.0.4",
+        "@salesforce/source-deploy-retrieve": "7.5.5",
         "expand-home-dir": "0.0.3",
         "find-java-home": "0.2.0",
         "path-exists": "3.0.0",
@@ -41286,7 +41453,7 @@
         "@salesforce/salesforcedx-sobjects-faux-generator": "56.5.0",
         "@salesforce/salesforcedx-utils-vscode": "56.5.0",
         "@salesforce/schemas": "^1",
-        "@salesforce/source-deploy-retrieve": "6.0.4",
+        "@salesforce/source-deploy-retrieve": "7.5.5",
         "@salesforce/templates": "^55.1.0",
         "@salesforce/ts-types": "1.5.21",
         "adm-zip": "0.4.13",

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -10,7 +10,7 @@
   },
   "main": "out/src",
   "dependencies": {
-    "@salesforce/core": "^3.23.2",
+    "@salesforce/core": "^3.31.18",
     "@salesforce/salesforcedx-utils-vscode": "56.5.1",
     "jsforce": "2.0.0-beta.18",
     "shelljs": "0.8.5"

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -11,7 +11,7 @@
   ],
   "main": "out/src",
   "dependencies": {
-    "@salesforce/core": "^3.23.2",
+    "@salesforce/core": "^3.31.18",
     "applicationinsights": "1.0.7",
     "cross-spawn": "7.0.3",
     "rxjs": "^5.4.1",

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -84,7 +84,7 @@
       "main": "dist/index.js",
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "@salesforce/core": "3.30.9"
+        "@salesforce/core": "3.31.18"
       },
       "devDependencies": {}
     }

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "@salesforce/apex-node": "^1.0.0",
-    "@salesforce/core": "^3.23.2",
+    "@salesforce/core": "^3.31.18",
     "@salesforce/salesforcedx-apex-replay-debugger": "56.5.1",
     "@salesforce/salesforcedx-utils": "56.5.1",
     "@salesforce/salesforcedx-utils-vscode": "56.5.1",
@@ -97,7 +97,7 @@
       "main": "dist/index.js",
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "@salesforce/core": "3.30.9"
+        "@salesforce/core": "3.31.18"
       },
       "devDependencies": {}
     }

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@salesforce/apex-node": "^1.0.0",
     "@salesforce/apex-tmlanguage": "1.4.0",
-    "@salesforce/core": "^3.23.2",
+    "@salesforce/core": "^3.31.18",
     "@salesforce/salesforcedx-utils-vscode": "56.5.1",
     "@salesforce/source-deploy-retrieve": "7.5.5",
     "expand-home-dir": "0.0.3",
@@ -91,7 +91,7 @@
       "dependencies": {
         "applicationinsights": "1.0.7",
         "@salesforce/apex-tmlanguage": "1.4.0",
-        "@salesforce/core": "3.30.9",
+        "@salesforce/core": "3.31.18",
         "@salesforce/templates": "55.1.0",
         "@salesforce/source-deploy-retrieve": "7.5.5",
         "shelljs": "0.8.5"

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -29,7 +29,7 @@
     "@salesforce/apex-tmlanguage": "1.4.0",
     "@salesforce/core": "^3.23.2",
     "@salesforce/salesforcedx-utils-vscode": "56.5.0",
-    "@salesforce/source-deploy-retrieve": "6.0.4",
+    "@salesforce/source-deploy-retrieve": "7.5.5",
     "expand-home-dir": "0.0.3",
     "find-java-home": "0.2.0",
     "path-exists": "3.0.0",
@@ -93,7 +93,7 @@
         "@salesforce/apex-tmlanguage": "1.4.0",
         "@salesforce/core": "3.30.9",
         "@salesforce/templates": "55.1.0",
-        "@salesforce/source-deploy-retrieve": "6.0.4",
+        "@salesforce/source-deploy-retrieve": "7.5.5",
         "shelljs": "0.8.5"
       },
       "devDependencies": {}

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@heroku/functions-core": "0.4.2",
     "@octokit/plugin-paginate-rest": "2.21.3",
-    "@salesforce/core": "^3.23.2",
+    "@salesforce/core": "^3.31.18",
     "@salesforce/salesforcedx-sobjects-faux-generator": "56.5.1",
     "@salesforce/salesforcedx-utils-vscode": "56.5.1",
     "@salesforce/schemas": "^1",
@@ -87,7 +87,7 @@
       "dependencies": {
         "applicationinsights": "1.0.7",
         "@heroku/functions-core": "0.4.2",
-        "@salesforce/core": "3.30.9",
+        "@salesforce/core": "3.31.18",
         "@salesforce/templates": "55.1.0",
         "@salesforce/source-deploy-retrieve": "7.5.5",
         "shelljs": "0.8.5"

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -31,7 +31,7 @@
     "@salesforce/salesforcedx-sobjects-faux-generator": "56.5.0",
     "@salesforce/salesforcedx-utils-vscode": "56.5.0",
     "@salesforce/schemas": "^1",
-    "@salesforce/source-deploy-retrieve": "6.0.4",
+    "@salesforce/source-deploy-retrieve": "7.5.5",
     "@salesforce/templates": "^55.1.0",
     "@salesforce/ts-types": "1.5.21",
     "adm-zip": "0.4.13",
@@ -89,7 +89,7 @@
         "@heroku/functions-core": "0.4.2",
         "@salesforce/core": "3.30.9",
         "@salesforce/templates": "55.1.0",
-        "@salesforce/source-deploy-retrieve": "6.0.4",
+        "@salesforce/source-deploy-retrieve": "7.5.5",
         "shelljs": "0.8.5"
       },
       "devDependencies": {}

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveMetadata/forceSourceRetrieveCmp.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceRetrieveMetadata/forceSourceRetrieveCmp.ts
@@ -5,36 +5,22 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {
-  CliCommandExecutor,
-  Command,
-  CommandOutput,
-  SfdxCommandBuilder
-} from '@salesforce/salesforcedx-utils-vscode';
-import { TelemetryData } from '@salesforce/salesforcedx-utils-vscode';
-import {
   ContinueResponse,
   LocalComponent
 } from '@salesforce/salesforcedx-utils-vscode';
 import {
   ComponentSet,
-  RetrieveResult,
-  SourceComponent
-} from '@salesforce/source-deploy-retrieve';
-import { SourceRetrieveResult } from '@salesforce/source-deploy-retrieve/lib/src/client/types';
+  RetrieveResult} from '@salesforce/source-deploy-retrieve';
 import { ComponentLike } from '@salesforce/source-deploy-retrieve/lib/src/resolve/types';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { RetrieveDescriber, RetrieveMetadataTrigger } from '.';
-import { channelService } from '../../channels';
+import { RetrieveMetadataTrigger } from '.';
 import { nls } from '../../messages';
-import { sfdxCoreSettings } from '../../settings';
 import { SfdxPackageDirectories } from '../../sfdxProject';
-import { telemetryService } from '../../telemetry';
-import { MetadataDictionary, workspaceUtils } from '../../util';
+import { workspaceUtils } from '../../util';
 import { RetrieveExecutor } from '../baseDeployRetrieve';
 import {
   SfdxCommandlet,
-  SfdxCommandletExecutor,
   SfdxWorkspaceChecker
 } from '../util';
 import { RetrieveComponentOutputGatherer } from '../util/parameterGatherers';

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "@salesforce/aura-language-server": "3.11.0",
-    "@salesforce/core": "^3.23.2",
+    "@salesforce/core": "^3.31.18",
     "@salesforce/lightning-lsp-common": "3.11.0",
     "@salesforce/salesforcedx-utils-vscode": "56.5.1",
     "applicationinsights": "1.0.7",
@@ -92,7 +92,7 @@
       "dependencies": {
         "applicationinsights": "1.0.7",
         "@salesforce/aura-language-server": "3.11.0",
-        "@salesforce/core": "3.30.9",
+        "@salesforce/core": "3.31.18",
         "@salesforce/lightning-lsp-common": "3.11.0"
       },
       "devDependencies": {}

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -25,7 +25,7 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/core": "^3.23.2",
+    "@salesforce/core": "^3.31.8",
     "@salesforce/eslint-config-lwc": "0.3.0",
     "@salesforce/lightning-lsp-common": "3.11.0",
     "@salesforce/lwc-language-server": "3.11.0",
@@ -99,7 +99,7 @@
       "main": "dist/index.js",
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "@salesforce/core": "3.30.9",
+        "@salesforce/core": "3.31.18",
         "@salesforce/lightning-lsp-common": "3.11.0",
         "@salesforce/lwc-language-server": "3.11.0"
       },

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {
     "@salesforce/apex-tmlanguage": "1.6.0",
-    "@salesforce/core": "^3.23.2",
+    "@salesforce/core": "^3.31.18",
     "@salesforce/soql-builder-ui": "0.2.0",
     "@salesforce/soql-data-view": "0.1.0",
     "@salesforce/soql-language-server": "0.7.1",
@@ -120,7 +120,7 @@
       "dependencies": {
         "applicationinsights": "1.0.7",
         "@salesforce/apex-tmlanguage": "1.6.0",
-        "@salesforce/core": "3.30.9",
+        "@salesforce/core": "3.31.18",
         "shelljs": "0.8.5",
         "@salesforce/soql-builder-ui": "0.2.0",
         "@salesforce/soql-data-view": "0.1.0",


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
- bumps SDR version from 6.0.4 to 7.5.5
- bumps sfdx-core to 3.31.18
### What issues does this PR fix or reference?
 @W-11549361@, https://github.com/forcedotcom/salesforcedx-vscode/issues/4498

### Functionality Before
@salesforce/source-deploy-retrieve at 6.0.4
@salesforce/core at ^3.23.0

### Functionality After
@salesforce/source-deploy-retrieve at 7.5.5
@salesforce/core at ^3.31.18