### PR TITLE
feat: support new template directive in LWCs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4549,14 +4549,14 @@
       }
     },
     "node_modules/@lwc/engine-dom": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@lwc/engine-dom/-/engine-dom-2.13.3.tgz",
-      "integrity": "sha512-f1GIJ5y1B6yfTvSF6p+zT/3aJAgxkVh0dGp6jTMAygXm6xcfHGpVsK9SXYXhpKdJUrkdGwJBzv7JjylThkqCYg=="
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/@lwc/engine-dom/-/engine-dom-2.26.1.tgz",
+      "integrity": "sha512-P6tWBWPBdN1aF+ti4AKWeCaSdr0Jgw+SHnSsjmO0PD7iMZjWJQEg91hvlCU90pxXJSbsXh3BaBBqcwJLAzS/bA=="
     },
     "node_modules/@lwc/errors": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@lwc/errors/-/errors-2.13.3.tgz",
-      "integrity": "sha512-HmImrcMTg/l0CJbKjQ4ZUKsxt2l5L6perjJOZUkk/lVyAUSXInNWPGQEv9ZBwTPSTvdIOXcpT/2S+F1XwPSyMA=="
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/@lwc/errors/-/errors-2.26.1.tgz",
+      "integrity": "sha512-8rYNUephXfXUxy2VzPQygSdwU0uB1NYY/2EWKULvb6+1equctLPPQChbquQH6nzPw+j5AwLMcB1B342tbPvWkw=="
     },
     "node_modules/@lwc/eslint-plugin-lwc": {
       "version": "0.6.0",
@@ -4571,9 +4571,9 @@
       }
     },
     "node_modules/@lwc/shared": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@lwc/shared/-/shared-2.13.3.tgz",
-      "integrity": "sha512-1AA0z+LFpxaLsufay+BpE8cIX1NJY2r5jp1kqro9hU9NG+iltDQ35bKG4uV3E/QcQ8f5Yme5lR3F1M69kExDrA=="
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/@lwc/shared/-/shared-2.26.1.tgz",
+      "integrity": "sha512-Pf30K/pfGQESAUE405rEKiupTJ3P8hYuCDVbsz+L9RRu+2OuAW2f/rlJveYnPAbn19WAOwyckYMYtDlC2DCUjA=="
     },
     "node_modules/@lwc/style-compiler": {
       "version": "0.34.8",
@@ -4587,28 +4587,17 @@
       }
     },
     "node_modules/@lwc/template-compiler": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@lwc/template-compiler/-/template-compiler-2.13.3.tgz",
-      "integrity": "sha512-3wuMasZLiei2C1/wFzWav9KWUvs7wi+mSa7LbUlS+sZXbMtzXfbzLgGzzV0WDvaDquRLBsPrp/Fda/6mGnlFFA==",
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/@lwc/template-compiler/-/template-compiler-2.26.1.tgz",
+      "integrity": "sha512-kQdGbRmmMXZMCwPOgBgX/JfGVityRG6mLfG/la13vts8n7NEGc2t2k1FsvZlTJzCrjDkA8LUNsJjwAChkTPt9w==",
       "dependencies": {
-        "@lwc/errors": "2.13.3",
-        "@lwc/shared": "2.13.3",
-        "acorn": "~8.7.1",
+        "@lwc/errors": "2.26.1",
+        "@lwc/shared": "2.26.1",
+        "acorn": "~8.8.0",
         "astring": "~1.8.3",
         "estree-walker": "~2.0.2",
         "he": "~1.2.0",
         "parse5": "~6.0.1"
-      }
-    },
-    "node_modules/@lwc/template-compiler/node_modules/acorn": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/@monorepo-utils/package-utils": {
@@ -5252,11 +5241,11 @@
       }
     },
     "node_modules/@salesforce/aura-language-server": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-3.11.0.tgz",
-      "integrity": "sha512-KMFB7PUmvIwujjGDroPp00cM1ONFmFotwea6t8iLDDg6ur6xuLgBCrqrbvj4swapUTXIzrA3U3S4767QTVtZeg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-4.0.2.tgz",
+      "integrity": "sha512-hWdzMGWUOD1DFhYN7x1ep7xZsrtH9LXU5GQVKuNAoTVsCXcGUqJNX2v9Bss+CVrHHKc2cF4Nh0sM6bZ3pf0jmA==",
       "dependencies": {
-        "@salesforce/lightning-lsp-common": "3.11.0",
+        "@salesforce/lightning-lsp-common": "4.0.2",
         "acorn": "^6.0.0",
         "acorn-loose": "^6.0.0",
         "acorn-walk": "^6.0.0",
@@ -5686,9 +5675,9 @@
       "integrity": "sha512-/ZiVwtVkmq2jWRRzgsC4SEy8m54gPaDc8e+jIfnIiR04iSeSRhYJxG+ktLSYVN2jMbVWA58HfEJSCx+73GcQCg=="
     },
     "node_modules/@salesforce/lightning-lsp-common": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-3.11.0.tgz",
-      "integrity": "sha512-/2eH1C/qx2OygxLn1iH4maRINEhhcxBAXgmlMvjt21a1OTNSgzqSY/pAxTzlss0hla0Vrdtkq7q4JkPp9l0tyg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-4.0.2.tgz",
+      "integrity": "sha512-zK1O2CgpJ62/NUR5rO53tjbDVoQBoDmZvo7pNPaAZCnCQpQf1IN5fOLAj7gclGHGqsyO7du92PIdE6qxxZsMOA==",
       "dependencies": {
         "decamelize": "^2.0.0",
         "deep-equal": "^1.0.1",
@@ -5752,17 +5741,17 @@
       "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
     },
     "node_modules/@salesforce/lwc-language-server": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-3.11.0.tgz",
-      "integrity": "sha512-zuGwJ7acaAcz5IjPnJ71YZsv3l9HC6l1DFcxW8dA7ZM1tNoTP+MByBN8ag9PKKZbssJB7Eov5ft36BcCtLoaYw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-4.0.2.tgz",
+      "integrity": "sha512-cJ4kEtknQeTstTW9TvwNSJ1+oKmTd48F4bwEp4ccav+gfDp6RjpLtC/lwJb9xHNDeDoSoxS/JkDGvbC8IN0zPw==",
       "dependencies": {
         "@lwc/compiler": "0.34.8",
-        "@lwc/engine-dom": "2.13.3",
-        "@lwc/errors": "2.13.3",
-        "@lwc/template-compiler": "2.13.3",
+        "@lwc/engine-dom": "2.26.1",
+        "@lwc/errors": "2.26.1",
+        "@lwc/template-compiler": "2.26.1",
         "@salesforce/apex": "0.0.12",
         "@salesforce/label": "0.0.12",
-        "@salesforce/lightning-lsp-common": "3.11.0",
+        "@salesforce/lightning-lsp-common": "4.0.2",
         "@salesforce/resourceurl": "0.0.12",
         "@salesforce/schema": "0.0.12",
         "@salesforce/user": "0.0.12",
@@ -41535,9 +41524,9 @@
       "version": "56.6.15",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/aura-language-server": "3.11.0",
+        "@salesforce/aura-language-server": "4.0.2",
         "@salesforce/core": "^3.31.18",
-        "@salesforce/lightning-lsp-common": "3.11.0",
+        "@salesforce/lightning-lsp-common": "4.0.2",
         "@salesforce/salesforcedx-utils-vscode": "56.6.15",
         "applicationinsights": "1.0.7",
         "vscode-extension-telemetry": "0.0.17",
@@ -41605,8 +41594,8 @@
       "dependencies": {
         "@salesforce/core": "^3.31.8",
         "@salesforce/eslint-config-lwc": "0.3.0",
-        "@salesforce/lightning-lsp-common": "3.11.0",
-        "@salesforce/lwc-language-server": "3.11.0",
+        "@salesforce/lightning-lsp-common": "4.0.2",
+        "@salesforce/lwc-language-server": "4.0.2",
         "@salesforce/salesforcedx-utils-vscode": "56.6.15",
         "ajv": "6.12.6",
         "applicationinsights": "1.0.7",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -25,9 +25,9 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/aura-language-server": "3.11.0",
+    "@salesforce/aura-language-server": "4.0.2",
     "@salesforce/core": "^3.31.18",
-    "@salesforce/lightning-lsp-common": "3.11.0",
+    "@salesforce/lightning-lsp-common": "4.0.2",
     "@salesforce/salesforcedx-utils-vscode": "56.6.15",
     "applicationinsights": "1.0.7",
     "vscode-extension-telemetry": "0.0.17",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "@salesforce/core": "^3.31.8",
     "@salesforce/eslint-config-lwc": "0.3.0",
-    "@salesforce/lightning-lsp-common": "3.11.0",
-    "@salesforce/lwc-language-server": "3.11.0",
+    "@salesforce/lightning-lsp-common": "4.0.2",
+    "@salesforce/lwc-language-server": "4.0.2",
     "@salesforce/salesforcedx-utils-vscode": "56.6.15",
     "ajv": "6.12.6",
     "applicationinsights": "1.0.7",


### PR DESCRIPTION
### What does this PR do?
Updated to the major Lighting Language Server upgrade, which includes support for template directives coming in 242.

### What issues does this PR fix or reference?
@W-11940409@

### Functionality Before
Template directives [here](https://github.com/forcedotcom/lightning-language-server/pull/518) showed as syntax errors.

### Functionality After
Directives do not complain about syntax errors in VS Code; note that deploying the code will not work correctly until used in orgs running 242.
