### PR TITLE
chore: update how we import command const and alter test 

### DIFF
--- a/packages/salesforcedx-vscode-core/src/constants.ts
+++ b/packages/salesforcedx-vscode-core/src/constants.ts
@@ -49,3 +49,6 @@ export const AURA_PATH = '/force-app/main/default/aura/';
 export const APEX_CLASSES_PATH = '/force-app/main/default/classes/';
 export const LWC_PATH = '/force-app/main/default/lwc/';
 export const FUNCTIONS_PATH = '/functions/';
+
+// Commands
+export const ORG_OPEN_COMMAND = 'sfdx.force.org.open';

--- a/packages/salesforcedx-vscode-core/src/context/workspaceContext.ts
+++ b/packages/salesforcedx-vscode-core/src/context/workspaceContext.ts
@@ -12,7 +12,7 @@ import {
 } from '@salesforce/salesforcedx-utils-vscode';
 import * as vscode from 'vscode';
 import { workspaceContextUtils } from '.';
-import { showOrg } from '../decorators';
+import { decorators } from '../decorators';
 
 /**
  * Manages the context of a workspace during a session with an open SFDX project.
@@ -47,7 +47,8 @@ export class WorkspaceContext {
       // error reported by setupWorkspaceOrgType
       console.error(e)
     );
-    await showOrg();
+    decorators.addAProperty = 'abcd';
+    await decorators.showOrg();
   }
 
   get username(): string | undefined {

--- a/packages/salesforcedx-vscode-core/src/context/workspaceContext.ts
+++ b/packages/salesforcedx-vscode-core/src/context/workspaceContext.ts
@@ -47,7 +47,7 @@ export class WorkspaceContext {
       // error reported by setupWorkspaceOrgType
       console.error(e)
     );
-    decorators.addAProperty = 'abcd';
+
     await decorators.showOrg();
   }
 

--- a/packages/salesforcedx-vscode-core/src/decorators/index.ts
+++ b/packages/salesforcedx-vscode-core/src/decorators/index.ts
@@ -6,9 +6,13 @@
  */
 
 export { showDemoMode } from './demo-mode-decorator';
-export { showOrg } from './scratch-org-decorator';
 export {
   disposeTraceFlagExpiration,
   hideTraceFlagExpiration,
   showTraceFlagExpiration
 } from './traceflag-time-decorator';
+import { showOrg } from './scratch-org-decorator';
+
+export const decorators = {
+  showOrg
+} as const;

--- a/packages/salesforcedx-vscode-core/src/decorators/scratch-org-decorator.ts
+++ b/packages/salesforcedx-vscode-core/src/decorators/scratch-org-decorator.ts
@@ -7,7 +7,7 @@
 
 import { ConfigUtil } from '@salesforce/salesforcedx-utils-vscode';
 import { StatusBarAlignment, StatusBarItem, window } from 'vscode';
-import { ORG_OPEN_COMMAND } from '../../src';
+import { ORG_OPEN_COMMAND } from '../../src/constants';
 import { nls } from '../messages';
 
 let statusBarItem: StatusBarItem | undefined;

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -92,7 +92,10 @@ import {
   registerConflictView,
   setupConflictView
 } from './conflict';
-import { ENABLE_SOBJECT_REFRESH_ON_STARTUP } from './constants';
+import {
+  ENABLE_SOBJECT_REFRESH_ON_STARTUP,
+  ORG_OPEN_COMMAND
+} from './constants';
 import { workspaceContextUtils } from './context';
 import { workspaceContext } from './context';
 import * as decorators from './decorators';
@@ -106,8 +109,6 @@ import { taskViewService } from './statuses';
 import { showTelemetryMessage, telemetryService } from './telemetry';
 import { isCLIInstalled, setUpOrgExpirationWatcher } from './util';
 import { OrgAuthInfo } from './util/authInfo';
-
-export const ORG_OPEN_COMMAND = 'sfdx.force.org.open';
 
 const flagOverwrite: FlagParameter<string> = {
   flag: '--forceoverwrite'

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -96,9 +96,12 @@ import {
   ENABLE_SOBJECT_REFRESH_ON_STARTUP,
   ORG_OPEN_COMMAND
 } from './constants';
-import { workspaceContextUtils } from './context';
-import { workspaceContext } from './context';
-import * as decorators from './decorators';
+import { workspaceContext, workspaceContextUtils } from './context';
+import {
+  decorators,
+  disposeTraceFlagExpiration,
+  showDemoMode
+} from './decorators';
 import { isDemoMode } from './modes/demo-mode';
 import { notificationService, ProgressNotification } from './notifications';
 import { orgBrowser } from './orgBrowser';
@@ -742,7 +745,7 @@ async function initializeProject(extensionContext: vscode.ExtensionContext) {
 
   // Demo mode decorator
   if (isDemoMode()) {
-    decorators.showDemoMode();
+    showDemoMode();
   }
 }
 
@@ -753,6 +756,6 @@ export function deactivate(): Promise<void> {
   telemetryService.sendExtensionDeactivationEvent();
   telemetryService.dispose();
 
-  decorators.disposeTraceFlagExpiration();
+  disposeTraceFlagExpiration();
   return turnOffLogging();
 }

--- a/packages/salesforcedx-vscode-core/test/jest/decorators/scratch-org-decorator.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/decorators/scratch-org-decorator.test.ts
@@ -1,7 +1,7 @@
 import { ConfigUtil } from '@salesforce/salesforcedx-utils-vscode';
 import * as vscode from 'vscode';
 import { ORG_OPEN_COMMAND } from '../../../src/constants';
-import { showOrg } from '../../../src/decorators';
+import { decorators } from '../../../src/decorators';
 import { nls } from '../../../src/messages';
 
 describe('scratch org decorator', () => {
@@ -37,7 +37,7 @@ describe('scratch org decorator', () => {
   describe('show Org', () => {
     it('should show the browser icon in the status bar when a default username is set', async () => {
       getDefaultUsernameOrAliasMock.mockResolvedValue(testUser);
-      await showOrg();
+      await decorators.showOrg();
       expect(getDefaultUsernameOrAliasMock).toHaveBeenCalled();
       expect(createStatusBarItemMock).toHaveBeenCalled();
       expect(mockStatusBarItem.tooltip).toEqual(
@@ -48,7 +48,7 @@ describe('scratch org decorator', () => {
       expect(mockStatusBarItem.text).toEqual(browserIcon);
     });
     it('should not show the browser icon in the status bar when a default username is not set', async () => {
-      await showOrg();
+      await decorators.showOrg();
       expect(getDefaultUsernameOrAliasMock).toHaveBeenCalled();
       expect(createStatusBarItemMock).not.toHaveBeenCalled();
       expect(mockStatusBarItem.tooltip).toEqual('');
@@ -58,12 +58,12 @@ describe('scratch org decorator', () => {
     });
     it('should dispose and set to undefined the status bar when a default username is not set and the status bar exists', async () => {
       getDefaultUsernameOrAliasMock.mockResolvedValue(testUser);
-      await showOrg();
+      await decorators.showOrg();
       expect(getDefaultUsernameOrAliasMock).toHaveBeenCalled();
       expect(createStatusBarItemMock).toHaveBeenCalled();
 
       getDefaultUsernameOrAliasMock.mockResolvedValue(undefined);
-      await showOrg();
+      await decorators.showOrg();
       expect(getDefaultUsernameOrAliasMock).toHaveBeenCalledTimes(2);
       expect(createStatusBarItemMock).toHaveBeenCalledTimes(1);
       expect(mockStatusBarItem.dispose).toHaveBeenCalled();

--- a/packages/salesforcedx-vscode-core/test/jest/decorators/scratch-org-decorator.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/decorators/scratch-org-decorator.test.ts
@@ -1,6 +1,6 @@
 import { ConfigUtil } from '@salesforce/salesforcedx-utils-vscode';
 import * as vscode from 'vscode';
-import { ORG_OPEN_COMMAND } from '../../../src';
+import { ORG_OPEN_COMMAND } from '../../../src/constants';
 import { showOrg } from '../../../src/decorators';
 import { nls } from '../../../src/messages';
 
@@ -24,13 +24,14 @@ describe('scratch org decorator', () => {
       onDidChange: jest.fn(),
       onDidCreate: jest.fn()
     };
-    createStatusBarItemMock = (vscode.window.createStatusBarItem as any).mockReturnValue(
-      mockStatusBarItem
-    );
+    createStatusBarItemMock = (vscode.window
+      .createStatusBarItem as any).mockReturnValue(mockStatusBarItem);
     createFileSystemWatcherMock = (vscode.workspace
       .createFileSystemWatcher as any).mockReturnValue(mockWatcher);
-    getDefaultUsernameOrAliasMock = jest
-      .spyOn(ConfigUtil, 'getDefaultUsernameOrAlias');
+    getDefaultUsernameOrAliasMock = jest.spyOn(
+      ConfigUtil,
+      'getDefaultUsernameOrAlias'
+    );
   });
 
   describe('show Org', () => {
@@ -39,7 +40,9 @@ describe('scratch org decorator', () => {
       await showOrg();
       expect(getDefaultUsernameOrAliasMock).toHaveBeenCalled();
       expect(createStatusBarItemMock).toHaveBeenCalled();
-      expect(mockStatusBarItem.tooltip).toEqual(nls.localize('status_bar_open_org_tooltip'));
+      expect(mockStatusBarItem.tooltip).toEqual(
+        nls.localize('status_bar_open_org_tooltip')
+      );
       expect(mockStatusBarItem.command).toEqual(openOrgCommand);
       expect(mockStatusBarItem.show).toHaveBeenCalled();
       expect(mockStatusBarItem.text).toEqual(browserIcon);

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/context/workspaceContext.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/context/workspaceContext.test.ts
@@ -9,7 +9,7 @@ import * as vscode from 'vscode';
 import { SFDX_CONFIG_FILE, SFDX_FOLDER } from '../../../src/constants';
 import { workspaceContextUtils } from '../../../src/context';
 import { WorkspaceContext } from '../../../src/context/workspaceContext';
-import { showOrg } from '../../../src/decorators';
+import { decorators } from '../../../src/decorators';
 import { workspaceUtils } from '../../../src/util';
 
 const env = createSandbox();
@@ -118,7 +118,7 @@ describe('WorkspaceContext', () => {
       .stub(workspaceContextUtil, 'username')
       .get(() => testUser);
     aliasStub = env.stub(workspaceContextUtil, 'alias').get(() => testAlias);
-    showOrgStub = env.stub(showOrg).resolves();
+    showOrgStub = env.stub(decorators, 'showOrg').resolves();
 
     const extensionContext = ({
       subscriptions: []


### PR DESCRIPTION
Just a place holder PR for showing updates to get things working again for int tests for PR #4514 

Fix two things here.
1. So the issue with running the integration tests in core was a circular dependency.  index.ts -> decorators.ts -> index.ts.  It def wasn't obvious and I only eventually found the solution by looking at what changed paired with the stack trace. Fix was to move the command constant from index to the constants file and 🏁 
2. After getting the int tests running again I was seeing a failure in the workspaceContest test.  There were two issues there.  The first was how the  stub for showOrg was getting created: 
`showOrgStub = env.stub(showOrg).resolves();` ❌ 
`showOrgStub = env.stub(decorators, 'showOrg').resolves();` ✅ 
The second was our old pass by value problem friend.  I fixed it by wrapping show org in an object. 
