### PR TITLE
chore: add names to all GHA workflows.  put slack notification back

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -507,18 +507,7 @@ jobs:
 
 workflows:
   version: 2.1
-
-  # run a build and a windows test on every commit
-  commit-workflow:
-    when:
-      and:
-        - not: << pipeline.parameters.publish >>
-        - not: << pipeline.parameters.pre-publish >>
-    jobs:
-      - build-all
-      - unit-tests
-      - integration-tests
-
+  
   pre-publish-workflow:
     when: << pipeline.parameters.pre-publish >>
     jobs:

--- a/.github/workflows/buildAll.yml
+++ b/.github/workflows/buildAll.yml
@@ -1,3 +1,4 @@
+name: Build All
 on:
   workflow_call:
 

--- a/.github/workflows/createReleaseBranch.yml
+++ b/.github/workflows/createReleaseBranch.yml
@@ -64,3 +64,15 @@ jobs:
     - run: echo “Release Type is ${{ github.event.inputs.releaseType || 'minor' }}”
     - run: echo “Release Branch is ${{ steps.branch.outputs.branch }}”
 
+  slack_notification:
+    if: ${{ always() }}
+    needs: create_branch
+    uses: ./.github/workflows/slackNotification.yml
+    secrets: inherit
+    with:
+      title: "Release Branch v${{ needs.create_branch.outputs.version }} (${{ needs.create_branch.outputs.release_type }})"
+      failedEvent: "Create Release Branch"
+      successfulEvent: "${{ github.event.repository.html_url }}/tree/${{ needs.create_branch.outputs.branch }}"
+      type: "created"
+      result: ${{ needs.create_branch.outputs.result }}
+      workflow: "create-release-branch.yml"

--- a/.github/workflows/integrationTests.yml
+++ b/.github/workflows/integrationTests.yml
@@ -1,3 +1,4 @@
+name: Integration Tests
 on:
   workflow_call:
 

--- a/.github/workflows/integrationTestsWindows.yml
+++ b/.github/workflows/integrationTestsWindows.yml
@@ -1,3 +1,4 @@
+name: Integration Tests Windows
 on:
   workflow_call:
 

--- a/.github/workflows/nightlyBuildDevelop.yml
+++ b/.github/workflows/nightlyBuildDevelop.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   nightly-build-develop:
-    uses: ./.github/workflows/buildAll.yml
+    uses:  ./.github/workflows/nightlyBuild.yml
     with:
       branch: develop

--- a/.github/workflows/nightlyBuildMain.yml
+++ b/.github/workflows/nightlyBuildMain.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   nightly-build-main:
-    uses: ./.github/workflows/buildAll.yml
+    uses:  ./.github/workflows/nightlyBuild.yml
     with:
       branch: main

--- a/.github/workflows/testCommitExceptMain.yml
+++ b/.github/workflows/testCommitExceptMain.yml
@@ -1,4 +1,4 @@
-name: commit workflow
+name: Commit Workflow
 on:
   push:
     branches-ignore: [main, develop]

--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -1,3 +1,5 @@
+name: Unit Tests
+
 on:
   workflow_call:
 

--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -1,3 +1,4 @@
+name: Unit Tests Linux
 on:
   workflow_call:
 

--- a/.github/workflows/unitTestsWindows.yml
+++ b/.github/workflows/unitTestsWindows.yml
@@ -1,3 +1,4 @@
+name: Unit Tests Windows
 on:
   workflow_call:
 

--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -1,4 +1,4 @@
-name: validate pr
+name: Validate PR
 on:
   pull_request:
     branches: [develop]


### PR DESCRIPTION
### What does this PR do?
Add Name for any github actions workflows that were missing it.  Put the slack notification back on the cutReleaseBranch job since it is now merged into main. 

### What issues does this PR fix or reference?
@W-11949791@ 

### Functionality Before
<img width="356" alt="Screen Shot 2022-12-07 at 5 11 46 PM" src="https://user-images.githubusercontent.com/76090802/206317202-fdd891e6-d7a0-4126-8eb7-b16b1fe3981a.png">


### Functionality After
Names will be listed instead of workflow files. 
