### PR TITLE
fix: fix extra line from default apex template and all default versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41483,7 +41483,7 @@
         "@salesforce/salesforcedx-utils-vscode": "56.9.0",
         "@salesforce/schemas": "^1",
         "@salesforce/source-deploy-retrieve": "7.5.5",
-        "@salesforce/templates": "^55.1.0",
+        "@salesforce/templates": "^57.0.2",
         "@salesforce/ts-types": "1.5.21",
         "adm-zip": "0.4.13",
         "applicationinsights": "1.0.7",
@@ -41522,6 +41522,27 @@
       },
       "engines": {
         "vscode": "^1.61.2"
+      }
+    },
+    "packages/salesforcedx-vscode-core/node_modules/@salesforce/templates": {
+      "version": "57.0.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-57.0.2.tgz",
+      "integrity": "sha512-Dix0l6pNGtLCK9HJwdejCfTeQFAPlvF1Ww0H3UN8sU4ji440EhwD4BbHL6HMusxCnANEhD6tJ46OVmlPEcDhJg==",
+      "dependencies": {
+        "@salesforce/core": "^3.24.0",
+        "@salesforce/kit": "^1.7.1",
+        "got": "^11.8.2",
+        "mime-types": "^2.1.27",
+        "proxy-agent": "^5.0.0",
+        "proxy-from-env": "^1.1.0",
+        "shelljs": "^0.8.5",
+        "tar": "^6.1.10",
+        "tslib": "^1",
+        "yeoman-environment": "^3.9.1",
+        "yeoman-generator": "^5.6.1"
+      },
+      "engines": {
+        "node": ">=14.17.0"
       }
     },
     "packages/salesforcedx-vscode-core/node_modules/@types/node": {

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -92,7 +92,7 @@
         "applicationinsights": "1.0.7",
         "@salesforce/apex-tmlanguage": "1.4.0",
         "@salesforce/core": "3.31.18",
-        "@salesforce/templates": "55.1.0",
+        "@salesforce/templates": "57.0.2",
         "@salesforce/source-deploy-retrieve": "7.5.5",
         "shelljs": "0.8.5"
       },

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -32,7 +32,7 @@
     "@salesforce/salesforcedx-utils-vscode": "56.9.0",
     "@salesforce/schemas": "^1",
     "@salesforce/source-deploy-retrieve": "7.5.5",
-    "@salesforce/templates": "^55.1.0",
+    "@salesforce/templates": "^57.0.2",
     "@salesforce/ts-types": "1.5.21",
     "adm-zip": "0.4.13",
     "applicationinsights": "1.0.7",
@@ -88,7 +88,7 @@
         "applicationinsights": "1.0.7",
         "@heroku/functions-core": "0.4.2",
         "@salesforce/core": "3.31.18",
-        "@salesforce/templates": "55.1.0",
+        "@salesforce/templates": "57.0.2",
         "@salesforce/source-deploy-retrieve": "7.5.5",
         "shelljs": "0.8.5"
       },


### PR DESCRIPTION
### What does this PR do?
Bumps the templates library, which contains a fix removing the additional line which is added when creating Apex Classes from the default class template.

This PR also includes the version bump that sets the default API version for all metadata to the latest major Salesforce version 56.

### What issues does this PR fix or reference?
#3490 

Compare behavior before (left) with after (right):
<img width="1254" alt="Screen Shot 2022-12-08 at 6 19 24 PM" src="https://user-images.githubusercontent.com/9795193/206587338-c2aaa7a3-ee98-4829-b34d-a2527754696e.png">
