### PR TITLE
ci: fix nightly workflow for branch handling

### DIFF
--- a/.github/workflows/buildAll.yml
+++ b/.github/workflows/buildAll.yml
@@ -1,6 +1,10 @@
 name: Build All
 on:
   workflow_call:
+    inputs:
+      branch:
+        type: string
+        required: false
 
 jobs:
   build-all:
@@ -11,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch }}
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}

--- a/.github/workflows/integrationTests.yml
+++ b/.github/workflows/integrationTests.yml
@@ -1,7 +1,13 @@
 name: Integration Tests
 on:
   workflow_call:
+    inputs:
+      branch:
+        type: string
+        required: false
 
 jobs:
   windows-integration-tests:
     uses: ./.github/workflows/integrationTestsWindows.yml
+    with:
+      branch: ${{ inputs.branch }}

--- a/.github/workflows/integrationTestsWindows.yml
+++ b/.github/workflows/integrationTestsWindows.yml
@@ -1,6 +1,10 @@
 name: Integration Tests Windows
 on:
   workflow_call:
+    inputs:
+      branch:
+        type: string
+        required: false
 
 jobs:
   windows-integration-tests:
@@ -13,6 +17,8 @@ jobs:
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch }}
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}

--- a/.github/workflows/nightlyBuild.yml
+++ b/.github/workflows/nightlyBuild.yml
@@ -10,12 +10,12 @@ jobs:
   unit-tests:
     uses: ./.github/workflows/unitTests.yml
     with:
-      ref: ${{ inputs.branch }}
+      branch: ${{ inputs.branch }}
   integration-tests:
     uses: ./.github/workflows/integrationTests.yml
     with:
-      ref: ${{ inputs.branch }}
+      branch: ${{ inputs.branch }}
   build-all:
     uses: ./.github/workflows/buildAll.yml
     with:
-      ref: ${{ inputs.branch }}
+      branch: ${{ inputs.branch }}

--- a/.github/workflows/nightlyBuildDevelop.yml
+++ b/.github/workflows/nightlyBuildDevelop.yml
@@ -3,7 +3,7 @@ name: Nightly Build Develop
 on:
   workflow_dispatch:
   schedule:
-    - cron: 10 20 * * *
+    - cron: 10 6 * * *
 
 jobs:
   nightly-build-develop:

--- a/.github/workflows/nightlyBuildMain.yml
+++ b/.github/workflows/nightlyBuildMain.yml
@@ -3,7 +3,7 @@ name: Nightly Build Main
 on:
   workflow_dispatch:
   schedule:
-    - cron: 40 20 * * *
+    - cron: 40 6 * * *
 
 jobs:
   nightly-build-main:

--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -2,9 +2,16 @@ name: Unit Tests
 
 on:
   workflow_call:
-
+    inputs:
+      branch:
+        type: string
+        required: false
 jobs:
   linux-unit-tests:
     uses: ./.github/workflows/unitTestsLinux.yml
+    with:
+      branch: ${{ inputs.branch }}
   windows-unit-tests:
     uses: ./.github/workflows/unitTestsWindows.yml
+    with:
+      branch: ${{ inputs.branch }}

--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -1,6 +1,10 @@
 name: Unit Tests Linux
 on:
   workflow_call:
+    inputs:
+      branch:
+        type: string
+        required: false
 
 jobs:
   linux-unit-tests:
@@ -12,6 +16,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch }}
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}

--- a/.github/workflows/unitTestsWindows.yml
+++ b/.github/workflows/unitTestsWindows.yml
@@ -1,7 +1,11 @@
 name: Unit Tests Windows
 on:
   workflow_call:
-
+    inputs:
+      branch:
+        type: string
+        required: false
+        
 jobs:
   windows-unit-tests:
     strategy:
@@ -13,6 +17,8 @@ jobs:
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch }}
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}


### PR DESCRIPTION
### What does this PR do?
Update the GHA nightly workflows to fix the issue of being able to pass a branch to run on the other workflows. Note that the branch inputs are optional on all but the nightly workflow and should default to an empty string which will continuing using the default behavior.  

Also updated the time when the nightly tasks are run to be more middle of the night.

### What issues does this PR fix or reference?
@W-11949791@

### Functionality Before
nightly runs for main/develop failing due to branch inputs not being supported for the underlying workflows. 

### Functionality After
Update to allow passing the specific branch.
