### PR TITLE
fix: Fix "No authorization information found" Error After Authenticating an Org

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25932,6 +25932,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -25946,16 +25947,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -25969,6 +25973,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -25984,6 +25989,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -25932,7 +25932,6 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -25947,19 +25946,16 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -25973,7 +25969,6 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -25989,7 +25984,6 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },

--- a/packages/salesforcedx-utils-vscode/src/config/configUtil.ts
+++ b/packages/salesforcedx-utils-vscode/src/config/configUtil.ts
@@ -12,7 +12,6 @@ import {
   SfConfigProperties,
   StateAggregator
 } from '@salesforce/core';
-import { AuthUtil } from '..';
 import { ConfigAggregatorProvider } from '../providers';
 
 export enum ConfigSource {
@@ -126,9 +125,7 @@ export class ConfigUtil {
       return;
     }
 
-    const username = await AuthUtil.getInstance().getUsername(
-      defaultUsernameOrAlias
-    );
+    const username = await getUsernameFor(defaultUsernameOrAlias);
     return username ? String(username) : undefined;
   }
 
@@ -144,9 +141,15 @@ export class ConfigUtil {
       return;
     }
 
-    const username = await AuthUtil.getInstance().getUsername(
-      defaultDevHubUsernameOrAlias
-    );
+    const username = await getUsernameFor(defaultDevHubUsernameOrAlias);
     return username ? String(username) : undefined;
   }
+}
+
+async function getUsernameFor(usernameOrAlias: string) {
+  const info = await StateAggregator.getInstance();
+  const username = usernameOrAlias
+    ? info.aliases.getUsername(String(usernameOrAlias))
+    : undefined;
+  return username ? String(username) : undefined;
 }

--- a/packages/salesforcedx-utils-vscode/src/config/configUtil.ts
+++ b/packages/salesforcedx-utils-vscode/src/config/configUtil.ts
@@ -120,18 +120,36 @@ export class ConfigUtil {
    * @returns The username for the configured Org if it exists.
    */
   public static async getUsername(): Promise<string | undefined> {
-    const configAggregator = await ConfigAggregatorProvider.getInstance().getConfigAggregator();
-    const defaultUsernameOrAlias = configAggregator.getPropertyValue(
-      OrgConfigProperties.TARGET_ORG
-    );
+    const defaultUsernameOrAlias = await ConfigUtil.getDefaultUsernameOrAlias();
     if (!defaultUsernameOrAlias) {
       return;
     }
 
-    const info = await StateAggregator.getInstance();
-    const username = defaultUsernameOrAlias
-      ? info.aliases.getUsername(String(defaultUsernameOrAlias))
-      : undefined;
+    const username = await getUsernameFor(defaultUsernameOrAlias);
     return username ? String(username) : undefined;
   }
+
+  /**
+   * Get the username of the default dev hub for the project.
+   *
+   * @returns The username for the configured default dev hub
+   * Org if it exists.
+   */
+  public static async getDevHubUsername(): Promise<string | undefined> {
+    const defaultDevHubUsernameOrAlias = await ConfigUtil.getDefaultDevHubUsernameOrAlias();
+    if (!defaultDevHubUsernameOrAlias) {
+      return;
+    }
+
+    const username = await getUsernameFor(defaultDevHubUsernameOrAlias);
+    return username ? String(username) : undefined;
+  }
+}
+
+async function getUsernameFor(usernameOrAlias: string) {
+  const info = await StateAggregator.getInstance();
+  const username = usernameOrAlias
+    ? info.aliases.getUsername(String(usernameOrAlias))
+    : undefined;
+  return username ? String(username) : undefined;
 }

--- a/packages/salesforcedx-utils-vscode/src/config/configUtil.ts
+++ b/packages/salesforcedx-utils-vscode/src/config/configUtil.ts
@@ -12,6 +12,7 @@ import {
   SfConfigProperties,
   StateAggregator
 } from '@salesforce/core';
+import { AuthUtil } from '..';
 import { ConfigAggregatorProvider } from '../providers';
 
 export enum ConfigSource {
@@ -125,7 +126,9 @@ export class ConfigUtil {
       return;
     }
 
-    const username = await getUsernameFor(defaultUsernameOrAlias);
+    const username = await AuthUtil.getInstance().getUsername(
+      defaultUsernameOrAlias
+    );
     return username ? String(username) : undefined;
   }
 
@@ -141,15 +144,9 @@ export class ConfigUtil {
       return;
     }
 
-    const username = await getUsernameFor(defaultDevHubUsernameOrAlias);
+    const username = await AuthUtil.getInstance().getUsername(
+      defaultDevHubUsernameOrAlias
+    );
     return username ? String(username) : undefined;
   }
-}
-
-async function getUsernameFor(usernameOrAlias: string) {
-  const info = await StateAggregator.getInstance();
-  const username = usernameOrAlias
-    ? info.aliases.getUsername(String(usernameOrAlias))
-    : undefined;
-  return username ? String(username) : undefined;
 }

--- a/packages/salesforcedx-utils-vscode/src/context/workspaceContextUtil.ts
+++ b/packages/salesforcedx-utils-vscode/src/context/workspaceContextUtil.ts
@@ -1,4 +1,3 @@
-import { StateAggregator } from '@salesforce/core';
 /*
  * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
@@ -6,9 +5,9 @@ import { StateAggregator } from '@salesforce/core';
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthInfo, Connection } from '@salesforce/core';
+import { AuthInfo, Connection, StateAggregator } from '@salesforce/core';
 import * as vscode from 'vscode';
-import { ConfigAggregatorProvider, ConfigUtil } from '..';
+import { ConfigAggregatorProvider } from '..';
 import { AuthUtil } from '../auth/authUtil';
 import { projectPaths } from '../helpers';
 import { nls } from '../messages';

--- a/packages/salesforcedx-utils-vscode/src/context/workspaceContextUtil.ts
+++ b/packages/salesforcedx-utils-vscode/src/context/workspaceContextUtil.ts
@@ -83,7 +83,7 @@ export class WorkspaceContextUtil {
   }
 
   protected async handleCliConfigChange() {
-    // Core's types can return stale cached data at times when
+    // Core's types can return stale cached data when
     // this handler is called right after modifying the config file.
     // Reloading the Config Aggregator and StateAggregator here ensures
     // that they are refreshed when the config file changes, and are

--- a/packages/salesforcedx-utils-vscode/test/jest/context/workspaceContextUtil.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/context/workspaceContextUtil.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthInfo, Connection } from '@salesforce/core';
+import { AuthInfo, Connection, StateAggregator } from '@salesforce/core';
 import * as vscode from 'vscode';
 import { ConfigAggregatorProvider, WorkspaceContextUtil } from '../../../src';
 import { AuthUtil } from '../../../src/auth/authUtil';
@@ -25,9 +25,10 @@ describe('WorkspaceContext', () => {
   let getUsernameOrAliasStub: jest.SpyInstance;
   let workspaceContextUtil: any; // TODO find a better way
 
-  let mockWatcher: { onDidChange: any; onDidCreate: any; onDidDelete: any; };
+  let mockWatcher: { onDidChange: any; onDidCreate: any; onDidDelete: any };
   let mockFileSystemWatcher: jest.SpyInstance;
   let reloadConfigAggregatorsMock: jest.SpyInstance;
+  let stateAggregatorClearInstanceMock: jest.SpyInstance;
 
   beforeEach(async () => {
     mockWatcher = {
@@ -35,7 +36,14 @@ describe('WorkspaceContext', () => {
       onDidCreate: jest.fn(),
       onDidDelete: jest.fn()
     };
-    reloadConfigAggregatorsMock = jest.spyOn(ConfigAggregatorProvider.prototype, 'reloadConfigAggregators');
+    reloadConfigAggregatorsMock = jest.spyOn(
+      ConfigAggregatorProvider.prototype,
+      'reloadConfigAggregators'
+    );
+    stateAggregatorClearInstanceMock = jest.spyOn(
+      StateAggregator,
+      'clearInstance'
+    );
 
     mockFileSystemWatcher = (vscode.workspace
       .createFileSystemWatcher as any).mockReturnValue(mockWatcher);
@@ -43,8 +51,10 @@ describe('WorkspaceContext', () => {
     const context = {
       subscriptions: []
     };
-    getUsernameOrAliasStub = (authUtilMock.prototype.getDefaultUsernameOrAlias as any).mockReturnValue(testAlias);
-    getUsernameStub = (authUtilMock.prototype.getUsername as any).mockReturnValue(testUser);
+    getUsernameOrAliasStub = (authUtilMock.prototype
+      .getDefaultUsernameOrAlias as any).mockReturnValue(testAlias);
+    getUsernameStub = (authUtilMock.prototype
+      .getUsername as any).mockReturnValue(testUser);
     authUtilMock.getInstance.mockReturnValue(new AuthUtil());
 
     workspaceContextUtil = WorkspaceContextUtil.getInstance(true);
@@ -54,15 +64,19 @@ describe('WorkspaceContext', () => {
   it('test for the constructor', () => {
     expect(workspaceContextUtil).toHaveProperty('sessionConnections');
     expect(workspaceContextUtil).toHaveProperty('onOrgChangeEmitter');
-    expect(workspaceContextUtil).toHaveProperty('cliConfigWatcher', mockWatcher);
+    expect(workspaceContextUtil).toHaveProperty(
+      'cliConfigWatcher',
+      mockWatcher
+    );
   });
-  it('should load the default username and alias upon initialization', () => {
+  it('should load the default username and alias and clear the cache of the core types upon initialization', () => {
     expect(workspaceContextUtil.username).toEqual(testUser);
     expect(workspaceContextUtil.alias).toEqual(testAlias);
     expect(reloadConfigAggregatorsMock).toHaveBeenCalled();
+    expect(stateAggregatorClearInstanceMock).toHaveBeenCalled();
   });
 
-  it('should update default username and alias upon config change', async () => {
+  it('should update default username and alias and clear the cache of the core types upon config change', async () => {
     getUsernameOrAliasStub.mockReturnValue(testUser2);
     getUsernameStub.mockReturnValue(testUser2);
 
@@ -73,6 +87,8 @@ describe('WorkspaceContext', () => {
 
     expect(workspaceContextUtil.username).toEqual(testUser2);
     expect(workspaceContextUtil.alias).toEqual(undefined);
+    expect(reloadConfigAggregatorsMock).toHaveBeenCalled();
+    expect(stateAggregatorClearInstanceMock).toHaveBeenCalled();
   });
 
   it('should update default username to undefined if username is not set', async () => {
@@ -127,24 +143,28 @@ describe('WorkspaceContext', () => {
     let createConnectionStub: jest.SpyInstance;
 
     beforeEach(() => {
-      createAuthStub = jest
-        .spyOn(AuthInfo, 'create');
-      createConnectionStub = jest
-        .spyOn(Connection, 'create');
+      createAuthStub = jest.spyOn(AuthInfo, 'create');
+      createConnectionStub = jest.spyOn(Connection, 'create');
     });
 
     it('should return connection for the default org', async () => {
       authInfoMock.create.mockResolvedValue(mockAuthInfo as any);
       authInfoMock.create.mockResolvedValue(mockAuthInfo as any);
-      connectionMock.create.mockResolvedValue(mockConnection as unknown as Promise<Connection<any>>);
+      connectionMock.create.mockResolvedValue(
+        (mockConnection as unknown) as Promise<Connection<any>>
+      );
       const connection = await workspaceContextUtil.getConnection();
-      expect(connectionMock.create).toHaveBeenCalledWith({ authInfo: mockAuthInfo });
+      expect(connectionMock.create).toHaveBeenCalledWith({
+        authInfo: mockAuthInfo
+      });
       expect(connection).toEqual(mockConnection);
     });
 
     it('should return a cached connection for the default org if there is one', async () => {
       authInfoMock.create.mockResolvedValue(mockAuthInfo as any);
-      connectionMock.create.mockResolvedValue(mockConnection as unknown as Promise<Connection<any>>);
+      connectionMock.create.mockResolvedValue(
+        (mockConnection as unknown) as Promise<Connection<any>>
+      );
       await workspaceContextUtil.getConnection();
       await workspaceContextUtil.getConnection();
 

--- a/packages/salesforcedx-vscode-core/src/orgPicker/index.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/index.ts
@@ -5,4 +5,4 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export { OrgList, FileInfo } from './orgList';
+export { OrgList } from './orgList';

--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -14,6 +14,7 @@ import {
 import * as vscode from 'vscode';
 import { workspaceContext } from '../context';
 import { nls } from '../messages';
+import { OrgAuthInfo } from '../util';
 
 export class OrgList implements vscode.Disposable {
   private statusBarItem: vscode.StatusBarItem;
@@ -57,7 +58,7 @@ export class OrgList implements vscode.Disposable {
   public async filterAuthInfo(
     orgAuthorizations: OrgAuthorization[]
   ): Promise<string[]> {
-    const defaultDevHubUsername = await ConfigUtil.getDevHubUsername();
+    const defaultDevHubUsername = await OrgAuthInfo.getDevHubUsername();
 
     const authList = [];
     const today = new Date();

--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -63,6 +63,10 @@ export class OrgList implements vscode.Disposable {
     const authList = [];
     const today = new Date();
     for (const orgAuth of orgAuthorizations) {
+      // When this is called right after logging out of an org, there can
+      // still be a cached Org Auth in the list with a "No auth information found"
+      // error. This warning prevents that error from stopping the process, and
+      // should help in debugging if there are any other Org Auths with errors.
       if (orgAuth.error) {
         console.warn(
           `Org Auth for username: ${orgAuth.username} has an error: ${orgAuth.error}`

--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -48,7 +48,7 @@ export class OrgList implements vscode.Disposable {
     return orgAuthorizations;
   }
 
-  private async getAuthFieldsFor(username: string): Promise<AuthFields> {
+  public async getAuthFieldsFor(username: string): Promise<AuthFields> {
     const authInfo: AuthInfo = await AuthInfo.create({
       username
     });
@@ -114,7 +114,7 @@ export class OrgList implements vscode.Disposable {
     return authList;
   }
 
-  private async updateOrgList(): Promise<string[]> {
+  public async updateOrgList(): Promise<string[]> {
     const orgAuthorizations = await this.getOrgAuthorizations();
     if (orgAuthorizations && orgAuthorizations.length === 0) {
       return [];

--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -79,6 +79,7 @@ export class OrgList implements vscode.Disposable {
     const today = new Date();
     for (const orgAuth of orgAuthorizations) {
       if (orgAuth.error) {
+        // todo: warn, log, or silent?
         console.warn(
           `Org Auth for username: ${orgAuth.username} has an error: ${orgAuth.error}`
         );

--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -72,7 +72,6 @@ export class OrgList implements vscode.Disposable {
     const today = new Date();
     for (const orgAuth of orgAuthorizations) {
       if (orgAuth.error) {
-        // todo: warn, log, or silent?
         console.warn(
           `Org Auth for username: ${orgAuth.username} has an error: ${orgAuth.error}`
         );

--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -78,6 +78,12 @@ export class OrgList implements vscode.Disposable {
     const authList = [];
     const today = new Date();
     for (const orgAuth of orgAuthorizations) {
+      if (orgAuth.error) {
+        console.warn(
+          `Org Auth for username: ${orgAuth.username} has an error: ${orgAuth.error}`
+        );
+        continue;
+      }
       const authFields: AuthFields = await this.getAuthFieldsFor(
         orgAuth.username
       );

--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -16,13 +16,6 @@ import { workspaceContext } from '../context';
 import { nls } from '../messages';
 import { OrgAuthInfo } from '../util';
 
-export interface FileInfo {
-  scratchAdminUsername?: string;
-  isDevHub?: boolean;
-  username: string;
-  devHubUsername?: string;
-  expirationDate?: string;
-}
 export class OrgList implements vscode.Disposable {
   private statusBarItem: vscode.StatusBarItem;
 
@@ -42,7 +35,7 @@ export class OrgList implements vscode.Disposable {
     this.displayDefaultUsername(alias || username);
   }
 
-  public displayDefaultUsername(defaultUsernameOrAlias?: string) {
+  private displayDefaultUsername(defaultUsernameOrAlias?: string) {
     if (defaultUsernameOrAlias) {
       this.statusBarItem.text = `$(plug) ${defaultUsernameOrAlias}`;
     } else {
@@ -55,7 +48,7 @@ export class OrgList implements vscode.Disposable {
     return orgAuthorizations;
   }
 
-  public async getAuthFieldsFor(username: string): Promise<AuthFields> {
+  private async getAuthFieldsFor(username: string): Promise<AuthFields> {
     const authInfo: AuthInfo = await AuthInfo.create({
       username
     });
@@ -122,7 +115,7 @@ export class OrgList implements vscode.Disposable {
     return authList;
   }
 
-  public async updateOrgList(): Promise<string[]> {
+  private async updateOrgList(): Promise<string[]> {
     const orgAuthorizations = await this.getOrgAuthorizations();
     if (orgAuthorizations && orgAuthorizations.length === 0) {
       return [];

--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -14,7 +14,6 @@ import {
 import * as vscode from 'vscode';
 import { workspaceContext } from '../context';
 import { nls } from '../messages';
-import { OrgAuthInfo } from '../util';
 
 export class OrgList implements vscode.Disposable {
   private statusBarItem: vscode.StatusBarItem;
@@ -58,15 +57,7 @@ export class OrgList implements vscode.Disposable {
   public async filterAuthInfo(
     orgAuthorizations: OrgAuthorization[]
   ): Promise<string[]> {
-    const defaultDevHubUsernameOrAlias = await OrgAuthInfo.getDefaultDevHubUsernameOrAlias(
-      false
-    );
-    let defaultDevHubUsername: string | undefined;
-    if (defaultDevHubUsernameOrAlias) {
-      defaultDevHubUsername = await OrgAuthInfo.getUsername(
-        defaultDevHubUsernameOrAlias
-      );
-    }
+    const defaultDevHubUsername = await ConfigUtil.getDevHubUsername();
 
     const authList = [];
     const today = new Date();

--- a/packages/salesforcedx-vscode-core/src/util/authInfo.ts
+++ b/packages/salesforcedx-vscode-core/src/util/authInfo.ts
@@ -17,6 +17,19 @@ import { notificationService } from '../notifications';
 import { telemetryService } from '../telemetry';
 
 export class OrgAuthInfo {
+  public static async getDevHubUsername() {
+    const defaultDevHubUsernameOrAlias = await OrgAuthInfo.getDefaultDevHubUsernameOrAlias(
+      false
+    );
+    let defaultDevHubUsername: string | undefined;
+    if (defaultDevHubUsernameOrAlias) {
+      defaultDevHubUsername = await OrgAuthInfo.getUsername(
+        defaultDevHubUsernameOrAlias
+      );
+    }
+    return defaultDevHubUsername;
+  }
+
   public static async getDefaultUsernameOrAlias(
     enableWarning: boolean
   ): Promise<string | undefined> {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgPicker/orgList.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgPicker/orgList.test.ts
@@ -209,10 +209,10 @@ describe('orgList Tests', () => {
           .returns({
             devHubUsername: dummyDevHubUsername1
           });
-        getDevHubUsernameStub.resolves(dummyDevHubUsername1);
         getAllAliasesForStub
           .withArgs(authInfoObjectsWithOneError[0].username)
           .returns([AN_ALIAS]);
+        getDevHubUsernameStub.resolves(dummyDevHubUsername1);
 
         const authList = await orgList.filterAuthInfo(
           authInfoObjectsWithOneError

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgPicker/orgList.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgPicker/orgList.test.ts
@@ -12,6 +12,7 @@ import * as vscode from 'vscode';
 import { nls } from '../../../src/messages';
 import { OrgList } from '../../../src/orgPicker';
 import * as util from '../../../src/util';
+import { OrgAuthInfo } from '../../../src/util';
 
 const AN_ALIAS = 'anAlias';
 const sandbox = createSandbox();
@@ -62,7 +63,7 @@ describe('orgList Tests', () => {
     });
 
     describe('Filter Authorization Info', async () => {
-      let defaultDevHubStub: SinonStub;
+      let getDevHubUsernameStub: SinonStub;
       let getUsernameStub: SinonStub;
       let stateAggregatorCreateStub: SinonStub;
       let getAllStub: SinonStub;
@@ -73,7 +74,7 @@ describe('orgList Tests', () => {
       let fakeStateAggregator: any;
 
       beforeEach(() => {
-        defaultDevHubStub = sandbox.stub(ConfigUtil, 'getDevHubUsername');
+        getDevHubUsernameStub = sandbox.stub(OrgAuthInfo, 'getDevHubUsername');
         getUsernameStub = sandbox.stub(util.OrgAuthInfo, 'getUsername');
 
         getAllStub = sandbox.stub();
@@ -149,7 +150,7 @@ describe('orgList Tests', () => {
         getAuthFieldsForStub
           .withArgs(dummyOrgAuth1.username)
           .returns({ scratchAdminUsername: 'nonadmin@user.com' });
-        defaultDevHubStub.resolves(null);
+        getDevHubUsernameStub.resolves(null);
         getAllStub.returns([]);
 
         // Act
@@ -170,7 +171,7 @@ describe('orgList Tests', () => {
         getAuthFieldsForStub
           .withArgs(dummyScratchOrgAuth2.username)
           .returns({ devHubUsername: dummyDevHubUsername2 });
-        defaultDevHubStub.resolves(dummyDevHubUsername1);
+        getDevHubUsernameStub.resolves(dummyDevHubUsername1);
         getUsernameStub.resolves(dummyDevHubUsername1);
         getAllStub.returns([]);
 
@@ -190,7 +191,7 @@ describe('orgList Tests', () => {
         getAuthFieldsForStub
           .withArgs(dummyScratchOrgAuth2.username)
           .returns({ devHubUsername: dummyDevHubUsername2 });
-        defaultDevHubStub.returns(dummyDevHubUsername1);
+        getDevHubUsernameStub.returns(dummyDevHubUsername1);
         getUsernameStub.resolves(dummyDevHubUsername1);
         getAllStub.returns([]);
 
@@ -208,7 +209,7 @@ describe('orgList Tests', () => {
           .returns({
             devHubUsername: dummyDevHubUsername1
           });
-        defaultDevHubStub.resolves(dummyDevHubUsername1);
+        getDevHubUsernameStub.resolves(dummyDevHubUsername1);
         getAllAliasesForStub
           .withArgs(authInfoObjectsWithOneError[0].username)
           .returns([AN_ALIAS]);
@@ -216,7 +217,7 @@ describe('orgList Tests', () => {
         const authList = await orgList.filterAuthInfo(
           authInfoObjectsWithOneError
         );
-        expect(defaultDevHubStub.calledOnce).to.equal(true);
+        expect(getDevHubUsernameStub.calledOnce).to.equal(true);
         expect(authList.length).to.equal(1);
         expect(authList[0].includes(AN_ALIAS)).to.equal(true);
         expect(authList[0].includes(dummyScratchOrgAuth1.username)).to.equal(
@@ -226,7 +227,7 @@ describe('orgList Tests', () => {
 
       it('should display alias with username when alias is available', async () => {
         // Arrange
-        defaultDevHubStub.resolves(null);
+        getDevHubUsernameStub.resolves(null);
         const authInfoObjects: OrgAuthorization[] = [
           dummyOrgAuth1,
           dummyOrgAuth2
@@ -283,7 +284,7 @@ describe('orgList Tests', () => {
             devHubUsername: dummyDevHubUsername1,
             expirationDate: tomorrow.toISOString().split('T')[0]
           });
-        defaultDevHubStub.resolves(dummyDevHubUsername1);
+        getDevHubUsernameStub.resolves(dummyDevHubUsername1);
         getUsernameStub.resolves(dummyDevHubUsername1);
         getAllStub.returns([]);
 


### PR DESCRIPTION
### What does this PR do?
* Skips Org Authentications that have errors when building the org list for display.
* Clears the cache of StateAggregator after modifying the config file to ensure it loads up the freshest data.

### What issues does this PR fix or reference?
#4519, @W-11970040@

### Functionality Before
1. Authorize an org (SFDX: Authorize an Org)
2. Log out from all auth’d orgs (or just the default) (SFDX: Log Out from All Authorized Orgs)
3. Click on the “No Default Org Set” in the bottom status bar
4. See the “No auth info found for <org auth’d in step 1>” error msg

or

1. Authorize an org with an alias (SFDX: Authorize an Org) 
2. Right click on a Class or the classes folder in the Explorer View
3. Click "SFDX: Deploy Source to Org"
4. See the “No auth info found for <org auth’d in step 1>” error msg

![2022-12-12_11-35-07 (1)](https://user-images.githubusercontent.com/46458081/207181708-9c23d505-b3e7-4d32-a156-9385ed95687a.gif)

### Functionality After
1. Authorize an org (SFDX: Authorize an Org)
2. Log out from all auth’d orgs (or just the default) (SFDX: Log Out from All Authorized Orgs)
3. Click on the “No Default Org Set” in the bottom status bar
4. See the command palette open with org list and its 5 options for Authorizing an Org, Authorizing a Dev Hub, etc.

and 

1. Authorize an org with an alias (SFDX: Authorize an Org) 
2. Right click on a Class or the classes folder in the Explorer View
3. Click "SFDX: Deploy Source to Org"
4. See the metadata deploy to the Org successfully (no auth error is thrown)



 
