### PR TITLE
chore: bump functions-core from 0.5.1 to 0.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1862,9 +1862,9 @@
       }
     },
     "node_modules/@heroku/functions-core": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@heroku/functions-core/-/functions-core-0.5.1.tgz",
-      "integrity": "sha512-ADsWxCiJATf1gQKfOVdPakEYXrgYoDw84Xr5JAwXpRlcoVP5D4rVfNkQ0JWvtrUno2KF/c8VSx5jqvY9Wg4suQ==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@heroku/functions-core/-/functions-core-0.5.2.tgz",
+      "integrity": "sha512-kqlBT/lT9wuRDxD7q6HyN7j1JZz3+eryo0Jqos5b0Cx0aHxU/3xHNEZF8o+dauX4VvcaReHxNvrRjkxFVt3RwA==",
       "dependencies": {
         "@heroku-cli/color": "^1.1.15",
         "@heroku/project-descriptor": "0.0.6",
@@ -1881,7 +1881,7 @@
         "openpgp": "^5.5.0",
         "semver": "^7.3.8",
         "sha256-file": "^1.0.0",
-        "yeoman-environment": "~3.12.1"
+        "yeoman-environment": "~3.13.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -25932,6 +25932,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -25946,16 +25947,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -25969,6 +25973,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -25984,6 +25989,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -39631,9 +39637,9 @@
       }
     },
     "node_modules/yeoman-environment": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-3.12.1.tgz",
-      "integrity": "sha512-q5nC954SE4BEkWFXOwkifbelEZrza6z7vnXCC9bTWvfHjRiaG45eqzv/M6/u4l6PvB/KMmBPgMrACV2mBHE+PQ==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-3.13.0.tgz",
+      "integrity": "sha512-eBPpBZCvFzx6yk17x+ZrOHp8ADDv6qHradV+SgdugaQKIy9NjEX5AkbwdTHLOgccSTkQ9rN791xvYOu6OmqjBg==",
       "dependencies": {
         "@npmcli/arborist": "^4.0.4",
         "are-we-there-yet": "^2.0.0",
@@ -41476,7 +41482,7 @@
       "version": "56.10.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@heroku/functions-core": "0.5.1",
+        "@heroku/functions-core": "0.5.2",
         "@octokit/plugin-paginate-rest": "2.21.3",
         "@salesforce/core": "^3.31.18",
         "@salesforce/salesforcedx-sobjects-faux-generator": "56.10.0",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -25,7 +25,7 @@
     "Other"
   ],
   "dependencies": {
-    "@heroku/functions-core": "0.5.1",
+    "@heroku/functions-core": "0.5.2",
     "@octokit/plugin-paginate-rest": "2.21.3",
     "@salesforce/core": "^3.31.18",
     "@salesforce/salesforcedx-sobjects-faux-generator": "56.10.0",
@@ -86,7 +86,7 @@
       "main": "dist/index.js",
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "@heroku/functions-core": "0.4.2",
+        "@heroku/functions-core": "0.5.2",
         "@salesforce/core": "3.31.18",
         "@salesforce/templates": "57.0.2",
         "@salesforce/source-deploy-retrieve": "7.5.5",


### PR DESCRIPTION
Primarily to pick up the adjustments to the Python functions template needed for the transition from alpha to beta:
https://github.com/heroku/sf-functions-core/pull/175

Full changes:
https://github.com/heroku/sf-functions-core/compare/v0.5.1...v0.5.2

@W-12110517@