### PR TITLE
fix: update lightning-language-server versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4574,14 +4574,14 @@
       }
     },
     "node_modules/@lwc/engine-dom": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@lwc/engine-dom/-/engine-dom-2.13.3.tgz",
-      "integrity": "sha512-f1GIJ5y1B6yfTvSF6p+zT/3aJAgxkVh0dGp6jTMAygXm6xcfHGpVsK9SXYXhpKdJUrkdGwJBzv7JjylThkqCYg=="
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/@lwc/engine-dom/-/engine-dom-2.26.1.tgz",
+      "integrity": "sha512-P6tWBWPBdN1aF+ti4AKWeCaSdr0Jgw+SHnSsjmO0PD7iMZjWJQEg91hvlCU90pxXJSbsXh3BaBBqcwJLAzS/bA=="
     },
     "node_modules/@lwc/errors": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@lwc/errors/-/errors-2.13.3.tgz",
-      "integrity": "sha512-HmImrcMTg/l0CJbKjQ4ZUKsxt2l5L6perjJOZUkk/lVyAUSXInNWPGQEv9ZBwTPSTvdIOXcpT/2S+F1XwPSyMA=="
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/@lwc/errors/-/errors-2.26.1.tgz",
+      "integrity": "sha512-8rYNUephXfXUxy2VzPQygSdwU0uB1NYY/2EWKULvb6+1equctLPPQChbquQH6nzPw+j5AwLMcB1B342tbPvWkw=="
     },
     "node_modules/@lwc/eslint-plugin-lwc": {
       "version": "0.6.0",
@@ -4596,9 +4596,9 @@
       }
     },
     "node_modules/@lwc/shared": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@lwc/shared/-/shared-2.13.3.tgz",
-      "integrity": "sha512-1AA0z+LFpxaLsufay+BpE8cIX1NJY2r5jp1kqro9hU9NG+iltDQ35bKG4uV3E/QcQ8f5Yme5lR3F1M69kExDrA=="
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/@lwc/shared/-/shared-2.26.1.tgz",
+      "integrity": "sha512-Pf30K/pfGQESAUE405rEKiupTJ3P8hYuCDVbsz+L9RRu+2OuAW2f/rlJveYnPAbn19WAOwyckYMYtDlC2DCUjA=="
     },
     "node_modules/@lwc/style-compiler": {
       "version": "0.34.8",
@@ -4612,28 +4612,17 @@
       }
     },
     "node_modules/@lwc/template-compiler": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@lwc/template-compiler/-/template-compiler-2.13.3.tgz",
-      "integrity": "sha512-3wuMasZLiei2C1/wFzWav9KWUvs7wi+mSa7LbUlS+sZXbMtzXfbzLgGzzV0WDvaDquRLBsPrp/Fda/6mGnlFFA==",
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/@lwc/template-compiler/-/template-compiler-2.26.1.tgz",
+      "integrity": "sha512-kQdGbRmmMXZMCwPOgBgX/JfGVityRG6mLfG/la13vts8n7NEGc2t2k1FsvZlTJzCrjDkA8LUNsJjwAChkTPt9w==",
       "dependencies": {
-        "@lwc/errors": "2.13.3",
-        "@lwc/shared": "2.13.3",
-        "acorn": "~8.7.1",
+        "@lwc/errors": "2.26.1",
+        "@lwc/shared": "2.26.1",
+        "acorn": "~8.8.0",
         "astring": "~1.8.3",
         "estree-walker": "~2.0.2",
         "he": "~1.2.0",
         "parse5": "~6.0.1"
-      }
-    },
-    "node_modules/@lwc/template-compiler/node_modules/acorn": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/@monorepo-utils/package-utils": {
@@ -5277,11 +5266,11 @@
       }
     },
     "node_modules/@salesforce/aura-language-server": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-3.11.0.tgz",
-      "integrity": "sha512-KMFB7PUmvIwujjGDroPp00cM1ONFmFotwea6t8iLDDg6ur6xuLgBCrqrbvj4swapUTXIzrA3U3S4767QTVtZeg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-4.1.0.tgz",
+      "integrity": "sha512-SWfl3V9G0qYzEWyZPZN0L0Qkuy2HABdKaWi5dqRhIOGE8USW6symPWJqED2aE4rqWcN80Sdw1qIqCxO0v1UC8A==",
       "dependencies": {
-        "@salesforce/lightning-lsp-common": "3.11.0",
+        "@salesforce/lightning-lsp-common": "4.1.0",
         "acorn": "^6.0.0",
         "acorn-loose": "^6.0.0",
         "acorn-walk": "^6.0.0",
@@ -5711,9 +5700,9 @@
       "integrity": "sha512-/ZiVwtVkmq2jWRRzgsC4SEy8m54gPaDc8e+jIfnIiR04iSeSRhYJxG+ktLSYVN2jMbVWA58HfEJSCx+73GcQCg=="
     },
     "node_modules/@salesforce/lightning-lsp-common": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-3.11.0.tgz",
-      "integrity": "sha512-/2eH1C/qx2OygxLn1iH4maRINEhhcxBAXgmlMvjt21a1OTNSgzqSY/pAxTzlss0hla0Vrdtkq7q4JkPp9l0tyg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-4.1.0.tgz",
+      "integrity": "sha512-NN+Fl2AVjWM67qC5zKSL1qYWXJEFfouoz2LzLbMADkImlGcO+PSHWFE5UVht66pBuE3mSVk8IGVL3A0Pyx0OqQ==",
       "dependencies": {
         "decamelize": "^2.0.0",
         "deep-equal": "^1.0.1",
@@ -5777,17 +5766,17 @@
       "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
     },
     "node_modules/@salesforce/lwc-language-server": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-3.11.0.tgz",
-      "integrity": "sha512-zuGwJ7acaAcz5IjPnJ71YZsv3l9HC6l1DFcxW8dA7ZM1tNoTP+MByBN8ag9PKKZbssJB7Eov5ft36BcCtLoaYw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-4.1.0.tgz",
+      "integrity": "sha512-u32TKhlLXrJz0mKtXWu/cHIhzuMP00mnoJb/olAjqExT1SsWgLgrdIE9GQ+LStbOvVrsqU+AzGtTpYhRurahaw==",
       "dependencies": {
         "@lwc/compiler": "0.34.8",
-        "@lwc/engine-dom": "2.13.3",
-        "@lwc/errors": "2.13.3",
-        "@lwc/template-compiler": "2.13.3",
+        "@lwc/engine-dom": "2.26.1",
+        "@lwc/errors": "2.26.1",
+        "@lwc/template-compiler": "2.26.1",
         "@salesforce/apex": "0.0.12",
         "@salesforce/label": "0.0.12",
-        "@salesforce/lightning-lsp-common": "3.11.0",
+        "@salesforce/lightning-lsp-common": "4.1.0",
         "@salesforce/resourceurl": "0.0.12",
         "@salesforce/schema": "0.0.12",
         "@salesforce/user": "0.0.12",
@@ -41590,9 +41579,9 @@
       "version": "56.10.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/aura-language-server": "3.11.0",
+        "@salesforce/aura-language-server": "4.1.0",
         "@salesforce/core": "^3.31.18",
-        "@salesforce/lightning-lsp-common": "3.11.0",
+        "@salesforce/lightning-lsp-common": "4.1.0",
         "@salesforce/salesforcedx-utils-vscode": "56.10.0",
         "applicationinsights": "1.0.7",
         "vscode-extension-telemetry": "0.0.17",
@@ -41660,8 +41649,8 @@
       "dependencies": {
         "@salesforce/core": "^3.31.8",
         "@salesforce/eslint-config-lwc": "0.3.0",
-        "@salesforce/lightning-lsp-common": "3.11.0",
-        "@salesforce/lwc-language-server": "3.11.0",
+        "@salesforce/lightning-lsp-common": "4.1.0",
+        "@salesforce/lwc-language-server": "4.1.0",
         "@salesforce/salesforcedx-utils-vscode": "56.10.0",
         "ajv": "6.12.6",
         "applicationinsights": "1.0.7",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -25,9 +25,9 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/aura-language-server": "3.11.0",
+    "@salesforce/aura-language-server": "4.1.0",
     "@salesforce/core": "^3.31.18",
-    "@salesforce/lightning-lsp-common": "3.11.0",
+    "@salesforce/lightning-lsp-common": "4.1.0",
     "@salesforce/salesforcedx-utils-vscode": "56.10.0",
     "applicationinsights": "1.0.7",
     "vscode-extension-telemetry": "0.0.17",
@@ -91,9 +91,9 @@
       "main": "dist/index.js",
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "@salesforce/aura-language-server": "3.11.0",
+        "@salesforce/aura-language-server": "4.1.0",
         "@salesforce/core": "3.31.18",
-        "@salesforce/lightning-lsp-common": "3.11.0"
+        "@salesforce/lightning-lsp-common": "4.1.0"
       },
       "devDependencies": {}
     }

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "@salesforce/core": "^3.31.8",
     "@salesforce/eslint-config-lwc": "0.3.0",
-    "@salesforce/lightning-lsp-common": "3.11.0",
-    "@salesforce/lwc-language-server": "3.11.0",
+    "@salesforce/lightning-lsp-common": "4.1.0",
+    "@salesforce/lwc-language-server": "4.1.0",
     "@salesforce/salesforcedx-utils-vscode": "56.10.0",
     "ajv": "6.12.6",
     "applicationinsights": "1.0.7",
@@ -100,8 +100,8 @@
       "dependencies": {
         "applicationinsights": "1.0.7",
         "@salesforce/core": "3.31.18",
-        "@salesforce/lightning-lsp-common": "3.11.0",
-        "@salesforce/lwc-language-server": "3.11.0"
+        "@salesforce/lightning-lsp-common": "4.1.0",
+        "@salesforce/lwc-language-server": "4.1.0"
       },
       "devDependencies": {}
     }


### PR DESCRIPTION
### What does this PR do?
Updates the version of the lighting-language-server dependencies to pick up updated lighting/analyticsWaveApi typings from forcedotcom/lightning-language-server#530.

### What issues does this PR fix or reference?
@W-10758280@

### Functionality Before
No hover text or code completion for some new analyticsWaveApi adapters

### Functionality After
Hover text and code completion for some new analyticsWaveApi adapters
