### PR TITLE
ci: add custom name for vsixs uploaded for publish

### DIFF
--- a/.github/workflows/buildAll.yml
+++ b/.github/workflows/buildAll.yml
@@ -5,6 +5,10 @@ on:
       branch:
         type: string
         required: false
+      label:
+        type: string
+        required: false
+        default: 'VS Code Extensions'
 
 jobs:
   build-all:
@@ -33,6 +37,6 @@ jobs:
       - name: Upload Extensions
         uses: actions/upload-artifact@v3
         with:
-          name: VS Code Extensions
+          name: ${{ inputs.label }}
           path: ./extensions/
   

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -5,6 +5,9 @@ on:
       branch:
         type: string
         required: false
+      label:
+        type: string
+        required: false
 
 jobs:
   unit-tests:
@@ -19,3 +22,4 @@ jobs:
     uses: ./.github/workflows/buildAll.yml
     with:
       branch: ${{ inputs.branch }}
+      label: ${{ inputs.label }}

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -8,6 +8,7 @@ on:
       label:
         type: string
         required: false
+        default: 'VS Code Extensions'
 
 jobs:
   unit-tests:

--- a/.github/workflows/publishOnMergeWIthMain.yml
+++ b/.github/workflows/publishOnMergeWIthMain.yml
@@ -6,11 +6,26 @@ on:
   workflow_dispatch:
 
 jobs:
+  get-version:
+    name: 'Get Release Version'
+    runs-on: ubuntu-latest
+    outputs:
+      RELEASE_VERSION: ${{ steps.getMainVersion.outputs.version }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: 'main'
+      - id: getMainVersion
+        run: |
+          echo "version="$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")"" >> $GITHUB_OUTPUT
+      - run: echo "Main Release Version is ${{ steps.getMainVersion.outputs.version }}"
   build-and-test:
     uses: ./.github/workflows/buildAndTest.yml
+    needs: [get-version]
     with: 
       branch: 'main'
+      label: ${{ needs.get-version.outputs.RELEASE_VERSION }}
   publish:
     needs: [build-and-test]
+    secrets: inherit
     uses: ./.github/workflows/publish.yml
-  

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -51,7 +51,7 @@ jobs:
     steps: 
       - uses: actions/download-artifact@v3
         with:
-          name: VS Code Extensions
+          name: ${{ inputs.version }}
           path: ./extensions
       - name: Display downloaded vsix files
         run: ls -R ./extensions


### PR DESCRIPTION
### What does this PR do?
- add a custom name for publish vsixes  that get uploaded during the publish flow
- add secrets to the publish flow so that slack calls will work
- 
### What issues does this PR fix or reference?
@W-11596486@

### Functionality Before
All artifacts uploaded though GHA were named the same

### Functionality After
Artifacts uploaded during publish flow use version for the name. 
