### PR TITLE
ci: Fix how was generate the SHAs for validating published extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "vscode:bundle:extension": "lerna run bundle:extension",
     "vscode:package": "npm run vscode:bundle:debugger && npm run vscode:bundle:extension && lerna run vscode:package --concurrency 1 && npm run reformat",
     "vsix:install": "find ./packages -name '*.vsix' -exec code --install-extension {} \\;",
-    "vscode:sha256": "lerna run vscode:sha256 --concurrency 1",
+    "vscode:sha256": "node ./scripts/generate-sha256.js >> ./SHA256",
     "vscode:publish": "lerna run vscode:publish --concurrency 1",
     "watch": "lerna run --parallel watch",
     "eslint-check": "eslint --print-config .eslintrc.json | eslint-config-prettier-check",

--- a/scripts/generate-sha256.js
+++ b/scripts/generate-sha256.js
@@ -1,19 +1,24 @@
 #!/usr/bin/env node
-
+const path = require('path');
 const shell = require('shelljs');
 
-// Generate the SHA256 for the .vsix that matches the version in package.json
+const cwd = process.cwd();
+const vsixfiles = path.join(cwd, 'extensions');
+const vsixes = shell.ls(vsixfiles);
 
-const packageVersion = JSON.parse(shell.cat('package.json')).version;
-const vsix = shell.ls().filter(file => file.match(`-${packageVersion}.vsix`));
-
-if (!vsix.length) {
-  shell.error('No VSIX found matching the requested version in package.json');
+if (!vsixes.length) {
+  shell.error(
+    'No VSIX files found matching the requested version in package.json'
+  );
   shell.exit(1);
 }
 
-if (/win32/.test(process.platform)) {
-  shell.exec(`CertUtil -hashfile ${vsix} SHA256`);
-} else {
-  shell.exec(`shasum -a 256 ${vsix}`);
+process.chdir('extensions');
+for (let i = 0; i < vsixes.length; i++) {
+  const vsix = vsixes[i];
+  if (/win32/.test(process.platform)) {
+    shell.exec(`CertUtil -hashfile ${vsix} SHA256`);
+  } else {
+    shell.exec(`shasum -a 256 ${vsix}`);
+  }
 }


### PR DESCRIPTION
### What does this PR do?
Update the script and related npm script for generating the SHAs during publishing.

Note this PR is targeting main b/c it needs to be in main in order to get executed for during the deploy.

### What issues does this PR fix or reference?
@W-11596486@

### Functionality Before
Previous way SHAs were generated depended on the vsix being in the each package directory.  With GHA we have them all in a single top level directory. 

### Functionality After
sha report correctly built off the single directory of vsix files. 
