### PR TITLE
chore: bump functions-core from 0.5.1 to 0.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1834,9 +1834,9 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
     },
     "node_modules/@heroku-cli/color": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@heroku-cli/color/-/color-1.1.15.tgz",
-      "integrity": "sha512-eUjF6KD36iQm+32mMVExWosmLQsimtWIe6xdKFGpxGTTEM1SPd4ut+dsWVax38WRumezRsQpV0GADYUxuPewwQ==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@heroku-cli/color/-/color-1.1.16.tgz",
+      "integrity": "sha512-97bYxNaDe/+GCUAKu0V2qudQmR3NFRnv3SrQd2FTtOAa9OWKwkvoBs2WzT7MkNwP4DIpYL6W/e3CSfShfhzEMw==",
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "chalk": "^2.4.1",
@@ -1862,26 +1862,26 @@
       }
     },
     "node_modules/@heroku/functions-core": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@heroku/functions-core/-/functions-core-0.5.1.tgz",
-      "integrity": "sha512-ADsWxCiJATf1gQKfOVdPakEYXrgYoDw84Xr5JAwXpRlcoVP5D4rVfNkQ0JWvtrUno2KF/c8VSx5jqvY9Wg4suQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@heroku/functions-core/-/functions-core-0.5.3.tgz",
+      "integrity": "sha512-SoJ+8wbke9nRZms2DojMv8bg25ISV5IcvguWMo6XF73knGjAHPqu9AEDOU/w3/X99bfPntfrqT/ipZgbt2c9ow==",
       "dependencies": {
-        "@heroku-cli/color": "^1.1.15",
+        "@heroku-cli/color": "^1.1.16",
         "@heroku/project-descriptor": "0.0.6",
         "@salesforce/core": "^2.37.1",
-        "@salesforce/templates": "^55.1.0",
+        "@salesforce/templates": "^57.1.0",
         "axios": "^0.27.2",
         "cloudevents": "^6.0.3",
-        "fs-extra": "^10.1.0",
+        "fs-extra": "^11.1.0",
         "global-agent": "^3.0.0",
         "handlebars": "^4.7.7",
         "mem-fs": "^2.2.1",
         "mem-fs-editor": "^9.5.0",
-        "node-fetch": "^2.6.7",
+        "node-fetch": "^2.6.8",
         "openpgp": "^5.5.0",
         "semver": "^7.3.8",
         "sha256-file": "^1.0.0",
-        "yeoman-environment": "~3.12.1"
+        "yeoman-environment": "~3.13.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1965,16 +1965,16 @@
       }
     },
     "node_modules/@heroku/functions-core/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.14"
       }
     },
     "node_modules/@heroku/functions-core/node_modules/jsforce": {
@@ -6172,19 +6172,24 @@
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/@salesforce/templates": {
-      "version": "55.1.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-55.1.0.tgz",
-      "integrity": "sha512-xx5oTxDSsxs+21TegMRWqvqmDZuc1dfu65sgYuu8xq5niomNMpEUJuRQNNP7B6T/K4mqkJfOnIKAjTjaeRLCkQ==",
+      "version": "57.1.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-57.1.0.tgz",
+      "integrity": "sha512-4XTfNS+wBOM/QJpulJmTBb7o0m0ysfJo2mmTWu6Niz4QfXrSR2LlOc22aet/uTt5okqvmGnpbzG1xF4zzFc8fg==",
       "dependencies": {
         "@salesforce/core": "^3.24.0",
+        "@salesforce/kit": "^1.7.1",
         "got": "^11.8.2",
         "mime-types": "^2.1.27",
         "proxy-agent": "^5.0.0",
         "proxy-from-env": "^1.1.0",
+        "shelljs": "^0.8.5",
         "tar": "^6.1.10",
         "tslib": "^1",
         "yeoman-environment": "^3.9.1",
         "yeoman-generator": "^5.6.1"
+      },
+      "engines": {
+        "node": ">=14.17.0"
       }
     },
     "node_modules/@salesforce/ts-sinon": {
@@ -23333,9 +23338,9 @@
       "integrity": "sha512-pTeU6NgUrexiLNtd+AKwvg6cngHMvj5FZ5e2bbv2ogBSIc9yhkXSSaTScfSRZnwHIh5YFmYSYlemLWkiKD7rog=="
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.8.tgz",
+      "integrity": "sha512-RZ6dBYuj8dRSfxpUSu+NsdF1dpPpluJxwOp+6IoDp/sH2QNDSvurYsAa+F1WxY2RjA1iP93xhcsUoYbF2XBqVg==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -25982,6 +25987,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -25996,16 +26002,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -26019,6 +26028,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -26034,6 +26044,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -39619,9 +39630,9 @@
       }
     },
     "node_modules/yeoman-environment": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-3.12.1.tgz",
-      "integrity": "sha512-q5nC954SE4BEkWFXOwkifbelEZrza6z7vnXCC9bTWvfHjRiaG45eqzv/M6/u4l6PvB/KMmBPgMrACV2mBHE+PQ==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-3.13.0.tgz",
+      "integrity": "sha512-eBPpBZCvFzx6yk17x+ZrOHp8ADDv6qHradV+SgdugaQKIy9NjEX5AkbwdTHLOgccSTkQ9rN791xvYOu6OmqjBg==",
       "dependencies": {
         "@npmcli/arborist": "^4.0.4",
         "are-we-there-yet": "^2.0.0",
@@ -41464,7 +41475,7 @@
       "version": "56.15.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@heroku/functions-core": "0.5.1",
+        "@heroku/functions-core": "0.5.3",
         "@octokit/plugin-paginate-rest": "2.21.3",
         "@salesforce/core": "^3.31.18",
         "@salesforce/salesforcedx-sobjects-faux-generator": "56.15.0",
@@ -41510,27 +41521,6 @@
       },
       "engines": {
         "vscode": "^1.61.2"
-      }
-    },
-    "packages/salesforcedx-vscode-core/node_modules/@salesforce/templates": {
-      "version": "57.0.2",
-      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-57.0.2.tgz",
-      "integrity": "sha512-Dix0l6pNGtLCK9HJwdejCfTeQFAPlvF1Ww0H3UN8sU4ji440EhwD4BbHL6HMusxCnANEhD6tJ46OVmlPEcDhJg==",
-      "dependencies": {
-        "@salesforce/core": "^3.24.0",
-        "@salesforce/kit": "^1.7.1",
-        "got": "^11.8.2",
-        "mime-types": "^2.1.27",
-        "proxy-agent": "^5.0.0",
-        "proxy-from-env": "^1.1.0",
-        "shelljs": "^0.8.5",
-        "tar": "^6.1.10",
-        "tslib": "^1",
-        "yeoman-environment": "^3.9.1",
-        "yeoman-generator": "^5.6.1"
-      },
-      "engines": {
-        "node": ">=14.17.0"
       }
     },
     "packages/salesforcedx-vscode-core/node_modules/@types/node": {

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -25,7 +25,7 @@
     "Other"
   ],
   "dependencies": {
-    "@heroku/functions-core": "0.5.1",
+    "@heroku/functions-core": "0.5.3",
     "@octokit/plugin-paginate-rest": "2.21.3",
     "@salesforce/core": "^3.31.18",
     "@salesforce/salesforcedx-sobjects-faux-generator": "56.15.0",


### PR DESCRIPTION
### What does this PR do?
Bumps the version of `functions-core` to which includes updated Java and Python runtimes as well as template fixes.

Full changes:
https://github.com/heroku/sf-functions-core/compare/v0.5.1...v0.5.3

### What issues does this PR fix or reference?
@W-12157391@

### Functionality Before
* The Java runtime version was `1.1.2`
* The Python runtime version was `0.0.0` and installed from GitHub
* There was a bug in the Java function template that prevented unit tests from compiling

### Functionality After
* The Java runtime version is now `1.1.3`
* The Python runtime version is now `0.0.1` and installs from PyPI
* The Java function template has been fixed so that unit tests compile and run
