### PR TITLE
feat: Switch to Project Path at Activation for Better Integration with Shared Libraries

### DIFF
--- a/packages/salesforcedx-utils/src/helpers/ensureCurrentWorkingDirIsProjectPath.ts
+++ b/packages/salesforcedx-utils/src/helpers/ensureCurrentWorkingDirIsProjectPath.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import * as fs from 'fs';
+export function ensureCurrentWorkingDirIsProjectPath(
+  rootWorkspacePath: string
+): void {
+  if (
+    rootWorkspacePath &&
+    process.cwd() !== rootWorkspacePath &&
+    fs.existsSync(rootWorkspacePath)
+  ) {
+    process.chdir(rootWorkspacePath);
+  }
+}

--- a/packages/salesforcedx-utils/src/helpers/index.ts
+++ b/packages/salesforcedx-utils/src/helpers/index.ts
@@ -1,1 +1,2 @@
 export { extractJsonObject } from './extractJsonObject';
+export { ensureCurrentWorkingDirIsProjectPath } from './ensureCurrentWorkingDirIsProjectPath';

--- a/packages/salesforcedx-utils/test/jest/helpers/ensureCurrentWorkingDirIsProjectPath.test.ts
+++ b/packages/salesforcedx-utils/test/jest/helpers/ensureCurrentWorkingDirIsProjectPath.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import * as fs from 'fs';
+import { ensureCurrentWorkingDirIsProjectPath } from '../../../src';
+
+describe('ensureCurrentWorkingDirIsProjectPath', () => {
+  let fsExistsSyncSpy: jest.SpyInstance;
+  let processCwdSpy: jest.SpyInstance;
+  let processChDirSpy: jest.SpyInstance;
+  const dummyProjectPath = 'a/project/path';
+  const dummyDefaultPath = '/';
+
+  beforeEach(() => {
+    fsExistsSyncSpy = jest.spyOn(fs, 'existsSync');
+    processCwdSpy = jest.spyOn(process, 'cwd');
+    processChDirSpy = jest
+      .spyOn(process, 'chdir')
+      .mockImplementation(jest.fn());
+  });
+
+  it('should change the processes current working directory to the project directory', async () => {
+    processCwdSpy.mockReturnValue(dummyDefaultPath);
+    fsExistsSyncSpy.mockReturnValue(true);
+
+    ensureCurrentWorkingDirIsProjectPath(dummyProjectPath);
+
+    expect(processChDirSpy).toHaveBeenCalledWith(dummyProjectPath);
+  });
+
+  it('should not change the processes current working directory when already in the project directory', async () => {
+    processCwdSpy.mockReturnValue(dummyProjectPath);
+
+    await ensureCurrentWorkingDirIsProjectPath(dummyProjectPath);
+
+    expect(processChDirSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not change the processes current working directory when the project path does not exist', async () => {
+    processCwdSpy.mockReturnValue(dummyDefaultPath);
+    fsExistsSyncSpy.mockReturnValue(false);
+
+    await ensureCurrentWorkingDirIsProjectPath(dummyProjectPath);
+
+    expect(processChDirSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -1,11 +1,15 @@
+import { getRootWorkspacePath } from '@salesforce/salesforcedx-utils-vscode';
 /*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { getRootWorkspacePath } from '@salesforce/salesforcedx-utils-vscode';
-import { SFDX_CORE_CONFIGURATION_NAME } from '@salesforce/salesforcedx-utils-vscode';
+import { ensureCurrentWorkingDirIsProjectPath } from '@salesforce/salesforcedx-utils';
+import {
+  getRootWorkspacePath,
+  SFDX_CORE_CONFIGURATION_NAME
+} from '@salesforce/salesforcedx-utils-vscode';
 import * as fs from 'fs';
 import * as vscode from 'vscode';
 import { channelService } from './channels';
@@ -595,32 +599,19 @@ async function setupOrgBrowser(
 }
 
 export async function activate(extensionContext: vscode.ExtensionContext) {
-  const rootWorkspacePath = getRootWorkspacePath();
-  if (
-    rootWorkspacePath &&
-    process.cwd() !== rootWorkspacePath &&
-    fs.existsSync(rootWorkspacePath)
-  ) {
-    try {
-      // Switch to the project directory so that the main @salesforce
-      // node libraries work correctly.  @salesforce/core,
-      // @salesforce/source-tracking, etc. all use process.cwd()
-      // internally.  This causes issues when used from VSCE, as VSCE
-      // processes can run with a path that does not reflect the current
-      // project path (it often returns '/' from process.cwd()).
-      // Switching to the project path here at activation time ensures that
-      // commands are run with the project path returned from process.cwd(),
-      // thus avoiding the potential errors surfaced when the libs call
-      // process.cwd().
-      process.chdir(rootWorkspacePath);
-    } catch (error) {
-      console.log(
-        'There was an error switching to the root project path on activation.'
-      );
-    }
-  }
-
   const extensionHRStart = process.hrtime();
+  const rootWorkspacePath = getRootWorkspacePath();
+  // Switch to the project directory so that the main @salesforce
+  // node libraries work correctly.  @salesforce/core,
+  // @salesforce/source-tracking, etc. all use process.cwd()
+  // internally.  This causes issues when used from VSCE, as VSCE
+  // processes can run with a path that does not reflect the current
+  // project path (it often returns '/' from process.cwd()).
+  // Switching to the project path here at activation time ensures that
+  // commands are run with the project path returned from process.cwd(),
+  // thus avoiding the potential errors surfaced when the libs call
+  // process.cwd().
+  ensureCurrentWorkingDirIsProjectPath(rootWorkspacePath);
   const { name, aiKey, version } = extensionContext.extension.packageJSON;
   await telemetryService.initializeService(
     extensionContext,

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -1,4 +1,3 @@
-import { getRootWorkspacePath } from '@salesforce/salesforcedx-utils-vscode';
 /*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.


### PR DESCRIPTION
### What does this PR do?
* Sets the current working directory to the projectPath at activation time for better integration with VSCE's's core shared libraries.

### What issues does this PR fix or reference?
@W-12424555@

### Functionality Before
VSCE processes run in the default dir ('/') on a Mac

### Functionality After
VSCE processes run in the project directory (returning project path from process.cwd()) after activation.

