### PR TITLE
ci: add manual publish option

### DIFF
--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -1,15 +1,17 @@
 name: Publish in Microsoft Marketplace
 on:
   release:
-    types: [published, edited]
+    # This limits the workflow to releases that are not pre-releases 
+    # From the docs: A release was published, or a pre-release was changed to a release.
+    types: [ released ]
+  #  Button for publishing main branch in case there is a failure on the release.
+  workflow_call:
     
 jobs:
 
   publish-start-notification:
     name: "Publish Start Notification"
     uses: ./.github/workflows/slackNotification.yml
-    # Only run this job is not a prerelease
-    if: ${{ !github.event.release.prerelease }}
     secrets: inherit
     with:
       title: "Publish waiting for approval in github."
@@ -17,10 +19,9 @@ jobs:
       type: "notification"
       workflow: "publishVSCode.yml"
   
-  prepare_environment:
+  prepare-environment-from-main:
     name: 'Get Release Version'
     runs-on: ubuntu-latest
-    if: ${{ !github.event.release.prerelease }}
     environment: publish
     outputs:
       RELEASE_VERSION: ${{ steps.getMainVersion.outputs.version }}
@@ -44,7 +45,7 @@ jobs:
       - run: echo "SF_CHANGE_CASE_SCHEDULE_BUILD is ${{ steps.getScheduledBuild.outputs.sfChangeCaseScheduleBuild }}"\
 
   ctc-open:
-    needs: [prepare_environment]
+    needs: [ prepare-environment-from-main ]
     uses: salesforcecli/github-workflows/.github/workflows/ctcOpen.yml@main
     secrets: inherit
 
@@ -56,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     env: 
       VSCE_PERSONAL_ACCESS_TOKEN: ${{ secrets.VSCE_PERSONAL_ACCESS_TOKEN }}
-      PUBLISH_VERSION: ${{ needs.prepare_environment.outputs.RELEASE_VERSION }}
+      PUBLISH_VERSION: ${{ needs.prepare-environment-from-main.outputs.RELEASE_VERSION }}
       GITHUB_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
     steps: 
       - name: Setup Node.js

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -5,7 +5,7 @@ on:
     # From the docs: A release was published, or a pre-release was changed to a release.
     types: [ released ]
   #  Button for publishing main branch in case there is a failure on the release.
-  workflow_call:
+  workflow_dispatch:
     
 jobs:
 


### PR DESCRIPTION
### What does this PR do?
- Add a button to the release job for publishing from main.
- Update the configuration for firing off the publish job to only happen for actual releases and not pre-releases instead of filtering in the workflow. 

### What issues does this PR fix or reference?
@W-12370302@

