### PR TITLE
ci: update windows int test GHA to use nvmrc

### DIFF
--- a/.github/workflows/integrationTestsWindows.yml
+++ b/.github/workflows/integrationTestsWindows.yml
@@ -8,10 +8,6 @@ on:
 
 jobs:
   windows-integration-tests:
-    strategy:
-      matrix:
-        node_version: [lts/*]
-      fail-fast: false
     runs-on: windows-latest
     timeout-minutes: 60
     env:
@@ -23,7 +19,7 @@ jobs:
           ref: ${{ inputs.branch }}
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node_version }}
+          node-version-file: '.nvmrc'
           cache: npm
       - run: npm config set scripts-prepend-node-path true
       - run: npm install -g sfdx-cli


### PR DESCRIPTION
### What does this PR do?
After changing the VSCode version used to run the windows integration tests it was discovered that the npm version has now changed for the node install flow we were using in the GHA.  To stay consistent with local development I altered the GHA to use the .nvmrc file to pick the npm/node version installed for running the int tests. 

I verified this functionality in my fork prior to opening this PR. 
https://github.com/gbockus-sf/salesforcedx-vscode/actions/runs/4127688182/jobs/7131203184

### What issues does this PR fix or reference?
@W-12498824@

### Functionality Before
Int tests fail on npm setting 
```
Run npm config set scripts-prepend-node-path true
npm ERR! `scripts-prepend-node-path` is not a valid npm option

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\npm\cache\_logs\2023-02-08T19_0[6](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/4126592791/jobs/7130795645#step:5:7)_09_219Z-debug-0.log
Error: Process completed with exit code 1.
```

### Functionality After
We use node/npm defined in npm rc and set the prepend path without error. 
