### PR TITLE
chore: update request-light dependency to avoid patching https.request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24798,7 +24798,6 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24813,19 +24812,16 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -24839,7 +24835,6 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24855,7 +24850,6 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13418,19 +13418,6 @@
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
     },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-    },
-    "node_modules/es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
-      "dependencies": {
-        "es6-promise": "^4.0.3"
-      }
-    },
     "node_modules/esbuild": {
       "version": "0.15.10",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.10.tgz",
@@ -24811,6 +24798,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24825,16 +24813,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -24848,6 +24839,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24863,6 +24855,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -32477,67 +32470,9 @@
       }
     },
     "node_modules/request-light": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.2.4.tgz",
-      "integrity": "sha512-pM9Fq5jRnSb+82V7M97rp8FE9/YNeP2L9eckB4Szd7lyeclSIx02aIpPO/6e4m6Dy31+FBN/zkFMTd2HkNO3ow==",
-      "dependencies": {
-        "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^2.2.1",
-        "vscode-nls": "^4.0.0"
-      }
-    },
-    "node_modules/request-light/node_modules/agent-base": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-      "dependencies": {
-        "es6-promisify": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/request-light/node_modules/debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/request-light/node_modules/http-proxy-agent": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-      "dependencies": {
-        "agent-base": "4",
-        "debug": "3.1.0"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
-      }
-    },
-    "node_modules/request-light/node_modules/https-proxy-agent": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
-      "dependencies": {
-        "agent-base": "^4.3.0",
-        "debug": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
-      }
-    },
-    "node_modules/request-light/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
-    "node_modules/request-light/node_modules/vscode-nls": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",
-      "integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw=="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.7.0.tgz",
+      "integrity": "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q=="
     },
     "node_modules/request-promise-core": {
       "version": "1.1.4",
@@ -39109,7 +39044,7 @@
         "@salesforce/salesforcedx-utils": "57.2.0",
         "async-lock": "1.0.0",
         "faye": "1.1.2",
-        "request-light": "0.2.4",
+        "request-light": "^0.7.0",
         "vscode-debugadapter": "1.28.0",
         "vscode-debugprotocol": "1.28.0"
       },
@@ -39171,7 +39106,7 @@
         "mocha-junit-reporter": "^1.23.3",
         "mocha-multi-reporters": "^1.1.7",
         "nyc": "^15",
-        "request-light": "0.2.4",
+        "request-light": "^0.7.0",
         "sinon": "^13.0.1",
         "ts-jest": "28.0.8",
         "typescript": "^4.7.4",
@@ -39261,7 +39196,7 @@
         "mocha-multi-reporters": "^1.1.7",
         "mock-spawn": "0.2.6",
         "nyc": "^15.1.0",
-        "request-light": "0.2.4",
+        "request-light": "^0.7.0",
         "sinon": "^13.0.1",
         "source-map-support": "^0.4.15",
         "typescript": "^4.7.4"
@@ -39298,7 +39233,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "cross-spawn": "7.0.3",
-        "request-light": "0.2.4",
+        "request-light": "^0.7.0",
         "rxjs": "^5.4.1",
         "tree-kill": "^1.1.0"
       },
@@ -39344,7 +39279,7 @@
         "mock-spawn": "0.2.6",
         "nyc": "^15",
         "proxyquire": "2.1.3",
-        "request-light": "0.2.4",
+        "request-light": "^0.7.0",
         "shelljs": "0.8.5",
         "sinon": "^13.0.1",
         "ts-jest": "28.0.8",
@@ -39812,7 +39747,7 @@
         "@salesforce/salesforcedx-utils-vscode": "57.2.0",
         "async-lock": "1.0.0",
         "path-exists": "3.0.0",
-        "request-light": "0.2.4",
+        "request-light": "^0.7.0",
         "vscode-extension-telemetry": "0.0.17"
       },
       "devDependencies": {

--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -15,7 +15,7 @@
     "@salesforce/salesforcedx-utils": "57.2.0",
     "async-lock": "1.0.0",
     "faye": "1.1.2",
-    "request-light": "0.2.4",
+    "request-light": "^0.7.0",
     "vscode-debugadapter": "1.28.0",
     "vscode-debugprotocol": "1.28.0"
   },

--- a/packages/salesforcedx-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-apex-replay-debugger/package.json
@@ -31,7 +31,7 @@
     "mocha-junit-reporter": "^1.23.3",
     "mocha-multi-reporters": "^1.1.7",
     "nyc": "^15",
-    "request-light": "0.2.4",
+    "request-light": "^0.7.0",
     "sinon": "^13.0.1",
     "ts-jest": "28.0.8",
     "typescript": "^4.7.4",

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/commands/apexExecutionOverlayResultCommand.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/commands/apexExecutionOverlayResultCommand.test.ts
@@ -684,8 +684,8 @@ export function createExpectedXHROptions(
       Accept: 'application/json',
       Authorization: `OAuth 123`,
       'Content-Length': requestBody
-        ? Buffer.byteLength(requestBody, 'utf-8')
-        : 0,
+        ? String(Buffer.byteLength(requestBody, 'utf-8'))
+        : '0',
       'Sforce-Call-Options': `client=${CLIENT_ID}`
     },
     data: requestBody

--- a/packages/salesforcedx-test-utils-vscode/package.json
+++ b/packages/salesforcedx-test-utils-vscode/package.json
@@ -27,7 +27,7 @@
     "mocha-multi-reporters": "^1.1.7",
     "mock-spawn": "0.2.6",
     "nyc": "^15.1.0",
-    "request-light": "0.2.4",
+    "request-light": "^0.7.0",
     "sinon": "^13.0.1",
     "source-map-support": "^0.4.15",
     "typescript": "^4.7.4"

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -38,7 +38,7 @@
     "mock-spawn": "0.2.6",
     "nyc": "^15",
     "proxyquire": "2.1.3",
-    "request-light": "0.2.4",
+    "request-light": "^0.7.0",
     "shelljs": "0.8.5",
     "sinon": "^13.0.1",
     "ts-jest": "28.0.8",

--- a/packages/salesforcedx-utils/package.json
+++ b/packages/salesforcedx-utils/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "cross-spawn": "7.0.3",
-    "request-light": "0.2.4",
+    "request-light": "^0.7.0",
     "rxjs": "^5.4.1",
     "tree-kill": "^1.1.0"
   },

--- a/packages/salesforcedx-utils/src/requestService/requestService.ts
+++ b/packages/salesforcedx-utils/src/requestService/requestService.ts
@@ -123,14 +123,14 @@ export class RequestService {
         Accept: 'application/json',
         Authorization: `OAuth ${this.accessToken}`,
         'Content-Length': requestBody
-          ? Buffer.byteLength(requestBody, 'utf-8')
-          : 0,
+          ? String(Buffer.byteLength(requestBody, 'utf-8'))
+          : '0',
         'Sforce-Call-Options': `client=${CLIENT_ID}`
       },
       data: requestBody
     };
 
-    if (this.proxyAuthorization) {
+    if (this.proxyAuthorization && options.headers) {
       options.headers['Proxy-Authorization'] = this.proxyAuthorization;
     }
 

--- a/packages/salesforcedx-utils/test/jest/requestService/__snapshots__/requestService.test.ts.snap
+++ b/packages/salesforcedx-utils/test/jest/requestService/__snapshots__/requestService.test.ts.snap
@@ -7,7 +7,7 @@ Array [
     "headers": Object {
       "Accept": "application/json",
       "Authorization": "OAuth totallyfake-access-token-not-real-1234",
-      "Content-Length": 27,
+      "Content-Length": "27",
       "Content-Type": "application/json;charset=utf-8",
       "Proxy-Authorization": "this-is-fake-proxy-auth",
       "Sforce-Call-Options": "client=sfdx-vscode",
@@ -26,7 +26,7 @@ Array [
     "headers": Object {
       "Accept": "application/json",
       "Authorization": "OAuth totallyfake-access-token-not-real-1234",
-      "Content-Length": 27,
+      "Content-Length": "27",
       "Content-Type": "application/json;charset=utf-8",
       "Sforce-Call-Options": "client=sfdx-vscode",
     },
@@ -44,7 +44,7 @@ Array [
     "headers": Object {
       "Accept": "application/json",
       "Authorization": "OAuth totallyfake-access-token-not-real-1234",
-      "Content-Length": 0,
+      "Content-Length": "0",
       "Content-Type": "application/json;charset=utf-8",
       "Sforce-Call-Options": "client=sfdx-vscode",
     },

--- a/packages/salesforcedx-utils/test/jest/requestService/requestService.test.ts
+++ b/packages/salesforcedx-utils/test/jest/requestService/requestService.test.ts
@@ -151,11 +151,14 @@ describe('RequestService unit tests.', () => {
   describe('sendRequest()', () => {
     it('Should make the xhr call on sendRequest.', async () => {
       const fakeOptions: XHROptions = {
-        responseType: 'json/and/stuff'
+        type: 'json/and/stuff',
+        url: 'https://www.nothing-here.com'
       };
       const fakeXhrResponse: XHRResponse = {
         responseText: 'fakeResponse',
-        status: 0
+        status: 0,
+        body: new Uint8Array(),
+        headers: {}
       };
 
       mockedRequestLight.xhr.mockResolvedValue(fakeXhrResponse);

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -31,7 +31,7 @@
     "@salesforce/salesforcedx-utils-vscode": "57.2.0",
     "async-lock": "1.0.0",
     "path-exists": "3.0.0",
-    "request-light": "0.2.4",
+    "request-light": "^0.7.0",
     "vscode-extension-telemetry": "0.0.17"
   },
   "devDependencies": {

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/vscode-integration/commands/apexExecutionOverlayActionCommand.test.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/vscode-integration/commands/apexExecutionOverlayActionCommand.test.ts
@@ -188,8 +188,8 @@ export function createExpectedXHROptions(
       Accept: 'application/json',
       Authorization: `OAuth 123`,
       'Content-Length': requestBody
-        ? Buffer.byteLength(requestBody, 'utf-8')
-        : 0,
+        ? String(Buffer.byteLength(requestBody, 'utf-8'))
+        : '0',
       'Sforce-Call-Options': `client=${CLIENT_ID}`
     },
     data: requestBody


### PR DESCRIPTION
### What does this PR do?
Update the version of request-light we import and ^ the dep so we pickup updates in the future. 

This is to fix the issue where when SDR attempts to go find the current API version via a request using the got module it is failing due to an older agent-base that patched https.request.

The error was only present in when running via vsix.  I believe with was b/c request-light is getting bundled with the source and it would load in such a way that the https.request was patched at startup vs when needed when running in debugging mode.

The problem code can be found in the before version bundle by running `npm run vscode:bundle` from the top level directory of the project.  Then view the `packages/salesforcedx-vscode-core/dist/index.js` file and search for `https.request =`.  
Note this is no longer present after the update. 

*Before*
npm ls agent-base 
```
├─┬ request-light@0.2.4 extraneous
│ ├── agent-base@4.3.0 extraneous
│ ├─┬ http-proxy-agent@2.1.0 extraneous
│ │ └── agent-base@4.3.0 deduped
│ └─┬ https-proxy-agent@2.2.4 extraneous
│   └── agent-base@4.3.0 deduped
```

*After*
 npm ls agent-base
request-light no longer imports agent-base

### What issues does this PR fix or reference?
@W-9466545@

### Functionality Before
Retrieve operation would fail due with the following error 
`An error was encountered during conflict detection. RequestError: connect ECONNREFUSED 127.0.0.1:443`

### Functionality After
Retrieve works as expected (triggered via the deploy with conflict detection turned on)

