### PR TITLE
fix: update test icons to account for bundling, fix apexDB location, and fix checkpoint issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "vscode:bundle:debugger": "lerna run bundle:debugger",
     "vscode:bundle:extension": "lerna run bundle:extension",
     "vscode:package": "npm run vscode:bundle:debugger && npm run vscode:bundle:extension && lerna run vscode:package --concurrency 1 && npm run reformat",
-    "vsix:install": "find ./packages -name '*.vsix' -exec code --install-extension {} \\;",
+    "vsix:install": "find ./packages -name '*.vsix' -exec code-insiders --install-extension {} \\;",
     "vscode:sha256": "node ./scripts/generate-sha256.js >> ./SHA256",
     "vscode:publish": "lerna run vscode:publish --concurrency 1",
     "watch": "lerna run --parallel watch",

--- a/packages/salesforcedx-utils-vscode/src/helpers/extensionUris.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/extensionUris.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as vscode from 'vscode';
+
+function extensionUri(extensionName: string) {
+  const extensionRef = vscode.extensions.getExtension(extensionName);
+
+  if (extensionRef) {
+    return extensionRef.extensionUri;
+  }
+  throw new Error(`Unable to find extension ${extensionName}`);
+}
+
+function join(baseUri: vscode.Uri, relativePath: string) {
+  return vscode.Uri.joinPath(baseUri, relativePath);
+}
+
+export const extensionUris = {
+  extensionUri,
+  join
+};

--- a/packages/salesforcedx-utils-vscode/src/helpers/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/index.ts
@@ -13,6 +13,7 @@ export {
   getRelativeProjectPath,
   projectPaths
 } from './paths';
+export * from './extensionUris';
 export { TraceFlags } from './traceFlags';
 export { TraceFlagsRemover } from './traceFlagsRemover';
 export {

--- a/packages/salesforcedx-utils-vscode/src/helpers/paths.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/paths.ts
@@ -147,7 +147,10 @@ function relativeStateFolder(): string {
 }
 
 function relativeToolsFolder(): string {
-  const relativePathToToolsFolder = path.join(projectPaths.relativeStateFolder(), TOOLS);
+  const relativePathToToolsFolder = path.join(
+    projectPaths.relativeStateFolder(),
+    TOOLS
+  );
   return relativePathToToolsFolder;
 }
 

--- a/packages/salesforcedx-utils-vscode/test/jest/helpers/extensionUris.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/helpers/extensionUris.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as vscode from 'vscode';
+import { extensionUris } from '../../../src';
+
+describe('extensionUris Unit Tests.', () => {
+  describe('extensionUri()', () => {
+    const fakeExtensionRef = {
+      extensionUri: { url: 'fake' }
+    };
+    const fakeExtensionName = 'salesforce.someExtension';
+
+    beforeEach(() => {
+      vscode.extensions.getExtension = jest.fn();
+    });
+
+    it('Should return extensionUrl if found.', () => {
+      (vscode.extensions.getExtension as any).mockReturnValue(fakeExtensionRef);
+      const result = extensionUris.extensionUri(fakeExtensionName);
+      expect(vscode.extensions.getExtension).toHaveBeenCalledWith(
+        fakeExtensionName
+      );
+      expect(result).toEqual(fakeExtensionRef.extensionUri);
+    });
+
+    it('Should throw an error if extension is not found.', () => {
+      (vscode.extensions.getExtension as any).mockReturnValue(undefined);
+      expect(() => {
+        extensionUris.extensionUri(fakeExtensionName);
+      }).toThrowError(/^Unable to find extension/);
+    });
+  });
+
+  describe('join()', () => {
+    const fakeResultUri = { url: 'file://totallyfake' };
+    it('Should return joined Uri and relative path.', () => {
+      const fakeUri: any = { scheme: true };
+      const path = '/a/b/c/e';
+      (vscode.Uri.joinPath as any).mockReturnValue(fakeResultUri);
+      const result = extensionUris.join(fakeUri, path);
+      expect(vscode.Uri.joinPath).toHaveBeenCalledWith(fakeUri, path);
+      expect(result).toEqual(fakeResultUri);
+    });
+  });
+});

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/breakpoints/checkpointService.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/breakpoints/checkpointService.ts
@@ -808,14 +808,14 @@ export async function processBreakpointChangedForCheckpoints(
   for (const bp of breakpointsChangedEvent.removed) {
     if (bp.condition && bp.condition!.toLowerCase().indexOf(CHECKPOINT) >= 0) {
       await lock.acquire(CHECKPOINTS_LOCK_STRING, async () => {
-        const breakpointId = (bp as any)._id;
+        const breakpointId = bp.id;
         checkpointService.deleteCheckpointNodeIfExists(breakpointId);
       });
     }
   }
 
   for (const bp of breakpointsChangedEvent.changed) {
-    const breakpointId = (bp as any)._id;
+    const breakpointId = bp.id;
     if (
       bp.condition &&
       bp.condition!.toLowerCase().indexOf(CHECKPOINT) >= 0 &&
@@ -862,7 +862,7 @@ export async function processBreakpointChangedForCheckpoints(
       bp instanceof vscode.SourceBreakpoint
     ) {
       await lock.acquire(CHECKPOINTS_LOCK_STRING, async () => {
-        const breakpointId = (bp as any)._id;
+        const breakpointId = bp.id;
         const checkpointOverlayAction = parseCheckpointInfoFromBreakpoint(bp);
         const uri = code2ProtocolConverter(bp.location.uri);
         const filename = uri.substring(uri.lastIndexOf('/') + 1);

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/vscode-integration/checkpoints/checkpointService.test.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/vscode-integration/checkpoints/checkpointService.test.ts
@@ -199,7 +199,6 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
       CHECKPOINT,
       undefined
     );
-    (breakpoint as any)._id = breakpointId;
     bpAdd.push(breakpoint);
     await processBreakpointChangedForCheckpoints({
       added: bpAdd,
@@ -209,7 +208,7 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
 
     // Verify that a single checkpoint has been added to the checkpoint service
     const theNode = checkpointService.returnCheckpointNodeIfAlreadyExists(
-      breakpointId
+      breakpoint.id
     );
     if (!theNode) {
       assert.fail(
@@ -232,8 +231,7 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
       CHECKPOINT,
       undefined
     );
-    const breakpointId1 = breakpointId + '1';
-    (breakpoint1 as any)._id = breakpointId1;
+
     bpAdd.push(breakpoint1);
     const breakpoint2 = new vscode.SourceBreakpoint(
       location,
@@ -241,8 +239,7 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
       CHECKPOINT,
       undefined
     );
-    const breakpointId2 = breakpointId + '2';
-    (breakpoint2 as any)._id = breakpointId2;
+
     bpAdd.push(breakpoint2);
 
     await processBreakpointChangedForCheckpoints({
@@ -253,22 +250,22 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
 
     // Verify that a single checkpoint has been added to the checkpoint service
     const theNode1 = checkpointService.returnCheckpointNodeIfAlreadyExists(
-      breakpointId1
+      breakpoint1.id
     );
     if (!theNode1) {
       assert.fail(
         'Should have created a node in the checkpointService with id: ' +
-          breakpointId1
+          breakpoint1.id
       );
     }
 
     const theNode2 = checkpointService.returnCheckpointNodeIfAlreadyExists(
-      breakpointId2
+      breakpoint2.id
     );
     if (!theNode2) {
       assert.fail(
         'Should have created a node in the checkpointService with id: ' +
-          breakpointId2
+          breakpoint1.id
       );
     }
     expect(lockSpy.calledTwice).to.equal(true);
@@ -286,7 +283,7 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
       CHECKPOINT,
       undefined
     );
-    (breakpoint as any)._id = breakpointId;
+
     bpAdd.push(breakpoint);
     await processBreakpointChangedForCheckpoints({
       added: bpAdd,
@@ -296,7 +293,7 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
 
     // Verify that a single checkpoint has been added to the checkpoint service
     const theNode = checkpointService.returnCheckpointNodeIfAlreadyExists(
-      breakpointId
+      breakpoint.id
     );
     if (!theNode) {
       assert.fail(
@@ -313,7 +310,7 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
     });
 
     const deletedNote = checkpointService.returnCheckpointNodeIfAlreadyExists(
-      breakpointId
+      breakpoint.id
     );
     // The node should be undefined as it was deleted
     if (deletedNote) {
@@ -335,7 +332,7 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
       CHECKPOINT,
       undefined
     );
-    (breakpoint as any)._id = breakpointId;
+
     bpAdd.push(breakpoint);
     await processBreakpointChangedForCheckpoints({
       added: bpAdd,
@@ -345,7 +342,7 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
 
     // Verify that a single checkpoint has been added to the checkpoint service
     let theNode = checkpointService.returnCheckpointNodeIfAlreadyExists(
-      breakpointId
+      breakpoint.id
     );
     if (!theNode) {
       assert.fail(
@@ -363,7 +360,7 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
       CHECKPOINT,
       '4'
     );
-    (breakpoint2 as any)._id = breakpointId;
+
     bpChange.push(breakpoint2);
     await processBreakpointChangedForCheckpoints({
       added: bpEmpty,
@@ -374,7 +371,7 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
     // Verify that the checkpoint has been updated, that the enabled flag is set to false and
     // the iterations has been updated from 1 to 4
     theNode = checkpointService.returnCheckpointNodeIfAlreadyExists(
-      breakpointId
+      breakpoint.id
     );
     if (!theNode) {
       assert.fail(
@@ -401,7 +398,7 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
       CHECKPOINT,
       undefined
     );
-    (breakpoint as any)._id = breakpointId;
+
     bpAdd.push(breakpoint);
     await processBreakpointChangedForCheckpoints({
       added: bpAdd,
@@ -411,7 +408,7 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
 
     // Verify that a single checkpoint has been added to the checkpoint service
     let theNode = checkpointService.returnCheckpointNodeIfAlreadyExists(
-      breakpointId
+      breakpoint.id
     );
     if (!theNode) {
       assert.fail(
@@ -426,7 +423,7 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
       undefined, // change the condition from 'checkpoint' to undefined
       undefined
     );
-    (breakpoint2 as any)._id = breakpointId;
+
     bpChange.push(breakpoint2);
     await processBreakpointChangedForCheckpoints({
       added: bpEmpty,
@@ -436,7 +433,7 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
 
     // Verify that the checkpoint has been updated and that the enabled flag is set to false
     theNode = checkpointService.returnCheckpointNodeIfAlreadyExists(
-      breakpointId
+      breakpoint.id
     );
     if (theNode) {
       assert.fail(
@@ -459,7 +456,7 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
       CHECKPOINT,
       undefined
     );
-    (breakpoint as any)._id = breakpointId;
+
     bpAdd.push(breakpoint);
     await processBreakpointChangedForCheckpoints({
       added: bpAdd,
@@ -469,7 +466,7 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
 
     // Verify that a single checkpoint has been added to the checkpoint service
     let theNode = checkpointService.returnCheckpointNodeIfAlreadyExists(
-      breakpointId
+      breakpoint.id
     );
     if (!theNode) {
       assert.fail(
@@ -484,7 +481,7 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
       CHECKPOINT, // keep the checkpoint condition
       undefined
     );
-    (breakpoint2 as any)._id = breakpointId;
+
     bpChange.push(breakpoint2);
     await processBreakpointChangedForCheckpoints({
       added: bpEmpty,
@@ -494,7 +491,7 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
 
     // Verify that the checkpoint has been updated and that the enabled flag is set to false
     theNode = checkpointService.returnCheckpointNodeIfAlreadyExists(
-      breakpointId
+      breakpoint.id
     );
     if (theNode) {
       assert.fail(
@@ -517,7 +514,7 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
       CHECKPOINT,
       undefined
     );
-    (breakpoint as any)._id = breakpointId;
+
     bpAdd.push(breakpoint);
     await processBreakpointChangedForCheckpoints({
       added: bpAdd,
@@ -527,7 +524,7 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
 
     // The first breakpoint should have no ActionScript or ActionScriptType
     let theNode = checkpointService.returnCheckpointNodeIfAlreadyExists(
-      breakpointId
+      breakpoint.id
     );
     if (theNode) {
       expect(theNode.getActionScriptType()).to.be.equal(ActionScriptEnum.None);
@@ -547,7 +544,7 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
     });
 
     theNode = checkpointService.returnCheckpointNodeIfAlreadyExists(
-      breakpointId
+      breakpoint.id
     );
     if (theNode) {
       expect(theNode.getActionScriptType()).to.be.equal(ActionScriptEnum.Apex);
@@ -568,7 +565,7 @@ describe('Verify checkpoint callback for vscode.debug.onDidChangeBreakpoints', (
     });
 
     theNode = checkpointService.returnCheckpointNodeIfAlreadyExists(
-      breakpointId
+      breakpoint.id
     );
     if (theNode) {
       expect(theNode.getActionScriptType()).to.be.equal(ActionScriptEnum.SOQL);

--- a/packages/salesforcedx-vscode-apex/jest.config.js
+++ b/packages/salesforcedx-vscode-apex/jest.config.js
@@ -1,0 +1,4 @@
+// eslint:disable-next-line:no-var-requires
+const baseConfig = require('../../config/jest.base.config');
+
+module.exports = Object.assign({}, baseConfig);

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -68,6 +68,7 @@
     "watch": "tsc -watch -p .",
     "clean": "shx rm -rf node_modules && cd out && node ../../../scripts/clean-all-but-jar.js && shx rm -rf coverage && shx rm -rf .nyc_output",
     "test": "npm run test:vscode-integration",
+    "test:unit": "jest --coverage",
     "test:vscode-integration": "node ../../scripts/run-vscode-integration-tests-with-top-level-extensions",
     "test:vscode-insiders-integration": "cross-env CODE_VERSION=insiders npm run test:vscode-integration"
   },

--- a/packages/salesforcedx-vscode-apex/src/commands/forceLaunchApexReplayDebuggerWithCurrentFile.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceLaunchApexReplayDebuggerWithCurrentFile.ts
@@ -18,7 +18,7 @@ import {
 } from '@salesforce/salesforcedx-utils-vscode';
 import * as vscode from 'vscode';
 import { nls } from '../messages';
-import { testOutlineProvider } from '../views/testOutlineProvider';
+import { getTestOutlineProvider } from '../views/testOutlineProvider';
 import { forceAnonApexDebug } from './forceAnonApexExecute';
 
 export async function forceLaunchApexReplayDebuggerWithCurrentFile() {
@@ -80,6 +80,7 @@ async function getApexTestClassName(
     return undefined;
   }
 
+  const testOutlineProvider = getTestOutlineProvider();
   await testOutlineProvider.refresh();
   let testClassName = testOutlineProvider.getTestClassName(sourceUri);
   // This is a little bizarre.  Intellisense is reporting that getTestClassName() returns a string,

--- a/packages/salesforcedx-vscode-apex/src/constants.ts
+++ b/packages/salesforcedx-vscode-apex/src/constants.ts
@@ -1,91 +1,14 @@
 /*
- * Copyright (c) 2017, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import * as path from 'path';
 import * as vscode from 'vscode';
-import { nls } from './messages';
 
 export const DEBUGGER_LINE_BREAKPOINTS = 'debugger/lineBreakpoints';
 export const DEBUGGER_EXCEPTION_BREAKPOINTS = 'debugger/exceptionBreakpoints';
-
-export const LIGHT_BLUE_BUTTON = path.join(
-  __filename,
-  '..',
-  '..',
-  '..',
-  'resources',
-  'light',
-  'testNotRun.svg'
-);
-
-export const LIGHT_RED_BUTTON = path.join(
-  __filename,
-  '..',
-  '..',
-  '..',
-  'resources',
-  'light',
-  'testFail.svg'
-);
-export const LIGHT_GREEN_BUTTON = path.join(
-  __filename,
-  '..',
-  '..',
-  '..',
-  'resources',
-  'light',
-  'testPass.svg'
-);
-export const LIGHT_ORANGE_BUTTON = path.join(
-  __filename,
-  '..',
-  '..',
-  '..',
-  'resources',
-  'light',
-  'testSkip.svg'
-);
-
-export const DARK_BLUE_BUTTON = path.join(
-  __filename,
-  '..',
-  '..',
-  '..',
-  'resources',
-  'dark',
-  'testNotRun.svg'
-);
-export const DARK_RED_BUTTON = path.join(
-  __filename,
-  '..',
-  '..',
-  '..',
-  'resources',
-  'dark',
-  'testFail.svg'
-);
-export const DARK_GREEN_BUTTON = path.join(
-  __filename,
-  '..',
-  '..',
-  '..',
-  'resources',
-  'dark',
-  'testPass.svg'
-);
-export const DARK_ORANGE_BUTTON = path.join(
-  __filename,
-  '..',
-  '..',
-  '..',
-  'resources',
-  'dark',
-  'testSkip.svg'
-);
 
 const startPos = new vscode.Position(0, 0);
 const endPos = new vscode.Position(0, 1);
@@ -94,4 +17,5 @@ export const SET_JAVA_DOC_LINK =
   'https://developer.salesforce.com/tools/vscode/en/vscode-desktop/java-setup';
 export const SFDX_APEX_CONFIGURATION_NAME = 'salesforcedx-vscode-apex';
 export const APEX_EXTENSION_NAME = 'salesforcedx-vscode-apex';
+export const VSCODE_APEX_EXTENSION_NAME = `salesforce.${APEX_EXTENSION_NAME}`;
 export const LSP_ERR = 'apexLSPError';

--- a/packages/salesforcedx-vscode-apex/src/helpers/languageServerUtils.ts
+++ b/packages/salesforcedx-vscode-apex/src/helpers/languageServerUtils.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {
+  extensionUris,
+  projectPaths
+} from '@salesforce/salesforcedx-utils-vscode';
+import { copyFileSync, existsSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import * as vscode from 'vscode';
+import { VSCODE_APEX_EXTENSION_NAME } from '../constants';
+
+const setupDB = (): void => {
+  if (
+    vscode.workspace.workspaceFolders &&
+    vscode.workspace.workspaceFolders[0]
+  ) {
+    const dbPath = projectPaths.apexLanguageServerDatabase();
+    if (existsSync(dbPath)) {
+      unlinkSync(dbPath);
+    }
+
+    try {
+      const extensionUri = extensionUris.extensionUri(
+        VSCODE_APEX_EXTENSION_NAME
+      );
+      const systemDb = extensionUris
+        .join(extensionUri, join('resources', 'apex.db'))
+        .toString();
+
+      if (existsSync(systemDb)) {
+        copyFileSync(systemDb, dbPath);
+      }
+    } catch (e) {
+      console.log(e);
+    }
+  }
+};
+
+export const languageServerUtils = {
+  setupDB
+};

--- a/packages/salesforcedx-vscode-apex/src/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/index.ts
@@ -39,13 +39,14 @@ import {
 import * as languageServer from './languageServer';
 import { nls } from './messages';
 import { telemetryService } from './telemetry';
-import { testOutlineProvider } from './views/testOutlineProvider';
+import { getTestOutlineProvider } from './views/testOutlineProvider';
 import { ApexTestRunner, TestRunType } from './views/testRunner';
 
 let languageClient: LanguageClient | undefined;
 
 export async function activate(extensionContext: vscode.ExtensionContext) {
   const extensionHRStart = process.hrtime();
+  const testOutlineProvider = getTestOutlineProvider();
   if (vscode.workspace && vscode.workspace.workspaceFolders) {
     const apexDirPath = getTestResultsFolder(
       vscode.workspace.workspaceFolders[0].uri.fsPath,
@@ -96,7 +97,7 @@ export async function activate(extensionContext: vscode.ExtensionContext) {
       .then(async () => {
         if (languageClient) {
           languageClient.onNotification('indexer/done', async () => {
-            await testOutlineProvider.refresh();
+            await getTestOutlineProvider().refresh();
           });
         }
         // TODO: This currently keeps existing behavior in which we set the language
@@ -260,6 +261,7 @@ function registerCommands(): vscode.Disposable {
 }
 
 async function registerTestView(): Promise<vscode.Disposable> {
+  const testOutlineProvider = getTestOutlineProvider();
   // Create TestRunner
   const testRunner = new ApexTestRunner(testOutlineProvider);
 

--- a/packages/salesforcedx-vscode-apex/src/languageServer.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageServer.ts
@@ -20,6 +20,7 @@ import {
 } from 'vscode-languageclient';
 import { LSP_ERR, VSCODE_APEX_EXTENSION_NAME } from './constants';
 import { soqlMiddleware } from './embeddedSoql';
+import { languageServerUtils } from './helpers/languageServerUtils';
 import { nls } from './messages';
 import * as requirements from './requirements';
 import { telemetryService } from './telemetry';
@@ -35,7 +36,7 @@ async function createServer(
   extensionContext: vscode.ExtensionContext
 ): Promise<Executable> {
   try {
-    setupDB();
+    languageServerUtils.setupDB();
     const requirementsData = await requirements.resolveRequirements();
     const uberJar = path.resolve(
       extensionContext.extensionPath,
@@ -96,33 +97,6 @@ async function createServer(
     vscode.window.showErrorMessage(err);
     telemetryService.sendException(LSP_ERR, err.error);
     throw err;
-  }
-}
-
-export function setupDB(): void {
-  if (
-    vscode.workspace.workspaceFolders &&
-    vscode.workspace.workspaceFolders[0]
-  ) {
-    const dbPath = projectPaths.apexLanguageServerDatabase();
-    if (fs.existsSync(dbPath)) {
-      fs.unlinkSync(dbPath);
-    }
-
-    try {
-      const extensionUri = extensionUris.extensionUri(
-        VSCODE_APEX_EXTENSION_NAME
-      );
-      const systemDb = extensionUris
-        .join(extensionUri, path.join('resources', 'apex.db'))
-        .toString();
-
-      if (fs.existsSync(systemDb)) {
-        fs.copyFileSync(systemDb, dbPath);
-      }
-    } catch (e) {
-      console.log(e);
-    }
   }
 }
 

--- a/packages/salesforcedx-vscode-apex/src/languageServer.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageServer.ts
@@ -5,7 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { projectPaths } from '@salesforce/salesforcedx-utils-vscode';
+import {
+  extensionUris,
+  projectPaths
+} from '@salesforce/salesforcedx-utils-vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -15,7 +18,7 @@ import {
   LanguageClientOptions,
   RevealOutputChannelOn
 } from 'vscode-languageclient';
-import { LSP_ERR } from './constants';
+import { LSP_ERR, VSCODE_APEX_EXTENSION_NAME } from './constants';
 import { soqlMiddleware } from './embeddedSoql';
 import { nls } from './messages';
 import * as requirements from './requirements';
@@ -107,7 +110,13 @@ export function setupDB(): void {
     }
 
     try {
-      const systemDb = path.join(__dirname, '..', '..', 'resources', 'apex.db');
+      const extensionUri = extensionUris.extensionUri(
+        VSCODE_APEX_EXTENSION_NAME
+      );
+      const systemDb = extensionUris
+        .join(extensionUri, path.join('resources', 'apex.db'))
+        .toString();
+
       if (fs.existsSync(systemDb)) {
         fs.copyFileSync(systemDb, dbPath);
       }

--- a/packages/salesforcedx-vscode-apex/src/views/icons/IconsEnum.ts
+++ b/packages/salesforcedx-vscode-apex/src/views/icons/IconsEnum.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { join } from 'path';
+
+export const ICONS = {
+  LIGHT_BLUE_BUTTON: join('resources', 'light', 'testNotRun.svg'),
+  LIGHT_RED_BUTTON: join('resources', 'light', 'testFail.svg'),
+  LIGHT_GREEN_BUTTON: join('resources', 'light', 'testPass.svg'),
+  LIGHT_ORANGE_BUTTON: join('resources', 'light', 'testSkip.svg'),
+  DARK_BLUE_BUTTON: join('resources', 'dark', 'testNotRun.svg'),
+  DARK_RED_BUTTON: join('resources', 'dark', 'testFail.svg'),
+  DARK_GREEN_BUTTON: join('resources', 'dark', 'testPass.svg'),
+  DARK_ORANGE_BUTTON: join('resources', 'dark', 'testSkip.svg')
+};
+
+export type iconKey = keyof typeof ICONS;
+export enum IconsEnum {
+  LIGHT_BLUE_BUTTON = 'LIGHT_BLUE_BUTTON',
+  LIGHT_RED_BUTTON = 'LIGHT_RED_BUTTON',
+  LIGHT_ORANGE_BUTTON = 'LIGHT_ORANGE_BUTTON',
+  LIGHT_GREEN_BUTTON = 'LIGHT_GREEN_BUTTON',
+  DARK_BLUE_BUTTON = 'DARK_BLUE_BUTTON',
+  DARK_RED_BUTTON = 'DARK_RED_BUTTON',
+  DARK_GREEN_BUTTON = 'DARK_GREEN_BUTTON',
+  DARK_ORANGE_BUTTON = 'DARK_ORANGE_BUTTON'
+}

--- a/packages/salesforcedx-vscode-apex/src/views/icons/iconHelpers.ts
+++ b/packages/salesforcedx-vscode-apex/src/views/icons/iconHelpers.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { extensionUris } from '@salesforce/salesforcedx-utils-vscode';
+import { VSCODE_APEX_EXTENSION_NAME } from '../../constants';
+import { iconKey, ICONS } from './IconsEnum';
+
+/**
+ * Get the Uri for an icon located in the resources directory.
+ * @param key A key from the {@link IconsEnum}
+ * @returns The Uri to the icon image.
+ */
+const getIconPath = (key: iconKey) => {
+  const baseExtensionPath = extensionUris.extensionUri(
+    VSCODE_APEX_EXTENSION_NAME
+  );
+  const iconUri = extensionUris.join(baseExtensionPath, ICONS[key]);
+  return iconUri;
+};
+
+export const iconHelpers = {
+  getIconPath
+};

--- a/packages/salesforcedx-vscode-apex/src/views/icons/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/views/icons/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+export * from './iconHelpers';
+export * from './IconsEnum';

--- a/packages/salesforcedx-vscode-apex/src/views/testOutlineProvider.ts
+++ b/packages/salesforcedx-vscode-apex/src/views/testOutlineProvider.ts
@@ -8,23 +8,14 @@ import { TestResult } from '@salesforce/apex-node';
 import { readFileSync } from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import {
-  APEX_GROUP_RANGE,
-  DARK_BLUE_BUTTON,
-  DARK_GREEN_BUTTON,
-  DARK_ORANGE_BUTTON,
-  DARK_RED_BUTTON,
-  LIGHT_BLUE_BUTTON,
-  LIGHT_GREEN_BUTTON,
-  LIGHT_ORANGE_BUTTON,
-  LIGHT_RED_BUTTON
-} from '../constants';
+import { APEX_GROUP_RANGE } from '../constants';
 import {
   getApexTests,
   LanguageClientStatus,
   languageClientUtils
 } from '../languageClientUtils';
 import { nls } from '../messages';
+import { iconHelpers, IconsEnum } from './icons';
 import { ApexTestMethod } from './lspConverter';
 
 // Message
@@ -266,8 +257,8 @@ export abstract class TestNode extends vscode.TreeItem {
   }
 
   public iconPath = {
-    light: LIGHT_BLUE_BUTTON,
-    dark: DARK_BLUE_BUTTON
+    light: iconHelpers.getIconPath(IconsEnum.LIGHT_BLUE_BUTTON),
+    dark: iconHelpers.getIconPath(IconsEnum.DARK_BLUE_BUTTON)
   };
 
   // TODO: create a ticket to address this particular issue.
@@ -280,20 +271,20 @@ export abstract class TestNode extends vscode.TreeItem {
     if (outcome === 'Pass') {
       // Passed Test
       this.iconPath = {
-        light: LIGHT_GREEN_BUTTON,
-        dark: DARK_GREEN_BUTTON
+        light: iconHelpers.getIconPath(IconsEnum.LIGHT_GREEN_BUTTON),
+        dark: iconHelpers.getIconPath(IconsEnum.DARK_GREEN_BUTTON)
       };
     } else if (outcome === 'Fail') {
       // Failed test
       this.iconPath = {
-        light: LIGHT_RED_BUTTON,
-        dark: DARK_RED_BUTTON
+        light: iconHelpers.getIconPath(IconsEnum.LIGHT_RED_BUTTON),
+        dark: iconHelpers.getIconPath(IconsEnum.DARK_RED_BUTTON)
       };
     } else if (outcome === 'Skip') {
       // Skipped test
       this.iconPath = {
-        light: LIGHT_ORANGE_BUTTON,
-        dark: DARK_ORANGE_BUTTON
+        light: iconHelpers.getIconPath(IconsEnum.LIGHT_ORANGE_BUTTON),
+        dark: iconHelpers.getIconPath(IconsEnum.DARK_ORANGE_BUTTON)
       };
     }
 
@@ -368,4 +359,11 @@ export class ApexTestNode extends TestNode {
   public contextValue = 'apexTest';
 }
 
-export const testOutlineProvider = new ApexTestOutlineProvider(null);
+let testOutlineProviderInst: ApexTestOutlineProvider;
+
+export const getTestOutlineProvider = () => {
+  if (!testOutlineProviderInst) {
+    testOutlineProviderInst = new ApexTestOutlineProvider(null);
+  }
+  return testOutlineProviderInst;
+};

--- a/packages/salesforcedx-vscode-apex/test/jest/utils/languageServerUtils.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/utils/languageServerUtils.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {
+  extensionUris,
+  projectPaths
+} from '@salesforce/salesforcedx-utils-vscode';
+import * as fs from 'fs';
+import * as vscode from 'vscode';
+import { VSCODE_APEX_EXTENSION_NAME } from '../../../src/constants';
+import { languageServerUtils } from '../../../src/helpers/languageServerUtils';
+
+describe('languageServer Unit Tests.', () => {
+  describe('setupDb()', () => {
+    const fakeApexDb = '.sfdx/tools/apex.db';
+    const fakeExtensionUri = { uri: 'file://here/is/the/extension' };
+    const fakeUrl = 'this/is/a/fake/uri';
+    const fakeUri = {
+      url: fakeUrl,
+      toString: () => {
+        return fakeUrl;
+      }
+    };
+    let existsSyncSpy: jest.SpyInstance;
+    let unlinkSyncSpy: jest.SpyInstance;
+    let copyFileSyncSpy: jest.SpyInstance;
+    let extensionUriSpy: jest.SpyInstance;
+    let joinSpy: jest.SpyInstance;
+    let apexLanguageServerDatabaseSpy: jest.SpyInstance;
+    let logSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      (vscode.workspace.workspaceFolders as any) = ['totally/valid/workspace'];
+      existsSyncSpy = jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+      unlinkSyncSpy = jest.spyOn(fs, 'unlinkSync').mockReturnValue();
+      copyFileSyncSpy = jest.spyOn(fs, 'copyFileSync').mockReturnValue();
+      extensionUriSpy = jest
+        .spyOn(extensionUris, 'extensionUri')
+        .mockReturnValue(fakeExtensionUri as any);
+      joinSpy = jest
+        .spyOn(extensionUris, 'join')
+        .mockReturnValue(fakeUri as any);
+      apexLanguageServerDatabaseSpy = jest
+        .spyOn(projectPaths, 'apexLanguageServerDatabase')
+        .mockReturnValue(fakeApexDb);
+      logSpy = jest.spyOn(console, 'log');
+    });
+
+    it('Should do nothing if there are no workspace folders.', () => {
+      (vscode.workspace.workspaceFolders as any) = [];
+      languageServerUtils.setupDB();
+      expect(existsSyncSpy).not.toHaveBeenCalled();
+      expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it('Should unlink existing and create new db.', () => {
+      languageServerUtils.setupDB();
+      expect(existsSyncSpy).toHaveBeenCalledWith(fakeApexDb);
+      expect(unlinkSyncSpy).toHaveBeenCalled();
+      expect(apexLanguageServerDatabaseSpy).toHaveBeenCalled();
+      expect(extensionUriSpy).toHaveBeenCalledWith(VSCODE_APEX_EXTENSION_NAME);
+      expect(joinSpy).toHaveBeenCalled();
+      expect(existsSyncSpy).toHaveBeenCalledWith(fakeUrl);
+      expect(copyFileSyncSpy).toHaveBeenCalledWith(fakeUrl, fakeApexDb);
+    });
+
+    it('Should skip unlink and create new db.', () => {
+      existsSyncSpy.mockReturnValueOnce(false).mockReturnValueOnce(true);
+      languageServerUtils.setupDB();
+      expect(existsSyncSpy).toHaveBeenCalledWith(fakeApexDb);
+      expect(unlinkSyncSpy).not.toHaveBeenCalled();
+      expect(copyFileSyncSpy).toHaveBeenCalledWith(fakeUrl, fakeApexDb);
+    });
+
+    it('Should skip db create if existing.', () => {
+      existsSyncSpy.mockReturnValue(false);
+      languageServerUtils.setupDB();
+      expect(existsSyncSpy).toHaveBeenCalledWith(fakeApexDb);
+      expect(copyFileSyncSpy).not.toHaveBeenCalled();
+    });
+
+    it('Should log a thrown error.', () => {
+      const handyError = new Error('oh no, file gone');
+      existsSyncSpy.mockReset();
+      existsSyncSpy.mockReturnValue(false);
+      extensionUriSpy.mockImplementation(() => {
+        throw handyError;
+      });
+      languageServerUtils.setupDB();
+      expect(existsSyncSpy).toHaveBeenCalledTimes(1);
+      expect(unlinkSyncSpy).not.toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalledWith(handyError);
+    });
+  });
+});

--- a/packages/salesforcedx-vscode-apex/test/jest/views/icons/iconHelpers.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/views/icons/iconHelpers.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { extensionUris } from '@salesforce/salesforcedx-utils-vscode';
+import * as vscode from 'vscode';
+import { VSCODE_APEX_EXTENSION_NAME } from '../../../../src/constants';
+import { iconHelpers, ICONS, IconsEnum } from '../../../../src/views/icons';
+
+describe('iconHelpers Unit Tests.', () => {
+  describe('getIconPath()', () => {
+    const fakeUri = { filePath: '/some/place/apexy' };
+    const fakeIconUri = { filePath: '/all/the/way/to/the/icon.svg' };
+    beforeEach(() => {
+      jest
+        .spyOn(extensionUris, 'extensionUri')
+        .mockReturnValue((fakeUri as unknown) as vscode.Uri);
+      jest
+        .spyOn(extensionUris, 'join')
+        .mockReturnValue((fakeIconUri as unknown) as vscode.Uri);
+    });
+
+    it('Should return the path for enum value.', () => {
+      const iconUri = iconHelpers.getIconPath(IconsEnum.LIGHT_BLUE_BUTTON);
+      expect(extensionUris.extensionUri).toHaveBeenCalledWith(
+        VSCODE_APEX_EXTENSION_NAME
+      );
+      expect(extensionUris.join).toHaveBeenCalledWith(
+        fakeUri,
+        ICONS[IconsEnum.LIGHT_BLUE_BUTTON]
+      );
+      expect(iconUri).toEqual(fakeIconUri);
+    });
+  });
+});

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/languageServer.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/languageServer.test.ts
@@ -13,10 +13,10 @@ import { createSandbox, SinonStub } from 'sinon';
 import * as vscode from 'vscode';
 import { Uri } from 'vscode';
 import { RevealOutputChannelOn } from 'vscode-languageclient';
+import { languageServerUtils } from '../../src/helpers/languageServerUtils';
 import {
   buildClientOptions,
-  code2ProtocolConverter,
-  setupDB
+  code2ProtocolConverter
 } from '../../src/languageServer';
 
 describe('Apex Language Server Client', () => {
@@ -133,27 +133,27 @@ describe('Apex Language Server Client', () => {
     });
 
     it('should check if apex db and system db exist', async () => {
-      setupDB();
+      languageServerUtils.setupDB();
 
       expect(existsStub.calledTwice).to.be.true;
     });
 
     it('should delete apex db if it exists', async () => {
-      setupDB();
+      languageServerUtils.setupDB();
 
       expect(existsStub.calledTwice).to.be.true;
     });
 
     it('should do nothing if apex db does not exist', async () => {
       existsStub.onFirstCall().returns(false);
-      setupDB();
+      languageServerUtils.setupDB();
 
       expect(existsStub.calledTwice).to.be.true;
       expect(unlinkStub.notCalled).to.be.true;
     });
 
     it('should copy system db to apex db location if system db exists', async () => {
-      setupDB();
+      languageServerUtils.setupDB();
 
       expect(existsStub.calledTwice).to.be.true;
       expect(copyStub.calledOnce).to.be.true;
@@ -162,7 +162,7 @@ describe('Apex Language Server Client', () => {
     it('should do nothing if system db does not exist', async () => {
       existsStub.onFirstCall().returns(true);
       existsStub.onSecondCall().returns(false);
-      setupDB();
+      languageServerUtils.setupDB();
 
       expect(existsStub.calledTwice).to.be.true;
       expect(unlinkStub.calledOnce).to.be.true;

--- a/packages/salesforcedx-vscode-lwc/src/constants.ts
+++ b/packages/salesforcedx-vscode-lwc/src/constants.ts
@@ -7,6 +7,7 @@
 
 export const ESLINT_NODEPATH_CONFIG = 'eslint.nodePath';
 export const LWC_EXTENSION_NAME = 'salesforcedx-vscode-lwc';
+export const VSCODE_LWC_EXTENSION_NAME = `salesforce.${LWC_EXTENSION_NAME}`;
 
 export const log = (message: string) => {
   console.log(message);

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/testExplorer/iconPaths.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/testExplorer/iconPaths.ts
@@ -4,62 +4,51 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+
+import { extensionUris } from '@salesforce/salesforcedx-utils-vscode';
 import * as path from 'path';
+import * as vscode from 'vscode';
+import { VSCODE_LWC_EXTENSION_NAME } from '../../constants';
 import { TestResult, TestResultStatus } from '../types';
 
-const extensionPath = path.join(__filename, '..', '..', '..', '..', '..');
-const LIGHT_BLUE_BUTTON = path.join(
+const extensionPath = extensionUris.extensionUri(VSCODE_LWC_EXTENSION_NAME);
+const LIGHT_BLUE_BUTTON = extensionUris.join(
   extensionPath,
-  'resources',
-  'light',
-  'testNotRun.svg'
+  path.join('resources', 'light', 'testNotRun.svg')
 );
 
-const LIGHT_RED_BUTTON = path.join(
+const LIGHT_RED_BUTTON = extensionUris.join(
   extensionPath,
-  'resources',
-  'light',
-  'testFail.svg'
-);
-const LIGHT_GREEN_BUTTON = path.join(
-  extensionPath,
-  'resources',
-  'light',
-  'testPass.svg'
-);
-const LIGHT_ORANGE_BUTTON = path.join(
-  extensionPath,
-  'resources',
-  'light',
-  'testSkip.svg'
+  path.join('resources', 'light', 'testFail.svg')
 );
 
-const DARK_BLUE_BUTTON = path.join(
+const LIGHT_GREEN_BUTTON = extensionUris.join(
   extensionPath,
-  'resources',
-  'dark',
-  'testNotRun.svg'
+  path.join('resources', 'light', 'testPass.svg')
 );
-const DARK_RED_BUTTON = path.join(
+const LIGHT_ORANGE_BUTTON = extensionUris.join(
   extensionPath,
-  'resources',
-  'dark',
-  'testFail.svg'
-);
-const DARK_GREEN_BUTTON = path.join(
-  extensionPath,
-  'resources',
-  'dark',
-  'testPass.svg'
-);
-const DARK_ORANGE_BUTTON = path.join(
-  extensionPath,
-  'resources',
-  'dark',
-  'testSkip.svg'
+  path.join('resources', 'light', 'testSkip.svg')
 );
 
-type IconPath = { light: string; dark: string };
+const DARK_BLUE_BUTTON = extensionUris.join(
+  extensionPath,
+  path.join('resources', 'dark', 'testNotRun.svg')
+);
+const DARK_RED_BUTTON = extensionUris.join(
+  extensionPath,
+  path.join('resources', 'dark', 'testFail.svg')
+);
+const DARK_GREEN_BUTTON = extensionUris.join(
+  extensionPath,
+  path.join('resources', 'dark', 'testPass.svg')
+);
+const DARK_ORANGE_BUTTON = extensionUris.join(
+  extensionPath,
+  path.join('resources', 'dark', 'testSkip.svg')
+);
+
+type IconPath = { light: vscode.Uri; dark: vscode.Uri };
 
 /**
  * Get icon path in the test explorer for test result

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/testExplorer/testNode.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/testSupport/testExplorer/testNode.test.ts
@@ -88,34 +88,48 @@ describe('Sfdx Test Node', () => {
       testExecutionInfo.testResult = undefined;
       const mockLabel = 'mockTest';
       const groupNode = new SfdxTestNode(mockLabel, testExecutionInfo);
-      expect(groupNode.iconPath.dark.endsWith('testNotRun.svg')).to.equal(true);
-      expect(groupNode.iconPath.light.endsWith('testNotRun.svg')).to.equal(
-        true
-      );
+      expect(
+        groupNode.iconPath.dark.toString().endsWith('testNotRun.svg')
+      ).to.equal(true);
+      expect(
+        groupNode.iconPath.light.toString().endsWith('testNotRun.svg')
+      ).to.equal(true);
     });
 
     it('Should set correct icon paths for passed tests', () => {
       testExecutionInfo.testResult = { status: TestResultStatus.PASSED };
       const mockLabel = 'mockTest';
       const groupNode = new SfdxTestNode(mockLabel, testExecutionInfo);
-      expect(groupNode.iconPath.dark.endsWith('testPass.svg')).to.equal(true);
-      expect(groupNode.iconPath.light.endsWith('testPass.svg')).to.equal(true);
+      expect(
+        groupNode.iconPath.dark.toString().endsWith('testPass.svg')
+      ).to.equal(true);
+      expect(
+        groupNode.iconPath.light.toString().endsWith('testPass.svg')
+      ).to.equal(true);
     });
 
     it('Should set correct icon paths for failed tests', () => {
       testExecutionInfo.testResult = { status: TestResultStatus.FAILED };
       const mockLabel = 'mockTest';
       const groupNode = new SfdxTestNode(mockLabel, testExecutionInfo);
-      expect(groupNode.iconPath.dark.endsWith('testFail.svg')).to.equal(true);
-      expect(groupNode.iconPath.light.endsWith('testFail.svg')).to.equal(true);
+      expect(
+        groupNode.iconPath.dark.toString().endsWith('testFail.svg')
+      ).to.equal(true);
+      expect(
+        groupNode.iconPath.light.toString().endsWith('testFail.svg')
+      ).to.equal(true);
     });
 
     it('Should set correct icon paths for skipped tests', () => {
       testExecutionInfo.testResult = { status: TestResultStatus.SKIPPED };
       const mockLabel = 'mockTest';
       const groupNode = new SfdxTestNode(mockLabel, testExecutionInfo);
-      expect(groupNode.iconPath.dark.endsWith('testSkip.svg')).to.equal(true);
-      expect(groupNode.iconPath.light.endsWith('testSkip.svg')).to.equal(true);
+      expect(
+        groupNode.iconPath.dark.toString().endsWith('testSkip.svg')
+      ).to.equal(true);
+      expect(
+        groupNode.iconPath.light.toString().endsWith('testSkip.svg')
+      ).to.equal(true);
     });
 
     it('Should set correct icon paths for tests with unknown results', () => {
@@ -124,10 +138,12 @@ describe('Sfdx Test Node', () => {
       };
       const mockLabel = 'mockTest';
       const groupNode = new SfdxTestNode(mockLabel, testExecutionInfo);
-      expect(groupNode.iconPath.dark.endsWith('testNotRun.svg')).to.equal(true);
-      expect(groupNode.iconPath.light.endsWith('testNotRun.svg')).to.equal(
-        true
-      );
+      expect(
+        groupNode.iconPath.dark.toString().endsWith('testNotRun.svg')
+      ).to.equal(true);
+      expect(
+        groupNode.iconPath.light.toString().endsWith('testNotRun.svg')
+      ).to.equal(true);
     });
   });
 

--- a/scripts/setup-jest.ts
+++ b/scripts/setup-jest.ts
@@ -36,18 +36,24 @@ const getMockVSCode = () => {
     },
     EventEmitter,
     ExtensionMode: { Production: 1, Development: 2, Test: 3 },
+    extensions: {
+      getExtension: jest.fn()
+    },
     languages: {
       createDiagnosticCollection: jest.fn()
     },
     Uri: {
       parse: jest.fn(),
-      file: jest.fn()
+      file: jest.fn(),
+      joinPath: jest.fn()
     },
+    Position: jest.fn(),
     ProgressLocation: {
       SourceControl: 1,
       Window: 10,
       Notification: 15
     },
+    Range: jest.fn(),
     StatusBarAlignment: {
       Left: 1,
       Right: 2


### PR DESCRIPTION
### What does this PR do?
Primarily this PR addresses fixing accessing files in the resources directory for bundled vsixes. 
 - Icons shows in the lwc and Apex Test views.
 - Setting up the apexDb

Secondarily there was a simple fix to how checkpoints are handled so I just did the update here. 

### What issues does this PR fix or reference?
@W-12545057@ #4534 
@W-12545057@ #4673 

### Functionality Before
No icons would show up in the Test views.
checkpoints would be removed out of order in the checkpoints view.

### Functionality After
We have icons.
![Screenshot 2023-02-16 at 12 42 09 AM](https://user-images.githubusercontent.com/76090802/219288261-16f4037a-7709-4427-a3be-e23ff35e97d3.png)

checkpoints are correctly removed from the debug panel when toggle in a cls. 
![Screenshot 2023-02-16 at 12 44 40 AM](https://user-images.githubusercontent.com/76090802/219288654-76d9caeb-c21b-4362-b08c-4f09108c7cc3.png)

Notes: 
To exercise the checkpoints functionality you can toggle a checkpoint via the `SFDX: Toggle Checkpoint` command in the CP or by creating a breakpoint and setting the expression to 'checkpoint'.  Checkpoints can also be removed by clicking an active checkpoint (breakpoint). 
