### PR TITLE
ci: update build/publish steps to use nvm for node version

### DIFF
--- a/.github/workflows/buildAll.yml
+++ b/.github/workflows/buildAll.yml
@@ -12,10 +12,6 @@ on:
 
 jobs:
   build-all:
-    strategy:
-      matrix:
-        node_version: [lts/-1]
-      fail-fast: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -23,7 +19,7 @@ jobs:
           ref: ${{ inputs.branch }}
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node_version }}
+          node-version-file: '.nvmrc'
           cache: npm
       - run: npm ci
       - run: npm --version

--- a/.github/workflows/createReleaseBranch.yml
+++ b/.github/workflows/createReleaseBranch.yml
@@ -32,16 +32,16 @@ jobs:
       RELEASE_TYPE: ${{ github.event.inputs.releaseType || 'minor' }}
 
     steps:
-    - name: Setup Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16.13.x'
     - name: Checkout
       uses: actions/checkout@v3
       with:
         ref: 'develop'
         ssh-strict: false
         token: ${{ secrets.IDEE_GH_TOKEN }}
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version-file: '.nvmrc'
     - uses: ./.github/actions/gitConfig
       with:
         email: ${{ secrets.IDEE_GH_EMAIL }}

--- a/.github/workflows/publishBetaRelease.yml
+++ b/.github/workflows/publishBetaRelease.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '16.13.x'
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.ref }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
       - run: npm install -g lerna
       - run: npm install
       - run: npm run compile

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -57,15 +57,14 @@ jobs:
       PUBLISH_VERSION: ${{ needs.prepare-environment-from-main.outputs.RELEASE_VERSION }}
       GITHUB_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
     steps: 
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '16.13.x'
       - name: Checkout
         uses: actions/checkout@v3
         with:
           ref: 'main'
           token: ${{ secrets.IDEE_GH_TOKEN }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
       - name: downloadExtensionsFromRelease
         run: | 
           mkdir ./extensions

--- a/.github/workflows/tagAndRelease.yml
+++ b/.github/workflows/tagAndRelease.yml
@@ -13,15 +13,15 @@ jobs:
     env: 
       RELEASE_VERSION: ${{ inputs.version }}
     steps:
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '16.13.x'
       - name: Checkout
         uses: actions/checkout@v3
         with:
           ref: 'main'
           token: ${{ secrets.IDEE_GH_TOKEN }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
       - uses: ./.github/actions/gitConfig
         with:
           email: ${{ secrets.IDEE_GH_EMAIL }}


### PR DESCRIPTION
### What does this PR do?
Update the setup-node steps in our GHA configs to use the `.nvmrc` file to install the same version of node we use locally and define in package.json. 

### What issues does this PR fix or reference?
@W-12573832@

### Functionality Before
GHA scripts failed due to node version mismatch

### Functionality After
GHA script succeed. 

### Notes
Verified the buildall flow and createReleaseBranch flow in my fork [here](https://github.com/gbockus-sf/salesforcedx-vscode/actions)
