### PR TITLE
ci: remove environment from release and update publishing doc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,9 @@ jobs:
       type: "notification"
       workflow: "release.yml"
   
-  prepare_environment:
+  get_release_version:
     name: 'Get Release Version'
     runs-on: ubuntu-latest
-    environment: publish
     outputs:
       RELEASE_VERSION: ${{ steps.getMainVersion.outputs.version }}
     steps:
@@ -30,8 +29,8 @@ jobs:
       - run: echo "Main Version is ${{ steps.getMainVersion.outputs.version }}"
 
   release:
-    needs: [prepare_environment]
+    needs: [get_release_version]
     uses: ./.github/workflows/tagAndRelease.yml
     with: 
-      version: ${{ needs.prepare_environment.outputs.RELEASE_VERSION }}
+      version: ${{ needs.get_release_version.outputs.RELEASE_VERSION }}
     secrets: inherit

--- a/contributing/publishing.md
+++ b/contributing/publishing.md
@@ -55,7 +55,7 @@ After the release has been created, it will trigger a publish action that will s
 
 Before approving the release to the marketplace, download the vsix files from the release you just created, install them locally and verify they are working as expected.
 
-Alternatively, you can download the files using the (gh cli)[https://cli.github.com/] and then upload them all at once. Replace `v57.3.0` with the tag name for the release that you are testing, and to whatever download directory you would like. Additionally, `code` can be replaced by `code-insiders`.
+Alternatively, you can download the files using the [gh cli](https://cli.github.com/) and then upload them all at once. Replace `v57.3.0` with the tag name for the release that you are testing, and to whatever download directory you would like. Additionally, `code` can be replaced by `code-insiders`.
 
 `> gh release download v57.3.0 --dir ~/Downloads/v57.3.0 --pattern '*.vscode'`  
 `> find ~/Downloads/v53.3.0 -type f -name "*.vsix" -exec code --install-extension {} \;`

--- a/contributing/publishing.md
+++ b/contributing/publishing.md
@@ -60,11 +60,11 @@ Alternatively, you can download the files using the [gh cli](https://cli.github.
 `> gh release download v57.3.0 --dir ~/Downloads/v57.3.0 --pattern '*.vscode'`  
 `> find ~/Downloads/v53.3.0 -type f -name "*.vsix" -exec code --install-extension {} \;`
 
-After completing your release testing following our internal template, approve the publish job on your .
+After completing your release testing following our internal template, approve the publish job "Publish in Microsoft Marketplace" to allow the extensions to be uploaded to the marketplace and complete the release process.
 
 ## Post-Publishing the .vsix
 
-1. Update the Salesforce Extension Pack to the version you just published. Either go to Extensions, select Salesforce Extension pack, and update... or go to https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode, download the version you published, and install. The publish may take a few minutes to register in the marketplace.
+1. Update the Salesforce Extension Pack to the version you just published. Either go to the Extensions tab, select Salesforce Extension pack, and update... or go to https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode, download the version you published, and install. The publish may take a few minutes to register in the marketplace.
 2. Restart Visual Studio Code
 3. Test & validate the application - verify all the extensions are running, and run a command or two.
 4. Once validated, post an announcement in #platform-dev-tools

--- a/contributing/publishing.md
+++ b/contributing/publishing.md
@@ -45,27 +45,28 @@ The PreRelease job will verify if the version of the branch to be merged is newe
 ## Publishing Main
 
 The merge into `main` will trigger a run of the 'Test, Build, and Release' GHA workflow (https://github.com/forcedotcom/salesforcedx-vscode/actions/workflows/testBuildAndRelease.yml) that will:
+
 - run the tests
 - build vsix files
 - send a slack notification that a release workflow has been initiated
 - create a tag and release in GitHub
 
-In the 'Test, Build, and Release' workflow:
-1. click Review deployments button
-1. click the publish checkbox
-1. click the approve and deploy button
-
 After the release has been created, it will trigger a publish action that will send a notification to slack to request approval to publish the vsix files to the marketplace.
 
-Before approving the release to the marketplace, download the vsix files, install them locally and verify they are working as expected.
+Before approving the release to the marketplace, download the vsix files from the release you just created, install them locally and verify they are working as expected.
 
-After you feel comfortable publishing to the marketplace, approve the publish job in the GitHub Action UI.
+Alternatively, you can download the files using the (gh cli)[https://cli.github.com/] and then upload them all at once. Replace `v57.3.0` with the tag name for the release that you are testing, and to whatever download directory you would like. Additionally, `code` can be replaced by `code-insiders`.
+
+`> gh release download v57.3.0 --dir ~/Downloads/v57.3.0 --pattern '*.vscode'`  
+`> find ~/Downloads/v53.3.0 -type f -name "*.vsix" -exec code --install-extension {} \;`
+
+After completing your release testing following our internal template, approve the publish job on your .
 
 ## Post-Publishing the .vsix
 
-1. Update the Salesforce Extension Pack to the version you just published. Either go to Extensions, select Salesforce Extension pack, and update... or go to https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode, download the version you published, and install.
+1. Update the Salesforce Extension Pack to the version you just published. Either go to Extensions, select Salesforce Extension pack, and update... or go to https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode, download the version you published, and install. The publish may take a few minutes to register in the marketplace.
 2. Restart Visual Studio Code
-3. Test & validate the application.
+3. Test & validate the application - verify all the extensions are running, and run a command or two.
 4. Once validated, post an announcement in #platform-dev-tools
 
 ---


### PR DESCRIPTION
### What does this PR do?
The environment during the `Test, Build, and Release` GHA was proving unnecessary. We can't get the VSIX files from the held build, so our updated flow should be: 
- `Test, Build, and Release` creates a github release without intervention
-  `Publish in Microsoft Marketplace` job starts automatically and pauses execution to allow for testing
-  VSIX files are downloaded from there for testing
-  If a serious bug is found, we can delete the tag & release
-  Otherwise, approve the `Publish in Microsoft Marketplace` job

### What issues does this PR fix or reference?
Follow-up to #4627 

### Functionality Before
- `Test, Build, and Release` **needs to be manually approved before creating a release**
-  `Publish in Microsoft Marketplace` job **starts after approval** and pauses execution to allow for testing
-  VSIX files are downloaded from there for testing
-  If a serious bug is found, we can delete the tag & release
-  Otherwise, approve the `Publish in Microsoft Marketplace` job

### Functionality After
- `Test, Build, and Release` creates a github release without intervention
-  `Publish in Microsoft Marketplace` job starts automatically and pauses execution to allow for testing
-  VSIX files are downloaded from there for testing
-  If a serious bug is found, we can delete the tag & release
-  Otherwise, approve the `Publish in Microsoft Marketplace` job

[skip-pr-validation]