### PR TITLE
chore: fix unit tests

### DIFF
--- a/packages/salesforcedx-apex-debugger/test/unit/commands/baseDebuggerCommand.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/unit/commands/baseDebuggerCommand.test.ts
@@ -32,7 +32,7 @@ export function getDefaultHeaders(contentLength: number): any {
     'Content-Type': 'application/json;charset=utf-8',
     Accept: 'application/json',
     Authorization: `OAuth 123`,
-    'Content-Length': contentLength,
+    'Content-Length': String(contentLength),
     'Sforce-Call-Options': `client=${CLIENT_ID}`
   };
 }

--- a/packages/salesforcedx-visualforce-language-server/test/unit/javascriptMode.test.ts
+++ b/packages/salesforcedx-visualforce-language-server/test/unit/javascriptMode.test.ts
@@ -46,7 +46,8 @@ describe('HTML Javascript Support', () => {
     }
   }
 
-  it('Should display completions', () => {
+  it('Should display completions', function() {
+    this.timeout(30000);
     assertCompletions('<html><script>window.|</script></html>', ['location']);
   });
 });


### PR DESCRIPTION
### What does this PR do?
There was a single unit test that was regularly failing locally due to a timeout.  Fixed it locally by adding a longer timeout.
There were some unit tests that were failing locally due to the recent request-light update.  Fixed. 

### What issues does this PR fix or reference?
Related to @W-9466545@

### Functionality Before
Unit tests failed local

### Functionality After
Unit tests pass. 

### Notes
Created 
https://github.com/forcedotcom/easywriter/issues/140 to track why a couple of the tests suites are exiting early in GHA which is why we didn't see the unit test failure in the visualforce package on GHA. 