### PR TITLE
feat: add pull/push for source-tracked Sandboxes

### DIFF
--- a/packages/salesforcedx-vscode-core/src/context/workspaceOrgType.ts
+++ b/packages/salesforcedx-vscode-core/src/context/workspaceOrgType.ts
@@ -22,13 +22,15 @@ export async function getWorkspaceOrgType(
     throw e;
   }
   const username = await OrgAuthInfo.getUsername(defaultUsernameOrAlias);
-  const isScratchOrg = await OrgAuthInfo.isAScratchOrg(username).catch(err =>
+  const hasChangeTracking = await OrgAuthInfo.hasChangeTracking(
+    username
+  ).catch(err =>
     telemetryService.sendException(
-      'get_workspace_org_type_scratch_org',
+      'get_workspace_org_type_has_change_tracking',
       err.message
     )
   );
-  return isScratchOrg ? OrgType.SourceTracked : OrgType.NonSourceTracked;
+  return hasChangeTracking ? OrgType.SourceTracked : OrgType.NonSourceTracked;
 }
 
 export function setWorkspaceOrgTypeWithOrgType(orgType: OrgType) {

--- a/packages/salesforcedx-vscode-core/src/util/authInfo.ts
+++ b/packages/salesforcedx-vscode-core/src/util/authInfo.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { AuthInfo, Connection, StateAggregator } from '@salesforce/core';
+import { AuthInfo, Connection, StateAggregator, Org } from '@salesforce/core';
 import {
   ConfigSource,
   ConfigUtil
@@ -112,6 +112,13 @@ export class OrgAuthInfo {
     return Promise.resolve(
       typeof authInfoFields.devHubUsername !== 'undefined'
     );
+  }
+
+  public static async hasChangeTracking(username: string): Promise<boolean> {
+    // authInfo.getFields().tracksSource is not always set, org.tracksSource() is handling setting it first if needed
+    const org = await Org.create({ aliasOrUsername: username });
+    const hasChangeTracking = await org.tracksSource();
+    return Promise.resolve(hasChangeTracking);
   }
 
   public static async getConnection(

--- a/packages/salesforcedx-vscode-core/src/util/authInfo.ts
+++ b/packages/salesforcedx-vscode-core/src/util/authInfo.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { AuthInfo, Connection, StateAggregator, Org } from '@salesforce/core';
+import { AuthInfo, Connection, Org, StateAggregator } from '@salesforce/core';
 import {
   ConfigSource,
   ConfigUtil


### PR DESCRIPTION
### What does this PR do?
Add pull/push operations in command palette for Sandboxes with Source Tracking enabled.

### What issues does this PR fix or reference?
#2952

### Functionality Before
In a source-tracked sandbox, push/pull commands were not available in the command palette:
- SFDX: Push Source to Default Scratch Org
- SFDX: Pull Source to Default Scratch Org
- SFDX: Push Source to Default Scratch Org and Override Conflicts
- ...

### Functionality After
All these commands that are source-tracking related become available for all orgs having source tracking enabled, not only Scratch Orgs.
