### PR TITLE
feat: bump lightning language server version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5429,14 +5429,14 @@
       }
     },
     "node_modules/@lwc/engine-dom": {
-      "version": "2.26.1",
-      "resolved": "https://registry.npmjs.org/@lwc/engine-dom/-/engine-dom-2.26.1.tgz",
-      "integrity": "sha512-P6tWBWPBdN1aF+ti4AKWeCaSdr0Jgw+SHnSsjmO0PD7iMZjWJQEg91hvlCU90pxXJSbsXh3BaBBqcwJLAzS/bA=="
+      "version": "2.37.3",
+      "resolved": "https://registry.npmjs.org/@lwc/engine-dom/-/engine-dom-2.37.3.tgz",
+      "integrity": "sha512-f0mV3Uf9OHsgA8veJDcBUh78ZO8JzdssAgyTZqEMgvYvO7DPppE6OF86NGUS4CPPzKg0GmnoMRsi8RFgq3TlEQ=="
     },
     "node_modules/@lwc/errors": {
-      "version": "2.26.1",
-      "resolved": "https://registry.npmjs.org/@lwc/errors/-/errors-2.26.1.tgz",
-      "integrity": "sha512-8rYNUephXfXUxy2VzPQygSdwU0uB1NYY/2EWKULvb6+1equctLPPQChbquQH6nzPw+j5AwLMcB1B342tbPvWkw=="
+      "version": "2.37.3",
+      "resolved": "https://registry.npmjs.org/@lwc/errors/-/errors-2.37.3.tgz",
+      "integrity": "sha512-3tM8p5YRdLNcPp/wJ3zchPcWGKsWjv4QtiITcVrDZvKxjdgYWE0VMS2804kJEoDWxIO7xFIoAAezcseIPaytaQ=="
     },
     "node_modules/@lwc/eslint-plugin-lwc": {
       "version": "1.5.1",
@@ -5455,9 +5455,9 @@
       }
     },
     "node_modules/@lwc/shared": {
-      "version": "2.26.1",
-      "resolved": "https://registry.npmjs.org/@lwc/shared/-/shared-2.26.1.tgz",
-      "integrity": "sha512-Pf30K/pfGQESAUE405rEKiupTJ3P8hYuCDVbsz+L9RRu+2OuAW2f/rlJveYnPAbn19WAOwyckYMYtDlC2DCUjA=="
+      "version": "2.37.3",
+      "resolved": "https://registry.npmjs.org/@lwc/shared/-/shared-2.37.3.tgz",
+      "integrity": "sha512-XsCWQmDuPztOsFuM3OnGKVqmsOMiKtkyV3HZ/Vj5/evGWiMrbu2SW6gwsIfCoUOt2cZb1TSzqkULKTwfPRCvEg=="
     },
     "node_modules/@lwc/style-compiler": {
       "version": "0.34.8",
@@ -5471,13 +5471,13 @@
       }
     },
     "node_modules/@lwc/template-compiler": {
-      "version": "2.26.1",
-      "resolved": "https://registry.npmjs.org/@lwc/template-compiler/-/template-compiler-2.26.1.tgz",
-      "integrity": "sha512-kQdGbRmmMXZMCwPOgBgX/JfGVityRG6mLfG/la13vts8n7NEGc2t2k1FsvZlTJzCrjDkA8LUNsJjwAChkTPt9w==",
+      "version": "2.37.3",
+      "resolved": "https://registry.npmjs.org/@lwc/template-compiler/-/template-compiler-2.37.3.tgz",
+      "integrity": "sha512-42VnkAIL+stUvZNoh28YD/c97sWfTHNdvfxZ05b8RVu6rc9608QNSAIQ1zWAPbmaBgiOzohqf1xtm+jGRs+9/g==",
       "dependencies": {
-        "@lwc/errors": "2.26.1",
-        "@lwc/shared": "2.26.1",
-        "acorn": "~8.8.0",
+        "@lwc/errors": "2.37.3",
+        "@lwc/shared": "2.37.3",
+        "acorn": "~8.8.2",
         "astring": "~1.8.3",
         "estree-walker": "~2.0.2",
         "he": "~1.2.0",
@@ -6508,11 +6508,11 @@
       }
     },
     "node_modules/@salesforce/aura-language-server": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-4.1.0.tgz",
-      "integrity": "sha512-SWfl3V9G0qYzEWyZPZN0L0Qkuy2HABdKaWi5dqRhIOGE8USW6symPWJqED2aE4rqWcN80Sdw1qIqCxO0v1UC8A==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-4.4.0.tgz",
+      "integrity": "sha512-laMMEdEHiWoJdqfaz0rrY6OIv5F9Row71pBW/9WIwWEKRdUUIGVKxVoLJk2klmY4aN0yGNDMvh+bxZA6DUIfPQ==",
       "dependencies": {
-        "@salesforce/lightning-lsp-common": "4.1.0",
+        "@salesforce/lightning-lsp-common": "4.4.0",
         "acorn": "^6.0.0",
         "acorn-loose": "^6.0.0",
         "acorn-walk": "^6.0.0",
@@ -6973,9 +6973,9 @@
       "integrity": "sha512-/ZiVwtVkmq2jWRRzgsC4SEy8m54gPaDc8e+jIfnIiR04iSeSRhYJxG+ktLSYVN2jMbVWA58HfEJSCx+73GcQCg=="
     },
     "node_modules/@salesforce/lightning-lsp-common": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-4.1.0.tgz",
-      "integrity": "sha512-NN+Fl2AVjWM67qC5zKSL1qYWXJEFfouoz2LzLbMADkImlGcO+PSHWFE5UVht66pBuE3mSVk8IGVL3A0Pyx0OqQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-4.4.0.tgz",
+      "integrity": "sha512-W330zKA44p6IuyYh3/ji8Jf0NW/y6MQJcI9HkjugD49iOdWi3wTgMxF0bfdKsjYNe95qeVYOmqi4hLGEN5DHXg==",
       "dependencies": {
         "decamelize": "^2.0.0",
         "deep-equal": "^1.0.1",
@@ -7059,17 +7059,17 @@
       "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
     },
     "node_modules/@salesforce/lwc-language-server": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-4.1.0.tgz",
-      "integrity": "sha512-u32TKhlLXrJz0mKtXWu/cHIhzuMP00mnoJb/olAjqExT1SsWgLgrdIE9GQ+LStbOvVrsqU+AzGtTpYhRurahaw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-4.4.0.tgz",
+      "integrity": "sha512-83l/640NbaHLvEoTpF6SHnrG1faXju7J+N5RBISIOaFQ0tYwjOzbkLDLjG0Otr3GSwTIWm/zMezY729eQMsjZw==",
       "dependencies": {
         "@lwc/compiler": "0.34.8",
-        "@lwc/engine-dom": "2.26.1",
-        "@lwc/errors": "2.26.1",
-        "@lwc/template-compiler": "2.26.1",
+        "@lwc/engine-dom": "2.37.3",
+        "@lwc/errors": "2.37.3",
+        "@lwc/template-compiler": "2.37.3",
         "@salesforce/apex": "0.0.12",
         "@salesforce/label": "0.0.12",
-        "@salesforce/lightning-lsp-common": "4.1.0",
+        "@salesforce/lightning-lsp-common": "4.4.0",
         "@salesforce/resourceurl": "0.0.12",
         "@salesforce/schema": "0.0.12",
         "@salesforce/user": "0.0.12",
@@ -27231,6 +27231,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -27245,16 +27246,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -27268,6 +27272,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -27283,6 +27288,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -40887,9 +40893,9 @@
       "version": "57.6.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/aura-language-server": "4.1.0",
+        "@salesforce/aura-language-server": "4.4.0",
         "@salesforce/core": "^3.31.18",
-        "@salesforce/lightning-lsp-common": "4.1.0",
+        "@salesforce/lightning-lsp-common": "4.4.0",
         "@salesforce/salesforcedx-utils-vscode": "57.6.0",
         "applicationinsights": "1.0.7",
         "vscode-extension-telemetry": "0.0.17",
@@ -40957,8 +40963,8 @@
       "dependencies": {
         "@salesforce/core": "^3.31.8",
         "@salesforce/eslint-config-lwc": "3.3.3",
-        "@salesforce/lightning-lsp-common": "4.1.0",
-        "@salesforce/lwc-language-server": "4.1.0",
+        "@salesforce/lightning-lsp-common": "4.4.0",
+        "@salesforce/lwc-language-server": "4.4.0",
         "@salesforce/salesforcedx-utils-vscode": "57.6.0",
         "ajv": "6.12.6",
         "applicationinsights": "1.0.7",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -25,9 +25,9 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/aura-language-server": "4.1.0",
+    "@salesforce/aura-language-server": "4.4.0",
     "@salesforce/core": "^3.31.18",
-    "@salesforce/lightning-lsp-common": "4.1.0",
+    "@salesforce/lightning-lsp-common": "4.4.0",
     "@salesforce/salesforcedx-utils-vscode": "57.6.0",
     "applicationinsights": "1.0.7",
     "vscode-extension-telemetry": "0.0.17",
@@ -91,9 +91,9 @@
       "main": "dist/index.js",
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "@salesforce/aura-language-server": "4.1.0",
+        "@salesforce/aura-language-server": "4.4.0",
         "@salesforce/core": "3.31.18",
-        "@salesforce/lightning-lsp-common": "4.1.0"
+        "@salesforce/lightning-lsp-common": "4.4.0"
       },
       "devDependencies": {}
     }

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "@salesforce/core": "^3.31.8",
     "@salesforce/eslint-config-lwc": "3.3.3",
-    "@salesforce/lightning-lsp-common": "4.1.0",
-    "@salesforce/lwc-language-server": "4.1.0",
+    "@salesforce/lightning-lsp-common": "4.4.0",
+    "@salesforce/lwc-language-server": "4.4.0",
     "@salesforce/salesforcedx-utils-vscode": "57.6.0",
     "ajv": "6.12.6",
     "applicationinsights": "1.0.7",
@@ -100,8 +100,8 @@
       "dependencies": {
         "applicationinsights": "1.0.7",
         "@salesforce/core": "3.31.18",
-        "@salesforce/lightning-lsp-common": "4.1.0",
-        "@salesforce/lwc-language-server": "4.1.0"
+        "@salesforce/lightning-lsp-common": "4.4.0",
+        "@salesforce/lwc-language-server": "4.4.0"
       },
       "devDependencies": {}
     }


### PR DESCRIPTION
### What does this PR do?
Updates the version of the lighting-language-server dependencies to pick up:
- updated lighting/salesAutomationRulesApi typings from https://github.com/forcedotcom/lightning-language-server/pull/555.
- updated lightning/messageService to be optional from https://github.com/forcedotcom/lightning-language-server/pull/547
- updated lightning/placeQuoteApi, lightning/industriesSchedulerApi, lightning/salesEnablementProgramApi typings from: https://github.com/forcedotcom/lightning-language-server/pull/544

### What issues does this PR fix or reference?
@W-12689558@

### Functionality Before
No hover text or code completion for some adapters

### Functionality After
Hover text and code completion for some adapters