### PR TITLE
fix: set home as save path for unsaved query results

### DIFF
--- a/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataFileService.ts
+++ b/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataFileService.ts
@@ -8,6 +8,7 @@
 import { JsonMap } from '@salesforce/ts-types';
 import * as fs from 'fs';
 import { QueryResult } from 'jsforce';
+import { homedir } from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { getDocumentName, getRootWorkspacePath } from '../commonUtils';
@@ -55,15 +56,17 @@ export class QueryDataFileService {
       this.queryData.records
     );
     const defaultFileName = this.dataProvider.getFileName();
-    /* queryDataDefaultFilePath will be used as the default options in the save dialog
-        fileName: The name of the soqlFile viewed in the builder
-        path: the same directory as the .soql file text doc.
-    note: directory must exist to show up in save dialog.
+    /*
+        queryDataDefaultFilePath will be used as the default options in the save dialog
+            fileName: The name of the soqlFile viewed in the builder
+            path: the same directory as the .soql file text doc
+                  or the home directory if .soql file does not exist yet
     */
-    const queryDataDefaultFilePath = path.join(
-      path.parse(this.document.uri.path).dir,
-      defaultFileName
-    );
+    let saveDir = path.parse(this.document.uri.path).dir;
+    if (!saveDir) {
+      saveDir = homedir();
+    }
+    const queryDataDefaultFilePath = path.join(saveDir, defaultFileName);
 
     const fileInfo: vscode.Uri | undefined = await vscode.window.showSaveDialog(
       {


### PR DESCRIPTION
### What does this PR do?
By default, SOQL query results are saved to the same directory as the .soql file from which the query is generated. However, when the SOQL query is not yet saved, the default directory was set to the root. This PR changes the behavior so that the default directory for unsaved query results is set to the home directory instead of the root.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/try-code-builder-feedback/issues/201
@W-12081773@

### Functionality Before
View query results of unsaved SOQL query. Save as CSV or JSON. The save dialog shows the root directory as the default save directory.

### Functionality After
View query results of unsaved SOQL query. Save as CSV or JSON. The save dialog shows the home directory as the default save directory.
