### PR TITLE
chore: updates fix bundling of vsixs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -121,6 +121,7 @@
       "version": "7.19.1",
       "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.19.1.tgz",
       "integrity": "sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==",
+      "peer": true,
       "dependencies": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
         "eslint-visitor-keys": "^2.1.0",
@@ -5550,6 +5551,7 @@
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
       "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
+      "peer": true,
       "dependencies": {
         "eslint-scope": "5.1.1"
       }
@@ -6854,57 +6856,6 @@
       "resolved": "https://registry.npmjs.org/@salesforce/dev-config/-/dev-config-3.1.0.tgz",
       "integrity": "sha512-cPph7ibj3DeSzWDFLcLtxOh5fmUlDUY2Ezq43n0V6auVP+l8orxRHjCExHS86SB3QKVgXkC8yYhryXiS8KF7Zw==",
       "dev": true
-    },
-    "node_modules/@salesforce/eslint-config-lwc": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/eslint-config-lwc/-/eslint-config-lwc-3.4.0.tgz",
-      "integrity": "sha512-RV1of9PVpVHiz4RPc6YugGyw6cyzmddDUZzv3YwIhXqdhra+Enb+DJerVCexSXKGkcZ1vF9uTuQOAOE6tA5J1A==",
-      "dependencies": {
-        "@babel/core": "~7.21.0",
-        "@babel/eslint-parser": "~7.19.1",
-        "eslint-restricted-globals": "~0.2.0",
-        "semver": "^7.3.8"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "@lwc/eslint-plugin-lwc": "^1.0.0",
-        "@salesforce/eslint-plugin-lightning": "^1.0.0",
-        "eslint": "^7 || ^8",
-        "eslint-plugin-import": "*",
-        "eslint-plugin-jest": "*"
-      }
-    },
-    "node_modules/@salesforce/eslint-config-lwc/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@salesforce/eslint-config-lwc/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@salesforce/eslint-config-lwc/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@salesforce/eslint-plugin-lightning": {
       "version": "1.0.0",
@@ -40771,7 +40722,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/core": "^3.31.8",
-        "@salesforce/eslint-config-lwc": "3.4.0",
+        "@salesforce/eslint-config-lwc": "3.3.3",
         "@salesforce/lightning-lsp-common": "4.4.0",
         "@salesforce/lwc-language-server": "4.4.0",
         "@salesforce/salesforcedx-utils-vscode": "57.8.0",
@@ -40813,6 +40764,103 @@
         "vscode": "^1.61.2"
       }
     },
+    "packages/salesforcedx-vscode-lwc/node_modules/@babel/core": {
+      "version": "7.18.13",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.13.tgz",
+      "integrity": "sha512-ZisbOvRRusFktksHSG6pjj1CSvkPkcZq/KHD45LAkVP/oiHJkNBZWfpvlLmX8OtHDG8IuzsFlVRWo08w7Qxn0A==",
+      "dependencies": {
+        "@ampproject/remapping": "^2.1.0",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.18.13",
+        "@babel/helper-compilation-targets": "^7.18.9",
+        "@babel/helper-module-transforms": "^7.18.9",
+        "@babel/helpers": "^7.18.9",
+        "@babel/parser": "^7.18.13",
+        "@babel/template": "^7.18.10",
+        "@babel/traverse": "^7.18.13",
+        "@babel/types": "^7.18.13",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.1",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/@salesforce/eslint-config-lwc": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@salesforce/eslint-config-lwc/-/eslint-config-lwc-3.3.3.tgz",
+      "integrity": "sha512-AZyBta7Y9N2IcJ4LbmIXSQzUoPoZ2cvoi75mqS+9QgUJfB7Il/vRj6NlflSOG14gkA4dmxoT7R6siGj2AYQ+PQ==",
+      "dependencies": {
+        "@babel/core": "~7.18.5",
+        "@babel/eslint-parser": "~7.18.2",
+        "eslint-restricted-globals": "~0.2.0",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "@lwc/eslint-plugin-lwc": "^1.0.0",
+        "@salesforce/eslint-plugin-lightning": "^1.0.0",
+        "eslint": "^7 || ^8",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-jest": "*"
+      }
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/@salesforce/eslint-config-lwc/node_modules/@babel/eslint-parser": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.18.9.tgz",
+      "integrity": "sha512-KzSGpMBggz4fKbRbWLNyPVTuQr6cmCcBhOyXTw/fieOVaw5oYAwcAj4a7UKcDYCPxQq+CG1NCDZH9e2JTXquiQ==",
+      "dependencies": {
+        "eslint-scope": "^5.1.1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.11.0",
+        "eslint": "^7.5.0 || ^8.0.0"
+      }
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/@salesforce/eslint-config-lwc/node_modules/@babel/eslint-parser/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/@salesforce/eslint-config-lwc/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "packages/salesforcedx-vscode-lwc/node_modules/@types/node": {
       "version": "12.0.12",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.12.tgz",
@@ -40830,6 +40878,17 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.10.tgz",
       "integrity": "sha512-BgeaZuElf7DEYZhWYDTc/XcLZXdVgFkVSTa13BqKvbnmUrxr3TJFKofUxCtDO9UQOdhnV+HPOESdHiHKZOJV1A==",
       "dev": true
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "packages/salesforcedx-vscode-lwc/node_modules/semver": {
       "version": "5.7.1",
@@ -40864,6 +40923,11 @@
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.8.tgz",
       "integrity": "sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ==",
       "dev": true
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "packages/salesforcedx-vscode-soql": {
       "version": "57.8.0",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -68,7 +68,7 @@
     "dbaeumer.vscode-eslint"
   ],
   "scripts": {
-    "bundle:extension": "esbuild ./src/index.ts  --bundle --outfile=dist/index.js --format=cjs --platform=node --external:vscode  --external:@salesforce/core --external:applicationinsights --external:@salesforce/lightning-lsp-common --external:@salesforce/lwc-language-serve --minify",
+    "bundle:extension": "esbuild ./src/index.ts  --bundle --outfile=dist/index.js --format=cjs --platform=node --loader:.node=file --external:vscode  --external:@salesforce/core --external:applicationinsights --external:@salesforce/lightning-lsp-common --external:@salesforce/lwc-language-serve --minify",
     "vscode:prepublish": "npm prune --production",
     "vscode:package": "ts-node -P ./tsconfig.json ../../scripts/vsce-bundled-extension.ts",
     "vscode:sha256": "node ../../scripts/generate-sha256.js >> ../../SHA256",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "@salesforce/core": "^3.31.8",
-    "@salesforce/eslint-config-lwc": "3.4.0",
+    "@salesforce/eslint-config-lwc": "3.3.3",
     "@salesforce/lightning-lsp-common": "4.4.0",
     "@salesforce/lwc-language-server": "4.4.0",
     "@salesforce/salesforcedx-utils-vscode": "57.8.0",


### PR DESCRIPTION
### What does this PR do?
- Add a flag to esbuild for the vscode-lwc package to get around the fsevents error 
  - ```       ✘ [ERROR] No loader is configured for ".node" files: node_modules/fsevents/fsevents.node

           node_modules/fsevents/fsevents.js:13:23:
             13 │ const Native = require("./fsevents.node");
                ╵                        ~~~~~~~~~~~~~~~~~```
- Revert @salesforce/eslint-config-lwc back to 3.3.3 
  - ```       ✘ [ERROR] Could not resolve "@babel/preset-typescript/package.json"

           node_modules/@babel/core/lib/config/files/module-types.js:87:40:
             87 │ ...st packageJson = require("@babel/preset-typescript/package.json");```

### What issues does this PR fix or reference?
@W-12947525@

### Functionality Before
bundling fails

### Functionality After
bundling succeeds
