### PR TITLE
ci: add error handling for changelog generation

### DIFF
--- a/scripts/create-release-branch.js
+++ b/scripts/create-release-branch.js
@@ -110,15 +110,22 @@ if (!isBetaRelease()) {
   shell.exec(`git fetch`)
 
   // Generate changelog
-  const latestReleasedVersion = String(shell.exec(`git describe --tags --abbrev=0`));
-  const latestReleasedBranchName = `release/${latestReleasedVersion}`
-  const parsedCommits = changeLogGeneratorUtils.parseCommits(changeLogGeneratorUtils.getCommits(releaseBranchName, latestReleasedBranchName));
-  const groupedMessages = changeLogGeneratorUtils.getMessagesGroupedByPackage(parsedCommits, '');
-  const changeLog = changeLogGeneratorUtils.getChangeLogText(releaseBranchName, groupedMessages);
-  changeLogGeneratorUtils.writeChangeLog(changeLog);
+  try {
+    //... but don't prevent errors from creating the release branch since we already merged to develop
+    const latestReleasedVersion = String(shell.exec(`git describe --tags --abbrev=0`));
+    const latestReleasedBranchName = `release/${latestReleasedVersion}`
+    const parsedCommits = changeLogGeneratorUtils.parseCommits(changeLogGeneratorUtils.getCommits(releaseBranchName, latestReleasedBranchName));
+    const groupedMessages = changeLogGeneratorUtils.getMessagesGroupedByPackage(parsedCommits, '');
+    const changeLog = changeLogGeneratorUtils.getChangeLogText(releaseBranchName, groupedMessages);
+    changeLogGeneratorUtils.writeChangeLog(changeLog);
+  
+    const commitCommand = `git commit -a -m "chore: generated CHANGELOG for ${releaseBranchName}"`;
+    shell.exec(commitCommand);
+  } catch (e) {
+    logger.error(`Changelog could not be generated - you're on your own for this one!`);
+    logger.error(e);
+  }
 
-  const commitCommand = `git commit -a -m "chore: generated CHANGELOG for ${releaseBranchName}"`;
-  shell.exec(commitCommand);
 }
 
 // Push new release branch to remote


### PR DESCRIPTION
### What does this PR do?
Allows for a release branch to be generated even if the changelog creation fails. This week there was an error that caused a patch release to fail, but the commit had already been pushed to develop. This avoids having to revert or cherry-pick the version bump commit.

Example of the changelog failing in my fork [here](https://github.com/randi274/salesforcedx-vscode-fork/actions/runs/4692455457/jobs/8318195026), but [the branch](https://github.com/randi274/salesforcedx-vscode-fork/tree/release/v57.10.5) is still created.
Whereas [this](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/4670468097) failure in the main repo did not create the correct branch, and I had to create + cherry-pick the version bump.

### What issues does this PR fix or reference?
@W-12471668@

### Functionality Before
A failure in the changelog creation wouldn't create the release branch.

### Functionality After
A failure can occur, but the branch will still be created, so the release notes may be manually or locally generated.
