### PR TITLE
fix: update lls to fix core devs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6543,11 +6543,11 @@
       }
     },
     "node_modules/@salesforce/aura-language-server": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-4.4.0.tgz",
-      "integrity": "sha512-laMMEdEHiWoJdqfaz0rrY6OIv5F9Row71pBW/9WIwWEKRdUUIGVKxVoLJk2klmY4aN0yGNDMvh+bxZA6DUIfPQ==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-4.4.2.tgz",
+      "integrity": "sha512-fkQmdtqJo1vIWOHV2q/+GpZyOdcg/LA1COiIOmJpBQGOxBu1X6kjfqircdJ2y0BP2k7U9E+NP077TV5/8pm97A==",
       "dependencies": {
-        "@salesforce/lightning-lsp-common": "4.4.0",
+        "@salesforce/lightning-lsp-common": "4.4.2",
         "acorn": "^6.0.0",
         "acorn-loose": "^6.0.0",
         "acorn-walk": "^6.0.0",
@@ -6895,9 +6895,9 @@
       "integrity": "sha512-/ZiVwtVkmq2jWRRzgsC4SEy8m54gPaDc8e+jIfnIiR04iSeSRhYJxG+ktLSYVN2jMbVWA58HfEJSCx+73GcQCg=="
     },
     "node_modules/@salesforce/lightning-lsp-common": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-4.4.0.tgz",
-      "integrity": "sha512-W330zKA44p6IuyYh3/ji8Jf0NW/y6MQJcI9HkjugD49iOdWi3wTgMxF0bfdKsjYNe95qeVYOmqi4hLGEN5DHXg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-4.4.2.tgz",
+      "integrity": "sha512-rtXqY2SfCKPt3jDTgM9ybYGhsdWpOp8b9TDGI2hksqe4D3aP/ipwrmUlp4td6yXyNFS8gqFq4gap5gbENrLX9g==",
       "dependencies": {
         "decamelize": "^2.0.0",
         "deep-equal": "^1.0.1",
@@ -6981,9 +6981,9 @@
       "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
     },
     "node_modules/@salesforce/lwc-language-server": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-4.4.0.tgz",
-      "integrity": "sha512-83l/640NbaHLvEoTpF6SHnrG1faXju7J+N5RBISIOaFQ0tYwjOzbkLDLjG0Otr3GSwTIWm/zMezY729eQMsjZw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-4.4.2.tgz",
+      "integrity": "sha512-9ohgNJyPBQGLGd9ZzuMvRxw2UngppCC//EH3cAeNn4J/aLv/WAcPnMMBILj24v5+oNogSolTTspuy6++MRdhLw==",
       "dependencies": {
         "@lwc/compiler": "0.34.8",
         "@lwc/engine-dom": "2.37.3",
@@ -6991,7 +6991,7 @@
         "@lwc/template-compiler": "2.37.3",
         "@salesforce/apex": "0.0.12",
         "@salesforce/label": "0.0.12",
-        "@salesforce/lightning-lsp-common": "4.4.0",
+        "@salesforce/lightning-lsp-common": "4.4.2",
         "@salesforce/resourceurl": "0.0.12",
         "@salesforce/schema": "0.0.12",
         "@salesforce/user": "0.0.12",
@@ -40647,9 +40647,9 @@
       "version": "57.11.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/aura-language-server": "4.4.0",
+        "@salesforce/aura-language-server": "4.4.2",
         "@salesforce/core": "^3.31.18",
-        "@salesforce/lightning-lsp-common": "4.4.0",
+        "@salesforce/lightning-lsp-common": "4.4.2",
         "@salesforce/salesforcedx-utils-vscode": "57.11.0",
         "applicationinsights": "1.0.7",
         "vscode-extension-telemetry": "0.0.17",
@@ -40717,8 +40717,8 @@
       "dependencies": {
         "@salesforce/core": "^3.31.8",
         "@salesforce/eslint-config-lwc": "3.3.3",
-        "@salesforce/lightning-lsp-common": "4.4.0",
-        "@salesforce/lwc-language-server": "4.4.0",
+        "@salesforce/lightning-lsp-common": "4.4.2",
+        "@salesforce/lwc-language-server": "4.4.2",
         "@salesforce/salesforcedx-utils-vscode": "57.11.0",
         "ajv": "6.12.6",
         "applicationinsights": "1.0.7",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -25,9 +25,9 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/aura-language-server": "4.4.0",
+    "@salesforce/aura-language-server": "4.4.2",
     "@salesforce/core": "^3.31.18",
-    "@salesforce/lightning-lsp-common": "4.4.0",
+    "@salesforce/lightning-lsp-common": "4.4.2",
     "@salesforce/salesforcedx-utils-vscode": "57.11.0",
     "applicationinsights": "1.0.7",
     "vscode-extension-telemetry": "0.0.17",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "@salesforce/core": "^3.31.8",
     "@salesforce/eslint-config-lwc": "3.3.3",
-    "@salesforce/lightning-lsp-common": "4.4.0",
-    "@salesforce/lwc-language-server": "4.4.0",
+    "@salesforce/lightning-lsp-common": "4.4.2",
+    "@salesforce/lwc-language-server": "4.4.2",
     "@salesforce/salesforcedx-utils-vscode": "57.11.0",
     "ajv": "6.12.6",
     "applicationinsights": "1.0.7",
@@ -100,8 +100,8 @@
       "dependencies": {
         "applicationinsights": "1.0.7",
         "@salesforce/core": "3.31.18",
-        "@salesforce/lightning-lsp-common": "4.4.0",
-        "@salesforce/lwc-language-server": "4.4.0"
+        "@salesforce/lightning-lsp-common": "4.4.2",
+        "@salesforce/lwc-language-server": "4.4.2"
       },
       "devDependencies": {}
     }


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where internal developers weren't able to use the Lightning Language Server with the BLT setup.

### What issues does this PR fix or reference?
@W-13007946@. Includes forcedotcom/lightning-language-server#564.

### Functionality Before
The LWC Language Server would show errors if BLT was not included in Core developer setup. 

### Functionality After
The Language Server checks for a configuration setup at a different location that is more commonly used, and doesn't require the use of the core config if it can't be located.
