### PR TITLE
feat: bump lightning language server version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6543,11 +6543,11 @@
       }
     },
     "node_modules/@salesforce/aura-language-server": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-4.4.2.tgz",
-      "integrity": "sha512-fkQmdtqJo1vIWOHV2q/+GpZyOdcg/LA1COiIOmJpBQGOxBu1X6kjfqircdJ2y0BP2k7U9E+NP077TV5/8pm97A==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-4.5.0.tgz",
+      "integrity": "sha512-XxPy7ODqHnYn9qC/IUhfqi0Z5500jGWvRUjyxAppIQJP+pKc/XRgXlmwrC5s5i+iwTXaAVmuIKiuKtbjdcu3IA==",
       "dependencies": {
-        "@salesforce/lightning-lsp-common": "4.4.2",
+        "@salesforce/lightning-lsp-common": "4.5.0",
         "acorn": "^6.0.0",
         "acorn-loose": "^6.0.0",
         "acorn-walk": "^6.0.0",
@@ -7075,9 +7075,9 @@
       "integrity": "sha512-/ZiVwtVkmq2jWRRzgsC4SEy8m54gPaDc8e+jIfnIiR04iSeSRhYJxG+ktLSYVN2jMbVWA58HfEJSCx+73GcQCg=="
     },
     "node_modules/@salesforce/lightning-lsp-common": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-4.4.2.tgz",
-      "integrity": "sha512-rtXqY2SfCKPt3jDTgM9ybYGhsdWpOp8b9TDGI2hksqe4D3aP/ipwrmUlp4td6yXyNFS8gqFq4gap5gbENrLX9g==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-4.5.0.tgz",
+      "integrity": "sha512-A4fiZlNjUZAgFjq4ikpVHmmiCVcJbH1oRROIwEvAtV9Z33/P1gcQPi6lp1WBQ+74kInb/WSXVLSIedAhdKiInQ==",
       "dependencies": {
         "decamelize": "^2.0.0",
         "deep-equal": "^1.0.1",
@@ -7161,9 +7161,9 @@
       "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
     },
     "node_modules/@salesforce/lwc-language-server": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-4.4.2.tgz",
-      "integrity": "sha512-9ohgNJyPBQGLGd9ZzuMvRxw2UngppCC//EH3cAeNn4J/aLv/WAcPnMMBILj24v5+oNogSolTTspuy6++MRdhLw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-4.5.0.tgz",
+      "integrity": "sha512-LrBwjj2ZiV36iYann7vDgen2ZhykWZ8xn7p/dxUW5zT2zKRHIx1uBdBmDLuUrtkwYR4SQ3bYLbqdVIjmyBBuag==",
       "dependencies": {
         "@lwc/compiler": "0.34.8",
         "@lwc/engine-dom": "2.37.3",
@@ -7171,7 +7171,7 @@
         "@lwc/template-compiler": "2.37.3",
         "@salesforce/apex": "0.0.12",
         "@salesforce/label": "0.0.12",
-        "@salesforce/lightning-lsp-common": "4.4.2",
+        "@salesforce/lightning-lsp-common": "4.5.0",
         "@salesforce/resourceurl": "0.0.12",
         "@salesforce/schema": "0.0.12",
         "@salesforce/user": "0.0.12",
@@ -27441,6 +27441,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -27455,16 +27456,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -27478,6 +27482,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -27493,6 +27498,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -41130,9 +41136,9 @@
       "version": "57.11.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/aura-language-server": "4.4.2",
+        "@salesforce/aura-language-server": "4.5.0",
         "@salesforce/core": "3.34.7",
-        "@salesforce/lightning-lsp-common": "4.4.2",
+        "@salesforce/lightning-lsp-common": "4.5.0",
         "@salesforce/salesforcedx-utils-vscode": "57.11.0",
         "applicationinsights": "1.0.7",
         "vscode-extension-telemetry": "0.0.17",
@@ -41200,8 +41206,8 @@
       "dependencies": {
         "@salesforce/core": "3.34.7",
         "@salesforce/eslint-config-lwc": "3.3.3",
-        "@salesforce/lightning-lsp-common": "4.4.2",
-        "@salesforce/lwc-language-server": "4.4.2",
+        "@salesforce/lightning-lsp-common": "4.5.0",
+        "@salesforce/lwc-language-server": "4.5.0",
         "@salesforce/salesforcedx-utils-vscode": "57.11.0",
         "ajv": "6.12.6",
         "applicationinsights": "1.0.7",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -25,9 +25,9 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/aura-language-server": "4.4.2",
+    "@salesforce/aura-language-server": "4.5.0",
     "@salesforce/core": "3.34.7",
-    "@salesforce/lightning-lsp-common": "4.4.2",
+    "@salesforce/lightning-lsp-common": "4.5.0",
     "@salesforce/salesforcedx-utils-vscode": "57.11.0",
     "applicationinsights": "1.0.7",
     "vscode-extension-telemetry": "0.0.17",
@@ -92,9 +92,9 @@
       "main": "dist/index.js",
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "@salesforce/aura-language-server": "4.4.0",
+        "@salesforce/aura-language-server": "4.5.0",
         "@salesforce/core": "3.34.7",
-        "@salesforce/lightning-lsp-common": "4.4.0"
+        "@salesforce/lightning-lsp-common": "4.5.0"
       },
       "devDependencies": {}
     }

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "@salesforce/core": "3.34.7",
     "@salesforce/eslint-config-lwc": "3.3.3",
-    "@salesforce/lightning-lsp-common": "4.4.2",
-    "@salesforce/lwc-language-server": "4.4.2",
+    "@salesforce/lightning-lsp-common": "4.5.0",
+    "@salesforce/lwc-language-server": "4.5.0",
     "@salesforce/salesforcedx-utils-vscode": "57.11.0",
     "ajv": "6.12.6",
     "applicationinsights": "1.0.7",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -100,8 +100,8 @@
       "dependencies": {
         "applicationinsights": "1.0.7",
         "@salesforce/core": "3.34.7",
-        "@salesforce/lightning-lsp-common": "4.4.2",
-        "@salesforce/lwc-language-server": "4.4.2"
+        "@salesforce/lightning-lsp-common": "4.5.0",
+        "@salesforce/lwc-language-server": "4.5.0"
       },
       "devDependencies": {}
     }


### PR DESCRIPTION
### What does this PR do?
Updates the version of the lighting-language-server dependencies to pick up:
- support for lwc:if, lwc:elseif and lwc:else new HTML directives from https://github.com/forcedotcom/lightning-language-server/pull/565

### What issues does this PR fix or reference?
@W-12051474@

### Functionality After
- Autocomplete:
![image](https://user-images.githubusercontent.com/113132642/234088493-8668d37f-a0a2-4eca-8f6f-ba85a49d1b4f.png)
- On hover info:
![image](https://user-images.githubusercontent.com/113132642/234088532-05516770-9df8-4790-9c77-cafc68633bb5.png)
