### PR TITLE
chore: update bundles to exclude source-tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27441,6 +27441,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -27455,16 +27456,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -27478,6 +27482,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -27493,6 +27498,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -40931,6 +40937,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/salesforcedx-apex-debugger": "57.11.1",
+        "@salesforce/salesforcedx-utils-vscode": "57.11.1",
         "vscode-debugprotocol": "1.28.0",
         "vscode-extension-telemetry": "0.0.17"
       },

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -25,6 +25,7 @@
   ],
   "dependencies": {
     "@salesforce/salesforcedx-apex-debugger": "57.11.1",
+    "@salesforce/salesforcedx-utils-vscode": "57.11.1",
     "vscode-debugprotocol": "1.28.0",
     "vscode-extension-telemetry": "0.0.17"
   },
@@ -47,7 +48,7 @@
   "scripts": {
     "bundle:extension": "npm run bundle:extension:build && npm run bundle:extension:copy",
     "bundle:extension:copy": "cp ../salesforcedx-apex-debugger/dist/apexdebug.js ./dist/",
-    "bundle:extension:build": "esbuild ./src/index.ts  --bundle --outfile=dist/index.js --format=cjs --platform=node --external:vscode --external:@salesforce/core --minify",
+    "bundle:extension:build": "esbuild ./src/index.ts  --bundle --outfile=dist/index.js --format=cjs --platform=node --external:vscode --external:@salesforce/core --external:@salesforce/source-tracking --minify",
     "vscode:prepublish": "npm prune --production",
     "vscode:package": "ts-node -P ./tsconfig.json ../../scripts/vsce-bundled-extension.ts",
     "vscode:sha256": "node ../../scripts/generate-sha256.js >> ../../SHA256",
@@ -84,7 +85,8 @@
       "main": "dist/index.js",
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "@salesforce/core": "^3.34.8"
+        "@salesforce/core": "^3.34.8",
+        "@salesforce/source-tracking": "3.1.1"
       },
       "devDependencies": {}
     }

--- a/packages/salesforcedx-vscode-apex-debugger/tsconfig.json
+++ b/packages/salesforcedx-vscode-apex-debugger/tsconfig.json
@@ -14,6 +14,9 @@
       "path": "../salesforcedx-apex-debugger"
     },
     {
+      "path": "../salesforcedx-utils-vscode"
+    },
+    {
       "path": "../salesforcedx-test-utils-vscode"
     }
   ]

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -57,7 +57,7 @@
   "scripts": {
     "bundle:extension": "npm run bundle:extension:build && npm run bundle:extension:copy",
     "bundle:extension:copy": "cp ../salesforcedx-apex-replay-debugger/dist/apexreplaydebug.js ./dist/",
-    "bundle:extension:build": "esbuild ./src/index.ts  --bundle --outfile=dist/index.js --format=cjs --platform=node --external:vscode --external:@salesforce/core --external:applicationinsights --minify",
+    "bundle:extension:build": "esbuild ./src/index.ts  --bundle --outfile=dist/index.js --format=cjs --platform=node --external:vscode --external:@salesforce/core --external:@salesforce/source-tracking --external:applicationinsights --minify",
     "vscode:prepublish": "npm prune --production",
     "vscode:package": "ts-node -P ./tsconfig.json ../../scripts/vsce-bundled-extension.ts",
     "vscode:sha256": "node ../../scripts/generate-sha256.js >> ../../SHA256",
@@ -97,7 +97,8 @@
       "main": "dist/index.js",
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "@salesforce/core": "^3.34.8"
+        "@salesforce/core": "^3.34.8",
+        "@salesforce/source-tracking": "3.1.1"
       },
       "devDependencies": {}
     }

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -54,7 +54,7 @@
     "vscode-uri": "1.0.1"
   },
   "scripts": {
-    "bundle:extension": "esbuild ./src/index.ts  --bundle --outfile=dist/index.js --format=cjs --platform=node --external:vscode  --external:@salesforce/core --external:applicationinsights --external:@salesforce/lightning-lsp-common --external:@salesforce/aura-language-server --minify",
+    "bundle:extension": "esbuild ./src/index.ts  --bundle --outfile=dist/index.js --format=cjs --platform=node --external:vscode  --external:@salesforce/core --external:@salesforce/source-tracking --external:applicationinsights --external:@salesforce/lightning-lsp-common --external:@salesforce/aura-language-server --minify",
     "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
     "compile": "tsc -p ./",
     "lint": "tslint --project .",
@@ -93,6 +93,7 @@
       "dependencies": {
         "applicationinsights": "1.0.7",
         "@salesforce/core": "^3.34.8",
+        "@salesforce/source-tracking": "3.1.1",
         "@salesforce/aura-language-server": "4.5.0",
         "@salesforce/lightning-lsp-common": "4.5.0"
       },

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -68,7 +68,7 @@
     "dbaeumer.vscode-eslint"
   ],
   "scripts": {
-    "bundle:extension": "esbuild ./src/index.ts  --bundle --outfile=dist/index.js --format=cjs --platform=node --loader:.node=file --external:vscode  --external:@salesforce/core --external:applicationinsights --external:@salesforce/lightning-lsp-common --external:@salesforce/lwc-language-serve --minify",
+    "bundle:extension": "esbuild ./src/index.ts  --bundle --outfile=dist/index.js --format=cjs --platform=node --loader:.node=file --external:vscode  --external:@salesforce/core --external:@salesforce/source-tracking --external:applicationinsights --external:@salesforce/lightning-lsp-common --external:@salesforce/lwc-language-serve --minify",
     "vscode:prepublish": "npm prune --production",
     "vscode:package": "ts-node -P ./tsconfig.json ../../scripts/vsce-bundled-extension.ts",
     "vscode:sha256": "node ../../scripts/generate-sha256.js >> ../../SHA256",
@@ -100,6 +100,7 @@
       "dependencies": {
         "applicationinsights": "1.0.7",
         "@salesforce/core": "^3.34.8",
+        "@salesforce/source-tracking": "3.1.1",
         "@salesforce/lightning-lsp-common": "4.5.0",
         "@salesforce/lwc-language-server": "4.5.0"
       },

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -75,7 +75,7 @@
     "vscode-languageclient": "6.1.3"
   },
   "scripts": {
-    "bundle:extension": "esbuild ./src/index.ts  --bundle --outfile=dist/index.js --format=cjs --platform=node --external:vscode  --external:@salesforce/core --external:applicationinsights --external:shelljs --external:@salesforce/soql-model --external:@salesforce/soql-language-server --external:@salesforce/soql-data-view --external:@salesforce/soql-builder-ui --minify",
+    "bundle:extension": "esbuild ./src/index.ts  --bundle --outfile=dist/index.js --format=cjs --platform=node --external:vscode  --external:@salesforce/core --external:@salesforce/source-tracking  --external:applicationinsights --external:shelljs --external:@salesforce/soql-model --external:@salesforce/soql-language-server --external:@salesforce/soql-data-view --external:@salesforce/soql-builder-ui --minify",
     "build": "npm run compile",
     "compile": "tsc -p ./",
     "lint": "eslint -c .eslintrc.json --ext .ts ./src",
@@ -122,6 +122,7 @@
         "applicationinsights": "1.0.7",
         "@salesforce/apex-tmlanguage": "1.6.0",
         "@salesforce/core": "^3.34.8",
+        "@salesforce/source-tracking": "3.1.1",
         "shelljs": "0.8.5",
         "@salesforce/soql-builder-ui": "0.2.0",
         "@salesforce/soql-data-view": "0.1.0",


### PR DESCRIPTION
### What does this PR do?
Update the extensions that use the salesforcedx-vscode-utils package to exclude `@salesforce/source-tracking` from the bundle.  

### What issues does this PR fix or reference?
Related to 
@W-11309172@
@W-13051164@

### Functionality Before
vsixes for several extensions failed to activate.

### Functionality After
all extensions activate. 
![Screenshot 2023-04-28 at 1 14 50 AM](https://user-images.githubusercontent.com/76090802/235068933-dcddbe2a-c9bf-42cc-a9db-785729460477.png)

