### PR TITLE
fix: Only Update Source Tracking After Retrieve When Org Type Is Source-Tracked

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
@@ -30,6 +30,7 @@ import { channelService, OUTPUT_CHANNEL } from '../channels';
 import { PersistentStorageService } from '../conflict/persistentStorageService';
 import { TELEMETRY_METADATA_COUNT } from '../constants';
 import { WorkspaceContext } from '../context';
+import { getWorkspaceOrgType, OrgType } from '../context/workspaceOrgType';
 import { handleDeployDiagnostics } from '../diagnostics';
 import { nls } from '../messages';
 import { setApiVersionOn } from '../services/sdr/componentSetUtils';
@@ -232,10 +233,13 @@ export abstract class RetrieveExecutor<T> extends DeployRetrieveExecutor<T> {
     this.setupCancellation(operation, token);
 
     const result: RetrieveResult = await operation.pollStatus();
-    await SourceTrackingService.updateSourceTrackingAfterRetrieve(
-      sourceTracking,
-      result
-    );
+    const orgType = await getWorkspaceOrgType();
+    if (orgType === OrgType.SourceTracked) {
+      await SourceTrackingService.updateSourceTrackingAfterRetrieve(
+        sourceTracking,
+        result
+      );
+    }
 
     return result;
   }


### PR DESCRIPTION
### What does this PR do?
* only makes the call to `sourceTracking.updateTrackingFromRetrieve()` when connected to a source-tracked org

### What issues does this PR fix or reference?
@W-13153391@

### Functionality Before
**NOTE: this behavior is currently only observed on the develop branch, and is not in released production VSCE.**
* If `sourceTracking.updateTrackingFromRetrieve()` is called when connected to a non source tracked org, it throws an error.
  * VSCE was not handling the error so it gets surfaced to users:

![2023-05-04_11-07-48 (1)](https://user-images.githubusercontent.com/46458081/236313615-de50e1a2-c25c-4905-83eb-b6d1b4ae2cde.gif)
  

### Functionality After
* VSCE does not call `sourceTracking.updateTrackingFromRetrieve()` when connected to a non source tracked org, avoiding the error. 
