### PR TITLE
fix: soql builder should not error when no default org

### DIFF
--- a/packages/salesforcedx-vscode-soql/src/sfdx.ts
+++ b/packages/salesforcedx-vscode-soql/src/sfdx.ts
@@ -34,15 +34,19 @@ export const debouncedShowChannelAndErrorMessage = debounce(
 );
 
 export async function withSFConnection(
-  f: (conn: Connection) => void
+  f: (conn: Connection) => void,
+  showErrorMessage = true
 ): Promise<void> {
   try {
     const conn = await workspaceContext.getConnection();
     return f((conn as unknown) as Connection);
   } catch (e) {
-    debouncedShowChannelAndErrorMessage(e);
+    if (showErrorMessage) {
+      debouncedShowChannelAndErrorMessage(e);
+    }
   }
 }
+
 export async function retrieveSObjects(): Promise<string[]> {
   let foundSObjectNames: string[] = [];
   await withSFConnection(async conn => {
@@ -69,10 +73,11 @@ export async function retrieveSObject(
 }
 
 workspaceContext.onOrgChange(async (orgInfo: any) => {
+  const showErrorMessage = !!orgInfo.username;
   await withSFConnection(conn => {
     conn.describeGlobal$.clear();
     conn.describe$.clear();
-  });
+  }, showErrorMessage);
 });
 
 export function onOrgChange(f: (orgInfo: any) => Promise<void>): void {

--- a/packages/salesforcedx-vscode-soql/src/sfdx.ts
+++ b/packages/salesforcedx-vscode-soql/src/sfdx.ts
@@ -72,13 +72,15 @@ export async function retrieveSObject(
   return name;
 }
 
-workspaceContext.onOrgChange(async (orgInfo: any) => {
+export async function onOrgChangeDefaultHandler(orgInfo: any) {
   const showErrorMessage = !!orgInfo.username;
   await withSFConnection(conn => {
     conn.describeGlobal$.clear();
     conn.describe$.clear();
   }, showErrorMessage);
-});
+}
+
+workspaceContext.onOrgChange(onOrgChangeDefaultHandler);
 
 export function onOrgChange(f: (orgInfo: any) => Promise<void>): void {
   workspaceContext.onOrgChange(f);

--- a/packages/salesforcedx-vscode-soql/test/jest/sfdx.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/sfdx.test.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as sfdx from '../../src/sfdx';
+
+describe('withSFConnection', () => {
+  function run(showErrorMessage: boolean) {
+    it(`should ${
+      showErrorMessage ? '' : 'not '
+    } show error message when showErrorMessage=${showErrorMessage}`, async () => {
+      const debouncedShowChannelAndErrorMessageSpy = jest.spyOn(
+        sfdx,
+        'debouncedShowChannelAndErrorMessage'
+      );
+
+      await sfdx.withSFConnection(jest.fn(), showErrorMessage);
+
+      expect(debouncedShowChannelAndErrorMessageSpy).toHaveBeenCalledTimes(
+        showErrorMessage ? 1 : 0
+      );
+    });
+  }
+
+  run(true);
+  run(false);
+});

--- a/packages/salesforcedx-vscode-soql/test/jest/sfdx.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/sfdx.test.ts
@@ -8,47 +8,51 @@
 import { OrgInfo } from '@salesforce/salesforcedx-utils';
 import * as sfdx from '../../src/sfdx';
 
-describe('withSFConnection', () => {
-  function run(showErrorMessage: boolean) {
-    it(`should ${
-      showErrorMessage ? '' : 'not '
-    } show error message when showErrorMessage=${showErrorMessage}`, async () => {
-      const debouncedShowChannelAndErrorMessageSpy = jest.spyOn(
-        sfdx,
-        'debouncedShowChannelAndErrorMessage'
-      );
+describe('sfdx utils', () => {
+  let debouncedShowChannelAndErrorMessageSpy;
 
-      await sfdx.withSFConnection(jest.fn(), showErrorMessage);
+  beforeEach(() => {
+    debouncedShowChannelAndErrorMessageSpy = jest
+      .spyOn(sfdx, 'debouncedShowChannelAndErrorMessage')
+      .mockImplementation(() => Promise.resolve());
+  });
 
-      expect(debouncedShowChannelAndErrorMessageSpy).toHaveBeenCalledTimes(
-        showErrorMessage ? 1 : 0
-      );
-    });
-  }
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
-  run(true);
-  run(false);
-});
+  describe('withSFConnection', () => {
+    function run(showErrorMessage: boolean) {
+      it(`should ${
+        showErrorMessage ? '' : 'not '
+      } show error message when showErrorMessage=${showErrorMessage}`, async () => {
+        await sfdx.withSFConnection(jest.fn(), showErrorMessage);
 
-describe('onOrgChangeDefaultHandler', () => {
-  function run(orgInfo: OrgInfo) {
-    const isDefaultOrgSet = !!orgInfo.username;
-    const maybeNot = isDefaultOrgSet ? '' : 'not ';
+        expect(debouncedShowChannelAndErrorMessageSpy).toHaveBeenCalledTimes(
+          showErrorMessage ? 1 : 0
+        );
+      });
+    }
 
-    it(`should ${maybeNot} show connection error message when default org is ${maybeNot} set`, async () => {
-      const debouncedShowChannelAndErrorMessageSpy = jest.spyOn(
-        sfdx,
-        'debouncedShowChannelAndErrorMessage'
-      );
+    run(true);
+    run(false);
+  });
 
-      await sfdx.onOrgChangeDefaultHandler(orgInfo);
+  describe('onOrgChangeDefaultHandler', () => {
+    function run(orgInfo: OrgInfo) {
+      const isDefaultOrgSet = !!orgInfo.username;
+      const maybeNot = isDefaultOrgSet ? '' : 'not ';
 
-      expect(debouncedShowChannelAndErrorMessageSpy).toHaveBeenCalledTimes(
-        isDefaultOrgSet ? 1 : 0
-      );
-    });
-  }
+      it(`should ${maybeNot} show connection error message when default org is ${maybeNot} set`, async () => {
+        await sfdx.onOrgChangeDefaultHandler(orgInfo);
 
-  run({ username: 'x' } as OrgInfo);
-  run({ username: undefined } as OrgInfo);
+        expect(debouncedShowChannelAndErrorMessageSpy).toHaveBeenCalledTimes(
+          isDefaultOrgSet ? 1 : 0
+        );
+      });
+    }
+
+    run({ username: 'x' } as OrgInfo);
+    run({ username: undefined } as OrgInfo);
+  });
 });

--- a/packages/salesforcedx-vscode-soql/test/jest/sfdx.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/sfdx.test.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { OrgInfo } from '@salesforce/salesforcedx-utils';
 import * as sfdx from '../../src/sfdx';
 
 describe('withSFConnection', () => {
@@ -27,4 +28,27 @@ describe('withSFConnection', () => {
 
   run(true);
   run(false);
+});
+
+describe('onOrgChangeDefaultHandler', () => {
+  function run(orgInfo: OrgInfo) {
+    const isDefaultOrgSet = !!orgInfo.username;
+    const maybeNot = isDefaultOrgSet ? '' : 'not ';
+
+    it(`should ${maybeNot} show connection error message when default org is ${maybeNot} set`, async () => {
+      const debouncedShowChannelAndErrorMessageSpy = jest.spyOn(
+        sfdx,
+        'debouncedShowChannelAndErrorMessage'
+      );
+
+      await sfdx.onOrgChangeDefaultHandler(orgInfo);
+
+      expect(debouncedShowChannelAndErrorMessageSpy).toHaveBeenCalledTimes(
+        isDefaultOrgSet ? 1 : 0
+      );
+    });
+  }
+
+  run({ username: 'x' } as OrgInfo);
+  run({ username: undefined } as OrgInfo);
 });

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/sfdx.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/sfdx.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/sfdx.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/sfdx.test.ts
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
@@ -14,16 +20,29 @@ describe('sfdx utils', () => {
     sandbox.restore();
   });
 
-  it('should display an error, channel log, and send telemetry if can not get connection to org', async () => {
-    sandbox.stub(sfdx.workspaceContext, 'getConnection').throws();
-    const vscodeErrorMessageSpy = sandbox.spy(
-      vscode.window,
-      'showErrorMessage'
-    );
-    const channelServiceSpy = sandbox.spy(sfdx.channelService, 'appendLine');
-    await sfdx.withSFConnection(async () => {});
-    sfdx.debouncedShowChannelAndErrorMessage.flush();
-    expect(vscodeErrorMessageSpy.callCount).to.equal(1);
-    expect(channelServiceSpy.callCount).to.equal(1);
+  describe('withSFConnection', () => {
+    function run(showErrorMessage: boolean) {
+      it(`should ${
+        showErrorMessage ? '' : 'not '
+      }display an error, channel log, and send telemetry if can not get connection to org when showErrorMessage=${showErrorMessage}`, async () => {
+        sandbox.stub(sfdx.workspaceContext, 'getConnection').throws();
+        const vscodeErrorMessageSpy = sandbox.spy(
+          vscode.window,
+          'showErrorMessage'
+        );
+        const channelServiceSpy = sandbox.spy(
+          sfdx.channelService,
+          'appendLine'
+        );
+        await sfdx.withSFConnection(async () => {}, showErrorMessage);
+        sfdx.debouncedShowChannelAndErrorMessage.flush();
+        const errorCount = showErrorMessage ? 1 : 0;
+        expect(vscodeErrorMessageSpy.callCount).to.equal(errorCount);
+        expect(channelServiceSpy.callCount).to.equal(errorCount);
+      });
+    }
+
+    run(true);
+    run(false);
   });
 });


### PR DESCRIPTION
### What does this PR do?

Suppresses the `error_connection` ("We can’t query your org") toast message when no default org is set when opening VS Code. It retains the message in other cases, such as when actually opening the SOQL builder or trying to query the org.

### What issues does this PR fix or reference?
@W-13131914@

### Functionality Before
When opening VS Code without a default org set, the SOQL extension would display an error on project load. Additional errors also shown when trying to open the SOQL builder or run a SOQL query.

### Functionality After
When opening VS Code without a default org set, no error is shown on project load. Errors are only shown when trying to open the SOQL builder or run a SOQL query.