### PR TITLE
build: update bundling for salesforce/templates

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -93,7 +93,7 @@
         "applicationinsights": "1.0.7",
         "@salesforce/apex-tmlanguage": "1.4.0",
         "@salesforce/core": "^3.34.8",
-        "@salesforce/templates": "57.0.2",
+        "@salesforce/templates": "^57.1.2",
         "@salesforce/source-deploy-retrieve": "^8.0.1",
         "shelljs": "0.8.5"
       },

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -88,7 +88,7 @@
         "@heroku/functions-core": "0.7.0",
         "@salesforce/core": "^3.34.8",
         "@salesforce/source-tracking": "3.1.1",
-        "@salesforce/templates": "57.0.2",
+        "@salesforce/templates": "^57.1.2",
         "@salesforce/source-deploy-retrieve": "^8.0.1",
         "shelljs": "0.8.5"
       },


### PR DESCRIPTION
### What does this PR do?
This is a follow-up to #4851 to include bundling updates. It was discovered during release testing that `@salesforce/templates` had not been included in the bundled updates for the extensions. 

### What issues does this PR fix or reference?
#4851 

### Functionality Before
Templates had not been updated in the bundled release.

### Functionality After
Templates will be updated correctly next week.
