### PR TITLE
perf: update to lightning language server performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6545,11 +6545,11 @@
       }
     },
     "node_modules/@salesforce/aura-language-server": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-4.6.0.tgz",
-      "integrity": "sha512-vm2W0Tr9WxmhbjkqdIQeXQgLxrkZmKaR+12BZSCWZYodv5MFArx/pg+Kj2iG/ZOvolpJz4VdSLA8ivZn7x40Ug==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-4.6.1.tgz",
+      "integrity": "sha512-MXZrJka3NwzUVDYWDCSni/IuQYuUr3CPCZpK5QnZ904dEK6OwkRwyrZtbUfCHwMG0XUtTx5LBoke2wlDBjRquA==",
       "dependencies": {
-        "@salesforce/lightning-lsp-common": "4.6.0",
+        "@salesforce/lightning-lsp-common": "4.6.1",
         "acorn": "^6.0.0",
         "acorn-loose": "^6.0.0",
         "acorn-walk": "^6.0.0",
@@ -7190,9 +7190,9 @@
       "integrity": "sha512-/ZiVwtVkmq2jWRRzgsC4SEy8m54gPaDc8e+jIfnIiR04iSeSRhYJxG+ktLSYVN2jMbVWA58HfEJSCx+73GcQCg=="
     },
     "node_modules/@salesforce/lightning-lsp-common": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-4.6.0.tgz",
-      "integrity": "sha512-gL5XZmc1/wzAVLkpJSM5i4entP5taIThnx6hhzxOzZJjiKUd6JEItBvWOOzainrk/1wF1Kdppcm9M0Q0m9pqYw==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-4.6.1.tgz",
+      "integrity": "sha512-Qf0SXNou5/bxelQDMzjdyoDkVU8QS87JaLX3qR64Y4oRe2iuidbPWWCmXhW/7zxExJUWVfnFPv9ls5g3+kM1mg==",
       "dependencies": {
         "decamelize": "^2.0.0",
         "deep-equal": "^1.0.1",
@@ -7276,9 +7276,9 @@
       "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
     },
     "node_modules/@salesforce/lwc-language-server": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-4.6.0.tgz",
-      "integrity": "sha512-PUydO1mZsBCGtGWLKS0JTnFX3Ye4CDFax+4IaRtWK7In08bA0zmlSFlaUPuVeUOQAwG+s4sDkirI6NzvVtRxMA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-4.6.1.tgz",
+      "integrity": "sha512-vV0y7HkUK/WnpOZKavsTZT7i4AQrEZAV2ylvEiixcQP0+IyMXQgpGcPtjOpbOXFYfetuxeR2Z1VL7fzCthnoBg==",
       "dependencies": {
         "@lwc/compiler": "0.34.8",
         "@lwc/engine-dom": "2.37.3",
@@ -7286,7 +7286,7 @@
         "@lwc/template-compiler": "2.37.3",
         "@salesforce/apex": "0.0.12",
         "@salesforce/label": "0.0.12",
-        "@salesforce/lightning-lsp-common": "4.6.0",
+        "@salesforce/lightning-lsp-common": "4.6.1",
         "@salesforce/resourceurl": "0.0.12",
         "@salesforce/schema": "0.0.12",
         "@salesforce/user": "0.0.12",
@@ -41672,9 +41672,9 @@
       "version": "57.14.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/aura-language-server": "4.6.0",
+        "@salesforce/aura-language-server": "4.6.1",
         "@salesforce/core": "^3.34.8",
-        "@salesforce/lightning-lsp-common": "4.6.0",
+        "@salesforce/lightning-lsp-common": "4.6.1",
         "@salesforce/salesforcedx-utils-vscode": "57.14.1",
         "applicationinsights": "1.0.7",
         "vscode-extension-telemetry": "0.0.17",
@@ -41742,8 +41742,8 @@
       "dependencies": {
         "@salesforce/core": "^3.34.8",
         "@salesforce/eslint-config-lwc": "3.3.3",
-        "@salesforce/lightning-lsp-common": "4.6.0",
-        "@salesforce/lwc-language-server": "4.6.0",
+        "@salesforce/lightning-lsp-common": "4.6.1",
+        "@salesforce/lwc-language-server": "4.6.1",
         "@salesforce/salesforcedx-utils-vscode": "57.14.1",
         "ajv": "6.12.6",
         "applicationinsights": "1.0.7",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -25,9 +25,9 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/aura-language-server": "4.6.0",
+    "@salesforce/aura-language-server": "4.6.1",
     "@salesforce/core": "^3.34.8",
-    "@salesforce/lightning-lsp-common": "4.6.0",
+    "@salesforce/lightning-lsp-common": "4.6.1",
     "@salesforce/salesforcedx-utils-vscode": "57.14.1",
     "applicationinsights": "1.0.7",
     "vscode-extension-telemetry": "0.0.17",
@@ -94,8 +94,8 @@
         "applicationinsights": "1.0.7",
         "@salesforce/core": "^3.34.8",
         "@salesforce/source-tracking": "3.1.1",
-        "@salesforce/aura-language-server": "4.6.0",
-        "@salesforce/lightning-lsp-common": "4.6.0"
+        "@salesforce/aura-language-server": "4.6.1",
+        "@salesforce/lightning-lsp-common": "4.6.1"
       },
       "devDependencies": {}
     }

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "@salesforce/core": "^3.34.8",
     "@salesforce/eslint-config-lwc": "3.3.3",
-    "@salesforce/lightning-lsp-common": "4.6.0",
-    "@salesforce/lwc-language-server": "4.6.0",
+    "@salesforce/lightning-lsp-common": "4.6.1",
+    "@salesforce/lwc-language-server": "4.6.1",
     "@salesforce/salesforcedx-utils-vscode": "57.14.1",
     "ajv": "6.12.6",
     "applicationinsights": "1.0.7",
@@ -101,8 +101,8 @@
         "applicationinsights": "1.0.7",
         "@salesforce/core": "^3.34.8",
         "@salesforce/source-tracking": "3.1.1",
-        "@salesforce/lightning-lsp-common": "4.6.0",
-        "@salesforce/lwc-language-server": "4.6.0"
+        "@salesforce/lightning-lsp-common": "4.6.1",
+        "@salesforce/lwc-language-server": "4.6.1"
       },
       "devDependencies": {}
     }


### PR DESCRIPTION
### What does this PR do?
Updates the lightning language server dependency to process stale components faster during initialization. 

### What issues does this PR fix or reference?
#4829, forcedotcom/lightning-language-server#568

### Functionality Before
Startup of projects with large LWCs was slowed significantly by reloading the list of components in a loop.

### Functionality After
These projects should now startup faster as that list is loaded in advance.
