### PR TITLE
feat: expose TelemetryService class in core API

### DIFF
--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -9,6 +9,7 @@ import {
   getRootWorkspacePath,
   SFDX_CORE_CONFIGURATION_NAME
 } from '@salesforce/salesforcedx-utils-vscode';
+import { TelemetryService } from '@salesforce/salesforcedx-utils-vscode';
 import * as fs from 'fs';
 import * as vscode from 'vscode';
 import { channelService } from './channels';
@@ -672,7 +673,10 @@ export async function activate(extensionContext: vscode.ExtensionContext) {
     SfdxWorkspaceChecker,
     WorkspaceContext,
     taskViewService,
-    telemetryService
+    telemetryService,
+    services: {
+      TelemetryService
+    }
   };
 
   registerFunctionInvokeCodeLensProvider(extensionContext);


### PR DESCRIPTION
Service will be used to report back telemetry data from within the GPT extension.


### What does this PR do?
Exposes the `TelemetryService` in the core API.

### What issues does this PR fix or reference?
@W-13218122@

### Functionality Before
Only the telemetry service which had been instantiated in the core extension was exposed via the API

### Functionality After
We have access to the TelemetryService class to instantiate and report from within the GPT extension.
