### PR TITLE
ci: update e2e gha to compile vs code

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -66,6 +66,7 @@ jobs:
         - name: Install Test Dependencies
           run: |
             npm install
+            npm run compile
           working-directory: salesforcedx-vscode-automation-tests
         - name: Install the SFDX CLI
           run: npm install -g sfdx-cli


### PR DESCRIPTION
### What does this PR do?
Adds the compile step for the e2e tests github action so the WDIO tests can run properly.

### What issues does this PR fix or reference?
@W-13186088@

### Functionality Before
Seeing early build failures in our e2e tests: https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/5124595477/jobs/9216629182

### Functionality After
The fundamentals are working: https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/5135713045
