### PR TITLE
fix: re-run pr validation

### DIFF
--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -1,7 +1,7 @@
 name: Validate PR
 on:
   pull_request:
-    types: [opened, reopened, edited]
+    types: [opened, reopened, edited, synchronize]
     branches: [develop]
 
 jobs:

--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -1,12 +1,13 @@
 name: Validate PR
 on:
   pull_request:
+    types: [opened, reopened, edited]
     branches: [develop]
 
 jobs:
   pr-validation:
     uses: salesforcecli/github-workflows/.github/workflows/validatePR.yml@main
-  code-quality: 
+  code-quality:
     strategy:
       matrix:
         node_version: [lts/-1]


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Runs the validate PR workflow when just the PR description is edited.
### What issues does this PR fix or reference?
https://github.com/forcedotcom/easywriter/issues/173, @W-13522251@

### Functionality Before
Validate PR workflow runs when commits are pushed to the branch.

### Functionality After
In addition to the existing functionality, Now Validate PR workflow also runs when just the PR description is edited with no commits pushed.
