### PR TITLE
feat: expose WorkspaceContext from core extension API

### DIFF
--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -676,7 +676,8 @@ export async function activate(extensionContext: vscode.ExtensionContext) {
     telemetryService,
     services: {
       ChannelService,
-      TelemetryService
+      TelemetryService,
+      WorkspaceContext
     }
   };
 


### PR DESCRIPTION
### What does this PR do?
* exposes WorkspaceContext, so that we can use the API from the core extension to access the connection to the default org in dependent extensions

### What issues does this PR fix or reference?
@W-13217600@

### Functionality Before
* workspace context was not exposed via the API

### Functionality After
* workspace context is exposed via the API
