### PR TITLE
feat: add authorize devhub to e2e gha

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,5 @@
 name: End to End Tests
-on: 
+on:
   workflow_dispatch:
     inputs:
       automationBranch:
@@ -86,11 +86,15 @@ jobs:
         - name: Run headless test
           uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3
           with:
-            run: npm run automation-tests
+            run: |
+              npm run setup
+              npm run automation-tests
             working-directory: salesforcedx-vscode-automation-tests
           env:
             VSCODE_VERSION: ${{ matrix.vscodeVersion }}
             SPEC_FILES: ${{ inputs.specFiles || '*.e2e.ts' }}
+            SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL_E2E }}
+            ORG_ID: ${{ secrets.ORG_ID_E2E }}
         - uses: actions/upload-artifact@v3
           if: failure()
           with:


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
- Adds a new command `npm run setup` before running any e2e test in step `Run headless test`
- Make use of two GHA secrets
### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @W-12516010@

### Functionality Before
No Authorization step before running e2e test.

### Functionality After
Authorize to a persistent testing org before running one / all e2e test.
