### PR TITLE
fix: changed export style of componentSetUtils.ts and added unit tests back in

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -630,20 +630,29 @@
       "internalConsoleOptions": "neverOpen"
     },
     {
-      "name": "Debug Tests - VSCode Core - Unit Tests",
-      "cwd": "${workspaceRoot}/packages/salesforcedx-vscode-core",
-      "type": "node",
-      "request": "launch",
-      "runtimeArgs": ["--inspect-brk", "${workspaceRoot}/packages/salesforcedx-vscode-core/node_modules/.bin/jest", "--runInBand", "--coverage", "false"],
-      "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen"
-    },
-    {
       "name": "Debug Tests - SObjects Faux Generator - Unit Tests",
       "cwd": "${workspaceRoot}/packages/salesforcedx-sobjects-faux-generator",
       "type": "node",
       "request": "launch",
       "runtimeArgs": ["--inspect-brk", "${workspaceRoot}/packages/salesforcedx-sobjects-faux-generator/node_modules/.bin/jest", "--runInBand", "--coverage", "false"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    },
+    {
+      "name": "Debug Tests - Utils VSCode - Unit Tests",
+      "cwd": "${workspaceRoot}/packages/salesforcedx-utils-vscode",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": ["--inspect-brk", "${workspaceRoot}/packages/salesforcedx-utils-vscode/node_modules/.bin/jest", "--runInBand", "--coverage", "false"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    },
+    {
+      "name": "Debug Tests - VSCode Core - Unit Tests",
+      "cwd": "${workspaceRoot}/packages/salesforcedx-vscode-core",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": ["--inspect-brk", "${workspaceRoot}/packages/salesforcedx-vscode-core/node_modules/.bin/jest", "--runInBand", "--coverage", "false"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
     }

--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
@@ -33,7 +33,7 @@ import { TELEMETRY_METADATA_COUNT } from '../constants';
 import { WorkspaceContext, workspaceContextUtils } from '../context';
 import { handleDeployDiagnostics } from '../diagnostics';
 import { nls } from '../messages';
-import { setApiVersion, setSourceApiVersion } from '../services/sdr/componentSetUtils';
+import { componentSetUtils } from '../services/sdr/componentSetUtils';
 import { DeployQueue, sfdxCoreSettings } from '../settings';
 import { SfdxPackageDirectories } from '../sfdxProject';
 import { createComponentCount, formatException } from './util';
@@ -62,8 +62,8 @@ export abstract class DeployRetrieveExecutor<
 
     try {
       const components = await this.getComponents(response);
-      await setApiVersion(components);
-      await setSourceApiVersion(components);
+      await componentSetUtils.setApiVersion(components);
+      await componentSetUtils.setSourceApiVersion(components);
 
       this.telemetry.addProperty(
         TELEMETRY_METADATA_COUNT,

--- a/packages/salesforcedx-vscode-core/src/conflict/metadataCacheService.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/metadataCacheService.ts
@@ -19,7 +19,7 @@ import * as shell from 'shelljs';
 import * as vscode from 'vscode';
 import { RetrieveExecutor } from '../commands/baseDeployRetrieve';
 import { WorkspaceContext } from '../context/workspaceContext';
-import { setApiVersion } from '../services/sdr/componentSetUtils';
+import { componentSetUtils } from '../services/sdr/componentSetUtils';
 import { SfdxPackageDirectories } from '../sfdxProject';
 import { workspaceUtils } from '../util';
 
@@ -138,7 +138,7 @@ export class MetadataCacheService {
     const components = comps || (await this.getSourceComponents());
     this.clearDirectory(this.cachePath, true);
 
-    await setApiVersion(components);
+    await componentSetUtils.setApiVersion(components);
     const connection = await WorkspaceContext.getInstance().getConnection();
     const operation = await components.retrieve({
       usernameOrConnection: connection,

--- a/packages/salesforcedx-vscode-core/src/services/sdr/componentSetUtils.ts
+++ b/packages/salesforcedx-vscode-core/src/services/sdr/componentSetUtils.ts
@@ -10,7 +10,7 @@ import { ComponentSet } from '@salesforce/source-deploy-retrieve';
 import { WorkspaceContext } from '../../context/workspaceContext';
 import { SfdxProjectConfig } from '../../sfdxProject';
 
-export async function setApiVersion(componentSet: ComponentSet): Promise<void> {
+async function setApiVersion(componentSet: ComponentSet): Promise<void> {
   // For a listing (and order of precedence) of how to retrieve the value of apiVersion,
   // see "apiVersion: Order of Precedence" in the "How API Version and Source API Version
   // Work in Salesforce CLI" doc.
@@ -25,13 +25,13 @@ export async function setApiVersion(componentSet: ComponentSet): Promise<void> {
   }
 
   // If no user-configured API Version is present, then get the version from the org.
-  const orgApiVersion = await module.exports.getOrgApiVersion();
+  const orgApiVersion = await componentSetUtils.getOrgApiVersion();
   componentSet.apiVersion = orgApiVersion && orgApiVersion.length > 0
     ? orgApiVersion
     : componentSet.apiVersion;
 }
 
-export async function setSourceApiVersion(componentSet: ComponentSet): Promise<void> {
+async function setSourceApiVersion(componentSet: ComponentSet): Promise<void> {
   // For a listing (and order of precedence) of how to retrieve the value of sourceApiVersion,
   // see "sourceApiVersion: Order of Precedence" in the "How API Version and Source API Version
   // Work in Salesforce CLI" doc.
@@ -54,21 +54,21 @@ export async function setSourceApiVersion(componentSet: ComponentSet): Promise<v
 
   // Next, if it still is not set, set it to the highest API version supported by the target org.
   if (!sourceApiVersion) {
-    const orgApiVersion = await module.exports.getOrgApiVersion();
+    const orgApiVersion = await componentSetUtils.getOrgApiVersion();
     sourceApiVersion = orgApiVersion;
   }
 
   componentSet.sourceApiVersion = sourceApiVersion;
 }
 
-export async function getOrgApiVersion(): Promise<string> {
+async function getOrgApiVersion(): Promise<string> {
   const connection = await WorkspaceContext.getInstance().getConnection();
   const apiVersion = connection.getApiVersion();
 
   return apiVersion;
 }
 
-module.exports = {
+export const componentSetUtils = {
   setApiVersion,
   setSourceApiVersion,
   getOrgApiVersion

--- a/packages/salesforcedx-vscode-core/src/services/sdr/componentSetUtils.ts
+++ b/packages/salesforcedx-vscode-core/src/services/sdr/componentSetUtils.ts
@@ -25,7 +25,7 @@ export async function setApiVersion(componentSet: ComponentSet): Promise<void> {
   }
 
   // If no user-configured API Version is present, then get the version from the org.
-  const orgApiVersion = await exports.getOrgApiVersion();
+  const orgApiVersion = await module.exports.getOrgApiVersion();
   componentSet.apiVersion = orgApiVersion && orgApiVersion.length > 0
     ? orgApiVersion
     : componentSet.apiVersion;
@@ -54,7 +54,7 @@ export async function setSourceApiVersion(componentSet: ComponentSet): Promise<v
 
   // Next, if it still is not set, set it to the highest API version supported by the target org.
   if (!sourceApiVersion) {
-    const orgApiVersion = await exports.getOrgApiVersion();
+    const orgApiVersion = await module.exports.getOrgApiVersion();
     sourceApiVersion = orgApiVersion;
   }
 
@@ -67,3 +67,9 @@ export async function getOrgApiVersion(): Promise<string> {
 
   return apiVersion;
 }
+
+module.exports = {
+  setApiVersion,
+  setSourceApiVersion,
+  getOrgApiVersion
+};

--- a/packages/salesforcedx-vscode-core/src/services/sdr/componentSetUtils.ts
+++ b/packages/salesforcedx-vscode-core/src/services/sdr/componentSetUtils.ts
@@ -25,7 +25,7 @@ export async function setApiVersion(componentSet: ComponentSet): Promise<void> {
   }
 
   // If no user-configured API Version is present, then get the version from the org.
-  const orgApiVersion = await getOrgApiVersion();
+  const orgApiVersion = await exports.getOrgApiVersion();
   componentSet.apiVersion = orgApiVersion && orgApiVersion.length > 0
     ? orgApiVersion
     : componentSet.apiVersion;
@@ -54,7 +54,7 @@ export async function setSourceApiVersion(componentSet: ComponentSet): Promise<v
 
   // Next, if it still is not set, set it to the highest API version supported by the target org.
   if (!sourceApiVersion) {
-    const orgApiVersion = await getOrgApiVersion();
+    const orgApiVersion = await exports.getOrgApiVersion();
     sourceApiVersion = orgApiVersion;
   }
 

--- a/packages/salesforcedx-vscode-core/test/jest/conflict/metadataCacheService.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/conflict/metadataCacheService.test.ts
@@ -7,7 +7,7 @@
 import { ComponentSet } from '@salesforce/source-deploy-retrieve';
 import { MetadataCacheService } from '../../../src/conflict';
 import { WorkspaceContext } from '../../../src/context';
-import * as sdrUtils from '../../../src/services/sdr/componentSetUtils';
+import { componentSetUtils } from '../../../src/services/sdr/componentSetUtils';
 
 describe('MetadataCacheService', () => {
   let getSourceComponentsStub: jest.SpyInstance;
@@ -32,9 +32,11 @@ describe('MetadataCacheService', () => {
         } as any);
       getSourceComponentsStub = jest
         .spyOn(MetadataCacheService.prototype, 'getSourceComponents');
+
       setApiVersionStub = jest
-        .spyOn(sdrUtils, 'setApiVersion')
+        .spyOn(componentSetUtils, 'setApiVersion')
         .mockImplementation(jest.fn());
+
       retrieveStub = jest
         .spyOn(dummyComponentSet, 'retrieve')
         .mockResolvedValue({} as any);

--- a/packages/salesforcedx-vscode-core/test/jest/services/sdr/componentSetUtils.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/services/sdr/componentSetUtils.test.ts
@@ -8,7 +8,7 @@
 import { ConfigUtil } from '@salesforce/salesforcedx-utils-vscode';
 import { ComponentSet } from '@salesforce/source-deploy-retrieve';
 import { WorkspaceContext } from '../../../../src/context/workspaceContext';
-import * as componentSetUtils from '../../../../src/services/sdr/componentSetUtils';
+import { componentSetUtils } from '../../../../src/services/sdr/componentSetUtils';
 import { SfdxProjectConfig } from '../../../../src/sfdxProject';
 
 describe('componentSetUtils', () => {
@@ -17,12 +17,6 @@ describe('componentSetUtils', () => {
   });
 
   describe('setApiVersion', () => {
-    it('should validate that apiVersion is set via ConfigUtil when present', async () => {
-      expect(1).toBe(1);
-      // TODO: needed to back this out for a hot fix.
-    });
-
-    /*
     it('should validate that apiVersion is set via ConfigUtil when present', async () => {
       // *** Set (faked) componentSet.sourceApiVersion
       const componentSet = new ComponentSet();
@@ -192,6 +186,5 @@ describe('componentSetUtils', () => {
       expect(orgApiVersion).toBe('60.0');
       expect(getInstanceMock).toHaveBeenCalled();
     });
-  */
   });
 });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
@@ -39,7 +39,6 @@ import { basename, dirname, join, sep } from 'path';
 import { SinonSpy, SinonStub, spy } from 'sinon';
 import * as vscode from 'vscode';
 import { channelService } from '../../../src/channels';
-import { ForceSourcePushExecutor } from '../../../src/commands';
 import {
   DeployExecutor,
   DeployRetrieveExecutor,
@@ -49,7 +48,7 @@ import { PersistentStorageService } from '../../../src/conflict/persistentStorag
 import { WorkspaceContext } from '../../../src/context';
 import { getAbsoluteFilePath } from '../../../src/diagnostics';
 import { nls } from '../../../src/messages';
-import * as componentSetUtils from '../../../src/services/sdr/componentSetUtils';
+import { componentSetUtils } from '../../../src/services/sdr/componentSetUtils';
 import { DeployQueue } from '../../../src/settings';
 import { SfdxPackageDirectories } from '../../../src/sfdxProject';
 import { workspaceUtils } from '../../../src/util';


### PR DESCRIPTION
### What does this PR do?
This PR adds the unit tests for componentSetUtils.ts back in.  In order to do so:
1. The way function are exported in componentSetUtils.ts was changed
2. How the functions in componentSetUtils are imported was changed to reflect the new export style
3. The unit tests for componentSetUtils was aded back in.


### What issues does this PR fix or reference?
https://github.com/forcedotcom/salesforcedx-vscode/issues/4938, @W-10273533@
