### PR TITLE
chore: add unit tests on mac

### DIFF
--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -15,3 +15,7 @@ jobs:
     uses: ./.github/workflows/unitTestsWindows.yml
     with:
       branch: ${{ inputs.branch }}
+  mac-unit-tests:
+    uses: ./.github/workflows/unitTestsMac.yml
+    with:
+      branch: ${{ inputs.branch }}

--- a/.github/workflows/unitTestsMac.yml
+++ b/.github/workflows/unitTestsMac.yml
@@ -1,0 +1,29 @@
+name: Unit Tests Mac
+on:
+  workflow_call:
+    inputs:
+      branch:
+        type: string
+        required: false
+env:
+  NODE_OPTIONS: --max-old-space-size=8192
+
+jobs:
+  mac-unit-tests:
+    strategy:
+      matrix:
+        node_version: [lts/-1, lts/*]
+      fail-fast: false
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node_version }}
+          cache: npm
+      - run: npm ci
+      - run: npm run compile
+      - run: npm run test:unit


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
 Adds a workflow to run Unit Tests on macOs env.
 Adding the workflow to debug corev4 upgrade. As the unit tests are failing only on GH and not on local. Want to see the unit tests run on mac runners.
### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @W-13751160@

### Functionality Before
Unit Tests run on windows and linux runners

### Functionality After
Unit Tests run on windows, linux as well as mac runners
