### PR TITLE
feat: replace sfdx to sf style flag name

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
@@ -79,9 +79,9 @@ export class IsvDebugBootstrapExecutor extends SfdxCommandletExecutor<{}> {
   public buildCreateProjectCommand(data: IsvDebugBootstrapConfig): Command {
     return new SfdxCommandBuilder()
       .withDescription(nls.localize('isv_debug_bootstrap_step1_create_project'))
-      .withArg('force:project:create')
-      .withFlag('--projectname', data.projectName)
-      .withFlag('--outputdir', data.projectUri)
+      .withArg('project generate')
+      .withFlag('--name', data.projectName)
+      .withFlag('--output-dir', data.projectUri)
       .withFlag('--template', 'standard')
       .withLogName('isv_debug_bootstrap_create_project')
       .build();
@@ -92,10 +92,10 @@ export class IsvDebugBootstrapExecutor extends SfdxCommandletExecutor<{}> {
       .withDescription(
         nls.localize('isv_debug_bootstrap_step2_configure_project')
       )
-      .withArg('force:config:set')
-      .withArg(`isvDebuggerSid=${data.sessionId}`)
-      .withArg(`isvDebuggerUrl=${data.loginUrl}`)
-      .withArg(`instanceUrl=${data.loginUrl}`)
+      .withArg('config set')
+      .withArg(`org-isv-debugger-sid=${data.sessionId}`)
+      .withArg(`org-isv-debugger-url=${data.loginUrl}`)
+      .withArg(`org-instance-url=${data.loginUrl}`)
       .withLogName('isv_debug_bootstrap_configure_project')
       .build();
   }
@@ -109,9 +109,9 @@ export class IsvDebugBootstrapExecutor extends SfdxCommandletExecutor<{}> {
           'isv_debug_bootstrap_step2_configure_project_retrieve_namespace'
         )
       )
-      .withArg('force:data:soql:query')
+      .withArg('data query')
       .withFlag('--query', 'SELECT NamespacePrefix FROM Organization LIMIT 1')
-      .withFlag('--targetusername', data.sessionId)
+      .withFlag('--target-org', data.sessionId)
       .withJson()
       .withLogName('isv_debug_bootstrap_configure_project_retrieve_namespace')
       .build();
@@ -138,10 +138,10 @@ export class IsvDebugBootstrapExecutor extends SfdxCommandletExecutor<{}> {
       .withDescription(
         nls.localize('isv_debug_bootstrap_step3_retrieve_org_source')
       )
-      .withArg('force:mdapi:retrieve')
-      .withFlag('--retrievetargetdir', this.relativeMetdataTempPath)
-      .withFlag('--unpackaged', this.relativeApexPackageXmlPath)
-      .withFlag('--targetusername', data.sessionId)
+      .withArg('project retrieve start')
+      .withFlag('--target-metadata-dir', this.relativeMetdataTempPath)
+      .withFlag('--manifest', this.relativeApexPackageXmlPath)
+      .withFlag('--target-org', data.sessionId)
       .withLogName('isv_debug_bootstrap_retrieve_org_source')
       .build();
   }
@@ -153,12 +153,12 @@ export class IsvDebugBootstrapExecutor extends SfdxCommandletExecutor<{}> {
       .withDescription(
         nls.localize('isv_debug_bootstrap_step4_convert_org_source')
       )
-      .withArg('force:mdapi:convert')
+      .withArg('project convert mdapi')
       .withFlag(
-        '--rootdir',
+        '--root-dir',
         path.join(this.relativeMetdataTempPath, 'unpackaged')
       )
-      .withFlag('--outputdir', 'force-app')
+      .withFlag('--output-dir', 'force-app')
       .withLogName('isv_debug_bootstrap_convert_org_source')
       .build();
   }
@@ -185,10 +185,10 @@ export class IsvDebugBootstrapExecutor extends SfdxCommandletExecutor<{}> {
       .withDescription(
         nls.localize('isv_debug_bootstrap_step6_retrieve_packages_source')
       )
-      .withArg('force:mdapi:retrieve')
-      .withFlag('--retrievetargetdir', this.relativeMetdataTempPath)
-      .withFlag('--packagenames', packageNames.join(','))
-      .withFlag('--targetusername', data.sessionId)
+      .withArg('project retrieve start')
+      .withFlag('--target-metadata-dir', this.relativeMetdataTempPath)
+      .withFlag('--package-name', packageNames.join(','))
+      .withFlag('--target-org', data.sessionId)
       .withLogName('isv_debug_bootstrap_retrieve_packages_source')
       .build();
   }
@@ -203,13 +203,13 @@ export class IsvDebugBootstrapExecutor extends SfdxCommandletExecutor<{}> {
           packageName
         )
       )
-      .withArg('force:mdapi:convert')
+      .withArg('project convert mdapi')
       .withFlag(
-        '--rootdir',
+        '--root-dir',
         path.join(this.relativeMetdataTempPath, 'packages', packageName)
       )
       .withFlag(
-        '--outputdir',
+        '--output-dir',
         path.join(this.relativeInstalledPackagesPath, packageName)
       )
       .withLogName('isv_debug_bootstrap_convert_package_source')

--- a/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
@@ -170,8 +170,8 @@ export class IsvDebugBootstrapExecutor extends SfdxCommandletExecutor<{}> {
       .withDescription(
         nls.localize('isv_debug_bootstrap_step5_list_installed_packages')
       )
-      .withArg('force:package:installed:list')
-      .withFlag('--targetusername', data.sessionId)
+      .withArg('package installed list')
+      .withFlag('--target-org', data.sessionId)
       .withJson()
       .withLogName('isv_debug_bootstrap_list_installed_packages')
       .build();

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/isvdebugger/bootstrapCmd.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/isvdebugger/bootstrapCmd.test.ts
@@ -162,7 +162,7 @@ describe('ISV Debugging Project Bootstrap Command', () => {
         }
       );
       expect(createCommand.toCommand()).to.equal(
-        `sfdx force:project:create --projectname ${PROJECT_NAME} --outputdir ${PROJECT_DIR[0].fsPath} --template standard`
+        `sfdx project generate --name ${PROJECT_NAME} --output-dir ${PROJECT_DIR[0].fsPath} --template standard`
       );
       expect(createCommand.description).to.equal(
         nls.localize('isv_debug_bootstrap_step1_create_project')
@@ -182,7 +182,7 @@ describe('ISV Debugging Project Bootstrap Command', () => {
         }
       );
       expect(configureCommand.toCommand()).to.equal(
-        `sfdx force:config:set isvDebuggerSid=${SESSION_ID} isvDebuggerUrl=${LOGIN_URL} instanceUrl=${LOGIN_URL}`
+        `sfdx config set org-isv-debugger-sid=${SESSION_ID} org-isv-debugger-url=${LOGIN_URL} org-instance-url=${LOGIN_URL}`
       );
       expect(configureCommand.description).to.equal(
         nls.localize('isv_debug_bootstrap_step2_configure_project')
@@ -202,7 +202,7 @@ describe('ISV Debugging Project Bootstrap Command', () => {
         }
       );
       expect(command.toCommand()).to.equal(
-        `sfdx force:data:soql:query --query SELECT NamespacePrefix FROM Organization LIMIT 1 --targetusername ${SESSION_ID} --json --loglevel fatal`
+        `sfdx data query --query SELECT NamespacePrefix FROM Organization LIMIT 1 --target-org ${SESSION_ID} --json --loglevel fatal`
       );
       expect(command.description).to.equal(
         nls.localize(
@@ -236,7 +236,7 @@ describe('ISV Debugging Project Bootstrap Command', () => {
         projectTemplate: 'standard'
       });
       expect(command.toCommand()).to.equal(
-        `sfdx force:mdapi:retrieve --retrievetargetdir ${builder.relativeMetdataTempPath} --unpackaged ${builder.relativeApexPackageXmlPath} --targetusername ${SESSION_ID}`
+        `sfdx project retrieve start target-metadata-dir ${builder.relativeMetdataTempPath} --manifest ${builder.relativeApexPackageXmlPath} --target-org ${SESSION_ID}`
       );
       expect(command.description).to.equal(
         nls.localize('isv_debug_bootstrap_step3_retrieve_org_source')
@@ -254,10 +254,10 @@ describe('ISV Debugging Project Bootstrap Command', () => {
         projectTemplate: projectTemplateEnum.standard
       });
       expect(command.toCommand()).to.equal(
-        `sfdx force:mdapi:convert --rootdir ${path.join(
+        `sfdx project convert mdapi --root-dir ${path.join(
           builder.relativeMetdataTempPath,
           'unpackaged'
-        )} --outputdir force-app`
+        )} --output-dir force-app`
       );
       expect(command.description).to.equal(
         nls.localize('isv_debug_bootstrap_step4_convert_org_source')
@@ -275,7 +275,7 @@ describe('ISV Debugging Project Bootstrap Command', () => {
         projectTemplate: projectTemplateEnum.standard
       });
       expect(command.toCommand()).to.equal(
-        `sfdx force:package:installed:list --targetusername ${SESSION_ID} --json --loglevel fatal`
+        `sfdx package installed list --target-org ${SESSION_ID} --json --loglevel fatal`
       );
       expect(command.description).to.equal(
         nls.localize('isv_debug_bootstrap_step5_list_installed_packages')
@@ -297,7 +297,7 @@ describe('ISV Debugging Project Bootstrap Command', () => {
         packageNames
       );
       expect(command.toCommand()).to.equal(
-        `sfdx force:mdapi:retrieve --retrievetargetdir ${builder.relativeMetdataTempPath} --packagenames mypackage_abc,mpackage_def --targetusername ${SESSION_ID}`
+        `sfdx project retrieve start target-metadata-dir ${builder.relativeMetdataTempPath} --package-name mypackage_abc,mpackage_def --target-org ${SESSION_ID}`
       );
       expect(command.description).to.equal(
         nls.localize('isv_debug_bootstrap_step6_retrieve_packages_source')
@@ -311,11 +311,11 @@ describe('ISV Debugging Project Bootstrap Command', () => {
         packageName
       );
       expect(command.toCommand()).to.equal(
-        `sfdx force:mdapi:convert --rootdir ${path.join(
+        `sfdx project convert mdapi --root-dir ${path.join(
           builder.relativeMetdataTempPath,
           'packages',
           packageName
-        )} --outputdir ${path.join(
+        )} --output-dir ${path.join(
           builder.relativeInstalledPackagesPath,
           packageName
         )}`

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/isvdebugger/bootstrapCmd.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/isvdebugger/bootstrapCmd.test.ts
@@ -236,7 +236,7 @@ describe('ISV Debugging Project Bootstrap Command', () => {
         projectTemplate: 'standard'
       });
       expect(command.toCommand()).to.equal(
-        `sfdx project retrieve start target-metadata-dir ${builder.relativeMetdataTempPath} --manifest ${builder.relativeApexPackageXmlPath} --target-org ${SESSION_ID}`
+        `sfdx project retrieve start --target-metadata-dir ${builder.relativeMetdataTempPath} --manifest ${builder.relativeApexPackageXmlPath} --target-org ${SESSION_ID}`
       );
       expect(command.description).to.equal(
         nls.localize('isv_debug_bootstrap_step3_retrieve_org_source')
@@ -297,7 +297,7 @@ describe('ISV Debugging Project Bootstrap Command', () => {
         packageNames
       );
       expect(command.toCommand()).to.equal(
-        `sfdx project retrieve start target-metadata-dir ${builder.relativeMetdataTempPath} --package-name mypackage_abc,mpackage_def --target-org ${SESSION_ID}`
+        `sfdx project retrieve start --target-metadata-dir ${builder.relativeMetdataTempPath} --package-name mypackage_abc,mpackage_def --target-org ${SESSION_ID}`
       );
       expect(command.description).to.equal(
         nls.localize('isv_debug_bootstrap_step6_retrieve_packages_source')


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Upgrades deprecated cli flags to new flags.
Removes warnings while setting up the ISV debugger

### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @W-13834204@

### Changes
| Old style  | New style |
|--------|--------|
| --outputdir | --output-dir |
| --projectname | --name |
| --targetusername | --target-org |
| --retrievetargetdir | --target-metadata-dir |
| --unpackaged | --manifest |
|--packagenames | --package-name |
isvDebuggerSid | org-isv-debugger-sid
isvDebuggerUrl |org-isv-debugger-url
instanceUrl |org-instance-url


### Functionality After
Cli warnings should go away

Docs for reference: https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_mdapi.htm#cli_reference_force_mdapi_retrieve