### PR TITLE
chore: fix int test

### DIFF
--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcPreview.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcPreview.test.ts
@@ -149,6 +149,7 @@ describe('forceLightningLwcPreview', () => {
   let existsSyncStub: sinon.SinonStub<[fs.PathLike], boolean>;
   let lstatSyncStub: sinon.SinonStub<[fs.PathLike], fs.Stats>;
   let showErrorMessageStub: sinon.SinonStub;
+  let isSFDXContainerModeStub: sinon.SinonStub;
   const root = /^win32/.test(process.platform) ? 'c:\\' : '/var';
   const mockLwcFileDirectory = path.join(
     root,
@@ -317,6 +318,7 @@ describe('forceLightningLwcPreview', () => {
       'streamCommandOutput'
     );
     appendLineSpy = sinon.spy(ChannelService.prototype, 'appendLine');
+    isSFDXContainerModeStub.returns(false);
   });
 
   afterEach(() => {


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Fixes the failing LWC integration tests.
### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @ W-13848833@

### Functionality Before
`isSFDXContainerModeStub` was missing from ForceLightningLwcPreview integration tests

### Functionality After
Added `isSFDXContainerModeStub` to ForceLightningLwcPreview integration tests
