### PR TITLE
chore: remove pinned vsc version from int test run

### DIFF
--- a/.github/workflows/integrationTestsWindows.yml
+++ b/.github/workflows/integrationTestsWindows.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 60
     env:
-      CODE_VERSION: 1.74.3
+      CODE_VERSION: stable
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v3


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Replaces the `1.74.3` pinned version of vscode with `stable` in IntegrationTestsWindows.yml
Now it allows the win integration tests to run on latest stable version of vscode.
### What issues does this PR fix or reference?
 @W-12498824@

### Functionality Before
Win Integration tests were run on vscode v1.74.3

### Functionality After
Win Integration tests run on latest stable version

Reference: #[VSCode Issue](https://github.com/microsoft/vscode/issues/181528)