### PR TITLE
fix: apex ls for java 1.8+

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/languageServer.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageServer.ts
@@ -75,7 +75,7 @@ async function createServer(
         '-Dtrace.protocol=false',
         `-Dapex.lsp.root.log.level=${LANGUAGE_SERVER_LOG_LEVEL}`,
         `-agentlib:jdwp=transport=dt_socket,server=y,suspend=${SUSPEND_LANGUAGE_SERVER_STARTUP ? 'y' : 'n'
-        },address=*:${JDWP_DEBUG_PORT},quiet=y`
+        },address=${JDWP_DEBUG_PORT},quiet=y`
       );
       if (process.env.YOURKIT_PROFILER_AGENT) {
         if (SUSPEND_LANGUAGE_SERVER_STARTUP) {


### PR DESCRIPTION
### What does this PR do?
Update apex language server jar for customers that cannot upgrade java 1.8 to another supported jre

### What issues does this PR fix or reference?
@W-14016188@

### Functionality Before
Customers with java 1.8 could not get the language server to start

### Functionality After
Java 1.8 user should be able to launch the apex language server.