### PR TITLE
chore: unschedule creation of release branch

### DIFF
--- a/.github/workflows/createReleaseBranch.yml
+++ b/.github/workflows/createReleaseBranch.yml
@@ -3,8 +3,8 @@ name: Create Release Branch
 on:
   repository_dispatch:
     types: create_release_branch
-  schedule:
-    - cron: '0 13 * * 1'
+  # schedule:
+  # - cron: '0 13 * * 1'
   workflow_dispatch:
     inputs:
       releaseType:


### PR DESCRIPTION
### What does this PR do?
- Removes the setup to schedule weekly creations of release branch

### Functionality Before
- Release branch is created automatically every mondyat at 1 pm

### Functionality After
- Release branch is created on demand

[skip-validate-pr]
