### PR TITLE
chore: Set Default For Telemetry Service aiKey Param

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/telemetry/telemetry.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/telemetry.ts
@@ -56,7 +56,7 @@ export class TelemetryService {
   private static instance: TelemetryService;
   private extensionContext: ExtensionContext | undefined;
   private reporter: TelemetryReporter | undefined;
-  private aiKey: string = '';
+  private aiKey: string = 'ec3632a4-df47-47a4-98dc-8134cacbaf7e';
   private version: string = '';
   /**
    * Cached promise to check if CLI telemetry config is enabled
@@ -79,13 +79,13 @@ export class TelemetryService {
   public async initializeService(
     extensionContext: ExtensionContext,
     extensionName: string,
-    aiKey: string,
-    version: string
+    version: string,
+    aiKey?: string
   ): Promise<void> {
     this.extensionContext = extensionContext;
     this.extensionName = extensionName;
-    this.aiKey = aiKey;
     this.version = version;
+    this.aiKey = aiKey || this.aiKey;
 
     this.checkCliTelemetry()
       .then(async cliEnabled => {

--- a/packages/salesforcedx-utils-vscode/test/unit/telemetry/telemetry.dev.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/unit/telemetry/telemetry.dev.test.ts
@@ -58,7 +58,6 @@ describe('Telemetry dev mode', () => {
     await telemetryService.initializeService(
       mockExtensionContext as any,
       extensionName,
-      'fakeAPIKey',
       'fakeVersion'
     );
 
@@ -74,7 +73,6 @@ describe('Telemetry dev mode', () => {
     await telemetryService.initializeService(
       mockExtensionContext as any,
       extensionName,
-      'fakeApiKey',
       'fakeVersion'
     );
 

--- a/packages/salesforcedx-vscode-apex/src/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/index.ts
@@ -80,8 +80,8 @@ export async function activate(extensionContext: vscode.ExtensionContext) {
   await telemetryService.initializeService(
     extensionContext,
     APEX_EXTENSION_NAME,
-    extensionPackage.aiKey,
-    extensionPackage.version
+    extensionPackage.version,
+    extensionPackage.aiKey
   );
 
   // start the language server and client

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -568,12 +568,12 @@ export async function activate(extensionContext: vscode.ExtensionContext) {
   // thus avoiding the potential errors surfaced when the libs call
   // process.cwd().
   ensureCurrentWorkingDirIsProjectPath(rootWorkspacePath);
-  const { name, aiKey, version } = extensionContext.extension.packageJSON;
+  const { name, version, aiKey } = extensionContext.extension.packageJSON;
   await telemetryService.initializeService(
     extensionContext,
     name,
-    aiKey,
-    version
+    version,
+    aiKey
   );
   showTelemetryMessage(extensionContext);
 

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/telemetry/index.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/telemetry/index.test.ts
@@ -50,8 +50,8 @@ describe('Telemetry', () => {
       await telemetryService.initializeService(
         mockExtensionContext,
         'ext_name',
-        'testKey007',
-        'v0.0.1'
+        'v0.0.1',
+        'testKey007'
       );
 
       const telemetryReporter = telemetryService.getReporter();
@@ -67,8 +67,8 @@ describe('Telemetry', () => {
       await telemetryService.initializeService(
         mockExtensionContext,
         'ext_name',
-        'testKey007',
-        'v0.0.1'
+        'v0.0.1',
+        'testKey007'
       );
 
       const telemetryEnabled = await telemetryService.isTelemetryEnabled();
@@ -86,8 +86,8 @@ describe('Telemetry', () => {
       await telemetryService.initializeService(
         mockExtensionContext,
         'ext_name',
-        'testKey007',
-        'v0.0.1'
+        'v0.0.1',
+        'testKey007'
       );
 
       const telemetryEnabled = await telemetryService.isTelemetryEnabled();
@@ -105,8 +105,8 @@ describe('Telemetry', () => {
       await telemetryService.initializeService(
         mockExtensionContext,
         'ext_name',
-        'testKey007',
-        'v0.0.1'
+        'v0.0.1',
+        'testKey007'
       );
 
       expect(teleStub.firstCall.args).to.eql([false]);
@@ -145,8 +145,8 @@ describe('Telemetry', () => {
       await telemetryService.initializeService(
         mockExtensionContext,
         'ext_name',
-        'testKey007',
-        'v0.0.1'
+        'v0.0.1',
+        'testKey007'
       );
 
       const telemetryEnabled = await telemetryService.isTelemetryEnabled();
@@ -164,8 +164,8 @@ describe('Telemetry', () => {
       await telemetryService.initializeService(
         mockExtensionContext,
         'ext_name',
-        'testKey007',
-        'v0.0.1'
+        'v0.0.1',
+        'testKey007'
       );
 
       const telemetryEnabled = await telemetryService.isTelemetryEnabled();

--- a/packages/salesforcedx-vscode-lightning/src/index.ts
+++ b/packages/salesforcedx-vscode-lightning/src/index.ts
@@ -89,8 +89,8 @@ export async function activate(extensionContext: ExtensionContext) {
   await TelemetryService.getInstance().initializeService(
     extensionContext,
     name,
-    aiKey,
-    version
+    version,
+    aiKey
   );
 
   // Start the Aura Language Server

--- a/packages/salesforcedx-vscode-lwc/src/index.ts
+++ b/packages/salesforcedx-vscode-lwc/src/index.ts
@@ -63,8 +63,8 @@ export async function activate(extensionContext: ExtensionContext) {
   await telemetryService.initializeService(
     extensionContext,
     LWC_EXTENSION_NAME,
-    aiKey,
-    version
+    version,
+    aiKey
   );
 
   // if we have no workspace folders, exit

--- a/packages/salesforcedx-vscode-soql/src/telemetry/index.ts
+++ b/packages/salesforcedx-vscode-soql/src/telemetry/index.ts
@@ -24,8 +24,8 @@ export async function startTelemetry(
   await telemetryService.initializeService(
     extensionContext,
     extensionPackage.name,
-    extensionPackage.aiKey,
-    extensionPackage.version
+    extensionPackage.version,
+    extensionPackage.aiKey
   );
   telemetryService.sendExtensionActivationEvent(hrtime);
 }


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
As a developer, to avoid copying the `aikey` to every new extension that utilizes the Telemetry Service from Core Library we should set a default key that the Telemetry Service will utilize if none is provided on instantiation.


### What issues does this PR fix or reference?
@W-13485911@

### Functionality Before
Require to pass in aiKey when instantiating the Telemetry Service 

### Functionality After
aiKey is an optional param and it's set with a default value on instantiation of Telemetry Service 
