### PR TITLE
chore: bump lls version to 4.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7183,11 +7183,11 @@
       }
     },
     "node_modules/@salesforce/aura-language-server": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-4.7.0.tgz",
-      "integrity": "sha512-eu0gpb9CAZJFz49K887CsFBmCvLY4sSoUEItAaU2XuuXT0aspCFOOWtbUV4p8gwqAJhJAVWl47IsEDRCCODIsQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-4.7.1.tgz",
+      "integrity": "sha512-HAzrwhs4GjpHh4zezIounz7pqKbfGWcsZrls1WqbfuFDG55IhmcwqVDT+S/xsouiwUpOllU5mr6yvKYZh1B00Q==",
       "dependencies": {
-        "@salesforce/lightning-lsp-common": "4.7.0",
+        "@salesforce/lightning-lsp-common": "4.7.1",
         "acorn": "^6.0.0",
         "acorn-loose": "^6.0.0",
         "acorn-walk": "^6.0.0",
@@ -7655,9 +7655,9 @@
       "integrity": "sha512-/ZiVwtVkmq2jWRRzgsC4SEy8m54gPaDc8e+jIfnIiR04iSeSRhYJxG+ktLSYVN2jMbVWA58HfEJSCx+73GcQCg=="
     },
     "node_modules/@salesforce/lightning-lsp-common": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-4.7.0.tgz",
-      "integrity": "sha512-A9s5CVFkFUA4lY/9thrDo6/FCapotc+8nzUFNfJGFH6tN+QEKawH8QYyCz13p1zvjLuo2X7uaWfibUki6ba5fA==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-4.7.1.tgz",
+      "integrity": "sha512-ewV613EdMMjBGt13UsfCj8Omsz3cMpuODmyDzHvcmJfjUSLcoeYsmeTC0BJjzZXnBD3iWyYBo1ckB+rPH6dYnQ==",
       "dependencies": {
         "decamelize": "^2.0.0",
         "deep-equal": "^1.0.1",
@@ -7763,9 +7763,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@salesforce/lwc-language-server": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-4.7.0.tgz",
-      "integrity": "sha512-Ch7cR5UzeCnHntm/2P8b7yT6gsO+DkEDtCMSatFtDvJvjtPbYShdGoGPDmyv9cqwBU81D57BIJ7Pl3lbIVurug==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-4.7.1.tgz",
+      "integrity": "sha512-nCDWUks+vaIwdZETu0fv1dnShoNZ0G2YFLBkfp7dAiL2i5R9GnoluiYkdKrtqc/mM+2PE88GpqGFzgHPm/jPZQ==",
       "dependencies": {
         "@lwc/compiler": "2.50.0",
         "@lwc/engine-dom": "2.50.0",
@@ -7775,7 +7775,7 @@
         "@lwc/template-compiler": "2.50.0",
         "@salesforce/apex": "0.0.12",
         "@salesforce/label": "0.0.12",
-        "@salesforce/lightning-lsp-common": "4.7.0",
+        "@salesforce/lightning-lsp-common": "4.7.1",
         "@salesforce/resourceurl": "0.0.12",
         "@salesforce/schema": "0.0.12",
         "@salesforce/user": "0.0.12",
@@ -27894,6 +27894,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -27908,16 +27909,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -27931,6 +27935,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -27946,6 +27951,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -40139,9 +40145,9 @@
       "version": "58.15.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/aura-language-server": "4.7.0",
+        "@salesforce/aura-language-server": "4.7.1",
         "@salesforce/core": "4.3.11",
-        "@salesforce/lightning-lsp-common": "4.7.0",
+        "@salesforce/lightning-lsp-common": "4.7.1",
         "@salesforce/salesforcedx-utils-vscode": "58.15.0",
         "applicationinsights": "1.0.7",
         "vscode-extension-telemetry": "0.0.17",
@@ -40209,8 +40215,8 @@
       "dependencies": {
         "@salesforce/core": "4.3.11",
         "@salesforce/eslint-config-lwc": "3.3.3",
-        "@salesforce/lightning-lsp-common": "4.7.0",
-        "@salesforce/lwc-language-server": "4.7.0",
+        "@salesforce/lightning-lsp-common": "4.7.1",
+        "@salesforce/lwc-language-server": "4.7.1",
         "@salesforce/salesforcedx-utils-vscode": "58.15.0",
         "ajv": "6.12.6",
         "applicationinsights": "1.0.7",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -24,9 +24,9 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/aura-language-server": "4.7.0",
+    "@salesforce/aura-language-server": "4.7.1",
     "@salesforce/core": "4.3.11",
-    "@salesforce/lightning-lsp-common": "4.7.0",
+    "@salesforce/lightning-lsp-common": "4.7.1",
     "@salesforce/salesforcedx-utils-vscode": "58.15.0",
     "applicationinsights": "1.0.7",
     "vscode-extension-telemetry": "0.0.17",
@@ -93,8 +93,8 @@
         "applicationinsights": "1.0.7",
         "@salesforce/core": "4.3.11",
         "@salesforce/source-tracking": "4.1.3",
-        "@salesforce/aura-language-server": "4.7.0",
-        "@salesforce/lightning-lsp-common": "4.7.0"
+        "@salesforce/aura-language-server": "4.7.1",
+        "@salesforce/lightning-lsp-common": "4.7.1"
       },
       "devDependencies": {}
     }

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -26,8 +26,8 @@
   "dependencies": {
     "@salesforce/core": "4.3.11",
     "@salesforce/eslint-config-lwc": "3.3.3",
-    "@salesforce/lightning-lsp-common": "4.7.0",
-    "@salesforce/lwc-language-server": "4.7.0",
+    "@salesforce/lightning-lsp-common": "4.7.1",
+    "@salesforce/lwc-language-server": "4.7.1",
     "@salesforce/salesforcedx-utils-vscode": "58.15.0",
     "ajv": "6.12.6",
     "applicationinsights": "1.0.7",
@@ -100,8 +100,8 @@
         "applicationinsights": "1.0.7",
         "@salesforce/core": "4.3.11",
         "@salesforce/source-tracking": "4.1.3",
-        "@salesforce/lightning-lsp-common": "4.7.0",
-        "@salesforce/lwc-language-server": "4.7.0"
+        "@salesforce/lightning-lsp-common": "4.7.1",
+        "@salesforce/lwc-language-server": "4.7.1"
       },
       "devDependencies": {}
     }


### PR DESCRIPTION
### What does this PR do?
- Updates the version of the lighting-language-server dependencies to pick up: 
https://github.com/forcedotcom/lightning-language-server/pull/578

### What issues does this PR fix or reference?
#4994 

### Functionality Before
- Language server crashes if main class can't be identified

### Functionality After
- Language server doesn't crash if main class can't be identified
