### PR TITLE
chore: schedule e2e tests to run nightly

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,6 +22,8 @@ on:
         required: false
         default: true
         type: boolean
+  schedule:
+    - cron: 10 6 * * *
 
 jobs:
 


### PR DESCRIPTION
### What does this PR do?
- Makes e2e run every night

### What issues does this PR fix or reference
@W-14242077@

### Functionality Before
- e2e would only run manually

### Functionality After
- e2e run automatically every night
