### PR TITLE
fix: only depbot changes to both pkg json and lock

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,7 @@ updates:
         update-types: ["version-update:semver-major"]
     open-pull-requests-limit: 10
     rebase-strategy: disabled
+    versioning-strategy: increase
   # Major version updates (not to be auto-merged)
   - package-ecosystem: "npm"
     directory: "/" # Location of package manifests
@@ -39,6 +40,7 @@ updates:
           ["version-update:semver-minor", "version-update:semver-patch"]
     open-pull-requests-limit: 10
     rebase-strategy: disabled
+    versioning-strategy: increase
   # Exclude updates to doc tools
   # TODO: Enable after adding automated check(s) for doc generation
   - package-ecosystem: "bundler"


### PR DESCRIPTION
@W-14260306@
Modify dependabot.yml to allow only dep changes that affect package.json.
This change should prevent PRs from being created when the module being bump is transient dependency.