### PR TITLE
chore: schedule e2e categories instead

### DIFF
--- a/.github/workflows/apexE2E.yml
+++ b/.github/workflows/apexE2E.yml
@@ -1,7 +1,8 @@
 name: Apex End to End Tests
 
 on:
-
+  schedule:
+    - cron: 10 6 * * *
   workflow_dispatch:
     inputs:
       automationBranch:

--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -1,7 +1,8 @@
 name: Core End to End Tests
 
 on:
-
+  schedule:
+    - cron: 10 6 * * *
   workflow_dispatch:
     inputs:
       automationBranch:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,8 +22,6 @@ on:
         required: false
         default: true
         type: boolean
-  schedule:
-    - cron: 10 6 * * *
 
 jobs:
 

--- a/.github/workflows/lspE2E.yml
+++ b/.github/workflows/lspE2E.yml
@@ -1,7 +1,8 @@
 name: LSP End to End Tests
 
 on:
-
+  schedule:
+    - cron: 10 6 * * *
   workflow_dispatch:
     inputs:
       automationBranch:


### PR DESCRIPTION
### What does this PR do?
- Unschedules End to End Tests workflow and schedules the 3 workflows called from it (Apex, Core and LSP)

### Functionality Before
- Tests being skipped in scheduled runs

### Functionality After
- Tests running nightly

[skip-validate-pr]