### PR TITLE
fix: update aura html grammar scope

### DIFF
--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -116,7 +116,7 @@
     "grammars": [
       {
         "language": "html",
-        "scopeName": "text.html.basic",
+        "scopeName": "aura.html",
         "path": "./syntaxes/html.tmLanguage.json"
       }
     ],

--- a/packages/salesforcedx-vscode-lightning/syntaxes/html.tmLanguage.json
+++ b/packages/salesforcedx-vscode-lightning/syntaxes/html.tmLanguage.json
@@ -6,7 +6,7 @@
   ],
   "version": "https://github.com/textmate/html.tmbundle/commit/a723f08ebd49c67c22aca08dd8f17d0bf836ec93",
   "name": "HTML",
-  "scopeName": "text.html.basic",
+  "scopeName": "aura.html",
   "injections": {
     "R:text.html - (comment.block, text.html source)": {
       "comment": "Use R: to ensure this matches after any other injections.",
@@ -354,7 +354,7 @@
                       "name": "punctuation.definition.tag.begin.html"
                     },
                     "2": {
-                      "name": "text.html.basic"
+                      "name": "aura.html"
                     }
                   },
                   "patterns": [
@@ -376,10 +376,10 @@
                     {
                       "begin": "(?!\\G)",
                       "end": "(?=</(?i:script))",
-                      "name": "text.html.basic",
+                      "name": "aura.html",
                       "patterns": [
                         {
-                          "include": "text.html.basic"
+                          "include": "aura.html"
                         }
                       ]
                     }


### PR DESCRIPTION
### What does this PR do?
The html grammar in the Aura extension had a three part name that forced it to take precedence when looking at html associated files.  (text.html.basic).  This has been reported as an issue a couple of times for php which has an html grammar scope of (html.php). 

I altered the scope name to be simpler (aura.html) and now php html files are correctly parsed and visually marked up by the php grammar file. 


### What issues does this PR fix or reference?
@W-10934996@
#5154
#1988

### Functionality Before
![image](https://github.com/forcedotcom/salesforcedx-vscode/assets/76090802/0f652a95-7ea1-4b14-a78b-f2a24e06b063)


### Functionality After
Aura html file still works properly
![image](https://github.com/forcedotcom/salesforcedx-vscode/assets/76090802/31bd386d-5b76-4132-991c-d12c00c448f1)

php files also works properly 
![image](https://github.com/forcedotcom/salesforcedx-vscode/assets/76090802/8fa5d541-bc83-4b98-b02d-45139a21feab)


