### PR TITLE
Cristi/schedule e2e tests

### DIFF
--- a/.github/workflows/apexE2E.yml
+++ b/.github/workflows/apexE2E.yml
@@ -1,6 +1,8 @@
 name: Apex End to End Tests
 
 on:
+  schedule:
+    - cron: 10 6 * * *
   workflow_dispatch:
     inputs:
       automationBranch:
@@ -70,7 +72,7 @@ on:
 jobs:
 
   apexLSP:
-    if: ${{ github.event.inputs.apexLsp }}
+    if: ${{ github.event.inputs.apexLsp || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
@@ -78,7 +80,7 @@ jobs:
       testToRun: 'apexLsp.e2e.ts'
 
   apexReplayDebugger:
-    if: ${{ github.event.inputs.apexReplayDebugger }}
+    if: ${{ github.event.inputs.apexReplayDebugger || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
@@ -86,7 +88,7 @@ jobs:
       testToRun: 'apexReplayDebugger.e2e.ts'
 
   debugApexTests:
-    if: ${{ github.event.inputs.debugApexTests }}
+    if: ${{ github.event.inputs.debugApexTests || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
@@ -94,7 +96,7 @@ jobs:
       testToRun: 'debugApexTests.e2e.ts'
 
   runApexTests:
-    if: ${{ github.event.inputs.runApexTests }}
+    if: ${{ github.event.inputs.runApexTests || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
@@ -102,7 +104,7 @@ jobs:
       testToRun: 'runApexTests.e2e.ts'
 
   trailApexReplayDebugger:
-    if: ${{ github.event.inputs.trailApexReplayDebugger }}
+    if: ${{ github.event.inputs.trailApexReplayDebugger || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:

--- a/.github/workflows/apexE2E.yml
+++ b/.github/workflows/apexE2E.yml
@@ -1,8 +1,6 @@
 name: Apex End to End Tests
 
 on:
-  schedule:
-    - cron: 10 6 * * *
   workflow_dispatch:
     inputs:
       automationBranch:
@@ -72,41 +70,41 @@ on:
 jobs:
 
   apexLSP:
-    if: ${{ inputs.apexLsp }}
+    if: ${{ github.event.inputs.apexLsp }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ inputs.automationBranch }}
+      automationBranch: ${{ github.event.inputs.automationBranch }}
       testToRun: 'apexLsp.e2e.ts'
 
   apexReplayDebugger:
-    if: ${{ inputs.apexReplayDebugger }}
+    if: ${{ github.event.inputs.apexReplayDebugger }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ inputs.automationBranch }}
+      automationBranch: ${{ github.event.inputs.automationBranch }}
       testToRun: 'apexReplayDebugger.e2e.ts'
 
   debugApexTests:
-    if: ${{ inputs.debugApexTests }}
+    if: ${{ github.event.inputs.debugApexTests }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ inputs.automationBranch }}
+      automationBranch: ${{ github.event.inputs.automationBranch }}
       testToRun: 'debugApexTests.e2e.ts'
 
   runApexTests:
-    if: ${{ inputs.runApexTests }}
+    if: ${{ github.event.inputs.runApexTests }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ inputs.automationBranch }}
+      automationBranch: ${{ github.event.inputs.automationBranch }}
       testToRun: 'runApexTests.e2e.ts'
 
   trailApexReplayDebugger:
-    if: ${{ inputs.trailApexReplayDebugger }}
+    if: ${{ github.event.inputs.trailApexReplayDebugger }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ inputs.automationBranch }}
+      automationBranch: ${{ github.event.inputs.automationBranch }}
       testToRun: 'trailApexReplayDebugger.e2e.ts'

--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -1,6 +1,8 @@
 name: Core End to End Tests
 
 on:
+  schedule:
+    - cron: 10 6 * * *
   workflow_dispatch:
     inputs:
       automationBranch:
@@ -90,7 +92,7 @@ on:
 jobs:
 
   anInitialSuite:
-    if: ${{ github.event.inputs.anInitialSuite }}
+    if: ${{ github.event.inputs.anInitialSuite || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
@@ -98,7 +100,7 @@ jobs:
       testToRun: 'anInitialSuite.e2e.ts'
 
   authentication:
-    if: ${{ github.event.inputs.authentication }}
+    if: ${{ github.event.inputs.authentication || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
@@ -106,7 +108,7 @@ jobs:
       testToRun: 'authentication.e2e.ts'
 
   deployAndRetrieve:
-    if: ${{ github.event.inputs.deployAndRetrieve }}
+    if: ${{ github.event.inputs.deployAndRetrieve || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
@@ -114,7 +116,7 @@ jobs:
       testToRun: 'deployAndRetrieve.e2e.ts'
 
   manifestBuilder:
-    if: ${{ github.event.inputs.manifestBuilder }}
+    if: ${{ github.event.inputs.manifestBuilder || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
@@ -122,7 +124,7 @@ jobs:
       testToRun: 'manifestBuilder.e2e.ts'
 
   pushAndPull:
-    if: ${{ github.event.inputs.pushAndPull }}
+    if: ${{ github.event.inputs.pushAndPull || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
@@ -130,7 +132,7 @@ jobs:
       testToRun: 'pushAndPull.e2e.ts'
 
   sObjectsDefinitions:
-    if: ${{ github.event.inputs.sObjectsDefinitions }}
+    if: ${{ github.event.inputs.sObjectsDefinitions || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
@@ -138,7 +140,7 @@ jobs:
       testToRun: 'sObjectsDefinitions.e2e.ts'
 
   templates:
-    if: ${{ github.event.inputs.templates }}
+    if: ${{ github.event.inputs.templates || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:

--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -1,8 +1,6 @@
 name: Core End to End Tests
 
 on:
-  schedule:
-    - cron: 10 6 * * *
   workflow_dispatch:
     inputs:
       automationBranch:
@@ -92,57 +90,57 @@ on:
 jobs:
 
   anInitialSuite:
-    if: ${{ inputs.anInitialSuite }}
+    if: ${{ github.event.inputs.anInitialSuite }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ inputs.automationBranch }}
+      automationBranch: ${{ github.event.inputs.automationBranch }}
       testToRun: 'anInitialSuite.e2e.ts'
 
   authentication:
-    if: ${{ inputs.authentication }}
+    if: ${{ github.event.inputs.authentication }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ inputs.automationBranch }}
+      automationBranch: ${{ github.event.inputs.automationBranch }}
       testToRun: 'authentication.e2e.ts'
 
   deployAndRetrieve:
-    if: ${{ inputs.deployAndRetrieve }}
+    if: ${{ github.event.inputs.deployAndRetrieve }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ inputs.automationBranch }}
+      automationBranch: ${{ github.event.inputs.automationBranch }}
       testToRun: 'deployAndRetrieve.e2e.ts'
 
   manifestBuilder:
-    if: ${{ inputs.manifestBuilder }}
+    if: ${{ github.event.inputs.manifestBuilder }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ inputs.automationBranch }}
+      automationBranch: ${{ github.event.inputs.automationBranch }}
       testToRun: 'manifestBuilder.e2e.ts'
 
   pushAndPull:
-    if: ${{ inputs.pushAndPull }}
+    if: ${{ github.event.inputs.pushAndPull }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ inputs.automationBranch }}
+      automationBranch: ${{ github.event.inputs.automationBranch }}
       testToRun: 'pushAndPull.e2e.ts'
 
   sObjectsDefinitions:
-    if: ${{ inputs.sObjectsDefinitions }}
+    if: ${{ github.event.inputs.sObjectsDefinitions }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ inputs.automationBranch }}
+      automationBranch: ${{ github.event.inputs.automationBranch }}
       testToRun: 'sObjectsDefinitions.e2e.ts'
 
   templates:
-    if: ${{ inputs.templates }}
+    if: ${{ github.event.inputs.templates }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ inputs.automationBranch }}
+      automationBranch: ${{ github.event.inputs.automationBranch }}
       testToRun: 'templates.e2e.ts'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,7 @@
 name: End to End Tests
 on:
+  schedule:
+    - cron: 10 6 * * *
   workflow_dispatch:
     inputs:
       automationBranch:
@@ -26,22 +28,22 @@ on:
 jobs:
 
   Apex_E2E_tests:
-    if: ${{ inputs.apexE2ETests }}
+    if: ${{ github.event.inputs.apexE2ETests || github.event_name == 'schedule' }}
     uses: ./.github/workflows/apexE2E.yml
     secrets: inherit
     with:
-      automationBranch: ${{ inputs.automationBranch }}
+      automationBranch: ${{ github.event.inputs.automationBranch }}
 
   Core_E2E_tests:
-    if: ${{ inputs.coreE2ETests }}
+    if: ${{ github.event.inputs.coreE2ETests || github.event_name == 'schedule' }}
     uses: ./.github/workflows/coreE2E.yml
     secrets: inherit
     with:
-      automationBranch: ${{ inputs.automationBranch }}
+      automationBranch: ${{ github.event.inputs.automationBranch }}
 
   LSP_E2E_tests:
-    if: ${{ inputs.lspE2ETests }}
+    if: ${{ github.event.inputs.lspE2ETests || github.event_name == 'schedule' }}
     uses: ./.github/workflows/lspE2E.yml
     secrets: inherit
     with:
-      automationBranch: ${{ inputs.automationBranch }}
+      automationBranch: ${{ github.event.inputs.automationBranch }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,7 +1,5 @@
 name: End to End Tests
 on:
-  schedule:
-    - cron: 10 6 * * *
   workflow_dispatch:
     inputs:
       automationBranch:
@@ -28,21 +26,21 @@ on:
 jobs:
 
   Apex_E2E_tests:
-    if: ${{ github.event.inputs.apexE2ETests || github.event_name == 'schedule' }}
+    if: ${{ github.event.inputs.apexE2ETests }}
     uses: ./.github/workflows/apexE2E.yml
     secrets: inherit
     with:
       automationBranch: ${{ github.event.inputs.automationBranch }}
 
   Core_E2E_tests:
-    if: ${{ github.event.inputs.coreE2ETests || github.event_name == 'schedule' }}
+    if: ${{ github.event.inputs.coreE2ETests }}
     uses: ./.github/workflows/coreE2E.yml
     secrets: inherit
     with:
       automationBranch: ${{ github.event.inputs.automationBranch }}
 
   LSP_E2E_tests:
-    if: ${{ github.event.inputs.lspE2ETests || github.event_name == 'schedule' }}
+    if: ${{ github.event.inputs.lspE2ETests }}
     uses: ./.github/workflows/lspE2E.yml
     secrets: inherit
     with:

--- a/.github/workflows/lspE2E.yml
+++ b/.github/workflows/lspE2E.yml
@@ -1,8 +1,6 @@
 name: LSP End to End Tests
 
 on:
-  schedule:
-    - cron: 10 6 * * *
   workflow_dispatch:
     inputs:
       automationBranch:
@@ -42,17 +40,17 @@ on:
 jobs:
 
   auraLSP:
-    if: ${{ inputs.auraLsp }}
+    if: ${{ github.event.inputs.auraLsp }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ inputs.automationBranch }}
+      automationBranch: ${{ github.event.inputs.automationBranch }}
       testToRun: 'auraLsp.e2e.ts'
 
   visualforceLSP:
-    if: ${{ inputs.visualforceLsp }}
+    if: ${{ github.event.inputs.visualforceLsp }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ inputs.automationBranch }}
+      automationBranch: ${{ github.event.inputs.automationBranch }}
       testToRun: 'visualforceLsp.e2e.ts'

--- a/.github/workflows/lspE2E.yml
+++ b/.github/workflows/lspE2E.yml
@@ -1,6 +1,8 @@
 name: LSP End to End Tests
 
 on:
+  schedule:
+    - cron: 10 6 * * *
   workflow_dispatch:
     inputs:
       automationBranch:
@@ -40,7 +42,7 @@ on:
 jobs:
 
   auraLSP:
-    if: ${{ github.event.inputs.auraLsp }}
+    if: ${{ github.event.inputs.auraLsp || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
@@ -48,7 +50,7 @@ jobs:
       testToRun: 'auraLsp.e2e.ts'
 
   visualforceLSP:
-    if: ${{ github.event.inputs.visualforceLsp }}
+    if: ${{ github.event.inputs.visualforceLsp || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:


### PR DESCRIPTION
### What does this PR do?
- Adds condition to if to include runs triggered with "schedule"

### Functionality Before
- Tests being skipped in scheduled runs because if condition was missing

### Functionality After
- Tests finally running..

These runs were triggered on my fork with a workflow like the one I fixed in this PR:
- [Apex End to End Tests](https://github.com/CristiCanizales/salesforcedx-vscode-fork/actions/runs/6551352223)
- [LSP End to End Tests](https://github.com/CristiCanizales/salesforcedx-vscode-fork/actions/runs/6551359213)
- [Core End to End Tests](https://github.com/CristiCanizales/salesforcedx-vscode-fork/actions/runs/6551373889)

They're failing because I don't have the right setup on my fork (secrets and all that) but they're being run automatically as scheduled

[skip-validate-pr]