### PR TITLE
Cristi/e2e manual runs

### DIFF
--- a/.github/workflows/apexE2E.yml
+++ b/.github/workflows/apexE2E.yml
@@ -72,41 +72,41 @@ on:
 jobs:
 
   apexLSP:
-    if: ${{ github.event.inputs.apexLsp || github.event_name == 'schedule' }}
+    if: ${{ inputs.apexLsp || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ github.event.inputs.automationBranch }}
+      automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'apexLsp.e2e.ts'
 
   apexReplayDebugger:
-    if: ${{ github.event.inputs.apexReplayDebugger || github.event_name == 'schedule' }}
+    if: ${{ inputs.apexReplayDebugger || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ github.event.inputs.automationBranch }}
+      automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'apexReplayDebugger.e2e.ts'
 
   debugApexTests:
-    if: ${{ github.event.inputs.debugApexTests || github.event_name == 'schedule' }}
+    if: ${{ inputs.debugApexTests || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ github.event.inputs.automationBranch }}
+      automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'debugApexTests.e2e.ts'
 
   runApexTests:
-    if: ${{ github.event.inputs.runApexTests || github.event_name == 'schedule' }}
+    if: ${{ inputs.runApexTests || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ github.event.inputs.automationBranch }}
+      automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'runApexTests.e2e.ts'
 
   trailApexReplayDebugger:
-    if: ${{ github.event.inputs.trailApexReplayDebugger || github.event_name == 'schedule' }}
+    if: ${{ inputs.trailApexReplayDebugger || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ github.event.inputs.automationBranch }}
+      automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'trailApexReplayDebugger.e2e.ts'

--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -92,57 +92,57 @@ on:
 jobs:
 
   anInitialSuite:
-    if: ${{ github.event.inputs.anInitialSuite || github.event_name == 'schedule' }}
+    if: ${{ inputs.anInitialSuite || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ github.event.inputs.automationBranch }}
+      automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'anInitialSuite.e2e.ts'
 
   authentication:
-    if: ${{ github.event.inputs.authentication || github.event_name == 'schedule' }}
+    if: ${{ inputs.authentication || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ github.event.inputs.automationBranch }}
+      automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'authentication.e2e.ts'
 
   deployAndRetrieve:
-    if: ${{ github.event.inputs.deployAndRetrieve || github.event_name == 'schedule' }}
+    if: ${{ inputs.deployAndRetrieve || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ github.event.inputs.automationBranch }}
+      automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'deployAndRetrieve.e2e.ts'
 
   manifestBuilder:
-    if: ${{ github.event.inputs.manifestBuilder || github.event_name == 'schedule' }}
+    if: ${{ inputs.manifestBuilder || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ github.event.inputs.automationBranch }}
+      automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'manifestBuilder.e2e.ts'
 
   pushAndPull:
-    if: ${{ github.event.inputs.pushAndPull || github.event_name == 'schedule' }}
+    if: ${{ inputs.pushAndPull || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ github.event.inputs.automationBranch }}
+      automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'pushAndPull.e2e.ts'
 
   sObjectsDefinitions:
-    if: ${{ github.event.inputs.sObjectsDefinitions || github.event_name == 'schedule' }}
+    if: ${{ inputs.sObjectsDefinitions || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ github.event.inputs.automationBranch }}
+      automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'sObjectsDefinitions.e2e.ts'
 
   templates:
-    if: ${{ github.event.inputs.templates || github.event_name == 'schedule' }}
+    if: ${{ inputs.templates || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ github.event.inputs.automationBranch }}
+      automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'templates.e2e.ts'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,22 +26,22 @@ on:
 jobs:
 
   Apex_E2E_tests:
-    if: ${{ github.event.inputs.apexE2ETests }}
+    if: ${{ inputs.apexE2ETests }}
     uses: ./.github/workflows/apexE2E.yml
     secrets: inherit
     with:
-      automationBranch: ${{ github.event.inputs.automationBranch }}
+      automationBranch: ${{ inputs.automationBranch }}
 
   Core_E2E_tests:
-    if: ${{ github.event.inputs.coreE2ETests }}
+    if: ${{ inputs.coreE2ETests }}
     uses: ./.github/workflows/coreE2E.yml
     secrets: inherit
     with:
-      automationBranch: ${{ github.event.inputs.automationBranch }}
+      automationBranch: ${{ inputs.automationBranch }}
 
   LSP_E2E_tests:
-    if: ${{ github.event.inputs.lspE2ETests }}
+    if: ${{ inputs.lspE2ETests }}
     uses: ./.github/workflows/lspE2E.yml
     secrets: inherit
     with:
-      automationBranch: ${{ github.event.inputs.automationBranch }}
+      automationBranch: ${{ inputs.automationBranch }}

--- a/.github/workflows/lspE2E.yml
+++ b/.github/workflows/lspE2E.yml
@@ -42,17 +42,17 @@ on:
 jobs:
 
   auraLSP:
-    if: ${{ github.event.inputs.auraLsp || github.event_name == 'schedule' }}
+    if: ${{ inputs.auraLsp || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ github.event.inputs.automationBranch }}
+      automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'auraLsp.e2e.ts'
 
   visualforceLSP:
-    if: ${{ github.event.inputs.visualforceLsp || github.event_name == 'schedule' }}
+    if: ${{ inputs.visualforceLsp || github.event_name == 'schedule' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ github.event.inputs.automationBranch }}
+      automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'visualforceLsp.e2e.ts'


### PR DESCRIPTION
### What does this PR do?
- Removes github.event prefix from inputs in e2e workflows as it was causing the manually triggered runs to run all of the options instead of only the selected ones

### Functionality Before
- Even if you only selected one e2e category/suite, all of the other options would run too

### Functionality After
- Only selected options run

[skip-validate-pr]