### PR TITLE
chore: use node 18 for e2e test workflow

### DIFF
--- a/.github/workflows/runE2ETest.yml
+++ b/.github/workflows/runE2ETest.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         nodeVersion:
-          - 16.15.1
+          - 18.11.0
         vscodeVersion:
           - stable
     steps:


### PR DESCRIPTION
Update runE2ETest.yml to download Node 18 instead of Node 16 so that E2E tests can be run after the upgrade to Node 18.

@W-13209367@