### PR TITLE
Slack notification for e2e test runs

### DIFF
--- a/.github/workflows/apexE2E.yml
+++ b/.github/workflows/apexE2E.yml
@@ -118,9 +118,9 @@ jobs:
     secrets: inherit
     with:
       title: 'Apex E2E Tests'
-      summary: 'Apex LSP: ${{ needs.apexLSP.result }}, Apex Replay Debugger: ${{ needs.apexReplayDebugger.result }}, Debug Apex Tests: ${{ needs.debugApexTests.result }}, Run Apex Tests: ${{ needs.runApexTests.result }}, Trail Apex Replay Debugger: ${{ needs.trailApexReplayDebugger.result }}'
-      result: 'Success'
-      workflow: 'actions/runs/${{ github.run_id}}'
+      summary: '\n- Apex LSP: ${{ needs.apexLSP.result }},\n- Apex Replay Debugger: ${{ needs.apexReplayDebugger.result }},\n- Debug Apex Tests: ${{ needs.debugApexTests.result }},\n- Run Apex Tests: ${{ needs.runApexTests.result }},\n- Trail Apex Replay Debugger: ${{ needs.trailApexReplayDebugger.result }}'
+      result: 'All the tests passed.'
+      workflow: 'actions/runs/${{ github.run_id }}'
       type: 'e2e'
 
   slack_failure_notification:
@@ -130,7 +130,7 @@ jobs:
     secrets: inherit
     with:
       title: 'Apex E2E Tests'
-      summary: 'Apex LSP: ${{ needs.apexLSP.result }}, Apex Replay Debugger: ${{ needs.apexReplayDebugger.result }}, Debug Apex Tests: ${{ needs.debugApexTests.result }}, Run Apex Tests: ${{ needs.runApexTests.result }}, Trail Apex Replay Debugger: ${{ needs.trailApexReplayDebugger.result }}'
-      result: 'Failure'
-      workflow: 'actions/runs/${{ github.run_id}}'
+      summary: '\n- Apex LSP: ${{ needs.apexLSP.result }},\n- Apex Replay Debugger: ${{ needs.apexReplayDebugger.result }},\n- Debug Apex Tests: ${{ needs.debugApexTests.result }},\n- Run Apex Tests: ${{ needs.runApexTests.result }},\n- Trail Apex Replay Debugger: ${{ needs.trailApexReplayDebugger.result }}'
+      result: 'Not all the tests passed.'
+      workflow: 'actions/runs/${{ github.run_id }}'
       type: 'e2e'

--- a/.github/workflows/apexE2E.yml
+++ b/.github/workflows/apexE2E.yml
@@ -111,14 +111,26 @@ jobs:
       automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'trailApexReplayDebugger.e2e.ts'
 
-  slack_notification:
-    if: ${{ always() }}
+  slack_success_notification:
+    if: ${{ success() }}
     needs: [apexLSP, apexReplayDebugger, debugApexTests, runApexTests, trailApexReplayDebugger]
     uses: ./.github/workflows/slackNotification.yml
     secrets: inherit
     with:
       title: 'Apex E2E Tests'
       summary: 'Apex LSP: ${{ needs.apexLSP.result }}, Apex Replay Debugger: ${{ needs.apexReplayDebugger.result }}, Debug Apex Tests: ${{ needs.debugApexTests.result }}, Run Apex Tests: ${{ needs.runApexTests.result }}, Trail Apex Replay Debugger: ${{ needs.trailApexReplayDebugger.result }}'
-      result: ${{ github.event.workflow.result }}
+      result: 'Success'
+      workflow: 'actions/runs/${{ github.run_id}}'
+      type: 'e2e'
+
+  slack_failure_notification:
+    if: ${{ failure() }}
+    needs: [apexLSP, apexReplayDebugger, debugApexTests, runApexTests, trailApexReplayDebugger]
+    uses: ./.github/workflows/slackNotification.yml
+    secrets: inherit
+    with:
+      title: 'Apex E2E Tests'
+      summary: 'Apex LSP: ${{ needs.apexLSP.result }}, Apex Replay Debugger: ${{ needs.apexReplayDebugger.result }}, Debug Apex Tests: ${{ needs.debugApexTests.result }}, Run Apex Tests: ${{ needs.runApexTests.result }}, Trail Apex Replay Debugger: ${{ needs.trailApexReplayDebugger.result }}'
+      result: 'Failure'
       workflow: 'actions/runs/${{ github.run_id}}'
       type: 'e2e'

--- a/.github/workflows/apexE2E.yml
+++ b/.github/workflows/apexE2E.yml
@@ -124,7 +124,7 @@ jobs:
       type: 'e2e'
 
   slack_failure_notification:
-    if: ${{ failure() || cancelled() }}
+    if: ${{ failure() }}
     needs: [apexLSP, apexReplayDebugger, debugApexTests, runApexTests, trailApexReplayDebugger]
     uses: ./.github/workflows/slackNotification.yml
     secrets: inherit
@@ -132,5 +132,17 @@ jobs:
       title: 'Apex E2E Tests'
       summary: '\n- Apex LSP: ${{ needs.apexLSP.result }}\n- Apex Replay Debugger: ${{ needs.apexReplayDebugger.result }}\n- Debug Apex Tests: ${{ needs.debugApexTests.result }}\n- Run Apex Tests: ${{ needs.runApexTests.result }}\n- Trail Apex Replay Debugger: ${{ needs.trailApexReplayDebugger.result }}'
       result: 'Not all the tests passed.'
+      workflow: 'actions/runs/${{ github.run_id }}'
+      type: 'e2e'
+    
+  slack_cancelled_notification:
+    if: ${{ cancelled() }}
+    needs: [apexLSP, apexReplayDebugger, debugApexTests, runApexTests, trailApexReplayDebugger]
+    uses: ./.github/workflows/slackNotification.yml
+    secrets: inherit
+    with:
+      title: 'Apex E2E Tests'
+      summary: '\n- Apex LSP: ${{ needs.apexLSP.result }}\n- Apex Replay Debugger: ${{ needs.apexReplayDebugger.result }}\n- Debug Apex Tests: ${{ needs.debugApexTests.result }}\n- Run Apex Tests: ${{ needs.runApexTests.result }}\n- Trail Apex Replay Debugger: ${{ needs.trailApexReplayDebugger.result }}'
+      result: 'The workflow was cancelled.'
       workflow: 'actions/runs/${{ github.run_id }}'
       type: 'e2e'

--- a/.github/workflows/apexE2E.yml
+++ b/.github/workflows/apexE2E.yml
@@ -134,7 +134,7 @@ jobs:
       result: 'Not all the tests passed.'
       workflow: 'actions/runs/${{ github.run_id }}'
       type: 'e2e'
-    
+
   slack_cancelled_notification:
     if: ${{ cancelled() }}
     needs: [apexLSP, apexReplayDebugger, debugApexTests, runApexTests, trailApexReplayDebugger]

--- a/.github/workflows/apexE2E.yml
+++ b/.github/workflows/apexE2E.yml
@@ -118,7 +118,7 @@ jobs:
     secrets: inherit
     with:
       title: 'Apex E2E Tests'
-      summary: '\n- Apex LSP: ${{ needs.apexLSP.result }},\n- Apex Replay Debugger: ${{ needs.apexReplayDebugger.result }},\n- Debug Apex Tests: ${{ needs.debugApexTests.result }},\n- Run Apex Tests: ${{ needs.runApexTests.result }},\n- Trail Apex Replay Debugger: ${{ needs.trailApexReplayDebugger.result }}'
+      summary: '\n- Apex LSP: ${{ needs.apexLSP.result }}\n- Apex Replay Debugger: ${{ needs.apexReplayDebugger.result }}\n- Debug Apex Tests: ${{ needs.debugApexTests.result }}\n- Run Apex Tests: ${{ needs.runApexTests.result }}\n- Trail Apex Replay Debugger: ${{ needs.trailApexReplayDebugger.result }}'
       result: 'All the tests passed.'
       workflow: 'actions/runs/${{ github.run_id }}'
       type: 'e2e'
@@ -130,7 +130,7 @@ jobs:
     secrets: inherit
     with:
       title: 'Apex E2E Tests'
-      summary: '\n- Apex LSP: ${{ needs.apexLSP.result }},\n- Apex Replay Debugger: ${{ needs.apexReplayDebugger.result }},\n- Debug Apex Tests: ${{ needs.debugApexTests.result }},\n- Run Apex Tests: ${{ needs.runApexTests.result }},\n- Trail Apex Replay Debugger: ${{ needs.trailApexReplayDebugger.result }}'
+      summary: '\n- Apex LSP: ${{ needs.apexLSP.result }}\n- Apex Replay Debugger: ${{ needs.apexReplayDebugger.result }}\n- Debug Apex Tests: ${{ needs.debugApexTests.result }}\n- Run Apex Tests: ${{ needs.runApexTests.result }}\n- Trail Apex Replay Debugger: ${{ needs.trailApexReplayDebugger.result }}'
       result: 'Not all the tests passed.'
       workflow: 'actions/runs/${{ github.run_id }}'
       type: 'e2e'

--- a/.github/workflows/apexE2E.yml
+++ b/.github/workflows/apexE2E.yml
@@ -124,7 +124,7 @@ jobs:
       type: 'e2e'
 
   slack_failure_notification:
-    if: ${{ failure() }}
+    if: ${{ failure() || cancelled() }}
     needs: [apexLSP, apexReplayDebugger, debugApexTests, runApexTests, trailApexReplayDebugger]
     uses: ./.github/workflows/slackNotification.yml
     secrets: inherit

--- a/.github/workflows/apexE2E.yml
+++ b/.github/workflows/apexE2E.yml
@@ -110,3 +110,15 @@ jobs:
     with:
       automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'trailApexReplayDebugger.e2e.ts'
+
+  slack_notification:
+    if: ${{ always() }}
+    needs: [apexLSP, apexReplayDebugger, debugApexTests, runApexTests, trailApexReplayDebugger]
+    uses: ./.github/workflows/slackNotification.yml
+    secrets: inherit
+    with:
+      title: 'Apex E2E Tests'
+      summary: 'Apex LSP: ${{ needs.apexLSP.result }}, Apex Replay Debugger: ${{ needs.apexReplayDebugger.result }}, Debug Apex Tests: ${{ needs.debugApexTests.result }}, Run Apex Tests: ${{ needs.runApexTests.result }}, Trail Apex Replay Debugger: ${{ needs.trailApexReplayDebugger.result }}'
+      result: ${{ github.event.workflow.result }}
+      workflow: 'actions/runs/${{ github.run_id}}'
+      type: 'e2e'

--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -160,7 +160,7 @@ jobs:
       type: 'e2e'
 
   slack_failure_notification:
-    if: ${{ failure() || cancelled() }}
+    if: ${{ failure()}}
     needs: [anInitialSuite, authentication, deployAndRetrieve, manifestBuilder, pushAndPull, sObjectsDefinitions, templates]
     uses: ./.github/workflows/slackNotification.yml
     secrets: inherit
@@ -168,5 +168,17 @@ jobs:
       title: 'Core E2E Tests'
       summary: '\n- An Initial Suite: ${{ needs.anInitialSuite.result }}\n- Authentication: ${{ needs.authentication.result }}\n- Deploy and Retrieve: ${{ needs.deployAndRetrieve.result }}\n- Manifest Builder: ${{ needs.manifestBuilder.result }}\n- Push and Pull: ${{ needs.pushAndPull.result }}\n- SObjects Definitions: ${{ needs.sObjectsDefinitions.result }}\n- Templates: ${{ needs.templates.result }}'
       result: 'Not all the tests passed.'
+      workflow: 'actions/runs/${{ github.run_id }}'
+      type: 'e2e'
+
+  slack_cancelled_notification:
+    if: ${{ cancelled() }}
+    needs: [anInitialSuite, authentication, deployAndRetrieve, manifestBuilder, pushAndPull, sObjectsDefinitions, templates]
+    uses: ./.github/workflows/slackNotification.yml
+    secrets: inherit
+    with:
+      title: 'Core E2E Tests'
+      summary: '\n- An Initial Suite: ${{ needs.anInitialSuite.result }}\n- Authentication: ${{ needs.authentication.result }}\n- Deploy and Retrieve: ${{ needs.deployAndRetrieve.result }}\n- Manifest Builder: ${{ needs.manifestBuilder.result }}\n- Push and Pull: ${{ needs.pushAndPull.result }}\n- SObjects Definitions: ${{ needs.sObjectsDefinitions.result }}\n- Templates: ${{ needs.templates.result }}'
+      result: 'The workflow was cancelled.'
       workflow: 'actions/runs/${{ github.run_id }}'
       type: 'e2e'

--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -160,7 +160,7 @@ jobs:
       type: 'e2e'
 
   slack_failure_notification:
-    if: ${{ failure() }}
+    if: ${{ failure() || cancelled() }}
     needs: [anInitialSuite, authentication, deployAndRetrieve, manifestBuilder, pushAndPull, sObjectsDefinitions, templates]
     uses: ./.github/workflows/slackNotification.yml
     secrets: inherit

--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -154,9 +154,9 @@ jobs:
     secrets: inherit
     with:
       title: 'Core E2E Tests'
-      summary: 'An Initial Suite: ${{ needs.anInitialSuite.result }}, Authentication: ${{ needs.authentication.result }}, Deploy and Retrieve: ${{ needs.deployAndRetrieve.result }}, Manifest Builder: ${{ needs.manifestBuilder.result }}, Push and Pull: ${{ needs.pushAndPull.result }}, SObjects Definitions: ${{ needs.sObjectsDefinitions.result }}, Templates: ${{ needs.templates.result }}'
-      result: 'Success'
-      workflow: 'actions/runs/${{ github.run_id}}'
+      summary: '\n- An Initial Suite: ${{ needs.anInitialSuite.result }},\n- Authentication: ${{ needs.authentication.result }},\n- Deploy and Retrieve: ${{ needs.deployAndRetrieve.result }},\n- Manifest Builder: ${{ needs.manifestBuilder.result }},\n- Push and Pull: ${{ needs.pushAndPull.result }},\n- SObjects Definitions: ${{ needs.sObjectsDefinitions.result }},\n- Templates: ${{ needs.templates.result }}'
+      result: 'All the tests passed.'
+      workflow: 'actions/runs/${{ github.run_id }}'
       type: 'e2e'
 
   slack_failure_notification:
@@ -166,7 +166,7 @@ jobs:
     secrets: inherit
     with:
       title: 'Core E2E Tests'
-      summary: 'An Initial Suite: ${{ needs.anInitialSuite.result }}, Authentication: ${{ needs.authentication.result }}, Deploy and Retrieve: ${{ needs.deployAndRetrieve.result }}, Manifest Builder: ${{ needs.manifestBuilder.result }}, Push and Pull: ${{ needs.pushAndPull.result }}, SObjects Definitions: ${{ needs.sObjectsDefinitions.result }}, Templates: ${{ needs.templates.result }}'
-      result: 'Failure'
-      workflow: 'actions/runs/${{ github.run_id}}'
+      summary: '\n- An Initial Suite: ${{ needs.anInitialSuite.result }},\n- Authentication: ${{ needs.authentication.result }},\n- Deploy and Retrieve: ${{ needs.deployAndRetrieve.result }},\n- Manifest Builder: ${{ needs.manifestBuilder.result }},\n- Push and Pull: ${{ needs.pushAndPull.result }},\n- SObjects Definitions: ${{ needs.sObjectsDefinitions.result }},\n- Templates: ${{ needs.templates.result }}'
+      result: 'Not all the tests passed.'
+      workflow: 'actions/runs/${{ github.run_id }}'
       type: 'e2e'

--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -146,3 +146,15 @@ jobs:
     with:
       automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'templates.e2e.ts'
+
+  slack_notification:
+    if: ${{ always() }}
+    needs: [anInitialSuite, authentication, deployAndRetrieve, manifestBuilder, pushAndPull, sObjectsDefinitions, templates]
+    uses: ./.github/workflows/slackNotification.yml
+    secrets: inherit
+    with:
+      title: 'Core E2E Tests'
+      summary: 'An Initial Suite: ${{ needs.anInitialSuite.result }}, Authentication: ${{ needs.authentication.result }}, Deploy and Retrieve: ${{ needs.deployAndRetrieve.result }}, Manifest Builder: ${{ needs.manifestBuilder.result }}, Push and Pull: ${{ needs.pushAndPull.result }}, SObjects Definitions: ${{ needs.sObjectsDefinitions.result }}, Templates: ${{ needs.templates.result }}'
+      result: ${{ github.event.workflow.result }}
+      workflow: 'actions/runs/${{ github.run_id}}'
+      type: 'e2e'

--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -154,7 +154,7 @@ jobs:
     secrets: inherit
     with:
       title: 'Core E2E Tests'
-      summary: '\n- An Initial Suite: ${{ needs.anInitialSuite.result }},\n- Authentication: ${{ needs.authentication.result }},\n- Deploy and Retrieve: ${{ needs.deployAndRetrieve.result }},\n- Manifest Builder: ${{ needs.manifestBuilder.result }},\n- Push and Pull: ${{ needs.pushAndPull.result }},\n- SObjects Definitions: ${{ needs.sObjectsDefinitions.result }},\n- Templates: ${{ needs.templates.result }}'
+      summary: '\n- An Initial Suite: ${{ needs.anInitialSuite.result }}\n- Authentication: ${{ needs.authentication.result }}\n- Deploy and Retrieve: ${{ needs.deployAndRetrieve.result }}\n- Manifest Builder: ${{ needs.manifestBuilder.result }}\n- Push and Pull: ${{ needs.pushAndPull.result }}\n- SObjects Definitions: ${{ needs.sObjectsDefinitions.result }}\n- Templates: ${{ needs.templates.result }}'
       result: 'All the tests passed.'
       workflow: 'actions/runs/${{ github.run_id }}'
       type: 'e2e'
@@ -166,7 +166,7 @@ jobs:
     secrets: inherit
     with:
       title: 'Core E2E Tests'
-      summary: '\n- An Initial Suite: ${{ needs.anInitialSuite.result }},\n- Authentication: ${{ needs.authentication.result }},\n- Deploy and Retrieve: ${{ needs.deployAndRetrieve.result }},\n- Manifest Builder: ${{ needs.manifestBuilder.result }},\n- Push and Pull: ${{ needs.pushAndPull.result }},\n- SObjects Definitions: ${{ needs.sObjectsDefinitions.result }},\n- Templates: ${{ needs.templates.result }}'
+      summary: '\n- An Initial Suite: ${{ needs.anInitialSuite.result }}\n- Authentication: ${{ needs.authentication.result }}\n- Deploy and Retrieve: ${{ needs.deployAndRetrieve.result }}\n- Manifest Builder: ${{ needs.manifestBuilder.result }}\n- Push and Pull: ${{ needs.pushAndPull.result }}\n- SObjects Definitions: ${{ needs.sObjectsDefinitions.result }}\n- Templates: ${{ needs.templates.result }}'
       result: 'Not all the tests passed.'
       workflow: 'actions/runs/${{ github.run_id }}'
       type: 'e2e'

--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -147,14 +147,26 @@ jobs:
       automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'templates.e2e.ts'
 
-  slack_notification:
-    if: ${{ always() }}
+  slack_success_notification:
+    if: ${{ success() }}
     needs: [anInitialSuite, authentication, deployAndRetrieve, manifestBuilder, pushAndPull, sObjectsDefinitions, templates]
     uses: ./.github/workflows/slackNotification.yml
     secrets: inherit
     with:
       title: 'Core E2E Tests'
       summary: 'An Initial Suite: ${{ needs.anInitialSuite.result }}, Authentication: ${{ needs.authentication.result }}, Deploy and Retrieve: ${{ needs.deployAndRetrieve.result }}, Manifest Builder: ${{ needs.manifestBuilder.result }}, Push and Pull: ${{ needs.pushAndPull.result }}, SObjects Definitions: ${{ needs.sObjectsDefinitions.result }}, Templates: ${{ needs.templates.result }}'
-      result: ${{ github.event.workflow.result }}
+      result: 'Success'
+      workflow: 'actions/runs/${{ github.run_id}}'
+      type: 'e2e'
+
+  slack_failure_notification:
+    if: ${{ failure() }}
+    needs: [anInitialSuite, authentication, deployAndRetrieve, manifestBuilder, pushAndPull, sObjectsDefinitions, templates]
+    uses: ./.github/workflows/slackNotification.yml
+    secrets: inherit
+    with:
+      title: 'Core E2E Tests'
+      summary: 'An Initial Suite: ${{ needs.anInitialSuite.result }}, Authentication: ${{ needs.authentication.result }}, Deploy and Retrieve: ${{ needs.deployAndRetrieve.result }}, Manifest Builder: ${{ needs.manifestBuilder.result }}, Push and Pull: ${{ needs.pushAndPull.result }}, SObjects Definitions: ${{ needs.sObjectsDefinitions.result }}, Templates: ${{ needs.templates.result }}'
+      result: 'Failure'
       workflow: 'actions/runs/${{ github.run_id}}'
       type: 'e2e'

--- a/.github/workflows/lspE2E.yml
+++ b/.github/workflows/lspE2E.yml
@@ -88,7 +88,7 @@ jobs:
       type: 'e2e'
 
   slack_failure_notification:
-    if: ${{ failure() }}
+    if: ${{ failure() || cancelled() }}
     needs: [auraLSP, lwcLSP, visualforceLSP]
     uses: ./.github/workflows/slackNotification.yml
     secrets: inherit

--- a/.github/workflows/lspE2E.yml
+++ b/.github/workflows/lspE2E.yml
@@ -75,14 +75,26 @@ jobs:
       automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'visualforceLsp.e2e.ts'
 
-  slack_notification:
-    if: ${{ always() }}
+  slack_success_notification:
+    if: ${{ success() }}
     needs: [auraLSP, lwcLSP, visualforceLSP]
     uses: ./.github/workflows/slackNotification.yml
     secrets: inherit
     with:
       title: 'LSP E2E Tests'
       summary: 'Aura LSP: ${{ needs.auraLSP.result }}, LWC LSP: ${{ needs.lwcLSP.result }}, Visualforce LSP: ${{ needs.visualforceLSP.result }}'
-      result: ${{ github.event.workflow.result }}
+      result: 'Success'
+      workflow: 'actions/runs/${{ github.run_id}}'
+      type: 'e2e'
+
+  slack_failurenotification:
+    if: ${{ failure() }}
+    needs: [auraLSP, lwcLSP, visualforceLSP]
+    uses: ./.github/workflows/slackNotification.yml
+    secrets: inherit
+    with:
+      title: 'LSP E2E Tests'
+      summary: 'Aura LSP: ${{ needs.auraLSP.result }},\nLWC LSP: ${{ needs.lwcLSP.result }},\nVisualforce LSP: ${{ needs.visualforceLSP.result }}'
+      result: 'Failure'
       workflow: 'actions/runs/${{ github.run_id}}'
       type: 'e2e'

--- a/.github/workflows/lspE2E.yml
+++ b/.github/workflows/lspE2E.yml
@@ -88,7 +88,7 @@ jobs:
       type: 'e2e'
 
   slack_failure_notification:
-    if: ${{ failure() || cancelled() }}
+    if: ${{ failure() }}
     needs: [auraLSP, lwcLSP, visualforceLSP]
     uses: ./.github/workflows/slackNotification.yml
     secrets: inherit
@@ -96,5 +96,17 @@ jobs:
       title: 'LSP E2E Tests'
       summary: '\n- Aura LSP: ${{ needs.auraLSP.result }}\n- LWC LSP: ${{ needs.lwcLSP.result }}\n- Visualforce LSP: ${{ needs.visualforceLSP.result }}'
       result: 'Not all the tests passed.'
+      workflow: 'actions/runs/${{ github.run_id }}'
+      type: 'e2e'
+
+  slack_cancelled_notification:
+    if: ${{ cancelled() }}
+    needs: [auraLSP, lwcLSP, visualforceLSP]
+    uses: ./.github/workflows/slackNotification.yml
+    secrets: inherit
+    with:
+      title: 'LSP E2E Tests'
+      summary: '\n- Aura LSP: ${{ needs.auraLSP.result }}\n- LWC LSP: ${{ needs.lwcLSP.result }}\n- Visualforce LSP: ${{ needs.visualforceLSP.result }}'
+      result: 'The workflow was cancelled.'
       workflow: 'actions/runs/${{ github.run_id }}'
       type: 'e2e'

--- a/.github/workflows/lspE2E.yml
+++ b/.github/workflows/lspE2E.yml
@@ -82,7 +82,7 @@ jobs:
     secrets: inherit
     with:
       title: 'LSP E2E Tests'
-      summary: '\n- Aura LSP: ${{ needs.auraLSP.result }},\n- LWC LSP: ${{ needs.lwcLSP.result }},\n- Visualforce LSP: ${{ needs.visualforceLSP.result }}'
+      summary: '\n- Aura LSP: ${{ needs.auraLSP.result }}\n- LWC LSP: ${{ needs.lwcLSP.result }}\n- Visualforce LSP: ${{ needs.visualforceLSP.result }}'
       result: 'All the tests passed.'
       workflow: 'actions/runs/${{ github.run_id }}'
       type: 'e2e'
@@ -94,7 +94,7 @@ jobs:
     secrets: inherit
     with:
       title: 'LSP E2E Tests'
-      summary: '\n- Aura LSP: ${{ needs.auraLSP.result }},\n- LWC LSP: ${{ needs.lwcLSP.result }},\n- Visualforce LSP: ${{ needs.visualforceLSP.result }}'
+      summary: '\n- Aura LSP: ${{ needs.auraLSP.result }}\n- LWC LSP: ${{ needs.lwcLSP.result }}\n- Visualforce LSP: ${{ needs.visualforceLSP.result }}'
       result: 'Not all the tests passed.'
       workflow: 'actions/runs/${{ github.run_id }}'
       type: 'e2e'

--- a/.github/workflows/lspE2E.yml
+++ b/.github/workflows/lspE2E.yml
@@ -74,3 +74,15 @@ jobs:
     with:
       automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'visualforceLsp.e2e.ts'
+
+  slack_notification:
+    if: ${{ always() }}
+    needs: [auraLSP, lwcLSP, visualforceLSP]
+    uses: ./.github/workflows/slackNotification.yml
+    secrets: inherit
+    with:
+      title: 'LSP E2E Tests'
+      summary: 'Aura LSP: ${{ needs.auraLSP.result }}, LWC LSP: ${{ needs.lwcLSP.result }}, Visualforce LSP: ${{ needs.visualforceLSP.result }}'
+      result: ${{ github.event.workflow.result }}
+      workflow: 'actions/runs/${{ github.run_id}}'
+      type: 'e2e'

--- a/.github/workflows/lspE2E.yml
+++ b/.github/workflows/lspE2E.yml
@@ -82,19 +82,19 @@ jobs:
     secrets: inherit
     with:
       title: 'LSP E2E Tests'
-      summary: 'Aura LSP: ${{ needs.auraLSP.result }}, LWC LSP: ${{ needs.lwcLSP.result }}, Visualforce LSP: ${{ needs.visualforceLSP.result }}'
-      result: 'Success'
-      workflow: 'actions/runs/${{ github.run_id}}'
+      summary: '\n- Aura LSP: ${{ needs.auraLSP.result }},\n- LWC LSP: ${{ needs.lwcLSP.result }},\n- Visualforce LSP: ${{ needs.visualforceLSP.result }}'
+      result: 'All the tests passed.'
+      workflow: 'actions/runs/${{ github.run_id }}'
       type: 'e2e'
 
-  slack_failurenotification:
+  slack_failure_notification:
     if: ${{ failure() }}
     needs: [auraLSP, lwcLSP, visualforceLSP]
     uses: ./.github/workflows/slackNotification.yml
     secrets: inherit
     with:
       title: 'LSP E2E Tests'
-      summary: 'Aura LSP: ${{ needs.auraLSP.result }},\nLWC LSP: ${{ needs.lwcLSP.result }},\nVisualforce LSP: ${{ needs.visualforceLSP.result }}'
-      result: 'Failure'
-      workflow: 'actions/runs/${{ github.run_id}}'
+      summary: '\n- Aura LSP: ${{ needs.auraLSP.result }},\n- LWC LSP: ${{ needs.lwcLSP.result }},\n- Visualforce LSP: ${{ needs.visualforceLSP.result }}'
+      result: 'Not all the tests passed.'
+      workflow: 'actions/runs/${{ github.run_id }}'
       type: 'e2e'

--- a/.github/workflows/slackNotification.yml
+++ b/.github/workflows/slackNotification.yml
@@ -38,7 +38,7 @@ on:
 jobs:
   notification_on_success:
     runs-on: ubuntu-latest
-    if: inputs.result == 'success' 
+    if: inputs.result == 'success'
     steps:
       - name: Announce success
         uses: slackapi/slack-github-action@v1.22.0

--- a/.github/workflows/slackNotification.yml
+++ b/.github/workflows/slackNotification.yml
@@ -15,7 +15,7 @@ on:
       successfulEvent:
         description: URL for the successful event
         type: string
-      notification: 
+      notification:
         description: The message to be displayed for a notification.
         type: string
       type:
@@ -24,10 +24,15 @@ on:
       workflow:
         description: Caller workflow
         type: string
+      summary:
+        description: Summary of e2e results
+        type: string
     secrets:
       IDEE_RELEASE_SLACK_WEBHOOK:
         required: true
       IDEE_MAIN_SLACK_WEBHOOK:
+        required: true
+      IDEE_E2E_SLACK_WEBHOOK:
         required: true
 
 jobs:
@@ -67,7 +72,7 @@ jobs:
 
   general_notification:
     runs-on: ubuntu-latest
-    if: inputs.type == 'notification' 
+    if: inputs.type == 'notification'
     steps:
       - name: General Notification
         uses: slackapi/slack-github-action@v1.22.0
@@ -82,3 +87,19 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.IDEE_MAIN_SLACK_WEBHOOK }}
 
+  e2e_notification:
+    runs-on: ubuntu-latest
+    if: inputs.type == 'e2e'
+    steps:
+      - name: E2E Tests slack notification
+        uses: slackapi/slack-github-action@v1.22.0
+        with:
+          payload: |
+            {
+              "category": "${{ inputs.title }}",
+              "summary": "${{ inputs.summary }}",
+              "event": "${{ github.event.repository.html_url }}/${{ inputs.workflow }}",
+              "result": "${{ inputs.result }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.IDEE_E2E_SLACK_WEBHOOK }}


### PR DESCRIPTION
### What does this PR do?
Every time the Apex E2E, Core E2E or LSP E2E workflows are run, a notification with details about the outcome of each run is sent via slack

### What issues does this PR fix or reference?
@W-14324982@

### Functionality Before
- no notifications after running e2e tests

### Functionality After
- notifications after running e2e tests are sent to slack channel #e2e-tests-results
