### PR TITLE
chore: reschedule cut of release branch

### DIFF
--- a/.github/workflows/createReleaseBranch.yml
+++ b/.github/workflows/createReleaseBranch.yml
@@ -3,14 +3,14 @@ name: Create Release Branch
 on:
   repository_dispatch:
     types: create_release_branch
-  # schedule:
-  # - cron: '0 13 * * 1'
+  schedule:
+  - cron: '0 13 * * 1'
   workflow_dispatch:
     inputs:
       releaseType:
         description: 'Select the release type (default is minor)'
         required: true
-        default: 'patch'
+        default: 'minor'
         type: choice
         options:
           - minor


### PR DESCRIPTION
### What does this PR do?
- Reschedules the creation of the release branch

### What issues does this PR fix or reference?
 @W-14352369@

### Functionality Before
- We needed to manually trigger a new cut for the release branch every week

### Functionality After
- A new release branch is created every Monday