### PR TITLE
chore: fix soql LSP location for vsix and fix GHA for node 18

### DIFF
--- a/.github/workflows/createReleaseBranch.yml
+++ b/.github/workflows/createReleaseBranch.yml
@@ -45,9 +45,9 @@ jobs:
         with:
           email: ${{ secrets.IDEE_GH_EMAIL }}
       - name: Set NPM at the correct version for Lerna
-        run: npm install -g npm@8.12.1
+        run: npm install -g npm@@9.8.1
       - run: npm ci
-      - run: npm install -g shelljs && npm install -g lerna
+      - run: npm install -g shelljs && npm install -g lerna@5.5.4
       - name: Create and Push the Release Branch
         id: create_step
         run: |

--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -10,10 +10,6 @@ env:
 
 jobs:
   linux-unit-tests:
-    strategy:
-      matrix:
-        node_version: [lts/*]
-      fail-fast: false
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -22,7 +18,7 @@ jobs:
           ref: ${{ inputs.branch }}
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node_version }}
+          node-version-file: '.nvmrc'
           cache: npm
       - run: npm ci
       - run: npm run compile

--- a/.github/workflows/unitTestsWindows.yml
+++ b/.github/workflows/unitTestsWindows.yml
@@ -10,10 +10,6 @@ env:
 
 jobs:
   windows-unit-tests:
-    strategy:
-      matrix:
-        node_version: [lts/*]
-      fail-fast: false
     runs-on: windows-latest
     timeout-minutes: 20
     steps:
@@ -23,7 +19,7 @@ jobs:
           ref: ${{ inputs.branch }}
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node_version }}
+          node-version-file: '.nvmrc'
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
       - run: npm ci

--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -8,16 +8,12 @@ jobs:
   pr-validation:
     uses: salesforcecli/github-workflows/.github/workflows/validatePR.yml@main
   code-quality:
-    strategy:
-      matrix:
-        node_version: [lts/*]
-      fail-fast: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node_version }}
+          node-version-file: '.nvmrc'
           cache: npm
       - run: npm ci
       - name: Lint

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -118,6 +118,13 @@
     ],
     "packageUpdates": {
       "main": "dist/index.js",
+      "serverPath": [
+        "node_modules",
+        "@salesforce",
+        "soql-language-server",
+        "lib",
+        "server.js"
+      ],
       "dependencies": {
         "applicationinsights": "1.0.7",
         "@salesforce/apex-tmlanguage": "1.6.0",


### PR DESCRIPTION
### What does this PR do?
With the node18 upgrade we moved to npm workspaces which changed where dependencies  are located in the project.  For development they are pulled up to the root node_modules folder when shared across packaged, but still have to be in the package node_modules folder when running as a VSIX. 

I missed this update for ensuring we get the SOQL LSP from the right location in vsix. 

GHA updates: 
The node LST version changed from 18->20 on 10/24/2023.  
Updated our GHA that were using lts/* to use the nvm file for getting the node version

Update the created release branch GHA to pin the npm and lerna version to the same version as in the repo. 

### What issues does this PR fix or reference?
@W-13209367@

### Functionality Before
SOQL LSP fails to start when on used via vsix. 

### Functionality After
SOQL LSP behaves normally when used both in dev and vsix. 
GHA use node 18
create release branch GHA works