### PR TITLE
chore: get right id from workflow_run

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,7 +3,8 @@ on:
   workflow_run:
     workflows:
      - Nightly Build Develop
-    types: 
+     - Test, Build, and Release
+    types:
       - completed
   workflow_dispatch:
     inputs:
@@ -39,7 +40,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch || 'develop' }}
-      runId: ${{ inputs.runId || github.event.workflow_run.run_number }}
+      runId: ${{ inputs.runId || github.event.workflow_run.id }}
 
   Core_E2E_tests:
     if: ${{ inputs.coreE2ETests || github.event_name == 'workflow_run' }}
@@ -47,7 +48,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch || 'develop' }}
-      runId: ${{ inputs.runId || github.event.workflow_run.run_number }}
+      runId: ${{ inputs.runId || github.event.workflow_run.id }}
 
   LSP_E2E_tests:
     if: ${{ inputs.lspE2ETests || github.event_name == 'workflow_run' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,8 @@ on:
   workflow_run:
     workflows:
      - Nightly Build Develop
+    types: 
+      - completed
   workflow_dispatch:
     inputs:
       automationBranch:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -53,4 +53,4 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch || 'develop' }}
-      runId: ${{ inputs.runId || github.event.workflow_run.run_number }}
+      runId: ${{ inputs.runId || github.event.workflow_run.id }}


### PR DESCRIPTION
### What does this PR do?
- Uses the right run id of the Nightly Build Develop workflow run

### What issues does this PR fix or reference?
@W-14182445@

### Functionality Before
- e2e.yml is triggered only after Nightly Build Develop runs
- e2e.yml has the run number instead of the run id of Nightly Build Develop
- e2e.yml would run after when Nightly Build Develop status was `requested`, `in_progress` and `completed`

### Functionality After
- e2e.yml has the right run id of the triggering workflow (`Nightly Build Develop` and `Test, Build, and Release`)
- e2e.yml runs only when triggering workflow status is `completed`
- e2e.yml is triggered after triggering workflow runs
