### PR TITLE
chore: bump lls to 4.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7489,11 +7489,11 @@
       }
     },
     "node_modules/@salesforce/aura-language-server": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-4.7.1.tgz",
-      "integrity": "sha512-HAzrwhs4GjpHh4zezIounz7pqKbfGWcsZrls1WqbfuFDG55IhmcwqVDT+S/xsouiwUpOllU5mr6yvKYZh1B00Q==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-4.7.2.tgz",
+      "integrity": "sha512-2Q4/MMLDkGs9+bHec6zghPzCBDiHjHLNdarGoYbJg/tkL1Sqbuxj8lBx6WKxtymBrxAkg6ooGs918cyL+82nIA==",
       "dependencies": {
-        "@salesforce/lightning-lsp-common": "4.7.1",
+        "@salesforce/lightning-lsp-common": "4.7.2",
         "acorn": "^6.0.0",
         "acorn-loose": "^6.0.0",
         "acorn-walk": "^6.0.0",
@@ -7508,6 +7508,9 @@
         "vscode-languageserver-types": "3.14.0",
         "vscode-nls": "^4.1.2",
         "vscode-uri": "1.0.6"
+      },
+      "bin": {
+        "aura-language-server": "bin/aura-language-server.js"
       }
     },
     "node_modules/@salesforce/aura-language-server/node_modules/acorn": {
@@ -7899,9 +7902,9 @@
       "integrity": "sha512-/ZiVwtVkmq2jWRRzgsC4SEy8m54gPaDc8e+jIfnIiR04iSeSRhYJxG+ktLSYVN2jMbVWA58HfEJSCx+73GcQCg=="
     },
     "node_modules/@salesforce/lightning-lsp-common": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-4.7.1.tgz",
-      "integrity": "sha512-ewV613EdMMjBGt13UsfCj8Omsz3cMpuODmyDzHvcmJfjUSLcoeYsmeTC0BJjzZXnBD3iWyYBo1ckB+rPH6dYnQ==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-4.7.2.tgz",
+      "integrity": "sha512-DCXcd+Z5GXSU3qv3Y9mcRYAOtDpTg3W3+tv42LQ518iZbcCVm32a4vi+Gj2Dteau6UeCc8T4ankACc0B6Cyj+Q==",
       "dependencies": {
         "decamelize": "^2.0.0",
         "deep-equal": "^1.0.1",
@@ -8007,9 +8010,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@salesforce/lwc-language-server": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-4.7.1.tgz",
-      "integrity": "sha512-nCDWUks+vaIwdZETu0fv1dnShoNZ0G2YFLBkfp7dAiL2i5R9GnoluiYkdKrtqc/mM+2PE88GpqGFzgHPm/jPZQ==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-4.7.2.tgz",
+      "integrity": "sha512-GhV8MJdQONw+9mUzgIH+ZWOUq5XPhn9y/Zcv/YiAxIqWJ+rpQ0nds+bQKzjKFlQGX97z7jyLHeWmPD1+SUy2Lw==",
       "dependencies": {
         "@lwc/compiler": "2.50.0",
         "@lwc/engine-dom": "2.50.0",
@@ -8019,7 +8022,7 @@
         "@lwc/template-compiler": "2.50.0",
         "@salesforce/apex": "0.0.12",
         "@salesforce/label": "0.0.12",
-        "@salesforce/lightning-lsp-common": "4.7.1",
+        "@salesforce/lightning-lsp-common": "4.7.2",
         "@salesforce/resourceurl": "0.0.12",
         "@salesforce/schema": "0.0.12",
         "@salesforce/user": "0.0.12",
@@ -8036,6 +8039,9 @@
         "vscode-nls": "^4.1.2",
         "vscode-uri": "^2.1.2",
         "xml2js": "^0.4.23"
+      },
+      "bin": {
+        "lwc-language-server": "bin/lwc-language-server.js"
       }
     },
     "node_modules/@salesforce/lwc-language-server/node_modules/camel-case": {
@@ -40574,9 +40580,9 @@
       "version": "59.3.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/aura-language-server": "4.7.1",
+        "@salesforce/aura-language-server": "4.7.2",
         "@salesforce/core": "5.3.0",
-        "@salesforce/lightning-lsp-common": "4.7.1",
+        "@salesforce/lightning-lsp-common": "4.7.2",
         "@salesforce/salesforcedx-utils-vscode": "59.3.0",
         "applicationinsights": "1.0.7",
         "vscode-extension-telemetry": "0.0.17",
@@ -40921,8 +40927,8 @@
       "dependencies": {
         "@salesforce/core": "5.3.0",
         "@salesforce/eslint-config-lwc": "3.5.1",
-        "@salesforce/lightning-lsp-common": "4.7.1",
-        "@salesforce/lwc-language-server": "4.7.1",
+        "@salesforce/lightning-lsp-common": "4.7.2",
+        "@salesforce/lwc-language-server": "4.7.2",
         "@salesforce/salesforcedx-utils-vscode": "59.3.0",
         "ajv": "6.12.6",
         "applicationinsights": "1.0.7",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -24,9 +24,9 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/aura-language-server": "4.7.1",
+    "@salesforce/aura-language-server": "4.7.2",
     "@salesforce/core": "5.3.0",
-    "@salesforce/lightning-lsp-common": "4.7.1",
+    "@salesforce/lightning-lsp-common": "4.7.2",
     "@salesforce/salesforcedx-utils-vscode": "59.3.0",
     "applicationinsights": "1.0.7",
     "vscode-extension-telemetry": "0.0.17",
@@ -106,8 +106,8 @@
         "applicationinsights": "1.0.7",
         "@salesforce/core": "5.3.0",
         "@salesforce/source-tracking": "4.2.14",
-        "@salesforce/aura-language-server": "4.7.1",
-        "@salesforce/lightning-lsp-common": "4.7.1"
+        "@salesforce/aura-language-server": "4.7.2",
+        "@salesforce/lightning-lsp-common": "4.7.2"
       },
       "devDependencies": {}
     }

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -26,8 +26,8 @@
   "dependencies": {
     "@salesforce/core": "5.3.0",
     "@salesforce/eslint-config-lwc": "3.5.1",
-    "@salesforce/lightning-lsp-common": "4.7.1",
-    "@salesforce/lwc-language-server": "4.7.1",
+    "@salesforce/lightning-lsp-common": "4.7.2",
+    "@salesforce/lwc-language-server": "4.7.2",
     "@salesforce/salesforcedx-utils-vscode": "59.3.0",
     "ajv": "6.12.6",
     "applicationinsights": "1.0.7",
@@ -106,8 +106,8 @@
         "applicationinsights": "1.0.7",
         "@salesforce/core": "5.3.0",
         "@salesforce/source-tracking": "4.2.14",
-        "@salesforce/lightning-lsp-common": "4.7.1",
-        "@salesforce/lwc-language-server": "4.7.1"
+        "@salesforce/lightning-lsp-common": "4.7.2",
+        "@salesforce/lwc-language-server": "4.7.2"
       },
       "devDependencies": {}
     }


### PR DESCRIPTION
### What does this PR do?
- Updates the version of the lighting-language-server dependencies to pick up: 
https://github.com/forcedotcom/lightning-language-server/pull/583

### What issues does this PR fix or reference?
#5069, @W-14391061@ 

### Functionality Before
- Language server crashes if a class has a property with only a setter.

### Functionality After
- Language server doesn't crash if a class has a property with only a setter.
