### PR TITLE
chore:  grammar local fix

### DIFF
--- a/packages/salesforcedx-vscode-apex/.gitignore
+++ b/packages/salesforcedx-vscode-apex/.gitignore
@@ -1,0 +1,1 @@
+grammars

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -74,6 +74,7 @@
     "lint:fix": "npm run lint -- --fix",
     "watch": "tsc -watch -p .",
     "clean": "shx rm -rf node_modules && cd out && node ../../../scripts/clean-all-but-jar.js && shx rm -rf coverage && shx rm -rf .nyc_output",
+    "copy:files": "shx cp -R ../../node_modules/@salesforce/apex-tmlanguage/grammars .",
     "test": "npm run test:vscode-integration",
     "test:unit": "jest --coverage",
     "test:vscode-integration": "node ../../scripts/run-vscode-integration-tests-with-top-level-extensions",
@@ -87,6 +88,7 @@
       "README.md",
       ".vscodeignore",
       "OSSREADME.json",
+      "grammars",
       "resources",
       "snippets",
       "syntaxes",
@@ -388,12 +390,12 @@
       {
         "language": "apex",
         "scopeName": "source.apex",
-        "path": "./node_modules/@salesforce/apex-tmlanguage/grammars/apex.tmLanguage"
+        "path": "./grammars/apex.tmLanguage"
       },
       {
         "language": "apex-anon",
         "scopeName": "source.apex",
-        "path": "./node_modules/@salesforce/apex-tmlanguage/grammars/apex.tmLanguage"
+        "path": "./grammars/apex.tmLanguage"
       }
     ],
     "snippets": [

--- a/packages/salesforcedx-vscode-soql/.gitignore
+++ b/packages/salesforcedx-vscode-soql/.gitignore
@@ -1,0 +1,1 @@
+grammars

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -86,6 +86,7 @@
     "lint:fix": "npm run lint -- --fix",
     "watch": "tsc -watch -p .",
     "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",
+    "copy:files": "shx cp -R ../../node_modules/@salesforce/apex-tmlanguage/grammars .",
     "test": "npm run test:vscode-integration",
     "test:ui:prepare": "extest get-vscode -s ~/.vscode-test-resources && extest get-chromedriver -s ~/.vscode-test-resources ",
     "test:ui:install": "extest install-vsix -f ./salesforcedx-vscode-soql-*.vsix -s ~/.vscode-test-resources -e test/ui-test/resources/extensions ",
@@ -119,6 +120,7 @@
       "package.nls.json",
       "README.md",
       ".vscodeignore",
+      "grammars",
       "images",
       "dist"
     ],
@@ -174,7 +176,7 @@
       {
         "language": "soql",
         "scopeName": "source.soql",
-        "path": "./node_modules/@salesforce/apex-tmlanguage/grammars/soql.tmLanguage"
+        "path": "./grammars/soql.tmLanguage"
       }
     ],
     "commands": [


### PR DESCRIPTION
### What does this PR do?
Update how the apex and soql extension pull in the apex & soql grammar file so that it works locally & in vsix.  Note this is a fallout change from moving to npm workspaces. 

### What issues does this PR fix or reference?
Related to @W-14413832@

### Functionality Before
Local debug runs couldn't find the apex or soql grammar files. 

### Functionality After
grammar files are found for both vsix and local development. 
