### PR TITLE
Mz/telemetry service refactor

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/commands/commandletExecutors.ts
+++ b/packages/salesforcedx-utils-vscode/src/commands/commandletExecutors.ts
@@ -11,7 +11,7 @@ import {
   Properties,
   TelemetryBuilder,
   TelemetryData,
-  TelemetryService
+  TelemetryProvider
 } from '../index';
 import { nls } from '../messages';
 import { SfdxSettingsService } from '../settings';
@@ -62,7 +62,7 @@ export abstract class SfdxCommandletExecutor<T>
     properties?: Properties,
     measurements?: Measurements
   ) {
-    TelemetryService.getInstance().sendCommandEvent(
+    TelemetryProvider.getInstance().sendCommandEvent(
       logName,
       hrstart,
       properties,
@@ -161,7 +161,7 @@ export abstract class LibraryCommandletExecutor<T>
   public async execute(response: ContinueResponse<T>): Promise<void> {
     const startTime = process.hrtime();
     const channelService = new ChannelService(this.outputChannel);
-    const telemetryService = TelemetryService.getInstance();
+    const telemetryService = TelemetryProvider.getInstance();
     if (SfdxSettingsService.getEnableClearOutputBeforeEachCommand()) {
       channelService.clear();
     }

--- a/packages/salesforcedx-utils-vscode/src/config/configUtil.ts
+++ b/packages/salesforcedx-utils-vscode/src/config/configUtil.ts
@@ -13,9 +13,13 @@ import {
   StateAggregator
 } from '@salesforce/core';
 import { workspaceUtils } from '..';
-import { SF_CONFIG_DISABLE_TELEMETRY, TARGET_DEV_HUB_KEY, TARGET_ORG_KEY } from '../constants';
+import {
+  SF_CONFIG_DISABLE_TELEMETRY,
+  TARGET_DEV_HUB_KEY,
+  TARGET_ORG_KEY
+} from '../constants';
 import { ConfigAggregatorProvider } from '../providers';
-import { TelemetryService } from '../telemetry/telemetry';
+import { TelemetryProvider } from '../telemetry/telemetry';
 
 export enum ConfigSource {
   Local,
@@ -68,12 +72,12 @@ export class ConfigUtil {
     } catch (err) {
       console.error(err);
       if (err instanceof Error) {
-        TelemetryService.getInstance().sendException(
+        TelemetryProvider.getInstance().sendException(
           'get_default_username_alias',
           err.message
         );
       }
-      throw(err);
+      throw err;
     }
   }
 
@@ -114,9 +118,7 @@ export class ConfigUtil {
     string | undefined
   > {
     const globalConfig = await Config.create({ isGlobal: true });
-    const defaultGlobalDevHubUserName = globalConfig.get(
-      TARGET_DEV_HUB_KEY
-    );
+    const defaultGlobalDevHubUserName = globalConfig.get(TARGET_DEV_HUB_KEY);
 
     return defaultGlobalDevHubUserName
       ? String(defaultGlobalDevHubUserName)

--- a/packages/salesforcedx-utils-vscode/src/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/index.ts
@@ -31,7 +31,7 @@ export {
   WorkspaceContextUtil
 } from './context/workspaceContextUtil';
 export {
-  TelemetryService,
+  TelemetryProvider,
   TelemetryBuilder,
   TelemetryData,
   Properties,

--- a/packages/salesforcedx-utils-vscode/src/telemetry/telemetry.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/telemetry.ts
@@ -60,7 +60,7 @@ export class TelemetryProvider {
   private static instances = new Map<string, TelemetryService>();
   public static getInstance(extensionName?: string): TelemetryService {
     // If there is no parameter, it is in the context of core extension
-    if (typeof extensionName == undefined) {
+    if (!extensionName) {
       if (!TelemetryProvider.instances.has(SFDX_CORE_EXTENSION_NAME)) {
         TelemetryProvider.instances.set(
           SFDX_CORE_EXTENSION_NAME,
@@ -68,15 +68,12 @@ export class TelemetryProvider {
         );
       }
       return TelemetryProvider.instances.get(
-        SFDX_CORE_CONFIGURATION_NAME
+        SFDX_CORE_EXTENSION_NAME
       ) as TelemetryService;
     } else {
       // If there is parameter, it is called by a external extension
       if (!TelemetryProvider.instances.has(extensionName as string)) {
-        TelemetryProvider.instances.set(
-          SFDX_CORE_EXTENSION_NAME,
-          new TelemetryService()
-        );
+        TelemetryProvider.instances.set(extensionName, new TelemetryService());
       }
       return TelemetryProvider.instances.get(
         extensionName as string

--- a/packages/salesforcedx-vscode-apex/src/telemetry/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/telemetry/index.ts
@@ -4,5 +4,5 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { TelemetryService } from '@salesforce/salesforcedx-utils-vscode';
-export const telemetryService = TelemetryService.getInstance();
+import { TelemetryProvider } from '@salesforce/salesforcedx-utils-vscode';
+export const telemetryService = TelemetryProvider.getInstance();

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -9,7 +9,7 @@ import {
   ChannelService,
   getRootWorkspacePath,
   SFDX_CORE_CONFIGURATION_NAME,
-  TelemetryService
+  TelemetryProvider
 } from '@salesforce/salesforcedx-utils-vscode';
 import * as vscode from 'vscode';
 import { channelService } from './channels';
@@ -164,11 +164,10 @@ function registerCommands(
     'sfdx.force.source.deploy.in.manifest',
     forceSourceDeployManifest
   );
-  const forceSourceDeployMultipleSourcePathsCmd =
-    vscode.commands.registerCommand(
-      'sfdx.force.source.deploy.multiple.source.paths',
-      forceSourceDeploySourcePaths
-    );
+  const forceSourceDeployMultipleSourcePathsCmd = vscode.commands.registerCommand(
+    'sfdx.force.source.deploy.multiple.source.paths',
+    forceSourceDeploySourcePaths
+  );
   const forceSourceDeploySourcePathCmd = vscode.commands.registerCommand(
     'sfdx.force.source.deploy.source.path',
     forceSourceDeploySourcePaths
@@ -432,22 +431,20 @@ function registerInternalDevCommands(
     forceInternalLightningAppCreate
   );
 
-  const forceInternalLightningComponentCreateCmd =
-    vscode.commands.registerCommand(
-      'sfdx.internal.lightning.component.create',
-      forceInternalLightningComponentCreate
-    );
+  const forceInternalLightningComponentCreateCmd = vscode.commands.registerCommand(
+    'sfdx.internal.lightning.component.create',
+    forceInternalLightningComponentCreate
+  );
 
   const forceInternalLightningEventCreateCmd = vscode.commands.registerCommand(
     'sfdx.internal.lightning.event.create',
     forceInternalLightningEventCreate
   );
 
-  const forceInternalLightningInterfaceCreateCmd =
-    vscode.commands.registerCommand(
-      'sfdx.internal.lightning.interface.create',
-      forceInternalLightningInterfaceCreate
-    );
+  const forceInternalLightningInterfaceCreateCmd = vscode.commands.registerCommand(
+    'sfdx.internal.lightning.interface.create',
+    forceInternalLightningInterfaceCreate
+  );
 
   const forceInternalLightningLwcCreateCmd = vscode.commands.registerCommand(
     'sfdx.internal.lightning.lwc.create',
@@ -619,7 +616,7 @@ export async function activate(extensionContext: vscode.ExtensionContext) {
     telemetryService,
     services: {
       ChannelService,
-      TelemetryService,
+      TelemetryProvider,
       WorkspaceContext
     }
   };

--- a/packages/salesforcedx-vscode-core/src/telemetry/index.ts
+++ b/packages/salesforcedx-vscode-core/src/telemetry/index.ts
@@ -4,12 +4,12 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { TelemetryService } from '@salesforce/salesforcedx-utils-vscode';
+import { TelemetryProvider } from '@salesforce/salesforcedx-utils-vscode';
 import { commands, ExtensionContext, Uri, window } from 'vscode';
 import { TELEMETRY_GLOBAL_VALUE, TELEMETRY_OPT_OUT_LINK } from '../constants';
 import { nls } from '../messages';
 
-export const telemetryService = TelemetryService.getInstance();
+export const telemetryService = TelemetryProvider.getInstance();
 
 export function showTelemetryMessage(extensionContext: ExtensionContext) {
   const messageAlreadyPrompted = extensionContext.globalState.get(

--- a/packages/salesforcedx-vscode-lightning/src/index.ts
+++ b/packages/salesforcedx-vscode-lightning/src/index.ts
@@ -6,7 +6,7 @@
  */
 
 import { shared as lspCommon } from '@salesforce/lightning-lsp-common';
-import { TelemetryService } from '@salesforce/salesforcedx-utils-vscode';
+import { TelemetryProvider } from '@salesforce/salesforcedx-utils-vscode';
 import * as path from 'path';
 import {
   ExtensionContext,
@@ -84,7 +84,7 @@ export async function activate(extensionContext: ExtensionContext) {
   console.log('WorkspaceType detected: ' + workspaceType);
 
   // Initialize telemetry service
-  await TelemetryService.getInstance().initializeService(extensionContext);
+  await TelemetryProvider.getInstance().initializeService(extensionContext);
 
   // Start the Aura Language Server
 
@@ -178,7 +178,9 @@ export async function activate(extensionContext: ExtensionContext) {
   extensionContext.subscriptions.push(disp);
 
   // Notify telemetry that our extension is now active
-  TelemetryService.getInstance().sendExtensionActivationEvent(extensionHRStart);
+  TelemetryProvider.getInstance().sendExtensionActivationEvent(
+    extensionHRStart
+  );
 }
 
 let indexingResolve: any;
@@ -209,5 +211,5 @@ function reportIndexing(indexingPromise: Promise<void>) {
 
 export function deactivate() {
   console.log('Aura Components Extension Deactivated');
-  TelemetryService.getInstance().sendExtensionDeactivationEvent();
+  TelemetryProvider.getInstance().sendExtensionDeactivationEvent();
 }

--- a/packages/salesforcedx-vscode-lwc/src/telemetry/index.ts
+++ b/packages/salesforcedx-vscode-lwc/src/telemetry/index.ts
@@ -5,5 +5,5 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { TelemetryService } from '@salesforce/salesforcedx-utils-vscode';
-export const telemetryService = TelemetryService.getInstance();
+import { TelemetryProvider } from '@salesforce/salesforcedx-utils-vscode';
+export const telemetryService = TelemetryProvider.getInstance();

--- a/packages/salesforcedx-vscode-soql/src/telemetry/index.ts
+++ b/packages/salesforcedx-vscode-soql/src/telemetry/index.ts
@@ -4,11 +4,11 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { TelemetryService } from '@salesforce/salesforcedx-utils-vscode';
+import { TelemetryProvider } from '@salesforce/salesforcedx-utils-vscode';
 import { JsonMap } from '@salesforce/ts-types';
 import * as vscode from 'vscode';
 
-export const telemetryService = TelemetryService.getInstance();
+export const telemetryService = TelemetryProvider.getInstance();
 
 export async function startTelemetry(
   extensionContext: vscode.ExtensionContext,


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
TelemetryService used to be a singleton in core. This caused mess in App Insights of telemetry when it was exported to extensions that are not part of core (e.g. Einstein for Devlopers). This PR refactors TelemetryService by exposing TelemetryProvider to provide TelemetryService instances according to the extension context instead of using a singleton.

### What issues does this PR fix or reference?
@W-14250302@

### Functionality Before
![image](https://github.com/forcedotcom/salesforcedx-vscode/assets/132491513/0ddd1bf1-8cd8-4f34-b06c-633678c0ced5)
A non-related command is associated with Einstein for Developers extension.

### Functionality After
The issue gets fixed. There is no abnormal telemetry event being observed.