### PR TITLE
feat: add vscode setting for Apex LS trace level

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -358,6 +358,17 @@
           "type": "boolean",
           "default": false,
           "description": "%apex_code_completion_stats_description%"
+        },
+        "apex.trace.server": {
+          "type": "string",
+          "enum": ["verbose", "messages", "off"],
+          "default": "off",
+          "description": "%apex_trace_server_description%",
+          "enumDescriptions": [
+            "%apex_verbose_level_trace_description%",
+            "%apex_messages_level_trace_description%",
+            "%apex_off_level_trace_description%"
+          ]
         }
       }
     },

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -361,7 +361,11 @@
         },
         "apex.trace.server": {
           "type": "string",
-          "enum": ["verbose", "messages", "off"],
+          "enum": [
+            "verbose",
+            "messages",
+            "off"
+          ],
           "default": "off",
           "description": "%apex_trace_server_description%",
           "enumDescriptions": [

--- a/packages/salesforcedx-vscode-apex/package.nls.json
+++ b/packages/salesforcedx-vscode-apex/package.nls.json
@@ -21,5 +21,9 @@
   "force_apex_test_suite_run_text": "SFDX: Run Apex Test Suite",
   "force_apex_test_suite_create_text": "SFDX: Create Apex Test Suite",
   "force_apex_test_suite_build_text": "SFDX: Add Tests to Apex Test Suite",
-  "apex_code_completion_stats_description": "Allow Apex Language Server to collect telemetry on code completion usage"
+  "apex_code_completion_stats_description": "Allow Apex Language Server to collect telemetry on code completion usage",
+  "apex_trace_server_description": "Controls the level of detail for trace logs in Apex Language Server",
+  "apex_verbose_level_trace_description": "Output everything, including all details about notifications & responses received from the client, requests being sent from the server.",
+  "apex_messages_level_trace_description": "Only output high-level messages of notifications & responses received from the client, requests being sent from the server.",
+  "apex_off_level_trace_description": "No output. Turn off all tracing."
 }

--- a/packages/salesforcedx-vscode-apex/package.nls.json
+++ b/packages/salesforcedx-vscode-apex/package.nls.json
@@ -21,9 +21,9 @@
   "force_apex_test_suite_run_text": "SFDX: Run Apex Test Suite",
   "force_apex_test_suite_create_text": "SFDX: Create Apex Test Suite",
   "force_apex_test_suite_build_text": "SFDX: Add Tests to Apex Test Suite",
-  "apex_code_completion_stats_description": "Allow Apex Language Server to collect telemetry on code completion usage",
-  "apex_trace_server_description": "Controls the level of detail for trace logs in Apex Language Server",
-  "apex_verbose_level_trace_description": "Output everything, including all details about notifications & responses received from the client, requests being sent from the server.",
-  "apex_messages_level_trace_description": "Only output high-level messages of notifications & responses received from the client, requests being sent from the server.",
-  "apex_off_level_trace_description": "No output. Turn off all tracing."
+  "apex_code_completion_stats_description": "Allow the Apex Language Server to collect telemetry on code completion usage",
+  "apex_trace_server_description": "Controls the level of detail for trace logs in the Apex Language Server",
+  "apex_verbose_level_trace_description": "Output everything, including details about notifications and responses received by the client, and requests sent by the server.",
+  "apex_messages_level_trace_description": "Only output high-level messages of notifications and responses received by the client, and requests sent by the server.",
+  "apex_off_level_trace_description": "Don't generate any output. Turn off all tracing."
 }


### PR DESCRIPTION
### What does this PR do?
This PR allows users to change the trace level of Apex LS in VS Code Settings UI.

### What issues does this PR fix or reference?
@W-14363691@

### Functionality Before
The trace level is set off by default. It is not available for users to change it in VS Code Settings UI.

### Functionality After
Users can change the trace level of Apex LS in VS Code Settings UI.