### PR TITLE
chore: new setting for NODE_EXTRA_CA_CERTS environment value

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -968,6 +968,11 @@
           "type": "boolean",
           "default": false,
           "description": "%enable_sobject_refresh_on_startup_description%"
+        },
+        "salesforcedx-vscode-core.NODE_EXTRA_CA_CERTS": {
+          "type": "string",
+          "default": null,
+          "description": "%node_extra_ca_certs_description%"
         }
       }
     },

--- a/packages/salesforcedx-vscode-core/package.nls.ja.json
+++ b/packages/salesforcedx-vscode-core/package.nls.ja.json
@@ -68,5 +68,6 @@
   "force_diff_folder_against_org": "SFDX: フォルダと組織の差分を表示",
   "force_analytics_template_create_text": "SFDX: サンプルの Analytics テンプレートを作成",
   "force_sobjects_refresh": "SFDX: SObject 定義を更新",
+  "node_extra_ca_certs": "NODE_EXTRA_CA_CERTS CLI environment variable value",
   "enable_sobject_refresh_on_startup_description": "プロジェクトに sObject 定義がない場合、拡張機能が有効化される際に自動的に sObject 定義を更新するかどうかを指定します。"
 }

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -74,6 +74,7 @@
   "force_diff_folder_against_org": "SFDX: Diff Folder Against Org",
   "force_analytics_template_create_text": "SFDX: Create Sample Analytics Template",
   "force_sobjects_refresh": "SFDX: Refresh SObject Definitions",
+  "node_extra_ca_certs_description": "NODE_EXTRA_CA_CERTS CLI environment variable value",
   "enable_sobject_refresh_on_startup_description": "If a project has no sObject definitions, specifies whether to automatically refresh sObject definitions on extension activation (true) or not (false).",
   "force_launch_apex_replay_debugger_with_current_file": "SFDX: Launch Apex Replay Debugger with Current File",
   "setting_clear_output_tab_description": "When a new command is run, clear the output content from the previous command."

--- a/packages/salesforcedx-vscode-core/src/constants.ts
+++ b/packages/salesforcedx-vscode-core/src/constants.ts
@@ -47,9 +47,10 @@ export const ENABLE_DEPLOY_AND_RETRIEVE_FOR_SOURCE_TRACKED_ORGS =
   'enableDeployAndRetrieveForSourceTrackedOrgs.enabled';
 export const ENABLE_SOURCE_TRACKING_FOR_DEPLOY_RETRIEVE =
   'experimental.enableSourceTrackingForDeployAndRetrieve';
+export const NODE_EXTRA_CA_CERTS = 'nodeExtraCaCerts';
 export const CLI = {
   ORG_LOGIN_DEVICE: 'org:login:device',
-  ORG_LOGIN_WEB: 'org:login:web'
+  ORG_LOGIN_WEB: 'org:login:web',
 };
 export const APEX_FILE_NAME_EXTENSION = '.apex';
 export const SOQL_FILE_NAME_EXTENSION = '.soql';

--- a/packages/salesforcedx-vscode-core/src/constants.ts
+++ b/packages/salesforcedx-vscode-core/src/constants.ts
@@ -47,10 +47,10 @@ export const ENABLE_DEPLOY_AND_RETRIEVE_FOR_SOURCE_TRACKED_ORGS =
   'enableDeployAndRetrieveForSourceTrackedOrgs.enabled';
 export const ENABLE_SOURCE_TRACKING_FOR_DEPLOY_RETRIEVE =
   'experimental.enableSourceTrackingForDeployAndRetrieve';
-export const NODE_EXTRA_CA_CERTS = 'nodeExtraCaCerts';
+export const ENV_NODE_EXTRA_CA_CERTS = 'NODE_EXTRA_CA_CERTS';
 export const CLI = {
   ORG_LOGIN_DEVICE: 'org:login:device',
-  ORG_LOGIN_WEB: 'org:login:web',
+  ORG_LOGIN_WEB: 'org:login:web'
 };
 export const APEX_FILE_NAME_EXTENSION = '.apex';
 export const SOQL_FILE_NAME_EXTENSION = '.soql';

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -377,6 +377,8 @@ function registerCommands(
   );
 
   return vscode.Disposable.from(
+    forceRenameComponentCmd,
+    forceDiffFolder,
     forceAuthAccessTokenCmd,
     dataQueryInputCmd,
     dataQuerySelectionCmd,
@@ -430,6 +432,8 @@ function registerCommands(
     orgListCleanCmd,
     orgLoginWebCmd,
     orgLoginWebDevHubCmd,
+    orgLogoutAllCmd,
+    orgLogoutDefaultCmd,
     orgOpenCmd
   );
 }

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -109,7 +109,11 @@ import { isSfdxProjectOpened } from './predicates';
 import { registerPushOrDeployOnSave, sfdxCoreSettings } from './settings';
 import { taskViewService } from './statuses';
 import { showTelemetryMessage, telemetryService } from './telemetry';
-import { isCLIInstalled, setUpOrgExpirationWatcher } from './util';
+import {
+  isCLIInstalled,
+  setUpOrgExpirationWatcher,
+  setNodeExtraCaCerts
+} from './util';
 import { OrgAuthInfo } from './util/authInfo';
 
 const flagOverwrite: FlagParameter<string> = {
@@ -527,6 +531,7 @@ export async function activate(extensionContext: vscode.ExtensionContext) {
   // thus avoiding the potential errors surfaced when the libs call
   // process.cwd().
   ensureCurrentWorkingDirIsProjectPath(rootWorkspacePath);
+  setNodeExtraCaCerts();
   await telemetryService.initializeService(extensionContext);
   showTelemetryMessage(extensionContext);
 

--- a/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
@@ -99,7 +99,10 @@ export class SfdxCoreSettings {
   }
 
   public getNodeExtraCaCerts(): string {
-    return this.getConfigValue(ENV_NODE_EXTRA_CA_CERTS, '');
+    return this.getConfigValue(
+      ENV_NODE_EXTRA_CA_CERTS,
+      process.env.NODE_EXTRA_CA_CERTS ?? ''
+    );
   }
 
   private getConfigValue<T>(key: string, defaultValue: T): T {

--- a/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
@@ -7,7 +7,7 @@
 
 import {
   SETTING_CLEAR_OUTPUT_TAB,
-  SFDX_CORE_CONFIGURATION_NAME,
+  SFDX_CORE_CONFIGURATION_NAME
 } from '@salesforce/salesforcedx-utils-vscode';
 import * as vscode from 'vscode';
 import {
@@ -20,7 +20,7 @@ import {
   PUSH_OR_DEPLOY_ON_SAVE_OVERRIDE_CONFLICTS,
   RETRIEVE_TEST_CODE_COVERAGE,
   SHOW_CLI_SUCCESS_INFO_MSG,
-  TELEMETRY_ENABLED,
+  TELEMETRY_ENABLED
 } from '../constants';
 /**
  * A centralized location for interacting with sfdx-core settings.
@@ -67,7 +67,7 @@ export class SfdxCoreSettings {
   public getPushOrDeployOnSaveOverrideConflicts(): boolean {
     return this.getConfigValue<boolean>(
       PUSH_OR_DEPLOY_ON_SAVE_OVERRIDE_CONFLICTS,
-      false,
+      false
     );
   }
 
@@ -78,7 +78,7 @@ export class SfdxCoreSettings {
   public getEnableSourceTrackingForDeployAndRetrieve(): boolean {
     return this.getConfigValue(
       ENABLE_SOURCE_TRACKING_FOR_DEPLOY_RETRIEVE,
-      true,
+      true
     );
   }
 

--- a/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
@@ -14,7 +14,7 @@ import {
   CONFLICT_DETECTION_ENABLED,
   ENABLE_SOURCE_TRACKING_FOR_DEPLOY_RETRIEVE,
   INTERNAL_DEVELOPMENT_FLAG,
-  NODE_EXTRA_CA_CERTS,
+  ENV_NODE_EXTRA_CA_CERTS,
   PREFER_DEPLOY_ON_SAVE_ENABLED,
   PUSH_OR_DEPLOY_ON_SAVE_ENABLED,
   PUSH_OR_DEPLOY_ON_SAVE_OVERRIDE_CONFLICTS,
@@ -99,7 +99,7 @@ export class SfdxCoreSettings {
   }
 
   public getNodeExtraCaCerts(): string {
-    return this.getConfigValue(NODE_EXTRA_CA_CERTS, '');
+    return this.getConfigValue(ENV_NODE_EXTRA_CA_CERTS, '');
   }
 
   private getConfigValue<T>(key: string, defaultValue: T): T {

--- a/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
@@ -7,19 +7,20 @@
 
 import {
   SETTING_CLEAR_OUTPUT_TAB,
-  SFDX_CORE_CONFIGURATION_NAME
+  SFDX_CORE_CONFIGURATION_NAME,
 } from '@salesforce/salesforcedx-utils-vscode';
 import * as vscode from 'vscode';
 import {
   CONFLICT_DETECTION_ENABLED,
   ENABLE_SOURCE_TRACKING_FOR_DEPLOY_RETRIEVE,
   INTERNAL_DEVELOPMENT_FLAG,
+  NODE_EXTRA_CA_CERTS,
   PREFER_DEPLOY_ON_SAVE_ENABLED,
   PUSH_OR_DEPLOY_ON_SAVE_ENABLED,
   PUSH_OR_DEPLOY_ON_SAVE_OVERRIDE_CONFLICTS,
   RETRIEVE_TEST_CODE_COVERAGE,
   SHOW_CLI_SUCCESS_INFO_MSG,
-  TELEMETRY_ENABLED
+  TELEMETRY_ENABLED,
 } from '../constants';
 /**
  * A centralized location for interacting with sfdx-core settings.
@@ -66,7 +67,7 @@ export class SfdxCoreSettings {
   public getPushOrDeployOnSaveOverrideConflicts(): boolean {
     return this.getConfigValue<boolean>(
       PUSH_OR_DEPLOY_ON_SAVE_OVERRIDE_CONFLICTS,
-      false
+      false,
     );
   }
 
@@ -75,7 +76,10 @@ export class SfdxCoreSettings {
   }
 
   public getEnableSourceTrackingForDeployAndRetrieve(): boolean {
-    return this.getConfigValue(ENABLE_SOURCE_TRACKING_FOR_DEPLOY_RETRIEVE, true);
+    return this.getConfigValue(
+      ENABLE_SOURCE_TRACKING_FOR_DEPLOY_RETRIEVE,
+      true,
+    );
   }
 
   public getRetrieveTestCodeCoverage(): boolean {
@@ -92,6 +96,10 @@ export class SfdxCoreSettings {
 
   public getEnableClearOutputBeforeEachCommand(): boolean {
     return this.getConfigValue(SETTING_CLEAR_OUTPUT_TAB, false);
+  }
+
+  public getNodeExtraCaCerts(): string {
+    return this.getConfigValue(NODE_EXTRA_CA_CERTS, '');
   }
 
   private getConfigValue<T>(key: string, defaultValue: T): T {

--- a/packages/salesforcedx-vscode-core/src/util/cliConfiguration.ts
+++ b/packages/salesforcedx-vscode-core/src/util/cliConfiguration.ts
@@ -12,10 +12,12 @@ import {
 import { which } from 'shelljs';
 import { window } from 'vscode';
 import {
+  ENV_NODE_EXTRA_CA_CERTS,
   ENV_SF_DISABLE_TELEMETRY,
   SFDX_CLI_DOWNLOAD_LINK
 } from '../constants';
 import { nls } from '../messages';
+import { sfdxCoreSettings } from '../settings';
 
 export function isCLIInstalled(): boolean {
   let isInstalled = false;
@@ -48,4 +50,11 @@ export function disableCLITelemetry() {
 export async function isCLITelemetryAllowed() {
   const isTelemetryDisabled = await ConfigUtil.isTelemetryDisabled();
   return !isTelemetryDisabled;
+}
+
+export function setNodeExtraCaCerts() {
+  GlobalCliEnvironment.environmentVariables.set(
+    ENV_NODE_EXTRA_CA_CERTS,
+    sfdxCoreSettings.getNodeExtraCaCerts()
+  );
 }

--- a/packages/salesforcedx-vscode-core/src/util/index.ts
+++ b/packages/salesforcedx-vscode-core/src/util/index.ts
@@ -10,6 +10,7 @@ export {
   disableCLITelemetry,
   isCLIInstalled,
   isCLITelemetryAllowed,
+  setNodeExtraCaCerts,
   showCLINotInstalledMessage
 } from './cliConfiguration';
 export { workspaceUtils } from './rootWorkspace';


### PR DESCRIPTION
### What does this PR do?
- Adds new core setting for the NODE_EXTRA_CA_CERTS environment value

### What issues does this PR fix or reference?
@W-11384659@

### Functionality Before
- NODE_EXTRA_CA_CERTS has no effect in deploy/retrieve operations

### Functionality After
- new setting for NODE_EXTRA_CA_CERTS so it has effect in deploy/retrieve operations
