### PR TITLE
feat: add ext deps to enable faster activation

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -62,6 +62,9 @@
     "typescript": "^5.2.2",
     "vscode-extension-telemetry": "0.0.17"
   },
+  "extensionDependencies": [
+    "salesforce.salesforcedx-vscode-core"
+  ],
   "scripts": {
     "bundle:extension": "npm run bundle:extension:build && npm run bundle:extension:copy",
     "bundle:extension:copy": "cp ./out/apex-jorje-lsp.jar ./dist/",

--- a/packages/salesforcedx-vscode-expanded/package.json
+++ b/packages/salesforcedx-vscode-expanded/package.json
@@ -36,6 +36,7 @@
     "salesforce.salesforcedx-vscode-lightning",
     "salesforce.salesforcedx-vscode-visualforce",
     "salesforce.salesforcedx-vscode-lwc",
+    "salesforce.salesforcedx-vscode-soql",
     "salesforce.salesforce-vscode-slds",
     "redhat.vscode-xml",
     "dbaeumer.vscode-eslint",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -60,6 +60,9 @@
     "typescript": "^5.2.2",
     "vscode-uri": "1.0.1"
   },
+  "extensionDependencies": [
+    "salesforce.salesforcedx-vscode-core"
+  ],
   "scripts": {
     "bundle:extension": "esbuild ./src/index.ts  --bundle --outfile=dist/index.js --format=cjs --platform=node --external:vscode  --external:@salesforce/core --external:@salesforce/source-tracking --external:applicationinsights --external:@salesforce/lightning-lsp-common --external:@salesforce/aura-language-server --minify",
     "clean": "shx rm -rf node_modules && shx rm -rf out && shx rm -rf coverage && shx rm -rf .nyc_output",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -73,7 +73,8 @@
     "which": "1.3.1"
   },
   "extensionDependencies": [
-    "dbaeumer.vscode-eslint"
+    "dbaeumer.vscode-eslint",
+    "salesforce.salesforcedx-vscode-core"
   ],
   "scripts": {
     "bundle:extension": "esbuild ./src/index.ts  --bundle --outfile=dist/index.js --format=cjs --platform=node --loader:.node=file --external:vscode  --external:@salesforce/core --external:@salesforce/source-tracking --external:applicationinsights --external:@salesforce/lightning-lsp-common --external:@salesforce/lwc-language-serve --external:@babel/preset-typescript/package.json --minify",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -78,6 +78,9 @@
     "vscode-extension-tester": "^5.0.0",
     "vscode-languageclient": "6.1.3"
   },
+  "extensionDependencies": [
+    "salesforce.salesforcedx-vscode-core"
+  ],
   "scripts": {
     "bundle:extension": "esbuild ./src/index.ts  --bundle --outfile=dist/index.js --format=cjs --platform=node --external:vscode  --external:@salesforce/core --external:@salesforce/source-tracking  --external:applicationinsights --external:shelljs --external:@salesforce/soql-model --external:@salesforce/soql-language-server --external:@salesforce/soql-data-view --external:@salesforce/soql-builder-ui --minify",
     "build": "npm run compile",


### PR DESCRIPTION
### What does this PR do?
Update the extensions to have extDeps when not already present. 
core <- apex, lwc, lighting, soql
apex <- apex-debugger, apex-replay-debugger

One concern is this makes uninstalling individual extensions have an order. You can not uninstall an ext until all ext with deps have been uninstalled.   Not an issue when using extension packs. 

### What issues does this PR fix or reference?
@W-14418821@

### Functionality Before
four extension attempted to activate at the same time

### Functionality After
core activates first, then apex, lwc, lightning, and soql, then the debugger after apex.

Tested vsix files on windows to verify all extensions load

![Screenshot 2023-11-28 at 12 49 37 AM](https://github.com/forcedotcom/salesforcedx-vscode/assets/76090802/bfea3f11-5ba7-4245-95f0-24c030f4b39f)
