### PR TITLE
Cristi/w 14366453/e2e in old vscode

### DIFF
--- a/.github/workflows/runE2ETest.yml
+++ b/.github/workflows/runE2ETest.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         nodeVersion:
-          - 18.11.0
+          - 18.18.2
         vscodeVersion:
           - stable
     steps:

--- a/.github/workflows/vscodeSupportE2E.yml
+++ b/.github/workflows/vscodeSupportE2E.yml
@@ -24,7 +24,6 @@ on:
       vscodeVersion:
         description: 'VS Code Version'
         required: false
-        default: '1.61.2'
         type: string
 
 jobs:
@@ -37,7 +36,7 @@ jobs:
         nodeVersion:
           - 18.11.0
         vscodeVersion:
-          - ${{ inputs.vscodeVersion }}
+          - ${{ inputs.vscodeVersion || '1.61.2'}}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -48,7 +47,7 @@ jobs:
         run: |
           mkdir ./extensions
           pwd
-          gh run download ${{ inputs.runId }} -D ./extensions
+          gh run download ${{ inputs.runId || github.event.workflow_run.id }} -D ./extensions
           mv ./extensions/*/* ./extensions/
         working-directory: salesforcedx-vscode
         env:
@@ -73,7 +72,7 @@ jobs:
         with:
           repository: forcedotcom/salesforcedx-vscode-automation-tests
           path: salesforcedx-vscode-automation-tests
-          ref: ${{ inputs.automationBranch }}
+          ref: ${{ inputs.automationBranch || 'develop' }}
       - name: Install Test Dependencies
         run: |
           npm install
@@ -102,7 +101,7 @@ jobs:
           working-directory: salesforcedx-vscode-automation-tests
         env:
           VSCODE_VERSION: ${{ matrix.vscodeVersion }}
-          SPEC_FILES: ${{ inputs.testToRun }}
+          SPEC_FILES: ${{ inputs.testToRun || 'anInitialSuite.e2e.ts' }}
           SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL_E2E }}
           ORG_ID: ${{ secrets.ORG_ID_E2E }}
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/vscodeSupportE2E.yml
+++ b/.github/workflows/vscodeSupportE2E.yml
@@ -15,6 +15,7 @@ on:
       testToRun:
         description: 'Run this E2E test'
         required: false
+        default: 'anInitialSuite.e2e.ts'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -23,7 +24,7 @@ on:
       vscodeVersion:
         description: 'VS Code Version'
         required: false
-        default: 'stable'
+        default: '1.61.2'
         type: string
 
 jobs:
@@ -36,7 +37,7 @@ jobs:
         nodeVersion:
           - 18.11.0
         vscodeVersion:
-          - ${{ inputs.vscodeVersion || '1.61.2' }}
+          - ${{ inputs.vscodeVersion }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -101,7 +102,7 @@ jobs:
           working-directory: salesforcedx-vscode-automation-tests
         env:
           VSCODE_VERSION: ${{ matrix.vscodeVersion }}
-          SPEC_FILES: 'anInitialSuite.e2e.ts'
+          SPEC_FILES: ${{ inputs.testToRun }}
           SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL_E2E }}
           ORG_ID: ${{ secrets.ORG_ID_E2E }}
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/vscodeSupportE2E.yml
+++ b/.github/workflows/vscodeSupportE2E.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         nodeVersion:
-          - 18.11.0
+          - 18.18.2
         vscodeVersion:
           - ${{ inputs.vscodeVersion || '1.61.2'}}
     steps:

--- a/.github/workflows/vscodeSupportE2E.yml
+++ b/.github/workflows/vscodeSupportE2E.yml
@@ -1,0 +1,111 @@
+name: VS Code Support E2E Tests
+on:
+  workflow_run:
+    workflows:
+      - Nightly Build Develop
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      automationBranch:
+        description: 'Set the branch to use for automation tests'
+        required: false
+        default: 'develop'
+        type: string
+      testToRun:
+        description: 'Run this E2E test'
+        required: false
+        type: string
+      runId:
+        description: 'Run ID of the workflow run that created the vsixes'
+        required: false
+        type: string
+      vscodeVersion:
+        description: 'VS Code Version'
+        required: false
+        default: 'stable'
+        type: string
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        nodeVersion:
+          - 18.11.0
+        vscodeVersion:
+          - ${{ inputs.vscodeVersion }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: ./salesforcedx-vscode
+          ref: ${{ github.event.ref }}
+      - name: Download extension vsixes
+        run: |
+          mkdir ./extensions
+          pwd
+          gh run download ${{ inputs.runId }} -D ./extensions
+          mv ./extensions/*/* ./extensions/
+        working-directory: salesforcedx-vscode
+        env:
+          GITHUB_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
+      - name: Display downloaded vsix files
+        run: ls -R ./salesforcedx-vscode/extensions
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.nodeVersion }}
+          cache: npm
+          cache-dependency-path: |
+            salesforcedx-vscode/package-lock.json
+            salesforcedx-vscode-automation-tests/package-lock.json
+      - name: Setup java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+      - name: Clone automation tests
+        uses: actions/checkout@v3
+        with:
+          repository: forcedotcom/salesforcedx-vscode-automation-tests
+          path: salesforcedx-vscode-automation-tests
+          ref: ${{ inputs.automationBranch }}
+      - name: Install Test Dependencies
+        run: |
+          npm install
+        working-directory: salesforcedx-vscode-automation-tests
+      - name: Install the SFDX CLI
+        run: npm install -g sfdx-cli
+      - name: Verify CLI
+        shell: bash
+        run: |
+          set -e
+          sfdx version
+          SFDX_CLI_VERSION=$(sfdx version)
+          if [[ ((`echo $SFDX_CLI_VERSION | grep -c "sfdx-cli/"` > 0))]]
+          then
+            echo "sfdx-cli installed -" $SFDX_CLI_VERSION
+          else
+            echo "The sfdx-cli installation could not be verified"
+            exit 1
+          fi
+      - name: Run headless test
+        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3
+        with:
+          run: |
+            npm run setup
+            npm run automation-tests
+          working-directory: salesforcedx-vscode-automation-tests
+        env:
+          VSCODE_VERSION: ${{ matrix.vscodeVersion }}
+          SPEC_FILES: 'anInitialSuite.e2e.ts'
+          SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL_E2E }}
+          ORG_ID: ${{ secrets.ORG_ID_E2E }}
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: screenshots
+          path: ./salesforcedx-vscode-automation-tests/screenshots

--- a/.github/workflows/vscodeSupportE2E.yml
+++ b/.github/workflows/vscodeSupportE2E.yml
@@ -36,7 +36,7 @@ jobs:
         nodeVersion:
           - 18.11.0
         vscodeVersion:
-          - ${{ inputs.vscodeVersion }}
+          - ${{ inputs.vscodeVersion || '1.61.2' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/packages/salesforcedx-apex-debugger/test/integration/adapter.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/integration/adapter.test.ts
@@ -5,213 +5,208 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-// import * as util from '@salesforce/salesforcedx-test-utils-vscode/out/src/orgUtils';
-// import {
-//   CliCommandExecutor,
-//   CommandExecution,
-//   SfdxCommandBuilder
-// } from '@salesforce/salesforcedx-utils-vscode';
+import * as util from '@salesforce/salesforcedx-test-utils-vscode/out/src/orgUtils';
+import {
+  CliCommandExecutor,
+  CommandExecution,
+  SfdxCommandBuilder
+} from '@salesforce/salesforcedx-utils-vscode';
 import { expect } from 'chai';
-// import * as path from 'path';
-// import * as rimraf from 'rimraf';
-// import { DebugClient } from 'vscode-debugadapter-testsupport';
-// import { DebugProtocol } from 'vscode-debugprotocol';
-// import Uri from 'vscode-uri';
-// import { LaunchRequestArguments } from '../../src/adapter/apexDebug';
-// import { LineBreakpointInfo } from '../../src/breakpoints/lineBreakpoint';
+import * as path from 'path';
+import * as rimraf from 'rimraf';
+import { DebugClient } from 'vscode-debugadapter-testsupport';
+import { DebugProtocol } from 'vscode-debugprotocol';
+import Uri from 'vscode-uri';
+import { LaunchRequestArguments } from '../../src/adapter/apexDebug';
+import { LineBreakpointInfo } from '../../src/breakpoints/lineBreakpoint';
 
-// const PROJECT_NAME = `project_${new Date().getTime()}`;
-// const SIMPLE_VARIABLES_DIR = path.join(
-//   __dirname,
-//   '..',
-//   '..',
-//   '..',
-//   'test',
-//   'integration',
-//   'config',
-//   'variables'
-// );
-// const SOURCE_FOLDER = path.join(SIMPLE_VARIABLES_DIR, 'source');
-// const APEX_EXEC_FILE = path.join(SIMPLE_VARIABLES_DIR, 'apexExec', 'test.apex');
-// const LINE_BREAKPOINT_INFO: LineBreakpointInfo[] = [];
+const PROJECT_NAME = `project_${new Date().getTime()}`;
+const SIMPLE_VARIABLES_DIR = path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'test',
+  'integration',
+  'config',
+  'variables'
+);
+const SOURCE_FOLDER = path.join(SIMPLE_VARIABLES_DIR, 'source');
+const APEX_EXEC_FILE = path.join(SIMPLE_VARIABLES_DIR, 'apexExec', 'test.apex');
+const LINE_BREAKPOINT_INFO: LineBreakpointInfo[] = [];
 
 /**
  * These integration tests assume the environment has authenticated to
  * a Dev Hub and it is set as the default Dev Hub.
  */
 describe.skip('Interactive debugger adapter - integration', () => {
-  // jest.setTimeout(320000);
-  // let dc: DebugClient;
-  // let userName: string;
-  // let projectPath: string;
-  // let apexClassUri: string;
+  jest.setTimeout(320000);
+  let dc: DebugClient;
+  let userName: string;
+  let projectPath: string;
+  let apexClassUri: string;
 
-  // beforeAll(async () => {
-  //   // Create SFDX project
-  //   projectPath = path.join(process.cwd(), PROJECT_NAME);
-  //   console.log(`projectPath: ${projectPath}`);
-  //   await util.createSFDXProject(PROJECT_NAME);
-  //   // Create scratch org with Debug Apex enabled
-  //   util.addFeatureToScratchOrgConfig(PROJECT_NAME, 'DebugApex');
-  //   apexClassUri = Uri.file(
-  //     `${projectPath}/force-app/main/default/classes/BasicVariables.cls`
-  //   ).toString();
-  //   if (process.platform === 'win32') {
-  //     apexClassUri = apexClassUri.replace('%3A', ':');
-  //   }
-  //   console.log(`apexClassUri: ${apexClassUri}`);
-  //   LINE_BREAKPOINT_INFO.push({
-  //     uri: apexClassUri,
-  //     typeref: 'BasicVariables',
-  //     lines: [
-  //       14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 27, 29, 30, 31, 32, 33,
-  //       34, 36, 37, 39, 40, 42
-  //     ]
-  //   });
-  //   LINE_BREAKPOINT_INFO.push({
-  //     uri: apexClassUri,
-  //     typeref: 'BasicVariables$MyInnerClass',
-  //     lines: [6, 7]
-  //   });
-  //   userName = await util.createScratchOrg(PROJECT_NAME);
-  //   // Push source to scratch org
-  //   await util.pushSource(SOURCE_FOLDER, PROJECT_NAME, userName);
-  //   // Assign Debug Apex permission to user
-  //   await util.assignPermissionSet('DebugApex', userName);
-  //   // Start debugger client
-  //   // Use dc.start(4711) to debug the adapter during
-  //   // tests (adapter needs to be launched in debug mode separately).
-  //   dc = new DebugClient('node', './out/src/adapter/apexDebug.js', 'apex');
-  //   await dc.start();
-  //   dc.defaultTimeout = 10000;
-  // });
-
-  // afterAll(async () => {
-  //   if (userName) {
-  //     await util.deleteScratchOrg(PROJECT_NAME, userName);
-  //   }
-  //   rimraf.sync(projectPath);
-  //   if (dc) {
-  //     await dc.stop();
-  //   }
-  // });
-
-  it('Your test suite must contain at least one test.', async () => {
-    const aux = true;
-    expect(aux).to.equal(true);
+  beforeAll(async () => {
+    // Create SFDX project
+    projectPath = path.join(process.cwd(), PROJECT_NAME);
+    console.log(`projectPath: ${projectPath}`);
+    await util.createSFDXProject(PROJECT_NAME);
+    // Create scratch org with Debug Apex enabled
+    util.addFeatureToScratchOrgConfig(PROJECT_NAME, 'DebugApex');
+    apexClassUri = Uri.file(
+      `${projectPath}/force-app/main/default/classes/BasicVariables.cls`
+    ).toString();
+    if (process.platform === 'win32') {
+      apexClassUri = apexClassUri.replace('%3A', ':');
+    }
+    console.log(`apexClassUri: ${apexClassUri}`);
+    LINE_BREAKPOINT_INFO.push({
+      uri: apexClassUri,
+      typeref: 'BasicVariables',
+      lines: [
+        14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 27, 29, 30, 31, 32, 33,
+        34, 36, 37, 39, 40, 42
+      ]
+    });
+    LINE_BREAKPOINT_INFO.push({
+      uri: apexClassUri,
+      typeref: 'BasicVariables$MyInnerClass',
+      lines: [6, 7]
+    });
+    userName = await util.createScratchOrg(PROJECT_NAME);
+    // Push source to scratch org
+    await util.pushSource(SOURCE_FOLDER, PROJECT_NAME, userName);
+    // Assign Debug Apex permission to user
+    await util.assignPermissionSet('DebugApex', userName);
+    // Start debugger client
+    // Use dc.start(4711) to debug the adapter during
+    // tests (adapter needs to be launched in debug mode separately).
+    dc = new DebugClient('node', './out/src/adapter/apexDebug.js', 'apex');
+    await dc.start();
+    dc.defaultTimeout = 10000;
   });
 
-  // it('Should not attach', async () => {
-  //   try {
-  //     await dc.attachRequest({});
-  //     expect.fail('Debugger client should have thrown an error');
-  //     // tslint:disable-next-line:no-empty
-  //   } catch (error) {}
-  // });
+  afterAll(async () => {
+    if (userName) {
+      await util.deleteScratchOrg(PROJECT_NAME, userName);
+    }
+    rimraf.sync(projectPath);
+    if (dc) {
+      await dc.stop();
+    }
+  });
 
-  // it('End-to-end flow', async () => {
-  //   // Launch Apex Debugger session
-  //   const launchResponse = await dc.launchRequest({
-  //     sfdxProject: projectPath
-  //   } as LaunchRequestArguments);
-  //   expect(launchResponse.success).to.equal(true);
-  //   try {
-  //     // Add breakpoint
-  //     const apexClassPath = Uri.parse(apexClassUri).fsPath;
-  //     console.log(`apexClassPath: ${apexClassPath}`);
-  //     const addBreakpointsResponse = await dc.setBreakpointsRequest({
-  //       source: {
-  //         path: apexClassPath
-  //       },
-  //       lines: [42]
-  //     });
-  //     expect(addBreakpointsResponse.success).to.equal(true);
-  //     expect(addBreakpointsResponse.body.breakpoints.length).to.equal(1);
-  //     expect(addBreakpointsResponse.body.breakpoints[0]).to.deep.equal({
-  //       verified: true,
-  //       source: {
-  //         path: apexClassPath
-  //       },
-  //       line: 42
-  //     } as DebugProtocol.Breakpoint);
-  //     // Invoke Apex method
-  //     execApexNoWait(APEX_EXEC_FILE, userName);
-  //     // Verify stack
-  //     const stackTraceResponse = await dc.assertStoppedLocation('', {
-  //       path: apexClassPath,
-  //       line: 42
-  //     });
-  //     expect(stackTraceResponse.success).to.equal(true);
-  //     expect(stackTraceResponse.body.stackFrames.length).to.equal(2);
-  //     expect(stackTraceResponse.body.stackFrames[0].name).to.equal(
-  //       'BasicVariables.testAll()'
-  //     );
-  //     expect(stackTraceResponse.body.stackFrames[1].name).to.equal(
-  //       'anon.execute()'
-  //     );
-  //     // Verify threads
-  //     const threadResponse = await dc.threadsRequest();
-  //     expect(threadResponse.success).to.equal(true);
-  //     expect(threadResponse.body.threads.length).to.equal(1);
-  //     // Verify scopes
-  //     const scopesResponse = await dc.scopesRequest({
-  //       frameId: stackTraceResponse.body.stackFrames[0].id
-  //     });
-  //     expect(scopesResponse.success).to.equal(true);
-  //     expect(scopesResponse.body.scopes.length).to.equal(3);
-  //     expect(scopesResponse.body.scopes[0].name).to.equal('Local');
-  //     expect(scopesResponse.body.scopes[1].name).to.equal('Static');
-  //     expect(scopesResponse.body.scopes[2].name).to.equal('Global');
-  //     // Verify variables
-  //     const variablesResponse = await dc.variablesRequest({
-  //       variablesReference: scopesResponse.body.scopes[0].variablesReference
-  //     });
-  //     expect(variablesResponse.success).to.equal(true);
-  //     expect(variablesResponse.body.variables.length).is.greaterThan(0);
-  //     // Expand variables
-  //     for (const variable of variablesResponse.body.variables) {
-  //       if (variable.variablesReference === 0) {
-  //         continue;
-  //       }
-  //       const expandResponse = await dc.variablesRequest({
-  //         variablesReference: variable.variablesReference
-  //       });
-  //       expect(expandResponse.success).to.equal(true);
-  //       expect(expandResponse.body.variables.length).is.greaterThan(0);
-  //     }
-  //     // Finish the debugged request
-  //     const nextResponse = await dc.nextRequest({
-  //       threadId: threadResponse.body.threads[0].id
-  //     });
-  //     expect(nextResponse.success).to.equal(true);
-  //     // Delete breakpoint
-  //     const deleteBreakpointsResponse = await dc.setBreakpointsRequest({
-  //       source: {
-  //         path: apexClassPath
-  //       },
-  //       lines: []
-  //     });
-  //     expect(deleteBreakpointsResponse.success).to.equal(true);
-  //     expect(deleteBreakpointsResponse.body.breakpoints.length).to.equal(0);
-  //   } finally {
-  //     // Disconnect Apex Debugger session
-  //     const disconnectResponse = await dc.disconnectRequest({});
-  //     expect(disconnectResponse.success).to.equal(true);
-  //   }
-  // });
+  it('Should not attach', async () => {
+    try {
+      await dc.attachRequest({});
+      expect.fail('Debugger client should have thrown an error');
+      // tslint:disable-next-line:no-empty
+    } catch (error) {}
+  });
+
+  it('End-to-end flow', async () => {
+    // Launch Apex Debugger session
+    const launchResponse = await dc.launchRequest({
+      sfdxProject: projectPath
+    } as LaunchRequestArguments);
+    expect(launchResponse.success).to.equal(true);
+    try {
+      // Add breakpoint
+      const apexClassPath = Uri.parse(apexClassUri).fsPath;
+      console.log(`apexClassPath: ${apexClassPath}`);
+      const addBreakpointsResponse = await dc.setBreakpointsRequest({
+        source: {
+          path: apexClassPath
+        },
+        lines: [42]
+      });
+      expect(addBreakpointsResponse.success).to.equal(true);
+      expect(addBreakpointsResponse.body.breakpoints.length).to.equal(1);
+      expect(addBreakpointsResponse.body.breakpoints[0]).to.deep.equal({
+        verified: true,
+        source: {
+          path: apexClassPath
+        },
+        line: 42
+      } as DebugProtocol.Breakpoint);
+      // Invoke Apex method
+      execApexNoWait(APEX_EXEC_FILE, userName);
+      // Verify stack
+      const stackTraceResponse = await dc.assertStoppedLocation('', {
+        path: apexClassPath,
+        line: 42
+      });
+      expect(stackTraceResponse.success).to.equal(true);
+      expect(stackTraceResponse.body.stackFrames.length).to.equal(2);
+      expect(stackTraceResponse.body.stackFrames[0].name).to.equal(
+        'BasicVariables.testAll()'
+      );
+      expect(stackTraceResponse.body.stackFrames[1].name).to.equal(
+        'anon.execute()'
+      );
+      // Verify threads
+      const threadResponse = await dc.threadsRequest();
+      expect(threadResponse.success).to.equal(true);
+      expect(threadResponse.body.threads.length).to.equal(1);
+      // Verify scopes
+      const scopesResponse = await dc.scopesRequest({
+        frameId: stackTraceResponse.body.stackFrames[0].id
+      });
+      expect(scopesResponse.success).to.equal(true);
+      expect(scopesResponse.body.scopes.length).to.equal(3);
+      expect(scopesResponse.body.scopes[0].name).to.equal('Local');
+      expect(scopesResponse.body.scopes[1].name).to.equal('Static');
+      expect(scopesResponse.body.scopes[2].name).to.equal('Global');
+      // Verify variables
+      const variablesResponse = await dc.variablesRequest({
+        variablesReference: scopesResponse.body.scopes[0].variablesReference
+      });
+      expect(variablesResponse.success).to.equal(true);
+      expect(variablesResponse.body.variables.length).is.greaterThan(0);
+      // Expand variables
+      for (const variable of variablesResponse.body.variables) {
+        if (variable.variablesReference === 0) {
+          continue;
+        }
+        const expandResponse = await dc.variablesRequest({
+          variablesReference: variable.variablesReference
+        });
+        expect(expandResponse.success).to.equal(true);
+        expect(expandResponse.body.variables.length).is.greaterThan(0);
+      }
+      // Finish the debugged request
+      const nextResponse = await dc.nextRequest({
+        threadId: threadResponse.body.threads[0].id
+      });
+      expect(nextResponse.success).to.equal(true);
+      // Delete breakpoint
+      const deleteBreakpointsResponse = await dc.setBreakpointsRequest({
+        source: {
+          path: apexClassPath
+        },
+        lines: []
+      });
+      expect(deleteBreakpointsResponse.success).to.equal(true);
+      expect(deleteBreakpointsResponse.body.breakpoints.length).to.equal(0);
+    } finally {
+      // Disconnect Apex Debugger session
+      const disconnectResponse = await dc.disconnectRequest({});
+      expect(disconnectResponse.success).to.equal(true);
+    }
+  });
 });
 
-// function execApexNoWait(
-//   apexExecFilePath: string,
-//   userName: string
-// ): CommandExecution {
-//   return new CliCommandExecutor(
-//     new SfdxCommandBuilder()
-//       .withArg('force:apex:execute')
-//       .withFlag('--apexcodefile', apexExecFilePath)
-//       .withFlag('--targetusername', userName)
-//       .withJson()
-//       .build(),
-//     { cwd: process.cwd() }
-//   ).execute();
-// }
+function execApexNoWait(
+  apexExecFilePath: string,
+  userName: string
+): CommandExecution {
+  return new CliCommandExecutor(
+    new SfdxCommandBuilder()
+      .withArg('force:apex:execute')
+      .withFlag('--apexcodefile', apexExecFilePath)
+      .withFlag('--targetusername', userName)
+      .withJson()
+      .build(),
+    { cwd: process.cwd() }
+  ).execute();
+}

--- a/packages/salesforcedx-apex-debugger/test/integration/adapter.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/integration/adapter.test.ts
@@ -39,184 +39,184 @@ const LINE_BREAKPOINT_INFO: LineBreakpointInfo[] = [];
  * These integration tests assume the environment has authenticated to
  * a Dev Hub and it is set as the default Dev Hub.
  */
-describe.skip('Interactive debugger adapter - integration', () => {
-  jest.setTimeout(320000);
-  let dc: DebugClient;
-  let userName: string;
-  let projectPath: string;
-  let apexClassUri: string;
+// describe.skip('Interactive debugger adapter - integration', () => {
+//   jest.setTimeout(320000);
+//   let dc: DebugClient;
+//   let userName: string;
+//   let projectPath: string;
+//   let apexClassUri: string;
 
-  beforeAll(async () => {
-    // Create SFDX project
-    projectPath = path.join(process.cwd(), PROJECT_NAME);
-    console.log(`projectPath: ${projectPath}`);
-    await util.createSFDXProject(PROJECT_NAME);
-    // Create scratch org with Debug Apex enabled
-    util.addFeatureToScratchOrgConfig(PROJECT_NAME, 'DebugApex');
-    apexClassUri = Uri.file(
-      `${projectPath}/force-app/main/default/classes/BasicVariables.cls`
-    ).toString();
-    if (process.platform === 'win32') {
-      apexClassUri = apexClassUri.replace('%3A', ':');
-    }
-    console.log(`apexClassUri: ${apexClassUri}`);
-    LINE_BREAKPOINT_INFO.push({
-      uri: apexClassUri,
-      typeref: 'BasicVariables',
-      lines: [
-        14,
-        15,
-        16,
-        17,
-        18,
-        19,
-        20,
-        21,
-        22,
-        23,
-        24,
-        25,
-        27,
-        29,
-        30,
-        31,
-        32,
-        33,
-        34,
-        36,
-        37,
-        39,
-        40,
-        42
-      ]
-    });
-    LINE_BREAKPOINT_INFO.push({
-      uri: apexClassUri,
-      typeref: 'BasicVariables$MyInnerClass',
-      lines: [6, 7]
-    });
-    userName = await util.createScratchOrg(PROJECT_NAME);
-    // Push source to scratch org
-    await util.pushSource(SOURCE_FOLDER, PROJECT_NAME, userName);
-    // Assign Debug Apex permission to user
-    await util.assignPermissionSet('DebugApex', userName);
-    // Start debugger client
-    // Use dc.start(4711) to debug the adapter during
-    // tests (adapter needs to be launched in debug mode separately).
-    dc = new DebugClient('node', './out/src/adapter/apexDebug.js', 'apex');
-    await dc.start();
-    dc.defaultTimeout = 10000;
-  });
+//   beforeAll(async () => {
+//     // Create SFDX project
+//     projectPath = path.join(process.cwd(), PROJECT_NAME);
+//     console.log(`projectPath: ${projectPath}`);
+//     await util.createSFDXProject(PROJECT_NAME);
+//     // Create scratch org with Debug Apex enabled
+//     util.addFeatureToScratchOrgConfig(PROJECT_NAME, 'DebugApex');
+//     apexClassUri = Uri.file(
+//       `${projectPath}/force-app/main/default/classes/BasicVariables.cls`
+//     ).toString();
+//     if (process.platform === 'win32') {
+//       apexClassUri = apexClassUri.replace('%3A', ':');
+//     }
+//     console.log(`apexClassUri: ${apexClassUri}`);
+//     LINE_BREAKPOINT_INFO.push({
+//       uri: apexClassUri,
+//       typeref: 'BasicVariables',
+//       lines: [
+//         14,
+//         15,
+//         16,
+//         17,
+//         18,
+//         19,
+//         20,
+//         21,
+//         22,
+//         23,
+//         24,
+//         25,
+//         27,
+//         29,
+//         30,
+//         31,
+//         32,
+//         33,
+//         34,
+//         36,
+//         37,
+//         39,
+//         40,
+//         42
+//       ]
+//     });
+//     LINE_BREAKPOINT_INFO.push({
+//       uri: apexClassUri,
+//       typeref: 'BasicVariables$MyInnerClass',
+//       lines: [6, 7]
+//     });
+//     userName = await util.createScratchOrg(PROJECT_NAME);
+//     // Push source to scratch org
+//     await util.pushSource(SOURCE_FOLDER, PROJECT_NAME, userName);
+//     // Assign Debug Apex permission to user
+//     await util.assignPermissionSet('DebugApex', userName);
+//     // Start debugger client
+//     // Use dc.start(4711) to debug the adapter during
+//     // tests (adapter needs to be launched in debug mode separately).
+//     dc = new DebugClient('node', './out/src/adapter/apexDebug.js', 'apex');
+//     await dc.start();
+//     dc.defaultTimeout = 10000;
+//   });
 
-  afterAll(async () => {
-    if (userName) {
-      await util.deleteScratchOrg(PROJECT_NAME, userName);
-    }
-    rimraf.sync(projectPath);
-    if (dc) {
-      await dc.stop();
-    }
-  });
+//   afterAll(async () => {
+//     if (userName) {
+//       await util.deleteScratchOrg(PROJECT_NAME, userName);
+//     }
+//     rimraf.sync(projectPath);
+//     if (dc) {
+//       await dc.stop();
+//     }
+//   });
 
-  it('Should not attach', async () => {
-    try {
-      await dc.attachRequest({});
-      expect.fail('Debugger client should have thrown an error');
-      // tslint:disable-next-line:no-empty
-    } catch (error) {}
-  });
+//   it('Should not attach', async () => {
+//     try {
+//       await dc.attachRequest({});
+//       expect.fail('Debugger client should have thrown an error');
+//       // tslint:disable-next-line:no-empty
+//     } catch (error) {}
+//   });
 
-  it('End-to-end flow', async () => {
-    // Launch Apex Debugger session
-    const launchResponse = await dc.launchRequest({
-      sfdxProject: projectPath
-    } as LaunchRequestArguments);
-    expect(launchResponse.success).to.equal(true);
-    try {
-      // Add breakpoint
-      const apexClassPath = Uri.parse(apexClassUri).fsPath;
-      console.log(`apexClassPath: ${apexClassPath}`);
-      const addBreakpointsResponse = await dc.setBreakpointsRequest({
-        source: {
-          path: apexClassPath
-        },
-        lines: [42]
-      });
-      expect(addBreakpointsResponse.success).to.equal(true);
-      expect(addBreakpointsResponse.body.breakpoints.length).to.equal(1);
-      expect(addBreakpointsResponse.body.breakpoints[0]).to.deep.equal({
-        verified: true,
-        source: {
-          path: apexClassPath
-        },
-        line: 42
-      } as DebugProtocol.Breakpoint);
-      // Invoke Apex method
-      execApexNoWait(APEX_EXEC_FILE, userName);
-      // Verify stack
-      const stackTraceResponse = await dc.assertStoppedLocation('', {
-        path: apexClassPath,
-        line: 42
-      });
-      expect(stackTraceResponse.success).to.equal(true);
-      expect(stackTraceResponse.body.stackFrames.length).to.equal(2);
-      expect(stackTraceResponse.body.stackFrames[0].name).to.equal(
-        'BasicVariables.testAll()'
-      );
-      expect(stackTraceResponse.body.stackFrames[1].name).to.equal(
-        'anon.execute()'
-      );
-      // Verify threads
-      const threadResponse = await dc.threadsRequest();
-      expect(threadResponse.success).to.equal(true);
-      expect(threadResponse.body.threads.length).to.equal(1);
-      // Verify scopes
-      const scopesResponse = await dc.scopesRequest({
-        frameId: stackTraceResponse.body.stackFrames[0].id
-      });
-      expect(scopesResponse.success).to.equal(true);
-      expect(scopesResponse.body.scopes.length).to.equal(3);
-      expect(scopesResponse.body.scopes[0].name).to.equal('Local');
-      expect(scopesResponse.body.scopes[1].name).to.equal('Static');
-      expect(scopesResponse.body.scopes[2].name).to.equal('Global');
-      // Verify variables
-      const variablesResponse = await dc.variablesRequest({
-        variablesReference: scopesResponse.body.scopes[0].variablesReference
-      });
-      expect(variablesResponse.success).to.equal(true);
-      expect(variablesResponse.body.variables.length).is.greaterThan(0);
-      // Expand variables
-      for (const variable of variablesResponse.body.variables) {
-        if (variable.variablesReference === 0) {
-          continue;
-        }
-        const expandResponse = await dc.variablesRequest({
-          variablesReference: variable.variablesReference
-        });
-        expect(expandResponse.success).to.equal(true);
-        expect(expandResponse.body.variables.length).is.greaterThan(0);
-      }
-      // Finish the debugged request
-      const nextResponse = await dc.nextRequest({
-        threadId: threadResponse.body.threads[0].id
-      });
-      expect(nextResponse.success).to.equal(true);
-      // Delete breakpoint
-      const deleteBreakpointsResponse = await dc.setBreakpointsRequest({
-        source: {
-          path: apexClassPath
-        },
-        lines: []
-      });
-      expect(deleteBreakpointsResponse.success).to.equal(true);
-      expect(deleteBreakpointsResponse.body.breakpoints.length).to.equal(0);
-    } finally {
-      // Disconnect Apex Debugger session
-      const disconnectResponse = await dc.disconnectRequest({});
-      expect(disconnectResponse.success).to.equal(true);
-    }
-  });
-});
+//   it('End-to-end flow', async () => {
+//     // Launch Apex Debugger session
+//     const launchResponse = await dc.launchRequest({
+//       sfdxProject: projectPath
+//     } as LaunchRequestArguments);
+//     expect(launchResponse.success).to.equal(true);
+//     try {
+//       // Add breakpoint
+//       const apexClassPath = Uri.parse(apexClassUri).fsPath;
+//       console.log(`apexClassPath: ${apexClassPath}`);
+//       const addBreakpointsResponse = await dc.setBreakpointsRequest({
+//         source: {
+//           path: apexClassPath
+//         },
+//         lines: [42]
+//       });
+//       expect(addBreakpointsResponse.success).to.equal(true);
+//       expect(addBreakpointsResponse.body.breakpoints.length).to.equal(1);
+//       expect(addBreakpointsResponse.body.breakpoints[0]).to.deep.equal({
+//         verified: true,
+//         source: {
+//           path: apexClassPath
+//         },
+//         line: 42
+//       } as DebugProtocol.Breakpoint);
+//       // Invoke Apex method
+//       execApexNoWait(APEX_EXEC_FILE, userName);
+//       // Verify stack
+//       const stackTraceResponse = await dc.assertStoppedLocation('', {
+//         path: apexClassPath,
+//         line: 42
+//       });
+//       expect(stackTraceResponse.success).to.equal(true);
+//       expect(stackTraceResponse.body.stackFrames.length).to.equal(2);
+//       expect(stackTraceResponse.body.stackFrames[0].name).to.equal(
+//         'BasicVariables.testAll()'
+//       );
+//       expect(stackTraceResponse.body.stackFrames[1].name).to.equal(
+//         'anon.execute()'
+//       );
+//       // Verify threads
+//       const threadResponse = await dc.threadsRequest();
+//       expect(threadResponse.success).to.equal(true);
+//       expect(threadResponse.body.threads.length).to.equal(1);
+//       // Verify scopes
+//       const scopesResponse = await dc.scopesRequest({
+//         frameId: stackTraceResponse.body.stackFrames[0].id
+//       });
+//       expect(scopesResponse.success).to.equal(true);
+//       expect(scopesResponse.body.scopes.length).to.equal(3);
+//       expect(scopesResponse.body.scopes[0].name).to.equal('Local');
+//       expect(scopesResponse.body.scopes[1].name).to.equal('Static');
+//       expect(scopesResponse.body.scopes[2].name).to.equal('Global');
+//       // Verify variables
+//       const variablesResponse = await dc.variablesRequest({
+//         variablesReference: scopesResponse.body.scopes[0].variablesReference
+//       });
+//       expect(variablesResponse.success).to.equal(true);
+//       expect(variablesResponse.body.variables.length).is.greaterThan(0);
+//       // Expand variables
+//       for (const variable of variablesResponse.body.variables) {
+//         if (variable.variablesReference === 0) {
+//           continue;
+//         }
+//         const expandResponse = await dc.variablesRequest({
+//           variablesReference: variable.variablesReference
+//         });
+//         expect(expandResponse.success).to.equal(true);
+//         expect(expandResponse.body.variables.length).is.greaterThan(0);
+//       }
+//       // Finish the debugged request
+//       const nextResponse = await dc.nextRequest({
+//         threadId: threadResponse.body.threads[0].id
+//       });
+//       expect(nextResponse.success).to.equal(true);
+//       // Delete breakpoint
+//       const deleteBreakpointsResponse = await dc.setBreakpointsRequest({
+//         source: {
+//           path: apexClassPath
+//         },
+//         lines: []
+//       });
+//       expect(deleteBreakpointsResponse.success).to.equal(true);
+//       expect(deleteBreakpointsResponse.body.breakpoints.length).to.equal(0);
+//     } finally {
+//       // Disconnect Apex Debugger session
+//       const disconnectResponse = await dc.disconnectRequest({});
+//       expect(disconnectResponse.success).to.equal(true);
+//     }
+//   });
+// });
 
 function execApexNoWait(
   apexExecFilePath: string,

--- a/packages/salesforcedx-apex-debugger/test/integration/adapter.test.ts
+++ b/packages/salesforcedx-apex-debugger/test/integration/adapter.test.ts
@@ -5,230 +5,213 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import * as util from '@salesforce/salesforcedx-test-utils-vscode/out/src/orgUtils';
-import {
-  CliCommandExecutor,
-  CommandExecution,
-  SfdxCommandBuilder
-} from '@salesforce/salesforcedx-utils-vscode';
+// import * as util from '@salesforce/salesforcedx-test-utils-vscode/out/src/orgUtils';
+// import {
+//   CliCommandExecutor,
+//   CommandExecution,
+//   SfdxCommandBuilder
+// } from '@salesforce/salesforcedx-utils-vscode';
 import { expect } from 'chai';
-import * as path from 'path';
-import * as rimraf from 'rimraf';
-import { DebugClient } from 'vscode-debugadapter-testsupport';
-import { DebugProtocol } from 'vscode-debugprotocol';
-import Uri from 'vscode-uri';
-import { LaunchRequestArguments } from '../../src/adapter/apexDebug';
-import { LineBreakpointInfo } from '../../src/breakpoints/lineBreakpoint';
+// import * as path from 'path';
+// import * as rimraf from 'rimraf';
+// import { DebugClient } from 'vscode-debugadapter-testsupport';
+// import { DebugProtocol } from 'vscode-debugprotocol';
+// import Uri from 'vscode-uri';
+// import { LaunchRequestArguments } from '../../src/adapter/apexDebug';
+// import { LineBreakpointInfo } from '../../src/breakpoints/lineBreakpoint';
 
-const PROJECT_NAME = `project_${new Date().getTime()}`;
-const SIMPLE_VARIABLES_DIR = path.join(
-  __dirname,
-  '..',
-  '..',
-  '..',
-  'test',
-  'integration',
-  'config',
-  'variables'
-);
-const SOURCE_FOLDER = path.join(SIMPLE_VARIABLES_DIR, 'source');
-const APEX_EXEC_FILE = path.join(SIMPLE_VARIABLES_DIR, 'apexExec', 'test.apex');
-const LINE_BREAKPOINT_INFO: LineBreakpointInfo[] = [];
+// const PROJECT_NAME = `project_${new Date().getTime()}`;
+// const SIMPLE_VARIABLES_DIR = path.join(
+//   __dirname,
+//   '..',
+//   '..',
+//   '..',
+//   'test',
+//   'integration',
+//   'config',
+//   'variables'
+// );
+// const SOURCE_FOLDER = path.join(SIMPLE_VARIABLES_DIR, 'source');
+// const APEX_EXEC_FILE = path.join(SIMPLE_VARIABLES_DIR, 'apexExec', 'test.apex');
+// const LINE_BREAKPOINT_INFO: LineBreakpointInfo[] = [];
 
 /**
  * These integration tests assume the environment has authenticated to
  * a Dev Hub and it is set as the default Dev Hub.
  */
-// describe.skip('Interactive debugger adapter - integration', () => {
-//   jest.setTimeout(320000);
-//   let dc: DebugClient;
-//   let userName: string;
-//   let projectPath: string;
-//   let apexClassUri: string;
+describe.skip('Interactive debugger adapter - integration', () => {
+  // jest.setTimeout(320000);
+  // let dc: DebugClient;
+  // let userName: string;
+  // let projectPath: string;
+  // let apexClassUri: string;
 
-//   beforeAll(async () => {
-//     // Create SFDX project
-//     projectPath = path.join(process.cwd(), PROJECT_NAME);
-//     console.log(`projectPath: ${projectPath}`);
-//     await util.createSFDXProject(PROJECT_NAME);
-//     // Create scratch org with Debug Apex enabled
-//     util.addFeatureToScratchOrgConfig(PROJECT_NAME, 'DebugApex');
-//     apexClassUri = Uri.file(
-//       `${projectPath}/force-app/main/default/classes/BasicVariables.cls`
-//     ).toString();
-//     if (process.platform === 'win32') {
-//       apexClassUri = apexClassUri.replace('%3A', ':');
-//     }
-//     console.log(`apexClassUri: ${apexClassUri}`);
-//     LINE_BREAKPOINT_INFO.push({
-//       uri: apexClassUri,
-//       typeref: 'BasicVariables',
-//       lines: [
-//         14,
-//         15,
-//         16,
-//         17,
-//         18,
-//         19,
-//         20,
-//         21,
-//         22,
-//         23,
-//         24,
-//         25,
-//         27,
-//         29,
-//         30,
-//         31,
-//         32,
-//         33,
-//         34,
-//         36,
-//         37,
-//         39,
-//         40,
-//         42
-//       ]
-//     });
-//     LINE_BREAKPOINT_INFO.push({
-//       uri: apexClassUri,
-//       typeref: 'BasicVariables$MyInnerClass',
-//       lines: [6, 7]
-//     });
-//     userName = await util.createScratchOrg(PROJECT_NAME);
-//     // Push source to scratch org
-//     await util.pushSource(SOURCE_FOLDER, PROJECT_NAME, userName);
-//     // Assign Debug Apex permission to user
-//     await util.assignPermissionSet('DebugApex', userName);
-//     // Start debugger client
-//     // Use dc.start(4711) to debug the adapter during
-//     // tests (adapter needs to be launched in debug mode separately).
-//     dc = new DebugClient('node', './out/src/adapter/apexDebug.js', 'apex');
-//     await dc.start();
-//     dc.defaultTimeout = 10000;
-//   });
+  // beforeAll(async () => {
+  //   // Create SFDX project
+  //   projectPath = path.join(process.cwd(), PROJECT_NAME);
+  //   console.log(`projectPath: ${projectPath}`);
+  //   await util.createSFDXProject(PROJECT_NAME);
+  //   // Create scratch org with Debug Apex enabled
+  //   util.addFeatureToScratchOrgConfig(PROJECT_NAME, 'DebugApex');
+  //   apexClassUri = Uri.file(
+  //     `${projectPath}/force-app/main/default/classes/BasicVariables.cls`
+  //   ).toString();
+  //   if (process.platform === 'win32') {
+  //     apexClassUri = apexClassUri.replace('%3A', ':');
+  //   }
+  //   console.log(`apexClassUri: ${apexClassUri}`);
+  //   LINE_BREAKPOINT_INFO.push({
+  //     uri: apexClassUri,
+  //     typeref: 'BasicVariables',
+  //     lines: [
+  //       14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 27, 29, 30, 31, 32, 33,
+  //       34, 36, 37, 39, 40, 42
+  //     ]
+  //   });
+  //   LINE_BREAKPOINT_INFO.push({
+  //     uri: apexClassUri,
+  //     typeref: 'BasicVariables$MyInnerClass',
+  //     lines: [6, 7]
+  //   });
+  //   userName = await util.createScratchOrg(PROJECT_NAME);
+  //   // Push source to scratch org
+  //   await util.pushSource(SOURCE_FOLDER, PROJECT_NAME, userName);
+  //   // Assign Debug Apex permission to user
+  //   await util.assignPermissionSet('DebugApex', userName);
+  //   // Start debugger client
+  //   // Use dc.start(4711) to debug the adapter during
+  //   // tests (adapter needs to be launched in debug mode separately).
+  //   dc = new DebugClient('node', './out/src/adapter/apexDebug.js', 'apex');
+  //   await dc.start();
+  //   dc.defaultTimeout = 10000;
+  // });
 
-//   afterAll(async () => {
-//     if (userName) {
-//       await util.deleteScratchOrg(PROJECT_NAME, userName);
-//     }
-//     rimraf.sync(projectPath);
-//     if (dc) {
-//       await dc.stop();
-//     }
-//   });
+  // afterAll(async () => {
+  //   if (userName) {
+  //     await util.deleteScratchOrg(PROJECT_NAME, userName);
+  //   }
+  //   rimraf.sync(projectPath);
+  //   if (dc) {
+  //     await dc.stop();
+  //   }
+  // });
 
-//   it('Should not attach', async () => {
-//     try {
-//       await dc.attachRequest({});
-//       expect.fail('Debugger client should have thrown an error');
-//       // tslint:disable-next-line:no-empty
-//     } catch (error) {}
-//   });
+  it('Your test suite must contain at least one test.', async () => {
+    const aux = true;
+    expect(aux).to.equal(true);
+  });
 
-//   it('End-to-end flow', async () => {
-//     // Launch Apex Debugger session
-//     const launchResponse = await dc.launchRequest({
-//       sfdxProject: projectPath
-//     } as LaunchRequestArguments);
-//     expect(launchResponse.success).to.equal(true);
-//     try {
-//       // Add breakpoint
-//       const apexClassPath = Uri.parse(apexClassUri).fsPath;
-//       console.log(`apexClassPath: ${apexClassPath}`);
-//       const addBreakpointsResponse = await dc.setBreakpointsRequest({
-//         source: {
-//           path: apexClassPath
-//         },
-//         lines: [42]
-//       });
-//       expect(addBreakpointsResponse.success).to.equal(true);
-//       expect(addBreakpointsResponse.body.breakpoints.length).to.equal(1);
-//       expect(addBreakpointsResponse.body.breakpoints[0]).to.deep.equal({
-//         verified: true,
-//         source: {
-//           path: apexClassPath
-//         },
-//         line: 42
-//       } as DebugProtocol.Breakpoint);
-//       // Invoke Apex method
-//       execApexNoWait(APEX_EXEC_FILE, userName);
-//       // Verify stack
-//       const stackTraceResponse = await dc.assertStoppedLocation('', {
-//         path: apexClassPath,
-//         line: 42
-//       });
-//       expect(stackTraceResponse.success).to.equal(true);
-//       expect(stackTraceResponse.body.stackFrames.length).to.equal(2);
-//       expect(stackTraceResponse.body.stackFrames[0].name).to.equal(
-//         'BasicVariables.testAll()'
-//       );
-//       expect(stackTraceResponse.body.stackFrames[1].name).to.equal(
-//         'anon.execute()'
-//       );
-//       // Verify threads
-//       const threadResponse = await dc.threadsRequest();
-//       expect(threadResponse.success).to.equal(true);
-//       expect(threadResponse.body.threads.length).to.equal(1);
-//       // Verify scopes
-//       const scopesResponse = await dc.scopesRequest({
-//         frameId: stackTraceResponse.body.stackFrames[0].id
-//       });
-//       expect(scopesResponse.success).to.equal(true);
-//       expect(scopesResponse.body.scopes.length).to.equal(3);
-//       expect(scopesResponse.body.scopes[0].name).to.equal('Local');
-//       expect(scopesResponse.body.scopes[1].name).to.equal('Static');
-//       expect(scopesResponse.body.scopes[2].name).to.equal('Global');
-//       // Verify variables
-//       const variablesResponse = await dc.variablesRequest({
-//         variablesReference: scopesResponse.body.scopes[0].variablesReference
-//       });
-//       expect(variablesResponse.success).to.equal(true);
-//       expect(variablesResponse.body.variables.length).is.greaterThan(0);
-//       // Expand variables
-//       for (const variable of variablesResponse.body.variables) {
-//         if (variable.variablesReference === 0) {
-//           continue;
-//         }
-//         const expandResponse = await dc.variablesRequest({
-//           variablesReference: variable.variablesReference
-//         });
-//         expect(expandResponse.success).to.equal(true);
-//         expect(expandResponse.body.variables.length).is.greaterThan(0);
-//       }
-//       // Finish the debugged request
-//       const nextResponse = await dc.nextRequest({
-//         threadId: threadResponse.body.threads[0].id
-//       });
-//       expect(nextResponse.success).to.equal(true);
-//       // Delete breakpoint
-//       const deleteBreakpointsResponse = await dc.setBreakpointsRequest({
-//         source: {
-//           path: apexClassPath
-//         },
-//         lines: []
-//       });
-//       expect(deleteBreakpointsResponse.success).to.equal(true);
-//       expect(deleteBreakpointsResponse.body.breakpoints.length).to.equal(0);
-//     } finally {
-//       // Disconnect Apex Debugger session
-//       const disconnectResponse = await dc.disconnectRequest({});
-//       expect(disconnectResponse.success).to.equal(true);
-//     }
-//   });
-// });
+  // it('Should not attach', async () => {
+  //   try {
+  //     await dc.attachRequest({});
+  //     expect.fail('Debugger client should have thrown an error');
+  //     // tslint:disable-next-line:no-empty
+  //   } catch (error) {}
+  // });
 
-function execApexNoWait(
-  apexExecFilePath: string,
-  userName: string
-): CommandExecution {
-  return new CliCommandExecutor(
-    new SfdxCommandBuilder()
-      .withArg('force:apex:execute')
-      .withFlag('--apexcodefile', apexExecFilePath)
-      .withFlag('--targetusername', userName)
-      .withJson()
-      .build(),
-    { cwd: process.cwd() }
-  ).execute();
-}
+  // it('End-to-end flow', async () => {
+  //   // Launch Apex Debugger session
+  //   const launchResponse = await dc.launchRequest({
+  //     sfdxProject: projectPath
+  //   } as LaunchRequestArguments);
+  //   expect(launchResponse.success).to.equal(true);
+  //   try {
+  //     // Add breakpoint
+  //     const apexClassPath = Uri.parse(apexClassUri).fsPath;
+  //     console.log(`apexClassPath: ${apexClassPath}`);
+  //     const addBreakpointsResponse = await dc.setBreakpointsRequest({
+  //       source: {
+  //         path: apexClassPath
+  //       },
+  //       lines: [42]
+  //     });
+  //     expect(addBreakpointsResponse.success).to.equal(true);
+  //     expect(addBreakpointsResponse.body.breakpoints.length).to.equal(1);
+  //     expect(addBreakpointsResponse.body.breakpoints[0]).to.deep.equal({
+  //       verified: true,
+  //       source: {
+  //         path: apexClassPath
+  //       },
+  //       line: 42
+  //     } as DebugProtocol.Breakpoint);
+  //     // Invoke Apex method
+  //     execApexNoWait(APEX_EXEC_FILE, userName);
+  //     // Verify stack
+  //     const stackTraceResponse = await dc.assertStoppedLocation('', {
+  //       path: apexClassPath,
+  //       line: 42
+  //     });
+  //     expect(stackTraceResponse.success).to.equal(true);
+  //     expect(stackTraceResponse.body.stackFrames.length).to.equal(2);
+  //     expect(stackTraceResponse.body.stackFrames[0].name).to.equal(
+  //       'BasicVariables.testAll()'
+  //     );
+  //     expect(stackTraceResponse.body.stackFrames[1].name).to.equal(
+  //       'anon.execute()'
+  //     );
+  //     // Verify threads
+  //     const threadResponse = await dc.threadsRequest();
+  //     expect(threadResponse.success).to.equal(true);
+  //     expect(threadResponse.body.threads.length).to.equal(1);
+  //     // Verify scopes
+  //     const scopesResponse = await dc.scopesRequest({
+  //       frameId: stackTraceResponse.body.stackFrames[0].id
+  //     });
+  //     expect(scopesResponse.success).to.equal(true);
+  //     expect(scopesResponse.body.scopes.length).to.equal(3);
+  //     expect(scopesResponse.body.scopes[0].name).to.equal('Local');
+  //     expect(scopesResponse.body.scopes[1].name).to.equal('Static');
+  //     expect(scopesResponse.body.scopes[2].name).to.equal('Global');
+  //     // Verify variables
+  //     const variablesResponse = await dc.variablesRequest({
+  //       variablesReference: scopesResponse.body.scopes[0].variablesReference
+  //     });
+  //     expect(variablesResponse.success).to.equal(true);
+  //     expect(variablesResponse.body.variables.length).is.greaterThan(0);
+  //     // Expand variables
+  //     for (const variable of variablesResponse.body.variables) {
+  //       if (variable.variablesReference === 0) {
+  //         continue;
+  //       }
+  //       const expandResponse = await dc.variablesRequest({
+  //         variablesReference: variable.variablesReference
+  //       });
+  //       expect(expandResponse.success).to.equal(true);
+  //       expect(expandResponse.body.variables.length).is.greaterThan(0);
+  //     }
+  //     // Finish the debugged request
+  //     const nextResponse = await dc.nextRequest({
+  //       threadId: threadResponse.body.threads[0].id
+  //     });
+  //     expect(nextResponse.success).to.equal(true);
+  //     // Delete breakpoint
+  //     const deleteBreakpointsResponse = await dc.setBreakpointsRequest({
+  //       source: {
+  //         path: apexClassPath
+  //       },
+  //       lines: []
+  //     });
+  //     expect(deleteBreakpointsResponse.success).to.equal(true);
+  //     expect(deleteBreakpointsResponse.body.breakpoints.length).to.equal(0);
+  //   } finally {
+  //     // Disconnect Apex Debugger session
+  //     const disconnectResponse = await dc.disconnectRequest({});
+  //     expect(disconnectResponse.success).to.equal(true);
+  //   }
+  // });
+});
+
+// function execApexNoWait(
+//   apexExecFilePath: string,
+//   userName: string
+// ): CommandExecution {
+//   return new CliCommandExecutor(
+//     new SfdxCommandBuilder()
+//       .withArg('force:apex:execute')
+//       .withFlag('--apexcodefile', apexExecFilePath)
+//       .withFlag('--targetusername', userName)
+//       .withJson()
+//       .build(),
+//     { cwd: process.cwd() }
+//   ).execute();
+// }

--- a/packages/salesforcedx-apex-replay-debugger/test/integration/adapter.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/integration/adapter.test.ts
@@ -49,7 +49,7 @@ describe('Replay debugger adapter - integration', () => {
       'apex-replay'
     );
     await dc.start();
-    dc.defaultTimeout = 15000;
+    dc.defaultTimeout = 10000;
   });
 
   afterAll(async () => {

--- a/packages/salesforcedx-apex-replay-debugger/test/integration/adapter.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/integration/adapter.test.ts
@@ -49,7 +49,7 @@ describe('Replay debugger adapter - integration', () => {
       'apex-replay'
     );
     await dc.start();
-    dc.defaultTimeout = 10000;
+    dc.defaultTimeout = 15000;
   });
 
   afterAll(async () => {


### PR DESCRIPTION
### What does this PR do?
- Adds a new nightly GHA that will run just the initial E2E test suite (verifying extension start) against the desired version of vscode

### What issues does this PR fix or reference?
@W-14366453@

### Functionality after
- E2E anInitialSuite.e2e.ts Test run after Nightly build develop runs.
- E2E anInitialSuite.e2e.ts Test run against oldest vscode version we support (by default same as engines property in the source code) or any other we provide
- E2E anInitialSuite.e2e.ts Test is the default test we run but any other suite e.g deployAndRetrieve.e2e.ts can be run as well
![image](https://github.com/forcedotcom/salesforcedx-vscode/assets/113132642/ffd3a2fc-18d9-453e-8524-8cba9d51ceb1)

