### PR TITLE
fix: correct log file name formatting error

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/date/format.ts
+++ b/packages/salesforcedx-utils-vscode/src/date/format.ts
@@ -18,7 +18,7 @@ export const getYYYYMMddHHmmssDateFormat = (localUTCDate: Date): string => {
 };
 
 export const makeDoubleDigit = (currentDigit: number): string => {
-  return format('%02d', currentDigit);
+  return format('%d', currentDigit).padStart(2, '0');
 };
 
 export const optionYYYYMMddHHmmss: Intl.DateTimeFormatOptions = {

--- a/packages/salesforcedx-utils-vscode/test/jest/date/format.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/date/format.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {
+  getYYYYMMddHHmmssDateFormat,
+  makeDoubleDigit,
+  optionYYYYMMddHHmmss,
+  optionHHmm,
+  optionMMddYYYY
+} from '../../../src/date/format';
+
+describe('getYYYYMMddHHmmssDateFormat', () => {
+  it('should return the correct date format', () => {
+    const date = new Date('2022-01-01T12:34:56');
+    const formattedDate = getYYYYMMddHHmmssDateFormat(date);
+    expect(formattedDate).toBe('20220101123456');
+  });
+});
+
+describe('makeDoubleDigit', () => {
+  it('should return the double digit format for single digit numbers', () => {
+    const doubleDigit = makeDoubleDigit(5);
+    expect(doubleDigit).toBe('05');
+  });
+
+  it('should return the same number for double digit numbers', () => {
+    const doubleDigit = makeDoubleDigit(12);
+    expect(doubleDigit).toBe('12');
+  });
+});
+
+describe('optionYYYYMMddHHmmss', () => {
+  it('should have the correct options', () => {
+    expect(optionYYYYMMddHHmmss).toEqual({
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit'
+    });
+  });
+});
+
+describe('optionHHmm', () => {
+  it('should have the correct options', () => {
+    expect(optionHHmm).toEqual({
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  });
+});
+
+describe('optionMMddYYYY', () => {
+  it('should have the correct options', () => {
+    expect(optionMMddYYYY).toEqual({
+      month: '2-digit',
+      day: '2-digit',
+      year: 'numeric'
+    });
+  });
+});

--- a/packages/salesforcedx-vscode-apex/src/commands/forceAnonApexExecute.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceAnonApexExecute.ts
@@ -35,7 +35,8 @@ interface ApexExecuteParameters {
 }
 
 export class AnonApexGatherer
-  implements ParametersGatherer<ApexExecuteParameters> {
+  implements ParametersGatherer<ApexExecuteParameters>
+{
   public async gather(): Promise<
     CancelResponse | ContinueResponse<ApexExecuteParameters>
   > {
@@ -70,12 +71,9 @@ export class AnonApexGatherer
   }
 }
 
-export class AnonApexLibraryExecuteExecutor extends LibraryCommandletExecutor<
-  ApexExecuteParameters
-> {
-  public static diagnostics = vscode.languages.createDiagnosticCollection(
-    'apex-errors'
-  );
+export class AnonApexLibraryExecuteExecutor extends LibraryCommandletExecutor<ApexExecuteParameters> {
+  public static diagnostics =
+    vscode.languages.createDiagnosticCollection('apex-errors');
 
   private isDebugging: boolean;
 
@@ -168,6 +166,7 @@ export class AnonApexLibraryExecuteExecutor extends LibraryCommandletExecutor<
       return false;
     }
 
+    fs.mkdirSync(path.dirname(logFilePath), { recursive: true });
     fs.writeFileSync(logFilePath, logs);
 
     return true;
@@ -203,12 +202,8 @@ export class AnonApexLibraryExecuteExecutor extends LibraryCommandletExecutor<
     AnonApexLibraryExecuteExecutor.diagnostics.clear();
 
     if (response.diagnostic) {
-      const {
-        compileProblem,
-        exceptionMessage,
-        lineNumber,
-        columnNumber
-      } = response.diagnostic[0];
+      const { compileProblem, exceptionMessage, lineNumber, columnNumber } =
+        response.diagnostic[0];
       let message;
       if (compileProblem && compileProblem !== '') {
         message = compileProblem;
@@ -254,7 +249,7 @@ export class AnonApexLibraryExecuteExecutor extends LibraryCommandletExecutor<
   }
 }
 
-export const forceAnonApexExecute =  async () => {
+export const forceAnonApexExecute = async () => {
   const commandlet = new SfdxCommandlet(
     new SfdxWorkspaceChecker(),
     new AnonApexGatherer(),


### PR DESCRIPTION
@ W-13682486@
fix logfile name formatting error introduced by #5277
Ensures the directory to the logfiles is present before saving the log file when log file directories are not present issue [#178](https://github.com/forcedotcom/easywriter/issues/178)


