### PR TITLE
chore: wrong commands in package.json

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -524,11 +524,11 @@
           "when": "false"
         },
         {
-          "command": "sfdx.force.org.delete.default",
+          "command": "sfdx.org.delete.default",
           "when": "sfdx:project_opened"
         },
         {
-          "command": "sfdx.force.org.delete.username",
+          "command": "sfdx.org.delete.username",
           "when": "sfdx:project_opened"
         },
         {


### PR DESCRIPTION
### What does this PR do?
- Fixes org delete commands that were still in old sfdx style

### Functionality Before
- org delete commands show up outside of a sf project

### Functionality After
- org delete commands show up only inside of a sf project

[skip-validate-pr]