### PR TITLE
fix: default SF_LOG_LEVEL to fatal

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -976,7 +976,7 @@
         },
         "salesforcedx-vscode-core.SF_LOG_LEVEL": {
           "type": "string",
-          "default": null,
+          "default": "fatal",
           "description": "%sf_log_level_description%"
         }
       }


### PR DESCRIPTION
### What does this PR do?
- Sets SF_LOG_LEVEL to default in 'fatal'

[skip-validate-pr]
