### PR TITLE
fix: fix entry not found when launching apex replay debugger from apex class 

### DIFF
--- a/config/base-eslintrc.json
+++ b/config/base-eslintrc.json
@@ -37,7 +37,7 @@
         "",
         {
           "pattern": " \\* Copyright \\(c\\) \\d{4}, salesforce\\.com, inc\\.",
-          "template": " * Copyright (c) 2023, salesforce.com, inc."
+          "template": " * Copyright (c) 2024, salesforce.com, inc."
         },
         " * All rights reserved.",
         " * Licensed under the BSD 3-Clause license.",

--- a/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
@@ -6,6 +6,7 @@
  */
 
 import * as fs from 'fs';
+import { TelemetryService } from '..';
 
 export const isNullOrUndefined = (object: any): object is null | undefined => {
   return object === null || object === undefined;
@@ -39,6 +40,19 @@ export const flushFilePath = (filePath: string): string => {
     nativePath = nativePath.charAt(0).toLowerCase() + nativePath.slice(1);
   }
 
+  // check if the native path is the same case insensitive and then case sensitive
+  // so that condition can be reported via telemetry
+  if (
+    filePath.toLowerCase() !== nativePath.toLowerCase() &&
+    filePath !== nativePath
+  ) {
+    const telemetry = TelemetryService.getInstance();
+
+    telemetry.sendEventData('FilePathCaseMismatch', {
+      originalPath: filePath,
+      nativePath
+    });
+  }
   return nativePath;
 };
 

--- a/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
@@ -5,8 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import * as fs from 'fs';
-import { TelemetryService } from '..';
+import { realpathSync } from 'fs';
+import { basename } from 'path';
+import { telemetryService } from '../telemetry';
 
 export const isNullOrUndefined = (object: any): object is null | undefined => {
   return object === null || object === undefined;
@@ -29,7 +30,7 @@ export const flushFilePath = (filePath: string): string => {
     return filePath;
   }
 
-  let nativePath = fs.realpathSync.native(filePath);
+  let nativePath = realpathSync.native(filePath);
   if (/^win32/.test(process.platform)) {
     // The file path on Windows is in the form of "c:\Users\User Name\foo.cls".
     // When called, fs.realpathSync.native() is returning the file path back as
@@ -43,14 +44,12 @@ export const flushFilePath = (filePath: string): string => {
   // check if the native path is the same case insensitive and then case sensitive
   // so that condition can be reported via telemetry
   if (
-    filePath.toLowerCase() !== nativePath.toLowerCase() &&
-    filePath !== nativePath
+    filePath !== nativePath &&
+    filePath.toLowerCase() === nativePath.toLowerCase()
   ) {
-    const telemetry = TelemetryService.getInstance();
-
-    telemetry.sendEventData('FilePathCaseMismatch', {
-      originalPath: filePath,
-      nativePath
+    telemetryService.sendEventData('FilePathCaseMismatch', {
+      originalPath: basename(filePath),
+      nativePath: basename(nativePath)
     });
   }
   return nativePath;

--- a/packages/salesforcedx-utils-vscode/src/telemetry/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/index.ts
@@ -5,13 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-/**
- * This file is intentionally left blank. Telemetry Service is exported
- * in the root of salesforcedx-utils-vscode.
- *
- * If your service or util is dependent on telemetry service, please leave the index
- * of your service folder empty as well, and export your service in src/index.ts.
- * Otherwise, you will have a duplicate copy of telemetry service in your folder,
- * for webpack treats the index of each folder as an entry point
- * and bundles all of its dependencies.
- */
+import { TelemetryService } from './telemetry';
+
+export const telemetryService = TelemetryService.getInstance();

--- a/packages/salesforcedx-utils-vscode/test/jest/helpers/utils.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/helpers/utils.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, salesforce.com, inc.
+ * Copyright (c) 2024, salesforce.com, inc.
  * All rights reserved.
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/packages/salesforcedx-utils-vscode/test/jest/helpers/utils.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/helpers/utils.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { realpathSync } from 'fs';
+import { TelemetryService } from '../../../src';
+import { flushFilePath } from '../../../src/helpers/utils';
+
+describe('flushFilePath', () => {
+  let teleSpy: jest.SpyInstance;
+  beforeEach(() => {
+    jest.mock('fs');
+    jest.mock('../../../src/context/workspaceContextUtil');
+  });
+  it('should detect changes in character casing', () => {
+    const originalPath = './test.txt';
+    const alteredPath = './TEST.txt';
+
+    jest.spyOn(realpathSync, 'native').mockReturnValue(alteredPath);
+    teleSpy = jest.spyOn(TelemetryService.prototype, 'sendEventData');
+
+    const r = flushFilePath(originalPath);
+    expect(r).toEqual(alteredPath);
+    expect(teleSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not send to telemetry if there are no changes in character casing', () => {
+    const originalPath = './test.txt';
+    const alteredPath = './test.txt';
+
+    jest.spyOn(realpathSync, 'native').mockReturnValue(alteredPath);
+    teleSpy = jest.spyOn(TelemetryService.prototype, 'sendEventData');
+
+    const r = flushFilePath(originalPath);
+    expect(r).toEqual(alteredPath);
+    expect(teleSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/salesforcedx-vscode-apex/src/commands/forceLaunchApexReplayDebuggerWithCurrentFile.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/forceLaunchApexReplayDebuggerWithCurrentFile.ts
@@ -82,15 +82,14 @@ const getApexTestClassName = async (
 
   const testOutlineProvider = getTestOutlineProvider();
   await testOutlineProvider.refresh();
-  let testClassName = testOutlineProvider.getTestClassName(sourceUri);
   // This is a little bizarre.  Intellisense is reporting that getTestClassName() returns a string,
   // but it actually it returns string | undefined.  Well, regardless, since flushFilePath() takes
   // a string (and guards against empty strings) using the Non-null assertion operator
   // (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html#non-null-assertion-operator)
   // fixes the issue.
-  testClassName = fileUtils.flushFilePath(testClassName || '');
+  const flushedUri = vscode.Uri.file(fileUtils.flushFilePath(sourceUri.fsPath));
 
-  return testClassName;
+  return testOutlineProvider.getTestClassName(flushedUri);
 };
 
 const launchAnonymousApexReplayDebugger = async () => {


### PR DESCRIPTION
### What does this PR do?
Corrects a bug when starting the apex replay debugger from an apex class file "Apex: Launch Apex Replay Debugger With Current File"
### What issues does this PR fix or reference?
@W-12508503@

### Functionality Before
When launching Apex replay debugger with an Apex class the command would fail with a file system error stating the class name did not exist.

### Functionality After
The launch of Apex replay debugger is now using the full path to the current Apex class, rather than the name
