### PR TITLE
chore: setup Git2Gus for User Story when issues are labeled with 'feature' tag

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -25,11 +25,11 @@
     "area:xml": "a1aB0000000BPyKIAW"
   },
   "issueTypeLabels": {
-    "type:feature": "",
+    "feature": "USER STORY",
     "type:bug": "BUG P3",
     "type:security": "BUG P2",
     "type:feedback": "",
-    "type:duplicate": "",
+    "status:duplicate": "",
     "type:community-contrib": "USER STORY"
   },
   "defaultBuild": "offcore.tooling.58",


### PR DESCRIPTION
When Github issues are tagged with the `feature` tag, a new User Story is automatically created for the issue.  I modified `.git2gus/config.json` according to the instructions on the Git2Gus page: https://lwc-gus-bot.herokuapp.com/

[skip-validate-pr]
