### PR TITLE
fix: exclude source-tracking from apex ext bundle

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -68,7 +68,7 @@
   "scripts": {
     "bundle:extension": "npm run bundle:extension:build && npm run bundle:extension:copy",
     "bundle:extension:copy": "cp ./out/apex-jorje-lsp.jar ./dist/",
-    "bundle:extension:build": "esbuild ./src/index.ts  --bundle --outfile=dist/index.js --format=cjs --platform=node --external:vscode  --external:@salesforce/core --external:applicationinsights --external:shelljs --external:@salesforce/source-deploy-retrieve --minify",
+    "bundle:extension:build": "esbuild ./src/index.ts  --bundle --outfile=dist/index.js --format=cjs --platform=node --external:vscode  --external:@salesforce/core --external:applicationinsights --external:shelljs --external:@salesforce/source-deploy-retrieve --external:@salesforce/source-tracking --minify",
     "vscode:package": "ts-node  ../../scripts/vsce-bundled-extension.ts",
     "vscode:sha256": "node ../../scripts/generate-sha256.js >> ../../SHA256",
     "vscode:publish": "node ../../scripts/publish-vsix.js",
@@ -107,6 +107,7 @@
         "@salesforce/core": "6.4.7",
         "@salesforce/templates": "^60.1.0",
         "@salesforce/source-deploy-retrieve": "10.2.9",
+        "@salesforce/source-tracking": "5.1.3",
         "shelljs": "0.8.5"
       },
       "devDependencies": {}


### PR DESCRIPTION
@W-14840136@
Exclude @salesforce/source-tracking from being bundled with apex extension.
When included in the bundle, Apex extension activation fails.
