### PR TITLE
revert: comment out Verify CLI Version feature

### DIFF
--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -548,7 +548,7 @@ export async function activate(extensionContext: vscode.ExtensionContext) {
   // thus avoiding the potential errors surfaced when the libs call
   // process.cwd().
   ensureCurrentWorkingDirIsProjectPath(rootWorkspacePath);
-  validateCliInstallationAndVersion();
+  // validateCliInstallationAndVersion();
   setNodeExtraCaCerts();
   setSfLogLevel();
   await telemetryService.initializeService(extensionContext);


### PR DESCRIPTION
Comment out call to `verifyCliInstallationAndVersion()` in `packages/salesforcedx-vscode-core/src/index.ts` to temporarily disable the Verify CLI Version on Startup feature.

[skip-validate-pr]