### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/createReleaseBranch.yml
+++ b/.github/workflows/createReleaseBranch.yml
@@ -54,11 +54,11 @@ jobs:
           echo "Creating a ${{ github.event.inputs.releaseType || 'minor' }} release from branch release/v$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")"
           node scripts/create-release-branch.js
       - id: result
-        run: echo "result=${{ job.status }}" >> $GITHUB_OUTPUT
+        run: echo "result=${{ job.status }}" >> "$GITHUB_OUTPUT"
       - id: version
-        run: echo "version="$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")"" >> $GITHUB_OUTPUT
+        run: echo "version="$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")"" >> "$GITHUB_OUTPUT"
       - id: branch
-        run: echo "branch=release/v${{ steps.version.outputs.version }}" >> $GITHUB_OUTPUT
+        run: echo "branch=release/v${{ steps.version.outputs.version }}" >> "$GITHUB_OUTPUT"
       - run: echo "Release Version is ${{ steps.version.outputs.version }}"
       - run: echo “Release Type is ${{ github.event.inputs.releaseType || 'minor' }}”
       - run: echo “Release Branch is ${{ steps.branch.outputs.branch }}”

--- a/.github/workflows/generateChangelog.yml
+++ b/.github/workflows/generateChangelog.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Generate CHANGELOG
         run: npm run changelog
       - id: result
-        run: echo "result=${{ job.status }}" >> $GITHUB_OUTPUT
+        run: echo "result=${{ job.status }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/mergeReleaseBranch.yml
+++ b/.github/workflows/mergeReleaseBranch.yml
@@ -19,7 +19,7 @@ jobs:
           ref: ${{ inputs.releaseBranch }}
       - id: getReleaseVersion
         run: |
-          echo "version="$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")"" >> $GITHUB_OUTPUT
+          echo "version="$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")"" >> "$GITHUB_OUTPUT"
       - run: echo "Release Version is ${{ steps.getReleaseVersion.outputs.version }}"
 
   get_main_version:
@@ -33,7 +33,7 @@ jobs:
           ref: 'main'
       - id: getMainVersion
         run: |
-          echo "version="$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")"" >> $GITHUB_OUTPUT
+          echo "version="$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")"" >> "$GITHUB_OUTPUT"
       - run: echo "Main Version is ${{ steps.getMainVersion.outputs.version }}"
 
   merge-release-branch:

--- a/.github/workflows/publishBetaRelease.yml
+++ b/.github/workflows/publishBetaRelease.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: getVersion
-        run: echo "version="$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")"" >> $GITHUB_OUTPUT
+        run: echo "version="$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")"" >> "$GITHUB_OUTPUT"
       - run: echo "Release Version is ${{ steps.getVersion.outputs.version }}"
 
   create_git_tag:
@@ -76,7 +76,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - id: version
-        run: echo "version=${{ env.VERSION }}" >> $GITHUB_OUTPUT
+        run: echo "version=${{ env.VERSION }}" >> "$GITHUB_OUTPUT"
 
   slack_notification:
     if: ${{ always() }}

--- a/.github/workflows/publishBetaRelease.yml
+++ b/.github/workflows/publishBetaRelease.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: getVersion
-        run: echo "::set-output name=version::"$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")""
+        run: echo "version="$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")"" >> $GITHUB_OUTPUT
       - run: echo "Release Version is ${{ steps.getVersion.outputs.version }}"
 
   create_git_tag:

--- a/.github/workflows/publishOpenVSX.yml
+++ b/.github/workflows/publishOpenVSX.yml
@@ -33,15 +33,15 @@ jobs:
           ref: 'main'
       - id: getMainVersion
         run: |
-          echo "version="$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")"" >> $GITHUB_OUTPUT
+          echo "version="$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")"" >> "$GITHUB_OUTPUT"
       - run: echo "Main Version is ${{ steps.getMainVersion.outputs.version }}"
       - id: getGusBuild
         run: | 
-          echo "gusBuild=${{ steps.getMainVersion.outputs.version }}" >> $GITHUB_OUTPUT
+          echo "gusBuild=${{ steps.getMainVersion.outputs.version }}" >> "$GITHUB_OUTPUT"
       - run: echo "GUS BUILD is ${{ steps.getGusBuild.outputs.gusBuild }}"
       - id: getScheduledBuild
         run: | 
-          echo "sfChangeCaseScheduleBuild=offcore.tooling.${{ steps.getMainVersion.outputs.version }}" >> $GITHUB_OUTPUT
+          echo "sfChangeCaseScheduleBuild=offcore.tooling.${{ steps.getMainVersion.outputs.version }}" >> "$GITHUB_OUTPUT"
       - run: echo "SF_CHANGE_CASE_SCHEDULE_BUILD is ${{ steps.getScheduledBuild.outputs.sfChangeCaseScheduleBuild }}"\
 
 

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -33,15 +33,15 @@ jobs:
           ref: 'main'
       - id: getMainVersion
         run: |
-          echo "version="$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")"" >> $GITHUB_OUTPUT
+          echo "version="$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")"" >> "$GITHUB_OUTPUT"
       - run: echo "Main Version is ${{ steps.getMainVersion.outputs.version }}"
       - id: getGusBuild
         run: | 
-          echo "gusBuild=${{ steps.getMainVersion.outputs.version }}" >> $GITHUB_OUTPUT
+          echo "gusBuild=${{ steps.getMainVersion.outputs.version }}" >> "$GITHUB_OUTPUT"
       - run: echo "GUS BUILD is ${{ steps.getGusBuild.outputs.gusBuild }}"
       - id: getScheduledBuild
         run: | 
-          echo "sfChangeCaseScheduleBuild=offcore.tooling.${{ steps.getMainVersion.outputs.version }}" >> $GITHUB_OUTPUT
+          echo "sfChangeCaseScheduleBuild=offcore.tooling.${{ steps.getMainVersion.outputs.version }}" >> "$GITHUB_OUTPUT"
       - run: echo "SF_CHANGE_CASE_SCHEDULE_BUILD is ${{ steps.getScheduledBuild.outputs.sfChangeCaseScheduleBuild }}"\
 
   ctc-open:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           ref: 'main'
       - id: getMainVersion
         run: |
-          echo "version="$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")"" >> $GITHUB_OUTPUT
+          echo "version="$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")"" >> "$GITHUB_OUTPUT"
       - run: echo "Main Version is ${{ steps.getMainVersion.outputs.version }}"
 
   release:

--- a/.github/workflows/tagAndRelease.yml
+++ b/.github/workflows/tagAndRelease.yml
@@ -105,7 +105,7 @@ jobs:
           git push origin develop
       - id: complete
         run: |
-         echo "status=complete" >> $GITHUB_OUTPUT
+         echo "status=complete" >> "$GITHUB_OUTPUT"
       - id: finish
         run: |
          echo "VSCode Tag and Release Success"

--- a/.github/workflows/testBuildAndRelease.yml
+++ b/.github/workflows/testBuildAndRelease.yml
@@ -16,7 +16,7 @@ jobs:
           ref: 'main'
       - id: getMainVersion
         run: |
-          echo "version="$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")"" >> $GITHUB_OUTPUT
+          echo "version="$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")"" >> "$GITHUB_OUTPUT"
       - run: echo "Main Release Version is ${{ steps.getMainVersion.outputs.version }}"
   build-and-test:
     uses: ./.github/workflows/buildAndTest.yml


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter