### PR TITLE
Update einstein-setup.md

### DIFF
--- a/docs/_articles/en/einstein/einstein-setup.md
+++ b/docs/_articles/en/einstein/einstein-setup.md
@@ -66,10 +66,10 @@ Install Einstein for Developers:
 
 - If you are using Code Builder, click the Extensions icon in the Activity Bar in Code Builder, search for “Einstein for Developers” and click **Install**.
 
-- You may run into some odd generated code outcomes if you have multiple AI-enabled extensions installed in VS Code. We recommend you disable all other AI-enabled extensions when working with Einstein for Developers:
+- You may run into some unexpected generated code outcomes if you have multiple AI-enabled extensions installed in VS Code. We recommend you disable all other AI-enabled extensions when working with Einstein for Developers:
   1. Click the Extensions icon in the Activity Bar, search for the extension to disable by name.
   2. Click **Disable** in the extension's marketplace page.
-  3. Repeat for all installed AI-enabled extensions you have installed.
+  3. Repeat for all installed AI-enabled extensions.
  
 
 **Note**: To use Einstein for Developers on your desktop, you must have the [Salesforce Extension Pack]() installed in your VS Code desktop application. See [Install Salesforce Extensions](https://developer.salesforce.com/tools/vscode/en/vscode-desktop/install) for more information.

--- a/docs/_articles/en/einstein/einstein-setup.md
+++ b/docs/_articles/en/einstein/einstein-setup.md
@@ -66,7 +66,9 @@ Install Einstein for Developers:
 
 - If you are using Code Builder, click the Extensions icon in the Activity Bar in Code Builder, search for “Einstein for Developers” and click **Install**.
 
-**Note**: To use Einstein for Developers locally, you must have the [Salesforce Extensions pack]() installed in your VS Code for desktop application. See [Install Salesforce Extensions](https://developer.salesforce.com/tools/vscode/en/vscode-desktop/install) for more information.
+- If you have any other "competing" AI-enabled extensions such as GitHub Copilot installed, click the Extensions icon in the Activity Bar, search for the extension by name and click **Disable** in the extension's marketplace page. Do this for all installed AI-enabled extensions.
+
+**Note**: To use Einstein for Developers on your desktop, you must have the [Salesforce Extensions pack]() installed in your VS Code desktop application. See [Install Salesforce Extensions](https://developer.salesforce.com/tools/vscode/en/vscode-desktop/install) for more information.
 
 ## Connect to an Org
 

--- a/docs/_articles/en/einstein/einstein-setup.md
+++ b/docs/_articles/en/einstein/einstein-setup.md
@@ -66,7 +66,11 @@ Install Einstein for Developers:
 
 - If you are using Code Builder, click the Extensions icon in the Activity Bar in Code Builder, search for “Einstein for Developers” and click **Install**.
 
-- If you have any other "competing" AI-enabled extensions such as GitHub Copilot installed, click the Extensions icon in the Activity Bar, search for the extension by name and click **Disable** in the extension's marketplace page. Do this for all installed AI-enabled extensions.
+- You may run into some odd generated code outcomes if you have multiple AI-enabled extensions installed in VS Code. We recommend you disable all other AI-enabled extensions when working with Einstein for Developers:
+  1. Click the Extensions icon in the Activity Bar, search for the extension to disable by name.
+  2. Click **Disable** in the extension's marketplace page.
+  3. Repeat for all installed AI-enabled extensions you have installed.
+ 
 
 **Note**: To use Einstein for Developers on your desktop, you must have the [Salesforce Extension Pack]() installed in your VS Code desktop application. See [Install Salesforce Extensions](https://developer.salesforce.com/tools/vscode/en/vscode-desktop/install) for more information.
 

--- a/docs/_articles/en/einstein/einstein-setup.md
+++ b/docs/_articles/en/einstein/einstein-setup.md
@@ -68,7 +68,7 @@ Install Einstein for Developers:
 
 - If you have any other "competing" AI-enabled extensions such as GitHub Copilot installed, click the Extensions icon in the Activity Bar, search for the extension by name and click **Disable** in the extension's marketplace page. Do this for all installed AI-enabled extensions.
 
-**Note**: To use Einstein for Developers on your desktop, you must have the [Salesforce Extensions pack]() installed in your VS Code desktop application. See [Install Salesforce Extensions](https://developer.salesforce.com/tools/vscode/en/vscode-desktop/install) for more information.
+**Note**: To use Einstein for Developers on your desktop, you must have the [Salesforce Extension Pack]() installed in your VS Code desktop application. See [Install Salesforce Extensions](https://developer.salesforce.com/tools/vscode/en/vscode-desktop/install) for more information.
 
 ## Connect to an Org
 


### PR DESCRIPTION
[DOC] Update Docs adding information about needing to avoid multiple AI enabled VSCode extensions

Description
As a eGPT user, I should know that having multiple AI enabled extensions is known to cause some issues and should be avoided.



AC

Update docs adding section where we let our users know they should completely disabled all but one AI enabled extension (copilot, CodeGenie, E4D).
Notes

Just disabling the extensions is not enough. There are overlays for hot keys and inline completion that can have unexpected results. Fully disabling the extensions from the Extensions menu is the correct way to ensure consistent results.
We will eventually do the work to ensure we can work in parallel with the other extension but not before open beta of inline.


 @W-14879717@

### Functionality Before
No instructions to disable other extensions.

### Functionality After
Instructions added.
