### PR TITLE
fix: check java version was criteria was ambiguous

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-apex/src/messages/i18n.ts
@@ -80,6 +80,7 @@ export const messages = {
     'An unsupported Java version was detected. Download and install [Java 11](https://www.oracle.com/technetwork/java/javase/downloads/jdk11-downloads-5066655.html) or [Java 17](https://www.oracle.com/java/technologies/downloads/#java17) to run the extensions. For more information, see [Set Your Java Version](%s).',
   wrong_java_version_short:
     'Unsupported Java version',
+  java_version_check_command_failed: 'Running java command %s failed with error: %s',
   force_apex_test_suite_build_text: 'SFDX: Build Apex Test Suite',
   unable_to_locate_editor: 'You can run this command only on a source file.',
   unable_to_locate_document: 'You can run this command only on a source file.',

--- a/packages/salesforcedx-vscode-apex/src/requirements.ts
+++ b/packages/salesforcedx-vscode-apex/src/requirements.ts
@@ -102,14 +102,11 @@ const isLocal = (javaHome: string): boolean => {
 export const checkJavaVersion = async (javaHome: string): Promise<boolean> => {
   return new Promise((resolve, reject) => {
     cp.execFile(
-      javaHome + '/bin/java',
-      ['-version'],
+      javaHome + '/bin/javax',
+      ['-XshowSettings:properties', '-version'],
       {},
       (error, stdout, stderr) => {
-        if (
-          stderr.indexOf('build 11.') < 0 &&
-          stderr.indexOf('build 17.') < 0
-        ) {
+        if (!/java\.version\s*=\s*(?:11|17)/g.test(stderr)) {
           reject(nls.localize('wrong_java_version_text', SET_JAVA_DOC_LINK));
         } else {
           resolve(true);

--- a/packages/salesforcedx-vscode-apex/src/requirements.ts
+++ b/packages/salesforcedx-vscode-apex/src/requirements.ts
@@ -102,7 +102,7 @@ const isLocal = (javaHome: string): boolean => {
 export const checkJavaVersion = async (javaHome: string): Promise<boolean> => {
   return new Promise((resolve, reject) => {
     cp.execFile(
-      javaHome + '/bin/javax',
+      javaHome + '/bin/java',
       ['-XshowSettings:properties', '-version'],
       {},
       (error, stdout, stderr) => {

--- a/packages/salesforcedx-vscode-apex/src/requirements.ts
+++ b/packages/salesforcedx-vscode-apex/src/requirements.ts
@@ -100,12 +100,16 @@ const isLocal = (javaHome: string): boolean => {
 };
 
 export const checkJavaVersion = async (javaHome: string): Promise<boolean> => {
+  const cmdFile = path.join(javaHome, 'bin', 'java');
+  const commandOptions = ['-XshowSettings:properties', '-version'];
   return new Promise((resolve, reject) => {
-    cp.execFile(
-      javaHome + '/bin/java',
-      ['-XshowSettings:properties', '-version'],
+    cp.execFile(cmdFile,
+      commandOptions,
       {},
       (error, stdout, stderr) => {
+        if (error) {
+          reject(nls.localize('java_version_check_command_failed', `${cmdFile} ${commandOptions.join(' ')}`, error.message));
+        }
         if (!/java\.version\s*=\s*(?:11|17)/g.test(stderr)) {
           reject(nls.localize('wrong_java_version_text', SET_JAVA_DOC_LINK));
         } else {

--- a/packages/salesforcedx-vscode-apex/test/jest/languageUtils/requirements.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/languageUtils/requirements.test.ts
@@ -9,6 +9,7 @@ import { fail } from 'assert';
 import { expect } from 'chai';
 import * as cp from 'child_process';
 import * as fs from 'fs';
+import * as path from 'path';
 import { createSandbox, SinonSandbox, SinonStub } from 'sinon';
 import * as vscode from 'vscode';
 import { SET_JAVA_DOC_LINK } from '../../../src/constants';
@@ -109,13 +110,17 @@ describe('Java Requirements Test', () => {
   });
 
   it('Should reject java version check when execFile fails', async () => {
-    execFileStub.yields({message: 'its broken'}, '', '');
+    execFileStub.yields({ message: 'its broken' }, '', '');
     try {
-      await checkJavaVersion('~/java_home');
+      await checkJavaVersion(path.join('~', 'java_home'));
       fail('Should have thrown when the Java version is not supported');
     } catch (err) {
       expect(err).to.equal(
-        nls.localize('java_version_check_command_failed', '~/java_home/bin/java -XshowSettings:properties -version', 'its broken')
+        nls.localize(
+          'java_version_check_command_failed',
+          `${path.join('~', 'java_home', 'bin', 'java')} -XshowSettings:properties -version`,
+          'its broken'
+        )
       );
     }
   });

--- a/packages/salesforcedx-vscode-apex/test/jest/languageUtils/requirements.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/languageUtils/requirements.test.ts
@@ -5,7 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-
 import { fail } from 'assert';
 import { expect } from 'chai';
 import * as cp from 'child_process';
@@ -32,12 +31,9 @@ describe('Java Requirements Test', () => {
   beforeEach(() => {
     sandbox = createSandbox();
     settingStub = sandbox.stub();
-    sandbox
-      .stub(vscode.workspace, 'getConfiguration')
-      .withArgs()
-      .returns({
-        get: settingStub
-      });
+    sandbox.stub(vscode.workspace, 'getConfiguration').withArgs().returns({
+      get: settingStub
+    });
     pathExistsStub = sandbox.stub(fs, 'existsSync').resolves(true);
     execFileStub = sandbox.stub(cp, 'execFile');
   });
@@ -108,6 +104,18 @@ describe('Java Requirements Test', () => {
     } catch (err) {
       expect(err).to.equal(
         nls.localize('wrong_java_version_text', SET_JAVA_DOC_LINK)
+      );
+    }
+  });
+
+  it('Should reject java version check when execFile fails', async () => {
+    execFileStub.yields({message: 'its broken'}, '', '');
+    try {
+      await checkJavaVersion('~/java_home');
+      fail('Should have thrown when the Java version is not supported');
+    } catch (err) {
+      expect(err).to.equal(
+        nls.localize('java_version_check_command_failed', '~/java_home/bin/java -XshowSettings:properties -version', 'its broken')
       );
     }
   });

--- a/packages/salesforcedx-vscode-apex/test/jest/languageUtils/requirements.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/languageUtils/requirements.test.ts
@@ -5,7 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-// tslint:disable:no-unused-expression
 
 import { fail } from 'assert';
 import { expect } from 'chai';
@@ -13,18 +12,16 @@ import * as cp from 'child_process';
 import * as fs from 'fs';
 import { createSandbox, SinonSandbox, SinonStub } from 'sinon';
 import * as vscode from 'vscode';
-import { SET_JAVA_DOC_LINK } from '../../src/constants';
-import { nls } from '../../src/messages';
+import { SET_JAVA_DOC_LINK } from '../../../src/constants';
+import { nls } from '../../../src/messages';
 import {
   checkJavaVersion,
   JAVA_HOME_KEY,
   resolveRequirements
-} from '../../src/requirements';
+} from '../../../src/requirements';
 
 const jdk = 'openjdk1.8.0.302_8.56.0.22_x64';
 const runtimePath = `~/java_home/real/jdk/${jdk}`;
-
-// TODO: Move this to a new unit test directory
 
 describe('Java Requirements Test', () => {
   let sandbox: SinonSandbox;
@@ -62,13 +59,13 @@ describe('Java Requirements Test', () => {
 
   it('Should allow valid java runtime path outside the project', async () => {
     settingStub.withArgs(JAVA_HOME_KEY).returns(runtimePath);
-    execFileStub.yields('', '', 'build 11.0.0');
+    execFileStub.yields('', '', 'java.version = 11.0.0');
     const requirements = await resolveRequirements();
     expect(requirements.java_home).contains(jdk);
   });
 
   it('Should not support Java 8', async () => {
-    execFileStub.yields('', '', 'build 1.8.0');
+    execFileStub.yields('', '', 'java.version = 1.8.0');
     try {
       await checkJavaVersion('~/java_home');
       fail('Should have thrown when the Java version is not supported');
@@ -80,7 +77,7 @@ describe('Java Requirements Test', () => {
   });
 
   it('Should support Java 11', async () => {
-    execFileStub.yields('', '', 'build 11.0.0');
+    execFileStub.yields('', '', 'java.version = 11.0.0');
     try {
       const result = await checkJavaVersion('~/java_home');
       expect(result).to.equal(true);
@@ -92,7 +89,7 @@ describe('Java Requirements Test', () => {
   });
 
   it('Should support Java 17', async () => {
-    execFileStub.yields('', '', 'build 17.2.3');
+    execFileStub.yields('', '', 'java.version = 17.2.3');
     try {
       const result = await checkJavaVersion('~/java_home');
       expect(result).to.equal(true);
@@ -104,7 +101,7 @@ describe('Java Requirements Test', () => {
   });
 
   it('Should not support Java 20', async () => {
-    execFileStub.yields('', '', 'build 20.0.0');
+    execFileStub.yields('', '', 'java.version = 20.0.0');
     try {
       await checkJavaVersion('~/java_home');
       fail('Should have thrown when the Java version is not supported');

--- a/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploySourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/forceSourceDeploySourcePath.ts
@@ -70,8 +70,7 @@ export const forceSourceDeploySourcePaths = async (
       // passed in (sourceUri) is actually an array and not a single URI.
       uris = sourceUri;
     } else {
-      uris = [];
-      uris.push(sourceUri);
+      uris = [sourceUri];
     }
   }
 


### PR DESCRIPTION

Modified the check to include java option `XshowSettings:properties`

<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?

### What issues does this PR fix or reference?
@W-14888195@ #5358 

### Functionality Before
The validation of java version used a string match for `build 17.` and the customer's java version reported `build 17+` causing a false positive when check version during startup

### Functionality After
The validation function has been changed to run the java version command with an option that displays all of the assign System properties the JVM will be using. One of the is `java.version = nn[.nn[.nn]]`. This representation is more reliable that using the `build` string from the java version command.
