### PR TITLE
fix: bump lls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6357,11 +6357,11 @@
       }
     },
     "node_modules/@salesforce/aura-language-server": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-4.7.3.tgz",
-      "integrity": "sha512-1CfLRLAqrhxkqF/vhgbci+NpmaiSyT1zaJdfNoxAVTQ644Hn8qGMSvlseX3zWDlJhS8kOb//9BGXVwNWb6FO4Q==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-4.7.4.tgz",
+      "integrity": "sha512-96+iI5XV9dF7+B77oGUrhTIHudJX15vnnNUjRcx10RS8pTjuhktnHq/Kz22qeNSnD61T9FPaVIbGrTRRwmZY1Q==",
       "dependencies": {
-        "@salesforce/lightning-lsp-common": "4.7.3",
+        "@salesforce/lightning-lsp-common": "4.7.4",
         "acorn": "^6.0.0",
         "acorn-loose": "^6.0.0",
         "acorn-walk": "^6.0.0",
@@ -6774,9 +6774,9 @@
       "integrity": "sha512-/ZiVwtVkmq2jWRRzgsC4SEy8m54gPaDc8e+jIfnIiR04iSeSRhYJxG+ktLSYVN2jMbVWA58HfEJSCx+73GcQCg=="
     },
     "node_modules/@salesforce/lightning-lsp-common": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-4.7.3.tgz",
-      "integrity": "sha512-B2yQKhxRsIo2aDagk/chURbQn6VzL72AlmB0cyMxRPEv0uJbRZEidlcriylc7Spde2AZs4TAZBn2pYcjFFEe3g==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-4.7.4.tgz",
+      "integrity": "sha512-2JDSzTiAPpzsPK3knG9kcKQc+fTkb0fd3iWluUYxpyewYkbe/idcFLK4z9PB/BPrK23Av2+Dn9zIqspR2Ke+pw==",
       "dependencies": {
         "decamelize": "^2.0.0",
         "deep-equal": "^1.0.1",
@@ -6882,9 +6882,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@salesforce/lwc-language-server": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-4.7.3.tgz",
-      "integrity": "sha512-14y/iFDqBdvoQAuKp3maTCqWFRS7gBPx3Oq46mcG4F+UEIEmza7Ytkffwd8qiruB8b8TIE9IPG3dNlTDvu0Vkw==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-4.7.4.tgz",
+      "integrity": "sha512-eKatb6kjdVHNJNhANPtVhK9GLJT26YjcAH8VlwD4K/EtVcgVGU6eRx8C4Nhnct/Fa2dyBmJF/ppS2AdanisSLw==",
       "dependencies": {
         "@lwc/compiler": "2.50.0",
         "@lwc/engine-dom": "2.50.0",
@@ -6894,7 +6894,7 @@
         "@lwc/template-compiler": "2.50.0",
         "@salesforce/apex": "0.0.12",
         "@salesforce/label": "0.0.12",
-        "@salesforce/lightning-lsp-common": "4.7.3",
+        "@salesforce/lightning-lsp-common": "4.7.4",
         "@salesforce/resourceurl": "0.0.12",
         "@salesforce/schema": "0.0.12",
         "@salesforce/user": "0.0.12",
@@ -37070,9 +37070,9 @@
       "version": "59.16.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/aura-language-server": "4.7.3",
+        "@salesforce/aura-language-server": "4.7.4",
         "@salesforce/core": "6.4.7",
-        "@salesforce/lightning-lsp-common": "4.7.3",
+        "@salesforce/lightning-lsp-common": "4.7.4",
         "@salesforce/salesforcedx-utils-vscode": "59.16.0",
         "applicationinsights": "1.0.7",
         "vscode-extension-telemetry": "0.0.17",
@@ -37148,8 +37148,8 @@
       "dependencies": {
         "@salesforce/core": "6.4.7",
         "@salesforce/eslint-config-lwc": "3.5.1",
-        "@salesforce/lightning-lsp-common": "4.7.3",
-        "@salesforce/lwc-language-server": "4.7.3",
+        "@salesforce/lightning-lsp-common": "4.7.4",
+        "@salesforce/lwc-language-server": "4.7.4",
         "@salesforce/salesforcedx-utils-vscode": "59.16.0",
         "ajv": "6.12.6",
         "applicationinsights": "1.0.7",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -24,9 +24,9 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/aura-language-server": "4.7.3",
+    "@salesforce/aura-language-server": "4.7.4",
     "@salesforce/core": "6.4.7",
-    "@salesforce/lightning-lsp-common": "4.7.3",
+    "@salesforce/lightning-lsp-common": "4.7.4",
     "@salesforce/salesforcedx-utils-vscode": "59.16.0",
     "applicationinsights": "1.0.7",
     "vscode-extension-telemetry": "0.0.17",
@@ -120,8 +120,8 @@
         "applicationinsights": "1.0.7",
         "@salesforce/core": "6.4.7",
         "@salesforce/source-tracking": "5.1.3",
-        "@salesforce/aura-language-server": "4.7.3",
-        "@salesforce/lightning-lsp-common": "4.7.3"
+        "@salesforce/aura-language-server": "4.7.4",
+        "@salesforce/lightning-lsp-common": "4.7.4"
       },
       "devDependencies": {}
     }

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -26,8 +26,8 @@
   "dependencies": {
     "@salesforce/core": "6.4.7",
     "@salesforce/eslint-config-lwc": "3.5.1",
-    "@salesforce/lightning-lsp-common": "4.7.3",
-    "@salesforce/lwc-language-server": "4.7.3",
+    "@salesforce/lightning-lsp-common": "4.7.4",
+    "@salesforce/lwc-language-server": "4.7.4",
     "@salesforce/salesforcedx-utils-vscode": "59.16.0",
     "ajv": "6.12.6",
     "applicationinsights": "1.0.7",
@@ -117,8 +117,8 @@
         "applicationinsights": "1.0.7",
         "@salesforce/core": "6.4.7",
         "@salesforce/source-tracking": "5.1.3",
-        "@salesforce/lightning-lsp-common": "4.7.3",
-        "@salesforce/lwc-language-server": "4.7.3"
+        "@salesforce/lightning-lsp-common": "4.7.4",
+        "@salesforce/lwc-language-server": "4.7.4"
       },
       "devDependencies": {}
     }


### PR DESCRIPTION
### What does this PR do?
Updates the version of the lighting-language-server dependencies to pick up changes from https://github.com/forcedotcom/lightning-language-server/pull/586 to disable the generation of `jsconfig.json` file on core if there is an existing `tsconfig.json`.

### What issues does this PR fix or reference?
@W-14943725@

### Functionality Before
- conflict between `tsconfig.json` and `jsconfig.json` file that is automatically generated.

### Functionality After
- the generation of `jsconfig.json` file on core is disabled if there is an existing `tsconfig.json`.