### PR TITLE
chore: downgrade VSCode to 1.85.2 for E2E tests

### DIFF
--- a/.github/workflows/runE2ETest.yml
+++ b/.github/workflows/runE2ETest.yml
@@ -26,7 +26,7 @@ jobs:
         nodeVersion:
           - 18.18.2
         vscodeVersion:
-          - stable
+          - 1.85.2
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
### What does this PR do?
Downgrades the VSCode version used for our E2E tests from 1.86.0 to 1.85.2

### What issues does this PR fix or reference?
@W-14972243@

### Why this workaround is needed
Our E2E tests started failing with this error sometime between the hours of 1AM and 9AM on 2/1/2024, between the [original run of the E2E tests workflow and its rerun](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/7737166196): `ERROR @wdio/cli:utils: A service failed in the 'onPrepare' hook SevereServiceError: Couldn't set up Chromedriver Response code 404 (Not Found)`.  After digging into this error message, we found that the time the E2E test failures started happening was the same as when the `latest` version of VSCode changed from 1.85.2 to 1.86.0, which changed the Chromedriver version used from [114.0.5735.289](https://raw.githubusercontent.com/microsoft/vscode/1.85.2/cgmanifest.json) to [118.0.5993.159](https://raw.githubusercontent.com/microsoft/vscode/1.86.0/cgmanifest.json).

The problem with this Chromedriver upgrade is Chrome changed the location of the JSON endpoints starting from Chromedriver v115 to a [new URL](https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json) - the endpoints need to be parsed out of that big JSON block.  The [old URL](https://chromedriver.storage.googleapis.com/LATEST_RELEASE_114) gives a `The specified key does not exist.` [error message](https://chromedriver.storage.googleapis.com/LATEST_RELEASE_118) for versions v115 and later.  However, WDIO is still searching for the endpoint at the old URL, which means the endpoint won't be found for newer Chromedriver versions.  This is a WDIO bug, and thus we will need to use the workaround of using VSCode 1.85.2 for our E2E tests until WDIO fixes the bug and starts to support the new URL for Chromedriver.  (WDIO has a bug fix in progress: https://github.com/webdriverio-community/wdio-vscode-service/pull/94)