### PR TITLE
chore: add comment for why we are using VSCode 1.85.2 for E2E tests

### DIFF
--- a/.github/workflows/runE2ETest.yml
+++ b/.github/workflows/runE2ETest.yml
@@ -25,6 +25,8 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
         nodeVersion:
           - 18.18.2
+        # We are using VSCode version 1.85.2 instead of the latest version because of a WDIO bug. Starting from Chromedriver v115, the JSON endpoint was moved to a new URL, but WDIO is still trying to find the endpoint only at the old URL. VSCode 1.85.2 is the last supported version of VSCode because it uses Chromedriver v114, which is the last Chromedriver version that can be found using the old URL. VSCode 1.86.0 uses Chromedriver v118, which has an endpoint that can be found only at the new URL.
+        # We are using VSCode 1.85.2 for our E2E tests as a workaround until WDIO fixes this bug: https://github.com/webdriverio-community/wdio-vscode-service/pull/94
         vscodeVersion:
           - 1.85.2
     steps:


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Adds a comment in runE2ETest.yml explaining why we are using VSCode 1.85.2 instead of the latest VSCode version for our E2E tests

### What issues does this PR fix or reference?
@W-14972243@
