### PR TITLE
fix: sfdx to sf for auth access token, generate manifest and rename lwc component

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -334,7 +334,7 @@
           "when": "sfdx:project_opened"
         },
         {
-          "command": "sfdx.lightning.rename",
+          "command": "sfdx.rename.lightning.component",
           "when": "sfdx:project_opened && resource =~ /.*\\/(lwc|aura)\\/.*(\\/[^\\/]+\\.(html|css|js|xml|svg|cmp|app|design|auradoc))?$/"
         }
       ],
@@ -468,7 +468,7 @@
           "when": "false"
         },
         {
-          "command": "sfdx.lightning.rename",
+          "command": "sfdx.rename.lightning.component",
           "when": "false"
         },
         {
@@ -911,8 +911,8 @@
         "title": "%force_launch_apex_replay_debugger_with_current_file%"
       },
       {
-        "command": "sfdx.lightning.rename",
-        "title": "%force_lightning_rename_component_text%"
+        "command": "sfdx.rename.lightning.component",
+        "title": "%rename_lightning_component_text%"
       }
     ],
     "configuration": {

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -348,7 +348,7 @@
           "when": "sfdx:project_opened"
         },
         {
-          "command": "sfdx.force.auth.accessToken",
+          "command": "sfdx.org.login.access.token",
           "when": "sfdx:project_opened"
         },
         {
@@ -631,8 +631,8 @@
         "title": "%org_login_web_authorize_org_text%"
       },
       {
-        "command": "sfdx.force.auth.accessToken",
-        "title": "%force_auth_access_token_authorize_org_text%"
+        "command": "sfdx.org.login.access.token",
+        "title": "%org_login_access_token_text%"
       },
       {
         "command": "sfdx.org.logout.all",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -330,7 +330,7 @@
           "when": "sfdx:project_opened && resourceLangId != 'forcesourcemanifest'"
         },
         {
-          "command": "sfdx.create.manifest",
+          "command": "sfdx.project.generate.manifest",
           "when": "sfdx:project_opened"
         },
         {
@@ -464,7 +464,7 @@
           "when": "!sfdx:internal_dev"
         },
         {
-          "command": "sfdx.create.manifest",
+          "command": "sfdx.project.generate.manifest",
           "when": "false"
         },
         {
@@ -883,8 +883,8 @@
         }
       },
       {
-        "command": "sfdx.create.manifest",
-        "title": "%force_create_manifest%"
+        "command": "sfdx.project.generate.manifest",
+        "title": "%project_generate_manifest%"
       },
       {
         "command": "sfdx.force.diff",

--- a/packages/salesforcedx-vscode-core/package.nls.ja.json
+++ b/packages/salesforcedx-vscode-core/package.nls.ja.json
@@ -71,5 +71,6 @@
   "stop_apex_debug_logging": "SFDX: Replay Debugger 用の Apex デバッグログを無効化",
   "telemetry_enabled_description": "Salesforce による利用状況データの収集を有効化するかどうかを指定します。この設定で有効化していても、VS Code 全体の設定 `telemetry.enableTelemetry` が優先されます。",
   "visualforce_generate_component_text": "SFDX: Visualforce コンポーネントを作成",
-  "visualforce_generate_page_text": "SFDX: Visualforce ページを作成"
+  "visualforce_generate_page_text": "SFDX: Visualforce ページを作成",
+  "rename_lightning_component_text": "SFDX: Rename Component"
 }

--- a/packages/salesforcedx-vscode-core/package.nls.ja.json
+++ b/packages/salesforcedx-vscode-core/package.nls.ja.json
@@ -16,7 +16,7 @@
   "delete_source_text": "SFDX: プロジェクトおよび組織から削除",
   "delete_source_this_source_text": "SFDX: このソースをプロジェクトと組織から削除",
   "enable_sobject_refresh_on_startup_description": "プロジェクトに sObject 定義がない場合、拡張機能が有効化される際に自動的に sObject 定義を更新するかどうかを指定します。",
-  "force_auth_access_token_authorize_org_text": "SFDX: Authorize an Org using Session ID",
+  "org_login_access_token_text": "SFDX: Authorize an Org using Session ID",
   "force_diff_against_org": "SFDX: ファイルと組織の差分を表示",
   "force_diff_folder_against_org": "SFDX: フォルダと組織の差分を表示",
   "force_lightning_lwc_test_create_text": "SFDX: Lightning Web コンポーネントのテストを作成",

--- a/packages/salesforcedx-vscode-core/package.nls.ja.json
+++ b/packages/salesforcedx-vscode-core/package.nls.ja.json
@@ -55,6 +55,7 @@
   "org_open_default_scratch_org_text": "SFDX: デフォルトの組織を開く",
   "project_deploy_start_default_org_text": "SFDX: デフォルトのスクラッチ組織へソースをプッシュ",
   "project_deploy_start_ignore_conflicts_default_org_text": "SFDX: Push Source to Default Org and Ignore Conflicts",
+  "project_generate_manifest": "SFDX: Generate Manifest File",
   "project_generate_text": "SFDX: プロジェクトを作成",
   "project_generate_with_manifest_text": "SFDX: マニフェストファイルを使用してプロジェクトを作成",
   "project_retrieve_start_default_org_text": "SFDX: デフォルトのスクラッチ組織からソースをプル",

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -19,7 +19,7 @@
   "enable_sobject_refresh_on_startup_description": "If a project has no sObject definitions, specifies whether to automatically refresh sObject definitions on extension activation (true) or not (false).",
   "enable_source_tracking_for_deploy_and_retrieve": "Specifies whether source-tracking is enabled for deploy or retrieve operations in a source-tracked org. Disable source-tracking if you are experiencing performance issues using deploy or retrieve commands on your source-tracked orgs.",
   "org_login_access_token_text": "SFDX: Authorize an Org using Session ID",
-  "force_create_manifest": "SFDX: Generate Manifest File",
+  "project_generate_manifest": "SFDX: Generate Manifest File",
   "force_diff_against_org": "SFDX: Diff File Against Org",
   "force_diff_folder_against_org": "SFDX: Diff Folder Against Org",
   "force_launch_apex_replay_debugger_with_current_file": "SFDX: Launch Apex Replay Debugger with Current File",

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -24,7 +24,7 @@
   "force_diff_folder_against_org": "SFDX: Diff Folder Against Org",
   "force_launch_apex_replay_debugger_with_current_file": "SFDX: Launch Apex Replay Debugger with Current File",
   "force_lightning_lwc_test_create_text": "SFDX: Create Lightning Web Component Test",
-  "force_lightning_rename_component_text": "SFDX: Rename Component",
+  "rename_lightning_component_text": "SFDX: Rename Component",
   "force_manifest_editor_show_text": "SFDX: Show Package Manifest Editor",
   "force_package_install_text": "SFDX: Install Package",
   "force_sobjects_refresh": "SFDX: Refresh SObject Definitions",

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -18,7 +18,7 @@
   "delete_source_this_source_text": "SFDX: Delete This from Project and Org",
   "enable_sobject_refresh_on_startup_description": "If a project has no sObject definitions, specifies whether to automatically refresh sObject definitions on extension activation (true) or not (false).",
   "enable_source_tracking_for_deploy_and_retrieve": "Specifies whether source-tracking is enabled for deploy or retrieve operations in a source-tracked org. Disable source-tracking if you are experiencing performance issues using deploy or retrieve commands on your source-tracked orgs.",
-  "force_auth_access_token_authorize_org_text": "SFDX: Authorize an Org using Session ID",
+  "org_login_access_token_text": "SFDX: Authorize an Org using Session ID",
   "force_create_manifest": "SFDX: Generate Manifest File",
   "force_diff_against_org": "SFDX: Diff File Against Org",
   "force_diff_folder_against_org": "SFDX: Diff Folder Against Org",

--- a/packages/salesforcedx-vscode-core/src/commands/auth/orgLoginAccessToken.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/auth/orgLoginAccessToken.ts
@@ -17,13 +17,11 @@ import {
   AccessTokenParamsGatherer
 } from './authParamsGatherer';
 
-export class ForceAuthAccessTokenExecutor extends LibraryCommandletExecutor<
-  AccessTokenParams
-> {
+export class OrgLoginAccessTokenExecutor extends LibraryCommandletExecutor<AccessTokenParams> {
   constructor() {
     super(
-      nls.localize('force_auth_access_token_authorize_org_text'),
-      'force_auth_access_token',
+      nls.localize('org_login_access_token_text'),
+      'org_login_access_token',
       OUTPUT_CHANNEL
     );
   }
@@ -36,7 +34,7 @@ export class ForceAuthAccessTokenExecutor extends LibraryCommandletExecutor<
       increment?: number | undefined;
     }>,
     token?: vscode.CancellationToken
-  /* eslint-enable @typescript-eslint/no-unused-vars */
+    /* eslint-enable @typescript-eslint/no-unused-vars */
   ): Promise<boolean> {
     const { instanceUrl, accessToken, alias } = response.data;
     try {
@@ -53,7 +51,7 @@ export class ForceAuthAccessTokenExecutor extends LibraryCommandletExecutor<
       if (error.message && error.message.includes('Bad_OAuth_Token')) {
         // Provide a user-friendly message for invalid / expired session ID
         channelService.appendLine(
-          nls.localize('force_auth_access_token_login_bad_oauth_token_message')
+          nls.localize('org_login_access_token_bad_oauth_token_message')
         );
       }
       throw error;
@@ -66,11 +64,11 @@ export class ForceAuthAccessTokenExecutor extends LibraryCommandletExecutor<
 const workspaceChecker = new SfdxWorkspaceChecker();
 const parameterGatherer = new AccessTokenParamsGatherer();
 
-export async function forceAuthAccessToken() {
+export async function orgLoginAccessToken() {
   const commandlet = new SfdxCommandlet(
     workspaceChecker,
     parameterGatherer,
-    new ForceAuthAccessTokenExecutor()
+    new OrgLoginAccessTokenExecutor()
   );
   await commandlet.run();
 }

--- a/packages/salesforcedx-vscode-core/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/index.ts
@@ -65,7 +65,7 @@ export {
   forceRefreshSObjects,
   initSObjectDefinitions
 } from './forceRefreshSObjects';
-export { forceRenameLightningComponent } from './forceRenameLightningComponent';
+export { renameLightningComponent } from './renameLightningComponent';
 export { forceSourceDeployManifest } from './forceSourceDeployManifest';
 export {
   LibraryDeploySourcePathExecutor,

--- a/packages/salesforcedx-vscode-core/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/index.ts
@@ -50,7 +50,7 @@ export {
   ManifestChecker,
   deleteSource
 } from './deleteSource';
-export { forceCreateManifest } from './forceCreateManifest';
+export { projectGenerateManifest } from './projectGenerateManifest';
 export { DescribeMetadataExecutor, describeMetadata } from './describeMetadata';
 export { ListMetadataExecutor, listMetadata } from './listMetadata';
 export {

--- a/packages/salesforcedx-vscode-core/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/index.ts
@@ -15,7 +15,7 @@ export {
   PRODUCTION_URL,
   SANDBOX_URL
 } from './auth/authParamsGatherer';
-export { forceAuthAccessToken } from './auth/forceAuthAccessTokenLogin';
+export { orgLoginAccessToken } from './auth/orgLoginAccessToken';
 export {
   DeviceCodeResponse,
   OrgLoginWebContainerExecutor,

--- a/packages/salesforcedx-vscode-core/src/commands/projectGenerateManifest.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/projectGenerateManifest.ts
@@ -17,18 +17,18 @@ import { nls } from '../messages';
 import { workspaceUtils } from '../util';
 import { FilePathGatherer, SfdxCommandlet, SfdxWorkspaceChecker } from './util';
 
-const CREATE_MANIFEST_EXECUTOR = 'force_create_manifest';
+const GENERATE_MANIFEST_EXECUTOR = 'project_generate_manifest';
 const DEFAULT_MANIFEST = 'package.xml';
 const MANIFEST_SAVE_PLACEHOLDER = 'manifest_input_save_placeholder';
 const MANIFEST_SAVE_PROMPT = 'manifest_input_save_prompt';
 
-export class ManifestCreateExecutor extends LibraryCommandletExecutor<string> {
+export class GenerateManifestExecutor extends LibraryCommandletExecutor<string> {
   private sourcePaths: string[];
   private responseText: string | undefined;
   constructor(sourcePaths: string[], responseText: string | undefined) {
     super(
-      nls.localize(CREATE_MANIFEST_EXECUTOR),
-      CREATE_MANIFEST_EXECUTOR,
+      nls.localize(GENERATE_MANIFEST_EXECUTOR),
+      GENERATE_MANIFEST_EXECUTOR,
       OUTPUT_CHANNEL
     );
     this.sourcePaths = sourcePaths;
@@ -42,7 +42,7 @@ export class ManifestCreateExecutor extends LibraryCommandletExecutor<string> {
       increment?: number | undefined;
     }>,
     token?: vscode.CancellationToken
-  /* eslint-enable @typescript-eslint/no-unused-vars */
+    /* eslint-enable @typescript-eslint/no-unused-vars */
   ): Promise<boolean> {
     if (this.sourcePaths) {
       const packageXML = await ComponentSet.fromSource(
@@ -60,7 +60,7 @@ export class ManifestCreateExecutor extends LibraryCommandletExecutor<string> {
   }
 }
 
-export async function forceCreateManifest(
+export async function projectGenerateManifest(
   sourceUri: vscode.Uri,
   uris: vscode.Uri[] | undefined
 ) {
@@ -78,7 +78,7 @@ export async function forceCreateManifest(
     const commandlet = new SfdxCommandlet(
       new SfdxWorkspaceChecker(),
       new FilePathGatherer(sourceUri),
-      new ManifestCreateExecutor(sourcePaths, responseText)
+      new GenerateManifestExecutor(sourcePaths, responseText)
     );
     await commandlet.run();
   }

--- a/packages/salesforcedx-vscode-core/src/commands/renameLightningComponent.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/renameLightningComponent.ts
@@ -21,7 +21,7 @@ import { OUTPUT_CHANNEL } from '../channels';
 import { nls } from '../messages';
 import { SfdxCommandlet, SfdxWorkspaceChecker } from './util';
 
-const RENAME_LIGHTNING_COMPONENT_EXECUTOR = 'force_rename_lightning_component';
+const RENAME_LIGHTNING_COMPONENT_EXECUTOR = 'rename_lightning_component';
 const RENAME_INPUT_PLACEHOLDER = 'rename_component_input_placeholder';
 const RENAME_INPUT_PROMPT = 'rename_component_input_prompt';
 const RENAME_INPUT_DUP_ERROR = 'rename_component_input_dup_error';
@@ -33,9 +33,7 @@ const LWC = 'lwc';
 const AURA = 'aura';
 const TEST_FOLDER = '__tests__';
 
-export class RenameLwcComponentExecutor extends LibraryCommandletExecutor<
-  ComponentName
-> {
+export class RenameLwcComponentExecutor extends LibraryCommandletExecutor<ComponentName> {
   private sourceFsPath: string;
   constructor(sourceFsPath: string) {
     super(
@@ -65,7 +63,7 @@ export class RenameLwcComponentExecutor extends LibraryCommandletExecutor<
   }
 }
 
-export async function forceRenameLightningComponent(sourceUri: vscode.Uri) {
+export async function renameLightningComponent(sourceUri: vscode.Uri) {
   const sourceFsPath = sourceUri.fsPath;
   if (sourceFsPath) {
     const commandlet = new SfdxCommandlet(
@@ -243,7 +241,9 @@ export function isNameMatch(
       `${componentName}\\.(html|js|js-meta.xml|css|svg|test.js)`
     );
   } else {
-    regularExp = new RegExp(`${componentName}(((Controller|Renderer|Helper)?\\.js)|(\\.(cmp|app|css|design|auradoc|svg|evt)))`);
+    regularExp = new RegExp(
+      `${componentName}(((Controller|Renderer|Helper)?\\.js)|(\\.(cmp|app|css|design|auradoc|svg|evt)))`
+    );
   }
   return Boolean(item.match(regularExp));
 }

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -30,7 +30,7 @@ import {
   debuggerStop,
   deleteSource,
   orgLoginAccessToken,
-  forceCreateManifest,
+  projectGenerateManifest,
   forceLightningLwcTestCreate,
   forcePackageInstall,
   forceRefreshSObjects,
@@ -532,7 +532,10 @@ async function setupOrgBrowser(
     }
   );
 
-  vscode.commands.registerCommand('sfdx.create.manifest', forceCreateManifest);
+  vscode.commands.registerCommand(
+    'sfdx.project.generate.manifest',
+    projectGenerateManifest
+  );
 }
 
 export async function activate(extensionContext: vscode.ExtensionContext) {

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -29,7 +29,7 @@ import {
   dataQuery,
   debuggerStop,
   deleteSource,
-  forceAuthAccessToken,
+  orgLoginAccessToken,
   forceCreateManifest,
   forceLightningLwcTestCreate,
   forcePackageInstall,
@@ -133,9 +133,9 @@ function registerCommands(
   extensionContext: vscode.ExtensionContext
 ): vscode.Disposable {
   // Customer-facing commands
-  const forceAuthAccessTokenCmd = vscode.commands.registerCommand(
-    'sfdx.force.auth.accessToken',
-    forceAuthAccessToken
+  const orgLoginAccessTokenCmd = vscode.commands.registerCommand(
+    'sfdx.org.login.access.token',
+    orgLoginAccessToken
   );
   const orgLoginWebCmd = vscode.commands.registerCommand(
     'sfdx.org.login.web',
@@ -393,7 +393,7 @@ function registerCommands(
   return vscode.Disposable.from(
     forceRenameComponentCmd,
     forceDiffFolder,
-    forceAuthAccessTokenCmd,
+    orgLoginAccessTokenCmd,
     dataQueryInputCmd,
     dataQuerySelectionCmd,
     forceDiffFile,

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -34,7 +34,7 @@ import {
   forceLightningLwcTestCreate,
   forcePackageInstall,
   forceRefreshSObjects,
-  forceRenameLightningComponent,
+  renameLightningComponent,
   forceSourceDeployManifest,
   forceSourceDeploySourcePaths,
   forceSourceDiff,
@@ -385,13 +385,13 @@ function registerCommands(
   );
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const forceRenameComponentCmd = vscode.commands.registerCommand(
-    'sfdx.lightning.rename',
-    forceRenameLightningComponent
+  const renameLightningComponentCmd = vscode.commands.registerCommand(
+    'sfdx.rename.lightning.component',
+    renameLightningComponent
   );
 
   return vscode.Disposable.from(
-    forceRenameComponentCmd,
+    renameLightningComponentCmd,
     forceDiffFolder,
     orgLoginAccessTokenCmd,
     dataQueryInputCmd,

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ja.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ja.ts
@@ -40,9 +40,8 @@ export const messages = {
 
   org_login_web_authorize_dev_hub_text: 'SFDX: Dev Hub 組織を認証',
   org_login_web_authorize_org_text: 'SFDX: 組織を認証',
-  force_auth_access_token_authorize_org_text:
-    'SFDX: Authorize an Org using Session ID',
-  force_auth_access_token_login_bad_oauth_token_message:
+  org_login_access_token_text: 'SFDX: Authorize an Org using Session ID',
+  org_login_access_token_bad_oauth_token_message:
     'The session ID that you are trying to use is not valid. Check if it has expired, or use a valid session ID.',
 
   parameter_directory_strict_not_available:

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ja.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ja.ts
@@ -111,7 +111,7 @@ export const messages = {
     'ソースファイルを削除すると、コンピュータからファイルが削除され、デフォルトの組織から対応するメタデータが取り除かれます。このソースをプロジェクトおよび組織から削除してもよろしいですか？',
   confirm_delete_source_button_text: 'ソースを削除',
   cancel_delete_source_button_text: 'キャンセル',
-
+  rename_lightning_component: 'SFDX: Rename Component',
   view_all_changes_text: 'すべての変更を参照 (ローカルおよびスクラッチ組織内)',
 
   apex_generate_class_text: 'SFDX: Apex クラスを作成',

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ja.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ja.ts
@@ -165,6 +165,7 @@ export const messages = {
   project_generate_analytics_template_display_text: 'Analytics',
   project_generate_empty_template: '空のプロジェクトテンプレート',
   project_generate_analytics_template: 'Analytics のプロジェクトテンプレート',
+  project_generate_manifest: 'SFDX: Generate Manifest File',
   apex_generate_trigger_text: 'SFDX: Apex トリガを作成',
   start_apex_debug_logging:
     'SFDX: Replay Debugger 用に Apex デバッグログを有効化',

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -139,7 +139,7 @@ export const messages = {
   lightning_generate_interface_text: 'SFDX: Create Aura Interface',
   force_function_create_text: 'SFDX: Create Function',
   force_function_containerless_start_text: 'SFDX: Start Local Function',
-  force_create_manifest: 'SFDX: Generate Manifest File',
+  project_generate_manifest: 'SFDX: Generate Manifest File',
   force_function_start_no_org_auth:
     'No default org is set. We recommend that you select an active scratch org (SFDX: Set a Default Org) or create a new scratch org (SFDX: Authorize a Dev Hub, then SFDX: Create a Default Scratch Org).',
   force_function_start_warning_no_toml:

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -657,7 +657,7 @@ export const messages = {
   sobject_refresh_standard: 'Standard SObjects',
   force_sobjects_no_refresh_if_already_active_error_text:
     'A refresh of your sObject definitions is already underway. If you need to restart the process, cancel the running task.',
-  force_rename_lightning_component: 'SFDX: Rename Component',
+  rename_lightning_component: 'SFDX: Rename Component',
   rename_component_input_dup_error:
     'Component name is already in use in LWC or Aura',
   rename_component_input_dup_file_name_error:

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -42,9 +42,8 @@ export const messages = {
 
   org_login_web_authorize_dev_hub_text: 'SFDX: Authorize a Dev Hub',
   org_login_web_authorize_org_text: 'SFDX: Authorize an Org',
-  force_auth_access_token_authorize_org_text:
-    'SFDX: Authorize an Org using Session ID',
-  force_auth_access_token_login_bad_oauth_token_message:
+  org_login_access_token_text: 'SFDX: Authorize an Org using Session ID',
+  org_login_access_token_bad_oauth_token_message:
     'The session ID that you are trying to use is not valid. Check if it has expired, or use a valid session ID.',
   org_login_device_code_parse_error:
     'There was an unexpected error authorizing to your org in a container environment.',

--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -124,7 +124,7 @@ export class OrgList implements vscode.Disposable {
       '$(plus) ' + nls.localize('org_login_web_authorize_org_text'),
       '$(plus) ' + nls.localize('org_login_web_authorize_dev_hub_text'),
       '$(plus) ' + nls.localize('org_create_default_scratch_org_text'),
-      '$(plus) ' + nls.localize('force_auth_access_token_authorize_org_text'),
+      '$(plus) ' + nls.localize('org_login_access_token_text'),
       '$(plus) ' + nls.localize('org_list_clean_text')
     ];
 
@@ -151,9 +151,8 @@ export class OrgList implements vscode.Disposable {
         vscode.commands.executeCommand('sfdx.org.create');
         return { type: 'CONTINUE', data: {} };
       }
-      case '$(plus) ' +
-        nls.localize('force_auth_access_token_authorize_org_text'): {
-        vscode.commands.executeCommand('sfdx.force.auth.accessToken');
+      case '$(plus) ' + nls.localize('org_login_access_token_text'): {
+        vscode.commands.executeCommand('sfdx.org.login.access.token');
         return { type: 'CONTINUE', data: {} };
       }
       case '$(plus) ' + nls.localize('org_list_clean_text'): {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/auth/orgLoginAccessToken.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/auth/orgLoginAccessToken.test.ts
@@ -10,14 +10,14 @@ import { assert, createSandbox, SinonStub } from 'sinon';
 import { channelService } from '../../../../src/channels/index';
 import {
   AccessTokenParamsGatherer,
-  forceAuthAccessToken
+  orgLoginAccessToken
 } from '../../../../src/commands';
 import { SfdxWorkspaceChecker } from '../../../../src/commands/util';
 import { nls } from '../../../../src/messages';
 
 const sandbox = createSandbox();
 
-describe('Force Auth Access Token Login', () => {
+describe('Org Login Access Token', () => {
   let workspaceCheckerStub: SinonStub;
   let accessTokenParamsGathererStub: SinonStub;
   let authInfoCreateStub: SinonStub;
@@ -64,7 +64,7 @@ describe('Force Auth Access Token Login', () => {
   });
 
   it('Should create and save auth info', async () => {
-    await forceAuthAccessToken();
+    await orgLoginAccessToken();
     assert.calledOnce(authInfoCreateStub);
     assert.calledWith(authInfoCreateStub, {
       accessTokenOptions: {
@@ -87,12 +87,12 @@ describe('Force Auth Access Token Login', () => {
       );
     });
 
-    await forceAuthAccessToken();
+    await orgLoginAccessToken();
 
     assert.calledOnce(channelServiceStub);
     assert.calledWith(
       channelServiceStub,
-      nls.localize('force_auth_access_token_login_bad_oauth_token_message')
+      nls.localize('org_login_access_token_bad_oauth_token_message')
     );
     assert.notCalled(handleAliasAndDefaultSettingsStub);
   });

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/projectGenerateManifest.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/projectGenerateManifest.test.ts
@@ -13,7 +13,7 @@ import * as sinon from 'sinon';
 import { createSandbox } from 'sinon';
 import * as util from 'util';
 import * as vscode from 'vscode';
-import { ManifestCreateExecutor } from '../../../src/commands/forceCreateManifest';
+import { GenerateManifestExecutor } from '../../../src/commands/projectGenerateManifest';
 import { nls } from '../../../src/messages';
 
 const classPath = '/force-app/main/default/classes/';
@@ -26,7 +26,9 @@ const EMPTY_MANIFEST = `<?xml version="1.0" encoding="UTF-8"?>
   %s
   <version>53.0</version>
 </Package>`;
-const APEX_MANIFEST = util.format(EMPTY_MANIFEST, `
+const APEX_MANIFEST = util.format(
+  EMPTY_MANIFEST,
+  `
 <types>
   %s
   <name>ApexClass</name>
@@ -36,9 +38,8 @@ const APEX_MANIFEST = util.format(EMPTY_MANIFEST, `
 const env = createSandbox();
 let openTextDocumentSpy: sinon.SinonSpy;
 
-describe('Force Create Manifest', () => {
+describe('Project Generate Manifest', () => {
   describe('Happy Path Unit Tests', () => {
-
     beforeEach(() => {
       openTextDocumentSpy = env.spy(vscode.workspace, 'openTextDocument');
     });
@@ -48,7 +49,10 @@ describe('Force Create Manifest', () => {
     });
 
     it('Should create first manifest from single sourceUri', async () => {
-      const packageXML = util.format(APEX_MANIFEST, `<member>${CLASS_1}</member>`);
+      const packageXML = util.format(
+        APEX_MANIFEST,
+        `<member>${CLASS_1}</member>`
+      );
       env.stub(ComponentSet, 'fromSource').returns({
         getPackageXml: () => {
           return packageXML;
@@ -58,7 +62,10 @@ describe('Force Create Manifest', () => {
       env.stub(fs, 'mkdirSync').returns(undefined);
       env.stub(fs, 'writeFileSync').returns(undefined);
       const packageName = 'package' + generateRandomSuffix() + '.xml';
-      const executor = new ManifestCreateExecutor([URI_1.fsPath], packageName);
+      const executor = new GenerateManifestExecutor(
+        [URI_1.fsPath],
+        packageName
+      );
       await executor.run({
         type: 'CONTINUE',
         data: ''
@@ -68,20 +75,27 @@ describe('Force Create Manifest', () => {
     });
 
     it('Should create manifest from list of uris', async () => {
-      const packageXML = util.format(APEX_MANIFEST, `<member>${CLASS_1}</member>\n<member>${CLASS_2}</member>\n`);
+      const packageXML = util.format(
+        APEX_MANIFEST,
+        `<member>${CLASS_1}</member>\n<member>${CLASS_2}</member>\n`
+      );
       env.stub(ComponentSet, 'fromSource').returns({
         getPackageXml: () => {
           return packageXML;
         }
       });
-      env.stub(fs, 'existsSync')
+      env
+        .stub(fs, 'existsSync')
         .onFirstCall()
         .returns(true)
         .onSecondCall()
         .returns(false);
       env.stub(fs, 'writeFileSync').returns(undefined);
       const packageName = 'package' + generateRandomSuffix() + '.xml';
-      const executor = new ManifestCreateExecutor([URI_1.fsPath, URI_2.fsPath], packageName);
+      const executor = new GenerateManifestExecutor(
+        [URI_1.fsPath, URI_2.fsPath],
+        packageName
+      );
       await executor.run({
         type: 'CONTINUE',
         data: ''
@@ -92,18 +106,25 @@ describe('Force Create Manifest', () => {
 
     it('Should create but not save manifest if cancelled', async () => {
       const writeFileSpy = env.spy(fs, 'writeFileSync');
-      const packageXML = util.format(APEX_MANIFEST, `<member>${CLASS_1}</member>\n<member>${CLASS_2}</member>\n`);
+      const packageXML = util.format(
+        APEX_MANIFEST,
+        `<member>${CLASS_1}</member>\n<member>${CLASS_2}</member>\n`
+      );
       env.stub(ComponentSet, 'fromSource').returns({
         getPackageXml: () => {
           return packageXML;
         }
       });
-      env.stub(fs, 'existsSync')
+      env
+        .stub(fs, 'existsSync')
         .onFirstCall()
         .returns(true)
         .onSecondCall()
         .returns(false);
-      const executor = new ManifestCreateExecutor([URI_1.fsPath, URI_2.fsPath], undefined);
+      const executor = new GenerateManifestExecutor(
+        [URI_1.fsPath, URI_2.fsPath],
+        undefined
+      );
       await executor.run({
         type: 'CONTINUE',
         data: ''
@@ -114,19 +135,26 @@ describe('Force Create Manifest', () => {
     });
 
     it('Should use default manifest name if none is supplied', async () => {
-      const packageXML = util.format(APEX_MANIFEST, `<member>${CLASS_1}</member>\n<member>${CLASS_2}</member>\n`);
+      const packageXML = util.format(
+        APEX_MANIFEST,
+        `<member>${CLASS_1}</member>\n<member>${CLASS_2}</member>\n`
+      );
       env.stub(ComponentSet, 'fromSource').returns({
         getPackageXml: () => {
           return packageXML;
         }
       });
-      env.stub(fs, 'existsSync')
+      env
+        .stub(fs, 'existsSync')
         .onFirstCall()
         .returns(true)
         .onSecondCall()
         .returns(false);
       env.stub(fs, 'writeFileSync').returns(undefined);
-      const executor = new ManifestCreateExecutor([URI_1.fsPath, URI_2.fsPath], '');
+      const executor = new GenerateManifestExecutor(
+        [URI_1.fsPath, URI_2.fsPath],
+        ''
+      );
       await executor.run({
         type: 'CONTINUE',
         data: ''
@@ -138,13 +166,17 @@ describe('Force Create Manifest', () => {
     });
 
     it('Should append correct extension', async () => {
-      const packageXML = util.format(APEX_MANIFEST, `<member>${CLASS_1}</member>\n<member>${CLASS_2}</member>\n`);
+      const packageXML = util.format(
+        APEX_MANIFEST,
+        `<member>${CLASS_1}</member>\n<member>${CLASS_2}</member>\n`
+      );
       env.stub(ComponentSet, 'fromSource').returns({
         getPackageXml: () => {
           return packageXML;
         }
       });
-      env.stub(fs, 'existsSync')
+      env
+        .stub(fs, 'existsSync')
         .onFirstCall()
         .returns(true)
         .onSecondCall()
@@ -152,7 +184,10 @@ describe('Force Create Manifest', () => {
       env.stub(fs, 'writeFileSync').returns(undefined);
       const randomSuffix = generateRandomSuffix();
       const packageName = 'package' + randomSuffix + '.txt';
-      const executor = new ManifestCreateExecutor([URI_1.fsPath, URI_2.fsPath], packageName);
+      const executor = new GenerateManifestExecutor(
+        [URI_1.fsPath, URI_2.fsPath],
+        packageName
+      );
       await executor.run({
         type: 'CONTINUE',
         data: ''
@@ -170,12 +205,16 @@ describe('Force Create Manifest', () => {
           return packageXML;
         }
       });
-      env.stub(fs, 'existsSync')
+      env
+        .stub(fs, 'existsSync')
         .onFirstCall()
         .returns(true)
         .onSecondCall()
         .returns(false);
-      const executor = new ManifestCreateExecutor([URI_1.fsPath, URI_2.fsPath], undefined);
+      const executor = new GenerateManifestExecutor(
+        [URI_1.fsPath, URI_2.fsPath],
+        undefined
+      );
       await executor.run({
         type: 'CONTINUE',
         data: ''
@@ -183,11 +222,9 @@ describe('Force Create Manifest', () => {
 
       expect(openTextDocumentSpy.calledOnce).to.equal(true);
     });
-
   });
 
   describe('Exception Handling Unit Tests', () => {
-
     beforeEach(() => {
       openTextDocumentSpy = env.spy(vscode.workspace, 'openTextDocument');
     });
@@ -197,12 +234,15 @@ describe('Force Create Manifest', () => {
     });
 
     it('Should handle exception while creating component set', async () => {
-      env.stub(ComponentSet, 'fromSource').throws(
-        new Error(nls.localize('error_creating_packagexml'))
-      );
+      env
+        .stub(ComponentSet, 'fromSource')
+        .throws(new Error(nls.localize('error_creating_packagexml')));
       let exceptionThrown = false;
       try {
-        const executor = new ManifestCreateExecutor([URI_1.fsPath, URI_2.fsPath], '');
+        const executor = new GenerateManifestExecutor(
+          [URI_1.fsPath, URI_2.fsPath],
+          ''
+        );
         await executor.run({
           type: 'CONTINUE',
           data: ''
@@ -218,7 +258,10 @@ describe('Force Create Manifest', () => {
     });
 
     it('Should enforce unique manifest names', async () => {
-      const packageXML = util.format(APEX_MANIFEST, `<member>${CLASS_1}</member>`);
+      const packageXML = util.format(
+        APEX_MANIFEST,
+        `<member>${CLASS_1}</member>`
+      );
       env.stub(ComponentSet, 'fromSource').returns({
         getPackageXml: () => {
           return packageXML;
@@ -229,12 +272,11 @@ describe('Force Create Manifest', () => {
 
       let exceptionThrown = false;
       try {
-        const executor = new ManifestCreateExecutor([URI_1.fsPath], fileName);
+        const executor = new GenerateManifestExecutor([URI_1.fsPath], fileName);
         await executor.run({
           type: 'CONTINUE',
           data: ''
         });
-
       } catch (e) {
         exceptionThrown = true;
         expect(e.message).to.contain(fileName);
@@ -243,7 +285,6 @@ describe('Force Create Manifest', () => {
       expect(openTextDocumentSpy.called).to.equal(false);
     });
   });
-
 });
 
 function generateRandomSuffix() {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/renameLightningComponent.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/renameLightningComponent.test.ts
@@ -54,7 +54,7 @@ let renameStub: sinon.SinonStub;
 let statStub: sinon.SinonStub;
 let readdirStub: sinon.SinonStub;
 
-describe('Lightning Component', () => {
+describe('Rename Lightning Component', () => {
   describe('Happy Path Unit Test', () => {
     beforeEach(() => {
       renameStub = env.stub(fs.promises, 'rename').resolves(undefined);

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/renameLightningComponent.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/renameLightningComponent.test.ts
@@ -15,7 +15,7 @@ import {
   inputGuard,
   isNameMatch,
   RenameLwcComponentExecutor
-} from '../../../src/commands/forceRenameLightningComponent';
+} from '../../../src/commands/renameLightningComponent';
 import { nls } from '../../../src/messages';
 
 const RENAME_INPUT_DUP_ERROR = 'rename_component_input_dup_error';
@@ -25,8 +25,27 @@ const lwcPath = vscode.Uri.parse('/force-app/main/default/lwc');
 const auraPath = vscode.Uri.parse('/force-app/main/default/aura/');
 const lwcComponent = 'hero';
 const auraComponent = 'page';
-const itemsInHero = ['hero.css', 'hero.html', 'hero.js', 'hero.js-meta.xml', 'templateOne.html'];
-const itemsInPage = ['page.auradoc', 'page.cmp', 'page.cmp-meta.xml', 'page.css', 'page.design', 'page.svg', 'pageController.js', 'pageHelper.js', 'pageRenderer.js', 'page.evt', 'page.evt-meta.xml', 'templateOne.css'];
+const itemsInHero = [
+  'hero.css',
+  'hero.html',
+  'hero.js',
+  'hero.js-meta.xml',
+  'templateOne.html'
+];
+const itemsInPage = [
+  'page.auradoc',
+  'page.cmp',
+  'page.cmp-meta.xml',
+  'page.css',
+  'page.design',
+  'page.svg',
+  'pageController.js',
+  'pageHelper.js',
+  'pageRenderer.js',
+  'page.evt',
+  'page.evt-meta.xml',
+  'templateOne.css'
+];
 const testFolder = '__tests__';
 const testFiles = ['hero.test.js', 'example.test.js'];
 
@@ -35,7 +54,7 @@ let renameStub: sinon.SinonStub;
 let statStub: sinon.SinonStub;
 let readdirStub: sinon.SinonStub;
 
-describe('Force Rename Lightning Component', () => {
+describe('Lightning Component', () => {
   describe('Happy Path Unit Test', () => {
     beforeEach(() => {
       renameStub = env.stub(fs.promises, 'rename').resolves(undefined);
@@ -346,27 +365,57 @@ describe('Force Rename Lightning Component', () => {
     it('should return true of file name and component name match for essential Aura files', () => {
       const componentName = 'page';
       const componentPath = path.join(auraPath.fsPath, auraComponent);
-      expect(isNameMatch(itemsInPage[0], componentName, componentPath)).to.equal(true);
-      expect(isNameMatch(itemsInPage[1], componentName, componentPath)).to.equal(true);
-      expect(isNameMatch(itemsInPage[2], componentName, componentPath)).to.equal(true);
-      expect(isNameMatch(itemsInPage[3], componentName, componentPath)).to.equal(true);
-      expect(isNameMatch(itemsInPage[4], componentName, componentPath)).to.equal(true);
-      expect(isNameMatch(itemsInPage[5], componentName, componentPath)).to.equal(true);
-      expect(isNameMatch(itemsInPage[6], componentName, componentPath)).to.equal(true);
-      expect(isNameMatch(itemsInPage[7], componentName, componentPath)).to.equal(true);
-      expect(isNameMatch(itemsInPage[8], componentName, componentPath)).to.equal(true);
-      expect(isNameMatch(itemsInPage[9], componentName, componentPath)).to.equal(true);
-      expect(isNameMatch(itemsInPage[10], componentName, componentPath)).to.equal(true);
+      expect(
+        isNameMatch(itemsInPage[0], componentName, componentPath)
+      ).to.equal(true);
+      expect(
+        isNameMatch(itemsInPage[1], componentName, componentPath)
+      ).to.equal(true);
+      expect(
+        isNameMatch(itemsInPage[2], componentName, componentPath)
+      ).to.equal(true);
+      expect(
+        isNameMatch(itemsInPage[3], componentName, componentPath)
+      ).to.equal(true);
+      expect(
+        isNameMatch(itemsInPage[4], componentName, componentPath)
+      ).to.equal(true);
+      expect(
+        isNameMatch(itemsInPage[5], componentName, componentPath)
+      ).to.equal(true);
+      expect(
+        isNameMatch(itemsInPage[6], componentName, componentPath)
+      ).to.equal(true);
+      expect(
+        isNameMatch(itemsInPage[7], componentName, componentPath)
+      ).to.equal(true);
+      expect(
+        isNameMatch(itemsInPage[8], componentName, componentPath)
+      ).to.equal(true);
+      expect(
+        isNameMatch(itemsInPage[9], componentName, componentPath)
+      ).to.equal(true);
+      expect(
+        isNameMatch(itemsInPage[10], componentName, componentPath)
+      ).to.equal(true);
     });
 
     it('should return false if file type is not in LWC or Aura or file name and component name do not match', () => {
       const lwcComponentPath = path.join(lwcPath.fsPath, lwcComponent);
       const auraComponentPath = path.join(auraPath.fsPath, auraComponent);
       expect(isNameMatch('hero.jpg', 'hero', lwcComponentPath)).to.equal(false);
-      expect(isNameMatch('hero1.css', 'hero', lwcComponentPath)).to.equal(false);
-      expect(isNameMatch('page.jpg', 'page', auraComponentPath)).to.equal(false);
-      expect(isNameMatch('page1.css', 'hero', auraComponentPath)).to.equal(false);
-      expect(isNameMatch('pageEvt.js', 'page', auraComponentPath)).to.equal(false);
+      expect(isNameMatch('hero1.css', 'hero', lwcComponentPath)).to.equal(
+        false
+      );
+      expect(isNameMatch('page.jpg', 'page', auraComponentPath)).to.equal(
+        false
+      );
+      expect(isNameMatch('page1.css', 'hero', auraComponentPath)).to.equal(
+        false
+      );
+      expect(isNameMatch('pageEvt.js', 'page', auraComponentPath)).to.equal(
+        false
+      );
     });
   });
 

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgPicker/orgList.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgPicker/orgList.test.ts
@@ -365,13 +365,12 @@ describe('orgList Tests', () => {
       it('should return Continue and call sfdx:force:auth:accessToken command if SFDX: Authorize an Org using Session ID', async () => {
         orgListStub.returns(orgsList);
         quickPickStub.returns(
-          '$(plus) ' +
-            nls.localize('force_auth_access_token_authorize_org_text')
+          '$(plus) ' + nls.localize('org_login_access_token_text')
         );
         const response = await orgList.setDefaultOrg();
         expect(response.type).to.equal('CONTINUE');
         expect(
-          executeCommandStub.calledWith('sfdx.force.auth.accessToken')
+          executeCommandStub.calledWith('sfdx.org.login.access.token')
         ).to.equal(true);
       });
 


### PR DESCRIPTION
### What does this PR do?
- Transitions "SFDX: Authorize an Org using Session ID" & "SFDX: Generate Manifest File" & "SFDX: Rename Component" commands to SF

### What issues does this PR fix or reference?
@W-14720800@
