### PR TITLE
Sonal/extversioninfo

### DIFF
--- a/docs/_articles/en/index.md
+++ b/docs/_articles/en/index.md
@@ -10,11 +10,11 @@ The Salesforce Extension pack includes tools for developing on the Salesforce pl
 
 ### Salesforce Extensions for Desktop
 
-Want to develop locally? Already using VS Code? Install Salesforce Extensions and Salesforce CLI to develop quickly and more productively on Salesforce platform. See [installation instructions](https://developer.salesforce.com/tools/vscode/en/vscode-desktop/install).
+Want to develop locally? Already using VS Code? Install Salesforce Extensions and Salesforce CLI to develop quickly and more productively on Salesforce platform. See [installation instructions](https://developer.salesforce.com/tools/vscode/en/vscode-desktop/install). The minimum Visual Studio Code version required for the Salesforce Extension Pack is 1.82.
 
 <span>Download using the links below, or read the [installation instructions](./en/getting-started/install).<span><br/><a class="slds-button slds-button_neutral landing__header-cta slds-m-vertical--x-large" href="https://code.visualstudio.com">Download Visual Studio Code</a><a class="slds-button slds-button_brand landing__header-cta slds-m-vertical--x-large" href="https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode">Install the Salesforce Extensions</a>
 
-**Note**: The minimum Visual Studio Code version required to run Salesforce Extension Pack version 59.15.0 and later is 1.82. 
+**Note**: We recommend that you use Salesforce Extension Pack version 59.15.0 or earlier if you aren't able to update your version of VS Code. Note that we aren't able to support fixes for versions of the Salesforce Extension Pack earlier than 59.15.0. 
 
 ### Code Builder
 

--- a/docs/_articles/en/index.md
+++ b/docs/_articles/en/index.md
@@ -14,6 +14,8 @@ Want to develop locally? Already using VS Code? Install Salesforce Extensions an
 
 <span>Download using the links below, or read the [installation instructions](./en/getting-started/install).<span><br/><a class="slds-button slds-button_neutral landing__header-cta slds-m-vertical--x-large" href="https://code.visualstudio.com">Download Visual Studio Code</a><a class="slds-button slds-button_brand landing__header-cta slds-m-vertical--x-large" href="https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode">Install the Salesforce Extensions</a>
 
+**Note**: The minimum Visual Studio Code version required to run Salesforce Extension Pack version 59.15.0 and later is 1.82. 
+
 ### Code Builder
 
 Code Builder is a browser-based version of the desktop experience, with everything installed and pre-configured for you. It's provides all the goodness of the desktop experience, but provides you the flexibility to work anywhere, from any computer. See [Code Builder Overview](https://developer.salesforce.com/tools/vscode/en/codebuilder/about) for more information.

--- a/docs/_articles/en/index.md
+++ b/docs/_articles/en/index.md
@@ -14,7 +14,7 @@ Want to develop locally? Already using VS Code? Install Salesforce Extensions an
 
 <span>Download using the links below, or read the [installation instructions](./en/getting-started/install).<span><br/><a class="slds-button slds-button_neutral landing__header-cta slds-m-vertical--x-large" href="https://code.visualstudio.com">Download Visual Studio Code</a><a class="slds-button slds-button_brand landing__header-cta slds-m-vertical--x-large" href="https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode">Install the Salesforce Extensions</a>
 
-**Note**: We recommend that you use Salesforce Extension Pack version 59.15.0 or earlier if you aren't able to update your version of VS Code. Note that we aren't able to support fixes for versions of the Salesforce Extension Pack earlier than 59.15.0. 
+**Note**: We recommend that you use Salesforce Extension Pack versions earlier than 59.15.0 if you aren't able to update your version of VS Code. Note that we aren't able to support fixes for these earlier versions. 
 
 ### Code Builder
 

--- a/docs/_articles/en/vscode-desktop/install.md
+++ b/docs/_articles/en/vscode-desktop/install.md
@@ -13,7 +13,8 @@ Install Visual Studio Code on any computer running macOS, Windows, or Linux. VS 
 
 To install Visual Studio Code visit <https://code.visualstudio.com> and click the big green **Download** button. After the download finishes, open the installer and follow the steps to complete the installation. The minimum Visual Studio Code version required for the Salesforce Extension Pack is 1.82.
 
-**Note**: We recommend that you use Salesforce Extension Pack version 59.15.0 or earlier if you aren't able to update your version of VS Code. Note that we aren't able to support fixes for versions of the Salesforce Extension Pack earlier than 59.15.0. 
+
+**Note**: We recommend that you use Salesforce Extension Pack versions earlier than 59.15.0 if you aren't able to update your version of VS Code. Note that we aren't able to support fixes for these earlier versions.
 
 ## Salesforce Extension Pack
 

--- a/docs/_articles/en/vscode-desktop/install.md
+++ b/docs/_articles/en/vscode-desktop/install.md
@@ -11,9 +11,9 @@ Before you get started, install the required software on your computer.
 
 Install Visual Studio Code on any computer running macOS, Windows, or Linux. VS Code’s [system requirements](https://code.visualstudio.com/docs/supporting/requirements) are fairly small, so it should run well on most computers.
 
-To install Visual Studio Code visit <https://code.visualstudio.com> and click the big green **Download** button. After the download finishes, open the installer and follow the steps to complete the installation.
+To install Visual Studio Code visit <https://code.visualstudio.com> and click the big green **Download** button. After the download finishes, open the installer and follow the steps to complete the installation. The minimum Visual Studio Code version required for the Salesforce Extension Pack is 1.82.
 
-Note: The minimum Visual Studio Code version required to run Salesforce Extension Pack version 59.15.0 and later is 1.82.
+**Note**: We recommend that you use Salesforce Extension Pack version 59.15.0 or earlier if you aren't able to update your version of VS Code. Note that we aren't able to support fixes for versions of the Salesforce Extension Pack earlier than 59.15.0. 
 
 ## Salesforce Extension Pack
 

--- a/docs/_articles/en/vscode-desktop/install.md
+++ b/docs/_articles/en/vscode-desktop/install.md
@@ -13,6 +13,8 @@ Install Visual Studio Code on any computer running macOS, Windows, or Linux. VS 
 
 To install Visual Studio Code visit <https://code.visualstudio.com> and click the big green **Download** button. After the download finishes, open the installer and follow the steps to complete the installation.
 
+Note: The minimum Visual Studio Code version required to run Salesforce Extension Pack version 59.15.0 and later is 1.82.
+
 ## Salesforce Extension Pack
 
 Want to develop locally? Already using VS Code? Install Salesforce Extensions and Salesforce CLI to develop quickly and more productively on Salesforce platform.


### PR DESCRIPTION
Update our Salesforce Extensions doc as well as the Marketplace doc to reflect minimum supported VSCode version

### What does this PR do?

### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @W-15007187@

### Functionality Before
No minimum version information for VS Code

### Functionality After
Added minimum version information for VS Code

