### PR TITLE
chore: add extension pack telemetry

### DIFF
--- a/packages/salesforcedx-vscode-core/src/constants.ts
+++ b/packages/salesforcedx-vscode-core/src/constants.ts
@@ -22,6 +22,9 @@ export const TELEMETRY_GLOBAL_VALUE = 'sfdxTelemetryMessage';
 export const TELEMETRY_OPT_OUT_LINK =
   'https://developer.salesforce.com/tools/vscode/en/faq/telemetry';
 export const TELEMETRY_METADATA_COUNT = 'metadataCount';
+export const BASE_EXTENSION = 'salesforce.salesforcedx-vscode';
+export const EXPANDED_EXTENSION = 'salesforce.salesforcedx-vscode-expanded';
+export const EXT_PACK_STATUS = 'extensionPackStatus';
 
 export const CONFIG_SET_EXECUTOR = 'config_set_org_text';
 export const CONFIG_SET_NAME = 'config_set_title';

--- a/packages/salesforcedx-vscode-core/test/jest/index.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/index.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { TelemetryService } from '@salesforce/salesforcedx-utils-vscode';
+import * as vscode from 'vscode';
+import { reportExtensionPackStatus } from '../../src';
+
+describe('reportExtensionPackStatus', () => {
+  const fakeExtension = {
+    extensionUri: { url: 'fake' }
+  };
+  let telemetrySpy: jest.SpyInstance;
+  const extensionsSpy = jest.fn();
+
+  beforeEach(() => {
+    vscode.extensions.getExtension = extensionsSpy;
+  });
+
+  it('reports NONE if neither base nor expanded packs are installed', () => {
+    extensionsSpy.mockReturnValue(undefined);
+    telemetrySpy = jest.spyOn(TelemetryService.prototype, 'sendEventData');
+
+    reportExtensionPackStatus();
+
+    expect(telemetrySpy).toHaveBeenCalledTimes(1);
+    expect(telemetrySpy).toHaveBeenCalledWith('extensionPackStatus', {extpack: 'NONE'});
+  });
+
+  it('reports BASE if only the base pack is installed', () => {
+    extensionsSpy.mockReturnValueOnce(fakeExtension);
+    extensionsSpy.mockReturnValueOnce(undefined);
+    telemetrySpy = jest.spyOn(TelemetryService.prototype, 'sendEventData');
+
+    reportExtensionPackStatus();
+
+    expect(telemetrySpy).toHaveBeenCalledTimes(1);
+    expect(telemetrySpy).toHaveBeenCalledWith('extensionPackStatus', {extpack: 'BASE'});
+  });
+
+  it('reports EXPANDED if only the expanded pack is installed', () => {
+    extensionsSpy.mockReturnValueOnce(undefined);
+    extensionsSpy.mockReturnValueOnce(fakeExtension);
+    telemetrySpy = jest.spyOn(TelemetryService.prototype, 'sendEventData');
+
+    reportExtensionPackStatus();
+
+    expect(telemetrySpy).toHaveBeenCalledTimes(1);
+    expect(telemetrySpy).toHaveBeenCalledWith('extensionPackStatus', {extpack: 'EXPANDED'});
+  });
+
+  it('reports BOTH if both the base and expanded packs are installed', () => {
+    extensionsSpy.mockReturnValue(fakeExtension);
+    telemetrySpy = jest.spyOn(TelemetryService.prototype, 'sendEventData');
+
+    reportExtensionPackStatus();
+
+    expect(telemetrySpy).toHaveBeenCalledTimes(1);
+    expect(telemetrySpy).toHaveBeenCalledWith('extensionPackStatus', {extpack: 'BOTH'});
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Report if either, both, or neither of the base and expanded packs are installed on launch of the core extension.

### What issues does this PR fix or reference?
@W-14926576@

### Functionality Before
We were not tracking extension pack telemetry.

### Functionality After
We send a telemetry event to record the pack telemetry.
