### PR TITLE
fix: update "sfdx" examples in docs to their "sf" equivalents

### DIFF
--- a/docs/_articles/en/apex/interactive-debugger.md
+++ b/docs/_articles/en/apex/interactive-debugger.md
@@ -39,7 +39,7 @@ Note: You can use the default license provided to License Management orgs only w
    1. Click **Add Assignments**.
    1. Select the users to whom you want to assign the permission set, and then click **Assign**.
    1. Click **Done**.
-1. **Optional**: In VS Code, run **SFDX: Pull Source from Default Scratch Org**. Then, add your new permission set to your source control repository. If you have a copy of the permission set in your Salesforce DX project, you can assign permissions to scratch org users by running `sfdx force:user:permset:assign -n Your_Perm_Set_Name`.
+1. **Optional**: In VS Code, run **SFDX: Pull Source from Default Scratch Org**. Then, add your new permission set to your source control repository. If you have a copy of the permission set in your Salesforce DX project, you can assign permissions to scratch org users by running `sf org assign permset --name Your_Perm_Set_Name`.
 1. In VS Code, create a launch configuration for Apex Debugger.
    1. To open the Debug view, in the VS Code Activity Bar, click the bug icon (hover text: Debug).
    1. To create a `launch.json` file, click the gear icon (hover text: Configure or Fix launch.json) and then select **Apex Debugger**. (If you’ve already created this file, clicking the gear icon opens the file.)

--- a/docs/_articles/en/deploy-changes/metadata-operations.md
+++ b/docs/_articles/en/deploy-changes/metadata-operations.md
@@ -23,7 +23,7 @@ You can retrieve source for a manifest, source files, directories, or folders:
   - With a source file open in the editor, right-click in the editing pane and select **SFDX: Retrieve This Source from Org**.
   - With a source file open in the editor, open the Command Palette and run **SFDX: Retrieve This Source from Org**.
 
-When you select an item to retrieve source, only the existing nested items in the directory structure are retrieved. For example, if you retrieve source for the `classes` folder, the Apex classes that **currently exist in that directory** are retrieved. The command doesn’t retrieve all the Apex classes in the org; it updates only the classes that exist in the folder. To retrieve a new Apex class, add that class (or all Apex classes) to a `package.xml` file and retrieve the source using the manifest file. You could also use a terminal to run `sfdx force:source:retrieve --metadata ApexClass:YourApexClass`.
+When you select an item to retrieve source, only the existing nested items in the directory structure are retrieved. For example, if you retrieve source for the `classes` folder, the Apex classes that **currently exist in that directory** are retrieved. The command doesn’t retrieve all the Apex classes in the org; it updates only the classes that exist in the folder. To retrieve a new Apex class, add that class (or all Apex classes) to a `package.xml` file and retrieve the source using the manifest file. You could also use a terminal to run `sf project retrieve start --metadata ApexClass:YourApexClass`.
 
 You can also use [Org Browser](./en/user-guide/development-models/#create-project-and-use-org-browser) to retrieve source.
 

--- a/docs/_articles/en/localdev/set-up-lwc-local-dev.md
+++ b/docs/_articles/en/localdev/set-up-lwc-local-dev.md
@@ -10,9 +10,9 @@ To set up LWC Local Development, install the server, enable and authorize a Dev 
 Run this command from a command-line interface.
 
 ```
-sfdx plugins:install @salesforce/lwc-dev-server
+sf plugins install @salesforce/lwc-dev-server
 ```
 
-> **Troubleshooting Tip:** Due to a known issue, it's likely you'll see several errors when you install the plug-in. Run `sfdx plugins --core` to see if the plug-in is installed. If yes, try to start the Local Development server. If successful, you're good to proceed.
+> **Troubleshooting Tip:** Due to a known issue, it's likely you'll see several errors when you install the plug-in. Run `sf plugins --core` to see if the plug-in is installed. If yes, try to start the Local Development server. If successful, you're good to proceed.
 
 After you select **SFDX: Preview Component Locally**, the Command Palette displays a list of preview options. You can choose to preview your component in the desktop browser or in a virtual mobile device (iOS or Android). Mobile previews require additional setup. See [Preview Lightning Web Components on Mobile](https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.mobile_extensions) in the _Lightning Web Components Dev Guide_.

--- a/docs/_articles/en/sf-dev-env/byotemplate.md
+++ b/docs/_articles/en/sf-dev-env/byotemplate.md
@@ -12,23 +12,23 @@ Use custom templates to quickly add your own code template to source files when 
 This [git repo subdirectory](https://github.com/forcedotcom/salesforcedx-templates/tree/main/src/templates) contains a collection of official Salesforce templates for metadata components. Only updates made to the files listed in this directory show up in source files in VS Code. You can clone this subdirectory, or replicate it locally. You must keep the same folder structure. Just update relevant template files with your code, and remove the files that you don’t wish to override.
 
 ## Set Default Template Location
- You can store template files in a local directory, or in a GitHub project. Set ``customOrgMetadataTemplates`` to your custom template location:
-1. Run ``sfdx config:set customOrgMetadataTemplates=<GitHub repo or local template directory>`` command from the terminal inside VS Code. 
-2. Run ``sfdx config:list`` to confirm that the configuration setting is updated. 
+ You can store template files in a local directory, or in a GitHub project. Set the ``org-custom-metadata-templates`` configuration variable to your custom template location:
+1. Run ``sf config set org-custom-metadata-templates <GitHub repo or local template directory>`` command from the terminal inside VS Code. 
+2. Run ``sf config list`` to confirm that the configuration setting is updated. 
 
-**Note:** The `sfdx-config.json` config file in your `<project-folder>/.sfdx` folder is updated with a new entry in the format,`` "customOrgMetadataTemplates": "<GitHub repo or local template directory>"``.
+**Note:** The `sfdx-config.json` config file in your `<project-folder>/.sfdx` folder is updated with a new entry in the format `` "customOrgMetadataTemplates": "<GitHub repo or local template directory>"``.
 
- See [CLI Runtime Configuration Values](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_dev_cli_config_values.htm) for more information about configuration settings.
+ See [CLI Runtime Configuration Variables](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_dev_cli_config_values.htm) for more information about configuration settings.
 
 ## Set Template Location Examples
--  ``sfdx config:set customOrgMetadataTemplates=https://github.com/vscodeuser/salesforcedx-templates/tree/main/src/templates/ ``sets the ``customOrgMetadataTemplates`` configuration value to a directory on user ``vscodeuser``'s GitHub repo.
--   ``sfdx config:set customOrgMetadataTemplates=/Users/vscodeuser/CustomTemplateProject/MyCustomTemplates`` sets the ``customOrgMetadataTemplates`` configuration value to the ``MyCustomTemplates`` directory on a local machine.
+-  ``sf config set org-custom-metadata-templates https://github.com/vscodeuser/salesforcedx-templates/tree/main/src/templates/`` sets the ``org-custom-metadata-templates`` configuration variable to a directory on user ``vscodeuser``'s GitHub repo.
+-  ``sf config set org-custom-metadata-templates /Users/vscodeuser/CustomTemplateProject/MyCustomTemplates`` sets the ``org-custom-metadata-templates`` configuration variable to the ``MyCustomTemplates`` directory on a local machine.
 
 ## Use Custom Templates On GitHub
 1. Clone this [git repo subdirectory](https://github.com/forcedotcom/salesforcedx-templates/tree/main/src/templates).
 2. In your cloned repo, delete all folders except the folders that contains the templates you want to use. 
 3. Make updates to the custom templates in your repo.
-4. Check that ``customOrgMetadataTemplates`` points to this repo.
+4. Check that ``org-custom-metadata-templates`` points to this repo.
 
 ## Use Local Custom Templates
 The Salesforce Extensions require your templates to follow the exact folder structure and nomenclature as this repo. There’s no such restriction when you use the CLI to specify templates for metadata objects.
@@ -36,7 +36,7 @@ The Salesforce Extensions require your templates to follow the exact folder stru
 1. Create a folder in your VS Code project directory to hold your custom templates. Name the folder something intuitive, for example "MyCustomTemplates".
 2. Carefully check folder and file names in this [git repo](https://github.com/forcedotcom/salesforcedx-templates/tree/main/src/templates), and create sub-folders of the same names that contain the files you wish to customize. For example, create a sub-folder named ``lightningapp`` and add a file named ``DefaultLightningController.js`` to customize the default lightning controller JavaScript file, and a sub-folder named ``apexclass`` and add a file named ``DefaultApexClass.cls`` to add custom code to an Apex class. 
 3. Make updates to your custom template files.
-4. Check that ``customOrgMetadataTemplates`` points to your custom templates directory.
+4. Check that ``org-custom-metadata-templates `` points to your custom templates directory.
 
 ## Make an Update to a Remote Template in GitHub
 VS Code downloads the template files locally (`~/.sfdx/custom-templates` on macOS/Linux or `%USERPROFILE%\.sfdx\custom-templates` on Windows) the first time the template repository is accessed. To use updated templates, clear the local cached files to download the template files again.

--- a/docs/_articles/en/source-control/source-format.md
+++ b/docs/_articles/en/source-control/source-format.md
@@ -5,7 +5,7 @@ lang: en
 
 The commands that Salesforce Extensions for VS Code uses to push, pull, deploy, and retrieve your source assume that your files are in source format (rather than metadata format). Source format is optimized for working with version control systems. For details, see [Salesforce DX Project Structure and Source Format](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_source_file_format.htm) in the _Salesforce DX Developer Guide_.
 
-Because legacy tools such as Force.com IDE used the metadata format, you can’t directly open your such projects in VS Code. You must either convert your metadata to source format (using `sfdx force:mdapi:convert`) or create a new project and then retrieve the metadata from your org using the manifest (`package.xml` file) that you used in your previous IDE.
+Because legacy tools such as Force.com IDE used the metadata format, you can’t directly open your such projects in VS Code. You must either convert your metadata to source format (using `sf project convert mdapi`) or create a new project and then retrieve the metadata from your org using the manifest (`package.xml` file) that you used in your previous IDE.
 
 ## Convert Metadata to Source Format and Maintain Git History
 
@@ -41,11 +41,11 @@ Follow these steps to convert the project from metadata to source format, withou
 
 1. Create a temporary SFDX project outside of the Git repo. This temporary project has the structure and a configuration file as required by a Salesforce project.
 
-   `$ sf project:generate -n tempproj`
+   `$ sf project generate --name tempproj`
 
 1. Convert the project in metadata into a temporary project.
 
-   `$ sfdx force:mdapi:convert --rootdir ./project/metadata --outputdir ./tempproj`
+   `$ sf project convert mdapi --root-dir ./project/metadata --output-dir ./tempproj`
 
    Now you have two copies of the project, one in the original location and the other in the new directory `temproj`, where the project files after converting them to the source format are stored.
 
@@ -99,7 +99,7 @@ These commands set the rename detection limit and convert to source format in a 
 ```text
 `$ git config merge.renameLimit 999999`
 
-`$ sfdx force:mdapi:convert -r src -d src2`
+`$ sf project convert mdapi --root-dir src --output-dir src2`
 
 `$ rm -rf src`
 


### PR DESCRIPTION
### What does this PR do?

Updates all CLI (terminal) examples in the docs from "sfdx" to "sf".  I obviously left all VScode command pallet references as-is. 

### What issues does this PR fix or reference?
@W-15052113@