### PR TITLE
Cristi/push fix

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/cli/parsers/projectDeployStartResultParser.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/parsers/projectDeployStartResultParser.ts
@@ -53,7 +53,9 @@ export class ProjectDeployStartResultParser {
         message: this.response.message ?? 'Push failed. ',
         name: this.response.name ?? 'DeployFailed',
         status: this.response.status,
-        files: this.response.data ?? this.response.result.files
+        files: (this.response.data ?? this.response.result.files).filter(
+          (file: { state: string }) => file.state === 'Failed'
+        )
       } as ProjectDeployStartErrorResponse;
     }
   }

--- a/packages/salesforcedx-utils-vscode/src/cli/parsers/projectRetrieveStartResultParser.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/parsers/projectRetrieveStartResultParser.ts
@@ -53,7 +53,9 @@ export class ProjectRetrieveStartResultParser {
         message: this.response.message ?? 'Pull failed. ',
         name: this.response.name ?? 'RetrieveFailed',
         status: this.response.status,
-        files: this.response.data ?? this.response.result.files
+        files: (this.response.data ?? this.response.result.files).filter(
+          (file: { state: string }) => file.state === 'Failed'
+        )
       } as ProjectRetrieveStartErrorResponse;
     }
   }

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/projectDeployStartResultParser.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/projectDeployStartResultParser.test.ts
@@ -85,7 +85,7 @@ describe('Correctly output deploy results', () => {
         { key: 'type', label: nls.localize('table_header_type') },
         { key: 'filePath', label: nls.localize('table_header_project_path') }
       ],
-      nls.localize('table_title_deployed_source')
+      nls.localize('table_title_pushed_source')
     );
     expect(output).to.be.equal(`${successTable}\n`);
   });
@@ -105,7 +105,7 @@ describe('Correctly output deploy results', () => {
         { key: 'type', label: nls.localize('table_header_type') },
         { key: 'filePath', label: nls.localize('table_header_project_path') }
       ],
-      nls.localize('table_title_deployed_source')
+      nls.localize('table_title_pushed_source')
     );
     const expectedOutput = `${successTable}\n${nls.localize(
       'table_no_results_found'


### PR DESCRIPTION
### What does this PR do?
- Fixes error when trying to generate the output table from all the files involved in a push and some of the files didn't have errors. Now the files considered for the output table are only those that failed

### Functionality Before
- no error messages shown upon errors

### Functionality After
- Correct displaying of error messages

[skip-validate-pr]