### PR TITLE
chore: fix incorrectly wired checkbox in BaseSuiteE2E.yml

### DIFF
--- a/.github/workflows/baseSuiteE2E.yml
+++ b/.github/workflows/baseSuiteE2E.yml
@@ -136,7 +136,7 @@ jobs:
       os: ${{ inputs.os || '["ubuntu-latest"]' }}
 
   lwcLSP:
-    if: ${{ inputs.templates || github.event_name == 'workflow_run' }}
+    if: ${{ inputs.lwcLsp || github.event_name == 'workflow_run' }}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:


### PR DESCRIPTION
In the Base E2E Test Suite, wire the LWC LSP checkbox correctly to the LWC LSP E2E test instead of to Templates.

[skip-validate-pr]