### PR TITLE
fix: bump apex lsp to include command rename

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/index.ts
@@ -136,11 +136,11 @@ const registerCommands = (): vscode.Disposable => {
     apexDebugMethodRunCodeActionDelegate
   );
   const anonApexRunDelegateCmd = vscode.commands.registerCommand(
-    'sfdx.force.anon.apex.run.delegate',
+    'sfdx.anon.apex.run.delegate',
     anonApexExecute
   );
   const anonApexDebugDelegateCmd = vscode.commands.registerCommand(
-    'sfdx.force.anon.apex.debug.delegate',
+    'sfdx.anon.apex.debug.delegate',
     anonApexDebug
   );
   const apexLogGetCmd = vscode.commands.registerCommand(


### PR DESCRIPTION
@W-15122337@ #5467 

Updates apex lsp to account for anon apex command rename in extensions
