### PR TITLE
chore: fix base e2e workflow to successfully get vsixes when triggered with workflow run

### DIFF
--- a/.github/workflows/baseSuiteE2E.yml
+++ b/.github/workflows/baseSuiteE2E.yml
@@ -121,7 +121,7 @@ jobs:
       automationBranch: ${{ inputs.automationBranch || github.event_name == 'workflow_run' }}
       testToRun: 'anInitialSuite.e2e.ts'
       vscodeVersion: ${{ inputs.vscodeVersion || '1.82.3' }}
-      runId: ${{ inputs.runId }}
+      runId: ${{ inputs.runId || github.event.workflow_run.id  }}
       os: ${{ inputs.os || '["ubuntu-latest"]' }}
 
   authentication:
@@ -132,7 +132,7 @@ jobs:
       automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'authentication.e2e.ts'
       vscodeVersion: ${{ inputs.vscodeVersion || '1.82.3' }}
-      runId: ${{ inputs.runId }}
+      runId: ${{ inputs.runId || github.event.workflow_run.id  }}
       os: ${{ inputs.os || '["ubuntu-latest"]' }}
 
   lwcLSP:
@@ -143,7 +143,7 @@ jobs:
       automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'lwcLsp.e2e.ts'
       vscodeVersion: ${{ inputs.vscodeVersion || '1.82.3' }}
-      runId: ${{ inputs.runId }}
+      runId: ${{ inputs.runId || github.event.workflow_run.id  }}
       os: ${{ inputs.os || '["ubuntu-latest"]' }}
 
   deployAndRetrieve:
@@ -154,7 +154,7 @@ jobs:
       automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'deployAndRetrieve.e2e.ts'
       vscodeVersion: ${{ inputs.vscodeVersion || '1.82.3' }}
-      runId: ${{ inputs.runId }}
+      runId: ${{ inputs.runId || github.event.workflow_run.id  }}
       os: ${{ inputs.os || '["ubuntu-latest"]' }}
 
   apexLSP:
@@ -165,7 +165,7 @@ jobs:
       automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'apexLsp.e2e.ts'
       vscodeVersion: ${{ inputs.vscodeVersion || '1.82.3' }}
-      runId: ${{ inputs.runId }}
+      runId: ${{ inputs.runId || github.event.workflow_run.id  }}
       os: ${{ inputs.os || '["ubuntu-latest"]' }}
 
   runApexTests:
@@ -176,7 +176,7 @@ jobs:
       automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'runApexTests.e2e.ts'
       vscodeVersion: ${{ inputs.vscodeVersion || '1.82.3' }}
-      runId: ${{ inputs.runId }}
+      runId: ${{ inputs.runId || github.event.workflow_run.id  }}
       os: ${{ inputs.os || '["ubuntu-latest"]' }}
 
   slack_success_notification:
@@ -188,7 +188,7 @@ jobs:
         lwcLSP,
         deployAndRetrieve,
         apexLSP,
-        runApexTests,
+        runApexTests
       ]
     uses: ./.github/workflows/slackNotification.yml
     secrets: inherit
@@ -210,7 +210,7 @@ jobs:
         lwcLSP,
         deployAndRetrieve,
         apexLSP,
-        runApexTests,
+        runApexTests
       ]
     uses: ./.github/workflows/slackNotification.yml
     secrets: inherit
@@ -232,7 +232,7 @@ jobs:
         lwcLSP,
         deployAndRetrieve,
         apexLSP,
-        runApexTests,
+        runApexTests
       ]
     uses: ./.github/workflows/slackNotification.yml
     secrets: inherit


### PR DESCRIPTION
### What does this PR do?
- fixes base e2e workflow to successfully get vsixes with run id when triggered with workflow run

### Functionality Before
- run id was only passed when workflow was manually started and received input for run id

### Functionality After
- run id is passed by user input or by workflow run

[skip-validate-pr]