### PR TITLE
chore: fix automation branch input for AnInitialSuite in Base E2E Suite

### DIFF
--- a/.github/workflows/baseSuiteE2E.yml
+++ b/.github/workflows/baseSuiteE2E.yml
@@ -118,7 +118,7 @@ jobs:
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:
-      automationBranch: ${{ inputs.automationBranch || github.event_name == 'workflow_run' }}
+      automationBranch: ${{ inputs.automationBranch }}
       testToRun: 'anInitialSuite.e2e.ts'
       vscodeVersion: ${{ inputs.vscodeVersion || '1.82.3' }}
       runId: ${{ inputs.runId || github.event.workflow_run.id  }}


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Fixes an issue where AnInitialSuite cannot be cloned in the Base E2E Suite because of an incorrect input of automationBranch

[skip-validate-pr]
