### PR TITLE
docs: sync ja docs with latest en versions

### DIFF
--- a/docs/_articles/ja/codebuilder/about.md
+++ b/docs/_articles/ja/codebuilder/about.md
@@ -5,24 +5,17 @@ lang: en
 
 ## Overview
 
-Salesforce Code Builder is a web-based integrated development environment that has all the power and flexibility of Visual Studio Code, Salesforce Extensions for VS Code, and Salesforce CLI in your web browser. Code Builder provides a modern developer experience for all developers, regardless of expertise level. Code Builder makes it easy for admins and developers alike to work in the cloud without having to worry about downloading software, setup or your machine specs.
+Salesforce Code Builder is a web-based integrated development environment that has all the power and flexibility of Visual Studio Code, Salesforce Extensions for VS Code, and Salesforce CLI in your web browser. Code Builder provides a modern developer experience for all developers, regardless of expertise level. Code Builder makes it easy for admins and developers alike to work in the cloud without having to worry about downloading software, setup or your machine specs. With Code Builder, you can work from anywhere. Bookmark your development environment to return to it, or access the link from a different machine. Unlike a desktop IDE, Code Builder saves your work for you without you explicitly having to do so.
 
-Code Builder is development environment that can be spun up in seconds, and is custom to your Salesforce org and your specified project. Through Code Builder, access your favorite Salesforce languages and frameworks, such as Apex, SOQL, Visualforce, Aura, and Lightning Web Components. Access rich developer tools such as debuggers for Apex, Linting and so on.
+Code Builder is development environment that can be spun up quickly, and is custom to your Salesforce org and your specified project. Through Code Builder, access your favorite Salesforce languages and frameworks, such as Apex, SOQL, Visualforce, Aura, and Lightning Web Components. Access rich developer tools such as debuggers for Apex, linting, and so on.
 You can install Code Builder as a managed package in any supported Salesforce org edition.
 
 ![Code Builder Welcome Page](./images/codebuilder_welcome.png)
 
-> **_NOTE:_** This feature is a Beta Service. Customer may opt to try such Beta Service in its sole discretion. Any use of the Beta Service is subject to the applicable Beta Services Terms provided at [Agreements and Terms](https://www.salesforce.com/company/legal/agreements/).
-
-### Important Considerations for Code Builder Beta
-
-- We've capped usage for beta at 20 hours for a maximum of 30 days.
-- We highly recommend that you save your work and close the browser tab that is running Code Builder to stop the usage clock when you aren’t using Code Builder.
-- Code Builder is in open beta and is available to try on a first-come, first-served basis. Once you join beta, you might be added to a waitlist, and will receive an email when a spot opens up for you.
-
 ## Additional Resources
 
 - Trailhead: [Code Builder Quick Look](https://trailhead.salesforce.com/content/learn/modules/code-builder-quick-look)
+- Trailblazer Community: [Code Builder Community Group](https://trailhead.salesforce.com/trailblazer-community/groups/0F94S000000kJcFSAU?tab=discussion&sort=LAST_MODIFIED_DATE_DESC)
 
 ## Bugs and Feedback
 

--- a/docs/_articles/ja/codebuilder/cb-diffs.md
+++ b/docs/_articles/ja/codebuilder/cb-diffs.md
@@ -2,23 +2,19 @@
 title: What's Different
 lang: en
 ---
+
 ## What’s Different in Code Builder
 
 Code Builder unleashes the power of Salesforce Extensions for VS Code and offers the same rich features as the desktop version. No matter whether you're using VS Code on your desktop or Code Builder from a browser, the Salesforce extensions you access are the same. While the extensions generally function the same way regardless of how they're accessed, there are some nuances to be aware of:
 
-* Code Builder is installed as a managed package, and it comes with everything you need: VS Code, Salesforce extensions, and Salesforce CLI. No installation required. 
-* Unlike VS Code for the desktop, you can't add any new extensions to your Code Builder development environment.
-* Because Code Builder is inherently lightweight and optimized to run in the cloud, access to certain functionalities is limited:    
-    * Functions development is available only for Javascript and Typescript functions.
-    * LWC Local Development (beta) is not available in Code Builder. You can't preview LWC components locally, but deploy them to your org to view them.
-* With Code Builder, you can work from anywhere. Bookmark your development environment to return to it, or access the link from a different machine. 
-* Unlike a desktop IDE, Code Builder saves your work for you without you explicitly having to do so. However, your beta environment's usage is capped at 20 hours. Once the clock runs out, your data and metadata are deleted. Be sure to push your work to your source control system or deploy your changes to your org. 
-* Because your Code Builder instance runs in the cloud, authorizing an org from it follows a different (device) flow than the desktop IDE. See [Connect to Different Org](https://developer.salesforce.com/tools/vscode/en/codebuilder/cb-start/#connect-to-a-different-org) for steps.
+- Because your Code Builder instance runs in the cloud, authorizing an org from it follows a different (device) flow than the desktop version. See [Connect to Different Org](https://developer.salesforce.com/tools/vscode/en/codebuilder/cb-start/#connect-to-a-different-org) for steps.
+- Code Builder is installed as a managed package, and it comes with everything you need: VS Code, Salesforce extensions, and Salesforce CLI. No installation required on your local machine.
+- Unlike VS Code for desktop, you cannot access the Microsoft Marketplace from Code Builder. Instead, you can add extensions available in [Open VSX](https://open-vsx.org/) marketplace to your Code Builder environment. This means that you might see differences in the extensions that are available.
+- The third-party authorization sequence is different in Code Builder.
+- We keep the Salesforce extensions up to date for you in Code Builder. You don’t need to take any action.
 
 ## Known Gaps and Issues
-Code Builder is currently in beta, and we are actively collecting feedback from our customers as we continue to work on improving our project. See [Known Gaps and Issues](https://github.com/forcedotcom/try-code-builder-feedback/wiki/Known-Gaps-and-Issues) for a list of issues we are aware of. 
+
+See [Known Gaps and Issues](https://github.com/forcedotcom/try-code-builder-feedback/wiki/Known-Gaps-and-Issues) for a list of issues we're aware of.
 
 If you notice any issues that haven't made our list, or want to provide other types of feedback, such as initial impressions or feature requests, [file an issue](https://github.com/forcedotcom/try-code-builder-feedback/issues) in the GitHub repo. We want to understand what features and enhancements are important to you.
-
-## Important Considerations for Code Builder Beta
-We've capped usage for beta at 20 hours for a maximum of 30 days. We highly recommend that you save your work and close the browser tab to stop the usage clock when you aren’t using Code Builder.

--- a/docs/_articles/ja/codebuilder/cb-remove.md
+++ b/docs/_articles/ja/codebuilder/cb-remove.md
@@ -1,0 +1,45 @@
+---
+title: Remove Code Builder
+lang: en
+---
+
+## Uninstall Code Builder
+
+You can uninstall Code Builder, if necessary. If you plan to reinstall Code Builder, don't delete the Code Builder auth providers. However, if you deleted the auth providers, you can recreate them by re-enabling the Code Builder preference in Setup.
+
+**Important**: Uninstalling Code Builder also removes all associated data including, but not limited to, projects and activity history.
+
+### Remove Permission Set Assignments
+
+Before you uninstall the Code Builder package, remove permission set assignments, then delete Code Builder permissions sets.
+
+First, remove the Code Builder permission set group assignments from all Code Builder users.
+
+- CodeBuilderGroup
+
+Next, delete the Code Builder permission sets.
+
+From Setup, enter `Permission Sets` in the Quick Find box, then select **Permission Sets**.
+Delete the `Code Builder Package` permission set.
+
+### Uninstall the Code Builder Package
+
+After you remove the permission set and permission set assignments, you can uninstall the Code Builder package, which removes the application and all its associated data and objects.
+
+Before you uninstall the package:
+
+- Remove Code Builder permission Set assignments.
+- Delete Code Builder permission sets.
+
+1. From Setup, enter `Installed Packages` in the Quick Find box, then select **Installed Packages**.
+2. Click **Uninstall**, then scroll to the bottom of the page to choose whether to save and export a copy of the package’s data.
+3. Select **Yes, I want to uninstall this package and permanently delete all associated components**.
+4. Click **Uninstall**.
+
+### Disable Code Builder Preference
+
+When Code Builder was installed, a Salesforce admin first enabled Code Builder. To ensure that Code Builder can’t be installed or used, you can disable the Code Builder preference.
+
+From Setup, enter `Code Builder` in the Quick Find box, then select **Code Builder**.
+Disable **Enable Code Builder**.
+You no longer can install or upgrade the Code Builder app and users see Code Builder has not been enabled for your org when they try to use it.

--- a/docs/_articles/ja/codebuilder/cb-setup.md
+++ b/docs/_articles/ja/codebuilder/cb-setup.md
@@ -3,37 +3,93 @@ title: Set Up Code Builder
 lang: en
 ---
 
-## Install the Code Builder Managed Package
+Enable Code Builder to provide the permissions needed to install the Code Builder managed package in a supported Salesforce edition.
 
-Salesforce Code Builder is a second-generation (2GP) managed package that you can install in any supported Salesforce org edition.
+### Required Editions
 
-1. Go to App Exchange and search for the Code builder managed package.
-2. Click **Get It Now**.
-3. Select the org in which you want to install Code Builder.
-4. Check terms and conditions and click **Confirm and Install**.
+**Available in**: Lightning Experience in Enterprise, Performance, Professional, and Unlimited Editions.
 
-![Install Button](./images/install_button.png)
+**Not Available in**: EU Operating Zone. EU Operating zone is a special paid offering that provides an enhanced level of data residency commitment. Code Builder is supported in orgs in the EU that aren’t part of EU OZ, per standard product terms and conditions.
 
-Grant access and click **Continue**.
+## Enable and Install Code Builder
 
-![Grant Access](./images/grant_access.png)
+To install Code Builder in a Professional Edition org, the org must have API access. If you attempt to install Code Builder in a Professional Edition org without API access, an installation error occurs. To request the API add-on, contact your Account Executive.
 
-Click **Done**.
+**Note**: Turning on Code Builder in Government Cloud Plus organizations can send data outside the authorization boundary. Contact your Salesforce account executive for more details.
+
+1. From Setup, enter Code Builder in the Quick Find box, then select Code Builder.
+
+2. Enable Code Builder, and then review and accept the license agreement, which allows you to install the package.You can disable the preference at any time. If Code Builder is already installed, disabling the preference prevents access to the Code Builder application.
+
+3. Click **Install Package**.
+   After the installer launches, you’re guided through the installation process to install the latest version of the Code Builder managed package. You can come back to this Setup page to reinstall or upgrade the package.
+
+4. Select **Install for All Users**, and then click **Install**.
+
+5. Approve third-party access and click **Continue**.
+
+The code Builder Dashboard in now available in App Launcher. Be sure to assign the appropriate Code Builder permission sets to team members.
+
+## Confirm Code Builder Package Installation
+
+When installation is completed, you receive a confirmation email. You can confirm the installation on the Installed Packages Setup page.
+
+From Setup, enter `Installed Packages` in the Quick Find box, then select **Installed Packages**. You see an entry for Code Builder that looks something like this. If you get the message that the app is taking a long time to install, you get automatically redirected to this page after you click **Done**.
+
+![Installed Package](./images/installed_package.png)
+
+## Add Team Members as Users in the Code Builder Org
+
+Code Builder is accessed through a user-based license and works with the [Identity](https://help.salesforce.com/s/articleView?id=sf.users_license_types_available.htm&type=5) or the [Free Limited Access](https://help.salesforce.com/s/articleView?id=release-notes.rn_sfdx_dev_hub.htm&release=218&type=5) licenses.
+
+The number of Code Builder licenses available depends on the Salesforce edition:
+
+
+| Salesforce Edition      | Professional      |  Enterprise     |  Unlimited     |   Trial    |
+|  ---  |  ---  |  ---  |  ---  |  ---  |
+|     Code Builder Users  |  10     |  40     |  100     | If org edition includes Code Builder.|
+
+
+
+
+**Note**: Additional Code Builder user licenses are available as a part of a scratch org add-on purchase. Each scratch org add-on gives you one Code Builder user license. See [Salesforce Add-on Pricing](https://www.salesforce.com/content/dam/web/en_us/www/documents/pricing/all-add-ons.pdf) for more information.
+
+Add any team members who aren’t already users in the Code Builder org:
+
+1. Log in to the Code Builder org.
+2. From Setup, enter `Users` in the Quick Find box, then select **Users.**
+3. Click **New User** or **Add Multiple Users**.
+4. Select the appropriate license type and profile based on the user’s role.
+5. Select the **Generate passwords and notify user via email** checkbox.
+6. Click **Save**.
+
+**Note**: This procedure generates an email inviting the new users into the org. But until you’re finished setting up Code Builder, there’s not much for them to do in the org. We recommend that you let your team know that you’re setting up Code Builder and to wait until they hear from you before logging in.
 
 ## Assign Permissions
 
 As an admin, assign user permissions:
 
-1. From Setup, enter `Permission Sets` in the Quick Find box, then select **Permission Sets**.
-2. Click **CodeBuilder**.
+1. From Setup, enter `Permission Set Groups` in the Quick Find box, then select **Permission Set Groups**.
+2. Click **CodeBuilderGroup**.
 3. Click **Manage Assignments**
 4. Click **Add Assignments**.
-5. Select the checkboxes next to the names of the users you want assigned to the permission set, and click **Assign**.
+5. Select the checkboxes next to the names of the users to assign the permission set group, and click **Next**.
+6. Click **Assign**.
 
-Your users can now go to the App Launcher and launch **Code Builder(Beta)**.
+Your users can now go to the App Launcher and launch **Code Builder**.
+
+## Upgrade to the Latest Code Builder Version
+
+In most cases, you don’t have to do anything to upgrade to the latest version of the Code Builder. When we release a new package version, we update your org automatically.
+
+However, sometimes the push upgrade doesn’t work. If you don’t have the latest version, we recommend that you manually install the package through the Code Builder Setup page. If a newer version doesn’t exist, the package installer informs you that you already have the latest version.
 
 ## See Also
 
-[Install a Package](https://help.salesforce.com/s/articleView?id=sf.distribution_installing_packages.htm&type=5)
+[Installing Packages](https://developer.salesforce.com/docs/atlas.en-us.appExchangeInstallGuide.meta/appExchangeInstallGuide/appexchange_install_installation.htm)
 
 [Assign a Permission Set to Multiple Users](https://help.salesforce.com/s/articleView?id=sf.perm_sets_mass_assign.htm&type=5)
+
+[View and Manage Users](https://help.salesforce.com/s/articleView?id=sf.admin_users.htm&type=5)
+[Standard Profiles](https://help.salesforce.com/s/articleView?id=sf.standard_profiles.htm&type=5)
+[User Licenses](https://help.salesforce.com/s/articleView?id=sf.users_understanding_license_types.htm&type=5)

--- a/docs/_articles/ja/codebuilder/cb-start.md
+++ b/docs/_articles/ja/codebuilder/cb-start.md
@@ -1,56 +1,55 @@
 ---
-title: Code Builder Quick Start
+title: Get Started with Code Builder
 lang: en
 ---
 
 ## Overview
 
-Complete this Quick Start to become familiar with the Code Builder interface and perform some simple tasks in your Code Builder environment.
-
-## Important Considerations for Code Builder Beta
-
-We've capped usage for beta at 20 hours for a maximum of 30 days. We highly recommend that you save your work and close the browser tab that is running Code Builder to stop the usage clock when you aren’t using it.
+Complete this Quick Start to become familiar with the Code Builder interface and perform some simple tasks in your Code Builder environment. Before you start, see [Code Builder Overview](./en/codebuilder/about) for more information and important considerations.
 
 ### Don’t Forget to Save Your Work
 
-Working in the cloud has its advantages. However, unlike working on a desktop where you save your files to a local machine, you must either deploy your changes to your org, or commit them to source control to save your work. Save your work before you close the Code Builder tab on your browser so you don’t lose it.
+Working in the cloud has its advantages. However, unlike working on a desktop where you save your files to a local machine, you must either deploy your changes to your org or commit them to source control to save your work somewhere permanent. Work saved in your Code Builder environment will be there when you return, but Code Builder is not suited for permanent-long-term storage. We recommend saving your work before you close the Code Builder tab.
 
-**Note:** Throughout the beta, Code Builder environments could be deleted. All beta environments will be removed before GA.
+**Note**:  We may delete your Code Builder environment if its been inactive for longer than 60 days. 
 
-## Let’s Get Started
+## Create Your Code Builder Environment
 
-To get started you’ll do the following:
+1. From the App Launcher, find and open **Code Builder Dashboard**.
 
-1. Create a Code Builder environment.
-2. Create a Salesforce DX project.
-3. Connect to your org by logging in.
-   Now you’re ready to use Code Builder.
+**Note:** If you don't see Code Builder Dashboard as an option, contact your admin to make sure you have the correct license and permission set assigned to you.
 
-## Connect to Your Dev Environment
+2. Click **Launch** to launch your Code Builder environment. A new environment is created for you the first time to launch. We've also created an empty Salesforce DX project to help you get started. Note that it takes a few minutes for a new environment to be created and loaded. You know everything is ready when you see “Welcome to Salesforce Code Builder”.
 
-1. From the App Launcher, find and open **Code Builder**.
-
-**Note:** If you don't see Code Builder as an option, or you see an empty screen when you launch it, contact your admin to make sure you have the correct license and permission set assigned to you.
-
-2. Click **Get Started**.
-3. Click **New Project** to create a new Salesforce DX project.
-4. Give your project a name and choose **Standard** for project type.
-
-Next, connect an org to your Code Builder environment. You can choose to connect to a Salesforce org or a sandbox org.
-
-1. Log in to your development environment, click **Allow** to grant access, then click **Next**.
-2. Choose an alias (nickname) for your org. If you work on many orgs, make sure the nickname helps you identify the org quickly in the future.
-   Your new Code Builder environment is now available on your dashboard.
-3. Click **Launch** to launch Code Builder in a new tab.
-4. Now sit back and relax for a few minutes while Code Builder creates and configures your workspace. Code Builder might take a fews minutes to start up when it initially sets up.
+![Code Builder Dashboard](./images/cb_dashboard.png)
 
 **Tip**: Once you have created your Code Builder environment, launch it from the dashboard at any time, or bookmark it for fast access.
 
+**Note**: The `.bashrc`,`.profile` and `.bash_logout` files are overwritten every time you launch your Code Builder enviroment. We recommend that you do not edit these files because your changes will be lost. Create new `.bashrc.local`,`.profile.local` and `.bash_logout.local` files to store your Dotfile customizations.
+
+## Connect to a Salesforce Org
+
+Next, connect an org to your Code Builder environment. During the course of development, you'll use different types of orgs for different stages. For example, it's common to use a Developer sandbox or Developer Edition org during the development phase, and move to other sandbox types for integration, testing, and staging. Eventually, you'll deploy your changes to a production org. You can connect Code Builder to any of these orgs to deploy or retrieve metadata.
+
+To connect to an org the first time you launch Code Builder:
+
+1. In your Code Builder environment, click **Connect an Org** to connect to the Salesforce org you want to work in.
+2. Enter the login URL or select the org you want to log into.
+3. Enter an alias for the org, for example, dev_pro_sandbox or my_playground.
+4. A code is displayed in a text box. Click **Connect**.
+5. Log in with the relevant username and password. Click **Allow**.
+6. Click **Continue**. You’re now connected to an org, and its name is visible in the status bar at the bottom in the Code Builder tab.
+
+You can change the org you are connected to by clicking on the name of the current org to bring up the Command Palette and run **SFDX: Authorize an Org** again.
+
+**Note**: After you authorize an org, we take care of future authorizations so you don't have to continually log in. Just click the org’s name and then choose the org from the list.
+
 ## Let's Take A Quick Tour
 
-You’re now in your developer environment in Code Builder. Code Builder has VS Code’s rich IDE plus it gives you easy access to cool Salesforce development-specific tools through the Salesforce extension pack. Let’s take a quick tour and get to know the lay of the land. Your screen looks something like this:
+You’re now in your developer environment in Code Builder. Code Builder has a rich IDE and it gives you access to cool Salesforce-specific development tools through the expanded Salesforce Extension pack. Let’s take a quick tour and get to know the lay of the land. Your screen looks something like this:
 
-![code_builder_ui](./images/code_builder_ui.jpg)
+![code_builder_ui](./images/code_builder_ga_ui_dark.jpg)
+
 The Code Builder user interface is divided into five main areas.
 
 **Activity Bar**: Located on the left-hand side, it contains iconic buttons to switch between different views. In our example, the Explorer view is active.
@@ -65,7 +64,7 @@ The Code Builder user interface is divided into five main areas.
 
 ## Get To Know Your Org – Use the Org Browser
 
-Take a closer look at the activity bar and notice a cloud icon. This icon represents the Org Browser. It’s a part of the Salesforce Extension pack. It helps you browse and retrieve metadata from your org without having to use a manifest file. Use the Org Browser to retrieve metadata.
+Take a closer look at the activity bar and notice a cloud icon. This icon represents the Org Browser. It’s a part of the Salesforce Extension pack. It helps you browse and retrieve metadata from your org without having to use a manifest file. Use Org Browser to retrieve the metadata source into your local project.
 
 **More Information**: You can find more information about the [Org Browser](https://developer.salesforce.com/tools/vscode/en/user-guide/org-browser) in the Salesforce Extension Pack documentation.
 
@@ -91,26 +90,10 @@ Let’s build and run a simple SOQL query on the Account object:
 You’re prompted to save your changes if you close the untitled file.
 
 5. Save the changes to a file using a “.soql” extension.
-6. Let’s rerun the saved query – Right click the file and select **Open With…** then select SOQL Builder.
+6. Let’s rerun the saved query – Right-click the file and select **Open With…** then select SOQL Builder.
    The file opens in SOQL Builder and you can rerun or edit the query as you wish.
 
-**More Information**: For more information on building complex queries see the [SOQL Builder](https://developer.salesforce.com/tools/vscode/en/soql/soql-builder) in the Salesforce Extensions for Visual Studio Code documentation.
-
-## Connect to a Different Org
-
-During the course of development, you'll use different types of orgs for different stages. For example, it's common to use a Developer sandbox or Development Edition org during the development phase, and move to other sandbox types for integration, testing, and staging. Eventually, you'll deploy your changes to a production org. You can connect Code Builder to any of these orgs to deploy or retrieve metadata.
-
-To log into another org:
-
-1. Click the org picker(which show the alias for the current org) in the status bar, to bring up the Command Palette.
-2. From the Command Palette run **SFDX: Authorize an Org**.
-3. Enter the login URL or select the org you want to log into.
-4. Enter an alias for the org, for example, dev_pro_sandbox or my_playground.
-5. A code is displayed in a text box. click **Connect**.
-6. Log in with the relevant username and password. Click **Allow**.
-7. Click **Continue**. You’re now connected to a different org, and its name is visible in the status bar at the bottom.
-
-Once you authorize an org, we take care of future authorizations so you don't have to continually log in. Just click the org’s name and then choose the org from the list.
+For more information on building complex queries see the [SOQL Builder](https://developer.salesforce.com/tools/vscode/en/soql/soql-builder) in the Salesforce Extensions for Visual Studio Code documentation.
 
 ## Create, Retrieve, and Deploy a Custom Field
 
@@ -118,7 +101,7 @@ Let’s add a custom field to an object in our org and pull its metadata into ou
 
 First let’s add a custom field –
 
-1. From **Setup**, go to **Object Manager** | **Account**.
+1. From **Setup**, go to **Object Manager** and select **Account**.
 2. Click **Fields & Relationships**.
 3. Click **New**.
 4. For data type, select **Date**, then click **Next**.
@@ -133,8 +116,9 @@ Now let’s retrieve metadata for this new field –
 1. Return to Code Builder and open Org Browser.
 2. Scroll down to **Custom Objects** and navigate to **Account**.
 3. Click the retrieve icon next to the Account component to run **SFDX: Retrieve Source from Org**.
-4. From the Activity Bar, click the Explorer and navigate to `force-app/main/default/object/Account`
-   Lo and behold, in the `fields` folder, a file named `createdon_c.field-meta.xml` contains metadata for your new custom field!
+4. From the Activity Bar, click the Explorer and navigate to `force-app/main/default/object/Account`.
+
+Lo and behold, in the `fields` folder, a file named `createdon_c.field-meta.xml` contains metadata for your new custom field!
 
 The metadata is here for your reference:
 
@@ -154,8 +138,8 @@ The metadata is here for your reference:
 We’ll now make a simple edit to this field and deploy our changes back to our org with a single click.
 
 1. Edit `createdon_c.field-meta.xml` and change the `<required>` tag value to `true` to indicate that this custom field is required.
-2. Right click the `objects/Account` folder and click **SFDX: Deploy Source to Org**.
-3. After the command has successfully run, go back to your org and check details of the **Created On** custom field and confirm that it’s now a required field.
+2. Right-click the `objects/Account` folder and click **SFDX: Deploy Source to Org**.
+3. After the command has successfully run, go back to your org and check the details of the **Created On** custom field and confirm that it’s now a required field.
 
 ## Create and Deploy a New Lightning Web Component
 
@@ -172,7 +156,7 @@ Three new files are created in the `force-app/main/default/lwc/newCBComponent` f
 
 Update the files –
 
-1. In the HTML file, `newCBComponent.html`, copy and paste the following code:
+In `newCBComponent.html`, copy and paste the following code:
 
 ```
 <template>
@@ -181,7 +165,7 @@ Update the files –
 </template>
 ```
 
-2. In the HTML file, `newCBComponent.js`, copy, and paste the following code:
+In `newCBComponent.js`, copy, and paste the following code:
 
 ```
 import { LightningElement } from 'lwc';
@@ -192,11 +176,14 @@ export default class NewCBComponent extends LightningElement {
        this.greeting = event.target.value;
    }
 }
-```
-
-3. In the HTML file, `newCBComponent.js-meta.xml`, copy and paste the following code:
 
 ```
+
+In `newCBComponent.js-meta.xml`, copy and paste the following code:
+
+<!-- prettier-ignore -->
+```html
+
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
    <apiVersion>54.0</apiVersion>
@@ -207,13 +194,14 @@ export default class NewCBComponent extends LightningElement {
    <target>lightning__HomePage</target>
  </targets>
 </LightningComponentBundle>
+
 ```
 
-4. Save all the files.
+Save all the files.
 
 Let’s deploy this new component to our org –
 
-1. Right-click the `force-app/main/default/lwc/newCBComponent` folder and click **SFDX: Deploy Source to Org**
+Right-click the `force-app/main/default/lwc/newCBComponent` folder and click **SFDX: Deploy Source to Org**.
 
 Your output window shows this message:
 
@@ -239,5 +227,5 @@ Congratulations on successfully creating and deploying a new Lightning Web Compo
 
 You can take your time and use these resources to learn more about what you can do in Code Builder:
 
-- [Visual Studio Code User Interface](https://code.visualstudio.com/docs/getstarted/userinterface) to get to know the Visual Studio code user interface
+- [Visual Studio Code User Interface](https://code.visualstudio.com/docs/getstarted/userinterface) to get to know the Visual Studio code user interface.
 - [Salesforce Extensions](https://developer.salesforce.com/tools/vscode) to learn about all the powerful features of the Salesforce Extension for VS Code.

--- a/docs/_articles/ja/codebuilder/cb-tips.md
+++ b/docs/_articles/ja/codebuilder/cb-tips.md
@@ -1,0 +1,12 @@
+---
+title: Useful Tips for Using Code Builder
+lang: en
+---
+
+## Install Extensions from Open VSX Registry
+
+Maximize your productivity in Code Builder by installing additional extensions to your Code Builder environment. [Open VSX](https://open-vsx.org) is an Eclipse open-source project and alternative to the Visual Studio Marketplace. Extensions available here can be installed in Code Builder. You can browse and install these extensions from within VS Code. Bring up the Extensions view by clicking on the Extensions icon in the Activity Bar or the **View: Extensions** command (⇧⌘X).
+
+## Reset your Code Builder Environment
+
+Reset your Code Builder environment to start building with a fresh environment. Resetting deletes everything stored in your Code Builder environment and all your data so you have a clean space to work with. To reset your Code Builder environment, click the dropdown next to the launch button and select **Reset Environment**.


### PR DESCRIPTION
### What does this PR do?
The Code Builder ja docs folder has old versions of the en files that refer to Beta. This PR updates ja folder to have the latest en files, which no longer refer to Beta. I'll separately follow up to see how to get the ja files localized.

### What issues does this PR fix or reference?
@W-15256202@

