### PR TITLE
fix: support folder with symbol link

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
@@ -5,8 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { realpathSync, lstatSync } from 'fs';
-import { basename, resolve, dirname } from 'path';
+import { basename } from 'path';
 import { telemetryService } from '../telemetry';
 
 export const isNullOrUndefined = (object: any): object is null | undefined => {
@@ -35,7 +34,11 @@ export const flushFilePath = (filePath: string): string => {
     return filePath;
   }
 
-  let nativePath = isSymbolicLink(filePath)? filePath: realpathSync.native(filePath);
+  // let nativePath = realpathSync.native(filePath);
+  // Above is the original assigned nativePath value.
+  // We found that filePath is the correct path and the stale name issue
+  // no longer exists.
+  let nativePath = filePath;
   if (/^win32/.test(process.platform)) {
     // The file path on Windows is in the form of "c:\Users\User Name\foo.cls".
     // When called, fs.realpathSync.native() is returning the file path back as
@@ -58,22 +61,6 @@ export const flushFilePath = (filePath: string): string => {
     });
   }
   return nativePath;
-};
-
-export const isSymbolicLink = (path: string) => {
-  try {
-    let currentPath = resolve(path);
-    // track down the path until it is a root path
-    while(currentPath !== dirname(currentPath)) {
-      const stats = lstatSync(currentPath);
-      const isLink = stats.isSymbolicLink();
-      if (isLink) return true;
-      currentPath = dirname(currentPath);
-    }
-    return false;
-  } catch (err) {
-      throw new Error('The path does not exist');
-  }
 };
 
 export const flushFilePaths = (filePaths: string[]): string[] => {

--- a/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
@@ -61,9 +61,11 @@ export const flushFilePath = (filePath: string): string => {
 };
 
 const isSymbolicLink = (path: string) => {
+  // regex of windows root path
+  const winRootDir = /^[A-Za-z]:\\$/;
   try {
     let currentPath = resolve(path);
-    while(currentPath !== '/') {
+    while(currentPath !== '/'  && !winRootDir.test(currentPath)) {
       const stats = lstatSync(currentPath);
       const isLink = stats.isSymbolicLink();
       if (isLink) return true;

--- a/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
@@ -60,7 +60,7 @@ export const flushFilePath = (filePath: string): string => {
   return nativePath;
 };
 
-const isSymbolicLink = (path: string) => {
+export const isSymbolicLink = (path: string) => {
   try {
     let currentPath = resolve(path);
     // track down the path until it is a root path

--- a/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
@@ -61,11 +61,10 @@ export const flushFilePath = (filePath: string): string => {
 };
 
 const isSymbolicLink = (path: string) => {
-  // regex of windows root path
-  const winRootDir = /^[A-Za-z]:\\$/;
   try {
     let currentPath = resolve(path);
-    while(currentPath !== '/'  && !winRootDir.test(currentPath)) {
+    // track down the path until it is a root path
+    while(currentPath !== dirname(currentPath)) {
       const stats = lstatSync(currentPath);
       const isLink = stats.isSymbolicLink();
       if (isLink) return true;

--- a/packages/salesforcedx-utils-vscode/test/jest/helpers/utils.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/helpers/utils.test.ts
@@ -4,11 +4,9 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { realpathSync, writeFileSync, existsSync, unlinkSync, mkdirSync, symlinkSync, rmdirSync } from 'fs';
-import { execSync } from 'node:child_process';
-import * as os from 'os';
+import { realpathSync, writeFileSync, existsSync, unlinkSync } from 'fs';
 import { TelemetryService } from '../../../src';
-import { extractJsonObject, flushFilePath, isSymbolicLink } from '../../../src/helpers/utils';
+import { extractJsonObject, flushFilePath } from '../../../src/helpers/utils';
 
 describe('flushFilePath', () => {
   let teleSpy: jest.SpyInstance;
@@ -27,16 +25,6 @@ describe('flushFilePath', () => {
       unlinkSync(originalPath);
     }
   });
-  it('should detect changes in character casing', () => {
-    const alteredPath = './TEST.txt';
-
-    jest.spyOn(realpathSync, 'native').mockReturnValue(alteredPath);
-    teleSpy = jest.spyOn(TelemetryService.prototype, 'sendEventData');
-
-    const r = flushFilePath(originalPath);
-    expect(r).toEqual(alteredPath);
-    expect(teleSpy).toHaveBeenCalledTimes(1);
-  });
 
   it('should not send to telemetry if there are no changes in character casing', () => {
     const alteredPath = './test.txt';
@@ -47,33 +35,6 @@ describe('flushFilePath', () => {
     const r = flushFilePath(originalPath);
     expect(r).toEqual(alteredPath);
     expect(teleSpy).not.toHaveBeenCalled();
-  });
-});
-
-describe('isSymbolicLink', () => {
-  const sourceFolder = './source';
-  const linkedFolder = './linked';
-
-  afterEach(() => {
-    if (existsSync(linkedFolder)) {
-      unlinkSync(linkedFolder);
-    }
-    if (existsSync(sourceFolder)) {
-      rmdirSync(sourceFolder);
-    }
-  });
-  it('should keep the symbolic link if it is', () => {
-    if (!existsSync(sourceFolder)) {
-      mkdirSync(sourceFolder);
-    }
-    const platform = os.platform();
-    if (platform === 'win32') {
-      const cmd = `mklink /j "${linkedFolder}" "${sourceFolder}"`;
-      execSync(cmd, { stdio: 'ignore' });
-    } else {
-      symlinkSync(sourceFolder, linkedFolder, 'dir');
-    }
-    expect(isSymbolicLink(linkedFolder)).toBe(true);
   });
 });
 

--- a/packages/salesforcedx-utils-vscode/test/jest/helpers/utils.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/helpers/utils.test.ts
@@ -4,39 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { realpathSync, writeFileSync, existsSync, unlinkSync } from 'fs';
-import { TelemetryService } from '../../../src';
-import { extractJsonObject, flushFilePath } from '../../../src/helpers/utils';
-
-describe('flushFilePath', () => {
-  let teleSpy: jest.SpyInstance;
-  let originalPath = '';
-  beforeEach(() => {
-    jest.mock('fs');
-    jest.mock('../../../src/context/workspaceContextUtil');
-    originalPath = './test.txt';
-    const fileContent = 'Hello, world!';
-    writeFileSync(originalPath, fileContent);
-  });
-
-  afterEach(() => {
-    // Clean up the file after each test
-    if (existsSync(originalPath)) {
-      unlinkSync(originalPath);
-    }
-  });
-
-  it('should not send to telemetry if there are no changes in character casing', () => {
-    const alteredPath = './test.txt';
-
-    jest.spyOn(realpathSync, 'native').mockReturnValue(alteredPath);
-    teleSpy = jest.spyOn(TelemetryService.prototype, 'sendEventData');
-
-    const r = flushFilePath(originalPath);
-    expect(r).toEqual(alteredPath);
-    expect(teleSpy).not.toHaveBeenCalled();
-  });
-});
+import { extractJsonObject } from '../../../src/helpers/utils';
 
 describe('extractJsonObject unit tests', () => {
   const initialValue = {


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
The vsce has been using `realpathSync.native(filePath)` to get the canonical pathname of a given path. So for customers that are using sfdx project with a symbolic link, it fails to run deploy or retrieve commands with error: “Error deploying or retrieving source: The file or directory that you tried to deploy or retrieve isn’t in a package directory that’s specified in your sfdx-project.json file. Add this location to your “packageDirectories” value, or deploy or retrieve a different file or directory. For details about sfdx-project.json, see: https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_ws_config.htm"

The reason why it uses `realpathSync.native(filePath)`  is that there was a [previous issue fix](https://github.com/forcedotcom/salesforcedx-vscode/pull/4362). So this PR adds a check based on that fix to detect if the path refers to somewhere under a symbolic link. If there is one, then we will return the exact symbolic link, rather than the original folder. So there will not be a mismatch.

With this update, I also tested the [scenario](https://github.com/forcedotcom/salesforcedx-vscode/pull/4362) of the previous issue. And it is also working fine.

### What issues does this PR fix or reference?
@W-15247490@

### Functionality Before
Customers who work within a symbolic link are not able to use VSCE to run deploy and retrieve commands. 

To establish the symbolic link, 
in mac/unix, run `ln -s /path/to/target /path/to/link`,
in windows, run `mklink /j C:\LinkToFolder C:\TargetFolder`.

e.g.

1. Open the project folder in the VS code. Set the Salesforce CLI Extension version to 60.2.3.
2. Create one APEX/LWC/ any other component and try to deploy it.
3. It will get deployed.
4. Now Open the folder that you have mapped to the original project in VS code.
5. Make sure that your Salesforce CLI Extension is set to user 60.2.3 version.
6. Create one APEX/LWC/ any other component, and try to deploy it.
7. You will face the same error as the customer is facing.

Also there is no error from the [former issue.](https://github.com/forcedotcom/salesforcedx-vscode/pull/4362) 

### Functionality After

The functions of deploying and retrieving work fine in the symbolic link.