### PR TITLE
chore: show correct input values in Slack notifications for scheduled runs of Base E2E Suite

### DIFF
--- a/.github/workflows/baseSuiteE2E.yml
+++ b/.github/workflows/baseSuiteE2E.yml
@@ -188,7 +188,7 @@ jobs:
         lwcLSP,
         deployAndRetrieve,
         apexLSP,
-        runApexTests,
+        runApexTests
       ]
     uses: ./.github/workflows/slackNotification.yml
     secrets: inherit
@@ -210,7 +210,7 @@ jobs:
         lwcLSP,
         deployAndRetrieve,
         apexLSP,
-        runApexTests,
+        runApexTests
       ]
     uses: ./.github/workflows/slackNotification.yml
     secrets: inherit
@@ -232,7 +232,7 @@ jobs:
         lwcLSP,
         deployAndRetrieve,
         apexLSP,
-        runApexTests,
+        runApexTests
       ]
     uses: ./.github/workflows/slackNotification.yml
     secrets: inherit

--- a/.github/workflows/baseSuiteE2E.yml
+++ b/.github/workflows/baseSuiteE2E.yml
@@ -188,14 +188,14 @@ jobs:
         lwcLSP,
         deployAndRetrieve,
         apexLSP,
-        runApexTests
+        runApexTests,
       ]
     uses: ./.github/workflows/slackNotification.yml
     secrets: inherit
     with:
       title: 'Base E2E Test Suite'
-      vscodeVersion: ${{ inputs.vscodeVersion }}
-      testsBranch: ${{ inputs.automationBranch }}
+      vscodeVersion: ${{ inputs.vscodeVersion || '1.82.3' }}
+      testsBranch: ${{ inputs.automationBranch || 'develop' }}
       summary: '\n- An Initial Suite: ${{ needs.anInitialSuite.result }}\n- Authentication: ${{ needs.authentication.result }}\n- LWC LSP: ${{ needs.lwcLSP.result }}\n- Deploy and Retrieve: ${{ needs.deployAndRetrieve.result }}\n- Apex LSP: ${{ needs.apexLSP.result }}\n- Run Apex Tests: ${{ needs.runApexTests.result }}'
       result: 'All the tests passed.'
       workflow: 'actions/runs/${{ github.run_id }}'
@@ -210,14 +210,14 @@ jobs:
         lwcLSP,
         deployAndRetrieve,
         apexLSP,
-        runApexTests
+        runApexTests,
       ]
     uses: ./.github/workflows/slackNotification.yml
     secrets: inherit
     with:
       title: 'Base E2E Test Suite'
-      vscodeVersion: ${{ inputs.vscodeVersion }}
-      testsBranch: ${{ inputs.automationBranch }}
+      vscodeVersion: ${{ inputs.vscodeVersion || '1.82.3' }}
+      testsBranch: ${{ inputs.automationBranch || 'develop' }}
       summary: '\n- An Initial Suite: ${{ needs.anInitialSuite.result }}\n- Authentication: ${{ needs.authentication.result }}\n- LWC LSP: ${{ needs.lwcLSP.result }}\n- Deploy and Retrieve: ${{ needs.deployAndRetrieve.result }}\n- Apex LSP: ${{ needs.apexLSP.result }}\n- Run Apex Tests: ${{ needs.runApexTests.result }}'
       result: 'Not all the tests passed.'
       workflow: 'actions/runs/${{ github.run_id }}'
@@ -232,14 +232,14 @@ jobs:
         lwcLSP,
         deployAndRetrieve,
         apexLSP,
-        runApexTests
+        runApexTests,
       ]
     uses: ./.github/workflows/slackNotification.yml
     secrets: inherit
     with:
       title: 'Base E2E Test Suite'
-      vscodeVersion: ${{ inputs.vscodeVersion }}
-      testsBranch: ${{ inputs.automationBranch }}
+      vscodeVersion: ${{ inputs.vscodeVersion || '1.82.3' }}
+      testsBranch: ${{ inputs.automationBranch || 'develop' }}
       summary: '\n- An Initial Suite: ${{ needs.anInitialSuite.result }}\n- Authentication: ${{ needs.authentication.result }}\n- LWC LSP: ${{ needs.lwcLSP.result }}\n- Deploy and Retrieve: ${{ needs.deployAndRetrieve.result }}\n- Apex LSP: ${{ needs.apexLSP.result }}\n- Run Apex Tests: ${{ needs.runApexTests.result }}'
       result: 'The workflow was cancelled.'
       workflow: 'actions/runs/${{ github.run_id }}'


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Show the correct values for **VSCode version** and **E2E branch** inputs in Slack notifications for scheduled runs of Base E2E suite that are triggered by other workflows, instead of a blank value.

Blank value was being shown because the default VSCode version and E2E branch were being used, and default values were treated as blank instead of their actual value when displayed in human-readable format.

![Screenshot 2024-03-15 at 11 15 26 AM](https://github.com/forcedotcom/salesforcedx-vscode/assets/139700604/dd0f46ad-56f1-4807-be2a-9be75bb803f8)

[skip-validate-pr]