### PR TITLE
chore: revert sf to sf in project_opened and generate apex unit test

### DIFF
--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -221,7 +221,7 @@
       "commandPalette": [
         {
           "command": "sf.debug.exception.breakpoint",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         }
       ]
     },

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -28,7 +28,7 @@
           "light": "images/light/cloud-upload.svg"
         },
         "title": "%sf_update_checkpoints_in_org%",
-        "when": "sf:project_opened"
+        "when": "sfdx:project_opened"
       },
       {
         "command": "sf.launch.replay.debugger.last.logfile",
@@ -130,15 +130,15 @@
       "commandPalette": [
         {
           "command": "sf.create.checkpoints",
-          "when": "sf:project_opened && sf:has_target_org"
+          "when": "sfdx:project_opened && sf:has_target_org"
         },
         {
           "command": "sf.toggle.checkpoint",
-          "when": "sf:project_opened && editorLangId == 'apex'"
+          "when": "sfdx:project_opened && editorLangId == 'apex'"
         },
         {
           "command": "sf.launch.replay.debugger.last.logfile",
-          "when": "sf:project_opened && !inDebugMode"
+          "when": "sfdx:project_opened && !inDebugMode"
         },
         {
           "command": "sf.test.view.debugTests",
@@ -165,7 +165,7 @@
         {
           "command": "sf.create.checkpoints",
           "group": "navigation",
-          "when": "view == sf.view.checkpoint && sf:project_opened"
+          "when": "view == sf.view.checkpoint && sfdx:project_opened"
         }
       ]
     },
@@ -174,7 +174,7 @@
         {
           "id": "sf.view.checkpoint",
           "name": "%view_checkpoints%",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         }
       ]
     }

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -194,19 +194,19 @@
       "commandPalette": [
         {
           "command": "sf.anon.apex.execute.selection",
-          "when": "sf:project_opened && editorHasSelection && sf:has_target_org"
+          "when": "sfdx:project_opened && editorHasSelection && sf:has_target_org"
         },
         {
           "command": "sf.anon.apex.execute.document",
-          "when": "sf:project_opened && !editorHasSelection && sf:has_target_org"
+          "when": "sfdx:project_opened && !editorHasSelection && sf:has_target_org"
         },
         {
           "command": "sf.apex.log.get",
-          "when": "sf:project_opened && sf:has_target_org"
+          "when": "sfdx:project_opened && sf:has_target_org"
         },
         {
           "command": "sf.apex.test.last.class.run",
-          "when": "sf:project_opened && sf:has_cached_test_class && sf:has_target_org"
+          "when": "sfdx:project_opened && sf:has_cached_test_class && sf:has_target_org"
         },
         {
           "command": "sf.apex.test.class.run",
@@ -218,23 +218,23 @@
         },
         {
           "command": "sf.apex.test.last.method.run",
-          "when": "sf:project_opened && sf:has_cached_test_method && sf:has_target_org"
+          "when": "sfdx:project_opened && sf:has_cached_test_method && sf:has_target_org"
         },
         {
           "command": "sf.apex.test.run",
-          "when": "sf:project_opened && sf:has_target_org"
+          "when": "sfdx:project_opened && sf:has_target_org"
         },
         {
           "command": "sf.apex.test.suite.run",
-          "when": "sf:project_opened && sf:has_target_org"
+          "when": "sfdx:project_opened && sf:has_target_org"
         },
         {
           "command": "sf.apex.test.suite.create",
-          "when": "sf:project_opened && sf:has_target_org"
+          "when": "sfdx:project_opened && sf:has_target_org"
         },
         {
           "command": "sf.apex.test.suite.add",
-          "when": "sf:project_opened && sf:has_target_org"
+          "when": "sfdx:project_opened && sf:has_target_org"
         },
         {
           "command": "sf.test.view.runClassTests",
@@ -305,7 +305,7 @@
         {
           "id": "sf.test.view",
           "name": "%test_view_name%",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         }
       ]
     },

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -536,7 +536,7 @@
           "when": "sfdx:project_opened && resourceLangId != 'forcesourcemanifest' && editorIsOpen && sf:has_target_org"
         },
         {
-          "command": "sf.set.default.org",
+          "command": "sfdx.set.default.org",
           "when": "sfdx:project_opened"
         },
         {
@@ -831,7 +831,7 @@
         "title": "%delete_source_this_source_text%"
       },
       {
-        "command": "sf.set.default.org",
+        "command": "sfdx.set.default.org",
         "title": "%config_set_org_text%"
       },
       {

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -452,7 +452,7 @@
           "when": "sfdx:project_opened && editorHasSelection && sf:has_target_org"
         },
         {
-          "command": "sf.project.generate",
+          "command": "sfdx.project.generate",
           "when": "!sf:internal_dev"
         },
         {
@@ -775,7 +775,7 @@
         "title": "%data_query_selection_text%"
       },
       {
-        "command": "sf.project.generate",
+        "command": "sfdx.project.generate",
         "title": "%project_generate_text%"
       },
       {

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -157,14 +157,14 @@
         {
           "id": "metadata",
           "name": "Metadata",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         }
       ],
       "conflicts": [
         {
           "id": "conflicts",
           "name": "Conflicts",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         }
       ]
     },
@@ -205,37 +205,37 @@
       "editor/context": [
         {
           "command": "sf.retrieve.current.source.file",
-          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org"
+          "when": "sfdx:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org"
         },
         {
           "command": "sf.retrieve.in.manifest",
-          "when": "sf:project_opened && resourceLangId == 'forcesourcemanifest' && sf:has_target_org"
+          "when": "sfdx:project_opened && resourceLangId == 'forcesourcemanifest' && sf:has_target_org"
         },
         {
           "command": "sf.deploy.current.source.file",
-          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org"
+          "when": "sfdx:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org"
         },
         {
           "command": "sf.deploy.in.manifest",
-          "when": "sf:project_opened && resourceLangId == 'forcesourcemanifest' && sf:has_target_org"
+          "when": "sfdx:project_opened && resourceLangId == 'forcesourcemanifest' && sf:has_target_org"
         },
         {
           "command": "sf.delete.source.current.file",
-          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org"
+          "when": "sfdx:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org"
         },
         {
           "command": "sf.diff",
-          "when": "!explorerResourceIsFolder && sf:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org"
+          "when": "!explorerResourceIsFolder && sfdx:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org"
         },
         {
           "command": "sf.launch.apex.replay.debugger.with.current.file",
-          "when": "sf:project_opened && resource =~ /.\\.(cls|apex|log)?$/"
+          "when": "sfdx:project_opened && resource =~ /.\\.(cls|apex|log)?$/"
         }
       ],
       "explorer/context": [
         {
           "command": "sf.lightning.generate.lwc",
-          "when": "explorerResourceIsFolder && resourceFilename == lwc && sf:project_opened"
+          "when": "explorerResourceIsFolder && resourceFilename == lwc && sfdx:project_opened"
         },
         {
           "command": "sf.internal.lightning.generate.lwc",
@@ -243,31 +243,31 @@
         },
         {
           "command": "sf.apex.generate.class",
-          "when": "explorerResourceIsFolder && resourcePath =~ /classes/ && sf:project_opened"
+          "when": "explorerResourceIsFolder && resourcePath =~ /classes/ && sfdx:project_opened"
         },
         {
-          "command": "sf.apex.generate.unit.test.class",
-          "when": "explorerResourceIsFolder && resourcePath =~ /classes/ && sf:project_opened"
+          "command": "sfdx.apex.generate.unit.test.class",
+          "when": "explorerResourceIsFolder && resourcePath =~ /classes/ && sfdx:project_opened"
         },
         {
           "command": "sf.folder.diff",
-          "when": "explorerResourceIsFolder && sf:project_opened && sf:has_target_org"
+          "when": "explorerResourceIsFolder && sfdx:project_opened && sf:has_target_org"
         },
         {
           "command": "sf.analytics.generate.template",
-          "when": "explorerResourceIsFolder && resourceFilename == waveTemplates && sf:project_opened"
+          "when": "explorerResourceIsFolder && resourceFilename == waveTemplates && sfdx:project_opened"
         },
         {
           "command": "sf.visualforce.generate.component",
-          "when": "explorerResourceIsFolder && resourceFilename == components && sf:project_opened"
+          "when": "explorerResourceIsFolder && resourceFilename == components && sfdx:project_opened"
         },
         {
           "command": "sf.visualforce.generate.page",
-          "when": "explorerResourceIsFolder && resourceFilename == pages && sf:project_opened"
+          "when": "explorerResourceIsFolder && resourceFilename == pages && sfdx:project_opened"
         },
         {
           "command": "sf.lightning.generate.app",
-          "when": "explorerResourceIsFolder && resourceFilename == aura && sf:project_opened"
+          "when": "explorerResourceIsFolder && resourceFilename == aura && sfdx:project_opened"
         },
         {
           "command": "sf.internal.lightning.generate.app",
@@ -275,7 +275,7 @@
         },
         {
           "command": "sf.lightning.generate.aura.component",
-          "when": "explorerResourceIsFolder && resourceFilename == aura && sf:project_opened"
+          "when": "explorerResourceIsFolder && resourceFilename == aura && sfdx:project_opened"
         },
         {
           "command": "sf.internal.lightning.generate.aura.component",
@@ -283,7 +283,7 @@
         },
         {
           "command": "sf.lightning.generate.event",
-          "when": "explorerResourceIsFolder && resourceFilename == aura && sf:project_opened"
+          "when": "explorerResourceIsFolder && resourceFilename == aura && sfdx:project_opened"
         },
         {
           "command": "sf.internal.lightning.generate.event",
@@ -291,7 +291,7 @@
         },
         {
           "command": "sf.lightning.generate.interface",
-          "when": "explorerResourceIsFolder && resourceFilename == aura && sf:project_opened"
+          "when": "explorerResourceIsFolder && resourceFilename == aura && sfdx:project_opened"
         },
         {
           "command": "sf.internal.lightning.generate.interface",
@@ -299,45 +299,45 @@
         },
         {
           "command": "sf.apex.generate.trigger",
-          "when": "explorerResourceIsFolder && resourceFilename == triggers && sf:project_opened"
+          "when": "explorerResourceIsFolder && resourceFilename == triggers && sfdx:project_opened"
         },
         {
           "command": "sf.diff",
-          "when": "!explorerResourceIsFolder && sf:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org"
+          "when": "!explorerResourceIsFolder && sfdx:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org"
         },
         {
           "command": "sf.retrieve.source.path",
-          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org"
+          "when": "sfdx:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org"
         },
         {
           "command": "sf.retrieve.in.manifest",
-          "when": "sf:project_opened && resourceLangId == 'forcesourcemanifest' && sf:has_target_org"
+          "when": "sfdx:project_opened && resourceLangId == 'forcesourcemanifest' && sf:has_target_org"
         },
         {
           "command": "sf.deploy.source.path",
-          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org"
+          "when": "sfdx:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org"
         },
         {
           "command": "sf.deploy.in.manifest",
-          "when": "sf:project_opened && resourceLangId == 'forcesourcemanifest' && sf:has_target_org"
+          "when": "sfdx:project_opened && resourceLangId == 'forcesourcemanifest' && sf:has_target_org"
         },
         {
           "command": "sf.delete.source",
-          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org"
+          "when": "sfdx:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org"
         },
         {
           "command": "sf.project.generate.manifest",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.rename.lightning.component",
-          "when": "sf:project_opened && resource =~ /.*\\/(lwc|aura)\\/.*(\\/[^\\/]+\\.(html|css|js|xml|svg|cmp|app|design|auradoc))?$/"
+          "when": "sfdx:project_opened && resource =~ /.*\\/(lwc|aura)\\/.*(\\/[^\\/]+\\.(html|css|js|xml|svg|cmp|app|design|auradoc))?$/"
         }
       ],
       "commandPalette": [
         {
           "command": "sf.package.install",
-          "when": "sf:project_opened && sf:has_target_org"
+          "when": "sfdx:project_opened && sf:has_target_org"
         },
         {
           "command": "sf.org.login.web.dev.hub",
@@ -345,111 +345,111 @@
         },
         {
           "command": "sf.org.login.access.token",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.org.login.web",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.org.logout.all",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.org.logout.default",
-          "when": "sf:project_opened && sf:has_target_org"
+          "when": "sfdx:project_opened && sf:has_target_org"
         },
         {
           "command": "sf.open.documentation",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.org.create",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.org.open",
-          "when": "sf:project_opened && sf:has_target_org"
+          "when": "sfdx:project_opened && sf:has_target_org"
         },
         {
           "command": "sf.project.retrieve.start",
-          "when": "sf:project_opened && !sf:isv_debug_project && sf:target_org_has_change_tracking && sf:has_target_org"
+          "when": "sfdx:project_opened && !sf:isv_debug_project && sf:target_org_has_change_tracking && sf:has_target_org"
         },
         {
           "command": "sf.project.retrieve.start.ignore.conflicts",
-          "when": "sf:project_opened && !sf:isv_debug_project && sf:target_org_has_change_tracking && sf:has_target_org"
+          "when": "sfdx:project_opened && !sf:isv_debug_project && sf:target_org_has_change_tracking && sf:has_target_org"
         },
         {
           "command": "sf.project.deploy.start",
-          "when": "sf:project_opened && !sf:isv_debug_project && sf:target_org_has_change_tracking && sf:has_target_org"
+          "when": "sfdx:project_opened && !sf:isv_debug_project && sf:target_org_has_change_tracking && sf:has_target_org"
         },
         {
           "command": "sf.project.deploy.start.ignore.conflicts",
-          "when": "sf:project_opened && !sf:isv_debug_project && sf:target_org_has_change_tracking && sf:has_target_org"
+          "when": "sfdx:project_opened && !sf:isv_debug_project && sf:target_org_has_change_tracking && sf:has_target_org"
         },
         {
           "command": "sf.view.all.changes",
-          "when": "sf:project_opened && !sf:isv_debug_project && sf:target_org_has_change_tracking"
+          "when": "sfdx:project_opened && !sf:isv_debug_project && sf:target_org_has_change_tracking"
         },
         {
           "command": "sf.view.local.changes",
-          "when": "sf:project_opened && !sf:isv_debug_project && sf:target_org_has_change_tracking"
+          "when": "sfdx:project_opened && !sf:isv_debug_project && sf:target_org_has_change_tracking"
         },
         {
           "command": "sf.view.remote.changes",
-          "when": "sf:project_opened && !sf:isv_debug_project && sf:target_org_has_change_tracking"
+          "when": "sfdx:project_opened && !sf:isv_debug_project && sf:target_org_has_change_tracking"
         },
         {
           "command": "sf.task.stop",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.apex.generate.class",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
-          "command": "sf.apex.generate.unit.test.class",
-          "when": "sf:project_opened"
+          "command": "sfdx.apex.generate.unit.test.class",
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.analytics.generate.template",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.visualforce.generate.component",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.visualforce.generate.page",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.debugger.stop",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.config.list",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.alias.list",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.org.display.default",
-          "when": "sf:project_opened && sf:has_target_org"
+          "when": "sfdx:project_opened && sf:has_target_org"
         },
         {
           "command": "sf.org.display.username",
-          "when": "sf:project_opened && sf:has_target_org"
+          "when": "sfdx:project_opened && sf:has_target_org"
         },
         {
           "command": "sf.data.query.input",
-          "when": "sf:project_opened && !editorHasSelection && sf:has_target_org"
+          "when": "sfdx:project_opened && !editorHasSelection && sf:has_target_org"
         },
         {
           "command": "sf.data.query.selection",
-          "when": "sf:project_opened && editorHasSelection && sf:has_target_org"
+          "when": "sfdx:project_opened && editorHasSelection && sf:has_target_org"
         },
         {
           "command": "sf.project.generate",
@@ -469,15 +469,15 @@
         },
         {
           "command": "sf.apex.generate.trigger",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.start.apex.debug.logging",
-          "when": "sf:project_opened && sf:replay_debugger_extension && sf:has_target_org"
+          "when": "sfdx:project_opened && sf:replay_debugger_extension && sf:has_target_org"
         },
         {
           "command": "sf.stop.apex.debug.logging",
-          "when": "sf:project_opened && sf:replay_debugger_extension && sf:has_target_org"
+          "when": "sfdx:project_opened && sf:replay_debugger_extension && sf:has_target_org"
         },
         {
           "command": "sf.debug.isv.bootstrap",
@@ -501,19 +501,19 @@
         },
         {
           "command": "sf.retrieve.current.source.file",
-          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && editorIsOpen && sf:has_target_org"
+          "when": "sfdx:project_opened && resourceLangId != 'forcesourcemanifest' && editorIsOpen && sf:has_target_org"
         },
         {
           "command": "sf.retrieve.in.manifest",
-          "when": "sf:project_opened && resourceLangId == 'forcesourcemanifest' && sf:has_target_org"
+          "when": "sfdx:project_opened && resourceLangId == 'forcesourcemanifest' && sf:has_target_org"
         },
         {
           "command": "sf.deploy.current.source.file",
-          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && editorIsOpen && sf:has_target_org"
+          "when": "sfdx:project_opened && resourceLangId != 'forcesourcemanifest' && editorIsOpen && sf:has_target_org"
         },
         {
           "command": "sf.deploy.in.manifest",
-          "when": "sf:project_opened && resourceLangId == 'forcesourcemanifest' && sf:has_target_org"
+          "when": "sfdx:project_opened && resourceLangId == 'forcesourcemanifest' && sf:has_target_org"
         },
         {
           "command": "sf.delete.source",
@@ -521,31 +521,31 @@
         },
         {
           "command": "sf.org.delete.default",
-          "when": "sf:project_opened && sf:has_target_org"
+          "when": "sfdx:project_opened && sf:has_target_org"
         },
         {
           "command": "sf.org.delete.username",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.org.list.clean",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.delete.source.current.file",
-          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && editorIsOpen && sf:has_target_org"
+          "when": "sfdx:project_opened && resourceLangId != 'forcesourcemanifest' && editorIsOpen && sf:has_target_org"
         },
         {
           "command": "sf.set.default.org",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.lightning.generate.lwc",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.force.lightning.lwc.test.create",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.internal.lightning.generate.lwc",
@@ -553,7 +553,7 @@
         },
         {
           "command": "sf.lightning.generate.app",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.internal.lightning.generate.app",
@@ -561,7 +561,7 @@
         },
         {
           "command": "sf.lightning.generate.aura.component",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.internal.lightning.generate.aura.component",
@@ -569,7 +569,7 @@
         },
         {
           "command": "sf.lightning.generate.event",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.internal.lightning.generate.event",
@@ -577,7 +577,7 @@
         },
         {
           "command": "sf.lightning.generate.interface",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.internal.lightning.generate.interface",
@@ -597,19 +597,19 @@
         },
         {
           "command": "sf.internal.refreshsobjects",
-          "when": "sf:project_opened && sf:has_target_org"
+          "when": "sfdx:project_opened && sf:has_target_org"
         },
         {
           "command": "sf.launch.apex.replay.debugger.with.current.file",
-          "when": "sf:project_opened && resource =~ /.\\.(cls|apex|log)?$/"
+          "when": "sfdx:project_opened && resource =~ /.\\.(cls|apex|log)?$/"
         },
         {
           "command": "sf.metadata.view.type.refresh",
-          "when": "sf:project_opened && sf:has_target_org"
+          "when": "sfdx:project_opened && sf:has_target_org"
         },
         {
           "command": "sf.metadata.view.component.refresh",
-          "when": "sf:project_opened && sf:has_target_org"
+          "when": "sfdx:project_opened && sf:has_target_org"
         }
       ]
     },
@@ -687,7 +687,7 @@
         "title": "%apex_generate_class_text%"
       },
       {
-        "command": "sf.apex.generate.unit.test.class",
+        "command": "sfdx.apex.generate.unit.test.class",
         "title": "%apex_generate_unit_test_class_text%"
       },
       {

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -328,7 +328,7 @@ const registerCommands = (
     dataQuery
   );
   const projectGenerateCmd = vscode.commands.registerCommand(
-    'sf.project.generate',
+    'sfdx.project.generate',
     sfProjectGenerate
   );
 

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -490,7 +490,7 @@ const registerOrgPickerCommands = (
   orgListParam: OrgList
 ): vscode.Disposable => {
   const setDefaultOrgCmd = vscode.commands.registerCommand(
-    'sf.set.default.org',
+    'sfdx.set.default.org',
     () => orgListParam.setDefaultOrg()
   );
   return vscode.Disposable.from(setDefaultOrgCmd);

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -239,7 +239,7 @@ const registerCommands = (
     apexGenerateClass
   );
   const apexGenerateUnitTestClassCmd = vscode.commands.registerCommand(
-    'sf.apex.generate.unit.test.class',
+    'sfdx.apex.generate.unit.test.class',
     apexGenerateUnitTestClass
   );
   const analyticsGenerateTemplateCmd = vscode.commands.registerCommand(
@@ -620,7 +620,7 @@ export const activate = async (extensionContext: vscode.ExtensionContext) => {
 
   void vscode.commands.executeCommand(
     'setContext',
-    'sf:project_opened',
+    'sfdx:project_opened',
     salesforceProjectOpened
   );
 

--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -24,7 +24,7 @@ export class OrgList implements vscode.Disposable {
       vscode.StatusBarAlignment.Left,
       49
     );
-    this.statusBarItem.command = 'sf.set.default.org';
+    this.statusBarItem.command = 'sfdx.set.default.org';
     this.statusBarItem.tooltip = nls.localize('status_bar_org_picker_tooltip');
     this.statusBarItem.show();
 

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -177,19 +177,19 @@
       "commandPalette": [
         {
           "command": "sf.lightning.lwc.start",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.lightning.lwc.stop",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.lightning.lwc.open",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "sf.lightning.lwc.preview",
-          "when": "sf:project_opened && resource =~ /.*\\/lwc\\/[^\\/]+(\\/[^\\/]+\\.(html|css|js))?$/"
+          "when": "sfdx:project_opened && resource =~ /.*\\/lwc\\/[^\\/]+(\\/[^\\/]+\\.(html|css|js))?$/"
         },
         {
           "command": "sf.lightning.lwc.test.file.run",
@@ -213,11 +213,11 @@
         },
         {
           "command": "sf.lightning.lwc.test.runAllTests",
-          "when": "sf:project_opened || sf:internal_dev"
+          "when": "sfdx:project_opened || sf:internal_dev"
         },
         {
           "command": "sf.lightning.lwc.test.refreshTestExplorer",
-          "when": "sf:project_opened || sf:internal_dev"
+          "when": "sfdx:project_opened || sf:internal_dev"
         },
         {
           "command": "sf.lightning.lwc.test.editorTitle.run",
@@ -237,13 +237,13 @@
         },
         {
           "command": "sf.lightning.lwc.test.stopWatchingAllTests",
-          "when": "sf:project_opened || sf:internal_dev"
+          "when": "sfdx:project_opened || sf:internal_dev"
         }
       ],
       "editor/context": [
         {
           "command": "sf.lightning.lwc.preview",
-          "when": "sf:project_opened && resource =~ /.*\\/lwc\\/[^\\/]+(\\/[^\\/]+\\.(html|css|js))?$/"
+          "when": "sfdx:project_opened && resource =~ /.*\\/lwc\\/[^\\/]+(\\/[^\\/]+\\.(html|css|js))?$/"
         }
       ],
       "editor/title": [
@@ -271,13 +271,13 @@
       "editor/title/context": [
         {
           "command": "sf.lightning.lwc.preview",
-          "when": "sf:project_opened && resource =~ /.*\\/lwc\\/[^\\/]+(\\/[^\\/]+\\.(html|css|js))?$/"
+          "when": "sfdx:project_opened && resource =~ /.*\\/lwc\\/[^\\/]+(\\/[^\\/]+\\.(html|css|js))?$/"
         }
       ],
       "explorer/context": [
         {
           "command": "sf.lightning.lwc.preview",
-          "when": "sf:project_opened && resource =~ /.*\\/lwc\\/[^\\/]+(\\/[^\\/]+\\.(html|css|js))?$/"
+          "when": "sfdx:project_opened && resource =~ /.*\\/lwc\\/[^\\/]+(\\/[^\\/]+\\.(html|css|js))?$/"
         }
       ],
       "view/item/context": [
@@ -334,7 +334,7 @@
         {
           "id": "sf.lightning.lwc.test.view",
           "name": "%lightning_lwc_test_view_name%",
-          "when": "sf:project_opened || sf:internal_dev"
+          "when": "sfdx:project_opened || sf:internal_dev"
         }
       ]
     }

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -196,7 +196,7 @@
       "commandPalette": [
         {
           "command": "soql.builder.open.new",
-          "when": "sf:project_opened"
+          "when": "sfdx:project_opened"
         },
         {
           "command": "soql.builder.toggle",


### PR DESCRIPTION
### What does this PR do?
Reverts: 
- sf:project_opened -->  sfdx:project_opened 
- sf.project.generate -->  sfdx.project.generate
- sf.apex.generate.unit.test.class --> sfdx.apex.generate.unit.test.class
- sf.set.default.org --> sfdx.set.default.org

[skip-validate-pr]
