### PR TITLE
fix: prevent negative extension activations times

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/helpers/activationTracker.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/activationTracker.ts
@@ -60,7 +60,7 @@ export class ActivationTracker {
     let extensionActivationTime = -1;
     if (
       extensionInfo?.loadStartDate &&
-      activateEndDate.getTime() <= extensionInfo.loadStartDate.getTime()
+      activateEndDate.getTime() >= extensionInfo.loadStartDate.getTime()
     ) {
       // subtract activateEndDate from loadStartDate to get the time spent loading the extension if loadStartDate is not undefined
       extensionActivationTime =

--- a/packages/salesforcedx-utils-vscode/src/helpers/activationTracker.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/activationTracker.ts
@@ -50,24 +50,36 @@ export class ActivationTracker {
   async markActivationStop(activationEndDate?: Date): Promise<void> {
     // capture date and elapsed HR time
     const activateEndDate = activationEndDate ?? new Date();
-    const hrEnd = this.telemetryService.getEndHRTime(this._activationInfo.startActivateHrTime);
+    const hrEnd = this.telemetryService.getEndHRTime(
+      this._activationInfo.startActivateHrTime
+    );
     // getting extension info. This may take up to 10 seconds, as log record creation might be lagging from
     // this code. All needed data have been captured for telemetry, so a wait here should have no effect
     // on quality of telemetry data
     const extensionInfo = await getExtensionInfo(this.extensionContext);
-    // subtract activateEndDate from loadStartDate to get the time spent loading the extension if loadStartDate is not undefined
-    const extensionActivationTime = extensionInfo?.loadStartDate
-      ? activateEndDate.getTime() - extensionInfo.loadStartDate.getTime()
-      : -1;
-
-    this._activationInfo = {
-      ...this._activationInfo,
-      ...extensionInfo,
-      extensionActivationTime,
-      activateEndDate,
-      markEndTime: hrEnd
-    };
-    this.telemetryService.sendActivationEventInfo(this.activationInfo);
+    let extensionActivationTime = -1;
+    if (
+      extensionInfo?.loadStartDate &&
+      activateEndDate.getTime() <= extensionInfo.loadStartDate.getTime()
+    ) {
+      // subtract activateEndDate from loadStartDate to get the time spent loading the extension if loadStartDate is not undefined
+      extensionActivationTime =
+        activateEndDate.getTime() - extensionInfo.loadStartDate.getTime();
+    }
+    if (extensionActivationTime < 0) {
+      this.telemetryService.sendExtensionActivationEvent(
+        this._activationInfo.startActivateHrTime
+      );
+    } else {
+      this._activationInfo = {
+        ...this._activationInfo,
+        ...extensionInfo,
+        extensionActivationTime,
+        activateEndDate,
+        markEndTime: hrEnd
+      };
+      this.telemetryService.sendActivationEventInfo(this.activationInfo);
+    }
   }
 
   public get activationInfo(): ActivationInfo {

--- a/packages/salesforcedx-utils-vscode/test/jest/helpers/activationTrackerClass.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/helpers/activationTrackerClass.test.ts
@@ -77,12 +77,13 @@ describe('ActivationTracker', () => {
     );
   });
   it('should not sendActivationEventInfo when loadStartDate is undefined', async () => {
+    const loadStartDate: Date | undefined = undefined;
     const mockExtensionInfo = {
       isActive: true,
       path: '/path/to/extension',
       kind: ExtensionKind.Workspace,
       uri: Uri.parse('file:///path/to/extension'),
-      loadStartDate: undefined
+      loadStartDate
     };
 
     (getExtensionInfo as jest.Mock).mockResolvedValue(mockExtensionInfo);


### PR DESCRIPTION
@W-15328509@
Prevent negative extension activation time from being included in telemetry data

Modified the calculations and logic that sends the extended activation data to telemetry to:
- Only calculate activation time when load start date is present and activate end date >= load start date
- Only send extended activation data if activation time > -1
