### PR TITLE
fix: bump apex-node for dangling comma fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6245,9 +6245,9 @@
       "integrity": "sha512-L4zUDy4lxF7+mM7DYPfOKZ4lqiAIquRx0vHAUJMBaxD4bCiT+70Df++aOfGO9FOJNctvPtT5bLrFRfdos4y4Mg=="
     },
     "node_modules/@salesforce/apex-node": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@salesforce/apex-node/-/apex-node-4.0.5.tgz",
-      "integrity": "sha512-lV/1VJgo6OsRlVBDk9MT8to2OWs4shOM/8nILd6jcxLfM7LW3k3Fjm62mZQrXe1jzxW7FN7FRWCC0e3Ys1LZPA==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@salesforce/apex-node/-/apex-node-4.0.6.tgz",
+      "integrity": "sha512-3XuW+cAsKecDrMQKODFmau50qALqeUy6QhQWV7nxmtN94orehYB6TiPrDREVQxn7AolR7WHE1CGNeCMvsGnO7A==",
       "dependencies": {
         "@salesforce/core": "^6.7.4",
         "@salesforce/kit": "^3.1.0",
@@ -37021,7 +37021,7 @@
       "version": "60.9.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/apex-node": "4.0.5",
+        "@salesforce/apex-node": "4.0.6",
         "@salesforce/apex-tmlanguage": "1.8.0",
         "@salesforce/core": "6.7.4",
         "@salesforce/salesforcedx-utils-vscode": "60.9.0",
@@ -37108,7 +37108,7 @@
       "version": "60.9.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/apex-node": "4.0.5",
+        "@salesforce/apex-node": "4.0.6",
         "@salesforce/core": "6.7.4",
         "@salesforce/salesforcedx-apex-replay-debugger": "60.9.0",
         "@salesforce/salesforcedx-utils": "60.9.0",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -180,7 +180,7 @@
     }
   },
   "dependencies": {
-    "@salesforce/apex-node": "4.0.5",
+    "@salesforce/apex-node": "4.0.6",
     "@salesforce/core": "6.7.4",
     "@salesforce/salesforcedx-apex-replay-debugger": "60.9.0",
     "@salesforce/salesforcedx-utils": "60.9.0",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -320,7 +320,7 @@
     }
   },
   "dependencies": {
-    "@salesforce/apex-node": "4.0.5",
+    "@salesforce/apex-node": "4.0.6",
     "@salesforce/apex-tmlanguage": "1.8.0",
     "@salesforce/core": "6.7.4",
     "@salesforce/salesforcedx-utils-vscode": "60.9.0",


### PR DESCRIPTION
pick up latest v4 version of apex-node to correct test result parsing error when no code coverage is in test results.

### What does this PR do?

### What issues does this PR fix or reference?
#5534 , @W-15530915@

### Functionality Before
When using the highlight code coverage feature and running apex tests without code coverage, extensions were displaying an message stating coverage results parsing failed. This is due to a bug introduced in apex-node streaming changes in v60.8.0.

### Functionality After
The fix to apex-node corrected the JSON results used for highlighting code coverage, when there is not code coverage present, no produces the correct warning that no code coverage is present in the latest test run for the apex class opened in the editor.
