### PR TITLE
feat: migrate from @salesforce/core v6 -> v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15396,9 +15396,9 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.4.tgz",
-      "integrity": "sha512-utnwm92SyozgA3hhH2I8qldf2lBqm6qHOICawRNRFu1qMe3+oqr+GcXjGqTmXTMGE5T4eC03kr/rlh5C1IRdZA==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.6.tgz",
+      "integrity": "sha512-M2SovcRxD4+vC493Uc2GZVcZaj66CCJhWurC4viynVSTvrpErCShNcDz1lAho6n9REQKvL/ll4A4/fw6Y9z8nw==",
       "funding": [
         {
           "type": "github",
@@ -29971,14 +29971,14 @@
       "dev": true
     },
     "node_modules/proxy-agent": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
-      "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
+      "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.2",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.3",
         "lru-cache": "^7.14.1",
         "pac-proxy-agent": "^7.0.1",
         "proxy-from-env": "^1.1.0",
@@ -30000,9 +30000,9 @@
       }
     },
     "node_modules/proxy-agent/node_modules/http-proxy-agent": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
-      "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -30012,9 +30012,9 @@
       }
     },
     "node_modules/proxy-agent/node_modules/https-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "4"
@@ -37120,7 +37120,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/core": "7.2.0",
-        "@salesforce/source-deploy-retrieve": "10.3.3",
+        "@salesforce/source-deploy-retrieve": "11.0.1",
         "@salesforce/source-tracking": "5.1.11",
         "applicationinsights": "1.0.7",
         "cross-spawn": "7.0.3",
@@ -37193,6 +37193,29 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "packages/salesforcedx-utils-vscode/node_modules/@salesforce/source-deploy-retrieve": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-11.0.1.tgz",
+      "integrity": "sha512-vQ5Fytvsz5L3JXykOIphf11oWBtRGUdpUomSPN2pXep7BG3RYQ/C2AlSXL9dwHqaQmSm2B2KjMp2+y//bpNWcQ==",
+      "dependencies": {
+        "@salesforce/core": "^7.2.0",
+        "@salesforce/kit": "^3.1.0",
+        "@salesforce/ts-types": "^2.0.9",
+        "fast-levenshtein": "^3.0.0",
+        "fast-xml-parser": "^4.3.6",
+        "got": "^11.8.6",
+        "graceful-fs": "^4.2.11",
+        "ignore": "^5.3.1",
+        "jszip": "^3.10.1",
+        "mime": "2.6.0",
+        "minimatch": "^5.1.6",
+        "proxy-agent": "^6.4.0",
+        "ts-retry-promise": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "packages/salesforcedx-utils-vscode/node_modules/@salesforce/ts-types": {
@@ -37364,6 +37387,17 @@
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dependencies": {
         "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/salesforcedx-utils-vscode/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=10"
@@ -38284,7 +38318,7 @@
         "@salesforce/salesforcedx-sobjects-faux-generator": "60.9.0",
         "@salesforce/salesforcedx-utils-vscode": "60.9.0",
         "@salesforce/schemas": "^1.6.1",
-        "@salesforce/source-deploy-retrieve": "10.3.3",
+        "@salesforce/source-deploy-retrieve": "11.0.1",
         "@salesforce/templates": "^60.1.0",
         "@salesforce/ts-types": "2.0.9",
         "adm-zip": "0.5.10",
@@ -38375,6 +38409,48 @@
       },
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/salesforcedx-vscode-core/node_modules/@salesforce/source-deploy-retrieve": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-11.0.1.tgz",
+      "integrity": "sha512-vQ5Fytvsz5L3JXykOIphf11oWBtRGUdpUomSPN2pXep7BG3RYQ/C2AlSXL9dwHqaQmSm2B2KjMp2+y//bpNWcQ==",
+      "dependencies": {
+        "@salesforce/core": "^7.2.0",
+        "@salesforce/kit": "^3.1.0",
+        "@salesforce/ts-types": "^2.0.9",
+        "fast-levenshtein": "^3.0.0",
+        "fast-xml-parser": "^4.3.6",
+        "got": "^11.8.6",
+        "graceful-fs": "^4.2.11",
+        "ignore": "^5.3.1",
+        "jszip": "^3.10.1",
+        "mime": "2.6.0",
+        "minimatch": "^5.1.6",
+        "proxy-agent": "^6.4.0",
+        "ts-retry-promise": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/salesforcedx-vscode-core/node_modules/@salesforce/source-deploy-retrieve/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "packages/salesforcedx-vscode-core/node_modules/@salesforce/source-deploy-retrieve/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -698,18 +698,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/runtime-corejs3": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.22.6.tgz",
-      "integrity": "sha512-M+37LLIRBTEVjktoJjbw4KVhupF0U/3PYUCbBwgAd9k17hoKhRu1n935QiG7Tuxv0LJOMrb2vuKEeYUlv0iyiw==",
-      "dependencies": {
-        "core-js-pure": "^3.30.2",
-        "regenerator-runtime": "^0.13.11"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/template": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
@@ -6359,106 +6347,6 @@
         "node": ">=18.18.2"
       }
     },
-    "node_modules/@salesforce/apex-node/node_modules/@salesforce/core": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.2.0.tgz",
-      "integrity": "sha512-N/9hv7Vdr9sEuob9vo90odcQ7dJPtfOQVIE5R8vFcfaHK3W3ej9EpHsaV55PkaVG+hxRhZ2oOVA3UaVfp/diOw==",
-      "dependencies": {
-        "@jsforce/jsforce-node": "^3.1.0",
-        "@salesforce/kit": "^3.1.0",
-        "@salesforce/schemas": "^1.7.0",
-        "@salesforce/ts-types": "^2.0.9",
-        "ajv": "^8.12.0",
-        "change-case": "^4.1.2",
-        "faye": "^1.4.0",
-        "form-data": "^4.0.0",
-        "js2xmlparser": "^4.0.1",
-        "jsonwebtoken": "9.0.2",
-        "jszip": "3.10.1",
-        "pino": "^8.19.0",
-        "pino-abstract-transport": "^1.1.0",
-        "pino-pretty": "^10.3.1",
-        "proper-lockfile": "^4.1.2",
-        "semver": "^7.6.0",
-        "ts-retry-promise": "^0.7.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/@salesforce/ts-types": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.9.tgz",
-      "integrity": "sha512-boUD9jw5vQpTCPCCmK/NFTWjSuuW+lsaxOynkyNXLW+zxOc4GDjhtKc4j0vWZJQvolpafbyS8ZLFHZJvs12gYA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/change-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
-      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "capital-case": "^1.0.4",
-        "constant-case": "^3.0.4",
-        "dot-case": "^3.0.4",
-        "header-case": "^2.0.4",
-        "no-case": "^3.0.4",
-        "param-case": "^3.0.4",
-        "pascal-case": "^3.1.2",
-        "path-case": "^3.0.4",
-        "sentence-case": "^3.0.4",
-        "snake-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/constant-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
-      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case": "^2.0.2"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/@salesforce/apex-node/node_modules/faye": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
@@ -6511,39 +6399,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@salesforce/apex-node/node_modules/header-case": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
-      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-      "dependencies": {
-        "capital-case": "^1.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "node_modules/@salesforce/apex-node/node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@salesforce/apex-node/node_modules/minimatch": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
@@ -6566,66 +6421,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/@salesforce/apex-node/node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/path-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
-      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/sentence-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
-      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
     "node_modules/@salesforce/apex-node/node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -6636,41 +6431,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/snake-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "node_modules/@salesforce/apex-node/node_modules/upper-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
-      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/upper-case-first": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
-      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@salesforce/apex-tmlanguage": {
       "version": "1.8.0",
@@ -6757,20 +6517,19 @@
       "integrity": "sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww=="
     },
     "node_modules/@salesforce/core": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-6.7.4.tgz",
-      "integrity": "sha512-zB/dnhz/x9Kw6r1Ub6Uawc1zFHF84RfERv3UTcdZPtaaEodUQpZSu9avAUaGGEufWaNjPK+RRSgeZ1tG67g8qg==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.3.0.tgz",
+      "integrity": "sha512-c/gZLvKFHvgAv/Gyd4LjGGQykvGLn67QtCmdT7Hnm57bTDZoyr7XJXcaI+ILN0NO47guG1tEWP5eBvAi+u2DNA==",
       "dependencies": {
+        "@jsforce/jsforce-node": "^3.1.0",
         "@salesforce/kit": "^3.1.0",
-        "@salesforce/schemas": "^1.6.1",
+        "@salesforce/schemas": "^1.7.0",
         "@salesforce/ts-types": "^2.0.9",
-        "@types/semver": "^7.5.8",
         "ajv": "^8.12.0",
         "change-case": "^4.1.2",
         "faye": "^1.4.0",
         "form-data": "^4.0.0",
         "js2xmlparser": "^4.0.1",
-        "jsforce": "^2.0.0-beta.29",
         "jsonwebtoken": "9.0.2",
         "jszip": "3.10.1",
         "pino": "^8.19.0",
@@ -7576,33 +7335,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/@salesforce/core": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.2.0.tgz",
-      "integrity": "sha512-N/9hv7Vdr9sEuob9vo90odcQ7dJPtfOQVIE5R8vFcfaHK3W3ej9EpHsaV55PkaVG+hxRhZ2oOVA3UaVfp/diOw==",
-      "dependencies": {
-        "@jsforce/jsforce-node": "^3.1.0",
-        "@salesforce/kit": "^3.1.0",
-        "@salesforce/schemas": "^1.7.0",
-        "@salesforce/ts-types": "^2.0.9",
-        "ajv": "^8.12.0",
-        "change-case": "^4.1.2",
-        "faye": "^1.4.0",
-        "form-data": "^4.0.0",
-        "js2xmlparser": "^4.0.1",
-        "jsonwebtoken": "9.0.2",
-        "jszip": "3.10.1",
-        "pino": "^8.19.0",
-        "pino-abstract-transport": "^1.1.0",
-        "pino-pretty": "^10.3.1",
-        "proper-lockfile": "^4.1.2",
-        "semver": "^7.6.0",
-        "ts-retry-promise": "^0.7.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@salesforce/source-deploy-retrieve/node_modules/@salesforce/ts-types": {
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.9.tgz",
@@ -7612,117 +7344,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/change-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
-      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "capital-case": "^1.0.4",
-        "constant-case": "^3.0.4",
-        "dot-case": "^3.0.4",
-        "header-case": "^2.0.4",
-        "no-case": "^3.0.4",
-        "param-case": "^3.0.4",
-        "pascal-case": "^3.1.2",
-        "path-case": "^3.0.4",
-        "sentence-case": "^3.0.4",
-        "snake-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/constant-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
-      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case": "^2.0.2"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/faye": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
-      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
-      "dependencies": {
-        "asap": "*",
-        "csprng": "*",
-        "faye-websocket": ">=0.9.1",
-        "safe-buffer": "*",
-        "tough-cookie": "*",
-        "tunnel-agent": "*"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/header-case": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
-      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-      "dependencies": {
-        "capital-case": "^1.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@salesforce/source-deploy-retrieve/node_modules/minimatch": {
@@ -7736,100 +7357,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/path-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
-      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/sentence-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
-      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/snake-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/@salesforce/source-deploy-retrieve/node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/upper-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
-      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/upper-case-first": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
-      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@salesforce/source-tracking": {
       "version": "6.0.2",
@@ -7850,41 +7381,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@salesforce/source-tracking/node_modules/@salesforce/core": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.2.0.tgz",
-      "integrity": "sha512-N/9hv7Vdr9sEuob9vo90odcQ7dJPtfOQVIE5R8vFcfaHK3W3ej9EpHsaV55PkaVG+hxRhZ2oOVA3UaVfp/diOw==",
-      "dependencies": {
-        "@jsforce/jsforce-node": "^3.1.0",
-        "@salesforce/kit": "^3.1.0",
-        "@salesforce/schemas": "^1.7.0",
-        "@salesforce/ts-types": "^2.0.9",
-        "ajv": "^8.12.0",
-        "change-case": "^4.1.2",
-        "faye": "^1.4.0",
-        "form-data": "^4.0.0",
-        "js2xmlparser": "^4.0.1",
-        "jsonwebtoken": "9.0.2",
-        "jszip": "3.10.1",
-        "pino": "^8.19.0",
-        "pino-abstract-transport": "^1.1.0",
-        "pino-pretty": "^10.3.1",
-        "proper-lockfile": "^4.1.2",
-        "semver": "^7.6.0",
-        "ts-retry-promise": "^0.7.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/source-tracking/node_modules/@salesforce/core/node_modules/ts-retry-promise": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/ts-retry-promise/-/ts-retry-promise-0.7.1.tgz",
-      "integrity": "sha512-NhHOCZ2AQORvH42hOPO5UZxShlcuiRtm7P2jIq2L2RY3PBxw2mLnUsEdHrIslVBFya1v5aZmrR55lWkzo13LrQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@salesforce/source-tracking/node_modules/@salesforce/ts-types": {
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.9.tgz",
@@ -7894,186 +7390,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@salesforce/source-tracking/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@salesforce/source-tracking/node_modules/camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/source-tracking/node_modules/change-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
-      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "capital-case": "^1.0.4",
-        "constant-case": "^3.0.4",
-        "dot-case": "^3.0.4",
-        "header-case": "^2.0.4",
-        "no-case": "^3.0.4",
-        "param-case": "^3.0.4",
-        "pascal-case": "^3.1.2",
-        "path-case": "^3.0.4",
-        "sentence-case": "^3.0.4",
-        "snake-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/source-tracking/node_modules/constant-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
-      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case": "^2.0.2"
-      }
-    },
-    "node_modules/@salesforce/source-tracking/node_modules/dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/source-tracking/node_modules/faye": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
-      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
-      "dependencies": {
-        "asap": "*",
-        "csprng": "*",
-        "faye-websocket": ">=0.9.1",
-        "safe-buffer": "*",
-        "tough-cookie": "*",
-        "tunnel-agent": "*"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@salesforce/source-tracking/node_modules/header-case": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
-      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-      "dependencies": {
-        "capital-case": "^1.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/source-tracking/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "node_modules/@salesforce/source-tracking/node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/source-tracking/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@salesforce/source-tracking/node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/source-tracking/node_modules/param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/source-tracking/node_modules/pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/source-tracking/node_modules/path-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
-      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/source-tracking/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@salesforce/source-tracking/node_modules/sentence-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
-      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
-    "node_modules/@salesforce/source-tracking/node_modules/snake-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/@salesforce/source-tracking/node_modules/ts-retry-promise": {
@@ -8089,33 +7405,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
-    "node_modules/@salesforce/source-tracking/node_modules/upper-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
-      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/source-tracking/node_modules/upper-case-first": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
-      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/@salesforce/source-tracking/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "node_modules/@salesforce/templates": {
-      "version": "60.1.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-60.1.0.tgz",
-      "integrity": "sha512-gleKq/osf1vVfrh8s52sqA0U8Syx9PX31kAcMRJ2nc7k6tPY1TRMzGZVeuQc1twnx/XusWJ4dJfmO+uVvEXEhg==",
+      "version": "60.1.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-60.1.2.tgz",
+      "integrity": "sha512-n5TITtDxwOC2eEpOMdt3u7p554JQkDUOrhzGqlIz2fWGupMbh/hg6qj25V7rS2yKn10aGI8AYKhUDMp1ivuPaQ==",
       "dependencies": {
-        "@salesforce/core": "^6.1.0",
+        "@salesforce/core": "^7.0.0",
         "@salesforce/kit": "^3.0.15",
         "got": "^11.8.2",
         "hpagent": "^1.2.0",
@@ -12198,14 +11493,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/comment-json": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-3.0.3.tgz",
@@ -13218,16 +12505,6 @@
         "url": "https://opencollective.com/core-js"
       }
     },
-    "node_modules/core-js-pure": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.32.0.tgz",
-      "integrity": "sha512-qsev1H+dTNYpDUEURRuOXMvpdtAnNEvQWS/FMJ2Vb5AY8ZP4rAPQldkE27joykZPJTe0+IVgHZYh1P5Xu1/i1g==",
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -13555,16 +12832,6 @@
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "dev": true
-    },
-    "node_modules/csv-parse": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
-      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg=="
-    },
-    "node_modules/csv-stringify": {
-      "version": "5.6.5",
-      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.5.tgz",
-      "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A=="
     },
     "node_modules/cz-conventional-changelog": {
       "version": "3.3.0",
@@ -21798,182 +21065,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/jsforce": {
-      "version": "2.0.0-beta.29",
-      "resolved": "https://registry.npmjs.org/jsforce/-/jsforce-2.0.0-beta.29.tgz",
-      "integrity": "sha512-Fq7xjOYOikyozZZDQNTfzsAdhcO0rUXwtavsjM+cCYUFiCMVOJJavgco303zOsJk3v8sdAYnGgHyKckLIhnyAg==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@babel/runtime-corejs3": "^7.12.5",
-        "@types/node": "^12.19.9",
-        "abort-controller": "^3.0.0",
-        "base64url": "^3.0.1",
-        "commander": "^4.0.1",
-        "core-js": "^3.6.4",
-        "csv-parse": "^4.8.2",
-        "csv-stringify": "^5.3.4",
-        "faye": "^1.4.0",
-        "form-data": "^4.0.0",
-        "fs-extra": "^8.1.0",
-        "https-proxy-agent": "^5.0.0",
-        "inquirer": "^7.0.0",
-        "multistream": "^3.1.0",
-        "node-fetch": "^2.6.1",
-        "open": "^7.0.0",
-        "regenerator-runtime": "^0.13.3",
-        "strip-ansi": "^6.0.0",
-        "xml2js": "^0.5.0"
-      },
-      "bin": {
-        "jsforce": "bin/jsforce",
-        "jsforce-gen-schema": "bin/jsforce-gen-schema"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/jsforce/node_modules/@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
-    },
-    "node_modules/jsforce/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jsforce/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jsforce/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jsforce/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/jsforce/node_modules/faye": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
-      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
-      "dependencies": {
-        "asap": "*",
-        "csprng": "*",
-        "faye-websocket": ">=0.9.1",
-        "safe-buffer": "*",
-        "tough-cookie": "*",
-        "tunnel-agent": "*"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/jsforce/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jsforce/node_modules/inquirer": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
-      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
-      "dependencies": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^3.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.19",
-        "mute-stream": "0.0.8",
-        "run-async": "^2.4.0",
-        "rxjs": "^6.6.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "through": "^2.3.6"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/jsforce/node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
-    "node_modules/jsforce/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jsforce/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jsforce/node_modules/xml2js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -29033,21 +28124,6 @@
       },
       "engines": {
         "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/open": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
-      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
-      "dependencies": {
-        "is-docker": "^2.0.0",
-        "is-wsl": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -38765,7 +37841,7 @@
         "@salesforce/salesforcedx-utils-vscode": "60.9.0",
         "@salesforce/schemas": "^1.6.1",
         "@salesforce/source-deploy-retrieve": "11.0.1",
-        "@salesforce/templates": "^60.1.0",
+        "@salesforce/templates": "^60.1.2",
         "@salesforce/ts-types": "2.0.9",
         "adm-zip": "0.5.10",
         "applicationinsights": "1.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2641,6 +2641,87 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
+    "node_modules/@jsforce/jsforce-node": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jsforce/jsforce-node/-/jsforce-node-3.1.0.tgz",
+      "integrity": "sha512-xsn6Qj36YyhG7uCL9DOswZhqN/OVIpXm5s8AWD7V9hSJfp5ReebEsjT7a52ztEMmkUAYjWvZC5alBJr7jJCJig==",
+      "dependencies": {
+        "@sindresorhus/is": "^4",
+        "@types/node": "^18.15.3",
+        "abort-controller": "^3.0.0",
+        "base64url": "^3.0.1",
+        "csv-parse": "^5.5.2",
+        "csv-stringify": "^6.4.4",
+        "faye": "^1.4.0",
+        "form-data": "^4.0.0",
+        "fs-extra": "^8.1.0",
+        "https-proxy-agent": "^5.0.0",
+        "multistream": "^3.1.0",
+        "node-fetch": "^2.6.1",
+        "strip-ansi": "^6.0.0",
+        "xml2js": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jsforce/jsforce-node/node_modules/@types/node": {
+      "version": "18.19.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.31.tgz",
+      "integrity": "sha512-ArgCD39YpyyrtFKIqMDvjz79jto5fcI/SVUs2HwB+f0dAzq68yqOdyaSivLiLugSziTpNXLQrVb7RZFmdZzbhA==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@jsforce/jsforce-node/node_modules/csv-parse": {
+      "version": "5.5.5",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.5.5.tgz",
+      "integrity": "sha512-erCk7tyU3yLWAhk6wvKxnyPtftuy/6Ak622gOO7BCJ05+TYffnPCJF905wmOQm+BpkX54OdAl8pveJwUdpnCXQ=="
+    },
+    "node_modules/@jsforce/jsforce-node/node_modules/csv-stringify": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.4.6.tgz",
+      "integrity": "sha512-h2V2XZ3uOTLilF5dPIptgUfN/o2ia/80Ie0Lly18LAnw5s8Eb7kt8rfxSUy24AztJZas9f6DPZpVlzDUtFt/ag=="
+    },
+    "node_modules/@jsforce/jsforce-node/node_modules/faye": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
+      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
+      "dependencies": {
+        "asap": "*",
+        "csprng": "*",
+        "faye-websocket": ">=0.9.1",
+        "safe-buffer": "*",
+        "tough-cookie": "*",
+        "tunnel-agent": "*"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@jsforce/jsforce-node/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jsforce/jsforce-node/node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/@lerna/add": {
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/@lerna/add/-/add-5.5.4.tgz",
@@ -33418,6 +33499,11 @@
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
       "dev": true
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
     "node_modules/unique-filename": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
@@ -36633,7 +36719,7 @@
       "version": "60.9.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "6.7.4",
+        "@salesforce/core": "7.2.0",
         "@salesforce/salesforcedx-utils-vscode": "60.9.0",
         "jsforce": "2.0.0-beta.29",
         "shelljs": "0.8.5"
@@ -36673,6 +36759,44 @@
         "vscode": "^1.82.0"
       }
     },
+    "packages/salesforcedx-sobjects-faux-generator/node_modules/@salesforce/core": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.2.0.tgz",
+      "integrity": "sha512-N/9hv7Vdr9sEuob9vo90odcQ7dJPtfOQVIE5R8vFcfaHK3W3ej9EpHsaV55PkaVG+hxRhZ2oOVA3UaVfp/diOw==",
+      "dependencies": {
+        "@jsforce/jsforce-node": "^3.1.0",
+        "@salesforce/kit": "^3.1.0",
+        "@salesforce/schemas": "^1.7.0",
+        "@salesforce/ts-types": "^2.0.9",
+        "ajv": "^8.12.0",
+        "change-case": "^4.1.2",
+        "faye": "^1.4.0",
+        "form-data": "^4.0.0",
+        "js2xmlparser": "^4.0.1",
+        "jsonwebtoken": "9.0.2",
+        "jszip": "3.10.1",
+        "pino": "^8.19.0",
+        "pino-abstract-transport": "^1.1.0",
+        "pino-pretty": "^10.3.1",
+        "proper-lockfile": "^4.1.2",
+        "semver": "^7.6.0",
+        "ts-retry-promise": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/salesforcedx-sobjects-faux-generator/node_modules/@salesforce/ts-types": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.9.tgz",
+      "integrity": "sha512-boUD9jw5vQpTCPCCmK/NFTWjSuuW+lsaxOynkyNXLW+zxOc4GDjhtKc4j0vWZJQvolpafbyS8ZLFHZJvs12gYA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "packages/salesforcedx-sobjects-faux-generator/node_modules/@types/node": {
       "version": "18.18.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.6.tgz",
@@ -36688,6 +36812,212 @@
         "@types/glob": "*",
         "@types/node": "*"
       }
+    },
+    "packages/salesforcedx-sobjects-faux-generator/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "packages/salesforcedx-sobjects-faux-generator/node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-sobjects-faux-generator/node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-sobjects-faux-generator/node_modules/constant-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
+      }
+    },
+    "packages/salesforcedx-sobjects-faux-generator/node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-sobjects-faux-generator/node_modules/faye": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
+      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
+      "dependencies": {
+        "asap": "*",
+        "csprng": "*",
+        "faye-websocket": ">=0.9.1",
+        "safe-buffer": "*",
+        "tough-cookie": "*",
+        "tunnel-agent": "*"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "packages/salesforcedx-sobjects-faux-generator/node_modules/header-case": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "dependencies": {
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-sobjects-faux-generator/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "packages/salesforcedx-sobjects-faux-generator/node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-sobjects-faux-generator/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/salesforcedx-sobjects-faux-generator/node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-sobjects-faux-generator/node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-sobjects-faux-generator/node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-sobjects-faux-generator/node_modules/path-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-sobjects-faux-generator/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/salesforcedx-sobjects-faux-generator/node_modules/sentence-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "packages/salesforcedx-sobjects-faux-generator/node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-sobjects-faux-generator/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "packages/salesforcedx-sobjects-faux-generator/node_modules/upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-sobjects-faux-generator/node_modules/upper-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-sobjects-faux-generator/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "packages/salesforcedx-test-utils-vscode": {
       "name": "@salesforce/salesforcedx-test-utils-vscode",
@@ -36789,7 +37119,7 @@
       "version": "60.9.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "6.7.4",
+        "@salesforce/core": "7.2.0",
         "@salesforce/source-deploy-retrieve": "10.3.3",
         "@salesforce/source-tracking": "5.1.11",
         "applicationinsights": "1.0.7",
@@ -36824,6 +37154,58 @@
         "vscode": "^1.82.0"
       }
     },
+    "packages/salesforcedx-utils-vscode/node_modules/@salesforce/core": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.2.0.tgz",
+      "integrity": "sha512-N/9hv7Vdr9sEuob9vo90odcQ7dJPtfOQVIE5R8vFcfaHK3W3ej9EpHsaV55PkaVG+hxRhZ2oOVA3UaVfp/diOw==",
+      "dependencies": {
+        "@jsforce/jsforce-node": "^3.1.0",
+        "@salesforce/kit": "^3.1.0",
+        "@salesforce/schemas": "^1.7.0",
+        "@salesforce/ts-types": "^2.0.9",
+        "ajv": "^8.12.0",
+        "change-case": "^4.1.2",
+        "faye": "^1.4.0",
+        "form-data": "^4.0.0",
+        "js2xmlparser": "^4.0.1",
+        "jsonwebtoken": "9.0.2",
+        "jszip": "3.10.1",
+        "pino": "^8.19.0",
+        "pino-abstract-transport": "^1.1.0",
+        "pino-pretty": "^10.3.1",
+        "proper-lockfile": "^4.1.2",
+        "semver": "^7.6.0",
+        "ts-retry-promise": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/salesforcedx-utils-vscode/node_modules/@salesforce/core/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/salesforcedx-utils-vscode/node_modules/@salesforce/ts-types": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.9.tgz",
+      "integrity": "sha512-boUD9jw5vQpTCPCCmK/NFTWjSuuW+lsaxOynkyNXLW+zxOc4GDjhtKc4j0vWZJQvolpafbyS8ZLFHZJvs12gYA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "packages/salesforcedx-utils-vscode/node_modules/@types/cross-spawn": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.0.tgz",
@@ -36849,6 +37231,21 @@
         "@types/node": "*"
       }
     },
+    "packages/salesforcedx-utils-vscode/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "packages/salesforcedx-utils-vscode/node_modules/applicationinsights": {
       "version": "1.8.10",
       "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.8.10.tgz",
@@ -36858,6 +37255,44 @@
         "continuation-local-storage": "^3.2.1",
         "diagnostic-channel": "0.3.1",
         "diagnostic-channel-publishers": "0.4.4"
+      }
+    },
+    "packages/salesforcedx-utils-vscode/node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-utils-vscode/node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-utils-vscode/node_modules/constant-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
       }
     },
     "packages/salesforcedx-utils-vscode/node_modules/diagnostic-channel": {
@@ -36876,6 +37311,100 @@
         "diagnostic-channel": "*"
       }
     },
+    "packages/salesforcedx-utils-vscode/node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-utils-vscode/node_modules/faye": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
+      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
+      "dependencies": {
+        "asap": "*",
+        "csprng": "*",
+        "faye-websocket": ">=0.9.1",
+        "safe-buffer": "*",
+        "tough-cookie": "*",
+        "tunnel-agent": "*"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "packages/salesforcedx-utils-vscode/node_modules/header-case": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "dependencies": {
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-utils-vscode/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "packages/salesforcedx-utils-vscode/node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-utils-vscode/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/salesforcedx-utils-vscode/node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-utils-vscode/node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-utils-vscode/node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-utils-vscode/node_modules/path-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "packages/salesforcedx-utils-vscode/node_modules/semver": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
@@ -36883,6 +37412,51 @@
       "bin": {
         "semver": "bin/semver"
       }
+    },
+    "packages/salesforcedx-utils-vscode/node_modules/sentence-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "packages/salesforcedx-utils-vscode/node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-utils-vscode/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "packages/salesforcedx-utils-vscode/node_modules/upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-utils-vscode/node_modules/upper-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-utils-vscode/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "packages/salesforcedx-utils/node_modules/@types/node": {
       "version": "18.18.6",
@@ -37023,7 +37597,7 @@
       "dependencies": {
         "@salesforce/apex-node": "4.0.5",
         "@salesforce/apex-tmlanguage": "1.8.0",
-        "@salesforce/core": "6.7.4",
+        "@salesforce/core": "7.2.0",
         "@salesforce/salesforcedx-utils-vscode": "60.9.0",
         "expand-home-dir": "0.0.3",
         "find-java-home": "0.2.0",
@@ -37109,7 +37683,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/apex-node": "4.0.5",
-        "@salesforce/core": "6.7.4",
+        "@salesforce/core": "7.2.0",
         "@salesforce/salesforcedx-apex-replay-debugger": "60.9.0",
         "@salesforce/salesforcedx-utils": "60.9.0",
         "@salesforce/salesforcedx-utils-vscode": "60.9.0",
@@ -37146,11 +37720,293 @@
         "vscode": "^1.82.0"
       }
     },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/@salesforce/core": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.2.0.tgz",
+      "integrity": "sha512-N/9hv7Vdr9sEuob9vo90odcQ7dJPtfOQVIE5R8vFcfaHK3W3ej9EpHsaV55PkaVG+hxRhZ2oOVA3UaVfp/diOw==",
+      "dependencies": {
+        "@jsforce/jsforce-node": "^3.1.0",
+        "@salesforce/kit": "^3.1.0",
+        "@salesforce/schemas": "^1.7.0",
+        "@salesforce/ts-types": "^2.0.9",
+        "ajv": "^8.12.0",
+        "change-case": "^4.1.2",
+        "faye": "^1.4.0",
+        "form-data": "^4.0.0",
+        "js2xmlparser": "^4.0.1",
+        "jsonwebtoken": "9.0.2",
+        "jszip": "3.10.1",
+        "pino": "^8.19.0",
+        "pino-abstract-transport": "^1.1.0",
+        "pino-pretty": "^10.3.1",
+        "proper-lockfile": "^4.1.2",
+        "semver": "^7.6.0",
+        "ts-retry-promise": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/@salesforce/ts-types": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.9.tgz",
+      "integrity": "sha512-boUD9jw5vQpTCPCCmK/NFTWjSuuW+lsaxOynkyNXLW+zxOc4GDjhtKc4j0vWZJQvolpafbyS8ZLFHZJvs12gYA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/@types/node": {
       "version": "18.18.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.6.tgz",
       "integrity": "sha512-wf3Vz+jCmOQ2HV1YUJuCWdL64adYxumkrxtc+H1VUQlnQI04+5HtH+qZCOE21lBE7gIrt+CwX2Wv8Acrw5Ak6w==",
       "dev": true
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/constant-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/faye": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
+      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
+      "dependencies": {
+        "asap": "*",
+        "csprng": "*",
+        "faye-websocket": ">=0.9.1",
+        "safe-buffer": "*",
+        "tough-cookie": "*",
+        "tunnel-agent": "*"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/header-case": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "dependencies": {
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/path-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/sentence-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/upper-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/@salesforce/core": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.2.0.tgz",
+      "integrity": "sha512-N/9hv7Vdr9sEuob9vo90odcQ7dJPtfOQVIE5R8vFcfaHK3W3ej9EpHsaV55PkaVG+hxRhZ2oOVA3UaVfp/diOw==",
+      "dependencies": {
+        "@jsforce/jsforce-node": "^3.1.0",
+        "@salesforce/kit": "^3.1.0",
+        "@salesforce/schemas": "^1.7.0",
+        "@salesforce/ts-types": "^2.0.9",
+        "ajv": "^8.12.0",
+        "change-case": "^4.1.2",
+        "faye": "^1.4.0",
+        "form-data": "^4.0.0",
+        "js2xmlparser": "^4.0.1",
+        "jsonwebtoken": "9.0.2",
+        "jszip": "3.10.1",
+        "pino": "^8.19.0",
+        "pino-abstract-transport": "^1.1.0",
+        "pino-pretty": "^10.3.1",
+        "proper-lockfile": "^4.1.2",
+        "semver": "^7.6.0",
+        "ts-retry-promise": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/@salesforce/ts-types": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.9.tgz",
+      "integrity": "sha512-boUD9jw5vQpTCPCCmK/NFTWjSuuW+lsaxOynkyNXLW+zxOc4GDjhtKc4j0vWZJQvolpafbyS8ZLFHZJvs12gYA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "packages/salesforcedx-vscode-apex/node_modules/@types/node": {
       "version": "18.18.6",
@@ -37166,6 +38022,106 @@
       "dependencies": {
         "@types/glob": "*",
         "@types/node": "*"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/constant-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/faye": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
+      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
+      "dependencies": {
+        "asap": "*",
+        "csprng": "*",
+        "faye-websocket": ">=0.9.1",
+        "safe-buffer": "*",
+        "tough-cookie": "*",
+        "tunnel-agent": "*"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/header-case": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "dependencies": {
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
       }
     },
     "packages/salesforcedx-vscode-apex/node_modules/lru-cache": {
@@ -37190,10 +38146,46 @@
         "node": ">=10"
       }
     },
+    "packages/salesforcedx-vscode-apex/node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/path-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "packages/salesforcedx-vscode-apex/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -37202,6 +38194,46 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/sentence-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/upper-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
       }
     },
     "packages/salesforcedx-vscode-apex/node_modules/vscode-jsonrpc": {
@@ -37248,7 +38280,7 @@
       "version": "60.9.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "6.7.4",
+        "@salesforce/core": "7.2.0",
         "@salesforce/salesforcedx-sobjects-faux-generator": "60.9.0",
         "@salesforce/salesforcedx-utils-vscode": "60.9.0",
         "@salesforce/schemas": "^1.6.1",
@@ -37307,6 +38339,47 @@
         "vscode": "^1.82.0"
       }
     },
+    "packages/salesforcedx-vscode-core/node_modules/@salesforce/core": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.2.0.tgz",
+      "integrity": "sha512-N/9hv7Vdr9sEuob9vo90odcQ7dJPtfOQVIE5R8vFcfaHK3W3ej9EpHsaV55PkaVG+hxRhZ2oOVA3UaVfp/diOw==",
+      "dependencies": {
+        "@jsforce/jsforce-node": "^3.1.0",
+        "@salesforce/kit": "^3.1.0",
+        "@salesforce/schemas": "^1.7.0",
+        "@salesforce/ts-types": "^2.0.9",
+        "ajv": "^8.12.0",
+        "change-case": "^4.1.2",
+        "faye": "^1.4.0",
+        "form-data": "^4.0.0",
+        "js2xmlparser": "^4.0.1",
+        "jsonwebtoken": "9.0.2",
+        "jszip": "3.10.1",
+        "pino": "^8.19.0",
+        "pino-abstract-transport": "^1.1.0",
+        "pino-pretty": "^10.3.1",
+        "proper-lockfile": "^4.1.2",
+        "semver": "^7.6.0",
+        "ts-retry-promise": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/salesforcedx-vscode-core/node_modules/@salesforce/core/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "packages/salesforcedx-vscode-core/node_modules/@salesforce/ts-types": {
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.9.tgz",
@@ -37334,6 +38407,21 @@
         "@types/node": "*"
       }
     },
+    "packages/salesforcedx-vscode-core/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "packages/salesforcedx-vscode-core/node_modules/applicationinsights": {
       "version": "1.8.10",
       "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.8.10.tgz",
@@ -37354,6 +38442,44 @@
         "concat-map": "0.0.1"
       }
     },
+    "packages/salesforcedx-vscode-core/node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-core/node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-core/node_modules/constant-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
+      }
+    },
     "packages/salesforcedx-vscode-core/node_modules/diagnostic-channel": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.3.1.tgz",
@@ -37368,6 +38494,31 @@
       "integrity": "sha512-l126t01d2ZS9EreskvEtZPrcgstuvH3rbKy82oUhUrVmBaGx4hO9wECdl3cvZbKDYjMF3QJDB5z5dL9yWAjvZQ==",
       "peerDependencies": {
         "diagnostic-channel": "*"
+      }
+    },
+    "packages/salesforcedx-vscode-core/node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-core/node_modules/faye": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
+      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
+      "dependencies": {
+        "asap": "*",
+        "csprng": "*",
+        "faye-websocket": ">=0.9.1",
+        "safe-buffer": "*",
+        "tough-cookie": "*",
+        "tunnel-agent": "*"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "packages/salesforcedx-vscode-core/node_modules/glob": {
@@ -37389,6 +38540,39 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "packages/salesforcedx-vscode-core/node_modules/header-case": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "dependencies": {
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-core/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "packages/salesforcedx-vscode-core/node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-core/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "packages/salesforcedx-vscode-core/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -37400,6 +38584,42 @@
         "node": "*"
       }
     },
+    "packages/salesforcedx-vscode-core/node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-core/node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-core/node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-core/node_modules/path-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "packages/salesforcedx-vscode-core/node_modules/semver": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
@@ -37408,10 +38628,50 @@
         "semver": "bin/semver"
       }
     },
+    "packages/salesforcedx-vscode-core/node_modules/sentence-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "packages/salesforcedx-vscode-core/node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "packages/salesforcedx-vscode-core/node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "packages/salesforcedx-vscode-core/node_modules/upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-core/node_modules/upper-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-core/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "packages/salesforcedx-vscode-expanded": {
       "version": "60.9.0",
@@ -37425,7 +38685,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/aura-language-server": "4.8.0",
-        "@salesforce/core": "6.7.4",
+        "@salesforce/core": "7.2.0",
         "@salesforce/lightning-lsp-common": "4.8.0",
         "@salesforce/salesforcedx-utils-vscode": "60.9.0",
         "applicationinsights": "1.0.7",
@@ -37464,6 +38724,58 @@
         "vscode": "^1.82.0"
       }
     },
+    "packages/salesforcedx-vscode-lightning/node_modules/@salesforce/core": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.2.0.tgz",
+      "integrity": "sha512-N/9hv7Vdr9sEuob9vo90odcQ7dJPtfOQVIE5R8vFcfaHK3W3ej9EpHsaV55PkaVG+hxRhZ2oOVA3UaVfp/diOw==",
+      "dependencies": {
+        "@jsforce/jsforce-node": "^3.1.0",
+        "@salesforce/kit": "^3.1.0",
+        "@salesforce/schemas": "^1.7.0",
+        "@salesforce/ts-types": "^2.0.9",
+        "ajv": "^8.12.0",
+        "change-case": "^4.1.2",
+        "faye": "^1.4.0",
+        "form-data": "^4.0.0",
+        "js2xmlparser": "^4.0.1",
+        "jsonwebtoken": "9.0.2",
+        "jszip": "3.10.1",
+        "pino": "^8.19.0",
+        "pino-abstract-transport": "^1.1.0",
+        "pino-pretty": "^10.3.1",
+        "proper-lockfile": "^4.1.2",
+        "semver": "^7.6.0",
+        "ts-retry-promise": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/salesforcedx-vscode-lightning/node_modules/@salesforce/core/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/salesforcedx-vscode-lightning/node_modules/@salesforce/ts-types": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.9.tgz",
+      "integrity": "sha512-boUD9jw5vQpTCPCCmK/NFTWjSuuW+lsaxOynkyNXLW+zxOc4GDjhtKc4j0vWZJQvolpafbyS8ZLFHZJvs12gYA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "packages/salesforcedx-vscode-lightning/node_modules/@types/node": {
       "version": "18.18.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.6.tgz",
@@ -37476,6 +38788,21 @@
       "integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg==",
       "dev": true
     },
+    "packages/salesforcedx-vscode-lightning/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "packages/salesforcedx-vscode-lightning/node_modules/applicationinsights": {
       "version": "1.8.10",
       "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.8.10.tgz",
@@ -37485,6 +38812,44 @@
         "continuation-local-storage": "^3.2.1",
         "diagnostic-channel": "0.3.1",
         "diagnostic-channel-publishers": "0.4.4"
+      }
+    },
+    "packages/salesforcedx-vscode-lightning/node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-lightning/node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-lightning/node_modules/constant-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
       }
     },
     "packages/salesforcedx-vscode-lightning/node_modules/diagnostic-channel": {
@@ -37503,12 +38868,146 @@
         "diagnostic-channel": "*"
       }
     },
+    "packages/salesforcedx-vscode-lightning/node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-lightning/node_modules/faye": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
+      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
+      "dependencies": {
+        "asap": "*",
+        "csprng": "*",
+        "faye-websocket": ">=0.9.1",
+        "safe-buffer": "*",
+        "tough-cookie": "*",
+        "tunnel-agent": "*"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "packages/salesforcedx-vscode-lightning/node_modules/header-case": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "dependencies": {
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-lightning/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "packages/salesforcedx-vscode-lightning/node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-lightning/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/salesforcedx-vscode-lightning/node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-lightning/node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-lightning/node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-lightning/node_modules/path-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "packages/salesforcedx-vscode-lightning/node_modules/semver": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "packages/salesforcedx-vscode-lightning/node_modules/sentence-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "packages/salesforcedx-vscode-lightning/node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-lightning/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "packages/salesforcedx-vscode-lightning/node_modules/upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-lightning/node_modules/upper-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
       }
     },
     "packages/salesforcedx-vscode-lightning/node_modules/vscode-languageclient": {
@@ -37523,11 +39022,16 @@
         "vscode": "^1.30"
       }
     },
+    "packages/salesforcedx-vscode-lightning/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
     "packages/salesforcedx-vscode-lwc": {
       "version": "60.9.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "6.7.4",
+        "@salesforce/core": "7.2.0",
         "@salesforce/eslint-config-lwc": "3.5.1",
         "@salesforce/lightning-lsp-common": "4.8.0",
         "@salesforce/lwc-language-server": "4.8.0",
@@ -37579,6 +39083,73 @@
         "vscode": "^1.82.0"
       }
     },
+    "packages/salesforcedx-vscode-lwc/node_modules/@salesforce/core": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.2.0.tgz",
+      "integrity": "sha512-N/9hv7Vdr9sEuob9vo90odcQ7dJPtfOQVIE5R8vFcfaHK3W3ej9EpHsaV55PkaVG+hxRhZ2oOVA3UaVfp/diOw==",
+      "dependencies": {
+        "@jsforce/jsforce-node": "^3.1.0",
+        "@salesforce/kit": "^3.1.0",
+        "@salesforce/schemas": "^1.7.0",
+        "@salesforce/ts-types": "^2.0.9",
+        "ajv": "^8.12.0",
+        "change-case": "^4.1.2",
+        "faye": "^1.4.0",
+        "form-data": "^4.0.0",
+        "js2xmlparser": "^4.0.1",
+        "jsonwebtoken": "9.0.2",
+        "jszip": "3.10.1",
+        "pino": "^8.19.0",
+        "pino-abstract-transport": "^1.1.0",
+        "pino-pretty": "^10.3.1",
+        "proper-lockfile": "^4.1.2",
+        "semver": "^7.6.0",
+        "ts-retry-promise": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/@salesforce/core/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/@salesforce/core/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/@salesforce/ts-types": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.9.tgz",
+      "integrity": "sha512-boUD9jw5vQpTCPCCmK/NFTWjSuuW+lsaxOynkyNXLW+zxOc4GDjhtKc4j0vWZJQvolpafbyS8ZLFHZJvs12gYA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "packages/salesforcedx-vscode-lwc/node_modules/@types/node": {
       "version": "18.18.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.6.tgz",
@@ -37602,6 +39173,44 @@
         "diagnostic-channel-publishers": "0.4.4"
       }
     },
+    "packages/salesforcedx-vscode-lwc/node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/constant-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
+      }
+    },
     "packages/salesforcedx-vscode-lwc/node_modules/diagnostic-channel": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.3.1.tgz",
@@ -37618,12 +39227,146 @@
         "diagnostic-channel": "*"
       }
     },
+    "packages/salesforcedx-vscode-lwc/node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/faye": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
+      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
+      "dependencies": {
+        "asap": "*",
+        "csprng": "*",
+        "faye-websocket": ">=0.9.1",
+        "safe-buffer": "*",
+        "tough-cookie": "*",
+        "tunnel-agent": "*"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/header-case": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "dependencies": {
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/path-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "packages/salesforcedx-vscode-lwc/node_modules/semver": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/sentence-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-lwc/node_modules/upper-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
       }
     },
     "packages/salesforcedx-vscode-lwc/node_modules/vscode-languageclient": {
@@ -37644,12 +39387,17 @@
       "integrity": "sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ==",
       "dev": true
     },
+    "packages/salesforcedx-vscode-lwc/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
     "packages/salesforcedx-vscode-soql": {
       "version": "60.9.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/apex-tmlanguage": "1.6.0",
-        "@salesforce/core": "6.7.4",
+        "@salesforce/core": "7.2.0",
         "@salesforce/soql-builder-ui": "0.2.0",
         "@salesforce/soql-data-view": "0.1.0",
         "@salesforce/soql-language-server": "0.7.1",
@@ -37707,11 +39455,66 @@
         "node": ">=12.4.0"
       }
     },
+    "packages/salesforcedx-vscode-soql/node_modules/@salesforce/core": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.2.0.tgz",
+      "integrity": "sha512-N/9hv7Vdr9sEuob9vo90odcQ7dJPtfOQVIE5R8vFcfaHK3W3ej9EpHsaV55PkaVG+hxRhZ2oOVA3UaVfp/diOw==",
+      "dependencies": {
+        "@jsforce/jsforce-node": "^3.1.0",
+        "@salesforce/kit": "^3.1.0",
+        "@salesforce/schemas": "^1.7.0",
+        "@salesforce/ts-types": "^2.0.9",
+        "ajv": "^8.12.0",
+        "change-case": "^4.1.2",
+        "faye": "^1.4.0",
+        "form-data": "^4.0.0",
+        "js2xmlparser": "^4.0.1",
+        "jsonwebtoken": "9.0.2",
+        "jszip": "3.10.1",
+        "pino": "^8.19.0",
+        "pino-abstract-transport": "^1.1.0",
+        "pino-pretty": "^10.3.1",
+        "proper-lockfile": "^4.1.2",
+        "semver": "^7.6.0",
+        "ts-retry-promise": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/salesforcedx-vscode-soql/node_modules/@salesforce/core/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "packages/salesforcedx-vscode-soql/node_modules/@salesforce/core/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "packages/salesforcedx-vscode-soql/node_modules/@salesforce/ts-types": {
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.9.tgz",
       "integrity": "sha512-boUD9jw5vQpTCPCCmK/NFTWjSuuW+lsaxOynkyNXLW+zxOc4GDjhtKc4j0vWZJQvolpafbyS8ZLFHZJvs12gYA==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -38023,6 +39826,15 @@
         "concat-map": "0.0.1"
       }
     },
+    "packages/salesforcedx-vscode-soql/node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
     "packages/salesforcedx-vscode-soql/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -38037,6 +39849,25 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "packages/salesforcedx-vscode-soql/node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "packages/salesforcedx-vscode-soql/node_modules/color-convert": {
@@ -38056,6 +39887,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "packages/salesforcedx-vscode-soql/node_modules/constant-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
+      }
     },
     "packages/salesforcedx-vscode-soql/node_modules/diagnostic-channel": {
       "version": "0.3.1",
@@ -38082,6 +39923,15 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "packages/salesforcedx-vscode-soql/node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "packages/salesforcedx-vscode-soql/node_modules/escape-string-regexp": {
@@ -38189,6 +40039,22 @@
         "node": ">=4.0"
       }
     },
+    "packages/salesforcedx-vscode-soql/node_modules/faye": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
+      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
+      "dependencies": {
+        "asap": "*",
+        "csprng": "*",
+        "faye-websocket": ">=0.9.1",
+        "safe-buffer": "*",
+        "tough-cookie": "*",
+        "tunnel-agent": "*"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "packages/salesforcedx-vscode-soql/node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -38225,11 +40091,32 @@
         "node": ">=8"
       }
     },
+    "packages/salesforcedx-vscode-soql/node_modules/header-case": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "dependencies": {
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-soql/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "packages/salesforcedx-vscode-soql/node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "packages/salesforcedx-vscode-soql/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -38249,6 +40136,52 @@
         "node": "*"
       }
     },
+    "packages/salesforcedx-vscode-soql/node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-soql/node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-soql/node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-soql/node_modules/path-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-soql/node_modules/sentence-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
     "packages/salesforcedx-vscode-soql/node_modules/sinon": {
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-13.0.1.tgz",
@@ -38265,6 +40198,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/sinon"
+      }
+    },
+    "packages/salesforcedx-vscode-soql/node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "packages/salesforcedx-vscode-soql/node_modules/strip-ansi": {
@@ -38294,8 +40236,7 @@
     "packages/salesforcedx-vscode-soql/node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "packages/salesforcedx-vscode-soql/node_modules/type-fest": {
       "version": "0.20.2",
@@ -38307,6 +40248,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/salesforcedx-vscode-soql/node_modules/upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "packages/salesforcedx-vscode-soql/node_modules/upper-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
       }
     },
     "packages/salesforcedx-vscode-soql/node_modules/vscode-jsonrpc": {
@@ -38350,8 +40307,7 @@
     "packages/salesforcedx-vscode-soql/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "packages/salesforcedx-vscode-visualforce": {
       "version": "60.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6341,29 +6341,30 @@
       "integrity": "sha512-L4zUDy4lxF7+mM7DYPfOKZ4lqiAIquRx0vHAUJMBaxD4bCiT+70Df++aOfGO9FOJNctvPtT5bLrFRfdos4y4Mg=="
     },
     "node_modules/@salesforce/apex-node": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@salesforce/apex-node/-/apex-node-4.0.5.tgz",
-      "integrity": "sha512-lV/1VJgo6OsRlVBDk9MT8to2OWs4shOM/8nILd6jcxLfM7LW3k3Fjm62mZQrXe1jzxW7FN7FRWCC0e3Ys1LZPA==",
+      "version": "5.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/apex-node/-/apex-node-5.0.0-beta.0.tgz",
+      "integrity": "sha512-DF9WdxGUqtaixRdV0YDhOlXCLTxaCHa7d2U618Yg6r1V2O4whEX9+wUJ7H6CtZMSsj/EUPAudrpfneMP2u8v0w==",
       "dependencies": {
-        "@salesforce/core": "^6.7.4",
+        "@jsforce/jsforce-node": "^3.1.0",
+        "@salesforce/core": "^7.0.0",
         "@salesforce/kit": "^3.1.0",
         "@types/istanbul-reports": "^3.0.4",
         "faye": "1.4.0",
         "glob": "^10.3.10",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.1.6",
-        "jsforce": "^2.0.0-beta.29"
+        "istanbul-reports": "^3.1.6"
       },
       "engines": {
         "node": ">=18.18.2"
       }
     },
     "node_modules/@salesforce/apex-node/node_modules/@salesforce/core": {
-      "version": "6.7.6",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-6.7.6.tgz",
-      "integrity": "sha512-0ZZ1GgUQTwTs8/xa+hmZd+wwKXkK8MNcI2Kn20HmHShsweA2Jp3Yaxx0+EbRPqhSBARXso+TADSnsOjlZvQ3tg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.2.0.tgz",
+      "integrity": "sha512-N/9hv7Vdr9sEuob9vo90odcQ7dJPtfOQVIE5R8vFcfaHK3W3ej9EpHsaV55PkaVG+hxRhZ2oOVA3UaVfp/diOw==",
       "dependencies": {
+        "@jsforce/jsforce-node": "^3.1.0",
         "@salesforce/kit": "^3.1.0",
         "@salesforce/schemas": "^1.7.0",
         "@salesforce/ts-types": "^2.0.9",
@@ -6372,7 +6373,6 @@
         "faye": "^1.4.0",
         "form-data": "^4.0.0",
         "js2xmlparser": "^4.0.1",
-        "jsforce": "^2.0.0-beta.29",
         "jsonwebtoken": "9.0.2",
         "jszip": "3.10.1",
         "pino": "^8.19.0",
@@ -38074,7 +38074,7 @@
       "version": "60.9.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/apex-node": "4.0.5",
+        "@salesforce/apex-node": "5.0.0-beta.0",
         "@salesforce/apex-tmlanguage": "1.8.0",
         "@salesforce/core": "7.2.0",
         "@salesforce/salesforcedx-utils-vscode": "60.9.0",
@@ -38161,7 +38161,7 @@
       "version": "60.9.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/apex-node": "4.0.5",
+        "@salesforce/apex-node": "5.0.0-beta.0",
         "@salesforce/core": "7.2.0",
         "@salesforce/salesforcedx-apex-replay-debugger": "60.9.0",
         "@salesforce/salesforcedx-utils": "60.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5844,9 +5844,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-3.19.0.tgz",
-      "integrity": "sha512-Vup9DGMWlPeRVSpC76XCByfDwu1/09Xo2YTyzsquD9vnkeqIl0j0nxEjaYb6Ui3cifozLyKc/Td0+z/zz15/og==",
+      "version": "3.26.3",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-3.26.3.tgz",
+      "integrity": "sha512-e6Vwu+cb2Sn4qFFpmY1fQLRWIY5ugruMuN94xb7+kyUzxrirYjJATPhuCT1G5xj9Dk+hTMH+Sp6XcHcVTS1lHg==",
       "dependencies": {
         "@types/cli-progress": "^3.11.5",
         "ansi-escapes": "^4.3.2",
@@ -5857,13 +5857,14 @@
         "cli-progress": "^3.12.0",
         "color": "^4.2.3",
         "debug": "^4.3.4",
-        "ejs": "^3.1.9",
+        "ejs": "^3.1.10",
         "get-package-type": "^0.1.0",
         "globby": "^11.1.0",
         "hyperlinker": "^1.0.0",
         "indent-string": "^4.0.0",
         "is-wsl": "^2.2.0",
         "js-yaml": "^3.14.1",
+        "minimatch": "^9.0.4",
         "natural-orderby": "^2.0.3",
         "object-treeify": "^1.1.33",
         "password-prompt": "^1.1.3",
@@ -5987,6 +5988,20 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@oclif/core/node_modules/sprintf-js": {
@@ -7539,22 +7554,49 @@
       }
     },
     "node_modules/@salesforce/source-deploy-retrieve": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-10.3.3.tgz",
-      "integrity": "sha512-eugVWykEQNheOqGkYvCcGXmO8eCieEsGtMe0wZvwBjvclUYx8tFDOlWhOhF0XaSWuhv1/lxjp9oUxaBr6s7zYA==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-11.0.1.tgz",
+      "integrity": "sha512-vQ5Fytvsz5L3JXykOIphf11oWBtRGUdpUomSPN2pXep7BG3RYQ/C2AlSXL9dwHqaQmSm2B2KjMp2+y//bpNWcQ==",
       "dependencies": {
-        "@salesforce/core": "^6.5.1",
-        "@salesforce/kit": "^3.0.15",
+        "@salesforce/core": "^7.2.0",
+        "@salesforce/kit": "^3.1.0",
         "@salesforce/ts-types": "^2.0.9",
         "fast-levenshtein": "^3.0.0",
-        "fast-xml-parser": "^4.3.4",
+        "fast-xml-parser": "^4.3.6",
         "got": "^11.8.6",
         "graceful-fs": "^4.2.11",
         "ignore": "^5.3.1",
         "jszip": "^3.10.1",
         "mime": "2.6.0",
         "minimatch": "^5.1.6",
-        "proxy-agent": "^6.3.1",
+        "proxy-agent": "^6.4.0",
+        "ts-retry-promise": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/@salesforce/core": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.2.0.tgz",
+      "integrity": "sha512-N/9hv7Vdr9sEuob9vo90odcQ7dJPtfOQVIE5R8vFcfaHK3W3ej9EpHsaV55PkaVG+hxRhZ2oOVA3UaVfp/diOw==",
+      "dependencies": {
+        "@jsforce/jsforce-node": "^3.1.0",
+        "@salesforce/kit": "^3.1.0",
+        "@salesforce/schemas": "^1.7.0",
+        "@salesforce/ts-types": "^2.0.9",
+        "ajv": "^8.12.0",
+        "change-case": "^4.1.2",
+        "faye": "^1.4.0",
+        "form-data": "^4.0.0",
+        "js2xmlparser": "^4.0.1",
+        "jsonwebtoken": "9.0.2",
+        "jszip": "3.10.1",
+        "pino": "^8.19.0",
+        "pino-abstract-transport": "^1.1.0",
+        "pino-pretty": "^10.3.1",
+        "proper-lockfile": "^4.1.2",
+        "semver": "^7.6.0",
         "ts-retry-promise": "^0.7.1"
       },
       "engines": {
@@ -7572,6 +7614,117 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/constant-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
+      }
+    },
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/faye": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
+      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
+      "dependencies": {
+        "asap": "*",
+        "csprng": "*",
+        "faye-websocket": ">=0.9.1",
+        "safe-buffer": "*",
+        "tough-cookie": "*",
+        "tunnel-agent": "*"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/header-case": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "dependencies": {
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@salesforce/source-deploy-retrieve/node_modules/minimatch": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
@@ -7583,28 +7736,153 @@
         "node": ">=10"
       }
     },
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/path-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/sentence-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/@salesforce/source-deploy-retrieve/node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
-    "node_modules/@salesforce/source-tracking": {
-      "version": "5.1.11",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-tracking/-/source-tracking-5.1.11.tgz",
-      "integrity": "sha512-hT+gtdiCaHPG4Pl/z+3vv1S8xOVZXP3YOetUaeewyARraII2lMyf9PDb5dIZH17C+ZDucFmJdO1zTEpBPzZjGQ==",
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
       "dependencies": {
-        "@oclif/core": "^3.18.2",
-        "@salesforce/core": "^6.5.1",
-        "@salesforce/kit": "^3.0.15",
-        "@salesforce/source-deploy-retrieve": "^10.3.1",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/upper-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@salesforce/source-deploy-retrieve/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/@salesforce/source-tracking": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/source-tracking/-/source-tracking-6.0.2.tgz",
+      "integrity": "sha512-xviMFTp3DxClNeNfXOd0VnPcpRCGzATd/VpdTAYzby9Z7Lpd4tu6SR2btMoOQ/kRvyqVlmQC2p+DRCJJnbGe3w==",
+      "dependencies": {
+        "@oclif/core": "^3.26.2",
+        "@salesforce/core": "^7.2.0",
+        "@salesforce/kit": "^3.1.0",
+        "@salesforce/source-deploy-retrieve": "^11.0.0",
         "@salesforce/ts-types": "^2.0.9",
-        "fast-xml-parser": "^4.2.5",
+        "fast-xml-parser": "^4.3.6",
         "graceful-fs": "^4.2.11",
         "isomorphic-git": "1.23.0",
         "ts-retry-promise": "^0.8.0"
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@salesforce/source-tracking/node_modules/@salesforce/core": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.2.0.tgz",
+      "integrity": "sha512-N/9hv7Vdr9sEuob9vo90odcQ7dJPtfOQVIE5R8vFcfaHK3W3ej9EpHsaV55PkaVG+hxRhZ2oOVA3UaVfp/diOw==",
+      "dependencies": {
+        "@jsforce/jsforce-node": "^3.1.0",
+        "@salesforce/kit": "^3.1.0",
+        "@salesforce/schemas": "^1.7.0",
+        "@salesforce/ts-types": "^2.0.9",
+        "ajv": "^8.12.0",
+        "change-case": "^4.1.2",
+        "faye": "^1.4.0",
+        "form-data": "^4.0.0",
+        "js2xmlparser": "^4.0.1",
+        "jsonwebtoken": "9.0.2",
+        "jszip": "3.10.1",
+        "pino": "^8.19.0",
+        "pino-abstract-transport": "^1.1.0",
+        "pino-pretty": "^10.3.1",
+        "proper-lockfile": "^4.1.2",
+        "semver": "^7.6.0",
+        "ts-retry-promise": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@salesforce/source-tracking/node_modules/@salesforce/core/node_modules/ts-retry-promise": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ts-retry-promise/-/ts-retry-promise-0.7.1.tgz",
+      "integrity": "sha512-NhHOCZ2AQORvH42hOPO5UZxShlcuiRtm7P2jIq2L2RY3PBxw2mLnUsEdHrIslVBFya1v5aZmrR55lWkzo13LrQ==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@salesforce/source-tracking/node_modules/@salesforce/ts-types": {
@@ -7616,6 +7894,186 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@salesforce/source-tracking/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@salesforce/source-tracking/node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@salesforce/source-tracking/node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@salesforce/source-tracking/node_modules/constant-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
+      }
+    },
+    "node_modules/@salesforce/source-tracking/node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@salesforce/source-tracking/node_modules/faye": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
+      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
+      "dependencies": {
+        "asap": "*",
+        "csprng": "*",
+        "faye-websocket": ">=0.9.1",
+        "safe-buffer": "*",
+        "tough-cookie": "*",
+        "tunnel-agent": "*"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@salesforce/source-tracking/node_modules/header-case": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "dependencies": {
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@salesforce/source-tracking/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/@salesforce/source-tracking/node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@salesforce/source-tracking/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@salesforce/source-tracking/node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@salesforce/source-tracking/node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@salesforce/source-tracking/node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@salesforce/source-tracking/node_modules/path-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@salesforce/source-tracking/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@salesforce/source-tracking/node_modules/sentence-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "node_modules/@salesforce/source-tracking/node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/@salesforce/source-tracking/node_modules/ts-retry-promise": {
@@ -7630,6 +8088,27 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@salesforce/source-tracking/node_modules/upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@salesforce/source-tracking/node_modules/upper-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@salesforce/source-tracking/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@salesforce/templates": {
       "version": "60.1.0",
@@ -13878,9 +14357,9 @@
       }
     },
     "node_modules/ejs": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
-      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "dependencies": {
         "jake": "^10.8.5"
       },
@@ -37121,7 +37600,7 @@
       "dependencies": {
         "@salesforce/core": "7.2.0",
         "@salesforce/source-deploy-retrieve": "11.0.1",
-        "@salesforce/source-tracking": "5.1.11",
+        "@salesforce/source-tracking": "6.0.2",
         "applicationinsights": "1.0.7",
         "cross-spawn": "7.0.3",
         "rxjs": "^5.4.1",
@@ -37193,29 +37672,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "packages/salesforcedx-utils-vscode/node_modules/@salesforce/source-deploy-retrieve": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-11.0.1.tgz",
-      "integrity": "sha512-vQ5Fytvsz5L3JXykOIphf11oWBtRGUdpUomSPN2pXep7BG3RYQ/C2AlSXL9dwHqaQmSm2B2KjMp2+y//bpNWcQ==",
-      "dependencies": {
-        "@salesforce/core": "^7.2.0",
-        "@salesforce/kit": "^3.1.0",
-        "@salesforce/ts-types": "^2.0.9",
-        "fast-levenshtein": "^3.0.0",
-        "fast-xml-parser": "^4.3.6",
-        "got": "^11.8.6",
-        "graceful-fs": "^4.2.11",
-        "ignore": "^5.3.1",
-        "jszip": "^3.10.1",
-        "mime": "2.6.0",
-        "minimatch": "^5.1.6",
-        "proxy-agent": "^6.4.0",
-        "ts-retry-promise": "^0.7.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "packages/salesforcedx-utils-vscode/node_modules/@salesforce/ts-types": {
@@ -37387,17 +37843,6 @@
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dependencies": {
         "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/salesforcedx-utils-vscode/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=10"
@@ -38409,48 +38854,6 @@
       },
       "bin": {
         "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/salesforcedx-vscode-core/node_modules/@salesforce/source-deploy-retrieve": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-11.0.1.tgz",
-      "integrity": "sha512-vQ5Fytvsz5L3JXykOIphf11oWBtRGUdpUomSPN2pXep7BG3RYQ/C2AlSXL9dwHqaQmSm2B2KjMp2+y//bpNWcQ==",
-      "dependencies": {
-        "@salesforce/core": "^7.2.0",
-        "@salesforce/kit": "^3.1.0",
-        "@salesforce/ts-types": "^2.0.9",
-        "fast-levenshtein": "^3.0.0",
-        "fast-xml-parser": "^4.3.6",
-        "got": "^11.8.6",
-        "graceful-fs": "^4.2.11",
-        "ignore": "^5.3.1",
-        "jszip": "^3.10.1",
-        "mime": "2.6.0",
-        "minimatch": "^5.1.6",
-        "proxy-agent": "^6.4.0",
-        "ts-retry-promise": "^0.7.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/salesforcedx-vscode-core/node_modules/@salesforce/source-deploy-retrieve/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "packages/salesforcedx-vscode-core/node_modules/@salesforce/source-deploy-retrieve/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6329,12 +6329,12 @@
       "integrity": "sha512-L4zUDy4lxF7+mM7DYPfOKZ4lqiAIquRx0vHAUJMBaxD4bCiT+70Df++aOfGO9FOJNctvPtT5bLrFRfdos4y4Mg=="
     },
     "node_modules/@salesforce/apex-node": {
-      "version": "5.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/apex-node/-/apex-node-5.0.0-beta.0.tgz",
-      "integrity": "sha512-DF9WdxGUqtaixRdV0YDhOlXCLTxaCHa7d2U618Yg6r1V2O4whEX9+wUJ7H6CtZMSsj/EUPAudrpfneMP2u8v0w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/apex-node/-/apex-node-6.0.0.tgz",
+      "integrity": "sha512-vgOmgfsF4BO1nDljSstcUncAJKRJ31OolsTIyl0FgP3TMnTGedF5SvkePoX+uJ0SujuF0qzy2YnMLA0XNnAwAg==",
       "dependencies": {
         "@jsforce/jsforce-node": "^3.1.0",
-        "@salesforce/core": "^7.0.0",
+        "@salesforce/core": "^7.2.0",
         "@salesforce/kit": "^3.1.0",
         "@types/istanbul-reports": "^3.0.4",
         "faye": "1.4.0",
@@ -37158,7 +37158,7 @@
       "version": "60.10.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/apex-node": "5.0.0-beta.0",
+        "@salesforce/apex-node": "6.0.0",
         "@salesforce/apex-tmlanguage": "1.8.0",
         "@salesforce/core": "7.2.0",
         "@salesforce/salesforcedx-utils-vscode": "60.10.0",
@@ -37245,7 +37245,7 @@
       "version": "60.10.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/apex-node": "5.0.0-beta.0",
+        "@salesforce/apex-node": "6.0.0",
         "@salesforce/core": "7.2.0",
         "@salesforce/salesforcedx-apex-replay-debugger": "60.10.0",
         "@salesforce/salesforcedx-utils": "60.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37198,9 +37198,9 @@
       "version": "60.9.0",
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@jsforce/jsforce-node": "3.1.0",
         "@salesforce/core": "7.2.0",
         "@salesforce/salesforcedx-utils-vscode": "60.9.0",
-        "jsforce": "2.0.0-beta.29",
         "shelljs": "0.8.5"
       },
       "devDependencies": {
@@ -38759,6 +38759,7 @@
       "version": "60.9.0",
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@jsforce/jsforce-node": "3.1.0",
         "@salesforce/core": "7.2.0",
         "@salesforce/salesforcedx-sobjects-faux-generator": "60.9.0",
         "@salesforce/salesforcedx-utils-vscode": "60.9.0",
@@ -38769,7 +38770,6 @@
         "adm-zip": "0.5.10",
         "applicationinsights": "1.0.7",
         "glob": "^7.1.2",
-        "jsforce": "2.0.0-beta.29",
         "rxjs": "^5.4.1",
         "sanitize-filename": "^1.6.1",
         "shelljs": "0.8.5"
@@ -39875,13 +39875,13 @@
       "version": "60.9.0",
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@jsforce/jsforce-node": "3.1.0",
         "@salesforce/apex-tmlanguage": "1.6.0",
         "@salesforce/core": "7.2.0",
         "@salesforce/soql-builder-ui": "0.2.0",
         "@salesforce/soql-data-view": "0.1.0",
         "@salesforce/soql-language-server": "0.7.1",
-        "@salesforce/soql-model": "0.2.3",
-        "jsforce": "2.0.0-beta.29"
+        "@salesforce/soql-model": "0.2.3"
       },
       "devDependencies": {
         "@salesforce/salesforcedx-sobjects-faux-generator": "60.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2630,9 +2630,9 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@jsforce/jsforce-node": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@jsforce/jsforce-node/-/jsforce-node-3.1.0.tgz",
-      "integrity": "sha512-xsn6Qj36YyhG7uCL9DOswZhqN/OVIpXm5s8AWD7V9hSJfp5ReebEsjT7a52ztEMmkUAYjWvZC5alBJr7jJCJig==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@jsforce/jsforce-node/-/jsforce-node-3.2.0.tgz",
+      "integrity": "sha512-3GjWNgWs0HFajVhIhwvBPb0B45o500wTBNEBYxy8XjeeRra+qw8A9xUrfVU7TAGev8kXuKhjJwaTiSzThpEnew==",
       "dependencies": {
         "@sindresorhus/is": "^4",
         "@types/node": "^18.15.3",
@@ -5832,9 +5832,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "3.26.3",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-3.26.3.tgz",
-      "integrity": "sha512-e6Vwu+cb2Sn4qFFpmY1fQLRWIY5ugruMuN94xb7+kyUzxrirYjJATPhuCT1G5xj9Dk+hTMH+Sp6XcHcVTS1lHg==",
+      "version": "3.26.4",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-3.26.4.tgz",
+      "integrity": "sha512-ntfo2ut7enNtAn/jB/dryMUPBM2Fh8Fydmi3k/Ybo6lCGU/hmsPFkBRjCEJAQMyNkK2yVZARaWogdOrcVgFz+w==",
       "dependencies": {
         "@types/cli-progress": "^3.11.5",
         "ansi-escapes": "^4.3.2",
@@ -6517,12 +6517,12 @@
       "integrity": "sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww=="
     },
     "node_modules/@salesforce/core": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.3.0.tgz",
-      "integrity": "sha512-c/gZLvKFHvgAv/Gyd4LjGGQykvGLn67QtCmdT7Hnm57bTDZoyr7XJXcaI+ILN0NO47guG1tEWP5eBvAi+u2DNA==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.3.1.tgz",
+      "integrity": "sha512-jdc0GOUlV4xvyF9dPbBKNPDvQc06uj5YHFEHvdhCAFtCvqgtubpDzlyDppac2kdKujh4c7UH2KreboNvJ3LsoQ==",
       "dependencies": {
         "@jsforce/jsforce-node": "^3.1.0",
-        "@salesforce/kit": "^3.1.0",
+        "@salesforce/kit": "^3.1.1",
         "@salesforce/schemas": "^1.7.0",
         "@salesforce/ts-types": "^2.0.9",
         "ajv": "^8.12.0",
@@ -6827,9 +6827,9 @@
       }
     },
     "node_modules/@salesforce/kit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/kit/-/kit-3.1.0.tgz",
-      "integrity": "sha512-X2d9O/U2wdQBXIrtVqQdMwo872Cv+qkYFzF0W+AQKG/LEe9cngnOzUVDYNkGD9tq3jcl+oenHXYuVDpkMhxTwA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/kit/-/kit-3.1.1.tgz",
+      "integrity": "sha512-Cjkh+USp5PtdZmD30r1Y7d+USpIhQz9B48w76esBtYpgqzhyj806LHkVgEfmorLNq2Qe8EO5rtUYd+XZ3rnV9w==",
       "dependencies": {
         "@salesforce/ts-types": "^2.0.9",
         "tslib": "^2.6.2"
@@ -7313,12 +7313,12 @@
       }
     },
     "node_modules/@salesforce/source-deploy-retrieve": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-11.0.1.tgz",
-      "integrity": "sha512-vQ5Fytvsz5L3JXykOIphf11oWBtRGUdpUomSPN2pXep7BG3RYQ/C2AlSXL9dwHqaQmSm2B2KjMp2+y//bpNWcQ==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-11.1.2.tgz",
+      "integrity": "sha512-QhRft7U/XMBDaZTbzacbHH4sapTW/d25V3Hiwua2lg/Ce6hEj/5w6l8LlO5UAyRpRMaMy2LfaTRygu+rT3AS8g==",
       "dependencies": {
-        "@salesforce/core": "^7.2.0",
-        "@salesforce/kit": "^3.1.0",
+        "@salesforce/core": "^7.3.1",
+        "@salesforce/kit": "^3.1.1",
         "@salesforce/ts-types": "^2.0.9",
         "fast-levenshtein": "^3.0.0",
         "fast-xml-parser": "^4.3.6",
@@ -7328,8 +7328,7 @@
         "jszip": "^3.10.1",
         "mime": "2.6.0",
         "minimatch": "^5.1.6",
-        "proxy-agent": "^6.4.0",
-        "ts-retry-promise": "^0.7.1"
+        "proxy-agent": "^6.4.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -7363,14 +7362,14 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@salesforce/source-tracking": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-tracking/-/source-tracking-6.0.2.tgz",
-      "integrity": "sha512-xviMFTp3DxClNeNfXOd0VnPcpRCGzATd/VpdTAYzby9Z7Lpd4tu6SR2btMoOQ/kRvyqVlmQC2p+DRCJJnbGe3w==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@salesforce/source-tracking/-/source-tracking-6.0.4.tgz",
+      "integrity": "sha512-4+QFC6hm2MHCUsQdgSNydSoyi9zJaFl1S6rwJl/HTGeISs3g8w3tI+SeskmpZCoXRVnNJxCHwHT3kAPhZbuFlg==",
       "dependencies": {
-        "@oclif/core": "^3.26.2",
-        "@salesforce/core": "^7.2.0",
-        "@salesforce/kit": "^3.1.0",
-        "@salesforce/source-deploy-retrieve": "^11.0.0",
+        "@oclif/core": "^3.26.4",
+        "@salesforce/core": "^7.3.0",
+        "@salesforce/kit": "^3.1.1",
+        "@salesforce/source-deploy-retrieve": "^11.0.1",
         "@salesforce/ts-types": "^2.0.9",
         "fast-xml-parser": "^4.3.6",
         "graceful-fs": "^4.2.11",
@@ -36282,8 +36281,8 @@
       "version": "60.10.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@jsforce/jsforce-node": "3.1.0",
-        "@salesforce/core": "7.2.0",
+        "@jsforce/jsforce-node": "3.2.0",
+        "@salesforce/core": "7.3.1",
         "@salesforce/salesforcedx-utils-vscode": "60.10.0",
         "shelljs": "0.8.5"
       },
@@ -36322,44 +36321,6 @@
         "vscode": "^1.82.0"
       }
     },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/@salesforce/core": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.2.0.tgz",
-      "integrity": "sha512-N/9hv7Vdr9sEuob9vo90odcQ7dJPtfOQVIE5R8vFcfaHK3W3ej9EpHsaV55PkaVG+hxRhZ2oOVA3UaVfp/diOw==",
-      "dependencies": {
-        "@jsforce/jsforce-node": "^3.1.0",
-        "@salesforce/kit": "^3.1.0",
-        "@salesforce/schemas": "^1.7.0",
-        "@salesforce/ts-types": "^2.0.9",
-        "ajv": "^8.12.0",
-        "change-case": "^4.1.2",
-        "faye": "^1.4.0",
-        "form-data": "^4.0.0",
-        "js2xmlparser": "^4.0.1",
-        "jsonwebtoken": "9.0.2",
-        "jszip": "3.10.1",
-        "pino": "^8.19.0",
-        "pino-abstract-transport": "^1.1.0",
-        "pino-pretty": "^10.3.1",
-        "proper-lockfile": "^4.1.2",
-        "semver": "^7.6.0",
-        "ts-retry-promise": "^0.7.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/@salesforce/ts-types": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.9.tgz",
-      "integrity": "sha512-boUD9jw5vQpTCPCCmK/NFTWjSuuW+lsaxOynkyNXLW+zxOc4GDjhtKc4j0vWZJQvolpafbyS8ZLFHZJvs12gYA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "packages/salesforcedx-sobjects-faux-generator/node_modules/@types/node": {
       "version": "18.18.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.6.tgz",
@@ -36375,212 +36336,6 @@
         "@types/glob": "*",
         "@types/node": "*"
       }
-    },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/change-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
-      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "capital-case": "^1.0.4",
-        "constant-case": "^3.0.4",
-        "dot-case": "^3.0.4",
-        "header-case": "^2.0.4",
-        "no-case": "^3.0.4",
-        "param-case": "^3.0.4",
-        "pascal-case": "^3.1.2",
-        "path-case": "^3.0.4",
-        "sentence-case": "^3.0.4",
-        "snake-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/constant-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
-      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case": "^2.0.2"
-      }
-    },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/faye": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
-      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
-      "dependencies": {
-        "asap": "*",
-        "csprng": "*",
-        "faye-websocket": ">=0.9.1",
-        "safe-buffer": "*",
-        "tough-cookie": "*",
-        "tunnel-agent": "*"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/header-case": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
-      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-      "dependencies": {
-        "capital-case": "^1.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/path-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
-      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/sentence-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
-      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/snake-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/upper-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
-      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/upper-case-first": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
-      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-sobjects-faux-generator/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "packages/salesforcedx-test-utils-vscode": {
       "name": "@salesforce/salesforcedx-test-utils-vscode",
@@ -36682,9 +36437,9 @@
       "version": "60.10.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "7.2.0",
-        "@salesforce/source-deploy-retrieve": "11.0.1",
-        "@salesforce/source-tracking": "6.0.2",
+        "@salesforce/core": "7.3.1",
+        "@salesforce/source-deploy-retrieve": "11.1.2",
+        "@salesforce/source-tracking": "6.0.4",
         "applicationinsights": "1.0.7",
         "cross-spawn": "7.0.3",
         "rxjs": "^5.4.1",
@@ -36717,58 +36472,6 @@
         "vscode": "^1.82.0"
       }
     },
-    "packages/salesforcedx-utils-vscode/node_modules/@salesforce/core": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.2.0.tgz",
-      "integrity": "sha512-N/9hv7Vdr9sEuob9vo90odcQ7dJPtfOQVIE5R8vFcfaHK3W3ej9EpHsaV55PkaVG+hxRhZ2oOVA3UaVfp/diOw==",
-      "dependencies": {
-        "@jsforce/jsforce-node": "^3.1.0",
-        "@salesforce/kit": "^3.1.0",
-        "@salesforce/schemas": "^1.7.0",
-        "@salesforce/ts-types": "^2.0.9",
-        "ajv": "^8.12.0",
-        "change-case": "^4.1.2",
-        "faye": "^1.4.0",
-        "form-data": "^4.0.0",
-        "js2xmlparser": "^4.0.1",
-        "jsonwebtoken": "9.0.2",
-        "jszip": "3.10.1",
-        "pino": "^8.19.0",
-        "pino-abstract-transport": "^1.1.0",
-        "pino-pretty": "^10.3.1",
-        "proper-lockfile": "^4.1.2",
-        "semver": "^7.6.0",
-        "ts-retry-promise": "^0.7.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/salesforcedx-utils-vscode/node_modules/@salesforce/core/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/salesforcedx-utils-vscode/node_modules/@salesforce/ts-types": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.9.tgz",
-      "integrity": "sha512-boUD9jw5vQpTCPCCmK/NFTWjSuuW+lsaxOynkyNXLW+zxOc4GDjhtKc4j0vWZJQvolpafbyS8ZLFHZJvs12gYA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "packages/salesforcedx-utils-vscode/node_modules/@types/cross-spawn": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.0.tgz",
@@ -36794,21 +36497,6 @@
         "@types/node": "*"
       }
     },
-    "packages/salesforcedx-utils-vscode/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "packages/salesforcedx-utils-vscode/node_modules/applicationinsights": {
       "version": "1.8.10",
       "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.8.10.tgz",
@@ -36818,44 +36506,6 @@
         "continuation-local-storage": "^3.2.1",
         "diagnostic-channel": "0.3.1",
         "diagnostic-channel-publishers": "0.4.4"
-      }
-    },
-    "packages/salesforcedx-utils-vscode/node_modules/camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-utils-vscode/node_modules/change-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
-      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "capital-case": "^1.0.4",
-        "constant-case": "^3.0.4",
-        "dot-case": "^3.0.4",
-        "header-case": "^2.0.4",
-        "no-case": "^3.0.4",
-        "param-case": "^3.0.4",
-        "pascal-case": "^3.1.2",
-        "path-case": "^3.0.4",
-        "sentence-case": "^3.0.4",
-        "snake-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-utils-vscode/node_modules/constant-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
-      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case": "^2.0.2"
       }
     },
     "packages/salesforcedx-utils-vscode/node_modules/diagnostic-channel": {
@@ -36874,100 +36524,6 @@
         "diagnostic-channel": "*"
       }
     },
-    "packages/salesforcedx-utils-vscode/node_modules/dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-utils-vscode/node_modules/faye": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
-      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
-      "dependencies": {
-        "asap": "*",
-        "csprng": "*",
-        "faye-websocket": ">=0.9.1",
-        "safe-buffer": "*",
-        "tough-cookie": "*",
-        "tunnel-agent": "*"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "packages/salesforcedx-utils-vscode/node_modules/header-case": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
-      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-      "dependencies": {
-        "capital-case": "^1.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-utils-vscode/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "packages/salesforcedx-utils-vscode/node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-utils-vscode/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/salesforcedx-utils-vscode/node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-utils-vscode/node_modules/param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-utils-vscode/node_modules/pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-utils-vscode/node_modules/path-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
-      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "packages/salesforcedx-utils-vscode/node_modules/semver": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
@@ -36975,51 +36531,6 @@
       "bin": {
         "semver": "bin/semver"
       }
-    },
-    "packages/salesforcedx-utils-vscode/node_modules/sentence-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
-      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
-    "packages/salesforcedx-utils-vscode/node_modules/snake-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-utils-vscode/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "packages/salesforcedx-utils-vscode/node_modules/upper-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
-      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-utils-vscode/node_modules/upper-case-first": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
-      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-utils-vscode/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "packages/salesforcedx-utils/node_modules/@types/node": {
       "version": "18.18.6",
@@ -37160,7 +36671,7 @@
       "dependencies": {
         "@salesforce/apex-node": "6.0.0",
         "@salesforce/apex-tmlanguage": "1.8.0",
-        "@salesforce/core": "7.2.0",
+        "@salesforce/core": "7.3.1",
         "@salesforce/salesforcedx-utils-vscode": "60.10.0",
         "expand-home-dir": "0.0.3",
         "find-java-home": "0.2.0",
@@ -37246,7 +36757,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/apex-node": "6.0.0",
-        "@salesforce/core": "7.2.0",
+        "@salesforce/core": "7.3.1",
         "@salesforce/salesforcedx-apex-replay-debugger": "60.10.0",
         "@salesforce/salesforcedx-utils": "60.10.0",
         "@salesforce/salesforcedx-utils-vscode": "60.10.0",
@@ -37283,293 +36794,11 @@
         "vscode": "^1.82.0"
       }
     },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/@salesforce/core": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.2.0.tgz",
-      "integrity": "sha512-N/9hv7Vdr9sEuob9vo90odcQ7dJPtfOQVIE5R8vFcfaHK3W3ej9EpHsaV55PkaVG+hxRhZ2oOVA3UaVfp/diOw==",
-      "dependencies": {
-        "@jsforce/jsforce-node": "^3.1.0",
-        "@salesforce/kit": "^3.1.0",
-        "@salesforce/schemas": "^1.7.0",
-        "@salesforce/ts-types": "^2.0.9",
-        "ajv": "^8.12.0",
-        "change-case": "^4.1.2",
-        "faye": "^1.4.0",
-        "form-data": "^4.0.0",
-        "js2xmlparser": "^4.0.1",
-        "jsonwebtoken": "9.0.2",
-        "jszip": "3.10.1",
-        "pino": "^8.19.0",
-        "pino-abstract-transport": "^1.1.0",
-        "pino-pretty": "^10.3.1",
-        "proper-lockfile": "^4.1.2",
-        "semver": "^7.6.0",
-        "ts-retry-promise": "^0.7.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/@salesforce/ts-types": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.9.tgz",
-      "integrity": "sha512-boUD9jw5vQpTCPCCmK/NFTWjSuuW+lsaxOynkyNXLW+zxOc4GDjhtKc4j0vWZJQvolpafbyS8ZLFHZJvs12gYA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/@types/node": {
       "version": "18.18.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.6.tgz",
       "integrity": "sha512-wf3Vz+jCmOQ2HV1YUJuCWdL64adYxumkrxtc+H1VUQlnQI04+5HtH+qZCOE21lBE7gIrt+CwX2Wv8Acrw5Ak6w==",
       "dev": true
-    },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/change-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
-      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "capital-case": "^1.0.4",
-        "constant-case": "^3.0.4",
-        "dot-case": "^3.0.4",
-        "header-case": "^2.0.4",
-        "no-case": "^3.0.4",
-        "param-case": "^3.0.4",
-        "pascal-case": "^3.1.2",
-        "path-case": "^3.0.4",
-        "sentence-case": "^3.0.4",
-        "snake-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/constant-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
-      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case": "^2.0.2"
-      }
-    },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/faye": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
-      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
-      "dependencies": {
-        "asap": "*",
-        "csprng": "*",
-        "faye-websocket": ">=0.9.1",
-        "safe-buffer": "*",
-        "tough-cookie": "*",
-        "tunnel-agent": "*"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/header-case": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
-      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-      "dependencies": {
-        "capital-case": "^1.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/path-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
-      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/sentence-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
-      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/snake-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/upper-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
-      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/upper-case-first": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
-      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
-    "packages/salesforcedx-vscode-apex/node_modules/@salesforce/core": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.2.0.tgz",
-      "integrity": "sha512-N/9hv7Vdr9sEuob9vo90odcQ7dJPtfOQVIE5R8vFcfaHK3W3ej9EpHsaV55PkaVG+hxRhZ2oOVA3UaVfp/diOw==",
-      "dependencies": {
-        "@jsforce/jsforce-node": "^3.1.0",
-        "@salesforce/kit": "^3.1.0",
-        "@salesforce/schemas": "^1.7.0",
-        "@salesforce/ts-types": "^2.0.9",
-        "ajv": "^8.12.0",
-        "change-case": "^4.1.2",
-        "faye": "^1.4.0",
-        "form-data": "^4.0.0",
-        "js2xmlparser": "^4.0.1",
-        "jsonwebtoken": "9.0.2",
-        "jszip": "3.10.1",
-        "pino": "^8.19.0",
-        "pino-abstract-transport": "^1.1.0",
-        "pino-pretty": "^10.3.1",
-        "proper-lockfile": "^4.1.2",
-        "semver": "^7.6.0",
-        "ts-retry-promise": "^0.7.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/salesforcedx-vscode-apex/node_modules/@salesforce/ts-types": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.9.tgz",
-      "integrity": "sha512-boUD9jw5vQpTCPCCmK/NFTWjSuuW+lsaxOynkyNXLW+zxOc4GDjhtKc4j0vWZJQvolpafbyS8ZLFHZJvs12gYA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
     },
     "packages/salesforcedx-vscode-apex/node_modules/@types/node": {
       "version": "18.18.6",
@@ -37585,106 +36814,6 @@
       "dependencies": {
         "@types/glob": "*",
         "@types/node": "*"
-      }
-    },
-    "packages/salesforcedx-vscode-apex/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "packages/salesforcedx-vscode-apex/node_modules/camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-apex/node_modules/change-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
-      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "capital-case": "^1.0.4",
-        "constant-case": "^3.0.4",
-        "dot-case": "^3.0.4",
-        "header-case": "^2.0.4",
-        "no-case": "^3.0.4",
-        "param-case": "^3.0.4",
-        "pascal-case": "^3.1.2",
-        "path-case": "^3.0.4",
-        "sentence-case": "^3.0.4",
-        "snake-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-apex/node_modules/constant-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
-      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case": "^2.0.2"
-      }
-    },
-    "packages/salesforcedx-vscode-apex/node_modules/dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-apex/node_modules/faye": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
-      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
-      "dependencies": {
-        "asap": "*",
-        "csprng": "*",
-        "faye-websocket": ">=0.9.1",
-        "safe-buffer": "*",
-        "tough-cookie": "*",
-        "tunnel-agent": "*"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "packages/salesforcedx-vscode-apex/node_modules/header-case": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
-      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-      "dependencies": {
-        "capital-case": "^1.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-apex/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "packages/salesforcedx-vscode-apex/node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
       }
     },
     "packages/salesforcedx-vscode-apex/node_modules/lru-cache": {
@@ -37709,42 +36838,6 @@
         "node": ">=10"
       }
     },
-    "packages/salesforcedx-vscode-apex/node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-apex/node_modules/param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-apex/node_modules/pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-apex/node_modules/path-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
-      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "packages/salesforcedx-vscode-apex/node_modules/semver": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
@@ -37757,46 +36850,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "packages/salesforcedx-vscode-apex/node_modules/sentence-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
-      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
-    "packages/salesforcedx-vscode-apex/node_modules/snake-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-apex/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "packages/salesforcedx-vscode-apex/node_modules/upper-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
-      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-apex/node_modules/upper-case-first": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
-      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
       }
     },
     "packages/salesforcedx-vscode-apex/node_modules/vscode-jsonrpc": {
@@ -37843,12 +36896,12 @@
       "version": "60.10.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@jsforce/jsforce-node": "3.1.0",
-        "@salesforce/core": "7.2.0",
+        "@jsforce/jsforce-node": "3.2.0",
+        "@salesforce/core": "7.3.1",
         "@salesforce/salesforcedx-sobjects-faux-generator": "60.10.0",
         "@salesforce/salesforcedx-utils-vscode": "60.10.0",
         "@salesforce/schemas": "^1.6.1",
-        "@salesforce/source-deploy-retrieve": "11.0.1",
+        "@salesforce/source-deploy-retrieve": "11.1.2",
         "@salesforce/templates": "^60.1.2",
         "@salesforce/ts-types": "2.0.9",
         "@salesforce/vscode-service-provider": "1.0.4",
@@ -37903,47 +36956,6 @@
         "vscode": "^1.82.0"
       }
     },
-    "packages/salesforcedx-vscode-core/node_modules/@salesforce/core": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.2.0.tgz",
-      "integrity": "sha512-N/9hv7Vdr9sEuob9vo90odcQ7dJPtfOQVIE5R8vFcfaHK3W3ej9EpHsaV55PkaVG+hxRhZ2oOVA3UaVfp/diOw==",
-      "dependencies": {
-        "@jsforce/jsforce-node": "^3.1.0",
-        "@salesforce/kit": "^3.1.0",
-        "@salesforce/schemas": "^1.7.0",
-        "@salesforce/ts-types": "^2.0.9",
-        "ajv": "^8.12.0",
-        "change-case": "^4.1.2",
-        "faye": "^1.4.0",
-        "form-data": "^4.0.0",
-        "js2xmlparser": "^4.0.1",
-        "jsonwebtoken": "9.0.2",
-        "jszip": "3.10.1",
-        "pino": "^8.19.0",
-        "pino-abstract-transport": "^1.1.0",
-        "pino-pretty": "^10.3.1",
-        "proper-lockfile": "^4.1.2",
-        "semver": "^7.6.0",
-        "ts-retry-promise": "^0.7.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/salesforcedx-vscode-core/node_modules/@salesforce/core/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "packages/salesforcedx-vscode-core/node_modules/@salesforce/ts-types": {
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.9.tgz",
@@ -37971,21 +36983,6 @@
         "@types/node": "*"
       }
     },
-    "packages/salesforcedx-vscode-core/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "packages/salesforcedx-vscode-core/node_modules/applicationinsights": {
       "version": "1.8.10",
       "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.8.10.tgz",
@@ -38006,44 +37003,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "packages/salesforcedx-vscode-core/node_modules/camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-core/node_modules/change-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
-      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "capital-case": "^1.0.4",
-        "constant-case": "^3.0.4",
-        "dot-case": "^3.0.4",
-        "header-case": "^2.0.4",
-        "no-case": "^3.0.4",
-        "param-case": "^3.0.4",
-        "pascal-case": "^3.1.2",
-        "path-case": "^3.0.4",
-        "sentence-case": "^3.0.4",
-        "snake-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-core/node_modules/constant-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
-      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case": "^2.0.2"
-      }
-    },
     "packages/salesforcedx-vscode-core/node_modules/diagnostic-channel": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.3.1.tgz",
@@ -38058,31 +37017,6 @@
       "integrity": "sha512-l126t01d2ZS9EreskvEtZPrcgstuvH3rbKy82oUhUrVmBaGx4hO9wECdl3cvZbKDYjMF3QJDB5z5dL9yWAjvZQ==",
       "peerDependencies": {
         "diagnostic-channel": "*"
-      }
-    },
-    "packages/salesforcedx-vscode-core/node_modules/dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-core/node_modules/faye": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
-      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
-      "dependencies": {
-        "asap": "*",
-        "csprng": "*",
-        "faye-websocket": ">=0.9.1",
-        "safe-buffer": "*",
-        "tough-cookie": "*",
-        "tunnel-agent": "*"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "packages/salesforcedx-vscode-core/node_modules/glob": {
@@ -38104,39 +37038,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/salesforcedx-vscode-core/node_modules/header-case": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
-      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-      "dependencies": {
-        "capital-case": "^1.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-core/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "packages/salesforcedx-vscode-core/node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-core/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "packages/salesforcedx-vscode-core/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -38148,42 +37049,6 @@
         "node": "*"
       }
     },
-    "packages/salesforcedx-vscode-core/node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-core/node_modules/param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-core/node_modules/pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-core/node_modules/path-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
-      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "packages/salesforcedx-vscode-core/node_modules/semver": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
@@ -38192,50 +37057,10 @@
         "semver": "bin/semver"
       }
     },
-    "packages/salesforcedx-vscode-core/node_modules/sentence-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
-      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
-    "packages/salesforcedx-vscode-core/node_modules/snake-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "packages/salesforcedx-vscode-core/node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "packages/salesforcedx-vscode-core/node_modules/upper-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
-      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-core/node_modules/upper-case-first": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
-      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-core/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "packages/salesforcedx-vscode-expanded": {
       "version": "60.10.0",
@@ -38249,7 +37074,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/aura-language-server": "4.8.0",
-        "@salesforce/core": "7.2.0",
+        "@salesforce/core": "7.3.1",
         "@salesforce/lightning-lsp-common": "4.8.0",
         "@salesforce/salesforcedx-utils-vscode": "60.10.0",
         "applicationinsights": "1.0.7",
@@ -38288,58 +37113,6 @@
         "vscode": "^1.82.0"
       }
     },
-    "packages/salesforcedx-vscode-lightning/node_modules/@salesforce/core": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.2.0.tgz",
-      "integrity": "sha512-N/9hv7Vdr9sEuob9vo90odcQ7dJPtfOQVIE5R8vFcfaHK3W3ej9EpHsaV55PkaVG+hxRhZ2oOVA3UaVfp/diOw==",
-      "dependencies": {
-        "@jsforce/jsforce-node": "^3.1.0",
-        "@salesforce/kit": "^3.1.0",
-        "@salesforce/schemas": "^1.7.0",
-        "@salesforce/ts-types": "^2.0.9",
-        "ajv": "^8.12.0",
-        "change-case": "^4.1.2",
-        "faye": "^1.4.0",
-        "form-data": "^4.0.0",
-        "js2xmlparser": "^4.0.1",
-        "jsonwebtoken": "9.0.2",
-        "jszip": "3.10.1",
-        "pino": "^8.19.0",
-        "pino-abstract-transport": "^1.1.0",
-        "pino-pretty": "^10.3.1",
-        "proper-lockfile": "^4.1.2",
-        "semver": "^7.6.0",
-        "ts-retry-promise": "^0.7.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/salesforcedx-vscode-lightning/node_modules/@salesforce/core/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/salesforcedx-vscode-lightning/node_modules/@salesforce/ts-types": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.9.tgz",
-      "integrity": "sha512-boUD9jw5vQpTCPCCmK/NFTWjSuuW+lsaxOynkyNXLW+zxOc4GDjhtKc4j0vWZJQvolpafbyS8ZLFHZJvs12gYA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "packages/salesforcedx-vscode-lightning/node_modules/@types/node": {
       "version": "18.18.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.6.tgz",
@@ -38352,21 +37125,6 @@
       "integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg==",
       "dev": true
     },
-    "packages/salesforcedx-vscode-lightning/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "packages/salesforcedx-vscode-lightning/node_modules/applicationinsights": {
       "version": "1.8.10",
       "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.8.10.tgz",
@@ -38376,44 +37134,6 @@
         "continuation-local-storage": "^3.2.1",
         "diagnostic-channel": "0.3.1",
         "diagnostic-channel-publishers": "0.4.4"
-      }
-    },
-    "packages/salesforcedx-vscode-lightning/node_modules/camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-lightning/node_modules/change-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
-      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "capital-case": "^1.0.4",
-        "constant-case": "^3.0.4",
-        "dot-case": "^3.0.4",
-        "header-case": "^2.0.4",
-        "no-case": "^3.0.4",
-        "param-case": "^3.0.4",
-        "pascal-case": "^3.1.2",
-        "path-case": "^3.0.4",
-        "sentence-case": "^3.0.4",
-        "snake-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-lightning/node_modules/constant-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
-      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case": "^2.0.2"
       }
     },
     "packages/salesforcedx-vscode-lightning/node_modules/diagnostic-channel": {
@@ -38432,146 +37152,12 @@
         "diagnostic-channel": "*"
       }
     },
-    "packages/salesforcedx-vscode-lightning/node_modules/dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-lightning/node_modules/faye": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
-      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
-      "dependencies": {
-        "asap": "*",
-        "csprng": "*",
-        "faye-websocket": ">=0.9.1",
-        "safe-buffer": "*",
-        "tough-cookie": "*",
-        "tunnel-agent": "*"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "packages/salesforcedx-vscode-lightning/node_modules/header-case": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
-      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-      "dependencies": {
-        "capital-case": "^1.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-lightning/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "packages/salesforcedx-vscode-lightning/node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-lightning/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/salesforcedx-vscode-lightning/node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-lightning/node_modules/param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-lightning/node_modules/pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-lightning/node_modules/path-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
-      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "packages/salesforcedx-vscode-lightning/node_modules/semver": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
-      }
-    },
-    "packages/salesforcedx-vscode-lightning/node_modules/sentence-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
-      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
-    "packages/salesforcedx-vscode-lightning/node_modules/snake-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-lightning/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "packages/salesforcedx-vscode-lightning/node_modules/upper-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
-      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-lightning/node_modules/upper-case-first": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
-      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
       }
     },
     "packages/salesforcedx-vscode-lightning/node_modules/vscode-languageclient": {
@@ -38586,16 +37172,11 @@
         "vscode": "^1.30"
       }
     },
-    "packages/salesforcedx-vscode-lightning/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "packages/salesforcedx-vscode-lwc": {
       "version": "60.10.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "7.2.0",
+        "@salesforce/core": "7.3.1",
         "@salesforce/eslint-config-lwc": "3.5.1",
         "@salesforce/lightning-lsp-common": "4.8.0",
         "@salesforce/lwc-language-server": "4.8.0",
@@ -38647,73 +37228,6 @@
         "vscode": "^1.82.0"
       }
     },
-    "packages/salesforcedx-vscode-lwc/node_modules/@salesforce/core": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.2.0.tgz",
-      "integrity": "sha512-N/9hv7Vdr9sEuob9vo90odcQ7dJPtfOQVIE5R8vFcfaHK3W3ej9EpHsaV55PkaVG+hxRhZ2oOVA3UaVfp/diOw==",
-      "dependencies": {
-        "@jsforce/jsforce-node": "^3.1.0",
-        "@salesforce/kit": "^3.1.0",
-        "@salesforce/schemas": "^1.7.0",
-        "@salesforce/ts-types": "^2.0.9",
-        "ajv": "^8.12.0",
-        "change-case": "^4.1.2",
-        "faye": "^1.4.0",
-        "form-data": "^4.0.0",
-        "js2xmlparser": "^4.0.1",
-        "jsonwebtoken": "9.0.2",
-        "jszip": "3.10.1",
-        "pino": "^8.19.0",
-        "pino-abstract-transport": "^1.1.0",
-        "pino-pretty": "^10.3.1",
-        "proper-lockfile": "^4.1.2",
-        "semver": "^7.6.0",
-        "ts-retry-promise": "^0.7.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/salesforcedx-vscode-lwc/node_modules/@salesforce/core/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "packages/salesforcedx-vscode-lwc/node_modules/@salesforce/core/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/salesforcedx-vscode-lwc/node_modules/@salesforce/ts-types": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.9.tgz",
-      "integrity": "sha512-boUD9jw5vQpTCPCCmK/NFTWjSuuW+lsaxOynkyNXLW+zxOc4GDjhtKc4j0vWZJQvolpafbyS8ZLFHZJvs12gYA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "packages/salesforcedx-vscode-lwc/node_modules/@types/node": {
       "version": "18.18.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.6.tgz",
@@ -38737,44 +37251,6 @@
         "diagnostic-channel-publishers": "0.4.4"
       }
     },
-    "packages/salesforcedx-vscode-lwc/node_modules/camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-lwc/node_modules/change-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
-      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "capital-case": "^1.0.4",
-        "constant-case": "^3.0.4",
-        "dot-case": "^3.0.4",
-        "header-case": "^2.0.4",
-        "no-case": "^3.0.4",
-        "param-case": "^3.0.4",
-        "pascal-case": "^3.1.2",
-        "path-case": "^3.0.4",
-        "sentence-case": "^3.0.4",
-        "snake-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-lwc/node_modules/constant-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
-      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case": "^2.0.2"
-      }
-    },
     "packages/salesforcedx-vscode-lwc/node_modules/diagnostic-channel": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.3.1.tgz",
@@ -38791,146 +37267,12 @@
         "diagnostic-channel": "*"
       }
     },
-    "packages/salesforcedx-vscode-lwc/node_modules/dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-lwc/node_modules/faye": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
-      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
-      "dependencies": {
-        "asap": "*",
-        "csprng": "*",
-        "faye-websocket": ">=0.9.1",
-        "safe-buffer": "*",
-        "tough-cookie": "*",
-        "tunnel-agent": "*"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "packages/salesforcedx-vscode-lwc/node_modules/header-case": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
-      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-      "dependencies": {
-        "capital-case": "^1.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-lwc/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "packages/salesforcedx-vscode-lwc/node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-lwc/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/salesforcedx-vscode-lwc/node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-lwc/node_modules/param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-lwc/node_modules/pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-lwc/node_modules/path-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
-      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "packages/salesforcedx-vscode-lwc/node_modules/semver": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
-      }
-    },
-    "packages/salesforcedx-vscode-lwc/node_modules/sentence-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
-      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
-    "packages/salesforcedx-vscode-lwc/node_modules/snake-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-lwc/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "packages/salesforcedx-vscode-lwc/node_modules/upper-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
-      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-lwc/node_modules/upper-case-first": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
-      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
       }
     },
     "packages/salesforcedx-vscode-lwc/node_modules/vscode-languageclient": {
@@ -38951,18 +37293,13 @@
       "integrity": "sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ==",
       "dev": true
     },
-    "packages/salesforcedx-vscode-lwc/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "packages/salesforcedx-vscode-soql": {
       "version": "60.10.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@jsforce/jsforce-node": "3.1.0",
+        "@jsforce/jsforce-node": "3.2.0",
         "@salesforce/apex-tmlanguage": "1.6.0",
-        "@salesforce/core": "7.2.0",
+        "@salesforce/core": "7.3.1",
         "@salesforce/soql-builder-ui": "0.2.0",
         "@salesforce/soql-data-view": "0.1.0",
         "@salesforce/soql-language-server": "0.7.1",
@@ -39019,66 +37356,11 @@
         "node": ">=12.4.0"
       }
     },
-    "packages/salesforcedx-vscode-soql/node_modules/@salesforce/core": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.2.0.tgz",
-      "integrity": "sha512-N/9hv7Vdr9sEuob9vo90odcQ7dJPtfOQVIE5R8vFcfaHK3W3ej9EpHsaV55PkaVG+hxRhZ2oOVA3UaVfp/diOw==",
-      "dependencies": {
-        "@jsforce/jsforce-node": "^3.1.0",
-        "@salesforce/kit": "^3.1.0",
-        "@salesforce/schemas": "^1.7.0",
-        "@salesforce/ts-types": "^2.0.9",
-        "ajv": "^8.12.0",
-        "change-case": "^4.1.2",
-        "faye": "^1.4.0",
-        "form-data": "^4.0.0",
-        "js2xmlparser": "^4.0.1",
-        "jsonwebtoken": "9.0.2",
-        "jszip": "3.10.1",
-        "pino": "^8.19.0",
-        "pino-abstract-transport": "^1.1.0",
-        "pino-pretty": "^10.3.1",
-        "proper-lockfile": "^4.1.2",
-        "semver": "^7.6.0",
-        "ts-retry-promise": "^0.7.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/salesforcedx-vscode-soql/node_modules/@salesforce/core/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "packages/salesforcedx-vscode-soql/node_modules/@salesforce/core/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "packages/salesforcedx-vscode-soql/node_modules/@salesforce/ts-types": {
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.9.tgz",
       "integrity": "sha512-boUD9jw5vQpTCPCCmK/NFTWjSuuW+lsaxOynkyNXLW+zxOc4GDjhtKc4j0vWZJQvolpafbyS8ZLFHZJvs12gYA==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -39390,15 +37672,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "packages/salesforcedx-vscode-soql/node_modules/camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "packages/salesforcedx-vscode-soql/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -39413,25 +37686,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "packages/salesforcedx-vscode-soql/node_modules/change-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
-      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "capital-case": "^1.0.4",
-        "constant-case": "^3.0.4",
-        "dot-case": "^3.0.4",
-        "header-case": "^2.0.4",
-        "no-case": "^3.0.4",
-        "param-case": "^3.0.4",
-        "pascal-case": "^3.1.2",
-        "path-case": "^3.0.4",
-        "sentence-case": "^3.0.4",
-        "snake-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "packages/salesforcedx-vscode-soql/node_modules/color-convert": {
@@ -39451,16 +37705,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "packages/salesforcedx-vscode-soql/node_modules/constant-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
-      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case": "^2.0.2"
-      }
     },
     "packages/salesforcedx-vscode-soql/node_modules/diagnostic-channel": {
       "version": "0.3.1",
@@ -39487,15 +37731,6 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver"
-      }
-    },
-    "packages/salesforcedx-vscode-soql/node_modules/dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "packages/salesforcedx-vscode-soql/node_modules/escape-string-regexp": {
@@ -39603,22 +37838,6 @@
         "node": ">=4.0"
       }
     },
-    "packages/salesforcedx-vscode-soql/node_modules/faye": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
-      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
-      "dependencies": {
-        "asap": "*",
-        "csprng": "*",
-        "faye-websocket": ">=0.9.1",
-        "safe-buffer": "*",
-        "tough-cookie": "*",
-        "tunnel-agent": "*"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "packages/salesforcedx-vscode-soql/node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -39655,32 +37874,11 @@
         "node": ">=8"
       }
     },
-    "packages/salesforcedx-vscode-soql/node_modules/header-case": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
-      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-      "dependencies": {
-        "capital-case": "^1.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-soql/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "packages/salesforcedx-vscode-soql/node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
     "packages/salesforcedx-vscode-soql/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -39700,52 +37898,6 @@
         "node": "*"
       }
     },
-    "packages/salesforcedx-vscode-soql/node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-soql/node_modules/param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-soql/node_modules/pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-soql/node_modules/path-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
-      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-soql/node_modules/sentence-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
-      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
     "packages/salesforcedx-vscode-soql/node_modules/sinon": {
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-13.0.1.tgz",
@@ -39762,15 +37914,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/sinon"
-      }
-    },
-    "packages/salesforcedx-vscode-soql/node_modules/snake-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "packages/salesforcedx-vscode-soql/node_modules/strip-ansi": {
@@ -39800,7 +37943,8 @@
     "packages/salesforcedx-vscode-soql/node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
     },
     "packages/salesforcedx-vscode-soql/node_modules/type-fest": {
       "version": "0.20.2",
@@ -39812,22 +37956,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/salesforcedx-vscode-soql/node_modules/upper-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
-      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "packages/salesforcedx-vscode-soql/node_modules/upper-case-first": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
-      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
       }
     },
     "packages/salesforcedx-vscode-soql/node_modules/vscode-jsonrpc": {
@@ -39871,7 +37999,8 @@
     "packages/salesforcedx-vscode-soql/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "packages/salesforcedx-vscode-visualforce": {
       "version": "60.10.0",

--- a/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
+++ b/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
@@ -106,8 +106,7 @@ export type TraceCategory =
   | 'breakpoints'
   | 'streaming';
 
-export interface LaunchRequestArguments
-  extends DebugProtocol.LaunchRequestArguments {
+export type LaunchRequestArguments = DebugProtocol.LaunchRequestArguments & {
   // comma separated list of trace selectors (see TraceCategory)
   trace?: boolean | string;
   userIdFilter?: string[];
@@ -117,11 +116,11 @@ export interface LaunchRequestArguments
   connectType?: string;
   workspaceSettings: WorkspaceSettings;
   lineBreakpointInfo?: LineBreakpointInfo[];
-}
+};
 
-export interface SetExceptionBreakpointsArguments {
+export type SetExceptionBreakpointsArguments = {
   exceptionInfo: ExceptionBreakpointInfo;
-}
+};
 
 export class ApexDebugStackFrameInfo {
   public readonly requestId: string;
@@ -245,7 +244,7 @@ export class ApexVariable extends Variable {
 
 export type FilterType = 'named' | 'indexed' | 'all';
 
-export interface VariableContainer {
+export type VariableContainer = {
   expand(
     session: ApexDebug,
     filter: FilterType,
@@ -254,7 +253,7 @@ export interface VariableContainer {
   ): Promise<ApexVariable[]>;
 
   getNumberOfChildren(): number | undefined;
-}
+};
 
 export type ScopeType = 'local' | 'static' | 'global';
 
@@ -744,7 +743,9 @@ export class ApexDebug extends LoggingDebugSession {
         else {
           this.sendEvent(
             new Event(SEND_METRIC_EVENT, {
-              subject: nls.localize('interactive_debugger_launched_successfully'),
+              subject: nls.localize(
+                'interactive_debugger_launched_successfully'
+              ),
               type: 'startInteractiveDebuggerSuccess'
             })
           );
@@ -762,13 +763,18 @@ export class ApexDebug extends LoggingDebugSession {
       if (error === undefined) {
         this.sendEvent(
           new Event(SEND_METRIC_EVENT, {
-            subject: nls.localize('isv_debugger_session_authentication_invalid'),
+            subject: nls.localize(
+              'isv_debugger_session_authentication_invalid'
+            ),
             type: 'startIsvDebuggerAuthenticationInvalid'
           })
         );
       }
       // telemetry for invalid org-isv-debugger-url
-      else if (String(error) === "TypeError: Cannot read properties of undefined (reading 'pathname')") {
+      else if (
+        String(error) ===
+        "TypeError: Cannot read properties of undefined (reading 'pathname')"
+      ) {
         this.sendEvent(
           new Event(SEND_METRIC_EVENT, {
             subject: nls.localize('org_isv_debugger_url_invalid'),

--- a/packages/salesforcedx-apex-debugger/src/breakpoints/exceptionBreakpoint.ts
+++ b/packages/salesforcedx-apex-debugger/src/breakpoints/exceptionBreakpoint.ts
@@ -5,9 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export interface ExceptionBreakpointInfo {
+export type ExceptionBreakpointInfo = {
   label: string;
   typeref: string;
   breakMode: string;
   uri?: string;
-}
+};

--- a/packages/salesforcedx-apex-debugger/src/breakpoints/lineBreakpoint.ts
+++ b/packages/salesforcedx-apex-debugger/src/breakpoints/lineBreakpoint.ts
@@ -5,18 +5,18 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export interface LineBreakpointInfo {
+export type LineBreakpointInfo = {
   uri: string;
   typeref: string;
   lines: number[];
-}
+};
 
-export interface LineBreakpointsInTyperef {
+export type LineBreakpointsInTyperef = {
   typeref: string;
   lines: number[];
-}
+};
 
-export interface ApexBreakpointLocation {
+export type ApexBreakpointLocation = {
   line: number;
   breakpointId: string;
-}
+};

--- a/packages/salesforcedx-apex-debugger/src/commands/protocol.ts
+++ b/packages/salesforcedx-apex-debugger/src/commands/protocol.ts
@@ -11,30 +11,32 @@
  * 2. Input those responses into {@link http://json2ts.com/} to generate Typescript interfaces.
  * 3. Remove duplicate interfaces that are used in more than one response object.
  * 4. Fixed bogus generated interface ReferenceEnum
+ *
+ * NOTE: These interfaces were converted to types during the Core v6 -> v7 upgrade to conform to new standards.
  */
-export interface DebuggerResponse {
+export type DebuggerResponse = {
   referencesResponse: ReferencesResponse;
   frameResponse: FrameResponse;
   stateResponse: StateResponse;
-}
+};
 
-export interface ReferencesResponse {
+export type ReferencesResponse = {
   references: References;
-}
+};
 
-export interface FrameResponse {
+export type FrameResponse = {
   frame: Frame;
-}
+};
 
-export interface StateResponse {
+export type StateResponse = {
   state: State;
-}
+};
 
-export interface References {
+export type References = {
   references: Reference[];
-}
+};
 
-export interface Reference {
+export type Reference = {
   type: string;
   id: number;
   typeRef: string;
@@ -44,79 +46,79 @@ export interface Reference {
   offset?: number;
   value?: Value[];
   tuple?: Tuple[];
-}
+};
 
-export interface Value {
+export type Value = {
   name: string;
   declaredTypeRef: string;
   nameForMessages: string;
   ref?: number;
   value?: string;
-}
+};
 
-export interface Field extends Value {
+export type Field = Value & {
   index: number;
-}
+};
 
-export interface Tuple {
+export type Tuple = {
   key: Value;
   value: Value;
-}
+};
 
-export interface Frame {
+export type Frame = {
   locals: Locals;
   statics: Statics;
   globals: Globals;
   stackFrame: StackFrame;
   references?: References;
-}
+};
 
-export interface Locals {
+export type Locals = {
   frameNumber: number;
   local: LocalValue[];
-}
+};
 
-export interface LocalValue extends Value {
+export type LocalValue = Value & {
   slot: number;
-}
+};
 
-export interface Statics {
+export type Statics = {
   typeRef: string;
   static: Value[];
-}
+};
 
-export interface Globals {
+export type Globals = {
   global: Value[];
-}
+};
 
-export interface StackFrame {
+export type StackFrame = {
   typeRef: string;
   fullName: string;
   lineNumber: number;
   frameNumber: number;
-}
+};
 
-export interface State {
+export type State = {
   locals: Locals;
   statics: Statics;
   globals: Globals;
   stack: Stack;
   references?: References;
-}
+};
 
-export interface Stack {
+export type Stack = {
   stackFrame: StackFrame[];
-}
+};
 
-export interface DebuggerRequest {
+export type DebuggerRequest = {
   getReferencesRequest: GetReferenceRequest;
-}
+};
 
-export interface GetReferenceRequest {
+export type GetReferenceRequest = {
   reference: ReferenceRequest[];
-}
+};
 
-export interface ReferenceRequest {
+export type ReferenceRequest = {
   reference: number;
   offset?: number;
-}
+};

--- a/packages/salesforcedx-apex-debugger/src/core/streamingClient.ts
+++ b/packages/salesforcedx-apex-debugger/src/core/streamingClient.ts
@@ -28,13 +28,13 @@ export enum ApexDebuggerEventType {
   SystemWarning
 }
 
-export interface StreamingEvent {
+export type StreamingEvent = {
   createdDate: string;
   replayId: number;
   type: string;
-}
+};
 
-export interface ApexDebuggerEvent {
+export type ApexDebuggerEvent = {
   SessionId: string;
   RequestId?: string;
   BreakpointId?: string;
@@ -43,12 +43,12 @@ export interface ApexDebuggerEvent {
   FileName?: string;
   Line?: number;
   Stacktrace?: string;
-}
+};
 
-export interface DebuggerMessage {
+export type DebuggerMessage = {
   event: StreamingEvent;
   sobject: ApexDebuggerEvent;
-}
+};
 
 export class StreamingClientInfo {
   public readonly channel: string;

--- a/packages/salesforcedx-apex-debugger/src/index.ts
+++ b/packages/salesforcedx-apex-debugger/src/index.ts
@@ -14,25 +14,25 @@ export enum VscodeDebuggerMessageType {
   Error
 }
 
-export interface VscodeDebuggerMessage {
+export type VscodeDebuggerMessage = {
   type: VscodeDebuggerMessageType;
   message: string;
-}
+};
 
-export interface WorkspaceSettings {
+export type WorkspaceSettings = {
   proxyUrl: string;
   proxyStrictSSL: boolean;
   proxyAuth: string;
   connectionTimeoutMs: number;
   setBreakpointTimeoutMs: number;
-}
+};
 
 // Define Metric object to be used for sending attributes to AppInsights telemetry
 // NOTE: Refer to attribute names 'message' and 'eventName' defined in sendTelemetryEvent() in telemetryReporter.d.ts, which match the names in AppInsights telemetry
-export interface Metric {
+export type Metric = {
   message: string; // match 'subject' attribute in Event from messages.d.ts
   eventName: string; // match 'type' attribute in Event from messages.d.ts
-}
+};
 
 // Type guard to check if the object conforms to Metric
 export const isMetric = (input: unknown): input is Metric =>

--- a/packages/salesforcedx-apex-replay-debugger/src/adapter/apexReplayDebug.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/adapter/apexReplayDebug.ts
@@ -52,14 +52,13 @@ export enum Step {
   Run
 }
 
-export interface LaunchRequestArguments
-  extends DebugProtocol.LaunchRequestArguments {
+export type LaunchRequestArguments = DebugProtocol.LaunchRequestArguments & {
   logFile: string;
   stopOnEntry?: boolean | true;
   trace?: boolean | string;
   lineBreakpointInfo?: LineBreakpointInfo[];
   projectPath: string | undefined;
-}
+};
 
 export class ApexVariable extends Variable {
   public readonly type: string;

--- a/packages/salesforcedx-apex-replay-debugger/src/breakpoints/index.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/breakpoints/index.ts
@@ -5,11 +5,12 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export interface LineBreakpointInfo {
+export type LineBreakpointInfo = {
   uri: string;
   typeref: string;
   lines: number[];
-}
+};
+
 export { BreakpointUtil } from './breakpointUtil';
 import { BreakpointUtil } from './breakpointUtil';
 export const breakpointUtil = BreakpointUtil.getInstance();

--- a/packages/salesforcedx-apex-replay-debugger/src/commands/apexExecutionOverlayResultCommand.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/commands/apexExecutionOverlayResultCommand.ts
@@ -8,12 +8,12 @@
 import { BaseCommand } from '@salesforce/salesforcedx-utils';
 import { SOBJECTS_URL } from '../constants';
 
-export interface ApexExecutionOverlayResultCommandFailure {
+export type ApexExecutionOverlayResultCommandFailure = {
   message: string;
   errorCode: string;
-}
+};
 
-export interface ApexExecutionOverlayResultCommandSuccess {
+export type ApexExecutionOverlayResultCommandSuccess = {
   attributes: Attributes;
   Id: string;
   IsDeleted: boolean;
@@ -36,55 +36,55 @@ export interface ApexExecutionOverlayResultCommandSuccess {
   ActionScriptType: string;
   ClassName: string;
   Namespace: string;
-}
+};
 
-export interface HeapDump {
+export type HeapDump = {
   className: string;
   extents: HeapDumpExtents[];
   heapDumpDate: Date;
   namespace: string;
-}
+};
 
-export interface HeapDumpExtents {
+export type HeapDumpExtents = {
   collectionType: string | null;
   count: number;
   definition: HeapDumpCollectionTypeDefinition[];
   extent: HeapDumpExtent[];
   totalSize: number;
   typeName: string;
-}
+};
 
-export interface HeapDumpCollectionTypeDefinition {
+export type HeapDumpCollectionTypeDefinition = {
   name: string;
   type: string;
-}
+};
 
-export interface HeapDumpExtent {
+export type HeapDumpExtent = {
   address: string;
   size: number;
   isStatic: boolean;
   symbols: string[] | null;
   value: HeapDumpExtentValue;
-}
+};
 
 // The Extent value has to be an any. The value can be a single value of varying
 // types or an array of values of varying types from a collection.
-export interface HeapDumpExtentValue {
+export type HeapDumpExtentValue = {
   value?: any;
   entry?: HeapDumpExtentValueEntry[];
-}
+};
 
-export interface HeapDumpExtentValueEntry {
+export type HeapDumpExtentValueEntry = {
   keyDisplayValue: string;
   value: HeapDumpExtentValue;
-}
+};
 
-export interface HeapDumpApexResult {
+export type HeapDumpApexResult = {
   apexError: string | null;
   apexExecutionResult: HeapDumpApexExecutionResult | null;
-}
+};
 
-export interface HeapDumpApexExecutionResult {
+export type HeapDumpApexExecutionResult = {
   column: number;
   compileProblem: string | null;
   compiled: boolean;
@@ -92,24 +92,24 @@ export interface HeapDumpApexExecutionResult {
   exceptionStackTrace: string | null;
   line: number;
   success: boolean;
-}
+};
 
 // If the queryError is returned then the queryMetadata and queryResult will both be null.
-export interface HeapDumpSOQLResult {
+export type HeapDumpSOQLResult = {
   queryError: string | null;
   queryMetadata: HeapDumpSOQLResultQueryMetadata | null;
   queryResult: HeapDumpSOQLResultQueryResult[] | null;
-}
+};
 
-export interface HeapDumpSOQLResultQueryMetadata {
+export type HeapDumpSOQLResultQueryMetadata = {
   columnMetadata: HeapDumpSOQLResultColumnMetadata[];
   entityName: string;
   groupBy: boolean;
   idSelected: boolean;
   keyPrefix: string;
-}
+};
 
-export interface HeapDumpSOQLResultColumnMetadata {
+export type HeapDumpSOQLResultColumnMetadata = {
   aggregate: boolean;
   apexType: string;
   booleanType: boolean;
@@ -122,7 +122,7 @@ export interface HeapDumpSOQLResultColumnMetadata {
   numberType: boolean;
   textType: boolean;
   updatable: boolean;
-}
+};
 
 // A note about the HeapDumpSOQLResultQueryResult. The fields from a SOQL
 // query will be the fields that the user asked for. For instance if Id,
@@ -130,15 +130,15 @@ export interface HeapDumpSOQLResultColumnMetadata {
 // through the HeapDumpSOQLResult.queryResult['Id'|'Name'|'AccountNumber'].
 // The field name strings would be accessed through the ColumnMetadata returned
 // with the query.
-export interface HeapDumpSOQLResultQueryResult {
+export type HeapDumpSOQLResultQueryResult = {
   attributes: Attributes;
   [fields: string]: any;
-}
+};
 
-export interface Attributes {
+export type Attributes = {
   type: string;
   url: string;
-}
+};
 
 export class ApexExecutionOverlayResultCommand extends BaseCommand {
   private readonly commandName = 'ApexExecutionOverlayResult';

--- a/packages/salesforcedx-apex-replay-debugger/src/commands/index.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/commands/index.ts
@@ -10,12 +10,12 @@ export enum ActionScriptEnum {
   SOQL = 'SOQL'
 }
 
-export interface OrgInfoError {
+export type OrgInfoError = {
   message: string;
   status: number;
   name: string;
   warnings: string[];
-}
+};
 
 export {
   ApexExecutionOverlayResultCommand,

--- a/packages/salesforcedx-apex-replay-debugger/src/index.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/index.ts
@@ -7,12 +7,12 @@
 
 export * from './constants';
 
-export interface MetricLaunch {
+export type MetricLaunch = {
   logSize: number;
   error: MetricError;
-}
+};
 
-export interface MetricError {
+export type MetricError = {
   subject: string;
   callstack: string;
-}
+};

--- a/packages/salesforcedx-apex-replay-debugger/src/states/debugLogState.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/states/debugLogState.ts
@@ -7,6 +7,6 @@
 
 import { LogContext } from '../core/logContext';
 
-export interface DebugLogState {
+export type DebugLogState = {
   handle(logFile: LogContext): boolean;
-}
+};

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@salesforce/core": "7.2.0",
     "@salesforce/salesforcedx-utils-vscode": "60.9.0",
-    "jsforce": "2.0.0-beta.29",
+    "@jsforce/jsforce-node": "3.1.0",
     "shelljs": "0.8.5"
   },
   "devDependencies": {

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -10,7 +10,7 @@
   },
   "main": "out/src",
   "dependencies": {
-    "@salesforce/core": "6.7.4",
+    "@salesforce/core": "7.2.0",
     "@salesforce/salesforcedx-utils-vscode": "60.9.0",
     "jsforce": "2.0.0-beta.29",
     "shelljs": "0.8.5"

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -10,9 +10,9 @@
   },
   "main": "out/src",
   "dependencies": {
-    "@salesforce/core": "7.2.0",
+    "@salesforce/core": "7.3.1",
     "@salesforce/salesforcedx-utils-vscode": "60.10.0",
-    "@jsforce/jsforce-node": "3.1.0",
+    "@jsforce/jsforce-node": "3.2.0",
     "shelljs": "0.8.5"
   },
   "devDependencies": {

--- a/packages/salesforcedx-sobjects-faux-generator/src/describe/index.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/describe/index.ts
@@ -10,6 +10,6 @@ export { SObjectDescribe, toMinimalSObject } from './sObjectDescribe';
 
 export type SObjectShortDescription = Pick<SObject, 'name' | 'custom'>;
 
-export interface SObjectSelector {
+export type SObjectSelector = {
   select(sobject: SObjectShortDescription): boolean;
-}
+};

--- a/packages/salesforcedx-sobjects-faux-generator/src/describe/sObjectDescribe.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/describe/sObjectDescribe.ts
@@ -5,8 +5,12 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import {
+  DescribeGlobalResult,
+  DescribeSObjectResult,
+  Field
+} from '@jsforce/jsforce-node';
 import { Connection } from '@salesforce/core';
-import { DescribeGlobalResult, DescribeSObjectResult, Field } from 'jsforce';
 import { CLIENT_ID } from '../constants';
 import { BatchRequest, BatchResponse, SObject } from '../types';
 import { SObjectField } from '../types/describe';

--- a/packages/salesforcedx-sobjects-faux-generator/src/messages/localization.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/messages/localization.ts
@@ -12,13 +12,13 @@ export const BASE_FILE_EXTENSION = 'js';
 export const DEFAULT_LOCALE = 'en';
 export const MISSING_LABEL_MSG = '!!! MISSING LABEL !!!';
 
-export interface Config {
+export type Config = {
   locale: string;
-}
+};
 
-export interface LocalizationProvider {
+export type LocalizationProvider = {
   localize(label: string, ...args: any[]): string;
-}
+};
 
 export class Localization implements LocalizationProvider {
   private readonly delegate: Message;

--- a/packages/salesforcedx-sobjects-faux-generator/src/transformer/sobjectTransformer.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/transformer/sobjectTransformer.ts
@@ -25,9 +25,9 @@ import {
   SObjectRefreshResult
 } from '../types';
 
-export interface CancellationToken {
+export type CancellationToken = {
   isCancellationRequested: boolean;
-}
+};
 
 export type SObjectRefreshTransformData = SObjectRefreshData & {
   typeNames: SObjectShortDescription[];

--- a/packages/salesforcedx-sobjects-faux-generator/src/transformer/transformerFactory.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/transformer/transformerFactory.ts
@@ -27,9 +27,9 @@ import {
 } from '../types';
 import { SObjectTransformer } from './sobjectTransformer';
 
-export interface CancellationToken {
+export type CancellationToken = {
   isCancellationRequested: boolean;
-}
+};
 
 export class SObjectTransformerFactory {
   public static async create(
@@ -90,13 +90,15 @@ export class SObjectTransformerFactory {
   }
 
   public static async createConnection(): Promise<Connection> {
-    const userApiVersionOverride = await ConfigUtil.getUserConfiguredApiVersion();
+    const userApiVersionOverride =
+      await ConfigUtil.getUserConfiguredApiVersion();
     const workspaceContextUtil = WorkspaceContextUtil.getInstance();
     const connection = await workspaceContextUtil.getConnection();
     const connectionForSourceApiVersion = await Connection.create({
       authInfo: await AuthInfo.create({ username: connection.getUsername() })
     });
-    const sourceApiVersion = await SObjectTransformerFactory.getSourceApiVersion();
+    const sourceApiVersion =
+      await SObjectTransformerFactory.getSourceApiVersion();
     // precedence user override > project config > connection default
     connectionForSourceApiVersion.setApiVersion(
       userApiVersionOverride || sourceApiVersion || connection.getApiVersion()

--- a/packages/salesforcedx-sobjects-faux-generator/src/types/describe.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/types/describe.ts
@@ -5,9 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { DescribeSObjectResult, Field } from 'jsforce';
-import { ChildRelationship } from 'jsforce/lib/api/soap/schema';
-export { ChildRelationship};
+import { DescribeSObjectResult, Field } from '@jsforce/jsforce-node';
+import { ChildRelationship } from '@jsforce/jsforce-node/lib/api/soap/schema';
+export { ChildRelationship };
 
 export type SObjectField = Pick<
   Field,

--- a/packages/salesforcedx-sobjects-faux-generator/src/types/general.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/types/general.ts
@@ -19,26 +19,26 @@ export enum SObjectRefreshSource {
   StartupMin = 'startupmin'
 }
 
-export interface FieldDeclaration {
+export type FieldDeclaration = {
   modifier: string;
   type: string;
   name: string;
   comment?: string;
-}
+};
 
 export type SObjectDefinition = Pick<SObject, 'name'> & {
   fields: FieldDeclaration[];
 };
 
-export interface SObjectDefinitionRetriever {
+export type SObjectDefinitionRetriever = {
   retrieve: (output: SObjectRefreshOutput) => Promise<void>;
-}
+};
 
-export interface SObjectGenerator {
+export type SObjectGenerator = {
   generate: (output: SObjectRefreshOutput) => void;
-}
+};
 
-export interface SObjectRefreshOutput {
+export type SObjectRefreshOutput = {
   sfdxPath: string;
   addTypeNames: (names: SObjectShortDescription[]) => void;
   getTypeNames: () => SObjectShortDescription[];
@@ -47,13 +47,13 @@ export interface SObjectRefreshOutput {
   addCustom: (standard: SObject[]) => void;
   getCustom: () => SObject[];
   setError: (message: string, stack?: string) => void;
-}
+};
 
-export interface SObjectRefreshResult {
+export type SObjectRefreshResult = {
   data: {
     cancelled: boolean;
     standardObjects?: number;
     customObjects?: number;
   };
   error?: { message: string; stack?: string };
-}
+};

--- a/packages/salesforcedx-sobjects-faux-generator/test/unit/sObjectMockData.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/unit/sObjectMockData.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { DescribeSObjectResult } from 'jsforce';
+import { DescribeSObjectResult } from '@jsforce/jsforce-node';
 import { SObject } from '../../src/types';
 
 // This is mock data of the raw response we get from SF's API

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -11,7 +11,7 @@
   "main": "out/src",
   "dependencies": {
     "@salesforce/core": "7.2.0",
-    "@salesforce/source-deploy-retrieve": "10.3.3",
+    "@salesforce/source-deploy-retrieve": "11.0.1",
     "@salesforce/source-tracking": "5.1.11",
     "applicationinsights": "1.0.7",
     "cross-spawn": "7.0.3",

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@salesforce/core": "7.2.0",
     "@salesforce/source-deploy-retrieve": "11.0.1",
-    "@salesforce/source-tracking": "5.1.11",
+    "@salesforce/source-tracking": "6.0.2",
     "applicationinsights": "1.0.7",
     "cross-spawn": "7.0.3",
     "rxjs": "^5.4.1",

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -10,7 +10,7 @@
   ],
   "main": "out/src",
   "dependencies": {
-    "@salesforce/core": "6.7.4",
+    "@salesforce/core": "7.2.0",
     "@salesforce/source-deploy-retrieve": "10.3.3",
     "@salesforce/source-tracking": "5.1.11",
     "applicationinsights": "1.0.7",

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -10,9 +10,9 @@
   ],
   "main": "out/src",
   "dependencies": {
-    "@salesforce/core": "7.2.0",
-    "@salesforce/source-deploy-retrieve": "11.0.1",
-    "@salesforce/source-tracking": "6.0.2",
+    "@salesforce/core": "7.3.1",
+    "@salesforce/source-deploy-retrieve": "11.1.2",
+    "@salesforce/source-tracking": "6.0.4",
     "applicationinsights": "1.0.7",
     "cross-spawn": "7.0.3",
     "rxjs": "^5.4.1",

--- a/packages/salesforcedx-utils-vscode/src/cli/commandExecutor.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/commandExecutor.ts
@@ -20,9 +20,9 @@ const cross_spawn = require('cross-spawn');
 const kill = require('tree-kill');
 /* eslint-enable @typescript-eslint/no-var-requires */
 
-export interface CancellationToken {
+export type CancellationToken = {
   isCancellationRequested: boolean;
-}
+};
 
 export class GlobalCliEnvironment {
   public static readonly environmentVariables = new Map<string, string>();
@@ -69,9 +69,9 @@ export class CliCommandExecutor {
     this.command = command;
     this.options = inheritGlobalEnvironmentVariables
       ? CliCommandExecutor.patchEnv(
-        options,
-        GlobalCliEnvironment.environmentVariables
-      )
+          options,
+          GlobalCliEnvironment.environmentVariables
+        )
       : options;
   }
 
@@ -109,14 +109,14 @@ export class CompositeCliCommandExecutor {
  * If we ever use a different executor, this class should be refactored and abstracted
  * to take an event emitter/observable instead of child_proces.
  */
-export interface CommandExecution {
+export type CommandExecution = {
   readonly command: Command;
   readonly cancellationToken?: CancellationToken;
   readonly processExitSubject: Observable<number | undefined>;
   readonly processErrorSubject: Observable<Error | undefined>;
   readonly stdoutSubject: Observable<Buffer | string>;
   readonly stderrSubject: Observable<Buffer | string>;
-}
+};
 
 export class CompositeCliCommandExecution implements CommandExecution {
   public readonly command: Command;
@@ -208,19 +208,13 @@ export class CliCommandExecution implements CommandExecution {
     let timerSubscriber: Subscription | null;
 
     // Process
-    this.processExitSubject = Observable.fromEvent(
-      childProcess,
-      'exit'
-    );
+    this.processExitSubject = Observable.fromEvent(childProcess, 'exit');
     this.processExitSubject.subscribe(() => {
       if (timerSubscriber) {
         timerSubscriber.unsubscribe();
       }
     });
-    this.processErrorSubject = Observable.fromEvent(
-      childProcess,
-      'error'
-    );
+    this.processErrorSubject = Observable.fromEvent(childProcess, 'error');
     this.processErrorSubject.subscribe(() => {
       if (timerSubscriber) {
         timerSubscriber.unsubscribe();

--- a/packages/salesforcedx-utils-vscode/src/cli/diffResultParser.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/diffResultParser.ts
@@ -8,9 +8,9 @@
 import { extractJsonObject } from '../helpers';
 
 /**
- * Interface that stores information about a successful diff operation
+ * Type that stores information about a successful diff operation
  */
-export interface DiffSuccessResponse {
+export type DiffSuccessResponse = {
   /**
    * Request status e.g. 0 = Success
    */
@@ -32,12 +32,12 @@ export interface DiffSuccessResponse {
      */
     fileName: string;
   };
-}
+};
 
 /**
- * Interface that stores information about an unsuccessful diff operation
+ * Type that stores information about an unsuccessful diff operation
  */
-export interface DiffErrorResponse {
+export type DiffErrorResponse = {
   /**
    * Name of the command that was executed e.g. Diff
    */
@@ -66,7 +66,7 @@ export interface DiffErrorResponse {
    * Array of warnings provided by the command
    */
   warnings: any[];
-}
+};
 
 export class DiffResultParser {
   private response: any;

--- a/packages/salesforcedx-utils-vscode/src/cli/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/index.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export interface Command {
+export type Command = {
   readonly command: string;
   readonly description?: string;
   readonly args: string[];
@@ -13,7 +13,7 @@ export interface Command {
 
   toString(): string;
   toCommand(): string;
-}
+};
 
 export { CommandBuilder, SfCommandBuilder } from './commandBuilder';
 export {

--- a/packages/salesforcedx-utils-vscode/src/cli/orgCreateResultParser.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/orgCreateResultParser.ts
@@ -7,15 +7,15 @@
 
 import { extractJsonObject } from '../helpers';
 
-export interface OrgCreateSuccessResult {
+export type OrgCreateSuccessResult = {
   status: number;
   result: {
     orgId: string;
     username: string;
   };
-}
+};
 
-export interface OrgCreateErrorResult {
+export type OrgCreateErrorResult = {
   status: number;
   name: string;
   message: string;
@@ -23,7 +23,7 @@ export interface OrgCreateErrorResult {
   commandName: string;
   stack: string;
   warnings: any[];
-}
+};
 
 export class OrgCreateResultParser {
   private response: any;

--- a/packages/salesforcedx-utils-vscode/src/cli/orgDisplay.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/orgDisplay.ts
@@ -10,7 +10,7 @@ import { CliCommandExecutor } from './commandExecutor';
 import { CommandOutput } from './commandOutput';
 
 export const ORG_DISPLAY_COMMAND = 'org:display';
-export interface OrgInfo {
+export type OrgInfo = {
   username: string;
   devHubId: string;
   id: string;
@@ -23,7 +23,7 @@ export interface OrgInfo {
   accessToken: string;
   instanceUrl: string;
   clientId: string;
-}
+};
 
 export class OrgDisplay {
   public async getOrgInfo(projectPath: string): Promise<OrgInfo> {

--- a/packages/salesforcedx-utils-vscode/src/cli/parsers/projectDeployStartResultParser.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/parsers/projectDeployStartResultParser.ts
@@ -9,7 +9,7 @@ import { extractJsonObject } from '../../helpers';
 
 export const CONFLICT_ERROR_NAME = 'SourceConflictError';
 
-export interface ProjectDeployStartResult {
+export type ProjectDeployStartResult = {
   columnNumber?: string;
   error?: string;
   filePath: string;
@@ -17,22 +17,22 @@ export interface ProjectDeployStartResult {
   lineNumber?: string;
   state?: string;
   type: string;
-}
+};
 
-export interface ProjectDeployStartErrorResponse {
+export type ProjectDeployStartErrorResponse = {
   message: string;
   name: string;
   status: number;
   files: ProjectDeployStartResult[];
   warnings: any[];
-}
+};
 
-export interface ProjectDeployStartSuccessResponse {
+export type ProjectDeployStartSuccessResponse = {
   status: number;
   result: {
     files: ProjectDeployStartResult[];
   };
-}
+};
 
 export class ProjectDeployStartResultParser {
   private response: any;

--- a/packages/salesforcedx-utils-vscode/src/cli/parsers/projectRetrieveStartResultParser.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/parsers/projectRetrieveStartResultParser.ts
@@ -9,7 +9,7 @@ import { extractJsonObject } from '../../helpers';
 
 export const CONFLICT_ERROR_NAME = 'SourceConflictError';
 
-export interface ProjectRetrieveStartResult {
+export type ProjectRetrieveStartResult = {
   columnNumber?: string;
   error?: string;
   filePath: string;
@@ -17,22 +17,22 @@ export interface ProjectRetrieveStartResult {
   lineNumber?: string;
   state?: string;
   type: string;
-}
+};
 
-export interface ProjectRetrieveStartErrorResponse {
+export type ProjectRetrieveStartErrorResponse = {
   message: string;
   name: string;
   status: number;
   files: ProjectRetrieveStartResult[];
   warnings: any[];
-}
+};
 
-export interface ProjectRetrieveStartSuccessResponse {
+export type ProjectRetrieveStartSuccessResponse = {
   status: number;
   result: {
     files: ProjectRetrieveStartResult[];
   };
-}
+};
 
 export class ProjectRetrieveStartResultParser {
   private response: any;

--- a/packages/salesforcedx-utils-vscode/src/context/workspaceContextUtil.ts
+++ b/packages/salesforcedx-utils-vscode/src/context/workspaceContextUtil.ts
@@ -11,10 +11,10 @@ import { ConfigAggregatorProvider, TelemetryService } from '..';
 import { ConfigUtil } from '../config/configUtil';
 import { projectPaths } from '../helpers';
 import { nls } from '../messages';
-export interface OrgUserInfo {
+export type OrgUserInfo = {
   username?: string;
   alias?: string;
-}
+};
 
 export const WORKSPACE_CONTEXT_ORG_ID_ERROR = 'workspace_context_org_id_error';
 /**

--- a/packages/salesforcedx-utils-vscode/src/helpers/traceFlags.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/traceFlags.ts
@@ -8,29 +8,29 @@ import { Connection } from '@salesforce/core';
 import { TraceFlagsRemover } from '../helpers';
 import { nls } from '../messages';
 
-interface UserRecord {
+type UserRecord = {
   Id: string;
-}
+};
 
-interface DebugLevelRecord {
+type DebugLevelRecord = {
   ApexCode: string;
   VisualForce: string;
-}
+};
 
-interface TraceFlagRecord {
+type TraceFlagRecord = {
   Id: string;
   LogType: string;
   DebugLevelId: string;
   StartDate: Date | undefined;
   ExpirationDate: Date | undefined;
   DebugLevel: DebugLevelRecord;
-}
+};
 
-interface DataRecordResult {
+type DataRecordResult = {
   id?: string;
   errors?: any[];
   success: boolean;
-}
+};
 
 export class TraceFlags {
   private readonly LOG_TIMER_LENGTH_MINUTES = 30;

--- a/packages/salesforcedx-utils-vscode/src/i18n/localization.ts
+++ b/packages/salesforcedx-utils-vscode/src/i18n/localization.ts
@@ -13,13 +13,13 @@ export const DEFAULT_LOCALE = 'en';
 export const LOCALE_JA = 'ja';
 export const MISSING_LABEL_MSG = '!!! MISSING LABEL !!!';
 
-export interface Config {
+export type Config = {
   locale: string;
-}
+};
 
-export interface LocalizationProvider {
+export type LocalizationProvider = {
   localize(label: string, ...args: any[]): string;
-}
+};
 
 export class Localization implements LocalizationProvider {
   private readonly delegate: Message;

--- a/packages/salesforcedx-utils-vscode/src/output/table.ts
+++ b/packages/salesforcedx-utils-vscode/src/output/table.ts
@@ -9,14 +9,14 @@ const COLUMN_SEPARATOR = '  ';
 const COLUMN_FILLER = ' ';
 const HEADER_FILLER = '─';
 
-export interface Row {
+export type Row = {
   [column: string]: string;
-}
+};
 
-export interface Column {
+export type Column = {
   key: string;
   label: string;
-}
+};
 
 export class Table {
   public createTable(rows: Row[], cols: Column[], title?: string): string {

--- a/packages/salesforcedx-utils-vscode/src/predicates/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/predicates/index.ts
@@ -8,9 +8,9 @@
 // This file is meant to mimics the functionality of Predicate and Predicates from Google Guava.
 // Expand as necessary.
 
-export interface Predicate<T> {
+export type Predicate<T> = {
   apply(item: T): PredicateResponse;
-}
+};
 
 export class PredicateResponse {
   public result: boolean;

--- a/packages/salesforcedx-utils-vscode/src/services/sourceTrackingService.ts
+++ b/packages/salesforcedx-utils-vscode/src/services/sourceTrackingService.ts
@@ -52,9 +52,7 @@ export class SourceTrackingService {
     return sourceStatusSummary.format();
   }
 
-  private static async getSourceTrackingForCurrentProject(): Promise<
-    SourceTracking
-  > {
+  private static async getSourceTrackingForCurrentProject(): Promise<SourceTracking> {
     const rootWorkspacePath = getRootWorkspacePath();
     const workspaceContext = WorkspaceContextUtil.getInstance();
     const connection = await workspaceContext.getConnection();
@@ -70,7 +68,7 @@ export class SourceTrackingService {
 type StatusActualState = 'Deleted' | 'Add' | 'Changed' | 'Unchanged';
 type StatusOrigin = 'Local' | 'Remote';
 
-interface StatusResult {
+type StatusResult = {
   state: string;
   fullName: string;
   type: string;
@@ -79,15 +77,15 @@ interface StatusResult {
   conflict?: boolean;
   actualState?: StatusActualState;
   origin: StatusOrigin;
-}
+};
 
-interface FormattedStatusResult {
+type FormattedStatusResult = {
   state: string;
   fullName: string;
   type: string;
   filePath?: string;
   ignored?: string;
-}
+};
 
 export class SourceStatusSummary {
   constructor(private statusOutputRows: StatusOutputRow[]) {}
@@ -181,7 +179,7 @@ class StatusResultsTable {
     );
 
     const table: string = new Table().createTable(
-      (this.statusResults as unknown) as Row[],
+      this.statusResults as unknown as Row[],
       this.columns
     );
 

--- a/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
+++ b/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
@@ -24,24 +24,24 @@ import { LogStream } from '../telemetry/reporters/logStream';
 import { LogStreamConfig } from '../telemetry/reporters/logStreamConfig';
 import { TelemetryFile } from '../telemetry/reporters/telemetryFile';
 
-interface CommandMetric {
+type CommandMetric = {
   extensionName: string;
   commandName: string;
   executionTime?: string;
-}
+};
 
-export interface Measurements {
+export type Measurements = {
   [key: string]: number;
-}
+};
 
-export interface Properties {
+export type Properties = {
   [key: string]: string;
-}
+};
 
-export interface TelemetryData {
+export type TelemetryData = {
   properties?: Properties;
   measurements?: Measurements;
-}
+};
 
 export class TelemetryBuilder {
   private properties?: Properties;
@@ -97,7 +97,9 @@ export class TelemetryService {
    * @param extensionName extension name
    */
   public static getInstance(extensionName?: string) {
-    return TelemetryServiceProvider.getInstance(extensionName);
+    return TelemetryServiceProvider.getInstance(
+      extensionName ?? 'salesforcedx-vscode-core'
+    );
   }
   /**
    * Cached promise to check if CLI telemetry config is enabled

--- a/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
+++ b/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
@@ -97,9 +97,7 @@ export class TelemetryService {
    * @param extensionName extension name
    */
   public static getInstance(extensionName?: string) {
-    return TelemetryServiceProvider.getInstance(
-      extensionName ?? 'salesforcedx-vscode-core'
-    );
+    return TelemetryServiceProvider.getInstance(extensionName);
   }
   /**
    * Cached promise to check if CLI telemetry config is enabled

--- a/packages/salesforcedx-utils-vscode/src/telemetry/interfaces/telemetryReporter.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/interfaces/telemetryReporter.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------*/
 'use strict';
 
-export interface TelemetryReporter {
+export type TelemetryReporter = {
   sendTelemetryEvent(
     eventName: string,
     properties?: { [key: string]: string },
@@ -18,4 +18,4 @@ export interface TelemetryReporter {
   ): void;
 
   dispose(): Promise<any>;
-}
+};

--- a/packages/salesforcedx-utils-vscode/src/types/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/types/index.ts
@@ -21,42 +21,42 @@ import { Event } from 'vscode';
 
 // Precondition checking
 ////////////////////////
-export interface PreconditionChecker {
+export type PreconditionChecker = {
   check(): Promise<boolean> | boolean;
-}
+};
 
-export interface PostconditionChecker<T> {
+export type PostconditionChecker<T> = {
   check(
     inputs: ContinueResponse<T> | CancelResponse
   ): Promise<ContinueResponse<T> | CancelResponse>;
-}
+};
 
 // Input gathering
 //////////////////
-export interface ContinueResponse<T> {
+export type ContinueResponse<T> = {
   type: 'CONTINUE';
   data: T;
-}
+};
 
-export interface CancelResponse {
+export type CancelResponse = {
   type: 'CANCEL';
   msg?: string;
-}
+};
 
-export interface ParametersGatherer<T> {
+export type ParametersGatherer<T> = {
   gather(): Promise<CancelResponse | ContinueResponse<T>>;
-}
+};
 
 // Execution
 //////////////////
-export interface FlagParameter<T> {
+export type FlagParameter<T> = {
   flag: T;
-}
+};
 
-export interface CommandletExecutor<T> {
+export type CommandletExecutor<T> = {
   execute(response: ContinueResponse<T>): void;
   readonly onDidFinishExecution?: Event<[number, number]>;
-}
+};
 
 // Selection
 ////////////

--- a/packages/salesforcedx-utils-vscode/test/jest/context/workspaceContextUtil.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/context/workspaceContextUtil.test.ts
@@ -38,6 +38,14 @@ jest.mock('@salesforce/core', () => {
 
     StateAggregator: {
       clearInstance: jest.fn() // no-op function
+    },
+
+    AuthInfo: {
+      create: jest.fn() // no-op function
+    },
+
+    Connection: {
+      create: jest.fn() // no-op function
     }
   };
 });

--- a/packages/salesforcedx-utils-vscode/test/jest/context/workspaceContextUtil.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/context/workspaceContextUtil.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthInfo, Connection, Messages, SfError, StateAggregator } from '@salesforce/core';
+import { AuthInfo, Connection, StateAggregator } from '@salesforce/core';
 import * as vscode from 'vscode';
 import {
   ConfigAggregatorProvider,
@@ -26,15 +26,19 @@ jest.mock('@salesforce/core', () => {
       }
     },
 
-    Messages: jest.fn().mockImplementation((elephant: string, giraffe: string, zebra: Map<string, string>) => {
+    Messages: jest.fn().mockImplementation((arg1: string, arg2: string, arg3: Map<string, string>) => {
       return {
-        loadMessages: jest.fn((elephant1, giraffe1) => {
-          return `Mocked message for elephant: ${elephant1} and giraffe: ${giraffe1}`;
+        loadMessages: jest.fn((arg4, arg5) => {
+          return `Mocked message for arg4: ${arg4} and arg5: ${arg5}`;
         })
       };
     }),
 
-    SfError: class{}
+    SfError: class{},
+
+    StateAggregator: {
+      clearInstance: jest.fn() // no-op function
+    }
   };
 });
 jest.mock('../../../src/config/configUtil');

--- a/packages/salesforcedx-utils-vscode/test/jest/context/workspaceContextUtil.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/context/workspaceContextUtil.test.ts
@@ -20,8 +20,7 @@ jest.mock('@salesforce/core', () => {
     Logger: {
       childFromRoot: () => {
         return {
-          debug: () => {} // no-op function
-          // Add other methods as needed
+          debug: jest.fn()
         };
       }
     },
@@ -37,15 +36,15 @@ jest.mock('@salesforce/core', () => {
     SfError: class{},
 
     StateAggregator: {
-      clearInstance: jest.fn() // no-op function
+      clearInstance: jest.fn()
     },
 
     AuthInfo: {
-      create: jest.fn() // no-op function
+      create: jest.fn()
     },
 
     Connection: {
-      create: jest.fn() // no-op function
+      create: jest.fn()
     }
   };
 });

--- a/packages/salesforcedx-utils-vscode/test/jest/context/workspaceContextUtil.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/context/workspaceContextUtil.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthInfo, Connection, StateAggregator } from '@salesforce/core';
+import { AuthInfo, Connection, Messages, SfError, StateAggregator } from '@salesforce/core';
 import * as vscode from 'vscode';
 import {
   ConfigAggregatorProvider,
@@ -15,7 +15,28 @@ import {
 import { ConfigUtil } from '../../../src/config/configUtil';
 import { WORKSPACE_CONTEXT_ORG_ID_ERROR } from '../../../src/context/workspaceContextUtil';
 import { nls } from '../../../src/messages';
-jest.mock('@salesforce/core');
+jest.mock('@salesforce/core', () => {
+  return {
+    Logger: {
+      childFromRoot: () => {
+        return {
+          debug: () => {} // no-op function
+          // Add other methods as needed
+        };
+      }
+    },
+
+    Messages: jest.fn().mockImplementation((elephant: string, giraffe: string, zebra: Map<string, string>) => {
+      return {
+        loadMessages: jest.fn((elephant1, giraffe1) => {
+          return `Mocked message for elephant: ${elephant1} and giraffe: ${giraffe1}`;
+        })
+      };
+    }),
+
+    SfError: class{}
+  };
+});
 jest.mock('../../../src/config/configUtil');
 
 const authInfoMock = jest.mocked(AuthInfo);

--- a/packages/salesforcedx-utils/src/types/cancellationToken.ts
+++ b/packages/salesforcedx-utils/src/types/cancellationToken.ts
@@ -4,6 +4,6 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-export interface CancellationToken {
+export type CancellationToken = {
   isCancellationRequested: boolean;
-}
+};

--- a/packages/salesforcedx-utils/src/types/command.ts
+++ b/packages/salesforcedx-utils/src/types/command.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-export interface Command {
+export type Command = {
   readonly command: string;
   readonly description?: string;
   readonly args: string[];
@@ -12,4 +12,4 @@ export interface Command {
 
   toString(): string;
   toCommand(): string;
-}
+};

--- a/packages/salesforcedx-utils/src/types/commandExecution.ts
+++ b/packages/salesforcedx-utils/src/types/commandExecution.ts
@@ -14,11 +14,11 @@ import { Command } from './command';
  * If we ever use a different executor, this class should be refactored and abstracted
  * to take an event emitter/observable instead of child_proces.
  */
-export interface CommandExecution {
+export type CommandExecution = {
   readonly command: Command;
   readonly cancellationToken?: CancellationToken;
   readonly processExitSubject: Observable<number | undefined>;
   readonly processErrorSubject: Observable<Error | undefined>;
   readonly stdoutSubject: Observable<Buffer | string>;
   readonly stderrSubject: Observable<Buffer | string>;
-}
+};

--- a/packages/salesforcedx-utils/src/types/localization/config.ts
+++ b/packages/salesforcedx-utils/src/types/localization/config.ts
@@ -4,6 +4,6 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-export interface Config {
+export type Config = {
   locale: string;
-}
+};

--- a/packages/salesforcedx-utils/src/types/localization/localizationProvider.ts
+++ b/packages/salesforcedx-utils/src/types/localization/localizationProvider.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-export interface LocalizationProvider {
+export type LocalizationProvider = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   localize(label: string, ...args: any[]): string;
-}
+};

--- a/packages/salesforcedx-utils/src/types/orgInfo.ts
+++ b/packages/salesforcedx-utils/src/types/orgInfo.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-export interface OrgInfo {
+export type OrgInfo = {
   username: string;
   devHubId: string;
   id: string;
@@ -17,4 +17,4 @@ export interface OrgInfo {
   accessToken: string;
   instanceUrl: string;
   clientId: string;
-}
+};

--- a/packages/salesforcedx-visualforce-language-server/src/languageModelCache.ts
+++ b/packages/salesforcedx-visualforce-language-server/src/languageModelCache.ts
@@ -7,11 +7,11 @@
 
 import { TextDocument } from 'vscode-languageserver';
 
-export interface LanguageModelCache<T> {
+export type LanguageModelCache<T> = {
   get(document: TextDocument): T;
   onDocumentRemoved(document: TextDocument): void;
   dispose(): void;
-}
+};
 
 export const getLanguageModelCache = <T>(
   maxEntries: number,

--- a/packages/salesforcedx-visualforce-language-server/src/modes/embeddedSupport.ts
+++ b/packages/salesforcedx-visualforce-language-server/src/modes/embeddedSupport.ts
@@ -15,12 +15,12 @@ import {
   TokenType
 } from '@salesforce/salesforcedx-visualforce-markup-language-server';
 
-export interface LanguageRange extends Range {
+export type LanguageRange = Range & {
   languageId: string;
   attributeValue?: boolean;
-}
+};
 
-export interface HTMLDocumentRegions {
+export type HTMLDocumentRegions = {
   getEmbeddedDocument(
     languageId: string,
     ignoreAttributeValues?: boolean
@@ -29,16 +29,16 @@ export interface HTMLDocumentRegions {
   getLanguageAtPosition(position: Position): string;
   getLanguagesInDocument(): string[];
   getImportedScripts(): string[];
-}
+};
 
 export const CSS_STYLE_RULE = '__';
 
-interface EmbeddedRegion {
+type EmbeddedRegion = {
   languageId: string;
   start: number;
   end: number;
   attributeValue?: boolean;
-}
+};
 
 export const getDocumentRegions = (
   languageService: LanguageService,

--- a/packages/salesforcedx-visualforce-language-server/src/modes/languageModes.ts
+++ b/packages/salesforcedx-visualforce-language-server/src/modes/languageModes.ts
@@ -32,7 +32,6 @@ import {
   TextEdit
 } from 'vscode-languageserver-types';
 
-
 import {
   getLanguageModelCache,
   LanguageModelCache
@@ -46,17 +45,17 @@ import { getJavascriptMode } from './javascriptMode';
 
 export { ColorInformation, ColorPresentation };
 
-export interface Settings {
+export type Settings = {
   css?: any;
   visualforce?: any;
   javascript?: any;
-}
+};
 
-export interface SettingProvider {
+export type SettingProvider = {
   getDocumentSettings(textDocument: TextDocument): Thenable<Settings>;
-}
+};
 
-export interface LanguageMode {
+export type LanguageMode = {
   configure?: (options: Settings) => void;
   doValidation?: (document: TextDocument, settings?: Settings) => Diagnostic[];
   doComplete?: (
@@ -96,9 +95,9 @@ export interface LanguageMode {
   getId();
   dispose(): void;
   onDocumentRemoved(document: TextDocument): void;
-}
+};
 
-export interface LanguageModes {
+export type LanguageModes = {
   getModeAtPosition(document: TextDocument, position: Position): LanguageMode;
   getModesInRange(document: TextDocument, range: Range): LanguageModeRange[];
   getAllModes(): LanguageMode[];
@@ -106,12 +105,12 @@ export interface LanguageModes {
   getMode(languageId: string): LanguageMode;
   onDocumentRemoved(document: TextDocument): void;
   dispose(): void;
-}
+};
 
-export interface LanguageModeRange extends Range {
+export type LanguageModeRange = Range & {
   mode: LanguageMode;
   attributeValue?: boolean;
-}
+};
 
 export const getLanguageModes = (supportedLanguages: {
   [languageId: string]: boolean;
@@ -147,7 +146,10 @@ export const getLanguageModes = (supportedLanguages: {
       }
       return null;
     },
-    getModesInRange: (document: TextDocument, range: Range): LanguageModeRange[] => {
+    getModesInRange: (
+      document: TextDocument,
+      range: Range
+    ): LanguageModeRange[] => {
       return documentRegions
         .get(document)
         .getLanguageRanges(range)

--- a/packages/salesforcedx-visualforce-markup-language-server/src/beautify/beautify-css.d.ts
+++ b/packages/salesforcedx-visualforce-markup-language-server/src/beautify/beautify-css.d.ts
@@ -3,16 +3,16 @@
  *  Licensed under the MIT License. See OSSREADME.json in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export interface IBeautifyCSSOptions {
+export type IBeautifyCSSOptions = {
   indent_size?: number; // (4) — indentation size,
   indent_char?: string; // (space) — character to indent with,
   selector_separator_newline?: boolean; // (true) - separate selectors with newline or not (e.g. "a,\nbr" or "a, br")
   end_with_newline?: boolean; // (false) - end with a newline
   newline_between_rules?: boolean; // (true) - add a new line after every css rule
-}
+};
 
-export interface IBeautifyCSS {
+export type IBeautifyCSS = {
   (value: string, options: IBeautifyCSSOptions): string;
-}
+};
 
 export declare var css_beautify: IBeautifyCSS;

--- a/packages/salesforcedx-visualforce-markup-language-server/src/beautify/beautify-html.d.ts
+++ b/packages/salesforcedx-visualforce-markup-language-server/src/beautify/beautify-html.d.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See OSSREADME.json in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export interface IBeautifyHTMLOptions {
+export type IBeautifyHTMLOptions = {
   /**
    * indent <head> and <body> sections
    * default false
@@ -100,10 +100,10 @@ export interface IBeautifyHTMLOptions {
    * end of line character to use
    */
   eol?: string;
-}
+};
 
-export interface IBeautifyHTML {
+export type IBeautifyHTML = {
   (value: string, options: IBeautifyHTMLOptions): string;
-}
+};
 
 export declare var html_beautify: IBeautifyHTML;

--- a/packages/salesforcedx-visualforce-markup-language-server/src/htmlLanguageService.ts
+++ b/packages/salesforcedx-visualforce-markup-language-server/src/htmlLanguageService.ts
@@ -44,7 +44,7 @@ export {
   DocumentLink
 };
 
-export interface HTMLFormatConfiguration {
+export type HTMLFormatConfiguration = {
   tabSize?: number;
   insertSpaces?: boolean;
   wrapLineLength?: number;
@@ -61,14 +61,14 @@ export interface HTMLFormatConfiguration {
   indentHandlebars?: boolean;
   endWithNewline?: boolean;
   extraLiners?: string;
-}
+};
 
-export interface CompletionConfiguration {
+export type CompletionConfiguration = {
   [provider: string]: boolean;
   hideAutoCompleteProposals?: boolean;
-}
+};
 
-export interface Node {
+export type Node = {
   tag: string;
   start: number;
   end: number;
@@ -76,7 +76,7 @@ export interface Node {
   children: Node[];
   parent: Node;
   attributes?: { [name: string]: string };
-}
+};
 
 export enum TokenType {
   StartCommentTag,
@@ -117,7 +117,7 @@ export enum ScannerState {
   BeforeAttributeValue
 }
 
-export interface Scanner {
+export type Scanner = {
   scan(): TokenType;
   getTokenType(): TokenType;
   getTokenOffset(): number;
@@ -126,7 +126,7 @@ export interface Scanner {
   getTokenText(): string;
   getTokenError(): string;
   getScannerState(): ScannerState;
-}
+};
 
 export declare type HTMLDocument = {
   roots: Node[];
@@ -134,11 +134,11 @@ export declare type HTMLDocument = {
   findNodeAt(offset: number): Node;
 };
 
-export interface DocumentContext {
+export type DocumentContext = {
   resolveReference(ref: string, base?: string): string;
-}
+};
 
-export interface LanguageService {
+export type LanguageService = {
   createScanner(input: string): Scanner;
   parseHTMLDocument(document: TextDocument): HTMLDocument;
   findDocumentHighlights(
@@ -175,7 +175,7 @@ export interface LanguageService {
     position: Position,
     htmlDocument: HTMLDocument
   ): string;
-}
+};
 
 export function getLanguageService(): LanguageService {
   return {

--- a/packages/salesforcedx-visualforce-markup-language-server/src/parser/htmlParser.ts
+++ b/packages/salesforcedx-visualforce-markup-language-server/src/parser/htmlParser.ts
@@ -68,11 +68,11 @@ export class Node {
   }
 }
 
-export interface HTMLDocument {
+export type HTMLDocument = {
   roots: Node[];
   findNodeBefore(offset: number): Node;
   findNodeAt(offset: number): Node;
-}
+};
 
 export function parse(text: string): HTMLDocument {
   const scanner = createScanner(text);

--- a/packages/salesforcedx-visualforce-markup-language-server/src/parser/htmlScanner.ts
+++ b/packages/salesforcedx-visualforce-markup-language-server/src/parser/htmlScanner.ts
@@ -196,7 +196,7 @@ export enum ScannerState {
   BeforeAttributeValue
 }
 
-export interface Scanner {
+export type Scanner = {
   scan(): TokenType;
   getTokenType(): TokenType;
   getTokenOffset(): number;
@@ -205,7 +205,7 @@ export interface Scanner {
   getTokenText(): string;
   getTokenError(): string;
   getScannerState(): ScannerState;
-}
+};
 
 const htmlScriptContents = {
   'text/x-handlebars-template': true

--- a/packages/salesforcedx-visualforce-markup-language-server/src/parser/htmlTags.ts
+++ b/packages/salesforcedx-visualforce-markup-language-server/src/parser/htmlTags.ts
@@ -53,7 +53,7 @@ export function isEmptyElement(e: string): boolean {
   );
 }
 
-export interface IHTMLTagProvider {
+export type IHTMLTagProvider = {
   getId(): string;
   isApplicable(languageId: string);
   collectTags(collector: (tag: string, label: string) => void): void;
@@ -66,11 +66,11 @@ export interface IHTMLTagProvider {
     attribute: string,
     collector: (value: string) => void
   ): void;
-}
+};
 
-export interface ITagSet {
+export type ITagSet = {
   [tag: string]: TagSpecification;
-}
+};
 
 export class TagSpecification {
   public readonly documentation: string;
@@ -82,9 +82,9 @@ export class TagSpecification {
   }
 }
 
-export interface IValueSets {
+export type IValueSets = {
   [tag: string]: string[];
-}
+};
 
 function localize(key: string, description: string): string {
   return description;

--- a/packages/salesforcedx-visualforce-markup-language-server/src/parser/visualforceTags.ts
+++ b/packages/salesforcedx-visualforce-markup-language-server/src/parser/visualforceTags.ts
@@ -22,9 +22,9 @@ class VisualforceTagSpecification extends TagSpecification {
   }
 }
 
-interface VisualforceTagSet {
+type VisualforceTagSet = {
   [tag: string]: VisualforceTagSpecification;
-}
+};
 
 export function getVisualforceTagProvider(): IHTMLTagProvider {
   const valueSets: IValueSets = {

--- a/packages/salesforcedx-visualforce-markup-language-server/test/unit/completion.test.ts
+++ b/packages/salesforcedx-visualforce-markup-language-server/test/unit/completion.test.ts
@@ -15,13 +15,13 @@ import {
 import * as htmlLanguageService from '../../src/htmlLanguageService';
 import { applyEdits } from './textEditSupport';
 
-export interface ItemDescription {
+export type ItemDescription = {
   label: string;
   documentation?: string;
   kind?: CompletionItemKind;
   resultText?: string;
   notAvailable?: boolean;
-}
+};
 
 describe('HTML Completion', () => {
   const assertCompletion = (

--- a/packages/salesforcedx-visualforce-markup-language-server/test/unit/scanner.test.ts
+++ b/packages/salesforcedx-visualforce-markup-language-server/test/unit/scanner.test.ts
@@ -15,11 +15,11 @@ import {
 } from '../../src/parser/htmlScanner';
 
 describe('HTML Scanner', () => {
-  interface Token {
+  type Token = {
     offset: number;
     type: TokenType;
     content?: string;
-  }
+  };
 
   const assertTokens = (tests: { input: string; tokens: Token[] }[]) => {
     let scannerState = ScannerState.WithinContent;

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -97,7 +97,7 @@
       "dependencies": {
         "applicationinsights": "1.0.7",
         "@salesforce/core": "7.2.0",
-        "@salesforce/source-tracking": "5.1.11"
+        "@salesforce/source-tracking": "6.0.2"
       },
       "devDependencies": {}
     }

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -96,8 +96,8 @@
       "main": "dist/index.js",
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "@salesforce/core": "7.2.0",
-        "@salesforce/source-tracking": "6.0.2"
+        "@salesforce/core": "7.3.1",
+        "@salesforce/source-tracking": "6.0.4"
       },
       "devDependencies": {}
     }

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -96,7 +96,7 @@
       "main": "dist/index.js",
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "@salesforce/core": "6.7.4",
+        "@salesforce/core": "7.2.0",
         "@salesforce/source-tracking": "5.1.11"
       },
       "devDependencies": {}

--- a/packages/salesforcedx-vscode-apex-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-debugger/src/index.ts
@@ -94,15 +94,15 @@ const registerCommands = (): vscode.Disposable => {
   );
 };
 
-export interface ExceptionBreakpointItem extends vscode.QuickPickItem {
+export type ExceptionBreakpointItem = vscode.QuickPickItem & {
   typeref: string;
   breakMode: DebugProtocol.ExceptionBreakMode;
   uri?: string;
-}
+};
 
-interface BreakModeItem extends vscode.QuickPickItem {
+type BreakModeItem = vscode.QuickPickItem & {
   breakMode: DebugProtocol.ExceptionBreakMode;
-}
+};
 
 const EXCEPTION_BREAK_MODES: BreakModeItem[] = [
   {

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -249,7 +249,7 @@
     "packageUpdates": {
       "dependencies": {
         "@salesforce/core": "7.2.0",
-        "@salesforce/source-tracking": "5.1.11",
+        "@salesforce/source-tracking": "6.0.2",
         "applicationinsights": "1.0.7"
       },
       "devDependencies": {},

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -180,7 +180,7 @@
     }
   },
   "dependencies": {
-    "@salesforce/apex-node": "4.0.5",
+    "@salesforce/apex-node": "5.0.0-beta.0",
     "@salesforce/core": "7.2.0",
     "@salesforce/salesforcedx-apex-replay-debugger": "60.9.0",
     "@salesforce/salesforcedx-utils": "60.9.0",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -180,7 +180,7 @@
     }
   },
   "dependencies": {
-    "@salesforce/apex-node": "5.0.0-beta.0",
+    "@salesforce/apex-node": "6.0.0",
     "@salesforce/core": "7.2.0",
     "@salesforce/salesforcedx-apex-replay-debugger": "60.10.0",
     "@salesforce/salesforcedx-utils": "60.10.0",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -181,7 +181,7 @@
   },
   "dependencies": {
     "@salesforce/apex-node": "4.0.5",
-    "@salesforce/core": "6.7.4",
+    "@salesforce/core": "7.2.0",
     "@salesforce/salesforcedx-apex-replay-debugger": "60.9.0",
     "@salesforce/salesforcedx-utils": "60.9.0",
     "@salesforce/salesforcedx-utils-vscode": "60.9.0",
@@ -248,7 +248,7 @@
     ],
     "packageUpdates": {
       "dependencies": {
-        "@salesforce/core": "6.7.4",
+        "@salesforce/core": "7.2.0",
         "@salesforce/source-tracking": "5.1.11",
         "applicationinsights": "1.0.7"
       },

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -181,7 +181,7 @@
   },
   "dependencies": {
     "@salesforce/apex-node": "6.0.0",
-    "@salesforce/core": "7.2.0",
+    "@salesforce/core": "7.3.1",
     "@salesforce/salesforcedx-apex-replay-debugger": "60.10.0",
     "@salesforce/salesforcedx-utils": "60.10.0",
     "@salesforce/salesforcedx-utils-vscode": "60.10.0",
@@ -248,8 +248,8 @@
     ],
     "packageUpdates": {
       "dependencies": {
-        "@salesforce/core": "7.2.0",
-        "@salesforce/source-tracking": "6.0.2",
+        "@salesforce/core": "7.3.1",
+        "@salesforce/source-tracking": "6.0.4",
         "applicationinsights": "1.0.7"
       },
       "devDependencies": {},

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/breakpoints/checkpointService.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/breakpoints/checkpointService.ts
@@ -62,14 +62,14 @@ const EDITABLE_FIELD_LABEL_ACTION_SCRIPT = 'Script: ';
 const EDITABLE_FIELD_LABEL_ACTION_SCRIPT_TYPE = 'Type: ';
 
 // These are the action script types for the ApexExecutionOverlayAction.
-export interface ApexExecutionOverlayAction {
+export type ApexExecutionOverlayAction = {
   ActionScript: string;
   ActionScriptType: ActionScriptEnum;
   ExecutableEntityName: string | undefined;
   IsDumpingHeap: boolean;
   Iteration: number;
   Line: number;
-}
+};
 
 export class CheckpointService implements TreeDataProvider<BaseNode> {
   private static instance: CheckpointService;

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/apexExecutionOverlayActionCommand.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/apexExecutionOverlayActionCommand.ts
@@ -8,18 +8,18 @@
 import { SOBJECTS_URL } from '@salesforce/salesforcedx-apex-replay-debugger/out/src/constants';
 import { BaseCommand } from '@salesforce/salesforcedx-utils';
 
-export interface ApexExecutionOverlayFailureResult {
+export type ApexExecutionOverlayFailureResult = {
   message: string;
   errorCode: string;
   fields: string[];
-}
+};
 
-export interface ApexExecutionOverlaySuccessResult {
+export type ApexExecutionOverlaySuccessResult = {
   id: string;
   success: boolean;
   errors: string[];
   warnings: string[];
-}
+};
 
 export class ApexExecutionOverlayActionCommand extends BaseCommand {
   private readonly commandName = 'ApexExecutionOverlayAction';

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/batchDeleteExistingOverlayActionsCommand.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/batchDeleteExistingOverlayActionsCommand.ts
@@ -11,29 +11,29 @@ import {
   RestHttpMethodEnum
 } from '@salesforce/salesforcedx-utils';
 
-export interface BatchRequests {
+export type BatchRequests = {
   batchRequests: BatchRequest[];
-}
+};
 
-export interface BatchRequest {
+export type BatchRequest = {
   method: RestHttpMethodEnum;
   url: string;
-}
+};
 
-export interface BatchDeleteResponse {
+export type BatchDeleteResponse = {
   hasErrors: boolean;
   results: BatchDeleteResult[];
-}
+};
 
-export interface BatchDeleteResult {
+export type BatchDeleteResult = {
   statusCode: number;
   result: SingleResult[] | null;
-}
+};
 
-export interface SingleResult {
+export type SingleResult = {
   errorCode: string;
   message: string;
-}
+};
 
 export class BatchDeleteExistingOverlayActionCommand extends BaseCommand {
   private readonly requests: BatchRequests;

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/queryExistingOverlayActionIdsCommand.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/queryExistingOverlayActionIdsCommand.ts
@@ -8,23 +8,23 @@
 import { QUERY_URL } from '@salesforce/salesforcedx-apex-replay-debugger/out/src/constants';
 import { BaseCommand } from '@salesforce/salesforcedx-utils';
 
-export interface QueryOverlayActionIdsSuccessResult {
+export type QueryOverlayActionIdsSuccessResult = {
   size: number;
   totalSize: number;
   done: boolean;
   queryLocator: any;
   entityTypeName: string;
   records: ApexExecutionOverlayActionRecord[];
-}
-export interface ApexExecutionOverlayActionRecord {
+};
+export type ApexExecutionOverlayActionRecord = {
   attributes: ApexExecutionOverlayActionRecordAttribute;
   Id: string;
-}
+};
 
-export interface ApexExecutionOverlayActionRecordAttribute {
+export type ApexExecutionOverlayActionRecordAttribute = {
   type: string;
   url: string;
-}
+};
 
 export class QueryExistingOverlayActionIdsCommand extends BaseCommand {
   private readonly userId: string;

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/quickLaunch.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/quickLaunch.ts
@@ -33,16 +33,16 @@ import { nls } from '../messages';
 import { retrieveTestCodeCoverage } from '../utils';
 import { launchFromLogFile } from './launchFromLogFile';
 
-interface TestRunResult {
+type TestRunResult = {
   logFileId?: string;
   message?: string;
   success: boolean;
-}
+};
 
-interface LogFileRetrieveResult {
+type LogFileRetrieveResult = {
   filePath?: string;
   success: boolean;
-}
+};
 
 export class QuickLaunch {
   public async debugTest(

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/vscode-integration/commands/quickLaunch.test.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/vscode-integration/commands/quickLaunch.test.ts
@@ -11,7 +11,7 @@ import {
   TestResult
 } from '@salesforce/apex-node/lib/src/tests/types';
 import { AuthInfo, ConfigAggregator, Connection } from '@salesforce/core';
-import { MockTestOrgData, TestContext } from '@salesforce/core/lib/testSetup';
+import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import {
   ContinueResponse,
   notificationService,

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -393,7 +393,7 @@
       "dependencies": {
         "@salesforce/apex-tmlanguage": "1.4.0",
         "@salesforce/core": "7.2.0",
-        "@salesforce/source-tracking": "5.1.11",
+        "@salesforce/source-tracking": "6.0.2",
         "@salesforce/templates": "^60.1.0",
         "applicationinsights": "1.0.7",
         "shelljs": "0.8.5"

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -322,7 +322,7 @@
   "dependencies": {
     "@salesforce/apex-node": "6.0.0",
     "@salesforce/apex-tmlanguage": "1.8.0",
-    "@salesforce/core": "7.2.0",
+    "@salesforce/core": "7.3.1",
     "@salesforce/salesforcedx-utils-vscode": "60.10.0",
     "expand-home-dir": "0.0.3",
     "find-java-home": "0.2.0",
@@ -392,8 +392,8 @@
     "packageUpdates": {
       "dependencies": {
         "@salesforce/apex-tmlanguage": "1.4.0",
-        "@salesforce/core": "7.2.0",
-        "@salesforce/source-tracking": "6.0.2",
+        "@salesforce/core": "7.3.1",
+        "@salesforce/source-tracking": "6.0.4",
         "@salesforce/templates": "^60.1.2",
         "applicationinsights": "1.0.7",
         "shelljs": "0.8.5"

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -320,7 +320,7 @@
     }
   },
   "dependencies": {
-    "@salesforce/apex-node": "4.0.5",
+    "@salesforce/apex-node": "5.0.0-beta.0",
     "@salesforce/apex-tmlanguage": "1.8.0",
     "@salesforce/core": "7.2.0",
     "@salesforce/salesforcedx-utils-vscode": "60.9.0",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -320,7 +320,7 @@
     }
   },
   "dependencies": {
-    "@salesforce/apex-node": "5.0.0-beta.0",
+    "@salesforce/apex-node": "6.0.0",
     "@salesforce/apex-tmlanguage": "1.8.0",
     "@salesforce/core": "7.2.0",
     "@salesforce/salesforcedx-utils-vscode": "60.10.0",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -394,7 +394,7 @@
         "@salesforce/apex-tmlanguage": "1.4.0",
         "@salesforce/core": "7.2.0",
         "@salesforce/source-tracking": "6.0.2",
-        "@salesforce/templates": "^60.1.0",
+        "@salesforce/templates": "^60.1.2",
         "applicationinsights": "1.0.7",
         "shelljs": "0.8.5"
       },

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -322,7 +322,7 @@
   "dependencies": {
     "@salesforce/apex-node": "4.0.5",
     "@salesforce/apex-tmlanguage": "1.8.0",
-    "@salesforce/core": "6.7.4",
+    "@salesforce/core": "7.2.0",
     "@salesforce/salesforcedx-utils-vscode": "60.9.0",
     "expand-home-dir": "0.0.3",
     "find-java-home": "0.2.0",
@@ -392,7 +392,7 @@
     "packageUpdates": {
       "dependencies": {
         "@salesforce/apex-tmlanguage": "1.4.0",
-        "@salesforce/core": "6.7.4",
+        "@salesforce/core": "7.2.0",
         "@salesforce/source-tracking": "5.1.11",
         "@salesforce/templates": "^60.1.0",
         "applicationinsights": "1.0.7",

--- a/packages/salesforcedx-vscode-apex/src/commands/anonApexExecute.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/anonApexExecute.ts
@@ -28,11 +28,11 @@ import { OUTPUT_CHANNEL, channelService } from '../channels';
 import { workspaceContext } from '../context';
 import { nls } from '../messages';
 
-interface ApexExecuteParameters {
+type ApexExecuteParameters = {
   apexCode?: string;
   fileName?: string;
   selection?: vscode.Range;
-}
+};
 
 export class AnonApexGatherer
   implements ParametersGatherer<ApexExecuteParameters>

--- a/packages/salesforcedx-vscode-apex/src/commands/apexLogGet.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/apexLogGet.ts
@@ -23,10 +23,10 @@ import { nls } from '../messages';
 
 const LOG_DIRECTORY = projectPaths.debugLogsFolder();
 
-interface ApexDebugLogItem extends vscode.QuickPickItem {
+type ApexDebugLogItem = vscode.QuickPickItem & {
   id: string;
   startTime: string;
-}
+};
 
 export type ApexDebugLogIdStartTime = {
   id: string;

--- a/packages/salesforcedx-vscode-apex/src/commands/apexTestRun.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/apexTestRun.ts
@@ -55,9 +55,9 @@ export enum TestType {
   Suite,
   Class
 }
-export interface ApexTestQuickPickItem extends QuickPickItem {
+export type ApexTestQuickPickItem = QuickPickItem & {
   type: TestType;
-}
+};
 
 export class TestsSelector
   implements ParametersGatherer<ApexTestQuickPickItem>

--- a/packages/salesforcedx-vscode-apex/src/requirements.ts
+++ b/packages/salesforcedx-vscode-apex/src/requirements.ts
@@ -22,10 +22,10 @@ const findJavaHome = require('find-java-home');
 
 export const JAVA_HOME_KEY = 'salesforcedx-vscode-apex.java.home';
 export const JAVA_MEMORY_KEY = 'salesforcedx-vscode-apex.java.memory';
-export interface RequirementsData {
+export type RequirementsData = {
   java_home: string;
   java_memory: number | null;
-}
+};
 
 /**
  * Resolves the requirements needed to run the extension.
@@ -103,19 +103,21 @@ export const checkJavaVersion = async (javaHome: string): Promise<boolean> => {
   const cmdFile = path.join(javaHome, 'bin', 'java');
   const commandOptions = ['-XshowSettings:properties', '-version'];
   return new Promise((resolve, reject) => {
-    cp.execFile(cmdFile,
-      commandOptions,
-      {},
-      (error, stdout, stderr) => {
-        if (error) {
-          reject(nls.localize('java_version_check_command_failed', `${cmdFile} ${commandOptions.join(' ')}`, error.message));
-        }
-        if (!/java\.version\s*=\s*(?:11|17)/g.test(stderr)) {
-          reject(nls.localize('wrong_java_version_text', SET_JAVA_DOC_LINK));
-        } else {
-          resolve(true);
-        }
+    cp.execFile(cmdFile, commandOptions, {}, (error, stdout, stderr) => {
+      if (error) {
+        reject(
+          nls.localize(
+            'java_version_check_command_failed',
+            `${cmdFile} ${commandOptions.join(' ')}`,
+            error.message
+          )
+        );
       }
-    );
+      if (!/java\.version\s*=\s*(?:11|17)/g.test(stderr)) {
+        reject(nls.localize('wrong_java_version_text', SET_JAVA_DOC_LINK));
+      } else {
+        resolve(true);
+      }
+    });
   });
 };

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/apexExecute.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/apexExecute.test.ts
@@ -6,7 +6,7 @@
  */
 import { ExecuteService } from '@salesforce/apex-node';
 import { AuthInfo, ConfigAggregator, Connection } from '@salesforce/core';
-import { MockTestOrgData, TestContext } from '@salesforce/core/lib/testSetup';
+import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import {
   ChannelService,
   ContinueResponse,

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/launchApexReplayDebuggerWithCurrentFile.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/launchApexReplayDebuggerWithCurrentFile.test.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { TestContext } from '@salesforce/core/lib/testSetup';
+import { TestContext } from '@salesforce/core/testSetup';
 import {
   fileUtils,
   notificationService,

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/embeddedSoql/soqlCompletion.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/embeddedSoql/soqlCompletion.test.ts
@@ -33,12 +33,12 @@ import { soqlMiddleware } from '../../../src/embeddedSoql';
 
 const SOQL_SPECIAL_COMPLETION_ITEM_LABEL = '_SOQL_';
 
-interface JavaApexLocation {
+type JavaApexLocation = {
   startIndex: number;
   endIndex: number;
   line: number;
   column: number;
-}
+};
 const createApexLSPSpecialSOQLCompletionItem = (
   soqlText: string,
   location: JavaApexLocation
@@ -124,9 +124,8 @@ describe('Test embedded SOQL middleware to forward to SOQL LSP for code-completi
       expect(items.length).to.equal(1);
       expect(items[0]).to.equal(FAKE_SOQL_COMPLETION_ITEM);
       const virtualDocUri = executeCommandSpy.lastCall.args[1];
-      const soqlVirtualDoc = await vscode.workspace.openTextDocument(
-        virtualDocUri
-      );
+      const soqlVirtualDoc =
+        await vscode.workspace.openTextDocument(virtualDocUri);
       expect(soqlVirtualDoc.getText()).to.equal(soqlCode.replace('|', ''));
     });
   });
@@ -182,7 +181,10 @@ const prepareFile = async (
   return { doc: await activate(fileUri), position };
 };
 
-const getCursorPosition  =(text: string, cursorChar: string = '|'): Position => {
+const getCursorPosition = (
+  text: string,
+  cursorChar: string = '|'
+): Position => {
   for (const [line, lineText] of text.split('\n').entries()) {
     const column = lineText.indexOf(cursorChar);
     if (column >= 0) return new Position(line, column);

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -24,7 +24,7 @@
     "Other"
   ],
   "dependencies": {
-    "@salesforce/core": "6.7.4",
+    "@salesforce/core": "7.2.0",
     "@salesforce/salesforcedx-sobjects-faux-generator": "60.9.0",
     "@salesforce/salesforcedx-utils-vscode": "60.9.0",
     "@salesforce/schemas": "^1.6.1",
@@ -96,7 +96,7 @@
       "main": "dist/index.js",
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "@salesforce/core": "6.7.4",
+        "@salesforce/core": "7.2.0",
         "@salesforce/source-tracking": "5.1.11",
         "@salesforce/templates": "^60.1.0",
         "@salesforce/source-deploy-retrieve": "10.3.3",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -97,7 +97,7 @@
       "dependencies": {
         "applicationinsights": "1.0.7",
         "@salesforce/core": "7.2.0",
-        "@salesforce/source-tracking": "5.1.11",
+        "@salesforce/source-tracking": "6.0.2",
         "@salesforce/templates": "^60.1.0",
         "@salesforce/source-deploy-retrieve": "11.0.1",
         "shelljs": "0.8.5"

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -34,7 +34,7 @@
     "adm-zip": "0.5.10",
     "applicationinsights": "1.0.7",
     "glob": "^7.1.2",
-    "jsforce": "2.0.0-beta.29",
+    "@jsforce/jsforce-node": "3.1.0",
     "rxjs": "^5.4.1",
     "sanitize-filename": "^1.6.1",
     "shelljs": "0.8.5"

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -24,18 +24,18 @@
     "Other"
   ],
   "dependencies": {
-    "@salesforce/core": "7.2.0",
+    "@salesforce/core": "7.3.1",
     "@salesforce/salesforcedx-sobjects-faux-generator": "60.10.0",
     "@salesforce/salesforcedx-utils-vscode": "60.10.0",
     "@salesforce/schemas": "^1.6.1",
-    "@salesforce/source-deploy-retrieve": "11.0.1",
+    "@salesforce/source-deploy-retrieve": "11.1.2",
     "@salesforce/templates": "^60.1.2",
     "@salesforce/ts-types": "2.0.9",
     "@salesforce/vscode-service-provider": "1.0.4",
     "adm-zip": "0.5.10",
     "applicationinsights": "1.0.7",
     "glob": "^7.1.2",
-    "@jsforce/jsforce-node": "3.1.0",
+    "@jsforce/jsforce-node": "3.2.0",
     "rxjs": "^5.4.1",
     "sanitize-filename": "^1.6.1",
     "shelljs": "0.8.5"
@@ -97,10 +97,10 @@
       "main": "dist/index.js",
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "@salesforce/core": "7.2.0",
-        "@salesforce/source-tracking": "6.0.2",
+        "@salesforce/core": "7.3.1",
+        "@salesforce/source-tracking": "6.0.4",
         "@salesforce/templates": "^60.1.2",
-        "@salesforce/source-deploy-retrieve": "11.0.1",
+        "@salesforce/source-deploy-retrieve": "11.1.2",
         "shelljs": "0.8.5"
       },
       "devDependencies": {}

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -28,7 +28,7 @@
     "@salesforce/salesforcedx-sobjects-faux-generator": "60.9.0",
     "@salesforce/salesforcedx-utils-vscode": "60.9.0",
     "@salesforce/schemas": "^1.6.1",
-    "@salesforce/source-deploy-retrieve": "10.3.3",
+    "@salesforce/source-deploy-retrieve": "11.0.1",
     "@salesforce/templates": "^60.1.0",
     "@salesforce/ts-types": "2.0.9",
     "adm-zip": "0.5.10",
@@ -99,7 +99,7 @@
         "@salesforce/core": "7.2.0",
         "@salesforce/source-tracking": "5.1.11",
         "@salesforce/templates": "^60.1.0",
-        "@salesforce/source-deploy-retrieve": "10.3.3",
+        "@salesforce/source-deploy-retrieve": "11.0.1",
         "shelljs": "0.8.5"
       },
       "devDependencies": {}

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -29,7 +29,7 @@
     "@salesforce/salesforcedx-utils-vscode": "60.9.0",
     "@salesforce/schemas": "^1.6.1",
     "@salesforce/source-deploy-retrieve": "11.0.1",
-    "@salesforce/templates": "^60.1.0",
+    "@salesforce/templates": "^60.1.2",
     "@salesforce/ts-types": "2.0.9",
     "adm-zip": "0.5.10",
     "applicationinsights": "1.0.7",
@@ -98,7 +98,7 @@
         "applicationinsights": "1.0.7",
         "@salesforce/core": "7.2.0",
         "@salesforce/source-tracking": "6.0.2",
-        "@salesforce/templates": "^60.1.0",
+        "@salesforce/templates": "^60.1.2",
         "@salesforce/source-deploy-retrieve": "11.0.1",
         "shelljs": "0.8.5"
       },

--- a/packages/salesforcedx-vscode-core/src/commands/auth/authParamsGatherer.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/auth/authParamsGatherer.ts
@@ -20,16 +20,16 @@ export const PRODUCTION_URL = 'https://login.salesforce.com';
 export const SANDBOX_URL = 'https://test.salesforce.com';
 export const INSTANCE_URL_PLACEHOLDER = 'https://na35.salesforce.com';
 
-export interface AuthParams {
+export type AuthParams = {
   alias: string;
   loginUrl: string;
-}
+};
 
-export interface AccessTokenParams {
+export type AccessTokenParams = {
   alias: string;
   instanceUrl: string;
   accessToken: string;
-}
+};
 
 async function inputInstanceUrl() {
   const instanceUrlInputOptions = {

--- a/packages/salesforcedx-vscode-core/src/commands/auth/orgLoginWeb.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/auth/orgLoginWeb.ts
@@ -39,12 +39,12 @@ import {
 import { AuthParams, AuthParamsGatherer } from './authParamsGatherer';
 import { OrgLogoutAll } from './orgLogout';
 
-export interface DeviceCodeResponse {
+export type DeviceCodeResponse = {
   user_code: string;
   device_code: string;
   interval: number;
   verification_uri: string;
-}
+};
 
 export class OrgLoginWebContainerExecutor extends SfCommandletExecutor<AuthParams> {
   protected showChannelOutput = false;

--- a/packages/salesforcedx-vscode-core/src/commands/auth/orgLoginWebDevHub.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/auth/orgLoginWebDevHub.ts
@@ -102,9 +102,9 @@ export class AuthDevHubParamsGatherer
   }
 }
 
-export interface AuthDevHubParams {
+export type AuthDevHubParams = {
   alias: string;
-}
+};
 
 const workspaceChecker = new SfWorkspaceChecker();
 const parameterGatherer = new AuthDevHubParamsGatherer();

--- a/packages/salesforcedx-vscode-core/src/commands/dataQuery.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/dataQuery.ts
@@ -90,10 +90,10 @@ export class GetQueryAndApiInputs
   }
 }
 
-export interface QueryAndApiInputs {
+export type QueryAndApiInputs = {
   query: string;
   api: ApiType;
-}
+};
 
 export enum ApiType {
   REST,

--- a/packages/salesforcedx-vscode-core/src/commands/debuggerStop.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/debuggerStop.ts
@@ -28,20 +28,20 @@ import {
   SfWorkspaceChecker
 } from './util';
 
-interface QueryResponse {
+type QueryResponse = {
   status: number;
   result: QueryResult;
-}
+};
 
-interface QueryResult {
+type QueryResult = {
   size: number;
   totalSize: number;
   records: QueryRecord[];
-}
+};
 
-interface QueryRecord {
+type QueryRecord = {
   Id: string;
-}
+};
 
 export type IdSelection = { id: string };
 export class IdGatherer implements ParametersGatherer<IdSelection> {

--- a/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
@@ -43,14 +43,14 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unused-vars
 const AdmZip = require('adm-zip');
 
-export interface InstalledPackageInfo {
+export type InstalledPackageInfo = {
   id: string;
   name: string;
   namespace: string;
   versionId: string;
   versionName: string;
   versionNumber: string;
-}
+};
 
 export const ISVDEBUGGER = 'isvdebuggermdapitmp';
 export const INSTALLED_PACKAGES = 'installed-packages';
@@ -455,11 +455,11 @@ export class IsvDebugBootstrapExecutor extends SfCommandletExecutor<{}> {
 export type IsvDebugBootstrapConfig = ProjectNameAndPathAndTemplate &
   ForceIdeUri;
 
-export interface ForceIdeUri {
+export type ForceIdeUri = {
   loginUrl: string;
   sessionId: string;
   orgName: string;
-}
+};
 
 export class EnterForceIdeUri implements ParametersGatherer<ForceIdeUri> {
   public static readonly uriValidator = (value: string) => {

--- a/packages/salesforcedx-vscode-core/src/commands/orgCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/orgCreate.ts
@@ -171,10 +171,10 @@ export class AliasGatherer implements ParametersGatherer<Alias> {
     };
   }
 }
-export interface Alias {
+export type Alias = {
   alias: string;
   expirationDays: string;
-}
+};
 
 export type AliasAndFileSelection = Alias & FileSelection;
 

--- a/packages/salesforcedx-vscode-core/src/commands/packageInstall.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/packageInstall.ts
@@ -53,13 +53,13 @@ export class PackageInstallExecutor extends SfCommandletExecutor<PackageIdAndIns
 
 export type PackageIdAndInstallationKey = PackageID & InstallationKey;
 
-export interface PackageID {
+export type PackageID = {
   packageId: string;
-}
+};
 
-export interface InstallationKey {
+export type InstallationKey = {
   installationKey: string;
-}
+};
 
 export class SelectPackageID implements ParametersGatherer<PackageID> {
   public async gather(): Promise<CancelResponse | ContinueResponse<PackageID>> {

--- a/packages/salesforcedx-vscode-core/src/commands/projectGenerate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/projectGenerate.ts
@@ -87,17 +87,17 @@ export type ProjectNameAndPathAndTemplate = ProjectName &
   ProjectURI &
   ProjectTemplate;
 
-export interface ProjectURI {
+export type ProjectURI = {
   projectUri: string;
-}
+};
 
-export interface ProjectName {
+export type ProjectName = {
   projectName: string;
-}
+};
 
-export interface ProjectTemplate {
+export type ProjectTemplate = {
   projectTemplate: string;
-}
+};
 
 export class SelectProjectTemplate
   implements ParametersGatherer<ProjectTemplate>

--- a/packages/salesforcedx-vscode-core/src/commands/renameLightningComponent.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/renameLightningComponent.ts
@@ -73,7 +73,7 @@ export const renameLightningComponent = (sourceUri: vscode.Uri): void => {
     );
     void commandlet.run();
   }
-}
+};
 export type ComponentName = {
   name?: string;
 };

--- a/packages/salesforcedx-vscode-core/src/commands/renameLightningComponent.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/renameLightningComponent.ts
@@ -74,9 +74,9 @@ export async function renameLightningComponent(sourceUri: vscode.Uri) {
     await commandlet.run();
   }
 }
-export interface ComponentName {
+export type ComponentName = {
   name?: string;
-}
+};
 export class GetComponentName implements ParametersGatherer<ComponentName> {
   private sourceFsPath: string;
   constructor(sourceFsPath: string) {

--- a/packages/salesforcedx-vscode-core/src/commands/retrieveMetadata/retrieveDescriber.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/retrieveMetadata/retrieveDescriber.ts
@@ -10,7 +10,7 @@ import { LocalComponent } from '@salesforce/salesforcedx-utils-vscode';
 /**
  * Provides information for force.source.retrieve.component execution
  */
-export interface RetrieveDescriber {
+export type RetrieveDescriber = {
   /**
    * Builds the force:source:retrieve metadata argument
    * @param data optional data to use while building the argument
@@ -23,4 +23,4 @@ export interface RetrieveDescriber {
    * @returns local representations of components
    */
   gatherOutputLocations(): Promise<LocalComponent[]>;
-}
+};

--- a/packages/salesforcedx-vscode-core/src/commands/retrieveMetadata/retrieveMetadataTrigger.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/retrieveMetadata/retrieveMetadataTrigger.ts
@@ -10,9 +10,9 @@ import { RetrieveDescriber } from './retrieveDescriber';
 /**
  * An object capable of triggering the force:source:retrieve metadata command
  */
-export interface RetrieveMetadataTrigger {
+export type RetrieveMetadataTrigger = {
   /**
    * The RetrieveDescriber to use for the retrieve execution
    */
   describer(): RetrieveDescriber;
-}
+};

--- a/packages/salesforcedx-vscode-core/src/commands/templates/analyticsGenerateTemplate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/analyticsGenerateTemplate.ts
@@ -56,10 +56,10 @@ export class LibraryAnalyticsGenerateTemplateExecutor extends LibraryBaseTemplat
 
 export type TemplateAndDir = DirFileNameSelection & Template;
 
-export interface Template {
+export type Template = {
   // fileName is the templateName
   fileName: string;
-}
+};
 
 export class SelectProjectTemplate implements ParametersGatherer<Template> {
   public async gather(): Promise<CancelResponse | ContinueResponse<Template>> {

--- a/packages/salesforcedx-vscode-core/src/commands/templates/libraryBaseTemplateCommand.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/libraryBaseTemplateCommand.ts
@@ -26,10 +26,10 @@ import {
   SourcePathStrategy
 } from '../util';
 
-interface ExecutionResult {
+type ExecutionResult = {
   output?: string;
   error?: Error;
-}
+};
 
 /**
  * Base class for all template commands

--- a/packages/salesforcedx-vscode-core/src/commands/util/commandParams.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/commandParams.ts
@@ -5,9 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export interface CommandParams {
+export type CommandParams = {
   readonly command: string;
   // handle to localized user facing help text, with entries for diff flags
   description: Record<string, string>;
   logName: Record<string, string>; // metric key
-}
+};

--- a/packages/salesforcedx-vscode-core/src/commands/util/commandletExecutor.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/commandletExecutor.ts
@@ -8,7 +8,7 @@
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode';
 import * as vscode from 'vscode';
 
-export interface CommandletExecutor<T> {
+export type CommandletExecutor<T> = {
   execute(response: ContinueResponse<T>): void;
   readonly onDidFinishExecution?: vscode.Event<[number, number]>;
-}
+};

--- a/packages/salesforcedx-vscode-core/src/commands/util/conflictDetectionMessages.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/conflictDetectionMessages.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export interface ConflictDetectionMessages {
+export type ConflictDetectionMessages = {
   warningMessageKey: string;
   commandHint: (input: string | string[]) => string;
-}
+};

--- a/packages/salesforcedx-vscode-core/src/commands/util/flagParameter.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/flagParameter.ts
@@ -5,6 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export interface FlagParameter<T> {
+export type FlagParameter<T> = {
   flag?: T;
-}
+};

--- a/packages/salesforcedx-vscode-core/src/commands/util/sourcePathStrategies.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/sourcePathStrategies.ts
@@ -79,9 +79,9 @@ class LwcTestPathStrategy implements SourcePathStrategy {
   }
 }
 
-export interface SourcePathStrategy {
+export type SourcePathStrategy = {
   getPathToSource(dirPath: string, fileName: string, fileExt: string): string;
-}
+};
 
 export class PathStrategyFactory {
   public static createDefaultStrategy(): DefaultPathStrategy {

--- a/packages/salesforcedx-vscode-core/src/conflict/componentDiffer.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/componentDiffer.ts
@@ -9,10 +9,10 @@ import { SourceComponent } from '@salesforce/source-deploy-retrieve';
 import * as fs from 'fs';
 import * as path from 'path';
 
-export interface ComponentDiff {
+export type ComponentDiff = {
   projectPath: string;
   cachePath: string;
-}
+};
 
 /**
  * Finds the file paths of files that differ for a component stored in two locations
@@ -33,7 +33,7 @@ export function diffComponents(
   if (projectComponent.xml) {
     projectPaths.push(projectComponent.xml);
   }
-  const projectRoot = projectComponent.content ?? (projectComponent.xml ?? '');
+  const projectRoot = projectComponent.content ?? projectComponent.xml ?? '';
   for (const file of projectPaths) {
     const key = path.relative(projectRoot, file);
     projectIndex.set(key, file);
@@ -44,7 +44,7 @@ export function diffComponents(
   if (cacheComponent.xml) {
     cachePaths.push(cacheComponent.xml);
   }
-  const cacheRoot = cacheComponent.content ?? (cacheComponent.xml ?? '');
+  const cacheRoot = cacheComponent.content ?? cacheComponent.xml ?? '';
   for (const file of cachePaths) {
     const key = path.relative(cacheRoot, file);
     cacheIndex.set(key, file);

--- a/packages/salesforcedx-vscode-core/src/conflict/directoryDiffer.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/directoryDiffer.ts
@@ -16,30 +16,30 @@ import { notificationService } from '../notifications';
 import { telemetryService } from '../telemetry';
 import { MetadataCacheResult } from './metadataCacheService';
 
-export interface TimestampFileProperties {
+export type TimestampFileProperties = {
   localRelPath: string;
   remoteRelPath: string;
   localLastModifiedDate?: string | undefined;
   remoteLastModifiedDate?: string | undefined;
-}
+};
 
-export interface DirectoryDiffResults {
+export type DirectoryDiffResults = {
   different: Set<TimestampFileProperties>;
   localRoot: string;
   remoteRoot: string;
   scannedLocal?: number;
   scannedRemote?: number;
-}
+};
 
-export interface DirectoryDiffer {
+export type DirectoryDiffer = {
   diff(localSourcePath: string, remoteSourcePath: string): DirectoryDiffResults;
-}
+};
 
-interface FileStats {
+type FileStats = {
   filename: string;
   subdir: string;
   relPath: string;
-}
+};
 
 export class CommonDirDirectoryDiffer implements DirectoryDiffer {
   constructor() {}

--- a/packages/salesforcedx-vscode-core/src/conflict/metadataCacheService.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/metadataCacheService.ts
@@ -23,11 +23,11 @@ import { SalesforcePackageDirectories } from '../salesforceProject';
 import { componentSetUtils } from '../services/sdr/componentSetUtils';
 import { workspaceUtils } from '../util';
 
-export interface MetadataContext {
+export type MetadataContext = {
   baseDirectory: string;
   commonRoot: string;
   components: SourceComponent[];
-}
+};
 
 export const enum PathType {
   Folder = 'folder',
@@ -36,7 +36,7 @@ export const enum PathType {
   Unknown = 'unknown'
 }
 
-export interface MetadataCacheResult {
+export type MetadataCacheResult = {
   selectedPath: string;
   selectedType: PathType;
 
@@ -44,18 +44,18 @@ export interface MetadataCacheResult {
   cache: MetadataContext;
   project: MetadataContext;
   properties: FileProperties[];
-}
+};
 
-export interface CorrelatedComponent {
+export type CorrelatedComponent = {
   cacheComponent: SourceComponent;
   projectComponent: SourceComponent;
   lastModifiedDate: string;
-}
+};
 
-interface RecomposedComponent {
+type RecomposedComponent = {
   component?: SourceComponent;
   children: Map<string, SourceComponent>;
-}
+};
 
 const STATE_FOLDER = projectPaths.relativeStateFolder();
 

--- a/packages/salesforcedx-vscode-core/src/conflict/persistentStorageService.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/persistentStorageService.ts
@@ -17,9 +17,9 @@ import { ExtensionContext, Memento } from 'vscode';
 import { WorkspaceContext } from '../context';
 import { nls } from '../messages';
 
-interface ConflictFileProperties {
+type ConflictFileProperties = {
   lastModifiedDate: string;
-}
+};
 
 export class PersistentStorageService {
   private storage: Memento;

--- a/packages/salesforcedx-vscode-core/src/orgBrowser/metadataCmp.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/metadataCmp.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { ListMetadataQuery } from '@jsforce/jsforce-node/lib/api/metadata';
 import { Connection } from '@salesforce/core';
 import {
   isNullOrUndefined,
@@ -12,7 +13,6 @@ import {
 } from '@salesforce/salesforcedx-utils-vscode';
 import { standardValueSet } from '@salesforce/source-deploy-retrieve/lib/src/registry';
 import * as fs from 'fs';
-import { ListMetadataQuery } from 'jsforce/api/metadata';
 import * as path from 'path';
 import { WorkspaceContext } from '../context';
 import { nls } from '../messages';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/auth/orgLoginWebDevHub.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/auth/orgLoginWebDevHub.test.ts
@@ -10,7 +10,7 @@ import {
   instantiateContext,
   restoreContext,
   stubContext
-} from '@salesforce/core/lib/testSetup';
+} from '@salesforce/core/testSetup';
 import { ConfigSource } from '@salesforce/salesforcedx-utils-vscode';
 import { expect } from 'chai';
 import { SinonSandbox, SinonSpy, SinonStub } from 'sinon';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
@@ -10,7 +10,7 @@ import {
   MockTestOrgData,
   restoreContext,
   stubContext
-} from '@salesforce/core/lib/testSetup';
+} from '@salesforce/core/testSetup';
 import {
   ConfigUtil,
   ContinueResponse,

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/deployManifest.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/deployManifest.test.ts
@@ -11,7 +11,7 @@ import {
   MockTestOrgData,
   restoreContext,
   stubContext
-} from '@salesforce/core/lib/testSetup';
+} from '@salesforce/core/testSetup';
 import { SourceTrackingService } from '@salesforce/salesforcedx-utils-vscode';
 import { ComponentSet } from '@salesforce/source-deploy-retrieve';
 import { expect } from 'chai';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/deploySourcePath.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/deploySourcePath.test.ts
@@ -11,7 +11,7 @@ import {
   MockTestOrgData,
   restoreContext,
   stubContext
-} from '@salesforce/core/lib/testSetup';
+} from '@salesforce/core/testSetup';
 import {
   ContinueResponse,
   fileUtils,

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/retrieveManifest.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/retrieveManifest.test.ts
@@ -10,7 +10,7 @@ import {
   MockTestOrgData,
   restoreContext,
   stubContext
-} from '@salesforce/core/lib/testSetup';
+} from '@salesforce/core/testSetup';
 import { SourceTrackingService } from '@salesforce/salesforcedx-utils-vscode';
 import { ComponentSet } from '@salesforce/source-deploy-retrieve';
 import { expect } from 'chai';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/retrieveMetadata/retrieveComponent.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/retrieveMetadata/retrieveComponent.test.ts
@@ -11,7 +11,7 @@ import {
   MockTestOrgData,
   restoreContext,
   stubContext
-} from '@salesforce/core/lib/testSetup';
+} from '@salesforce/core/testSetup';
 import {
   ContinueResponse,
   LocalComponent,

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/retrieveSourcePath.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/retrieveSourcePath.test.ts
@@ -11,7 +11,7 @@ import {
   MockTestOrgData,
   restoreContext,
   stubContext
-} from '@salesforce/core/lib/testSetup';
+} from '@salesforce/core/testSetup';
 import {
   CancelResponse,
   ContinueResponse,

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
@@ -10,7 +10,7 @@ import {
   MockTestOrgData,
   restoreContext,
   stubContext
-} from '@salesforce/core/lib/testSetup';
+} from '@salesforce/core/testSetup';
 import {
   projectPaths,
   WorkspaceContextUtil

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "@salesforce/aura-language-server": "4.8.0",
-    "@salesforce/core": "7.2.0",
+    "@salesforce/core": "7.3.1",
     "@salesforce/lightning-lsp-common": "4.8.0",
     "@salesforce/salesforcedx-utils-vscode": "60.10.0",
     "applicationinsights": "1.0.7",
@@ -118,8 +118,8 @@
       ],
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "@salesforce/core": "7.2.0",
-        "@salesforce/source-tracking": "6.0.2",
+        "@salesforce/core": "7.3.1",
+        "@salesforce/source-tracking": "6.0.4",
         "@salesforce/aura-language-server": "4.8.0",
         "@salesforce/lightning-lsp-common": "4.8.0"
       },

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "@salesforce/aura-language-server": "4.8.0",
-    "@salesforce/core": "6.7.4",
+    "@salesforce/core": "7.2.0",
     "@salesforce/lightning-lsp-common": "4.8.0",
     "@salesforce/salesforcedx-utils-vscode": "60.9.0",
     "applicationinsights": "1.0.7",
@@ -118,7 +118,7 @@
       ],
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "@salesforce/core": "6.7.4",
+        "@salesforce/core": "7.2.0",
         "@salesforce/source-tracking": "5.1.11",
         "@salesforce/aura-language-server": "4.8.0",
         "@salesforce/lightning-lsp-common": "4.8.0"

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -119,7 +119,7 @@
       "dependencies": {
         "applicationinsights": "1.0.7",
         "@salesforce/core": "7.2.0",
-        "@salesforce/source-tracking": "5.1.11",
+        "@salesforce/source-tracking": "6.0.2",
         "@salesforce/aura-language-server": "4.8.0",
         "@salesforce/lightning-lsp-common": "4.8.0"
       },

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -372,7 +372,7 @@
     }
   ],
   "dependencies": {
-    "@salesforce/core": "7.2.0",
+    "@salesforce/core": "7.3.1",
     "@salesforce/eslint-config-lwc": "3.5.1",
     "@salesforce/lightning-lsp-common": "4.8.0",
     "@salesforce/lwc-language-server": "4.8.0",
@@ -451,10 +451,10 @@
     ],
     "packageUpdates": {
       "dependencies": {
-        "@salesforce/core": "7.2.0",
+        "@salesforce/core": "7.3.1",
         "@salesforce/lightning-lsp-common": "4.8.0",
         "@salesforce/lwc-language-server": "4.8.0",
-        "@salesforce/source-tracking": "6.0.2",
+        "@salesforce/source-tracking": "6.0.4",
         "applicationinsights": "1.0.7"
       },
       "devDependencies": {},

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -454,7 +454,7 @@
         "@salesforce/core": "7.2.0",
         "@salesforce/lightning-lsp-common": "4.8.0",
         "@salesforce/lwc-language-server": "4.8.0",
-        "@salesforce/source-tracking": "5.1.11",
+        "@salesforce/source-tracking": "6.0.2",
         "applicationinsights": "1.0.7"
       },
       "devDependencies": {},

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -372,7 +372,7 @@
     }
   ],
   "dependencies": {
-    "@salesforce/core": "6.7.4",
+    "@salesforce/core": "7.2.0",
     "@salesforce/eslint-config-lwc": "3.5.1",
     "@salesforce/lightning-lsp-common": "4.8.0",
     "@salesforce/lwc-language-server": "4.8.0",
@@ -451,7 +451,7 @@
     ],
     "packageUpdates": {
       "dependencies": {
-        "@salesforce/core": "6.7.4",
+        "@salesforce/core": "7.2.0",
         "@salesforce/lightning-lsp-common": "4.8.0",
         "@salesforce/lwc-language-server": "4.8.0",
         "@salesforce/source-tracking": "5.1.11",

--- a/packages/salesforcedx-vscode-lwc/src/commands/lightningLwcPreview.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/lightningLwcPreview.ts
@@ -41,24 +41,24 @@ export const enum PlatformName {
   iOS = 'iOS'
 }
 
-interface IOSSimulatorDevice {
+type IOSSimulatorDevice = {
   name: string;
   udid: string;
   state: string;
   runtimeId: string;
   isAvailable: boolean;
-}
+};
 
-interface AndroidVirtualDevice {
+type AndroidVirtualDevice = {
   name: string;
   displayName: string;
   deviceName: string;
   path: string;
   target: string;
   api: string;
-}
+};
 
-interface PreviewQuickPickItem extends vscode.QuickPickItem {
+type PreviewQuickPickItem = vscode.QuickPickItem & {
   label: string;
   detail: string;
   alwaysShow: boolean;
@@ -66,11 +66,11 @@ interface PreviewQuickPickItem extends vscode.QuickPickItem {
   id: PreviewPlatformType;
   defaultTargetName: string;
   platformName: keyof typeof PlatformName;
-}
+};
 
-export interface DeviceQuickPickItem extends vscode.QuickPickItem {
+export type DeviceQuickPickItem = vscode.QuickPickItem & {
   name: string;
-}
+};
 
 export const platformOptions: PreviewQuickPickItem[] = [
   {

--- a/packages/salesforcedx-vscode-lwc/src/commands/lightningLwcStart.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/lightningLwcStart.ts
@@ -39,12 +39,12 @@ export const enum errorHints {
   INACTIVE_SCRATCH_ORG = 'Error authenticating to your scratch org. Make sure that it is still active'
 }
 
-export interface LightningLwcStartOptions {
+export type LightningLwcStartOptions = {
   /** whether to automatically open the browser after server start */
   openBrowser: boolean;
   /** component name to preview in the browser */
   componentName?: string;
-}
+};
 
 export class LightningLwcStartExecutor extends SfCommandletExecutor<{}> {
   private readonly options: LightningLwcStartOptions;

--- a/packages/salesforcedx-vscode-lwc/src/service/devServerService.ts
+++ b/packages/salesforcedx-vscode-lwc/src/service/devServerService.ts
@@ -11,9 +11,9 @@ import {
   DEV_SERVER_PREVIEW_ROUTE
 } from '../commands/commandConstants';
 
-export interface ServerHandler {
+export type ServerHandler = {
   stop(): Promise<void>;
-}
+};
 
 export class DevServerService {
   private static _instance: DevServerService;

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/testRunner/taskService.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/testRunner/taskService.ts
@@ -8,9 +8,9 @@ import * as vscode from 'vscode';
 import { channelService } from '../../channel';
 import { nls } from '../../messages';
 
-interface SfTaskDefinition extends vscode.TaskDefinition {
+type SfTaskDefinition = vscode.TaskDefinition & {
   sfTaskId: string;
-}
+};
 
 /**
  * A wrapper over vscode.Task that emits events during task lifecycle

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/types/index.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/types/index.ts
@@ -26,12 +26,12 @@ export const enum TestResultStatus {
 }
 
 /**
- * Test Result interface contains the test result status.
+ * Test Result type contains the test result status.
  * For now, failure messages are stored in DiagnosticCollection instead of here.
  */
-export interface TestResult {
+export type TestResult = {
   status: TestResultStatus;
-}
+};
 
 /**
  * The discriminant enum for the TestExecutionInfo discriminated union.
@@ -56,18 +56,18 @@ export const isTestCaseInfo = (
  * The title and ancestorTitles will be used to match and merge with the existing test cases
  * created by test file parser.
  */
-export interface RawTestResult {
+export type RawTestResult = {
   title: string;
   ancestorTitles?: string[];
   status: TestResultStatus;
-}
+};
 
 /**
  * Test File Information.
  * It contains the test's URI, location (The beginning of the documentation by default),
  * test results and associated test cases information.
  */
-export interface TestFileInfo {
+export type TestFileInfo = {
   kind: TestInfoKind.TEST_FILE;
   testType: TestType;
   testUri: Uri;
@@ -75,14 +75,14 @@ export interface TestFileInfo {
   testResult?: TestResult;
   testCasesInfo?: TestCaseInfo[];
   rawTestResults?: RawTestResult[];
-}
+};
 
 /**
  * Test Case Information.
  * It contains the test case's URI, location, and
  * test name and ancestor titles, which are used for matching with test results.
  */
-export interface TestCaseInfo {
+export type TestCaseInfo = {
   kind: TestInfoKind.TEST_CASE;
   testType: TestType;
   testUri: Uri;
@@ -90,18 +90,18 @@ export interface TestCaseInfo {
   testResult?: TestResult;
   testName: string;
   ancestorTitles?: string[];
-}
+};
 
 /**
  * Test Directory Information.
  * It contains the test directory Uri.
  */
-export interface TestDirectoryInfo {
+export type TestDirectoryInfo = {
   kind: TestInfoKind.TEST_DIRECTORY;
   testType: TestType;
   testUri: Uri;
   testResult?: TestResult;
-}
+};
 
 /**
  * Test Execution Information.
@@ -112,7 +112,7 @@ export type TestExecutionInfo = TestCaseInfo | TestFileInfo | TestDirectoryInfo;
 /**
  * Top level Jest output JSON object shape
  */
-export interface LwcJestTestResults {
+export type LwcJestTestResults = {
   numFailedTestSuites: number;
   numFailedTests: number;
   numPassedTestSuites: number;
@@ -123,7 +123,7 @@ export interface LwcJestTestResults {
   numTotalTestSuites: number;
   numTotalTests: number;
   testResults: LwcJestTestFileResult[];
-}
+};
 
 /**
  * Jest Test Assertion Result status.
@@ -142,18 +142,18 @@ type LwcJestTestResultStatus =
 /**
  * Jest Test File Result
  */
-export interface LwcJestTestFileResult {
+export type LwcJestTestFileResult = {
   status: 'passed' | 'failed';
   startTime: number;
   endTime: number;
   name: string;
   assertionResults: LwcJestTestAssertionResult[];
-}
+};
 
 /**
  * Jest Test Assertion Result
  */
-export interface LwcJestTestAssertionResult {
+export type LwcJestTestAssertionResult = {
   status: LwcJestTestResultStatus;
   title: string;
   ancestorTitles: string[];
@@ -163,4 +163,4 @@ export interface LwcJestTestAssertionResult {
     column: number;
     line: number;
   };
-}
+};

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -37,7 +37,7 @@
     "@salesforce/soql-data-view": "0.1.0",
     "@salesforce/soql-language-server": "0.7.1",
     "@salesforce/soql-model": "0.2.3",
-    "jsforce": "2.0.0-beta.29"
+    "@jsforce/jsforce-node": "3.1.0"
   },
   "devDependencies": {
     "@salesforce/salesforcedx-sobjects-faux-generator": "60.9.0",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -32,12 +32,12 @@
   ],
   "dependencies": {
     "@salesforce/apex-tmlanguage": "1.6.0",
-    "@salesforce/core": "7.2.0",
+    "@salesforce/core": "7.3.1",
     "@salesforce/soql-builder-ui": "0.2.0",
     "@salesforce/soql-data-view": "0.1.0",
     "@salesforce/soql-language-server": "0.7.1",
     "@salesforce/soql-model": "0.2.3",
-    "@jsforce/jsforce-node": "3.1.0"
+    "@jsforce/jsforce-node": "3.2.0"
   },
   "devDependencies": {
     "@salesforce/salesforcedx-sobjects-faux-generator": "60.10.0",
@@ -138,8 +138,8 @@
       "dependencies": {
         "applicationinsights": "1.0.7",
         "@salesforce/apex-tmlanguage": "1.6.0",
-        "@salesforce/core": "7.2.0",
-        "@salesforce/source-tracking": "6.0.2",
+        "@salesforce/core": "7.3.1",
+        "@salesforce/source-tracking": "6.0.4",
         "shelljs": "0.8.5",
         "@salesforce/soql-builder-ui": "0.2.0",
         "@salesforce/soql-data-view": "0.1.0",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "@salesforce/apex-tmlanguage": "1.6.0",
-    "@salesforce/core": "6.7.4",
+    "@salesforce/core": "7.2.0",
     "@salesforce/soql-builder-ui": "0.2.0",
     "@salesforce/soql-data-view": "0.1.0",
     "@salesforce/soql-language-server": "0.7.1",
@@ -138,7 +138,7 @@
       "dependencies": {
         "applicationinsights": "1.0.7",
         "@salesforce/apex-tmlanguage": "1.6.0",
-        "@salesforce/core": "6.7.4",
+        "@salesforce/core": "7.2.0",
         "@salesforce/source-tracking": "5.1.11",
         "shelljs": "0.8.5",
         "@salesforce/soql-builder-ui": "0.2.0",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -139,7 +139,7 @@
         "applicationinsights": "1.0.7",
         "@salesforce/apex-tmlanguage": "1.6.0",
         "@salesforce/core": "7.2.0",
-        "@salesforce/source-tracking": "5.1.11",
+        "@salesforce/source-tracking": "6.0.2",
         "shelljs": "0.8.5",
         "@salesforce/soql-builder-ui": "0.2.0",
         "@salesforce/soql-data-view": "0.1.0",

--- a/packages/salesforcedx-vscode-soql/src/editor/queryRunner.ts
+++ b/packages/salesforcedx-vscode-soql/src/editor/queryRunner.ts
@@ -5,10 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { QueryResult } from '@jsforce/jsforce-node';
 import { Connection } from '@salesforce/core';
 import { soqlComments } from '@salesforce/soql-common';
 import { JsonMap } from '@salesforce/ts-types';
-import { QueryResult } from 'jsforce';
 import * as vscode from 'vscode';
 import { nls } from '../messages';
 export class QueryRunner {
@@ -21,9 +21,7 @@ export class QueryRunner {
     const pureSOQLText = soqlComments.parseHeaderComments(queryText).soqlText;
 
     try {
-      const rawQueryData = (await this.connection.query(
-        pureSOQLText
-      ));
+      const rawQueryData = await this.connection.query(pureSOQLText);
       const cleanQueryData = {
         ...rawQueryData,
         records: this.flattenQueryRecords(rawQueryData.records)

--- a/packages/salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts
+++ b/packages/salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts
@@ -25,10 +25,10 @@ import { TelemetryModelJson } from '../telemetry';
 import { QueryRunner } from './queryRunner';
 
 // TODO: This should be exported from soql-builder-ui
-export interface SoqlEditorEvent {
+export type SoqlEditorEvent = {
   type: string;
   payload?: string | string[] | JsonMap;
-}
+};
 
 // TODO: This should be shared with soql-builder-ui
 export enum MessageType {

--- a/packages/salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts
+++ b/packages/salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts
@@ -5,10 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { DescribeSObjectResult, QueryResult } from '@jsforce/jsforce-node';
 import { Connection } from '@salesforce/core';
 import { JsonMap } from '@salesforce/ts-types';
 import { debounce } from 'debounce';
-import { DescribeSObjectResult, QueryResult } from 'jsforce';
 import * as vscode from 'vscode';
 import { trackErrorWithTelemetry } from '../commonUtils';
 import { nls } from '../messages';

--- a/packages/salesforcedx-vscode-soql/src/lspClient/orgMetadata.ts
+++ b/packages/salesforcedx-vscode-soql/src/lspClient/orgMetadata.ts
@@ -22,10 +22,10 @@ import { channelService, retrieveSObject, retrieveSObjects } from '../sf';
 
 export { SObject, SObjectField };
 
-export interface OrgDataSource {
+export type OrgDataSource = {
   retrieveSObjectsList(): Promise<string[]>;
   retrieveSObject(sobjectName: string): Promise<SObject | undefined>;
-}
+};
 
 export class FileSystemOrgDataSource implements OrgDataSource {
   private getLocalDatapath(): string | undefined {

--- a/packages/salesforcedx-vscode-soql/src/queryDataView/dataProviders/iDataProvider.ts
+++ b/packages/salesforcedx-vscode-soql/src/queryDataView/dataProviders/iDataProvider.ts
@@ -7,9 +7,9 @@
 
 import { JsonMap } from '@salesforce/ts-types';
 
-export interface DataProvider {
+export type DataProvider = {
   fileExtension: string;
   documentName: string;
   getFileName(): string;
   getFileContent(query: string, data: JsonMap[]): string;
-}
+};

--- a/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataFileService.ts
+++ b/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataFileService.ts
@@ -5,8 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { QueryResult } from '@jsforce/jsforce-node';
 import { JsonMap } from '@salesforce/ts-types';
-import { QueryResult } from 'jsforce';
 import { homedir } from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';

--- a/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataHelper.ts
+++ b/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataHelper.ts
@@ -4,9 +4,9 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { QueryResult } from '@jsforce/jsforce-node';
 import { ColumnData, SelectAnalyzer } from '@salesforce/soql-model';
 import { JsonMap } from '@salesforce/ts-types';
-import { QueryResult } from 'jsforce';
 
 export type ExtendedQueryData = QueryResult<JsonMap> & {
   columnData: ColumnData;

--- a/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataHelper.ts
+++ b/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataHelper.ts
@@ -8,9 +8,9 @@ import { ColumnData, SelectAnalyzer } from '@salesforce/soql-model';
 import { JsonMap } from '@salesforce/ts-types';
 import { QueryResult } from 'jsforce';
 
-export interface ExtendedQueryData extends QueryResult<JsonMap> {
+export type ExtendedQueryData = QueryResult<JsonMap> & {
   columnData: ColumnData;
-}
+};
 
 export function extendQueryData(
   queryText: string,

--- a/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataViewService.ts
+++ b/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataViewService.ts
@@ -32,10 +32,10 @@ import {
 import { extendQueryData } from './queryDataHelper';
 import { getHtml } from './queryDataHtml';
 
-export interface DataViewEvent {
+export type DataViewEvent = {
   type: string;
   format?: FileFormat;
-}
+};
 
 export class QueryDataViewService {
   public currentPanel: vscode.WebviewPanel | undefined = undefined;

--- a/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataViewService.ts
+++ b/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataViewService.ts
@@ -5,8 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { QueryResult } from '@jsforce/jsforce-node';
 import { JsonMap } from '@salesforce/ts-types';
-import { QueryResult } from 'jsforce';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { getDocumentName, trackErrorWithTelemetry } from '../commonUtils';

--- a/packages/salesforcedx-vscode-soql/src/sf.ts
+++ b/packages/salesforcedx-vscode-soql/src/sf.ts
@@ -5,12 +5,12 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { DescribeSObjectResult } from '@jsforce/jsforce-node';
 import { Connection } from '@salesforce/core';
 import {
   ChannelService,
   WorkspaceContextUtil
 } from '@salesforce/salesforcedx-utils-vscode';
-import { DescribeSObjectResult } from 'jsforce';
 import * as vscode from 'vscode';
 import { nls } from './messages';
 

--- a/packages/salesforcedx-vscode-soql/src/telemetry/index.ts
+++ b/packages/salesforcedx-vscode-soql/src/telemetry/index.ts
@@ -22,10 +22,10 @@ export async function stopTelemetry(): Promise<void> {
   telemetryService.sendExtensionDeactivationEvent();
 }
 
-export interface TelemetryModelJson extends JsonMap {
+export type TelemetryModelJson = JsonMap & {
   fields: number;
   orderBy: number;
   limit: number;
   errors: number;
   unsupported: number;
-}
+};

--- a/packages/salesforcedx-vscode-soql/src/telemetry/index.ts
+++ b/packages/salesforcedx-vscode-soql/src/telemetry/index.ts
@@ -5,7 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { TelemetryService } from '@salesforce/salesforcedx-utils-vscode';
-import { JsonMap } from '@salesforce/ts-types';
 import * as vscode from 'vscode';
 
 export const telemetryService = TelemetryService.getInstance();
@@ -23,7 +22,7 @@ export const stopTelemetry = (): Promise<void> => {
   return Promise.resolve();
 };
 
-export type TelemetryModelJson = JsonMap & {
+export type TelemetryModelJson = {
   fields: number;
   orderBy: number;
   limit: number;

--- a/packages/salesforcedx-vscode-soql/test/jest/queryDataView/queryDataFileService.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/queryDataView/queryDataFileService.test.ts
@@ -4,8 +4,8 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { QueryResult } from '@jsforce/jsforce-node';
 import { JsonMap } from '@salesforce/ts-types';
-import { QueryResult } from 'jsforce';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import {
@@ -20,9 +20,9 @@ describe('Query Data File Service', () => {
     totalSize: 1,
     records: [{ Id: '123' }]
   };
-  const document = ({
+  const document = {
     uri: { fsPath: '/path/to/file' }
-  } as unknown) as vscode.TextDocument;
+  } as unknown as vscode.TextDocument;
 
   it('should save the file and return the file path', async () => {
     const format = FileFormat.JSON;

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/queryDataView/dataProviders/csvDataProvider.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/queryDataView/dataProviders/csvDataProvider.test.ts
@@ -9,11 +9,11 @@ import { JsonMap } from '@salesforce/ts-types';
 import { expect } from 'chai';
 import { CsvDataProvider } from '../../../../src/queryDataView/dataProviders/csvDataProvider';
 
-interface TestQuery {
+type TestQuery = {
   queryText: string;
   queryResults: JsonMap[];
   csvOutput: string[];
-}
+};
 
 const attributes = {
   type: 'type',
@@ -34,11 +34,7 @@ const simpleQuery: TestQuery = {
       B: 'd'
     }
   ],
-  csvOutput: [
-    'A,B',
-    'a,b',
-    'c,d'
-  ]
+  csvOutput: ['A,B', 'a,b', 'c,d']
 };
 const childToParentRel: TestQuery = {
   queryText: 'SELECT A, B.X FROM C',
@@ -60,11 +56,7 @@ const childToParentRel: TestQuery = {
       }
     }
   ],
-  csvOutput: [
-    'A,B.X',
-    'a,b',
-    'c,d'
-  ]
+  csvOutput: ['A,B.X', 'a,b', 'c,d']
 };
 const parentToChildRel: TestQuery = {
   queryText: 'SELECT A, (SELECT X FROM B) FROM C',
@@ -92,12 +84,7 @@ const parentToChildRel: TestQuery = {
       }
     }
   ],
-  csvOutput: [
-    'A,B.X',
-    'a,',
-    'c,b',
-    'c,d'
-  ]
+  csvOutput: ['A,B.X', 'a,', 'c,b', 'c,d']
 };
 const aggFn: TestQuery = {
   queryText: 'SELECT A, MIN(B) FROM C GROUP BY A',
@@ -113,11 +100,7 @@ const aggFn: TestQuery = {
       expr0: 10
     }
   ],
-  csvOutput: [
-    'A,MIN(B)',
-    'a,5',
-    'c,10'
-  ]
+  csvOutput: ['A,MIN(B)', 'a,5', 'c,10']
 };
 const alias: TestQuery = {
   queryText: 'SELECT A, MIN(B) min FROM C GROUP BY A',
@@ -133,11 +116,7 @@ const alias: TestQuery = {
       min: 10
     }
   ],
-  csvOutput: [
-    'A,min',
-    'a,5',
-    'c,10'
-  ]
+  csvOutput: ['A,min', 'a,5', 'c,10']
 };
 
 describe('CsvDataProvider', () => {
@@ -160,5 +139,10 @@ describe('CsvDataProvider', () => {
 
 function testQuery(q: TestQuery): void {
   const provider = new CsvDataProvider('x.soql');
-  expect(provider.getFileContent(q.queryText, q.queryResults).split('\n').map(s => s.trim())).deep.eq(q.csvOutput);
+  expect(
+    provider
+      .getFileContent(q.queryText, q.queryResults)
+      .split('\n')
+      .map(s => s.trim())
+  ).deep.eq(q.csvOutput);
 }

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/queryDataView/queryDataViewService.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/queryDataView/queryDataViewService.test.ts
@@ -7,7 +7,7 @@
 
 import { JsonMap } from '@salesforce/ts-types';
 import { expect } from 'chai';
-import { QueryResult } from 'jsforce';
+import { QueryResult } from '@jsforce/jsforce-node';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import { getDocumentName } from '../../../src/commonUtils';
@@ -34,10 +34,11 @@ describe('Query Data View Service', () => {
 
   beforeEach(async () => {
     sandbox = sinon.createSandbox();
-    docProviderDisposable = vscode.workspace.registerTextDocumentContentProvider(
-      'sfdc-test',
-      new MockTextDocumentProvider()
-    );
+    docProviderDisposable =
+      vscode.workspace.registerTextDocumentContentProvider(
+        'sfdc-test',
+        new MockTextDocumentProvider()
+      );
     mockTextDocument = await vscode.workspace.openTextDocument(
       vscode.Uri.parse('sfdc-test:test/examples/soql/mocksoql.soql')
     );
@@ -72,7 +73,10 @@ describe('Query Data View Service', () => {
     expect(postMessageSpy.callCount).equal(1);
 
     const postMessageArgs = postMessageSpy.args[0][0];
-    expect(postMessageArgs.data).to.eql({ columnData: mockColumnData, ...mockQueryData });
+    expect(postMessageArgs.data).to.eql({
+      columnData: mockColumnData,
+      ...mockQueryData
+    });
     expect(postMessageArgs.documentName).equal(
       getDocumentName(mockTextDocument)
     );

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/testUtilities.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/testUtilities.ts
@@ -7,7 +7,7 @@
 
 import { AuthInfo, Connection } from '@salesforce/core';
 import { JsonMap } from '@salesforce/ts-types';
-import { QueryResult } from 'jsforce';
+import { QueryResult } from '@jsforce/jsforce-node';
 import { SinonSandbox, SinonSpy } from 'sinon';
 import * as vscode from 'vscode';
 import {
@@ -322,7 +322,7 @@ export function getMockConnection(
     username: 'test'
   });
 
-  const mockConnection = ({
+  const mockConnection = {
     authInfo: mockAuthInfo,
     describeGlobal$: () => {
       return Promise.resolve(mockDescribeGlobalResponse);
@@ -332,7 +332,7 @@ export function getMockConnection(
       return Promise.resolve(sobjectMetadata);
     },
     query: () => Promise.resolve(mockQueryData)
-  } as unknown) as Connection;
+  } as unknown as Connection;
 
   return mockConnection;
 }
@@ -352,11 +352,12 @@ export function getFailingMockConnection(
     },
     query: () => Promise.reject(new Error('Unexpected error'))
   };
-  return (mockConnection as unknown) as Connection;
+  return mockConnection as unknown as Connection;
 }
 
 export class MockTextDocumentProvider
-  implements vscode.TextDocumentContentProvider {
+  implements vscode.TextDocumentContentProvider
+{
   public provideTextDocumentContent(
     uri: vscode.Uri,
     token: vscode.CancellationToken

--- a/scripts/reportInstalls.ts
+++ b/scripts/reportInstalls.ts
@@ -11,18 +11,18 @@ import { DEFAULT_AIKEY } from '../packages/salesforcedx-utils-vscode/src/constan
 
 const promisifiedExec = promisify(exec);
 
-interface InstallTelemetryData {
+type InstallTelemetryData = {
   // To align with the properties property for appInsightsClient.trackEvent
   [key: string]: string;
   install: string;
   ratingcount: string;
   marketplace: string;
   'common.extname': string;
-}
+};
 
 // These properties match the values provided in the statistics array from the
 // vsce cli output
-interface InstallTelemetryDataMS extends InstallTelemetryData {
+type InstallTelemetryDataMS = InstallTelemetryData & {
   averagerating: string;
   trendingdaily: string;
   trendingmonthly: string;
@@ -30,7 +30,7 @@ interface InstallTelemetryDataMS extends InstallTelemetryData {
   updateCount: string;
   weightedRating: string;
   downloadCount: string;
-}
+};
 
 type TelemetryData = InstallTelemetryData | InstallTelemetryDataMS;
 


### PR DESCRIPTION
### What does this PR do?

Migrates @salesforce/core from v6.7.4 -> v7.3.1

This upgrade means we are able to support Core v7 in our other dependencies, so the following dependencies are also migrated from Core v6 -> v7 in this PR:

1. @salesforce/source-deploy-retrieve - v10.3.3 -> v11.1.2
2. @salesforce/source-tracking - v5.1.11 -> v6.0.4
3. @salesforce/apex-node - v4.0.5 -> v6.0.0
4. @salesforce/templates - v60.1.0 -> v60.1.2
5. jsforce v2.0.0-beta.29 -> @jsforce/jsforce-node v3.2.0

Additional changes:
1. Changed the import of `@salesforce/core/testSetup` to use top-level imports
2. Replaced all usages of Interfaces with Types to match the new standards
3. Fixed the mocking of @salesforce/core in `workspaceContextUtils.test.ts` unit test to make it pass

### What issues does this PR fix or reference?
@W-15472197@

### Functionality Before
Extensions monorepo uses v6 of @salesforce/core

### Functionality After
Extensions monrepo uses v7 of @salesforce/core, which means we are now able to pull in new features from our shared libraries
