### PR TITLE
chore: test e2e continue working on macos 12

### DIFF
--- a/.github/workflows/runE2ETest.yml
+++ b/.github/workflows/runE2ETest.yml
@@ -23,7 +23,7 @@ on:
       os:
         description: 'Operating System(s) to run the E2E tests on'
         required: false
-        default: '["macos-latest", "ubuntu-latest", "windows-latest"]'
+        default: '["macos-12", "ubuntu-latest", "windows-latest"]'
         type: string
 
 jobs:


### PR DESCRIPTION
### What does this PR do?
- Use macos-12 instead of macos-latest so E2E pass on mac

### What issues does this PR fix or reference?
[skip-validate-pr]