### PR TITLE
chore: update bug report issue template to ask for Salesforce CLI instead of SFDX CLI

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -38,7 +38,7 @@ _Feel free to attach a screenshot_.
 
 **Salesforce Extension Version in VS Code**:
 
-**SFDX CLI Version**:
+**Salesforce CLI Version**:
 
 **OS and version**:
 


### PR DESCRIPTION
Changes the bug report template in Github issues to ask for Salesforce CLI version instead of SFDX CLI version.

[skip-validate-pr]