### PR TITLE
chore: ask in bug report issues template whether the issue is a regression

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -43,3 +43,5 @@ _Feel free to attach a screenshot_.
 **OS and version**:
 
 **VS Code version**:
+
+**Most recent version of the extensions where this was working**:


### PR DESCRIPTION
Ask customers in bug report Github issues template for most recent version of the extensions where the functionality was working.

[skip-validate-pr]