### PR TITLE
will revert: use dummy tokens for Publish Microsoft Marketplace and Publish OpenVSX Registry workflows to test

### DIFF
--- a/.github/workflows/publishOpenVSX.yml
+++ b/.github/workflows/publishOpenVSX.yml
@@ -54,7 +54,7 @@ jobs:
     needs: [ 'ctc-open', 'prepare-environment-from-main' ]    
     runs-on: ubuntu-latest
     env: 
-      OVSX_PAT: ${{ secrets.OVSX_PAT }}
+      OVSX_PAT: 'DummyOVSXPAT'
       PUBLISH_VERSION: ${{ needs.prepare-environment-from-main.outputs.RELEASE_VERSION }}
       GITHUB_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
     steps: 

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -53,7 +53,7 @@ jobs:
     needs: [ 'ctc-open', 'prepare-environment-from-main' ]    
     runs-on: ubuntu-latest
     env: 
-      VSCE_PERSONAL_ACCESS_TOKEN: ${{ secrets.VSCE_PERSONAL_ACCESS_TOKEN }}
+      VSCE_PERSONAL_ACCESS_TOKEN: 'DummyVSCEPAT'
       PUBLISH_VERSION: ${{ needs.prepare-environment-from-main.outputs.RELEASE_VERSION }}
       GITHUB_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
     steps: 


### PR DESCRIPTION
Will revert - Hard-code the values of the access tokens in the Publish in Microsoft Marketplace and Publish in Open VSX Registry GHA workflows to dummy values, in order to test a failed publish run in the real environment.

[skip-validate-pr]