### PR TITLE
fix: Remove "Warning: Ignoring extra certs from null, load failed: error:80000002:system library::No such file or directory" warning when "Salesforcedx-vscode-core: NODE_EXTRA_CA_CERTS" setting is not set

### DIFF
--- a/packages/salesforcedx-vscode-core/src/util/cliConfiguration.ts
+++ b/packages/salesforcedx-vscode-core/src/util/cliConfiguration.ts
@@ -54,10 +54,13 @@ export const isCLITelemetryAllowed = async () => {
 };
 
 export const setNodeExtraCaCerts = () => {
-  GlobalCliEnvironment.environmentVariables.set(
-    ENV_NODE_EXTRA_CA_CERTS,
-    salesforceCoreSettings.getNodeExtraCaCerts()
-  );
+  const extraCerts = salesforceCoreSettings.getNodeExtraCaCerts();
+  if (extraCerts) {
+    GlobalCliEnvironment.environmentVariables.set(
+      ENV_NODE_EXTRA_CA_CERTS,
+      extraCerts
+    );
+  }
 };
 
 export const setSfLogLevel = () => {


### PR DESCRIPTION
### What does this PR do?
Removes the **Warning: Ignoring extra certs from `null`, load failed: error:80000002:system library::No such file or directory** warning when the `Salesforcedx-vscode-core: NODE_EXTRA_CA_CERTS` setting is not set.

### What issues does this PR fix or reference?
[skip-validate-pr]

### Functionality Before
![Screenshot 2024-05-06 at 10 39 48 AM](https://github.com/forcedotcom/salesforcedx-vscode/assets/139700604/5001bdfa-5371-46c2-9b58-911f196d7912)

### Functionality After
![Screenshot 2024-05-06 at 10 40 49 AM](https://github.com/forcedotcom/salesforcedx-vscode/assets/139700604/660e96fd-d3c0-40cc-a5c6-494118872724)