### PR TITLE
Revert "chore: dummy tokens for Publish Microsoft Marketplace and Publish OpenVSX Registry workflows to test (#5568)"

### DIFF
--- a/.github/workflows/publishOpenVSX.yml
+++ b/.github/workflows/publishOpenVSX.yml
@@ -54,7 +54,7 @@ jobs:
     needs: [ 'ctc-open', 'prepare-environment-from-main' ]    
     runs-on: ubuntu-latest
     env: 
-      OVSX_PAT: 'DummyOVSXPAT'
+      OVSX_PAT: ${{ secrets.OVSX_PAT }}
       PUBLISH_VERSION: ${{ needs.prepare-environment-from-main.outputs.RELEASE_VERSION }}
       GITHUB_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
     steps: 

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -53,7 +53,7 @@ jobs:
     needs: [ 'ctc-open', 'prepare-environment-from-main' ]    
     runs-on: ubuntu-latest
     env: 
-      VSCE_PERSONAL_ACCESS_TOKEN: 'DummyVSCEPAT'
+      VSCE_PERSONAL_ACCESS_TOKEN: ${{ secrets.VSCE_PERSONAL_ACCESS_TOKEN }}
       PUBLISH_VERSION: ${{ needs.prepare-environment-from-main.outputs.RELEASE_VERSION }}
       GITHUB_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
     steps: 


### PR DESCRIPTION
This reverts commit 5735f63769d24c065518f99be7f985c5b422e3c5.

[skip-validate-pr]