### PR TITLE
chore: add --skip-duplicate flag in Publish workflows to fail silently if version already exists

### DIFF
--- a/.github/workflows/publishOpenVSX.yml
+++ b/.github/workflows/publishOpenVSX.yml
@@ -1,24 +1,23 @@
 name: Publish in Open VSX Registry
 on:
   release:
-    # This limits the workflow to releases that are not pre-releases 
+    # This limits the workflow to releases that are not pre-releases
     # From the docs: A release was published, or a pre-release was changed to a release.
-    types: [ released ]
+    types: [released]
   #  Button for publishing main branch in case there is a failure on the release.
   workflow_dispatch:
-    
-jobs:
 
+jobs:
   publish-start-notification:
-    name: "Publish in Open VSX Start Notification"
+    name: 'Publish in Open VSX Start Notification'
     uses: ./.github/workflows/slackNotification.yml
     secrets: inherit
     with:
-      title: "Publish in Open VSX waiting for approval in github."
-      notification: "New Release triggered publish build and job is ready for approval."
-      type: "notification"
-      workflow: "publishOpenVSX.yml"
-  
+      title: 'Publish in Open VSX waiting for approval in github.'
+      notification: 'New Release triggered publish build and job is ready for approval.'
+      type: 'notification'
+      workflow: 'publishOpenVSX.yml'
+
   prepare-environment-from-main:
     name: 'Get Release Version'
     runs-on: ubuntu-latest
@@ -36,28 +35,27 @@ jobs:
           echo "version="$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")"" >> $GITHUB_OUTPUT
       - run: echo "Main Version is ${{ steps.getMainVersion.outputs.version }}"
       - id: getGusBuild
-        run: | 
+        run: |
           echo "gusBuild=${{ steps.getMainVersion.outputs.version }}" >> $GITHUB_OUTPUT
       - run: echo "GUS BUILD is ${{ steps.getGusBuild.outputs.gusBuild }}"
       - id: getScheduledBuild
-        run: | 
+        run: |
           echo "sfChangeCaseScheduleBuild=offcore.tooling.${{ steps.getMainVersion.outputs.version }}" >> $GITHUB_OUTPUT
       - run: echo "SF_CHANGE_CASE_SCHEDULE_BUILD is ${{ steps.getScheduledBuild.outputs.sfChangeCaseScheduleBuild }}"\
 
-
   ctc-open:
-    needs: [ prepare-environment-from-main ]
+    needs: [prepare-environment-from-main]
     uses: salesforcecli/github-workflows/.github/workflows/ctcOpen.yml@main
     secrets: inherit
 
   publish:
-    needs: [ 'ctc-open', 'prepare-environment-from-main' ]    
+    needs: ['ctc-open', 'prepare-environment-from-main']
     runs-on: ubuntu-latest
-    env: 
+    env:
       OVSX_PAT: ${{ secrets.OVSX_PAT }}
       PUBLISH_VERSION: ${{ needs.prepare-environment-from-main.outputs.RELEASE_VERSION }}
       GITHUB_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
-    steps: 
+    steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -67,14 +65,14 @@ jobs:
         with:
           node-version-file: '.nvmrc'
       - name: downloadExtensionsFromRelease
-        run: | 
+        run: |
           mkdir ./extensions
           gh release download v${{ env.PUBLISH_VERSION }} -D ./extensions
       - name: Display downloaded vsix files
         run: ls -R ./extensions
       - run: npm ci
       - run: |
-          cmd=$(find ./extensions -type f -name "*.vsix" -print0 | xargs -0 -I {} printf 'npx ovsx publish "%s" -p "%s" && ' '{}' "${OVSX_PAT}" | sed 's/ && $//') && [ -n "$cmd" ] && eval "$cmd" && echo "SUCCESSFULLY published"
+          cmd=$(find ./extensions -type f -name "*.vsix" -print0 | xargs -0 -I {} printf 'npx ovsx publish --skip-duplicate "%s" -p "%s" && ' '{}' "${OVSX_PAT}" | sed 's/ && $//') && [ -n "$cmd" ] && eval "$cmd" && echo "SUCCESSFULLY published"
 
   ctcCloseSuccess:
     needs: [ctc-open, publish]

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -1,24 +1,23 @@
 name: Publish in Microsoft Marketplace
 on:
   release:
-    # This limits the workflow to releases that are not pre-releases 
+    # This limits the workflow to releases that are not pre-releases
     # From the docs: A release was published, or a pre-release was changed to a release.
-    types: [ released ]
+    types: [released]
   #  Button for publishing main branch in case there is a failure on the release.
   workflow_dispatch:
-    
-jobs:
 
+jobs:
   publish-start-notification:
-    name: "Publish in MS Marketplace Start Notification"
+    name: 'Publish in MS Marketplace Start Notification'
     uses: ./.github/workflows/slackNotification.yml
     secrets: inherit
     with:
-      title: "Publish in MS Marketplace waiting for approval in github."
-      notification: "New Release triggered publish build and job is ready for approval."
-      type: "notification"
-      workflow: "publishVSCode.yml"
-  
+      title: 'Publish in MS Marketplace waiting for approval in github.'
+      notification: 'New Release triggered publish build and job is ready for approval.'
+      type: 'notification'
+      workflow: 'publishVSCode.yml'
+
   prepare-environment-from-main:
     name: 'Get Release Version'
     runs-on: ubuntu-latest
@@ -36,27 +35,27 @@ jobs:
           echo "version="$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")"" >> $GITHUB_OUTPUT
       - run: echo "Main Version is ${{ steps.getMainVersion.outputs.version }}"
       - id: getGusBuild
-        run: | 
+        run: |
           echo "gusBuild=${{ steps.getMainVersion.outputs.version }}" >> $GITHUB_OUTPUT
       - run: echo "GUS BUILD is ${{ steps.getGusBuild.outputs.gusBuild }}"
       - id: getScheduledBuild
-        run: | 
+        run: |
           echo "sfChangeCaseScheduleBuild=offcore.tooling.${{ steps.getMainVersion.outputs.version }}" >> $GITHUB_OUTPUT
       - run: echo "SF_CHANGE_CASE_SCHEDULE_BUILD is ${{ steps.getScheduledBuild.outputs.sfChangeCaseScheduleBuild }}"\
 
   ctc-open:
-    needs: [ prepare-environment-from-main ]
+    needs: [prepare-environment-from-main]
     uses: salesforcecli/github-workflows/.github/workflows/ctcOpen.yml@main
     secrets: inherit
 
   publish:
-    needs: [ 'ctc-open', 'prepare-environment-from-main' ]    
+    needs: ['ctc-open', 'prepare-environment-from-main']
     runs-on: ubuntu-latest
-    env: 
+    env:
       VSCE_PERSONAL_ACCESS_TOKEN: ${{ secrets.VSCE_PERSONAL_ACCESS_TOKEN }}
       PUBLISH_VERSION: ${{ needs.prepare-environment-from-main.outputs.RELEASE_VERSION }}
       GITHUB_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
-    steps: 
+    steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -66,14 +65,14 @@ jobs:
         with:
           node-version-file: '.nvmrc'
       - name: downloadExtensionsFromRelease
-        run: | 
+        run: |
           mkdir ./extensions
           gh release download v${{ env.PUBLISH_VERSION }} -D ./extensions
       - name: Display downloaded vsix files
         run: ls -R ./extensions
       - run: npm ci
       - run: |
-          cmd=$(find . -type f -name "*.vsix" -print0 | xargs -0 printf 'npx vsce publish --pat "%s" --packagePath "%s" && ' "${VSCE_PERSONAL_ACCESS_TOKEN}" | sed 's/ && $//')&&[ -n "$cmd" ] && eval "$cmd" && echo "SUCCESSFULLY published"
+          cmd=$(find . -type f -name "*.vsix" -print0 | xargs -0 printf 'npx vsce publish --skip-duplicate --pat "%s" --packagePath "%s" && ' "${VSCE_PERSONAL_ACCESS_TOKEN}" | sed 's/ && $//')&&[ -n "$cmd" ] && eval "$cmd" && echo "SUCCESSFULLY published"
 
   ctcCloseSuccess:
     needs: [ctc-open, publish]


### PR DESCRIPTION
Adds the `--skip-duplicate` flag to the commands in the **Publish to Microsoft Marketplace** and **Publish to Open VSX Registry** workflows so that they fail silently if the version being published already exists.

This is needed to handle the case where the Publish workflow fails halfway through, with some extensions published and some not published.  The extensions are always published in the same order, so we want to be able to publish the remaining extensions during a rerun and not be blocked by fail-fast.

@W-15437641@