### PR TITLE
docs: more prominent notes for known issue with trusted IP ranges

### DIFF
--- a/docs/_articles/en/codebuilder/cb-setup.md
+++ b/docs/_articles/en/codebuilder/cb-setup.md
@@ -5,7 +5,7 @@ lang: en
 
 Enable Code Builder to provide the permissions needed to install the Code Builder managed package in a supported Salesforce edition.
 
-### Supported Editions
+## Supported Editions
 
 **Available in**: Lightning Experience in Enterprise, Performance, Professional, and Unlimited Editions.
 
@@ -17,7 +17,9 @@ Code Builder isn't available in sandboxes. However, during the development lifec
 
 To install Code Builder in a Professional Edition org, the org must have API access. If you attempt to install Code Builder in a Professional Edition org without API access, an installation error occurs. To request the API add-on, contact your Account Executive.
 
-**Note**: Turning on Code Builder in Government Cloud Plus organizations can send data outside the authorization boundary. Contact your Salesforce account executive for more details.
+**Note**:
+- Turning on Code Builder in Government Cloud Plus organizations can send data outside the authorization boundary. Contact your Salesforce account executive for more details.
+- Code Builder runs in the cloud with a different IP address from your org and your computer. If your org has Trusted IP Ranges configured in Network Access in Setup, you can't connect to an org from Code Builder because the IP range for Code Builder can vary. See the [Known Gaps and Issues doc](https://github.com/forcedotcom/code-builder-feedback/wiki/Known-Gaps-and-Issues#ip-restricted-orgs) on GitHub.
 
 1. From Setup, enter Code Builder in the Quick Find box, then select Code Builder.
 

--- a/docs/_articles/en/codebuilder/cb-start.md
+++ b/docs/_articles/en/codebuilder/cb-start.md
@@ -31,6 +31,8 @@ Working in the cloud has its advantages. However, unlike working on a desktop wh
 
 Next, connect an org to your Code Builder environment. During the course of development, you'll use different types of orgs for different stages. For example, it's common to use a Developer sandbox or Developer Edition org during the development phase, and move to other sandbox types for integration, testing, and staging. Eventually, you'll deploy your changes to a production org. You can connect Code Builder to any of these orgs to deploy or retrieve metadata.
 
+**Note**: Code Builder runs in the cloud with a different IP address from your org and your computer. If your org has Trusted IP Ranges configured in Network Access in Setup, you can't connect to an org from Code Builder because the IP range for Code Builder can vary. See the [Known Gaps and Issues doc](https://github.com/forcedotcom/code-builder-feedback/wiki/Known-Gaps-and-Issues#ip-restricted-orgs) on GitHub.
+
 To connect to an org the first time you launch Code Builder:
 
 1. In your Code Builder environment, click **Connect an Org** to connect to the Salesforce org you want to work in.


### PR DESCRIPTION
### What does this PR do?
Surface more prominently the known issue that Code Builder won't work if the org has trusted IP ranges 

### What issues does this PR fix or reference?
#@W-15808576@

### Functionality Before
Known issue mentioned in [Known Gaps and Issues doc](https://github.com/forcedotcom/code-builder-feedback/wiki/Known-Gaps-and-Issues#ip-restricted-orgs) on GitHub.

### Functionality After
Known issue also mentioned prominently in doc where user is likely to encounter this issue (setup and connect to org topics)
