### PR TITLE
fix: bump @salesforce/apex-node to v6.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5905,9 +5905,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "3.26.4",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-3.26.4.tgz",
-      "integrity": "sha512-ntfo2ut7enNtAn/jB/dryMUPBM2Fh8Fydmi3k/Ybo6lCGU/hmsPFkBRjCEJAQMyNkK2yVZARaWogdOrcVgFz+w==",
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-3.27.0.tgz",
+      "integrity": "sha512-Fg93aNFvXzBq5L7ztVHFP2nYwWU1oTCq48G0TjF/qC1UN36KWa2H5Hsm72kERd5x/sjy2M2Tn4kDEorUlpXOlw==",
       "dependencies": {
         "@types/cli-progress": "^3.11.5",
         "ansi-escapes": "^4.3.2",
@@ -5917,7 +5917,7 @@
         "clean-stack": "^3.0.1",
         "cli-progress": "^3.12.0",
         "color": "^4.2.3",
-        "debug": "^4.3.4",
+        "debug": "^4.3.5",
         "ejs": "^3.1.10",
         "get-package-type": "^0.1.0",
         "globby": "^11.1.0",
@@ -6019,6 +6019,22 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/@oclif/core/node_modules/debug": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@oclif/core/node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -6409,19 +6425,20 @@
       "integrity": "sha512-L4zUDy4lxF7+mM7DYPfOKZ4lqiAIquRx0vHAUJMBaxD4bCiT+70Df++aOfGO9FOJNctvPtT5bLrFRfdos4y4Mg=="
     },
     "node_modules/@salesforce/apex-node": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/apex-node/-/apex-node-6.0.0.tgz",
-      "integrity": "sha512-vgOmgfsF4BO1nDljSstcUncAJKRJ31OolsTIyl0FgP3TMnTGedF5SvkePoX+uJ0SujuF0qzy2YnMLA0XNnAwAg==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/apex-node/-/apex-node-6.1.2.tgz",
+      "integrity": "sha512-GF1ou91qxtTIduK4idq+OtQ3sKAXwA3WYLTYXPfJ+HiWQu9Qq/aRFSyl3I/+DAXqtTXXYJL3ocdZ7KH5EzBCJg==",
       "dependencies": {
-        "@jsforce/jsforce-node": "^3.1.0",
-        "@salesforce/core": "^7.2.0",
-        "@salesforce/kit": "^3.1.0",
+        "@jsforce/jsforce-node": "^3.2.0",
+        "@salesforce/core": "^7.3.10",
+        "@salesforce/kit": "^3.1.2",
         "@types/istanbul-reports": "^3.0.4",
+        "bfj": "^8.0.0",
         "faye": "1.4.0",
-        "glob": "^10.3.10",
+        "glob": "^10.3.16",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.1.6"
+        "istanbul-reports": "^3.1.7"
       },
       "engines": {
         "node": ">=18.18.2"
@@ -6459,30 +6476,47 @@
       }
     },
     "node_modules/@salesforce/apex-node/node_modules/glob": {
-      "version": "10.3.10",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
+      "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
       "dependencies": {
         "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.5",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "path-scurry": "^1.11.1"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@salesforce/apex-node/node_modules/jackspeak": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
+      "integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/@salesforce/apex-node/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -6494,9 +6528,9 @@
       }
     },
     "node_modules/@salesforce/apex-node/node_modules/minipass": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -6597,27 +6631,27 @@
       "integrity": "sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww=="
     },
     "node_modules/@salesforce/core": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.3.1.tgz",
-      "integrity": "sha512-jdc0GOUlV4xvyF9dPbBKNPDvQc06uj5YHFEHvdhCAFtCvqgtubpDzlyDppac2kdKujh4c7UH2KreboNvJ3LsoQ==",
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.3.10.tgz",
+      "integrity": "sha512-kEKoqkmhWNoiucAE3Ylv6FpC4iVgk4aE0dmcwSmNrMjxSbtjQJGUybprfO/itrLJv+56eM7/4FARQQ2gDbRzQQ==",
       "dependencies": {
-        "@jsforce/jsforce-node": "^3.1.0",
+        "@jsforce/jsforce-node": "^3.2.0",
         "@salesforce/kit": "^3.1.1",
-        "@salesforce/schemas": "^1.7.0",
+        "@salesforce/schemas": "^1.9.0",
         "@salesforce/ts-types": "^2.0.9",
-        "ajv": "^8.12.0",
+        "ajv": "^8.15.0",
         "change-case": "^4.1.2",
         "faye": "^1.4.0",
         "form-data": "^4.0.0",
         "js2xmlparser": "^4.0.1",
         "jsonwebtoken": "9.0.2",
         "jszip": "3.10.1",
-        "pino": "^8.19.0",
-        "pino-abstract-transport": "^1.1.0",
+        "pino": "^8.21.0",
+        "pino-abstract-transport": "^1.2.0",
         "pino-pretty": "^10.3.1",
         "proper-lockfile": "^4.1.2",
-        "semver": "^7.6.0",
-        "ts-retry-promise": "^0.7.1"
+        "semver": "^7.6.2",
+        "ts-retry-promise": "^0.8.1"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -6635,14 +6669,14 @@
       }
     },
     "node_modules/@salesforce/core/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
+      "integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
         "json-schema-traverse": "^1.0.0",
         "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "uri-js": "^4.4.1"
       },
       "funding": {
         "type": "github",
@@ -6847,9 +6881,9 @@
       }
     },
     "node_modules/@salesforce/kit": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/kit/-/kit-3.1.1.tgz",
-      "integrity": "sha512-Cjkh+USp5PtdZmD30r1Y7d+USpIhQz9B48w76esBtYpgqzhyj806LHkVgEfmorLNq2Qe8EO5rtUYd+XZ3rnV9w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/kit/-/kit-3.1.2.tgz",
+      "integrity": "sha512-si+ddvZDgx9q5czxAANuK5xhz3pv+KGspQy1wyia/7HDPKadA0QZkLTzUnO1Ju4Mux32CNHEb2y9lw9jj+eVTA==",
       "dependencies": {
         "@salesforce/ts-types": "^2.0.9",
         "tslib": "^2.6.2"
@@ -7192,9 +7226,9 @@
       "integrity": "sha512-RbZBlljl+LjMZtzFsLpE9LneX7uiWS35M0ecJGkEI6ACIV0sKH48PRbSANVko+FNyzzSkLCc2m6HvXnwiaQoTQ=="
     },
     "node_modules/@salesforce/schemas": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/schemas/-/schemas-1.7.0.tgz",
-      "integrity": "sha512-Z0PiCEV55khm0PG+DsnRYCjaDmacNe3HDmsoSm/CSyYvJJm+D5vvkHKN9/PKD/gaRe8XAU836yfamIYFblLINw=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/schemas/-/schemas-1.9.0.tgz",
+      "integrity": "sha512-LiN37zG5ODT6z70sL1fxF7BQwtCX9JOWofSU8iliSNIM+WDEeinnoFtVqPInRSNt8I0RiJxIKCrqstsmQRBNvA=="
     },
     "node_modules/@salesforce/soql-builder-ui": {
       "version": "0.2.0",
@@ -7311,11 +7345,11 @@
       }
     },
     "node_modules/@salesforce/source-deploy-retrieve": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-11.1.2.tgz",
-      "integrity": "sha512-QhRft7U/XMBDaZTbzacbHH4sapTW/d25V3Hiwua2lg/Ce6hEj/5w6l8LlO5UAyRpRMaMy2LfaTRygu+rT3AS8g==",
+      "version": "11.6.5",
+      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-11.6.5.tgz",
+      "integrity": "sha512-JwYhLOLAkyIBsZXMt9OnDUqI8BJRu6sr5cs6EXfOD4rpIrEqpNN3+m9Gnkoe3onmTBUg4AuxFTuBT8SaBorw2g==",
       "dependencies": {
-        "@salesforce/core": "^7.3.1",
+        "@salesforce/core": "^7.3.9",
         "@salesforce/kit": "^3.1.1",
         "@salesforce/ts-types": "^2.0.9",
         "fast-levenshtein": "^3.0.0",
@@ -7360,19 +7394,19 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@salesforce/source-tracking": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-tracking/-/source-tracking-6.0.4.tgz",
-      "integrity": "sha512-4+QFC6hm2MHCUsQdgSNydSoyi9zJaFl1S6rwJl/HTGeISs3g8w3tI+SeskmpZCoXRVnNJxCHwHT3kAPhZbuFlg==",
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/@salesforce/source-tracking/-/source-tracking-6.3.4.tgz",
+      "integrity": "sha512-3WaoTCsWyq1GOlThUqMjON1/CTFk/ifpuvlcoyLWPno5PQe6FhxAcaGR/aRnEjuYTeClJ4rgNOFxrjcHORFCdw==",
       "dependencies": {
-        "@oclif/core": "^3.26.4",
-        "@salesforce/core": "^7.3.0",
-        "@salesforce/kit": "^3.1.1",
-        "@salesforce/source-deploy-retrieve": "^11.0.1",
+        "@oclif/core": "^3.26.6",
+        "@salesforce/core": "^7.3.9",
+        "@salesforce/kit": "^3.1.2",
+        "@salesforce/source-deploy-retrieve": "^11.6.4",
         "@salesforce/ts-types": "^2.0.9",
         "fast-xml-parser": "^4.3.6",
         "graceful-fs": "^4.2.11",
-        "isomorphic-git": "1.23.0",
-        "ts-retry-promise": "^0.8.0"
+        "isomorphic-git": "^1.25.10",
+        "ts-retry-promise": "^0.8.1"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -7387,14 +7421,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@salesforce/source-tracking/node_modules/ts-retry-promise": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/ts-retry-promise/-/ts-retry-promise-0.8.0.tgz",
-      "integrity": "sha512-elI/GkojPANBikPaMWQnk4T/bOJ6tq/hqXyQRmhfC9PAD6MoHmXIXK7KilJrlpx47VAKCGcmBrTeK5dHk6YAYg==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@salesforce/source-tracking/node_modules/tslib": {
@@ -9990,6 +10016,26 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
     },
+    "node_modules/bfj": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/bfj/-/bfj-8.0.0.tgz",
+      "integrity": "sha512-6KJe4gFrZ4lhmvWcUIj37yFAs36mi2FZXuTkw6udZ/QsX/znFypW4SatqcLA5K5T4BAWgJZD73UFEJJQxuJjoA==",
+      "dependencies": {
+        "bluebird": "^3.7.2",
+        "check-types": "^11.2.3",
+        "hoopy": "^0.1.4",
+        "jsonpath": "^1.1.1",
+        "tryer": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/bfj/node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
     "node_modules/big-integer": {
       "version": "1.6.51",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
@@ -10747,6 +10793,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/check-types": {
+      "version": "11.2.3",
+      "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.2.3.tgz",
+      "integrity": "sha512-+67P1GkJRaxQD6PKK0Et9DhwQB+vGg3PM5+aavopCpZT1lj9jeqfvpgTLAWErNj8qApkkmXlu/Ug74kmhagkXg=="
     },
     "node_modules/cheerio": {
       "version": "1.0.0-rc.12",
@@ -14806,9 +14857,9 @@
       }
     },
     "node_modules/fast-redact": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.3.0.tgz",
-      "integrity": "sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
       "engines": {
         "node": ">=6"
       }
@@ -16715,6 +16766,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/hoopy": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
+      "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -18112,11 +18171,11 @@
       }
     },
     "node_modules/isomorphic-git": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.23.0.tgz",
-      "integrity": "sha512-7mQlnZivFwrU6B3CswvmoNtVN8jqF9BcLf80uk7yh4fNA8PhFjAfQigi2Hu/Io0cmIvpOc7vn0/Rq3KtL5Ph8g==",
+      "version": "1.25.10",
+      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.25.10.tgz",
+      "integrity": "sha512-IxGiaKBwAdcgBXwIcxJU6rHLk+NrzYaaPKXXQffcA0GW3IUrQXdUPDXDo+hkGVcYruuz/7JlGBiuaeTCgIgivQ==",
       "dependencies": {
-        "async-lock": "^1.1.0",
+        "async-lock": "^1.4.1",
         "clean-git-ref": "^2.0.1",
         "crc-32": "^1.2.0",
         "diff3": "0.0.3",
@@ -18136,9 +18195,9 @@
       }
     },
     "node_modules/isomorphic-git/node_modules/async-lock": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.0.tgz",
-      "integrity": "sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ=="
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -18268,9 +18327,9 @@
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
-      "integrity": "sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
       "dependencies": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
@@ -20710,6 +20769,33 @@
       "engines": [
         "node >= 0.2.0"
       ]
+    },
+    "node_modules/jsonpath": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
+      "integrity": "sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==",
+      "dependencies": {
+        "esprima": "1.2.2",
+        "static-eval": "2.0.2",
+        "underscore": "1.12.1"
+      }
+    },
+    "node_modules/jsonpath/node_modules/esprima": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
+      "integrity": "sha512-+JpPZam9w5DuJ3Q67SqsMGtiHKENSMRVoxvArfJZK01/BfLEObtZ6orJa/MtoGNR/rfMgp5837T41PAmTwAv/A==",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/jsonpath/node_modules/underscore": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "node_modules/JSONStream": {
       "version": "1.3.5",
@@ -28034,24 +28120,24 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-scurry": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
-      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dependencies": {
-        "lru-cache": "^9.1.1 || ^10.0.0",
+        "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
-      "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -28127,30 +28213,30 @@
       }
     },
     "node_modules/pino": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-8.20.0.tgz",
-      "integrity": "sha512-uhIfMj5TVp+WynVASaVEJFTncTUe4dHBq6CWplu/vBgvGHhvBvQfxz+vcOrnnBQdORH3izaGEurLfNlq3YxdFQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
+      "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
         "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^1.1.0",
+        "pino-abstract-transport": "^1.2.0",
         "pino-std-serializers": "^6.0.0",
         "process-warning": "^3.0.0",
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.2.0",
         "safe-stable-stringify": "^2.3.1",
         "sonic-boom": "^3.7.0",
-        "thread-stream": "^2.0.0"
+        "thread-stream": "^2.6.0"
       },
       "bin": {
         "pino": "bin.js"
       }
     },
     "node_modules/pino-abstract-transport": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz",
-      "integrity": "sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
+      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
       "dependencies": {
         "readable-stream": "^4.0.0",
         "split2": "^4.0.0"
@@ -30609,6 +30695,87 @@
         "node": ">=8"
       }
     },
+    "node_modules/static-eval": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
+      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
+      "dependencies": {
+        "escodegen": "^1.8.1"
+      }
+    },
+    "node_modules/static-eval/node_modules/escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/static-eval/node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+    },
+    "node_modules/static-eval/node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/static-eval/node_modules/optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/static-eval/node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/static-eval/node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -31356,9 +31523,9 @@
       }
     },
     "node_modules/thread-stream": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.4.0.tgz",
-      "integrity": "sha512-xZYtOtmnA63zj04Q+F9bdEay5r47bvpo1CaNqsKi7TpoJHcotUez8Fkfo2RJWpW91lnnaApdpRbVwCWsy+ifcw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
+      "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
       "dependencies": {
         "real-require": "^0.2.0"
       }
@@ -31503,6 +31670,11 @@
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
       }
+    },
+    "node_modules/tryer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
+      "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
     },
     "node_modules/ts-api-utils": {
       "version": "1.0.3",
@@ -31750,9 +31922,9 @@
       }
     },
     "node_modules/ts-retry-promise": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/ts-retry-promise/-/ts-retry-promise-0.7.1.tgz",
-      "integrity": "sha512-NhHOCZ2AQORvH42hOPO5UZxShlcuiRtm7P2jIq2L2RY3PBxw2mLnUsEdHrIslVBFya1v5aZmrR55lWkzo13LrQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/ts-retry-promise/-/ts-retry-promise-0.8.1.tgz",
+      "integrity": "sha512-+AHPUmAhr5bSRRK5CurE9kNH8gZlEHnCgusZ0zy2bjfatUBDX0h6vGQjiT0YrGwSDwRZmU+bapeX6mj55FOPvg==",
       "engines": {
         "node": ">=6"
       }
@@ -33050,7 +33222,6 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -35311,7 +35482,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jsforce/jsforce-node": "3.2.0",
-        "@salesforce/core": "7.3.1",
+        "@salesforce/core": "7.3.10",
         "@salesforce/salesforcedx-utils-vscode": "60.16.0",
         "shelljs": "0.8.5"
       },
@@ -35466,9 +35637,9 @@
       "version": "60.16.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "7.3.1",
-        "@salesforce/source-deploy-retrieve": "11.1.2",
-        "@salesforce/source-tracking": "6.0.4",
+        "@salesforce/core": "7.3.10",
+        "@salesforce/source-deploy-retrieve": "11.6.5",
+        "@salesforce/source-tracking": "6.3.4",
         "applicationinsights": "1.0.7",
         "cross-spawn": "7.0.3",
         "rxjs": "^5.4.1",
@@ -35668,9 +35839,9 @@
       "version": "60.16.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/apex-node": "6.0.0",
+        "@salesforce/apex-node": "6.1.2",
         "@salesforce/apex-tmlanguage": "1.8.0",
-        "@salesforce/core": "7.3.1",
+        "@salesforce/core": "7.3.10",
         "@salesforce/salesforcedx-utils-vscode": "60.16.0",
         "expand-home-dir": "0.0.3",
         "find-java-home": "0.2.0",
@@ -35838,8 +36009,8 @@
       "version": "60.16.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/apex-node": "6.0.0",
-        "@salesforce/core": "7.3.1",
+        "@salesforce/apex-node": "6.1.2",
+        "@salesforce/core": "7.3.10",
         "@salesforce/salesforcedx-apex-replay-debugger": "60.16.0",
         "@salesforce/salesforcedx-utils": "60.16.0",
         "@salesforce/salesforcedx-utils-vscode": "60.16.0",
@@ -36109,11 +36280,11 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jsforce/jsforce-node": "3.2.0",
-        "@salesforce/core": "7.3.1",
+        "@salesforce/core": "7.3.10",
         "@salesforce/salesforcedx-sobjects-faux-generator": "60.16.0",
         "@salesforce/salesforcedx-utils-vscode": "60.16.0",
         "@salesforce/schemas": "^1.6.1",
-        "@salesforce/source-deploy-retrieve": "11.1.2",
+        "@salesforce/source-deploy-retrieve": "11.6.5",
         "@salesforce/templates": "^60.1.2",
         "@salesforce/ts-types": "2.0.9",
         "@salesforce/vscode-service-provider": "1.0.4",
@@ -36367,7 +36538,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/aura-language-server": "4.8.0",
-        "@salesforce/core": "7.3.1",
+        "@salesforce/core": "7.3.10",
         "@salesforce/lightning-lsp-common": "4.8.0",
         "@salesforce/salesforcedx-utils-vscode": "60.16.0",
         "applicationinsights": "1.0.7",
@@ -36550,7 +36721,7 @@
       "version": "60.16.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "7.3.1",
+        "@salesforce/core": "7.3.10",
         "@salesforce/eslint-config-lwc": "3.5.1",
         "@salesforce/lightning-lsp-common": "4.8.0",
         "@salesforce/lwc-language-server": "4.8.0",
@@ -36754,7 +36925,7 @@
       "dependencies": {
         "@jsforce/jsforce-node": "3.2.0",
         "@salesforce/apex-tmlanguage": "1.6.0",
-        "@salesforce/core": "7.3.1",
+        "@salesforce/core": "7.3.10",
         "@salesforce/soql-builder-ui": "0.2.0",
         "@salesforce/soql-data-view": "0.1.0",
         "@salesforce/soql-language-server": "0.7.1",

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -11,7 +11,7 @@
   "main": "out/src",
   "dependencies": {
     "@jsforce/jsforce-node": "3.2.0",
-    "@salesforce/core": "7.3.1",
+    "@salesforce/core": "7.3.10",
     "@salesforce/salesforcedx-utils-vscode": "60.16.0",
     "shelljs": "0.8.5"
   },

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -10,9 +10,9 @@
   ],
   "main": "out/src",
   "dependencies": {
-    "@salesforce/core": "7.3.1",
-    "@salesforce/source-deploy-retrieve": "11.1.2",
-    "@salesforce/source-tracking": "6.0.4",
+    "@salesforce/core": "7.3.10",
+    "@salesforce/source-deploy-retrieve": "11.6.5",
+    "@salesforce/source-tracking": "6.3.4",
     "applicationinsights": "1.0.7",
     "cross-spawn": "7.0.3",
     "rxjs": "^5.4.1",

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -98,7 +98,7 @@
       "main": "dist/index.js",
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "@salesforce/core": "7.3.1",
+        "@salesforce/core": "7.3.10",
         "@salesforce/source-tracking": "6.0.4"
       },
       "devDependencies": {}

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -24,8 +24,8 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/apex-node": "6.0.0",
-    "@salesforce/core": "7.3.1",
+    "@salesforce/apex-node": "6.1.2",
+    "@salesforce/core": "7.3.10",
     "@salesforce/salesforcedx-apex-replay-debugger": "60.16.0",
     "@salesforce/salesforcedx-utils": "60.16.0",
     "@salesforce/salesforcedx-utils-vscode": "60.16.0",
@@ -106,8 +106,8 @@
     "packageUpdates": {
       "main": "dist/index.js",
       "dependencies": {
-        "@salesforce/core": "7.3.1",
-        "@salesforce/source-tracking": "6.0.4",
+        "@salesforce/core": "7.3.10",
+        "@salesforce/source-tracking": "6.3.4",
         "applicationinsights": "1.0.7"
       },
       "devDependencies": {}

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -24,9 +24,9 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/apex-node": "6.0.0",
+    "@salesforce/apex-node": "6.1.2",
     "@salesforce/apex-tmlanguage": "1.8.0",
-    "@salesforce/core": "7.3.1",
+    "@salesforce/core": "7.3.10",
     "@salesforce/salesforcedx-utils-vscode": "60.16.0",
     "expand-home-dir": "0.0.3",
     "find-java-home": "0.2.0",
@@ -104,8 +104,8 @@
       "languageServerDir": "dist",
       "dependencies": {
         "@salesforce/apex-tmlanguage": "1.4.0",
-        "@salesforce/core": "7.3.1",
-        "@salesforce/source-tracking": "6.0.4",
+        "@salesforce/core": "7.3.10",
+        "@salesforce/source-tracking": "6.3.4",
         "applicationinsights": "1.0.7",
         "shelljs": "0.8.5"
       },

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -25,11 +25,11 @@
   ],
   "dependencies": {
     "@jsforce/jsforce-node": "3.2.0",
-    "@salesforce/core": "7.3.1",
+    "@salesforce/core": "7.3.10",
     "@salesforce/salesforcedx-sobjects-faux-generator": "60.16.0",
     "@salesforce/salesforcedx-utils-vscode": "60.16.0",
     "@salesforce/schemas": "^1.6.1",
-    "@salesforce/source-deploy-retrieve": "11.1.2",
+    "@salesforce/source-deploy-retrieve": "11.6.5",
     "@salesforce/templates": "^60.1.2",
     "@salesforce/ts-types": "2.0.9",
     "@salesforce/vscode-service-provider": "1.0.4",
@@ -99,10 +99,10 @@
       "main": "dist/index.js",
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "@salesforce/core": "7.3.1",
-        "@salesforce/source-tracking": "6.0.4",
+        "@salesforce/core": "7.3.10",
+        "@salesforce/source-tracking": "6.3.4",
         "@salesforce/templates": "^60.1.2",
-        "@salesforce/source-deploy-retrieve": "11.1.2",
+        "@salesforce/source-deploy-retrieve": "11.6.5",
         "shelljs": "0.8.5"
       },
       "devDependencies": {}

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "@salesforce/aura-language-server": "4.8.0",
-    "@salesforce/core": "7.3.1",
+    "@salesforce/core": "7.3.10",
     "@salesforce/lightning-lsp-common": "4.8.0",
     "@salesforce/salesforcedx-utils-vscode": "60.16.0",
     "applicationinsights": "1.0.7",
@@ -120,8 +120,8 @@
       ],
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "@salesforce/core": "7.3.1",
-        "@salesforce/source-tracking": "6.0.4",
+        "@salesforce/core": "7.3.10",
+        "@salesforce/source-tracking": "6.3.4",
         "@salesforce/aura-language-server": "4.8.0",
         "@salesforce/lightning-lsp-common": "4.8.0"
       },

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -24,7 +24,7 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/core": "7.3.1",
+    "@salesforce/core": "7.3.10",
     "@salesforce/eslint-config-lwc": "3.5.1",
     "@salesforce/lightning-lsp-common": "4.8.0",
     "@salesforce/lwc-language-server": "4.8.0",
@@ -116,10 +116,10 @@
         "server.js"
       ],
       "dependencies": {
-        "@salesforce/core": "7.3.1",
+        "@salesforce/core": "7.3.10",
         "@salesforce/lightning-lsp-common": "4.8.0",
         "@salesforce/lwc-language-server": "4.8.0",
-        "@salesforce/source-tracking": "6.0.4",
+        "@salesforce/source-tracking": "6.3.4",
         "applicationinsights": "1.0.7"
       },
       "devDependencies": {}

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@jsforce/jsforce-node": "3.2.0",
     "@salesforce/apex-tmlanguage": "1.6.0",
-    "@salesforce/core": "7.3.1",
+    "@salesforce/core": "7.3.10",
     "@salesforce/soql-builder-ui": "0.2.0",
     "@salesforce/soql-data-view": "0.1.0",
     "@salesforce/soql-language-server": "0.7.1",
@@ -140,8 +140,8 @@
       "dependencies": {
         "applicationinsights": "1.0.7",
         "@salesforce/apex-tmlanguage": "1.6.0",
-        "@salesforce/core": "7.3.1",
-        "@salesforce/source-tracking": "6.0.4",
+        "@salesforce/core": "7.3.10",
+        "@salesforce/source-tracking": "6.3.4",
         "shelljs": "0.8.5",
         "@salesforce/soql-builder-ui": "0.2.0",
         "@salesforce/soql-data-view": "0.1.0",


### PR DESCRIPTION
### What does this PR do?
Pulls in fixes in the @salesforce/apex-node dependency for:
1. All Apex classes/triggers in the ApexCodeCoverageAggregate table are displayed when the "Show Only Aggregated Code Coverage" setting is checked
2. Add heap monitoring

### What issues does this PR fix or reference?
@W-15783639@, @W-15760648@