### PR TITLE
chore: point to the right apex-pmd in Open VSX

### DIFF
--- a/packages/salesforcedx-vscode-expanded/package.json
+++ b/packages/salesforcedx-vscode-expanded/package.json
@@ -43,6 +43,7 @@
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
     "chuckjonas.apex-pmd",
+    "pmd.apex-pmd",
     "financialforce.lana"
   ]
 }


### PR DESCRIPTION
### What does this PR do?
apex-pmd has different publishers in VS Code Marketplace and Open VSX Registry. Code Builder installs the extensions from Open VSX, so apex-pmd is not able to be installed in Code Builder. The entry for Open VSX is added. By adding the entry, installing from VS Code marketplace is not affected and no errors can be detected. There is also no error to install apex-pmd from Open VSX with the existence of the entry for Marketplace confirmed by CB team.

### What issues does this PR fix or reference?
@W-15936982@

### Functionality Before
apex-pmd is not installed from Open VSX.

### Functionality After
apex-pmd is installed from Open VSX