### PR TITLE
chore: update screenshots folder name to match actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/runE2ETest.yml
+++ b/.github/workflows/runE2ETest.yml
@@ -109,5 +109,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: screenshots
+          name: screenshots-${{ inputs.testToRun }}-${{ matrix.os }}
           path: ./salesforcedx-vscode-automation-tests/screenshots


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Fixes the issue where screenshots were not being produced for E2E test failures.  The issue is happening as a result of the breaking change in actions/upload-artifact@v4.

### What issues does this PR fix or reference?
@W-15960945@

### Functionality Before
Only one job in a failing E2E test run produces screenshots; the other jobs produce error messages in the upload artifact step with the error message `Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run`.
https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/9477771277

### Functionality After
All jobs in a failing E2E test run produce screenshots, in separate folders for each job.
https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/9486595338
