### PR TITLE
fix: externalize bfj dependency to allow bundling

### DIFF
--- a/packages/salesforcedx-vscode-apex-replay-debugger/esbuild.config.js
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/esbuild.config.js
@@ -16,7 +16,8 @@ const sharedConfig = {
     'vscode',
     '@salesforce/core',
     '@salesforce/source-tracking',
-    'applicationinsights'
+    'applicationinsights',
+    'bfj'
   ],
   minify: true
 };
@@ -41,6 +42,8 @@ const sharedConfig = {
     entryPoints: ['./src/index.ts'],
     outfile: 'dist/index.js'
   });
-})().then(async () => {
-  // await copyFiles(srcPath, destPath);
-}).catch(() => process.exit(1));
+})()
+  .then(async () => {
+    // await copyFiles(srcPath, destPath);
+  })
+  .catch(() => process.exit(1));

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -108,7 +108,8 @@
       "dependencies": {
         "@salesforce/core": "7.3.10",
         "@salesforce/source-tracking": "6.3.4",
-        "applicationinsights": "1.0.7"
+        "applicationinsights": "1.0.7",
+        "bfj": "8.0.0"
       },
       "devDependencies": {}
     }

--- a/packages/salesforcedx-vscode-apex/esbuild.config.js
+++ b/packages/salesforcedx-vscode-apex/esbuild.config.js
@@ -18,7 +18,8 @@ const sharedConfig = {
     'applicationinsights',
     'shelljs',
     '@salesforce/source-deploy-retrieve',
-    '@salesforce/source-tracking'
+    '@salesforce/source-tracking',
+    'bfj'
   ],
   minify: true
 };
@@ -43,6 +44,8 @@ const sharedConfig = {
     entryPoints: ['./src/index.ts'],
     outfile: 'dist/index.js'
   });
-})().then(async () => {
-  // await copyFiles(srcPath, destPath);
-}).catch(() => process.exit(1));
+})()
+  .then(async () => {
+    // await copyFiles(srcPath, destPath);
+  })
+  .catch(() => process.exit(1));

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -107,7 +107,8 @@
         "@salesforce/core": "7.3.10",
         "@salesforce/source-tracking": "6.3.4",
         "applicationinsights": "1.0.7",
-        "shelljs": "0.8.5"
+        "shelljs": "0.8.5",
+        "bfj": "8.0.0"
       },
       "devDependencies": {}
     }


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Externalize the `bfj` dependency used in @salesforce/apex-node so that @salesforce/apex-node can be bundled without issues.

### What issues does this PR fix or reference?
@W-15960945@

### Functionality Before
Apex extension does not activate and produces and error message.

### Functionality After
Apex extension works as expected.
https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/9501952453
