### PR TITLE
chore: downgrade @salesforce/apex-node to v6.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6424,128 +6424,6 @@
       "resolved": "https://registry.npmjs.org/@salesforce/apex/-/apex-0.0.12.tgz",
       "integrity": "sha512-L4zUDy4lxF7+mM7DYPfOKZ4lqiAIquRx0vHAUJMBaxD4bCiT+70Df++aOfGO9FOJNctvPtT5bLrFRfdos4y4Mg=="
     },
-    "node_modules/@salesforce/apex-node": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@salesforce/apex-node/-/apex-node-6.1.2.tgz",
-      "integrity": "sha512-GF1ou91qxtTIduK4idq+OtQ3sKAXwA3WYLTYXPfJ+HiWQu9Qq/aRFSyl3I/+DAXqtTXXYJL3ocdZ7KH5EzBCJg==",
-      "dependencies": {
-        "@jsforce/jsforce-node": "^3.2.0",
-        "@salesforce/core": "^7.3.10",
-        "@salesforce/kit": "^3.1.2",
-        "@types/istanbul-reports": "^3.0.4",
-        "bfj": "^8.0.0",
-        "faye": "1.4.0",
-        "glob": "^10.3.16",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.1.7"
-      },
-      "engines": {
-        "node": ">=18.18.2"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/faye": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
-      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
-      "dependencies": {
-        "asap": "*",
-        "csprng": "*",
-        "faye-websocket": ">=0.9.1",
-        "safe-buffer": "*",
-        "tough-cookie": "*",
-        "tunnel-agent": "*"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/foreground-child": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/glob": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
-      "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/jackspeak": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
-      "integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/minimatch": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@salesforce/apex-tmlanguage": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@salesforce/apex-tmlanguage/-/apex-tmlanguage-1.8.0.tgz",
@@ -10016,26 +9894,6 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
     },
-    "node_modules/bfj": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/bfj/-/bfj-8.0.0.tgz",
-      "integrity": "sha512-6KJe4gFrZ4lhmvWcUIj37yFAs36mi2FZXuTkw6udZ/QsX/znFypW4SatqcLA5K5T4BAWgJZD73UFEJJQxuJjoA==",
-      "dependencies": {
-        "bluebird": "^3.7.2",
-        "check-types": "^11.2.3",
-        "hoopy": "^0.1.4",
-        "jsonpath": "^1.1.1",
-        "tryer": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      }
-    },
-    "node_modules/bfj/node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-    },
     "node_modules/big-integer": {
       "version": "1.6.51",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
@@ -10793,11 +10651,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/check-types": {
-      "version": "11.2.3",
-      "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.2.3.tgz",
-      "integrity": "sha512-+67P1GkJRaxQD6PKK0Et9DhwQB+vGg3PM5+aavopCpZT1lj9jeqfvpgTLAWErNj8qApkkmXlu/Ug74kmhagkXg=="
     },
     "node_modules/cheerio": {
       "version": "1.0.0-rc.12",
@@ -16766,14 +16619,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/hoopy": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
-      "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==",
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -20769,33 +20614,6 @@
       "engines": [
         "node >= 0.2.0"
       ]
-    },
-    "node_modules/jsonpath": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
-      "integrity": "sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==",
-      "dependencies": {
-        "esprima": "1.2.2",
-        "static-eval": "2.0.2",
-        "underscore": "1.12.1"
-      }
-    },
-    "node_modules/jsonpath/node_modules/esprima": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
-      "integrity": "sha512-+JpPZam9w5DuJ3Q67SqsMGtiHKENSMRVoxvArfJZK01/BfLEObtZ6orJa/MtoGNR/rfMgp5837T41PAmTwAv/A==",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/jsonpath/node_modules/underscore": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "node_modules/JSONStream": {
       "version": "1.3.5",
@@ -30695,87 +30513,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/static-eval": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
-      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
-      "dependencies": {
-        "escodegen": "^1.8.1"
-      }
-    },
-    "node_modules/static-eval/node_modules/escodegen": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=4.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/static-eval/node_modules/fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
-    },
-    "node_modules/static-eval/node_modules/levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-      "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/static-eval/node_modules/optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/static-eval/node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/static-eval/node_modules/type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -31670,11 +31407,6 @@
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
       }
-    },
-    "node_modules/tryer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
-      "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
     },
     "node_modules/ts-api-utils": {
       "version": "1.0.3",
@@ -33222,6 +32954,7 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -35839,7 +35572,7 @@
       "version": "61.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/apex-node": "6.1.2",
+        "@salesforce/apex-node": "6.0.1",
         "@salesforce/apex-tmlanguage": "1.8.0",
         "@salesforce/core": "7.3.10",
         "@salesforce/salesforcedx-utils-vscode": "61.0.0",
@@ -36009,7 +35742,7 @@
       "version": "61.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/apex-node": "6.1.2",
+        "@salesforce/apex-node": "6.0.1",
         "@salesforce/core": "7.3.10",
         "@salesforce/salesforcedx-apex-replay-debugger": "61.0.0",
         "@salesforce/salesforcedx-utils": "61.0.0",
@@ -36081,6 +35814,25 @@
         "node": ">=12"
       }
     },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/@salesforce/apex-node": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/apex-node/-/apex-node-6.0.1.tgz",
+      "integrity": "sha512-bOD2jJzJsqovpq+b9SKVOQpNBjXsk0QDOkJUlugNw6ssOjnA98HfCjLQYOhT1MoG35BD4mf7eAwd7c+ztV7RIA==",
+      "dependencies": {
+        "@jsforce/jsforce-node": "^3.2.0",
+        "@salesforce/core": "^7.3.9",
+        "@salesforce/kit": "^3.1.2",
+        "@types/istanbul-reports": "^3.0.4",
+        "faye": "1.4.0",
+        "glob": "^10.3.10",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.6"
+      },
+      "engines": {
+        "node": ">=18.18.2"
+      }
+    },
     "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/@types/node": {
       "version": "18.18.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.6.tgz",
@@ -36134,6 +35886,108 @@
         "esbuild": "^0.17.1 || ^0.18.0 || ^0.19.0 || ^0.20.0"
       }
     },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/faye": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
+      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
+      "dependencies": {
+        "asap": "*",
+        "csprng": "*",
+        "faye-websocket": ">=0.9.1",
+        "safe-buffer": "*",
+        "tough-cookie": "*",
+        "tunnel-agent": "*"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/foreground-child": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.0.tgz",
+      "integrity": "sha512-CrWQNaEl1/6WeZoarcM9LHupTo3RpZO2Pdk1vktwzPiQTsJnAKJmm3TACKeG5UZbWDfaH2AbvYxzP96y0MT7fA==",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/glob": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
+      "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/jackspeak": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
+      "integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "packages/salesforcedx-vscode-apex/node_modules/@esbuild/android-arm": {
       "version": "0.19.12",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
@@ -36164,6 +36018,25 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/@salesforce/apex-node": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/apex-node/-/apex-node-6.0.1.tgz",
+      "integrity": "sha512-bOD2jJzJsqovpq+b9SKVOQpNBjXsk0QDOkJUlugNw6ssOjnA98HfCjLQYOhT1MoG35BD4mf7eAwd7c+ztV7RIA==",
+      "dependencies": {
+        "@jsforce/jsforce-node": "^3.2.0",
+        "@salesforce/core": "^7.3.9",
+        "@salesforce/kit": "^3.1.2",
+        "@types/istanbul-reports": "^3.0.4",
+        "faye": "1.4.0",
+        "glob": "^10.3.10",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.6"
+      },
+      "engines": {
+        "node": ">=18.18.2"
       }
     },
     "packages/salesforcedx-vscode-apex/node_modules/@types/node": {
@@ -36229,6 +36102,89 @@
         "esbuild": "^0.17.1 || ^0.18.0 || ^0.19.0 || ^0.20.0"
       }
     },
+    "packages/salesforcedx-vscode-apex/node_modules/faye": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
+      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
+      "dependencies": {
+        "asap": "*",
+        "csprng": "*",
+        "faye-websocket": ">=0.9.1",
+        "safe-buffer": "*",
+        "tough-cookie": "*",
+        "tunnel-agent": "*"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/foreground-child": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.0.tgz",
+      "integrity": "sha512-CrWQNaEl1/6WeZoarcM9LHupTo3RpZO2Pdk1vktwzPiQTsJnAKJmm3TACKeG5UZbWDfaH2AbvYxzP96y0MT7fA==",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/glob": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
+      "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/jackspeak": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
+      "integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "packages/salesforcedx-vscode-apex/node_modules/minimatch": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
@@ -36238,6 +36194,25 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/salesforcedx-vscode-apex/node_modules/vscode-jsonrpc": {

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -24,7 +24,7 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/apex-node": "6.1.2",
+    "@salesforce/apex-node": "6.0.1",
     "@salesforce/core": "7.3.10",
     "@salesforce/salesforcedx-apex-replay-debugger": "61.0.0",
     "@salesforce/salesforcedx-utils": "61.0.0",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -24,7 +24,7 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/apex-node": "6.1.2",
+    "@salesforce/apex-node": "6.0.1",
     "@salesforce/apex-tmlanguage": "1.8.0",
     "@salesforce/core": "7.3.10",
     "@salesforce/salesforcedx-utils-vscode": "61.0.0",


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Downgrade the @salesforce/apex-node dependency to not include the heap monitoring change which was causing issues with bundling.

### What issues does this PR fix or reference?
@W-15960945@

### Functionality Before
Apex extension does not activate and produces and error message.

### Functionality After
Apex extension works as expected.
https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/9500842559