### PR TITLE
chore: update closeStaleIssues.yml to close stale issues tagged with "missing required information"

### DIFF
--- a/.github/workflows/closeStaleIssues.yml
+++ b/.github/workflows/closeStaleIssues.yml
@@ -26,4 +26,4 @@ jobs:
           close-issue-reason: not_planned
           operations-per-run: 100
           exempt-issue-labels: announcement,bug,on hold,waiting for internal reply,feature
-          any-of-labels: more information required
+          any-of-labels: more information required,missing required information


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Update the **Close Stale Issues** GHA workflow to also close issues tagged with "missing required information"

### What issues does this PR fix or reference?
[skip-validate-pr]

### Functionality Before
**Close Stale Issues** only runs on issues tagged with "more information required"

### Functionality After
**Close Stale Issues** runs on issues tagged with "more information required" and "missing required information"