### PR TITLE
fix: allow user to filter by null strings in SOQL Builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7109,9 +7109,9 @@
       "integrity": "sha512-LiN37zG5ODT6z70sL1fxF7BQwtCX9JOWofSU8iliSNIM+WDEeinnoFtVqPInRSNt8I0RiJxIKCrqstsmQRBNvA=="
     },
     "node_modules/@salesforce/soql-builder-ui": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/soql-builder-ui/-/soql-builder-ui-0.2.0.tgz",
-      "integrity": "sha512-v0ivG7erPxj7VFe6XEFGTijroVmqfFbAkGFM7pN1aZ11EuAk5xLUpWoZqN/bauX/KPKfyI3asE2T7JLfQYHIzw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/soql-builder-ui/-/soql-builder-ui-1.0.0.tgz",
+      "integrity": "sha512-kLKpcjKbiFdC4CMMynv/oEfVOq0cO1ffOdOYvTkGiPlTHeYNfVIfBpQ1H8EtNuu2f5Wi3WxB1zUsTGpZlBKAJg==",
       "engines": {
         "node": ">=10.13.0",
         "npm": ">=6.4.1",
@@ -7203,9 +7203,9 @@
       "integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ=="
     },
     "node_modules/@salesforce/soql-model": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@salesforce/soql-model/-/soql-model-0.2.3.tgz",
-      "integrity": "sha512-MscHFmVioNgYhpcZvHlG7VCj+TiYHt2HnjHB0fUZiOX/G1BSBllpyGuy4j3vpmuLURT6GzInTa1fHD1zARyArw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/soql-model/-/soql-model-1.0.0.tgz",
+      "integrity": "sha512-ggCsoAyfjg+KKP5EWu7DhhCOwhP1ZwHUDpSTiU75jd3nCKpPlJaZhIp3eqzikxLBVZ89HRTRkid/8CSFAwBgYA==",
       "dependencies": {
         "@salesforce/soql-common": "0.2.2",
         "antlr4ts": "^0.5.0-alpha.3"
@@ -36901,10 +36901,10 @@
         "@jsforce/jsforce-node": "3.2.0",
         "@salesforce/apex-tmlanguage": "1.6.0",
         "@salesforce/core": "7.3.10",
-        "@salesforce/soql-builder-ui": "0.2.0",
+        "@salesforce/soql-builder-ui": "1.0.0",
         "@salesforce/soql-data-view": "0.1.0",
         "@salesforce/soql-language-server": "0.7.1",
-        "@salesforce/soql-model": "0.2.3"
+        "@salesforce/soql-model": "1.0.0"
       },
       "devDependencies": {
         "@salesforce/salesforcedx-sobjects-faux-generator": "61.0.1",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -34,10 +34,10 @@
     "@jsforce/jsforce-node": "3.2.0",
     "@salesforce/apex-tmlanguage": "1.6.0",
     "@salesforce/core": "7.3.10",
-    "@salesforce/soql-builder-ui": "0.2.0",
+    "@salesforce/soql-builder-ui": "1.0.0",
     "@salesforce/soql-data-view": "0.1.0",
     "@salesforce/soql-language-server": "0.7.1",
-    "@salesforce/soql-model": "0.2.3"
+    "@salesforce/soql-model": "1.0.0"
   },
   "devDependencies": {
     "@salesforce/salesforcedx-sobjects-faux-generator": "61.0.1",
@@ -143,10 +143,10 @@
         "@salesforce/core": "7.3.10",
         "@salesforce/source-tracking": "6.3.4",
         "shelljs": "0.8.5",
-        "@salesforce/soql-builder-ui": "0.2.0",
+        "@salesforce/soql-builder-ui": "1.0.0",
         "@salesforce/soql-data-view": "0.1.0",
         "@salesforce/soql-language-server": "0.7.1",
-        "@salesforce/soql-model": "0.2.3"
+        "@salesforce/soql-model": "1.0.0"
       },
       "devDependencies": {}
     }


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
This PR will update the dependencies `soql-builder-ui` and `soql-model` in the SOQL Builder extension. The new versions include a bug fix addressing issue https://github.com/forcedotcom/soql-tooling/issues/268 where users were unable to filter for NULL values if the SObject field type is a string. 
[The functional change in the soql-tooling repo is here](https://github.com/forcedotcom/soql-tooling/pull/285/files#diff-c349389e35d166cc7575fc1d35958ec6eb8ad43ae0fcf1ef24473cb3ff50bfe7R17)

Note: The soql-tooling repo had not been touched in 3 years, some of the changes address issues with development workflow such as linting and building. We also had some issue with out release automation in CI, so I ended up manually publishing to NPM with a fresh start at `v1.0.0` for `soql-model` and `soql-builder-ui`.
### What issues does this PR fix or reference?

[@W-15920576@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001tOhgfYAC/view)
### Functionality Before

![Screenshot 2024-06-14 at 11 01 53 AM](https://github.com/forcedotcom/salesforcedx-vscode/assets/25188632/b0d54cb1-a2bb-4c01-a71c-b2bd1d7c6ddb)

### Functionality After

![Screenshot 2024-06-14 at 10 59 49 AM](https://github.com/forcedotcom/salesforcedx-vscode/assets/25188632/672ba67f-6cd7-4c97-8357-9c9b88352632)
