### PR TITLE
Mz/pin jsonpath

### DIFF
--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -109,7 +109,7 @@
         "@salesforce/core": "7.5.0",
         "@salesforce/source-tracking": "6.5.1",
         "applicationinsights": "1.0.7",
-        "jsonpath": "^1.1.1"
+        "jsonpath": "1.1.1"
       },
       "devDependencies": {}
     }

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -108,7 +108,7 @@
         "@salesforce/source-tracking": "6.5.1",
         "applicationinsights": "1.0.7",
         "shelljs": "0.8.5",
-        "jsonpath": "^1.1.1"
+        "jsonpath": "1.1.1"
       },
       "devDependencies": {}
     }

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/retrieveMetadata/retrieveComponent.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/retrieveMetadata/retrieveComponent.test.ts
@@ -238,7 +238,8 @@ describe('Retrieve Component(s)', () => {
       };
       pollStatusStub.resolves(
         new RetrieveResult(
-          retrieveResponse ,
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+          retrieveResponse as MetadataApiRetrieveStatus,
           componentSet
         )
       );

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/retrieveMetadata/retrieveComponent.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/retrieveMetadata/retrieveComponent.test.ts
@@ -238,7 +238,7 @@ describe('Retrieve Component(s)', () => {
       };
       pollStatusStub.resolves(
         new RetrieveResult(
-          retrieveResponse as MetadataApiRetrieveStatus,
+          retrieveResponse ,
           componentSet
         )
       );


### PR DESCRIPTION
### What does this PR do?
After consuming apex-node v6.1.3 which pins bfj version to 8.0.0, jsonpath is fixed to 1.1.1. So after this PR there is no need to worry about the version bumping of jsonpath unconsciously.

### What issues does this PR fix or reference?
@W-16038857@

### Functionality Before
jsonpath ^1.1.1
### Functionality After
jsonpath 1.1.1