### PR TITLE
feat: opt in bundling @salesforce/core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6332,128 +6332,6 @@
       "resolved": "https://registry.npmjs.org/@salesforce/apex/-/apex-0.0.12.tgz",
       "integrity": "sha512-L4zUDy4lxF7+mM7DYPfOKZ4lqiAIquRx0vHAUJMBaxD4bCiT+70Df++aOfGO9FOJNctvPtT5bLrFRfdos4y4Mg=="
     },
-    "node_modules/@salesforce/apex-node": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@salesforce/apex-node/-/apex-node-6.1.3.tgz",
-      "integrity": "sha512-H+F044YEIzaL107IuUXRVy54HnOdWBVZ8X9Fw8RqCwXn9PWLzHCOAkQP/wFEACKeZx1crRuyP4chR2+0dIcPug==",
-      "dependencies": {
-        "@jsforce/jsforce-node": "^3.2.0",
-        "@salesforce/core": "^7.4.1",
-        "@salesforce/kit": "^3.1.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "bfj": "^8.0.0",
-        "faye": "1.4.0",
-        "glob": "^10.3.16",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.1.7"
-      },
-      "engines": {
-        "node": ">=18.18.2"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/faye": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
-      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
-      "dependencies": {
-        "asap": "*",
-        "csprng": "*",
-        "faye-websocket": ">=0.9.1",
-        "safe-buffer": "*",
-        "tough-cookie": "*",
-        "tunnel-agent": "*"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/foreground-child": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.0.tgz",
-      "integrity": "sha512-CrWQNaEl1/6WeZoarcM9LHupTo3RpZO2Pdk1vktwzPiQTsJnAKJmm3TACKeG5UZbWDfaH2AbvYxzP96y0MT7fA==",
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/glob": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
-      "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/jackspeak": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
-      "integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/minimatch": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/@salesforce/apex-node/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@salesforce/apex-tmlanguage": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@salesforce/apex-tmlanguage/-/apex-tmlanguage-1.8.0.tgz",
@@ -6538,11 +6416,10 @@
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.6.tgz",
       "integrity": "sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww=="
     },
-    "node_modules/@salesforce/core": {
+    "node_modules/@salesforce/core-bundle": {
       "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-7.5.0.tgz",
-      "integrity": "sha512-mPg9Tj2Qqe/TY7q+CRNSeYYTV+dj/LflM7Fu/32EPLCEPGVIiSp/RaTFLTZwDcFX9BVYHOa2h6oliuO2Qnno+A==",
-      "deprecated": "this package has been deprecated, should have been released as v8.0.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/core-bundle/-/core-bundle-7.5.0.tgz",
+      "integrity": "sha512-wOtPjT4ji1CLM6T8bF47S8dXnqrQt2hvbqDseur/v3rzYSXN26uSpdn8uVWHpkM8oCbkLfDPKQd0pnUyd3VvCw==",
       "dependencies": {
         "@jsforce/jsforce-node": "^3.2.0",
         "@salesforce/kit": "^3.1.6",
@@ -6567,7 +6444,7 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@salesforce/core/node_modules/@salesforce/ts-types": {
+    "node_modules/@salesforce/core-bundle/node_modules/@salesforce/ts-types": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.10.tgz",
       "integrity": "sha512-ulGQ1oUGXrmSUi6NGbxZZ7ykSDv439x+WYZpkMgFLC8Dx0TxJXfUAJYeZh7eKO5xI/ob3iyvN+RBcBkp4KFN1w==",
@@ -6575,7 +6452,7 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@salesforce/core/node_modules/ajv": {
+    "node_modules/@salesforce/core-bundle/node_modules/ajv": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
       "integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
@@ -6590,7 +6467,7 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@salesforce/core/node_modules/camel-case": {
+    "node_modules/@salesforce/core-bundle/node_modules/camel-case": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
       "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
@@ -6599,7 +6476,7 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/@salesforce/core/node_modules/change-case": {
+    "node_modules/@salesforce/core-bundle/node_modules/change-case": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
       "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
@@ -6618,7 +6495,7 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/@salesforce/core/node_modules/constant-case": {
+    "node_modules/@salesforce/core-bundle/node_modules/constant-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
       "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
@@ -6628,7 +6505,7 @@
         "upper-case": "^2.0.2"
       }
     },
-    "node_modules/@salesforce/core/node_modules/dot-case": {
+    "node_modules/@salesforce/core-bundle/node_modules/dot-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
       "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
@@ -6637,7 +6514,7 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/@salesforce/core/node_modules/faye": {
+    "node_modules/@salesforce/core-bundle/node_modules/faye": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
       "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
@@ -6653,7 +6530,7 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/@salesforce/core/node_modules/header-case": {
+    "node_modules/@salesforce/core-bundle/node_modules/header-case": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
       "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
@@ -6662,12 +6539,12 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/@salesforce/core/node_modules/json-schema-traverse": {
+    "node_modules/@salesforce/core-bundle/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
-    "node_modules/@salesforce/core/node_modules/lower-case": {
+    "node_modules/@salesforce/core-bundle/node_modules/lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
       "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
@@ -6675,7 +6552,7 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/@salesforce/core/node_modules/no-case": {
+    "node_modules/@salesforce/core-bundle/node_modules/no-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
       "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
@@ -6684,7 +6561,7 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/@salesforce/core/node_modules/param-case": {
+    "node_modules/@salesforce/core-bundle/node_modules/param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
       "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
@@ -6693,7 +6570,7 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/@salesforce/core/node_modules/pascal-case": {
+    "node_modules/@salesforce/core-bundle/node_modules/pascal-case": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
       "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
@@ -6702,7 +6579,7 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/@salesforce/core/node_modules/path-case": {
+    "node_modules/@salesforce/core-bundle/node_modules/path-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
       "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
@@ -6711,7 +6588,7 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/@salesforce/core/node_modules/sentence-case": {
+    "node_modules/@salesforce/core-bundle/node_modules/sentence-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
       "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
@@ -6721,7 +6598,7 @@
         "upper-case-first": "^2.0.2"
       }
     },
-    "node_modules/@salesforce/core/node_modules/snake-case": {
+    "node_modules/@salesforce/core-bundle/node_modules/snake-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
       "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
@@ -6730,12 +6607,12 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/@salesforce/core/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    "node_modules/@salesforce/core-bundle/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
-    "node_modules/@salesforce/core/node_modules/upper-case": {
+    "node_modules/@salesforce/core-bundle/node_modules/upper-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
       "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
@@ -6743,7 +6620,7 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/@salesforce/core/node_modules/upper-case-first": {
+    "node_modules/@salesforce/core-bundle/node_modules/upper-case-first": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
       "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
@@ -7242,12 +7119,12 @@
         "node": "*"
       }
     },
-    "node_modules/@salesforce/source-deploy-retrieve": {
+    "node_modules/@salesforce/source-deploy-retrieve-bundle": {
       "version": "11.6.10",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-11.6.10.tgz",
-      "integrity": "sha512-/2MlCffvuZjrMebcOmivvIkV17a1T0eLBS+AJhwqClwyyoTxAj+YNIq8nUcDzNn4A8Qg62yYz2Im3DxlADe+Wg==",
+      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve-bundle/-/source-deploy-retrieve-bundle-11.6.10.tgz",
+      "integrity": "sha512-tewFZvJAm4rW9QBHQO6TxZNYseJD68AdJfbmqP6eWtvQ7QMR+jHBuYg+nr7ylIOL62TsEd8ucsvcy3CaZfhy4Q==",
       "dependencies": {
-        "@salesforce/core": "^7.4.1",
+        "@salesforce/core-bundle": "^7.4.1",
         "@salesforce/kit": "^3.1.6",
         "@salesforce/ts-types": "^2.0.9",
         "fast-levenshtein": "^3.0.0",
@@ -7264,18 +7141,15 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/@salesforce/ts-types": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.9.tgz",
-      "integrity": "sha512-boUD9jw5vQpTCPCCmK/NFTWjSuuW+lsaxOynkyNXLW+zxOc4GDjhtKc4j0vWZJQvolpafbyS8ZLFHZJvs12gYA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
+    "node_modules/@salesforce/source-deploy-retrieve-bundle/node_modules/@salesforce/ts-types": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.10.tgz",
+      "integrity": "sha512-ulGQ1oUGXrmSUi6NGbxZZ7ykSDv439x+WYZpkMgFLC8Dx0TxJXfUAJYeZh7eKO5xI/ob3iyvN+RBcBkp4KFN1w==",
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/minimatch": {
+    "node_modules/@salesforce/source-deploy-retrieve-bundle/node_modules/minimatch": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
       "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
@@ -7286,20 +7160,15 @@
         "node": ">=10"
       }
     },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "node_modules/@salesforce/source-tracking": {
+    "node_modules/@salesforce/source-tracking-bundle": {
       "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-tracking/-/source-tracking-6.5.1.tgz",
-      "integrity": "sha512-K3f6if2lwSolqzC7CUJJAzw2TUcGFrL83WfSPgQsYwPxPE1o7uJJ/iH662He7ZoMxZrGl2vcptg7vEC3jX5nig==",
+      "resolved": "https://registry.npmjs.org/@salesforce/source-tracking-bundle/-/source-tracking-bundle-6.5.1.tgz",
+      "integrity": "sha512-P7Rf86cZzUVKHZREdnNJNw+BGXkAPuiBLGIOd3ySEDswiMpLGxziCU/JH5+WCF6vhB+onmOs3Ke3Do3iUVEQKA==",
       "dependencies": {
         "@oclif/core": "^4.0.3",
-        "@salesforce/core": "^7.3.10",
+        "@salesforce/core-bundle": "^7.3.10",
         "@salesforce/kit": "^3.1.2",
-        "@salesforce/source-deploy-retrieve": "^11.6.5",
+        "@salesforce/source-deploy-retrieve-bundle": "^11.6.5",
         "@salesforce/ts-types": "^2.0.9",
         "fast-xml-parser": "^4.4.0",
         "graceful-fs": "^4.2.11",
@@ -7310,28 +7179,20 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@salesforce/source-tracking/node_modules/@salesforce/ts-types": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.9.tgz",
-      "integrity": "sha512-boUD9jw5vQpTCPCCmK/NFTWjSuuW+lsaxOynkyNXLW+zxOc4GDjhtKc4j0vWZJQvolpafbyS8ZLFHZJvs12gYA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
+    "node_modules/@salesforce/source-tracking-bundle/node_modules/@salesforce/ts-types": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.10.tgz",
+      "integrity": "sha512-ulGQ1oUGXrmSUi6NGbxZZ7ykSDv439x+WYZpkMgFLC8Dx0TxJXfUAJYeZh7eKO5xI/ob3iyvN+RBcBkp4KFN1w==",
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@salesforce/source-tracking/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "node_modules/@salesforce/templates": {
+    "node_modules/@salesforce/templates-bundle": {
       "version": "61.0.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-61.0.1.tgz",
-      "integrity": "sha512-q493YeqsSUXxu9bjc6CukCSfW9G28YB/QFSJjtlSgG3DOxxTC0GrQaJZaXog0dsOYFdMPtfHTAhWGG8udyXKfQ==",
+      "resolved": "https://registry.npmjs.org/@salesforce/templates-bundle/-/templates-bundle-61.0.1.tgz",
+      "integrity": "sha512-tXUkmQbsdNF+9c3V7dzm9Iez471BQZUoIL3uPNIaK3SYEa+LkDZsBzk/zFtCScMN0wMQ8NR3UU9yg6NRKKFbOA==",
       "dependencies": {
-        "@salesforce/core": "^7.3.10",
+        "@salesforce/core-bundle": "^7.3.10",
         "@salesforce/kit": "^3.1.2",
         "got": "^11.8.2",
         "hpagent": "^1.2.0",
@@ -7346,10 +7207,10 @@
         "node": ">=18.18.2"
       }
     },
-    "node_modules/@salesforce/templates/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    "node_modules/@salesforce/templates-bundle/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@salesforce/ts-sinon": {
       "version": "1.4.0",
@@ -27655,6 +27516,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw=="
+    },
     "node_modules/pacote": {
       "version": "13.6.2",
       "resolved": "https://registry.npmjs.org/pacote/-/pacote-13.6.2.tgz",
@@ -35190,7 +35056,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jsforce/jsforce-node": "3.2.0",
-        "@salesforce/core": "7.5.0",
+        "@salesforce/core-bundle": "7.5.0",
         "@salesforce/salesforcedx-utils-vscode": "61.2.0",
         "shelljs": "0.8.5"
       },
@@ -35345,9 +35211,9 @@
       "version": "61.2.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "7.5.0",
-        "@salesforce/source-deploy-retrieve": "11.6.10",
-        "@salesforce/source-tracking": "6.5.1",
+        "@salesforce/core-bundle": "7.5.0",
+        "@salesforce/source-deploy-retrieve-bundle": "11.6.10",
+        "@salesforce/source-tracking-bundle": "6.5.1",
         "applicationinsights": "1.0.7",
         "cross-spawn": "7.0.3",
         "rxjs": "^5.4.1",
@@ -35547,9 +35413,9 @@
       "version": "61.2.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/apex-node": "6.1.3",
+        "@salesforce/apex-node-bundle": "6.1.3",
         "@salesforce/apex-tmlanguage": "1.8.0",
-        "@salesforce/core": "7.5.0",
+        "@salesforce/core-bundle": "7.5.0",
         "@salesforce/salesforcedx-utils-vscode": "61.2.0",
         "expand-home-dir": "0.0.3",
         "find-java-home": "0.2.0",
@@ -35717,8 +35583,8 @@
       "version": "61.2.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/apex-node": "6.1.3",
-        "@salesforce/core": "7.5.0",
+        "@salesforce/apex-node-bundle": "6.1.3",
+        "@salesforce/core-bundle": "7.5.0",
         "@salesforce/salesforcedx-apex-replay-debugger": "61.2.0",
         "@salesforce/salesforcedx-utils": "61.2.0",
         "@salesforce/salesforcedx-utils-vscode": "61.2.0",
@@ -35789,6 +35655,26 @@
         "node": ">=12"
       }
     },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/@salesforce/apex-node-bundle": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@salesforce/apex-node-bundle/-/apex-node-bundle-6.1.3.tgz",
+      "integrity": "sha512-3rZ067vdaa/6BpGujAV8Q68YzAa2nkfSQaBzaBxHdRd5xEbrlCxBa8MIS+D+wuzY4hfube3j6pCvEZEGNwtNvQ==",
+      "dependencies": {
+        "@jsforce/jsforce-node": "^3.2.0",
+        "@salesforce/core-bundle": "^7.4.1",
+        "@salesforce/kit": "^3.1.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "bfj": "^8.0.0",
+        "faye": "1.4.0",
+        "glob": "^10.3.16",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.7"
+      },
+      "engines": {
+        "node": ">=18.18.2"
+      }
+    },
     "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/@types/node": {
       "version": "18.18.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.6.tgz",
@@ -35842,6 +35728,109 @@
         "esbuild": "^0.17.1 || ^0.18.0 || ^0.19.0 || ^0.20.0"
       }
     },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/faye": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
+      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
+      "dependencies": {
+        "asap": "*",
+        "csprng": "*",
+        "faye-websocket": ">=0.9.1",
+        "safe-buffer": "*",
+        "tough-cookie": "*",
+        "tunnel-agent": "*"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/foreground-child": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
+      "integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/glob": {
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.2.tgz",
+      "integrity": "sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/jackspeak": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
+      "integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/salesforcedx-vscode-apex-replay-debugger/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "packages/salesforcedx-vscode-apex/node_modules/@esbuild/android-arm": {
       "version": "0.19.12",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
@@ -35872,6 +35861,26 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/@salesforce/apex-node-bundle": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@salesforce/apex-node-bundle/-/apex-node-bundle-6.1.3.tgz",
+      "integrity": "sha512-3rZ067vdaa/6BpGujAV8Q68YzAa2nkfSQaBzaBxHdRd5xEbrlCxBa8MIS+D+wuzY4hfube3j6pCvEZEGNwtNvQ==",
+      "dependencies": {
+        "@jsforce/jsforce-node": "^3.2.0",
+        "@salesforce/core-bundle": "^7.4.1",
+        "@salesforce/kit": "^3.1.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "bfj": "^8.0.0",
+        "faye": "1.4.0",
+        "glob": "^10.3.16",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.7"
+      },
+      "engines": {
+        "node": ">=18.18.2"
       }
     },
     "packages/salesforcedx-vscode-apex/node_modules/@types/node": {
@@ -35937,6 +35946,90 @@
         "esbuild": "^0.17.1 || ^0.18.0 || ^0.19.0 || ^0.20.0"
       }
     },
+    "packages/salesforcedx-vscode-apex/node_modules/faye": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
+      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
+      "dependencies": {
+        "asap": "*",
+        "csprng": "*",
+        "faye-websocket": ">=0.9.1",
+        "safe-buffer": "*",
+        "tough-cookie": "*",
+        "tunnel-agent": "*"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/foreground-child": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
+      "integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/glob": {
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.2.tgz",
+      "integrity": "sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/jackspeak": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
+      "integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "packages/salesforcedx-vscode-apex/node_modules/minimatch": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
@@ -35946,6 +36039,25 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/salesforcedx-vscode-apex/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/salesforcedx-vscode-apex/node_modules/vscode-jsonrpc": {
@@ -35988,12 +36100,12 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jsforce/jsforce-node": "3.2.0",
-        "@salesforce/core": "7.5.0",
+        "@salesforce/core-bundle": "7.5.0",
         "@salesforce/salesforcedx-sobjects-faux-generator": "61.2.0",
         "@salesforce/salesforcedx-utils-vscode": "61.2.0",
         "@salesforce/schemas": "^1.6.1",
-        "@salesforce/source-deploy-retrieve": "11.6.10",
-        "@salesforce/templates": "^61.0.1",
+        "@salesforce/source-deploy-retrieve-bundle": "11.6.10",
+        "@salesforce/templates-bundle": "61.0.1",
         "@salesforce/ts-types": "2.0.9",
         "@salesforce/vscode-service-provider": "1.0.4",
         "adm-zip": "0.5.10",
@@ -36246,7 +36358,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/aura-language-server": "4.8.0",
-        "@salesforce/core": "7.5.0",
+        "@salesforce/core-bundle": "7.5.0",
         "@salesforce/lightning-lsp-common": "4.8.0",
         "@salesforce/salesforcedx-utils-vscode": "61.2.0",
         "applicationinsights": "1.0.7",
@@ -36429,7 +36541,7 @@
       "version": "61.2.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "7.5.0",
+        "@salesforce/core-bundle": "7.5.0",
         "@salesforce/eslint-config-lwc": "3.5.1",
         "@salesforce/lightning-lsp-common": "4.8.0",
         "@salesforce/lwc-language-server": "4.8.0",
@@ -36633,7 +36745,7 @@
       "dependencies": {
         "@jsforce/jsforce-node": "3.2.0",
         "@salesforce/apex-tmlanguage": "1.6.0",
-        "@salesforce/core": "7.5.0",
+        "@salesforce/core-bundle": "7.5.0",
         "@salesforce/soql-builder-ui": "1.0.0",
         "@salesforce/soql-data-view": "0.1.0",
         "@salesforce/soql-language-server": "0.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36105,7 +36105,7 @@
         "@salesforce/salesforcedx-utils-vscode": "61.2.0",
         "@salesforce/schemas": "^1.6.1",
         "@salesforce/source-deploy-retrieve-bundle": "11.6.10",
-        "@salesforce/templates-bundle": "61.0.1",
+        "@salesforce/templates-bundle": "^61.0.1",
         "@salesforce/ts-types": "2.0.9",
         "@salesforce/vscode-service-provider": "1.0.4",
         "adm-zip": "0.5.10",

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -11,9 +11,9 @@
   "main": "out/src",
   "dependencies": {
     "@jsforce/jsforce-node": "3.2.0",
-    "@salesforce/core": "7.5.0",
     "@salesforce/salesforcedx-utils-vscode": "61.2.0",
-    "shelljs": "0.8.5"
+    "shelljs": "0.8.5",
+    "@salesforce/core-bundle": "7.5.0"
   },
   "devDependencies": {
     "@types/chai": "4.3.3",

--- a/packages/salesforcedx-sobjects-faux-generator/scripts/regenerateMinsSObjects.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/scripts/regenerateMinsSObjects.ts
@@ -19,7 +19,7 @@ import { SObjectShortDescription } from '../src/describe';
 import { OrgObjectDetailRetriever } from '../src/retriever';
 import { SObject } from '../src/types';
 
-import { Connection, Org } from '@salesforce/core';
+import { Connection, Org } from '@salesforce/core-bundle';
 
 // tslint:disable-next-line:no-floating-promises
 (async () => {

--- a/packages/salesforcedx-sobjects-faux-generator/src/describe/sObjectDescribe.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/describe/sObjectDescribe.ts
@@ -10,7 +10,7 @@ import {
   DescribeSObjectResult,
   Field
 } from '@jsforce/jsforce-node';
-import { Connection } from '@salesforce/core';
+import { Connection } from '@salesforce/core-bundle';
 import { CLIENT_ID } from '../constants';
 import { BatchRequest, BatchResponse, SObject } from '../types';
 import { SObjectField } from '../types/describe';

--- a/packages/salesforcedx-sobjects-faux-generator/src/retriever/orgObjectRetriever.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/retriever/orgObjectRetriever.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Connection } from '@salesforce/core';
+import { Connection } from '@salesforce/core-bundle';
 import {
   SObjectDescribe,
   SObjectSelector,

--- a/packages/salesforcedx-sobjects-faux-generator/src/transformer/transformerFactory.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/transformer/transformerFactory.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { AuthInfo, Connection, SfProject } from '@salesforce/core';
+import { AuthInfo, Connection, SfProject } from '@salesforce/core-bundle';
 import {
   ConfigUtil,
   WorkspaceContextUtil

--- a/packages/salesforcedx-sobjects-faux-generator/test/integration/sObjectDescribe.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/integration/sObjectDescribe.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthInfo, Connection } from '@salesforce/core';
+import { AuthInfo, Connection } from '@salesforce/core-bundle';
 import { fail } from 'assert';
 import { expect } from 'chai';
 import { createSandbox } from 'sinon';

--- a/packages/salesforcedx-sobjects-faux-generator/test/integration/sobjectTransformer.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/integration/sobjectTransformer.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthInfo } from '@salesforce/core';
+import { AuthInfo } from '@salesforce/core-bundle';
 import { projectPaths } from '@salesforce/salesforcedx-utils-vscode';
 import { fail } from 'assert';
 import { expect } from 'chai';

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -10,14 +10,14 @@
   ],
   "main": "out/src",
   "dependencies": {
-    "@salesforce/core": "7.5.0",
-    "@salesforce/source-deploy-retrieve": "11.6.10",
-    "@salesforce/source-tracking": "6.5.1",
     "applicationinsights": "1.0.7",
     "cross-spawn": "7.0.3",
     "rxjs": "^5.4.1",
     "strip-ansi": "^5.2.0",
-    "tree-kill": "^1.1.0"
+    "tree-kill": "^1.1.0",
+    "@salesforce/core-bundle": "7.5.0",
+    "@salesforce/source-tracking-bundle": "6.5.1",
+    "@salesforce/source-deploy-retrieve-bundle": "11.6.10"
   },
   "devDependencies": {
     "@types/cross-spawn": "6.0.0",

--- a/packages/salesforcedx-utils-vscode/src/config/configUtil.ts
+++ b/packages/salesforcedx-utils-vscode/src/config/configUtil.ts
@@ -11,7 +11,7 @@ import {
   Org,
   OrgConfigProperties,
   StateAggregator
-} from '@salesforce/core';
+} from '@salesforce/core-bundle';
 import { workspaceUtils } from '..';
 import {
   SF_CONFIG_DISABLE_TELEMETRY,

--- a/packages/salesforcedx-utils-vscode/src/context/workspaceContextUtil.ts
+++ b/packages/salesforcedx-utils-vscode/src/context/workspaceContextUtil.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthInfo, Connection, StateAggregator } from '@salesforce/core';
+import { AuthInfo, Connection, StateAggregator } from '@salesforce/core-bundle';
 import * as vscode from 'vscode';
 import { ConfigAggregatorProvider, TelemetryService } from '..';
 import { ConfigUtil } from '../config/configUtil';

--- a/packages/salesforcedx-utils-vscode/src/helpers/paths.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/paths.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Global } from '@salesforce/core';
+import { Global } from '@salesforce/core-bundle';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';

--- a/packages/salesforcedx-utils-vscode/src/helpers/traceFlags.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/traceFlags.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { Connection } from '@salesforce/core';
+import { Connection } from '@salesforce/core-bundle';
 import { TraceFlagsRemover } from '../helpers';
 import { nls } from '../messages';
 

--- a/packages/salesforcedx-utils-vscode/src/helpers/traceFlagsRemover.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/traceFlagsRemover.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { Connection } from '@salesforce/core';
+import { Connection } from '@salesforce/core-bundle';
 
 /**
  * TraceFlagsRemover is a singleton which deletes trace flags created by the extensions.

--- a/packages/salesforcedx-utils-vscode/src/providers/configAggregatorProvider.ts
+++ b/packages/salesforcedx-utils-vscode/src/providers/configAggregatorProvider.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { ConfigAggregator } from '@salesforce/core';
+import { ConfigAggregator } from '@salesforce/core-bundle';
 import { workspaceUtils } from '../workspaces';
 
 /*

--- a/packages/salesforcedx-utils-vscode/src/providers/sourceTrackingProvider.ts
+++ b/packages/salesforcedx-utils-vscode/src/providers/sourceTrackingProvider.ts
@@ -5,11 +5,11 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Connection, Org, SfProject } from '@salesforce/core';
+import { Connection, Org, SfProject } from '@salesforce/core-bundle';
 import {
   SourceTracking,
   SourceTrackingOptions
-} from '@salesforce/source-tracking';
+} from '@salesforce/source-tracking-bundle';
 
 /*
  * The SourceTrackingProvider class is used to instantiate

--- a/packages/salesforcedx-utils-vscode/src/services/sourceTrackingService.ts
+++ b/packages/salesforcedx-utils-vscode/src/services/sourceTrackingService.ts
@@ -5,9 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Connection } from '@salesforce/core';
-import { RetrieveResult } from '@salesforce/source-deploy-retrieve';
-import { SourceTracking, StatusOutputRow } from '@salesforce/source-tracking';
+import { Connection } from '@salesforce/core-bundle';
+import { RetrieveResult } from '@salesforce/source-deploy-retrieve-bundle';
+import { SourceTracking, StatusOutputRow } from '@salesforce/source-tracking-bundle';
 import { WorkspaceContextUtil } from '../context/workspaceContextUtil';
 import { nls } from '../messages';
 import { Row, Table } from '../output';

--- a/packages/salesforcedx-utils-vscode/test/jest/config/configUtil.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/config/configUtil.test.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { Config, Org, StateAggregator } from '@salesforce/core';
+import { Config, Org, StateAggregator } from '@salesforce/core-bundle';
 import { ConfigUtil, TARGET_ORG_KEY, workspaceUtils } from '../../../src';
 import { ConfigAggregatorProvider } from './../../../src/providers/configAggregatorProvider';
 

--- a/packages/salesforcedx-utils-vscode/test/jest/context/workspaceContextUtil.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/context/workspaceContextUtil.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthInfo, Connection, StateAggregator } from '@salesforce/core';
+import { AuthInfo, Connection, StateAggregator } from '@salesforce/core-bundle';
 import * as vscode from 'vscode';
 import {
   ConfigAggregatorProvider,
@@ -15,7 +15,7 @@ import {
 import { ConfigUtil } from '../../../src/config/configUtil';
 import { WORKSPACE_CONTEXT_ORG_ID_ERROR } from '../../../src/context/workspaceContextUtil';
 import { nls } from '../../../src/messages';
-jest.mock('@salesforce/core', () => {
+jest.mock('@salesforce/core-bundle', () => {
   return {
     Logger: {
       childFromRoot: () => {

--- a/packages/salesforcedx-utils-vscode/test/jest/helpers/paths.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/helpers/paths.test.ts
@@ -25,7 +25,7 @@ import {
   TOOLS
 } from '../../../src/helpers/paths';
 
-jest.mock('@salesforce/core', () => {
+jest.mock('@salesforce/core-bundle', () => {
   return {
     Global: {
       SFDX_STATE_FOLDER: '.sfdx',
@@ -34,7 +34,7 @@ jest.mock('@salesforce/core', () => {
   };
 });
 
-jest.mock('@salesforce/source-tracking', () => {
+jest.mock('@salesforce/source-tracking-bundle', () => {
   return {};
 });
 

--- a/packages/salesforcedx-utils-vscode/test/jest/services/source-tracking/sourceTrackingService.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/services/source-tracking/sourceTrackingService.test.ts
@@ -8,8 +8,8 @@ import { WorkspaceContextUtil } from '../../../../src';
 import { SourceTrackingService } from '../../../../src/services';
 import { testData } from './testData';
 
-jest.mock('@salesforce/core', () => ({
-  ...jest.requireActual('@salesforce/core'),
+jest.mock('@salesforce/core-bundle', () => ({
+  ...jest.requireActual('@salesforce/core-bundle'),
   Org: { create: jest.fn() },
   SfProject: { resolve: jest.fn() }
 }));

--- a/packages/salesforcedx-vscode-apex-debugger/esbuild.config.js
+++ b/packages/salesforcedx-vscode-apex-debugger/esbuild.config.js
@@ -6,7 +6,8 @@
  */
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { build } = require('esbuild');
-// const fs = require('fs').promises;
+const esbuildPluginPino = require('esbuild-plugin-pino');
+const fs = require('fs').promises;
 
 // Configure and run the build process
 const sharedConfig = {
@@ -14,33 +15,35 @@ const sharedConfig = {
   format: 'cjs',                    // Output format (CommonJS)
   platform: 'node',                 // Platform target (Node.js)
   minify: true,                     // Minify the output
+  keepNames: true,                  // keepNames to get rid of
   external: [
-    'vscode',
-    '@salesforce/core',
-    '@salesforce/source-tracking'
+    'vscode'
+  ],
+  plugins: [
+    esbuildPluginPino({ transports: ['pino-pretty'] })
   ]
 };
 
 // copy core-bundle/lib/transformStream.js to dist if core-bundle is included
-// const copyFiles = async (src, dest) => {
-//   try {
-//     // Copy the file
-//     await fs.copyFile(src, dest);
-//     console.log(`File was copied from ${src} to ${dest}`);
-//   } catch (error) {
-//     console.error('An error occurred:', error);
-//   }
-// };
+const copyFiles = async (src, dest) => {
+  try {
+    // Copy the file
+    await fs.copyFile(src, dest);
+    console.log(`File was copied from ${src} to ${dest}`);
+  } catch (error) {
+    console.error('An error occurred:', error);
+  }
+};
 
-// const srcPath = '../../node_modules/@salesforce/core-bundle/lib/transformStream.js';
-// const destPath = './dist/transformStream.js';
+const srcPath = '../../node_modules/@salesforce/core-bundle/lib/transformStream.js';
+const destPath = './dist/transformStream.js';
 
 (async () => {
   await build({
     ...sharedConfig,
     entryPoints: ['./src/index.ts'],
-    outfile: 'dist/index.js'
+    outdir: 'dist'
   });
 })().then(async () => {
-  // await copyFiles(srcPath, destPath);
+  await copyFiles(srcPath, destPath);
 }).catch(() => process.exit(1));

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -97,9 +97,7 @@
     "packageUpdates": {
       "main": "dist/index.js",
       "dependencies": {
-        "applicationinsights": "1.0.7",
-        "@salesforce/core": "7.5.0",
-        "@salesforce/source-tracking": "6.5.1"
+        "applicationinsights": "1.0.7"
       },
       "devDependencies": {}
     }

--- a/packages/salesforcedx-vscode-apex-replay-debugger/esbuild.config.js
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/esbuild.config.js
@@ -6,7 +6,8 @@
  */
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { build } = require('esbuild');
-// const fs = require('fs').promises;
+const esbuildPluginPino = require('esbuild-plugin-pino');
+const fs = require('fs').promises;
 
 const sharedConfig = {
   bundle: true,
@@ -14,34 +15,36 @@ const sharedConfig = {
   platform: 'node',
   external: [
     'vscode',
-    '@salesforce/core',
-    '@salesforce/source-tracking',
     'applicationinsights',
     'jsonpath'
   ],
-  minify: true
+  minify: true,
+  keepNames: true,
+  plugins: [
+    esbuildPluginPino({ transports: ['pino-pretty'] })
+  ]
 };
 
 // copy core-bundle/lib/transformStream.js to dist if core-bundle is included
-// const copyFiles = async (src, dest) => {
-//   try {
-//     // Copy the file
-//     await fs.copyFile(src, dest);
-//     console.log(`File was copied from ${src} to ${dest}`);
-//   } catch (error) {
-//     console.error('An error occurred:', error);
-//   }
-// };
+const copyFiles = async (src, dest) => {
+  try {
+    // Copy the file
+    await fs.copyFile(src, dest);
+    console.log(`File was copied from ${src} to ${dest}`);
+  } catch (error) {
+    console.error('An error occurred:', error);
+  }
+};
 
-// const srcPath = '../../node_modules/@salesforce/core-bundle/lib/transformStream.js';
-// const destPath = './dist/transformStream.js';
+const srcPath = '../../node_modules/@salesforce/core-bundle/lib/transformStream.js';
+const destPath = './dist/transformStream.js';
 
 (async () => {
   await build({
     ...sharedConfig,
     entryPoints: ['./src/index.ts'],
-    outfile: 'dist/index.js'
+    outdir: 'dist'
   });
 })().then(async () => {
-  // await copyFiles(srcPath, destPath);
+  await copyFiles(srcPath, destPath);
 }).catch(() => process.exit(1));

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -24,14 +24,14 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/apex-node": "6.1.3",
-    "@salesforce/core": "7.5.0",
     "@salesforce/salesforcedx-apex-replay-debugger": "61.2.0",
     "@salesforce/salesforcedx-utils": "61.2.0",
     "@salesforce/salesforcedx-utils-vscode": "61.2.0",
     "async-lock": "1.0.0",
     "request-light": "^0.7.0",
-    "vscode-extension-telemetry": "0.0.17"
+    "vscode-extension-telemetry": "0.0.17",
+    "@salesforce/core-bundle": "7.5.0",
+    "@salesforce/apex-node-bundle": "6.1.3"
   },
   "devDependencies": {
     "@salesforce/salesforcedx-test-utils-vscode": "61.2.0",
@@ -106,8 +106,6 @@
     "packageUpdates": {
       "main": "dist/index.js",
       "dependencies": {
-        "@salesforce/core": "7.5.0",
-        "@salesforce/source-tracking": "6.5.1",
         "applicationinsights": "1.0.7",
         "jsonpath": "1.1.1"
       },

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/quickLaunch.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/quickLaunch.ts
@@ -12,8 +12,8 @@ import {
   TestLevel,
   TestResult,
   TestService
-} from '@salesforce/apex-node';
-import { Connection } from '@salesforce/core';
+} from '@salesforce/apex-node-bundle';
+import { Connection } from '@salesforce/core-bundle';
 import {
   ContinueResponse,
   LibraryCommandletExecutor,

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/context/workspaceContext.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/context/workspaceContext.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Connection } from '@salesforce/core';
+import { Connection } from '@salesforce/core-bundle';
 import { WorkspaceContextUtil } from '@salesforce/salesforcedx-utils-vscode';
 import * as vscode from 'vscode';
 

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/vscode-integration/commands/quickLaunch.test.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/vscode-integration/commands/quickLaunch.test.ts
@@ -5,13 +5,13 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { LogService, TestService } from '@salesforce/apex-node';
+import { LogService, TestService } from '@salesforce/apex-node-bundle';
 import {
   TestLevel,
   TestResult
-} from '@salesforce/apex-node/lib/src/tests/types';
-import { AuthInfo, ConfigAggregator, Connection } from '@salesforce/core';
-import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
+} from '@salesforce/apex-node-bundle/lib/src/tests/types';
+import { AuthInfo, ConfigAggregator, Connection } from '@salesforce/core-bundle';
+import { MockTestOrgData, TestContext } from '@salesforce/core-bundle';
 import {
   ContinueResponse,
   notificationService,

--- a/packages/salesforcedx-vscode-apex/esbuild.config.js
+++ b/packages/salesforcedx-vscode-apex/esbuild.config.js
@@ -6,7 +6,8 @@
  */
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { build } = require('esbuild');
-// const fs = require('fs').promises;
+const esbuildPluginPino = require('esbuild-plugin-pino');
+const fs = require('fs').promises;
 
 const sharedConfig = {
   bundle: true,
@@ -14,36 +15,37 @@ const sharedConfig = {
   platform: 'node',
   external: [
     'vscode',
-    '@salesforce/core',
     'applicationinsights',
     'shelljs',
-    '@salesforce/source-deploy-retrieve',
-    '@salesforce/source-tracking',
     'jsonpath'
+  ],
+  keepNames: true,
+  plugins: [
+    esbuildPluginPino({ transports: ['pino-pretty'] })
   ],
   minify: true
 };
 
 // copy core-bundle/lib/transformStream.js to dist if core-bundle is included
-// const copyFiles = async (src, dest) => {
-//   try {
-//     // Copy the file
-//     await fs.copyFile(src, dest);
-//     console.log(`File was copied from ${src} to ${dest}`);
-//   } catch (error) {
-//     console.error('An error occurred:', error);
-//   }
-// };
+const copyFiles = async (src, dest) => {
+  try {
+    // Copy the file
+    await fs.copyFile(src, dest);
+    console.log(`File was copied from ${src} to ${dest}`);
+  } catch (error) {
+    console.error('An error occurred:', error);
+  }
+};
 
-// const srcPath = '../../node_modules/@salesforce/core-bundle/lib/transformStream.js';
-// const destPath = './dist/transformStream.js';
+const srcPath = '../../node_modules/@salesforce/core-bundle/lib/transformStream.js';
+const destPath = './dist/transformStream.js';
 
 (async () => {
   await build({
     ...sharedConfig,
     entryPoints: ['./src/index.ts'],
-    outfile: 'dist/index.js'
+    outdir: 'dist'
   });
 })().then(async () => {
-  // await copyFiles(srcPath, destPath);
+  await copyFiles(srcPath, destPath);
 }).catch(() => process.exit(1));

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -24,15 +24,15 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/apex-node": "6.1.3",
     "@salesforce/apex-tmlanguage": "1.8.0",
-    "@salesforce/core": "7.5.0",
     "@salesforce/salesforcedx-utils-vscode": "61.2.0",
     "expand-home-dir": "0.0.3",
     "find-java-home": "0.2.0",
     "shelljs": "0.8.5",
     "vscode-extension-telemetry": "0.0.17",
-    "vscode-languageclient": "8.1.0"
+    "vscode-languageclient": "8.1.0",
+    "@salesforce/core-bundle": "7.5.0",
+    "@salesforce/apex-node-bundle": "6.1.3"
   },
   "devDependencies": {
     "@salesforce/salesforcedx-test-utils-vscode": "61.2.0",
@@ -104,8 +104,6 @@
       "languageServerDir": "dist",
       "dependencies": {
         "@salesforce/apex-tmlanguage": "1.4.0",
-        "@salesforce/core": "7.5.0",
-        "@salesforce/source-tracking": "6.5.1",
         "applicationinsights": "1.0.7",
         "shelljs": "0.8.5",
         "jsonpath": "1.1.1"

--- a/packages/salesforcedx-vscode-apex/src/codecoverage/colorizer.ts
+++ b/packages/salesforcedx-vscode-apex/src/codecoverage/colorizer.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { CodeCoverageResult } from '@salesforce/apex-node';
+import { CodeCoverageResult } from '@salesforce/apex-node-bundle';
 import {
   SFDX_FOLDER,
   projectPaths

--- a/packages/salesforcedx-vscode-apex/src/commands/anonApexExecute.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/anonApexExecute.ts
@@ -7,8 +7,8 @@
 import {
   ExecuteAnonymousResponse,
   ExecuteService
-} from '@salesforce/apex-node';
-import { Connection } from '@salesforce/core';
+} from '@salesforce/apex-node-bundle';
+import { Connection } from '@salesforce/core-bundle';
 import {
   CancelResponse,
   ContinueResponse,

--- a/packages/salesforcedx-vscode-apex/src/commands/apexLogGet.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/apexLogGet.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { LogRecord, LogService } from '@salesforce/apex-node';
+import { LogRecord, LogService } from '@salesforce/apex-node-bundle';
 import {
   CancelResponse,
   ContinueResponse,

--- a/packages/salesforcedx-vscode-apex/src/commands/apexTestRun.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/apexTestRun.ts
@@ -14,7 +14,7 @@ import {
   TestLevel,
   TestResult,
   TestService
-} from '@salesforce/apex-node';
+} from '@salesforce/apex-node-bundle';
 import {
   getRootWorkspacePath,
   hasRootWorkspace,

--- a/packages/salesforcedx-vscode-apex/src/commands/apexTestRunCodeAction.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/apexTestRunCodeAction.ts
@@ -13,9 +13,9 @@ import {
   TestLevel,
   TestResult,
   TestService
-} from '@salesforce/apex-node';
-import { ApexDiagnostic } from '@salesforce/apex-node/lib/src/utils';
-import { NamedPackageDir, SfProject } from '@salesforce/core';
+} from '@salesforce/apex-node-bundle';
+import { ApexDiagnostic } from '@salesforce/apex-node-bundle/lib/src/utils';
+import { NamedPackageDir, SfProject } from '@salesforce/core-bundle';
 import { notificationService } from '@salesforce/salesforcedx-utils-vscode';
 import {
   ContinueResponse,

--- a/packages/salesforcedx-vscode-apex/src/commands/apexTestSuite.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/apexTestSuite.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { TestService } from '@salesforce/apex-node';
+import { TestService } from '@salesforce/apex-node-bundle';
 import {
   CancelResponse,
   ContinueResponse,

--- a/packages/salesforcedx-vscode-apex/src/context/workspaceContext.ts
+++ b/packages/salesforcedx-vscode-apex/src/context/workspaceContext.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Connection } from '@salesforce/core';
+import { Connection } from '@salesforce/core-bundle';
 import { WorkspaceContextUtil } from '@salesforce/salesforcedx-utils-vscode';
 import * as vscode from 'vscode';
 

--- a/packages/salesforcedx-vscode-apex/src/views/testOutlineProvider.ts
+++ b/packages/salesforcedx-vscode-apex/src/views/testOutlineProvider.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { TestResult } from '@salesforce/apex-node';
+import { TestResult } from '@salesforce/apex-node-bundle';
 import { readFileSync } from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/apexExecute.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/apexExecute.test.ts
@@ -4,9 +4,9 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { ExecuteService } from '@salesforce/apex-node';
-import { AuthInfo, ConfigAggregator, Connection } from '@salesforce/core';
-import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
+import { ExecuteService } from '@salesforce/apex-node-bundle';
+import { AuthInfo, ConfigAggregator, Connection } from '@salesforce/core-bundle';
+import { MockTestOrgData, TestContext } from '@salesforce/core-bundle';
 import {
   ChannelService,
   ContinueResponse,

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/apexTestRun.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/apexTestRun.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { HumanReporter, TestLevel, TestService } from '@salesforce/apex-node';
+import { HumanReporter, TestLevel, TestService } from '@salesforce/apex-node-bundle';
 import { expect } from 'chai';
 import { assert, createSandbox, match, SinonStub } from 'sinon';
 import * as vscode from 'vscode';

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/apexTestRunCodeAction.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/apexTestRunCodeAction.test.ts
@@ -11,10 +11,10 @@ import {
   TestLevel,
   TestResult,
   TestService
-} from '@salesforce/apex-node';
-import { SfProject } from '@salesforce/core';
+} from '@salesforce/apex-node-bundle';
+import { SfProject } from '@salesforce/core-bundle';
 import * as pathUtils from '@salesforce/salesforcedx-utils-vscode';
-import { ComponentSet } from '@salesforce/source-deploy-retrieve';
+import { ComponentSet } from '@salesforce/source-deploy-retrieve-bundle';
 import { expect } from 'chai';
 import { join } from 'path';
 import { assert, createSandbox, match, SinonStub } from 'sinon';

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/apexTestSuite.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/apexTestSuite.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { TestService } from '@salesforce/apex-node';
+import { TestService } from '@salesforce/apex-node-bundle';
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode';
 import { expect } from 'chai';
 import { createSandbox } from 'sinon';

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/launchApexReplayDebuggerWithCurrentFile.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/launchApexReplayDebuggerWithCurrentFile.test.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { TestContext } from '@salesforce/core/testSetup';
+import { TestContext } from '@salesforce/core-bundle';
 import {
   fileUtils,
   notificationService,

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/views/testJSONOutputs.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/views/testJSONOutputs.ts
@@ -7,7 +7,7 @@
 import {
   ApexTestResultData,
   ApexTestResultOutcome
-} from '@salesforce/apex-node';
+} from '@salesforce/apex-node-bundle';
 import * as vscode from 'vscode';
 import { FAIL_RESULT, PASS_RESULT } from '../../../src/constants';
 

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/views/testNamespacedOutputs.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/views/testNamespacedOutputs.ts
@@ -7,7 +7,7 @@
 import {
   ApexTestResultData,
   ApexTestResultOutcome
-} from '@salesforce/apex-node';
+} from '@salesforce/apex-node-bundle';
 import * as vscode from 'vscode';
 import {
   apexLibMultipleSummary,

--- a/packages/salesforcedx-vscode-core/esbuild.config.js
+++ b/packages/salesforcedx-vscode-core/esbuild.config.js
@@ -16,10 +16,8 @@ const sharedConfig = {
     'vscode',
     'applicationinsights',
     'shelljs',
-    '@salesforce/core',
-    '@salesforce/source-tracking',
-    '@salesforce/templates',
-    '@salesforce/source-deploy-retrieve'
+    '@salesforce/core-bundle',
+    '@salesforce/templates-bundle'
   ],
   minify: true
 };

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -37,7 +37,7 @@
     "sanitize-filename": "^1.6.1",
     "shelljs": "0.8.5",
     "@salesforce/core-bundle": "7.5.0",
-    "@salesforce/templates-bundle": "61.0.1",
+    "@salesforce/templates-bundle": "^61.0.1",
     "@salesforce/source-deploy-retrieve-bundle": "11.6.10"
   },
   "devDependencies": {

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -25,12 +25,9 @@
   ],
   "dependencies": {
     "@jsforce/jsforce-node": "3.2.0",
-    "@salesforce/core": "7.5.0",
     "@salesforce/salesforcedx-sobjects-faux-generator": "61.2.0",
     "@salesforce/salesforcedx-utils-vscode": "61.2.0",
     "@salesforce/schemas": "^1.6.1",
-    "@salesforce/source-deploy-retrieve": "11.6.10",
-    "@salesforce/templates": "^61.0.1",
     "@salesforce/ts-types": "2.0.9",
     "@salesforce/vscode-service-provider": "1.0.4",
     "adm-zip": "0.5.10",
@@ -38,7 +35,10 @@
     "glob": "^7.1.2",
     "rxjs": "^5.4.1",
     "sanitize-filename": "^1.6.1",
-    "shelljs": "0.8.5"
+    "shelljs": "0.8.5",
+    "@salesforce/core-bundle": "7.5.0",
+    "@salesforce/templates-bundle": "61.0.1",
+    "@salesforce/source-deploy-retrieve-bundle": "11.6.10"
   },
   "devDependencies": {
     "@salesforce/salesforcedx-test-utils-vscode": "61.2.0",
@@ -99,11 +99,8 @@
       "main": "dist/index.js",
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "@salesforce/core": "7.5.0",
-        "@salesforce/source-tracking": "6.5.1",
-        "@salesforce/templates": "^61.0.1",
-        "@salesforce/source-deploy-retrieve": "11.6.10",
-        "shelljs": "0.8.5"
+        "shelljs": "0.8.5",
+        "@salesforce/templates-bundle": "^61.0.1"
       },
       "devDependencies": {}
     }

--- a/packages/salesforcedx-vscode-core/src/commands/auth/orgLoginAccessToken.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/auth/orgLoginAccessToken.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthInfo, AuthSideEffects } from '@salesforce/core';
+import { AuthInfo, AuthSideEffects } from '@salesforce/core-bundle';
 import { LibraryCommandletExecutor } from '@salesforce/salesforcedx-utils-vscode';
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode';
 import * as vscode from 'vscode';

--- a/packages/salesforcedx-vscode-core/src/commands/auth/orgLogout.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/auth/orgLogout.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthRemover } from '@salesforce/core';
+import { AuthRemover } from '@salesforce/core-bundle';
 import {
   Command,
   ConfigUtil,

--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
@@ -20,11 +20,11 @@ import {
   MetadataApiDeploy,
   MetadataApiRetrieve,
   RetrieveResult
-} from '@salesforce/source-deploy-retrieve';
+} from '@salesforce/source-deploy-retrieve-bundle';
 import {
   ComponentStatus,
   RequestStatus
-} from '@salesforce/source-deploy-retrieve/lib/src/client/types';
+} from '@salesforce/source-deploy-retrieve-bundle/lib/src/client/types';
 import { join } from 'path';
 import * as vscode from 'vscode';
 import { channelService, OUTPUT_CHANNEL } from '../channels';

--- a/packages/salesforcedx-vscode-core/src/commands/deployManifest.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/deployManifest.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode';
-import { ComponentSet } from '@salesforce/source-deploy-retrieve';
+import { ComponentSet } from '@salesforce/source-deploy-retrieve-bundle';
 import { join } from 'path';
 import * as vscode from 'vscode';
 import { channelService } from '../channels';

--- a/packages/salesforcedx-vscode-core/src/commands/deploySourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/deploySourcePath.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode';
-import { ComponentSet } from '@salesforce/source-deploy-retrieve';
+import { ComponentSet } from '@salesforce/source-deploy-retrieve-bundle';
 import * as vscode from 'vscode';
 import { channelService } from '../channels';
 import { getConflictMessagesFor } from '../conflict/messages';

--- a/packages/salesforcedx-vscode-core/src/commands/projectGenerate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/projectGenerate.ts
@@ -11,7 +11,7 @@ import {
   ParametersGatherer,
   PostconditionChecker
 } from '@salesforce/salesforcedx-utils-vscode';
-import { ProjectOptions, TemplateType } from '@salesforce/templates';
+import { ProjectOptions, TemplateType } from '@salesforce/templates-bundle';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';

--- a/packages/salesforcedx-vscode-core/src/commands/projectGenerateManifest.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/projectGenerateManifest.ts
@@ -7,7 +7,7 @@
 
 import { LibraryCommandletExecutor } from '@salesforce/salesforcedx-utils-vscode';
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode';
-import { ComponentSet } from '@salesforce/source-deploy-retrieve';
+import { ComponentSet } from '@salesforce/source-deploy-retrieve-bundle';
 import * as fs from 'fs';
 import { join, parse } from 'path';
 import { format } from 'util';

--- a/packages/salesforcedx-vscode-core/src/commands/renameLightningComponent.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/renameLightningComponent.ts
@@ -12,7 +12,7 @@ import {
   ContinueResponse,
   ParametersGatherer
 } from '@salesforce/salesforcedx-utils-vscode';
-import { CreateUtil } from '@salesforce/templates';
+import { CreateUtil } from '@salesforce/templates-bundle';
 import * as fs from 'fs';
 import * as path from 'path';
 import { format } from 'util';

--- a/packages/salesforcedx-vscode-core/src/commands/retrieveManifest.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/retrieveManifest.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode';
-import { ComponentSet } from '@salesforce/source-deploy-retrieve';
+import { ComponentSet } from '@salesforce/source-deploy-retrieve-bundle';
 import { join } from 'path';
 import * as vscode from 'vscode';
 import { channelService } from '../channels';

--- a/packages/salesforcedx-vscode-core/src/commands/retrieveMetadata/libraryRetrieveSourcePathExecutor.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/retrieveMetadata/libraryRetrieveSourcePathExecutor.ts
@@ -12,8 +12,8 @@ import {
 import {
   ComponentSet,
   RetrieveResult
-} from '@salesforce/source-deploy-retrieve';
-import { ComponentLike } from '@salesforce/source-deploy-retrieve/lib/src/resolve/types';
+} from '@salesforce/source-deploy-retrieve-bundle';
+import { ComponentLike } from '@salesforce/source-deploy-retrieve-bundle/lib/src/resolve/types';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { nls } from '../../messages';

--- a/packages/salesforcedx-vscode-core/src/commands/retrieveSourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/retrieveSourcePath.ts
@@ -9,7 +9,7 @@ import {
   ContinueResponse,
   PostconditionChecker
 } from '@salesforce/salesforcedx-utils-vscode';
-import { ComponentSet } from '@salesforce/source-deploy-retrieve';
+import { ComponentSet } from '@salesforce/source-deploy-retrieve-bundle';
 import * as vscode from 'vscode';
 import { channelService } from '../channels';
 import { nls } from '../messages';

--- a/packages/salesforcedx-vscode-core/src/commands/templates/analyticsGenerateTemplate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/analyticsGenerateTemplate.ts
@@ -11,7 +11,7 @@ import {
   DirFileNameSelection,
   ParametersGatherer
 } from '@salesforce/salesforcedx-utils-vscode';
-import { AnalyticsTemplateOptions, TemplateType } from '@salesforce/templates';
+import { AnalyticsTemplateOptions, TemplateType } from '@salesforce/templates-bundle';
 import * as vscode from 'vscode';
 import { nls } from '../../messages';
 import {

--- a/packages/salesforcedx-vscode-core/src/commands/templates/executors/LibraryApexGenerateClassExecutor.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/executors/LibraryApexGenerateClassExecutor.ts
@@ -6,7 +6,7 @@
  */
 
 import { DirFileNameSelection } from '@salesforce/salesforcedx-utils-vscode';
-import { ApexClassOptions, TemplateType } from '@salesforce/templates';
+import { ApexClassOptions, TemplateType } from '@salesforce/templates-bundle';
 import { nls } from '../../../messages';
 import { LibraryBaseTemplateCommand } from '../libraryBaseTemplateCommand';
 import { APEX_CLASS_TYPE } from '../metadataTypeConstants';

--- a/packages/salesforcedx-vscode-core/src/commands/templates/executors/LibraryApexGenerateTriggerExecutor.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/executors/LibraryApexGenerateTriggerExecutor.ts
@@ -6,7 +6,7 @@
  */
 
 import { DirFileNameSelection } from '@salesforce/salesforcedx-utils-vscode';
-import { ApexTriggerOptions, TemplateType } from '@salesforce/templates';
+import { ApexTriggerOptions, TemplateType } from '@salesforce/templates-bundle';
 import { nls } from '../../../messages';
 import { LibraryBaseTemplateCommand } from '../libraryBaseTemplateCommand';
 import { APEX_TRIGGER_TYPE } from '../metadataTypeConstants';

--- a/packages/salesforcedx-vscode-core/src/commands/templates/executors/LibraryApexGenerateUnitTestClassExecutor.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/executors/LibraryApexGenerateUnitTestClassExecutor.ts
@@ -6,7 +6,7 @@
  */
 
 import { DirFileNameSelection } from '@salesforce/salesforcedx-utils-vscode';
-import { ApexClassOptions, TemplateType } from '@salesforce/templates';
+import { ApexClassOptions, TemplateType } from '@salesforce/templates-bundle';
 import { nls } from '../../../messages';
 import { LibraryBaseTemplateCommand } from '../libraryBaseTemplateCommand';
 import { APEX_CLASS_TYPE } from '../metadataTypeConstants';

--- a/packages/salesforcedx-vscode-core/src/commands/templates/libraryBaseTemplateCommand.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/libraryBaseTemplateCommand.ts
@@ -11,7 +11,7 @@ import {
   TemplateOptions,
   TemplateService,
   TemplateType
-} from '@salesforce/templates';
+} from '@salesforce/templates-bundle';
 import * as path from 'path';
 import { ProgressLocation, window, workspace } from 'vscode';
 import { channelService } from '../../channels';

--- a/packages/salesforcedx-vscode-core/src/commands/templates/lightningGenerateApp.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/lightningGenerateApp.ts
@@ -9,7 +9,7 @@ import {
   DirFileNameSelection,
   LocalComponent
 } from '@salesforce/salesforcedx-utils-vscode';
-import { LightningAppOptions, TemplateType } from '@salesforce/templates';
+import { LightningAppOptions, TemplateType } from '@salesforce/templates-bundle';
 import { Uri } from 'vscode';
 import { nls } from '../../messages';
 import { salesforceCoreSettings } from '../../settings';

--- a/packages/salesforcedx-vscode-core/src/commands/templates/lightningGenerateAuraComponent.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/lightningGenerateAuraComponent.ts
@@ -9,7 +9,7 @@ import {
   DirFileNameSelection,
   LocalComponent
 } from '@salesforce/salesforcedx-utils-vscode';
-import { LightningComponentOptions, TemplateType } from '@salesforce/templates';
+import { LightningComponentOptions, TemplateType } from '@salesforce/templates-bundle';
 import { Uri } from 'vscode';
 import { nls } from '../../messages';
 import { salesforceCoreSettings } from '../../settings';

--- a/packages/salesforcedx-vscode-core/src/commands/templates/lightningGenerateEvent.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/lightningGenerateEvent.ts
@@ -9,7 +9,7 @@ import {
   DirFileNameSelection,
   LocalComponent
 } from '@salesforce/salesforcedx-utils-vscode';
-import { LightningEventOptions, TemplateType } from '@salesforce/templates';
+import { LightningEventOptions, TemplateType } from '@salesforce/templates-bundle';
 import { Uri } from 'vscode';
 import { nls } from '../../messages';
 import { salesforceCoreSettings } from '../../settings';

--- a/packages/salesforcedx-vscode-core/src/commands/templates/lightningGenerateInterface.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/lightningGenerateInterface.ts
@@ -9,7 +9,7 @@ import {
   DirFileNameSelection,
   LocalComponent
 } from '@salesforce/salesforcedx-utils-vscode';
-import { LightningInterfaceOptions, TemplateType } from '@salesforce/templates';
+import { LightningInterfaceOptions, TemplateType } from '@salesforce/templates-bundle';
 import { Uri } from 'vscode';
 import { nls } from '../../messages';
 import { salesforceCoreSettings } from '../../settings';

--- a/packages/salesforcedx-vscode-core/src/commands/templates/lightningGenerateLwc.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/lightningGenerateLwc.ts
@@ -9,7 +9,7 @@ import {
   DirFileNameSelection,
   LocalComponent
 } from '@salesforce/salesforcedx-utils-vscode';
-import { LightningComponentOptions, TemplateType } from '@salesforce/templates';
+import { LightningComponentOptions, TemplateType } from '@salesforce/templates-bundle';
 import { Uri } from 'vscode';
 import { nls } from '../../messages';
 import { salesforceCoreSettings } from '../../settings';

--- a/packages/salesforcedx-vscode-core/src/commands/templates/visualforceGenerateComponent.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/visualforceGenerateComponent.ts
@@ -12,7 +12,7 @@ import {
 import {
   TemplateType,
   VisualforceComponentOptions
-} from '@salesforce/templates';
+} from '@salesforce/templates-bundle';
 import { nls } from '../../messages';
 import {
   CompositeParametersGatherer,

--- a/packages/salesforcedx-vscode-core/src/commands/templates/visualforceGeneratePage.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/visualforceGeneratePage.ts
@@ -9,7 +9,7 @@ import {
   DirFileNameSelection,
   LocalComponent
 } from '@salesforce/salesforcedx-utils-vscode';
-import { TemplateType, VisualforcePageOptions } from '@salesforce/templates';
+import { TemplateType, VisualforcePageOptions } from '@salesforce/templates-bundle';
 import { nls } from '../../messages';
 import {
   CompositeParametersGatherer,

--- a/packages/salesforcedx-vscode-core/src/commands/util/createComponentCount.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/createComponentCount.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { MetadataComponent } from '@salesforce/source-deploy-retrieve';
+import { MetadataComponent } from '@salesforce/source-deploy-retrieve-bundle';
 
 export const createComponentCount = (components: Iterable<MetadataComponent>) => {
   const quantities: { [type: string]: number } = {};

--- a/packages/salesforcedx-vscode-core/src/commands/util/parameterGatherers.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/parameterGatherers.ts
@@ -10,7 +10,7 @@ import {
   LocalComponent,
   ParametersGatherer
 } from '@salesforce/salesforcedx-utils-vscode';
-import { ComponentSet, registry } from '@salesforce/source-deploy-retrieve';
+import { ComponentSet, registry } from '@salesforce/source-deploy-retrieve-bundle';
 import * as glob from 'glob';
 import * as path from 'path';
 import * as vscode from 'vscode';

--- a/packages/salesforcedx-vscode-core/src/conflict/componentDiffer.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/componentDiffer.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { SourceComponent } from '@salesforce/source-deploy-retrieve';
+import { SourceComponent } from '@salesforce/source-deploy-retrieve-bundle';
 import * as fs from 'fs';
 import * as path from 'path';
 

--- a/packages/salesforcedx-vscode-core/src/conflict/directoryDiffer.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/directoryDiffer.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { SourceComponent } from '@salesforce/source-deploy-retrieve';
+import { SourceComponent } from '@salesforce/source-deploy-retrieve-bundle';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';

--- a/packages/salesforcedx-vscode-core/src/conflict/metadataCacheService.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/metadataCacheService.ts
@@ -11,7 +11,7 @@ import {
   MetadataApiRetrieve,
   RetrieveResult,
   SourceComponent
-} from '@salesforce/source-deploy-retrieve';
+} from '@salesforce/source-deploy-retrieve-bundle';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';

--- a/packages/salesforcedx-vscode-core/src/conflict/persistentStorageService.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/persistentStorageService.ts
@@ -12,7 +12,7 @@ import {
 import {
   DeployResult,
   FileProperties
-} from '@salesforce/source-deploy-retrieve';
+} from '@salesforce/source-deploy-retrieve-bundle';
 import { ExtensionContext, Memento } from 'vscode';
 import { WorkspaceContext } from '../context';
 import { nls } from '../messages';

--- a/packages/salesforcedx-vscode-core/src/context/workspaceContext.ts
+++ b/packages/salesforcedx-vscode-core/src/context/workspaceContext.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Connection } from '@salesforce/core';
+import { Connection } from '@salesforce/core-bundle';
 import {
   OrgUserInfo,
   WorkspaceContextUtil

--- a/packages/salesforcedx-vscode-core/src/context/workspaceOrgType.ts
+++ b/packages/salesforcedx-vscode-core/src/context/workspaceOrgType.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { Org } from '@salesforce/core';
+import { Org } from '@salesforce/core-bundle';
 import * as vscode from 'vscode';
 import { OrgAuthInfo, workspaceUtils } from '../util';
 import { WorkspaceContext } from './workspaceContext';

--- a/packages/salesforcedx-vscode-core/src/diagnostics/diagnostics.ts
+++ b/packages/salesforcedx-vscode-core/src/diagnostics/diagnostics.ts
@@ -9,7 +9,7 @@ import { getRootWorkspacePath } from '@salesforce/salesforcedx-utils-vscode';
 import {
   ComponentStatus,
   DeployResult
-} from '@salesforce/source-deploy-retrieve';
+} from '@salesforce/source-deploy-retrieve-bundle';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { SfCommandletExecutor } from '../commands/util';

--- a/packages/salesforcedx-vscode-core/src/orgBrowser/metadataCmp.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/metadataCmp.ts
@@ -5,13 +5,13 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { ListMetadataQuery } from '@jsforce/jsforce-node/lib/api/metadata';
-import { Connection } from '@salesforce/core';
+import { Connection } from '@salesforce/core-bundle';
 import {
   isNullOrUndefined,
   projectPaths,
   workspaceUtils
 } from '@salesforce/salesforcedx-utils-vscode';
-import { standardValueSet } from '@salesforce/source-deploy-retrieve/lib/src/registry';
+import { standardValueSet } from '@salesforce/source-deploy-retrieve-bundle/lib/src/registry';
 import * as fs from 'fs';
 import * as path from 'path';
 import { WorkspaceContext } from '../context';

--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { AuthFields, AuthInfo, OrgAuthorization } from '@salesforce/core';
+import { AuthFields, AuthInfo, OrgAuthorization } from '@salesforce/core-bundle';
 import {
   CancelResponse,
   ConfigUtil,

--- a/packages/salesforcedx-vscode-core/src/salesforceProject/salesforceProjectConfig.ts
+++ b/packages/salesforcedx-vscode-core/src/salesforceProject/salesforceProjectConfig.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { SfProject, SfProjectJson } from '@salesforce/core';
+import { SfProject, SfProjectJson } from '@salesforce/core-bundle';
 import { JsonArray } from '@salesforce/ts-types';
 import * as path from 'path';
 import * as vscode from 'vscode';

--- a/packages/salesforcedx-vscode-core/src/services/sdr/componentSetUtils.ts
+++ b/packages/salesforcedx-vscode-core/src/services/sdr/componentSetUtils.ts
@@ -6,7 +6,7 @@
  */
 
 import { ConfigUtil } from '@salesforce/salesforcedx-utils-vscode';
-import { ComponentSet } from '@salesforce/source-deploy-retrieve';
+import { ComponentSet } from '@salesforce/source-deploy-retrieve-bundle';
 import { WorkspaceContext } from '../../context/workspaceContext';
 import { SalesforceProjectConfig } from '../../salesforceProject';
 

--- a/packages/salesforcedx-vscode-core/src/util/authInfo.ts
+++ b/packages/salesforcedx-vscode-core/src/util/authInfo.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { AuthInfo, Connection, StateAggregator } from '@salesforce/core';
+import { AuthInfo, Connection, StateAggregator } from '@salesforce/core-bundle';
 import {
   ConfigSource,
   ConfigUtil

--- a/packages/salesforcedx-vscode-core/src/util/orgUtil.ts
+++ b/packages/salesforcedx-vscode-core/src/util/orgUtil.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthFields, AuthInfo } from '@salesforce/core';
+import { AuthFields, AuthInfo } from '@salesforce/core-bundle';
 import { channelService } from '../channels';
 import { nls } from '../messages';
 import { notificationService } from '../notifications';

--- a/packages/salesforcedx-vscode-core/test/jest/commands/deployExecutor.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/commands/deployExecutor.test.ts
@@ -9,7 +9,7 @@ import {
   ContinueResponse,
   SourceTrackingService
 } from '@salesforce/salesforcedx-utils-vscode';
-import { ComponentSet } from '@salesforce/source-deploy-retrieve';
+import { ComponentSet } from '@salesforce/source-deploy-retrieve-bundle';
 import * as fs from 'fs';
 import { channelService } from '../../../src/channels';
 import {
@@ -23,9 +23,9 @@ import * as diagnostics from '../../../src/diagnostics';
 import { SalesforcePackageDirectories } from '../../../src/salesforceProject';
 import { DeployQueue, salesforceCoreSettings } from '../../../src/settings';
 
-jest.mock('@salesforce/source-deploy-retrieve', () => {
+jest.mock('@salesforce/source-deploy-retrieve-bundle', () => {
   return {
-    ...jest.requireActual('@salesforce/source-deploy-retrieve'),
+    ...jest.requireActual('@salesforce/source-deploy-retrieve-bundle'),
     ComponentSet: jest.fn().mockImplementation(() => {
       return {
         deploy: jest.fn().mockImplementation(() => {

--- a/packages/salesforcedx-vscode-core/test/jest/commands/retrieveExecutor.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/commands/retrieveExecutor.test.ts
@@ -9,7 +9,7 @@ import {
   ContinueResponse,
   SourceTrackingService
 } from '@salesforce/salesforcedx-utils-vscode';
-import { ComponentSet } from '@salesforce/source-deploy-retrieve';
+import { ComponentSet } from '@salesforce/source-deploy-retrieve-bundle';
 import * as fs from 'fs';
 import { RetrieveExecutor } from '../../../src/commands/baseDeployRetrieve';
 import { OrgType, workspaceContextUtils } from '../../../src/context';

--- a/packages/salesforcedx-vscode-core/test/jest/commands/templates/executors/LibraryApexGenerateUnitTestClassExecutor.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/commands/templates/executors/LibraryApexGenerateUnitTestClassExecutor.test.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { TemplateType } from '@salesforce/templates';
+import { TemplateType } from '@salesforce/templates-bundle';
 import {
   CREATE_UNIT_NAME_KEY,
   LibraryApexGenerateUnitTestClassExecutor,

--- a/packages/salesforcedx-vscode-core/test/jest/conflict/metadataCacheService.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/conflict/metadataCacheService.test.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { ComponentSet } from '@salesforce/source-deploy-retrieve';
+import { ComponentSet } from '@salesforce/source-deploy-retrieve-bundle';
 import { MetadataCacheService } from '../../../src/conflict';
 import { WorkspaceContext } from '../../../src/context';
 import { componentSetUtils } from '../../../src/services/sdr/componentSetUtils';

--- a/packages/salesforcedx-vscode-core/test/jest/context/workspaceOrgType.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/context/workspaceOrgType.test.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { Org } from '@salesforce/core';
+import { Org } from '@salesforce/core-bundle';
 import { WorkspaceContext } from '../../../src/context';
 import {
   getWorkspaceOrgType,

--- a/packages/salesforcedx-vscode-core/test/jest/services/sdr/componentSetUtils.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/services/sdr/componentSetUtils.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { ConfigUtil } from '@salesforce/salesforcedx-utils-vscode';
-import { ComponentSet } from '@salesforce/source-deploy-retrieve';
+import { ComponentSet } from '@salesforce/source-deploy-retrieve-bundle';
 import { WorkspaceContext } from '../../../../src/context/workspaceContext';
 import { SalesforceProjectConfig } from '../../../../src/salesforceProject';
 import { componentSetUtils } from '../../../../src/services/sdr/componentSetUtils';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/auth/orgLoginAccessToken.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/auth/orgLoginAccessToken.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthInfo } from '@salesforce/core';
+import { AuthInfo } from '@salesforce/core-bundle';
 import { assert, createSandbox, SinonStub } from 'sinon';
 import { channelService } from '../../../../src/channels/index';
 import {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/auth/orgLoginWebDevHub.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/auth/orgLoginWebDevHub.test.ts
@@ -5,12 +5,12 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { ConfigFile } from '@salesforce/core';
+import { ConfigFile } from '@salesforce/core-bundle';
 import {
   instantiateContext,
   restoreContext,
   stubContext
-} from '@salesforce/core/testSetup';
+} from '@salesforce/core-bundle';
 import { ConfigSource } from '@salesforce/salesforcedx-utils-vscode';
 import { expect } from 'chai';
 import { SinonSandbox, SinonSpy, SinonStub } from 'sinon';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/auth/orgLogout.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/auth/orgLogout.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthRemover } from '@salesforce/core';
+import { AuthRemover } from '@salesforce/core-bundle';
 import { notificationService } from '@salesforce/salesforcedx-utils-vscode';
 import { expect } from 'chai';
 import { createSandbox, SinonSandbox, SinonStub } from 'sinon';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/baseDeployRetrieve.test.ts
@@ -4,13 +4,13 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { Connection } from '@salesforce/core';
+import { Connection } from '@salesforce/core-bundle';
 import {
   instantiateContext,
   MockTestOrgData,
   restoreContext,
   stubContext
-} from '@salesforce/core/testSetup';
+} from '@salesforce/core-bundle';
 import {
   ConfigUtil,
   ContinueResponse,
@@ -28,11 +28,11 @@ import {
   registry,
   RetrieveResult,
   SourceComponent
-} from '@salesforce/source-deploy-retrieve';
+} from '@salesforce/source-deploy-retrieve-bundle';
 import {
   MetadataApiDeployStatus,
   RequestStatus
-} from '@salesforce/source-deploy-retrieve/lib/src/client/types';
+} from '@salesforce/source-deploy-retrieve-bundle/lib/src/client/types';
 import { fail } from 'assert';
 import { expect } from 'chai';
 import { basename, dirname, join, sep } from 'path';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/deployManifest.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/deployManifest.test.ts
@@ -5,15 +5,15 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Connection } from '@salesforce/core';
+import { Connection } from '@salesforce/core-bundle';
 import {
   instantiateContext,
   MockTestOrgData,
   restoreContext,
   stubContext
-} from '@salesforce/core/testSetup';
+} from '@salesforce/core-bundle';
 import { SourceTrackingService } from '@salesforce/salesforcedx-utils-vscode';
-import { ComponentSet } from '@salesforce/source-deploy-retrieve';
+import { ComponentSet } from '@salesforce/source-deploy-retrieve-bundle';
 import { expect } from 'chai';
 import * as path from 'path';
 import { SinonStub } from 'sinon';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/deploySourcePath.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/deploySourcePath.test.ts
@@ -5,13 +5,13 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Connection } from '@salesforce/core';
+import { Connection } from '@salesforce/core-bundle';
 import {
   instantiateContext,
   MockTestOrgData,
   restoreContext,
   stubContext
-} from '@salesforce/core/testSetup';
+} from '@salesforce/core-bundle';
 import {
   ContinueResponse,
   fileUtils,
@@ -20,7 +20,7 @@ import {
 import {
   ComponentSet,
   MetadataResolver
-} from '@salesforce/source-deploy-retrieve';
+} from '@salesforce/source-deploy-retrieve-bundle';
 import { expect } from 'chai';
 import * as path from 'path';
 import { SinonStub } from 'sinon';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/projectGenerateManifest.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/projectGenerateManifest.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { ComponentSet } from '@salesforce/source-deploy-retrieve';
+import { ComponentSet } from '@salesforce/source-deploy-retrieve-bundle';
 import { fail } from 'assert';
 import { expect } from 'chai';
 import * as fs from 'fs';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/retrieveManifest.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/retrieveManifest.test.ts
@@ -4,15 +4,15 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { Connection } from '@salesforce/core';
+import { Connection } from '@salesforce/core-bundle';
 import {
   instantiateContext,
   MockTestOrgData,
   restoreContext,
   stubContext
-} from '@salesforce/core/testSetup';
+} from '@salesforce/core-bundle';
 import { SourceTrackingService } from '@salesforce/salesforcedx-utils-vscode';
-import { ComponentSet } from '@salesforce/source-deploy-retrieve';
+import { ComponentSet } from '@salesforce/source-deploy-retrieve-bundle';
 import { expect } from 'chai';
 import * as path from 'path';
 import { SinonStub } from 'sinon';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/retrieveMetadata/retrieveComponent.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/retrieveMetadata/retrieveComponent.test.ts
@@ -5,13 +5,13 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Connection } from '@salesforce/core';
+import { Connection } from '@salesforce/core-bundle';
 import {
   instantiateContext,
   MockTestOrgData,
   restoreContext,
   stubContext
-} from '@salesforce/core/testSetup';
+} from '@salesforce/core-bundle';
 import {
   ContinueResponse,
   LocalComponent,
@@ -23,11 +23,11 @@ import {
   registry,
   RetrieveResult,
   SourceComponent
-} from '@salesforce/source-deploy-retrieve';
+} from '@salesforce/source-deploy-retrieve-bundle';
 import {
   MetadataApiRetrieveStatus,
   RequestStatus
-} from '@salesforce/source-deploy-retrieve/lib/src/client/types';
+} from '@salesforce/source-deploy-retrieve-bundle/lib/src/client/types';
 import { expect } from 'chai';
 import * as path from 'path';
 import { SinonStub } from 'sinon';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/retrieveSourcePath.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/retrieveSourcePath.test.ts
@@ -5,13 +5,13 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Connection } from '@salesforce/core';
+import { Connection } from '@salesforce/core-bundle';
 import {
   instantiateContext,
   MockTestOrgData,
   restoreContext,
   stubContext
-} from '@salesforce/core/testSetup';
+} from '@salesforce/core-bundle';
 import {
   CancelResponse,
   ContinueResponse,
@@ -22,7 +22,7 @@ import {
   ComponentSet,
   registry,
   SourceComponent
-} from '@salesforce/source-deploy-retrieve';
+} from '@salesforce/source-deploy-retrieve-bundle';
 import { expect } from 'chai';
 import * as path from 'path';
 import { SinonStub } from 'sinon';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/sourceDiff.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/sourceDiff.test.ts
@@ -8,7 +8,7 @@
 import {
   MetadataType,
   SourceComponent
-} from '@salesforce/source-deploy-retrieve';
+} from '@salesforce/source-deploy-retrieve-bundle';
 import { expect } from 'chai';
 import * as path from 'path';
 import { assert, createSandbox, match, SinonSpy, SinonStub, stub } from 'sinon';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/apexGenerateClass.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/apexGenerateClass.test.ts
@@ -6,8 +6,8 @@
  */
 
 import { ConfigUtil } from '@salesforce/salesforcedx-utils-vscode';
-import { TemplateService } from '@salesforce/templates';
-import { nls as templatesNls } from '@salesforce/templates/lib/i18n';
+import { TemplateService } from '@salesforce/templates-bundle';
+import { nls as templatesNls } from '@salesforce/templates-bundle/lib/i18n';
 import * as path from 'path';
 import * as shell from 'shelljs';
 import * as sinon from 'sinon';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/apexGenerateTrigger.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/apexGenerateTrigger.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { TemplateService } from '@salesforce/templates';
+import { TemplateService } from '@salesforce/templates-bundle';
 import * as path from 'path';
 import * as shell from 'shelljs';
 import { SinonStub, stub } from 'sinon';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/customTemplates.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/customTemplates.test.ts
@@ -6,8 +6,8 @@
  */
 
 import { ConfigUtil } from '@salesforce/salesforcedx-utils-vscode';
-import { TemplateService } from '@salesforce/templates';
-import { nls as templatesNls } from '@salesforce/templates/lib/i18n';
+import { TemplateService } from '@salesforce/templates-bundle';
+import { nls as templatesNls } from '@salesforce/templates-bundle/lib/i18n';
 import * as path from 'path';
 import * as shell from 'shelljs';
 import * as sinon from 'sinon';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/lightningGenerateEvent.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/lightningGenerateEvent.test.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { TemplateService } from '@salesforce/templates';
+import { TemplateService } from '@salesforce/templates-bundle';
 import * as path from 'path';
 import * as shell from 'shelljs';
 import { SinonStub, stub } from 'sinon';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/lightningGenerateInterface.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/lightningGenerateInterface.test.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { TemplateService } from '@salesforce/templates';
+import { TemplateService } from '@salesforce/templates-bundle';
 import * as path from 'path';
 import * as shell from 'shelljs';
 import * as sinon from 'sinon';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/lightningGenerateLwc.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/lightningGenerateLwc.test.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { TemplateService } from '@salesforce/templates';
+import { TemplateService } from '@salesforce/templates-bundle';
 import * as path from 'path';
 import * as shell from 'shelljs';
 import * as sinon from 'sinon';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/visualforceGenerateComponent.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/visualforceGenerateComponent.test.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { TemplateService } from '@salesforce/templates';
+import { TemplateService } from '@salesforce/templates-bundle';
 import * as path from 'path';
 import * as shell from 'shelljs';
 import * as sinon from 'sinon';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/visualforceGeneratePage.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/templates/visualforceGeneratePage.test.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { TemplateService } from '@salesforce/templates';
+import { TemplateService } from '@salesforce/templates-bundle';
 import * as path from 'path';
 import * as shell from 'shelljs';
 import * as sinon from 'sinon';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/betaDeployRetrieve.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/betaDeployRetrieve.test.ts
@@ -5,8 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { ComponentSet, registry } from '@salesforce/source-deploy-retrieve';
-import { SourceComponent } from '@salesforce/source-deploy-retrieve';
+import { ComponentSet, registry } from '@salesforce/source-deploy-retrieve-bundle';
+import { SourceComponent } from '@salesforce/source-deploy-retrieve-bundle';
 import { expect } from 'chai';
 import { createSandbox, SinonStub } from 'sinon';
 import * as vscode from 'vscode';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/parameterGatherers.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/parameterGatherers.test.ts
@@ -13,7 +13,7 @@ import {
   ComponentSet,
   registry,
   SourceComponent
-} from '@salesforce/source-deploy-retrieve';
+} from '@salesforce/source-deploy-retrieve-bundle';
 import { expect } from 'chai';
 import * as path from 'path';
 import { join } from 'path';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/sourceResultOutput.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/sourceResultOutput.test.ts
@@ -12,7 +12,7 @@
 //   SourceDeployResult,
 //   SourceRetrieveResult,
 //   ToolingDeployStatus
-// } from '@salesforce/source-deploy-retrieve';
+// } from '@salesforce/source-deploy-retrieve-bundle';
 // import { expect } from 'chai';
 // import * as path from 'path';
 // import {

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/componentDiffer.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/componentDiffer.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { SourceComponent } from '@salesforce/source-deploy-retrieve';
+import { SourceComponent } from '@salesforce/source-deploy-retrieve-bundle';
 import { expect } from 'chai';
 import * as fs from 'fs';
 import * as os from 'os';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/metadataCacheService.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/metadataCacheService.test.ts
@@ -12,11 +12,11 @@ import {
   MetadataApiRetrieve,
   RetrieveResult,
   SourceComponent
-} from '@salesforce/source-deploy-retrieve';
+} from '@salesforce/source-deploy-retrieve-bundle';
 import {
   MetadataApiRetrieveStatus,
   RequestStatus
-} from '@salesforce/source-deploy-retrieve/lib/src/client/types';
+} from '@salesforce/source-deploy-retrieve-bundle/lib/src/client/types';
 import * as AdmZip from 'adm-zip';
 import { expect } from 'chai';
 import * as fs from 'fs';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/persistentStorageService.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/persistentStorageService.test.ts
@@ -5,8 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { ComponentSet, DeployResult, FileProperties, registry, SourceComponent} from '@salesforce/source-deploy-retrieve';
-import { MetadataApiDeployStatus, RequestStatus} from '@salesforce/source-deploy-retrieve/lib/src/client/types';
+import { ComponentSet, DeployResult, FileProperties, registry, SourceComponent} from '@salesforce/source-deploy-retrieve-bundle';
+import { MetadataApiDeployStatus, RequestStatus} from '@salesforce/source-deploy-retrieve-bundle/lib/src/client/types';
 import { expect } from 'chai';
 import { basename, dirname, join} from 'path';
 import { PersistentStorageService } from '../../../src/conflict/persistentStorageService';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/timestampConflictDetector.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/conflict/timestampConflictDetector.test.ts
@@ -8,7 +8,7 @@
 import {
   FileProperties,
   SourceComponent
-} from '@salesforce/source-deploy-retrieve';
+} from '@salesforce/source-deploy-retrieve-bundle';
 import { fail } from 'assert';
 import { expect } from 'chai';
 import * as path from 'path';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/context/workspaceOrgTypeInteg.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/context/workspaceOrgTypeInteg.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthInfo, Org } from '@salesforce/core';
+import { AuthInfo, Org } from '@salesforce/core-bundle';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { createSandbox } from 'sinon';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgBrowser/metadataCmp.test.ts
@@ -4,18 +4,18 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { Connection } from '@salesforce/core';
+import { Connection } from '@salesforce/core-bundle';
 import {
   instantiateContext,
   MockTestOrgData,
   restoreContext,
   stubContext
-} from '@salesforce/core/testSetup';
+} from '@salesforce/core-bundle';
 import {
   projectPaths,
   WorkspaceContextUtil
 } from '@salesforce/salesforcedx-utils-vscode';
-import { standardValueSet } from '@salesforce/source-deploy-retrieve/lib/src/registry';
+import { standardValueSet } from '@salesforce/source-deploy-retrieve-bundle/lib/src/registry';
 import { expect } from 'chai';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/orgPicker/orgList.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/orgPicker/orgList.test.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { AuthInfo, OrgAuthorization, StateAggregator } from '@salesforce/core';
+import { AuthInfo, OrgAuthorization, StateAggregator } from '@salesforce/core-bundle';
 import { ConfigUtil } from '@salesforce/salesforcedx-utils-vscode';
 import { expect } from 'chai';
 import { createSandbox, SinonStub } from 'sinon';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/util/authInfo.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/util/authInfo.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthInfo, Connection, StateAggregator } from '@salesforce/core';
+import { AuthInfo, Connection, StateAggregator } from '@salesforce/core-bundle';
 import { ConfigUtil } from '@salesforce/salesforcedx-utils-vscode';
 import { expect } from 'chai';
 import { createSandbox, SinonStub } from 'sinon';

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/util/cliConfiguration.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/util/cliConfiguration.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Config, ConfigFile, Global } from '@salesforce/core';
+import { Config, ConfigFile, Global } from '@salesforce/core-bundle';
 import {
   ConfigUtil,
   GlobalCliEnvironment

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/util/orgUtil.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/util/orgUtil.test.ts
@@ -6,7 +6,7 @@
  */
 
 // Imports for testing
-import { AuthInfo } from '@salesforce/core';
+import { AuthInfo } from '@salesforce/core-bundle';
 import { expect } from 'chai';
 import { before } from 'mocha';
 import { createSandbox, SinonSandbox, SinonSpy, SinonStub } from 'sinon';

--- a/packages/salesforcedx-vscode-lightning/esbuild.config.js
+++ b/packages/salesforcedx-vscode-lightning/esbuild.config.js
@@ -6,7 +6,8 @@
  */
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { build } = require('esbuild');
-// const fs = require('fs').promises;
+const esbuildPluginPino = require('esbuild-plugin-pino');
+const fs = require('fs').promises;
 
 const sharedConfig = {
   bundle: true,
@@ -14,35 +15,37 @@ const sharedConfig = {
   platform: 'node',
   external: [
     'vscode',
-    '@salesforce/core',
-    '@salesforce/source-tracking',
     'applicationinsights',
     '@salesforce/lightning-lsp-common',
     '@salesforce/aura-language-server'
   ],
-  minify: true
+  minify: true,
+  keepNames: true,
+  plugins: [
+    esbuildPluginPino({ transports: ['pino-pretty'] })
+  ]
 };
 
 // copy core-bundle/lib/transformStream.js to dist if core-bundle is included
-// const copyFiles = async (src, dest) => {
-//   try {
-//     // Copy the file
-//     await fs.copyFile(src, dest);
-//     console.log(`File was copied from ${src} to ${dest}`);
-//   } catch (error) {
-//     console.error('An error occurred:', error);
-//   }
-// };
+const copyFiles = async (src, dest) => {
+  try {
+    // Copy the file
+    await fs.copyFile(src, dest);
+    console.log(`File was copied from ${src} to ${dest}`);
+  } catch (error) {
+    console.error('An error occurred:', error);
+  }
+};
 
-// const srcPath = '../../node_modules/@salesforce/core-bundle/lib/transformStream.js';
-// const destPath = './dist/transformStream.js';
+const srcPath = '../../node_modules/@salesforce/core-bundle/lib/transformStream.js';
+const destPath = './dist/transformStream.js';
 
 (async () => {
   await build({
     ...sharedConfig,
     entryPoints: ['./src/index.ts'],
-    outfile: 'dist/index.js'
+    outdir: 'dist'
   });
 })().then(async () => {
-  // await copyFiles(srcPath, destPath);
+  await copyFiles(srcPath, destPath);
 }).catch(() => process.exit(1));

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -25,12 +25,12 @@
   ],
   "dependencies": {
     "@salesforce/aura-language-server": "4.8.0",
-    "@salesforce/core": "7.5.0",
     "@salesforce/lightning-lsp-common": "4.8.0",
     "@salesforce/salesforcedx-utils-vscode": "61.2.0",
     "applicationinsights": "1.0.7",
     "vscode-extension-telemetry": "0.0.17",
-    "vscode-languageclient": "^5.2.1"
+    "vscode-languageclient": "^5.2.1",
+    "@salesforce/core-bundle": "7.5.0"
   },
   "devDependencies": {
     "@salesforce/salesforcedx-test-utils-vscode": "61.2.0",
@@ -120,8 +120,6 @@
       ],
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "@salesforce/core": "7.5.0",
-        "@salesforce/source-tracking": "6.5.1",
         "@salesforce/aura-language-server": "4.8.0",
         "@salesforce/lightning-lsp-common": "4.8.0"
       },

--- a/packages/salesforcedx-vscode-lwc/esbuild.config.js
+++ b/packages/salesforcedx-vscode-lwc/esbuild.config.js
@@ -6,7 +6,8 @@
  */
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { build } = require('esbuild');
-// const fs = require('fs').promises;
+const esbuildPluginPino = require('esbuild-plugin-pino');
+const fs = require('fs').promises;
 
 const sharedConfig = {
   bundle: true,
@@ -15,36 +16,38 @@ const sharedConfig = {
   loader: { '.node': 'file' },
   external: [
     'vscode',
-    '@salesforce/core',
-    '@salesforce/source-tracking',
     'applicationinsights',
     '@salesforce/lightning-lsp-common',
     '@salesforce/lwc-language-server',
     '@babel/preset-typescript/package.json'
   ],
-  minify: true
+  minify: true,
+  keepNames: true,
+  plugins: [
+    esbuildPluginPino({ transports: ['pino-pretty'] })
+  ]
 };
 
 // copy core-bundle/lib/transformStream.js to dist if core-bundle is included
-// const copyFiles = async (src, dest) => {
-//   try {
-//     // Copy the file
-//     await fs.copyFile(src, dest);
-//     console.log(`File was copied from ${src} to ${dest}`);
-//   } catch (error) {
-//     console.error('An error occurred:', error);
-//   }
-// };
+const copyFiles = async (src, dest) => {
+  try {
+    // Copy the file
+    await fs.copyFile(src, dest);
+    console.log(`File was copied from ${src} to ${dest}`);
+  } catch (error) {
+    console.error('An error occurred:', error);
+  }
+};
 
-// const srcPath = '../../node_modules/@salesforce/core-bundle/lib/transformStream.js';
-// const destPath = './dist/transformStream.js';
+const srcPath = '../../node_modules/@salesforce/core-bundle/lib/transformStream.js';
+const destPath = './dist/transformStream.js';
 
 (async () => {
   await build({
     ...sharedConfig,
     entryPoints: ['./src/index.ts'],
-    outfile: 'dist/index.js'
+    outdir: 'dist'
   });
 })().then(async () => {
-  // await copyFiles(srcPath, destPath);
+  await copyFiles(srcPath, destPath);
 }).catch(() => process.exit(1));

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -24,7 +24,6 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/core": "7.5.0",
     "@salesforce/eslint-config-lwc": "3.5.1",
     "@salesforce/lightning-lsp-common": "4.8.0",
     "@salesforce/lwc-language-server": "4.8.0",
@@ -37,7 +36,8 @@
     "strip-ansi": "^5.2.0",
     "uuid": "^3.3.3",
     "vscode-extension-telemetry": "0.0.17",
-    "vscode-languageclient": "^5.2.1"
+    "vscode-languageclient": "^5.2.1",
+    "@salesforce/core-bundle": "7.5.0"
   },
   "devDependencies": {
     "@salesforce/salesforcedx-test-utils-vscode": "61.2.0",
@@ -116,10 +116,8 @@
         "server.js"
       ],
       "dependencies": {
-        "@salesforce/core": "7.5.0",
         "@salesforce/lightning-lsp-common": "4.8.0",
         "@salesforce/lwc-language-server": "4.8.0",
-        "@salesforce/source-tracking": "6.5.1",
         "applicationinsights": "1.0.7"
       },
       "devDependencies": {}

--- a/packages/salesforcedx-vscode-soql/esbuild.config.js
+++ b/packages/salesforcedx-vscode-soql/esbuild.config.js
@@ -6,7 +6,8 @@
  */
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { build } = require('esbuild');
-// const fs = require('fs').promises;
+const esbuildPluginPino = require('esbuild-plugin-pino');
+const fs = require('fs').promises;
 
 const sharedConfig = {
   bundle: true,
@@ -14,8 +15,6 @@ const sharedConfig = {
   platform: 'node',
   external: [
     'vscode',
-    '@salesforce/core',
-    '@salesforce/source-tracking',
     'applicationinsights',
     'shelljs',
     '@salesforce/soql-model',
@@ -23,29 +22,33 @@ const sharedConfig = {
     '@salesforce/soql-data-view',
     '@salesforce/soql-builder-ui'
   ],
-  minify: true
+  minify: true,
+  keepNames: true,
+  plugins: [
+    esbuildPluginPino({ transports: ['pino-pretty'] })
+  ]
 };
 
 // copy core-bundle/lib/transformStream.js to dist if core-bundle is included
-// const copyFiles = async (src, dest) => {
-//   try {
-//     // Copy the file
-//     await fs.copyFile(src, dest);
-//     console.log(`File was copied from ${src} to ${dest}`);
-//   } catch (error) {
-//     console.error('An error occurred:', error);
-//   }
-// };
+const copyFiles = async (src, dest) => {
+  try {
+    // Copy the file
+    await fs.copyFile(src, dest);
+    console.log(`File was copied from ${src} to ${dest}`);
+  } catch (error) {
+    console.error('An error occurred:', error);
+  }
+};
 
-// const srcPath = '../../node_modules/@salesforce/core-bundle/lib/transformStream.js';
-// const destPath = './dist/transformStream.js';
+const srcPath = '../../node_modules/@salesforce/core-bundle/lib/transformStream.js';
+const destPath = './dist/transformStream.js';
 
 (async () => {
   await build({
     ...sharedConfig,
     entryPoints: ['./src/index.ts'],
-    outfile: 'dist/index.js'
+    outdir: 'dist'
   });
 })().then(async () => {
-  // await copyFiles(srcPath, destPath);
+  await copyFiles(srcPath, destPath);
 }).catch(() => process.exit(1));

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -33,11 +33,11 @@
   "dependencies": {
     "@jsforce/jsforce-node": "3.2.0",
     "@salesforce/apex-tmlanguage": "1.6.0",
-    "@salesforce/core": "7.5.0",
     "@salesforce/soql-builder-ui": "1.0.0",
     "@salesforce/soql-data-view": "0.1.0",
     "@salesforce/soql-language-server": "0.7.1",
-    "@salesforce/soql-model": "1.0.0"
+    "@salesforce/soql-model": "1.0.0",
+    "@salesforce/core-bundle": "7.5.0"
   },
   "devDependencies": {
     "@salesforce/salesforcedx-sobjects-faux-generator": "61.2.0",
@@ -140,8 +140,6 @@
       "dependencies": {
         "applicationinsights": "1.0.7",
         "@salesforce/apex-tmlanguage": "1.6.0",
-        "@salesforce/core": "7.5.0",
-        "@salesforce/source-tracking": "6.5.1",
         "shelljs": "0.8.5",
         "@salesforce/soql-builder-ui": "1.0.0",
         "@salesforce/soql-data-view": "0.1.0",

--- a/packages/salesforcedx-vscode-soql/src/editor/queryRunner.ts
+++ b/packages/salesforcedx-vscode-soql/src/editor/queryRunner.ts
@@ -6,7 +6,7 @@
  */
 
 import { QueryResult } from '@jsforce/jsforce-node';
-import { Connection } from '@salesforce/core';
+import { Connection } from '@salesforce/core-bundle';
 import { soqlComments } from '@salesforce/soql-common';
 import { JsonMap } from '@salesforce/ts-types';
 import * as vscode from 'vscode';

--- a/packages/salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts
+++ b/packages/salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts
@@ -6,7 +6,7 @@
  */
 
 import { DescribeSObjectResult, QueryResult } from '@jsforce/jsforce-node';
-import { Connection } from '@salesforce/core';
+import { Connection } from '@salesforce/core-bundle';
 import { JsonMap } from '@salesforce/ts-types';
 import { debounce } from 'debounce';
 import * as vscode from 'vscode';

--- a/packages/salesforcedx-vscode-soql/src/sf.ts
+++ b/packages/salesforcedx-vscode-soql/src/sf.ts
@@ -6,7 +6,7 @@
  */
 
 import { DescribeSObjectResult } from '@jsforce/jsforce-node';
-import { Connection } from '@salesforce/core';
+import { Connection } from '@salesforce/core-bundle';
 import {
   ChannelService,
   WorkspaceContextUtil

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/client/client.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/client/client.test.ts
@@ -26,7 +26,7 @@ import {
   SOQL_CONFIGURATION_NAME,
   SOQL_VALIDATION_CONFIG
 } from '../../../src/constants';
-import { Connection } from '@salesforce/core';
+import { Connection } from '@salesforce/core-bundle';
 
 // eslint-disable-next-line @typescript-eslint/no-inferrable-types
 async function sleep(ms: number = 0) {

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/client/completion.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/client/completion.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { expect } from 'chai';
-import { Connection } from '@salesforce/core';
+import { Connection } from '@salesforce/core-bundle';
 import * as path from 'path';
 import * as fsExtra from 'fs-extra';
 import * as sinon from 'sinon';

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/editor/queryRunner.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/editor/queryRunner.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { expect } from 'chai';
-import { Connection } from '@salesforce/core';
+import { Connection } from '@salesforce/core-bundle';
 import * as sinon from 'sinon';
 import { QueryRunner } from '../../../src/editor/queryRunner';
 import { getMockConnection, mockQueryText } from '../testUtilities';

--- a/packages/salesforcedx-vscode-soql/test/vscode-integration/testUtilities.ts
+++ b/packages/salesforcedx-vscode-soql/test/vscode-integration/testUtilities.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthInfo, Connection } from '@salesforce/core';
+import { AuthInfo, Connection } from '@salesforce/core-bundle';
 import { JsonMap } from '@salesforce/ts-types';
 import { QueryResult } from '@jsforce/jsforce-node';
 import { SinonSandbox, SinonSpy } from 'sinon';


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
This PR replaces `@salesforce/core`, `@salesforce/source-deploy-retrieve`, `@salesforce/source-tracking` and `@salesforce/apex-node` with the bundle-able modules in all extensions and bundles the dependency `@salesforce/core-bundle`, `@salesforce/source-deploy-retrieve-bundle`, `@salesforce/source-tracking-bundle` that were previously externalized in the extensions. 

### What issues does this PR fix or reference?
@W-15635320@

### Functionality Before
core, sdr, source-tracking are externalized during the esbuild bundle. The size of the extension pack is up to 100MB now.

### Functionality After
After opting in the dependencies with bundle-able versions and bundle the dependencies, the size of the extension pack is reduced to 61.7MB and a significant improvement in extension startup performance is expected.