### PR TITLE
Mz/remove eslint

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -30,7 +30,7 @@
     "@salesforce/salesforcedx-utils-vscode": "61.2.1",
     "@salesforce/schemas": "^1.6.1",
     "@salesforce/source-deploy-retrieve-bundle": "11.6.10",
-    "@salesforce/templates-bundle": "^61.0.1",
+    "@salesforce/templates-bundle": "61.0.1",
     "@salesforce/ts-types": "2.0.9",
     "@salesforce/vscode-service-provider": "1.0.4",
     "adm-zip": "0.5.10",
@@ -100,7 +100,7 @@
       "dependencies": {
         "applicationinsights": "1.0.7",
         "shelljs": "0.8.5",
-        "@salesforce/templates-bundle": "^61.0.1"
+        "@salesforce/templates-bundle": "61.0.1"
       },
       "devDependencies": {}
     }

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -75,7 +75,6 @@
     "which": "1.3.1"
   },
   "extensionDependencies": [
-    "dbaeumer.vscode-eslint",
     "salesforce.salesforcedx-vscode-core"
   ],
   "scripts": {


### PR DESCRIPTION
### What does this PR do?
Remove ESLint from LWC extension dependency

### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @W-16103963@

### Functionality Before
ESLint is a dependency and v3 of ESLint causes LWC to fail to load in older ver of VS Code. But LWC actually does not depend on ESLint. So we are going to remove it.

### Functionality After
ESLint is no longer required for LWC