### PR TITLE
chore: add windows os to apexlsp and aninitialsuite

### DIFF
--- a/.github/workflows/apexE2ENew.yml
+++ b/.github/workflows/apexE2ENew.yml
@@ -102,7 +102,7 @@ jobs:
       testToRun: 'apexLsp.e2e.ts'
       vscodeVersion: ${{ inputs.vscodeVersion || 'stable' }}
       runId: ${{ inputs.runId || github.event.workflow_run.id  }}
-      os: '["macos-latest", "ubuntu-latest"]'
+      os: '["macos-latest", "ubuntu-latest", "windows-latest"]'
 
   apexReplayDebugger:
     if: ${{ inputs.apexReplayDebugger || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}

--- a/.github/workflows/e2eNew.yml
+++ b/.github/workflows/e2eNew.yml
@@ -112,7 +112,7 @@ jobs:
       testToRun: 'anInitialSuite.e2e.ts'
       vscodeVersion: ${{ inputs.vscodeVersion || 'stable' }}
       runId: ${{ inputs.runId || github.event.workflow_run.id  }}
-      os: '["macos-latest", "ubuntu-latest"]'
+      os: '["macos-latest", "ubuntu-latest", "windows-latest"]'
 
   sObjectsDefinitions:
     if: ${{ inputs.sObjectsDefinitions || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}


### PR DESCRIPTION
### What does this PR do?
Adds windows os to apexLsp and anInitialSuite

### Functionality Before
<insert gif and/or summary>

### Functionality After
- apexLsp.e2e.ts and anInitialSuite.e2e.ts run agains windows os

[skip-validate-pr]

Test runs: 
- [Apex End to End Tests - ESM](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/9814756714) ✅ 
- [E2E Test Suite - ESM](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/9814831064) ✅ 
