### PR TITLE
chore: collapse all tests commands only show up within open project

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -241,6 +241,10 @@
         {
           "command": "sf.test.view.refresh",
           "when": "false"
+        },
+        {
+          "command": "sf.test.view.collapseAll",
+          "when": "sf:project_opened"
         }
       ]
     },

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -283,6 +283,10 @@
           "when": "sf:project_opened || sf:internal_dev"
         },
         {
+          "command": "sf.lightning.lwc.test.view.collapseAll",
+          "when": "sf:project_opened"
+        },
+        {
           "command": "sf.lightning.lwc.test.refreshTestExplorer",
           "when": "sf:project_opened || sf:internal_dev"
         },


### PR DESCRIPTION
### What does this PR do?
- Adds condition to collapse all tests commands so they only show up within an open sf project

### What issues does this PR fix or reference?
@W-16296381@

### Functionality After
- `SFDX: Collapse All Apex Tests` and `SFDX: Lightning Web Components Collapse All Tests` only show up within an open sf project