### PR TITLE
fix: bump lightning-language-server dependencies from v4.8.0 to v4.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6473,11 +6473,11 @@
       }
     },
     "node_modules/@salesforce/aura-language-server": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-4.8.0.tgz",
-      "integrity": "sha512-AXxSgShk5e4AFuSYnlu5JiMj0xkArU4F55iHSTJ6OOPW25FA57xAFfKI+bgrsMyIKsmAPgjuSi2cHQMcVrgOZQ==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-4.11.0.tgz",
+      "integrity": "sha512-sejcEPfZGCdMttDykK0cDai9hr06Hq5wwhsmLzGNYSZFUb7YDvKdrU2jjO+zFRQINXV6hDUEb8f1IqrwDfE9pQ==",
       "dependencies": {
-        "@salesforce/lightning-lsp-common": "4.8.0",
+        "@salesforce/lightning-lsp-common": "4.11.0",
         "acorn": "^6.0.0",
         "acorn-loose": "^6.0.0",
         "acorn-walk": "^6.0.0",
@@ -6873,9 +6873,9 @@
       "integrity": "sha512-/ZiVwtVkmq2jWRRzgsC4SEy8m54gPaDc8e+jIfnIiR04iSeSRhYJxG+ktLSYVN2jMbVWA58HfEJSCx+73GcQCg=="
     },
     "node_modules/@salesforce/lightning-lsp-common": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-4.8.0.tgz",
-      "integrity": "sha512-QAQrB/gRplA2hH1qUeKlaKSMrFRzmnd7hlW719fhQVNQm4Arwr9gnXQsk/vQfu8pe628acdZ/ORhi2+dZ66Big==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-4.11.0.tgz",
+      "integrity": "sha512-IOpJ1zpeTq5WEv72cJncQo1FodvFMkP0444/5RfYNivYx7gcWnt+/ZTlcQKB50+N1f2cBuqlDCg56fQ+RJjh5Q==",
       "dependencies": {
         "decamelize": "^2.0.0",
         "deep-equal": "^1.0.1",
@@ -6914,6 +6914,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -6951,9 +6952,9 @@
       "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
     },
     "node_modules/@salesforce/lwc-language-server": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-4.8.0.tgz",
-      "integrity": "sha512-C8ZDmKqksHZZisRcKOZMMj9/QQMSOQnsn6Dzj8OC1jqxtaBmuCJ7nPwFBIO014AGOmj/Q8ArN8+COPFDIRUlyw==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-4.11.0.tgz",
+      "integrity": "sha512-zq2D1r64tn8Spt7LutNihl0aqhcx8V1jrNBrvNpzAURUCJdRAlbNR0NOsvWqO8Cr0K2LL+1oniAkL/+GkOxeTg==",
       "dependencies": {
         "@lwc/compiler": "2.50.0",
         "@lwc/engine-dom": "2.50.0",
@@ -6963,7 +6964,7 @@
         "@lwc/template-compiler": "2.50.0",
         "@salesforce/apex": "0.0.12",
         "@salesforce/label": "0.0.12",
-        "@salesforce/lightning-lsp-common": "4.8.0",
+        "@salesforce/lightning-lsp-common": "4.11.0",
         "@salesforce/resourceurl": "0.0.12",
         "@salesforce/schema": "0.0.12",
         "@salesforce/user": "0.0.12",
@@ -34277,9 +34278,9 @@
       "version": "61.6.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/aura-language-server": "4.8.0",
+        "@salesforce/aura-language-server": "4.11.0",
         "@salesforce/core-bundle": "8.2.0",
-        "@salesforce/lightning-lsp-common": "4.8.0",
+        "@salesforce/lightning-lsp-common": "4.11.0",
         "@salesforce/salesforcedx-utils-vscode": "61.6.0",
         "applicationinsights": "1.0.7",
         "vscode-extension-telemetry": "0.0.17",
@@ -34463,8 +34464,8 @@
       "dependencies": {
         "@salesforce/core-bundle": "8.2.0",
         "@salesforce/eslint-config-lwc": "3.5.1",
-        "@salesforce/lightning-lsp-common": "4.8.0",
-        "@salesforce/lwc-language-server": "4.8.0",
+        "@salesforce/lightning-lsp-common": "4.11.0",
+        "@salesforce/lwc-language-server": "4.11.0",
         "@salesforce/salesforcedx-utils-vscode": "61.6.0",
         "ajv": "6.12.6",
         "applicationinsights": "1.0.7",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -24,9 +24,9 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/aura-language-server": "4.8.0",
+    "@salesforce/aura-language-server": "4.11.0",
     "@salesforce/core-bundle": "8.2.0",
-    "@salesforce/lightning-lsp-common": "4.8.0",
+    "@salesforce/lightning-lsp-common": "4.11.0",
     "@salesforce/salesforcedx-utils-vscode": "61.6.0",
     "applicationinsights": "1.0.7",
     "vscode-extension-telemetry": "0.0.17",
@@ -120,8 +120,8 @@
       ],
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "@salesforce/aura-language-server": "4.8.0",
-        "@salesforce/lightning-lsp-common": "4.8.0"
+        "@salesforce/aura-language-server": "4.11.0",
+        "@salesforce/lightning-lsp-common": "4.11.0"
       },
       "devDependencies": {}
     }

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -26,8 +26,8 @@
   "dependencies": {
     "@salesforce/core-bundle": "8.2.0",
     "@salesforce/eslint-config-lwc": "3.5.1",
-    "@salesforce/lightning-lsp-common": "4.8.0",
-    "@salesforce/lwc-language-server": "4.8.0",
+    "@salesforce/lightning-lsp-common": "4.11.0",
+    "@salesforce/lwc-language-server": "4.11.0",
     "@salesforce/salesforcedx-utils-vscode": "61.6.0",
     "ajv": "6.12.6",
     "applicationinsights": "1.0.7",
@@ -115,8 +115,8 @@
         "server.js"
       ],
       "dependencies": {
-        "@salesforce/lightning-lsp-common": "4.8.0",
-        "@salesforce/lwc-language-server": "4.8.0",
+        "@salesforce/lightning-lsp-common": "4.11.0",
+        "@salesforce/lwc-language-server": "4.11.0",
         "applicationinsights": "1.0.7"
       },
       "devDependencies": {}


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Bumps the version of @salesforce/lightning-lsp-common, @salesforce/aura-language-server, and @salesforce/lwc-language-server to include the changes in the LWC LSP for supporting lightning-record-picker

### What issues does this PR fix or reference?
@W-14457297@