### PR TITLE
build: env vars to for log level and storage path

### DIFF
--- a/.github/workflows/runE2ETest.yml
+++ b/.github/workflows/runE2ETest.yml
@@ -113,8 +113,10 @@ jobs:
           SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL_E2E }}
           ORG_ID: ${{ secrets.ORG_ID_E2E }}
           THROTTLE_FACTOR: ${{ env.THROTTLE_FACTOR }}
-          E2E_VSCODE_STORAGE_PATH: ./salesforcedx-vscode-automation-tests/wdio-test-artfacts
+          E2E_VSCODE_STORAGE_PATH: wdio-test-artfacts
           E2E_LOG_LEVEL: info
+      - name: list wdio-test-artifacts
+        run: ls -R salesforcedx-vscode-automation-tests/wdio-test-artifacts
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/runE2ETest.yml
+++ b/.github/workflows/runE2ETest.yml
@@ -113,8 +113,10 @@ jobs:
           SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL_E2E }}
           ORG_ID: ${{ secrets.ORG_ID_E2E }}
           THROTTLE_FACTOR: ${{ env.THROTTLE_FACTOR }}
+          E2E_VSCODE_STORAGE_PATH: ./salesforcedx-vscode-automation-tests/wdio-test-artfacts
+          E2E_LOG_LEVEL: info
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: screenshots-${{ inputs.testToRun }}-${{ matrix.os }}
-          path: ./salesforcedx-vscode-automation-tests/screenshots
+          name: wdio-test-artfacts-${{ inputs.testToRun }}-${{ matrix.os }}
+          path: ./salesforcedx-vscode-automation-tests/wdio-test-artfacts


### PR DESCRIPTION
@W-16124376@
add env vars for e2e test runs to configure log level and wdio storage dir.

depends on [PR](https://github.com/forcedotcom/salesforcedx-vscode-automation-tests/pull/95) on automation repo