### PR TITLE
chore: message for status: owned by another team

### DIFF
--- a/.github/workflows/validateUpdatedIssues.yml
+++ b/.github/workflows/validateUpdatedIssues.yml
@@ -72,9 +72,9 @@ jobs:
         with:
           repo-token: ${{ secrets.IDEE_GH_TOKEN }}
           message: >
-            We have determined that the issue you reported exists in code owned by another team that uses only the official support channels.
+            We have determined that the issue you reported exists in code owned by another team that uses only the official support channels, and thus we are closing this issue.
             To ensure that your issue is addressed, open an official [Salesforce customer support](https://help.salesforce.com/s/) ticket with a link to this issue.
-            We encourage anyone experiencing this issue to do the same to increase the priority. We will keep this issue open for the community to collaborate on.
+            We encourage anyone experiencing this issue to do the same to increase the priority.
 
   new-feature-on-another-team:
     if: >-


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Updates the message for `status: owned by another team` to say that issues owned by another team will be closed.

### What issues does this PR fix or reference?
[skip-validate-pr]