### PR TITLE
fix: strip ansi color control chars from json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33393,7 +33393,6 @@
         "applicationinsights": "1.0.7",
         "cross-spawn": "7.0.3",
         "rxjs": "^5.4.1",
-        "strip-ansi": "^5.2.0",
         "tree-kill": "^1.1.0"
       },
       "devDependencies": {

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -16,7 +16,6 @@
     "applicationinsights": "1.0.7",
     "cross-spawn": "7.0.3",
     "rxjs": "^5.4.1",
-    "strip-ansi": "^5.2.0",
     "tree-kill": "^1.1.0"
   },
   "devDependencies": {

--- a/packages/salesforcedx-utils-vscode/src/cli/commandOutput.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/commandOutput.ts
@@ -27,6 +27,13 @@ export class CommandOutput {
           if (data !== undefined && String(data) === '0') {
             return resolve(stripAnsiInJson(this.stdoutBuffer, hasJsonEnabled));
           } else {
+            // Is the command is sf cli - if so, just use stdoutBuffer before stderrBuffer
+            if (execution.command.command === 'sf') {
+              return reject(
+                stripAnsiInJson(this.stdoutBuffer, hasJsonEnabled) ||
+                stripAnsiInJson(this.stderrBuffer, hasJsonEnabled)
+              );
+            }
             return reject(
               stripAnsiInJson(this.stderrBuffer, hasJsonEnabled) ||
                 stripAnsiInJson(this.stdoutBuffer, hasJsonEnabled)

--- a/packages/salesforcedx-utils-vscode/src/cli/commandOutput.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/commandOutput.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { stripAnsiInJson } from '../helpers/utils';
 import { CommandExecution } from './commandExecutor';
 
 export class CommandOutput {
@@ -12,6 +13,7 @@ export class CommandOutput {
   private stderrBuffer = '';
 
   public async getCmdResult(execution: CommandExecution): Promise<string> {
+    const hasJsonEnabled = execution.command.args?.some(arg => arg === '--json');
     execution.stdoutSubject.subscribe(realData => {
       this.stdoutBuffer += realData.toString();
     });
@@ -23,9 +25,12 @@ export class CommandOutput {
       (resolve: (result: string) => void, reject: (reason: string) => void) => {
         execution.processExitSubject.subscribe(data => {
           if (data !== undefined && String(data) === '0') {
-            return resolve(this.stdoutBuffer);
+            return resolve(stripAnsiInJson(this.stdoutBuffer, hasJsonEnabled));
           } else {
-            return reject(this.stderrBuffer || this.stdoutBuffer);
+            return reject(
+              stripAnsiInJson(this.stderrBuffer, hasJsonEnabled) ||
+                stripAnsiInJson(this.stdoutBuffer, hasJsonEnabled)
+            );
           }
         });
       }

--- a/packages/salesforcedx-utils-vscode/src/commands/channelService.ts
+++ b/packages/salesforcedx-utils-vscode/src/commands/channelService.ts
@@ -5,9 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import stripAnsi from 'strip-ansi';
 import { OutputChannel, window } from 'vscode';
 import { CommandExecution } from '../cli';
+import { stripAnsi } from '../helpers/utils';
 import { nls } from '../messages';
 import { SettingsService } from '../settings';
 

--- a/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
@@ -85,3 +85,36 @@ export const fileUtils = {
   flushFilePath,
   extractJsonObject
 };
+
+export const stripAnsiInJson = (str: string, hasJson: boolean): string => {
+  return hasJson ? str.replaceAll(ansiRegex(), '') : str;
+};
+
+/*
+Copied from https://github.com/sindresorhus/strip-ansi/blob/master/index.js
+
+MIT License
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without
+limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+export const ansiRegex = ({ onlyFirst = false } = {}): RegExp => {
+  const pattern = [
+    '[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
+    '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))'
+  ].join('|');
+
+  return new RegExp(pattern, onlyFirst ? undefined : 'g');
+};

--- a/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
@@ -87,7 +87,7 @@ export const fileUtils = {
 };
 
 export const stripAnsiInJson = (str: string, hasJson: boolean): string => {
-  return str && hasJson ? str.replaceAll(ansiRegex(), '') : str;
+  return str && hasJson ? stripAnsi(str) : str;
 };
 
 export const stripAnsi = (str: string): string => {

--- a/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
@@ -87,7 +87,11 @@ export const fileUtils = {
 };
 
 export const stripAnsiInJson = (str: string, hasJson: boolean): string => {
-  return hasJson ? str.replaceAll(ansiRegex(), '') : str;
+  return str && hasJson ? str.replaceAll(ansiRegex(), '') : str;
+};
+
+export const stripAnsi = (str: string): string => {
+  return str ? str.replaceAll(ansiRegex(), '') : str;
 };
 
 /*

--- a/packages/salesforcedx-utils-vscode/test/jest/helpers/utils.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/helpers/utils.test.ts
@@ -4,33 +4,67 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { extractJsonObject } from '../../../src/helpers/utils';
+import { extractJsonObject, stripAnsiInJson } from '../../../src/helpers/utils';
 
-describe('extractJsonObject unit tests', () => {
-  const initialValue = {
-    how: 'does',
-    it: true,
-    get: 5,
-    handled: false
-  };
-  const jsonString = JSON.stringify(initialValue);
+describe('utils tests', () => {
+  describe('extractJsonObject unit tests', () => {
+    const initialValue = {
+      how: 'does',
+      it: true,
+      get: 5,
+      handled: false
+    };
+    const jsonString = JSON.stringify(initialValue);
 
-  it('Should be able to parse a json string.', () => {
-    const result = extractJsonObject(jsonString);
-    expect(result).toStrictEqual(initialValue);
+    it('Should be able to parse a json string.', () => {
+      const result = extractJsonObject(jsonString);
+      expect(result).toStrictEqual(initialValue);
+    });
+
+    it('Should throw error if argument is a simple text', () => {
+      const invalidJson = initialValue.how;
+      expect(() => extractJsonObject(invalidJson)).toThrow(
+        'The string "does" is not a valid JSON string.'
+      );
+    });
+
+    it('Should throw error if argument is invalid JSON string', () => {
+      const invalidJson = jsonString.substring(10);
+      expect(() => extractJsonObject(invalidJson)).toThrow(
+        `The string "${invalidJson}" is not a valid JSON string.`
+      );
+    });
   });
+  describe('stripAnsiInJson', () => {
+    it('should return the original string if hasJson is false', () => {
+      const input = 'some string';
+      const result = stripAnsiInJson(input, false);
+      expect(result).toBe(input);
+    });
 
-  it('Should throw error if argument is a simple text', () => {
-    const invalidJson = initialValue.how;
-    expect(() => extractJsonObject(invalidJson)).toThrow(
-      'The string "does" is not a valid JSON string.'
-    );
-  });
+    it('should return the stripped string if hasJson is true', () => {
+      const input = '\u001b[4msome string\u001b[0m';
+      const result = stripAnsiInJson(input, true);
+      expect(result).toBe('some string');
+    });
 
-  it('Should throw error if argument is invalid JSON string', () => {
-    const invalidJson = jsonString.substring(10);
-    expect(() => extractJsonObject(invalidJson)).toThrow(
-      `The string "${invalidJson}" is not a valid JSON string.`
-    );
+    it('should return the original JSON string if hasJson is false', () => {
+      const input = '{"key": "value"}';
+      const result = stripAnsiInJson(input, false);
+      expect(result).toBe(input);
+    });
+
+    it('should return the stripped JSON string if hasJson is true', () => {
+      const input = '{"key": "\u001b[4mvalue\u001b[0m"}';
+      const result = stripAnsiInJson(input, true);
+      expect(result).toBe('{"key": "value"}');
+    });
+
+    it('should handle complex JSON with ANSI codes', () => {
+      const input =
+        '{"key1": "\u001b[31mvalue1\u001b[0m", "key2": "\u001b[32mvalue2\u001b[0m"}';
+      const result = stripAnsiInJson(input, true);
+      expect(result).toBe('{"key1": "value1", "key2": "value2"}');
+    });
   });
 });

--- a/packages/salesforcedx-utils-vscode/test/jest/helpers/utils.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/helpers/utils.test.ts
@@ -48,6 +48,18 @@ describe('utils tests', () => {
       expect(result).toBe('some string');
     });
 
+    it('should return the original string even when it contains ANSI if hasJson is false', () => {
+      const input = '\u001b[4msome string\u001b[0m';
+      const result = stripAnsiInJson(input, false);
+      expect(result).toBe('\u001b[4msome string\u001b[0m');
+    });
+
+    it('should return the original string if hasJson is true and the string does not contain ANSI', () => {
+      const input = 'some string';
+      const result = stripAnsiInJson(input, true);
+      expect(result).toBe(input);
+    });
+
     it('should return the original JSON string if hasJson is false', () => {
       const input = '{"key": "value"}';
       const result = stripAnsiInJson(input, false);

--- a/packages/salesforcedx-utils/src/cli/commandOutput.ts
+++ b/packages/salesforcedx-utils/src/cli/commandOutput.ts
@@ -30,9 +30,16 @@ export class CommandOutput {
           if (data !== undefined && String(data) === '0') {
             return resolve(stripAnsiInJson(this.stdoutBuffer, hasJsonEnabled));
           } else {
+            // Is the command is sf cli - if so, just use stdoutBuffer before stderrBuffer
+            if (execution.command.command === 'sf') {
+              return reject(
+                stripAnsiInJson(this.stdoutBuffer, hasJsonEnabled) ||
+                stripAnsiInJson(this.stderrBuffer, hasJsonEnabled)
+              );
+            }
             return reject(
               stripAnsiInJson(this.stderrBuffer, hasJsonEnabled) ||
-                stripAnsiInJson(this.stdoutBuffer, hasJsonEnabled)
+              stripAnsiInJson(this.stdoutBuffer, hasJsonEnabled)
             );
           }
         });

--- a/packages/salesforcedx-utils/src/cli/commandOutput.ts
+++ b/packages/salesforcedx-utils/src/cli/commandOutput.ts
@@ -5,13 +5,18 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { stripAnsiInJson } from '../helpers';
 import { CommandExecution } from '../types';
+import { JSON_FLAG } from './commandBuilder';
 
 export class CommandOutput {
   private stdoutBuffer = '';
   private stderrBuffer = '';
 
   public async getCmdResult(execution: CommandExecution): Promise<string> {
+    const hasJsonEnabled = execution.command?.args?.some(
+      arg => arg === JSON_FLAG
+    );
     execution.stdoutSubject.subscribe(realData => {
       this.stdoutBuffer += realData.toString();
     });
@@ -23,9 +28,12 @@ export class CommandOutput {
       (resolve: (result: string) => void, reject: (reason: string) => void) => {
         execution.processExitSubject.subscribe(data => {
           if (data !== undefined && String(data) === '0') {
-            return resolve(this.stdoutBuffer);
+            return resolve(stripAnsiInJson(this.stdoutBuffer, hasJsonEnabled));
           } else {
-            return reject(this.stderrBuffer || this.stdoutBuffer);
+            return reject(
+              stripAnsiInJson(this.stderrBuffer, hasJsonEnabled) ||
+                stripAnsiInJson(this.stdoutBuffer, hasJsonEnabled)
+            );
           }
         });
       }

--- a/packages/salesforcedx-utils/src/helpers/index.ts
+++ b/packages/salesforcedx-utils/src/helpers/index.ts
@@ -6,3 +6,4 @@
  */
 export { extractJsonObject } from './extractJsonObject';
 export { ensureCurrentWorkingDirIsProjectPath } from './ensureCurrentWorkingDirIsProjectPath';
+export { stripAnsiInJson } from './utils';

--- a/packages/salesforcedx-utils/src/helpers/utils.ts
+++ b/packages/salesforcedx-utils/src/helpers/utils.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+export const stripAnsiInJson = (str: string, hasJson: boolean): string => {
+  return hasJson ? str.replaceAll(ansiRegex(), '') : str;
+};
+
+/*
+Copied from https://github.com/sindresorhus/strip-ansi/blob/master/index.js
+
+MIT License
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without
+limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+const ansiRegex = ({ onlyFirst = false } = {}): RegExp => {
+  const pattern = [
+    '[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
+    '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))'
+  ].join('|');
+
+  return new RegExp(pattern, onlyFirst ? undefined : 'g');
+};

--- a/packages/salesforcedx-utils/test/jest/cli/commandOutput.test.ts
+++ b/packages/salesforcedx-utils/test/jest/cli/commandOutput.test.ts
@@ -28,6 +28,9 @@ describe('CommandOutput Unit Tests.', () => {
       },
       processExitSubject: {
         subscribe: jest.fn()
+      },
+      command: {
+        command: 'sf'
       }
     };
     commandOutput = new CommandOutput();
@@ -77,7 +80,8 @@ describe('CommandOutput Unit Tests.', () => {
     });
   });
 
-  it('Should have data from stderr on failure.', async () => {
+  it('Should have data from stderr on failure for not command sf.', async () => {
+    fakeExecution.command.command = 'notsf';
     const stdoutCallback =
       fakeExecution.stdoutSubject.subscribe.mock.calls[0][0];
     stdoutCallback(goodOutput);
@@ -93,16 +97,45 @@ describe('CommandOutput Unit Tests.', () => {
     });
   });
 
-  it('Should have data from stdout on failure if there is no stderr.', async () => {
+  it('Should have data from stdout on failure if there is no stderr when command not sf.', async () => {
+    fakeExecution.command.command = 'notsf';
     const stdoutCallback =
       fakeExecution.stdoutSubject.subscribe.mock.calls[0][0];
     stdoutCallback(goodOutput);
     const exitCallback =
       fakeExecution.processExitSubject.subscribe.mock.calls[0][0];
-    // Call the exit callback with a 0 response to indicate success
+    // Call the exit callback with a 1 response to indicate failure
     exitCallback(failCode);
     result.catch(outValue => {
       expect(outValue).toEqual(goodOutput);
+    });
+  });
+  it('Should have data from stdout on failure for sf command.', async () => {
+    const stdoutCallback =
+      fakeExecution.stdoutSubject.subscribe.mock.calls[0][0];
+    stdoutCallback(badOutput);
+    const stderrCallback =
+      fakeExecution.stderrSubject.subscribe.mock.calls[0][0];
+    stderrCallback(goodOutput);
+    const exitCallback =
+      fakeExecution.processExitSubject.subscribe.mock.calls[0][0];
+    // Call the exit callback with a 0 response to indicate success
+    exitCallback(failCode);
+    result.catch(outValue => {
+      expect(outValue).toEqual(badOutput);
+    });
+  });
+
+  it('Should have data from stderr on failure if there is no stdout when sf command.', async () => {
+    const stderrCallback =
+      fakeExecution.stderrSubject.subscribe.mock.calls[0][0];
+    stderrCallback(badOutput);
+    const exitCallback =
+      fakeExecution.processExitSubject.subscribe.mock.calls[0][0];
+    // Call the exit callback with a 1 response to indicate failure
+    exitCallback(failCode);
+    result.catch(outValue => {
+      expect(outValue).toEqual(badOutput);
     });
   });
 });

--- a/packages/salesforcedx-utils/test/jest/cli/commandOutput.test.ts
+++ b/packages/salesforcedx-utils/test/jest/cli/commandOutput.test.ts
@@ -90,7 +90,7 @@ describe('CommandOutput Unit Tests.', () => {
     stderrCallback(badOutput);
     const exitCallback =
       fakeExecution.processExitSubject.subscribe.mock.calls[0][0];
-    // Call the exit callback with a 0 response to indicate success
+    // Call the exit callback with a 1 response to indicate failure
     exitCallback(failCode);
     result.catch(outValue => {
       expect(outValue).toEqual(badOutput);
@@ -119,7 +119,7 @@ describe('CommandOutput Unit Tests.', () => {
     stderrCallback(goodOutput);
     const exitCallback =
       fakeExecution.processExitSubject.subscribe.mock.calls[0][0];
-    // Call the exit callback with a 0 response to indicate success
+    // Call the exit callback with a 1 response to indicate failure
     exitCallback(failCode);
     result.catch(outValue => {
       expect(outValue).toEqual(badOutput);


### PR DESCRIPTION
A number of CLI commands are returning ANSI color characters in JSON results. This change removes those characters prior to the JSON strings being parsed.

This change also include removal of the strip-ansi dependency and replaced with internal functions

@W-16375638@, #5695
