### PR TITLE
feat: return deploy status from command 

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/commands/commandletExecutors.ts
+++ b/packages/salesforcedx-utils-vscode/src/commands/commandletExecutors.ts
@@ -160,7 +160,7 @@ export abstract class LibraryCommandletExecutor<T>
     token?: vscode.CancellationToken
   ): Promise<boolean>;
 
-  public async execute(response: ContinueResponse<T>): Promise<void> {
+  public async execute(response: ContinueResponse<T>): Promise<boolean> {
     const startTime = process.hrtime();
     const channelService = new ChannelService(this.outputChannel);
     const telemetryService = TelemetryService.getInstance();
@@ -220,6 +220,7 @@ export abstract class LibraryCommandletExecutor<T>
         properties,
         measurements
       );
+      return !!success;
     } catch (e) {
       if (e instanceof Error) {
         telemetryService.sendException(e.name, e.message);
@@ -227,6 +228,7 @@ export abstract class LibraryCommandletExecutor<T>
         channelService.appendLine(e.message);
       }
       channelService.showChannelOutput();
+      return false;
     }
   }
 

--- a/packages/salesforcedx-utils-vscode/test/jest/commands/commandletExecutors.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/commands/commandletExecutors.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import * as vscode from 'vscode';
+import { ContinueResponse } from '../../../src';
+import { LibraryCommandletExecutor } from '../../../src/commands/commandletExecutors';
+
+jest.mock('../../../src/commands/channelService');
+jest.mock('vscode');
+
+describe('commandletExecutors Unit Tests.', () => {
+  describe('LibraryCommandletExecutor', () => {
+    class TestLibraryCommandletExecutor<T> extends LibraryCommandletExecutor<T> {
+      // eslint-disable-next-line @typescript-eslint/require-await
+      public async run(
+        response: ContinueResponse<T>,
+        progress?: vscode.Progress<{
+          message?: string | undefined;
+          increment?: number | undefined; }>
+          , token?: vscode.CancellationToken
+        ): Promise<boolean> {
+          return true;
+      }
+    }
+
+    it('resolves with boolean success/fail response', async () => {
+      const testLibraryCommandletExecutor = new TestLibraryCommandletExecutor('', '', vscode.window.createOutputChannel(''));
+
+      const result = await testLibraryCommandletExecutor.execute({ type: 'CONTINUE', data: {} });
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/packages/salesforcedx-vscode-core/src/commands/deploySourcePath.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/deploySourcePath.ts
@@ -80,7 +80,8 @@ export const deploySourcePaths = async (
       )
     );
 
-    await commandlet.run();
+    const result = await commandlet.run();
+    return result;
   }
 };
 

--- a/packages/salesforcedx-vscode-core/src/commands/source/sourceTrackingGetStatusExecutor.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/source/sourceTrackingGetStatusExecutor.ts
@@ -27,14 +27,17 @@ export class SourceTrackingGetStatusExecutor extends LibraryCommandletExecutor<
   }
 
   public async execute(): Promise<boolean> {
-    const sourceStatusSummary: string = await SourceTrackingService.getSourceStatusSummary(
-      this.options || {}
-    );
-    channelService.appendLine(nls.localize('source_status'));
-    channelService.appendLine(sourceStatusSummary);
-    channelService.showChannelOutput();
-
-    return true;
+    try {
+      const sourceStatusSummary: string = await SourceTrackingService.getSourceStatusSummary(
+        this.options || {}
+      );
+      channelService.appendLine(nls.localize('source_status'));
+      channelService.appendLine(sourceStatusSummary);
+      channelService.showChannelOutput();
+      return true;
+    } catch (e) {
+      return false;
+    }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/salesforcedx-vscode-core/src/commands/source/sourceTrackingGetStatusExecutor.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/source/sourceTrackingGetStatusExecutor.ts
@@ -26,13 +26,15 @@ export class SourceTrackingGetStatusExecutor extends LibraryCommandletExecutor<
     this.options = options;
   }
 
-  public async execute(): Promise<void> {
+  public async execute(): Promise<boolean> {
     const sourceStatusSummary: string = await SourceTrackingService.getSourceStatusSummary(
       this.options || {}
     );
     channelService.appendLine(nls.localize('source_status'));
     channelService.appendLine(sourceStatusSummary);
     channelService.showChannelOutput();
+
+    return true;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/salesforcedx-vscode-core/test/jest/commands/source/sourceTrackingGetStatusExecutor.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/commands/source/sourceTrackingGetStatusExecutor.test.ts
@@ -58,12 +58,12 @@ describe('SourceTrackingGetStatusExecutor', () => {
         local: true,
         remote: true
       });
-  
+
       const result = await executor.execute();
-  
+
       expect(result).toBe(true);
     });
-  
+
     it('should resolve with undefined if it throws an error', async () => {
       getSourceStatusSummaryMock = jest
         .spyOn(SourceTrackingService, 'getSourceStatusSummary')

--- a/packages/salesforcedx-vscode-core/test/jest/commands/source/sourceTrackingGetStatusExecutor.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/commands/source/sourceTrackingGetStatusExecutor.test.ts
@@ -52,6 +52,35 @@ describe('SourceTrackingGetStatusExecutor', () => {
       expect(appendSpy).toHaveBeenCalledWith(dummySourceStatusSummary);
       expect(showChannelOutputSpy).toHaveBeenCalled();
     });
+
+    it('should resolve with true on success', async () => {
+      const executor = new SourceTrackingGetStatusExecutor('', '', {
+        local: true,
+        remote: true
+      });
+  
+      const result = await executor.execute();
+  
+      expect(result).toBe(true);
+    });
+  
+    it('should resolve with undefined if it throws an error', async () => {
+      getSourceStatusSummaryMock = jest
+        .spyOn(SourceTrackingService, 'getSourceStatusSummary')
+        .mockImplementationOnce(() => {
+          throw new Error();
+        });
+      const executor = new SourceTrackingGetStatusExecutor('', '', {
+        local: true,
+        remote: true
+      });
+      let result;
+      try {
+        result = await executor.execute();
+      } catch (e) {
+        expect(result).toBe(undefined);
+      }
+    });
   });
 
   describe('run', () => {


### PR DESCRIPTION
### What does this PR do?
Additionally returns status of deploy to those who directly call the vscode extension command

### What issues does this PR fix or reference?
@W-16420054@

### Functionality Before
`await vscode.commands.executeCommand('sf.deploy.current.source.file');`
Would wait for completion of deploy command, but not inform caller directly of success of failure.

### Functionality After
`const result = await vscode.commands.executeCommand('sf.deploy.current.source.file');`
Now additionally returns true/false if deploy was successful or a failure (still waits for completion)
