### PR TITLE
fix: no infinite running command notification for diff file and folder commands

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/sourceDiff.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/sourceDiff.ts
@@ -85,7 +85,7 @@ export const sourceFolderDiff = async (explorerPath: vscode.Uri) => {
     new FilePathGatherer(explorerPath),
     new MetadataCacheExecutor(
       username,
-      'Source Diff',
+      nls.localize('source_diff_folder_text'),
       'source-diff-loader',
       handleCacheResults
     )

--- a/packages/salesforcedx-vscode-core/src/commands/sourceDiff.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/sourceDiff.ts
@@ -109,7 +109,7 @@ export const handleCacheResults = async (
     }
   } else {
     const message = nls.localize('source_diff_components_not_in_org');
-    await notificationService.showErrorMessage(message);
+    notificationService.showErrorMessage(message);
     throw new Error(message);
   }
 };

--- a/packages/salesforcedx-vscode-core/src/commands/sourceDiff.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/sourceDiff.ts
@@ -105,11 +105,11 @@ export const handleCacheResults = async (
         username
       );
     } else if (cache.selectedType === PathType.Folder) {
-      await differ.diffFolder(cache, username);
+      differ.diffFolder(cache, username);
     }
   } else {
     const message = nls.localize('source_diff_components_not_in_org');
-    notificationService.showErrorMessage(message);
+    void notificationService.showErrorMessage(message);
     throw new Error(message);
   }
 };

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ja.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ja.ts
@@ -513,6 +513,7 @@ export const messages = {
   conflict_detect_diff_command_title: 'ファイルを比較',
 
   source_diff_text: 'SFDX: 組織のファイルとの差分を表示',
+  source_diff_folder_text: 'SFDX: Diff Folder Against Org',
   source_diff_components_not_in_org:
     'Selected components are not available in the org',
   source_diff_unsupported_type:

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -626,6 +626,7 @@ export const messages = {
   conflict_detect_local_last_modified_date: 'Local last sync date: %s',
 
   source_diff_text: 'SFDX: Diff File Against Org',
+  source_diff_folder_text: 'SFDX: Diff Folder Against Org',
   source_diff_components_not_in_org:
     'Selected components are not available in the org',
   source_diff_unsupported_type:
@@ -660,8 +661,7 @@ export const messages = {
   sobjects_no_refresh_if_already_active_error_text:
     'A refresh of your sObject definitions is already underway. If you need to restart the process, cancel the running task.',
   rename_lightning_component: 'SFDX: Rename Component',
-  component_input_dup_error:
-    'Component name is already in use in LWC or Aura',
+  component_input_dup_error: 'Component name is already in use in LWC or Aura',
   rename_component_input_dup_file_name_error:
     'This file name is already in use in the current component directory. Choose a different name and try again.',
   rename_component_input_placeholder: 'Enter a unique component name',
@@ -702,6 +702,6 @@ export const messages = {
   input_no_component_name: 'Input does not contain component name',
   component_empty: 'Component cannot be empty',
   create_not_supported: 'Create is not supported for multiple components',
-  input_incorrect_properties: 'Input does not contain correct component properties'
-
+  input_incorrect_properties:
+    'Input does not contain correct component properties'
 };


### PR DESCRIPTION
### What does this PR do?
Gets rid of the Running SFDX: Diff File Against Org notification when the diff source fails.

### What issues does this PR fix or reference?
@W-16006725@

### Functionality Before
- Running notification even when the command already failed
<img width="560" alt="image" src="https://github.com/user-attachments/assets/1058538a-d5df-4f37-9cc5-f9f7267e25fb">


### Functionality After
- Only failure notifications when it fails
<img width="567" alt="image" src="https://github.com/user-attachments/assets/f7fc6e41-5bba-4bff-a58f-055f67cb1508">

