### PR TITLE
fix: "SFDX: Generate Manifest File" command should not exist for manifest files

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -326,7 +326,7 @@
         },
         {
           "command": "sf.project.generate.manifest",
-          "when": "sf:project_opened"
+          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest'"
         },
         {
           "command": "sf.rename.lightning.component",


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Fixes an issue where the "SFDX: Generate Manifest File" command exists in Explorer view context menu for manifest files and can be used to generate a blank manifest file.

### What issues does this PR fix or reference?
@W-16550710@

### Functionality Before
When you right click on a manifest file in Explorer view context menu, "SFDX: Generate Manifest File" is an option and can be used to generate a blank manifest file.
Video of issue: https://drive.google.com/file/d/10ovH5qZZ0g2g3cZRLptd2pCTpjeCB2xX/view?usp=sharing

### Functionality After
When you right click on a manifest file in Explorer view context menu, "SFDX: Generate Manifest File" is not an option.