### PR TITLE
chore: set vscode version to 1.92.2 for e2e tests

### DIFF
--- a/.github/workflows/apexE2E.yml
+++ b/.github/workflows/apexE2E.yml
@@ -36,7 +36,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'stable'
+        default: '1.92.2'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -78,7 +78,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'stable'
+        default: '1.92.2'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'

--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -41,7 +41,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'stable'
+        default: '1.92.2'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -88,7 +88,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'stable'
+        default: '1.92.2'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'

--- a/.github/workflows/deployRetrieveE2E.yml
+++ b/.github/workflows/deployRetrieveE2E.yml
@@ -36,7 +36,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'stable'
+        default: '1.92.2'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -78,7 +78,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'stable'
+        default: '1.92.2'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,7 +43,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version for ESM branches'
         required: false
-        default: 'stable'
+        default: '1.92.2'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -57,7 +57,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch || 'testesm' }}
-      vscodeVersion: ${{ inputs.vscodeVersion || 'stable' }}
+      vscodeVersion: ${{ inputs.vscodeVersion || '1.92.2' }}
       runId: ${{ inputs.runId || github.event.workflow_run.id }}
 
   Core_E2E_tests:
@@ -66,7 +66,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch || 'testesm' }}
-      vscodeVersion: ${{ inputs.vscodeVersion || 'stable' }}
+      vscodeVersion: ${{ inputs.vscodeVersion || '1.92.2' }}
       runId: ${{ inputs.runId || github.event.workflow_run.id }}
 
   DeployAndRetrieve_E2E_tests:
@@ -75,7 +75,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch || 'testesm' }}
-      vscodeVersion: ${{ inputs.vscodeVersion || 'stable' }}
+      vscodeVersion: ${{ inputs.vscodeVersion || '1.92.2' }}
       runId: ${{ inputs.runId || github.event.workflow_run.id }}
 
   LSP_E2E_tests:
@@ -84,7 +84,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch || 'testesm' }}
-      vscodeVersion: ${{ inputs.vscodeVersion || 'stable' }}
+      vscodeVersion: ${{ inputs.vscodeVersion || '1.92.2' }}
       runId: ${{ inputs.runId || github.event.workflow_run.id }}
 
   # LWC_E2E_tests:
@@ -93,7 +93,7 @@ jobs:
   #   secrets: inherit
   #   with:
   #     automationBranch: ${{ inputs.automationBranch || 'testesm' }}
-  #     vscodeVersion: ${{ inputs.vscodeVersion || 'stable' }}
+  #     vscodeVersion: ${{ inputs.vscodeVersion || '1.92.2' }}
   #     runId: ${{ inputs.runId || github.event.workflow_run.id }}
 
   Apex_E2E_tests_min_vscode_version:

--- a/.github/workflows/lspE2E.yml
+++ b/.github/workflows/lspE2E.yml
@@ -26,7 +26,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'stable'
+        default: '1.92.2'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -58,7 +58,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'stable'
+        default: '1.92.2'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'

--- a/.github/workflows/lwcE2E.yml
+++ b/.github/workflows/lwcE2E.yml
@@ -6,7 +6,7 @@ on:
       automationBranch:
         description: 'Set the branch to use for automation tests'
         required: false
-        default: 'develop'
+        default: 'testesm'
         type: string
       debugLwcTests:
         description: 'Debug LWC Tests'
@@ -21,7 +21,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: '1.85.2'
+        default: '1.92.2'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -48,7 +48,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: '1.85.2'
+        default: '1.92.2'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'


### PR DESCRIPTION
### What does this PR do?
- Sets VSCode version for e2e tests to 1.92.2 while we figure out why they're failing for stable (1.93)

[skip-validate-pr]