### PR TITLE
fix(deps): bump to latest lightning-language-server @W-16625817@

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6668,11 +6668,11 @@
       }
     },
     "node_modules/@salesforce/aura-language-server": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-4.12.1.tgz",
-      "integrity": "sha512-q1zDHICtVspkR9bG7VX5DlHAPKTQT9e9UGjQHTZZ6vsUKt7b7T47Z5hklq3FCHFC4WDRzcxriJZiDcs6gkg6FA==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/aura-language-server/-/aura-language-server-4.12.2.tgz",
+      "integrity": "sha512-7wnvn4wiSIz8sAOH2uPPeQG7VsW0P4ylIe1ERBqXX+vQcD+egRJWpCqh6BW98gGDu59VF3pOvAJPAEVSk2WFRA==",
       "dependencies": {
-        "@salesforce/lightning-lsp-common": "4.12.1",
+        "@salesforce/lightning-lsp-common": "4.12.2",
         "acorn": "^6.0.0",
         "acorn-loose": "^6.0.0",
         "acorn-walk": "^6.0.0",
@@ -7068,9 +7068,9 @@
       "integrity": "sha512-/ZiVwtVkmq2jWRRzgsC4SEy8m54gPaDc8e+jIfnIiR04iSeSRhYJxG+ktLSYVN2jMbVWA58HfEJSCx+73GcQCg=="
     },
     "node_modules/@salesforce/lightning-lsp-common": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-4.12.1.tgz",
-      "integrity": "sha512-+bgRMAiqj0J5PDp52XfzsxdHwJ+sfE70rwJD7/+sqn4hKH7YQkXEgrGmfndHIzvgor0CCnXPtexAjNLdMaLA9Q==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/lightning-lsp-common/-/lightning-lsp-common-4.12.2.tgz",
+      "integrity": "sha512-Qp2vJmXh1X7rSatyZm+HubeMeQEtOqbNgoCijvsCPl7vgm4+W8hHyrHaFO9qgvMofAiCzkzimgJ/CiF9IOlsEA==",
       "dependencies": {
         "decamelize": "^2.0.0",
         "deep-equal": "^1.0.1",
@@ -7147,9 +7147,9 @@
       "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
     },
     "node_modules/@salesforce/lwc-language-server": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-4.12.1.tgz",
-      "integrity": "sha512-IR9faSXccH4BDjIbftk/oA0Dsz/3+K9SkvTNbaQ1IdB+axa5qMExmCNzsW8hTTiUpmreOCpTUEVl1Gu1FguUAQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/lwc-language-server/-/lwc-language-server-4.12.2.tgz",
+      "integrity": "sha512-0jQ1Hfto1sFKYHQvXt8A8QGY2n4tWJHS1o1753ae68IBlmoMyqLyY5Ay4u1AofHTDNiqvq+WGxBxztE39Wy3mw==",
       "dependencies": {
         "@lwc/compiler": "2.50.0",
         "@lwc/engine-dom": "2.50.0",
@@ -7159,7 +7159,7 @@
         "@lwc/template-compiler": "2.50.0",
         "@salesforce/apex": "0.0.12",
         "@salesforce/label": "0.0.12",
-        "@salesforce/lightning-lsp-common": "4.12.1",
+        "@salesforce/lightning-lsp-common": "4.12.2",
         "@salesforce/resourceurl": "0.0.12",
         "@salesforce/schema": "0.0.12",
         "@salesforce/user": "0.0.12",
@@ -34473,9 +34473,9 @@
       "version": "61.12.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/aura-language-server": "4.12.1",
+        "@salesforce/aura-language-server": "4.12.2",
         "@salesforce/core-bundle": "8.2.0",
-        "@salesforce/lightning-lsp-common": "4.12.1",
+        "@salesforce/lightning-lsp-common": "4.12.2",
         "@salesforce/salesforcedx-utils-vscode": "61.12.0",
         "applicationinsights": "1.0.7",
         "vscode-extension-telemetry": "0.0.17",
@@ -34659,8 +34659,8 @@
       "dependencies": {
         "@salesforce/core-bundle": "8.2.0",
         "@salesforce/eslint-config-lwc": "3.6.0",
-        "@salesforce/lightning-lsp-common": "4.12.1",
-        "@salesforce/lwc-language-server": "4.12.1",
+        "@salesforce/lightning-lsp-common": "4.12.2",
+        "@salesforce/lwc-language-server": "4.12.2",
         "@salesforce/salesforcedx-utils-vscode": "61.12.0",
         "ajv": "6.12.6",
         "applicationinsights": "1.0.7",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -24,9 +24,9 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/aura-language-server": "4.12.1",
+    "@salesforce/aura-language-server": "4.12.2",
     "@salesforce/core-bundle": "8.2.0",
-    "@salesforce/lightning-lsp-common": "4.12.1",
+    "@salesforce/lightning-lsp-common": "4.12.2",
     "@salesforce/salesforcedx-utils-vscode": "61.12.0",
     "applicationinsights": "1.0.7",
     "vscode-extension-telemetry": "0.0.17",
@@ -120,8 +120,8 @@
       ],
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "@salesforce/aura-language-server": "4.12.1",
-        "@salesforce/lightning-lsp-common": "4.12.1"
+        "@salesforce/aura-language-server": "4.12.2",
+        "@salesforce/lightning-lsp-common": "4.12.2"
       },
       "devDependencies": {}
     }

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -26,8 +26,8 @@
   "dependencies": {
     "@salesforce/core-bundle": "8.2.0",
     "@salesforce/eslint-config-lwc": "3.6.0",
-    "@salesforce/lightning-lsp-common": "4.12.1",
-    "@salesforce/lwc-language-server": "4.12.1",
+    "@salesforce/lightning-lsp-common": "4.12.2",
+    "@salesforce/lwc-language-server": "4.12.2",
     "@salesforce/salesforcedx-utils-vscode": "61.12.0",
     "ajv": "6.12.6",
     "applicationinsights": "1.0.7",
@@ -115,8 +115,8 @@
         "server.js"
       ],
       "dependencies": {
-        "@salesforce/lightning-lsp-common": "4.12.1",
-        "@salesforce/lwc-language-server": "4.12.1",
+        "@salesforce/lightning-lsp-common": "4.12.2",
+        "@salesforce/lwc-language-server": "4.12.2",
         "applicationinsights": "1.0.7"
       },
       "devDependencies": {}


### PR DESCRIPTION
### What does this PR do?
Bumps the versions of @salesforce/lightning-lsp-common, @salesforce/aura-language-server, and @salesforce/lwc-language-server to remove TypeScript-related files from the `.forceignore` for JS-only projects. See https://github.com/forcedotcom/lightning-language-server/pull/601 for details.

### What issues does this PR fix or reference?
@W-16625817@
