### PR TITLE
fix: show error message for push/pull when the error does not involve files

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/cli/parsers/projectDeployStartResultParser.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/parsers/projectDeployStartResultParser.ts
@@ -23,7 +23,7 @@ export type ProjectDeployStartErrorResponse = {
   message: string;
   name: string;
   status: number;
-  files: ProjectDeployStartResult[];
+  files?: ProjectDeployStartResult[];
   warnings: any[];
 };
 
@@ -49,14 +49,17 @@ export class ProjectDeployStartResultParser {
 
   public getErrors(): ProjectDeployStartErrorResponse | undefined {
     if (this.response.status === 1) {
+      const files = this.response.data ?? this.response.result?.files;
       return {
         message: this.response.message ?? 'Push failed. ',
         name: this.response.name ?? 'DeployFailed',
         status: this.response.status,
-        files: (this.response.data ?? this.response.result.files).filter(
-          (file: { state: string }) =>
-            file.state === 'Failed' || file.state === 'Conflict'
-        )
+        ...(files && {
+          files: files.filter(
+            (file: { state: string }) =>
+              file.state === 'Failed' || file.state === 'Conflict'
+          )
+        })
       } as ProjectDeployStartErrorResponse;
     }
   }

--- a/packages/salesforcedx-utils-vscode/src/cli/parsers/projectRetrieveStartResultParser.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/parsers/projectRetrieveStartResultParser.ts
@@ -23,7 +23,7 @@ export type ProjectRetrieveStartErrorResponse = {
   message: string;
   name: string;
   status: number;
-  files: ProjectRetrieveStartResult[];
+  files?: ProjectRetrieveStartResult[];
   warnings: any[];
 };
 
@@ -49,14 +49,18 @@ export class ProjectRetrieveStartResultParser {
 
   public getErrors(): ProjectRetrieveStartErrorResponse | undefined {
     if (this.response.status === 1) {
+      const files = this.response.data ?? this.response.result?.files;
+
       return {
         message: this.response.message ?? 'Pull failed. ',
         name: this.response.name ?? 'RetrieveFailed',
         status: this.response.status,
-        files: (this.response.data ?? this.response.result.files).filter(
-          (file: { state: string }) =>
-            file.state === 'Failed' || file.state === 'Conflict'
-        )
+        ...(files && {
+          files: files.filter(
+            (file: { state: string }) =>
+              file.state === 'Failed' || file.state === 'Conflict'
+          )
+        })
       } as ProjectRetrieveStartErrorResponse;
     }
   }

--- a/packages/salesforcedx-vscode-core/src/diagnostics/diagnostics.ts
+++ b/packages/salesforcedx-vscode-core/src/diagnostics/diagnostics.ts
@@ -55,7 +55,7 @@ export const handlePushDiagnosticErrors = (
 
   const diagnosticMap: Map<string, vscode.Diagnostic[]> = new Map();
   if (Reflect.has(errors, 'files')) {
-    errors.files.forEach(error => {
+    errors.files?.forEach(error => {
       const fileUri = getFileUri(
         workspacePath,
         error.filePath,

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/diagnostics/index.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/diagnostics/index.test.ts
@@ -63,7 +63,7 @@ describe('Diagnostics', () => {
       fullName: 'Testing'
     };
 
-    pushErrorResult.files.push(resultItem);
+    pushErrorResult.files?.push(resultItem);
 
     handlePushDiagnosticErrors(
       pushErrorResult,
@@ -106,8 +106,8 @@ describe('Diagnostics', () => {
       fullName: 'SomeController'
     };
 
-    pushErrorResult.files.push(resultItem1);
-    pushErrorResult.files.push(resultItem2);
+    pushErrorResult.files?.push(resultItem1);
+    pushErrorResult.files?.push(resultItem2);
 
     handlePushDiagnosticErrors(
       pushErrorResult,
@@ -158,7 +158,7 @@ describe('Diagnostics', () => {
       type: 'ApexClass'
     };
 
-    pushErrorResult.files.push(resultItem);
+    pushErrorResult.files?.push(resultItem);
     handlePushDiagnosticErrors(
       pushErrorResult,
       workspacePath,
@@ -193,8 +193,8 @@ describe('Diagnostics', () => {
       filePath: 'N/A'
     };
 
-    pushErrorResult.files.push(resultItem1);
-    pushErrorResult.files.push(resultItem2);
+    pushErrorResult.files?.push(resultItem1);
+    pushErrorResult.files?.push(resultItem2);
     handlePushDiagnosticErrors(
       pushErrorResult,
       workspacePath,


### PR DESCRIPTION
### What does this PR do?
- Shows error message for push/pull when the error is not related to files

### Functionality Before
- no error message and command kept running forever
![image](https://github.com/user-attachments/assets/c45299a8-c65d-4595-abd4-d6f13ae96c35)


### Functionality After
- Error message displayed and no infinite notification for running push/pull
<img width="1395" alt="image" src="https://github.com/user-attachments/assets/df035fbc-dd70-42dd-af77-06ac59e04fd7">

[skip-validate-pr]


