### PR TITLE
chore: close stale issues workflow should include issues with 'waiting for user' tag

### DIFF
--- a/.github/workflows/closeStaleIssues.yml
+++ b/.github/workflows/closeStaleIssues.yml
@@ -26,4 +26,4 @@ jobs:
           close-issue-reason: not_planned
           operations-per-run: 100
           exempt-issue-labels: announcement,bug,on hold,waiting for internal reply,feature
-          any-of-labels: more information required,missing required information
+          any-of-labels: more information required,missing required information,waiting for user


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Close Stale Issues GHA workflow checks for issues tagged with `waiting for user`.

### What issues does this PR fix or reference?
[skip-validate-pr]

### Functionality Before
Issues tagged with `waiting for user` are not automatically closed.

### Functionality After
Issues tagged with `waiting for user` are automatically closed after 5 days of inactivity.
