### PR TITLE
chore: use macos-latest in runE2ETest.yml

### DIFF
--- a/.github/workflows/runE2ETest.yml
+++ b/.github/workflows/runE2ETest.yml
@@ -23,7 +23,7 @@ on:
       os:
         description: 'Operating System(s) to run the E2E tests on'
         required: false
-        default: '["macos-12", "ubuntu-latest", "windows-latest"]'
+        default: '["macos-latest", "ubuntu-latest", "windows-latest"]'
         type: string
 
 jobs:


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Updates runE2ETest.yml to run E2E tests on macos-latest instead of macos-12.

### What issues does this PR fix or reference?
[skip-validate-pr]

### Functionality Before
Mac E2E tests run on macos-12.

### Functionality After
Mac E2E tests run on macos-latest.

E2E test run: https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/11073776789 ✅ 
