### PR TITLE
chore: skip mdDeployRetrieve if vscodeVersion is not 1.92.2

### DIFF
--- a/.github/workflows/deployRetrieveE2E.yml
+++ b/.github/workflows/deployRetrieveE2E.yml
@@ -145,9 +145,9 @@ jobs:
       testToRun: 'pushAndPull.e2e.ts'
       vscodeVersion: ${{ inputs.vscodeVersion }}
       runId: ${{ inputs.runId }}
-  
+
   mdDeployRetrieve:
-    if: ${{ inputs.mdDeployRetrieve }}
+    if: ${{ inputs.mdDeployRetrieve && inputs.vscodeVersion == '1.92.2'}}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:


### PR DESCRIPTION
### What does this PR do?
- Skips mdDeployRetrieve e2e test if vscodeVersion is not 1.92.2

[skip-validate-pr]