### PR TITLE
chore: disable mddeployretrieve test on macos

### DIFF
--- a/.github/workflows/deployRetrieveE2E.yml
+++ b/.github/workflows/deployRetrieveE2E.yml
@@ -155,6 +155,7 @@ jobs:
       testToRun: 'metadataDeployRetrieve.e2e.ts'
       vscodeVersion: ${{ inputs.vscodeVersion }}
       runId: ${{ inputs.runId }}
+      os: '["ubuntu-latest", "windows-latest"]'
 
   slack_success_notification:
     if: ${{ success() }}


### PR DESCRIPTION
### What does this PR do?
- Skips mdDeployRetrieve e2e test on macos
[skip-validate-pr]