### PR TITLE
feat!: bump major version and bundle deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6113,22 +6113,23 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.0.8.tgz",
-      "integrity": "sha512-9AzNoRlKfIeuqOin+HK9cyouELeup7sX+MGIFc5dR+bnG0sSzFnV1A/Z57E7KWrY5NdWULHYT5NhiL1YpEhG2w==",
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.0.27.tgz",
+      "integrity": "sha512-9j92jHr6k2tjQ6/mIwNi46Gqw+qbPFQ02mxT5T8/nxO2fgsPL3qL0kb9SR1il5AVfqpgLIG3uLUcw87rgaioUg==",
       "dependencies": {
         "ansi-escapes": "^4.3.2",
-        "ansis": "^3.1.1",
+        "ansis": "^3.3.2",
         "clean-stack": "^3.0.1",
         "cli-spinners": "^2.9.2",
-        "debug": "^4.3.5",
+        "debug": "^4.3.7",
         "ejs": "^3.1.10",
         "get-package-type": "^0.1.0",
         "globby": "^11.1.0",
         "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
+        "is-wsl": "^3",
         "lilconfig": "^3.1.2",
         "minimatch": "^9.0.5",
+        "semver": "^7.6.3",
         "string-width": "^4.2.3",
         "supports-color": "^8",
         "widest-line": "^3.1.0",
@@ -6137,6 +6138,113 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/clean-stack": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
+      "integrity": "sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==",
+      "dependencies": {
+        "escape-string-regexp": "4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@oclif/core/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/@oclif/core/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -6363,13 +6471,13 @@
       "integrity": "sha512-L4zUDy4lxF7+mM7DYPfOKZ4lqiAIquRx0vHAUJMBaxD4bCiT+70Df++aOfGO9FOJNctvPtT5bLrFRfdos4y4Mg=="
     },
     "node_modules/@salesforce/apex-node-bundle": {
-      "version": "8.1.7",
-      "resolved": "https://registry.npmjs.org/@salesforce/apex-node-bundle/-/apex-node-bundle-8.1.7.tgz",
-      "integrity": "sha512-HFAAhlAk6YH85J3nkLSURnbaDYj8ap1UGUuNXF4+D1P5V3PJkg5mDs/fbrHKSNEl1Jhor/xOTsCm3q6+T/pISA==",
+      "version": "8.1.12",
+      "resolved": "https://registry.npmjs.org/@salesforce/apex-node-bundle/-/apex-node-bundle-8.1.12.tgz",
+      "integrity": "sha512-5CjGk4vor61r47qTGu7RdnF9sKXazdDtVwrGhYrCFvjN3i9tg4kNJBRCubgkxyU7CoPEvyPWg9qzkg1FZGQ3MQ==",
       "dependencies": {
-        "@jsforce/jsforce-node": "^3.4.1",
-        "@salesforce/core-bundle": "^8.5.5",
-        "@salesforce/kit": "^3.2.2",
+        "@jsforce/jsforce-node": "^3.5.1",
+        "@salesforce/core-bundle": "^8.6.1",
+        "@salesforce/kit": "^3.2.3",
         "@types/istanbul-reports": "^3.0.4",
         "bfj": "8.0.0",
         "fast-glob": "^3.3.2",
@@ -6380,6 +6488,27 @@
       },
       "engines": {
         "node": ">=18.18.2"
+      }
+    },
+    "node_modules/@salesforce/apex-node-bundle/node_modules/@jsforce/jsforce-node": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@jsforce/jsforce-node/-/jsforce-node-3.5.1.tgz",
+      "integrity": "sha512-P+pfsLL6AddDeBP3iswjlB1+YM4w2ZsWTqunGjMA0/Aj8Jt4gA+XycV+fGEbGzsm6DvSvbZUnyrfkRYNsT9F8Q==",
+      "dependencies": {
+        "@sindresorhus/is": "^4",
+        "base64url": "^3.0.1",
+        "csv-parse": "^5.5.2",
+        "csv-stringify": "^6.4.4",
+        "faye": "^1.4.0",
+        "form-data": "^4.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "multistream": "^3.1.0",
+        "node-fetch": "^2.6.1",
+        "strip-ansi": "^6.0.0",
+        "xml2js": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@salesforce/apex-node-bundle/node_modules/faye": {
@@ -6396,6 +6525,29 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@salesforce/apex-node-bundle/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@salesforce/apex-node-bundle/node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/@salesforce/apex-tmlanguage": {
@@ -6483,9 +6635,9 @@
       "integrity": "sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww=="
     },
     "node_modules/@salesforce/core-bundle": {
-      "version": "8.5.7",
-      "resolved": "https://registry.npmjs.org/@salesforce/core-bundle/-/core-bundle-8.5.7.tgz",
-      "integrity": "sha512-T19+BuJqAMY7pintTv/SjSvqmGtZrvvrr+njWMpbKUgQLreHIBs3EiV/CACgU89CLsBbBEw2jGBamvcKvULqPw==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/core-bundle/-/core-bundle-8.6.1.tgz",
+      "integrity": "sha512-5viFsuezC2jGIzrmlOieeN7/E2w9WbC+skgfD1JVPU8wV9XNdoFrCunMRsWfx28MMo33pG9eXiZc1u9tWY04aw==",
       "dependencies": {
         "@jsforce/jsforce-node": "^3.4.1",
         "@salesforce/kit": "^3.2.2",
@@ -7187,15 +7339,15 @@
       }
     },
     "node_modules/@salesforce/source-deploy-retrieve-bundle": {
-      "version": "12.6.3",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve-bundle/-/source-deploy-retrieve-bundle-12.6.3.tgz",
-      "integrity": "sha512-FwuMS6Xox52O2g8/KwWw5osW+SHiUBUaq9ksAvy/to7J0PGAJYIyQjIKzBo1eQIBF15AR/ruKj1LilcgMznWVg==",
+      "version": "12.7.4",
+      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve-bundle/-/source-deploy-retrieve-bundle-12.7.4.tgz",
+      "integrity": "sha512-pVurxCiwuL5jMNW7UjB4idYvubU1sh3Pb3zOx3mgU3vCCmH4O1DsFTTlYmQy2FLk0hnNGtLYbBmlEtsfQXpLCQ==",
       "dependencies": {
-        "@salesforce/core-bundle": "^8.5.4",
+        "@salesforce/core-bundle": "^8.6.1",
         "@salesforce/kit": "^3.2.2",
         "@salesforce/ts-types": "^2.0.12",
         "fast-levenshtein": "^3.0.0",
-        "fast-xml-parser": "^4.4.1",
+        "fast-xml-parser": "^4.5.0",
         "got": "^11.8.6",
         "graceful-fs": "^4.2.11",
         "ignore": "^5.3.2",
@@ -7232,18 +7384,18 @@
       }
     },
     "node_modules/@salesforce/source-tracking-bundle": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-tracking-bundle/-/source-tracking-bundle-7.0.6.tgz",
-      "integrity": "sha512-tCkp7S6r77vBZdT0TWCVBnHCqT7CO8/4a51PxtGKy3O7EmP5sqrru2H44N4BT6FEn39uTA+tP1Cu+U6QbhA01g==",
+      "version": "7.1.17",
+      "resolved": "https://registry.npmjs.org/@salesforce/source-tracking-bundle/-/source-tracking-bundle-7.1.17.tgz",
+      "integrity": "sha512-bidkL9Gz+BJHGZ5EFRPD7+Pxo/7NPqpS7DFfMYnJbLFUVa09H4uQzfiU+f9sX8g7LZeVfhjfpp5htDfvOz7xAQ==",
       "dependencies": {
-        "@oclif/core": "^4.0.8",
-        "@salesforce/core-bundle": "^8.1.1",
-        "@salesforce/kit": "^3.1.6",
-        "@salesforce/source-deploy-retrieve-bundle": "^12.1.5",
-        "@salesforce/ts-types": "^2.0.10",
-        "fast-xml-parser": "^4.4.0",
+        "@oclif/core": "^4.0.23",
+        "@salesforce/core-bundle": "^8.6.1",
+        "@salesforce/kit": "^3.2.3",
+        "@salesforce/source-deploy-retrieve-bundle": "^12.7.4",
+        "@salesforce/ts-types": "^2.0.12",
+        "fast-xml-parser": "^4.5.0",
         "graceful-fs": "^4.2.11",
-        "isomorphic-git": "^1.25.10",
+        "isomorphic-git": "^1.27.1",
         "ts-retry-promise": "^0.8.1"
       },
       "engines": {
@@ -7251,19 +7403,19 @@
       }
     },
     "node_modules/@salesforce/source-tracking-bundle/node_modules/@salesforce/ts-types": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.10.tgz",
-      "integrity": "sha512-ulGQ1oUGXrmSUi6NGbxZZ7ykSDv439x+WYZpkMgFLC8Dx0TxJXfUAJYeZh7eKO5xI/ob3iyvN+RBcBkp4KFN1w==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.12.tgz",
+      "integrity": "sha512-BIJyduJC18Kc8z+arUm5AZ9VkPRyw1KKAm+Tk+9LT99eOzhNilyfKzhZ4t+tG2lIGgnJpmytZfVDZ0e2kFul8g==",
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@salesforce/templates": {
-      "version": "61.4.10",
-      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-61.4.10.tgz",
-      "integrity": "sha512-89MbXZ+Y+LsThO72F2OYqq8GPXEhPKE+ptLyBxObKE+3FgDEhFDsU2Va5sEVLye/2Z7o95jTFEgfkALs/ILXKg==",
+      "version": "62.0.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-62.0.1.tgz",
+      "integrity": "sha512-hLtWJaWNt4yWZSQgIpEt4eJ5P8Llr/GVRFSKfOPtFkBxqquj2qDlWWvXz+KkEc35vxUguAfX+xEddOQgrT0QVQ==",
       "dependencies": {
-        "@salesforce/kit": "^3.2.2",
+        "@salesforce/kit": "^3.2.3",
         "ejs": "^3.1.10",
         "got": "^11.8.2",
         "hpagent": "^1.2.0",
@@ -9178,9 +9330,9 @@
       }
     },
     "node_modules/ansis": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.2.0.tgz",
-      "integrity": "sha512-Yk3BkHH9U7oPyCN3gL5Tc7CpahG/+UFv/6UG03C311Vy9lzRmA5uoxDTpU9CO3rGHL6KzJz/pdDeXZCZ5Mu/Sg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.3.2.tgz",
+      "integrity": "sha512-cFthbBlt+Oi0i9Pv/j6YdVWJh54CtjGACaMPCIrEV4Ha7HWsIjXDwseYV79TIL0B4+KfSwD5S70PeQDkPUd1rA==",
       "engines": {
         "node": ">=15"
       }
@@ -10674,6 +10826,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -10694,6 +10847,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
       "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       },
@@ -17271,6 +17425,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -17315,6 +17470,37 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-interactive": {
@@ -17593,6 +17779,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -17645,9 +17832,9 @@
       }
     },
     "node_modules/isomorphic-git": {
-      "version": "1.25.10",
-      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.25.10.tgz",
-      "integrity": "sha512-IxGiaKBwAdcgBXwIcxJU6rHLk+NrzYaaPKXXQffcA0GW3IUrQXdUPDXDo+hkGVcYruuz/7JlGBiuaeTCgIgivQ==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.27.1.tgz",
+      "integrity": "sha512-X32ph5zIWfT75QAqW2l3JCIqnx9/GWd17bRRehmn3qmWc34OYbSXY6Cxv0o9bIIY+CWugoN4nQFHNA+2uYf2nA==",
       "dependencies": {
         "async-lock": "^1.4.1",
         "clean-git-ref": "^2.0.1",
@@ -21710,6 +21897,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.2.0.tgz",
       "integrity": "sha512-sauLxniAmvnhhRjFwPNnJKaPFYyddAgbYdeUpHULtCT/GhzdCx/MDNy+Y40lBxTQUrMzDE8e0S43Z5uqfO0REg==",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -32969,10 +33157,10 @@
     },
     "packages/salesforcedx-apex-debugger": {
       "name": "@salesforce/salesforcedx-apex-debugger",
-      "version": "61.17.0",
+      "version": "62.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/salesforcedx-utils": "61.17.0",
+        "@salesforce/salesforcedx-utils": "62.0.0",
         "@vscode/debugadapter": "1.65.0",
         "@vscode/debugprotocol": "1.65.0",
         "async-lock": "1.0.0",
@@ -32980,7 +33168,7 @@
         "request-light": "^0.7.0"
       },
       "devDependencies": {
-        "@salesforce/salesforcedx-test-utils-vscode": "61.17.0",
+        "@salesforce/salesforcedx-test-utils-vscode": "62.0.0",
         "@types/async-lock": "0.0.20",
         "@types/chai": "4.3.3",
         "@types/jest": "^29.5.5",
@@ -33027,10 +33215,10 @@
     },
     "packages/salesforcedx-apex-replay-debugger": {
       "name": "@salesforce/salesforcedx-apex-replay-debugger",
-      "version": "61.17.0",
+      "version": "62.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/salesforcedx-utils": "61.17.0",
+        "@salesforce/salesforcedx-utils": "62.0.0",
         "@vscode/debugadapter": "1.65.0",
         "@vscode/debugprotocol": "1.65.0",
         "vscode-uri": "1.0.1"
@@ -33077,12 +33265,12 @@
     },
     "packages/salesforcedx-sobjects-faux-generator": {
       "name": "@salesforce/salesforcedx-sobjects-faux-generator",
-      "version": "61.17.0",
+      "version": "62.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jsforce/jsforce-node": "3.4.1",
-        "@salesforce/core-bundle": "8.5.7",
-        "@salesforce/salesforcedx-utils-vscode": "61.17.0",
+        "@salesforce/core-bundle": "8.6.1",
+        "@salesforce/salesforcedx-utils-vscode": "62.0.0",
         "shelljs": "0.8.5"
       },
       "devDependencies": {
@@ -33138,10 +33326,10 @@
     },
     "packages/salesforcedx-test-utils-vscode": {
       "name": "@salesforce/salesforcedx-test-utils-vscode",
-      "version": "61.17.0",
+      "version": "62.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/salesforcedx-utils-vscode": "61.17.0",
+        "@salesforce/salesforcedx-utils-vscode": "62.0.0",
         "shelljs": "0.8.5"
       },
       "devDependencies": {
@@ -33235,7 +33423,7 @@
     },
     "packages/salesforcedx-utils": {
       "name": "@salesforce/salesforcedx-utils",
-      "version": "61.17.0",
+      "version": "62.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "cross-spawn": "7.0.3",
@@ -33265,12 +33453,12 @@
     },
     "packages/salesforcedx-utils-vscode": {
       "name": "@salesforce/salesforcedx-utils-vscode",
-      "version": "61.17.0",
+      "version": "62.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core-bundle": "8.5.7",
-        "@salesforce/source-deploy-retrieve-bundle": "12.6.3",
-        "@salesforce/source-tracking-bundle": "7.0.6",
+        "@salesforce/core-bundle": "8.6.1",
+        "@salesforce/source-deploy-retrieve-bundle": "12.7.4",
+        "@salesforce/source-tracking-bundle": "7.1.17",
         "@salesforce/vscode-service-provider": "1.2.1",
         "applicationinsights": "1.0.7",
         "cross-spawn": "7.0.3",
@@ -33371,10 +33559,10 @@
     },
     "packages/salesforcedx-visualforce-language-server": {
       "name": "@salesforce/salesforcedx-visualforce-language-server",
-      "version": "61.17.0",
+      "version": "62.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/salesforcedx-visualforce-markup-language-server": "61.17.0",
+        "@salesforce/salesforcedx-visualforce-markup-language-server": "62.0.0",
         "typescript": "^5.2.2",
         "vscode-css-languageservice": "2.1.9",
         "vscode-languageserver": "5.2.1",
@@ -33409,7 +33597,7 @@
     },
     "packages/salesforcedx-visualforce-markup-language-server": {
       "name": "@salesforce/salesforcedx-visualforce-markup-language-server",
-      "version": "61.17.0",
+      "version": "62.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "vscode-languageserver-types": "3.4.0",
@@ -33460,20 +33648,20 @@
       "integrity": "sha512-nB56YeA3cStjwWT2WJJUifWh3e4FxEwN4aIr3EKV3DOt6WPSrBAtotKJhvoOrCcqsHDZofNy6gg9d1KvsqbdhA=="
     },
     "packages/salesforcedx-vscode": {
-      "version": "61.17.0",
+      "version": "62.0.0",
       "license": "BSD-3-Clause",
       "engines": {
         "vscode": "^1.86.0"
       }
     },
     "packages/salesforcedx-vscode-apex": {
-      "version": "61.17.0",
+      "version": "62.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/apex-node-bundle": "8.1.7",
+        "@salesforce/apex-node-bundle": "8.1.12",
         "@salesforce/apex-tmlanguage": "1.8.0",
-        "@salesforce/core-bundle": "8.5.7",
-        "@salesforce/salesforcedx-utils-vscode": "61.17.0",
+        "@salesforce/core-bundle": "8.6.1",
+        "@salesforce/salesforcedx-utils-vscode": "62.0.0",
         "@salesforce/vscode-service-provider": "1.2.1",
         "expand-home-dir": "0.0.3",
         "find-java-home": "0.2.0",
@@ -33482,7 +33670,7 @@
         "vscode-languageclient": "8.1.0"
       },
       "devDependencies": {
-        "@salesforce/salesforcedx-test-utils-vscode": "61.17.0",
+        "@salesforce/salesforcedx-test-utils-vscode": "62.0.0",
         "@salesforce/ts-sinon": "1.4.0",
         "@types/chai": "4.3.3",
         "@types/mocha": "^5",
@@ -33515,16 +33703,16 @@
       }
     },
     "packages/salesforcedx-vscode-apex-debugger": {
-      "version": "61.17.0",
+      "version": "62.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/salesforcedx-apex-debugger": "61.17.0",
-        "@salesforce/salesforcedx-utils-vscode": "61.17.0",
+        "@salesforce/salesforcedx-apex-debugger": "62.0.0",
+        "@salesforce/salesforcedx-utils-vscode": "62.0.0",
         "@vscode/debugprotocol": "1.65.0",
         "vscode-extension-telemetry": "0.0.17"
       },
       "devDependencies": {
-        "@salesforce/salesforcedx-test-utils-vscode": "61.17.0",
+        "@salesforce/salesforcedx-test-utils-vscode": "62.0.0",
         "@types/chai": "4.3.3",
         "@types/mocha": "^5",
         "@types/node": "^18.11.9",
@@ -33638,20 +33826,20 @@
       }
     },
     "packages/salesforcedx-vscode-apex-replay-debugger": {
-      "version": "61.17.0",
+      "version": "62.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/apex-node-bundle": "8.1.7",
-        "@salesforce/core-bundle": "8.5.7",
-        "@salesforce/salesforcedx-apex-replay-debugger": "61.17.0",
-        "@salesforce/salesforcedx-utils": "61.17.0",
-        "@salesforce/salesforcedx-utils-vscode": "61.17.0",
+        "@salesforce/apex-node-bundle": "8.1.12",
+        "@salesforce/core-bundle": "8.6.1",
+        "@salesforce/salesforcedx-apex-replay-debugger": "62.0.0",
+        "@salesforce/salesforcedx-utils": "62.0.0",
+        "@salesforce/salesforcedx-utils-vscode": "62.0.0",
         "async-lock": "1.0.0",
         "request-light": "^0.7.0",
         "vscode-extension-telemetry": "0.0.17"
       },
       "devDependencies": {
-        "@salesforce/salesforcedx-test-utils-vscode": "61.17.0",
+        "@salesforce/salesforcedx-test-utils-vscode": "62.0.0",
         "@salesforce/ts-sinon": "1.4.0",
         "@types/async-lock": "0.0.20",
         "@types/chai": "4.3.3",
@@ -33908,16 +34096,16 @@
       "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
     },
     "packages/salesforcedx-vscode-core": {
-      "version": "61.17.0",
+      "version": "62.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jsforce/jsforce-node": "3.4.1",
-        "@salesforce/core-bundle": "8.5.7",
-        "@salesforce/salesforcedx-sobjects-faux-generator": "61.17.0",
-        "@salesforce/salesforcedx-utils-vscode": "61.17.0",
+        "@salesforce/core-bundle": "8.6.1",
+        "@salesforce/salesforcedx-sobjects-faux-generator": "62.0.0",
+        "@salesforce/salesforcedx-utils-vscode": "62.0.0",
         "@salesforce/schemas": "1.9.0",
-        "@salesforce/source-deploy-retrieve-bundle": "12.6.3",
-        "@salesforce/templates": "61.4.10",
+        "@salesforce/source-deploy-retrieve-bundle": "12.7.4",
+        "@salesforce/templates": "62.0.1",
         "@salesforce/ts-types": "2.0.12",
         "@salesforce/vscode-service-provider": "1.2.1",
         "adm-zip": "0.5.10",
@@ -33928,7 +34116,7 @@
         "shelljs": "0.8.5"
       },
       "devDependencies": {
-        "@salesforce/salesforcedx-test-utils-vscode": "61.17.0",
+        "@salesforce/salesforcedx-test-utils-vscode": "62.0.0",
         "@salesforce/ts-sinon": "^1.0.0",
         "@types/adm-zip": "^0.5.0",
         "@types/chai": "4.3.3",
@@ -34151,26 +34339,26 @@
       }
     },
     "packages/salesforcedx-vscode-expanded": {
-      "version": "61.17.0",
+      "version": "62.0.0",
       "license": "BSD-3-Clause",
       "engines": {
         "vscode": "^1.86.0"
       }
     },
     "packages/salesforcedx-vscode-lightning": {
-      "version": "61.17.0",
+      "version": "62.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/aura-language-server": "4.12.2",
-        "@salesforce/core-bundle": "8.5.7",
+        "@salesforce/core-bundle": "8.6.1",
         "@salesforce/lightning-lsp-common": "4.12.2",
-        "@salesforce/salesforcedx-utils-vscode": "61.17.0",
+        "@salesforce/salesforcedx-utils-vscode": "62.0.0",
         "applicationinsights": "1.0.7",
         "vscode-extension-telemetry": "0.0.17",
         "vscode-languageclient": "^5.2.1"
       },
       "devDependencies": {
-        "@salesforce/salesforcedx-test-utils-vscode": "61.17.0",
+        "@salesforce/salesforcedx-test-utils-vscode": "62.0.0",
         "@types/chai": "4.3.3",
         "@types/mocha": "^5",
         "@types/node": "^18.11.9",
@@ -34342,14 +34530,14 @@
       }
     },
     "packages/salesforcedx-vscode-lwc": {
-      "version": "61.17.0",
+      "version": "62.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core-bundle": "8.5.7",
+        "@salesforce/core-bundle": "8.6.1",
         "@salesforce/eslint-config-lwc": "3.6.0",
         "@salesforce/lightning-lsp-common": "4.12.2",
         "@salesforce/lwc-language-server": "4.12.2",
-        "@salesforce/salesforcedx-utils-vscode": "61.17.0",
+        "@salesforce/salesforcedx-utils-vscode": "62.0.0",
         "ajv": "6.12.6",
         "applicationinsights": "1.0.7",
         "jest-editor-support": "^30.1.0",
@@ -34361,7 +34549,7 @@
         "vscode-languageclient": "^5.2.1"
       },
       "devDependencies": {
-        "@salesforce/salesforcedx-test-utils-vscode": "61.17.0",
+        "@salesforce/salesforcedx-test-utils-vscode": "62.0.0",
         "@types/chai": "4.3.3",
         "@types/mocha": "^5",
         "@types/node": "^18.11.9",
@@ -34544,21 +34732,21 @@
       "dev": true
     },
     "packages/salesforcedx-vscode-soql": {
-      "version": "61.17.0",
+      "version": "62.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jsforce/jsforce-node": "3.4.1",
         "@salesforce/apex-tmlanguage": "1.6.0",
-        "@salesforce/core-bundle": "8.5.7",
+        "@salesforce/core-bundle": "8.6.1",
         "@salesforce/soql-builder-ui": "1.0.0",
         "@salesforce/soql-data-view": "0.1.0",
         "@salesforce/soql-language-server": "0.7.1",
         "@salesforce/soql-model": "1.0.0"
       },
       "devDependencies": {
-        "@salesforce/salesforcedx-sobjects-faux-generator": "61.17.0",
-        "@salesforce/salesforcedx-test-utils-vscode": "61.17.0",
-        "@salesforce/salesforcedx-utils-vscode": "61.17.0",
+        "@salesforce/salesforcedx-sobjects-faux-generator": "62.0.0",
+        "@salesforce/salesforcedx-test-utils-vscode": "62.0.0",
+        "@salesforce/salesforcedx-utils-vscode": "62.0.0",
         "@salesforce/soql-common": "0.2.1",
         "@salesforce/ts-sinon": "1.4.0",
         "@salesforce/ts-types": "2.0.12",
@@ -35271,18 +35459,18 @@
       "dev": true
     },
     "packages/salesforcedx-vscode-visualforce": {
-      "version": "61.17.0",
+      "version": "62.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/salesforcedx-visualforce-language-server": "61.17.0",
-        "@salesforce/salesforcedx-visualforce-markup-language-server": "61.17.0",
+        "@salesforce/salesforcedx-visualforce-language-server": "62.0.0",
+        "@salesforce/salesforcedx-visualforce-markup-language-server": "62.0.0",
         "vscode-extension-telemetry": "0.0.17",
         "vscode-languageclient": "5.2.1",
         "vscode-languageserver-protocol": "3.14.1",
         "vscode-languageserver-types": "3.14.0"
       },
       "devDependencies": {
-        "@salesforce/salesforcedx-test-utils-vscode": "61.17.0",
+        "@salesforce/salesforcedx-test-utils-vscode": "62.0.0",
         "@types/chai": "4.3.3",
         "@types/mocha": "^5",
         "@types/node": "^18.11.9",
@@ -35336,11 +35524,11 @@
       }
     },
     "packages/system-tests": {
-      "version": "61.17.0",
+      "version": "62.0.0",
       "license": "BSD-3-Clause",
       "devDependencies": {
-        "@salesforce/salesforcedx-test-utils-vscode": "61.17.0",
-        "@salesforce/salesforcedx-utils-vscode": "61.17.0",
+        "@salesforce/salesforcedx-test-utils-vscode": "62.0.0",
+        "@salesforce/salesforcedx-utils-vscode": "62.0.0",
         "@types/chai": "4.3.3",
         "@types/mocha": "^5",
         "@types/node": "^18.11.9",

--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -2,7 +2,7 @@
   "name": "@salesforce/salesforcedx-apex-debugger",
   "displayName": "Apex Debugger Adapter",
   "description": "Implements the VS Code Debug Protocol for the Apex Debugger",
-  "version": "61.17.0",
+  "version": "62.0.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -12,7 +12,7 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-utils": "61.17.0",
+    "@salesforce/salesforcedx-utils": "62.0.0",
     "@vscode/debugadapter": "1.65.0",
     "@vscode/debugprotocol": "1.65.0",
     "async-lock": "1.0.0",
@@ -20,7 +20,7 @@
     "request-light": "^0.7.0"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "61.17.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "62.0.0",
     "@types/async-lock": "0.0.20",
     "@types/chai": "4.3.3",
     "@types/jest": "^29.5.5",

--- a/packages/salesforcedx-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-apex-replay-debugger/package.json
@@ -2,7 +2,7 @@
   "name": "@salesforce/salesforcedx-apex-replay-debugger",
   "displayName": "Apex Replay Debug Adapter",
   "description": "Implements the VS Code Debug Protocol for the Apex Replay Debugger",
-  "version": "61.17.0",
+  "version": "62.0.0",
   "publisher": "salesforce",
   "preview": true,
   "license": "BSD-3-Clause",
@@ -13,7 +13,7 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-utils": "61.17.0",
+    "@salesforce/salesforcedx-utils": "62.0.0",
     "@vscode/debugadapter": "1.65.0",
     "@vscode/debugprotocol": "1.65.0",
     "vscode-uri": "1.0.1"

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -2,7 +2,7 @@
   "name": "@salesforce/salesforcedx-sobjects-faux-generator",
   "displayName": "Salesforce SObject Faux Generator",
   "description": "Fetches sobjects and generates their faux apex class to be used for Apex Language Server",
-  "version": "61.17.0",
+  "version": "62.0.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -11,8 +11,8 @@
   "main": "out/src",
   "dependencies": {
     "@jsforce/jsforce-node": "3.4.1",
-    "@salesforce/core-bundle": "8.5.7",
-    "@salesforce/salesforcedx-utils-vscode": "61.17.0",
+    "@salesforce/core-bundle": "8.6.1",
+    "@salesforce/salesforcedx-utils-vscode": "62.0.0",
     "shelljs": "0.8.5"
   },
   "devDependencies": {

--- a/packages/salesforcedx-test-utils-vscode/package.json
+++ b/packages/salesforcedx-test-utils-vscode/package.json
@@ -2,14 +2,14 @@
   "name": "@salesforce/salesforcedx-test-utils-vscode",
   "displayName": "SFDX Test Utilities for VS Code",
   "description": "Provides test utilities to interface the SFDX libraries with VS Code",
-  "version": "61.17.0",
+  "version": "62.0.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "categories": [
     "Other"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-utils-vscode": "61.17.0",
+    "@salesforce/salesforcedx-utils-vscode": "62.0.0",
     "shelljs": "0.8.5"
   },
   "devDependencies": {

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "@salesforce/salesforcedx-utils-vscode",
   "displayName": "SFDX Utilities for VS Code",
   "description": "Provides utilities to interface the SFDX libraries with VS Code",
-  "version": "61.17.0",
+  "version": "62.0.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "categories": [
@@ -10,9 +10,9 @@
   ],
   "main": "out/src",
   "dependencies": {
-    "@salesforce/core-bundle": "8.5.7",
-    "@salesforce/source-deploy-retrieve-bundle": "12.6.3",
-    "@salesforce/source-tracking-bundle": "7.0.6",
+    "@salesforce/core-bundle": "8.6.1",
+    "@salesforce/source-deploy-retrieve-bundle": "12.7.4",
+    "@salesforce/source-tracking-bundle": "7.1.17",
     "@salesforce/vscode-service-provider": "1.2.1",
     "applicationinsights": "1.0.7",
     "cross-spawn": "7.0.3",

--- a/packages/salesforcedx-utils-vscode/test/jest/context/workspaceContextUtil.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/context/workspaceContextUtil.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthInfo, Connection, StateAggregator } from '@salesforce/core-bundle';
+import { AuthInfo, Connection, EnvVars, StateAggregator } from '@salesforce/core-bundle';
 import * as vscode from 'vscode';
 import {
   ConfigAggregatorProvider,
@@ -45,6 +45,10 @@ jest.mock('@salesforce/core-bundle', () => {
 
     Connection: {
       create: jest.fn()
+    },
+    envVars:
+    {
+      getNumber: jest.fn()
     }
   };
 });

--- a/packages/salesforcedx-utils-vscode/test/jest/context/workspaceContextUtil.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/context/workspaceContextUtil.test.ts
@@ -63,7 +63,7 @@ describe('WorkspaceContextUtil', () => {
   const dummyOrgId = '000dummyOrgId';
   const dummyOrgId2 = '000dummyOrgId2';
   const context = {
-    subscriptions: []
+    subscriptions: [] as vscode.Disposable[]
   };
 
   let getUsernameStub: jest.SpyInstance;

--- a/packages/salesforcedx-utils/package.json
+++ b/packages/salesforcedx-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/salesforcedx-utils",
   "displayName": "Node Utilities for VS Code",
-  "version": "61.17.0",
+  "version": "62.0.0",
   "description": "Provides node specific utilities for the Salesforce VSCode extensions",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",

--- a/packages/salesforcedx-visualforce-language-server/package.json
+++ b/packages/salesforcedx-visualforce-language-server/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@salesforce/salesforcedx-visualforce-language-server",
   "description": "Visualforce language server",
-  "version": "61.17.0",
+  "version": "62.0.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
     "vscode": "^1.86.0"
   },
   "dependencies": {
-    "@salesforce/salesforcedx-visualforce-markup-language-server": "61.17.0",
+    "@salesforce/salesforcedx-visualforce-markup-language-server": "62.0.0",
     "typescript": "^5.2.2",
     "vscode-css-languageservice": "2.1.9",
     "vscode-languageserver": "5.2.1",

--- a/packages/salesforcedx-visualforce-markup-language-server/package.json
+++ b/packages/salesforcedx-visualforce-markup-language-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/salesforcedx-visualforce-markup-language-server",
   "description": "Language service for Visualforce Markup",
-  "version": "61.17.0",
+  "version": "62.0.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "61.17.0",
+  "version": "62.0.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -24,13 +24,13 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-apex-debugger": "61.17.0",
-    "@salesforce/salesforcedx-utils-vscode": "61.17.0",
+    "@salesforce/salesforcedx-apex-debugger": "62.0.0",
+    "@salesforce/salesforcedx-utils-vscode": "62.0.0",
     "@vscode/debugprotocol": "1.65.0",
     "vscode-extension-telemetry": "0.0.17"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "61.17.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "62.0.0",
     "@types/chai": "4.3.3",
     "@types/mocha": "^5",
     "@types/node": "^18.11.9",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "61.17.0",
+  "version": "62.0.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -24,17 +24,17 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/apex-node-bundle": "8.1.7",
-    "@salesforce/core-bundle": "8.5.7",
-    "@salesforce/salesforcedx-apex-replay-debugger": "61.17.0",
-    "@salesforce/salesforcedx-utils": "61.17.0",
-    "@salesforce/salesforcedx-utils-vscode": "61.17.0",
+    "@salesforce/apex-node-bundle": "8.1.12",
+    "@salesforce/core-bundle": "8.6.1",
+    "@salesforce/salesforcedx-apex-replay-debugger": "62.0.0",
+    "@salesforce/salesforcedx-utils": "62.0.0",
+    "@salesforce/salesforcedx-utils-vscode": "62.0.0",
     "async-lock": "1.0.0",
     "request-light": "^0.7.0",
     "vscode-extension-telemetry": "0.0.17"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "61.17.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "62.0.0",
     "@salesforce/ts-sinon": "1.4.0",
     "@types/async-lock": "0.0.20",
     "@types/chai": "4.3.3",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "61.17.0",
+  "version": "62.0.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -24,10 +24,10 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/apex-node-bundle": "8.1.7",
+    "@salesforce/apex-node-bundle": "8.1.12",
     "@salesforce/apex-tmlanguage": "1.8.0",
-    "@salesforce/core-bundle": "8.5.7",
-    "@salesforce/salesforcedx-utils-vscode": "61.17.0",
+    "@salesforce/core-bundle": "8.6.1",
+    "@salesforce/salesforcedx-utils-vscode": "62.0.0",
     "@salesforce/vscode-service-provider": "1.2.1",
     "expand-home-dir": "0.0.3",
     "find-java-home": "0.2.0",
@@ -36,7 +36,7 @@
     "vscode-languageclient": "8.1.0"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "61.17.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "62.0.0",
     "@salesforce/ts-sinon": "1.4.0",
     "@types/chai": "4.3.3",
     "@types/mocha": "^5",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "61.17.0",
+  "version": "62.0.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -25,12 +25,12 @@
   ],
   "dependencies": {
     "@jsforce/jsforce-node": "3.4.1",
-    "@salesforce/core-bundle": "8.5.7",
-    "@salesforce/salesforcedx-sobjects-faux-generator": "61.17.0",
-    "@salesforce/salesforcedx-utils-vscode": "61.17.0",
+    "@salesforce/core-bundle": "8.6.1",
+    "@salesforce/salesforcedx-sobjects-faux-generator": "62.0.0",
+    "@salesforce/salesforcedx-utils-vscode": "62.0.0",
     "@salesforce/schemas": "1.9.0",
-    "@salesforce/source-deploy-retrieve-bundle": "12.6.3",
-    "@salesforce/templates": "61.4.10",
+    "@salesforce/source-deploy-retrieve-bundle": "12.7.4",
+    "@salesforce/templates": "62.0.1",
     "@salesforce/ts-types": "2.0.12",
     "@salesforce/vscode-service-provider": "1.2.1",
     "adm-zip": "0.5.10",
@@ -41,7 +41,7 @@
     "shelljs": "0.8.5"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "61.17.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "62.0.0",
     "@salesforce/ts-sinon": "^1.0.0",
     "@types/adm-zip": "^0.5.0",
     "@types/chai": "4.3.3",

--- a/packages/salesforcedx-vscode-expanded/package.json
+++ b/packages/salesforcedx-vscode-expanded/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "61.17.0",
+  "version": "62.0.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "61.17.0",
+  "version": "62.0.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -25,15 +25,15 @@
   ],
   "dependencies": {
     "@salesforce/aura-language-server": "4.12.2",
-    "@salesforce/core-bundle": "8.5.7",
+    "@salesforce/core-bundle": "8.6.1",
     "@salesforce/lightning-lsp-common": "4.12.2",
-    "@salesforce/salesforcedx-utils-vscode": "61.17.0",
+    "@salesforce/salesforcedx-utils-vscode": "62.0.0",
     "applicationinsights": "1.0.7",
     "vscode-extension-telemetry": "0.0.17",
     "vscode-languageclient": "^5.2.1"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "61.17.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "62.0.0",
     "@types/chai": "4.3.3",
     "@types/mocha": "^5",
     "@types/node": "^18.11.9",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "61.17.0",
+  "version": "62.0.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -24,11 +24,11 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/core-bundle": "8.5.7",
+    "@salesforce/core-bundle": "8.6.1",
     "@salesforce/eslint-config-lwc": "3.6.0",
     "@salesforce/lightning-lsp-common": "4.12.2",
     "@salesforce/lwc-language-server": "4.12.2",
-    "@salesforce/salesforcedx-utils-vscode": "61.17.0",
+    "@salesforce/salesforcedx-utils-vscode": "62.0.0",
     "ajv": "6.12.6",
     "applicationinsights": "1.0.7",
     "jest-editor-support": "^30.1.0",
@@ -40,7 +40,7 @@
     "vscode-languageclient": "^5.2.1"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "61.17.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "62.0.0",
     "@types/chai": "4.3.3",
     "@types/mocha": "^5",
     "@types/node": "^18.11.9",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -9,7 +9,7 @@
   "repository": {
     "url": "https://github.com/forcedotcom/salesforcedx-vscode"
   },
-  "version": "61.17.0",
+  "version": "62.0.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "icon": "images/VSCodeSoql.png",
@@ -33,16 +33,16 @@
   "dependencies": {
     "@jsforce/jsforce-node": "3.4.1",
     "@salesforce/apex-tmlanguage": "1.6.0",
-    "@salesforce/core-bundle": "8.5.7",
+    "@salesforce/core-bundle": "8.6.1",
     "@salesforce/soql-builder-ui": "1.0.0",
     "@salesforce/soql-data-view": "0.1.0",
     "@salesforce/soql-language-server": "0.7.1",
     "@salesforce/soql-model": "1.0.0"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-sobjects-faux-generator": "61.17.0",
-    "@salesforce/salesforcedx-test-utils-vscode": "61.17.0",
-    "@salesforce/salesforcedx-utils-vscode": "61.17.0",
+    "@salesforce/salesforcedx-sobjects-faux-generator": "62.0.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "62.0.0",
+    "@salesforce/salesforcedx-utils-vscode": "62.0.0",
     "@salesforce/soql-common": "0.2.1",
     "@salesforce/ts-sinon": "1.4.0",
     "@salesforce/ts-types": "2.0.12",

--- a/packages/salesforcedx-vscode-visualforce/package.json
+++ b/packages/salesforcedx-vscode-visualforce/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "61.17.0",
+  "version": "62.0.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {
@@ -24,15 +24,15 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/salesforcedx-visualforce-language-server": "61.17.0",
-    "@salesforce/salesforcedx-visualforce-markup-language-server": "61.17.0",
+    "@salesforce/salesforcedx-visualforce-language-server": "62.0.0",
+    "@salesforce/salesforcedx-visualforce-markup-language-server": "62.0.0",
     "vscode-extension-telemetry": "0.0.17",
     "vscode-languageclient": "5.2.1",
     "vscode-languageserver-protocol": "3.14.1",
     "vscode-languageserver-types": "3.14.0"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "61.17.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "62.0.0",
     "@types/chai": "4.3.3",
     "@types/mocha": "^5",
     "@types/node": "^18.11.9",

--- a/packages/salesforcedx-vscode/package.json
+++ b/packages/salesforcedx-vscode/package.json
@@ -14,7 +14,7 @@
     "color": "#ECECEC",
     "theme": "light"
   },
-  "version": "61.17.0",
+  "version": "62.0.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "engines": {

--- a/packages/system-tests/package.json
+++ b/packages/system-tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "system-tests",
   "description": "System tests for Salesforce DX Extensions for VS Code",
-  "version": "61.17.0",
+  "version": "62.0.0",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",
   "main": "./out/src",
@@ -9,8 +9,8 @@
     "vscode": "^1.86.0"
   },
   "devDependencies": {
-    "@salesforce/salesforcedx-test-utils-vscode": "61.17.0",
-    "@salesforce/salesforcedx-utils-vscode": "61.17.0",
+    "@salesforce/salesforcedx-test-utils-vscode": "62.0.0",
+    "@salesforce/salesforcedx-utils-vscode": "62.0.0",
     "@types/chai": "4.3.3",
     "@types/mocha": "^5",
     "@types/node": "^18.11.9",


### PR DESCRIPTION
### What does this PR do?
- Bump major version to 62.0.0
- Bump bundle dependencies for
   - @salesforce/core-bundle
   -   @salesforce/source-deploy-retrieve-bundle
   -   @salesforce/source-tracking-bundle
   -   @salesforce/templates-bundle
   -   @salesforce/apex-node-bundle

### What issues does this PR fix or reference?
@W-16901209@