### PR TITLE
fix: move resolve orphan apex lang server

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/index.ts
@@ -110,6 +110,12 @@ export const activate = async (extensionContext: vscode.ExtensionContext) => {
   };
 
   void activationTracker.markActivationStop(new Date());
+
+  setImmediate(() => {
+    // Resolve any found orphan language servers in the background
+    void lsoh.resolveAnyFoundOrphanLanguageServers();
+  });
+
   return exportedApi;
 };
 
@@ -308,8 +314,6 @@ const createLanguageClient = async (
   languageServerStatusBarItem: ApexLSPStatusBarItem
 ): Promise<void> => {
   const telemetryService = await getTelemetryService();
-  // Resolve any found orphan language servers
-  void lsoh.resolveAnyFoundOrphanLanguageServers();
   // Initialize Apex language server
   try {
     const langClientHRStart = process.hrtime();


### PR DESCRIPTION
Move resolveAnyFoundOrphanLanguageServers outside of client setup Run resolveAnyFoundOrphanLanguageServers in separate tick on main loop
### What does this PR do?

### What issues does this PR fix or reference?
@W-16953996@

### Functionality Before
Code to locate and resolve orphaned apex language servers was run inside the language client setup, with potential downside of impeding performance.

### Functionality After
Code to locate and resolve orphaned apex language servers now runs as the last element of the apex extension activate function. It is also run with a setImmediate so it will run on the next iteration of the main loop.

