### PR TITLE
fix: add file watcher for folder deletes

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/languageServer.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageServer.ts
@@ -167,6 +167,7 @@ export const buildClientOptions = (): LanguageClientOptions => {
     synchronize: {
       configurationSection: 'apex',
       fileEvents: [
+        vscode.workspace.createFileSystemWatcher('**/', true, true, false), // only events for folder deletions
         vscode.workspace.createFileSystemWatcher('**/*.{cls,trigger,apex}'), // Apex classes
         vscode.workspace.createFileSystemWatcher('**/sfdx-project.json') // SFDX workspace configuration file
       ]


### PR DESCRIPTION
Adds an additional file watcher that will trigger when an entire folder is deleted.

Depends on a new language server to be included in this PR (see LSP repo for details).

@W-16207484@