### PR TITLE
chore: first e2e tests in redhat repo

### DIFF
--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -6,7 +6,7 @@ on:
       automationBranch:
         description: 'Set the branch to use for automation tests'
         required: false
-        default: 'main'
+        default: 'cristi/poc'
         type: string
       anInitialSuite:
         description: 'Verify Extensions'
@@ -41,11 +41,12 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: '1.92.2'
+        default: 'stable'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
         required: true
+        default: '11340376864'
         type: string
 
   workflow_call:
@@ -53,46 +54,47 @@ on:
       automationBranch:
         description: 'Set the branch to use for automation tests'
         required: false
-        default: 'main'
+        default: 'cristi/poc'
         type: string
       anInitialSuite:
         description: 'Verify Extensions'
         required: false
-        default: true
+        default: false
         type: boolean
       authentication:
         description: 'Authentication'
         required: false
-        default: true
+        default: false
         type: boolean
       miscellaneous:
         description: 'Miscellaneous Commands'
         required: false
-        default: true
+        default: false
         type: boolean
       sObjectsDefinitions:
         description: 'sObjects Definitions'
         required: false
-        default: true
+        default: false
         type: boolean
       templates:
         description: 'Create Commands'
         required: false
-        default: true
+        default: false
         type: boolean
       sfdxProjectJson:
         description: 'sfdx-project.json'
         required: false
-        default: true
+        default: false
         type: boolean
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: '1.92.2'
+        default: 'stable'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
         required: false
+        default: '11340376864'
         type: string
 
 jobs:
@@ -155,7 +157,7 @@ jobs:
       testToRun: 'sfdxProjectJson.e2e.ts'
       vscodeVersion: ${{ inputs.vscodeVersion }}
       runId: ${{ inputs.runId }}
-  
+
   createProjectTest:
     if: ${{ inputs.miscellaneous }}
     uses: ./.github/workflows/runE2ETest.yml

--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -41,7 +41,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'stable'
+        default: '1.92.2'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -88,7 +88,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'stable'
+        default: '1.92.2'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -102,7 +102,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch }}
-      testToRun: 'anInitialSuite.e2e.js'
+      testToRun: 'anInitialSuite.e2e.ts'
       vscodeVersion: ${{ inputs.vscodeVersion }}
       runId: ${{ inputs.runId }}
 
@@ -162,7 +162,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch }}
-      testToRun: 'createProject.e2e.js'
+      testToRun: 'createProject.e2e.ts'
       vscodeVersion: ${{ inputs.vscodeVersion }}
       runId: ${{ inputs.runId }}
 

--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -162,7 +162,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch }}
-      testToRun: 'createProject.e2e.ts'
+      testToRun: 'createProjectTest.e2e.ts'
       vscodeVersion: ${{ inputs.vscodeVersion }}
       runId: ${{ inputs.runId }}
 

--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -6,7 +6,7 @@ on:
       automationBranch:
         description: 'Set the branch to use for automation tests'
         required: false
-        default: 'cristi/poc'
+        default: 'main'
         type: string
       anInitialSuite:
         description: 'Verify Extensions'
@@ -16,27 +16,27 @@ on:
       authentication:
         description: 'Authentication'
         required: false
-        default: false
+        default: true
         type: boolean
       miscellaneous:
         description: 'Miscellaneous Commands'
         required: false
-        default: false
+        default: true
         type: boolean
       sObjectsDefinitions:
         description: 'sObjects Definitions'
         required: false
-        default: false
+        default: true
         type: boolean
       templates:
         description: 'Create Commands'
         required: false
-        default: false
+        default: true
         type: boolean
       sfdxProjectJson:
         description: 'sfdx-project.json'
         required: false
-        default: false
+        default: true
         type: boolean
       vscodeVersion:
         description: 'VSCode Version'
@@ -46,7 +46,6 @@ on:
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
         required: true
-        default: '11340376864'
         type: string
 
   workflow_call:
@@ -54,37 +53,37 @@ on:
       automationBranch:
         description: 'Set the branch to use for automation tests'
         required: false
-        default: 'cristi/poc'
+        default: 'main'
         type: string
       anInitialSuite:
         description: 'Verify Extensions'
         required: false
-        default: false
+        default: true
         type: boolean
       authentication:
         description: 'Authentication'
         required: false
-        default: false
+        default: true
         type: boolean
       miscellaneous:
         description: 'Miscellaneous Commands'
         required: false
-        default: false
+        default: true
         type: boolean
       sObjectsDefinitions:
         description: 'sObjects Definitions'
         required: false
-        default: false
+        default: true
         type: boolean
       templates:
         description: 'Create Commands'
         required: false
-        default: false
+        default: true
         type: boolean
       sfdxProjectJson:
         description: 'sfdx-project.json'
         required: false
-        default: false
+        default: true
         type: boolean
       vscodeVersion:
         description: 'VSCode Version'
@@ -94,7 +93,6 @@ on:
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
         required: false
-        default: '11340376864'
         type: string
 
 jobs:
@@ -164,7 +162,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch }}
-      testToRun: 'createProjectTest.e2e.ts'
+      testToRun: 'createProject.e2e.js'
       vscodeVersion: ${{ inputs.vscodeVersion }}
       runId: ${{ inputs.runId }}
 

--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -104,7 +104,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch }}
-      testToRun: 'anInitialSuite.e2e.ts'
+      testToRun: 'anInitialSuite.e2e.js'
       vscodeVersion: ${{ inputs.vscodeVersion }}
       runId: ${{ inputs.runId }}
 

--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -16,27 +16,27 @@ on:
       authentication:
         description: 'Authentication'
         required: false
-        default: true
+        default: false
         type: boolean
       miscellaneous:
         description: 'Miscellaneous Commands'
         required: false
-        default: true
+        default: false
         type: boolean
       sObjectsDefinitions:
         description: 'sObjects Definitions'
         required: false
-        default: true
+        default: false
         type: boolean
       templates:
         description: 'Create Commands'
         required: false
-        default: true
+        default: false
         type: boolean
       sfdxProjectJson:
         description: 'sfdx-project.json'
         required: false
-        default: true
+        default: false
         type: boolean
       vscodeVersion:
         description: 'VSCode Version'

--- a/.github/workflows/coreE2EredHat.yml
+++ b/.github/workflows/coreE2EredHat.yml
@@ -112,6 +112,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch }}
+      automationRepo: 'salesforcedx-vscode-automation-tests-redhat'
       testToRun: 'anInitialSuite.e2e.js'
       vscodeVersion: ${{ inputs.vscodeVersion }}
       runId: ${{ inputs.runId }}
@@ -122,6 +123,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch }}
+      automationRepo: 'salesforcedx-vscode-automation-tests-redhat'
       testToRun: 'createProject.e2e.js'
       vscodeVersion: ${{ inputs.vscodeVersion }}
       runId: ${{ inputs.runId }}

--- a/.github/workflows/coreE2EredHat.yml
+++ b/.github/workflows/coreE2EredHat.yml
@@ -1,4 +1,4 @@
-name: Core End to End Tests
+name: Core End to End Tests - Redhat
 
 on:
   workflow_dispatch:

--- a/.github/workflows/coreE2EredHat.yml
+++ b/.github/workflows/coreE2EredHat.yml
@@ -1,0 +1,246 @@
+name: Core End to End Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      automationBranch:
+        description: 'Set the branch to use for automation tests'
+        required: false
+        default: 'main'
+        type: string
+      anInitialSuite:
+        description: 'Verify Extensions'
+        required: false
+        default: true
+        type: boolean
+      createProject:
+        description: 'Create Project'
+        required: false
+        default: true
+        type: boolean
+      # authentication:
+      #   description: 'Authentication'
+      #   required: false
+      #   default: true
+      #   type: boolean
+      # miscellaneous:
+      #   description: 'Miscellaneous Commands'
+      #   required: false
+      #   default: true
+      #   type: boolean
+      # sObjectsDefinitions:
+      #   description: 'sObjects Definitions'
+      #   required: false
+      #   default: true
+      #   type: boolean
+      # templates:
+      #   description: 'Create Commands'
+      #   required: false
+      #   default: true
+      #   type: boolean
+      # sfdxProjectJson:
+      #   description: 'sfdx-project.json'
+      #   required: false
+      #   default: true
+      #   type: boolean
+      vscodeVersion:
+        description: 'VSCode Version'
+        required: false
+        default: 'stable'
+        type: string
+      runId:
+        description: 'Run ID of the workflow run that created the vsixes'
+        required: true
+        type: string
+
+  workflow_call:
+    inputs:
+      automationBranch:
+        description: 'Set the branch to use for automation tests'
+        required: false
+        default: 'main'
+        type: string
+      anInitialSuite:
+        description: 'Verify Extensions'
+        required: false
+        default: true
+        type: boolean
+      createProject:
+        description: 'Create Project'
+        required: false
+        default: true
+        type: boolean
+      # authentication:
+      #   description: 'Authentication'
+      #   required: false
+      #   default: true
+      #   type: boolean
+      # miscellaneous:
+      #   description: 'Miscellaneous Commands'
+      #   required: false
+      #   default: true
+      #   type: boolean
+      # sObjectsDefinitions:
+      #   description: 'sObjects Definitions'
+      #   required: false
+      #   default: true
+      #   type: boolean
+      # templates:
+      #   description: 'Create Commands'
+      #   required: false
+      #   default: true
+      #   type: boolean
+      # sfdxProjectJson:
+      #   description: 'sfdx-project.json'
+      #   required: false
+      #   default: true
+      #   type: boolean
+      vscodeVersion:
+        description: 'VSCode Version'
+        required: false
+        default: 'stable'
+        type: string
+      runId:
+        description: 'Run ID of the workflow run that created the vsixes'
+        required: false
+        type: string
+
+jobs:
+  anInitialSuite:
+    if: ${{ inputs.anInitialSuite }}
+    uses: ./.github/workflows/runE2ETest.yml
+    secrets: inherit
+    with:
+      automationBranch: ${{ inputs.automationBranch }}
+      testToRun: 'anInitialSuite.e2e.js'
+      vscodeVersion: ${{ inputs.vscodeVersion }}
+      runId: ${{ inputs.runId }}
+
+  createProject:
+    if: ${{ inputs.createProject }}
+    uses: ./.github/workflows/runE2ETest.yml
+    secrets: inherit
+    with:
+      automationBranch: ${{ inputs.automationBranch }}
+      testToRun: 'createProject.e2e.js'
+      vscodeVersion: ${{ inputs.vscodeVersion }}
+      runId: ${{ inputs.runId }}
+
+  # authentication:
+  #   if: ${{ inputs.authentication }}
+  #   uses: ./.github/workflows/runE2ETest.yml
+  #   secrets: inherit
+  #   with:
+  #     automationBranch: ${{ inputs.automationBranch }}
+  #     testToRun: 'authentication.e2e.js'
+  #     vscodeVersion: ${{ inputs.vscodeVersion }}
+  #     runId: ${{ inputs.runId }}
+
+  # miscellaneous:
+  #   if: ${{ inputs.miscellaneous }}
+  #   uses: ./.github/workflows/runE2ETest.yml
+  #   secrets: inherit
+  #   with:
+  #     automationBranch: ${{ inputs.automationBranch }}
+  #     testToRun: 'miscellaneous.e2e.js'
+  #     vscodeVersion: ${{ inputs.vscodeVersion }}
+  #     runId: ${{ inputs.runId }}
+
+  # sObjectsDefinitions:
+  #   if: ${{ inputs.sObjectsDefinitions }}
+  #   uses: ./.github/workflows/runE2ETest.yml
+  #   secrets: inherit
+  #   with:
+  #     automationBranch: ${{ inputs.automationBranch }}
+  #     testToRun: 'sObjectsDefinitions.e2e.js'
+  #     vscodeVersion: ${{ inputs.vscodeVersion }}
+  #     runId: ${{ inputs.runId }}
+
+  # templates:
+  #   if: ${{ inputs.templates }}
+  #   uses: ./.github/workflows/runE2ETest.yml
+  #   secrets: inherit
+  #   with:
+  #     automationBranch: ${{ inputs.automationBranch }}
+  #     testToRun: 'templates.e2e.js'
+  #     vscodeVersion: ${{ inputs.vscodeVersion }}
+  #     runId: ${{ inputs.runId }}
+
+  # sfdxProjectJson:
+  #   if: ${{ inputs.sfdxProjectJson }}
+  #   uses: ./.github/workflows/runE2ETest.yml
+  #   secrets: inherit
+  #   with:
+  #     automationBranch: ${{ inputs.automationBranch }}
+  #     testToRun: 'sfdxProjectJson.e2e.js'
+  #     vscodeVersion: ${{ inputs.vscodeVersion }}
+  #     runId: ${{ inputs.runId }}
+
+  slack_success_notification:
+    if: ${{ success() }}
+    needs: [
+        anInitialSuite,
+        createProject
+        # authentication,
+        # miscellaneous,
+        # sObjectsDefinitions,
+        # templates,
+        # sfdxProjectJson
+      ]
+    uses: ./.github/workflows/slackNotification.yml
+    secrets: inherit
+    with:
+      title: 'Core E2E Tests'
+      vscodeVersion: ${{ inputs.vscodeVersion }}
+      testsBranch: ${{ inputs.automationBranch }}
+      summary: '\n- An Initial Suite: ${{ needs.anInitialSuite.result }}\n- Create Project: ${{ needs.createProject.result }}'
+      # summary: '\n- An Initial Suite: ${{ needs.anInitialSuite.result }}\n- Create Project: ${{ needs.createProject.result }}\n- Authentication: ${{ needs.authentication.result }}\n- Miscellaneous: ${{ needs.miscellaneous.result }}\n- SObjects Definitions: ${{ needs.sObjectsDefinitions.result }}\n- Templates: ${{ needs.templates.result }}\n- SFDX Project Json: ${{ needs.sfdxProjectJson.result}}'
+      result: 'All the tests passed.'
+      workflow: 'actions/runs/${{ github.run_id }}'
+      type: 'e2e'
+
+  slack_failure_notification:
+    if: ${{ failure()}}
+    needs: [
+        anInitialSuite,
+        createProject
+        # authentication,
+        # miscellaneous,
+        # sObjectsDefinitions,
+        # templates,
+        # sfdxProjectJson
+      ]
+    uses: ./.github/workflows/slackNotification.yml
+    secrets: inherit
+    with:
+      title: 'Core E2E Tests'
+      vscodeVersion: ${{ inputs.vscodeVersion }}
+      testsBranch: ${{ inputs.automationBranch }}
+      summary: '\n- An Initial Suite: ${{ needs.anInitialSuite.result }}\n- Create Project: ${{ needs.createProject.result }}'
+      # summary: '\n- An Initial Suite: ${{ needs.anInitialSuite.result }}\n- Create Project: ${{ needs.createProject.result }}\n- Authentication: ${{ needs.authentication.result }}\n- Miscellaneous: ${{ needs.miscellaneous.result }}\n- SObjects Definitions: ${{ needs.sObjectsDefinitions.result }}\n- Templates: ${{ needs.templates.result }}\n- SFDX Project Json: ${{ needs.sfdxProjectJson.result}}'
+      result: 'Not all the tests passed.'
+      workflow: 'actions/runs/${{ github.run_id }}'
+      type: 'e2e'
+
+  slack_cancelled_notification:
+    if: ${{ cancelled() }}
+    needs: [
+        anInitialSuite,
+        createProject
+        # authentication,
+        # miscellaneous,
+        # sObjectsDefinitions,
+        # templates,
+        # sfdxProjectJson
+      ]
+    uses: ./.github/workflows/slackNotification.yml
+    secrets: inherit
+    with:
+      title: 'Core E2E Tests'
+      vscodeVersion: ${{ inputs.vscodeVersion }}
+      testsBranch: ${{ inputs.automationBranch }}
+      summary: '\n- An Initial Suite: ${{ needs.anInitialSuite.result }}\n- Create Project: ${{ needs.createProject.result }}'
+      # summary: '\n- An Initial Suite: ${{ needs.anInitialSuite.result }}\n- Create Project: ${{ needs.createProject.result }}\n- Authentication: ${{ needs.authentication.result }}\n- Miscellaneous: ${{ needs.miscellaneous.result }}\n- SObjects Definitions: ${{ needs.sObjectsDefinitions.result }}\n- Templates: ${{ needs.templates.result }}\n- Templates: ${{ needs.templates.result }}\n- SFDX Project Json: ${{ needs.sfdxProjectJson.result}}'
+      result: 'The workflow was cancelled.'
+      workflow: 'actions/runs/${{ github.run_id }}'
+      type: 'e2e'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -74,6 +74,15 @@ jobs:
       vscodeVersion: ${{ inputs.vscodeVersion || '1.92.2' }}
       runId: ${{ inputs.runId || github.event.workflow_run.id }}
 
+  Core_E2E_tests_RedHat:
+    if: ${{ inputs.coreE2ETests || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
+    uses: ./.github/workflows/coreE2EredHat.yml
+    secrets: inherit
+    with:
+      automationBranch: ${{ inputs.automationBranch || 'main' }}
+      vscodeVersion: ${{ inputs.vscodeVersion || 'stable' }}
+      runId: ${{ inputs.runId || github.event.workflow_run.id }}
+
   DeployAndRetrieve_E2E_tests:
     if: ${{ inputs.deployAndRetrieveE2ETests || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
     uses: ./.github/workflows/deployRetrieveE2E.yml
@@ -122,6 +131,15 @@ jobs:
   Core_E2E_tests_min_vscode_version:
     if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
     uses: ./.github/workflows/coreE2E.yml
+    secrets: inherit
+    with:
+      automationBranch: 'main'
+      vscodeVersion: '1.86.0'
+      runId: ${{ github.event.workflow_run.id }}
+
+  Core_E2E_tests_RedHat_min_vscode_version:
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
+    uses: ./.github/workflows/coreE2EredHat.yml
     secrets: inherit
     with:
       automationBranch: 'main'

--- a/.github/workflows/runE2ETest.yml
+++ b/.github/workflows/runE2ETest.yml
@@ -7,6 +7,11 @@ on:
         required: false
         default: 'main'
         type: string
+      automationRepo:
+        description: 'Set the repo to use for automation tests'
+        required: false
+        default: 'salesforcedx-vscode-automation-tests'
+        type: string
       testToRun:
         description: 'Run this E2E test'
         required: false
@@ -60,7 +65,7 @@ jobs:
           cache: npm
           cache-dependency-path: |
             salesforcedx-vscode/package-lock.json
-            salesforcedx-vscode-automation-tests-redhat/package-lock.json
+            ${{ inputs.automationRepo }}/package-lock.json
       - name: Setup java
         uses: actions/setup-java@v4
         with:
@@ -69,13 +74,13 @@ jobs:
       - name: Clone automation tests
         uses: actions/checkout@v4
         with:
-          repository: forcedotcom/salesforcedx-vscode-automation-tests-redhat
-          path: salesforcedx-vscode-automation-tests-redhat
+          repository: forcedotcom/${{ inputs.automationRepo }}
+          path: ${{ inputs.automationRepo }}
           ref: ${{ inputs.automationBranch }}
       - name: Install Test Dependencies
         run: |
           npm install
-        working-directory: salesforcedx-vscode-automation-tests-redhat
+        working-directory: ${{ inputs.automationRepo }}
       - name: Install the Salesforce CLI
         run: npm install -g @salesforce/cli
       - name: Verify CLI
@@ -102,7 +107,7 @@ jobs:
         with:
           run: |
             npm run automation-tests
-          working-directory: salesforcedx-vscode-automation-tests-redhat
+          working-directory: ${{ inputs.automationRepo }}
         env:
           VSCODE_VERSION: ${{ matrix.vscodeVersion }}
           SPEC_FILES: ${{ inputs.testToRun }}
@@ -113,4 +118,4 @@ jobs:
         if: failure()
         with:
           name: screenshots-${{ inputs.testToRun }}-${{ matrix.os }}
-          path: ./salesforcedx-vscode-automation-tests-redhat/screenshots
+          path: ./${{ inputs.automationRepo }}/screenshots

--- a/.github/workflows/runE2ETest.yml
+++ b/.github/workflows/runE2ETest.yml
@@ -5,38 +5,11 @@ on:
       automationBranch:
         description: 'Set the branch to use for automation tests'
         required: false
-        default: 'cristi/poc'
+        default: 'main'
         type: string
       testToRun:
         description: 'Run this E2E test'
         required: false
-        type: string
-      vscodeVersion:
-        description: 'VSCode Version'
-        required: false
-        default: '1.86.0'
-        type: string
-      runId:
-        description: 'Run ID of the workflow run that created the vsixes'
-        required: false
-        type: string
-      os:
-        description: 'Operating System(s) to run the E2E tests on'
-        required: false
-        default: '["macos-latest", "ubuntu-latest", "windows-latest"]'
-        type: string
-
-  workflow_dispatch:
-    inputs:
-      automationBranch:
-        description: 'Set the branch to use for automation tests'
-        required: false
-        default: 'cristi/poc'
-        type: string
-      testToRun:
-        description: 'Run this E2E test'
-        required: false
-        default: 'authentication.e2e.ts'
         type: string
       vscodeVersion:
         description: 'VSCode Version'
@@ -46,7 +19,6 @@ on:
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
         required: false
-        default: '11340376864'
         type: string
       os:
         description: 'Operating System(s) to run the E2E tests on'

--- a/.github/workflows/runE2ETest.yml
+++ b/.github/workflows/runE2ETest.yml
@@ -5,7 +5,7 @@ on:
       automationBranch:
         description: 'Set the branch to use for automation tests'
         required: false
-        default: 'develop'
+        default: 'cristi/poc'
         type: string
       testToRun:
         description: 'Run this E2E test'
@@ -14,7 +14,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: '1.85.2'
+        default: '1.86.0'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -26,6 +26,33 @@ on:
         default: '["macos-latest", "ubuntu-latest", "windows-latest"]'
         type: string
 
+  workflow_dispatch:
+    inputs:
+      automationBranch:
+        description: 'Set the branch to use for automation tests'
+        required: false
+        default: 'cristi/poc'
+        type: string
+      testToRun:
+        description: 'Run this E2E test'
+        required: false
+        default: 'authentication.e2e.ts'
+        type: string
+      vscodeVersion:
+        description: 'VSCode Version'
+        required: false
+        default: 'stable'
+        type: string
+      runId:
+        description: 'Run ID of the workflow run that created the vsixes'
+        required: false
+        default: '11340376864'
+        type: string
+      os:
+        description: 'Operating System(s) to run the E2E tests on'
+        required: false
+        default: '["macos-latest", "ubuntu-latest", "windows-latest"]'
+        type: string
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -61,7 +88,7 @@ jobs:
           cache: npm
           cache-dependency-path: |
             salesforcedx-vscode/package-lock.json
-            salesforcedx-vscode-automation-tests/package-lock.json
+            salesforcedx-vscode-automation-tests-redhat/package-lock.json
       - name: Setup java
         uses: actions/setup-java@v4
         with:
@@ -70,13 +97,13 @@ jobs:
       - name: Clone automation tests
         uses: actions/checkout@v4
         with:
-          repository: forcedotcom/salesforcedx-vscode-automation-tests
-          path: salesforcedx-vscode-automation-tests
+          repository: forcedotcom/salesforcedx-vscode-automation-tests-redhat
+          path: salesforcedx-vscode-automation-tests-redhat
           ref: ${{ inputs.automationBranch }}
       - name: Install Test Dependencies
         run: |
           npm install
-        working-directory: salesforcedx-vscode-automation-tests
+        working-directory: salesforcedx-vscode-automation-tests-redhat
       - name: Install the Salesforce CLI
         run: npm install -g @salesforce/cli
       - name: Verify CLI
@@ -104,7 +131,7 @@ jobs:
           run: |
             npm run setup
             npm run automation-tests
-          working-directory: salesforcedx-vscode-automation-tests
+          working-directory: salesforcedx-vscode-automation-tests-redhat
         env:
           VSCODE_VERSION: ${{ matrix.vscodeVersion }}
           SPEC_FILES: ${{ inputs.testToRun }}
@@ -115,4 +142,4 @@ jobs:
         if: failure()
         with:
           name: screenshots-${{ inputs.testToRun }}-${{ matrix.os }}
-          path: ./salesforcedx-vscode-automation-tests/screenshots
+          path: ./salesforcedx-vscode-automation-tests-redhat/screenshots

--- a/.github/workflows/runE2ETest.yml
+++ b/.github/workflows/runE2ETest.yml
@@ -129,7 +129,6 @@ jobs:
         uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3
         with:
           run: |
-            npm run setup
             npm run automation-tests
           working-directory: salesforcedx-vscode-automation-tests-redhat
         env:


### PR DESCRIPTION
### What does this PR do?
- Adds new workflow for coreE2E in order to be able to run e2e tests from redhat repo
- Adds redhat tests so they run as part of nightlies
- Modifies runE2ETest.yml to pass the repo as a param

### What issues does this PR fix or reference?
@W-16838814@
