### PR TITLE
Mz/disable apex ls error telemetry

### DIFF
--- a/packages/salesforcedx-utils/src/types/localization/localizationProvider.ts
+++ b/packages/salesforcedx-utils/src/types/localization/localizationProvider.ts
@@ -5,6 +5,5 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 export type LocalizationProvider = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   localize(label: string, ...args: any[]): string;
 };

--- a/packages/salesforcedx-visualforce-language-server/src/visualforceServer.ts
+++ b/packages/salesforcedx-visualforce-language-server/src/visualforceServer.ts
@@ -25,7 +25,6 @@ import {
   ColorInformation,
   ColorPresentationRequest,
   DocumentColorRequest,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   ServerCapabilities as CPServerCapabilities
 } from 'vscode-languageserver-protocol';
 import { ConfigurationParams, ConfigurationRequest } from 'vscode-languageserver-protocol';

--- a/packages/salesforcedx-vscode-apex-debugger/src/adapter/debugConfigurationProvider.ts
+++ b/packages/salesforcedx-vscode-apex-debugger/src/adapter/debugConfigurationProvider.ts
@@ -26,7 +26,7 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
 
   public provideDebugConfigurations(
     folder: vscode.WorkspaceFolder | undefined,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
     token?: vscode.CancellationToken
   ): vscode.ProviderResult<vscode.DebugConfiguration[]> {
     return [DebugConfigurationProvider.getConfig(folder)];
@@ -35,7 +35,7 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
   public resolveDebugConfiguration(
     folder: vscode.WorkspaceFolder | undefined,
     config: vscode.DebugConfiguration,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
     token?: vscode.CancellationToken
   ): vscode.ProviderResult<vscode.DebugConfiguration> {
     return this.asyncDebugConfig(folder, config).catch(async err => {

--- a/packages/salesforcedx-vscode-apex-debugger/src/context/isvContext.ts
+++ b/packages/salesforcedx-vscode-apex-debugger/src/context/isvContext.ts
@@ -27,11 +27,11 @@ export const registerIsvAuthWatcher = (extensionContext: vscode.ExtensionContext
   if (vscode.workspace.workspaceFolders instanceof Array && vscode.workspace.workspaceFolders.length > 0) {
     const configPath = projectPaths.salesforceProjectConfig();
     const isvAuthWatcher = vscode.workspace.createFileSystemWatcher(configPath);
-    /* eslint-disable @typescript-eslint/no-unused-vars */
+
     isvAuthWatcher.onDidChange(uri => setupGlobalDefaultUserIsvAuth());
     isvAuthWatcher.onDidCreate(uri => setupGlobalDefaultUserIsvAuth());
     isvAuthWatcher.onDidDelete(uri => setupGlobalDefaultUserIsvAuth());
-    /* eslint-enable @typescript-eslint/no-unused-vars */
+
     extensionContext.subscriptions.push(isvAuthWatcher);
   }
 };

--- a/packages/salesforcedx-vscode-apex-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-debugger/src/index.ts
@@ -185,7 +185,7 @@ export const getExceptionBreakpointCache = (): Map<string, ExceptionBreakpointIt
 
 const registerFileWatchers = (): vscode.Disposable => {
   const clsWatcher = vscode.workspace.createFileSystemWatcher('**/*.cls');
-  /* eslint-disable @typescript-eslint/no-unused-vars */
+
   clsWatcher.onDidChange(uri => notifyDebuggerSessionFileChanged());
   clsWatcher.onDidCreate(uri => notifyDebuggerSessionFileChanged());
   clsWatcher.onDidDelete(uri => notifyDebuggerSessionFileChanged());
@@ -193,7 +193,7 @@ const registerFileWatchers = (): vscode.Disposable => {
   trgWatcher.onDidChange(uri => notifyDebuggerSessionFileChanged());
   trgWatcher.onDidCreate(uri => notifyDebuggerSessionFileChanged());
   trgWatcher.onDidDelete(uri => notifyDebuggerSessionFileChanged());
-  /* eslint-enable @typescript-eslint/no-unused-vars */
+
   return vscode.Disposable.from(clsWatcher, trgWatcher);
 };
 

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -387,6 +387,11 @@
           "type": "boolean",
           "default": false,
           "description": "%apex_code_disable-warnings-for-missing-coverage%"
+        },
+        "salesforcedx-vscode-apex.enable-apex-ls-error-to-telemetry": {
+          "type": "boolean",
+          "default": false,
+          "description": "%enable-apex-ls-error-to-telemetry%"
         }
       }
     },

--- a/packages/salesforcedx-vscode-apex/package.nls.ja.json
+++ b/packages/salesforcedx-vscode-apex/package.nls.ja.json
@@ -19,6 +19,7 @@
   "apex_verbose_level_trace_description": "Output everything, including details about notifications and responses received by the client, and requests sent by the server.",
   "configuration_title": "Salesforce Apex Configuration",
   "collapse_tests_title": "SFDX: Apex テストを隠す",
+  "enable-apex-ls-error-to-telemetry": "Allow the Apex Language Server to collect telemetry of errors",
   "go_to_definition_title": "定義に移動",
   "java_home_description": "Specifies the folder path to the Java 11, Java 17, or Java 21 runtime used to launch the Apex Language Server. Note on Windows the backslashes must be escaped.\n\nMac Example: `/Library/Java/JavaVirtualMachines/openjdk-11.jdk/Contents/Home`\n\nWindows Example: `C:\\\\Program Files\\\\Zulu\\\\zulu-17`\n\nLinux Example: `/usr/lib/jvm/java-21-openjdk-amd64`",
   "refresh_test_title": "テストを更新",

--- a/packages/salesforcedx-vscode-apex/package.nls.json
+++ b/packages/salesforcedx-vscode-apex/package.nls.json
@@ -19,6 +19,7 @@
   "apex_verbose_level_trace_description": "Output everything, including details about notifications and responses received by the client, and requests sent by the server.",
   "configuration_title": "Salesforce Apex Configuration",
   "collapse_tests_title": "SFDX: Collapse All Apex Tests",
+  "enable-apex-ls-error-to-telemetry": "Allow the Apex Language Server to collect telemetry of errors",
   "go_to_definition_title": "Go to Definition",
   "java_home_description": "Specifies the folder path to the Java 11, Java 17, or Java 21 runtime used to launch the Apex Language Server. Note on Windows the backslashes must be escaped.\n\nMac Example: `/Library/Java/JavaVirtualMachines/openjdk-11.jdk/Contents/Home`\n\nWindows Example: `C:\\\\Program Files\\\\Zulu\\\\zulu-17`\n\nLinux Example: `/usr/lib/jvm/java-21-openjdk-amd64`",
   "java_memory_description": "Specifies the amount of memory allocation to the Apex Language Server in MB, or null to use the system default value.",

--- a/packages/salesforcedx-vscode-apex/src/languageServer.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageServer.ts
@@ -14,7 +14,7 @@ import { LSP_ERR, UBER_JAR_NAME } from './constants';
 import { soqlMiddleware } from './embeddedSoql';
 import { nls } from './messages';
 import * as requirements from './requirements';
-import { retrieveEnableSyncInitJobs } from './settings';
+import { retrieveEnableApexLSErrorToTelemetry, retrieveEnableSyncInitJobs } from './settings';
 import { getTelemetryService } from './telemetry/telemetry';
 
 const JDWP_DEBUG_PORT = 2739;
@@ -75,8 +75,7 @@ const createServer = async (extensionContext: vscode.ExtensionContext): Promise<
       args.push(
         '-Dtrace.protocol=false',
         `-Dapex.lsp.root.log.level=${LANGUAGE_SERVER_LOG_LEVEL}`,
-        `-agentlib:jdwp=transport=dt_socket,server=y,suspend=${
-          SUSPEND_LANGUAGE_SERVER_STARTUP ? 'y' : 'n'
+        `-agentlib:jdwp=transport=dt_socket,server=y,suspend=${SUSPEND_LANGUAGE_SERVER_STARTUP ? 'y' : 'n'
         },address=*:${JDWP_DEBUG_PORT},quiet=y`
       );
       if (process.env.YOURKIT_PROFILER_AGENT) {
@@ -153,7 +152,8 @@ export const buildClientOptions = (): LanguageClientOptions => {
     },
     initializationOptions: {
       enableEmbeddedSoqlCompletion: soqlExtensionInstalled,
-      enableSynchronizedInitJobs: retrieveEnableSyncInitJobs()
+      enableSynchronizedInitJobs: retrieveEnableSyncInitJobs(),
+      enableErrorToTelemetry: retrieveEnableApexLSErrorToTelemetry()
     },
     ...(soqlExtensionInstalled ? { middleware: soqlMiddleware } : {}),
     errorHandler: new ApexErrorHandler()

--- a/packages/salesforcedx-vscode-apex/src/languageServer.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageServer.ts
@@ -75,7 +75,8 @@ const createServer = async (extensionContext: vscode.ExtensionContext): Promise<
       args.push(
         '-Dtrace.protocol=false',
         `-Dapex.lsp.root.log.level=${LANGUAGE_SERVER_LOG_LEVEL}`,
-        `-agentlib:jdwp=transport=dt_socket,server=y,suspend=${SUSPEND_LANGUAGE_SERVER_STARTUP ? 'y' : 'n'
+        `-agentlib:jdwp=transport=dt_socket,server=y,suspend=${
+          SUSPEND_LANGUAGE_SERVER_STARTUP ? 'y' : 'n'
         },address=*:${JDWP_DEBUG_PORT},quiet=y`
       );
       if (process.env.YOURKIT_PROFILER_AGENT) {

--- a/packages/salesforcedx-vscode-apex/src/settings.ts
+++ b/packages/salesforcedx-vscode-apex/src/settings.ts
@@ -17,3 +17,9 @@ export const retrieveTestCodeCoverage = (): boolean => {
 export const retrieveEnableSyncInitJobs = (): boolean => {
   return vscode.workspace.getConfiguration().get<boolean>('salesforcedx-vscode-apex.wait-init-jobs', true);
 };
+
+export const retrieveEnableApexLSErrorToTelemetry = (): boolean => {
+  return vscode.workspace
+    .getConfiguration()
+    .get<boolean>('salesforcedx-vscode-apex.enable-apex-ls-error-to-telemetry', false);
+};

--- a/packages/salesforcedx-vscode-apex/src/views/testOutlineProvider.ts
+++ b/packages/salesforcedx-vscode-apex/src/views/testOutlineProvider.ts
@@ -14,7 +14,6 @@ import { nls } from '../messages';
 import { IconsEnum, iconHelpers } from './icons';
 import { ApexTestMethod } from './lspConverter';
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
 const safeLocalize = (val: string) => nls.localize(val);
 
 // Message
@@ -161,7 +160,7 @@ export class ApexTestOutlineProvider implements vscode.TreeDataProvider<TestNode
           this.apexTestMap.set(test.definingType, apexGroup);
         }
         const apexTest = new ApexTestNode(test.methodName, test.location);
-        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+
         apexTest.name = apexGroup.label + '.' + apexTest.label;
         this.apexTestMap.set(apexTest.name, apexTest);
         apexGroup.children.push(apexTest);
@@ -240,7 +239,7 @@ export abstract class TestNode extends vscode.TreeItem {
   };
 
   // TODO: create a ticket to address this particular issue.
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+
   // @ts-ignore
   get tooltip(): string {
     return this.description;

--- a/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/apexTestRunCodeAction.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/vscode-integration/commands/apexTestRunCodeAction.test.ts
@@ -375,33 +375,30 @@ describe('Apex Test Run - Code Action', () => {
         testLevel: TestLevel.RunSpecifiedTests
       });
       const apexLibExecutor = new ApexLibraryTestRunExecutor(['testClass', 'secondTestClass'], 'path/to/dir', false);
-      runTestStub.callsFake(
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        (payload, codecoverage, exitEarly, progressReporter, token) => {
-          progressReporter.report({
-            type: 'StreamingClientProgress',
-            value: 'streamingTransportUp',
-            message: 'Listening for streaming state changes...'
-          });
-          progressReporter.report({
-            type: 'StreamingClientProgress',
-            value: 'streamingProcessingTestRun',
-            message: 'Processing test run 707500000000000001',
-            testRunId: '707500000000000001'
-          });
-          progressReporter.report({
-            type: 'FormatTestResultProgress',
-            value: 'retrievingTestRunSummary',
-            message: 'Retrieving test run summary record'
-          });
-          progressReporter.report({
-            type: 'FormatTestResultProgress',
-            value: 'queryingForAggregateCodeCoverage',
-            message: 'Querying for aggregate code coverage results'
-          });
-          return passingResult;
-        }
-      );
+      runTestStub.callsFake((payload, codecoverage, exitEarly, progressReporter, token) => {
+        progressReporter.report({
+          type: 'StreamingClientProgress',
+          value: 'streamingTransportUp',
+          message: 'Listening for streaming state changes...'
+        });
+        progressReporter.report({
+          type: 'StreamingClientProgress',
+          value: 'streamingProcessingTestRun',
+          message: 'Processing test run 707500000000000001',
+          testRunId: '707500000000000001'
+        });
+        progressReporter.report({
+          type: 'FormatTestResultProgress',
+          value: 'retrievingTestRunSummary',
+          message: 'Retrieving test run summary record'
+        });
+        progressReporter.report({
+          type: 'FormatTestResultProgress',
+          value: 'queryingForAggregateCodeCoverage',
+          message: 'Querying for aggregate code coverage results'
+        });
+        return passingResult;
+      });
 
       await apexLibExecutor.run(undefined, progress, cancellationToken);
 

--- a/packages/salesforcedx-vscode-core/src/commands/aliasList.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/aliasList.ts
@@ -10,7 +10,6 @@ import { nls } from '../messages';
 import { EmptyParametersGatherer, SfCommandlet, SfCommandletExecutor, SfWorkspaceChecker } from './util';
 
 export class AliasList extends SfCommandletExecutor<{}> {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public build(data: {}): Command {
     return new SfCommandBuilder()
       .withDescription(nls.localize('alias_list_text'))

--- a/packages/salesforcedx-vscode-core/src/commands/auth/orgLoginAccessToken.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/auth/orgLoginAccessToken.ts
@@ -19,7 +19,6 @@ export class OrgLoginAccessTokenExecutor extends LibraryCommandletExecutor<Acces
     super(nls.localize('org_login_access_token_text'), 'org_login_access_token', OUTPUT_CHANNEL);
   }
 
-  /* eslint-disable @typescript-eslint/no-unused-vars */
   public async run(
     response: ContinueResponse<AccessTokenParams>,
     progress?: vscode.Progress<{
@@ -27,7 +26,6 @@ export class OrgLoginAccessTokenExecutor extends LibraryCommandletExecutor<Acces
       increment?: number | undefined;
     }>,
     token?: vscode.CancellationToken
-    /* eslint-enable @typescript-eslint/no-unused-vars */
   ): Promise<boolean> {
     const { instanceUrl, accessToken, alias } = response.data;
     try {

--- a/packages/salesforcedx-vscode-core/src/commands/auth/orgLogout.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/auth/orgLogout.ts
@@ -35,7 +35,6 @@ export class OrgLogoutAll extends SfCommandletExecutor<{}> {
     return instance;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public build(data: {}): Command {
     return new SfCommandBuilder()
       .withDescription(nls.localize('org_logout_all_text'))
@@ -61,7 +60,6 @@ export class OrgLogoutDefault extends LibraryCommandletExecutor<string> {
     super(nls.localize('org_logout_default_text'), 'org_logout_default', OUTPUT_CHANNEL);
   }
 
-  /* eslint-disable @typescript-eslint/no-unused-vars */
   public async run(
     response: ContinueResponse<string>,
     progress?: Progress<{
@@ -69,7 +67,6 @@ export class OrgLogoutDefault extends LibraryCommandletExecutor<string> {
       increment?: number | undefined;
     }>,
     token?: CancellationToken
-    /* eslint-enable @typescript-eslint/no-unused-vars */
   ): Promise<boolean> {
     try {
       await removeUsername(response.data);

--- a/packages/salesforcedx-vscode-core/src/commands/configList.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/configList.ts
@@ -10,7 +10,6 @@ import { nls } from '../messages';
 import { EmptyParametersGatherer, SfCommandlet, SfCommandletExecutor, SfWorkspaceChecker } from './util';
 
 export class ConfigList extends SfCommandletExecutor<{}> {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public build(data: {}): Command {
     return new SfCommandBuilder()
       .withDescription(nls.localize('config_list_text'))

--- a/packages/salesforcedx-vscode-core/src/commands/configSet.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/configSet.ts
@@ -33,7 +33,6 @@ export class ConfigSetExecutor extends LibraryCommandletExecutor<{}> {
     this.usernameOrAlias = `${usernameOrAlias}`.split(',')[0];
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public async run(response: ContinueResponse<string>): Promise<boolean> {
     let result: boolean;
     let message: string | undefined;

--- a/packages/salesforcedx-vscode-core/src/commands/dataQuery.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/dataQuery.ts
@@ -87,7 +87,6 @@ export enum ApiType {
 
 const workspaceChecker = new SfWorkspaceChecker();
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const dataQuery = (explorerDir?: any): void => {
   const parameterGatherer = new GetQueryAndApiInputs();
   const commandlet = new SfCommandlet(workspaceChecker, parameterGatherer, new DataQueryExecutor());

--- a/packages/salesforcedx-vscode-core/src/commands/debuggerStop.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/debuggerStop.ts
@@ -58,7 +58,6 @@ export class DebuggerSessionDetachExecutor extends SfCommandletExecutor<IdSelect
 }
 
 export class StopActiveDebuggerSessionExecutor extends SfCommandletExecutor<{}> {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public build(data: {}): Command {
     return new SfCommandBuilder()
       .withArg('data:query')

--- a/packages/salesforcedx-vscode-core/src/commands/describeMetadata.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/describeMetadata.ts
@@ -23,7 +23,6 @@ export class DescribeMetadataExecutor extends SfCommandletExecutor<string> {
     super();
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public build(data: {}): Command {
     return new SfCommandBuilder()
       .withArg('org:list:metadata-types')

--- a/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
@@ -35,7 +35,7 @@ import {
 } from '../projectGenerate';
 import { CompositeParametersGatherer, EmptyPreChecker, SfCommandlet, SfCommandletExecutor } from '../util';
 // below uses require due to bundling restrictions
-// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unused-vars
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const AdmZip = require('adm-zip');
 
 export type InstalledPackageInfo = {
@@ -56,7 +56,6 @@ export class IsvDebugBootstrapExecutor extends SfCommandletExecutor<{}> {
   public readonly relativeApexPackageXmlPath = path.join(this.relativeMetadataTempPath, PACKAGE_XML);
   public readonly relativeInstalledPackagesPath = path.join(projectPaths.relativeToolsFolder(), INSTALLED_PACKAGES);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public build(data: {}): Command {
     throw new Error('not in use');
   }
@@ -349,12 +348,10 @@ export class IsvDebugBootstrapExecutor extends SfCommandletExecutor<{}> {
     return result;
   }
 
-  /* eslint-disable @typescript-eslint/no-unused-vars */
   protected attachExecution(
     execution: CommandExecution,
     cancellationTokenSource: vscode.CancellationTokenSource,
     cancellationToken: vscode.CancellationToken
-    /* eslint-enable @typescript-eslint/no-unused-vars */
   ) {
     channelService.streamCommandOutput(execution);
     channelService.showChannelOutput();

--- a/packages/salesforcedx-vscode-core/src/commands/listMetadata.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/listMetadata.ts
@@ -28,7 +28,6 @@ export class ListMetadataExecutor extends SfCommandletExecutor<string> {
     this.folder = folder;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public build(data: {}): Command {
     const builder = new SfCommandBuilder()
       .withArg('org:list:metadata')

--- a/packages/salesforcedx-vscode-core/src/commands/orgCreate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/orgCreate.ts
@@ -74,7 +74,6 @@ export class OrgCreateExecutor extends SfCommandletExecutor<AliasAndFileSelectio
       stdOut += realData.toString();
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     execution.processExitSubject.subscribe(async exitCode => {
       this.logMetric(execution.command.logName, startTime);
       try {

--- a/packages/salesforcedx-vscode-core/src/commands/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/orgList.ts
@@ -10,7 +10,6 @@ import { nls } from '../messages';
 import { PromptConfirmGatherer, SfCommandlet, SfCommandletExecutor, SfWorkspaceChecker } from './util';
 
 export class OrgListExecutor extends SfCommandletExecutor<{}> {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public build(data: { choice?: string }): Command {
     return new SfCommandBuilder()
       .withDescription(nls.localize('org_list_clean_text'))

--- a/packages/salesforcedx-vscode-core/src/commands/orgOpen.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/orgOpen.ts
@@ -24,7 +24,6 @@ import { workspaceUtils } from '../util';
 import { EmptyParametersGatherer, SfCommandlet, SfCommandletExecutor, SfWorkspaceChecker } from './util';
 
 export class OrgOpenContainerExecutor extends SfCommandletExecutor<{}> {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public build(data: {}): Command {
     return new SfCommandBuilder()
       .withDescription(nls.localize('org_open_default_scratch_org_text'))
@@ -94,7 +93,7 @@ export class OrgOpenContainerExecutor extends SfCommandletExecutor<{}> {
 
 export class OrgOpenExecutor extends SfCommandletExecutor<{}> {
   protected showChannelOutput = false;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
   public build(data: {}): Command {
     return new SfCommandBuilder()
       .withDescription(nls.localize('org_open_default_scratch_org_text'))

--- a/packages/salesforcedx-vscode-core/src/commands/projectGenerateManifest.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/projectGenerateManifest.ts
@@ -30,7 +30,7 @@ export class GenerateManifestExecutor extends LibraryCommandletExecutor<string> 
     this.sourcePaths = sourcePaths;
     this.responseText = responseText;
   }
-  /* eslint-disable @typescript-eslint/no-unused-vars */
+
   public async run(
     response: ContinueResponse<string>,
     progress?: vscode.Progress<{
@@ -38,7 +38,6 @@ export class GenerateManifestExecutor extends LibraryCommandletExecutor<string> 
       increment?: number | undefined;
     }>,
     token?: vscode.CancellationToken
-    /* eslint-enable @typescript-eslint/no-unused-vars */
   ): Promise<boolean> {
     if (this.sourcePaths) {
       const packageXML = await ComponentSet.fromSource(this.sourcePaths).getPackageXml();

--- a/packages/salesforcedx-vscode-core/src/commands/projectRetrieveStart.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/projectRetrieveStart.ts
@@ -50,7 +50,6 @@ export class ProjectRetrieveStartExecutor extends SfCommandletExecutor<{}> {
     this.flag = flag;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public build(data: {}): Command {
     const builder = new SfCommandBuilder()
       .withDescription(nls.localize(this.params.description.default))

--- a/packages/salesforcedx-vscode-core/src/commands/refreshSObjects.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/refreshSObjects.ts
@@ -83,7 +83,7 @@ export class RefreshSObjectsExecutor extends SfCommandletExecutor<{}> {
   public static readonly onRefreshSObjectsCommandCompletion =
     RefreshSObjectsExecutor.refreshSObjectsCommandCompletionEventEmitter.event;
   private static isActive = false;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
   public build(data: {}): Command {
     return new SfCommandBuilder()
       .withDescription(nls.localize('sobjects_refresh'))

--- a/packages/salesforcedx-vscode-core/src/commands/source/sourceTrackingGetStatusExecutor.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/source/sourceTrackingGetStatusExecutor.ts
@@ -27,7 +27,6 @@ export class SourceTrackingGetStatusExecutor extends LibraryCommandletExecutor<s
     channelService.showChannelOutput();
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public async run(response: ContinueResponse<string>): Promise<boolean> {
     await this.execute();
     return true;

--- a/packages/salesforcedx-vscode-core/src/commands/startApexDebugLogging.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/startApexDebugLogging.ts
@@ -37,7 +37,6 @@ export class StartApexDebugLoggingExecutor extends SfCommandletExecutor<{}> {
     channelService.streamCommandOutput(execution);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public async execute(response: ContinueResponse<{}>): Promise<void> {
     const startTime = process.hrtime();
     const executionWrapper = new CompositeCliCommandExecutor(this.build()).execute(this.cancellationToken);

--- a/packages/salesforcedx-vscode-core/src/commands/stopApexDebugLogging.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/stopApexDebugLogging.ts
@@ -20,7 +20,6 @@ export class StopApexDebugLoggingExecutor extends SfCommandletExecutor<{}> {
     return deleteTraceFlag();
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public execute(response: ContinueResponse<{}>): void {
     const startTime = process.hrtime();
     const cancellationTokenSource = new vscode.CancellationTokenSource();

--- a/packages/salesforcedx-vscode-core/src/commands/templates/baseTemplateCommand.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/baseTemplateCommand.ts
@@ -49,7 +49,6 @@ export abstract class BaseTemplateCommand extends SfCommandletExecutor<DirFileNa
     taskViewService.addCommandExecution(execution, cancellationTokenSource);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected runPostCommandTasks(data: DirFileNameSelection) {
     // By default do nothing
     // This method is overridden in child classes to run any post command tasks

--- a/packages/salesforcedx-vscode-core/src/commands/util/sfCommandletExecutor.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/sfCommandletExecutor.ts
@@ -101,12 +101,10 @@ export abstract class SfCommandletExecutor<T> implements CommandletExecutor<T> {
     return parsed;
   }
 
-  /* eslint-disable @typescript-eslint/no-unused-vars */
   protected getTelemetryData(
     success: boolean,
     response: ContinueResponse<T>,
     output: string
-    /* eslint-enable @typescript-eslint/no-unused-vars */
   ): TelemetryData | undefined {
     return;
   }
@@ -117,7 +115,7 @@ export abstract class SfCommandletExecutor<T> implements CommandletExecutor<T> {
    * timestamps post-operation, in order to be in sync for the
    * "Detect Conflicts at Sync" setting.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
   protected updateCache(result: any): void {}
 
   public abstract build(data: T): Command;

--- a/packages/salesforcedx-vscode-core/src/conflict/conflictNode.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/conflictNode.ts
@@ -52,7 +52,7 @@ export class ConflictNode extends vscode.TreeItem {
   }
 
   // TODO: create issue to track this
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+
   // @ts-ignore
   get tooltip() {
     if (this._conflict) {

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -113,17 +113,14 @@ const flagIgnoreConflicts: FlagParameter<string> = {
   flag: '--ignore-conflicts'
 };
 
-const registerCommands = (
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  extensionContext: vscode.ExtensionContext
-): vscode.Disposable => {
+const registerCommands = (extensionContext: vscode.ExtensionContext): vscode.Disposable => {
   // Customer-facing commands
   const orgLoginAccessTokenCmd = vscode.commands.registerCommand('sf.org.login.access.token', orgLoginAccessToken);
   const orgLoginWebCmd = vscode.commands.registerCommand('sf.org.login.web', orgLoginWeb);
   const orgLoginWebDevHubCmd = vscode.commands.registerCommand('sf.org.login.web.dev.hub', orgLoginWebDevHub);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
   const orgLogoutAllCmd = vscode.commands.registerCommand('sf.org.logout.all', orgLogoutAll);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
   const orgLogoutDefaultCmd = vscode.commands.registerCommand('sf.org.logout.default', orgLogoutDefault);
   const openDocumentationCmd = vscode.commands.registerCommand('sf.open.documentation', openDocumentation);
   const orgCreateCmd = vscode.commands.registerCommand('sf.org.create', orgCreate);
@@ -241,12 +238,10 @@ const registerCommands = (
 
   const diffFile = vscode.commands.registerCommand('sf.diff', sourceDiff);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const diffFolder = vscode.commands.registerCommand('sf.folder.diff', sourceFolderDiff);
 
   const forceRefreshSObjectsCmd = vscode.commands.registerCommand('sf.internal.refreshsobjects', refreshSObjects);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const renameLightningComponentCmd = vscode.commands.registerCommand(
     'sf.rename.lightning.component',
     renameLightningComponent
@@ -323,10 +318,7 @@ const registerCommands = (
   );
 };
 
-const registerInternalDevCommands = (
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  extensionContext: vscode.ExtensionContext
-): vscode.Disposable => {
+const registerInternalDevCommands = (extensionContext: vscode.ExtensionContext): vscode.Disposable => {
   const internalLightningGenerateAppCmd = vscode.commands.registerCommand(
     'sf.internal.lightning.generate.app',
     internalLightningGenerateApp

--- a/packages/salesforcedx-vscode-core/src/orgBrowser/metadataOutlineProvider.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/metadataOutlineProvider.ts
@@ -68,7 +68,6 @@ export class MetadataOutlineProvider implements vscode.TreeDataProvider<BrowserN
         break;
       case NodeType.Folder:
       case NodeType.MetadataType:
-        // eslint-disable-next-line no-case-declarations
         let nodeType: NodeType = NodeType.MetadataComponent;
         if (TypeUtils.FOLDER_TYPES.has(element.fullName)) {
           nodeType = NodeType.Folder;

--- a/packages/salesforcedx-vscode-core/src/predicates/salesforcePredicates.ts
+++ b/packages/salesforcedx-vscode-core/src/predicates/salesforcePredicates.ts
@@ -14,7 +14,6 @@ import { nls } from '../messages';
 import { workspaceUtils } from '../util';
 
 export class IsSalesforceProjectOpened implements Predicate<typeof workspace> {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public apply(item: typeof workspace): PredicateResponse {
     if (!workspaceUtils.hasRootWorkspace()) {
       return PredicateResponse.of(false, nls.localize('predicates_no_folder_opened_text'));

--- a/packages/salesforcedx-vscode-core/src/services/getCoreLoggerService.ts
+++ b/packages/salesforcedx-vscode-core/src/services/getCoreLoggerService.ts
@@ -5,8 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 import { FieldValue, Fields, LoggerInterface, LogLine, LoggerLevelValue } from '@salesforce/vscode-service-provider';
 
 export class CoreLoggerService implements LoggerInterface {

--- a/packages/salesforcedx-vscode-lwc/src/commands/lightningLwcStart.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/lightningLwcStart.ts
@@ -66,7 +66,6 @@ export class LightningLwcStartExecutor extends SfCommandletExecutor<{}> {
     );
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public execute(response: ContinueResponse<{}>): void {
     const startTime = process.hrtime();
     const cancellationTokenSource = new vscode.CancellationTokenSource();

--- a/packages/salesforcedx-vscode-lwc/src/index.ts
+++ b/packages/salesforcedx-vscode-lwc/src/index.ts
@@ -114,7 +114,6 @@ const getActivationMode = (): string => {
   return config.get('activationMode') || 'autodetect'; // default to autodetect
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const registerCommands = (_extensionContext: ExtensionContext): Disposable => {
   return Disposable.from(
     commands.registerCommand('sf.lightning.lwc.start', lightningLwcStart),

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/codeLens/provideLwcTestCodeLens.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/codeLens/provideLwcTestCodeLens.ts
@@ -18,7 +18,7 @@ import { TestExecutionInfo, TestInfoKind, TestType } from '../types';
  */
 export const provideLwcTestCodeLens = async (
   document: TextDocument,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
   token: CancellationToken
 ): Promise<CodeLens[]> => {
   const fsPath = document.uri.fsPath;

--- a/packages/salesforcedx-vscode-soql/src/editor/soqlEditorProvider.ts
+++ b/packages/salesforcedx-vscode-soql/src/editor/soqlEditorProvider.ts
@@ -28,7 +28,7 @@ export class SOQLEditorProvider implements vscode.CustomTextEditorProvider {
   public async resolveCustomTextEditor(
     document: vscode.TextDocument,
     webviewPanel: vscode.WebviewPanel,
-    // eslint-disable-next-line
+
     _token: vscode.CancellationToken
   ): Promise<void> {
     const soqlBuilderWebAssetsPathParam: string[] =

--- a/packages/salesforcedx-vscode-soql/src/lspClient/codeCompletion.ts
+++ b/packages/salesforcedx-vscode-soql/src/lspClient/codeCompletion.ts
@@ -60,7 +60,6 @@ async function filterByContext(
   return filteredItems;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function isString(x: any): x is string {
   return typeof x === 'string';
 }
@@ -208,7 +207,7 @@ const expandFunctions: {
             .map(v =>
               newCompletionItem(
                 v.value,
-                // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+
                 "'" + v.value + "'",
                 CompletionItemKind.Value
               )


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->
# The PR needs to be with an updated jorje jar. Do NOT merge until jar is updated.
### What does this PR do?
This PR exposes a user setting that user can choose to turn on the telemetry for error reporting from Apex Language server. The setting is off by default, so error telemetry is not reported to save the storage on azure.

### What issues does this PR fix or reference?
@W-17380991@

### Functionality Before
Apex Language Server reports telemetry about errors.

### Functionality After
Apex Language Server does not report error telemetry by default, and user can toggle the setting on for us to understand the error.
