### PR TITLE
fix: prevent `Request textDocument/documentHighlight failed with message: Debug Failure. False expression. Code: -32603` error when selecting Javascript code in the embedded `<script>` tag

### DIFF
--- a/packages/salesforcedx-visualforce-language-server/src/modes/javascriptMode.ts
+++ b/packages/salesforcedx-visualforce-language-server/src/modes/javascriptMode.ts
@@ -238,7 +238,7 @@ export const getJavascriptMode = (documentRegions: LanguageModelCache<HTMLDocume
         document.uri
       ]);
 
-      if (highlights && highlights.length > 0) {
+      if (highlights?.length > 0) {
         // Only one file to search above so there should only be one result
         return highlights[0].highlightSpans.map(entry => {
           return {

--- a/packages/salesforcedx-visualforce-language-server/src/modes/javascriptMode.ts
+++ b/packages/salesforcedx-visualforce-language-server/src/modes/javascriptMode.ts
@@ -234,10 +234,11 @@ export const getJavascriptMode = (documentRegions: LanguageModelCache<HTMLDocume
     findDocumentHighlight: (document: TextDocument, position: Position): DocumentHighlight[] => {
       updateCurrentTextDocument(document);
       const highlights = jsLanguageService.getDocumentHighlights(FILE_NAME, currentTextDocument.offsetAt(position), [
+        FILE_NAME,
         document.uri
       ]);
 
-      if (highlights.length > 0) {
+      if (highlights && highlights.length > 0) {
         // Only one file to search above so there should only be one result
         return highlights[0].highlightSpans.map(entry => {
           return {


### PR DESCRIPTION
### What does this PR do?
Prevent Visualforce Language Server from throwing `Request textDocument/documentHighlight failed with message: Debug Failure. False expression. Code: -32603` error when selecting Javascript code in the `<script>` tag embedded in Visualforce page/component, as described in #5279.

### What issues does this PR fix or reference?
Fixes [#5279](https://github.com/forcedotcom/salesforcedx-vscode/issues/5279), which is linked to @W-14687315@

### Functionality Before
Clicking/selecting any Javascript code's variable/function inside `<script>` tags on a Visualforce page throws an error, forcing VSCode to switch to the Output panel, "Visualforce Language Server" outputs.

### Functionality After
No error occurs, clicked/selected javascript mode's variable/function is highlighted across the Javascript/HTML handlers code.  
Please see [this comment](https://github.com/forcedotcom/salesforcedx-vscode/issues/5279#issuecomment-2506557611) for the root cause analysis.

### == DISCLAIMER: no tests ==
Unfortunately, lacking experience with Typescript/Jest - thus unable to properly test the solution...  
Only verified the fix by modifying the compiled `{userDir}/.vscode/salesforce.salesforcedx-vscode-visualforce-#/dist/languageserver.js` code.