### PR TITLE
fix: use correct telemetry enable setting

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
+++ b/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
@@ -173,7 +173,7 @@ export class TelemetryService implements TelemetryServiceInterface {
 
   public isTelemetryExtensionConfigurationEnabled(): boolean {
     return (
-      workspace.getConfiguration('telemetry').get<boolean>('enableTelemetry', true) &&
+      workspace.getConfiguration('telemetry').get<string>('telemetryLevel', 'off') !== 'off' &&
       workspace.getConfiguration(SFDX_CORE_CONFIGURATION_NAME).get<boolean>('telemetry.enabled', true)
     );
   }

--- a/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
+++ b/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
@@ -173,7 +173,7 @@ export class TelemetryService implements TelemetryServiceInterface {
 
   public isTelemetryExtensionConfigurationEnabled(): boolean {
     return (
-      workspace.getConfiguration('telemetry').get<string>('telemetryLevel', 'off') !== 'off' &&
+      workspace.getConfiguration('telemetry').get<string>('telemetryLevel', 'all') !== 'off' &&
       workspace.getConfiguration(SFDX_CORE_CONFIGURATION_NAME).get<boolean>('telemetry.enabled', true)
     );
   }

--- a/packages/salesforcedx-utils-vscode/test/jest/telemetry/telemetry.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/telemetry/telemetry.test.ts
@@ -88,9 +88,9 @@ describe('Telemetry', () => {
       ['off', false, false]
     ])(
       'should return true if telemetryLevel is %s and SFDX_CORE_CONFIGURATION_NAME.telemetry.enabled is %s',
-      (first, second, expectedResult) => {
-        mockConfiguration.get.mockReturnValueOnce(first);
-        mockConfiguration.get.mockReturnValueOnce(second);
+      (firstReturnValue, secondReturnValue, expectedResult) => {
+        mockConfiguration.get.mockReturnValueOnce(firstReturnValue);
+        mockConfiguration.get.mockReturnValueOnce(secondReturnValue);
 
         const result = instance.isTelemetryExtensionConfigurationEnabled();
 

--- a/packages/salesforcedx-utils-vscode/test/jest/telemetry/telemetry.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/telemetry/telemetry.test.ts
@@ -5,8 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { TelemetryServiceInterface } from '@salesforce/vscode-service-provider';
+import { workspace } from 'vscode';
 import { TelemetryService } from '../../../src';
-import { SFDX_CORE_EXTENSION_NAME } from '../../../src/constants';
+import { SFDX_CORE_CONFIGURATION_NAME, SFDX_CORE_EXTENSION_NAME } from '../../../src/constants';
 import { TelemetryServiceProvider } from '../../../src/services/telemetry';
 
 describe('Telemetry', () => {
@@ -62,6 +63,40 @@ describe('Telemetry', () => {
       const secondInstance = TelemetryServiceProvider.getInstance(extensionName);
       expect(secondInstance).toBe(firstInstance);
     });
+  });
+  describe('Telemetry Service - isTelemetryExtensionConfigurationEnabled', () => {
+    const mockedWorkspace = jest.mocked(workspace);
+    let instance: TelemetryServiceInterface;
+
+    const mockConfiguration = {
+      get: jest.fn().mockReturnValue('true')
+    };
+
+    beforeEach(() => {
+      jest.spyOn(mockedWorkspace, 'getConfiguration').mockReturnValue(mockConfiguration as any);
+      instance = TelemetryService.getInstance();
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it.each([
+      ['on', true, true],
+      ['off', true, false],
+      ['on', false, false],
+      ['off', false, false]
+    ])(
+      'should return true if telemetryLevel is %s and SFDX_CORE_CONFIGURATION_NAME.telemetry.enabled is %s',
+      (first, second, expectedResult) => {
+        mockConfiguration.get.mockReturnValueOnce(first);
+        mockConfiguration.get.mockReturnValueOnce(second);
+
+        const result = instance.isTelemetryExtensionConfigurationEnabled();
+
+        expect(result).toBe(expectedResult);
+      }
+    );
   });
   describe('Telemetry Service - isTelemetryEnabled', () => {
     let spyIsTelemetryExtensionConfigurationEnabled: jest.SpyInstance;

--- a/packages/salesforcedx-utils-vscode/test/jest/telemetry/telemetry.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/telemetry/telemetry.test.ts
@@ -82,9 +82,9 @@ describe('Telemetry', () => {
     });
 
     it.each([
-      ['on', true, true],
+      ['all', true, true],
       ['off', true, false],
-      ['on', false, false],
+      ['all', false, false],
       ['off', false, false]
     ])(
       'should return true if telemetryLevel is %s and SFDX_CORE_CONFIGURATION_NAME.telemetry.enabled is %s',


### PR DESCRIPTION
### What does this PR do?
This PR updates the configuration used to check if telemetry is enable from `enableTelemetry `  -> `telemetryLevel `

### What issues does this PR fix or reference?
[@W-16742651@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000021EuMgYAK/view)

### Functionality Before
Disabling telemetry was still sending telemetry in vscode.

### Functionality After
Disabling telemetry prevent telemetry from being sent in vscode.
