### PR TITLE
fix: excluding schema from bundling to avoid warning

### DIFF
--- a/packages/salesforcedx-vscode-core/esbuild.config.js
+++ b/packages/salesforcedx-vscode-core/esbuild.config.js
@@ -12,7 +12,7 @@ const sharedConfig = {
   bundle: true,
   format: 'cjs',
   platform: 'node',
-  external: ['vscode', 'applicationinsights', 'shelljs'],
+  external: ['vscode', 'applicationinsights', 'shelljs', '@salesforce/schemas'],
   minify: true,
   keepNames: true,
   plugins: [esbuildPluginPino({ transports: ['pino-pretty'] })],

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -90,7 +90,7 @@
       "dependencies": {
         "applicationinsights": "1.0.7",
         "shelljs": "0.8.5",
-        "@salesforce/schemas": "*"
+        "@salesforce/schemas": "1.9.0"
       },
       "devDependencies": {}
     }

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -89,7 +89,8 @@
       "main": "dist/src/index.js",
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "shelljs": "0.8.5"
+        "shelljs": "0.8.5",
+        "@salesforce/schemas": "*"
       },
       "devDependencies": {}
     }


### PR DESCRIPTION
excluding schema from bundling to avoid warning

### What does this PR do?
This excludes the schema module from bundling so the path is accessible when referencing it from sfdx-project.json.

### What issues does this PR fix or reference?
[@W-16771336@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000021ThG5YAK/view)

### Functionality Before
Users of extensions were seeing warning `Unable to load schema from '/Users/<user>/.vscode/extensions/salesforce.salesforcedx-vscode-core-61.12.0/node_modules/@salesforce/schemas/project-scratch-def.schema.json` when they open sfdx-project.json

### Functionality After
The warning goes away.
