### PR TITLE
fix: hide commands outside of forceapp main default

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -241,7 +241,7 @@
         },
         {
           "command": "sf.folder.diff",
-          "when": "explorerResourceIsFolder && sf:project_opened && sf:has_target_org"
+          "when": "explorerResourceIsFolder && sf:project_opened && sf:has_target_org && resourcePath =~ /force-app\\/main\\/default/"
         },
         {
           "command": "sf.analytics.generate.template",
@@ -293,11 +293,11 @@
         },
         {
           "command": "sf.diff",
-          "when": "!explorerResourceIsFolder && sf:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org"
+          "when": "!explorerResourceIsFolder && sf:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org && resourcePath =~ /force-app\\/main\\/default/"
         },
         {
           "command": "sf.retrieve.source.path",
-          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org"
+          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org && resourcePath =~ /force-app\\/main\\/default/"
         },
         {
           "command": "sf.retrieve.in.manifest",
@@ -305,7 +305,7 @@
         },
         {
           "command": "sf.deploy.source.path",
-          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org"
+          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org && resourcePath =~ /force-app\\/main\\/default/"
         },
         {
           "command": "sf.deploy.in.manifest",
@@ -313,15 +313,15 @@
         },
         {
           "command": "sf.delete.source",
-          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org"
+          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org && resourcePath =~ /force-app\\/main\\/default/"
         },
         {
           "command": "sf.project.generate.manifest",
-          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest'"
+          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && resourcePath =~ /force-app\\/main\\/default/"
         },
         {
           "command": "sf.rename.lightning.component",
-          "when": "sf:project_opened && resource =~ /.*\\/(lwc|aura)\\/.*(\\/[^\\/]+\\.(html|css|js|xml|svg|cmp|app|design|auradoc))?$/"
+          "when": "sf:project_opened && resource =~ /.*\\/(lwc|aura)\\/.*(\\/[^\\/]+\\.(html|css|js|xml|svg|cmp|app|design|auradoc))?$/ && resourcePath =~ /force-app\\/main\\/default/"
         }
       ],
       "commandPalette": [

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -195,7 +195,7 @@
       "editor/context": [
         {
           "command": "sf.retrieve.current.source.file",
-          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org"
+          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org && resourcePath =~ /force-app\\/main\\/default/"
         },
         {
           "command": "sf.retrieve.in.manifest",
@@ -203,7 +203,7 @@
         },
         {
           "command": "sf.deploy.current.source.file",
-          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org"
+          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org && resourcePath =~ /force-app\\/main\\/default/"
         },
         {
           "command": "sf.deploy.in.manifest",
@@ -211,11 +211,11 @@
         },
         {
           "command": "sf.delete.source.current.file",
-          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org"
+          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org && resourcePath =~ /force-app\\/main\\/default/"
         },
         {
           "command": "sf.diff",
-          "when": "!explorerResourceIsFolder && sf:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org"
+          "when": "!explorerResourceIsFolder && sf:project_opened && resourceLangId != 'forcesourcemanifest' && sf:has_target_org && resourcePath =~ /force-app\\/main\\/default/"
         },
         {
           "command": "sf.launch.apex.replay.debugger.with.current.file",


### PR DESCRIPTION
### What does this PR do?
- Makes the constraints in package.json stricter so that `SFDX: Delete This from Project and Org`, `SFDX: Deploy This Source to Org`, `SFDX: Diff File Against Org` and `SFDX: Retrieve This Source from Org` commands don't show up in the context menu for files that aren't meant to be deployed to the org.

### What issues does this PR fix or reference?
@W-17568713@

### Functionality After
![image](https://github.com/user-attachments/assets/0d763cf1-7eb7-417d-93b6-351c87702190)

