### PR TITLE
feat: exclude auraenabled as valid annotation

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/settings.ts
+++ b/packages/salesforcedx-vscode-apex/src/settings.ts
@@ -17,7 +17,8 @@ const APEX_ACTION_PROP_DEF_MODIFIERS = ['static'];
 const APEX_ACTION_PROP_ACCESS_MODIFIERS = ['global', 'public'];
 const APEX_ACTION_CLASS_REST_ANNOTATION = ['RestResource'];
 const APEX_ACTION_METHOD_REST_ANNOTATION = ['HttpDelete', 'HttpGet', 'HttpPatch', 'HttpPost', 'HttpPut'];
-const APEX_ACTION_METHOD_ANNOTATION = ['AuraEnabled'];
+// 'AuraEnabled' was removed for W-17550288 and should be added back with W-17579102
+const APEX_ACTION_METHOD_ANNOTATION: string[] = [];
 
 // Default eligibility for general OAS generation. Users can changed the setting through VSCode configurations
 const DEFAULT_CLASS_ACCESS_MODIFIERS = ['global', 'public'];

--- a/packages/salesforcedx-vscode-apex/test/jest/settings.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/settings.test.ts
@@ -6,7 +6,7 @@
  */
 import { SFDX_CORE_CONFIGURATION_NAME } from '@salesforce/salesforcedx-utils-vscode';
 import * as vscode from 'vscode';
-import { retrieveEnableSyncInitJobs, retrieveTestCodeCoverage } from '../../src/settings';
+import { retrieveAAMethodAnnotations, retrieveEnableSyncInitJobs, retrieveTestCodeCoverage } from '../../src/settings';
 
 describe('settings Unit Tests.', () => {
   const vscodeMocked = jest.mocked(vscode);
@@ -39,5 +39,16 @@ describe('settings Unit Tests.', () => {
     expect(result).toBe(true);
     expect(getConfigurationMock).toHaveBeenCalledWith();
     expect(getFn).toHaveBeenCalledWith('salesforcedx-vscode-apex.wait-init-jobs', true);
+  });
+
+  it('Should be able to get retrieveAAMethodAnnotations setting.', () => {
+    getConfigurationMock.mockReturnValue({
+      get: getFn.mockReturnValue(['UserDefinedModifier'])
+    } as any);
+
+    const result = retrieveAAMethodAnnotations();
+    expect(result).toEqual(['UserDefinedModifier']);
+    expect(getConfigurationMock).toHaveBeenCalledWith();
+    expect(getFn).toHaveBeenCalledWith('salesforcedx-vscode-apex.apexoas.aa.method.annotations', []);
   });
 });


### PR DESCRIPTION
feat: exclude auraenabled as valid annotation

### What does this PR do?
removes auraenabled from valid apex action method annotations list.

### What issues does this PR fix or reference?
[@W-17550288@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000027eEZ9YAM/view)

### Functionality Before
AuraEnabled was passing eligibility checks

### Functionality After
AuraEnabled fails eligibility checks
