### PR TITLE
feat: add operations tag to esr xml and operationId to yaml

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/commands/apexActionController.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/apexActionController.ts
@@ -17,7 +17,8 @@ import { nls } from '../messages';
 import {
   ApexClassOASEligibleResponse,
   ApexClassOASGatherContextResponse,
-  ApexOASInfo
+  ApexOASInfo,
+  ExternalServiceOperation
 } from '../openApiUtilities/schemas';
 import { getTelemetryService } from '../telemetry/telemetry';
 import { MetadataOrchestrator } from './metadataOrchestrator';
@@ -244,6 +245,7 @@ export class ApexActionController {
     const baseName = path.basename(fullPath).split('.')[0];
     const safeOasSpec = oasSpec.replaceAll('"', '&apos;').replaceAll('type: Id', 'type: string');
     const { description, version } = this.extractInfoProperties(safeOasSpec);
+    const operations = this.getOperationsFromYaml(safeOasSpec);
     const orgVersion = await (await WorkspaceContextUtil.getInstance().getConnection()).retrieveMaxApiVersion();
     if (!orgVersion) {
       throw new Error(nls.localize('error_retrieving_org_version'));
@@ -274,6 +276,9 @@ export class ApexActionController {
           schemaUploadFileName: `${baseName.toLowerCase()}_openapi`,
           status: 'Complete',
           systemVersion: '3',
+          operations: {
+            ExternalServiceOperation: operations
+          },
           registrationProvider: baseName,
           ...(this.isVersionGte(orgVersion, '63.0') // Guarded inclusion for API version 254 and above (instance api version 63.0 and above)
             ? {
@@ -309,9 +314,26 @@ export class ApexActionController {
     if (!parsed?.info?.description || !parsed?.info?.version) {
       throw new Error(nls.localize('error_parsing_yaml'));
     }
+
     return {
       description: parsed?.info?.description,
       version: parsed?.info?.version
     };
+  };
+  private getOperationsFromYaml = (oasSpec: string): ExternalServiceOperation[] => {
+    const parsed = parse(oasSpec);
+    if (!parsed?.paths) {
+      throw new Error(nls.localize('error_parsing_yaml'));
+    }
+    const operations = parsed.paths
+      ? Object.keys(parsed.paths).flatMap(path =>
+          Object.keys(parsed.paths[path]).map(operation => ({
+            name: parsed.paths[path][operation].operationId,
+            active: true
+          }))
+        )
+      : [];
+
+    return operations;
   };
 }

--- a/packages/salesforcedx-vscode-apex/src/commands/apexActionController.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/apexActionController.ts
@@ -326,9 +326,9 @@ export class ApexActionController {
       throw new Error(nls.localize('error_parsing_yaml'));
     }
     const operations = parsed.paths
-      ? Object.keys(parsed.paths).flatMap(path =>
-          Object.keys(parsed.paths[path]).map(operation => ({
-            name: parsed.paths[path][operation].operationId,
+      ? Object.keys(parsed.paths).flatMap(p =>
+          Object.keys(parsed.paths[p]).map(operation => ({
+            name: parsed.paths[p][operation].operationId,
             active: true
           }))
         )

--- a/packages/salesforcedx-vscode-apex/src/commands/apexActionController.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/apexActionController.ts
@@ -260,7 +260,12 @@ export class ApexActionController {
       if (jsonObj.ExternalServiceRegistration?.schema) {
         jsonObj.ExternalServiceRegistration.schema = safeOasSpec;
       } else {
-        throw new Error('schema_element_not_found');
+        throw new Error(nls.localize('schema_element_not_found'));
+      }
+      if (jsonObj.ExternalServiceRegistration?.operations.ExternalServiceOperation) {
+        jsonObj.ExternalServiceRegistration.operations.ExternalServiceOperation = operations;
+      } else {
+        throw new Error(nls.localize('operations_element_not_found'));
       }
     } else {
       // Create a new XML structure

--- a/packages/salesforcedx-vscode-apex/src/commands/apexActionController.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/apexActionController.ts
@@ -262,7 +262,7 @@ export class ApexActionController {
       } else {
         throw new Error(nls.localize('schema_element_not_found'));
       }
-      if (jsonObj.ExternalServiceRegistration?.operations.ExternalServiceOperation) {
+      if (jsonObj.ExternalServiceRegistration?.operations?.ExternalServiceOperation) {
         jsonObj.ExternalServiceRegistration.operations.ExternalServiceOperation = operations;
       } else {
         throw new Error(nls.localize('operations_element_not_found'));

--- a/packages/salesforcedx-vscode-apex/src/commands/metadataOrchestrator.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/metadataOrchestrator.ts
@@ -203,7 +203,7 @@ export class MetadataOrchestrator {
   Ensure no sensitive details are included. Decline requests unrelated to OpenAPI v3 specs or asking for sensitive information.`;
 
     const userPrompt =
-      'Generate an OpenAPI v3 specification for the following Apex class. The OpenAPI v3 specification should be a YAML file. The paths should be in the format of /{ClassName}/{MethodName} for all the @AuraEnabled methods specified. For every `type: object`, generate a `#/components/schemas` entry for that object. The method should have a $ref entry pointing to the generated `#/components/schemas` entry. Only include methods that have the @AuraEnabled annotation in the paths of the OpenAPI v3 specification. I do not want AUTHOR_PLACEHOLDER in the result. Do not forget info.description property';
+      'Generate an OpenAPI v3 specification for the following Apex class. The OpenAPI v3 specification should be a YAML file. The paths should be in the format of /{ClassName}/{MethodName} for all the @AuraEnabled methods specified. For every `type: object`, generate a `#/components/schemas` entry for that object. The method should have a $ref entry pointing to the generated `#/components/schemas` entry. Only include methods that have the @AuraEnabled annotation in the paths of the OpenAPI v3 specification. I do not want AUTHOR_PLACEHOLDER in the result. Do not forget info.description property. For each path, you define operations (HTTP methods) that can be used to access that path. Make sure that each operation includes a mandatory operationId property, which should be a unique string matching the operations name.';
 
     const systemTag = '<|system|>';
     const endOfPromptTag = '<|endofprompt|>';

--- a/packages/salesforcedx-vscode-apex/src/messages/i18n.ja.ts
+++ b/packages/salesforcedx-vscode-apex/src/messages/i18n.ja.ts
@@ -101,6 +101,7 @@ export const messages = {
   registry_access_failed: 'Failed to retrieve ESR directory name from the registry.',
   full_path_failed: 'Failed to determine the full path for the OpenAPI document.',
   schema_element_not_found: 'The <schema> element was not found in the provided XML.',
+  operations_element_not_found: 'The <operations> element was not found in the provided XML.',
   error_retrieving_org_version: 'Failed to retrieve org version',
   error_parsing_yaml: 'Error parsing YAML'
 };

--- a/packages/salesforcedx-vscode-apex/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-apex/src/messages/i18n.ts
@@ -121,6 +121,7 @@ export const messages = {
   registry_access_failed: 'Failed to retrieve ESR directory name from the registry.',
   full_path_failed: 'Failed to determine the full path for the OpenAPI document.',
   schema_element_not_found: 'The <schema> element was not found in the provided XML.',
+  operations_element_not_found: 'The <operations> element was not found in the provided XML.',
   error_retrieving_org_version: 'Failed to retrieve org version',
   error_parsing_yaml: 'Error parsing YAML'
 };

--- a/packages/salesforcedx-vscode-apex/src/openApiUtilities/schemas.ts
+++ b/packages/salesforcedx-vscode-apex/src/openApiUtilities/schemas.ts
@@ -83,6 +83,11 @@ export type ApexOASInfo = {
   description: string;
   version: string;
 };
+
+export type ExternalServiceOperation = {
+  name: string;
+  active: boolean;
+};
 // export interface ApexClassOASFilter {
 //   modifiers: string[] | null;
 // }


### PR DESCRIPTION
### What does this PR do?
- Adds Operations Tag to External Service Registration XML and operationId to yaml within schema tag

### What issues does this PR fix or reference?
@W-17626169@

### ESR
```
<?xml version="1.0" encoding="UTF-8"?>
<ExternalServiceRegistration xmlns="http://soap.sforce.com/2006/04/metadata">
  <description>Property API for managing properties</description>
  <label>PropertyAPI</label>
  <schema>openapi: 3.0.0
info:
  title: Property API
  version: &apos;1.0.0&apos;
  description: Property API for managing properties
paths:
  /PropertyAPI/getPropertyById:
    get:
      summary: Get property by ID
      operationId: getPropertyById
      responses:
        &apos;200&apos;:
          description: Property found
          content:
            application/json:
              schema:
                $ref: &apos;#/components/schemas/Property&apos;
  /PropertyAPI/createProperty:
    post:
      summary: Create property
      operationId: createProperty
      parameters:
        - name: searchKey
          in: query
          required: true
          schema:
            type: string
        - name: maxPrice
          in: query
          required: true
          schema:
            type: integer
        - name: minBedrooms
          in: query
          required: true
          schema:
            type: integer
        - name: minBathrooms
          in: query
          required: true
          schema:
            type: integer
      responses:
        &apos;200&apos;:
          description: Property created
          content:
            application/json:
              schema:
                $ref: &apos;#/components/schemas/Property&apos;
components:
  schemas:
    Property:
      type: object
      properties:
        Id:
          type: string
        Address:
          type: string
        Price:
          type: integer
        Bedrooms:
          type: integer
        Bathrooms:
          type: integer
</schema>
  <schemaType>OpenApi3</schemaType>
  <schemaUploadFileExtension>yaml</schemaUploadFileExtension>
  <schemaUploadFileName>propertyapi_openapi</schemaUploadFileName>
  <status>Complete</status>
  <systemVersion>3</systemVersion>
  <operations>
    <ExternalServiceOperation>
      <name>getPropertyById</name>
      <active>true</active>
    </ExternalServiceOperation>
    <ExternalServiceOperation>
      <name>createProperty</name>
      <active>true</active>
    </ExternalServiceOperation>
  </operations>
  <registrationProvider>PropertyAPI</registrationProvider>
  <registrationProviderType>Custom</registrationProviderType>
  <namedCredentialReference>Guariqueteo1</namedCredentialReference>
</ExternalServiceRegistration>

```
