### PR TITLE
W 17693649

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/oas/documentProcessorPipeline/ruleset.spectral.ts
+++ b/packages/salesforcedx-vscode-apex/src/oas/documentProcessorPipeline/ruleset.spectral.ts
@@ -122,6 +122,60 @@ const ruleset = {
         field: 'description',
         function: truthy
       }
+    },
+    'operations-description': {
+      description: 'operations.description is required',
+      given: '$.paths[*][get,post,put,delete,patch]',
+      message: 'operations.description is required',
+      then: {
+        field: 'description',
+        function: truthy
+      }
+    },
+    'operations-operationId': {
+      description: 'operations.operationId is required',
+      given: '$.paths[*][get,post,put,delete,patch]',
+      message: 'operations.operationId is required',
+      then: {
+        field: 'operationId',
+        function: truthy
+      }
+    },
+    'operations-callbacks': {
+      description: 'operations.callbacks should not be present',
+      given: '$.paths[*][get,post,put,delete,patch]',
+      message: 'operations.callbacks should not be present',
+      then: {
+        field: 'callbacks',
+        function: undefined
+      }
+    },
+    'operations-deprecated': {
+      description: 'operations.deprecated should not be present',
+      given: '$.paths[*][get,post,put,delete,patch]',
+      message: 'operations.deprecated should not be present',
+      then: {
+        field: 'deprecated',
+        function: undefined
+      }
+    },
+    'operations-security': {
+      description: 'operations.security should not be present',
+      given: '$.paths[*][get,post,put,delete,patch]',
+      message: 'operations.security should not be present',
+      then: {
+        field: 'security',
+        function: undefined
+      }
+    },
+    'operations-servers': {
+      description: 'operations.servers should not be present',
+      given: '$.paths[*][get,post,put,delete,patch]',
+      message: 'operations.servers should not be present',
+      then: {
+        field: 'servers',
+        function: undefined
+      }
     }
   }
 };

--- a/packages/salesforcedx-vscode-apex/src/oas/documentProcessorPipeline/ruleset.spectral.ts
+++ b/packages/salesforcedx-vscode-apex/src/oas/documentProcessorPipeline/ruleset.spectral.ts
@@ -197,7 +197,7 @@ const ruleset = {
           schema: {
             type: 'object',
             properties: {
-              'application/xml': { type: 'object' }
+              'application/json': { type: 'object' }
             },
             additionalProperties: false
           }
@@ -482,6 +482,51 @@ const ruleset = {
             }
           }
         }
+      }
+    },
+    'response-headers': {
+      description: 'operations.responses.headers are not allowed',
+      given: '$.paths[*][get,post,put,delete,patch].responses.*',
+      message: 'operations.responses.headers are not allowed',
+      then: {
+        field: 'headers',
+        function: undefined
+      }
+    },
+    'response-content': {
+      description: 'operations.responses.content should be application/json',
+      given: '$.paths[*][get,post,put,delete,patch].responses.*',
+      message: 'operations.responses.content should be application/json',
+      then: {
+        field: 'content',
+        function: schema,
+        functionOptions: {
+          schema: {
+            type: 'object',
+            properties: {
+              'application/json': { type: 'object' }
+            },
+            additionalProperties: false
+          }
+        }
+      }
+    },
+    'request-media-encoding': {
+      description: 'request-media-encoding is not allowed',
+      given: '$.paths[*][get,post,put,delete,patch].requestBody.content.*',
+      message: 'request-media-encoding is not allowed',
+      then: {
+        field: 'encoding',
+        function: undefined
+      }
+    },
+    'response-media-encoding': {
+      description: 'response-media-encoding is not allowed',
+      given: '$.paths[*][get,post,put,delete,patch].responses.*.content.*',
+      message: 'response-media-encoding is not allowed',
+      then: {
+        field: 'encoding',
+        function: undefined
       }
     }
   }

--- a/packages/salesforcedx-vscode-apex/src/oas/documentProcessorPipeline/ruleset.spectral.ts
+++ b/packages/salesforcedx-vscode-apex/src/oas/documentProcessorPipeline/ruleset.spectral.ts
@@ -176,6 +176,33 @@ const ruleset = {
         field: 'servers',
         function: undefined
       }
+    },
+    'request-body-description': {
+      description: 'requestBody description is required',
+      given: '$.paths[*][get,post,put,delete,patch].requestBody',
+      message: 'requestBody description is required',
+      then: {
+        field: 'description',
+        function: truthy
+      }
+    },
+    'request-body-content': {
+      description: 'requestBody content must be /application/json',
+      given: '$.paths[*][get,post,put,delete,patch].requestBody',
+      message: 'requestBody content must be /application/json',
+      then: {
+        field: 'content',
+        function: schema,
+        functionOptions: {
+          schema: {
+            type: 'object',
+            properties: {
+              'application/xml': { type: 'object' }
+            },
+            additionalProperties: false
+          }
+        }
+      }
     }
   }
 };

--- a/packages/salesforcedx-vscode-apex/src/oas/documentProcessorPipeline/ruleset.spectral.ts
+++ b/packages/salesforcedx-vscode-apex/src/oas/documentProcessorPipeline/ruleset.spectral.ts
@@ -203,6 +203,286 @@ const ruleset = {
           }
         }
       }
+    },
+    'paths-parameters-in': {
+      description: 'paths.parameters in `cookie` is not allowed',
+      given: '$.paths[*]',
+      message: 'paths.parameters in `cookie` is not allowed',
+      then: {
+        field: 'parameters',
+        function: schema,
+        functionOptions: {
+          schema: {
+            type: 'array',
+            items: {
+              type: 'object',
+              patternProperties: {
+                in: {
+                  type: 'string',
+                  pattern: 'query|header|path'
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    'operations-parameters-in': {
+      description: 'operations.parameters in `cookie` is not allowed',
+      given: '$.paths[*][get,post,put,delete,patch]',
+      message: 'operations.parameters in `cookie` is not allowed',
+      then: {
+        field: 'parameters',
+        function: schema,
+        functionOptions: {
+          schema: {
+            type: 'array',
+            items: {
+              type: 'object',
+              patternProperties: {
+                in: {
+                  type: 'string',
+                  pattern: 'query|header|path'
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    'paths-parameters-description': {
+      description: 'paths.parameters.description is required',
+      given: '$.paths[*]',
+      message: 'paths.parameters.description is required',
+      then: {
+        field: 'parameters',
+        function: schema,
+        functionOptions: {
+          schema: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                description: {
+                  type: 'string'
+                }
+              },
+              required: ['description']
+            }
+          }
+        }
+      }
+    },
+    'operations-parameters-description': {
+      description: 'operations.parameters.description is required',
+      given: '$.paths[*][get,post,put,delete,patch]',
+      message: 'operations.parameters.description is required',
+      then: {
+        field: 'parameters',
+        function: schema,
+        functionOptions: {
+          schema: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                description: {
+                  type: 'string'
+                }
+              },
+              required: ['description']
+            }
+          }
+        }
+      }
+    },
+    'paths-parameters-deprecated': {
+      description: 'path.parameters.deprecated is not allowed',
+      given: '$.paths[*]',
+      message: 'path.parameters.deprecated is not allowed',
+      then: {
+        field: 'parameters',
+        function: schema,
+        functionOptions: {
+          schema: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                in: { type: 'string' },
+                description: {
+                  type: 'string'
+                },
+                required: { type: 'boolean' },
+                allowEmptyValue: { type: 'boolean' },
+                style: { type: 'string' },
+                explode: { type: 'boolean' },
+                allowReserved: { type: 'boolean' },
+                schema: { type: 'object' },
+                example: {},
+                examples: { type: 'object' },
+                content: { type: 'object' }
+              },
+              additionalProperties: false
+            }
+          }
+        }
+      }
+    },
+    'operations-parameters-deprecated': {
+      description: 'operations.parameters.deprecated is not allowed',
+      given: '$.paths[*][get,post,put,delete,patch]',
+      message: 'operations.parameters.deprecated is not allowed',
+      then: {
+        field: 'parameters',
+        function: schema,
+        functionOptions: {
+          schema: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                in: { type: 'string' },
+                description: {
+                  type: 'string'
+                },
+                required: { type: 'boolean' },
+                allowEmptyValue: { type: 'boolean' },
+                style: { type: 'string' },
+                explode: { type: 'boolean' },
+                allowReserved: { type: 'boolean' },
+                schema: { type: 'object' },
+                example: {},
+                examples: { type: 'object' },
+                content: { type: 'object' }
+              },
+              additionalProperties: false
+            }
+          }
+        }
+      }
+    },
+    'paths-parameters-explode': {
+      description: 'path.parameters.explode should be set to false',
+      given: '$.paths[*]',
+      message: 'path.parameters.explode should be set to false',
+      then: {
+        field: 'parameters',
+        function: schema,
+        functionOptions: {
+          schema: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                explode: { enum: [false] }
+              }
+            }
+          }
+        }
+      }
+    },
+    'operations-parameters-explode': {
+      description: 'operations.parameters.explode should be set to false',
+      given: '$.paths[*][get,post,put,delete,patch]',
+      message: 'operations.parameters.explode should be set to false',
+      then: {
+        field: 'parameters',
+        function: schema,
+        functionOptions: {
+          schema: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                explode: { enum: [false] }
+              }
+            }
+          }
+        }
+      }
+    },
+    'paths-parameters-allowReserved': {
+      description: 'path.parameters.allowReserved should be set to false',
+      given: '$.paths[*]',
+      message: 'path.parameters.allowReserved should be set to false',
+      then: {
+        field: 'parameters',
+        function: schema,
+        functionOptions: {
+          schema: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                allowReserved: { enum: [false] }
+              }
+            }
+          }
+        }
+      }
+    },
+    'operations-parameters-allowReserved': {
+      description: 'operations.parameters.allowReserved should be set to false',
+      given: '$.paths[*][get,post,put,delete,patch]',
+      message: 'operations.parameters.allowReserved should be set to false',
+      then: {
+        field: 'parameters',
+        function: schema,
+        functionOptions: {
+          schema: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                allowReserved: { enum: [false] }
+              }
+            }
+          }
+        }
+      }
+    },
+    'paths-parameters-content': {
+      description: 'path.parameters.content should be `application/json`',
+      given: '$.paths[*]',
+      message: 'path.parameters.content should be `application/json`',
+      then: {
+        field: 'parameters',
+        function: schema,
+        functionOptions: {
+          schema: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                content: { enum: ['application/json'] }
+              }
+            }
+          }
+        }
+      }
+    },
+    'operations-parameters-content': {
+      description: 'operations.parameters.content should be `application/json`',
+      given: '$.paths[*][get,post,put,delete,patch]',
+      message: 'operations.parameters.content should be `application/json`',
+      then: {
+        field: 'parameters',
+        function: schema,
+        functionOptions: {
+          schema: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                content: { enum: ['application/json'] }
+              }
+            }
+          }
+        }
+      }
     }
   }
 };

--- a/packages/salesforcedx-vscode-apex/test/jest/oas/documentProcessingPipeline/ruleset.spectral.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/oas/documentProcessingPipeline/ruleset.spectral.test.ts
@@ -240,6 +240,201 @@ components:
     expect(JSON.stringify(result)).toMatch(/info-description/);
   });
 
+  it('operations-description is required', async () => {
+    const inputYaml = `openapi: 3.0.0
+info:
+  title: demoClass API
+  version: '1.0.0'
+servers:
+  - url: https://files.example.com
+    description: Optional server description, e.g. Main (production) server
+paths:
+  /demoClass/doDelete:
+    delete:
+      summary: delete method
+      operationId: doDelete
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        Id:
+          type: string`;
+
+    const result = await runRulesetAgainstYaml(inputYaml);
+
+    expect(JSON.stringify(result)).toMatch(/operations-description/);
+  });
+
+  it('operations-operationId is required', async () => {
+    const inputYaml = `openapi: 3.0.0
+info:
+  title: demoClass API
+  version: '1.0.0'
+servers:
+  - url: https://files.example.com
+    description: Optional server description, e.g. Main (production) server
+paths:
+  /demoClass/doDelete:
+    delete:
+      summary: delete method
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        Id:
+          type: string`;
+
+    const result = await runRulesetAgainstYaml(inputYaml);
+
+    expect(JSON.stringify(result)).toMatch(/operations-operationId/);
+  });
+
+  it('operations-callbacks should not be present', async () => {
+    const inputYaml = `openapi: 3.0.0
+info:
+  title: demoClass API
+  version: '1.0.0'
+servers:
+  - url: https://files.example.com
+    description: Optional server description, e.g. Main (production) server
+paths:
+  /demoClass/doDelete:
+    delete:
+      summary: delete method
+      callbacks: # Callback definition
+        myEvent: # Event name
+          "{$request.body#/callbackUrl}": # The callback URL,
+            # Refers to the passed URL
+            post:
+              requestBody: # Contents of the callback message
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        message:
+                          type: string
+                          example: Some event happened
+                      required:
+                        - message
+              responses: # Expected responses to the callback message
+                "200":
+                  description: Your server returns this code if it accepts the callback
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        Id:
+          type: string`;
+
+    const result = await runRulesetAgainstYaml(inputYaml);
+
+    expect(JSON.stringify(result)).toMatch(/operations-callbacks/);
+  });
+
+  it('operations-deprecated should not be present', async () => {
+    const inputYaml = `openapi: 3.0.0
+info:
+  title: demoClass API
+  version: '1.0.0'
+servers:
+  - url: https://files.example.com
+    description: Optional server description, e.g. Main (production) server
+paths:
+  /demoClass/doDelete:
+    delete:
+      deprecated: true
+      summary: delete method
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        Id:
+          type: string`;
+
+    const result = await runRulesetAgainstYaml(inputYaml);
+
+    expect(JSON.stringify(result)).toMatch(/operations-deprecated/);
+  });
+
+  it('operations-security should not be present', async () => {
+    const inputYaml = `openapi: 3.0.0
+info:
+  title: demoClass API
+  version: '1.0.0'
+servers:
+  - url: https://files.example.com
+    description: Optional server description, e.g. Main (production) server
+paths:
+  /demoClass/doDelete:
+    delete:
+      security:
+        - OAuth2: [admin]
+      summary: delete method
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        Id:
+          type: string`;
+
+    const result = await runRulesetAgainstYaml(inputYaml);
+
+    expect(JSON.stringify(result)).toMatch(/operations-security/);
+  });
+
+  it('operations-servers should not be present', async () => {
+    const inputYaml = `openapi: 3.0.0
+info:
+  title: demoClass API
+  version: '1.0.0'
+servers:
+  - url: https://files.example.com
+    description: Optional server description, e.g. Main (production) server
+paths:
+  /demoClass/doDelete:
+    delete:
+      servers:
+        - url: https://files.example.com
+        description: Override base path for all operations with the /files path
+      summary: delete method
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        Id:
+          type: string`;
+
+    const result = await runRulesetAgainstYaml(inputYaml);
+
+    expect(JSON.stringify(result)).toMatch(/operations-servers/);
+  });
+
   it('should not log errors when all rules are met', async () => {
     const inputYaml = `openapi: 3.0.0
 info:
@@ -255,6 +450,7 @@ paths:
     delete:
       summary: delete method
       operationId: doDelete
+      description: 'great op description'
       responses:
         '200':
           description: OK
@@ -277,6 +473,12 @@ components:
     expect(JSON.stringify(result)).not.toMatch(/paths-method-head/);
     expect(JSON.stringify(result)).not.toMatch(/paths-method-trace/);
     expect(JSON.stringify(result)).not.toMatch(/info-description/);
+    expect(JSON.stringify(result)).not.toMatch(/operations-description/);
+    expect(JSON.stringify(result)).not.toMatch(/operations-operationId/);
+    expect(JSON.stringify(result)).not.toMatch(/operations-callbacks/);
+    expect(JSON.stringify(result)).not.toMatch(/operations-deprecated/);
+    expect(JSON.stringify(result)).not.toMatch(/operations-security/);
+    expect(JSON.stringify(result)).not.toMatch(/operations-servers/);
   });
 });
 

--- a/packages/salesforcedx-vscode-apex/test/jest/oas/documentProcessingPipeline/ruleset.spectral.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/oas/documentProcessingPipeline/ruleset.spectral.test.ts
@@ -435,6 +435,75 @@ components:
     expect(JSON.stringify(result)).toMatch(/operations-servers/);
   });
 
+  it('request body description is required', async () => {
+    const inputYaml = `openapi: 3.0.0
+info:
+  title: demoClass API
+  version: '1.0.0'
+servers:
+  - url: https://files.example.com
+    description: Optional server description, e.g. Main (production) server
+paths:
+  /demoClass/doDelete:
+    delete:
+      summary: delete method
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        Id:
+          type: string`;
+
+    const result = await runRulesetAgainstYaml(inputYaml);
+
+    expect(JSON.stringify(result)).toMatch(/request-body-description/);
+  });
+
+  it('requestBody content must be /application/json', async () => {
+    const inputYaml = `openapi: 3.0.0
+info:
+  title: demoClass API
+  version: '1.0.0'
+servers:
+  - url: https://files.example.com
+    description: Optional server description, e.g. Main (production) server
+paths:
+  /demoClass/doDelete:
+    delete:
+      summary: delete method
+      requestBody:
+        required: true
+        description: 'truly great requestBody description'
+        content:
+          text/plain:
+            schema:
+              type: string
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        Id:
+          type: string`;
+
+    const result = await runRulesetAgainstYaml(inputYaml);
+
+    expect(JSON.stringify(result)).toMatch(/request-body-content/);
+  });
+
   it('should not log errors when all rules are met', async () => {
     const inputYaml = `openapi: 3.0.0
 info:
@@ -479,6 +548,8 @@ components:
     expect(JSON.stringify(result)).not.toMatch(/operations-deprecated/);
     expect(JSON.stringify(result)).not.toMatch(/operations-security/);
     expect(JSON.stringify(result)).not.toMatch(/operations-servers/);
+    expect(JSON.stringify(result)).not.toMatch(/request-body-description/);
+    expect(JSON.stringify(result)).not.toMatch(/request-body-content/);
   });
 });
 

--- a/packages/salesforcedx-vscode-apex/test/jest/oas/documentProcessingPipeline/ruleset.spectral.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/oas/documentProcessingPipeline/ruleset.spectral.test.ts
@@ -504,6 +504,515 @@ components:
     expect(JSON.stringify(result)).toMatch(/request-body-content/);
   });
 
+  it('paths.parameters in `cookie` is not allowed', async () => {
+    const inputYaml = `openapi: 3.0.0
+info:
+  title: demoClass API
+  version: '1.0.0'
+servers:
+  - url: https://files.example.com
+    description: Optional server description, e.g. Main (production) server
+paths:
+  /demoClass/doDelete:
+    parameters:
+      - in: cookie
+        name: csrftoken
+        schema:
+          type: string
+    delete:
+      summary: delete method
+      requestBody:
+        required: true
+        description: 'truly great requestBody description'
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        Id:
+          type: string`;
+
+    const result = await runRulesetAgainstYaml(inputYaml);
+
+    expect(JSON.stringify(result)).toMatch(/paths-parameters-in/);
+  });
+
+  it('operations.parameters in `cookie` is not allowed', async () => {
+    const inputYaml = `openapi: 3.0.0
+info:
+  title: demoClass API
+  version: '1.0.0'
+servers:
+  - url: https://files.example.com
+    description: Optional server description, e.g. Main (production) server
+paths:
+  /demoClass/doDelete:
+    delete:
+      summary: delete method
+      operationId: doDelete
+      description: 'great op description'
+      parameters:
+        - in: cookie
+          name: csrftoken
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        Id:
+          type: string`;
+
+    const result = await runRulesetAgainstYaml(inputYaml);
+
+    expect(JSON.stringify(result)).toMatch(/operations-parameters-in/);
+  });
+
+  it('paths.parameters description is required', async () => {
+    const inputYaml = `openapi: 3.0.0
+info:
+  title: demoClass API
+  version: '1.0.0'
+servers:
+  - url: https://files.example.com
+    description: Optional server description, e.g. Main (production) server
+paths:
+  /demoClass/doDelete:
+    parameters:
+      - in: path
+        name: id # Note the name is the same as in the path
+        required: true
+        schema:
+          type: integer
+          minimum: 1
+    delete:
+      summary: delete method
+      requestBody:
+        required: true
+        description: 'truly great requestBody description'
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        Id:
+          type: string`;
+
+    const result = await runRulesetAgainstYaml(inputYaml);
+
+    expect(JSON.stringify(result)).toMatch(/paths-parameters-description/);
+  });
+
+  it('operations.parameters description is required', async () => {
+    const inputYaml = `openapi: 3.0.0
+info:
+  title: demoClass API
+  version: '1.0.0'
+  description: info description
+servers:
+  - url: https://files.example.com
+    description: Optional server description, e.g. Main (production) server
+paths:
+  /demoClass/doDelete:
+    delete:
+      summary: delete method
+      operationId: doDelete
+      description: 'great op description'
+      parameters:
+        - in: path
+          name: id # Note the name is the same as in the path
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        Id:
+          type: string`;
+
+    const result = await runRulesetAgainstYaml(inputYaml);
+
+    expect(JSON.stringify(result)).toMatch(/operations-parameters-description/);
+  });
+
+  it('paths.parameters deprecated is not allowed', async () => {
+    const inputYaml = `openapi: 3.0.0
+info:
+  title: demoClass API
+  version: '1.0.0'
+servers:
+  - url: https://files.example.com
+    description: Optional server description, e.g. Main (production) server
+paths:
+  /demoClass/doDelete:
+    parameters:
+      - in: path
+        name: id # Note the name is the same as in the path
+        required: true
+        schema:
+          type: integer
+          minimum: 1
+        description: desc
+        deprecated: true
+    delete:
+      summary: delete method
+      requestBody:
+        required: true
+        description: 'truly great requestBody description'
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        Id:
+          type: string`;
+
+    const result = await runRulesetAgainstYaml(inputYaml);
+
+    expect(JSON.stringify(result)).toMatch(/paths-parameters-deprecated/);
+  });
+
+  it('operations.parameters deprecated is not allowed', async () => {
+    const inputYaml = `openapi: 3.0.0
+info:
+  title: demoClass API
+  version: '1.0.0'
+servers:
+  - url: https://files.example.com
+    description: Optional server description, e.g. Main (production) server
+paths:
+  /demoClass/doDelete:
+    delete:
+      summary: delete method
+      parameters:
+        - in: path
+          name: id # Note the name is the same as in the path
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+          description: desc
+          deprecated: true
+      requestBody:
+        required: true
+        description: 'truly great requestBody description'
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        Id:
+          type: string`;
+
+    const result = await runRulesetAgainstYaml(inputYaml);
+
+    expect(JSON.stringify(result)).toMatch(/operations-parameters-deprecated/);
+  });
+
+  it('paths.parameters explode should be false', async () => {
+    const inputYaml = `openapi: 3.0.0
+info:
+  title: demoClass API
+  version: '1.0.0'
+servers:
+  - url: https://files.example.com
+    description: Optional server description, e.g. Main (production) server
+paths:
+  /demoClass/doDelete:
+    parameters:
+      - in: path
+        name: id # Note the name is the same as in the path
+        required: true
+        schema:
+          type: integer
+          minimum: 1
+        description: desc
+        explode: true
+    delete:
+      summary: delete method
+      requestBody:
+        required: true
+        description: 'truly great requestBody description'
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        Id:
+          type: string`;
+
+    const result = await runRulesetAgainstYaml(inputYaml);
+
+    expect(JSON.stringify(result)).toMatch(/paths-parameters-explode/);
+  });
+
+  it('operations.parameters explode should be false', async () => {
+    const inputYaml = `openapi: 3.0.0
+info:
+  title: demoClass API
+  version: '1.0.0'
+servers:
+  - url: https://files.example.com
+    description: Optional server description, e.g. Main (production) server
+paths:
+  /demoClass/doDelete:
+    delete:
+      summary: delete method
+      parameters:
+        - in: path
+          name: id # Note the name is the same as in the path
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+          description: desc
+          explode: true
+      requestBody:
+        required: true
+        description: 'truly great requestBody description'
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        Id:
+          type: string`;
+
+    const result = await runRulesetAgainstYaml(inputYaml);
+
+    expect(JSON.stringify(result)).toMatch(/operations-parameters-explode/);
+  });
+
+  it('paths.parameters allowReserved should be false', async () => {
+    const inputYaml = `openapi: 3.0.0
+info:
+  title: demoClass API
+  version: '1.0.0'
+servers:
+  - url: https://files.example.com
+    description: Optional server description, e.g. Main (production) server
+paths:
+  /demoClass/doDelete:
+    parameters:
+      - in: path
+        name: id # Note the name is the same as in the path
+        required: true
+        schema:
+          type: integer
+          minimum: 1
+        description: desc
+        allowReserved: true
+    delete:
+      summary: delete method
+      requestBody:
+        required: true
+        description: 'truly great requestBody description'
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        Id:
+          type: string`;
+
+    const result = await runRulesetAgainstYaml(inputYaml);
+
+    expect(JSON.stringify(result)).toMatch(/paths-parameters-allowReserved/);
+  });
+
+  it('operations.parameters allowReserved should be false', async () => {
+    const inputYaml = `openapi: 3.0.0
+info:
+  title: demoClass API
+  version: '1.0.0'
+servers:
+  - url: https://files.example.com
+    description: Optional server description, e.g. Main (production) server
+paths:
+  /demoClass/doDelete:
+    delete:
+      summary: delete method
+      parameters:
+        - in: path
+          name: id # Note the name is the same as in the path
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+          description: desc
+          allowReserved: true
+      requestBody:
+        required: true
+        description: 'truly great requestBody description'
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        Id:
+          type: string`;
+
+    const result = await runRulesetAgainstYaml(inputYaml);
+
+    expect(JSON.stringify(result)).toMatch(/operations-parameters-allowReserved/);
+  });
+
+  it('paths.parameters content should be `application/json`', async () => {
+    const inputYaml = `openapi: 3.0.0
+info:
+  title: demoClass API
+  version: '1.0.0'
+servers:
+  - url: https://files.example.com
+    description: Optional server description, e.g. Main (production) server
+paths:
+  /demoClass/doDelete:
+    parameters:
+      - in: path
+        name: id # Note the name is the same as in the path
+        required: true
+        schema:
+          type: integer
+          minimum: 1
+        description: desc
+        content:
+          text/plain
+    delete:
+      summary: delete method
+      requestBody:
+        required: true
+        description: 'truly great requestBody description'
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        Id:
+          type: string`;
+
+    const result = await runRulesetAgainstYaml(inputYaml);
+
+    expect(JSON.stringify(result)).toMatch(/paths-parameters-content/);
+  });
+
+  it('operations.parameters content should be `application/json`', async () => {
+    const inputYaml = `openapi: 3.0.0
+info:
+  title: demoClass API
+  version: '1.0.0'
+servers:
+  - url: https://files.example.com
+    description: Optional server description, e.g. Main (production) server
+paths:
+  /demoClass/doDelete:
+    delete:
+      summary: delete method
+      parameters:
+        - in: path
+          name: id # Note the name is the same as in the path
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+          description: desc
+          content:
+            text/plain
+      requestBody:
+        required: true
+        description: 'truly great requestBody description'
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        Id:
+          type: string`;
+
+    const result = await runRulesetAgainstYaml(inputYaml);
+
+    expect(JSON.stringify(result)).toMatch(/operations-parameters-content/);
+  });
+
   it('should not log errors when all rules are met', async () => {
     const inputYaml = `openapi: 3.0.0
 info:
@@ -516,10 +1025,26 @@ servers:
 paths:
   /demoClass/doDelete:
     description: 'great path description'
+    parameters:
+      - in: path
+        name: id # Note the name is the same as in the path
+        required: true
+        schema:
+          type: integer
+          minimum: 1
+        description: The user ID
     delete:
       summary: delete method
       operationId: doDelete
       description: 'great op description'
+      parameters:
+        - in: path
+          name: id # Note the name is the same as in the path
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+          description: The user ID
       responses:
         '200':
           description: OK
@@ -550,6 +1075,18 @@ components:
     expect(JSON.stringify(result)).not.toMatch(/operations-servers/);
     expect(JSON.stringify(result)).not.toMatch(/request-body-description/);
     expect(JSON.stringify(result)).not.toMatch(/request-body-content/);
+    expect(JSON.stringify(result)).not.toMatch(/paths-parameters-in/);
+    expect(JSON.stringify(result)).not.toMatch(/operations-parameters-in/);
+    expect(JSON.stringify(result)).not.toMatch(/paths-parameters-description/);
+    expect(JSON.stringify(result)).not.toMatch(/operations-parameters-description/);
+    expect(JSON.stringify(result)).not.toMatch(/paths-parameters-deprecated/);
+    expect(JSON.stringify(result)).not.toMatch(/operations-parameters-deprecated/);
+    expect(JSON.stringify(result)).not.toMatch(/paths-parameters-explode/);
+    expect(JSON.stringify(result)).not.toMatch(/operations-parameters-explode/);
+    expect(JSON.stringify(result)).not.toMatch(/paths-parameters-allowReserved/);
+    expect(JSON.stringify(result)).not.toMatch(/operations-parameters-allowReserved/);
+    expect(JSON.stringify(result)).not.toMatch(/paths-parameters-content/);
+    expect(JSON.stringify(result)).not.toMatch(/operations-parameters-content/);
   });
 });
 


### PR DESCRIPTION
feat: adding rulesets for operations, parameters, request, response & media type

### What does this PR do?
Adds the remaining salesforce specific rules.

### What issues does this PR fix or reference?
[@W-17693649@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000028gXx5YAE/view)

### Functionality Before
Rulesets for operations, parameters, request, response & media type didn't exist.

### Functionality After
Rulesets for operations, parameters, request, response & media type exist.
