### PR TITLE
feat: call Mulesoft ACD extension with command "mule-dx-api.open-api-project" and OAS document vscode URI when new OAS doc created

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/commands/apexActionController.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/apexActionController.ts
@@ -107,6 +107,23 @@ export class ApexActionController {
               );
             }
           }
+
+          // Step 8: Call Mulesoft extension if installed
+          if (await this.isCommandAvailable('mule-dx-api.open-api-project')) {
+            try {
+              const yamlUri = vscode.Uri.file(this.replaceXmlToYaml(fullPath[1]));
+              await vscode.commands.executeCommand('mule-dx-api.open-api-project', yamlUri);
+              console.log('mule-dx-api.open-api-project command executed successfully');
+            } catch (error) {
+              telemetryService.sendEventData('mule-dx-api.open-api-project command could not be executed', {
+                error: error.message
+              });
+              console.error('mule-dx-api.open-api-project command could not be executed', error);
+            }
+          } else {
+            telemetryService.sendEventData('mule-dx-api.open-api-project command not found');
+            console.log('mule-dx-api.open-api-project command not found');
+          }
         }
       );
 
@@ -502,5 +519,15 @@ export class ApexActionController {
       vscode.Uri.file(filepath2),
       diffWindowName
     );
+  };
+
+  /**
+   * Checks if a VSCode command is available.
+   * @param commandId Command ID of the VSCode command to check
+   * @returns boolean - true if the command is available, false otherwise
+   */
+  private isCommandAvailable = async (commandId: string): Promise<boolean> => {
+    const commands = await vscode.commands.getCommands(true);
+    return commands.includes(commandId);
   };
 }

--- a/packages/salesforcedx-vscode-apex/src/commands/apexActionController.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/apexActionController.ts
@@ -109,21 +109,22 @@ export class ApexActionController {
           }
 
           // Step 8: Call Mulesoft extension if installed
-          if (await this.isCommandAvailable('mule-dx-api.open-api-project')) {
-            try {
-              const yamlUri = vscode.Uri.file(this.replaceXmlToYaml(fullPath[1]));
-              await vscode.commands.executeCommand('mule-dx-api.open-api-project', yamlUri);
-              console.log('mule-dx-api.open-api-project command executed successfully');
-            } catch (error) {
-              telemetryService.sendEventData('mule-dx-api.open-api-project command could not be executed', {
-                error: error.message
-              });
-              console.error('mule-dx-api.open-api-project command could not be executed', error);
+          const callMulesoftExtension = async () => {
+            if (await this.isCommandAvailable('mule-dx-api.open-api-project')) {
+              try {
+                const yamlUri = vscode.Uri.file(this.replaceXmlToYaml(fullPath[1]));
+                await vscode.commands.executeCommand('mule-dx-api.open-api-project', yamlUri);
+              } catch (error) {
+                telemetryService.sendEventData('mule-dx-api.open-api-project command could not be executed', {
+                  error: error.message
+                });
+                console.error('mule-dx-api.open-api-project command could not be executed', error);
+              }
+            } else {
+              telemetryService.sendEventData('mule-dx-api.open-api-project command not found');
             }
-          } else {
-            telemetryService.sendEventData('mule-dx-api.open-api-project command not found');
-            console.log('mule-dx-api.open-api-project command not found');
-          }
+          };
+          await callMulesoftExtension();
         }
       );
 


### PR DESCRIPTION
### What does this PR do?
When a new OpenAPI v3 specification is created:
- Calls the "mule-dx-api.open-api-project" command with the OAS document vscode URI if the command is available
- Sends an error to telemetry if the command is not available or the command cannot be executed

### What issues does this PR fix or reference?
@W-17681341@
