### PR TITLE
fix: updating ruleset to find parameter related issue if parameter is defined and tests

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/oas/documentProcessorPipeline/ruleset.spectral.ts
+++ b/packages/salesforcedx-vscode-apex/src/oas/documentProcessorPipeline/ruleset.spectral.ts
@@ -11,6 +11,39 @@ const ruleset = {
   extends: [oas],
   // the rules defined below are based on recommendations from https://docs.google.com/document/d/1WwfAPlB4YKHyRhLm1g_hHZja4hjbYkoTrIqIZvGxE5s/edit?tab=t.0
   rules: {
+    'info-contact': {
+      description: 'info-contact rule disabled',
+      given: '$',
+      message: 'info-contact rule disabled',
+      then: {
+        field: 'info',
+        function: schema,
+        functionOptions: {
+          schema: {
+            type: 'object',
+            properties: {
+              contact: {}
+            }
+          }
+        }
+      }
+    },
+    'operation-tag-defined': {
+      description: 'operation-tag-defined rule disabled',
+      given: '$.paths[*][get,post,put,delete,patch]',
+      message: 'operation-tag-defined rule disabled',
+      then: {
+        function: schema,
+        functionOptions: {
+          schema: {
+            type: 'object',
+            properties: {
+              tags: {}
+            }
+          }
+        }
+      }
+    },
     'openapi-version': {
       description: 'openapi version must be 3.0.0',
       given: '$',

--- a/packages/salesforcedx-vscode-apex/src/oas/documentProcessorPipeline/ruleset.spectral.ts
+++ b/packages/salesforcedx-vscode-apex/src/oas/documentProcessorPipeline/ruleset.spectral.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { enumeration, pattern, schema, truthy, undefined } from '@stoplight/spectral-functions';
+import { enumeration, schema, truthy, undefined } from '@stoplight/spectral-functions';
 import { oas } from '@stoplight/spectral-rulesets';
 
 const ruleset = {
@@ -209,17 +209,31 @@ const ruleset = {
       given: '$.paths[*]',
       message: 'paths.parameters in `cookie` is not allowed',
       then: {
-        field: 'parameters',
         function: schema,
         functionOptions: {
           schema: {
-            type: 'array',
-            items: {
-              type: 'object',
-              patternProperties: {
-                in: {
-                  type: 'string',
-                  pattern: 'query|header|path'
+            if: {
+              properties: {
+                parameters: {
+                  type: 'array'
+                }
+              }
+            },
+            then: {
+              properties: {
+                parameters: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    patternProperties: {
+                      in: {
+                        not: {
+                          type: 'string',
+                          enum: ['cookie']
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -232,17 +246,29 @@ const ruleset = {
       given: '$.paths[*][get,post,put,delete,patch]',
       message: 'operations.parameters in `cookie` is not allowed',
       then: {
-        field: 'parameters',
         function: schema,
         functionOptions: {
           schema: {
-            type: 'array',
-            items: {
-              type: 'object',
-              patternProperties: {
-                in: {
-                  type: 'string',
-                  pattern: 'query|header|path'
+            if: {
+              properties: {
+                parameters: {
+                  type: 'array'
+                }
+              }
+            },
+            then: {
+              properties: {
+                parameters: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    patternProperties: {
+                      in: {
+                        type: 'string',
+                        enum: ['query', 'header', 'path']
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -255,19 +281,31 @@ const ruleset = {
       given: '$.paths[*]',
       message: 'paths.parameters.description is required',
       then: {
-        field: 'parameters',
         function: schema,
         functionOptions: {
           schema: {
-            type: 'array',
-            items: {
-              type: 'object',
+            if: {
               properties: {
-                description: {
-                  type: 'string'
+                parameters: {
+                  type: 'array'
                 }
-              },
-              required: ['description']
+              }
+            },
+            then: {
+              properties: {
+                parameters: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      description: {
+                        type: 'string'
+                      }
+                    },
+                    required: ['description']
+                  }
+                }
+              }
             }
           }
         }
@@ -278,19 +316,31 @@ const ruleset = {
       given: '$.paths[*][get,post,put,delete,patch]',
       message: 'operations.parameters.description is required',
       then: {
-        field: 'parameters',
         function: schema,
         functionOptions: {
           schema: {
-            type: 'array',
-            items: {
-              type: 'object',
+            if: {
               properties: {
-                description: {
-                  type: 'string'
+                parameters: {
+                  type: 'array'
                 }
-              },
-              required: ['description']
+              }
+            },
+            then: {
+              properties: {
+                parameters: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      description: {
+                        type: 'string'
+                      }
+                    },
+                    required: ['description']
+                  }
+                }
+              }
             }
           }
         }
@@ -301,30 +351,42 @@ const ruleset = {
       given: '$.paths[*]',
       message: 'path.parameters.deprecated is not allowed',
       then: {
-        field: 'parameters',
         function: schema,
         functionOptions: {
           schema: {
-            type: 'array',
-            items: {
-              type: 'object',
+            if: {
               properties: {
-                name: { type: 'string' },
-                in: { type: 'string' },
-                description: {
-                  type: 'string'
-                },
-                required: { type: 'boolean' },
-                allowEmptyValue: { type: 'boolean' },
-                style: { type: 'string' },
-                explode: { type: 'boolean' },
-                allowReserved: { type: 'boolean' },
-                schema: { type: 'object' },
-                example: {},
-                examples: { type: 'object' },
-                content: { type: 'object' }
-              },
-              additionalProperties: false
+                parameters: {
+                  type: 'array'
+                }
+              }
+            },
+            then: {
+              properties: {
+                parameters: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      name: { type: 'string' },
+                      in: { type: 'string' },
+                      description: {
+                        type: 'string'
+                      },
+                      required: { type: 'boolean' },
+                      allowEmptyValue: { type: 'boolean' },
+                      style: { type: 'string' },
+                      explode: { type: 'boolean' },
+                      allowReserved: { type: 'boolean' },
+                      schema: { type: 'object' },
+                      example: {},
+                      examples: { type: 'object' },
+                      content: { type: 'object' }
+                    },
+                    additionalProperties: false
+                  }
+                }
+              }
             }
           }
         }
@@ -335,30 +397,42 @@ const ruleset = {
       given: '$.paths[*][get,post,put,delete,patch]',
       message: 'operations.parameters.deprecated is not allowed',
       then: {
-        field: 'parameters',
         function: schema,
         functionOptions: {
           schema: {
-            type: 'array',
-            items: {
-              type: 'object',
+            if: {
               properties: {
-                name: { type: 'string' },
-                in: { type: 'string' },
-                description: {
-                  type: 'string'
-                },
-                required: { type: 'boolean' },
-                allowEmptyValue: { type: 'boolean' },
-                style: { type: 'string' },
-                explode: { type: 'boolean' },
-                allowReserved: { type: 'boolean' },
-                schema: { type: 'object' },
-                example: {},
-                examples: { type: 'object' },
-                content: { type: 'object' }
-              },
-              additionalProperties: false
+                parameters: {
+                  type: 'array'
+                }
+              }
+            },
+            then: {
+              properties: {
+                parameters: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      name: { type: 'string' },
+                      in: { type: 'string' },
+                      description: {
+                        type: 'string'
+                      },
+                      required: { type: 'boolean' },
+                      allowEmptyValue: { type: 'boolean' },
+                      style: { type: 'string' },
+                      explode: { type: 'boolean' },
+                      allowReserved: { type: 'boolean' },
+                      schema: { type: 'object' },
+                      example: {},
+                      examples: { type: 'object' },
+                      content: { type: 'object' }
+                    },
+                    additionalProperties: false
+                  }
+                }
+              }
             }
           }
         }
@@ -369,15 +443,33 @@ const ruleset = {
       given: '$.paths[*]',
       message: 'path.parameters.explode should be set to false',
       then: {
-        field: 'parameters',
         function: schema,
         functionOptions: {
           schema: {
-            type: 'array',
-            items: {
-              type: 'object',
+            if: {
               properties: {
-                explode: { enum: [false] }
+                parameters: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      explode: { type: 'boolean' }
+                    }
+                  }
+                }
+              }
+            },
+            then: {
+              properties: {
+                parameters: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      explode: { enum: [false] }
+                    }
+                  }
+                }
               }
             }
           }
@@ -389,15 +481,33 @@ const ruleset = {
       given: '$.paths[*][get,post,put,delete,patch]',
       message: 'operations.parameters.explode should be set to false',
       then: {
-        field: 'parameters',
         function: schema,
         functionOptions: {
           schema: {
-            type: 'array',
-            items: {
-              type: 'object',
+            if: {
               properties: {
-                explode: { enum: [false] }
+                parameters: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      explode: { type: 'boolean' }
+                    }
+                  }
+                }
+              }
+            },
+            then: {
+              properties: {
+                parameters: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      explode: { enum: [false] }
+                    }
+                  }
+                }
               }
             }
           }
@@ -409,15 +519,33 @@ const ruleset = {
       given: '$.paths[*]',
       message: 'path.parameters.allowReserved should be set to false',
       then: {
-        field: 'parameters',
         function: schema,
         functionOptions: {
           schema: {
-            type: 'array',
-            items: {
-              type: 'object',
+            if: {
               properties: {
-                allowReserved: { enum: [false] }
+                parameters: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      allowReserved: { type: 'boolean' }
+                    }
+                  }
+                }
+              }
+            },
+            then: {
+              properties: {
+                parameters: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      allowReserved: { enum: [false] }
+                    }
+                  }
+                }
               }
             }
           }
@@ -429,15 +557,33 @@ const ruleset = {
       given: '$.paths[*][get,post,put,delete,patch]',
       message: 'operations.parameters.allowReserved should be set to false',
       then: {
-        field: 'parameters',
         function: schema,
         functionOptions: {
           schema: {
-            type: 'array',
-            items: {
-              type: 'object',
+            if: {
               properties: {
-                allowReserved: { enum: [false] }
+                parameters: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      allowReserved: { type: 'boolean' }
+                    }
+                  }
+                }
+              }
+            },
+            then: {
+              properties: {
+                parameters: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      allowReserved: { enum: [false] }
+                    }
+                  }
+                }
               }
             }
           }
@@ -449,15 +595,33 @@ const ruleset = {
       given: '$.paths[*]',
       message: 'path.parameters.content should be `application/json`',
       then: {
-        field: 'parameters',
         function: schema,
         functionOptions: {
           schema: {
-            type: 'array',
-            items: {
-              type: 'object',
+            if: {
               properties: {
-                content: { enum: ['application/json'] }
+                parameters: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      content: { type: 'string' }
+                    }
+                  }
+                }
+              }
+            },
+            then: {
+              properties: {
+                parameters: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      content: { enum: ['application/json'] }
+                    }
+                  }
+                }
               }
             }
           }
@@ -469,15 +633,33 @@ const ruleset = {
       given: '$.paths[*][get,post,put,delete,patch]',
       message: 'operations.parameters.content should be `application/json`',
       then: {
-        field: 'parameters',
         function: schema,
         functionOptions: {
           schema: {
-            type: 'array',
-            items: {
-              type: 'object',
+            if: {
               properties: {
-                content: { enum: ['application/json'] }
+                parameters: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      content: { type: 'string' }
+                    }
+                  }
+                }
+              }
+            },
+            then: {
+              properties: {
+                parameters: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      content: { enum: ['application/json'] }
+                    }
+                  }
+                }
               }
             }
           }

--- a/packages/salesforcedx-vscode-apex/test/jest/oas/documentProcessingPipeline/ruleset.spectral.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/oas/documentProcessingPipeline/ruleset.spectral.test.ts
@@ -1299,6 +1299,78 @@ components:
   });
 });
 
+it('should not throw false positives when `parameters` property is missing', async () => {
+  const inputYaml = `openapi: 3.0.0
+info:
+  title: MyRestResource
+  version: 1.0.0
+  description: This is auto-generated OpenAPI v3 spec for MyRestResource.
+paths:
+  /MyRestResource/doGet:
+    get:
+      summary: Retrieves an Account record by ID.
+      description: >-
+        This method handles HTTP GET requests to this endpoint. It parses the
+
+        request URL to extract the Account ID, and then queries the database to
+        fetch the
+
+        corresponding Account record. The record is then returned as a JSON
+        response.
+      operationId: getAccountById
+      responses:
+        '200':
+          description: The requested Account record.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+  /MyRestResource/doPut:
+    put:
+      summary: doPut
+      description: Creates a new Account record
+      operationId: doPut
+      responses:
+        '200':
+          description: Account created successfully
+          content:
+            application/json:
+              schema:
+                type: string
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        Id:
+          type: string
+          description: The unique identifier of the Account.
+        Name:
+          type: string
+          description: The name of the Account.
+        Phone:
+          type: string
+          description: The phone number of the Account.
+        Website:
+          type: string
+          description: The website URL of the Account.`;
+
+  const result = await runRulesetAgainstYaml(inputYaml);
+
+  expect(JSON.stringify(result)).not.toMatch(/paths-parameters-in/);
+  expect(JSON.stringify(result)).not.toMatch(/operations-parameters-in/);
+  expect(JSON.stringify(result)).not.toMatch(/paths-parameters-description/);
+  expect(JSON.stringify(result)).not.toMatch(/operations-parameters-description/);
+  expect(JSON.stringify(result)).not.toMatch(/paths-parameters-deprecated/);
+  expect(JSON.stringify(result)).not.toMatch(/operations-parameters-deprecated/);
+  expect(JSON.stringify(result)).not.toMatch(/paths-parameters-explode/);
+  expect(JSON.stringify(result)).not.toMatch(/operations-parameters-explode/);
+  expect(JSON.stringify(result)).not.toMatch(/paths-parameters-allowReserved/);
+  expect(JSON.stringify(result)).not.toMatch(/operations-parameters-allowReserved/);
+  expect(JSON.stringify(result)).not.toMatch(/paths-parameters-content/);
+  expect(JSON.stringify(result)).not.toMatch(/operations-parameters-content/);
+});
+
 const runRulesetAgainstYaml = async (inputYaml: string) => {
   const spectral = new Spectral();
 

--- a/packages/salesforcedx-vscode-apex/test/jest/oas/documentProcessingPipeline/ruleset.spectral.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/oas/documentProcessingPipeline/ruleset.spectral.test.ts
@@ -1371,6 +1371,130 @@ components:
   expect(JSON.stringify(result)).not.toMatch(/operations-parameters-content/);
 });
 
+it('should not log info-contact & operation-tag-defined', async () => {
+  const inputYaml = `openapi: 3.0.0
+info:
+  title: CaseManager
+  version: 1.0.0
+  description: This is auto-generated OpenAPI v3 spec for CaseManager.
+paths:
+  /CaseManager/getCaseById:
+    get:
+      summary: Retrieve a Case record using the provided Case ID.
+      description: Method to retrieve a Case record using the provided Case ID.
+      tags:
+        - Case Management
+      responses:
+        '200':
+          description: The Case record retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Case'
+      operationId: getCaseById
+  /CaseManager/createCase:
+    post:
+      summary: Create a new Case record
+      description: Method to create a new Case record with the provided details.
+      tags:
+        - Case Management
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                subject:
+                  type: string
+                status:
+                  type: string
+                origin:
+                  type: string
+                priority:
+                  type: string
+      responses:
+        '200':
+          description: The newly created Case ID
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Id'
+      operationId: createCase
+  /CaseManager/deleteCase:
+    delete:
+      summary: Deletes a Case record using the provided Case ID.
+      description: Method to delete a Case record using the provided Case ID.
+      tags:
+        - Case Management
+      responses:
+        '204':
+          description: Case record successfully deleted.
+      operationId: deleteCase
+  /CaseManager/upsertCase:
+    put:
+      summary: Upsert a Case record using the provided details and Case ID.
+      description: Method to upsert a Case record using the provided details and Case ID.
+      tags:
+        - Case Management
+      parameters:
+        - name: subject
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: status
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: origin
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: priority
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: id
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The Case ID of the upserted Case.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Id'
+      operationId: upsertCase
+components:
+  schemas:
+    Case:
+      type: object
+      properties:
+        CaseNumber:
+          type: string
+        Subject:
+          type: string
+        Status:
+          type: string
+        Origin:
+          type: string
+        Priority:
+          type: string
+    Id:
+      type: string
+      description: The unique identifier of the Case record.`;
+
+  const result = await runRulesetAgainstYaml(inputYaml);
+
+  expect(JSON.stringify(result)).not.toMatch(/info-contact/);
+  expect(JSON.stringify(result)).not.toMatch(/operation-tag-defined/);
+});
+
 const runRulesetAgainstYaml = async (inputYaml: string) => {
   const spectral = new Spectral();
 


### PR DESCRIPTION
fix: updating ruleset to find parameter related issue if parameter is defined and tests

### What does this PR do?
It prevents the false positives that were showing up when `parameters` value was not set.

### What issues does this PR fix or reference?
[@ W-17712024@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000028mCCfYAM/view)

### Functionality Before
`parameters` related errors were showing up even though the property itself was not defined.

### Functionality After
`parameters` related errors are not showing up even though the property itself was not defined.
