### PR TITLE
[W-17722121] chore: update git2gus default build for v63

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -31,7 +31,7 @@
     "status:duplicate": "",
     "type:community-contrib": "USER STORY"
   },
-  "defaultBuild": "offcore.tooling.62",
+  "defaultBuild": "offcore.tooling.63",
   "hideWorkItemUrl": "true",
   "statusWhenClosed": "CLOSED"
 }


### PR DESCRIPTION
### What does this PR do?
Updates the `defaultBuild` for Git2Gus to `offcore.tooling.63`.

### What issues does this PR fix or reference?
@W-17722121@