### PR TITLE
fix(readme): change to img.shields.io because david-dm.org is down

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Salesforce Extensions for VS Code
 
-[![Dev Dependencies](https://david-dm.org/forcedotcom/salesforcedx-vscode/dev-status.svg)](contributing/dependencies.md)
+[![Dev Dependencies](https://img.shields.io/librariesio/github/forcedotcom/salesforcedx-vscode)](contributing/dependencies.md)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
 ## Introduction


### PR DESCRIPTION
### What does this PR do?
[skip-validate-pr]

Changes the unavailable image 
[![Dev Dependencies](https://david-dm.org/forcedotcom/salesforcedx-vscode/dev-status.svg)](contributing/dependencies.md)

to the available image at
[![Dev Dependencies](https://img.shields.io/librariesio/github/forcedotcom/salesforcedx-vscode)](contributing/dependencies.md)