### PR TITLE
[W-17722121] chore: bump @salesforce/templates to v63.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7224,9 +7224,10 @@
       }
     },
     "node_modules/@salesforce/templates": {
-      "version": "62.0.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-62.0.1.tgz",
-      "integrity": "sha512-hLtWJaWNt4yWZSQgIpEt4eJ5P8Llr/GVRFSKfOPtFkBxqquj2qDlWWvXz+KkEc35vxUguAfX+xEddOQgrT0QVQ==",
+      "version": "63.0.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-63.0.1.tgz",
+      "integrity": "sha512-6qxBDX3zx9trcDRE/57z6J/zosLLjJceCdRJibh/g9bNojI1ad+mDNubTfgHELXVhdZR8qpv5Kb7CqNuf8bURA==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/kit": "^3.2.3",
         "ejs": "^3.1.10",
@@ -7235,7 +7236,7 @@
         "mime-types": "^2.1.35",
         "proxy-from-env": "^1.1.0",
         "tar": "^6.2.1",
-        "tslib": "^2.6.2"
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=18.18.2"
@@ -33358,7 +33359,7 @@
         "@salesforce/salesforcedx-utils-vscode": "62.16.0",
         "@salesforce/schemas": "1.9.0",
         "@salesforce/source-deploy-retrieve-bundle": "12.7.4",
-        "@salesforce/templates": "62.0.1",
+        "@salesforce/templates": "63.0.1",
         "@salesforce/ts-types": "2.0.12",
         "@salesforce/vscode-service-provider": "1.2.1",
         "adm-zip": "0.5.10",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -30,7 +30,7 @@
     "@salesforce/salesforcedx-utils-vscode": "62.16.0",
     "@salesforce/schemas": "1.9.0",
     "@salesforce/source-deploy-retrieve-bundle": "12.7.4",
-    "@salesforce/templates": "62.0.1",
+    "@salesforce/templates": "63.0.1",
     "@salesforce/ts-types": "2.0.12",
     "@salesforce/vscode-service-provider": "1.2.1",
     "adm-zip": "0.5.10",


### PR DESCRIPTION
## DO NOT MERGE UNTIL AFTER R2

### What does this PR do?
Bumps the @salesforce/templates dependency to v63.0.1.

### What issues does this PR fix or reference?
@W-17722121@