### PR TITLE
fix: remove duplicate rule

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/oas/documentProcessorPipeline/ruleset.spectral.ts
+++ b/packages/salesforcedx-vscode-apex/src/oas/documentProcessorPipeline/ruleset.spectral.ts
@@ -165,15 +165,6 @@ const ruleset = {
         function: truthy
       }
     },
-    'operations-operationId': {
-      description: 'operations.operationId is required',
-      given: '$.paths[*][get,post,put,delete,patch]',
-      message: 'operations.operationId is required',
-      then: {
-        field: 'operationId',
-        function: truthy
-      }
-    },
     'operations-callbacks': {
       description: 'operations.callbacks should not be present',
       given: '$.paths[*][get,post,put,delete,patch]',

--- a/packages/salesforcedx-vscode-apex/test/jest/oas/documentProcessingPipeline/ruleset.spectral.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/oas/documentProcessingPipeline/ruleset.spectral.test.ts
@@ -269,34 +269,6 @@ components:
     expect(JSON.stringify(result)).toMatch(/operations-description/);
   });
 
-  it('operations-operationId is required', async () => {
-    const inputYaml = `openapi: 3.0.0
-info:
-  title: demoClass API
-  version: '1.0.0'
-servers:
-  - url: https://files.example.com
-    description: Optional server description, e.g. Main (production) server
-paths:
-  /demoClass/doDelete:
-    delete:
-      summary: delete method
-      responses:
-        '200':
-          description: OK
-components:
-  schemas:
-    Account:
-      type: object
-      properties:
-        Id:
-          type: string`;
-
-    const result = await runRulesetAgainstYaml(inputYaml);
-
-    expect(JSON.stringify(result)).toMatch(/operations-operationId/);
-  });
-
   it('operations-callbacks should not be present', async () => {
     const inputYaml = `openapi: 3.0.0
 info:
@@ -1273,7 +1245,6 @@ components:
     expect(JSON.stringify(result)).not.toMatch(/paths-method-trace/);
     expect(JSON.stringify(result)).not.toMatch(/info-description/);
     expect(JSON.stringify(result)).not.toMatch(/operations-description/);
-    expect(JSON.stringify(result)).not.toMatch(/operations-operationId/);
     expect(JSON.stringify(result)).not.toMatch(/operations-callbacks/);
     expect(JSON.stringify(result)).not.toMatch(/operations-deprecated/);
     expect(JSON.stringify(result)).not.toMatch(/operations-security/);


### PR DESCRIPTION
remove duplicate rule, default oas library already has rule with code: 'operation-operationId'

### What does this PR do?
removes the duplicate rule

### What issues does this PR fix or reference?
[@<Insert GUS WI>@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000029daGNYAY/view)

### Functionality Before
Two warning were being shown for same error.

### Functionality After
One warning shown for missing operation id error.
