### PR TITLE
fix: make 'without sharing' and 'inherited sharing' eligible for OAS generation

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/settings.ts
+++ b/packages/salesforcedx-vscode-apex/src/settings.ts
@@ -9,7 +9,7 @@ import { SFDX_CORE_CONFIGURATION_NAME } from '@salesforce/salesforcedx-utils-vsc
 import * as vscode from 'vscode';
 
 // Eligibility for OpenAPI Document ONLY, should not be changed by users unless overwriting in settings.json
-const APEX_ACTION_CLASS_DEF_MODIFIERS = ['withsharing'];
+const APEX_ACTION_CLASS_DEF_MODIFIERS = ['withsharing', 'withoutsharing', 'inheritedsharing'];
 const APEX_ACTION_CLASS_ACCESS_MODIFIERS = ['global', 'public'];
 const APEX_ACTION_METHOD_DEF_MODIFIERS = ['static'];
 const APEX_ACTION_METHOD_ACCESS_MODIFIERS = ['global', 'public'];


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-17775324@

### Functionality Before
Only Apex classes with the `with sharing` modifier are eligible for OAS generation.

### Functionality After
Apex classes with the `without sharing` or `inherited sharing` modifiers are also eligible for OAS generation.  Apex classes with no sharing modifiers continue to be ineligible.
