### PR TITLE
feat: bump dependencies to catch up with latest md types in sdr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5968,21 +5968,22 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "4.0.27",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.0.27.tgz",
-      "integrity": "sha512-9j92jHr6k2tjQ6/mIwNi46Gqw+qbPFQ02mxT5T8/nxO2fgsPL3qL0kb9SR1il5AVfqpgLIG3uLUcw87rgaioUg==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.2.6.tgz",
+      "integrity": "sha512-agk1Tlm7qMemWx+qq5aNgkYwX2JCkoVP4M0ruFveJrarmdUPbKZTMW1j/eg8lNKZh1sp68ytZyKhYXYEfRPcww==",
+      "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.2",
-        "ansis": "^3.3.2",
+        "ansis": "^3.10.0",
         "clean-stack": "^3.0.1",
         "cli-spinners": "^2.9.2",
-        "debug": "^4.3.7",
+        "debug": "^4.4.0",
         "ejs": "^3.1.10",
         "get-package-type": "^0.1.0",
         "globby": "^11.1.0",
         "indent-string": "^4.0.0",
-        "is-wsl": "^3",
-        "lilconfig": "^3.1.2",
+        "is-wsl": "^2.2.0",
+        "lilconfig": "^3.1.3",
         "minimatch": "^9.0.5",
         "semver": "^7.6.3",
         "string-width": "^4.2.3",
@@ -5999,6 +6000,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
       "integrity": "sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==",
+      "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "4.0.0"
       },
@@ -6013,6 +6015,7 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
       "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       },
@@ -6021,9 +6024,10 @@
       }
     },
     "node_modules/@oclif/core/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -6040,6 +6044,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -6051,28 +6056,16 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/is-wsl": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@oclif/core/node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -6086,12 +6079,14 @@
     "node_modules/@oclif/core/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -6540,7 +6535,7 @@
       "integrity": "sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww=="
     },
     "node_modules/@salesforce/core-bundle": {
-      "version": "8.6.1",
+      "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/@salesforce/core-bundle/-/core-bundle-8.6.1.tgz",
       "integrity": "sha512-5viFsuezC2jGIzrmlOieeN7/E2w9WbC+skgfD1JVPU8wV9XNdoFrCunMRsWfx28MMo33pG9eXiZc1u9tWY04aw==",
       "dependencies": {
@@ -7168,15 +7163,16 @@
       }
     },
     "node_modules/@salesforce/source-deploy-retrieve-bundle": {
-      "version": "12.7.4",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve-bundle/-/source-deploy-retrieve-bundle-12.7.4.tgz",
-      "integrity": "sha512-pVurxCiwuL5jMNW7UjB4idYvubU1sh3Pb3zOx3mgU3vCCmH4O1DsFTTlYmQy2FLk0hnNGtLYbBmlEtsfQXpLCQ==",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve-bundle/-/source-deploy-retrieve-bundle-12.15.0.tgz",
+      "integrity": "sha512-VWRMWonZop5UEcqi0Wr8kLFuV8P0J4TAN9iYIEOHhbm3S1F7I6fXmpVAPXYE+avgb4bmEdt8Ym2jxCglP9PL2g==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core-bundle": "^8.6.1",
-        "@salesforce/kit": "^3.2.2",
+        "@salesforce/core-bundle": "^8.8.2",
+        "@salesforce/kit": "^3.2.3",
         "@salesforce/ts-types": "^2.0.12",
         "fast-levenshtein": "^3.0.0",
-        "fast-xml-parser": "^4.5.0",
+        "fast-xml-parser": "^4.5.1",
         "got": "^11.8.6",
         "graceful-fs": "^4.2.11",
         "ignore": "^5.3.2",
@@ -7184,7 +7180,8 @@
         "jszip": "^3.10.1",
         "mime": "2.6.0",
         "minimatch": "^9.0.5",
-        "proxy-agent": "^6.4.0"
+        "proxy-agent": "^6.4.0",
+        "yaml": "^2.6.1"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -7194,6 +7191,7 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -7205,18 +7203,19 @@
       }
     },
     "node_modules/@salesforce/source-tracking-bundle": {
-      "version": "7.1.17",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-tracking-bundle/-/source-tracking-bundle-7.1.17.tgz",
-      "integrity": "sha512-bidkL9Gz+BJHGZ5EFRPD7+Pxo/7NPqpS7DFfMYnJbLFUVa09H4uQzfiU+f9sX8g7LZeVfhjfpp5htDfvOz7xAQ==",
+      "version": "7.3.14",
+      "resolved": "https://registry.npmjs.org/@salesforce/source-tracking-bundle/-/source-tracking-bundle-7.3.14.tgz",
+      "integrity": "sha512-Esagi6w7yKuvMooHnj3un2hWg+PbwCbrznS3Ga23DJKrtw81nY2OkHnj/bSdrs0agqn4xAD/WhhbZS1JH5orog==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@oclif/core": "^4.0.23",
-        "@salesforce/core-bundle": "^8.6.1",
+        "@oclif/core": "^4.2.6",
+        "@salesforce/core-bundle": "^8.8.2",
         "@salesforce/kit": "^3.2.3",
-        "@salesforce/source-deploy-retrieve-bundle": "^12.7.4",
+        "@salesforce/source-deploy-retrieve-bundle": "^12.14.8",
         "@salesforce/ts-types": "^2.0.12",
-        "fast-xml-parser": "^4.5.0",
+        "fast-xml-parser": "^4.5.1",
         "graceful-fs": "^4.2.11",
-        "isomorphic-git": "^1.27.1",
+        "isomorphic-git": "^1.27.2",
         "ts-retry-promise": "^0.8.1"
       },
       "engines": {
@@ -9124,11 +9123,12 @@
       }
     },
     "node_modules/ansis": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.3.2.tgz",
-      "integrity": "sha512-cFthbBlt+Oi0i9Pv/j6YdVWJh54CtjGACaMPCIrEV4Ha7HWsIjXDwseYV79TIL0B4+KfSwD5S70PeQDkPUd1rA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.14.0.tgz",
+      "integrity": "sha512-R1LnSpYZWMDEFoAyCrfgToVz4ES25luDpjlZsUlD5GXdPWb91U+TZGkxWAOvt+7zWRY/ctOxhtTx5HUtL3qmbA==",
+      "license": "ISC",
       "engines": {
-        "node": ">=15"
+        "node": ">=14"
       }
     },
     "node_modules/antlr4-c3": {
@@ -10626,7 +10626,8 @@
     "node_modules/clean-git-ref": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
-      "integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw=="
+      "integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
+      "license": "Apache-2.0"
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -11910,6 +11911,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -12830,7 +12832,8 @@
     "node_modules/diff3": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
-      "integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g=="
+      "integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
+      "license": "MIT"
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -14559,9 +14562,9 @@
       "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw=="
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.0.tgz",
-      "integrity": "sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.1.tgz",
+      "integrity": "sha512-y655CeyUQ+jj7KBbYMc4FG01V8ZQqjN+gDYGJ50RtfsUB8iG9AmwmwoAgeKLJdmueKKMrH1RJ7yXHTSoczdv5w==",
       "funding": [
         {
           "type": "github",
@@ -14572,6 +14575,7 @@
           "url": "https://paypal.me/naturalintelligence"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "strnum": "^1.0.5"
       },
@@ -17245,7 +17249,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -17290,37 +17293,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-inside-container": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-      "dependencies": {
-        "is-docker": "^3.0.0"
-      },
-      "bin": {
-        "is-inside-container": "cli.js"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-inside-container/node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-interactive": {
@@ -17594,7 +17566,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -17608,9 +17579,10 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/isbinaryfile": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.2.tgz",
-      "integrity": "sha512-GvcjojwonMjWbTkfMpnVHVqXW/wKMYDfEpY94/8zy8HFMOqb/VL6oeONq9v87q4ttVlaTLnGXnJD4B5B1OTGIg==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.4.tgz",
+      "integrity": "sha512-YKBKVkKhty7s8rxddb40oOkuP0NbaeXrQvLin6QMHL7Ypiy2RW9LwOVrVgZRyOrhQlayMd9t+D8yDy8MKFTSDQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 18.0.0"
       },
@@ -17647,9 +17619,10 @@
       }
     },
     "node_modules/isomorphic-git": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.27.1.tgz",
-      "integrity": "sha512-X32ph5zIWfT75QAqW2l3JCIqnx9/GWd17bRRehmn3qmWc34OYbSXY6Cxv0o9bIIY+CWugoN4nQFHNA+2uYf2nA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.29.0.tgz",
+      "integrity": "sha512-zWGqk8901cicvVEhVpN76AwKrS/TzHak2NQCtNXIAavpMIy/yqh+d/JtC9A8AUKZAauUdOyEWKI29tuCLAL+Zg==",
+      "license": "MIT",
       "dependencies": {
         "async-lock": "^1.4.1",
         "clean-git-ref": "^2.0.1",
@@ -17658,6 +17631,7 @@
         "ignore": "^5.1.4",
         "minimisted": "^2.0.0",
         "pako": "^1.0.10",
+        "path-browserify": "^1.0.1",
         "pify": "^4.0.1",
         "readable-stream": "^3.4.0",
         "sha.js": "^2.4.9",
@@ -17673,7 +17647,8 @@
     "node_modules/isomorphic-git/node_modules/async-lock": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
-      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ=="
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -20234,9 +20209,10 @@
       }
     },
     "node_modules/lilconfig": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
-      "integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "license": "MIT",
       "engines": {
         "node": ">=14"
       },
@@ -21378,6 +21354,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
       "integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5"
       }
@@ -27033,6 +27010,12 @@
         "upper-case-first": "^1.1.0"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
+    },
     "node_modules/path-case": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
@@ -29054,6 +29037,7 @@
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "license": "(MIT AND BSD-3-Clause)",
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -31961,6 +31945,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
       "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "license": "MIT",
       "dependencies": {
         "string-width": "^4.0.0"
       },
@@ -32430,10 +32415,13 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "node_modules/yaml": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
-      "dev": true,
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
         "node": ">= 14"
       }
@@ -32673,7 +32661,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jsforce/jsforce-node": "3.4.1",
-        "@salesforce/core-bundle": "8.6.1",
+        "@salesforce/core-bundle": "8.8.2",
         "@salesforce/salesforcedx-utils-vscode": "63.0.0",
         "shelljs": "0.8.5"
       },
@@ -32819,9 +32807,9 @@
       "version": "63.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core-bundle": "8.6.1",
-        "@salesforce/source-deploy-retrieve-bundle": "12.7.4",
-        "@salesforce/source-tracking-bundle": "7.1.17",
+        "@salesforce/core-bundle": "8.8.2",
+        "@salesforce/source-deploy-retrieve-bundle": "12.15.0",
+        "@salesforce/source-tracking-bundle": "7.3.14",
         "@salesforce/vscode-service-provider": "1.2.1",
         "applicationinsights": "1.0.7",
         "cross-spawn": "7.0.6",
@@ -32963,7 +32951,7 @@
       "dependencies": {
         "@salesforce/apex-node-bundle": "8.1.12",
         "@salesforce/apex-tmlanguage": "1.8.0",
-        "@salesforce/core-bundle": "8.6.1",
+        "@salesforce/core-bundle": "8.8.2",
         "@salesforce/salesforcedx-utils-vscode": "63.0.0",
         "@salesforce/vscode-service-provider": "1.2.1",
         "expand-home-dir": "0.0.3",
@@ -33107,7 +33095,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/apex-node-bundle": "8.1.12",
-        "@salesforce/core-bundle": "8.6.1",
+        "@salesforce/core-bundle": "8.8.2",
         "@salesforce/salesforcedx-apex-replay-debugger": "63.0.0",
         "@salesforce/salesforcedx-utils": "63.0.0",
         "@salesforce/salesforcedx-utils-vscode": "63.0.0",
@@ -33355,11 +33343,11 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jsforce/jsforce-node": "3.4.1",
-        "@salesforce/core-bundle": "8.6.1",
+        "@salesforce/core-bundle": "8.8.2",
         "@salesforce/salesforcedx-sobjects-faux-generator": "63.0.0",
         "@salesforce/salesforcedx-utils-vscode": "63.0.0",
         "@salesforce/schemas": "1.9.0",
-        "@salesforce/source-deploy-retrieve-bundle": "12.7.4",
+        "@salesforce/source-deploy-retrieve-bundle": "12.15.0",
         "@salesforce/templates": "62.0.1",
         "@salesforce/ts-types": "2.0.12",
         "@salesforce/vscode-service-provider": "1.2.1",
@@ -33561,7 +33549,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/aura-language-server": "4.12.2",
-        "@salesforce/core-bundle": "8.6.1",
+        "@salesforce/core-bundle": "8.8.2",
         "@salesforce/lightning-lsp-common": "4.12.2",
         "@salesforce/salesforcedx-utils-vscode": "63.0.0",
         "applicationinsights": "1.0.7",
@@ -33728,7 +33716,7 @@
       "version": "63.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core-bundle": "8.6.1",
+        "@salesforce/core-bundle": "8.8.2",
         "@salesforce/lightning-lsp-common": "4.12.2",
         "@salesforce/lwc-language-server": "4.12.2",
         "@salesforce/salesforcedx-utils-vscode": "63.0.0",
@@ -34299,7 +34287,7 @@
       "dependencies": {
         "@jsforce/jsforce-node": "3.4.1",
         "@salesforce/apex-tmlanguage": "1.6.0",
-        "@salesforce/core-bundle": "8.6.1",
+        "@salesforce/core-bundle": "8.8.2",
         "@salesforce/soql-builder-ui": "1.0.0",
         "@salesforce/soql-data-view": "0.1.0",
         "@salesforce/soql-language-server": "0.7.1",

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -11,7 +11,7 @@
   "main": "out/src",
   "dependencies": {
     "@jsforce/jsforce-node": "3.4.1",
-    "@salesforce/core-bundle": "8.6.1",
+    "@salesforce/core-bundle": "8.8.2",
     "@salesforce/salesforcedx-utils-vscode": "63.0.0",
     "shelljs": "0.8.5"
   },

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -10,9 +10,9 @@
   ],
   "main": "out/src",
   "dependencies": {
-    "@salesforce/core-bundle": "8.6.1",
-    "@salesforce/source-deploy-retrieve-bundle": "12.7.4",
-    "@salesforce/source-tracking-bundle": "7.1.17",
+    "@salesforce/core-bundle": "8.8.2",
+    "@salesforce/source-deploy-retrieve-bundle": "12.15.0",
+    "@salesforce/source-tracking-bundle": "7.3.14",
     "@salesforce/vscode-service-provider": "1.2.1",
     "applicationinsights": "1.0.7",
     "cross-spawn": "7.0.6",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "@salesforce/apex-node-bundle": "8.1.12",
-    "@salesforce/core-bundle": "8.6.1",
+    "@salesforce/core-bundle": "8.8.2",
     "@salesforce/salesforcedx-apex-replay-debugger": "63.0.0",
     "@salesforce/salesforcedx-utils": "63.0.0",
     "@salesforce/salesforcedx-utils-vscode": "63.0.0",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@salesforce/apex-node-bundle": "8.1.12",
     "@salesforce/apex-tmlanguage": "1.8.0",
-    "@salesforce/core-bundle": "8.6.1",
+    "@salesforce/core-bundle": "8.8.2",
     "@salesforce/salesforcedx-utils-vscode": "63.0.0",
     "@salesforce/vscode-service-provider": "1.2.1",
     "expand-home-dir": "0.0.3",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -25,11 +25,11 @@
   ],
   "dependencies": {
     "@jsforce/jsforce-node": "3.4.1",
-    "@salesforce/core-bundle": "8.6.1",
+    "@salesforce/core-bundle": "8.8.2",
     "@salesforce/salesforcedx-sobjects-faux-generator": "63.0.0",
     "@salesforce/salesforcedx-utils-vscode": "63.0.0",
     "@salesforce/schemas": "1.9.0",
-    "@salesforce/source-deploy-retrieve-bundle": "12.7.4",
+    "@salesforce/source-deploy-retrieve-bundle": "12.15.0",
     "@salesforce/templates": "62.0.1",
     "@salesforce/ts-types": "2.0.12",
     "@salesforce/vscode-service-provider": "1.2.1",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "@salesforce/aura-language-server": "4.12.2",
-    "@salesforce/core-bundle": "8.6.1",
+    "@salesforce/core-bundle": "8.8.2",
     "@salesforce/lightning-lsp-common": "4.12.2",
     "@salesforce/salesforcedx-utils-vscode": "63.0.0",
     "applicationinsights": "1.0.7",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -24,7 +24,7 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/core-bundle": "8.6.1",
+    "@salesforce/core-bundle": "8.8.2",
     "@salesforce/lightning-lsp-common": "4.12.2",
     "@salesforce/lwc-language-server": "4.12.2",
     "@salesforce/salesforcedx-utils-vscode": "63.0.0",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@jsforce/jsforce-node": "3.4.1",
     "@salesforce/apex-tmlanguage": "1.6.0",
-    "@salesforce/core-bundle": "8.6.1",
+    "@salesforce/core-bundle": "8.8.2",
     "@salesforce/soql-builder-ui": "1.0.0",
     "@salesforce/soql-data-view": "0.1.0",
     "@salesforce/soql-language-server": "0.7.1",


### PR DESCRIPTION
### What does this PR do?
- Bumps SDR, core and st libraries to catch up with latest

### Functionality Before
- deployment of some md types is not supported

### Functionality After
- deployment of some md types like aiEvaluationDefinition is now supported

[skip-validate-pr]
