### PR TITLE
[W-17854317] fix: diff source now works for ____.object-meta.xml files

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/sourceDiff.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/sourceDiff.ts
@@ -84,7 +84,17 @@ export const sourceFolderDiff = async (explorerPath: vscode.Uri) => {
 export const handleCacheResults = async (username: string, cache?: MetadataCacheResult): Promise<void> => {
   if (cache) {
     if (cache.selectedType === PathType.Individual && cache.cache.components) {
-      await differ.diffOneFile(cache.selectedPath, cache.cache.components[0], username);
+      if (cache.selectedPath.endsWith('object-meta.xml')) {
+        // object-meta.xml files are listed as the last item in the cache.cache.components array
+        await differ.diffOneFile(
+          cache.selectedPath,
+          cache.cache.components[cache.cache.components.length - 1],
+          username
+        );
+      } else {
+        // all other metadata files are listed as the first item in the cache.cache.components array
+        await differ.diffOneFile(cache.selectedPath, cache.cache.components[0], username);
+      }
     } else if (cache.selectedType === PathType.Folder) {
       differ.diffFolder(cache, username);
     }


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-17854317@

### Functionality Before
**SFDX: Diff Source Against Org** does not work for ____.object-meta.xml files.  The command completes successfully but the diff does not popup in Editor View.

### Functionality After
**SFDX: Diff Source Against Org** works for ____.object-meta.xml files.  The diff pops up in Editor View like all other diffs.
