### PR TITLE
chore: screenshots in E2E tests specify VSCode version in filename

### DIFF
--- a/.github/workflows/runE2ETest.yml
+++ b/.github/workflows/runE2ETest.yml
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: failure() && inputs.automationRepo == 'salesforcedx-vscode-automation-tests'
         with:
-          name: screenshots-${{ inputs.testToRun }}-${{ matrix.os }}
+          name: screenshots-${{ inputs.testToRun }}-${{ matrix.os }}-${{ inputs.vscodeVersion }}
           path: ./${{ inputs.automationRepo }}/screenshots
       - uses: actions/upload-artifact@v4
         if: failure() && inputs.automationRepo == 'salesforcedx-vscode-automation-tests-redhat'

--- a/.github/workflows/runE2ETest.yml
+++ b/.github/workflows/runE2ETest.yml
@@ -133,5 +133,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: failure() && inputs.automationRepo == 'salesforcedx-vscode-automation-tests-redhat'
         with:
-          name: screenshots-${{ inputs.testToRun }}-${{ matrix.os }}
+          name: screenshots-${{ inputs.testToRun }}-${{ matrix.os }}-${{ inputs.vscodeVersion }}
           path: ./salesforcedx-vscode/extensions/screenshots

--- a/.github/workflows/runE2ETest.yml
+++ b/.github/workflows/runE2ETest.yml
@@ -10,7 +10,7 @@ on:
       automationRepo:
         description: 'Set the repo to use for automation tests'
         required: false
-        default: 'salesforcedx-vscode-automation-tests'
+        default: 'salesforcedx-vscode-automation-tests-redhat'
         type: string
       testToRun:
         description: 'Run this E2E test'


### PR DESCRIPTION
### What does this PR do?
E2E screenshots filename now includes VSCode version of the job.

### What issues does this PR fix or reference?
[skip-validate-pr]

### Functionality Before
The nightly build and release E2E tests run on both the latest and minimum supported VSCode versions.  If the same test on the same OS fails for both VSCode versions, only one set of screenshots is produced, and the other job throws an error, because the filenames of the screenshot zip files are the same.  See this run: https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/13378208445

### Functionality After
E2E screenshots filename now includes VSCode version of the job.  Both jobs can produce screenshots without errors.
