### PR TITLE
chore: skip Github issues validation for issues labeled with 'type:bug'

### DIFF
--- a/.github/workflows/closeStaleIssues.yml
+++ b/.github/workflows/closeStaleIssues.yml
@@ -25,5 +25,5 @@ jobs:
           stale-issue-message: 'This issue has not received a response in 3 days. It will auto-close in 2 days unless a response is posted.'
           close-issue-reason: not_planned
           operations-per-run: 100
-          exempt-issue-labels: announcement,bug,on hold,waiting for internal reply,feature
+          exempt-issue-labels: announcement,type:bug,on hold,waiting for internal reply,feature
           any-of-labels: more information required,missing required information,waiting for user

--- a/.github/workflows/validateNewIssues.yml
+++ b/.github/workflows/validateNewIssues.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   # Check if the issue is a feature request, and if it is, tag it with 'type:enhancements' (this job is a prerequisite to all the other jobs)
   check-feature-request:
-    if: ${{ !contains(github.event.issue.labels.*.name, 'announcement') && !contains(github.event.issue.labels.*.name, 'missing required information') && !contains(github.event.issue.labels.*.name, 'validated') && !contains(github.event.issue.labels.*.name, 'type:enhancements') && !contains(github.event.issue.labels.*.name, 'feature') && !contains(github.event.issue.labels.*.name, 'bug') && !contains(github.event.issue.labels.*.name, 'pending release') }}
+    if: ${{ !contains(github.event.issue.labels.*.name, 'announcement') && !contains(github.event.issue.labels.*.name, 'missing required information') && !contains(github.event.issue.labels.*.name, 'validated') && !contains(github.event.issue.labels.*.name, 'type:enhancements') && !contains(github.event.issue.labels.*.name, 'feature') && !contains(github.event.issue.labels.*.name, 'type:bug') && !contains(github.event.issue.labels.*.name, 'pending release') }}
     outputs:
       is_feature_request: ${{ steps.check_feature_request.outputs.is_feature_request }}
     runs-on: ubuntu-latest
@@ -31,7 +31,7 @@ jobs:
           repo-token: ${{ secrets.IDEE_GH_TOKEN }}
 
   new-issue:
-    if: ${{ !contains(github.event.issue.labels.*.name, 'announcement') && !contains(github.event.issue.labels.*.name, 'missing required information') && !contains(github.event.issue.labels.*.name, 'validated') && !contains(github.event.issue.labels.*.name, 'type:enhancements') && !contains(github.event.issue.labels.*.name, 'feature') && !contains(github.event.issue.labels.*.name, 'bug') && !contains(github.event.issue.labels.*.name, 'pending release') && (needs.check-feature-request.outputs.is_feature_request != 'true') }}
+    if: ${{ !contains(github.event.issue.labels.*.name, 'announcement') && !contains(github.event.issue.labels.*.name, 'missing required information') && !contains(github.event.issue.labels.*.name, 'validated') && !contains(github.event.issue.labels.*.name, 'type:enhancements') && !contains(github.event.issue.labels.*.name, 'feature') && !contains(github.event.issue.labels.*.name, 'type:bug') && !contains(github.event.issue.labels.*.name, 'pending release') && (needs.check-feature-request.outputs.is_feature_request != 'true') }}
     needs: [check-feature-request]
     runs-on: ubuntu-latest
     steps:
@@ -52,7 +52,7 @@ jobs:
             If you require immediate assistance, contact Salesforce Customer Support.
 
   validate-new-issue:
-    if: ${{ !contains(github.event.issue.labels.*.name, 'announcement') && !contains(github.event.issue.labels.*.name, 'missing required information') && !contains(github.event.issue.labels.*.name, 'validated') && !contains(github.event.issue.labels.*.name, 'type:enhancements') && !contains(github.event.issue.labels.*.name, 'feature') && !contains(github.event.issue.labels.*.name, 'bug') && !contains(github.event.issue.labels.*.name, 'pending release') && (needs.check-feature-request.outputs.is_feature_request != 'true') }}
+    if: ${{ !contains(github.event.issue.labels.*.name, 'announcement') && !contains(github.event.issue.labels.*.name, 'missing required information') && !contains(github.event.issue.labels.*.name, 'validated') && !contains(github.event.issue.labels.*.name, 'type:enhancements') && !contains(github.event.issue.labels.*.name, 'feature') && !contains(github.event.issue.labels.*.name, 'type:bug') && !contains(github.event.issue.labels.*.name, 'pending release') && (needs.check-feature-request.outputs.is_feature_request != 'true') }}
     needs: [check-feature-request, new-issue]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/validateUpdatedIssues.yml
+++ b/.github/workflows/validateUpdatedIssues.yml
@@ -21,9 +21,9 @@ jobs:
     # - 'feature'
     # - 'type:enhancements'
     # - 'status:owned by another team'
-    # - 'bug'
+    # - 'type:bug'
     # - 'pending release'
-    if: contains(github.event.issue.labels.*.name, 'missing required information') && !contains(github.event.issue.labels.*.name, 'announcement') && !contains(github.event.issue.labels.*.name, 'validated') && !contains(github.event.issue.labels.*.name, 'investigating') && !contains(github.event.issue.labels.*.name, 'feature') && !contains(github.event.issue.labels.*.name, 'type:enhancements') && !contains(github.event.issue.labels.*.name, 'status:owned by another team') && !contains(github.event.issue.labels.*.name, 'bug') && !contains(github.event.issue.labels.*.name, 'pending release')
+    if: contains(github.event.issue.labels.*.name, 'missing required information') && !contains(github.event.issue.labels.*.name, 'announcement') && !contains(github.event.issue.labels.*.name, 'validated') && !contains(github.event.issue.labels.*.name, 'investigating') && !contains(github.event.issue.labels.*.name, 'feature') && !contains(github.event.issue.labels.*.name, 'type:enhancements') && !contains(github.event.issue.labels.*.name, 'status:owned by another team') && !contains(github.event.issue.labels.*.name, 'type:bug') && !contains(github.event.issue.labels.*.name, 'pending release')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### What does this PR do?
Github issues validation checks for label `type:bug` rather than label `bug`

### What issues does this PR fix or reference?
[skip-validate-pr]