### PR TITLE
fix: retrieve ContentTypeBundle in org browser

### DIFF
--- a/packages/salesforcedx-vscode-core/src/util/metadataDictionary.ts
+++ b/packages/salesforcedx-vscode-core/src/util/metadataDictionary.ts
@@ -89,6 +89,13 @@ const DEFINITIONS: { [key: string]: MetadataInfo } = {
     directory: 'experiencePropertyTypeBundles',
     pathStrategy: PathStrategyFactory.createDefaultStrategy(),
     extensions: [`${sep}schema.json`]
+  },
+  contenttypebundle: {
+    type: 'ContentTypeBundle',
+    suffix: 'json',
+    directory: 'contentTypes',
+    pathStrategy: PathStrategyFactory.createDefaultStrategy(),
+    extensions: [`${sep}schema.json`]
   }
 };
 

--- a/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/postconditionCheckers.test.ts
+++ b/packages/salesforcedx-vscode-core/test/vscode-integration/commands/util/postconditionCheckers.test.ts
@@ -245,6 +245,35 @@ describe('Postcondition Checkers', () => {
         expect(promptStub.firstCall).to.null;
       });
 
+      it('Should prompt overwrite for ContentTypeBundle components that exist', async () => {
+        existsStub.returns(false);
+        const data = {
+          fileName: 'Test1',
+          outputdir: 'package/tests',
+          type: 'ContentTypeBundle',
+          suffix: 'json'
+        };
+        pathExists(true, data, '/schema.json');
+
+        await checker.check({ type: 'CONTINUE', data });
+
+        expect(promptStub.firstCall.args[0]).to.eql([data]);
+      });
+
+      it('Should prompt overwrite for ContentTypeBundle components that does not exist', async () => {
+        existsStub.returns(false);
+        const data = {
+          fileName: 'Test1',
+          outputdir: 'package/tests',
+          type: 'ContentTypeBundle',
+          suffix: 'json'
+        };
+
+        await checker.check({ type: 'CONTINUE', data });
+
+        expect(promptStub.firstCall).to.null;
+      });
+
       it('Should determine a component exists if at least one of its file extensions do', async () => {
         const dictionaryStub = env.stub(MetadataDictionary, 'getInfo');
         dictionaryStub.returns({


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
This PR adds ContentTypeBundle to the metadata dictionary. Similar to the ExperiencePropertyType, the metadata ContentTypeBundle type doesn't have a -meta.xml instead it has a static schema.json file for each metadata. Adding an entry to the metadata dictionary to fix this issue

### What issues does this PR fix or reference?
#https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000027SVnGYAW/view, @W-17522423@

### Functionality Before
Retrieving ContentTypeBundle throws an error and doesn't show the overwrite popup when metadata locally exists

### Functionality After
Retrieving ContentTypeBundle is successful with org browser.
