### PR TITLE
[W-17856593] fix: correct url for 'set your java version' link

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/constants.ts
+++ b/packages/salesforcedx-vscode-apex/src/constants.ts
@@ -13,7 +13,8 @@ export const DEBUGGER_EXCEPTION_BREAKPOINTS = 'debugger/exceptionBreakpoints';
 const startPos = new vscode.Position(0, 0);
 const endPos = new vscode.Position(0, 1);
 export const APEX_GROUP_RANGE = new vscode.Range(startPos, endPos);
-export const SET_JAVA_DOC_LINK = 'https://developer.salesforce.com/tools/vscode/en/vscode-desktop/java-setup';
+export const SET_JAVA_DOC_LINK =
+  'https://developer.salesforce.com/docs/platform/sfvscode-extensions/guide/java-setup.html';
 export const SFDX_APEX_CONFIGURATION_NAME = 'salesforcedx-vscode-apex';
 export const APEX_EXTENSION_NAME = 'salesforcedx-vscode-apex';
 export const VSCODE_APEX_EXTENSION_NAME = `salesforce.${APEX_EXTENSION_NAME}`;


### PR DESCRIPTION
### What does this PR do?
The link to "Set Your Java Version" in error notification now points to the correct URL.

### What issues does this PR fix or reference?
#6098, @W-17856593@
