### PR TITLE
[W-17812942] fix: use correct id for mulesoft extension

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/commands/oasUtils.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/oasUtils.ts
@@ -57,7 +57,7 @@ export const createProblemTabEntriesForOasDocument = (
 
   gil.addDiagnostics(adjustErrors);
 
-  const mulesoftExtension = vscode.extensions.getExtension('mulesoft.mulesoft-extension-id');
+  const mulesoftExtension = vscode.extensions.getExtension('salesforce.mule-dx-agentforce-api-component');
   if (!mulesoftExtension?.isActive) {
     OasProcessor.diagnosticCollection.set(uri, adjustErrors);
   }


### PR DESCRIPTION
### What does this PR do?
Replaces the placeholder id for Mulesoft extension with the real extension id `salesforce.mule-dx-agentforce-api-component`.

### What issues does this PR fix or reference?
@W-17812942@
