### PR TITLE
fix: problems tab shows problems for newly generated OAS doc with timestamp in manual merge case

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/commands/apexActionController.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/apexActionController.ts
@@ -165,7 +165,7 @@ export class ApexActionController {
 
           // Step: 10 Create entries in problems tab for generated file
           createProblemTabEntriesForOasDocument(
-            this.isESRDecomposed ? this.replaceXmlToYaml(fullPath[0]) : fullPath[0],
+            this.isESRDecomposed ? this.replaceXmlToYaml(fullPath[1]) : fullPath[1],
             processedOasResult,
             this.isESRDecomposed
           );


### PR DESCRIPTION
### What does this PR do?
If the user regenerates the OAS doc for an Apex class and chooses to do a manual merge, the problems in the Problems tab will be for the newly generated OAS doc \<ApexClass\>_\<timestamp\>.yaml instead of the original OAS doc \<ApexClass\>.yaml.

### What issues does this PR fix or reference?
[skip-validate-pr]
