### PR TITLE
@W-17902076@ fix: fix the condition to prevent a false positive of the "paths.<method>.description is required" warning

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/oas/documentProcessorPipeline/ruleset.spectral.ts
+++ b/packages/salesforcedx-vscode-apex/src/oas/documentProcessorPipeline/ruleset.spectral.ts
@@ -120,7 +120,7 @@ const ruleset = {
     },
     'paths-method-description': {
       description: 'paths.<method>.description is required',
-      given: '$.paths.*',
+      given: '$.paths[*][get,post,put,delete,patch]',
       message: 'paths.<method>.description is required',
       then: {
         field: 'description',


### PR DESCRIPTION
### What does this PR do?
Fixes the condition to prevent a false positive of the `paths.<method>.description is required` warning.

### What issues does this PR fix or reference?
@W-17902076@
