### PR TITLE
fix: W-18034479 - hide validate oas command when mulesoft extension is installed

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -149,7 +149,7 @@
         },
         {
           "command": "sf.validate.oas.document",
-          "when": "sf:project_opened && sf:has_target_org && ((resource =~ /.\\.externalServiceRegistration-meta\\.(xml)?$/ && !sf:is_esr_decomposed) || resource =~ /.\\.(yaml)?$/) && salesforcedx-einstein-gpt.isEnabled"
+          "when": "sf:project_opened && sf:has_target_org && ((resource =~ /.\\.externalServiceRegistration-meta\\.(xml)?$/ && !sf:is_esr_decomposed) || resource =~ /.\\.(yaml)?$/) && salesforcedx-einstein-gpt.isEnabled && mule-dx-api-component.isDisabled"
         }
       ],
       "explorer/context": [
@@ -159,7 +159,7 @@
         },
         {
           "command": "sf.validate.oas.document",
-          "when": "sf:project_opened && sf:has_target_org && ((resource =~ /.\\.externalServiceRegistration-meta\\.(xml)?$/ && !sf:is_esr_decomposed) || resource =~ /.\\.(yaml)?$/) && salesforcedx-einstein-gpt.isEnabled"
+          "when": "sf:project_opened && sf:has_target_org && ((resource =~ /.\\.externalServiceRegistration-meta\\.(xml)?$/ && !sf:is_esr_decomposed) || resource =~ /.\\.(yaml)?$/) && salesforcedx-einstein-gpt.isEnabled && mule-dx-api-component.isDisabled"
         }
       ],
       "view/title": [
@@ -282,7 +282,7 @@
         },
         {
           "command": "sf.validate.oas.document",
-          "when": "sf:project_opened && sf:has_target_org && (resource =~ /.\\.externalServiceRegistration-meta\\.(xml)?$/ || resource =~ /.\\.(yaml)?$/) && salesforcedx-einstein-gpt.isEnabled"
+          "when": "sf:project_opened && sf:has_target_org && (resource =~ /.\\.externalServiceRegistration-meta\\.(xml)?$/ || resource =~ /.\\.(yaml)?$/) && salesforcedx-einstein-gpt.isEnabled && mule-dx-api-component.isDisabled"
         }
       ]
     },

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -149,7 +149,7 @@
         },
         {
           "command": "sf.validate.oas.document",
-          "when": "sf:project_opened && sf:has_target_org && ((resource =~ /.\\.externalServiceRegistration-meta\\.(xml)?$/ && !sf:is_esr_decomposed) || resource =~ /.\\.(yaml)?$/) && salesforcedx-einstein-gpt.isEnabled && mule-dx-api-component.isDisabled"
+          "when": "sf:project_opened && sf:has_target_org && ((resource =~ /.\\.externalServiceRegistration-meta\\.(xml)?$/ && !sf:is_esr_decomposed) || resource =~ /.\\.(yaml)?$/) && salesforcedx-einstein-gpt.isEnabled && sf:muleDxApiInactive"
         }
       ],
       "explorer/context": [
@@ -159,7 +159,7 @@
         },
         {
           "command": "sf.validate.oas.document",
-          "when": "sf:project_opened && sf:has_target_org && ((resource =~ /.\\.externalServiceRegistration-meta\\.(xml)?$/ && !sf:is_esr_decomposed) || resource =~ /.\\.(yaml)?$/) && salesforcedx-einstein-gpt.isEnabled && mule-dx-api-component.isDisabled"
+          "when": "sf:project_opened && sf:has_target_org && ((resource =~ /.\\.externalServiceRegistration-meta\\.(xml)?$/ && !sf:is_esr_decomposed) || resource =~ /.\\.(yaml)?$/) && salesforcedx-einstein-gpt.isEnabled && sf:muleDxApiInactive"
         }
       ],
       "view/title": [
@@ -282,7 +282,7 @@
         },
         {
           "command": "sf.validate.oas.document",
-          "when": "sf:project_opened && sf:has_target_org && (resource =~ /.\\.externalServiceRegistration-meta\\.(xml)?$/ || resource =~ /.\\.(yaml)?$/) && salesforcedx-einstein-gpt.isEnabled && mule-dx-api-component.isDisabled"
+          "when": "sf:project_opened && sf:has_target_org && (resource =~ /.\\.externalServiceRegistration-meta\\.(xml)?$/ || resource =~ /.\\.(yaml)?$/) && salesforcedx-einstein-gpt.isEnabled && sf:muleDxApiInactive"
         }
       ]
     },

--- a/packages/salesforcedx-vscode-apex/src/commands/apexActionController.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/apexActionController.ts
@@ -136,28 +136,10 @@ export class ApexActionController {
             documentInfo: infos,
             documentHints: hints
           };
-
-          // Step 10: Call Mulesoft extension if installed
-          const callMulesoftExtension = async () => {
-            if (await this.isCommandAvailable('mule-dx-api.open-api-project')) {
-              try {
-                const yamlUri = vscode.Uri.file(this.esrHandler.replaceXmlToYaml(fullPath[1]));
-                await vscode.commands.executeCommand('mule-dx-api.open-api-project', yamlUri);
-              } catch (error) {
-                telemetryService.sendEventData('mule-dx-api.open-api-project command could not be executed', {
-                  error: error.message
-                });
-                console.error('mule-dx-api.open-api-project command could not be executed', error);
-              }
-            } else {
-              telemetryService.sendEventData('mule-dx-api.open-api-project command not found');
-            }
-          };
-          await callMulesoftExtension();
         }
       );
 
-      // Step 11: Notify Success
+      // Step 10: Notify Success
       if (overwrite) {
         // Case 1: User decided to overwrite the original ESR file
         notificationService.showInformationMessage(nls.localize('openapi_doc_created', type.toLowerCase(), name));

--- a/packages/salesforcedx-vscode-apex/src/commands/apexActionController.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/apexActionController.ts
@@ -27,6 +27,14 @@ export class ApexActionController {
   public async initialize(extensionContext: vscode.ExtensionContext) {
     await WorkspaceContextUtil.getInstance().initialize(extensionContext);
     this.isESRDecomposed = await checkIfESRIsDecomposed();
+
+    const muleDxApiExtension = vscode.extensions.getExtension('salesforce.mule-dx-api-component');
+
+    if (!muleDxApiExtension?.isActive) {
+      await vscode.commands.executeCommand('setContext', 'sf:muleDxApiInactive', true);
+    } else {
+      await vscode.commands.executeCommand('setContext', 'sf:muleDxApiInactive', false);
+    }
   }
 
   /**

--- a/packages/salesforcedx-vscode-apex/src/commands/apexActionController.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/apexActionController.ts
@@ -27,14 +27,6 @@ export class ApexActionController {
   public async initialize(extensionContext: vscode.ExtensionContext) {
     await WorkspaceContextUtil.getInstance().initialize(extensionContext);
     this.isESRDecomposed = await checkIfESRIsDecomposed();
-
-    const muleDxApiExtension = vscode.extensions.getExtension('salesforce.mule-dx-api-component');
-
-    if (!muleDxApiExtension?.isActive) {
-      await vscode.commands.executeCommand('setContext', 'sf:muleDxApiInactive', true);
-    } else {
-      await vscode.commands.executeCommand('setContext', 'sf:muleDxApiInactive', false);
-    }
   }
 
   /**

--- a/packages/salesforcedx-vscode-apex/src/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/index.ts
@@ -98,6 +98,14 @@ export const activate = async (extensionContext: vscode.ExtensionContext) => {
   // Initialize if ESR xml is decomposed
   void vscode.commands.executeCommand('setContext', 'sf:is_esr_decomposed', isESRDecomposed);
 
+  const muleDxApiExtension = vscode.extensions.getExtension('salesforce.mule-dx-agentforce-api-component');
+
+  // Set context based on mulesoft extension
+  if (!muleDxApiExtension?.isActive) {
+    await vscode.commands.executeCommand('setContext', 'sf:muleDxApiInactive', true);
+  } else {
+    await vscode.commands.executeCommand('setContext', 'sf:muleDxApiInactive', false);
+  }
   // Commands
   const commands = registerCommands();
   extensionContext.subscriptions.push(commands);

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -195,7 +195,7 @@
       "editor/context": [
         {
           "command": "sf.retrieve.current.source.file",
-          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && resourceLangId != 'yaml' && sf:has_target_org"
+          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && resourceLangId != 'yaml' && resourceLangId != 'als' && sf:has_target_org"
         },
         {
           "command": "sf.retrieve.in.manifest",
@@ -203,7 +203,7 @@
         },
         {
           "command": "sf.deploy.current.source.file",
-          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && resourceLangId != 'yaml' && sf:has_target_org"
+          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && resourceLangId != 'yaml' && resourceLangId != 'als' && sf:has_target_org"
         },
         {
           "command": "sf.deploy.in.manifest",
@@ -297,7 +297,7 @@
         },
         {
           "command": "sf.retrieve.source.path",
-          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && resourceLangId != 'yaml' && sf:has_target_org"
+          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && resourceLangId != 'yaml' && resourceLangId != 'als' && sf:has_target_org"
         },
         {
           "command": "sf.retrieve.in.manifest",
@@ -305,7 +305,7 @@
         },
         {
           "command": "sf.deploy.source.path",
-          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && resourceLangId != 'yaml' && sf:has_target_org"
+          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && resourceLangId != 'yaml' && resourceLangId != 'als' && sf:has_target_org"
         },
         {
           "command": "sf.deploy.in.manifest",
@@ -491,7 +491,7 @@
         },
         {
           "command": "sf.retrieve.current.source.file",
-          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && resourceLangId != 'yaml' && editorIsOpen && sf:has_target_org"
+          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && resourceLangId != 'yaml' && resourceLangId != 'als' && editorIsOpen && sf:has_target_org"
         },
         {
           "command": "sf.retrieve.in.manifest",
@@ -499,7 +499,7 @@
         },
         {
           "command": "sf.deploy.current.source.file",
-          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && resourceLangId != 'yaml' && editorIsOpen && sf:has_target_org"
+          "when": "sf:project_opened && resourceLangId != 'forcesourcemanifest' && resourceLangId != 'yaml' && resourceLangId != 'als' && editorIsOpen && sf:has_target_org"
         },
         {
           "command": "sf.deploy.in.manifest",


### PR DESCRIPTION
### What does this PR do?
- Modifies condition for `SFDX: Validate OpenAPI Document (Beta)` command so it doesn't show up when with Mulesoft Extension is enabled

### What issues does this PR fix or reference?
@W-18034479@

### Functionality Before
- `SFDX: Validate OpenAPI Document (Beta)` command shows up even with Mulesoft Extension enabled

### Functionality After
- `SFDX: Validate OpenAPI Document (Beta)` command doesn't show up when Mulesoft Extension is enabled
