### PR TITLE
[DRAFT] feat: Apex Code Coverage - configurable `red_green` and `red_blue` color themes

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -519,6 +519,19 @@
           "type": "number",
           "default": 750,
           "description": "%apex_generation_output_token_limit%"
+        },
+        "salesforcedx-vscode-apex.apex-code-coverage-color-theme": {
+          "type": "string",
+          "enum": [
+            "red_green",
+            "red_blue"
+          ],
+          "default": "red_green",
+          "description": "%apex_code_coverage_color_theme%",
+          "enumDescriptions": [
+            "%apex_code_coverage_color_theme-red_green_description%",
+            "%apex_code_coverage_color_theme-red_blue_description%"
+          ]
         }
       }
     },

--- a/packages/salesforcedx-vscode-apex/package.nls.ja.json
+++ b/packages/salesforcedx-vscode-apex/package.nls.ja.json
@@ -36,5 +36,8 @@
   "run_tests_title": "テストを実行",
   "show_error_title": "エラーを表示",
   "test_view_container_title": "テストビューア",
-  "test_view_name": "Apex テスト"
+  "test_view_name": "Apex テスト",
+  "apex_code_coverage_color_theme": "Select the colors theme for Apex Tests code coverage",
+  "apex_code_coverage_color_theme-red_green_description": "Displays uncovered/covered lines with red/green color.",
+  "apex_code_coverage_color_theme-red_blue_description": "Displays uncovered/covered lines with red/blue color."
 }

--- a/packages/salesforcedx-vscode-apex/package.nls.json
+++ b/packages/salesforcedx-vscode-apex/package.nls.json
@@ -37,5 +37,8 @@
   "run_tests_title": "Run Tests",
   "show_error_title": "Display Error",
   "test_view_container_title": "Test Viewer",
-  "test_view_name": "Apex Tests"
+  "test_view_name": "Apex Tests",
+  "apex_code_coverage_color_theme": "Select the colors theme for Apex Tests code coverage",
+  "apex_code_coverage_color_theme-red_green_description": "Displays uncovered/covered lines with red/green color.",
+  "apex_code_coverage_color_theme-red_blue_description": "Displays uncovered/covered lines with red/blue color."
 }

--- a/packages/salesforcedx-vscode-apex/src/codecoverage/decorations.ts
+++ b/packages/salesforcedx-vscode-apex/src/codecoverage/decorations.ts
@@ -6,18 +6,58 @@
  */
 
 import { window } from 'vscode';
+import { retrieveApexCodeCoverageColorTheme } from '../settings';
 
-const lime = (opacity: number): string => `rgba(45, 121, 11, ${opacity})`;
-const red = (opacity: number): string => `rgba(253, 72, 73, ${opacity})`;
+enum CoverageColorsTheme {
+  RED_GREEN,
+  RED_BLUE
+}
+
+interface CoverageColors {
+  colorCovered: string;
+  colorUncovered: string;
+}
+
+const getSelectedColorTheme = (): CoverageColorsTheme => {
+  const configColorTheme = retrieveApexCodeCoverageColorTheme();
+  switch (configColorTheme) {
+    case 'red_blue': {
+      return CoverageColorsTheme.RED_BLUE;
+    }
+    default:
+      return CoverageColorsTheme.RED_GREEN;
+  }
+};
+
+// const colorCovered = (opacity: number): string => `rgba(45, 121, 11, ${opacity})`;
+// const colorUncovered = (opacity: number): string => `rgba(253, 72, 73, ${opacity})`;
+const CoverageColorsService = (colorType: CoverageColorsTheme) => {
+  return {
+    [CoverageColorsTheme.RED_GREEN]: (opacity: number): CoverageColors => ({
+      colorCovered: `rgba(45, 121, 11, ${opacity})`,
+      colorUncovered: `rgba(253, 72, 73, ${opacity})`
+    }),
+    [CoverageColorsTheme.RED_BLUE]: (opacity: number): CoverageColors => ({
+      colorCovered: `rgba(45, 121, 255, ${opacity})`,
+      colorUncovered: `rgba(253, 72, 73, ${opacity})`
+    })
+  }[colorType];
+};
+
+const getCoverageColors = (opacity: number) => {
+  return CoverageColorsService(getSelectedColorTheme())(opacity);
+};
+
+const selectedCoverageColors = getCoverageColors(0.5);
 
 export const coveredLinesDecorationType = window.createTextEditorDecorationType({
-  backgroundColor: lime(0.5),
+  backgroundColor: selectedCoverageColors.colorCovered,
   borderRadius: '.2em',
-  overviewRulerColor: lime(0.5)
+  overviewRulerColor: selectedCoverageColors.colorCovered
 });
 
 export const uncoveredLinesDecorationType = window.createTextEditorDecorationType({
-  backgroundColor: red(0.5),
+  backgroundColor: selectedCoverageColors.colorUncovered,
   borderRadius: '.2em',
-  overviewRulerColor: red(0.5)
+  overviewRulerColor: selectedCoverageColors.colorUncovered
 });

--- a/packages/salesforcedx-vscode-apex/src/settings.ts
+++ b/packages/salesforcedx-vscode-apex/src/settings.ts
@@ -25,6 +25,8 @@ const DEFAULT_CLASS_ACCESS_MODIFIERS = ['global', 'public'];
 const DEFAULT_METHOD_ACCESS_MODIFIERS = ['global', 'public'];
 const DEFAULT_PROP_ACCESS_MODIFIERS = ['global', 'public'];
 
+const DEFAULT_CODE_COVERAGE_COLOR_THEME = 'red_green';
+
 export const retrieveTestCodeCoverage = (): boolean => {
   return vscode.workspace
     .getConfiguration(SFDX_CORE_CONFIGURATION_NAME)
@@ -117,3 +119,9 @@ export const retrieveGeneralPropAccessModifiers = (): string[] =>
   vscode.workspace
     .getConfiguration()
     .get<string[]>('salesforcedx-vscode-apex.apexoas.general.prop.access-modifiers', DEFAULT_PROP_ACCESS_MODIFIERS);
+
+export const retrieveApexCodeCoverageColorTheme = (): string => {
+  return vscode.workspace
+    .getConfiguration()
+    .get<string>('salesforcedx-vscode-apex.apex-code-coverage-color-theme', DEFAULT_CODE_COVERAGE_COLOR_THEME);
+};


### PR DESCRIPTION
### What does this PR do?
This is a very raw implementation of the configurable "color theme" for Apex code coverage (per discussion #5807):
- `red_green` (default): uncoveredLines: **red**, coveredLines: **green**
- `red_blue` ("Developer Console" alike): uncoveredLines: **red**, coveredLines: **blue**

This ColorTheme selection is exposed as `salesforcedx-vscode-apex.apex-code-coverage-color-theme` configuration property.

### What issues does this PR fix or reference?
See discussion #5807.

### Functionality Before
Apex code coverage colors are static: uncoveredLines: **red**, coveredLines: **green**.

### Functionality After
Apex coverage colors can be switched between `red_green`/`red_blue` options from the Settings page.
Example `red_green` (same as current colors):
![ApexCodeCoverageColorTheme_redGreen](https://github.com/user-attachments/assets/992d71fe-118f-4188-80e9-ce6c876f12ea)

Example `red_blue`:
![ApexCodeCoverageColorTheme_redBlue](https://github.com/user-attachments/assets/adb80c9e-e9b2-4982-80ae-fd0414e017d9)

---

### Working Items ###
- [x] **FEAT:** Impl `red_green` and `red_blue` color themes, base functionality.
  - // DISCLAIMER: I don't have much experience with JS/TS programming; basically tried to mimic what already was there or around.
- [ ] **I18N:** `packages/salesforcedx-vscode-apex/package.nls.ja.json` Japanese description labels to be translated.
- [ ] **TESTS:** Impl unit tests to validate how decorations are being applied.
  - **// DISCLAIMER: I have no experience with JS/TS testing, so this is completely absent at the moment. _Any_ help is highly appreciated.**
  - Note: from a brief research, this doesn't seem like an easy task, because VSCode API does not allow retrieving currently applied decorations. [This article](https://github.com/microsoft/vscode/issues/136164#issuecomment-956027228) suggests adding an "injection pattern" for testing to inspect what TextEditorDecorationType values are passed - but I have no experience with JS/TS testing, so that is way above my skills.
- [ ] **FEAT:** Impl dynamically applying selectedColorTheme's colors when switching between `red_green` and `red_blue` options on the _Settings_ page.
  - I tried coverting `coveredLinesDecorationType`/`uncoveredLinesDecorationType` from constants into functions, so that every time the `CodeCoverageHandler.setCoverageDecorators(...)` runs, it reads the current color theme setting and returns the new TextEditorDecorationType instance with selected theme's colors.
    - It didn't work, those **dynamically-created TextEditorDecorationTypes do not get auto-disposed** when we are applying different TextEditorDecorationType (probably for [this reason](https://github.com/microsoft/vscode-extension-samples/issues/22#issuecomment-321555992)). As a result, it was impossible to toggle the decorations off, and when we switch to other color theme option, colors got applied **on top of** the previous colors - not looking good at all.
    - Because of that, I ended up building the decorations just once. This means that switching the color theme requires reloading extensions host/window.