### PR TITLE
fix: W-17700700 - typo passing isESRDecomposed

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/oas/ExternalServiceRegistrationManager.ts
+++ b/packages/salesforcedx-vscode-apex/src/oas/ExternalServiceRegistrationManager.ts
@@ -65,7 +65,7 @@ export class ExternalServiceRegistrationManager {
     processedOasResult: ProcessorInputOutput,
     fullPath: [string, string, boolean]
   ): Promise<void> {
-    this.initialize(this.isESRDecomposed, processedOasResult, fullPath);
+    this.initialize(isESRDecomposed, processedOasResult, fullPath);
     const orgVersion = await (await workspaceContext.getConnection()).retrieveMaxApiVersion();
     if (!orgVersion) {
       throw new Error(nls.localize('error_retrieving_org_version'));

--- a/packages/salesforcedx-vscode-apex/test/jest/oas/externalServiceRegistrationManager.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/oas/externalServiceRegistrationManager.test.ts
@@ -141,10 +141,10 @@ describe('ExternalServiceRegistrationManager', () => {
 
       await esrHandler.generateEsrMD(true, processedOasResult, fullPath);
 
-      expect(esrHandler['initialize']).toHaveBeenCalledWith(false, processedOasResult, fullPath);
+      expect(esrHandler['initialize']).toHaveBeenCalledWith(true, processedOasResult, fullPath);
       expect(esrHandler.writeAndOpenEsrFile).toHaveBeenCalled();
       expect(esrHandler.displayFileDifferences).toHaveBeenCalled();
-      expect(createProblemTabEntriesForOasDocument).toHaveBeenCalledWith(fullPath[1], processedOasResult, false);
+      expect(createProblemTabEntriesForOasDocument).toHaveBeenCalledWith(fullPath[1], processedOasResult, true);
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
fixes typo - using this.x instead of param x

### What issues does this PR fix or reference?
@W-17700700@

### Functionality Before
- only xml file created even in decomposed mode

### Functionality After
- xml and yaml file created in decomposed mode
