### PR TITLE
W-18117993 test: fix mock to avoid writes to the filesystem

### DIFF
--- a/packages/salesforcedx-utils-vscode/test/jest/telemetry/reporters/determineReporters.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/telemetry/reporters/determineReporters.test.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import * as fs from 'fs';
 import { AppInsights } from '../../../../src';
 import * as Settings from '../../../../src/settings';
 import { determineReporters } from '../../../../src/telemetry/reporters/determineReporters';
@@ -11,6 +12,11 @@ import { LogStream } from '../../../../src/telemetry/reporters/logStream';
 import { LogStreamConfig } from '../../../../src/telemetry/reporters/logStreamConfig';
 import { TelemetryFile } from '../../../../src/telemetry/reporters/telemetryFile';
 import { TelemetryReporterConfig } from '../../../../src/telemetry/reporters/telemetryReporterConfig';
+
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  createWriteStream: jest.fn()
+}));
 
 describe('determineReporters', () => {
   let config: TelemetryReporterConfig;
@@ -68,6 +74,12 @@ describe('determineReporters', () => {
     });
 
     it('should return AppInsights and LogStream reporters when not in dev mode and log stream is enabled', () => {
+      const fsMocked = jest.mocked(fs);
+      fsMocked.createWriteStream.mockReturnValue({
+        write: jest.fn(),
+        end: jest.fn()
+      } as any);
+
       LogStreamConfig.isEnabledFor = jest.fn().mockReturnValue(true);
       const reporters = determineReporters(config);
       expect(reporters).toHaveLength(2);


### PR DESCRIPTION
### What does this PR do?
determineReporters.test.ts `should return AppInsights and LogStream reporters...` calls `determineReporters` which calls new on LogStream whose constructor uses fs.createWriteStream.  This results in a file being creates when the test is run.

adds mocks for fs.createWriteStream, based on the ones in LogStream.test.ts 

### What issues does this PR fix or reference?
@W-18117993@

### Functionality Before
run determineReporters.test.ts `should return AppInsights and LogStream reporters...`, see a file created.

### Functionality After
no file created