### PR TITLE
fix: W-18160073 - adding SHA256.md back from commit before it was removed

### DIFF
--- a/SHA256.md
+++ b/SHA256.md
@@ -1,0 +1,38 @@
+Currently, Visual Studio Code extensions are not signed or verified on the
+Microsoft Visual Studio Code Marketplace. Salesforce provides the Secure Hash
+Algorithm (SHA) of each extension that we publish. To verify the extensions,
+make sure that their SHA values match the values in the list below.
+
+1. Instead of installing the Visual Code Extension directly from within Visual
+   Studio Code, download the VS Code extension that you want to check by
+   following the instructions at
+   https://code.visualstudio.com/docs/editor/extension-gallery#_common-questions.
+   For example, download,
+   https://salesforce.gallery.vsassets.io/_apis/public/gallery/publisher/salesforce/extension/salesforcedx-vscode-core/63.7.0/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage.
+
+2. From a terminal, run:
+
+shasum -a 256 <location_of_the_downloaded_file>
+
+3. Confirm that the SHA in your output matches the value in this list of SHAs.
+
+d9d3a00f60da319a37b563a7f6b8f52df865f8ade0ec513c3febaddef6b110de  salesforcedx-vscode-63.7.0.vsix
+454ebbbdb82e15b63b3c040aa6dbd4fe01c6d08f574faa721f6dc4a5a1f52911  salesforcedx-vscode-apex-63.7.0.vsix
+20fe6f150e79cc468e443ddfeb5606a90a3dc19f3fcd0663577fecb0a17b20a8  salesforcedx-vscode-apex-debugger-63.7.0.vsix
+5877846977b5376ac313b632f9157330d62663ffc088406dd5db3aba1107222c  salesforcedx-vscode-apex-replay-debugger-63.7.0.vsix
+23ebe92799b27389369bcc4dbdc9a8113f05d62824f21204063b026af5b74442  salesforcedx-vscode-core-63.7.0.vsix
+fe187a6d95c9d8064d884adfa8795ab7a996efcea6fbc0764edf238dedbcd998  salesforcedx-vscode-expanded-63.7.0.vsix
+dc42979832f9c716c83065bb77d4cdc407e07876ca4f32c1bed1f256cddc68ed  salesforcedx-vscode-lightning-63.7.0.vsix
+e360b048364abd1628a9a8dd39379294ca5ab556431a086aee20ed2a48547d5f  salesforcedx-vscode-lwc-63.7.0.vsix
+f4ab85b9fc22eb020065123c2d9f2517da28a9ad2f84db6899b28cdb497665ac  salesforcedx-vscode-soql-63.7.0.vsix
+b7090f3f41bc6ec88b7a376d53a43c8915de6949b7a03ed95a8b7f3681e438da  salesforcedx-vscode-visualforce-63.7.0.vsix
+
+
+4. Change the filename extension for the file that you downloaded from .zip to
+.vsix.
+
+5. In Visual Studio Code, from the Extensions view, select ... > Install from
+VSIX.
+
+6. Install the verified VSIX file.
+


### PR DESCRIPTION
adding SHA256.md back from commit before it was removed. I got the file use:

```git checkout 3afafcdc81530083d98e562a5a2f9ddfd55a5b41 SHA256.md```

### What does this PR do?
adds the SHA256 back. 

### What issues does this PR fix or reference?
@W-18160073@

### Functionality Before
File was deleted in commit: https://github.com/forcedotcom/salesforcedx-vscode/commit/390ee4bb72b0db7fe4cf0b308f18a99006a08590 and was causing merge conflicts when trying to release: https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/14341754952/job/40210926277  

### Functionality After
Adding the file back.
