### PR TITLE
W-18257178 fix: apex replay debugger error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32352,7 +32352,7 @@
         "@salesforce/salesforcedx-utils": "63.9.0",
         "@vscode/debugadapter": "1.68.0",
         "@vscode/debugprotocol": "1.68.0",
-        "vscode-uri": "<=1.0.6"
+        "vscode-uri": "1.0.6"
       },
       "devDependencies": {
         "@types/chai": "4.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32352,7 +32352,7 @@
         "@salesforce/salesforcedx-utils": "63.9.0",
         "@vscode/debugadapter": "1.68.0",
         "@vscode/debugprotocol": "1.68.0",
-        "vscode-uri": "^1.0.1"
+        "vscode-uri": "<=1.0.6"
       },
       "devDependencies": {
         "@types/chai": "4.3.3",
@@ -32472,6 +32472,12 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "packages/salesforcedx-apex-replay-debugger/node_modules/vscode-uri": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.6.tgz",
+      "integrity": "sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww==",
       "license": "MIT"
     },
     "packages/salesforcedx-apex-replay-debugger/node_modules/yargs": {

--- a/packages/salesforcedx-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-apex-replay-debugger/package.json
@@ -16,7 +16,7 @@
     "@salesforce/salesforcedx-utils": "63.9.0",
     "@vscode/debugadapter": "1.68.0",
     "@vscode/debugprotocol": "1.68.0",
-    "vscode-uri": "<=1.0.6"
+    "vscode-uri": "1.0.6"
   },
   "devDependencies": {
     "@types/chai": "4.3.3",

--- a/packages/salesforcedx-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-apex-replay-debugger/package.json
@@ -16,7 +16,7 @@
     "@salesforce/salesforcedx-utils": "63.9.0",
     "@vscode/debugadapter": "1.68.0",
     "@vscode/debugprotocol": "1.68.0",
-    "vscode-uri": "^1.0.1"
+    "vscode-uri": "<=1.0.6"
   },
   "devDependencies": {
     "@types/chai": "4.3.3",


### PR DESCRIPTION
apex replay debugger error was caused by:

```
"[UriError]: Scheme is missing: {scheme: \"\", authority: \"\", path: \"/Users/madhur.shrivastava/salesforcedx-vscode-automation-tests-redhat/e2e-temp/TempProject-ApexReplayDebugger/.sfdx/tools/debug/logs/07LDP000018XY442AG.log\", query: \"\", fragment: \"\"}"
```
Related issue: https://github.com/eclipse-theia/theia/issues/5308

### What does this PR do?
Restricts the vscode-uri version to <=1.0.6

### What issues does this PR fix or reference?
@W-18257178@

### Functionality Before
Apex Replay Debugger from a log file was broken and would never stop at the break point in a file.

### Functionality After
Apex Replay Debugger works when manually tested.
