### PR TITLE
W-17652496 chore: bump @salesforce/templates to v63.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6833,9 +6833,9 @@
       }
     },
     "node_modules/@salesforce/templates": {
-      "version": "63.0.3",
-      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-63.0.3.tgz",
-      "integrity": "sha512-jePrdKA2R6fBo53u1S1lIduHoLTzFQHCcKMVLAURizZn5zsxQSzzTMfSWLt6HmVSfMsjR5RC+g+KiYK3Qe4fDQ==",
+      "version": "63.0.4",
+      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-63.0.4.tgz",
+      "integrity": "sha512-YmkVqKQjrpWKf/Jt6TULp5/L+juhMqqLMRRxioVUDnbZNQx0ZuzdTmwxyGtkljV1XQVMJgR6g3JO7wwcyEMtNA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/kit": "^3.2.3",
@@ -33593,7 +33593,7 @@
         "@salesforce/salesforcedx-utils-vscode": "63.9.1",
         "@salesforce/schemas": "1.9.0",
         "@salesforce/source-deploy-retrieve-bundle": "12.15.0",
-        "@salesforce/templates": "63.0.3",
+        "@salesforce/templates": "63.0.4",
         "@salesforce/ts-types": "2.0.12",
         "@salesforce/vscode-service-provider": "1.4.0",
         "applicationinsights": "1.0.7",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -30,7 +30,7 @@
     "@salesforce/salesforcedx-utils-vscode": "63.9.1",
     "@salesforce/schemas": "1.9.0",
     "@salesforce/source-deploy-retrieve-bundle": "12.15.0",
-    "@salesforce/templates": "63.0.3",
+    "@salesforce/templates": "63.0.4",
     "@salesforce/ts-types": "2.0.12",
     "@salesforce/vscode-service-provider": "1.4.0",
     "applicationinsights": "1.0.7",


### PR DESCRIPTION
### What does this PR do?
Pulls in the change in https://github.com/forcedotcom/salesforcedx-templates/pull/662

### What issues does this PR fix or reference?
@W-17652496@, @W-17275130@

### Functionality Before
`npm install` fails in a new Salesforce project

### Functionality After
`npm install` works in a new Salesforce project
