### PR TITLE
chore: upgrade jest-editor-support dependency to latest version so LWC extension can activate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -251,6 +251,43 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/@babel/helper-environment-visitor": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
+      "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
+      "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.24.7",
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-hoist-variables": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
+      "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-member-expression-to-functions": {
       "version": "7.25.9",
       "license": "MIT",
@@ -341,6 +378,18 @@
       "dependencies": {
         "@babel/traverse": "^7.25.9",
         "@babel/types": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+      "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -14745,16 +14794,38 @@
       }
     },
     "node_modules/jest-editor-support": {
-      "version": "30.3.1",
+      "version": "31.1.2",
+      "resolved": "https://registry.npmjs.org/jest-editor-support/-/jest-editor-support-31.1.2.tgz",
+      "integrity": "sha512-QlCN8dWVxMcmvzbkH2G1gSNjMPFM+69+Lx9WZcpYiHEaqrb1QKuVJrVNfbjHrlv0PhgCvzf1EdYKh8qqrQ3Rhw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.15.7",
-        "@babel/runtime": "^7.15.4",
-        "@babel/traverse": "^7.15.4",
-        "@babel/types": "^7.15.6",
-        "@jest/types": "^27.1.1",
+        "@babel/parser": "^7.20.7",
+        "@babel/runtime": "^7.20.7",
+        "@babel/traverse": "7.23.2",
+        "@babel/types": "^7.20.7",
         "core-js": "^3.17.3",
         "jest-snapshot": "^27.2.0"
+      }
+    },
+    "node_modules/jest-editor-support/node_modules/@babel/traverse": {
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.23.0",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-hoist-variables": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/parser": "^7.23.0",
+        "@babel/types": "^7.23.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/jest-editor-support/node_modules/@jest/transform": {
@@ -27586,7 +27657,7 @@
         "@salesforce/lwc-language-server": "4.12.3",
         "@salesforce/salesforcedx-utils-vscode": "63.11.0",
         "applicationinsights": "1.0.7",
-        "jest-editor-support": "30.3.1",
+        "jest-editor-support": "31.1.2",
         "jest-regex-util": "^24.9.0",
         "rxjs": "^5.4.1",
         "strip-ansi": "^5.2.0",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -29,7 +29,7 @@
     "@salesforce/lwc-language-server": "4.12.3",
     "@salesforce/salesforcedx-utils-vscode": "63.11.0",
     "applicationinsights": "1.0.7",
-    "jest-editor-support": "30.3.1",
+    "jest-editor-support": "31.1.2",
     "jest-regex-util": "^24.9.0",
     "rxjs": "^5.4.1",
     "strip-ansi": "^5.2.0",
@@ -94,7 +94,7 @@
         "@salesforce/lightning-lsp-common": "4.12.3",
         "@salesforce/lwc-language-server": "4.12.3",
         "applicationinsights": "1.0.7",
-        "jest-editor-support": "30.3.1"
+        "jest-editor-support": "31.1.2"
       },
       "devDependencies": {}
     }


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Upgrades the **jest-editor-support** dependency from v30.3.1 to v31.1.2 so that the LWC extension is able to activate.

### What issues does this PR fix or reference?
[skip-validate-pr]
