### PR TITLE
fix: W-18483821 - use latest instead of stable in e2e related workflows

### DIFF
--- a/.github/workflows/apexE2E.yml
+++ b/.github/workflows/apexE2E.yml
@@ -41,7 +41,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'stable'
+        default: 'latest'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -88,7 +88,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'stable'
+        default: 'latest'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'

--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -46,7 +46,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'stable'
+        default: 'latest'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -98,7 +98,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'stable'
+        default: 'latest'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -185,15 +185,8 @@ jobs:
 
   slack_success_notification:
     if: ${{ success() }}
-    needs: [
-        anInitialSuite,
-        authentication,
-        createProject,
-        miscellaneous,
-        sObjectsDefinitions,
-        templates,
-        sfdxProjectJson
-      ]
+    needs:
+      [anInitialSuite, authentication, createProject, miscellaneous, sObjectsDefinitions, templates, sfdxProjectJson]
     uses: ./.github/workflows/slackNotification.yml
     secrets: inherit
     with:
@@ -207,15 +200,8 @@ jobs:
 
   slack_failure_notification:
     if: ${{ failure() }}
-    needs: [
-        anInitialSuite,
-        authentication,
-        createProject,
-        miscellaneous,
-        sObjectsDefinitions,
-        templates,
-        sfdxProjectJson
-      ]
+    needs:
+      [anInitialSuite, authentication, createProject, miscellaneous, sObjectsDefinitions, templates, sfdxProjectJson]
     uses: ./.github/workflows/slackNotification.yml
     secrets: inherit
     with:
@@ -229,15 +215,8 @@ jobs:
 
   slack_cancelled_notification:
     if: ${{ cancelled() }}
-    needs: [
-        anInitialSuite,
-        authentication,
-        createProject,
-        miscellaneous,
-        sObjectsDefinitions,
-        templates,
-        sfdxProjectJson
-      ]
+    needs:
+      [anInitialSuite, authentication, createProject, miscellaneous, sObjectsDefinitions, templates, sfdxProjectJson]
     uses: ./.github/workflows/slackNotification.yml
     secrets: inherit
     with:

--- a/.github/workflows/deployRetrieveE2E.yml
+++ b/.github/workflows/deployRetrieveE2E.yml
@@ -36,7 +36,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'stable'
+        default: 'latest'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -78,7 +78,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'stable'
+        default: 'latest'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -131,7 +131,7 @@ jobs:
       runId: ${{ inputs.runId }}
 
   mdDeployRetrieve:
-    if: ${{ inputs.mdDeployRetrieve && inputs.vscodeVersion == 'stable'}}
+    if: ${{ inputs.mdDeployRetrieve && inputs.vscodeVersion == 'latest'}}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,7 +48,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'stable'
+        default: 'latest'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -62,7 +62,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch || 'main' }}
-      vscodeVersion: ${{ inputs.vscodeVersion || 'stable' }}
+      vscodeVersion: ${{ inputs.vscodeVersion || 'latest' }}
       runId: ${{ inputs.runId || github.event.workflow_run.id }}
 
   Core:
@@ -71,7 +71,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch || 'main' }}
-      vscodeVersion: ${{ inputs.vscodeVersion || 'stable' }}
+      vscodeVersion: ${{ inputs.vscodeVersion || 'latest' }}
       runId: ${{ inputs.runId || github.event.workflow_run.id }}
 
   DeployAndRetrieve:
@@ -80,7 +80,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch || 'main' }}
-      vscodeVersion: ${{ inputs.vscodeVersion || 'stable' }}
+      vscodeVersion: ${{ inputs.vscodeVersion || 'latest' }}
       runId: ${{ inputs.runId || github.event.workflow_run.id }}
 
   LSP:
@@ -89,7 +89,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch || 'main' }}
-      vscodeVersion: ${{ inputs.vscodeVersion || 'stable' }}
+      vscodeVersion: ${{ inputs.vscodeVersion || 'latest' }}
       runId: ${{ inputs.runId || github.event.workflow_run.id }}
 
   LWC:
@@ -98,7 +98,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch || 'main' }}
-      vscodeVersion: ${{ inputs.vscodeVersion || 'stable' }}
+      vscodeVersion: ${{ inputs.vscodeVersion || 'latest' }}
       runId: ${{ inputs.runId || github.event.workflow_run.id }}
 
   SOQL:
@@ -107,7 +107,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch || 'main' }}
-      vscodeVersion: ${{ inputs.vscodeVersion || 'stable' }}
+      vscodeVersion: ${{ inputs.vscodeVersion || 'latest' }}
       runId: ${{ inputs.runId || github.event.workflow_run.id }}
 
   Apex_min_vscode_version:

--- a/.github/workflows/lspE2E.yml
+++ b/.github/workflows/lspE2E.yml
@@ -26,7 +26,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'stable'
+        default: 'latest'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -58,7 +58,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'stable'
+        default: 'latest'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'

--- a/.github/workflows/lwcE2E.yml
+++ b/.github/workflows/lwcE2E.yml
@@ -21,7 +21,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'stable'
+        default: 'latest'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -48,7 +48,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'stable'
+        default: 'latest'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'

--- a/.github/workflows/runE2ETest.yml
+++ b/.github/workflows/runE2ETest.yml
@@ -40,7 +40,8 @@ jobs:
         nodeVersion:
           - 22.15.0
         vscodeVersion:
-          - ${{ inputs.vscodeVersion }}
+          - 1.99.3
+          - 1.100.0
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/runE2ETest.yml
+++ b/.github/workflows/runE2ETest.yml
@@ -19,7 +19,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'stable'
+        default: 'latest'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -38,10 +38,9 @@ jobs:
       matrix:
         os: ${{ fromJson(inputs.os) }}
         nodeVersion:
-          - 22.15.0
+          - 20.17.0
         vscodeVersion:
-          - 1.99.3
-          - 1.100.0
+          - ${{ inputs.vscodeVersion }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/runE2ETest.yml
+++ b/.github/workflows/runE2ETest.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         os: ${{ fromJson(inputs.os) }}
         nodeVersion:
-          - 20.17.0
+          - 22.15.0
         vscodeVersion:
           - ${{ inputs.vscodeVersion }}
     steps:

--- a/.github/workflows/soqlE2E.yml
+++ b/.github/workflows/soqlE2E.yml
@@ -16,7 +16,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'stable'
+        default: 'latest'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -38,7 +38,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'stable'
+        default: 'latest'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'


### PR DESCRIPTION
### What does this PR do?
Updates vscodeVersion default value to latest instead of stable in e2e related workflows

### What issues does this PR fix or reference?
@W-18483821@

Test run: [Core End to End Tests](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/14936408989) ✅ 