### PR TITLE
chore: W-18379540 - use vscode api instead of fs in lwc package

### DIFF
--- a/packages/salesforcedx-vscode-lwc/src/commands/lightningLwcPreview.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/lightningLwcPreview.ts
@@ -145,12 +145,6 @@ export const lwcPreview = async (sourceUri: URI) => {
 
   try {
     const stat = await vscode.workspace.fs.stat(sourceUri);
-    if (!stat) {
-      const message = nls.localize('lightning_lwc_preview_file_nonexist', resourcePath);
-      showError(new Error(message), logName, commandName);
-      return;
-    }
-
     const isSFDX = true; // TODO support non SFDX Projects
     const isDirectory = stat.type === vscode.FileType.Directory;
     const componentName = isDirectory
@@ -163,7 +157,7 @@ export const lwcPreview = async (sourceUri: URI) => {
     }
 
     await executePreview(startTime, componentName, resourcePath);
-  } catch (error) {
+  } catch {
     const message = nls.localize('lightning_lwc_preview_file_nonexist', resourcePath);
     showError(new Error(message), logName, commandName);
     return;
@@ -553,10 +547,6 @@ export const getProjectRootDirectory = async (startPath: string): Promise<string
   try {
     const startUri = vscode.Uri.file(startPath);
     const stat = await vscode.workspace.fs.stat(startUri);
-    if (!stat) {
-      return undefined;
-    }
-
     const searchingForFile = 'sfdx-project.json';
     let dir: string | undefined = stat.type === vscode.FileType.Directory ? startPath : path.dirname(startPath);
     while (dir) {

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/commands/lwcTestDebugAction.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/commands/lwcTestDebugAction.ts
@@ -22,7 +22,11 @@ const debugSessionStartTimes = new Map<string, [number, number]>();
  * @param args CLI arguments
  * @param cwd current working directory
  */
-export const getDebugConfiguration = (command: string, args: string[], cwd: string): vscode.DebugConfiguration => {
+export const getDebugConfiguration = async (
+  command: Promise<string>,
+  args: string[],
+  cwd: string
+): Promise<vscode.DebugConfiguration> => {
   const sfDebugSessionId = uuid.v4();
   const debugConfiguration: vscode.DebugConfiguration = {
     sfDebugSessionId,
@@ -30,7 +34,7 @@ export const getDebugConfiguration = (command: string, args: string[], cwd: stri
     request: 'launch',
     name: 'Debug LWC test(s)',
     cwd,
-    runtimeExecutable: command,
+    runtimeExecutable: await command,
     args,
     resolveSourceMapLocations: ['**', '!**/node_modules/**'],
     console: 'integratedTerminal',
@@ -47,11 +51,11 @@ export const getDebugConfiguration = (command: string, args: string[], cwd: stri
  */
 const lwcTestDebug = async (testExecutionInfo: TestExecutionInfo) => {
   const testRunner = new TestRunner(testExecutionInfo, TestRunType.DEBUG);
-  const shellExecutionInfo = testRunner.getShellExecutionInfo();
+  const shellExecutionInfo = await testRunner.getShellExecutionInfo();
   if (shellExecutionInfo) {
     const { command, args, workspaceFolder, testResultFsPath } = shellExecutionInfo;
     testRunner.startWatchingTestResults(testResultFsPath);
-    const debugConfiguration = getDebugConfiguration(command, args, workspaceFolder.uri.fsPath);
+    const debugConfiguration = await getDebugConfiguration(Promise.resolve(command), args, workspaceFolder.uri.fsPath);
     await vscode.debug.startDebugging(workspaceFolder, debugConfiguration);
   }
 };

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/testRunner/testResultsWatcher.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/testRunner/testResultsWatcher.ts
@@ -5,7 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { getTestResultsFolder } from '@salesforce/salesforcedx-utils-vscode';
-import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { URI } from 'vscode-uri';
@@ -64,13 +63,10 @@ class TestResultsWatcher implements vscode.Disposable {
     }
   }
 
-  private updateTestResultsFromTestResultsJson(testResultsUri: URI) {
+  private async updateTestResultsFromTestResultsJson(testResultsUri: URI) {
     try {
-      const { fsPath: testResultsFsPath } = testResultsUri;
-      const testResultsJSON = fs.readFileSync(testResultsFsPath, {
-        encoding: 'utf8'
-      });
-      const testResults = JSON.parse(testResultsJSON);
+      const testResultsContent = await vscode.workspace.fs.readFile(testResultsUri);
+      const testResults = JSON.parse(testResultsContent.toString());
       lwcTestIndexer.updateTestResults(testResults);
     } catch (error) {
       console.error(error);

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/testRunner/testRunner.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/testRunner/testRunner.ts
@@ -115,14 +115,14 @@ export class TestRunner {
   /**
    * Generate shell execution info necessary for task execution
    */
-  public getShellExecutionInfo() {
+  public async getShellExecutionInfo() {
     const workspaceFolder = workspace.getTestWorkspaceFolder(this.testExecutionInfo.testUri);
     if (workspaceFolder) {
       const jestExecutionInfo = this.getJestExecutionInfo(workspaceFolder);
       if (jestExecutionInfo) {
         const { jestArgs, jestOutputFilePath } = jestExecutionInfo;
         const cwd = workspaceFolder.uri.fsPath;
-        const lwcTestRunnerExecutable = workspace.getLwcTestRunnerExecutable(cwd);
+        const lwcTestRunnerExecutable = await workspace.getLwcTestRunnerExecutable(cwd);
         const cliArgs: string[] = workspace.getCliArgsFromJestArgs(jestArgs, this.testRunType);
         if (lwcTestRunnerExecutable) {
           return {
@@ -161,7 +161,7 @@ export class TestRunner {
    * Returns the task wrapper on task creation if successful.
    */
   public async executeAsSfTask(): Promise<SfTask | undefined> {
-    const shellExecutionInfo = this.getShellExecutionInfo();
+    const shellExecutionInfo = await this.getShellExecutionInfo();
     if (shellExecutionInfo) {
       const { command, args, workspaceFolder, testResultFsPath } = shellExecutionInfo;
       this.startWatchingTestResults(testResultFsPath);


### PR DESCRIPTION
### What does this PR do?
- Updates code to use vscode api instead of fs in lwc package

### What issues does this PR fix or reference?
@W-18379540@

Test run: [LWC End to End Tests](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/14942482352) ✅ 