### PR TITLE
@W-18524127 chore: add common properties to exception events in O11yReporter

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/telemetry/reporters/o11yReporter.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/reporters/o11yReporter.ts
@@ -103,6 +103,7 @@ export class O11yReporter extends Disposable implements TelemetryReporter {
         properties: props,
         measurements
       });
+
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       this.o11yService.upload();
     }
@@ -122,10 +123,12 @@ export class O11yReporter extends Disposable implements TelemetryReporter {
       const orgId = WorkspaceContextUtil.getInstance().orgId || '';
       const orgShape = WorkspaceContextUtil.getInstance().orgShape || '';
       const devHubId = WorkspaceContextUtil.getInstance().devHubId || '';
-      const properties = this.applyTelemetryTag({ orgId, orgShape, devHubId });
+      const baseProps = { orgId, orgShape, devHubId };
+      const props = this.applyTelemetryTag({ ...baseProps, ...this.aggregateLoggingProperties() });
+
       this.o11yService.logEvent({
         exception: error,
-        properties,
+        properties: props,
         measurements
       });
 


### PR DESCRIPTION
### What does this PR do?
Add Common Properties to Exception Events in O11yReporter

Changes :
- Modified `sendExceptionEvent` method to include aggregated logging properties
- Added the following properties to exception events:
  - System information (OS, platform version, memory, CPU)
  - VS Code specific data (machine ID, session ID, version)
  - User context (user ID, session ID)
  - Internal properties (for internal hosts)
- Maintained existing organization properties (orgId, orgShape, devHubId) and telemetry tags

Why :
This change ensures consistent telemetry data across all event types. Previously, exception events only included organization-related properties, while regular telemetry events included a comprehensive set of properties. This inconsistency made it harder to correlate exceptions with system state and user context.

### What issues does this PR fix or reference?
# @W-18524127@

### Functionality Before
<insert gif and/or summary>

### Functionality After
<insert gif and/or summary>
