### PR TITLE
chore: await reset output folder

### DIFF
--- a/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/src/generator/fauxClassGenerator.ts
@@ -44,7 +44,7 @@ export class FauxClassGenerator implements SObjectGenerator {
 
   public async generate(output: SObjectRefreshOutput): Promise<void> {
     const outputFolderPath = path.join(output.sfdxPath, ...REL_BASE_FOLDER, this.relativePath);
-    if (!this.resetOutputFolder(outputFolderPath)) {
+    if (!(await this.resetOutputFolder(outputFolderPath))) {
       throw nls.localize('no_sobject_output_folder_text', outputFolderPath);
     }
 

--- a/packages/salesforcedx-sobjects-faux-generator/test/jest/generator/fauxClassGenerator.test.ts
+++ b/packages/salesforcedx-sobjects-faux-generator/test/jest/generator/fauxClassGenerator.test.ts
@@ -150,7 +150,7 @@ describe('FauxClassGenerator Unit Tests.', () => {
       try {
         await fauxClassGeneratorInst.generate(fakeOutput as SObjectRefreshOutput);
       } catch (error) {
-        expect(error.message).toEqual(expectedError);
+        expect(error).toEqual(expectedError);
       }
     });
 


### PR DESCRIPTION
### What does this PR do?
Adds missing await

[skip-validate-pr]

Test run: [Core End to End Tests](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/15122787289) ✅ 