### PR TITLE
chore: add script to install vsixes from last commit workflow from branch

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,7 +35,10 @@ export default [
       'packages/salesforcedx-vscode-soql/test/vscode-integration',
       'packages/salesforcedx-vscode-soql/test/ui-test/resources/.mocharc-debug.ts',
       'packages/salesforcedx-vscode-lwc/test/vscode-integration',
-      'packages/salesforcedx-vscode-core/test/vscode-integration/**'
+      'packages/salesforcedx-vscode-core/test/vscode-integration/**',
+      'scripts/installVSIXFromBranch.ts',
+      'scripts/vsce-bundled-extension.ts',
+      'scripts/reportInstalls.ts'
     ]
   },
   eslintPluginPrettierRecommended,

--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
     "aggregateJUnit": "node scripts/aggregate-junit-xml.js",
     "link-lsp": "yarn link @salesforce/aura-language-server @salesforce/lwc-language-server @salesforce/lightning-lsp-common && lerna exec yarn link @salesforce/aura-language-server @salesforce/lwc-language-server @salesforce/lightning-lsp-common --scope salesforcedx-vscode-lightning && lerna exec yarn link @salesforce/lwc-language-server @salesforce/lightning-lsp-common --scope salesforcedx-vscode-lwc",
     "unlink-lsp": "yarn unlink @salesforce/aura-language-server @salesforce/lwc-language-server @salesforce/lightning-lsp-common && lerna exec yarn unlink @salesforce/aura-language-server @salesforce/lwc-language-server @salesforce/lightning-lsp-common --scope salesforcedx-vscode-lightning && lerna exec yarn unlink @salesforce/lwc-language-server @salesforce/lightning-lsp-common --scope salesforcedx-vscode-lwc",
-    "report:installs": "ts-node scripts/reportInstalls.ts"
+    "report:installs": "ts-node scripts/reportInstalls.ts",
+    "test-vsix": "ts-node scripts/installVSIXFromBranch.ts code"
   },
   "husky": {
     "hooks": {

--- a/scripts/installVSIXFromBranch.ts
+++ b/scripts/installVSIXFromBranch.ts
@@ -1,0 +1,112 @@
+#! /usr/bin/env node
+/**
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ **/
+import { execSync } from 'child_process';
+import { existsSync, rmSync } from 'fs';
+
+type WorkflowRun = {
+  databaseId: string;
+};
+
+// Order matters - uninstall dependent extensions first
+const EXTENSION_IDS = [
+  'salesforce.salesforcedx-vscode-apex-debugger',
+  'salesforce.salesforcedx-vscode-apex-replay-debugger',
+  'salesforce.salesforcedx-vscode-lightning',
+  'salesforce.salesforcedx-vscode-visualforce',
+  'salesforce.salesforcedx-vscode-lwc',
+  'salesforce.salesforcedx-vscode-soql',
+  'salesforce.salesforcedx-vscode-apex',
+  'salesforce.salesforcedx-vscode-core'
+];
+
+const SAVE_DIRECTORY = './extensions';
+const IDE = process.argv[2] as string;
+
+const logger = (msg: string, obj?: unknown) => {
+  if (!obj) {
+    console.log(`*** ${msg}`);
+  } else {
+    console.log(`*** ${msg}`, obj);
+  }
+};
+
+logger('==========================');
+logger('Hello easier VSIX testing!');
+logger('==========================\n');
+
+if (existsSync(SAVE_DIRECTORY)) {
+  logger(`Deleting previous VSIX files. \n`);
+  rmSync(SAVE_DIRECTORY, { recursive: true, force: true });
+}
+
+const currentBranch = execSync('git branch --show-current', { encoding: 'utf8' }).trim();
+logger(`The branch that you are testing with is: ${currentBranch}`);
+logger('\n');
+
+logger('Getting the latest successful Commit Workflow for this run');
+const latestWorkflowForBranch = execSync(`gh run list -e push -s success -L 1  --json databaseId -b ${currentBranch}`, {
+  encoding: 'utf8'
+}).trim();
+logger('\n');
+
+if (latestWorkflowForBranch === '[]') {
+  logger('No successful workflow runs found for this branch. Exiting.');
+  process.exit(0);
+}
+
+const ghJobRun: WorkflowRun = JSON.parse(latestWorkflowForBranch)[0];
+
+logger(`Saving the resources for job ID ${ghJobRun.databaseId} \n`);
+execSync(`gh run download ${ghJobRun.databaseId} -D ${SAVE_DIRECTORY}`, { stdio: 'inherit' });
+execSync(`mv ${SAVE_DIRECTORY}/*/* ${SAVE_DIRECTORY}/`, { stdio: 'inherit' });
+
+logger(`Downloaded the following resources for job ID ${ghJobRun.databaseId} \n`);
+execSync(`ls ${SAVE_DIRECTORY}`, { stdio: 'inherit' });
+
+// Find all VSIX files in the save directory
+const vsixFiles = execSync(`find ${SAVE_DIRECTORY} -name "*.vsix"`, { encoding: 'utf8' }).split('\n').filter(Boolean);
+
+if (vsixFiles.length > 0) {
+  logger('\nCleaning up any old Salesforce extensions (if applicable) and installing the new VSIX files.');
+
+  // First uninstall Agentforce for Developers
+  try {
+    logger('\n');
+    execSync(`${IDE} --uninstall-extension salesforce.salesforcedx-einstein-gpt`, { stdio: 'inherit' });
+  } catch (error) {
+    logger('Agentforce for Developers was not installed, continuing...');
+  }
+
+  // Uninstall code-analyzer
+  try {
+    logger('\n');
+    execSync(`${IDE} --uninstall-extension salesforce.sfdx-code-analyzer-vscode`, { stdio: 'inherit' });
+  } catch (error) {
+    logger('code-analyzer was not installed, continuing...');
+  }
+
+  // Uninstall all existing Salesforce extensions
+  EXTENSION_IDS.forEach(extensionId => {
+    try {
+      logger('\n');
+      execSync(`${IDE} --uninstall-extension ${extensionId}`, { stdio: 'inherit' });
+    } catch (error) {
+      logger(`${extensionId} couldn't be uninstalled, continuing...`);
+    }
+  });
+
+  // Install all new VSIX files
+  vsixFiles.forEach(vsixFile => {
+    logger('\n');
+    execSync(`${IDE} --install-extension ${vsixFile}`, { stdio: 'inherit' });
+  });
+
+  logger(`Done! All Salesforce Extensions VSIX files were installed in ${IDE}. Reload VS Code and start your testing.`);
+} else {
+  logger(`No VSIX files could be found in your ${SAVE_DIRECTORY}.`);
+}


### PR DESCRIPTION
### What does this PR do?
This pull request introduces a new script for testing VSIX files, updates the ESLint configuration to include additional scripts, and adds a new npm script for testing VSIX installations. The most significant changes are grouped below for clarity.

### New Script for VSIX Testing:
* Added a new script `scripts/installVSIXFromBranch.ts` to automate the process of downloading, uninstalling, and installing Salesforce VSIX extensions for testing. The script identifies the latest successful GitHub workflow run for the current branch, downloads related VSIX files, and installs them in the specified IDE. It also handles cleanup of old extensions.

### Configuration Updates:
* Updated `eslint.config.mjs` to include the new script `scripts/installVSIXFromBranch.ts` and other related scripts in the linting configuration.
* Added a new npm script `test-vsix` in `package.json` to execute the VSIX installation script with a specified IDE.

### What issues does this PR fix or reference?
[skip-validate-pr]