### PR TITLE
fix: update vscodeVersionRegex to support minor releases with 3-digits (e.g. "v1.100.2")

### DIFF
--- a/.github/actions/validate-issue/src/index.ts
+++ b/.github/actions/validate-issue/src/index.ts
@@ -126,7 +126,7 @@ async function run() {
 
       // Checking VSCode version
       const vscodeVersionRegex =
-        /(?:\*{2}VS Code version\*{2}:\s*(?:Version:\s*)?v?(1\.\d{2}\.\d))|(?:VS Code version:\s*(?:Version:\s*)?v?(1\.\d{2}\.\d))/g;
+        /(?:\*{2}VS Code version\*{2}:\s*(?:Version:\s*)?v?(1\.\d{2,3}\.\d))|(?:VS Code version:\s*(?:Version:\s*)?v?(1\.\d{2,3}\.\d))/g;
 
       // Search all bodies and get an array of all versions found (first or second capture group)
       const vscodeVersions = bodies


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
VS Code minor release number raised into 3 digits now (current latest version is _v1.**100**.2_).
Updated the `vscodeVersionRegex` to allow minor releases with 3 digits.

### What issues does this PR fix or reference?
None.

### Functionality Before
- Validations are passing only for VS Cpde Versions having 2-digits in the minor release: _"v1.99.1"_
- Reporting issues with _"**VS Code Version:** v1.100.2"_ value would fail the validation check, and issue gets marked with the `label:missing required information` label (see [this job run results](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/15215888713/job/42801186936)).

### Functionality After
Validation should pass for _"**VS Code Version:** v1.100.2"_ value.

[skip-validate-pr]
