### PR TITLE
[W-15663214][W-18609524] fix: syntax highlighting when @isTest annotation is on the same line as the test method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4763,9 +4763,9 @@
       }
     },
     "node_modules/@salesforce/apex-tmlanguage": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/apex-tmlanguage/-/apex-tmlanguage-1.8.0.tgz",
-      "integrity": "sha512-RuY6dRtMkBFPdhsNW6Re0QnxUjhKgkqs+0L4jADZQKmADqXgfINjfy2ACnbEUygx0Xa3O05lncVJwxSyH0Crag==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/apex-tmlanguage/-/apex-tmlanguage-1.8.1.tgz",
+      "integrity": "sha512-i0rg/2DD5RaUFiPiD79zIFGhGoWGg2wXi84IySm1bwciXlMp8uWhoDTQhvIVb4y5mUZBwJmAIkvrNheoCPwtKQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -29135,7 +29135,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/apex-node-bundle": "^8.1.26",
-        "@salesforce/apex-tmlanguage": "1.8.0",
+        "@salesforce/apex-tmlanguage": "1.8.1",
         "@salesforce/core-bundle": "^8.10.3",
         "@salesforce/salesforcedx-utils": "63.15.0",
         "@salesforce/salesforcedx-utils-vscode": "63.15.0",
@@ -29402,7 +29402,7 @@
       "version": "63.15.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/apex-tmlanguage": "1.8.0",
+        "@salesforce/apex-tmlanguage": "1.8.1",
         "@salesforce/core-bundle": "^8.10.3",
         "@salesforce/salesforcedx-sobjects-faux-generator": "63.15.0",
         "@salesforce/salesforcedx-utils-vscode": "63.15.0",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "@salesforce/apex-node-bundle": "^8.1.26",
-    "@salesforce/apex-tmlanguage": "1.8.0",
+    "@salesforce/apex-tmlanguage": "1.8.1",
     "@salesforce/core-bundle": "^8.10.3",
     "@salesforce/salesforcedx-utils": "63.15.0",
     "@salesforce/salesforcedx-utils-vscode": "63.15.0",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -31,7 +31,7 @@
     "soql builder"
   ],
   "dependencies": {
-    "@salesforce/apex-tmlanguage": "1.8.0",
+    "@salesforce/apex-tmlanguage": "1.8.1",
     "@salesforce/core-bundle": "^8.10.3",
     "@salesforce/salesforcedx-sobjects-faux-generator": "63.15.0",
     "@salesforce/salesforcedx-utils-vscode": "63.15.0",


### PR DESCRIPTION
### What does this PR do?
Fixes the syntax highlighting when the `@isTest` annotation is placed on the same line as the test method.

### What issues does this PR fix or reference?
@W-15663214@, @W-18609524@, https://github.com/forcedotcom/salesforcedx-vscode/issues/6297

### Functionality Before
![weird syntax highlighting before](https://github.com/user-attachments/assets/5c87973b-60a4-421d-b8a3-cacbb49d4bfd)
![customer issue before](https://github.com/user-attachments/assets/14a5d4aa-85d9-49b5-ab44-cb1507f258af)

### Functionality After
![correct syntax highlighting after](https://github.com/user-attachments/assets/de54e4de-b679-4101-8938-22ea42b001f0)
![customer issue after](https://github.com/user-attachments/assets/425bd975-3d47-4047-a24e-d1e0b40259f6)

[skip-validate-pr]