### PR TITLE
feat: [@W-18572237@] implement aura enabled oas gen

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -501,10 +501,9 @@
           "type": "string",
           "enum": [
             "LEAST_CALLS",
-            "MOST_CALLS",
-            "JSON_METHOD_BY_METHOD"
+            "MOST_CALLS"
           ],
-          "default": "JSON_METHOD_BY_METHOD",
+          "default": "LEAST_CALLS",
           "description": "%apex_oas_generation_strategy%"
         },
         "salesforcedx-vscode-apex.oas_generation_include_schema": {

--- a/packages/salesforcedx-vscode-apex/src/commands/oasDocumentChecker.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/oasDocumentChecker.ts
@@ -67,7 +67,11 @@ class OasDocumentChecker {
             openApiDocument = fs.readFileSync(fullPath, 'utf8');
           }
           // Step 3: Process the OAS document
-          const processedOasResult = await processOasDocumentFromYaml(openApiDocument, undefined, undefined, true);
+          const processedOasResult = await processOasDocumentFromYaml(openApiDocument, {
+            context: undefined,
+            eligibleResult: undefined,
+            isRevalidation: true
+          });
 
           // Step 4: Report/Refresh problems found
           createProblemTabEntriesForOasDocument(fullPath, processedOasResult, this.isESRDecomposed);

--- a/packages/salesforcedx-vscode-apex/src/oas/documentProcessorPipeline/betaInfoInjectionStep.ts
+++ b/packages/salesforcedx-vscode-apex/src/oas/documentProcessorPipeline/betaInfoInjectionStep.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { OpenAPIV3 } from 'openapi-types';
+import { ProcessorInputOutput, ProcessorStep } from './processorStep';
+
+type ExtendedInfoObject = OpenAPIV3.InfoObject & {
+  [key: `x-${string}`]: string;
+};
+
+export class BetaInfoInjectionStep implements ProcessorStep {
+  private betaInfo: string | undefined;
+
+  constructor(betaInfo: string | undefined) {
+    this.betaInfo = betaInfo;
+  }
+
+  process(input: ProcessorInputOutput): Promise<ProcessorInputOutput> {
+    const modifiedOASDoc = this.injectBetaInfo(input.openAPIDoc);
+
+    return new Promise(resolve => {
+      resolve({ ...input, openAPIDoc: modifiedOASDoc });
+    });
+  }
+
+  private injectBetaInfo(oasDoc: OpenAPIV3.Document<{}>): OpenAPIV3.Document<{}> {
+    const info = oasDoc.info || {};
+    const updatedInfo: ExtendedInfoObject = { ...info };
+
+    if (this.betaInfo) {
+      updatedInfo['x-betaInfo'] = this.betaInfo;
+    }
+
+    return {
+      ...oasDoc,
+      info: updatedInfo
+    };
+  }
+}

--- a/packages/salesforcedx-vscode-apex/src/oas/documentProcessorPipeline/oasProcessor.ts
+++ b/packages/salesforcedx-vscode-apex/src/oas/documentProcessorPipeline/oasProcessor.ts
@@ -7,7 +7,8 @@
 
 import { OpenAPIV3 } from 'openapi-types';
 import * as vscode from 'vscode';
-import { ApexClassOASEligibleResponse } from '../schemas';
+import { ApexClassOASEligibleResponse, ApexClassOASGatherContextResponse } from '../schemas';
+import { BetaInfoInjectionStep } from './betaInfoInjectionStep';
 import { MethodValidationStep } from './methodValidationStep';
 import { OasReorderStep } from './oasReorderStep';
 import { OasValidationStep } from './oasValidationStep';
@@ -16,19 +17,27 @@ import { ProcessorInputOutput } from './processorStep';
 import { PropertyCorrectionStep } from './propertyCorrectionStep';
 import { ReconcileDuplicateSemanticPathsStep } from './reconcileDuplicateSemanticPathsStep';
 
+export type ProcessOasDocumentOptions = {
+  context?: ApexClassOASGatherContextResponse;
+  eligibleResult?: ApexClassOASEligibleResponse;
+  isRevalidation?: boolean;
+  betaInfo?: string;
+};
+
 export class OasProcessor {
   private document: OpenAPIV3.Document;
-  private eligibilityResult?: ApexClassOASEligibleResponse;
+  private options?: ProcessOasDocumentOptions;
   static diagnosticCollection: vscode.DiagnosticCollection =
     vscode.languages.createDiagnosticCollection('OAS Validations');
-  constructor(document: OpenAPIV3.Document, eligibilityResult?: ApexClassOASEligibleResponse) {
+  constructor(document: OpenAPIV3.Document, options?: ProcessOasDocumentOptions) {
     this.document = document;
-    this.eligibilityResult = eligibilityResult;
+    this.options = options;
   }
 
-  async process(doCorrections = false): Promise<ProcessorInputOutput> {
-    const pipeline = doCorrections
+  async process(): Promise<ProcessorInputOutput> {
+    const pipeline = !this.options?.isRevalidation
       ? new Pipeline(new PropertyCorrectionStep())
+          .addStep(new BetaInfoInjectionStep(this.options?.betaInfo))
           .addStep(new ReconcileDuplicateSemanticPathsStep())
           .addStep(new MethodValidationStep())
           .addStep(new OasValidationStep())
@@ -43,7 +52,7 @@ export class OasProcessor {
     const output = await pipeline.execute({
       openAPIDoc: this.document,
       errors: [],
-      eligibilityResult: this.eligibilityResult
+      eligibilityResult: this.options?.eligibleResult
     });
     console.log('Pipeline output:', output);
     return output;

--- a/packages/salesforcedx-vscode-apex/src/oas/generationStrategy/generationStrategyFactory.ts
+++ b/packages/salesforcedx-vscode-apex/src/oas/generationStrategy/generationStrategyFactory.ts
@@ -5,22 +5,42 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { ApexClassOASEligibleResponse, ApexClassOASGatherContextResponse } from '../schemas';
-import { JsonMethodByMethodStrategy } from './json/jsonMethodByMethod';
+import {
+  ApexClassOASEligibleResponse,
+  ApexClassOASGatherContextResponse,
+  PromptGenerationStrategyBid
+} from '../schemas';
+import { ApexRestStrategy } from './json/apexRest';
+import { AuraEnabledStrategy } from './json/auraEnabledStrategy';
 
-export enum GenerationStrategy {
-  JSON_METHOD_BY_METHOD = 'JsonMethodByMethod'
-}
+export type GenerationStrategyType = 'ApexRest' | 'AuraEnabled';
 
-export type Strategy = JsonMethodByMethodStrategy;
+export type StrategyTypes = ApexRestStrategy | AuraEnabledStrategy;
 
-export class GenerationStrategyFactory {
-  public static initializeAllStrategies(
-    metadata: ApexClassOASEligibleResponse,
-    context: ApexClassOASGatherContextResponse
-  ): Map<GenerationStrategy, Strategy> {
-    const strategies = new Map<GenerationStrategy, Strategy>();
-    strategies.set(GenerationStrategy.JSON_METHOD_BY_METHOD, new JsonMethodByMethodStrategy(metadata, context));
-    return strategies;
-  }
-}
+export const initializeAndBid = async (
+  metadata: ApexClassOASEligibleResponse,
+  context: ApexClassOASGatherContextResponse
+): Promise<{
+  strategies: Map<GenerationStrategyType, StrategyTypes>;
+  bids: Map<GenerationStrategyType, PromptGenerationStrategyBid>;
+}> => {
+  // Initialize strategies
+  const strategies = new Map<GenerationStrategyType, StrategyTypes>();
+  strategies.set('ApexRest', new ApexRestStrategy(metadata, context));
+  strategies.set('AuraEnabled', new AuraEnabledStrategy(metadata, context));
+
+  // Get bids from all strategies
+  const bidPromises = Array.from(strategies.entries())
+    .filter(([_, strategy]) => strategy)
+    .map(
+      async ([strategyName, strategy]): Promise<[GenerationStrategyType, PromptGenerationStrategyBid]> => [
+        strategyName,
+        await strategy.bid()
+      ]
+    );
+
+  const bidResults = await Promise.all(bidPromises);
+  const bids = new Map(bidResults);
+
+  return { strategies, bids };
+};

--- a/packages/salesforcedx-vscode-apex/src/oas/generationStrategy/json/apexRest.ts
+++ b/packages/salesforcedx-vscode-apex/src/oas/generationStrategy/json/apexRest.ts
@@ -10,6 +10,7 @@ import { DocumentSymbol } from 'vscode';
 import { SUM_TOKEN_MAX_LIMIT, IMPOSED_FACTOR, PROMPT_TOKEN_MAX_LIMIT } from '..';
 import { nls } from '../../../messages';
 import { cleanupGeneratedDoc, parseOASDocFromJson } from '../../../oasUtils';
+import { retrieveAAClassRestAnnotations, retrieveAAMethodRestAnnotations } from '../../../settings';
 import { getTelemetryService } from '../../../telemetry/telemetry';
 import GenerationInteractionLogger from '../../generationInteractionLogger';
 import {
@@ -33,54 +34,72 @@ import { openAPISchema_v3_0_guided } from '../openapi3.schema';
 
 const gil = GenerationInteractionLogger.getInstance();
 
-export class JsonMethodByMethodStrategy extends GenerationStrategy {
-  llmRequests: Map<string, Promise<string>>;
-  llmResponses: Map<string, string>;
-  metadata: ApexClassOASEligibleResponse;
-  context: ApexClassOASGatherContextResponse;
-  prompts: Map<string, string>;
-  strategyName: string;
-  biddedCallCount: number;
-  maxBudget: number;
+export class ApexRestStrategy extends GenerationStrategy {
   methodsList: string[];
   methodsDocSymbolMap: Map<string, DocumentSymbol>;
   methodsContextMap: Map<string, ApexOASMethodDetail>;
-  documentText: string;
-  classPrompt: string; // The prompt for the entire class
   urlMapping: string;
-  openAPISchema: string;
+  servicePrompts: Map<string, string>;
+  serviceResponses: Map<string, string>;
+  serviceRequests: Map<string, Promise<string>>;
+  sourceText: string;
+  classPrompt: string; // The prompt for the entire class
+  oasSchema: string;
 
   public constructor(metadata: ApexClassOASEligibleResponse, context: ApexClassOASGatherContextResponse) {
-    super();
-    this.metadata = metadata;
-    this.context = context;
-    this.prompts = new Map();
-    this.strategyName = 'JsonMethodByMethod';
-    this.biddedCallCount = 0;
-    this.maxBudget = SUM_TOKEN_MAX_LIMIT * IMPOSED_FACTOR;
+    super(
+      metadata,
+      context,
+      'ApexRest',
+      0,
+      SUM_TOKEN_MAX_LIMIT * IMPOSED_FACTOR,
+      'OpenAPI documents generated from Apex classes using Apex REST annotations are in beta.'
+    );
     this.methodsList = [];
-    this.llmResponses = new Map();
+    this.servicePrompts = new Map();
+    this.serviceResponses = new Map();
     this.methodsDocSymbolMap = new Map();
     this.methodsContextMap = new Map();
-    this.llmRequests = new Map();
-    this.documentText = fs.readFileSync(new URL(this.metadata.resourceUri.toString()), 'utf8');
+    this.serviceRequests = new Map();
+    this.sourceText = fs.readFileSync(new URL(this.metadata.resourceUri.toString()), 'utf8');
     this.classPrompt = buildClassPrompt(this.context.classDetail);
-    const restResourceAnnotation = this.context.classDetail.annotations.find(a => a.name === 'RestResource');
+    const restResourceAnnotation = this.context.classDetail.annotations.find(a =>
+      retrieveAAClassRestAnnotations().includes(a.name)
+    );
     this.urlMapping = restResourceAnnotation?.parameters.urlMapping ?? `/${this.context.classDetail.name}/`;
-    this.openAPISchema = JSON.stringify(openAPISchema_v3_0_guided);
+    this.oasSchema = JSON.stringify(openAPISchema_v3_0_guided);
   }
 
-  async resolveLLMResponses(llmRequests: Map<string, Promise<string>>): Promise<Map<string, string>> {
-    const methodNames = Array.from(llmRequests.keys());
-    const llmResponses = await Promise.allSettled(Array.from(llmRequests.values()));
+  private hasValidRestAnnotations(): boolean {
+    const validClassAnnotations = retrieveAAClassRestAnnotations();
+    const validMethodAnnotations = retrieveAAMethodRestAnnotations();
+
+    // Check for class-level RestResource annotation
+    const hasRestResourceAnnotation = this.context.classDetail.annotations.some(a =>
+      validClassAnnotations.includes(a.name)
+    );
+
+    if (!hasRestResourceAnnotation) {
+      return false;
+    }
+
+    // Check for at least one method with HTTP REST annotation
+    return this.context.methods.some(method =>
+      method.annotations.some(annotation => validMethodAnnotations.includes(annotation.name))
+    );
+  }
+
+  async resolveLLMResponses(serviceRequests: Map<string, Promise<string>>): Promise<Map<string, string>> {
+    const methodNames = Array.from(serviceRequests.keys());
+    const serviceResponses = await Promise.allSettled(Array.from(serviceRequests.values()));
     return new Map(
       methodNames.map((methodName, index) => {
-        const result = llmResponses[index];
+        const result = serviceResponses[index];
         if (result.status === 'fulfilled') {
           gil.addRawResponse(result.value);
           return [methodName, result.value];
         } else {
-          gil.addRawResponse(`Promise ${index} rejected with reason: ${result.reason}`);
+          gil.addRawResponse(`Promise ${index} rejected with reason: ${JSON.stringify(result.reason)}`);
           console.log(`Promise ${index} rejected with reason:`, result.reason);
           return [methodName, ''];
         }
@@ -90,7 +109,7 @@ export class JsonMethodByMethodStrategy extends GenerationStrategy {
 
   prevalidateLLMResponse(): string[] {
     const validResponses: string[] = [];
-    for (const [methodName, response] of this.llmResponses) {
+    for (const [methodName, response] of this.serviceResponses) {
       if (response === '') {
         console.log(`LLM response for ${methodName} is empty.`);
         continue;
@@ -131,29 +150,43 @@ export class JsonMethodByMethodStrategy extends GenerationStrategy {
     return validResponses;
   }
 
-  async callLLMWithPrompts(retryLimit: number = 3): Promise<string[]> {
+  public async generateOAS(): Promise<string> {
+    const oas = await this.resolveOASContent();
+    if (oas.length > 0) {
+      try {
+        const combinedText = combineYamlByMethod(oas, this.context.classDetail.name);
+        return combinedText;
+      } catch (e) {
+        throw new Error(nls.localize('failed_to_combine_oas', e));
+      }
+    } else {
+      throw new Error(nls.localize('no_oas_generated'));
+    }
+  }
+
+  private async resolveOASContent(): Promise<string[]> {
     try {
       const llmService = await this.getLLMServiceInterface();
 
-      for (const [methodName, prompt] of this.prompts) {
+      for (const [methodName, prompt] of this.servicePrompts) {
         if (prompt?.length > 0) {
           gil.addPrompt(prompt);
-          this.llmRequests.set(
+          this.serviceRequests.set(
             methodName,
             this.executeWithRetry(
               () =>
                 this.includesOASSchema()
                   ? llmService.callLLM(prompt, undefined, this.outputTokenLimit, {
-                      parameters: { guided_json: this.openAPISchema }
+                      parameters: { guided_json: this.oasSchema }
                     })
                   : llmService.callLLM(prompt, undefined, this.outputTokenLimit),
-              retryLimit
+              3
             )
           );
         }
       }
 
-      this.llmResponses = await this.resolveLLMResponses(this.llmRequests);
+      this.serviceResponses = await this.resolveLLMResponses(this.serviceRequests);
       return this.prevalidateLLMResponse();
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
@@ -165,7 +198,7 @@ export class JsonMethodByMethodStrategy extends GenerationStrategy {
     const telemetryService = await getTelemetryService();
     let attempts = 0;
     while (attempts < retryLimit) {
-      await this.incrementCallCount();
+      await this.incrementResolutionAttempts();
       const result = await fn();
       // Attempt to parse the result to ensure it's valid JSON
       try {
@@ -187,28 +220,24 @@ export class JsonMethodByMethodStrategy extends GenerationStrategy {
     throw new Error('Unexpected error in executeWithRetry');
   }
 
-  public async generateOAS(): Promise<string> {
-    const oas = await this.callLLMWithPrompts();
-    if (oas.length > 0) {
-      try {
-        const combinedText = combineYamlByMethod(oas, this.context.classDetail.name);
-        return combinedText;
-      } catch (e) {
-        throw new Error(nls.localize('failed_to_combine_oas', e));
-      }
-    } else {
-      throw new Error(nls.localize('no_oas_generated'));
+  public async bid(): Promise<PromptGenerationStrategyBid> {
+    // First check if the class has valid REST annotations
+    if (!this.hasValidRestAnnotations()) {
+      return {
+        result: {
+          maxBudget: 0,
+          callCounts: 0
+        }
+      };
     }
-  }
 
-  public bid(): PromptGenerationStrategyBid {
     const generationResult = this.generate();
-    return {
+    return Promise.resolve({
       result: generationResult
-    };
+    });
   }
 
-  public generate(): PromptGenerationResult {
+  private generate(): PromptGenerationResult {
     const list = (this.metadata.symbols ?? []).filter(s => s.isApexOasEligible);
     for (const symbol of list) {
       const methodName = symbol.docSymbol.name;
@@ -220,14 +249,14 @@ export class JsonMethodByMethodStrategy extends GenerationStrategy {
 
       const input = generatePromptForMethod(
         methodName,
-        this.documentText,
+        this.sourceText,
         this.methodsDocSymbolMap,
         this.methodsContextMap,
         this.classPrompt
       );
       const tokenCount = this.getPromptTokenCount(input);
       if (tokenCount <= PROMPT_TOKEN_MAX_LIMIT * IMPOSED_FACTOR) {
-        this.prompts.set(methodName, input);
+        this.servicePrompts.set(methodName, input);
         this.biddedCallCount++;
         const currentBudget = Math.floor((PROMPT_TOKEN_MAX_LIMIT - tokenCount) * IMPOSED_FACTOR);
         if (currentBudget < this.maxBudget) {
@@ -235,7 +264,7 @@ export class JsonMethodByMethodStrategy extends GenerationStrategy {
         }
       } else {
         // as long as there is one failure, the strategy will be considered failed
-        this.prompts.clear();
+        this.servicePrompts.clear();
         this.biddedCallCount = 0;
         this.maxBudget = 0;
         return {
@@ -248,5 +277,9 @@ export class JsonMethodByMethodStrategy extends GenerationStrategy {
       maxBudget: this.maxBudget,
       callCounts: this.biddedCallCount
     };
+  }
+
+  get openAPISchema(): string {
+    return this.oasSchema;
   }
 }

--- a/packages/salesforcedx-vscode-apex/src/oas/generationStrategy/json/auraEnabledStrategy.ts
+++ b/packages/salesforcedx-vscode-apex/src/oas/generationStrategy/json/auraEnabledStrategy.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { ConfigUtil } from '@salesforce/salesforcedx-utils-vscode';
+import * as fs from 'node:fs';
+import { SUM_TOKEN_MAX_LIMIT, IMPOSED_FACTOR } from '..';
+import { workspaceContext } from '../../../context';
+import {
+  ApexClassOASEligibleResponse,
+  ApexClassOASGatherContextResponse,
+  PromptGenerationStrategyBid
+} from '../../schemas';
+import { buildClassPrompt } from '../buildPromptUtils';
+import { GenerationStrategy } from '../generationStrategy';
+import { openAPISchema_v3_0_guided } from '../openapi3.schema';
+
+const MIN_ORG_VERSION = 65.0;
+
+export class AuraEnabledStrategy extends GenerationStrategy {
+  private isDefaultOrg: boolean;
+  private isOrgVersionCompatible: boolean;
+
+  constructor(metadata: ApexClassOASEligibleResponse, context: ApexClassOASGatherContextResponse) {
+    super(
+      metadata,
+      context,
+      'AuraEnabled',
+      0,
+      SUM_TOKEN_MAX_LIMIT * IMPOSED_FACTOR,
+      'OpenAPI documents generated from Apex classes using @AuraEnabled annotations are in beta.'
+    );
+    this.servicePrompts = new Map();
+    this.serviceResponses = new Map();
+    this.serviceRequests = new Map();
+    this.sourceText = fs.readFileSync(new URL(this.metadata.resourceUri.toString()), 'utf8');
+    this.classPrompt = buildClassPrompt(this.context.classDetail);
+    this.oasSchema = JSON.stringify(openAPISchema_v3_0_guided);
+    this.isDefaultOrg = false;
+    this.isOrgVersionCompatible = false;
+  }
+
+  get openAPISchema(): string {
+    return this.oasSchema;
+  }
+
+  private async checkOrgVersion(): Promise<void> {
+    try {
+      const targetOrg = await ConfigUtil.getTargetOrgOrAlias();
+      this.isDefaultOrg = targetOrg !== undefined;
+
+      if (this.isDefaultOrg) {
+        const connection = await workspaceContext.getConnection();
+        const apiVersion = connection.getApiVersion();
+        // Convert API version to number by handling decimal format (e.g. "58.0")
+        const numericVersion = parseFloat(apiVersion);
+        this.isOrgVersionCompatible = numericVersion >= MIN_ORG_VERSION;
+      }
+    } catch (err) {
+      console.error('Failed to initialize org checks:', err);
+      this.isDefaultOrg = false;
+      this.isOrgVersionCompatible = false;
+    }
+  }
+
+  public async bid(): Promise<PromptGenerationStrategyBid> {
+    // Initialize org checks
+    await this.checkOrgVersion();
+
+    // Check if any method has @AuraEnabled annotation
+    const hasAuraEnabled = this.context.methods.some(method =>
+      method.annotations.some(annotation => annotation.name === 'AuraEnabled')
+    );
+
+    // Only bid if we have Aura-enabled methods AND we're in the default org AND the org version is compatible AND the class exists in org
+    const shouldBid = hasAuraEnabled && this.isDefaultOrg && this.isOrgVersionCompatible;
+
+    return {
+      result: {
+        maxBudget: shouldBid ? this.maxBudget : 0,
+        callCounts: shouldBid ? 1 : 0
+      }
+    };
+  }
+
+  public async generateOAS(): Promise<string> {
+    const responses: string[] = [];
+
+    // Get the connection and make the API call
+    const connection = await workspaceContext.getConnection();
+    const className = this.context.classDetail.name;
+    const apiVersion = connection.getApiVersion();
+    const endpoint = `${connection.instanceUrl}/services/data/v${apiVersion}/specifications/oas3/apex/${className}`;
+
+    try {
+      const result = await connection.request({
+        method: 'GET',
+        url: endpoint
+      });
+      responses.push(JSON.stringify(result));
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      throw new Error(`Failed to fetch OAS specification from org: ${errorMessage}`);
+    }
+    this.oasSchema = responses.join('\n');
+    return this.oasSchema;
+  }
+}

--- a/packages/salesforcedx-vscode-apex/src/oasUtils.ts
+++ b/packages/salesforcedx-vscode-apex/src/oasUtils.ts
@@ -20,7 +20,6 @@ import * as vscode from 'vscode';
 import { URI } from 'vscode-uri';
 import * as yaml from 'yaml';
 import { SF_LOG_LEVEL_SETTING, VSCODE_APEX_EXTENSION_NAME } from './constants';
-import { nls } from './messages';
 import OasProcessor from './oas/documentProcessorPipeline';
 import { ProcessorInputOutput } from './oas/documentProcessorPipeline/processorStep';
 import GenerationInteractionLogger from './oas/generationInteractionLogger';
@@ -34,44 +33,50 @@ const gil = GenerationInteractionLogger.getInstance();
 /**
  * Processes an OAS document from a YAML string.
  * @param {string} oasDoc - The OAS document as a YAML string.
- * @param {ApexClassOASGatherContextResponse} [context] - The context for the OAS document.
- * @param {ApexClassOASEligibleResponse} [eligibleResult] - The eligible result for the OAS document.
- * @param {boolean} [isRevalidation] - Whether the document is being revalidated.
+ * @param {object} [options] - Options for processing the OAS document.
+ * @param {ApexClassOASGatherContextResponse} [options.context] - The context for the OAS document.
+ * @param {ApexClassOASEligibleResponse} [options.eligibleResult] - The eligible result for the OAS document.
+ * @param {boolean} [options.isRevalidation] - Whether the document is being revalidated.
+ * @param {string} [options.betaInfo] - Beta information for the document.
  * @returns {Promise<ProcessorInputOutput>} - The processed OAS document.
  */
 export const processOasDocumentFromYaml = async (
   oasDoc: string,
-  context?: ApexClassOASGatherContextResponse,
-  eligibleResult?: ApexClassOASEligibleResponse,
-  isRevalidation?: boolean
-): Promise<ProcessorInputOutput> =>
-  processOasDocument(JSON.stringify(parseOASDocFromYaml(oasDoc)), context, eligibleResult, isRevalidation);
+  options?: {
+    context?: ApexClassOASGatherContextResponse;
+    eligibleResult?: ApexClassOASEligibleResponse;
+    isRevalidation?: boolean;
+    betaInfo?: string;
+  }
+): Promise<ProcessorInputOutput> => processOasDocument(JSON.stringify(parseOASDocFromYaml(oasDoc)), options);
 
 /**
  * Processes an OAS document.
  * @param {string} oasDoc - The OAS document as a string.
- * @param {ApexClassOASGatherContextResponse} [context] - The context for the OAS document.
- * @param {ApexClassOASEligibleResponse} [eligibleResult] - The eligible result for the OAS document.
- * @param {boolean} [isRevalidation] - Whether the document is being revalidated.
+ * @param {object} [options] - Options for processing the OAS document.
+ * @param {ApexClassOASGatherContextResponse} [options.context] - The context for the OAS document.
+ * @param {ApexClassOASEligibleResponse} [options.eligibleResult] - The eligible result for the OAS document.
+ * @param {boolean} [options.isRevalidation] - Whether the document is being revalidated.
+ * @param {string} [options.betaInfo] - Beta information for the document.
  * @returns {Promise<ProcessorInputOutput>} - The processed OAS document.
  * @throws Will throw an error if the document is invalid for processing.
  */
 export const processOasDocument = async (
   oasDoc: string,
-  context?: ApexClassOASGatherContextResponse,
-  eligibleResult?: ApexClassOASEligibleResponse,
-  isRevalidation?: boolean
-): Promise<ProcessorInputOutput> => {
-  if (isRevalidation || context?.classDetail.annotations.find(a => a.name === 'RestResource')) {
-    const parsed = parseOASDocFromJson(oasDoc);
-
-    const oasProcessor = new OasProcessor(parsed, eligibleResult);
-
-    const processResult = await oasProcessor.process(!isRevalidation);
-
-    return processResult;
+  options?: {
+    context?: ApexClassOASGatherContextResponse;
+    eligibleResult?: ApexClassOASEligibleResponse;
+    isRevalidation?: boolean;
+    betaInfo?: string;
   }
-  throw nls.localize('invalid_file_for_processing_oas_doc');
+): Promise<ProcessorInputOutput> => {
+  const parsed = parseOASDocFromJson(oasDoc);
+
+  const oasProcessor = new OasProcessor(parsed, options);
+
+  const processResult = await oasProcessor.process();
+
+  return processResult;
 };
 
 /**

--- a/packages/salesforcedx-vscode-apex/src/settings.ts
+++ b/packages/salesforcedx-vscode-apex/src/settings.ts
@@ -17,8 +17,7 @@ const APEX_ACTION_PROP_DEF_MODIFIERS = ['static'];
 const APEX_ACTION_PROP_ACCESS_MODIFIERS = ['global', 'public'];
 const APEX_ACTION_CLASS_REST_ANNOTATION = ['RestResource'];
 const APEX_ACTION_METHOD_REST_ANNOTATION = ['HttpDelete', 'HttpGet', 'HttpPatch', 'HttpPost', 'HttpPut'];
-// 'AuraEnabled' was removed for W-17550288 and should be added back with W-17579102
-const APEX_ACTION_METHOD_ANNOTATION: string[] = [];
+const APEX_ACTION_METHOD_ANNOTATION: string[] = ['AuraEnabled'];
 
 // Default eligibility for general OAS generation. Users can changed the setting through VSCode configurations
 const DEFAULT_CLASS_ACCESS_MODIFIERS = ['global', 'public'];

--- a/packages/salesforcedx-vscode-apex/test/jest/settings.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/settings.test.ts
@@ -47,7 +47,7 @@ describe('settings Unit Tests.', () => {
     } as any);
 
     const result = retrieveAAMethodAnnotations();
-    expect(result).toEqual(['UserDefinedModifier']);
+    expect(result).toEqual(['AuraEnabled', 'UserDefinedModifier']);
     expect(getConfigurationMock).toHaveBeenCalledWith();
     expect(getFn).toHaveBeenCalledWith('salesforcedx-vscode-apex.apexoas.aa.method.annotations', []);
   });


### PR DESCRIPTION
Changes:

- Reenabled Aura Enabled annotations for jorje LS config
- Create new Aura Enabled generation strategy
  - Used API version guard to reject Aura Enable generation requests against an org whose version does not support the request
- Modified bid process to use smallest bid by default
- Add new correction step that is used to inject a "x-betaInfo" property into info block, if the strategy defines a betaInfo string

@W-18572237@