### PR TITLE
[W-18684311]: chore: update git2gus v64

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -31,7 +31,7 @@
     "status:duplicate": "",
     "type:community-contrib": "USER STORY"
   },
-  "defaultBuild": "offcore.tooling.63",
+  "defaultBuild": "offcore.tooling.64",
   "hideWorkItemUrl": "true",
   "statusWhenClosed": "CLOSED"
 }


### PR DESCRIPTION
What does this PR do?
Updates the defaultBuild for Git2Gus to offcore.tooling.64.

What issues does this PR fix or reference?
[@W-18684311@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002FSvc9YAD/view)