### PR TITLE
@W-18726739 chore: add o11y reporting apex extension

### DIFF
--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -16,6 +16,8 @@
   },
   "version": "63.16.3",
   "publisher": "salesforce",
+  "o11yUploadEndpoint": "https://794testsite.my.site.com/byolwr/webruntime/log/metrics",
+  "enableO11y": "true",
   "license": "BSD-3-Clause",
   "engines": {
     "vscode": "^1.90.0"


### PR DESCRIPTION
### What does this PR do?
Add configuration to the apex extension so it will begin reporting telemetry to both o11y/splunk & appInsights 

### What issues does this PR fix or reference?
@W-18726739@

### Functionality Before
Telemetry for Apex extension & Apex LSP only goes to appinsights

### Functionality After
Telemetry for Apex extension & Apex LSP only goes to both appinsights & olly

### QE
- Downloaded vsix and verified that on install apex extension starts as usual and AI data is being reported.  
