### PR TITLE
chore: vscode types version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,7 @@ updates:
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-major']
+      - dependency-name: '@types/vscode'
     open-pull-requests-limit: 3
     rebase-strategy: auto
     versioning-strategy: increase

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@types/cross-spawn": "6.0.6",
         "@types/jest": "^29.5.5",
         "@types/semver": "7.5.8",
+        "@types/vscode": "1.90.0",
         "@typescript-eslint/eslint-plugin": "8.33.0",
         "@typescript-eslint/parser": "8.33.0",
         "@vscode/test-electron": "2.3.0",
@@ -6947,9 +6948,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.100.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.100.0.tgz",
-      "integrity": "sha512-4uNyvzHoraXEeCamR3+fzcBlh7Afs4Ifjs4epINyUX/jvdk0uzLnwiDY35UKDKnkCHP5Nu3dljl2H8lR6s+rQw==",
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.90.0.tgz",
+      "integrity": "sha512-oT+ZJL7qHS9Z8bs0+WKf/kQ27qWYR3trsXpq46YDjFqBsMLG4ygGGjPaJ2tyrH0wJzjOEmDyg9PDJBBhWg9pkQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -29247,7 +29248,6 @@
         "@salesforce/core": "^8.11.4",
         "@types/jest": "^29.5.5",
         "@types/node": "^20.0.0",
-        "@types/vscode": "^1.100.0",
         "jest": "^29.7.0",
         "jest-junit": "14.0.1",
         "ts-jest": "^29.1.1",
@@ -29311,7 +29311,6 @@
         "@types/cross-spawn": "6.0.6",
         "@types/jest": "^29.5.5",
         "@types/node": "^20.0.0",
-        "@types/vscode": "^1.100.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.1.1",
         "typescript": "^5.6.2"
@@ -29450,7 +29449,6 @@
         "@types/ejs": "3.1.5",
         "@types/node": "^20.0.0",
         "@types/sinon": "^2.3.7",
-        "@types/vscode": "^1.100.0",
         "cross-env": "5.2.0",
         "esbuild": "0.25.4",
         "esbuild-plugin-pino": "^2.2.2",
@@ -29473,7 +29471,6 @@
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
-        "@types/vscode": "^1.100.0",
         "cross-env": "5.2.0",
         "esbuild": "0.25.4",
         "esbuild-plugin-pino": "^2.2.2"
@@ -29511,7 +29508,6 @@
       "devDependencies": {
         "@types/async-lock": "1.4.2",
         "@types/node": "^20.0.0",
-        "@types/vscode": "^1.100.0",
         "cross-env": "5.2.0",
         "esbuild": "0.25.4",
         "esbuild-plugin-pino": "^2.2.2"
@@ -29570,7 +29566,6 @@
       "devDependencies": {
         "@types/jest": "^29.5.5",
         "@types/node": "^20.0.0",
-        "@types/vscode": "^1.100.0",
         "cross-env": "5.2.0",
         "esbuild": "0.25.4",
         "esbuild-plugin-pino": "^2.2.2",
@@ -29617,7 +29612,6 @@
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
-        "@types/vscode": "^1.100.0",
         "@types/which": "^1.3.1",
         "cross-env": "5.2.0",
         "esbuild": "0.25.4",
@@ -29663,7 +29657,6 @@
       "devDependencies": {
         "@types/node": "^20.0.0",
         "@types/uuid": "^3.4.8",
-        "@types/vscode": "^1.100.0",
         "@types/which": "^1.3.1",
         "cross-env": "5.2.0",
         "esbuild": "0.25.4",
@@ -29712,7 +29705,6 @@
         "@types/debounce": "^1.2.0",
         "@types/node": "^20.0.0",
         "@types/papaparse": "^5.2.3",
-        "@types/vscode": "^1.100.0",
         "applicationinsights": "1.0.7",
         "cross-env": "5.2.0",
         "esbuild": "0.25.4",
@@ -29749,7 +29741,6 @@
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
-        "@types/vscode": "^1.100.0",
         "cross-env": "5.2.0",
         "typescript": "^5.6.2"
       },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/cross-spawn": "6.0.6",
     "@types/jest": "^29.5.5",
     "@types/semver": "7.5.8",
+    "@types/vscode": "1.90.0",
     "@typescript-eslint/eslint-plugin": "8.33.0",
     "@typescript-eslint/parser": "8.33.0",
     "@vscode/test-electron": "2.3.0",

--- a/packages/salesforcedx-sobjects-faux-generator/package.json
+++ b/packages/salesforcedx-sobjects-faux-generator/package.json
@@ -17,7 +17,6 @@
     "@salesforce/core": "^8.11.4",
     "@types/jest": "^29.5.5",
     "@types/node": "^20.0.0",
-    "@types/vscode": "^1.100.0",
     "jest": "^29.7.0",
     "jest-junit": "14.0.1",
     "ts-jest": "^29.1.1",

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -28,7 +28,6 @@
     "@types/cross-spawn": "6.0.6",
     "@types/jest": "^29.5.5",
     "@types/node": "^20.0.0",
-    "@types/vscode": "^1.100.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
     "typescript": "^5.6.2"

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -32,7 +32,6 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "@types/vscode": "^1.100.0",
     "cross-env": "5.2.0",
     "esbuild": "0.25.4",
     "esbuild-plugin-pino": "^2.2.2"

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -36,7 +36,6 @@
   "devDependencies": {
     "@types/async-lock": "1.4.2",
     "@types/node": "^20.0.0",
-    "@types/vscode": "^1.100.0",
     "cross-env": "5.2.0",
     "esbuild": "0.25.4",
     "esbuild-plugin-pino": "^2.2.2"

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -52,7 +52,6 @@
     "@types/ejs": "3.1.5",
     "@types/node": "^20.0.0",
     "@types/sinon": "^2.3.7",
-    "@types/vscode": "^1.100.0",
     "cross-env": "5.2.0",
     "esbuild": "0.25.4",
     "esbuild-plugin-pino": "^2.2.2",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -44,7 +44,6 @@
   "devDependencies": {
     "@types/jest": "^29.5.5",
     "@types/node": "^20.0.0",
-    "@types/vscode": "^1.100.0",
     "cross-env": "5.2.0",
     "esbuild": "0.25.4",
     "esbuild-plugin-pino": "^2.2.2",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "@types/vscode": "^1.100.0",
     "@types/which": "^1.3.1",
     "cross-env": "5.2.0",
     "esbuild": "0.25.4",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -42,7 +42,6 @@
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@types/uuid": "^3.4.8",
-    "@types/vscode": "^1.100.0",
     "@types/which": "^1.3.1",
     "cross-env": "5.2.0",
     "esbuild": "0.25.4",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -51,7 +51,6 @@
     "@types/debounce": "^1.2.0",
     "@types/node": "^20.0.0",
     "@types/papaparse": "^5.2.3",
-    "@types/vscode": "^1.100.0",
     "applicationinsights": "1.0.7",
     "cross-env": "5.2.0",
     "esbuild": "0.25.4",

--- a/packages/salesforcedx-vscode-visualforce/package.json
+++ b/packages/salesforcedx-vscode-visualforce/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "@types/vscode": "^1.100.0",
     "cross-env": "5.2.0",
     "typescript": "^5.6.2"
   },


### PR DESCRIPTION
[skip-validate-pr]

undo this https://github.com/forcedotcom/salesforcedx-vscode/pull/6310
put types/vscode at the top-level pjson devDep
dependabot config to prevent it from happening again