### PR TITLE
refactor: userId without query

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/startApexDebugLogging.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/startApexDebugLogging.ts
@@ -17,14 +17,9 @@ const command = 'start_apex_debug_logging';
 export const turnOnLogging = async (extensionContext: vscode.ExtensionContext): Promise<void> => {
   handleStartCommand(command);
 
-  const connection = await WorkspaceContext.getInstance().getConnection();
+  const traceFlags = new TraceFlags(await WorkspaceContext.getInstance().getConnection());
 
-  const traceFlags = new TraceFlags(connection);
-  const username = connection.getUsername();
-  if (!username) {
-    throw new Error('No username found for the current connection.');
-  }
-  const userId = await traceFlags.getUserIdOrThrow(username);
+  const userId = await traceFlags.getUserIdOrThrow();
 
   // If an expired TraceFlag exists for the current user, delete it
   await traceFlags.deleteExpiredTraceFlags(userId);
@@ -42,7 +37,9 @@ export const turnOnLogging = async (extensionContext: vscode.ExtensionContext): 
     const expirationDate = extensionContext.workspaceState.get<Date>(TRACE_FLAG_EXPIRATION_KEY);
     if (expirationDate) {
       const expirationDateValidated = new Date(expirationDate);
-      await notificationService.showInformationMessage(`Trace flag already exists. It will expire at ${expirationDateValidated.toLocaleTimeString()}.`);
+      await notificationService.showInformationMessage(
+        `Trace flag already exists. It will expire at ${expirationDateValidated.toLocaleTimeString()}.`
+      );
     }
   }
 };

--- a/packages/salesforcedx-vscode-core/src/commands/stopApexDebugLogging.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/stopApexDebugLogging.ts
@@ -18,13 +18,8 @@ export const turnOffLogging = async (extensionContext: vscode.ExtensionContext):
   handleStartCommand(command);
 
   const connection = await WorkspaceContext.getInstance().getConnection();
-
   const traceFlags = new TraceFlags(connection);
-  const username = connection.getUsername();
-  if (!username) {
-    throw new Error('No username found for the current connection.');
-  }
-  const userId = await traceFlags.getUserIdOrThrow(username);
+  const userId = await traceFlags.getUserIdOrThrow();
 
   // Check if a TraceFlag already exists for the current user
   const myTraceFlag = await traceFlags.getTraceFlagForUser(userId);

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -217,14 +217,12 @@ const registerCommands = (extensionContext: vscode.ExtensionContext): vscode.Dis
 
   const apexGenerateTriggerCmd = vscode.commands.registerCommand('sf.apex.generate.trigger', apexGenerateTrigger);
 
-  const startApexDebugLoggingCmd = vscode.commands.registerCommand(
-    'sf.start.apex.debug.logging',
-    () => turnOnLogging(extensionContext)
+  const startApexDebugLoggingCmd = vscode.commands.registerCommand('sf.start.apex.debug.logging', () =>
+    turnOnLogging(extensionContext)
   );
 
-  const stopApexDebugLoggingCmd = vscode.commands.registerCommand(
-    'sf.stop.apex.debug.logging',
-    () => turnOffLogging(extensionContext)
+  const stopApexDebugLoggingCmd = vscode.commands.registerCommand('sf.stop.apex.debug.logging', () =>
+    turnOffLogging(extensionContext)
   );
 
   const isvDebugBootstrapCmd = vscode.commands.registerCommand('sf.debug.isv.bootstrap', isvDebugBootstrap);
@@ -503,13 +501,9 @@ export const activate = async (extensionContext: vscode.ExtensionContext) => {
   MetricsReporter.extensionPackStatus();
 
   // Delete expired TraceFlags for the current user
-  const connection = await WorkspaceContext.getInstance().getConnection();
-  const traceFlags = new TraceFlags(connection);
-  const username = connection.getUsername();
-  if (!username) {
-    throw new Error('No username found for the current connection.');
-  }
-  const userId = await traceFlags.getUserIdOrThrow(username);
+  const traceFlags = new TraceFlags(await WorkspaceContext.getInstance().getConnection());
+
+  const userId = await traceFlags.getUserIdOrThrow();
 
   const expiredTraceFlagExists = await traceFlags.deleteExpiredTraceFlags(userId);
   if (expiredTraceFlagExists) {


### PR DESCRIPTION
there's some cleaner non-query ways to get a userId.  since traceflags requires a Connection, asking for a username to query for a userId is kinda silly...it's the one for the connection.

This will preclude managing other users' trace flags, but we don't we have that requirement.  TraceFlags class was built to do more than we need.