### PR TITLE
chore: temporarily pin E2E to run on VSCode version 1.100.3 instead of latest

### DIFF
--- a/.github/workflows/apexE2E.yml
+++ b/.github/workflows/apexE2E.yml
@@ -41,7 +41,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'latest'
+        default: '1.100.3'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -88,7 +88,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'latest'
+        default: '1.100.3'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'

--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -46,7 +46,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'latest'
+        default: '1.100.3'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -98,7 +98,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'latest'
+        default: '1.100.3'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'

--- a/.github/workflows/deployRetrieveE2E.yml
+++ b/.github/workflows/deployRetrieveE2E.yml
@@ -36,7 +36,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'latest'
+        default: '1.100.3'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -78,7 +78,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'latest'
+        default: '1.100.3'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -131,7 +131,7 @@ jobs:
       runId: ${{ inputs.runId }}
 
   mdDeployRetrieve:
-    if: ${{ inputs.mdDeployRetrieve && inputs.vscodeVersion == 'latest'}}
+    if: ${{ inputs.mdDeployRetrieve && inputs.vscodeVersion == '1.100.3'}}
     uses: ./.github/workflows/runE2ETest.yml
     secrets: inherit
     with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,7 +48,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'latest'
+        default: '1.100.3'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -62,7 +62,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch || 'main' }}
-      vscodeVersion: ${{ inputs.vscodeVersion || 'latest' }}
+      vscodeVersion: ${{ inputs.vscodeVersion || '1.100.3' }}
       runId: ${{ inputs.runId || github.event.workflow_run.id }}
 
   Core:
@@ -71,7 +71,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch || 'main' }}
-      vscodeVersion: ${{ inputs.vscodeVersion || 'latest' }}
+      vscodeVersion: ${{ inputs.vscodeVersion || '1.100.3' }}
       runId: ${{ inputs.runId || github.event.workflow_run.id }}
 
   DeployAndRetrieve:
@@ -80,7 +80,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch || 'main' }}
-      vscodeVersion: ${{ inputs.vscodeVersion || 'latest' }}
+      vscodeVersion: ${{ inputs.vscodeVersion || '1.100.3' }}
       runId: ${{ inputs.runId || github.event.workflow_run.id }}
 
   LSP:
@@ -89,7 +89,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch || 'main' }}
-      vscodeVersion: ${{ inputs.vscodeVersion || 'latest' }}
+      vscodeVersion: ${{ inputs.vscodeVersion || '1.100.3' }}
       runId: ${{ inputs.runId || github.event.workflow_run.id }}
 
   LWC:
@@ -98,7 +98,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch || 'main' }}
-      vscodeVersion: ${{ inputs.vscodeVersion || 'latest' }}
+      vscodeVersion: ${{ inputs.vscodeVersion || '1.100.3' }}
       runId: ${{ inputs.runId || github.event.workflow_run.id }}
 
   SOQL:
@@ -107,7 +107,7 @@ jobs:
     secrets: inherit
     with:
       automationBranch: ${{ inputs.automationBranch || 'main' }}
-      vscodeVersion: ${{ inputs.vscodeVersion || 'latest' }}
+      vscodeVersion: ${{ inputs.vscodeVersion || '1.100.3' }}
       runId: ${{ inputs.runId || github.event.workflow_run.id }}
 
   Apex_min_vscode_version:

--- a/.github/workflows/lspE2E.yml
+++ b/.github/workflows/lspE2E.yml
@@ -26,7 +26,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'latest'
+        default: '1.100.3'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -58,7 +58,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'latest'
+        default: '1.100.3'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'

--- a/.github/workflows/lwcE2E.yml
+++ b/.github/workflows/lwcE2E.yml
@@ -21,7 +21,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'latest'
+        default: '1.100.3'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -48,7 +48,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'latest'
+        default: '1.100.3'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'

--- a/.github/workflows/runE2ETest.yml
+++ b/.github/workflows/runE2ETest.yml
@@ -19,7 +19,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'latest'
+        default: '1.100.3'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'

--- a/.github/workflows/soqlE2E.yml
+++ b/.github/workflows/soqlE2E.yml
@@ -16,7 +16,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'latest'
+        default: '1.100.3'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'
@@ -38,7 +38,7 @@ on:
       vscodeVersion:
         description: 'VSCode Version'
         required: false
-        default: 'latest'
+        default: '1.100.3'
         type: string
       runId:
         description: 'Run ID of the workflow run that created the vsixes'


### PR DESCRIPTION
[skip-validate-pr]