### PR TITLE
fix: add 'No components retrieved' message in Output Tab if a manifest that contains no valid components is retrieved

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/baseDeployRetrieve.ts
@@ -291,6 +291,9 @@ export abstract class RetrieveExecutor<T> extends DeployRetrieveExecutor<T> {
       );
     }
 
+    if (output === '') {
+      output = nls.localize('lib_retrieve_no_results') + '\n';
+    }
     return output;
   }
 }

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -673,6 +673,7 @@ export const messages = {
   beta_tapi_membertype_error: 'Unexpected error creating %s member',
   beta_tapi_car_error: 'Unexpected error creating container async request',
   beta_tapi_queue_status: 'The deploy is still in the Queue',
+  lib_retrieve_no_results: 'No components retrieved',
   lib_retrieve_result_title: 'Retrieved Source',
   lib_retrieve_result_parse_error: 'Not able to parse current results.',
   lib_retrieve_message_title: 'Retrieve Warnings',


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Provides a "No components retrieved" message in the Output Tab if a user tries to retrieve a manifest containing no valid components.

### What issues does this PR fix or reference?
@W-18811418@

### Functionality Before
![Screenshot 2025-06-17 at 1 32 55 PM](https://github.com/user-attachments/assets/9feeb9d3-6dd3-4423-89a5-74bbd3a44ff5)

### Functionality After
![Screenshot 2025-06-17 at 3 00 30 PM (2)](https://github.com/user-attachments/assets/bfdef788-9b9b-4b59-918e-300181888e65)
