### PR TITLE
refactor: initial refactor to use vscode's fs api instead of node fs in apex package

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/codecoverage/colorizer.ts
+++ b/packages/salesforcedx-vscode-apex/src/codecoverage/colorizer.ts
@@ -6,8 +6,7 @@
  */
 
 import { CodeCoverageResult } from '@salesforce/apex-node-bundle';
-import { SFDX_FOLDER, projectPaths } from '@salesforce/salesforcedx-utils-vscode';
-import { existsSync, readFileSync } from 'node:fs';
+import { SFDX_FOLDER, projectPaths, fileOrFolderExists, readFile } from '@salesforce/salesforcedx-utils-vscode';
 import { join, extname, basename } from 'node:path';
 import { Range, TextDocument, TextEditor, TextLine, window, workspace } from 'vscode';
 import { channelService } from '../channels';
@@ -43,22 +42,22 @@ type CoverageItem = {
   lines: { [key: string]: number };
 };
 
-const getTestRunId = (): string => {
+const getTestRunId = async (): Promise<string> => {
   const testRunIdFile = join(pathToApexTestResultsFolder, 'test-run-id.txt');
-  if (!existsSync(testRunIdFile)) {
+  if (!(await fileOrFolderExists(testRunIdFile))) {
     throw new Error(nls.localize('colorizer_no_code_coverage_on_project'));
   }
-  return readFileSync(testRunIdFile, 'utf8');
+  return readFile(testRunIdFile);
 };
 
-const getCoverageData = (): CoverageItem[] | CodeCoverageResult[] => {
-  const testRunId = getTestRunId();
+const getCoverageData = async (): Promise<CoverageItem[] | CodeCoverageResult[]> => {
+  const testRunId = await getTestRunId();
   const testResultFilePath = join(pathToApexTestResultsFolder, `test-result-${testRunId}.json`);
 
-  if (!existsSync(testResultFilePath)) {
+  if (!(await fileOrFolderExists(testResultFilePath))) {
     throw new Error(nls.localize('colorizer_no_code_coverage_on_test_results', testRunId));
   }
-  const testResultOutput = readFileSync(testResultFilePath, 'utf8');
+  const testResultOutput = await readFile(testResultFilePath);
   const testResult = JSON.parse(testResultOutput);
   if (testResult.coverage === undefined && testResult.codecoverage === undefined) {
     throw new Error(nls.localize('colorizer_no_code_coverage_on_test_results', testRunId));
@@ -82,14 +81,14 @@ export class CodeCoverageHandler {
   public uncoveredLines: Range[] = [];
 
   constructor(private statusBar: StatusBarToggle) {
-    window.onDidChangeActiveTextEditor(this.onDidChangeActiveTextEditor, this);
-    this.onDidChangeActiveTextEditor(window.activeTextEditor);
+    window.onDidChangeActiveTextEditor(async () => await this.onDidChangeActiveTextEditor(), this);
+    void this.onDidChangeActiveTextEditor(window.activeTextEditor);
   }
 
-  public onDidChangeActiveTextEditor(editor?: TextEditor) {
+  public async onDidChangeActiveTextEditor(editor?: TextEditor) {
     if (editor && this.statusBar.isHighlightingEnabled) {
       try {
-        const coverage = applyCoverageToSource(editor.document);
+        const coverage = await applyCoverageToSource(editor.document);
         this.coveredLines = coverage.coveredLines;
         this.uncoveredLines = coverage.uncoveredLines;
         this.setCoverageDecorators(editor);
@@ -99,7 +98,7 @@ export class CodeCoverageHandler {
     }
   }
 
-  public toggleCoverage() {
+  public async toggleCoverage() {
     const editor = window.activeTextEditor;
     if (this.statusBar.isHighlightingEnabled) {
       this.statusBar.toggle(false);
@@ -111,7 +110,7 @@ export class CodeCoverageHandler {
     } else {
       try {
         if (editor?.document) {
-          const coverage = applyCoverageToSource(editor.document);
+          const coverage = await applyCoverageToSource(editor.document);
           this.coveredLines = coverage.coveredLines;
           this.uncoveredLines = coverage.uncoveredLines;
           this.setCoverageDecorators(editor);
@@ -141,19 +140,19 @@ export class CodeCoverageHandler {
   }
 }
 
-const applyCoverageToSource = (
+const applyCoverageToSource = async (
   document?: TextDocument
-): {
+): Promise<{
   coveredLines: Range[];
   uncoveredLines: Range[];
-} => {
+}> => {
   if (
     document &&
     !document.uri.fsPath.includes(SFDX_FOLDER) &&
     isApexMetadata(document.uri.fsPath) &&
     !IS_TEST_REG_EXP.test(document.getText())
   ) {
-    const codeCovArray = getCoverageData();
+    const codeCovArray = await getCoverageData();
     const apexMemberName = getApexMemberName(document.uri.fsPath);
     const codeCovItem = codeCovArray.find(covItem => covItem.name === apexMemberName);
 

--- a/packages/salesforcedx-vscode-apex/src/commands/anonApexExecute.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/anonApexExecute.ts
@@ -16,9 +16,10 @@ import {
   TraceFlags,
   getYYYYMMddHHmmssDateFormat,
   hasRootWorkspace,
-  projectPaths
+  projectPaths,
+  createDirectory,
+  writeFile
 } from '@salesforce/salesforcedx-utils-vscode';
-import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { URI } from 'vscode-uri';
@@ -137,13 +138,13 @@ class AnonApexLibraryExecuteExecutor extends LibraryCommandletExecutor<ApexExecu
     return logFilePath;
   }
 
-  private saveLogFile(logFilePath: string, logs?: string): boolean {
+  private async saveLogFile(logFilePath: string, logs?: string): Promise<boolean> {
     if (!logFilePath || !logs) {
       return false;
     }
 
-    fs.mkdirSync(path.dirname(logFilePath), { recursive: true });
-    fs.writeFileSync(logFilePath, logs);
+    await createDirectory(path.dirname(logFilePath));
+    await writeFile(logFilePath, logs);
 
     return true;
   }

--- a/packages/salesforcedx-vscode-apex/src/commands/oasDocumentChecker.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/oasDocumentChecker.ts
@@ -4,15 +4,15 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { notificationService, WorkspaceContextUtil } from '@salesforce/salesforcedx-utils-vscode';
+import { notificationService, readFile, WorkspaceContextUtil } from '@salesforce/salesforcedx-utils-vscode';
 import { XMLParser } from 'fast-xml-parser';
-import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
-import type { URI } from 'vscode-uri';
+import { URI } from 'vscode-uri';
 import { nls } from '../messages';
 import { checkIfESRIsDecomposed, createProblemTabEntriesForOasDocument, processOasDocumentFromYaml } from '../oasUtils';
 import { getTelemetryService } from '../telemetry/telemetry';
+
 // This class runs the validation and correction logic on Oas Documents
 class OasDocumentChecker {
   private isESRDecomposed: boolean = false;
@@ -50,13 +50,13 @@ class OasDocumentChecker {
           const fullPath = sourceUri ? sourceUri.fsPath : vscode.window.activeTextEditor?.document.uri.fsPath || '';
 
           // Step 1: Validate eligibility
-          if (!this.isFilePathEligible(fullPath)) {
+          if (!(await this.isFilePathEligible(fullPath))) {
             throw nls.localize('invalid_file_for_generating_oas_doc');
           }
           // Step 2: Extract openAPI document if embedded inside xml
           let openApiDocument: string;
           if (fullPath.endsWith('.xml')) {
-            const xmlContent = fs.readFileSync(fullPath, 'utf8');
+            const xmlContent = await readFile(fullPath);
             const parser = new XMLParser();
             const jsonObj = parser.parse(xmlContent);
             openApiDocument = jsonObj.ExternalServiceRegistration?.schema;
@@ -64,7 +64,7 @@ class OasDocumentChecker {
               throw nls.localize('no_oas_doc_in_file');
             }
           } else {
-            openApiDocument = fs.readFileSync(fullPath, 'utf8');
+            openApiDocument = await readFile(fullPath);
           }
           // Step 3: Process the OAS document
           const processedOasResult = await processOasDocumentFromYaml(openApiDocument, undefined, undefined, true);
@@ -97,7 +97,10 @@ class OasDocumentChecker {
     telemetryService.sendException(telemetryEvent, errorMessage);
   };
 
-  private isFilePathEligible = (fullPath: string): boolean => {
+  /**
+   * Checks if the file path is eligible for OAS validation.
+   */
+  private async isFilePathEligible(fullPath: string): Promise<boolean> {
     // check if yaml or xml, else return false
     if (!(fullPath.endsWith('.yaml') || fullPath.endsWith('.externalServiceRegistration-meta.xml'))) {
       return false;
@@ -105,7 +108,7 @@ class OasDocumentChecker {
 
     // if xml, check registrationProviderType to be ApexRest
     if (fullPath.endsWith('.xml')) {
-      const xmlContent = fs.readFileSync(fullPath, 'utf8');
+      const xmlContent = await readFile(fullPath);
       const parser = new XMLParser();
       const jsonObj = parser.parse(xmlContent);
       const registrationProviderType = jsonObj.ExternalServiceRegistration?.registrationProviderType;
@@ -121,7 +124,7 @@ class OasDocumentChecker {
       const dirName = path.dirname(fullPath);
       const associatedXmlFileName = `${className}.externalServiceRegistration-meta.xml`;
 
-      const xmlContent = fs.readFileSync(path.join(dirName, associatedXmlFileName), 'utf8');
+      const xmlContent = await readFile(path.join(dirName, associatedXmlFileName));
       const parser = new XMLParser();
       const jsonObj = parser.parse(xmlContent);
       const registrationProviderType = jsonObj.ExternalServiceRegistration?.registrationProviderType;
@@ -131,7 +134,7 @@ class OasDocumentChecker {
     }
 
     return false;
-  };
+  }
 }
 
 export const validateOpenApiDocument = async (sourceUri: URI | URI[]): Promise<void> => {

--- a/packages/salesforcedx-vscode-apex/src/oas/externalServiceRegistrationManager.ts
+++ b/packages/salesforcedx-vscode-apex/src/oas/externalServiceRegistrationManager.ts
@@ -6,10 +6,15 @@
  */
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 
-import { workspaceUtils } from '@salesforce/salesforcedx-utils-vscode';
+import {
+  workspaceUtils,
+  fileOrFolderExists,
+  readFile,
+  createDirectory,
+  writeFile
+} from '@salesforce/salesforcedx-utils-vscode';
 import { RegistryAccess } from '@salesforce/source-deploy-retrieve-bundle';
 import { XMLBuilder, XMLParser } from 'fast-xml-parser';
-import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { OpenAPIV3 } from 'openapi-types';
 import * as vscode from 'vscode';
@@ -67,7 +72,7 @@ export class ExternalServiceRegistrationManager {
   ): Promise<void> {
     await this.initialize(isESRDecomposed, processedOasResult, fullPath);
 
-    const existingContent = fs.existsSync(this.newPath) ? fs.readFileSync(this.newPath, 'utf8') : undefined;
+    const existingContent = (await fileOrFolderExists(this.newPath)) ? await readFile(this.newPath) : undefined;
 
     //Step 1: Build the content of the ESR Xml file
     const updatedContent = await this.buildESRXml(existingContent);
@@ -95,7 +100,7 @@ export class ExternalServiceRegistrationManager {
    */
   public async writeAndOpenEsrFile(updatedContent: string) {
     try {
-      fs.writeFileSync(this.newPath, updatedContent);
+      await writeFile(this.newPath, updatedContent);
       await vscode.workspace.openTextDocument(this.newPath).then((newDocument: vscode.TextDocument) => {
         void vscode.window.showTextDocument(newDocument);
       });
@@ -141,7 +146,7 @@ export class ExternalServiceRegistrationManager {
       jsonObj = parser.parse(existingContent);
       if (this.isESRDecomposed) {
         jsonObj = esrObject;
-        this.buildESRYaml(this.newPath, safeOasSpec);
+        await this.buildESRYaml(this.newPath, safeOasSpec);
       } else {
         if (jsonObj.ExternalServiceRegistration?.schema) {
           jsonObj.ExternalServiceRegistration.schema = safeOasSpec;
@@ -152,7 +157,7 @@ export class ExternalServiceRegistrationManager {
       jsonObj.ExternalServiceRegistration.operations = operations;
     } else {
       jsonObj = esrObject;
-      if (this.isESRDecomposed) this.buildESRYaml(this.newPath, safeOasSpec);
+      if (this.isESRDecomposed) await this.buildESRYaml(this.newPath, safeOasSpec);
     }
 
     const builder = new XMLBuilder({ ignoreAttributes: false, format: true, processEntities: false });
@@ -225,11 +230,11 @@ export class ExternalServiceRegistrationManager {
    * @param esrXmlPath - The path to the ESR XML file.
    * @param safeOasSpec - The contents of the OAS doc that will be written to the YAML file.
    */
-  public buildESRYaml(esrXmlPath: string, safeOasSpec: string) {
+  public async buildESRYaml(esrXmlPath: string, safeOasSpec: string) {
     this.gil.addFinalDoc(safeOasSpec);
     const esrYamlPath = replaceXmlToYaml(esrXmlPath);
     try {
-      fs.writeFileSync(esrYamlPath, safeOasSpec, 'utf8');
+      await writeFile(esrYamlPath, safeOasSpec);
       console.log(`File created at ${esrYamlPath}`);
     } catch (err) {
       throw new Error('Error writing file:', err);
@@ -270,13 +275,11 @@ export class ExternalServiceRegistrationManager {
     }
 
     // Step 2: Verify folder exists and if not create it
-    if (!fs.existsSync(folder)) {
-      fs.mkdirSync(folder, { recursive: true });
-    }
+    await createDirectory(folder);
 
     // Step 3: Check if File Exists
     const fullPath = path.join(folder, filename);
-    if (fs.existsSync(fullPath)) {
+    if (await fileOrFolderExists(fullPath)) {
       const whatToDo = await this.handleExistingESR();
       if (whatToDo === 'cancel') {
         throw new Error(nls.localize('operation_cancelled'));
@@ -285,9 +288,7 @@ export class ExternalServiceRegistrationManager {
         const namePart = path.basename(filename, '.externalServiceRegistration-meta.xml');
         const newFileName = namePart + '_' + currentTimestamp + '.externalServiceRegistration-meta.xml';
         const esr_files_for_merge_folder = path.join(workspaceUtils.getRootWorkspacePath(), 'esr_files_for_merge');
-        if (!fs.existsSync(esr_files_for_merge_folder)) {
-          fs.mkdirSync(esr_files_for_merge_folder);
-        }
+        await createDirectory(esr_files_for_merge_folder);
         const newFullPath = path.join(esr_files_for_merge_folder, newFileName);
         return [fullPath, newFullPath];
       }

--- a/packages/salesforcedx-vscode-apex/src/oas/generationInteractionLogger.ts
+++ b/packages/salesforcedx-vscode-apex/src/oas/generationInteractionLogger.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import * as fs from 'node:fs';
+import { createDirectory, writeFile } from '@salesforce/salesforcedx-utils-vscode';
 import { join } from 'node:path';
 import * as vscode from 'vscode';
 import type { URI } from 'vscode-uri';
@@ -147,7 +147,7 @@ export default class GenerationInteractionLogger {
     };
   }
 
-  public writeLogs(): void {
+  public async writeLogs(): Promise<void> {
     if (this.okToLog()) {
       // create a file path based on current date time
       const logPath = join(process.cwd(), 'llm-logs');
@@ -155,9 +155,9 @@ export default class GenerationInteractionLogger {
       const fileName = `oas-gen-logs-${dateTime}.json`;
       const filePath = join(logPath, fileName);
 
-      fs.mkdirSync(logPath, { recursive: true });
+      await createDirectory(logPath);
       // write to the file
-      fs.writeFileSync(filePath, JSON.stringify(this.gatherAllFields(), undefined, 2), 'utf8');
+      await writeFile(filePath, JSON.stringify(this.gatherAllFields(), undefined, 2));
     }
   }
 

--- a/packages/salesforcedx-vscode-apex/src/oas/generationStrategy/buildPromptUtils.ts
+++ b/packages/salesforcedx-vscode-apex/src/oas/generationStrategy/buildPromptUtils.ts
@@ -4,8 +4,8 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { readFile } from '@salesforce/salesforcedx-utils-vscode';
 import * as ejs from 'ejs';
-import * as fs from 'node:fs';
 import { DocumentSymbol } from 'vscode';
 import { nls } from '../../messages';
 import { ejsTemplateHelpers, EjsTemplatesEnum } from '../../oasUtils';
@@ -89,21 +89,22 @@ export const getPromptForMethodContext = (methodContext: ApexOASMethodDetail | u
   return methodContextPrompt;
 };
 
-export const generatePromptForMethod = (
+export const generatePromptForMethod = async (
   methodName: string,
   docText: string,
   methodsDocSymbolMap: Map<string, DocumentSymbol>,
   methodsContextMap: Map<string, ApexOASMethodDetail>,
   classPrompt: string
-): string => {
-  const templatePath = ejsTemplateHelpers.getTemplatePath(EjsTemplatesEnum.METHOD_BY_METHOD);
+): Promise<string> => {
+  const templatePath = await ejsTemplateHelpers.getTemplatePath(EjsTemplatesEnum.METHOD_BY_METHOD);
 
   let additionalUserPrompts = '';
   const methodImplementation = getMethodImplementation(methodName, docText, methodsDocSymbolMap);
   const methodContext = methodsContextMap.get(methodName);
   additionalUserPrompts += getPromptForMethodContext(methodContext);
   try {
-    const renderedTemplate = ejs.render(fs.readFileSync(templatePath.fsPath, 'utf8'), {
+    const templateContent = await readFile(templatePath.fsPath);
+    const renderedTemplate = ejs.render(templateContent, {
       classPrompt,
       methodImplementation,
       additionalUserPrompts

--- a/packages/salesforcedx-vscode-apex/src/oas/generationStrategy/generationStrategy.ts
+++ b/packages/salesforcedx-vscode-apex/src/oas/generationStrategy/generationStrategy.ts
@@ -24,8 +24,8 @@ export abstract class GenerationStrategy {
   abstract strategyName: string;
   abstract biddedCallCount: number;
   abstract maxBudget: number;
-  abstract bid(): PromptGenerationStrategyBid;
-  abstract generate(): PromptGenerationResult; // generate the prompt(s) to be sent to the LLM
+  abstract bid(): Promise<PromptGenerationStrategyBid>;
+  abstract generate(): Promise<PromptGenerationResult>; // generate the prompt(s) to be sent to the LLM
   abstract callLLMWithPrompts(): Promise<string[]>;
   abstract generateOAS(): Promise<string>; // generate OAS with the generated prompt(s)
   abstract openAPISchema: string | undefined;

--- a/packages/salesforcedx-vscode-apex/src/oas/generationStrategy/generationStrategyFactory.ts
+++ b/packages/salesforcedx-vscode-apex/src/oas/generationStrategy/generationStrategyFactory.ts
@@ -15,12 +15,14 @@ export enum GenerationStrategy {
 export type Strategy = JsonMethodByMethodStrategy;
 
 export class GenerationStrategyFactory {
-  public static initializeAllStrategies(
+  public static async initializeAllStrategies(
     metadata: ApexClassOASEligibleResponse,
     context: ApexClassOASGatherContextResponse
-  ): Map<GenerationStrategy, Strategy> {
+  ): Promise<Map<GenerationStrategy, Strategy>> {
     const strategies = new Map<GenerationStrategy, Strategy>();
-    strategies.set(GenerationStrategy.JSON_METHOD_BY_METHOD, new JsonMethodByMethodStrategy(metadata, context));
+    const strategy = new JsonMethodByMethodStrategy(metadata, context);
+    await strategy.initialize();
+    strategies.set(GenerationStrategy.JSON_METHOD_BY_METHOD, strategy);
     return strategies;
   }
 }

--- a/packages/salesforcedx-vscode-apex/src/oas/generationStrategy/promptsHandler.ts
+++ b/packages/salesforcedx-vscode-apex/src/oas/generationStrategy/promptsHandler.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import * as fs from 'node:fs';
+import { fileOrFolderExists, createDirectory, writeFile } from '@salesforce/salesforcedx-utils-vscode';
 import * as path from 'node:path';
 import { stringify } from 'yaml';
 import { sourcePrompts } from './prompts';
@@ -15,13 +15,11 @@ export const PROMPTS_FILE = path.join(PROMPTS_DIR, 'prompts.yaml');
 
 const getPromptsFromSource = (): Record<string, any> => sourcePrompts;
 
-export const ensurePromptsExist = (): void => {
-  if (!fs.existsSync(PROMPTS_DIR)) {
-    fs.mkdirSync(PROMPTS_DIR, { recursive: true });
-  }
+export const ensurePromptsExist = async (): Promise<void> => {
+  await createDirectory(PROMPTS_DIR);
 
-  if (!fs.existsSync(PROMPTS_FILE)) {
+  if (!(await fileOrFolderExists(PROMPTS_FILE))) {
     const extractedPrompts = getPromptsFromSource();
-    fs.writeFileSync(PROMPTS_FILE, stringify(extractedPrompts), 'utf8');
+    await writeFile(PROMPTS_FILE, stringify(extractedPrompts));
   }
 };

--- a/packages/salesforcedx-vscode-apex/src/oasUtils.ts
+++ b/packages/salesforcedx-vscode-apex/src/oasUtils.ts
@@ -11,9 +11,13 @@ import {
   extensionUris,
   getJsonCandidate,
   identifyJsonTypeInString,
-  workspaceUtils
+  workspaceUtils,
+  createDirectory,
+  readDirectory,
+  readFile,
+  stat,
+  writeFile
 } from '@salesforce/salesforcedx-utils-vscode';
-import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { OpenAPIV3 } from 'openapi-types';
 import * as vscode from 'vscode';
@@ -173,38 +177,35 @@ export enum EjsTemplateKeys {
  * @param {string} src - The source directory.
  * @param {string} dest - The destination directory.
  */
-const copyDirectorySync = (src: string, dest: string) => {
-  if (!fs.existsSync(dest)) {
-    fs.mkdirSync(dest, { recursive: true });
-  }
+const copyDirectorySync = async (src: string, dest: string) => {
+  await createDirectory(dest);
 
-  const entries = fs.readdirSync(src, { withFileTypes: true });
+  const entries = await readDirectory(src);
 
   for (const entry of entries) {
-    const srcPath = path.join(src, entry.name);
-    const destPath = path.join(dest, entry.name);
+    const srcPath = path.join(src, entry);
+    const destPath = path.join(dest, entry);
 
-    if (entry.isDirectory()) {
-      copyDirectorySync(srcPath, destPath);
+    if ((await stat(srcPath))?.type === vscode.FileType.Directory) {
+      await copyDirectorySync(srcPath, destPath);
     } else {
-      fs.copyFileSync(srcPath, destPath);
+      const content = await readFile(srcPath);
+      await writeFile(destPath, content);
     }
   }
 };
 
 /**
  * Resolves the template directory URI.
- * @returns {URI} - The URI of the template directory.
+ * @returns {Promise<URI>} - The URI of the template directory.
  */
-const resolveTemplateDir = (): URI => {
+const resolveTemplateDir = async (): Promise<URI> => {
   const logLevel = vscode.workspace.getConfiguration().get(SF_LOG_LEVEL_SETTING, 'fatal');
   const extensionDir = extensionUris.extensionUri(VSCODE_APEX_EXTENSION_NAME);
   if (logLevel !== 'fatal') {
-    if (!fs.existsSync(TEMPLATES_DIR)) {
-      fs.mkdirSync(TEMPLATES_DIR, { recursive: true });
-      // copy contents of extensionDir to TEMPLATES_DIR
-      copyDirectorySync(path.join(extensionDir.fsPath, 'resources', 'templates'), TEMPLATES_DIR);
-    }
+    await createDirectory(TEMPLATES_DIR);
+    // copy contents of extensionDir to TEMPLATES_DIR
+    await copyDirectorySync(path.join(extensionDir.fsPath, 'resources', 'templates'), TEMPLATES_DIR);
     return URI.file(path.join(process.cwd(), DOT_SFDX));
   }
   return extensionDir;
@@ -217,10 +218,10 @@ export const ejsTemplateHelpers = {
   /**
    * Gets the template path for a given key.
    * @param {ejsTemplateKey} key - The key for the template.
-   * @returns {URI} - The URI of the template path.
+   * @returns {Promise<URI>} - The URI of the template path.
    */
-  getTemplatePath: (key: ejsTemplateKey): URI => {
-    const baseExtensionPath = resolveTemplateDir();
+  getTemplatePath: async (key: ejsTemplateKey): Promise<URI> => {
+    const baseExtensionPath = await resolveTemplateDir();
     return URI.file(path.join(baseExtensionPath.fsPath, PROMPT_TEMPLATES[key]));
   }
 };

--- a/packages/salesforcedx-vscode-apex/src/requirements.ts
+++ b/packages/salesforcedx-vscode-apex/src/requirements.ts
@@ -8,12 +8,12 @@
 // From https://github.com/redhat-developer/vscode-java
 // Original version licensed under the Eclipse Public License (EPL)
 
+import { fileOrFolderExists } from '@salesforce/salesforcedx-utils-vscode';
 import * as cp from 'node:child_process';
-import * as fs from 'node:fs';
 import { homedir } from 'node:os';
 import * as path from 'node:path';
-import { join } from 'node:path';
 import { workspace } from 'vscode';
+import * as vscode from 'vscode';
 import { SET_JAVA_DOC_LINK } from './constants';
 import { nls } from './messages';
 
@@ -54,7 +54,7 @@ const validateJavaInstallation = async (javaHome: string): Promise<boolean> => {
   const binDir = path.join(javaHome, 'bin');
 
   // Check if bin directory exists and is accessible
-  if (!fs.existsSync(binDir)) {
+  if (!(await fileOrFolderExists(binDir))) {
     throw new Error(nls.localize('java_bin_missing_text', javaHome));
   }
 
@@ -63,14 +63,19 @@ const validateJavaInstallation = async (javaHome: string): Promise<boolean> => {
     const platformBinary = getPlatformSpecificBinary(binary);
     const binaryPath = path.join(binDir, platformBinary);
 
-    if (!fs.existsSync(binaryPath)) {
+    if (!(await fileOrFolderExists(binaryPath))) {
       throw new Error(nls.localize('java_binary_missing_text', platformBinary, javaHome));
     }
 
     // On Windows, we don't check for X_OK permission
     if (process.platform !== 'win32') {
       try {
-        await fs.promises.access(binaryPath, fs.constants.X_OK);
+        const uri = vscode.Uri.file(binaryPath);
+        const stat = await vscode.workspace.fs.stat(uri);
+        // Check if file is executable (has execute permission)
+        if (stat.permissions === undefined || !(stat.permissions & 0o111)) {
+          throw new Error(nls.localize('java_binary_not_executable_text', platformBinary, javaHome));
+        }
       } catch {
         throw new Error(nls.localize('java_binary_not_executable_text', platformBinary, javaHome));
       }
@@ -81,7 +86,7 @@ const validateJavaInstallation = async (javaHome: string): Promise<boolean> => {
 };
 
 const checkJavaRuntime = async (): Promise<string> =>
-  new Promise((resolve, reject) => {
+  new Promise(async (resolve, reject) => {
     let source: string;
     let javaHome: string | undefined = readJavaConfig();
 
@@ -111,7 +116,7 @@ const checkJavaRuntime = async (): Promise<string> =>
         return;
       }
 
-      if (!fs.existsSync(expandedHome)) {
+      if (!(await fileOrFolderExists(expandedHome))) {
         reject(nls.localize('source_missing_text', source, SET_JAVA_DOC_LINK));
         return;
       }
@@ -152,7 +157,7 @@ const expandHomeDir = (p: string): string | undefined => {
   }
   if (p === '~') return homedir();
   if (!p.startsWith('~/')) return p;
-  return join(homedir(), p.slice(2));
+  return path.join(homedir(), p.slice(2));
 };
 
 const isLocal = (javaHome: string): boolean => {

--- a/packages/salesforcedx-vscode-apex/src/views/testOutlineProvider.ts
+++ b/packages/salesforcedx-vscode-apex/src/views/testOutlineProvider.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { TestResult } from '@salesforce/apex-node-bundle';
-import { readFileSync } from 'node:fs';
+import { readFile } from '@salesforce/salesforcedx-utils-vscode';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { URI } from 'vscode-uri';
@@ -121,7 +121,7 @@ export class ApexTestOutlineProvider implements vscode.TreeDataProvider<TestNode
 
   public async onResultFileCreate(apexTestPath: string, testResultFile: string) {
     const testRunIdFile = path.join(apexTestPath, TEST_RUN_ID_FILE);
-    const testRunId = readFileSync(testRunIdFile).toString();
+    const testRunId = await readFile(testRunIdFile);
     const testResultFilePath = path.join(
       apexTestPath,
       !testRunId ? TEST_RESULT_JSON_FILE : `test-result-${testRunId}.json`
@@ -129,7 +129,7 @@ export class ApexTestOutlineProvider implements vscode.TreeDataProvider<TestNode
 
     if (testResultFile === testResultFilePath) {
       await this.refresh();
-      this.updateTestResults(testResultFile);
+      await this.updateTestResults(testResultFile);
     }
   }
 
@@ -176,8 +176,8 @@ export class ApexTestOutlineProvider implements vscode.TreeDataProvider<TestNode
     return this.rootNode;
   }
 
-  public updateTestResults(testResultFilePath: string) {
-    const testResultOutput = readFileSync(testResultFilePath, 'utf8');
+  public async updateTestResults(testResultFilePath: string) {
+    const testResultOutput = await readFile(testResultFilePath);
     const testResultContent = JSON.parse(testResultOutput) as TestResult;
 
     this.updateTestsFromLibrary(testResultContent);

--- a/packages/salesforcedx-vscode-apex/test/jest/oas/externalServiceRegistrationManager.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/oas/externalServiceRegistrationManager.test.ts
@@ -6,7 +6,6 @@
  */
 import { workspaceUtils } from '@salesforce/salesforcedx-utils-vscode';
 import { RegistryAccess } from '@salesforce/source-deploy-retrieve-bundle';
-import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { OpenAPIV3 } from 'openapi-types';
 import * as vscode from 'vscode';
@@ -21,7 +20,6 @@ import {
 import * as oasUtils from '../../../src/oasUtils';
 import { createProblemTabEntriesForOasDocument } from '../../../src/oasUtils';
 
-jest.mock('node:fs');
 describe('ExternalServiceRegistrationManager', () => {
   let esrHandler: ExternalServiceRegistrationManager;
   let oasSpec: OpenAPIV3.Document;
@@ -79,6 +77,11 @@ describe('ExternalServiceRegistrationManager', () => {
     } as ProcessorInputOutput;
 
     esrHandler = new ExternalServiceRegistrationManager();
+
+    // Mock vscode.workspace.fs methods
+    jest.spyOn(vscode.workspace.fs, 'stat').mockResolvedValue({ type: vscode.FileType.File } as vscode.FileStat);
+    jest.spyOn(vscode.workspace.fs, 'writeFile').mockResolvedValue();
+    jest.spyOn(vscode.workspace.fs, 'createDirectory').mockResolvedValue();
   });
   describe('initialize', () => {
     it('should initialize with right values', () => {
@@ -109,7 +112,7 @@ describe('ExternalServiceRegistrationManager', () => {
   describe('generateEsrMD', () => {
     it('should call the necessary methods to generate ESR metadata', async () => {
       (vscode.window.showQuickPick as jest.Mock).mockResolvedValue('TestCredential');
-      (fs.existsSync as jest.Mock).mockReturnValue(false);
+      jest.spyOn(vscode.workspace.fs, 'stat').mockRejectedValue(new Error('File not found'));
       jest.spyOn(esrHandler, 'initialize' as any);
       jest.spyOn(esrHandler, 'writeAndOpenEsrFile').mockResolvedValue();
       jest.spyOn(esrHandler, 'displayFileDifferences').mockResolvedValue();
@@ -265,13 +268,13 @@ describe('ExternalServiceRegistrationManager', () => {
     expect(result).toContain('<description>oas description</description>');
   });
 
-  it('buildESRYaml', () => {
+  it('buildESRYaml', async () => {
     const esrXmlPath = '/path/to/esr.externalServiceRegistration-meta.xml';
     const safeOasSpec = 'safeOasSpec';
 
-    esrHandler.buildESRYaml(esrXmlPath, safeOasSpec);
+    await esrHandler.buildESRYaml(esrXmlPath, safeOasSpec);
 
-    expect(fs.writeFileSync).toHaveBeenCalledWith('/path/to/esr.yaml', safeOasSpec, 'utf8');
+    expect(vscode.workspace.fs.writeFile).toHaveBeenCalledWith(URI.file('/path/to/esr.yaml'), expect.any(Uint8Array));
   });
 
   it('replaceXmlToYaml', () => {


### PR DESCRIPTION
### What does this PR do?
This pull request refactors several modules in the `salesforcedx-vscode-apex` package to replace synchronous file system operations with asynchronous ones, improving performance and scalability. The changes primarily involve replacing `fs` methods with equivalent asynchronous methods from `@salesforce/salesforcedx-utils-vscode`. Additionally, some methods and classes were updated to support asynchronous workflows.

### Refactoring for Asynchronous File Operations

#### Code Coverage Colorizer (`colorizer.ts`):
* Replaced synchronous file system methods (`existsSync`, `readFileSync`) with asynchronous equivalents (`fileOrFolderExists`, `readFile`) in `getTestRunId` and `getCoverageData`. Updated these methods to return Promises. [[1]](diffhunk://#diff-ea543aaf6f42af859a2622a239ac19093cc409ad94cf0a7ef3b9f746cdc958d0L9-R9) [[2]](diffhunk://#diff-ea543aaf6f42af859a2622a239ac19093cc409ad94cf0a7ef3b9f746cdc958d0L46-R60)
* Modified `applyCoverageToSource` to be asynchronous, ensuring coverage data is fetched asynchronously.
* Updated `CodeCoverageHandler` methods (`onDidChangeActiveTextEditor`, `toggleCoverage`) to handle asynchronous coverage application. [[1]](diffhunk://#diff-ea543aaf6f42af859a2622a239ac19093cc409ad94cf0a7ef3b9f746cdc958d0L85-R91) [[2]](diffhunk://#diff-ea543aaf6f42af859a2622a239ac19093cc409ad94cf0a7ef3b9f746cdc958d0L102-R101) [[3]](diffhunk://#diff-ea543aaf6f42af859a2622a239ac19093cc409ad94cf0a7ef3b9f746cdc958d0L114-R113)

#### Anonymous Apex Execution (`anonApexExecute.ts`):
* Replaced synchronous directory creation (`mkdirSync`) and file writing (`writeFileSync`) with asynchronous methods (`createDirectory`, `writeFile`) in `saveLogFile`. [[1]](diffhunk://#diff-4794f80a20e51360e3f9de9fe797a34b0fdc31a9ec8478fb90d176902c0e1ad1L19-L21) [[2]](diffhunk://#diff-4794f80a20e51360e3f9de9fe797a34b0fdc31a9ec8478fb90d176902c0e1ad1L140-R147)

#### Apex Test Run (`apexTestRun.ts`):
* Updated `readFileSync` to `readFile` for asynchronous file reading in `TestsSelector` class. Adjusted filtering and mapping logic to handle Promises. [[1]](diffhunk://#diff-3fa2015f22c91caf80674524a3b1d214f94528b0eeed6a062bcc3e42210c2ae6L28-L30) [[2]](diffhunk://#diff-3fa2015f22c91caf80674524a3b1d214f94528b0eeed6a062bcc3e42210c2ae6L86-R97)

#### Apex Test Suite (`apexTestSuite.ts`):
* Replaced synchronous file reading (`readFileSync`) with asynchronous `readFile` in `listApexClassItems`. Updated logic to handle Promises during filtering and sorting. [[1]](diffhunk://#diff-d9c52d09009947cf2f229cf11e9f659296807b0d6d0d77d05b669882bab3090bL16-L18) [[2]](diffhunk://#diff-d9c52d09009947cf2f229cf11e9f659296807b0d6d0d77d05b669882bab3090bL31-R44)

#### OpenAPI Document Checker (`oasDocumentChecker.ts`):
* Replaced synchronous file reading (`readFileSync`) with asynchronous `readFile` in methods handling XML parsing and validation. Updated `isFilePathEligible` to be asynchronous. [[1]](diffhunk://#diff-bceb0a6e9b563b7586d8816d5ce7ade3985e2083734bfcf15f8a5ccec14a57e8L7-R15) [[2]](diffhunk://#diff-bceb0a6e9b563b7586d8816d5ce7ade3985e2083734bfcf15f8a5ccec14a57e8L53-R67) [[3]](diffhunk://#diff-bceb0a6e9b563b7586d8816d5ce7ade3985e2083734bfcf15f8a5ccec14a57e8L100-R111) [[4]](diffhunk://#diff-bceb0a6e9b563b7586d8816d5ce7ade3985e2083734bfcf15f8a5ccec14a57e8L124-R127) [[5]](diffhunk://#diff-bceb0a6e9b563b7586d8816d5ce7ade3985e2083734bfcf15f8a5ccec14a57e8L134-R137)

#### External Service Registration Manager (`externalServiceRegistrationManager.ts`):
* Replaced synchronous file system methods (`existsSync`, `readFileSync`, `writeFileSync`, `mkdirSync`) with asynchronous equivalents (`fileOrFolderExists`, `readFile`, `writeFile`, `createDirectory`) across multiple methods. [[1]](diffhunk://#diff-733914704df098b1ed0de16961c514216181722a2783ffc6f7758b05bd6255c3L9-L12) [[2]](diffhunk://#diff-733914704df098b1ed0de16961c514216181722a2783ffc6f7758b05bd6255c3L70-R75) [[3]](diffhunk://#diff-733914704df098b1ed0de16961c514216181722a2783ffc6f7758b05bd6255c3L98-R103) [[4]](diffhunk://#diff-733914704df098b1ed0de16961c514216181722a2783ffc6f7758b05bd6255c3L144-R149) [[5]](diffhunk://#diff-733914704df098b1ed0de16961c514216181722a2783ffc6f7758b05bd6255c3L155-R160) [[6]](diffhunk://#diff-733914704df098b1ed0de16961c514216181722a2783ffc6f7758b05bd6255c3L228-R237) [[7]](diffhunk://#diff-733914704df098b1ed0de16961c514216181722a2783ffc6f7758b05bd6255c3L273-R282) [[8]](diffhunk://#diff-733914704df098b1ed0de16961c514216181722a2783ffc6f7758b05bd6255c3L288-R291)

### What issues does this PR fix or reference?
@W-18379548@