### PR TITLE
fix: all -meta.xml files are language ForceSourceManifest to avoid RedHat XML extension errors

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -1000,7 +1000,8 @@
           "forcesourcemanifest"
         ],
         "filenamePatterns": [
-          "**/manifest/**/*.xml"
+          "**/manifest/**/*.xml",
+          "**/*/*-meta.xml"
         ]
       }
     ],


### PR DESCRIPTION
### What does this PR do?
Changes the language of **-meta.xml** files from XML to ForceSourceManifest to get rid of errors coming from the RedHat XML extension, which is included with the Salesforce Extension Pack Expanded.

### What issues does this PR fix or reference?
#6364

### Functionality Before
![Screenshot 2025-06-19 at 11 47 40 AM](https://github.com/user-attachments/assets/ebfcb559-1743-421d-9afa-254adf867ffb)

### Functionality After
![Screenshot 2025-06-19 at 11 48 16 AM](https://github.com/user-attachments/assets/56c6ca11-1faa-4a04-aa73-0b654494d874)

[skip-validate-pr]