### PR TITLE
fix: W-18885359 - allow retries upon connection timeouts when running apex tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5545,9 +5545,9 @@
       "license": "MIT"
     },
     "node_modules/@salesforce/apex-node-bundle": {
-      "version": "8.1.32",
-      "resolved": "https://registry.npmjs.org/@salesforce/apex-node-bundle/-/apex-node-bundle-8.1.32.tgz",
-      "integrity": "sha512-HTb9j3ExdiLK69tgm3zS+eytHMTOX5Ix39aQ7YnyVDcZ53reQxNoqr9QzZzHtJU/hvz04F82qNDcMANAIgLVEA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/apex-node-bundle/-/apex-node-bundle-8.2.0.tgz",
+      "integrity": "sha512-u/d2lBIHvajeqNCBe+uZduALWZoCe8W0QQ434q3cSdkZ+9B48zPkyNaVlEkVjx3Sef4EA0ZU0Pbxq58wmcvCYA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/core-bundle": "^8.14.0",
@@ -5555,7 +5555,7 @@
         "@types/istanbul-reports": "^3.0.4",
         "bfj": "8.0.0",
         "fast-glob": "^3.3.2",
-        "faye": "1.4.0",
+        "faye": "1.4.1",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.1.7"
@@ -14964,9 +14964,9 @@
       }
     },
     "node_modules/faye": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
-      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.1.tgz",
+      "integrity": "sha512-Cg/khikhqlvumHO3efwx2tps2ZgQRjUMrO24G0quz7MMzRYYaEjU224YFXOeuPIvanRegIchVxj6pmHK1W0ikA==",
       "license": "Apache-2.0",
       "dependencies": {
         "asap": "*",
@@ -33979,7 +33979,7 @@
       "version": "64.2.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/apex-node-bundle": "^8.1.26",
+        "@salesforce/apex-node-bundle": "^8.2.0",
         "@salesforce/apex-tmlanguage": "1.8.1",
         "@salesforce/salesforcedx-utils": "*",
         "@salesforce/salesforcedx-utils-vscode": "*",
@@ -34050,7 +34050,7 @@
       "version": "64.2.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/apex-node-bundle": "^8.1.26",
+        "@salesforce/apex-node-bundle": "^8.2.0",
         "@salesforce/salesforcedx-apex-replay-debugger": "*",
         "@salesforce/salesforcedx-utils": "*",
         "@salesforce/salesforcedx-utils-vscode": "*",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -24,7 +24,7 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/apex-node-bundle": "^8.1.26",
+    "@salesforce/apex-node-bundle": "^8.2.0",
     "@salesforce/salesforcedx-apex-replay-debugger": "*",
     "@salesforce/salesforcedx-utils": "*",
     "@salesforce/salesforcedx-utils-vscode": "*",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -26,7 +26,7 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/apex-node-bundle": "^8.1.26",
+    "@salesforce/apex-node-bundle": "^8.2.0",
     "@salesforce/apex-tmlanguage": "1.8.1",
     "@salesforce/salesforcedx-utils": "*",
     "@salesforce/salesforcedx-utils-vscode": "*",


### PR DESCRIPTION
### What does this PR do?
This pull request updates the dependency version for `@salesforce/apex-node-bundle` in two package files to ensure compatibility with the latest features and fixes.

Dependency updates:

* [`packages/salesforcedx-vscode-apex-replay-debugger/package.json`](diffhunk://#diff-8e3011a2d03be5d9d45a26ed3196a4ce5ba9fc9ce4423de8d832d2943f8c7ec3L27-R27): Updated `@salesforce/apex-node-bundle` from version `^8.1.26` to `^8.2.0`.
* [`packages/salesforcedx-vscode-apex/package.json`](diffhunk://#diff-12a773ded187140236b6d2177f127cf2097bc2ae1f02a413cc096b58a58201dcL29-R29): Updated `@salesforce/apex-node-bundle` from version `^8.1.26` to `^8.2.0`.

### What issues does this PR fix or reference?
@W-18885359@