### PR TITLE
refactor: W-18488820 - last of fs and eslint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -264,6 +264,18 @@ export default [
         }
       ],
       'import/no-self-import': 'error',
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['node:fs', 'fs'],
+              message:
+                "Use VSCode's fs API instead of Node.js fs for web extension compatibility. See https://code.visualstudio.com/api/references/vscode-api#FileSystem for documentation."
+            }
+          ]
+        }
+      ],
       'jsdoc/check-alignment': 'error',
       'jsdoc/check-indentation': 'error',
       'jsdoc/newline-after-description': 'off',

--- a/packages/salesforcedx-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-apex-replay-debugger/package.json
@@ -15,6 +15,7 @@
   ],
   "dependencies": {
     "@salesforce/salesforcedx-utils": "64.3.0",
+    "@salesforce/salesforcedx-utils-vscode": "64.3.0",
     "@vscode/debugadapter": "1.68.0",
     "@vscode/debugprotocol": "1.68.0",
     "vscode-uri": "^3.1.0"

--- a/packages/salesforcedx-apex-replay-debugger/src/adapter/apexReplayDebug.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/adapter/apexReplayDebug.ts
@@ -94,7 +94,7 @@ export class ApexReplayDebug extends LoggingDebugSession {
       })
     );
 
-    this.logContext = new LogContext(args, this);
+    this.logContext = await LogContext.create(args, this);
     this.heapDumpService = new HeapDumpService(this.logContext);
 
     if (!this.logContext.hasLogLines()) {

--- a/packages/salesforcedx-apex-replay-debugger/src/core/logContext.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/core/logContext.ts
@@ -58,8 +58,8 @@ export class LogContext {
   private readonly util = new LogContextUtil();
   private readonly session: ApexReplayDebug;
   private readonly launchArgs: LaunchRequestArguments;
-  private readonly logLines: string[] = [];
-  private readonly logSize: number;
+  private logLines: string[] = [];
+  private logSize: number = 0;
   private state: DebugLogState | undefined;
   private frameHandles = new Handles<ApexDebugStackFrameInfo>();
   private staticVariablesClassMap = new Map<string, Map<string, ApexVariableContainer>>();
@@ -78,11 +78,20 @@ export class LogContext {
   private backupStaticVariablesClassMap = this.staticVariablesClassMap;
   private backupVariableHandles = this.variableHandles;
 
-  constructor(launchArgs: LaunchRequestArguments, session: ApexReplayDebug) {
+  private constructor(launchArgs: LaunchRequestArguments, session: ApexReplayDebug) {
     this.launchArgs = launchArgs;
     this.session = session;
-    this.logLines = this.util.readLogFile(launchArgs.logFile);
-    this.logSize = this.util.getFileSize(launchArgs.logFile);
+  }
+
+  public static async create(launchArgs: LaunchRequestArguments, session: ApexReplayDebug): Promise<LogContext> {
+    const instance = new LogContext(launchArgs, session);
+    await instance.initialize();
+    return instance;
+  }
+
+  private async initialize(): Promise<void> {
+    this.logLines = await this.util.readLogFile(this.launchArgs.logFile);
+    this.logSize = await this.util.getFileSize(this.launchArgs.logFile);
   }
 
   public getUtil(): LogContextUtil {

--- a/packages/salesforcedx-apex-replay-debugger/src/core/logContextUtil.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/core/logContextUtil.ts
@@ -5,21 +5,22 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import * as fs from 'node:fs';
+import { readFile, stat } from '@salesforce/salesforcedx-utils-vscode';
 
 export class LogContextUtil {
-  public getFileSize(filePath: string): number {
+  public async getFileSize(filePath: string): Promise<number> {
     try {
-      const stats = fs.statSync(filePath);
+      const stats = await stat(filePath);
       return stats.size;
     } catch {
       return 0;
     }
   }
 
-  public readLogFile(logFilePath: string): string[] {
+  public async readLogFile(logFilePath: string): Promise<string[]> {
     try {
-      return fs.readFileSync(logFilePath, 'utf-8').trim().split(/\r?\n/);
+      const content = await readFile(logFilePath);
+      return content.trim().split(/\r?\n/);
     } catch {
       return [];
     }

--- a/packages/salesforcedx-apex-replay-debugger/test/integration/adapter.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/integration/adapter.test.ts
@@ -74,7 +74,7 @@ describe('Replay debugger adapter - integration', () => {
     );
     const testName = 'recursive';
     const logFilePath = path.join(LOG_FOLDER, `${testName}.log`);
-    goldFileUtil = new GoldFileUtil(dc, path.join(LOG_FOLDER, `${testName}.gold`));
+    goldFileUtil = await GoldFileUtil.create(dc, path.join(LOG_FOLDER, `${testName}.gold`));
 
     const launchResponse = await dc.launchRequest({
       // @ts-expect-error this code added a new property to the LaunchRequestArguments type
@@ -139,7 +139,7 @@ describe('Replay debugger adapter - integration', () => {
     });
     const testName = 'statics';
     const logFilePath = path.join(LOG_FOLDER, `${testName}.log`);
-    goldFileUtil = new GoldFileUtil(dc, path.join(LOG_FOLDER, `${testName}.gold`));
+    goldFileUtil = await GoldFileUtil.create(dc, path.join(LOG_FOLDER, `${testName}.gold`));
 
     const launchResponse = await dc.launchRequest({
       // @ts-expect-error this code added a new property to the LaunchRequestArguments type

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/apexReplayDebug.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/apexReplayDebug.test.ts
@@ -34,8 +34,13 @@ import { HeapDumpService } from '../../../src/core/heapDumpService';
 import { nls } from '../../../src/messages';
 
 export class MockApexReplayDebug extends ApexReplayDebug {
-  public setLogFile(args: LaunchRequestArguments) {
-    this.logContext = new LogContext(args, this);
+  public async setLogFile(args: LaunchRequestArguments): Promise<void> {
+    this.logContext = await LogContext.create(args, this);
+    this.heapDumpService = new HeapDumpService(this.logContext);
+  }
+
+  public async setLogContext(logContext: LogContext): Promise<void> {
+    this.logContext = logContext;
     this.heapDumpService = new HeapDumpService(this.logContext);
   }
 
@@ -85,14 +90,10 @@ describe('Replay debugger adapter - unit', () => {
     let sendEventSpy: jest.SpyInstance;
     let response: DebugProtocol.LaunchResponse;
     let args: LaunchRequestArguments;
-    let hasLogLinesStub: jest.SpyInstance;
-    let meetsLogLevelRequirementsStub: jest.SpyInstance;
     let readLogFileStub: jest.SpyInstance;
     let getLogSizeStub: jest.SpyInstance;
     let printToDebugConsoleStub: jest.SpyInstance;
     let errorToDebugConsoleStub: jest.SpyInstance;
-    let scanLogForHeapDumpLinesStub: jest.SpyInstance;
-    let fetchOverlayResultsForApexHeapDumpsStub: jest.SpyInstance;
     const lineBpInfo: LineBreakpointInfo[] = [];
     lineBpInfo.push({
       uri: 'classA',
@@ -126,37 +127,36 @@ describe('Replay debugger adapter - unit', () => {
         // Call the original implementation for non-output events
         return jest.requireActual('@vscode/debugadapter').DebugSession.prototype.sendEvent.call(adapter, event);
       });
-      readLogFileStub = jest.spyOn(LogContextUtil.prototype, 'readLogFile').mockReturnValue(['line1', 'line2']);
+      readLogFileStub = jest.spyOn(LogContextUtil.prototype, 'readLogFile').mockResolvedValue(['line1', 'line2']);
       getLogSizeStub = jest.spyOn(LogContext.prototype, 'getLogSize').mockReturnValue(123);
     });
 
     afterEach(() => {
       sendResponseSpy.mockRestore();
       sendEventSpy.mockRestore();
-      hasLogLinesStub.mockRestore();
-      meetsLogLevelRequirementsStub.mockRestore();
       readLogFileStub.mockRestore();
       getLogSizeStub.mockRestore();
       printToDebugConsoleStub.mockRestore();
       errorToDebugConsoleStub.mockRestore();
-      if (scanLogForHeapDumpLinesStub) {
-        scanLogForHeapDumpLinesStub.mockRestore();
-      }
-      if (fetchOverlayResultsForApexHeapDumpsStub) {
-        fetchOverlayResultsForApexHeapDumpsStub.mockRestore();
-      }
+      jest.restoreAllMocks();
     });
 
     it('Should return error when there are no log lines', async () => {
-      hasLogLinesStub = jest.spyOn(LogContext.prototype, 'hasLogLines').mockReturnValue(false);
-      meetsLogLevelRequirementsStub = jest
-        .spyOn(LogContext.prototype, 'meetsLogLevelRequirements')
-        .mockReturnValue(false);
+      const mockLogContext = {
+        hasLogLines: jest.fn().mockReturnValue(false),
+        meetsLogLevelRequirements: jest.fn().mockReturnValue(false),
+        getLogSize: jest.fn().mockReturnValue(123),
+        getLogFileName: jest.fn().mockReturnValue(logFileName),
+        scanLogForHeapDumpLines: jest.fn().mockReturnValue(false),
+        fetchOverlayResultsForApexHeapDumps: jest.fn().mockResolvedValue(true)
+      } as unknown as LogContext;
+
+      jest.spyOn(LogContext, 'create').mockResolvedValue(mockLogContext);
 
       await adapter.launchRequest(response, args);
 
-      expect(hasLogLinesStub).toHaveBeenCalledTimes(1);
-      expect(meetsLogLevelRequirementsStub).toHaveBeenCalledTimes(0);
+      expect(mockLogContext.hasLogLines).toHaveBeenCalledTimes(1);
+      expect(mockLogContext.meetsLogLevelRequirements).toHaveBeenCalledTimes(0);
       expect(sendResponseSpy).toHaveBeenCalledTimes(1);
       expect(sendEventSpy).toHaveBeenCalledTimes(4);
       const actualResponse: DebugProtocol.LaunchResponse = sendResponseSpy.mock.calls[0][0];
@@ -174,15 +174,21 @@ describe('Replay debugger adapter - unit', () => {
     });
 
     it('Should return error when log levels are incorrect', async () => {
-      hasLogLinesStub = jest.spyOn(LogContext.prototype, 'hasLogLines').mockReturnValue(true);
-      meetsLogLevelRequirementsStub = jest
-        .spyOn(LogContext.prototype, 'meetsLogLevelRequirements')
-        .mockReturnValue(false);
+      const mockLogContext = {
+        hasLogLines: jest.fn().mockReturnValue(true),
+        meetsLogLevelRequirements: jest.fn().mockReturnValue(false),
+        getLogSize: jest.fn().mockReturnValue(123),
+        getLogFileName: jest.fn().mockReturnValue(logFileName),
+        scanLogForHeapDumpLines: jest.fn().mockReturnValue(false),
+        fetchOverlayResultsForApexHeapDumps: jest.fn().mockResolvedValue(true)
+      } as unknown as LogContext;
+
+      jest.spyOn(LogContext, 'create').mockResolvedValue(mockLogContext);
 
       await adapter.launchRequest(response, args);
 
-      expect(hasLogLinesStub).toHaveBeenCalledTimes(1);
-      expect(meetsLogLevelRequirementsStub).toHaveBeenCalledTimes(1);
+      expect(mockLogContext.hasLogLines).toHaveBeenCalledTimes(1);
+      expect(mockLogContext.meetsLogLevelRequirements).toHaveBeenCalledTimes(1);
       expect(sendResponseSpy).toHaveBeenCalledTimes(1);
       expect(sendEventSpy).toHaveBeenCalledTimes(4);
       const actualResponse: DebugProtocol.LaunchResponse = sendResponseSpy.mock.calls[0][0];
@@ -200,16 +206,22 @@ describe('Replay debugger adapter - unit', () => {
     });
 
     it('Should send response', async () => {
-      hasLogLinesStub = jest.spyOn(LogContext.prototype, 'hasLogLines').mockReturnValue(true);
-      meetsLogLevelRequirementsStub = jest
-        .spyOn(LogContext.prototype, 'meetsLogLevelRequirements')
-        .mockReturnValue(true);
+      const mockLogContext = {
+        hasLogLines: jest.fn().mockReturnValue(true),
+        meetsLogLevelRequirements: jest.fn().mockReturnValue(true),
+        getLogSize: jest.fn().mockReturnValue(123),
+        getLogFileName: jest.fn().mockReturnValue(logFileName),
+        scanLogForHeapDumpLines: jest.fn().mockReturnValue(false),
+        fetchOverlayResultsForApexHeapDumps: jest.fn().mockResolvedValue(true)
+      } as unknown as LogContext;
+
+      jest.spyOn(LogContext, 'create').mockResolvedValue(mockLogContext);
 
       args.lineBreakpointInfo = lineBpInfo;
       await adapter.launchRequest(response, args);
 
-      expect(hasLogLinesStub).toHaveBeenCalledTimes(1);
-      expect(meetsLogLevelRequirementsStub).toHaveBeenCalledTimes(1);
+      expect(mockLogContext.hasLogLines).toHaveBeenCalledTimes(1);
+      expect(mockLogContext.meetsLogLevelRequirements).toHaveBeenCalledTimes(1);
       expect(printToDebugConsoleStub).toHaveBeenCalledTimes(1);
       const consoleMessage = printToDebugConsoleStub.mock.calls[0][0];
       expect(consoleMessage).toBe(nls.localize('session_started_text', logFileName));
@@ -219,80 +231,97 @@ describe('Replay debugger adapter - unit', () => {
     });
 
     it('Should not scan for log lines if projectPath is undefined', async () => {
-      hasLogLinesStub = jest.spyOn(LogContext.prototype, 'hasLogLines').mockReturnValue(true);
-      meetsLogLevelRequirementsStub = jest
-        .spyOn(LogContext.prototype, 'meetsLogLevelRequirements')
-        .mockReturnValue(true);
-      scanLogForHeapDumpLinesStub = jest.spyOn(LogContext.prototype, 'scanLogForHeapDumpLines').mockReturnValue(false);
+      const mockLogContext = {
+        hasLogLines: jest.fn().mockReturnValue(true),
+        meetsLogLevelRequirements: jest.fn().mockReturnValue(true),
+        getLogSize: jest.fn().mockReturnValue(123),
+        getLogFileName: jest.fn().mockReturnValue(logFileName),
+        scanLogForHeapDumpLines: jest.fn().mockReturnValue(false),
+        fetchOverlayResultsForApexHeapDumps: jest.fn().mockResolvedValue(true)
+      } as unknown as LogContext;
+
+      jest.spyOn(LogContext, 'create').mockResolvedValue(mockLogContext);
 
       adapter.setProjectPath(undefined);
       await adapter.launchRequest(response, args);
 
-      expect(hasLogLinesStub).toHaveBeenCalledTimes(1);
-      expect(meetsLogLevelRequirementsStub).toHaveBeenCalledTimes(1);
-      expect(scanLogForHeapDumpLinesStub).toHaveBeenCalledTimes(0);
+      expect(mockLogContext.hasLogLines).toHaveBeenCalledTimes(1);
+      expect(mockLogContext.meetsLogLevelRequirements).toHaveBeenCalledTimes(1);
+      expect(mockLogContext.scanLogForHeapDumpLines).toHaveBeenCalledTimes(0);
     });
 
     it('Should scan log lines for heap dumps if projectPath is set', async () => {
-      hasLogLinesStub = jest.spyOn(LogContext.prototype, 'hasLogLines').mockReturnValue(true);
-      meetsLogLevelRequirementsStub = jest
-        .spyOn(LogContext.prototype, 'meetsLogLevelRequirements')
-        .mockReturnValue(true);
-      scanLogForHeapDumpLinesStub = jest.spyOn(LogContext.prototype, 'scanLogForHeapDumpLines').mockReturnValue(false);
-      fetchOverlayResultsForApexHeapDumpsStub = jest
-        .spyOn(LogContext.prototype, 'fetchOverlayResultsForApexHeapDumps')
-        .mockResolvedValue(true);
+      const mockLogContext = {
+        hasLogLines: jest.fn().mockReturnValue(true),
+        meetsLogLevelRequirements: jest.fn().mockReturnValue(true),
+        getLogSize: jest.fn().mockReturnValue(123),
+        getLogFileName: jest.fn().mockReturnValue(logFileName),
+        scanLogForHeapDumpLines: jest.fn().mockReturnValue(false),
+        fetchOverlayResultsForApexHeapDumps: jest.fn().mockResolvedValue(true)
+      } as unknown as LogContext;
+
+      jest.spyOn(LogContext, 'create').mockResolvedValue(mockLogContext);
 
       args.lineBreakpointInfo = lineBpInfo;
       await adapter.launchRequest(response, args);
 
-      expect(hasLogLinesStub).toHaveBeenCalledTimes(1);
-      expect(meetsLogLevelRequirementsStub).toHaveBeenCalledTimes(1);
-      expect(scanLogForHeapDumpLinesStub).toHaveBeenCalledTimes(1);
+      expect(mockLogContext.hasLogLines).toHaveBeenCalledTimes(1);
+      expect(mockLogContext.meetsLogLevelRequirements).toHaveBeenCalledTimes(1);
+      expect(mockLogContext.scanLogForHeapDumpLines).toHaveBeenCalledTimes(1);
       // fetchOverlayResultsForApexHeapDumps should not be called if scanLogForHeapDumpLines returns false
-      expect(fetchOverlayResultsForApexHeapDumpsStub).toHaveBeenCalledTimes(0);
+      expect(mockLogContext.fetchOverlayResultsForApexHeapDumps).toHaveBeenCalledTimes(0);
     });
 
     it('Should call to fetch overlay results if heap dumps are found in the logs', async () => {
-      hasLogLinesStub = jest.spyOn(LogContext.prototype, 'hasLogLines').mockReturnValue(true);
-      meetsLogLevelRequirementsStub = jest
-        .spyOn(LogContext.prototype, 'meetsLogLevelRequirements')
-        .mockReturnValue(true);
-      scanLogForHeapDumpLinesStub = jest.spyOn(LogContext.prototype, 'scanLogForHeapDumpLines').mockReturnValue(true);
-      fetchOverlayResultsForApexHeapDumpsStub = jest
-        .spyOn(LogContext.prototype, 'fetchOverlayResultsForApexHeapDumps')
-        .mockResolvedValue(true);
+      const mockLogContext = {
+        hasLogLines: jest.fn().mockReturnValue(true),
+        meetsLogLevelRequirements: jest.fn().mockReturnValue(true),
+        getLogSize: jest.fn().mockReturnValue(123),
+        getLogFileName: jest.fn().mockReturnValue(logFileName),
+        scanLogForHeapDumpLines: jest.fn().mockReturnValue(true),
+        fetchOverlayResultsForApexHeapDumps: jest.fn().mockResolvedValue(true)
+      } as unknown as LogContext;
+
+      jest.spyOn(LogContext, 'create').mockResolvedValue(mockLogContext);
 
       args.lineBreakpointInfo = lineBpInfo;
       await adapter.launchRequest(response, args);
 
-      expect(hasLogLinesStub).toHaveBeenCalledTimes(1);
-      expect(meetsLogLevelRequirementsStub).toHaveBeenCalledTimes(1);
-      expect(scanLogForHeapDumpLinesStub).toHaveBeenCalledTimes(1);
-      expect(fetchOverlayResultsForApexHeapDumpsStub).toHaveBeenCalledTimes(1);
+      expect(mockLogContext.hasLogLines).toHaveBeenCalledTimes(1);
+      expect(mockLogContext.meetsLogLevelRequirements).toHaveBeenCalledTimes(1);
+      expect(mockLogContext.scanLogForHeapDumpLines).toHaveBeenCalledTimes(1);
+      expect(mockLogContext.fetchOverlayResultsForApexHeapDumps).toHaveBeenCalledTimes(1);
     });
 
     it('Should report a wrap up error if fetching heap dumps has a failure', async () => {
-      hasLogLinesStub = jest.spyOn(LogContext.prototype, 'hasLogLines').mockReturnValue(true);
-      meetsLogLevelRequirementsStub = jest
-        .spyOn(LogContext.prototype, 'meetsLogLevelRequirements')
-        .mockReturnValue(true);
-      scanLogForHeapDumpLinesStub = jest.spyOn(LogContext.prototype, 'scanLogForHeapDumpLines').mockReturnValue(true);
-      fetchOverlayResultsForApexHeapDumpsStub = jest
-        .spyOn(LogContext.prototype, 'fetchOverlayResultsForApexHeapDumps')
-        .mockResolvedValue(false);
+      const mockLogContext = {
+        hasLogLines: jest.fn().mockReturnValue(true),
+        meetsLogLevelRequirements: jest.fn().mockReturnValue(true),
+        getLogSize: jest.fn().mockReturnValue(123),
+        getLogFileName: jest.fn().mockReturnValue(logFileName),
+        scanLogForHeapDumpLines: jest.fn().mockReturnValue(true),
+        fetchOverlayResultsForApexHeapDumps: jest.fn().mockResolvedValue(false)
+      } as unknown as LogContext;
+
+      jest.spyOn(LogContext, 'create').mockResolvedValue(mockLogContext);
 
       args.lineBreakpointInfo = lineBpInfo;
+      args.projectPath = projectPath; // Ensure projectPath is set
+      adapter.setProjectPath(projectPath); // Reset adapter's projectPath
+      // Stub errorToDebugConsole directly on the adapter instance
+      adapter.errorToDebugConsole = jest.fn(function () {});
+
       await adapter.launchRequest(response, args);
 
-      expect(hasLogLinesStub).toHaveBeenCalledTimes(1);
-      expect(meetsLogLevelRequirementsStub).toHaveBeenCalledTimes(1);
-      expect(scanLogForHeapDumpLinesStub).toHaveBeenCalledTimes(1);
-      expect(fetchOverlayResultsForApexHeapDumpsStub).toHaveBeenCalledTimes(1);
-      expect(errorToDebugConsoleStub).toHaveBeenCalledTimes(1);
-      expect(sendEventSpy).toHaveBeenCalledTimes(4);
-      const errorMessage = errorToDebugConsoleStub.mock.calls[0][0];
+      expect(mockLogContext.hasLogLines).toHaveBeenCalledTimes(1);
+      expect(mockLogContext.meetsLogLevelRequirements).toHaveBeenCalledTimes(1);
+      expect(mockLogContext.scanLogForHeapDumpLines).toHaveBeenCalledTimes(1);
+      expect(mockLogContext.fetchOverlayResultsForApexHeapDumps).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line jest/unbound-method
+      expect(adapter.errorToDebugConsole as jest.Mock).toHaveBeenCalledTimes(1);
+      const errorMessage = (adapter.errorToDebugConsole as jest.Mock).mock.calls[0][0];
       expect(errorMessage).toBe(nls.localize('heap_dump_error_wrap_up_text'));
+      expect(sendEventSpy).toHaveBeenCalledTimes(4);
       expect(sendEventSpy.mock.calls[1][0]).toBeInstanceOf(Event);
       expect(sendEventSpy.mock.calls[1][0].body.subject).toBe('Fetching heap dumps failed');
       expect(sendEventSpy.mock.calls[2][0]).toBeInstanceOf(InitializedEvent);
@@ -432,7 +461,7 @@ describe('Replay debugger adapter - unit', () => {
         body: { threads: [] }
       });
       sendResponseSpy = jest.spyOn(ApexReplayDebug.prototype, 'sendResponse');
-      readLogFileStub = jest.spyOn(LogContextUtil.prototype, 'readLogFile').mockReturnValue(['line1', 'line2']);
+      readLogFileStub = jest.spyOn(LogContextUtil.prototype, 'readLogFile').mockResolvedValue(['line1', 'line2']);
       adapter.setLogFile(launchRequestArgs);
     });
 
@@ -490,7 +519,7 @@ describe('Replay debugger adapter - unit', () => {
         threadId: ApexReplayDebug.THREAD_ID
       };
       sendResponseSpy = jest.spyOn(ApexReplayDebug.prototype, 'sendResponse');
-      readLogFileStub = jest.spyOn(LogContextUtil.prototype, 'readLogFile').mockReturnValue(['line1', 'line2']);
+      readLogFileStub = jest.spyOn(LogContextUtil.prototype, 'readLogFile').mockResolvedValue(['line1', 'line2']);
       adapter.setLogFile(launchRequestArgs);
       getFramesStub = jest.spyOn(LogContext.prototype, 'getFrames').mockReturnValue(sampleStackFrames);
     });
@@ -886,8 +915,6 @@ describe('Replay debugger adapter - unit', () => {
       let sendEventSpy: jest.SpyInstance;
       let sendResponseSpy: jest.SpyInstance;
       let createMappingsFromLineBreakpointInfo: jest.SpyInstance;
-      let hasLogLinesStub: jest.SpyInstance;
-      let meetsLogLevelRequirementsStub: jest.SpyInstance;
       const initializedResponse = {
         success: true,
         type: 'response',
@@ -910,10 +937,17 @@ describe('Replay debugger adapter - unit', () => {
 
       beforeEach(() => {
         adapter = new MockApexReplayDebug();
-        hasLogLinesStub = jest.spyOn(LogContext.prototype, 'hasLogLines').mockReturnValue(true);
-        meetsLogLevelRequirementsStub = jest
-          .spyOn(LogContext.prototype, 'meetsLogLevelRequirements')
-          .mockReturnValue(true);
+        const mockLogContext = {
+          hasLogLines: jest.fn().mockReturnValue(true),
+          meetsLogLevelRequirements: jest.fn().mockReturnValue(true),
+          getLogSize: jest.fn().mockReturnValue(123),
+          getLogFileName: jest.fn().mockReturnValue('test.log'),
+          scanLogForHeapDumpLines: jest.fn().mockReturnValue(false),
+          fetchOverlayResultsForApexHeapDumps: jest.fn().mockResolvedValue(true)
+        } as unknown as LogContext;
+
+        jest.spyOn(LogContext, 'create').mockResolvedValue(mockLogContext);
+
         // Create a targeted sendEvent spy that filters out output events
         sendEventSpy = jest.spyOn(ApexReplayDebug.prototype, 'sendEvent').mockImplementation(event => {
           if (event.event === 'output') {
@@ -929,11 +963,10 @@ describe('Replay debugger adapter - unit', () => {
       });
 
       afterEach(() => {
-        hasLogLinesStub.mockRestore();
-        meetsLogLevelRequirementsStub.mockRestore();
         sendResponseSpy.mockRestore();
         sendEventSpy.mockRestore();
         createMappingsFromLineBreakpointInfo.mockRestore();
+        jest.restoreAllMocks();
       });
 
       it('Should handle undefined args', async () => {

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/apexReplayDebugVariablesHandling.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/adapter/apexReplayDebugVariablesHandling.test.ts
@@ -192,9 +192,9 @@ describe('Replay debugger adapter variable handling - unit', () => {
   describe('Heapdump', () => {
     let heapDumpService: HeapDumpService;
 
-    beforeAll(() => {
+    beforeAll(async () => {
       adapter = new MockApexReplayDebug();
-      const logContext = new LogContext(launchRequestArgs, adapter);
+      const logContext = await LogContext.create(launchRequestArgs, adapter);
       heapDumpService = new HeapDumpService(logContext);
     });
 

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/core/logContext.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/core/logContext.test.ts
@@ -57,15 +57,15 @@ describe('LogContext', () => {
     projectPath: 'path/project'
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     readLogFileSpy = jest
       .spyOn(LogContextUtil.prototype, 'readLogFile')
-      .mockReturnValue(['43.0 APEX_CODE,FINEST;...;VISUALFORCE,FINER;..', 'line1', 'line2']);
-    getFileSizeSpy = jest.spyOn(LogContextUtil.prototype, 'getFileSize').mockReturnValue(123);
+      .mockResolvedValue(['43.0 APEX_CODE,FINEST;...;VISUALFORCE,FINER;..', 'line1', 'line2']);
+    getFileSizeSpy = jest.spyOn(LogContextUtil.prototype, 'getFileSize').mockResolvedValue(123);
     shouldTraceLogFileStub = jest.fn().mockReturnValue(true);
     printToDebugConsoleSpy = jest.spyOn(ApexReplayDebug.prototype, 'printToDebugConsole').mockImplementation(() => {});
     revertStateAfterHeapDumpSpy = jest.spyOn(LogContext.prototype, 'revertStateAfterHeapDump');
-    context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+    context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
   });
 
   afterEach(() => {
@@ -94,22 +94,22 @@ describe('LogContext', () => {
     expect(context.hasLogLines()).toBe(true);
   });
 
-  it('Should not have log lines', () => {
+  it('Should not have log lines', async () => {
     readLogFileSpy.mockRestore();
-    readLogFileSpy = jest.spyOn(LogContextUtil.prototype, 'readLogFile').mockReturnValue([]);
-    context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+    readLogFileSpy = jest.spyOn(LogContextUtil.prototype, 'readLogFile').mockResolvedValue([]);
+    context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
 
     expect(context.hasLogLines()).toBe(false);
   });
 
-  it('Should detect log level requirements', () => {
+  it('Should detect log level requirements', async () => {
     expect(context.meetsLogLevelRequirements()).toBe(true);
 
     readLogFileSpy.mockRestore();
     readLogFileSpy = jest
       .spyOn(LogContextUtil.prototype, 'readLogFile')
-      .mockReturnValue(['43.0 APEX_CODE,DEBUG;...;VISUALFORCE,DEBUG;..', 'line1', 'line2']);
-    context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+      .mockResolvedValue(['43.0 APEX_CODE,DEBUG;...;VISUALFORCE,DEBUG;..', 'line1', 'line2']);
+    context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
 
     expect(context.meetsLogLevelRequirements()).toBe(false);
   });
@@ -152,13 +152,13 @@ describe('LogContext', () => {
     expect(context.hasState()).toBe(true);
   });
 
-  it('Should pause parsing the log', () => {
+  it('Should pause parsing the log', async () => {
     readLogFileSpy.mockRestore();
     // Provide two log lines to ensure two calls to printToDebugConsole
     readLogFileSpy = jest
       .spyOn(LogContextUtil.prototype, 'readLogFile')
-      .mockReturnValue(['43.0 APEX_CODE,FINEST;...;VISUALFORCE,FINER;..', 'line1', 'line2']);
-    context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+      .mockResolvedValue(['43.0 APEX_CODE,FINEST;...;VISUALFORCE,FINER;..', 'line1', 'line2']);
+    context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
     jest.spyOn(context.getSession(), 'shouldTraceLogFile').mockReturnValue(true);
     let call = 0;
     jest.spyOn(NoOpState.prototype, 'handle').mockImplementation(() => {
@@ -175,30 +175,30 @@ describe('LogContext', () => {
     expect(printToDebugConsoleSpy).toHaveBeenCalledTimes(2);
   });
 
-  it('Should revert state if there is a heapdump', () => {
+  it('Should revert state if there is a heapdump', async () => {
     jest.spyOn(LogContext.prototype, 'hasHeapDump').mockReturnValue(true);
-    context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+    context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
     context.updateFrames();
     expect(revertStateAfterHeapDumpSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('Should not revert state if there is no heapdump', () => {
+  it('Should not revert state if there is no heapdump', async () => {
     jest.spyOn(LogContext.prototype, 'hasHeapDump').mockReturnValue(false);
-    context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+    context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
     context.updateFrames();
     expect(revertStateAfterHeapDumpSpy).toHaveBeenCalledTimes(0);
   });
 
-  it('Should detect and parse HEAP_DUMP log entries', () => {
+  it('Should detect and parse HEAP_DUMP log entries', async () => {
     readLogFileSpy.mockRestore();
     readLogFileSpy = jest
       .spyOn(LogContextUtil.prototype, 'readLogFile')
-      .mockReturnValue([
+      .mockResolvedValue([
         '43.0 APEX_CODE,FINEST;...;VISUALFORCE,FINER;..',
         '<TimeInfo>|HEAP_DUMP|[11]|<HeapDumpId1>|<ClassName1>|<Namespace1>|11',
         '<TimeInfo>|HEAP_DUMP|[22]|<HeapDumpId2>|<ClassName2>|<Namespace2>|22'
       ]);
-    context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+    context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
     expect(context.scanLogForHeapDumpLines()).toBe(true);
     expect(context.hasHeapDump()).toBe(true);
     const apexHeapDumps = context.getHeapDumps();
@@ -213,43 +213,43 @@ describe('LogContext', () => {
     expect(apexHeapDumps[1].getLine()).toBe(22);
   });
 
-  it('Should not find heapdump with incorrect line', () => {
+  it('Should not find heapdump with incorrect line', async () => {
     readLogFileSpy.mockRestore();
     readLogFileSpy = jest
       .spyOn(LogContextUtil.prototype, 'readLogFile')
-      .mockReturnValue([
+      .mockResolvedValue([
         '43.0 APEX_CODE,FINEST;...;VISUALFORCE,FINER;..',
         '<TimeInfo>|HEAP_DUMP|[11]|<HeapDumpId1>|ClassName1|Namespace1|11'
       ]);
 
-    context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+    context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
 
     expect(context.scanLogForHeapDumpLines()).toBe(true);
     const heapdump = context.getHeapDumpForThisLocation('ClassName1', 22);
     expect(heapdump).toBeUndefined();
   });
 
-  it('Should not find heapdump with incorrect class name', () => {
+  it('Should not find heapdump with incorrect class name', async () => {
     readLogFileSpy.mockRestore();
     readLogFileSpy = jest
       .spyOn(LogContextUtil.prototype, 'readLogFile')
-      .mockReturnValue([
+      .mockResolvedValue([
         '43.0 APEX_CODE,FINEST;...;VISUALFORCE,FINER;..',
         '<TimeInfo>|HEAP_DUMP|[11]|<HeapDumpId1>|ClassName1|Namespace1|11'
       ]);
 
-    context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+    context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
 
     expect(context.scanLogForHeapDumpLines()).toBe(true);
     const heapdump = context.getHeapDumpForThisLocation('ClassName2', 11);
     expect(heapdump).toBeUndefined();
   });
 
-  it('Should have heapdump for top frame', () => {
+  it('Should have heapdump for top frame', async () => {
     readLogFileSpy.mockRestore();
     readLogFileSpy = jest
       .spyOn(LogContextUtil.prototype, 'readLogFile')
-      .mockReturnValue([
+      .mockResolvedValue([
         '43.0 APEX_CODE,FINEST;...;VISUALFORCE,FINER;..',
         `<TimeInfo>|${EVENT_HEAP_DUMP}|[11]|<HeapDumpId1>|ClassName1|Namespace1|11`
       ]);
@@ -257,18 +257,20 @@ describe('LogContext', () => {
       name: 'ClassName1',
       line: 11
     } as StackFrame);
-    context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+    context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
+    // Set initial state so parseLogEvent can process the heap dump event
     context.setState(new LogEntryState());
+    // Scan for heap dumps and parse the log event to set lastSeenHeapDumpClass and lastSeenHeapDumpLine
+    context.scanLogForHeapDumpLines();
     context.parseLogEvent(`<TimeInfo>|${EVENT_HEAP_DUMP}|[11]|<HeapDumpId1>|ClassName1|Namespace1|11`);
-    expect(context.scanLogForHeapDumpLines()).toBe(true);
     expect(context.hasHeapDumpForTopFrame()).toBe('<HeapDumpId1>');
   });
 
-  it('Should not have heapdump for top frame', () => {
+  it('Should not have heapdump for top frame', async () => {
     readLogFileSpy.mockRestore();
     readLogFileSpy = jest
       .spyOn(LogContextUtil.prototype, 'readLogFile')
-      .mockReturnValue([
+      .mockResolvedValue([
         '43.0 APEX_CODE,FINEST;...;VISUALFORCE,FINER;..',
         `<TimeInfo>|${EVENT_HEAP_DUMP}|[11]|<HeapDumpId1>|ClassName1|Namespace1|11`
       ]);
@@ -276,16 +278,13 @@ describe('LogContext', () => {
       name: 'ClassName1',
       line: 22
     } as StackFrame);
-    context = new LogContext(launchRequestArgs, new ApexReplayDebug());
-    context.setState(new LogEntryState());
-    context.parseLogEvent(`<TimeInfo>|${EVENT_HEAP_DUMP}|[11]|<HeapDumpId1>|ClassName1|Namespace1|11`);
-    expect(context.scanLogForHeapDumpLines()).toBe(true);
+    context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
     expect(context.hasHeapDumpForTopFrame()).toBeUndefined();
   });
 
   describe('Log event parser', () => {
-    beforeEach(() => {
-      context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+    beforeEach(async () => {
+      context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
     });
 
     it('Should detect LogEntry as the first state', () => {

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/core/logContextUtil.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/core/logContextUtil.test.ts
@@ -5,8 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import * as path from 'node:path';
+import * as vscode from 'vscode';
 import { LogContextUtil } from '../../../src/core/logContextUtil';
+
+jest.mock('vscode');
 
 describe('Log context utilities', () => {
   describe('Read log file', () => {
@@ -14,20 +16,29 @@ describe('Log context utilities', () => {
 
     beforeEach(() => {
       util = new LogContextUtil();
+      jest.clearAllMocks();
     });
 
-    it('Should return empty array with bad log file', () => {
-      expect(util.readLogFile('foo.log')).toHaveLength(0);
+    it('Should return empty array with bad log file', async () => {
+      (vscode.workspace.fs.readFile as jest.Mock).mockRejectedValue(new Error('File not found'));
+      const result = await util.readLogFile('foo.log');
+      expect(result).toHaveLength(0);
     });
 
-    it('Should return array of log lines', () => {
-      const logFilePath = path.join(__dirname, '..', '..', 'integration', 'config', 'logs', 'recursive.log');
-      expect(util.readLogFile(logFilePath)).not.toHaveLength(0);
+    it('Should return array of log lines', async () => {
+      const mockContent = Buffer.from('line1\nline2\nline3', 'utf8');
+      (vscode.workspace.fs.readFile as jest.Mock).mockResolvedValue(mockContent);
+      const result = await util.readLogFile('test.log');
+      expect(result).not.toHaveLength(0);
+      expect(result).toEqual(['line1', 'line2', 'line3']);
     });
 
-    it('Should get file size', () => {
-      const logFilePath = path.join(__dirname, '..', '..', 'integration', 'config', 'logs', 'recursive.log');
-      expect(util.getFileSize(logFilePath)).toBeGreaterThan(0);
+    it('Should get file size', async () => {
+      const mockFileStat = { size: 123 };
+      (vscode.workspace.fs.stat as jest.Mock).mockResolvedValue(mockFileStat as vscode.FileStat);
+      const result = await util.getFileSize('test.log');
+      expect(result).toBeGreaterThan(0);
+      expect(result).toBe(123);
     });
 
     it('Should strip brackets', () => {

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/states/frameEntryState.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/states/frameEntryState.test.ts
@@ -49,9 +49,9 @@ describe('Frame entry event', () => {
     getStaticMapStub.mockRestore();
   });
 
-  it('Should add a frame', () => {
+  it('Should add a frame', async () => {
     const state = new FrameEntryState(['signature']);
-    const context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+    const context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
     context.getFrames().push({ id: 0, name: 'execute_anonymous_apex' } as StackFrame);
 
     expect(state.handle(context)).toBe(false);
@@ -73,9 +73,9 @@ describe('Frame entry event', () => {
     expect(context.getStaticVariablesClassMap().get('signature')!.size).toBe(0);
   });
 
-  it('Should parse the class name from method signature and add it to static variable map', () => {
+  it('Should parse the class name from method signature and add it to static variable map', async () => {
     const state = new FrameEntryState(['className.method']);
-    const context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+    const context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
     context.getFrames().push({ id: 0, name: 'execute_anonymous_apex' } as StackFrame);
 
     expect(state.handle(context)).toBe(false);
@@ -97,9 +97,9 @@ describe('Frame entry event', () => {
     expect(context.getStaticVariablesClassMap().get('className')!.size).toBe(0);
   });
 
-  it('Should use existing static variables when the entry is for a class that was seen earlier', () => {
+  it('Should use existing static variables when the entry is for a class that was seen earlier', async () => {
     const state = new FrameEntryState(['previousClass.seenBefore']);
-    const context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+    const context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
     context.getFrames().push({ id: 0, name: 'execute_anonymous_apex' } as StackFrame);
 
     expect(state.handle(context)).toBe(false);

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/states/frameExitState.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/states/frameExitState.test.ts
@@ -30,8 +30,8 @@ describe('Frame exit event', () => {
     projectPath: undefined
   };
 
-  beforeEach(() => {
-    context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+  beforeEach(async () => {
+    context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
   });
 
   it('Should not remove anything if there are no frames', () => {

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/states/logEntryState.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/states/logEntryState.test.ts
@@ -23,15 +23,15 @@ describe('LogEntry event', () => {
   let readLogFileStub: jest.SpyInstance;
 
   beforeEach(() => {
-    readLogFileStub = jest.spyOn(LogContextUtil.prototype, 'readLogFile').mockReturnValue(['line1', 'line2']);
+    readLogFileStub = jest.spyOn(LogContextUtil.prototype, 'readLogFile').mockResolvedValue(['line1', 'line2']);
   });
 
   afterEach(() => {
     readLogFileStub.mockRestore();
   });
 
-  it('Should handle event', () => {
-    const context = new LogContext(
+  it('Should handle event', async () => {
+    const context = await LogContext.create(
       {
         logFile: '/path/foo.log',
         stopOnEntry: true,

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/states/noOpState.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/states/noOpState.test.ts
@@ -20,8 +20,8 @@ import { LogContext } from '../../../src/core';
 import { NoOpState } from '../../../src/states';
 
 describe('NoOp event', () => {
-  it('Should handle event', () => {
-    const context = new LogContext(
+  it('Should handle event', async () => {
+    const context = await LogContext.create(
       {
         logFile: '/path/foo.log',
         trace: true

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/states/statementExecuteState.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/states/statementExecuteState.test.ts
@@ -31,8 +31,8 @@ describe('Statement execute event', () => {
     projectPath: undefined
   };
 
-  beforeEach(() => {
-    context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+  beforeEach(async () => {
+    context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
   });
 
   it('Should not update frame without any frames', () => {

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/states/userDebugState.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/states/userDebugState.test.ts
@@ -34,8 +34,8 @@ describe('User debug event', () => {
     projectPath: undefined
   };
 
-  beforeEach(() => {
-    context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+  beforeEach(async () => {
+    context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
     warnToDebugConsoleStub = jest.spyOn(ApexReplayDebug.prototype, 'warnToDebugConsole');
     getLogLinesStub = jest
       .spyOn(LogContext.prototype, 'getLogLines')

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/states/variableAssignmentState.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/states/variableAssignmentState.test.ts
@@ -40,10 +40,10 @@ describe('Variable assignment event', () => {
     const STATIC_PRIMITIVE_VARIABLE_ASSIGNMENT = 'fakeTime|VARIABLE_ASSIGNMENT|[5]|signature.staticInteger|5';
     const LOCAL_PRIMITIVE_VARIABLE_ASSIGNMENT = 'fakeTime|VARIABLE_ASSIGNMENT|[5]|localInteger|0';
 
-    beforeEach(() => {
+    beforeEach(async () => {
       // push frames on
       const state = new FrameEntryState(['signature']);
-      context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+      context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
       context.getFrames().push({ id: 0, name: 'execute_anonymous_apex' } as StackFrame);
       expect(state.handle(context)).toBe(false);
 
@@ -104,10 +104,10 @@ describe('Variable assignment event', () => {
     const LOCAL_NESTED_JSON_VARIABLE_ASSIGNMENT = `fakeTime|VARIABLE_ASSIGNMENT|[8]|this|{"a":"0x37e2e22e","b1":BLOB(5 bytes),"b2":BLOB(50 bytes),"d":3.14,"m":"0xff6e2ff","s":"MyObject.s"}|${DUMMY_REF}`;
     const LOCAL_NESTED_INNER_VARIABLE_ASSIGNMENT = `fakeTime|VARIABLE_ASSIGNMENT|[12]|this.s|"MyObject.s"|${DUMMY_REF}`;
     const LOCAL_NESTED_JSON_INNER_VARIABLE_ASSIGNMENT = `fakeTime|VARIABLE_ASSIGNMENT|[10]|this.a|{"Name":"MyObjectAccount"}|${DUMMY_REF}`;
-    beforeEach(() => {
+    beforeEach(async () => {
       // push frames on
       const state = new FrameEntryState(['signature']);
-      context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+      context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
       context.getFrames().push({ id: 0, name: 'execute_anonymous_apex' } as StackFrame);
       expect(state.handle(context)).toBe(false);
       // add begin states for a local and static variable
@@ -244,10 +244,10 @@ describe('Variable assignment event', () => {
     const STATIC_NESTED_REASSIGNMENT2 = `04:35:37.25 (28667298)|VARIABLE_ASSIGNMENT|[11]|NestedClass.staticAcc2|{"Name":"staticacc1"}|${DUMMY_REF1}`;
     const STATIC_NESTED_REASSIGNMENT3 = `04:35:37.25 (30077406)|VARIABLE_ASSIGNMENT|[16]|NestedClass.staticAcc1|{"Name":"changed in method1"}|${DUMMY_REF2}`;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       // push frames on
       const state = new FrameEntryState(['signature']);
-      context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+      context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
       context.getFrames().push({ id: 0, name: 'execute_anonymous_apex' } as StackFrame);
       expect(state.handle(context)).toBe(false);
       // add begin states for a local and static variable
@@ -353,10 +353,10 @@ describe('Variable assignment event', () => {
     const PARENT_VARIABLE_ASSIGNMENT = `fakeTime|VARIABLE_ASSIGNMENT|[10]|this.m|${CHILD_REF}|${PARENT_REF}`;
     const PARENT_VARIABLE_ASSIGNMENT2 = `fakeTime|VARIABLE_ASSIGNMENT|[10]|this.n|${CHILD_REF}|${PARENT_REF}`;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       // push frames on
       const state = new FrameEntryState(['signature']);
-      context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+      context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
       context.getFrames().push({ id: 0, name: 'execute_anonymous_apex' } as StackFrame);
       expect(state.handle(context)).toBe(false);
       // add begin states for a local and static variable
@@ -435,10 +435,10 @@ describe('Variable assignment event', () => {
     const SET_BEGIN = '09:43:08.67 (107041268)|VARIABLE_SCOPE_BEGIN|[30]|aset|Set<MyObject>|true|false';
     const SET_ASSIGNMENT = `09:43:08.67 (107119928)|VARIABLE_ASSIGNMENT|[30]|aset|${SET_VALUE}|${DUMMY_REF3}`;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       // push frames on
       const state = new FrameEntryState(['signature']);
-      context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+      context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
       context.getFrames().push({ id: 0, name: 'execute_anonymous_apex' } as StackFrame);
       expect(state.handle(context)).toBe(false);
       getUriFromSignatureStub = jest

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/states/variableBeginState.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/states/variableBeginState.test.ts
@@ -50,9 +50,9 @@ describe('Variable begin scope event', () => {
     getStaticMapStub.mockRestore();
   });
 
-  it('Should add static variable to frame', () => {
+  it('Should add static variable to frame', async () => {
     const entryState = new VariableBeginState(STATIC_VARIABLE_LOG_LINE.split('|'));
-    const context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+    const context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
     context.getFrames().push({ id: 0, name: 'execute_anonymous_apex' } as StackFrame);
 
     expect(entryState.handle(context)).toBe(false);
@@ -61,9 +61,9 @@ describe('Variable begin scope event', () => {
     expect(context.getStaticVariablesClassMap().get('fakeClass')?.has('staticInteger')).toBe(true);
   });
 
-  it('Should add local variable to frame', () => {
+  it('Should add local variable to frame', async () => {
     const state = new FrameEntryState(['signature']);
-    const context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+    const context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
     context.getFrames().push({ id: 0, name: 'execute_anonymous_apex' } as StackFrame);
 
     expect(state.handle(context)).toBe(false);
@@ -94,9 +94,9 @@ describe('Variable begin scope event', () => {
     });
   });
 
-  it('Should create class entry in static variable map when class has not been seen before', () => {
+  it('Should create class entry in static variable map when class has not been seen before', async () => {
     const entryState = new VariableBeginState(STATIC_VARIABLE_LOG_LINE.split('|'));
-    const context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+    const context = await LogContext.create(launchRequestArgs, new ApexReplayDebug());
     context.getFrames().push({ id: 0, name: 'execute_anonymous_apex' } as StackFrame);
 
     expect(entryState.handle(context)).toBe(false);

--- a/packages/salesforcedx-apex-replay-debugger/tsconfig.json
+++ b/packages/salesforcedx-apex-replay-debugger/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.common.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "out",
+    "outDir": "out"
   },
   "exclude": [
     "node_modules",
@@ -11,7 +11,10 @@
   ],
   "references": [
     {
-      "path": "../salesforcedx-utils" 
+      "path": "../salesforcedx-utils"
+    },
+    {
+      "path": "../salesforcedx-utils-vscode"
     }
   ]
 }

--- a/packages/salesforcedx-utils-vscode/src/commands/preconditionCheckers.ts
+++ b/packages/salesforcedx-utils-vscode/src/commands/preconditionCheckers.ts
@@ -7,7 +7,7 @@
 
 import * as path from 'node:path';
 import { workspace } from 'vscode';
-import { fileOrFolderExists } from '../helpers/fs';
+import { fileOrFolderExists } from '../helpers';
 import { nls } from '../messages';
 import { Predicate, PredicateResponse } from '../predicates';
 import { PreconditionChecker, SFDX_PROJECT_FILE } from '../types';

--- a/packages/salesforcedx-utils-vscode/src/helpers/activationTrackerUtils.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/activationTrackerUtils.ts
@@ -10,7 +10,7 @@ import { EOL } from 'node:os';
 import { join, sep } from 'node:path';
 import { ExtensionContext, extensions, Uri } from 'vscode';
 import { z } from 'zod';
-import { readFile } from './fs';
+import { readFile } from './index';
 
 type ParsedLog = {
   dateTime: Date;
@@ -110,8 +110,8 @@ export const getExtensionHostLogActivationRecords = async (
 
   const pid =
     sessionStartMatches.groups &&
-      'pid' in sessionStartMatches.groups &&
-      typeof sessionStartMatches.groups.pid === 'string'
+    'pid' in sessionStartMatches.groups &&
+    typeof sessionStartMatches.groups.pid === 'string'
       ? sessionStartMatches.groups.pid
       : undefined;
 

--- a/packages/salesforcedx-utils-vscode/src/helpers/fs.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/fs.ts
@@ -52,6 +52,36 @@ export const fileOrFolderExists = async (filePath: string): Promise<boolean> => 
 };
 
 /**
+ * Checks if a path is a directory
+ * @param path The path to check
+ * @returns True if the path exists and is a directory, false otherwise
+ */
+export const isDirectory = async (path: string): Promise<boolean> => {
+  try {
+    const uri = URI.file(path);
+    const fileStat = await vscode.workspace.fs.stat(uri);
+    return fileStat.type === vscode.FileType.Directory;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Checks if a path is a file
+ * @param path The path to check
+ * @returns True if the path exists and is a file, false otherwise
+ */
+export const isFile = async (path: string): Promise<boolean> => {
+  try {
+    const uri = URI.file(path);
+    const fileStat = await vscode.workspace.fs.stat(uri);
+    return fileStat.type === vscode.FileType.File;
+  } catch {
+    return false;
+  }
+};
+
+/**
  * Creates a directory recursively.  Will not throw if the directory already exists.
  * @param dirPath The path to the directory
  */
@@ -137,5 +167,22 @@ export const ensureCurrentWorkingDirIsProjectPath = async (rootWorkspacePath: st
     } catch {
       // Path doesn't exist, do nothing
     }
+  }
+};
+
+/**
+ * Renames or moves a file or directory
+ * @param oldPath The current path of the file or directory
+ * @param newPath The new path for the file or directory
+ */
+export const rename = async (oldPath: string, newPath: string): Promise<void> => {
+  try {
+    const oldUri = URI.file(oldPath);
+    const newUri = URI.file(newPath);
+    await vscode.workspace.fs.rename(oldUri, newUri);
+  } catch (error) {
+    throw new Error(
+      `Failed to rename ${oldPath} to ${newPath}: ${error instanceof Error ? error.message : String(error)}`
+    );
   }
 };

--- a/packages/salesforcedx-utils-vscode/src/helpers/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/index.ts
@@ -13,8 +13,11 @@ export {
   deleteFile,
   ensureCurrentWorkingDirIsProjectPath,
   fileOrFolderExists,
+  isDirectory,
+  isFile,
   readDirectory,
   readFile,
+  rename,
   safeDelete,
   stat,
   writeFile

--- a/packages/salesforcedx-utils-vscode/src/helpers/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/index.ts
@@ -8,6 +8,7 @@
 export { ActivationTracker } from './activationTracker';
 export { isSFContainerMode } from './env';
 export * from './extensionUris';
+// eslint-disable-next-line no-restricted-imports
 export {
   createDirectory,
   deleteFile,

--- a/packages/salesforcedx-utils-vscode/src/helpers/paths.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/paths.ts
@@ -10,7 +10,7 @@ import * as path from 'node:path';
 import { URI } from 'vscode-uri';
 import { WorkspaceContextUtil } from '..';
 import { workspaceUtils } from '../workspaces/workspaceUtils';
-import { createDirectory } from './fs';
+import { createDirectory } from './index';
 
 export const ORGS = 'orgs';
 export const METADATA = 'metadata';

--- a/packages/salesforcedx-utils-vscode/test/jest/helpers/fs.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/helpers/fs.test.ts
@@ -19,7 +19,7 @@ import {
   isDirectory,
   isFile,
   rename
-} from '../../../src/helpers/fs';
+} from '../../../src/helpers';
 
 jest.mock('vscode');
 const vscodeMocked = jest.mocked(vscode);

--- a/packages/salesforcedx-visualforce-language-server/package.json
+++ b/packages/salesforcedx-visualforce-language-server/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@salesforce/salesforcedx-visualforce-markup-language-server": "64.3.0",
+    "@salesforce/salesforcedx-utils-vscode": "64.3.0",
     "typescript": "5.8.3",
     "vscode-css-languageservice": "^2.1.9",
     "vscode-languageserver": "^9.0.1",

--- a/packages/salesforcedx-visualforce-language-server/test/jest/formatting.test.ts
+++ b/packages/salesforcedx-visualforce-language-server/test/jest/formatting.test.ts
@@ -5,6 +5,7 @@
 'use strict';
 
 import * as assert from 'node:assert';
+// eslint-disable-next-line no-restricted-imports
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 

--- a/packages/salesforcedx-visualforce-language-server/tsconfig.json
+++ b/packages/salesforcedx-visualforce-language-server/tsconfig.json
@@ -6,10 +6,17 @@
     "strict": false,
     "noImplicitAny": false
   },
-  "exclude": ["node_modules", ".vscode-test", "out"],
+  "exclude": [
+    "node_modules",
+    ".vscode-test",
+    "out"
+  ],
   "references": [
     {
       "path": "../salesforcedx-visualforce-markup-language-server"
+    },
+    {
+      "path": "../salesforcedx-utils-vscode"
     }
   ]
 }

--- a/packages/salesforcedx-vscode-apex-debugger/tsconfig.json
+++ b/packages/salesforcedx-vscode-apex-debugger/tsconfig.json
@@ -4,16 +4,20 @@
     "rootDir": ".",
     "outDir": "out"
   },
-  "exclude": ["node_modules", ".vscode-test", "out"],
+  "exclude": [
+    "node_modules",
+    ".vscode-test",
+    "out"
+  ],
   "references": [
     {
       "path": "../salesforcedx-apex-debugger"
     },
     {
-      "path": "../salesforcedx-utils-vscode"
+      "path": "../salesforcedx-utils"
     },
     {
-      "path": "../salesforcedx-utils"
+      "path": "../salesforcedx-utils-vscode"
     },
     {
       "path": "../salesforcedx-vscode-apex"

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/activation/getDialogStartingPath.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/activation/getDialogStartingPath.ts
@@ -6,17 +6,16 @@
  */
 
 import { LAST_OPENED_LOG_FOLDER_KEY } from '@salesforce/salesforcedx-apex-replay-debugger';
-import { projectPaths, workspaceUtils } from '@salesforce/salesforcedx-utils-vscode';
-import { existsSync } from 'node:fs';
+import { projectPaths, workspaceUtils, fileOrFolderExists } from '@salesforce/salesforcedx-utils-vscode';
 import * as vscode from 'vscode';
 import { URI } from 'vscode-uri';
 
-export const getDialogStartingPath = (extContext: vscode.ExtensionContext): URI | undefined => {
+export const getDialogStartingPath = async (extContext: vscode.ExtensionContext): Promise<URI | undefined> => {
   if (workspaceUtils.hasRootWorkspace()) {
     // If the user has already selected a document through getLogFileName then
     // use that path if it still exists.
     const pathToLastOpenedLogFolder = getLastOpenedLogFolder(extContext);
-    if (pathToLastOpenedLogFolder && folderExists(pathToLastOpenedLogFolder)) {
+    if (pathToLastOpenedLogFolder && (await folderExists(pathToLastOpenedLogFolder))) {
       const lastOpenedLogFolderUri = getUriFor(pathToLastOpenedLogFolder);
       return lastOpenedLogFolderUri;
     }
@@ -24,7 +23,7 @@ export const getDialogStartingPath = (extContext: vscode.ExtensionContext): URI 
     // same directory that the SFDX download logs command would download to
     // if it exists.
     const pathToWorkspaceLogsFolder = projectPaths.debugLogsFolder();
-    if (folderExists(pathToWorkspaceLogsFolder)) {
+    if (await folderExists(pathToWorkspaceLogsFolder)) {
       const workspaceLogsFolderUri = getUriFor(pathToWorkspaceLogsFolder);
       return workspaceLogsFolderUri;
     }
@@ -40,6 +39,6 @@ const getLastOpenedLogFolder = (extContext: vscode.ExtensionContext): string | u
   return pathToLastOpenedLogFolder;
 };
 
-const folderExists = (path: string): boolean => existsSync(path);
+const folderExists = async (path: string): Promise<boolean> => await fileOrFolderExists(path);
 
 const getUriFor = (path: string): URI => URI.file(path);

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
@@ -54,8 +54,8 @@ if (!salesforceCoreExtension) {
   throw new Error('Salesforce Core Extension not initialized');
 }
 
-const registerCommands = (): vscode.Disposable => {
-  const dialogStartingPathUri = getDialogStartingPath(extContext);
+const registerCommands = async (): Promise<vscode.Disposable> => {
+  const dialogStartingPathUri = await getDialogStartingPath(extContext);
   const promptForLogCmd = vscode.commands.registerCommand('extension.replay-debugger.getLogFileName', async () => {
     const fileUris: URI[] | undefined = await vscode.window.showOpenDialog({
       canSelectFiles: true,
@@ -162,7 +162,7 @@ export const activate = async (extensionContext: vscode.ExtensionContext) => {
   const extensionHRStart = process.hrtime();
 
   extContext = extensionContext;
-  const commands = registerCommands();
+  const commands = await registerCommands();
   const debugHandlers = registerDebugHandlers();
   const debugConfigProvider = vscode.debug.registerDebugConfigurationProvider(
     'apex-replay',

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/jest/activation/getDialogStartingPath.test.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/jest/activation/getDialogStartingPath.test.ts
@@ -7,43 +7,47 @@
 
 import { LAST_OPENED_LOG_FOLDER_KEY } from '@salesforce/salesforcedx-apex-replay-debugger';
 import { projectPaths, workspaceUtils } from '@salesforce/salesforcedx-utils-vscode';
-import * as fs from 'node:fs';
+import * as vscode from 'vscode';
 import { URI } from 'vscode-uri';
 import { getDialogStartingPath } from '../../../src/activation/getDialogStartingPath';
+
+jest.mock('vscode');
 
 describe('getDialogStartingPath', () => {
   const testPath = '/here/is/a/fake/path/to/';
   let hasRootWorkspaceStub: jest.SpyInstance;
   let mockGet: jest.SpyInstance;
   let mockExtensionContext: any;
-  let pathExistsMock: jest.SpyInstance;
   let vsCodeUriMock: jest.SpyInstance;
   let debugLogsFolderMock: jest.SpyInstance;
   let stateFolderMock: jest.SpyInstance;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     hasRootWorkspaceStub = jest.spyOn(workspaceUtils, 'hasRootWorkspace');
     mockGet = jest.fn();
     mockExtensionContext = {
       workspaceState: { get: mockGet }
     };
-    pathExistsMock = jest.spyOn(fs, 'existsSync').mockReturnValue(true);
     vsCodeUriMock = jest.spyOn(URI, 'file');
     debugLogsFolderMock = jest.spyOn(projectPaths, 'debugLogsFolder');
     stateFolderMock = jest.spyOn(projectPaths, 'stateFolder');
+
+    // Mock VSCode workspace.fs.stat to return directory type (exists)
+    (vscode.workspace.fs.stat as jest.Mock).mockResolvedValue({ type: vscode.FileType.Directory });
   });
 
-  it('Should return last opened log folder if present', () => {
+  it('Should return last opened log folder if present', async () => {
     hasRootWorkspaceStub.mockReturnValue(true);
     mockGet.mockReturnValue(testPath);
     vsCodeUriMock.mockReturnValue({ path: testPath } as URI);
 
     // Act
-    const dialogStartingPathUri = getDialogStartingPath(mockExtensionContext);
+    const dialogStartingPathUri = await getDialogStartingPath(mockExtensionContext);
 
     expect(hasRootWorkspaceStub).toHaveBeenCalled();
     expect(mockGet).toHaveBeenCalledWith(LAST_OPENED_LOG_FOLDER_KEY);
-    expect(pathExistsMock).toHaveBeenCalledWith(testPath);
+    expect(vscode.workspace.fs.stat).toHaveBeenCalled();
     expect(vsCodeUriMock).toHaveBeenCalledWith(testPath);
     expect((dialogStartingPathUri as URI).path).toEqual(testPath);
   });
@@ -58,11 +62,11 @@ describe('getDialogStartingPath', () => {
     } as URI);
 
     // Act
-    const dialogStartingPathUri = getDialogStartingPath(mockExtensionContext);
+    const dialogStartingPathUri = await getDialogStartingPath(mockExtensionContext);
 
     expect(hasRootWorkspaceStub).toHaveBeenCalled();
     expect(mockGet).toHaveBeenCalledWith(LAST_OPENED_LOG_FOLDER_KEY);
-    expect(pathExistsMock).toHaveBeenCalledWith(fakePathToDebugLogsFolder);
+    expect(vscode.workspace.fs.stat).toHaveBeenCalled();
     expect(vsCodeUriMock).toHaveBeenCalledWith(fakePathToDebugLogsFolder);
     expect((dialogStartingPathUri as URI).path).toEqual(fakePathToDebugLogsFolder);
   });
@@ -72,7 +76,8 @@ describe('getDialogStartingPath', () => {
     mockGet.mockReturnValue(undefined);
     const fakePathToDebugLogsFolder = 'path/to/debug/logs';
     debugLogsFolderMock.mockReturnValue(fakePathToDebugLogsFolder);
-    pathExistsMock.mockReturnValueOnce(false);
+    // Mock that the debug logs folder doesn't exist
+    (vscode.workspace.fs.stat as jest.Mock).mockRejectedValueOnce(new Error('Not found'));
     const fakePathToStateFolder = 'path/to/state';
     stateFolderMock.mockReturnValue(fakePathToStateFolder);
     vsCodeUriMock.mockReturnValue({
@@ -80,11 +85,11 @@ describe('getDialogStartingPath', () => {
     } as URI);
 
     // Act
-    const dialogStartingPathUri = getDialogStartingPath(mockExtensionContext);
+    const dialogStartingPathUri = await getDialogStartingPath(mockExtensionContext);
 
     expect(hasRootWorkspaceStub).toHaveBeenCalled();
     expect(mockGet).toHaveBeenCalledWith(LAST_OPENED_LOG_FOLDER_KEY);
-    expect(pathExistsMock).toHaveBeenCalledWith(fakePathToDebugLogsFolder);
+    expect(vscode.workspace.fs.stat).toHaveBeenCalled();
     expect(vsCodeUriMock).toHaveBeenCalledWith(fakePathToStateFolder);
     expect((dialogStartingPathUri as URI).path).toEqual(fakePathToStateFolder);
   });
@@ -94,7 +99,7 @@ describe('getDialogStartingPath', () => {
     mockGet.mockReturnValue(testPath);
 
     // Act
-    const dialogStartingPathUri = getDialogStartingPath(mockExtensionContext);
+    const dialogStartingPathUri = await getDialogStartingPath(mockExtensionContext);
 
     expect(dialogStartingPathUri as URI).toEqual(undefined);
   });

--- a/packages/salesforcedx-vscode-apex-replay-debugger/tsconfig.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/tsconfig.json
@@ -4,8 +4,16 @@
     "rootDir": ".",
     "outDir": "out"
   },
-  "exclude": ["node_modules", ".vscode-test", "out", "dist"],
-  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": [
+    "node_modules",
+    ".vscode-test",
+    "out",
+    "dist"
+  ],
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ],
   "references": [
     {
       "path": "../salesforcedx-apex-replay-debugger"
@@ -17,10 +25,10 @@
       "path": "../salesforcedx-utils-vscode"
     },
     {
-      "path": "../salesforcedx-vscode-core"
+      "path": "../salesforcedx-vscode-apex"
     },
     {
-      "path": "../salesforcedx-vscode-apex"
+      "path": "../salesforcedx-vscode-core"
     }
   ]
 }

--- a/packages/salesforcedx-vscode-apex/tsconfig.json
+++ b/packages/salesforcedx-vscode-apex/tsconfig.json
@@ -4,14 +4,23 @@
     "rootDir": ".",
     "outDir": "out"
   },
-  "include": ["src/**/*.ts", "src/oas/generationStrategy/*.json", "test/**/*.ts"],
-  "exclude": ["node_modules", ".vscode-test", "out", "dist"],
+  "include": [
+    "src/**/*.ts",
+    "src/oas/generationStrategy/*.json",
+    "test/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    ".vscode-test",
+    "out",
+    "dist"
+  ],
   "references": [
     {
-      "path": "../salesforcedx-utils-vscode"
+      "path": "../salesforcedx-utils"
     },
     {
-      "path": "../salesforcedx-utils"
+      "path": "../salesforcedx-utils-vscode"
     },
     {
       "path": "../salesforcedx-vscode-core"

--- a/packages/salesforcedx-vscode-core/src/commands/describeMetadata.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/describeMetadata.ts
@@ -5,12 +5,19 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { Command, CommandOutput, SfCommandBuilder } from '@salesforce/salesforcedx-utils';
-import { CliCommandExecution, CliCommandExecutor, workspaceUtils } from '@salesforce/salesforcedx-utils-vscode';
-import * as fs from 'node:fs';
+import {
+  CliCommandExecution,
+  CliCommandExecutor,
+  createDirectory,
+  workspaceUtils,
+  writeFile
+} from '@salesforce/salesforcedx-utils-vscode';
 import * as path from 'node:path';
 import { SfCommandletExecutor } from './util';
 
 class DescribeMetadataExecutor extends SfCommandletExecutor<string> {
+  private execution?: CliCommandExecution;
+
   public constructor() {
     super();
   }
@@ -23,7 +30,20 @@ class DescribeMetadataExecutor extends SfCommandletExecutor<string> {
       .build();
   }
 
-  public execute(): CliCommandExecution {
+  public execute(): void {
+    if (!this.execution) {
+      this.execution = this.createExecution();
+    }
+  }
+
+  public getExecution(): CliCommandExecution {
+    if (!this.execution) {
+      this.execution = this.createExecution();
+    }
+    return this.execution;
+  }
+
+  private createExecution(): CliCommandExecution {
     const startTime = process.hrtime();
     const execution = new CliCommandExecutor(this.build({}), {
       cwd: workspaceUtils.getRootWorkspacePath()
@@ -38,13 +58,13 @@ class DescribeMetadataExecutor extends SfCommandletExecutor<string> {
 
 export const describeMetadata = async (outputFolder: string): Promise<string> => {
   const describeMetadataExecutor = new DescribeMetadataExecutor();
-  const execution = describeMetadataExecutor.execute();
-  await fs.promises.mkdir(outputFolder, { recursive: true });
+  const execution = describeMetadataExecutor.getExecution();
+  await createDirectory(outputFolder);
 
   const filePath = path.join(outputFolder, 'metadataTypes.json');
 
   const cmdOutput = new CommandOutput();
   const result = await cmdOutput.getCmdResult(execution);
-  fs.writeFileSync(filePath, result);
+  await writeFile(filePath, result);
   return result;
 };

--- a/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/isvdebugging/bootstrapCmd.ts
@@ -4,19 +4,22 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { CommandOutput, Command, SfCommandBuilder } from '@salesforce/salesforcedx-utils';
+import { Command, CommandOutput, SfCommandBuilder } from '@salesforce/salesforcedx-utils';
 import {
   CancelResponse,
   CliCommandExecutor,
   CommandExecution,
   CompositeParametersGatherer,
   ContinueResponse,
+  createDirectory,
   ParametersGatherer,
+  ProgressNotification,
   projectPaths,
-  ProgressNotification
+  readFile,
+  safeDelete,
+  writeFile
 } from '@salesforce/salesforcedx-utils-vscode';
 import { SpawnOptions } from 'node:child_process';
-import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { URL } from 'node:url';
 import sanitize = require('sanitize-filename'); // NOTE: Do not follow the instructions in the Quick Fix to use the default import because that causes an error popup when you use Launch Extensions
@@ -162,7 +165,7 @@ export class IsvDebugBootstrapExecutor extends SfCommandletExecutor<{}> {
     const projectInstalledPackagesPath = path.join(projectPath, this.relativeInstalledPackagesPath);
 
     // remove any previous project at this path location
-    await fs.promises.rm(projectPath, { recursive: true, force: true });
+    await safeDelete(projectPath, { recursive: true });
     // 1: create project
     await this.executeCommand(
       this.buildCreateProjectCommand(response.data),
@@ -188,13 +191,9 @@ export class IsvDebugBootstrapExecutor extends SfCommandletExecutor<{}> {
     );
     try {
       const salesforceProjectJsonFile = path.join(projectPath, 'sfdx-project.json');
-      const salesforceProjectConfig = JSON.parse(
-        await fs.promises.readFile(salesforceProjectJsonFile, { encoding: 'utf-8' })
-      );
+      const salesforceProjectConfig = JSON.parse(await readFile(salesforceProjectJsonFile));
       salesforceProjectConfig.namespace = this.parseOrgNamespaceQueryResultJson(orgNamespaceInfoResponseJson);
-      await fs.promises.writeFile(salesforceProjectJsonFile, JSON.stringify(salesforceProjectConfig, null, 2), {
-        encoding: 'utf-8'
-      });
+      await writeFile(salesforceProjectJsonFile, JSON.stringify(salesforceProjectConfig, null, 2));
     } catch (error) {
       console.error(error);
       channelService.appendLine(nls.localize('error_updating_salesforce_project', error.toString()));
@@ -204,8 +203,8 @@ export class IsvDebugBootstrapExecutor extends SfCommandletExecutor<{}> {
 
     // 3a: create package.xml for downloading org apex
     try {
-      await fs.promises.mkdir(projectMetadataTempPath, { recursive: true });
-      await fs.promises.writeFile(
+      await createDirectory(projectMetadataTempPath);
+      await writeFile(
         apexRetrievePackageXmlPath,
         `<?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
@@ -217,8 +216,7 @@ export class IsvDebugBootstrapExecutor extends SfCommandletExecutor<{}> {
     <members>*</members>
     <name>ApexTrigger</name>
   </types>
-</Package>`,
-        { encoding: 'utf-8' }
+</Package>`
       );
     } catch (error) {
       console.error(error);
@@ -245,7 +243,7 @@ export class IsvDebugBootstrapExecutor extends SfCommandletExecutor<{}> {
     const packageInfos = this.parsePackageInstalledListJson(packagesJson);
 
     // 5a: create directory where packages are to be retrieved
-    await fs.promises.mkdir(projectInstalledPackagesPath, { recursive: true }); // .sfdx/tools/installed-packages
+    await createDirectory(projectInstalledPackagesPath); // .sfdx/tools/installed-packages
     const packageNames = packageInfos.map(entry => entry.name);
 
     // 5b: retrieve packages
@@ -264,10 +262,9 @@ export class IsvDebugBootstrapExecutor extends SfCommandletExecutor<{}> {
 
       // generate installed-package.json file
       try {
-        await fs.promises.writeFile(
+        await writeFile(
           path.join(projectInstalledPackagesPath, packageInfo.name.replaceAll('.', '-'), 'installed-package.json'),
-          JSON.stringify(packageInfo, null, 2),
-          { encoding: 'utf-8' }
+          JSON.stringify(packageInfo, null, 2)
         );
       } catch (error) {
         console.error(error);
@@ -279,7 +276,7 @@ export class IsvDebugBootstrapExecutor extends SfCommandletExecutor<{}> {
 
     // 5c: cleanup temp files
     try {
-      await fs.promises.rm(projectMetadataTempPath, { recursive: true, force: true });
+      await safeDelete(projectMetadataTempPath, { recursive: true });
     } catch (error) {
       console.error(error);
       channelService.appendLine(nls.localize('error_cleanup_temp_files', error.toString()));
@@ -291,8 +288,8 @@ export class IsvDebugBootstrapExecutor extends SfCommandletExecutor<{}> {
     channelService.appendLine(nls.localize('isv_debug_bootstrap_generate_launchjson'));
     try {
       const projectVsCodeFolder = path.join(projectPath, '.vscode');
-      await fs.promises.mkdir(projectVsCodeFolder, { recursive: true });
-      await fs.promises.writeFile(
+      await createDirectory(projectVsCodeFolder);
+      await writeFile(
         path.join(projectVsCodeFolder, 'launch.json'),
         // mostly duplicated from ApexDebuggerConfigurationProvider to avoid hard dependency from core to debugger module
         JSON.stringify(
@@ -313,8 +310,7 @@ export class IsvDebugBootstrapExecutor extends SfCommandletExecutor<{}> {
           },
           null,
           2
-        ),
-        { encoding: 'utf-8' }
+        )
       );
     } catch (error) {
       console.error(error);
@@ -378,7 +374,7 @@ class EnterForceIdeUri implements ParametersGatherer<ForceIdeUri> {
       if (typeof loginUrl !== 'string' || typeof sessionId !== 'string') {
         return nls.localize('parameter_gatherer_invalid_forceide_url');
       }
-    } catch (e) {
+    } catch {
       return nls.localize('parameter_gatherer_invalid_forceide_url');
     }
 

--- a/packages/salesforcedx-vscode-core/src/commands/projectGenerate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/projectGenerate.ts
@@ -10,10 +10,10 @@ import {
   CompositeParametersGatherer,
   ContinueResponse,
   ParametersGatherer,
-  PostconditionChecker
+  PostconditionChecker,
+  fileOrFolderExists
 } from '@salesforce/salesforcedx-utils-vscode';
 import { ProjectOptions, TemplateType } from '@salesforce/templates';
-import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { URI } from 'vscode-uri';
@@ -141,8 +141,7 @@ export class PathExistsChecker implements PostconditionChecker<ProjectNameAndPat
     inputs: ContinueResponse<ProjectNameAndPathAndTemplate> | CancelResponse
   ): Promise<ContinueResponse<ProjectNameAndPathAndTemplate> | CancelResponse> {
     if (inputs.type === 'CONTINUE') {
-      const pathExists = fs.existsSync(path.join(inputs.data.projectUri, `${inputs.data.projectName}/`));
-      if (!pathExists) {
+      if (!(await fileOrFolderExists(path.join(inputs.data.projectUri, `${inputs.data.projectName}/`)))) {
         return inputs;
       } else {
         const overwrite = await notificationService.showWarningMessage(

--- a/packages/salesforcedx-vscode-core/src/commands/refreshSObjects.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/refreshSObjects.ts
@@ -18,6 +18,7 @@ import {
   CancelResponse,
   ConfigUtil,
   ContinueResponse,
+  fileOrFolderExists,
   isSFContainerMode,
   LocalCommandExecution,
   notificationService,
@@ -28,7 +29,6 @@ import {
   SfWorkspaceChecker,
   WorkspaceContextUtil
 } from '@salesforce/salesforcedx-utils-vscode';
-import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { channelService } from '../channels';
@@ -186,7 +186,7 @@ export const initSObjectDefinitions = async (projectPath: string, isSettingEnabl
     const sobjectFolder = isSettingEnabled ? getSObjectsDirectory() : getStandardSObjectsDirectory();
     const refreshSource = isSettingEnabled ? 'startup' : 'startupmin';
 
-    if (!fs.existsSync(sobjectFolder)) {
+    if (!(await fileOrFolderExists(sobjectFolder))) {
       telemetryService.sendEventData('sObjectRefreshNotification', { type: refreshSource }, undefined);
       try {
         await refreshSObjects(refreshSource);

--- a/packages/salesforcedx-vscode-core/src/commands/renameLightningComponent.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/renameLightningComponent.ts
@@ -10,10 +10,11 @@ import {
   ContinueResponse,
   ParametersGatherer,
   notificationService,
-  LibraryCommandletExecutor
+  LibraryCommandletExecutor,
+  readDirectory,
+  rename
 } from '@salesforce/salesforcedx-utils-vscode';
 import { CreateUtil } from '@salesforce/templates';
-import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { URI } from 'vscode-uri';
@@ -95,25 +96,25 @@ const inputGuard = async (sourceFsPath: string, newName: string): Promise<string
 const renameComponent = async (sourceFsPath: string, newName: string): Promise<void> => {
   const componentPath = await getComponentPath(sourceFsPath);
   const componentName = getComponentName(componentPath);
-  const items = await fs.promises.readdir(componentPath);
+  const items = await readDirectory(componentPath);
   for (const item of items) {
     // only rename the file that has same name with component
     if (isNameMatch(item, componentName, componentPath)) {
       const newItem = item.replace(componentName, newName);
-      await fs.promises.rename(path.join(componentPath, item), path.join(componentPath, newItem));
+      await rename(path.join(componentPath, item), path.join(componentPath, newItem));
     }
     if (item === TEST_FOLDER) {
       const testFolderPath = path.join(componentPath, TEST_FOLDER);
-      const testFiles = await fs.promises.readdir(testFolderPath);
+      const testFiles = await readDirectory(testFolderPath);
       for (const file of testFiles) {
         if (isNameMatch(file, componentName, componentPath)) {
           const newFile = file.replace(componentName, newName);
-          await fs.promises.rename(path.join(testFolderPath, file), path.join(testFolderPath, newFile));
+          await rename(path.join(testFolderPath, file), path.join(testFolderPath, newFile));
         }
       }
     }
   }
   const newComponentPath = path.join(path.dirname(componentPath), newName);
-  await fs.promises.rename(componentPath, newComponentPath);
+  await rename(componentPath, newComponentPath);
   void notificationService.showWarningMessage(nls.localize(RENAME_WARNING));
 };

--- a/packages/salesforcedx-vscode-core/src/commands/templates/internalCommandUtils.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/internalCommandUtils.ts
@@ -8,10 +8,10 @@
 import {
   CancelResponse,
   ContinueResponse,
+  isDirectory,
   ParametersGatherer,
   PreconditionChecker
 } from '@salesforce/salesforcedx-utils-vscode';
-import * as fs from 'node:fs';
 import { Uri } from 'vscode';
 import { salesforceCoreSettings } from '../../settings';
 
@@ -29,9 +29,8 @@ export class FileInternalPathGatherer implements ParametersGatherer<{ outputdir:
 
   public async gather(): Promise<CancelResponse | ContinueResponse<{ outputdir: string }>> {
     const outputdir = this.filePath;
-    const isDir = fs.existsSync(outputdir) && fs.lstatSync(outputdir).isDirectory();
 
-    if (isDir) {
+    if (await isDirectory(outputdir)) {
       return { type: 'CONTINUE', data: { outputdir } };
     }
 

--- a/packages/salesforcedx-vscode-core/src/commands/util/commandletExecutor.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/commandletExecutor.ts
@@ -9,6 +9,6 @@ import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode';
 import * as vscode from 'vscode';
 
 export type CommandletExecutor<T> = {
-  execute(response: ContinueResponse<T>): void;
+  execute(response: ContinueResponse<T>): void | Promise<void>;
   readonly onDidFinishExecution?: vscode.Event<[number, number]>;
 };

--- a/packages/salesforcedx-vscode-core/src/commands/util/lwcAuraDuplicateComponentCheckers.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/lwcAuraDuplicateComponentCheckers.ts
@@ -5,8 +5,12 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { getMessageFromError, notificationService, PostconditionChecker } from '@salesforce/salesforcedx-utils-vscode';
-import * as fs from 'node:fs';
+import {
+  getMessageFromError,
+  notificationService,
+  PostconditionChecker,
+  readDirectory
+} from '@salesforce/salesforcedx-utils-vscode';
 import { nls } from '../../messages';
 import { ContinueOrCancel, getComponentName, getComponentPath, isContinue, OneOrMany } from '../../util';
 import { isComponentName, isDirFileNameSelection } from '../../util/types';
@@ -46,7 +50,7 @@ export class LwcAuraDuplicateComponentCheckerForRename implements PostconditionC
     try {
       const componentPath = await getComponentPath(this.sourceFsPath);
       await checkForDuplicateName(componentPath, name);
-      const items = await fs.promises.readdir(componentPath);
+      const items = await readDirectory(componentPath);
       await checkForDuplicateInComponent(componentPath, name, items);
       return { type: 'CONTINUE', data: inputs.data };
     } catch (error) {

--- a/packages/salesforcedx-vscode-core/src/commands/util/overwriteComponentPrompt.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/overwriteComponentPrompt.ts
@@ -5,8 +5,12 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { LocalComponent, PostconditionChecker, workspaceUtils } from '@salesforce/salesforcedx-utils-vscode';
-import { existsSync } from 'node:fs';
+import {
+  fileOrFolderExists,
+  LocalComponent,
+  PostconditionChecker,
+  workspaceUtils
+} from '@salesforce/salesforcedx-utils-vscode';
 import { join } from 'node:path';
 import { nls } from '../../messages';
 import { notificationService } from '../../notifications';
@@ -21,7 +25,19 @@ export class OverwriteComponentPrompt implements PostconditionChecker<OneOrMany>
       const { data } = inputs;
       // normalize data into a list when processing
       const componentsToCheck = data instanceof Array ? data : [data];
-      const foundComponents = componentsToCheck.filter(component => this.componentExists(component));
+
+      // Check which components exist using Promise.all
+      const componentExistenceResults = await Promise.all(
+        componentsToCheck.map(async component => ({
+          component,
+          exists: await this.componentExists(component)
+        }))
+      );
+
+      // Filter components that exist (any of their files exist)
+      const foundComponents = componentExistenceResults
+        .filter(result => result.exists.some(exists => exists))
+        .map(result => result.component);
 
       if (foundComponents.length > 0) {
         const toSkip = await this.promptOverwrite(foundComponents);
@@ -40,17 +56,19 @@ export class OverwriteComponentPrompt implements PostconditionChecker<OneOrMany>
     return { type: 'CANCEL' };
   }
 
-  private componentExists(component: LocalComponent) {
+  private async componentExists(component: LocalComponent) {
     const { fileName, type, outputdir } = component;
     const info = MetadataDictionary.getInfo(type);
     const pathStrategy = info ? info.pathStrategy : PathStrategyFactory.createDefaultStrategy();
-    return this.getFileExtensions(component).some(extension => {
-      const path = join(
-        workspaceUtils.getRootWorkspacePath(),
-        pathStrategy.getPathToSource(outputdir, fileName, extension)
-      );
-      return existsSync(path);
-    });
+    return await Promise.all(
+      this.getFileExtensions(component).map(async extension => {
+        const path = join(
+          workspaceUtils.getRootWorkspacePath(),
+          pathStrategy.getPathToSource(outputdir, fileName, extension)
+        );
+        return await fileOrFolderExists(path);
+      })
+    );
   }
 
   private getFileExtensions(component: LocalComponent) {

--- a/packages/salesforcedx-vscode-core/src/commands/util/sfCommandletExecutor.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/sfCommandletExecutor.ts
@@ -60,7 +60,7 @@ export abstract class SfCommandletExecutor<T> implements CommandletExecutor<T> {
     telemetryService.sendCommandEvent(logName, hrstart, properties, measurements);
   }
 
-  public execute(response: ContinueResponse<T>): void {
+  public execute(response: ContinueResponse<T>): void | Promise<void> {
     const startTime = process.hrtime();
     const cancellationTokenSource = new vscode.CancellationTokenSource();
     const cancellationToken = cancellationTokenSource.token;

--- a/packages/salesforcedx-vscode-core/src/commands/util/sfWorkspaceChecker.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/sfWorkspaceChecker.ts
@@ -11,8 +11,8 @@ import { notificationService } from '../../notifications';
 import { isSalesforceProjectOpened } from '../../predicates';
 
 export class SfWorkspaceChecker implements PreconditionChecker {
-  public check(): boolean {
-    const result = isSalesforceProjectOpened.apply(workspace);
+  public async check(): Promise<boolean> {
+    const result = await isSalesforceProjectOpened.apply(workspace);
     if (!result.result) {
       notificationService.showErrorMessage(result.message);
       return false;

--- a/packages/salesforcedx-vscode-core/src/commands/util/timestampConflictChecker.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/timestampConflictChecker.ts
@@ -62,7 +62,7 @@ export class TimestampConflictChecker implements PostconditionChecker<string> {
           this.isManifest
         );
         const detector = new TimestampConflictDetector();
-        const diffs = detector.createDiffs(result);
+        const diffs = await detector.createDiffs(result);
 
         channelService.showCommandWithTimestamp(
           `${nls.localize('channel_end')} ${nls.localize('conflict_detect_execution_name')}\n`

--- a/packages/salesforcedx-vscode-core/src/conflict/conflictUtils.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/conflictUtils.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { readFile } from '@salesforce/salesforcedx-utils-vscode';
+
+/**
+ * Compares two files to determine if they differ in content.
+ * Reads both files in parallel for better performance.
+ * @param one Path to the first file
+ * @param two Path to the second file
+ * @returns Promise<boolean> True if files differ, false if they are identical
+ */
+export const filesDiffer = async (one: string, two: string): Promise<boolean> => {
+  const [buffer1, buffer2] = await Promise.all([readFile(one), readFile(two)]);
+  return buffer1 !== buffer2;
+};

--- a/packages/salesforcedx-vscode-core/src/conflict/directoryDiffer.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/directoryDiffer.ts
@@ -5,8 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { readDirectory, isDirectory } from '@salesforce/salesforcedx-utils-vscode';
 import { SourceComponent } from '@salesforce/source-deploy-retrieve-bundle';
-import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { URI } from 'vscode-uri';
@@ -15,6 +15,7 @@ import { conflictView } from '../conflict';
 import { nls } from '../messages';
 import { notificationService } from '../notifications';
 import { telemetryService } from '../telemetry';
+import { filesDiffer } from './conflictUtils';
 import { MetadataCacheResult } from './metadataCacheService';
 
 export type TimestampFileProperties = {
@@ -33,7 +34,7 @@ export type DirectoryDiffResults = {
 };
 
 type DirectoryDiffer = {
-  diff(localSourcePath: string, remoteSourcePath: string): DirectoryDiffResults;
+  diff(localSourcePath: string, remoteSourcePath: string): Promise<DirectoryDiffResults>;
 };
 
 type FileStats = {
@@ -43,18 +44,18 @@ type FileStats = {
 };
 
 class CommonDirDirectoryDiffer implements DirectoryDiffer {
-  public diff(localSourcePath: string, remoteSourcePath: string): DirectoryDiffResults {
-    const localSet = this.listFiles(localSourcePath);
+  public async diff(localSourcePath: string, remoteSourcePath: string): Promise<DirectoryDiffResults> {
+    const localSet = await this.listFiles(localSourcePath);
     const different = new Set<TimestampFileProperties>();
 
     // process remote files to generate differences
     let scannedRemote = 0;
-    this.walkFiles(remoteSourcePath, '', stats => {
+    await this.walkFiles(remoteSourcePath, '', async stats => {
       scannedRemote++;
       if (localSet.has(stats.relPath)) {
         const file1 = path.join(localSourcePath, stats.relPath);
         const file2 = path.join(remoteSourcePath, stats.relPath);
-        if (this.filesDiffer(file1, file2)) {
+        if (await filesDiffer(file1, file2)) {
           different.add({
             localRelPath: stats.relPath,
             remoteRelPath: stats.relPath
@@ -72,43 +73,36 @@ class CommonDirDirectoryDiffer implements DirectoryDiffer {
     };
   }
 
-  private filesDiffer(one: string, two: string): boolean {
-    const buffer1 = fs.readFileSync(one);
-    const buffer2 = fs.readFileSync(two);
-    return !buffer1.equals(buffer2);
-  }
-
-  private listFiles(root: string): Set<string> {
+  private async listFiles(root: string): Promise<Set<string>> {
     const results = new Set<string>();
-    this.walkFiles(root, '', stats => {
+    await this.walkFiles(root, '', async stats => {
       results.add(stats.relPath);
     });
     return results;
   }
 
-  private walkFiles(root: string, subdir: string, callback: (stats: FileStats) => void) {
+  private async walkFiles(root: string, subdir: string, callback: (stats: FileStats) => Promise<void>) {
     const fullDir = path.join(root, subdir);
-    const subdirList = fs.readdirSync(fullDir);
+    const subdirList = await readDirectory(fullDir);
 
-    subdirList.forEach(filename => {
+    for (const filename of subdirList) {
       const fullPath = path.join(fullDir, filename);
-      const stat = fs.statSync(fullPath);
       const relPath = path.join(subdir, filename);
 
-      if (stat && stat.isDirectory()) {
-        this.walkFiles(root, relPath, callback);
+      if (await isDirectory(fullPath)) {
+        await this.walkFiles(root, relPath, callback);
       } else {
-        callback({ filename, subdir, relPath });
+        await callback({ filename, subdir, relPath });
       }
-    });
+    }
   }
 }
 
-export const diffFolder = (cache: MetadataCacheResult, username: string) => {
+export const diffFolder = async (cache: MetadataCacheResult, username: string): Promise<void> => {
   const localPath = path.join(cache.project.baseDirectory, cache.project.commonRoot);
   const remotePath = path.join(cache.cache.baseDirectory, cache.cache.commonRoot);
   const differ = new CommonDirDirectoryDiffer();
-  const diffs = differ.diff(localPath, remotePath);
+  const diffs = await differ.diff(localPath, remotePath);
 
   conflictView.visualizeDifferences(nls.localize('source_diff_folder_title', username), username, true, diffs, true);
 };

--- a/packages/salesforcedx-vscode-core/src/conflict/index.ts
+++ b/packages/salesforcedx-vscode-core/src/conflict/index.ts
@@ -14,6 +14,7 @@ import { ConflictView } from './conflictView';
 export { DirectoryDiffResults } from './directoryDiffer';
 export { MetadataCacheExecutor, MetadataCacheResult, MetadataCacheService, PathType } from './metadataCacheService';
 export { PersistentStorageService } from './persistentStorageService';
+export { filesDiffer } from './conflictUtils';
 export const conflictView = ConflictView.getInstance();
 
 export const setupConflictView = async (extensionContext: ExtensionContext): Promise<void> => {

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -425,7 +425,7 @@ export const activate = async (extensionContext: vscode.ExtensionContext): Promi
   }
 
   // Context
-  const salesforceProjectOpened = isSalesforceProjectOpened.apply(vscode.workspace).result;
+  const salesforceProjectOpened = (await isSalesforceProjectOpened.apply(vscode.workspace)).result;
 
   // TODO: move this and the replay debugger commands to the apex extension
   let replayDebuggerExtensionInstalled = false;

--- a/packages/salesforcedx-vscode-core/src/predicates/salesforcePredicates.ts
+++ b/packages/salesforcedx-vscode-core/src/predicates/salesforcePredicates.ts
@@ -5,18 +5,22 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Predicate, PredicateResponse, workspaceUtils } from '@salesforce/salesforcedx-utils-vscode';
-import * as fs from 'node:fs';
+import {
+  Predicate,
+  PredicateResponse,
+  fileOrFolderExists,
+  workspaceUtils
+} from '@salesforce/salesforcedx-utils-vscode';
 import * as path from 'node:path';
 import { workspace } from 'vscode';
 import { SFDX_PROJECT_FILE } from '../constants';
 import { nls } from '../messages';
 
 export class IsSalesforceProjectOpened implements Predicate<typeof workspace> {
-  public apply(item: typeof workspace): PredicateResponse {
+  public async apply(item: typeof workspace): Promise<PredicateResponse> {
     if (!workspaceUtils.hasRootWorkspace()) {
       return PredicateResponse.of(false, nls.localize('predicates_no_folder_opened_text'));
-    } else if (!fs.existsSync(path.join(workspaceUtils.getRootWorkspacePath(), SFDX_PROJECT_FILE))) {
+    } else if (!(await fileOrFolderExists(path.join(workspaceUtils.getRootWorkspacePath(), SFDX_PROJECT_FILE)))) {
       return PredicateResponse.of(false, nls.localize('predicates_no_salesforce_project_found_text'));
     } else {
       return PredicateResponse.true();

--- a/packages/salesforcedx-vscode-core/src/salesforceProject/salesforceProjectConfig.ts
+++ b/packages/salesforcedx-vscode-core/src/salesforceProject/salesforceProjectConfig.ts
@@ -26,7 +26,8 @@ export default class SalesforceProjectConfig {
   }
 
   private static async initializeSalesforceProjectConfig() {
-    if (!SalesforceProjectConfig.instance && isSalesforceProjectOpened.apply(vscode.workspace).result) {
+    const predicateResult = await isSalesforceProjectOpened.apply(vscode.workspace);
+    if (!SalesforceProjectConfig.instance && predicateResult.result) {
       const salesforceProjectPath = workspaceUtils.getRootWorkspacePath();
       try {
         const salesforceProject = await SfProject.resolve(salesforceProjectPath);

--- a/packages/salesforcedx-vscode-core/src/util/componentUtils.ts
+++ b/packages/salesforcedx-vscode-core/src/util/componentUtils.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import * as fs from 'node:fs';
+import { isFile } from '@salesforce/salesforcedx-utils-vscode';
 import * as path from 'node:path';
 
 export const LWC = 'lwc';
@@ -23,8 +23,7 @@ const getLightningComponentDirectory = (sourceFsPath: string): string => {
 };
 
 export const getComponentPath = async (sourceFsPath: string): Promise<string> => {
-  const stats = await fs.promises.stat(sourceFsPath);
-  let dirname = stats.isFile() ? path.dirname(sourceFsPath) : sourceFsPath;
+  let dirname = (await isFile(sourceFsPath)) ? path.dirname(sourceFsPath) : sourceFsPath;
   dirname = getLightningComponentDirectory(dirname);
   return dirname;
 };

--- a/packages/salesforcedx-vscode-core/test/jest/commands/deployExecutor.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/commands/deployExecutor.test.ts
@@ -6,7 +6,7 @@
  */
 import { ConfigUtil, ContinueResponse, SourceTrackingService } from '@salesforce/salesforcedx-utils-vscode';
 import { ComponentSet } from '@salesforce/source-deploy-retrieve-bundle';
-import * as fs from 'node:fs';
+import * as vscode from 'vscode';
 import { channelService } from '../../../src/channels';
 import { DeployExecutor, DeployRetrieveExecutor } from '../../../src/commands/baseDeployRetrieve';
 import { SfCommandletExecutor } from '../../../src/commands/util';
@@ -70,7 +70,7 @@ describe('Deploy Executor', () => {
 
   beforeEach(async () => {
     jest.spyOn(process, 'cwd').mockReturnValue(dummyProcessCwd);
-    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(vscode.workspace.fs, 'stat').mockResolvedValue({ type: vscode.FileType.File } as vscode.FileStat);
     jest.spyOn(WorkspaceContext, 'getInstance').mockReturnValue(mockWorkspaceContext);
     jest.spyOn(ConfigUtil, 'getUsername').mockResolvedValue(dummyUsername);
     getSourceTrackingSpy = jest.spyOn(SourceTrackingService, 'getSourceTracking').mockResolvedValue({

--- a/packages/salesforcedx-vscode-core/test/jest/commands/refreshSObjectsExecutor.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/commands/refreshSObjectsExecutor.test.ts
@@ -7,7 +7,7 @@
 
 import * as fauxGen from '@salesforce/salesforcedx-sobjects-faux-generator';
 import { ConfigUtil, LocalCommandExecution, WorkspaceContextUtil } from '@salesforce/salesforcedx-utils-vscode';
-import * as fs from 'node:fs';
+import * as vscode from 'vscode';
 import { channelService } from '../../../src/channels';
 import { RefreshSObjectsExecutor } from '../../../src/commands/refreshSObjects';
 import { SalesforceProjectConfig } from '../../../src/salesforceProject';
@@ -20,7 +20,7 @@ describe('RefreshSObjectsExecutor', () => {
 
     jest.spyOn(channelService, 'clear').mockImplementation(jest.fn());
     jest.spyOn(channelService, 'streamCommandOutput').mockImplementation(jest.fn());
-    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(vscode.workspace.fs, 'stat').mockResolvedValue({ type: vscode.FileType.File } as vscode.FileStat);
     jest.spyOn(ConfigUtil, 'getUserConfiguredApiVersion').mockResolvedValue(undefined);
     jest.spyOn(SalesforceProjectConfig, 'getValue').mockResolvedValue(undefined);
     jest.spyOn(WorkspaceContextUtil, 'getInstance').mockReturnValue({

--- a/packages/salesforcedx-vscode-core/test/jest/commands/retrieveExecutor.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/commands/retrieveExecutor.test.ts
@@ -6,7 +6,7 @@
  */
 import { ConfigUtil, ContinueResponse, SourceTrackingService } from '@salesforce/salesforcedx-utils-vscode';
 import { ComponentSet } from '@salesforce/source-deploy-retrieve-bundle';
-import * as fs from 'node:fs';
+import * as vscode from 'vscode';
 import { RetrieveExecutor } from '../../../src/commands/baseDeployRetrieve';
 import { OrgType, workspaceContextUtils } from '../../../src/context';
 import { WorkspaceContext } from '../../../src/context/workspaceContext';
@@ -49,7 +49,7 @@ describe('Retrieve Executor', () => {
 
   beforeEach(async () => {
     jest.spyOn(process, 'cwd').mockReturnValue(dummyProcessCwd);
-    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(vscode.workspace.fs, 'stat').mockResolvedValue({ type: vscode.FileType.File } as vscode.FileStat);
     jest.spyOn(ConfigUtil, 'getUsername').mockResolvedValue('test@username.com');
     workspaceContextGetInstanceSpy = jest.spyOn(WorkspaceContext, 'getInstance').mockReturnValue(mockWorkspaceContext);
     getSourceTrackingSpy = jest

--- a/packages/salesforcedx-vscode-core/test/jest/conflict/conflictUtils.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/conflict/conflictUtils.test.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as vscode from 'vscode';
+import { filesDiffer } from '../../../src/conflict/conflictUtils';
+
+describe('conflictUtils', () => {
+  let workspaceFsReadFileMock: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    workspaceFsReadFileMock = jest.spyOn(vscode.workspace.fs, 'readFile');
+  });
+
+  afterEach(() => {
+    workspaceFsReadFileMock.mockRestore();
+  });
+
+  describe('filesDiffer', () => {
+    it('should return true when files have different content', async () => {
+      const file1 = '/path/to/file1.txt';
+      const file2 = '/path/to/file2.txt';
+
+      workspaceFsReadFileMock
+        .mockResolvedValueOnce(Buffer.from('content1'))
+        .mockResolvedValueOnce(Buffer.from('content2'));
+
+      const result = await filesDiffer(file1, file2);
+
+      expect(result).toBe(true);
+      expect(workspaceFsReadFileMock).toHaveBeenCalledTimes(2);
+      expect(workspaceFsReadFileMock).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          path: file1,
+          scheme: 'file'
+        })
+      );
+      expect(workspaceFsReadFileMock).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          path: file2,
+          scheme: 'file'
+        })
+      );
+    });
+
+    it('should return false when files have identical content', async () => {
+      const file1 = '/path/to/file1.txt';
+      const file2 = '/path/to/file2.txt';
+      const content = 'identical content';
+
+      workspaceFsReadFileMock.mockResolvedValueOnce(Buffer.from(content)).mockResolvedValueOnce(Buffer.from(content));
+
+      const result = await filesDiffer(file1, file2);
+
+      expect(result).toBe(false);
+      expect(workspaceFsReadFileMock).toHaveBeenCalledTimes(2);
+      expect(workspaceFsReadFileMock).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          path: file1,
+          scheme: 'file'
+        })
+      );
+      expect(workspaceFsReadFileMock).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          path: file2,
+          scheme: 'file'
+        })
+      );
+    });
+
+    it('should handle empty files correctly', async () => {
+      const file1 = '/path/to/empty1.txt';
+      const file2 = '/path/to/empty2.txt';
+
+      workspaceFsReadFileMock.mockResolvedValueOnce(Buffer.from('')).mockResolvedValueOnce(Buffer.from(''));
+
+      const result = await filesDiffer(file1, file2);
+
+      expect(result).toBe(false);
+      expect(workspaceFsReadFileMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('should detect differences when one file is empty and the other is not', async () => {
+      const file1 = '/path/to/empty.txt';
+      const file2 = '/path/to/nonempty.txt';
+
+      workspaceFsReadFileMock.mockResolvedValueOnce(Buffer.from('')).mockResolvedValueOnce(Buffer.from('some content'));
+
+      const result = await filesDiffer(file1, file2);
+
+      expect(result).toBe(true);
+      expect(workspaceFsReadFileMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle binary content correctly', async () => {
+      const file1 = '/path/to/binary1.bin';
+      const file2 = '/path/to/binary2.bin';
+      const binary1 = Buffer.from([0x01, 0x02, 0x03]);
+      const binary2 = Buffer.from([0x01, 0x02, 0x04]);
+
+      workspaceFsReadFileMock.mockResolvedValueOnce(binary1).mockResolvedValueOnce(binary2);
+
+      const result = await filesDiffer(file1, file2);
+
+      expect(result).toBe(true);
+      expect(workspaceFsReadFileMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle large content efficiently with Promise.all', async () => {
+      const file1 = '/path/to/large1.txt';
+      const file2 = '/path/to/large2.txt';
+      const largeContent1 = 'a'.repeat(10000);
+      const largeContent2 = 'b'.repeat(10000);
+
+      workspaceFsReadFileMock
+        .mockResolvedValueOnce(Buffer.from(largeContent1))
+        .mockResolvedValueOnce(Buffer.from(largeContent2));
+
+      const startTime = Date.now();
+      const result = await filesDiffer(file1, file2);
+      const endTime = Date.now();
+
+      expect(result).toBe(true);
+      expect(workspaceFsReadFileMock).toHaveBeenCalledTimes(2);
+      // Both files should be read in parallel, so the total time should be roughly
+      // the time of one read operation, not two sequential reads
+      expect(endTime - startTime).toBeLessThan(100); // Should be very fast
+    });
+
+    it('should propagate readFile errors', async () => {
+      const file1 = '/path/to/file1.txt';
+      const file2 = '/path/to/file2.txt';
+      const error = new Error('File not found');
+
+      workspaceFsReadFileMock.mockRejectedValueOnce(error);
+
+      await expect(filesDiffer(file1, file2)).rejects.toThrow('File not found');
+      expect(workspaceFsReadFileMock).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          path: file1,
+          scheme: 'file'
+        })
+      );
+      expect(workspaceFsReadFileMock).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          path: file2,
+          scheme: 'file'
+        })
+      );
+    });
+
+    it('should handle case-sensitive string comparisons', async () => {
+      const file1 = '/path/to/file1.txt';
+      const file2 = '/path/to/file2.txt';
+
+      workspaceFsReadFileMock
+        .mockResolvedValueOnce(Buffer.from('Hello World'))
+        .mockResolvedValueOnce(Buffer.from('hello world'));
+
+      const result = await filesDiffer(file1, file2);
+
+      expect(result).toBe(true);
+      expect(workspaceFsReadFileMock).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/salesforcedx-vscode-core/test/jest/conflict/timestampConflictDetector.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/conflict/timestampConflictDetector.test.ts
@@ -34,11 +34,11 @@ describe('TimestampConflictDetector', () => {
       // Only return a diff for the first file, which should have tripped the timestamp check
       diffComponentsStub = jest
         .spyOn(diffUtils, 'diffComponents')
-        .mockReturnValueOnce(testData.dummyDiffs)
-        .mockReturnValueOnce([]);
+        .mockResolvedValueOnce(testData.dummyDiffs)
+        .mockResolvedValueOnce([]);
       const timestampConflictDetector = new TimestampConflictDetector();
 
-      const diffs = timestampConflictDetector.createDiffs(testData.dummyMetadataCacheResult as any);
+      const diffs = await timestampConflictDetector.createDiffs(testData.dummyMetadataCacheResult as any);
 
       expect(correlateResultsStub).toHaveBeenCalledWith(testData.dummyMetadataCacheResult);
       expect(persistentStorageServiceMock).toHaveBeenCalled();

--- a/packages/salesforcedx-vscode-lightning/test/jest/package/packageDependencies.test.ts
+++ b/packages/salesforcedx-vscode-lightning/test/jest/package/packageDependencies.test.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+// eslint-disable-next-line no-restricted-imports
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 

--- a/scripts/setup-jest.ts
+++ b/scripts/setup-jest.ts
@@ -133,7 +133,8 @@ const getMockVSCode = () => {
         createDirectory: jest.fn(),
         delete: jest.fn(),
         readFile: jest.fn(),
-        readDirectory: jest.fn()
+        readDirectory: jest.fn(),
+        rename: jest.fn()
       },
       registerTextDocumentContentProvider: jest.fn(),
       registerFileSystemProvider: jest.fn()


### PR DESCRIPTION
### What does this PR do?
This pull request introduces several significant changes to enhance the `salesforcedx-apex-replay-debugger` package by improving its compatibility with asynchronous operations, refactoring code for better maintainability, and ensuring web extension compatibility. Key updates include converting synchronous file operations to asynchronous, introducing factory methods for object creation, and updating tests accordingly.

### Code Refactoring and Asynchronous Enhancements:
* Refactored `LogContext` to use an asynchronous factory method `LogContext.create()` for initialization, replacing the synchronous constructor. Added an `initialize` method to handle asynchronous setup of `logLines` and `logSize`. (`packages/salesforcedx-apex-replay-debugger/src/core/logContext.ts`, [packages/salesforcedx-apex-replay-debugger/src/core/logContext.tsL81-R94](diffhunk://#diff-9b6681cb57e56576bb79c27f8d96c447cbb728225ac3cb6b1eed7c3702ddb467L81-R94))
* Updated `LogContextUtil` to replace synchronous file operations (`fs.readFileSync` and `fs.statSync`) with asynchronous equivalents (`readFile` and `stat`) from `@salesforce/salesforcedx-utils-vscode`. (`packages/salesforcedx-apex-replay-debugger/src/core/logContextUtil.ts`, [packages/salesforcedx-apex-replay-debugger/src/core/logContextUtil.tsL8-R23](diffhunk://#diff-5efe90fc16e67c6cbd7fb1ebd95985792b5bfcdd1cafe763d1381f0c6dbf7833L8-R23))
* Modified `GoldFileUtil` to use an asynchronous factory method `GoldFileUtil.create()` and updated its `close` method to be asynchronous. (`packages/salesforcedx-apex-replay-debugger/test/integration/goldFileUtil.ts`, [packages/salesforcedx-apex-replay-debugger/test/integration/goldFileUtil.tsR8-R31](diffhunk://#diff-9dc38902f30743d01c97ffbfa2b90c6bd5a3f46dd12fa98a681038af716553dbR8-R31))

### Test Updates:
* Updated unit tests to mock asynchronous methods like `LogContext.create` and replaced direct property stubs with mock objects for `LogContext`. (`packages/salesforcedx-apex-replay-debugger/test/unit/adapter/apexReplayDebug.test.ts`, [[1]](diffhunk://#diff-9c6e006787feec58f37ba272b6f83f2bd943268bcb9f36689a391f8304c62b86L129-R159) [[2]](diffhunk://#diff-9c6e006787feec58f37ba272b6f83f2bd943268bcb9f36689a391f8304c62b86L177-R191) [[3]](diffhunk://#diff-9c6e006787feec58f37ba272b6f83f2bd943268bcb9f36689a391f8304c62b86L203-R224)
* Adjusted integration tests to use the new asynchronous `GoldFileUtil.create` method. (`packages/salesforcedx-apex-replay-debugger/test/integration/adapter.test.ts`, [[1]](diffhunk://#diff-616f9ce48bac5d296a302e2df01a710ab9d27f12f48e7bd02bde8948af6bdeb5L77-R77) [[2]](diffhunk://#diff-616f9ce48bac5d296a302e2df01a710ab9d27f12f48e7bd02bde8948af6bdeb5L142-R142)

### Dependency and Configuration Updates:
* Added a new dependency on `@salesforce/salesforcedx-utils-vscode` in `package.json` to support asynchronous file operations. (`packages/salesforcedx-apex-replay-debugger/package.json`, [packages/salesforcedx-apex-replay-debugger/package.jsonR18](diffhunk://#diff-0cd496b2ba8248fd3a32b3bb652fa94e672f17a0b0d676aa1bf38d235a1d9164R18))
* Introduced an ESLint rule to restrict the use of Node.js `fs` module, promoting the use of VSCode's file system API for web extension compatibility. (`eslint.config.mjs`, [eslint.config.mjsR267-R278](diffhunk://#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2R267-R278))

### What issues does this PR fix or reference?
@ W-18488820@