### PR TITLE
fix: W-18939319 - manifest generation is cancelled when escaping

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/projectGenerateManifest.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/projectGenerateManifest.ts
@@ -28,8 +28,8 @@ const MANIFEST_SAVE_PROMPT = 'manifest_input_save_prompt';
 
 class GenerateManifestExecutor extends LibraryCommandletExecutor<string> {
   private sourcePaths: string[];
-  private responseText: string | undefined;
-  constructor(sourcePaths: string[], responseText: string | undefined) {
+  private responseText: string;
+  constructor(sourcePaths: string[], responseText: string) {
     super(nls.localize(GENERATE_MANIFEST_EXECUTOR), GENERATE_MANIFEST_EXECUTOR, OUTPUT_CHANNEL);
     this.sourcePaths = sourcePaths;
     this.responseText = responseText;
@@ -45,12 +45,10 @@ class GenerateManifestExecutor extends LibraryCommandletExecutor<string> {
   ): Promise<boolean> {
     if (this.sourcePaths) {
       const packageXML = await ComponentSet.fromSource(this.sourcePaths).getPackageXml();
-      if (this.responseText === undefined) {
-        // Canceled and declined to name the document
-        await openUntitledDocument(packageXML);
-      } else {
-        saveDocument(this.responseText, packageXML);
-      }
+      // responseText is guaranteed to be a string here since we check for cancellation at the top level
+      // If responseText is empty string, user clicked OK without entering a name (will use default filename)
+      // If responseText has content, user entered a filename
+      await saveDocument(this.responseText, packageXML);
       return true;
     }
     return false;
@@ -68,6 +66,13 @@ export const projectGenerateManifest = async (sourceUri: URI, uris: URI[] | unde
     prompt: nls.localize(MANIFEST_SAVE_PROMPT)
   };
   const responseText = await vscode.window.showInputBox(inputOptions);
+
+  // If user cancelled the input (pressed Escape), don't proceed
+  if (responseText === undefined) {
+    void vscode.window.showWarningMessage(nls.localize('manifest_generation_cancelled'));
+    return;
+  }
+
   if (sourcePaths) {
     const commandlet = new SfCommandlet(
       new SfWorkspaceChecker(),
@@ -76,15 +81,6 @@ export const projectGenerateManifest = async (sourceUri: URI, uris: URI[] | unde
     );
     await commandlet.run();
   }
-};
-
-const openUntitledDocument = async (packageXML: string): Promise<void> => {
-  const newManifest = await vscode.workspace.openTextDocument({
-    content: packageXML,
-    language: 'xml'
-  });
-
-  void vscode.window.showTextDocument(newManifest);
 };
 
 const saveDocument = async (response: string, packageXML: string): Promise<void> => {

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -210,6 +210,7 @@ export const messages = {
   manifest_input_dupe_error: 'Manifest with the name %s already exists. Delete this manifest or use another name.',
   manifest_input_save_placeholder: 'Enter a unique manifest file name (without file extension)',
   manifest_input_save_prompt: 'Press Enter to confirm your input or Escape to cancel and view unsaved manifest file',
+  manifest_generation_cancelled: 'SFDX: Generate Manifest File was cancelled.',
   REST_API: 'REST API',
   tooling_API: 'Tooling API',
   REST_API_description: 'Execute the query with REST API',


### PR DESCRIPTION
### What does this PR do?
This pull request refactors and improves the `GenerateManifestExecutor` class and related functionality in the `projectGenerateManifest.ts` file. The changes enhance user input handling, simplify the code by removing unused methods, and add a new user-facing message for cancellation scenarios.

### Refactoring and Simplification:
* Removed the `openUntitledDocument` method, as it is no longer needed. The logic now ensures that the manifest is either saved with a user-provided name or a default name.
* Updated the `responseText` property in the `GenerateManifestExecutor` class to be non-optional, simplifying its usage and ensuring it is always a string.

### Improved User Input Handling:
* Added a check to handle user cancellation (e.g., pressing Escape) when entering a filename. If the input is canceled, a warning message is displayed, and the process stops.
* Adjusted the logic for saving the document to handle cases where the user provides an empty string as the filename, using a default name in such cases.

### User Messaging:
* Added a new localized message, `manifest_generation_cancelled`, to inform users when the manifest generation process is canceled.

### What issues does this PR fix or reference?
@W-18939319@
