### PR TITLE
feat: W-18337792 - org display command does not rely on CLI but on core library

### DIFF
--- a/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
+++ b/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
@@ -592,7 +592,7 @@ export class ApexDebug extends LoggingDebugSession {
         this.myRequestService.instanceUrl = isvDebuggerUrl;
         this.myRequestService.accessToken = isvDebuggerSid;
       } else {
-        const orgInfo = await new OrgDisplay().getOrgInfo(args.salesforceProject);
+        const orgInfo = await new OrgDisplay().getOrgInfo();
         this.myRequestService.instanceUrl = orgInfo.instanceUrl;
         this.myRequestService.accessToken = orgInfo.accessToken;
       }

--- a/packages/salesforcedx-apex-replay-debugger/src/adapter/apexReplayDebug.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/adapter/apexReplayDebug.ts
@@ -85,6 +85,7 @@ export class ApexReplayDebug extends LoggingDebugSession {
     }
     response.success = false;
     this.setupLogger(args);
+    this.projectPath = args.projectPath;
     this.log(TRACE_CATEGORY_LAUNCH, `launchRequest: args=${JSON.stringify(args)}`);
     this.sendEvent(
       new Event(SEND_METRIC_GENERAL_EVENT, {
@@ -456,6 +457,10 @@ export class ApexReplayDebug extends LoggingDebugSession {
 
   public errorToDebugConsole(msg: string, sourceFile?: Source, sourceLine?: number): void {
     this.printToDebugConsole(msg, sourceFile, sourceLine, 'stderr');
+  }
+
+  public getProjectPath(): string | undefined {
+    return this.projectPath;
   }
 }
 

--- a/packages/salesforcedx-apex-replay-debugger/src/adapter/apexReplayDebug.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/adapter/apexReplayDebug.ts
@@ -83,7 +83,6 @@ export class ApexReplayDebug extends LoggingDebugSession {
       breakpointUtil.createMappingsFromLineBreakpointInfo(args.lineBreakpointInfo);
       delete args.lineBreakpointInfo;
     }
-    this.projectPath = args.projectPath;
     response.success = false;
     this.setupLogger(args);
     this.log(TRACE_CATEGORY_LAUNCH, `launchRequest: args=${JSON.stringify(args)}`);
@@ -126,11 +125,7 @@ export class ApexReplayDebug extends LoggingDebugSession {
       );
     } else {
       this.printToDebugConsole(nls.localize('session_started_text', this.logContext.getLogFileName()));
-      if (
-        this.projectPath &&
-        this.logContext.scanLogForHeapDumpLines() &&
-        !(await this.logContext.fetchOverlayResultsForApexHeapDumps(this.projectPath))
-      ) {
+      if (this.logContext.scanLogForHeapDumpLines() && !(await this.logContext.fetchOverlayResultsForApexHeapDumps())) {
         response.message = nls.localize('heap_dump_error_wrap_up_text');
         this.errorToDebugConsole(nls.localize('heap_dump_error_wrap_up_text'));
         this.sendEvent(

--- a/packages/salesforcedx-apex-replay-debugger/src/core/logContext.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/core/logContext.ts
@@ -232,10 +232,10 @@ export class LogContext {
     return this.apexHeapDumps.length > 0;
   }
 
-  public async fetchOverlayResultsForApexHeapDumps(projectPath: string): Promise<boolean> {
+  public async fetchOverlayResultsForApexHeapDumps(): Promise<boolean> {
     let success = true;
     try {
-      const orgInfo = await new OrgDisplay().getOrgInfo(projectPath);
+      const orgInfo = await new OrgDisplay().getOrgInfo();
       const requestService = new RequestService();
       requestService.instanceUrl = orgInfo.instanceUrl;
       requestService.accessToken = orgInfo.accessToken;

--- a/packages/salesforcedx-utils/package.json
+++ b/packages/salesforcedx-utils/package.json
@@ -16,6 +16,7 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
+    "@salesforce/core-bundle": "^8.12.0",
     "cross-spawn": "7.0.6",
     "request-light": "^0.8.0",
     "rxjs": "^5.4.1",

--- a/packages/salesforcedx-utils/src/cli/orgDisplay.ts
+++ b/packages/salesforcedx-utils/src/cli/orgDisplay.ts
@@ -5,26 +5,157 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { OrgInfo } from '../types';
-import { CliCommandExecutor } from './cliCommandExecutor';
-import { CommandOutput } from './commandOutput';
-import { SfCommandBuilder } from './sfCommandBuilder';
+import { AuthInfo, Connection, Org, Config, StateAggregator } from '@salesforce/core-bundle';
+import { OrgInfo, OrgQueryResult, ScratchOrgQueryResult, ScratchOrgInfo } from '../types/orgInfo';
 
 export class OrgDisplay {
-  public async getOrgInfo(projectPath: string): Promise<OrgInfo> {
-    const execution = new CliCommandExecutor(new SfCommandBuilder().withArg('org:display').withJson().build(), {
-      cwd: projectPath
-    }).execute();
+  private username?: string;
 
-    const cmdOutput = new CommandOutput();
-    const result = await cmdOutput.getCmdResult(execution);
-    try {
-      // will be removed as part of removing CLI calls
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      const orgInfo = JSON.parse(result).result as OrgInfo;
-      return Promise.resolve(orgInfo);
-    } catch {
-      return Promise.reject(result);
+  constructor(username?: string) {
+    this.username = username;
+  }
+
+  public async getUsername(): Promise<string> {
+    if (this.username) {
+      return this.username;
     }
+
+    // Try to get username from project config
+    try {
+      const config = await Config.create(Config.getDefaultOptions());
+      const username = config.get('target-org');
+      if (username && typeof username === 'string') {
+        return username;
+      }
+    } catch {
+      // Ignore config errors
+    }
+
+    // Try to get from state aggregator
+    try {
+      const stateAggregator = await StateAggregator.getInstance();
+      const aliases = stateAggregator.aliases.getAll();
+      const defaultAlias = aliases['defaultusername'];
+      if (defaultAlias && typeof defaultAlias === 'string') {
+        return defaultAlias;
+      }
+    } catch {
+      // Ignore state errors
+    }
+
+    throw new Error('No username provided and no default username found in project config or state');
+  }
+
+  public async getOrgInfo(): Promise<OrgInfo> {
+    const username = await this.getUsername();
+    const authInfo = await AuthInfo.create({ username });
+    const connection = await Connection.create({ authInfo });
+    const org = await Org.create({ connection });
+
+    return this.getOrgInfoFromConnection(org, connection, authInfo, username);
+  }
+
+  private async getOrgInfoFromConnection(
+    org: Org,
+    connection: Connection,
+    authInfo: AuthInfo,
+    username: string
+  ): Promise<OrgInfo> {
+    const authFields = authInfo.getFields(true);
+
+    // Get alias using StateAggregator
+    const stateAggregator = await StateAggregator.getInstance();
+    const aliases = stateAggregator.aliases.getAll(username);
+    const alias = aliases.length > 0 ? aliases[0] : '';
+
+    // Check if this is a scratch org
+    const isScratchOrg = Boolean(authFields.devHubUsername);
+
+    // Test connection to determine status
+    let connectionStatus = 'Disconnected';
+    try {
+      await connection.identity();
+      connectionStatus = 'Connected';
+    } catch {
+      connectionStatus = 'Disconnected';
+    }
+
+    // Get organization details via SOQL
+    const orgQuery = await connection.singleRecordQuery<OrgQueryResult>(
+      'SELECT Id, Name, CreatedDate, CreatedBy.Username, OrganizationType, InstanceName, IsSandbox FROM Organization'
+    );
+
+    // For scratch orgs, get detailed information from the dev hub
+    let scratchOrgInfo: ScratchOrgInfo = {
+      status: 'Active',
+      createdBy: orgQuery.CreatedBy.Username,
+      createdDate: orgQuery.CreatedDate,
+      expirationDate: '',
+      edition: 'Developer',
+      orgName: orgQuery.Name
+    };
+
+    if (isScratchOrg && authFields.orgId) {
+      try {
+        const hubOrg = await org.getDevHubOrg();
+        if (hubOrg) {
+          const hubConnection = hubOrg.getConnection();
+          // Query the dev hub for scratch org information
+          const scratchOrgQuery = await hubConnection.singleRecordQuery<ScratchOrgQueryResult>(
+            "SELECT Status, CreatedBy.Username, CreatedDate, ExpirationDate, Edition, OrgName FROM ScratchOrgInfo WHERE ScratchOrg = '" +
+              authFields.orgId.substring(0, 15) +
+              "'"
+          );
+
+          scratchOrgInfo = {
+            status: scratchOrgQuery.Status,
+            createdBy: scratchOrgQuery.CreatedBy.Username,
+            createdDate: scratchOrgQuery.CreatedDate,
+            expirationDate: scratchOrgQuery.ExpirationDate,
+            edition: scratchOrgQuery.Edition,
+            orgName: scratchOrgQuery.OrgName,
+            password: authFields.password || ''
+          };
+        }
+      } catch {
+        // If we can't get scratch org info, fall back to basic info
+        scratchOrgInfo.expirationDate = authFields.expirationDate || '';
+      }
+    }
+
+    // Determine org type and status
+    let edition = scratchOrgInfo.edition;
+    const status = scratchOrgInfo.status;
+
+    if (!isScratchOrg) {
+      if (orgQuery.IsSandbox) {
+        edition = 'Sandbox';
+      } else if (orgQuery.OrganizationType === 'Enterprise') {
+        edition = 'Enterprise';
+      } else if (orgQuery.OrganizationType === 'Professional') {
+        edition = 'Professional';
+      }
+    }
+
+    const orgInfo: OrgInfo = {
+      username,
+      devHubId: authFields.devHubUsername || '',
+      id: authFields.orgId || orgQuery.Id,
+      createdBy: scratchOrgInfo.createdBy,
+      createdDate: scratchOrgInfo.createdDate,
+      expirationDate: scratchOrgInfo.expirationDate,
+      status,
+      edition,
+      orgName: scratchOrgInfo.orgName,
+      accessToken: authFields.accessToken || '',
+      instanceUrl: authFields.instanceUrl || '',
+      clientId: authFields.clientId || '',
+      apiVersion: authFields.instanceApiVersion || '',
+      alias,
+      connectionStatus,
+      password: scratchOrgInfo.password || ''
+    };
+
+    return orgInfo;
   }
 }

--- a/packages/salesforcedx-utils/src/types/orgInfo.ts
+++ b/packages/salesforcedx-utils/src/types/orgInfo.ts
@@ -17,4 +17,37 @@ export type OrgInfo = {
   accessToken: string;
   instanceUrl: string;
   clientId: string;
+  apiVersion: string;
+  alias: string;
+  connectionStatus: string;
+  password?: string;
+};
+
+export type OrgQueryResult = {
+  Id: string;
+  Name: string;
+  CreatedDate: string;
+  CreatedBy: { Username: string };
+  OrganizationType: string;
+  InstanceName: string;
+  IsSandbox: boolean;
+};
+
+export type ScratchOrgQueryResult = {
+  Status: string;
+  CreatedBy: { Username: string };
+  CreatedDate: string;
+  ExpirationDate: string;
+  Edition: string;
+  OrgName: string;
+};
+
+export type ScratchOrgInfo = {
+  status: string;
+  createdBy: string;
+  createdDate: string;
+  expirationDate: string;
+  edition: string;
+  orgName: string;
+  password?: string;
 };

--- a/packages/salesforcedx-utils/test/jest/cli/orgDisplay.test.ts
+++ b/packages/salesforcedx-utils/test/jest/cli/orgDisplay.test.ts
@@ -4,46 +4,224 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { CliCommandExecutor, CommandOutput, OrgDisplay } from '../../../src';
+
+import { AuthInfo, Connection, Org, Config, StateAggregator } from '@salesforce/core-bundle';
+import { OrgDisplay } from '../../../src';
+
+// Mock the Salesforce Core classes
+jest.mock('@salesforce/core-bundle', () => ({
+  AuthInfo: {
+    create: jest.fn()
+  },
+  Connection: {
+    create: jest.fn()
+  },
+  Org: {
+    create: jest.fn()
+  },
+  Config: {
+    create: jest.fn(),
+    getDefaultOptions: jest.fn()
+  },
+  StateAggregator: {
+    getInstance: jest.fn()
+  }
+}));
 
 describe('OrgDisplay unit tests.', () => {
-  const fakeExecution = {
-    totally: 'fake'
-  };
-  const resultObj = {
-    result: {
-      org: 'info'
-    }
-  };
-  const fakeResult = JSON.stringify(resultObj);
-  const fakePath = '/here/is/a/fake/path';
+  let orgDisplay: OrgDisplay;
+  let mockAuthInfo: any;
+  let mockConnection: any;
+  let mockOrg: any;
+  let mockConfig: any;
+  let mockStateAggregator: any;
 
-  let executeSpy: jest.SpyInstance;
-  let getCmdResultSpy: jest.SpyInstance;
   beforeEach(() => {
-    executeSpy = jest.spyOn(CliCommandExecutor.prototype, 'execute').mockReturnValue(fakeExecution as any);
-    getCmdResultSpy = jest.spyOn(CommandOutput.prototype, 'getCmdResult').mockResolvedValue(fakeResult);
+    orgDisplay = new OrgDisplay();
+
+    // Reset all mocks
+    jest.clearAllMocks();
+
+    // Setup mock AuthInfo
+    mockAuthInfo = {
+      getUsername: jest.fn().mockReturnValue('test@example.com'),
+      getFields: jest.fn().mockReturnValue({
+        username: 'test@example.com',
+        orgId: '00D1234567890123',
+        accessToken: 'test-token',
+        instanceUrl: 'https://test.salesforce.com',
+        clientId: 'test-client-id'
+      })
+    };
+
+    // Setup mock Connection
+    mockConnection = {
+      identity: jest.fn().mockResolvedValue({}),
+      singleRecordQuery: jest.fn().mockResolvedValue({
+        Id: '00D1234567890123',
+        Name: 'Test Org',
+        CreatedDate: '2024-01-01T00:00:00.000+0000',
+        CreatedBy: { Username: 'admin@example.com' },
+        OrganizationType: 'Enterprise'
+      }),
+      instanceUrl: 'https://test.salesforce.com',
+      accessToken: 'test-token'
+    };
+
+    // Setup mock Org
+    mockOrg = {
+      getDevHubOrg: jest.fn()
+    };
+
+    // Setup mock Config
+    mockConfig = {
+      get: jest.fn()
+    };
+
+    // Setup mock StateAggregator
+    mockStateAggregator = {
+      aliases: {
+        getAll: jest.fn().mockReturnValue([])
+      }
+    };
+
+    jest.mocked(AuthInfo).create.mockResolvedValue(mockAuthInfo);
+    jest.mocked(Connection).create.mockResolvedValue(mockConnection);
+    jest.mocked(Org).create.mockResolvedValue(mockOrg);
+    jest.mocked(Config).create.mockResolvedValue(mockConfig);
+    jest.mocked(Config).getDefaultOptions.mockReturnValue({});
+    jest.mocked(StateAggregator).getInstance.mockResolvedValue(mockStateAggregator);
   });
 
   it('Should create instance.', () => {
-    const orgDisplay = new OrgDisplay();
     expect(orgDisplay).toBeInstanceOf(OrgDisplay);
   });
 
-  it('Should be able to successfully get org info.', async () => {
-    const orgDisplay = new OrgDisplay();
-    const result = await orgDisplay.getOrgInfo(fakePath);
-    expect(result).toEqual(resultObj.result);
-    expect(executeSpy).toHaveBeenCalled();
-    expect(getCmdResultSpy).toHaveBeenCalledWith(fakeExecution);
+  it('Should be able to successfully get org info with username provided.', async () => {
+    const orgDisplayWithUsername = new OrgDisplay('test@example.com');
+
+    const result = await orgDisplayWithUsername.getOrgInfo();
+
+    expect(result).toEqual({
+      username: 'test@example.com',
+      devHubId: '',
+      id: '00D1234567890123',
+      createdBy: 'admin@example.com',
+      createdDate: '2024-01-01T00:00:00.000+0000',
+      expirationDate: '',
+      status: 'Active',
+      edition: 'Enterprise',
+      orgName: 'Test Org',
+      accessToken: 'test-token',
+      instanceUrl: 'https://test.salesforce.com',
+      clientId: 'test-client-id',
+      apiVersion: '',
+      alias: '',
+      connectionStatus: 'Connected',
+      password: ''
+    });
   });
 
-  it('Should reject with result when json is not parseable.', async () => {
-    const partialJson = fakeResult.substring(2);
-    getCmdResultSpy.mockResolvedValue(partialJson);
-    const orgDisplay = new OrgDisplay();
-    expect(orgDisplay.getOrgInfo(fakePath)).rejects.toEqual(partialJson);
-    expect(executeSpy).toHaveBeenCalled();
-    expect(getCmdResultSpy).toHaveBeenCalledWith(fakeExecution);
+  it('Should get username from config when not provided.', async () => {
+    // Mock config to return username
+    mockConfig.get.mockReturnValue('test@example.com');
+
+    const result = await orgDisplay.getOrgInfo();
+
+    expect(result.username).toBe('test@example.com');
+  });
+
+  it('Should get username from state aggregator when config fails.', async () => {
+    // Mock state aggregator to return username
+    mockStateAggregator.aliases.getAll.mockReturnValue({
+      defaultusername: 'test@example.com'
+    });
+
+    const result = await orgDisplay.getOrgInfo();
+
+    expect(result.username).toBe('test@example.com');
+  });
+
+  it('Should throw error when no username can be found.', async () => {
+    await expect(orgDisplay.getOrgInfo()).rejects.toThrow(
+      'No username provided and no default username found in project config or state'
+    );
+  });
+
+  it('Should handle scratch org detection.', async () => {
+    const orgDisplayWithUsername = new OrgDisplay('test@example.com');
+
+    // Mock auth fields to indicate scratch org
+    mockAuthInfo.getFields.mockReturnValue({
+      username: 'test@example.com',
+      orgId: '00D1234567890123',
+      accessToken: 'test-token',
+      instanceUrl: 'https://test.salesforce.com',
+      clientId: 'test-client-id',
+      devHubUsername: 'devhub@example.com'
+    });
+
+    // Mock dev hub org
+    const mockHubOrg = {
+      getConnection: jest.fn().mockReturnValue({
+        singleRecordQuery: jest.fn().mockResolvedValue({
+          Status: 'Active',
+          CreatedBy: { Username: 'admin@example.com' },
+          CreatedDate: '2024-01-01T00:00:00.000+0000',
+          ExpirationDate: '2024-12-31T00:00:00.000+0000',
+          Edition: 'Developer',
+          OrgName: 'Test Scratch Org'
+        })
+      })
+    };
+    mockOrg.getDevHubOrg.mockResolvedValue(mockHubOrg);
+
+    const result = await orgDisplayWithUsername.getOrgInfo();
+
+    expect(result.devHubId).toBe('devhub@example.com');
+    expect(result.edition).toBe('Developer');
+    expect(result.status).toBe('Active');
+    expect(result.expirationDate).toBe('2024-12-31T00:00:00.000+0000');
+  });
+
+  it('Should handle sandbox org detection.', async () => {
+    const orgDisplayWithUsername = new OrgDisplay('test@example.com');
+
+    // Mock org query for sandbox
+    mockConnection.singleRecordQuery.mockResolvedValue({
+      Id: '00D1234567890123',
+      Name: 'Test Sandbox',
+      CreatedDate: '2024-01-01T00:00:00.000+0000',
+      CreatedBy: { Username: 'admin@example.com' },
+      OrganizationType: 'Enterprise',
+      InstanceName: 'NA1',
+      IsSandbox: true
+    });
+
+    const result = await orgDisplayWithUsername.getOrgInfo();
+
+    expect(result.edition).toBe('Sandbox');
+  });
+
+  it('Should retrieve alias when available.', async () => {
+    const orgDisplayWithUsername = new OrgDisplay('test@example.com');
+
+    // Mock state aggregator to return aliases
+    mockStateAggregator.aliases.getAll.mockReturnValue(['test-alias']);
+
+    const result = await orgDisplayWithUsername.getOrgInfo();
+
+    expect(result.alias).toBe('test-alias');
+  });
+
+  it('Should return empty string when no alias is available.', async () => {
+    const orgDisplayWithUsername = new OrgDisplay('test@example.com');
+
+    // Mock state aggregator to return empty array
+    mockStateAggregator.aliases.getAll.mockReturnValue([]);
+
+    const result = await orgDisplayWithUsername.getOrgInfo();
+
+    expect(result.alias).toBe('');
   });
 });

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/breakpoints/checkpointService.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/breakpoints/checkpointService.ts
@@ -82,7 +82,7 @@ export class CheckpointService implements TreeDataProvider<BaseNode> {
     if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0]) {
       this.salesforceProject = URI.file(vscode.workspace.workspaceFolders[0].uri.fsPath).fsPath;
       try {
-        this.orgInfo = await new OrgDisplay().getOrgInfo(this.salesforceProject);
+        this.orgInfo = await new OrgDisplay().getOrgInfo();
       } catch (error) {
         const result = JSON.parse(error) as OrgInfoError;
         const errorMessage = `${nls.localize('unable_to_retrieve_org_info')} : ${result.message}`;


### PR DESCRIPTION
### What does this PR do?
This pull request introduces significant improvements to the Salesforce DX utilities and Apex Debugger modules, focusing on replacing CLI-based org information retrieval with a more robust approach using the Salesforce Core library. It also includes code refactoring, bug fixes, and enhancements to unit tests.

### Refactoring and Core Library Integration:
* Replaced CLI-based org information retrieval in `OrgDisplay` with a new implementation using the `@salesforce/core-bundle` library. This includes methods for retrieving org details, handling scratch orgs, and detecting connection status. (`[[1]](diffhunk://#diff-e0c6140a7332a95989f3ffab1ab6e82c5909d1b5905a93c68da1c884624600e8L8-R159)`, `[[2]](diffhunk://#diff-9b6681cb57e56576bb79c27f8d96c447cbb728225ac3cb6b1eed7c3702ddb467L235-R238)`, `[[3]](diffhunk://#diff-fcc8414a4915e401e66b4f787fd30d58d40505b38e4a0c09fb416ef391b3d9b5L595-R595)`, `[[4]](diffhunk://#diff-b31b3e858735603799fbff54c375e13809ba353e0fb6d7e2f696c2c31bb06b59L85-R85)`)
* Added new types (`OrgQueryResult`, `ScratchOrgQueryResult`, `ScratchOrgInfo`) to support the enhanced org information retrieval. (`[packages/salesforcedx-utils/src/types/orgInfo.tsR20-R52](diffhunk://#diff-ef712ba1f5e468a1e3b6da6073affb0213b275018e8a9fdfc428cb956454860eR20-R52)`)

### Bug Fixes and Code Improvements:
* Fixed the order of `this.projectPath` assignment in `ApexReplayDebug` to ensure it is set before being accessed. (`[packages/salesforcedx-apex-replay-debugger/src/adapter/apexReplayDebug.tsL86-R88](diffhunk://#diff-2440d460852d148dbe998f1e4f960edc9f7550db937359b6874336396192291dL86-R88)`)
* Removed redundant `projectPath` parameter from `fetchOverlayResultsForApexHeapDumps` and other related methods to simplify the code. (`[[1]](diffhunk://#diff-2440d460852d148dbe998f1e4f960edc9f7550db937359b6874336396192291dL129-R129)`, `[[2]](diffhunk://#diff-9b6681cb57e56576bb79c27f8d96c447cbb728225ac3cb6b1eed7c3702ddb467L235-R238)`)

### Unit Test Enhancements:
* Updated `OrgDisplay` unit tests to mock Salesforce Core library components and validate the new org information retrieval logic. Added tests for various scenarios, such as handling scratch orgs, sandboxes, and missing usernames. (`[packages/salesforcedx-utils/test/jest/cli/orgDisplay.test.tsL7-R225](diffhunk://#diff-a36a4640a2dc7d8abfc2fa108fe067cf87e2341cb52ba7493bbc9e8f9a82a628L7-R225)`)

### Dependency Updates:
* Added `@salesforce/core-bundle` as a dependency in `salesforcedx-utils` to enable the new org information retrieval functionality. (`[packages/salesforcedx-utils/package.jsonR19](diffhunk://#diff-c6f9106231853a3b8516aec41c2ba0fb22e73b0bc28da50e7ab6f8dc50d8f604R19)`)

### What issues does this PR fix or reference?
@W-18337792@