### PR TITLE
chore: update change-log-generator-utils.js so that new changelogs for each release do not include the content of the previous changelog

### DIFF
--- a/scripts/change-log-generator-utils.js
+++ b/scripts/change-log-generator-utils.js
@@ -195,11 +195,9 @@ function getPackageHeaders(filesChanged) {
  */
 function writeChangeLog(textToInsert) {
   logger(`\nStep 5: Adding changelog to: ${constants.CHANGE_LOG_PATH}`);
-  let data = fs.readFileSync(constants.CHANGE_LOG_PATH);
   let fd = fs.openSync(constants.CHANGE_LOG_PATH, 'w+');
   let buffer = Buffer.from(textToInsert.toString());
   fs.writeSync(fd, buffer, 0, buffer.length, 0);
-  fs.writeSync(fd, data, 0, data.length, buffer.length);
   fs.closeSync(fd);
 }
 


### PR DESCRIPTION
### Functionality Before
Changelogs automatically generated by the **generateChangelog.yml** GHA workflow contain the contents of the previous changelog underneath new content for the current release.

### Functionality After
Changelogs automatically generated by the **generateChangelog.yml** GHA workflow contain only new content for the current release.

[skip-validate-pr]
