### PR TITLE
test: add retry and pause to TrailApexReplayDebugger.e2e.ts so "Get Apex Debug Logs" step works in Ubuntu

### DIFF
--- a/packages/salesforcedx-vscode-automation-tests/test/specs/trailApexReplayDebugger.e2e.ts
+++ b/packages/salesforcedx-vscode-automation-tests/test/specs/trailApexReplayDebugger.e2e.ts
@@ -175,6 +175,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', () =>
         expect(quickPicks).to.not.be.undefined;
         expect(quickPicks.length).to.be.greaterThan(0);
         await prompt.selectQuickPick('User User - ApexTestHandler');
+        await pause(Duration.seconds(2));
       },
       3,
       'Failed to select log file from quick picks'


### PR DESCRIPTION
### What does this PR do?
Adds a retry and pause to TrailApexReplayDebugger.e2e.ts so the "Get Apex Debug Logs" step works in Ubuntu.

### What issues does this PR fix or reference?
[skip-validate-pr]

### Functionality Before
TrailApexReplayDebugger.e2e.ts fails in Ubuntu

### Functionality After
All E2E tests are green