### PR TITLE
[W-19101015] ci: delete scratch org infos for deleted orgs in svcideebot org automatically once per day to avoid storage limit exceeded error

### DIFF
--- a/.github/workflows/cleanupDeletedScratchOrgs.yml
+++ b/.github/workflows/cleanupDeletedScratchOrgs.yml
@@ -53,7 +53,7 @@ jobs:
           sf data delete bulk \
             --sobject ScratchOrgInfo \
             --where "Status = 'Deleted'" \
-            --target-org cleanup-org \
+            --target-org vscodeOrg \
             --wait 10
           echo "✅ Successfully deleted scratch org records"
 

--- a/.github/workflows/cleanupDeletedScratchOrgs.yml
+++ b/.github/workflows/cleanupDeletedScratchOrgs.yml
@@ -1,0 +1,76 @@
+name: Cleanup Deleted Scratch Orgs
+
+on:
+  workflow_dispatch: # Allow manual trigger
+  schedule:
+    - cron: '0 2 * * *' # Run at 2 AM UTC (10 PM EST) every day
+
+jobs:
+  cleanup-scratch-orgs:
+    runs-on: ubuntu-latest
+
+    env:
+      SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL_E2E }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
+          cache: npm
+
+      - name: Install Salesforce CLI
+        run: |
+          npm install -g @salesforce/cli
+          sf --version
+
+      - name: Authenticate with Salesforce
+        run: |
+          echo "Authenticating with Salesforce org..."
+          sf org login sfdx-url \
+            --sfdx-url-file <(echo "$SFDX_AUTH_URL") \
+            --alias vscodeOrg \
+            --set-default
+
+      - name: Query existing deleted scratch orgs
+        id: query-deleted
+        run: |
+          echo "Querying for deleted scratch orgs..."
+          DELETED_COUNT=$(sf data query \
+            --query "SELECT COUNT() FROM ScratchOrgInfo WHERE Status = 'Deleted'" \
+            --target-org vscodeOrg \
+            --json | jq -r '.result.totalSize')
+          echo "Found $DELETED_COUNT deleted scratch org records to clean up"
+          echo "deleted_count=$DELETED_COUNT" >> $GITHUB_OUTPUT
+
+      - name: Delete scratch org records
+        if: steps.query-deleted.outputs.deleted_count > 0
+        run: |
+          echo "Deleting ${{ steps.query-deleted.outputs.deleted_count }} deleted scratch org records..."
+          sf data delete bulk \
+            --sobject ScratchOrgInfo \
+            --where "Status = 'Deleted'" \
+            --target-org cleanup-org \
+            --wait 10
+          echo "✅ Successfully deleted scratch org records"
+
+      - name: No records to delete
+        if: steps.query-deleted.outputs.deleted_count == 0
+        run: |
+          echo "ℹ️ No deleted scratch org records found to clean up"
+
+      - name: Logout from Salesforce
+        if: always()
+        run: |
+          sf org logout --target-org vscodeOrg --no-prompt || true
+
+      - name: Workflow summary
+        if: always()
+        run: |
+          echo "## Scratch Org Cleanup Summary" >> $GITHUB_STEP_SUMMARY
+          echo "- **Deleted Records:** ${{ steps.query-deleted.outputs.deleted_count || '0' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Status:** ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Timestamp:** $(date -u)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/cleanupDeletedScratchOrgs.yml
+++ b/.github/workflows/cleanupDeletedScratchOrgs.yml
@@ -39,21 +39,38 @@ jobs:
         id: query-deleted
         run: |
           echo "Querying for deleted scratch orgs..."
-          DELETED_COUNT=$(sf data query \
-            --query "SELECT COUNT() FROM ScratchOrgInfo WHERE Status = 'Deleted'" \
+          DELETED_RECORDS=$(sf data query \
+            --query "SELECT Id FROM ScratchOrgInfo WHERE Status = 'Deleted'" \
             --target-org vscodeOrg \
-            --json | jq -r '.result.totalSize')
+            --json)
+          DELETED_COUNT=$(echo "$DELETED_RECORDS" | jq -r '.result.totalSize')
           echo "Found $DELETED_COUNT deleted scratch org records to clean up"
           echo "deleted_count=$DELETED_COUNT" >> $GITHUB_OUTPUT
+          echo "deleted_records<<EOF" >> $GITHUB_OUTPUT
+          echo "$DELETED_RECORDS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Delete scratch org records
+      - name: Export and delete scratch org records
         if: steps.query-deleted.outputs.deleted_count > 0
         run: |
+          echo "Exporting ${{ steps.query-deleted.outputs.deleted_count }} deleted scratch org records to CSV..."
+
+          # Write records to CSV file
+          echo '${{ steps.query-deleted.outputs.deleted_records }}' | \
+            jq -r '.result.records[] | [.Id] | @csv' > deleted_scratch_orgs.csv
+
+          # Add CSV header
+          sed -i '1i"Id"' deleted_scratch_orgs.csv
+
+          echo "✅ Exported records to deleted_scratch_orgs.csv"
+          echo "CSV file contents:"
+          cat deleted_scratch_orgs.csv
+
           echo "Deleting ${{ steps.query-deleted.outputs.deleted_count }} deleted scratch org records..."
           sf data delete bulk \
             --sobject ScratchOrgInfo \
-            --where "Status = 'Deleted'" \
             --target-org vscodeOrg \
+            --file deleted_scratch_orgs.csv \
             --wait 10
           echo "✅ Successfully deleted scratch org records"
 


### PR DESCRIPTION
### What does this PR do?
Every time a new scratch org is created from the svcideebot dev hub, a scratch org info entry is created in the svcideebot org.  Each E2E test run creates and deletes a scratch org, generating over 50 scratch org info entries.  In the past, we have been manually running a query to delete the scratch org infos from the org whenever we get the "storage limit exceeded" error, but this is becoming a much more frequent chore now that E2E runs on every commit.  Therefore, I created a new GHA workflow that automatically runs the query to do the cleanup for us once per day.

Here's a successful run of the workflow: https://github.com/daphne-sfdc/salesforcedx-vscode-cleanup-deleted-scratch-orgs/actions/runs/16427936296

### What issues does this PR fix or reference?
@W-19101015@

### Functionality Before
<img width="1920" height="1080" alt="Screenshot 2025-07-21 at 4 38 39 PM (2)" src="https://github.com/user-attachments/assets/ed37efcb-10da-421d-9ffe-10e1e5af66ae" />

### Functionality After
<img width="1920" height="1080" alt="Screenshot 2025-07-21 at 4 56 18 PM (2)" src="https://github.com/user-attachments/assets/52efc56b-5134-485d-b217-daa0d9f19f9d" />
