### PR TITLE
Fix (Org Browser): Error fetching metadata for org

### DIFF
--- a/packages/salesforcedx-vscode-core/src/orgBrowser/metadataType.ts
+++ b/packages/salesforcedx-vscode-core/src/orgBrowser/metadataType.ts
@@ -66,7 +66,7 @@ export class TypeUtils {
 
 const buildTypesList = (describeResult: DescribeMetadataResult): MetadataObject[] => {
   try {
-    const metadataTypeObjects = describeResult.metadataObjects
+    const metadataTypeObjects = describeResult.result.metadataObjects
       .filter(type => !isNullOrUndefined(type.xmlName) && !TypeUtils.UNSUPPORTED_TYPES.has(type.xmlName))
       .map(mdTypeObject => ({
         ...mdTypeObject,


### PR DESCRIPTION
### What does this PR do?
Fixes Org Browser not working. (v64.5.1)
Looks like it was broken in: https://github.com/forcedotcom/salesforcedx-vscode/commit/31b5c9e820e4eb66eb3a9ae70d51c9b125c73c63#diff-15798cb9be5d209ab5eac67a90ddafd3d29b01a2a8d601e56260f0ce072bb157R69
The property it references is actually deeper in the object:
<img width="203" height="112" alt="image" src="https://github.com/user-attachments/assets/ed928b26-5e4d-4241-b0ec-142de166027d" />


### What issues does this PR fix or reference?
- issue describing the problem, but is too old to have been because of this: #5261
- reference to the ticked mentioned on the related breaking change: @W-18338037@

### Functionality Before
Org Browser fails loading the org metadata with error:
> Error: Error fetching metadata for org. Run "SFDX: Authorize an Org" to authorize your org again.

### Functionality After
Org Browser displays the metadata from an org.
