### PR TITLE
fix: launch extensions was not working

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/cli/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/cli/index.ts
@@ -16,7 +16,9 @@ export { OrgCreateErrorResult, OrgCreateResultParser, OrgCreateSuccessResult } f
 export { OrgOpenContainerResultParser, OrgOpenErrorResult, OrgOpenSuccessResult } from './orgOpenContainerResultParser';
 export {
   ProjectRetrieveStartResultParser,
-  ProjectRetrieveStartResult
+  ProjectRetrieveStartResult,
+  ProjectRetrieveStartErrorResponse,
+  ProjectRetrieveStartSuccessResponse
 } from './parsers/projectRetrieveStartResultParser';
 export {
   CONFLICT_ERROR_NAME,

--- a/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/pushOrDeployOnSave.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { TimingUtils } from '@salesforce/salesforcedx-utils-vscode/src/helpers/timingUtils';
+import { TimingUtils } from '@salesforce/salesforcedx-utils-vscode';
 import * as path from 'node:path';
 import { setTimeout } from 'node:timers';
 import * as vscode from 'vscode';

--- a/packages/salesforcedx-vscode-core/test/jest/commands/util/sfCommandlet.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/commands/util/sfCommandlet.test.ts
@@ -4,11 +4,11 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { ProjectRetrieveStartResultParser } from '@salesforce/salesforcedx-utils-vscode';
 import {
+  ProjectRetrieveStartResultParser,
   ProjectRetrieveStartErrorResponse,
   ProjectRetrieveStartSuccessResponse
-} from '@salesforce/salesforcedx-utils-vscode/src/cli/parsers/projectRetrieveStartResultParser';
+} from '@salesforce/salesforcedx-utils-vscode';
 import { channelService } from '../../../../src/channels';
 import { DeployType, ProjectDeployStartExecutor } from '../../../../src/commands/projectDeployStart';
 import { ProjectRetrieveStartExecutor } from '../../../../src/commands/projectRetrieveStart';


### PR DESCRIPTION
### What does this PR do?
This pull request includes updates to imports and export statements to improve module organization and simplify paths. The most notable changes involve consolidating import paths for consistency and adding new exports for better functionality.

### Module organization and path simplification:
* Updated the import path for `TimingUtils` in `pushOrDeployOnSave.ts` to remove the redundant `src/helpers` subdirectory, simplifying the module reference.
* Consolidated imports for `ProjectRetrieveStartResultParser`, `ProjectRetrieveStartErrorResponse`, and `ProjectRetrieveStartSuccessResponse` in `sfCommandlet.test.ts` to use a single, simplified path.

### Export enhancements:
* Added `ProjectRetrieveStartErrorResponse` and `ProjectRetrieveStartSuccessResponse` to the exports in `index.ts` to expand the available functionality from the `projectRetrieveStartResultParser` module.

### What issues does this PR fix or reference?
[skip-validate-pr]

### Functionality Before
- couldn't launch extensions

### Functionality After
- extensions can be launched
