### PR TITLE
chore: W-19157078 - fix finish log for turn on apex debug log

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6120,9 +6120,9 @@
       "link": true
     },
     "node_modules/@salesforce/salesforcedx-vscode-test-tools": {
-      "version": "1.0.1-dev.122",
-      "resolved": "https://registry.npmjs.org/@salesforce/salesforcedx-vscode-test-tools/-/salesforcedx-vscode-test-tools-1.0.1-dev.122.tgz",
-      "integrity": "sha512-pMk/7sPltOHKEnWcAqtE/2WEaU4dW2cQqpQnUW/n5KzFyiQzIL8KgJkQriUx7lPYNqd5ubE62W4HYWD6V5DrFg==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@salesforce/salesforcedx-vscode-test-tools/-/salesforcedx-vscode-test-tools-1.1.6.tgz",
+      "integrity": "sha512-g+CGE0IK7+8jyhZux10m9JpuemTkUItfiBWhum+s8YRFIhoLuPh91wejzge5Qz2Id/nHGtCoLg7+0j8s6ET1SQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -6130,9 +6130,7 @@
         "chai": "^4.5.0",
         "cross-spawn": "^7.0.3",
         "fast-glob": "^3.3.2",
-        "mocha": "^11.7.1",
-        "mocha-steps": "^1.3.0",
-        "vscode-extension-tester": "^8.15.0",
+        "vscode-extension-tester": "^8.16.0",
         "yargs": "^17.7.2"
       }
     },
@@ -23035,13 +23033,6 @@
         "mocha": ">=3.1.2"
       }
     },
-    "node_modules/mocha-steps": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/mocha-steps/-/mocha-steps-1.3.0.tgz",
-      "integrity": "sha512-KZvpMJTqzLZw3mOb+EEuYi4YZS41C9iTnb7skVFRxHjUd1OYbl64tCMSmpdIRM9LnwIrSOaRfPtNpF5msgv6Eg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/mocha/node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -35914,7 +35905,7 @@
       "version": "64.7.0",
       "devDependencies": {
         "@commitlint/config-conventional": "19.5.0",
-        "@salesforce/salesforcedx-vscode-test-tools": "*",
+        "@salesforce/salesforcedx-vscode-test-tools": "^1.1.6",
         "@types/chai": "^4.3.17",
         "@types/cross-spawn": "^6.0.6",
         "@types/mocha": "^10.0.9",

--- a/packages/salesforcedx-utils-vscode/src/messages/i18n.ts
+++ b/packages/salesforcedx-utils-vscode/src/messages/i18n.ts
@@ -37,7 +37,7 @@ export const messages = {
   channel_end_with_sfdx_not_found:
     'Salesforce CLI is not installed. Install it from https://developer.salesforce.com/tools/salesforcecli',
   channel_end_with_error: 'ended with error %s',
-  channel_end: 'ended',
+  channel_end: 'Ended',
   predicates_no_folder_opened_text: 'No folder opened. Open a Salesforce DX project in VS Code.',
   predicates_no_salesforce_project_found_text:
     'No sfdx-project.json found in the root directory of your open project. Open a Salesforce DX project in VS Code.',

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/messages/i18n.ts
@@ -26,7 +26,7 @@ export const messages = {
   local_source_is_out_of_sync_with_the_server:
     "The local source is out of sync with the server. Push any changes you've made locally to your org, and pull any changes you've made in the org into your local project.",
   long_command_start: 'Starting',
-  long_command_end: 'Ending',
+  long_command_end: 'Ended',
   sf_update_checkpoints_in_org: 'SFDX: Update Checkpoints in Org',
   checkpoint_creation_status_org_info: 'Step 1 of 6: Retrieving org information',
   checkpoint_creation_status_source_line_info: 'Step 2 of 6: Retrieving source and line information',

--- a/packages/salesforcedx-vscode-automation-tests/package.json
+++ b/packages/salesforcedx-vscode-automation-tests/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@commitlint/config-conventional": "19.5.0",
-    "@salesforce/salesforcedx-vscode-test-tools": "*",
+    "@salesforce/salesforcedx-vscode-test-tools": "^1.1.6",
     "@types/chai": "^4.3.17",
     "@types/cross-spawn": "^6.0.6",
     "@types/mocha": "^10.0.9",

--- a/packages/salesforcedx-vscode-automation-tests/test/specs/anInitialSuite.e2e.ts
+++ b/packages/salesforcedx-vscode-automation-tests/test/specs/anInitialSuite.e2e.ts
@@ -122,7 +122,6 @@ describe('An Initial Suite', () => {
       expect(commands).to.include('SFDX: Authorize an Org');
       expect(commands).to.include('SFDX: Authorize an Org using Session ID');
       expect(commands).to.include('SFDX: Cancel Active Command');
-      expect(commands).to.include('SFDX: Configure Apex Debug Exceptions');
       expect(commands).to.include('SFDX: Create a Default Scratch Org...');
       expect(commands).to.include('SFDX: Create and Set Up Project for ISV Debugging');
       expect(commands).to.include('SFDX: Create Apex Class');

--- a/packages/salesforcedx-vscode-automation-tests/test/specs/apexReplayDebugger.e2e.ts
+++ b/packages/salesforcedx-vscode-automation-tests/test/specs/apexReplayDebugger.e2e.ts
@@ -103,7 +103,7 @@ describe('Apex Replay Debugger', () => {
       10
     );
     expect(outputPanelText).to.contain('SFDX: Turn On Apex Debug Log for Replay Debugger');
-    expect(outputPanelText).to.contain('ended with exit code 0');
+    expect(outputPanelText).to.contain('Ended SFDX: Turn On Apex Debug Log for Replay Debugger');
   });
 
   it('Run the Anonymous Apex Debugger with Currently Selected Text', async () => {
@@ -278,7 +278,7 @@ describe('Apex Replay Debugger', () => {
       'Starting SFDX: Turn Off Apex Debug Log for Replay Debugger',
       10
     );
-    expect(outputPanelText).to.contain('ended with exit code 0');
+    expect(outputPanelText).to.contain('Ended SFDX: Turn On Apex Debug Log for Replay Debugger');
   });
 
   after('Tear down and clean up the testing environment', async () => {

--- a/packages/salesforcedx-vscode-automation-tests/test/specs/apexReplayDebugger.e2e.ts
+++ b/packages/salesforcedx-vscode-automation-tests/test/specs/apexReplayDebugger.e2e.ts
@@ -102,7 +102,6 @@ describe('Apex Replay Debugger', () => {
       'Starting SFDX: Turn On Apex Debug Log for Replay Debugger',
       10
     );
-    expect(outputPanelText).to.contain('SFDX: Turn On Apex Debug Log for Replay Debugger');
     expect(outputPanelText).to.contain('Ended SFDX: Turn On Apex Debug Log for Replay Debugger');
   });
 
@@ -278,7 +277,7 @@ describe('Apex Replay Debugger', () => {
       'Starting SFDX: Turn Off Apex Debug Log for Replay Debugger',
       10
     );
-    expect(outputPanelText).to.contain('Ended SFDX: Turn On Apex Debug Log for Replay Debugger');
+    expect(outputPanelText).to.contain('Ended SFDX: Turn Off Apex Debug Log for Replay Debugger');
   });
 
   after('Tear down and clean up the testing environment', async () => {

--- a/packages/salesforcedx-vscode-automation-tests/test/specs/apexReplayDebugger.e2e.ts
+++ b/packages/salesforcedx-vscode-automation-tests/test/specs/apexReplayDebugger.e2e.ts
@@ -134,7 +134,7 @@ describe('Apex Replay Debugger', () => {
     expect(outputPanelText).to.contain('Executed successfully.');
     expect(outputPanelText).to.contain('|EXECUTION_STARTED');
     expect(outputPanelText).to.contain('|EXECUTION_FINISHED');
-    expect(outputPanelText).to.contain('ended Execute Anonymous Apex');
+    expect(outputPanelText).to.contain('Ended Execute Anonymous Apex');
   });
 
   it('SFDX: Get Apex Debug Logs', async () => {
@@ -164,7 +164,7 @@ describe('Apex Replay Debugger', () => {
     const outputPanelText = await attemptToFindOutputPanelText('Apex', 'Starting SFDX: Get Apex Debug Logs', 10);
     expect(outputPanelText).to.contain('|EXECUTION_STARTED');
     expect(outputPanelText).to.contain('|EXECUTION_FINISHED');
-    expect(outputPanelText).to.contain('ended SFDX: Get Apex Debug Logs');
+    expect(outputPanelText).to.contain('Ended SFDX: Get Apex Debug Logs');
 
     // Verify content on log file
     const textEditor = await retryOperation(async () => {
@@ -255,7 +255,7 @@ describe('Apex Replay Debugger', () => {
     expect(outputPanelText).to.contain('Executed successfully.');
     expect(outputPanelText).to.contain('|EXECUTION_STARTED');
     expect(outputPanelText).to.contain('|EXECUTION_FINISHED');
-    expect(outputPanelText).to.contain('ended Execute Anonymous Apex');
+    expect(outputPanelText).to.contain('Ended Execute Anonymous Apex');
   });
 
   it('SFDX: Turn Off Apex Debug Log for Replay Debugger', async () => {

--- a/packages/salesforcedx-vscode-automation-tests/test/specs/runApexTests.e2e.ts
+++ b/packages/salesforcedx-vscode-automation-tests/test/specs/runApexTests.e2e.ts
@@ -125,7 +125,7 @@ describe('Run Apex Tests', () => {
       'Pass Rate            100%',
       'TEST NAME',
       'ExampleApexClass1Test.validateSayHello  Pass',
-      'ended SFDX: Run Apex Tests'
+      'Ended SFDX: Run Apex Tests'
     ];
 
     await verifyOutputPanelText(outputPanelText, expectedTexts);
@@ -157,7 +157,7 @@ describe('Run Apex Tests', () => {
       'Pass Rate            100%',
       'TEST NAME',
       'ExampleApexClass2Test.validateSayHello  Pass',
-      'ended SFDX: Run Apex Tests'
+      'Ended SFDX: Run Apex Tests'
     ];
 
     await verifyOutputPanelText(outputPanelText, expectedTexts);
@@ -191,7 +191,7 @@ describe('Run Apex Tests', () => {
       'ExampleApexClass1Test.validateSayHello  Pass',
       'ExampleApexClass2Test.validateSayHello  Pass',
       'ExampleApexClass3Test.validateSayHello  Pass',
-      'ended SFDX: Run Apex Tests'
+      'Ended SFDX: Run Apex Tests'
     ];
 
     await verifyOutputPanelText(outputPanelText, expectedTexts);
@@ -221,7 +221,7 @@ describe('Run Apex Tests', () => {
       'Pass Rate            100%',
       'TEST NAME',
       'ExampleApexClass1Test.validateSayHello  Pass',
-      'ended SFDX: Run Apex Tests'
+      'Ended SFDX: Run Apex Tests'
     ];
     await verifyOutputPanelText(outputPanelText, expectedTexts);
   });
@@ -263,7 +263,7 @@ describe('Run Apex Tests', () => {
       'ExampleApexClass1Test.validateSayHello  Pass',
       'ExampleApexClass2Test.validateSayHello  Pass',
       'ExampleApexClass3Test.validateSayHello  Pass',
-      'ended SFDX: Run Apex Tests'
+      'Ended SFDX: Run Apex Tests'
     ];
     await verifyOutputPanelText(outputPanelText, expectedTexts);
 
@@ -287,7 +287,7 @@ describe('Run Apex Tests', () => {
       'Pass Rate            100%',
       'TEST NAME',
       'ExampleApexClass2Test.validateSayHello  Pass',
-      'ended SFDX: Run Apex Tests'
+      'Ended SFDX: Run Apex Tests'
     ];
     expect(terminalText).to.not.be.undefined;
     await verifyOutputPanelText(terminalText!, expectedTexts);
@@ -299,12 +299,7 @@ describe('Run Apex Tests', () => {
     // Clear the Output view.
     await dismissAllNotifications();
     await clearOutputView(Duration.seconds(2));
-    const terminalText = await runTestCaseFromSideBar(
-      workbench,
-      'Apex Tests',
-      'validateSayHello',
-      'Run Single Test'
-    );
+    const terminalText = await runTestCaseFromSideBar(workbench, 'Apex Tests', 'validateSayHello', 'Run Single Test');
     const expectedTexts = [
       '=== Test Summary',
       'Outcome              Passed',
@@ -312,7 +307,7 @@ describe('Run Apex Tests', () => {
       'Pass Rate            100%',
       'TEST NAME',
       'ExampleApexClass1Test.validateSayHello  Pass',
-      'ended SFDX: Run Apex Tests'
+      'Ended SFDX: Run Apex Tests'
     ];
     expect(terminalText).to.not.be.undefined;
     await verifyOutputPanelText(terminalText!, expectedTexts);
@@ -391,7 +386,7 @@ describe('Run Apex Tests', () => {
       'Pass Rate            100%',
       'TEST NAME',
       'AccountServiceTest.should_create_account  Pass',
-      'ended SFDX: Run Apex Tests'
+      'Ended SFDX: Run Apex Tests'
     ];
 
     await verifyOutputPanelText(outputPanelText, expectedTexts);
@@ -475,14 +470,13 @@ describe('Run Apex Tests', () => {
     const expectedTexts = [
       '=== Test Summary',
       'TEST NAME',
-      'ended SFDX: Run Apex Tests',
       'Outcome              Passed',
       'Tests Ran            2',
       'Pass Rate            100%',
       'TEST NAME',
       'ExampleApexClass1Test.validateSayHello  Pass',
       'ExampleApexClass2Test.validateSayHello  Pass',
-      'ended SFDX: Run Apex Tests'
+      'Ended SFDX: Run Apex Tests'
     ];
     await verifyOutputPanelText(outputPanelText, expectedTexts);
   });

--- a/packages/salesforcedx-vscode-automation-tests/test/specs/trailApexReplayDebugger.e2e.ts
+++ b/packages/salesforcedx-vscode-automation-tests/test/specs/trailApexReplayDebugger.e2e.ts
@@ -116,7 +116,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', () =>
     expect(outputPanelText).to.contain(
       'SFDX: Update Checkpoints in Org, Step 6 of 6: Confirming successful checkpoint creation'
     );
-    expect(outputPanelText).to.contain('Ending SFDX: Update Checkpoints in Org');
+    expect(outputPanelText).to.contain('Ended SFDX: Update Checkpoints in Org');
   });
 
   it('SFDX: Turn On Apex Debug Log for Replay Debugger', async () => {
@@ -138,7 +138,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', () =>
       10
     );
     expect(outputPanelText).to.contain('SFDX: Turn On Apex Debug Log for Replay Debugger');
-    expect(outputPanelText).to.contain('ended with exit code 0');
+    expect(outputPanelText).to.contain('Ended SFDX: Turn On Apex Debug Log for Replay Debugger');
   });
 
   it('Run Apex Tests', async () => {

--- a/packages/salesforcedx-vscode-automation-tests/test/specs/trailApexReplayDebugger.e2e.ts
+++ b/packages/salesforcedx-vscode-automation-tests/test/specs/trailApexReplayDebugger.e2e.ts
@@ -137,7 +137,6 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', () =>
       'Starting SFDX: Turn On Apex Debug Log for Replay Debugger',
       10
     );
-    expect(outputPanelText).to.contain('SFDX: Turn On Apex Debug Log for Replay Debugger');
     expect(outputPanelText).to.contain('Ended SFDX: Turn On Apex Debug Log for Replay Debugger');
   });
 
@@ -187,7 +186,7 @@ describe('"Find and Fix Bugs with Apex Replay Debugger" Trailhead Module', () =>
     const outputPanelText = await attemptToFindOutputPanelText('Apex', 'Starting SFDX: Get Apex Debug Logs', 10);
     expect(outputPanelText).to.contain('|EXECUTION_STARTED');
     expect(outputPanelText).to.contain('|EXECUTION_FINISHED');
-    expect(outputPanelText).to.contain('ended SFDX: Get Apex Debug Logs');
+    expect(outputPanelText).to.contain('Ended SFDX: Get Apex Debug Logs');
 
     // Verify content on log file
     const editorView = workbench.getEditorView();

--- a/packages/salesforcedx-vscode-core/src/commands/startApexDebugLogging.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/startApexDebugLogging.ts
@@ -12,8 +12,11 @@ import {
   TraceFlags
 } from '@salesforce/salesforcedx-utils-vscode';
 import * as vscode from 'vscode';
+import { channelService } from '../channels';
 import { WorkspaceContext } from '../context';
-import { handleStartCommand, handleFinishCommand } from '../utils/channelUtils';
+import { coerceMessageKey, nls } from '../messages';
+import { telemetryService } from '../telemetry';
+import { handleStartCommand } from '../utils/channelUtils';
 
 const command = 'start_apex_debug_logging';
 
@@ -38,7 +41,12 @@ export const turnOnLogging = async (extensionContext: vscode.ExtensionContext): 
     extensionContext.workspaceState.update(userSpecificKey, expirationDate);
     showTraceFlagExpiration(expirationDate);
 
-    await handleFinishCommand(command, true);
+    channelService.showCommandWithTimestamp(
+      `${nls.localize(coerceMessageKey('long_command_end'))} ${nls.localize(coerceMessageKey(command))}`
+    );
+
+    await notificationService.showInformationMessage(`${nls.localize(coerceMessageKey(command))} successfully ran`);
+    telemetryService.sendCommandEvent(command);
   } catch {
     const expirationDate = extensionContext.workspaceState.get<Date>(userSpecificKey);
     if (expirationDate) {

--- a/packages/salesforcedx-vscode-core/src/commands/startApexDebugLogging.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/startApexDebugLogging.ts
@@ -30,7 +30,6 @@ export const turnOnLogging = async (extensionContext: vscode.ExtensionContext): 
   // Get user-specific key for storing expiration date
   const userSpecificKey = getTraceFlagExpirationKey(userId);
 
-  let success = false;
   try {
     const debugLevelResultId = await traceFlags.getOrCreateDebugLevel();
     const expirationDate = traceFlags.calculateExpirationDate(new Date());
@@ -38,7 +37,6 @@ export const turnOnLogging = async (extensionContext: vscode.ExtensionContext): 
 
     extensionContext.workspaceState.update(userSpecificKey, expirationDate);
     showTraceFlagExpiration(expirationDate);
-    success = true;
   } catch {
     const expirationDate = extensionContext.workspaceState.get<Date>(userSpecificKey);
     if (expirationDate) {
@@ -48,6 +46,6 @@ export const turnOnLogging = async (extensionContext: vscode.ExtensionContext): 
       );
     }
   } finally {
-    void handleFinishCommand(command, success);
+    void handleFinishCommand(command, true);
   }
 };

--- a/packages/salesforcedx-vscode-core/src/commands/stopApexDebugLogging.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/stopApexDebugLogging.ts
@@ -12,11 +12,8 @@ import {
   getTraceFlagExpirationKey
 } from '@salesforce/salesforcedx-utils-vscode';
 import * as vscode from 'vscode';
-import { channelService } from '../channels';
 import { WorkspaceContext } from '../context';
-import { coerceMessageKey, nls } from '../messages';
-import { telemetryService } from '../telemetry';
-import { handleStartCommand } from '../utils/channelUtils';
+import { handleFinishCommand, handleStartCommand } from '../utils/channelUtils';
 
 const command = 'stop_apex_debug_logging';
 
@@ -38,14 +35,8 @@ export const turnOffLogging = async (extensionContext: vscode.ExtensionContext):
     extensionContext.workspaceState.update(userSpecificKey, undefined);
 
     disposeTraceFlagExpiration();
-
-    channelService.showCommandWithTimestamp(
-      `${nls.localize(coerceMessageKey('long_command_end'))} ${nls.localize(coerceMessageKey(command))}`
-    );
-
-    await notificationService.showInformationMessage(`${nls.localize(coerceMessageKey(command))} successfully ran`);
-    telemetryService.sendCommandEvent(command);
   } else {
     await notificationService.showInformationMessage('No active trace flag found.');
   }
+  void handleFinishCommand(command, true);
 };

--- a/packages/salesforcedx-vscode-core/src/commands/stopApexDebugLogging.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/stopApexDebugLogging.ts
@@ -5,10 +5,18 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { notificationService, TraceFlags, disposeTraceFlagExpiration, getTraceFlagExpirationKey } from '@salesforce/salesforcedx-utils-vscode';
+import {
+  notificationService,
+  TraceFlags,
+  disposeTraceFlagExpiration,
+  getTraceFlagExpirationKey
+} from '@salesforce/salesforcedx-utils-vscode';
 import * as vscode from 'vscode';
+import { channelService } from '../channels';
 import { WorkspaceContext } from '../context';
-import { handleStartCommand, handleFinishCommand } from '../utils/channelUtils';
+import { coerceMessageKey, nls } from '../messages';
+import { telemetryService } from '../telemetry';
+import { handleStartCommand } from '../utils/channelUtils';
 
 const command = 'stop_apex_debug_logging';
 
@@ -30,7 +38,13 @@ export const turnOffLogging = async (extensionContext: vscode.ExtensionContext):
     extensionContext.workspaceState.update(userSpecificKey, undefined);
 
     disposeTraceFlagExpiration();
-    await handleFinishCommand(command, true);
+
+    channelService.showCommandWithTimestamp(
+      `${nls.localize(coerceMessageKey('long_command_end'))} ${nls.localize(coerceMessageKey(command))}`
+    );
+
+    await notificationService.showInformationMessage(`${nls.localize(coerceMessageKey(command))} successfully ran`);
+    telemetryService.sendCommandEvent(command);
   } else {
     await notificationService.showInformationMessage('No active trace flag found.');
   }

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -22,7 +22,7 @@ export const messages = {
   channel_end_with_sfdx_not_found:
     'Salesforce CLI is not installed. Install it from https://developer.salesforce.com/tools/salesforcecli',
   channel_end_with_error: 'ended with error %s',
-  channel_end: 'ended',
+  channel_end: 'Ended',
 
   progress_notification_text: 'Running %s',
 
@@ -200,7 +200,6 @@ export const messages = {
   project_generate_empty_template: 'Empty project template',
   project_generate_analytics_template: 'Analytics project template',
   apex_generate_trigger_text: 'SFDX: Create Apex Trigger',
-  long_command_end: 'Ended',
   start_apex_debug_logging: 'SFDX: Turn On Apex Debug Log for Replay Debugger',
   stop_apex_debug_logging: 'SFDX: Turn Off Apex Debug Log for Replay Debugger',
   isv_debug_bootstrap_create_project: 'SFDX: ISV Debugger Setup, Step 1 of 5: Creating project',

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -200,6 +200,7 @@ export const messages = {
   project_generate_empty_template: 'Empty project template',
   project_generate_analytics_template: 'Analytics project template',
   apex_generate_trigger_text: 'SFDX: Create Apex Trigger',
+  long_command_end: 'Ended',
   start_apex_debug_logging: 'SFDX: Turn On Apex Debug Log for Replay Debugger',
   stop_apex_debug_logging: 'SFDX: Turn Off Apex Debug Log for Replay Debugger',
   isv_debug_bootstrap_create_project: 'SFDX: ISV Debugger Setup, Step 1 of 5: Creating project',

--- a/packages/salesforcedx-vscode-core/src/utils/channelUtils.ts
+++ b/packages/salesforcedx-vscode-core/src/utils/channelUtils.ts
@@ -25,9 +25,9 @@ export const handleFinishCommand = async (
   isSuccess: boolean,
   error: string = 'Command failed'
 ): Promise<void> => {
-  const exitCode = isSuccess ? '0' : '1';
-  channelService.showCommandWithTimestamp(nls.localize(coerceMessageKey(command)));
-  channelService.appendLine(` ${nls.localize('channel_end_with_exit_code', exitCode)}`);
+  channelService.showCommandWithTimestamp(
+    `${nls.localize(coerceMessageKey('channel_end'))} ${nls.localize(coerceMessageKey(command))}`
+  );
 
   if (isSuccess) {
     await notificationService.showInformationMessage(`${nls.localize(coerceMessageKey(command))} successfully ran`);


### PR DESCRIPTION
### What does this PR do?
This pull request updates the messaging and logging behavior in the Apex Replay Debugger extension and its associated tests. The most significant changes include refining message keys, improving test assertions for command outputs, and enhancing logging functionality with additional telemetry and notifications.

### Messaging Updates:
* [`packages/salesforcedx-vscode-apex-replay-debugger/src/messages/i18n.ts`](diffhunk://#diff-df1010c2f1fd5c69f6839e120a387d5e7d671c4e4c9a4be369968265de74f881L29-R29): Changed the `long_command_end` message from "Ending" to "Ended" for consistency in command completion messages.

### Test Updates:
* [`packages/salesforcedx-vscode-automation-tests/test/specs/apexReplayDebugger.e2e.ts`](diffhunk://#diff-f32189fe95c6c0b0de8ffdf22c01a12a3506f444f9d7e66b5e01257368cf6d83L106-R106): Updated test assertions to check for the refined "Ended" message in command outputs, ensuring alignment with the new messaging format. [[1]](diffhunk://#diff-f32189fe95c6c0b0de8ffdf22c01a12a3506f444f9d7e66b5e01257368cf6d83L106-R106) [[2]](diffhunk://#diff-f32189fe95c6c0b0de8ffdf22c01a12a3506f444f9d7e66b5e01257368cf6d83L281-R281)
* [`packages/salesforcedx-vscode-automation-tests/test/specs/trailApexReplayDebugger.e2e.ts`](diffhunk://#diff-979b86e7dcf1b9e97bf9ec140ae64e5397c3e2a4ca972443e67eed66019de325L119-R119): Modified test cases to validate the updated "Ended" message for commands like "SFDX: Update Checkpoints in Org" and "SFDX: Turn On Apex Debug Log for Replay Debugger." [[1]](diffhunk://#diff-979b86e7dcf1b9e97bf9ec140ae64e5397c3e2a4ca972443e67eed66019de325L119-R119) [[2]](diffhunk://#diff-979b86e7dcf1b9e97bf9ec140ae64e5397c3e2a4ca972443e67eed66019de325L141-R141)

### Logging Enhancements:
* [`packages/salesforcedx-vscode-core/src/commands/startApexDebugLogging.ts`](diffhunk://#diff-dd4903803adf2339af4d17a095961c5ea463d4de49b26f4187932fbf7aa7a737L41-R49): Improved logging functionality by replacing `handleFinishCommand` with detailed command completion logs using `channelService.showCommandWithTimestamp`. Added telemetry tracking and user notifications for successful command execution.

### What issues does this PR fix or reference?
@W-19157078@