### PR TITLE
W-19136990: Backwards compatibility i.e. fixing telemetry service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       "dependencies": {
         "@actions/core": "^1.11.0",
         "@actions/github": "^6.0.0",
+        "@salesforce/vscode-service-provider": "1.4.2",
         "a": "3.0.1",
         "node": "^20.17.0",
         "npm": "^10",
@@ -6467,9 +6468,9 @@
       "license": "MIT"
     },
     "node_modules/@salesforce/vscode-service-provider": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/vscode-service-provider/-/vscode-service-provider-1.4.1.tgz",
-      "integrity": "sha512-p8+6AGDj3Dha6fG/6VO3hkpkF/4hTkQ/2vxJrdl9MJxdfCyFhjhlSH7oQEYzfNfueyGwQu0extyEXO1QLja+cg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/vscode-service-provider/-/vscode-service-provider-1.4.2.tgz",
+      "integrity": "sha512-qBG1YvisKJI9KP/aUvnoGfeKyGtnpaZBOa+HzFXXEUGmM3qnKXB+JbpnhRvzoLDEfoL+OtQvu2RJSGgx10hXpQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=18.18.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,11 @@
       "dependencies": {
         "@actions/core": "^1.11.0",
         "@actions/github": "^6.0.0",
-        "@salesforce/vscode-service-provider": "1.4.2",
+        "@salesforce/vscode-service-provider": "1.5.0",
         "a": "3.0.1",
         "node": "^20.17.0",
         "npm": "^10",
+        "picomatch": "4.0.3",
         "semver": "^7.5.4",
         "ts-node": "10.9.2"
       },
@@ -6468,9 +6469,9 @@
       "license": "MIT"
     },
     "node_modules/@salesforce/vscode-service-provider": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@salesforce/vscode-service-provider/-/vscode-service-provider-1.4.2.tgz",
-      "integrity": "sha512-qBG1YvisKJI9KP/aUvnoGfeKyGtnpaZBOa+HzFXXEUGmM3qnKXB+JbpnhRvzoLDEfoL+OtQvu2RJSGgx10hXpQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/vscode-service-provider/-/vscode-service-provider-1.5.0.tgz",
+      "integrity": "sha512-x/KO689KwVTMWrbTuKGyguoZ2Eb6ALHZM9FFftL94PJ96bL+fFmHOQEgm9ya8WakN9Q2tboJOh79Z9G1EhkhNw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=18.18.2"
@@ -9233,6 +9234,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/append-transform": {
@@ -20157,6 +20170,18 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/jest-editor-support/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/jest-editor-support/node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -20645,6 +20670,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jest-util/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/jest-validate": {
@@ -22610,6 +22648,18 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mime": {
@@ -28250,12 +28300,12 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -29600,6 +29650,19 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/real-require": {
@@ -32484,18 +32547,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/title-case": {
@@ -35417,7 +35468,7 @@
         "vscode-uri": "^3.1.0"
       },
       "devDependencies": {
-        "@salesforce/vscode-service-provider": "^1.4.1",
+        "@salesforce/vscode-service-provider": "^1.5.0",
         "@types/jest": "^29.5.5",
         "@types/node": "^20.0.0",
         "@vscode/debugadapter-testsupport": "1.68.0",
@@ -35502,7 +35553,7 @@
         "@salesforce/core-bundle": "^8.18.4",
         "@salesforce/salesforcedx-utils": "64.7.0",
         "@salesforce/source-tracking-bundle": "^7.4.9",
-        "@salesforce/vscode-service-provider": "^1.4.1",
+        "@salesforce/vscode-service-provider": "^1.5.0",
         "applicationinsights": "1.0.7",
         "cross-spawn": "7.0.6",
         "o11y": "250.14.0",
@@ -35773,7 +35824,7 @@
         "@salesforce/apex-tmlanguage": "1.8.1",
         "@salesforce/salesforcedx-utils": "64.7.0",
         "@salesforce/salesforcedx-utils-vscode": "64.7.0",
-        "@salesforce/vscode-service-provider": "^1.4.1",
+        "@salesforce/vscode-service-provider": "^1.5.0",
         "@stoplight/spectral-core": "1.20.0",
         "@stoplight/spectral-functions": "1.10.1",
         "@stoplight/spectral-rulesets": "1.22.0",
@@ -36275,7 +36326,7 @@
         "@salesforce/source-deploy-retrieve-bundle": "^12.21.6",
         "@salesforce/templates": "^64.2.1",
         "@salesforce/ts-types": "2.0.12",
-        "@salesforce/vscode-service-provider": "^1.4.1",
+        "@salesforce/vscode-service-provider": "^1.5.0",
         "applicationinsights": "1.0.7",
         "glob": "^11.0.1",
         "o11y": "250.14.0",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,11 @@
   "dependencies": {
     "@actions/core": "^1.11.0",
     "@actions/github": "^6.0.0",
-    "@salesforce/vscode-service-provider": "1.4.2",
+    "@salesforce/vscode-service-provider": "1.5.0",
     "a": "3.0.1",
     "node": "^20.17.0",
     "npm": "^10",
+    "picomatch": "4.0.3",
     "semver": "^7.5.4",
     "ts-node": "10.9.2"
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@actions/core": "^1.11.0",
     "@actions/github": "^6.0.0",
+    "@salesforce/vscode-service-provider": "1.4.2",
     "a": "3.0.1",
     "node": "^20.17.0",
     "npm": "^10",

--- a/packages/salesforcedx-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-apex-replay-debugger/package.json
@@ -20,7 +20,7 @@
     "vscode-uri": "^3.1.0"
   },
   "devDependencies": {
-    "@salesforce/vscode-service-provider": "^1.4.1",
+    "@salesforce/vscode-service-provider": "^1.5.0",
     "@types/jest": "^29.5.5",
     "@types/node": "^20.0.0",
     "@vscode/debugadapter-testsupport": "1.68.0",

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -13,7 +13,7 @@
     "@salesforce/core-bundle": "^8.18.4",
     "@salesforce/salesforcedx-utils": "64.7.0",
     "@salesforce/source-tracking-bundle": "^7.4.9",
-    "@salesforce/vscode-service-provider": "^1.4.1",
+    "@salesforce/vscode-service-provider": "^1.5.0",
     "applicationinsights": "1.0.7",
     "cross-spawn": "7.0.6",
     "o11y": "250.14.0",

--- a/packages/salesforcedx-utils-vscode/src/helpers/activationTracker.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/activationTracker.ts
@@ -42,7 +42,7 @@ export class ActivationTracker {
     }
 
     const activationInfo: ActivationInfo = {
-      activateStartTime: this.startTime,
+      startActivateHrTime: this.startTime,
       activateStartDate: this.activateStartDate,
       activateEndDate,
       extensionActivationTime: TimingUtils.getElapsedTime(this.startTime),

--- a/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
+++ b/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
@@ -102,13 +102,18 @@ export class TelemetryService implements TelemetryServiceInterface {
    * @returns number in milliseconds, or undefined if input is undefined
    */
   public hrTimeToMilliseconds(hrTime?: number | [number, number]): number {
-    const timing = hrTime ?? [0, 0];
-    if (typeof timing === 'number') {
-      return timing;
+public hrTimeToMilliseconds(hrTime?: number | [number, number]): number {
+    if (typeof hrTime === 'number') {
+      return hrTime;
     }
+    if (!hrTime) {
+      return 0;
+    }
+
     // Convert hrtime [seconds, nanoseconds] to milliseconds since epoch
-    const [seconds, nanoseconds] = timing;
+    const [seconds, nanoseconds] = hrTime;
     return seconds * 1000 + nanoseconds / 1000000;
+  }
   }
 
   public getEndHRTime(hrstart: [number, number]): number {

--- a/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
+++ b/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
@@ -102,18 +102,15 @@ export class TelemetryService implements TelemetryServiceInterface {
    * @returns number in milliseconds, or undefined if input is undefined
    */
   public hrTimeToMilliseconds(hrTime?: number | [number, number]): number {
-public hrTimeToMilliseconds(hrTime?: number | [number, number]): number {
-    if (typeof hrTime === 'number') {
-      return hrTime;
-    }
     if (!hrTime) {
       return 0;
+    } else if (typeof hrTime === 'number') {
+      return hrTime;
+    } else {
+      // Convert hrtime [seconds, nanoseconds] to milliseconds since epoch
+      const [seconds, nanoseconds] = hrTime;
+      return seconds * 1000 + nanoseconds / 1000000;
     }
-
-    // Convert hrtime [seconds, nanoseconds] to milliseconds since epoch
-    const [seconds, nanoseconds] = hrTime;
-    return seconds * 1000 + nanoseconds / 1000000;
-  }
   }
 
   public getEndHRTime(hrstart: [number, number]): number {

--- a/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
+++ b/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { Properties, Measurements, TelemetryData, TelemetryReporter } from '@salesforce/vscode-service-provider';
 import { ExtensionContext, ExtensionMode, workspace } from 'vscode';
 import { z } from 'zod';
 import {
@@ -17,15 +18,40 @@ import { disableCLITelemetry, isCLITelemetryAllowed } from '../telemetry/cliConf
 import { determineReporters, initializeO11yReporter } from '../telemetry/reporters/determineReporters';
 import { TelemetryReporterConfig } from '../telemetry/reporters/telemetryReporterConfig';
 import { isInternalHost } from '../telemetry/utils/isInternal';
-import {
-  Properties,
-  Measurements,
-  TelemetryData,
-  TelemetryServiceInterface,
-  TelemetryReporter,
-  ActivationInfo
-} from '../types';
 import { UserService } from './userService';
+
+// Our simplified interface - uses service provider types but keeps our method signatures
+export interface TelemetryServiceInterface {
+  initializeService(extensionContext: ExtensionContext): Promise<void>;
+  getTelemetryReporterName(): string;
+  getReporters(): TelemetryReporter[];
+  isTelemetryEnabled(): Promise<boolean>;
+  checkCliTelemetry(): Promise<boolean>;
+  isTelemetryExtensionConfigurationEnabled(): boolean;
+  setCliTelemetryEnabled(isEnabled: boolean): void;
+  sendActivationEventInfo(activationInfo: ActivationInfo): void;
+  sendExtensionActivationEvent(startTime?: number, markEndTime?: number, telemetryData?: TelemetryData): void;
+  sendExtensionDeactivationEvent(): void;
+  sendCommandEvent(
+    commandName?: string,
+    startTime?: number,
+    properties?: Properties,
+    measurements?: Measurements
+  ): void;
+  sendException(name: string, message: string): void;
+  sendEventData(eventName: string, properties?: { [key: string]: string }, measures?: { [key: string]: number }): void;
+  dispose(): void;
+}
+
+// Our ActivationInfo type - compatible with existing code
+export type ActivationInfo = {
+  activateStartTime: number;
+  activateStartDate: Date;
+  activateEndDate?: Date;
+  extensionActivationTime: number;
+  markEndTime?: number;
+  loadStartDate?: Date;
+};
 
 type CommandMetric = {
   extensionName: string;

--- a/packages/salesforcedx-utils-vscode/src/types/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/types/index.ts
@@ -104,8 +104,7 @@ export {
   Properties,
   TelemetryData,
   ExtensionInfo,
-  ExtensionsInfo
+  ExtensionsInfo,
+  ActivationInfo,
+  TelemetryServiceInterface
 } from '@salesforce/vscode-service-provider';
-
-// Export our simplified telemetry interface and types
-export { TelemetryServiceInterface, ActivationInfo } from '../services/telemetry';

--- a/packages/salesforcedx-utils-vscode/src/types/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/types/index.ts
@@ -16,7 +16,7 @@ export {
   CLIENT_ID,
   SFDX_FOLDER
 } from './constants';
-import { Event, ExtensionContext, Uri, ExtensionKind } from 'vscode';
+import { Event } from 'vscode';
 
 // Precondition checking
 ////////////////////////
@@ -97,98 +97,15 @@ export type LocalComponent = DirFileNameSelection & {
 
 export { MessageArgs } from '@salesforce/salesforcedx-utils';
 
-// Telemetry types
-//////////////////
+// Re-export telemetry types from vscode-service-provider
+export {
+  TelemetryReporter,
+  Measurements,
+  Properties,
+  TelemetryData,
+  ExtensionInfo,
+  ExtensionsInfo
+} from '@salesforce/vscode-service-provider';
 
-export interface TelemetryReporter {
-  sendTelemetryEvent(
-    eventName: string,
-    properties?: {
-      [key: string]: string;
-    },
-    measurements?: {
-      [key: string]: number;
-    }
-  ): void;
-  sendExceptionEvent(
-    exceptionName: string,
-    exceptionMessage: string,
-    measurements?: {
-      [key: string]: number;
-    }
-  ): void;
-  dispose(): Promise<void>;
-}
-
-export type Measurements = {
-  [key: string]: number;
-};
-
-export type Properties = {
-  [key: string]: string;
-};
-
-export type TelemetryData = {
-  properties?: Properties;
-  measurements?: Measurements;
-};
-
-export type ExtensionInfo = {
-  isActive: boolean;
-  path: string;
-  kind: ExtensionKind;
-  uri: Uri;
-  loadStartDate: Date;
-};
-
-export type ExtensionsInfo = {
-  [extensionId: string]: ExtensionInfo;
-};
-
-export type ActivationInfo = Partial<ExtensionInfo> & {
-  activateStartTime: number;
-  activateStartDate: Date;
-  activateEndDate?: Date;
-  extensionActivationTime: number;
-  markEndTime?: number;
-};
-
-export interface TelemetryServiceInterface {
-  /**
-   * Initialize Telemetry Service during extension activation.
-   * @param extensionContext extension context
-   */
-  initializeService(extensionContext: ExtensionContext): Promise<void>;
-  /**
-   * Helper to get the name for telemetryReporter
-   * if the extension from extension pack, use salesforcedx-vscode
-   * otherwise use the extension name
-   * exported only for unit test
-   */
-  getTelemetryReporterName(): string;
-  getReporters(): TelemetryReporter[];
-  isTelemetryEnabled(): Promise<boolean>;
-  checkCliTelemetry(): Promise<boolean>;
-  isTelemetryExtensionConfigurationEnabled(): boolean;
-  setCliTelemetryEnabled(isEnabled: boolean): void;
-  sendActivationEventInfo(activationInfo: ActivationInfo): void;
-  sendExtensionActivationEvent(startTime?: number, markEndTime?: number, telemetryData?: TelemetryData): void;
-  sendExtensionDeactivationEvent(): void;
-  sendCommandEvent(
-    commandName?: string,
-    startTime?: number,
-    properties?: Properties,
-    measurements?: Measurements
-  ): void;
-  sendException(name: string, message: string): void;
-  sendEventData(
-    eventName: string,
-    properties?: {
-      [key: string]: string;
-    },
-    measures?: {
-      [key: string]: number;
-    }
-  ): void;
-  dispose(): void;
-}
+// Export our simplified telemetry interface and types
+export { TelemetryServiceInterface, ActivationInfo } from '../services/telemetry';

--- a/packages/salesforcedx-utils-vscode/test/jest/helpers/activationTrackerClass.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/helpers/activationTrackerClass.test.ts
@@ -66,7 +66,7 @@ describe('ActivationTracker', () => {
 
     expect(telemetryService.sendActivationEventInfo).toHaveBeenCalledWith(
       expect.objectContaining({
-        activateStartTime: expect.any(Number),
+        startActivateHrTime: expect.any(Number),
         activateStartDate: expect.any(Date),
         activateEndDate: expect.any(Date),
         extensionActivationTime: expect.any(Number),

--- a/packages/salesforcedx-utils-vscode/test/jest/helpers/activationTrackerClass.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/helpers/activationTrackerClass.test.ts
@@ -8,7 +8,7 @@ import { ExtensionContext } from 'vscode';
 import { ActivationTracker } from '../../../src/helpers/activationTracker';
 import { getExtensionInfo } from '../../../src/helpers/activationTrackerUtils';
 import { TimingUtils } from '../../../src/helpers/timingUtils';
-import { TelemetryService } from '../../../src/services/telemetry';
+import { TelemetryServiceInterface } from '../../../src/types';
 
 jest.mock('../../../src/helpers/timingUtils', () => ({
   TimingUtils: {
@@ -33,7 +33,7 @@ jest.mock('vscode', () => ({
 
 describe('ActivationTracker', () => {
   let extensionContext: ExtensionContext;
-  let telemetryService: TelemetryService;
+  let telemetryService: TelemetryServiceInterface;
   let tracker: ActivationTracker;
 
   beforeEach(() => {
@@ -46,7 +46,7 @@ describe('ActivationTracker', () => {
     telemetryService = {
       sendActivationEventInfo: jest.fn(),
       sendExtensionActivationEvent: jest.fn()
-    } as unknown as TelemetryService;
+    } as unknown as TelemetryServiceInterface;
 
     // Set up default mock return values for TimingUtils
     (TimingUtils.getCurrentTime as jest.Mock).mockReturnValue(Date.now());

--- a/packages/salesforcedx-utils-vscode/test/jest/telemetry/telemetry.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/telemetry/telemetry.test.ts
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2024, salesforce.com, inc.
+ * Copyright (c) 2025, salesforce.com, inc.
  * All rights reserved.
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
 import { workspace } from 'vscode';
 import { TelemetryService, TelemetryServiceInterface } from '../../../src';
 import { SFDX_CORE_EXTENSION_NAME } from '../../../src/constants';
@@ -352,42 +354,22 @@ describe('Telemetry', () => {
       });
     });
 
-    describe('convertTimingToNumber helper method', () => {
+    describe('hrTimeToMilliseconds helper method', () => {
       it('should convert number correctly', () => {
         const startTime = Date.now();
-        const result = (instance as any).convertTimingToNumber(startTime);
+        const result = (instance as any).hrTimeToMilliseconds(startTime);
         expect(result).toBe(startTime);
       });
 
       it('should convert hrtime tuple correctly', () => {
         const hrtime: [number, number] = [1000, 500000000]; // 1000 seconds + 500ms
-        const result = (instance as any).convertTimingToNumber(hrtime);
+        const result = (instance as any).hrTimeToMilliseconds(hrtime);
         expect(result).toBe(1000500); // 1000 seconds * 1000 + 500ms
       });
 
-      it('should handle undefined correctly', () => {
-        const result = (instance as any).convertTimingToNumber(undefined);
-        expect(result).toBeUndefined();
-      });
-
-      it('should warn and return undefined for invalid formats', () => {
-        const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
-
-        const result = (instance as any).convertTimingToNumber('invalid' as any);
-        expect(result).toBeUndefined();
-        expect(consoleSpy).toHaveBeenCalledWith('Invalid timing format provided:', 'invalid');
-
-        consoleSpy.mockRestore();
-      });
-
-      it('should handle malformed arrays correctly', () => {
-        const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
-
-        const result = (instance as any).convertTimingToNumber([1, 2, 3] as any);
-        expect(result).toBeUndefined();
-        expect(consoleSpy).toHaveBeenCalledWith('Invalid timing format provided:', [1, 2, 3]);
-
-        consoleSpy.mockRestore();
+      it('should handle undefined by defaulting to [0, 0]', () => {
+        const result = (instance as any).hrTimeToMilliseconds(undefined);
+        expect(result).toBe(0); // [0, 0] converts to 0 milliseconds
       });
     });
   });

--- a/packages/salesforcedx-utils-vscode/test/jest/telemetry/telemetry.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/telemetry/telemetry.test.ts
@@ -180,4 +180,215 @@ describe('Telemetry', () => {
       expect(await instance.isTelemetryEnabled()).toBe(false);
     });
   });
+
+  describe('Telemetry Service - Backwards Compatibility', () => {
+    let instance: TelemetryService;
+    let mockReporter: any;
+
+    beforeEach(() => {
+      // Clear instances to get fresh instance
+      TelemetryServiceProvider.instances.clear();
+      instance = TelemetryServiceProvider.getInstance() as TelemetryService;
+
+      // Mock reporters to avoid actual telemetry sends
+      mockReporter = {
+        sendTelemetryEvent: jest.fn(),
+        sendExceptionEvent: jest.fn(),
+        sendEventData: jest.fn(),
+        dispose: jest.fn()
+      };
+
+      // Replace the reporters array with our mock
+      (instance as any).reporters = [mockReporter];
+
+      // Set the extension name properly for testing
+      (instance as any).extensionName = 'salesforcedx-vscode-core';
+
+      // Enable telemetry for testing by mocking the validation method to call the callback directly
+      (instance as any).validateTelemetry = jest.fn((callback: () => void) => {
+        callback(); // Call immediately for testing
+      });
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      TelemetryServiceProvider.instances.clear();
+    });
+
+    describe('sendExtensionActivationEvent timing parameter compatibility', () => {
+      it('should work with number startTime (new format)', () => {
+        // Use a recent timestamp that won't cause negative time issues
+        const startTime = Date.now() - 50; // 50ms ago
+
+        expect(() => {
+          instance.sendExtensionActivationEvent(startTime);
+        }).not.toThrow();
+
+        expect(mockReporter.sendTelemetryEvent).toHaveBeenCalledWith(
+          'activationEvent',
+          expect.objectContaining({ extensionName: 'salesforcedx-vscode-core' }),
+          expect.objectContaining({ startupTime: expect.any(Number) })
+        );
+      });
+
+      it('should work with hrtime tuple startTime (legacy format)', () => {
+        // Create a valid hrtime tuple representing 50ms ago
+        const now = Date.now();
+        const fiftyMsAgo = now - 50;
+        const hrtime: [number, number] = [Math.floor(fiftyMsAgo / 1000), (fiftyMsAgo % 1000) * 1000000];
+
+        expect(() => {
+          instance.sendExtensionActivationEvent(hrtime);
+        }).not.toThrow();
+
+        expect(mockReporter.sendTelemetryEvent).toHaveBeenCalledWith(
+          'activationEvent',
+          expect.objectContaining({ extensionName: 'salesforcedx-vscode-core' }),
+          expect.objectContaining({ startupTime: expect.any(Number) })
+        );
+      });
+
+      it('should work with undefined startTime', () => {
+        expect(() => {
+          instance.sendExtensionActivationEvent(undefined, 100);
+        }).not.toThrow();
+
+        expect(mockReporter.sendTelemetryEvent).toHaveBeenCalledWith(
+          'activationEvent',
+          expect.objectContaining({ extensionName: 'salesforcedx-vscode-core' }),
+          expect.objectContaining({ startupTime: 100 })
+        );
+      });
+
+      it('should use markEndTime when provided, regardless of startTime format', () => {
+        const startTime = Date.now() - 50;
+        const markEndTime = 250;
+
+        instance.sendExtensionActivationEvent(startTime, markEndTime);
+
+        expect(mockReporter.sendTelemetryEvent).toHaveBeenCalledWith(
+          'activationEvent',
+          expect.objectContaining({ extensionName: 'salesforcedx-vscode-core' }),
+          expect.objectContaining({ startupTime: markEndTime })
+        );
+      });
+    });
+
+    describe('sendCommandEvent timing parameter compatibility', () => {
+      it('should work with number startTime (new format)', () => {
+        const startTime = Date.now() - 50; // 50ms ago
+
+        expect(() => {
+          instance.sendCommandEvent('test_command', startTime, { testProp: 'value' });
+        }).not.toThrow();
+
+        expect(mockReporter.sendTelemetryEvent).toHaveBeenCalledWith(
+          'commandExecution',
+          expect.objectContaining({
+            extensionName: 'salesforcedx-vscode-core',
+            commandName: 'test_command',
+            testProp: 'value'
+          }),
+          expect.objectContaining({ executionTime: expect.any(Number) })
+        );
+      });
+
+      it('should work with hrtime tuple startTime (legacy format)', () => {
+        // Create a valid hrtime tuple representing 50ms ago
+        const now = Date.now();
+        const fiftyMsAgo = now - 50;
+        const hrtime: [number, number] = [Math.floor(fiftyMsAgo / 1000), (fiftyMsAgo % 1000) * 1000000];
+
+        expect(() => {
+          instance.sendCommandEvent('test_command', hrtime, { testProp: 'value' });
+        }).not.toThrow();
+
+        expect(mockReporter.sendTelemetryEvent).toHaveBeenCalledWith(
+          'commandExecution',
+          expect.objectContaining({
+            extensionName: 'salesforcedx-vscode-core',
+            commandName: 'test_command',
+            testProp: 'value'
+          }),
+          expect.objectContaining({ executionTime: expect.any(Number) })
+        );
+      });
+
+      it('should work with undefined startTime', () => {
+        expect(() => {
+          instance.sendCommandEvent('test_command', undefined, { testProp: 'value' });
+        }).not.toThrow();
+
+        expect(mockReporter.sendTelemetryEvent).toHaveBeenCalledWith(
+          'commandExecution',
+          expect.objectContaining({
+            extensionName: 'salesforcedx-vscode-core',
+            commandName: 'test_command',
+            testProp: 'value'
+          }),
+          // No executionTime measurement when startTime is undefined
+          expect.not.objectContaining({ executionTime: expect.any(Number) })
+        );
+      });
+
+      it('should include measurements when provided with timing', () => {
+        const startTime = Date.now() - 50;
+        const measurements = { customMetric: 42 };
+
+        instance.sendCommandEvent('test_command', startTime, { testProp: 'value' }, measurements);
+
+        expect(mockReporter.sendTelemetryEvent).toHaveBeenCalledWith(
+          'commandExecution',
+          expect.objectContaining({
+            extensionName: 'salesforcedx-vscode-core',
+            commandName: 'test_command',
+            testProp: 'value'
+          }),
+          expect.objectContaining({
+            executionTime: expect.any(Number),
+            customMetric: 42
+          })
+        );
+      });
+    });
+
+    describe('convertTimingToNumber helper method', () => {
+      it('should convert number correctly', () => {
+        const startTime = Date.now();
+        const result = (instance as any).convertTimingToNumber(startTime);
+        expect(result).toBe(startTime);
+      });
+
+      it('should convert hrtime tuple correctly', () => {
+        const hrtime: [number, number] = [1000, 500000000]; // 1000 seconds + 500ms
+        const result = (instance as any).convertTimingToNumber(hrtime);
+        expect(result).toBe(1000500); // 1000 seconds * 1000 + 500ms
+      });
+
+      it('should handle undefined correctly', () => {
+        const result = (instance as any).convertTimingToNumber(undefined);
+        expect(result).toBeUndefined();
+      });
+
+      it('should warn and return undefined for invalid formats', () => {
+        const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+        const result = (instance as any).convertTimingToNumber('invalid' as any);
+        expect(result).toBeUndefined();
+        expect(consoleSpy).toHaveBeenCalledWith('Invalid timing format provided:', 'invalid');
+
+        consoleSpy.mockRestore();
+      });
+
+      it('should handle malformed arrays correctly', () => {
+        const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+        const result = (instance as any).convertTimingToNumber([1, 2, 3] as any);
+        expect(result).toBeUndefined();
+        expect(consoleSpy).toHaveBeenCalledWith('Invalid timing format provided:', [1, 2, 3]);
+
+        consoleSpy.mockRestore();
+      });
+    });
+  });
 });

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -30,7 +30,7 @@
     "@salesforce/apex-tmlanguage": "1.8.1",
     "@salesforce/salesforcedx-utils": "64.7.0",
     "@salesforce/salesforcedx-utils-vscode": "64.7.0",
-    "@salesforce/vscode-service-provider": "^1.4.1",
+    "@salesforce/vscode-service-provider": "^1.5.0",
     "@stoplight/spectral-core": "1.20.0",
     "@stoplight/spectral-functions": "1.10.1",
     "@stoplight/spectral-rulesets": "1.22.0",

--- a/packages/salesforcedx-vscode-apex/test/jest/telemetry/mockTelemetryService.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/telemetry/mockTelemetryService.ts
@@ -57,7 +57,11 @@ export class MockTelemetryService extends TelemetryService implements TelemetryS
     // Mock implementation - use local ActivationInfo type
   }
 
-  public sendExtensionActivationEvent(startTime?: number, markEndTime?: number, telemetryData?: TelemetryData): void {
+  public sendExtensionActivationEvent(
+    hrstart?: number | [number, number],
+    markEndTime?: number,
+    telemetryData?: TelemetryData
+  ): void {
     // Mock implementation
   }
 
@@ -67,7 +71,7 @@ export class MockTelemetryService extends TelemetryService implements TelemetryS
 
   public sendCommandEvent(
     commandName?: string,
-    startTime?: number,
+    startTime?: number | [number, number],
     properties?: Properties,
     measurements?: Measurements
   ): void {

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -32,7 +32,7 @@
     "@salesforce/source-deploy-retrieve-bundle": "^12.21.6",
     "@salesforce/templates": "^64.2.1",
     "@salesforce/ts-types": "2.0.12",
-    "@salesforce/vscode-service-provider": "^1.4.1",
+    "@salesforce/vscode-service-provider": "^1.5.0",
     "applicationinsights": "1.0.7",
     "glob": "^11.0.1",
     "o11y": "250.14.0",


### PR DESCRIPTION
### What does this PR do?
Adds backwards compatibility to the changes we introduced for the telemetry service. 

### What issues does this PR fix or reference?
@W-19136990@

### Functionality Before
Only had the new methods and nothin else

### Functionality After
Now works if you pass in "hrtime(): [number, number]" OR "now(): number"