### PR TITLE
[W-19387779] ci: runApexTests.e2e.ts works on Mac again

### DIFF
--- a/packages/salesforcedx-vscode-automation-tests/test/specs/runApexTests.e2e.ts
+++ b/packages/salesforcedx-vscode-automation-tests/test/specs/runApexTests.e2e.ts
@@ -355,7 +355,6 @@ describe('Run Apex Tests', () => {
     await verifyOutputPanelText(terminalText!, expectedTexts);
   });
 
-  // Known issue on Mac GHA: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002KT1FhYAL/view
   it('Run a test that fails and fix it', async () => {
     logTestStart(testSetup, 'Run a test that fails and fix it');
 

--- a/packages/salesforcedx-vscode-automation-tests/test/specs/runApexTests.e2e.ts
+++ b/packages/salesforcedx-vscode-automation-tests/test/specs/runApexTests.e2e.ts
@@ -137,7 +137,7 @@ describe('Run Apex Tests', () => {
     expect(await statusBar.getAttribute('aria-label')).to.contain('Indexing complete');
   });
 
-  it.skip('Run All Tests via Apex Class', async () => {
+  it('Run All Tests via Apex Class', async () => {
     logTestStart(testSetup, 'Run All Tests via Apex Class');
     const workbench = getWorkbench();
     const textEditor = await getTextEditor(workbench, 'ExampleApexClass1Test.cls');
@@ -170,7 +170,7 @@ describe('Run Apex Tests', () => {
     await verifyOutputPanelText(outputPanelText, expectedTexts);
   });
 
-  it.skip('Run Single Test via Apex Class', async () => {
+  it('Run Single Test via Apex Class', async () => {
     logTestStart(testSetup, 'Run Single Test via Apex Class');
     const workbench = getWorkbench();
     const textEditor = await getTextEditor(workbench, 'ExampleApexClass2Test.cls');
@@ -203,7 +203,7 @@ describe('Run Apex Tests', () => {
     await verifyOutputPanelText(outputPanelText, expectedTexts);
   });
 
-  it.skip('Run All Tests via Command Palette', async () => {
+  it('Run All Tests via Command Palette', async () => {
     logTestStart(testSetup, 'Run All Tests via Command Palette');
     // Clear the Output view.
     await dismissAllNotifications();
@@ -237,7 +237,7 @@ describe('Run Apex Tests', () => {
     await verifyOutputPanelText(outputPanelText, expectedTexts);
   });
 
-  it.skip('Run Single Class via Command Palette', async () => {
+  it('Run Single Class via Command Palette', async () => {
     logTestStart(testSetup, 'Run Single Class via Command Palette');
     // Clear the Output view.
     await dismissAllNotifications();
@@ -266,7 +266,7 @@ describe('Run Apex Tests', () => {
     await verifyOutputPanelText(outputPanelText, expectedTexts);
   });
 
-  it.skip('Run All tests via Test Sidebar', async () => {
+  it('Run All tests via Test Sidebar', async () => {
     logTestStart(testSetup, 'Run All tests via Test Sidebar');
     const workbench = getWorkbench();
     const testingView = await workbench.getActivityBar().getViewControl('Testing');
@@ -313,7 +313,7 @@ describe('Run Apex Tests', () => {
     }
   });
 
-  it.skip('Run All Tests on a Class via the Test Sidebar', async () => {
+  it('Run All Tests on a Class via the Test Sidebar', async () => {
     logTestStart(testSetup, 'Run All Tests on a Class via the Test Sidebar');
     const workbench = getWorkbench();
     // Clear the Output view.
@@ -334,7 +334,7 @@ describe('Run Apex Tests', () => {
     await verifyOutputPanelText(terminalText!, expectedTexts);
   });
 
-  it.skip('Run Single Test via the Test Sidebar', async () => {
+  it('Run Single Test via the Test Sidebar', async () => {
     logTestStart(testSetup, 'Run Single Test via the Test Sidebar');
     const workbench = getWorkbench();
     // Clear the Output view.

--- a/packages/salesforcedx-vscode-automation-tests/test/specs/runApexTests.e2e.ts
+++ b/packages/salesforcedx-vscode-automation-tests/test/specs/runApexTests.e2e.ts
@@ -37,7 +37,8 @@ import {
   getWorkbench,
   replaceLineInFile,
   verifyOutputPanelText,
-  waitForAndGetCodeLens
+  waitForAndGetCodeLens,
+  zoom
 } from '@salesforce/salesforcedx-vscode-test-tools/lib/src/ui-interaction';
 import { expect } from 'chai';
 import { By, InputBox, QuickOpenBox, SideBarView } from 'vscode-extension-tester';
@@ -136,7 +137,7 @@ describe('Run Apex Tests', () => {
     expect(await statusBar.getAttribute('aria-label')).to.contain('Indexing complete');
   });
 
-  it('Run All Tests via Apex Class', async () => {
+  it.skip('Run All Tests via Apex Class', async () => {
     logTestStart(testSetup, 'Run All Tests via Apex Class');
     const workbench = getWorkbench();
     const textEditor = await getTextEditor(workbench, 'ExampleApexClass1Test.cls');
@@ -169,7 +170,7 @@ describe('Run Apex Tests', () => {
     await verifyOutputPanelText(outputPanelText, expectedTexts);
   });
 
-  it('Run Single Test via Apex Class', async () => {
+  it.skip('Run Single Test via Apex Class', async () => {
     logTestStart(testSetup, 'Run Single Test via Apex Class');
     const workbench = getWorkbench();
     const textEditor = await getTextEditor(workbench, 'ExampleApexClass2Test.cls');
@@ -202,7 +203,7 @@ describe('Run Apex Tests', () => {
     await verifyOutputPanelText(outputPanelText, expectedTexts);
   });
 
-  it('Run All Tests via Command Palette', async () => {
+  it.skip('Run All Tests via Command Palette', async () => {
     logTestStart(testSetup, 'Run All Tests via Command Palette');
     // Clear the Output view.
     await dismissAllNotifications();
@@ -236,7 +237,7 @@ describe('Run Apex Tests', () => {
     await verifyOutputPanelText(outputPanelText, expectedTexts);
   });
 
-  it('Run Single Class via Command Palette', async () => {
+  it.skip('Run Single Class via Command Palette', async () => {
     logTestStart(testSetup, 'Run Single Class via Command Palette');
     // Clear the Output view.
     await dismissAllNotifications();
@@ -265,7 +266,7 @@ describe('Run Apex Tests', () => {
     await verifyOutputPanelText(outputPanelText, expectedTexts);
   });
 
-  it('Run All tests via Test Sidebar', async () => {
+  it.skip('Run All tests via Test Sidebar', async () => {
     logTestStart(testSetup, 'Run All tests via Test Sidebar');
     const workbench = getWorkbench();
     const testingView = await workbench.getActivityBar().getViewControl('Testing');
@@ -312,7 +313,7 @@ describe('Run Apex Tests', () => {
     }
   });
 
-  it('Run All Tests on a Class via the Test Sidebar', async () => {
+  it.skip('Run All Tests on a Class via the Test Sidebar', async () => {
     logTestStart(testSetup, 'Run All Tests on a Class via the Test Sidebar');
     const workbench = getWorkbench();
     // Clear the Output view.
@@ -333,7 +334,7 @@ describe('Run Apex Tests', () => {
     await verifyOutputPanelText(terminalText!, expectedTexts);
   });
 
-  it('Run Single Test via the Test Sidebar', async () => {
+  it.skip('Run Single Test via the Test Sidebar', async () => {
     logTestStart(testSetup, 'Run Single Test via the Test Sidebar');
     const workbench = getWorkbench();
     // Clear the Output view.
@@ -358,7 +359,7 @@ describe('Run Apex Tests', () => {
   it('Run a test that fails and fix it', async () => {
     logTestStart(testSetup, 'Run a test that fails and fix it');
 
-    await executeQuickPick('View: Close All Editors', Duration.seconds(1));
+    await zoom('Out', 2); // Zoom out the editor view
 
     // Create Apex class AccountService
     await createApexClassWithBugs(classesFolderPath);

--- a/packages/salesforcedx-vscode-automation-tests/test/specs/runApexTests.e2e.ts
+++ b/packages/salesforcedx-vscode-automation-tests/test/specs/runApexTests.e2e.ts
@@ -355,10 +355,12 @@ describe('Run Apex Tests', () => {
   });
 
   // Known issue on Mac GHA: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002KT1FhYAL/view
-  (process.platform === 'darwin' ? it.skip : it)('Run a test that fails and fix it', async () => {
+  it('Run a test that fails and fix it', async () => {
     logTestStart(testSetup, 'Run a test that fails and fix it');
-    // Create Apex class AccountService
 
+    await executeQuickPick('View: Close All Editors', Duration.seconds(1));
+
+    // Create Apex class AccountService
     await createApexClassWithBugs(classesFolderPath);
 
     // Push source to org


### PR DESCRIPTION
### What does this PR do?
Gets rid of the following error that was causing **runApexTests.e2e.ts** to fail:
``` 
✘ Run a test that fails and fix it (9715ms)
      Error: element click intercepted: Element <div class="monaco-list-row" role="option" data-index="2" data-last-element="false" data-parity="even" aria-setsize="15" aria-posinset="3" id="list_id_9_2" aria-label="AccountService.cls-meta.xml" aria-level="1" draggable="false" style="top: 44px; height: 22px;">...</div> is not clickable at point (513, 84). Other element would receive the click: <input class="input" autocorrect="off" autocapitalize="off" spellcheck="false" type="text" wrap="off" aria-label="Type to narrow down results. - Open File" role="textbox" aria-haspopup="menu" aria-autocomplete="list" aria-describedby="quickInput_message" aria-controls="quickInput_list" placeholder="" style="background-color: inherit; color: var(--vscode-input-foreground); width: calc(100% + 0px);" aria-activedescendant="">
  (Session info: chrome=138.0.7204.100)
```

The test failure happened because the VSCode window size was too small, causing **AccountService.cls** to not be visible when trying to select it from the "Open File..." command palette popup.

I resolved the issue by zooming out VSCode to compensate for the smaller window size.

<img width="1024" height="684" alt="Run Apex Tests Run a test that fails and fix it" src="https://github.com/user-attachments/assets/f881001b-0413-45b8-a901-44e5e9536870" />

### What issues does this PR fix or reference?
@W-19387779@

### Functionality Before
**runApexTests.e2e.ts** fails during the "Run a test that fails and fix it" step.

### Functionality After
**runApexTests.e2e.ts** passes.
