### PR TITLE
chore: update date in copyright header

### DIFF
--- a/packages/salesforcedx-vscode-apex-debugger/esbuild.config.mjs
+++ b/packages/salesforcedx-vscode-apex-debugger/esbuild.config.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, salesforce.com, inc.
+ * Copyright (c) 2025, salesforce.com, inc.
  * All rights reserved.
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/packages/salesforcedx-vscode-apex-replay-debugger/esbuild.config.mjs
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/esbuild.config.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, salesforce.com, inc.
+ * Copyright (c) 2025, salesforce.com, inc.
  * All rights reserved.
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/packages/salesforcedx-vscode-apex/esbuild.config.mjs
+++ b/packages/salesforcedx-vscode-apex/esbuild.config.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, salesforce.com, inc.
+ * Copyright (c) 2025, salesforce.com, inc.
  * All rights reserved.
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/packages/salesforcedx-vscode-core/esbuild.config.mjs
+++ b/packages/salesforcedx-vscode-core/esbuild.config.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, salesforce.com, inc.
+ * Copyright (c) 2025, salesforce.com, inc.
  * All rights reserved.
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/packages/salesforcedx-vscode-lightning/esbuild.config.mjs
+++ b/packages/salesforcedx-vscode-lightning/esbuild.config.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, salesforce.com, inc.
+ * Copyright (c) 2025, salesforce.com, inc.
  * All rights reserved.
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/packages/salesforcedx-vscode-lwc/esbuild.config.mjs
+++ b/packages/salesforcedx-vscode-lwc/esbuild.config.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, salesforce.com, inc.
+ * Copyright (c) 2025, salesforce.com, inc.
  * All rights reserved.
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause


### PR DESCRIPTION
### What does this PR do?
This pull request updates the copyright year in the `esbuild.config.mjs` files across several packages from 2024 to 2025. No functional or code logic changes are included; this is a standard annual copyright update.


[skip-validate-pr]