### PR TITLE
chore: fix for diff file

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/sourceDiff.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/sourceDiff.ts
@@ -76,20 +76,14 @@ export const sourceFolderDiff = async (explorerPath?: URI) => {
 
 const handleCacheResults = async (username: string, cache?: MetadataCacheResult): Promise<void> => {
   if (cache) {
-    if (
-      cache.selectedType === PathType.Individual &&
-      cache.cache.components &&
-      typeof cache.selectedPath === 'string'
-    ) {
+    const paths = Array.isArray(cache.selectedPath) ? cache.selectedPath : [cache.selectedPath];
+
+    if (cache.selectedType === PathType.Individual && cache.cache.components) {
       // If selectedPath is a string, diff the single file
-      await differ.diffOneFile(cache.selectedPath, cache.cache.components[0], username);
-    } else if (
-      cache.selectedType === PathType.Multiple &&
-      cache.cache.components &&
-      Array.isArray(cache.selectedPath)
-    ) {
+      await differ.diffOneFile(paths[0], cache.cache.components[0], username);
+    } else if (cache.selectedType === PathType.Multiple && cache.cache.components) {
       // If selectedPath is an array, use the diffMultipleFiles function from directoryDiffer
-      await differ.diffMultipleFiles(username, cache.selectedPath, cache);
+      await differ.diffMultipleFiles(username, paths, cache);
     } else if (cache.selectedType === PathType.Folder) {
       await differ.diffFolder(cache, username);
     }


### PR DESCRIPTION
### What does this PR do?
This pull request refactors the handling of the `selectedPath` property in the `handleCacheResults` function within `sourceDiff.ts`. The main goal is to simplify the logic for processing single and multiple file paths by normalizing `selectedPath` to always be an array, which improves code readability and maintainability.

Refactoring and code simplification:

* Normalized `selectedPath` to always be an array (`paths`), removing separate checks for string and array types, which streamlines the logic for both individual and multiple file diffs.
* Updated calls to `diffOneFile` and `diffMultipleFiles` to use the normalized `paths` variable, ensuring consistent handling of file paths regardless of the input type.

### What issues does this PR fix or reference?
[skip-validate-pr]