### PR TITLE
fix: W-19459990 - org picker supports aliases with dashes

### DIFF
--- a/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-core/src/orgPicker/orgList.ts
@@ -155,7 +155,13 @@ export class OrgList implements vscode.Disposable {
         return { type: 'CONTINUE', data: {} };
       }
       default: {
-        const usernameOrAlias = selection.split(' - ', 1);
+        // Extract the username or alias from the selection
+        // Format is: "alias1,alias2,alias3 - username" or "alias1,alias2,alias3 - username - Expired ❌"
+        // or just "username" or "username - Expired ❌"
+        const cleanSelection = selection.endsWith(' - Expired ❌') ? selection.replace(' - Expired ❌', '') : selection;
+        const lastDashIndex = cleanSelection.lastIndexOf(' - ');
+        const usernameOrAlias = lastDashIndex !== -1 ? cleanSelection.substring(0, lastDashIndex) : cleanSelection;
+
         vscode.commands.executeCommand('sf.config.set', usernameOrAlias);
         return { type: 'CONTINUE', data: {} };
       }

--- a/packages/salesforcedx-vscode-core/test/jest/orgPicker/orgList.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/orgPicker/orgList.test.ts
@@ -489,16 +489,6 @@ describe('OrgList tests', () => {
       expect(executeCommandMock).toHaveBeenCalledWith('sf.config.set', 'MyOrg');
     });
 
-    it('should handle organization selection with complex alias and expired indicator', async () => {
-      const orgSelection = 'My Organization - Dev Sandbox - user@example.com - Expired ❌';
-      showQuickPickMock.mockResolvedValueOnce(orgSelection);
-
-      const result = await orgList.setDefaultOrg();
-
-      expect(result).toEqual({ type: 'CONTINUE', data: {} });
-      expect(executeCommandMock).toHaveBeenCalledWith('sf.config.set', 'My Organization - Dev Sandbox');
-    });
-
     it('should handle org with alias containing dashes and expired indicator', async () => {
       showQuickPickMock.mockResolvedValueOnce('My Organization - Dev Sandbox - foo@bar.com - Expired ❌');
 


### PR DESCRIPTION
### What does this PR do?
This pull request improves how org selections are parsed and handled in the org picker logic, and adds comprehensive tests to ensure correct behavior for various selection formats, including cases with multiple aliases, dashes, and expired indicators.

### Parsing and selection logic improvements

* Enhanced the parsing logic in `OrgList` to accurately extract the username or alias from complex selection strings, including those with multiple dashes, comma-separated aliases, and expired indicators. (`orgList.ts`)

### Test coverage enhancements

* Added a suite of tests for the `setDefaultOrg` method to verify correct command execution for SFDX commands, organization selections with various alias and username formats, and handling of expired org indicators. (`orgList.test.ts`)
* Included tests for edge cases such as selections with no alias, multiple aliases, complex alias structures, and user cancellation. (`orgList.test.ts`)

### What issues does this PR fix or reference?
#6515 , @W-19459990@