### PR TITLE
fix(create apex class): Apex Class commands overwriting existing files with no warning

### DIFF
--- a/packages/salesforcedx-vscode-core/src/commands/templates/apexGenerateClass.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/apexGenerateClass.ts
@@ -9,8 +9,10 @@ import {
   CompositeParametersGatherer,
   LocalComponent,
   ParametersGatherer,
-  SfWorkspaceChecker
+  SfWorkspaceChecker,
+  workspaceUtils
 } from '@salesforce/salesforcedx-utils-vscode';
+import * as path from 'node:path';
 import type { URI } from 'vscode-uri';
 import { MetadataTypeGatherer, SelectFileName, SelectOutputDir, SfCommandlet, SimpleGatherer } from '../util';
 import { OverwriteComponentPrompt } from '../util/overwriteComponentPrompt';
@@ -53,8 +55,11 @@ export const apexGenerateClass = async (sourceUri?: URI) => {
   const gatherers = getParamGatherers();
 
   if (sourceUri) {
-    gatherers.outputDirGatherer = new SimpleGatherer<OutputDirParameter>({
-      outputdir: sourceUri.fsPath
+    const workspaceRoot = workspaceUtils.getRootWorkspacePath();
+    const relativePath = path.relative(workspaceRoot, sourceUri.fsPath);
+
+    gatherers.outputDirGatherer = new SimpleGatherer({
+      outputdir: relativePath
     });
   }
 

--- a/packages/salesforcedx-vscode-core/src/commands/templates/apexGenerateUnitTestClass.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/templates/apexGenerateUnitTestClass.ts
@@ -9,8 +9,10 @@ import {
   CompositeParametersGatherer,
   LocalComponent,
   ParametersGatherer,
-  SfWorkspaceChecker
+  SfWorkspaceChecker,
+  workspaceUtils
 } from '@salesforce/salesforcedx-utils-vscode';
+import * as path from 'node:path';
 import type { URI } from 'vscode-uri';
 import { MetadataTypeGatherer, OverwriteComponentPrompt, SfCommandlet, SimpleGatherer } from '../util';
 import { getParamGatherers } from './apexGenerateClass';
@@ -38,7 +40,7 @@ export const apexGenerateUnitTestClass = async (
             outputdir: outputDirectory
           })
         : new SimpleGatherer<OutputDirParameter>({
-            outputdir: outputDirectory.fsPath
+            outputdir: path.relative(workspaceUtils.getRootWorkspacePath(), outputDirectory.fsPath)
           });
   } else {
     outputDirGatherer = gatherers.outputDirGatherer;

--- a/packages/salesforcedx-vscode-core/src/util/types.ts
+++ b/packages/salesforcedx-vscode-core/src/util/types.ts
@@ -20,8 +20,8 @@ export type ComponentName = {
 };
 
 export type DeployRetrieveOperationType = 'deploy' | 'retrieve' | 'push' | 'pull' | 'delete';
-export const isContinue = (contineOrCancel: ContinueOrCancel): contineOrCancel is ContinueResponse<OneOrMany> =>
-  Reflect.get(contineOrCancel, 'type') === 'CONTINUE';
+export const isContinue = (continueOrCancel: ContinueOrCancel): continueOrCancel is ContinueResponse<OneOrMany> =>
+  Reflect.get(continueOrCancel, 'type') === 'CONTINUE';
 
 export const isComponentName = (component: ComponentName | LocalComponent): component is ComponentName =>
   Reflect.has(component, 'name');

--- a/packages/salesforcedx-vscode-core/test/jest/commands/templates/apexGenerateClass.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/commands/templates/apexGenerateClass.test.ts
@@ -5,7 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { CompositeParametersGatherer, SfWorkspaceChecker } from '@salesforce/salesforcedx-utils-vscode';
+import { CompositeParametersGatherer, SfWorkspaceChecker, workspaceUtils } from '@salesforce/salesforcedx-utils-vscode';
+import * as path from 'node:path';
 import { URI } from 'vscode-uri';
 import { apexGenerateClass } from '../../../../src/commands/templates';
 import { clearGathererCache } from '../../../../src/commands/templates/apexGenerateClass';
@@ -37,6 +38,9 @@ jest.mock('@salesforce/salesforcedx-utils-vscode', () => {
   };
 });
 
+const testProjectPath = path.resolve('test', 'project', 'path');
+const testClassesDir = path.resolve('force-app', 'main', 'default', 'classes');
+const testClassesPath = path.join(testProjectPath, testClassesDir);
 const selectFileNameMocked = jest.mocked(SelectFileName);
 const metadataTypeGathererMocked = jest.mocked(MetadataTypeGatherer);
 const selectOutputDirMocked = jest.mocked(SelectOutputDir);
@@ -53,6 +57,7 @@ describe('apexGenerateClass Unit Tests.', () => {
   beforeEach(() => {
     clearGathererCache();
     runMock = jest.fn();
+    jest.spyOn(workspaceUtils, 'getRootWorkspacePath').mockReturnValue(testProjectPath);
     // Note that the entire sfCommandlet module can not be mocked like the other modules b/c
     // there are multiple exports there that cause issues if not available.
     sfCommandletMocked = jest.spyOn(commandlet, 'SfCommandlet').mockImplementation((): any => ({
@@ -81,6 +86,26 @@ describe('apexGenerateClass Unit Tests.', () => {
     expect(selectFileNameMocked).toHaveBeenCalledWith(APEX_CLASS_NAME_MAX_LENGTH);
     // still called to initialize, not actually used
     expect(selectOutputDirMocked).toHaveBeenCalled();
+    expect(simpleGathererMocked).toHaveBeenCalled();
+    expect(metadataTypeGathererMocked).toHaveBeenCalledWith(APEX_CLASS_TYPE);
+    expect(libraryApexGenerateClassExecutorMocked).toHaveBeenCalled();
+    expect(sfCommandletMocked).toHaveBeenCalled();
+    expect(sfWorkspaceCheckerMocked).toHaveBeenCalled();
+    expect(compositeParametersGathererMocked).toHaveBeenCalled();
+    expect(overwriteComponentPromptMocked).toHaveBeenCalled();
+    expect(runMock).toHaveBeenCalled();
+  });
+
+  it('Should handle absolute path from context menu', async () => {
+    const sourceUri = URI.file(testClassesPath);
+    await apexGenerateClass(sourceUri);
+    // When the command is executed from the context menu in the explorer on the classes folder,
+    // the fsPath property being used to derive the final path is absolute, but the output directory should
+    // always be the relative path from the workspace root.
+    expect(simpleGathererMocked).toHaveBeenCalledWith({
+      outputdir: testClassesDir
+    });
+    expect(selectFileNameMocked).toHaveBeenCalledWith(APEX_CLASS_NAME_MAX_LENGTH);
     expect(simpleGathererMocked).toHaveBeenCalled();
     expect(metadataTypeGathererMocked).toHaveBeenCalledWith(APEX_CLASS_TYPE);
     expect(libraryApexGenerateClassExecutorMocked).toHaveBeenCalled();

--- a/packages/salesforcedx-vscode-core/test/jest/commands/templates/apexGenerateClass.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/commands/templates/apexGenerateClass.test.ts
@@ -39,7 +39,7 @@ jest.mock('@salesforce/salesforcedx-utils-vscode', () => {
 });
 
 const testProjectPath = path.resolve('test', 'project', 'path');
-const testClassesDir = path.resolve('force-app', 'main', 'default', 'classes');
+const testClassesDir = path.join('force-app', 'main', 'default', 'classes');
 const testClassesPath = path.join(testProjectPath, testClassesDir);
 const selectFileNameMocked = jest.mocked(SelectFileName);
 const metadataTypeGathererMocked = jest.mocked(MetadataTypeGatherer);

--- a/packages/salesforcedx-vscode-core/test/jest/commands/templates/apexGenerateUnitTestClass.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/commands/templates/apexGenerateUnitTestClass.test.ts
@@ -39,7 +39,7 @@ jest.mock('@salesforce/salesforcedx-utils-vscode', () => {
 });
 
 const testProjectPath = path.resolve('test', 'project', 'path');
-const testClassesDir = path.resolve('force-app', 'main', 'default', 'classes');
+const testClassesDir = path.join('force-app', 'main', 'default', 'classes');
 const testClassesPath = path.join(testProjectPath, testClassesDir);
 const selectFileNameMocked = jest.mocked(SelectFileName);
 const metadataTypeGathererMocked = jest.mocked(MetadataTypeGatherer);

--- a/packages/salesforcedx-vscode-core/test/jest/commands/templates/apexGenerateUnitTestClass.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/commands/templates/apexGenerateUnitTestClass.test.ts
@@ -5,7 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { CompositeParametersGatherer, SfWorkspaceChecker } from '@salesforce/salesforcedx-utils-vscode';
+import { CompositeParametersGatherer, SfWorkspaceChecker, workspaceUtils } from '@salesforce/salesforcedx-utils-vscode';
+import * as path from 'node:path';
 import { URI } from 'vscode-uri';
 import { apexGenerateUnitTestClass } from '../../../../src/commands/templates';
 import { clearGathererCache } from '../../../../src/commands/templates/apexGenerateClass';
@@ -37,6 +38,9 @@ jest.mock('@salesforce/salesforcedx-utils-vscode', () => {
   };
 });
 
+const testProjectPath = path.resolve('test', 'project', 'path');
+const testClassesDir = path.resolve('force-app', 'main', 'default', 'classes');
+const testClassesPath = path.join(testProjectPath, testClassesDir);
 const selectFileNameMocked = jest.mocked(SelectFileName);
 const metadataTypeGathererMocked = jest.mocked(MetadataTypeGatherer);
 const selectOutputDirMocked = jest.mocked(SelectOutputDir);
@@ -53,6 +57,7 @@ describe('apexGenerateUnitTestClass Unit Tests.', () => {
   beforeEach(() => {
     clearGathererCache();
     runMock = jest.fn();
+    jest.spyOn(workspaceUtils, 'getRootWorkspacePath').mockReturnValue(testProjectPath);
     // Note that the entire sfCommandlet module can not be mocked like the other modules b/c
     // there are multiple exports there that cause issues if not available.
     sfCommandletMocked = jest.spyOn(commandlet, 'SfCommandlet').mockImplementation((): any => ({
@@ -80,6 +85,25 @@ describe('apexGenerateUnitTestClass Unit Tests.', () => {
     const selectedPathUris = [selectedPathUri];
     await apexGenerateUnitTestClass(selectedPathUri, selectedPathUris);
     expect(simpleGathererMocked).toHaveBeenCalledTimes(1);
+    expect(metadataTypeGathererMocked).toHaveBeenCalledWith(APEX_CLASS_TYPE);
+    expect(libraryApexGenerateUnitTestClassExecutorMocked).toHaveBeenCalled();
+    expect(sfCommandletMocked).toHaveBeenCalled();
+    expect(sfWorkspaceCheckerMocked).toHaveBeenCalled();
+    expect(compositeParametersGathererMocked).toHaveBeenCalled();
+    expect(overwriteComponentPromptMocked).toHaveBeenCalled();
+    expect(runMock).toHaveBeenCalled();
+  });
+
+  it('Should handle absolute path from context menu', async () => {
+    const sourceUri = URI.file(testClassesPath);
+    await apexGenerateUnitTestClass(sourceUri);
+    // When the command is executed from the context menu in the explorer on the classes folder,
+    // the fsPath property being used to derive the final path is absolute, but the output directory should
+    // always be the relative path from the workspace root.
+    expect(simpleGathererMocked).toHaveBeenCalledWith({
+      outputdir: testClassesDir
+    });
+    expect(selectFileNameMocked).toHaveBeenCalledWith(APEX_CLASS_NAME_MAX_LENGTH);
     expect(metadataTypeGathererMocked).toHaveBeenCalledWith(APEX_CLASS_TYPE);
     expect(libraryApexGenerateUnitTestClassExecutorMocked).toHaveBeenCalled();
     expect(sfCommandletMocked).toHaveBeenCalled();


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where when creating an apex class/apex unit test class would overwrite existing class in the same directory with the same name without any warning when invoked from the context menu. The same command would work as expected when invoked from the command palette.

When invoking the command from the right-click VSCode context menu, the `fsPath` property of the URI argument is being concatenated with the relative `classes` folder path to derive the path of the file to create. The `fsPath` itself is the full path of the file being created, hence the final concatenated path is built incorrectly. This path is then used by the `OverwriteComponentPrompt` post conditions checker to check if the file with the same name exists in the same path which causes the overwrite prompt to not trigger.
When invoking the command from the command palette, this URI isn't used to derive the final path hence it works as expected in that case.

The `pre-push` husky hooks were failing because of a failing test in the `@salesforce/salesforcedx-visualforce-language-server:test` test suite which is unrelated to my changes (i think). I checked if this test is failing even without my changes and surely it is, so, I pushed the changes anyway with `--no-verify`. Hope its not an issue :mask:.
Please let me know of any changes if needed.


### What issues does this PR fix or reference?
#5837

### Functionality Before
https://github.com/user-attachments/assets/22bc509f-0ee4-452b-8c47-d247bf117a7f

### Functionality After
https://github.com/user-attachments/assets/f15d3f41-3c03-47d9-b74c-d8ee3ec8881b
> [!NOTE]
> The class metadata files are not visible in this video demo because I have configured VS Code to exclude them from the context menu. However, those files are still being created correctly.

### Test Cases
1. Create a new apex class from the command palette using `SFDX: Create Apex Class` - Passed ✅ 
2. Create a new apex class with a name that already exists in the same classes directory form the command palette using `SFDX: Create Apex Class` - Passed ✅ 
3. Create a new apex unit test class from the command palette using `SFDX: Create Apex Unit Test Class` - Passed ✅ 
4. Create a new apex unit test class with a name that already exists in the same classes directory from the command palette using `SFDX: Create Apex Unit Test Class` - Passed ✅ 
5. Create a new apex class from the VSCode file context menu using `SFDX: Create Apex Class` - Passed ✅ 
6. Create a new apex class with a name that already exists in the same classes directory from the VSCode file context menu using `SFDX: Create Apex Class` - Passed ✅ 
7. Create a new apex unit test class from the VSCode file context menu using `SFDX: Create Apex Unit Test Class` - Passed ✅ 
8. Create a new apex unit test class with a name that already exists in the same classes directory from the VSCode file context menu using `SFDX: Create Apex Unit Test Class` - Passed ✅
9. Execute all the above test cases with a SFDX project with custom directory structure - Passed ✅  


### PR Checklist
- [x] Sign CLA
- [x] Add necessary unit tests
- [x] Execute functional manual tests
- [x] Attach necessary attachments

[skip-validate-pr]