### PR TITLE
feat: new webUserId telemetry entry for hashed (orgID-userID) to identify users on the web

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/constants.ts
+++ b/packages/salesforcedx-utils-vscode/src/constants.ts
@@ -21,3 +21,4 @@ export const INTERNAL_FILTER = 'internal.salesforce.com';
 export const TRACE_FLAG_EXPIRATION_KEY = 'apexReplayDebugger.traceFlagExpiration';
 export const APEX_CODE_DEBUG_LEVEL = 'FINEST';
 export const VISUALFORCE_DEBUG_LEVEL = 'FINER';
+export const UNAUTHENTICATED_USER = 'UNAUTHENTICATED_USER';

--- a/packages/salesforcedx-utils-vscode/src/helpers/telemetryUtils.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/telemetryUtils.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { createHash } from 'node:crypto';
+import { ExtensionContext, extensions } from 'vscode';
+
+// Type definition for the Core extension API
+interface SalesforceVSCodeCoreApi {
+  getSharedTelemetryUserId?: () => Promise<string>;
+}
+
+/**
+ * Attempts to get the shared telemetry user ID from the Core extension.
+ * Returns undefined if the Core extension is not available or doesn't have the method.
+ */
+export const getSharedTelemetryUserId = async (): Promise<string | undefined> => {
+  try {
+    const coreExtension = extensions.getExtension<SalesforceVSCodeCoreApi>('salesforce.salesforcedx-vscode-core');
+    if (coreExtension?.isActive && coreExtension.exports?.getSharedTelemetryUserId) {
+      return await coreExtension.exports.getSharedTelemetryUserId();
+    }
+  } catch (error) {
+    // Silently ignore errors - we'll fall back to extension-specific storage
+    console.log(`Failed to get shared telemetry user ID: ${String(error)}`);
+  }
+  return undefined;
+};
+
+/**
+ * Creates a one-way hash of orgId and userId for telemetry compliance.
+ * This ensures customer data cannot be decoded while maintaining user distinction.
+ * The result is stored in the "webUserId" field for telemetry purposes.
+ */
+export const hashUserIdentifier = (orgId: string, userId: string): string =>
+  createHash('sha256').update(`${orgId}-${userId}`).digest('hex');
+
+/**
+ * Refreshes telemetry reporters for ALL extension instances when org authorization changes.
+ * This ensures that all extensions (Core, Apex, etc.) use the updated hashed user ID in the webUserId field.
+ */
+export const refreshAllExtensionReporters = async (coreExtensionContext: ExtensionContext): Promise<void> => {
+  // Import here to avoid circular dependency
+  const { TelemetryServiceProvider, TelemetryService } = await import('../services/telemetry.js');
+
+  console.log('Refreshing telemetry reporters for all extensions...');
+
+  const refreshPromises: Promise<void>[] = [];
+
+  // Refresh reporters for all registered extension instances
+  for (const [extensionName, telemetryService] of TelemetryServiceProvider.instances) {
+    if (telemetryService instanceof TelemetryService && 'refreshReporters' in telemetryService) {
+      const refreshPromise = telemetryService.refreshReporters(coreExtensionContext).catch((error: unknown) => {
+        console.log(`Failed to refresh telemetry reporters for ${extensionName}:`, String(error));
+      });
+      refreshPromises.push(refreshPromise);
+    }
+  }
+
+  // Wait for all refresh operations to complete
+  await Promise.all(refreshPromises);
+  console.log('Completed refreshing telemetry reporters for all extensions');
+};

--- a/packages/salesforcedx-utils-vscode/src/services/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/services/index.ts
@@ -6,4 +6,9 @@
  */
 
 export { SourceTrackingType, SourceTrackingService } from './sourceTrackingService';
-export { UserService } from './userService';
+export {
+  UserService,
+  getWebTelemetryUserId,
+  SharedTelemetryProvider,
+  DefaultSharedTelemetryProvider
+} from './userService';

--- a/packages/salesforcedx-utils-vscode/src/telemetry/reporters/determineReporters.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/reporters/determineReporters.ts
@@ -28,14 +28,14 @@ const clearO11yInitializationPromise = (extName: string) => {
 };
 
 export const determineReporters = (config: TelemetryReporterConfig) => {
-  const { extName, version, aiKey, userId, reporterName, isDevMode } = config;
+  const { extName, version, aiKey, userId, reporterName, isDevMode, webUserId } = config;
   const reporters: TelemetryReporter[] = [];
 
   if (isDevMode) {
     addDevModeReporter(reporters, extName);
   } else {
     addO11yReporter(reporters, extName);
-    addAppInsightsReporter(reporters, reporterName, version, aiKey, userId);
+    addAppInsightsReporter(reporters, reporterName, version, aiKey, userId, webUserId);
     addLogstreamReporter(reporters, extName);
   }
   return reporters;
@@ -54,17 +54,19 @@ const addAppInsightsReporter = (
   reporterName: string,
   version: string,
   aiKey: string,
-  userId: string
+  userId: string,
+  webUserId: string
 ) => {
   console.log('adding AppInsights reporter.');
-  reporters.push(new AppInsights(reporterName, version, aiKey, userId, true));
+  reporters.push(new AppInsights(reporterName, version, aiKey, userId, webUserId, true));
 };
 
 export const initializeO11yReporter = async (
   extName: string,
   o11yUploadEndpoint: string,
   userId: string,
-  version: string
+  version: string,
+  webUserId: string
 ): Promise<void> => {
   if (o11yReporterInstances.has(extName)) return;
 
@@ -73,7 +75,7 @@ export const initializeO11yReporter = async (
     return;
   }
 
-  const o11yReporterInstance = new O11yReporter(extName, version, o11yUploadEndpoint, userId);
+  const o11yReporterInstance = new O11yReporter(extName, version, o11yUploadEndpoint, userId, webUserId);
   const initPromise = o11yReporterInstance
     .initialize(extName)
     .catch(err => {

--- a/packages/salesforcedx-utils-vscode/src/telemetry/reporters/telemetryReporterConfig.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/reporters/telemetryReporterConfig.ts
@@ -11,4 +11,5 @@ export interface TelemetryReporterConfig {
   userId: string;
   reporterName: string;
   isDevMode: boolean;
+  webUserId: string;
 }

--- a/packages/salesforcedx-utils-vscode/test/jest/telemetry/reporters/__snapshots__/appInsights.test.ts.snap
+++ b/packages/salesforcedx-utils-vscode/test/jest/telemetry/reporters/__snapshots__/appInsights.test.ts.snap
@@ -8,6 +8,7 @@ exports[`AppInsights sendTelemetryEvent and sendExceptionEvent should send orgId
     "devHubId": "",
     "orgId": "000dummyOrgId",
     "orgShape": "",
+    "webUserId": "test-webUser",
   },
 }
 `;
@@ -20,6 +21,7 @@ exports[`AppInsights sendTelemetryEvent and sendExceptionEvent should send telem
     "devHubId": "",
     "orgId": "000dummyOrgId",
     "orgShape": "",
+    "webUserId": "test-webUser",
   },
 }
 `;

--- a/packages/salesforcedx-utils-vscode/test/jest/telemetry/reporters/appInsights.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/telemetry/reporters/appInsights.test.ts
@@ -37,7 +37,7 @@ describe('AppInsights', () => {
     });
 
     it('should send telemetry data to appInsightsClient.trackEvent', () => {
-      appInsights = new AppInsights(fakeExtensionId, fakeExtensionVersion, '', fakeUserId, false);
+      appInsights = new AppInsights(fakeExtensionId, fakeExtensionVersion, '', fakeUserId, 'test-webUser', false);
       (appInsights as any).userOptIn = true;
       (appInsights as any).appInsightsClient = {
         trackException: trackExceptionMock,
@@ -75,7 +75,7 @@ describe('AppInsights', () => {
     };
 
     beforeEach(() => {
-      appInsights = new AppInsights(fakeExtensionId, fakeExtensionVersion, 'aKey', fakeUserId, false);
+      appInsights = new AppInsights(fakeExtensionId, fakeExtensionVersion, 'aKey', fakeUserId, 'test-webUser', false);
       (appInsights as any).appInsightsClient = appInsightsClientMock;
     });
 
@@ -107,7 +107,7 @@ describe('AppInsights', () => {
     let commonProperties: CommonProperties;
 
     beforeEach(() => {
-      appInsights = new AppInsights(fakeExtensionId, fakeExtensionVersion, fakeKey, fakeUserId, false);
+      appInsights = new AppInsights(fakeExtensionId, fakeExtensionVersion, fakeKey, fakeUserId, 'test-webUser', false);
       commonProperties = appInsights['getCommonProperties']();
     });
 
@@ -137,7 +137,7 @@ describe('AppInsights', () => {
         shell: '/bin/bash',
         homedir: '/home/testuser'
       });
-      appInsights = new AppInsights(fakeExtensionId, fakeExtensionVersion, fakeKey, fakeUserId, false);
+      appInsights = new AppInsights(fakeExtensionId, fakeExtensionVersion, fakeKey, fakeUserId, 'test-webUser', false);
       internalProperties = appInsights['getInternalProperties']();
     });
 
@@ -183,7 +183,7 @@ describe('AppInsights', () => {
         shell: '/bin/bash',
         homedir: '/home/testuser'
       });
-      appInsights = new AppInsights(fakeExtensionId, fakeExtensionVersion, fakeKey, fakeUserId, false);
+      appInsights = new AppInsights(fakeExtensionId, fakeExtensionVersion, fakeKey, fakeUserId, 'test-webUser', false);
     });
 
     afterEach(() => {
@@ -198,14 +198,14 @@ describe('AppInsights', () => {
       const commonProps = appInsights['getCommonProperties']();
       const internalProps = appInsights['getInternalProperties']();
       const result = appInsights['aggregateLoggingProperties']();
-      expect(result).toEqual({ ...commonProps, ...internalProps });
+      expect(result).toEqual({ ...commonProps, ...internalProps, webUserId: 'test-webUser' });
     });
 
     it('should return common properties when is not internal user', () => {
       jest.spyOn(os, 'hostname').mockReturnValue('test.salesforce.com');
       const commonProps = appInsights['getCommonProperties']();
       const result = appInsights['aggregateLoggingProperties']();
-      expect(result).toEqual(commonProps);
+      expect(result).toEqual({ ...commonProps, webUserId: 'test-webUser' });
     });
   });
 });

--- a/packages/salesforcedx-utils-vscode/test/jest/telemetry/reporters/determineReporters.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/telemetry/reporters/determineReporters.test.ts
@@ -5,8 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-/* eslint-disable import/extensions */
-/* eslint-disable import/no-unresolved */
 // @ts-nocheck
 
 /**
@@ -139,23 +137,26 @@ describe('initializeO11yReporter', () => {
 
   it('should initialize and add an O11yReporter instance', async () => {
     const { initializeO11yReporter } = await import('../../../../src/telemetry/reporters/determineReporters');
-    await initializeO11yReporter(extName, o11yUploadEndpoint, userId, version);
-    expect(O11yReporterMock).toHaveBeenCalledWith(extName, version, o11yUploadEndpoint, userId);
+    const webUserId = 'test-webUserId';
+    await initializeO11yReporter(extName, o11yUploadEndpoint, userId, version, webUserId);
+    expect(O11yReporterMock).toHaveBeenCalledWith(extName, version, o11yUploadEndpoint, userId, webUserId);
     expect(initializeMock).toHaveBeenCalledWith(extName);
   });
 
   it('should not re-initialize if already initialized', async () => {
     const { initializeO11yReporter } = await import('../../../../src/telemetry/reporters/determineReporters');
-    await initializeO11yReporter(extName, o11yUploadEndpoint, userId, version);
+    const webUserId = 'test-webUserId';
+    await initializeO11yReporter(extName, o11yUploadEndpoint, userId, version, webUserId);
     O11yReporterMock.mockClear();
     initializeMock.mockClear();
-    await initializeO11yReporter(extName, o11yUploadEndpoint, userId, version);
+    await initializeO11yReporter(extName, o11yUploadEndpoint, userId, version, webUserId);
     expect(O11yReporterMock).not.toHaveBeenCalled();
     expect(initializeMock).not.toHaveBeenCalled();
   });
 
   it('should wait for in-progress initialization if called concurrently', async () => {
     const { initializeO11yReporter } = await import('../../../../src/telemetry/reporters/determineReporters');
+    const webUserId = 'test-webUserId';
     let resolveInit: (() => void) | undefined;
     initializeMock.mockImplementation(
       () =>
@@ -163,8 +164,8 @@ describe('initializeO11yReporter', () => {
           resolveInit = res;
         })
     );
-    const p1 = initializeO11yReporter(extName, o11yUploadEndpoint, userId, version);
-    const p2 = initializeO11yReporter(extName, o11yUploadEndpoint, userId, version);
+    const p1 = initializeO11yReporter(extName, o11yUploadEndpoint, userId, version, webUserId);
+    const p2 = initializeO11yReporter(extName, o11yUploadEndpoint, userId, version, webUserId);
     if (resolveInit) {
       resolveInit();
     }
@@ -175,11 +176,14 @@ describe('initializeO11yReporter', () => {
 
   it('should clean up if initialization fails', async () => {
     const { initializeO11yReporter } = await import('../../../../src/telemetry/reporters/determineReporters');
+    const webUserId = 'test-webUserId';
     initializeMock.mockRejectedValue(new Error('fail!'));
-    await expect(initializeO11yReporter(extName, o11yUploadEndpoint, userId, version)).resolves.toBeUndefined();
+    await expect(
+      initializeO11yReporter(extName, o11yUploadEndpoint, userId, version, webUserId)
+    ).resolves.toBeUndefined();
     // Try again, should attempt to re-initialize
     initializeMock.mockResolvedValue(undefined);
-    await initializeO11yReporter(extName, o11yUploadEndpoint, userId, version);
+    await initializeO11yReporter(extName, o11yUploadEndpoint, userId, version, webUserId);
     expect(O11yReporterMock).toHaveBeenCalledTimes(2);
   });
 
@@ -187,7 +191,8 @@ describe('initializeO11yReporter', () => {
     const { initializeO11yReporter, determineReporters: reImportedDetermineReporters } = await import(
       '../../../../src/telemetry/reporters/determineReporters'
     );
-    await initializeO11yReporter(extName, o11yUploadEndpoint, userId, version);
+    const webUserId = 'test-webUserId';
+    await initializeO11yReporter(extName, o11yUploadEndpoint, userId, version, webUserId);
     const config = {
       extName,
       version,

--- a/packages/salesforcedx-utils-vscode/test/jest/telemetry/reporters/o11yReporter.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/telemetry/reporters/o11yReporter.test.ts
@@ -43,7 +43,7 @@ describe('O11yReporter', () => {
       get: jest.fn().mockReturnValue('testTelemetryTag')
     } as any);
 
-    o11yReporter = new O11yReporter(fakeExtensionId, fakeExtensionVersion, fakeEndpoint, fakeUserId);
+    o11yReporter = new O11yReporter(fakeExtensionId, fakeExtensionVersion, fakeEndpoint, fakeUserId, 'test-webUser');
   });
 
   afterEach(() => {
@@ -140,7 +140,13 @@ describe('O11yReporter', () => {
         get: jest.fn().mockReturnValue(undefined)
       } as any);
 
-      const reporterWithoutTag = new O11yReporter(fakeExtensionId, fakeExtensionVersion, fakeEndpoint, fakeUserId);
+      const reporterWithoutTag = new O11yReporter(
+        fakeExtensionId,
+        fakeExtensionVersion,
+        fakeEndpoint,
+        fakeUserId,
+        'test-webUser'
+      );
       sendMock.mockClear();
 
       reporterWithoutTag.sendTelemetryEvent('eventWithoutTag');

--- a/packages/salesforcedx-utils-vscode/test/jest/telemetry/reporters/telemetryReporterConfig.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/telemetry/reporters/telemetryReporterConfig.test.ts
@@ -17,7 +17,8 @@ describe('TelemetryReporterConfig', () => {
       aiKey: '1234567890',
       userId: 'user123',
       reporterName: 'test-extension-name',
-      isDevMode: false
+      isDevMode: false,
+      webUserId: 'webUser123'
     };
   });
 
@@ -78,5 +79,14 @@ describe('TelemetryReporterConfig', () => {
   it('should have the updated isDevMode flag', () => {
     config.isDevMode = true;
     expect(config.isDevMode).toBe(true);
+  });
+
+  it('config should have webUserId property of type string', () => {
+    expect(config).toHaveProperty('webUserId');
+    expect(typeof config.webUserId).toBe('string');
+  });
+
+  it('should have the correct webUserId field', () => {
+    expect(config.webUserId).toBe('webUser123');
   });
 });

--- a/packages/salesforcedx-vscode-core/test/jest/telemetry/index.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/telemetry/index.test.ts
@@ -7,7 +7,7 @@
 
 import { TELEMETRY_GLOBAL_USER_ID } from '@salesforce/salesforcedx-utils-vscode';
 import * as os from 'node:os';
-import { extensions, window, Extension } from 'vscode';
+import { extensions, window, workspace, Extension } from 'vscode';
 import { TELEMETRY_GLOBAL_VALUE, TELEMETRY_INTERNAL_VALUE, TELEMETRY_OPT_OUT_LINK } from '../../../src/constants';
 import { nls } from '../../../src/messages';
 import { SalesforceCoreSettings } from '../../../src/settings/salesforceCoreSettings';
@@ -25,6 +25,14 @@ describe('Telemetry', () => {
     jest.spyOn(SalesforceCoreSettings.prototype, 'getTelemetryEnabled').mockReturnValue(true);
     teleSpy = jest.spyOn(telemetryService, 'setCliTelemetryEnabled');
     cliSpy = jest.spyOn(telemetryService, 'checkCliTelemetry').mockResolvedValue(true);
+
+    // Mock createFileSystemWatcher to return a proper mock object
+    jest.spyOn(workspace, 'createFileSystemWatcher').mockReturnValue({
+      onDidChange: jest.fn(),
+      onDidCreate: jest.fn(),
+      onDidDelete: jest.fn(),
+      dispose: jest.fn()
+    } as any);
   });
 
   afterEach(() => {


### PR DESCRIPTION
### What does this PR do?
Puts the change in https://github.com/forcedotcom/salesforcedx-vscode/pull/6482 into a new `webUserId` field in telemetry.  Users will have 2 forms of identification:
1. the original `userId`, which is the CLI ID
2. `webUserId`, which is a hashed version of (orgID-userID)

### What issues does this PR fix or reference?
@W-19176017@

### Functionality Before
Users have 1 form of identification in telemetry, which is `userId`

### Functionality After
Users have 2 forms of identification in telemetry: `userId` and `webUserId`
<img width="810" height="487" alt="Screenshot 2025-09-03 at 12 22 07 AM" src="https://github.com/user-attachments/assets/9e3e3929-8d47-43fd-bcf4-f1196a7f25bf" />

