### PR TITLE
chore: W-18521546 - replace usage of node crypto

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/services/userService.ts
+++ b/packages/salesforcedx-utils-vscode/src/services/userService.ts
@@ -6,13 +6,16 @@
  */
 
 import { CommandOutput, SfCommandBuilder } from '@salesforce/salesforcedx-utils';
-import { randomBytes } from 'node:crypto';
 import { ExtensionContext } from 'vscode';
 import { CliCommandExecutor, workspaceUtils } from '..';
 import { TELEMETRY_GLOBAL_USER_ID } from '../constants';
 
 export class UserService {
-  private static getRandomUserId = (): string => randomBytes(20).toString('hex');
+  private static getRandomUserId = (): string => {
+    const array = new Uint8Array(20);
+    globalThis.crypto.getRandomValues(array);
+    return Array.from(array, byte => byte.toString(16).padStart(2, '0')).join('');
+  };
 
   private static async executeCliTelemetry(): Promise<string> {
     const command = new SfCommandBuilder().withArg('telemetry').withJson().build();


### PR DESCRIPTION
### What does this PR do?
This pull request updates the way random user IDs are generated in the `UserService` class to use the browser-compatible `crypto.getRandomValues` API instead of Node's `randomBytes`. This change improves compatibility for environments where Node's crypto module is not available.

Random user ID generation:

* Replaced the use of `randomBytes` from Node's `crypto` module with `globalThis.crypto.getRandomValues` in the `getRandomUserId` method of `UserService` to generate a 20-byte random hex string, making the code browser-compatible.

### What issues does this PR fix or reference?
@W-18521546@