### PR TITLE
fix: support projects with namespace but org without replay debugger W-19604488

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/helpers/paths.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/paths.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Global } from '@salesforce/core';
+import { Global } from '@salesforce/core/global';
 import * as path from 'node:path';
 import { URI } from 'vscode-uri';
 import { WorkspaceContextUtil } from '..';
@@ -54,61 +54,32 @@ export const getRelativeProjectPath = (fsPath: string = '', packageDirs: string[
   return packageDirIndex !== -1 ? fsPath.slice(packageDirIndex) : fsPath;
 };
 
-export const fileExtensionsMatch = (sourceUri: URI, targetExtension: string): boolean => {
-  const extension = sourceUri.path.split('.').pop()?.toLowerCase();
-  return extension === targetExtension.toLowerCase();
-};
+export const fileExtensionsMatch = (sourceUri: URI, targetExtension: string): boolean =>
+  sourceUri.path.split('.').pop()?.toLowerCase() === targetExtension.toLowerCase();
 
 const stateFolder = (): string =>
   workspaceUtils.hasRootWorkspace() ? path.join(workspaceUtils.getRootWorkspacePath(), Global.SFDX_STATE_FOLDER) : '';
 
-const metadataFolder = (): string => {
-  const username = WorkspaceContextUtil.getInstance().username;
-  const pathToMetadataFolder = path.join(projectPaths.stateFolder(), ORGS, String(username), METADATA);
-  return pathToMetadataFolder;
-};
+const metadataFolder = (): string =>
+  path.join(projectPaths.stateFolder(), ORGS, String(WorkspaceContextUtil.getInstance().username), METADATA);
 
-const apexTestResultsFolder = (): string => {
-  const pathToApexTestResultsFolder = path.join(toolsFolder(), TEST_RESULTS, APEX);
-  return pathToApexTestResultsFolder;
-};
+const apexTestResultsFolder = (): string => path.join(toolsFolder(), TEST_RESULTS, APEX);
 
-const apexLanguageServerDatabase = (): string => {
-  const pathToApexLangServerDb = path.join(toolsFolder(), APEX_DB);
-  return pathToApexLangServerDb;
-};
+const apexLanguageServerDatabase = (): string => path.join(toolsFolder(), APEX_DB);
 
-const lwcTestResultsFolder = (): string => {
-  const pathToLwcTestResultsFolder = path.join(testResultsFolder(), LWC);
-  return pathToLwcTestResultsFolder;
-};
+const lwcTestResultsFolder = (): string => path.join(testResultsFolder(), LWC);
 
-const testResultsFolder = (): string => {
-  const pathToTestResultsFolder = path.join(toolsFolder(), TEST_RESULTS);
-  return pathToTestResultsFolder;
-};
+const testResultsFolder = (): string => path.join(toolsFolder(), TEST_RESULTS);
 
-const debugLogsFolder = (): string => {
-  const pathToDebugLogsFolder = path.join(toolsFolder(), DEBUG, LOGS);
-  return pathToDebugLogsFolder;
-};
+const debugLogsFolder = (): string => path.join(toolsFolder(), DEBUG, LOGS);
 
-const salesforceProjectConfig = (): string => {
-  const pathToSalesforceProjectConfig = path.join(projectPaths.stateFolder(), SFDX_CONFIG_FILE);
-  return pathToSalesforceProjectConfig;
-};
+const salesforceProjectConfig = (): string => path.join(projectPaths.stateFolder(), SFDX_CONFIG_FILE);
 
-const toolsFolder = (): string => {
-  const pathToToolsFolder = path.join(projectPaths.stateFolder(), TOOLS);
-  return pathToToolsFolder;
-};
+const toolsFolder = (): string => path.join(projectPaths.stateFolder(), TOOLS);
 
 const relativeStateFolder = (): string => Global.STATE_FOLDER;
 
-const relativeToolsFolder = (): string => {
-  const relativePathToToolsFolder = path.join(projectPaths.relativeStateFolder(), TOOLS);
-  return relativePathToToolsFolder;
-};
+const relativeToolsFolder = (): string => path.join(projectPaths.relativeStateFolder(), TOOLS);
 
 export const projectPaths = {
   stateFolder,

--- a/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
@@ -128,21 +128,10 @@ const flushFilePath = (filePath: string): string => {
   return nativePath;
 };
 
-const flushFilePaths = (filePaths: string[]): string[] => {
-  for (let i = 0; i < filePaths.length; i++) {
-    filePaths[i] = flushFilePath(filePaths[i]);
-  }
-
-  return filePaths;
-};
-
 export const fileUtils = {
-  flushFilePaths,
   flushFilePath,
   extractJson
 };
-
-export const stripAnsiInJson = (str: string, hasJson: boolean): string => (str && hasJson ? stripAnsi(str) : str);
 
 export const stripAnsi = (str: string): string => (str ? str.replaceAll(ansiRegex(), '') : str);
 

--- a/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/utils.ts
@@ -8,7 +8,7 @@
 import { basename } from 'node:path';
 import { telemetryService } from '../telemetry';
 
-export const getJsonCandidate = (str: string): string | null => {
+export const getJsonCandidate = (str: string): string | undefined => {
   const firstCurly = str.indexOf('{');
   const lastCurly = str.lastIndexOf('}');
   const firstSquare = str.indexOf('[');
@@ -18,22 +18,18 @@ export const getJsonCandidate = (str: string): string | null => {
   const isObject = firstCurly !== -1 && lastCurly !== -1 && firstCurly < lastCurly;
   const isArray = firstSquare !== -1 && lastSquare !== -1 && firstSquare < lastSquare;
 
-  let jsonCandidate: string | null = null;
-
   if (isObject && isArray) {
     // If both are present, pick the one that appears first
-    jsonCandidate =
-      firstCurly < firstSquare ? str.slice(firstCurly, lastCurly + 1) : str.slice(firstSquare, lastSquare + 1);
+    return firstCurly < firstSquare ? str.slice(firstCurly, lastCurly + 1) : str.slice(firstSquare, lastSquare + 1);
   } else if (isObject) {
-    jsonCandidate = str.slice(firstCurly, lastCurly + 1);
+    return str.slice(firstCurly, lastCurly + 1);
   } else if (isArray) {
-    jsonCandidate = str.slice(firstSquare, lastSquare + 1);
+    return str.slice(firstSquare, lastSquare + 1);
   }
-  return jsonCandidate;
 };
 
 export const identifyJsonTypeInString = (str: string): 'object' | 'array' | 'primitive' | 'none' => {
-  const jsonCandidate: string | null = getJsonCandidate(str.trim()); // Remove leading/trailing whitespace
+  const jsonCandidate = getJsonCandidate(str.trim()); // Remove leading/trailing whitespace
 
   // Check if the JSON candidate is a valid object or array
   if (jsonCandidate) {
@@ -81,7 +77,7 @@ export const identifyJsonTypeInString = (str: string): 'object' | 'array' | 'pri
 export const extractJson = <T = any>(str: string): T => {
   const trimmedString = str.trim(); // Remove leading/trailing whitespace
 
-  const jsonCandidate: string | null = getJsonCandidate(trimmedString);
+  const jsonCandidate = getJsonCandidate(trimmedString);
   const jsonType = identifyJsonTypeInString(trimmedString);
 
   if (!jsonCandidate || jsonType === 'none' || jsonType === 'primitive') {

--- a/packages/salesforcedx-utils-vscode/test/jest/helpers/utils.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/helpers/utils.test.ts
@@ -4,7 +4,9 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { extractJson, fixupError, stripAnsiInJson } from '../../../src/helpers/utils';
+import { extractJson, fixupError, stripAnsi } from '../../../src/helpers/utils';
+
+const stripAnsiInJson = (str: string, hasJson: boolean): string => (str && hasJson ? stripAnsi(str) : str);
 
 describe('utils tests', () => {
   describe('extractJson unit tests', () => {

--- a/packages/salesforcedx-vscode-apex/src/commands/launchApexReplayDebuggerWithCurrentFile.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/launchApexReplayDebuggerWithCurrentFile.ts
@@ -21,24 +21,18 @@ import { getTestOutlineProvider } from '../views/testOutlineProvider';
 import { anonApexDebug } from './anonApexExecute';
 
 export const launchApexReplayDebuggerWithCurrentFile = async () => {
-  const editor = vscode.window.activeTextEditor;
-  if (!editor) {
-    void notificationService.showErrorMessage(nls.localize('unable_to_locate_editor'));
-    return;
-  }
-
-  const sourceUri = editor.document.uri;
+  const sourceUri = vscode.window.activeTextEditor?.document.uri;
   if (!sourceUri) {
     void notificationService.showErrorMessage(nls.localize('unable_to_locate_document'));
     return;
   }
 
-  if (isLogFile(sourceUri)) {
+  if (fileExtensionsMatch(sourceUri, 'log')) {
     await launchReplayDebuggerLogFile(sourceUri);
     return;
   }
 
-  if (isAnonymousApexFile(sourceUri)) {
+  if (fileExtensionsMatch(sourceUri, 'apex')) {
     await launchAnonymousApexReplayDebugger();
     return;
   }
@@ -51,10 +45,6 @@ export const launchApexReplayDebuggerWithCurrentFile = async () => {
 
   void notificationService.showErrorMessage(nls.localize('launch_apex_replay_debugger_unsupported_file'));
 };
-
-const isLogFile = (sourceUri: URI): boolean => fileExtensionsMatch(sourceUri, 'log');
-
-const isAnonymousApexFile = (sourceUri: URI): boolean => fileExtensionsMatch(sourceUri, 'apex');
 
 const launchReplayDebuggerLogFile = async (sourceUri: URI) => {
   await vscode.commands.executeCommand('sf.launch.replay.debugger.logfile', {

--- a/packages/salesforcedx-vscode-apex/src/constants.ts
+++ b/packages/salesforcedx-vscode-apex/src/constants.ts
@@ -19,10 +19,6 @@ const APEX_EXTENSION_NAME = 'salesforcedx-vscode-apex';
 export const VSCODE_APEX_EXTENSION_NAME = `salesforce.${APEX_EXTENSION_NAME}`;
 export const LSP_ERR = 'apexLSPError';
 
-export const PASS_RESULT = 'Pass';
-export const FAIL_RESULT = 'Fail';
-export const SKIP_RESULT = 'Skip';
-
 export const APEX_TESTS = 'ApexTests';
 export const API = {
   doneIndexing: 'indexer/done'

--- a/packages/salesforcedx-vscode-apex/src/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/index.ts
@@ -45,8 +45,8 @@ import {
 import { nls } from './messages';
 import { checkIfESRIsDecomposed } from './oasUtils';
 import { getTelemetryService, setTelemetryService } from './telemetry/telemetry';
-import { getTestOutlineProvider, TestNode } from './views/testOutlineProvider';
-import { ApexTestRunner, TestRunType } from './views/testRunner';
+import { TEST_OUTLINE_PROVIDER_BASE_ID, getTestOutlineProvider, TestNode } from './views/testOutlineProvider';
+import { runAllApexTests, runApexTests, showErrorMessage, TestRunType } from './views/testRunner';
 
 const metadataOrchestrator = new MetadataOrchestrator();
 
@@ -163,41 +163,37 @@ const registerCommands = (context: vscode.ExtensionContext): vscode.Disposable =
       }
     )
   );
+
 const registerTestView = (): vscode.Disposable => {
   const testOutlineProvider = getTestOutlineProvider();
-  // Create TestRunner
-  const testRunner = new ApexTestRunner(testOutlineProvider);
-
-  // Test View
-
   return vscode.Disposable.from(
-    vscode.window.registerTreeDataProvider(testOutlineProvider.getId(), testOutlineProvider),
+    vscode.window.registerTreeDataProvider(TEST_OUTLINE_PROVIDER_BASE_ID, testOutlineProvider),
     // Run Test Button on Test View command
-    vscode.commands.registerCommand(`${testOutlineProvider.getId()}.run`, () => testRunner.runAllApexTests()),
+    vscode.commands.registerCommand(`${TEST_OUTLINE_PROVIDER_BASE_ID}.run`, () => runAllApexTests(testOutlineProvider)),
     // Show Error Message command
-    vscode.commands.registerCommand(`${testOutlineProvider.getId()}.showError`, (test: TestNode) =>
-      testRunner.showErrorMessage(test)
+    vscode.commands.registerCommand(`${TEST_OUTLINE_PROVIDER_BASE_ID}.showError`, (test: TestNode) =>
+      showErrorMessage(test)
     ),
     // Show Definition command
-    vscode.commands.registerCommand(`${testOutlineProvider.getId()}.goToDefinition`, (test: TestNode) =>
-      testRunner.showErrorMessage(test)
+    vscode.commands.registerCommand(`${TEST_OUTLINE_PROVIDER_BASE_ID}.goToDefinition`, (test: TestNode) =>
+      showErrorMessage(test)
     ),
     // Run Class Tests command
-    vscode.commands.registerCommand(`${testOutlineProvider.getId()}.runClassTests`, (test: TestNode) =>
-      testRunner.runApexTests([test.name], TestRunType.Class)
+    vscode.commands.registerCommand(`${TEST_OUTLINE_PROVIDER_BASE_ID}.runClassTests`, (test: TestNode) =>
+      runApexTests([test.name], TestRunType.Class)
     ),
     // Run Single Test command
-    vscode.commands.registerCommand(`${testOutlineProvider.getId()}.runSingleTest`, (test: TestNode) =>
-      testRunner.runApexTests([test.name], TestRunType.Method)
+    vscode.commands.registerCommand(`${TEST_OUTLINE_PROVIDER_BASE_ID}.runSingleTest`, (test: TestNode) =>
+      runApexTests([test.name], TestRunType.Method)
     ),
     // Refresh Test View command
-    vscode.commands.registerCommand(`${testOutlineProvider.getId()}.refresh`, () => {
+    vscode.commands.registerCommand(`${TEST_OUTLINE_PROVIDER_BASE_ID}.refresh`, () => {
       if (languageClientManager.getStatus().isReady()) {
         return testOutlineProvider.refresh();
       }
     }),
     // Collapse All Apex Tests command
-    vscode.commands.registerCommand(`${testOutlineProvider.getId()}.collapseAll`, () =>
+    vscode.commands.registerCommand(`${TEST_OUTLINE_PROVIDER_BASE_ID}.collapseAll`, () =>
       testOutlineProvider.collapseAll()
     )
   );

--- a/packages/salesforcedx-vscode-apex/src/languageUtils/languageClientManager.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageUtils/languageClientManager.ts
@@ -16,7 +16,7 @@ import * as languageServer from '../languageServer';
 import { nls } from '../messages';
 import { retrieveEnableSyncInitJobs } from '../settings';
 import { getTelemetryService } from '../telemetry/telemetry';
-import { ApexLSPConverter, ApexTestMethod, LSPApexTestMethod } from '../views/lspConverter';
+import { toApexTestMethod, ApexTestMethod, LSPApexTestMethod } from '../views/lspConverter';
 import { getTestOutlineProvider } from '../views/testOutlineProvider';
 
 export enum ClientStatus {
@@ -118,7 +118,7 @@ export class LanguageClientManager {
   public async getApexTests(): Promise<ApexTestMethod[]> {
     return this.clientInstance
       ? (await this.clientInstance.sendRequest<LSPApexTestMethod[]>('test/getTestMethods')).map(requestInfo =>
-          ApexLSPConverter.toApexTestMethod(requestInfo)
+          toApexTestMethod(requestInfo)
         )
       : [];
   }

--- a/packages/salesforcedx-vscode-apex/src/messages/i18n.ja.ts
+++ b/packages/salesforcedx-vscode-apex/src/messages/i18n.ja.ts
@@ -158,7 +158,6 @@ export const messages: Partial<Record<MessageKey, string>> = {
   test_view_no_tests_message: 'Apex テストが見つかりませんでした',
   test_view_show_error_title: 'エラーを表示',
   unable_to_locate_document: 'ソースファイルに対してのみこのコマンドを実行できます。',
-  unable_to_locate_editor: 'ソースファイルに対してのみこのコマンドを実行できます。',
   unknown: '不明',
   unknown_error: '不明なエラー',
   validate_eligibility: '適格性を検証中です。',

--- a/packages/salesforcedx-vscode-apex/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-apex/src/messages/i18n.ts
@@ -108,8 +108,7 @@ export const messages = {
   java_version_check_command_failed: 'Running java command %s failed with error: %s',
   launch_apex_replay_debugger_unsupported_file:
     'You can only run this command with Anonymous Apex files, Apex Test files, or Apex Debug Log files.',
-  launch_apex_replay_debugger_with_selected_file:
-    'Launch Apex Replay Debugger with Selected File',
+  launch_apex_replay_debugger_with_selected_file: 'Launch Apex Replay Debugger with Selected File',
   merge: 'Manually merge with existing ESR',
   method_not_found_in_doc_symbols: 'Method %s is not found in the document symbols',
   mixed_frameworks_not_allowed:
@@ -159,7 +158,6 @@ export const messages = {
   test_view_no_tests_message: 'No Apex Tests Found',
   test_view_show_error_title: 'Show Error',
   unable_to_locate_document: 'You can run this command only on a source file.',
-  unable_to_locate_editor: 'You can run this command only on a source file.',
   unknown: 'Unknown',
   unknown_error: 'Unknown error',
   unknown_bid_rule: 'Unknown bid rule "%s"',

--- a/packages/salesforcedx-vscode-apex/src/namespaceLensRewriter.ts
+++ b/packages/salesforcedx-vscode-apex/src/namespaceLensRewriter.ts
@@ -9,12 +9,15 @@ import * as vscode from 'vscode';
 const singleTest = ['Run Test', 'Debug Test'];
 const allTests = ['Run All Tests', 'Debug All Tests'];
 
+const orgHasNamespaceOrProjectDoesNot = (namespaceFromOrg?: string) => (namespaceFromProject?: string) =>
+  namespaceFromOrg !== undefined || namespaceFromProject === undefined;
+
 // Jorje sticks the namespace from sfdx-project.json (namespaceFromProject) on the arguments, like ns.class.method
 // org may or may not actually use the namespace (ex: scratch org with --no-namespace)
 // namespaceFromOrg represents the namespace that came from auth files (ie, when the org is created/auth'd)
 export const rewriteNamespaceLens =
   (namespaceFromOrg?: string) => (namespaceFromProject?: string) => (lens: vscode.CodeLens) => {
-    if (namespaceFromOrg !== undefined || !lens.command?.title || namespaceFromProject === undefined) {
+    if (orgHasNamespaceOrProjectDoesNot(namespaceFromOrg)(namespaceFromProject) || !lens.command?.title) {
       // if the org is a namespaces, we preserve the namespace from the LS.
       // if the project has no namespace, we want to use what the LS provides (its use of the namespace is the cause of https://github.com/forcedotcom/salesforcedx-vscode/issues/6458 )
       return lens;
@@ -32,10 +35,22 @@ export const rewriteNamespaceLens =
     } else if (allTests.includes(lens.command.title)) {
       // namespace.class => class
       console.debug(`provideCodeLenses Middleware > All tests originally: ${lens.command.arguments}`);
-      lens.command.arguments = lens.command.arguments?.map((arg: string) =>
-        arg.startsWith(`${namespaceFromProject}.`) && arg.split('.').length === 2 ? arg.split('.').at(-1) : arg
+      lens.command.arguments = lens.command.arguments?.map(
+        rewriteClassArgument(namespaceFromOrg)(namespaceFromProject)
       );
       console.debug(`provideCodeLenses Middleware > All tests modified: ${lens.command.arguments}`);
     }
     return lens;
+  };
+
+/** ns.class => class when ns is not on the org but is in the project.  Ignores other namespaces besides the project namespace. */
+export const rewriteClassArgument =
+  (namespaceFromOrg?: string) =>
+  (namespaceFromProject?: string) =>
+  (arg: string): string => {
+    if (orgHasNamespaceOrProjectDoesNot(namespaceFromOrg)(namespaceFromProject)) {
+      return arg;
+    }
+    // the ! assertion is safe because we know it has at least one dot
+    return arg.startsWith(`${namespaceFromProject}.`) && arg.split('.').length === 2 ? arg.split('.').at(-1)! : arg;
   };

--- a/packages/salesforcedx-vscode-apex/src/views/lspConverter.ts
+++ b/packages/salesforcedx-vscode-apex/src/views/lspConverter.ts
@@ -29,31 +29,23 @@ export type ApexTestMethod = {
   location: vscode.Location;
 };
 
-export class ApexLSPConverter {
-  public static toApexTestMethod(requestInfo: LSPApexTestMethod): ApexTestMethod {
-    const testLocation = ApexLSPConverter.toLocation(requestInfo.location);
-    return {
-      methodName: requestInfo.methodName,
-      definingType: requestInfo.definingType,
-      location: testLocation
-    };
-  }
+export const toApexTestMethod = (requestInfo: LSPApexTestMethod): ApexTestMethod => ({
+  ...requestInfo,
+  location: toLocation(requestInfo.location)
+});
 
-  public static toUri(lspUri: string): URI {
-    const uriString = lspUri;
-    const uriPath = URI.parse(uriString).path;
-    return URI.file(uriPath);
-  }
+const toUri = (lspUri: string): URI => {
+  const uriPath = URI.parse(lspUri).path;
+  return URI.file(uriPath);
+};
 
-  public static toLocation(lspLocation: LSPLocation): vscode.Location {
-    const actualUri = ApexLSPConverter.toUri(lspLocation.uri);
-    const actualStart = ApexLSPConverter.toPosition(lspLocation.range.start);
-    const actualEnd = ApexLSPConverter.toPosition(lspLocation.range.end);
-    const actualRange = new vscode.Range(actualStart, actualEnd);
-    return new vscode.Location(actualUri, actualRange);
-  }
+const toPosition = (lspPosition: LSPPosition): vscode.Position =>
+  new vscode.Position(lspPosition.line, lspPosition.character);
 
-  public static toPosition(lspPosition: LSPPosition): vscode.Position {
-    return new vscode.Position(lspPosition.line, lspPosition.character);
-  }
-}
+const toLocation = (lspLocation: LSPLocation): vscode.Location => {
+  const actualUri = toUri(lspLocation.uri);
+  const actualStart = toPosition(lspLocation.range.start);
+  const actualEnd = toPosition(lspLocation.range.end);
+  const actualRange = new vscode.Range(actualStart, actualEnd);
+  return new vscode.Location(actualUri, actualRange);
+};

--- a/packages/salesforcedx-vscode-apex/src/views/testOutlineProvider.ts
+++ b/packages/salesforcedx-vscode-apex/src/views/testOutlineProvider.ts
@@ -100,17 +100,18 @@ export class ApexTestOutlineProvider implements vscode.TreeDataProvider<TestNode
   }
 
   public async refresh(): Promise<void> {
+    this.rootNode = null; // Reset tests
+    this.apexTestMap.clear();
+    this.testStrings.clear();
+    // we'll need some namespace information to get the correct namespace on the classes.
     const vscodeCoreExtension = await getVscodeCoreExtension();
-
     const [nsFromOrg, nsFromProject] = await Promise.all([
       vscodeCoreExtension.exports.OrgAuthInfo.getAuthFields().then(fields => fields.namespacePrefix ?? undefined),
       vscodeCoreExtension.exports.services.SalesforceProjectConfig.getInstance().then(
         cfg => cfg.getContents().namespace
       )
     ]);
-    this.rootNode = null; // Reset tests
-    this.apexTestMap.clear();
-    this.testStrings.clear();
+
     this.apexTestInfo = (await getApexTests())?.map(testMethod => ({
       ...testMethod,
       //

--- a/packages/salesforcedx-vscode-apex/src/views/testOutlineProvider.ts
+++ b/packages/salesforcedx-vscode-apex/src/views/testOutlineProvider.ts
@@ -39,23 +39,16 @@ export class ApexTestOutlineProvider implements vscode.TreeDataProvider<TestNode
   public onDidChangeTreeData = this.onDidChangeTestData.event;
 
   private apexTestMap: Map<string, TestNode> = new Map<string, TestNode>();
-  private rootNode: TestNode | null;
+  private rootNode: TestNode | null = null;
   public testStrings: Set<string> = new Set<string>();
-  private apexTestInfo: ApexTestMethod[] | null;
+  private apexTestInfo: ApexTestMethod[] | null = null;
   private testIndex: Map<string, string> = new Map<string, string>();
-
-  constructor(apexTestInfo: ApexTestMethod[] | null) {
-    this.rootNode = null;
-    this.apexTestInfo = apexTestInfo;
-    this.createTestIndex();
-    this.getAllApexTests();
-  }
 
   public getChildren(element: TestNode): TestNode[] {
     if (element) {
       return element.children;
     } else {
-      if (this.rootNode && this.rootNode.children.length > 0) {
+      if (this.rootNode?.children.length) {
         return this.rootNode.children;
       } else {
         let message = NO_TESTS_MESSAGE;
@@ -69,11 +62,9 @@ export class ApexTestOutlineProvider implements vscode.TreeDataProvider<TestNode
           message = LOADING_MESSAGE;
           description = '';
         }
-        const emptyArray = new Array<ApexTestNode>();
         const testToDisplay = new ApexTestNode(message, null);
         testToDisplay.description = description;
-        emptyArray.push(testToDisplay);
-        return emptyArray;
+        return [testToDisplay];
       }
     }
   }
@@ -341,7 +332,7 @@ let testOutlineProviderInst: ApexTestOutlineProvider;
 
 export const getTestOutlineProvider = () => {
   if (!testOutlineProviderInst) {
-    testOutlineProviderInst = new ApexTestOutlineProvider(null);
+    testOutlineProviderInst = new ApexTestOutlineProvider();
   }
   return testOutlineProviderInst;
 };

--- a/packages/salesforcedx-vscode-apex/src/views/testRunner.ts
+++ b/packages/salesforcedx-vscode-apex/src/views/testRunner.ts
@@ -61,21 +61,6 @@ export const showErrorMessage = async (test: TestNode): Promise<void> => {
   }
 };
 
-const updateSelection = async (index: vscode.Range | number): Promise<void> => {
-  const editor = vscode.window.activeTextEditor;
-  if (editor) {
-    if (index instanceof vscode.Range) {
-      editor.selection = new vscode.Selection(index.start, index.end);
-      editor.revealRange(index); // Show selection
-    } else {
-      const line = editor.document.lineAt(index);
-      const startPos = new vscode.Position(line.lineNumber, line.firstNonWhitespaceCharacterIndex);
-      editor.selection = new vscode.Selection(startPos, line.range.end);
-      editor.revealRange(line.range); // Show selection
-    }
-  }
-};
-
 export const runApexTests = async (tests: string[], testRunType: TestRunType) => {
   const languageClientStatus = languageClientManager.getStatus();
   if (!languageClientStatus.isReady()) {
@@ -106,5 +91,20 @@ const getTempFolder = async (): Promise<string> => {
     return apexDir;
   } else {
     throw new Error(nls.localize('cannot_determine_workspace'));
+  }
+};
+
+const updateSelection = async (index: vscode.Range | number): Promise<void> => {
+  const editor = vscode.window.activeTextEditor;
+  if (editor) {
+    if (index instanceof vscode.Range) {
+      editor.selection = new vscode.Selection(index.start, index.end);
+      editor.revealRange(index); // Show selection
+    } else {
+      const line = editor.document.lineAt(index);
+      const startPos = new vscode.Position(line.lineNumber, line.firstNonWhitespaceCharacterIndex);
+      editor.selection = new vscode.Selection(startPos, line.range.end);
+      editor.revealRange(line.range); // Show selection
+    }
   }
 };

--- a/packages/salesforcedx-vscode-apex/src/views/testRunner.ts
+++ b/packages/salesforcedx-vscode-apex/src/views/testRunner.ts
@@ -26,10 +26,8 @@ export enum TestRunType {
   Method
 }
 
-export const runAllApexTests = async (testOutline: ApexTestOutlineProvider): Promise<void> => {
-  const tests = Array.from(testOutline.testStrings.values());
-  await runApexTests(tests, TestRunType.All);
-};
+export const runAllApexTests = async (testOutline: ApexTestOutlineProvider): Promise<void> =>
+  runApexTests(Array.from(testOutline.getTestStrings()), TestRunType.All);
 
 export const showErrorMessage = async (test: TestNode): Promise<void> => {
   let testNode = test;
@@ -61,12 +59,12 @@ export const showErrorMessage = async (test: TestNode): Promise<void> => {
   }
 };
 
-export const runApexTests = async (tests: string[], testRunType: TestRunType) => {
+export const runApexTests = async (tests: string[], testRunType: TestRunType): Promise<void> => {
   const languageClientStatus = languageClientManager.getStatus();
   if (!languageClientStatus.isReady()) {
     if (languageClientStatus.failedToInitialize()) {
       vscode.window.showErrorMessage(languageClientStatus.getStatusMessage());
-      return [];
+      return;
     }
   }
 

--- a/packages/salesforcedx-vscode-apex/test/jest/namespaceLensRewriter.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/namespaceLensRewriter.test.ts
@@ -6,7 +6,7 @@
  */
 
 import * as vscode from 'vscode';
-import { rewriteNamespaceLens } from '../../src/namespaceLensRewriter';
+import { rewriteClassArgument, rewriteNamespaceLens } from '../../src/namespaceLensRewriter';
 
 describe('rewriteNamespaceLens Unit Tests', () => {
   const createMockCodeLens = (title: string, args?: string[]): vscode.CodeLens => ({
@@ -259,5 +259,33 @@ describe('rewriteNamespaceLens Unit Tests', () => {
       expect(singleResult.command?.arguments).toEqual(['TestClass.testMethod']);
       expect(allResult.command?.arguments).toEqual(['TestClass']);
     });
+  });
+});
+
+describe('rewriteClassArgument Unit Tests', () => {
+  const noOrgNamespaceRewriter = rewriteClassArgument()('MyNamespace');
+  it('should rewrite namespace.class to class', () => {
+    const result = noOrgNamespaceRewriter('MyNamespace.MyClass');
+    expect(result).toEqual('MyClass');
+  });
+
+  it('should not rewrite class if namespace is not in project', () => {
+    const result = rewriteClassArgument()()('MyNamespace.MyClass');
+    expect(result).toEqual('MyNamespace.MyClass');
+  });
+
+  it('should not rewrite class if namespace is not in org', () => {
+    const result = noOrgNamespaceRewriter('MyClass');
+    expect(result).toEqual('MyClass');
+  });
+
+  it('should not rewrite other namespaces', () => {
+    const result = noOrgNamespaceRewriter('OtherNamespace.MyClass');
+    expect(result).toEqual('OtherNamespace.MyClass');
+  });
+
+  it('should not rewrite if the project and org have the same namespace', () => {
+    const result = rewriteClassArgument('MyNamespace')('MyNamespace')('MyNamespace.MyClass');
+    expect(result).toEqual('MyNamespace.MyClass');
   });
 });

--- a/packages/salesforcedx-vscode-apex/test/jest/views/testOutlineProvider.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/views/testOutlineProvider.test.ts
@@ -9,7 +9,7 @@ import * as vscode from 'vscode';
 import { URI } from 'vscode-uri';
 import { iconHelpers } from '../../../src/views/icons/iconHelpers';
 
-import { getTestOutlineProvider } from '../../../src/views/testOutlineProvider';
+import { getTestOutlineProvider, TEST_OUTLINE_PROVIDER_BASE_ID } from '../../../src/views/testOutlineProvider';
 
 describe('testOutlineProvider Unit Tests.', () => {
   const vscodeMocked = jest.mocked(vscode);
@@ -22,11 +22,6 @@ describe('testOutlineProvider Unit Tests.', () => {
     commandMock = jest.spyOn(vscodeMocked.commands, 'executeCommand');
   });
 
-  it('sets test outline provider id', () => {
-    const provider = getTestOutlineProvider();
-    expect(provider.getId()).toBe('sf.test.view');
-  });
-
   it('calls collapse all apex tests', () => {
     const provider = getTestOutlineProvider();
 
@@ -34,6 +29,8 @@ describe('testOutlineProvider Unit Tests.', () => {
 
     expect(commandMock).toHaveBeenCalledTimes(1);
     expect(commandMock.mock.calls[0].length).toBe(1);
-    expect(commandMock.mock.calls[0][0]).toBe(`workbench.actions.treeView.${provider.getId()}.collapseAll`);
+    expect(commandMock.mock.calls[0][0]).toBe(
+      `workbench.actions.treeView.${TEST_OUTLINE_PROVIDER_BASE_ID}.collapseAll`
+    );
   });
 });

--- a/packages/salesforcedx-vscode-core/src/commands/util/libraryPathsGatherer.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/util/libraryPathsGatherer.ts
@@ -16,12 +16,9 @@ export class LibraryPathsGatherer implements ParametersGatherer<string[]> {
   }
 
   public async gather(): Promise<ContinueResponse<string[]>> {
-    const sourcePaths = this.uris.map(uri => uri.fsPath);
-    const flushedSourcePaths = fileUtils.flushFilePaths(sourcePaths);
-
     return {
       type: 'CONTINUE',
-      data: flushedSourcePaths
+      data: this.uris.map(uri => uri.fsPath).map(fileUtils.flushFilePath)
     };
   }
 }


### PR DESCRIPTION
### What does this PR do?
primary
- fix namespace issue from jorje (similar to the change for codelens middleware from https://github.com/forcedotcom/salesforcedx-vscode/pull/6467 but for the 2 missing non-code-lens use cases)
  
other
- refactoring and simplifying that test tree view and the test command code (see PR notes)

### What issues does this PR fix or reference?
@W-19604488@

QA both the WI issue and some general "around the test runner" 
