### PR TITLE
chore: update git2gus v65 - W-19704215

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -31,7 +31,7 @@
     "status:duplicate": "",
     "type:community-contrib": "USER STORY"
   },
-  "defaultBuild": "offcore.tooling.64",
+  "defaultBuild": "offcore.tooling.65",
   "hideWorkItemUrl": "true",
   "statusWhenClosed": "CLOSED"
 }


### PR DESCRIPTION
What does this PR do?
Updates the defaultBuild for Git2Gus to offcore.tooling.65.

What issues does this PR fix or reference?
[@W-19704215@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002M9aKZYAZ/view)
