### PR TITLE
fix: prompt reauth for non-refreshable access tokens W-19787780

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/context/workspaceContextUtil.ts
+++ b/packages/salesforcedx-utils-vscode/src/context/workspaceContextUtil.ts
@@ -96,8 +96,19 @@ export class WorkspaceContextUtil {
         }
       } catch {
         this.sessionConnections.delete(this._username);
+        // we only want to display one message per username, even though many consumers are requesting connections.
         if (!this.knownBadConnections.has(this._username)) {
-          vscode.window.showErrorMessage('Unable to refresh your access token.  Please login again.', { modal: true });
+          const selection = await vscode.window.showErrorMessage(
+            nls.localize('error_access_token_expired'),
+            {
+              modal: true,
+              detail: nls.localize('error_access_token_expired_detail')
+            },
+            nls.localize('error_access_token_expired_login_button')
+          );
+          if (selection === 'Login') {
+            await vscode.commands.executeCommand('sf.org.login.web', connectionDetails.connection.instanceUrl);
+          }
         }
         this.knownBadConnections.add(this._username);
 

--- a/packages/salesforcedx-utils-vscode/src/helpers/traceFlags.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/traceFlags.ts
@@ -179,45 +179,45 @@ export class TraceFlags {
     }
     return false;
   }
-
-  public async handleTraceFlagCleanup(extensionContext: vscode.ExtensionContext): Promise<void> {
-    // Change the status bar message to reflect the trace flag expiration date for the new target org
-
-    // If there is a non-expired TraceFlag with DeveloperName 'ReplayDebuggerLevels' for the current user, update the status bar message
-    const newTraceFlags = new TraceFlags(await WorkspaceContextUtil.getInstance().getConnection()); // Get the new connection after switching
-    const newUserId = await newTraceFlags.getUserIdOrThrow();
-    const myTraceFlag = await newTraceFlags.getTraceFlagForUser(newUserId);
-
-    const userSpecificKey = getTraceFlagExpirationKey(newUserId);
-
-    if (!myTraceFlag) {
-      extensionContext.workspaceState.update(userSpecificKey, undefined);
-      disposeTraceFlagExpiration();
-      return;
-    }
-
-    const currentTime = new Date();
-    if (myTraceFlag.ExpirationDate && new Date(myTraceFlag.ExpirationDate) > currentTime) {
-      extensionContext.workspaceState.update(userSpecificKey, myTraceFlag.ExpirationDate);
-    } else {
-      extensionContext.workspaceState.update(userSpecificKey, undefined);
-    }
-
-    // Delete expired TraceFlags for the current user
-    const expiredTraceFlagExists = await newTraceFlags.deleteExpiredTraceFlags(newUserId);
-    if (expiredTraceFlagExists) {
-      extensionContext.workspaceState.update(userSpecificKey, undefined);
-    }
-
-    // Apex Replay Debugger Expiration Status Bar Entry
-    const expirationDate = extensionContext.workspaceState.get<string>(userSpecificKey);
-    if (expirationDate) {
-      showTraceFlagExpiration(new Date(expirationDate));
-    } else {
-      disposeTraceFlagExpiration();
-    }
-  }
 }
+
+export const handleTraceFlagCleanup = async (extensionContext: vscode.ExtensionContext): Promise<void> => {
+  // Change the status bar message to reflect the trace flag expiration date for the new target org
+
+  // If there is a non-expired TraceFlag with DeveloperName 'ReplayDebuggerLevels' for the current user, update the status bar message
+  const newTraceFlags = new TraceFlags(await WorkspaceContextUtil.getInstance().getConnection()); // Get the new connection after switching
+  const newUserId = await newTraceFlags.getUserIdOrThrow();
+  const myTraceFlag = await newTraceFlags.getTraceFlagForUser(newUserId);
+
+  const userSpecificKey = getTraceFlagExpirationKey(newUserId);
+
+  if (!myTraceFlag) {
+    extensionContext.workspaceState.update(userSpecificKey, undefined);
+    disposeTraceFlagExpiration();
+    return;
+  }
+
+  const currentTime = new Date();
+  if (myTraceFlag.ExpirationDate && new Date(myTraceFlag.ExpirationDate) > currentTime) {
+    extensionContext.workspaceState.update(userSpecificKey, myTraceFlag.ExpirationDate);
+  } else {
+    extensionContext.workspaceState.update(userSpecificKey, undefined);
+  }
+
+  // Delete expired TraceFlags for the current user
+  const expiredTraceFlagExists = await newTraceFlags.deleteExpiredTraceFlags(newUserId);
+  if (expiredTraceFlagExists) {
+    extensionContext.workspaceState.update(userSpecificKey, undefined);
+  }
+
+  // Apex Replay Debugger Expiration Status Bar Entry
+  const expirationDate = extensionContext.workspaceState.get<string>(userSpecificKey);
+  if (expirationDate) {
+    showTraceFlagExpiration(new Date(expirationDate));
+  } else {
+    disposeTraceFlagExpiration();
+  }
+};
 
 let statusBarItem: StatusBarItem | undefined;
 

--- a/packages/salesforcedx-utils-vscode/src/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/index.ts
@@ -27,7 +27,7 @@ export { OrgUserInfo, OrgShape, WorkspaceContextUtil } from './context/workspace
 export { TelemetryService, TelemetryBuilder } from './services/telemetry';
 export { isInternalHost } from './telemetry/utils/isInternal';
 export * from './helpers';
-export { TraceFlags } from './helpers/traceFlags';
+export { TraceFlags, handleTraceFlagCleanup } from './helpers/traceFlags';
 export { TimingUtils } from './helpers/timingUtils';
 export { AppInsights } from './telemetry/reporters/appInsights';
 export { hasRootWorkspace, getRootWorkspace, getRootWorkspacePath, workspaceUtils } from './workspaces';

--- a/packages/salesforcedx-utils-vscode/src/messages/i18n.ts
+++ b/packages/salesforcedx-utils-vscode/src/messages/i18n.ts
@@ -31,6 +31,11 @@ export const messages = {
     'No default org is set. Run "SFDX: Create a Default Scratch Org" or "SFDX: Authorize an Org" to set one.',
   cannot_determine_workspace: 'Unable to determine workspace folders for workspace',
 
+  error_access_token_expired: 'Access token expired or invalid',
+  error_access_token_expired_detail:
+    'Please reauthenticate using the login button or the `SFDX Authorize an Org` command.',
+  error_access_token_expired_login_button: 'Login',
+
   channel_name: 'Salesforce CLI',
   channel_starting_message: 'Starting ',
   channel_end_with_exit_code: 'ended with exit code %s',

--- a/packages/salesforcedx-vscode-core/src/commands/auth/orgLoginWeb.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/auth/orgLoginWeb.ts
@@ -28,7 +28,11 @@ class OrgLoginWebExecutor extends SfCommandletExecutor<AuthParams> {
   }
 }
 
-export const orgLoginWeb = async (): Promise<void> => {
-  const commandlet = new SfCommandlet(new SfWorkspaceChecker(), new AuthParamsGatherer(), new OrgLoginWebExecutor());
+export const orgLoginWeb = async (instanceUrl: string): Promise<void> => {
+  const commandlet = new SfCommandlet(
+    new SfWorkspaceChecker(),
+    new AuthParamsGatherer(instanceUrl),
+    new OrgLoginWebExecutor()
+  );
   await commandlet.run();
 };

--- a/packages/salesforcedx-vscode-core/src/context/workspaceContext.ts
+++ b/packages/salesforcedx-vscode-core/src/context/workspaceContext.ts
@@ -9,10 +9,10 @@ import { Connection } from '@salesforce/core';
 import {
   OrgUserInfo,
   WorkspaceContextUtil,
-  TraceFlags,
   disposeTraceFlagExpiration,
   UserService,
-  refreshAllExtensionReporters
+  refreshAllExtensionReporters,
+  handleTraceFlagCleanup
 } from '@salesforce/salesforcedx-utils-vscode';
 import * as vscode from 'vscode';
 import { decorators } from '../decorators';
@@ -84,9 +84,7 @@ export class WorkspaceContext {
     }
 
     try {
-      const connection = await WorkspaceContextUtil.getInstance().getConnection();
-      const traceFlags = new TraceFlags(connection);
-      await traceFlags.handleTraceFlagCleanup(this.extensionContext);
+      await handleTraceFlagCleanup(this.extensionContext);
     } catch (error) {
       // If the action performed results in no default org set, we need to remove the trace flag expiration
       disposeTraceFlagExpiration();

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -166,7 +166,6 @@ const registerCommands = (extensionContext: vscode.ExtensionContext): vscode.Dis
     vscode.commands.registerCommand('sf.debug.isv.bootstrap', isvDebugBootstrap),
     vscode.commands.registerCommand('sf.config.set', configSet),
     vscode.commands.registerCommand('sf.org.list.clean', orgList),
-    vscode.commands.registerCommand('sf.org.login.web', orgLoginWeb),
     vscode.commands.registerCommand('sf.org.login.web.dev.hub', orgLoginWebDevHub),
     vscode.commands.registerCommand('sf.org.logout.all', orgLogoutAll),
     vscode.commands.registerCommand('sf.org.logout.default', orgLogoutDefault),
@@ -216,6 +215,9 @@ const setupOrgBrowser = async (extensionContext: vscode.ExtensionContext): Promi
 export const activate = async (extensionContext: vscode.ExtensionContext): Promise<SalesforceVSCodeCoreApi> => {
   const activationStartTime = TimingUtils.getCurrentTime();
   const activateTracker = new ActivationTracker(extensionContext, telemetryService);
+  // we need this command very early in activation process to handle auth issues from access token only orgs.
+  extensionContext.subscriptions.push(vscode.commands.registerCommand('sf.org.login.web', orgLoginWeb));
+
   const rootWorkspacePath = getRootWorkspacePath();
   // Switch to the project directory so that the main @salesforce
   // node libraries work correctly.  @salesforce/core,

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -11,9 +11,8 @@ import {
   SFDX_CORE_CONFIGURATION_NAME,
   SfWorkspaceChecker,
   TelemetryService,
+  handleTraceFlagCleanup,
   TimingUtils,
-  TraceFlags,
-  WorkspaceContextUtil,
   ensureCurrentWorkingDirIsProjectPath,
   getRootWorkspacePath,
   isSalesforceProjectOpened
@@ -324,8 +323,7 @@ export const activate = async (extensionContext: vscode.ExtensionContext): Promi
 
   // Handle trace flag cleanup after setting target org
   try {
-    const connection = await WorkspaceContextUtil.getInstance().getConnection();
-    await new TraceFlags(connection).handleTraceFlagCleanup(extensionContext);
+    await handleTraceFlagCleanup(extensionContext);
   } catch (error) {
     console.log('Trace flag cleanup not completed during activation of CLI Integration extension', error);
   }


### PR DESCRIPTION
### What does this PR do?
mostly for CodeBuilder, workspaceContextUtils prompts the user to reauth when the token is expired.
- only happens for non-refreshable tokens
- presets the instanceurl/alias to avoid making the user do anything

secondary
- reduce some getConnection calls by refactoring the traceFlag stuff (becuase it's also part of ext activation)
- moves the orgLogin command very early in the ext activation

### What issues does this PR fix or reference?
@W-19787780@
