### PR TITLE
W-19829802 Add check for CodeBuilder to re-enable auth commands

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/helpers/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/index.ts
@@ -28,7 +28,8 @@ export {
   TraceFlags,
   showTraceFlagExpiration,
   disposeTraceFlagExpiration,
-  getTraceFlagExpirationKey
+  getTraceFlagExpirationKey,
+  handleTraceFlagCleanup
 } from './traceFlags';
 export {
   difference,

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -306,23 +306,23 @@
         },
         {
           "command": "sf.org.login.web.dev.hub",
-          "when": "sf:project_opened && !isWeb"
+          "when": "sf:project_opened && (!isWeb || (isWeb && sf:code_builder_enabled))"
         },
         {
           "command": "sf.org.login.access.token",
-          "when": "sf:project_opened && !isWeb"
+          "when": "sf:project_opened && (!isWeb || (isWeb && sf:code_builder_enabled))"
         },
         {
           "command": "sf.org.login.web",
-          "when": "sf:project_opened && !isWeb"
+          "when": "sf:project_opened && (!isWeb || (isWeb && sf:code_builder_enabled))"
         },
         {
           "command": "sf.org.logout.all",
-          "when": "sf:project_opened && !isWeb"
+          "when": "sf:project_opened && (!isWeb || (isWeb && sf:code_builder_enabled))"
         },
         {
           "command": "sf.org.logout.default",
-          "when": "sf:project_opened && sf:has_target_org && !isWeb"
+          "when": "sf:project_opened && sf:has_target_org && (!isWeb || (isWeb && sf:code_builder_enabled))"
         },
         {
           "command": "sf.open.documentation",
@@ -330,11 +330,11 @@
         },
         {
           "command": "sf.org.create",
-          "when": "sf:project_opened && !isWeb"
+          "when": "sf:project_opened && (!isWeb || (isWeb && sf:code_builder_enabled))"
         },
         {
           "command": "sf.org.open",
-          "when": "sf:project_opened && sf:has_target_org && !isWeb"
+          "when": "sf:project_opened && sf:has_target_org && (!isWeb || (isWeb && sf:code_builder_enabled))"
         },
         {
           "command": "sf.project.retrieve.start",
@@ -398,15 +398,15 @@
         },
         {
           "command": "sf.alias.list",
-          "when": "sf:project_opened && !isWeb"
+          "when": "sf:project_opened && (!isWeb || (isWeb && sf:code_builder_enabled))"
         },
         {
           "command": "sf.org.display.default",
-          "when": "sf:project_opened && sf:has_target_org && !isWeb"
+          "when": "sf:project_opened && sf:has_target_org && (!isWeb || (isWeb && sf:code_builder_enabled))"
         },
         {
           "command": "sf.org.display.username",
-          "when": "sf:project_opened && sf:has_target_org && !isWeb"
+          "when": "sf:project_opened && sf:has_target_org && (!isWeb || (isWeb && sf:code_builder_enabled))"
         },
         {
           "command": "sf.data.query.input",
@@ -418,11 +418,11 @@
         },
         {
           "command": "sf.project.generate",
-          "when": "!sf:internal_dev && !isWeb"
+          "when": "!sf:internal_dev && (!isWeb || (isWeb && sf:code_builder_enabled))"
         },
         {
           "command": "sf.project.generate.with.manifest",
-          "when": "!sf:internal_dev && !isWeb"
+          "when": "!sf:internal_dev && (!isWeb || (isWeb && sf:code_builder_enabled))"
         },
         {
           "command": "sf.project.generate.manifest",
@@ -438,15 +438,15 @@
         },
         {
           "command": "sf.start.apex.debug.logging",
-          "when": "sf:project_opened && sf:replay_debugger_extension && sf:has_target_org && !isWeb"
+          "when": "sf:project_opened && sf:replay_debugger_extension && sf:has_target_org && (!isWeb || (isWeb && sf:code_builder_enabled))"
         },
         {
           "command": "sf.stop.apex.debug.logging",
-          "when": "sf:project_opened && sf:replay_debugger_extension && sf:has_target_org && !isWeb"
+          "when": "sf:project_opened && sf:replay_debugger_extension && sf:has_target_org && (!isWeb || (isWeb && sf:code_builder_enabled))"
         },
         {
           "command": "sf.debug.isv.bootstrap",
-          "when": "!sf:internal_dev && !isWeb"
+          "when": "!sf:internal_dev && (!isWeb || (isWeb && sf:code_builder_enabled))"
         },
         {
           "command": "sf.retrieve.component",
@@ -486,15 +486,15 @@
         },
         {
           "command": "sf.org.delete.default",
-          "when": "sf:project_opened && sf:has_target_org && !isWeb"
+          "when": "sf:project_opened && sf:has_target_org && (!isWeb || (isWeb && sf:code_builder_enabled))"
         },
         {
           "command": "sf.org.delete.username",
-          "when": "sf:project_opened && !isWeb"
+          "when": "sf:project_opened && (!isWeb || (isWeb && sf:code_builder_enabled))"
         },
         {
           "command": "sf.org.list.clean",
-          "when": "sf:project_opened && !isWeb"
+          "when": "sf:project_opened && (!isWeb || (isWeb && sf:code_builder_enabled))"
         },
         {
           "command": "sf.delete.source.current.file",

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -294,6 +294,10 @@ export const activate = async (extensionContext: vscode.ExtensionContext): Promi
 
   void vscode.commands.executeCommand('setContext', 'sf:project_opened', salesforceProjectOpened);
 
+  // Set Code Builder context
+  const codeBuilderEnabled = process.env.CODE_BUILDER === 'true';
+  void vscode.commands.executeCommand('setContext', 'sf:code_builder_enabled', codeBuilderEnabled);
+
   // Set initial context
   await checkPackageDirectoriesEditorView();
 


### PR DESCRIPTION
### What does this PR do?
Add a check for the environment variable CODE_BUILDER which can be used to re-enable the auth related commands 

### What issues does this PR fix or reference?
@W-19829802@

### Functionality Before
No auth related commands in CodeBuilder environments 

### Functionality After
Auth commands available in CodeBuilder Environments 
