### PR TITLE
fix: adding new optional param - W-20176558

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6379,12 +6379,12 @@
       "license": "MIT"
     },
     "node_modules/@salesforce/apex-node": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/@salesforce/apex-node/-/apex-node-8.3.3.tgz",
-      "integrity": "sha512-s3gTHl8i2h7+7drK7YBvRwZkSLl54G5d/KaGAhJWZAK2WGcPtPdoIOyiMj7rg2NRjswFnC68D9Kt3yBCWyPKCw==",
+      "version": "8.3.7",
+      "resolved": "https://registry.npmjs.org/@salesforce/apex-node/-/apex-node-8.3.7.tgz",
+      "integrity": "sha512-Nwyza/zw8JOeCE+nC07zpKQT5Z1hLxVxsVlT4Xd6uq7Oj3GnhTDCXy201vxjRATPySulPyj/KpCQxYliO+H3fw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "^8.23.1",
+        "@salesforce/core": "^8.23.4",
         "@salesforce/kit": "^3.2.4",
         "@types/istanbul-reports": "^3.0.4",
         "fast-glob": "^3.3.2",
@@ -6473,9 +6473,9 @@
       "license": "MIT"
     },
     "node_modules/@salesforce/core": {
-      "version": "8.23.3",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-8.23.3.tgz",
-      "integrity": "sha512-BD9cOUOw3wTR8ud6dBacLvA4x0KAfQXkNGdxtU9ujz5nEW86ms5tU1AEUzVXnhuDrrtdQZh7/yTGxqg5mS7rZg==",
+      "version": "8.23.4",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-8.23.4.tgz",
+      "integrity": "sha512-+JZMFD76P7X8fLSrHJRi9+ygjTehqZqJRXxmNq51miqIHY1Xlb0qH/yr9u5QEGsFIOZ8H8oStl/Zj+ZbrFs0vw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jsforce/jsforce-node": "^3.10.8",
@@ -36704,7 +36704,7 @@
       "version": "65.4.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/apex-node": "^8.3.1",
+        "@salesforce/apex-node": "^8.3.7",
         "@salesforce/apex-tmlanguage": "^1.8.3",
         "@salesforce/salesforcedx-utils": "65.4.0",
         "@salesforce/salesforcedx-utils-vscode": "65.4.0",
@@ -36785,7 +36785,7 @@
       "version": "65.4.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/apex-node": "^8.3.1",
+        "@salesforce/apex-node": "^8.3.7",
         "@salesforce/salesforcedx-apex-replay-debugger": "65.4.0",
         "@salesforce/salesforcedx-utils": "65.4.0",
         "@salesforce/salesforcedx-utils-vscode": "65.4.0",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -24,7 +24,7 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/apex-node": "^8.3.1",
+    "@salesforce/apex-node": "^8.3.7",
     "@salesforce/salesforcedx-apex-replay-debugger": "65.4.0",
     "@salesforce/salesforcedx-utils": "65.4.0",
     "@salesforce/salesforcedx-utils-vscode": "65.4.0",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/quickLaunch.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/quickLaunch.ts
@@ -85,7 +85,9 @@ class QuickLaunch {
       const payload = await testService.buildSyncPayload(
         TestLevel.RunSpecifiedTests,
         testMethod ? `${testClass}.${testMethod}` : undefined,
-        testClass
+        testClass,
+        undefined,
+        !retrieveTestCodeCoverage() // the setting enables code coverage, so we need to pass false to disable it
       );
       // W-18453221
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -26,7 +26,7 @@
     "Programming Languages"
   ],
   "dependencies": {
-    "@salesforce/apex-node": "^8.3.1",
+    "@salesforce/apex-node": "^8.3.7",
     "@salesforce/apex-tmlanguage": "^1.8.3",
     "@salesforce/salesforcedx-utils": "65.4.0",
     "@salesforce/salesforcedx-utils-vscode": "65.4.0",

--- a/packages/salesforcedx-vscode-apex/src/commands/apexTestRun.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/apexTestRun.ts
@@ -167,9 +167,23 @@ const buildTestPayload = async (
   const testLevel = TestLevel.RunSpecifiedTests;
   switch (data.type) {
     case TestType.Class:
-      return await testService.buildAsyncPayload(testLevel, undefined, data.label);
+      return await testService.buildAsyncPayload(
+        testLevel,
+        undefined,
+        data.label,
+        undefined,
+        undefined,
+        !settings.retrieveTestCodeCoverage() // the setting enables code coverage, so we need to pass false to disable it
+      );
     case TestType.Suite:
-      return await testService.buildAsyncPayload(testLevel, undefined, undefined, data.label);
+      return await testService.buildAsyncPayload(
+        testLevel,
+        undefined,
+        undefined,
+        data.label,
+        undefined,
+        !settings.retrieveTestCodeCoverage()
+      );
     case TestType.AllLocal:
       return { testLevel: TestLevel.RunLocalTests };
     case TestType.All:

--- a/packages/salesforcedx-vscode-apex/src/commands/apexTestRunCodeAction.ts
+++ b/packages/salesforcedx-vscode-apex/src/commands/apexTestRunCodeAction.ts
@@ -67,7 +67,14 @@ export class ApexLibraryTestRunExecutor extends LibraryCommandletExecutor<{}> {
     const vscodeCoreExtension = await getVscodeCoreExtension();
     const connection = await vscodeCoreExtension.exports.WorkspaceContext.getInstance().getConnection();
     const testService = new TestService(connection);
-    const payload = await testService.buildAsyncPayload(TestLevel.RunSpecifiedTests, this.tests.join());
+    const payload = await testService.buildAsyncPayload(
+      TestLevel.RunSpecifiedTests,
+      this.tests.join(),
+      undefined,
+      undefined,
+      undefined,
+      !this.codeCoverage // the setting enables code coverage, so we need to pass false to disable it
+    );
 
     const progressReporter: Progress<ApexTestProgressValue> = {
       report: value => {


### PR DESCRIPTION
### What does this PR do?
Passes in the new optional param with payload. This ensures that we skip calculating the code coverage in additon to report the coverage. https://developer.salesforce.com/docs/atlas.en-us.api_tooling.meta/api_tooling/intro_rest_resources_testing_runner_async.htm


### What issues does this PR fix or reference?
[@W-20176558@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002P3m8mYAB/view)
