### PR TITLE
feat: schemas from core W-20329918

### DIFF
--- a/.cursor/plans/upgrade_zod_to_v4_9d176744.plan.md
+++ b/.cursor/plans/upgrade_zod_to_v4_9d176744.plan.md
@@ -1,0 +1,60 @@
+---
+name: Upgrade Zod to v4
+overview: Update salesforcedx-utils-vscode package to use Zod v4, fixing the breaking changes in error message syntax.
+todos: []
+---
+
+# Upgrade Zod to v4
+
+## Changes Required
+
+### 1. Update package.json dependency
+
+Update [`packages/salesforcedx-utils-vscode/package.json`](packages/salesforcedx-utils-vscode/package.json) to use Zod v4:
+
+- Change `"zod": "3.25.76"` to `"zod": "^4.1.12"` (matching the version already used by other dependencies)
+
+### 2. Fix breaking changes in telemetry.ts
+
+Update [`packages/salesforcedx-utils-vscode/src/services/telemetry.ts`](packages/salesforcedx-utils-vscode/src/services/telemetry.ts) line 370-376:
+
+- Change `message` parameter to `error` parameter in Zod v4
+- Reference: [Zod v4 Changelog](https://zod.dev/v4/changelog) and [Error Customization](https://zod.dev/error-customization)
+
+**Before:**
+
+```typescript
+const extensionPackageJsonSchema = z.object({
+  name: z.string({ message: 'Extension name is not defined in package.json' }),
+  version: z.string({ message: 'Extension version is not defined in package.json' }),
+  aiKey: z.string().optional(),
+  o11yUploadEndpoint: z.string().optional(),
+  enableO11y: z.string().optional()
+});
+```
+
+**After:**
+
+```typescript
+const extensionPackageJsonSchema = z.object({
+  name: z.string({ error: 'Extension name is not defined in package.json' }),
+  version: z.string({ error: 'Extension version is not defined in package.json' }),
+  aiKey: z.string().optional(),
+  o11yUploadEndpoint: z.string().optional(),
+  enableO11y: z.string().optional()
+});
+```
+
+### 3. No changes needed for activationTrackerUtils.ts
+
+The usage in [`packages/salesforcedx-utils-vscode/src/helpers/activationTrackerUtils.ts`](packages/salesforcedx-utils-vscode/src/helpers/activationTrackerUtils.ts) (line 22-28) uses basic `z.object()` and `z.string()` which remain compatible in v4.
+
+### 4. Run validation steps
+
+After changes, run the standard validation workflow from repo root:
+
+1. `npm install` - update dependencies
+2. `npm run compile` - verify compilation
+3. `npm run lint` - check linting
+4. `npm run test` - run tests
+5. `npx knip` - check for dead code

--- a/package-lock.json
+++ b/package-lock.json
@@ -3312,9 +3312,9 @@
       }
     },
     "node_modules/@jsforce/jsforce-node": {
-      "version": "3.10.8",
-      "resolved": "https://registry.npmjs.org/@jsforce/jsforce-node/-/jsforce-node-3.10.8.tgz",
-      "integrity": "sha512-XGD/ivZz+htN5SgctFyEZ+JNG6C8FXzaEwvPbRSdsIy/hpWlexY38XtTpdT5xX3KnYSnOE4zA1M/oIbTm7RD/Q==",
+      "version": "3.10.10",
+      "resolved": "https://registry.npmjs.org/@jsforce/jsforce-node/-/jsforce-node-3.10.10.tgz",
+      "integrity": "sha512-/zUOX9kapwk8lyjmTYgXlBF+GbqcEpb0zrkDfX9i94xu5cvzERZxRHqSSaS/IImoDmvoSbatFSVfB7Y4lmANOw==",
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^4",
@@ -5458,14 +5458,13 @@
       "license": "MIT"
     },
     "node_modules/@salesforce/core": {
-      "version": "8.23.4",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-8.23.4.tgz",
-      "integrity": "sha512-+JZMFD76P7X8fLSrHJRi9+ygjTehqZqJRXxmNq51miqIHY1Xlb0qH/yr9u5QEGsFIOZ8H8oStl/Zj+ZbrFs0vw==",
+      "version": "8.24.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-8.24.0.tgz",
+      "integrity": "sha512-8Ra5RT95bRkmHmaaFgABwkXbnHNSNS7l9gbJzJgO6VQpaEeytGPPyymnAE7TcTM2xp/QwlXn+PgX4biX7Lb7JA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@jsforce/jsforce-node": "^3.10.8",
+        "@jsforce/jsforce-node": "^3.10.10",
         "@salesforce/kit": "^3.2.4",
-        "@salesforce/schemas": "^1.10.3",
         "@salesforce/ts-types": "^2.0.12",
         "ajv": "^8.17.1",
         "change-case": "^4.1.2",
@@ -5473,7 +5472,7 @@
         "faye": "^1.4.1",
         "form-data": "^4.0.4",
         "js2xmlparser": "^4.0.1",
-        "jsonwebtoken": "9.0.2",
+        "jsonwebtoken": "9.0.3",
         "jszip": "3.10.1",
         "memfs": "^4.30.1",
         "pino": "^9.7.0",
@@ -5481,7 +5480,8 @@
         "pino-pretty": "^11.3.0",
         "proper-lockfile": "^4.1.2",
         "semver": "^7.7.3",
-        "ts-retry-promise": "^0.8.1"
+        "ts-retry-promise": "^0.8.1",
+        "zod": "^4.1.12"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -6079,12 +6079,6 @@
       "resolved": "https://registry.npmjs.org/@salesforce/schema/-/schema-0.0.21.tgz",
       "integrity": "sha512-4Ol0ZsF+vKcnc1j+Ld0RIKGAJrRcuYdaRNjyre/ae8IBqMG3ZykOgfAyJdtGFirJO1y4v4eAAqnTVSinrAZ44Q==",
       "license": "MIT"
-    },
-    "node_modules/@salesforce/schemas": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@salesforce/schemas/-/schemas-1.10.3.tgz",
-      "integrity": "sha512-FKfvtrYTcvTXE9advzS25/DEY9yJhEyLvStm++eQFtnAaX1pe4G3oGHgiQ0q55BM5+0AlCh0+0CVtQv1t4oJRA==",
-      "license": "ISC"
     },
     "node_modules/@salesforce/soql-builder-ui": {
       "version": "1.0.0",
@@ -20721,12 +20715,12 @@
       }
     },
     "node_modules/jsonwebtoken": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
       "license": "MIT",
       "dependencies": {
-        "jws": "^3.2.2",
+        "jws": "^4.0.1",
         "lodash.includes": "^4.3.0",
         "lodash.isboolean": "^3.0.3",
         "lodash.isinteger": "^4.0.4",
@@ -20842,9 +20836,9 @@
       "license": "MIT"
     },
     "node_modules/jwa": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
-      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
@@ -20853,12 +20847,12 @@
       }
     },
     "node_modules/jws": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
-      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.2",
+        "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -32952,9 +32946,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
+      "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -33441,7 +33435,7 @@
         "rxjs": "^5.4.1",
         "tree-kill": "^1.1.0",
         "vscode-uri": "^3.1.0",
-        "zod": "3.25.76"
+        "zod": "^4.1.12"
       },
       "devDependencies": {
         "@salesforce/source-deploy-retrieve": "^12.29.1",
@@ -33811,12 +33805,11 @@
       "version": "65.7.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "^8.23.3",
+        "@salesforce/core": "^8.24.0",
         "@salesforce/o11y-reporter": "1.6.0",
         "@salesforce/salesforcedx-sobjects-faux-generator": "*",
         "@salesforce/salesforcedx-utils": "*",
         "@salesforce/salesforcedx-utils-vscode": "*",
-        "@salesforce/schemas": "1.10.3",
         "@salesforce/source-deploy-retrieve": "^12.29.1",
         "@salesforce/source-tracking": "^7.7.0",
         "@salesforce/templates": "^65.1.1",

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -21,7 +21,7 @@
     "rxjs": "^5.4.1",
     "tree-kill": "^1.1.0",
     "vscode-uri": "^3.1.0",
-    "zod": "3.25.76"
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "@salesforce/source-deploy-retrieve": "^12.29.1",

--- a/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
+++ b/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
@@ -368,8 +368,8 @@ export class TelemetryService implements TelemetryServiceInterface {
 }
 
 const extensionPackageJsonSchema = z.object({
-  name: z.string({ message: 'Extension name is not defined in package.json' }),
-  version: z.string({ message: 'Extension version is not defined in package.json' }),
+  name: z.string({ error: 'Extension name is not defined in package.json' }),
+  version: z.string({ error: 'Extension version is not defined in package.json' }),
   aiKey: z.string().optional(),
   o11yUploadEndpoint: z.string().optional(),
   enableO11y: z.string().optional()

--- a/packages/salesforcedx-vscode-core/esbuild.config.mjs
+++ b/packages/salesforcedx-vscode-core/esbuild.config.mjs
@@ -29,7 +29,7 @@ await build({
   ...nodeConfig,
   entryPoints: ['./src/index.ts'],
   outdir: 'dist/src',
-  external: [...nodeConfig.external, 'applicationinsights', '@salesforce/schemas'],
+  external: [...nodeConfig.external, 'applicationinsights'],
   minify: true
 });
 

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -24,12 +24,11 @@
     "Other"
   ],
   "dependencies": {
-    "@salesforce/core": "^8.23.3",
+    "@salesforce/core": "^8.24.0",
     "@salesforce/o11y-reporter": "1.6.0",
     "@salesforce/salesforcedx-sobjects-faux-generator": "*",
     "@salesforce/salesforcedx-utils": "*",
     "@salesforce/salesforcedx-utils-vscode": "*",
-    "@salesforce/schemas": "1.10.3",
     "@salesforce/source-deploy-retrieve": "^12.29.1",
     "@salesforce/source-tracking": "^7.7.0",
     "@salesforce/templates": "^65.1.1",
@@ -68,8 +67,7 @@
       "main": "dist/src/index.js",
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "@salesforce/o11y-reporter": "1.6.0",
-        "@salesforce/schemas": "1.10.3"
+        "@salesforce/o11y-reporter": "1.6.0"
       },
       "devDependencies": {}
     }
@@ -106,10 +104,20 @@
         "tsconfig.tsbuildinfo"
       ]
     },
+    "copy:schemas": {
+      "command": "shx mkdir -p resources/schemas && shx cp ../../node_modules/@salesforce/core/schemas/* ./resources/schemas",
+      "files": [
+        "../../node_modules/@salesforce/core/schemas"
+      ],
+      "output": [
+        "resources/schemas"
+      ]
+    },
     "vscode:bundle": {
       "command": "node ./esbuild.config.mjs",
       "dependencies": [
-        "compile"
+        "compile",
+        "copy:schemas"
       ],
       "files": [
         "esbuild.config.mjs",
@@ -924,11 +932,11 @@
     "jsonValidation": [
       {
         "fileMatch": "sfdx-project.json",
-        "url": "./node_modules/@salesforce/schemas/sfdx-project.schema.json"
+        "url": "./resources/schemas/sfdx-project.schema.json"
       },
       {
         "fileMatch": "*-scratch-def.json",
-        "url": "./node_modules/@salesforce/schemas/project-scratch-def.schema.json"
+        "url": "./resources/schemas/project-scratch-def.schema.json"
       }
     ],
     "languages": [

--- a/packages/salesforcedx-vscode-core/resources/schemas/project-scratch-def.schema.json
+++ b/packages/salesforcedx-vscode-core/resources/schemas/project-scratch-def.schema.json
@@ -1,0 +1,1789 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "orgName": {
+      "description": "The name of the scratch org.",
+      "title": "Organization Name",
+      "type": "string"
+    },
+    "edition": {
+      "description": "The Salesforce edition of the scratch org.",
+      "type": "string",
+      "enum": [
+        "Developer",
+        "Enterprise",
+        "Group",
+        "Partner Developer",
+        "Partner Enterprise",
+        "Partner Group",
+        "Partner Professional",
+        "Professional"
+      ]
+    },
+    "country": {
+      "description": "Dev Hub's country. If you want to override this value, enter the two-character, upper-case ISO-3166 country code (Alpha-2 code). You can find a full list of these codes at several sites, such as: https://www.iso.org/obp/ui/#search. This value sets the locale of the scratch org.",
+      "type": "string",
+      "maxLength": 2
+    },
+    "username": {
+      "description": "A user name formatted like test-unique_identifier@orgName.net.",
+      "type": "string"
+    },
+    "adminEmail": {
+      "description": "Email address of the Dev Hub user making the scratch org creation request.",
+      "title": "Administrator Email Address",
+      "type": "string"
+    },
+    "description": {
+      "description": "The description is a good way to document the scratch org's purpose. You can view or edit the description in the Dev Hub. From App Launcher, select Scratch Org Info or Active Scratch Orgs, then click the scratch org number.",
+      "title": "Description of the Org",
+      "type": "string"
+    },
+    "hasSampleData": {
+      "description": "Valid values are true and false. False is the default, which creates an org without sample data.",
+      "title": "Include Sample Data",
+      "default": false,
+      "type": "boolean"
+    },
+    "language": {
+      "description": "Default language for the country. To override the language set by the Dev Hub locale, see Supported Languages (https://help.salesforce.com/articleView?id=faq_getstart_what_languages_does.htm&type=5&language=en_US) for the codes to use in this field.",
+      "title": "Default Language",
+      "type": "string",
+      "maxLength": 5
+    },
+    "features": {
+      "description": "Features to enable in the scratch org.",
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "title": "AddCustomApps:<value>",
+                "type": "string",
+                "pattern": "^AddCustomApps:[0-9]+$"
+              },
+              {
+                "title": "AddCustomObjects:<value>",
+                "type": "string",
+                "pattern": "^AddCustomObjects:[0-9]+$"
+              },
+              {
+                "title": "AddCustomRelationships:<value>",
+                "type": "string",
+                "pattern": "^AddCustomRelationships:[0-9]+$"
+              },
+              {
+                "title": "AddCustomTabs:<value>",
+                "type": "string",
+                "pattern": "^AddCustomTabs:[0-9]+$"
+              },
+              {
+                "title": "AddDataComCRMRecordCredit:<value>",
+                "type": "string",
+                "pattern": "^AddDataComCRMRecordCredit:[0-9]+$"
+              },
+              {
+                "title": "AddInsightsQueryLimit:<value>",
+                "type": "string",
+                "pattern": "^AddInsightsQueryLimit:[0-9]+$"
+              },
+              {
+                "title": "AdditionalFieldHistory:<value>",
+                "type": "string",
+                "pattern": "^AdditionalFieldHistory:[0-9]+$"
+              },
+              {
+                "title": "AssetScheduling:<value>",
+                "type": "string",
+                "pattern": "^AssetScheduling:[0-9]+$"
+              },
+              {
+                "title": "CalloutSizeMB:<value>",
+                "type": "string",
+                "pattern": "^CalloutSizeMB:[0-9]+$"
+              },
+              {
+                "title": "ConcStreamingClients:<value>",
+                "type": "string",
+                "pattern": "^ConcStreamingClients:[0-9]+$"
+              },
+              {
+                "title": "ConsolePersistenceInterval:<value>",
+                "type": "string",
+                "pattern": "^ConsolePersistenceInterval:[0-9]+$"
+              },
+              {
+                "title": "EducationCloud:<value>",
+                "type": "string",
+                "pattern": "^EducationCloud:[0-9]+$"
+              },
+              {
+                "title": "EmpPublishRateLimit:<value>",
+                "type": "string",
+                "pattern": "^EmpPublishRateLimit:[0-9]+$"
+              },
+              {
+                "title": "EncryptionStatisticsInterval:<value>",
+                "type": "string",
+                "pattern": "^EncryptionStatisticsInterval:[0-9]+$"
+              },
+              {
+                "title": "EncryptionSyncInterval:<value>",
+                "type": "string",
+                "pattern": "^EncryptionSyncInterval:[0-9]+$"
+              },
+              {
+                "title": "FieldService:<value>",
+                "type": "string",
+                "pattern": "^FieldService:[0-9]+$"
+              },
+              {
+                "title": "FieldServiceAppointmentAssistantUser:<value>",
+                "type": "string",
+                "pattern": "^FieldServiceAppointmentAssistantUser:[0-9]+$"
+              },
+              {
+                "title": "FieldServiceDispatcherUser:<value>",
+                "type": "string",
+                "pattern": "^FieldServiceDispatcherUser:[0-9]+$"
+              },
+              {
+                "title": "FieldServiceLastMileUser:<value>",
+                "type": "string",
+                "pattern": "^FieldServiceLastMileUser:[0-9]+$"
+              },
+              {
+                "title": "FieldServiceMobileUser:<value>",
+                "type": "string",
+                "pattern": "^FieldServiceMobileUser:[0-9]+$"
+              },
+              {
+                "title": "FieldServiceSchedulingUser:<value>",
+                "type": "string",
+                "pattern": "^FieldServiceSchedulingUser:[0-9]+$"
+              },
+              {
+                "title": "FinancialServicesCommunityUser:<value>",
+                "type": "string",
+                "pattern": "^FinancialServicesCommunityUser:[0-9]+$"
+              },
+              {
+                "title": "FinancialServicesUser:<value>",
+                "type": "string",
+                "pattern": "^FinancialServicesUser:[0-9]+$"
+              },
+              {
+                "title": "GenStreamingEventsPerDay:<value>",
+                "type": "string",
+                "pattern": "^GenStreamingEventsPerDay:[0-9]+$"
+              },
+              {
+                "title": "HoursBetweenCoverageJob:<value>",
+                "type": "string",
+                "pattern": "^HoursBetweenCoverageJob:[0-9]+$"
+              },
+              {
+                "title": "LoyaltyMaxOrderLinePerHour:<value>",
+                "type": "string",
+                "pattern": "^LoyaltyMaxOrderLinePerHour:[0-9]+$"
+              },
+              {
+                "title": "LoyaltyMaxProcExecPerHour:<value>",
+                "type": "string",
+                "pattern": "^LoyaltyMaxProcExecPerHour:[0-9]+$"
+              },
+              {
+                "title": "LoyaltyMaxTransactions:<value>",
+                "type": "string",
+                "pattern": "^LoyaltyMaxTransactions:[0-9]+$"
+              },
+              {
+                "title": "LoyaltyMaxTrxnJournals:<value>",
+                "type": "string",
+                "pattern": "^LoyaltyMaxTrxnJournals:[0-9]+$"
+              },
+              {
+                "title": "LoyaltyMaximumPartners:<value>",
+                "type": "string",
+                "pattern": "^LoyaltyMaximumPartners:[0-9]+$"
+              },
+              {
+                "title": "LoyaltyMaximumPrograms:<value>",
+                "type": "string",
+                "pattern": "^LoyaltyMaximumPrograms:[0-9]+$"
+              },
+              {
+                "title": "MaxActiveDPEDefs:<value>",
+                "type": "string",
+                "pattern": "^MaxActiveDPEDefs:[0-9]+$"
+              },
+              {
+                "title": "MaxApexCodeSize:<value>",
+                "type": "string",
+                "pattern": "^MaxApexCodeSize:[0-9]+$"
+              },
+              {
+                "title": "MaxCustomLabels:<value>",
+                "type": "string",
+                "pattern": "^MaxCustomLabels:[0-9]+$"
+              },
+              {
+                "title": "MaxDataSourcesPerDPE:<value>",
+                "type": "string",
+                "pattern": "^MaxDataSourcesPerDPE:[0-9]+$"
+              },
+              {
+                "title": "MaxDatasetLinksPerDT:<value>",
+                "type": "string",
+                "pattern": "^MaxDatasetLinksPerDT:[0-9]+$"
+              },
+              {
+                "title": "MaxDecisionTableAllowed:<value>",
+                "type": "string",
+                "pattern": "^MaxDecisionTableAllowed:[0-9]+$"
+              },
+              {
+                "title": "MaxFavoritesAllowed:<value>",
+                "type": "string",
+                "pattern": "^MaxFavoritesAllowed:[0-9]+$"
+              },
+              {
+                "title": "MaxFieldsPerNode:<value>",
+                "type": "string",
+                "pattern": "^MaxFieldsPerNode:[0-9]+$"
+              },
+              {
+                "title": "MaxInputColumnsPerDT:<value>",
+                "type": "string",
+                "pattern": "^MaxInputColumnsPerDT:[0-9]+$"
+              },
+              {
+                "title": "MaxLoyaltyProcessRules:<value>",
+                "type": "string",
+                "pattern": "^MaxLoyaltyProcessRules:[0-9]+$"
+              },
+              {
+                "title": "MaxNoOfLexThemesAllowed:<value>",
+                "type": "string",
+                "pattern": "^MaxNoOfLexThemesAllowed:[0-9]+$"
+              },
+              {
+                "title": "MaxNodesPerDPE:<value>",
+                "type": "string",
+                "pattern": "^MaxNodesPerDPE:[0-9]+$"
+              },
+              {
+                "title": "MaxOutputColumnsPerDT:<value>",
+                "type": "string",
+                "pattern": "^MaxOutputColumnsPerDT:[0-9]+$"
+              },
+              {
+                "title": "MaxSourceObjectPerDSL:<value>",
+                "type": "string",
+                "pattern": "^MaxSourceObjectPerDSL:[0-9]+$"
+              },
+              {
+                "title": "MaxStreamingTopics:<value>",
+                "type": "string",
+                "pattern": "^MaxStreamingTopics:[0-9]+$"
+              },
+              {
+                "title": "MaxUserNavItemsAllowed:<value>",
+                "type": "string",
+                "pattern": "^MaxUserNavItemsAllowed:[0-9]+$"
+              },
+              {
+                "title": "MaxUserStreamingChannels:<value>",
+                "type": "string",
+                "pattern": "^MaxUserStreamingChannels:[0-9]+$"
+              },
+              {
+                "title": "MaxWritebacksPerDPE:<value>",
+                "type": "string",
+                "pattern": "^MaxWritebacksPerDPE:[0-9]+$"
+              },
+              {
+                "title": "MedVisDescriptorLimit:<value>",
+                "type": "string",
+                "pattern": "^MedVisDescriptorLimit:[0-9]+$"
+              },
+              {
+                "title": "MobileExtMaxFileSizeMB:<value>",
+                "type": "string",
+                "pattern": "^MobileExtMaxFileSizeMB:[0-9]+$"
+              },
+              {
+                "title": "NumPlatformEvents:<value>",
+                "type": "string",
+                "pattern": "^NumPlatformEvents:[0-9]+$"
+              },
+              {
+                "title": "PlatformConnect:<value>",
+                "type": "string",
+                "pattern": "^PlatformConnect:[0-9]+$"
+              },
+              {
+                "title": "PlatformEventsPerDay:<value>",
+                "type": "string",
+                "pattern": "^PlatformEventsPerDay:[0-9]+$"
+              },
+              {
+                "title": "StreamingEventsPerDay:<value>",
+                "type": "string",
+                "pattern": "^StreamingEventsPerDay:[0-9]+$"
+              },
+              {
+                "title": "SubPerStreamingChannel:<value>",
+                "type": "string",
+                "pattern": "^SubPerStreamingChannel:[0-9]+$"
+              },
+              {
+                "title": "SubPerStreamingTopic:<value>",
+                "type": "string",
+                "pattern": "^SubPerStreamingTopic:[0-9]+$"
+              }
+            ]
+          },
+          {
+            "enum": [
+              "AIAttribution",
+              "API",
+              "AccountInspection",
+              "AccountingSubledgerGrowthEdition",
+              "AccountingSubledgerStarterEdition",
+              "AccountingSubledgerUser",
+              "AdmissionsConnectUser",
+              "AdvisorLinkFeature",
+              "AdvisorLinkPathwaysFeature",
+              "AllUserIdServiceAccess",
+              "AnalyticsAdminPerms",
+              "AnalyticsAppEmbedded",
+              "ApexGuruCodeAnalyzer",
+              "ArcGraphCommunity",
+              "Assessments",
+              "AssociationEngine",
+              "AuthorApex",
+              "B2BCommerce",
+              "B2BLoyaltyManagement",
+              "B2CCommerceGMV",
+              "B2CLoyaltyManagement",
+              "B2CLoyaltyManagementPlus",
+              "BYOCCaaS",
+              "BYOOTT",
+              "BatchManagement",
+              "BenefitManagement",
+              "BigObjectsBulkAPI",
+              "BillingAdvanced",
+              "Briefcase",
+              "BudgetManagement",
+              "BusinessRulesEngine",
+              "CGAnalytics",
+              "CMSMaxContType",
+              "CMSMaxNodesPerContType",
+              "CMSUnlimitedUse",
+              "CPQ",
+              "CacheOnlyKeys",
+              "CampaignInfluence2",
+              "CascadeDelete",
+              "CaseClassification",
+              "CaseWrapUp",
+              "ChangeDataCapture",
+              "Chatbot",
+              "ChatterEmailFooterLogo",
+              "ChatterEmailFooterText",
+              "ChatterEmailSenderName",
+              "CloneApplication",
+              "Communities",
+              "CompareReportsOrgPerm",
+              "ConAppPluginExecuteAsUser",
+              "ConnectedAppCustomNotifSubscription",
+              "ConnectedAppToolingAPI",
+              "ConsentEventStream",
+              "ContactsToMultipleAccounts",
+              "ContractApprovals",
+              "ContractManagement",
+              "ContractMgmtInd",
+              "CoreCpq",
+              "CustomFieldDataTranslation",
+              "CustomNotificationType",
+              "CustomerDataPlatform",
+              "CustomerDataPlatformLite",
+              "CustomerExperienceAnalytics",
+              "DSARPortability",
+              "DataComDnbAccounts",
+              "DataComFullClean",
+              "DataMaskUser",
+              "DataProcessingEngine",
+              "DebugApex",
+              "DecisionTable",
+              "DefaultWorkflowUser",
+              "DeferSharingCalc",
+              "DevOpsCenter",
+              "DevelopmentWave",
+              "DeviceTrackingEnabled",
+              "DisableManageIdConfAPI",
+              "DisclosureFramework",
+              "Division",
+              "DocGen",
+              "DocGenDesigner",
+              "DocGenInd",
+              "DocumentChecklist",
+              "DocumentReaderPageLimit",
+              "DurableClassicStreamingAPI",
+              "DurableGenericStreamingAPI",
+              "DynamicClientCreationLimit",
+              "EAOutputConnectors",
+              "EASyncOut",
+              "EAndUDigitalSales",
+              "EAndUSelfServicePortal",
+              "ERMAnalytics",
+              "EdPredictionM3Threshold",
+              "EdPredictionTimeout",
+              "EdPredictionTimeoutBulk",
+              "EdPredictionTimeoutByomBulk",
+              "Einstein1AIPlatform",
+              "EinsteinAnalyticsPlus",
+              "EinsteinArticleRecommendations",
+              "EinsteinBuilderFree",
+              "EinsteinDocReader",
+              "EinsteinRecommendationBuilder",
+              "EinsteinRecommendationBuilderMetadata",
+              "EinsteinSearch",
+              "EinsteinVisits",
+              "EinsteinVisitsED",
+              "EmbeddedLoginForIE",
+              "EnableManageIdConfUI",
+              "EnablePRM",
+              "EnableSetPasswordInApi",
+              "Enablement",
+              "EnergyAndUtilitiesCloud",
+              "Entitlements",
+              "EntityTranslation",
+              "EventLogFile",
+              "ExcludeSAMLSessionIndex",
+              "Explainability",
+              "ExpressionSetMaxExecPerHour",
+              "ExternalIdentityLogin",
+              "FSCAlertFramework",
+              "FSCServiceProcess",
+              "FieldAuditTrail",
+              "FieldServiceMobileExtension",
+              "FinanceLogging",
+              "FinancialServicesInsuranceUser",
+              "FlowSites",
+              "ForceComPlatform",
+              "ForecastEnableCustomField",
+              "Functions",
+              "Fundraising",
+              "GenericStreaming",
+              "Grantmaking",
+              "GuidanceHubAllowed",
+              "HLSAnalytics",
+              "HealthCloudAddOn",
+              "HealthCloudEOLOverride",
+              "HealthCloudForCmty",
+              "HealthCloudMedicationReconciliation",
+              "HealthCloudPNMAddOn",
+              "HealthCloudUser",
+              "HighVelocitySales",
+              "HighVolumePlatformEventAddOn",
+              "IdentityProvisioningFeatures",
+              "IgnoreQueryParamWhitelist",
+              "IndustriesActionPlan",
+              "IndustriesBranchManagement",
+              "IndustriesCompliantDataSharing",
+              "IndustriesManufacturingCmty",
+              "IndustriesMfgAccountForecast",
+              "IndustriesMfgAdvncdAccFrcs",
+              "IndustriesMfgPartnerVisitMgmt",
+              "IndustriesMfgProgram",
+              "IndustriesMfgRebates",
+              "IndustriesMfgTargets",
+              "InsightsPlatform",
+              "InsuranceCalculationUser",
+              "InsuranceClaimMgmt",
+              "InsurancePolicyAdmin",
+              "IntelligentDocumentReader",
+              "Interaction",
+              "InvestigativeCaseManagement",
+              "InvoiceManagement",
+              "IoT",
+              "JigsawUser",
+              "Knowledge",
+              "LegacyLiveAgentRouting",
+              "LightningSalesConsole",
+              "LightningScheduler",
+              "LightningServiceConsole",
+              "LiveAgent",
+              "LiveMessage",
+              "LongLayoutSectionTitles",
+              "LoyaltyAnalytics",
+              "LoyaltyEngine",
+              "LoyaltyManagementStarter",
+              "Macros",
+              "MarketingCloud",
+              "MarketingUser",
+              "MaterialityAssessment",
+              "MaxAudTypeCriterionPerAud",
+              "MaxWishlistsItemsPerWishlist",
+              "MaxWishlistsPerStoreAccUsr",
+              "MinKeyRotationInterval",
+              "MobileSecurity",
+              "MobileVoiceAndLLM",
+              "MultiCurrency",
+              "MultiLevelMasterDetail",
+              "MutualAuthentication",
+              "MyTrailhead",
+              "NonprofitCloudCaseManagementUser",
+              "ObjectLinking",
+              "OmnistudioDesigner",
+              "OmnistudioMetadata",
+              "OmnistudioRuntime",
+              "OrderManagement",
+              "OrderSaveBehaviorBoth",
+              "OrderSaveLogicEnabled",
+              "OutboundMessageHTTPSession",
+              "OutcomeManagement",
+              "PSSAssetManagement",
+              "PardotScFeaturesCampaignInfluence",
+              "PersonAccounts",
+              "PipelineInspection",
+              "PlatformCache",
+              "PlatformEncryption",
+              "ProcessBuilder",
+              "ProductCatalogManagementAddOn",
+              "ProductCatalogManagementPCAddOn",
+              "ProductCatalogManagementViewerAddOn",
+              "ProductsAndSchedules",
+              "ProgramManagement",
+              "ProviderFreePlatformCache",
+              "ProviderManagement",
+              "PublicSectorAccess",
+              "PublicSectorApplicationUsageCreditsAddOn",
+              "PublicSectorSiteTemplate",
+              "RateManagement",
+              "RecordTypes",
+              "RefreshOnInvalidSession",
+              "RevSubscriptionManagement",
+              "S1ClientComponentCacheSize",
+              "SAML20SingleLogout",
+              "SCIMProtocol",
+              "SFDOInsightsDataIntegrityUser",
+              "SalesCloudEinstein",
+              "SalesUser",
+              "SalesforceContentUser",
+              "SalesforceFeedbackManagementStarter",
+              "SalesforceHostedMCP",
+              "SalesforceIdentityForCommunities",
+              "SalesforcePricing",
+              "ScvMultipartyAndConsult",
+              "SecurityEventEnabled",
+              "SentimentInsightsFeature",
+              "ServiceCatalog",
+              "ServiceCloud",
+              "ServiceCloudVoicePartnerTelephony",
+              "ServiceUser",
+              "SessionIdInLogEnabled",
+              "SharedActivities",
+              "Sites",
+              "SocialCustomerService",
+              "StateAndCountryPicklist",
+              "StreamingAPI",
+              "SurveyAdvancedFeatures",
+              "SustainabilityApp",
+              "SustainabilityCloud",
+              "TCRMforSustainability",
+              "TalentRecruitmentManagement",
+              "TimeSheetTemplateSettings",
+              "TimelineConditionsLimit",
+              "TimelineEventLimit",
+              "TimelineRecordTypeLimit",
+              "TransactionFinalizers",
+              "UsageManagement",
+              "WaveMaxCurrency",
+              "WavePlatform",
+              "WorkThanksPref",
+              "Workflow",
+              "WorkflowFlowActionFeature",
+              "WorkplaceCommandCenterUser"
+            ],
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "template": {
+      "description": "The template id for the scratch org shape. (Pilot)",
+      "title": "Template ID",
+      "type": "string"
+    },
+    "settings": {
+      "description": "Settings for the scratch org.",
+      "type": "object",
+      "properties": {
+        "accountingSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_accountingsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "accountInsightsSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_accountinsightssettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "accountIntelligenceSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_accountintelligencesettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "accountPlanSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_accountplansettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "accountSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_accountsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "actionsSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_actionssettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "activitiesSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_activitiessettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "addressSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_addresssettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "agentforceForDevelopersSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_agentforcefordeveloperssettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "agentPlatformSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_agentplatformsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "aIReplyRecommendationsSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_aireplyrecommendationssettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "analyticsSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_analyticssettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "apexSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_apexsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "appAnalyticsSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_appanalyticssettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "appExperienceSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_appexperiencesettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "associationEngineSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_associationenginesettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "automatedContactsSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_automatedcontactssettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "botSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_botsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "branchManagementSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_branchmanagementsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "businessHoursSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_businesshourssettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "campaignSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_campaignsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "caseSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_casesettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "chatterAnswersSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_chatteranswerssettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "chatterEmailsMDSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_chatteremailmdsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "chatterSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_chattersettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "codeBuilderSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_codebuildersettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "collectionsDashboardSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_collectionsdashboardsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "communitiesSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_communitiessettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "companySettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_companyprofilesettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "connectedAppSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_connectedappsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "contentSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_contentsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "contractSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_contractsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "conversationalIntelligenceSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_conversationalintelligencesettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "conversationChannelDefinition": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_conversationchanneldefinition.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "currencySettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_currencysettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "customAddressFieldSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_customaddressfieldsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "dataDotComSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_datadotcomsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "dataImportManagementSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_dataimportmanagementsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "deploymentSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_deploymentsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "devHubSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_devhubsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "documentGenerationSetting": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_documentgenerationsetting.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "dynamicFormsSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_dynamicformssettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "eACSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_eacsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "einsteinAgentSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_einsteinagentsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "einsteinAISettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_einsteinaisettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "einsteinGptSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_einsteingptsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "emailAdministrationSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_emailadministrationsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "emailIntegrationSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_emailintegrationsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "emailTemplateSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_emailtemplatesettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "employeeUserSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_employeeusersettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "encryptionKeySettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_encryptionkeysettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "enhancedNotesSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_enhancednotessettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "entitlementSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_entitlementsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "eventSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_eventsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "experienceBundleSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_experiencebundlesettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "externalClientAppSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_externalclientappsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "externalServicesSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_externalservicessettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "fieldServiceSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_fieldservicesettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "filesConnectSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_filesconnectsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "fileUploadAndDownloadSecuritySettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_fileuploadanddownloadsecuritysettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "flowSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_flowsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "forecastingObjectListSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_forecastingobjectlistsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "forecastingSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_forecastingsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "highVelocitySalesSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_highvelocitysalessettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "ideasSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_ideassettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "identityProviderSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_identityprovidersettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "iframeWhiteListUrlSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_iframewhitelisturlsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "incidentMgmtSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_incidentmgmtsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "industriesEinsteinFeatureSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/industrieseinsteinfeaturesettings_metadata_api.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "industriesLoyaltySettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/industriesloyaltysettings_metadata_api.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "industriesSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_industriessettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "interestTaggingSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_interesttaggingsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "inventorySettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_inventorysettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "invLatePymntRiskCalcSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_invlatepymntriskcalcsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "invocableActionSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_invocableactionsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "ioTSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_iotsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "knowledgeSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_knowledgesettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "languageSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_languagesettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "leadConfigSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_leadconfigsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "leadConvertSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_leadconvertsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "lightningExperienceSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_lightningexperiencesettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "liveAgentSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_liveagentsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "liveMessageSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_livemessagesettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "macroSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_macrosettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "mailMergeSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_mailmergesettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "mapAndLocationSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_mapandlocationsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "meetingsSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_meetingssettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "mfgServiceConsoleSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/mfg_mfgserviceconsolesettings_metadata_api.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "mobileSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_mobilesettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "myDomainSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_mydomainsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "nameSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_namesettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "notificationsSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_notificationssettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "oauthOidcSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_oauthoidcsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "objectHierarchyRelationship": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/mfg_objecthierarchyrelationshipsettings_metadata_api.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "objectLinkingSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_objectlinkingsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "omniChannelSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_omnichannelsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "opportunityInsightsSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_opportunityinsightssettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "opportunityScoreSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_opportunityscoresettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "opportunitySettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_opportunityssettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "orderManagementSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_ordermanagementsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "orderSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_ordersettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "orgPreferenceSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_orgpreferencesettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "orgSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_orgsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "pardotEinsteinSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_pardoteinsteinsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "pardotSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_pardotsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "partyDataModelSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_partydatamodelsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "pathAssistantSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_pathassistantsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "paymentsSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_paymentssettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "picklistSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_picklistsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "platformEncryptionSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_platformencryptionsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "platformEventSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_platformeventsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "predictionBuilderSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_predictionbuildersettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "privacySettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_privacysettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "processFlowMigration": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_processflowmigration.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "productSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_productsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "quoteSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_quotessettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "realTimeEventSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_realtimeeventsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "recordPageSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_recordpagesettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "retailExecutionSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/metadata_api_retexset.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "salesAgreementSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/mfg_salesagreementsettings_metadata_api.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "sandboxSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_sandboxsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "schemaSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_schemasettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "searchSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_searchsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "securitySettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_securitysettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "serviceCloudVoiceSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_servicecloudvoicesettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "serviceSetupAssistantSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_servicesetupassistantsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "sharingSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_sharingsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "siteSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_sitesettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "socialCustomerServiceSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_socialcustomerservicesettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "socialProfileSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_socialprofilesettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "sourceTrackingSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_sourcetrackingsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "subscriptionManagementSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_subscriptionmanagementsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "surveySettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_surveysettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "territory2Settings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_territory2settings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "trailheadSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_trailheadsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "trialOrgSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_trialorgsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "userEngagementSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_userengagementsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "userInterfaceSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_userinterfacesettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "userManagementSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_usermanagementsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "voiceSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_voicesettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "warrantyLifeCycleMgmtSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_mfg_warrantylifecyclemgmtsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "workDotComSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_WorkDotComSettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "workforceEngagementSettings": {
+          "description": "For more details go to https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_workforceengagementsettings.htm",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        }
+      },
+      "additionalProperties": {}
+    },
+    "release": {
+      "description": "Same Salesforce release as the Dev Hub org. Options are preview or previous. Can use only during Salesforce release transition periods.",
+      "type": "string",
+      "enum": [
+        "preview",
+        "previous"
+      ]
+    }
+  },
+  "required": [
+    "edition"
+  ],
+  "additionalProperties": {},
+  "$id": "https://schemas.salesforce.com/project-scratch-def.json",
+  "title": "Scratch Org Definition Configuration",
+  "description": "The scratch org definition file contains the configuration values that determine the shape of the scratch org."
+}

--- a/packages/salesforcedx-vscode-core/resources/schemas/sfdx-project.schema.json
+++ b/packages/salesforcedx-vscode-core/resources/schemas/sfdx-project.schema.json
@@ -1,0 +1,909 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "The name of your Salesforce project.",
+      "type": "string"
+    },
+    "packageDirectories": {
+      "title": "Package Directories",
+      "description": "Package directories indicate which directories to target when syncing source to and from the scratch org. These directories can contain source from your managed package, unmanaged package, or unpackaged source, for example, ant tool or change set.",
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "default": {
+                "description": "If you have specified more than one path, include this parameter for the default path to indicate which is the default package directory.",
+                "default": true,
+                "type": "boolean"
+              },
+              "path": {
+                "title": "Path",
+                "description": "If you don't specify a path, the Salesforce CLI uses a placeholder when you create a package.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "path"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "default": {
+                "description": "If you have specified more than one path, include this parameter for the default path to indicate which is the default package directory.",
+                "default": true,
+                "type": "boolean"
+              },
+              "path": {
+                "title": "Path",
+                "description": "If you don't specify a path, the Salesforce CLI uses a placeholder when you create a package.",
+                "type": "string"
+              },
+              "ancestorId": {
+                "title": "Ancestor ID",
+                "description": "The ancestor that's the immediate parent of the version that you're creating. The package version ID to supply starts with '05i'.",
+                "type": "string"
+              },
+              "ancestorVersion": {
+                "title": "Ancestor Version",
+                "description": "The ancestor that's the immediate parent of the version that you're creating. The ancestor version uses the format major.minor.patch.build.",
+                "type": "string"
+              },
+              "apexTestAccess": {
+                "description": "Additional access that should be granted to the user when running package Apex tests",
+                "type": "object",
+                "properties": {
+                  "permissionSets": {
+                    "title": "Permission Sets",
+                    "description": "The list of permission sets to enable while running Apex tests",
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "permissionSetLicenses": {
+                    "title": "Permission Set Licenses",
+                    "description": "The list of permission sets licenses to enable while running Apex tests",
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "permissionSets",
+                  "permissionSetLicenses"
+                ],
+                "additionalProperties": false
+              },
+              "definitionFile": {
+                "title": "Definition File",
+                "description": "Reference an external .json file to specify the features and org preferences required for the metadata of your package, such as the scratch org definition.",
+                "type": "string"
+              },
+              "dependencies": {
+                "description": "To specify dependencies for 2GP within the same Dev Hub, use either the package version alias or a combination of the package name and the version number.",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "package": {
+                      "type": "string"
+                    },
+                    "versionNumber": {
+                      "type": "string"
+                    },
+                    "branch": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "package"
+                  ],
+                  "additionalProperties": {}
+                }
+              },
+              "includeProfileUserLicenses": {
+                "title": "Include Profile User Licenses",
+                "description": "Whether to include <userLicense> elements in profile metadata. Defaults to false.",
+                "default": false,
+                "type": "boolean"
+              },
+              "package": {
+                "title": "Package Identifier",
+                "description": "The package name you specified when creating the package.",
+                "type": "string"
+              },
+              "packageMetadataAccess": {
+                "title": "Package Metadata Access",
+                "description": "Additional access that should be granted to the user while deploying package metadata, available in Salesforce API version 61.0 and above",
+                "type": "object",
+                "properties": {
+                  "permissionSets": {
+                    "title": "Permission Sets",
+                    "description": "The list of permission sets to enable while deploying package metadata",
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ]
+                  },
+                  "permissionSetLicenses": {
+                    "title": "Permission Set Licenses",
+                    "description": "The list of permission set licenses to enable while deploying package metadata",
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "permissionSets",
+                  "permissionSetLicenses"
+                ],
+                "additionalProperties": false
+              },
+              "postInstallScript": {
+                "title": "Post Install Script",
+                "description": "The post install script.",
+                "type": "string"
+              },
+              "postInstallUrl": {
+                "title": "Post Install Url",
+                "description": "The post install url.",
+                "type": "string"
+              },
+              "releaseNotesUrl": {
+                "title": "Release Notes Url",
+                "description": "The release notes url.",
+                "type": "string"
+              },
+              "scopeProfiles": {
+                "title": "Scope Profiles",
+                "description": "Determines whether to include profile settings from only the directory being packaged (true), or whether to include profile settings from all package directories (false). If not specified, the default is false.",
+                "default": false,
+                "type": "boolean"
+              },
+              "uninstallScript": {
+                "title": "Uninstall Script",
+                "description": "The uninstall script.",
+                "type": "string"
+              },
+              "calculateTransitiveDependencies": {
+                "title": "Calculate Transitive Dependencies",
+                "description": "Set to true if only specifing direct package dependencies and the transitive (i.e., indirect) dependencies should be calculated by Salesforce.",
+                "default": false,
+                "type": "boolean"
+              },
+              "versionDescription": {
+                "title": "Version Description",
+                "description": "Human readable version information, format not specified.",
+                "type": "string"
+              },
+              "versionName": {
+                "title": "Version Name",
+                "description": "If not specified, the CLI uses versionNumber as the version name.",
+                "type": "string"
+              },
+              "versionNumber": {
+                "title": "Version Number",
+                "description": "Version numbers are formatted as major.minor.patch.build. For example, 1.2.1.8. Required when package is specified.",
+                "type": "string"
+              },
+              "unpackagedMetadata": {
+                "title": "Unpackaged Metadata",
+                "description": "Metadata not meant to be packaged, but deployed when testing packaged metadata",
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "title": "Path",
+                    "description": "The path name of the package directory containing the unpackaged metadata",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path"
+                ],
+                "additionalProperties": false
+              },
+              "seedMetadata": {
+                "title": "Seed Metadata",
+                "description": "Metadata not meant to be packaged, but deployed before deploying packaged metadata",
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "title": "Path",
+                    "description": "The path name of the package directory containing the seed metadata",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path"
+                ],
+                "additionalProperties": false
+              },
+              "functions": {
+                "description": "@deprecated",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "path",
+              "package",
+              "versionNumber"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "namespace": {
+      "description": "A namespace is an alphanumeric identifier that distinguishes your package and its contents from other packages in your customer's org. For steps on how to register a namespace and link it to your Dev Hub org, see Create and Register Your Namespace for Second-Generation Managed Packages on developer.salesforce.com. If you're creating an unlocked package, you can create it without a namespace.",
+      "type": "string"
+    },
+    "sourceApiVersion": {
+      "title": "Source API Version",
+      "description": "The API version that the source is compatible with. By default it matches the API version.",
+      "default": "48.0",
+      "type": "string"
+    },
+    "sfdcLoginUrl": {
+      "title": "SFDC Login URL",
+      "description": "The login URL that the force:auth commands use. If not specified, the default is login.salesforce.com. Override the default value if you want users to authorize to a specific Salesforce instance. For example, if you want to authorize into a sandbox org, set this parameter to test.salesforce.com.",
+      "type": "string"
+    },
+    "signupTargetLoginUrl": {
+      "description": "The url that is used when creating new scratch orgs. This is typically only used for testing prerelease environments.",
+      "type": "string"
+    },
+    "oauthLocalPort": {
+      "description": "By default, the OAuth port is 1717. However, change this port if this port is already in use, and you plan to create a connected app in your Dev Hub org to support JWT-based authorization.",
+      "default": 1717,
+      "type": "number"
+    },
+    "plugins": {
+      "title": "CLI Plugins custom settings",
+      "description": "Salesforce CLI plugin configurations used with this project.",
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {}
+    },
+    "packageAliases": {
+      "title": "Aliases for packaging ids",
+      "description": "The Salesforce CLI updates this file with the aliases when you create a package or package version. You can also manually update this section for existing packages or package versions. You can use the alias instead of the cryptic package ID when running CLI force:package commands.",
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "packageBundles": {
+      "title": "Package Bundles",
+      "description": "Package bundle entries for managing package bundles.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "Bundle Name",
+            "description": "The name of the bundle.",
+            "type": "string"
+          },
+          "versionName": {
+            "title": "Version Name",
+            "description": "Human readable name for the version.",
+            "type": "string"
+          },
+          "versionNumber": {
+            "title": "Version Number",
+            "description": "The version number in the format major.minor (e.g., 1.0).",
+            "type": "string",
+            "pattern": "^\\d+\\.\\d+$"
+          },
+          "versionDescription": {
+            "title": "Version Description",
+            "description": "Human readable version information, format not specified.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "versionName",
+          "versionNumber"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "packageBundleAliases": {
+      "title": "Package Bundle Aliases",
+      "description": "Aliases for package bundles.",
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "registryPresets": {
+      "title": "Custom predefined presets for decomposing metadata types",
+      "description": "@deprecated use `sourceBehaviorOptions`. Filenames from https://github.com/forcedotcom/source-deploy-retrieve/tree/main/src/registry/presets",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "sourceBehaviorOptions": {
+      "title": "Custom predefined presets for decomposing metadata types",
+      "description": "Filenames from https://github.com/forcedotcom/source-deploy-retrieve/tree/main/src/registry/presets",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "registryCustomizations": {
+      "type": "object",
+      "properties": {
+        "types": {
+          "$ref": "#/definitions/__schema0"
+        },
+        "suffixes": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "strictDirectoryNames": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "childTypes": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "types",
+        "suffixes",
+        "strictDirectoryNames",
+        "childTypes"
+      ],
+      "additionalProperties": false
+    },
+    "replacements": {
+      "title": "Replacements for metadata that are executed during deployments",
+      "description": "The Salesforce CLI will conditionally replace portions of your metadata during a deployment",
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "replaceWhenEnv": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "env": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "env",
+                    "value"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "filename": {
+                "type": "string"
+              },
+              "stringToReplace": {
+                "type": "string"
+              },
+              "replaceWithFile": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "filename",
+              "stringToReplace",
+              "replaceWithFile"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "replaceWhenEnv": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "env": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "env",
+                    "value"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "filename": {
+                "type": "string"
+              },
+              "stringToReplace": {
+                "type": "string"
+              },
+              "replaceWithEnv": {
+                "type": "string"
+              },
+              "allowUnsetEnvVariable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "filename",
+              "stringToReplace",
+              "replaceWithEnv"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "replaceWhenEnv": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "env": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "env",
+                    "value"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "filename": {
+                "type": "string"
+              },
+              "regexToReplace": {
+                "type": "string"
+              },
+              "replaceWithFile": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "filename",
+              "regexToReplace",
+              "replaceWithFile"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "replaceWhenEnv": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "env": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "env",
+                    "value"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "filename": {
+                "type": "string"
+              },
+              "regexToReplace": {
+                "type": "string"
+              },
+              "replaceWithEnv": {
+                "type": "string"
+              },
+              "allowUnsetEnvVariable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "filename",
+              "regexToReplace",
+              "replaceWithEnv"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "replaceWhenEnv": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "env": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "env",
+                    "value"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "glob": {
+                "type": "string"
+              },
+              "stringToReplace": {
+                "type": "string"
+              },
+              "replaceWithFile": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "glob",
+              "stringToReplace",
+              "replaceWithFile"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "replaceWhenEnv": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "env": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "env",
+                    "value"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "glob": {
+                "type": "string"
+              },
+              "stringToReplace": {
+                "type": "string"
+              },
+              "replaceWithEnv": {
+                "type": "string"
+              },
+              "allowUnsetEnvVariable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "glob",
+              "stringToReplace",
+              "replaceWithEnv"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "replaceWhenEnv": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "env": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "env",
+                    "value"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "glob": {
+                "type": "string"
+              },
+              "regexToReplace": {
+                "type": "string"
+              },
+              "replaceWithFile": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "glob",
+              "regexToReplace",
+              "replaceWithFile"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "replaceWhenEnv": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "env": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "env",
+                    "value"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "glob": {
+                "type": "string"
+              },
+              "regexToReplace": {
+                "type": "string"
+              },
+              "replaceWithEnv": {
+                "type": "string"
+              },
+              "allowUnsetEnvVariable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "glob",
+              "regexToReplace",
+              "replaceWithEnv"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "pushPackageDirectoriesSequentially": {
+      "description": "@deprecated only works with deprecated commands. See https://github.com/forcedotcom/cli/discussions/2402",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "packageDirectories"
+  ],
+  "additionalProperties": false,
+  "$id": "http://schemas.salesforce.com/sfdx-project.json",
+  "title": "Salesforce DX Project File",
+  "definitions": {
+    "__schema0": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "directoryName": {
+            "type": "string"
+          },
+          "suffix": {
+            "type": "string"
+          },
+          "strictDirectoryName": {
+            "type": "boolean"
+          },
+          "ignoreParsedFullName": {
+            "type": "boolean"
+          },
+          "folderContentType": {
+            "type": "string"
+          },
+          "folderType": {
+            "type": "string"
+          },
+          "xmlElementName": {
+            "type": "string"
+          },
+          "uniqueIdElement": {
+            "type": "string"
+          },
+          "isAddressable": {
+            "type": "boolean"
+          },
+          "unaddressableWithoutParent": {
+            "type": "boolean"
+          },
+          "supportsWildcardAndName": {
+            "type": "boolean"
+          },
+          "supportsPartialDelete": {
+            "type": "boolean"
+          },
+          "aliasFor": {
+            "type": "string"
+          },
+          "children": {
+            "type": "object",
+            "properties": {
+              "types": {
+                "$ref": "#/definitions/__schema0"
+              },
+              "suffixes": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "directories": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "types",
+              "suffixes"
+            ],
+            "additionalProperties": false
+          },
+          "strategies": {
+            "type": "object",
+            "properties": {
+              "adapter": {
+                "type": "string",
+                "enum": [
+                  "mixedContent",
+                  "matchingContentFile",
+                  "decomposed",
+                  "bundle",
+                  "default"
+                ]
+              },
+              "transformer": {
+                "type": "string",
+                "enum": [
+                  "decomposed",
+                  "staticResource",
+                  "standard"
+                ]
+              },
+              "decomposition": {
+                "type": "string",
+                "enum": [
+                  "topLevel",
+                  "folderPerType"
+                ]
+              }
+            },
+            "required": [
+              "adapter"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "directoryName"
+        ],
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/packages/salesforcedx-vscode-core/src/constants.ts
+++ b/packages/salesforcedx-vscode-core/src/constants.ts
@@ -6,7 +6,6 @@
  */
 
 export const SFDX_PROJECT_FILE = 'sfdx-project.json';
-export const STATUS_BAR_MSG_TIMEOUT_MS = 5000;
 export const ENV_SF_DISABLE_TELEMETRY = 'SF_DISABLE_TELEMETRY';
 export const PKG_ID_PREFIX = '04t';
 


### PR DESCRIPTION
### What does this PR do?
use the new schemas published in sfdx-core
- copy them into extension resources folder instead of referring to node-modules, removing that whole schemas repo and its node_modules from our vsix!

other:
sfdx-core uses zod4 now, so we bump our minimal zod usage to 4 (see cursor plan for details)
bumping sfdx-core for a jswonwebtoken security fix keeps us from getting pinged about that vuln

### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @W-20329918@
