### PR TITLE
[W-20436630] fix: adjust esr record xml for ga

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -468,7 +468,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1779,7 +1778,6 @@
       "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.92.1.tgz",
       "integrity": "sha512-XXWCBVwyhaKZISN7aM1fv/3fWDGyxr84ObywnUrL8aHvJLoIeskWFAP/fqw3c5MFCrJ3ZV97RWLbv6JiBQugdg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "find-my-way-ts": "^0.1.6",
         "msgpackr": "^1.11.4",
@@ -3833,7 +3831,6 @@
       "resolved": "https://registry.npmjs.org/@lwc/template-compiler/-/template-compiler-8.16.0.tgz",
       "integrity": "sha512-mykA5/6cyjIOw6ADLWtt/sle7jzNsEF0ener+FsscbiMLQSZr9vt8sGO3F1+RKZajqySr1zZxlv7tgS2toIYGQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lwc/errors": "8.16.0",
         "@lwc/shared": "8.16.0",
@@ -4368,7 +4365,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -5020,7 +5016,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.37.0.tgz",
       "integrity": "sha512-JD6DerIKdJGmRp4jQyX5FlrQjA4tjOw1cvfsPAZXfOOEErMUHjPcPSICS+6WnM0nB0efSFARh0KAZss+bvExOA==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -5330,7 +5325,6 @@
       "integrity": "sha512-Mfr7rVcFB+J16VzLbbqLF9Yo1W7G2bgjkVv0vPUrlkz1dgYdAjZpaQpjs6dVlRO5Uopt11loYu4SS+wnxPopMw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "clipboardy": "^4.0.0",
         "clone-deep": "^4.0.1",
@@ -10024,7 +10018,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10115,7 +10108,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11268,7 +11260,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -12932,7 +12923,6 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -14314,7 +14304,6 @@
       "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
       "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "fast-check": "^3.23.1"
@@ -14648,7 +14637,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -14825,7 +14813,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -19195,7 +19182,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -20458,7 +20444,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -22149,7 +22134,6 @@
       "integrity": "sha512-5EK+Cty6KheMS/YLPPMJC64g5V61gIR25KsRItHw6x4hEKT6Njp1n9LOlH4gpevuwMVS66SXaBBpg+RWZkza4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "browser-stdout": "^1.3.1",
         "chokidar": "^4.0.1",
@@ -25066,7 +25050,6 @@
       "version": "4.0.2",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -28757,7 +28740,6 @@
         }
       ],
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@bazel/runfiles": "^6.3.1",
         "jszip": "^3.10.1",
@@ -31006,8 +30988,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",
@@ -31189,7 +31170,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -31258,7 +31238,6 @@
       "integrity": "sha512-r1XG74QgShUgXph1BYseJ+KZd17bKQib/yF3SR+demvytiRXrwd12Blnz5eYGm8tXaeRdd4x88MlfwldHoudGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.42.0",
         "@typescript-eslint/types": "8.42.0",

--- a/packages/salesforcedx-vscode-apex-oas/src/oas/externalServiceRegistrationManager.ts
+++ b/packages/salesforcedx-vscode-apex-oas/src/oas/externalServiceRegistrationManager.ts
@@ -234,11 +234,11 @@ export class ExternalServiceRegistrationManager {
         schemaType: 'OpenApi3',
         schemaUploadFileExtension: 'yaml',
         schemaUploadFileName: `${className.toLowerCase()}_openapi`,
-        status: 'Complete',
+        status: isGa ? undefined : 'Complete',
         operations: isGa ? undefined : operations,
         ...(isGa ? { registrationProviderAsset: className } : { registrationProvider: className }),
         registrationProviderType: this.providerType,
-        namedCredential: 'null'
+        namedCredential: isGa ? undefined : 'null'
       }
     };
   }

--- a/packages/salesforcedx-vscode-apex-oas/test/jest/oas/externalServiceRegistrationManager.test.ts
+++ b/packages/salesforcedx-vscode-apex-oas/test/jest/oas/externalServiceRegistrationManager.test.ts
@@ -348,6 +348,9 @@ describe('ExternalServiceRegistrationManager', () => {
     expect(result.ExternalServiceRegistration).toHaveProperty('label', className);
     expect(result.ExternalServiceRegistration).toHaveProperty('schema', safeOasSpec);
     expect(result.ExternalServiceRegistration).toHaveProperty('operations', operations);
+    // For orgs < 66.0, status should be 'Complete' and namedCredential should be 'null'
+    expect(result.ExternalServiceRegistration).toHaveProperty('status', 'Complete');
+    expect(result.ExternalServiceRegistration).toHaveProperty('namedCredential', 'null');
   });
 
   it('createESRObject should not include operations for orgs >= 66.0', async () => {
@@ -366,6 +369,25 @@ describe('ExternalServiceRegistrationManager', () => {
     expect(result.ExternalServiceRegistration).toHaveProperty('schema', safeOasSpec);
     // For orgs >= 66.0, operations should be undefined (not included in the object)
     expect(result.ExternalServiceRegistration.operations).toBeUndefined();
+    // For orgs >= 66.0, status and namedCredential should be undefined
+    expect(result.ExternalServiceRegistration.status).toBeUndefined();
+    expect(result.ExternalServiceRegistration.namedCredential).toBeUndefined();
+  });
+
+  it('createESRObject should not include status and namedCredential when orgApiVersion is undefined', async () => {
+    const description = 'Test Description';
+    const className = 'TestClass';
+    const safeOasSpec = 'safeOasSpec';
+    const operations: any = [{ active: true, name: 'getPets' }];
+
+    // Test with undefined orgApiVersion - treated as GA (>= 66.0)
+    await esrHandler['initialize'](false, processedOasResult, fullPath);
+    const result = esrHandler.createESRObject(description, className, safeOasSpec, operations);
+
+    expect(result).toHaveProperty('ExternalServiceRegistration');
+    // When orgApiVersion is undefined, status and namedCredential should be undefined
+    expect(result.ExternalServiceRegistration.status).toBeUndefined();
+    expect(result.ExternalServiceRegistration.namedCredential).toBeUndefined();
   });
 
   it('extractInfoProperties', async () => {


### PR DESCRIPTION
# Fix: Adjust ESR Record XML for GA

## Summary
This PR updates the External Service Registration (ESR) XML generation to conditionally include `status` and `namedCredential` fields based on the org API version. For GA orgs (API version >= 66.0 or undefined), these fields are omitted from the XML. For pre-GA orgs (API version < 66.0), these fields are included with their previous values.

## Changes
- **Modified** `externalServiceRegistrationManager.ts`:
  - Updated `createESRObject` method to conditionally set `status` and `namedCredential` based on `isGa` flag
  - For GA orgs: `status` and `namedCredential` are set to `undefined` (omitted from XML)
  - For pre-GA orgs: `status` is set to `'Complete'` and `namedCredential` is set to `'null'`

- **Added** unit tests in `externalServiceRegistrationManager.test.ts`:
  - Test for orgs < 66.0: Verifies `status` is `'Complete'` and `namedCredential` is `'null'`
  - Test for orgs >= 66.0: Verifies `status` and `namedCredential` are `undefined`
  - Test for undefined `orgApiVersion`: Verifies `status` and `namedCredential` are `undefined` (treated as GA)

## Technical Details
The change aligns the ESR XML structure with the GA requirements where:
- `status` field is no longer needed for GA orgs
- `namedCredential` field is no longer needed for GA orgs

The logic uses the existing `isGa` flag which is `true` when `orgApiVersion >= 66.0` or `orgApiVersion === undefined`.

## Testing
- All existing tests pass
- New tests added to verify the conditional behavior for both GA and pre-GA scenarios
- Tests verify that the fields are correctly omitted or included based on org API version

## Files Changed
- `packages/salesforcedx-vscode-apex-oas/src/oas/externalServiceRegistrationManager.ts`
- `packages/salesforcedx-vscode-apex-oas/test/jest/oas/externalServiceRegistrationManager.test.ts`
- `package-lock.json` (dependency updates)
@W-20436630@