### PR TITLE
[W-20175122] feat: add new apex testing extension to extension packs

### DIFF
--- a/packages/salesforcedx-vscode-expanded/package.json
+++ b/packages/salesforcedx-vscode-expanded/package.json
@@ -45,6 +45,7 @@
   ],
   "extensionPack": [
     "salesforce.salesforcedx-vscode-apex",
+    "salesforce.salesforcedx-vscode-apex-testing",
     "salesforce.salesforcedx-vscode-apex-oas",
     "salesforce.salesforcedx-vscode-apex-replay-debugger",
     "salesforce.salesforcedx-einstein-gpt",

--- a/packages/salesforcedx-vscode/package.json
+++ b/packages/salesforcedx-vscode/package.json
@@ -45,6 +45,7 @@
   ],
   "extensionPack": [
     "salesforce.salesforcedx-vscode-apex",
+    "salesforce.salesforcedx-vscode-apex-testing",
     "salesforce.salesforcedx-vscode-apex-oas",
     "salesforce.salesforcedx-vscode-apex-replay-debugger",
     "salesforce.salesforcedx-einstein-gpt",


### PR DESCRIPTION
### What does this PR do?
This pull request adds the `salesforce.salesforcedx-vscode-apex-testing` extension to the extension packs in both `salesforcedx-vscode-expanded` and `salesforcedx-vscode`. This ensures that users of these extension packs will automatically get the Apex Testing extension, improving support for Apex test development and execution.

Extension pack updates:

* Added `salesforce.salesforcedx-vscode-apex-testing` to the `extensionPack` array in `packages/salesforcedx-vscode-expanded/package.json`, so it is included when installing the expanded Salesforce DX extension pack.
* Added `salesforce.salesforcedx-vscode-apex-testing` to the `extensionPack` array in `packages/salesforcedx-vscode/package.json`, so it is included when installing the core Salesforce DX extension pack.

### What issues does this PR fix or reference?
#6705, @W-20175122@
