### PR TITLE
[W-20592203] fix: apply code coverage decorations when navigating to Apex files

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/codecoverage/colorizer.ts
+++ b/packages/salesforcedx-vscode-apex/src/codecoverage/colorizer.ts
@@ -73,7 +73,7 @@ export class CodeCoverageHandler {
   public uncoveredLines: Range[] = [];
 
   constructor(private statusBar: StatusBarToggle) {
-    window.onDidChangeActiveTextEditor(async () => await this.onDidChangeActiveTextEditor(), this);
+    window.onDidChangeActiveTextEditor(async (editor) => await this.onDidChangeActiveTextEditor(editor), this);
     void this.onDidChangeActiveTextEditor(window.activeTextEditor);
   }
 


### PR DESCRIPTION
## Fix: Apply code coverage decorations when navigating to Apex files

### Problem
When Apex test results are available with code coverage and the "Highlight Apex Code Coverage" status bar item is enabled, navigating to an Apex class in the editor does not show the highlights until the status bar item is toggled off and on. This happens for each file visited that has code coverage.

### Solution
Fixed the `window.onDidChangeActiveTextEditor` event listener callback in `CodeCoverageHandler` to properly receive and pass the `editor` parameter. Previously, the callback wasn't receiving the editor instance, causing decorations to not be applied automatically when switching files.

### Changes
- Updated `packages/salesforcedx-vscode-apex/src/codecoverage/colorizer.ts` to pass the editor parameter from the event callback to `onDidChangeActiveTextEditor()`

### Testing
- ✅ Compile passed
- ✅ Lint passed
- ✅ Tests passed
- ✅ Bundle passed

Code coverage decorations now appear automatically when navigating to Apex files with coverage data, without requiring manual toggle of the status bar item.

@W-20592203@