### PR TITLE
[W-20920609] fix: authorizing an org without inputting an alias in the input box uses default alias vscodeOrg

### DIFF
--- a/packages/salesforcedx-vscode-org/src/commands/auth/authParamsGatherer.ts
+++ b/packages/salesforcedx-vscode-org/src/commands/auth/authParamsGatherer.ts
@@ -123,14 +123,15 @@ export class AuthParamsGatherer implements ParametersGatherer<AuthParams> {
           prompt: nls.localize('parameter_gatherer_enter_alias_name'),
           placeHolder: DEFAULT_ALIAS
         });
-    // Hitting enter with no alias will default the alias to 'vscodeOrg'
+    // Closing the dialog (ESC/cancel) will cancel the operation
     if (alias === undefined) {
       return { type: 'CANCEL' };
     }
+    // Hitting enter with no alias will default the alias to 'vscodeOrg'
     return {
       type: 'CONTINUE',
       data: {
-        alias: alias ?? DEFAULT_ALIAS,
+        alias: alias || DEFAULT_ALIAS,
         loginUrl: this.instanceUrl ?? PRODUCTION_URL
       }
     };
@@ -145,7 +146,7 @@ export class AccessTokenParamsGatherer implements ParametersGatherer<AccessToken
     }
 
     const alias = await inputAlias();
-    // Hitting enter with no alias will default the alias to 'vscodeOrg'
+    // Closing the dialog (ESC/cancel) will cancel the operation
     if (alias === undefined) {
       return { type: 'CANCEL' };
     }
@@ -154,11 +155,12 @@ export class AccessTokenParamsGatherer implements ParametersGatherer<AccessToken
     if (accessToken === undefined) {
       return { type: 'CANCEL' };
     }
+    // Hitting enter with no alias will default the alias to 'vscodeOrg'
     return {
       type: 'CONTINUE',
       data: {
         accessToken,
-        alias: alias ?? DEFAULT_ALIAS,
+        alias: alias || DEFAULT_ALIAS,
         instanceUrl
       }
     };


### PR DESCRIPTION
### What does this PR do?
When you authorize an org, you are asked to input an alias in the input box.  Supposedly if you leave that box blank, the alias should default to `vscodeOrg`.  This PR fixes a regression where an empty string is used as the alias instead of the default value, hence no alias was set.

### What issues does this PR fix or reference?
@W-20920609@

### Functionality Before
<img width="2032" height="1162" alt="Screenshot 2026-01-16 at 2 41 16 PM" src="https://github.com/user-attachments/assets/16fe6058-3f9b-4fd9-87a9-a630e2780cb3" />

### Functionality After
<img width="2032" height="1162" alt="Screenshot 2026-01-16 at 2 43 14 PM" src="https://github.com/user-attachments/assets/ad42cf74-bf1c-4468-a5d5-974992b0b2fc" />