### PR TITLE
ci: do not validate closed Github issues

### DIFF
--- a/.github/workflows/validateNewIssues.yml
+++ b/.github/workflows/validateNewIssues.yml
@@ -5,7 +5,7 @@
 # For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 #
 
-name: "Validate New Issues"
+name: 'Validate New Issues'
 on:
   issues:
     types: [opened]
@@ -13,7 +13,7 @@ on:
 jobs:
   # Check if the issue is a feature request, and if it is, tag it with 'type:enhancements' (this job is a prerequisite to all the other jobs)
   check-feature-request:
-    if: ${{ !contains(github.event.issue.labels.*.name, 'announcement') && !contains(github.event.issue.labels.*.name, 'missing required information') && !contains(github.event.issue.labels.*.name, 'validated') && !contains(github.event.issue.labels.*.name, 'type:enhancements') && !contains(github.event.issue.labels.*.name, 'feature') && !contains(github.event.issue.labels.*.name, 'type:bug') && !contains(github.event.issue.labels.*.name, 'pending release') }}
+    if: ${{ github.event.issue.state != 'closed' && !contains(github.event.issue.labels.*.name, 'announcement') && !contains(github.event.issue.labels.*.name, 'missing required information') && !contains(github.event.issue.labels.*.name, 'validated') && !contains(github.event.issue.labels.*.name, 'type:enhancements') && !contains(github.event.issue.labels.*.name, 'feature') && !contains(github.event.issue.labels.*.name, 'type:bug') && !contains(github.event.issue.labels.*.name, 'pending release') }}
     outputs:
       is_feature_request: ${{ steps.check_feature_request.outputs.is_feature_request }}
     runs-on: ubuntu-latest
@@ -31,7 +31,7 @@ jobs:
           repo-token: ${{ secrets.IDEE_GH_TOKEN }}
 
   new-issue:
-    if: ${{ !contains(github.event.issue.labels.*.name, 'announcement') && !contains(github.event.issue.labels.*.name, 'missing required information') && !contains(github.event.issue.labels.*.name, 'validated') && !contains(github.event.issue.labels.*.name, 'type:enhancements') && !contains(github.event.issue.labels.*.name, 'feature') && !contains(github.event.issue.labels.*.name, 'type:bug') && !contains(github.event.issue.labels.*.name, 'pending release') && (needs.check-feature-request.outputs.is_feature_request != 'true') }}
+    if: ${{ github.event.issue.state != 'closed' && !contains(github.event.issue.labels.*.name, 'announcement') && !contains(github.event.issue.labels.*.name, 'missing required information') && !contains(github.event.issue.labels.*.name, 'validated') && !contains(github.event.issue.labels.*.name, 'type:enhancements') && !contains(github.event.issue.labels.*.name, 'feature') && !contains(github.event.issue.labels.*.name, 'type:bug') && !contains(github.event.issue.labels.*.name, 'pending release') && (needs.check-feature-request.outputs.is_feature_request != 'true') }}
     needs: [check-feature-request]
     runs-on: ubuntu-latest
     steps:
@@ -52,7 +52,7 @@ jobs:
             If you require immediate assistance, contact Salesforce Customer Support.
 
   validate-new-issue:
-    if: ${{ !contains(github.event.issue.labels.*.name, 'announcement') && !contains(github.event.issue.labels.*.name, 'missing required information') && !contains(github.event.issue.labels.*.name, 'validated') && !contains(github.event.issue.labels.*.name, 'type:enhancements') && !contains(github.event.issue.labels.*.name, 'feature') && !contains(github.event.issue.labels.*.name, 'type:bug') && !contains(github.event.issue.labels.*.name, 'pending release') && (needs.check-feature-request.outputs.is_feature_request != 'true') }}
+    if: ${{ github.event.issue.state != 'closed' && !contains(github.event.issue.labels.*.name, 'announcement') && !contains(github.event.issue.labels.*.name, 'missing required information') && !contains(github.event.issue.labels.*.name, 'validated') && !contains(github.event.issue.labels.*.name, 'type:enhancements') && !contains(github.event.issue.labels.*.name, 'feature') && !contains(github.event.issue.labels.*.name, 'type:bug') && !contains(github.event.issue.labels.*.name, 'pending release') && (needs.check-feature-request.outputs.is_feature_request != 'true') }}
     needs: [check-feature-request, new-issue]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/validateUpdatedIssues.yml
+++ b/.github/workflows/validateUpdatedIssues.yml
@@ -23,7 +23,8 @@ jobs:
     # - 'status:owned by another team'
     # - 'type:bug'
     # - 'pending release'
-    if: contains(github.event.issue.labels.*.name, 'missing required information') && !contains(github.event.issue.labels.*.name, 'announcement') && !contains(github.event.issue.labels.*.name, 'validated') && !contains(github.event.issue.labels.*.name, 'investigating') && !contains(github.event.issue.labels.*.name, 'feature') && !contains(github.event.issue.labels.*.name, 'type:enhancements') && !contains(github.event.issue.labels.*.name, 'status:owned by another team') && !contains(github.event.issue.labels.*.name, 'type:bug') && !contains(github.event.issue.labels.*.name, 'pending release')
+    # Skip if issue is closed
+    if: github.event.issue.state != 'closed' && contains(github.event.issue.labels.*.name, 'missing required information') && !contains(github.event.issue.labels.*.name, 'announcement') && !contains(github.event.issue.labels.*.name, 'validated') && !contains(github.event.issue.labels.*.name, 'investigating') && !contains(github.event.issue.labels.*.name, 'feature') && !contains(github.event.issue.labels.*.name, 'type:enhancements') && !contains(github.event.issue.labels.*.name, 'status:owned by another team') && !contains(github.event.issue.labels.*.name, 'type:bug') && !contains(github.event.issue.labels.*.name, 'pending release')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +40,7 @@ jobs:
           repo-token: ${{ secrets.IDEE_GH_TOKEN}}
 
   new-feature:
-    if: ${{ (github.event.label.name == 'feature' || github.event.label.name == 'type:enhancements') && !contains(github.event.issue.labels.*.name, 'status:owned by another team') }}
+    if: ${{ github.event.issue.state != 'closed' && (github.event.label.name == 'feature' || github.event.label.name == 'type:enhancements') && !contains(github.event.issue.labels.*.name, 'status:owned by another team') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -57,7 +58,7 @@ jobs:
             Thank you for filing this feature request. We appreciate your feedback and will review the feature at our next grooming session. We prioritize feature requests with more upvotes and comments.
 
   owned-by-other-team:
-    if: ${{ github.event.label.name == 'status:owned by another team' && !contains(github.event.issue.labels.*.name, 'feature') && !contains(github.event.issue.labels.*.name, 'type:enhancements') }}
+    if: ${{ github.event.issue.state != 'closed' && github.event.label.name == 'status:owned by another team' && !contains(github.event.issue.labels.*.name, 'feature') && !contains(github.event.issue.labels.*.name, 'type:enhancements') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -78,6 +79,8 @@ jobs:
 
   new-feature-on-another-team:
     if: >-
+      github.event.issue.state != 'closed'
+      &&
       (github.event.label.name == 'feature' || github.event.label.name == 'type:enhancements' || github.event.label.name == 'status:owned by another team')
       &&
       ((contains(github.event.issue.labels.*.name, 'feature') || contains(github.event.issue.labels.*.name, 'type:enhancements')) && contains(github.event.issue.labels.*.name, 'status:owned by another team'))


### PR DESCRIPTION
### What does this PR do?
Updates the GHA workflows **Validate New Issues** and **Validate Updated Issues** to skip validation of closed issues.

### What issues does this PR fix or reference?
[skip-validate-pr]
