### PR TITLE
[W-21056199] feat: add services extension to packs andedupe coverage setting

### DIFF
--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/utils/settings.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/utils/settings.ts
@@ -5,8 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { SFDX_CORE_CONFIGURATION_NAME } from '@salesforce/salesforcedx-utils-vscode';
 import * as vscode from 'vscode';
 
+const APEX_TESTING_CONFIGURATION_NAME = 'salesforcedx-vscode-apex-testing';
+
 export const retrieveTestCodeCoverage = (): boolean =>
-  vscode.workspace.getConfiguration(SFDX_CORE_CONFIGURATION_NAME).get<boolean>('retrieve-test-code-coverage', false);
+  vscode.workspace.getConfiguration(APEX_TESTING_CONFIGURATION_NAME).get<boolean>('retrieve-test-code-coverage', false);

--- a/packages/salesforcedx-vscode-apex-testing/test/jest/settings.test.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/jest/settings.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import * as vscode from 'vscode';
+import {
+  retrieveOutputFormat,
+  retrievePerformanceThreshold,
+  retrieveTestCodeCoverage,
+  retrieveTestRunConcise,
+  retrieveTestSortOrder,
+  retrieveCoverageThreshold
+} from '../../src/settings';
+
+const APEX_TESTING_CONFIGURATION_NAME = 'salesforcedx-vscode-apex-testing';
+
+describe('settings Unit Tests.', () => {
+  const vscodeMocked = jest.mocked(vscode);
+  let getConfigurationMock: jest.SpyInstance;
+  let getFn: jest.Mock;
+
+  beforeEach(() => {
+    getConfigurationMock = jest.spyOn(vscodeMocked.workspace, 'getConfiguration');
+    getFn = jest.fn();
+  });
+
+  it('Should be able to get retrieveTestCodeCoverage setting.', () => {
+    getConfigurationMock.mockReturnValue({
+      get: getFn.mockReturnValue(false)
+    } as any);
+
+    const result = retrieveTestCodeCoverage();
+
+    expect(result).toBe(false);
+    expect(getConfigurationMock).toHaveBeenCalledWith(APEX_TESTING_CONFIGURATION_NAME);
+    expect(getFn).toHaveBeenCalledWith('retrieve-test-code-coverage', false);
+  });
+
+  it('Should be able to get retrieveTestRunConcise setting.', () => {
+    getConfigurationMock.mockReturnValue({
+      get: getFn.mockReturnValue(false)
+    } as any);
+
+    const result = retrieveTestRunConcise();
+
+    expect(result).toBe(false);
+    expect(getConfigurationMock).toHaveBeenCalledWith(APEX_TESTING_CONFIGURATION_NAME);
+    expect(getFn).toHaveBeenCalledWith('test-run-concise', false);
+  });
+
+  it('Should be able to get retrieveOutputFormat setting.', () => {
+    getConfigurationMock.mockReturnValue({
+      get: getFn.mockReturnValue('markdown')
+    } as any);
+
+    const result = retrieveOutputFormat();
+
+    expect(result).toBe('markdown');
+    expect(getConfigurationMock).toHaveBeenCalledWith(APEX_TESTING_CONFIGURATION_NAME);
+    expect(getFn).toHaveBeenCalledWith('outputFormat', 'markdown');
+  });
+
+  it('Should be able to get retrieveTestSortOrder setting.', () => {
+    getConfigurationMock.mockReturnValue({
+      get: getFn.mockReturnValue('runtime')
+    } as any);
+
+    const result = retrieveTestSortOrder();
+
+    expect(result).toBe('runtime');
+    expect(getConfigurationMock).toHaveBeenCalledWith(APEX_TESTING_CONFIGURATION_NAME);
+    expect(getFn).toHaveBeenCalledWith('testSortOrder', 'runtime');
+  });
+
+  it('Should be able to get retrievePerformanceThreshold setting.', () => {
+    getConfigurationMock.mockReturnValue({
+      get: getFn.mockReturnValue(5000)
+    } as any);
+
+    const result = retrievePerformanceThreshold();
+
+    expect(result).toBe(5000);
+    expect(getConfigurationMock).toHaveBeenCalledWith(APEX_TESTING_CONFIGURATION_NAME);
+    expect(getFn).toHaveBeenCalledWith('testPerformanceThresholdMs', 5000);
+  });
+
+  it('Should be able to get retrieveCoverageThreshold setting.', () => {
+    getConfigurationMock.mockReturnValue({
+      get: getFn.mockReturnValue(75)
+    } as any);
+
+    const result = retrieveCoverageThreshold();
+
+    expect(result).toBe(75);
+    expect(getConfigurationMock).toHaveBeenCalledWith(APEX_TESTING_CONFIGURATION_NAME);
+    expect(getFn).toHaveBeenCalledWith('testCoverageThresholdPercent', 75);
+  });
+});

--- a/packages/salesforcedx-vscode-apex/src/messages/i18n.ja.ts
+++ b/packages/salesforcedx-vscode-apex/src/messages/i18n.ja.ts
@@ -44,11 +44,11 @@ export const messages: Partial<Record<MessageKey, string>> = {
   cannot_determine_workspace: 'ワークスペースのフォルダを特定できませんでした。',
   client_name: 'Apex 言語サーバ',
   colorizer_no_code_coverage_current_file:
-    'このファイルでコードカバレッジの情報が見つかりませんでした。ユーザまたはワークスペースの設定で、"salesforcedx-vscode-core.retrieve-test-code-coverage" を true に設定してください。次に、このファイルを含むApex テストを実行してください。Apex テストのサイドバーまたは、ファイル内の テストの実行 または すべてのテストの実行 のコードレンズを使用してテストを実行できます。',
+    'このファイルでコードカバレッジの情報が見つかりませんでした。ユーザまたはワークスペースの設定で、"salesforcedx-vscode-apex-testing.retrieve-test-code-coverage" を true に設定してください。次に、このファイルを含むApex テストを実行してください。Apex テストのサイドバーまたは、ファイル内の テストの実行 または すべてのテストの実行 のコードレンズを使用してテストを実行できます。',
   colorizer_no_code_coverage_on_project:
-    'このプロジェクトでテスト実行の情報が見つかりませんでした。ユーザまたはワークスペースの設定で、"salesforcedx-vscode-core.retrieve-test-code-coverage" を true に設定してください。次に、Apex テストのサイドバーまたは、テストクラスファイル内の テストの実行 または すべてのテストの実行 のコードレンズを使用してテストを実行してください。',
+    'このプロジェクトでテスト実行の情報が見つかりませんでした。ユーザまたはワークスペースの設定で、"salesforcedx-vscode-apex-testing.retrieve-test-code-coverage" を true に設定してください。次に、Apex テストのサイドバーまたは、テストクラスファイル内の テストの実行 または すべてのテストの実行 のコードレンズを使用してテストを実行してください。',
   colorizer_no_code_coverage_on_test_results:
-    'テスト実行 %s のコードカバレッジの情報が見つかりませんでした。ユーザまたはワークスペースの設定で、"salesforcedx-vscode-core.retrieve-test-code-coverage" を true に設定してください。次に、Apex テストのサイドバーまたは、テストクラスファイル内の テストの実行 または すべてのテストの実行 のコードレンズを使用してテストを実行してください。',
+    'テスト実行 %s のコードカバレッジの情報が見つかりませんでした。ユーザまたはワークスペースの設定で、"salesforcedx-vscode-apex-testing.retrieve-test-code-coverage" を true に設定してください。次に、Apex テストのサイドバーまたは、テストクラスファイル内の テストの実行 または すべてのテストの実行 のコードレンズを使用してテストを実行してください。',
   colorizer_out_of_sync_code_coverage_data:
     'このファイルは更新されているようです。コードカバレッジの数値を更新するには、このファイルでテストを実行してください。',
   colorizer_statusbar_hover_text: 'Apex コードカバレッジを強調表示',

--- a/packages/salesforcedx-vscode-apex/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-apex/src/messages/i18n.ts
@@ -43,11 +43,11 @@ export const messages = {
   channel_name: 'Apex',
   client_name: 'Apex Language Server',
   colorizer_no_code_coverage_current_file:
-    'No code coverage information was found for file %s. Set "salesforcedx-vscode-core.retrieve-test-code-coverage": true in your user or workspace settings. Then, run Apex tests that include methods in this file. You can run tests from the Apex Tests sidebar or using the Run Tests or Run All Tests code lens within the file.',
+    'No code coverage information was found for file %s. Set "salesforcedx-vscode-apex-testing.retrieve-test-code-coverage": true in your user or workspace settings. Then, run Apex tests that include methods in this file. You can run tests from the Apex Tests sidebar or using the Run Tests or Run All Tests code lens within the file.',
   colorizer_no_code_coverage_on_project:
-    'No test run information was found for this project. Set "salesforcedx-vscode-core.retrieve-test-code-coverage": true in your user or workspace settings, then run Apex tests from the Apex Tests sidebar or using the Run Tests or Run All Tests code lens within a test class file.',
+    'No test run information was found for this project. Set "salesforcedx-vscode-apex-testing.retrieve-test-code-coverage": true in your user or workspace settings, then run Apex tests from the Apex Tests sidebar or using the Run Tests or Run All Tests code lens within a test class file.',
   colorizer_no_code_coverage_on_test_results:
-    'No code coverage information was found for test run %s. Set "salesforcedx-vscode-core.retrieve-test-code-coverage": true in your user or workspace settings, then run Apex tests from the Apex Tests sidebar or using the Run Tests or Run All Tests code lens within a test class file.',
+    'No code coverage information was found for test run %s. Set "salesforcedx-vscode-apex-testing.retrieve-test-code-coverage": true in your user or workspace settings, then run Apex tests from the Apex Tests sidebar or using the Run Tests or Run All Tests code lens within a test class file.',
   colorizer_out_of_sync_code_coverage_data:
     'It looks like this file has been updated. To update your code coverage numbers, run the tests in this file.',
   colorizer_statusbar_hover_text: 'Highlight Apex Code Coverage',

--- a/packages/salesforcedx-vscode-apex/src/settings.ts
+++ b/packages/salesforcedx-vscode-apex/src/settings.ts
@@ -5,7 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { SFDX_CORE_CONFIGURATION_NAME } from '@salesforce/salesforcedx-utils-vscode';
 import * as vscode from 'vscode';
 
 // Eligibility for OpenAPI Document ONLY, should not be changed by users unless overwriting in settings.json
@@ -23,9 +22,6 @@ const APEX_ACTION_METHOD_ANNOTATION: string[] = ['AuraEnabled'];
 const DEFAULT_CLASS_ACCESS_MODIFIERS = ['global', 'public'];
 const DEFAULT_METHOD_ACCESS_MODIFIERS = ['global', 'public'];
 const DEFAULT_PROP_ACCESS_MODIFIERS = ['global', 'public'];
-
-export const retrieveTestCodeCoverage = (): boolean =>
-  vscode.workspace.getConfiguration(SFDX_CORE_CONFIGURATION_NAME).get<boolean>('retrieve-test-code-coverage', false);
 
 export const retrieveEnableSyncInitJobs = (): boolean =>
   vscode.workspace.getConfiguration().get<boolean>('salesforcedx-vscode-apex.wait-init-jobs', true);

--- a/packages/salesforcedx-vscode-apex/test/jest/settings.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/settings.test.ts
@@ -4,9 +4,8 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { SFDX_CORE_CONFIGURATION_NAME } from '@salesforce/salesforcedx-utils-vscode';
 import * as vscode from 'vscode';
-import { retrieveAAMethodAnnotations, retrieveEnableSyncInitJobs, retrieveTestCodeCoverage } from '../../src/settings';
+import { retrieveAAMethodAnnotations, retrieveEnableSyncInitJobs } from '../../src/settings';
 
 describe('settings Unit Tests.', () => {
   const vscodeMocked = jest.mocked(vscode);
@@ -16,18 +15,6 @@ describe('settings Unit Tests.', () => {
   beforeEach(() => {
     getConfigurationMock = jest.spyOn(vscodeMocked.workspace, 'getConfiguration');
     getFn = jest.fn();
-  });
-
-  it('Should be able to get retrieveTestCodeCoverage setting.', () => {
-    getConfigurationMock.mockReturnValue({
-      get: getFn.mockReturnValue(false)
-    } as any);
-
-    const result = retrieveTestCodeCoverage();
-
-    expect(result).toBe(false);
-    expect(getConfigurationMock).toHaveBeenCalledWith(SFDX_CORE_CONFIGURATION_NAME);
-    expect(getFn).toHaveBeenCalledWith('retrieve-test-code-coverage', false);
   });
 
   it('Should be able to get retrieveEnableSyncInitJobs setting.', () => {

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -827,11 +827,6 @@
           "default": true,
           "description": "%show_cli_success_msg_description%"
         },
-        "salesforcedx-vscode-core.retrieve-test-code-coverage": {
-          "type": "boolean",
-          "default": false,
-          "description": "%retrieve_test_code_coverage_text%"
-        },
         "salesforcedx-vscode-core.telemetry.enabled": {
           "type": "boolean",
           "default": true,

--- a/packages/salesforcedx-vscode-core/src/constants.ts
+++ b/packages/salesforcedx-vscode-core/src/constants.ts
@@ -25,7 +25,6 @@ export const PUSH_OR_DEPLOY_ON_SAVE_ENABLED = 'push-or-deploy-on-save.enabled';
 export const PREFER_DEPLOY_ON_SAVE_ENABLED = 'push-or-deploy-on-save.preferDeployOnSave';
 export const PUSH_OR_DEPLOY_ON_SAVE_IGNORE_CONFLICTS = 'push-or-deploy-on-save.ignoreConflictsOnPush';
 export const DEPLOY_ON_SAVE_SHOW_OUTPUT_PANEL = 'push-or-deploy-on-save.showOutputPanel';
-export const RETRIEVE_TEST_CODE_COVERAGE = 'retrieve-test-code-coverage';
 export const SHOW_CLI_SUCCESS_INFO_MSG = 'show-cli-success-msg';
 export const TELEMETRY_ENABLED = 'telemetry.enabled';
 export const ENABLE_SOBJECT_REFRESH_ON_STARTUP = 'enable-sobject-refresh-on-startup';

--- a/packages/salesforcedx-vscode-core/src/settings/salesforceCoreSettings.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/salesforceCoreSettings.ts
@@ -17,7 +17,6 @@ import {
   PUSH_OR_DEPLOY_ON_SAVE_ENABLED,
   PUSH_OR_DEPLOY_ON_SAVE_IGNORE_CONFLICTS,
   DEPLOY_ON_SAVE_SHOW_OUTPUT_PANEL,
-  RETRIEVE_TEST_CODE_COVERAGE,
   SHOW_CLI_SUCCESS_INFO_MSG,
   TELEMETRY_ENABLED,
   ALL_EXCEPTION_CATCHER_ENABLED,
@@ -81,10 +80,6 @@ export class SalesforceCoreSettings {
 
   public getEnableSourceTrackingForDeployAndRetrieve(): boolean {
     return this.getConfigValue(ENABLE_SOURCE_TRACKING_FOR_DEPLOY_RETRIEVE, true);
-  }
-
-  public getRetrieveTestCodeCoverage(): boolean {
-    return this.getConfigValue(RETRIEVE_TEST_CODE_COVERAGE, false);
   }
 
   public getInternalDev(): boolean {

--- a/packages/salesforcedx-vscode-expanded/package.json
+++ b/packages/salesforcedx-vscode-expanded/package.json
@@ -55,6 +55,7 @@
     "salesforce.salesforcedx-vscode-visualforce",
     "salesforce.salesforcedx-vscode-lwc",
     "salesforce.salesforcedx-vscode-soql",
+    "salesforce.salesforcedx-vscode-services",
     "salesforce.salesforce-vscode-slds",
     "salesforce.sfdx-code-analyzer-vscode",
     "salesforce.apex-language-server-extension",

--- a/packages/salesforcedx-vscode/package.json
+++ b/packages/salesforcedx-vscode/package.json
@@ -54,6 +54,7 @@
     "salesforce.salesforcedx-vscode-org",
     "salesforce.salesforcedx-vscode-visualforce",
     "salesforce.salesforcedx-vscode-lwc",
+    "salesforce.salesforcedx-vscode-services",
     "salesforce.salesforcedx-vscode-soql",
     "salesforce.salesforce-vscode-slds",
     "salesforce.sfdx-code-analyzer-vscode",


### PR DESCRIPTION
### What does this PR do?
- Adds services extension to both packs
- removes duplicate setting for retrieve test code coverage

### What issues does this PR fix or reference?
@W-21056199@