### PR TITLE
test: don't emit compiled test into /out W-21104256

### DIFF
--- a/packages/salesforcedx-sobjects-faux-generator/test/jest/tsconfig.json
+++ b/packages/salesforcedx-sobjects-faux-generator/test/jest/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "../../src/**/*.ts"]
+}

--- a/packages/salesforcedx-sobjects-faux-generator/tsconfig.json
+++ b/packages/salesforcedx-sobjects-faux-generator/tsconfig.json
@@ -7,8 +7,7 @@
   },
   "include": [
     "src/**/*",
-    "src/data/*.json",
-    "test/**/*"
+    "src/data/*.json"
   ],
   "exclude": [
     "node_modules",

--- a/packages/salesforcedx-utils-vscode/test/jest/tsconfig.json
+++ b/packages/salesforcedx-utils-vscode/test/jest/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "../../src/**/*.ts"]
+}

--- a/packages/salesforcedx-utils-vscode/tsconfig.json
+++ b/packages/salesforcedx-utils-vscode/tsconfig.json
@@ -11,8 +11,7 @@
     "dist"
   ],
   "include": [
-    "src/**/*.ts",
-    "test/**/*.ts"
+    "src/**/*.ts"
   ],
   "references": [
     {

--- a/packages/salesforcedx-utils/test/jest/tsconfig.json
+++ b/packages/salesforcedx-utils/test/jest/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "../../src/**/*.ts"]
+}

--- a/packages/salesforcedx-utils/tsconfig.json
+++ b/packages/salesforcedx-utils/tsconfig.json
@@ -5,6 +5,6 @@
     "outDir": "out"
   },
   "exclude": ["node_modules", ".vscode-test", "out", "dist"],
-  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "include": ["src/**/*.ts"],
   "references": []
 }

--- a/packages/salesforcedx-vscode-apex-oas/test/jest/tsconfig.json
+++ b/packages/salesforcedx-vscode-apex-oas/test/jest/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "../../src/**/*.ts"]
+}

--- a/packages/salesforcedx-vscode-apex-oas/tsconfig.json
+++ b/packages/salesforcedx-vscode-apex-oas/tsconfig.json
@@ -8,7 +8,7 @@
     "strictNullChecks": true
   },
   "exclude": ["node_modules", ".vscode-test", "out", "dist"],
-  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "include": ["src/**/*.ts"],
   "references": [
     {
       "path": "../salesforcedx-utils-vscode"

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/jest/tsconfig.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/jest/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "../../src/**/*.ts"]
+}

--- a/packages/salesforcedx-vscode-apex-replay-debugger/tsconfig.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "out"
   },
   "exclude": ["node_modules", ".vscode-test", "out", "dist"],
-  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "include": ["src/**/*.ts"],
   "references": [
     {
       "path": "../salesforcedx-apex-replay-debugger"

--- a/packages/salesforcedx-vscode-apex-testing/test/jest/tsconfig.json
+++ b/packages/salesforcedx-vscode-apex-testing/test/jest/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "../../src/**/*.ts"]
+}

--- a/packages/salesforcedx-vscode-apex-testing/tsconfig.json
+++ b/packages/salesforcedx-vscode-apex-testing/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": ".",
     "outDir": "out"
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "include": ["src/**/*.ts"],
   "exclude": ["node_modules", ".vscode-test", "out", "dist"],
   "references": [
     {

--- a/packages/salesforcedx-vscode-apex/test/jest/tsconfig.json
+++ b/packages/salesforcedx-vscode-apex/test/jest/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "../../src/**/*.ts"]
+}

--- a/packages/salesforcedx-vscode-apex/tsconfig.json
+++ b/packages/salesforcedx-vscode-apex/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": ".",
     "outDir": "out"
   },
-  "include": ["src/**/*.ts", "src/oas/generationStrategy/*.json", "test/**/*.ts"],
+  "include": ["src/**/*.ts", "src/oas/generationStrategy/*.json"],
   "exclude": ["node_modules", ".vscode-test", "out", "dist"],
   "references": [
     {

--- a/packages/salesforcedx-vscode-core/test/jest/tsconfig.json
+++ b/packages/salesforcedx-vscode-core/test/jest/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "../../src/**/*.ts"]
+}

--- a/packages/salesforcedx-vscode-core/tsconfig.json
+++ b/packages/salesforcedx-vscode-core/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "out"
   },
   "exclude": ["node_modules", ".vscode-test", "out", "dist"],
-  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "include": ["src/**/*.ts"],
   "references": [
     {
       "path": "../salesforcedx-sobjects-faux-generator"

--- a/packages/salesforcedx-vscode-i18n/test/jest/tsconfig.json
+++ b/packages/salesforcedx-vscode-i18n/test/jest/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "../../src/**/*.ts"]
+}

--- a/packages/salesforcedx-vscode-i18n/tsconfig.json
+++ b/packages/salesforcedx-vscode-i18n/tsconfig.json
@@ -5,6 +5,6 @@
     "outDir": "out"
   },
   "exclude": ["node_modules", ".vscode-test", "out", "dist"],
-  "include": ["src/**/*.ts", "test/**/*.ts", "scripts/**/*.ts"],
+  "include": ["src/**/*.ts", "scripts/**/*.ts"],
   "references": []
 }

--- a/packages/salesforcedx-vscode-lwc/tsconfig.json
+++ b/packages/salesforcedx-vscode-lwc/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "out"
   },
   "exclude": ["node_modules", ".vscode-test", "out", "dist"],
-  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "include": ["src/**/*.ts"],
   "references": [
     {
       "path": "../salesforcedx-lightning-lsp-common"

--- a/packages/salesforcedx-vscode-org-browser/test/jest/tsconfig.json
+++ b/packages/salesforcedx-vscode-org-browser/test/jest/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "../../src/**/*.ts"]
+}

--- a/packages/salesforcedx-vscode-org-browser/tsconfig.json
+++ b/packages/salesforcedx-vscode-org-browser/tsconfig.json
@@ -12,7 +12,7 @@
     ]
   },
   "exclude": ["node_modules", ".vscode-test", "out", "dist"],
-  "include": ["src/**/*.ts", "test/**/*.ts", "playwright.config.web.ts", "playwright.config.desktop.ts"],
+  "include": ["src/**/*.ts", "playwright.config.web.ts", "playwright.config.desktop.ts", "test/playwright/**/*.ts"],
   "references": [
     {
       "path": "../salesforcedx-vscode-i18n"

--- a/packages/salesforcedx-vscode-org/test/jest/tsconfig.json
+++ b/packages/salesforcedx-vscode-org/test/jest/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "../../src/**/*.ts"]
+}

--- a/packages/salesforcedx-vscode-org/tsconfig.json
+++ b/packages/salesforcedx-vscode-org/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": ".",
     "outDir": "out"
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "include": ["src/**/*.ts"],
   "exclude": ["node_modules", ".vscode-test", "out", "dist"],
   "references": [
     {

--- a/packages/salesforcedx-vscode-services/test/jest/tsconfig.json
+++ b/packages/salesforcedx-vscode-services/test/jest/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "../../src/**/*.ts"]
+}

--- a/packages/salesforcedx-vscode-services/tsconfig.json
+++ b/packages/salesforcedx-vscode-services/tsconfig.json
@@ -12,6 +12,6 @@
     ]
   },
   "exclude": ["node_modules", ".vscode-test", "out", "dist"],
-  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "include": ["src/**/*.ts"],
   "references": []
 }

--- a/packages/salesforcedx-vscode-soql/test/jest/tsconfig.json
+++ b/packages/salesforcedx-vscode-soql/test/jest/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "../../src/**/*.ts"]
+}

--- a/packages/salesforcedx-vscode-soql/tsconfig.json
+++ b/packages/salesforcedx-vscode-soql/tsconfig.json
@@ -15,7 +15,7 @@
     "src/soql-builder-ui",
     "test/jest/soql-builder-ui"
   ],
-  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "include": ["src/**/*.ts"],
   "references": [
     {
       "path": "../salesforcedx-sobjects-faux-generator"


### PR DESCRIPTION
### What does this PR do?
ts-jest compiles TS on the fly
puts a noEmit in test dirs to prevent emitting test files into `/out` in a new tsconfig file for each pkg.

doesn't touch mocha/automation tests

### What issues does this PR fix or reference?
@W-21104256@
