### PR TITLE
feat: defer apex-testing activation until test view is opened W-21308493

### DIFF
--- a/packages/salesforcedx-vscode-apex-testing/package.json
+++ b/packages/salesforcedx-vscode-apex-testing/package.json
@@ -212,10 +212,7 @@
       ]
     }
   },
-  "activationEvents": [
-    "workspaceContains:sfdx-project.json",
-    "onFileSystem:memfs"
-  ],
+  "activationEvents": [],
   "main": "./dist/index.js",
   "browser": "./dist/web/index.js",
   "types": "./out/src/index.d.ts",
@@ -230,7 +227,13 @@
       ]
     },
     "views": {
-      "test": []
+      "test": [
+        {
+          "id": "sf.test.view",
+          "name": "%test_view_name%",
+          "when": "sf:project_opened"
+        }
+      ]
     },
     "menus": {
       "view/title": [

--- a/packages/salesforcedx-vscode-apex-testing/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/index.ts
@@ -165,8 +165,11 @@ const activateEffect = (context: vscode.ExtensionContext) =>
       .pipe(Effect.catchAll(() => Effect.succeed(false)));
 
     // Only set up project-specific features if we're in a Salesforce project
-    if (isSalesforceProject && vscode.workspace?.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
+    if (isSalesforceProject) {
       const testOutlineProvider = getTestOutlineProvider();
+      context.subscriptions.push(
+        vscode.window.registerTreeDataProvider(testOutlineProvider.getId(), testOutlineProvider)
+      );
       const testController = getTestController();
       yield* Effect.log('[Apex Testing] Test controller created');
 


### PR DESCRIPTION
## Summary
- Declare `sf.test.view` statically in `views.test` so the sidebar icon appears without activating the extension
- Remove `workspaceContains:sfdx-project.json` and `onFileSystem:memfs` activation events — VS Code 1.74+ auto-generates `onView` from the view contribution
- Register tree data provider on activation so the view populates when clicked
- Simplify activation guard to just `isSalesforceProject` (workspace folder check was redundant)

@W-21308493@

## Test plan
- [ ] Open a Salesforce project — Test Viewer sidebar icon should appear
- [ ] Verify extension does NOT activate on project open (check Output > Extension Host)
- [ ] Click the Test Viewer icon — extension should activate and populate tests
- [ ] Run Apex test commands from command palette — extension should activate on demand
- [ ] Verify Playwright web tests still pass

Made with [Cursor](https://cursor.com)