### PR TITLE
[W-19805646] feat: expose hidden setting to enable creating Typescript LWC components

### DIFF
--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -466,7 +466,13 @@
     "configuration": {
       "type": "object",
       "title": "%lightning_lwc_preferences%",
-      "properties": {}
+      "properties": {
+        "salesforcedx-vscode-lwc.preview.typeScriptSupport": {
+          "type": "boolean",
+          "default": false,
+          "description": "%lightning_lwc_preview_typescript_support_desc%"
+        }
+      }
     }
   }
 }

--- a/packages/salesforcedx-vscode-lwc/package.nls.json
+++ b/packages/salesforcedx-vscode-lwc/package.nls.json
@@ -3,6 +3,7 @@
   "lightning_lwc_debugger_desc": "Debug configuration for running LWC jest tests in VSCode.",
   "lightning_lwc_preferences": "Salesforce Lightning Web Components",
   "lightning_lwc_preview_typescript_support": "Enable experimental support for TypeScript",
+  "lightning_lwc_preview_typescript_support_desc": "Enables experimental TypeScript support for Lightning Web Components, including tsconfig initialization and TypeScript file generation.",
   "lightning_lwc_test_case_debug_text": "SFDX: Debug Lightning Web Component Test Case",
   "lightning_lwc_test_collapse_all_text": "SFDX: Lightning Web Component Collapse All Tests",
   "lightning_lwc_test_case_run_text": "SFDX: Run Lightning Web Component Test Case",


### PR DESCRIPTION
### What does this PR do?
Exposes the hidden setting `salesforcedx-vscode-lwc.preview.typeScriptSupport` to enable creating Typescript LWC components.

Here's the new setting in the UI:
<img width="855" height="99" alt="Screenshot 2026-02-19 at 11 06 08 PM" src="https://github.com/user-attachments/assets/74df1ca4-353b-43de-b7ff-3d33fcbaa092" />

When the setting's checkbox is checked, you'll see this extra selection in the command palette when you run **SFDX: Create Lightning Web Component**:
<img width="565" height="104" alt="Screenshot 2026-02-19 at 11 06 53 PM" src="https://github.com/user-attachments/assets/8ff3ecaf-960c-4fbf-bc86-a3a987ab47e3" />

### What issues does this PR fix or reference?
@W-19805646@
