### PR TITLE
[W-19981684] chore: update @salesforce/templates to ^66.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9742,9 +9742,9 @@
       }
     },
     "node_modules/@salesforce/templates": {
-      "version": "65.5.9",
-      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-65.5.9.tgz",
-      "integrity": "sha512-t/DZHdb9WJUr87lxU9Lzu7bZa0uKAULRbjkLp2g2L9BtYgQNZTtcNUCH341oxJC+BHNsrGimQ9gkwvJpy9C5zg==",
+      "version": "66.1.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-66.1.0.tgz",
+      "integrity": "sha512-FOb1MAf1nr3BTbpPbb5GNwqeNh64Z+chDceopBtTUZf6ibL4xU9+iuCS76+E/PFCmcYtD4uZfdEqh11EexAbDw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/kit": "^3.2.4",
@@ -9753,7 +9753,7 @@
         "hpagent": "^1.2.0",
         "mime-types": "^3.0.2",
         "proxy-from-env": "^1.1.0",
-        "tar": "^7.5.7",
+        "tar": "^7.5.8",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -63876,7 +63876,7 @@
         "@salesforce/salesforcedx-utils-vscode": "*",
         "@salesforce/source-deploy-retrieve": "^12.31.12",
         "@salesforce/source-tracking": "^7.8.1",
-        "@salesforce/templates": "^65.1.1",
+        "@salesforce/templates": "^66.1.0",
         "@salesforce/ts-types": "2.0.12",
         "@salesforce/vscode-i18n": "*",
         "@salesforce/vscode-service-provider": "^1.5.0",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -34,7 +34,7 @@
     "@salesforce/salesforcedx-utils-vscode": "*",
     "@salesforce/source-deploy-retrieve": "^12.31.12",
     "@salesforce/source-tracking": "^7.8.1",
-    "@salesforce/templates": "^65.1.1",
+    "@salesforce/templates": "^66.1.0",
     "@salesforce/ts-types": "2.0.12",
     "@salesforce/vscode-i18n": "*",
     "@salesforce/vscode-service-provider": "^1.5.0",


### PR DESCRIPTION
### What does this PR do?
Updates `@salesforce/templates` to the version created in https://github.com/forcedotcom/salesforcedx-templates/pull/727.

### What issues does this PR fix or reference?
@W-19981684@
