### PR TITLE
feat(services): OTLP span file dump for AI consumption W-21360938

### DIFF
--- a/.claude/skills/playwright-e2e/SKILL.md
+++ b/.claude/skills/playwright-e2e/SKILL.md
@@ -19,6 +19,19 @@ Guidelines for writing and iterating on Playwright tests for VS Code extensions.
 
 Shared code (helpers, locators, configuration) for tests.
 
+## Span files (when debugging traces)
+
+Local only — span export disabled in CI/GHA.
+
+- Output: `~/.sf/vscode-spans/` — `web-*.jsonl` (test:web), `node-*.jsonl` (test:desktop)
+- Auto-enabled when !CI (no manual enable needed)
+- Latest: `ls -lt ~/.sf/vscode-spans/`
+- Clear before run for fresh output: `rm -rf ~/.sf/vscode-spans/`
+- Format: JSONL; parse each line with `JSON.parse`
+- Fields: `name`, `traceId`, `spanId`, `parentSpanId`, `durationMs`, `status`, `startTime`, `attributes`
+
+See `.claude/skills/span-file-export/SKILL.md` for enable/OTLP vs file.
+
 ## References
 
 - https://playwright.dev/docs - Playwright docs

--- a/.claude/skills/span-file-export/SKILL.md
+++ b/.claude/skills/span-file-export/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: span-file-export
+description: Use file-based span export for AI consumption. Where it lives, how to enable/clear, settings for Node and Web. Use when enabling span file dump, debugging traces for AI, or configuring local observability.
+---
+
+# Span File Export
+
+Local span export to `~/.sf/vscode-spans/` for AI consumers. Simplified flat JSON Lines format.
+
+## Choose One: OTLP vs File
+
+- **OTLP** (`enableLocalTraces`): Grafana/Jaeger UI — for humans
+- **File** (`enableFileTraces`): `.jsonl` on disk — for AI agents, Cursor
+
+Use only one at a time.
+
+## Where It Lives
+
+All spans in one directory: `~/.sf/vscode-spans/`
+
+| Prefix | Path pattern |
+|--------|--------------|
+| Node | `node-{extensionName}-{ISO-timestamp}.jsonl` |
+| Web | `web-{extensionName}-{ISO-timestamp}.jsonl` |
+
+Find latest: `ls -lt ~/.sf/vscode-spans/`
+
+## Enable (Desktop)
+
+Settings → search `enableFileTraces` → check, or:
+
+```json
+{ "salesforcedx-vscode-salesforcedx.enableFileTraces": true }
+```
+
+## Enable (Web / run:web)
+
+Web POSTs to local span file server (port 3003). Server must be running.
+
+1. Start server: `npm run spans:server -w salesforcedx-vscode-services`
+2. Add to `.esbuild-web-extra-settings.json` at repo root (gitignored):
+
+```json
+{ "salesforcedx-vscode-salesforcedx.enableFileTraces": true }
+```
+
+3. Run `npm run run:web -w packages/<extension>`
+4. If settings don't appear: `rm -rf packages/salesforcedx-vscode-services/.wireit packages/salesforcedx-vscode-services/dist`
+
+`test:web` starts the span file server automatically via wireit service dep.
+
+## Clear
+
+`rm ~/.sf/vscode-spans/*` or `rm -rf ~/.sf/vscode-spans/`
+
+## Format
+
+Simplified flat JSON — one object per line:
+
+```jsonl
+{"name":"deploy","traceId":"abc","spanId":"def","parentSpanId":"","durationMs":1234,"status":"OK","startTime":"2026-02-25T10:30:00.000Z","attributes":{"componentCount":"5"}}
+```
+
+Parse with `JSON.parse` per line.

--- a/.cursor/plans/file_span_exporter_1f1dd784.plan.md
+++ b/.cursor/plans/file_span_exporter_1f1dd784.plan.md
@@ -1,0 +1,227 @@
+---
+name: File Span Exporter
+overview: 'Add a configurable file-based span exporter that writes simplified JSON Lines to `~/.sf/vscode-spans/`. Node writes directly; Web POSTs to a local span file server (port 3003). Config toggle: `enableFileTraces`.'
+todos:
+  - id: config
+    content: Add `getFileTracesEnabled()` to localTracing.ts + `enableFileTraces` setting to package.json contributes + package.nls.json
+    status: completed
+  - id: shared-serializer
+    content: Create shared span-to-simplified-JSON serialization in spanUtils.ts (ReadableSpan → flat JSON line)
+    status: completed
+  - id: node-exporter
+    content: Create fileSpanExporterNode.ts — implements SpanExporter, fs.appendFile to timestamped file in ~/.sf/vscode-spans/
+    status: completed
+  - id: web-exporter
+    content: Create fileSpanExporterWeb.ts — implements SpanExporter, POSTs spans via fetch to localhost:3003
+    status: completed
+  - id: span-server
+    content: Create scripts/spanFileServer.ts — local HTTP server that receives web span POSTs and appends to ~/.sf/vscode-spans/web-*.jsonl. Add wireit service spans:server + wire as test:web dep in all packages.
+    status: completed
+  - id: wire-node
+    content: Wire FileSpanExporterNode into spansNode.ts spanProcessor array
+    status: completed
+  - id: wire-web
+    content: Wire FileSpanExporterWeb into spansWeb.ts spanProcessor array
+    status: completed
+  - id: skill
+    content: Update .claude/skills/span-file-export/SKILL.md with final paths, format, and cleanup instructions
+    status: completed
+  - id: verify
+    content: compile, lint, test, bundle, knip, check:dupes
+    status: completed
+  - id: verify-spans
+    content: Enable enableFileTraces, run test:web (services) and test:desktop (org-browser), review output span files
+    status: completed
+isProject: false
+---
+
+# File-based Span Export for AI Consumption
+
+## Decisions
+
+- **Directory with timestamped files** per session (each extension activation = new file)
+- **Simplified JSON** — flat `{name, traceId, spanId, parentSpanId, durationMs, status, attributes}` per line. AI-optimized, not OTEL-compatible (OTLP HTTP is for tools)
+
+## Paths
+
+- **Node**: `~/.sf/vscode-spans/node-{extensionName}-{ISO-timestamp}.jsonl`
+- **Web**: also `~/.sf/vscode-spans/web-{extensionName}-{ISO-timestamp}.jsonl` (via local span file server on port 3003)
+- `node-` / `web-` prefix makes platform obvious when both exist in the same listing
+- All spans in one directory regardless of platform
+- AI finds latest: `ls -lt ~/.sf/vscode-spans/` → read top file
+- Each `test:web` run = fresh VS Code instance = fresh file (small, focused)
+
+## Format
+
+One span per line, flat JSON:
+
+```jsonl
+{"name":"deploy","traceId":"abc123","spanId":"def456","parentSpanId":"","durationMs":1234,"status":"OK","startTime":"2026-02-25T10:30:00.000Z","attributes":{"componentCount":"5"}}
+{"name":"import @salesforce/source-tracking","traceId":"abc123","spanId":"ghi789","parentSpanId":"def456","durationMs":890,"status":"OK","startTime":"2026-02-25T10:30:00.100Z","attributes":{}}
+```
+
+Uses existing `spanDuration` and `convertAttributes` from [spanUtils.ts](packages/salesforcedx-vscode-services/src/observability/spanUtils.ts).
+
+## Shared Serialization
+
+**File**: [spanUtils.ts](packages/salesforcedx-vscode-services/src/observability/spanUtils.ts)
+
+Add `serializeSpanForFile(span: ReadableSpan): string` — converts a ReadableSpan to the flat JSON line format. Used by both Node and Web exporters.
+
+```ts
+const serializeSpanForFile = (span: ReadableSpan): string =>
+  JSON.stringify({
+    name: span.name,
+    traceId: span.spanContext().traceId,
+    spanId: span.spanContext().spanId,
+    parentSpanId: span.parentSpanContext?.spanId ?? '',
+    durationMs: spanDuration(span),
+    status: span.status.code === SpanStatusCode.ERROR ? 'ERROR' : 'OK',
+    startTime: new Date(span.startTime[0] * 1000 + span.startTime[1] / 1_000_000).toISOString(),
+    attributes: convertAttributes(span.attributes)
+  });
+```
+
+## Node Exporter
+
+**File**: `packages/salesforcedx-vscode-services/src/observability/fileSpanExporterNode.ts`
+
+- Implements `SpanExporter` (export, shutdown)
+- On construction: create file path `join(Global.SF_DIR, 'vscode-spans', 'node-{extensionName}-{timestamp}.jsonl')`
+- `mkdir -p` the directory via `fs.mkdirSync(dir, { recursive: true })`
+- `export()`: append one JSON line per span via `fs.appendFileSync`
+- Extension name comes from resource attributes on the first span batch
+
+## Web Exporter
+
+**Problem**: Web runs in browser with memfs — no real filesystem. Same reason OTLP works via HTTP to localhost.
+
+**Solution**: Web exporter POSTs simplified span JSON to a local HTTP server that writes to disk. Same `~/.sf/vscode-spans/` dir as Node, `web-` prefix.
+
+**File**: `packages/salesforcedx-vscode-services/src/observability/fileSpanExporterWeb.ts`
+
+- Implements `SpanExporter`
+- `export()`: serialize spans via `serializeSpanForFile`, POST as JSON array to `http://localhost:3003/spans`
+- Uses `fetch` (available in browser)
+- If server unreachable: log once, no-op (don't break the extension)
+- Extension name sent as header or in payload for filename
+
+**File**: `packages/salesforcedx-vscode-services/scripts/spanFileServer.ts`
+
+Local HTTP server (like [o11yDebugServer.ts](packages/salesforcedx-vscode-services/scripts/o11yDebugServer.ts)):
+
+- Listens on port 3003
+- POST `/spans` — receives `{ extensionName: string, spans: string[] }` (array of JSON lines)
+- Appends lines to `~/.sf/vscode-spans/web-{extensionName}-{timestamp}.jsonl` via `fs.appendFileSync`
+- Creates directory if needed
+- CORS headers for browser access
+- One file per unique extensionName (timestamp set on first request per extension)
+- Runnable via `npm run spans:server` (wireit, service mode)
+
+### Wireit Config
+
+In `salesforcedx-vscode-services/package.json`:
+
+```json
+"spans:server": "wireit"
+```
+
+```json
+"spans:server": {
+  "command": "ts-node scripts/spanFileServer.ts",
+  "service": true,
+  "files": ["scripts/spanFileServer.ts"]
+}
+```
+
+Add `"spans:server"` as a dependency of `test:web` in every package that has one:
+
+- `salesforcedx-vscode-services` — already local, add `"spans:server"` to deps
+- `salesforcedx-vscode-metadata` — add `"../salesforcedx-vscode-services:spans:server"`
+- `salesforcedx-vscode-org-browser` — add `"../salesforcedx-vscode-services:spans:server"`
+- `salesforcedx-vscode-apex-testing` — add `"../salesforcedx-vscode-services:spans:server"`
+- `playwright-vscode-ext` — add `"../salesforcedx-vscode-services:spans:server"`
+
+Wireit `service: true` starts the server before tests run and shuts it down when the dependent command finishes.
+
+### Usage
+
+- `test:web` automatically starts span file server (no manual step)
+- Manual dev: `npm run spans:server -w salesforcedx-vscode-services` in a terminal, then `npm run run:web`
+
+## Config
+
+**File**: [localTracing.ts](packages/salesforcedx-vscode-services/src/observability/localTracing.ts)
+
+Add `getFileTracesEnabled()` — same pattern as `getLocalTracesEnabled`.
+
+**File**: [package.json](packages/salesforcedx-vscode-services/package.json) contributes.configuration
+
+Add `salesforcedx-vscode-salesforcedx.enableFileTraces`:
+
+- type: boolean, default: false
+- description from package.nls.json
+
+## Wiring
+
+**[spansNode.ts](packages/salesforcedx-vscode-services/src/observability/spansNode.ts)**:
+
+```ts
+...(getFileTracesEnabled() ? [new SpanTransformProcessor(new FileSpanExporterNode())] : [])
+```
+
+**[spansWeb.ts](packages/salesforcedx-vscode-services/src/observability/spansWeb.ts)**:
+
+```ts
+...(getFileTracesEnabled() ? [new SpanTransformProcessor(new FileSpanExporterWeb())] : [])
+```
+
+## Data Flow
+
+```mermaid
+flowchart TD
+    subgraph Node [Node]
+        A1[Spans] --> B1["serializeSpanForFile()"]
+        B1 --> C1["~/.sf/vscode-spans/node-{ext}-{ts}.jsonl"]
+    end
+    subgraph Web [Web]
+        A2[Spans] --> B2["serializeSpanForFile()"]
+        B2 -->|"fetch POST :3003"| D2[spanFileServer]
+        D2 --> C2["~/.sf/vscode-spans/web-{ext}-{ts}.jsonl"]
+    end
+```
+
+## Cleanup
+
+- `rm ~/.sf/vscode-spans/*` or `rm -rf ~/.sf/vscode-spans/`
+- Both Node and Web spans land in the same directory
+- Files accumulate across sessions; user/AI clears as needed
+
+## Skill
+
+Update `.claude/skills/span-file-export/SKILL.md` with:
+
+- Directory-based paths and how to find latest file
+- Simplified JSON format (not OTLP)
+- Cleanup: `rm ~/.sf/vscode-spans/`
+- Enable in settings (desktop + web via `.esbuild-web-extra-settings.json`)
+- Use only 1: OTLP for humans, file for AI
+
+## Verification
+
+Per [verification skill](.claude/skills/verification/SKILL.md): compile, lint, test, bundle, knip, check:dupes.
+
+### Manual span verification
+
+After standard verification passes:
+
+1. Enable file traces in `.esbuild-web-extra-settings.json`:
+
+```json
+{ "salesforcedx-vscode-salesforcedx.enableFileTraces": true }
+```
+
+1. Run `npm run test:web -w salesforcedx-vscode-services` (span file server starts automatically via wireit service dep) — check `~/.sf/vscode-spans/` for `web-` prefixed files
+2. Run `npm run test:desktop -w salesforcedx-vscode-org-browser` — check `~/.sf/vscode-spans/` for `node-` prefixed files
+3. Review the span files: confirm valid JSONL, flat format, reasonable span names and durations
+4. Clean up: `rm -rf ~/.sf/vscode-spans/`

--- a/packages/playwright-vscode-ext/package.json
+++ b/packages/playwright-vscode-ext/package.json
@@ -54,7 +54,8 @@
       "command": "playwright test --config=playwright.config.web.ts",
       "dependencies": [
         "compile",
-        "../salesforcedx-vscode-services:vscode:bundle"
+        "../salesforcedx-vscode-services:vscode:bundle",
+        "../salesforcedx-vscode-services:spans:server"
       ],
       "files": [
         "src/**/*.ts",

--- a/packages/playwright-vscode-ext/src/fixtures/createDesktopTest.ts
+++ b/packages/playwright-vscode-ext/src/fixtures/createDesktopTest.ts
@@ -76,10 +76,17 @@ export const createDesktopTest = (options: CreateDesktopTestOptions) => {
       // Use subdirectory of workspace for user data (keeps everything isolated and together)
       const userDataDir = path.join(workspaceDir, '.vscode-test-user-data');
       await fs.mkdir(userDataDir, { recursive: true });
-      if (userSettings !== undefined && Object.keys(userSettings).length > 0) {
+      const effectiveUserSettings = {
+        ...(!process.env.CI ? { 'salesforcedx-vscode-salesforcedx.enableFileTraces': true } : {}),
+        ...userSettings
+      };
+      if (Object.keys(effectiveUserSettings).length > 0) {
         const userSettingsDir = path.join(userDataDir, 'User');
         await fs.mkdir(userSettingsDir, { recursive: true });
-        await fs.writeFile(path.join(userSettingsDir, 'settings.json'), JSON.stringify(userSettings, null, 2));
+        await fs.writeFile(
+          path.join(userSettingsDir, 'settings.json'),
+          JSON.stringify(effectiveUserSettings, null, 2)
+        );
       }
       const extensionsDir = path.join(workspaceDir, '.vscode-test-extensions');
       await fs.mkdir(extensionsDir, { recursive: true });

--- a/packages/salesforcedx-vscode-apex-testing/package.json
+++ b/packages/salesforcedx-vscode-apex-testing/package.json
@@ -176,6 +176,7 @@
         "compile",
         "vscode:bundle",
         "../salesforcedx-vscode-services:vscode:bundle",
+        "../salesforcedx-vscode-services:spans:server",
         "../salesforcedx-vscode-metadata:vscode:bundle",
         "../playwright-vscode-ext:compile"
       ],

--- a/packages/salesforcedx-vscode-metadata/package.json
+++ b/packages/salesforcedx-vscode-metadata/package.json
@@ -162,6 +162,7 @@
       "dependencies": [
         "vscode:bundle",
         "../salesforcedx-vscode-services:vscode:bundle",
+        "../salesforcedx-vscode-services:spans:server",
         "../playwright-vscode-ext:compile"
       ],
       "files": [

--- a/packages/salesforcedx-vscode-org-browser/package.json
+++ b/packages/salesforcedx-vscode-org-browser/package.json
@@ -178,6 +178,7 @@
       "dependencies": [
         "vscode:bundle",
         "../salesforcedx-vscode-services:vscode:bundle",
+        "../salesforcedx-vscode-services:spans:server",
         "../playwright-vscode-ext:compile"
       ],
       "files": [

--- a/packages/salesforcedx-vscode-services/esbuild.config.mjs
+++ b/packages/salesforcedx-vscode-services/esbuild.config.mjs
@@ -48,6 +48,11 @@ const buildWebConfig = async () => {
     }
   }
 
+  // Enable file traces for local runs (not CI) — span files in ~/.sf/vscode-spans/
+  if (!process.env.CI) {
+    configMap['salesforcedx-vscode-salesforcedx.enableFileTraces'] = true;
+  }
+
   // Read extra settings if ESBUILD_WEB_LOCAL is set
   if (process.env.ESBUILD_WEB_LOCAL) {
     const extraSettingsPath = join(repoRoot, '.esbuild-web-extra-settings.json');

--- a/packages/salesforcedx-vscode-services/package.json
+++ b/packages/salesforcedx-vscode-services/package.json
@@ -72,7 +72,8 @@
     "test:web:ui": "DEBUG_MODE=1 npm run test:web -- --headed",
     "test:web:debug": "npm run test:web -- --debug",
     "test:e2e": "wireit",
-    "o11y:debug": "wireit"
+    "o11y:debug": "wireit",
+    "spans:server": "wireit"
   },
   "wireit": {
     "build:icons": {
@@ -217,7 +218,8 @@
       "command": "playwright test --config=playwright.config.web.ts",
       "dependencies": [
         "vscode:bundle",
-        "../playwright-vscode-ext:compile"
+        "../playwright-vscode-ext:compile",
+        "spans:server"
       ],
       "files": [
         "playwright.config.web.ts"
@@ -243,6 +245,13 @@
       "service": true,
       "files": [
         "scripts/o11yDebugServer.ts"
+      ]
+    },
+    "spans:server": {
+      "command": "ts-node scripts/spanFileServer.ts",
+      "service": true,
+      "files": [
+        "scripts/spanFileServer.ts"
       ]
     }
   },
@@ -290,6 +299,11 @@
           "type": "boolean",
           "default": false,
           "description": "%configuration.otelConsole.description%"
+        },
+        "salesforcedx-vscode-salesforcedx.enableFileTraces": {
+          "type": "boolean",
+          "default": false,
+          "description": "%configuration.otelFile.description%"
         }
       }
     },

--- a/packages/salesforcedx-vscode-services/package.nls.json
+++ b/packages/salesforcedx-vscode-services/package.nls.json
@@ -1,12 +1,1 @@
-{
-  "displayName": "Salesforce VSCode Services",
-  "description": "Core services and APIs for Salesforce VS Code extensions.",
-  "configuration.title": "Salesforce Services Configuration",
-  "configuration.protectedOrg.description": "Org is a production org. Applies only to web console. Changing this value has no effect",
-  "configuration.instanceUrl.description": "Salesforce instance URL for web extensions. Only valid in browser",
-  "configuration.accessToken.description": "Salesforce access token for web extensions. Only valid in browser",
-  "configuration.apiVersion.description": "Salesforce api version (example: 65.0). Only valid in browser",
-  "configuration.retrieveOnLoad.description": "Comma-separated list of metadata to retrieve on load (format: MetadataType:FullName, e.g. ApexClass:Foo,CustomObject:Account). Web only.",
-  "configuration.otelLocal.description": "Enable local OpenTelemetry traces for debugging and performance monitoring. Start the trace viewer using docker run -p 3000:3000 -p 4317:4317 -p 4318:4318 --rm -it docker.io/grafana/otel-lgtm",
-  "configuration.otelConsole.description": "Send OpenTelemetry traces for debugging and performance monitoring to the console (browser or electron)."
-}
+{"displayName":"Salesforce VSCode Services","description":"Core services and APIs for Salesforce VS Code extensions.","configuration.title":"Salesforce Services Configuration","configuration.protectedOrg.description":"Org is a production org. Applies only to web console. Changing this value has no effect","configuration.instanceUrl.description":"Salesforce instance URL for web extensions. Only valid in browser","configuration.accessToken.description":"Salesforce access token for web extensions. Only valid in browser","configuration.apiVersion.description":"Salesforce api version (example: 65.0). Only valid in browser","configuration.retrieveOnLoad.description":"Comma-separated list of metadata to retrieve on load (format: MetadataType:FullName, e.g. ApexClass:Foo,CustomObject:Account). Web only.","configuration.otelLocal.description":"Enable local OpenTelemetry traces for debugging and performance monitoring. Start the trace viewer using docker run -p 3000:3000 -p 4317:4317 -p 4318:4318 --rm -it docker.io/grafana/otel-lgtm","configuration.otelConsole.description":"Send OpenTelemetry traces for debugging and performance monitoring to the console (browser or electron).","configuration.otelFile.description":"Export spans to ~/.sf/vscode-spans/ for AI consumption. Node writes directly; Web POSTs to local span file server (port 3003). Use OTLP (enableLocalTraces) for humans or file for AI - not both."}

--- a/packages/salesforcedx-vscode-services/scripts/spanFileServer.ts
+++ b/packages/salesforcedx-vscode-services/scripts/spanFileServer.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+/* eslint-disable no-restricted-imports -- standalone Node script, not extension code */
+/* eslint-disable functional/no-try-statements -- sync request handling */
+/* eslint-disable @typescript-eslint/consistent-type-assertions -- JSON.parse result */
+import { appendFileSync, mkdirSync } from 'node:fs';
+import * as http from 'node:http';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const PORT = 3003;
+const SPANS_DIR = join(homedir(), '.sf', 'vscode-spans');
+
+const filePaths = new Map<string, string>();
+
+const getFilePath = (extensionName: string): string => {
+  const existing = filePaths.get(extensionName);
+  if (existing) return existing;
+  const timestamp = new Date().toISOString().replaceAll(/[:.]/g, '-');
+  const path = join(SPANS_DIR, `web-${extensionName}-${timestamp}.jsonl`);
+  filePaths.set(extensionName, path);
+  return path;
+};
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type'
+};
+
+const send = (res: http.ServerResponse, status: number, body: string): void => {
+  res.writeHead(status, { ...corsHeaders, 'Content-Type': 'application/json' });
+  res.end(body);
+};
+
+const handleRequest = (req: http.IncomingMessage, res: http.ServerResponse): void => {
+  if (req.method === 'OPTIONS') {
+    send(res, 200, '');
+    return;
+  }
+
+  if (req.method !== 'POST' || req.url !== '/spans') {
+    send(res, 404, JSON.stringify({ error: 'POST /spans only' }));
+    return;
+  }
+
+  const chunks: Buffer[] = [];
+  req.on('data', (chunk: Buffer) => chunks.push(chunk));
+  req.on('end', () => {
+    try {
+      const body = Buffer.concat(chunks).toString();
+      const parsed = JSON.parse(body) as { extensionName?: string; spans?: string[] };
+      const { extensionName, spans } = parsed;
+
+      if (typeof extensionName !== 'string' || !Array.isArray(spans)) {
+        send(res, 400, JSON.stringify({ error: 'Expected { extensionName: string, spans: string[] }' }));
+        return;
+      }
+
+      mkdirSync(SPANS_DIR, { recursive: true });
+      const filePath = getFilePath(extensionName);
+      const lines = spans.filter((s): s is string => typeof s === 'string').join('\n') + (spans.length > 0 ? '\n' : '');
+      if (lines) appendFileSync(filePath, lines);
+
+      send(res, 200, JSON.stringify({ success: true }));
+    } catch (error) {
+      send(res, 400, JSON.stringify({ error: String(error) }));
+    }
+  });
+};
+
+const server = http.createServer(handleRequest);
+server.listen(PORT, () => {
+  console.log(`Span file server listening on http://localhost:${PORT}`);
+  console.log(`Writing to ${SPANS_DIR}\n`);
+});
+
+server.on('error', err => {
+  console.error('Server error:', err);
+  process.exit(1);
+});

--- a/packages/salesforcedx-vscode-services/src/observability/fileSpanExporterNode.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/fileSpanExporterNode.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+/* eslint-disable no-restricted-imports -- Node-only exporter, not used in web bundle */
+import { ExportResult, ExportResultCode } from '@opentelemetry/core';
+import { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
+import { Global } from '@salesforce/core/global';
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { serializeSpanForFile } from './spanUtils';
+
+const SPANS_DIR = join(Global.SF_DIR, 'vscode-spans');
+
+/** Span exporter that appends simplified JSON lines to ~/.sf/vscode-spans/node-{extensionName}-{timestamp}.jsonl */
+export class FileSpanExporterNode implements SpanExporter {
+  private readonly filePath: string;
+
+  constructor(extensionName: string) {
+    mkdirSync(SPANS_DIR, { recursive: true });
+    const timestamp = new Date().toISOString().replaceAll(/[:.]/g, '-');
+    this.filePath = join(SPANS_DIR, `node-${extensionName}-${timestamp}.jsonl`);
+  }
+
+  public export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
+    const lines = spans.map(serializeSpanForFile).join('\n') + (spans.length > 0 ? '\n' : '');
+    if (!lines) {
+      resultCallback({ code: ExportResultCode.SUCCESS });
+      return;
+    }
+    const result: ExportResult = (() => {
+      // eslint-disable-next-line functional/no-try-statements -- sync fs op, no Effect in exporter
+      try {
+        appendFileSync(this.filePath, lines);
+        return { code: ExportResultCode.SUCCESS };
+      } catch (error) {
+        return { code: ExportResultCode.FAILED, error };
+      }
+    })();
+    resultCallback(result);
+  }
+
+  // eslint-disable-next-line class-methods-use-this -- SpanExporter interface requires shutdown
+  public shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/packages/salesforcedx-vscode-services/src/observability/fileSpanExporterWeb.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/fileSpanExporterWeb.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { ExportResult, ExportResultCode } from '@opentelemetry/core';
+import { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
+import { serializeSpanForFile } from './spanUtils';
+
+const SPAN_FILE_SERVER_URL = 'http://localhost:3003/spans';
+
+const serverUnreachable = { logged: false };
+
+/** Span exporter that POSTs simplified JSON lines to local span file server (port 3003). */
+export class FileSpanExporterWeb implements SpanExporter {
+  constructor(private readonly extensionName: string) {}
+
+  public export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
+    if (spans.length === 0) {
+      resultCallback({ code: ExportResultCode.SUCCESS });
+      return;
+    }
+
+    const payload = { extensionName: this.extensionName, spans: spans.map(serializeSpanForFile) };
+
+    fetch(SPAN_FILE_SERVER_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+      .then(res =>
+        res.ok
+          ? resultCallback({ code: ExportResultCode.SUCCESS })
+          : resultCallback({ code: ExportResultCode.FAILED, error: new Error(`HTTP ${res.status}`) })
+      )
+      .catch(error => {
+        if (!serverUnreachable.logged) {
+          console.warn('Span file server unreachable at localhost:3003 — enableFileTraces needs spans:server running');
+          serverUnreachable.logged = true;
+        }
+        resultCallback({ code: ExportResultCode.FAILED, error });
+      });
+  }
+
+  // eslint-disable-next-line class-methods-use-this -- SpanExporter interface requires shutdown
+  public shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/packages/salesforcedx-vscode-services/src/observability/localTracing.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/localTracing.ts
@@ -18,6 +18,10 @@ export const getLocalTracesEnabled = (): boolean =>
 export const getConsoleTracesEnabled = (): boolean =>
   getOptionalBooleanConfiguration(SALESFORCE_DX_SECTION)('enableConsoleTraces');
 
+/** export spans to ~/.sf/vscode-spans/ for AI consumption. Node writes directly; Web POSTs to local span file server (port 3003). */
+export const getFileTracesEnabled = (): boolean =>
+  getOptionalBooleanConfiguration(SALESFORCE_DX_SECTION)('enableFileTraces');
+
 const getOptionalBooleanConfiguration =
   (section: string) =>
   (configName: string): boolean => {

--- a/packages/salesforcedx-vscode-services/src/observability/spanUtils.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/spanUtils.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import type { Attributes } from '@opentelemetry/api';
+import { type Attributes, SpanStatusCode } from '@opentelemetry/api';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 
 /** Check if a span is a top-level span (has no parent) */
@@ -30,3 +30,16 @@ export const getExtensionNameAndVersionAttributes = (
   const extensionVersion = attributes['extension.version'] ?? 'unknown';
   return { 'common.extname': String(extensionName), 'common.extversion': String(extensionVersion) };
 };
+
+/** Serialize span to flat JSON line for file export (AI-optimized). */
+export const serializeSpanForFile = (span: ReadableSpan): string =>
+  JSON.stringify({
+    name: span.name,
+    traceId: span.spanContext().traceId,
+    spanId: span.spanContext().spanId,
+    parentSpanId: span.parentSpanContext?.spanId ?? '',
+    durationMs: spanDuration(span),
+    status: span.status?.code === SpanStatusCode.ERROR ? 'ERROR' : 'OK',
+    startTime: new Date(span.startTime[0] * 1000 + span.startTime[1] / 1_000_000).toISOString(),
+    attributes: convertAttributes(span.attributes)
+  });

--- a/packages/salesforcedx-vscode-services/src/observability/spansNode.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/spansNode.ts
@@ -12,7 +12,8 @@ import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base';
 import { Global } from '@salesforce/core/global';
 import { join } from 'node:path';
 import { DEFAULT_AI_CONNECTION_STRING, isTelemetryExtensionConfigurationEnabled } from './appInsights';
-import { getConsoleTracesEnabled, getLocalTracesEnabled } from './localTracing';
+import { FileSpanExporterNode } from './fileSpanExporterNode';
+import { getConsoleTracesEnabled, getFileTracesEnabled, getLocalTracesEnabled } from './localTracing';
 import { O11ySpanExporter } from './o11ySpanExporter';
 import { SpanTransformProcessor } from './spanTransformProcessor';
 
@@ -46,6 +47,7 @@ export const NodeSdkLayerFor = ({ extensionName, extensionVersion, o11yEndpoint,
       ...(o11yEndpoint && (o11yEndpoint.includes('localhost') || isTelemetryExtensionConfigurationEnabled())
         ? [new SpanTransformProcessor(new O11ySpanExporter(extensionName, o11yEndpoint, productFeatureId))]
         : []),
-      ...(getLocalTracesEnabled() ? [new SpanTransformProcessor(new OTLPTraceExporter())] : [])
+      ...(getLocalTracesEnabled() ? [new SpanTransformProcessor(new OTLPTraceExporter())] : []),
+      ...(getFileTracesEnabled() ? [new SpanTransformProcessor(new FileSpanExporterNode(extensionName))] : [])
     ]
   }));

--- a/packages/salesforcedx-vscode-services/src/observability/spansWeb.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/spansWeb.ts
@@ -10,7 +10,8 @@ import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-web';
 import { isTelemetryExtensionConfigurationEnabled } from './appInsights';
 import { ApplicationInsightsWebExporter } from './applicationInsightsWebExporter';
-import { getConsoleTracesEnabled, getLocalTracesEnabled } from './localTracing';
+import { FileSpanExporterWeb } from './fileSpanExporterWeb';
+import { getConsoleTracesEnabled, getFileTracesEnabled, getLocalTracesEnabled } from './localTracing';
 import { O11ySpanExporter } from './o11ySpanExporter';
 import { SpanTransformProcessor } from './spanTransformProcessor';
 
@@ -35,6 +36,7 @@ export const WebSdkLayerFor = ({ extensionName, extensionVersion, o11yEndpoint, 
       ...(o11yEndpoint && (o11yEndpoint.includes('localhost') || isTelemetryExtensionConfigurationEnabled())
         ? [new SpanTransformProcessor(new O11ySpanExporter(extensionName, o11yEndpoint, productFeatureId))]
         : []),
-      ...(getLocalTracesEnabled() ? [new SpanTransformProcessor(new OTLPTraceExporter())] : [])
+      ...(getLocalTracesEnabled() ? [new SpanTransformProcessor(new OTLPTraceExporter())] : []),
+      ...(getFileTracesEnabled() ? [new SpanTransformProcessor(new FileSpanExporterWeb(extensionName))] : [])
     ]
   }));


### PR DESCRIPTION
### What does this PR do?

Adds file-based span export to `~/.sf/vscode-spans/` for AI agents. Supports Node (direct write) and Web (POST to local server on port 3003).

### What issues does this PR fix or reference?
@W-21360938@

Made with [Cursor](https://cursor.com)