### PR TITLE
fix: @W-21347563 - load o11y_schema/sf_pdp via dynamic import() to avoid ERR_REQUIRE_ESM in CJS

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/telemetry/reporters/o11yReporter.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/reporters/o11yReporter.ts
@@ -18,8 +18,9 @@ const pdpEventSchemaCache: { promise: Promise<Record<string, unknown>> | null } 
   promise: null
 };
 const getPdpEventSchema = async (): Promise<Record<string, unknown>> => {
+  // @ts-ignore - o11y_schema has no types
   pdpEventSchemaCache.promise ??= import('o11y_schema/sf_pdp').then(
-    (m: { pdpEventSchema: Record<string, unknown> }) => m.pdpEventSchema
+    (m) => m.pdpEventSchema
   );
   return pdpEventSchemaCache.promise;
 };

--- a/packages/salesforcedx-vscode-services/src/observability/o11ySpanExporter.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/o11ySpanExporter.ts
@@ -20,8 +20,9 @@ const pdpEventSchemaCache: { promise: Promise<Record<string, unknown>> | null } 
   promise: null
 };
 const getPdpEventSchema = async (): Promise<Record<string, unknown>> => {
+  // @ts-ignore - o11y_schema has no types
   pdpEventSchemaCache.promise ??= import('o11y_schema/sf_pdp').then(
-    (m: { pdpEventSchema: Record<string, unknown> }) => m.pdpEventSchema
+    (m) => m.pdpEventSchema
   );
   return pdpEventSchemaCache.promise;
 };


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?

This change replaces the top-level static import of o11y_schema/sf_pdp in o11yReporter.ts and o11ySpanExporter.ts with a lazily loaded, cached dynamic import().

Since o11y_schema is ESM-only, a static import gets compiled to require() when consumed from a CommonJS context (e.g., AFV extension or MCP server), resulting in ERR_REQUIRE_ESM at runtime. By introducing a getPdpEventSchema() helper that dynamically loads and caches the schema, PDP telemetry continues to work seamlessly across both ESM and CJS consumers without changing existing call patterns.

### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @W-21347563@

### Functionality Before
<insert gif and/or summary>

### Functionality After
<insert gif and/or summary>
