### PR TITLE
[W-21368115] chore(eslint): improve no-unused-i18n-messages rule 

### DIFF
--- a/packages/eslint-local-rules/src/noDuplicateI18nValues.ts
+++ b/packages/eslint-local-rules/src/noDuplicateI18nValues.ts
@@ -80,24 +80,28 @@ export const noDuplicateI18nValues = RuleCreator.withoutDocs({
     }
 
     const enMessages: MessagesObject = extractMessagesObject(enAst);
+
+    const unwrapAsExpression = (node: TSESTree.Expression): TSESTree.Expression =>
+      node.type === AST_NODE_TYPES.TSAsExpression ? unwrapAsExpression(node.expression) : node;
+
+    let messagesObject: TSESTree.ObjectExpression | null = null;
+
     return {
-      Property: (node: TSESTree.Property): void => {
-        // Check if this property is part of a messages object
-        // Structure can be: messages = { prop } OR messages = { prop } as const
-        if (node.parent?.type !== AST_NODE_TYPES.ObjectExpression) {
-          return;
-        }
-
-        // Handle both direct and "as const" cases
-        const initialDeclarator = node.parent.parent;
-        const declarator =
-          initialDeclarator?.type === AST_NODE_TYPES.TSAsExpression ? initialDeclarator.parent : initialDeclarator;
-
+      VariableDeclarator: (node: TSESTree.VariableDeclarator): void => {
         if (
-          declarator?.type !== AST_NODE_TYPES.VariableDeclarator ||
-          declarator.id.type !== AST_NODE_TYPES.Identifier ||
-          declarator.id.name !== 'messages'
+          node.id.type === AST_NODE_TYPES.Identifier &&
+          node.id.name === 'messages' &&
+          node.init
         ) {
+          const init = unwrapAsExpression(node.init);
+          if (init.type === AST_NODE_TYPES.ObjectExpression) {
+            messagesObject = init;
+          }
+        }
+      },
+
+      Property: (node: TSESTree.Property): void => {
+        if (!messagesObject || node.parent !== messagesObject) {
           return;
         }
 

--- a/packages/eslint-local-rules/src/noUnusedI18nMessages.ts
+++ b/packages/eslint-local-rules/src/noUnusedI18nMessages.ts
@@ -4,7 +4,6 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
 import * as tsParser from '@typescript-eslint/parser';
 import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
 import { RuleCreator } from '@typescript-eslint/utils/eslint-utils';
@@ -22,9 +21,19 @@ type RuleOptions = {
 
 const DEFAULT_OPTIONS: RuleOptions = {};
 
-const findPackageRoot = (i18nPath: string): string | undefined => {
-  let dir = path.dirname(i18nPath);
-  const root = path.parse(i18nPath).root;
+const unwrapAsExpression = (node: TSESTree.Expression): TSESTree.Expression =>
+  node.type === AST_NODE_TYPES.TSAsExpression
+    ? unwrapAsExpression(node.expression)
+    : node;
+
+const addRef = (counts: Map<string, number>, key: string): void => {
+  counts.set(key, (counts.get(key) ?? 0) + 1);
+};
+
+const findPackageRoot = (file: string): string | undefined => {
+  let dir = path.dirname(file);
+  const root = path.parse(file).root;
+
   while (dir !== root) {
     if (fs.existsSync(path.join(dir, 'package.json'))) {
       return dir;
@@ -36,46 +45,45 @@ const findPackageRoot = (i18nPath: string): string | undefined => {
 
 const findTsFiles = (packageRoot: string): string[] => {
   const result: string[] = [];
-  const searchDirs = [
-    path.join(packageRoot, 'src'),
-    path.join(packageRoot, 'test')
-  ].filter(d => fs.existsSync(d));
+  const searchDirs = ['src', 'test']
+    .map(d => path.join(packageRoot, d))
+    .filter(d => fs.existsSync(d));
 
   const walk = (dir: string): void => {
-    const entries = fs.readdirSync(dir, { withFileTypes: true });
-    for (const entry of entries) {
-      const fullPath = path.join(dir, entry.name);
-      if (entry.isDirectory() && entry.name !== 'node_modules' && !entry.name.startsWith('.')) {
-        walk(fullPath);
-      } else if (entry.isFile() && entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) {
-        result.push(fullPath);
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+
+      if (
+        entry.isDirectory() &&
+        entry.name !== 'node_modules' &&
+        !entry.name.startsWith('.')
+      ) {
+        walk(full);
+      } else if (
+        entry.isFile() &&
+        entry.name.endsWith('.ts') &&
+        !entry.name.endsWith('.d.ts')
+      ) {
+        result.push(full);
       }
     }
   };
 
-  for (const searchDir of searchDirs) {
-    walk(searchDir);
-  }
+  searchDirs.forEach(walk);
   return result;
 };
 
 const loadPackageNlsKeys = (packageRoot: string): Set<string> => {
-  const nlsPath = path.join(packageRoot, 'package.nls.json');
   try {
-    const content = fs.readFileSync(nlsPath, 'utf8');
+    const content = fs.readFileSync(
+      path.join(packageRoot, 'package.nls.json'),
+      'utf8'
+    );
     const nls = JSON.parse(content) as Record<string, string>;
     return new Set(Object.keys(nls));
   } catch {
     return new Set();
   }
-};
-
-const collectLiteralStringArg = (node: TSESTree.CallExpression): string | undefined => {
-  const firstArg = node.arguments[0];
-  if (firstArg?.type === AST_NODE_TYPES.Literal && typeof firstArg.value === 'string') {
-    return firstArg.value;
-  }
-  return undefined;
 };
 
 const isNlsLocalizeCall = (node: TSESTree.CallExpression): boolean =>
@@ -86,107 +94,8 @@ const isNlsLocalizeCall = (node: TSESTree.CallExpression): boolean =>
   node.callee.property.name === 'localize';
 
 const isCoerceMessageKeyCall = (node: TSESTree.CallExpression): boolean =>
-  node.callee.type === AST_NODE_TYPES.Identifier && node.callee.name === 'coerceMessageKey';
-
-const traverse = (node: unknown, visitor: (n: TSESTree.CallExpression) => void): void => {
-  if (!node || typeof node !== 'object' || !('type' in node) || typeof (node as { type: unknown }).type !== 'string') {
-    return;
-  }
-  const n = node as TSESTree.Node;
-  if (n.type === AST_NODE_TYPES.CallExpression) {
-    visitor(n);
-  }
-  for (const value of Object.values(n as unknown as Record<string, unknown>)) {
-    if (Array.isArray(value)) {
-      value.forEach(v => traverse(v, visitor));
-    } else {
-      traverse(value, visitor);
-    }
-  }
-};
-
-const traverseLiterals = (
-  node: unknown,
-  visitor: (n: TSESTree.Literal) => void
-): void => {
-  if (!node || typeof node !== 'object' || !('type' in node) || typeof (node as { type: unknown }).type !== 'string') {
-    return;
-  }
-  const n = node as TSESTree.Node;
-  if (n.type === AST_NODE_TYPES.Literal && typeof (n as TSESTree.Literal).value === 'string') {
-    visitor(n as TSESTree.Literal);
-  }
-  for (const value of Object.values(n as unknown as Record<string, unknown>)) {
-    if (Array.isArray(value)) {
-      value.forEach(v => traverseLiterals(v, visitor));
-    } else {
-      traverseLiterals(value, visitor);
-    }
-  }
-};
-
-const traverseMemberExpressions = (
-  node: unknown,
-  visitor: (n: TSESTree.MemberExpression) => void
-): void => {
-  if (!node || typeof node !== 'object' || !('type' in node) || typeof (node as { type: unknown }).type !== 'string') {
-    return;
-  }
-  const n = node as TSESTree.Node;
-  if (
-    n.type === AST_NODE_TYPES.MemberExpression &&
-    n.object.type === AST_NODE_TYPES.Identifier &&
-    n.property.type === AST_NODE_TYPES.Identifier
-  ) {
-    visitor(n);
-  }
-  for (const value of Object.values(n as unknown as Record<string, unknown>)) {
-    if (Array.isArray(value)) {
-      value.forEach(v => traverseMemberExpressions(v, visitor));
-    } else {
-      traverseMemberExpressions(value, visitor);
-    }
-  }
-};
-
-const collectUsedKeysFromSource = (
-  source: string,
-  knownKeys: Set<string>
-): Set<string> => {
-  const usedKeys = new Set<string>();
-  let ast: TSESTree.Program;
-  try {
-    ast = tsParser.parse(source, {
-      sourceType: 'module',
-      ecmaVersion: 2020
-    }) as unknown as TSESTree.Program;
-  } catch {
-    return usedKeys;
-  }
-
-  traverse(ast, node => {
-    const key = collectLiteralStringArg(node);
-    if (key && (isNlsLocalizeCall(node) || isCoerceMessageKeyCall(node))) {
-      usedKeys.add(key);
-    }
-  });
-
-  traverseLiterals(ast, node => {
-    const value = node.value;
-    if (typeof value === 'string' && knownKeys.has(value)) {
-      usedKeys.add(value);
-    }
-  });
-
-  traverseMemberExpressions(ast, node => {
-    const obj = node.object as TSESTree.Identifier;
-    const prop = node.property as TSESTree.Identifier;
-    if (obj.name === 'messages' && knownKeys.has(prop.name)) {
-      usedKeys.add(prop.name);
-    }
-  });
-  return usedKeys;
-};
+    node.callee.type === AST_NODE_TYPES.Identifier &&
+  node.callee.name === 'coerceMessageKey';
 
 const isKeyExcludedByPattern = (key: string, patterns: string[]): boolean =>
   patterns.some(p => {
@@ -197,26 +106,96 @@ const isKeyExcludedByPattern = (key: string, patterns: string[]): boolean =>
     }
   });
 
+const collectReferenceCountsFromSource = (
+  source: string,
+  knownKeys: Set<string>
+): Map<string, number> => {
+  const counts = new Map<string, number>();
+
+  let ast: TSESTree.Program;
+  try {
+    ast = tsParser.parse(source, {
+      sourceType: 'module',
+      ecmaVersion: 2020
+    }) as unknown as TSESTree.Program;
+  } catch {
+    return counts;
+  }
+
+  const visitor = (node: TSESTree.Node): void => {
+    switch (node.type) {
+      case AST_NODE_TYPES.CallExpression: {
+        const first = node.arguments[0];
+        if (
+          first?.type === AST_NODE_TYPES.Literal &&
+          typeof first.value === 'string'
+        ) {
+          if (isNlsLocalizeCall(node) || isCoerceMessageKeyCall(node)) {
+            addRef(counts, first.value);
+          }
+        }
+        break;
+      }
+
+      case AST_NODE_TYPES.Literal: {
+        if (
+          typeof node.value === 'string' &&
+          knownKeys.has(node.value)
+        ) {
+          addRef(counts, node.value);
+        }
+        break;
+      }
+
+      case AST_NODE_TYPES.MemberExpression: {
+        if (
+          node.object.type === AST_NODE_TYPES.Identifier &&
+          node.object.name === 'messages' &&
+          node.property.type === AST_NODE_TYPES.Identifier &&
+          knownKeys.has(node.property.name)
+        ) {
+          addRef(counts, node.property.name);
+        }
+        break;
+      }
+    }
+
+    const nodeRecord = node as unknown as Record<string, unknown>;
+    for (const value of Object.values(nodeRecord)) {
+      if (Array.isArray(value)) {
+        for (const v of value) {
+          if (v && typeof v === 'object' && 'type' in v) visitor(v as TSESTree.Node);
+        }
+      } else if (value && typeof value === 'object' && 'type' in value) {
+        visitor(value as TSESTree.Node);
+      }
+    }
+  };
+
+  visitor(ast);
+  return counts;
+};
+
 export const noUnusedI18nMessages = RuleCreator.withoutDocs({
   meta: {
     type: 'problem',
-    docs: {
-      description:
-        'Report unused message keys in i18n.ts. Considers a key used if it appears in nls.localize(), coerceMessageKey(), package.nls.json, as any string literal, or as messages.key property access'
-    },
     schema: [
       {
         type: 'object',
+        description:
+        'Options for configuring unused i18n message detection.',
         properties: {
           allowList: {
+            description:
+            'Keys that should never be reported as unused.',
             type: 'array',
-            items: { type: 'string' },
-            description: 'Keys to never report (e.g. used via constants)'
+            items: { type: 'string' }
           },
           dynamicKeyPatterns: {
+            description:
+            'Regex patterns for keys used dynamically at runtime.',
             type: 'array',
-            items: { type: 'string' },
-            description: 'Regex patterns for keys used only at runtime'
+            items: { type: 'string' }
           }
         },
         additionalProperties: false
@@ -224,72 +203,88 @@ export const noUnusedI18nMessages = RuleCreator.withoutDocs({
     ],
     defaultOptions: [DEFAULT_OPTIONS],
     messages: {
-      unused: 'Message key "{{key}}" is not used. Remove it or add to allowList if used via constants.'
+      unused:
+        'Message key "{{key}}" is not used. Remove it or add to allowList if used via constants.',
+      invalidAllowListEntry:
+        'allowList entry "{{key}}" does not exist in this messages file. Remove it from the allowList in eslint.config.mjs.'
     }
   },
   defaultOptions: [DEFAULT_OPTIONS],
+
   create: (context, [opts = DEFAULT_OPTIONS]) => {
-    const filename = context.filename ?? context.getFilename();
-    const normalized = filename.replaceAll('\\', '/');
-    if (!normalized.endsWith('messages/i18n.ts')) {
+    const filename = context.getFilename();
+    if (!filename.replaceAll('\\', '/').endsWith('messages/i18n.ts')) {
       return {};
     }
 
     const packageRoot = findPackageRoot(filename);
-    if (!packageRoot) {
-      return {};
-    }
+    if (!packageRoot) return {};
 
     const allowList = new Set(opts.allowList);
-    const dynamicPatterns = opts.dynamicKeyPatterns ?? DEFAULT_DYNAMIC_KEY_PATTERNS;
+    const dynamicPatterns =
+      opts.dynamicKeyPatterns ?? DEFAULT_DYNAMIC_KEY_PATTERNS;
+
     const nlsKeys = loadPackageNlsKeys(packageRoot);
 
     let knownKeys = new Set<string>();
     try {
-      const i18nSource = fs.readFileSync(filename, 'utf8');
-      const i18nAst = tsParser.parse(i18nSource, {
+      const source = fs.readFileSync(filename, 'utf8');
+      const ast = tsParser.parse(source, {
         sourceType: 'module',
         ecmaVersion: 2020
       }) as unknown as TSESTree.Program;
-      knownKeys = new Set(Object.keys(extractMessagesObject(i18nAst)));
+
+      knownKeys = new Set(Object.keys(extractMessagesObject(ast)));
     } catch {
-      // Fallback: usedKeys will only have nls/coerce/package.nls
+      // ignore
     }
 
-    const usedKeys = new Set<string>(nlsKeys);
-    for (const filePath of findTsFiles(packageRoot)) {
+    const refCounts = new Map<string, number>();
+    nlsKeys.forEach(k => addRef(refCounts, k));
+
+    for (const file of findTsFiles(packageRoot)) {
+      if (path.resolve(file) === path.resolve(filename)) continue;
+
       try {
-        const source = fs.readFileSync(filePath, 'utf8');
-        for (const k of collectUsedKeysFromSource(source, knownKeys)) {
-          usedKeys.add(k);
+        const source = fs.readFileSync(file, 'utf8');
+        const fileCounts = collectReferenceCountsFromSource(
+          source,
+          knownKeys
+        );
+        for (const [k, c] of fileCounts) {
+          refCounts.set(k, (refCounts.get(k) ?? 0) + c);
         }
       } catch {
-        // Skip unreadable files
+        // skip
       }
     }
 
+    let messagesObject: TSESTree.ObjectExpression | null = null;
+
     return {
-      Property: (node: TSESTree.Property): void => {
-        if (node.parent?.type !== AST_NODE_TYPES.ObjectExpression) {
-          return;
-        }
-
-        const grandparent = node.parent.parent;
-        const declarator =
-          grandparent?.type === AST_NODE_TYPES.TSAsExpression ? grandparent.parent : grandparent;
-
+      VariableDeclarator: (node: TSESTree.VariableDeclarator) => {
         if (
-          declarator?.type !== AST_NODE_TYPES.VariableDeclarator ||
-          declarator.id.type !== AST_NODE_TYPES.Identifier ||
-          declarator.id.name !== 'messages'
+          node.id.type === AST_NODE_TYPES.Identifier &&
+          node.id.name === 'messages' &&
+          node.init
         ) {
+          const init = unwrapAsExpression(node.init);
+          if (init.type === AST_NODE_TYPES.ObjectExpression) {
+            messagesObject = init;
+          }
+        }
+      },
+
+      Property: (node: TSESTree.Property) => {
+        if (!messagesObject || node.parent !== messagesObject) {
           return;
         }
 
         const key = extractKey(node);
+        if (!key) return;
+
         if (
-          !key ||
-          usedKeys.has(key) ||
+          (refCounts.get(key) ?? 0) > 0 ||
           allowList.has(key) ||
           isKeyExcludedByPattern(key, dynamicPatterns)
         ) {
@@ -301,6 +296,18 @@ export const noUnusedI18nMessages = RuleCreator.withoutDocs({
           messageId: 'unused',
           data: { key }
         });
+      },
+
+      'Program:exit': (node: TSESTree.Program) => {
+        for (const key of allowList) {
+          if (!knownKeys.has(key)) {
+            context.report({
+              node,
+              messageId: 'invalidAllowListEntry',
+              data: { key }
+            });
+          }
+        }
       }
     };
   }

--- a/packages/eslint-local-rules/test/no-unused-i18n-messages.test.ts
+++ b/packages/eslint-local-rules/test/no-unused-i18n-messages.test.ts
@@ -71,6 +71,24 @@ ruleTester.run('no-unused-i18n-messages', noUnusedI18nMessages, {
         { messageId: 'unused', data: { key: 'unused_one' } },
         { messageId: 'unused', data: { key: 'unused_two' } }
       ]
+    },
+    {
+      name: 'declaration is not counted as reference - quoted key only in messages object',
+      code: `export const messages = {
+        used_in_code: 'a',
+        'quoted_unused_key': 'value'
+      } as const;`,
+      filename: i18nPath,
+      errors: [{ messageId: 'unused', data: { key: 'quoted_unused_key' } }]
+    },
+    {
+      name: 'allowList entry that does not exist in messages is reported',
+      code: `export const messages = {
+        used_in_code: 'a'
+      } as const;`,
+      filename: i18nPath,
+      options: [{ allowList: ['nonexistent_key'] }],
+      errors: [{ messageId: 'invalidAllowListEntry', data: { key: 'nonexistent_key' } }]
     }
   ]
 });

--- a/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
+++ b/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
@@ -1308,7 +1308,12 @@ export class ApexDebug extends LoggingDebugSession {
     const systemChannelInfo = clientInfos[0];
     const userChannelInfo = clientInfos[1];
 
-    return await this.myStreamingService.subscribe(projectPath, this.myRequestService, systemChannelInfo, userChannelInfo);
+    return await this.myStreamingService.subscribe(
+      projectPath,
+      this.myRequestService,
+      systemChannelInfo,
+      userChannelInfo
+    );
   }
 
   public handleEvent(message: DebuggerMessage): void {


### PR DESCRIPTION
- Fixes rule to correctly distinguish declarations from references — quoted keys in the messages object were previously counted as usages of themselves
- Replaces boolean used-set with reference count map for accurate detection
- Adds invalidAllowListEntry validation: allowList keys that don't exist in the messages file are reported, closing the gap where stale config entries could go unnoticed
- Refactors noDuplicateI18nValues to use AST-first visitor pattern (VariableDeclarator + Property) instead of fragile node.parent.parent navigation
- Adds test coverage for the quoted-key edge case and allowList validation

### What does this PR do?

- Fixes the `no-unused-i18n-messages` rule to correctly distinguish declarations from references — quoted keys in the messages object were previously counted as usages of themselves
- Replaces a boolean "used" set with a reference count map, enabling more accurate detection
- Adds `invalidAllowListEntry` validation: keys listed in `allowList` that don't exist in the messages file are now reported, closing the gap where stale config entries could go unnoticed
- Refactors `noDuplicateI18nValues` to use an AST-first pattern (`VariableDeclarator` + `Property` visitors) instead of fragile `node.parent.parent` navigation
- Adds test coverage for the quoted-key edge case and the new allowList validation

### What issues does this PR fix or reference?
@W-21368115@

Made-with: Cursor