### PR TITLE
docs(skills): add Effect LS diagnostics [skip-validate-pr]

### DIFF
--- a/.claude/skills/effect-best-practices/SKILL.md
+++ b/.claude/skills/effect-best-practices/SKILL.md
@@ -6,7 +6,20 @@ version: 1.1.0
 
 # Effect-TS Best Practices
 
-This skill enforces opinionated, consistent patterns for Effect-TS codebases. These patterns optimize for type safety, testability, observability, and maintainability.
+This skill enforces opinionated, consistent patterns for Effect-TS codebases.
+
+## Effect LS diagnostics (agent usage)
+
+Cursor's `read_lints` does not surface Effect Language Server diagnostics. Use the CLI:
+
+```bash
+npx effect-language-service diagnostics --file <path>
+# or whole project:
+npx effect-language-service diagnostics --project tsconfig.json
+```
+
+- Run when editing Effect code; fix reported issues (e.g. `unnecessaryFailYieldableError` → yield error directly)
+- `effect-language-service quickfixes` shows proposed code changes
 
 ## Quick Reference: Critical Rules
 

--- a/.claude/skills/verification/SKILL.md
+++ b/.claude/skills/verification/SKILL.md
@@ -9,20 +9,21 @@ Do each of these steps, in order. Do not move to a step unless all previous are 
 
 1. `npm run compile` - See [references/compile.md](references/compile.md) for commands and errors
 2. `npm run lint` - fix any new errors or warnings
-3. `npm run test` - See [references/unit-tests.md]
-4. `npm run vscode:bundle` to ensure the extensions still bundle
+3. Effect code: `npx effect-language-service diagnostics --project tsconfig.json` (or `--file <path>`) — fix reported issues; `read_lints` does not surface Effect LS
+4. `npm run test` - See [references/unit-tests.md]
+5. `npm run vscode:bundle` to ensure the extensions still bundle
 
-5. If working in packages with `test:web`/`test:desktop` scripts:
+6. If working in packages with `test:web`/`test:desktop` scripts:
    - Package-level only (not in root): `salesforcedx-vscode-core`, `salesforcedx-vscode-services` (web), `salesforcedx-vscode-org-browser`, `salesforcedx-vscode-metadata`, `salesforcedx-vscode-apex-testing`, `playwright-vscode-ext`
    - Run from root: `npm run test:web -w <package-name> -- --retries 0` / `npm run test:desktop -w <package-name> -- --retries 0` (use `--` to forward params to the underlying command)
    - Skip if not in these packages
 
-6. `npx knip` - check for dead code related to your changes
+7. `npx knip` - check for dead code related to your changes
 
 - **Fix ALL unused exports** - if knip shows unused exports, remove them immediately unless they're used for tests. Exception for [ts4023 reasons](../ts4023-effect-errors/SKILL.md)
 - Don't leave any exports that are only used within the same file
 
-7. check for dupes `npm run check:dupes` and then look in `jscpd-report` to make sure none of your changes are flagged.
+8. check for dupes `npm run check:dupes` and then look in `jscpd-report` to make sure none of your changes are flagged.
 
 ## Rules
 


### PR DESCRIPTION
### What does this PR do?
Adds Effect Language Server diagnostics guidance to effect-best-practices and verification skills. Cursor's read_lints does not surface Effect LS; agents must use the CLI.

### What issues does this PR fix or reference?
[skip-validate-pr]

Made with [Cursor](https://cursor.com)