### PR TITLE
ci: fix packaging error from templates bug

### DIFF
--- a/packages/salesforcedx-vscode-core/esbuild.config.mjs
+++ b/packages/salesforcedx-vscode-core/esbuild.config.mjs
@@ -12,14 +12,25 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const copyFiles = (src, dest) => {
+const copyTreeSanitized = (src, dest) => {
   const stats = fs.statSync(src);
-  try {
-    if (stats.isDirectory()) {
-      fs.cpSync(src, dest, { recursive: true });
-    } else {
-      fs.cpSync(src, dest);
+  if (!stats.isDirectory()) {
+    fs.cpSync(src, dest);
+    return;
+  }
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src)) {
+    const sanitized = entry.trimEnd();
+    if (sanitized !== entry) {
+      console.warn(`Sanitized filename: "${entry}" → "${sanitized}" in ${src}`);
     }
+    copyTreeSanitized(path.join(src, entry), path.join(dest, sanitized));
+  }
+};
+
+const copyFiles = (src, dest) => {
+  try {
+    copyTreeSanitized(src, dest);
     console.log(`Copied from ${src} to ${dest}`);
   } catch (error) {
     console.error('An error occurred:', error);


### PR DESCRIPTION

Root cause: @salesforce/templates ships two files with a trailing space in the filename (lds-guide-graphql.md). The esbuild config's copyFiles used fs.cpSync which preserves those filenames verbatim. When vsce package builds the vsix, the trailing space creates an invalid OPC Part URI.

Fix: Replaced the flat fs.cpSync with a recursive copyTreeSanitized that trimEnd()s each filename during the copy, and logs a warning when it does so.

The upstream fix belongs in @salesforce/templates, but this makes the build resilient to similar issues from any dependency.

https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/22685119194/job/65783398814

[skip-validate-pr]
