### PR TITLE
[W-21452352] ci: soql-common version should not be bumped during Create Release Branch

### DIFF
--- a/packages/soql-common/package.json
+++ b/packages/soql-common/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@salesforce/soql-common",
-  "version": "66.0.3",
+  "version": "1.0.0",
+  "versionedIndependently": true,
   "description": "Common SOQL parsing utilities",
   "publisher": "salesforce",
   "license": "BSD-3-Clause",

--- a/scripts/create-release-branch.js
+++ b/scripts/create-release-branch.js
@@ -8,8 +8,10 @@ const logger = require('./logger-util');
 
 const RELEASE_TYPE = process.env['RELEASE_TYPE'];
 
-// Check if package publishes (extension via vscode:publish, or npm via publishConfig)
-const shouldUpdateVersion = pkgJson => pkgJson.scripts?.['vscode:publish'] || pkgJson.publishConfig;
+// Check if package publishes (extension via vscode:publish, or npm via publishConfig),
+// but skip packages that manage their own version independently.
+const shouldUpdateVersion = pkgJson =>
+  !pkgJson.versionedIndependently && (pkgJson.scripts?.['vscode:publish'] || pkgJson.publishConfig);
 
 // Update version only in packages that publish (extensions + npm packages)
 const updatePackageVersions = nextVersion => {


### PR DESCRIPTION
### What does this PR do?
**soql-common** is an independent NPMJS package that should not share its version numbering with the extensions.

### What issues does this PR fix or reference?
@W-21452352@
