### PR TITLE
[W-21475437] fix: add back missing label when running SFDX: Create Lightning Web Component

### DIFF
--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ja.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ja.ts
@@ -25,6 +25,7 @@ export const messages: Partial<Record<MessageKey, string>> = {
   parameter_gatherer_enter_file_name: 'ファイル名を入力',
   parameter_gatherer_enter_dir_name: 'フォルダを入力 (Enter で確認または Esc でキャンセル)',
   parameter_gatherer_enter_project_name: 'プロジェクト名を入力',
+  parameter_gatherer_select_lwc_type: 'LWC コンポーネントタイプを選択',
 
   project_retrieve_start_default_org_text: 'SFDX: デフォルトのスクラッチ組織からソースをプル',
 

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -25,6 +25,7 @@ export const messages = {
   parameter_gatherer_enter_installation_key_if_necessary:
     'Enter the installation key, if required, or leave the field blank',
   parameter_gatherer_enter_project_name: 'Enter project name',
+  parameter_gatherer_select_lwc_type: 'Select LWC component type',
   project_retrieve_start_default_org_text: 'SFDX: Pull Source from Default Org',
   project_retrieve_start_ignore_conflicts_default_org_text: 'SFDX: Pull Source from Default Org and Ignore Conflicts',
   project_deploy_start_default_org_text: 'SFDX: Push Source to Default Org',


### PR DESCRIPTION
### What does this PR do?
The label for "Select LWC component type" when running **SFDX: Create Lightning Web Component** accidentally got removed.  This PR adds the label back.

### What issues does this PR fix or reference?
@W-21475437@

### Functionality Before
<img width="227" height="110" alt="Screenshot 2026-03-06 at 12 18 51 AM" src="https://github.com/user-attachments/assets/f64a6f0c-3fd6-49da-9429-2832e1730f1e" />

### Functionality After
<img width="243" height="106" alt="Screenshot 2026-03-06 at 12 40 13 AM" src="https://github.com/user-attachments/assets/420e3642-596e-47a2-824f-fbd7d12983be" />