### PR TITLE
[W-21452352] chore: bump @salesforce/soql-language-server to v0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7795,105 +7795,6 @@
       "resolved": "packages/soql-common",
       "link": true
     },
-    "node_modules/@salesforce/soql-language-server": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/soql-language-server/-/soql-language-server-0.7.1.tgz",
-      "integrity": "sha512-X2vMhKhNVVwmqvq/W4aa+XDSLnkgtMg8jHuJ5tP7INslrwyD7sXo6uubmK2HTJe1a7KT0MNCDEw2JP5ScwVwGw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@salesforce/soql-common": "0.2.1",
-        "antlr4-c3": "^1.1.13",
-        "antlr4ts": "^0.5.0-alpha.3",
-        "debounce": "^1.2.0",
-        "vscode-languageclient": "6.1.3",
-        "vscode-languageserver": "6.1.1",
-        "vscode-languageserver-protocol": "3.15.3",
-        "vscode-languageserver-textdocument": "1.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@salesforce/soql-language-server/node_modules/@salesforce/soql-common": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/soql-common/-/soql-common-0.2.1.tgz",
-      "integrity": "sha512-6/yoLlADP1PdR0I/zBBGX7U2s9lOX3JIvJaDiUivnNtM4waLUJJVOWq6XUY+NCDxJ9Du423W2AjLte5QHQOq6Q==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@salesforce/soql-language-server/node_modules/debounce": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
-      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
-      "license": "MIT"
-    },
-    "node_modules/@salesforce/soql-language-server/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@salesforce/soql-language-server/node_modules/vscode-jsonrpc": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
-      "integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0 || >=10.0.0"
-      }
-    },
-    "node_modules/@salesforce/soql-language-server/node_modules/vscode-languageclient": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-6.1.3.tgz",
-      "integrity": "sha512-YciJxk08iU5LmWu7j5dUt9/1OLjokKET6rME3cI4BRpiF6HZlusm2ZwPt0MYJ0lV5y43sZsQHhyon2xBg4ZJVA==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^6.3.0",
-        "vscode-languageserver-protocol": "^3.15.3"
-      },
-      "engines": {
-        "vscode": "^1.41.0"
-      }
-    },
-    "node_modules/@salesforce/soql-language-server/node_modules/vscode-languageserver": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-6.1.1.tgz",
-      "integrity": "sha512-DueEpkUAkD5XTR4MLYNr6bQIp/UFR0/IPApgXU3YfCBCB08u2sm9hRCs6DxYZELkk++STPjpcjksR2H8qI3cDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "vscode-languageserver-protocol": "^3.15.3"
-      },
-      "bin": {
-        "installServerIntoExtension": "bin/installServerIntoExtension"
-      }
-    },
-    "node_modules/@salesforce/soql-language-server/node_modules/vscode-languageserver-protocol": {
-      "version": "3.15.3",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz",
-      "integrity": "sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==",
-      "license": "MIT",
-      "dependencies": {
-        "vscode-jsonrpc": "^5.0.1",
-        "vscode-languageserver-types": "3.15.1"
-      }
-    },
-    "node_modules/@salesforce/soql-language-server/node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz",
-      "integrity": "sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA==",
-      "license": "MIT"
-    },
-    "node_modules/@salesforce/soql-language-server/node_modules/vscode-languageserver-types": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
-      "integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==",
-      "license": "MIT"
-    },
     "node_modules/@salesforce/source-deploy-retrieve": {
       "version": "12.31.14",
       "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.31.14.tgz",
@@ -47899,7 +47800,7 @@
         "@salesforce/effect-ext-utils": "*",
         "@salesforce/salesforcedx-utils-vscode": "*",
         "@salesforce/soql-common": "*",
-        "@salesforce/soql-language-server": "0.7.1",
+        "@salesforce/soql-language-server": "^0.8.0",
         "@salesforce/vscode-i18n": "*",
         "antlr4ts": "^0.5.0-alpha.3",
         "debounce": "^2.2.0",
@@ -48341,6 +48242,44 @@
         }
       }
     },
+    "packages/salesforcedx-vscode-soql/node_modules/@salesforce/soql-language-server": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/soql-language-server/-/soql-language-server-0.8.0.tgz",
+      "integrity": "sha512-iHW1QEDDdBhM9gy7k8CKXrmNwWz/kVezCOzV95VpAMO8O2KAN5+lgjeJdSx5VBlI4pFdOw8sH63io4dxTpRT/A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@salesforce/soql-common": "2.0.0",
+        "antlr4-c3": "^1.1.13",
+        "antlr4ts": "^0.5.0-alpha.3",
+        "debounce": "^1.2.0",
+        "vscode-languageclient": "6.1.3",
+        "vscode-languageserver": "6.1.1",
+        "vscode-languageserver-protocol": "3.15.3",
+        "vscode-languageserver-textdocument": "1.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "packages/salesforcedx-vscode-soql/node_modules/@salesforce/soql-language-server/node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "license": "MIT"
+    },
+    "packages/salesforcedx-vscode-soql/node_modules/@salesforce/soql-language-server/node_modules/vscode-languageclient": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-6.1.3.tgz",
+      "integrity": "sha512-YciJxk08iU5LmWu7j5dUt9/1OLjokKET6rME3cI4BRpiF6HZlusm2ZwPt0MYJ0lV5y43sZsQHhyon2xBg4ZJVA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.3.0",
+        "vscode-languageserver-protocol": "^3.15.3"
+      },
+      "engines": {
+        "vscode": "^1.41.0"
+      }
+    },
     "packages/salesforcedx-vscode-soql/node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
@@ -48487,6 +48426,58 @@
         "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
+    },
+    "packages/salesforcedx-vscode-soql/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "packages/salesforcedx-vscode-soql/node_modules/vscode-jsonrpc": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
+      "integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0 || >=10.0.0"
+      }
+    },
+    "packages/salesforcedx-vscode-soql/node_modules/vscode-languageserver": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-6.1.1.tgz",
+      "integrity": "sha512-DueEpkUAkD5XTR4MLYNr6bQIp/UFR0/IPApgXU3YfCBCB08u2sm9hRCs6DxYZELkk++STPjpcjksR2H8qI3cDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "^3.15.3"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "packages/salesforcedx-vscode-soql/node_modules/vscode-languageserver-protocol": {
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz",
+      "integrity": "sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "^5.0.1",
+        "vscode-languageserver-types": "3.15.1"
+      }
+    },
+    "packages/salesforcedx-vscode-soql/node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz",
+      "integrity": "sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA==",
+      "license": "MIT"
+    },
+    "packages/salesforcedx-vscode-soql/node_modules/vscode-languageserver-types": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
+      "integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==",
+      "license": "MIT"
     },
     "packages/salesforcedx-vscode-visualforce": {
       "version": "66.0.3",

--- a/packages/salesforcedx-vscode-soql/esbuild.config.mjs
+++ b/packages/salesforcedx-vscode-soql/esbuild.config.mjs
@@ -6,7 +6,10 @@
  */
 import { build } from 'esbuild';
 import copy from 'esbuild-plugin-copy';
+import { createRequire } from 'node:module';
 import { nodeConfig } from '../../scripts/bundling/node.mjs';
+
+const require = createRequire(import.meta.url);
 
 const commonConfig = {
   external: ['vscode']
@@ -38,6 +41,6 @@ await build({
 await build({
   ...nodeConfig,
   ...commonConfig,
-  entryPoints: ['../../node_modules/@salesforce/soql-language-server/lib/server.js'],
+  entryPoints: [require.resolve('@salesforce/soql-language-server/lib/server.js')],
   outfile: './dist/server.js'
 });

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -39,7 +39,7 @@
     "effect": "^3.19.14",
     "@salesforce/salesforcedx-utils-vscode": "*",
     "@salesforce/soql-common": "*",
-    "@salesforce/soql-language-server": "0.7.1",
+    "@salesforce/soql-language-server": "^0.8.0",
     "@salesforce/vscode-i18n": "*",
     "antlr4ts": "^0.5.0-alpha.3",
     "debounce": "^2.2.0",


### PR DESCRIPTION
### What does this PR do?
Updates `@salesforce/soql-language-server` to v0.8.0, which is the version that uses v2.0.0 of `@salesforce/soql-common`.

### What issues does this PR fix or reference?
@W-21452352@

### Testing

* SFDX: Execute SOQL Query... ✅
* SFDX: Execute SOQL Query With Currently Selected Text ✅
* SFDX: Create Query in SOQL Builder ✅
* SOQL Builder works ✅
* Can save the SOQL query ✅

In a .soql file
- Autocompletion ✅
- Correct coloring ✅

<img width="1229" height="584" alt="Screenshot 2026-03-06 at 4 58 46 PM" src="https://github.com/user-attachments/assets/a3163704-2c94-470d-94ac-8286d802dfce" />

<img width="430" height="199" alt="Screenshot 2026-03-06 at 4 59 00 PM" src="https://github.com/user-attachments/assets/021651c0-d9d4-485b-b0de-aba84f90a828" />