### PR TITLE
ci(verification): force verification when AIs stop W-21490816

### DIFF
--- a/.cursor/agents/verifier.md
+++ b/.cursor/agents/verifier.md
@@ -1,0 +1,24 @@
+---
+name: verifier
+description: Validates completed work. Use after tasks are marked done to confirm implementations are functional. Run compile, lint, effect LS (uncommitted .ts only), test, vscode:bundle, knip. Report pass/fail only; do NOT fix.
+model: cursor-composer-1.5
+---
+
+You are a skeptical validator. Your job is to verify that work claimed as complete actually passes verification.
+
+Run these steps in order from the repo root. Stop at first failure. Report pass/fail for each step. Do NOT fix anything — only report.
+
+1. **compile** — `npm run compile`
+2. **lint** — `npm run lint`
+3. **effect LS** — For each uncommitted .ts file (`git diff --name-only HEAD`), run `npx effect-language-service diagnostics --file <path>`. Skip if none.
+4. **test** — `npm run test`
+5. **vscode:bundle** — `npm run vscode:bundle`
+6. **knip** — `npx -y knip`
+
+**Wireit:** The user may have `--watch` running. Wireit "all cached" / no-op output is success, not failure. Do not treat cache hits as problems.
+
+Report:
+
+- What passed
+- What failed (with error summary)
+- Do not accept claims at face value — run the commands

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "hooks": {
+    "stop": [{ "command": ".cursor/hooks/verify-stop.sh" }]
+  }
+}

--- a/.cursor/hooks/verify-stop.sh
+++ b/.cursor/hooks/verify-stop.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Stop hook: run compile, lint, effect LS (uncommitted .ts only), test, vscode:bundle.
+# On first failure, output followup_message for agent to fix. Wireit cache hits = success.
+# stderr → Hooks output channel
+set -e
+
+ROOT="${CURSOR_PROJECT_DIR:-.}"
+cd "$ROOT"
+echo "[verify-stop] starting" >&2
+
+fail() {
+  local step="$1"
+  local out="$2"
+  # Strip control chars (incl. ANSI codes) so JSON stays valid; escape \ " for JSON
+  local err
+  err=$(printf '%s' "$out" | head -c 500 | tr -d '\000-\037\177' | tr '\n' ' ' | sed 's/\\/\\\\/g; s/"/\\"/g')
+  echo "[verify-stop] failed: $step" >&2
+  echo "{\"followup_message\": \"Verification failed: $step — $err. Fix and re-run verification.\"}"
+  exit 0
+}
+
+run_step() {
+  local step="$1"
+  local cmd="$2"
+  local out
+  out=$(eval "$cmd" 2>&1) || fail "$step" "$out"
+}
+
+run_step "compile" "npm run compile" && echo "[verify-stop] compile ok" >&2
+run_step "lint" "npm run lint" && echo "[verify-stop] lint ok" >&2
+
+# Effect LS: only uncommitted .ts files
+ts_files=$(git diff --name-only HEAD 2>/dev/null | grep '\.ts$' || true)
+if [ -n "$ts_files" ]; then
+  for f in $ts_files; do
+    [ -f "$f" ] && run_step "effect LS ($f)" "npx effect-language-service diagnostics --file $f"
+  done
+fi
+[ -z "$ts_files" ] && echo "[verify-stop] effect LS skipped (no uncommitted .ts)" >&2
+
+run_step "test" "npm run test" && echo "[verify-stop] test ok" >&2
+run_step "vscode:bundle" "npm run vscode:bundle" && echo "[verify-stop] vscode:bundle ok" >&2
+echo "[verify-stop] all passed" >&2

--- a/.cursor/rules/verification.mdc
+++ b/.cursor/rules/verification.mdc
@@ -4,3 +4,7 @@ alwaysApply: true
 ---
 
 After making code changes, follow the verification checklist in .claude/skills/verification/SKILL.md: compile, lint, test, bundle, knip, check:dupes.
+
+Delegate to the verifier subagent (@.cursor/agents/verifier.md) to confirm verification passes. The verifier runs compile, lint, effect LS, test, vscode:bundle, knip and reports pass/fail; do not fix in the verifier — parent fixes.
+
+A stop hook runs compile, lint, effect LS, test, vscode:bundle when the agent stops (knip excluded — repo has pre-existing unused files). If verification fails, the agent continues with a fix instruction.


### PR DESCRIPTION
### What does this PR do?

Cursor stop hook + verifier subagent to run compile, lint, effect LS, test, vscode:bundle when agent stops. Returns followup_message on failure so agent continues with fix instruction.

### What issues does this PR fix or reference?
@W-21490816@

Made with [Cursor](https://cursor.com)