### PR TITLE
[W-21474821] refactor: remove isSalesforceProjectOpened, replace with ProjectService

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/commands/preconditionCheckers.ts
+++ b/packages/salesforcedx-utils-vscode/src/commands/preconditionCheckers.ts
@@ -5,24 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import * as path from 'node:path';
-import { SFDX_PROJECT_FILE } from '../constants';
-import { fileOrFolderExists } from '../helpers/fs';
-import { nls } from '../messages/messages';
-import { workspaceUtils } from '../workspaces/workspaceUtils';
-
 export type PreconditionChecker = {
   check(): Promise<boolean> | boolean;
-};
-
-export const isSalesforceProjectOpened = async (): Promise<
-  { result: true; message?: never } | { result: false; message: string }
-> => {
-  if (!workspaceUtils.hasRootWorkspace()) {
-    return { result: false, message: nls.localize('predicates_no_folder_opened_text') };
-  }
-  if (!(await fileOrFolderExists(path.join(workspaceUtils.getRootWorkspacePath(), SFDX_PROJECT_FILE)))) {
-    return { result: false, message: nls.localize('predicates_no_salesforce_project_found_text') };
-  }
-  return { result: true };
 };

--- a/packages/salesforcedx-utils-vscode/src/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/index.ts
@@ -13,7 +13,6 @@ export {
   EmptyParametersGatherer,
   type FlagParameter
 } from './commands/parameterGatherers';
-export { isSalesforceProjectOpened } from './commands/preconditionCheckers';
 export { SfCommandletExecutor, LibraryCommandletExecutor } from './commands/commandletExecutors';
 export { SfCommandlet } from './commands/sfCommandlet';
 export { ConfigUtil } from './config/configUtil';

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -4,13 +4,12 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
+import { ExtensionProviderService, getServicesApi } from '@salesforce/effect-ext-utils';
 import {
   ActivationTracker,
   ChannelService,
   ensureCurrentWorkingDirIsProjectPath,
   getRootWorkspacePath,
-  isSalesforceProjectOpened,
   notificationService,
   ProgressNotification,
   SFDX_CORE_CONFIGURATION_NAME,
@@ -20,6 +19,7 @@ import {
 } from '@salesforce/salesforcedx-utils-vscode';
 import { RegistryAccess } from '@salesforce/source-deploy-retrieve';
 import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
@@ -245,8 +245,15 @@ export const activate = async (extensionContext: vscode.ExtensionContext): Promi
     return api;
   }
 
-  // Context
-  const salesforceProjectOpened = (await isSalesforceProjectOpened()).result;
+  // Context — ProjectService.isSalesforceProject() sets sf:project_opened as a side effect
+  const salesforceProjectOpened = await Effect.runPromise(
+    Effect.gen(function* () {
+      const servicesApi = yield* getServicesApi;
+      return yield* servicesApi.services.ProjectService.isSalesforceProject().pipe(
+        Effect.provide(Layer.succeedContext(servicesApi.services.prebuiltServicesDependencies))
+      );
+    }).pipe(Effect.catchAllCause(() => Effect.succeed(false)))
+  );
 
   // TODO: move this and the replay debugger commands to the apex extension
   void vscode.commands.executeCommand(
@@ -254,8 +261,6 @@ export const activate = async (extensionContext: vscode.ExtensionContext): Promi
     'sf:replay_debugger_extension',
     vscode.extensions.getExtension('salesforce.salesforcedx-vscode-apex-replay-debugger') !== undefined
   );
-
-  void vscode.commands.executeCommand('setContext', 'sf:project_opened', salesforceProjectOpened);
 
   // Set Code Builder context
   const codeBuilderEnabled = process.env.CODE_BUILDER === 'true';

--- a/packages/salesforcedx-vscode-core/src/salesforceProject/salesforceProjectConfig.ts
+++ b/packages/salesforcedx-vscode-core/src/salesforceProject/salesforceProjectConfig.ts
@@ -5,8 +5,11 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { SfProject, SfProjectJson } from '@salesforce/core/project';
-import { isSalesforceProjectOpened, notificationService, workspaceUtils } from '@salesforce/salesforcedx-utils-vscode';
+import { getServicesApi } from '@salesforce/effect-ext-utils';
+import { notificationService, workspaceUtils } from '@salesforce/salesforcedx-utils-vscode';
 import { JsonArray } from '@salesforce/ts-types';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { SFDX_PROJECT_FILE } from '../constants';
@@ -24,7 +27,15 @@ export default class SalesforceProjectConfig {
   }
 
   private static async initializeSalesforceProjectConfig() {
-    if (!SalesforceProjectConfig.instance && (await isSalesforceProjectOpened()).result) {
+    const isProject = await Effect.runPromise(
+      Effect.gen(function* () {
+        const api = yield* getServicesApi;
+        return yield* api.services.ProjectService.isSalesforceProject().pipe(
+          Effect.provide(Layer.succeedContext(api.services.prebuiltServicesDependencies))
+        );
+      }).pipe(Effect.catchAllCause(() => Effect.succeed(false)))
+    );
+    if (!SalesforceProjectConfig.instance && isProject) {
       const salesforceProjectPath = workspaceUtils.getRootWorkspacePath();
       try {
         const salesforceProject = await SfProject.resolve(salesforceProjectPath);


### PR DESCRIPTION
Removes `isSalesforceProjectOpened` from `salesforcedx-utils-vscode` and replaces its two remaining usages in `salesforcedx-vscode-core` with `ProjectService.isSalesforceProject()` from the services extension.
- `core/src/index.ts` (activation): replaced with an Effect-based `getServicesApi` call; removed the now-redundant explicit `sf:project_opened` `setContext` (the `ProjectService` sets it as a side effect)
- `salesforceProjectConfig.ts`: same replacement pattern for the project guard
- `preconditionCheckers.ts`: deleted `isSalesforceProjectOpened` and its unused imports; `PreconditionChecker` type remains
- `salesforcedx-utils-vscode/src/index.ts`: removed the export
### What issues does this PR fix or reference?
@W-21474821@