### PR TITLE
refactor(telemetry): maintain pft once initialized W-21528130

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
+++ b/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
@@ -196,7 +196,13 @@ export class TelemetryService implements TelemetryServiceInterface {
     const userId = await UserService.getTelemetryUserId(extensionContext);
     const webUserId = await getWebTelemetryUserId(extensionContext, this.getSharedTelemetryProvider(extensionContext));
 
-    const { productFeatureId } = extensionPackageJsonSchema.parse(extensionContext.extension.packageJSON);
+    // priority: extension specific one, OR core default one, OR original one
+    const { productFeatureId: thisExtensionPftId } = extensionPackageJsonSchema.parse(
+      this.extensionContext!.extension.packageJSON
+    );
+    const { productFeatureId: coreEtensionPftId } = extensionPackageJsonSchema.parse(
+      extensionContext.extension.packageJSON
+    );
     this.reporters
       .filter(r => r instanceof AppInsights || r instanceof O11yReporter)
       .map(r => {
@@ -205,7 +211,9 @@ export class TelemetryService implements TelemetryServiceInterface {
         return r;
       })
       .filter(r => r instanceof O11yReporter)
-      .map(r => (r.productFeatureId = productFeatureId ?? r.productFeatureId));
+      // don't overwrite PFT if already set
+      .filter(r => r.productFeatureId === undefined)
+      .map(r => (r.productFeatureId = thisExtensionPftId ?? coreEtensionPftId));
   }
 
   public async isTelemetryEnabled(): Promise<boolean> {


### PR DESCRIPTION
### What does this PR do?

Don't overwrite productFeatureId on shared telemetry reporters once set. Only set PFT on reporters where it is undefined.

### What issues does this PR fix or reference?
@W-21528130@

Made with [Cursor](https://cursor.com)