### PR TITLE
ci: more local checks W-21532785

### DIFF
--- a/package.json
+++ b/package.json
@@ -362,18 +362,28 @@
       ],
       "output": []
     },
+    "check:lock-sync": {
+      "command": "npm ci --dry-run",
+      "files": [
+        "package.json",
+        "package-lock.json"
+      ],
+      "output": []
+    },
     "precommit": {
       "dependencies": [
         "compile",
         "lint",
         "check:peer-deps",
         "check:typescript-project-references",
-        "check:package-lock"
+        "check:package-lock",
+        "check:lock-sync"
       ]
     },
     "prepush": {
       "dependencies": [
-        "lint",
+        "precommit",
+        "vscode:bundle",
         "test"
       ]
     },


### PR DESCRIPTION
### What does this PR do?
Adds lock-sync verification to precommit and expands prepush to run precommit, vscode:bundle, and test.

- **check:lock-sync**: `npm ci --dry-run` verifies package-lock.json is in sync with package.json
- **prepush**: now runs precommit, vscode:bundle, test (was lint, test only)

### What issues does this PR fix or reference?
@W-21532785@