### PR TITLE
[W-21532462] fix: when executing a SOQL query, show row count at the bottom of the Output Tab instead of at the top

### DIFF
--- a/packages/salesforcedx-vscode-soql/src/commands/dataQuery.ts
+++ b/packages/salesforcedx-vscode-soql/src/commands/dataQuery.ts
@@ -37,6 +37,7 @@ class DataQueryExecutor {
       const connection = await getConnection();
       const queryResult = await runSoqlQuery(connection, query, api === 'TOOLING');
       displayTableResults(queryResult);
+      channelService.appendLine(nls.localize('data_query_complete', queryResult.totalSize));
       await this.saveResultsToCSV(queryResult);
     } catch (error) {
       channelService.appendLine(formatErrorMessage(error));
@@ -458,8 +459,6 @@ const runSoqlQuery = async (connection: Connection, query: string, useTooling = 
       nls.localize('data_query_warning_limit', missingRecords, maxFetch, result.totalSize, maxFetch)
     );
   }
-
-  channelService.appendLine(nls.localize('data_query_complete', result.totalSize));
 
   return result;
 };


### PR DESCRIPTION
### What does this PR do?
Moves the row count to the bottom of the Output Tab for **SFDX: Execute SOQL Query** and **SFDX: Execute SOQL Query with Currently Selected Text**.

### What issues does this PR fix or reference?
#6943, @W-21532462@

### Functionality Before
```
Running query...
Query complete with 13 records returned

=== Query Results
Id                  Name                                 AnnualRevenue
──────────────────  ───────────────────────────────────  ─────────────
001Hr00001lNW3NIAW  United Oil & Gas Corp.               5600000000   
001Hr00001lNW3KIAW  Pyramid Construction Inc.            950000000    
001Hr00001lNW3OIAW  Express Logistics and Transport      950000000    
001Hr00001lNW3MIAW  Grand Hotels & Resorts Ltd           500000000    
001Hr00001lNW3JIAW  Burlington Textiles Corp of America  350000000    
001Hr00001lNW3IIAW  Edge Communications                  139000000    
001Hr00001lNW3LIAW  Dickenson plc                        50000000     
001Hr00001lNW3SIAW  GenePoint                            30000000     
001Hr00001lNW3RIAW  United Oil & Gas, Singapore                       
001Hr00001jwcmvIAA  Sample Account for Entitlements                   
001Hr00001lNW3PIAW  University of Arizona                             
001Hr00001lNW3QIAW  United Oil & Gas, UK                              
001Hr00001lNW3TIAW  sForce  
```

### Functionality After
```
Running query...

=== Query Results
Id                  Name                                 AnnualRevenue
──────────────────  ───────────────────────────────────  ─────────────
001Hr00001lNW3NIAW  United Oil & Gas Corp.               5600000000   
001Hr00001lNW3KIAW  Pyramid Construction Inc.            950000000    
001Hr00001lNW3OIAW  Express Logistics and Transport      950000000    
001Hr00001lNW3MIAW  Grand Hotels & Resorts Ltd           500000000    
001Hr00001lNW3JIAW  Burlington Textiles Corp of America  350000000    
001Hr00001lNW3IIAW  Edge Communications                  139000000    
001Hr00001lNW3LIAW  Dickenson plc                        50000000     
001Hr00001lNW3SIAW  GenePoint                            30000000     
001Hr00001lNW3RIAW  United Oil & Gas, Singapore                       
001Hr00001jwcmvIAA  Sample Account for Entitlements                   
001Hr00001lNW3PIAW  University of Arizona                             
001Hr00001lNW3QIAW  United Oil & Gas, UK                              
001Hr00001lNW3TIAW  sForce                                            

Query complete with 13 records returned
```
