### PR TITLE
chore(deps): group @salesforce/* dependabot updates @W-21361802@

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,10 @@ updates:
       day: 'wednesday'
       time: '06:00'
       timezone: 'America/Los_Angeles'
+    groups:
+      salesforce-deps:
+        patterns:
+          - '@salesforce/*'
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-major']


### PR DESCRIPTION
### What does this PR do?
Adds a dependabot `groups` entry so minor/patch updates for all `@salesforce/*` packages (e.g. `@salesforce/templates`, `@salesforce/ts-types`, `@salesforce/vscode-i18n`, `@salesforce/core`) are batched into a single PR instead of competing for the open-PR limit.

### What issues does this PR fix or reference?
@W-21361802@

### Functionality Before
Dependabot opens separate PRs per dependency; `@salesforce/*` updates can be starved by the limit of 3.

### Functionality After
`@salesforce/*` updates are grouped into one PR per run.