### PR TITLE
W-21630880  build(changelog): support non-alpha scopes in TYPE_REGEX

### DIFF
--- a/scripts/change-log-constants.js
+++ b/scripts/change-log-constants.js
@@ -14,6 +14,6 @@ module.exports = Object.freeze({
   RELEASE_REGEX: new RegExp(/^origin\/release\/v\d{2}\.\d{1,2}\.\d/),
   PR_REGEX: new RegExp(/(\(#\d+\))/),
   COMMIT_REGEX: new RegExp(/^([\da-zA-Z]+)/),
-  TYPE_REGEX: new RegExp(/([a-zA-Z]+)(?:\([a-zA-Z]+\))?:/),
+  TYPE_REGEX: new RegExp(/([a-zA-Z]+)(?:\([\w-]+\))?:/),
   GUS_WI_REGEX: new RegExp(/\[W-\d+\]\s*/g)
 });


### PR DESCRIPTION
## Summary

- Fix `TYPE_REGEX` in `scripts/change-log-constants.js` to support conventional commit scopes containing hyphens, digits, or underscores (e.g. `fix(lwc-lsp):`, `feat(org-browser):`, `feat(apex2):`)
- Previously, the scope pattern `(?:\([a-zA-Z]+\))?` only allowed pure alpha characters. Scopes with hyphens or digits caused `TYPE_REGEX.exec()` to return `null`, leaving `map[TYPE]` unset — which caused `generateKey` to silently drop the PR entry from the generated changelog entirely
- Fix: change the scope character class from `[a-zA-Z]+` to `[\w-]+`

## Root Cause

```js
// Before — scope only allows [a-zA-Z]+
TYPE_REGEX: new RegExp(/([a-zA-Z]+)(?:\([a-zA-Z]+\))?:/),

// After — scope allows word chars + hyphen
TYPE_REGEX: new RegExp(/([a-zA-Z]+)(?:\([\w-]+\))?:/),
```

For a commit like `feat(org-browser): make new org browser the only org browser (#6988)`, the scope `org-browser` contains a hyphen. The regex failure propagated: `buildMapFromCommit` → `generateKey` (returned `''` due to `!type` guard) → PR silently dropped.

## Validation — Changelog scan since v66.1.1

Running the fixed filter against `origin/develop...origin/release/v66.1.1` shows **9 PRs** correctly included:

| PR | Category | Message |
|----|----------|---------|
| #6996 | Added | New command "SFDX: Create SOQL Query" |
| #6995 | Fixed | Preserve SELECT column order in SOQL query output when fields have null values |
| **#6988** | **Added** | **Make new org browser the only org browser** *(previously dropped)* |
| #6987 | Added | Change trace flag debug level |
| #6981 | Added | SFDX: Create Query in SOQL Builder asks for filename before creating |
| #6980 | Fixed | Run Apex Tests from org; display short name, send full class name |
| #6967 | Fixed | Auto-populate Test Controller after org authorization |
| #6975 | Fixed | When executing a SOQL query, show row count at the bottom of the Output Tab |
| #6965 | Added | Setup vscode-languageclient/browser |

PR #6988 (`feat(org-browser):`) was the specific reproducer — it is now correctly included.

14 PRs remain correctly excluded (`chore`, `refactor`, `ci`, `test` types, and merge/version-bump commits without PR numbers).

## Test plan

- [ ] Verify `scripts/change-log-constants.js` `TYPE_REGEX` matches `fix(lwc-lsp):`, `feat(apex2):`, `fix:`, `feat(scope):` — all capturing the correct type group
- [ ] Run changelog generation and confirm PR #6988 appears in the output

@W-21630880@