### PR TITLE
test(playwright): allow appinsights e2e network errors

### DIFF
--- a/packages/playwright-vscode-ext/src/utils/helpers.ts
+++ b/packages/playwright-vscode-ext/src/utils/helpers.ts
@@ -64,6 +64,7 @@ const NON_CRITICAL_NETWORK_PATTERNS: readonly string[] = [
   'webPackagePaths.js',
   'workbench.web.main.nls.js',
   'marketplace.visualstudio.com',
+  'in.applicationinsights.azure.com', // Azure Application Insights telemetry (e.g. /v2/track)
   'vscode-unpkg.net', // VS Code extension marketplace CDN
   'scratchOrgInfo', // asking the org if it's a devhub during auth ?
   'Package2Member', // Tooling API Package2Member can return 400 in scratch orgs; apex-testing handles it and falls back


### PR DESCRIPTION
### What does this PR do?

[skip-validate-pr]

Adds `in.applicationinsights.azure.com` to non-critical network patterns so e2e tests don't fail on Application Insights telemetry (e.g. /v2/track).

### What issues does this PR fix or reference?
N/A

Made with [Cursor](https://cursor.com)