### PR TITLE
[W-21636406] ci: soql-common releases should not trigger Publish to Microsoft Marketplace and Publish to Open VSX Registry workflows

### DIFF
--- a/.github/workflows/publishOpenVSX.yml
+++ b/.github/workflows/publishOpenVSX.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   prepare-environment-from-main:
     name: 'Get Release Version'
+    if: github.event_name != 'release' || !startsWith(github.event.release.tag_name, 'soql-common')
     runs-on: ubuntu-latest
     environment: publish
     outputs:

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   prepare-environment-from-main:
     name: 'Get Release Version'
+    if: github.event_name != 'release' || !startsWith(github.event.release.tag_name, 'soql-common')
     runs-on: ubuntu-latest
     environment: publish
     outputs:


### PR DESCRIPTION
### What does this PR do?
**soql-common** releases were unintentionally triggering the **Publish to Microsoft Marketplace** and **Publish to Open VSX Registry** workflows.  This PR removes the accidental trigger.

### What issues does this PR fix or reference?
@W-21636406@
