### PR TITLE
W-21616134: trigger CBW release after publishing extensions to marketplace

### DIFF
--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -84,9 +84,11 @@ jobs:
       changeCaseId: ${{ needs.ctc-open.outputs.changeCaseId }}
       status: Not Implemented
 
+  # Set repo variable CBW_TRIGGER_ENABLED=false to disable dispatch to code-builder-web.
+  # Default (unset): dispatch after publish. Use when publishing without CBW promotion.
   trigger-cbw-release:
     needs: [publish, prepare-environment-from-main]
-    if: needs.publish.result == 'success'
+    if: needs.publish.result == 'success' && vars.CBW_TRIGGER_ENABLED != 'false'
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:

--- a/contributing/publishing.md
+++ b/contributing/publishing.md
@@ -80,6 +80,8 @@ find ~/Downloads/v64.8.0 -type f -name "*.vsix" -exec code --install-extension {
 
 After completing your release testing following our internal template, approve the publish job "Publish in Microsoft Marketplace" and "Publish in Open VSX Registry" to allow the extensions to be uploaded and complete the release process.
 
+**Code Builder Web promotion:** After publishing to the MS Marketplace, the workflow dispatches to `code-builder-web` to trigger a CBW release and auto-promote to production. Set repo variable `CBW_TRIGGER_ENABLED=false` (Settings → Secrets and variables → Actions → Variables) to publish without triggering CBW. Default (unset) enables the trigger.
+
 ## Troubleshooting
 
 - 401 errors on publish? You probably need to update the VSCE PAT. https://salesforce.quip.com/E8GWA5TuI8jp


### PR DESCRIPTION
## Summary

- Add `trigger-cbw-release` job to `publishVSCode.yml` that fires a `repository_dispatch` event to `forcedotcom/code-builder-web` after extensions are successfully published to the MS Marketplace.
- Fire-and-forget — sends a single API call with the published version in the payload and does not block CTC close jobs.
- Uses existing `IDEE_GH_TOKEN` (scope updated to include `code-builder-web` repo).

Work item: @W-21616134@

**Companion PR**: In `forcedotcom/code-builder-web` — adds the `promote-on-publish.yml` receiver workflow and `auto-promote` support in `release.yml`.

## Test plan

- [ ] Verify `trigger-cbw-release` job runs after `publish` succeeds and sends the dispatch
- [ ] Verify CTC close jobs are unaffected (no new dependency)
- [x] Verify `IDEE_GH_TOKEN` has `repo` scope on `forcedotcom/code-builder-web`