### PR TITLE
fix(metadata): hide LWC command when no project open W-21668883

### DIFF
--- a/packages/playwright-vscode-ext/src/fixtures/createDesktopTest.ts
+++ b/packages/playwright-vscode-ext/src/fixtures/createDesktopTest.ts
@@ -15,7 +15,7 @@ import * as path from 'node:path';
 
 import { filterErrors } from '../utils/helpers';
 import { resolveRepoRoot } from '../utils/repoRoot';
-import { createTestWorkspace } from './desktopWorkspace';
+import { createEmptyTestWorkspace, createTestWorkspace } from './desktopWorkspace';
 
 /** Close timeout before force-kill (non-macOS-CI path). */
 const CLOSE_TIMEOUT_MS = 5000;
@@ -40,6 +40,8 @@ type CreateDesktopTestOptions = {
   /** __dirname from the calling extension's fixture file (e.g., '<pkg>/test/playwright/fixtures') */
   fixturesDir: string;
   orgAlias?: string;
+  /** When true, use empty workspace (no sfdx-project.json). Default false. */
+  emptyWorkspace?: boolean;
   /** Additional extension directory names to load (ex: ['salesforcedx-vscode-metadata'] for apex-testing "SFDX: Create Apex Class") */
   additionalExtensionDirs?: string[];
   /** When false, do not pass --disable-extensions (needed when loading multiple dev extensions). Default true. */
@@ -50,7 +52,14 @@ type CreateDesktopTestOptions = {
 
 /** Creates a Playwright test instance configured for desktop Electron testing with services extension */
 export const createDesktopTest = (options: CreateDesktopTestOptions) => {
-  const { fixturesDir, orgAlias, additionalExtensionDirs = [], disableOtherExtensions = true, userSettings } = options;
+  const {
+    fixturesDir,
+    orgAlias,
+    emptyWorkspace = false,
+    additionalExtensionDirs = [],
+    disableOtherExtensions = true,
+    userSettings
+  } = options;
 
   const test = base.extend<TestFixtures, WorkerFixtures>({
     // Download VS Code once per worker (cached at repo root .vscode-test/)
@@ -67,7 +76,7 @@ export const createDesktopTest = (options: CreateDesktopTestOptions) => {
 
     // Create workspace directory (shared with electronApp so tests can access path)
     workspaceDir: async ({}, use): Promise<void> => {
-      const dir = await createTestWorkspace(orgAlias);
+      const dir = emptyWorkspace ? await createEmptyTestWorkspace() : await createTestWorkspace(orgAlias);
       await use(dir);
     },
 

--- a/packages/playwright-vscode-ext/src/fixtures/desktopWorkspace.ts
+++ b/packages/playwright-vscode-ext/src/fixtures/desktopWorkspace.ts
@@ -11,6 +11,10 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { DREAMHOUSE_ORG_ALIAS } from '../orgs/dreamhouseScratchOrgSetup';
 
+/** Create a temporary empty workspace directory (no sfdx-project.json) for desktop tests */
+export const createEmptyTestWorkspace = async (): Promise<string> =>
+  fs.mkdtemp(path.join(os.tmpdir(), 'vscode-e2e-empty-'));
+
 /** Create a temporary workspace directory with sfdx-project.json for desktop tests */
 export const createTestWorkspace = async (orgAlias = DREAMHOUSE_ORG_ALIAS): Promise<string> => {
   const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vscode-e2e-test-'));

--- a/packages/salesforcedx-vscode-metadata/package.json
+++ b/packages/salesforcedx-vscode-metadata/package.json
@@ -326,6 +326,10 @@
         {
           "command": "sf.metadata.project.generate.manifest",
           "when": "isFileSystemResource && salesforcedx-vscode-metadata.showSharedCommands && sf:project_opened && resourceLangId != 'forcesourcemanifest'"
+        },
+        {
+          "command": "sf.metadata.lightning.generate.lwc",
+          "when": "sf:project_opened"
         }
       ],
       "editor/context": [

--- a/packages/salesforcedx-vscode-metadata/test/playwright/fixtures/desktopFixtures.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/fixtures/desktopFixtures.ts
@@ -18,3 +18,4 @@ export const dreamhouseDesktopTest = createDesktopTest({
   orgAlias: DREAMHOUSE_ORG_ALIAS
 });
 export const nonTrackingDesktopTest = createDesktopTest({ fixturesDir: __dirname, orgAlias: NON_TRACKING_ORG_ALIAS });
+export const emptyWorkspaceDesktopTest = createDesktopTest({ fixturesDir: __dirname, emptyWorkspace: true });

--- a/packages/salesforcedx-vscode-metadata/test/playwright/fixtures/index.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/fixtures/index.ts
@@ -24,3 +24,4 @@ webTest.afterEach(async ({ page }, testInfo) => {
 export const test = isDesktop ? desktopTest : webTest;
 export const dreamhouseTest = isDesktop ? dreamhouseDesktopTest : webTest;
 export const nonTrackingTest = isDesktop ? nonTrackingDesktopTest : webTest;
+export { emptyWorkspaceDesktopTest } from './desktopFixtures';

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/noProjectCommandsHidden.headless.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/noProjectCommandsHidden.headless.spec.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { emptyWorkspaceDesktopTest } from '../fixtures';
+import {
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  waitForVSCodeWorkbench,
+  assertWelcomeTabExists,
+  closeWelcomeTabs,
+  ensureSecondarySideBarHidden,
+  verifyCommandDoesNotExist,
+  validateNoCriticalErrors,
+  isDesktop
+} from '@salesforce/playwright-vscode-ext';
+import packageNls from '../../../package.nls.json';
+
+(isDesktop() ? emptyWorkspaceDesktopTest : emptyWorkspaceDesktopTest.skip.bind(emptyWorkspaceDesktopTest))(
+  'No project: LWC create and deploy/retrieve/delete commands hidden',
+  async ({ page }) => {
+    const consoleErrors = setupConsoleMonitoring(page);
+    const networkErrors = setupNetworkMonitoring(page);
+
+    await emptyWorkspaceDesktopTest.step('setup with empty workspace', async () => {
+      await waitForVSCodeWorkbench(page);
+      await assertWelcomeTabExists(page);
+      await closeWelcomeTabs(page);
+      await ensureSecondarySideBarHidden(page);
+    });
+
+    await emptyWorkspaceDesktopTest.step('verify LWC create does not exist', async () => {
+      await verifyCommandDoesNotExist(page, packageNls.lightning_generate_lwc_text);
+    });
+
+    await emptyWorkspaceDesktopTest.step('verify deploy/retrieve/delete/generate manifest do not exist', async () => {
+      await verifyCommandDoesNotExist(page, packageNls.project_deploy_start_default_org_text);
+      await verifyCommandDoesNotExist(page, packageNls.project_deploy_start_ignore_conflicts_default_org_text);
+      await verifyCommandDoesNotExist(page, packageNls.project_retrieve_start_default_org_text);
+      await verifyCommandDoesNotExist(page, packageNls.project_retrieve_start_ignore_conflicts_default_org_text);
+      await verifyCommandDoesNotExist(page, packageNls.deploy_this_source_text);
+      await verifyCommandDoesNotExist(page, packageNls.deploy_in_manifest_text);
+      await verifyCommandDoesNotExist(page, packageNls.retrieve_this_source_text);
+      await verifyCommandDoesNotExist(page, packageNls.retrieve_in_manifest_text);
+      await verifyCommandDoesNotExist(page, packageNls.delete_source_text);
+      await verifyCommandDoesNotExist(page, packageNls.project_generate_manifest_text);
+    });
+
+    await validateNoCriticalErrors(emptyWorkspaceDesktopTest, consoleErrors, networkErrors);
+  }
+);


### PR DESCRIPTION
### What does this PR do?
Adds a when clause so the LWC create command is hidden when no Salesforce project is open.

### What issues does this PR fix or reference?
@W-21668883@

Made with [Cursor](https://cursor.com)