### PR TITLE
feat: add support for creating agent project templates @W-21522177

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -477,6 +477,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -517,7 +518,6 @@
       "integrity": "sha512-QGmsKi2PBO/MHSQk+AAgA9R6OHQr+VqnniFE0eMWZcVcfBZoA2dKn2hUsl3Csg/Plt9opRUWdY7//VXsrIlEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
         "eslint-visitor-keys": "^2.1.0",
@@ -537,7 +537,6 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -2166,6 +2165,7 @@
       "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.94.5.tgz",
       "integrity": "sha512-z05APUiDDPbodhTkH/RJqOLoCU11bU2IZLfcwLFrld03+ob1VeqRnELQlmueLIYm6NZifHAtjl32V+GRt34y4A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "find-my-way-ts": "^0.1.6",
         "msgpackr": "^1.11.4",
@@ -2883,6 +2883,7 @@
       "resolved": "https://registry.npmjs.org/@eslint/json/-/json-0.3.0.tgz",
       "integrity": "sha512-fdih4NZ6sGMI3YFZUqShMJ/AWvDzDrNepqDlTwRQUfgR434jmajVYIMNc2Vs2M2cHjxZpcHG6FRsrxuiwYvprA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@humanwhocodes/momoa": "^3.2.0"
       },
@@ -4603,6 +4604,7 @@
       "resolved": "https://registry.npmjs.org/@lwc/compiler/-/compiler-8.16.0.tgz",
       "integrity": "sha512-XaAredo9pXS9uCEHuYqB0EeJIbH3owNpT8zToWdG2sGolK091WQ8hFHB2twkBXvsy+YqbqEMbwdKH3WvC9sWEw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.26.9",
         "@babel/plugin-transform-async-generator-functions": "7.26.8",
@@ -4662,7 +4664,8 @@
       "resolved": "https://registry.npmjs.org/@lwc/engine-dom/-/engine-dom-8.26.2.tgz",
       "integrity": "sha512-1Lb4iucOxk9mLZbe+bN2sds8+uzQouujvQsP5fsXRiGCD3quNm2INU9sRSBrdt/Q2/EhXvODpTCMh/iZ41pdTg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@lwc/engine-server": {
       "version": "8.28.2",
@@ -4677,7 +4680,8 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/@lwc/errors/-/errors-8.16.0.tgz",
       "integrity": "sha512-cglxtbp500a2F/WNNDOkwUky2a6KzqPJ4syr6yhuOS5ifgPN2wbuiMJHRzD7Q6EW/e0dHtZxX9Xlyf49JjjzWQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@lwc/eslint-plugin-lwc": {
       "version": "3.4.0",
@@ -5460,6 +5464,7 @@
       "integrity": "sha512-slZ53nIWM1QLCooFNmHZkzCkiB+R02OQsjOoJ3IpsewaMKpJ1YkQdaNJwDn5jEHpui7Fwj/XmKS3+6iwpD5oQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.6.0"
       }
@@ -5469,6 +5474,7 @@
       "resolved": "https://registry.npmjs.org/@lwc/template-compiler/-/template-compiler-8.16.0.tgz",
       "integrity": "sha512-mykA5/6cyjIOw6ADLWtt/sle7jzNsEF0ener+FsscbiMLQSZr9vt8sGO3F1+RKZajqySr1zZxlv7tgS2toIYGQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lwc/errors": "8.16.0",
         "@lwc/shared": "8.16.0",
@@ -6097,6 +6103,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -6305,6 +6312,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6565,6 +6573,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
       "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.2.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -6596,6 +6605,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.203.0.tgz",
       "integrity": "sha512-vM2+rPq0Vi3nYA5akQD2f3QwossDnTDLvKbea6u/A2NZ3XDkPxMfo/PNrDoXhDUD/0pPo2CdH5ce/thn9K0kLw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.203.0",
         "@opentelemetry/core": "2.0.1",
@@ -6641,6 +6651,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.5.0.tgz",
       "integrity": "sha512-BeJLtU+f5Gf905cJX9vXFQorAr6TAfK3SPvTFqP+scfIpDQEJfRaGJWta7sJgP+m4dNtBf9y3yvBKVAZZtJQVA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/resources": "2.5.0"
@@ -6688,6 +6699,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
       "integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/resources": "2.0.1",
@@ -6721,6 +6733,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.2.0.tgz",
       "integrity": "sha512-+OaRja3f0IqGG2kptVeYsrZQK9nKRSpfFrKtRBq4uh6nIB8bTBgaGvYQrQoRrQWQMA5dK5yLhDMDc0dvYvCOIQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/context-async-hooks": "2.2.0",
         "@opentelemetry/core": "2.2.0",
@@ -6770,6 +6783,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.2.0.tgz",
       "integrity": "sha512-x/LHsDBO3kfqaFx5qSzBljJ5QHsRXrvS4MybBDy1k7Svidb8ZyIPudWVzj3s5LpPkYZIgi9e+7tdsNCnptoelw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.2.0",
         "@opentelemetry/sdk-trace-base": "2.2.0"
@@ -6818,6 +6832,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
       "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -7118,6 +7133,7 @@
       "integrity": "sha512-PFyPV2GITbqd3IrnadiUawTZiTirVVakS63DeJvxhbpxRGQ5ZmpzQnEec7xLOUiA59ipeu85HhZNybtV+Ve0wQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "clipboardy": "^5.3.1",
         "clone-deep": "^4.0.1",
@@ -7706,6 +7722,7 @@
       "integrity": "sha512-lC3GL2j6B2wAGeTFWT0h47BFg+0R7naqqlQW+ANvNSaIC/qEB+tNSRcdAZ8DRTojsI3GRdpgq3FTB1llbrFBng==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -7815,6 +7832,25 @@
     "node_modules/@salesforce/soql-common": {
       "resolved": "packages/soql-common",
       "link": true
+    },
+    "node_modules/@salesforce/templates": {
+      "version": "66.5.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-66.5.0.tgz",
+      "integrity": "sha512-lKnXEepqB775+hkZ0erZ+g+cLB2VA7sAirFnPjN/3PJJ/3sC9lSMB8DQfxCJOOinTFHh9fPhNfeFT/zPHTXppQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@salesforce/kit": "^3.2.4",
+        "ejs": "^3.1.10",
+        "got": "^11.8.6",
+        "hpagent": "^1.2.0",
+        "mime-types": "^3.0.2",
+        "proxy-from-env": "^1.1.0",
+        "tar": "^7.5.9",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.18.2"
+      }
     },
     "node_modules/@salesforce/ts-types": {
       "version": "2.0.12",
@@ -8767,6 +8803,7 @@
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -9255,6 +9292,7 @@
       "integrity": "sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.57.0",
@@ -9294,6 +9332,7 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -10341,6 +10380,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10465,6 +10505,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12504,6 +12545,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -14958,6 +15000,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -16996,6 +17039,7 @@
       "resolved": "https://registry.npmjs.org/effect/-/effect-3.19.19.tgz",
       "integrity": "sha512-Yc8U/SVXo2dHnaP7zNBlAo83h/nzSJpi7vph6Hzyl4ulgMBIgPmz3UzOjb9sBgpFE00gC0iETR244sfXDNLHRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "fast-check": "^3.23.1"
@@ -17345,6 +17389,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -17588,6 +17633,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -18041,6 +18087,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -18126,6 +18173,7 @@
       "integrity": "sha512-P9s/qXSMTpRTerE2FQ0qJet2gKbcGyFTPAJipoKxmWqR6uuFqIqk8FuEfg5yBieOezVrEfAMZrEwJ6yEp+1MFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/utils": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
@@ -22778,6 +22826,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -23849,6 +23898,7 @@
       "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/fake-timers": "^29.7.0",
@@ -25753,6 +25803,7 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -26383,6 +26434,7 @@
       "resolved": "https://registry.npmjs.org/koa/-/koa-3.1.2.tgz",
       "integrity": "sha512-2LOQnFKu3m0VxpE+5sb5+BRTSKrXmNxGgxVRiKwD9s5KQB1zID/FRXhtzeV7RT1L2GVpdEEAfVuclFOMGl1ikA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^1.3.8",
         "content-disposition": "~1.0.1",
@@ -26940,6 +26992,7 @@
       "integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -28131,6 +28184,7 @@
       "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "browser-stdout": "^1.3.1",
         "chokidar": "^4.0.1",
@@ -31044,6 +31098,7 @@
       "version": "4.0.3",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -40014,6 +40069,7 @@
         }
       ],
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@bazel/runfiles": "^6.5.0",
         "jszip": "^3.10.1",
@@ -43043,7 +43099,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",
@@ -43270,6 +43327,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -47968,6 +48026,7 @@
       "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "browser-stdout": "^1.3.1",
@@ -48622,7 +48681,7 @@
         "@salesforce/salesforcedx-utils-vscode": "*",
         "@salesforce/source-deploy-retrieve": "^12.31.22",
         "@salesforce/source-tracking": "^7.8.6",
-        "@salesforce/templates": "^66.4.2",
+        "@salesforce/templates": "^66.5.0",
         "@salesforce/ts-types": "2.0.12",
         "@salesforce/vscode-i18n": "*",
         "@salesforce/vscode-service-provider": "^1.5.0",
@@ -48682,25 +48741,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "packages/salesforcedx-vscode-core/node_modules/@salesforce/templates": {
-      "version": "66.4.2",
-      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-66.4.2.tgz",
-      "integrity": "sha512-RywQcNUMzcWwHtoEn9aAWTirotJ9sFjirfmHWitB/xX8dvw6QEY4sHg4Pz12GAViTH3AkORmASpQdudKqofN6g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@salesforce/kit": "^3.2.4",
-        "ejs": "^3.1.10",
-        "got": "^11.8.6",
-        "hpagent": "^1.2.0",
-        "mime-types": "^3.0.2",
-        "proxy-from-env": "^1.1.0",
-        "tar": "^7.5.9",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18.18.2"
       }
     },
     "packages/salesforcedx-vscode-core/node_modules/balanced-match": {
@@ -49042,7 +49082,7 @@
         "@salesforce/o11y-reporter": "^1.8.1",
         "@salesforce/source-deploy-retrieve": "^12.31.22",
         "@salesforce/source-tracking": "^7.8.6",
-        "@salesforce/templates": "^66.4.2",
+        "@salesforce/templates": "^66.5.0",
         "@salesforce/vscode-i18n": "*",
         "@vscode/extension-telemetry": "^1.0.0",
         "effect": "^3.19.19",
@@ -49221,25 +49261,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "packages/salesforcedx-vscode-services/node_modules/@salesforce/templates": {
-      "version": "66.4.2",
-      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-66.4.2.tgz",
-      "integrity": "sha512-RywQcNUMzcWwHtoEn9aAWTirotJ9sFjirfmHWitB/xX8dvw6QEY4sHg4Pz12GAViTH3AkORmASpQdudKqofN6g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@salesforce/kit": "^3.2.4",
-        "ejs": "^3.1.10",
-        "got": "^11.8.6",
-        "hpagent": "^1.2.0",
-        "mime-types": "^3.0.2",
-        "proxy-from-env": "^1.1.0",
-        "tar": "^7.5.9",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18.18.2"
       }
     },
     "packages/salesforcedx-vscode-services/node_modules/@types/node": {
@@ -49560,50 +49581,13 @@
       "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
       "license": "MIT"
     },
-    "packages/salesforcedx-vscode-soql/node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/salesforcedx-vscode-soql/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "packages/salesforcedx-vscode-soql/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "packages/salesforcedx-vscode-soql/node_modules/rollup": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -34,7 +34,7 @@
     "@salesforce/salesforcedx-utils-vscode": "*",
     "@salesforce/source-deploy-retrieve": "^12.31.22",
     "@salesforce/source-tracking": "^7.8.6",
-    "@salesforce/templates": "^66.4.2",
+    "@salesforce/templates": "^66.5.0",
     "@salesforce/ts-types": "2.0.12",
     "@salesforce/vscode-i18n": "*",
     "@salesforce/vscode-service-provider": "^1.5.0",
@@ -412,6 +412,10 @@
           "when": "!sf:internal_dev && (!isWeb || (isWeb && sf:code_builder_enabled))"
         },
         {
+          "command": "sf.agent.generate.project",
+          "when": "false"
+        },
+        {
           "command": "sf.nativemobile.generate.project",
           "when": "false"
         },
@@ -609,6 +613,10 @@
       {
         "command": "sf.project.generate",
         "title": "%project_generate_text%"
+      },
+      {
+        "command": "sf.agent.generate.project",
+        "title": "%agent_generate_project_text%"
       },
       {
         "command": "sf.nativemobile.generate.project",

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -32,6 +32,7 @@
   "project_deploy_start_ignore_conflicts_default_org_text": "SFDX: Push Source to Default Org and Ignore Conflicts",
   "project_generate_manifest": "SFDX: Generate Manifest File",
   "project_generate_text": "SFDX: Create Project",
+  "agent_generate_project_text": "SFDX: Create Agent Project",
   "nativemobile_generate_project_text": "SFDX: Create Native Mobile Project",
   "project_generate_with_manifest_text": "SFDX: Create Project with Manifest",
   "project_retrieve_start_default_org_text": "SFDX: Pull Source from Default Org",

--- a/packages/salesforcedx-vscode-core/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/index.ts
@@ -19,6 +19,7 @@ export { retrieveSourcePaths } from './retrieveSourcePath';
 export { openDocumentation } from './openDocumentation';
 export { projectDeployStart } from './projectDeployStart';
 export {
+  agentProjectGenerate,
   nativemobileProjectGenerate,
   projectGenerateWithManifest,
   ProjectGenerateArgs,

--- a/packages/salesforcedx-vscode-core/src/commands/projectGenerate.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/projectGenerate.ts
@@ -80,7 +80,7 @@ type ProjectName = {
   projectName: string;
 };
 
-export type ProjectTemplate = 'standard' | 'empty' | 'analytics' | 'reactb2e' | 'reactb2x' | 'nativemobile';
+export type ProjectTemplate = 'standard' | 'empty' | 'analytics' | 'reactb2e' | 'reactb2x' | 'nativemobile' | 'agent';
 
 class SelectProjectTemplate implements ParametersGatherer<{ projectTemplate: ProjectTemplate }> {
   private readonly initialTemplate?: ProjectTemplate;
@@ -226,6 +226,10 @@ export const sfProjectGenerate = async (args?: ProjectGenerateArgs): Promise<voi
 
 export const nativemobileProjectGenerate = async (): Promise<void> => {
   await sfProjectGenerate({ projectTemplate: 'nativemobile' });
+};
+
+export const agentProjectGenerate = async (): Promise<void> => {
+  await sfProjectGenerate({ projectTemplate: 'agent' });
 };
 
 export const projectGenerateWithManifest = async (args?: ProjectGenerateArgs): Promise<void> => {

--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -44,6 +44,7 @@ import {
   lightningGenerateAuraComponent,
   lightningGenerateEvent,
   lightningGenerateInterface,
+  agentProjectGenerate,
   nativemobileProjectGenerate,
   openDocumentation,
   packageInstall,
@@ -130,6 +131,7 @@ const registerCommands = (_extensionContext: vscode.ExtensionContext): vscode.Di
     vscode.commands.registerCommand('sf.lightning.generate.interface', lightningGenerateInterface),
     vscode.commands.registerCommand('sf.config.list', configList),
     vscode.commands.registerCommand('sf.project.generate', sfProjectGenerate),
+    vscode.commands.registerCommand('sf.agent.generate.project', agentProjectGenerate),
     vscode.commands.registerCommand('sf.nativemobile.generate.project', nativemobileProjectGenerate),
     vscode.commands.registerCommand('sf.package.install', packageInstall),
     vscode.commands.registerCommand('sf.project.generate.with.manifest', projectGenerateWithManifest),
@@ -263,11 +265,7 @@ export const activate = async (extensionContext: vscode.ExtensionContext): Promi
     CommandEventDispatcher.getInstance()
   );
 
-  if (
-    metadataExtension &&
-    vscode.workspace.workspaceFolders &&
-    vscode.workspace.workspaceFolders.length > 0
-  ) {
+  if (metadataExtension && vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
     // Refresh SObject definitions if there aren't any faux classes (metadata ext registers the command)
     const sobjectRefreshStartup: boolean = vscode.workspace
       .getConfiguration(SFDX_CORE_CONFIGURATION_NAME)

--- a/packages/salesforcedx-vscode-services/package.json
+++ b/packages/salesforcedx-vscode-services/package.json
@@ -43,7 +43,7 @@
     "@salesforce/o11y-reporter": "^1.8.1",
     "@salesforce/source-deploy-retrieve": "^12.31.22",
     "@salesforce/source-tracking": "^7.8.6",
-    "@salesforce/templates": "^66.4.2",
+    "@salesforce/templates": "^66.5.0",
     "@salesforce/vscode-i18n": "*",
     "@vscode/extension-telemetry": "^1.0.0",
     "effect": "^3.19.19",


### PR DESCRIPTION
### What does this PR do?
Adds support for agent project generation by:

Extracting agent project generation to a dedicated command
Removing agent from the template selection UI
Adding sf.agent.generate.project command (hidden from command palette)
Command can be invoked programmatically via agentProjectGenerate()

### What issues does this PR fix or reference?
@W-21522177@