### PR TITLE
fix(org): clear global StateAggregator cache so new orgs appear in picker W-21567195

### DIFF
--- a/packages/salesforcedx-vscode-org/src/util/orgUtil.ts
+++ b/packages/salesforcedx-vscode-org/src/util/orgUtil.ts
@@ -104,7 +104,7 @@ export const updateConfigAndStateAggregators = async (): Promise<void> => {
   // Also force the StateAggregator to reload to have the latest
   // authorization info. Called without args to clear ALL cached instances,
   // including the default one used by AuthInfo.listAllAuthorizations().
-  StateAggregator.clearInstance();
+  await StateAggregator.clearInstanceAsync();
 
   // Trigger Apex Test Controller to discover tests after org auth/set-default. Delay so config
   // and TargetOrgRef can propagate before refresh runs.

--- a/packages/salesforcedx-vscode-org/test/jest/util/orgUtil.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/util/orgUtil.test.ts
@@ -348,7 +348,7 @@ describe('testing setTargetOrgOrAlias', () => {
     mockConfigAggregatorProvider = jest
       .spyOn(ConfigAggregatorProvider, 'getInstance')
       .mockReturnValue(mockConfigAggregatorProviderInstance as any);
-    stateAggregatorClearInstanceMock = jest.spyOn(StateAggregator, 'clearInstance').mockImplementation();
+    stateAggregatorClearInstanceMock = jest.spyOn(StateAggregator, 'clearInstanceAsync').mockResolvedValue();
   });
 
   it('should set provided username or alias as default configs', async () => {


### PR DESCRIPTION
What does this PR do?
Fixes StateAggregator.clearInstance() in updateConfigAndStateAggregators to clear the correct cache instance. Previously it passed workspaceUtils.getRootWorkspacePath() as the cache key, which only cleared a workspace-keyed entry. AuthInfo.listAllAuthorizations() retrieves the StateAggregator via getInstance() (no args), which uses Global.DIR as the key — a different entry that remained stale. Calling clearInstance() without args matches Global.DIR and clears the instance that listAllAuthorizations depends on.

What issues does this PR fix or reference?
@W-21567195@