### PR TITLE
test(e2e): command visibility for apex-log and apex-testing W-21728589

### DIFF
--- a/packages/salesforcedx-vscode-apex-log/test/playwright/fixtures/desktopFixtures.ts
+++ b/packages/salesforcedx-vscode-apex-log/test/playwright/fixtures/desktopFixtures.ts
@@ -18,3 +18,15 @@ export const desktopTest = createDesktopTest({
     'git.autofetch': false
   }
 });
+
+export const emptyWorkspaceDesktopTest = createDesktopTest({
+  fixturesDir: __dirname,
+  emptyWorkspace: true,
+  additionalExtensionDirs: ['salesforcedx-vscode-metadata'],
+  disableOtherExtensions: false,
+  userSettings: {
+    'github.gitAuthentication': false,
+    'git.terminalAuthentication': false,
+    'git.autofetch': false
+  }
+});

--- a/packages/salesforcedx-vscode-apex-log/test/playwright/fixtures/index.ts
+++ b/packages/salesforcedx-vscode-apex-log/test/playwright/fixtures/index.ts
@@ -7,7 +7,7 @@
 
 import { test as webTest } from '@playwright/test';
 
-import { desktopTest } from './desktopFixtures';
+import { desktopTest, emptyWorkspaceDesktopTest } from './desktopFixtures';
 
 const isDesktop = process.env.VSCODE_DESKTOP === '1';
 
@@ -21,3 +21,4 @@ webTest.afterEach(async ({ page }, testInfo) => {
 });
 
 export const test = isDesktop ? desktopTest : webTest;
+export const emptyWorkspaceTest = isDesktop ? emptyWorkspaceDesktopTest : webTest;

--- a/packages/salesforcedx-vscode-apex-log/test/playwright/specs/noOrgVisibility.headless.spec.ts
+++ b/packages/salesforcedx-vscode-apex-log/test/playwright/specs/noOrgVisibility.headless.spec.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  validateNoCriticalErrors,
+  verifyCommandDoesNotExist,
+  verifyCommandExists,
+  isDesktop
+} from '@salesforce/playwright-vscode-ext';
+import packageNls from '../../../package.nls.json';
+import { test } from '../fixtures';
+
+(isDesktop() ? test : test.skip.bind(test))(
+  'Apex Log commands visibility when project is open but no org is connected',
+  async ({ page }) => {
+    const consoleErrors = setupConsoleMonitoring(page);
+    const networkErrors = setupNetworkMonitoring(page);
+
+    await test.step('verify project-only commands are visible', async () => {
+      // Create Anonymous Apex Script should be visible with just a project
+      await verifyCommandExists(page, packageNls['apexLog.command.createAnonymousApexScript'], 30_000);
+    });
+
+    await test.step('verify org-dependent commands are hidden', async () => {
+      // Get Apex Debug Logs requires an org
+      await verifyCommandDoesNotExist(page, packageNls['apexLog.command.logGet']);
+
+      // Open Trace Flags requires an org
+      await verifyCommandDoesNotExist(page, packageNls['apexLog.command.traceFlagsOpen']);
+
+      // Execute Anonymous Apex (Document) requires an org
+      await verifyCommandDoesNotExist(page, packageNls['apexLog.command.executeDocument']);
+
+      // Execute Anonymous Apex (Selection) requires an org
+      await verifyCommandDoesNotExist(page, packageNls['apexLog.command.executeSelection']);
+
+      // Trace Flag commands require an org
+      await verifyCommandDoesNotExist(page, packageNls['apexLog.command.traceFlagsCreateForCurrentUser']);
+      await verifyCommandDoesNotExist(page, packageNls['apexLog.command.traceFlagsDeleteForCurrentUser']);
+    });
+
+    await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+  }
+);

--- a/packages/salesforcedx-vscode-apex-log/test/playwright/specs/noProjectVisibility.headless.spec.ts
+++ b/packages/salesforcedx-vscode-apex-log/test/playwright/specs/noProjectVisibility.headless.spec.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  validateNoCriticalErrors,
+  verifyCommandDoesNotExist,
+  isDesktop
+} from '@salesforce/playwright-vscode-ext';
+import packageNls from '../../../package.nls.json';
+import { emptyWorkspaceTest as test } from '../fixtures';
+
+(isDesktop() ? test : test.skip.bind(test))(
+  'Apex Log commands are hidden when no project is open',
+  async ({ page }) => {
+    const consoleErrors = setupConsoleMonitoring(page);
+    const networkErrors = setupNetworkMonitoring(page);
+
+    await test.step('verify all apex log commands are hidden', async () => {
+      // Create Anonymous Apex Script
+      await verifyCommandDoesNotExist(page, packageNls['apexLog.command.createAnonymousApexScript']);
+
+      // Get Apex Debug Logs
+      await verifyCommandDoesNotExist(page, packageNls['apexLog.command.logGet']);
+
+      // Open Trace Flags
+      await verifyCommandDoesNotExist(page, packageNls['apexLog.command.traceFlagsOpen']);
+
+      // Execute Anonymous Apex (Document)
+      await verifyCommandDoesNotExist(page, packageNls['apexLog.command.executeDocument']);
+
+      // Execute Anonymous Apex (Selection)
+      await verifyCommandDoesNotExist(page, packageNls['apexLog.command.executeSelection']);
+
+      // Trace Flag commands
+      await verifyCommandDoesNotExist(page, packageNls['apexLog.command.traceFlagsCreateForCurrentUser']);
+      await verifyCommandDoesNotExist(page, packageNls['apexLog.command.traceFlagsDeleteForCurrentUser']);
+    });
+
+    await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+  }
+);

--- a/packages/salesforcedx-vscode-apex-testing/test/playwright/fixtures/desktopFixtures.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/playwright/fixtures/desktopFixtures.ts
@@ -18,3 +18,15 @@ export const desktopTest = createDesktopTest({
     'git.autofetch': false
   }
 });
+
+export const emptyWorkspaceDesktopTest = createDesktopTest({
+  fixturesDir: __dirname,
+  emptyWorkspace: true,
+  additionalExtensionDirs: ['salesforcedx-vscode-metadata'],
+  disableOtherExtensions: false,
+  userSettings: {
+    'github.gitAuthentication': false,
+    'git.terminalAuthentication': false,
+    'git.autofetch': false
+  }
+});

--- a/packages/salesforcedx-vscode-apex-testing/test/playwright/fixtures/index.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/playwright/fixtures/index.ts
@@ -7,7 +7,7 @@
 
 import { test as webTest } from '@playwright/test';
 
-import { desktopTest } from './desktopFixtures';
+import { desktopTest, emptyWorkspaceDesktopTest } from './desktopFixtures';
 
 const isDesktop = process.env.VSCODE_DESKTOP === '1';
 
@@ -23,3 +23,4 @@ webTest.afterEach(async ({ page }, testInfo) => {
 // Export the appropriate test based on environment (fixtures differ)
 // expect is the same for both, so just re-export it directly
 export const test = isDesktop ? desktopTest : webTest;
+export const emptyWorkspaceTest = isDesktop ? emptyWorkspaceDesktopTest : webTest;

--- a/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/noOrgVisibility.headless.spec.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/noOrgVisibility.headless.spec.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  validateNoCriticalErrors,
+  verifyCommandDoesNotExist,
+  verifyCommandExists,
+  isDesktop
+} from '@salesforce/playwright-vscode-ext';
+import packageNls from '../../../package.nls.json';
+import { test } from '../fixtures';
+
+(isDesktop() ? test : test.skip.bind(test))(
+  'Apex Testing commands visibility when project is open but no org is connected',
+  async ({ page }) => {
+    const consoleErrors = setupConsoleMonitoring(page);
+    const networkErrors = setupNetworkMonitoring(page);
+
+    await test.step('verify project-only commands are visible', async () => {
+      // Create Apex Unit Test Class should be visible with just a project
+      await verifyCommandExists(page, packageNls.apex_generate_unit_test_class_text, 30_000);
+
+      // Open Apex Test Explorer Walkthrough should be visible with just a project
+      await verifyCommandExists(page, packageNls.apex_testing_walkthrough_open_command, 5000);
+    });
+
+    await test.step('verify org-dependent commands are hidden', async () => {
+      // Run Apex Tests requires an org
+      await verifyCommandDoesNotExist(page, packageNls.apex_test_run_text);
+
+      // Run Apex Test Suite requires an org
+      await verifyCommandDoesNotExist(page, packageNls.apex_test_suite_run_text);
+
+      // Create Apex Test Suite requires an org
+      await verifyCommandDoesNotExist(page, packageNls.apex_test_suite_create_text);
+
+      // Add Tests to Apex Test Suite requires an org
+      await verifyCommandDoesNotExist(page, packageNls.apex_test_suite_add_text);
+
+      // Re-Run Last Run Apex Test Class requires an org
+      await verifyCommandDoesNotExist(page, packageNls.apex_test_last_class_run_text);
+
+      // Re-Run Last Run Apex Test Method requires an org
+      await verifyCommandDoesNotExist(page, packageNls.apex_test_last_method_run_text);
+    });
+
+    await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+  }
+);

--- a/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/noProjectVisibility.headless.spec.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/noProjectVisibility.headless.spec.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  validateNoCriticalErrors,
+  verifyCommandDoesNotExist,
+  isDesktop
+} from '@salesforce/playwright-vscode-ext';
+import packageNls from '../../../package.nls.json';
+import { emptyWorkspaceTest as test } from '../fixtures';
+
+(isDesktop() ? test : test.skip.bind(test))(
+  'Apex Testing commands are hidden when no project is open',
+  async ({ page }) => {
+    const consoleErrors = setupConsoleMonitoring(page);
+    const networkErrors = setupNetworkMonitoring(page);
+
+    await test.step('verify all apex testing commands are hidden', async () => {
+      // Create Apex Unit Test Class
+      await verifyCommandDoesNotExist(page, packageNls.apex_generate_unit_test_class_text);
+
+      // Open Apex Test Explorer Walkthrough
+      await verifyCommandDoesNotExist(page, packageNls.apex_testing_walkthrough_open_command);
+
+      // Run Apex Tests
+      await verifyCommandDoesNotExist(page, packageNls.apex_test_run_text);
+
+      // Run Apex Test Suite
+      await verifyCommandDoesNotExist(page, packageNls.apex_test_suite_run_text);
+
+      // Create Apex Test Suite
+      await verifyCommandDoesNotExist(page, packageNls.apex_test_suite_create_text);
+
+      // Add Tests to Apex Test Suite
+      await verifyCommandDoesNotExist(page, packageNls.apex_test_suite_add_text);
+
+      // Re-Run Last Run Apex Test Class
+      await verifyCommandDoesNotExist(page, packageNls.apex_test_last_class_run_text);
+
+      // Re-Run Last Run Apex Test Method
+      await verifyCommandDoesNotExist(page, packageNls.apex_test_last_method_run_text);
+    });
+
+    await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+  }
+);


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-21728589@

### Summary
Adds Playwright E2E tests to verify command visibility for Apex Log and Apex Testing extensions when no project is open or no org is connected.

each ext's e2e are responsible for ensuring that its commands show/hide correctly since we don't have initialSuite anymore managing that across the extensions

### Test plan
Run playwright tests:
- `packages/salesforcedx-vscode-apex-log/test/playwright/specs/noOrgVisibility.headless.spec.ts`
- `packages/salesforcedx-vscode-apex-log/test/playwright/specs/noProjectVisibility.headless.spec.ts`
- `packages/salesforcedx-vscode-apex-testing/test/playwright/specs/noOrgVisibility.headless.spec.ts`
- `packages/salesforcedx-vscode-apex-testing/test/playwright/specs/noProjectVisibility.headless.spec.ts`