### PR TITLE
feat: dispatch CBW release type as minor @W-21731533@

### DIFF
--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -97,10 +97,12 @@ jobs:
           GH_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
         run: |
           VERSION="${{ needs.prepare-environment-from-main.outputs.RELEASE_VERSION }}"
-          echo "Dispatching extension-publish event to code-builder-web with version $VERSION"
+          RELEASE_TYPE="minor"
+          echo "Dispatching extension-publish event to code-builder-web with version $VERSION (release-type: $RELEASE_TYPE)"
           gh api repos/forcedotcom/code-builder-web/dispatches \
             --method POST \
             -f event_type=extension-publish \
             -f "client_payload[version]=$VERSION" \
-            -f "client_payload[source]=publishVSCode"
+            -f "client_payload[source]=publishVSCode" \
+            -f "client_payload[release_type]=$RELEASE_TYPE"
           echo "Dispatch sent successfully"


### PR DESCRIPTION
## Summary

When `publishVSCode.yml` triggers a CBW release via `repository_dispatch`, the payload didn't include a release type, so CBW defaulted to `patch`. Weekly extension publishes are feature-level updates and should produce minor CBW versions. This adds `release_type=minor` to the dispatch payload.

## Changes

- `.github/workflows/publishVSCode.yml`: added `client_payload[release_type]=minor` to the CBW dispatch step.

**Companion PR:** forcedotcom/code-builder-web — reads/validates the `release_type` payload and passes it to `release.yml`.

Ref: [@W-21731533@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002WslmkYAB/view)

## Test plan

- [x] Verify dispatch payload includes `release_type` field (dry-run `promote-on-publish` on CBW side)
- [x] Confirm CBW companion PR is merged first so the field is consumed