### PR TITLE
fix(org): surface port 1717 auth guidance W-21749958

### DIFF
--- a/packages/salesforcedx-vscode-org/README.md
+++ b/packages/salesforcedx-vscode-org/README.md
@@ -12,6 +12,13 @@ This extension provides Salesforce org and authorization management commands for
 - **Log Out from Default Org** - Remove authorization for the current default org
 - **Log Out from All Authorized Orgs** - Remove all stored org authorizations
 
+When **Authorize an Org** fails because local port `1717` is already in use, the extension now shows an explicit troubleshooting message and a **Show Output** action so you can inspect the full CLI error details.
+
+#### Port 1717 Troubleshooting for Authorize an Org
+
+- macOS/Linux: `lsof -i :1717`, then `kill -9 <PID>`, then retry authorization.
+- Windows: `netstat -ano | findstr :1717`, then `taskkill /PID <PID> /F`, then retry authorization.
+
 ### Org Management Commands
 
 - **Create a Default Scratch Org** - Create a new scratch org and set it as default

--- a/packages/salesforcedx-vscode-org/src/commands/auth/orgLoginWeb.ts
+++ b/packages/salesforcedx-vscode-org/src/commands/auth/orgLoginWeb.ts
@@ -7,16 +7,21 @@
 import { sfProjectPreconditionChecker } from '@salesforce/effect-ext-utils';
 import { Command, SfCommandBuilder } from '@salesforce/salesforcedx-utils';
 import {
+  ChannelService,
+  CliCommandExecutor,
+  ContinueResponse,
+  ProgressNotification,
   SfCommandlet,
   SfCommandletExecutor,
-  CliCommandExecutor,
   TimingUtils,
-  workspaceUtils,
-  ContinueResponse
+  notificationService,
+  workspaceUtils
 } from '@salesforce/salesforcedx-utils-vscode';
 import * as vscode from 'vscode';
+import { OUTPUT_CHANNEL } from '../../channels';
 import { ORG_LOGIN_WEB } from '../../constants';
 import { nls } from '../../messages';
+import { getPortKillInstructions, isAuthPortConflictError } from '../../util/authErrorParser';
 import { updateConfigAndStateAggregators } from '../../util/orgUtil';
 import { getVerificationCodeDescription, showVerificationCodeIfNeeded } from '../../util/verificationCode';
 import { AuthParams, AuthParamsGatherer } from './authParamsGatherer';
@@ -24,8 +29,14 @@ import { AuthParams, AuthParamsGatherer } from './authParamsGatherer';
 class OrgLoginWebExecutor extends SfCommandletExecutor<AuthParams> {
   protected showChannelOutput = false;
 
+  constructor() {
+    super(OUTPUT_CHANNEL);
+  }
+
   public build(data: AuthParams): Command {
-    const command = new SfCommandBuilder().withDescription(getVerificationCodeDescription(nls.localize('org_login_web_authorize_org_text')));
+    const command = new SfCommandBuilder().withDescription(
+      getVerificationCodeDescription(nls.localize('org_login_web_authorize_org_text'))
+    );
 
     command
       .withArg(ORG_LOGIN_WEB)
@@ -46,7 +57,46 @@ class OrgLoginWebExecutor extends SfCommandletExecutor<AuthParams> {
       env: { SF_JSON_TO_STDOUT: 'true' }
     }).execute(cancellationToken);
 
-    this.attachExecution(execution, cancellationTokenSource, cancellationToken);
+    const channelService = new ChannelService(OUTPUT_CHANNEL);
+    channelService.streamCommandOutput(execution);
+    ProgressNotification.show(execution, cancellationTokenSource);
+
+    let stderrOutput = '';
+    let hasHandledFailure = false;
+
+    const showPortConflictError = async () => {
+      const message = `${nls.localize('org_login_web_port_conflict_notification_message')}\n\n${getPortKillInstructions()}`;
+      const showOutputText = nls.localize('org_login_web_show_output_button_text');
+      const selection = await notificationService.showErrorMessage(message, showOutputText);
+      if (selection === showOutputText) {
+        channelService.showChannelOutput();
+      }
+    };
+
+    const showFailure = async (errorOutput: string) => {
+      if (hasHandledFailure) {
+        return;
+      }
+      hasHandledFailure = true;
+      if (isAuthPortConflictError(errorOutput)) {
+        await showPortConflictError();
+      } else {
+        notificationService.showFailedExecution(execution.command.toString(), channelService);
+      }
+    };
+
+    execution.stderrSubject.subscribe(data => {
+      stderrOutput += data.toString();
+    });
+
+    execution.processErrorSubject.subscribe(data => {
+      void showFailure(data?.message ?? stderrOutput);
+    });
+
+    cancellationToken.onCancellationRequested(() => {
+      notificationService.showCanceledExecution(execution.command.toString(), channelService);
+    });
+
     void showVerificationCodeIfNeeded();
 
     // old rxjs doesn't like async functions in subscribe, but we use them and they seem to work.
@@ -57,7 +107,10 @@ class OrgLoginWebExecutor extends SfCommandletExecutor<AuthParams> {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const exitCode = Array.isArray(data) ? data[0] : data;
       if (exitCode === 0) {
+        await notificationService.showSuccessfulExecution(execution.command.toString(), channelService);
         await updateConfigAndStateAggregators();
+      } else {
+        await showFailure(stderrOutput);
       }
     });
   }

--- a/packages/salesforcedx-vscode-org/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-org/src/messages/i18n.ts
@@ -50,7 +50,16 @@ export const messages = {
   org_login_access_token_text: 'SFDX: Authorize an Org using Session ID',
   org_login_web_authorize_dev_hub_text: 'SFDX: Authorize a Dev Hub',
   org_login_web_authorize_org_text: 'SFDX: Authorize an Org',
-  org_login_web_verification_code_message: 'Verification Code: %s — If prompted, enter this code in your browser window.',
+  org_login_web_port_conflict_notification_message:
+    'Could not authorize your org because local port 1717 is already in use. Close the process using that port, then try again.',
+  org_login_web_port_conflict_steps_label: 'Try this:',
+  org_login_web_port_conflict_find_process_unix: 'Find process: lsof -i :1717',
+  org_login_web_port_conflict_kill_process_unix: 'Kill process: kill -9 <PID>',
+  org_login_web_port_conflict_find_process_windows: 'Find process: netstat -ano | findstr :1717',
+  org_login_web_port_conflict_kill_process_windows: 'Kill process: taskkill /PID <PID> /F',
+  org_login_web_show_output_button_text: 'Show Output',
+  org_login_web_verification_code_message:
+    'Verification Code: %s — If prompted, enter this code in your browser window.',
   org_login_web_verification_code_suffix: '(Verification Code: %s)',
   org_logout_all_text: 'SFDX: Log Out from Authorized Orgs',
   org_logout_default_text: 'SFDX: Log Out from Default Org',
@@ -92,5 +101,5 @@ export const messages = {
   status_bar_org_picker_tooltip: 'Change Default Org',
   table_header_name: 'Name',
   table_header_success: 'Success',
-  table_header_value: 'Value',
+  table_header_value: 'Value'
 } as const;

--- a/packages/salesforcedx-vscode-org/src/util/authErrorParser.ts
+++ b/packages/salesforcedx-vscode-org/src/util/authErrorParser.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { nls } from '../messages';
+
+const PORT_CONFLICT_PATTERNS = [
+  /port\s+1717.*already in use/i,
+  /port\s+1717.*in use/i,
+  /Cannot start the OAuth redirect server on port 1717/i,
+  /kill the process running on port 1717/i,
+  /EADDRINUSE/i
+];
+
+export const isAuthPortConflictError = (errorOutput: string): boolean =>
+  PORT_CONFLICT_PATTERNS.some(pattern => pattern.test(errorOutput));
+
+export const extractPortConflictCliMessage = (errorOutput: string): string | undefined => {
+  const trimmedOutput = errorOutput.trim();
+  const portInUseErrorMatch = trimmedOutput.match(
+    /Error \(PortInUseError\):[\s\S]*?OAuthLocalPort in the sfdx-project\.json file\./i
+  );
+  return portInUseErrorMatch?.[0].trim();
+};
+
+export const getPortKillInstructions = (platform = process.platform): string =>
+  platform === 'win32'
+    ? `${nls.localize('org_login_web_port_conflict_steps_label')}\n1. ${nls.localize(
+        'org_login_web_port_conflict_find_process_windows'
+      )}\n, 2. ${nls.localize('org_login_web_port_conflict_kill_process_windows')}`
+    : `${nls.localize('org_login_web_port_conflict_steps_label')}\n1. ${nls.localize(
+        'org_login_web_port_conflict_find_process_unix'
+      )}\n, 2. ${nls.localize('org_login_web_port_conflict_kill_process_unix')}`;

--- a/packages/salesforcedx-vscode-org/test/jest/util/authErrorParser.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/util/authErrorParser.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  extractPortConflictCliMessage,
+  getPortKillInstructions,
+  isAuthPortConflictError
+} from '../../../src/util/authErrorParser';
+
+describe('authErrorParser', () => {
+  it('detects the CLI message about killing process on port 1717', () => {
+    const cliError = 'Kill the process running on port 1717 and rerun this command.';
+    expect(isAuthPortConflictError(cliError)).toBe(true);
+  });
+
+  it('detects port already in use errors for 1717', () => {
+    const cliError = 'Error: listen EADDRINUSE: address already in use 127.0.0.1:1717';
+    expect(isAuthPortConflictError(cliError)).toBe(true);
+  });
+
+  it('does not flag unrelated auth failures as port conflict', () => {
+    const cliError = 'Error authenticating with org: invalid_grant';
+    expect(isAuthPortConflictError(cliError)).toBe(false);
+  });
+
+  it('extracts the CLI PortInUseError message block', () => {
+    const cliError = `Error (PortInUseError): Cannot start the OAuth redirect server on port 1717.
+
+Try this:
+Kill the process running on port 1717 or use a custom connected app and update OAuthLocalPort in the sfdx-project.json file.
+
+Additional log lines after this message.`;
+
+    expect(extractPortConflictCliMessage(cliError)).toBe(
+      'Error (PortInUseError): Cannot start the OAuth redirect server on port 1717.\n\nTry this:\nKill the process running on port 1717 or use a custom connected app and update OAuthLocalPort in the sfdx-project.json file.'
+    );
+  });
+
+  it('returns undefined when PortInUseError format is not present', () => {
+    const cliError = 'Error authenticating with org: invalid_grant';
+    expect(extractPortConflictCliMessage(cliError)).toBeUndefined();
+  });
+
+  it('returns platform-specific port kill instructions', () => {
+    expect(getPortKillInstructions('darwin')).toBe(
+      'Try this:\n1. Find process: lsof -i :1717\n, 2. Kill process: kill -9 <PID>'
+    );
+    expect(getPortKillInstructions('win32')).toBe(
+      'Try this:\n1. Find process: netstat -ano | findstr :1717\n, 2. Kill process: taskkill /PID <PID> /F'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Surface a friendly, actionable notification when `SFDX: Authorize an Org` fails due to port `1717` being in use.
- Keep full CLI `PortInUseError` details in the `Salesforce Org Management` output channel and avoid duplicate output lines.
- Add localized remediation copy and unit tests for port-conflict detection/instruction formatting.

## Test plan
- [ ] save this file in your project's root directoty [port1717.js](https://github.com/user-attachments/files/26252524/port1717.js)
- [ ] run `node port1717.js` from project root
- [ ] Run `SFDX: Authorize an Org`
- [ ] Manually reproduced port-1717 conflict and validated notification/output behavior

### What issues does this PR fix or reference?
@W-21749958@

Made with [Cursor](https://cursor.com)