### PR TITLE
ci: retry publishes [skip-validate-pr]

### DIFF
--- a/.github/workflows/publishOpenVSX.yml
+++ b/.github/workflows/publishOpenVSX.yml
@@ -62,8 +62,10 @@ jobs:
       - name: Display downloaded vsix files
         run: ls -R ./extensions
       - uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
-      - run: |
-          cmd=$(find ./extensions -type f -name "*.vsix" -print0 | xargs -0 -I {} printf 'npx ovsx publish --skip-duplicate "%s" -p "%s" && ' '{}' "${OVSX_PAT}" | sed 's/ && $//') && [ -n "$cmd" ] && eval "$cmd" && echo "SUCCESSFULLY published"
+      - uses: salesforcecli/github-workflows/.github/actions/retry@main
+        with:
+          command: |
+            cmd=$(find ./extensions -type f -name "*.vsix" -print0 | xargs -0 -I {} printf 'npx ovsx publish --skip-duplicate "%s" -p "%s" && ' '{}' "${OVSX_PAT}" | sed 's/ && $//') && [ -n "$cmd" ] && eval "$cmd" && echo "SUCCESSFULLY published"
 
   ctcCloseSuccess:
     needs: [ctc-open, publish]

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -64,8 +64,10 @@ jobs:
       - uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
       - name: Validate VSIX OPC Part URIs
         run: node scripts/validate-vsix-opc.mjs ./extensions
-      - run: |
-          cmd=$(find . -type f -name "*.vsix" -print0 | xargs -0 -I {} printf 'npx vsce publish --skip-duplicate --pat "%s" --packagePath "%s" && ' "${VSCE_PERSONAL_ACCESS_TOKEN}" '{}' | sed 's/ && $//')&&[ -n "$cmd" ] && eval "$cmd" && echo "SUCCESSFULLY published"
+      - uses: salesforcecli/github-workflows/.github/actions/retry@main
+        with:
+          command: |
+            cmd=$(find . -type f -name "*.vsix" -print0 | xargs -0 -I {} printf 'npx vsce publish --skip-duplicate --pat "%s" --packagePath "%s" && ' "${VSCE_PERSONAL_ACCESS_TOKEN}" '{}' | sed 's/ && $//')&&[ -n "$cmd" ] && eval "$cmd" && echo "SUCCESSFULLY published"
 
   ctcCloseSuccess:
     needs: [ctc-open, publish]


### PR DESCRIPTION
### What does this PR do?
Retries VSIX publishing to Open VSX and VS Code Marketplace using `salesforcecli/github-workflows/.github/actions/retry@main`.

### What issues does this PR fix or reference?
[skip-validate-pr]

### Functionality Before
Publishes were single-attempt; failures required manual workflow re-runs.

### Functionality After
Publishes automatically retry on failure.

Made with [Cursor](https://cursor.com)