### PR TITLE
@W-21786623@ fix: derive CBW release type from git tags instead of hardcoding minor

### DIFF
--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -15,16 +15,35 @@ jobs:
     environment: publish
     outputs:
       RELEASE_VERSION: ${{ steps.getMainVersion.outputs.version }}
+      CBW_RELEASE_TYPE: ${{ steps.cbwReleaseType.outputs.type }}
       GUS_BUILD: ${{ steps.getGusBuild.outputs.gusBuild}}
       SF_CHANGE_CASE_SCHEDULE_BUILD: ${{ steps.getScheduledBuild.outputs.sfChangeCaseScheduleBuild }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: 'main'
+      - run: git fetch --tags --quiet
       - id: getMainVersion
         run: |
           echo "version="$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")"" >> $GITHUB_OUTPUT
       - run: echo "Main Version is ${{ steps.getMainVersion.outputs.version }}"
+      - id: cbwReleaseType
+        run: |
+          VERSION="${{ steps.getMainVersion.outputs.version }}"
+          PREV_TAG=$(git tag -l 'v[0-9]*' --sort=-v:refname | grep -v "^v${VERSION}$" | head -1)
+          PREV_VERSION="${PREV_TAG#v}"
+
+          CURR_MINOR=$(echo "$VERSION" | cut -d. -f1-2)
+          PREV_MINOR=$(echo "$PREV_VERSION" | cut -d. -f1-2)
+
+          if [ "$CURR_MINOR" = "$PREV_MINOR" ]; then
+            TYPE="patch"
+          else
+            TYPE="minor"
+          fi
+
+          echo "type=$TYPE" >> $GITHUB_OUTPUT
+          echo "CBW release type: $TYPE (current=$VERSION, previous=$PREV_VERSION)"
       - id: getGusBuild
         run: |
           echo "gusBuild=${{ steps.getMainVersion.outputs.version }}" >> $GITHUB_OUTPUT
@@ -99,7 +118,7 @@ jobs:
           GH_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
         run: |
           VERSION="${{ needs.prepare-environment-from-main.outputs.RELEASE_VERSION }}"
-          RELEASE_TYPE="minor"
+          RELEASE_TYPE="${{ needs.prepare-environment-from-main.outputs.CBW_RELEASE_TYPE }}"
           echo "Dispatching extension-publish event to code-builder-web with version $VERSION (release-type: $RELEASE_TYPE)"
           gh api repos/forcedotcom/code-builder-web/dispatches \
             --method POST \


### PR DESCRIPTION
## Summary

`publishVSCode.yml` hardcoded `RELEASE_TYPE="minor"` when dispatching to code-builder-web, so every marketplace publish — including patches — triggered a minor version bump in CBW. For example, the `v66.3.2` patch release just caused a CBW minor bump when it should have been a patch.

The fix adds a `cbwReleaseType` step to `prepare-environment-from-main` that compares `MAJOR.MINOR` of the current version against the previous git tag. If the prefix matches, it's a patch. If it differs, it's a minor. `trigger-cbw-release` now reads this derived value instead of the hardcoded string.

## Changes
- Added `git fetch --tags --quiet` step after checkout (shallow clones don't include tags by default)
- Added `cbwReleaseType` step that compares adjacent git tags to derive `patch` vs `minor`
- Added `CBW_RELEASE_TYPE` output to `prepare-environment-from-main`
- Replaced hardcoded `RELEASE_TYPE="minor"` in `trigger-cbw-release` with `needs.prepare-environment-from-main.outputs.CBW_RELEASE_TYPE`

## How it works

The `v[0-9]*` glob naturally excludes `soql-common-v*` tags. Examples from real v66 history:

| Previous tag | Current tag | `MAJOR.MINOR` comparison | Result |
|---|---|---|---|
| `v66.0.3` | `v66.1.1` | `66.0` != `66.1` | **minor** (weekly release) |
| `v66.1.1` | `v66.2.1` | `66.1` != `66.2` | **minor** (weekly release) |
| `v66.2.1` | `v66.2.2` | `66.2` == `66.2` | **patch** |
| `v66.2.3` | `v66.3.1` | `66.2` != `66.3` | **minor** (weekly release) |
| `v66.3.1` | `v66.3.2` | `66.3` == `66.3` | **patch** (the release that triggered this fix) |

Note: a simple `patch > 0` check does NOT work here because weekly minor releases routinely ship with patches applied during the release cycle (e.g. `v66.1.1` is the first tag for the 66.1 minor — `v66.1.0` was never published).

## Receiving side

No changes needed in CBW. `promote-on-publish.yml` already reads `client_payload.release_type` dynamically.

## Test plan
- [x] CI validation on this workflow YAML change (no code, so pre-commit hooks for compile/test are not applicable)
- [ ] Verify on next patch release that CBW receives `release_type=patch`
- [ ] Verify on next weekly minor that CBW receives `release_type=minor`

@W-21786623@