### PR TITLE
[W-21770863] fix(core): only run refreshSObjects definitions on sfdx projects

### DIFF
--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -263,12 +263,17 @@ export const activate = async (extensionContext: vscode.ExtensionContext): Promi
     CommandEventDispatcher.getInstance()
   );
 
-  if (metadataExtension && vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
-    // Refresh SObject definitions if there aren't any faux classes (metadata ext registers the command)
+  if (
+    metadataExtension &&
+    salesforceProjectOpened &&
+    vscode.workspace.workspaceFolders &&
+    vscode.workspace.workspaceFolders.length > 0
+  ) {
+    // Refresh SObject definitions only for an open Salesforce project
+    // when faux classes are missing (metadata extension registers the command).
     const sobjectRefreshStartup: boolean = vscode.workspace
       .getConfiguration(SFDX_CORE_CONFIGURATION_NAME)
       .get<boolean>(ENABLE_SOBJECT_REFRESH_ON_STARTUP, false);
-
     await initSObjectDefinitions(vscode.workspace.workspaceFolders[0].uri.fsPath, sobjectRefreshStartup);
   }
 


### PR DESCRIPTION
## Summary
- Fixes `W-21770863` where `.sfdx` could be created outside expected scenarios during extension startup.
- Ensures core only triggers `sf.internal.refreshsobjects` when all of the following are true:
  - metadata extension is available,
  - current workspace is a Salesforce project (`ProjectService.isSalesforceProject()`),
  - `salesforcedx-vscode-core.enable-sobject-refresh-on-startup` is `true`.
- Removes redundant project-file guard from `initSObjectDefinitions` and keeps responsibility in activation flow.
- Updates unit coverage for `initSObjectDefinitions` behavior.
## Root Cause
Core activation still called `initSObjectDefinitions(...)` on non sfdx projects even when startup refresh setting was disabled, using the `startupmin` path, 
## Changes
- `packages/salesforcedx-vscode-core/src/index.ts`
  - Kept startup behavior dependent on Salesforce-project-opened context.
## Test Plan
  - [ ] Open non-SFDX workspace with full Extension Pack and verify `.sfdx` is not created on startup. Run **SFDX: Create Project** command just to trigger Salesforce CLI Integration extension activation, and escape so the actual command execution is cancelled.
  - [ ] Open SFDX project and make sure thee `.sfdx` folder gets created

@W-21770863@