### PR TITLE
[W-21674925] feat: update @salesforce/templates to v66.7.0 for the UiBundle naming change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7817,25 +7817,6 @@
       "resolved": "packages/soql-common",
       "link": true
     },
-    "node_modules/@salesforce/templates": {
-      "version": "66.6.2",
-      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-66.6.2.tgz",
-      "integrity": "sha512-ACrKYF586OtPD9PfDivFL9p66Bb08wbVOlp/FnlphjLFmcVNGxNlmG0bJnZqjHQnckZOvtrVfwBaHxS4iFObtg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@salesforce/kit": "^3.2.4",
-        "ejs": "^3.1.10",
-        "got": "^11.8.6",
-        "hpagent": "^1.2.0",
-        "mime-types": "^3.0.2",
-        "proxy-from-env": "^1.1.0",
-        "tar": "^7.5.12",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18.18.2"
-      }
-    },
     "node_modules/@salesforce/ts-types": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.12.tgz",
@@ -48719,7 +48700,7 @@
         "@salesforce/salesforcedx-utils-vscode": "*",
         "@salesforce/source-deploy-retrieve": "^12.31.22",
         "@salesforce/source-tracking": "^7.8.6",
-        "@salesforce/templates": "^66.6.2",
+        "@salesforce/templates": "^66.7.0",
         "@salesforce/ts-types": "2.0.12",
         "@salesforce/vscode-i18n": "*",
         "@salesforce/vscode-service-provider": "^1.5.0",
@@ -48779,6 +48760,25 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "packages/salesforcedx-vscode-core/node_modules/@salesforce/templates": {
+      "version": "66.7.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-66.7.0.tgz",
+      "integrity": "sha512-duvdr1aMA4mpm7TFDQPTQY7rB9Yz2iS3TibkNw+K21K0CqBwqJLHsAAl7GdLoCbTqJ0J6uyidaXIj1FnbZ8zcg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@salesforce/kit": "^3.2.4",
+        "ejs": "^3.1.10",
+        "got": "^11.8.6",
+        "hpagent": "^1.2.0",
+        "mime-types": "^3.0.2",
+        "proxy-from-env": "^1.1.0",
+        "tar": "^7.5.12",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.18.2"
       }
     },
     "packages/salesforcedx-vscode-core/node_modules/balanced-match": {
@@ -49121,7 +49121,7 @@
         "@salesforce/o11y-reporter": "^1.8.1",
         "@salesforce/source-deploy-retrieve": "^12.31.22",
         "@salesforce/source-tracking": "^7.8.6",
-        "@salesforce/templates": "^66.6.2",
+        "@salesforce/templates": "^66.7.0",
         "@salesforce/vscode-i18n": "*",
         "@vscode/extension-telemetry": "^1.0.0",
         "effect": "^3.20.0",
@@ -49300,6 +49300,25 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "packages/salesforcedx-vscode-services/node_modules/@salesforce/templates": {
+      "version": "66.7.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-66.7.0.tgz",
+      "integrity": "sha512-duvdr1aMA4mpm7TFDQPTQY7rB9Yz2iS3TibkNw+K21K0CqBwqJLHsAAl7GdLoCbTqJ0J6uyidaXIj1FnbZ8zcg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@salesforce/kit": "^3.2.4",
+        "ejs": "^3.1.10",
+        "got": "^11.8.6",
+        "hpagent": "^1.2.0",
+        "mime-types": "^3.0.2",
+        "proxy-from-env": "^1.1.0",
+        "tar": "^7.5.12",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.18.2"
       }
     },
     "packages/salesforcedx-vscode-services/node_modules/@types/node": {

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -34,7 +34,7 @@
     "@salesforce/salesforcedx-utils-vscode": "*",
     "@salesforce/source-deploy-retrieve": "^12.31.22",
     "@salesforce/source-tracking": "^7.8.6",
-    "@salesforce/templates": "^66.6.2",
+    "@salesforce/templates": "^66.7.0",
     "@salesforce/ts-types": "2.0.12",
     "@salesforce/vscode-i18n": "*",
     "@salesforce/vscode-service-provider": "^1.5.0",

--- a/packages/salesforcedx-vscode-services/package.json
+++ b/packages/salesforcedx-vscode-services/package.json
@@ -43,7 +43,7 @@
     "@salesforce/o11y-reporter": "^1.8.1",
     "@salesforce/source-deploy-retrieve": "^12.31.22",
     "@salesforce/source-tracking": "^7.8.6",
-    "@salesforce/templates": "^66.6.2",
+    "@salesforce/templates": "^66.7.0",
     "@salesforce/vscode-i18n": "*",
     "@vscode/extension-telemetry": "^1.0.0",
     "effect": "^3.20.0",

--- a/packages/salesforcedx-vscode-services/src/core/templateService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/templateService.ts
@@ -45,8 +45,8 @@ export type TemplateOptionsFor<T extends SfTemplates.TemplateType> =
                         ? SfTemplates.VisualforcePageOptions
                         : T extends SfTemplates.TemplateType.StaticResource
                           ? SfTemplates.StaticResourceOptions
-                          : T extends SfTemplates.TemplateType.WebApplication
-                            ? SfTemplates.WebApplicationOptions
+                          : T extends SfTemplates.TemplateType.UIBundle
+                            ? SfTemplates.UIBundleOptions
                             : SfTemplates.TemplateOptions;
 
 /** Params for create - templateType discriminates which options are required */


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Updates `@salesforce/templates` to **v66.7.0** to pick up the naming change of `WebApplication` -> `UiBundle` for the **React External App** and **React Internal App** templates for **SFDX: Create Project**.

### What issues does this PR fix or reference?
@W-21674925@

### External App File Explorer
<img width="381" height="956" alt="Image" src="https://github.com/user-attachments/assets/499874d1-8dc7-4f95-9583-a70584844d07" />
<img width="381" height="956" alt="Image" src="https://github.com/user-attachments/assets/0b7b9bc6-382a-4c02-b6ee-d2c1aab3024a" />

### Internal App File Explorer
<img width="497" height="957" alt="Image" src="https://github.com/user-attachments/assets/59680574-41b1-4da5-8086-88fd0bb10f4d" />
