### PR TITLE
[W-21674925] feat: update @salesforce/templates to v66.7.2 for the UiBundle naming change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48700,7 +48700,7 @@
         "@salesforce/salesforcedx-utils-vscode": "*",
         "@salesforce/source-deploy-retrieve": "^12.31.22",
         "@salesforce/source-tracking": "^7.8.6",
-        "@salesforce/templates": "^66.7.1",
+        "@salesforce/templates": "^66.7.2",
         "@salesforce/ts-types": "2.0.12",
         "@salesforce/vscode-i18n": "*",
         "@salesforce/vscode-service-provider": "^1.5.0",
@@ -48763,9 +48763,9 @@
       }
     },
     "packages/salesforcedx-vscode-core/node_modules/@salesforce/templates": {
-      "version": "66.7.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-66.7.1.tgz",
-      "integrity": "sha512-MCHKy2Fjll528Yoxg7WiSHx3yWKanxFFtpW3IYQQhBpjyh4lkbwT5/iOMfihkqdD9HjzTQxDvAW+FRjCBq2HlQ==",
+      "version": "66.7.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-66.7.2.tgz",
+      "integrity": "sha512-fHfi0ahguBRTQNF8Bbpu6yLiomrg0MUQxu6aAzxHT/F5APk50kxPjkzla3vudZgXsYS2DCP5TjuHB9STNB0MyQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/kit": "^3.2.4",
@@ -49121,7 +49121,7 @@
         "@salesforce/o11y-reporter": "^1.8.1",
         "@salesforce/source-deploy-retrieve": "^12.31.22",
         "@salesforce/source-tracking": "^7.8.6",
-        "@salesforce/templates": "^66.7.1",
+        "@salesforce/templates": "^66.7.2",
         "@salesforce/vscode-i18n": "*",
         "@vscode/extension-telemetry": "^1.0.0",
         "effect": "^3.20.0",
@@ -49303,9 +49303,9 @@
       }
     },
     "packages/salesforcedx-vscode-services/node_modules/@salesforce/templates": {
-      "version": "66.7.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-66.7.1.tgz",
-      "integrity": "sha512-MCHKy2Fjll528Yoxg7WiSHx3yWKanxFFtpW3IYQQhBpjyh4lkbwT5/iOMfihkqdD9HjzTQxDvAW+FRjCBq2HlQ==",
+      "version": "66.7.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-66.7.2.tgz",
+      "integrity": "sha512-fHfi0ahguBRTQNF8Bbpu6yLiomrg0MUQxu6aAzxHT/F5APk50kxPjkzla3vudZgXsYS2DCP5TjuHB9STNB0MyQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/kit": "^3.2.4",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -34,7 +34,7 @@
     "@salesforce/salesforcedx-utils-vscode": "*",
     "@salesforce/source-deploy-retrieve": "^12.31.22",
     "@salesforce/source-tracking": "^7.8.6",
-    "@salesforce/templates": "^66.7.1",
+    "@salesforce/templates": "^66.7.2",
     "@salesforce/ts-types": "2.0.12",
     "@salesforce/vscode-i18n": "*",
     "@salesforce/vscode-service-provider": "^1.5.0",

--- a/packages/salesforcedx-vscode-services/package.json
+++ b/packages/salesforcedx-vscode-services/package.json
@@ -43,7 +43,7 @@
     "@salesforce/o11y-reporter": "^1.8.1",
     "@salesforce/source-deploy-retrieve": "^12.31.22",
     "@salesforce/source-tracking": "^7.8.6",
-    "@salesforce/templates": "^66.7.1",
+    "@salesforce/templates": "^66.7.2",
     "@salesforce/vscode-i18n": "*",
     "@vscode/extension-telemetry": "^1.0.0",
     "effect": "^3.20.0",


### PR DESCRIPTION
### What does this PR do?
Updates `@salesforce/templates` to **v66.7.2** to pick up the naming change of `WebApplication` -> `UiBundle` for the **React External App** and **React Internal App** templates for **SFDX: Create Project**.

### What issues does this PR fix or reference?
@W-21674925@

### External App File Explorer
<img width="541" height="987" alt="Screenshot 2026-03-30 at 12 34 29 PM" src="https://github.com/user-attachments/assets/892e8dd7-af9b-43f3-9d08-a90b43bbb52e" />
<img width="541" height="987" alt="Screenshot 2026-03-30 at 12 34 40 PM" src="https://github.com/user-attachments/assets/c4ff48c6-82df-4972-9c97-92304712b582" />

### Internal App File Explorer
<img width="541" height="987" alt="Screenshot 2026-03-30 at 12 36 03 PM" src="https://github.com/user-attachments/assets/32b8bc51-13e8-4a01-89de-d6b1a24edaa5" />