### PR TITLE
fix: changelog TYPE_REGEX now supports scoped commit messages W-21968600

### DIFF
--- a/scripts/change-log-constants.js
+++ b/scripts/change-log-constants.js
@@ -14,6 +14,6 @@ module.exports = Object.freeze({
   RELEASE_REGEX: new RegExp(/^origin\/release\/v\d{2}\.\d{1,2}\.\d/),
   PR_REGEX: new RegExp(/(\(#\d+\))/),
   COMMIT_REGEX: new RegExp(/^([\da-zA-Z]+)/),
-  TYPE_REGEX: new RegExp(/([a-zA-Z]+)(?:\([\w-]+\))?:/),
+  TYPE_REGEX: new RegExp(/([a-zA-Z]+)(?:\([^)]*\))?:/),
   GUS_WI_REGEX: new RegExp(/\[W-\d+\]\s*/g)
 });


### PR DESCRIPTION
### What does this PR do?

Fixes `TYPE_REGEX` in `scripts/change-log-constants.js` to accept any characters inside scope parentheses. The old pattern `[\w-]+` only matched word characters and hyphens, so multi-word scopes like `fix(apex, lwc):` would fail to match and the commit would be silently dropped from the changelog. The new pattern `[^)]*` matches everything up to the closing paren.

### What issues does this PR fix or reference?

@W-21968600@


Made with [Cursor](https://cursor.com)