### PR TITLE
fix(metadata): code builder org diff via virtual documents W-21971085

### DIFF
--- a/packages/salesforcedx-vscode-metadata/src/commands/sourceDiff.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/sourceDiff.ts
@@ -16,6 +16,7 @@ import { getConflictStateRef } from '../conflict/conflictTreeProvider';
 import { CONFLICTS_VIEW_ID, conflictTreeProvider, ensureConflictView } from '../conflict/conflictView';
 import { nls } from '../messages';
 import { diffComponentSet } from '../shared/diff/diffComponentSet';
+import { resolveDiffUrisForWorkbench } from '../shared/diff/sourceDiffVirtualDocument';
 
 // TODO: this might belong on fsService as an option for readDirectory
 /** Recursively get all file URIs from a directory */
@@ -57,14 +58,11 @@ const sourceDiffCoreEffect = Effect.fn('sourceDiffCore')(function* (sourceUri: U
   const firstPair = diffsOpen[0];
 
   if (firstPair) {
-    yield* Effect.sync(() =>
-      void vscode.commands.executeCommand(
-        'vscode.diff',
-        firstPair.remoteUri,
-        firstPair.localUri,
-        nls.localize('source_diff_title', 'remote', firstPair.fileName, firstPair.fileName)
-      )
+    const title = nls.localize('source_diff_title', 'remote', firstPair.fileName, firstPair.fileName);
+    const { left, right } = yield* Effect.promise(() =>
+      resolveDiffUrisForWorkbench(firstPair.remoteUri, firstPair.localUri)
     );
+    yield* Effect.sync(() => void vscode.commands.executeCommand('vscode.diff', left, right, title));
   }
 
   if (diffsOpen.length >= 2) {

--- a/packages/salesforcedx-vscode-metadata/src/conflict/conflictView.ts
+++ b/packages/salesforcedx-vscode-metadata/src/conflict/conflictView.ts
@@ -11,6 +11,7 @@ import * as SubscriptionRef from 'effect/SubscriptionRef';
 import * as vscode from 'vscode';
 import { nls } from '../messages';
 import { isDiffFilePair, type DiffFilePair } from '../shared/diff/diffTypes';
+import { resolveDiffUrisForWorkbench } from '../shared/diff/sourceDiffVirtualDocument';
 import { detectConflictsFromTracking } from './conflictDetection';
 import { ConflictTreeItem } from './conflictTreeItem';
 import {
@@ -47,9 +48,12 @@ export const ensureConflictView = Effect.fn('ensureConflictView')(function* () {
 export const conflictDiffCommandEffect = (entry: DiffFilePair | ConflictTreeItem) => {
   const pair = isDiffFilePair(entry) ? entry : entry?.pair;
   return pair && isDiffFilePair(pair)
-    ? Effect.sync(() => {
+    ? Effect.gen(function* () {
         const title = nls.localize('conflict_detect_diff_title', 'remote', pair.fileName, pair.fileName);
-        void vscode.commands.executeCommand('vscode.diff', pair.remoteUri, pair.localUri, title);
+        const { left, right } = yield* Effect.promise(() =>
+          resolveDiffUrisForWorkbench(pair.remoteUri, pair.localUri)
+        );
+        yield* Effect.sync(() => void vscode.commands.executeCommand('vscode.diff', left, right, title));
       })
     : Effect.void;
 };

--- a/packages/salesforcedx-vscode-metadata/src/index.ts
+++ b/packages/salesforcedx-vscode-metadata/src/index.ts
@@ -38,9 +38,11 @@ import {
   getMetadataRuntime,
   setAllServicesLayer
 } from './services/extensionProvider';
+import { registerSourceDiffVirtualDocumentProvider } from './shared/diff/sourceDiffVirtualDocument';
 import { createSourceTrackingStatusBar } from './statusBar/sourceTrackingStatusBar';
 
 export const activate = async (context: vscode.ExtensionContext): Promise<void> => {
+  registerSourceDiffVirtualDocumentProvider(context);
   const extensionScope = Effect.runSync(getExtensionScope());
   setAllServicesLayer(buildAllServicesLayer(context));
   await getMetadataRuntime().runPromise(activateEffect(context).pipe(Scope.extend(extensionScope)));

--- a/packages/salesforcedx-vscode-metadata/src/shared/diff/diffHelpers.ts
+++ b/packages/salesforcedx-vscode-metadata/src/shared/diff/diffHelpers.ts
@@ -17,6 +17,7 @@ import { Utils } from 'vscode-uri';
 import { nls } from '../../messages';
 import { MissingDefaultOrgError } from './diffErrors';
 import { createDiffFilePair, isDiffFilePair, type DiffFilePair } from './diffTypes';
+import { rebaseFileUriToWorkspaceFolder } from './rebaseFileUriToWorkspaceFolder';
 
 /** Convert file paths to HashableUri set. Uses FsService.toUri for correct scheme (memfs in web). */
 export const pathsToHashableUris = Effect.fn('pathsToHashableUris')(function* (paths: string[]) {
@@ -69,6 +70,8 @@ const createMatchedPair = Effect.fn('createMatchedPair')(function* (props: {
   remoteUris: HashSet.HashSet<HashableUri>;
   projectUri: HashableUri;
 }) {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const fsService = yield* api.services.FsService;
   const { projectUri, remoteUris } = props;
   const projectFileName = Utils.basename(projectUri);
   const projectParentDir = getParentDir(projectUri);
@@ -76,7 +79,11 @@ const createMatchedPair = Effect.fn('createMatchedPair')(function* (props: {
     p => Utils.basename(p) === projectFileName && getParentDir(p) === projectParentDir
   );
   return matchedRemoteUri
-    ? createDiffFilePair({ localUri: projectUri, remoteUri: matchedRemoteUri, fileName: projectFileName })
+    ? createDiffFilePair({
+        localUri: fsService.HashableUri.fromUri(rebaseFileUriToWorkspaceFolder(projectUri)),
+        remoteUri: fsService.HashableUri.fromUri(rebaseFileUriToWorkspaceFolder(matchedRemoteUri)),
+        fileName: projectFileName
+      })
     : yield* Effect.void;
 });
 

--- a/packages/salesforcedx-vscode-metadata/src/shared/diff/rebaseFileUriToWorkspaceFolder.ts
+++ b/packages/salesforcedx-vscode-metadata/src/shared/diff/rebaseFileUriToWorkspaceFolder.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as vscode from 'vscode';
+import { URI, Utils } from 'vscode-uri';
+
+/**
+ * In browser / virtual workspaces (e.g. Code Builder), plain `file://` URIs under the project root may not be
+ * openable by `vscode.diff` ("No file system handle registered"). Re-express a `file` URI using the workspace
+ * folder's URI scheme and path so the workbench resolves it like other workspace files.
+ */
+export const rebaseFileUriToWorkspaceFolder = (uri: URI): URI => {
+  if (uri.scheme !== 'file') {
+    return uri;
+  }
+  const vscodeUri = URI.file(uri.fsPath);
+  const folder =
+    typeof vscode.workspace.getWorkspaceFolder === 'function'
+      ? vscode.workspace.getWorkspaceFolder(vscodeUri) ?? findFolderByFsPathPrefix(uri)
+      : findFolderByFsPathPrefix(uri);
+  if (!folder) {
+    return uri;
+  }
+
+  const relativeFromApi =
+    typeof vscode.workspace.asRelativePath === 'function'
+      ? vscode.workspace.asRelativePath(vscodeUri, false)
+      : vscodeUri.fsPath;
+  const relative =
+    relativeFromApi === vscodeUri.fsPath ? computeManualRelativeToFolder(folder, uri) : relativeFromApi;
+
+  if (relative === vscodeUri.fsPath) {
+    return uri;
+  }
+  if (!relative) {
+    return URI.parse(folder.uri.toString());
+  }
+  const normalized = relative.replaceAll('\\', '/');
+  if (normalized.startsWith('../')) {
+    return uri;
+  }
+  const segments = normalized.split('/').filter(Boolean);
+  const folderUri = URI.parse(folder.uri.toString());
+  return segments.length > 0 ? Utils.joinPath(folderUri, ...segments) : folderUri;
+};
+
+const computeManualRelativeToFolder = (folder: vscode.WorkspaceFolder, uri: URI): string => {
+  const rootPath = folder.uri.fsPath.replaceAll('\\', '/').replace(/\/$/, '');
+  const filePath = uri.fsPath.replaceAll('\\', '/');
+  if (filePath !== rootPath && !filePath.startsWith(`${rootPath}/`)) {
+    return uri.fsPath;
+  }
+  return filePath === rootPath ? '' : filePath.slice(rootPath.length + 1);
+};
+
+const findFolderByFsPathPrefix = (uri: URI): vscode.WorkspaceFolder | undefined => {
+  const folders = vscode.workspace.workspaceFolders;
+  if (!folders?.length) {
+    return undefined;
+  }
+  const normalizedFile = uri.fsPath.replaceAll('\\', '/');
+  return folders.find(f => {
+    const root = f.uri.fsPath.replaceAll('\\', '/').replace(/\/$/, '');
+    return normalizedFile === root || normalizedFile.startsWith(`${root}/`);
+  });
+};

--- a/packages/salesforcedx-vscode-metadata/src/shared/diff/sourceDiffVirtualDocument.ts
+++ b/packages/salesforcedx-vscode-metadata/src/shared/diff/sourceDiffVirtualDocument.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as vscode from 'vscode';
+import { URI, Utils } from 'vscode-uri';
+
+/** Virtual scheme for source diff in VS Code for Web (e.g. Code Builder): workbench cannot open raw `file://` in `vscode.diff`. */
+export const SOURCE_DIFF_VIRTUAL_SCHEME = 'sf-metadata-source-diff';
+
+const contentByUri = new Map<string, string>();
+
+const randomSessionId = (): string =>
+  globalThis.crypto && 'randomUUID' in globalThis.crypto
+    ? globalThis.crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+const decodeUtf8 = (data: Uint8Array): string => new TextDecoder('utf8').decode(data);
+
+export const registerSourceDiffVirtualDocumentProvider = (context: vscode.ExtensionContext): void => {
+  const provider: vscode.TextDocumentContentProvider = {
+    provideTextDocumentContent: (uri: URI): string => contentByUri.get(uri.toString()) ?? ''
+  };
+  context.subscriptions.push(
+    vscode.workspace.registerTextDocumentContentProvider(SOURCE_DIFF_VIRTUAL_SCHEME, provider),
+    vscode.workspace.onDidCloseTextDocument(doc => {
+      if (doc.uri.scheme === SOURCE_DIFF_VIRTUAL_SCHEME) {
+        contentByUri.delete(doc.uri.toString());
+      }
+    })
+  );
+};
+
+/**
+ * On desktop, returns the original URIs. On Web, reads both files via `workspace.fs` and returns virtual URIs
+ * backed by {@link registerSourceDiffVirtualDocumentProvider} so `vscode.diff` can open without a file handle.
+ */
+export const resolveDiffUrisForWorkbench = async (
+  remoteUri: URI,
+  localUri: URI
+): Promise<{ left: URI; right: URI }> => {
+  if (vscode.env.uiKind !== vscode.UIKind.Web) {
+    return { left: remoteUri, right: localUri };
+  }
+  const [remoteBytes, localBytes] = await Promise.all([
+    vscode.workspace.fs.readFile(remoteUri),
+    vscode.workspace.fs.readFile(localUri)
+  ]);
+  const session = randomSessionId();
+  const remoteName = Utils.basename(remoteUri);
+  const localName = Utils.basename(localUri);
+  const left = URI.parse(`${SOURCE_DIFF_VIRTUAL_SCHEME}:/${session}/remote/${remoteName}`);
+  const right = URI.parse(`${SOURCE_DIFF_VIRTUAL_SCHEME}:/${session}/local/${localName}`);
+  contentByUri.set(left.toString(), decodeUtf8(remoteBytes));
+  contentByUri.set(right.toString(), decodeUtf8(localBytes));
+  return { left, right };
+};


### PR DESCRIPTION
### What does this PR do?

Fixes **“Unable to read file … No file system handle registered (/home)”** when opening **org vs. local source diffs** (and conflict diffs) in **Salesforce Code Builder** and other **VS Code for the Web** hosts.

### What issues does this PR fix or reference?

@W-21971085@

---

#### Background: what was going wrong

In **Code Builder**, the workbench runs in the browser. Opening a compare with `vscode.diff` using ordinary **`file://`** URIs under paths such as `/home/codebuilder/...` can fail even when the files exist in the project and in the org. The error surfaces as:

- `Unable to read file '…/force-app/.../MyClass.cls' (Unavailable (FileSystemError): Error: No file system handle registered (/home))`
- The diff tab title still shows the expected pattern, e.g. `remote//MyClass.cls ↔ local//MyClass.cls`, because that title comes from the Salesforce metadata extension’s source-diff command—not because the workbench successfully resolved both sides.

The extension host can often **read** those paths via `vscode.workspace.fs.readFile`, but the **diff editor** in the web workbench resolves **`file://`** URIs through a different path and may not have a registered handle for that `/home` root. So the failure is not “file missing”; it is **URI resolution for the diff UI** in the browser.

#### Why URI “rebasing” alone is not enough

An earlier approach expressed workspace files using `vscode-uri`’s `Utils.joinPath(workspaceFolder.uri, relativeSegments)` so local (and cache) paths align with the workspace folder. That helps when the workspace uses a **non-`file`** scheme (e.g. virtual FS). In Code Builder, the workspace folder is often **already** `file://…`. Joining paths from that root still yields **`file://`** URIs, so **`vscode.diff` sees the same class of URI** and the browser can still refuse to open them.

#### Fix: virtual documents on Web (`UIKind.Web`)

For **`vscode.env.uiKind === vscode.UIKind.Web`**:

1. **Read** both sides with `vscode.workspace.fs.readFile(remoteUri)` and `readFile(localUri)` (same URIs the diff pipeline already uses).
2. **Store** the UTF-8 text in memory, keyed by virtual URI.
3. **Open** the compare with **`vscode.diff`** using URIs in a dedicated scheme: **`sf-metadata-source-diff:`**, served by a **`TextDocumentContentProvider`** registered at metadata extension activation (same general pattern as `sf-org-apex` in Apex Testing).

On **desktop** (`UIKind.Desktop`), behavior is unchanged: **`vscode.diff`** is still invoked with the original remote and local URIs (no eager read, no virtual scheme).

#### Other changes in this PR

- **`rebaseFileUriToWorkspaceFolder`**: When building diff pairs in `diffHelpers`, local and remote URIs are passed through this helper so paths are expressed relative to the workspace folder where applicable (helps desktop and any host where the workspace root is not plain `file://`). Includes guards when `getWorkspaceFolder` / `asRelativePath` are unavailable (e.g. in unit tests).
- **`sourceDiffVirtualDocument.ts`**: Defines `SOURCE_DIFF_VIRTUAL_SCHEME`, `registerSourceDiffVirtualDocumentProvider`, `resolveDiffUrisForWorkbench`, and clears cached content when virtual documents close.
- **`sourceDiff.ts`** and **`conflictView.ts`**: Resolve URIs through `resolveDiffUrisForWorkbench` before `vscode.diff`.
- **`index.ts`**: Registers the virtual document provider on activate.

### Functionality Before

In Code Builder, **Diff against org** / **source diff** / **conflict diff** could fail with **No file system handle registered (/home)** and the compare editor would not open, despite the Apex (or other) source existing locally and in the org.

### Functionality After

On **VS Code for the Web**, the compare opens using **virtual `sf-metadata-source-diff:`** documents backed by content read through **`workspace.fs`**, so the diff editor no longer depends on raw **`file://`** handles for `/home`. Desktop behavior and performance characteristics for normal diffs remain the same.
