### PR TITLE
fix(hashable-uri): strip subclass for vscode RPC serialization W-21972447

### DIFF
--- a/packages/salesforcedx-vscode-metadata/src/commands/sourceDiff.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/sourceDiff.ts
@@ -60,8 +60,8 @@ const sourceDiffCoreEffect = Effect.fn('sourceDiffCore')(function* (sourceUri: U
     yield* Effect.sync(() =>
       void vscode.commands.executeCommand(
         'vscode.diff',
-        firstPair.remoteUri,
-        firstPair.localUri,
+        firstPair.remoteUri.toUri(),
+        firstPair.localUri.toUri(),
         nls.localize('source_diff_title', 'remote', firstPair.fileName, firstPair.fileName)
       )
     );

--- a/packages/salesforcedx-vscode-metadata/src/conflict/conflictView.ts
+++ b/packages/salesforcedx-vscode-metadata/src/conflict/conflictView.ts
@@ -49,14 +49,14 @@ export const conflictDiffCommandEffect = (entry: DiffFilePair | ConflictTreeItem
   return pair && isDiffFilePair(pair)
     ? Effect.sync(() => {
         const title = nls.localize('conflict_detect_diff_title', 'remote', pair.fileName, pair.fileName);
-        void vscode.commands.executeCommand('vscode.diff', pair.remoteUri, pair.localUri, title);
+        void vscode.commands.executeCommand('vscode.diff', pair.remoteUri.toUri(), pair.localUri.toUri(), title);
       })
     : Effect.void;
 };
 
 export const conflictOpenCommandEffect = (node: ConflictTreeItem) => {
   const pair = node?.pair;
-  return pair ? Effect.sync(() => void vscode.window.showTextDocument(pair.localUri)) : Effect.void;
+  return pair ? Effect.sync(() => void vscode.window.showTextDocument(pair.localUri.toUri())) : Effect.void;
 };
 
 /** Detect conflicts, populate tree, focus view. Used when status bar clicked with conflicts. */

--- a/packages/salesforcedx-vscode-metadata/src/conflict/resultStorage.ts
+++ b/packages/salesforcedx-vscode-metadata/src/conflict/resultStorage.ts
@@ -145,7 +145,7 @@ export const buildTimestampIndexFromDir = Effect.fn('resultStorage.buildTimestam
 
   const byKey = yield* Stream.fromIterable(allJsonUris).pipe(
     Stream.mapEffect(uri =>
-      fs.readFile(uri).pipe(
+      fs.readFile(uri.toUri()).pipe(
         Effect.tapError(e => Effect.logWarning('skipping unreadable result file', e)),
         Effect.option,
         // Attach sourceUri so each row remembers which file it came from.
@@ -178,7 +178,7 @@ export const buildTimestampIndexFromDir = Effect.fn('resultStorage.buildTimestam
     // Group by component key; first entry wins because rows are sorted newest-first.
     Effect.map(sortedArray => Object.groupBy(sortedArray, (x: TimestampRow) => x.key)),
     // Delete stale files in the background — best-effort, must not block the caller.
-    Effect.tap(bk => Effect.forkDaemon(Effect.forEach(getStaleUris(bk, allJsonUris), uri => fs.safeDelete(uri))))
+    Effect.tap(bk => Effect.forkDaemon(Effect.forEach(getStaleUris(bk, allJsonUris), uri => fs.safeDelete(uri.toUri()))))
   );
 
   return new Map(Object.entries(byKey).map(([key, rows]) => [key, rows![0].lastModifiedDate]));

--- a/packages/salesforcedx-vscode-metadata/src/shared/diff/diffHelpers.ts
+++ b/packages/salesforcedx-vscode-metadata/src/shared/diff/diffHelpers.ts
@@ -109,7 +109,7 @@ export const matchUrisToComponents = Effect.fn('matchUrisToComponents')(function
 export const filesAreNotIdentical = Effect.fn('filesAreNotIdentical')(function* (pair: DiffFilePair) {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const [buffer1, buffer2] = (yield* Effect.all(
-    [api.services.FsService.readFile(pair.remoteUri), api.services.FsService.readFile(pair.localUri)],
+    [api.services.FsService.readFile(pair.remoteUri.toUri()), api.services.FsService.readFile(pair.localUri.toUri())],
     { concurrency: 'unbounded' }
   ).pipe(
     Effect.tapError(e => Effect.logWarning('filesAreNotIdentical: readFile failed, skipping pair', e)),

--- a/packages/salesforcedx-vscode-services/src/vscode/hashableUri.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/hashableUri.ts
@@ -61,4 +61,9 @@ export class HashableUri extends URI {
   }): HashableUri {
     return HashableUri.fromUri(URI.from(components));
   }
+
+  /** Strip HashableUri subclass back to a plain URI for RPC serialization (e.g. vscode.diff) */
+  public toUri(): URI {
+    return URI.from({ scheme: this.scheme, authority: this.authority, path: this.path, query: this.query, fragment: this.fragment });
+  }
 }


### PR DESCRIPTION
### What does this PR do?

`HashableUri` extends `URI` but VS Code's internal RPC serializer uses `instanceof URI` checks, causing diff commands to fail when passed a subclass instance. Add `toUri()` to strip back to a plain `URI`, and call it wherever we pass `HashableUri` to `vscode.diff` / `vscode.window.showTextDocument`.

### What issues does this PR fix or reference?

@W-21972447@

### Functionality Before

`vscode.diff` and conflict view diff commands failed / showed incorrect URIs when `HashableUri` instances were passed directly.

### Functionality After

Diff commands work correctly — URIs are serialized as plain `vscode-uri` `URI` instances.

Made with [Cursor](https://cursor.com)