### PR TITLE
fix: CBW esbuild web config returns undefined when no org alias set W-21985385

### DIFF
--- a/packages/salesforcedx-vscode-services/esbuild.config.mjs
+++ b/packages/salesforcedx-vscode-services/esbuild.config.mjs
@@ -88,10 +88,10 @@ const buildWebConfig = async () => {
       console.error(`[esbuild] Failed to get web config from org ${process.env.ESBUILD_WEB_ORG_ALIAS}:`, error.message);
       throw error;
     }
-  }
 
-  // Enable file traces — span files in ~/.sf/vscode-spans/
-  configMap['salesforcedx-vscode-salesforcedx.enableFileTraces'] = true;
+    // Enable file traces — span files in ~/.sf/vscode-spans/
+    configMap['salesforcedx-vscode-salesforcedx.enableFileTraces'] = true;
+  }
 
   // Read extra settings if ESBUILD_WEB_LOCAL is set
   if (process.env.ESBUILD_WEB_LOCAL) {

--- a/packages/salesforcedx-vscode-services/esbuild.config.mjs
+++ b/packages/salesforcedx-vscode-services/esbuild.config.mjs
@@ -64,9 +64,9 @@ const repoRoot = join(packageDir, '../..');
 // Derive section and keys from package.json contributes.configuration.properties
 
 const buildWebConfig = async () => {
-  const configMap = {};
-
   if (process.env.ESBUILD_WEB_ORG_ALIAS) {
+    const configMap = {};
+
     try {
       const { stdout } = await execAsync(`sf org display -o ${process.env.ESBUILD_WEB_ORG_ALIAS} --json`, {
         env: { ...process.env, NO_COLOR: '1' }
@@ -91,23 +91,22 @@ const buildWebConfig = async () => {
 
     // Enable file traces — span files in ~/.sf/vscode-spans/
     configMap['salesforcedx-vscode-salesforcedx.enableFileTraces'] = true;
-  }
 
-  // Read extra settings if ESBUILD_WEB_LOCAL is set
-  if (process.env.ESBUILD_WEB_LOCAL) {
-    const extraSettingsPath = join(repoRoot, '.esbuild-web-extra-settings.json');
-    if (existsSync(extraSettingsPath)) {
-      try {
-        const extraSettingsContent = await readFile(extraSettingsPath, 'utf-8');
-        const extraSettings = JSON.parse(extraSettingsContent);
-        Object.assign(configMap, extraSettings);
-      } catch (error) {
-        console.warn(`Failed to read extra settings: ${error.message}`);
+    // Read extra settings if ESBUILD_WEB_LOCAL is set
+    if (process.env.ESBUILD_WEB_LOCAL) {
+      const extraSettingsPath = join(repoRoot, '.esbuild-web-extra-settings.json');
+      if (existsSync(extraSettingsPath)) {
+        try {
+          const extraSettingsContent = await readFile(extraSettingsPath, 'utf-8');
+          const extraSettings = JSON.parse(extraSettingsContent);
+          Object.assign(configMap, extraSettings);
+        } catch (error) {
+          console.warn(`Failed to read extra settings: ${error.message}`);
+        }
       }
     }
+    return JSON.stringify(configMap);
   }
-
-  return Object.keys(configMap).length > 0 ? JSON.stringify(configMap) : undefined;
 };
 
 // Desktop build (Node.js environment)


### PR DESCRIPTION
### What does this PR do?

Scopes `buildWebConfig()` config-map creation and all related logic (file traces, extra settings) inside the `ESBUILD_WEB_ORG_ALIAS` guard so CI builds that lack the env var get `undefined` instead of a populated config object that triggers workspace-config setup.

### What issues does this PR fix or reference?

@W-21985385@

### Before/After

**Before:** `buildWebConfig()` always returned a config string (at minimum `enableFileTraces`), even without `ESBUILD_WEB_ORG_ALIAS`, causing web auth workspace config to execute in CI.

**After:** Returns `undefined` when `ESBUILD_WEB_ORG_ALIAS` is unset; all config logic only runs when the env var is present.

Made with [Cursor](https://cursor.com)