### PR TITLE
chore: bump @salesforce/source-tracking to ^7.8.10 W-21988088

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7880,9 +7880,9 @@
       "link": true
     },
     "node_modules/@salesforce/source-deploy-retrieve": {
-      "version": "12.32.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.32.1.tgz",
-      "integrity": "sha512-q3u6bxgv3b4UscVvtWXCllgf5WouQd86IG7Kg76kyFryTTMBoSJIygRXNm5EMwlsHwBvfJhTn8zdpesJ1HkgPQ==",
+      "version": "12.32.3",
+      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.32.3.tgz",
+      "integrity": "sha512-fHB4SAelLJPim4GA/xI0ob9aXVosIISGM3nkyxVif3zj9XAa6F5xzof1SbtM2QQ4PUXl+xkr6dwcRMcVuH26kQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@salesforce/core": "^8.27.1",
@@ -7935,14 +7935,14 @@
       }
     },
     "node_modules/@salesforce/source-tracking": {
-      "version": "7.8.8",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-tracking/-/source-tracking-7.8.8.tgz",
-      "integrity": "sha512-+sEJb+AhZRtuxvTu5ADfIyBX+OpQ4hoR4b+HPYjC8dnloJs+xgU3RLWm/pe7xcbP0q2/Tv36HJ7wAPIapcGKdA==",
+      "version": "7.8.10",
+      "resolved": "https://registry.npmjs.org/@salesforce/source-tracking/-/source-tracking-7.8.10.tgz",
+      "integrity": "sha512-rCAz9mDWxAI/Gv5XJ+vKZU2+PVh38KUfvYezWv81audKeJc5ZD5H7IESGIIJCjLw2z3YLX+cDiemFG1wtM/Lgg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@salesforce/core": "^8.27.1",
-        "@salesforce/kit": "^3.2.4",
-        "@salesforce/source-deploy-retrieve": "^12.32.1",
+        "@salesforce/core": "^8.28.1",
+        "@salesforce/kit": "^3.2.6",
+        "@salesforce/source-deploy-retrieve": "^12.32.3",
         "@salesforce/ts-types": "^2.0.12",
         "fast-xml-parser": "^5.5.7",
         "graceful-fs": "^4.2.11",
@@ -7951,6 +7951,15 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@salesforce/source-tracking/node_modules/@salesforce/kit": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@salesforce/kit/-/kit-3.2.6.tgz",
+      "integrity": "sha512-O8S4LWerHa9Zosqh+IoQjgLtpxMOfObRxaRnUdRV4MLtFUi+bQxQiyFvve6eEaBaMP1b1xVDQpvSvQ+PXEDGFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@salesforce/ts-types": "^2.0.12"
       }
     },
     "node_modules/@salesforce/templates": {
@@ -46724,7 +46733,7 @@
         "@salesforce/effect-ext-utils": "*",
         "@salesforce/o11y-reporter": "^1.8.1",
         "@salesforce/salesforcedx-utils": "*",
-        "@salesforce/source-tracking": "^7.8.8",
+        "@salesforce/source-tracking": "^7.8.10",
         "@salesforce/vscode-i18n": "*",
         "@salesforce/vscode-service-provider": "^1.5.0",
         "@vscode/extension-telemetry": "^1.0.0",
@@ -48959,7 +48968,7 @@
         "@salesforce/salesforcedx-utils": "*",
         "@salesforce/salesforcedx-utils-vscode": "*",
         "@salesforce/source-deploy-retrieve": "^12.32.1",
-        "@salesforce/source-tracking": "^7.8.8",
+        "@salesforce/source-tracking": "^7.8.10",
         "@salesforce/templates": "^66.7.10",
         "@salesforce/ts-types": "^2.0.12",
         "@salesforce/vscode-i18n": "*",
@@ -49083,7 +49092,7 @@
       "devDependencies": {
         "@salesforce/playwright-vscode-ext": "*",
         "@salesforce/source-deploy-retrieve": "^12.32.1",
-        "@salesforce/source-tracking": "^7.8.8",
+        "@salesforce/source-tracking": "^7.8.10",
         "salesforcedx-vscode-services": "*"
       },
       "engines": {
@@ -49149,7 +49158,7 @@
         "@salesforce/core": "^8.28.0",
         "@salesforce/o11y-reporter": "^1.8.1",
         "@salesforce/source-deploy-retrieve": "^12.32.1",
-        "@salesforce/source-tracking": "^7.8.8",
+        "@salesforce/source-tracking": "^7.8.10",
         "@salesforce/templates": "^66.7.10",
         "@salesforce/vscode-i18n": "*",
         "@vscode/extension-telemetry": "^1.0.0",
@@ -49185,7 +49194,7 @@
         "@opentelemetry/sdk-trace-web": "2.2.0",
         "@salesforce/core": "^8.28.0",
         "@salesforce/source-deploy-retrieve": "^12.32.1",
-        "@salesforce/source-tracking": "^7.8.8",
+        "@salesforce/source-tracking": "^7.8.10",
         "@types/vscode": "^1.90.0",
         "effect": "^3.20.0",
         "jsforce": "^3.10.2",

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -14,7 +14,7 @@
     "@salesforce/effect-ext-utils": "*",
     "@salesforce/o11y-reporter": "^1.8.1",
     "@salesforce/salesforcedx-utils": "*",
-    "@salesforce/source-tracking": "^7.8.8",
+    "@salesforce/source-tracking": "^7.8.10",
     "@salesforce/vscode-i18n": "*",
     "@salesforce/vscode-service-provider": "^1.5.0",
     "@vscode/extension-telemetry": "^1.0.0",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -33,7 +33,7 @@
     "@salesforce/salesforcedx-utils": "*",
     "@salesforce/salesforcedx-utils-vscode": "*",
     "@salesforce/source-deploy-retrieve": "^12.32.1",
-    "@salesforce/source-tracking": "^7.8.8",
+    "@salesforce/source-tracking": "^7.8.10",
     "@salesforce/templates": "^66.7.10",
     "@salesforce/ts-types": "^2.0.12",
     "@salesforce/vscode-i18n": "*",

--- a/packages/salesforcedx-vscode-metadata/package.json
+++ b/packages/salesforcedx-vscode-metadata/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@salesforce/source-deploy-retrieve": "^12.32.1",
-    "@salesforce/source-tracking": "^7.8.8",
+    "@salesforce/source-tracking": "^7.8.10",
     "@salesforce/playwright-vscode-ext": "*",
     "salesforcedx-vscode-services": "*"
   },

--- a/packages/salesforcedx-vscode-services-types/package.json
+++ b/packages/salesforcedx-vscode-services-types/package.json
@@ -78,7 +78,7 @@
     "@opentelemetry/sdk-trace-web": "2.2.0",
     "@salesforce/core": "^8.28.0",
     "@salesforce/source-deploy-retrieve": "^12.32.1",
-    "@salesforce/source-tracking": "^7.8.8",
+    "@salesforce/source-tracking": "^7.8.10",
     "@types/vscode": "^1.90.0",
     "effect": "^3.20.0",
     "jsforce": "^3.10.2",

--- a/packages/salesforcedx-vscode-services/package.json
+++ b/packages/salesforcedx-vscode-services/package.json
@@ -42,7 +42,7 @@
     "@salesforce/core": "^8.28.0",
     "@salesforce/o11y-reporter": "^1.8.1",
     "@salesforce/source-deploy-retrieve": "^12.32.1",
-    "@salesforce/source-tracking": "^7.8.8",
+    "@salesforce/source-tracking": "^7.8.10",
     "@salesforce/templates": "^66.7.10",
     "@salesforce/vscode-i18n": "*",
     "@vscode/extension-telemetry": "^1.0.0",


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-21988088@

### Changes
- Bump `@salesforce/source-tracking` from `^7.8.8` to `^7.8.10` across all 5 consuming packages:
  - `salesforcedx-vscode-metadata`
  - `salesforcedx-utils-vscode`
  - `salesforcedx-vscode-core`
  - `salesforcedx-vscode-services-types`
  - `salesforcedx-vscode-services`
- Update `package-lock.json`


Made with [Cursor](https://cursor.com)