### PR TITLE
fix(metadata): correct success toasts around conflict override and cancel - W-21994945

### DIFF
--- a/packages/salesforcedx-vscode-metadata/src/commands/deployManifest.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/deployManifest.ts
@@ -27,7 +27,6 @@ export const deployManifestCommand = Effect.fn('deployManifestCommand')(
       Effect.flatMap(cs => deployComponentSet({ componentSet: cs }))
     );
   },
-  withConfigurableSuccessNotification(nls.localize('command_succeeded_text', nls.localize('deploy_in_manifest_text'))),
   Effect.catchTag(
     'NoActiveEditorError',
     () => new ManifestSelectionRequiredError({ message: nls.localize('deploy_select_manifest') })
@@ -38,5 +37,6 @@ export const deployManifestCommand = Effect.fn('deployManifestCommand')(
       operationType: err.operationType,
       retryOperation: deployComponentSet({ componentSet: err.componentSet })
     })
-  )
+  ),
+  withConfigurableSuccessNotification(nls.localize('command_succeeded_text', nls.localize('deploy_in_manifest_text')))
 );

--- a/packages/salesforcedx-vscode-metadata/src/commands/projectDeployStart.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/projectDeployStart.ts
@@ -25,6 +25,13 @@ const deployEffect = Effect.fn('projectDeploy.deployEffect')(function* (ignoreCo
 /** Deploy local changes to the default org */
 export const projectDeployStartCommand = (ignoreConflicts = false) =>
   deployEffect(ignoreConflicts).pipe(
+    Effect.catchTag('ConflictsDetectedError', err =>
+      handleConflictWithRetry({
+        pairs: err.pairs,
+        operationType: err.operationType,
+        retryOperation: deployEffect(true)
+      })
+    ),
     withConfigurableSuccessNotification(
       nls.localize(
         'command_succeeded_text',
@@ -36,13 +43,6 @@ export const projectDeployStartCommand = (ignoreConflicts = false) =>
     Effect.catchTag('EmptyComponentSetError', () =>
       Effect.sync(() => {
         void vscode.window.showInformationMessage(nls.localize('no_local_changes_to_deploy'));
-      })
-    ),
-    Effect.catchTag('ConflictsDetectedError', err =>
-      handleConflictWithRetry({
-        pairs: err.pairs,
-        operationType: err.operationType,
-        retryOperation: deployEffect(true)
       })
     )
   );

--- a/packages/salesforcedx-vscode-metadata/src/commands/retrieveManifest.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/retrieveManifest.ts
@@ -29,9 +29,6 @@ export const retrieveManifestCommand = Effect.fn('retrieveManifestCommand')(
 
     yield* retrieveComponentSet({ componentSet, ignoreConflicts: true });
   },
-  withConfigurableSuccessNotification(
-    nls.localize('command_succeeded_text', nls.localize('retrieve_in_manifest_text'))
-  ),
   Effect.catchTag(
     'NoActiveEditorError',
     () => new ManifestSelectionRequiredError({ message: nls.localize('retrieve_select_manifest') })
@@ -42,5 +39,8 @@ export const retrieveManifestCommand = Effect.fn('retrieveManifestCommand')(
       operationType: err.operationType,
       retryOperation: retrieveComponentSet({ componentSet: err.componentSet, ignoreConflicts: true })
     })
+  ),
+  withConfigurableSuccessNotification(
+    nls.localize('command_succeeded_text', nls.localize('retrieve_in_manifest_text'))
   )
 );

--- a/packages/salesforcedx-vscode-metadata/src/commands/retrieveSourcePath.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/retrieveSourcePath.ts
@@ -44,7 +44,6 @@ export const retrieveSourcePathsCommand = Effect.fn('retrieveSourcePathsCommand'
     // we can ignore conflicts because we already did the detectConflicts check
     yield* retrieveComponentSet({ componentSet, ignoreConflicts: true });
   },
-  withConfigurableSuccessNotification(nls.localize('command_succeeded_text', nls.localize('retrieve_this_source_text'))),
   Effect.catchTag('NoActiveEditorError', () =>
     Effect.promise(() => vscode.window.showErrorMessage(nls.localize('retrieve_select_file_or_directory'))).pipe(
       Effect.as(undefined)
@@ -56,5 +55,6 @@ export const retrieveSourcePathsCommand = Effect.fn('retrieveSourcePathsCommand'
       operationType: err.operationType,
       retryOperation: retrieveComponentSet({ componentSet: err.componentSet, ignoreConflicts: true })
     })
-  )
+  ),
+  withConfigurableSuccessNotification(nls.localize('command_succeeded_text', nls.localize('retrieve_this_source_text')))
 );

--- a/packages/salesforcedx-vscode-metadata/src/conflict/conflictFlow.ts
+++ b/packages/salesforcedx-vscode-metadata/src/conflict/conflictFlow.ts
@@ -46,8 +46,8 @@ export const detectConflicts = Effect.fn('detectConflicts')(function* (
 });
 
 /**
- * On conflict: show modal, if Override retry with retryEffect, else cancel.
- * Use for deploy/retrieve where retry with skipConflictCheck/ignoreConflicts is supported.
+ * On conflict: show modal; Override runs retryEffect; View conflicts fails with UserCancellationError
+ * (same as dismiss — command registration handles it without an error toast).
  */
 export const handleConflictWithRetry = Effect.fn('handleConflictWithRetry')(function* <A, E, R>(
   options: HandleConflictWithRetryOptions<A, E, R>
@@ -84,5 +84,8 @@ export const handleConflictWithRetry = Effect.fn('handleConflictWithRetry')(func
     emptyLabel: nls.localize('conflict_detect_no_conflicts')
   });
 
-  return result === 'continue' ? yield* options.retryOperation : yield* Effect.void;
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  return result === 'continue'
+    ? yield* options.retryOperation
+    : yield* new api.services.UserCancellationError();
 });


### PR DESCRIPTION
### What does this PR do?

Fixes two related issues in the Salesforce Metadata extension around **optional success notifications** (`salesforcedx-vscode-metadata.showSuccessNotification`) and the **deploy/retrieve conflict modal**:

1. **Success toast missing after Override** — `Effect.fn` applies pipeline steps in order. `withConfigurableSuccessNotification` uses `Effect.tap` on the generator effect only. When the generator failed first with `ConflictsDetectedError` and the `catchTag` handler ran the retry successfully, that success never passed through the tap, so the configured success message did not appear after override.

2. **False success toast after View conflicts** — `handleConflictWithRetry` returned `Effect.void` when the user chose “View conflicts” instead of Override, so the command still completed successfully and the success tap could run (notably on deploy paths that wrap an inner effect with the notification).

**Changes**

- **`retrieveManifestCommand`, `retrieveSourcePathsCommand`, `deployManifestCommand`** — Move `withConfigurableSuccessNotification` to run **after** the `ConflictsDetectedError` handler (and after `NoActiveEditor`/manifest errors where applicable), so the tap runs on the final success path including post-conflict retry.
- **`projectDeployStartCommand`** — Apply conflict handling first, then the success notification, then `EmptyComponentSetError`. Order avoids both missing the toast after conflict resolution and showing the deploy-success toast when the only outcome is “no local changes.”
- **`handleConflictWithRetry`** — When the user does not choose Override (`View conflicts`), yield `UserCancellationError` (same pattern as dismissing the modal). `registerCommand` already catches that tag and completes silently, so there is no error toast and no false success toast.

### What issues does this PR fix or reference?

@W-21994945@

**GUS:** [W-21994945](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002XwwBIYAZ/view)

### Functionality Before

- With success notifications enabled, Override after a conflict on retrieve (manifest / source path) or deploy (manifest) did not show the success information message.
- Deploy with conflicts → View conflicts → cancel could still show a success notification.

### Functionality After

- Success notification appears when the user overrides conflicts and the operation completes, if the setting is on.
- Choosing View conflicts (non-override path) does not show a success notification; behavior matches user cancellation.

Made with [Cursor](https://cursor.com)