### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/packages/playwright-vscode-ext/src/orgs/shared.ts
+++ b/packages/playwright-vscode-ext/src/orgs/shared.ts
@@ -7,17 +7,23 @@
 
 import type { OrgAuthResult, OrgDisplayResult } from './types';
 import type { AuthFields } from '@salesforce/core';
-import { exec } from 'node:child_process';
+import { exec, execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
 export const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 export const env = { ...process.env, NO_COLOR: '1' };
+const ORG_ALIAS_REGEX = /^[A-Za-z0-9._-]+$/;
 
 /** Try to use existing org, return auth fields if found */
 export const tryUseExistingOrg = async (orgAlias: string): Promise<OrgAuthResult | undefined> => {
+  if (!ORG_ALIAS_REGEX.test(orgAlias)) {
+    return undefined;
+  }
+
   try {
     const displayResponse = JSON.parse(
-      (await execAsync(`sf org display -o ${orgAlias} --json`, { env })).stdout
+      (await execFileAsync('sf', ['org', 'display', '-o', orgAlias, '--json'], { env })).stdout
     ) as OrgDisplayResult;
 
     return {

--- a/packages/playwright-vscode-ext/src/shared/screenshotUtils.ts
+++ b/packages/playwright-vscode-ext/src/shared/screenshotUtils.ts
@@ -22,10 +22,18 @@ export const saveScreenshot = async (page: Page, fileName: string, fullPage = fa
     const testResultsDir = path.join(process.cwd(), 'test-results');
     fs.mkdirSync(testResultsDir, { recursive: true });
 
-    // Create the full path
-    const filePath = path.join(testResultsDir, fileName);
+    if (path.isAbsolute(fileName)) {
+      throw new Error('Invalid screenshot file name');
+    }
 
-    // Take the screenshot
+    const sanitizedFileName = path.basename(fileName);
+    const resolvedTestResultsDir = path.resolve(testResultsDir);
+    const filePath = path.resolve(testResultsDir, sanitizedFileName);
+
+    if (!filePath.startsWith(`${resolvedTestResultsDir}${path.sep}`)) {
+      throw new Error('Invalid screenshot file name');
+    }
+
     await page.screenshot({ path: filePath, fullPage });
 
     return filePath;


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `packages/playwright-vscode-ext/src/orgs/shared.ts:L14`

User-controllable values are interpolated directly into shell commands executed via `child_process.exec`. In `tryUseExistingOrg`, `orgAlias` is embedded in a command string (e.g., ``sf org display -o ${orgAlias} --json``). Because `exec` invokes a shell, metacharacters in `orgAlias` could execute unintended commands. This pattern is also used by callers that pass alias values into other command strings.

## Solution

Replace `exec` with `execFile`/`spawn` and pass arguments as an array (no shell parsing). Validate aliases against a strict allowlist regex (e.g., `^[A-Za-z0-9._-]+$`) before use.

## Changes

- `packages/playwright-vscode-ext/src/orgs/shared.ts` (modified)
- `packages/playwright-vscode-ext/src/shared/screenshotUtils.ts` (modified)