### PR TITLE
fix(soql): toggle button correctly switches from builder view to text editor view when Output Panel is open - W-22014751

### DIFF
--- a/packages/salesforcedx-vscode-soql/src/commands/soqlBuilderToggle.ts
+++ b/packages/salesforcedx-vscode-soql/src/commands/soqlBuilderToggle.ts
@@ -11,6 +11,10 @@ import { URI } from 'vscode-uri';
 import { BUILDER_VIEW_TYPE, EDITOR_VIEW_TYPE, OPEN_WITH_COMMAND } from '../constants';
 
 export const soqlBuilderToggle = Effect.fn('soql_builder_toggle')(function* (doc: URI) {
-  const viewType = vscode.window.activeTextEditor ? BUILDER_VIEW_TYPE : EDITOR_VIEW_TYPE;
+  const activeTab = vscode.window.tabGroups.activeTabGroup.activeTab;
+  const isInBuilderView =
+    activeTab?.input instanceof vscode.TabInputCustom &&
+    activeTab.input.viewType === BUILDER_VIEW_TYPE;
+  const viewType = isInBuilderView ? EDITOR_VIEW_TYPE : BUILDER_VIEW_TYPE;
   yield* Effect.promise(() => vscode.commands.executeCommand(OPEN_WITH_COMMAND, doc, viewType));
 });


### PR DESCRIPTION
### What does this PR do?
The toggle button is supposed to switch between the builder and text editor views for .soql files.  It detects the current view - if the current view is the builder, clicking the button switches to the text editor, and vice versa.

When the Output Panel is open, VSCode exposes its readonly output channel as a `TextEditor`.  This makes it misleading because when you are in the builder view and click the toggle button, the button believes you are actually in the text editor view and gives you the builder view, causing a no-op.

The bug caused this behavior:
1. Open a SOQL query in the builder view
2. Open the Output Tab
3. Click on the button to toggle to the text editor view - it does not work

What I fixed in this PR is to make the toggle button check for the **active editor tab**.  That way the Output Panel does not hijack the `activeTextEditor`, and the builder view is always detected as such when it is the active editor.

### What issues does this PR fix or reference?
@W-22014751@