### PR TITLE
fix(soql): strip the .soql file ending when saving query results as CSV or JSON - W-21735234

### DIFF
--- a/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataFileService.ts
+++ b/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataFileService.ts
@@ -123,7 +123,7 @@ export class QueryDataFileService {
     private format: FileFormat,
     private document: vscode.TextDocument
   ) {
-    this.documentName = getDocumentName(document);
+    this.documentName = stripTrailingExtension(getDocumentName(document), 'soql');
     this.dataProvider = this.getDataProvider();
   }
 

--- a/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataFileService.ts
+++ b/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataFileService.ts
@@ -69,6 +69,19 @@ const validateExportResultsFileNameInput = (value: string, fileExtension: string
 const normalizeExportResultsFileBaseName = (value: string, fileExtension: string): string =>
   stripTrailingExtension(value.trim(), fileExtension);
 
+const writeQueryResultsAndNotify = Effect.fn('queryDataFileService.writeQueryResultsAndNotify')(function* (params: {
+  fileUri: URI;
+  fileContentString: string;
+}) {
+  const { fileUri, fileContentString } = params;
+  const api = yield* getServicesApi;
+  yield* api.services.FsService.writeFile(fileUri, fileContentString);
+  const { fsPath } = yield* api.services.WorkspaceService.getWorkspaceInfoOrThrow();
+  showFileInExplorer(fileUri, fsPath);
+  showSaveSuccessMessage(Utils.basename(fileUri));
+  return fileUri;
+});
+
 const saveQueryResultsViaMemfsPrompts = Effect.fn('queryDataFileService.saveQueryResultsViaMemfsPrompts')(function* (params: {
   queryText: string;
   queryData: QueryResult<JsonMap>;
@@ -106,11 +119,7 @@ const saveQueryResultsViaMemfsPrompts = Effect.fn('queryDataFileService.saveQuer
   yield* promptService.ensureMetadataOverwriteOrThrow({ uris: [fileUri] });
 
   const fileContentString = dataProvider.getFileContent(queryText, queryData.records);
-  yield* api.services.FsService.writeFile(fileUri, fileContentString);
-
-  showFileInExplorer(fileUri, workspaceInfo.fsPath);
-  showSaveSuccessMessage(Utils.basename(fileUri));
-  return fileUri;
+  return yield* writeQueryResultsAndNotify({ fileUri, fileContentString });
 });
 
 export class QueryDataFileService {
@@ -161,19 +170,9 @@ export class QueryDataFileService {
     return uriOrNull ?? undefined;
   }
 
-  private async persistExportedResults(fileUri: URI): Promise<URI | undefined> {
+  private async persistExportedResults(fileUri: URI): Promise<URI> {
     const fileContentString = this.dataProvider.getFileContent(this.queryText, this.queryData.records);
-    const workspacePath = await getSoqlRuntime().runPromise(
-      Effect.gen(function* () {
-        const api = yield* getServicesApi;
-        yield* api.services.FsService.writeFile(fileUri, fileContentString);
-        const { fsPath } = yield* api.services.WorkspaceService.getWorkspaceInfoOrThrow();
-        return fsPath;
-      })
-    );
-    showFileInExplorer(fileUri, workspacePath);
-    showSaveSuccessMessage(Utils.basename(fileUri));
-    return fileUri;
+    return getSoqlRuntime().runPromise(writeQueryResultsAndNotify({ fileUri, fileContentString }));
   }
 }
 

--- a/packages/salesforcedx-vscode-soql/test/jest/queryDataView/queryDataFileService.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/queryDataView/queryDataFileService.test.ts
@@ -40,4 +40,24 @@ describe('Query Data File Service', () => {
     expect(mockRunPromise).toHaveBeenCalled();
     expect(savedFileUri?.fsPath).toEqual(URI.file(savedFilePath).fsPath);
   });
+
+  it('strips .soql extension from the suggested save dialog filename', async () => {
+    const soqlDocument = {
+      uri: URI.file('/path/to/AAA.soql')
+    } as unknown as vscode.TextDocument;
+
+    for (const [format, expectedName] of [
+      [FileFormat.CSV, 'AAA.csv'],
+      [FileFormat.JSON, 'AAA.json']
+    ] as const) {
+      (vscode.window.showSaveDialog as any).mockClear();
+      (vscode.window.showSaveDialog as any).mockReturnValue(undefined);
+
+      const service = new QueryDataFileService(queryText, queryData, format, soqlDocument);
+      await service.save();
+
+      const calledWith = (vscode.window.showSaveDialog as jest.Mock).mock.calls[0][0];
+      expect(calledWith.defaultUri.path.endsWith(expectedName)).toBe(true);
+    }
+  });
 });

--- a/packages/salesforcedx-vscode-soql/test/jest/queryDataView/queryDataFileService.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/queryDataView/queryDataFileService.test.ts
@@ -32,13 +32,14 @@ describe('Query Data File Service', () => {
     const savedFilePath = '/test/path/to/savedFile.json';
     const queryDataFileService = new QueryDataFileService(queryText, queryData, format, document);
 
-    (vscode.window.showSaveDialog as any).mockReturnValue(URI.file(savedFilePath));
-    mockRunPromise.mockResolvedValue('/test/workspace');
+    const savedUri = URI.file(savedFilePath);
+    (vscode.window.showSaveDialog as any).mockReturnValue(savedUri);
+    mockRunPromise.mockResolvedValue(savedUri);
 
     const savedFileUri = await queryDataFileService.save();
 
     expect(mockRunPromise).toHaveBeenCalled();
-    expect(savedFileUri?.fsPath).toEqual(URI.file(savedFilePath).fsPath);
+    expect(savedFileUri?.fsPath).toEqual(savedUri.fsPath);
   });
 
   it('strips .soql extension from the suggested save dialog filename', async () => {


### PR DESCRIPTION
### What does this PR do?
After you execute a SOQL query in the builder view using the "Run Query" button, you have the option to save the results as a CSV or JSON file.  Suppose your SOQL file is named `AAA.soql`.  The suggested names for the CSV and JSON files used to be `AAA.soql.csv` and `AAA.soql.json`.  This PR changes the suggested names to `AAA.csv` and `AAA.json`, which is what users expect.

Also did refactoring of the handling of success notifications after saving the file, to remove duplicate code between the memfs path for Web Console and the desktop path.

### What issues does this PR fix or reference?
@W-21735234@

### Functionality Before
<img width="400" alt="image" src="https://github.com/user-attachments/assets/10c40e74-c999-4207-a04a-a8cae4783b21" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/5643dc62-a51d-4cd4-bdb7-ec6cddcc70d5" />

### Functionality After
<img width="400" alt="Screenshot 2026-04-14 at 12 20 40 PM" src="https://github.com/user-attachments/assets/23fb32a6-3b9a-428d-a3f2-cedea79e1f52" />
<img width="400" alt="Screenshot 2026-04-14 at 12 21 11 PM" src="https://github.com/user-attachments/assets/00e71995-68de-4b9e-b5d2-d0a6880ce685" />

