### PR TITLE
feat(metadata): progress indicator around component set preparation - W-22034326

### DIFF
--- a/packages/salesforcedx-vscode-apex-testing/src/services/extensionProvider.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/services/extensionProvider.ts
@@ -72,9 +72,9 @@ export const setAllServicesLayer = (layer: ReturnType<typeof buildAllServicesLay
  * Built once on first use to avoid rebuilding ComponentSetService and other
  * stateful services across test discovery, runs, and code-completion calls
  */
-const createApexTestingRuntime = () => ManagedRuntime.make(AllServicesLayer);
-let _apexTestingRuntime: ReturnType<typeof createApexTestingRuntime> | undefined;
-export const getApexTestingRuntime = () => {
-  _apexTestingRuntime ??= createApexTestingRuntime();
-  return _apexTestingRuntime;
-};
+type ApexTestingRuntime = ManagedRuntime.ManagedRuntime<
+  Layer.Layer.Success<ReturnType<typeof buildAllServicesLayer>>,
+  Layer.Layer.Error<ReturnType<typeof buildAllServicesLayer>>
+>;
+let _apexTestingRuntime: ApexTestingRuntime | undefined;
+export const getApexTestingRuntime = () => (_apexTestingRuntime ??= ManagedRuntime.make(AllServicesLayer));

--- a/packages/salesforcedx-vscode-metadata/src/commands/deleteSourcePath.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/deleteSourcePath.ts
@@ -15,6 +15,7 @@ import { deleteComponentSet } from '../shared/delete/deleteComponentSet';
 import { type DeleteSourceFailedError } from '../shared/delete/deleteErrors';
 import { formatDeployOutput } from '../shared/deploy/formatDeployOutput';
 import { withConfigurableSuccessNotification } from '../utils/withConfigurableSuccessNotification';
+import { withPreparationProgress } from '../utils/withPreparationProgress';
 
 /** throws the standard UserCancellationError if the user cancels the deletion */
 const showDeleteConfirmation = Effect.fn('showDeleteConfirmation')(function* () {
@@ -28,16 +29,15 @@ const showDeleteConfirmation = Effect.fn('showDeleteConfirmation')(function* () 
   return response === PROCEED ? (true as const) : yield* new api.services.UserCancellationError();
 });
 
-const deletePaths = (uris: URI[]) =>
-  Effect.gen(function* () {
-    const api = yield* (yield* ExtensionProviderService).getServicesApi;
-    const componentSetService = yield* api.services.ComponentSetService;
-    return yield* componentSetService.getComponentSetFromUris(uris).pipe(
-      Effect.flatMap(componentSetService.ensureNonEmptyComponentSet),
-      Effect.tap(cs => detectConflicts(cs, 'delete')),
-      Effect.flatMap(cs => deleteComponentSet({ componentSet: cs }))
-    );
-  });
+const deletePaths = Effect.fn('deletePaths')(function* (uris: URI[]) {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const componentSetService = yield* api.services.ComponentSetService;
+  return yield* componentSetService.getComponentSetFromUris(uris).pipe(
+    Effect.flatMap(componentSetService.ensureNonEmptyComponentSet),
+    withPreparationProgress('delete', cs => detectConflicts(cs, 'delete')),
+    Effect.flatMap(cs => deleteComponentSet({ componentSet: cs }))
+  );
+});
 
 /** Delete source paths from the default org */
 export const deleteSourcePathsCommand = Effect.fn('deleteSourcePaths')(

--- a/packages/salesforcedx-vscode-metadata/src/commands/deployManifest.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/deployManifest.ts
@@ -12,6 +12,7 @@ import { detectConflicts, handleConflictWithRetry } from '../conflict/conflictFl
 import { nls } from '../messages';
 import { deployComponentSet } from '../shared/deploy/deployComponentSet';
 import { withConfigurableSuccessNotification } from '../utils/withConfigurableSuccessNotification';
+import { withPreparationProgress } from '../utils/withPreparationProgress';
 import { ManifestSelectionRequiredError } from './manifestErrors';
 
 export const deployManifestCommand = Effect.fn('deployManifestCommand')(
@@ -23,7 +24,7 @@ export const deployManifestCommand = Effect.fn('deployManifestCommand')(
     return yield* Effect.succeed(resolved).pipe(
       Effect.flatMap(uri => api.services.ComponentSetService.getComponentSetFromManifest(uri)),
       Effect.flatMap(api.services.ComponentSetService.ensureNonEmptyComponentSet),
-      Effect.tap(cs => detectConflicts(cs, 'deploy')),
+      withPreparationProgress('deploy', cs => detectConflicts(cs, 'deploy')),
       Effect.flatMap(cs => deployComponentSet({ componentSet: cs }))
     );
   },

--- a/packages/salesforcedx-vscode-metadata/src/commands/deploySourcePath.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/deploySourcePath.ts
@@ -13,6 +13,7 @@ import { detectConflicts, handleConflictWithRetry } from '../conflict/conflictFl
 import { nls } from '../messages';
 import { deployComponentSet } from '../shared/deploy/deployComponentSet';
 import { withConfigurableSuccessNotification } from '../utils/withConfigurableSuccessNotification';
+import { withPreparationProgress } from '../utils/withPreparationProgress';
 
 // shared logic for both the editor command and the uri command
 const deployUris = Effect.fn('deploySourcePath.deployUris')(
@@ -23,7 +24,7 @@ const deployUris = Effect.fn('deploySourcePath.deployUris')(
     return yield* Effect.succeed(Array.from(uris)).pipe(
       Effect.flatMap(componentSetService.getComponentSetFromUris),
       Effect.flatMap(componentSetService.ensureNonEmptyComponentSet),
-      Effect.tap(cs => detectConflicts(cs, 'deploy')),
+      withPreparationProgress('deploy', cs => detectConflicts(cs, 'deploy')),
       Effect.flatMap(cs => deployComponentSet({ componentSet: cs }))
     );
   },

--- a/packages/salesforcedx-vscode-metadata/src/commands/projectDeployStart.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/projectDeployStart.ts
@@ -12,12 +12,13 @@ import { detectConflicts, handleConflictWithRetry } from '../conflict/conflictFl
 import { nls } from '../messages';
 import { deployComponentSet } from '../shared/deploy/deployComponentSet';
 import { withConfigurableSuccessNotification } from '../utils/withConfigurableSuccessNotification';
+import { withPreparationProgress } from '../utils/withPreparationProgress';
 
 const deployEffect = Effect.fn('projectDeploy.deployEffect')(function* (ignoreConflicts: boolean) {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   return yield* api.services.MetadataDeployService.getComponentSetForDeploy().pipe(
     Effect.flatMap((yield* api.services.ComponentSetService).ensureNonEmptyComponentSet),
-    Effect.tap(cs => (ignoreConflicts ? Effect.void : detectConflicts(cs, 'deploy'))),
+    withPreparationProgress('deploy', ignoreConflicts ? undefined : cs => detectConflicts(cs, 'deploy')),
     Effect.flatMap(cs => deployComponentSet({ componentSet: cs }))
   );
 });

--- a/packages/salesforcedx-vscode-metadata/src/commands/retrieveManifest.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/retrieveManifest.ts
@@ -12,6 +12,7 @@ import { detectConflicts, handleConflictWithRetry } from '../conflict/conflictFl
 import { nls } from '../messages';
 import { retrieveComponentSet } from '../shared/retrieve/retrieveComponentSet';
 import { withConfigurableSuccessNotification } from '../utils/withConfigurableSuccessNotification';
+import { withPreparationProgress } from '../utils/withPreparationProgress';
 import { ManifestSelectionRequiredError } from './manifestErrors';
 
 /** Retrieve from the default org using a manifest file */
@@ -24,7 +25,7 @@ export const retrieveManifestCommand = Effect.fn('retrieveManifestCommand')(
     const componentSet = yield* Effect.succeed(resolved).pipe(
       Effect.flatMap(uri => api.services.ComponentSetService.getComponentSetFromManifest(uri)),
       Effect.flatMap(api.services.ComponentSetService.ensureNonEmptyComponentSet),
-      Effect.tap(cs => detectConflicts(cs, 'retrieve'))
+      withPreparationProgress('retrieve', cs => detectConflicts(cs, 'retrieve'))
     );
 
     yield* retrieveComponentSet({ componentSet, ignoreConflicts: true });

--- a/packages/salesforcedx-vscode-metadata/src/commands/retrieveSourcePath.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/retrieveSourcePath.ts
@@ -13,6 +13,7 @@ import { detectConflicts, handleConflictWithRetry } from '../conflict/conflictFl
 import { nls } from '../messages';
 import { retrieveComponentSet } from '../shared/retrieve/retrieveComponentSet';
 import { withConfigurableSuccessNotification } from '../utils/withConfigurableSuccessNotification';
+import { withPreparationProgress } from '../utils/withPreparationProgress';
 
 /** Retrieve source paths from the default org */
 // When a single file is selected and "Retrieve Source from Org" is executed,
@@ -38,7 +39,7 @@ export const retrieveSourcePathsCommand = Effect.fn('retrieveSourcePathsCommand'
     const componentSet = yield* Effect.succeed(Array.from(resolvedUris)).pipe(
       Effect.flatMap(componentSetService.getComponentSetFromUris),
       Effect.flatMap(componentSetService.ensureNonEmptyComponentSet),
-      Effect.tap(cs => detectConflicts(cs, 'retrieve'))
+      withPreparationProgress('retrieve', cs => detectConflicts(cs, 'retrieve'))
     );
 
     // we can ignore conflicts because we already did the detectConflicts check

--- a/packages/salesforcedx-vscode-metadata/src/commands/retrieveStart/projectRetrieveStart.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/retrieveStart/projectRetrieveStart.ts
@@ -13,6 +13,7 @@ import { nls } from '../../messages';
 import { formatRetrieveOutput } from '../../shared/retrieve/formatRetrieveOutput';
 import { retrieveComponentSet } from '../../shared/retrieve/retrieveComponentSet';
 import { withConfigurableSuccessNotification } from '../../utils/withConfigurableSuccessNotification';
+import { withPreparationProgress } from '../../utils/withPreparationProgress';
 
 /**
  * Apply remote deletes and retrieve non-deletes. Skips retrieve when only deletes exist.
@@ -56,13 +57,14 @@ const retrieveEffect = Effect.fn('retrieveEffect')(
     // that were remotely deleted.
     [...deletesCS].map(member => nonDeletesCS.add(member));
 
-    const combinedCS = yield* componentSetService.ensureNonEmptyComponentSet(nonDeletesCS).pipe(
+    // Build combined CS for conflict detection, then run the actual retrieve.
+    // combinedCS is used only for conflict detection; applyAndRetrieve sources its own component set.
+    yield* componentSetService.ensureNonEmptyComponentSet(nonDeletesCS).pipe(
       Effect.tap(cs =>
         channelService.appendToChannel(`Found ${cs.size} remote change${cs.size === 1 ? '' : 's'} to retrieve`)
-      )
+      ),
+      withPreparationProgress('retrieve', ignoreConflicts ? undefined : cs => detectConflicts(cs, 'retrieve'))
     );
-
-    if (!ignoreConflicts) yield* detectConflicts(combinedCS, 'retrieve');
     yield* applyAndRetrieve();
   },
   Effect.catchTag('ConflictsDetectedError', err =>

--- a/packages/salesforcedx-vscode-metadata/src/commands/retrieveStart/projectRetrieveStart.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/retrieveStart/projectRetrieveStart.ts
@@ -44,22 +44,21 @@ const retrieveEffect = Effect.fn('retrieveEffect')(
       { concurrency: 'unbounded' }
     );
 
-    const [nonDeletesCS, deletesCS] = yield* Effect.all(
+    yield* Effect.all(
       [
         sourceTrackingService.getRemoteNonDeletesAsComponentSet({ applyIgnore: true }),
         sourceTrackingService.getRemoteDeletesAsComponentSet()
       ],
       { concurrency: 'unbounded' }
-    );
-
-    // Merge delete members into non-deletes ComponentSet for a combined conflict check + non-empty guard.
-    // deletesCS members are added so detectConflictsFromTracking filters include locally-modified files
-    // that were remotely deleted.
-    [...deletesCS].map(member => nonDeletesCS.add(member));
-
-    // Build combined CS for conflict detection, then run the actual retrieve.
-    // combinedCS is used only for conflict detection; applyAndRetrieve sources its own component set.
-    yield* componentSetService.ensureNonEmptyComponentSet(nonDeletesCS).pipe(
+    ).pipe(
+      // Merge delete members into non-deletes ComponentSet for a combined conflict check + non-empty guard.
+      // deletesCS members are added so detectConflictsFromTracking filters include locally-modified files
+      // that were remotely deleted.
+      Effect.map(([nonDeletesCS, deletesCS]) => {
+        [...deletesCS].map(member => nonDeletesCS.add(member));
+        return nonDeletesCS;
+      }),
+      Effect.flatMap(componentSetService.ensureNonEmptyComponentSet),
       Effect.tap(cs =>
         channelService.appendToChannel(`Found ${cs.size} remote change${cs.size === 1 ? '' : 's'} to retrieve`)
       ),

--- a/packages/salesforcedx-vscode-metadata/src/messages/i18n.ja.ts
+++ b/packages/salesforcedx-vscode-metadata/src/messages/i18n.ja.ts
@@ -27,6 +27,11 @@ export const messages: Partial<Record<MessageKey, string>> = {
 
   source_diff_title: '%s//%s ↔ ローカル //%s',
 
+  preparing_deployment: 'デプロイの準備中...',
+  preparing_retrieval: '取得の準備中...',
+  preparing_deletion: '削除の準備中...',
+  checking_for_conflicts: '競合を確認中...',
+
   deploy_on_save_error_no_target_org:
     '保存時のデプロイ実行中にエラー: デフォルトの組織が設定されていません。"SFDX: 組織を認証" を実行して、保存した変更をデプロイしてください。'
 };

--- a/packages/salesforcedx-vscode-metadata/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-metadata/src/messages/i18n.ts
@@ -115,6 +115,12 @@ export const messages = {
   conflict_detection_enabled_description:
     "When enabled, check for conflicts before deploy/retrieve on orgs that don't support source tracking. Orgs with tracking always check conflicts.",
 
+  // Preparation phase progress
+  preparing_deployment: 'Preparing deployment...',
+  preparing_retrieval: 'Preparing retrieval...',
+  preparing_deletion: 'Preparing deletion...',
+  checking_for_conflicts: 'Checking for conflicts...',
+
   // SObject refresh
   sobjects_refresh: 'SFDX: Refresh SObject Definitions',
   sobject_refresh_all: 'All SObjects',

--- a/packages/salesforcedx-vscode-metadata/src/services/extensionProvider.ts
+++ b/packages/salesforcedx-vscode-metadata/src/services/extensionProvider.ts
@@ -70,10 +70,10 @@ export const setAllServicesLayer = (layer: ReturnType<typeof buildAllServicesLay
  * Single persistent runtime for metadata extension Effect executions.
  * Built once on first use to avoid rebuilding services across command invocations.
  */
-const createMetadataRuntime = () => ManagedRuntime.make(AllServicesLayer);
+type MetadataRuntime = ManagedRuntime.ManagedRuntime<
+  Layer.Layer.Success<ReturnType<typeof buildAllServicesLayer>>,
+  Layer.Layer.Error<ReturnType<typeof buildAllServicesLayer>>
+>;
 // eslint-disable-next-line functional/no-let
-let _metadataRuntime: ReturnType<typeof createMetadataRuntime> | undefined;
-export const getMetadataRuntime = () => {
-  _metadataRuntime ??= createMetadataRuntime();
-  return _metadataRuntime;
-};
+let _metadataRuntime: MetadataRuntime | undefined;
+export const getMetadataRuntime = () => (_metadataRuntime ??= ManagedRuntime.make(AllServicesLayer));

--- a/packages/salesforcedx-vscode-metadata/src/utils/withPreparationProgress.ts
+++ b/packages/salesforcedx-vscode-metadata/src/utils/withPreparationProgress.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
+import * as Deferred from 'effect/Deferred';
+import * as Effect from 'effect/Effect';
+import * as Exit from 'effect/Exit';
+import * as Runtime from 'effect/Runtime';
+import type { NonEmptyComponentSet, UserCancellationError } from 'salesforcedx-vscode-services';
+import * as vscode from 'vscode';
+import { nls } from '../messages';
+
+type OperationType = 'deploy' | 'retrieve' | 'delete';
+
+const titleKey = (op: OperationType) =>
+  op === 'deploy'
+    ? ('preparing_deployment' as const)
+    : op === 'retrieve'
+      ? ('preparing_retrieval' as const)
+      : ('preparing_deletion' as const);
+
+/**
+ * Pipeable Effect operator that shows a VS Code progress notification during the
+ * preparation phase of a deploy/retrieve/delete command.
+ *
+ * The notification opens immediately when the operator begins executing — before the
+ * preparation effect runs — so users see feedback the moment they invoke the command.
+ *
+ * **Two-phase notification behavior:**
+ * 1. `"Preparing {deployment|retrieval|deletion}..."` — shown while the ComponentSet is built by the upstream `prepare` effect.
+ * 2. `"Checking for conflicts..."` — shown only when `detectConflictsFn` is provided and the ComponentSet was built successfully.
+ *
+ * The notification closes automatically when the preparation completes (success or failure)
+ * or when the user presses the Cancel button.
+ *
+ * **Cancellation:** When the user cancels, the active sub-effect (prepare or conflict detection)
+ * is interrupted via a cancellation Deferred raced against each phase. The operator then fails
+ * with {@link UserCancellationError}, which is silently swallowed by `registerCommandWithLayer`
+ * (same as all other command cancellations).
+ *
+ * **Conflict errors:** Any error thrown by `detectConflictsFn` (e.g. `ConflictsDetectedError`) is
+ * propagated unchanged through the pipeline so command handlers can still
+ * `Effect.catchTag('ConflictsDetectedError', ...)`.
+ *
+ * @param operationType - Determines the initial notification title.
+ * @param detectConflictsFn - Optional conflict detection effect to run after the prepare phase. When omitted (e.g. when `ignoreConflicts` is true), both the conflict phase and its "Checking for conflicts..." message update are skipped.
+ *
+ * @example
+ * Deploy with conflict detection:
+ * ```ts
+ * buildComponentSet.pipe(
+ *   Effect.flatMap(ensureNonEmptyComponentSet),
+ *   withPreparationProgress('deploy', cs => detectConflicts(cs, 'deploy')),
+ *   Effect.flatMap(cs => deployComponentSet({ componentSet: cs }))
+ * )
+ * ```
+ *
+ * @example
+ * Deploy ignoring conflicts (no conflict phase):
+ * ```ts
+ * buildComponentSet.pipe(
+ *   Effect.flatMap(ensureNonEmptyComponentSet),
+ *   withPreparationProgress('deploy'),
+ *   Effect.flatMap(cs => deployComponentSet({ componentSet: cs }))
+ * )
+ * ```
+ */
+export const withPreparationProgress =
+  // ConflictsE/ConflictsR capture the error and requirements of detectConflictsFn so callers
+  // can still catchTag('ConflictsDetectedError', ...) and the runtime requirement is explicit.
+  <ConflictsE = never, ConflictsR = never>(
+    operationType: OperationType,
+    detectConflictsFn?: (cs: NonEmptyComponentSet) => Effect.Effect<void, ConflictsE, ConflictsR>
+  ) =>
+  <E, R>(prepare: Effect.Effect<NonEmptyComponentSet, E, R>) =>
+    Effect.gen(function* () {
+      const api = yield* (yield* ExtensionProviderService).getServicesApi;
+      const runtime = yield* Effect.runtime<R | ConflictsR>();
+      const cancelDeferred = yield* Deferred.make<never, UserCancellationError>();
+
+      const raceWithCancel = <A, E2, R2>(effect: Effect.Effect<A, E2, R2>) =>
+        Effect.raceFirst(effect, Deferred.await(cancelDeferred));
+
+      return yield* Effect.async<NonEmptyComponentSet, E | ConflictsE | UserCancellationError>(resume => {
+        void vscode.window.withProgress(
+          {
+            location: vscode.ProgressLocation.Notification,
+            title: nls.localize(titleKey(operationType)),
+            cancellable: true
+          },
+          async (progress, token) => {
+            token.onCancellationRequested(() =>
+              void Runtime.runPromise(runtime)(
+                Deferred.fail(cancelDeferred, new api.services.UserCancellationError())
+              )
+            );
+
+            const pipeline = Effect.gen(function* () {
+              const cs = yield* raceWithCancel(prepare);
+              if (detectConflictsFn) {
+                yield* Effect.sync(() => progress.report({ message: nls.localize('checking_for_conflicts') }));
+                yield* raceWithCancel(detectConflictsFn(cs));
+              }
+              return cs;
+            });
+
+            const exit = await Runtime.runPromise(runtime)(Effect.exit(pipeline));
+            resume(Exit.isSuccess(exit) ? Effect.succeed(exit.value) : Effect.failCause(exit.cause));
+          }
+        );
+      });
+    });

--- a/packages/salesforcedx-vscode-metadata/src/utils/withPreparationProgress.ts
+++ b/packages/salesforcedx-vscode-metadata/src/utils/withPreparationProgress.ts
@@ -89,7 +89,6 @@ export const withPreparationProgress =
         void vscode.window.withProgress(
           {
             location: vscode.ProgressLocation.Notification,
-            title: nls.localize(titleKey(operationType)),
             cancellable: true
           },
           async (progress, token) => {
@@ -99,10 +98,14 @@ export const withPreparationProgress =
               )
             );
 
+            const report = (key: Parameters<typeof nls.localize>[0]) =>
+              Effect.sync(() => progress.report({ message: nls.localize(key) }));
+
             const pipeline = Effect.gen(function* () {
+              yield* report(titleKey(operationType));
               const cs = yield* raceWithCancel(prepare);
               if (detectConflictsFn) {
-                yield* Effect.sync(() => progress.report({ message: nls.localize('checking_for_conflicts') }));
+                yield* report('checking_for_conflicts');
                 yield* raceWithCancel(detectConflictsFn(cs));
               }
               return cs;

--- a/packages/salesforcedx-vscode-metadata/test/jest/utils/withPreparationProgress.test.ts
+++ b/packages/salesforcedx-vscode-metadata/test/jest/utils/withPreparationProgress.test.ts
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
+import * as Effect from 'effect/Effect';
+import * as vscode from 'vscode';
+import { UserCancellationError } from 'salesforcedx-vscode-services/src/vscode/prompts/promptService';
+import type { NonEmptyComponentSet } from 'salesforcedx-vscode-services';
+import { withPreparationProgress } from '../../../src/utils/withPreparationProgress';
+import { ConflictsDetectedError } from '../../../src/conflict/conflictErrors';
+
+// Minimal branded NonEmptyComponentSet for testing
+const makeCS = (size = 1) => ({ size } as unknown as NonEmptyComponentSet);
+
+const mockUserCancellationError = UserCancellationError;
+
+const createMockServicesApi = () => ({
+  services: {
+    UserCancellationError: mockUserCancellationError
+  }
+});
+
+const createMockExtensionProvider = () =>
+  ({
+    getServicesApi: Effect.succeed(createMockServicesApi())
+  }) as unknown as ExtensionProviderService;
+
+const provideServices = (e: Effect.Effect<unknown, unknown, unknown>) =>
+  e.pipe(Effect.provideService(ExtensionProviderService, createMockExtensionProvider()));
+
+const runWithServices = <A>(effect: Effect.Effect<A, unknown, ExtensionProviderService>) =>
+  Effect.runPromise(effect.pipe(provideServices) as Effect.Effect<A, unknown, never>);
+
+const runWithServicesExit = <A>(effect: Effect.Effect<A, unknown, ExtensionProviderService>) =>
+  Effect.runPromiseExit(effect.pipe(provideServices) as Effect.Effect<A, unknown, never>);
+
+/** Make withProgress call the task callback immediately, returning a controllable token */
+const setupWithProgress = () => {
+  const progress = { report: jest.fn() };
+  const cancellationListeners: (() => void)[] = [];
+  const token = {
+    isCancellationRequested: false,
+    onCancellationRequested: jest.fn((listener: () => void) => {
+      cancellationListeners.push(listener);
+      return { dispose: jest.fn() };
+    })
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (vscode.window.withProgress as jest.Mock).mockImplementation((_options: unknown, task: any) =>
+    task(progress, token)
+  );
+
+  const cancel = () => cancellationListeners.forEach(l => l());
+  return { progress, token, cancel };
+};
+
+describe('withPreparationProgress', () => {
+  describe('notification title', () => {
+    it('shows "Preparing deployment..." for deploy', async () => {
+      setupWithProgress();
+      const cs = makeCS();
+      await runWithServices(Effect.succeed(cs).pipe(withPreparationProgress('deploy')));
+      expect(vscode.window.withProgress).toHaveBeenCalledWith(
+        expect.objectContaining({ title: expect.stringContaining('deployment') }),
+        expect.any(Function)
+      );
+    });
+
+    it('shows "Preparing retrieval..." for retrieve', async () => {
+      setupWithProgress();
+      const cs = makeCS();
+      await runWithServices(Effect.succeed(cs).pipe(withPreparationProgress('retrieve')));
+      expect(vscode.window.withProgress).toHaveBeenCalledWith(
+        expect.objectContaining({ title: expect.stringContaining('retrieval') }),
+        expect.any(Function)
+      );
+    });
+
+    it('shows "Preparing deletion..." for delete', async () => {
+      setupWithProgress();
+      const cs = makeCS();
+      await runWithServices(Effect.succeed(cs).pipe(withPreparationProgress('delete')));
+      expect(vscode.window.withProgress).toHaveBeenCalledWith(
+        expect.objectContaining({ title: expect.stringContaining('deletion') }),
+        expect.any(Function)
+      );
+    });
+  });
+
+  it('returns the ComponentSet from prepare on success', async () => {
+    setupWithProgress();
+    const cs = makeCS(5);
+    const result = await runWithServices(Effect.succeed(cs).pipe(withPreparationProgress('deploy')));
+    expect(result).toBe(cs);
+  });
+
+  it('runs detectConflictsFn when provided', async () => {
+    setupWithProgress();
+    const cs = makeCS();
+    const detectConflictsFn = jest.fn(() => Effect.void);
+
+    await runWithServices(
+      Effect.succeed(cs).pipe(withPreparationProgress('deploy', detectConflictsFn))
+    );
+
+    expect(detectConflictsFn).toHaveBeenCalledWith(cs);
+  });
+
+  it('updates progress message to checking_for_conflicts before running detectConflictsFn', async () => {
+    const { progress } = setupWithProgress();
+    const cs = makeCS();
+    const calls: string[] = [];
+
+    const detectConflictsFn = jest.fn(() => {
+      calls.push('detect');
+      return Effect.void;
+    });
+
+    jest.mocked(progress.report).mockImplementation(({ message }: { message?: string }) => {
+      if (message) calls.push(message);
+    });
+
+    await runWithServices(
+      Effect.succeed(cs).pipe(withPreparationProgress('deploy', detectConflictsFn))
+    );
+
+    const detectIdx = calls.indexOf('detect');
+    const messageIdx = calls.findIndex(c => c.includes('conflict'));
+    expect(messageIdx).toBeGreaterThanOrEqual(0);
+    expect(messageIdx).toBeLessThan(detectIdx);
+  });
+
+  it('does not call detectConflictsFn when not provided', async () => {
+    const { progress } = setupWithProgress();
+    const cs = makeCS();
+    const result = await runWithServices(Effect.succeed(cs).pipe(withPreparationProgress('deploy')));
+
+    expect(result).toBe(cs);
+    expect(progress.report).not.toHaveBeenCalled();
+  });
+
+  it('propagates prepare failures', async () => {
+    setupWithProgress();
+    const error = new Error('build failed');
+    const exit = await runWithServicesExit(
+      Effect.fail(error).pipe(withPreparationProgress('deploy'))
+    );
+
+    expect(exit._tag).toBe('Failure');
+  });
+
+  it('propagates ConflictsDetectedError from detectConflictsFn', async () => {
+    setupWithProgress();
+    const cs = makeCS();
+    const conflictsError = new ConflictsDetectedError({ pairs: [], componentSet: cs, operationType: 'deploy' });
+    const detectConflictsFn = jest.fn(() => Effect.fail(conflictsError));
+
+    const exit = await runWithServicesExit(
+      Effect.succeed(cs).pipe(withPreparationProgress('deploy', detectConflictsFn))
+    );
+
+    expect(exit._tag).toBe('Failure');
+  });
+
+  it('is cancellable — progress notification has cancellable: true', async () => {
+    setupWithProgress();
+    const cs = makeCS();
+    await runWithServices(Effect.succeed(cs).pipe(withPreparationProgress('deploy')));
+
+    expect(vscode.window.withProgress).toHaveBeenCalledWith(
+      expect.objectContaining({ cancellable: true }),
+      expect.any(Function)
+    );
+  });
+
+  it('uses ProgressLocation.Notification', async () => {
+    setupWithProgress();
+    const cs = makeCS();
+    await runWithServices(Effect.succeed(cs).pipe(withPreparationProgress('deploy')));
+
+    expect(vscode.window.withProgress).toHaveBeenCalledWith(
+      expect.objectContaining({ location: vscode.ProgressLocation.Notification }),
+      expect.any(Function)
+    );
+  });
+});

--- a/packages/salesforcedx-vscode-metadata/test/jest/utils/withPreparationProgress.test.ts
+++ b/packages/salesforcedx-vscode-metadata/test/jest/utils/withPreparationProgress.test.ts
@@ -60,34 +60,31 @@ const setupWithProgress = () => {
 };
 
 describe('withPreparationProgress', () => {
-  describe('notification title', () => {
-    it('shows "Preparing deployment..." for deploy', async () => {
-      setupWithProgress();
+  describe('initial progress message', () => {
+    it('reports "Preparing deployment..." for deploy', async () => {
+      const { progress } = setupWithProgress();
       const cs = makeCS();
       await runWithServices(Effect.succeed(cs).pipe(withPreparationProgress('deploy')));
-      expect(vscode.window.withProgress).toHaveBeenCalledWith(
-        expect.objectContaining({ title: expect.stringContaining('deployment') }),
-        expect.any(Function)
+      expect(progress.report).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('deployment') })
       );
     });
 
-    it('shows "Preparing retrieval..." for retrieve', async () => {
-      setupWithProgress();
+    it('reports "Preparing retrieval..." for retrieve', async () => {
+      const { progress } = setupWithProgress();
       const cs = makeCS();
       await runWithServices(Effect.succeed(cs).pipe(withPreparationProgress('retrieve')));
-      expect(vscode.window.withProgress).toHaveBeenCalledWith(
-        expect.objectContaining({ title: expect.stringContaining('retrieval') }),
-        expect.any(Function)
+      expect(progress.report).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('retrieval') })
       );
     });
 
-    it('shows "Preparing deletion..." for delete', async () => {
-      setupWithProgress();
+    it('reports "Preparing deletion..." for delete', async () => {
+      const { progress } = setupWithProgress();
       const cs = makeCS();
       await runWithServices(Effect.succeed(cs).pipe(withPreparationProgress('delete')));
-      expect(vscode.window.withProgress).toHaveBeenCalledWith(
-        expect.objectContaining({ title: expect.stringContaining('deletion') }),
-        expect.any(Function)
+      expect(progress.report).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('deletion') })
       );
     });
   });
@@ -141,7 +138,7 @@ describe('withPreparationProgress', () => {
     const result = await runWithServices(Effect.succeed(cs).pipe(withPreparationProgress('deploy')));
 
     expect(result).toBe(cs);
-    expect(progress.report).not.toHaveBeenCalled();
+    expect(progress.report).toHaveBeenCalledTimes(1);
   });
 
   it('propagates prepare failures', async () => {

--- a/packages/salesforcedx-vscode-org-browser/src/services/extensionProvider.ts
+++ b/packages/salesforcedx-vscode-org-browser/src/services/extensionProvider.ts
@@ -68,10 +68,10 @@ export const setAllServicesLayer = (layer: ReturnType<typeof buildAllServicesLay
  * Built once on first use to avoid rebuilding ComponentSetService and other
  * stateful services on each tree-node expansion
  */
-const createOrgBrowserRuntime = () => ManagedRuntime.make(AllServicesLayer);
+type OrgBrowserRuntime = ManagedRuntime.ManagedRuntime<
+  Layer.Layer.Success<ReturnType<typeof buildAllServicesLayer>>,
+  Layer.Layer.Error<ReturnType<typeof buildAllServicesLayer>>
+>;
 // eslint-disable-next-line functional/no-let
-let _orgBrowserRuntime: ReturnType<typeof createOrgBrowserRuntime> | undefined;
-export const getOrgBrowserRuntime = () => {
-  _orgBrowserRuntime ??= createOrgBrowserRuntime();
-  return _orgBrowserRuntime;
-};
+let _orgBrowserRuntime: OrgBrowserRuntime | undefined;
+export const getOrgBrowserRuntime = () => (_orgBrowserRuntime ??= ManagedRuntime.make(AllServicesLayer));

--- a/packages/salesforcedx-vscode-org/src/extensionProvider.ts
+++ b/packages/salesforcedx-vscode-org/src/extensionProvider.ts
@@ -76,13 +76,12 @@ export const setAllServicesLayer = (layer: ReturnType<typeof buildAllServicesLay
  * Single persistent runtime for org extension Effect executions.
  * Built once on first use to avoid rebuilding services across commands.
  */
-const createOrgRuntime = () => ManagedRuntime.make(AllServicesLayer);
-
-let _orgRuntime: ReturnType<typeof createOrgRuntime> | undefined;
-export const getOrgRuntime = () => {
-  _orgRuntime ??= createOrgRuntime();
-  return _orgRuntime;
-};
+type OrgRuntime = ManagedRuntime.ManagedRuntime<
+  Layer.Layer.Success<ReturnType<typeof buildAllServicesLayer>>,
+  Layer.Layer.Error<ReturnType<typeof buildAllServicesLayer>>
+>;
+let _orgRuntime: OrgRuntime | undefined;
+export const getOrgRuntime = () => (_orgRuntime ??= ManagedRuntime.make(AllServicesLayer));
 
 /** Reset cached runtime. Used by tests when AllServicesLayer changes between tests. */
 export const resetOrgRuntimeForTesting = (): void => {

--- a/packages/salesforcedx-vscode-soql/src/services/extensionProvider.ts
+++ b/packages/salesforcedx-vscode-soql/src/services/extensionProvider.ts
@@ -63,10 +63,9 @@ export const setAllServicesLayer = (layer: ReturnType<typeof buildAllServicesLay
  * stateful services across sobject_metadata_request, sobjects_request, and
  * code-completion calls
  */
-const createSoqlRuntime = () => ManagedRuntime.make(AllServicesLayer);
-
-let _soqlRuntime: ReturnType<typeof createSoqlRuntime> | undefined;
-export const getSoqlRuntime = () => {
-  if (!_soqlRuntime) _soqlRuntime = createSoqlRuntime();
-  return _soqlRuntime;
-};
+type SoqlRuntime = ManagedRuntime.ManagedRuntime<
+  Layer.Layer.Success<ReturnType<typeof buildAllServicesLayer>>,
+  Layer.Layer.Error<ReturnType<typeof buildAllServicesLayer>>
+>;
+let _soqlRuntime: SoqlRuntime | undefined;
+export const getSoqlRuntime = () => (_soqlRuntime ??= ManagedRuntime.make(AllServicesLayer));


### PR DESCRIPTION
## Summary
- New `withPreparationProgress` utility shows cancellable progress notification during component set creation, conflict detection, and diff computation before deploy/retrieve/delete
- Refactored deploy, retrieve, and delete commands to use shared preparation flow instead of inline progress handling
- Added i18n messages for progress labels

### What issues does this PR fix or reference?
@W-22034326@
https://github.com/forcedotcom/salesforcedx-vscode/issues/7188

## Test plan
- [ ] Deploy/retrieve/delete commands show progress during preparation
- [ ] Cancelling progress cancels the operation
- [ ] Unit tests pass for `withPreparationProgress`


Made with [Cursor](https://cursor.com)