### PR TITLE
ci: publish salesforcedx-vscode-i18n to npm independently - W-22048490

### DIFF
--- a/.github/workflows/publishI18nPackage.yml
+++ b/.github/workflows/publishI18nPackage.yml
@@ -1,20 +1,101 @@
 name: Publish i18n Package to npm
 
 on:
-  release:
-    types: [released]
+  push:
+    branches:
+      - develop
+    paths:
+      - 'packages/salesforcedx-vscode-i18n/**'
   workflow_dispatch:
     inputs:
-      githubTag:
-        description: release tag to publish (e.g., v65.4.0)
-        required: true
+      tag:
+        description: 'Release tag to publish (e.g., vscode-i18n-v1.0.4). Leave empty to create a new release from commits.'
+        required: false
         type: string
+      releaseType:
+        description: 'Version bump type when creating a new release from commits (ignored if tag is provided)'
+        required: false
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 jobs:
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ steps.tag-output.outputs.tag }}
+    steps:
+      - name: Get Github user info
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.tag == ''
+        id: github-user-info
+        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@main
+        with:
+          SVC_CLI_BOT_GITHUB_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
+
+      - uses: actions/checkout@v4
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.tag == ''
+        with:
+          token: ${{ secrets.IDEE_GH_TOKEN }}
+          fetch-depth: 0
+
+      - name: Conventional Changelog Action
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.tag == ''
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@3a392e9aa44a72686b0fc13259a90d287dd0877c
+        env:
+          RELEASE_TYPE: ${{ github.event.inputs.releaseType }}
+        with:
+          git-user-name: ${{ steps.github-user-info.outputs.username }}
+          git-user-email: ${{ steps.github-user-info.outputs.email }}
+          github-token: ${{ secrets.IDEE_GH_TOKEN }}
+          tag-prefix: 'vscode-i18n-v'
+          version-file: './packages/salesforcedx-vscode-i18n/package.json'
+          git-path: 'packages/salesforcedx-vscode-i18n'
+          release-count: '0'
+          output-file: 'packages/salesforcedx-vscode-i18n/CHANGELOG.md'
+          skip-on-empty: ${{ github.event_name == 'push' }}
+          skip-tag: false
+          pre-changelog-generation: packages/salesforcedx-vscode-i18n/scripts/vscode-i18n-version-hook.js
+          pre-commit: packages/salesforcedx-vscode-i18n/scripts/vscode-i18n-version-hook.js
+
+      - name: Create Github Release
+        if: steps.changelog.outputs.skipped == 'false'
+        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b
+        with:
+          name: ${{ steps.changelog.outputs.tag }}
+          tag: ${{ steps.changelog.outputs.tag }}
+          commit: develop
+          body: ${{ steps.changelog.outputs.clean_changelog }}
+          token: ${{ secrets.IDEE_GH_TOKEN }}
+          skipIfReleaseExists: true
+
+      - id: tag-output
+        run: |
+          if [ -n "$INPUT_TAG" ]; then
+            echo "tag=$INPUT_TAG" >> $GITHUB_OUTPUT
+          elif [ "$CHANGELOG_SKIPPED" != "true" ] && [ -n "$CHANGELOG_TAG" ]; then
+            echo "tag=$CHANGELOG_TAG" >> $GITHUB_OUTPUT
+          else
+            echo "tag=" >> $GITHUB_OUTPUT
+          fi
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          CHANGELOG_SKIPPED: ${{ steps.changelog.outputs.skipped }}
+          CHANGELOG_TAG: ${{ steps.changelog.outputs.tag }}
+
   publish:
+    name: Build and publish to npm
+    needs: create-release
+    if: needs.create-release.outputs.tag != ''
     uses: salesforcecli/github-workflows/.github/workflows/npmPublish.yml@main
     with:
-      githubTag: ${{ github.event.release.tag_name || inputs.githubTag }}
+      githubTag: ${{ needs.create-release.outputs.tag }}
       packageManager: npm
       nodeVersion: ${{ vars.NODE_VERSION || 'lts/*' }}
       packagePath: ./packages/salesforcedx-vscode-i18n

--- a/.github/workflows/publishSoqlCommon.yml
+++ b/.github/workflows/publishSoqlCommon.yml
@@ -61,8 +61,8 @@ jobs:
           output-file: 'packages/soql-common/CHANGELOG.md'
           skip-on-empty: ${{ github.event_name == 'push' }}
           skip-tag: false
-          pre-changelog-generation: scripts/soql-common-version-hook.js
-          pre-commit: scripts/soql-common-version-hook.js
+          pre-changelog-generation: packages/soql-common/scripts/soql-common-version-hook.js
+          pre-commit: packages/soql-common/scripts/soql-common-version-hook.js
 
       - name: Create Github Release
         if: steps.changelog.outputs.skipped == 'false'

--- a/packages/playwright-vscode-ext/src/utils/helpers.ts
+++ b/packages/playwright-vscode-ext/src/utils/helpers.ts
@@ -71,7 +71,9 @@ const NON_CRITICAL_ERROR_PATTERNS: readonly string[] = [
   'workspaceStorage', // Workspace storage access errors during initialization (non-critical)
   'Illegal assignment from String to Integer', // Execute anonymous compile error (intentionally triggered in E2E)
   'Network error occurred', // VS Code Extension Host IPC keep-alive poller warning (non-critical)
-  'PerfSampleError' // Electron perf sampling noise (non-critical, unrelated to extension behavior)
+  'PerfSampleError', // Electron perf sampling noise (non-critical, unrelated to extension behavior)
+  'copilotCli', // GitHub Copilot CLI extension noise (non-critical)
+  'remoteAgentHostService' // VS Code remote agent host service noise (non-critical)
 ] as const;
 
 const NON_CRITICAL_NETWORK_PATTERNS: readonly string[] = [

--- a/packages/salesforcedx-vscode-i18n/package.json
+++ b/packages/salesforcedx-vscode-i18n/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@salesforce/vscode-i18n",
   "version": "66.6.0",
+  "versionedIndependently": true,
   "description": "Internationalization (i18n) library for Salesforce VS Code extensions",
   "author": "Salesforce",
   "license": "BSD-3-Clause",
@@ -15,14 +16,23 @@
   "main": "out/src/index.js",
   "types": "out/src/index.d.ts",
   "exports": {
-    ".": "./out/src/index.js",
-    "./tsPlugin": "./out/src/hover/tsPlugin.js"
+    ".": {
+      "types": "./out/src/index.d.ts",
+      "default": "./out/src/index.js"
+    },
+    "./tsPlugin": {
+      "types": "./out/src/hover/tsPlugin.d.ts",
+      "default": "./out/src/hover/tsPlugin.js"
+    }
   },
   "files": [
     "tsPlugin.js",
-    "out/**/*.js",
-    "out/**/*.d.ts",
-    "out/**/*.d.ts.map"
+    "out/src/**/*.js",
+    "out/src/**/*.js.map",
+    "out/src/**/*.d.ts",
+    "out/src/**/*.d.ts.map",
+    "LICENSE.txt",
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/salesforcedx-vscode-i18n/scripts/vscode-i18n-version-hook.js
+++ b/packages/salesforcedx-vscode-i18n/scripts/vscode-i18n-version-hook.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+/**
+ * pre-changelog-generation hook for TriPSs/conventional-changelog-action.
+ * When RELEASE_TYPE env var is set (from workflow_dispatch input), override
+ * the version bump type instead of relying solely on conventional commits.
+ */
+exports.preVersionGeneration = (proposedVersion) => {
+  const releaseType = process.env.RELEASE_TYPE
+  if (!releaseType || !['major', 'minor', 'patch'].includes(releaseType)) {
+    return proposedVersion
+  }
+  const { version } = require('../package.json')
+  const [major, minor, patch] = version.split('.').map(Number)
+  if (releaseType === 'major') return `${major + 1}.0.0`
+  if (releaseType === 'minor') return `${major}.${minor + 1}.0`
+  return `${major}.${minor}.${patch + 1}`
+}
+
+/**
+ * pre-commit hook for TriPSs/conventional-changelog-action.
+ * Patches the vscode-i18n version in the root package-lock.json so it stays
+ * in sync with the bumped packages/salesforcedx-vscode-i18n/package.json.
+ */
+exports.preCommit = ({ version }) => {
+  const lockPath = path.join(process.env.GITHUB_WORKSPACE, 'package-lock.json')
+  const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'))
+  if (lock.packages?.['packages/salesforcedx-vscode-i18n']) {
+    lock.packages['packages/salesforcedx-vscode-i18n'].version = version
+  }
+  fs.writeFileSync(lockPath, JSON.stringify(lock, null, 2) + '\n')
+}

--- a/packages/soql-common/scripts/soql-common-version-hook.js
+++ b/packages/soql-common/scripts/soql-common-version-hook.js
@@ -13,7 +13,7 @@ exports.preVersionGeneration = (proposedVersion) => {
   if (!releaseType || !['major', 'minor', 'patch'].includes(releaseType)) {
     return proposedVersion
   }
-  const { version } = require('../packages/soql-common/package.json')
+  const { version } = require('../package.json')
   const [major, minor, patch] = version.split('.').map(Number)
   if (releaseType === 'major') return `${major + 1}.0.0`
   if (releaseType === 'minor') return `${major}.${minor + 1}.0`


### PR DESCRIPTION
### What does this PR do?

- Configures `@salesforce/vscode-i18n` to publish to npm independently of the main extension release cycle, mirroring the `soql-common` pattern
- Adds `versionedIndependently: true` so `create-release-branch.js` skips i18n during main version bumps
- Narrows `files` to `out/src/**` (removes test artifacts); adds `types` to each export condition
- Moves `scripts/soql-common-version-hook.js` into `packages/soql-common/scripts/` (co-located)
- Adds `packages/salesforcedx-vscode-i18n/scripts/vscode-i18n-version-hook.js`
- Rewrites `publishI18nPackage.yml` to trigger on push to `develop` with conventional-changelog, tag prefix `vscode-i18n-v`, and `workflow_dispatch` support

### What issues does this PR fix or reference?
@W-22048490@

### Functionality Before

n/a — CI/publishing change only

### Functionality After

Merging to `develop` triggers an independent version bump and npm publish of `@salesforce/vscode-i18n`.

Made with [Cursor](https://cursor.com)