### PR TITLE
ci: cache VS Code binaries in GHA to prevent e2e CI timeouts - W-22065072

### DIFF
--- a/.github/actions/cache-vscode-desktop/action.yml
+++ b/.github/actions/cache-vscode-desktop/action.yml
@@ -1,0 +1,31 @@
+name: Cache VS Code Desktop
+description: Restore VS Code Desktop cache; rewrites PLAYWRIGHT_VSCODE_VERSION to on-disk version when only a fallback exists; save after job regardless of test outcome
+inputs:
+  vscode-version:
+    description: VS Code version for cache key (e.g. 1.97.0)
+    required: true
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache/restore@v4
+      id: restore
+      with:
+        path: .vscode-test
+        key: vscode-desktop-${{ runner.os }}-${{ inputs.vscode-version }}
+        restore-keys: vscode-desktop-${{ runner.os }}-
+    - shell: bash
+      run: |
+        exact=$(ls .vscode-test 2>/dev/null | grep -E "^vscode-.*-${{ inputs.vscode-version }}$" | head -1)
+        if [ -z "$exact" ]; then
+          fallback=$(ls .vscode-test 2>/dev/null | grep -E '^vscode-.*-[0-9.]+$' | sort -V | tail -1)
+          if [ -n "$fallback" ]; then
+            onDisk=$(echo "$fallback" | sed -E 's/.*-([0-9.]+)$/\1/')
+            echo "PLAYWRIGHT_VSCODE_VERSION=$onDisk" >> "$GITHUB_ENV"
+            echo "Fallback: using on-disk version $onDisk instead of pinned ${{ inputs.vscode-version }}"
+          fi
+        fi
+    - uses: actions/cache/save@v4
+      if: always() && steps.restore.outputs.cache-hit != 'true'
+      with:
+        path: .vscode-test
+        key: vscode-desktop-${{ runner.os }}-${{ inputs.vscode-version }}

--- a/.github/actions/cache-vscode-web/action.yml
+++ b/.github/actions/cache-vscode-web/action.yml
@@ -1,0 +1,24 @@
+name: Cache VS Code Web
+description: Restore VS Code Web cache, detect cached commit, save after job regardless of test outcome
+inputs:
+  vscode-version:
+    description: VS Code version for cache key (e.g. 1.97.0)
+    required: true
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache/restore@v4
+      id: restore
+      with:
+        path: .vscode-test-web
+        key: vscode-web-${{ inputs.vscode-version }}
+        restore-keys: vscode-web-
+    - shell: bash
+      run: |
+        dir=$(ls .vscode-test-web 2>/dev/null | grep -E '^vscode-web-stable-' | head -1)
+        [ -n "$dir" ] && echo "PLAYWRIGHT_WEB_VSCODE_COMMIT=${dir#vscode-web-stable-}" >> "$GITHUB_ENV"
+    - uses: actions/cache/save@v4
+      if: always() && steps.restore.outputs.cache-hit != 'true'
+      with:
+        path: .vscode-test-web
+        key: vscode-web-${{ inputs.vscode-version }}

--- a/.github/workflows/apexLogE2E.yml
+++ b/.github/workflows/apexLogE2E.yml
@@ -137,7 +137,7 @@ jobs:
       MINIMAL_ORG_ALIAS: minimalTestOrg
       SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL_E2E }}
       VSCODE_DESKTOP: 1
-      PLAYWRIGHT_DESKTOP_VSCODE_VERSION: ${{ vars.PLAYWRIGHT_DESKTOP_VSCODE_VERSION }}
+      PLAYWRIGHT_VSCODE_VERSION: ${{ vars.PLAYWRIGHT_VSCODE_VERSION }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/apexReplayDebuggerE2E.yml
+++ b/.github/workflows/apexReplayDebuggerE2E.yml
@@ -33,7 +33,7 @@ jobs:
       MINIMAL_ORG_ALIAS: minimalTestOrg
       SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL_E2E }}
       VSCODE_DESKTOP: 1
-      PLAYWRIGHT_DESKTOP_VSCODE_VERSION: ${{ vars.PLAYWRIGHT_DESKTOP_VSCODE_VERSION }}
+      PLAYWRIGHT_VSCODE_VERSION: ${{ vars.PLAYWRIGHT_VSCODE_VERSION }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/apexTestingE2E.yml
+++ b/.github/workflows/apexTestingE2E.yml
@@ -156,7 +156,7 @@ jobs:
       MINIMAL_ORG_ALIAS: minimalTestOrg
       SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL_E2E }}
       VSCODE_DESKTOP: 1
-      PLAYWRIGHT_DESKTOP_VSCODE_VERSION: ${{ vars.PLAYWRIGHT_DESKTOP_VSCODE_VERSION }}
+      PLAYWRIGHT_VSCODE_VERSION: ${{ vars.PLAYWRIGHT_VSCODE_VERSION }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -33,7 +33,7 @@ jobs:
       MINIMAL_ORG_ALIAS: minimalTestOrg
       SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL_E2E }}
       VSCODE_DESKTOP: 1
-      PLAYWRIGHT_DESKTOP_VSCODE_VERSION: ${{ vars.PLAYWRIGHT_DESKTOP_VSCODE_VERSION }}
+      PLAYWRIGHT_VSCODE_VERSION: ${{ vars.PLAYWRIGHT_VSCODE_VERSION }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/metadataE2E.yml
+++ b/.github/workflows/metadataE2E.yml
@@ -177,7 +177,7 @@ jobs:
       NON_TRACKING_ORG_ALIAS: nonTrackingTestOrg
       SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL_E2E }}
       VSCODE_DESKTOP: 1
-      PLAYWRIGHT_DESKTOP_VSCODE_VERSION: ${{ vars.PLAYWRIGHT_DESKTOP_VSCODE_VERSION }}
+      PLAYWRIGHT_VSCODE_VERSION: ${{ vars.PLAYWRIGHT_VSCODE_VERSION }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -452,7 +452,7 @@ jobs:
       NON_TRACKING_ORG_ALIAS: nonTrackingTestOrg
       SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL_E2E }}
       VSCODE_DESKTOP: 1
-      PLAYWRIGHT_DESKTOP_VSCODE_VERSION: ${{ vars.PLAYWRIGHT_DESKTOP_VSCODE_VERSION }}
+      PLAYWRIGHT_VSCODE_VERSION: ${{ vars.PLAYWRIGHT_VSCODE_VERSION }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/orgBrowserE2E.yml
+++ b/.github/workflows/orgBrowserE2E.yml
@@ -59,6 +59,11 @@ jobs:
           npm run test:web -w salesforcedx-vscode-org-browser -- --reporter=html
 
       # Only run expensive setup when try-run failed (cache miss). On cache hit we never reach these steps.
+      - uses: ./.github/actions/cache-vscode-web
+        if: steps.try-run.outcome == 'failure'
+        with:
+          vscode-version: ${{ vars.PLAYWRIGHT_VSCODE_VERSION }}
+
       - name: Install Salesforce CLI
         if: steps.try-run.outcome == 'failure'
         uses: salesforcecli/github-workflows/.github/actions/retry@main
@@ -144,7 +149,7 @@ jobs:
     env:
       DREAMHOUSE_ORG_ALIAS: orgBrowserDreamhouseTestOrg
       SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL_E2E }}
-      PLAYWRIGHT_DESKTOP_VSCODE_VERSION: ${{ vars.PLAYWRIGHT_DESKTOP_VSCODE_VERSION }}
+      PLAYWRIGHT_VSCODE_VERSION: ${{ vars.PLAYWRIGHT_VSCODE_VERSION }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -178,6 +183,11 @@ jobs:
           npm run test:desktop -w salesforcedx-vscode-org-browser -- --reporter=html
 
       # Only run expensive setup when try-run failed (cache miss). On cache hit we never reach these steps.
+      - uses: ./.github/actions/cache-vscode-desktop
+        if: steps.try-run.outcome == 'failure'
+        with:
+          vscode-version: ${{ vars.PLAYWRIGHT_VSCODE_VERSION }}
+
       - name: Install Salesforce CLI
         if: steps.try-run.outcome == 'failure'
         uses: salesforcecli/github-workflows/.github/actions/retry@main

--- a/.github/workflows/orgE2E.yml
+++ b/.github/workflows/orgE2E.yml
@@ -31,7 +31,7 @@ jobs:
 
     env:
       VSCODE_DESKTOP: 1
-      PLAYWRIGHT_DESKTOP_VSCODE_VERSION: ${{ vars.PLAYWRIGHT_DESKTOP_VSCODE_VERSION }}
+      PLAYWRIGHT_VSCODE_VERSION: ${{ vars.PLAYWRIGHT_VSCODE_VERSION }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/playwrightVscodeExtE2E.yml
+++ b/.github/workflows/playwrightVscodeExtE2E.yml
@@ -54,6 +54,11 @@ jobs:
         run: |
           npm run test:web -w @salesforce/playwright-vscode-ext
 
+      - uses: ./.github/actions/cache-vscode-web
+        if: steps.try-run.outcome == 'failure'
+        with:
+          vscode-version: ${{ vars.PLAYWRIGHT_VSCODE_VERSION }}
+
       - name: Run Playwright web tests (parallel)
         if: steps.try-run.outcome == 'failure'
         id: parallel-run
@@ -98,7 +103,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     env:
-      PLAYWRIGHT_DESKTOP_VSCODE_VERSION: ${{ vars.PLAYWRIGHT_DESKTOP_VSCODE_VERSION }}
+      PLAYWRIGHT_VSCODE_VERSION: ${{ vars.PLAYWRIGHT_VSCODE_VERSION }}
     strategy:
       matrix:
         os: [macos-latest, windows-latest]
@@ -136,6 +141,11 @@ jobs:
           npm run test:desktop -w @salesforce/playwright-vscode-ext
 
       # Only run expensive setup when try-run failed (cache miss). On cache hit we never reach these steps.
+      - uses: ./.github/actions/cache-vscode-desktop
+        if: steps.try-run.outcome == 'failure'
+        with:
+          vscode-version: ${{ vars.PLAYWRIGHT_VSCODE_VERSION }}
+
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
         run: npx playwright install chromium --with-deps

--- a/.github/workflows/soqlE2E.yml
+++ b/.github/workflows/soqlE2E.yml
@@ -146,7 +146,7 @@ jobs:
       MINIMAL_ORG_ALIAS: minimalTestOrg
       SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL_E2E }}
       VSCODE_DESKTOP: 1
-      PLAYWRIGHT_DESKTOP_VSCODE_VERSION: ${{ vars.PLAYWRIGHT_DESKTOP_VSCODE_VERSION }}
+      PLAYWRIGHT_VSCODE_VERSION: ${{ vars.PLAYWRIGHT_VSCODE_VERSION }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/packages/playwright-vscode-ext/src/config/downloadVSCode.ts
+++ b/packages/playwright-vscode-ext/src/config/downloadVSCode.ts
@@ -16,6 +16,6 @@ import { resolveRepoRoot } from '../utils/repoRoot';
 export default async (): Promise<void> => {
   const repoRoot = resolveRepoRoot(__dirname);
   const cachePath = path.join(repoRoot, '.vscode-test');
-  const version = process.env.PLAYWRIGHT_DESKTOP_VSCODE_VERSION ?? undefined;
+  const version = process.env.PLAYWRIGHT_VSCODE_VERSION ?? undefined;
   await downloadAndUnzipVSCode({ version, cachePath });
 };

--- a/packages/playwright-vscode-ext/src/fixtures/createDesktopTest.ts
+++ b/packages/playwright-vscode-ext/src/fixtures/createDesktopTest.ts
@@ -70,7 +70,7 @@ export const createDesktopTest = (options: CreateDesktopTestOptions) => {
       async ({}, use): Promise<void> => {
         const repoRoot = resolveRepoRoot(fixturesDir);
         const cachePath = path.join(repoRoot, '.vscode-test');
-        const version = process.env.PLAYWRIGHT_DESKTOP_VSCODE_VERSION ?? undefined;
+        const version = process.env.PLAYWRIGHT_VSCODE_VERSION ?? undefined;
         const executablePath = await downloadAndUnzipVSCode({ version, cachePath });
         await use(executablePath);
       },

--- a/packages/playwright-vscode-ext/src/web/createHeadlessServer.ts
+++ b/packages/playwright-vscode-ext/src/web/createHeadlessServer.ts
@@ -39,6 +39,7 @@ export const createHeadlessServer = async (options: HeadlessServerOptions): Prom
       browserType: 'chromium',
       headless: true,
       quality: 'stable',
+      commit: process.env.PLAYWRIGHT_WEB_VSCODE_COMMIT,
       port: Number(process.env.PORT) || 3001,
       printServerLog: true,
       verbose: true,


### PR DESCRIPTION
## Summary

- `update.code.visualstudio.com` 504s/timeouts cause e2e CI failures because both `@vscode/test-web` and `@vscode/test-electron` unconditionally hit the API unless the binary is already on disk
- New composite actions (`cache-vscode-web`, `cache-vscode-desktop`) cache VS Code binaries in GHA keyed by version with prefix fallback restore-keys
- On fallback restore, detects the on-disk commit/version from folder names and rewrites the pin so the library skips all network calls
- Split `cache/restore` + `cache/save` ensures the cache is written even when tests fail
- Renames `PLAYWRIGHT_DESKTOP_VSCODE_VERSION` → `PLAYWRIGHT_VSCODE_VERSION` (single variable for both web and desktop)

## What issues does this PR fix or reference?

@W-22065072@

gonna be hard to prove success or "not causing problems" but there are caches now
<img width="1621" height="597" alt="Screenshot 2026-04-16 at 12 32 50 PM" src="https://github.com/user-attachments/assets/25081c4d-6d6c-4bbc-b163-ef4bb3eb090e" />


Made with [Cursor](https://cursor.com)