### PR TITLE
chore(lwc): replace uuid with globalThis.crypto.randomUUID() - W-22073901

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9333,13 +9333,6 @@
       "integrity": "sha512-wkXrVzX5yoqLnndOwFsieJA7oKM8cNkOKJtf/3vVGSUFkWDKZvFHpIl9Pvqb/T9UsawBBFMTTD8xu7sK5MWuvg==",
       "license": "MIT"
     },
-    "node_modules/@types/uuid": {
-      "version": "3.4.13",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.13.tgz",
-      "integrity": "sha512-pAeZeUbLE4Z9Vi9wsWV2bYPTweEHeJJy0G4pEjOA/FSvy1Ad5U5Km8iDV6TKre1mjBiVNfAdVHKruP8bAh4Q5A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/vscode": {
       "version": "1.90.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.90.0.tgz",
@@ -43928,16 +43921,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -49007,14 +48990,12 @@
         "jest-editor-support": "31.1.2",
         "jest-regex-util": "^24.9.0",
         "strip-ansi": "^5.2.0",
-        "uuid": "^3.3.3",
         "vscode-html-languageservice": "^5.5.1",
         "vscode-languageclient": "^9.0.1",
         "vscode-uri": "^3.1.0",
         "which": "1.3.1"
       },
       "devDependencies": {
-        "@types/uuid": "^3.4.8",
         "@types/which": "^1.3.1"
       },
       "engines": {

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -37,14 +37,12 @@
     "jest-editor-support": "31.1.2",
     "jest-regex-util": "^24.9.0",
     "strip-ansi": "^5.2.0",
-    "uuid": "^3.3.3",
     "vscode-languageclient": "^9.0.1",
     "vscode-uri": "^3.1.0",
     "vscode-html-languageservice": "^5.5.1",
     "which": "1.3.1"
   },
   "devDependencies": {
-    "@types/uuid": "^3.4.8",
     "@types/which": "^1.3.1"
   },
   "extensionDependencies": [

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/commands/lwcTestDebugAction.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/commands/lwcTestDebugAction.ts
@@ -5,7 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { TimingUtils } from '@salesforce/salesforcedx-utils-vscode';
-import * as uuid from 'uuid';
 import * as vscode from 'vscode';
 import { telemetryService } from '../../telemetry';
 import { TestRunner, TestRunType } from '../testRunner';
@@ -28,7 +27,7 @@ const getDebugConfiguration = async (
   args: string[],
   cwd: string
 ): Promise<vscode.DebugConfiguration> => {
-  const sfDebugSessionId = uuid.v4();
+  const sfDebugSessionId = globalThis.crypto.randomUUID();
   const debugConfiguration: vscode.DebugConfiguration = {
     sfDebugSessionId,
     type: 'node',

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/testRunner/testRunner.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/testRunner/testRunner.ts
@@ -7,7 +7,6 @@
 import { TimingUtils } from '@salesforce/salesforcedx-utils-vscode';
 import { escapeStrForRegex } from 'jest-regex-util';
 import * as path from 'node:path';
-import * as uuid from 'uuid';
 import * as vscode from 'vscode';
 import { nls } from '../../messages';
 import { telemetryService } from '../../telemetry';
@@ -61,7 +60,7 @@ export class TestRunner {
    * @param logName Telemetry log name. If specified we will send command telemetry event when task finishes
    */
   constructor(testExecutionInfo: TestExecutionInfo, testRunType: TestRunType, logName?: string) {
-    this.testRunId = uuid.v4();
+    this.testRunId = globalThis.crypto.randomUUID();
     this.testExecutionInfo = testExecutionInfo;
     this.testRunType = testRunType;
     this.logName = logName;

--- a/packages/salesforcedx-vscode-services/esbuild.config.mjs
+++ b/packages/salesforcedx-vscode-services/esbuild.config.mjs
@@ -52,7 +52,7 @@ const generateTemplatesManifest = async () => {
   const prefix = distTemplates.replace(/\\/g, '/') + '/';
   const paths = (await readdir(distTemplates, { recursive: true, withFileTypes: true }))
     .filter(e => e.isFile() && e.name !== 'manifest.json')
-    .map(e => `${e.path.replace(/\\/g, '/')}/${e.name}`.replace(prefix, ''));
+    .map(e => `${(e.parentPath ?? e.path).replace(/\\/g, '/')}/${e.name}`.replace(prefix, ''));
 
   await writeFile(join(distTemplates, 'manifest.json'), JSON.stringify(paths));
   console.log(`[esbuild] Generated templates manifest: ${paths.length} files`);


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-22073901@

### Description

Removes the `uuid` v3 package from `salesforcedx-vscode-lwc` in favor of the platform-native `globalThis.crypto.randomUUID()`. The real value here is dependency reduction — one fewer package (+ its types) to audit, update, and bundle, using an API that ships with every modern JS runtime (browser and Node 19+).

Also fixes a pre-existing Node 22+/24 compat bug in `salesforcedx-vscode-services/esbuild.config.mjs` where `Dirent.path` (deprecated Node 22, `undefined` Node 24) blocked `vscode:bundle` on newer Node versions.

### Changes

- Replace `uuid.v4()` → `globalThis.crypto.randomUUID()` in `testRunner.ts` and `lwcTestDebugAction.ts`
- Remove `uuid` and `@types/uuid` from `salesforcedx-vscode-lwc/package.json`
- Fix `Dirent.parentPath ?? Dirent.path` in `esbuild.config.mjs` for Node 22+ compat

Made with [Cursor](https://cursor.com)