### PR TITLE
test(soql): split e2e specs into focused suites - W-22104894

### DIFF
--- a/.claude/skills/playwright-e2e/references/analyze-e2e.md
+++ b/.claude/skills/playwright-e2e/references/analyze-e2e.md
@@ -27,17 +27,36 @@ Organized by branch and run ID.
 - `gh run download <run-id> -D <directory>` - Download artifacts
 - `gh run view <run-id> --web` - Open in browser
 
+## Artifact location (mandatory)
+
+**Always use `.e2e-artifacts/` as the root** — gitignored. Never use a variant name (e.g. `.e2e-artifacts-win/`).
+
+Structure (matches playwright-e2e-monitor agent):
+```
+.e2e-artifacts/<branch-name>/<run-id>-<workflow-name>/
+  playwright-report/
+  playwright-test-results-soql-desktop-windows-latest/   ← platform encoded in artifact name
+  playwright-test-results-soql-desktop-macos-latest/
+  playwright-test-results-soql-web/
+```
+
+Download command:
+```bash
+gh run download <run-id> -D .e2e-artifacts/<branch-name>/<run-id>-<workflow-name>
+```
+
+Platform artifacts are distinguished by name suffix (`windows-latest`, `macos-latest`, `web`) — no extra platform subdirectory needed.
+
 ## Span files from CI artifacts
 
-- Download: `gh run download <run-id> -D .e2e-artifacts`
-- Location: `.e2e-artifacts/playwright-test-results-*/spans/*.jsonl`
+- Location: `.e2e-artifacts/<branch>/<run>/playwright-test-results-*/spans/*.jsonl`
 - Format: JSONL (one span per line, parse with `JSON.parse`)
 - Fields: `name`, `traceId`, `spanId`, `parentSpanId`, `durationMs`, `status`, `startTime`, `attributes`
 
 Quick inspect:
 
 ```bash
-ls -lt .e2e-artifacts/playwright-test-results-*/spans/*.jsonl
+ls -lt .e2e-artifacts/*/*/playwright-test-results-*/spans/*.jsonl
 ```
 
 Read spans compact JSON:
@@ -45,7 +64,7 @@ Read spans compact JSON:
 ```bash
 python3 - <<'PY'
 import glob, json
-for path in glob.glob('.e2e-artifacts/playwright-test-results-*/spans/*.jsonl'):
+for path in glob.glob('.e2e-artifacts/*/*/playwright-test-results-*/spans/*.jsonl'):
     print(f'### {path}')
     with open(path, encoding='utf-8') as f:
         for line in f:
@@ -76,7 +95,7 @@ Extract frames from failing test `.webm` to step through a moment:
 - **Cmd** (e.g. 1:29–1:36 → -ss 89 -to 96):
 
 ```bash
-mkdir -p .e2e-artifacts/frames && ffmpeg -i <path>/<video>.webm -ss 89 -to 96 -vf "fps=6" -q:v 2 .e2e-artifacts/frames/frame_%04d.png
+mkdir -p .e2e-artifacts/frames && ffmpeg -i .e2e-artifacts/<branch>/<run>/playwright-test-results-*/<video>.webm -ss 89 -to 96 -vf "fps=6" -q:v 2 .e2e-artifacts/frames/frame_%04d.png
 ```
 
 - `fps=6` ≈ 6 frames/sec; output `frame_0001.png`+

--- a/packages/playwright-vscode-ext/src/pages/commands.ts
+++ b/packages/playwright-vscode-ext/src/pages/commands.ts
@@ -35,7 +35,7 @@ export const openCommandPalette = async (page: Page): Promise<void> => {
     const input = widget.locator('input.input');
     await expect(input).toBeVisible({ timeout: 5000 });
     await expect(input).toHaveValue(/^>/, { timeout: 5000 });
-  }).toPass({ timeout: 15_000 });
+  }).toPass({ timeout: 30_000 });
 };
 
 const executeCommand = async (page: Page, command: string, hasNotText?: string): Promise<void> => {
@@ -93,7 +93,7 @@ export const executeCommandWithCommandPalette = async (
     await dismissAllQuickInputWidgets(page);
     await openCommandPalette(page);
     await executeCommand(page, command, hasNotText);
-  }).toPass({ timeout: 15_000 });
+  }).toPass({ timeout: 30_000 });
 };
 
 /** Shared helper: closes command palette */

--- a/packages/playwright-vscode-ext/src/utils/helpers.ts
+++ b/packages/playwright-vscode-ext/src/utils/helpers.ts
@@ -90,7 +90,10 @@ const NON_CRITICAL_NETWORK_PATTERNS: readonly string[] = [
   // Salesforce OAuth userinfo endpoint (can 403/500 if session is invalid/expired in web,
   // non-critical for these tests.  sfdx-core will query user/organization sobjects as fallback )
   // https://github.com/forcedotcom/sfdx-core/blob/8d378c3a6f88a1d370ddc3f43954a90d7159377d/src/org/authInfo.ts#L1236
-  'services/oauth2/userinfo'
+  'services/oauth2/userinfo',
+  // Salesforce sObject describe endpoint — LSP/autocomplete may describe objects (including internal
+  // types like "Object") as-you-type; describe 404s are non-critical to test assertions
+  '/describe'
 ] as const;
 
 export const setupConsoleMonitoring = (page: Page): ConsoleError[] => {

--- a/packages/salesforcedx-vscode-soql/playwright.config.desktop.ts
+++ b/packages/salesforcedx-vscode-soql/playwright.config.desktop.ts
@@ -6,4 +6,4 @@
  */
 import { createDesktopConfig } from '@salesforce/playwright-vscode-ext';
 
-export default createDesktopConfig();
+export default createDesktopConfig({ timeout: 180_000 });

--- a/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-builder.spec.ts
+++ b/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-builder.spec.ts
@@ -7,8 +7,6 @@
 
 import { expect } from '@playwright/test';
 import {
-  clearOutputChannel,
-  ensureOutputPanelOpen,
   ensureSecondarySideBarHidden,
   executeCommandWithCommandPalette,
   QUICK_INPUT_WIDGET,
@@ -26,15 +24,15 @@ import {
 import { test } from '../fixtures';
 import packageNls from '../../../package.nls.json';
 
-// Expected text fragments matched against the SOQL output channel after each operation.
-// "records returned" comes from i18n key data_query_complete: 'Query complete with %d records returned'
 // "Query plan retrieved successfully" comes from i18n key query_plan_complete
-const QUERY_COMPLETE_TEXT = 'records returned';
 const PLAN_COMPLETE_TEXT = 'Query plan retrieved successfully';
 const SOQL_CHANNEL = 'SOQL';
-const SOQL_FILE = 'MySoqlFile';
+const SOQL_FILE = 'MySoqlBuilderFile';
+// executeQueryPlan always calls vscChannel.show() in its finally block — the Output panel
+// opens automatically. Waiting for it directly avoids racing with ensureOutputPanelOpen.
+const OUTPUT_PANEL = '[id="workbench.panel.output"]';
 
-test('SOQL: build query in builder, toggle to text editor, run queries and get query plans', async ({ page }) => {
+test('SOQL Builder: build query, run, get plan, toggle round-trip', async ({ page }) => {
   const consoleErrors = setupConsoleMonitoring(page);
   const networkErrors = setupNetworkMonitoring(page);
 
@@ -54,7 +52,7 @@ test('SOQL: build query in builder, toggle to text editor, run queries and get q
     await saveScreenshot(page, 'step1.after-command.png');
 
     const quickInput = page.locator(QUICK_INPUT_WIDGET);
-    await quickInput.waitFor({ state: 'visible', timeout: 30_000 });
+    await quickInput.waitFor({ state: 'visible', timeout: 60_000 });
     await page.keyboard.type(SOQL_FILE);
     await page.keyboard.press('Enter');
     await saveScreenshot(page, 'step1.file-name-entered.png');
@@ -130,8 +128,9 @@ test('SOQL: build query in builder, toggle to text editor, run queries and get q
     await soqlFrame.getByRole('button', { name: 'Get Query Plan' }).click();
     await saveScreenshot(page, 'step4.get-query-plan-clicked.png');
 
-    // Query plan output appears in the SOQL output channel
-    await ensureOutputPanelOpen(page);
+    // executeQueryPlan calls vscChannel.show() when done — wait for the panel to open naturally
+    await page.locator(OUTPUT_PANEL).waitFor({ state: 'visible', timeout: 30_000 });
+    await selectOutputChannel(page, SOQL_CHANNEL);
     await waitForOutputChannelText(page, {
       expectedText: PLAN_COMPLETE_TEXT,
       timeout: 30_000
@@ -150,7 +149,7 @@ test('SOQL: build query in builder, toggle to text editor, run queries and get q
     await toggleButton.click();
     await saveScreenshot(page, 'step5.after-toggle-to-text.png');
 
-    // After toggling, a second MySoqlFile.soql tab opens (text editor alongside builder)
+    // After toggling, a second MySoqlBuilderFile.soql tab opens (text editor alongside builder)
     const soqlTabs = page.locator('[role="tab"]').filter({ hasText: `${SOQL_FILE}.soql` });
     await expect(soqlTabs, `two ${SOQL_FILE}.soql tabs should exist after toggling to text editor`).toHaveCount(2, {
       timeout: 10_000
@@ -158,135 +157,19 @@ test('SOQL: build query in builder, toggle to text editor, run queries and get q
     await saveScreenshot(page, 'step5.two-tabs-visible.png');
   });
 
-  await test.step('run query via "Run Query" code lens', async () => {
-    // Code lenses render as buttons in VS Code desktop
-    const runQueryLens = page.getByRole('button', { name: 'Run Query' });
-    await expect(runQueryLens, '"Run Query" code lens should be visible at the top of the file').toBeVisible({
-      timeout: 15_000
-    });
-    await saveScreenshot(page, 'step6.code-lens-visible.png');
-
-    await runQueryLens.click();
-
-    // Code lens path always shows an API-type quick pick (REST API vs Tooling API)
-    await waitForQuickInputFirstOption(page, { quickInputVisibleTimeout: 10_000, optionVisibleTimeout: 10_000 });
-    await page.keyboard.press('Enter'); // selects "REST API" (first option)
-    await saveScreenshot(page, 'step6.api-selected.png');
-
-    await ensureOutputPanelOpen(page);
-    await selectOutputChannel(page, SOQL_CHANNEL);
-    await waitForOutputChannelText(page, { expectedText: QUERY_COMPLETE_TEXT, timeout: 30_000 });
-    await saveScreenshot(page, 'step6.run-query-output-verified.png');
-  });
-
-  await test.step('get query plan via "Get Query Plan" code lens', async () => {
-    const soqlTab = page.locator('[role="tab"]').filter({ hasText: `${SOQL_FILE}.soql` });
-    await soqlTab.last().click();
-
-    await ensureOutputPanelOpen(page);
-    await selectOutputChannel(page, SOQL_CHANNEL);
-    await clearOutputChannel(page);
-
-    const planLens = page.getByRole('button', { name: 'Get Query Plan' });
-    await expect(planLens, '"Get Query Plan" code lens should be visible').toBeVisible({ timeout: 10_000 });
-    await planLens.click();
-
-    // Get Query Plan always uses REST API — no API-picker quick input is shown
-    await waitForOutputChannelText(page, { expectedText: PLAN_COMPLETE_TEXT, timeout: 30_000 });
-    await saveScreenshot(page, 'step7.get-query-plan-output-verified.png');
-  });
-
-  await test.step('execute SOQL query with current file via command palette', async () => {
-    const soqlTab = page.locator('[role="tab"]').filter({ hasText: `${SOQL_FILE}.soql` });
-    await soqlTab.last().click();
-
-    await ensureOutputPanelOpen(page);
-    await selectOutputChannel(page, SOQL_CHANNEL);
-    await clearOutputChannel(page);
-
-    await executeCommandWithCommandPalette(page, packageNls.data_query_document_text);
-    await saveScreenshot(page, 'step8.command-executed.png');
-
-    await waitForQuickInputFirstOption(page, { quickInputVisibleTimeout: 10_000, optionVisibleTimeout: 10_000 });
-    await page.keyboard.press('Enter'); // selects "REST API"
-
-    await waitForOutputChannelText(page, { expectedText: QUERY_COMPLETE_TEXT, timeout: 30_000 });
-    await saveScreenshot(page, 'step8.current-file-query-output-verified.png');
-  });
-
-  await test.step('get SOQL query plan with current file via command palette', async () => {
-    const soqlTab = page.locator('[role="tab"]').filter({ hasText: `${SOQL_FILE}.soql` });
-    await soqlTab.last().click();
-
-    await ensureOutputPanelOpen(page);
-    await selectOutputChannel(page, SOQL_CHANNEL);
-    await clearOutputChannel(page);
-
-    await executeCommandWithCommandPalette(page, packageNls.query_plan_document_text);
-    await saveScreenshot(page, 'step9.command-executed.png');
-
-    // Get Query Plan does not prompt for API type
-    await waitForOutputChannelText(page, { expectedText: PLAN_COMPLETE_TEXT, timeout: 30_000 });
-    await saveScreenshot(page, 'step9.current-file-plan-output-verified.png');
-  });
-
-  await test.step('execute SOQL query with currently selected text via command palette', async () => {
-    const soqlTab = page.locator('[role="tab"]').filter({ hasText: `${SOQL_FILE}.soql` });
-    await soqlTab.last().click();
-
-    await ensureOutputPanelOpen(page);
-    await selectOutputChannel(page, SOQL_CHANNEL);
-    await clearOutputChannel(page);
-
-    // Select all text in the editor so the command has a selection to operate on
-    await soqlTab.last().click();
-    await executeCommandWithCommandPalette(page, 'Select All');
-    await saveScreenshot(page, 'step10.text-selected.png');
-
-    await executeCommandWithCommandPalette(page, packageNls.data_query_selection_text);
-    await saveScreenshot(page, 'step10.command-executed.png');
-
-    await waitForQuickInputFirstOption(page, { quickInputVisibleTimeout: 10_000, optionVisibleTimeout: 10_000 });
-    await page.keyboard.press('Enter'); // selects "REST API"
-
-    await waitForOutputChannelText(page, { expectedText: QUERY_COMPLETE_TEXT, timeout: 30_000 });
-    await saveScreenshot(page, 'step10.selected-text-query-output-verified.png');
-  });
-
-  await test.step('get SOQL query plan with currently selected text via command palette', async () => {
-    const soqlTab = page.locator('[role="tab"]').filter({ hasText: `${SOQL_FILE}.soql` });
-    await soqlTab.last().click();
-
-    await ensureOutputPanelOpen(page);
-    await selectOutputChannel(page, SOQL_CHANNEL);
-    await clearOutputChannel(page);
-
-    // Select all text in the editor so the command has a selection to operate on
-    await soqlTab.last().click();
-    await executeCommandWithCommandPalette(page, 'Select All');
-    await saveScreenshot(page, 'step11.text-selected.png');
-
-    await executeCommandWithCommandPalette(page, packageNls.query_plan_selection_text);
-    await saveScreenshot(page, 'step11.command-executed.png');
-
-    // Get Query Plan does not prompt for API type
-    await waitForOutputChannelText(page, { expectedText: PLAN_COMPLETE_TEXT, timeout: 30_000 });
-    await saveScreenshot(page, 'step11.selected-text-plan-output-verified.png');
-  });
-
   await test.step('toggle from Text Editor back to SOQL Builder', async () => {
     // We are now in the text editor view; toggle should switch focus back to the builder
     const toggleButton = page.getByRole('button', { name: packageNls.soql_builder_toggle });
     await expect(toggleButton, 'toggle button should be visible from text editor').toBeVisible();
     await toggleButton.click();
-    await saveScreenshot(page, 'step12.after-toggle-to-builder.png');
+    await saveScreenshot(page, 'step6.after-toggle-to-builder.png');
 
-    // Verify the active tab is still MySoqlFile.soql (builder view now active)
+    // Verify the active tab is MySoqlBuilderFile.soql (builder view now active)
     const activeTab = page.locator('[role="tab"][aria-selected="true"]').filter({ hasText: `${SOQL_FILE}.soql` });
     await expect(activeTab, `active tab should be ${SOQL_FILE}.soql after toggling back to builder`).toBeVisible({
       timeout: 10_000
     });
-    await saveScreenshot(page, 'step12.builder-active.png');
+    await saveScreenshot(page, 'step6.builder-active.png');
   });
 
   await validateNoCriticalErrors(test, consoleErrors, networkErrors);

--- a/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-builder.spec.ts
+++ b/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-builder.spec.ts
@@ -33,6 +33,7 @@ const SOQL_FILE = 'MySoqlBuilderFile';
 const OUTPUT_PANEL = '[id="workbench.panel.output"]';
 
 test('SOQL Builder: build query, run, get plan, toggle round-trip', async ({ page }) => {
+  test.setTimeout(180_000);
   const consoleErrors = setupConsoleMonitoring(page);
   const networkErrors = setupNetworkMonitoring(page);
 

--- a/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-query-plan.spec.ts
+++ b/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-query-plan.spec.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from '@playwright/test';
+import {
+  clearOutputChannel,
+  EDITOR,
+  ensureSecondarySideBarHidden,
+  executeCommandWithCommandPalette,
+  QUICK_INPUT_WIDGET,
+  saveScreenshot,
+  selectOutputChannel,
+  setupConsoleMonitoring,
+  setupMinimalOrgAndAuth,
+  setupNetworkMonitoring,
+  validateNoCriticalErrors,
+  verifyCommandExists,
+  waitForExtensionsActivated,
+  waitForOutputChannelText,
+  waitForQuickInputFirstOption
+} from '@salesforce/playwright-vscode-ext';
+import { test } from '../fixtures';
+import packageNls from '../../../package.nls.json';
+
+// "Query plan retrieved successfully" comes from i18n key query_plan_complete
+const PLAN_COMPLETE_TEXT = 'Query plan retrieved successfully';
+const SOQL_CHANNEL = 'SOQL';
+const SOQL_FILE = 'MySoqlQueryPlanFile';
+const SOQL_QUERY = 'SELECT Id, Name FROM Account LIMIT 10';
+// executeQueryPlan calls vscChannel.show() in its finally block — the Output panel opens automatically.
+// Waiting for it directly avoids racing with ensureOutputPanelOpen.
+const OUTPUT_PANEL = '[id="workbench.panel.output"]';
+
+test('SOQL Query Plan: code lens, current file, selected text via command palette', async ({ page }) => {
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  await test.step('setup workbench', async () => {
+    await setupMinimalOrgAndAuth(page);
+    await waitForExtensionsActivated(page);
+    await ensureSecondarySideBarHidden(page);
+    await saveScreenshot(page, 'setup.complete.png');
+    await verifyCommandExists(page, packageNls.soql_open_new_text_editor);
+  });
+
+  await test.step('create SOQL file via text editor command', async () => {
+    await executeCommandWithCommandPalette(page, packageNls.soql_open_new_text_editor);
+    await saveScreenshot(page, 'step1.after-command.png');
+
+    const quickInput = page.locator(QUICK_INPUT_WIDGET);
+    await quickInput.waitFor({ state: 'visible', timeout: 30_000 });
+    await page.keyboard.type(SOQL_FILE);
+    await page.keyboard.press('Enter');
+    await saveScreenshot(page, 'step1.file-name-entered.png');
+
+    await waitForQuickInputFirstOption(page, { quickInputVisibleTimeout: 10_000, optionVisibleTimeout: 10_000 });
+    await page.keyboard.press('Enter');
+    await saveScreenshot(page, 'step1.dir-selected.png');
+
+    const soqlTab = page.locator('[role="tab"]').filter({ hasText: `${SOQL_FILE}.soql` });
+    await expect(soqlTab, `${SOQL_FILE}.soql tab should be visible`).toBeVisible({ timeout: 20_000 });
+    await saveScreenshot(page, 'step1.soql-tab-visible.png');
+
+    // Type the query into the empty editor (file opens focused and ready for input)
+    await page.locator(EDITOR).first().click();
+    await page.keyboard.type(SOQL_QUERY);
+    await executeCommandWithCommandPalette(page, 'File: Save');
+    await saveScreenshot(page, 'step1.query-saved.png');
+  });
+
+  await test.step('get query plan via "Get Query Plan" code lens', async () => {
+    const planLens = page.getByRole('button', { name: 'Get Query Plan' });
+    await expect(planLens, '"Get Query Plan" code lens should be visible').toBeVisible({ timeout: 15_000 });
+    await saveScreenshot(page, 'step2.code-lens-visible.png');
+
+    await planLens.click();
+
+    // Get Query Plan always uses REST API — no API-picker quick input is shown
+    // executeQueryPlan calls vscChannel.show() in finally — wait for the panel to open naturally
+    await page.locator(OUTPUT_PANEL).waitFor({ state: 'visible', timeout: 30_000 });
+    await selectOutputChannel(page, SOQL_CHANNEL);
+    await waitForOutputChannelText(page, { expectedText: PLAN_COMPLETE_TEXT, timeout: 30_000 });
+    await saveScreenshot(page, 'step2.get-query-plan-output-verified.png');
+  });
+
+  await test.step('get query plan with current file via command palette', async () => {
+    const soqlTab = page.locator('[role="tab"]').filter({ hasText: `${SOQL_FILE}.soql` });
+    await soqlTab.click();
+
+    await selectOutputChannel(page, SOQL_CHANNEL);
+    await clearOutputChannel(page);
+
+    await executeCommandWithCommandPalette(page, packageNls.query_plan_document_text);
+    await saveScreenshot(page, 'step3.command-executed.png');
+
+    // Get Query Plan does not prompt for API type
+    await waitForOutputChannelText(page, { expectedText: PLAN_COMPLETE_TEXT, timeout: 30_000 });
+    await saveScreenshot(page, 'step3.current-file-plan-output-verified.png');
+  });
+
+  await test.step('get query plan with currently selected text via command palette', async () => {
+    const soqlTab = page.locator('[role="tab"]').filter({ hasText: `${SOQL_FILE}.soql` });
+    await soqlTab.click();
+
+    await selectOutputChannel(page, SOQL_CHANNEL);
+    await clearOutputChannel(page);
+
+    // Select all text in the editor so the command has a selection to operate on
+    await soqlTab.click();
+    await executeCommandWithCommandPalette(page, 'Select All');
+    await saveScreenshot(page, 'step4.text-selected.png');
+
+    await executeCommandWithCommandPalette(page, packageNls.query_plan_selection_text);
+    await saveScreenshot(page, 'step4.command-executed.png');
+
+    // Get Query Plan does not prompt for API type
+    await waitForOutputChannelText(page, { expectedText: PLAN_COMPLETE_TEXT, timeout: 30_000 });
+    await saveScreenshot(page, 'step4.selected-text-plan-output-verified.png');
+  });
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-query-plan.spec.ts
+++ b/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-query-plan.spec.ts
@@ -36,6 +36,7 @@ const SOQL_QUERY = 'SELECT Id, Name FROM Account LIMIT 10';
 const OUTPUT_PANEL = '[id="workbench.panel.output"]';
 
 test('SOQL Query Plan: code lens, current file, selected text via command palette', async ({ page }) => {
+  test.setTimeout(180_000);
   const consoleErrors = setupConsoleMonitoring(page);
   const networkErrors = setupNetworkMonitoring(page);
 

--- a/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-run-query.spec.ts
+++ b/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-run-query.spec.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from '@playwright/test';
+import {
+  clearOutputChannel,
+  EDITOR,
+  ensureSecondarySideBarHidden,
+  executeCommandWithCommandPalette,
+  QUICK_INPUT_WIDGET,
+  saveScreenshot,
+  selectOutputChannel,
+  setupConsoleMonitoring,
+  setupMinimalOrgAndAuth,
+  setupNetworkMonitoring,
+  validateNoCriticalErrors,
+  verifyCommandExists,
+  waitForExtensionsActivated,
+  waitForOutputChannelText,
+  waitForQuickInputFirstOption
+} from '@salesforce/playwright-vscode-ext';
+import { test } from '../fixtures';
+import packageNls from '../../../package.nls.json';
+
+// "records returned" comes from i18n key data_query_complete: 'Query complete with %d records returned'
+const QUERY_COMPLETE_TEXT = 'records returned';
+const SOQL_CHANNEL = 'SOQL';
+const SOQL_FILE = 'MySoqlRunQueryFile';
+const SOQL_QUERY = 'SELECT Id, Name FROM Account LIMIT 10';
+// dataQuery calls vscChannel.show() when done — the Output panel opens automatically.
+// Waiting for it directly avoids racing with ensureOutputPanelOpen.
+const OUTPUT_PANEL = '[id="workbench.panel.output"]';
+
+test('SOQL Run Query: code lens, current file, selected text via command palette', async ({ page }) => {
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  await test.step('setup workbench', async () => {
+    await setupMinimalOrgAndAuth(page);
+    await waitForExtensionsActivated(page);
+    await ensureSecondarySideBarHidden(page);
+    await saveScreenshot(page, 'setup.complete.png');
+    await verifyCommandExists(page, packageNls.soql_open_new_text_editor);
+  });
+
+  await test.step('create SOQL file via text editor command', async () => {
+    await executeCommandWithCommandPalette(page, packageNls.soql_open_new_text_editor);
+    await saveScreenshot(page, 'step1.after-command.png');
+
+    const quickInput = page.locator(QUICK_INPUT_WIDGET);
+    await quickInput.waitFor({ state: 'visible', timeout: 30_000 });
+    await page.keyboard.type(SOQL_FILE);
+    await page.keyboard.press('Enter');
+    await saveScreenshot(page, 'step1.file-name-entered.png');
+
+    await waitForQuickInputFirstOption(page, { quickInputVisibleTimeout: 10_000, optionVisibleTimeout: 10_000 });
+    await page.keyboard.press('Enter');
+    await saveScreenshot(page, 'step1.dir-selected.png');
+
+    const soqlTab = page.locator('[role="tab"]').filter({ hasText: `${SOQL_FILE}.soql` });
+    await expect(soqlTab, `${SOQL_FILE}.soql tab should be visible`).toBeVisible({ timeout: 20_000 });
+    await saveScreenshot(page, 'step1.soql-tab-visible.png');
+
+    // Type the query into the empty editor (file opens focused and ready for input)
+    await page.locator(EDITOR).first().click();
+    await page.keyboard.type(SOQL_QUERY);
+    await executeCommandWithCommandPalette(page, 'File: Save');
+    await saveScreenshot(page, 'step1.query-saved.png');
+  });
+
+  await test.step('run query via "Run Query" code lens', async () => {
+    const runQueryLens = page.getByRole('button', { name: 'Run Query' });
+    await expect(runQueryLens, '"Run Query" code lens should be visible').toBeVisible({ timeout: 15_000 });
+    await saveScreenshot(page, 'step2.code-lens-visible.png');
+
+    await runQueryLens.click();
+
+    // Code lens path always shows an API-type quick pick (REST API vs Tooling API)
+    await waitForQuickInputFirstOption(page, { quickInputVisibleTimeout: 10_000, optionVisibleTimeout: 10_000 });
+    await page.keyboard.press('Enter'); // selects "REST API" (first option)
+    await saveScreenshot(page, 'step2.api-selected.png');
+
+    // dataQuery calls vscChannel.show() when done — wait for the panel to open naturally
+    await page.locator(OUTPUT_PANEL).waitFor({ state: 'visible', timeout: 30_000 });
+    await selectOutputChannel(page, SOQL_CHANNEL);
+    await waitForOutputChannelText(page, { expectedText: QUERY_COMPLETE_TEXT, timeout: 30_000 });
+    await saveScreenshot(page, 'step2.run-query-output-verified.png');
+  });
+
+  await test.step('execute SOQL query with current file via command palette', async () => {
+    const soqlTab = page.locator('[role="tab"]').filter({ hasText: `${SOQL_FILE}.soql` });
+    await soqlTab.click();
+
+    await selectOutputChannel(page, SOQL_CHANNEL);
+    await clearOutputChannel(page);
+
+    await executeCommandWithCommandPalette(page, packageNls.data_query_document_text);
+    await saveScreenshot(page, 'step3.command-executed.png');
+
+    await waitForQuickInputFirstOption(page, { quickInputVisibleTimeout: 10_000, optionVisibleTimeout: 10_000 });
+    await page.keyboard.press('Enter'); // selects "REST API"
+
+    await waitForOutputChannelText(page, { expectedText: QUERY_COMPLETE_TEXT, timeout: 30_000 });
+    await saveScreenshot(page, 'step3.current-file-query-output-verified.png');
+  });
+
+  await test.step('execute SOQL query with currently selected text via command palette', async () => {
+    const soqlTab = page.locator('[role="tab"]').filter({ hasText: `${SOQL_FILE}.soql` });
+    await soqlTab.click();
+
+    await selectOutputChannel(page, SOQL_CHANNEL);
+    await clearOutputChannel(page);
+
+    // Select all text in the editor so the command has a selection to operate on
+    await soqlTab.click();
+    await executeCommandWithCommandPalette(page, 'Select All');
+    await saveScreenshot(page, 'step4.text-selected.png');
+
+    await executeCommandWithCommandPalette(page, packageNls.data_query_selection_text);
+    await saveScreenshot(page, 'step4.command-executed.png');
+
+    await waitForQuickInputFirstOption(page, { quickInputVisibleTimeout: 10_000, optionVisibleTimeout: 10_000 });
+    await page.keyboard.press('Enter'); // selects "REST API"
+
+    await waitForOutputChannelText(page, { expectedText: QUERY_COMPLETE_TEXT, timeout: 30_000 });
+    await saveScreenshot(page, 'step4.selected-text-query-output-verified.png');
+  });
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-22104894@

### Description

Splits `soql.spec.ts` into three focused specs:

- `soql-builder.spec.ts` — builder UI, toggle round-trip, query plan from builder
- `soql-run-query.spec.ts` — run query via code lens, current file, and selected text
- `soql-query-plan.spec.ts` — query plan via code lens, current file, and selected text

Each spec uses the `soql_open_new_text_editor` (file-create) command to create its own isolated file, removing the dependency on the SOQL Builder for run-query and query-plan tests.

Also fixes a race condition: replaces `ensureOutputPanelOpen` with direct `waitFor` on the output panel locator, since `executeQueryPlan` / `dataQuery` call `vscChannel.show()` in their `finally` block. Ran 5x locally without retries.

I ran this 5 times locally to make sure it was stable there.  GHA 🤷🏻 

Made with [Cursor](https://cursor.com)