### PR TITLE
ci: changelog script handles other release tags

### DIFF
--- a/scripts/create-release-notes.ts
+++ b/scripts/create-release-notes.ts
@@ -36,7 +36,11 @@ function getCurrentRemoteReleaseBranch(): string {
  */
 function getPreviousRemoteReleaseBranch(): string {
   logger('\nStep 2: Getting latest tag to compare last published version');
-  const latestReleasedTag = execSync('git describe --tags --abbrev=0', { encoding: 'utf8' }).trim();
+  // Match only top-level extension release tags (e.g. v66.5.4), excluding
+  // subpackage tags like `vscode-i18n-v66.7.0` or `soql-common-v2.0.0`.
+  const latestReleasedTag = execSync(`git describe --tags --abbrev=0 --match 'v[0-9]*'`, {
+    encoding: 'utf8'
+  }).trim();
   const latestReleasedBranchName = `${constants.REMOTE_RELEASE_BRANCH_PREFIX_NO_VERSION}/${latestReleasedTag}`;
   validateReleaseBranch(latestReleasedBranchName);
   return latestReleasedBranchName;


### PR DESCRIPTION
## What does this PR do?

`getPreviousRemoteReleaseBranch` in `scripts/create-release-notes.ts` used `git describe --tags --abbrev=0`, which picks the most recent tag of any kind. Subpackage release tags (e.g. `vscode-i18n-v66.7.0`, `soql-common-v2.0.0`) would be selected, producing an invalid release branch name.

Restrict tag match to top-level extension tags (`v[0-9]*`) so only tags like `v66.5.4` are considered.

### What issues does this PR fix or reference?

[skip-validate-pr]

Made with [Cursor](https://cursor.com)