### PR TITLE
refactor: remove unnecessary current-state stream merges - W-22166418

### DIFF
--- a/.claude/skills/effect-best-practices/SKILL.md
+++ b/.claude/skills/effect-best-practices/SKILL.md
@@ -426,6 +426,28 @@ For RPC contracts and cluster workflows, see:
 
 - `references/rpc-cluster-patterns.md` - RpcGroup, Workflow.make, Activity patterns
 
+## SubscriptionRef
+
+`SubscriptionRef<A>` is a mutable ref whose `.changes` stream **always emits the current value as element 0**, then all future mutations.
+
+Implemented as (from `effect/src/internal/subscriptionRef.ts`):
+```ts
+stream.concat(stream.make(currentValue), stream.fromPubSub(pubsub))
+```
+The `Ref.get` + pubsub subscription happen atomically under a semaphore — no events are missed.
+
+```typescript
+// WRONG — prepended get is always redundant
+Stream.concat(Stream.fromEffect(SubscriptionRef.get(ref)), ref.changes)
+Stream.concat(Stream.make(yield* SubscriptionRef.get(ref)), ref.changes)
+Stream.merge(Stream.fromEffect(SubscriptionRef.get(ref)), ref.changes)
+
+// CORRECT — .changes already provides the snapshot
+ref.changes.pipe(...)
+```
+
+To skip the initial snapshot (e.g. avoid a spurious refresh on activation), use `Stream.drop(1)`.
+
 ## Anti-Patterns (Forbidden)
 
 These patterns are **never acceptable**:

--- a/.claude/skills/services-extension-consumption/SKILL.md
+++ b/.claude/skills/services-extension-consumption/SKILL.md
@@ -239,10 +239,24 @@ yield *
   );
 ```
 
+**`ref.changes` always emits the current value as element 0**, then future changes. Never prepend an explicit get:
+
+```typescript
+// WRONG — the fromEffect/get is redundant; .changes already emits current value first
+Stream.concat(Stream.fromEffect(SubscriptionRef.get(ref)), ref.changes)
+Stream.concat(Stream.make(yield* SubscriptionRef.get(ref)), ref.changes)
+
+// CORRECT
+ref.changes
+```
+
+To suppress the initial snapshot (e.g. avoid triggering a refresh before a tree provider is ready), use `Stream.drop(1)`.
+
 Ref behavior (concise):
 
 - Default-org update: username from User SOQL when present; else AuthInfo login username on the connection.
 - `TargetOrgRef` snapshot without username: optional `ConfigUtil.getUsername()` (project default) before treating as no target org — see `salesforcedx-vscode-org` `orgDisplay`.
+- `TargetOrgRef` value is always an object (never `undefined`); only fields like `orgId` within it are optional.
 
 ## Complete Example Pattern
 

--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
       - run: npm run compile
       - run: npm run test
+        env:
+          WIREIT_PARALLEL: 1
       - run: npm run capture:results
       # Archive test results and coverage reports
       - name: Archive test results and coverage reports

--- a/packages/salesforcedx-vscode-apex-log/src/logs/logAutoCollect.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/logs/logAutoCollect.ts
@@ -123,7 +123,7 @@ export const createLogAutoCollect = Effect.fn('ApexLog.createLogAutoCollect')(fu
 
   // when the org changes, clear the knownIds
   yield* Effect.fork(
-    Stream.concat(Stream.fromEffect(SubscriptionRef.get(targetOrgRef)), targetOrgRef.changes).pipe(
+    targetOrgRef.changes.pipe(
       Stream.map(orgInfo => orgInfo.orgId),
       Stream.changes,
       Stream.as(undefined),
@@ -131,10 +131,7 @@ export const createLogAutoCollect = Effect.fn('ApexLog.createLogAutoCollect')(fu
     )
   );
 
-  const dynamicPollStream = Stream.concat(
-    Stream.make(yield* SubscriptionRef.get(pollIntervalRef)),
-    pollIntervalRef.changes
-  ).pipe(
+  const dynamicPollStream = pollIntervalRef.changes.pipe(
     Stream.filter(d => Duration.greaterThan(d, Duration.zero)), // 0 means don't poll
     Stream.flatMap(
       interval => Stream.fromSchedule(Schedule.spaced(interval)).pipe(Stream.filter(() => vscode.window.state.active)),
@@ -146,10 +143,7 @@ export const createLogAutoCollect = Effect.fn('ApexLog.createLogAutoCollect')(fu
   const refreshStream = traceFlagRefreshRef.changes.pipe(Stream.as(undefined));
   // When org becomes ready, status bar fetches trace flags and sets the ref. LogAutoCollect must also
   // react to org changes so it doesn't miss the initial ref update (race on workspace reload).
-  const orgChangeStream = Stream.concat(
-    Stream.fromEffect(SubscriptionRef.get(targetOrgRef)),
-    targetOrgRef.changes
-  ).pipe(
+  const orgChangeStream = targetOrgRef.changes.pipe(
     Stream.map(orgInfo => orgInfo.orgId),
     Stream.changes,
     Stream.as(undefined)

--- a/packages/salesforcedx-vscode-apex-log/src/statusBar/traceFlagStatusBar.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/statusBar/traceFlagStatusBar.ts
@@ -72,7 +72,7 @@ export const createTraceFlagStatusBar = () =>
       Stream.mergeAll(
         [
           // because the org changed — re-query trace flags from the new org
-          Stream.concat(Stream.fromEffect(SubscriptionRef.get(targetOrgRef)), targetOrgRef.changes).pipe(
+          targetOrgRef.changes.pipe(
             Stream.map(orgInfo => orgInfo.orgId),
             Stream.changes,
             Stream.tap(() =>

--- a/packages/salesforcedx-vscode-apex-testing/src/watchers/testDiscovery.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/watchers/testDiscovery.ts
@@ -9,7 +9,6 @@ import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import * as Effect from 'effect/Effect';
 import { isString } from 'effect/Predicate';
 import * as Stream from 'effect/Stream';
-import * as SubscriptionRef from 'effect/SubscriptionRef';
 import { getTestController } from '../views/testController';
 
 /** Initialize test discovery when an org is available, and re-discover on org changes */
@@ -21,10 +20,7 @@ export const initializeTestDiscovery = Effect.fn('apex-testing.initializeTestDis
   const channelService = yield* api.services.ChannelService;
   // Subscribe to org changes and re-discover tests when org changes
   yield* Effect.forkDaemon(
-    Stream.concat(
-      Stream.fromEffect(SubscriptionRef.get(targetOrgRef)), // current value
-      targetOrgRef.changes // any changes to the org
-    ).pipe(
+    targetOrgRef.changes.pipe(
       Stream.map(org => org.orgId),
       Stream.filter(isString),
       Stream.changes,

--- a/packages/salesforcedx-vscode-metadata/src/statusBar/sourceTrackingStatusBar.ts
+++ b/packages/salesforcedx-vscode-metadata/src/statusBar/sourceTrackingStatusBar.ts
@@ -105,10 +105,7 @@ export const createSourceTrackingStatusBar = Effect.fn('createSourceTrackingStat
       Stream.runForEach(() => SubscriptionRef.set(pollIntervalRef, Duration.seconds(getPollingIntervalSeconds())))
     )
   );
-  const orgChangeStream = Stream.concat(
-    Stream.fromEffect(SubscriptionRef.get(targetOrgRef)), // if initial state has already been set
-    targetOrgRef.changes // ongoing org changes
-  ).pipe(
+  const orgChangeStream = targetOrgRef.changes.pipe(
     Stream.filter(orgInfo => orgInfo && typeof orgInfo === 'object' && 'tracksSource' in orgInfo),
     Stream.tap(orgInfo =>
       Effect.sync(() => {
@@ -124,10 +121,7 @@ export const createSourceTrackingStatusBar = Effect.fn('createSourceTrackingStat
   );
 
   // Dynamic poll stream that restarts when interval changes
-  const dynamicPollStream = Stream.concat(
-    Stream.make(yield* SubscriptionRef.get(pollIntervalRef)),
-    pollIntervalRef.changes
-  ).pipe(
+  const dynamicPollStream = pollIntervalRef.changes.pipe(
     Stream.filter(d => Duration.greaterThan(d, Duration.zero)), // 0 means don't poll
     Stream.flatMap(
       interval => Stream.fromSchedule(Schedule.fixed(interval)).pipe(Stream.filter(() => vscode.window.state.active)),

--- a/packages/salesforcedx-vscode-org-browser/src/index.ts
+++ b/packages/salesforcedx-vscode-org-browser/src/index.ts
@@ -81,15 +81,10 @@ export const activateEffect = Effect.fn(`activation:${EXTENSION_NAME}`)(function
   );
 
   yield* Effect.forkDaemon(
-    Stream.merge(
-      // get the initial state
-      Stream.fromEffect(SubscriptionRef.get(targetOrgRef)),
-      // get the ongoing changes
-      targetOrgRef.changes
-    ).pipe(
-      Stream.filter(isNotUndefined),
+    targetOrgRef.changes.pipe(
       Stream.map(org => org.orgId),
       Stream.changes,
+      // we do want a change to "no org" to trigger the refresh so it shows the empty state.
       Stream.tap(orgId => svc.appendToChannel(`Target org changed to ${orgId ?? '<NOT SET>'}`)),
       Stream.tap(() => svc.appendToChannel('Org changed, will try to update OrgBrowser')),
       Stream.runForEach(() => Effect.promise(() => treeProvider.refreshType()))

--- a/packages/salesforcedx-vscode-org/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-org/src/orgPicker/orgList.ts
@@ -12,7 +12,6 @@ import { Duration } from 'effect';
 import * as Effect from 'effect/Effect';
 import * as Order from 'effect/Order';
 import * as Stream from 'effect/Stream';
-import * as SubscriptionRef from 'effect/SubscriptionRef';
 import * as vscode from 'vscode';
 import { ORG_OPEN_COMMAND } from '../constants';
 import { nls } from '../messages';
@@ -243,7 +242,7 @@ export const createOrgPicker = Effect.fn('OrgPicker.createOrgPicker')(function* 
   const targetOrgRef = yield* api.services.TargetOrgRef();
 
   yield* Effect.forkDaemon(
-    Stream.concat(Stream.fromEffect(SubscriptionRef.get(targetOrgRef)), targetOrgRef.changes).pipe(
+    targetOrgRef.changes.pipe(
       Stream.tap(orgInfo => Effect.log('Org Extension:orgChange', orgInfo)),
       Stream.tap(orgInfo =>
         Effect.sync(() => (orgInfo.username ? orgOpenStatusBarItem.show() : orgOpenStatusBarItem.hide()))

--- a/packages/salesforcedx-vscode-services/src/vscode/context.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/context.ts
@@ -6,7 +6,6 @@
  */
 import * as Effect from 'effect/Effect';
 import * as Stream from 'effect/Stream';
-import * as SubscriptionRef from 'effect/SubscriptionRef';
 import * as vscode from 'vscode';
 import { getDefaultOrgRef } from '../core/defaultOrgRef';
 import { ChannelService } from './channelService';
@@ -28,10 +27,7 @@ const updateContext = (orgInfo: { orgId?: string; username?: string; tracksSourc
 export const watchDefaultOrgContext = Effect.fn('watchDefaultOrgContext')(function* () {
   const ref = yield* getDefaultOrgRef();
   const channelService = yield* ChannelService;
-  return yield* Stream.concat(
-    Stream.fromEffect(SubscriptionRef.get(ref)), // current value
-    ref.changes // future changes
-  ).pipe(
+  return yield* ref.changes.pipe(
     Stream.tap(orgInfo => channelService.appendToChannel(`watchDefaultOrgContext: ${JSON.stringify(orgInfo)}`)),
     Stream.runForEach(updateContext)
   );

--- a/packages/salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts
+++ b/packages/salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts
@@ -135,10 +135,7 @@ export class SOQLEditorInstance {
       Effect.gen(function* () {
         const api = yield* (yield* ExtensionProviderService).getServicesApi;
         const targetOrgRef = yield* api.services.TargetOrgRef();
-        yield* Stream.concat(
-          Stream.make(undefined),
-          targetOrgRef.changes.pipe(Stream.as(undefined))
-        ).pipe(
+        yield* targetOrgRef.changes.pipe(Stream.as(undefined)).pipe(
           Stream.mapEffect(() => Effect.promise(() => isDefaultOrgSet())),
           Stream.changes,
           Stream.runForEach(isOrgSet =>


### PR DESCRIPTION
### What does this PR do?

Removes redundant `mergeWithCurrentState` calls from subscription refs across org-browser, SOQL, apex-testing, metadata, and source-tracking packages.

No functional change intended.

### What issues does this PR fix or reference?
@W-22166418@

### Functionality Before
No change—refactor only.

### Functionality After
No change—refactor only.

Made with [Cursor](https://cursor.com)