### PR TITLE
fix(metadata-scraping): use page.goto() in initial discovery step to cirvumvent bot detection - W-22170404

### DIFF
--- a/scripts/xsd/scrape-all-metadata-pages.ts
+++ b/scripts/xsd/scrape-all-metadata-pages.ts
@@ -111,10 +111,13 @@ const discoverMetadataTypes = async (page: Page): Promise<{ name: string; url: s
   console.log(`   Fetching: ${JSON_DOC_URL}`);
 
   try {
-    // Fetch the JSON document directly (no browser needed for this part!)
-    const response = await page.context().request.get(JSON_DOC_URL);
-    if (!response.ok()) {
-      throw new Error(`Failed to fetch JSON document: ${response.status()} ${response.statusText()}`);
+    // Use page.goto() so the actual Chromium engine makes the request with its real TLS
+    // fingerprint and browser-specific headers (sec-ch-ua, sec-fetch-*, etc.).
+    // page.context().request.get() uses Node.js networking, which fails TLS fingerprint
+    // checks on bot-protected endpoints like Salesforce docs from cloud runner IPs.
+    const response = await page.goto(JSON_DOC_URL, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+    if (!response || !response.ok()) {
+      throw new Error(`Failed to fetch JSON document: ${response?.status()} ${response?.statusText()}`);
     }
 
     const docData = await response.json();


### PR DESCRIPTION
### What does this PR do?
Recently, Salesforce improved the bot detection check on the Metadata API Developer Guide.  This was causing our **Generate XSD for Metadata Types** GHA workflow runs to be blocked as made by bots, and thus failing in the initial discovery step with this error:
```
🔍 Launching discovery browser...

🔍 Discovering metadata types from JSON documentation...
   Fetching: https://developer.salesforce.com/docs/get_document/atlas.en-us.api_meta.meta
   ❌ Discovery failed: Error: Failed to fetch JSON document: 403 Forbidden
    at /home/runner/work/salesforcedx-vscode/salesforcedx-vscode/scripts/xsd/scrape-all-metadata-pages.ts:117:13
    at step (/home/runner/work/salesforcedx-vscode/salesforcedx-vscode/scripts/xsd/scrape-all-metadata-pages.ts:72:23)
    at Object.next (/home/runner/work/salesforcedx-vscode/salesforcedx-vscode/scripts/xsd/scrape-all-metadata-pages.ts:53:53)
    at fulfilled (/home/runner/work/salesforcedx-vscode/salesforcedx-vscode/scripts/xsd/scrape-all-metadata-pages.ts:44:58)
   📋 Using fallback list...

✅ Discovery browser closed

⚠️  No metadata types to scrape. Exiting.
```

This PR updates the discovery browser to call `page.goto()` instead of `page.context().request.get()`.  This works because `page.goto()` uses the TLS fingerprint from the Chromium browser, while `page.context().request.get()` uses the TLS fingerprint from Node.js and gets detected as a bot.

Passing run: https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/24782975997/job/72518995447
Generated PR: https://github.com/forcedotcom/salesforcedx-vscode/pull/7232

### What issues does this PR fix or reference?
@W-22170404@