### PR TITLE
ci: publish eslint-plugin-vscode-extensions to npm independently - W-22048497

### DIFF
--- a/.github/workflows/publishEslintPlugin.yml
+++ b/.github/workflows/publishEslintPlugin.yml
@@ -1,0 +1,109 @@
+name: Publish ESLint Plugin to npm
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - 'packages/eslint-local-rules/**'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g., eslint-plugin-vscode-extensions-v1.0.4). Leave empty to create a new release from commits.'
+        required: false
+        type: string
+      releaseType:
+        description: 'Version bump type when creating a new release from commits (ignored if tag is provided)'
+        required: false
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      prerelease:
+        description: 'Publish as prerelease (does not affect latest dist-tag)'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ steps.tag-output.outputs.tag }}
+    steps:
+      - name: Get Github user info
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.tag == ''
+        id: github-user-info
+        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@main
+        with:
+          SVC_CLI_BOT_GITHUB_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
+
+      - uses: actions/checkout@v4
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.tag == ''
+        with:
+          token: ${{ secrets.IDEE_GH_TOKEN }}
+          fetch-depth: 0
+
+      - name: Conventional Changelog Action
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.tag == ''
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@3a392e9aa44a72686b0fc13259a90d287dd0877c
+        env:
+          RELEASE_TYPE: ${{ github.event.inputs.releaseType }}
+        with:
+          git-user-name: ${{ steps.github-user-info.outputs.username }}
+          git-user-email: ${{ steps.github-user-info.outputs.email }}
+          github-token: ${{ secrets.IDEE_GH_TOKEN }}
+          tag-prefix: 'eslint-plugin-vscode-extensions-v'
+          version-file: './packages/eslint-local-rules/package.json'
+          git-path: 'packages/eslint-local-rules'
+          release-count: '0'
+          output-file: 'packages/eslint-local-rules/CHANGELOG.md'
+          skip-on-empty: ${{ github.event_name == 'push' }}
+          skip-tag: false
+          pre-changelog-generation: packages/eslint-local-rules/scripts/eslint-plugin-version-hook.js
+          pre-commit: packages/eslint-local-rules/scripts/eslint-plugin-version-hook.js
+
+      - name: Create Github Release
+        if: steps.changelog.outputs.skipped == 'false'
+        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b
+        with:
+          name: ${{ steps.changelog.outputs.tag }}
+          tag: ${{ steps.changelog.outputs.tag }}
+          commit: develop
+          body: ${{ steps.changelog.outputs.clean_changelog }}
+          token: ${{ secrets.IDEE_GH_TOKEN }}
+          skipIfReleaseExists: true
+
+      - id: tag-output
+        run: |
+          if [ -n "$INPUT_TAG" ]; then
+            echo "tag=$INPUT_TAG" >> $GITHUB_OUTPUT
+          elif [ "$CHANGELOG_SKIPPED" != "true" ] && [ -n "$CHANGELOG_TAG" ]; then
+            echo "tag=$CHANGELOG_TAG" >> $GITHUB_OUTPUT
+          else
+            echo "tag=" >> $GITHUB_OUTPUT
+          fi
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          CHANGELOG_SKIPPED: ${{ steps.changelog.outputs.skipped }}
+          CHANGELOG_TAG: ${{ steps.changelog.outputs.tag }}
+
+  publish:
+    name: Build and publish to npm
+    needs: create-release
+    if: needs.create-release.outputs.tag != ''
+    uses: salesforcecli/github-workflows/.github/workflows/npmPublish.yml@main
+    with:
+      githubTag: ${{ needs.create-release.outputs.tag }}
+      packageManager: npm
+      nodeVersion: ${{ vars.NODE_VERSION || 'lts/*' }}
+      packagePath: ./packages/eslint-local-rules
+      prerelease: ${{ github.event.inputs.prerelease == 'true' }}
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publishI18nPackage.yml
+++ b/.github/workflows/publishI18nPackage.yml
@@ -21,6 +21,11 @@ on:
           - patch
           - minor
           - major
+      prerelease:
+        description: 'Publish as prerelease (does not affect latest dist-tag)'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   create-release:
@@ -99,6 +104,6 @@ jobs:
       packageManager: npm
       nodeVersion: ${{ vars.NODE_VERSION || 'lts/*' }}
       packagePath: ./packages/salesforcedx-vscode-i18n
-      prerelease: false
+      prerelease: ${{ github.event.inputs.prerelease == 'true' }}
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publishSoqlCommon.yml
+++ b/.github/workflows/publishSoqlCommon.yml
@@ -21,6 +21,11 @@ on:
           - patch
           - minor
           - major
+      prerelease:
+        description: 'Publish as prerelease (does not affect latest dist-tag)'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   create-release:
@@ -99,6 +104,6 @@ jobs:
       packageManager: npm
       nodeVersion: ${{ vars.NODE_VERSION || 'lts/*' }}
       packagePath: ./packages/soql-common
-      prerelease: false
+      prerelease: ${{ github.event.inputs.prerelease == 'true' }}
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/architecture/Typescript.md
+++ b/docs/architecture/Typescript.md
@@ -33,6 +33,24 @@ export default [
   {
     plugins: { json: jsonPlugin }
   },
+  // TypeScript source files
+  {
+    files: ['src/**/*.ts'],
+    plugins: { local: localRulesPlugin },
+    rules: {
+      // i18n
+      'local/no-duplicate-i18n-values': 'error',
+      'local/no-unused-i18n-messages': 'error',
+      // vscode API hygiene
+      'local/no-vscode-message-literals': 'error',
+      'local/no-vscode-progress-title-literals': 'error',
+      'local/no-vscode-quickpick-description-literals': 'error',
+      'local/no-vscode-validateinput-literals': 'error',
+      'local/no-vscode-uri': 'error',
+      'local/command-must-be-in-package-json': 'error',
+    }
+  },
+  // package.json validation (requires @eslint/json)
   {
     files: ['**/package.json'],
     language: 'json/json',
@@ -42,14 +60,19 @@ export default [
       'local/package-json-extension-icon': 'error',
       'local/package-json-icon-paths': 'error',
       'local/package-json-command-refs': 'error',
-      'local/package-json-view-refs': 'error'
+      'local/package-json-view-refs': 'error',
+      'local/package-json-salesforce-dep-versions': 'error',
     }
   },
+  // .vscodeignore validation
   {
     files: ['packages/*/.vscodeignore'],
     plugins: { local: localRulesPlugin },
     processor: 'local/vscodeignoreText',
-    rules: { 'local/vscodeignore-required-patterns': 'error' }
+    rules: {
+      'local/vscodeignore-required-patterns': 'error',
+      'local/vscodeignore-contributes-conflict': 'error',
+    }
   }
 ];
 ```

--- a/docs/architecture/Typescript.md
+++ b/docs/architecture/Typescript.md
@@ -17,6 +17,45 @@ This repo has been around for a long time and doesn't always follow these guidel
 
 There are a lot of eslint rules in the repo, and we're expanding their use and trying to tighten up a lot of the older code. You can take the eslint configuration from this repo as a starting point. The custom rules for VS Code extension packages are published to npm as [`@salesforce/eslint-plugin-vscode-extensions`](https://www.npmjs.com/package/@salesforce/eslint-plugin-vscode-extensions) (source: `packages/eslint-local-rules`).
 
+#### Installing the plugin in your extension repo
+
+```bash
+npm install --save-dev @salesforce/eslint-plugin-vscode-extensions @eslint/json
+```
+
+In your `eslint.config.mjs`:
+
+```js
+import jsonPlugin from '@eslint/json';
+import localRulesPlugin from '@salesforce/eslint-plugin-vscode-extensions';
+
+export default [
+  {
+    plugins: { json: jsonPlugin }
+  },
+  {
+    files: ['**/package.json'],
+    language: 'json/json',
+    plugins: { json: jsonPlugin, local: localRulesPlugin },
+    rules: {
+      'local/package-json-i18n-descriptions': 'error',
+      'local/package-json-extension-icon': 'error',
+      'local/package-json-icon-paths': 'error',
+      'local/package-json-command-refs': 'error',
+      'local/package-json-view-refs': 'error'
+    }
+  },
+  {
+    files: ['packages/*/.vscodeignore'],
+    plugins: { local: localRulesPlugin },
+    processor: 'local/vscodeignoreText',
+    rules: { 'local/vscodeignore-required-patterns': 'error' }
+  }
+];
+```
+
+See the [package README](../../packages/eslint-local-rules/README.md) for the full list of available rules and their descriptions.
+
 ### current EcmaScript
 
 You'll see old code, and AIs are trained on it. There's often better ways in recent ES versions, but the old ones are still around for compatibility. Eslint rules can help keep things up to date using newer techniques.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9468,7 +9468,6 @@
       "version": "8.57.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.0.tgz",
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
@@ -9493,7 +9492,6 @@
       "version": "8.57.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.0.tgz",
       "integrity": "sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/tsconfig-utils": "^8.57.0",
@@ -9565,7 +9563,6 @@
       "version": "8.57.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.0.tgz",
       "integrity": "sha512-nvExQqAHF01lUM66MskSaZulpPL5pgy5hI5RfrxviLgzZVffB5yYzw27uK/ft8QnKXI2X0LBrHJFr1TaZtAibw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.57.0",
@@ -9583,7 +9580,6 @@
       "version": "8.57.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.0.tgz",
       "integrity": "sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -9625,7 +9621,6 @@
       "version": "8.57.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.0.tgz",
       "integrity": "sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -9639,7 +9634,6 @@
       "version": "8.57.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.0.tgz",
       "integrity": "sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/project-service": "8.57.0",
@@ -9667,7 +9661,6 @@
       "version": "8.57.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.0.tgz",
       "integrity": "sha512-5iIHvpD3CZe06riAsbNxxreP+MuYgVUsV0n4bwLH//VJmgtt54sQeY2GszntJ4BjYCpMzrfVh2SBnUQTtys2lQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
@@ -9691,7 +9684,6 @@
       "version": "8.57.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.0.tgz",
       "integrity": "sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.57.0",
@@ -9709,7 +9701,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -42430,7 +42421,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
       "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.12"
@@ -45409,15 +45399,15 @@
       "version": "65.7.0",
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@humanwhocodes/momoa": "^3.3.10",
+        "@typescript-eslint/parser": "^8.50.0",
+        "@typescript-eslint/utils": "^8.50.0",
         "minimatch": "^10.2.4"
       },
       "devDependencies": {
-        "@humanwhocodes/momoa": "^3.3.10",
         "@types/eslint": "^9.0.0",
         "@types/estree": "^1.0.0",
-        "@typescript-eslint/parser": "^8.50.0",
-        "@typescript-eslint/rule-tester": "^8.50.0",
-        "@typescript-eslint/utils": "^8.50.0"
+        "@typescript-eslint/rule-tester": "^8.50.0"
       },
       "peerDependencies": {
         "@eslint/json": "^0.3.0",

--- a/packages/eslint-local-rules/LICENSE.txt
+++ b/packages/eslint-local-rules/LICENSE.txt
@@ -1,0 +1,27 @@
+Copyright (c) 2026 Salesforce, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of Salesforce nor the names of its contributors may be
+used to endorse or promote products derived from this software without specific
+prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY SALESFORCE AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL SALESFORCE OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/eslint-local-rules/package.json
+++ b/packages/eslint-local-rules/package.json
@@ -1,13 +1,37 @@
 {
   "name": "@salesforce/eslint-plugin-vscode-extensions",
   "version": "65.7.0",
+  "versionedIndependently": true,
   "description": "Custom ESLint rules for Salesforce VSCode extensions",
+  "author": "Salesforce",
+  "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/forcedotcom/salesforcedx-vscode"
+  },
+  "bugs": {
+    "url": "https://github.com/forcedotcom/salesforcedx-vscode/issues"
+  },
+  "homepage": "https://github.com/forcedotcom/salesforcedx-vscode/tree/develop/packages/eslint-local-rules",
   "main": "out/index.js",
+  "types": "out/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./out/index.d.ts",
+      "default": "./out/index.js"
+    }
+  },
   "files": [
     "out/**/*.js",
+    "out/**/*.js.map",
     "out/**/*.d.ts",
+    "out/**/*.d.ts.map",
+    "LICENSE.txt",
     "README.md"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "compile": "wireit",
     "test": "wireit",
@@ -87,21 +111,19 @@
     "eslintplugin",
     "salesforce"
   ],
-  "author": "Salesforce",
-  "license": "BSD-3-Clause",
   "peerDependencies": {
     "@eslint/json": "^0.3.0",
     "eslint": ">=8.0.0"
   },
   "dependencies": {
+    "@humanwhocodes/momoa": "^3.3.10",
+    "@typescript-eslint/parser": "^8.50.0",
+    "@typescript-eslint/utils": "^8.50.0",
     "minimatch": "^10.2.4"
   },
   "devDependencies": {
-    "@humanwhocodes/momoa": "^3.3.10",
     "@types/eslint": "^9.0.0",
     "@types/estree": "^1.0.0",
-    "@typescript-eslint/parser": "^8.50.0",
-    "@typescript-eslint/rule-tester": "^8.50.0",
-    "@typescript-eslint/utils": "^8.50.0"
+    "@typescript-eslint/rule-tester": "^8.50.0"
   }
 }

--- a/packages/eslint-local-rules/scripts/eslint-plugin-version-hook.js
+++ b/packages/eslint-local-rules/scripts/eslint-plugin-version-hook.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+/**
+ * pre-changelog-generation hook for TriPSs/conventional-changelog-action.
+ * When RELEASE_TYPE env var is set (from workflow_dispatch input), override
+ * the version bump type instead of relying solely on conventional commits.
+ */
+exports.preVersionGeneration = (proposedVersion) => {
+  const releaseType = process.env.RELEASE_TYPE
+  if (!releaseType || !['major', 'minor', 'patch'].includes(releaseType)) {
+    return proposedVersion
+  }
+  const { version } = require('../package.json')
+  const [major, minor, patch] = version.split('.').map(Number)
+  if (releaseType === 'major') return `${major + 1}.0.0`
+  if (releaseType === 'minor') return `${major}.${minor + 1}.0`
+  return `${major}.${minor}.${patch + 1}`
+}
+
+/**
+ * pre-commit hook for TriPSs/conventional-changelog-action.
+ * Patches the eslint-plugin version in the root package-lock.json so it stays
+ * in sync with the bumped packages/eslint-local-rules/package.json.
+ */
+exports.preCommit = ({ version }) => {
+  const lockPath = path.join(process.env.GITHUB_WORKSPACE, 'package-lock.json')
+  const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'))
+  if (lock.packages?.['packages/eslint-local-rules']) {
+    lock.packages['packages/eslint-local-rules'].version = version
+  }
+  fs.writeFileSync(lockPath, JSON.stringify(lock, null, 2) + '\n')
+}


### PR DESCRIPTION
### What does this PR do?

Adds npm publish infrastructure for \`@salesforce/eslint-plugin-vscode-extensions\`, mirroring the pattern from \`salesforcedx-vscode-i18n\`. Also adds \`prerelease\` input to the i18n and soql-common publish workflows to match. Updates agent skills with Slack IDs and Slack ping step.

- \`package.json\`: add \`versionedIndependently\`, \`types\`, \`exports\`, \`publishConfig\`, \`repository\`, \`bugs\`, \`homepage\`; update \`files\` to include source maps + \`LICENSE.txt\`; move \`@humanwhocodes/momoa\`, \`@typescript-eslint/parser\`, \`@typescript-eslint/utils\` from devDeps → deps (all imported in src)
- \`LICENSE.txt\`: copied from repo root
- \`scripts/eslint-plugin-version-hook.js\`: pre-changelog/pre-commit hook for \`conventional-changelog-action\`
- \`.github/workflows/publishEslintPlugin.yml\`: triggers on push to \`develop\` at \`packages/eslint-local-rules/**\`; supports \`workflow_dispatch\` with tag + prerelease inputs; tags as \`eslint-plugin-vscode-extensions-vX.Y.Z\`
- \`.github/workflows/publishI18nPackage.yml\`, \`publishSoqlCommon.yml\`: add \`prerelease\` boolean input to match eslint plugin workflow
- \`.claude/skills/gus-cli/SKILL.md\`: add Slack IDs to team members table
- \`.claude/skills/pr-draft/SKILL.md\`: add Slack ping step after reviewer reassignment; add GitHub issues/discussion search step before finalizing PR body

### What issues does this PR fix or reference?

@W-22048497@

Made with [Cursor](https://cursor.com)