### PR TITLE
docs(skills): add GitHub issue/discussion search to pr-draft - W-22187438

### DIFF
--- a/.claude/skills/gus-cli/SKILL.md
+++ b/.claude/skills/gus-cli/SKILL.md
@@ -47,16 +47,15 @@ Objects: `ADM_Work__c`, `ADM_Epic__c` (not ADM_Theme\_\_c).
 
 **Default when unassigned:** Platform Dev Tools Scrum Team `005B0000000GIODIA4` – use when work isn't assigned to a person yet.
 
-| Name | Id | GitHub login |
-|---|---|---|
-| Cristina Cañizales | `005EE000008cgrGYAQ` | `CristiCanizales` |
-| Daphne Yang | `005EE000005d0jdYAA` | `daphne-sfdc` |
-| Jonny Hork | `005B0000004pYWjIAM` | `jonnyhork` |
-| Kyle Walker | `005EE0000010oCLYAY` | `kylewalke` |
-| Madhur Shrivastava | `005EE00000VZK5FYAX` | `madhur310` |
-| Peter Hale | `005B0000000GFvWIAW` | `peternhale` |
-| Shane McLaughlin | `005B00000024wGBIAY` | `mshanemc` |
-| Sonal Budhiraja | `005B0000005ccPnIAI` | `sbudhirajadoc` |
+| Name               | Id                   | GitHub login      | Slack ID      |
+| ------------------ | -------------------- | ----------------- | ------------- |
+| Cristina Cañizales | `005EE000008cgrGYAQ` | `CristiCanizales` | `U040DRU0ADA` |
+| Daphne Yang        | `005EE000005d0jdYAA` | `daphne-sfdc`     | `U03CKVATVCY` |
+| Jonny Hork         | `005B0000004pYWjIAM` | `jonnyhork`       | `WFGT1L8HF`   |
+| Kyle Walker        | `005EE0000010oCLYAY` | `kylewalke`       | `U02GCUGEAUU` |
+| Madhur Shrivastava | `005EE00000VZK5FYAX` | `madhur310`       | `U0852LWKWSW` |
+| Peter Hale         | `005B0000000GFvWIAW` | `peternhale`      | `WAR9BDB8T`   |
+| Shane McLaughlin   | `005B00000024wGBIAY` | `mshanemc`        | `WB4TF6RFY`   |
 
 ## Work items (ADM_Work\_\_c)
 
@@ -79,7 +78,7 @@ Closed statuses: see ## Status\_\_c values. Use `LIMIT 50` (or 100) when queryin
 
 **`-v` + `--flags-dir` don't combine on create:** `-v` takes precedence; flags-dir values are dropped. Workaround: create without Details, then update with `--flags-dir` only.
 
-**Details\_\_c formatting (readable WI body):** Details__c is a Rich Text Area (extraTypeInfo: richtextarea)—use HTML, not markdown. The `-v` flag parses space-separated key=value; use `--flags-dir` with a `values` file ([ref](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_flag_values_in_files.htm)):
+**Details\_\_c formatting (readable WI body):** Details\_\_c is a Rich Text Area (extraTypeInfo: richtextarea)—use HTML, not markdown. The `-v` flag parses space-separated key=value; use `--flags-dir` with a `values` file ([ref](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_flag_values_in_files.htm)):
 
 1. `mkdir -p /tmp/gus-flags`
 2. Create `values` with one line: `Details__c='<p><strong>Section</strong></p><p>Content. <code>inline code</code></p><ul><li>item</li></ul><p><strong>Ref:</strong> <a href="https://...">url</a></p>'`
@@ -90,6 +89,7 @@ Constraints: File must be single-line (flags-dir treats each line as a separate 
 **After create:** Always provide the work item link. Format: `https://gus.lightning.force.com/lightning/r/ADM_Work__c/<recordId>/view` (replace `<recordId>` with the Id from the create output, e.g. `a07EE00002V3a8YYAR`). Example: [a07EE00002V3a8YYAR](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002V3a8YYAR/view).
 
 **CRITICAL:** After creation, you MUST query the `Name` (W-XXXXX) to append to the PR title as ` - W-XXXXX`. The `id` returned by `sf data create` is NOT the `W-XXXXX` name.
+
 ```bash
 sf data query --query "SELECT Name FROM ADM_Work__c WHERE Id = '<id_from_create>'" -o gus --json
 ```

--- a/.claude/skills/pr-draft/SKILL.md
+++ b/.claude/skills/pr-draft/SKILL.md
@@ -27,6 +27,11 @@ Draft PR titles and bodies per salesforcedx-vscode conventions. Requires a Gus w
      1. Get current review requests: `gh pr view <url> --json reviewRequests --jq '.reviewRequests[].login'`
      2. Remove each existing reviewer: `gh pr edit <url> --remove-reviewer <login>`
      3. Add selected QA person: `gh pr edit <url> --add-reviewer <github_login>` (from [gus-cli Team members](../gus-cli/SKILL.md#team-members-assignee__c-qa_engineer__c))
+   - **Slack ping:** After reviewer reassignment, send a message to `#ide-exp-code-review` (channel ID `C054SJJAB24`) tagging the QA person (use Slack ID from [gus-cli Team members](../gus-cli/SKILL.md#team-members-assignee__c-qa_engineer__c)):
+     ```
+     <@SLACK_ID> PR ready for review: <pr_url> (W-XXXXX: <gus_wi_url>)
+     ```
+     If Slack MCP is unavailable, tell the user: "Slack MCP is not configured — please manually ping `<@SLACK_ID>` in `#ide-exp-code-review` with the PR and WI links. To enable this automatically, set up the Slack MCP."
 
 ## Target branch
 

--- a/.claude/skills/pr-draft/SKILL.md
+++ b/.claude/skills/pr-draft/SKILL.md
@@ -29,7 +29,7 @@ Draft PR titles and bodies per salesforcedx-vscode conventions. Requires a Gus w
      3. Add selected QA person: `gh pr edit <url> --add-reviewer <github_login>` (from [gus-cli Team members](../gus-cli/SKILL.md#team-members-assignee__c-qa_engineer__c))
    - **Slack ping:** After reviewer reassignment, send a message to `#ide-exp-code-review` (channel ID `C054SJJAB24`) tagging the QA person (use Slack ID from [gus-cli Team members](../gus-cli/SKILL.md#team-members-assignee__c-qa_engineer__c)):
      ```
-     <@SLACK_ID> PR ready for review: <pr_url> (W-XXXXX: <gus_wi_url>)
+     <@SLACK_ID> PR ready for review: <pr_url|PR #NNNN> (<gus_wi_url|W-XXXXX>)
      ```
      If Slack MCP is unavailable, tell the user: "Slack MCP is not configured — please manually ping `<@SLACK_ID>` in `#ide-exp-code-review` with the PR and WI links. To enable this automatically, set up the Slack MCP."
 

--- a/.claude/skills/pr-draft/SKILL.md
+++ b/.claude/skills/pr-draft/SKILL.md
@@ -44,6 +44,17 @@ Draft PR titles and bodies per salesforcedx-vscode conventions. Requires a Gus w
 - Example: `build(extensions): consolidate apex-tmlanguage - W-21735053`
 - **Avoid:** leading brackets — `[W-21735053] build(extensions): …`; bare trailing WI without ` - ` — `build(extensions): … W-21735053`
 
+## GitHub issues & discussions
+
+Before finalizing body, fetch and analyze:
+
+1. **Issues:** `gh issue list --state open --limit 200 --json number,title,body,comments`
+2. **Discussions:** `gh api graphql` — fetch all open discussions (title, number, url, body)
+3. **LLM relevance pass:** read PR diff/commits + all issue/discussion titles+bodies; identify candidates
+4. **Auto-include** any issue where a comment contains the PR's W-XXXXX (e.g. `W-12345`) — no prompt needed; Git2Gus already established the link
+5. **Show remaining candidates** (issues and discussions the LLM flagged as related); ask user which to include
+6. **Format:** issues as `#<number>`, discussions as full URL — both in the "What issues does this PR fix or reference?" section
+
 ## Body format
 
 - Base body on branch commits only


### PR DESCRIPTION
### What does this PR do?

Adds a step to the `pr-draft` skill directing the agent to search GitHub issues and discussions before finalizing the PR body. Relevant issues are auto-included when linked via W-XXXXX comment; remaining candidates are shown to the user.

### What issues does this PR fix or reference?
@W-22187438@

Made with [Cursor](https://cursor.com)