### PR TITLE
fix(metadata-scraping): add hover documentation support for metadata types that have a description but no Fields table - W-22169417

### DIFF
--- a/packages/salesforcedx-vscode-core/metadata_types_map_scraped.json
+++ b/packages/salesforcedx-vscode-core/metadata_types_map_scraped.json
@@ -1,4 +1,10 @@
 {
+  "Metadata Type Limits": {
+    "fields": [],
+    "short_description": "Certain metadata types have deploy and retrieve limits. Limits apply to each individual deploy or retrieve transaction, and there are daily limits for specific metadata types. The individual deploy and retrieve limits represent the maximum count that a metadata type may be deployed or retrieved in a single package zip. Daily deploy and retrieve limits apply to individual org usage within a 24-hour period. Metadata Deploy Limits",
+    "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_metadata_type_limits.htm",
+    "parent": "Metadata"
+  },
   "ActivationPlatform": {
     "fields": [
       {
@@ -79,6 +85,12 @@
     ],
     "short_description": "Represents the ActivationPlatform configuration, such as platform name, delivery schedule, output format, and destination folder.",
     "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_activationplatform.htm",
+    "parent": "Metadata"
+  },
+  "ActivationPlatformActvAttr": {
+    "fields": [],
+    "short_description": "Represents the information about activation attributes. Reserved for future use.",
+    "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_activationplatformactvattr.htm",
     "parent": "Metadata"
   },
   "ActivationPlatformField": {
@@ -998,6 +1010,12 @@
     "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_datasourceobject.htm",
     "parent": "Metadata"
   },
+  "DataSourceTenant": {
+    "fields": [],
+    "short_description": "For internal use only.",
+    "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_datasourcetenant.htm",
+    "parent": "Metadata"
+  },
   "DataSrcDataModelFieldMap": {
     "fields": [
       {
@@ -1432,6 +1450,12 @@
     "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_externaldatasource.htm",
     "parent": "Metadata"
   },
+  "ExternalDataTransportFieldTemplate": {
+    "fields": [],
+    "short_description": "For internal use only.",
+    "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_externaldatatransportfieldtemplate.htm",
+    "parent": "Metadata"
+  },
   "ExternalDataTranObject": {
     "fields": [
       {
@@ -1613,6 +1637,12 @@
     "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_externaldatatranobject.htm",
     "parent": "Metadata"
   },
+  "ExternalDataTransportObjectTemplate": {
+    "fields": [],
+    "short_description": "For internal use only.",
+    "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_externaldatatransportobjecttemplate.htm",
+    "parent": "Metadata"
+  },
   "FieldSrcTrgtRelationship": {
     "fields": [
       {
@@ -1658,6 +1688,12 @@
     ],
     "short_description": "Stores the relationships between a data model object (DMO) and its fields. For example, the Individual.Id field has a one-to-many relationship (1:M) with the ContactPointEmail.PartyId field.",
     "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_fieldsrctrgtrelationship.htm",
+    "parent": "Metadata"
+  },
+  "InternalDataConnector": {
+    "fields": [],
+    "short_description": "For internal use only.",
+    "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_internaldataconnector.htm",
     "parent": "Metadata"
   },
   "MarketSegmentDefinition": {
@@ -4838,6 +4874,12 @@
     "short_description": "Represents an Apex trigger. A trigger is Apex code that executes before or after specific data manipulation language (DML) events occur, such as before object records are inserted into the database, or after records have been deleted. For more information, see “Manage Apex Triggers” in Salesforce Help. This type extends the MetadataWithContent metadata type and inherits its content and fullName fields.",
     "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_triggers.htm",
     "parent": "MetadataWithContent"
+  },
+  "AppMenu": {
+    "fields": [],
+    "short_description": "Represents the app menu or the Salesforce mobile navigation menu. Reserved for future use.",
+    "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_appmenu.htm",
+    "parent": "Metadata"
   },
   "AppointmentAssignmentPolicy": {
     "fields": [
@@ -26121,6 +26163,12 @@
     "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_flowtest.htm",
     "parent": "Metadata"
   },
+  "FlowValueMap": {
+    "fields": [],
+    "short_description": "Reserved for future use.",
+    "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_flowvaluemap.htm",
+    "parent": "Metadata"
+  },
   "DocumentFolder": {
     "fields": [
       {
@@ -28237,6 +28285,12 @@
     ],
     "short_description": "Represents a first-generation managed package to be installed or uninstalled. Deploying a newer version of a currently installed package upgrades the package. You can install up to 20 first-generation managed packages in a single deployment. To install an unlocked or second-generation managed package, use the sf package install Salesforce CLI command.",
     "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_installedpackage.htm",
+    "parent": "Metadata"
+  },
+  "IntegArtifactDef": {
+    "fields": [],
+    "short_description": "For internal use only.",
+    "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_integartifactdef.htm",
     "parent": "Metadata"
   },
   "IntegrationProviderDef": {
@@ -33915,6 +33969,12 @@
     "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_ocrtemplate.htm",
     "parent": "Metadata"
   },
+  "Industries Common Resources": {
+    "fields": [],
+    "short_description": "Certain feature sets are shared across industries. This guide contains developer documentation to help you put those features to work.",
+    "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_omnisupervisorconfig.htm",
+    "parent": "Metadata"
+  },
   "OutboundNetworkConnection": {
     "fields": [
       {
@@ -39331,6 +39391,12 @@
     ],
     "short_description": "Represents the common base type and valid values for role or territory.",
     "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_roleorterritory.htm",
+    "parent": "Metadata"
+  },
+  "RpaRobotPoolMetadata": {
+    "fields": [],
+    "short_description": "Reserved for future use.",
+    "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_rparobotpoolmetadata.htm",
     "parent": "Metadata"
   },
   "SalesWorkQueueSettings": {
@@ -46309,7 +46375,7 @@
         "Field Type": "boolean"
       },
       {
-        "Description": "Indicates whether the org has enabled language extension packages (true) or not (false). Language extension packages contain translations of components in other packages. This field has a default value of false. This field is available in API version 58.0 and later. enableLanguageExtensionPackage (beta) is a pilot or beta service that is subject to the Beta Services Terms at Agreements - Salesforce.com or a written Unified Pilot Agreement if executed by Customer, and applicable terms in the Product Terms Directory. Use of this pilot or beta service is at the Customer's sole discretion.Note",
+        "Description": "Indicates whether the org has enabled language extension packages (true) or not (false). Language extension packages contain translations of components in other packages. This field has a default value of false. This field is available in API version 58.0 and later. enableLanguageExtensionPackage (beta) is a pilot or beta service that is subject to the Beta Services Terms at Agreements - Salesforce.com or a written Unified Pilot Agreement if executed by Customer, and applicable terms in the Product Terms Directory. Use of this pilot or beta service is at the Customer's sole discretion.",
         "Field Name": "enableLanguageExtensionPackage\n                                (beta)",
         "Field Type": "boolean"
       },
@@ -46324,7 +46390,7 @@
         "Field Type": "boolean"
       },
       {
-        "Description": "Indicates whether platform-only languages are enabled (true) or not (false). This field has a default value of false. Setting this field to true also sets enableEndUserLanguages to true.",
+        "Description": "Indicates whether platform-only languages are enabled (true) or not (false). This field has a default value of false. Setting this field to true also sets enableEndUserLanguagestrue.",
         "Field Name": "enablePlatformLanguages",
         "Field Type": "boolean"
       },
@@ -53889,6 +53955,12 @@
     "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_usercriteria.htm",
     "parent": "Metadata"
   },
+  "UserProfileSearchScope": {
+    "fields": [],
+    "short_description": "Reserved for internal use.",
+    "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_userprofilesearchscope.htm",
+    "parent": "Metadata"
+  },
   "UserProvisioningConfig": {
     "fields": [
       {
@@ -55050,6 +55122,12 @@
     ],
     "short_description": "WaveXmdOrganization represents a Salesforce organization.",
     "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_wavexmd.htm",
+    "parent": "Metadata"
+  },
+  "WebStoreBundle": {
+    "fields": [],
+    "short_description": "For internal use only.",
+    "url": "https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_webstorebundle.htm",
     "parent": "Metadata"
   },
   "WebStoreTemplate": {

--- a/scripts/xsd/scrape-all-metadata-pages.ts
+++ b/scripts/xsd/scrape-all-metadata-pages.ts
@@ -155,19 +155,9 @@ const discoverMetadataTypes = async (page: Page): Promise<{ name: string; url: s
     // Pages to exclude but still process their children (skip page only, continue recursion)
     const excludedPagesOnly = [
       'meta_data_cloud_types',
-      'meta_activationplatformactvattr',
-      'meta_datasourcetenant',
-      'meta_externaldatatransportfieldtemplate',
-      'meta_externaldatatransportobjecttemplate',
-      'meta_internaldataconnector',
-      'meta_appmenu',
       'meta_digitalexperiencebundle_marketing',
       'meta_digitalexperiencebundle_site',
-      'meta_flowvaluemap',
-      'meta_rparobotpoolmetadata',
-      'meta_settings',
-      'meta_userprofilesearchscope',
-      'meta_webstorebundle'
+      'meta_settings'
     ];
 
     // Recursively extract metadata type entries (including nested subtypes)

--- a/scripts/xsd/scrapeUtils.ts
+++ b/scripts/xsd/scrapeUtils.ts
@@ -138,10 +138,10 @@ export const loadMetadataPage = async (
       const tableCount = await contentFrame.evaluate(getTableCountEvaluator());
 
       if (tableCount === 0) {
-        console.log(`${indent}❌ No tables found after all strategies`);
-        return { success: false, contentFrame: null };
+        console.log(`${indent}⚠️ No tables found — will attempt description-only extraction`);
+      } else {
+        console.log(`${indent}✅ Found ${tableCount} tables after scroll`);
       }
-      console.log(`${indent}✅ Found ${tableCount} tables after scroll`);
     }
 
     return { success: true, contentFrame };
@@ -528,7 +528,9 @@ export const extractMetadataFromPage = async (
       return {
         tablesData,
         pageHeadings: Array.from(pageHeadings),
-        headingsWithoutTables
+        headingsWithoutTables,
+        pageLevelDescription,
+        pageTitle
       };
 
       // ============================================================================
@@ -913,8 +915,13 @@ export const extractMetadataFromPage = async (
     const allTableFields = extractionResult.tablesData;
     const pageHeadingsSet = new Set<string>(extractionResult.pageHeadings as string[]);
 
-    // If no tables and no headings without tables, return empty
-    if (allTableFields.length === 0 && !extractionResult.headingsWithoutTables?.length) return [];
+    // If no tables, no headings without tables, and no page-level description, return empty
+    if (
+      allTableFields.length === 0 &&
+      !extractionResult.headingsWithoutTables?.length &&
+      !extractionResult.pageLevelDescription
+    )
+      return [];
 
     // Process all tables
     for (let i = 0; i < allTableFields.length; i++) {
@@ -948,6 +955,24 @@ export const extractMetadataFromPage = async (
     // Process headings without tables
     if (extractionResult.headingsWithoutTables && extractionResult.headingsWithoutTables.length > 0) {
       processHeadingsWithoutTables(results, extractionResult.headingsWithoutTables, url);
+    }
+
+    // Fallback for description-only pages (e.g. AppMenu): no tables, no section headings that
+    // produced entries, but the page does have a shortdesc.  Use the page title / typeName so the
+    // type at least gets a description entry and an XSD definition.
+    if (results.length === 0 && extractionResult.pageLevelDescription) {
+      const name = (extractionResult.pageTitle as string) || typeName;
+      const cleanedDesc = normalizeWhitespace(extractionResult.pageLevelDescription as string);
+      console.log(`     ℹ️  Adding description-only entry for ${name}`);
+      results.push({
+        name,
+        data: {
+          fields: [],
+          short_description: cleanedDesc,
+          url: url.split('#')[0],
+          parent: extractParentType(cleanedDesc, [])
+        }
+      });
     }
 
     // Special handling for Folder metadata type


### PR DESCRIPTION
### What does this PR do?
In the Metadata API Developer Guide, there are metadata types such as **[AppMenu](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_appmenu.htm)** that have a description but no Fields table.  Those metadata types were originally being excluded from the scraping.

This PR updates the behavior to add those metadata types to the XSD and produce hover documentation for them.

<img width="550" alt="Screenshot 2026-04-22 at 11 08 28 PM" src="https://github.com/user-attachments/assets/9472e141-2bbf-46c0-bbe5-80b784cedd7f" />

### What issues does this PR fix or reference?
@W-22169417@
