### PR TITLE
feat(lwc): add LWC LSP Playwright E2E test suite with web + desktop c…

### DIFF
--- a/.claude/agents/playwright-e2e-monitor.md
+++ b/.claude/agents/playwright-e2e-monitor.md
@@ -60,7 +60,7 @@ Monitor running e2e playwright tests, download artifacts on failure, provide ana
 **Running workflow → failure:**
 
 1. Branch: `feature/my-branch`
-2. Find "Metadata E2E (Playwright)" `in_progress`
+2. Find "Metadata E2E (Playwright)" or "LWC E2E (Playwright)" `in_progress`
 3. Monitor until `failure`
 4. Download to `.e2e-artifacts/feature/my-branch/<run-id>-Metadata-E2E-Playwright/`
 5. Report failure with artifact location, offer HTML report

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,8 @@
       "Bash(WIREIT_CACHE=none npm run *)",
       "Bash(sf org:*)",
       "WebFetch(domain:github.com)",
-      "WebFetch(domain:code.visualstudio.com)"
+      "WebFetch(domain:code.visualstudio.com)",
+      "Bash(find .vscode-test-web/ -name *.json)"
     ],
     "autoApprove": [
       "PostToolUse",

--- a/.claude/skills/playwright-e2e/SKILL.md
+++ b/.claude/skills/playwright-e2e/SKILL.md
@@ -65,7 +65,7 @@ See `references/full-suite-execution.md` for complete guide on running all E2E t
 
 To run only your new test in CI while iterating:
 
-1. **Disable other workflows** — add your branch to `branches-ignore` in `.github/workflows/*.yml` that have `push: branches-ignore: [main, develop]` (e.g. `testCommitExceptMain.yml`, `coreE2E.yml`, `orgBrowserE2E.yml`, etc.)
+1. **Disable other workflows** — add your branch to `branches-ignore` in `.github/workflows/*.yml` that have `push: branches-ignore: [main, develop]` (e.g. `testCommitExceptMain.yml`, `coreE2E.yml`, `orgBrowserE2E.yml`, `lwcPlaywrightE2E.yml`, etc.)
 2. **Filter target workflow** — add `--grep "Your Test Title"` to the test run command in the workflow you care about
 3. **Optional** — skip org setup steps not needed for your test (e.g. minimal/non-tracking orgs)
 4. **Restore** — remove branch from `branches-ignore`, remove `--grep`, uncomment skipped steps

--- a/.claude/skills/playwright-e2e/references/analyze-e2e.md
+++ b/.claude/skills/playwright-e2e/references/analyze-e2e.md
@@ -79,7 +79,7 @@ PY
 
 ## Workflow Detection
 
-Filter `workflowName` containing "(Playwright)". Examples: Metadata E2E, Services E2E, OrgBrowser E2E.
+Filter `workflowName` containing "(Playwright)". Examples: Metadata E2E, Services E2E, OrgBrowser E2E, LWC E2E.
 
 ## Finding video
 

--- a/.claude/skills/playwright-e2e/references/coding-playwright-tests.md
+++ b/.claude/skills/playwright-e2e/references/coding-playwright-tests.md
@@ -28,12 +28,18 @@ One test per file. Many steps allowed.
 
 **Use UI interactions:**
 
-- `Control+p` - Quick Open
+- Quick Open: `@salesforce/playwright-vscode-ext` `openFileByName` — palette "Go to File…" (web + desktop); VS Code 1.116+ rows often `basename` + segments + trailing `file results` — match logic `packages/playwright-vscode-ext/src/utils/fileHelpers.ts`
 - `Control+Home`, `Control+s` - navigate and save
 - `page.keyboard.type()` - edit content
 - Monaco editor selectors - interact with editor
 
 Tests must work identically in web and desktop.
+
+## Web headless (`createHeadlessServer`)
+
+- Virtual `folderPath` mount: Node `fs` does not see project files; use `folderUri` (`file://…`) or `.vscode/vscode-extension-test-disk-root.txt` (disk root) when services must resolve `SfProject` — see JSDoc on `packages/playwright-vscode-ext/src/web/createHeadlessServer.ts`
+- Load extra extensions via `additionalExtensionDirs` (e.g. metadata for LWC create). **Web** `headlessServer` + **desktop** fixture: empty `lwc/` + CustomLabels + empty `snippetsE2E` (snippet specs); other bundles via **SFDX: Create Lightning Web Component**.
+- LWC LSP ready (`waitForLwcLspReady` in `salesforcedx-vscode-lwc` `test/playwright/utils/lwcUtils.ts`): **web** — `LWC Extension` output line `LWC Language Server: indexing complete`; **desktop** — Editor Language Status / legacy status text `Indexing complete` (language status item often missing on web)
 
 ## Virtualized DOM
 

--- a/.claude/skills/playwright-e2e/references/iterating-playwright-tests.md
+++ b/.claude/skills/playwright-e2e/references/iterating-playwright-tests.md
@@ -49,3 +49,4 @@ https://github.com/redhat-developer/vscode-extension-tester - pageObject/Selecto
 
 - TS extension activation: `Error: Activating extension 'vscode.typescript-language-features'`
 - **All installed extensions temporarily disabled** (other extensions, not ours) - expected notification
+- VS Code 1.116+ / `@vscode/test-electron`: `cannot change enablement of github copilot chat extension` — workbench Copilot Chat toggle in test env; non-critical (`helpers.ts` `NON_CRITICAL_ERROR_PATTERNS`)

--- a/.claude/skills/services-extension-consumption/references/project-service.md
+++ b/.claude/skills/services-extension-consumption/references/project-service.md
@@ -9,7 +9,7 @@ Salesforce project resolution. Accessor pattern: call methods directly.
 Check if workspace is Salesforce project (sfdx-project.json exists):
 
 ```typescript
-const isProject = yield* api.services.ProjectService.isSalesforceProject();
+const isProject = yield * api.services.ProjectService.isSalesforceProject();
 ```
 
 Side effect: sets `sf:project_opened` context.
@@ -19,7 +19,7 @@ Side effect: sets `sf:project_opened` context.
 Get SfProject (fails if not Salesforce project):
 
 ```typescript
-const project = yield* api.services.ProjectService.getSfProject();
+const project = yield * api.services.ProjectService.getSfProject();
 ```
 
 Returns `SfProject` from `@salesforce/core`. Side effect: sets `sf:project_opened` context.
@@ -34,18 +34,20 @@ Returns `SfProject` from `@salesforce/core`. Side effect: sets `sf:project_opene
 From `salesforcedx-vscode-metadata`:
 
 ```typescript
-const packageDirs = (yield* api.services.ProjectService.getSfProject()).getPackageDirectories();
+const packageDirs = (yield * api.services.ProjectService.getSfProject()).getPackageDirectories();
 ```
 
 From `salesforcedx-vscode-org-browser`:
 
 ```typescript
-const dirs = (yield* api.services.ProjectService.getSfProject()).getPackageDirectories();
+const dirs = (yield * api.services.ProjectService.getSfProject()).getPackageDirectories();
 ```
 
 ## Notes
 
 - Cached globally (10 min TTL)
-- Cache key: workspace `fsPath`
+- Cache key: workspace `fsPath`; `vscode-test-web://` workspaces with `.vscode/vscode-extension-test-disk-root.txt` (E2E headless): file body = disk path for `@salesforce/core` `SfProject` cache
+- `SfProject.resolve` fails (e.g. virtual mount): `isSalesforceProject` may still true via root `sfdx-project.json` `vscode.workspace.fs` stat; `getSfProject` no that fallback—can fail while flag true
+- `isSalesforceProject` cache `tapError` sets `sf:project_opened` false on resolve/cache errors; `FailedToResolveSfProjectError` then `catchTag` fallback may set context again from manifest stat
 - Requires `WorkspaceService`
 - Use `getSfProject()` for project methods (getPackageDirectories, etc.)

--- a/.claude/skills/services-extension-consumption/references/workspace-service.md
+++ b/.claude/skills/services-extension-consumption/references/workspace-service.md
@@ -34,7 +34,7 @@ const packageDirs = (yield* api.services.ProjectService.getSfProject()).getPacka
 
 ## Notes
 
-- `isEmpty` - workspace folders exist
+- `isEmpty` — no workspace folders
 - `isVirtualFs` - non-file scheme (e.g., memfs://)
 - `fsPath` normalized (backslashes → forward slashes for virtual FS)
-- Cached globally
+- Cached globally; web: memo on first `yield*` (not import), so folders exist before snapshot

--- a/.github/workflows/lwcPlaywrightE2E.yml
+++ b/.github/workflows/lwcPlaywrightE2E.yml
@@ -1,0 +1,291 @@
+name: LWC E2E (Playwright)
+
+on:
+  workflow_dispatch:
+  push:
+    branches-ignore: [main, develop]
+    paths-ignore:
+      - '.claude/**'
+      - '.cursor/**'
+      - 'contributing/**'
+      - 'CONTRIBUTING.md'
+      - 'docs/**'
+      - '**/README*'
+      - 'SECURITY*'
+      - 'CODE_OF_CONDUCT*'
+      - 'CHANGELOG*'
+      - '**/CHANGELOG*'
+
+concurrency:
+  group: ci-${{ github.ref }}-lwcPlaywrightE2E
+  cancel-in-progress: true
+
+jobs:
+  e2e-web:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      DREAMHOUSE_ORG_ALIAS: orgBrowserDreamhouseTestOrg
+      SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL_E2E }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - uses: google/wireit@setup-github-actions-caching/v2
+
+      - name: Install dependencies
+        uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
+
+      # Try E2E tests first. When wireit cache hits, it skips the command and exits 0—we never need CLI, orgs, or Playwright.
+      # When cache misses, tests fail on missing org/chromium. E2E_NO_RETRIES=1 disables Playwright retries in config
+      # so failures are fast (env var doesn't affect wireit cache key since it's not part of the npm command).
+      - name: Try E2E tests
+        id: try-run
+        continue-on-error: true
+        timeout-minutes: 5
+        env:
+          DREAMHOUSE_ORG_ALIAS: orgBrowserDreamhouseTestOrg
+          CI: 1
+          E2E_NO_RETRIES: 1
+        run: |
+          npm run test:web -w salesforcedx-vscode-lwc -- --reporter=html
+
+      # Restore cached @vscode/test-web (same pattern as org-browser / playwright-vscode-ext E2E). Sets
+      # PLAYWRIGHT_WEB_VSCODE_COMMIT when a stable folder exists so headlessServer skips redundant downloads.
+      - uses: ./.github/actions/cache-vscode-web
+        if: steps.try-run.outcome == 'failure'
+        with:
+          vscode-version: ${{ vars.PLAYWRIGHT_VSCODE_VERSION }}
+
+      # Only run expensive setup when try-run failed (cache miss). On cache hit we never reach these steps.
+      - name: Install Salesforce CLI
+        if: steps.try-run.outcome == 'failure'
+        uses: salesforcecli/github-workflows/.github/actions/retry@main
+        with:
+          max_attempts: 3
+          command: npm i -g @salesforce/cli
+          retry_wait_seconds: 30
+
+      - name: Clone dreamhouse
+        if: steps.try-run.outcome == 'failure'
+        uses: salesforcecli/github-workflows/.github/actions/retry@main
+        with:
+          max_attempts: 3
+          command: git clone --depth=1 https://github.com/trailheadapps/dreamhouse-lwc dreamhouse-lwc
+          retry_wait_seconds: 60
+
+      - name: Auth to dev hub (global)
+        if: steps.try-run.outcome == 'failure'
+        uses: salesforcecli/github-workflows/.github/actions/retry@main
+        with:
+          max_attempts: 3
+          command: bash -c 'echo "$SFDX_AUTH_URL" | sf org login sfdx-url --set-default-dev-hub --alias hub --sfdx-url-stdin'
+          retry_wait_seconds: 30
+
+      - name: create scratch org and set up dreamhouse
+        if: steps.try-run.outcome == 'failure'
+        shell: bash
+        run: |
+          sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$DREAMHOUSE_ORG_ALIAS" --json --wait 30
+          sf project deploy start
+          sf org assign permset -n dreamhouse
+        working-directory: dreamhouse-lwc
+
+      - name: Run LWC Playwright web tests (parallel)
+        if: steps.try-run.outcome == 'failure'
+        id: parallel-run
+        continue-on-error: true
+        env:
+          DREAMHOUSE_ORG_ALIAS: orgBrowserDreamhouseTestOrg
+          CI: 1
+        run: |
+          npm run test:web -w salesforcedx-vscode-lwc -- --reporter=html
+
+      - name: Retry failed tests (sequential)
+        if: steps.try-run.outcome == 'failure' && steps.parallel-run.outcome == 'failure'
+        env:
+          DREAMHOUSE_ORG_ALIAS: orgBrowserDreamhouseTestOrg
+          CI: 1
+          PLAYWRIGHT_WORKERS: 1
+        run: |
+          npm run test:web -w salesforcedx-vscode-lwc -- --last-failed --reporter=html
+
+      - name: Copy span files to test-results
+        if: always()
+        shell: bash
+        run: |
+          mkdir -p packages/salesforcedx-vscode-lwc/test-results/spans
+          cp -r ~/.sf/vscode-spans/. packages/salesforcedx-vscode-lwc/test-results/spans/ 2>/dev/null || true
+
+      - name: Upload Playwright HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-lwc-web
+          path: packages/salesforcedx-vscode-lwc/playwright-report
+          if-no-files-found: ignore
+
+      - name: Upload Playwright test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results-lwc-web
+          path: packages/salesforcedx-vscode-lwc/test-results
+          if-no-files-found: ignore
+
+      - name: Cleanup scratch org
+        if: always() && steps.try-run.outcome == 'failure'
+        continue-on-error: true
+        run: |
+          sf org delete scratch -o "$DREAMHOUSE_ORG_ALIAS" --no-prompt || true
+
+  e2e-desktop:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+      fail-fast: false
+
+    env:
+      DREAMHOUSE_ORG_ALIAS: orgBrowserDreamhouseTestOrg
+      SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL_E2E }}
+      PLAYWRIGHT_VSCODE_VERSION: ${{ vars.PLAYWRIGHT_VSCODE_VERSION }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - uses: google/wireit@setup-github-actions-caching/v2
+
+      - name: Install dependencies
+        uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
+
+      # Try E2E tests first. When wireit cache hits, it skips the command and exits 0—we never need CLI, orgs, or Playwright.
+      # When cache misses, tests fail on missing org. E2E_NO_RETRIES=1 disables Playwright retries in config
+      # so failures are fast (env var doesn't affect wireit cache key since it's not part of the npm command).
+      - name: Try E2E tests
+        id: try-run
+        continue-on-error: true
+        timeout-minutes: 5
+        env:
+          DREAMHOUSE_ORG_ALIAS: orgBrowserDreamhouseTestOrg
+          CI: 1
+          VSCODE_DESKTOP: 1
+          E2E_NO_RETRIES: 1
+        run: |
+          npm run test:desktop -w salesforcedx-vscode-lwc -- --reporter=html
+
+      # Restore cached @vscode/test-electron (same pattern as other desktop Playwright E2E workflows).
+      - uses: ./.github/actions/cache-vscode-desktop
+        if: steps.try-run.outcome == 'failure'
+        with:
+          vscode-version: ${{ vars.PLAYWRIGHT_VSCODE_VERSION }}
+
+      # Only run expensive setup when try-run failed (cache miss). On cache hit we never reach these steps.
+      - name: Install Salesforce CLI
+        if: steps.try-run.outcome == 'failure'
+        uses: salesforcecli/github-workflows/.github/actions/retry@main
+        with:
+          max_attempts: 3
+          command: npm i -g @salesforce/cli
+          retry_wait_seconds: 30
+
+      - name: Install Playwright browsers and OS deps
+        if: steps.try-run.outcome == 'failure'
+        uses: salesforcecli/github-workflows/.github/actions/retry@main
+        with:
+          max_attempts: 3
+          command: npx playwright install chromium --with-deps
+          retry_wait_seconds: 60
+
+      - name: Clone dreamhouse
+        if: steps.try-run.outcome == 'failure'
+        uses: salesforcecli/github-workflows/.github/actions/retry@main
+        with:
+          max_attempts: 3
+          command: git clone --depth=1 https://github.com/trailheadapps/dreamhouse-lwc dreamhouse-lwc
+          retry_wait_seconds: 60
+
+      - name: Auth to dev hub (global)
+        if: steps.try-run.outcome == 'failure'
+        uses: salesforcecli/github-workflows/.github/actions/retry@main
+        with:
+          max_attempts: 3
+          command: bash -c 'echo "$SFDX_AUTH_URL" | sf org login sfdx-url --set-default-dev-hub --alias hub --sfdx-url-stdin'
+          retry_wait_seconds: 30
+
+      - name: create scratch org and set up dreamhouse
+        if: steps.try-run.outcome == 'failure'
+        shell: bash
+        run: |
+          sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$DREAMHOUSE_ORG_ALIAS" --json --wait 30
+          sf project deploy start
+          sf org assign permset -n dreamhouse
+        working-directory: dreamhouse-lwc
+
+      - name: Run LWC Playwright desktop tests (parallel)
+        if: steps.try-run.outcome == 'failure'
+        id: parallel-run
+        continue-on-error: true
+        env:
+          DREAMHOUSE_ORG_ALIAS: orgBrowserDreamhouseTestOrg
+          CI: 1
+          VSCODE_DESKTOP: 1
+        run: |
+          npm run test:desktop -w salesforcedx-vscode-lwc -- --reporter=html
+
+      - name: Retry failed tests (sequential)
+        if: steps.try-run.outcome == 'failure' && steps.parallel-run.outcome == 'failure'
+        env:
+          DREAMHOUSE_ORG_ALIAS: orgBrowserDreamhouseTestOrg
+          CI: 1
+          VSCODE_DESKTOP: 1
+          PLAYWRIGHT_WORKERS: 1
+        run: |
+          npm run test:desktop -w salesforcedx-vscode-lwc -- --last-failed --reporter=html
+
+      - name: Copy span files to test-results
+        if: always()
+        shell: bash
+        run: |
+          mkdir -p packages/salesforcedx-vscode-lwc/test-results/spans
+          cp -r ~/.sf/vscode-spans/. packages/salesforcedx-vscode-lwc/test-results/spans/ 2>/dev/null || true
+
+      - name: Upload Playwright HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-lwc-desktop-${{ matrix.os }}
+          path: packages/salesforcedx-vscode-lwc/playwright-report
+          if-no-files-found: ignore
+
+      - name: Upload Playwright test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results-lwc-desktop-${{ matrix.os }}
+          path: packages/salesforcedx-vscode-lwc/test-results
+          if-no-files-found: ignore
+
+      - name: Cleanup scratch org
+        if: always() && steps.try-run.outcome == 'failure'
+        continue-on-error: true
+        shell: bash
+        run: |
+          sf org delete scratch -o "$DREAMHOUSE_ORG_ALIAS" --no-prompt || true

--- a/packages/playwright-vscode-ext/src/config/createWebConfig.ts
+++ b/packages/playwright-vscode-ext/src/config/createWebConfig.ts
@@ -62,8 +62,10 @@ export const createWebConfig = (options: WebConfigOptions) =>
       command: 'tsx web/headlessServer.ts',
       url: 'http://localhost:3001',
       timeout: 120 * 1000,
-      // Always start fresh. Reusing run:web (port 3001) causes EPIPE/premature close when test process
-      // expects to control the server lifecycle.
-      reuseExistingServer: false
+      // CI: always spawn headlessServer so runs are isolated. Local (`reuseExistingServer: !process.env.CI`): if 3001
+      // is already up (stale headlessServer), reuse it instead of failing with "already used". For a guaranteed fresh
+      // server locally, free the port or run with `CI=true`. Reusing a different app on 3001 (e.g. interactive run:web)
+      // may cause EPIPE or flakes.
+      reuseExistingServer: !process.env.CI
     }
   });

--- a/packages/playwright-vscode-ext/src/fixtures/createDesktopTest.ts
+++ b/packages/playwright-vscode-ext/src/fixtures/createDesktopTest.ts
@@ -131,15 +131,18 @@ export const createDesktopTest = (options: CreateDesktopTestOptions) => {
           .map(dir => path.resolve(packageRoot, '..', dir))
       ].map(p => `--extensionDevelopmentPath=${p}`);
 
-      // Explicitly disable built-in GitHub/Copilot/Chat extensions that can trigger
-      // the GitHub OAuth browser tab on startup. `--disable-extensions` only disables
-      // user-installed extensions; built-ins must be disabled individually.
+      // Explicitly disable built-in GitHub/Microsoft/Copilot/Chat extensions that can trigger
+      // sign-in modals or the GitHub OAuth browser tab on startup. `--disable-extensions` only
+      // disables user-installed extensions; built-ins must be disabled individually.
       const disabledBuiltins = [
         'vscode.github',
         'vscode.github-authentication',
+        'vscode.microsoft-authentication',
         'GitHub.vscode-pull-request-github',
         'GitHub.copilot',
-        'GitHub.copilot-chat'
+        'GitHub.copilot-chat',
+        // Azure MS sign-in prompts during local desktop E2E (not needed for Salesforce extension tests).
+        'ms-vscode.azure-account'
       ].map(id => `--disable-extension=${id}`);
 
       const launchArgs = [
@@ -148,6 +151,12 @@ export const createDesktopTest = (options: CreateDesktopTestOptions) => {
         ...extensionArgs,
         ...(disableOtherExtensions ? ['--disable-extensions'] : []),
         ...disabledBuiltins,
+        // Align with `vscode-test`/runTest.ts: suppress welcome/release-notes churn and updates.
+        // `--skip-welcome` is critical to avoid first-run sign-in modals blocking desktop Playwright runs.
+        '--disable-updates',
+        '--skip-welcome',
+        '--skip-release-notes',
+        '--disable-gpu-sandbox',
         '--disable-workspace-trust',
         '--no-sandbox',
         workspaceDir

--- a/packages/playwright-vscode-ext/src/index.ts
+++ b/packages/playwright-vscode-ext/src/index.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 export {
+  assertWelcomeTabExists,
   setupConsoleMonitoring,
   setupNetworkMonitoring,
   filterErrors,

--- a/packages/playwright-vscode-ext/src/pages/settings.ts
+++ b/packages/playwright-vscode-ext/src/pages/settings.ts
@@ -20,6 +20,28 @@ import { WORKBENCH, SETTINGS_SEARCH_INPUT } from '../utils/locators';
 
 const settingsLocator = (page: Page): Locator => page.locator(SETTINGS_SEARCH_INPUT.join(','));
 
+/** User tab can become selected after search/navigation; workspace values require Workspace tab. */
+const ensureWorkspaceSettingsTab = async (page: Page): Promise<void> => {
+  const workspaceTab = page.getByRole('tab', { name: 'Workspace' });
+  await workspaceTab.click();
+  await expect(workspaceTab).toHaveAttribute('aria-selected', 'true', { timeout: 5000 });
+  await settingsLocator(page).first().waitFor({ state: 'visible', timeout: 15_000 });
+};
+
+/** VS Code settings text inputs use Monaco; fill() is sometimes ignored in web/headless — fall back to sequential keys. */
+const setSettingsTextboxValue = async (page: Page, inputElement: Locator, value: string): Promise<void> => {
+  const selectAllShortcut = isMacDesktop() ? 'Meta+A' : 'Control+A';
+  await inputElement.click({ timeout: 5000, force: true });
+  await inputElement.fill(value);
+  if ((await inputElement.inputValue().catch(() => '')) === value) {
+    return;
+  }
+  await inputElement.click({ force: true });
+  await page.keyboard.press(selectAllShortcut);
+  await page.keyboard.press('Backspace');
+  await inputElement.pressSequentially(value);
+};
+
 export const openSettingsUI = async (page: Page): Promise<void> => {
   await closeWelcomeTabs(page);
   await page.locator(WORKBENCH).click({ timeout: 60_000 });
@@ -32,6 +54,9 @@ export const openSettingsUI = async (page: Page): Promise<void> => {
   const workspaceTab = page.getByRole('tab', { name: 'Workspace' });
   await workspaceTab.click();
   await expect(workspaceTab).toHaveAttribute('aria-selected', 'true', { timeout: 3000 });
+  // Workspace tab can trigger navigation / DOM replace; wait for search input to exist again before callers interact
+  await page.waitForLoadState('domcontentloaded');
+  await settingsLocator(page).first().waitFor({ state: 'visible', timeout: 15_000 });
 };
 
 /** used for web, where auth fields need to be set to simulate what we'll receive from Core iframe.
@@ -66,24 +91,27 @@ export const upsertScratchOrgAuthFieldsToSettings = async (
 const performSearch =
   (page: Page) =>
   async (query: string): Promise<void> => {
-    // Reset search by selecting all and clearing
     const searchMonaco = settingsLocator(page).first();
-    await searchMonaco.waitFor({ timeout: 3000 });
-    await searchMonaco.click();
-    // seems to be necessary to avoid clearing the setting instead of the search box.
-    // TODO: figure out what to actually wait for (ex: can I tell if it's focused?)
-    await page.waitForTimeout(200);
-    // Triple-click on Monaco editor to select all text (more reliable than Control+A)
-    await searchMonaco.click({ clickCount: 3 });
-    await page.waitForTimeout(100);
-    // Clear using Backspace after selecting all
+    await searchMonaco.waitFor({ state: 'visible', timeout: 15_000 });
+    await page.waitForLoadState('domcontentloaded');
+
+    // Focus search; tab switches or reloads can detach the node — retry after navigation settles
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        await settingsLocator(page).first().click({ timeout: 5000 });
+        break;
+      } catch {
+        await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => undefined);
+        await page.waitForTimeout(300);
+      }
+    }
+
+    await page.waitForTimeout(150);
+    // Monaco settings search may not expose textarea in the light DOM; use keyboard clear instead of textarea assertion
+    const selectAllShortcut = process.platform === 'darwin' ? 'Meta+A' : 'Control+A';
+    await page.keyboard.press(selectAllShortcut);
     await page.keyboard.press('Backspace');
-    // Wait to ensure the backspace completes and search box is cleared
-    await page.waitForTimeout(200);
-    // Verify the search box is empty by checking the textarea value
-    const textarea = searchMonaco.locator('textarea').first();
-    await expect(textarea).toHaveValue('', { timeout: 2000 });
-    // Type the new query
+    await page.waitForTimeout(100);
     await page.keyboard.type(query);
   };
 
@@ -95,6 +123,8 @@ export const upsertSettings = async (page: Page, settings: Record<string, string
   const debugAria = process.env.E2E_ARIA_DEBUG === '1';
 
   for (const [id, value] of Object.entries(settings)) {
+    await ensureWorkspaceSettingsTab(page);
+
     // Debug visibility: take screenshot and aria snapshot before each search
     if (debugAria) {
       try {
@@ -112,6 +142,7 @@ export const upsertSettings = async (page: Page, settings: Record<string, string
 
     // First try an exact search by full id (section.key)
     await performSearch(page)(id);
+    await page.waitForLoadState('domcontentloaded');
 
     // Screenshot search box state after clear+type (debug: did clear work, is query correct?)
     if (Object.keys(settings).length > 1) {
@@ -126,13 +157,21 @@ export const upsertSettings = async (page: Page, settings: Record<string, string
     //          e.g. "a.b.c" → "searchResultModel_a_b.c"
     // ≥ 1.113: replace(/[\.\/]/g, '_') — ALL dots replaced
     //          e.g. "a.b.c" → "searchResultModel_a_b_c"
-    // Use an OR selector so this works across VS Code versions.
-    // Use .last() when duplicates exist (User + Workspace): we're on Workspace tab, so Workspace row is last
+    // Keys with hyphens (e.g. salesforce-web-console.apiVersion) also map '-' → '_' in current Settings UI:
+    //          → "searchResultModel_salesforce_web_console_apiVersion" (not ...salesforce-web-console_apiVersion)
+    // Use OR selectors across versions; .last() when User + Workspace duplicate rows exist (Workspace tab).
     const allDotsId = `searchResultModel_${id.replaceAll('.', '_')}`;
     const firstDotId = `searchResultModel_${id.replace('.', '_')}`;
-    const dataIdSelector =
-      allDotsId === firstDotId ? `[data-id="${allDotsId}"]` : `[data-id="${allDotsId}"], [data-id="${firstDotId}"]`;
-    const row = page.locator(dataIdSelector).last();
+    const dotsHyphensSlashesId = `searchResultModel_${id.replaceAll(new RegExp('[-./]', 'g'), '_')}`;
+    const dataIdSelector = [...new Set([allDotsId, firstDotId, dotsHyphensSlashesId])]
+      .map(s => `[data-id="${s}"]`)
+      .join(', ');
+    // Suffix match is robust when VS Code's sanitizeId differs (still ends with _<keyLastSegment>, e.g. _apiVersion)
+    const lastSegment = id.includes('.') ? id.slice(id.lastIndexOf('.') + 1) : id;
+    const rowByKeySuffix = page
+      .locator(`${WORKBENCH} [data-id^="searchResultModel_"][data-id$="_${lastSegment}"]`)
+      .last();
+    const row = page.locator(dataIdSelector).last().or(rowByKeySuffix);
 
     if (debugAria) {
       console.log(`[upsertSettings] using deterministic locator for ${id}: selector="${dataIdSelector}"`);
@@ -148,7 +187,15 @@ export const upsertSettings = async (page: Page, settings: Record<string, string
       } catch {}
     }
 
-    await row.waitFor({ state: 'attached', timeout: 15_000 });
+    try {
+      await row.waitFor({ state: 'attached', timeout: 15_000 });
+    } catch {
+      // Full setting id sometimes yields no Settings hits; shorter query (key segment) surfaces the row
+      await ensureWorkspaceSettingsTab(page);
+      await performSearch(page)(lastSegment);
+      await page.locator('[data-id^="searchResultModel_"]').first().waitFor({ state: 'attached', timeout: 15_000 });
+      await row.waitFor({ state: 'attached', timeout: 15_000 });
+    }
 
     await row.waitFor({ state: 'visible', timeout: 30_000 });
     if (debugAria) {
@@ -210,9 +257,7 @@ export const upsertSettings = async (page: Page, settings: Record<string, string
 
         const inputElement = textboxCount > 0 ? roleTextbox : roleSpinbutton;
         await inputElement.waitFor({ timeout: 30_000 });
-        await inputElement.click({ timeout: 5000 });
-        // fill() clears and types (reliable for both textbox and spinbutton; select-all + type can miss on desktop)
-        await inputElement.fill(value);
+        await setSettingsTextboxValue(page, inputElement, value);
         await inputElement.blur();
         await expect(inputElement).toHaveValue(value, { timeout: 10_000 });
       }

--- a/packages/playwright-vscode-ext/src/utils/dreamhouseScratchOrgSetup.ts
+++ b/packages/playwright-vscode-ext/src/utils/dreamhouseScratchOrgSetup.ts
@@ -17,6 +17,34 @@ export const DREAMHOUSE_ORG_ALIAS = 'orgBrowserDreamhouseTestOrg';
 
 const execAsync = promisify(exec);
 
+type SfOrgDisplayResultBody = {
+  accessToken: string;
+  instanceUrl: string;
+  apiVersion: string;
+};
+
+const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === 'object' && v !== null;
+
+const isSfOrgDisplayJson = (v: unknown): v is { result: SfOrgDisplayResultBody } => {
+  if (!isRecord(v) || !('result' in v)) return false;
+  const r = v.result;
+  if (!isRecord(r)) return false;
+  return (
+    typeof r.accessToken === 'string' &&
+    typeof r.instanceUrl === 'string' &&
+    typeof r.apiVersion === 'string'
+  );
+};
+
+type SfScratchCreateAuthFields = {
+  instanceUrl?: string;
+  accessToken?: string;
+  instanceApiVersion?: string;
+};
+
+const isSfScratchCreateJson = (v: unknown): v is { result?: { authFields?: SfScratchCreateAuthFields } } =>
+  isRecord(v) && (!('result' in v) || v.result === undefined || isRecord(v.result));
+
 const env = { ...process.env, NO_COLOR: '1' };
 /** this, if running all your tests locally, could create a lot of scratch orgs in parallel.  It's definitely better to run the steps once, or run just one test to get things going */
 export const create = async (): Promise<
@@ -25,10 +53,12 @@ export const create = async (): Promise<
   // Fast path for local iteration: use provided org and skip org creation/deploy
   // requires that you already did the deploy, permset, etc on the org.
   try {
-    const displayResponse = JSON.parse(
-      (await execAsync(`sf org display -o ${DREAMHOUSE_ORG_ALIAS} --json`, { env })).stdout
-    );
-    const result = displayResponse.result;
+    const stdout = (await execAsync(`sf org display -o ${DREAMHOUSE_ORG_ALIAS} --json`, { env })).stdout;
+    const displayResponse: unknown = JSON.parse(stdout);
+    if (!isSfOrgDisplayJson(displayResponse)) {
+      throw new Error('sf org display returned unexpected JSON shape');
+    }
+    const { result } = displayResponse;
 
     return {
       accessToken: result.accessToken,
@@ -53,8 +83,11 @@ export const create = async (): Promise<
     { cwd: repoDir, env }
   );
 
-  const createResponse = JSON.parse(createStdout);
-  const authFields = createResponse?.result?.authFields ?? {};
+  const createResponse: unknown = JSON.parse(createStdout);
+  if (!isSfScratchCreateJson(createResponse)) {
+    throw new Error('sf org create scratch returned unexpected JSON shape');
+  }
+  const authFields = createResponse.result?.authFields ?? {};
 
   if (!authFields.instanceUrl || !authFields.accessToken || !authFields.instanceApiVersion) {
     throw new Error(

--- a/packages/playwright-vscode-ext/src/utils/helpers.ts
+++ b/packages/playwright-vscode-ext/src/utils/helpers.ts
@@ -158,6 +158,7 @@ export const waitForVSCodeWorkbench = async (page: Page, navigate = true): Promi
     return;
   }
 
+  // Web: navigate if requested, then wait
   if (navigate) {
     await page.goto('/', { waitUntil: 'domcontentloaded' });
   }
@@ -340,6 +341,20 @@ export const dismissSignInWalkthroughDialog = async (page: Page): Promise<void> 
       : page.keyboard.press('Escape'));
   }
   await dialog.waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
+};
+
+/**
+ * Assert a Welcome or Walkthrough editor tab is visible (typical fresh **web** window with no folder).
+ * Call before {@link closeWelcomeTabs} so specs do not race an empty tab strip.
+ * No-op on desktop: an opened-folder workspace often has no Welcome tab.
+ */
+export const assertWelcomeTabExists = async (page: Page): Promise<void> => {
+  if (isDesktop()) {
+    return;
+  }
+  await dismissSignInWalkthroughDialog(page);
+  const welcomeTab = page.getByRole('tab', { name: /Welcome|Walkthrough/i }).first();
+  await expect(welcomeTab, 'Welcome or Walkthrough tab should be visible').toBeVisible({ timeout: 60_000 });
 };
 
 /** Close VS Code Welcome/Walkthrough tabs if they're open */

--- a/packages/playwright-vscode-ext/src/utils/locators.ts
+++ b/packages/playwright-vscode-ext/src/utils/locators.ts
@@ -38,8 +38,9 @@ export const APEX_TRACE_FLAG_STATUS_BAR = '#salesforce\\.salesforcedx-vscode-ape
 /** Notification list items in the notification center */
 export const NOTIFICATION_LIST_ITEM = `${WORKBENCH} .notification-list-item`;
 
-/** Settings editor search input */
+/** Settings editor search input (data-uri is stable across VS Code versions; Monaco may not expose a light-DOM textarea) */
 export const SETTINGS_SEARCH_INPUT = [
+  `${WORKBENCH} [data-uri^="settingseditor:searchinput"]`,
   `${WORKBENCH} .settings-header .search-container ${EDITOR}`,
   `${WORKBENCH} [aria-label="Settings"] .settings-header .search-container ${EDITOR}`
 ] as const;

--- a/packages/playwright-vscode-ext/src/web/createHeadlessServer.ts
+++ b/packages/playwright-vscode-ext/src/web/createHeadlessServer.ts
@@ -19,8 +19,18 @@ type HeadlessServerOptions = {
   /**
    * Local folder to mount as the VS Code Web workspace (`vscode-test-web://mount`).
    * Use with {@link createTestWorkspace} so tests see `sfdx-project.json` and project files.
+   *
+   * Prefer {@link folderUri} when extensions must resolve the project with Node `fs`
+   * (e.g. `@salesforce/core` `SfProject`): `folderPath` is always a virtual FS, so CLI-style
+   * resolution does not see real disk files.
    */
   folderPath?: string;
+  /**
+   * Workspace folder URI (e.g. `file:///var/.../project`). Use for E2E that need a **file** workspace
+   * so `SfProject` / `sf:project_opened` work; omit both this and `folderPath` for the default test
+   * workspace.
+   */
+  folderUri?: string;
 };
 
 /** Creates and starts a headless VS Code web server for testing an extension with services */
@@ -37,15 +47,20 @@ export const createHeadlessServer = async (options: HeadlessServerOptions): Prom
     console.log(`📁 Extension path: ${extensionDevelopmentPath}`);
     console.log(`📦 Extension paths: ${extensionPaths.join(', ')}`);
     if (options.folderPath !== undefined) {
-      console.log(`📂 Workspace folderPath: ${options.folderPath}`);
+      console.log(`📂 Workspace folderPath (virtual mount): ${options.folderPath}`);
+    }
+    if (options.folderUri !== undefined) {
+      console.log(`📂 Workspace folderUri: ${options.folderUri}`);
     }
 
     const repoRoot = resolveRepoRoot(options.callerDirname);
     const testRunnerDataDir = path.join(repoRoot, '.vscode-test-web');
 
+    // Do not launch Chromium via @vscode/test-web — Playwright's test runner is the only browser client.
+    // If browserType is chromium, test-web opens its own browser; when that browser's last page closes, it calls
+    // server.close() (see @vscode/test-web open() → context.once('close', …)), killing port 3001 mid-run.
     await open({
-      browserType: 'chromium',
-      headless: true,
+      browserType: 'none',
       quality: 'stable',
       commit: process.env.PLAYWRIGHT_WEB_VSCODE_COMMIT,
       port: Number(process.env.PORT) || 3001,
@@ -54,6 +69,7 @@ export const createHeadlessServer = async (options: HeadlessServerOptions): Prom
       extensionDevelopmentPath,
       extensionPaths,
       testRunnerDataDir,
+      ...(options.folderUri !== undefined ? { folderUri: options.folderUri } : {}),
       ...(options.folderPath !== undefined ? { folderPath: options.folderPath } : {}),
       browserOptions: [
         '--disable-web-security',

--- a/packages/salesforcedx-lightning-lsp-common/src/providers/lspFileSystemAccessor.ts
+++ b/packages/salesforcedx-lightning-lsp-common/src/providers/lspFileSystemAccessor.ts
@@ -44,6 +44,13 @@ import { NormalizedPath, normalizePath } from '../utils';
 const getEmptyDirectoryListing = (_uri: NormalizedPath): DirectoryEntry[] => [];
 
 /**
+ * True when `s` is already a document URI (`scheme:…`), including `memfs:/MyProject/…` (no `//` authority).
+ * Excludes Windows paths (`C:/…`) so they still go through path → URI conversion.
+ */
+const isDocumentUriString = (s: string): boolean =>
+  /^[a-z][\w+.-]*:/i.test(s) && !/^[A-Za-z]:[/\\]/i.test(s);
+
+/**
  * Convert a URI to a normalized file path.
  * Web uses memfs (single scheme); desktop uses file://. Pass the workspace folder URI when in web to align path extraction.
  */
@@ -198,10 +205,10 @@ export class LspFileSystemAccessor {
 
   public async getFileContent(uri: string): Promise<string | undefined> {
     if (this.connection) {
-      // If the caller already provides a full URI (e.g. an extension resource URI), use it as-is.
+      // If the caller already provides a full URI (e.g. file:///…, memfs:/MyProject/…), use it as-is.
       // Otherwise convert the filesystem path to the correct URI for the current workspace scheme.
-      const fileUri = uri.includes('://') ? uri : getFileUriForPath(normalizePath(uri), this.workspaceFolderUri);
-      const key = uri.includes('://') ? uri : normalizePath(uri);
+      const fileUri = isDocumentUriString(uri) ? uri : getFileUriForPath(normalizePath(uri), this.workspaceFolderUri);
+      const key = isDocumentUriString(uri) ? uri : normalizePath(uri);
       const params: WorkspaceReadFileParams = { uri: URI.parse(fileUri) };
       const result = await this.connection.sendRequest<WorkspaceReadFileResult>(WORKSPACE_READ_FILE_REQUEST, params);
       if (result.error) {
@@ -214,15 +221,18 @@ export class LspFileSystemAccessor {
   }
 
   public async getFileStat(uri: string): Promise<FileStat | undefined> {
-    const key = normalizePath(uri);
-    if (this.connection) {
-      const fileUri = getFileUriForPath(key, this.workspaceFolderUri);
-      const params: WorkspaceStatParams = { uri: URI.parse(fileUri) };
-      const result = await this.connection.sendRequest<WorkspaceStatResult>(WORKSPACE_STAT_REQUEST, params);
-      if (result.error) return undefined;
-      return result.stat;
+    if (!this.connection) {
+      return undefined;
     }
-    return undefined;
+    // Match getFileContent: callers pass full DocumentUris (file:///…, memfs:/MyProject/…). Do not run
+    // getFileUriForPath + URI.file() on those — especially memfs, which uses a single slash after the scheme.
+    const fileUri = isDocumentUriString(uri) ? uri : getFileUriForPath(normalizePath(uri), this.workspaceFolderUri);
+    const params: WorkspaceStatParams = { uri: URI.parse(fileUri) };
+    const result = await this.connection.sendRequest<WorkspaceStatResult>(WORKSPACE_STAT_REQUEST, params);
+    if (result.error) {
+      return undefined;
+    }
+    return result.stat;
   }
 
   public async fileExists(uri: string): Promise<boolean> {

--- a/packages/salesforcedx-lwc-language-server/src/baseServer.ts
+++ b/packages/salesforcedx-lwc-language-server/src/baseServer.ts
@@ -14,10 +14,8 @@ import {
   BaseWorkspaceContext,
   NormalizedPath,
   WorkspaceType,
-  normalizePath,
   LWC_SERVER_READY_NOTIFICATION
 } from '@salesforce/salesforcedx-lightning-lsp-common';
-import * as path from 'node:path';
 import { basename, dirname, parse } from 'node:path';
 import {
   getLanguageService,
@@ -49,6 +47,7 @@ import {
   FileEvent
 } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
+import { URI, Utils } from 'vscode-uri';
 import { AuraDataProvider } from './auraDataProvider';
 import ComponentIndexer from './componentIndexer';
 import { TYPESCRIPT_SUPPORT_SETTING } from './constants';
@@ -438,44 +437,43 @@ export abstract class BaseServer {
   // this can be removed.
   public async onDidChangeWatchedFiles(changeEvent: DidChangeWatchedFilesParams): Promise<void> {
     if (this.context.type === 'SFDX') {
+      const { changes } = changeEvent;
+
+      const lwcRootCreated = isLWCRootDirectoryCreated(this.context, changes);
+      const lwcDeleted = await containsDeletedLwcWatchedDirectory(this.context, changes);
+
+      const newBundleJsPaths: string[] = [];
+      if (!lwcRootCreated && !lwcDeleted) {
+        for (const event of changes) {
+          const insideLwcWatchedDirectory = await isLWCWatchedDirectory(this.context, event.uri);
+          if (event.type === FileChangeType.Created && insideLwcWatchedDirectory) {
+            const filePath = toResolvedPath(event.uri);
+            const { dir, name: fileName, ext } = parse(filePath);
+            const folderName = basename(dir);
+            const parentFolder = basename(dirname(dir));
+            if (/.*(.ts|.js)$/.test(ext) && folderName === fileName && parentFolder === 'lwc') {
+              newBundleJsPaths.push(filePath);
+            }
+          }
+        }
+      }
+
+      const shouldRefreshComponentIndex = lwcRootCreated || lwcDeleted || newBundleJsPaths.length > 0;
+
       try {
         const hasTsEnabled = await this.isTsSupportEnabled();
         if (hasTsEnabled) {
-          const { changes } = changeEvent;
-          if (isLWCRootDirectoryCreated(this.context, changes)) {
-            // LWC directory created
+          if (lwcRootCreated) {
             this.context.updateNamespaceRootTypeCache();
             if (this.componentIndexer) {
               await this.componentIndexer.updateSfdxTsConfigPath(this.connection);
             }
-          } else {
-            const hasDeleteEvent = await containsDeletedLwcWatchedDirectory(this.context, changes);
-            if (hasDeleteEvent) {
-              // We need to scan the file system for deletion events as the change event does not include
-              // information about the files that were deleted.
-              if (this.componentIndexer) {
-                await this.componentIndexer.updateSfdxTsConfigPath(this.connection);
-              }
-            } else {
-              const filePaths = [];
-              for (const event of changes) {
-                const insideLwcWatchedDirectory = await isLWCWatchedDirectory(this.context, event.uri);
-                if (event.type === FileChangeType.Created && insideLwcWatchedDirectory) {
-                  // File creation
-                  const filePath = toResolvedPath(event.uri);
-                  const { dir, name: fileName, ext } = parse(filePath);
-                  const folderName = basename(dir);
-                  const parentFolder = basename(dirname(dir));
-                  // Only update path mapping for newly created lwc modules
-                  if (/.*(.ts|.js)$/.test(ext) && folderName === fileName && parentFolder === 'lwc') {
-                    filePaths.push(filePath);
-                  }
-                }
-              }
-              if (filePaths.length > 0 && this.componentIndexer) {
-                await this.componentIndexer.insertSfdxTsConfigPath(filePaths);
-              }
+          } else if (lwcDeleted) {
+            if (this.componentIndexer) {
+              await this.componentIndexer.updateSfdxTsConfigPath(this.connection);
             }
+          } else if (newBundleJsPaths.length > 0 && this.componentIndexer) {
+            await this.componentIndexer.insertSfdxTsConfigPath(newBundleJsPaths);
           }
         }
       } catch (e) {
@@ -485,21 +483,33 @@ export abstract class BaseServer {
         });
       }
 
+      if (shouldRefreshComponentIndex && this.componentIndexer) {
+        await this.componentIndexer.init();
+      }
+
       if (this.typingIndexerData) {
-        const { changes } = changeEvent;
         const hasMetaChange = changes.some(
           e =>
             e.uri.endsWith('.resource-meta.xml') ||
             e.uri.endsWith('.asset-meta.xml') ||
             e.uri.endsWith('.messageChannel-meta.xml')
         );
-        const hasLabelChange = changes.some(e => e.uri.endsWith('CustomLabels.labels-meta.xml'));
+        const hasLabelChange = changes.some(e => e.uri.toLowerCase().endsWith('customlabels.labels-meta.xml'));
+        // Internal / tooling flows may update CustomLabels in the same batch as a new bundle without a separate
+        // watched-file event ordering guarantee; refreshing typings when a new LWC bundle meta is created keeps
+        // `.sfdx/typings/lwc/customlabels.d.ts` aligned without requiring a VS Code reload.
+        const hasNewLwcBundleMetaCreated = changes.some(
+          e =>
+            e.type === FileChangeType.Created &&
+            e.uri.includes('/lwc/') &&
+            e.uri.endsWith('.js-meta.xml')
+        );
         try {
           if (hasMetaChange) {
             await createNewMetaTypings(this.typingIndexerData);
             await deleteStaleMetaTypings(this.typingIndexerData);
           }
-          if (hasLabelChange) {
+          if (hasLabelChange || hasNewLwcBundleMetaCreated) {
             await saveCustomLabelTypings(this.typingIndexerData);
           }
         } catch (e) {
@@ -754,11 +764,12 @@ export abstract class BaseServer {
 
       // For SFDX workspaces, wait for sfdx-project.json to be loaded before initializing component indexer
       if (this.workspaceType === 'SFDX') {
-        const sfdxProjectPath = normalizePath(path.join(this.workspaceRoots[0], 'sfdx-project.json'));
-        const sfdxExists = await this.fileSystemAccessor.fileExists(sfdxProjectPath);
+        const folder0 = this.workspaceFolders[0];
+        const sfdxProjectUri = folder0 ? Utils.joinPath(URI.parse(folder0.uri), 'sfdx-project.json').toString() : '';
+        const sfdxExists = sfdxProjectUri ? await this.fileSystemAccessor.fileExists(sfdxProjectUri) : false;
         if (!sfdxExists) {
           Logger.info(
-            `[LWC] performDelayedInitialization: SFDX workspace but sfdx-project.json not found at ${sfdxProjectPath}, exiting early`
+            `[LWC] performDelayedInitialization: SFDX workspace but sfdx-project.json not found at ${sfdxProjectUri}, exiting early`
           );
           return;
         }
@@ -767,7 +778,8 @@ export abstract class BaseServer {
       this.componentIndexer = new ComponentIndexer({
         workspaceRoot: this.workspaceRoots[0],
         fileSystemAccessor: this.fileSystemAccessor,
-        workspaceType: this.workspaceType
+        workspaceType: this.workspaceType,
+        workspaceFolderUri: this.workspaceFolders[0]?.uri
       });
 
       await this.componentIndexer.init();

--- a/packages/salesforcedx-lwc-language-server/src/componentIndexer.ts
+++ b/packages/salesforcedx-lwc-language-server/src/componentIndexer.ts
@@ -19,6 +19,7 @@ import {
 import { snakeCase, camelCase } from 'change-case';
 import * as path from 'node:path';
 import { Connection, DocumentUri } from 'vscode-languageserver';
+import { URI, Utils } from 'vscode-uri';
 
 import { getWorkspaceRoot, getSfdxPackageDirsPattern } from './baseIndexer';
 
@@ -32,6 +33,8 @@ type ComponentIndexerAttributes = {
   workspaceRoot: NormalizedPath;
   fileSystemAccessor: LspFileSystemAccessor;
   workspaceType?: WorkspaceType;
+  /** First workspace folder URI (web virtual roots); used to stat `sfdx-project.json` when path strings are not real disk paths. */
+  workspaceFolderUri?: DocumentUri;
 };
 
 const AURA_DELIMITER = ':';
@@ -383,8 +386,10 @@ export default class ComponentIndexer {
 
     // For SFDX workspaces, ensure sfdx-project.json is loaded before initializing
     if (this.workspaceType === 'SFDX') {
-      const sfdxProjectPath = normalizePath(path.join(this.attributes.workspaceRoot, 'sfdx-project.json'));
-      if (!(await this.fileSystemAccessor.fileExists(sfdxProjectPath))) {
+      const sfdxProjectRef = this.attributes.workspaceFolderUri
+        ? Utils.joinPath(URI.parse(this.attributes.workspaceFolderUri), 'sfdx-project.json').toString()
+        : normalizePath(path.join(this.attributes.workspaceRoot, 'sfdx-project.json'));
+      if (!(await this.fileSystemAccessor.fileExists(sfdxProjectRef))) {
         return;
       }
     }

--- a/packages/salesforcedx-lwc-language-server/src/lwcServerBrowser.ts
+++ b/packages/salesforcedx-lwc-language-server/src/lwcServerBrowser.ts
@@ -36,7 +36,8 @@ export default class Server extends BaseServer {
     this.componentIndexer = new ComponentIndexer({
       workspaceRoot: this.workspaceRoots[0],
       fileSystemAccessor: this.fileSystemAccessor,
-      workspaceType: this.workspaceType
+      workspaceType: this.workspaceType,
+      workspaceFolderUri: this.workspaceFolders[0]?.uri
     });
     await this.componentIndexer.init();
     this.lwcDataProvider = new LWCDataProvider({ indexer: this.componentIndexer });

--- a/packages/salesforcedx-lwc-language-server/src/typing.ts
+++ b/packages/salesforcedx-lwc-language-server/src/typing.ts
@@ -7,9 +7,15 @@
 import * as path from 'node:path';
 import * as xml2js from 'xml2js';
 
+/** One `<labels>` block from CustomLabels.labels-meta.xml (xml2js shape). */
+interface CustomLabelBlock {
+  fullName: string | string[];
+}
+
 interface CustomLabelsXml {
   CustomLabels?: {
-    labels?: { fullName: string[] }[];
+    /** xml2js: one `<labels>` → object; multiple → array of objects */
+    labels?: CustomLabelBlock | CustomLabelBlock[];
   };
 }
 
@@ -24,7 +30,11 @@ const isCustomLabelsXml = (value: unknown): value is CustomLabelsXml => {
   if (typeof cl !== 'object' || cl === null) {
     return false;
   }
-  return !('labels' in cl) || Array.isArray(cl.labels);
+  if (!('labels' in cl)) {
+    return true;
+  }
+  const labels = cl.labels;
+  return typeof labels === 'object' && labels !== null;
 };
 
 const metaRegex = new RegExp(/(?<name>[\w.-]+)\.(?<type>\w.+)-meta$/);
@@ -91,9 +101,13 @@ export const declarationsFromCustomLabels = async (xmlDocument: string | Buffer)
   if (!isCustomLabelsXml(parsed) || !parsed.CustomLabels?.labels) {
     return '';
   }
-  const declarations: string[] = parsed.CustomLabels.labels.map(label =>
-    declaration('customLabel', label.fullName[0])
-  );
+  const labelsNode = parsed.CustomLabels.labels;
+  const labelBlocks: CustomLabelBlock[] = Array.isArray(labelsNode) ? labelsNode : [labelsNode];
+  const declarations: string[] = labelBlocks.map((label) => {
+    const raw = label.fullName;
+    const name = Array.isArray(raw) ? raw[0] : raw;
+    return declaration('customLabel', name);
+  });
   return declarations.join('\n');
 };
 

--- a/packages/salesforcedx-lwc-language-server/test/lwcServerNode.test.ts
+++ b/packages/salesforcedx-lwc-language-server/test/lwcServerNode.test.ts
@@ -211,10 +211,14 @@ const setupServerForTest = async (
 ): Promise<void> => {
   // `onInitialize` schedules a delayed init via setTimeout(0). Tests drive delayed init
   // explicitly, so drain that scheduled callback with a temporary no-op to avoid races.
-  const originalPerformDelayedInitialization = (testServer as any).performDelayedInitialization.bind(testServer);
-  (testServer as any).performDelayedInitialization = async () => {};
+  type PerformDelayedInit = () => Promise<void>;
+  const delayedInitMutable = testServer as unknown as { performDelayedInitialization: PerformDelayedInit };
+  const originalPerformDelayedInitialization: PerformDelayedInit = delayedInitMutable.performDelayedInitialization.bind(
+    testServer
+  ) as PerformDelayedInit;
+  delayedInitMutable.performDelayedInitialization = async (): Promise<void> => {};
   await new Promise(resolve => setTimeout(resolve, 0));
-  (testServer as any).performDelayedInitialization = originalPerformDelayedInitialization;
+  delayedInitMutable.performDelayedInitialization = originalPerformDelayedInitialization;
 
   // Reset delayed initialization flag to ensure fresh initialization
   testServer.isDelayedInitializationComplete = false;
@@ -877,7 +881,9 @@ describe('lwcServerNode', () => {
             (await provider.getFileContent(baseTsconfigPath)) ??
             (await server.fileSystemAccessor.getFileContent(baseTsconfigPath));
           if (tsConfigContent) {
-            const tsConfig = JSON.parse(tsConfigContent);
+            const tsConfig = JSON.parse(tsConfigContent) as {
+              compilerOptions?: { paths?: Record<string, unknown> };
+            };
             const pathMappingLength = Object.keys(tsConfig.compilerOptions?.paths ?? {}).length;
             // Discovery via findFiles: 11 components on disk (no test_component)
             if (pathMappingLength >= 11) {

--- a/packages/salesforcedx-lwc-language-server/test/typing.test.ts
+++ b/packages/salesforcedx-lwc-language-server/test/typing.test.ts
@@ -104,6 +104,29 @@ describe('declarationsFromCustomLabels', () => {
     expect(typings).toEqual(expectedDeclarations);
   });
 
+  it('Generates declarations when the xml has a single labels element (xml2js object, not array)', async () => {
+    const xmlDocument = `
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata">
+    <labels>
+        <fullName>only_one</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>only</shortDescription>
+        <value>Hi</value>
+    </labels>
+</CustomLabels>
+`;
+
+    const expected = `declare module "@salesforce/label/c.only_one" {
+    var only_one: string;
+    export default only_one;
+}`;
+
+    const typings: string = await declarationsFromCustomLabels(xmlDocument);
+    expect(typings).toEqual(expected);
+  });
+
   it('should not generate declarations when parsing an empty labels xml document', async () => {
     const xmlDocument = `
 <?xml version="1.0" encoding="UTF-8"?>

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -50,7 +50,8 @@
     "salesforcedx-vscode-services": "*"
   },
   "extensionDependencies": [
-    "salesforce.salesforcedx-vscode-services"
+    "salesforce.salesforcedx-vscode-services",
+    "salesforce.salesforcedx-vscode-metadata"
   ],
   "scripts": {
     "vscode:bundle": "wireit",
@@ -66,9 +67,9 @@
     "test:compile": "wireit",
     "test:web": "wireit",
     "test:web:ui": "DEBUG_MODE=1 npm run test:web -- --headed",
-    "test:web:debug": "npm run test:web -- --debug",
+    "test:web:debug": "wireit",
     "test:desktop": "wireit",
-    "test:desktop:debug": "npm run test:desktop -- --debug",
+    "test:desktop:debug": "wireit",
     "test:e2e": "wireit"
   },
   "wireit": {
@@ -133,6 +134,28 @@
         "vscode:bundle",
         "../salesforcedx-vscode-services:vscode:bundle",
         "../salesforcedx-vscode-services:spans:server",
+        "../salesforcedx-vscode-metadata:vscode:bundle",
+        "../playwright-vscode-ext:compile"
+      ],
+      "files": [
+        "playwright.config.web.ts",
+        "test/playwright/**/*.ts",
+        "package*.json"
+      ],
+      "output": []
+    },
+    "test:web:debug": {
+      "command": "playwright test --config=playwright.config.web.ts --debug",
+      "env": {
+        "PLAYWRIGHT_WORKERS": {
+          "external": true
+        }
+      },
+      "dependencies": [
+        "vscode:bundle",
+        "../salesforcedx-vscode-services:vscode:bundle",
+        "../salesforcedx-vscode-services:spans:server",
+        "../salesforcedx-vscode-metadata:vscode:bundle",
         "../playwright-vscode-ext:compile"
       ],
       "files": [
@@ -152,6 +175,28 @@
       "dependencies": [
         "vscode:bundle",
         "../salesforcedx-vscode-services:vscode:bundle",
+        "../salesforcedx-vscode-metadata:vscode:bundle",
+        "../playwright-vscode-ext:compile"
+      ],
+      "files": [
+        "playwright.config.desktop.ts",
+        "test/playwright/**/*.ts",
+        "package*.json"
+      ],
+      "output": []
+    },
+    "test:desktop:debug": {
+      "command": "playwright test --config=playwright.config.desktop.ts --debug",
+      "env": {
+        "VSCODE_DESKTOP": "1",
+        "PLAYWRIGHT_WORKERS": {
+          "external": true
+        }
+      },
+      "dependencies": [
+        "vscode:bundle",
+        "../salesforcedx-vscode-services:vscode:bundle",
+        "../salesforcedx-vscode-metadata:vscode:bundle",
         "../playwright-vscode-ext:compile"
       ],
       "files": [
@@ -184,12 +229,13 @@
       ]
     },
     "run:web": {
-      "command": "npx vscode-test-web --browserType=chromium --browserOption=--disable-web-security --browserOption=--remote-debugging-port=9222 --extensionDevelopmentPath . --extensionPath ../salesforcedx-vscode-org-browser --extensionPath ../salesforcedx-vscode-services --open-devtools --port 3001 --verbose --printServerLog --quality stable",
+      "command": "npx vscode-test-web --browserType=chromium --browserOption=--disable-web-security --browserOption=--remote-debugging-port=9222 --extensionDevelopmentPath . --extensionPath ../salesforcedx-vscode-org-browser --extensionPath ../salesforcedx-vscode-services --extensionPath ../salesforcedx-vscode-metadata --open-devtools --port 3001 --verbose --printServerLog --quality stable",
       "service": true,
       "dependencies": [
         "vscode:bundle",
         "../salesforcedx-vscode-org-browser:vscode:bundle",
-        "../salesforcedx-vscode-services:vscode:bundle"
+        "../salesforcedx-vscode-services:vscode:bundle",
+        "../salesforcedx-vscode-metadata:vscode:bundle"
       ]
     },
     "test": {

--- a/packages/salesforcedx-vscode-lwc/package.nls.json
+++ b/packages/salesforcedx-vscode-lwc/package.nls.json
@@ -1,4 +1,5 @@
 {
+  "lightning_generate_lwc_text": "SFDX: Create Lightning Web Component",
   "lightning_lwc_debugger": "Debug: LWC Jest Tests",
   "lightning_lwc_debugger_desc": "Debug configuration for running LWC jest tests in VSCode.",
   "lightning_lwc_preferences": "Salesforce Lightning Web Components",

--- a/packages/salesforcedx-vscode-lwc/src/index.ts
+++ b/packages/salesforcedx-vscode-lwc/src/index.ts
@@ -13,7 +13,7 @@ import {
 import { registerWorkspaceReadFileHandler } from '@salesforce/salesforcedx-lightning-lsp-common/workspaceReadFileHandler';
 import { ActivationTracker, detectWorkspaceType } from '@salesforce/salesforcedx-utils-vscode';
 import type { TelemetryServiceInterface } from '@salesforce/vscode-service-provider';
-import { ExtensionContext, workspace } from 'vscode';
+import { ExtensionContext, FileType, workspace } from 'vscode';
 import { URI, Utils } from 'vscode-uri';
 import { channelService } from './channel';
 import { log } from './constants';
@@ -25,6 +25,16 @@ import { startLwcFileWatcherViaServices } from './util/lwcFileWatcher';
 const getTelemetryService = async (): Promise<TelemetryServiceInterface> => {
   const telemetryModule = await import('./telemetry/index.js');
   return telemetryModule.telemetryService;
+};
+
+/** Path-string workspace detection fails for some virtual/test-web roots; `workspace.fs` uses the folder URI. */
+const rootHasSfdxProjectJson = async (folderUri: URI): Promise<boolean> => {
+  try {
+    const stat = await workspace.fs.stat(Utils.joinPath(folderUri, 'sfdx-project.json'));
+    return stat.type === FileType.File;
+  } catch {
+    return false;
+  }
 };
 
 export const activate = async (extensionContext: ExtensionContext) => {
@@ -75,11 +85,16 @@ export const activate = async (extensionContext: ExtensionContext) => {
     }
   });
 
-  // For workspace type detection, we still need to check the file system
-  // Create a temporary provider just for detection
-  // In web mode with no valid paths, default to UNKNOWN
-  const workspaceType: WorkspaceType =
+  // Path-based detection (Node fs paths) can return UNKNOWN for virtual workspaces; confirm via URI API.
+  let workspaceType: WorkspaceType =
     workspaceFolderPaths.length > 0 ? await detectWorkspaceType(workspaceFolderPaths) : 'UNKNOWN';
+  if (
+    workspaceType === 'UNKNOWN' &&
+    workspace.workspaceFolders[0] &&
+    (await rootHasSfdxProjectJson(workspace.workspaceFolders[0].uri))
+  ) {
+    workspaceType = 'SFDX';
+  }
 
   // Check if we have a valid project structure
   if (getActivationMode() === 'autodetect' && !isLWC(workspaceType)) {
@@ -107,6 +122,8 @@ export const activate = async (extensionContext: ExtensionContext) => {
     // Listen for server ready notification to update status
     client.onNotification(LWC_SERVER_READY_NOTIFICATION, () => {
       statusBarItem.ready();
+      // Web E2E: language status is not always exposed in the status bar; tests wait on this log line.
+      channelService.appendLine('LWC Language Server: indexing complete');
     });
 
     // Start the client and add it to subscriptions

--- a/packages/salesforcedx-vscode-lwc/src/lwcLspStatusBarItem.ts
+++ b/packages/salesforcedx-vscode-lwc/src/lwcLspStatusBarItem.ts
@@ -5,18 +5,31 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { LanguageStatusSeverity, languages, type Disposable, type LanguageStatusItem } from 'vscode';
+import { LanguageStatusSeverity, languages, type Disposable, type DocumentSelector, type LanguageStatusItem } from 'vscode';
 import { nls } from './messages';
+
+/** LWC bundle paths; virtual / test-web URIs may not glob-match the usual `lwc` path segment pattern. */
+const lwcDocumentSelector: DocumentSelector = [
+  { language: 'html', pattern: '**/lwc/**' },
+  { language: 'javascript', pattern: '**/lwc/**' },
+  { language: 'typescript', pattern: '**/lwc/**' }
+];
+
+/**
+ * Web: broaden selectors so language status still binds when workspace FS paths do not match the `lwc` glob.
+ * The LWC extension only activates for LWC workspaces (`autodetect` / `always`), so extra `language` filters
+ * do not affect unrelated project types.
+ */
+const languageStatusSelector: DocumentSelector =
+  process.env.ESBUILD_PLATFORM === 'web'
+    ? [...lwcDocumentSelector, { language: 'html' }, { language: 'javascript' }, { language: 'typescript' }]
+    : lwcDocumentSelector;
 
 export default class LwcLspStatusBarItem implements Disposable {
   private languageStatusItem: LanguageStatusItem;
 
   constructor() {
-    this.languageStatusItem = languages.createLanguageStatusItem('lwcLanguageServerStatus', [
-      { language: 'html', pattern: '**/lwc/**' },
-      { language: 'javascript', pattern: '**/lwc/**' },
-      { language: 'typescript', pattern: '**/lwc/**' }
-    ]);
+    this.languageStatusItem = languages.createLanguageStatusItem('lwcLanguageServerStatus', languageStatusSelector);
 
     this.indexing();
   }

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/codeLens/lwcTestCodeLensProvider.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/codeLens/lwcTestCodeLensProvider.ts
@@ -36,7 +36,7 @@ class LwcTestCodeLensProvider implements CodeLensProvider {
    * @param document text document
    * @param token cancellation token
    */
-  public async provideCodeLenses(document: TextDocument, token: CancellationToken): Promise<CodeLens[]> {
+  public provideCodeLenses(document: TextDocument, token: CancellationToken): CodeLens[] {
     return provideLwcTestCodeLens(document, token);
   }
 }

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/commands/lwcTestDebugAction.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/commands/lwcTestDebugAction.ts
@@ -99,8 +99,9 @@ export const lwcTestDebugActiveTextEditorTest = async () => {
 export const handleDidStartDebugSession = (session: vscode.DebugSession) => {
   const { configuration } = session;
   const { sfDebugSessionId } = configuration;
-  const startTime = TimingUtils.getCurrentTime();
-  debugSessionStartTimes.set(sfDebugSessionId, startTime);
+  if (typeof sfDebugSessionId === 'string') {
+    debugSessionStartTimes.set(sfDebugSessionId, TimingUtils.getCurrentTime());
+  }
 };
 
 /**
@@ -109,7 +110,8 @@ export const handleDidStartDebugSession = (session: vscode.DebugSession) => {
  */
 export const handleDidTerminateDebugSession = (session: vscode.DebugSession) => {
   const { configuration } = session;
-  const startTime = debugSessionStartTimes.get(configuration.sfDebugSessionId);
+  const { sfDebugSessionId } = configuration;
+  const startTime = typeof sfDebugSessionId === 'string' ? debugSessionStartTimes.get(sfDebugSessionId) : undefined;
   if (Array.isArray(startTime)) {
     telemetryService.sendCommandEvent(LWC_TEST_DEBUG_LOG_NAME, startTime, {
       workspaceType: workspaceService.getCurrentWorkspaceTypeForTelemetry()

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/commands/lwcTestWatchAction.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/commands/lwcTestWatchAction.ts
@@ -27,7 +27,7 @@ const lwcTestStartWatching = async (data: { testExecutionInfo: TestExecutionInfo
  * It will terminate the test watch task matched by the test URI.
  * @param data provided by test watch commands
  */
-const lwcTestStopWatching = async (data: { testExecutionInfo: TestExecutionInfo }) => {
+const lwcTestStopWatching = (data: { testExecutionInfo: TestExecutionInfo }) => {
   const { testExecutionInfo } = data;
   testWatcher.stopWatchingTest(testExecutionInfo);
 };

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/testIndexer/jestUtils.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/testIndexer/jestUtils.ts
@@ -10,7 +10,7 @@ import * as vscode from 'vscode';
 
 // strip-ansi: import fails (TS2306/TS1479); require works for both v5 and v7
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment
-const stripAnsi = require('strip-ansi');
+const stripAnsi: (input: string) => string = require('strip-ansi');
 
 type ParsedNodeWithAncestorTitles = Pick<ParsedNode, Exclude<keyof ParsedNode, 'children'>> & {
   name?: string;

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/testIndexer/lwcTestIndexer.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/testIndexer/lwcTestIndexer.ts
@@ -111,7 +111,7 @@ class LwcTestIndexer implements Indexer, vscode.Disposable {
     return await this.indexAllTestFiles();
   }
 
-  public async indexTestCases(testUri: URI) {
+  public indexTestCases(testUri: URI): TestCaseInfo[] {
     // parse
     const { fsPath: testFsPath } = testUri;
     const testFileInfo = this.testFileInfoMap.get(testFsPath) ?? this.indexTestFile(testFsPath);
@@ -123,7 +123,7 @@ class LwcTestIndexer implements Indexer, vscode.Disposable {
    * It lazily parses test information, until expanding the test file or providing code lens
    * @param testUri uri of test file
    */
-  public async findTestInfoFromLwcJestTestFile(testUri: URI): Promise<TestCaseInfo[]> {
+  public findTestInfoFromLwcJestTestFile(testUri: URI): TestCaseInfo[] {
     // parse
     const { fsPath: testFsPath } = testUri;
     const testFileInfo = this.testFileInfoMap.get(testFsPath) ?? this.indexTestFile(testFsPath);

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/testRunner/taskService.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/testRunner/taskService.ts
@@ -77,7 +77,7 @@ class TaskService {
         const { execution } = taskStartEvent;
         const { definition } = execution.task;
         const { sfTaskId } = definition;
-        if (sfTaskId) {
+        if (typeof sfTaskId === 'string') {
           const foundTask = this.createdTasks.get(sfTaskId);
           if (foundTask) {
             foundTask.notifyStartTask();
@@ -93,7 +93,7 @@ class TaskService {
         const { execution } = taskEndEvent;
         const { definition } = execution.task;
         const { sfTaskId } = definition;
-        if (sfTaskId) {
+        if (typeof sfTaskId === 'string') {
           const foundTask = this.createdTasks.get(sfTaskId);
           if (foundTask) {
             foundTask.notifyEndTask();

--- a/packages/salesforcedx-vscode-lwc/test/jest/testSupport/codeLens/provideLwcTestCodeLens.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/jest/testSupport/codeLens/provideLwcTestCodeLens.test.ts
@@ -7,6 +7,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import * as vscode from 'vscode';
 import { CancellationToken, TextDocument, extensions } from 'vscode';
 import { provideLwcTestCodeLens } from '../../../../src/testSupport/codeLens/provideLwcTestCodeLens';
 
@@ -20,7 +21,7 @@ describe('provideLwcTestCodeLens', () => {
         fsPath: '/test/path/testFile.test.js'
       },
       getText: jest.fn()
-    } as any;
+    } as unknown as TextDocument;
     mockToken = {} as CancellationToken;
   });
 
@@ -66,7 +67,7 @@ describe('Outer Suite', () => {
         fsPath: tempFile
       },
       getText: jest.fn().mockReturnValue('')
-    } as any;
+    } as unknown as TextDocument;
 
     const codeLenses = provideLwcTestCodeLens(mockDocument, mockToken);
 
@@ -84,7 +85,7 @@ describe('Outer Suite', () => {
     const getExtensionSpy = jest.spyOn(extensions, 'getExtension');
     getExtensionSpy.mockImplementation((extensionId: string) => {
       if (extensionId === 'firsttris.vscode-jest-runner') {
-        return mockJestRunnerExtension as any;
+        return mockJestRunnerExtension as unknown as vscode.Extension<unknown>;
       }
       return undefined; // Other extensions are not present
     });

--- a/packages/salesforcedx-vscode-lwc/test/jest/testSupport/testRunner/testRunner.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/jest/testSupport/testRunner/testRunner.test.ts
@@ -9,20 +9,20 @@ import { getTestNamePatternArgs } from '../../../../src/testSupport/testRunner/t
 
 describe('testRunner Unit Tests.', () => {
   describe('test getTestNamePatternArgs', () => {
-    it('Should return testNamePattern if flag is included', async () => {
+    it('Should return testNamePattern if flag is included', () => {
       const testName = 'Testing is Fun!';
       const testPatternArgs = getTestNamePatternArgs(testName);
       expect(testPatternArgs.length).toEqual(2);
       expect(testPatternArgs).toMatchSnapshot();
     });
-    it('Should escape certain symbols if testNamePattern is included', async () => {
+    it('Should escape certain symbols if testNamePattern is included', () => {
       const testName = 'Test ?$^*().[]{}|+ Symbols';
       const testNameEscaped = 'Test \\?\\$\\^\\*\\(\\)\\.\\[\\]\\{\\}\\|\\+ Symbols';
       const testPatternArgs = getTestNamePatternArgs(testName);
       expect(testPatternArgs).toContain(testNameEscaped);
       expect(testPatternArgs).toMatchSnapshot();
     });
-    it('Should not escape certain symbols if testNamePattern is included', async () => {
+    it('Should not escape certain symbols if testNamePattern is included', () => {
       const testName = 'Test !@#"%&;:,<>=~` Symbols';
       const testPatternArgs = getTestNamePatternArgs(testName);
       expect(testPatternArgs).toMatchSnapshot();

--- a/packages/salesforcedx-vscode-lwc/test/playwright/fixtures/desktopFixtures.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/fixtures/desktopFixtures.ts
@@ -10,16 +10,22 @@ import * as path from 'node:path';
 
 import { createDesktopTest, createTestWorkspace } from '@salesforce/playwright-vscode-ext';
 
+import { seedLwcHeadlessWorkspaceSupplement, seedSnippetsE2eEmptyBundle } from '../utils/createLwcTestWorkspace';
+
 export const desktopTest = createDesktopTest({
   fixturesDir: __dirname,
-  disableOtherExtensions: false
+  disableOtherExtensions: false,
+  additionalExtensionDirs: ['salesforcedx-vscode-metadata']
 }).extend({
   workspaceDir: async ({}, use) => {
     const dir = await createTestWorkspace(undefined);
-    const bundleDir = path.join(dir, 'force-app', 'main', 'default', 'lwc', 'snippetsE2E');
-    await fs.mkdir(bundleDir, { recursive: true });
-    await fs.writeFile(path.join(bundleDir, 'snippetsE2E.html'), '', 'utf8');
-    await fs.writeFile(path.join(bundleDir, 'snippetsE2E.js'), '', 'utf8');
+    const sfdxProjectPath = path.join(dir, 'sfdx-project.json');
+    const parsed: unknown = JSON.parse(await fs.readFile(sfdxProjectPath, 'utf8'));
+    if (typeof parsed === 'object' && parsed !== null) {
+      await fs.writeFile(sfdxProjectPath, JSON.stringify({ ...parsed, defaultLwcLanguage: 'javascript' }, null, 2));
+    }
+    await seedLwcHeadlessWorkspaceSupplement(dir);
+    await seedSnippetsE2eEmptyBundle(dir);
     await use(dir);
   }
 });

--- a/packages/salesforcedx-vscode-lwc/test/playwright/playwright.config.web.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/playwright.config.web.ts
@@ -4,7 +4,6 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
 import { createWebConfig } from '@salesforce/playwright-vscode-ext';
 
 export default createWebConfig({ testDir: './specs' });

--- a/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcCustomComponentsIndex.headless.spec.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcCustomComponentsIndex.headless.spec.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { expect } from '@playwright/test';
+import {
+  closeWelcomeTabs,
+  ensureSecondarySideBarHidden,
+  EDITOR_WITH_URI,
+  setupConsoleMonitoring,
+  validateNoCriticalErrors,
+  waitForVSCodeWorkbench
+} from '@salesforce/playwright-vscode-ext';
+import { test } from '../fixtures';
+import { createLwc, openLwcFile, openSfdxCustomComponentsJson, waitForLwcLspReady } from '../utils/lwcUtils';
+import { applyLwcWebScratchAuth } from '../utils/lwcWebScratchAuth';
+
+test.beforeEach(async ({ page }) => {
+  await waitForVSCodeWorkbench(page);
+  await closeWelcomeTabs(page);
+  await applyLwcWebScratchAuth(page);
+  await ensureSecondarySideBarHidden(page);
+});
+
+test('New LWC bundle updates .sfdx/indexes/lwc/custom-components.json without reloading VS Code', async ({ page }) => {
+  test.setTimeout(3 * 60 * 1000);
+
+  const consoleErrors = setupConsoleMonitoring(page);
+  const bundleCamel = 'idxCmp';
+
+  await test.step('create a bundle and wait for LWC language server indexing', async () => {
+    await createLwc(page, bundleCamel);
+    await openLwcFile(page, `${bundleCamel}.js`);
+    await waitForLwcLspReady(page);
+  });
+
+  await test.step('custom-components.json lists the new module path', async () => {
+    await openSfdxCustomComponentsJson(page);
+    const editor = page.locator(`${EDITOR_WITH_URI}[data-uri*="custom-components.json"]`);
+    const posix = `lwc/${bundleCamel}/${bundleCamel}.js`;
+    const winish = `lwc\\${bundleCamel}\\${bundleCamel}.js`;
+    await expect(async () => {
+      const text = (await editor.locator('.view-lines').textContent()) ?? '';
+      expect(text.includes(posix) || text.includes(winish)).toBe(true);
+    }).toPass({ timeout: 90_000 });
+  });
+
+  await validateNoCriticalErrors(test, consoleErrors);
+});

--- a/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcLspAutocompletion.headless.spec.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcLspAutocompletion.headless.spec.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { expect } from '@playwright/test';
+import {
+  DIRTY_EDITOR,
+  EDITOR_WITH_URI,
+  closeWelcomeTabs,
+  ensureSecondarySideBarHidden,
+  executeCommandWithCommandPalette,
+  setupConsoleMonitoring,
+  validateNoCriticalErrors,
+  waitForVSCodeWorkbench
+} from '@salesforce/playwright-vscode-ext';
+import { test } from '../fixtures';
+import { createLwc, goToLineCol, openLwcFile, waitForLwcLspReady } from '../utils/lwcUtils';
+import { applyLwcWebScratchAuth } from '../utils/lwcWebScratchAuth';
+
+test.beforeEach(async ({ page }) => {
+  await waitForVSCodeWorkbench(page);
+  await closeWelcomeTabs(page);
+  await applyLwcWebScratchAuth(page);
+  await ensureSecondarySideBarHidden(page);
+});
+
+test('LWC LSP provides autocompletion for lightning-* base components in HTML templates', async ({ page }) => {
+  test.setTimeout(3 * 60 * 1000);
+
+  const consoleErrors = setupConsoleMonitoring(page);
+
+  await test.step('create Lightning Web Component', async () => {
+    await createLwc(page, 'autoComp');
+  });
+
+  await test.step('wait for LWC LSP to finish indexing', async () => {
+    await openLwcFile(page, 'autoComp.html');
+    await waitForLwcLspReady(page);
+  });
+
+  await test.step('position cursor inside the template body to type a new element', async () => {
+    // Default template: line 1 "<template>", line 2 "</template>"
+    // Move to line 1 end and insert a new line to type in
+    const editor = page.locator(`${EDITOR_WITH_URI}[data-uri$="autoComp.html"]`);
+    await editor.click();
+    await goToLineCol(page, 1, 11); // end of "<template>"
+    await page.keyboard.press('Enter');
+  });
+
+  await test.step('type a partial lightning component tag and trigger autocompletion', async () => {
+    await page.keyboard.type('<lightnin');
+    // VS Code autocomplete appears automatically after a short delay; wait for it
+    const autocompleteList = page.locator('.editor-widget.suggest-widget .monaco-list-row');
+    await autocompleteList.first().waitFor({ state: 'visible', timeout: 15_000 });
+  });
+
+  await test.step('verify lightning-accordion appears in the suggestion list', async () => {
+    // The first suggestion should include a lightning-* component; confirm lightning-accordion is present
+    const suggestions = page.locator('.editor-widget.suggest-widget .monaco-list-row');
+    const suggestionTexts = await suggestions.allTextContents();
+    const hasLightningAccordion = suggestionTexts.some(t => t.toLowerCase().includes('lightning-accordion'));
+    expect(
+      hasLightningAccordion,
+      `Expected "lightning-accordion" in suggestions, got: ${suggestionTexts.slice(0, 5).join(' | ')}`
+    ).toBe(true);
+  });
+
+  await test.step('select the lightning-accordion suggestion and verify it is inserted', async () => {
+    // Click the lightning-accordion row directly
+    const accordionRow = page
+      .locator('.editor-widget.suggest-widget .monaco-list-row')
+      .filter({ hasText: /^lightning-accordion/ });
+    await accordionRow.first().click();
+
+    // Close the tag and save
+    await page.keyboard.type('>');
+    await executeCommandWithCommandPalette(page, 'File: Save');
+    await expect(
+      page.locator(DIRTY_EDITOR).first(),
+      'HTML editor should be saved after inserting suggestion'
+    ).not.toBeVisible({
+      timeout: 5000
+    });
+
+    // The inserted line should contain the accepted component name
+    const editor = page.locator(`${EDITOR_WITH_URI}[data-uri$="autoComp.html"]`);
+    await expect(editor).toContainText('lightning-accordion', { timeout: 5000 });
+  });
+
+  await validateNoCriticalErrors(test, consoleErrors);
+});

--- a/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcLspGoToDefinitionHtml.headless.spec.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcLspGoToDefinitionHtml.headless.spec.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { expect } from '@playwright/test';
+import {
+  EDITOR_WITH_URI,
+  TAB,
+  closeWelcomeTabs,
+  ensureSecondarySideBarHidden,
+  executeCommandWithCommandPalette,
+  setupConsoleMonitoring,
+  validateNoCriticalErrors,
+  waitForVSCodeWorkbench
+} from '@salesforce/playwright-vscode-ext';
+import { test } from '../fixtures';
+import { createLwc, goToLineCol, openLwcFile, waitForLwcLspReady } from '../utils/lwcUtils';
+import { applyLwcWebScratchAuth } from '../utils/lwcWebScratchAuth';
+
+test.beforeEach(async ({ page }) => {
+  await waitForVSCodeWorkbench(page);
+  await closeWelcomeTabs(page);
+  await applyLwcWebScratchAuth(page);
+  await ensureSecondarySideBarHidden(page);
+});
+
+test('LWC LSP Go to Definition navigates from HTML property binding to JS class property', async ({ page }) => {
+  test.setTimeout(3 * 60 * 1000);
+
+  const consoleErrors = setupConsoleMonitoring(page);
+
+  await test.step('create gtdHtmlComp via SFDX and open HTML (template patched after create)', async () => {
+    await createLwc(page, 'gtdHtmlComp');
+    await openLwcFile(page, 'gtdHtmlComp.html');
+  });
+
+  await test.step('wait for LWC LSP to finish indexing', async () => {
+    await waitForLwcLspReady(page);
+  });
+
+  await test.step('position cursor on the {greeting} binding in the HTML template', async () => {
+    // Patched HTML line 2: "    <p>{greeting}</p>" — place cursor on "greeting"
+    const editor = page.locator(`${EDITOR_WITH_URI}[data-uri$="gtdHtmlComp.html"]`);
+    await editor.click();
+    await goToLineCol(page, 2, 10);
+  });
+
+  await test.step('execute Go to Definition', async () => {
+    await executeCommandWithCommandPalette(page, 'Go to Definition');
+  });
+
+  await test.step('verify navigation targets gtdHtmlComp.js (class field location)', async () => {
+    // Prefer a visible editor for the JS module; tab label is a fallback if the URI attribute differs (e.g. peek).
+    const jsEditor = page.locator(`${EDITOR_WITH_URI}[data-uri*="gtdHtmlComp.js"]`);
+    const jsTab = page.locator(TAB).filter({ hasText: /gtdHtmlComp\.js/ });
+    await expect(
+      jsEditor.or(jsTab).first(),
+      'Go to Definition should open the JS class member for the binding'
+    ).toBeVisible({
+      timeout: 15_000
+    });
+  });
+
+  await validateNoCriticalErrors(test, consoleErrors);
+});

--- a/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcLspGoToDefinitionJs.headless.spec.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcLspGoToDefinitionJs.headless.spec.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * Web (`npm run test:web`): the spec below is skipped. VS Code for Web runs the TS/JS language service on a virtual
+ * filesystem (e.g. memfs); project-wide analysis is often "partial" until fully loaded, and path resolution differs
+ * from desktop `file://`. Navigating from LWC `.js` to extension typings (`engine.d.ts`) via Go to Type Definition is
+ * unreliable in headless web E2E even though typings exist in both hosts. Desktop matches typical local DX; see
+ * https://github.com/microsoft/vscode/pull/169311 (cross-file TS on web) and memfs handling in
+ * `salesforcedx-lwc-language-server` `componentIndexer`.
+ */
+import { expect } from '@playwright/test';
+import {
+  EDITOR,
+  EDITOR_WITH_URI,
+  TAB,
+  closeWelcomeTabs,
+  ensureSecondarySideBarHidden,
+  isDesktop,
+  setupConsoleMonitoring,
+  validateNoCriticalErrors,
+  waitForVSCodeWorkbench
+} from '@salesforce/playwright-vscode-ext';
+import { test } from '../fixtures';
+import { createLwc, openLwcFile, waitForLwcLspReady } from '../utils/lwcUtils';
+import { applyLwcWebScratchAuth } from '../utils/lwcWebScratchAuth';
+
+test.beforeEach(async ({ page }) => {
+  await waitForVSCodeWorkbench(page);
+  await closeWelcomeTabs(page);
+  await applyLwcWebScratchAuth(page);
+  await ensureSecondarySideBarHidden(page);
+});
+
+test('LWC LSP Go to Definition navigates from JS import to engine.d.ts LWC module declaration', async ({ page }) => {
+  test.skip(!isDesktop(), 'Desktop only — see file comment: web TS/navigation to typings is not stable for this E2E');
+
+  test.setTimeout(3 * 60 * 1000);
+
+  const consoleErrors = setupConsoleMonitoring(page);
+
+  await test.step('create Lightning Web Component', async () => {
+    await createLwc(page, 'gtdJsComp');
+  });
+
+  await test.step('wait for LWC LSP to finish indexing', async () => {
+    // Open the HTML file first so the status item appears, then switch back to JS
+    await openLwcFile(page, 'gtdJsComp.html');
+    await waitForLwcLspReady(page);
+    await openLwcFile(page, 'gtdJsComp.js');
+  });
+
+  await test.step('cmd+click LightningElement in the import binding to navigate to its declaration', async () => {
+    // Default SFDX template line 1: `import { LightningElement } from 'lwc';`
+    // Hover first so TypeScript computes the token's type info before cmd+clicking (mirrors manual test workflow).
+    // Use `.first()` to select the import binding, not the extends clause occurrence.
+    const editor = page.locator(`${EDITOR_WITH_URI}[data-uri$="gtdJsComp.js"]`);
+    await editor.waitFor({ state: 'visible', timeout: 10_000 });
+    const lightningToken = editor.locator('.view-lines span').filter({ hasText: /^LightningElement$/ }).first();
+    await lightningToken.waitFor({ state: 'visible', timeout: 10_000 });
+    // Hover to trigger TypeScript type resolution; wait for the hover card to show `LightningElement`
+    // before cmd+clicking — ensures TS has computed the declaration before Go to Definition fires.
+    // In parallel test runs the TS language service can be slow; the hover wait is the synchronisation point.
+    await lightningToken.hover();
+    await expect(
+      page.locator('.monaco-hover').filter({ hasText: /LightningElement/ }),
+      'hover tooltip should show LightningElement type info before cmd+click'
+    ).toBeVisible({ timeout: 20_000 });
+    await lightningToken.click({ modifiers: ['Meta'] });
+  });
+
+  await test.step('verify navigation opened the engine.d.ts LWC module declaration', async () => {
+    // Resolution target is the LWC LSP-generated engine.d.ts under .sfdx/typings/lwc/.
+    // URIs vary by host (file:, vscode-file:, virtual); TS may use Peek instead of a new tab.
+    const byUri = page
+      .locator(`${EDITOR_WITH_URI}[data-uri*="engine.d.ts"]`)
+      .or(page.locator(`${EDITOR_WITH_URI}[data-uri*="types.d.ts"]`))
+      .or(page.locator(`${EDITOR_WITH_URI}[data-uri*="typings"]`))
+      .or(page.locator(TAB).filter({ hasText: /engine\.d\.ts|types\.d\.ts/i }));
+    const byDeclaration = page
+      .locator(EDITOR_WITH_URI)
+      .filter({ hasText: /export class LightningElement\b|declare module ['"]lwc['"]/ });
+    const peekDeclaration = page
+      .locator('.peekview-widget')
+      .locator(EDITOR)
+      .filter({ hasText: /export class LightningElement\b|declare module ['"]lwc['"]/ });
+    await expect(
+      byUri.or(byDeclaration).or(peekDeclaration).first(),
+      'Go to Definition should open engine.d.ts LWC module declaration'
+    ).toBeVisible({
+      timeout: 30_000
+    });
+  });
+
+  await validateNoCriticalErrors(test, consoleErrors);
+});

--- a/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcLspIndexing.headless.spec.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcLspIndexing.headless.spec.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {
+  closeWelcomeTabs,
+  ensureSecondarySideBarHidden,
+  setupConsoleMonitoring,
+  validateNoCriticalErrors,
+  waitForVSCodeWorkbench
+} from '@salesforce/playwright-vscode-ext';
+import { test } from '../fixtures';
+import { createLwc, openLwcFile, waitForLwcLspReady } from '../utils/lwcUtils';
+import { applyLwcWebScratchAuth } from '../utils/lwcWebScratchAuth';
+
+test.beforeEach(async ({ page }) => {
+  await waitForVSCodeWorkbench(page);
+  await closeWelcomeTabs(page);
+  await applyLwcWebScratchAuth(page);
+  await ensureSecondarySideBarHidden(page);
+});
+
+test('LWC LSP finishes indexing and shows status in status bar', async ({ page }) => {
+  test.setTimeout(3 * 60 * 1000);
+
+  const consoleErrors = setupConsoleMonitoring(page);
+
+  await test.step('create Lightning Web Component', async () => {
+    await createLwc(page, 'indexComp');
+  });
+
+  await test.step('open LWC HTML file to activate language status item', async () => {
+    // The language status item (lwcLanguageServerStatus) only appears for LWC html/js/ts files
+    await openLwcFile(page, 'indexComp.html');
+  });
+
+  await test.step('wait for LWC LSP to finish indexing', async () => {
+    await waitForLwcLspReady(page);
+  });
+
+  await validateNoCriticalErrors(test, consoleErrors);
+});

--- a/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcLspSfdxTypings.headless.spec.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcLspSfdxTypings.headless.spec.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {
+  closeWelcomeTabs,
+  ensureSecondarySideBarHidden,
+  setupConsoleMonitoring,
+  validateNoCriticalErrors,
+  waitForVSCodeWorkbench
+} from '@salesforce/playwright-vscode-ext';
+import { test } from '../fixtures';
+import { assertLwcSfdxTypingsGenerated, createLwc, openLwcFile, waitForLwcLspReady } from '../utils/lwcUtils';
+import { applyLwcWebScratchAuth } from '../utils/lwcWebScratchAuth';
+
+test.beforeEach(async ({ page }) => {
+  await waitForVSCodeWorkbench(page);
+  await closeWelcomeTabs(page);
+  await applyLwcWebScratchAuth(page);
+  await ensureSecondarySideBarHidden(page);
+});
+
+test('LWC LSP writes SFDX typings under .sfdx/typings/lwc with expected module headers', async ({ page }) => {
+  test.setTimeout(3 * 60 * 1000);
+
+  const consoleErrors = setupConsoleMonitoring(page);
+
+  await test.step('create bundle and wait for LSP indexing (triggers typings copy into workspace)', async () => {
+    await createLwc(page, 'typingsProbe');
+    await openLwcFile(page, 'typingsProbe.js');
+    await waitForLwcLspReady(page);
+  });
+
+  await test.step('open each generated .d.ts and assert first-line module declarations', async () => {
+    await assertLwcSfdxTypingsGenerated(page);
+  });
+
+  await validateNoCriticalErrors(test, consoleErrors);
+});

--- a/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcSnippets.headless.spec.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcSnippets.headless.spec.ts
@@ -8,6 +8,8 @@
 import { expect, type Page } from '@playwright/test';
 
 import {
+  assertWelcomeTabExists,
+  closeSettingsTab,
   closeWelcomeTabs,
   EDITOR_WITH_URI,
   ensureSecondarySideBarHidden,
@@ -19,32 +21,65 @@ import {
   setupConsoleMonitoring,
   setupNetworkMonitoring,
   typingSpeed,
+  upsertSettings,
   validateNoCriticalErrors,
+  verifyCommandExists,
   waitForExtensionsActivated,
   waitForQuickInputFirstOption,
   waitForVSCodeWorkbench,
-  waitForWorkspaceReady,
-  WORKBENCH
+  waitForWorkspaceReady
 } from '@salesforce/playwright-vscode-ext';
 
 import { test } from '../fixtures';
 
 const isDesktop = process.env.VSCODE_DESKTOP === '1';
 
+/** Web: no scratch auth in this spec — disable deploy-on-save so `File: Save` does not log deploy errors (empty instanceUrl). */
+const disableDeployOnSaveWeb = async (page: Page): Promise<void> => {
+  if (isDesktop) {
+    return;
+  }
+  await upsertSettings(page, { 'salesforcedx-vscode-core.push-or-deploy-on-save.enabled': 'false' });
+  await closeSettingsTab(page);
+};
+
+/** Same title as `salesforcedx-vscode-metadata` `package.nls.json` `lightning_generate_lwc_text` (avoid cross-package imports). */
+const SFDX_CREATE_LWC_COMMAND = 'SFDX: Create Lightning Web Component';
+
+/** Web default workspace: create the bundle via **SFDX: Create Lightning Web Component** (metadata extension). */
+const createLwcBundleViaPalette = async (page: Page, componentName: string): Promise<void> => {
+  await verifyCommandExists(page, SFDX_CREATE_LWC_COMMAND, 120_000);
+  await executeCommandWithCommandPalette(page, SFDX_CREATE_LWC_COMMAND);
+
+  const quickInput = page.locator(QUICK_INPUT_WIDGET);
+  await quickInput.waitFor({ state: 'visible', timeout: 30_000 });
+
+  await waitForQuickInputFirstOption(page);
+  await page.keyboard.press('Enter');
+
+  await quickInput.getByText(/Enter Lightning Web Component name/i).waitFor({ state: 'visible', timeout: 10_000 });
+  await page.keyboard.type(componentName);
+  await page.keyboard.press('Enter');
+
+  await waitForQuickInputFirstOption(page);
+  await page.keyboard.press('Enter');
+
+  await page.locator(EDITOR_WITH_URI).first().waitFor({ state: 'visible', timeout: 20_000 });
+};
+
 /**
- * Desktop: Quick Open works against the real filesystem.
+ * Desktop: Quick Open works against the real filesystem; the desktop fixture seeds `snippetsE2E`.
  * Web: `@vscode/test-web`'s file system provider does not implement `provideFileSearch`, so
- * Quick Open returns "No matching results" for files that haven't already been opened. Navigate
- * the Files Explorer tree instead. `salesforcedx-vscode-services` also injects a `memfs:/MyProject`
- * workspace folder on web, but the tree navigation matches by path segment so it locates our
- * `force-app/.../snippetsE2E/*` files regardless of which workspace folder they live under.
+ * Quick Open returns "No matching results" for files that have not been opened. Navigate the
+ * Files Explorer tree instead.
  */
-const openSnippetsE2EFile = async (page: Page, fileName: 'snippetsE2E.html' | 'snippetsE2E.js'): Promise<void> => {
+const openLwcBundleFile = async (page: Page, bundleName: string, ext: 'html' | 'js'): Promise<void> => {
+  const fileName = ext === 'html' ? `${bundleName}.html` : `${bundleName}.js`;
   if (isDesktop) {
     await openFileByName(page, fileName);
     return;
   }
-  await openFileFromExplorerTree(page, fileName, ['force-app', 'main', 'default', 'lwc', 'snippetsE2E']);
+  await openFileFromExplorerTree(page, fileName, ['force-app', 'main', 'default', 'lwc', bundleName]);
 };
 
 /** Monaco may use NBSP; snippets can be one line or multiline — collapse for assertions. */
@@ -68,25 +103,35 @@ const dismissEditorOverlays = async (page: Page): Promise<void> => {
     .catch(() => {});
 };
 
-test('LWC snippets: Insert Snippet applies lwc-button in HTML', async ({ page }) => {
+test('LWC snippets: Insert Snippet applies lwc-button in HTML', async ({ page }, testInfo) => {
   test.setTimeout(120_000);
   const consoleErrors = setupConsoleMonitoring(page);
   const networkErrors = setupNetworkMonitoring(page);
+  const bundleName = isDesktop ? 'snippetsE2E' : `snippetsHtml${testInfo.workerIndex}${Date.now()}`;
 
   await test.step('wait for Salesforce project workspace', async () => {
     await waitForVSCodeWorkbench(page);
+    await assertWelcomeTabExists(page);
     await closeWelcomeTabs(page);
     await ensureSecondarySideBarHidden(page);
     await waitForWorkspaceReady(page);
     // salesforcedx-vscode-services creates a memfs:/MyProject workspace folder during activation.
-    // Wait until no extension shows "Activating" so file search providers (vscode-test-web-fs for
-    // our mount, memfs for the injected sample) are ready before Quick Open runs.
+    // Wait until no extension shows "Activating" so file search / indexing is ready before Quick Open runs.
     await waitForExtensionsActivated(page);
+    // Disable deploy-on-save AFTER the workspace folder is added so the setting persists to the correct workspace context.
+    await disableDeployOnSaveWeb(page);
     await saveScreenshot(page, 'lwc-snippets-html.workspace-ready.png');
   });
 
-  await test.step('open snippetsE2E.html', async () => {
-    await openSnippetsE2EFile(page, 'snippetsE2E.html');
+  await test.step('ensure LWC bundle exists (web: create via palette)', async () => {
+    if (!isDesktop) {
+      await createLwcBundleViaPalette(page, bundleName);
+      await saveScreenshot(page, 'lwc-snippets-html.after-create-lwc.png');
+    }
+  });
+
+  await test.step('open component HTML', async () => {
+    await openLwcBundleFile(page, bundleName, 'html');
     const editor = page.locator(EDITOR_WITH_URI).first();
     await editor.waitFor({ state: 'visible', timeout: 15_000 });
     await saveScreenshot(page, 'lwc-snippets-html.editor-open.png');
@@ -122,33 +167,35 @@ test('LWC snippets: Insert Snippet applies lwc-button in HTML', async ({ page })
   await validateNoCriticalErrors(test, consoleErrors, networkErrors);
 });
 
-test('LWC snippets: JS completion inserts lwc-event body', async ({ page }) => {
+test('LWC snippets: JS completion inserts lwc-event body', async ({ page }, testInfo) => {
   test.setTimeout(180_000);
   const consoleErrors = setupConsoleMonitoring(page);
   const networkErrors = setupNetworkMonitoring(page);
+  const bundleName = isDesktop ? 'snippetsE2E' : `snippetsJs${testInfo.workerIndex}${Date.now()}`;
 
   await test.step('wait for Salesforce project workspace', async () => {
     await waitForVSCodeWorkbench(page);
+    await assertWelcomeTabExists(page);
     await closeWelcomeTabs(page);
     await ensureSecondarySideBarHidden(page);
     await waitForWorkspaceReady(page);
     await waitForExtensionsActivated(page);
+    // Disable deploy-on-save AFTER the workspace folder is added so the setting persists to the correct workspace context.
+    await disableDeployOnSaveWeb(page);
     await saveScreenshot(page, 'lwc-snippets-js.workspace-ready.png');
   });
 
-  await test.step('open snippetsE2E.js and reload window for LWC language service', async () => {
-    await openSnippetsE2EFile(page, 'snippetsE2E.js');
-    const editor = page.locator(EDITOR_WITH_URI).first();
-    await editor.waitFor({ state: 'visible', timeout: 15_000 });
-    await executeCommandWithCommandPalette(page, 'Developer: Reload Window');
-    await page.locator(WORKBENCH).waitFor({ state: 'visible', timeout: 90_000 });
-    await closeWelcomeTabs(page);
-    await ensureSecondarySideBarHidden(page);
-    await waitForWorkspaceReady(page);
-    await waitForExtensionsActivated(page);
-    await openSnippetsE2EFile(page, 'snippetsE2E.js');
+  await test.step('ensure LWC bundle exists (web: create via palette)', async () => {
+    if (!isDesktop) {
+      await createLwcBundleViaPalette(page, bundleName);
+      await saveScreenshot(page, 'lwc-snippets-js.after-create-lwc.png');
+    }
+  });
+
+  await test.step('open component JS', async () => {
+    await openLwcBundleFile(page, bundleName, 'js');
     await page.locator(EDITOR_WITH_URI).first().waitFor({ state: 'visible', timeout: 20_000 });
-    await saveScreenshot(page, 'lwc-snippets-js.after-reload.png');
+    await saveScreenshot(page, 'lwc-snippets-js.after-open.png');
   });
 
   await test.step('type lwc prefix and accept lwc-event completion', async () => {

--- a/packages/salesforcedx-vscode-lwc/test/playwright/utils/createLwcTestWorkspace.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/utils/createLwcTestWorkspace.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/* Node fs/path: desktop fixture + headless server bootstrap only — not used from browser-driven web spec steps. */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+/** Seeded bundle content for `gtdHtmlComp` after **SFDX: Create Lightning Web Component** (replace template defaults). */
+export const LWC_GTD_HTML_COMP_SEED_JS = `import { LightningElement } from 'lwc';
+
+export default class Lwc1 extends LightningElement {
+    greeting = 'Hello, World!';
+}
+`;
+
+export const LWC_GTD_HTML_COMP_SEED_HTML = `<template>
+    <p>{greeting}</p>
+</template>
+`;
+
+/** Minimal `CustomLabels.labels-meta.xml` under scratch workspaces (optional metadata for LSP typings). */
+const LWC_E2E_SEED_CUSTOM_LABELS_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata">
+    <labels>
+        <fullName>LwcE2eSeedLabel</fullName>
+        <value>Seed value</value>
+    </labels>
+</CustomLabels>
+`;
+
+/** `force-app/main/default/lwc` + labels so the LSP can emit `customlabels.d.ts`; LWCs are created in tests via **SFDX: Create Lightning Web Component**. */
+export const seedLwcHeadlessWorkspaceSupplement = async (workspaceDir: string): Promise<void> => {
+  const lwcDir = path.join(workspaceDir, 'force-app', 'main', 'default', 'lwc');
+  await fs.mkdir(lwcDir, { recursive: true });
+  const labelsDir = path.join(workspaceDir, 'force-app', 'main', 'default', 'labels');
+  await fs.mkdir(labelsDir, { recursive: true });
+  await fs.writeFile(path.join(labelsDir, 'CustomLabels.labels-meta.xml'), LWC_E2E_SEED_CUSTOM_LABELS_XML);
+};
+
+/**
+ * Empty `snippetsE2E` bundle only — {@link ../specs/lwcSnippets.headless.spec.ts} opens these files before insert/completion;
+ * not created via SFDX to keep the HTML/JS bodies empty for snippet assertions.
+ */
+export const seedSnippetsE2eEmptyBundle = async (workspaceDir: string): Promise<void> => {
+  const bundleDir = path.join(workspaceDir, 'force-app', 'main', 'default', 'lwc', 'snippetsE2E');
+  await fs.mkdir(bundleDir, { recursive: true });
+  await Promise.all([
+    fs.writeFile(path.join(bundleDir, 'snippetsE2E.html'), '', 'utf8'),
+    fs.writeFile(path.join(bundleDir, 'snippetsE2E.js'), '', 'utf8')
+  ]);
+};
+

--- a/packages/salesforcedx-vscode-lwc/test/playwright/utils/lwcUtils.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/utils/lwcUtils.ts
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { expect, type Locator, type Page } from '@playwright/test';
+import {
+  DIRTY_EDITOR,
+  EDITOR_WITH_URI,
+  QUICK_INPUT_LIST_ROW,
+  QUICK_INPUT_WIDGET,
+  STATUS_BAR_ITEM_LABEL,
+  WORKBENCH,
+  closeWelcomeTabs,
+  ensureSecondarySideBarHidden,
+  executeCommandWithCommandPalette,
+  isDesktop,
+  openFileByName,
+  verifyCommandExists,
+  waitForQuickInputFirstOption
+} from '@salesforce/playwright-vscode-ext';
+import lwcPackageNls from '../../../package.nls.json';
+import { LWC_GTD_HTML_COMP_SEED_HTML, LWC_GTD_HTML_COMP_SEED_JS } from './createLwcTestWorkspace';
+
+/** Text shown in the LWC language status item when the LSP has finished indexing. */
+const LWC_LSP_READY_TEXT = 'Indexing complete';
+
+const replaceEditorContentAndSave = async (
+  page: Page,
+  editor: ReturnType<Page['locator']>,
+  content: string
+): Promise<void> => {
+  await editor.click();
+  await editor.locator('.view-line').first().waitFor({ state: 'visible', timeout: 5000 });
+  await executeCommandWithCommandPalette(page, 'Select All');
+  await page.keyboard.press('Delete');
+  await page.evaluate((t: string) => navigator.clipboard.writeText(t), content);
+  await executeCommandWithCommandPalette(page, 'Paste');
+  await executeCommandWithCommandPalette(page, 'File: Save');
+  await expect(page.locator(DIRTY_EDITOR).first(), 'editor should be saved (no dirty indicator)').not.toBeVisible({
+    timeout: 10_000
+  });
+};
+
+const pickNonStickyTreeItem = async (items: Locator, description: string): Promise<Locator> => {
+  const count = await items.count();
+  if (count === 0) {
+    throw new Error(`No Files Explorer tree item found for ${description}`);
+  }
+  for (let i = 0; i < count; i++) {
+    const candidate = items.nth(i);
+    const isSticky = await candidate.evaluate(el => el.classList.contains('monaco-tree-sticky-row'));
+    if (!isSticky) {
+      return candidate;
+    }
+  }
+  // Explorer sticky scrolling can duplicate rows; every visible match may be sticky. Prefer the last row (same idea as
+  // the multi-root `force-app` branch below) so expand/click still targets the real tree node.
+  return items.nth(count - 1);
+};
+
+/**
+ * Web / multi-root: expand a folder path in Files Explorer (`mount/` prefix when test-web presents that root).
+ * Reused for LWC bundles under `force-app/.../lwc` and for `.sfdx/typings/lwc` generated typings.
+ */
+const expandWebExplorerSegments = async (page: Page, pathSegments: string[]): Promise<void> => {
+  const segments = [...pathSegments];
+  const mountRows = page.getByRole('treeitem', { name: /^mount(\/|,|$)/ });
+  if ((await mountRows.count()) > 0) {
+    segments.unshift('mount');
+  }
+  for (const segment of segments) {
+    const escaped = segment.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const rows = page.getByRole('treeitem', { name: new RegExp(`^${escaped}(/|,|$)`) });
+    await rows.first().waitFor({ state: 'attached', timeout: 15_000 });
+    // Explorer re-renders rows (sticky scroll / virtualization); a locator can detach between wait and scroll.
+    // Re-resolve the row each attempt via expect().toPass().
+    await expect(async () => {
+      const rowCount = await rows.count();
+      let row: Locator;
+      if (segment === 'force-app' && segments[0] === 'mount' && rowCount > 1) {
+        const last = rows.nth(rowCount - 1);
+        row = (await last.evaluate(el => el.classList.contains('monaco-tree-sticky-row')))
+          ? await pickNonStickyTreeItem(rows, `"${segment}"`)
+          : last;
+      } else {
+        row = await pickNonStickyTreeItem(rows, `"${segment}"`);
+      }
+      await row.waitFor({ state: 'visible', timeout: 10_000 });
+      await row.scrollIntoViewIfNeeded();
+      const expanded = await row.getAttribute('aria-expanded');
+      if (expanded !== 'true') {
+        const twistie = row.locator('.monaco-tl-twistie').first();
+        const twistieCount = await twistie.count();
+        await (twistieCount > 0 ? twistie.click() : row.click());
+      }
+      await expect(row).toHaveAttribute('aria-expanded', 'true', { timeout: 10_000 });
+    }).toPass({ timeout: 45_000 });
+  }
+};
+
+/**
+ * LWC files sit under `force-app/main/default/lwc/<bundle>/`. Collapsed parents keep leaf rows out of the tree, so
+ * expand the path before single-clicking a file (web may use a `mount/` root; desktop opens the folder workspace).
+ */
+const expandExplorerPathToLwcFile = async (page: Page, fileName: string): Promise<void> => {
+  const dot = fileName.lastIndexOf('.');
+  const bundleDir = dot === -1 ? fileName : fileName.slice(0, dot);
+  await expandWebExplorerSegments(page, ['force-app', 'main', 'default', 'lwc', bundleDir]);
+};
+
+/**
+ * Single-click a leaf `treeitem` in web Files Explorer.
+ * Accessible names are often `filename` or `filename, …` (description suffix); match `^name(,|$)` like folder rows.
+ */
+const clickWebExplorerTreeitemExact = async (page: Page, fileName: string): Promise<void> => {
+  const escaped = fileName.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const allTreeItems = page.getByRole('treeitem', { name: new RegExp(`^${escaped}(,|$)`, 'i') });
+  await allTreeItems.first().waitFor({ state: 'attached', timeout: 15_000 });
+  await expect(async () => {
+    const n = await allTreeItems.count();
+    if (n === 0) {
+      throw new Error(`No Files Explorer tree item found for "${fileName}"`);
+    }
+    let toClick: Locator | undefined;
+    for (let i = 0; i < n; i++) {
+      const candidate = allTreeItems.nth(i);
+      const isSticky = await candidate.evaluate(el => el.classList.contains('monaco-tree-sticky-row'));
+      if (!isSticky) {
+        toClick = candidate;
+        break;
+      }
+    }
+    const row = toClick ?? allTreeItems.nth(n - 1);
+    await row.waitFor({ state: 'visible', timeout: 10_000 });
+    await row.scrollIntoViewIfNeeded();
+    await row.click({ timeout: 5000 });
+  }).toPass({ timeout: 45_000 });
+};
+
+/**
+ * On VS Code for Web, Quick Open often omits files that exist in Explorer until that file has been opened once
+ * from the tree (the file search index lags the Explorer view after SFDX create). Match manual workflow: single-click
+ * the file in Files Explorer so the editor opens reliably in E2E.
+ */
+const openLwcFileViaExplorer = async (page: Page, fileName: string): Promise<void> => {
+  await executeCommandWithCommandPalette(page, 'File: Focus on Files Explorer');
+  await expandExplorerPathToLwcFile(page, fileName);
+  await clickWebExplorerTreeitemExact(page, fileName);
+};
+
+/**
+ * Opens a file in the editor.
+ *
+ * Single-click in Files Explorer after expanding `force-app/.../lwc/<bundle>/` — **Go to File…** often misses
+ * newly created LWC files on both web and desktop until they are opened from the tree once.
+ */
+export const openLwcFile = async (page: Page, fileName: string): Promise<void> => {
+  await openLwcFileViaExplorer(page, fileName);
+  const editor = page.locator(`${EDITOR_WITH_URI}[data-uri*="${fileName}"]`);
+  await editor.waitFor({ state: 'visible', timeout: 15_000 });
+};
+
+/**
+ * Create bundles with **SFDX: Create Lightning Web Component** (same FS the UI uses), then open the `.js` editor.
+ */
+const createLwcViaSfdxCommand = async (page: Page, componentName: string): Promise<void> => {
+  const camelName = `${componentName[0].toLowerCase()}${componentName.slice(1)}`;
+  const jsFileName = `${camelName}.js`;
+
+  await closeWelcomeTabs(page);
+  await ensureSecondarySideBarHidden(page);
+  const createLwcCommand = lwcPackageNls.lightning_generate_lwc_text;
+  // Same wizard steps as `salesforcedx-vscode-metadata` `lwcGenerateComponent.headless.spec.ts`.
+  await verifyCommandExists(page, createLwcCommand, 120_000);
+  await executeCommandWithCommandPalette(page, createLwcCommand);
+  const quickInput = page.locator(QUICK_INPUT_WIDGET);
+  await quickInput.waitFor({ state: 'visible', timeout: 30_000 });
+
+  // Step 1 (optional): Select component type (JavaScript / TypeScript) — newer extension versions skip this picker.
+  const hasTypePicker = await quickInput
+    .locator(QUICK_INPUT_LIST_ROW)
+    .first()
+    .waitFor({ state: 'visible', timeout: 2000 })
+    .then(() => true)
+    .catch(() => false);
+  if (hasTypePicker) {
+    await page.keyboard.press('Enter');
+  }
+
+  // Step 2: Enter component name (SFDX: lowercase first letter, alphanumeric + underscores)
+  await quickInput.getByText(/Enter Lightning Web Component name/i).waitFor({ state: 'visible', timeout: 10_000 });
+  await page.keyboard.type(camelName);
+  await page.keyboard.press('Enter');
+
+  // Step 3: Select output directory (default)
+  await waitForQuickInputFirstOption(page, { optionVisibleTimeout: 15_000 });
+  await page.keyboard.press('Enter');
+
+  const jsEditor = page.locator(`${EDITOR_WITH_URI}[data-uri*="${jsFileName}"]`);
+  await jsEditor.waitFor({ state: 'visible', timeout: 45_000 });
+
+  if (componentName === 'gtdHtmlComp') {
+    await replaceEditorContentAndSave(page, jsEditor, LWC_GTD_HTML_COMP_SEED_JS);
+    await openLwcFile(page, `${camelName}.html`);
+    const htmlEditor = page.locator(`${EDITOR_WITH_URI}[data-uri*="${camelName}.html"]`);
+    await htmlEditor.waitFor({ state: 'visible', timeout: 15_000 });
+    await replaceEditorContentAndSave(page, htmlEditor, LWC_GTD_HTML_COMP_SEED_HTML);
+    await openLwcFile(page, jsFileName);
+    await jsEditor.waitFor({ state: 'visible', timeout: 10_000 });
+  }
+};
+
+/**
+ * Creates a Lightning Web Component via **SFDX: Create Lightning Web Component**, then opens its `.js` editor.
+ * Desktop and web use the same flow.
+ */
+export const createLwc = async (page: Page, componentName: string): Promise<void> => {
+  await createLwcViaSfdxCommand(page, componentName);
+};
+
+/**
+ * Waits for the LWC Language Server to finish indexing files.
+ * `createLanguageStatusItem` surfaces as the **Editor Language Status** control (status bar button), not `.statusbar-item-label`.
+ * Keep a fallback on the legacy label selector for older layouts.
+ */
+export const waitForLwcLspReady = async (page: Page, timeout = 90_000): Promise<void> => {
+  const editorLanguageStatus = page.locator(WORKBENCH).getByRole('button', { name: new RegExp(LWC_LSP_READY_TEXT) });
+  const legacyStatusBarLabel = page.locator(STATUS_BAR_ITEM_LABEL).filter({ hasText: LWC_LSP_READY_TEXT });
+  await expect(
+    editorLanguageStatus.or(legacyStatusBarLabel).first(),
+    `LWC LSP should show "${LWC_LSP_READY_TEXT}" when indexing is done`
+  ).toBeVisible({ timeout });
+};
+
+/**
+ * Filenames and first-line markers copied into `.sfdx/typings/lwc/` by the LWC language server on SFDX workspace init.
+ * Keep in sync with `writeTypings` in `@salesforce/salesforcedx-lightning-lsp-common` `baseContext.ts` and bundled
+ * sources under `packages/salesforcedx-vscode-lwc/resources/sfdx/typings/`.
+ */
+const LWC_SFDX_GENERATED_TYPINGS_EXPECTATIONS = [
+  { file: 'lds.d.ts', header: "declare module 'lightning/uiListApi'" },
+  { file: 'messageservice.d.ts', header: "declare module 'lightning/messageService'" },
+  { file: 'apex.d.ts', header: "declare module '@salesforce/apex'" },
+  { file: 'engine.d.ts', header: "declare module 'lwc'" },
+  { file: 'schema.d.ts', header: "declare module '@salesforce/schema'" }
+] as const;
+
+/**
+ * After indexing, assert each generated `.d.ts` exists and still declares the expected module (guards empty/corrupt copies).
+ */
+/** Open `.sfdx/indexes/lwc/custom-components.json` (LWC component index written by the language server). */
+export const openSfdxCustomComponentsJson = async (page: Page): Promise<void> => {
+  const fileName = 'custom-components.json';
+  await (isDesktop()
+    ? openFileByName(page, fileName)
+    : expect(async () => {
+        await executeCommandWithCommandPalette(page, 'File: Focus on Files Explorer');
+        await expandWebExplorerSegments(page, ['.sfdx', 'indexes', 'lwc']);
+        await clickWebExplorerTreeitemExact(page, fileName);
+      }).toPass({ timeout: 90_000 }));
+  await page.locator(`${EDITOR_WITH_URI}[data-uri*="${fileName}"]`).waitFor({ state: 'visible', timeout: 15_000 });
+};
+
+export const assertLwcSfdxTypingsGenerated = async (page: Page): Promise<void> => {
+  if (isDesktop()) {
+    for (const { file, header } of LWC_SFDX_GENERATED_TYPINGS_EXPECTATIONS) {
+      await openFileByName(page, file);
+      const editor = page.locator(`${EDITOR_WITH_URI}[data-uri*="${file}"]`);
+      await editor.waitFor({ state: 'visible', timeout: 15_000 });
+      await expect(editor.locator('.view-lines'), `generated typing ${file} should include ${header}`).toContainText(
+        header,
+        { timeout: 15_000 }
+      );
+    }
+    return;
+  }
+
+  await executeCommandWithCommandPalette(page, 'File: Focus on Files Explorer');
+  await expandWebExplorerSegments(page, ['.sfdx', 'typings', 'lwc']);
+  for (const { file, header } of LWC_SFDX_GENERATED_TYPINGS_EXPECTATIONS) {
+    await clickWebExplorerTreeitemExact(page, file);
+    const editor = page.locator(`${EDITOR_WITH_URI}[data-uri*="${file}"]`);
+    await editor.waitFor({ state: 'visible', timeout: 15_000 });
+    await expect(editor.locator('.view-lines'), `generated typing ${file} should include ${header}`).toContainText(
+      header,
+      { timeout: 15_000 }
+    );
+  }
+};
+
+/**
+ * Moves the editor cursor to a specific line and column using the Go to Line/Column command.
+ * Line and column are both 1-indexed.
+ */
+export const goToLineCol = async (page: Page, line: number, col: number): Promise<void> => {
+  await executeCommandWithCommandPalette(page, 'Go to Line/Column...');
+  const widget = page.locator(QUICK_INPUT_WIDGET);
+  await widget.waitFor({ state: 'visible', timeout: 5000 });
+  await page.keyboard.type(`${line}:${col}`);
+  await page.keyboard.press('Enter');
+  await widget.waitFor({ state: 'hidden', timeout: 5000 });
+};

--- a/packages/salesforcedx-vscode-lwc/test/playwright/utils/lwcWebScratchAuth.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/utils/lwcWebScratchAuth.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import type { Page } from '@playwright/test';
+import {
+  CODE_BUILDER_WEB_SECTION,
+  createDreamhouseOrg,
+  INSTANCE_URL_KEY,
+  ACCESS_TOKEN_KEY,
+  isDesktop,
+  upsertSettings,
+  waitForVSCodeWorkbench,
+  waitForWorkspaceReady
+} from '@salesforce/playwright-vscode-ext';
+
+/** Same keys as `salesforcedx-vscode-metadata` `src/constants.ts` (core owns push-or-deploy-on-save). */
+const CORE_CONFIG_SECTION = 'salesforcedx-vscode-core';
+const PUSH_OR_DEPLOY_ON_SAVE_ENABLED = 'push-or-deploy-on-save.enabled';
+
+/**
+ * VS Code for Web (Code Builder) does not use local CLI auth files. Injects scratch `instanceUrl` and `accessToken`
+ * via Settings (same as org-browser). We omit `salesforce-web-console.apiVersion`: SettingsService falls back to
+ * 64.0 when unset, and the Settings UI row for apiVersion is brittle across VS Code versions in headless web.
+ *
+ * With a real org token, **Deploy on Save** would run on every `File: Save` and surface conflict noise in the console
+ * (see metadata E2E: `deploySourcePath.headless.spec.ts`). Those messages fail `validateNoCriticalErrors`, so we turn
+ * deploy-on-save off here for all LWC web specs that use this helper.
+ *
+ * Local: reuse `orgBrowserDreamhouseTestOrg` or override with `DREAMHOUSE_ORG_ALIAS`. CI: provision the same org as org-browser E2E.
+ */
+export const applyLwcWebScratchAuth = async (page: Page): Promise<void> => {
+  if (isDesktop()) {
+    return;
+  }
+  const auth = await createDreamhouseOrg();
+  await waitForVSCodeWorkbench(page, true);
+  await waitForWorkspaceReady(page);
+  await upsertSettings(page, {
+    [`${CODE_BUILDER_WEB_SECTION}.${INSTANCE_URL_KEY}`]: auth.instanceUrl,
+    [`${CODE_BUILDER_WEB_SECTION}.${ACCESS_TOKEN_KEY}`]: auth.accessToken,
+    [`${CORE_CONFIG_SECTION}.${PUSH_OR_DEPLOY_ON_SAVE_ENABLED}`]: 'false'
+  });
+};

--- a/packages/salesforcedx-vscode-lwc/test/playwright/web/headlessServer.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/web/headlessServer.ts
@@ -5,24 +5,14 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import * as fs from 'node:fs/promises';
-import * as path from 'node:path';
+import { createHeadlessServer, setupSignalHandlers } from '@salesforce/playwright-vscode-ext';
 
-import { createHeadlessServer, createTestWorkspace, setupSignalHandlers } from '@salesforce/playwright-vscode-ext';
-
-const main = async (): Promise<void> => {
-  const dir = await createTestWorkspace(undefined);
-  const bundleDir = path.join(dir, 'force-app', 'main', 'default', 'lwc', 'snippetsE2E');
-  await fs.mkdir(bundleDir, { recursive: true });
-  await fs.writeFile(path.join(bundleDir, 'snippetsE2E.html'), '', 'utf8');
-  await fs.writeFile(path.join(bundleDir, 'snippetsE2E.js'), '', 'utf8');
-
-  await createHeadlessServer({
+if (require.main === module) {
+  void createHeadlessServer({
     extensionName: 'Lightning Web Components',
     callerDirname: __dirname,
-    folderPath: dir
+    /** **SFDX: Create Lightning Web Component** is contributed by the Metadata extension. */
+    additionalExtensionDirs: ['salesforcedx-vscode-metadata']
   });
   setupSignalHandlers();
-};
-
-void main();
+}

--- a/packages/salesforcedx-vscode-metadata/src/commands/createLwc.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/createLwc.ts
@@ -67,8 +67,8 @@ const determineComponentTemplate = Effect.fn('determineComponentTemplate')(funct
 export const createLwcCommand = Effect.fn('createLwcCommand')(function* (outputDirParam?: URI) {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const promptService = yield* api.services.PromptService;
-  const project = yield* api.services.ProjectService.getSfProject();
   const workspaceInfo = yield* api.services.WorkspaceService.getWorkspaceInfoOrThrow();
+  const project = yield* api.services.ProjectService.getSfProject();
 
   const template = yield* determineComponentTemplate(project);
   const componentName = yield* promptForComponentName();

--- a/packages/salesforcedx-vscode-metadata/src/shared/diff/diffTypes.ts
+++ b/packages/salesforcedx-vscode-metadata/src/shared/diff/diffTypes.ts
@@ -20,7 +20,7 @@ const isHashableUri = (u: unknown): u is HashableUri =>
 
 const HashableUriSchema = Schema.declare<HashableUri>(isHashableUri);
 
-export const DiffFilePairSchema = Schema.Struct({
+const DiffFilePairSchema = Schema.Struct({
   localUri: HashableUriSchema,
   remoteUri: HashableUriSchema,
   fileName: Schema.String

--- a/packages/salesforcedx-vscode-services/src/core/projectService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/projectService.ts
@@ -28,10 +28,24 @@ export class FailedToResolveSfProjectError extends Schema.TaggedError<FailedToRe
   }
 ) {}
 
-const setProjectOpenedContext = (value: boolean) =>
-  Effect.promise(() => vscode.commands.executeCommand('setContext', 'sf:project_opened', value)).pipe(
-    Effect.withSpan('setProjectOpenedContext', { attributes: { value } })
-  );
+const setProjectOpenedContext = (value: boolean, reason: string, extra?: Readonly<Record<string, unknown>>) =>
+  Effect.promise(async () => {
+    await vscode.commands.executeCommand('setContext', 'sf:project_opened', value);
+    const folders = vscode.workspace.workspaceFolders;
+    const first = folders?.[0];
+    const diagnostic = {
+      sf_project_opened: value,
+      reason,
+      workspaceFolderCount: folders?.length ?? 0,
+      firstFolderUri: first?.uri.toString(),
+      firstFolderScheme: first?.uri.scheme,
+      firstFolderFsPath: first?.uri.fsPath,
+      ...extra
+    };
+    console.info(
+      `[ProjectService] sf:project_opened context: ${JSON.stringify(diagnostic)} | "SFDX: Create Lightning Web Component" (sf.metadata.lightning.generate.lwc) is contributed by the Salesforce Metadata extension; command palette only requires sf:project_opened. If that command is still missing, Metadata is not running in this Extension Host. Explorer context menu also needs explorerResourceIsFolder and resourceFilename "lwc" (Developer: Inspect Context Keys on the lwc folder).`
+    );
+  }).pipe(Effect.withSpan('setProjectOpenedContext', { attributes: { value, reason } }));
 
 const resolveSfProject = (fsPath: string) =>
   Effect.tryPromise({
@@ -64,6 +78,47 @@ const CUSTOMOBJECTS_DIR = 'customObjects';
 const SOQLMETADATA_DIR = 'soqlMetadata';
 const TYPINGS_SEGMENTS = ['typings', 'lwc', 'sobjects'] as const;
 
+/** Playwright `vscode-test-web` mounts use `vscode-test-web://…`; `uri.fsPath` is `/`, so Node `SfProject.resolve` uses this marker (written by extension E2E headless servers before the web server starts). */
+const readVsCodeTestWebDiskRootMarker = Effect.promise(async (): Promise<string | undefined> => {
+  const folders = vscode.workspace.workspaceFolders;
+  if (!folders?.length || folders[0].uri.scheme !== 'vscode-test-web') {
+    return undefined;
+  }
+  const markerUri = vscode.Uri.joinPath(folders[0].uri, '.vscode', 'vscode-extension-test-disk-root.txt');
+  const { fs } = vscode.workspace;
+  if (typeof fs?.readFile !== 'function') {
+    return undefined;
+  }
+  // Jest may stub `readFile` as a no-op returning undefined; `Promise.resolve` normalizes non-Thenables.
+  return await Promise.resolve(fs.readFile(markerUri)).then(
+    buf => {
+      if (buf == null) {
+        return undefined;
+      }
+      const text = Buffer.from(buf).toString('utf8').trim();
+      return text.length > 0 ? text : undefined;
+    },
+    () => undefined
+  );
+}).pipe(Effect.withSpan('readVsCodeTestWebDiskRootMarker'));
+
+/** VS Code Web test mounts are not readable by Node `SfProject.resolve`; used when resolve fails on the disk key. */
+const workspaceRootSalesforceManifestExistsViaVscodeFs = Effect.promise(async (): Promise<boolean> => {
+  const folders = vscode.workspace.workspaceFolders;
+  if (!folders?.length) {
+    return false;
+  }
+  const uri = vscode.Uri.joinPath(folders[0].uri, 'sfdx-project.json');
+  const { fs } = vscode.workspace;
+  if (typeof fs?.stat !== 'function') {
+    return false;
+  }
+  return await Promise.resolve(fs.stat(uri)).then(
+    s => s != null && typeof s === 'object' && 'type' in s && s.type === vscode.FileType.File,
+    () => false
+  );
+}).pipe(Effect.withSpan('workspaceRootSalesforceManifestExistsViaVscodeFs'));
+
 export class ProjectService extends Effect.Service<ProjectService>()('ProjectService', {
   accessors: true,
   dependencies: [WorkspaceService.Default],
@@ -75,25 +130,39 @@ export class ProjectService extends Effect.Service<ProjectService>()('ProjectSer
       const workspaceDescription = yield* workspaceService.getWorkspaceInfo();
 
       if (workspaceDescription.isEmpty) {
-        yield* setProjectOpenedContext(false);
+        yield* setProjectOpenedContext(false, 'workspace_empty', {
+          cwd: workspaceDescription.cwd,
+          workspacePath: workspaceDescription.path
+        });
         return false;
       }
 
-      return yield* globalSfProjectCache.get(workspaceDescription.fsPath).pipe(
-        Effect.tap(() => setProjectOpenedContext(true)),
-        Effect.tapError(() => setProjectOpenedContext(false)),
+      const markerPath = yield* readVsCodeTestWebDiskRootMarker;
+      const cacheKey = markerPath ?? workspaceDescription.fsPath;
+
+      return yield* globalSfProjectCache.get(cacheKey).pipe(
+        Effect.tap(() => setProjectOpenedContext(true, 'workspace_non_empty')),
+        Effect.tapError(() => setProjectOpenedContext(false, 'workspace_empty')),
         Effect.map(() => true),
-        Effect.catchTag('FailedToResolveSfProjectError', () => Effect.succeed(false))
+        Effect.catchTag('FailedToResolveSfProjectError', () =>
+          Effect.gen(function* () {
+            const viaVscodeFs = yield* workspaceRootSalesforceManifestExistsViaVscodeFs;
+            yield* setProjectOpenedContext(viaVscodeFs, 'workspace_non_empty');
+            return viaVscodeFs;
+          })
+        )
       );
     });
 
     /** Get the SfProject instance for the workspace (fails if not a Salesforce project).  Side effect: sets the 'sf:project_opened' context to true or false */
     const getSfProject = Effect.fn('ProjectService.getSfProject')(function* () {
+      const markerPath = yield* readVsCodeTestWebDiskRootMarker;
       const workspacePath = (yield* workspaceService.getWorkspaceInfoOrThrow()).fsPath;
+      const cacheKey = markerPath ?? workspacePath;
       const project = yield* globalSfProjectCache
-        .get(workspacePath)
-        .pipe(Effect.tapError(() => setProjectOpenedContext(false)));
-      yield* setProjectOpenedContext(true);
+        .get(cacheKey)
+        .pipe(Effect.tapError(() => setProjectOpenedContext(false, 'workspace_empty')));
+      yield* setProjectOpenedContext(true, 'workspace_non_empty');
       return project;
     });
 
@@ -112,8 +181,7 @@ export class ProjectService extends Effect.Service<ProjectService>()('ProjectSer
               // Use URI.path which is normalized (always uses /) regardless of OS.
               // Compare case-insensitively: VS Code provides uppercase drive letters on
               // Windows (e.g. /C:/...) while vscode-uri normalizes to lowercase (/c:/...).
-              uri.path.toLowerCase().startsWith(`${dir.toLowerCase()}/`) ||
-              uri.path.toLowerCase() === dir.toLowerCase()
+              uri.path.toLowerCase().startsWith(`${dir.toLowerCase()}/`) || uri.path.toLowerCase() === dir.toLowerCase()
           )
       );
     });

--- a/packages/salesforcedx-vscode-services/src/core/schemas/traceFlagSchemas.ts
+++ b/packages/salesforcedx-vscode-services/src/core/schemas/traceFlagSchemas.ts
@@ -18,7 +18,7 @@ export const TraceFlagLogType = Schema.Literal('USER_DEBUG', 'DEVELOPER_LOG', 'C
 export type TraceFlagLogType = Schema.Schema.Type<typeof TraceFlagLogType>;
 
 /** Tooling API record shape from TraceFlag query. TracedEntityName is injected by getTraceFlags when resolving entity names. */
-export const ToolingTraceFlagRecordSchema = Schema.Struct({
+const ToolingTraceFlagRecordSchema = Schema.Struct({
   Id: Schema.String,
   LogType: TraceFlagLogType,
   StartDate: Schema.optional(NullableString),

--- a/packages/salesforcedx-vscode-services/src/index.ts
+++ b/packages/salesforcedx-vscode-services/src/index.ts
@@ -444,7 +444,13 @@ export { type ProjectService } from './core/projectService';
 export { type SdkLayerFor } from './observability/spans';
 export { type SettingsService } from './vscode/settingsService';
 export { type SettingsChangePubSub } from './vscode/settingsChangePubSub';
-export { DebugLevelItemSchema, TraceFlagItemStruct, TraceFlagLogType, type DebugLevelItem, type TraceFlagItem } from './core/schemas/traceFlagSchemas';
+export {
+  DebugLevelItemSchema,
+  TraceFlagItemStruct,
+  TraceFlagLogType,
+  type DebugLevelItem,
+  type TraceFlagItem
+} from './core/schemas/traceFlagSchemas';
 export { type TraceFlagService } from './core/traceFlagService';
 export { type WorkspaceService } from './vscode/workspaceService';
 export type { UserCancellationError } from './vscode/prompts/promptService';

--- a/packages/salesforcedx-vscode-services/src/vscode/workspaceService.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/workspaceService.ts
@@ -55,11 +55,6 @@ const getWorkspaceInfoTask = Effect.sync((): WorkspaceInfo => {
   Effect.withSpan('getWorkspaceInfoTask')
 );
 
-// Global cached workspace info - created once at module level.  Only used on web, since ws can change on desktop
-const globalCachedWorkspaceInfo = Effect.runSync(
-  Effect.cached(getWorkspaceInfoTask).pipe(Effect.withSpan('getWorkspaceInfo'))
-);
-
 const isNonEmptyWorkspace = (info: WorkspaceInfo): info is WorkspaceWithFolder => !info.isEmpty;
 
 export class NoWorkspaceOpenError extends Schema.TaggedError<NoWorkspaceOpenError>()('NoWorkspaceOpenError', {
@@ -71,13 +66,15 @@ export class WorkspaceService extends Effect.Service<WorkspaceService>()('Worksp
   effect: Effect.gen(function* () {
     /** Get info about the workspace */
     const getWorkspaceInfo = Effect.fn('WorkspaceService.getWorkspaceInfo')(function* () {
-      return process.env.ESBUILD_PLATFORM === 'web' ? yield* globalCachedWorkspaceInfo : yield* getWorkspaceInfoTask;
+      // Always read `vscode.workspace.workspaceFolders` fresh. Cached workspace info on web poisoned the first
+      // value when the memo ran before `vscode-test-web` mounted the folder (empty / wrong `fsPath`), breaking
+      // `sf:project_opened` and commands such as **SFDX: Create Lightning Web Component** in Playwright web E2E.
+      return yield* getWorkspaceInfoTask;
     });
 
     /** GetWorkspaceInfo, throws if there is not one open */
     const getWorkspaceInfoOrThrow = Effect.fn('WorkspaceService.getWorkspaceInfoOrThrow')(function* () {
-      const info =
-        process.env.ESBUILD_PLATFORM === 'web' ? yield* globalCachedWorkspaceInfo : yield* getWorkspaceInfoTask;
+      const info = yield* getWorkspaceInfoTask;
       return yield* isNonEmptyWorkspace(info)
         ? Effect.succeed(info)
         : Effect.fail(new NoWorkspaceOpenError({ message: 'No workspace is currently open' }));


### PR DESCRIPTION
…overage - W-22187438

  Add six new headless Playwright specs covering LWC language server features
  (indexing, SFDX typings generation, autocompletion, go-to-definition for HTML
  and JS, and custom components index). Include CI workflow
  (lwcPlaywrightE2E.yml), shared test utilities (lwcUtils.ts,
  createLwcTestWorkspace.ts, lwcWebScratchAuth.ts), and all supporting
  changes to playwright-vscode-ext, salesforcedx-lwc-language-server, and
  salesforcedx-vscode-services needed to make both web and desktop runs stable.

  Key fixes bundled with the new specs:
  - VS Code 1.117.0 Quick Open format change: pass leaf filename only to openFileByName so openSfdxCustomComponentsJson and assertLwcSfdxTypingsGenerated resolve correctly on desktop
  - TS 6.x Go-to-Definition behaviour: hover over the LightningElement import token to force type resolution, then Meta+click; wait for the hover tooltip to confirm TS is ready before navigation fires (fixes flakiness under parallel test load)
  - SFDX Create LWC wizard: handle optional component-type picker introduced in newer extension versions using QUICK_INPUT_LIST_ROW locator
  - lwcSnippets web stability: remove unreliable window reload; use deploy-on-save timing instead

<!--- PR title: <type>(optional scope): <description> - W-XXXXXXXX — append GUS work item at the end (space, hyphen, space, W-). Conventional commits: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?

### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @<Insert GUS WI>@

### Functionality Before
<insert gif and/or summary>

### Functionality After
<insert gif and/or summary>
