### PR TITLE
fix(perf): improve performance for apex test refresh after large deploy - W-22281000

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46693,7 +46693,8 @@
         "vscode-uri": "^3.1.0"
       },
       "devDependencies": {
-        "@salesforce/playwright-vscode-ext": "*"
+        "@salesforce/playwright-vscode-ext": "*",
+        "salesforcedx-vscode-services": "*"
       },
       "engines": {
         "vscode": "^1.90.0"

--- a/packages/salesforcedx-vscode-apex-testing/package.json
+++ b/packages/salesforcedx-vscode-apex-testing/package.json
@@ -35,7 +35,8 @@
     "vscode-uri": "^3.1.0"
   },
   "devDependencies": {
-    "@salesforce/playwright-vscode-ext": "*"
+    "@salesforce/playwright-vscode-ext": "*",
+    "salesforcedx-vscode-services": "*"
   },
   "extensionDependencies": [
     "salesforce.salesforcedx-vscode-services"

--- a/packages/salesforcedx-vscode-apex-testing/package.json
+++ b/packages/salesforcedx-vscode-apex-testing/package.json
@@ -69,7 +69,8 @@
         "../salesforcedx-utils:compile",
         "../salesforcedx-utils-vscode:compile",
         "../salesforcedx-vscode-i18n:compile",
-        "../effect-ext-utils:compile"
+        "../effect-ext-utils:compile",
+        "../salesforcedx-vscode-services:compile"
       ],
       "files": [
         "src/**/*.ts",

--- a/packages/salesforcedx-vscode-apex-testing/src/watchers/apexMetadataChangeWatcher.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/watchers/apexMetadataChangeWatcher.ts
@@ -9,6 +9,7 @@ import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import * as Duration from 'effect/Duration';
 import * as Effect from 'effect/Effect';
 import * as Option from 'effect/Option';
+import * as Ref from 'effect/Ref';
 import * as Stream from 'effect/Stream';
 import type { MetadataChangeEventType } from 'salesforcedx-vscode-services';
 import { IS_TEST_REG_EXP } from '../constants';
@@ -34,12 +35,19 @@ export const setupApexMetadataChangeWatcher = Effect.fn('apex-testing.watchApexM
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const notificationService = yield* api.services.MetadataChangeNotificationService;
 
+  // once any event passes filterApexTests, skip file reads for the rest of the burst
+  const willRefresh = yield* Ref.make(false);
+
   yield* Stream.fromPubSub(notificationService.pubsub).pipe(
+    // once one event passes filterApexTests, drop everything until refresh completes
+    Stream.filterEffect(() => Effect.map(Ref.get(willRefresh), v => !v)),
     Stream.filter(e => APEX_METADATA_TYPES.has(e.metadataType)),
     Stream.filter(e => APEX_CHANGE_TYPES.has(e.changeType)),
-    // let's filter out any local files that changed but are not apex tests
-    Stream.filterEffect(filterApexTests),
+    Stream.filterEffect(e =>
+      filterApexTests(e).pipe(Effect.tap(pass => (pass ? Ref.set(willRefresh, true) : Effect.void)))
+    ),
     Stream.debounce(Duration.millis(1000)),
+    Stream.tap(() => Ref.set(willRefresh, false)),
     Stream.runForEach(() => Effect.promise(() => testController.discoverTests()))
   );
 });

--- a/packages/salesforcedx-vscode-apex-testing/test/jest/watchers/apexMetadataChangeWatcher.test.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/jest/watchers/apexMetadataChangeWatcher.test.ts
@@ -6,7 +6,6 @@
  */
 
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
-import * as Context from 'effect/Context';
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
 import * as Option from 'effect/Option';
@@ -15,10 +14,9 @@ import * as Scope from 'effect/Scope';
 import * as TestClock from 'effect/TestClock';
 import * as TestContext from 'effect/TestContext';
 import { MetadataChangeNotificationService, type MetadataChangeEventType } from 'salesforcedx-vscode-services';
+import { FsService } from 'salesforcedx-vscode-services/src/vscode/fsService';
 import { URI } from 'vscode-uri';
 import { setupApexMetadataChangeWatcher } from '../../../src/watchers/apexMetadataChangeWatcher';
-
-const FsServiceTag = Context.GenericTag<{ readFile: (uri: unknown) => Effect.Effect<string> }>('FsService');
 
 const APEX_TEST_CONTENT = '@isTest\npublic class MyTest {}';
 const NON_TEST_CONTENT = 'public class MyClass {}';
@@ -37,7 +35,7 @@ const makeEvent = (
 /**
  * `replay: 16` lets us publish before the watcher subscribes; the subscriber receives buffered events.
  * `forkScoped` ties the watcher fiber to the test's scope so it's interrupted on test exit.
- * `TestClock.adjust` already calls `awaitSuspended` internally, so no manual fiber-yield flushing is needed.
+ * `TestClock.adjust` runs actions scheduled on or before the adjusted time.
  */
 const setupHarness = Effect.fn('setupHarness')(function* (readFileResponses: Map<string, string> = new Map()) {
   const pubsub = yield* PubSub.unbounded<MetadataChangeEventType>({ replay: 16 });
@@ -47,20 +45,19 @@ const setupHarness = Effect.fn('setupHarness')(function* (readFileResponses: Map
   const readFileFn = jest.fn((uri: unknown) => Effect.succeed(readFileResponses.get(String(uri)) ?? NON_TEST_CONTENT));
 
   const notificationLayer = Layer.succeed(MetadataChangeNotificationService, { pubsub } as any);
-  const fsLayer = Layer.succeed(FsServiceTag, { readFile: readFileFn });
+  const fsLayer = Layer.succeed(FsService, { readFile: readFileFn } as unknown as InstanceType<typeof FsService>);
   const extensionProviderLayer = Layer.succeed(ExtensionProviderService, {
     getServicesApi: Effect.succeed({
       services: {
         MetadataChangeNotificationService,
-        FsService: FsServiceTag
+        FsService
       }
     })
   } as any);
 
-  // FsServiceTag identifier matches the real FsService at runtime, but TS sees them as different
   const provided = setupApexMetadataChangeWatcher(testController).pipe(
     Effect.provide(Layer.mergeAll(notificationLayer, fsLayer, extensionProviderLayer))
-  ) as unknown as Effect.Effect<void>;
+  );
   yield* Effect.forkScoped(provided);
 
   return { pubsub, discoverTests, readFileFn };
@@ -79,6 +76,8 @@ describe('setupApexMetadataChangeWatcher', () => {
         const { pubsub, discoverTests } = yield* setupHarness(responses);
 
         yield* PubSub.publish(pubsub, makeEvent({ metadataType: 'ApexClass' }));
+        expect(discoverTests).not.toHaveBeenCalled();
+
         yield* advance;
 
         expect(discoverTests).toHaveBeenCalledTimes(1);

--- a/packages/salesforcedx-vscode-apex-testing/test/jest/watchers/apexMetadataChangeWatcher.test.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/jest/watchers/apexMetadataChangeWatcher.test.ts
@@ -13,7 +13,10 @@ import * as PubSub from 'effect/PubSub';
 import * as Scope from 'effect/Scope';
 import * as TestClock from 'effect/TestClock';
 import * as TestContext from 'effect/TestContext';
-import { MetadataChangeNotificationService, type MetadataChangeEventType } from 'salesforcedx-vscode-services';
+import {
+  MetadataChangeNotificationService,
+  type MetadataChangeEvent as MetadataChangeEventType
+} from 'salesforcedx-vscode-services/src/core/metadataChangeNotificationService';
 import { FsService } from 'salesforcedx-vscode-services/src/vscode/fsService';
 import { URI } from 'vscode-uri';
 import { setupApexMetadataChangeWatcher } from '../../../src/watchers/apexMetadataChangeWatcher';

--- a/packages/salesforcedx-vscode-apex-testing/test/jest/watchers/apexMetadataChangeWatcher.test.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/jest/watchers/apexMetadataChangeWatcher.test.ts
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
+import * as Context from 'effect/Context';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+import * as Option from 'effect/Option';
+import * as PubSub from 'effect/PubSub';
+import * as Scope from 'effect/Scope';
+import * as TestClock from 'effect/TestClock';
+import * as TestContext from 'effect/TestContext';
+import { MetadataChangeNotificationService, type MetadataChangeEventType } from 'salesforcedx-vscode-services';
+import { URI } from 'vscode-uri';
+import { setupApexMetadataChangeWatcher } from '../../../src/watchers/apexMetadataChangeWatcher';
+
+const FsServiceTag = Context.GenericTag<{ readFile: (uri: unknown) => Effect.Effect<string> }>('FsService');
+
+const APEX_TEST_CONTENT = '@isTest\npublic class MyTest {}';
+const NON_TEST_CONTENT = 'public class MyClass {}';
+
+const DEBOUNCE_PLUS_MARGIN = '1100 millis';
+
+const makeEvent = (
+  overrides: Partial<MetadataChangeEventType> & Pick<MetadataChangeEventType, 'metadataType'>
+): MetadataChangeEventType => ({
+  metadataType: overrides.metadataType,
+  fullName: overrides.fullName ?? 'MyClass',
+  changeType: overrides.changeType ?? 'changed',
+  fileUri: overrides.fileUri ?? Option.some(URI.file('/tmp/MyClass.cls'))
+});
+
+/**
+ * `replay: 16` lets us publish before the watcher subscribes; the subscriber receives buffered events.
+ * `forkScoped` ties the watcher fiber to the test's scope so it's interrupted on test exit.
+ * `TestClock.adjust` already calls `awaitSuspended` internally, so no manual fiber-yield flushing is needed.
+ */
+const setupHarness = Effect.fn('setupHarness')(function* (readFileResponses: Map<string, string> = new Map()) {
+  const pubsub = yield* PubSub.unbounded<MetadataChangeEventType>({ replay: 16 });
+  const discoverTests = jest.fn(() => Promise.resolve());
+  const testController = { discoverTests } as unknown as Parameters<typeof setupApexMetadataChangeWatcher>[0];
+
+  const readFileFn = jest.fn((uri: unknown) => Effect.succeed(readFileResponses.get(String(uri)) ?? NON_TEST_CONTENT));
+
+  const notificationLayer = Layer.succeed(MetadataChangeNotificationService, { pubsub } as any);
+  const fsLayer = Layer.succeed(FsServiceTag, { readFile: readFileFn });
+  const extensionProviderLayer = Layer.succeed(ExtensionProviderService, {
+    getServicesApi: Effect.succeed({
+      services: {
+        MetadataChangeNotificationService,
+        FsService: FsServiceTag
+      }
+    })
+  } as any);
+
+  // FsServiceTag identifier matches the real FsService at runtime, but TS sees them as different
+  const provided = setupApexMetadataChangeWatcher(testController).pipe(
+    Effect.provide(Layer.mergeAll(notificationLayer, fsLayer, extensionProviderLayer))
+  ) as unknown as Effect.Effect<void>;
+  yield* Effect.forkScoped(provided);
+
+  return { pubsub, discoverTests, readFileFn };
+});
+
+const advance = TestClock.adjust(DEBOUNCE_PLUS_MARGIN);
+
+const runTest = <A>(effect: Effect.Effect<A, unknown, Scope.Scope>) =>
+  Effect.runPromise(effect.pipe(Effect.scoped, Effect.provide(TestContext.TestContext)));
+
+describe('setupApexMetadataChangeWatcher', () => {
+  it('calls discoverTests after debounce when an apex test event arrives', () =>
+    runTest(
+      Effect.gen(function* () {
+        const responses = new Map([[URI.file('/tmp/MyClass.cls').toString(), APEX_TEST_CONTENT]]);
+        const { pubsub, discoverTests } = yield* setupHarness(responses);
+
+        yield* PubSub.publish(pubsub, makeEvent({ metadataType: 'ApexClass' }));
+        yield* advance;
+
+        expect(discoverTests).toHaveBeenCalledTimes(1);
+      })
+    ));
+
+  it('does not call discoverTests for non-apex metadata types', () =>
+    runTest(
+      Effect.gen(function* () {
+        const { pubsub, discoverTests } = yield* setupHarness();
+
+        yield* PubSub.publish(pubsub, makeEvent({ metadataType: 'LightningComponentBundle' }));
+        yield* advance;
+
+        expect(discoverTests).not.toHaveBeenCalled();
+      })
+    ));
+
+  it('does not call discoverTests for non-apex change types', () =>
+    runTest(
+      Effect.gen(function* () {
+        const { pubsub, discoverTests } = yield* setupHarness();
+
+        yield* PubSub.publish(
+          pubsub,
+          makeEvent({ metadataType: 'ApexClass', changeType: 'unchanged' as MetadataChangeEventType['changeType'] })
+        );
+        yield* advance;
+
+        expect(discoverTests).not.toHaveBeenCalled();
+      })
+    ));
+
+  it('does not read files for deleted events but still triggers discoverTests', () =>
+    runTest(
+      Effect.gen(function* () {
+        const { pubsub, readFileFn, discoverTests } = yield* setupHarness();
+
+        yield* PubSub.publish(pubsub, makeEvent({ metadataType: 'ApexClass', changeType: 'deleted' }));
+        yield* advance;
+
+        expect(readFileFn).not.toHaveBeenCalled();
+        expect(discoverTests).toHaveBeenCalledTimes(1);
+      })
+    ));
+
+  it('does not read files for ApexTestSuite events but still triggers discoverTests', () =>
+    runTest(
+      Effect.gen(function* () {
+        const { pubsub, readFileFn, discoverTests } = yield* setupHarness();
+
+        yield* PubSub.publish(pubsub, makeEvent({ metadataType: 'ApexTestSuite' }));
+        yield* advance;
+
+        expect(readFileFn).not.toHaveBeenCalled();
+        expect(discoverTests).toHaveBeenCalledTimes(1);
+      })
+    ));
+
+  it('skips file reads after first passing event in a burst', () =>
+    runTest(
+      Effect.gen(function* () {
+        const testUri = URI.file('/tmp/TestClass.cls');
+        const nonTestUri = URI.file('/tmp/Helper.cls');
+        const responses = new Map([[testUri.toString(), APEX_TEST_CONTENT]]);
+        const { pubsub, readFileFn, discoverTests } = yield* setupHarness(responses);
+
+        yield* PubSub.publish(pubsub, makeEvent({ metadataType: 'ApexClass', fileUri: Option.some(testUri) }));
+        yield* PubSub.publish(pubsub, makeEvent({ metadataType: 'ApexClass', fileUri: Option.some(nonTestUri) }));
+        yield* advance;
+
+        expect(readFileFn).toHaveBeenCalledTimes(1);
+        expect(discoverTests).toHaveBeenCalledTimes(1);
+      })
+    ));
+
+  it('resets the willRefresh ref after refresh so subsequent bursts are processed', () =>
+    runTest(
+      Effect.gen(function* () {
+        const testUri = URI.file('/tmp/TestClass.cls');
+        const responses = new Map([[testUri.toString(), APEX_TEST_CONTENT]]);
+        const { pubsub, discoverTests } = yield* setupHarness(responses);
+
+        yield* PubSub.publish(pubsub, makeEvent({ metadataType: 'ApexClass', fileUri: Option.some(testUri) }));
+        yield* advance;
+        expect(discoverTests).toHaveBeenCalledTimes(1);
+
+        yield* PubSub.publish(pubsub, makeEvent({ metadataType: 'ApexClass', fileUri: Option.some(testUri) }));
+        yield* advance;
+        expect(discoverTests).toHaveBeenCalledTimes(2);
+      })
+    ));
+
+  it('does not call discoverTests when no events pass the apex test filter', () =>
+    runTest(
+      Effect.gen(function* () {
+        const { pubsub, discoverTests } = yield* setupHarness();
+
+        yield* PubSub.publish(pubsub, makeEvent({ metadataType: 'ApexClass' }));
+        yield* advance;
+
+        expect(discoverTests).not.toHaveBeenCalled();
+      })
+    ));
+});


### PR DESCRIPTION
### What does this PR do?

After a large deploy, metadata change events flood the apex test watcher. Each event triggered `filterApexTests` (file reads), causing a burst of redundant work before any refresh ran.

Uses a `Ref` to short-circuit: once one event passes the filter, remaining burst events skip the file-read check entirely. The ref resets after the refresh completes.

### What issues does this PR fix or reference?

@W-22281000@

### Functionality Before

Large deploy → hundreds of `filterApexTests` file reads, one per changed file.

### Functionality After

Large deploy → at most one `filterApexTests` read per burst; all subsequent events in the burst are dropped without file I/O.

Made with [Cursor](https://cursor.com)