### PR TITLE
W-21981771: Use workflow_call to trigger CBW release after publish

### DIFF
--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -126,4 +126,3 @@ jobs:
       extensions: ${{ needs.publish.outputs.extensions }}
       version: ${{ needs.prepare-environment-from-main.outputs.RELEASE_VERSION }}
       release-type: ${{ needs.prepare-environment-from-main.outputs.CBW_RELEASE_TYPE }}
-    secrets: inherit

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Collect published extension names
         id: collect-extensions
         run: |
-          NAMES=$(node scripts/collect-extension-names.js ./extensions)
+          NAMES=$(node scripts/parse-extension-names.js ./extensions)
           echo "names=$NAMES" >> "$GITHUB_OUTPUT"
           echo "Published extensions: $NAMES"
       - uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -87,16 +87,7 @@ jobs:
       - name: Collect published extension names
         id: collect-extensions
         run: |
-          NAMES=$(node -e "
-            const fs = require('fs');
-            const names = fs.readdirSync('./extensions')
-              .filter(f => f.endsWith('.vsix'))
-              .map(f => f.replace(/-\d+\.\d+\.\d+\.vsix$/, ''))
-              .filter((v, i, a) => a.indexOf(v) === i)
-              .sort()
-              .join(',');
-            process.stdout.write(names);
-          ")
+          NAMES=$(node scripts/collect-extension-names.js ./extensions)
           echo "names=$NAMES" >> "$GITHUB_OUTPUT"
           echo "Published extensions: $NAMES"
       - uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -63,6 +63,8 @@ jobs:
   publish:
     needs: ['ctc-open', 'prepare-environment-from-main']
     runs-on: ubuntu-latest
+    outputs:
+      extensions: ${{ steps.collect-extensions.outputs.names }}
     env:
       VSCE_PERSONAL_ACCESS_TOKEN: ${{ secrets.VSCE_PERSONAL_ACCESS_TOKEN }}
       PUBLISH_VERSION: ${{ needs.prepare-environment-from-main.outputs.RELEASE_VERSION }}
@@ -82,6 +84,21 @@ jobs:
           gh release download v${{ env.PUBLISH_VERSION }} -D ./extensions
       - name: Display downloaded vsix files
         run: ls -R ./extensions
+      - name: Collect published extension names
+        id: collect-extensions
+        run: |
+          NAMES=$(node -e "
+            const fs = require('fs');
+            const names = fs.readdirSync('./extensions')
+              .filter(f => f.endsWith('.vsix'))
+              .map(f => f.replace(/-\d+\.\d+\.\d+\.vsix$/, ''))
+              .filter((v, i, a) => a.indexOf(v) === i)
+              .sort()
+              .join(',');
+            process.stdout.write(names);
+          ")
+          echo "names=$NAMES" >> "$GITHUB_OUTPUT"
+          echo "Published extensions: $NAMES"
       - uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
       - name: Validate VSIX OPC Part URIs
         run: node scripts/validate-vsix-opc.mjs ./extensions
@@ -108,24 +125,14 @@ jobs:
       status: Not Implemented
 
   # Set repo variable CBW_TRIGGER_ENABLED=false to disable dispatch to code-builder-web.
-  # Default (unset): dispatch after publish. Use when publishing without CBW promotion.
+  # Default (unset): trigger CBW release after publish. Use when publishing without CBW promotion.
   trigger-cbw-release:
     needs: [publish, prepare-environment-from-main]
     if: needs.publish.result == 'success' && vars.CBW_TRIGGER_ENABLED != 'false'
     continue-on-error: true
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger Code Builder Web release
-        env:
-          GH_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
-        run: |
-          VERSION="${{ needs.prepare-environment-from-main.outputs.RELEASE_VERSION }}"
-          RELEASE_TYPE="${{ needs.prepare-environment-from-main.outputs.CBW_RELEASE_TYPE }}"
-          echo "Dispatching extension-publish event to code-builder-web with version $VERSION (release-type: $RELEASE_TYPE)"
-          gh api repos/forcedotcom/code-builder-web/dispatches \
-            --method POST \
-            -f event_type=extension-publish \
-            -f "client_payload[version]=$VERSION" \
-            -f "client_payload[source]=publishVSCode" \
-            -f "client_payload[release_type]=$RELEASE_TYPE"
-          echo "Dispatch sent successfully"
+    uses: forcedotcom/code-builder-web/.github/workflows/release-on-extension-publish.yml@main
+    with:
+      extensions: ${{ needs.publish.outputs.extensions }}
+      version: ${{ needs.prepare-environment-from-main.outputs.RELEASE_VERSION }}
+      release-type: ${{ needs.prepare-environment-from-main.outputs.CBW_RELEASE_TYPE }}
+    secrets: inherit

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -120,7 +120,6 @@ jobs:
   trigger-cbw-release:
     needs: [publish, prepare-environment-from-main]
     if: needs.publish.result == 'success' && vars.CBW_TRIGGER_ENABLED != 'false'
-    continue-on-error: true
     uses: forcedotcom/code-builder-web/.github/workflows/release-on-extension-publish.yml@main
     with:
       extensions: ${{ needs.publish.outputs.extensions }}

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -126,3 +126,4 @@ jobs:
       extensions: ${{ needs.publish.outputs.extensions }}
       version: ${{ needs.prepare-environment-from-main.outputs.RELEASE_VERSION }}
       release-type: ${{ needs.prepare-environment-from-main.outputs.CBW_RELEASE_TYPE }}
+    secrets: inherit

--- a/scripts/collect-extension-names.js
+++ b/scripts/collect-extension-names.js
@@ -25,12 +25,14 @@ if (!dir) {
 // digits that are part of the extension name itself (e.g. "vscode-i18n").
 const VSIX_VERSION_SUFFIX = /-\d+\.\d+\.\d+\.vsix$/;
 
-const names = fs
-  .readdirSync(dir)
-  .filter(f => f.endsWith('.vsix'))
-  .map(f => f.replace(VSIX_VERSION_SUFFIX, ''))
-  .filter((v, i, a) => a.indexOf(v) === i)
-  .sort();
+const names = [
+  ...new Set(
+    fs
+      .readdirSync(dir)
+      .filter(filename => filename.endsWith('.vsix'))
+      .map(filename => filename.replace(VSIX_VERSION_SUFFIX, ''))
+  )
+].sort();
 
 if (names.length === 0) {
   console.error(`No .vsix files found in ${dir}`);

--- a/scripts/collect-extension-names.js
+++ b/scripts/collect-extension-names.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+/**
+ * Extract extension names from VSIX filenames in a directory.
+ *
+ * Usage: node scripts/collect-extension-names.js <directory>
+ *
+ * VSIX files follow the naming convention: <extension-name>-<semver>.vsix
+ * For example: salesforcedx-vscode-apex-log-66.5.2.vsix → salesforcedx-vscode-apex-log
+ *
+ * Outputs a comma-separated list of unique extension names to stdout.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const dir = process.argv[2];
+if (!dir) {
+  console.error('Usage: node collect-extension-names.js <directory>');
+  process.exit(1);
+}
+
+// Match a dash followed by a semver (digits.digits.digits) at the end of the
+// filename before .vsix. This strips the version suffix while preserving any
+// digits that are part of the extension name itself (e.g. "vscode-i18n").
+const VSIX_VERSION_SUFFIX = /-\d+\.\d+\.\d+\.vsix$/;
+
+const names = fs
+  .readdirSync(dir)
+  .filter(f => f.endsWith('.vsix'))
+  .map(f => f.replace(VSIX_VERSION_SUFFIX, ''))
+  .filter((v, i, a) => a.indexOf(v) === i)
+  .sort();
+
+if (names.length === 0) {
+  console.error(`No .vsix files found in ${dir}`);
+  process.exit(1);
+}
+
+process.stdout.write(names.join(','));

--- a/scripts/parse-extension-names.js
+++ b/scripts/parse-extension-names.js
@@ -3,7 +3,7 @@
 /**
  * Extract extension names from VSIX filenames in a directory.
  *
- * Usage: node scripts/collect-extension-names.js <directory>
+ * Usage: node scripts/parse-extension-names.js <directory>
  *
  * VSIX files follow the naming convention: <extension-name>-<semver>.vsix
  * For example: salesforcedx-vscode-apex-log-66.5.2.vsix → salesforcedx-vscode-apex-log
@@ -16,7 +16,7 @@ const path = require('path');
 
 const dir = process.argv[2];
 if (!dir) {
-  console.error('Usage: node collect-extension-names.js <directory>');
+  console.error('Usage: node parse-extension-names.js <directory>');
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
@W-21981771@

- Replace `repository_dispatch` API call with `uses:` syntax to call `release-on-extension-publish.yml` in `code-builder-web`
- Add `scripts/parse-extension-names.js` to extract published extension names from VSIX filenames and pass them as `workflow_call` inputs — CBW filters to only the extensions it bundles
- Determine CBW release type (patch vs minor) by comparing the current version tag against the previous one

### Dependency
- Depends on forcedotcom/code-builder-web#76 (must be merged first — provides the `release-on-extension-publish.yml` workflow)

## Test plan
- [ ] Verify script extracts correct names: `echo "salesforcedx-vscode-apex-log-66.5.2.vsix" > /tmp/test && node scripts/parse-extension-names.js /tmp/test`
- [ ] End-to-end: after both PRs merge, next extension publish triggers CBW release via `uses:` and only polls bundled extensions