### PR TITLE
ci: validate github actions workflows on PR - W-22294861

### DIFF
--- a/.claude/skills/verification/SKILL.md
+++ b/.claude/skills/verification/SKILL.md
@@ -11,6 +11,8 @@ Run this **only if the stop hook doesn't catch it**:
 
 1. **Dupes** — `npm run check:dupes`, check `jscpd-report` for flagged changes
 
+2. **GitHub Actions** (only if changing `.github/workflows/*.yml` or `.github/actions/*/action.yml`) — `npm run check:actions`
+
 3. **Playwright** (only if working in these packages: `salesforcedx-vscode-core`, `salesforcedx-vscode-org`, `salesforcedx-vscode-services`, `salesforcedx-vscode-org-browser`, `salesforcedx-vscode-metadata`, `salesforcedx-vscode-apex-testing`, `salesforcedx-vscode-apex-log`, `playwright-vscode-ext`)
    - Run from root: `npm run test:web -w <package-name> -- --retries 0` / `npm run test:desktop -w <package-name> -- --retries 0`
 

--- a/.claude/skills/verification/SKILL.md
+++ b/.claude/skills/verification/SKILL.md
@@ -11,7 +11,7 @@ Run this **only if the stop hook doesn't catch it**:
 
 1. **Dupes** — `npm run check:dupes`, check `jscpd-report` for flagged changes
 
-2. **GitHub Actions** (only if changing `.github/workflows/*.yml` or `.github/actions/*/action.yml`) — `npm run check:actions`
+2. **GitHub Actions** (only if changing `.github/workflows/*.{yml,yaml}` or `.github/actions/*/action.{yml,yaml}`) — `npm run check:actions`
 
 3. **Playwright** (only if working in these packages: `salesforcedx-vscode-core`, `salesforcedx-vscode-org`, `salesforcedx-vscode-services`, `salesforcedx-vscode-org-browser`, `salesforcedx-vscode-metadata`, `salesforcedx-vscode-apex-testing`, `salesforcedx-vscode-apex-log`, `playwright-vscode-ext`)
    - Run from root: `npm run test:web -w <package-name> -- --retries 0` / `npm run test:desktop -w <package-name> -- --retries 0`

--- a/.cursor/rules/verification.mdc
+++ b/.cursor/rules/verification.mdc
@@ -3,7 +3,7 @@ description: Run verification after code changes
 alwaysApply: true
 ---
 
-After making code changes, follow the verification checklist in .claude/skills/verification/SKILL.md: check:dupes. On compile failure, use `.claude/skills/verification/references/compile.md` (TS4023 / TS1261 skills).
+After making code changes, follow the verification checklist in .claude/skills/verification/SKILL.md: check:dupes; check:actions for GitHub Action changes. On compile failure, use `.claude/skills/verification/references/compile.md` (TS4023 / TS1261 skills).
 
 After code changes, launch the doc-maintenance subagent (@.claude/agents/doc-maintenance.md) in background.
 

--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -31,3 +31,14 @@ jobs:
         name: Compile ESLint rules
       - name: Lint
         run: npm run lint
+  validate-actions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
+          cache: npm
+      - uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
+      - name: Validate GitHub Actions
+        run: npm run check:actions

--- a/contributing/developing.md
+++ b/contributing/developing.md
@@ -183,7 +183,7 @@ Runs `markdown-link-check` on all markdown files in the repo to check for any br
 
 ### `npm run check:actions`
 
-Validates `.github/workflows/*.yml` and `.github/actions/*/action.yml`.
+Validates `.github/workflows/*.{yml,yaml}` and `.github/actions/*/action.{yml,yaml}`.
 
 ### `npm run check:peer-deps`
 

--- a/contributing/developing.md
+++ b/contributing/developing.md
@@ -181,6 +181,10 @@ Runs `markdown-link-check` on all markdown files in the repo to check for any br
 - Ignores [429 Too Many Requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429)
   - We get 429 mostly from github as there are many URLs pointing to PRs etc in Changelog
 
+### `npm run check:actions`
+
+Validates `.github/workflows/*.yml` and `.github/actions/*/action.yml`.
+
 ### `npm run check:peer-deps`
 
 This runs [check-peer-dependencies](https://www.npmjs.com/package/check-peer-dependencies) which

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -725,6 +725,12 @@ export default [
       '@typescript-eslint/no-unsafe-assignment': 'off'
     }
   },
+  {
+    files: ['scripts/validateActions.ts'],
+    rules: {
+      'no-restricted-imports': 'off'
+    }
+  },
   // ESLint plugin rules for eslint-local-rules package only
   {
     files: ['packages/eslint-local-rules/src/**/*.ts'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "url": "0.11.4"
       },
       "devDependencies": {
+        "@action-validator/core": "0.6.0",
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",
         "@effect/eslint-plugin": "0.3.2",
@@ -120,6 +121,13 @@
       "engines": {
         "node": ">=22.15.1"
       }
+    },
+    "node_modules/@action-validator/core": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@action-validator/core/-/core-0.6.0.tgz",
+      "integrity": "sha512-tPglwCr8Mm8SWzwnVewwFmqRx91F0WvMsM0BRAqH4CLalyGndm53Xvp+UcUSzswpk1wkjIDYI7RyEhWMLyPkig==",
+      "dev": true,
+      "license": "GPL-3.0-only"
     },
     "node_modules/@actions/core": {
       "version": "1.11.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "url": "0.11.4"
   },
   "devDependencies": {
+    "@action-validator/core": "0.6.0",
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
     "@effect/eslint-plugin": "0.3.2",
@@ -136,6 +137,7 @@
     "junit:report": "shx mkdir -p ./test-results && jrm ./test-results/all-junit-custom-unitTests.xml \"packages/**/junit-custom-unitTests.xml\"",
     "check:links": "find . -name \\*.md -not -path '*/node_modules/*' -print0 | xargs -0 -n1 npx markdown-link-check --quiet --alive 200,206,429",
     "check:dupes": "npx jscpd",
+    "check:actions": "wireit",
     "check:format:staged": "wireit",
     "check:knip": "wireit",
     "check:branch": "wireit",
@@ -365,6 +367,16 @@
       ],
       "output": []
     },
+    "check:actions": {
+      "command": "ts-node scripts/validateActions.ts",
+      "files": [
+        "scripts/validateActions.ts",
+        "scripts/tsconfig.json",
+        ".github/workflows/*.yml",
+        ".github/actions/*/action.yml"
+      ],
+      "output": []
+    },
     "check:knip": {
       "command": "npx knip --include exports,types,nsExports,nsTypes --no-config-hints",
       "dependencies": [
@@ -395,6 +407,7 @@
         "check:peer-deps",
         "check:package-lock",
         "check:lock-sync",
+        "check:actions",
         "check:knip"
       ]
     },

--- a/package.json
+++ b/package.json
@@ -372,8 +372,8 @@
       "files": [
         "scripts/validateActions.ts",
         "scripts/tsconfig.json",
-        ".github/workflows/*.yml",
-        ".github/actions/*/action.yml"
+        ".github/workflows/*.{yml,yaml}",
+        ".github/actions/*/action.{yml,yaml}"
       ],
       "output": []
     },

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -3,8 +3,13 @@
   "compilerOptions": {
     "outDir": "./dist",
     "noEmit": true,
+    "strictNullChecks": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
+    "target": "ES2023",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "lib": ["ES2023", "DOM"]
-  }
+  },
+  "include": ["*.ts"]
 }

--- a/scripts/validateActions.ts
+++ b/scripts/validateActions.ts
@@ -5,22 +5,33 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { validateAction, validateWorkflow } from '@action-validator/core';
+import { type ValidationError, type ValidationState, validateAction, validateWorkflow } from '@action-validator/core';
 import { Console, Effect, Stream } from 'effect';
 import { globSync, readFileSync } from 'node:fs';
 
 const program = Stream.concat(
-  Stream.fromIterable(globSync('.github/workflows/*.yml')).pipe(
+  Stream.fromIterable(globSync('.github/workflows/*.{yml,yaml}')).pipe(
     Stream.map(file => ({ file, result: validateWorkflow(readFileSync(file, 'utf8')) }))
   ),
-  Stream.fromIterable(globSync('.github/actions/*/action.yml')).pipe(
+  Stream.fromIterable(globSync('.github/actions/*/action.{yml,yaml}')).pipe(
     Stream.map(file => ({ file, result: validateAction(readFileSync(file, 'utf8')) }))
   )
 ).pipe(
   Stream.filter(({ result }) => result.errors.length > 0),
-  Stream.tap(({ file, result }) => Console.error(`\n${file}:\n${JSON.stringify(result, undefined, 2)}`)),
+  Stream.tap(({ file, result }) => Console.error(`\n${file}:\n${formatErrors(result)}`)),
   Stream.runCount,
   Effect.tap(failureCount => Console.log(`${failureCount} failed.`))
 );
 
 void Effect.runPromise(program).then(failureCount => process.exit(failureCount > 0 ? 1 : 0));
+
+const collectLeafErrors = (errors: ValidationError[]): string[] =>
+  errors.flatMap(err => {
+    if ('states' in err && err.states?.length) {
+      return err.states.flatMap(s => collectLeafErrors(s.errors));
+    }
+    const msg = ('detail' in err && err.detail) ?? err.title;
+    return ['path' in err ? `  ${err.path}: ${msg}` : `  ${msg}`];
+  });
+
+const formatErrors = (result: ValidationState): string => collectLeafErrors(result.errors).join('\n');

--- a/scripts/validateActions.ts
+++ b/scripts/validateActions.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { validateAction, validateWorkflow } from '@action-validator/core';
+import { Console, Effect, Stream } from 'effect';
+import { globSync, readFileSync } from 'node:fs';
+
+const program = Stream.concat(
+  Stream.fromIterable(globSync('.github/workflows/*.yml')).pipe(
+    Stream.map(file => ({ file, result: validateWorkflow(readFileSync(file, 'utf8')) }))
+  ),
+  Stream.fromIterable(globSync('.github/actions/*/action.yml')).pipe(
+    Stream.map(file => ({ file, result: validateAction(readFileSync(file, 'utf8')) }))
+  )
+).pipe(
+  Stream.filter(({ result }) => result.errors.length > 0),
+  Stream.tap(({ file, result }) => Console.error(`\n${file}:\n${JSON.stringify(result, undefined, 2)}`)),
+  Stream.runCount,
+  Effect.tap(failureCount => Console.log(`${failureCount} failed.`))
+);
+
+void Effect.runPromise(program).then(failureCount => process.exit(failureCount > 0 ? 1 : 0));

--- a/scripts/validateActions.ts
+++ b/scripts/validateActions.ts
@@ -26,12 +26,14 @@ const program = Stream.concat(
 void Effect.runPromise(program).then(failureCount => process.exit(failureCount > 0 ? 1 : 0));
 
 const collectLeafErrors = (errors: ValidationError[]): string[] =>
-  errors.flatMap(err => {
-    if ('states' in err && err.states?.length) {
-      return err.states.flatMap(s => collectLeafErrors(s.errors));
+  errors.flatMap(error => {
+    if ('states' in error && error.states?.length) {
+      return error.states.flatMap(state => collectLeafErrors(state.errors));
     }
-    const msg = ('detail' in err && err.detail) ?? err.title;
-    return ['path' in err ? `  ${err.path}: ${msg}` : `  ${msg}`];
+
+    const message = ('detail' in error && error.detail) ?? error.title;
+
+    return ['path' in error ? `  ${error.path}: ${message}` : `  ${message}`];
   });
 
 const formatErrors = (result: ValidationState): string => collectLeafErrors(result.errors).join('\n');


### PR DESCRIPTION
### What does this PR do?

Adds a `check:actions` script that runs [`@action-validator/core`](https://www.npmjs.com/package/@action-validator/core) over `.github/workflows/*.yml` and `.github/actions/*/action.yml`. Fails on schema errors so broken YAML/expression typos are caught at PR time instead of post-merge.

- `scripts/validateActions.ts` — Effect Stream over both glob sets; logs failures, exits non-zero on any errors
- wireit `check:actions` task; included in `check:everything`
- new `validate-actions` job in `validatePR.yml`
- docs in `contributing/developing.md` and verification skill/cursor rule
- eslint override to allow `node:fs` in this script

Sample run: https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/25175960233/job/73807993686?pr=7279

### What issues does this PR fix or reference?
@W-22294861@