### PR TITLE
W-22249980: Add Web Console manual release steps to publishing guide

### DIFF
--- a/contributing/publishing.md
+++ b/contributing/publishing.md
@@ -80,7 +80,25 @@ find ~/Downloads/v64.8.0 -type f -name "*.vsix" -exec code --install-extension {
 
 After completing your release testing following our internal template, approve the publish job "Publish in Microsoft Marketplace" and "Publish in Open VSX Registry" to allow the extensions to be uploaded and complete the release process.
 
-**Code Builder Web promotion:** After publishing to the MS Marketplace, the workflow dispatches to `code-builder-web` to trigger a CBW release and auto-promote to production. Set repo variable `CBW_TRIGGER_ENABLED=false` (Settings → Secrets and variables → Actions → Variables) to publish without triggering CBW. Default (unset) enables the trigger.
+### Web Console Release
+
+After extensions are published to the MS Marketplace, Web Console needs a new release so customers get the updated extensions. There are two paths:
+
+**Automatic (default):** The `publishVSCode.yml` workflow dispatches to `code-builder-web/release-on-extension-publish.yml` via `workflow_call`. That workflow polls the marketplace until the published extensions are available at the new version, then triggers a Web Console release with auto-promote to production. No manual steps needed.
+
+To disable the automatic trigger, set repo variable `CBW_TRIGGER_ENABLED=false` (Settings → Secrets and variables → Actions → Variables). Default (unset) enables the trigger.
+
+**Manual (when auto-promote is broken or disabled):** If the automatic flow fails or is disabled, you need to manually release and promote Web Console after confirming extensions are live in the marketplace:
+
+1. Go to the [release.yml](https://github.com/forcedotcom/code-builder-web/actions/workflows/release.yml) workflow in `code-builder-web`
+2. Click **Run workflow** from the `main` branch
+3. Set **release-type** to `patch` (or `minor` if the extension version bumped minor)
+4. Set **auto-promote** to `prd`
+5. Run the workflow — this builds, creates a new version, and dispatches `promote.yml` to sync to `/latest/` in production
+
+If you need to promote without a new release (e.g., re-promoting an existing version), use the [promote.yml](https://github.com/forcedotcom/code-builder-web/actions/workflows/promote.yml) workflow directly and select the version to promote to `prd`.
+
+Full details on the CBW release lifecycle, CDN caching, and rollback procedures are in [code-builder-web/docs/application-lifecycle.md](https://github.com/forcedotcom/code-builder-web/blob/main/docs/application-lifecycle.md).
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
@W-22249980@

The auto-promote flow for Web Console can fail or be disabled, and the manual release/promote process wasn't documented in this repo. The team missed a Web Console release last week because of this gap.

- Expand the single-line CBW note in `contributing/publishing.md` into a full "Web Console Release" subsection
- Document both the automatic (`workflow_call` → poll → release → promote) and manual (`release.yml` + `promote.yml`) paths
- Link to `code-builder-web/docs/application-lifecycle.md` for full lifecycle details (CDN caching, rollback, etc.)

## Test plan
- [ ] Verify markdown renders correctly on the PR files tab
- [ ] Confirm all links resolve (release.yml, promote.yml, application-lifecycle.md)