### PR TITLE
fix(soql): filter values are no longer blank when reopening a query in SOQL Builder UI - W-22223348

### DIFF
--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/services/soqlUtils.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/services/soqlUtils.ts
@@ -165,9 +165,9 @@ const convertUiModelToSoqlModel = (uiModel: ToolingModelJson): Query => {
       }
 
       const compareValue = uiModelCondition.compareValue
-        ? new LiteralImpl(uiModelCondition.compareValue.value)
+        ? new LiteralImpl(uiModelCondition.compareValue.type, uiModelCondition.compareValue.value)
         : uiModelCondition.values
-          ? uiModelCondition.values.map(value => new LiteralImpl(value.value))
+          ? uiModelCondition.values.map(value => new LiteralImpl(value.type, value.value))
           : undefined;
 
       if (field && compareValue) {

--- a/packages/salesforcedx-vscode-soql/src/soql-model/model/impl/literalImpl.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-model/model/impl/literalImpl.ts
@@ -5,11 +5,14 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Literal, SyntaxOptions } from '../model';
+import { Literal, LiteralType, SyntaxOptions } from '../model';
 
 export class LiteralImpl implements Literal {
   public readonly kind = 'literal' as const;
-  constructor(public value: string) {}
+  constructor(
+    public type: LiteralType,
+    public value: string
+  ) {}
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public toSoqlSyntax(options?: SyntaxOptions): string {
     return this.value;

--- a/packages/salesforcedx-vscode-soql/src/soql-model/model/model.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-model/model/model.ts
@@ -204,6 +204,7 @@ export type LiteralType = 'BOOLEAN' | 'CURRENCY' | 'DATE' | 'NULL' | 'NUMBER' | 
 
 export type Literal = CompareValue & {
   kind: 'literal';
+  type: LiteralType;
   value: string;
 };
 

--- a/packages/salesforcedx-vscode-soql/src/soql-model/serialization/deserializer.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-model/serialization/deserializer.ts
@@ -700,23 +700,23 @@ class QueryListener implements SoqlParserListener {
       ctx = ctx.soqlCommonLiterals();
     }
     if (ctx instanceof Parser.SoqlDateLiteralContext) {
-      return new LiteralImpl(ctx.text);
+      return new LiteralImpl('DATE', ctx.text);
     } else if (ctx instanceof Parser.SoqlDateTimeLiteralContext) {
-      return new LiteralImpl(ctx.text);
+      return new LiteralImpl('DATE', ctx.text);
     } else if (ctx instanceof Parser.SoqlTimeLiteralContext) {
-      return new LiteralImpl(ctx.text);
+      return new LiteralImpl('DATE', ctx.text);
     } else if (ctx instanceof Parser.SoqlDateFormulaLiteralContext) {
-      return new LiteralImpl(ctx.text);
+      return new LiteralImpl('DATE', ctx.text);
     } else if (ctx instanceof Parser.SoqlNumberLiteralContext) {
-      return new LiteralImpl(ctx.text);
+      return new LiteralImpl('NUMBER', ctx.text);
     } else if (ctx instanceof Parser.SoqlNullLiteralContext) {
-      return new LiteralImpl(ctx.text);
+      return new LiteralImpl('NULL', ctx.text);
     } else if (ctx instanceof Parser.SoqlBooleanLiteralContext) {
-      return new LiteralImpl(ctx.text);
+      return new LiteralImpl('BOOLEAN', ctx.text);
     } else if (ctx instanceof Parser.SoqlMultiCurrencyContext) {
-      return new LiteralImpl(ctx.text);
+      return new LiteralImpl('CURRENCY', ctx.text);
     }
-    return new LiteralImpl(ctx.text);
+    return new LiteralImpl('STRING', ctx.text);
   }
 
   protected exprsToCondition(ctx: Parser.SoqlWhereExprsContext): Condition {

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-model/deserializer.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-model/deserializer.test.ts
@@ -52,7 +52,7 @@ const testQueryModel = {
       kind: 'fieldCompare',
       field: { kind: 'fieldRef', fieldName: 'field1' },
       operator: '=',
-      compareValue: { kind: 'literal', value: '5' }
+      compareValue: { kind: 'literal', type: 'NUMBER', value: '5' }
     }
   },
   with: { unmodeledSyntax: 'WITH DATA CATEGORY cat__c AT val__c', reason: REASON_UNMODELED_WITH },
@@ -85,13 +85,13 @@ const selectCount = { kind: 'selectCount' };
 
 const limitZero = { limit: 0 };
 
-const literalTrue = { kind: 'literal', value: 'TRUE' };
-const literalFalse = { kind: 'literal', value: 'FALSE' };
-const literalCurrency = { kind: 'literal', value: 'USD1000' };
-const literalDate = { kind: 'literal', value: '2020-11-11' };
-const literalNull = { kind: 'literal', value: 'null' };
-const literalNumber = { kind: 'literal', value: '5' };
-const literalString = { kind: 'literal', value: "'HelloWorld'" };
+const literalTrue = { kind: 'literal', type: 'BOOLEAN', value: 'TRUE' };
+const literalFalse = { kind: 'literal', type: 'BOOLEAN', value: 'FALSE' };
+const literalCurrency = { kind: 'literal', type: 'CURRENCY', value: 'USD1000' };
+const literalDate = { kind: 'literal', type: 'DATE', value: '2020-11-11' };
+const literalNull = { kind: 'literal', type: 'NULL', value: 'null' };
+const literalNumber = { kind: 'literal', type: 'NUMBER', value: '5' };
+const literalString = { kind: 'literal', type: 'STRING', value: "'HelloWorld'" };
 
 const field = { kind: 'fieldRef', fieldName: 'field' };
 

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/impl/andOrConditionImpl.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/impl/andOrConditionImpl.test.ts
@@ -19,29 +19,45 @@ describe('AndOrConditionImpl should', () => {
         kind: 'fieldCompare',
         field: { kind: 'fieldRef', fieldName: 'field' },
         operator: '>',
-        compareValue: { kind: 'literal', value: '1' }
+        compareValue: { kind: 'literal', type: 'NUMBER', value: '1' }
       },
       andOr: 'OR',
       rightCondition: {
         kind: 'fieldCompare',
         field: { kind: 'fieldRef', fieldName: 'field' },
         operator: '<',
-        compareValue: { kind: 'literal', value: '5' }
+        compareValue: { kind: 'literal', type: 'NUMBER', value: '5' }
       }
     };
     const actual = new AndOrConditionImpl(
-      new FieldCompareConditionImpl(new FieldRefImpl('field'), ConditionOperator.GreaterThan, new LiteralImpl('1')),
+      new FieldCompareConditionImpl(
+        new FieldRefImpl('field'),
+        ConditionOperator.GreaterThan,
+        new LiteralImpl('NUMBER', '1')
+      ),
       AndOr.Or,
-      new FieldCompareConditionImpl(new FieldRefImpl('field'), ConditionOperator.LessThan, new LiteralImpl('5'))
+      new FieldCompareConditionImpl(
+        new FieldRefImpl('field'),
+        ConditionOperator.LessThan,
+        new LiteralImpl('NUMBER', '5')
+      )
     );
     expect(actual).toEqual(expected);
   });
   it('return left condition followed by AndOr operator followed by right condition for toSoqlSyntax()', () => {
     const expected = 'field > 1 OR field < 5';
     const actual = new AndOrConditionImpl(
-      new FieldCompareConditionImpl(new FieldRefImpl('field'), ConditionOperator.GreaterThan, new LiteralImpl('1')),
+      new FieldCompareConditionImpl(
+        new FieldRefImpl('field'),
+        ConditionOperator.GreaterThan,
+        new LiteralImpl('NUMBER', '1')
+      ),
       AndOr.Or,
-      new FieldCompareConditionImpl(new FieldRefImpl('field'), ConditionOperator.LessThan, new LiteralImpl('5'))
+      new FieldCompareConditionImpl(
+        new FieldRefImpl('field'),
+        ConditionOperator.LessThan,
+        new LiteralImpl('NUMBER', '5')
+      )
     ).toSoqlSyntax();
     expect(actual).toEqual(expected);
   });

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/impl/fieldCompareConditionImpl.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/impl/fieldCompareConditionImpl.test.ts
@@ -16,12 +16,12 @@ describe('FieldCompareConditionImpl should', () => {
       kind: 'fieldCompare',
       field: { kind: 'fieldRef', fieldName: 'field' },
       operator: '=',
-      compareValue: { kind: 'literal', value: "'abc'" }
+      compareValue: { kind: 'literal', type: 'STRING', value: "'abc'" }
     };
     const actual = new FieldCompareConditionImpl(
       new FieldRefImpl('field'),
       ConditionOperator.Equals,
-      new LiteralImpl("'abc'")
+      new LiteralImpl('STRING', "'abc'")
     );
     expect(actual).toEqual(expected);
   });
@@ -30,7 +30,7 @@ describe('FieldCompareConditionImpl should', () => {
     const actual = new FieldCompareConditionImpl(
       new FieldRefImpl('field'),
       ConditionOperator.Equals,
-      new LiteralImpl("'abc'")
+      new LiteralImpl('STRING', "'abc'")
     ).toSoqlSyntax();
     expect(actual).toEqual(expected);
   });

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/impl/inListConditionImpl.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/impl/inListConditionImpl.test.ts
@@ -17,21 +17,21 @@ describe('InListConditionImpl should', () => {
       field: { kind: 'fieldRef', fieldName: 'field' },
       operator: 'NOT IN',
       values: [
-        { kind: 'literal', value: "'abc'" },
-        { kind: 'literal', value: "'def'" }
+        { kind: 'literal', type: 'STRING', value: "'abc'" },
+        { kind: 'literal', type: 'STRING', value: "'def'" }
       ]
     };
     const actual = new InListConditionImpl(new FieldRefImpl('field'), ConditionOperator.NotIn, [
-      new LiteralImpl("'abc'"),
-      new LiteralImpl("'def'")
+      new LiteralImpl('STRING', "'abc'"),
+      new LiteralImpl('STRING', "'def'")
     ]);
     expect(actual).toEqual(expected);
   });
   it('return field, operator, and parenthesized comma-separated values separated by spaces for toSoqlSyntax()', () => {
     const expected = "field NOT IN ( 'abc', 'def' )";
     const actual = new InListConditionImpl(new FieldRefImpl('field'), ConditionOperator.NotIn, [
-      new LiteralImpl("'abc'"),
-      new LiteralImpl("'def'")
+      new LiteralImpl('STRING', "'abc'"),
+      new LiteralImpl('STRING', "'def'")
     ]).toSoqlSyntax();
     expect(actual).toEqual(expected);
   });

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/impl/includesConditionImpl.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/impl/includesConditionImpl.test.ts
@@ -17,21 +17,21 @@ describe('IncludesConditionImpl should', () => {
       field: { kind: 'fieldRef', fieldName: 'field' },
       operator: 'INCLUDES',
       values: [
-        { kind: 'literal', value: "'abc'" },
-        { kind: 'literal', value: "'def'" }
+        { kind: 'literal', type: 'STRING', value: "'abc'" },
+        { kind: 'literal', type: 'STRING', value: "'def'" }
       ]
     };
     const actual = new IncludesConditionImpl(new FieldRefImpl('field'), ConditionOperator.Includes, [
-      new LiteralImpl("'abc'"),
-      new LiteralImpl("'def'")
+      new LiteralImpl('STRING', "'abc'"),
+      new LiteralImpl('STRING', "'def'")
     ]);
     expect(actual).toEqual(expected);
   });
   it('return field, operator, and parenthesized comma-separated values separated by spaces for toSoqlSyntax()', () => {
     const expected = "field INCLUDES ( 'abc', 'def' )";
     const actual = new IncludesConditionImpl(new FieldRefImpl('field'), ConditionOperator.Includes, [
-      new LiteralImpl("'abc'"),
-      new LiteralImpl("'def'")
+      new LiteralImpl('STRING', "'abc'"),
+      new LiteralImpl('STRING', "'def'")
     ]).toSoqlSyntax();
     expect(actual).toEqual(expected);
   });

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/impl/literalImpl.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/impl/literalImpl.test.ts
@@ -9,13 +9,13 @@ import { LiteralImpl } from '../../../../../src/soql-model/model/impl/literalImp
 
 describe('LiteralImpl should', () => {
   it('store the literal type and value', () => {
-    const expected = { kind: 'literal', value: 'TRUE' };
-    const actual = new LiteralImpl('TRUE');
+    const expected = { kind: 'literal', type: 'BOOLEAN', value: 'TRUE' };
+    const actual = new LiteralImpl('BOOLEAN', 'TRUE');
     expect(actual).toEqual(expected);
   });
   it('return the value of the literal for toSoqlSyntax()', () => {
     const expected = 'TRUE';
-    const actual = new LiteralImpl('TRUE').toSoqlSyntax();
+    const actual = new LiteralImpl('BOOLEAN', 'TRUE').toSoqlSyntax();
     expect(actual).toEqual(expected);
   });
 });

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/impl/nestedConditionImpl.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/impl/nestedConditionImpl.test.ts
@@ -19,18 +19,26 @@ describe('NestedConditionImpl should', () => {
         kind: 'fieldCompare',
         field: { kind: 'fieldRef', fieldName: 'field' },
         operator: '=',
-        compareValue: { kind: 'literal', value: "'abc'" }
+        compareValue: { kind: 'literal', type: 'STRING', value: "'abc'" }
       }
     };
     const actual = new NestedConditionImpl(
-      new FieldCompareConditionImpl(new FieldRefImpl('field'), ConditionOperator.Equals, new LiteralImpl("'abc'"))
+      new FieldCompareConditionImpl(
+        new FieldRefImpl('field'),
+        ConditionOperator.Equals,
+        new LiteralImpl('STRING', "'abc'")
+      )
     );
     expect(actual).toEqual(expected);
   });
   it('return nested condition in parentheses for toSoqlSyntax()', () => {
     const expected = "( field = 'abc' )";
     const actual = new NestedConditionImpl(
-      new FieldCompareConditionImpl(new FieldRefImpl('field'), ConditionOperator.Equals, new LiteralImpl("'abc'"))
+      new FieldCompareConditionImpl(
+        new FieldRefImpl('field'),
+        ConditionOperator.Equals,
+        new LiteralImpl('STRING', "'abc'")
+      )
     ).toSoqlSyntax();
     expect(actual).toEqual(expected);
   });

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/impl/notConditionImpl.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/impl/notConditionImpl.test.ts
@@ -19,18 +19,26 @@ describe('NotConditionImpl should', () => {
         kind: 'fieldCompare',
         field: { kind: 'fieldRef', fieldName: 'field' },
         operator: '=',
-        compareValue: { kind: 'literal', value: "'abc'" }
+        compareValue: { kind: 'literal', type: 'STRING', value: "'abc'" }
       }
     };
     const actual = new NotConditionImpl(
-      new FieldCompareConditionImpl(new FieldRefImpl('field'), ConditionOperator.Equals, new LiteralImpl("'abc'"))
+      new FieldCompareConditionImpl(
+        new FieldRefImpl('field'),
+        ConditionOperator.Equals,
+        new LiteralImpl('STRING', "'abc'")
+      )
     );
     expect(actual).toEqual(expected);
   });
   it('return condition preceded by NOT keyword for toSoqlSyntax()', () => {
     const expected = "NOT field = 'abc'";
     const actual = new NotConditionImpl(
-      new FieldCompareConditionImpl(new FieldRefImpl('field'), ConditionOperator.Equals, new LiteralImpl("'abc'"))
+      new FieldCompareConditionImpl(
+        new FieldRefImpl('field'),
+        ConditionOperator.Equals,
+        new LiteralImpl('STRING', "'abc'")
+      )
     ).toSoqlSyntax();
     expect(actual).toEqual(expected);
   });

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/impl/queryImpl.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/impl/queryImpl.test.ts
@@ -36,7 +36,7 @@ describe('QueryImpl should', () => {
           kind: 'fieldCompare',
           field: { kind: 'fieldRef', fieldName: 'paint_it' },
           operator: '=',
-          compareValue: { kind: 'literal', value: "'black'" }
+          compareValue: { kind: 'literal', type: 'STRING' as const, value: "'black'" }
         }
       },
       with: {
@@ -75,7 +75,7 @@ describe('QueryImpl should', () => {
         new FieldCompareConditionImpl(
           new FieldRefImpl(expected.where.condition.field.fieldName),
           ConditionOperator.Equals,
-          new LiteralImpl(expected.where.condition.compareValue.value)
+          new LiteralImpl(expected.where.condition.compareValue.type, expected.where.condition.compareValue.value)
         )
       ),
       new UnmodeledSyntaxImpl(expected.with.unmodeledSyntax, REASON_UNMODELED_WITH),
@@ -100,7 +100,7 @@ describe('QueryImpl should', () => {
         new FieldCompareConditionImpl(
           new FieldRefImpl('paint_it'),
           ConditionOperator.Equals,
-          new LiteralImpl("'black'")
+          new LiteralImpl('STRING', "'black'")
         )
       )
     ).toSoqlSyntax();

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/impl/whereImpl.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/impl/whereImpl.test.ts
@@ -18,18 +18,26 @@ describe('WhereImpl should', () => {
         kind: 'fieldCompare',
         field: { kind: 'fieldRef', fieldName: 'field' },
         operator: '=',
-        compareValue: { kind: 'literal', value: "'abc'" }
+        compareValue: { kind: 'literal', type: 'STRING', value: "'abc'" }
       }
     };
     const actual = new WhereImpl(
-      new FieldCompareConditionImpl(new FieldRefImpl('field'), ConditionOperator.Equals, new LiteralImpl("'abc'"))
+      new FieldCompareConditionImpl(
+        new FieldRefImpl('field'),
+        ConditionOperator.Equals,
+        new LiteralImpl('STRING', "'abc'")
+      )
     );
     expect(actual).toEqual(expected);
   });
   it('return condition preceded by WHERE keyword for toSoqlSyntax()', () => {
     const expected = "WHERE field = 'abc'";
     const actual = new WhereImpl(
-      new FieldCompareConditionImpl(new FieldRefImpl('field'), ConditionOperator.Equals, new LiteralImpl("'abc'"))
+      new FieldCompareConditionImpl(
+        new FieldRefImpl('field'),
+        ConditionOperator.Equals,
+        new LiteralImpl('STRING', "'abc'")
+      )
     ).toSoqlSyntax();
     expect(actual).toEqual(expected);
   });

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/util.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/util.test.ts
@@ -29,7 +29,7 @@ import {
 import { SoqlModelUtils } from '../../../../src/soql-model/model/util';
 
 const field = new FieldRefImpl('field');
-const literal = new LiteralImpl("'Hello'");
+const literal = new LiteralImpl('STRING', "'Hello'");
 const conditionFieldCompare = new FieldCompareConditionImpl(field, ConditionOperator.Equals, literal);
 const conditionLike = new FieldCompareConditionImpl(field, ConditionOperator.Like, literal);
 const conditionInList = new InListConditionImpl(field, ConditionOperator.In, [literal]);


### PR DESCRIPTION
### What does this PR do?
There was a regression back in February where the values for all the Filter conditions were disappearing when closing and reopening a query in SOQL Builder UI.  The issue was during the migration, `type` was (incorrectly) framed by the linter as an unused type, and thus got removed, leaving only `value`.  This PR reverts that change and puts `type` back into the `Literal` object.

### What issues does this PR fix or reference?
@W-22223348@

### Functionality Before
<img width="1711" height="1528" alt="image" src="https://github.com/user-attachments/assets/5c3466d9-9f17-4234-b1a7-b9ffabf3abea" />

### Functionality After
<img width="1920" height="1080" alt="Screenshot 2026-05-01 at 12 38 16 PM" src="https://github.com/user-attachments/assets/653d6513-b820-44c4-85b2-ebe5304cc1b2" />
<img width="1920" height="1080" alt="Screenshot 2026-05-01 at 12 38 26 PM" src="https://github.com/user-attachments/assets/db78b085-ca84-4016-93f0-8ef6c42c8fef" />