### PR TITLE
fix(security): update package.json files so packages resolve to local version instead of NPMJS - W-22254726

### DIFF
--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -39,8 +39,8 @@
     "vscode-uri": "^3.1.0"
   },
   "devDependencies": {
-    "salesforcedx-vscode-apex": "*",
-    "salesforcedx-vscode-core": "*"
+    "salesforcedx-vscode-apex": "66.10.0",
+    "salesforcedx-vscode-core": "66.10.0"
   },
   "extensionDependencies": [
     "salesforce.salesforcedx-vscode-core"

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -1,5 +1,6 @@
 {
   "name": "salesforcedx-vscode-apex-debugger",
+  "private": true,
   "displayName": "Apex Interactive Debugger",
   "description": "Provides debugging support for the Apex programming language",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",

--- a/packages/salesforcedx-vscode-apex-log/package.json
+++ b/packages/salesforcedx-vscode-apex-log/package.json
@@ -38,7 +38,7 @@
     "@salesforce/core": "^8.28.0",
     "@salesforce/playwright-vscode-ext": "*",
     "esbuild": "0.27.4",
-    "salesforcedx-vscode-services": "*"
+    "salesforcedx-vscode-services": "66.10.0"
   },
   "scripts": {
     "vscode:bundle": "wireit",

--- a/packages/salesforcedx-vscode-apex-log/package.json
+++ b/packages/salesforcedx-vscode-apex-log/package.json
@@ -1,5 +1,6 @@
 {
   "name": "salesforcedx-vscode-apex-log",
+  "private": true,
   "displayName": "Salesforce Apex Log",
   "description": "Execute anonymous Apex, retrieve Apex logs, and manage trace flags",
   "icon": "images/VSCodeBundle.png",

--- a/packages/salesforcedx-vscode-apex-oas/package.json
+++ b/packages/salesforcedx-vscode-apex-oas/package.json
@@ -1,5 +1,6 @@
 {
   "name": "salesforcedx-vscode-apex-oas",
+  "private": true,
   "displayName": "Apex OpenAPI Specification",
   "description": "Provides OpenAPI Specification generation for Apex REST and AuraEnabled classes",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",

--- a/packages/salesforcedx-vscode-apex-oas/package.json
+++ b/packages/salesforcedx-vscode-apex-oas/package.json
@@ -49,8 +49,8 @@
     "@types/async-lock": "1.4.2",
     "@types/ejs": "3.1.5",
     "openapi-types": "12.1.3",
-    "salesforcedx-vscode-apex": "*",
-    "salesforcedx-vscode-core": "*",
+    "salesforcedx-vscode-apex": "66.10.0",
+    "salesforcedx-vscode-core": "66.10.0",
     "vscode-languageserver-protocol": "3.17.5"
   },
   "extensionDependencies": [

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -35,17 +35,17 @@
     "@salesforce/salesforcedx-utils-vscode": "*",
     "@salesforce/vscode-i18n": "*",
     "effect": "^3.20.0",
-    "salesforcedx-vscode-apex-log": "*",
+    "salesforcedx-vscode-apex-log": "66.10.0",
     "vscode-uri": "^3.1.0"
   },
   "devDependencies": {
     "@playwright/test": "*",
     "@salesforce/core": "^8.28.0",
     "@salesforce/playwright-vscode-ext": "*",
-    "salesforcedx-vscode-apex": "*",
-    "salesforcedx-vscode-core": "*",
-    "salesforcedx-vscode-metadata": "*",
-    "salesforcedx-vscode-services": "*"
+    "salesforcedx-vscode-apex": "66.10.0",
+    "salesforcedx-vscode-core": "66.10.0",
+    "salesforcedx-vscode-metadata": "66.10.0",
+    "salesforcedx-vscode-services": "66.10.0"
   },
   "extensionDependencies": [
     "salesforce.salesforcedx-vscode-apex",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -1,5 +1,6 @@
 {
   "name": "salesforcedx-vscode-apex-replay-debugger",
+  "private": true,
   "displayName": "Apex Replay Debugger",
   "description": "Replay Apex execution from Apex Debug Log",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",

--- a/packages/salesforcedx-vscode-apex-testing/package.json
+++ b/packages/salesforcedx-vscode-apex-testing/package.json
@@ -1,5 +1,6 @@
 {
   "name": "salesforcedx-vscode-apex-testing",
+  "private": true,
   "displayName": "Apex Testing",
   "description": "Provides Apex test execution and management features",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",

--- a/packages/salesforcedx-vscode-apex-testing/package.json
+++ b/packages/salesforcedx-vscode-apex-testing/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@salesforce/playwright-vscode-ext": "*",
-    "salesforcedx-vscode-services": "*"
+    "salesforcedx-vscode-services": "66.10.0"
   },
   "extensionDependencies": [
     "salesforce.salesforcedx-vscode-services"

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@salesforce/core": "^8.28.0",
-    "salesforcedx-vscode-core": "*"
+    "salesforcedx-vscode-core": "66.10.0"
   },
   "extensionDependencies": [
     "salesforce.salesforcedx-vscode-core",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -1,5 +1,6 @@
 {
   "name": "salesforcedx-vscode-apex",
+  "private": true,
   "displayName": "Apex",
   "description": "Provides code-editing features for the Apex programming language",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",

--- a/packages/salesforcedx-vscode-automation-tests/package.json
+++ b/packages/salesforcedx-vscode-automation-tests/package.json
@@ -1,5 +1,6 @@
 {
   "name": "salesforcedx-vscode-automation-tests",
+  "private": true,
   "version": "65.7.0",
   "description": "",
   "main": "index.js",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -1,5 +1,6 @@
 {
   "name": "salesforcedx-vscode-core",
+  "private": true,
   "displayName": "Salesforce CLI",
   "description": "Provides integration with the Salesforce CLI",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",

--- a/packages/salesforcedx-vscode-expanded/package.json
+++ b/packages/salesforcedx-vscode-expanded/package.json
@@ -1,5 +1,6 @@
 {
   "name": "salesforcedx-vscode-expanded",
+  "private": true,
   "displayName": "Salesforce Extension Pack (Expanded)",
   "description": "Extensions for developing on the Salesforce Platform",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@salesforce/playwright-vscode-ext": "*",
-    "salesforcedx-vscode-services": "*"
+    "salesforcedx-vscode-services": "66.10.0"
   },
   "scripts": {
     "clean": "shx rm -rf node_modules out dist coverage .nyc_output .wireit .eslintcache *.vsix",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -1,10 +1,212 @@
 {
+  "name": "salesforcedx-vscode-lightning",
+  "private": true,
+  "displayName": "Aura Components",
+  "description": "Provides code-editing features for Aura Components",
+  "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",
+  "bugs": {
+    "url": "https://github.com/forcedotcom/salesforcedx-vscode/issues"
+  },
+  "icon": "images/VSCodeLightning.png",
+  "galleryBanner": {
+    "color": "#ECECEC",
+    "theme": "light"
+  },
+  "repository": {
+    "url": "https://github.com/forcedotcom/salesforcedx-vscode"
+  },
+  "version": "66.10.0",
+  "publisher": "salesforce",
+  "license": "BSD-3-Clause",
+  "engines": {
+    "vscode": "^1.90.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "extensionDependencies": [
+    "salesforce.salesforcedx-vscode-core",
+    "salesforce.salesforcedx-vscode-services"
+  ],
+  "activationEvents": [],
+  "main": "./out/src",
+  "dependencies": {
+    "@salesforce/effect-ext-utils": "*",
+    "@salesforce/salesforcedx-aura-language-server": "*",
+    "@salesforce/salesforcedx-lightning-lsp-common": "*",
+    "@salesforce/salesforcedx-utils-vscode": "*",
+    "@salesforce/vscode-i18n": "*",
+    "acorn": "^6.0.0",
+    "acorn-loose": "^6.0.0",
+    "acorn-walk": "^6.0.0",
+    "applicationinsights": "1.0.7",
+    "effect": "^3.20.0",
+    "vscode-html-languageservice": "^5.5.1",
+    "vscode-languageclient": "^9.0.1",
+    "vscode-uri": "^3.1.0"
+  },
+  "devDependencies": {
+    "@salesforce/playwright-vscode-ext": "*",
+    "salesforcedx-vscode-services": "*"
+  },
+  "scripts": {
+    "clean": "shx rm -rf node_modules out dist coverage .nyc_output .wireit .eslintcache *.vsix",
+    "compile": "wireit",
+    "lint": "wireit",
+    "test": "wireit",
+    "test:compile": "wireit",
+    "test:desktop": "wireit",
+    "test:desktop:debug": "npm run test:desktop -- --debug",
+    "test:desktop:ui": "VSCODE_DESKTOP=1 npm run test:desktop -- --headed",
+    "vscode:bundle": "wireit",
+    "vscode:package:legacy": "wireit",
+    "vscode:prepublish": "npm prune --production",
+    "vscode:publish": "node ../../scripts/publish-vsix.js",
+    "vscode:sha256": "node ../../scripts/generate-sha256.js >> ../../SHA256"
+  },
+  "serverPath": [
+    "dist",
+    "auraServer.js"
+  ],
+  "packaging": {
+    "assets": [
+      "LICENSE.txt",
+      "package.nls.ja.json",
+      "package.nls.json",
+      "README.md",
+      ".vscodeignore",
+      "OSSREADME.json",
+      "images",
+      "syntaxes",
+      "dist",
+      "tern"
+    ],
+    "packageUpdates": {
+      "dependencies": {
+        "acorn": "^6.0.0",
+        "acorn-loose": "^6.0.0",
+        "acorn-walk": "^6.0.0",
+        "applicationinsights": "1.0.7",
+        "vscode-html-languageservice": "^5.5.1"
+      },
+      "devDependencies": {},
+      "main": "dist/index.js",
+      "serverPath": [
+        "dist",
+        "auraServer.js"
+      ]
+    }
+  },
   "o11yUploadEndpoint": "https://794testsite.my.site.com/byolwr/webruntime/log/metrics",
   "enableO11y": "true",
   "productFeatureId": "aJCEE0000000mLm4AI",
-  "activationEvents": [],
-  "bugs": {
-    "url": "https://github.com/forcedotcom/salesforcedx-vscode/issues"
+  "wireit": {
+    "compile": {
+      "clean": "if-file-deleted",
+      "command": "tsc --pretty",
+      "dependencies": [
+        "../effect-ext-utils:compile",
+        "../salesforcedx-utils-vscode:compile",
+        "../salesforcedx-vscode-i18n:compile",
+        "../salesforcedx-vscode-services:compile",
+        "../salesforcedx-aura-language-server:compile",
+        "../salesforcedx-lightning-lsp-common:compile"
+      ],
+      "files": [
+        "src/**/*.ts",
+        "tsconfig.json",
+        "../../tsconfig.common.json",
+        "package.json",
+        "package.nls*.json"
+      ],
+      "output": [
+        "out/**"
+      ]
+    },
+    "test:compile": {
+      "command": "tsc -p test/tsconfig.json",
+      "dependencies": [
+        "compile",
+        "../playwright-vscode-ext:compile"
+      ],
+      "files": [
+        "test/**/*.ts",
+        "test/tsconfig.json"
+      ],
+      "output": []
+    },
+    "lint": {
+      "command": "eslint --color --cache --cache-location .eslintcache .",
+      "dependencies": [
+        "../eslint-local-rules:compile",
+        "compile"
+      ],
+      "files": [
+        "src/**/*.ts",
+        "test/**/*.ts",
+        "../../eslint.config.mjs"
+      ],
+      "output": []
+    },
+    "test": {
+      "command": "jest",
+      "dependencies": [
+        "test:compile"
+      ],
+      "files": [
+        "test/**/*.ts",
+        "jest.config.js",
+        "../../config/jest.base.config.js"
+      ],
+      "output": [
+        "coverage"
+      ]
+    },
+    "test:desktop": {
+      "command": "playwright test --config=test/playwright/playwright.config.desktop.ts",
+      "env": {
+        "VSCODE_DESKTOP": "1",
+        "E2E_FROM_VSIX": {
+          "external": true
+        },
+        "PLAYWRIGHT_WORKERS": {
+          "external": true
+        }
+      },
+      "dependencies": [
+        "vscode:package:legacy",
+        "../salesforcedx-vscode-services:vscode:package",
+        "../salesforcedx-vscode-core:vscode:package:legacy",
+        "../playwright-vscode-ext:compile"
+      ],
+      "files": [
+        "test/playwright/**/*.ts",
+        "package*.json"
+      ],
+      "output": []
+    },
+    "vscode:bundle": {
+      "command": "node ./esbuild.config.mjs",
+      "dependencies": [
+        "compile",
+        "../salesforcedx-vscode-services:vscode:bundle"
+      ],
+      "files": [
+        "esbuild.config.mjs",
+        "../../scripts/bundling/node.mjs",
+        "out/**"
+      ],
+      "output": [
+        "dist",
+        "tern"
+      ]
+    },
+    "vscode:package:legacy": {
+      "command": "ts-node ../../scripts/vsce-bundled-extension.ts",
+      "dependencies": [
+        "vscode:bundle"
+      ]
+    }
   },
   "contributes": {
     "commands": [
@@ -153,206 +355,5 @@
         "id": "html"
       }
     ]
-  },
-  "icon": "images/VSCodeLightning.png",
-  "galleryBanner": {
-    "color": "#ECECEC",
-    "theme": "light"
-  },
-  "version": "66.10.0",
-  "publisher": "salesforce",
-  "license": "BSD-3-Clause",
-  "engines": {
-    "vscode": "^1.90.0"
-  },
-  "categories": [
-    "Programming Languages"
-  ],
-  "dependencies": {
-    "@salesforce/effect-ext-utils": "*",
-    "@salesforce/salesforcedx-aura-language-server": "*",
-    "@salesforce/salesforcedx-lightning-lsp-common": "*",
-    "@salesforce/salesforcedx-utils-vscode": "*",
-    "@salesforce/vscode-i18n": "*",
-    "acorn": "^6.0.0",
-    "acorn-loose": "^6.0.0",
-    "acorn-walk": "^6.0.0",
-    "applicationinsights": "1.0.7",
-    "effect": "^3.20.0",
-    "vscode-html-languageservice": "^5.5.1",
-    "vscode-languageclient": "^9.0.1",
-    "vscode-uri": "^3.1.0"
-  },
-  "devDependencies": {
-    "@salesforce/playwright-vscode-ext": "*",
-    "salesforcedx-vscode-services": "*"
-  },
-  "description": "Provides code-editing features for Aura Components",
-  "displayName": "Aura Components",
-  "extensionDependencies": [
-    "salesforce.salesforcedx-vscode-core",
-    "salesforce.salesforcedx-vscode-services"
-  ],
-  "main": "./out/src",
-  "name": "salesforcedx-vscode-lightning",
-  "packaging": {
-    "assets": [
-      "LICENSE.txt",
-      "package.nls.ja.json",
-      "package.nls.json",
-      "README.md",
-      ".vscodeignore",
-      "OSSREADME.json",
-      "images",
-      "syntaxes",
-      "dist",
-      "tern"
-    ],
-    "packageUpdates": {
-      "dependencies": {
-        "acorn": "^6.0.0",
-        "acorn-loose": "^6.0.0",
-        "acorn-walk": "^6.0.0",
-        "applicationinsights": "1.0.7",
-        "vscode-html-languageservice": "^5.5.1"
-      },
-      "devDependencies": {},
-      "main": "dist/index.js",
-      "serverPath": [
-        "dist",
-        "auraServer.js"
-      ]
-    }
-  },
-  "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",
-  "repository": {
-    "url": "https://github.com/forcedotcom/salesforcedx-vscode"
-  },
-  "scripts": {
-    "clean": "shx rm -rf node_modules out dist coverage .nyc_output .wireit .eslintcache *.vsix",
-    "compile": "wireit",
-    "lint": "wireit",
-    "test": "wireit",
-    "test:compile": "wireit",
-    "test:desktop": "wireit",
-    "test:desktop:debug": "npm run test:desktop -- --debug",
-    "test:desktop:ui": "VSCODE_DESKTOP=1 npm run test:desktop -- --headed",
-    "vscode:bundle": "wireit",
-    "vscode:package:legacy": "wireit",
-    "vscode:prepublish": "npm prune --production",
-    "vscode:publish": "node ../../scripts/publish-vsix.js",
-    "vscode:sha256": "node ../../scripts/generate-sha256.js >> ../../SHA256"
-  },
-  "serverPath": [
-    "dist",
-    "auraServer.js"
-  ],
-  "wireit": {
-    "compile": {
-      "clean": "if-file-deleted",
-      "command": "tsc --pretty",
-      "dependencies": [
-        "../effect-ext-utils:compile",
-        "../salesforcedx-utils-vscode:compile",
-        "../salesforcedx-vscode-i18n:compile",
-        "../salesforcedx-vscode-services:compile",
-        "../salesforcedx-aura-language-server:compile",
-        "../salesforcedx-lightning-lsp-common:compile"
-      ],
-      "files": [
-        "src/**/*.ts",
-        "tsconfig.json",
-        "../../tsconfig.common.json",
-        "package.json",
-        "package.nls*.json"
-      ],
-      "output": [
-        "out/**"
-      ]
-    },
-    "test:compile": {
-      "command": "tsc -p test/tsconfig.json",
-      "dependencies": [
-        "compile",
-        "../playwright-vscode-ext:compile"
-      ],
-      "files": [
-        "test/**/*.ts",
-        "test/tsconfig.json"
-      ],
-      "output": []
-    },
-    "lint": {
-      "command": "eslint --color --cache --cache-location .eslintcache .",
-      "dependencies": [
-        "../eslint-local-rules:compile",
-        "compile"
-      ],
-      "files": [
-        "src/**/*.ts",
-        "test/**/*.ts",
-        "../../eslint.config.mjs"
-      ],
-      "output": []
-    },
-    "test": {
-      "command": "jest",
-      "dependencies": [
-        "test:compile"
-      ],
-      "files": [
-        "test/**/*.ts",
-        "jest.config.js",
-        "../../config/jest.base.config.js"
-      ],
-      "output": [
-        "coverage"
-      ]
-    },
-    "test:desktop": {
-      "command": "playwright test --config=test/playwright/playwright.config.desktop.ts",
-      "env": {
-        "VSCODE_DESKTOP": "1",
-        "E2E_FROM_VSIX": {
-          "external": true
-        },
-        "PLAYWRIGHT_WORKERS": {
-          "external": true
-        }
-      },
-      "dependencies": [
-        "vscode:package:legacy",
-        "../salesforcedx-vscode-services:vscode:package",
-        "../salesforcedx-vscode-core:vscode:package:legacy",
-        "../playwright-vscode-ext:compile"
-      ],
-      "files": [
-        "test/playwright/**/*.ts",
-        "package*.json"
-      ],
-      "output": []
-    },
-    "vscode:bundle": {
-      "command": "node ./esbuild.config.mjs",
-      "dependencies": [
-        "compile",
-        "../salesforcedx-vscode-services:vscode:bundle"
-      ],
-      "files": [
-        "esbuild.config.mjs",
-        "../../scripts/bundling/node.mjs",
-        "out/**"
-      ],
-      "output": [
-        "dist",
-        "tern"
-      ]
-    },
-    "vscode:package:legacy": {
-      "command": "ts-node ../../scripts/vsce-bundled-extension.ts",
-      "dependencies": [
-        "vscode:bundle"
-      ]
-    }
   }
 }

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -1,5 +1,6 @@
 {
   "name": "salesforcedx-vscode-lwc",
+  "private": true,
   "displayName": "Lightning Web Components",
   "description": "Provides code-editing features for Lightning Web Components",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -47,7 +47,7 @@
     "@salesforce/playwright-vscode-ext": "*",
     "@types/uuid": "^3.4.8",
     "@types/which": "^1.3.1",
-    "salesforcedx-vscode-services": "*"
+    "salesforcedx-vscode-services": "66.10.0"
   },
   "extensionDependencies": [
     "salesforce.salesforcedx-vscode-services"

--- a/packages/salesforcedx-vscode-metadata/package.json
+++ b/packages/salesforcedx-vscode-metadata/package.json
@@ -1,5 +1,6 @@
 {
   "name": "salesforcedx-vscode-metadata",
+  "private": true,
   "displayName": "Salesforce Metadata",
   "description": "Metadata operations for Salesforce development",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",

--- a/packages/salesforcedx-vscode-metadata/package.json
+++ b/packages/salesforcedx-vscode-metadata/package.json
@@ -37,7 +37,7 @@
     "@salesforce/source-deploy-retrieve": "^12.32.5",
     "@salesforce/source-tracking": "^7.8.11",
     "@salesforce/playwright-vscode-ext": "*",
-    "salesforcedx-vscode-services": "*"
+    "salesforcedx-vscode-services": "66.10.0"
   },
   "extensionDependencies": [
     "salesforce.salesforcedx-vscode-services"

--- a/packages/salesforcedx-vscode-org-browser/package.json
+++ b/packages/salesforcedx-vscode-org-browser/package.json
@@ -37,7 +37,7 @@
     "@salesforce/core": "^8.28.0",
     "@salesforce/playwright-vscode-ext": "*",
     "@salesforce/source-deploy-retrieve": "^12.32.5",
-    "salesforcedx-vscode-services": "*"
+    "salesforcedx-vscode-services": "66.10.0"
   },
   "extensionDependencies": [
     "salesforce.salesforcedx-vscode-services"

--- a/packages/salesforcedx-vscode-org-browser/package.json
+++ b/packages/salesforcedx-vscode-org-browser/package.json
@@ -1,5 +1,6 @@
 {
   "name": "salesforcedx-vscode-org-browser",
+  "private": true,
   "displayName": "Salesforce Org Browser",
   "description": "View and retrieve metadata from your Salesforce org",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",

--- a/packages/salesforcedx-vscode-org/package.json
+++ b/packages/salesforcedx-vscode-org/package.json
@@ -1,5 +1,6 @@
 {
   "name": "salesforcedx-vscode-org",
+  "private": true,
   "displayName": "Salesforce Org Management",
   "description": "Provides org and authorization management commands for Salesforce Development",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",

--- a/packages/salesforcedx-vscode-services/package.json
+++ b/packages/salesforcedx-vscode-services/package.json
@@ -1,5 +1,6 @@
 {
   "name": "salesforcedx-vscode-services",
+  "private": true,
   "displayName": "Salesforce Services",
   "description": "a shared services extension for other extensions to use",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -1,5 +1,6 @@
 {
   "name": "salesforcedx-vscode-soql",
+  "private": true,
   "displayName": "SOQL",
   "description": "Provides code-editing features for SOQL",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -71,7 +71,7 @@
     "jest-environment-jsdom": "^29.0.0",
     "rollup": "^4.0.0",
     "rxjs": "^7.8.2",
-    "salesforcedx-vscode-services": "*"
+    "salesforcedx-vscode-services": "66.10.0"
   },
   "extensionDependencies": [
     "salesforce.salesforcedx-vscode-services"

--- a/packages/salesforcedx-vscode-visualforce/package.json
+++ b/packages/salesforcedx-vscode-visualforce/package.json
@@ -1,5 +1,6 @@
 {
   "name": "salesforcedx-vscode-visualforce",
+  "private": true,
   "displayName": "Visualforce",
   "description": "Provides syntax highlighting for the Visualforce framework",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",

--- a/packages/salesforcedx-vscode-visualforce/package.json
+++ b/packages/salesforcedx-vscode-visualforce/package.json
@@ -40,7 +40,7 @@
     "@salesforce/playwright-vscode-ext": "*",
     "@salesforce/salesforcedx-visualforce-language-server": "*",
     "@salesforce/salesforcedx-visualforce-markup-language-server": "*",
-    "salesforcedx-vscode-services": "*"
+    "salesforcedx-vscode-services": "66.10.0"
   },
   "extensionDependencies": [
     "salesforce.salesforcedx-vscode-services"

--- a/packages/salesforcedx-vscode/package.json
+++ b/packages/salesforcedx-vscode/package.json
@@ -1,5 +1,6 @@
 {
   "name": "salesforcedx-vscode",
+  "private": true,
   "displayName": "Salesforce Extension Pack",
   "description": "Extensions for developing on the Salesforce Platform",
   "qna": "https://github.com/forcedotcom/salesforcedx-vscode/issues",

--- a/scripts/create-release-branch.js
+++ b/scripts/create-release-branch.js
@@ -32,6 +32,48 @@ const updatePackageVersions = nextVersion => {
   });
 };
 
+// Update cross-package dependency version specifiers to match the new version.
+// Finds all workspace package names, then rewrites any dependency reference to
+// those names so the version tracks the monorepo release instead of falling
+// back to the public registry.
+const updateInternalDependencyVersions = (currentVersion, nextVersion) => {
+  const packagesDir = path.join(__dirname, '..', 'packages');
+
+  const workspacePackageNames = new Set(
+    fs
+      .readdirSync(packagesDir)
+      .filter(dir => fs.existsSync(path.join(packagesDir, dir, 'package.json')))
+      .map(dir => {
+        const pkgJson = JSON.parse(fs.readFileSync(path.join(packagesDir, dir, 'package.json'), 'utf8'));
+        return pkgJson.name;
+      })
+      .filter(Boolean)
+  );
+
+  fs.readdirSync(packagesDir).forEach(pkg => {
+    const pkgPath = path.join(packagesDir, pkg, 'package.json');
+    if (!fs.existsSync(pkgPath)) return;
+
+    const pkgJson = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    let changed = false;
+
+    for (const depField of ['dependencies', 'devDependencies', 'peerDependencies']) {
+      if (!pkgJson[depField]) continue;
+      for (const [name, version] of Object.entries(pkgJson[depField])) {
+        if (workspacePackageNames.has(name) && version === currentVersion) {
+          pkgJson[depField][name] = nextVersion;
+          changed = true;
+        }
+      }
+    }
+
+    if (changed) {
+      fs.writeFileSync(pkgPath, JSON.stringify(pkgJson, null, 2) + '\n');
+      logger.info(`Updated internal dependency references in ${pkg} to ${nextVersion}`);
+    }
+  });
+};
+
 function getReleaseVersion() {
   const currentVersion = require('../packages/salesforcedx-vscode/package.json').version;
   let [version, major, minor, patch] = currentVersion.match(/^(\d+)\.?(\d+)\.?(\*|\d+)$/);
@@ -97,7 +139,9 @@ execSync('git clean -xfd -e node_modules');
 
 // Update version in all package.json files
 logger.info(`Updating package versions to ${nextVersion}...`);
+const currentVersion = require('../packages/salesforcedx-vscode/package.json').version;
 updatePackageVersions(nextVersion);
+updateInternalDependencyVersions(currentVersion, nextVersion);
 
 // Add all package.json version update changes
 execSync(`git add "**/package.json"`);


### PR DESCRIPTION
### What does this PR do?
We had a security issue where packages could be squatted on NPMJS.  This PR contains 2 remediations in our code for this security issue:
1. Each extension's **package.json** now contains `"private": true` to avoid accidental publishes to NPMJS by our team.
2. In package.json, when the dependency's version is `*` instead of an explicit version number, running `npm install` could capture the version on NPMJS instead of the local version if `npm install` isn't run at the root level.  Therefore, I changed `*` to the latest version number and updated **create-release-branch.js** to bump those version numbers during each weekly release.

### What issues does this PR fix or reference?
@W-22254726@
