### PR TITLE
fix(ci): use repository_dispatch for CBW trigger - W-22384617

### DIFF
--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -116,13 +116,36 @@ jobs:
       status: Not Implemented
 
   # Set repo variable CBW_TRIGGER_ENABLED=false to disable dispatch to code-builder-web.
-  # Default (unset): trigger CBW release after publish. Use when publishing without CBW promotion.
+  # Default (unset): dispatch after publish. Use when publishing without CBW promotion.
+  # Uses repository_dispatch (not workflow_call) because GitHub Actions blocks
+  # public repos from calling reusable workflows in private repos.
   trigger-cbw-release:
     needs: [publish, prepare-environment-from-main]
     if: needs.publish.result == 'success' && vars.CBW_TRIGGER_ENABLED != 'false'
-    uses: forcedotcom/code-builder-web/.github/workflows/release-on-extension-publish.yml@main
-    with:
-      extensions: ${{ needs.publish.outputs.extensions }}
-      version: ${{ needs.prepare-environment-from-main.outputs.RELEASE_VERSION }}
-      release-type: ${{ needs.prepare-environment-from-main.outputs.CBW_RELEASE_TYPE }}
-    secrets: inherit
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate dispatch token
+        id: dispatch-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.CBW_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.CBW_DISPATCH_APP_PRIVATE_KEY }}
+          owner: forcedotcom
+          repositories: code-builder-web
+      - name: Trigger Code Builder Web release
+        env:
+          GH_TOKEN: ${{ steps.dispatch-token.outputs.token }}
+          VERSION: ${{ needs.prepare-environment-from-main.outputs.RELEASE_VERSION }}
+          RELEASE_TYPE: ${{ needs.prepare-environment-from-main.outputs.CBW_RELEASE_TYPE }}
+          EXTENSIONS: ${{ needs.publish.outputs.extensions }}
+        run: |
+          echo "Dispatching extension-publish event to code-builder-web with version $VERSION (release-type: $RELEASE_TYPE, extensions: $EXTENSIONS)"
+          gh api repos/forcedotcom/code-builder-web/dispatches \
+            --method POST \
+            -f event_type=extension-publish \
+            -f "client_payload[version]=$VERSION" \
+            -f "client_payload[source]=publishVSCode" \
+            -f "client_payload[release_type]=$RELEASE_TYPE" \
+            -f "client_payload[extensions]=$EXTENSIONS"
+          echo "Dispatch sent successfully"


### PR DESCRIPTION
## Summary
@W-22384617@

The `trigger-cbw-release` job introduced in #7273 uses a `uses:` reference to a reusable workflow in `forcedotcom/code-builder-web`. GitHub Actions blocks public repos from calling reusable workflows in private repos, even within the same org — so the `Publish in Microsoft Marketplace` workflow has been failing at workflow validation with 0 jobs scheduled (e.g. [run #25439642663](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/25439642663)).

This PR reverts the trigger job to a `repository_dispatch` API call. Behavior preserved:
- Still passes `extensions` (from `parse-extension-names.js`) so CBW can filter to only the extensions it bundles
- Still passes `version` and `release_type`
- Auth uses the "Platform Web IDE Release to Prod" GitHub App via the org-level `CBW_DISPATCH_APP_ID` variable + `CBW_DISPATCH_APP_PRIVATE_KEY` secret (least-privilege, short-lived token scoped to `code-builder-web`)

### Pairs with
- forcedotcom/code-builder-web#85 — re-adds `repository_dispatch: types: [extension-publish]` trigger on `release-on-extension-publish.yml` alongside `workflow_call`. Both PRs need to land for the next publish run to dispatch successfully.

### Why not just keep `uses:` and make CBW public?
Out of scope. The visibility constraint is real and not going away — `repository_dispatch` is the right pattern for cross-visibility cross-repo triggers.

## Test plan
- [ ] Confirm `salesforcedx-vscode` is on the access list for both `CBW_DISPATCH_APP_ID` (org variable) and `CBW_DISPATCH_APP_PRIVATE_KEY` (org secret) — verified
- [ ] After both this PR and #85 merge, next extension release publishes and successfully dispatches `extension-publish` to CBW with the `extensions` payload
- [ ] CBW's `release-on-extension-publish` run picks up the dispatch, polls marketplace, and triggers `release.yml` with the correct `release-type`