### PR TITLE
fix(ci): restore repository_dispatch trigger on release-on-extension-publish - W-22384617

### DIFF
--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -116,13 +116,36 @@ jobs:
       status: Not Implemented
 
   # Set repo variable CBW_TRIGGER_ENABLED=false to disable dispatch to code-builder-web.
-  # Default (unset): trigger CBW release after publish. Use when publishing without CBW promotion.
+  # Default (unset): dispatch after publish. Use when publishing without CBW promotion.
+  # Uses repository_dispatch (not workflow_call) because GitHub Actions blocks
+  # public repos from calling reusable workflows in private repos.
   trigger-cbw-release:
     needs: [publish, prepare-environment-from-main]
     if: needs.publish.result == 'success' && vars.CBW_TRIGGER_ENABLED != 'false'
-    uses: forcedotcom/code-builder-web/.github/workflows/release-on-extension-publish.yml@main
-    with:
-      extensions: ${{ needs.publish.outputs.extensions }}
-      version: ${{ needs.prepare-environment-from-main.outputs.RELEASE_VERSION }}
-      release-type: ${{ needs.prepare-environment-from-main.outputs.CBW_RELEASE_TYPE }}
-    secrets: inherit
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate dispatch token
+        id: dispatch-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.CBW_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.CBW_DISPATCH_APP_PRIVATE_KEY }}
+          owner: forcedotcom
+          repositories: code-builder-web
+      - name: Trigger Code Builder Web release
+        env:
+          GH_TOKEN: ${{ steps.dispatch-token.outputs.token }}
+          VERSION: ${{ needs.prepare-environment-from-main.outputs.RELEASE_VERSION }}
+          RELEASE_TYPE: ${{ needs.prepare-environment-from-main.outputs.CBW_RELEASE_TYPE }}
+          EXTENSIONS: ${{ needs.publish.outputs.extensions }}
+        run: |
+          echo "Dispatching extension-publish event to code-builder-web with version $VERSION (release-type: $RELEASE_TYPE, extensions: $EXTENSIONS)"
+          gh api repos/forcedotcom/code-builder-web/dispatches \
+            --method POST \
+            -f event_type=extension-publish \
+            -f "client_payload[version]=$VERSION" \
+            -f "client_payload[source]=publishVSCode" \
+            -f "client_payload[release_type]=$RELEASE_TYPE" \
+            -f "client_payload[extensions]=$EXTENSIONS"
+          echo "Dispatch sent successfully"

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -442,6 +442,12 @@
           "type": "boolean",
           "default": false,
           "description": "%soql_validation_flag%"
+        },
+        "salesforcedx-vscode-soql.maxQueryLimit": {
+          "type": "integer",
+          "default": 50000,
+          "minimum": 1,
+          "description": "%soql_max_query_limit%"
         }
       }
     },

--- a/packages/salesforcedx-vscode-soql/package.nls.json
+++ b/packages/salesforcedx-vscode-soql/package.nls.json
@@ -5,6 +5,7 @@
   "soql_open_new_text_editor": "SFDX: Create SOQL Query",
   "soql_builder_toggle": "Switch Between SOQL Builder and Text Editor",
   "soql_validation_flag": "Use REST API to validate SOQL queries and to identify errors.",
+  "soql_max_query_limit": "Maximum number of records to retrieve when running a query in the SOQL Builder. Default: 50000.\nWarning: Setting this to a high value may cause performance issues or timeouts.",
   "soql_walkthrough_open": "Open SOQL Walkthrough",
   "soql_walkthrough_title": "Get Started with SOQL",
   "soql_walkthrough_description": "Learn how to build and run SOQL queries using the visual SOQL Builder in VS Code.",

--- a/packages/salesforcedx-vscode-soql/src/commands/dataQuery.ts
+++ b/packages/salesforcedx-vscode-soql/src/commands/dataQuery.ts
@@ -16,7 +16,7 @@ type QueryResult = Awaited<ReturnType<Connection['query']>>;
 
 /**
  * Executes a SOQL query, auto-fetching all pages of results up to the user-configured
- * `org-max-query-limit` (default 10,000). Emits a lifecycle warning if results are truncated.
+ * `salesforcedx-vscode-soql.maxQueryLimit` setting (default 50,000).
  *
  * @param query - SOQL query string to execute
  * @param useTooling - Whether to use the Tooling API instead of REST
@@ -30,7 +30,12 @@ const runSoqlQuery = Effect.fn('runSoqlQuery')(function* (query: string, useTool
     nls.localize('data_query_running_query', useTooling ? nls.localize('tooling_API') : nls.localize('REST_API'))
   );
 
-  return yield* Effect.promise(() => connection.autoFetchQuery(query, { tooling: useTooling }));
+  const maxFetch = vscode.workspace.getConfiguration('salesforcedx-vscode-soql').get<number>('maxQueryLimit') ?? 50_000;
+  return yield* Effect.promise(() =>
+    useTooling
+      ? connection.tooling.query(query, { autoFetch: true, maxFetch })
+      : connection.query(query, { autoFetch: true, maxFetch })
+  );
 });
 
 const saveResultsToCSV = Effect.fn('saveResultsToCSV')(function* (queryResult: QueryResult) {

--- a/packages/salesforcedx-vscode-soql/src/editor/queryRunner.ts
+++ b/packages/salesforcedx-vscode-soql/src/editor/queryRunner.ts
@@ -17,16 +17,19 @@ const hasMessage = (obj: unknown): obj is { message: unknown } =>
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : hasMessage(error) ? String(error.message) : String(error);
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type QueryResult<T> = Awaited<ReturnType<Connection['query']>>;
+type QueryResult = Awaited<ReturnType<Connection['query']>>;
 
 export const runQuery =
   (conn: Connection) =>
-  async (queryText: string, options = { showErrors: true }): Promise<QueryResult<JsonMap>> => {
+  async (
+    queryText: string,
+    options: { showErrors?: boolean; maxRows?: number } = { showErrors: true }
+  ): Promise<QueryResult> => {
+    const { maxRows } = options;
     const pureSOQLText = soqlComments.parseHeaderComments(queryText).soqlText;
 
     try {
-      const rawQueryData = await conn.query(pureSOQLText);
+      const rawQueryData = await conn.query(pureSOQLText, { autoFetch: true, maxFetch: maxRows ?? 50_000 });
       return {
         ...rawQueryData,
         records: flattenQueryRecords(rawQueryData.records)

--- a/packages/salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts
+++ b/packages/salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts
@@ -229,6 +229,7 @@ export class SOQLEditorInstance {
         const runQueryDone = () => this.runQueryDone();
         const { document } = this;
         const openQueryDataView = (data: QueryResult<JsonMap>) => this.openQueryDataView(data);
+        const maxRows = vscode.workspace.getConfiguration('salesforcedx-vscode-soql').get<number>('maxQueryLimit');
         return Effect.gen(function* () {
           const isOrgSet = yield* Effect.promise(() => isDefaultOrgSet());
           if (!isOrgSet) {
@@ -247,7 +248,7 @@ export class SOQLEditorInstance {
                 location: vscode.ProgressLocation.Notification,
                 title: nls.localize('progress_running_query')
               },
-              () => runQuery(conn)(queryText)
+              () => runQuery(conn)(queryText, { maxRows })
             )
           );
           yield* Effect.promise(() => openQueryDataView(queryData));

--- a/packages/salesforcedx-vscode-soql/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-soql/src/messages/i18n.ts
@@ -66,7 +66,7 @@ export const messages = {
   data_query_running_query: 'Running query with %s...',
   data_query_complete: 'Query complete with %d records returned',
   data_query_warning_limit:
-    'Warning: The query result is missing %d records due to a %d record limit. Increase the number of records returned by setting the config value "org-max-query-limit" or the environment variable "SF_ORG_MAX_QUERY_LIMIT" to %d or greater than %d.',
+    'Warning: The query result is missing %d records due to a %d record limit. Increase the number of records returned by updating the "salesforcedx-vscode-soql.maxQueryLimit" setting to %d or greater than %d.',
   data_query_no_records: 'No records found',
   data_query_table_title: 'Query Results',
   soql_file_name_prompt: 'Enter a name for the new SOQL file',

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/app/app.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/app/app.ts
@@ -247,6 +247,7 @@ export default class App extends LightningElement {
   public handleLimitChanged(e: CustomEvent): void {
     this.modelService.changeLimit(e.detail.limit);
   }
+
   /* ---- WHERE HANDLERS ---- */
   public handleWhereSelection(e: CustomEvent): void {
     this.modelService.upsertWhereFieldExpr(e.detail);

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/limit/limit.html
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/limit/limit.html
@@ -27,7 +27,6 @@
         data-el-limit
         onchange={handleLimitChange}
         onkeyup={handleLimitChange}
-        max="2000"
       />
     </div>
   </div>

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/limit/limit.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/limit/limit.ts
@@ -21,10 +21,7 @@ export default class Limit extends LightningElement {
   public handleLimitChange(e: Event): void {
     e.preventDefault();
     const limit = e.target.value;
-    const sObjectSelected = new CustomEvent('limit__changed', {
-      detail: { limit }
-    });
-    this.dispatchEvent(sObjectSelected);
+    this.dispatchEvent(new CustomEvent('limit__changed', { detail: { limit } }));
   }
   /* eslint-enable @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access */
 }

--- a/packages/salesforcedx-vscode-soql/src/soql-data-view/index.html
+++ b/packages/salesforcedx-vscode-soql/src/soql-data-view/index.html
@@ -13,7 +13,13 @@
       <header>
         <div>
           <h3 id="webview-title"></h3>
-          <p id="total-records-size"></p>
+          <p id="total-records-size-row">
+            <span id="total-records-size"></span>
+            <span id="max-rows-hint" class="info-tooltip" hidden>
+              &#9432;
+              <span class="info-tooltip__text"></span>
+            </span>
+          </p>
         </div>
         <div class="button__save--group">
           <button id="save-csv-button" class="button__save">

--- a/packages/salesforcedx-vscode-soql/src/soql-data-view/queryDataView.css
+++ b/packages/salesforcedx-vscode-soql/src/soql-data-view/queryDataView.css
@@ -77,3 +77,36 @@ header {
   position: relative;
   top: 2px;
 }
+
+#total-records-size-row {
+  margin: 1em 0;
+}
+
+.info-tooltip {
+  position: relative;
+  cursor: default;
+  font-size: 1rem;
+  margin-left: 0.4rem;
+  color: var(--vscode-descriptionForeground, var(--soql-color-medium-grey));
+}
+
+.info-tooltip__text {
+  visibility: hidden;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  top: 1.4rem;
+  width: 22rem;
+  background: var(--vscode-editorHoverWidget-background, #fff);
+  color: var(--vscode-editorHoverWidget-foreground, #000);
+  border: 1px solid var(--vscode-editorHoverWidget-border, #ccc);
+  border-radius: 3px;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.85rem;
+  white-space: normal;
+  z-index: 10;
+}
+
+.info-tooltip:hover .info-tooltip__text {
+  visibility: visible;
+}

--- a/packages/salesforcedx-vscode-soql/src/soql-data-view/queryDataViewController.js
+++ b/packages/salesforcedx-vscode-soql/src/soql-data-view/queryDataViewController.js
@@ -78,6 +78,14 @@
     // Display the total number of records returned from the query
     const totalRecordsSizeEl = document.getElementById('total-records-size');
     totalRecordsSizeEl.innerText = `Returned ${queryData.records.length} of ${queryData.totalSize} total records`; // TODO: i18n
+    const hintEl = document.getElementById('max-rows-hint');
+    if (queryData.records.length < queryData.totalSize) {
+      hintEl.querySelector('.info-tooltip__text').innerText =
+        'To retrieve more records, update the Max Query Limit setting (salesforcedx-vscode-soql.maxQueryLimit).';
+      hintEl.removeAttribute('hidden');
+    } else {
+      hintEl.setAttribute('hidden', '');
+    }
 
     renderTableWith(queryData);
   }


### PR DESCRIPTION
## Summary
@W-22384617@

After landing the `workflow_call` rewrite, [salesforcedx-vscode publishVSCode.yml run #25439642663](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/25439642663) failed at workflow validation with 0 jobs scheduled. Root cause: GitHub Actions does not allow public repos to call reusable workflows in private repos via `uses:`, even within the same org. Per [GitHub docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#allowing-access-to-components-in-a-private-repository), access to a private repo's reusable workflows is allowed only from private repositories.

This PR re-adds the `repository_dispatch: types: [extension-publish]` trigger alongside `workflow_call`, so this workflow supports both visibility tiers:
- **Public callers** (e.g. `salesforcedx-vscode`) → `repository_dispatch`
- **Private callers** → `workflow_call`

Both paths authenticate with the same "Platform Web IDE Release to Prod" GitHub App and converge on the same `wait-and-release` job. Env vars use `inputs.X || github.event.client_payload.X` so the rest of the workflow doesn't care which trigger fired.

### Doc updates
- `README.md`: split onboarding into Option A (`repository_dispatch`) and Option B (`workflow_call`); workflow table updated
- `CLAUDE.md`: rewrote workflow description to cover both triggers
- `docs/application-lifecycle.md`: mermaid edge label and prose updated

### Pairs with
- forcedotcom/salesforcedx-vscode#TBD — switches the caller back to `repository_dispatch`. Both PRs need to land for the next publish run to dispatch successfully.

## Test plan
- [ ] Workflow file parses (verified locally with `yaml.safe_load`)
- [ ] After both PRs merge, next extension publish dispatches `extension-publish` and lands in this workflow's `wait-and-release` job
- [ ] `workflow_call` path remains functional for any future private callers