### PR TITLE
fix(lwc): remove duplicate registration of "SFDX: Create Lightning Web Component" command - W-22399742

### DIFF
--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -472,10 +472,6 @@
         {
           "command": "sf.lightning.lwc.test.stopWatchingAllTests",
           "when": "sf:project_opened || sf:internal_dev"
-        },
-        {
-          "command": "sf.metadata.lightning.generate.lwc",
-          "when": "sf:project_opened"
         }
       ]
     },


### PR DESCRIPTION
### What does this PR do?
The command **SFDX: Create Lightning Web Component** was registered twice in package.json.  This PR removes the duplicate registration so that the command only appears once in the command palette.

### What issues does this PR fix or reference?
@W-22399742@

### Functionality Before
<img width="1728" height="1117" alt="Screenshot 2026-05-06 at 6 00 45 PM" src="https://github.com/user-attachments/assets/c8754022-9e30-453d-802a-146268a67e01" />


### Functionality After
<img width="1728" height="1117" alt="Screenshot 2026-05-07 at 11 48 38 PM" src="https://github.com/user-attachments/assets/68d2039c-f60a-4e5a-9976-7b8031530cd4" />

