### PR TITLE
fix(metadata): add success notification for Deploy on Save - W-22399776

### DIFF
--- a/packages/salesforcedx-vscode-metadata/package.json
+++ b/packages/salesforcedx-vscode-metadata/package.json
@@ -355,6 +355,11 @@
           "type": "boolean",
           "default": false,
           "description": "%show_success_notification_description%"
+        },
+        "salesforcedx-vscode-metadata.deployOnSave.showSuccessNotification": {
+          "type": "boolean",
+          "default": false,
+          "description": "%deploy_on_save_show_success_notification_description%"
         }
       }
     },

--- a/packages/salesforcedx-vscode-metadata/package.nls.json
+++ b/packages/salesforcedx-vscode-metadata/package.nls.json
@@ -36,6 +36,7 @@
   "conflict_detection_enabled_description": "When enabled, check for conflicts before deploy/retrieve on orgs that don't support source tracking. Orgs with tracking always check conflicts.",
   "source_tracking_polling_interval_description": "Interval in seconds to poll for remote source tracking changes. Set to 0 to disable polling.",
   "show_success_notification_description": "Show an information notification on successful deploy, retrieve, or delete.",
+  "deploy_on_save_show_success_notification_description": "Show an information notification when deploy on save succeeds. Off by default to avoid notification storms with autosave.",
   "sobjects_refresh": "SFDX: Refresh SObject Definitions",
   "sobject_refresh_all": "All SObjects",
   "sobject_refresh_custom": "Custom SObjects",

--- a/packages/salesforcedx-vscode-metadata/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-metadata/src/messages/i18n.ts
@@ -42,6 +42,7 @@ export const messages = {
   deploy_select_file_or_directory: 'You can run SFDX: Deploy This Source to Org only on a source file or directory.',
   deploy_select_manifest: 'You can run SFDX: Deploy Source in Manifest to Org only on a manifest file.',
 
+  deploy_on_save_text: 'Deploy on save',
   deploy_on_save_error_no_target_org:
     'Error running deploy on save: No default org is set. Run "SFDX: Authorize an Org", then deploy the changes that you just saved.',
   deploy_on_save_error_generic: 'Deploy on save failed: %s',

--- a/packages/salesforcedx-vscode-metadata/src/services/deployOnSaveService.ts
+++ b/packages/salesforcedx-vscode-metadata/src/services/deployOnSaveService.ts
@@ -21,6 +21,7 @@ import { nls } from '../messages';
 import { getDeployOnSaveEnabled, getIgnoreConflicts } from '../settings/deployOnSaveSettings';
 import { deployComponentSet } from '../shared/deploy/deployComponentSet';
 import { DeployCompletedWithErrorsError } from '../shared/deploy/deployErrors';
+import { withConfigurableSuccessNotification } from '../utils/withConfigurableSuccessNotification';
 
 const ENQUEUE_DELAY_MS = 1000;
 
@@ -80,7 +81,9 @@ const deployQueuedFiles = Effect.fn('deployOnSave:deployQueuedFiles')(function* 
     }
   }
 
-  return yield* deployComponentSet({ componentSet });
+  return yield* deployComponentSet({ componentSet }).pipe(
+    withConfigurableSuccessNotification(nls.localize('command_succeeded_text', nls.localize('deploy_on_save_text')))
+  );
 });
 
 /** Handle deploy conflicts: populate conflict view scoped to the deployed component set */

--- a/packages/salesforcedx-vscode-metadata/src/services/deployOnSaveService.ts
+++ b/packages/salesforcedx-vscode-metadata/src/services/deployOnSaveService.ts
@@ -21,7 +21,6 @@ import { nls } from '../messages';
 import { getDeployOnSaveEnabled, getIgnoreConflicts } from '../settings/deployOnSaveSettings';
 import { deployComponentSet } from '../shared/deploy/deployComponentSet';
 import { DeployCompletedWithErrorsError } from '../shared/deploy/deployErrors';
-import { withConfigurableSuccessNotification } from '../utils/withConfigurableSuccessNotification';
 
 const ENQUEUE_DELAY_MS = 1000;
 
@@ -81,9 +80,15 @@ const deployQueuedFiles = Effect.fn('deployOnSave:deployQueuedFiles')(function* 
     }
   }
 
-  return yield* deployComponentSet({ componentSet }).pipe(
-    withConfigurableSuccessNotification(nls.localize('command_succeeded_text', nls.localize('deploy_on_save_text')))
-  );
+  const result = yield* deployComponentSet({ componentSet });
+  const showNotification = vscode.workspace
+    .getConfiguration('salesforcedx-vscode-metadata')
+    .get<boolean>('deployOnSave.showSuccessNotification', false);
+  if (showNotification)
+    void vscode.window.showInformationMessage(
+      nls.localize('command_succeeded_text', nls.localize('deploy_on_save_text'))
+    );
+  return result;
 });
 
 /** Handle deploy conflicts: populate conflict view scoped to the deployed component set */


### PR DESCRIPTION
### What does this PR do?
When users have the `salesforcedx-vscode-metadata.showSuccessNotification` setting turned on, they will get success notifications when deploys complete successfully.  However, that functionality did not translate to Deploy on Save.  This PR adds success notifications for Deploy on Save when the setting is checked.

<img width="1920" height="1080" alt="Screenshot 2026-05-08 at 12 19 24 AM" src="https://github.com/user-attachments/assets/070543e6-9820-4c5c-846d-bfaadef3c6d4" />

### What issues does this PR fix or reference?
@W-22399776@