### PR TITLE
fix(ci): add missing vscode_version input to servicesE2E workflow - W-22457072

### DIFF
--- a/.github/workflows/servicesE2E.yml
+++ b/.github/workflows/servicesE2E.yml
@@ -2,7 +2,21 @@ name: Services E2E (Playwright)
 
 on:
   workflow_dispatch:
+    inputs:
+      vscode_version:
+        description: 'VS Code version for E2E (e.g. 1.116.0). Empty uses repo variable
+          PLAYWRIGHT_VSCODE_VERSION.'
+        required: false
+        type: string
+        default: ''
   workflow_call:
+    inputs:
+      vscode_version:
+        description: 'VS Code version for E2E (e.g. 1.116.0). Empty uses repo variable
+          PLAYWRIGHT_VSCODE_VERSION.'
+        required: false
+        type: string
+        default: ''
   push:
     branches-ignore: [ main, develop ]
     paths-ignore:

--- a/.github/workflows/servicesE2E.yml
+++ b/.github/workflows/servicesE2E.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       vscode_version:
-        description: 'VS Code version for E2E (e.g. 1.116.0). Empty uses repo variable
+        description: 'VS Code version for E2E (e.g. 1.119.0). Empty uses repo variable
           PLAYWRIGHT_VSCODE_VERSION.'
         required: false
         type: string
@@ -12,7 +12,7 @@ on:
   workflow_call:
     inputs:
       vscode_version:
-        description: 'VS Code version for E2E (e.g. 1.116.0). Empty uses repo variable
+        description: 'VS Code version for E2E (e.g. 1.119.0). Empty uses repo variable
           PLAYWRIGHT_VSCODE_VERSION.'
         required: false
         type: string

--- a/packages/salesforcedx-vscode-i18n/src/hover/messageCache.ts
+++ b/packages/salesforcedx-vscode-i18n/src/hover/messageCache.ts
@@ -8,7 +8,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-export type MessageEntry = { text: string; namePos: number; nameEnd: number };
+type MessageEntry = { text: string; namePos: number; nameEnd: number };
 type MessagesMap = Record<string, MessageEntry>;
 
 type TsLike = {


### PR DESCRIPTION
## Summary
- `e2e.yml` was hitting `startup_failure` on every nightly run since May 5 because it passes `vscode_version` to `servicesE2E.yml`, but that workflow's `workflow_call` trigger had no inputs declared — GitHub Actions rejects undeclared inputs at startup, killing the entire E2E suite
- Added `vscode_version` input declarations to both `workflow_dispatch` and `workflow_call` triggers in `servicesE2E.yml`, matching the pattern used by all other Playwright E2E workflows
- Also removed unused `export` on `MessageEntry` type to fix pre-existing knip failure

@W-22457072@

## Test plan
- [ ] Merge to develop and verify the next Nightly Build Develop triggers e2e.yml without `startup_failure`
- [ ] Manually trigger `e2e.yml` via `workflow_dispatch` and confirm all jobs start