### PR TITLE
fix(ci): fix Playwright E2E workflow failures

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -118,91 +118,91 @@ jobs:
     uses: ./.github/workflows/playwrightVscodeExtE2E.yml
     secrets: inherit
     with:
-      vscode_version: ${{ inputs.vscodeVersion || 'latest' }}
+      vscode_version: ${{ inputs.vscodeVersion }}
 
   playwright-services:
     if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
     uses: ./.github/workflows/servicesE2E.yml
     secrets: inherit
     with:
-      vscode_version: ${{ inputs.vscodeVersion || 'latest' }}
+      vscode_version: ${{ inputs.vscodeVersion }}
 
   playwright-metadata:
     if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
     uses: ./.github/workflows/metadataE2E.yml
     secrets: inherit
     with:
-      vscode_version: ${{ inputs.vscodeVersion || 'latest' }}
+      vscode_version: ${{ inputs.vscodeVersion }}
 
   playwright-apex-log:
     if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
     uses: ./.github/workflows/apexLogE2E.yml
     secrets: inherit
     with:
-      vscode_version: ${{ inputs.vscodeVersion || 'latest' }}
+      vscode_version: ${{ inputs.vscodeVersion }}
 
   playwright-apex-testing:
     if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
     uses: ./.github/workflows/apexTestingE2E.yml
     secrets: inherit
     with:
-      vscode_version: ${{ inputs.vscodeVersion || 'latest' }}
+      vscode_version: ${{ inputs.vscodeVersion }}
 
   playwright-org:
     if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
     uses: ./.github/workflows/orgE2E.yml
     secrets: inherit
     with:
-      vscode_version: ${{ inputs.vscodeVersion || 'latest' }}
+      vscode_version: ${{ inputs.vscodeVersion }}
 
   playwright-org-browser:
     if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
     uses: ./.github/workflows/orgBrowserE2E.yml
     secrets: inherit
     with:
-      vscode_version: ${{ inputs.vscodeVersion || 'latest' }}
+      vscode_version: ${{ inputs.vscodeVersion }}
 
   playwright-soql:
     if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
     uses: ./.github/workflows/soqlE2E.yml
     secrets: inherit
     with:
-      vscode_version: ${{ inputs.vscodeVersion || 'latest' }}
+      vscode_version: ${{ inputs.vscodeVersion }}
 
   playwright-core:
     if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
     uses: ./.github/workflows/coreE2E.yml
     secrets: inherit
     with:
-      vscode_version: ${{ inputs.vscodeVersion || 'latest' }}
+      vscode_version: ${{ inputs.vscodeVersion }}
 
   playwright-apex-replay-debugger:
     if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
     uses: ./.github/workflows/apexReplayDebuggerE2E.yml
     secrets: inherit
     with:
-      vscode_version: ${{ inputs.vscodeVersion || 'latest' }}
+      vscode_version: ${{ inputs.vscodeVersion }}
 
   playwright-visualforce:
     if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
     uses: ./.github/workflows/visualforceE2E.yml
     secrets: inherit
     with:
-      vscode_version: ${{ inputs.vscodeVersion || 'latest' }}
+      vscode_version: ${{ inputs.vscodeVersion }}
 
   playwright-aura:
     if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
     uses: ./.github/workflows/auraE2E.yml
     secrets: inherit
     with:
-      vscode_version: ${{ inputs.vscodeVersion || 'latest' }}
+      vscode_version: ${{ inputs.vscodeVersion }}
 
   playwright-lwc:
     if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
     uses: ./.github/workflows/lwcPlaywrightE2E.yml
     secrets: inherit
     with:
-      vscode_version: ${{ inputs.vscodeVersion || 'latest' }}
+      vscode_version: ${{ inputs.vscodeVersion }}
 
   Apex_min_vscode_version:
     if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/playwrightE2EFullSuite.yml
+++ b/.github/workflows/playwrightE2EFullSuite.yml
@@ -81,8 +81,8 @@ jobs:
     with:
       vscode_version: ${{ inputs.vscode_version }}
 
-  snippets:
-    uses: ./.github/workflows/snippetsE2E.yml
+  lwc:
+    uses: ./.github/workflows/lwcPlaywrightE2E.yml
     secrets: inherit
     with:
       vscode_version: ${{ inputs.vscode_version }}


### PR DESCRIPTION
## Summary
- Replace deleted `snippetsE2E.yml` reference with `lwcPlaywrightE2E.yml` in `playwrightE2EFullSuite.yml`
- Remove `|| 'latest'` fallback for `vscode_version` in `e2e.yml` — the string `"latest"` is not a valid version for `@vscode/test-electron`, causing all Playwright desktop jobs to fail. Individual workflows already fall back to `vars.PLAYWRIGHT_VSCODE_VERSION` when the input is empty.

## Test plan
- [ ] Trigger `playwrightE2EFullSuite` workflow and verify the `lwc` job runs successfully
- [ ] Trigger `End to End Tests` workflow and verify Playwright desktop jobs no longer fail with `Invalid version latest`

[skip-validate-pr]

Test run: [Playwright E2E Full Suite](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/25814842233) ✅ 

🤖 Generated with [Claude Code](https://claude.com/claude-code)