### PR TITLE
fix: add root:true to recurring Effect spans trapped in activation traces - W-22491528

### DIFF
--- a/packages/salesforcedx-vscode-apex-log/src/logs/logAutoCollect.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/logs/logAutoCollect.ts
@@ -31,7 +31,7 @@ const isAfterTraceFlagStart =
     return userStart === undefined || st >= userStart;
   };
 
-const collectNewLogs = Effect.fn('LogAutoCollect.collectNewLogs')(function* (
+const collectNewLogs = Effect.fn('LogAutoCollect.collectNewLogs', { root: true })(function* (
   knownIdsRef: Ref.Ref<Set<string>>,
   collectorRef: SubscriptionRef.SubscriptionRef<LogCollectorState>
 ) {

--- a/packages/salesforcedx-vscode-apex-log/src/logs/logAutoCollect.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/logs/logAutoCollect.ts
@@ -31,10 +31,10 @@ const isAfterTraceFlagStart =
     return userStart === undefined || st >= userStart;
   };
 
-const collectNewLogs = Effect.fn('LogAutoCollect.collectNewLogs', { root: true })(function* (
-  knownIdsRef: Ref.Ref<Set<string>>,
-  collectorRef: SubscriptionRef.SubscriptionRef<LogCollectorState>
-) {
+const collectNewLogs = Effect.fn('LogAutoCollect.collectNewLogs', {
+  root: true,
+  attributes: { telemetryIgnore: true }
+})(function* (knownIdsRef: Ref.Ref<Set<string>>, collectorRef: SubscriptionRef.SubscriptionRef<LogCollectorState>) {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const knownIds = yield* Ref.get(knownIdsRef);
 

--- a/packages/salesforcedx-vscode-apex-testing/src/watchers/apexMetadataChangeWatcher.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/watchers/apexMetadataChangeWatcher.ts
@@ -18,9 +18,10 @@ import { getTestController } from '../views/testController';
 const APEX_METADATA_TYPES = new Set(['ApexClass', 'ApexTestSuite']);
 const APEX_CHANGE_TYPES = new Set<string>(['created', 'changed', 'deleted']);
 
-const filterApexTests = Effect.fn('isApexTestFileOrNotPresentLocally', { root: true })(function* (
-  e: MetadataChangeEventType
-) {
+const filterApexTests = Effect.fn('isApexTestFileOrNotPresentLocally', {
+  root: true,
+  attributes: { telemetryIgnore: true }
+})(function* (e: MetadataChangeEventType) {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const fsService = yield* api.services.FsService;
   // we can't read files we don't have anymore

--- a/packages/salesforcedx-vscode-apex-testing/src/watchers/apexMetadataChangeWatcher.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/watchers/apexMetadataChangeWatcher.ts
@@ -18,7 +18,9 @@ import { getTestController } from '../views/testController';
 const APEX_METADATA_TYPES = new Set(['ApexClass', 'ApexTestSuite']);
 const APEX_CHANGE_TYPES = new Set<string>(['created', 'changed', 'deleted']);
 
-const filterApexTests = Effect.fn('isApexTestFileOrNotPresentLocally')(function* (e: MetadataChangeEventType) {
+const filterApexTests = Effect.fn('isApexTestFileOrNotPresentLocally', { root: true })(function* (
+  e: MetadataChangeEventType
+) {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const fsService = yield* api.services.FsService;
   // we can't read files we don't have anymore

--- a/packages/salesforcedx-vscode-metadata/src/services/deployOnSaveService.ts
+++ b/packages/salesforcedx-vscode-metadata/src/services/deployOnSaveService.ts
@@ -52,7 +52,7 @@ export const shouldDeploy = Effect.fn('deployOnSave:shouldDeploy')(function* (ur
 
 /** Deploy queued files using MetadataDeployService */
 
-const deployQueuedFiles = Effect.fn('deployOnSave:deployQueuedFiles')(function* (uris: readonly URI[]) {
+const deployQueuedFiles = Effect.fn('deployOnSave:deployQueuedFiles', { root: true })(function* (uris: readonly URI[]) {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const [channelService, componentSetService, sourceTrackingService] = yield* Effect.all(
     [api.services.ChannelService, api.services.ComponentSetService, api.services.SourceTrackingService],

--- a/packages/salesforcedx-vscode-metadata/src/services/deployOnSaveService.ts
+++ b/packages/salesforcedx-vscode-metadata/src/services/deployOnSaveService.ts
@@ -52,7 +52,10 @@ export const shouldDeploy = Effect.fn('deployOnSave:shouldDeploy')(function* (ur
 
 /** Deploy queued files using MetadataDeployService */
 
-const deployQueuedFiles = Effect.fn('deployOnSave:deployQueuedFiles', { root: true })(function* (uris: readonly URI[]) {
+const deployQueuedFiles = Effect.fn('deployOnSave:deployQueuedFiles', {
+  root: true,
+  attributes: { telemetryIgnore: true }
+})(function* (uris: readonly URI[]) {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const [channelService, componentSetService, sourceTrackingService] = yield* Effect.all(
     [api.services.ChannelService, api.services.ComponentSetService, api.services.SourceTrackingService],

--- a/packages/salesforcedx-vscode-metadata/src/statusBar/sourceTrackingStatusBar.ts
+++ b/packages/salesforcedx-vscode-metadata/src/statusBar/sourceTrackingStatusBar.ts
@@ -18,7 +18,7 @@ import { calculateBackground, calculateCounts, dedupeStatus, getCommand, separat
 import { buildCombinedHoverText } from './hover';
 
 /** Refresh the status bar's data using data from tracking service */
-const refresh = Effect.fn('statusBarRefresh')(
+const refresh = Effect.fn('statusBarRefresh', { root: true })(
   function* (statusBarItem: vscode.StatusBarItem) {
     const api = yield* (yield* ExtensionProviderService).getServicesApi;
     const sourceTrackingService = yield* api.services.SourceTrackingService;

--- a/packages/salesforcedx-vscode-metadata/src/statusBar/sourceTrackingStatusBar.ts
+++ b/packages/salesforcedx-vscode-metadata/src/statusBar/sourceTrackingStatusBar.ts
@@ -18,7 +18,7 @@ import { calculateBackground, calculateCounts, dedupeStatus, getCommand, separat
 import { buildCombinedHoverText } from './hover';
 
 /** Refresh the status bar's data using data from tracking service */
-const refresh = Effect.fn('statusBarRefresh', { root: true })(
+const refresh = Effect.fn('statusBarRefresh', { root: true, attributes: { telemetryIgnore: true } })(
   function* (statusBarItem: vscode.StatusBarItem) {
     const api = yield* (yield* ExtensionProviderService).getServicesApi;
     const sourceTrackingService = yield* api.services.SourceTrackingService;

--- a/packages/salesforcedx-vscode-org/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-org/src/orgPicker/orgList.ts
@@ -266,9 +266,10 @@ type OrgTypeFromInfo = 'Scratch' | 'Sandbox' | 'Org';
 const getOrgTypeFromInfo = (orgInfo: typeof DefaultOrgInfoSchema.Type): OrgTypeFromInfo =>
   orgInfo.isScratch ? 'Scratch' : orgInfo.isSandbox ? 'Sandbox' : 'Org';
 
-const getStatusBarContent = Effect.fn('updateTargetOrgDisplay', { root: true })(function* (
-  orgInfo: typeof DefaultOrgInfoSchema.Type
-) {
+const getStatusBarContent = Effect.fn('updateTargetOrgDisplay', {
+  root: true,
+  attributes: { telemetryIgnore: true }
+})(function* (orgInfo: typeof DefaultOrgInfoSchema.Type) {
   const { username, aliases, isScratch } = orgInfo;
   if (!username) {
     return {

--- a/packages/salesforcedx-vscode-org/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-org/src/orgPicker/orgList.ts
@@ -266,7 +266,9 @@ type OrgTypeFromInfo = 'Scratch' | 'Sandbox' | 'Org';
 const getOrgTypeFromInfo = (orgInfo: typeof DefaultOrgInfoSchema.Type): OrgTypeFromInfo =>
   orgInfo.isScratch ? 'Scratch' : orgInfo.isSandbox ? 'Sandbox' : 'Org';
 
-const getStatusBarContent = Effect.fn('updateTargetOrgDisplay')(function* (orgInfo: typeof DefaultOrgInfoSchema.Type) {
+const getStatusBarContent = Effect.fn('updateTargetOrgDisplay', { root: true })(function* (
+  orgInfo: typeof DefaultOrgInfoSchema.Type
+) {
   const { username, aliases, isScratch } = orgInfo;
   if (!username) {
     return {


### PR DESCRIPTION
## Summary
- Recurring `Effect.fn` spans forked from activation effects inherited the parent span context, nesting under the long-lived activation trace in Tempo instead of appearing as independent root traces
- Added `{ root: true }` to 5 recurring span definitions across 4 extensions so each invocation starts its own trace
- Follows the same pattern already established in `traceFlagStatusBar.refresh`

## Changes
| Extension | File | Span name |
|-----------|------|-----------|
| metadata | `src/statusBar/sourceTrackingStatusBar.ts` | `statusBarRefresh` |
| metadata | `src/services/deployOnSaveService.ts` | `deployOnSave:deployQueuedFiles` |
| apex-log | `src/logs/logAutoCollect.ts` | `LogAutoCollect.collectNewLogs` |
| apex-testing | `src/watchers/apexMetadataChangeWatcher.ts` | `isApexTestFileOrNotPresentLocally` |
| org | `src/orgPicker/orgList.ts` | `updateTargetOrgDisplay` |

@W-22491528@

## Test plan
- [x] Pre-push hook ran compile, lint, and tests for all 4 affected packages
- [ ] Enable file traces, reload extensions, confirm affected spans appear as independent root traces in Tempo