### PR TITLE
fix: trace flag with coarser debug level is switched to use ReplayDebuggerLevels when ARD is run - W-22364952

### DIFF
--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/services/ensureTraceFlags.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/services/ensureTraceFlags.ts
@@ -9,14 +9,15 @@ import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import * as Effect from 'effect/Effect';
 import { AllServicesLayer } from './extensionProvider';
 
-/** Promise bridge for imperative code. Ensures trace flags exist for the current target org user. */
+/** Promise bridge for imperative code. Ensures trace flags exist for the current target org user with the ReplayDebuggerLevels debug level. */
 export const ensureTraceFlagsForCurrentUser = (): Promise<boolean> =>
   Effect.runPromise(
     Effect.gen(function* () {
       const api = yield* (yield* ExtensionProviderService).getServicesApi;
       const traceFlagService = yield* api.services.TraceFlagService;
       const userId = yield* traceFlagService.getUserId();
-      yield* traceFlagService.ensureTraceFlag(userId);
+      const debugLevelId = yield* traceFlagService.getOrCreateDebugLevel();
+      yield* traceFlagService.ensureTraceFlag(userId, undefined, undefined, debugLevelId);
       return true;
     }).pipe(
       Effect.catchAll(() => Effect.succeed(false)),


### PR DESCRIPTION
### What does this PR do?
Fixes a bug where the Apex Replay Debugger fails to run if the current trace flag is set to a level coarser than `ReplayDebuggerLevels`.  Now the trace flag switches its debug level from the coarser level to `ReplayDebuggerLevels` if the user runs Apex Replay Debugger.

### What issues does this PR fix or reference?
@W-22364952@

### Functionality Before
Trace flag remains with the coarser debug level.  User sees this error when running Apex Replay Debugger:
<img width="2032" height="1162" alt="Screenshot 2026-05-14 at 4 26 29 PM" src="https://github.com/user-attachments/assets/0ca60c05-ff93-41e1-b995-5ddb34fe91f1" />

### Functionality After
Trace flag is switched to debug level `ReplayDebuggerLevels`, which is compatible with Apex Replay Debugger.

### Testing
Trace flag is currently set to a coarse debug level incompatible for Apex Replay Debugger.
1. Click "Debug Test" code lens with ReplayDebuggerLevels already created -> existing trace flag switched to debug level ReplayDebuggerLevels ✅
2. Click "Debug Test" code lens without ReplayDebuggerLevels -> create ReplayDebuggerLevels debug level + switch existing trace flag to use it ✅
3. Run Apex Replay Debugger with ReplayDebuggerLevels already created -> existing trace flag switched to debug level ReplayDebuggerLevels ✅
4. Run Apex Replay Debugger without ReplayDebuggerLevels -> create ReplayDebuggerLevels debug level + switch existing trace flag to use it ✅
