### PR TITLE
fix: refresh TargetOrgRef on org switch so status bar updates - W-22544367

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -152,6 +152,56 @@
       }
     },
     {
+      "name": "Launch Extensions with Grafana Tracing",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}/packages/salesforcedx-vscode-visualforce",
+        "--extensionDevelopmentPath=${workspaceFolder}/packages/salesforcedx-vscode-soql",
+        "--extensionDevelopmentPath=${workspaceFolder}/packages/salesforcedx-vscode-lwc",
+        "--extensionDevelopmentPath=${workspaceFolder}/packages/salesforcedx-vscode-lightning",
+        "--extensionDevelopmentPath=${workspaceFolder}/packages/salesforcedx-vscode-core",
+        "--extensionDevelopmentPath=${workspaceFolder}/packages/salesforcedx-vscode-services",
+        "--extensionDevelopmentPath=${workspaceFolder}/packages/salesforcedx-vscode-org-browser",
+        "--extensionDevelopmentPath=${workspaceFolder}/packages/salesforcedx-vscode-org",
+        "--extensionDevelopmentPath=${workspaceFolder}/packages/salesforcedx-vscode-apex",
+        "--extensionDevelopmentPath=${workspaceFolder}/packages/salesforcedx-vscode-apex-testing",
+        "--extensionDevelopmentPath=${workspaceFolder}/packages/salesforcedx-vscode-apex-oas",
+        "--extensionDevelopmentPath=${workspaceFolder}/packages/salesforcedx-vscode-apex-replay-debugger",
+        "--extensionDevelopmentPath=${workspaceFolder}/packages/salesforcedx-vscode-apex-debugger",
+        "--extensionDevelopmentPath=${workspaceFolder}/packages/salesforcedx-vscode-apex-log",
+        "--extensionDevelopmentPath=${workspaceFolder}/packages/salesforcedx-vscode-metadata"
+      ],
+      "stopOnEntry": false,
+      "sourceMaps": true,
+      "smartStep": true,
+      "outFiles": [
+        "${workspaceFolder}/packages/*/out/src/**/*.js",
+        "${workspaceFolder}/packages/salesforcedx-vscode-apex-testing/dist/**/*.js",
+        "${workspaceFolder}/packages/salesforcedx-vscode-org-browser/dist/**/*.js",
+        "${workspaceFolder}/packages/salesforcedx-vscode-services/dist/**/*.js",
+        "${workspaceFolder}/packages/salesforcedx-vscode-metadata/dist/**/*.js",
+        "${workspaceFolder}/packages/salesforcedx-vscode-org/dist/**/*.js",
+        "${workspaceFolder}/packages/salesforcedx-vscode-apex/dist/**/*.js",
+        "${workspaceFolder}/packages/salesforcedx-vscode-apex-log/dist/**/*.js",
+        "${workspaceFolder}/packages/salesforcedx-vscode-apex-replay-debugger/dist/**/*.js",
+        "${workspaceFolder}/packages/salesforcedx-vscode-visualforce/dist/**/*.js"
+      ],
+      "env": {
+        "LANGUAGE_SERVER_LOG_LEVEL": "${env:LANGUAGE_SERVER_LOG_LEVEL}",
+        "SUSPEND_LANGUAGE_SERVER_STARTUP": "${env:SUSPEND_LANGUAGE_SERVER_STARTUP}",
+        "YOURKIT_PROFILER_AGENT": "${env:YOURKIT_PROFILER_AGENT}",
+        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318"
+      },
+      "sourceMapPathOverrides": {
+        "webpack:///salesforcedx-utils-vscode/./*": "${workspaceFolder}/packages/salesforcedx-utils-vscode/*",
+        "webpack:///salesforcedx-vscode-soql/./*": "${workspaceFolder}/packages/salesforcedx-vscode-soql/*",
+        "webpack:///salesforcedx-vscode-soql/../salesforcedx-utils-vscode/*": "${workspaceFolder}/packages/salesforcedx-utils-vscode/*",
+        "webpack:///*": "*"
+      }
+    },
+    {
       "name": "Launch Apex Debug adapter",
       "type": "node",
       "request": "launch",

--- a/packages/salesforcedx-vscode-org/src/util/orgUtil.ts
+++ b/packages/salesforcedx-vscode-org/src/util/orgUtil.ts
@@ -103,6 +103,15 @@ export const getAuthFieldsFor = async (username: string): Promise<AuthFields> =>
 
   return authInfo.getFields();
 };
+const refreshConnection = Effect.fn('updateConfigAndStateAggregators', {
+  root: true,
+  attributes: { telemetryIgnore: true }
+})(function* () {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  yield* api.services.ConfigService.invalidateConfigAggregator();
+  yield* api.services.ConnectionService.invalidateCachedConnections();
+  yield* api.services.ConnectionService.getConnection().pipe(Effect.catchAll(() => Effect.void));
+});
 
 export const updateConfigAndStateAggregators = async (): Promise<void> => {
   // Force the ConfigAggregatorProvider to reload its stored
@@ -115,12 +124,7 @@ export const updateConfigAndStateAggregators = async (): Promise<void> => {
   // including the default one used by AuthInfo.listAllAuthorizations().
   await StateAggregator.clearInstanceAsync();
 
-  await getOrgRuntime().runPromise(
-    Effect.gen(function* () {
-      const api = yield* (yield* ExtensionProviderService).getServicesApi;
-      yield* api.services.ConnectionService.invalidateCachedConnections();
-    })
-  );
+  await getOrgRuntime().runPromise(refreshConnection());
 
   // Trigger Apex Test Controller to discover tests after org auth/set-default. Delay so config
   // and TargetOrgRef can propagate before refresh runs.

--- a/packages/salesforcedx-vscode-org/test/jest/util/orgUtil.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/util/orgUtil.test.ts
@@ -22,9 +22,14 @@ import * as Layer from 'effect/Layer';
 import * as SubscriptionRef from 'effect/SubscriptionRef';
 import * as vscode from 'vscode';
 import { channelService } from '../../../src/channels';
+import { resetOrgRuntimeForTesting, setAllServicesLayer } from '../../../src/extensionProvider';
 import * as extensionProvider from '../../../src/extensionProvider';
 import { nls } from '../../../src/messages';
-import { checkForSoonToBeExpiredOrgs, setTargetOrgOrAlias } from '../../../src/util/orgUtil';
+import {
+  checkForSoonToBeExpiredOrgs,
+  setTargetOrgOrAlias,
+  updateConfigAndStateAggregators
+} from '../../../src/util/orgUtil';
 
 describe('orgUtil tests', () => {
   let showWarningMessageSpy: jest.SpyInstance;
@@ -391,5 +396,67 @@ describe('testing setTargetOrgOrAlias', () => {
 
     expect(writeCallOrder).toBeLessThan(reloadCallOrder);
     expect(reloadCallOrder).toBeLessThan(clearInstanceCallOrder);
+  });
+});
+
+describe('updateConfigAndStateAggregators', () => {
+  let getConnectionMock: jest.Mock;
+  let invalidateCachedConnectionsMock: jest.Mock;
+  let invalidateConfigAggregatorMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    resetOrgRuntimeForTesting();
+
+    jest.spyOn(ConfigAggregatorProvider, 'getInstance').mockReturnValue({
+      reloadConfigAggregators: jest.fn()
+    } as any);
+    jest.spyOn(StateAggregator, 'clearInstanceAsync').mockResolvedValue();
+    (vscode.commands.executeCommand as jest.Mock).mockResolvedValue(undefined);
+
+    getConnectionMock = jest.fn().mockReturnValue(Effect.succeed({}));
+    invalidateCachedConnectionsMock = jest.fn().mockReturnValue(Effect.void);
+    invalidateConfigAggregatorMock = jest.fn().mockReturnValue(Effect.void);
+
+    const mockServicesApi = {
+      services: {
+        ConfigService: {
+          invalidateConfigAggregator: invalidateConfigAggregatorMock
+        },
+        ConnectionService: {
+          getConnection: getConnectionMock,
+          invalidateCachedConnections: invalidateCachedConnectionsMock
+        }
+      }
+    } as unknown as SalesforceVSCodeServicesApi;
+
+    const layer = Layer.succeed(ExtensionProviderService, {
+      getServicesApi: Effect.succeed(mockServicesApi) as ExtensionProviderServiceType['getServicesApi']
+    });
+
+    resetOrgRuntimeForTesting();
+    setAllServicesLayer(layer as ReturnType<typeof extensionProvider.buildAllServicesLayer>);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    resetOrgRuntimeForTesting();
+  });
+
+  it('should call getConnection after invalidating caches to refresh TargetOrgRef', async () => {
+    await updateConfigAndStateAggregators();
+
+    expect(invalidateConfigAggregatorMock).toHaveBeenCalled();
+    expect(invalidateCachedConnectionsMock).toHaveBeenCalled();
+    expect(getConnectionMock).toHaveBeenCalled();
+  });
+
+  it('should not throw when getConnection fails', async () => {
+    getConnectionMock.mockReturnValue(Effect.fail(new Error('No target org configured')));
+
+    await expect(updateConfigAndStateAggregators()).resolves.toBeUndefined();
+    expect(invalidateConfigAggregatorMock).toHaveBeenCalled();
+    expect(invalidateCachedConnectionsMock).toHaveBeenCalled();
+    expect(getConnectionMock).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- When the default org is changed via the org picker, the source tracking status bar was not refreshing because `updateConfigAndStateAggregators` only invalidated caches without calling `getConnection()` — relying entirely on the file system watcher to detect the `.sf/config.json` write and trigger the TargetOrgRef update.
- Now proactively invalidates the config aggregator, clears connection cache, and calls `getConnection()` which triggers `maybeUpdateDefaultOrgRef` to update the TargetOrgRef — causing downstream subscribers (source tracking status bar, org picker) to refresh.
- Adds a root span `updateConfigAndStateAggregators` for observability in Tempo.

## Test plan
- [x] Unit tests pass (`packages/salesforcedx-vscode-org`)
- [x] New tests verify `getConnection` is called after cache invalidation
- [x] New tests verify graceful handling when `getConnection` fails (e.g. after logout)
- [x] Manual: switch orgs via org picker, verify source tracking status bar refreshes
- [x] Manual: verify `updateConfigAndStateAggregators` trace appears in Tempo with child spans
@W-22544367@