### PR TITLE
fix(services): honor custom metadata templates in TemplateService - W-22563778

### DIFF
--- a/packages/salesforcedx-vscode-services/src/core/templateService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/templateService.ts
@@ -29,7 +29,7 @@ export { TemplateType, type CreateOutput } from '@salesforce/templates';
 /**
  * Project options where `ns` and `loginurl` may be omitted by callers; the
  * service fills defaults (no namespace, production login URL) before invoking
- * @salesforce/templates which requires both as strings.
+ * @salesforce/templates which requires both as strings
  */
 type ProjectCreateOptions = Omit<SfTemplates.ProjectOptions, 'ns' | 'loginurl'> & {
   readonly ns?: string;

--- a/packages/salesforcedx-vscode-services/src/core/templateService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/templateService.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { OrgConfigProperties } from '@salesforce/core';
 import * as SfTemplates from '@salesforce/templates';
 import * as Effect from 'effect/Effect';
 import * as Option from 'effect/Option';
@@ -18,6 +19,7 @@ import * as vscode from 'vscode';
 import { Utils, type URI } from 'vscode-uri';
 import { nls } from '../messages';
 import { uriToPath } from '../vscode/paths';
+import { ConfigService } from './configService';
 import { ConnectionService } from './connectionService';
 import { ProjectService } from './projectService';
 
@@ -231,8 +233,15 @@ const withProjectDefaults = (params: CreateParams<SfTemplates.TemplateType>): Cr
  */
 export class TemplateService extends Effect.Service<TemplateService>()('TemplateService', {
   accessors: true,
-  dependencies: [ProjectService.Default, ConnectionService.Default],
+  dependencies: [ProjectService.Default, ConnectionService.Default, ConfigService.Default],
   effect: Effect.gen(function* () {
+    const resolveCustomTemplatesPath = Effect.fn('TemplateService.resolveCustomTemplatesPath')(function* () {
+      const configService = yield* ConfigService;
+      const agg = yield* configService.getConfigAggregator();
+      const value = agg.getPropertyValue<string>(OrgConfigProperties.ORG_CUSTOM_METADATA_TEMPLATES);
+      return value ? String(value) : undefined;
+    });
+
     const getTemplatesRootCached = yield* Effect.cached(getTemplatesRoot());
     const ensureTemplatesInFsOnce = yield* Effect.once(
       getTemplatesRootCached.pipe(
@@ -257,7 +266,10 @@ export class TemplateService extends Effect.Service<TemplateService>()('Template
             outputdir: path.relative(params.cwd, uriToPath(params.outputdir))
           }
         : optionsWithApiVersion;
-      return yield* Effect.tryPromise(() => templateService.create(params.templateType, templateOptions));
+      const customTemplatesPath = yield* resolveCustomTemplatesPath().pipe(Effect.orElseSucceed(() => undefined));
+      return yield* Effect.tryPromise(() =>
+        templateService.create(params.templateType, templateOptions, customTemplatesPath)
+      );
     });
     return { create };
   })

--- a/packages/salesforcedx-vscode-services/test/jest/core/templateService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/templateService.test.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { OrgConfigProperties } from '@salesforce/core';
+import type { ConfigAggregator } from '@salesforce/core/configAggregator';
+import * as SfTemplates from '@salesforce/templates';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+import { URI } from 'vscode-uri';
+import { ConfigService } from '../../../src/core/configService';
+import { ConnectionService } from '../../../src/core/connectionService';
+import { ProjectService } from '../../../src/core/projectService';
+import { TemplateService } from '../../../src/core/templateService';
+
+jest.mock('@salesforce/templates');
+jest.mock('node:fs');
+
+const vscode = require('vscode');
+
+const mockCreate = jest.fn();
+
+const mockExtensionUri = URI.file('/ext');
+
+const ORG_CUSTOM_METADATA_TEMPLATES_KEY: string = OrgConfigProperties.ORG_CUSTOM_METADATA_TEMPLATES;
+
+const createMockConfigService = (templateDir?: string): Layer.Layer<ConfigService> =>
+  Layer.succeed(
+    ConfigService,
+    ConfigService.make({
+      getConfigAggregator: () =>
+        Effect.succeed({
+          getPropertyValue: (prop: string) => (prop === ORG_CUSTOM_METADATA_TEMPLATES_KEY ? templateDir : undefined),
+          getConfig: () => ({}),
+          reload: () => Promise.resolve({})
+        } as unknown as ConfigAggregator),
+      invalidateConfigAggregator: () => Effect.void,
+      getTargetDevHub: () => Effect.succeed(undefined),
+      isCurrentTargetOrg: () => Effect.succeed(false),
+      isCurrentTargetDevHub: () => Effect.succeed(false),
+      unsetTargetOrg: () => Effect.void,
+      unsetTargetDevHub: () => Effect.void
+    })
+  );
+
+const createFailingConfigService = (): Layer.Layer<ConfigService> =>
+  Layer.succeed(
+    ConfigService,
+    ConfigService.make({
+      getConfigAggregator: () =>
+        Effect.fail(
+          new Error(
+            'config unavailable'
+          ) as unknown as import('../../../src/core/configService').FailedToCreateConfigAggregatorError
+        ),
+      invalidateConfigAggregator: () => Effect.void,
+      getTargetDevHub: () => Effect.succeed(undefined),
+      isCurrentTargetOrg: () => Effect.succeed(false),
+      isCurrentTargetDevHub: () => Effect.succeed(false),
+      unsetTargetOrg: () => Effect.void,
+      unsetTargetDevHub: () => Effect.void
+    })
+  );
+
+const createMockProjectService = (): Layer.Layer<ProjectService> => {
+  const mockSfProject = {
+    retrieveSfProjectJson: () => Promise.resolve({ get: () => '60.0' })
+  } as unknown as import('@salesforce/core').SfProject;
+  return Layer.succeed(
+    ProjectService,
+    ProjectService.make({
+      isSalesforceProject: () => Effect.succeed(true),
+      getSfProject: () => Effect.succeed(mockSfProject),
+      isInPackageDirectories: () => Effect.succeed(true),
+      ensureInPackageDirectories: () => Effect.void,
+      getSoqlMetadataPath: () => Effect.succeed(URI.file('/test/soql')),
+      getSoqlStandardObjectsPath: () => Effect.succeed(URI.file('/test/soql/std')),
+      getSoqlCustomObjectsPath: () => Effect.succeed(URI.file('/test/soql/custom')),
+      getFauxClassesPath: () => Effect.succeed(URI.file('/test/faux')),
+      getFauxStandardObjectsPath: () => Effect.succeed(URI.file('/test/faux/std')),
+      getFauxCustomObjectsPath: () => Effect.succeed(URI.file('/test/faux/custom')),
+      getTypingsPath: () => Effect.succeed(URI.file('/test/.sfdx/typings'))
+    })
+  );
+};
+
+const createMockConnectionService = (): Layer.Layer<ConnectionService> =>
+  Layer.succeed(
+    ConnectionService,
+    ConnectionService.make({
+      getConnection: () => Effect.succeed({ version: '60.0' } as unknown as import('@salesforce/core').Connection),
+      invalidateCachedConnections: () => Effect.void
+    })
+  );
+
+const createTestLayer = (configLayer: Layer.Layer<ConfigService>) => {
+  const deps = Layer.mergeAll(createMockProjectService(), createMockConnectionService(), configLayer);
+  return Layer.provideMerge(TemplateService.Default, deps);
+};
+
+const baseParams = {
+  cwd: '/test-project',
+  templateType: SfTemplates.TemplateType.ApexClass,
+  options: { template: 'DefaultApexClass', classname: 'MyClass' }
+} as const;
+
+describe('TemplateService', () => {
+  beforeEach(() => {
+    mockCreate.mockReset();
+    mockCreate.mockResolvedValue({ created: ['MyClass.cls'] });
+    (SfTemplates.TemplateService.getInstance as jest.Mock).mockReturnValue({ create: mockCreate });
+    vscode.extensions = {
+      getExtension: jest.fn().mockReturnValue({ extensionUri: mockExtensionUri })
+    };
+  });
+
+  it('passes custom templates path when ORG_CUSTOM_METADATA_TEMPLATES is set', async () => {
+    const layer = createTestLayer(createMockConfigService('/my/custom/templates'));
+
+    await Effect.runPromise(
+      TemplateService.create(baseParams as Parameters<typeof TemplateService.create>[0]).pipe(Effect.provide(layer))
+    );
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      SfTemplates.TemplateType.ApexClass,
+      expect.objectContaining({ classname: 'MyClass' }),
+      '/my/custom/templates'
+    );
+  });
+
+  it('passes undefined when ORG_CUSTOM_METADATA_TEMPLATES is not set', async () => {
+    const layer = createTestLayer(createMockConfigService(undefined));
+
+    await Effect.runPromise(
+      TemplateService.create(baseParams as Parameters<typeof TemplateService.create>[0]).pipe(Effect.provide(layer))
+    );
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      SfTemplates.TemplateType.ApexClass,
+      expect.objectContaining({ classname: 'MyClass' }),
+      undefined
+    );
+  });
+
+  it('falls back to undefined when getConfigAggregator fails', async () => {
+    const layer = createTestLayer(createFailingConfigService());
+
+    await Effect.runPromise(
+      TemplateService.create(baseParams as Parameters<typeof TemplateService.create>[0]).pipe(Effect.provide(layer))
+    );
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      SfTemplates.TemplateType.ApexClass,
+      expect.objectContaining({ classname: 'MyClass' }),
+      undefined
+    );
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Passes the `org-custom-metadata-templates` CLI config value to `@salesforce/templates` when generating metadata, fixing commands like "SFDX: Create Apex Class" that previously ignored custom templates.

### What issues does this PR fix or reference?

#7332, @W-22563778@

### Manual testing instructions

1. **Setup custom templates:**
   - Create directory structure: `mkdir -p <project>/.config/templates/apexclass`
   - Create template file `<project>/.config/templates/apexclass/DefaultApexClass.cls`:
     ```
     public with sharing class <%= apiName %> {
         // CUSTOM TEMPLATE MARKER
         public <%= apiName %>() {
         }
     }
     ```

2. **Configure the CLI (must be run from within a DX project):**
   ```
   sf config set org-custom-metadata-templates=<absolute-path-to>/templates
   ```
   Note: the path must point to the directory that directly contains subdirectories like `apexclass/`, not a parent above it.

3. **Test custom template is honored:**
   - Run command "SFDX: Create Apex Class" → select DefaultApexClass → enter a name
   - **Expected:** Generated class contains `// CUSTOM TEMPLATE MARKER`

4. **Test fallback when no custom template exists for a category:**
   - Do NOT create a custom `apextrigger/` directory
   - Run "SFDX: Create Apex Trigger"
   - **Expected:** Default built-in trigger template is used (no error)

5. **Test graceful fallback when config is unset:**
   - Run: `sf config unset org-custom-metadata-templates`
   - Run "SFDX: Create Apex Class"
   - **Expected:** Default built-in template is used (no error)