### PR TITLE
feat(eslint): prevent default: true in VSCode settings - W-22599687

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -769,6 +769,7 @@ export default [
       'local/package-json-extension-icon': 'error',
       'local/package-json-icon-paths': 'error',
       'local/package-json-command-refs': 'error',
+      'local/package-json-no-default-true': 'error',
       'local/package-json-view-refs': 'error',
       'local/package-json-salesforce-dep-versions': 'error'
     }

--- a/packages/eslint-local-rules/src/index.ts
+++ b/packages/eslint-local-rules/src/index.ts
@@ -23,6 +23,7 @@ import { packageJsonCommandRefs } from './packageJsonCommandRefs';
 import { packageJsonExtensionIcon } from './packageJsonExtensionIcon';
 import { packageJsonI18nDescriptions } from './packageJsonI18nDescriptions';
 import { packageJsonIconPaths } from './packageJsonIconPaths';
+import { packageJsonNoDefaultTrue } from './packageJsonNoDefaultTrue';
 import { packageJsonSalesforceDepVersions } from './packageJsonSalesforceDepVersions';
 import { packageJsonViewRefs } from './packageJsonViewRefs';
 import { queryBuilderHtmlI18nKeys } from './queryBuilderHtmlI18nKeys';
@@ -56,6 +57,7 @@ const plugin = {
     'package-json-extension-icon': packageJsonExtensionIcon,
     'package-json-icon-paths': packageJsonIconPaths,
     'package-json-command-refs': packageJsonCommandRefs,
+    'package-json-no-default-true': packageJsonNoDefaultTrue,
     'package-json-salesforce-dep-versions': packageJsonSalesforceDepVersions,
     'package-json-view-refs': packageJsonViewRefs,
     'vscodeignore-contributes-conflict': vscodeignoreContributesConflict,

--- a/packages/eslint-local-rules/src/packageJsonNoDefaultTrue.ts
+++ b/packages/eslint-local-rules/src/packageJsonNoDefaultTrue.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * ESLint rule: package-json-no-default-true
+ *
+ * Prevents VSCode configuration settings from using default: true, which creates
+ * unintuitive override behavior in the settings hierarchy.
+ *
+ * Problem: When a user sets a default:true setting to false globally, they cannot
+ * re-enable it for a specific workspace without explicitly setting it to true in
+ * workspace settings. This violates expectations about settings inheritance.
+ *
+ * Example from issue #6784:
+ * - Setting: salesforcedx-vscode-core.show-cli-success-msg (default: true)
+ * - User disables globally → false in User settings
+ * - User wants to enable for one workspace → Must set true in Workspace settings (unintuitive)
+ *
+ * Recommended alternatives:
+ * 1. Use default: false (opt-in) with positive naming
+ * - "enableFeature" default: false
+ * 2. Use default: false with negative naming
+ * - "suppressNotifications" default: false (false means show, true means hide)
+ *
+ * References:
+ * - GitHub issue: https://github.com/forcedotcom/salesforcedx-vscode/issues/6784
+ * - Slack discussion: https://salesforce-internal.slack.com/archives/C041ZPJH317/p1776276403896449
+ */
+
+import type { ArrayNode, ObjectNode, StringNode, ValueNode } from '@humanwhocodes/momoa';
+import type { Rule } from 'eslint';
+
+import { findNodeAtPath } from './jsonAstUtils';
+
+// Grandfathered settings that existed before this rule.
+// These are exempted to avoid breaking changes for existing users.
+// All new settings MUST use default: false.
+const ALLOWED_DEFAULT_TRUE_SETTINGS = new Set([
+  // visualforce (6 settings)
+  'visualforce.format.enable',
+  'visualforce.format.preserveNewLines',
+  'visualforce.suggest.html5',
+  'visualforce.validate.scripts',
+  'visualforce.validate.styles',
+  'visualforce.autoClosingTags',
+  // core (2 settings)
+  'salesforcedx-vscode-core.show-cli-success-msg',
+  'salesforcedx-vscode-core.telemetry.enabled',
+  // metadata (1 setting)
+  'salesforcedx-vscode-metadata.sourceTracking.enableConflictDetection',
+  // apex (1 setting)
+  'salesforcedx-vscode-apex.advanced.lspParityCapabilities'
+]);
+
+/**
+ * Checks if a type node indicates a boolean type.
+ * Handles both "boolean" string and ["boolean", ...] array cases.
+ */
+const isBooleanType = (typeNode: ValueNode): boolean => {
+  if (typeNode.type === 'String') {
+    return typeNode.value === 'boolean';
+  }
+  if (typeNode.type === 'Array') {
+    return (typeNode as ArrayNode).elements.some(
+      el => el.value.type === 'String' && (el.value as StringNode).value === 'boolean'
+    );
+  }
+  return false;
+};
+
+export const packageJsonNoDefaultTrue: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Prevent default: true on boolean VSCode configuration settings'
+    },
+    schema: [],
+    messages: {
+      defaultTrue:
+        "VSCode setting '{{setting}}' has default: true, which creates unintuitive override behavior. Use default: false (opt-in) or rephrase negatively (e.g., 'suppress' instead of 'show')."
+    }
+  },
+  create: context => {
+    const filename = context.filename ?? context.getFilename();
+    if (!filename.match(/packages\/[^/]+\/package\.json$/)) {
+      return {};
+    }
+
+    return {
+      // @eslint/json provides JSON AST with Document as root node
+      'Document:exit': (node: any) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        const ast = node?.body as ValueNode | undefined;
+        if (ast?.type !== 'Object') {
+          return;
+        }
+
+        // Find the contributes.configuration.properties object
+        const propertiesNodes = findNodeAtPath(ast, ['contributes', 'configuration', 'properties']);
+        if (propertiesNodes.length === 0 || propertiesNodes[0].type !== 'Object') {
+          return;
+        }
+
+        const propertiesNode = propertiesNodes[0] as ObjectNode;
+
+        // Iterate through each property definition
+        for (const propertyMember of propertiesNode.members) {
+          const propertyName = propertyMember.name.type === 'String' ? propertyMember.name.value : undefined;
+          if (!propertyName || propertyMember.value.type !== 'Object') {
+            continue;
+          }
+
+          // Check if this property is allowlisted
+          if (ALLOWED_DEFAULT_TRUE_SETTINGS.has(propertyName)) {
+            continue;
+          }
+
+          const propertyObject = propertyMember.value as ObjectNode;
+
+          // Find the type and default members
+          let typeNode: ValueNode | undefined;
+          let defaultNode: ValueNode | undefined;
+          let defaultMemberNode: any;
+
+          for (const member of propertyObject.members) {
+            if (member.name.type === 'String') {
+              if (member.name.value === 'type') {
+                typeNode = member.value;
+              } else if (member.name.value === 'default') {
+                defaultNode = member.value;
+                defaultMemberNode = member;
+              }
+            }
+          }
+
+          // Check if this is a boolean type with default: true
+          if (typeNode && isBooleanType(typeNode) && defaultNode?.type === 'Boolean' && defaultNode.value === true) {
+            context.report({
+              node: defaultMemberNode as unknown as Rule.Node,
+              messageId: 'defaultTrue',
+              data: { setting: propertyName }
+            });
+          }
+        }
+      }
+    } as Rule.RuleListener;
+  }
+};

--- a/packages/eslint-local-rules/test/packageJsonNoDefaultTrue.test.ts
+++ b/packages/eslint-local-rules/test/packageJsonNoDefaultTrue.test.ts
@@ -1,0 +1,333 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { packageJsonNoDefaultTrue } from '../src/packageJsonNoDefaultTrue';
+import { createJsonLinter, filterByRule } from './jsonLintHelper';
+
+const RULE_NAME = 'package-json-no-default-true';
+
+describe('package-json-no-default-true', () => {
+  it('should be exported', () => {
+    expect(packageJsonNoDefaultTrue).toBeDefined();
+    expect(packageJsonNoDefaultTrue.meta).toBeDefined();
+    expect(packageJsonNoDefaultTrue.meta?.type).toBe('problem');
+  });
+
+  describe('with Linter', () => {
+    const lintJson = createJsonLinter(RULE_NAME, packageJsonNoDefaultTrue);
+
+    it('should pass when boolean setting uses default: false', () => {
+      const code = JSON.stringify(
+        {
+          name: 'test',
+          contributes: {
+            configuration: {
+              properties: {
+                'test.setting': {
+                  type: 'boolean',
+                  default: false,
+                  description: '%test_description%'
+                }
+              }
+            }
+          }
+        },
+        null,
+        2
+      );
+
+      const errors = filterByRule(lintJson(code), RULE_NAME);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should pass when boolean setting uses default: null', () => {
+      const code = JSON.stringify(
+        {
+          name: 'test',
+          contributes: {
+            configuration: {
+              properties: {
+                'test.setting': {
+                  type: 'boolean',
+                  default: null,
+                  description: '%test_description%'
+                }
+              }
+            }
+          }
+        },
+        null,
+        2
+      );
+
+      const errors = filterByRule(lintJson(code), RULE_NAME);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should pass when non-boolean setting uses default: true', () => {
+      const code = JSON.stringify(
+        {
+          name: 'test',
+          contributes: {
+            configuration: {
+              properties: {
+                'test.stringSetting': {
+                  type: 'string',
+                  default: 'true',
+                  description: '%test_description%'
+                }
+              }
+            }
+          }
+        },
+        null,
+        2
+      );
+
+      const errors = filterByRule(lintJson(code), RULE_NAME);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should pass when number setting uses default: 1', () => {
+      const code = JSON.stringify(
+        {
+          name: 'test',
+          contributes: {
+            configuration: {
+              properties: {
+                'test.numberSetting': {
+                  type: 'number',
+                  default: 1,
+                  description: '%test_description%'
+                }
+              }
+            }
+          }
+        },
+        null,
+        2
+      );
+
+      const errors = filterByRule(lintJson(code), RULE_NAME);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should pass for allowlisted visualforce.format.enable', () => {
+      const code = JSON.stringify(
+        {
+          name: 'test',
+          contributes: {
+            configuration: {
+              properties: {
+                'visualforce.format.enable': {
+                  type: 'boolean',
+                  default: true,
+                  description: '%visualforce.format.enable.desc%'
+                }
+              }
+            }
+          }
+        },
+        null,
+        2
+      );
+
+      const errors = filterByRule(lintJson(code), RULE_NAME);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should pass for allowlisted salesforcedx-vscode-core.show-cli-success-msg', () => {
+      const code = JSON.stringify(
+        {
+          name: 'test',
+          contributes: {
+            configuration: {
+              properties: {
+                'salesforcedx-vscode-core.show-cli-success-msg': {
+                  type: 'boolean',
+                  default: true,
+                  description: '%show_cli_success_msg_description%'
+                }
+              }
+            }
+          }
+        },
+        null,
+        2
+      );
+
+      const errors = filterByRule(lintJson(code), RULE_NAME);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should pass for allowlisted salesforcedx-vscode-metadata.sourceTracking.enableConflictDetection', () => {
+      const code = JSON.stringify(
+        {
+          name: 'test',
+          contributes: {
+            configuration: {
+              properties: {
+                'salesforcedx-vscode-metadata.sourceTracking.enableConflictDetection': {
+                  type: 'boolean',
+                  default: true,
+                  description: '%source_tracking_enable_conflict_detection_description%'
+                }
+              }
+            }
+          }
+        },
+        null,
+        2
+      );
+
+      const errors = filterByRule(lintJson(code), RULE_NAME);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should error when new boolean setting uses default: true', () => {
+      const code = JSON.stringify(
+        {
+          name: 'test',
+          contributes: {
+            configuration: {
+              properties: {
+                'test.newFeature': {
+                  type: 'boolean',
+                  default: true,
+                  description: '%test_new_feature_description%'
+                }
+              }
+            }
+          }
+        },
+        null,
+        2
+      );
+
+      const errors = filterByRule(lintJson(code), RULE_NAME);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].messageId).toBe('defaultTrue');
+      expect(errors[0].message).toContain('test.newFeature');
+      expect(errors[0].message).toContain('unintuitive override behavior');
+    });
+
+    it('should error when boolean with type array ["boolean"] uses default: true', () => {
+      const code = JSON.stringify(
+        {
+          name: 'test',
+          contributes: {
+            configuration: {
+              properties: {
+                'test.nullableBoolean': {
+                  type: ['boolean', 'null'],
+                  default: true,
+                  description: '%test_description%'
+                }
+              }
+            }
+          }
+        },
+        null,
+        2
+      );
+
+      const errors = filterByRule(lintJson(code), RULE_NAME);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].messageId).toBe('defaultTrue');
+      expect(errors[0].message).toContain('test.nullableBoolean');
+    });
+
+    it('should handle multiple settings - error only on the violating one', () => {
+      const code = JSON.stringify(
+        {
+          name: 'test',
+          contributes: {
+            configuration: {
+              properties: {
+                'test.goodSetting': {
+                  type: 'boolean',
+                  default: false,
+                  description: '%test_good%'
+                },
+                'test.badSetting': {
+                  type: 'boolean',
+                  default: true,
+                  description: '%test_bad%'
+                },
+                'test.stringSetting': {
+                  type: 'string',
+                  default: 'value',
+                  description: '%test_string%'
+                }
+              }
+            }
+          }
+        },
+        null,
+        2
+      );
+
+      const errors = filterByRule(lintJson(code), RULE_NAME);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain('test.badSetting');
+    });
+
+    it('should ignore package.json files outside packages directory', () => {
+      const code = JSON.stringify(
+        {
+          name: 'test',
+          contributes: {
+            configuration: {
+              properties: {
+                'test.setting': {
+                  type: 'boolean',
+                  default: true,
+                  description: '%test%'
+                }
+              }
+            }
+          }
+        },
+        null,
+        2
+      );
+
+      const errors = filterByRule(lintJson(code, 'other/package.json'), RULE_NAME);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should handle package.json without contributes section', () => {
+      const code = JSON.stringify(
+        {
+          name: 'test',
+          version: '1.0.0'
+        },
+        null,
+        2
+      );
+
+      const errors = filterByRule(lintJson(code), RULE_NAME);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should handle package.json without configuration properties', () => {
+      const code = JSON.stringify(
+        {
+          name: 'test',
+          contributes: {
+            commands: []
+          }
+        },
+        null,
+        2
+      );
+
+      const errors = filterByRule(lintJson(code), RULE_NAME);
+      expect(errors).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds ESLint rule `package-json-no-default-true` to prevent boolean VSCode configuration settings from using `default: true`, which creates unintuitive override behavior.

## What issues does this PR fix or reference?

#6784, @W-22599687@

## Technical details

- **Rule**: Checks `contributes.configuration.properties` for boolean types with `default: true`
- **Enforcement**: Error level (fails CI, blocks PRs)
- **Grandfathering**: Allows 10 existing settings (6 visualforce, 2 core, 1 metadata, 1 apex)
- **Testing**: 14 unit tests covering valid/invalid cases

The rule guides developers to use `default: false` (opt-in) or rephrase negatively (e.g., "suppress" instead of "show").

🤖 Generated with [Claude Code](https://claude.com/claude-code)