### PR TITLE
feat(telemetry): add orgEdition to telemetry properties - W-22583951

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7690,9 +7690,9 @@
       }
     },
     "node_modules/@salesforce/core": {
-      "version": "8.30.4",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-8.30.4.tgz",
-      "integrity": "sha512-lMX+X87HbelGU9IA3IOHdP0CDcru1kQG4qDDJXoDYSp8MAcvJpNdOk6P06SutMqKv39XVS3VRfKL5lGiuRcDnA==",
+      "version": "8.31.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-8.31.0.tgz",
+      "integrity": "sha512-TXQoR7Bs0Dk5AuNY8eaNRhMeLDLcpJ8su7LVxn7VVfnRxITrRh4gkSuOAXdBKAqx0WcjRONDs1twedaOE7Xu4Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jsforce/jsforce-node": "^3.10.13",
@@ -45563,7 +45563,7 @@
         "@vscode/test-web": "^0.0.78"
       },
       "devDependencies": {
-        "@salesforce/core": "^8.28.0"
+        "@salesforce/core": "^8.31.0"
       },
       "engines": {
         "vscode": "^1.90.0"
@@ -45574,7 +45574,7 @@
       "version": "65.7.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "^8.28.0",
+        "@salesforce/core": "^8.31.0",
         "@salesforce/salesforcedx-utils": "*",
         "@salesforce/vscode-i18n": "*",
         "@vscode/debugadapter": "1.68.0",
@@ -45600,7 +45600,7 @@
       "version": "65.7.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "^8.28.0",
+        "@salesforce/core": "^8.31.0",
         "@salesforce/salesforcedx-utils": "*",
         "@salesforce/vscode-i18n": "*",
         "@vscode/debugadapter": "1.68.0",
@@ -46041,7 +46041,7 @@
       "version": "65.7.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "^8.28.0"
+        "@salesforce/core": "^8.31.0"
       },
       "devDependencies": {
         "rxjs": "^7.8.2"
@@ -46052,7 +46052,7 @@
       "version": "65.7.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "^8.28.0",
+        "@salesforce/core": "^8.31.0",
         "@salesforce/effect-ext-utils": "*",
         "@salesforce/o11y-reporter": "^1.8.1",
         "@salesforce/salesforcedx-utils": "*",
@@ -46125,7 +46125,7 @@
         "vscode-uri": "^3.1.0"
       },
       "devDependencies": {
-        "@salesforce/core": "^8.28.0",
+        "@salesforce/core": "^8.31.0",
         "salesforcedx-vscode-core": "66.12.3"
       },
       "engines": {
@@ -46136,7 +46136,7 @@
       "version": "66.12.3",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "^8.28.0",
+        "@salesforce/core": "^8.31.0",
         "@salesforce/effect-ext-utils": "*",
         "@salesforce/salesforcedx-apex-debugger": "*",
         "@salesforce/salesforcedx-utils": "*",
@@ -46167,7 +46167,7 @@
         "vscode-uri": "^3.1.0"
       },
       "devDependencies": {
-        "@salesforce/core": "^8.28.0",
+        "@salesforce/core": "^8.31.0",
         "@salesforce/playwright-vscode-ext": "*",
         "esbuild": "0.27.4",
         "salesforcedx-vscode-services": "66.12.3"
@@ -46680,7 +46680,7 @@
         "yaml": "^2.8.2"
       },
       "devDependencies": {
-        "@salesforce/core": "^8.28.0",
+        "@salesforce/core": "^8.31.0",
         "@types/async-lock": "1.4.2",
         "@types/ejs": "3.1.5",
         "openapi-types": "12.1.3",
@@ -46708,7 +46708,7 @@
       },
       "devDependencies": {
         "@playwright/test": "*",
-        "@salesforce/core": "^8.28.0",
+        "@salesforce/core": "^8.31.0",
         "@salesforce/playwright-vscode-ext": "*",
         "salesforcedx-vscode-apex": "66.12.3",
         "salesforcedx-vscode-core": "66.12.3",
@@ -48287,7 +48287,7 @@
       "version": "66.12.3",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "^8.28.0",
+        "@salesforce/core": "^8.31.0",
         "@salesforce/effect-ext-utils": "*",
         "@salesforce/o11y-reporter": "^1.8.1",
         "@salesforce/salesforcedx-utils": "*",
@@ -48412,7 +48412,7 @@
       "version": "66.12.3",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "^8.28.0",
+        "@salesforce/core": "^8.31.0",
         "@salesforce/effect-ext-utils": "*",
         "@salesforce/salesforcedx-utils": "*",
         "@salesforce/salesforcedx-utils-vscode": "*",
@@ -48439,7 +48439,7 @@
         "vscode-uri": "^3.1.0"
       },
       "devDependencies": {
-        "@salesforce/core": "^8.28.0",
+        "@salesforce/core": "^8.31.0",
         "@salesforce/playwright-vscode-ext": "*",
         "@salesforce/source-deploy-retrieve": "^12.32.5",
         "salesforcedx-vscode-services": "66.12.3"
@@ -48464,7 +48464,7 @@
         "@opentelemetry/sdk-trace-base": "2.6.1",
         "@opentelemetry/sdk-trace-node": "2.2.0",
         "@opentelemetry/sdk-trace-web": "2.7.0",
-        "@salesforce/core": "^8.28.0",
+        "@salesforce/core": "^8.31.0",
         "@salesforce/o11y-reporter": "^1.8.1",
         "@salesforce/source-deploy-retrieve": "^12.32.5",
         "@salesforce/source-tracking": "^7.8.16",
@@ -48501,7 +48501,7 @@
         "@opentelemetry/sdk-trace-base": "2.6.1",
         "@opentelemetry/sdk-trace-node": "2.2.0",
         "@opentelemetry/sdk-trace-web": "2.7.0",
-        "@salesforce/core": "^8.28.0",
+        "@salesforce/core": "^8.31.0",
         "@salesforce/source-deploy-retrieve": "^12.32.5",
         "@salesforce/source-tracking": "^7.8.16",
         "@types/vscode": "^1.90.0",
@@ -48545,7 +48545,7 @@
       "version": "66.12.3",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "^8.28.0",
+        "@salesforce/core": "^8.31.0",
         "@salesforce/effect-ext-utils": "*",
         "@salesforce/soql-common": "*",
         "@salesforce/soql-language-server": "^1.1.0",
@@ -48570,7 +48570,7 @@
         "@rollup/plugin-inject": "^5.0.0",
         "@rollup/plugin-node-resolve": "^16.0.0",
         "@rollup/plugin-terser": "^0.4.0",
-        "@salesforce/core": "^8.28.0",
+        "@salesforce/core": "^8.31.0",
         "@salesforce/eslint-config-lwc": "^4.1.2",
         "@salesforce/eslint-plugin-lightning": "^2.0.0",
         "@salesforce/playwright-vscode-ext": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -48570,7 +48570,6 @@
         "@rollup/plugin-inject": "^5.0.0",
         "@rollup/plugin-node-resolve": "^16.0.0",
         "@rollup/plugin-terser": "^0.4.0",
-        "@salesforce/core": "^8.31.0",
         "@salesforce/eslint-config-lwc": "^4.1.2",
         "@salesforce/eslint-plugin-lightning": "^2.0.0",
         "@salesforce/playwright-vscode-ext": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -48479,7 +48479,6 @@
       "devDependencies": {
         "@salesforce/playwright-vscode-ext": "*",
         "@types/node": "^20.0.0",
-        "jsforce": "^3.9.4",
         "svgtofont": "^3.5.0"
       },
       "engines": {

--- a/packages/playwright-vscode-ext/package.json
+++ b/packages/playwright-vscode-ext/package.json
@@ -12,7 +12,7 @@
     "@vscode/test-web": "^0.0.78"
   },
   "devDependencies": {
-    "@salesforce/core": "^8.28.0"
+    "@salesforce/core": "^8.31.0"
   },
   "scripts": {
     "compile": "wireit",

--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -13,7 +13,7 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/core": "^8.28.0",
+    "@salesforce/core": "^8.31.0",
     "@salesforce/salesforcedx-utils": "*",
     "@salesforce/vscode-i18n": "*",
     "@vscode/debugadapter": "1.68.0",

--- a/packages/salesforcedx-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-apex-replay-debugger/package.json
@@ -14,7 +14,7 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/core": "^8.28.0",
+    "@salesforce/core": "^8.31.0",
     "@salesforce/salesforcedx-utils": "*",
     "@salesforce/vscode-i18n": "*",
     "@vscode/debugadapter": "1.68.0",

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -10,7 +10,7 @@
   ],
   "main": "out/src",
   "dependencies": {
-    "@salesforce/core": "^8.28.0",
+    "@salesforce/core": "^8.31.0",
     "@salesforce/effect-ext-utils": "*",
     "@salesforce/o11y-reporter": "^1.8.1",
     "@salesforce/salesforcedx-utils": "*",

--- a/packages/salesforcedx-utils-vscode/src/context/workspaceContextUtil.ts
+++ b/packages/salesforcedx-utils-vscode/src/context/workspaceContextUtil.ts
@@ -45,6 +45,7 @@ export class WorkspaceContextUtil {
   protected _orgId?: string;
   protected _orgShape?: OrgShape;
   protected _devHubId?: string;
+  protected _orgEdition?: string;
 
   public readonly onOrgChange: vscode.Event<OrgUserInfo>;
 
@@ -185,7 +186,9 @@ export class WorkspaceContextUtil {
       this._alias = targetOrgOrAlias !== this._username ? targetOrgOrAlias : undefined;
       try {
         const connection = await this.getConnection();
-        this._orgId = connection?.getAuthInfoFields().orgId;
+        const authFields = connection?.getAuthInfoFields();
+        this._orgId = authFields?.orgId;
+        this._orgEdition = authFields?.orgEdition;
       } catch (error: unknown) {
         this._orgId = '';
         if (error instanceof Error) {
@@ -200,6 +203,7 @@ export class WorkspaceContextUtil {
       this._username = undefined;
       this._alias = undefined;
       this._orgId = undefined;
+      this._orgEdition = undefined;
     }
 
     this.onOrgChangeEmitter.fire({
@@ -234,5 +238,13 @@ export class WorkspaceContextUtil {
 
   public set devHubId(id: string | undefined) {
     this._devHubId = id;
+  }
+
+  public get orgEdition(): string | undefined {
+    return this._orgEdition;
+  }
+
+  public set orgEdition(edition: string | undefined) {
+    this._orgEdition = edition;
   }
 }

--- a/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
+++ b/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
@@ -120,7 +120,7 @@ export class TelemetryService implements TelemetryServiceInterface {
     this.isInternal = isInternalHost();
     this.isDevMode = extensionContext.extensionMode !== ExtensionMode.Production;
 
-    this.checkCliTelemetry()
+    await this.checkCliTelemetry()
       .then(cliEnabled => {
         this.setCliTelemetryEnabled(this.isTelemetryExtensionConfigurationEnabled() && cliEnabled);
       })

--- a/packages/salesforcedx-utils-vscode/src/telemetry/reporters/appInsights.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/reporters/appInsights.ts
@@ -254,6 +254,6 @@ export class AppInsights
 
 const getBaseProps = (): Record<string, string> => {
   const context = WorkspaceContextUtil.getInstance();
-  const { orgId = '', orgShape = '', devHubId = '' } = context;
-  return orgId ? { orgId, orgShape, devHubId } : {};
+  const { orgId = '', orgShape = '', devHubId = '', orgEdition = '' } = context;
+  return orgId ? { orgId, orgShape, devHubId, ...(orgEdition ? { orgEdition } : {}) } : {};
 };

--- a/packages/salesforcedx-utils-vscode/src/telemetry/reporters/o11yReporter.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/reporters/o11yReporter.ts
@@ -121,6 +121,7 @@ export class O11yReporter
       const orgId = WorkspaceContextUtil.getInstance().orgId ?? '';
       const orgShape = WorkspaceContextUtil.getInstance().orgShape ?? '';
       const devHubId = WorkspaceContextUtil.getInstance().devHubId ?? '';
+      const orgEdition = WorkspaceContextUtil.getInstance().orgEdition ?? '';
 
       // Add webUserId field to customDimensions
       let props = properties
@@ -128,7 +129,7 @@ export class O11yReporter
         : { ...this.aggregateLoggingProperties() };
       props = this.applyTelemetryTag(
         orgId
-          ? { ...props, orgId, orgShape, devHubId, webUserId: this.webUserId }
+          ? { ...props, orgId, orgShape, devHubId, ...(orgEdition ? { orgEdition } : {}), webUserId: this.webUserId }
           : { ...props, webUserId: this.webUserId }
       );
 
@@ -162,9 +163,10 @@ export class O11yReporter
       const orgId = WorkspaceContextUtil.getInstance().orgId ?? '';
       const orgShape = WorkspaceContextUtil.getInstance().orgShape ?? '';
       const devHubId = WorkspaceContextUtil.getInstance().devHubId ?? '';
+      const orgEdition = WorkspaceContextUtil.getInstance().orgEdition ?? '';
 
       // Add webUserId field to customDimensions
-      const baseProps = { orgId, orgShape, devHubId };
+      const baseProps = { orgId, orgShape, devHubId, ...(orgEdition ? { orgEdition } : {}) };
       const props = this.applyTelemetryTag({
         ...baseProps,
         ...this.aggregateLoggingProperties(),

--- a/packages/salesforcedx-utils-vscode/src/telemetry/reporters/telemetryFile.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/reporters/telemetryFile.ts
@@ -10,6 +10,7 @@ import * as vscode from 'vscode';
 import { URI } from 'vscode-uri';
 import { getRootWorkspacePath } from '../..';
 import { LOCAL_TELEMETRY_FILE } from '../../constants';
+import { WorkspaceContextUtil } from '../../context/workspaceContextUtil';
 
 /**
  * Represents a telemetry file that logs telemetry events by appending to a local file.
@@ -32,7 +33,8 @@ export class TelemetryFile implements TelemetryReporter {
     properties?: { [key: string]: string },
     measurements?: { [key: string]: number }
   ): void {
-    void this.writeToFile(eventName, { ...properties, ...measurements });
+    const baseProps = this.getBaseProps();
+    void this.writeToFile(eventName, { ...baseProps, ...properties, ...measurements });
   }
 
   public sendExceptionEvent(
@@ -70,6 +72,16 @@ export class TelemetryFile implements TelemetryReporter {
     const content = `${JSON.stringify({ timestamp, command, data }, null, 2)},`;
     this.buffer += content;
     await this.flushBuffer();
+  }
+
+  private getBaseProps(): Record<string, string> {
+    try {
+      const context = WorkspaceContextUtil.getInstance();
+      const { orgId = '', orgShape = '', devHubId = '', orgEdition = '' } = context;
+      return orgId ? { orgId, orgShape, devHubId, ...(orgEdition ? { orgEdition } : {}) } : {};
+    } catch {
+      return {};
+    }
   }
 
   private async flushBuffer(): Promise<void> {

--- a/packages/salesforcedx-utils-vscode/test/jest/context/workspaceContextUtil.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/context/workspaceContextUtil.test.ts
@@ -137,6 +137,38 @@ describe('WorkspaceContextUtil', () => {
     expect(stateAggregatorClearInstanceMock).toHaveBeenCalled();
   });
 
+  it('should populate orgEdition from auth fields when available', async () => {
+    getConnectionMock.mockReturnValue({
+      getAuthInfo: () => ({ isAccessTokenFlow: () => false }),
+      getAuthInfoFields: () => ({ orgId: dummyOrgId, orgEdition: 'Developer Edition' })
+    });
+
+    await workspaceContextUtil.initialize(context);
+
+    expect(workspaceContextUtil.orgEdition).toEqual('Developer Edition');
+  });
+
+  it('should leave orgEdition undefined when not in auth fields', async () => {
+    getConnectionMock.mockReturnValue({
+      getAuthInfo: () => ({ isAccessTokenFlow: () => false }),
+      getAuthInfoFields: () => ({ orgId: dummyOrgId })
+    });
+
+    await workspaceContextUtil.initialize(context);
+
+    expect(workspaceContextUtil.orgEdition).toBeUndefined();
+  });
+
+  it('should reset orgEdition to undefined when no target org', async () => {
+    workspaceContextUtil._orgEdition = 'Enterprise Edition';
+    getUsernameOrAliasStub.mockReturnValue(undefined);
+
+    const handler = mockWatcher.onDidChange.mock.calls[0][0];
+    await handler();
+
+    expect(workspaceContextUtil.orgEdition).toBeUndefined();
+  });
+
   it('should set _orgId to an empty string and log a message if there was a problem getting the connection', async () => {
     const dummyErrorMessage = 'There was a problem getting the connection.';
     const logMock = jest.spyOn(console, 'log');

--- a/packages/salesforcedx-utils-vscode/test/jest/telemetry/reporters/appInsights.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/telemetry/reporters/appInsights.test.ts
@@ -63,6 +63,28 @@ describe('AppInsights', () => {
       expect(trackExceptionMock).toHaveBeenCalledTimes(1);
       expect(trackExceptionMock.mock.calls[0][0]).toMatchSnapshot();
     });
+
+    it('should include orgEdition in event properties when available', () => {
+      getInstanceMock.mockReturnValue({
+        devHubId: '',
+        orgId: dummyOrgId,
+        orgShape: 'Production',
+        orgEdition: 'Enterprise Edition'
+      });
+
+      appInsights = new AppInsights(fakeExtensionId, fakeExtensionVersion, '', fakeUserId, 'test-webUser', false);
+      (appInsights as any).userOptIn = true;
+      (appInsights as any).appInsightsClient = {
+        trackException: trackExceptionMock,
+        trackEvent: trackEventMock
+      };
+
+      appInsights.sendTelemetryEvent('Test Event', {}, {});
+
+      const eventProps = trackEventMock.mock.calls[0][0].properties;
+      expect(eventProps.orgEdition).toBe('Enterprise Edition');
+      expect(eventProps.orgId).toBe(dummyOrgId);
+    });
   });
 
   describe('dispose', () => {

--- a/packages/salesforcedx-utils/package.json
+++ b/packages/salesforcedx-utils/package.json
@@ -83,7 +83,7 @@
     }
   },
   "dependencies": {
-    "@salesforce/core": "^8.28.0"
+    "@salesforce/core": "^8.31.0"
   },
   "devDependencies": {
     "rxjs": "^7.8.2"

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -28,7 +28,7 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/core": "^8.28.0",
+    "@salesforce/core": "^8.31.0",
     "@salesforce/effect-ext-utils": "*",
     "@salesforce/salesforcedx-apex-debugger": "*",
     "@salesforce/salesforcedx-utils": "*",

--- a/packages/salesforcedx-vscode-apex-log/package.json
+++ b/packages/salesforcedx-vscode-apex-log/package.json
@@ -35,7 +35,7 @@
     "vscode-uri": "^3.1.0"
   },
   "devDependencies": {
-    "@salesforce/core": "^8.28.0",
+    "@salesforce/core": "^8.31.0",
     "@salesforce/playwright-vscode-ext": "*",
     "esbuild": "0.27.4",
     "salesforcedx-vscode-services": "66.12.3"

--- a/packages/salesforcedx-vscode-apex-oas/package.json
+++ b/packages/salesforcedx-vscode-apex-oas/package.json
@@ -47,7 +47,7 @@
     "yaml": "^2.8.2"
   },
   "devDependencies": {
-    "@salesforce/core": "^8.28.0",
+    "@salesforce/core": "^8.31.0",
     "@types/async-lock": "1.4.2",
     "@types/ejs": "3.1.5",
     "openapi-types": "12.1.3",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@playwright/test": "*",
-    "@salesforce/core": "^8.28.0",
+    "@salesforce/core": "^8.31.0",
     "@salesforce/playwright-vscode-ext": "*",
     "salesforcedx-vscode-apex": "66.12.3",
     "salesforcedx-vscode-core": "66.12.3",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -39,7 +39,7 @@
     "vscode-uri": "^3.1.0"
   },
   "devDependencies": {
-    "@salesforce/core": "^8.28.0",
+    "@salesforce/core": "^8.31.0",
     "salesforcedx-vscode-core": "66.12.3"
   },
   "extensionDependencies": [

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -28,7 +28,7 @@
     "Other"
   ],
   "dependencies": {
-    "@salesforce/core": "^8.28.0",
+    "@salesforce/core": "^8.31.0",
     "@salesforce/effect-ext-utils": "*",
     "@salesforce/o11y-reporter": "^1.8.1",
     "@salesforce/salesforcedx-utils": "*",

--- a/packages/salesforcedx-vscode-core/src/context/workspaceContext.ts
+++ b/packages/salesforcedx-vscode-core/src/context/workspaceContext.ts
@@ -73,6 +73,12 @@ export class WorkspaceContext {
       if (orgShape !== 'Undefined') {
         WorkspaceContextUtil.getInstance().orgShape = orgShape;
         WorkspaceContextUtil.getInstance().devHubId = undefined;
+        try {
+          const connection = await WorkspaceContextUtil.getInstance().getConnection();
+          WorkspaceContextUtil.getInstance().orgEdition = connection.getAuthInfoFields().orgEdition;
+        } catch {
+          /* best effort — orgEdition may not yet be populated */
+        }
       }
       if (orgShape === 'Scratch') {
         const devHubId = await getDevHubIdFromScratchOrg(username);

--- a/packages/salesforcedx-vscode-core/test/jest/context/workspaceContext.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/context/workspaceContext.test.ts
@@ -40,11 +40,12 @@ describe('workspaceContext', () => {
       onOrgChange: jest.fn(),
       orgShape: undefined as OrgShape | undefined,
       devHubId: undefined as string | undefined,
+      orgEdition: undefined as string | undefined,
       username: 'mock-username',
       alias: 'mock-alias',
       orgId: 'mock-org-id',
       getConnection: jest.fn().mockResolvedValue({
-        getAuthInfoFields: jest.fn().mockReturnValue({ orgId: '000' })
+        getAuthInfoFields: jest.fn().mockReturnValue({ orgId: '000', orgEdition: 'Developer Edition' })
       })
     };
 
@@ -94,6 +95,30 @@ describe('workspaceContext', () => {
       expect(mockWorkspaceContextUtil.orgShape).toBe('Scratch');
       expect(getDevHubIdFromScratchOrgMock).toHaveBeenCalledWith(mockOrgUserInfo.username);
       expect(mockWorkspaceContextUtil.devHubId).toBe('test-dev-hub-id');
+    });
+
+    it('should set orgEdition from auth fields when orgShape is not Undefined', async () => {
+      getOrgShapeMock.mockResolvedValue('Production');
+      mockWorkspaceContextUtil.getConnection.mockResolvedValue({
+        getAuthInfoFields: jest.fn().mockReturnValue({ orgId: '000', orgEdition: 'Developer Edition' })
+      });
+      const workspaceContext = WorkspaceContext.getInstance();
+
+      await (workspaceContext as any).handleOrgShapeChange(mockOrgUserInfo);
+
+      expect(mockWorkspaceContextUtil.orgEdition).toBe('Developer Edition');
+    });
+
+    it('should not set orgEdition if getConnection fails', async () => {
+      mockWorkspaceContextUtil.orgEdition = undefined;
+      getOrgShapeMock.mockResolvedValue('Production');
+      mockWorkspaceContextUtil.getConnection.mockRejectedValue(new Error('connection failed'));
+      const workspaceContext = WorkspaceContext.getInstance();
+
+      await (workspaceContext as any).handleOrgShapeChange(mockOrgUserInfo);
+
+      expect(mockWorkspaceContextUtil.orgShape).toBe('Production');
+      expect(mockWorkspaceContextUtil.orgEdition).toBeUndefined();
     });
   });
 

--- a/packages/salesforcedx-vscode-org-browser/package.json
+++ b/packages/salesforcedx-vscode-org-browser/package.json
@@ -34,7 +34,7 @@
     "vscode-uri": "^3.1.0"
   },
   "devDependencies": {
-    "@salesforce/core": "^8.28.0",
+    "@salesforce/core": "^8.31.0",
     "@salesforce/playwright-vscode-ext": "*",
     "@salesforce/source-deploy-retrieve": "^12.32.5",
     "salesforcedx-vscode-services": "66.12.3"

--- a/packages/salesforcedx-vscode-org/package.json
+++ b/packages/salesforcedx-vscode-org/package.json
@@ -28,7 +28,7 @@
     "Other"
   ],
   "dependencies": {
-    "@salesforce/core": "^8.28.0",
+    "@salesforce/core": "^8.31.0",
     "@salesforce/effect-ext-utils": "*",
     "@salesforce/salesforcedx-utils": "*",
     "@salesforce/salesforcedx-utils-vscode": "*",

--- a/packages/salesforcedx-vscode-services-types/package.json
+++ b/packages/salesforcedx-vscode-services-types/package.json
@@ -75,7 +75,7 @@
     "@opentelemetry/sdk-trace-base": "2.6.1",
     "@opentelemetry/sdk-trace-node": "2.2.0",
     "@opentelemetry/sdk-trace-web": "2.7.0",
-    "@salesforce/core": "^8.28.0",
+    "@salesforce/core": "^8.31.0",
     "@salesforce/source-deploy-retrieve": "^12.32.5",
     "@salesforce/source-tracking": "^7.8.16",
     "@types/vscode": "^1.90.0",

--- a/packages/salesforcedx-vscode-services/package.json
+++ b/packages/salesforcedx-vscode-services/package.json
@@ -55,7 +55,6 @@
   "devDependencies": {
     "@salesforce/playwright-vscode-ext": "*",
     "@types/node": "^20.0.0",
-    "jsforce": "^3.9.4",
     "svgtofont": "^3.5.0"
   },
   "scripts": {

--- a/packages/salesforcedx-vscode-services/package.json
+++ b/packages/salesforcedx-vscode-services/package.json
@@ -40,7 +40,7 @@
     "@opentelemetry/sdk-trace-base": "2.6.1",
     "@opentelemetry/sdk-trace-node": "2.2.0",
     "@opentelemetry/sdk-trace-web": "2.7.0",
-    "@salesforce/core": "^8.28.0",
+    "@salesforce/core": "^8.31.0",
     "@salesforce/o11y-reporter": "^1.8.1",
     "@salesforce/source-deploy-retrieve": "^12.32.5",
     "@salesforce/source-tracking": "^7.8.16",

--- a/packages/salesforcedx-vscode-services/src/core/connectionService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/connectionService.ts
@@ -263,7 +263,7 @@ const getTracksSourceFromOrg = (conn: Connection) =>
 //** this info is used for quite a bit (ex: telemetry) so one we make the connection, we capture the info and store it in a ref */
 const maybeUpdateDefaultOrgRef = Effect.fn('maybeUpdateDefaultOrgRef')(function* (conn: Connection) {
   const aliasService = yield* AliasService;
-  const { orgId, devHubUsername, isScratch, isSandbox, tracksSource } = conn.getAuthInfoFields();
+  const { orgId, devHubUsername, isScratch, isSandbox, tracksSource, orgEdition } = conn.getAuthInfoFields();
   const defaultOrgRef = yield* getDefaultOrgRef();
   const existingOrgInfo = yield* SubscriptionRef.get(defaultOrgRef);
   const orgIdChanged = existingOrgInfo.orgId !== orgId;
@@ -325,7 +325,8 @@ const maybeUpdateDefaultOrgRef = Effect.fn('maybeUpdateDefaultOrgRef')(function*
       webUserId,
       aliases,
       username,
-      ...(typeof cliId === 'string' ? { cliId } : {})
+      ...(typeof cliId === 'string' ? { cliId } : {}),
+      ...(typeof orgEdition === 'string' ? { orgEdition } : {})
     } satisfies typeof DefaultOrgInfoSchema.Type).filter(([, v]) => v !== undefined)
   );
 

--- a/packages/salesforcedx-vscode-services/src/core/schemas/defaultOrgInfo.ts
+++ b/packages/salesforcedx-vscode-services/src/core/schemas/defaultOrgInfo.ts
@@ -20,5 +20,6 @@ export const DefaultOrgInfoSchema = Schema.Struct({
   // the actual userID from the salesforce org
   userId: Schema.optional(Schema.String),
   cliId: Schema.optional(Schema.String),
-  webUserId: Schema.optional(Schema.String)
+  webUserId: Schema.optional(Schema.String),
+  orgEdition: Schema.optional(Schema.String)
 });

--- a/packages/salesforcedx-vscode-services/src/observability/spanTransformProcessor.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/spanTransformProcessor.ts
@@ -37,10 +37,11 @@ export class SpanTransformProcessor extends BatchSpanProcessor {
 type TelemetryAttribute = [string, string | undefined];
 
 const getAdditionalAttributes = (extensionName: unknown, extensionVersion: unknown): TelemetryAttribute[] => {
-  const { orgId, devHubOrgId, isSandbox, isScratch, tracksSource, webUserId, cliId } = getDefaultOrgRef().pipe(
-    Effect.flatMap(ref => SubscriptionRef.get(ref)),
-    Effect.runSync
-  );
+  const { orgId, devHubOrgId, isSandbox, isScratch, tracksSource, webUserId, cliId, orgEdition } =
+    getDefaultOrgRef().pipe(
+      Effect.flatMap(ref => SubscriptionRef.get(ref)),
+      Effect.runSync
+    );
   const commonAttrs: TelemetryAttribute[] = [];
   if (typeof extensionName === 'string') {
     commonAttrs.push(['common.extname', extensionName]);
@@ -58,6 +59,7 @@ const getAdditionalAttributes = (extensionName: unknown, extensionVersion: unkno
     ['tracksSource', optionalBooleanToString(tracksSource)],
     ['userId', cliId],
     ['webUserId', webUserId],
+    ['orgEdition', orgEdition],
     ['telemetryTag', workspace.getConfiguration('salesforcedx-vscode-core')?.get('telemetry-tag')]
   ];
 };

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -48,7 +48,6 @@
     "vscode-uri": "^3.1.0"
   },
   "devDependencies": {
-    "@salesforce/core": "^8.31.0",
     "@babel/preset-typescript": "^7.0.0",
     "@lwc/engine-dom": "^9.0.0",
     "@lwc/eslint-plugin-lwc": "^3.3.0",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -35,7 +35,7 @@
     "soql builder"
   ],
   "dependencies": {
-    "@salesforce/core": "^8.28.0",
+    "@salesforce/core": "^8.31.0",
     "@salesforce/effect-ext-utils": "*",
     "effect": "^3.20.0",
     "@salesforce/soql-common": "*",
@@ -48,7 +48,7 @@
     "vscode-uri": "^3.1.0"
   },
   "devDependencies": {
-    "@salesforce/core": "^8.28.0",
+    "@salesforce/core": "^8.31.0",
     "@babel/preset-typescript": "^7.0.0",
     "@lwc/engine-dom": "^9.0.0",
     "@lwc/eslint-plugin-lwc": "^3.3.0",


### PR DESCRIPTION
## Summary
- Bump `@salesforce/core` to `^8.31.0` which adds `orgEdition` to `AuthFields`
- Propagate `orgEdition` through `WorkspaceContextUtil`, `connectionService`, and span attributes
- Enrich all telemetry reporters (AppInsights, O11y, TelemetryFile) with `orgEdition` when available

## Test plan
- [x] Verify telemetry events include `orgEdition` field when org is connected
- [ ] Verify `orgEdition` appears in span attributes via file exporter
- [x] Verify graceful fallback when `orgEdition` is not populated

### What issues does this PR fix or reference?
@W-22583951@