### PR TITLE
fix: SFDX: Install Package shows proper success notification after successful installation - W-22681257

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46012,23 +46012,6 @@
         "node": ">=4"
       }
     },
-    "packages/salesforcedx-sobjects-faux-generator": {
-      "name": "@salesforce/salesforcedx-sobjects-faux-generator",
-      "version": "65.7.0",
-      "extraneous": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@salesforce/salesforcedx-utils-vscode": "*",
-        "@salesforce/vscode-i18n": "*"
-      },
-      "devDependencies": {
-        "@salesforce/core": "^8.27.0",
-        "@salesforce/salesforcedx-utils": "*"
-      },
-      "engines": {
-        "vscode": "^1.90.0"
-      }
-    },
     "packages/salesforcedx-utils": {
       "name": "@salesforce/salesforcedx-utils",
       "version": "65.7.0",

--- a/packages/salesforcedx-vscode-core/src/commands/packageInstall.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/packageInstall.ts
@@ -5,42 +5,34 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Command, SfCommandBuilder } from '@salesforce/salesforcedx-utils';
+import { SfCommandBuilder } from '@salesforce/salesforcedx-utils';
 import {
   CancelResponse,
+  CliCommandExecutor,
   CompositeParametersGatherer,
+  ConfigUtil,
   ContinueResponse,
+  getConnection,
+  LibraryCommandletExecutor,
   ParametersGatherer,
-  SfCommandlet
+  SfCommandlet,
+  workspaceUtils
 } from '@salesforce/salesforcedx-utils-vscode';
 import * as vscode from 'vscode';
+import { channelService, OUTPUT_CHANNEL } from '../channels';
 import { PKG_ID_PREFIX } from '../constants';
+import { nls } from '../messages';
+import { EmptyPreChecker } from './util';
+
+const POLL_INTERVAL_MS = 30_000;
 
 const isAlphaNumString = (value: string | undefined): boolean =>
   value !== undefined && value !== '' && !/\W/.test(value);
 
 const isRecordIdFormat = (value: string = '', prefix: string): boolean =>
   isAlphaNumString(value) && value.startsWith(prefix) && (value.length === 15 || value.length === 18);
-import { nls } from '../messages';
-import { EmptyPreChecker, SfCommandletExecutor } from './util';
 
-class PackageInstallExecutor extends SfCommandletExecutor<PackageIdAndInstallationKey> {
-  public build(data: PackageIdAndInstallationKey): Command {
-    const builder = new SfCommandBuilder()
-      .withDescription(nls.localize('package_install_text'))
-      .withArg('package:install')
-      .withFlag('--package', data.packageId)
-      .withLogName('package_install');
-
-    if (data.installationKey) {
-      builder.withFlag('--installation-key', data.installationKey);
-    }
-
-    return builder.build();
-  }
-}
-
-type PackageIdAndInstallationKey = PackageID & InstallationKey;
+export type PackageIdAndInstallationKey = PackageID & InstallationKey;
 
 type PackageID = {
   packageId: string;
@@ -49,6 +41,98 @@ type PackageID = {
 type InstallationKey = {
   installationKey: string;
 };
+
+export class PackageInstallExecutor extends LibraryCommandletExecutor<PackageIdAndInstallationKey> {
+  private readonly pollIntervalMs: number;
+
+  constructor(pollIntervalMs = POLL_INTERVAL_MS) {
+    super(nls.localize('package_install_text'), 'package_install', OUTPUT_CHANNEL);
+    this.cancellable = true;
+    this.pollIntervalMs = pollIntervalMs;
+  }
+
+  public async run(
+    response: ContinueResponse<PackageIdAndInstallationKey>,
+    progress?: vscode.Progress<{ message?: string }>,
+    token?: vscode.CancellationToken
+  ): Promise<boolean> {
+    const { packageId, installationKey } = response.data;
+    const targetOrg = await ConfigUtil.getTargetOrgOrAlias();
+    const cwd = workspaceUtils.getRootWorkspacePath();
+
+    // Fire the install with --wait 0; we never read its output because the
+    // sf CLI process hangs on some versions regardless of flags.
+    const installBuilder = new SfCommandBuilder()
+      .withDescription(nls.localize('package_install_text'))
+      .withArg('package:install')
+      .withFlag('--package', packageId)
+      .withFlag('--wait', '0')
+      .withJson()
+      .withLogName('package_install');
+
+    if (installationKey) {
+      installBuilder.withFlag('--installation-key', installationKey);
+    }
+    if (targetOrg) {
+      installBuilder.withFlag('--target-org', targetOrg);
+    }
+
+    new CliCommandExecutor(installBuilder.build(), {
+      cwd,
+      env: { SF_JSON_TO_STDOUT: 'true' }
+    }).execute(token);
+
+    // Poll the org directly via @salesforce/core Connection — no CLI processes,
+    // no hanging, no timeouts needed.
+    progress?.report({ message: nls.localize('package_install_polling_message') });
+
+    while (true) {
+      await sleep(this.pollIntervalMs, token);
+
+      if (token?.isCancellationRequested) {
+        return false;
+      }
+
+      const status = await queryInstallStatus(packageId, targetOrg);
+
+      if (status === 'SUCCESS') {
+        return true;
+      }
+      if (status === 'ERROR') {
+        return false;
+      }
+      // undefined (not created yet / transient error) or IN_PROGRESS — keep polling
+    }
+  }
+}
+
+// Normalize a 15- or 18-char Salesforce ID to its 15-char prefix for comparison.
+const to15 = (id: string) => id.slice(0, 15);
+
+const queryInstallStatus = async (packageId: string, targetOrg: string | undefined): Promise<string | undefined> => {
+  try {
+    const conn = await getConnection(targetOrg);
+    const result = await conn.tooling.query<{ Status: string; SubscriberPackageVersionKey: string }>(
+      `SELECT Status, SubscriberPackageVersionKey FROM PackageInstallRequest
+       ORDER BY CreatedDate DESC LIMIT 10`
+    );
+    channelService.appendLine(`[package install] poll: ${JSON.stringify(result.records)}`);
+    const match = result.records?.find(r => to15(r.SubscriberPackageVersionKey) === to15(packageId));
+    return match?.Status ?? result.records?.[0]?.Status;
+  } catch (err) {
+    channelService.appendLine(`[package install] poll error: ${err instanceof Error ? err.message : String(err)}`);
+    return undefined;
+  }
+};
+
+const sleep = (ms: number, token?: vscode.CancellationToken): Promise<void> =>
+  new Promise(resolve => {
+    const timer = setTimeout(resolve, ms);
+    token?.onCancellationRequested(() => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
 
 class SelectPackageID implements ParametersGatherer<PackageID> {
   public async gather(): Promise<CancelResponse | ContinueResponse<PackageID>> {

--- a/packages/salesforcedx-vscode-core/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-core/src/messages/i18n.ts
@@ -40,6 +40,7 @@ export const messages = {
   config_list_no_results: 'No results found',
   alias_list_text: 'SFDX: List All Aliases',
   package_install_text: 'SFDX: Install Package',
+  package_install_polling_message: 'Package install in progress. Checking status every 30 seconds…',
   telemetry_legal_dialog_message:
     'You agree that Salesforce Extensions for VS Code may collect usage information, user environment, and crash reports for product improvements. Learn how to [opt out](%s).',
   telemetry_legal_dialog_button_text: 'Read more',

--- a/packages/salesforcedx-vscode-core/test/jest/commands/packageInstall.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/commands/packageInstall.test.ts
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { CliCommandExecutor, ConfigUtil, getConnection } from '@salesforce/salesforcedx-utils-vscode';
+import * as vscode from 'vscode';
+
+jest.mock('@salesforce/salesforcedx-utils-vscode', () => ({
+  ...jest.requireActual('@salesforce/salesforcedx-utils-vscode'),
+  CliCommandExecutor: jest.fn(),
+  ConfigUtil: { getTargetOrgOrAlias: jest.fn() },
+  getConnection: jest.fn(),
+  workspaceUtils: { getRootWorkspacePath: jest.fn().mockReturnValue('/workspace') }
+}));
+
+jest.mock('../../../src/channels', () => ({
+  OUTPUT_CHANNEL: {
+    appendLine: jest.fn(),
+    show: jest.fn(),
+    clear: jest.fn(),
+    dispose: jest.fn(),
+    hide: jest.fn(),
+    replace: jest.fn(),
+    append: jest.fn(),
+    name: 'Salesforce CLI'
+  },
+  channelService: { appendLine: jest.fn(), showChannelOutput: jest.fn() }
+}));
+
+jest.mock('../../../src/messages', () => ({
+  nls: { localize: (key: string) => key }
+}));
+
+import { PackageInstallExecutor, PackageIdAndInstallationKey } from '../../../src/commands/packageInstall';
+
+const MockCliCommandExecutor = CliCommandExecutor as jest.MockedClass<typeof CliCommandExecutor>;
+const mockGetTargetOrgOrAlias = jest.mocked(ConfigUtil.getTargetOrgOrAlias);
+const mockGetConnection = jest.mocked(getConnection);
+
+const PACKAGE_ID = '04tKY000000MF7uYAG';
+
+const makeResponse = (
+  packageId: string,
+  installationKey = ''
+): { type: 'CONTINUE'; data: PackageIdAndInstallationKey } => ({
+  type: 'CONTINUE',
+  data: { packageId, installationKey }
+});
+
+const mockProgress: vscode.Progress<{ message?: string }> = { report: jest.fn() };
+const mockToken = new vscode.CancellationTokenSource().token;
+
+// Executor with zero poll delay so tests run instantly
+const makeExecutor = () => new PackageInstallExecutor(0);
+
+// Build a mock tooling.query that returns the given sequence of statuses
+const setupConnectionMock = (...statuses: (string | null)[]) => {
+  const queryFn = jest.fn();
+  for (const status of statuses) {
+    if (status === null) {
+      queryFn.mockResolvedValueOnce({ records: [] });
+    } else {
+      queryFn.mockResolvedValueOnce({
+        records: [{ Status: status, SubscriberPackageVersionKey: PACKAGE_ID }]
+      });
+    }
+  }
+  mockGetConnection.mockResolvedValue({
+    tooling: { query: queryFn }
+  } as any);
+  return queryFn;
+};
+
+beforeEach(() => {
+  mockGetTargetOrgOrAlias.mockResolvedValue('testOrg');
+  MockCliCommandExecutor.mockImplementation(
+    () =>
+      ({
+        execute: jest.fn().mockReturnValue({
+          command: { toString: () => 'sf', logName: 'pkg', command: 'sf', args: [] },
+          processExitSubject: { subscribe: jest.fn() },
+          processErrorSubject: { subscribe: jest.fn() },
+          stdoutSubject: { subscribe: jest.fn() },
+          stderrSubject: { subscribe: jest.fn() }
+        })
+      }) as any
+  );
+});
+
+describe('PackageInstallExecutor.run', () => {
+  it('returns true when first poll is SUCCESS', async () => {
+    setupConnectionMock('SUCCESS');
+
+    const result = await makeExecutor().run(makeResponse(PACKAGE_ID), mockProgress, mockToken);
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when first poll is ERROR', async () => {
+    setupConnectionMock('ERROR');
+
+    const result = await makeExecutor().run(makeResponse(PACKAGE_ID), mockProgress, mockToken);
+
+    expect(result).toBe(false);
+  });
+
+  it('keeps polling through IN_PROGRESS until SUCCESS', async () => {
+    const queryFn = setupConnectionMock('IN_PROGRESS', 'IN_PROGRESS', 'SUCCESS');
+
+    const result = await makeExecutor().run(makeResponse(PACKAGE_ID), mockProgress, mockToken);
+
+    expect(result).toBe(true);
+    expect(queryFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries when getConnection throws (transient error)', async () => {
+    const queryFn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('auth error'))
+      .mockResolvedValueOnce({ records: [{ Status: 'SUCCESS', SubscriberPackageVersionKey: PACKAGE_ID }] });
+    mockGetConnection
+      .mockRejectedValueOnce(new Error('auth error'))
+      .mockResolvedValue({ tooling: { query: queryFn } } as any);
+
+    const result = await makeExecutor().run(makeResponse(PACKAGE_ID), mockProgress, mockToken);
+
+    expect(result).toBe(true);
+  });
+
+  it('retries when query returns empty records (request not created yet)', async () => {
+    const queryFn = setupConnectionMock(null, 'SUCCESS');
+
+    const result = await makeExecutor().run(makeResponse(PACKAGE_ID), mockProgress, mockToken);
+
+    expect(result).toBe(true);
+    expect(queryFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('matches by 15-char prefix when stored ID is 15 chars', async () => {
+    const queryFn = jest.fn().mockResolvedValueOnce({
+      records: [{ Status: 'SUCCESS', SubscriberPackageVersionKey: PACKAGE_ID.slice(0, 15) }]
+    });
+    mockGetConnection.mockResolvedValue({ tooling: { query: queryFn } } as any);
+
+    const result = await makeExecutor().run(makeResponse(PACKAGE_ID), mockProgress, mockToken);
+
+    expect(result).toBe(true);
+  });
+
+  it('passes targetOrg to getConnection', async () => {
+    setupConnectionMock('SUCCESS');
+
+    await makeExecutor().run(makeResponse(PACKAGE_ID), mockProgress, mockToken);
+
+    expect(mockGetConnection).toHaveBeenCalledWith('testOrg');
+  });
+
+  it('passes undefined targetOrg to getConnection when org is not configured', async () => {
+    mockGetTargetOrgOrAlias.mockResolvedValue(undefined);
+    setupConnectionMock('SUCCESS');
+
+    await makeExecutor().run(makeResponse(PACKAGE_ID), mockProgress, mockToken);
+
+    expect(mockGetConnection).toHaveBeenCalledWith(undefined);
+  });
+
+  it('shows polling progress message', async () => {
+    setupConnectionMock('SUCCESS');
+
+    const progress: vscode.Progress<{ message?: string }> = { report: jest.fn() };
+    await makeExecutor().run(makeResponse(PACKAGE_ID), progress, mockToken);
+
+    expect(progress.report).toHaveBeenCalledWith({ message: 'package_install_polling_message' });
+  });
+
+  it('passes --installation-key to install command', async () => {
+    setupConnectionMock('SUCCESS');
+
+    await makeExecutor().run(makeResponse(PACKAGE_ID, 'mySecretKey'), mockProgress, mockToken);
+
+    const installArgs = MockCliCommandExecutor.mock.calls[0][0].args;
+    expect(installArgs).toContain('--installation-key');
+    expect(installArgs).toContain('mySecretKey');
+  });
+
+  it('passes --target-org to install command', async () => {
+    setupConnectionMock('SUCCESS');
+
+    await makeExecutor().run(makeResponse(PACKAGE_ID), mockProgress, mockToken);
+
+    const installArgs = MockCliCommandExecutor.mock.calls[0][0].args;
+    expect(installArgs).toContain('--target-org');
+    expect(installArgs).toContain('testOrg');
+  });
+
+  it('falls back to result[0] when package ID is not in list', async () => {
+    const queryFn = jest.fn().mockResolvedValueOnce({
+      records: [{ Status: 'SUCCESS', SubscriberPackageVersionKey: '04tOTHER000000000' }]
+    });
+    mockGetConnection.mockResolvedValue({ tooling: { query: queryFn } } as any);
+
+    const result = await makeExecutor().run(makeResponse(PACKAGE_ID), mockProgress, mockToken);
+
+    expect(result).toBe(true);
+  });
+});


### PR DESCRIPTION
### What does this PR do?
When **SFDX: Install Package** is run, there is a progress notification toast that is displayed to indicate that the package is currently installing.  However, that progress notification doesn't change to a success notification when the package is finished installing, even after the user receives the email about successful installation and manually checking the status in the CLI shows status `SUCCESS`.

This PR changes that by polling for the status of the package installation every 30 seconds and displaying the status in the Output Tab under the **Salesforce CLI** tab.  Therefore, after the package completes its installation, users will receive feedback within 30 seconds about the success.

### What issues does this PR fix or reference?
@W-22681257@

### Functionality Before
The progress notification stays there forever, even though the CLI poll clearly indicates a successful installation.
<img width="1840" height="1196" alt="Screenshot 2026-05-26 at 2 53 02 PM" src="https://github.com/user-attachments/assets/913f30e3-bdb9-49a8-85d0-d8ab8eb087d1" />

### Functionality After
Polling status in the Output Tab every 30 seconds, and the progress notification replaced with a success notification upon completion.

In progress:
<img width="1840" height="1196" alt="Screenshot 2026-05-27 at 9 36 42 AM" src="https://github.com/user-attachments/assets/8d3aa082-db4b-4409-94fe-b7c4f2ddaae8" />

Successful installation:
<img width="1728" height="1117" alt="Screenshot 2026-05-27 at 9 45 27 AM" src="https://github.com/user-attachments/assets/77500ede-5e99-4ad7-8475-f5c7ff13375a" />