### PR TITLE
feat(services): managed-token placeholder + apiVersion default 67.0 (W-22680096)

### DIFF
--- a/packages/salesforcedx-vscode-services/package.json
+++ b/packages/salesforcedx-vscode-services/package.json
@@ -309,7 +309,7 @@
         },
         "salesforce-web-console.apiVersion": {
           "type": "string",
-          "default": "64.0",
+          "default": "67.0",
           "description": "%configuration.apiVersion.description%"
         },
         "salesforce-web-console.retrieveOnLoad": {

--- a/packages/salesforcedx-vscode-services/src/vscode/settingsService.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/settingsService.ts
@@ -17,7 +17,11 @@ import {
 } from '../constants';
 import { unknownToErrorCause } from '../core/shared';
 
-const FALLBACK_API_VERSION = '64.0';
+const FALLBACK_API_VERSION = '67.0';
+
+/* In web (Code Builder) mode authentication is managed by the host environment;
+   the extension uses this sentinel rather than reading from settings. */
+const WEB_MANAGED_TOKEN = 'web-console-managed-token';
 
 export class SettingsError extends S.TaggedError<SettingsError>()('MissingSettingsError', {
   cause: S.Unknown,
@@ -98,6 +102,9 @@ export class SettingsService extends Effect.Service<SettingsService>()('Settings
     });
 
     const getAccessToken = Effect.fn('SettingsService.getAccessToken')(function* () {
+      if (process.env.ESBUILD_PLATFORM === 'web') {
+        return yield* Effect.succeed(WEB_MANAGED_TOKEN);
+      }
       return yield* Effect.try({
         try: () => vscode.workspace.getConfiguration(CODE_BUILDER_WEB_SECTION).get<string>(ACCESS_TOKEN_KEY)?.trim(),
         catch: error => {

--- a/packages/salesforcedx-vscode-services/src/vscode/settingsService.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/settingsService.ts
@@ -19,8 +19,7 @@ import { unknownToErrorCause } from '../core/shared';
 
 const FALLBACK_API_VERSION = '67.0';
 
-/* In web (Code Builder) mode authentication is managed by the host environment;
-   the extension uses this sentinel rather than reading from settings. */
+// Web (Code Builder) auth is host-managed; this sentinel stands in for the real token.
 const WEB_MANAGED_TOKEN = 'web-console-managed-token';
 
 export class SettingsError extends S.TaggedError<SettingsError>()('MissingSettingsError', {
@@ -103,7 +102,7 @@ export class SettingsService extends Effect.Service<SettingsService>()('Settings
 
     const getAccessToken = Effect.fn('SettingsService.getAccessToken')(function* () {
       if (process.env.ESBUILD_PLATFORM === 'web') {
-        return yield* Effect.succeed(WEB_MANAGED_TOKEN);
+        return WEB_MANAGED_TOKEN;
       }
       return yield* Effect.try({
         try: () => vscode.workspace.getConfiguration(CODE_BUILDER_WEB_SECTION).get<string>(ACCESS_TOKEN_KEY)?.trim(),
@@ -223,7 +222,7 @@ export class SettingsService extends Effect.Service<SettingsService>()('Settings
       getInstanceUrl,
       /** Get the Salesforce access token from settings */
       getAccessToken,
-      /** Get the Salesforce API version from settings. In the form of '64.0' */
+      /** Get the Salesforce API version from settings. In the form of 'XX.0' */
       getApiVersion,
       /** Set the Salesforce instance URL in settings */
       setInstanceUrl,

--- a/packages/salesforcedx-vscode-services/test/jest/vscode/settingsService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/vscode/settingsService.test.ts
@@ -5,9 +5,11 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import * as Cause from 'effect/Cause';
 import * as Effect from 'effect/Effect';
+import * as Option from 'effect/Option';
 import * as vscode from 'vscode';
-import { SettingsService } from '../../../src/vscode/settingsService';
+import { SettingsError, SettingsService } from '../../../src/vscode/settingsService';
 
 const runAccessToken = () =>
   Effect.runPromiseExit(
@@ -83,9 +85,10 @@ describe('SettingsService.getAccessToken', () => {
 
     expect(exit._tag).toBe('Failure');
     if (exit._tag === 'Failure') {
-      const text = JSON.stringify(exit.cause);
-      expect(text).toContain('accessToken');
-      expect(text).toContain('MissingSettingsError');
+      const failure = Option.getOrThrow(Cause.failureOption(exit.cause));
+      expect(failure).toBeInstanceOf(SettingsError);
+      expect((failure as SettingsError)._tag).toBe('MissingSettingsError');
+      expect((failure as SettingsError).key).toBe('accessToken');
     }
   });
 });

--- a/packages/salesforcedx-vscode-services/test/jest/vscode/settingsService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/vscode/settingsService.test.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Effect from 'effect/Effect';
+import * as vscode from 'vscode';
+import { SettingsService } from '../../../src/vscode/settingsService';
+
+const runAccessToken = () =>
+  Effect.runPromiseExit(
+    Effect.gen(function* () {
+      const settings = yield* SettingsService;
+      return yield* settings.getAccessToken();
+    }).pipe(Effect.provide(SettingsService.Default))
+  );
+
+const runApiVersion = () =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const settings = yield* SettingsService;
+      return yield* settings.getApiVersion();
+    }).pipe(Effect.provide(SettingsService.Default))
+  );
+
+describe('SettingsService.getAccessToken', () => {
+  const originalPlatform = process.env.ESBUILD_PLATFORM;
+  let getConfigSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    getConfigSpy = jest.spyOn(vscode.workspace, 'getConfiguration');
+  });
+
+  afterEach(() => {
+    if (originalPlatform === undefined) {
+      delete process.env.ESBUILD_PLATFORM;
+    } else {
+      process.env.ESBUILD_PLATFORM = originalPlatform;
+    }
+    getConfigSpy.mockRestore();
+  });
+
+  it('returns the managed-token sentinel in web mode without reading settings', async () => {
+    process.env.ESBUILD_PLATFORM = 'web';
+
+    const exit = await runAccessToken();
+
+    expect(exit._tag).toBe('Success');
+    if (exit._tag === 'Success') {
+      expect(exit.value).toBe('web-console-managed-token');
+    }
+    expect(getConfigSpy).not.toHaveBeenCalled();
+  });
+
+  it('reads from settings and trims whitespace in desktop mode', async () => {
+    delete process.env.ESBUILD_PLATFORM;
+
+    getConfigSpy.mockReturnValue({
+      get: jest.fn().mockReturnValue('  real-desktop-token  '),
+      update: jest.fn()
+    } as unknown as vscode.WorkspaceConfiguration);
+
+    const exit = await runAccessToken();
+
+    expect(exit._tag).toBe('Success');
+    if (exit._tag === 'Success') {
+      expect(exit.value).toBe('real-desktop-token');
+    }
+    expect(getConfigSpy).toHaveBeenCalledWith('salesforce-web-console');
+  });
+
+  it('fails with SettingsError in desktop mode when the setting is empty', async () => {
+    delete process.env.ESBUILD_PLATFORM;
+
+    getConfigSpy.mockReturnValue({
+      get: jest.fn().mockReturnValue(''),
+      update: jest.fn()
+    } as unknown as vscode.WorkspaceConfiguration);
+
+    const exit = await runAccessToken();
+
+    expect(exit._tag).toBe('Failure');
+    if (exit._tag === 'Failure') {
+      const text = JSON.stringify(exit.cause);
+      expect(text).toContain('accessToken');
+      expect(text).toContain('MissingSettingsError');
+    }
+  });
+});
+
+describe('SettingsService.getApiVersion fallback', () => {
+  let getConfigSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    getConfigSpy = jest.spyOn(vscode.workspace, 'getConfiguration');
+  });
+
+  afterEach(() => {
+    getConfigSpy.mockRestore();
+  });
+
+  it('falls back to 67.0 when no value is configured', async () => {
+    getConfigSpy.mockReturnValue({
+      get: jest.fn().mockReturnValue(undefined),
+      update: jest.fn()
+    } as unknown as vscode.WorkspaceConfiguration);
+
+    expect(await runApiVersion()).toBe('67.0');
+  });
+
+  it('falls back to 67.0 for an empty configured value', async () => {
+    getConfigSpy.mockReturnValue({
+      get: jest.fn().mockReturnValue(''),
+      update: jest.fn()
+    } as unknown as vscode.WorkspaceConfiguration);
+
+    expect(await runApiVersion()).toBe('67.0');
+  });
+});


### PR DESCRIPTION
## Why

CB Web hosts these extensions inside an iframe and is migrating to a postMessage proxy lane where the parent LWC owns the real Salesforce session credential and substitutes the Authorization header before issuing org-bound fetches. Extensions in that environment stop expecting a real token from the web env — they construct `Bearer web-console-managed-token` (a managed-token placeholder) and let the LWC swap it for the real credential at the boundary.

Paired with a CBW-side transport ([forcedotcom/code-builder-web#100](https://github.com/forcedotcom/code-builder-web/pull/100)) and an extension-host worker fetch swap landing on a CBW feature branch. The full activation also requires a one-line change in the host LWC.

## ⚠️ Do not merge until activation

This PR breaks the existing direct-fetch path: extensions will attach the placeholder string instead of a real token, and any unproxied org calls will 401 immediately. Merge order:

1. CBW PR [#100](https://github.com/forcedotcom/code-builder-web/pull/100) (transport plumbing) — safe to merge first, inert
2. Core LWC reads `event.ports[0]` from IFRAME_READY and bridges API_REQUEST → org fetch
3. CBW W-22390378 (worker `self.fetch` swap) — depends on 1 + 2
4. **This PR** — only after 1-3 are live in prod

Drafting now so the diff can be reviewed early.

## Default apiVersion bump

`67.0` aligns with the API version the proxy lane targets in production.