### PR TITLE
fix: read apex test results from org-scoped folder in colorizer - W-22717485

### DIFF
--- a/packages/salesforcedx-vscode-apex-testing/src/codecoverage/colorizer.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/codecoverage/colorizer.ts
@@ -13,23 +13,12 @@ import { URI, Utils } from 'vscode-uri';
 import { IS_TEST_REG_EXP } from '../constants';
 import { nls } from '../messages';
 import { getApexTestingRuntime } from '../services/extensionProvider';
+import { getTestResultsFolder } from '../utils/pathHelpers';
 import { coveredLinesDecorationType, uncoveredLinesDecorationType } from './decorations';
 import { StatusBarToggle } from './statusBarToggle';
 
 const SFDX_FOLDER = '.sfdx';
-const TOOLS = 'tools';
-const TEST_RESULTS = 'testresults';
-const APEX = 'apex';
 const IS_CLS_OR_TRIGGER = /(\.cls|\.trigger)$/;
-
-/** Path segment for apex test results (works in Desktop and Web). */
-const getApexTestResultsUri = (): URI => {
-  const folder = workspace.workspaceFolders?.[0]?.uri;
-  if (!folder) {
-    throw new Error(nls.localize('colorizer_no_code_coverage_on_project'));
-  }
-  return Utils.joinPath(folder, SFDX_FOLDER, TOOLS, TEST_RESULTS, APEX);
-};
 
 const getLineRange = (document: TextDocument, lineNumber: number): Range => {
   const adjustedLineNumber = lineNumber - 1;
@@ -67,8 +56,7 @@ const readFileUri = async (uri: URI): Promise<string> => {
   return new TextDecoder().decode(data);
 };
 
-const getTestRunId = async (): Promise<string> => {
-  const apexTestResultsUri = getApexTestResultsUri();
+const getTestRunId = async (apexTestResultsUri: URI): Promise<string> => {
   const testRunIdUri = Utils.joinPath(apexTestResultsUri, 'test-run-id.txt');
   if (!(await fileExists(testRunIdUri))) {
     throw new Error(nls.localize('colorizer_no_code_coverage_on_project'));
@@ -77,8 +65,11 @@ const getTestRunId = async (): Promise<string> => {
 };
 
 const getCoverageData = async (): Promise<CoverageItem[] | CodeCoverageResult[]> => {
-  const testRunId = await getTestRunId();
-  const apexTestResultsUri = getApexTestResultsUri();
+  if (!workspace.workspaceFolders?.[0]?.uri) {
+    throw new Error(nls.localize('colorizer_no_code_coverage_on_project'));
+  }
+  const apexTestResultsUri = await getTestResultsFolder();
+  const testRunId = await getTestRunId(apexTestResultsUri);
   const testResultUri = Utils.joinPath(apexTestResultsUri, `test-result-${testRunId}.json`);
 
   if (!(await fileExists(testResultUri))) {

--- a/packages/salesforcedx-vscode-apex-testing/test/jest/codecoverage/colorizer.test.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/jest/codecoverage/colorizer.test.ts
@@ -11,10 +11,15 @@ jest.mock('../../../src/services/extensionProvider', () => ({
   })
 }));
 
+jest.mock('../../../src/utils/pathHelpers', () => ({
+  getTestResultsFolder: jest.fn()
+}));
+
 import * as vscode from 'vscode';
-import { URI } from 'vscode-uri';
+import { URI, Utils } from 'vscode-uri';
 import { CodeCoverageHandler } from '../../../src/codecoverage/colorizer';
 import { StatusBarToggle } from '../../../src/codecoverage/statusBarToggle';
+import { getTestResultsFolder } from '../../../src/utils/pathHelpers';
 
 describe('CodeCoverageHandler', () => {
   let mockStatusBar: StatusBarToggle;
@@ -84,6 +89,9 @@ describe('CodeCoverageHandler', () => {
         configurable: true,
         writable: true
       });
+      (getTestResultsFolder as jest.Mock).mockResolvedValue(
+        URI.file('/workspace/project/.sfdx/tools/testresults/apex/00DQI00000NGcnN2AT')
+      );
       jest.spyOn(vscode.workspace.fs, 'stat').mockRejectedValue(new Error('no file'));
       jest.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue({
         get: jest.fn().mockReturnValue(false)
@@ -93,6 +101,51 @@ describe('CodeCoverageHandler', () => {
       await handler.toggleCoverage();
 
       expect(mockStatusBar.toggle).toHaveBeenCalledWith(true);
+    });
+
+    it('reads test-run-id.txt from the org-scoped folder returned by getTestResultsFolder', async () => {
+      (mockStatusBar as { isHighlightingEnabled: boolean }).isHighlightingEnabled = false;
+      const orgScopedFolder = URI.file('/workspace/project/.sfdx/tools/testresults/apex/00DQI00000NGcnN2AT');
+      const workspaceFolders = [
+        { uri: URI.file('/workspace/project'), name: 'project', index: 0 }
+      ] as vscode.WorkspaceFolder[];
+      Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+        value: workspaceFolders,
+        configurable: true,
+        writable: true
+      });
+      (getTestResultsFolder as jest.Mock).mockResolvedValue(orgScopedFolder);
+
+      const testRunId = '707QI00001AMz3r';
+      const expectedTestRunIdUri = Utils.joinPath(orgScopedFolder, 'test-run-id.txt');
+      const expectedResultUri = Utils.joinPath(orgScopedFolder, `test-result-${testRunId}.json`);
+      const statSpy = jest.spyOn(vscode.workspace.fs, 'stat').mockResolvedValue({} as vscode.FileStat);
+      jest.spyOn(vscode.workspace.fs, 'readFile').mockImplementation((uri: URI) => {
+        if (uri.path === expectedTestRunIdUri.path) {
+          return Promise.resolve(new TextEncoder().encode(testRunId));
+        }
+        if (uri.path === expectedResultUri.path) {
+          return Promise.resolve(new TextEncoder().encode(JSON.stringify({ codecoverage: [] })));
+        }
+        return Promise.reject(new Error(`unexpected read: ${uri.path}`));
+      });
+
+      Object.defineProperty(mockEditor.document, 'uri', {
+        value: URI.file('/workspace/project/force-app/main/default/classes/MyClass.cls'),
+        configurable: true,
+        writable: true
+      });
+      jest.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue({
+        get: jest.fn().mockReturnValue(false)
+      } as unknown as vscode.WorkspaceConfiguration);
+      jest.spyOn(vscode.window, 'showWarningMessage').mockResolvedValue(undefined as unknown as vscode.MessageItem);
+
+      await handler.toggleCoverage();
+
+      expect(getTestResultsFolder).toHaveBeenCalled();
+      const statPaths = statSpy.mock.calls.map(([uri]) => (uri as URI).path);
+      expect(statPaths).toContain(expectedTestRunIdUri.path);
+      expect(statPaths).not.toContain('/workspace/project/.sfdx/tools/testresults/apex/test-run-id.txt');
     });
   });
 });


### PR DESCRIPTION
## What does this PR do?

Fixes a regression where the Apex code coverage colorizer silently failed to highlight covered/uncovered lines.

The writer ([pathHelpers.getTestResultsFolder](packages/salesforcedx-vscode-apex-testing/src/utils/pathHelpers.ts)) added an `<orgKey>` path segment in [PR #7300](https://github.com/forcedotcom/salesforcedx-vscode/pull/7300), but the reader in [colorizer.ts](packages/salesforcedx-vscode-apex-testing/src/codecoverage/colorizer.ts) still looked for `test-run-id.txt` directly under `.sfdx/tools/testresults/apex/`. With test results actually written to `.sfdx/tools/testresults/apex/<orgId>/`, the reader couldn't find them and threw `colorizer_no_code_coverage_on_project`.

## Changes

- Replace the local `getApexTestResultsUri()` helper with the shared async `getTestResultsFolder()` from `pathHelpers.ts`, so reader and writer agree on the org-scoped path.
- Update the colorizer test to mock `getTestResultsFolder` and assert that the org-scoped folder is read (and the un-scoped legacy path is not).

## What issues does this PR fix or reference?

#7359, @W-22717485@

## Test plan

- [x] `npx jest test/jest/codecoverage/colorizer.test.ts` — passes (4/4)
- [x] Full apex-testing jest suite — passes (257/258, 1 pre-existing skipped)
- [x] Lint clean
- [ ] Manual: run Apex tests on dreamhouse-lwc with `salesforcedx-vscode-apex-testing.retrieve-test-code-coverage: true`, toggle the colorizer status bar item, confirm covered lines highlight green and uncovered red.