### PR TITLE
fix(apex-log,services): throttle trace flag polling cascade - W-22390896

### DIFF
--- a/packages/salesforcedx-vscode-apex-log/package.json
+++ b/packages/salesforcedx-vscode-apex-log/package.json
@@ -282,6 +282,13 @@
           "minimum": 1,
           "maximum": 1440,
           "description": "%apexLog.configuration.traceFlagsDefaultDurationMinutes.description%"
+        },
+        "salesforcedx.traceFlagPollingInterval": {
+          "type": "number",
+          "default": 5,
+          "minimum": 0,
+          "maximum": 60,
+          "description": "%apexLog.configuration.traceFlagPollingInterval.description%"
         }
       }
     },

--- a/packages/salesforcedx-vscode-apex-log/package.nls.json
+++ b/packages/salesforcedx-vscode-apex-log/package.nls.json
@@ -19,5 +19,6 @@
   "apexLog.command.traceFlagsDeleteForId": "SFDX: Remove Trace Flag",
   "apexLog.command.traceFlagsChangeDebugLevel": "SFDX: Change Trace Flag Debug Level",
   "apexLog.command.traceFlagsCreateLogLevel": "SFDX: Create Debug Level",
-  "apexLog.command.traceFlagsDeleteDebugLevelForId": "SFDX: Remove Debug Level"
+  "apexLog.command.traceFlagsDeleteDebugLevelForId": "SFDX: Remove Debug Level",
+  "apexLog.configuration.traceFlagPollingInterval.description": "Interval in minutes between background TraceFlag polls (expired trace flag cleanup). Set to 0 to disable background polling entirely (manual trace flag commands still work). Default 5 minutes; min 1, max 60."
 }

--- a/packages/salesforcedx-vscode-apex-log/src/traceFlagCleanupScheduler.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/traceFlagCleanupScheduler.ts
@@ -10,8 +10,25 @@ import * as Duration from 'effect/Duration';
 import * as Effect from 'effect/Effect';
 import * as Schedule from 'effect/Schedule';
 import * as Stream from 'effect/Stream';
+import * as vscode from 'vscode';
 
-/** Runs trace flag cleanup every 5 minutes and immediately on each org connection. Forks and runs until extension scope closes. */
+const DEFAULT_POLL_INTERVAL_MINUTES = 5;
+const MIN_POLL_INTERVAL_MINUTES = 1;
+const MAX_POLL_INTERVAL_MINUTES = 60;
+
+/** Read `salesforcedx.traceFlagPollingInterval`; `0` disables background polling, otherwise clamped to [min, max]. */
+const getTraceFlagPollingIntervalMinutes = (): number => {
+  const raw = vscode.workspace
+    .getConfiguration('salesforcedx')
+    .get<number>('traceFlagPollingInterval', DEFAULT_POLL_INTERVAL_MINUTES);
+  if (raw === 0) return 0;
+  return Math.max(MIN_POLL_INTERVAL_MINUTES, Math.min(MAX_POLL_INTERVAL_MINUTES, raw));
+};
+
+/**
+ * Runs trace flag cleanup on each org connection AND on a user-configurable polling interval (default 5 min).
+ * Forks and runs until extension scope closes. `salesforcedx.traceFlagPollingInterval=0` disables the recurring poll.
+ */
 export const traceFlagCleanupScheduler = Effect.fn('traceFlagCleanupScheduler')(function* () {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const traceFlagService = yield* api.services.TraceFlagService;
@@ -21,15 +38,23 @@ export const traceFlagCleanupScheduler = Effect.fn('traceFlagCleanupScheduler')(
     Effect.catchAll(() => Effect.void)
   );
 
-  // Run once each time a new org is connected (catches pre-provisioned expired flags like SFDC_DevConsole).
+  // On org switch: drop prior-org caches, then cleanup pre-provisioned expired flags. @W-22390896
   yield* Effect.fork(
     targetOrgRef.changes.pipe(
       Stream.map(orgInfo => orgInfo.orgId),
       Stream.changes,
-      Stream.runForEach(() => cleanup)
+      Stream.runForEach(() => traceFlagService.invalidateCaches.pipe(Effect.zipRight(cleanup)))
     )
   );
 
-  yield* Effect.fork(Stream.fromSchedule(Schedule.fixed(Duration.minutes(5))).pipe(Stream.runForEach(() => cleanup)));
+  const intervalMinutes = getTraceFlagPollingIntervalMinutes();
+  yield* intervalMinutes > 0
+    ? Effect.fork(
+        Stream.fromSchedule(Schedule.fixed(Duration.minutes(intervalMinutes))).pipe(Stream.runForEach(() => cleanup))
+      )
+    : Effect.logInfo(
+        'salesforcedx.traceFlagPollingInterval=0 — background trace flag polling disabled (per-org-connect cleanup still runs)'
+      );
+
   yield* Effect.sleep(Duration.infinity);
 });

--- a/packages/salesforcedx-vscode-apex-log/src/traceFlags/traceFlagsContentProvider.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/traceFlags/traceFlagsContentProvider.ts
@@ -91,10 +91,7 @@ const fetchTraceFlagsContent = Effect.fn('ApexLog.fetchTraceFlagsContent')(funct
   });
 });
 
-/**
- * Virtual document provider for trace flags. Fetches from org on demand; no file on disk.
- * Documents are read-only.
- */
+/** Virtual document provider for trace flags. Read-only; fetches from org on demand. */
 class TraceFlagsContentProviderClass implements vscode.TextDocumentContentProvider {
   private readonly _onDidChange = new vscode.EventEmitter<URI>();
 
@@ -114,8 +111,14 @@ class TraceFlagsContentProviderClass implements vscode.TextDocumentContentProvid
     );
   }
 
+  /** Ask VS Code to re-render; skip if no editor has the doc open. @W-22390896 */
   public refresh(orgId: string): void {
-    this._onDidChange.fire(createTraceFlagsUri(orgId));
+    const uri = createTraceFlagsUri(orgId);
+    const uriString = uri.toString();
+    if (!vscode.workspace.textDocuments.some(d => d.uri.toString() === uriString)) {
+      return;
+    }
+    this._onDidChange.fire(uri);
   }
 }
 

--- a/packages/salesforcedx-vscode-services/src/core/traceFlagService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/traceFlagService.ts
@@ -5,8 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import * as Cache from 'effect/Cache';
 import * as Duration from 'effect/Duration';
 import * as Effect from 'effect/Effect';
+import * as Exit from 'effect/Exit';
 import * as Match from 'effect/Match';
 import * as Option from 'effect/Option';
 import * as ParseResult from 'effect/ParseResult';
@@ -34,6 +36,45 @@ import {
   type TraceFlagLogType
 } from './schemas/traceFlagSchemas';
 import { unknownToErrorCause } from './shared';
+
+/** Adaptive cache TTL ladder: 30s → 60s → 120s → 5min (capped). 4 steps by design. Failures not cached. @W-22390896 */
+export const ADAPTIVE_TTL_SEQUENCE_MS = [30_000, 60_000, 120_000, 300_000] as const;
+export const adaptiveTtl = (consecutiveNoChange: number): Duration.Duration =>
+  Duration.millis(ADAPTIVE_TTL_SEQUENCE_MS[Math.min(consecutiveNoChange, ADAPTIVE_TTL_SEQUENCE_MS.length - 1)]);
+
+/** Order-independent identity hash on id|expiration|debugLevel|active — SOQL reorderings don't reset TTL. */
+const tfHash = (tf: TraceFlagItem): string =>
+  `${tf.id}|${tf.expirationDate.getTime()}|${tf.debugLevelId ?? ''}|${tf.isActive ? 1 : 0}`;
+export const tfArrayHash = (arr: readonly TraceFlagItem[]): string => arr.map(tfHash).toSorted().join(';');
+export const tfOptionHash = (o: Option.Option<TraceFlagItem>): string => (Option.isSome(o) ? tfHash(o.value) : '');
+
+/** `prior === undefined` ⇒ no prior yet ⇒ never same (counter starts fresh at 0). */
+export const isSameTfArray = (prior: readonly TraceFlagItem[] | undefined, fresh: readonly TraceFlagItem[]): boolean =>
+  prior !== undefined && tfArrayHash(prior) === tfArrayHash(fresh);
+export const isSameTfOption = (
+  prior: Option.Option<TraceFlagItem> | undefined,
+  fresh: Option.Option<TraceFlagItem>
+): boolean => prior !== undefined && tfOptionHash(prior) === tfOptionHash(fresh);
+
+type AdaptiveCacheState<T> = { lastResult: T; consecutiveNoChange: number };
+
+/** Counter+TTL evolution: same result → counter += 1; otherwise → counter = 0. Exported for unit tests. */
+export const computeAdaptiveTtl = <T>(
+  prior: { lastResult: T; consecutiveNoChange: number } | undefined,
+  fresh: T,
+  isSame: (prior: T | undefined, fresh: T) => boolean
+): { newCount: number; ttl: Duration.Duration } => {
+  const same = isSame(prior?.lastResult, fresh);
+  const newCount = same && prior ? prior.consecutiveNoChange + 1 : 0;
+  return { newCount, ttl: adaptiveTtl(newCount) };
+};
+
+/** Narrow a string to TraceFlagLogType without using `as` (repo lint rule disallows type assertions). */
+const parseLogType = (s: string): TraceFlagLogType => {
+  if (s === 'USER_DEBUG') return 'USER_DEBUG';
+  if (s === 'CLASS_TRACING') return 'CLASS_TRACING';
+  return 'DEVELOPER_LOG';
+};
 
 const APEX_CODE_DEBUG_LEVEL = 'FINEST';
 const VISUALFORCE_DEBUG_LEVEL = 'FINER';
@@ -73,7 +114,7 @@ export class TraceFlagService extends Effect.Service<TraceFlagService>()('TraceF
     const connectionService = yield* ConnectionService;
     const traceFlagsChanged = yield* PubSub.sliding<TraceFlagItem[]>(1);
 
-    const getTraceFlags = Effect.fn('TraceFlagService.getTraceFlags')(function* () {
+    const getTraceFlagsImpl = Effect.fn('TraceFlagService.getTraceFlagsImpl')(function* () {
       const conn = yield* connectionService.getConnection();
       const query = `SELECT Id, LogType, StartDate, ExpirationDate, DebugLevelId, DebugLevel.ApexCode, DebugLevel.Visualforce, DebugLevel.DeveloperName, TracedEntityId
         FROM TraceFlag`;
@@ -162,7 +203,7 @@ export class TraceFlagService extends Effect.Service<TraceFlagService>()('TraceF
       );
     });
 
-    const getTraceFlagForUser = Effect.fn('TraceFlagService.getTraceFlagForUser')(function* (
+    const getTraceFlagForUserImpl = Effect.fn('TraceFlagService.getTraceFlagForUserImpl')(function* (
       userId: string,
       logType: TraceFlagLogType = 'DEVELOPER_LOG'
     ) {
@@ -224,6 +265,90 @@ export class TraceFlagService extends Effect.Service<TraceFlagService>()('TraceF
         : yield* new DebugLevelCreateError({ message: 'Debug level create returned no ID' });
     });
 
+    /* Adaptive TTL state: per-cache last-result + consecutive-no-change count. Service-instance scoped. */
+    const allTraceFlagsAdaptive = new Map<'all', AdaptiveCacheState<TraceFlagItem[]>>();
+    const traceFlagForUserAdaptive = new Map<string, AdaptiveCacheState<Option.Option<TraceFlagItem>>>();
+
+    /** Computes next TTL via `computeAdaptiveTtl` and updates state map in place. */
+    const bumpAdaptiveState = <K, T>(
+      stateMap: Map<K, AdaptiveCacheState<T>>,
+      key: K,
+      fresh: T,
+      isSame: (prior: T | undefined, fresh: T) => boolean
+    ): Duration.Duration => {
+      const { newCount, ttl } = computeAdaptiveTtl(stateMap.get(key), fresh, isSame);
+      stateMap.set(key, { lastResult: fresh, consecutiveNoChange: newCount });
+      return ttl;
+    };
+
+    /* Cached entries embed their adaptive TTL so Cache.makeWith's per-entry timeToLive(exit) can extract it. */
+    type EntryAll = { readonly value: TraceFlagItem[]; readonly ttl: Duration.Duration };
+    type EntryForUser = { readonly value: Option.Option<TraceFlagItem>; readonly ttl: Duration.Duration };
+
+    const allTraceFlagsCache = yield* Cache.makeWith({
+      capacity: 1,
+      lookup: (_key: 'all') =>
+        getTraceFlagsImpl().pipe(
+          Effect.map(
+            (value): EntryAll => ({
+              value,
+              ttl: bumpAdaptiveState(allTraceFlagsAdaptive, 'all', value, isSameTfArray)
+            })
+          )
+        ),
+      timeToLive: Exit.match({
+        onSuccess: (entry: EntryAll) => entry.ttl,
+        onFailure: () => Duration.zero
+      })
+    });
+
+    const traceFlagForUserCache = yield* Cache.makeWith({
+      capacity: 64,
+      lookup: (key: string) => {
+        const sepIdx = key.indexOf('::');
+        const userId = key.slice(0, sepIdx);
+        const logType = parseLogType(key.slice(sepIdx + 2));
+        return getTraceFlagForUserImpl(userId, logType).pipe(
+          Effect.map(
+            (value): EntryForUser => ({
+              value,
+              ttl: bumpAdaptiveState(traceFlagForUserAdaptive, key, value, isSameTfOption)
+            })
+          )
+        );
+      },
+      timeToLive: Exit.match({
+        onSuccess: (entry: EntryForUser) => entry.ttl,
+        onFailure: () => Duration.zero
+      })
+    });
+
+    const getTraceFlags = Effect.fn('TraceFlagService.getTraceFlags')(function* () {
+      const entry = yield* allTraceFlagsCache.get('all');
+      return entry.value;
+    });
+
+    const getTraceFlagForUser = Effect.fn('TraceFlagService.getTraceFlagForUser')(function* (
+      userId: string,
+      logType: TraceFlagLogType = 'DEVELOPER_LOG'
+    ) {
+      const entry = yield* traceFlagForUserCache.get(`${userId}::${logType}`);
+      return entry.value;
+    });
+
+    /**
+     * Drops both caches AND resets adaptive TTL state. Called synchronously inside every
+     * mutating method BEFORE PubSub.publish, so subscribers read fresh data on the next call.
+     */
+    const invalidateTraceFlagCaches = Effect.all([
+      allTraceFlagsCache.invalidateAll,
+      traceFlagForUserCache.invalidateAll,
+      Effect.sync(() => {
+        allTraceFlagsAdaptive.clear();
+        traceFlagForUserAdaptive.clear();
+      })
+    ]);
+
     const createTraceFlag = Effect.fn('TraceFlagService.createTraceFlag')(function* (
       userId: string,
       debugLevelId: string,
@@ -243,6 +368,7 @@ export class TraceFlagService extends Effect.Service<TraceFlagService>()('TraceF
           });
         }
       });
+      yield* invalidateTraceFlagCaches;
       const flags = yield* getTraceFlags().pipe(Effect.catchAll(() => Effect.succeed([])));
       yield* PubSub.publish(traceFlagsChanged, flags);
       return result.success && result.id ? result.id : undefined;
@@ -288,6 +414,7 @@ export class TraceFlagService extends Effect.Service<TraceFlagService>()('TraceF
           });
         }
       });
+      yield* invalidateTraceFlagCaches;
       const flags = yield* getTraceFlags().pipe(Effect.catchAll(() => Effect.succeed([])));
       yield* PubSub.publish(traceFlagsChanged, flags);
     });
@@ -304,6 +431,7 @@ export class TraceFlagService extends Effect.Service<TraceFlagService>()('TraceF
           });
         }
       });
+      yield* invalidateTraceFlagCaches;
       const flags = yield* getTraceFlags().pipe(Effect.catchAll(() => Effect.succeed([])));
       yield* PubSub.publish(traceFlagsChanged, flags);
     });
@@ -327,6 +455,7 @@ export class TraceFlagService extends Effect.Service<TraceFlagService>()('TraceF
           });
         }
       });
+      yield* invalidateTraceFlagCaches;
       const flags = yield* getTraceFlags().pipe(Effect.catchAll(() => Effect.succeed([])));
       yield* PubSub.publish(traceFlagsChanged, flags);
     });
@@ -376,7 +505,8 @@ export class TraceFlagService extends Effect.Service<TraceFlagService>()('TraceF
 
     const cleanupExpired = Effect.fn('TraceFlagService.cleanupExpired')(function* () {
       const userId = yield* getUserIdOrFail;
-      const existing = yield* getTraceFlagForUser(userId);
+      // Cleanup must see fresh server state; bypass cache to avoid stale-read decisions.
+      const existing = yield* getTraceFlagForUserImpl(userId, 'DEVELOPER_LOG');
       return yield* Option.match(existing, {
         onNone: () => Effect.succeed(false),
         onSome: tf =>
@@ -400,7 +530,9 @@ export class TraceFlagService extends Effect.Service<TraceFlagService>()('TraceF
       cleanupExpired,
       getOrCreateDebugLevel,
       getUserId,
-      traceFlagsChanged
+      traceFlagsChanged,
+      /** Drops both caches — used by the apex-log scheduler on org switch. @W-22390896 */
+      invalidateCaches: invalidateTraceFlagCaches
     };
   })
 }) {}

--- a/packages/salesforcedx-vscode-services/test/jest/core/traceFlagService.adaptive.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/traceFlagService.adaptive.test.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Duration from 'effect/Duration';
+import * as Option from 'effect/Option';
+import {
+  ADAPTIVE_TTL_SEQUENCE_MS,
+  adaptiveTtl,
+  computeAdaptiveTtl,
+  isSameTfArray,
+  isSameTfOption,
+  tfArrayHash,
+  tfOptionHash
+} from '../../../src/core/traceFlagService';
+import type { TraceFlagItem } from '../../../src/core/schemas/traceFlagSchemas';
+
+const makeItem = (overrides: Partial<TraceFlagItem> = {}): TraceFlagItem => ({
+  id: 'tf-1',
+  debugLevelId: 'dl-1',
+  tracedEntityId: '005xxx',
+  tracedEntityName: undefined,
+  logType: 'DEVELOPER_LOG',
+  startDate: undefined,
+  expirationDate: new Date('2026-12-31T00:00:00.000Z'),
+  isActive: true,
+  ...overrides
+});
+
+describe('TraceFlagService — adaptive TTL', () => {
+  describe('adaptiveTtl(n) — 30s → 60s → 120s → 300s cap', () => {
+    it('returns 30s at count 0', () => {
+      expect(Duration.toMillis(adaptiveTtl(0))).toBe(30_000);
+    });
+    it('returns 60s at count 1', () => {
+      expect(Duration.toMillis(adaptiveTtl(1))).toBe(60_000);
+    });
+    it('returns 120s at count 2', () => {
+      expect(Duration.toMillis(adaptiveTtl(2))).toBe(120_000);
+    });
+    it('returns 300s (5min cap) at count 3', () => {
+      expect(Duration.toMillis(adaptiveTtl(3))).toBe(300_000);
+    });
+    it('stays at 300s for counts beyond the cap (4, 10, 100)', () => {
+      expect(Duration.toMillis(adaptiveTtl(4))).toBe(300_000);
+      expect(Duration.toMillis(adaptiveTtl(10))).toBe(300_000);
+      expect(Duration.toMillis(adaptiveTtl(100))).toBe(300_000);
+    });
+    it('sequence matches the published table', () => {
+      const sequence = [0, 1, 2, 3].map(n => Duration.toMillis(adaptiveTtl(n)));
+      expect(sequence).toEqual([...ADAPTIVE_TTL_SEQUENCE_MS]);
+    });
+  });
+
+  describe('stable identity hashes (defeats SOQL reordering)', () => {
+    it('tfArrayHash is order-independent', () => {
+      const a = makeItem({ id: 'A' });
+      const b = makeItem({ id: 'B' });
+      const c = makeItem({ id: 'C' });
+      expect(tfArrayHash([a, b, c])).toBe(tfArrayHash([c, b, a]));
+      expect(tfArrayHash([a, b])).not.toBe(tfArrayHash([a, b, c]));
+    });
+    it('tfArrayHash changes when expiration changes', () => {
+      const t1 = makeItem({ expirationDate: new Date('2026-01-01T00:00:00.000Z') });
+      const t2 = makeItem({ expirationDate: new Date('2026-02-01T00:00:00.000Z') });
+      expect(tfArrayHash([t1])).not.toBe(tfArrayHash([t2]));
+    });
+    it('tfArrayHash changes when debugLevelId changes', () => {
+      const t1 = makeItem({ debugLevelId: 'dl-1' });
+      const t2 = makeItem({ debugLevelId: 'dl-2' });
+      expect(tfArrayHash([t1])).not.toBe(tfArrayHash([t2]));
+    });
+    it('tfArrayHash changes when isActive changes', () => {
+      const t1 = makeItem({ isActive: true });
+      const t2 = makeItem({ isActive: false });
+      expect(tfArrayHash([t1])).not.toBe(tfArrayHash([t2]));
+    });
+    it('tfOptionHash treats None and Some as different', () => {
+      expect(tfOptionHash(Option.none())).toBe('');
+      expect(tfOptionHash(Option.some(makeItem()))).not.toBe('');
+    });
+  });
+
+  describe('isSameTfArray / isSameTfOption', () => {
+    it('undefined prior → never same (so counter starts fresh at 0)', () => {
+      expect(isSameTfArray(undefined, [makeItem()])).toBe(false);
+      expect(isSameTfOption(undefined, Option.some(makeItem()))).toBe(false);
+    });
+    it('same content in different order → same', () => {
+      const a = makeItem({ id: 'A' });
+      const b = makeItem({ id: 'B' });
+      expect(isSameTfArray([a, b], [b, a])).toBe(true);
+    });
+    it('Option.none vs Option.none → same', () => {
+      expect(isSameTfOption(Option.none(), Option.none())).toBe(true);
+    });
+    it('Option.some(x) vs Option.some(x) → same', () => {
+      expect(isSameTfOption(Option.some(makeItem({ id: 'X' })), Option.some(makeItem({ id: 'X' })))).toBe(true);
+    });
+    it('Option.none vs Option.some → different', () => {
+      expect(isSameTfOption(Option.none(), Option.some(makeItem()))).toBe(false);
+      expect(isSameTfOption(Option.some(makeItem()), Option.none())).toBe(false);
+    });
+  });
+
+  describe('computeAdaptiveTtl — counter evolution', () => {
+    it('first call (no prior) → count 0, TTL 30s', () => {
+      const fresh = [makeItem()];
+      const { newCount, ttl } = computeAdaptiveTtl(undefined, fresh, isSameTfArray);
+      expect(newCount).toBe(0);
+      expect(Duration.toMillis(ttl)).toBe(30_000);
+    });
+
+    it('escalates 30 → 60 → 120 → 300 on consecutive identical results', () => {
+      const fresh = [makeItem({ id: 'tf-X' })];
+      let prior: { lastResult: TraceFlagItem[]; consecutiveNoChange: number } | undefined;
+
+      const results: number[] = [];
+      for (let i = 0; i < 5; i++) {
+        const { newCount, ttl } = computeAdaptiveTtl(prior, fresh, isSameTfArray);
+        results.push(Duration.toMillis(ttl));
+        prior = { lastResult: fresh, consecutiveNoChange: newCount };
+      }
+      // First call has no prior so counter = 0 (TTL 30s); subsequent 4 calls increment.
+      expect(results).toEqual([30_000, 60_000, 120_000, 300_000, 300_000]);
+    });
+
+    it('different result resets counter back to 0 (TTL drops to 30s)', () => {
+      const first = [makeItem({ id: 'A' })];
+      const second = [makeItem({ id: 'B' })]; // semantically different
+
+      // Prime to count=2 with `first`
+      const prior = { lastResult: first, consecutiveNoChange: 2 };
+
+      // Same content → counter would go to 3 → TTL=300s
+      const sameNext = computeAdaptiveTtl(prior, first, isSameTfArray);
+      expect(sameNext.newCount).toBe(3);
+      expect(Duration.toMillis(sameNext.ttl)).toBe(300_000);
+
+      // Change result → counter resets to 0 → TTL=30s
+      const change = computeAdaptiveTtl(prior, second, isSameTfArray);
+      expect(change.newCount).toBe(0);
+      expect(Duration.toMillis(change.ttl)).toBe(30_000);
+    });
+
+    it('benign SOQL reorder still counts as same (order-independent compare)', () => {
+      const a = makeItem({ id: 'A' });
+      const b = makeItem({ id: 'B' });
+      const c = makeItem({ id: 'C' });
+      const original = [a, b, c];
+      const reordered = [c, a, b]; // same data, different order — what SF can do without ORDER BY
+
+      const prior = { lastResult: original, consecutiveNoChange: 2 };
+      const { newCount, ttl } = computeAdaptiveTtl(prior, reordered, isSameTfArray);
+      expect(newCount).toBe(3); // counter advances, NOT reset
+      expect(Duration.toMillis(ttl)).toBe(300_000);
+    });
+
+    it('works for Option<TraceFlagItem> shape too', () => {
+      const item = makeItem({ id: 'OPT' });
+      const prior = { lastResult: Option.some(item), consecutiveNoChange: 1 };
+      const result = computeAdaptiveTtl(prior, Option.some(makeItem({ id: 'OPT' })), isSameTfOption);
+      expect(result.newCount).toBe(2);
+      expect(Duration.toMillis(result.ttl)).toBe(120_000);
+    });
+  });
+});

--- a/packages/salesforcedx-vscode-services/test/jest/core/traceFlagService.cache.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/traceFlagService.cache.test.ts
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import type { Connection } from '@salesforce/core';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+import { ConnectionService } from '../../../src/core/connectionService';
+import { TraceFlagService } from '../../../src/core/traceFlagService';
+
+const emptyToolingResult = { totalSize: 0, records: [] as never[], done: true };
+
+type MutationMocks = {
+  create?: jest.Mock;
+  update?: jest.Mock;
+  delete?: jest.Mock;
+};
+
+const makeMockConnection = (queryMock: jest.Mock, mut: MutationMocks = {}): Connection =>
+  ({
+    tooling: {
+      query: queryMock,
+      create: mut.create ?? jest.fn().mockResolvedValue({ success: true, id: 'newFlagId' }),
+      update: mut.update ?? jest.fn().mockResolvedValue({ success: true, id: 'updatedFlagId' }),
+      delete: mut.delete ?? jest.fn().mockResolvedValue({ success: true, id: 'deletedFlagId' })
+    }
+  }) as unknown as Connection;
+
+const createMockConnectionLayer = (queryMock: jest.Mock, mut: MutationMocks = {}): Layer.Layer<ConnectionService> =>
+  Layer.succeed(
+    ConnectionService,
+    ConnectionService.make({
+      getConnection: () => Effect.succeed(makeMockConnection(queryMock, mut)),
+      invalidateCachedConnections: () => Effect.void
+    })
+  );
+
+/**
+ * Use .DefaultWithoutDependencies so the mock ConnectionService overrides the baked-in dependency.
+ * .Default = Layer.provide(DefaultWithoutDependencies, deps) — passing .Default would re-apply the real
+ * ConnectionService and ignore our mock.
+ */
+/**
+ * `Layer.fresh` defeats Effect's default cross-runtime layer memoization so each test gets a brand-new
+ * TraceFlagService instance with its own caches + adaptive state. Prevents test pollution.
+ */
+const createTestLayer = (queryMock: jest.Mock, mut: MutationMocks = {}) =>
+  Layer.fresh(Layer.provide(TraceFlagService.DefaultWithoutDependencies, createMockConnectionLayer(queryMock, mut)));
+
+describe('TraceFlagService \u2014 cache (TTL + dedupe + invalidation)', () => {
+  describe('cascade-killer (concurrent dedupe)', () => {
+    it('4 concurrent getTraceFlagForUser(sameUserId, sameLogType) \u2192 1 SOQL', async () => {
+      const queryMock = jest.fn().mockResolvedValue(emptyToolingResult);
+      const layer = createTestLayer(queryMock);
+
+      const program = Effect.all(
+        [
+          TraceFlagService.getTraceFlagForUser('005xxxA'),
+          TraceFlagService.getTraceFlagForUser('005xxxA'),
+          TraceFlagService.getTraceFlagForUser('005xxxA'),
+          TraceFlagService.getTraceFlagForUser('005xxxA')
+        ],
+        { concurrency: 'unbounded' }
+      );
+
+      await Effect.runPromise(program.pipe(Effect.provide(layer)));
+      expect(queryMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('4 concurrent getTraceFlags() \u2192 1 SOQL', async () => {
+      const queryMock = jest.fn().mockResolvedValue(emptyToolingResult);
+      const layer = createTestLayer(queryMock);
+
+      const program = Effect.all(
+        [
+          TraceFlagService.getTraceFlags(),
+          TraceFlagService.getTraceFlags(),
+          TraceFlagService.getTraceFlags(),
+          TraceFlagService.getTraceFlags()
+        ],
+        { concurrency: 'unbounded' }
+      );
+
+      await Effect.runPromise(program.pipe(Effect.provide(layer)));
+      expect(queryMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('cache hit within TTL (sequential dedupe)', () => {
+    it('2 sequential getTraceFlagForUser \u2192 1 SOQL', async () => {
+      const queryMock = jest.fn().mockResolvedValue(emptyToolingResult);
+      const layer = createTestLayer(queryMock);
+
+      const program = Effect.gen(function* () {
+        yield* TraceFlagService.getTraceFlagForUser('005xxxA');
+        yield* TraceFlagService.getTraceFlagForUser('005xxxA');
+      });
+
+      await Effect.runPromise(program.pipe(Effect.provide(layer)));
+      expect(queryMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('2 sequential getTraceFlags \u2192 1 SOQL', async () => {
+      const queryMock = jest.fn().mockResolvedValue(emptyToolingResult);
+      const layer = createTestLayer(queryMock);
+
+      const program = Effect.gen(function* () {
+        yield* TraceFlagService.getTraceFlags();
+        yield* TraceFlagService.getTraceFlags();
+      });
+
+      await Effect.runPromise(program.pipe(Effect.provide(layer)));
+      expect(queryMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('cache key isolation (sanity)', () => {
+    it('different userIds are isolated', async () => {
+      const queryMock = jest.fn().mockResolvedValue(emptyToolingResult);
+      const layer = createTestLayer(queryMock);
+
+      const program = Effect.gen(function* () {
+        yield* TraceFlagService.getTraceFlagForUser('005xxxA');
+        yield* TraceFlagService.getTraceFlagForUser('005xxxB');
+      });
+
+      await Effect.runPromise(program.pipe(Effect.provide(layer)));
+      expect(queryMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('different logTypes are isolated', async () => {
+      const queryMock = jest.fn().mockResolvedValue(emptyToolingResult);
+      const layer = createTestLayer(queryMock);
+
+      const program = Effect.gen(function* () {
+        yield* TraceFlagService.getTraceFlagForUser('005xxxA', 'DEVELOPER_LOG');
+        yield* TraceFlagService.getTraceFlagForUser('005xxxA', 'USER_DEBUG');
+      });
+
+      await Effect.runPromise(program.pipe(Effect.provide(layer)));
+      expect(queryMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('errors are NOT cached (Exit.match skip-on-failure)', () => {
+    it('first call fails \u2192 second call retries (queries again)', async () => {
+      const queryMock = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('transient network failure'))
+        .mockResolvedValueOnce(emptyToolingResult);
+      const layer = createTestLayer(queryMock);
+
+      /*
+       * runPromiseExit + independent Effect.provide per call avoids a cross-file isolation issue where
+       * Effect.catchAll's effect on a single-gen continuation appears affected by other test files'
+       * module initialization. Each call is independent, so we directly inspect each Exit.
+       */
+      const firstExit = await Effect.runPromiseExit(
+        TraceFlagService.getTraceFlagForUser('005xxxA').pipe(Effect.provide(layer))
+      );
+      expect(firstExit._tag).toBe('Failure');
+
+      const secondExit = await Effect.runPromiseExit(
+        TraceFlagService.getTraceFlagForUser('005xxxA').pipe(Effect.provide(layer))
+      );
+      expect(secondExit._tag).toBe('Success');
+      expect(queryMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  /*
+   * Every mutation must invalidate the cache AND reset adaptive TTL state so the next read
+   * fetches fresh and starts at base TTL again.
+   *
+   * Pattern per test:
+   *   1) prime cache via getTraceFlags() (cache miss, queryMock=1)
+   *   2) confirm cache hit via another getTraceFlags()  (still queryMock=1)
+   *   3) invoke mutation, which internally calls invalidateTraceFlagCaches + getTraceFlags for PubSub
+   *      (queryMock=2 — the internal getTraceFlags after invalidation)
+   *
+   * If invalidation were broken, the post-mutation internal getTraceFlags would hit cache and queryMock would stay at 1.
+   * Therefore an assertion of "queryMock called > 1 times after mutation" directly proves invalidation works.
+   */
+  describe('mutations invalidate cache (reset on user action)', () => {
+    it('createTraceFlag invalidates cache', async () => {
+      const queryMock = jest.fn().mockResolvedValue(emptyToolingResult);
+      const layer = createTestLayer(queryMock);
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          yield* TraceFlagService.getTraceFlags();
+          yield* TraceFlagService.getTraceFlags();
+          expect(queryMock).toHaveBeenCalledTimes(1);
+          yield* TraceFlagService.createTraceFlag('005xxxA', 'dbgLvl-1');
+        }).pipe(Effect.provide(layer))
+      );
+      expect(queryMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('updateTraceFlag invalidates cache', async () => {
+      const queryMock = jest.fn().mockResolvedValue(emptyToolingResult);
+      const layer = createTestLayer(queryMock);
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          yield* TraceFlagService.getTraceFlags();
+          yield* TraceFlagService.getTraceFlags();
+          expect(queryMock).toHaveBeenCalledTimes(1);
+          yield* TraceFlagService.updateTraceFlag('flag-1', { debugLevelId: 'dbgLvl-2' });
+        }).pipe(Effect.provide(layer))
+      );
+      expect(queryMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('deleteTraceFlag invalidates cache', async () => {
+      const queryMock = jest.fn().mockResolvedValue(emptyToolingResult);
+      const layer = createTestLayer(queryMock);
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          yield* TraceFlagService.getTraceFlags();
+          yield* TraceFlagService.getTraceFlags();
+          expect(queryMock).toHaveBeenCalledTimes(1);
+          yield* TraceFlagService.deleteTraceFlag('flag-1');
+        }).pipe(Effect.provide(layer))
+      );
+      expect(queryMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('changeTraceFlagDebugLevel invalidates cache', async () => {
+      const queryMock = jest.fn().mockResolvedValue(emptyToolingResult);
+      const layer = createTestLayer(queryMock);
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          yield* TraceFlagService.getTraceFlags();
+          yield* TraceFlagService.getTraceFlags();
+          expect(queryMock).toHaveBeenCalledTimes(1);
+          yield* TraceFlagService.changeTraceFlagDebugLevel('flag-1', 'dbgLvl-3');
+        }).pipe(Effect.provide(layer))
+      );
+      expect(queryMock).toHaveBeenCalledTimes(2);
+    });
+  });
+});


### PR DESCRIPTION
Investigation summary for W-22390896:

The runtime cascade described in the security report (~40 Tooling API queries per burst from apex-log, apex-replay-debugger, apex-testing subscribing to traceFlagsChanged + the 5-min traceFlagCleanupScheduler) originates entirely in the forcedotcom/salesforcedx-vscode repo, specifically:
- packages/salesforcedx-vscode-services/src/core/traceFlagService.ts (the actual SOQL caller)
- packages/salesforcedx-vscode-apex-log/src/traceFlagCleanupScheduler.ts (the 5-min scheduler)
- The 3 subscriber extensions: apex-log, apex-replay-debugger, apex-testing
