### PR TITLE
chore: bump @salesforce/templates to 66.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7703,9 +7703,9 @@
       }
     },
     "node_modules/@salesforce/templates": {
-      "version": "66.9.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-66.9.0.tgz",
-      "integrity": "sha512-5eNZvN6GjELQ5KGx3AISH4MmTfit96sTdQYfqLpW0ZgAceS8os5TmHYp7BaZtvPeSsMw9AZMimtYhm0VBjSQtg==",
+      "version": "66.9.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-66.9.1.tgz",
+      "integrity": "sha512-3Z0cSqhSjH8NqmHjlJJXcaGIuzzVSi49TRo7JG9X9wsUS2exuTaEf8KN6N4dU11nUA03DlwxPM9d3bkUC8RzHQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/kit": "^3.2.6",
@@ -48809,7 +48809,7 @@
         "@salesforce/salesforcedx-utils": "*",
         "@salesforce/salesforcedx-utils-vscode": "*",
         "@salesforce/source-deploy-retrieve": "^12.32.5",
-        "@salesforce/templates": "^66.9.0",
+        "@salesforce/templates": "^66.9.1",
         "@salesforce/ts-types": "^2.0.12",
         "@salesforce/vscode-i18n": "*",
         "@salesforce/vscode-service-provider": "^1.5.0",
@@ -48991,7 +48991,7 @@
         "@salesforce/o11y-reporter": "^1.8.1",
         "@salesforce/source-deploy-retrieve": "^12.32.5",
         "@salesforce/source-tracking": "^7.8.16",
-        "@salesforce/templates": "^66.9.0",
+        "@salesforce/templates": "^66.9.1",
         "@salesforce/vscode-i18n": "*",
         "@vscode/extension-telemetry": "^1.0.0",
         "effect": "^3.21.2",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -34,7 +34,7 @@
     "@salesforce/salesforcedx-utils": "*",
     "@salesforce/salesforcedx-utils-vscode": "*",
     "@salesforce/source-deploy-retrieve": "^12.32.5",
-    "@salesforce/templates": "^66.9.0",
+    "@salesforce/templates": "^66.9.1",
     "@salesforce/ts-types": "^2.0.12",
     "@salesforce/vscode-i18n": "*",
     "@salesforce/vscode-service-provider": "^1.5.0",

--- a/packages/salesforcedx-vscode-services/package.json
+++ b/packages/salesforcedx-vscode-services/package.json
@@ -44,7 +44,7 @@
     "@salesforce/o11y-reporter": "^1.8.1",
     "@salesforce/source-deploy-retrieve": "^12.32.5",
     "@salesforce/source-tracking": "^7.8.16",
-    "@salesforce/templates": "^66.9.0",
+    "@salesforce/templates": "^66.9.1",
     "@salesforce/vscode-i18n": "*",
     "@vscode/extension-telemetry": "^1.0.0",
     "effect": "^3.21.2",


### PR DESCRIPTION
## Summary
- Bump `@salesforce/templates` from `^66.9.0` to `^66.9.1` in `salesforcedx-vscode-core` and `salesforcedx-vscode-services`.

### What issues does this PR fix or reference?
N/A

[skip-validate-pr]

🤖 Generated with [Claude Code](https://claude.com/claude-code)