### PR TITLE
test(automation-tests): trim runApexTests cases covered by Playwright - W-22795922

### DIFF
--- a/contributing/e2e-instructions.md
+++ b/contributing/e2e-instructions.md
@@ -1,4 +1,6 @@
-# Running E2E Tests
+# Running E2E Tests (Legacy RedHat/WDIO Framework)
+
+**Note:** This guide covers the legacy RedHat vscode-extension-tester framework. We're migrating to Playwright. For new e2e tests, see [.claude/skills/playwright-e2e/SKILL.md](../.claude/skills/playwright-e2e/SKILL.md).
 
 ## Prerequisites
 

--- a/contributing/tests.md
+++ b/contributing/tests.md
@@ -9,11 +9,14 @@ The test types from most preferred to least preferred are:
 
 1. Unit Tests - jest: Found under the test/jest directory.
    - `npm run test`
-1. End to End Tests - RedHat vscode-extension-tester: Found under the packages/salesforcedx-vscode-automation-tests directory.
+1. End to End Tests - Playwright: Found in each extension's test/playwright directory.
+   - Run spec-by-spec via IDE or via `npm run playwright` in the extension package
+1. Legacy End to End Tests - RedHat vscode-extension-tester: Found under the packages/salesforcedx-vscode-automation-tests directory (being phased out in favor of Playwright).
    - `npm run automation-test`
 
 To run all unit tests, execute `npm run compile && npm run test` from the root folder.
-Instructions for how to run E2E tests locally and on GHA are located in [e2e-instructions.md](./e2e-instructions.md).
+Instructions for running Playwright E2E tests locally are in [.claude/skills/playwright-e2e/SKILL.md](../.claude/skills/playwright-e2e/SKILL.md).
+Legacy RedHat/WDIO setup and instructions are in [e2e-instructions.md](./e2e-instructions.md).
 
 ### Unit Tests
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ If you're contributing to this repo, be sure to read the docs in `contributing`
 
 ### Core Topics
 
-- [Testing](./Testing.md) - unit tests, e2e testing (RedHat/Playwright), coverage
+- [Testing](./Testing.md) - unit tests, e2e testing (Playwright/legacy RedHat), coverage
 - [Build](./Build.md) - bundling, packaging, publishing
 - [Telemetry](./Telemetry.md) - usage metrics and logging
 

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -37,27 +37,9 @@ Use ex: `npm run test -w packages/salesforcedx-vscode-soql -- --coverage` to see
 
 e2e is even more crucial in the extensions because much of the extensions API is "run-time only." You **could** write unit tests to check vscode notifications, but you're mocking all of that and there's no way to assert that you're doing it correctly. It's more useful to have an e2e environment running **real** vscode and asserting it does what you expect.
 
-Both our e2e testing frameworks run both locally and in Github Actions
+Both run locally and in Github Actions. We're migrating toward Playwright and phasing out the RedHat framework.
 
-### old: redhat framework
-
-<https://github.com/forcedotcom/salesforcedx-vscode-test-tools> is our repo to make using <https://github.com/redhat-developer/vscode-extension-tester> simpler.
-
-See [contributing/e2e-instructions.md](../contributing/e2e-instructions.md) for instructions for the framework.
-
-pros
-
-- pre-defined selenium PageObject definitions for most of the vscode UI so you don't have to figure out or maintain selectors
-- versioned selectors for multiple vscode versions
-- you can import our library from anywhere else
-
-cons
-
-- it's slow and single-test-at-a-time
-- it's been super flaky
-- desktop only (so you might need to do playwright stuff to cover your web extension)
-
-### new: playwright
+### playwright (new, preferred)
 
 See [.claude/skills/playwright-e2e/SKILL.md](../.claude/skills/playwright-e2e/SKILL.md) for guidelines on writing, running, and debugging Playwright tests.
 
@@ -74,7 +56,15 @@ cons
 - you might spend some time screwing around getting the selectors right (recommendation: have your LLM log html snapshots so it can iterate based on the contents)
 - our test using this are much newer, and the code exists only within the extensions, so you'll be copy-pasting a bit if you want to reuse that. On the roadmap to make that more shared
 
-I'd probably start with playwright if I were doing a new extension.
+Use Playwright for any new e2e tests.
+
+### redhat/WDIO framework (legacy, being phased out)
+
+<https://github.com/forcedotcom/salesforcedx-vscode-test-tools> wraps <https://github.com/redhat-developer/vscode-extension-tester>.
+
+See [contributing/e2e-instructions.md](../contributing/e2e-instructions.md) for setup.
+
+**Cons:** slow, single-test-at-a-time, flaky, desktop-only. We're porting these tests to Playwright and this framework is deprecated. Don't add new WDIO tests.
 
 ### VSCode DOM
 

--- a/packages/salesforcedx-vscode-apex-testing/test/playwright/helpers/testExplorerHelpers.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/playwright/helpers/testExplorerHelpers.ts
@@ -97,6 +97,26 @@ export const runAllTestsAndWaitForCompletion = async (page: Page, timeout: numbe
   await expect(page.getByText(/Pass Rate/i)).toBeVisible({ timeout });
 };
 
+/**
+ * Test Explorer tree row by display name. The Test Explorer renders rows as ARIA treeitems
+ * whose accessible name embeds the display label, so getByRole('treeitem', { name: ... })
+ * matches a class or method node by substring.
+ */
+export const findTestExplorerItem = (page: Page, name: string): Locator => page.getByRole('treeitem', { name }).first();
+
+/**
+ * Hovers a Test Explorer tree row to reveal inline actions, then clicks the named action
+ * (e.g. `Run Test`, `Debug Test`). VS Code renders inline actions with the action label as
+ * `aria-label`; the underlying ARIA role differs between desktop and web (`link` vs `button`),
+ * so we match on aria-label rather than role.
+ */
+export const clickTreeItemAction = async (treeItem: Locator, actionLabel: string): Promise<void> => {
+  await treeItem.hover();
+  const action = treeItem.locator(`[aria-label="${actionLabel}"]`).first();
+  await action.waitFor({ state: 'visible', timeout: 10_000 });
+  await action.click();
+};
+
 export const focusAndTypeInFilter = async (page: Page, text: string): Promise<void> => {
   // Desktop uses a Monaco editor (data-uri="testing:filter") backed by a hidden
   // <textarea>; web uses a plain input. The Monaco view-lines layer intercepts

--- a/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/testExplorer.headless.spec.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/testExplorer.headless.spec.ts
@@ -15,7 +15,8 @@ import {
   setupConsoleMonitoring,
   setupMinimalOrgAndAuth,
   setupNetworkMonitoring,
-  validateNoCriticalErrors
+  validateNoCriticalErrors,
+  waitForRunApexTestsProgressNotificationGone
 } from '@salesforce/playwright-vscode-ext';
 
 import { test } from '../fixtures';
@@ -95,6 +96,24 @@ test('Apex Tests via Test Explorer: run all, verify discovery', async ({ page })
       .first();
     await expect(testClassItem).toBeVisible({ timeout: 30_000 });
     await saveScreenshot(page, 'step.test-class-found.png');
+  });
+
+  await test.step('run all tests on a class via Test Explorer tree-item action', async () => {
+    // Hover the test class row to reveal inline action buttons, then click "Run Test".
+    const classRow = page.locator(`.monaco-list-row[role="treeitem"][aria-label*="${testClassName}"]`).first();
+    await classRow.waitFor({ state: 'visible', timeout: 30_000 });
+    await classRow.hover();
+    const runTestAction = classRow.locator('a[aria-label="Run Test"]').first();
+    await runTestAction.waitFor({ state: 'visible', timeout: 10_000 });
+    await runTestAction.click();
+    await saveScreenshot(page, 'step.class-run-action-clicked.png');
+
+    await waitForRunApexTestsProgressNotificationGone(page, { timeout: TEST_RUN_TIMEOUT });
+
+    // Test Results panel re-renders Pass Rate after the new run completes.
+    await expect(page.getByText(/Pass Rate/i)).toBeVisible({ timeout: TEST_RUN_TIMEOUT });
+    await expect(page.getByText(testClassName).first()).toBeVisible({ timeout: TEST_RUN_TIMEOUT });
+    await saveScreenshot(page, 'step.class-run-done.png');
   });
 
   await validateNoCriticalErrors(test, consoleErrors, networkErrors);

--- a/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/testExplorer.headless.spec.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/testExplorer.headless.spec.ts
@@ -114,5 +114,22 @@ test('Apex Tests via Test Explorer: run all, verify discovery', async ({ page })
     await saveScreenshot(page, 'step.class-run-done.png');
   });
 
+  await test.step('run a single test method via Test Explorer tree-item action', async () => {
+    // Expand the class row to reveal its test methods.
+    const classRow = findTestExplorerItem(page, testClassName);
+    await classRow.locator('.monaco-tl-twistie').click({ force: true });
+    const methodRow = findTestExplorerItem(page, 'shouldDiscoverThisTest');
+    await methodRow.waitFor({ state: 'visible', timeout: 15_000 });
+    await clickTreeItemAction(methodRow, 'Run Test');
+    await saveScreenshot(page, 'step.method-run-action-clicked.png');
+
+    await waitForRunApexTestsProgressNotificationGone(page, { timeout: TEST_RUN_TIMEOUT });
+    await expect(page.getByText(/Pass Rate/i)).toBeVisible({ timeout: TEST_RUN_TIMEOUT });
+    await expect(page.getByText(`${testClassName}.shouldDiscoverThisTest`).first()).toBeVisible({
+      timeout: TEST_RUN_TIMEOUT
+    });
+    await saveScreenshot(page, 'step.method-run-done.png');
+  });
+
   await validateNoCriticalErrors(test, consoleErrors, networkErrors);
 });

--- a/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/testExplorer.headless.spec.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/testExplorer.headless.spec.ts
@@ -27,6 +27,8 @@ import {
   TEST_EXPLORER_PANEL,
   TEST_EXPLORER_TREE_ITEM,
   TEST_RESULTS_TAB,
+  clickTreeItemAction,
+  findTestExplorerItem,
   openTestExplorerAndDiscover
 } from '../helpers/testExplorerHelpers';
 
@@ -99,13 +101,9 @@ test('Apex Tests via Test Explorer: run all, verify discovery', async ({ page })
   });
 
   await test.step('run all tests on a class via Test Explorer tree-item action', async () => {
-    // Hover the test class row to reveal inline action buttons, then click "Run Test".
-    const classRow = page.locator(`.monaco-list-row[role="treeitem"][aria-label*="${testClassName}"]`).first();
+    const classRow = findTestExplorerItem(page, testClassName);
     await classRow.waitFor({ state: 'visible', timeout: 30_000 });
-    await classRow.hover();
-    const runTestAction = classRow.locator('a[aria-label="Run Test"]').first();
-    await runTestAction.waitFor({ state: 'visible', timeout: 10_000 });
-    await runTestAction.click();
+    await clickTreeItemAction(classRow, 'Run Test');
     await saveScreenshot(page, 'step.class-run-action-clicked.png');
 
     await waitForRunApexTestsProgressNotificationGone(page, { timeout: TEST_RUN_TIMEOUT });

--- a/packages/salesforcedx-vscode-automation-tests/test/specs/runApexTests.e2e.ts
+++ b/packages/salesforcedx-vscode-automation-tests/test/specs/runApexTests.e2e.ts
@@ -21,10 +21,8 @@ import {
 } from '@salesforce/salesforcedx-vscode-test-tools/lib/src/salesforce-components';
 import { TestSetup } from '@salesforce/salesforcedx-vscode-test-tools/lib/src/testSetup';
 import {
-  acceptNotification,
   attemptToFindOutputPanelText,
   clearOutputView,
-  clickFilePathOkButton,
   dismissAllNotifications,
   executeQuickPick,
   getTextEditor,
@@ -36,20 +34,17 @@ import {
   zoom
 } from '@salesforce/salesforcedx-vscode-test-tools/lib/src/ui-interaction';
 import { expect } from 'chai';
-import { By, InputBox, QuickOpenBox } from 'vscode-extension-tester';
+import { InputBox, QuickOpenBox } from 'vscode-extension-tester';
 import { apexTestExtensionConfigs } from '../testData/constants';
-import {
-  expandTestExplorerNamespaceAndPackage,
-  findCheckboxElement,
-  findTestItemByName,
-  getTestResultsTabText,
-  verifyTestItems,
-  verifyTestItemsIconColor
-} from '../utils/testsHelper';
+import { expandTestExplorerNamespaceAndPackage, findTestItemByName, getTestResultsTabText } from '../utils/testsHelper';
 import { getFolderPath } from '../utils/buildFilePathHelper';
 import { logTestStart } from '../utils/loggingHelper';
 
-/** Progress notification from metadata deploy (`deploying_one_component` / `deploying_n_components`). */
+// Tests for Run Apex Tests. Cases already covered by Playwright specs in
+// packages/salesforcedx-vscode-apex-testing/test/playwright/specs have been removed:
+// command-palette runs, palette-driven Test Sidebar run-all, and Apex Test Suite create/add/run.
+// What remains are cases without Playwright coverage: code-lens runs, Test Sidebar tree-item
+// action-button runs (class & method), and the failing-test-then-fix scenario.
 
 describe('Run Apex Tests', () => {
   let prompt: InputBox | QuickOpenBox;
@@ -83,16 +78,9 @@ describe('Run Apex Tests', () => {
       'RunApexTests - Error creating Apex class 2 and test'
     );
 
-    // Create Apex class 3 and test
-    await retryOperation(
-      () => createApexClassWithTest('ExampleApexClass3', classesFolderPath),
-      2,
-      'RunApexTests - Error creating Apex class 3 and test'
-    );
-
     await dismissAllNotifications();
     await executeQuickPick('SFDX: Push Source to Default Org', Duration.seconds(1));
-    await waitForNotificationToGoAway(/Deploying 6 components/i, Duration.TEN_MINUTES);
+    await waitForNotificationToGoAway(/Deploying 4 components/i, Duration.TEN_MINUTES);
   });
 
   beforeEach(function () {
@@ -165,151 +153,6 @@ describe('Run Apex Tests', () => {
     ];
 
     await verifyOutputPanelText(outputPanelText, expectedTexts);
-  });
-
-  it('Run All Tests via Command Palette', async () => {
-    logTestStart(testSetup, 'Run All Tests via Command Palette');
-    // Clear the Output view.
-    await dismissAllNotifications();
-    await clearOutputView(Duration.seconds(2));
-
-    // Run SFDX: Run Apex tests.
-    prompt = await executeQuickPick('SFDX: Run Apex Tests', Duration.seconds(15));
-
-    // Select the "All Tests" option
-    await prompt.selectQuickPick('All Tests');
-    // Look for the success notification that appears which says, "SFDX: Run Apex Tests successfully ran".
-    await verifyNotificationWithRetry(/SFDX: Run Apex Tests successfully ran/, Duration.TEN_MINUTES);
-
-    await pause(Duration.seconds(10)); // Remove this once we have a way to wait for the tests to finish running
-
-    // Verify test results are listed on vscode's Output section
-    // Also verify that all tests pass
-    const outputPanelText = await attemptToFindOutputPanelText('Apex Testing', '=== Test Results', 10);
-    const expectedTexts = [
-      '=== Test Summary',
-      'Outcome              Passed',
-      'Tests Ran            3',
-      'Pass Rate            100%',
-      'TEST NAME',
-      'ExampleApexClass1Test.validateSayHello  Pass',
-      'ExampleApexClass2Test.validateSayHello  Pass',
-      'ExampleApexClass3Test.validateSayHello  Pass',
-      'Ended SFDX: Run Apex Tests'
-    ];
-
-    await verifyOutputPanelText(outputPanelText, expectedTexts);
-  });
-
-  it('Run Single Class via Command Palette', async () => {
-    logTestStart(testSetup, 'Run Single Class via Command Palette');
-    // Clear the Output view.
-    await dismissAllNotifications();
-    await clearOutputView(Duration.seconds(2));
-
-    // Run SFDX: Run Apex tests.
-    prompt = await executeQuickPick('SFDX: Run Apex Tests', Duration.seconds(15));
-
-    // Select the "ExampleApexClass1Test" file
-    await prompt.selectQuickPick('ExampleApexClass1Test');
-    // Look for the success notification that appears which says, "SFDX: Run Apex Tests successfully ran".
-    await verifyNotificationWithRetry(/SFDX: Run Apex Tests successfully ran/, Duration.TEN_MINUTES);
-
-    // Verify test results are listed on vscode's Output section
-    // Also verify that all tests pass
-    const outputPanelText = await attemptToFindOutputPanelText('Apex Testing', '=== Test Results', 10);
-    const expectedTexts = [
-      '=== Test Summary',
-      'Outcome              Passed',
-      'Tests Ran            1',
-      'Pass Rate            100%',
-      'TEST NAME',
-      'ExampleApexClass1Test.validateSayHello  Pass',
-      'Ended SFDX: Run Apex Tests'
-    ];
-    await verifyOutputPanelText(outputPanelText, expectedTexts);
-  });
-
-  it('Run All tests via Test Sidebar', async () => {
-    logTestStart(testSetup, 'Run All tests via Test Sidebar');
-
-    await retryOperation(
-      async () => {
-        await executeQuickPick('View: Hide Secondary Side Bar');
-      },
-      3,
-      'RunApexTests - Error closing chat'
-    );
-
-    // Open the Test Sidebar - now uses VS Code's native Test Explorer
-    await retryOperation(
-      async () => {
-        await executeQuickPick('Testing: Focus on Test Explorer View');
-      },
-      3,
-      'RunApexTests - Error focusing on test explorer view'
-    );
-
-    await retryOperation(
-      async () => executeQuickPick('Test: Refresh Tests', Duration.seconds(1)),
-      3,
-      'RunApexTests - Error refreshing test explorer'
-    );
-    await pause(Duration.seconds(20)); // Wait for the tests to load
-
-    // Expand namespace/package so test classes are visible (grouping: Namespace → Package → Class → Method)
-    await expandTestExplorerNamespaceAndPackage();
-
-    // Verify the expected test items appear
-    const expectedTestNames = ['ExampleApexClass1Test', 'ExampleApexClass2Test', 'ExampleApexClass3Test'];
-    const testItems = await verifyTestItems(expectedTestNames);
-
-    // Clear the Output view.
-    await dismissAllNotifications();
-    await clearOutputView(Duration.seconds(2));
-
-    // Click the run tests button on the top right corner of the Test sidebar
-    await retryOperation(
-      async () => await executeQuickPick('Test: Run All Tests', Duration.seconds(1)),
-      3,
-      'RunApexTests - Error running all tests'
-    );
-
-    // Look for the success notification that appears which says, "SFDX: Run Apex Tests successfully ran".
-    await verifyNotificationWithRetry(/SFDX: Run Apex Tests successfully ran/, Duration.TEN_MINUTES);
-
-    // Verify the test report notification appears with dynamic runId
-    const notificationFound = await verifyNotificationWithRetry(
-      /Apex test report is ready: test-result-[a-zA-Z0-9]+\.md/,
-      Duration.seconds(30)
-    );
-    expect(notificationFound).to.equal(true);
-
-    // Click "Open Report" button on the notification (use partial match for the notification text)
-    const accepted = await acceptNotification('Apex test report is ready:', 'Open Report', Duration.seconds(5));
-    expect(accepted).to.equal(true);
-    await pause(Duration.seconds(3));
-
-    // Verify the markdown preview tab opens (tab label contains "Preview test-result-*.md")
-    const previewTab = await getWorkbench().findElement(By.css('div.tab-label[aria-label*="Preview test-result-"]'));
-    const tabLabel = await previewTab.getAttribute('aria-label');
-    expect(tabLabel).to.match(/Preview test-result-[a-zA-Z0-9]+\.md/);
-
-    // Verify test results in the Test Results tab (xterm terminal)
-    const testResultsText = await getTestResultsTabText('Apex Testing');
-    const expectedTextsInTestResultsTab = [
-      '=== Test Summary',
-      'Outcome              Passed',
-      'Tests Ran            3',
-      'Pass Rate            100%',
-      'ExampleApexClass1Test.validateSayHello  Pass',
-      'ExampleApexClass2Test.validateSayHello  Pass',
-      'ExampleApexClass3Test.validateSayHello  Pass'
-    ];
-    await verifyOutputPanelText(testResultsText, expectedTextsInTestResultsTab);
-
-    // Verify the tests that are passing are showing the right icon in Test Explorer
-    await verifyTestItemsIconColor(testItems, 'testPass');
   });
 
   it('Run All Tests on a Class via the Test Sidebar', async () => {
@@ -454,83 +297,6 @@ describe('Run Apex Tests', () => {
       'Ended SFDX: Run Apex Tests'
     ];
     await verifyOutputPanelText(testResultsText, expectedTexts);
-  });
-
-  it('Create Apex Test Suite', async () => {
-    logTestStart(testSetup, 'Create Apex Test Suite');
-    // Run SFDX: Create Apex Test Suite.
-    prompt = await executeQuickPick('SFDX: Create Apex Test Suite', Duration.seconds(2));
-
-    // Set the name of the new Apex Test Suite
-    await prompt.setText('ApexTestSuite');
-    await prompt.confirm();
-    await pause(Duration.seconds(2));
-
-    // Choose tests that will belong to the new Apex Test Suite
-    await prompt.setText('ExampleApexClass1Test');
-    const checkbox = await findCheckboxElement(prompt);
-    await checkbox.click();
-    await clickFilePathOkButton();
-
-    // Look for the success notification that appears which says, "SFDX: Create Apex Test Suite successfully ran".
-    await verifyNotificationWithRetry(/SFDX: Create Apex Test Suite successfully ran/, Duration.TEN_MINUTES);
-  });
-
-  it('Add test to Apex Test Suite', async () => {
-    logTestStart(testSetup, 'Add test to Apex Test Suite');
-    // Run SFDX: Add Tests to Apex Test Suite.
-    prompt = await executeQuickPick('SFDX: Add Tests to Apex Test Suite', Duration.seconds(1));
-
-    // Select the suite recently created called ApexTestSuite
-    await prompt.selectQuickPick('ApexTestSuite');
-    await pause(Duration.seconds(2));
-
-    // Choose tests that will belong to the already created Apex Test Suite
-    await prompt.setText('ExampleApexClass2Test');
-
-    await retryOperation(
-      async () => {
-        const checkbox = await findCheckboxElement(prompt);
-        await checkbox.click();
-      },
-      2,
-      'RunApexTests - Error clicking checkbox'
-    );
-    await clickFilePathOkButton();
-
-    // Look for the success notification that appears which says, "SFDX: Add Tests to Apex Test Suite successfully ran".
-    await verifyNotificationWithRetry(/SFDX: Add Tests to Apex Test Suite successfully ran/, Duration.TEN_MINUTES);
-  });
-
-  it('Run Apex Test Suite', async () => {
-    logTestStart(testSetup, 'Run Apex Test Suite');
-    // Clear the Output view.
-    await dismissAllNotifications();
-    await clearOutputView(Duration.seconds(2));
-
-    // Run SFDX: Run Apex Test Suite.
-    await executeQuickPick('SFDX: Run Apex Test Suite', Duration.seconds(1));
-
-    // Select the suite recently created called ApexTestSuite
-    await prompt.selectQuickPick('ApexTestSuite');
-    // Look for the success notification that appears which says, "SFDX: Run Apex Tests successfully ran".
-    await verifyNotificationWithRetry(/SFDX: Run Apex Tests successfully ran/, Duration.TEN_MINUTES);
-
-    // Verify test results are listed on vscode's Output section
-    // Also verify that all tests pass
-    const outputPanelText = await attemptToFindOutputPanelText('Apex Testing', '=== Test Results', 10);
-    const expectedTexts = [
-      '=== Test Summary',
-      'TEST NAME',
-      'Outcome              Passed',
-      'Tests Ran            2',
-      'Pass Rate            100%',
-      'TEST NAME',
-      'ExampleApexClass1Test.validateSayHello  Pass',
-      'ExampleApexClass2Test.validateSayHello  Pass',
-      'Ended SFDX: Run Apex Tests'
-    ];
-    await verifyOutputPanelText(outputPanelText, expectedTexts);
   });
 
   after('Tear down and clean up the testing environment', async () => {

--- a/packages/salesforcedx-vscode-automation-tests/test/specs/runApexTests.e2e.ts
+++ b/packages/salesforcedx-vscode-automation-tests/test/specs/runApexTests.e2e.ts
@@ -42,9 +42,10 @@ import { logTestStart } from '../utils/loggingHelper';
 
 // Tests for Run Apex Tests. Cases already covered by Playwright specs in
 // packages/salesforcedx-vscode-apex-testing/test/playwright/specs have been removed:
-// command-palette runs, palette-driven Test Sidebar run-all, and Apex Test Suite create/add/run.
-// What remains are cases without Playwright coverage: code-lens runs, Test Sidebar tree-item
-// action-button runs (class & method), and the failing-test-then-fix scenario.
+// command-palette runs, palette-driven Test Sidebar run-all, the class-level Test Sidebar
+// tree-item action-button run, and Apex Test Suite create/add/run. What remains are cases
+// without Playwright coverage: code-lens runs, the method-level Test Sidebar tree-item
+// action-button run, and the failing-test-then-fix scenario.
 
 describe('Run Apex Tests', () => {
   let prompt: InputBox | QuickOpenBox;
@@ -153,45 +154,6 @@ describe('Run Apex Tests', () => {
     ];
 
     await verifyOutputPanelText(outputPanelText, expectedTexts);
-  });
-
-  it('Run All Tests on a Class via the Test Sidebar', async () => {
-    logTestStart(testSetup, 'Run All Tests on a Class via the Test Sidebar');
-
-    // Expand namespace/package so test classes are visible (grouping: Namespace → Package → Class → Method)
-    await expandTestExplorerNamespaceAndPackage();
-
-    // Find and click on the test method in the Test Explorer
-    const testClassItem = await findTestItemByName('ExampleApexClass2Test');
-    await pause(Duration.seconds(5));
-    await testClassItem.click();
-
-    // Click Run Test action on the test class
-    const runTestsAction = await testClassItem.getActionButton('Run Test');
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    expect(runTestsAction).to.not.be.undefined;
-    await runTestsAction!.click();
-
-    // Verify success notification
-    await verifyNotificationWithRetry(/SFDX: Run Apex Tests successfully ran/, Duration.TEN_MINUTES);
-
-    // Verify the test report notification appears
-    const notificationFound = await verifyNotificationWithRetry(
-      /Apex test report is ready: test-result-[a-zA-Z0-9]+\.md/,
-      Duration.seconds(30)
-    );
-    expect(notificationFound).to.equal(true);
-
-    // Verify test results in the Test Results tab
-    const testResultsText = await getTestResultsTabText('Apex Testing');
-    const expectedTextsInTestResultsTab = [
-      '=== Test Summary',
-      'Outcome              Passed',
-      'Tests Ran            1',
-      'Pass Rate            100%',
-      'ExampleApexClass2Test.validateSayHello  Pass'
-    ];
-    await verifyOutputPanelText(testResultsText, expectedTextsInTestResultsTab);
   });
 
   it('Run Single Test via the Test Sidebar', async () => {

--- a/packages/salesforcedx-vscode-automation-tests/test/specs/runApexTests.e2e.ts
+++ b/packages/salesforcedx-vscode-automation-tests/test/specs/runApexTests.e2e.ts
@@ -36,16 +36,15 @@ import {
 import { expect } from 'chai';
 import { InputBox, QuickOpenBox } from 'vscode-extension-tester';
 import { apexTestExtensionConfigs } from '../testData/constants';
-import { expandTestExplorerNamespaceAndPackage, findTestItemByName, getTestResultsTabText } from '../utils/testsHelper';
 import { getFolderPath } from '../utils/buildFilePathHelper';
 import { logTestStart } from '../utils/loggingHelper';
 
 // Tests for Run Apex Tests. Cases already covered by Playwright specs in
 // packages/salesforcedx-vscode-apex-testing/test/playwright/specs have been removed:
-// command-palette runs, palette-driven Test Sidebar run-all, the class-level Test Sidebar
-// tree-item action-button run, and Apex Test Suite create/add/run. What remains are cases
-// without Playwright coverage: code-lens runs, the method-level Test Sidebar tree-item
-// action-button run, and the failing-test-then-fix scenario.
+// command-palette runs, palette-driven Test Sidebar run-all, both Test Sidebar
+// tree-item action-button runs (class & method), and Apex Test Suite create/add/run.
+// What remains are cases without Playwright coverage: code-lens runs and the
+// failing-test-then-fix scenario.
 
 describe('Run Apex Tests', () => {
   let prompt: InputBox | QuickOpenBox;
@@ -154,46 +153,6 @@ describe('Run Apex Tests', () => {
     ];
 
     await verifyOutputPanelText(outputPanelText, expectedTexts);
-  });
-
-  it('Run Single Test via the Test Sidebar', async () => {
-    logTestStart(testSetup, 'Run Single Test via the Test Sidebar');
-
-    // Expand namespace/package so test classes and methods are visible (grouping: Namespace → Package → Class → Method)
-    await expandTestExplorerNamespaceAndPackage();
-
-    // Find and click on the test method in the Test Explorer
-    await pause(Duration.seconds(5)); // Wait for the tests to load
-    const testMethodItem = await findTestItemByName('validateSayHello');
-    await pause(Duration.seconds(5));
-    await testMethodItem.click();
-
-    // Click Run Test action on the test method
-    const runTestAction = await testMethodItem.getActionButton('Run Test');
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    expect(runTestAction).to.not.be.undefined;
-    await runTestAction!.click();
-
-    // Verify success notification
-    await verifyNotificationWithRetry(/SFDX: Run Apex Tests successfully ran/, Duration.TEN_MINUTES);
-
-    // Verify the test report notification appears
-    const notificationFound = await verifyNotificationWithRetry(
-      /Apex test report is ready: test-result-[a-zA-Z0-9]+\.md/,
-      Duration.seconds(30)
-    );
-    expect(notificationFound).to.equal(true);
-
-    // Verify test results in the Test Results tab
-    const testResultsText = await getTestResultsTabText('Apex Testing');
-    const expectedTextsInTestResultsTab = [
-      '=== Test Summary',
-      'Outcome              Passed',
-      'Tests Ran            1',
-      'Pass Rate            100%',
-      'ExampleApexClass2Test.validateSayHello  Pass'
-    ];
-    await verifyOutputPanelText(testResultsText, expectedTextsInTestResultsTab);
   });
 
   it('Run a test that fails and fix it', async () => {


### PR DESCRIPTION
## Summary

Trim duplicated WDIO test cases from [runApexTests.e2e.ts](packages/salesforcedx-vscode-automation-tests/test/specs/runApexTests.e2e.ts). Cases already covered in the Playwright headless specs at [packages/salesforcedx-vscode-apex-testing/test/playwright/specs](packages/salesforcedx-vscode-apex-testing/test/playwright/specs) have been removed; tree-item-action cases that the WDIO suite uniquely covered have been ported to Playwright in [testExplorer.headless.spec.ts](packages/salesforcedx-vscode-apex-testing/test/playwright/specs/testExplorer.headless.spec.ts) and removed from WDIO.

**Removed (covered by Playwright):**
- Run All Tests via Command Palette
- Run Single Class via Command Palette
- Run All Tests via Test Sidebar (palette command)
- Run All Tests on a Class via the Test Sidebar (tree-item action) — **ported in this PR**
- Run Single Test via the Test Sidebar (method tree-item action) — **ported in this PR**
- Create Apex Test Suite
- Add Tests to Apex Test Suite
- Run Apex Test Suite

**Kept (no Playwright coverage yet):**
- Run All Tests via Apex Class (code lens)
- Run Single Test via Apex Class (code lens)
- Run a test that fails and fix it

**Playwright additions:**
- New \`test.step\`s for class- and method-level tree-item action runs in [testExplorer.headless.spec.ts](packages/salesforcedx-vscode-apex-testing/test/playwright/specs/testExplorer.headless.spec.ts).
- New helpers \`findTestExplorerItem\` and \`clickTreeItemAction\` in [testExplorerHelpers.ts](packages/salesforcedx-vscode-apex-testing/test/playwright/helpers/testExplorerHelpers.ts).

**Other:**
- The setup hook now creates 2 test classes (down from 3) and waits for \`Deploying 4 components\` (down from 6).
- Testing docs reordered to put Playwright before the legacy WDIO framework.

## Test plan
- [x] \`test:web\` and \`test:desktop\` pass for [testExplorer.headless.spec.ts](packages/salesforcedx-vscode-apex-testing/test/playwright/specs/testExplorer.headless.spec.ts) locally with \`--retries 0\`
- [ ] WDIO automation suite passes for the 3 remaining cases in [runApexTests.e2e.ts](packages/salesforcedx-vscode-automation-tests/test/specs/runApexTests.e2e.ts)
- [ ] Playwright headless suite for \`salesforcedx-vscode-apex-testing\` still green in CI

### What issues does this PR fix or reference?
@W-22795922@

🤖 Generated with [Claude Code](https://claude.com/claude-code)