### PR TITLE
chore: enable unicorn/no-empty-file ESLint rule - W-22816964

### DIFF
--- a/.claude/plans/W-22816964.md
+++ b/.claude/plans/W-22816964.md
@@ -1,0 +1,46 @@
+# W-22816964 — enable unicorn/no-empty-file
+
+## Context
+
+- add `'unicorn/no-empty-file': 'error'` to `eslint.config.mjs` unicorn block
+- rule flags files w/ only whitespace/comments/empty blocks
+- ref docs: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-empty-file.md
+- pre-scan: no empty `.ts`/`.mjs`/`.js` under `packages/` or `scripts/` (comment-only check)
+
+## Scope discipline
+
+- ONLY: rule enable + delete/populate any flagged files
+- NO unrelated refactors
+- if a flagged file is referenced (imports, exports, configs): populate w/ minimal content or remove + fix refs
+- if license-header-only: rule still flags; delete or populate
+
+## Phases
+
+### Phase 1 — enable rule + fix violations
+
+- add `'unicorn/no-empty-file': 'error'` in unicorn block (alphabetical, near other `no-*`)
+- run `npm run lint`
+- for each flagged file:
+  - unreferenced: delete
+  - referenced: populate w/ real export or remove + update importers
+- commit: `chore: enable unicorn/no-empty-file`
+
+files:
+
+- `eslint.config.mjs`
+- any flagged files (expected: zero based on pre-scan)
+
+## Skills to apply
+
+- concise (plan)
+- typescript
+- pr-draft (title `chore: ... - W-22816964`, GUS ref body)
+- feature-branch
+- verification
+
+## Verification
+
+- `npm run lint` zero violations
+- `npm run compile` passes (covers TS type-check)
+- if files deleted: `git grep` confirms no dangling imports
+- e2e: no e2e specs required — lint-only ESLint config change with zero runtime impact (no source files modified unless flagged; flagged files are unreferenced deletions or populated stubs verified by `npm run compile` + `git grep`)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -165,6 +165,7 @@ export default [
       'unicorn/explicit-length-check': 'error',
       'unicorn/no-array-reverse': 'error',
       'unicorn/no-array-sort': 'error',
+      'unicorn/no-empty-file': 'error',
       'unicorn/no-immediate-mutation': 'error',
       'unicorn/no-instanceof-builtins': 'error',
       'unicorn/no-single-promise-in-promise-methods': 'error',


### PR DESCRIPTION
## Summary

- Enabled `unicorn/no-empty-file` ESLint rule in `eslint.config.mjs`
- No violations found — codebase already compliant

## Plan

`.claude/plans/W-22816964.md`

## Test plan

- `npm run lint` passes with zero violations
- `npm run compile` passes (TypeScript type-check)

### What issues does this PR fix or reference?

@W-22816964@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002bRpYoYAK/view