### PR TITLE
Re-add context menu LWC creation option

### DIFF
--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -366,7 +366,16 @@
       "editor/title/context": [],
       "view/title": [],
       "view/item/context": [],
-      "explorer/context": [],
+			"explorer/context": [
+				{
+				  "command": "sf.metadata.lightning.generate.lwc",
+				  "when": "explorerResourceIsFolder && resourceFilename == lwc && sf:project_opened"
+				},
+				{
+				  "command": "sf.internal.lightning.generate.lwc",
+				  "when": "explorerResourceIsFolder && sf:internal_dev"
+				}
+			],
       "commandPalette": [
         {
           "command": "sf.metadata.lightning.generate.lwc",


### PR DESCRIPTION
This minor change re-introduces the context menu option for creating an LWC.

<!--- PR title: <type>(optional scope): <description> - W-XXXXXXXX — append GUS work item at the end (space, hyphen, space, W-). Conventional commits: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Re-adds the ability to create blank LWCs from the explorer context menu.  This is a small QoL fix for developers who are in the process of migrating from Visualforce to LWC or have net new development which requires LWCs.

### What issues does this PR fix or reference?
No issue at present, this was a personal issue that would be nice to have back for the people that used it.

### Functionality Before
Unable to create LWC from explorer context menu in VS Code.

### Functionality After
Able to create LWC from explorer context menu in VS Code.
