### PR TITLE
chore: enable unicorn/no-useless-switch-case ESLint rule - W-22818792

### DIFF
--- a/.claude/plans/W-22818792.md
+++ b/.claude/plans/W-22818792.md
@@ -1,0 +1,38 @@
+# W-22818792 — Enable unicorn/no-useless-switch-case
+
+## Context
+
+- Add `unicorn/no-useless-switch-case: error` to unicorn rules block in `eslint.config.mjs` (~line 162-198, alphabetically near other `no-useless-*`)
+- Rule flags empty `case` labels falling through to `default` — dead code
+- Run lint, fix violations
+
+## Done when
+
+- `unicorn/no-useless-switch-case` enabled at `error` level in `eslint.config.mjs`
+- `npm run lint` passes clean from repo root (no violations from new rule)
+
+## Phases
+
+### Phase 1: Enable rule + fix violations
+
+- Edit `eslint.config.mjs`: insert `'unicorn/no-useless-switch-case': 'error'` alphabetically (between `no-useless-promise-resolve-reject` and `no-useless-spread`)
+- Run `npm run lint` from repo root
+- Remove flagged useless cases (empty `case X:` falling through to `default`)
+- Re-run lint until clean
+- Commit message: `chore: enable unicorn/no-useless-switch-case`
+
+Files:
+- `eslint.config.mjs`
+- any `.ts`/`.js` flagged by lint
+
+## Skills
+
+- typescript
+- verification
+
+## Verification
+
+- `npm run lint` clean (root)
+- `npm run compile` clean — type check unaffected
+- existing unit tests pass for any package whose switch was edited
+- e2e: covered on branch CI if any touched file is exercised by playwright suite

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -178,6 +178,7 @@ export default [
       'unicorn/no-useless-length-check': 'error',
       'unicorn/no-useless-promise-resolve-reject': 'error',
       'unicorn/no-useless-spread': 'error',
+      'unicorn/no-useless-switch-case': 'error',
       'unicorn/numeric-separators-style': 'error',
       'unicorn/prefer-at': 'error',
       'unicorn/prefer-array-find': 'error',

--- a/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
+++ b/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
@@ -1367,9 +1367,6 @@ export class ApexDebug extends LoggingDebugSession {
         this.handleSystemWarning(message);
         break;
       }
-      case 'LogLine':
-      case 'OrgChange':
-      case 'Ready':
       default: {
         break;
       }

--- a/packages/salesforcedx-vscode-apex/src/languageUtils/languageClientManager.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageUtils/languageClientManager.ts
@@ -200,7 +200,6 @@ export class LanguageClientManager {
             restartBehavior
           );
           return this.RESTART_OPTIONS.cleanAndRestart;
-        case 'prompt':
         default:
           const promptItems: RestartQuickPickItem[] = [
             { label: this.RESTART_OPTIONS.restartOnly, description: '', type: 'restart' },


### PR DESCRIPTION
## Summary

- Enabled `unicorn/no-useless-switch-case` ESLint rule at error level
- Removed useless empty case labels falling through to default in multiple files
- Lint and compile passing clean

## Plan

See [.claude/plans/W-22818792.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-22818792-enable-unicorn-no-useless-switch-case-es/.claude/plans/W-22818792.md)

## Reviewer notes

- **Medium:** packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts:32 — paths skill: replace `import { basename } from 'node:path'` with `vscode-uri` Utils.basename. Out of scope for this lint-rule PR (pre-existing import).
- **Medium:** packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts:1329 — typescript skill: switch on ApexDebuggerEventType is non-exhaustive after removing fall-through cases. Add `const _exhaustive: never = message.sobject.Type;` in default, or document why HeartBeat/LogLine/OrgChange/Ready are intentionally ignored.
- **Low:** packages/salesforcedx-vscode-apex/src/languageUtils/languageClientManager.ts:222,246,273 — vscode-window-messages: three fire-and-forget showInformationMessage/showWarningMessage/showErrorMessage calls missing `void` keyword. Pre-existing code, not touched by this PR.

## Test plan

- [x] `npm run lint` passes clean from repo root
- [x] `npm run compile` passes clean — type checking unaffected
- [ ] existing unit tests pass for affected packages (verified by CI)

### What issues does this PR fix or reference?

@W-22818792@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002bRsJXYA0/view