### PR TITLE
chore: enable unicorn/prefer-array-some eslint rule - W-22818795

### DIFF
--- a/.claude/plans/W-22818795.md
+++ b/.claude/plans/W-22818795.md
@@ -1,0 +1,68 @@
+# W-22818795 — enable unicorn/prefer-array-some
+
+## Context
+
+- add `unicorn/prefer-array-some: error` in `eslint.config.mjs` unicorn block
+- alphabetical placement: between `prefer-array-find` and `prefer-class-fields` (~line 184)
+- replaces `.find()` / `.filter().length` boolean checks with `.some()`
+- ref: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-some.md
+
+## Scope discipline
+
+- ONLY: rule enable + mechanical autofixes
+- patterns (rule autofixes most):
+  - `arr.find(fn)` used as boolean → `arr.some(fn)`
+  - `arr.filter(fn).length > 0` / `!== 0` / `>= 1` → `arr.some(fn)`
+  - `arr.filter(fn).length === 0` → `!arr.some(fn)`
+- intentional cases: `// eslint-disable-next-line` + reason
+- no unrelated refactors
+
+## Phases
+
+### Phase 1 — enable rule + apply fixes
+
+- add `'unicorn/prefer-array-some': 'error'` (alphabetical, near `prefer-array-find`)
+- `npm run lint -- --fix` to apply autofixes
+- manually resolve any non-autofixable violations
+- `npm run compile` to verify types
+- commit: `chore: enable unicorn/prefer-array-some`
+
+files:
+
+- `eslint.config.mjs`
+- any `.ts` / `.tsx` / `.mjs` flagged across `packages/` and `scripts/`
+
+## Skills to apply
+
+- concise (plan)
+- typescript (style/naming)
+- pr-draft (title `chore: ... - W-22818795`, GUS ref)
+- feature-branch (on feature branch)
+- verification
+
+## Verification
+
+- `npm run compile` passes
+- `npm run lint` zero violations
+- semantics: `.some()` short-circuits; equivalent to `.find()` boolean / `.filter().length` checks
+- spot-check rewrites: no lost predicate logic; negation correct for `=== 0` cases
+
+### Affected-package detection (run before listing specs)
+
+- dry-run: `npm run lint -- --rule '{"unicorn/prefer-array-some":"error"}'` to enumerate violating files
+- bucket violations by package; for each affected package run the package's own jest unit tests: `npm run test --workspace=<pkg>`
+
+### Playwright specs to run locally (representative, by likely-affected package)
+
+Run these against a local ext host before pushing — branch e2e on PR is a backstop, not a substitute. Pick the specs whose package shows violations in the dry-run; the list below is the starting set based on grep of `.find(` / `.filter(...).length` in src:
+
+- `packages/salesforcedx-vscode-core/test/playwright/specs/configList.headless.spec.ts` — exercises `src/index.ts` activation path
+- `packages/salesforcedx-vscode-services/test/playwright/specs/retrieveOnLoadMetadata.headless.spec.ts` — exercises `virtualFsProvider/indexedDbStorage.ts` and `vscode/prompts/promptService.ts`
+- `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebugger.desktop.spec.ts` — exercises `adapter/apexReplayDebug.ts` and `commands/quickLaunch.ts`
+- `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/checkpoints.desktop.spec.ts` — exercises `breakpoints/checkpointService.ts`
+- `packages/salesforcedx-vscode-apex-testing/test/playwright/specs/runApexTestsCommandPalette.headless.spec.ts` — exercises `utils/testResultProcessor.ts`, `utils/testUtils.ts`, `utils/payloadBuilder.ts`
+- `packages/salesforcedx-vscode-apex-testing/test/playwright/specs/testExplorer.headless.spec.ts` — exercises `views/orgTestItems.ts` and `codecoverage/colorizer.ts`
+- `packages/salesforcedx-vscode-apex-log/test/playwright/specs/traceFlagsCrud.headless.spec.ts` — exercises `traceFlags/traceFlagJsonSync.ts`
+
+If the dry-run reveals violations in additional packages (e.g. `salesforcedx-vscode-apex` soqlCompletion, `salesforcedx-vscode-apex-oas` formatUtils/apexRest), append the matching package's smoke spec from `test/playwright/specs/` to the run list.
+

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -181,6 +181,7 @@ export default [
       'unicorn/numeric-separators-style': 'error',
       'unicorn/prefer-at': 'error',
       'unicorn/prefer-array-find': 'error',
+      'unicorn/prefer-array-some': 'error',
       'unicorn/prefer-class-fields': 'error',
       'unicorn/prefer-date-now': 'error',
       'unicorn/prefer-export-from': 'error',


### PR DESCRIPTION
## Summary
- Enable `unicorn/prefer-array-some` eslint rule in config
- Zero source violations found; rule is already-compliant across all packages
- No code changes required beyond rule activation in eslint.config.mjs

## Plan
[.claude/plans/W-22818795.md](/.claude/plans/W-22818795.md)

## Reviewer notes
- **High:** Verification skill flagged needing to run `npm run lint --fix`, but full repo lint with rule enabled passes with zero violations across all 77 wireit lint targets — no autofixes to apply. The rule is effectively already-compliant in the codebase, so no source changes are needed.
- **Medium:** Playwright e2e specs listed in plan (configList, retrieveOnLoadMetadata, apexReplayDebugger, checkpoints, runApexTestsCommandPalette, testExplorer, traceFlagsCrud) were not run locally. Skipping is justified since this PR contains zero source-file changes (only an eslint rule activation with no violations to fix), so behavior is unchanged.
- **Low:** Plan doc .claude/plans/W-22818795.md:5 has minor off-by-one in line reference; cosmetic only.
- **Low:** eslint.config.mjs unicorn block isn't strictly alphabetical (prefer-at at line 182 sorts after prefer-array-*). Pre-existing inconsistency, not introduced by this PR.
- **Low:** Discarded unrelated package-lock.json drift (\`@salesforce/apex-node\` caret-prefix changes) that wasn't part of this PR's intent.

## Test plan
- [x] `npm run compile` passes
- [x] `npm run lint` zero violations
- [ ] Semantics verified: `.some()` short-circuits; equivalent to `.find()` boolean / `.filter().length` checks (N/A — no code changes)
- [ ] Spot-check rewrites for correct predicate logic and negation (N/A — no code changes)

### What issues does this PR fix or reference?
@W-22818795@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002bS5OXYA0/view