### PR TITLE
chore: enable unicorn/prefer-native-coercion-functions - W-22818794

### DIFF
--- a/.claude/plans/W-22818794.md
+++ b/.claude/plans/W-22818794.md
@@ -1,0 +1,34 @@
+# W-22818794 — enable unicorn/prefer-native-coercion-functions
+
+## Context
+
+- Add `unicorn/prefer-native-coercion-functions: error` to unicorn block in `eslint.config.mjs`
+- Rule replaces `x => Boolean(x)` / `String(x)` / `Number(x)` / `BigInt(x)` / `Symbol(x)` with bare native fn
+- Autofixable; expect minimal churn
+- Insert alphabetically near other `prefer-*` rules (after line 190 `prefer-modern-math-apis` / before `prefer-node-protocol`)
+
+## Phases
+
+### Phase 1 — enable rule + autofix
+
+- Edit `eslint.config.mjs`: add `'unicorn/prefer-native-coercion-functions': 'error'` in unicorn rules block
+- Apply autofixes by bypassing wireit (root `lint` script orchestrates per-package wireit tasks that don't forward `--`):
+  - From repo root: `npx eslint . --fix --cache --cache-location .eslintcache`
+  - This matches per-package lint invocation (`eslint --color --cache --cache-location .eslintcache .`) but adds `--fix` and runs once across all workspaces
+- If any violations remain after autofix (rule has edge cases where autofix is unsafe, e.g. when the arrow fn has different `this`/extra args), fix manually per ESLint output
+- Stage modified source files
+- commitMessage: `chore: enable unicorn/prefer-native-coercion-functions`
+- files: `eslint.config.mjs`, any autofixed `.ts`/`.js` files across packages
+
+## Skills
+
+- typescript
+- verification
+
+## Verification
+
+- `npm run lint` clean (no remaining violations)
+- `npm run compile` passes (autofix didn't break types)
+- spot-check 2-3 autofixed diffs read sensibly (e.g., `.map(Boolean)` instead of `.map(x => Boolean(x))`)
+- unit tests on affected packages pass
+- e2e-covered: runtime behavior unchanged — coercion fns identical, no e2e run needed beyond branch CI

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -188,6 +188,7 @@ export default [
       'unicorn/prefer-export-from': 'error',
       'unicorn/prefer-includes': 'error',
       'unicorn/prefer-modern-math-apis': 'error',
+      'unicorn/prefer-native-coercion-functions': 'error',
       'unicorn/prefer-node-protocol': 'error',
       'unicorn/prefer-object-from-entries': 'error',
       'unicorn/prefer-optional-catch-binding': 'error',

--- a/packages/salesforcedx-vscode-services/src/core/apexLogService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/apexLogService.ts
@@ -49,7 +49,7 @@ const buildListLogsQuery = (limit: number, options?: ListLogsOptions): string =>
     ? `Operation LIKE '%${options.operationContains.replaceAll("'", "''")}%'`
     : undefined;
   const startTimeCondition = options?.startTimeAfter ? `StartTime >= ${options.startTimeAfter}` : undefined;
-  const conditions = [userIdCondition, operationCondition, startTimeCondition].filter((c): c is string => Boolean(c));
+  const conditions = [userIdCondition, operationCondition, startTimeCondition].filter(Boolean);
   const where = conditions.length > 0 ? ` WHERE ${conditions.join(' AND ')}` : '';
   return `${BASE_SELECT}${where} ORDER BY StartTime DESC LIMIT ${limit}`;
 };


### PR DESCRIPTION
## Summary

- Enabled `unicorn/prefer-native-coercion-functions` ESLint rule
- Applied autofixes to replace arrow-wrapped coercion functions with bare natives (`.map(Boolean)` instead of `.map(x => Boolean(x))`)
- Minimal impact: 1 source file autofixed (apexLogService.ts)

## Plan

[.claude/plans/W-22818794.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-22818794-enable-unicorn-prefer-native-coercion-fu/.claude/plans/W-22818794.md)

## Reviewer notes

### Low severity

- `apexLogService.ts:52` — autofix removed explicit type predicate `(c): c is string` from `.filter(Boolean)`. TS 5.9.3 infers the narrowing correctly and tests pass; restoring the predicate is optional documentation only.
- Plan `W-22818794.md:15` — wireit limitation worth documenting: root scripts with wireit.dependencies cannot forward extra args to per-package scripts; `npx eslint` workaround is appropriate.

## Test plan

- `npm run lint` clean (no remaining violations)
- `npm run compile` passes (autofix did not break types)
- spot-check autofixed diffs read sensibly (`.map(Boolean)` instead of `.map(x => Boolean(x))`)
- unit tests on affected packages pass

E2E: runtime behavior unchanged (coercion functions identical); e2e coverage via branch CI.

### What issues does this PR fix or reference?

@W-22818794@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002bSPQWYA4/view