### PR TITLE
chore: enable unicorn/prefer-structured-clone - W-22818796

### DIFF
--- a/.claude/plans/W-22818796.md
+++ b/.claude/plans/W-22818796.md
@@ -1,0 +1,44 @@
+# W-22818796 — Enable unicorn/prefer-structured-clone
+
+## Context
+
+- Add rule at error level in `eslint.config.mjs` unicorn block
+- Replaces `JSON.parse(JSON.stringify(x))` with `structuredClone(x)`
+- 2 flagged sites:
+  - `packages/salesforcedx-apex-replay-debugger/src/core/logContext.ts:155` — clones `StackFrame[]` (`@vscode/debugadapter`). `StackFrame` is a data-only class (`node_modules/@vscode/debugadapter/lib/debugSession.d.ts`: only public fields + constructor, no methods). `JSON.parse(JSON.stringify(...))` already strips the prototype; `structuredClone` likewise yields plain objects for non-builtin classes. Downstream usage reads `backup.id` only (logContext.ts:160-164), so semantics are equivalent.
+  - `packages/salesforcedx-vscode-apex-oas/src/oas/externalServiceRegistrationManager.ts:396` — clones `OpenAPIV3.Document`. `OpenAPIV3.Document` is a TypeScript interface from `openapi-types` (plain JSON object shape), so no class instances or non-cloneable values are present.
+
+## Clone-semantics risk assessment
+
+`structuredClone` differs from `JSON.parse(JSON.stringify(...))` for: functions (throws), `undefined` properties (preserved vs dropped), `Date`/`Map`/`Set`/`RegExp` (preserved vs lossy), class prototypes (lost in both), cycles (preserved vs throws). For both call sites the inputs are plain JSON-compatible data: DAP `StackFrame` fields are `number | string | Source | ...` (all JSON-safe), and OpenAPI documents are JSON by definition. No behavioral change expected.
+
+## Phases
+
+### Phase 1 — enable rule + replace sites
+
+- Insert `'unicorn/prefer-structured-clone': 'error',` alphabetically in unicorn rules (after `prefer-string-starts-ends-with`)
+- Replace both `JSON.parse(JSON.stringify(x))` with `structuredClone(x)`
+- Files:
+  - `eslint.config.mjs`
+  - `packages/salesforcedx-apex-replay-debugger/src/core/logContext.ts`
+  - `packages/salesforcedx-vscode-apex-oas/src/oas/externalServiceRegistrationManager.ts`
+- Commit: `chore: enable unicorn/prefer-structured-clone`
+
+## Skills
+
+- concise
+- typescript
+- verification
+
+## Verification
+
+- `npm run lint` clean
+- `npm run compile` clean for affected packages
+- Existing unit tests:
+  - `apexReplayDebugVariablesHandling.test.ts` references `copyStateForHeapDump` (line 124) but stubs it via `jest.spyOn(...)` without invoking the real implementation, so clone semantics are NOT exercised by unit tests.
+  - `cleanOasDocument` has no direct unit test coverage (grep returns no test references).
+  - Passing unit suites only confirm no regressions in tested paths; they do not validate the clone change itself.
+- e2e: `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebugger.desktop.spec.ts` exercises the replay debugger flow; run it to verify heap-dump backup/restore still works end-to-end. (`checkpoints.desktop.spec.ts` covers checkpoint flow but not heap-dump state copy.)
+- Manual verification:
+  - Replay debugger: load a log with a heap dump, step into a frame that triggers `copyStateForHeapDump`, confirm variables view matches pre-change behavior (backup/restore round-trip preserves stack frame ids and locals).
+  - OAS: regenerate an ESR for a sample apex class and diff the output against a pre-change run; confirm cleaned descriptions and document structure are byte-identical.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -196,6 +196,7 @@ export default [
       'unicorn/prefer-single-call': 'error',
       'unicorn/prefer-string-replace-all': 'error',
       'unicorn/prefer-string-starts-ends-with': 'error',
+      'unicorn/prefer-structured-clone': 'error',
       'unicorn/prefer-ternary': ['error'],
       'unicorn/prefer-simple-condition-first': 'error',
       'unicorn/filename-case': [

--- a/package-lock.json
+++ b/package-lock.json
@@ -46629,7 +46629,7 @@
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/apex-node": "8.4.27",
+        "@salesforce/apex-node": "^8.4.27",
         "@salesforce/effect-ext-utils": "*",
         "@salesforce/salesforcedx-utils": "*",
         "@salesforce/salesforcedx-utils-vscode": "*",
@@ -47215,7 +47215,7 @@
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/apex-node": "8.4.27",
+        "@salesforce/apex-node": "^8.4.27",
         "@salesforce/effect-ext-utils": "*",
         "@salesforce/salesforcedx-apex-replay-debugger": "*",
         "@salesforce/salesforcedx-utils": "*",
@@ -47243,7 +47243,7 @@
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/apex-node": "8.4.27",
+        "@salesforce/apex-node": "^8.4.27",
         "@salesforce/effect-ext-utils": "*",
         "@salesforce/types": "^1.7.1",
         "@salesforce/vscode-i18n": "*",
@@ -48928,6 +48928,7 @@
         "@salesforce/playwright-vscode-ext": "*",
         "@salesforce/source-deploy-retrieve": "^12.32.5",
         "@salesforce/source-tracking": "^7.8.16",
+        "@salesforce/types": "^1.7.1",
         "salesforcedx-vscode-services": "*"
       },
       "engines": {

--- a/packages/salesforcedx-apex-replay-debugger/src/core/logContext.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/core/logContext.ts
@@ -152,7 +152,7 @@ export class LogContext {
   }
 
   public copyStateForHeapDump(): void {
-    this.backupStackFrameInfos = JSON.parse(JSON.stringify(this.stackFrameInfos));
+    this.backupStackFrameInfos = structuredClone(this.stackFrameInfos);
     this.backupFrameHandles = this.frameHandles.copy();
     this.backupRefsMap = new Map<string, ApexVariableContainer>();
     this.backupVariableHandles = new Handles<ApexVariableContainer>();

--- a/packages/salesforcedx-vscode-apex-oas/src/oas/externalServiceRegistrationManager.ts
+++ b/packages/salesforcedx-vscode-apex-oas/src/oas/externalServiceRegistrationManager.ts
@@ -392,8 +392,7 @@ export class ExternalServiceRegistrationManager {
    * @returns A cleaned copy of the document
    */
   private cleanOasDocument(doc: OpenAPIV3.Document): OpenAPIV3.Document {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const cleaned = JSON.parse(JSON.stringify(doc)); // Deep clone the document
+    const cleaned = structuredClone(doc); // Deep clone the document
 
     // Clean all description fields in the document
     const descriptionPaths = [


### PR DESCRIPTION
## Summary
- Enabled `unicorn/prefer-structured-clone` ESLint rule at error level
- Replaced `JSON.parse(JSON.stringify(...))` with `structuredClone(...)` in apex-replay-debugger and apex-oas packages
- Both call sites clone plain JSON-compatible data; no behavioral change expected

## Plan
[.claude/plans/W-22818796.md](.claude/plans/W-22818796.md)

## Reviewer notes
- **Low:** `logContext.ts:163` — typescript skill suggests `.forEach()` for side-effect-only `.map()`. Skipped: conflicts with user global rule preferring `map` over `forEach`.
- **Low:** `externalServiceRegistrationManager.ts:395` — `structuredClone` preserves explicit `undefined` properties that `JSON.parse(JSON.stringify(...))` would drop; if upstream `processedOasResult.openAPIDoc` ever sets a key to `undefined`, the YAML output (`yaml.stringify`) will now emit it as `null`, changing ESR YAML byte-for-byte. Worth a snapshot/e2e check.
- **Low:** Plan asserts e2e/manual verification but no direct unit test exercises the new clone semantics (apexReplayDebugVariablesHandling.test.ts stubs `copyStateForHeapDump`; `cleanOasDocument` has no direct test). Consider adding a focused test or running e2e before merge.
- **Low:** Plan should mention running `npm run check:dupes` per verification skill, since replacing `JSON.parse(JSON.stringify(...))` with `structuredClone()` could affect duplicate-code patterns.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run compile` clean for affected packages
- [x] Existing unit tests pass
- [ ] e2e: `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebugger.desktop.spec.ts` exercises the replay debugger flow; run it to verify heap-dump backup/restore still works end-to-end
- [ ] Manual verification — Replay debugger: load a log with a heap dump, step into a frame that triggers `copyStateForHeapDump`, confirm variables view matches pre-change behavior
- [ ] Manual verification — OAS: regenerate an ESR for a sample apex class and diff the output against a pre-change run; confirm cleaned descriptions and document structure are byte-identical

### What issues does this PR fix or reference?
@W-22818796@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002bSBe8YAG/view