### PR TITLE
chore: enable unicorn/prefer-array-flat-map ESLint rule - W-22818797

### DIFF
--- a/.claude/plans/W-22818797.md
+++ b/.claude/plans/W-22818797.md
@@ -1,0 +1,72 @@
+# W-22818797 — enable unicorn/prefer-array-flat-map
+
+## Context
+
+- add `unicorn/prefer-array-flat-map: error` in `eslint.config.mjs` unicorn block
+- alphabetical placement: in unicorn rules block near other `prefer-array-*` (between `prefer-array-find` / `prefer-array-some`, before `prefer-at`)
+- replaces `.map(...).flat()` with `.flatMap(...)` — single pass, clearer intent
+- ref: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-flat-map.md
+
+## Scope discipline
+
+- ONLY: rule enable + mechanical autofixes
+- pattern (rule autofixes): `arr.map(fn).flat()` → `arr.flatMap(fn)`
+- intentional cases: `// eslint-disable-next-line` + reason
+- no unrelated refactors
+
+## Affected-package detection (run BEFORE Phase 1)
+
+`npm run lint` is a wireit wrapper around `eslint --color --cache .` per package (see `packages/*/package.json:56`); it does not accept `--rule`. So enumerate candidates by grep + enable-and-lint, not a `--rule` dry-run.
+
+1. enumerate candidate files (regex captures the chained pattern across newlines):
+   ```sh
+   find packages scripts -path '*/node_modules' -prune -o -type f \
+     \( -name "*.ts" -o -name "*.tsx" -o -name "*.mjs" \) -print \
+     | xargs pcregrep -Mn '\.map\([^;]{0,300}?\)\s*\.flat\(\)'
+   ```
+2. baseline grep at time of plan (worktree HEAD) finds two hits, both `Effect.all(...).flat()` — not direct `Array#map().flat()` chains. Rule may not flag them; treat as zero-violation baseline:
+   - `packages/salesforcedx-vscode-metadata/src/commands/sourceDiff.ts:37,112`
+   - `packages/salesforcedx-vscode-apex-testing/src/commands/apexTestRunCodeAction.ts:153`
+3. authoritative check after enabling the rule: `npm run compile` (builds `eslint-local-rules`) then `npm run lint` from repo root — ESLint output reports every `unicorn/prefer-array-flat-map` violation with file path; bucket by package.
+
+## Phases
+
+### Phase 1 — enable rule + apply fixes
+
+- add `'unicorn/prefer-array-flat-map': 'error'` (alphabetical, near `prefer-array-find`)
+- `npm run compile` (ensures `eslint-local-rules` built so root lint resolves)
+- `npm run lint -- --fix` to apply autofixes
+- manually resolve any non-autofixable violations (e.g. `Effect.all(...).flat()` is not `Array#map().flat()` — leave or `// eslint-disable-next-line` with reason)
+- `npm run compile` again to verify types after rewrites
+- commit: `chore: enable unicorn/prefer-array-flat-map`
+
+files:
+
+- `eslint.config.mjs`
+- any `.ts` / `.tsx` / `.mjs` flagged across `packages/` and `scripts/`
+
+## Skills to apply
+
+- concise (plan)
+- typescript (style/naming)
+- pr-draft (title `chore: ... - W-22818797`, GUS ref)
+- feature-branch (on feature branch)
+- verification
+
+## Verification
+
+- `npm run compile` passes
+- `npm run lint` zero violations
+- semantics: `.flatMap(fn)` equivalent to `.map(fn).flat()` (depth 1)
+- spot-check rewrites: callback unchanged; no `.flat(N)` with N>1 incorrectly converted; confirm no `Effect.all(...).flat()` accidentally rewritten (Effect's combinator is not `Array#map`)
+
+### Playwright specs to run locally (representative, by likely-affected package)
+
+Based on the candidate-file grep above, two packages are at risk. Run these locally before pushing; branch e2e on PR is a backstop, not a substitute. If the post-enable lint surfaces violations in additional packages, append the matching package's smoke spec from `test/playwright/specs/`.
+
+- `packages/salesforcedx-vscode-metadata/test/playwright/specs/sourceDiff.headless.spec.ts` — exercises `src/commands/sourceDiff.ts` (one of two candidate files; verifies recursive URI expansion still works if `subdirFiles.flat()` is rewritten)
+- `packages/salesforcedx-vscode-metadata/test/playwright/specs/sourceDiffMultiple.headless.spec.ts` — exercises the second `.flat()` site at `sourceDiff.ts:112` (multi-uri expansion path)
+- `packages/salesforcedx-vscode-apex-testing/test/playwright/specs/runApexTestsCommandPalette.headless.spec.ts` — exercises `src/commands/apexTestRunCodeAction.ts` (`.flat()` at line 153 in the package-dir glob pipeline)
+- `packages/salesforcedx-vscode-apex-testing/test/playwright/specs/testExplorer.headless.spec.ts` — backstop for the same package (Test Explorer activation surfaces command registration regressions)
+
+If the baseline grep is correct (zero true `Array#map().flat()` chains) and post-enable `npm run lint` reports zero violations, no source files change in this PR — only `eslint.config.mjs`. In that case run `packages/salesforcedx-vscode-core/test/playwright/specs/configList.headless.spec.ts` as a cross-package smoke to confirm no regression from the rule addition itself, and skip the per-package specs above.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -182,6 +182,7 @@ export default [
       'unicorn/numeric-separators-style': 'error',
       'unicorn/prefer-at': 'error',
       'unicorn/prefer-array-find': 'error',
+      'unicorn/prefer-array-flat-map': 'error',
       'unicorn/prefer-array-some': 'error',
       'unicorn/prefer-class-fields': 'error',
       'unicorn/prefer-date-now': 'error',


### PR DESCRIPTION
## Summary

- Enable `unicorn/prefer-array-flat-map` ESLint rule in `eslint.config.mjs`
- Rule enforces `.flatMap()` over `.map().flat()` for clearer intent and single-pass iteration
- Zero source violations found — only rule configuration change ships

## Plan

[.claude/plans/W-22818797.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-22818797-enable-unicorn-prefer-array-flat-map-esl/.claude/plans/W-22818797.md)

## Reviewer notes

- **Low severity (concise):** 8 wording trims to `.claude/plans/W-22818797.md` (remove 'add', 'manually', 'incorrectly', etc.). Plan file already committed; cosmetic only.
- **Medium severity (paths):** `packages/salesforcedx-vscode-apex-testing/src/commands/apexTestRunCodeAction.ts` uses `node:path` (lines 12, 149, 160). Pre-existing code, NOT modified by this WI (diff is 1 line in `eslint.config.mjs`). Out of scope.
- **Medium severity (effect-advocate):** `mapApexArtifactToFilesystem` in `apexTestRunCodeAction.ts:130` uses `Promise.all` instead of `Effect.all`. Pre-existing code, out of scope.
- **Low severity (thermonuclear):** pre-existing alphabetical ordering quirk in `eslint.config.mjs` unicorn block — 'prefer-at' (line 183) sits above 'prefer-array-find/flat-map/some'. New rule follows existing local convention; not introduced by this diff.
- **Low severity (thermonuclear):** plan lists representative Playwright specs but baseline shows zero rule-flaggable sites (only `Effect.all(...).flat()` patterns the rule can't flag). Per-package spec runs likely unnecessary; only `eslint.config.mjs` ships.

## Test plan

- [x] `npm run compile` passes
- [x] `npm run lint` zero violations
- [ ] Run smoke test: `npm run test:desktop -w salesforcedx-vscode-core -- packages/salesforcedx-vscode-core/test/playwright/specs/configList.headless.spec.ts --retries 0` to confirm ESLint rule addition has no regressions

### What issues does this PR fix or reference?

@W-22818797@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.salesforce.com/a07EE00002bSEvF