### PR TITLE
fix(lwc): re-add context menu LWC creation option - W-22845383

### DIFF
--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -366,7 +366,16 @@
       "editor/title/context": [],
       "view/title": [],
       "view/item/context": [],
-      "explorer/context": [],
+			"explorer/context": [
+				{
+				  "command": "sf.metadata.lightning.generate.lwc",
+				  "when": "explorerResourceIsFolder && resourceFilename == lwc && sf:project_opened"
+				},
+				{
+				  "command": "sf.internal.lightning.generate.lwc",
+				  "when": "explorerResourceIsFolder && sf:internal_dev"
+				}
+			],
       "commandPalette": [
         {
           "command": "sf.metadata.lightning.generate.lwc",

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -366,16 +366,16 @@
       "editor/title/context": [],
       "view/title": [],
       "view/item/context": [],
-			"explorer/context": [
-				{
-				  "command": "sf.metadata.lightning.generate.lwc",
-				  "when": "explorerResourceIsFolder && resourceFilename == lwc && sf:project_opened"
-				},
-				{
-				  "command": "sf.internal.lightning.generate.lwc",
-				  "when": "explorerResourceIsFolder && sf:internal_dev"
-				}
-			],
+      "explorer/context": [
+        {
+          "command": "sf.metadata.lightning.generate.lwc",
+          "when": "explorerResourceIsFolder && resourceFilename == lwc && sf:project_opened"
+        },
+        {
+          "command": "sf.internal.lightning.generate.lwc",
+          "when": "explorerResourceIsFolder && sf:internal_dev"
+        }
+      ],
       "commandPalette": [
         {
           "command": "sf.metadata.lightning.generate.lwc",

--- a/packages/salesforcedx-vscode-lwc/src/index.ts
+++ b/packages/salesforcedx-vscode-lwc/src/index.ts
@@ -128,6 +128,9 @@ export const activateEffect = Effect.fn('activation:salesforcedx-vscode-lwc')(fu
   yield* registerCommand('sf.metadata.lightning.generate.lwc', (outputDirParam?: URI) =>
     createLwcCommand(outputDirParam)
   );
+  yield* registerCommand('sf.internal.lightning.generate.lwc', (sourceUri?: URI) =>
+    createLwcCommand(sourceUri, { internal: true })
+  );
   yield* Effect.forkDaemon(startLwcFileWatcher());
   // Creates resources for js-meta.xml to work
   yield* activateMetaSupport(extensionContext.extensionUri);


### PR DESCRIPTION
This minor change re-introduces the context menu option for creating an LWC.

<!--- PR title: <type>(optional scope): <description> - W-XXXXXXXX — append GUS work item at the end (space, hyphen, space, W-). Conventional commits: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Re-adds the ability to create blank LWCs from the explorer context menu.  This is a small QoL fix for developers who are in the process of migrating from Visualforce to LWC or have net new development which requires LWCs.

### What issues does this PR fix or reference?
No issue at present, this was a personal issue that would be nice to have back for the people that used it.

### Functionality Before
Unable to create LWC from explorer context menu in VS Code.

### Functionality After
Able to create LWC from explorer context menu in VS Code.

---

**Adopted from #7379** by @vsdragon626 — commits preserved with author credit. Replayed onto develop for internal CI / AI review.

### Reviewer notes

Adopted onto develop (the original PR targeted `release/v66.14.2`). Two follow-up fixes stacked on the original commit:

- **High:** `sf.internal.lightning.generate.lwc` was declared in `package.json` but its `registerCommand` call had been dropped in #7267. The new explorer/context entry would have been a non-functional menu item under `sf:internal_dev`. Re-registered it in `packages/salesforcedx-vscode-lwc/src/index.ts`.
- **Medium:** the new `explorer/context` block in `package.json` used tabs while the rest of the file uses 2-space indentation. Re-indented to match.

### What issues does this PR fix or reference?

@W-22845383@

Co-authored-by: Thomas <vsdragon626@gmail.com>
