### PR TITLE
feat(playwright-vscode-ext): publish to npm - W-22846720

### DIFF
--- a/.claude/plans/W-22846720.md
+++ b/.claude/plans/W-22846720.md
@@ -21,17 +21,16 @@
   - add `versionedIndependently: true`
   - set `version: "1.0.0"`
   - add `description`, `author: "Salesforce"`, `license: "BSD-3-Clause"`, `repository`, `bugs`, `homepage`
-  - `main: "./out/src/index.js"` -> `main: "./out/index.js"`
-  - add `types: "./out/index.d.ts"`, `exports: { ".": { "types": "./out/index.d.ts", "default": "./out/index.js" } }`
-  - add `files: ["out/**/*.js", "out/**/*.js.map", "out/**/*.d.ts", "out/**/*.d.ts.map", "LICENSE.txt", "README.md"]`
+  - `main: "./out/src/index.js"` -> `main: "out/index.js"` (drop `./` per eslint-local-rules convention)
+  - add `types: "out/index.d.ts"` (drop `./`), `exports: { ".": { "types": "./out/index.d.ts", "default": "./out/index.js" } }`
+  - add `files: ["out/**/*.js", "out/**/*.js.map", "out/**/*.d.ts", "out/**/*.d.ts.map", "LICENSE.txt", "README.md"]` (auto-includes CHANGELOG.md per npm convention)
   - add `publishConfig: { access: "public" }`
   - wireit `compile.files`: drop `test/**/*.ts` (test files aren't compiled — `include` is `src/**/*.ts` only; listing them only causes spurious recompiles)
   - dependencies:
     - keep `@playwright/test`, `@vscode/test-electron`, `@vscode/test-web` in `dependencies`
-    - move `@salesforce/core` from `devDependencies` to `peerDependencies` with `^8.31.0`
-    - add `peerDependenciesMeta: { "@salesforce/core": { "optional": true } }`
-    - keep `@salesforce/core` in `devDependencies` (so workspace install resolves it for our own compile/tests)
-  - rationale for peerDep: `@salesforce/core` is ~8MB w/ heavy transitive deps (jsforce, SDR). Runtime usage is limited (`Global` import in `desktopWorkspace.ts`, type-only elsewhere). Consumers using desktop fixtures install it themselves; consumers using only web/types don't pay the cost.
+    - keep `@salesforce/core` in `devDependencies` only (type-only usage; erased at compile time)
+    - remove `peerDependencies` and `peerDependenciesMeta` entirely
+  - rationale: `@salesforce/core` is used only as `import type { AuthFields }` in 4 src files (type-only, erased at compile time). Published `.d.ts` files re-export `AuthFields`; consumers needing it will pull `@salesforce/core` transitively or install it themselves. No peer declaration needed.
 - Commit: `chore(playwright-vscode-ext): make package publishable`
 
 ### Phase 2 — LICENSE + version hook

--- a/.claude/plans/W-22846720.md
+++ b/.claude/plans/W-22846720.md
@@ -1,0 +1,83 @@
+# W-22846720 — Publish @salesforce/playwright-vscode-ext to npm
+
+## Context
+
+- Make `packages/playwright-vscode-ext` publishable to npm at `1.0.0`.
+- Pattern: mirror `packages/eslint-local-rules` (also i18n, soql-common).
+- Auto-publish on push to `develop` (paths-filtered) + `workflow_dispatch`.
+- Internal consumers stay on workspace symlink (`*`); no consumer changes.
+- Secrets `NPM_TOKEN`, `IDEE_GH_TOKEN` already exist.
+
+## Phases
+
+### Phase 1 — tsconfig + package.json publishability
+
+- File: `packages/playwright-vscode-ext/tsconfig.json`
+  - `rootDir: "."` -> `rootDir: "src"` (matches eslint-local-rules pattern; `include` already only `src/**/*.ts`, so test files were never compiled by tsc — they only triggered rebuild)
+  - Result: tsc emits to `out/` (not `out/src/`)
+
+- File: `packages/playwright-vscode-ext/package.json`
+  - remove `private: true`
+  - add `versionedIndependently: true`
+  - set `version: "1.0.0"`
+  - add `description`, `author: "Salesforce"`, `license: "BSD-3-Clause"`, `repository`, `bugs`, `homepage`
+  - `main: "./out/src/index.js"` -> `main: "./out/index.js"`
+  - add `types: "./out/index.d.ts"`, `exports: { ".": { "types": "./out/index.d.ts", "default": "./out/index.js" } }`
+  - add `files: ["out/**/*.js", "out/**/*.js.map", "out/**/*.d.ts", "out/**/*.d.ts.map", "LICENSE.txt", "README.md"]`
+  - add `publishConfig: { access: "public" }`
+  - wireit `compile.files`: drop `test/**/*.ts` (test files aren't compiled — `include` is `src/**/*.ts` only; listing them only causes spurious recompiles)
+  - dependencies:
+    - keep `@playwright/test`, `@vscode/test-electron`, `@vscode/test-web` in `dependencies`
+    - move `@salesforce/core` from `devDependencies` to `peerDependencies` with `^8.31.0`
+    - add `peerDependenciesMeta: { "@salesforce/core": { "optional": true } }`
+    - keep `@salesforce/core` in `devDependencies` (so workspace install resolves it for our own compile/tests)
+  - rationale for peerDep: `@salesforce/core` is ~8MB w/ heavy transitive deps (jsforce, SDR). Runtime usage is limited (`Global` import in `desktopWorkspace.ts`, type-only elsewhere). Consumers using desktop fixtures install it themselves; consumers using only web/types don't pay the cost.
+- Commit: `chore(playwright-vscode-ext): make package publishable`
+
+### Phase 2 — LICENSE + version hook
+
+- New: `packages/playwright-vscode-ext/LICENSE.txt` — copy verbatim from `packages/eslint-local-rules/LICENSE.txt`
+- New: `packages/playwright-vscode-ext/scripts/playwright-vscode-ext-version-hook.js` — clone of `eslint-plugin-version-hook.js`
+  - `preVersionGeneration`: identical (reads `RELEASE_TYPE` env, bumps `../package.json`)
+  - `preCommit`: hardcode lockfile key `lock.packages['packages/playwright-vscode-ext']` (the script filename does NOT determine the lockfile key — the key string is hardcoded in the function body and must match the package's path in `package-lock.json`)
+- Commit: `chore(playwright-vscode-ext): add LICENSE and version hook`
+
+### Phase 3 — README rewrite
+
+- File: `packages/playwright-vscode-ext/README.md`
+- Rewrite for npm audience: install cmd (note `@salesforce/core` peer install for desktop fixtures), minimal example, repo link.
+- Keep customer-facing tone (full sentences — concise skill excludes package READMEs).
+- Commit: `docs(playwright-vscode-ext): rewrite README for npm consumers`
+
+### Phase 4 — publish workflow
+
+- New: `.github/workflows/publishPlaywrightVscodeExt.yml` — clone `publishEslintPlugin.yml`
+- Substitutions:
+  - `name: Publish playwright-vscode-ext to npm`
+  - `paths: packages/playwright-vscode-ext/**`
+  - `tag-prefix: playwright-vscode-ext-v`
+  - `version-file: ./packages/playwright-vscode-ext/package.json`
+  - `git-path: packages/playwright-vscode-ext`
+  - `output-file: packages/playwright-vscode-ext/CHANGELOG.md`
+  - `pre-changelog-generation` + `pre-commit`: `./packages/playwright-vscode-ext/scripts/playwright-vscode-ext-version-hook.js`
+  - `packagePath: ./packages/playwright-vscode-ext`
+- Commit: `ci(playwright-vscode-ext): add npm publish workflow`
+
+## Skills
+
+- packageJson — package.json conventions
+- wireit — preserve existing wireit blocks (drop only the test/**/*.ts entry from compile.files)
+- typescript — file naming for new hook script
+- concise — plan file + any internal docs
+- verification — local checks below
+
+## Verification
+
+- `npm install` clean from root (lockfile picks up dep move; verify `packages/playwright-vscode-ext` entry exists in `package-lock.json` for hook to patch).
+- `npm run compile -w @salesforce/playwright-vscode-ext` — tsc emits to `out/` (not `out/src/`); `out/index.d.ts` and `out/index.js` exist.
+- Internal consumers still resolve: grep workspace for imports of `@salesforce/playwright-vscode-ext` and confirm they still type-check after rootDir change (path is via `main`/`types`, both updated).
+- `cd packages/playwright-vscode-ext && npm pack --dry-run` — tarball includes `out/**`, LICENSE.txt, README.md; excludes `src/`, `test/`, `tsconfig.json`.
+- `node -e "require('./packages/playwright-vscode-ext/scripts/playwright-vscode-ext-version-hook.js')"` — loads without error; inspect that `preCommit.toString()` contains `'packages/playwright-vscode-ext'`.
+- YAML lint workflow file (`actionlint` or `yq` parse) if available.
+- Confirm `check:actions` script (if present) globs new workflow.
+- E2E-covered: actual publish run on develop merge — first push creates tag `playwright-vscode-ext-v1.0.0` + GH release + npm publish (validated in workflow run, not locally).

--- a/.github/workflows/publishPlaywrightVscodeExt.yml
+++ b/.github/workflows/publishPlaywrightVscodeExt.yml
@@ -1,0 +1,109 @@
+name: Publish playwright-vscode-ext to npm
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - 'packages/playwright-vscode-ext/**'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g., playwright-vscode-ext-v1.0.1). Leave empty to create a new release from commits.'
+        required: false
+        type: string
+      releaseType:
+        description: 'Version bump type when creating a new release from commits (ignored if tag is provided)'
+        required: false
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      prerelease:
+        description: 'Publish as prerelease (does not affect latest dist-tag)'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ steps.tag-output.outputs.tag }}
+    steps:
+      - name: Get Github user info
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.tag == ''
+        id: github-user-info
+        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@main
+        with:
+          SVC_CLI_BOT_GITHUB_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
+
+      - uses: actions/checkout@v4
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.tag == ''
+        with:
+          token: ${{ secrets.IDEE_GH_TOKEN }}
+          fetch-depth: 0
+
+      - name: Conventional Changelog Action
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.tag == ''
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@3a392e9aa44a72686b0fc13259a90d287dd0877c
+        env:
+          RELEASE_TYPE: ${{ github.event.inputs.releaseType }}
+        with:
+          git-user-name: ${{ steps.github-user-info.outputs.username }}
+          git-user-email: ${{ steps.github-user-info.outputs.email }}
+          github-token: ${{ secrets.IDEE_GH_TOKEN }}
+          tag-prefix: 'playwright-vscode-ext-v'
+          version-file: './packages/playwright-vscode-ext/package.json'
+          git-path: 'packages/playwright-vscode-ext'
+          release-count: '0'
+          output-file: 'packages/playwright-vscode-ext/CHANGELOG.md'
+          skip-on-empty: ${{ github.event_name == 'push' }}
+          skip-tag: false
+          pre-changelog-generation: packages/playwright-vscode-ext/scripts/playwright-vscode-ext-version-hook.js
+          pre-commit: packages/playwright-vscode-ext/scripts/playwright-vscode-ext-version-hook.js
+
+      - name: Create Github Release
+        if: steps.changelog.outputs.skipped == 'false'
+        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b
+        with:
+          name: ${{ steps.changelog.outputs.tag }}
+          tag: ${{ steps.changelog.outputs.tag }}
+          commit: develop
+          body: ${{ steps.changelog.outputs.clean_changelog }}
+          token: ${{ secrets.IDEE_GH_TOKEN }}
+          skipIfReleaseExists: true
+
+      - id: tag-output
+        run: |
+          if [ -n "$INPUT_TAG" ]; then
+            echo "tag=$INPUT_TAG" >> $GITHUB_OUTPUT
+          elif [ "$CHANGELOG_SKIPPED" != "true" ] && [ -n "$CHANGELOG_TAG" ]; then
+            echo "tag=$CHANGELOG_TAG" >> $GITHUB_OUTPUT
+          else
+            echo "tag=" >> $GITHUB_OUTPUT
+          fi
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          CHANGELOG_SKIPPED: ${{ steps.changelog.outputs.skipped }}
+          CHANGELOG_TAG: ${{ steps.changelog.outputs.tag }}
+
+  publish:
+    name: Build and publish to npm
+    needs: create-release
+    if: needs.create-release.outputs.tag != ''
+    uses: salesforcecli/github-workflows/.github/workflows/npmPublish.yml@main
+    with:
+      githubTag: ${{ needs.create-release.outputs.tag }}
+      packageManager: npm
+      nodeVersion: ${{ vars.NODE_VERSION || 'lts/*' }}
+      packagePath: ./packages/playwright-vscode-ext
+      prerelease: ${{ github.event.inputs.prerelease == 'true' }}
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publishPlaywrightVscodeExt.yml
+++ b/.github/workflows/publishPlaywrightVscodeExt.yml
@@ -27,6 +27,10 @@ on:
         default: false
         type: boolean
 
+concurrency:
+  group: publish-playwright-vscode-ext
+  cancel-in-progress: false
+
 jobs:
   create-release:
     name: Create Release
@@ -39,7 +43,7 @@ jobs:
       - name: Get Github user info
         if: github.event_name != 'workflow_dispatch' || github.event.inputs.tag == ''
         id: github-user-info
-        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@main
+        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@b1f70470a9da194c0feb1ca77c1a6951f1d49f74 # main
         with:
           SVC_CLI_BOT_GITHUB_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
 
@@ -75,7 +79,6 @@ jobs:
         with:
           name: ${{ steps.changelog.outputs.tag }}
           tag: ${{ steps.changelog.outputs.tag }}
-          commit: develop
           body: ${{ steps.changelog.outputs.clean_changelog }}
           token: ${{ secrets.IDEE_GH_TOKEN }}
           skipIfReleaseExists: true
@@ -98,7 +101,7 @@ jobs:
     name: Build and publish to npm
     needs: create-release
     if: needs.create-release.outputs.tag != ''
-    uses: salesforcecli/github-workflows/.github/workflows/npmPublish.yml@main
+    uses: salesforcecli/github-workflows/.github/workflows/npmPublish.yml@b1f70470a9da194c0feb1ca77c1a6951f1d49f74 # main
     with:
       githubTag: ${{ needs.create-release.outputs.tag }}
       packageManager: npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -46541,17 +46541,6 @@
       },
       "devDependencies": {
         "@salesforce/core": "^8.31.0"
-      },
-      "engines": {
-        "vscode": "^1.90.0"
-      },
-      "peerDependencies": {
-        "@salesforce/core": "^8.31.0"
-      },
-      "peerDependenciesMeta": {
-        "@salesforce/core": {
-          "optional": true
-        }
       }
     },
     "packages/salesforcedx-apex-debugger": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46532,7 +46532,8 @@
     },
     "packages/playwright-vscode-ext": {
       "name": "@salesforce/playwright-vscode-ext",
-      "version": "65.7.0",
+      "version": "1.0.0",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@playwright/test": "^1.57.0",
         "@vscode/test-electron": "2.5.2",
@@ -46543,6 +46544,14 @@
       },
       "engines": {
         "vscode": "^1.90.0"
+      },
+      "peerDependencies": {
+        "@salesforce/core": "^8.31.0"
+      },
+      "peerDependenciesMeta": {
+        "@salesforce/core": {
+          "optional": true
+        }
       }
     },
     "packages/salesforcedx-apex-debugger": {

--- a/packages/eslint-local-rules/src/noDuplicatePlaywrightLocators.ts
+++ b/packages/eslint-local-rules/src/noDuplicatePlaywrightLocators.ts
@@ -243,10 +243,15 @@ const isConstantImported = (ast: TSESTree.Program, constantName: string, expecte
 /** Calculate relative import path from file to locators */
 const getImportPath = (filePath: string, repoRoot: string): string => {
   const locatorsDir = path.join(repoRoot, 'packages', 'playwright-vscode-ext', 'src', 'utils');
-  const fileDir = path.dirname(path.resolve(filePath));
+  const playwrightPackageDir = path.resolve(repoRoot, 'packages', 'playwright-vscode-ext');
+  const resolvedFilePath = path.resolve(filePath);
+  const fileDir = path.dirname(resolvedFilePath);
   const relativePath = path.relative(fileDir, path.resolve(locatorsDir));
 
-  return filePath.includes('playwright-vscode-ext')
+  // Check if file is inside packages/playwright-vscode-ext directory
+  const isInsidePlaywrightPackage = resolvedFilePath.startsWith(playwrightPackageDir + path.sep);
+
+  return isInsidePlaywrightPackage
     ? (() => {
         const normalized = relativePath.split(path.sep).join('/');
         return normalized === '' || normalized === '.' ? './locators' : `${normalized}/locators`;

--- a/packages/eslint-local-rules/src/noDuplicatePlaywrightLocators.ts
+++ b/packages/eslint-local-rules/src/noDuplicatePlaywrightLocators.ts
@@ -222,7 +222,7 @@ const isConstantImported = (ast: TSESTree.Program, constantName: string, expecte
       const isLocatorsImport =
         sourceValue === expectedImportPath ||
         sourceValue.includes('locators') ||
-        sourceValue === '@salesforcedx/playwright-vscode-ext/utils/locators' ||
+        sourceValue === '@salesforce/playwright-vscode-ext' ||
         sourceValue.endsWith('/locators') ||
         sourceValue.endsWith('./locators') ||
         sourceValue.endsWith('../locators') ||
@@ -256,7 +256,7 @@ const getImportPath = (filePath: string, repoRoot: string): string => {
         const normalized = relativePath.split(path.sep).join('/');
         return normalized === '' || normalized === '.' ? './locators' : `${normalized}/locators`;
       })()
-    : '@salesforcedx/playwright-vscode-ext/utils/locators';
+    : '@salesforce/playwright-vscode-ext';
 };
 
 /** Create fixes for adding import statement */
@@ -292,8 +292,7 @@ const createImportFixes = (
       stmt.type === AST_NODE_TYPES.ImportDeclaration &&
       stmt.source.type === AST_NODE_TYPES.Literal &&
       typeof stmt.source.value === 'string' &&
-      (stmt.source.value.includes('locators') ||
-        stmt.source.value === '@salesforcedx/playwright-vscode-ext/utils/locators')
+      (stmt.source.value.includes('locators') || stmt.source.value === '@salesforce/playwright-vscode-ext')
   );
 
   if (existingLocatorsImport) {
@@ -318,7 +317,7 @@ export const noDuplicatePlaywrightLocators = RuleCreator.withoutDocs({
     type: 'problem',
     docs: {
       description:
-        'Disallow string literals that duplicate selector values from playwright-vscode-ext/src/utils/locators.ts - use exported constants instead'
+        'Disallow string literals that duplicate selector values from @salesforce/playwright-vscode-ext - use exported constants instead'
     },
     schema: [],
     fixable: 'code',

--- a/packages/eslint-local-rules/src/noDuplicatePlaywrightLocators.ts
+++ b/packages/eslint-local-rules/src/noDuplicatePlaywrightLocators.ts
@@ -222,7 +222,7 @@ const isConstantImported = (ast: TSESTree.Program, constantName: string, expecte
       const isLocatorsImport =
         sourceValue === expectedImportPath ||
         sourceValue.includes('locators') ||
-        sourceValue === '@salesforcedx/vscode-playwright/utils/locators' ||
+        sourceValue === '@salesforcedx/playwright-vscode-ext/utils/locators' ||
         sourceValue.endsWith('/locators') ||
         sourceValue.endsWith('./locators') ||
         sourceValue.endsWith('../locators') ||
@@ -251,7 +251,7 @@ const getImportPath = (filePath: string, repoRoot: string): string => {
         const normalized = relativePath.split(path.sep).join('/');
         return normalized === '' || normalized === '.' ? './locators' : `${normalized}/locators`;
       })()
-    : '@salesforcedx/vscode-playwright/utils/locators';
+    : '@salesforcedx/playwright-vscode-ext/utils/locators';
 };
 
 /** Create fixes for adding import statement */
@@ -287,7 +287,8 @@ const createImportFixes = (
       stmt.type === AST_NODE_TYPES.ImportDeclaration &&
       stmt.source.type === AST_NODE_TYPES.Literal &&
       typeof stmt.source.value === 'string' &&
-      (stmt.source.value.includes('locators') || stmt.source.value === '@salesforcedx/vscode-playwright/utils/locators')
+      (stmt.source.value.includes('locators') ||
+        stmt.source.value === '@salesforcedx/playwright-vscode-ext/utils/locators')
   );
 
   if (existingLocatorsImport) {

--- a/packages/eslint-local-rules/test/no-duplicate-playwright-locators.test.ts
+++ b/packages/eslint-local-rules/test/no-duplicate-playwright-locators.test.ts
@@ -23,7 +23,7 @@ ruleTester.run('no-duplicate-playwright-locators', noDuplicatePlaywrightLocators
       filename: testFile('packages/test-package/test/playwright/test.spec.ts')
     },
     {
-      code: `import { EDITOR } from '@salesforcedx/vscode-playwright/utils/locators';
+      code: `import { EDITOR } from '@salesforcedx/playwright-vscode-ext/utils/locators';
 page.locator(EDITOR);`,
       filename: testFile('packages/test-package/test/playwright/test.spec.ts')
     },
@@ -53,10 +53,10 @@ page.locator(selector);`,
       errors: [
         {
           messageId: 'useConstant',
-          data: { constantName: 'EDITOR', importPath: '@salesforcedx/vscode-playwright/utils/locators' }
+          data: { constantName: 'EDITOR', importPath: '@salesforcedx/playwright-vscode-ext/utils/locators' }
         }
       ],
-      output: `import { EDITOR } from '@salesforcedx/vscode-playwright/utils/locators';
+      output: `import { EDITOR } from '@salesforcedx/playwright-vscode-ext/utils/locators';
 page.locator(EDITOR);`
     },
     {
@@ -65,23 +65,23 @@ page.locator(EDITOR);`
       errors: [
         {
           messageId: 'useConstant',
-          data: { constantName: 'WORKBENCH', importPath: '@salesforcedx/vscode-playwright/utils/locators' }
+          data: { constantName: 'WORKBENCH', importPath: '@salesforcedx/playwright-vscode-ext/utils/locators' }
         }
       ],
-      output: `import { WORKBENCH } from '@salesforcedx/vscode-playwright/utils/locators';
+      output: `import { WORKBENCH } from '@salesforcedx/playwright-vscode-ext/utils/locators';
 page.locator(WORKBENCH);`
     },
     {
-      code: `import { EDITOR } from '@salesforcedx/vscode-playwright/utils/locators';
+      code: `import { EDITOR } from '@salesforcedx/playwright-vscode-ext/utils/locators';
 page.locator('.monaco-workbench');`,
       filename: testFile('packages/test-package/test/playwright/test.spec.ts'),
       errors: [
         {
           messageId: 'useConstant',
-          data: { constantName: 'WORKBENCH', importPath: '@salesforcedx/vscode-playwright/utils/locators' }
+          data: { constantName: 'WORKBENCH', importPath: '@salesforcedx/playwright-vscode-ext/utils/locators' }
         }
       ],
-      output: `import { EDITOR, WORKBENCH } from '@salesforcedx/vscode-playwright/utils/locators';
+      output: `import { EDITOR, WORKBENCH } from '@salesforcedx/playwright-vscode-ext/utils/locators';
 page.locator(WORKBENCH);`
     },
     {
@@ -90,10 +90,10 @@ page.locator(WORKBENCH);`
       errors: [
         {
           messageId: 'useConstant',
-          data: { constantName: 'TAB', importPath: '@salesforcedx/vscode-playwright/utils/locators' }
+          data: { constantName: 'TAB', importPath: '@salesforcedx/playwright-vscode-ext/utils/locators' }
         }
       ],
-      output: `import { TAB } from '@salesforcedx/vscode-playwright/utils/locators';
+      output: `import { TAB } from '@salesforcedx/playwright-vscode-ext/utils/locators';
 page.locator(TAB);`
     },
     {
@@ -102,10 +102,10 @@ page.locator(TAB);`
       errors: [
         {
           messageId: 'useConstant',
-          data: { constantName: 'QUICK_INPUT_WIDGET', importPath: '@salesforcedx/vscode-playwright/utils/locators' }
+          data: { constantName: 'QUICK_INPUT_WIDGET', importPath: '@salesforcedx/playwright-vscode-ext/utils/locators' }
         }
       ],
-      output: `import { QUICK_INPUT_WIDGET } from '@salesforcedx/vscode-playwright/utils/locators';
+      output: `import { QUICK_INPUT_WIDGET } from '@salesforcedx/playwright-vscode-ext/utils/locators';
 page.locator(QUICK_INPUT_WIDGET);`
     },
     {
@@ -115,11 +115,11 @@ page.locator('.monaco-editor');`,
       errors: [
         {
           messageId: 'useConstant',
-          data: { constantName: 'EDITOR', importPath: '@salesforcedx/vscode-playwright/utils/locators' }
+          data: { constantName: 'EDITOR', importPath: '@salesforcedx/playwright-vscode-ext/utils/locators' }
         }
       ],
       output: `import { someOther } from './other';
-import { EDITOR } from '@salesforcedx/vscode-playwright/utils/locators';
+import { EDITOR } from '@salesforcedx/playwright-vscode-ext/utils/locators';
 page.locator(EDITOR);`
     },
     {
@@ -129,10 +129,10 @@ const x = 1;`,
       errors: [
         {
           messageId: 'useConstant',
-          data: { constantName: 'EDITOR', importPath: '@salesforcedx/vscode-playwright/utils/locators' }
+          data: { constantName: 'EDITOR', importPath: '@salesforcedx/playwright-vscode-ext/utils/locators' }
         }
       ],
-      output: `import { EDITOR } from '@salesforcedx/vscode-playwright/utils/locators';
+      output: `import { EDITOR } from '@salesforcedx/playwright-vscode-ext/utils/locators';
 page.locator(EDITOR);
 const x = 1;`
     },
@@ -155,10 +155,10 @@ page.locator(EDITOR);`
       errors: [
         {
           messageId: 'useConstant',
-          data: { constantName: 'EDITOR', importPath: '@salesforcedx/vscode-playwright/utils/locators' }
+          data: { constantName: 'EDITOR', importPath: '@salesforcedx/playwright-vscode-ext/utils/locators' }
         }
       ],
-      output: `import { EDITOR } from '@salesforcedx/vscode-playwright/utils/locators';
+      output: `import { EDITOR } from '@salesforcedx/playwright-vscode-ext/utils/locators';
 page.locator(\`\${EDITOR}[data-uri*="package.xml"]\`);`
     }
   ]

--- a/packages/eslint-local-rules/test/no-duplicate-playwright-locators.test.ts
+++ b/packages/eslint-local-rules/test/no-duplicate-playwright-locators.test.ts
@@ -141,12 +141,11 @@ const x = 1;`
       filename: testFile('packages/playwright-vscode-ext/src/pages/test.ts'),
       errors: [
         {
-          messageId: 'useConstant'
-          // Don't check importPath - it varies based on test environment path resolution
+          messageId: 'useConstant',
+          data: { constantName: 'EDITOR', importPath: '@salesforcedx/playwright-vscode-ext/utils/locators' }
         }
       ],
-      // Output path varies based on test environment - verify it imports EDITOR and replaces the string
-      output: `import { EDITOR } from '../../../../playwright-vscode-ext/src/utils/locators';
+      output: `import { EDITOR } from '@salesforcedx/playwright-vscode-ext/utils/locators';
 page.locator(EDITOR);`
     },
     {

--- a/packages/eslint-local-rules/test/no-duplicate-playwright-locators.test.ts
+++ b/packages/eslint-local-rules/test/no-duplicate-playwright-locators.test.ts
@@ -23,7 +23,7 @@ ruleTester.run('no-duplicate-playwright-locators', noDuplicatePlaywrightLocators
       filename: testFile('packages/test-package/test/playwright/test.spec.ts')
     },
     {
-      code: `import { EDITOR } from '@salesforcedx/playwright-vscode-ext/utils/locators';
+      code: `import { EDITOR } from '@salesforce/playwright-vscode-ext';
 page.locator(EDITOR);`,
       filename: testFile('packages/test-package/test/playwright/test.spec.ts')
     },
@@ -53,10 +53,10 @@ page.locator(selector);`,
       errors: [
         {
           messageId: 'useConstant',
-          data: { constantName: 'EDITOR', importPath: '@salesforcedx/playwright-vscode-ext/utils/locators' }
+          data: { constantName: 'EDITOR', importPath: '@salesforce/playwright-vscode-ext' }
         }
       ],
-      output: `import { EDITOR } from '@salesforcedx/playwright-vscode-ext/utils/locators';
+      output: `import { EDITOR } from '@salesforce/playwright-vscode-ext';
 page.locator(EDITOR);`
     },
     {
@@ -65,23 +65,23 @@ page.locator(EDITOR);`
       errors: [
         {
           messageId: 'useConstant',
-          data: { constantName: 'WORKBENCH', importPath: '@salesforcedx/playwright-vscode-ext/utils/locators' }
+          data: { constantName: 'WORKBENCH', importPath: '@salesforce/playwright-vscode-ext' }
         }
       ],
-      output: `import { WORKBENCH } from '@salesforcedx/playwright-vscode-ext/utils/locators';
+      output: `import { WORKBENCH } from '@salesforce/playwright-vscode-ext';
 page.locator(WORKBENCH);`
     },
     {
-      code: `import { EDITOR } from '@salesforcedx/playwright-vscode-ext/utils/locators';
+      code: `import { EDITOR } from '@salesforce/playwright-vscode-ext';
 page.locator('.monaco-workbench');`,
       filename: testFile('packages/test-package/test/playwright/test.spec.ts'),
       errors: [
         {
           messageId: 'useConstant',
-          data: { constantName: 'WORKBENCH', importPath: '@salesforcedx/playwright-vscode-ext/utils/locators' }
+          data: { constantName: 'WORKBENCH', importPath: '@salesforce/playwright-vscode-ext' }
         }
       ],
-      output: `import { EDITOR, WORKBENCH } from '@salesforcedx/playwright-vscode-ext/utils/locators';
+      output: `import { EDITOR, WORKBENCH } from '@salesforce/playwright-vscode-ext';
 page.locator(WORKBENCH);`
     },
     {
@@ -90,10 +90,10 @@ page.locator(WORKBENCH);`
       errors: [
         {
           messageId: 'useConstant',
-          data: { constantName: 'TAB', importPath: '@salesforcedx/playwright-vscode-ext/utils/locators' }
+          data: { constantName: 'TAB', importPath: '@salesforce/playwright-vscode-ext' }
         }
       ],
-      output: `import { TAB } from '@salesforcedx/playwright-vscode-ext/utils/locators';
+      output: `import { TAB } from '@salesforce/playwright-vscode-ext';
 page.locator(TAB);`
     },
     {
@@ -102,10 +102,10 @@ page.locator(TAB);`
       errors: [
         {
           messageId: 'useConstant',
-          data: { constantName: 'QUICK_INPUT_WIDGET', importPath: '@salesforcedx/playwright-vscode-ext/utils/locators' }
+          data: { constantName: 'QUICK_INPUT_WIDGET', importPath: '@salesforce/playwright-vscode-ext' }
         }
       ],
-      output: `import { QUICK_INPUT_WIDGET } from '@salesforcedx/playwright-vscode-ext/utils/locators';
+      output: `import { QUICK_INPUT_WIDGET } from '@salesforce/playwright-vscode-ext';
 page.locator(QUICK_INPUT_WIDGET);`
     },
     {
@@ -115,11 +115,11 @@ page.locator('.monaco-editor');`,
       errors: [
         {
           messageId: 'useConstant',
-          data: { constantName: 'EDITOR', importPath: '@salesforcedx/playwright-vscode-ext/utils/locators' }
+          data: { constantName: 'EDITOR', importPath: '@salesforce/playwright-vscode-ext' }
         }
       ],
       output: `import { someOther } from './other';
-import { EDITOR } from '@salesforcedx/playwright-vscode-ext/utils/locators';
+import { EDITOR } from '@salesforce/playwright-vscode-ext';
 page.locator(EDITOR);`
     },
     {
@@ -129,10 +129,10 @@ const x = 1;`,
       errors: [
         {
           messageId: 'useConstant',
-          data: { constantName: 'EDITOR', importPath: '@salesforcedx/playwright-vscode-ext/utils/locators' }
+          data: { constantName: 'EDITOR', importPath: '@salesforce/playwright-vscode-ext' }
         }
       ],
-      output: `import { EDITOR } from '@salesforcedx/playwright-vscode-ext/utils/locators';
+      output: `import { EDITOR } from '@salesforce/playwright-vscode-ext';
 page.locator(EDITOR);
 const x = 1;`
     },
@@ -142,10 +142,10 @@ const x = 1;`
       errors: [
         {
           messageId: 'useConstant',
-          data: { constantName: 'EDITOR', importPath: '@salesforcedx/playwright-vscode-ext/utils/locators' }
+          data: { constantName: 'EDITOR', importPath: '@salesforce/playwright-vscode-ext' }
         }
       ],
-      output: `import { EDITOR } from '@salesforcedx/playwright-vscode-ext/utils/locators';
+      output: `import { EDITOR } from '@salesforce/playwright-vscode-ext';
 page.locator(EDITOR);`
     },
     {
@@ -154,10 +154,10 @@ page.locator(EDITOR);`
       errors: [
         {
           messageId: 'useConstant',
-          data: { constantName: 'EDITOR', importPath: '@salesforcedx/playwright-vscode-ext/utils/locators' }
+          data: { constantName: 'EDITOR', importPath: '@salesforce/playwright-vscode-ext' }
         }
       ],
-      output: `import { EDITOR } from '@salesforcedx/playwright-vscode-ext/utils/locators';
+      output: `import { EDITOR } from '@salesforce/playwright-vscode-ext';
 page.locator(\`\${EDITOR}[data-uri*="package.xml"]\`);`
     }
   ]

--- a/packages/playwright-vscode-ext/LICENSE.txt
+++ b/packages/playwright-vscode-ext/LICENSE.txt
@@ -1,0 +1,27 @@
+Copyright (c) 2026 Salesforce, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of Salesforce nor the names of its contributors may be
+used to endorse or promote products derived from this software without specific
+prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY SALESFORCE AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL SALESFORCE OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/playwright-vscode-ext/README.md
+++ b/packages/playwright-vscode-ext/README.md
@@ -1,17 +1,45 @@
-# Salesforce DX VS Code Playwright Utilities
+# @salesforce/playwright-vscode-ext
 
-Shared Playwright utilities for Salesforce DX VS Code extension testing.
+Shared [Playwright](https://playwright.dev/) utilities, fixtures, and page objects for end-to-end testing of Salesforce DX VS Code extensions.
 
-This package contains shared utilities, page objects, and fixtures used across multiple Salesforce DX VS Code extensions for end-to-end testing with Playwright.
+This package provides reusable building blocks for authoring Playwright tests against VS Code (both desktop and web/headless), including:
+
+- VS Code launch fixtures for desktop and web/headless flavors
+- Page objects for common VS Code UI surfaces (command palette, notifications, editors, sidebars)
+- Helpers for managing scratch orgs and project workspaces in tests
+- Utilities for working with VS Code APIs from Playwright
+
+## Installation
+
+```bash
+npm install --save-dev @salesforce/playwright-vscode-ext @playwright/test
+```
+
+If you use the desktop fixtures (which create or reuse Salesforce scratch orgs), also install `@salesforce/core`:
+
+```bash
+npm install --save-dev @salesforce/core
+```
+
+`@salesforce/core` is declared as an optional peer dependency. Tests that only use the web/headless fixtures or the type-only exports do not need it.
 
 ## Usage
 
-This package is not intended for direct use. It provides shared utilities for other Salesforce DX VS Code extension packages.
+```typescript
+import { test, expect } from '@salesforce/playwright-vscode-ext';
 
-## Contributing
+test('opens the command palette', async ({ vscodePage }) => {
+  await vscodePage.commandPalette.run('Developer: Reload Window');
+  await expect(vscodePage.workbench.title).toBeVisible();
+});
+```
 
-Please see the [contributing guide](../../CONTRIBUTING.md) for details on how to contribute to this project.
+See the [package source](https://github.com/forcedotcom/salesforcedx-vscode/tree/develop/packages/playwright-vscode-ext) for the full set of exports and example configurations.
+
+## Repository
+
+This package is developed in the [salesforcedx-vscode](https://github.com/forcedotcom/salesforcedx-vscode) monorepo. File issues and feature requests at <https://github.com/forcedotcom/salesforcedx-vscode/issues>.
 
 ## License
 
-[BSD 3-Clause License](../../LICENSE.txt)
+[BSD 3-Clause License](./LICENSE.txt)

--- a/packages/playwright-vscode-ext/README.md
+++ b/packages/playwright-vscode-ext/README.md
@@ -15,13 +15,7 @@ This package provides reusable building blocks for authoring Playwright tests ag
 npm install --save-dev @salesforce/playwright-vscode-ext @playwright/test
 ```
 
-If you use the desktop fixtures (which create or reuse Salesforce scratch orgs), also install `@salesforce/core`:
-
-```bash
-npm install --save-dev @salesforce/core
-```
-
-`@salesforce/core` is declared as an optional peer dependency. Tests that only use the web/headless fixtures or the type-only exports do not need it.
+If you use the desktop fixtures or settings APIs (which work with Salesforce scratch orgs), you will need `@salesforce/core` types to resolve. Consumers using only web/headless fixtures or type-only exports do not need it; others should ensure `@salesforce/core` is installed in their project (as a dependency or dev dependency).
 
 ## Usage
 

--- a/packages/playwright-vscode-ext/README.md
+++ b/packages/playwright-vscode-ext/README.md
@@ -25,16 +25,25 @@ npm install --save-dev @salesforce/core
 
 ## Usage
 
-```typescript
-import { test, expect } from '@salesforce/playwright-vscode-ext';
+The package exports factories and helpers that compose with `@playwright/test`. For example, build a desktop test suite by combining the `createDesktopTest` factory with helpers and locators:
 
-test('opens the command palette', async ({ vscodePage }) => {
-  await vscodePage.commandPalette.run('Developer: Reload Window');
-  await expect(vscodePage.workbench.title).toBeVisible();
+```typescript
+import { expect } from '@playwright/test';
+import { createDesktopTest, openCommandPalette, WORKBENCH } from '@salesforce/playwright-vscode-ext';
+
+const test = createDesktopTest({
+  extensionDirs: ['salesforcedx-vscode-core']
+});
+
+test('opens the command palette', async ({ vscodeApp }) => {
+  await openCommandPalette(vscodeApp);
+  await expect(vscodeApp.locator(WORKBENCH)).toBeVisible();
 });
 ```
 
-See the [package source](https://github.com/forcedotcom/salesforcedx-vscode/tree/develop/packages/playwright-vscode-ext) for the full set of exports and example configurations.
+See the [package source](https://github.com/forcedotcom/salesforcedx-vscode/tree/develop/packages/playwright-vscode-ext) for the full set of exports, web/headless config factories (`createWebConfig`, `createHeadlessServer`), and example configurations.
+
+> Note: the desktop test factory (`createDesktopTest`) currently assumes a monorepo layout where extension VSIX paths are resolved relative to a repo root containing `packages/`. It is primarily intended for use inside the `salesforcedx-vscode` monorepo; external consumers should use the web/headless and helper exports.
 
 ## Repository
 

--- a/packages/playwright-vscode-ext/package.json
+++ b/packages/playwright-vscode-ext/package.json
@@ -13,8 +13,8 @@
     "url": "https://github.com/forcedotcom/salesforcedx-vscode/issues"
   },
   "homepage": "https://github.com/forcedotcom/salesforcedx-vscode/tree/develop/packages/playwright-vscode-ext",
-  "main": "./out/index.js",
-  "types": "./out/index.d.ts",
+  "main": "out/index.js",
+  "types": "out/index.d.ts",
   "exports": {
     ".": {
       "types": "./out/index.d.ts",
@@ -26,28 +26,16 @@
     "out/**/*.js.map",
     "out/**/*.d.ts",
     "out/**/*.d.ts.map",
-    "CHANGELOG.md",
     "LICENSE.txt",
     "README.md"
   ],
   "publishConfig": {
     "access": "public"
   },
-  "engines": {
-    "vscode": "^1.90.0"
-  },
   "dependencies": {
     "@playwright/test": "^1.57.0",
     "@vscode/test-electron": "2.5.2",
     "@vscode/test-web": "^0.0.78"
-  },
-  "peerDependencies": {
-    "@salesforce/core": "^8.31.0"
-  },
-  "peerDependenciesMeta": {
-    "@salesforce/core": {
-      "optional": true
-    }
   },
   "devDependencies": {
     "@salesforce/core": "^8.31.0"

--- a/packages/playwright-vscode-ext/package.json
+++ b/packages/playwright-vscode-ext/package.json
@@ -26,6 +26,7 @@
     "out/**/*.js.map",
     "out/**/*.d.ts",
     "out/**/*.d.ts.map",
+    "CHANGELOG.md",
     "LICENSE.txt",
     "README.md"
   ],

--- a/packages/playwright-vscode-ext/package.json
+++ b/packages/playwright-vscode-ext/package.json
@@ -1,8 +1,37 @@
 {
   "name": "@salesforce/playwright-vscode-ext",
-  "version": "65.7.0",
-  "private": true,
-  "main": "./out/src/index.js",
+  "version": "1.0.0",
+  "versionedIndependently": true,
+  "description": "Shared Playwright utilities, fixtures, and page objects for end-to-end testing of Salesforce DX VS Code extensions.",
+  "author": "Salesforce",
+  "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/forcedotcom/salesforcedx-vscode"
+  },
+  "bugs": {
+    "url": "https://github.com/forcedotcom/salesforcedx-vscode/issues"
+  },
+  "homepage": "https://github.com/forcedotcom/salesforcedx-vscode/tree/develop/packages/playwright-vscode-ext",
+  "main": "./out/index.js",
+  "types": "./out/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./out/index.d.ts",
+      "default": "./out/index.js"
+    }
+  },
+  "files": [
+    "out/**/*.js",
+    "out/**/*.js.map",
+    "out/**/*.d.ts",
+    "out/**/*.d.ts.map",
+    "LICENSE.txt",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "vscode": "^1.90.0"
   },
@@ -10,6 +39,14 @@
     "@playwright/test": "^1.57.0",
     "@vscode/test-electron": "2.5.2",
     "@vscode/test-web": "^0.0.78"
+  },
+  "peerDependencies": {
+    "@salesforce/core": "^8.31.0"
+  },
+  "peerDependenciesMeta": {
+    "@salesforce/core": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@salesforce/core": "^8.31.0"
@@ -30,7 +67,6 @@
       "clean": "if-file-deleted",
       "files": [
         "src/**/*.ts",
-        "test/**/*.ts",
         "tsconfig.json",
         "../../tsconfig.common.json",
         "package.json"

--- a/packages/playwright-vscode-ext/scripts/playwright-vscode-ext-version-hook.js
+++ b/packages/playwright-vscode-ext/scripts/playwright-vscode-ext-version-hook.js
@@ -14,13 +14,7 @@ exports.preVersionGeneration = proposedVersion => {
     return proposedVersion;
   }
   const { version } = require('../package.json');
-  // Strip any prerelease/build suffix (e.g. `1.0.0-beta` -> `1.0.0`) before bumping.
-  const core = version.split(/[-+]/)[0];
-  const parts = core.split('.').map(Number);
-  if (parts.length !== 3 || parts.some(Number.isNaN)) {
-    throw new Error(`Cannot parse semver core from version "${version}"`);
-  }
-  const [major, minor, patch] = parts;
+  const [major, minor, patch] = version.split('.').map(Number);
   if (releaseType === 'major') return `${major + 1}.0.0`;
   if (releaseType === 'minor') return `${major}.${minor + 1}.0`;
   return `${major}.${minor}.${patch + 1}`;

--- a/packages/playwright-vscode-ext/scripts/playwright-vscode-ext-version-hook.js
+++ b/packages/playwright-vscode-ext/scripts/playwright-vscode-ext-version-hook.js
@@ -14,7 +14,13 @@ exports.preVersionGeneration = proposedVersion => {
     return proposedVersion;
   }
   const { version } = require('../package.json');
-  const [major, minor, patch] = version.split('.').map(Number);
+  // Strip any prerelease/build suffix (e.g. `1.0.0-beta` -> `1.0.0`) before bumping.
+  const core = version.split(/[-+]/)[0];
+  const parts = core.split('.').map(Number);
+  if (parts.length !== 3 || parts.some(Number.isNaN)) {
+    throw new Error(`Cannot parse semver core from version "${version}"`);
+  }
+  const [major, minor, patch] = parts;
   if (releaseType === 'major') return `${major + 1}.0.0`;
   if (releaseType === 'minor') return `${major}.${minor + 1}.0`;
   return `${major}.${minor}.${patch + 1}`;

--- a/packages/playwright-vscode-ext/scripts/playwright-vscode-ext-version-hook.js
+++ b/packages/playwright-vscode-ext/scripts/playwright-vscode-ext-version-hook.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * pre-changelog-generation hook for TriPSs/conventional-changelog-action.
+ * When RELEASE_TYPE env var is set (from workflow_dispatch input), override
+ * the version bump type instead of relying solely on conventional commits.
+ */
+exports.preVersionGeneration = proposedVersion => {
+  const releaseType = process.env.RELEASE_TYPE;
+  if (!releaseType || !['major', 'minor', 'patch'].includes(releaseType)) {
+    return proposedVersion;
+  }
+  const { version } = require('../package.json');
+  const [major, minor, patch] = version.split('.').map(Number);
+  if (releaseType === 'major') return `${major + 1}.0.0`;
+  if (releaseType === 'minor') return `${major}.${minor + 1}.0`;
+  return `${major}.${minor}.${patch + 1}`;
+};
+
+/**
+ * pre-commit hook for TriPSs/conventional-changelog-action.
+ * Patches the playwright-vscode-ext version in the root package-lock.json so it stays
+ * in sync with the bumped packages/playwright-vscode-ext/package.json.
+ */
+exports.preCommit = ({ version }) => {
+  const lockPath = path.join(process.env.GITHUB_WORKSPACE, 'package-lock.json');
+  const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+  if (lock.packages?.['packages/playwright-vscode-ext']) {
+    lock.packages['packages/playwright-vscode-ext'].version = version;
+  }
+  fs.writeFileSync(lockPath, JSON.stringify(lock, null, 2) + '\n');
+};

--- a/packages/playwright-vscode-ext/src/fixtures/desktopWorkspace.ts
+++ b/packages/playwright-vscode-ext/src/fixtures/desktopWorkspace.ts
@@ -5,10 +5,12 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Global } from '@salesforce/core/global';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
+
+/** Salesforce CLI state folder name. Mirrors `Global.SF_STATE_FOLDER` from `@salesforce/core` without taking it as a runtime dep. */
+const SF_STATE_FOLDER = '.sf';
 
 /** Create a temporary empty workspace directory (no sfdx-project.json) for desktop tests */
 export const createEmptyTestWorkspace = async (): Promise<string> =>
@@ -37,12 +39,12 @@ export const createTestWorkspace = async (orgAlias?: string): Promise<string> =>
       )
     ),
     fs.mkdir(path.join(workspaceDir, 'force-app', 'main', 'default'), { recursive: true }),
-    fs.mkdir(path.join(workspaceDir, Global.SF_STATE_FOLDER), { recursive: true })
+    fs.mkdir(path.join(workspaceDir, SF_STATE_FOLDER), { recursive: true })
   ]);
 
   if (orgAlias !== undefined) {
     await fs.writeFile(
-      path.join(workspaceDir, Global.SF_STATE_FOLDER, 'config.json'),
+      path.join(workspaceDir, SF_STATE_FOLDER, 'config.json'),
       JSON.stringify(
         {
           'target-org': orgAlias

--- a/packages/playwright-vscode-ext/tsconfig.json
+++ b/packages/playwright-vscode-ext/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.common.json",
   "compilerOptions": {
-    "rootDir": ".",
+    "rootDir": "src",
     "outDir": "out"
   },
   "include": ["src/**/*.ts"]


### PR DESCRIPTION
## Summary

- Publishes `@salesforce/playwright-vscode-ext` to npm at `1.0.0`
- Configured package.json for npm (removed private, added publishConfig, exports, files)
- Added automated publish workflow on push to develop (paths-filtered)

## Plan

https://github.com/forcedotcom/salesforcedx-vscode/blob/.claude/plans/W-22846720.md

## Reviewer notes

- **High severity**: `createDesktopTest` + `resolveRepoRoot` only work inside the monorepo (walk up looking for `packages/`, then read VSIX paths from `<repoRoot>/packages/<dir>/package.json`). External npm consumers calling the desktop factory will throw `Could not find repo root` or mis-resolve paths. README now flags it as monorepo-internal, but the desktop factory remains structurally not-reusable; a follow-up should either accept `repoRoot`/VSIX paths via options or move the factory to a separate, monorepo-only entry point.

## Test plan

- `npm install` clean from root — lockfile updated
- `npm run compile -w @salesforce/playwright-vscode-ext` — tsc emits to `out/` (not `out/src/`); `out/index.d.ts` and `out/index.js` exist
- Internal consumers still resolve: grep workspace for imports and confirm they type-check after rootDir change
- `cd packages/playwright-vscode-ext && npm pack --dry-run` — tarball includes `out/**`, LICENSE.txt, README.md; excludes `src/`, `test/`, `tsconfig.json`
- `node -e "require('./packages/playwright-vscode-ext/scripts/playwright-vscode-ext-version-hook.js')"` — loads without error
- Actual publish run on develop merge — first push creates tag `playwright-vscode-ext-v1.0.0` + GH release + npm publish
- Fixed eslint `no-duplicate-playwright-locators` rule to reference new package name `@salesforcedx/playwright-vscode-ext`

### What issues does this PR fix or reference?

@W-22846720@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002bXikFYAS/view