### PR TITLE
feat(lwc): add check:circular-deps script to salesforcedx-vscode-lwc - W-22862561

### DIFF
--- a/.claude/plans/W-22862561.md
+++ b/.claude/plans/W-22862561.md
@@ -1,0 +1,49 @@
+# W-22862561 — Add check:circular-deps to salesforcedx-vscode-lwc
+
+## Context
+
+- One circular dep exists: `testRunner.ts` → `workspace/index.ts` → `getCliArgsFromJestArgs.ts` → `testRunner.ts` (via `TestRunType` type import)
+- Pattern: mirror `effect-ext-utils`/`salesforcedx-vscode-services` — wireit `check:circular-deps` task using `dpdm`, wired as `lint` dependency
+- `.circular-deps.json` already in root `.gitignore`
+
+### WI DoD alignment — "Wire into test/build deps"
+
+The WI DoD says "Wire into test/build deps" but the established monorepo pattern (both `effect-ext-utils` and `salesforcedx-vscode-services`) wires `check:circular-deps` **only into `lint.dependencies`** — not into `test` or `compile`. Reasons:
+
+1. **Circular wireit dependency**: `check:circular-deps` itself depends on `compile` (it runs `dpdm` on compiled output paths). Adding it as a `compile` dependency would create a wireit cycle.
+2. **Test already transitively covered**: `lint` runs in CI alongside `test`; both gate merge. Wiring into `test.dependencies` adds no gating value and slows the test task.
+3. **"build deps" = lint**: In this monorepo, the CI "build" matrix runs `lint` (which includes `check:circular-deps` via dependency) + `test` + `vscode:bundle`. The WI intent ("catch circular deps in CI") is satisfied by the lint wiring.
+
+Decision: follow the existing two-package precedent — wire into `lint.dependencies` only. This satisfies the WI DoD intent while avoiding a wireit cycle and unnecessary task-graph bloat.
+
+## Phases
+
+### Phase 1 — Break circular dependency
+
+- Move `TestRunType` from `src/testSupport/testRunner/testRunner.ts` to `src/testSupport/types/index.ts`
+- Update import in `testRunner.ts` to get `TestRunType` from `../types`
+- Update import in `workspace/getCliArgsFromJestArgs.ts` to get `TestRunType` from `../types` (not `../testRunner/testRunner`)
+
+**Commit:** `fix(lwc): break circular dep by moving TestRunType to shared types`
+
+### Phase 2 — Add check:circular-deps script
+
+- Add `"check:circular-deps": "wireit"` to `scripts` in `packages/salesforcedx-vscode-lwc/package.json`
+- Add wireit `check:circular-deps` entry (command: `dpdm --no-warning --no-tree --exit-code circular:1 -o .circular-deps.json src`, depends on `compile`, files: `src/**/*.ts`, `tsconfig.json`, `../../tsconfig.common.json`, output: `.circular-deps.json`)
+- Add `"check:circular-deps"` to `wireit.lint.dependencies` (matches `effect-ext-utils` and `salesforcedx-vscode-services` pattern)
+- Append `.circular-deps.json` to `clean` script
+
+**Commit:** `feat(lwc): add check:circular-deps wireit script`
+
+## Skills
+
+- wireit
+- packageJson
+- typescript
+
+## Verification
+
+- `npm run check:circular-deps -w packages/salesforcedx-vscode-lwc` exits 0
+- `npm run lint -w packages/salesforcedx-vscode-lwc` still passes (confirms check:circular-deps wired correctly into lint)
+- `npm run test -w packages/salesforcedx-vscode-lwc` still passes
+- Verify no wireit cycle: `npx wireit --dry-run` on lint task succeeds


### PR DESCRIPTION
## Summary

- Moves `TestRunType` from `testRunner.ts` to shared `src/testSupport/types/index.ts` to break an existing circular dependency
- Adds `check:circular-deps` wireit script to `salesforcedx-vscode-lwc` using `dpdm`, wired into `lint.dependencies` (matching the `effect-ext-utils` / `salesforcedx-vscode-services` pattern)
- `.circular-deps.json` output appended to `clean` script; already `.gitignore`d at root

## Plan

.claude/plans/W-22862561.md

## Test plan

- `npm run check:circular-deps -w packages/salesforcedx-vscode-lwc` exits 0
- `npm run lint -w packages/salesforcedx-vscode-lwc` passes (confirms wiring)
- `npm run test -w packages/salesforcedx-vscode-lwc` passes

### What issues does this PR fix or reference?

@W-22862561@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002bbK6qYAE/view