### PR TITLE
feat(playwright-vscode-ext): add check:circular-deps script - W-22862555

### DIFF
--- a/.claude/plans/W-22862555.md
+++ b/.claude/plans/W-22862555.md
@@ -1,0 +1,42 @@
+# W-22862555: Add check:circular-deps to playwright-vscode-ext
+
+## Context
+
+- `dpdm` already root devDep; no install needed
+- Mirror `salesforcedx-vscode-services` pattern: wireit script, dep of `lint`, output in `clean`
+- Package has ~27 source files across src/; cycles possible in pages/utils/fixtures
+
+## Phases
+
+### Phase 1: Add wireit check:circular-deps script
+
+- Add `"check:circular-deps": "wireit"` to `scripts`
+- Add wireit config block mirroring services pattern:
+  - command: `dpdm --no-warning --no-tree --exit-code circular:1 -o .circular-deps.json src`
+  - dependencies: `["compile"]`
+  - files: `["src/**/*.ts", "tsconfig.json", "../../tsconfig.common.json"]`
+  - output: `[".circular-deps.json"]`
+- Add `check:circular-deps` as dependency of `lint`
+- Append `.circular-deps.json` to `clean` script
+
+Commit: `feat(playwright-vscode-ext): add check:circular-deps wireit script - W-22862555`
+
+### Phase 2: Fix any circular dependencies (if found)
+
+- Run `npm run check:circular-deps -w packages/playwright-vscode-ext`
+- If cycles exist: reorganize imports, extract shared types, split files as needed
+- Re-run until exit 0
+
+Commit: `fix(playwright-vscode-ext): resolve circular dependencies - W-22862555`
+
+## Skills
+
+- wireit
+- packageJson
+- typescript
+
+## Verification
+
+- `npm run check:circular-deps -w packages/playwright-vscode-ext` exits 0 (not e2e-covered)
+- `npm run lint -w packages/playwright-vscode-ext` exits 0 (confirms wireit graph valid; not e2e-covered)
+- `npm run compile -w packages/playwright-vscode-ext` still passes (not e2e-covered)


### PR DESCRIPTION
## Summary

- Add `check:circular-deps` wireit script to `playwright-vscode-ext` package using `dpdm` (already a root devDep)
- Mirror the `salesforcedx-vscode-services` pattern: wireit script wired as a dependency of `lint`, output tracked in `clean`
- Fix any circular dependencies found during the run

## Plan

[.claude/plans/W-22862555.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-22862555-add-check-circular-deps-script-to-playwr/.claude/plans/W-22862555.md)

## Test plan

- `npm run check:circular-deps -w packages/playwright-vscode-ext` exits 0
- `npm run lint -w packages/playwright-vscode-ext` exits 0 (confirms wireit graph valid)
- `npm run compile -w packages/playwright-vscode-ext` still passes

### What issues does this PR fix or reference?
@W-22862555@

🤖 Generated by auto-build pipeline. Original WI: https://gus.salesforce.com/a07/a07EE00002bbBbPYAU