### PR TITLE
feat(playwright-vscode-ext): add check:circular-deps wireit script - W-22862555

### DIFF
--- a/.claude/plans/W-22862555.md
+++ b/.claude/plans/W-22862555.md
@@ -1,0 +1,45 @@
+# W-22862555 — Add check:circular-deps to playwright-vscode-ext
+
+## Context
+
+- `dpdm` already in root devDeps
+- Reference: `packages/salesforcedx-vscode-services/package.json` wireit config
+- Pattern: wireit task depends on `compile`, outputs `.circular-deps.json`, wired into `lint` deps
+- Target has no `test` wireit task to wire into; wire into `lint` deps like reference
+
+## Phases
+
+### Phase 1: Add check:circular-deps wireit script
+
+- Add `"check:circular-deps": "wireit"` to `scripts`
+- Add wireit block mirroring reference:
+  - command: `dpdm --no-warning --no-tree --exit-code circular:1 -o .circular-deps.json src`
+  - dependencies: `["compile"]`
+  - files: `["src/**/*.ts", "tsconfig.json", "../../tsconfig.common.json"]`
+  - output: `[".circular-deps.json"]`
+- Add `check:circular-deps` to `lint` wireit dependencies
+- Add `.circular-deps.json` to `clean` script
+
+Commit: `feat(playwright-vscode-ext): add check:circular-deps wireit script`
+
+### Phase 2: Fix any circular dependencies (if found)
+
+- Run `npm run check:circular-deps -w packages/playwright-vscode-ext`
+- If cycles found: reorganize imports/exports to break them
+- Re-run until exit 0
+
+Commit: `fix(playwright-vscode-ext): resolve circular dependencies`
+
+## Skills
+
+- wireit
+- packageJson
+- typescript
+
+## Verification
+
+- `npm run check:circular-deps -w packages/playwright-vscode-ext` exits 0 (manual/unit)
+- `npm run lint -w packages/playwright-vscode-ext` still passes (confirms wireit wiring) (manual/unit)
+- `.circular-deps.json` produced in package dir (manual/unit)
+
+None of these checks are e2e-covered.


### PR DESCRIPTION
## Summary

- Adds `check:circular-deps` wireit script to `playwright-vscode-ext` package using `dpdm`
- Wires the script into `lint` dependencies, mirroring the pattern from `salesforcedx-vscode-services`
- Adds `.circular-deps.json` output to `clean` script

## Plan

[.claude/plans/W-22862555.md](/.claude/plans/W-22862555.md)

## Test plan

- `npm run check:circular-deps -w packages/playwright-vscode-ext` exits 0
- `npm run lint -w packages/playwright-vscode-ext` still passes (confirms wireit wiring)
- `.circular-deps.json` produced in package dir

### What issues does this PR fix or reference?
@W-22862555@

🤖 Generated by auto-build pipeline. Original WI: https://gus.my.salesforce.com/a07EE00002bbBbPYAU