### PR TITLE
feat(playwright-vscode-ext): add check:circular-deps script - W-22862555

### DIFF
--- a/.claude/plans/W-22862555.md
+++ b/.claude/plans/W-22862555.md
@@ -1,0 +1,40 @@
+# W-22862555: Add check:circular-deps to playwright-vscode-ext
+
+## Context
+
+- `dpdm` already available at repo root (used by other packages)
+- Mirror `salesforcedx-vscode-services` pattern: wireit script, `compile` dep, `.circular-deps.json` output
+- `lint` should depend on `check:circular-deps`
+- `clean` script must remove `.circular-deps.json`
+
+## Phases
+
+### Phase 1: Add check:circular-deps wireit script + wire into lint/clean
+
+- Add `"check:circular-deps": "wireit"` to scripts
+- Add wireit config: command `dpdm --no-warning --no-tree --exit-code circular:1 -o .circular-deps.json src`, depends on `compile`, files `src/**/*.ts`, `tsconfig.json`, `../../tsconfig.common.json`, output `.circular-deps.json`
+- Add `check:circular-deps` to `lint` dependencies
+- Append `.circular-deps.json` removal to `clean` script
+- Run `npm run check:circular-deps -w packages/playwright-vscode-ext` to verify
+
+Commit: `feat(playwright-vscode-ext): add check:circular-deps wireit script - W-22862555`
+
+### Phase 2: Fix any circular dependencies (if surfaced)
+
+- If dpdm reports cycles, reorganize imports/exports to eliminate them
+- Re-run to confirm exit 0
+
+Commit: `fix(playwright-vscode-ext): eliminate circular dependencies - W-22862555`
+
+## Skills
+
+- wireit
+- packageJson
+- typescript
+
+## Verification
+
+- `npm run check:circular-deps -w packages/playwright-vscode-ext` exits 0
+- `npm run lint -w packages/playwright-vscode-ext` exits 0 (confirms wiring)
+- `npm run test:web -w packages/playwright-vscode-ext` exits 0 (local pre-PR step; confirms compile+e2e still pass)
+- e2e-covered: `packages/playwright-vscode-ext/test/playwright/specs/settings.headless.spec.ts` (imports from src exercise the dependency graph post-change; any circular breakage surfaces as compile/import failure in these specs)

--- a/packages/playwright-vscode-ext/package.json
+++ b/packages/playwright-vscode-ext/package.json
@@ -83,11 +83,11 @@
       "command": "eslint --color --cache --cache-location .eslintcache .",
       "dependencies": [
         "../eslint-local-rules:compile",
-        "check:circular-deps",
-        "compile"
+        "check:circular-deps"
       ],
       "files": [
         "src/**/*.ts",
+        "test/**/*.ts",
         "../../eslint.config.mjs"
       ],
       "output": []

--- a/packages/playwright-vscode-ext/package.json
+++ b/packages/playwright-vscode-ext/package.json
@@ -41,8 +41,9 @@
     "@salesforce/core": "^8.31.0"
   },
   "scripts": {
+    "check:circular-deps": "wireit",
     "compile": "wireit",
-    "clean": "shx rm -rf node_modules .wireit out .eslintcache tsconfig.tsbuildinfo",
+    "clean": "shx rm -rf node_modules .wireit out .eslintcache tsconfig.tsbuildinfo .circular-deps.json",
     "lint": "wireit",
     "test:web": "wireit",
     "test:web:ui": "DEBUG_MODE=1 npm run test:web -- --headed",
@@ -51,6 +52,20 @@
     "test:desktop:debug": "npm run test:desktop -- --debug"
   },
   "wireit": {
+    "check:circular-deps": {
+      "command": "dpdm --no-warning --no-tree --exit-code circular:1 -o .circular-deps.json src",
+      "dependencies": [
+        "compile"
+      ],
+      "files": [
+        "src/**/*.ts",
+        "tsconfig.json",
+        "../../tsconfig.common.json"
+      ],
+      "output": [
+        ".circular-deps.json"
+      ]
+    },
     "compile": {
       "command": "tsc --pretty",
       "clean": "if-file-deleted",
@@ -68,6 +83,7 @@
       "command": "eslint --color --cache --cache-location .eslintcache .",
       "dependencies": [
         "../eslint-local-rules:compile",
+        "check:circular-deps",
         "compile"
       ],
       "files": [

--- a/packages/playwright-vscode-ext/src/index.ts
+++ b/packages/playwright-vscode-ext/src/index.ts
@@ -26,7 +26,6 @@ export {
 
 export {
   removeAllDebugLevels,
-  disableMonacoAutoClosing,
   ensureSecondarySideBarHidden,
   waitForExtensionsActivated,
   closeWorkspaceToEmptyWindow,

--- a/packages/playwright-vscode-ext/src/index.ts
+++ b/packages/playwright-vscode-ext/src/index.ts
@@ -21,13 +21,17 @@ export {
   isDesktop,
   isMacDesktop,
   isWindowsDesktop,
-  validateNoCriticalErrors,
+  validateNoCriticalErrors
+} from './utils/helpers';
+
+export {
   removeAllDebugLevels,
+  disableMonacoAutoClosing,
   ensureSecondarySideBarHidden,
   waitForExtensionsActivated,
   closeWorkspaceToEmptyWindow,
   prepareNoFolderOpenForPaletteTests
-} from './utils/helpers';
+} from './utils/workflows';
 
 export { activeQuickInputWidget, activeQuickInputTextField } from './utils/quickInput';
 

--- a/packages/playwright-vscode-ext/src/utils/fileHelpers.ts
+++ b/packages/playwright-vscode-ext/src/utils/fileHelpers.ts
@@ -20,8 +20,6 @@ import { saveScreenshot } from '../shared/screenshotUtils';
 import {
   closeSettingsTab,
   closeWelcomeTabs,
-  disableMonacoAutoClosing,
-  ensureSecondarySideBarHidden,
   escapeRegExp,
   isDesktop,
   selectFirstQuickInputOption,
@@ -30,6 +28,7 @@ import {
 } from './helpers';
 import { DIRTY_EDITOR, EDITOR_WITH_URI, NOTIFICATION_LIST_ITEM, QUICK_INPUT_LIST_ROW, WORKBENCH } from './locators';
 import { activeQuickInputWidget } from './quickInput';
+import { disableMonacoAutoClosing, ensureSecondarySideBarHidden } from './workflows';
 
 /** Default timeout for deploy to complete (10 minutes, matches metadata deploy tests). */
 const DEFAULT_DEPLOY_COMPLETE_TIMEOUT_MS = 600_000;

--- a/packages/playwright-vscode-ext/src/utils/helpers.ts
+++ b/packages/playwright-vscode-ext/src/utils/helpers.ts
@@ -6,10 +6,7 @@
  */
 
 import { expect, type Page } from '@playwright/test';
-import { executeCommandWithCommandPalette } from '../pages/commands';
-import { upsertSettings } from '../pages/settings';
 import {
-  CODELENS_ITEM,
   QUICK_INPUT_LIST_ROW,
   QUICK_INPUT_WIDGET,
   SETTINGS_SEARCH_INPUT,
@@ -486,35 +483,6 @@ export const isMacDesktop = (): boolean => process.env.VSCODE_DESKTOP === '1' &&
 /** Returns true if running on Windows desktop (Electron) */
 export const isWindowsDesktop = (): boolean => process.env.VSCODE_DESKTOP === '1' && process.platform === 'win32';
 
-/**
- * Opens traceFlags.json and removes all debug levels via their Remove code lenses.
- * With no debug levels present, createTraceFlagForCurrentUser will auto-create
- * ReplayDebuggerLevels instead of showing the debug level picker.
- * Safe to call when no debug levels exist — the step is a no-op in that case.
- */
-export const removeAllDebugLevels = async (page: Page): Promise<void> => {
-  const removeLinks = page.locator(CODELENS_ITEM).filter({ hasText: /^Remove$/ });
-
-  await expect(async () => {
-    await executeCommandWithCommandPalette(page, 'SFDX: Open Trace Flags');
-    await expect(page.locator('.tab').filter({ hasText: /traceFlags\.json/ })).toBeVisible({ timeout: 10_000 });
-    // Wait for code lenses to render (attached is sufficient — they may be off-screen in web).
-    await expect(page.locator(CODELENS_ITEM).filter({ hasText: /Create Debug level/ })).toBeAttached({
-      timeout: 10_000
-    });
-
-    // This is only called when no trace flags are active, so all Remove lenses belong to
-    // debug levels — click the first one and re-iterate until none remain.
-    const link = removeLinks.first();
-    if (!(await link.isVisible({ timeout: 1000 }).catch(() => false))) return;
-    await link.scrollIntoViewIfNeeded();
-    const count = await removeLinks.count();
-    await link.click();
-    await expect(removeLinks).not.toHaveCount(count, { timeout: 10_000 });
-    throw new Error('removed one debug level, checking for more');
-  }).toPass({ timeout: 60_000 });
-};
-
 /** Validate no critical console or network errors occurred during test execution */
 export const validateNoCriticalErrors = async (
   test: { step: (name: string, fn: () => Promise<void>) => Promise<void> },
@@ -530,100 +498,4 @@ export const validateNoCriticalErrors = async (
     }
     await Promise.resolve(); // Satisfy require-await lint rule
   });
-};
-
-/**
- * Disable Monaco editor auto-closing features (brackets, quotes, etc.) to prevent duplicates during typing.
- * Uses VS Code settings API for cleaner, more maintainable approach.
- */
-export const disableMonacoAutoClosing = async (page: Page): Promise<void> => {
-  await upsertSettings(page, {
-    'editor.autoClosingBrackets': 'never',
-    'editor.autoClosingQuotes': 'never',
-    'editor.autoClosingOvertype': 'never'
-  });
-
-  // Close Settings tab so it doesn't interfere with subsequent operations
-  await closeSettingsTab(page);
-};
-
-/**
- * Wait for all VS Code extensions to finish activating by watching the
- * "Developer: Show Running Extensions" editor.  More reliable than polling
- * the command palette, especially on slow CI runners (e.g. Windows).
- *
- * While an extension is activating its row contains the text "Activating".
- * Once done the row shows "Activation: Xms" / "Startup Activation: Xms".
- * We wait until no rows contain "Activating" any more.
- *
- * @param timeout - Maximum ms to wait for all extensions to activate (default 120 000).
- */
-export const waitForExtensionsActivated = async (page: Page, timeout = 120_000): Promise<void> => {
-  await executeCommandWithCommandPalette(page, 'Developer: Show Running Extensions');
-
-  // The editor container gets class "runtime-extensions-editor" via createEditor()
-  const editor = page.locator('.runtime-extensions-editor');
-  await editor.waitFor({ state: 'visible', timeout: 15_000 });
-
-  // Wait for the list to populate (at least one row rendered)
-  const rows = editor.locator('.monaco-list-row');
-  await expect(rows).not.toHaveCount(0, { timeout: 30_000 });
-
-  // Wait until no row still contains "Activating" text
-  const stillActivating = rows.filter({ hasText: 'Activating' });
-  await expect(stillActivating).toHaveCount(0, { timeout });
-
-  // Close the Running Extensions tab via command palette (cross-platform, no hover needed)
-  const tab = page.getByRole('tab', { name: /Running Extensions/i });
-  await executeCommandWithCommandPalette(page, 'View: Close All Editors');
-  await tab.waitFor({ state: 'detached', timeout: 5000 }).catch(() => {});
-};
-
-/**
- * Ensure the secondary sidebar (auxiliary bar, typically used for Chat/Copilot) is hidden.
- * This is idempotent - only hides if currently visible, avoiding toggle state issues.
- * Useful to prevent keystrokes from going to chat input instead of editor.
- */
-export const ensureSecondarySideBarHidden = async (page: Page): Promise<void> => {
-  // VS Code's secondary sidebar is in the .part.auxiliarybar element
-  const auxiliaryBar = page.locator('.part.auxiliarybar');
-
-  await dismissWelcomeOnboardingOverlayIfPresent(page);
-
-  // Check if sidebar exists and is visible
-  // Use a short timeout to avoid hanging if it's not there
-  const isVisible = await auxiliaryBar.isVisible({ timeout: 1000 }).catch(() => false);
-
-  if (isVisible) {
-    // Focus workbench before opening palette (avoids F1/keystrokes going to auxiliary bar chat input)
-    await page.locator(WORKBENCH).click({ timeout: 5000, force: true });
-    // Use the explicit Hide command (not Toggle) to ensure we're hiding
-    await executeCommandWithCommandPalette(page, 'View: Hide Secondary Side Bar');
-
-    // Wait for it to actually hide
-    await auxiliaryBar.waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {
-      // Ignore error - may have been already hidden or command not available
-    });
-  }
-};
-
-/**
- * Runs `Workspaces: Close Workspace` so no folder is open (empty VS Code window).
- * Call after {@link waitForVSCodeWorkbench} / {@link closeWelcomeTabs} / {@link ensureSecondarySideBarHidden} if needed.
- */
-export const closeWorkspaceToEmptyWindow = async (page: Page): Promise<void> => {
-  await executeCommandWithCommandPalette(page, 'Workspaces: Close Workspace');
-  await waitForVSCodeWorkbench(page);
-};
-
-/**
- * From a desktop fixture that opened a workspace folder: prepare UI, then close the workspace so **no folder** is open.
- * Use when asserting palette commands with **no folder open**. Contrast: `createDesktopTest({ emptyWorkspace: true })` — a folder **is** open but has no `sfdx-project.json`.
- */
-export const prepareNoFolderOpenForPaletteTests = async (page: Page): Promise<void> => {
-  await waitForVSCodeWorkbench(page);
-  await closeWelcomeTabs(page);
-  await ensureSecondarySideBarHidden(page);
-  await closeWorkspaceToEmptyWindow(page);
-  await closeWelcomeTabs(page);
 };

--- a/packages/playwright-vscode-ext/src/utils/workflows.ts
+++ b/packages/playwright-vscode-ext/src/utils/workflows.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect, type Page } from '@playwright/test';
+import { executeCommandWithCommandPalette } from '../pages/commands';
+import { upsertSettings } from '../pages/settings';
+import {
+  closeSettingsTab,
+  closeWelcomeTabs,
+  dismissWelcomeOnboardingOverlayIfPresent,
+  waitForVSCodeWorkbench
+} from './helpers';
+import { CODELENS_ITEM, WORKBENCH } from './locators';
+
+/**
+ * Opens traceFlags.json and removes all debug levels via their Remove code lenses.
+ * With no debug levels present, createTraceFlagForCurrentUser will auto-create
+ * ReplayDebuggerLevels instead of showing the debug level picker.
+ * Safe to call when no debug levels exist — the step is a no-op in that case.
+ */
+export const removeAllDebugLevels = async (page: Page): Promise<void> => {
+  const removeLinks = page.locator(CODELENS_ITEM).filter({ hasText: /^Remove$/ });
+
+  await expect(async () => {
+    await executeCommandWithCommandPalette(page, 'SFDX: Open Trace Flags');
+    await expect(page.locator('.tab').filter({ hasText: /traceFlags\.json/ })).toBeVisible({ timeout: 10_000 });
+    // Wait for code lenses to render (attached is sufficient — they may be off-screen in web).
+    await expect(page.locator(CODELENS_ITEM).filter({ hasText: /Create Debug level/ })).toBeAttached({
+      timeout: 10_000
+    });
+
+    // This is only called when no trace flags are active, so all Remove lenses belong to
+    // debug levels — click the first one and re-iterate until none remain.
+    const link = removeLinks.first();
+    if (!(await link.isVisible({ timeout: 1000 }).catch(() => false))) return;
+    await link.scrollIntoViewIfNeeded();
+    const count = await removeLinks.count();
+    await link.click();
+    await expect(removeLinks).not.toHaveCount(count, { timeout: 10_000 });
+    throw new Error('removed one debug level, checking for more');
+  }).toPass({ timeout: 60_000 });
+};
+
+/**
+ * Disable Monaco editor auto-closing features (brackets, quotes, etc.) to prevent duplicates during typing.
+ * Uses VS Code settings API for cleaner, more maintainable approach.
+ */
+export const disableMonacoAutoClosing = async (page: Page): Promise<void> => {
+  await upsertSettings(page, {
+    'editor.autoClosingBrackets': 'never',
+    'editor.autoClosingQuotes': 'never',
+    'editor.autoClosingOvertype': 'never'
+  });
+
+  // Close Settings tab so it doesn't interfere with subsequent operations
+  await closeSettingsTab(page);
+};
+
+/**
+ * Wait for all VS Code extensions to finish activating by watching the
+ * "Developer: Show Running Extensions" editor.  More reliable than polling
+ * the command palette, especially on slow CI runners (e.g. Windows).
+ *
+ * While an extension is activating its row contains the text "Activating".
+ * Once done the row shows "Activation: Xms" / "Startup Activation: Xms".
+ * We wait until no rows contain "Activating" any more.
+ *
+ * @param timeout - Maximum ms to wait for all extensions to activate (default 120 000).
+ */
+export const waitForExtensionsActivated = async (page: Page, timeout = 120_000): Promise<void> => {
+  await executeCommandWithCommandPalette(page, 'Developer: Show Running Extensions');
+
+  // The editor container gets class "runtime-extensions-editor" via createEditor()
+  const editor = page.locator('.runtime-extensions-editor');
+  await editor.waitFor({ state: 'visible', timeout: 15_000 });
+
+  // Wait for the list to populate (at least one row rendered)
+  const rows = editor.locator('.monaco-list-row');
+  await expect(rows).not.toHaveCount(0, { timeout: 30_000 });
+
+  // Wait until no row still contains "Activating" text
+  const stillActivating = rows.filter({ hasText: 'Activating' });
+  await expect(stillActivating).toHaveCount(0, { timeout });
+
+  // Close the Running Extensions tab via command palette (cross-platform, no hover needed)
+  const tab = page.getByRole('tab', { name: /Running Extensions/i });
+  await executeCommandWithCommandPalette(page, 'View: Close All Editors');
+  await tab.waitFor({ state: 'detached', timeout: 5000 }).catch(() => {});
+};
+
+/**
+ * Ensure the secondary sidebar (auxiliary bar, typically used for Chat/Copilot) is hidden.
+ * This is idempotent - only hides if currently visible, avoiding toggle state issues.
+ * Useful to prevent keystrokes from going to chat input instead of editor.
+ */
+export const ensureSecondarySideBarHidden = async (page: Page): Promise<void> => {
+  // VS Code's secondary sidebar is in the .part.auxiliarybar element
+  const auxiliaryBar = page.locator('.part.auxiliarybar');
+
+  await dismissWelcomeOnboardingOverlayIfPresent(page);
+
+  // Check if sidebar exists and is visible
+  // Use a short timeout to avoid hanging if it's not there
+  const isVisible = await auxiliaryBar.isVisible({ timeout: 1000 }).catch(() => false);
+
+  if (isVisible) {
+    // Focus workbench before opening palette (avoids F1/keystrokes going to auxiliary bar chat input)
+    await page.locator(WORKBENCH).click({ timeout: 5000, force: true });
+    // Use the explicit Hide command (not Toggle) to ensure we're hiding
+    await executeCommandWithCommandPalette(page, 'View: Hide Secondary Side Bar');
+
+    // Wait for it to actually hide
+    await auxiliaryBar.waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {
+      // Ignore error - may have been already hidden or command not available
+    });
+  }
+};
+
+/**
+ * Runs `Workspaces: Close Workspace` so no folder is open (empty VS Code window).
+ * Call after {@link waitForVSCodeWorkbench} / {@link closeWelcomeTabs} / {@link ensureSecondarySideBarHidden} if needed.
+ */
+export const closeWorkspaceToEmptyWindow = async (page: Page): Promise<void> => {
+  await executeCommandWithCommandPalette(page, 'Workspaces: Close Workspace');
+  await waitForVSCodeWorkbench(page);
+};
+
+/**
+ * From a desktop fixture that opened a workspace folder: prepare UI, then close the workspace so **no folder** is open.
+ * Use when asserting palette commands with **no folder open**. Contrast: `createDesktopTest({ emptyWorkspace: true })` — a folder **is** open but has no `sfdx-project.json`.
+ */
+export const prepareNoFolderOpenForPaletteTests = async (page: Page): Promise<void> => {
+  await waitForVSCodeWorkbench(page);
+  await closeWelcomeTabs(page);
+  await ensureSecondarySideBarHidden(page);
+  await closeWorkspaceToEmptyWindow(page);
+  await closeWelcomeTabs(page);
+};

--- a/packages/playwright-vscode-ext/test/playwright/specs/commandPalette.headless.spec.ts
+++ b/packages/playwright-vscode-ext/test/playwright/specs/commandPalette.headless.spec.ts
@@ -7,13 +7,8 @@
 
 import { expect } from '@playwright/test';
 import { executeCommandWithCommandPalette, openCommandPalette } from '../../../src/pages/commands';
-import {
-  waitForVSCodeWorkbench,
-  closeWelcomeTabs,
-  isMacDesktop,
-  ensureSecondarySideBarHidden,
-  isDesktop
-} from '../../../src/utils/helpers';
+import { waitForVSCodeWorkbench, closeWelcomeTabs, isMacDesktop, isDesktop } from '../../../src/utils/helpers';
+import { ensureSecondarySideBarHidden } from '../../../src/utils/workflows';
 import { WORKBENCH } from '../../../src/utils/locators';
 import { activeQuickInputTextField, activeQuickInputWidget } from '../../../src/utils/quickInput';
 import { test } from '../fixtures/index';

--- a/packages/playwright-vscode-ext/test/playwright/specs/contextMenu.headless.spec.ts
+++ b/packages/playwright-vscode-ext/test/playwright/specs/contextMenu.headless.spec.ts
@@ -8,12 +8,8 @@
 import { expect } from '@playwright/test';
 import { executeEditorContextMenuCommand } from '../../../src/pages/contextMenu';
 import { createFileWithContents } from '../../../src/utils/fileHelpers';
-import {
-  waitForVSCodeWorkbench,
-  closeWelcomeTabs,
-  isMacDesktop,
-  ensureSecondarySideBarHidden
-} from '../../../src/utils/helpers';
+import { waitForVSCodeWorkbench, closeWelcomeTabs, isMacDesktop } from '../../../src/utils/helpers';
+import { ensureSecondarySideBarHidden } from '../../../src/utils/workflows';
 import { EDITOR_WITH_URI } from '../../../src/utils/locators';
 import { activeQuickInputTextField, activeQuickInputWidget } from '../../../src/utils/quickInput';
 import { test } from '../fixtures/index';

--- a/packages/playwright-vscode-ext/test/playwright/specs/fileOperations.headless.spec.ts
+++ b/packages/playwright-vscode-ext/test/playwright/specs/fileOperations.headless.spec.ts
@@ -7,12 +7,8 @@
 
 import { expect } from '@playwright/test';
 import { createFileWithContents } from '../../../src/utils/fileHelpers';
-import {
-  waitForVSCodeWorkbench,
-  closeWelcomeTabs,
-  waitForWorkspaceReady,
-  ensureSecondarySideBarHidden
-} from '../../../src/utils/helpers';
+import { waitForVSCodeWorkbench, closeWelcomeTabs, waitForWorkspaceReady } from '../../../src/utils/helpers';
+import { ensureSecondarySideBarHidden } from '../../../src/utils/workflows';
 import { EDITOR_WITH_URI, TAB } from '../../../src/utils/locators';
 import { test } from '../fixtures/index';
 

--- a/packages/playwright-vscode-ext/test/playwright/specs/helpers.headless.spec.ts
+++ b/packages/playwright-vscode-ext/test/playwright/specs/helpers.headless.spec.ts
@@ -6,12 +6,8 @@
  */
 
 import { expect } from '@playwright/test';
-import {
-  closeWelcomeTabs,
-  waitForWorkspaceReady,
-  waitForVSCodeWorkbench,
-  ensureSecondarySideBarHidden
-} from '../../../src/utils/helpers';
+import { closeWelcomeTabs, waitForWorkspaceReady, waitForVSCodeWorkbench } from '../../../src/utils/helpers';
+import { ensureSecondarySideBarHidden } from '../../../src/utils/workflows';
 import { WORKBENCH } from '../../../src/utils/locators';
 import { test } from '../fixtures/index';
 

--- a/packages/playwright-vscode-ext/test/playwright/specs/outputChannel.headless.spec.ts
+++ b/packages/playwright-vscode-ext/test/playwright/specs/outputChannel.headless.spec.ts
@@ -13,7 +13,8 @@ import {
   waitForOutputChannelText
 } from '../../../src/pages/outputChannel';
 import { saveScreenshot } from '../../../src/shared/screenshotUtils';
-import { waitForVSCodeWorkbench, closeWelcomeTabs, ensureSecondarySideBarHidden } from '../../../src/utils/helpers';
+import { waitForVSCodeWorkbench, closeWelcomeTabs } from '../../../src/utils/helpers';
+import { ensureSecondarySideBarHidden } from '../../../src/utils/workflows';
 import { EDITOR } from '../../../src/utils/locators';
 import { test } from '../fixtures/index';
 

--- a/packages/playwright-vscode-ext/test/playwright/specs/settings.headless.spec.ts
+++ b/packages/playwright-vscode-ext/test/playwright/specs/settings.headless.spec.ts
@@ -8,7 +8,8 @@
 import { expect } from '@playwright/test';
 import { openSettingsUI, upsertSettings } from '../../../src/pages/settings';
 import { saveScreenshot } from '../../../src/shared/screenshotUtils';
-import { waitForVSCodeWorkbench, closeWelcomeTabs, ensureSecondarySideBarHidden } from '../../../src/utils/helpers';
+import { waitForVSCodeWorkbench, closeWelcomeTabs } from '../../../src/utils/helpers';
+import { ensureSecondarySideBarHidden } from '../../../src/utils/workflows';
 import { SETTINGS_SEARCH_INPUT } from '../../../src/utils/locators';
 import { test } from '../fixtures/index';
 

--- a/packages/playwright-vscode-ext/test/playwright/specs/verifyCommandDoesNotExist.headless.spec.ts
+++ b/packages/playwright-vscode-ext/test/playwright/specs/verifyCommandDoesNotExist.headless.spec.ts
@@ -6,7 +6,8 @@
  */
 
 import { verifyCommandDoesNotExist } from '../../../src/pages/commands';
-import { waitForVSCodeWorkbench, closeWelcomeTabs, ensureSecondarySideBarHidden } from '../../../src/utils/helpers';
+import { waitForVSCodeWorkbench, closeWelcomeTabs } from '../../../src/utils/helpers';
+import { ensureSecondarySideBarHidden } from '../../../src/utils/workflows';
 import { test } from '../fixtures/index';
 
 test.describe('Command Palette', () => {


### PR DESCRIPTION
## Summary

- Adds `check:circular-deps` wireit script to `playwright-vscode-ext` using `dpdm`, mirroring the `salesforcedx-vscode-services` pattern
- Wires `check:circular-deps` as a dependency of `lint` and adds `.circular-deps.json` cleanup to the `clean` script
- Resolves the circular dependencies surfaced by the new script by reorganizing imports across `helpers`, `fileHelpers`, `workflows`, and the barrel index

## Plan

`.claude/plans/W-22862555.md`

## Test plan

- `npm run check:circular-deps -w packages/playwright-vscode-ext` exits 0
- `npm run lint -w packages/playwright-vscode-ext` exits 0 (confirms wiring)

### What issues does this PR fix or reference?

@W-22862555@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002bbBbPYAU/view