### PR TITLE
test(soql): add e2e coverage for Tooling API query path - W-22888084

### DIFF
--- a/.claude/plans/W-22888084.md
+++ b/.claude/plans/W-22888084.md
@@ -1,0 +1,37 @@
+# W-22888084: e2e SOQL run query via Tooling API
+
+## Context
+
+- Existing spec `packages/salesforcedx-vscode-soql/test/playwright/specs/soql-run-query.spec.ts` exercises REST API path exclusively
+- Quick pick shows "REST API" and "Tooling API" (from `queryUtils.ts` `API_ITEMS`)
+- `dataQuery.ts` routes `TOOLING` to `connection.tooling.query`
+- `ApexClass` is Tooling-only; querying it via REST would fail
+- Fixture uses `MINIMAL_ORG_ALIAS` — every org has ApexClass records
+
+## Phases
+
+### Phase 1: Add Tooling API e2e step
+
+**File:** `packages/salesforcedx-vscode-soql/test/playwright/specs/soql-run-query.spec.ts`
+
+- Add new `test.step` after "selected text" step (before `validateNoCriticalErrors`)
+- Clear output panel
+- Select all existing editor content (`Cmd+A` / `Control+A`) to replace the previous query
+- Type `SELECT Id, Name FROM ApexClass LIMIT 5` (overwrites selection), then save
+- Run via code lens "Run Query"
+- Select `/^Tooling API/` from quick pick (using `selectQuickInputOption`)
+- Assert `QUERY_COMPLETE_TEXT` in output channel (records returned)
+
+**Commit:** `test(soql): add e2e coverage for Tooling API query path - W-22888084`
+
+## Skills
+
+- playwright-e2e
+- typescript
+- concise
+
+## Verification
+
+- e2e-covered: Tooling API quick pick selection + query execution + records returned assertion
+  - Run locally: `npx playwright test packages/salesforcedx-vscode-soql/test/playwright/specs/soql-run-query.spec.ts --grep "Tooling API"` — must pass
+- Manual check: lint/typecheck pass (`npm run lint`, `tsc --noEmit` in soql package)

--- a/.claude/plans/W-22888084.md
+++ b/.claude/plans/W-22888084.md
@@ -5,7 +5,7 @@
 - Existing spec `packages/salesforcedx-vscode-soql/test/playwright/specs/soql-run-query.spec.ts` exercises REST API path exclusively
 - Quick pick shows "REST API" and "Tooling API" (from `queryUtils.ts` `API_ITEMS`)
 - `dataQuery.ts` routes `TOOLING` to `connection.tooling.query`
-- `ApexClass` is Tooling-only; querying it via REST would fail
+- `ApexClass` is queryable via both REST and Tooling API; used here to exercise the Tooling path
 - Fixture uses `MINIMAL_ORG_ALIAS` — every org has ApexClass records
 
 ## Phases

--- a/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-run-query.spec.ts
+++ b/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-run-query.spec.ts
@@ -159,5 +159,33 @@ test('SOQL Run Query: code lens, current file, selected text via command palette
     await saveScreenshot(page, 'step4.selected-text-query-output-verified.png');
   });
 
+  await test.step('run query via Tooling API', async () => {
+    const soqlTab = page.locator('[role="tab"]').filter({ hasText: `${SOQL_FILE}.soql` });
+    await soqlTab.click();
+
+    await selectOutputChannel(page, SOQL_CHANNEL);
+    await clearOutputChannel(page);
+
+    // Select all text and overwrite with a Tooling-only query (ApexClass is not available via REST)
+    const soqlEditor = page.locator(`${EDITOR}[data-uri$="${SOQL_FILE}.soql"]`);
+    await soqlEditor.locator('.view-line').first().click({ clickCount: 3 });
+    await page.keyboard.type('SELECT Id, Name FROM ApexClass LIMIT 5');
+    await executeCommandWithCommandPalette(page, 'File: Save');
+    await saveScreenshot(page, 'step5.tooling-query-saved.png');
+
+    const runQueryLens = page.getByRole('button', { name: 'Run Query' });
+    await expect(runQueryLens, '"Run Query" code lens should be visible').toBeVisible({ timeout: 15_000 });
+    await runQueryLens.click();
+
+    await selectQuickInputOption(page, /^Tooling API/, {
+      quickInputVisibleTimeout: 10_000,
+      optionVisibleTimeout: 10_000
+    });
+    await saveScreenshot(page, 'step5.tooling-api-selected.png');
+
+    await waitForOutputChannelText(page, { expectedText: QUERY_COMPLETE_TEXT, timeout: 30_000 });
+    await saveScreenshot(page, 'step5.tooling-query-output-verified.png');
+  });
+
   await validateNoCriticalErrors(test, consoleErrors, networkErrors);
 });

--- a/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-run-query.spec.ts
+++ b/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-run-query.spec.ts
@@ -166,9 +166,17 @@ test('SOQL Run Query: code lens, current file, selected text via command palette
     await selectOutputChannel(page, SOQL_CHANNEL);
     await clearOutputChannel(page);
 
-    // Select all text and overwrite with a Tooling-only query (ApexClass is not available via REST)
+    // Select all text and overwrite with a query to verify Tooling API execution
     const soqlEditor = page.locator(`${EDITOR}[data-uri$="${SOQL_FILE}.soql"]`);
     await soqlEditor.locator('.view-line').first().click({ clickCount: 3 });
+    await expect(
+      page
+        .locator('.statusbar-item')
+        .filter({ hasText: /\(\d+ selected\)/ })
+        .first()
+    ).toBeVisible({
+      timeout: 5000
+    });
     await page.keyboard.type('SELECT Id, Name FROM ApexClass LIMIT 5');
     await executeCommandWithCommandPalette(page, 'File: Save');
     await saveScreenshot(page, 'step5.tooling-query-saved.png');


### PR DESCRIPTION
## Summary

- Adds a new `test.step` in `soql-run-query.spec.ts` covering the Tooling API quick pick path
- Selects `Tooling API` from the query-type quick pick and asserts `QUERY_COMPLETE_TEXT` in the output channel
- Uses `ApexClass` (present in every org) so no fixture changes are needed

## Plan

[`.claude/plans/W-22888084.md`](.claude/plans/W-22888084.md)

## Test plan

Covered by new/modified e2e test:
- `packages/salesforcedx-vscode-soql/test/playwright/specs/soql-run-query.spec.ts` — Tooling API quick pick selection + query execution + records-returned assertion

### What issues does this PR fix or reference?
@W-22888084@

🤖 Generated by auto-build pipeline. Original WI: https://gus.my.salesforce.com/a07EE00002bhQAfYAM