### PR TITLE
feat(salesforcedx-vscode-metadata): add check:circular-deps script - W-22862559

### DIFF
--- a/.claude/plans/W-22862559.md
+++ b/.claude/plans/W-22862559.md
@@ -1,0 +1,38 @@
+# W-22862559: Add check:circular-deps to salesforcedx-vscode-metadata
+
+## Context
+
+- Package lacks `check:circular-deps` wireit script
+- Reference impl: `packages/salesforcedx-vscode-services/package.json`
+- dpdm already exits 0 (no cycles found) so only wiring needed
+- `clean` script needs `.circular-deps.json` added to rm list
+
+## Phases
+
+### Phase 1: Add check:circular-deps script and wire into lint
+
+- Add `"check:circular-deps": "wireit"` to `scripts`
+- Add wireit `check:circular-deps` config mirroring services package:
+  - command: `dpdm --no-warning --no-tree --exit-code circular:1 -o .circular-deps.json src`
+  - dependencies: `["compile"]`
+  - files: `["src/**/*.ts", "tsconfig.json", "../../tsconfig.common.json"]`
+  - output: `[".circular-deps.json"]`
+- Add `"check:circular-deps"` to `lint` wireit dependencies
+- Append `.circular-deps.json` to `clean` script rm list
+
+**Commit**: `feat(salesforcedx-vscode-metadata): add check:circular-deps script - W-22862559`
+
+**Files**:
+- `packages/salesforcedx-vscode-metadata/package.json`
+
+## Skills
+
+- wireit
+- packageJson
+- typescript
+
+## Verification
+
+- `npm run check:circular-deps -w packages/salesforcedx-vscode-metadata` exits 0 [manual/local-only]
+- `npm run lint -w packages/salesforcedx-vscode-metadata` still passes (lint depends on new script) [manual/local-only]
+- `.circular-deps.json` produced in package dir after run [manual/local-only]

--- a/packages/salesforcedx-vscode-metadata/package.json
+++ b/packages/salesforcedx-vscode-metadata/package.json
@@ -58,9 +58,10 @@
     "vscode:package": "wireit",
     "vscode:sha256": "node ../../scripts/generate-sha256.js >> ../../SHA256",
     "vscode:publish": "node ../../scripts/publish-vsix.js",
+    "check:circular-deps": "wireit",
     "compile": "wireit",
     "lint": "wireit",
-    "clean": "shx rm -rf node_modules out dist coverage .nyc_output .wireit .eslintcache *.vsix",
+    "clean": "shx rm -rf node_modules out dist coverage .nyc_output .wireit .eslintcache *.vsix .circular-deps.json",
     "test": "wireit",
     "test:compile": "wireit"
   },
@@ -134,10 +135,25 @@
         "coverage"
       ]
     },
+    "check:circular-deps": {
+      "command": "dpdm --no-warning --no-tree --exit-code circular:1 -o .circular-deps.json src",
+      "dependencies": [
+        "compile"
+      ],
+      "files": [
+        "src/**/*.ts",
+        "tsconfig.json",
+        "../../tsconfig.common.json"
+      ],
+      "output": [
+        ".circular-deps.json"
+      ]
+    },
     "lint": {
       "command": "eslint --color --cache --cache-location .eslintcache .",
       "dependencies": [
         "../eslint-local-rules:compile",
+        "check:circular-deps",
         "compile"
       ],
       "files": [


### PR DESCRIPTION
## Summary

- Adds `check:circular-deps` wireit script to `salesforcedx-vscode-metadata` package, mirroring the existing implementation in `salesforcedx-vscode-services`
- Wires `check:circular-deps` into the `lint` wireit dependency chain so circular dependency checks run as part of linting
- Appends `.circular-deps.json` to the `clean` script's rm list

## Plan

[.claude/plans/W-22862559.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-22862559-add-check-circular-deps-script-to-salesf/.claude/plans/W-22862559.md)

## Test plan

- `npm run check:circular-deps -w packages/salesforcedx-vscode-metadata` exits 0 [manual/local-only]
- `npm run lint -w packages/salesforcedx-vscode-metadata` still passes (lint depends on new script) [manual/local-only]
- `.circular-deps.json` produced in package dir after run [manual/local-only]

### What issues does this PR fix or reference?

@W-22862559@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002bbP1TYAU/view