### PR TITLE
test(soql): assert text-editor mode after SFDX: Create SOQL Query - W-22888087

### DIFF
--- a/.claude/plans/W-22888087.md
+++ b/.claude/plans/W-22888087.md
@@ -11,26 +11,35 @@
 
 ### 1. Add text-editor-mode assertion step to `soql-run-query.spec.ts`
 
-In `soql-run-query.spec.ts`, after the `.soql` tab is confirmed visible (line 66) and before clicking into the editor to type (line 70), add assertions that confirm text-editor mode:
+- Add assertions after `.soql` tab confirmed visible (line 66), before editor click (line 70)
+- Primary assertion: Monaco editor with the correct `data-uri` is visible for the `.soql` file (positive proof of text-editor mode)
+- Secondary assertion: no webview iframe inside the **active editor group** (scoped, not page-global)
 
 ```ts
-// Confirm text-editor mode: no webview iframe should be present (distinguishes from SOQL Builder)
-await expect(
-  page.locator('iframe.webview.ready'),
-  'no webview iframe — file opened in text editor, not SOQL Builder'
-).not.toBeAttached({ timeout: 5_000 });
-
-// Confirm Monaco editor is present for the .soql file
+// Confirm Monaco editor is present for the .soql file — this positively proves
+// text-editor mode (SOQL Builder renders a webview, not a Monaco editor)
 await expect(
   page.locator(`${EDITOR}[data-uri$="${SOQL_FILE}.soql"]`),
   'Monaco editor should be present for the .soql file'
 ).toBeVisible({ timeout: 5_000 });
+
+// Confirm no webview iframe in the active editor group. Scoped to
+// `.editor-group-container.active` to avoid false failures from unrelated
+// extension webviews (walkthrough panels, onboarding overlays) that may still
+// be attached elsewhere in the DOM after closeWelcomeTabs runs (tab close is
+// sync but iframe detach is async).
+await expect(
+  page.locator('.editor-group-container.active iframe.webview.ready'),
+  'no webview iframe in active editor group — file opened in text editor, not SOQL Builder'
+).not.toBeAttached({ timeout: 5_000 });
 ```
 
-Rationale for locator choices:
-- `iframe.webview.ready` is the exact selector used positively in `soql-builder.spec.ts:71`; its negative confirms text-editor mode.
-- `EDITOR` with `data-uri` suffix is already used in the same spec (line 130) for editor interactions.
-- The "editor focused" assertion is dropped: typing into the editor on line 71 already proves focus implicitly, and there is no stable standalone `toBeFocused()` assertion for Monaco's internal textarea routing.
+Rationale:
+- Monaco `data-uri` assertion is the **primary** signal: its presence definitively proves the file opened as a text editor, not a custom editor/webview. This alone is sufficient; the negative assertion is defense-in-depth.
+- Scoping to `.editor-group-container.active` ensures the negative assertion only checks the editor group where the `.soql` file lives, not the entire page. Other extensions (salesforcedx-vscode-core walkthrough, onboarding overlays) may have webview iframes attached in inactive groups or auxiliary panels — those are irrelevant to this test.
+- `iframe.webview.ready` — exact selector used positively in `soql-builder.spec.ts:71`; negative within the active group confirms text-editor mode.
+- `EDITOR` + `data-uri` suffix — already used at line 142 in same spec for the selected-text step.
+- "editor focused" assertion dropped — typing later in the step proves focus implicitly; no stable `toBeFocused()` for Monaco's internal textarea routing.
 
 **Files:**
 - `packages/salesforcedx-vscode-soql/test/playwright/specs/soql-run-query.spec.ts` (modify)
@@ -45,6 +54,7 @@ Rationale for locator choices:
 
 ## Verification
 
-- e2e-covered: text-editor mode confirmed (no webview iframe, Monaco editor present) in existing spec that already asserts command existence, file creation with `.soql` extension, and tab visibility
-- No new spec file needed; no duplication of existing assertions
-- Manual: confirm spec passes locally via `npm run test:web` and `npm run test:desktop` in `salesforcedx-vscode-soql`
+- e2e-covered: text-editor mode (Monaco editor present + no webview in active editor group) in existing spec — command existence, file creation, tab visibility already asserted
+- No new spec file; no duplication of existing assertions
+- Negative assertion scoped to active editor group — immune to false failures from unrelated extension webviews
+- Manual: run `npm run test:web` and `npm run test:desktop` in `salesforcedx-vscode-soql`

--- a/.claude/plans/W-22888087.md
+++ b/.claude/plans/W-22888087.md
@@ -1,0 +1,50 @@
+# W-22888087: e2e assert SFDX: Create SOQL Query command
+
+## Context
+
+- `soql.open.new.text.editor` (label `SFDX: Create SOQL Query`) already fully exercised as setup in `soql-run-query.spec.ts:48-68` and `soql-query-plan.spec.ts:48-68`: both call `verifyCommandExists`, execute the command, enter a filename, pick the default dir, and assert the `.soql` tab is visible.
+- A standalone spec re-proving the same flow is pure duplication cost.
+- The only assertion not present in those specs is confirming text-editor mode (no webview iframe), which distinguishes the text editor path from the SOQL Builder path (`soql-builder.spec.ts:71` uses `page.frameLocator('iframe.webview.ready')`).
+- Add this as a new `test.step` in the existing `soql-run-query.spec.ts` (between file creation and query typing) rather than a standalone file.
+
+## Phases
+
+### 1. Add text-editor-mode assertion step to `soql-run-query.spec.ts`
+
+In `soql-run-query.spec.ts`, after the `.soql` tab is confirmed visible (line 66) and before clicking into the editor to type (line 70), add assertions that confirm text-editor mode:
+
+```ts
+// Confirm text-editor mode: no webview iframe should be present (distinguishes from SOQL Builder)
+await expect(
+  page.locator('iframe.webview.ready'),
+  'no webview iframe — file opened in text editor, not SOQL Builder'
+).not.toBeAttached({ timeout: 5_000 });
+
+// Confirm Monaco editor is present for the .soql file
+await expect(
+  page.locator(`${EDITOR}[data-uri$="${SOQL_FILE}.soql"]`),
+  'Monaco editor should be present for the .soql file'
+).toBeVisible({ timeout: 5_000 });
+```
+
+Rationale for locator choices:
+- `iframe.webview.ready` is the exact selector used positively in `soql-builder.spec.ts:71`; its negative confirms text-editor mode.
+- `EDITOR` with `data-uri` suffix is already used in the same spec (line 130) for editor interactions.
+- The "editor focused" assertion is dropped: typing into the editor on line 71 already proves focus implicitly, and there is no stable standalone `toBeFocused()` assertion for Monaco's internal textarea routing.
+
+**Files:**
+- `packages/salesforcedx-vscode-soql/test/playwright/specs/soql-run-query.spec.ts` (modify)
+
+**Commit:** `test(soql): assert text-editor mode after SFDX: Create SOQL Query - W-22888087`
+
+## Skills
+
+- playwright-e2e
+- typescript
+- verification
+
+## Verification
+
+- e2e-covered: text-editor mode confirmed (no webview iframe, Monaco editor present) in existing spec that already asserts command existence, file creation with `.soql` extension, and tab visibility
+- No new spec file needed; no duplication of existing assertions
+- Manual: confirm spec passes locally via `npm run test:web` and `npm run test:desktop` in `salesforcedx-vscode-soql`

--- a/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-run-query.spec.ts
+++ b/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-run-query.spec.ts
@@ -66,6 +66,18 @@ test('SOQL Run Query: code lens, current file, selected text via command palette
     await expect(soqlTab, `${SOQL_FILE}.soql tab should be visible`).toBeVisible({ timeout: 20_000 });
     await saveScreenshot(page, 'step1.soql-tab-visible.png');
 
+    // Confirm text-editor mode: no webview iframe should be present (distinguishes from SOQL Builder)
+    await expect(
+      page.locator('iframe.webview.ready'),
+      'no webview iframe — file opened in text editor, not SOQL Builder'
+    ).not.toBeAttached({ timeout: 5000 });
+
+    // Confirm Monaco editor is present for the .soql file
+    await expect(
+      page.locator(`${EDITOR}[data-uri$="${SOQL_FILE}.soql"]`),
+      'Monaco editor should be present for the .soql file'
+    ).toBeVisible({ timeout: 5000 });
+
     // Type the query into the empty editor (file opens focused and ready for input)
     await page.locator(EDITOR).first().click();
     await page.keyboard.type(SOQL_QUERY);

--- a/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-run-query.spec.ts
+++ b/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-run-query.spec.ts
@@ -71,7 +71,7 @@ test('SOQL Run Query: code lens, current file, selected text via command palette
     await expect(
       page.locator(`${EDITOR}[data-uri$="${SOQL_FILE}.soql"]`),
       'Monaco editor should be present for the .soql file'
-    ).toBeVisible({ timeout: 5_000 });
+    ).toBeVisible({ timeout: 5000 });
 
     // Confirm no webview iframe in the active editor group. Scoped to
     // `.editor-group-container.active` to avoid false failures from unrelated
@@ -81,7 +81,7 @@ test('SOQL Run Query: code lens, current file, selected text via command palette
     await expect(
       page.locator('.editor-group-container.active iframe.webview.ready'),
       'no webview iframe in active editor group — file opened in text editor, not SOQL Builder'
-    ).not.toBeAttached({ timeout: 5_000 });
+    ).not.toBeAttached({ timeout: 5000 });
 
     // Type the query into the empty editor (file opens focused and ready for input)
     await page.locator(EDITOR).first().click();

--- a/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-run-query.spec.ts
+++ b/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-run-query.spec.ts
@@ -71,7 +71,7 @@ test('SOQL Run Query: code lens, current file, selected text via command palette
     await expect(
       page.locator(`${EDITOR}[data-uri$="${SOQL_FILE}.soql"]`),
       'Monaco editor should be present for the .soql file'
-    ).toBeVisible({ timeout: 5000 });
+    ).toBeVisible({ timeout: 5_000 });
 
     // Confirm no webview iframe in the active editor group. Scoped to
     // `.editor-group-container.active` to avoid false failures from unrelated
@@ -81,7 +81,7 @@ test('SOQL Run Query: code lens, current file, selected text via command palette
     await expect(
       page.locator('.editor-group-container.active iframe.webview.ready'),
       'no webview iframe in active editor group — file opened in text editor, not SOQL Builder'
-    ).not.toBeAttached({ timeout: 5000 });
+    ).not.toBeAttached({ timeout: 5_000 });
 
     // Type the query into the empty editor (file opens focused and ready for input)
     await page.locator(EDITOR).first().click();

--- a/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-run-query.spec.ts
+++ b/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-run-query.spec.ts
@@ -66,17 +66,22 @@ test('SOQL Run Query: code lens, current file, selected text via command palette
     await expect(soqlTab, `${SOQL_FILE}.soql tab should be visible`).toBeVisible({ timeout: 20_000 });
     await saveScreenshot(page, 'step1.soql-tab-visible.png');
 
-    // Confirm text-editor mode: no webview iframe should be present (distinguishes from SOQL Builder)
-    await expect(
-      page.locator('iframe.webview.ready'),
-      'no webview iframe — file opened in text editor, not SOQL Builder'
-    ).not.toBeAttached({ timeout: 5000 });
-
-    // Confirm Monaco editor is present for the .soql file
+    // Confirm Monaco editor is present for the .soql file — this positively proves
+    // text-editor mode (SOQL Builder renders a webview, not a Monaco editor)
     await expect(
       page.locator(`${EDITOR}[data-uri$="${SOQL_FILE}.soql"]`),
       'Monaco editor should be present for the .soql file'
     ).toBeVisible({ timeout: 5000 });
+
+    // Confirm no webview iframe in the active editor group. Scoped to
+    // `.editor-group-container.active` to avoid false failures from unrelated
+    // extension webviews (walkthrough panels, onboarding overlays) that may still
+    // be attached elsewhere in the DOM after closeWelcomeTabs runs (tab close is
+    // sync but iframe detach is async).
+    await expect(
+      page.locator('.editor-group-container.active iframe.webview.ready'),
+      'no webview iframe in active editor group — file opened in text editor, not SOQL Builder'
+    ).not.toBeAttached({ timeout: 5000 });
 
     // Type the query into the empty editor (file opens focused and ready for input)
     await page.locator(EDITOR).first().click();


### PR DESCRIPTION
## Summary

- Adds a text-editor-mode assertion step to the existing `soql-run-query.spec.ts` spec, after the `.soql` tab becomes visible
- Primary assertion: Monaco editor with the correct `data-uri` is visible — positively proves the file opened as a text editor (not SOQL Builder's webview)
- Secondary assertion: no `iframe.webview.ready` in `.editor-group-container.active` — scoped to active editor group to avoid false failures from unrelated extension webviews

## Plan

[.claude/plans/W-22888087.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-22888087-e2e-assert-sfdx-create-soql-query-comman/.claude/plans/W-22888087.md)

## Reviewer notes

- **low** — Numeric separator style (`5000`) on timeout values: `unicorn/numeric-separators-style` rejects `5_000` (1-digit group before separator is invalid per project lint config); 4-digit numbers must remain unseparated.
- **low** — Globally-scoped `iframe.webview.ready` selector could theoretically match unrelated webviews. Scoped to `.editor-group-container.active iframe.webview.ready` (implemented in this PR); further narrowing is defense-in-depth but not required in CI.

## Test plan

- e2e covered: Monaco editor presence + no webview in active editor group asserted by the modified spec (`soql-run-query.spec.ts`)
- Manual: `npm run test:web` and `npm run test:desktop` in `packages/salesforcedx-vscode-soql`

### What issues does this PR fix or reference?

@W-22888087@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002bh9U3YAI/view