### PR TITLE
test(lint): enable jest/no-focused-tests ESLint rule - W-11678119

### DIFF
--- a/.claude/plans/W-11678119.md
+++ b/.claude/plans/W-11678119.md
@@ -1,0 +1,22 @@
+# W-11678119 — Enable jest/no-focused-tests ESLint rule
+
+## Context
+
+- `eslint-plugin-jest` already installed/configured for test globs
+- `jest/unbound-method: error` exists at line 561 of `eslint.config.mjs`
+- No existing focused tests found in codebase
+
+## Phases
+
+### 1. Add rule
+
+- Add `'jest/no-focused-tests': 'error'` next to `jest/unbound-method` in `eslint.config.mjs` (line ~561)
+- Commit: `fix(lint): enable jest/no-focused-tests error rule - W-11678119`
+
+## Skills
+
+- typescript
+
+## Verification
+
+- `npm run lint` exits 0 with new rule present (manual run before PR)

--- a/.claude/plans/W-11678119.md
+++ b/.claude/plans/W-11678119.md
@@ -12,11 +12,6 @@
 
 - Add `'jest/no-focused-tests': 'error'` next to `jest/unbound-method` in `eslint.config.mjs` (line ~561)
 - Commit: `fix(lint): enable jest/no-focused-tests error rule - W-11678119`
-
-## Skills
-
-- typescript
-
 ## Verification
 
 - `npm run lint` exits 0 with new rule present (manual run before PR)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -559,6 +559,7 @@ export default [
       '@typescript-eslint/restrict-template-expressions': 'warn',
       '@typescript-eslint/unbound-method': 'off',
       'jest/unbound-method': 'error',
+      'jest/no-focused-tests': 'error',
       '@typescript-eslint/no-var-requires': 'off',
       'no-useless-constructor': 'off',
       'no-restricted-imports': 'off',


### PR DESCRIPTION
## Summary

- Adds `jest/no-focused-tests: error` to the ESLint config's test-files block, preventing focused tests (`.only`, `test.only`, `describe.only`) from being committed
- `eslint-plugin-jest` was already installed and configured; this closes the gap where focused tests could silently pass CI
- No existing violations found in the codebase

## Plan

.claude/plans/W-11678119.md

## Reviewer notes

- Low: eslint.config.mjs change confirmed clean: rule correctly placed in test-files config block, eslint-plugin-jest@28.14.0 exports `no-focused-tests`, no existing violations in codebase

## Test plan

- Run `npm run lint` and confirm it exits 0 with the new rule present

### What issues does this PR fix or reference?

@W-11678119@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000015NekrYAC/view