### PR TITLE
chore: enable jest/no-test-prefixes eslint rule - W-22865162

### DIFF
--- a/.claude/plans/W-22865162.md
+++ b/.claude/plans/W-22865162.md
@@ -1,0 +1,26 @@
+# W-22865162 — enable jest/no-test-prefixes
+
+## Context
+- Goal: add `jest/no-test-prefixes: 'error'` to jest rules block.
+- `eslint.config.mjs` line 561-563: jest rules block; `jest/no-focused-tests` (blocker) already merged.
+- Plugin `eslint-plugin-jest` 28.14.0 installed (package.json:80), wired for all test globs. No plugin add.
+- Rule rewrites `fit`/`xit`/`fdescribe`/`xdescribe` → `.only`/`.skip`. Autofixable.
+- One violation: `packages/salesforcedx-aura-language-server/test/aura-indexer/indexer.spec.ts:150` — `xit(` → `it.skip(`.
+
+## Phases
+### Phase 1 — enable rule + fix violation
+- Add `'jest/no-test-prefixes': 'error',` after line 562 in `eslint.config.mjs`.
+- Fix `indexer.spec.ts:150`: `xit(` → `it.skip(` (or run `eslint --fix`).
+- Files:
+  - `eslint.config.mjs`
+  - `packages/salesforcedx-aura-language-server/test/aura-indexer/indexer.spec.ts`
+- commit message: `chore: enable jest/no-test-prefixes eslint rule`
+
+## Skills to apply
+- typescript
+- verification
+
+## Verification
+- `npm run lint` passes (DoD).
+- grep no remaining `fit(`/`xit(`/`fdescribe(`/`xdescribe(` in test globs.
+- Not e2e-covered: lint is static; no e2e.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -560,6 +560,7 @@ export default [
       '@typescript-eslint/unbound-method': 'off',
       'jest/unbound-method': 'error',
       'jest/no-focused-tests': 'error',
+      'jest/no-test-prefixes': 'error',
       'jest/no-identical-title': 'error',
       '@typescript-eslint/no-var-requires': 'off',
       'no-useless-constructor': 'off',

--- a/packages/salesforcedx-aura-language-server/test/aura-indexer/indexer.spec.ts
+++ b/packages/salesforcedx-aura-language-server/test/aura-indexer/indexer.spec.ts
@@ -147,7 +147,7 @@ describe('indexer parsing content', () => {
     expect(tagInfo?.namespace).toEqual('c');
   });
 
-  xit('should handle indexing an invalid aura component', async () => {
+  it.skip('should handle indexing an invalid aura component', async () => {
     const context = new AuraWorkspaceContext(SFDX_WORKSPACE_ROOT, new LspFileSystemAccessor());
     context.initialize('SFDX');
     await context.configureProject();


### PR DESCRIPTION
## Summary
- Enabled jest/no-test-prefixes eslint rule to enforce modern .only/.skip syntax
- Fixed one violation in aura-language-server test file

## Plan
[.claude/plans/W-22865162.md](.claude/plans/W-22865162.md)

## Test plan
- [x] `npm run lint` passes
- [x] grep confirms no remaining `fit(`/`xit(`/`fdescribe(`/`xdescribe(` in test files

### What issues does this PR fix or reference?
@W-22865162@

🤖 Generated by auto-build pipeline. Original WI: https://gus.salesforce.com/a07EE00002bbwGfYAI