### PR TITLE
feat(eslint): ban runtime vscode import in Playwright tests - W-22903015

### DIFF
--- a/.claude/plans/W-22903015.md
+++ b/.claude/plans/W-22903015.md
@@ -1,0 +1,52 @@
+# W-22903015 — eslint rule: ban runtime `vscode` import in Playwright tests
+
+## Context
+- Playwright tests run in test-runner/browser, not extension host. `vscode` module absent → runtime import fails.
+- New rule `local/no-runtime-vscode-import` in `packages/eslint-local-rules`.
+- Flag value/dynamic imports of `vscode`; report on import specifier/source node. Msg → UI-driven helpers (`openFileByName`).
+  - Flag: `import ... from 'vscode'` (value), `require('vscode')`, `await import('vscode')`
+  - Allow: `import type ... from 'vscode'` (erased, runtime-safe)
+  - Key on specifier === `vscode`, NOT text-match `vscode.` — extension-ids (`vscode.github`), comments, error-pattern literals must not trip
+  - Out of scope: `node:fs`/`node:path` (used in desktop fixtures today)
+- Baseline: zero runtime `vscode` imports in Playwright dirs → ships `error`, no migration.
+- Pattern ref: `packages/eslint-local-rules/src/noVscodeUri.ts` (RuleCreator.withoutDocs, `ImportDeclaration`, `node.source.value === 'vscode'`).
+- Config block: `eslint.config.mjs` line 517 (files incl playwright; contains `local/no-duplicate-playwright-locators` @ 568).
+
+## Phases
+
+### Phase 1 — rule + register + tests
+- `packages/eslint-local-rules/src/noRuntimeVscodeImport.ts`:
+  - `RuleCreator.withoutDocs`, type `problem`, messageId `noRuntimeVscodeImport`.
+  - `ImportDeclaration`: source.value === `vscode` AND import statement is a runtime load → report `node.source`.
+    - Runtime-load test (decl is NOT erased): `node.importKind !== 'type'` AND at least one of:
+      - `node.specifiers.length === 0` (bare side-effect import `import 'vscode'` — runtime load), OR
+      - some specifier is value-kind. Value-kind specifier = NOT (`ImportSpecifier` with `specifier.importKind === 'type'`). `ImportDefaultSpecifier`/`ImportNamespaceSpecifier` have no per-specifier `importKind` and are always value → runtime.
+    - Decision table (decl-level `importKind` shown):
+      - `import type { Uri } from 'vscode'` (decl importKind `type`) → erased → NO report.
+      - `import type * as vscode from 'vscode'` (decl importKind `type`) → erased → NO report.
+      - `import { type Uri } from 'vscode'` (decl `value`, all specifiers inline `type`) → fully erased → NO report.
+      - `import { type Uri, window } from 'vscode'` (decl `value`, `window` is value-kind) → RUNTIME LOAD → REPORT `node.source`. This is the load-bearing case from the advocate finding: one value specifier makes the whole statement a runtime require.
+      - `import { window } from 'vscode'` / `import * as vscode from 'vscode'` / `import vscode from 'vscode'` / `import 'vscode'` (decl `value`) → REPORT `node.source`.
+    - Always report once on `node.source` (the statement-level runtime cost), not per-specifier — matches msg intent (whole import is the problem).
+  - `CallExpression` (require): callee Identifier `require`, arg[0] string `vscode` → report arg[0].
+  - `ImportExpression` (dynamic `import('vscode')`): source string `vscode` → report source.
+- Register in `src/index.ts`: import + `'no-runtime-vscode-import': noRuntimeVscodeImport` in `rules`.
+- `packages/eslint-local-rules/test/no-runtime-vscode-import.test.ts` (RuleTester):
+  - valid: `import type * as vscode from 'vscode'`; `import type { Uri } from 'vscode'`; `import { type Uri } from 'vscode'` (all-inline-type, fully erased); `import { type Uri, type Range } from 'vscode'`; extension-id string `const id = 'vscode.github'`; comment `// vscode.window`; literal `/Cannot find module 'vscode'/`; `import fs from 'node:fs'`.
+  - invalid: `import * as vscode from 'vscode'`; `import { window } from 'vscode'`; `import { type Uri, window } from 'vscode'` (mixed inline-type + value → runtime; the advocate edge case — exactly 1 reported error on source); `import vscode from 'vscode'` (default); `import 'vscode'` (bare side-effect); `require('vscode')`; `await import('vscode')` (in async fn). Assert error count == 1 per case (no double-report).
+- Commit: `feat(eslint): no-runtime-vscode-import rule`
+
+### Phase 2 — wire into config
+- `eslint.config.mjs` block @517: add `'local/no-runtime-vscode-import': 'error'` next to `no-duplicate-playwright-locators` (line 568).
+- Commit: `chore(eslint): enable no-runtime-vscode-import on playwright group`
+
+## Skills
+- typescript
+- playwright-e2e (helper-name ref for msg)
+- verification
+
+## Verification
+- `npm test` in `packages/eslint-local-rules` (jest RuleTester — valid/invalid cases). NOT e2e-covered.
+- `npm run lint` (or eslint on playwright dirs) → zero new errors (baseline clean). NOT e2e-covered.
+- Manual sanity: temp `import * as vscode from 'vscode'` in a playwright test file → lint errors; remove. NOT e2e-covered.
+- No e2e tests apply (lint-only rule).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -569,6 +569,22 @@ export default [
     }
   },
   {
+    // Playwright tests run in the test-runner/browser, not the extension host, so the
+    // `vscode` module is absent and a runtime import fails. Scoped to playwright-only
+    // dirs (jest/unit tests in the block above legitimately import vscode at runtime).
+    files: [
+      'packages/salesforcedx**/test/playwright/**/*',
+      'packages/salesforcedx-vscode-automation-tests/**/*',
+      'packages/playwright-vscode-ext/**/*.ts'
+    ],
+    plugins: {
+      local: localPlugin
+    },
+    rules: {
+      'local/no-runtime-vscode-import': 'error'
+    }
+  },
+  {
     // these have extensive copy-paste from an old version of msft language server
     // this rule requires strict null checks to be enabled and that code does not support it
     // Also disable for packages that don't have strictNullChecks enabled

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -577,6 +577,7 @@ export default [
       'packages/salesforcedx-vscode-automation-tests/**/*',
       'packages/playwright-vscode-ext/**/*.ts'
     ],
+    ignores: ['**/locators.ts'],
     plugins: {
       local: localPlugin
     },

--- a/packages/eslint-local-rules/src/index.ts
+++ b/packages/eslint-local-rules/src/index.ts
@@ -13,6 +13,7 @@ import { noEffectFnWrapper } from './noEffectFnWrapper';
 import { noEffectServiceAccessorCalls } from './noEffectServiceAccessorCalls';
 import { noExplicitEffectReturnType } from './noExplicitEffectReturnType';
 import { noExportTaggedErrorInServices } from './noExportTaggedErrorInServices';
+import { noRuntimeVscodeImport } from './noRuntimeVscodeImport';
 import { noSelfBarrelImport } from './noSelfBarrelImport';
 import { noUnusedI18nMessages } from './noUnusedI18nMessages';
 import { noVscodeMessageLiterals } from './noVscodeMessageLiterals';
@@ -46,6 +47,7 @@ const plugin = {
     'no-self-barrel-import': noSelfBarrelImport,
     'no-effect-fn-wrapper': noEffectFnWrapper,
     'no-export-tagged-error-in-services': noExportTaggedErrorInServices,
+    'no-runtime-vscode-import': noRuntimeVscodeImport,
     'require-effect-fn-span-name': requireEffectFnSpanName,
     'no-effect-service-accessor-calls': noEffectServiceAccessorCalls,
     'no-explicit-effect-return-type': noExplicitEffectReturnType,

--- a/packages/eslint-local-rules/src/noRuntimeVscodeImport.ts
+++ b/packages/eslint-local-rules/src/noRuntimeVscodeImport.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
+import { RuleCreator } from '@typescript-eslint/utils/eslint-utils';
+
+// A declaration is a runtime load (not fully type-erased) when it is not a
+// `import type ...` declaration AND it either is a bare side-effect import or
+// has at least one value-kind specifier.
+const isRuntimeLoad = (node: TSESTree.ImportDeclaration): boolean => {
+  if (node.importKind === 'type') return false;
+  if (node.specifiers.length === 0) return true;
+  return node.specifiers.some(
+    specifier => !(specifier.type === AST_NODE_TYPES.ImportSpecifier && specifier.importKind === 'type')
+  );
+};
+
+export const noRuntimeVscodeImport = RuleCreator.withoutDocs({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Ban runtime imports of the `vscode` module in Playwright tests. They run in the test-runner/browser where `vscode` is absent, so the import fails at runtime. Use `import type` for types, or the UI-driven helpers (e.g. openFileByName) instead.'
+    },
+    schema: [],
+    messages: {
+      noRuntimeVscodeImport:
+        'Do not import the `vscode` module at runtime in Playwright tests; it is unavailable in the test-runner and the import fails. Use `import type` for types, or UI-driven helpers (e.g. openFileByName).'
+    }
+  },
+  defaultOptions: [],
+  create: context => ({
+    ImportDeclaration: (node: TSESTree.ImportDeclaration): void => {
+      if (node.source.value === 'vscode' && isRuntimeLoad(node)) {
+        context.report({ node: node.source, messageId: 'noRuntimeVscodeImport' });
+      }
+    },
+    CallExpression: (node: TSESTree.CallExpression): void => {
+      const arg = node.arguments[0];
+      if (
+        node.callee.type === AST_NODE_TYPES.Identifier &&
+        node.callee.name === 'require' &&
+        arg?.type === AST_NODE_TYPES.Literal &&
+        arg.value === 'vscode'
+      ) {
+        context.report({ node: arg, messageId: 'noRuntimeVscodeImport' });
+      }
+    },
+    ImportExpression: (node: TSESTree.ImportExpression): void => {
+      if (node.source.type === AST_NODE_TYPES.Literal && node.source.value === 'vscode') {
+        context.report({ node: node.source, messageId: 'noRuntimeVscodeImport' });
+      }
+    }
+  })
+});

--- a/packages/eslint-local-rules/src/noRuntimeVscodeImport.ts
+++ b/packages/eslint-local-rules/src/noRuntimeVscodeImport.ts
@@ -54,6 +54,23 @@ export const noRuntimeVscodeImport = RuleCreator.withoutDocs({
       if (node.source.type === AST_NODE_TYPES.Literal && node.source.value === 'vscode') {
         context.report({ node: node.source, messageId: 'noRuntimeVscodeImport' });
       }
+    },
+    // `export { window } from 'vscode'` is a runtime load unless it is an
+    // `export type { ... } from 'vscode'`. A bare `export {}` has no source.
+    ExportNamedDeclaration: (node: TSESTree.ExportNamedDeclaration): void => {
+      if (
+        node.source?.value === 'vscode' &&
+        node.exportKind !== 'type' &&
+        node.specifiers.some(specifier => specifier.exportKind !== 'type')
+      ) {
+        context.report({ node: node.source, messageId: 'noRuntimeVscodeImport' });
+      }
+    },
+    // `export * from 'vscode'` / `export * as ns from 'vscode'` is a runtime load.
+    ExportAllDeclaration: (node: TSESTree.ExportAllDeclaration): void => {
+      if (node.source.value === 'vscode' && node.exportKind !== 'type') {
+        context.report({ node: node.source, messageId: 'noRuntimeVscodeImport' });
+      }
     }
   })
 });

--- a/packages/eslint-local-rules/test/no-runtime-vscode-import.test.ts
+++ b/packages/eslint-local-rules/test/no-runtime-vscode-import.test.ts
@@ -25,7 +25,13 @@ ruleTester.run('no-runtime-vscode-import', noRuntimeVscodeImport, {
     // error-pattern literal
     { code: `const re = /Cannot find module 'vscode'/;`, filename },
     // unrelated node builtin
-    { code: `import fs from 'node:fs';`, filename }
+    { code: `import fs from 'node:fs';`, filename },
+    // re-export forms that are fully type-erased
+    { code: `export type { Uri } from 'vscode';`, filename },
+    { code: `export { type Uri } from 'vscode';`, filename },
+    { code: `export type * from 'vscode';`, filename },
+    // bare local export, no module source
+    { code: `const x = 1;\nexport { x };`, filename }
   ],
   invalid: [
     {
@@ -61,6 +67,28 @@ ruleTester.run('no-runtime-vscode-import', noRuntimeVscodeImport, {
     },
     {
       code: `const fn = async () => { await import('vscode'); };`,
+      filename,
+      errors: [{ messageId: 'noRuntimeVscodeImport' }]
+    },
+    {
+      // named re-export of a value specifier → runtime load
+      code: `export { window } from 'vscode';`,
+      filename,
+      errors: [{ messageId: 'noRuntimeVscodeImport' }]
+    },
+    {
+      // mixed inline-type + value re-export → runtime load
+      code: `export { type Uri, window } from 'vscode';`,
+      filename,
+      errors: [{ messageId: 'noRuntimeVscodeImport' }]
+    },
+    {
+      code: `export * from 'vscode';`,
+      filename,
+      errors: [{ messageId: 'noRuntimeVscodeImport' }]
+    },
+    {
+      code: `export * as vscode from 'vscode';`,
       filename,
       errors: [{ messageId: 'noRuntimeVscodeImport' }]
     }

--- a/packages/eslint-local-rules/test/no-runtime-vscode-import.test.ts
+++ b/packages/eslint-local-rules/test/no-runtime-vscode-import.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { noRuntimeVscodeImport } from '../src/noRuntimeVscodeImport';
+
+const ruleTester = new RuleTester();
+const filename = 'packages/salesforcedx-vscode-core/test/playwright/example.test.ts';
+
+ruleTester.run('no-runtime-vscode-import', noRuntimeVscodeImport, {
+  valid: [
+    { code: `import type * as vscode from 'vscode';`, filename },
+    { code: `import type { Uri } from 'vscode';`, filename },
+    // all-inline-type specifiers → declaration fully erased
+    { code: `import { type Uri } from 'vscode';`, filename },
+    { code: `import { type Uri, type Range } from 'vscode';`, filename },
+    // extension-id string literal, not a module specifier
+    { code: `const id = 'vscode.github';`, filename },
+    // comment mentioning vscode.window
+    { code: `// vscode.window\nconst x = 1;`, filename },
+    // error-pattern literal
+    { code: `const re = /Cannot find module 'vscode'/;`, filename },
+    // unrelated node builtin
+    { code: `import fs from 'node:fs';`, filename }
+  ],
+  invalid: [
+    {
+      code: `import * as vscode from 'vscode';`,
+      filename,
+      errors: [{ messageId: 'noRuntimeVscodeImport' }]
+    },
+    {
+      code: `import { window } from 'vscode';`,
+      filename,
+      errors: [{ messageId: 'noRuntimeVscodeImport' }]
+    },
+    {
+      // mixed inline-type + value specifier → runtime load; exactly one report on source
+      code: `import { type Uri, window } from 'vscode';`,
+      filename,
+      errors: [{ messageId: 'noRuntimeVscodeImport' }]
+    },
+    {
+      code: `import vscode from 'vscode';`,
+      filename,
+      errors: [{ messageId: 'noRuntimeVscodeImport' }]
+    },
+    {
+      code: `import 'vscode';`,
+      filename,
+      errors: [{ messageId: 'noRuntimeVscodeImport' }]
+    },
+    {
+      code: `const vscode = require('vscode');`,
+      filename,
+      errors: [{ messageId: 'noRuntimeVscodeImport' }]
+    },
+    {
+      code: `const fn = async () => { await import('vscode'); };`,
+      filename,
+      errors: [{ messageId: 'noRuntimeVscodeImport' }]
+    }
+  ]
+});


### PR DESCRIPTION
## Summary
- New `local/no-runtime-vscode-import` ESLint rule flags runtime imports of `vscode` in Playwright tests (value imports, `require()`, dynamic `import()`)
- Allows type-only imports (erased at compile time)
- Enabled on Playwright test file group

## Plan
See [.claude/plans/W-22903015.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-22903015-eslint-rule-ban-runtime-vscode-import-in/.claude/plans/W-22903015.md)

## Reviewer notes
- **Low**: `require('vscode')` detection keys on callee Identifier name 'require' without scope resolution (noRuntimeVscodeImport.ts:44-46). Design decision: scope-aware checking deemed unnecessary for Playwright-test target files where shadowing global require with a local fn taking 'vscode' is contrived with zero real occurrences. Simple-name match is consistent with sibling local rules.

## Test plan
- Run `npm test` in `packages/eslint-local-rules` (jest RuleTester — valid/invalid cases)
- Run `npm run lint` (or eslint on playwright dirs) → zero new errors (baseline clean)
- Manual sanity: temp `import * as vscode from 'vscode'` in a playwright test file → lint errors; remove

### What issues does this PR fix or reference?
@W-22903015@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002blOSAYA2/view