### PR TITLE
fix(e2e): remove stale Mac Desktop skip for explorer diff context-menu - W-22916640

### DIFF
--- a/.claude/plans/W-22916640.md
+++ b/.claude/plans/W-22916640.md
@@ -1,0 +1,30 @@
+# W-22916640: Remove stale Mac Desktop skip for explorer context-menu diff
+
+## Context
+
+- `sourceDiff.headless.spec.ts:141` skips explorer context-menu diff on Mac Desktop
+- Skip is stale: `createDesktopTest.ts:247` sets `window.menuStyle: "custom"` — context menus render in DOM, Playwright can drive them on macOS
+- Other specs (lwcRename, auraRename, analyticsTemplates) already exercise `executeExplorerContextMenuCommand` on Mac Desktop without skip
+
+## Phases
+
+### Phase 1: Remove skip
+
+- Delete `step.skip(isMacDesktop(), 'Explorer context menu not available on Mac Desktop');` at line 141
+- Remove `isMacDesktop` from import if no other usage in file
+
+**Commit:** `fix(e2e): remove stale Mac Desktop skip for explorer diff context-menu - W-22916640`
+
+**Files:**
+- `packages/salesforcedx-vscode-metadata/test/playwright/specs/sourceDiff.headless.spec.ts`
+
+## Skills
+
+- playwright-e2e
+- typescript
+- verification
+
+## Verification
+
+- e2e-covered: run `npm run test:desktop -w salesforcedx-vscode-metadata -- --retries 0 --grep "explorer context menu"` validates the removed skip now runs on Mac Desktop; run `npm run test:web -w salesforcedx-vscode-metadata -- --retries 0 --grep "explorer context menu"` validates web
+- e2e-verified: `isMacDesktop` import removed from file if no other usage remains

--- a/.claude/plans/W-22916640.md
+++ b/.claude/plans/W-22916640.md
@@ -5,7 +5,7 @@
 - `sourceDiff.headless.spec.ts:141` skips explorer context-menu diff on Mac Desktop
 - `sourceDiffMultiple.headless.spec.ts:40` skips the entire folder-diff test on Mac Desktop for the same reason
 - Skip is stale: `createDesktopTest.ts:247` sets `window.menuStyle: "custom"` — context menus render in DOM, Playwright can drive them on macOS
-- Other specs (lwcRename, auraRename, analyticsTemplates) already exercise `executeExplorerContextMenuCommand` on Mac Desktop without skip
+- Other specs (lwcRename, auraRename, analyticsTemplates) exercise `executeExplorerContextMenuCommand` on Mac Desktop without skip
 - Both skips share identical rationale (`window.menuStyle: custom` removes the platform limitation); no technical basis to exclude folder diff
 
 ## Phases
@@ -39,7 +39,7 @@
 
 ## Verification
 
-- e2e-covered: run `npm run test:desktop -w salesforcedx-vscode-metadata -- --retries 0 --grep "Source Diff"` validates both tests (single-file and multi-file) run on Mac Desktop without skip
+- e2e-covered: run `npm run test:desktop -w salesforcedx-vscode-metadata -- --retries 0 --grep "Source Diff"` validates both tests run on Mac Desktop without skip
 - e2e-covered: run `npm run test:web -w salesforcedx-vscode-metadata -- --retries 0 --grep "Source Diff"` validates web targets
 - e2e-covered: alternatively, run spec files directly: `npx playwright test packages/salesforcedx-vscode-metadata/test/playwright/specs/sourceDiff.headless.spec.ts packages/salesforcedx-vscode-metadata/test/playwright/specs/sourceDiffMultiple.headless.spec.ts --retries 0`
-- manual-verified: `isMacDesktop` import removed from both files if no other usage remains
+- manual-verified: `isMacDesktop` import removed from both files if unused elsewhere

--- a/.claude/plans/W-22916640.md
+++ b/.claude/plans/W-22916640.md
@@ -3,20 +3,33 @@
 ## Context
 
 - `sourceDiff.headless.spec.ts:141` skips explorer context-menu diff on Mac Desktop
+- `sourceDiffMultiple.headless.spec.ts:40` skips the entire folder-diff test on Mac Desktop for the same reason
 - Skip is stale: `createDesktopTest.ts:247` sets `window.menuStyle: "custom"` — context menus render in DOM, Playwright can drive them on macOS
 - Other specs (lwcRename, auraRename, analyticsTemplates) already exercise `executeExplorerContextMenuCommand` on Mac Desktop without skip
+- Both skips share identical rationale (`window.menuStyle: custom` removes the platform limitation); no technical basis to exclude folder diff
 
 ## Phases
 
-### Phase 1: Remove skip
+### Phase 1: Remove skip from sourceDiff
 
 - Delete `step.skip(isMacDesktop(), 'Explorer context menu not available on Mac Desktop');` at line 141
+- Convert `async step =>` to `async () =>` since step param is no longer used
 - Remove `isMacDesktop` from import if no other usage in file
 
 **Commit:** `fix(e2e): remove stale Mac Desktop skip for explorer diff context-menu - W-22916640`
 
 **Files:**
 - `packages/salesforcedx-vscode-metadata/test/playwright/specs/sourceDiff.headless.spec.ts`
+
+### Phase 2: Remove skip from sourceDiffMultiple
+
+- Delete `test.skip(isMacDesktop(), 'Explorer context menu not available on Mac Desktop');` at line 40
+- Remove `isMacDesktop` from import if no other usage in file
+
+**Commit:** `refactor(e2e): remove stale isMacDesktop skip from sourceDiffMultiple test`
+
+**Files:**
+- `packages/salesforcedx-vscode-metadata/test/playwright/specs/sourceDiffMultiple.headless.spec.ts`
 
 ## Skills
 
@@ -26,5 +39,7 @@
 
 ## Verification
 
-- e2e-covered: run `npm run test:desktop -w salesforcedx-vscode-metadata -- --retries 0 --grep "explorer context menu"` validates the removed skip now runs on Mac Desktop; run `npm run test:web -w salesforcedx-vscode-metadata -- --retries 0 --grep "explorer context menu"` validates web
-- e2e-verified: `isMacDesktop` import removed from file if no other usage remains
+- e2e-covered: run `npm run test:desktop -w salesforcedx-vscode-metadata -- --retries 0 --grep "Source Diff"` validates both tests (single-file and multi-file) run on Mac Desktop without skip
+- e2e-covered: run `npm run test:web -w salesforcedx-vscode-metadata -- --retries 0 --grep "Source Diff"` validates web targets
+- e2e-covered: alternatively, run spec files directly: `npx playwright test packages/salesforcedx-vscode-metadata/test/playwright/specs/sourceDiff.headless.spec.ts packages/salesforcedx-vscode-metadata/test/playwright/specs/sourceDiffMultiple.headless.spec.ts --retries 0`
+- manual-verified: `isMacDesktop` import removed from both files if no other usage remains

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/sourceDiff.headless.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/sourceDiff.headless.spec.ts
@@ -22,7 +22,6 @@ import {
   verifyCommandExists,
   executeExplorerContextMenuCommand,
   saveScreenshot,
-  isMacDesktop,
   validateNoCriticalErrors,
   ensureOutputPanelOpen,
   selectOutputChannel,
@@ -137,9 +136,7 @@ test('Source Diff: diff shows diff editor', async ({ page }) => {
     await verifyDiffCompleted(page, classNamePalette, 'diff-palette');
   });
 
-  await test.step('create local change and diff via explorer context menu', async step => {
-    step.skip(isMacDesktop(), 'Explorer context menu not available on Mac Desktop');
-
+  await test.step('create local change and diff via explorer context menu', async () => {
     await executeCommandWithCommandPalette(page, 'View: Close All Editors');
 
     await openFileByName(page, `${classNamePalette}.cls`);

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/sourceDiffMultiple.headless.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/sourceDiffMultiple.headless.spec.ts
@@ -20,7 +20,6 @@ import {
   openFileByName,
   executeExplorerContextMenuCommand,
   saveScreenshot,
-  isMacDesktop,
   validateNoCriticalErrors,
   ensureOutputPanelOpen,
   selectOutputChannel,
@@ -37,7 +36,6 @@ import packageNls from '../../../package.nls.json';
 import { DEPLOY_TIMEOUT } from '../../constants';
 
 test('Source Diff (multiple files): opens first diff and populates conflict tree', async ({ page }) => {
-  test.skip(isMacDesktop(), 'Explorer context menu not available on Mac Desktop');
   test.setTimeout(DEPLOY_TIMEOUT);
   const consoleErrors = setupConsoleMonitoring(page);
   const networkErrors = setupNetworkMonitoring(page);


### PR DESCRIPTION
## Summary

- Removed stale Mac Desktop skip from explorer context-menu diff e2e test — menus render in DOM on macOS and Playwright can drive them
- Removed redundant isMacDesktop skip from sourceDiffMultiple test

## Plan

https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-22916640-run-diff-against-org-explorer-context-me/.claude/plans/W-22916640.md

## Test plan

- e2e-covered: modified tests validate the removed skip now runs on Mac Desktop (both desktop and web variants)

### What issues does this PR fix or reference?

@W-22916640@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002bqGCvYAM/view