### PR TITLE
test(playwright): enable Mac desktop context menu E2E tests - W-21336718

### DIFF
--- a/.claude/plans/W-21336718.md
+++ b/.claude/plans/W-21336718.md
@@ -2,13 +2,13 @@
 
 ## Context
 
-- `window.menuStyle: custom` (VS Code 1.101+) renders `.monaco-menu` HTML instead of native OS menus → Playwright can drive context menus on Mac desktop.
+- `window.menuStyle: custom` (VS Code 1.101+) renders `.monaco-menu` HTML, not native OS menus → Playwright can drive context menus on Mac desktop.
 - Fixture already sets it: `packages/playwright-vscode-ext/src/fixtures/createDesktopTest.ts:247` (added #7267). No fixture change needed.
-- Remaining work: strip `isMacDesktop()` skips from tests that were gated on broken Mac context menus.
+- Remaining work: strip `isMacDesktop()` skips from tests gated on broken Mac context menus.
 - WI list partly stale. Already clean (no isMacDesktop): all `salesforcedx-vscode-core` specs, metadata `manifestBuilder`.
 - `sourceDiff.headless.spec.ts` + `sourceDiffMultiple.headless.spec.ts` had Mac skips + `isMacDesktop` import — already removed on this branch by commit `1a1d6f25d` (#7427, W-22916640, `git show 1a1d6f25d`). Both now grep-clean (0 `isMacDesktop`). Do NOT touch / re-add — out of scope here, would conflict.
 - Out of scope: `commandPalette.headless.spec.ts` (Ctrl+Shift+P shortcut flake — separate issue).
-- `isMacDesktop()` helper stays (still used: `settings.ts` shortcut). Only remove the test/page-skip call sites + now-orphaned imports.
+- `isMacDesktop()` helper stays (still used: `settings.ts` shortcut). Only remove test/page-skip call sites + orphaned imports.
 
 ### Files to touch
 
@@ -29,7 +29,7 @@ salesforcedx-vscode-metadata specs (`test/playwright/specs/`):
 ### Phase 1 — Remove Mac skips, enable context-menu tests on Mac desktop
 
 - Edit playwright-vscode-ext: `contextMenu.headless.spec.ts` (rm 2 skips + import), `outputChannel.ts` (rm Mac branch + import).
-- Edit 6 metadata specs: swap skip wrappers → unconditional `test` (nonTracking keeps `isDesktop` gate), rm orphaned `isMacDesktop` imports + stale comments.
+- Edit 6 metadata specs: skip wrappers→unconditional `test` (nonTracking keeps `isDesktop` gate), rm orphaned `isMacDesktop` imports + stale comments.
 - commitMessage: `test(playwright): enable Mac desktop context menu E2E tests via window.menuStyle - W-21336718`
 - files: contextMenu.headless.spec.ts, outputChannel.ts, retrieveSourcePath/retrieveInManifest/generateManifest/deploySourcePath/deployManifest/nonTrackingOrgDeployRetrieveManifest.headless.spec.ts
 
@@ -42,9 +42,9 @@ salesforcedx-vscode-metadata specs (`test/playwright/specs/`):
 
 ## Verification
 
-- `npm run compile` (or tsc per package) — no unused-import / type errors after dropping imports. NOT e2e-covered.
+- `npm run compile` (or tsc per package) — no unused-import/type errors. NOT e2e-covered.
 - eslint affected packages — orphaned-import lint clean. NOT e2e-covered.
-- E2E-covered. Mac desktop CI exists for both affected packages (verified, NOT manual-only):
+- E2E-covered. Mac desktop CI for both affected packages (verified, NOT manual-only):
   - metadata specs: `metadataE2E.yml` matrix `os: [macos-latest, ...]` runs `npm run test:desktop -w salesforcedx-vscode-metadata` with `VSCODE_DESKTOP=1` (line 194/247). Source-diff specs additionally covered by `test:desktop:conflicts` job (same macos-latest matrix, line 486/534).
   - playwright-vscode-ext specs: `playwrightVscodeExtE2E.yml` (contextMenu, outputChannel).
   - `coreE2E.yml` covers only `salesforcedx-vscode-core` — irrelevant to this WI's edits.

--- a/.claude/plans/W-21336718.md
+++ b/.claude/plans/W-21336718.md
@@ -1,0 +1,52 @@
+# W-21336718 — Enable Mac desktop context menu E2E tests via window.menuStyle
+
+## Context
+
+- `window.menuStyle: custom` (VS Code 1.101+) renders `.monaco-menu` HTML instead of native OS menus → Playwright can drive context menus on Mac desktop.
+- Fixture already sets it: `packages/playwright-vscode-ext/src/fixtures/createDesktopTest.ts:247` (added #7267). No fixture change needed.
+- Remaining work: strip `isMacDesktop()` skips from tests that were gated on broken Mac context menus.
+- WI list partly stale. Already clean (no isMacDesktop): all `salesforcedx-vscode-core` specs, metadata `manifestBuilder`.
+- `sourceDiff.headless.spec.ts` + `sourceDiffMultiple.headless.spec.ts` had Mac skips + `isMacDesktop` import — already removed on this branch by commit `1a1d6f25d` (#7427, W-22916640, `git show 1a1d6f25d`). Both now grep-clean (0 `isMacDesktop`). Do NOT touch / re-add — out of scope here, would conflict.
+- Out of scope: `commandPalette.headless.spec.ts` (Ctrl+Shift+P shortcut flake — separate issue).
+- `isMacDesktop()` helper stays (still used: `settings.ts` shortcut). Only remove the test/page-skip call sites + now-orphaned imports.
+
+### Files to touch
+
+playwright-vscode-ext:
+- `test/playwright/specs/contextMenu.headless.spec.ts` — 2 `test.skip(isMacDesktop()...)` (lines 25, 49); drop `isMacDesktop` from import (line 11; `waitForVSCodeWorkbench`/`closeWelcomeTabs` stay).
+- `src/pages/outputChannel.ts` — remove Mac-skip branch (lines 308-315); existing try/catch fallback covers failure. Drop `isMacDesktop` from import (line 10; `isDesktop` stays, 4 uses).
+
+salesforcedx-vscode-metadata specs (`test/playwright/specs/`):
+- `retrieveSourcePath.headless.spec.ts` — `(isMacDesktop()? test.skip.bind(test): test)` → `test` (line 38); rm comment line 37; rm import (line 22).
+- `retrieveInManifest.headless.spec.ts` — same pattern (line 41); rm import (line 22).
+- `generateManifest.headless.spec.ts` — same (line 32); rm import (line 21).
+- `deploySourcePath.headless.spec.ts` — same (line 37); rm import (line 25).
+- `deployManifest.headless.spec.ts` — same (line 44); rm import (line 24).
+- `nonTrackingOrgDeployRetrieveManifest.headless.spec.ts` — `(isDesktop() && !isMacDesktop()? test: test.skip.bind(test))` → `(isDesktop()? test: test.skip.bind(test))` (line 37); rm `isMacDesktop` import (line 26); keep `isDesktop` (2 uses).
+
+## Phases
+
+### Phase 1 — Remove Mac skips, enable context-menu tests on Mac desktop
+
+- Edit playwright-vscode-ext: `contextMenu.headless.spec.ts` (rm 2 skips + import), `outputChannel.ts` (rm Mac branch + import).
+- Edit 6 metadata specs: swap skip wrappers → unconditional `test` (nonTracking keeps `isDesktop` gate), rm orphaned `isMacDesktop` imports + stale comments.
+- commitMessage: `test(playwright): enable Mac desktop context menu E2E tests via window.menuStyle - W-21336718`
+- files: contextMenu.headless.spec.ts, outputChannel.ts, retrieveSourcePath/retrieveInManifest/generateManifest/deploySourcePath/deployManifest/nonTrackingOrgDeployRetrieveManifest.headless.spec.ts
+
+## Skills
+
+- playwright-e2e — running/iterating Mac desktop specs, span analysis
+- concise — plan style
+- typescript — lint/compile after import removals
+- verification — pre-push gates
+
+## Verification
+
+- `npm run compile` (or tsc per package) — no unused-import / type errors after dropping imports. NOT e2e-covered.
+- eslint affected packages — orphaned-import lint clean. NOT e2e-covered.
+- E2E-covered. Mac desktop CI exists for both affected packages (verified, NOT manual-only):
+  - metadata specs: `metadataE2E.yml` matrix `os: [macos-latest, ...]` runs `npm run test:desktop -w salesforcedx-vscode-metadata` with `VSCODE_DESKTOP=1` (line 194/247). Source-diff specs additionally covered by `test:desktop:conflicts` job (same macos-latest matrix, line 486/534).
+  - playwright-vscode-ext specs: `playwrightVscodeExtE2E.yml` (contextMenu, outputChannel).
+  - `coreE2E.yml` covers only `salesforcedx-vscode-core` — irrelevant to this WI's edits.
+- Formerly-skipped paths (contextMenu both tests; metadata deploy/retrieve/generate manifest + source-path; outputChannel capture) now run on macos-latest — green run = done.
+- Quick local grep: `grep -rn isMacDesktop packages/playwright-vscode-ext/test packages/salesforcedx-vscode-metadata/test` → no skip wrappers remain (helper def + settings.ts shortcut may remain). `sourceDiff`/`sourceDiffMultiple` already 0 hits (cleaned by #7427) — confirm still 0, do not edit.

--- a/packages/playwright-vscode-ext/src/pages/outputChannel.ts
+++ b/packages/playwright-vscode-ext/src/pages/outputChannel.ts
@@ -7,7 +7,7 @@
 
 import { expect, type Page } from '@playwright/test';
 import { saveScreenshot } from '../shared/screenshotUtils';
-import { isDesktop, isMacDesktop } from '../utils/helpers';
+import { isDesktop } from '../utils/helpers';
 import { EDITOR, CONTEXT_MENU, EDITOR_WITH_URI, TAB, QUICK_INPUT_LIST_ROW } from '../utils/locators';
 import { activeQuickInputTextField, activeQuickInputWidget } from '../utils/quickInput';
 import { executeCommandWithCommandPalette, openCommandPalette } from './commands';
@@ -304,15 +304,6 @@ export const captureOutputChannelDetails = async (
 ): Promise<void> => {
   const safeChannelName = channelName.replaceAll(/[^a-zA-Z0-9]/g, '_');
   const screenshotFileName = screenshotName ?? `output-channel-${safeChannelName}.png`;
-
-  // Skip on Mac desktop - context menus don't work there
-  if (isMacDesktop()) {
-    console.log('Skipping "Open Output in Editor" on Mac Desktop (context menus not supported)');
-    await ensureOutputPanelOpen(page);
-    await selectOutputChannel(page, channelName);
-    await saveScreenshot(page, `test-results/${screenshotFileName}`, true);
-    return;
-  }
 
   await ensureOutputPanelOpen(page);
   await selectOutputChannel(page, channelName);

--- a/packages/playwright-vscode-ext/src/pages/outputChannel.ts
+++ b/packages/playwright-vscode-ext/src/pages/outputChannel.ts
@@ -294,7 +294,7 @@ export const waitForOutputChannelText = async (
 /**
  * Opens output channel for a named extension, opens it in editor, and takes a screenshot.
  * Useful for debugging when errors occur.
- * Note: Context menus don't work on Mac+Desktop+Electron, so this will skip on that platform.
+ * Note: Context menus now work on Mac desktop via `window.menuStyle: custom` (VS Code 1.101+).
  * In web VS Code, if opening in editor fails, falls back to screenshotting the output panel directly.
  */
 export const captureOutputChannelDetails = async (

--- a/packages/playwright-vscode-ext/test/playwright/specs/contextMenu.headless.spec.ts
+++ b/packages/playwright-vscode-ext/test/playwright/specs/contextMenu.headless.spec.ts
@@ -8,7 +8,7 @@
 import { expect } from '@playwright/test';
 import { executeEditorContextMenuCommand } from '../../../src/pages/contextMenu';
 import { createFileWithContents } from '../../../src/utils/fileHelpers';
-import { waitForVSCodeWorkbench, closeWelcomeTabs, isMacDesktop } from '../../../src/utils/helpers';
+import { waitForVSCodeWorkbench, closeWelcomeTabs } from '../../../src/utils/helpers';
 import { ensureSecondarySideBarHidden } from '../../../src/utils/workflows';
 import { EDITOR_WITH_URI } from '../../../src/utils/locators';
 import { activeQuickInputTextField, activeQuickInputWidget } from '../../../src/utils/quickInput';
@@ -22,8 +22,6 @@ test.describe('Context Menu', () => {
   });
 
   test('should execute editor context menu command', async ({ page }) => {
-    test.skip(isMacDesktop(), 'Context menus not supported on Mac desktop');
-
     await test.step('Create and open untitled file', async () => {
       await createFileWithContents(page, 'unused', 'Test content');
     });
@@ -46,8 +44,6 @@ test.describe('Context Menu', () => {
   });
 
   test('should execute explorer context menu command', async ({ page }) => {
-    test.skip(isMacDesktop(), 'Context menus not supported on Mac desktop');
-
     await test.step('Verify explorer view is accessible', async () => {
       // Focus explorer using keyboard shortcut
       await page.keyboard.press('Control+Shift+KeyE');

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/deployManifest.headless.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/deployManifest.headless.spec.ts
@@ -21,7 +21,6 @@ import {
   executeEditorContextMenuCommand,
   executeExplorerContextMenuCommand,
   executeCommandWithCommandPalette,
-  isMacDesktop,
   validateNoCriticalErrors,
   captureOutputChannelDetails,
   NOTIFICATION_LIST_ITEM,
@@ -41,7 +40,7 @@ import { DEPLOY_TIMEOUT } from '../../constants';
 // eslint-disable-next-line unicorn/prefer-string-replace-all -- regex escaping requires replace with regex pattern
 const escapeRegex = (str: string): string => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-(isMacDesktop() ? test.skip.bind(test) : test)('Deploy Manifest: deploys via all entry points', async ({ page }) => {
+test('Deploy Manifest: deploys via all entry points', async ({ page }) => {
   test.setTimeout(DEPLOY_TIMEOUT);
   const consoleErrors = setupConsoleMonitoring(page);
   const networkErrors = setupNetworkMonitoring(page);

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/deploySourcePath.headless.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/deploySourcePath.headless.spec.ts
@@ -22,7 +22,6 @@ import {
   executeEditorContextMenuCommand,
   executeExplorerContextMenuCommand,
   saveScreenshot,
-  isMacDesktop,
   validateNoCriticalErrors,
   EDITOR,
   NOTIFICATION_LIST_ITEM,
@@ -34,7 +33,7 @@ import { CORE_CONFIG_SECTION, DEPLOY_ON_SAVE_ENABLED } from '../../../src/consta
 import packageNls from '../../../package.nls.json';
 import { DEPLOY_TIMEOUT } from '../../constants';
 
-(isMacDesktop() ? test.skip.bind(test) : test)('Deploy Source Path: deploys via all entry points', async ({ page }) => {
+test('Deploy Source Path: deploys via all entry points', async ({ page }) => {
   test.setTimeout(DEPLOY_TIMEOUT);
   const consoleErrors = setupConsoleMonitoring(page);
   const networkErrors = setupNetworkMonitoring(page);

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/generateManifest.headless.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/generateManifest.headless.spec.ts
@@ -18,7 +18,6 @@ import {
   executeEditorContextMenuCommand,
   executeExplorerContextMenuCommand,
   executeCommandWithCommandPalette,
-  isMacDesktop,
   validateNoCriticalErrors,
   saveScreenshot,
   EDITOR,
@@ -29,94 +28,91 @@ import { SourceTrackingStatusBarPage } from '../pages/sourceTrackingStatusBarPag
 import packageNls from '../../../package.nls.json';
 import { messages } from '../../../src/messages/i18n';
 
-(isMacDesktop() ? test.skip.bind(test) : test)(
-  'Generate Manifest: generates via context menu entry points',
-  async ({ page }) => {
-    const consoleErrors = setupConsoleMonitoring(page);
-    const networkErrors = setupNetworkMonitoring(page);
+test('Generate Manifest: generates via context menu entry points', async ({ page }) => {
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
 
-    let className: string;
-    let statusBarPage: SourceTrackingStatusBarPage;
+  let className: string;
+  let statusBarPage: SourceTrackingStatusBarPage;
 
-    await test.step('setup minimal org', async () => {
-      const createResult = await createMinimalOrg();
-      await waitForVSCodeWorkbench(page);
-      await closeWelcomeTabs(page);
-      await ensureSecondarySideBarHidden(page);
-      await saveScreenshot(page, 'setup.after-workbench.png');
-      await upsertScratchOrgAuthFieldsToSettings(page, createResult);
-      await saveScreenshot(page, 'setup.after-auth-fields.png');
+  await test.step('setup minimal org', async () => {
+    const createResult = await createMinimalOrg();
+    await waitForVSCodeWorkbench(page);
+    await closeWelcomeTabs(page);
+    await ensureSecondarySideBarHidden(page);
+    await saveScreenshot(page, 'setup.after-workbench.png');
+    await upsertScratchOrgAuthFieldsToSettings(page, createResult);
+    await saveScreenshot(page, 'setup.after-auth-fields.png');
 
-      statusBarPage = new SourceTrackingStatusBarPage(page);
-      await statusBarPage.waitForVisible(120_000);
-      await saveScreenshot(page, 'setup.after-status-bar-visible.png');
-    });
+    statusBarPage = new SourceTrackingStatusBarPage(page);
+    await statusBarPage.waitForVisible(120_000);
+    await saveScreenshot(page, 'setup.after-status-bar-visible.png');
+  });
 
-    await test.step('1. Editor context menu', async () => {
-      // Create apex class (opens editor automatically)
-      className = `GenerateManifestTest${Date.now()}`;
-      await createApexClass(page, className);
-      await saveScreenshot(page, 'step1.after-create-class.png');
+  await test.step('1. Editor context menu', async () => {
+    // Create apex class (opens editor automatically)
+    className = `GenerateManifestTest${Date.now()}`;
+    await createApexClass(page, className);
+    await saveScreenshot(page, 'step1.after-create-class.png');
 
-      // Right-click in the editor → "SFDX: Generate Manifest File"
-      await executeEditorContextMenuCommand(page, packageNls.project_generate_manifest_text, `${className}.cls`);
-      await saveScreenshot(page, 'step1.after-context-menu.png');
+    // Right-click in the editor → "SFDX: Generate Manifest File"
+    await executeEditorContextMenuCommand(page, packageNls.project_generate_manifest_text, `${className}.cls`);
+    await saveScreenshot(page, 'step1.after-context-menu.png');
 
-      // Wait for input prompt
-      const quickInput = activeQuickInputWidget(page);
-      await quickInput.waitFor({ state: 'attached', timeout: 10_000 });
-      await quickInput.getByText(messages.manifest_input_save_prompt).waitFor({ state: 'attached', timeout: 10_000 });
-      await saveScreenshot(page, 'step1.manifest-prompt-visible.png');
+    // Wait for input prompt
+    const quickInput = activeQuickInputWidget(page);
+    await quickInput.waitFor({ state: 'attached', timeout: 10_000 });
+    await quickInput.getByText(messages.manifest_input_save_prompt).waitFor({ state: 'attached', timeout: 10_000 });
+    await saveScreenshot(page, 'step1.manifest-prompt-visible.png');
 
-      // Accept default filename (package.xml) by pressing Enter
-      await page.keyboard.press('Enter');
-      await saveScreenshot(page, 'step1.after-accept-filename.png');
+    // Accept default filename (package.xml) by pressing Enter
+    await page.keyboard.press('Enter');
+    await saveScreenshot(page, 'step1.after-accept-filename.png');
 
-      // Wait for manifest file to be created and opened
-      const manifestEditor = page.locator(`${EDITOR}[data-uri*="manifest/package.xml"]`).first();
-      await manifestEditor.waitFor({ state: 'visible', timeout: 15_000 });
-      await saveScreenshot(page, 'step1.manifest-opened.png');
+    // Wait for manifest file to be created and opened
+    const manifestEditor = page.locator(`${EDITOR}[data-uri*="manifest/package.xml"]`).first();
+    await manifestEditor.waitFor({ state: 'visible', timeout: 15_000 });
+    await saveScreenshot(page, 'step1.manifest-opened.png');
 
-      // Assert manifest file exists in explorer - focus explorer first, then look for file
-      await executeCommandWithCommandPalette(page, 'File: Focus on Files Explorer');
-      const manifestFile = page.getByRole('treeitem', { name: /package\.xml/i });
-      await expect(manifestFile).toBeVisible({ timeout: 10_000 });
-      await saveScreenshot(page, 'step1.manifest-in-explorer.png');
+    // Assert manifest file exists in explorer - focus explorer first, then look for file
+    await executeCommandWithCommandPalette(page, 'File: Focus on Files Explorer');
+    const manifestFile = page.getByRole('treeitem', { name: /package\.xml/i });
+    await expect(manifestFile).toBeVisible({ timeout: 10_000 });
+    await saveScreenshot(page, 'step1.manifest-in-explorer.png');
 
-      // Close editors to prepare for next step
-      await executeCommandWithCommandPalette(page, 'View: Close All Editors');
-      await saveScreenshot(page, 'step1.after-close-editors.png');
-    });
+    // Close editors to prepare for next step
+    await executeCommandWithCommandPalette(page, 'View: Close All Editors');
+    await saveScreenshot(page, 'step1.after-close-editors.png');
+  });
 
-    await test.step('2. Explorer context menu (folder)', async () => {
-      // Right-click classes folder in explorer → "SFDX: Generate Manifest File"
-      await executeExplorerContextMenuCommand(page, /classes/i, packageNls.project_generate_manifest_text);
-      await saveScreenshot(page, 'step2.after-context-menu.png');
+  await test.step('2. Explorer context menu (folder)', async () => {
+    // Right-click classes folder in explorer → "SFDX: Generate Manifest File"
+    await executeExplorerContextMenuCommand(page, /classes/i, packageNls.project_generate_manifest_text);
+    await saveScreenshot(page, 'step2.after-context-menu.png');
 
-      // Wait for input prompt
-      const quickInput = activeQuickInputWidget(page);
-      await quickInput.waitFor({ state: 'attached', timeout: 10_000 });
-      await quickInput.getByText(messages.manifest_input_save_prompt).waitFor({ state: 'attached', timeout: 10_000 });
-      await saveScreenshot(page, 'step2.manifest-prompt-visible.png');
+    // Wait for input prompt
+    const quickInput = activeQuickInputWidget(page);
+    await quickInput.waitFor({ state: 'attached', timeout: 10_000 });
+    await quickInput.getByText(messages.manifest_input_save_prompt).waitFor({ state: 'attached', timeout: 10_000 });
+    await saveScreenshot(page, 'step2.manifest-prompt-visible.png');
 
-      // Type a different filename to avoid overwrite prompt
-      await page.keyboard.type('package2');
-      await saveScreenshot(page, 'step2.after-type-filename.png');
-      await page.keyboard.press('Enter');
-      await saveScreenshot(page, 'step2.after-accept-filename.png');
+    // Type a different filename to avoid overwrite prompt
+    await page.keyboard.type('package2');
+    await saveScreenshot(page, 'step2.after-type-filename.png');
+    await page.keyboard.press('Enter');
+    await saveScreenshot(page, 'step2.after-accept-filename.png');
 
-      // Wait for manifest file to be created and opened
-      const manifestEditor = page.locator(`${EDITOR}[data-uri*="manifest/package2.xml"]`).first();
-      await manifestEditor.waitFor({ state: 'visible', timeout: 15_000 });
-      await saveScreenshot(page, 'step2.manifest-opened.png');
+    // Wait for manifest file to be created and opened
+    const manifestEditor = page.locator(`${EDITOR}[data-uri*="manifest/package2.xml"]`).first();
+    await manifestEditor.waitFor({ state: 'visible', timeout: 15_000 });
+    await saveScreenshot(page, 'step2.manifest-opened.png');
 
-      // Assert manifest file exists in explorer - focus explorer first, then look for file
-      await executeCommandWithCommandPalette(page, 'File: Focus on Files Explorer');
-      const manifestFile = page.getByRole('treeitem', { name: /package2\.xml/i });
-      await expect(manifestFile).toBeVisible({ timeout: 10_000 });
-      await saveScreenshot(page, 'step2.manifest-in-explorer.png');
-    });
+    // Assert manifest file exists in explorer - focus explorer first, then look for file
+    await executeCommandWithCommandPalette(page, 'File: Focus on Files Explorer');
+    const manifestFile = page.getByRole('treeitem', { name: /package2\.xml/i });
+    await expect(manifestFile).toBeVisible({ timeout: 10_000 });
+    await saveScreenshot(page, 'step2.manifest-in-explorer.png');
+  });
 
-    await validateNoCriticalErrors(test, consoleErrors, networkErrors);
-  }
-);
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/nonTrackingOrgDeployRetrieveManifest.headless.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/nonTrackingOrgDeployRetrieveManifest.headless.spec.ts
@@ -23,7 +23,6 @@ import {
   selectOutputChannel,
   waitForOutputChannelText,
   isDesktop,
-  isMacDesktop,
   activeQuickInputWidget,
   EDITOR,
   ensureSecondarySideBarHidden
@@ -34,7 +33,7 @@ import { messages } from '../../../src/messages/i18n';
 import packageNls from '../../../package.nls.json';
 import { DEPLOY_TIMEOUT, RETRIEVE_TIMEOUT } from '../../constants';
 
-(isDesktop() && !isMacDesktop() ? test : test.skip.bind(test))(
+(isDesktop() ? test : test.skip.bind(test))(
   'Non-Tracking Org: deploy/retrieve via manifest work without tracking',
   async ({ page }) => {
     test.setTimeout(RETRIEVE_TIMEOUT);

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/retrieveInManifest.headless.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/retrieveInManifest.headless.spec.ts
@@ -19,7 +19,6 @@ import {
   executeEditorContextMenuCommand,
   executeExplorerContextMenuCommand,
   executeCommandWithCommandPalette,
-  isMacDesktop,
   validateNoCriticalErrors,
   saveScreenshot,
   ensureOutputPanelOpen,
@@ -38,120 +37,117 @@ import { RETRIEVE_TIMEOUT } from '../../constants';
 
 test.setTimeout(RETRIEVE_TIMEOUT);
 
-(isMacDesktop() ? test.skip.bind(test) : test)(
-  'Retrieve In Manifest: retrieves via all entry points',
-  async ({ page }) => {
-    const consoleErrors = setupConsoleMonitoring(page);
-    const networkErrors = setupNetworkMonitoring(page);
+test('Retrieve In Manifest: retrieves via all entry points', async ({ page }) => {
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
 
-    let className: string;
-    let statusBarPage: SourceTrackingStatusBarPage;
+  let className: string;
+  let statusBarPage: SourceTrackingStatusBarPage;
 
-    await test.step('setup minimal org', async () => {
-      const createResult = await createMinimalOrg();
-      await waitForVSCodeWorkbench(page);
-      await closeWelcomeTabs(page);
-      await ensureSecondarySideBarHidden(page);
-      await saveScreenshot(page, 'setup.after-workbench.png');
-      await upsertScratchOrgAuthFieldsToSettings(page, createResult);
-      await saveScreenshot(page, 'setup.after-auth-fields.png');
+  await test.step('setup minimal org', async () => {
+    const createResult = await createMinimalOrg();
+    await waitForVSCodeWorkbench(page);
+    await closeWelcomeTabs(page);
+    await ensureSecondarySideBarHidden(page);
+    await saveScreenshot(page, 'setup.after-workbench.png');
+    await upsertScratchOrgAuthFieldsToSettings(page, createResult);
+    await saveScreenshot(page, 'setup.after-auth-fields.png');
 
-      statusBarPage = new SourceTrackingStatusBarPage(page);
-      await statusBarPage.waitForVisible(120_000);
-      await saveScreenshot(page, 'setup.after-status-bar-visible.png');
-    });
+    statusBarPage = new SourceTrackingStatusBarPage(page);
+    await statusBarPage.waitForVisible(120_000);
+    await saveScreenshot(page, 'setup.after-status-bar-visible.png');
+  });
 
-    await test.step('create apex class', async () => {
-      // Create apex class (opens editor automatically)
-      className = `RetrieveManifestTest${Date.now()}`;
-      await createApexClass(page, className);
-      await saveScreenshot(page, 'setup.after-create-class.png');
-    });
+  await test.step('create apex class', async () => {
+    // Create apex class (opens editor automatically)
+    className = `RetrieveManifestTest${Date.now()}`;
+    await createApexClass(page, className);
+    await saveScreenshot(page, 'setup.after-create-class.png');
+  });
 
-    await test.step('generate manifest from apex class', async () => {
-      // Generate manifest from the active editor (Apex class)
-      await executeCommandWithCommandPalette(page, packageNls.project_generate_manifest_text);
+  await test.step('generate manifest from apex class', async () => {
+    // Generate manifest from the active editor (Apex class)
+    await executeCommandWithCommandPalette(page, packageNls.project_generate_manifest_text);
 
-      // Wait for input prompt
-      const quickInput = activeQuickInputWidget(page);
-      await quickInput.waitFor({ state: 'attached', timeout: 10_000 });
-      await quickInput.getByText(messages.manifest_input_save_prompt).waitFor({ state: 'attached', timeout: 10_000 });
+    // Wait for input prompt
+    const quickInput = activeQuickInputWidget(page);
+    await quickInput.waitFor({ state: 'attached', timeout: 10_000 });
+    await quickInput.getByText(messages.manifest_input_save_prompt).waitFor({ state: 'attached', timeout: 10_000 });
 
-      // Accept default filename (package.xml) by pressing Enter
-      await page.keyboard.press('Enter');
+    // Accept default filename (package.xml) by pressing Enter
+    await page.keyboard.press('Enter');
 
-      // Wait for manifest file to be created and opened
-      const manifestEditor = page.locator(`${EDITOR}[data-uri*="manifest/package.xml"]`).first();
-      await manifestEditor.waitFor({ state: 'visible', timeout: 15_000 });
-    });
+    // Wait for manifest file to be created and opened
+    const manifestEditor = page.locator(`${EDITOR}[data-uri*="manifest/package.xml"]`).first();
+    await manifestEditor.waitFor({ state: 'visible', timeout: 15_000 });
+  });
 
-    await test.step('deploy class to org', async () => {
-      // Open the manifest file
-      await openFileByName(page, 'package.xml');
+  await test.step('deploy class to org', async () => {
+    // Open the manifest file
+    await openFileByName(page, 'package.xml');
 
-      // Ensure the manifest editor is focused and ready
-      const manifestEditor = page.locator(`${EDITOR}[data-uri*="manifest/package.xml"]`).first();
-      await manifestEditor.waitFor({ state: 'visible', timeout: 10_000 });
-      await manifestEditor.click();
+    // Ensure the manifest editor is focused and ready
+    const manifestEditor = page.locator(`${EDITOR}[data-uri*="manifest/package.xml"]`).first();
+    await manifestEditor.waitFor({ state: 'visible', timeout: 10_000 });
+    await manifestEditor.click();
 
-      // Deploy the manifest to push the class to the org
-      await executeEditorContextMenuCommand(page, packageNls.deploy_in_manifest_text, 'manifest/package.xml');
+    // Deploy the manifest to push the class to the org
+    await executeEditorContextMenuCommand(page, packageNls.deploy_in_manifest_text, 'manifest/package.xml');
 
-      // Verify deploy completes
-      const deployingNotification = await waitForDeployProgressNotificationToAppear(page, 30_000);
-      await expect(deployingNotification).not.toBeVisible({ timeout: RETRIEVE_TIMEOUT });
+    // Verify deploy completes
+    const deployingNotification = await waitForDeployProgressNotificationToAppear(page, 30_000);
+    await expect(deployingNotification).not.toBeVisible({ timeout: RETRIEVE_TIMEOUT });
 
-      // Check for deploy error notifications
-      const postDeployNotifications = page.locator(NOTIFICATION_LIST_ITEM);
-      const deployErrorPattern = new RegExp(
-        `${messages.deploy_completed_with_errors_message}|${messages.deploy_failed.replaceAll('%s', '.*')}`,
-        'i'
-      );
-      const deployErrorNotification = postDeployNotifications.filter({ hasText: deployErrorPattern }).first();
-      const hasDeployError = await deployErrorNotification.isVisible({ timeout: 2000 }).catch(() => false);
-      if (hasDeployError) {
-        const errorText = await deployErrorNotification.textContent();
-        throw new Error(`Deploy failed with error notification: ${errorText}`);
-      }
-    });
+    // Check for deploy error notifications
+    const postDeployNotifications = page.locator(NOTIFICATION_LIST_ITEM);
+    const deployErrorPattern = new RegExp(
+      `${messages.deploy_completed_with_errors_message}|${messages.deploy_failed.replaceAll('%s', '.*')}`,
+      'i'
+    );
+    const deployErrorNotification = postDeployNotifications.filter({ hasText: deployErrorPattern }).first();
+    const hasDeployError = await deployErrorNotification.isVisible({ timeout: 2000 }).catch(() => false);
+    if (hasDeployError) {
+      const errorText = await deployErrorNotification.textContent();
+      throw new Error(`Deploy failed with error notification: ${errorText}`);
+    }
+  });
 
-    await test.step('1. Editor context menu', async () => {
-      // Open the manifest file (Quick Open shows just "package.xml")
-      await openFileByName(page, 'package.xml');
+  await test.step('1. Editor context menu', async () => {
+    // Open the manifest file (Quick Open shows just "package.xml")
+    await openFileByName(page, 'package.xml');
 
-      // Ensure the manifest editor is focused and ready
-      const manifestEditor = page.locator(`${EDITOR}[data-uri*="manifest/package.xml"]`).first();
-      await manifestEditor.waitFor({ state: 'visible', timeout: 10_000 });
-      await manifestEditor.click();
+    // Ensure the manifest editor is focused and ready
+    const manifestEditor = page.locator(`${EDITOR}[data-uri*="manifest/package.xml"]`).first();
+    await manifestEditor.waitFor({ state: 'visible', timeout: 10_000 });
+    await manifestEditor.click();
 
-      // Prepare output channel before triggering command
-      await ensureOutputPanelOpen(page);
-      await selectOutputChannel(page, 'Salesforce Metadata');
+    // Prepare output channel before triggering command
+    await ensureOutputPanelOpen(page);
+    await selectOutputChannel(page, 'Salesforce Metadata');
 
-      // Right-click the manifest editor → "SFDX: Retrieve Source in Manifest from Org"
-      await executeEditorContextMenuCommand(page, packageNls.retrieve_in_manifest_text, 'manifest/package.xml');
+    // Right-click the manifest editor → "SFDX: Retrieve Source in Manifest from Org"
+    await executeEditorContextMenuCommand(page, packageNls.retrieve_in_manifest_text, 'manifest/package.xml');
 
-      // Verify retrieve starts and completes via output channel
-      await waitForOutputChannelText(page, { expectedText: 'Retrieving', timeout: 30_000 });
-      await waitForOutputChannelText(page, { expectedText: 'Retrieved Source', timeout: RETRIEVE_TIMEOUT });
-    });
+    // Verify retrieve starts and completes via output channel
+    await waitForOutputChannelText(page, { expectedText: 'Retrieving', timeout: 30_000 });
+    await waitForOutputChannelText(page, { expectedText: 'Retrieved Source', timeout: RETRIEVE_TIMEOUT });
+  });
 
-    await test.step('2. Explorer context menu (file)', async () => {
-      // Close any open editors to ensure clean state
-      await executeCommandWithCommandPalette(page, 'View: Close All Editors');
+  await test.step('2. Explorer context menu (file)', async () => {
+    // Close any open editors to ensure clean state
+    await executeCommandWithCommandPalette(page, 'View: Close All Editors');
 
-      // Prepare output channel
-      await ensureOutputPanelOpen(page);
-      await selectOutputChannel(page, 'Salesforce Metadata');
+    // Prepare output channel
+    await ensureOutputPanelOpen(page);
+    await selectOutputChannel(page, 'Salesforce Metadata');
 
-      // Right-click manifest in explorer → "SFDX: Retrieve Source in Manifest from Org"
-      await executeExplorerContextMenuCommand(page, /package\.xml/i, packageNls.retrieve_in_manifest_text);
+    // Right-click manifest in explorer → "SFDX: Retrieve Source in Manifest from Org"
+    await executeExplorerContextMenuCommand(page, /package\.xml/i, packageNls.retrieve_in_manifest_text);
 
-      // Verify retrieve starts and completes via output channel
-      await waitForOutputChannelText(page, { expectedText: 'Retrieving', timeout: 30_000 });
-      await waitForOutputChannelText(page, { expectedText: 'Retrieved Source', timeout: RETRIEVE_TIMEOUT });
-    });
+    // Verify retrieve starts and completes via output channel
+    await waitForOutputChannelText(page, { expectedText: 'Retrieving', timeout: 30_000 });
+    await waitForOutputChannelText(page, { expectedText: 'Retrieved Source', timeout: RETRIEVE_TIMEOUT });
+  });
 
-    await validateNoCriticalErrors(test, consoleErrors, networkErrors);
-  }
-);
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/retrieveSourcePath.headless.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/retrieveSourcePath.headless.spec.ts
@@ -19,7 +19,6 @@ import {
   openFileByName,
   executeExplorerContextMenuCommand,
   executeCommandWithCommandPalette,
-  isMacDesktop,
   validateNoCriticalErrors,
   saveScreenshot,
   ensureOutputPanelOpen,
@@ -34,90 +33,83 @@ import packageNls from '../../../package.nls.json';
 import { DEPLOY_TIMEOUT, RETRIEVE_TIMEOUT } from '../../constants';
 import { CORE_CONFIG_SECTION, DEPLOY_ON_SAVE_ENABLED } from '../../../src/constants';
 
-// Skip on Mac desktop (right-click doesn't work)
-(isMacDesktop() ? test.skip.bind(test) : test)(
-  'Retrieve Source Path: retrieves file via explorer context menu',
-  async ({ page }) => {
-    test.setTimeout(RETRIEVE_TIMEOUT);
+test('Retrieve Source Path: retrieves file via explorer context menu', async ({ page }) => {
+  test.setTimeout(RETRIEVE_TIMEOUT);
 
-    const consoleErrors = setupConsoleMonitoring(page);
-    const networkErrors = setupNetworkMonitoring(page);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
 
-    let className: string;
-    let statusBarPage: SourceTrackingStatusBarPage;
+  let className: string;
+  let statusBarPage: SourceTrackingStatusBarPage;
 
-    await test.step('setup minimal org', async () => {
-      const createResult = await createMinimalOrg();
-      await waitForVSCodeWorkbench(page);
-      await closeWelcomeTabs(page);
-      await ensureSecondarySideBarHidden(page);
-      await saveScreenshot(page, 'setup.after-workbench.png');
-      await upsertScratchOrgAuthFieldsToSettings(page, createResult);
-      await saveScreenshot(page, 'setup.after-auth-fields.png');
+  await test.step('setup minimal org', async () => {
+    const createResult = await createMinimalOrg();
+    await waitForVSCodeWorkbench(page);
+    await closeWelcomeTabs(page);
+    await ensureSecondarySideBarHidden(page);
+    await saveScreenshot(page, 'setup.after-workbench.png');
+    await upsertScratchOrgAuthFieldsToSettings(page, createResult);
+    await saveScreenshot(page, 'setup.after-auth-fields.png');
 
-      statusBarPage = new SourceTrackingStatusBarPage(page);
-      await statusBarPage.waitForVisible(120_000);
-      await saveScreenshot(page, 'setup.after-status-bar-visible.png');
-      await saveScreenshot(page, 'setup.complete.png');
-      await upsertSettings(page, { [`${CORE_CONFIG_SECTION}.${DEPLOY_ON_SAVE_ENABLED}`]: 'false' });
-    });
+    statusBarPage = new SourceTrackingStatusBarPage(page);
+    await statusBarPage.waitForVisible(120_000);
+    await saveScreenshot(page, 'setup.after-status-bar-visible.png');
+    await saveScreenshot(page, 'setup.complete.png');
+    await upsertSettings(page, { [`${CORE_CONFIG_SECTION}.${DEPLOY_ON_SAVE_ENABLED}`]: 'false' });
+  });
 
-    await test.step('create local apex class, deploy to org, and make remote change', async () => {
-      // Create apex class locally
-      className = `RetrieveSourcePathTest${Date.now()}`;
-      await createApexClass(page, className);
-      await saveScreenshot(page, 'step1.after-create-class.png');
+  await test.step('create local apex class, deploy to org, and make remote change', async () => {
+    // Create apex class locally
+    className = `RetrieveSourcePathTest${Date.now()}`;
+    await createApexClass(page, className);
+    await saveScreenshot(page, 'step1.after-create-class.png');
 
-      // Wait for local count to increment
-      await statusBarPage.waitForCounts({ local: 1 }, 60_000);
-      const countsAfterCreate = await statusBarPage.getCounts();
-      await saveScreenshot(
-        page,
-        `step1.after-create-counts-${countsAfterCreate.local}-${countsAfterCreate.remote}.png`
-      );
+    // Wait for local count to increment
+    await statusBarPage.waitForCounts({ local: 1 }, 60_000);
+    const countsAfterCreate = await statusBarPage.getCounts();
+    await saveScreenshot(page, `step1.after-create-counts-${countsAfterCreate.local}-${countsAfterCreate.remote}.png`);
 
-      // Deploy class to org so it exists for retrieve
-      await executeCommandWithCommandPalette(page, packageNls.deploy_this_source_text);
-      const deployingNotification = await waitForDeployProgressNotificationToAppear(page, 30_000);
-      await saveScreenshot(page, 'step1.deploy-notification-appeared.png');
-      await expect(deployingNotification).not.toBeVisible({ timeout: DEPLOY_TIMEOUT });
-      await statusBarPage.waitForCounts({ local: 0 }, 60_000);
-      await saveScreenshot(page, 'step1.after-deploy.png');
+    // Deploy class to org so it exists for retrieve
+    await executeCommandWithCommandPalette(page, packageNls.deploy_this_source_text);
+    const deployingNotification = await waitForDeployProgressNotificationToAppear(page, 30_000);
+    await saveScreenshot(page, 'step1.deploy-notification-appeared.png');
+    await expect(deployingNotification).not.toBeVisible({ timeout: DEPLOY_TIMEOUT });
+    await statusBarPage.waitForCounts({ local: 0 }, 60_000);
+    await saveScreenshot(page, 'step1.after-deploy.png');
 
-      // Simulate remote change by making a local edit
-      // This creates a scenario where the file exists remotely but differs locally
-      await openFileByName(page, `${className}.cls`);
-      await editOpenFile(page, 'Remote change simulation');
-      await statusBarPage.waitForCounts({ local: 1 }, 60_000);
-      await saveScreenshot(page, 'step1.after-edit.png');
-    });
+    // Simulate remote change by making a local edit
+    // This creates a scenario where the file exists remotely but differs locally
+    await openFileByName(page, `${className}.cls`);
+    await editOpenFile(page, 'Remote change simulation');
+    await statusBarPage.waitForCounts({ local: 1 }, 60_000);
+    await saveScreenshot(page, 'step1.after-edit.png');
+  });
 
-    await test.step('retrieve file via explorer context menu', async () => {
-      const initialCounts = await statusBarPage.getCounts();
-      await saveScreenshot(page, `step2.initial-counts-${initialCounts.local}-${initialCounts.remote}.png`);
+  await test.step('retrieve file via explorer context menu', async () => {
+    const initialCounts = await statusBarPage.getCounts();
+    await saveScreenshot(page, `step2.initial-counts-${initialCounts.local}-${initialCounts.remote}.png`);
 
-      // Prepare output channel before triggering command
-      await ensureOutputPanelOpen(page);
-      await selectOutputChannel(page, 'Salesforce Metadata');
+    // Prepare output channel before triggering command
+    await ensureOutputPanelOpen(page);
+    await selectOutputChannel(page, 'Salesforce Metadata');
 
-      // Right-click the apex class file in explorer and select retrieve
-      const classFilePattern = new RegExp(`${className}\\.cls$`, 'i');
-      await executeExplorerContextMenuCommand(page, classFilePattern, packageNls.retrieve_this_source_text);
-      await saveScreenshot(page, 'step2.after-context-menu.png');
+    // Right-click the apex class file in explorer and select retrieve
+    const classFilePattern = new RegExp(`${className}\\.cls$`, 'i');
+    await executeExplorerContextMenuCommand(page, classFilePattern, packageNls.retrieve_this_source_text);
+    await saveScreenshot(page, 'step2.after-context-menu.png');
 
-      // Verify retrieve starts and completes via output channel
-      // Retrieve operations may not show progress notifications consistently across platforms
-      await waitForOutputChannelText(page, { expectedText: 'Retrieving', timeout: 30_000 });
-      await saveScreenshot(page, 'step2.retrieve-started.png');
+    // Verify retrieve starts and completes via output channel
+    // Retrieve operations may not show progress notifications consistently across platforms
+    await waitForOutputChannelText(page, { expectedText: 'Retrieving', timeout: 30_000 });
+    await saveScreenshot(page, 'step2.retrieve-started.png');
 
-      await waitForOutputChannelText(page, { expectedText: 'Retrieved Source', timeout: RETRIEVE_TIMEOUT });
-      await saveScreenshot(page, 'step2.retrieve-complete.png');
+    await waitForOutputChannelText(page, { expectedText: 'Retrieved Source', timeout: RETRIEVE_TIMEOUT });
+    await saveScreenshot(page, 'step2.retrieve-complete.png');
 
-      // After retrieve, local count should decrease (file retrieved from org)
-      // We verify the retrieve operation completed successfully
-      await saveScreenshot(page, 'step2.final-state.png');
-    });
+    // After retrieve, local count should decrease (file retrieved from org)
+    // We verify the retrieve operation completed successfully
+    await saveScreenshot(page, 'step2.final-state.png');
+  });
 
-    await validateNoCriticalErrors(test, consoleErrors, networkErrors);
-  }
-);
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});


### PR DESCRIPTION
## Summary

- Removed Mac desktop skips from context menu E2E tests — now run on macOS via `window.menuStyle: custom`
- Dropped `isMacDesktop()` skip wrappers from 6 metadata deploy/retrieve/generate manifest specs
- Cleaned orphaned `isMacDesktop` imports from affected test files

## Plan

[.claude/plans/W-21336718.md](.claude/plans/W-21336718.md)

## Reviewer notes

None.

## Test plan

All changes are in E2E test files — verified by Mac desktop CI runs on `macos-latest`:
- `metadataE2E.yml` runs modified metadata specs
- `playwrightVscodeExtE2E.yml` runs modified contextMenu spec

### What issues does this PR fix or reference?

@W-21336718@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002VFUsXYAX/view