### PR TITLE
test(eslint): enable playwright/no-page-pause rule - W-22888212

### DIFF
--- a/.claude/plans/W-22888212.md
+++ b/.claude/plans/W-22888212.md
@@ -1,0 +1,63 @@
+# W-22888212 playwright lint: no-page-pause
+
+## Context
+
+- Child of W-21067614 (burn down eslint-plugin-playwright warnings, flip to error).
+- Pattern from siblings (jest/* rules): remove violations + enable rule as error.
+- `eslint-plugin-playwright` NOT yet a dep; no `playwright/*` rules in `eslint.config.mjs`. Must add plugin + scoped config block.
+- 9 `await page.pause()` calls, all inside DEBUG_MODE-gated `afterEach` hooks:
+  - 8 fixture `index.ts` files — `afterEach` body is ONLY the DEBUG_MODE pause block → remove whole `afterEach`:
+    - `packages/salesforcedx-vscode-apex-log/test/playwright/fixtures/index.ts:15-21`
+    - `packages/salesforcedx-vscode-metadata/test/playwright/fixtures/index.ts:20-`
+    - `packages/salesforcedx-vscode-services/test/playwright/fixtures/index.ts:17-`
+    - `packages/salesforcedx-vscode-apex-testing/test/playwright/fixtures/index.ts:15-`
+    - `packages/salesforcedx-vscode-lwc/test/playwright/fixtures/index.ts:14-`
+    - `packages/salesforcedx-vscode-soql/test/playwright/fixtures/index.ts:14-`
+    - `packages/salesforcedx-vscode-org-browser/test/playwright/fixtures/index.ts:18-`
+    - `packages/playwright-vscode-ext/test/playwright/fixtures/index.ts:18-24`
+  - 1 with extra video-rename logic — remove ONLY the DEBUG_MODE block, keep video rename:
+    - `packages/playwright-vscode-ext/src/fixtures/createDesktopTest.ts:419-423`
+- Rule `playwright/no-page-pause` ships in eslint-plugin-playwright 2.10.4 (latest).
+- Existing playwright config scope block (eslint.config.mjs ~577-593) globs: `packages/salesforcedx**/test/playwright/**/*`, `packages/salesforcedx-vscode-automation-tests/**/*`, `packages/playwright-vscode-ext/**/*.ts`.
+- Glob coverage for the lone `src/` pause: `packages/playwright-vscode-ext/**/*.ts` has NO `test/` segment, so it matches `packages/playwright-vscode-ext/src/fixtures/createDesktopTest.ts` (verified: that file is the one src-path violation, all 8 others are under `test/playwright/`). The `ignores: ['**/locators.ts']` does not affect it. Coverage MUST still be confirmed by the Phase 2 negative test (re-add pause → eslint errors at that exact path) rather than asserted.
+
+## Phases
+
+### Phase 1: remove page.pause calls
+- Delete DEBUG_MODE pause `afterEach` from 8 fixture index.ts (whole hook + its console.logs + import-unused cleanup if `testInfo`/`page` now unused — but hook removed so no unused).
+- In createDesktopTest.ts remove only DEBUG_MODE block (lines 419-423), keep video-rename + null guard.
+- Verify no other `await page.pause()` outside node_modules remain.
+- commit: `test(playwright): remove DEBUG_MODE page.pause debug calls - W-22888212`
+
+### Phase 2: add plugin dependency + wire import (infra pre-req)
+- Mirrors sibling W-22865166 split (Phase 1 infra compile, then Phase 2 WI rule). Here the infra step is: make the plugin resolvable before any rule references it.
+- Add `eslint-plugin-playwright` (^2.10.4) to root `package.json` devDependencies.
+- `npm install` to update lockfile.
+- Import plugin in `eslint.config.mjs` and register it in `plugins:` of the existing playwright-scoped block (~587, alongside `local: localPlugin`) WITHOUT enabling any rule yet.
+- Verify: `npx eslint eslint.config.mjs` parses (config loads, plugin resolves, no rule active so no behavior change).
+- commit: `chore(eslint): add eslint-plugin-playwright dependency - W-22888212`
+
+### Phase 3: enable rule as error (WI scope)
+- Add `'playwright/no-page-pause': 'error'` to the `rules:` of the playwright-scoped block (~590, alongside `local/no-runtime-vscode-import`).
+- Negative test confirming glob coverage at the src/ path (this is the [adversary:high] coverage proof, not an assertion):
+  - temporarily re-add `await page.pause();` to `packages/playwright-vscode-ext/src/fixtures/createDesktopTest.ts`, then `npx eslint packages/playwright-vscode-ext/src/fixtures/createDesktopTest.ts` → MUST report `playwright/no-page-pause` error → revert the temp edit.
+  - Repeat the same negative test against one `test/playwright/fixtures/index.ts` path to confirm the `salesforcedx**/test/playwright/**` glob also fires.
+- Confirm scope globs cover all 9 former locations via the two negative tests above (one src/, one test/).
+- commit: `test(eslint): enable playwright/no-page-pause rule - W-22888212`
+
+## Skills to apply
+
+- playwright-e2e (fixture/afterEach patterns)
+- packageJson (add dep, lockfile)
+- typescript (unused import cleanup, type-checking verification)
+- verification (lint run)
+- concise (any md edits)
+- feature-branch / pr-draft (already on branch sm/W-22888212-...)
+
+## Verification
+
+- `npx eslint <changed fixture files>` — passes; rule active, no violations. NOT e2e-covered.
+- `git grep -n "page.pause" -- 'packages/**/*.ts' ':!**/node_modules/**'` → 0 hits. NOT e2e-covered.
+- Coverage proof (Phase 3 negative tests) — re-add `page.pause()` at `playwright-vscode-ext/src/fixtures/createDesktopTest.ts` (src/ path) AND at one `test/playwright/fixtures/index.ts` → both error → revert. Confirms glob block reaches both src/ and test/ locations. NOT e2e-covered.
+- Build/typecheck changed packages (afterEach removal may leave unused `testInfo` import — none expected). NOT e2e-covered.
+- e2e-covered: actual playwright test runs on branch CI confirm fixtures still load (afterEach removal doesn't break test setup); no manual run needed.

--- a/.claude/plans/W-22888212.md
+++ b/.claude/plans/W-22888212.md
@@ -4,7 +4,7 @@
 
 - Child of W-21067614 (burn down eslint-plugin-playwright warnings, flip to error)
 - Pattern from siblings (jest/* rules): remove violations + enable rule as error
-- State of `eslint-plugin-playwright` + `playwright/*` rules: depends on which commit you check out — see "Implementation state" below. Pre-change (plan baseline): NOT a dep, no `playwright/*` rules in `eslint.config.mjs` → must add plugin + scoped config block. Post-Phase-2/3 (committed): dep present (`package.json` `^2.10.4`), rule active.
+- State of `eslint-plugin-playwright` + `playwright/*` rules: depends on commit checked out — → Implementation state below. Pre-change (plan baseline): NOT a dep, no `playwright/*` rules in `eslint.config.mjs` → must add plugin + scoped config block. Post-Phase-2/3 (committed): dep present (`package.json` `^2.10.4`), rule active.
 - 9 `await page.pause()` calls, all inside DEBUG_MODE-gated `afterEach` hooks:
   - 8 fixture `index.ts` files — `afterEach` body is ONLY the DEBUG_MODE pause block → remove whole `afterEach`:
     - `packages/salesforcedx-vscode-apex-log/test/playwright/fixtures/index.ts:15-21`
@@ -29,12 +29,12 @@
 ## Phases
 
 ### Phase 1: remove page.pause calls
-- DEBUG_MODE pause `afterEach` from 8 fixture index.ts deleted (whole hook + its console.logs + import-unused cleanup if `testInfo`/`page` now unused — but hook removed so no unused)
+- DEBUG_MODE pause `afterEach` from 8 fixture index.ts deleted (hook + console.logs + unused import cleanup if `testInfo`/`page` now unused — but hook removed so no unused)
 - createDesktopTest.ts: remove only DEBUG_MODE block (lines 419-423), keep video-rename + null guard
 - No other `await page.pause()` outside node_modules remain (verified)
 - commit: `test(playwright): remove DEBUG_MODE page.pause debug calls - W-22888212`
 
-### Phase 2: add plugin dependency + wire import (infra pre-req)
+### Phase 2: add plugin dependency + import
 - Mirrors sibling W-22865166 split (Phase 1 infra compile, then Phase 2 WI rule) — infra step: plugin resolvable before any rule references it
 - `eslint-plugin-playwright` (^2.10.4) to root `package.json` devDependencies
 - `npm install` to update lockfile
@@ -42,11 +42,11 @@
 - Verify: `npx eslint eslint.config.mjs` parses (config loads, plugin resolves, no rule active so no behavior change)
 - commit: `add eslint-plugin-playwright dependency - W-22888212`
 
-### Phase 3: enable rule as error (WI scope)
+### Phase 3: enable rule as error
 - `'playwright/no-page-pause': 'error'` to `rules:` of playwright-scoped block (~590, alongside `local/no-runtime-vscode-import`)
 - commit: `enable playwright/no-page-pause rule - W-22888212` (`cedee4a2a`)
 
-#### Negative test — EXECUTED, evidence recorded ([adversary:high])
+#### Negative test (executed)
 
 Method (non-destructive: temp `__negtest__.ts` files under each glob, not mutation of shipped source — keeps real tree untouched, no accidental commit of a re-added pause):
 ```
@@ -62,21 +62,12 @@ Output (run 2026-06-10, tree at `cedee4a2a`):
 - test/ glob `salesforcedx**/test/playwright/**`:
   `__negtest__.ts 2:9 error Unexpected use of page.pause()  playwright/no-page-pause` → FIRED
 - `git status` after cleanup: temp files removed, no source mutation
-Conclusion: both glob branches reach their paths; all 9 former locations covered. Not asserted — observed.
-
-## Skills to apply
-
-- playwright-e2e (fixture/afterEach patterns)
-- packageJson (add dep, lockfile)
-- typescript (unused import cleanup, type-checking verification)
-- verification (lint run)
-- concise (any md edits)
-- feature-branch / pr-draft (already on branch sm/W-22888212-...)
+Both globs reach all 9 locations (observed).
 
 ## Verification
 
 - `npx eslint <changed fixture files>` — passes; rule active, no violations. NOT e2e-covered.
 - `git grep -n "page.pause" -- 'packages/**/*.ts' ':!**/node_modules/**'` → 0 hits. NOT e2e-covered.
-- Coverage proof (Phase 3 negative test) — EXECUTED, see "Negative test — EXECUTED, evidence recorded" under Phase 3: temp violations under src/ and test/ globs both errored `playwright/no-page-pause`, baseline clean, temp files removed. Confirms glob block reaches both src/ and test/ locations. NOT e2e-covered.
+- Coverage proof (Phase 3 negative test) — EXECUTED, see "Negative test (executed)" under Phase 3: temp violations under src/ and test/ globs both errored `playwright/no-page-pause`, baseline clean, temp files removed. Confirms glob block reaches both src/ and test/ locations. NOT e2e-covered.
 - Build/typecheck changed packages (afterEach removal may leave unused `testInfo` import — none expected). NOT e2e-covered.
 - e2e-covered: actual playwright test runs on branch CI confirm fixtures still load (afterEach removal doesn't break test setup); no manual run needed.

--- a/.claude/plans/W-22888212.md
+++ b/.claude/plans/W-22888212.md
@@ -2,9 +2,9 @@
 
 ## Context
 
-- Child of W-21067614 (burn down eslint-plugin-playwright warnings, flip to error).
-- Pattern from siblings (jest/* rules): remove violations + enable rule as error.
-- `eslint-plugin-playwright` NOT yet a dep; no `playwright/*` rules in `eslint.config.mjs`. Must add plugin + scoped config block.
+- Child of W-21067614 (burn down eslint-plugin-playwright warnings, flip to error)
+- Pattern from siblings (jest/* rules): remove violations + enable rule as error
+- State of `eslint-plugin-playwright` + `playwright/*` rules: depends on which commit you check out — see "Implementation state" below. Pre-change (plan baseline): NOT a dep, no `playwright/*` rules in `eslint.config.mjs` → must add plugin + scoped config block. Post-Phase-2/3 (committed): dep present (`package.json` `^2.10.4`), rule active.
 - 9 `await page.pause()` calls, all inside DEBUG_MODE-gated `afterEach` hooks:
   - 8 fixture `index.ts` files — `afterEach` body is ONLY the DEBUG_MODE pause block → remove whole `afterEach`:
     - `packages/salesforcedx-vscode-apex-log/test/playwright/fixtures/index.ts:15-21`
@@ -17,33 +17,52 @@
     - `packages/playwright-vscode-ext/test/playwright/fixtures/index.ts:18-24`
   - 1 with extra video-rename logic — remove ONLY the DEBUG_MODE block, keep video rename:
     - `packages/playwright-vscode-ext/src/fixtures/createDesktopTest.ts:419-423`
-- Rule `playwright/no-page-pause` ships in eslint-plugin-playwright 2.10.4 (latest).
-- Existing playwright config scope block (eslint.config.mjs ~577-593) globs: `packages/salesforcedx**/test/playwright/**/*`, `packages/salesforcedx-vscode-automation-tests/**/*`, `packages/playwright-vscode-ext/**/*.ts`.
-- Glob coverage for the lone `src/` pause: `packages/playwright-vscode-ext/**/*.ts` has NO `test/` segment, so it matches `packages/playwright-vscode-ext/src/fixtures/createDesktopTest.ts` (verified: that file is the one src-path violation, all 8 others are under `test/playwright/`). The `ignores: ['**/locators.ts']` does not affect it. Coverage MUST still be confirmed by the Phase 2 negative test (re-add pause → eslint errors at that exact path) rather than asserted.
+- Rule `playwright/no-page-pause` ships in eslint-plugin-playwright 2.10.4 (latest)
+- Existing playwright config scope block (eslint.config.mjs ~577-593) globs: `packages/salesforcedx**/test/playwright/**/*`, `packages/salesforcedx-vscode-automation-tests/**/*`, `packages/playwright-vscode-ext/**/*.ts`
+- Glob coverage for the lone `src/` pause: `packages/playwright-vscode-ext/**/*.ts` has NO `test/` segment, matches `packages/playwright-vscode-ext/src/fixtures/createDesktopTest.ts` (verified: that file is the one src-path violation, all 8 others under `test/playwright/`) — `ignores: ['**/locators.ts']` does not affect it
+
+## Implementation state (plan is retrospective)
+
+- Plan committed `51105fe4b` 15:56; implementation committed after (`acedfd0f3` 15:59, `701da0459` 16:01, `cedee4a2a` 16:02). Findings reviewed against committed code, so Context above describes pre-change baseline; current tree reflects post-implementation.
+- Commit map: Phase 1 → `acedfd0f3`, Phase 2 (dep) → `701da0459` (added `eslint-plugin-playwright ^2.10.4`), Phase 3 (rule) → `cedee4a2a` (eslint.config.mjs +2/-1).
 
 ## Phases
 
 ### Phase 1: remove page.pause calls
-- Delete DEBUG_MODE pause `afterEach` from 8 fixture index.ts (whole hook + its console.logs + import-unused cleanup if `testInfo`/`page` now unused — but hook removed so no unused).
-- In createDesktopTest.ts remove only DEBUG_MODE block (lines 419-423), keep video-rename + null guard.
-- Verify no other `await page.pause()` outside node_modules remain.
+- DEBUG_MODE pause `afterEach` from 8 fixture index.ts deleted (whole hook + its console.logs + import-unused cleanup if `testInfo`/`page` now unused — but hook removed so no unused)
+- createDesktopTest.ts: remove only DEBUG_MODE block (lines 419-423), keep video-rename + null guard
+- No other `await page.pause()` outside node_modules remain (verified)
 - commit: `test(playwright): remove DEBUG_MODE page.pause debug calls - W-22888212`
 
 ### Phase 2: add plugin dependency + wire import (infra pre-req)
-- Mirrors sibling W-22865166 split (Phase 1 infra compile, then Phase 2 WI rule). Here the infra step is: make the plugin resolvable before any rule references it.
-- Add `eslint-plugin-playwright` (^2.10.4) to root `package.json` devDependencies.
-- `npm install` to update lockfile.
-- Import plugin in `eslint.config.mjs` and register it in `plugins:` of the existing playwright-scoped block (~587, alongside `local: localPlugin`) WITHOUT enabling any rule yet.
-- Verify: `npx eslint eslint.config.mjs` parses (config loads, plugin resolves, no rule active so no behavior change).
-- commit: `chore(eslint): add eslint-plugin-playwright dependency - W-22888212`
+- Mirrors sibling W-22865166 split (Phase 1 infra compile, then Phase 2 WI rule) — infra step: plugin resolvable before any rule references it
+- `eslint-plugin-playwright` (^2.10.4) to root `package.json` devDependencies
+- `npm install` to update lockfile
+- Import plugin in `eslint.config.mjs`, register in `plugins:` of existing playwright-scoped block (~587, alongside `local: localPlugin`) WITHOUT enabling any rule yet
+- Verify: `npx eslint eslint.config.mjs` parses (config loads, plugin resolves, no rule active so no behavior change)
+- commit: `add eslint-plugin-playwright dependency - W-22888212`
 
 ### Phase 3: enable rule as error (WI scope)
-- Add `'playwright/no-page-pause': 'error'` to the `rules:` of the playwright-scoped block (~590, alongside `local/no-runtime-vscode-import`).
-- Negative test confirming glob coverage at the src/ path (this is the [adversary:high] coverage proof, not an assertion):
-  - temporarily re-add `await page.pause();` to `packages/playwright-vscode-ext/src/fixtures/createDesktopTest.ts`, then `npx eslint packages/playwright-vscode-ext/src/fixtures/createDesktopTest.ts` → MUST report `playwright/no-page-pause` error → revert the temp edit.
-  - Repeat the same negative test against one `test/playwright/fixtures/index.ts` path to confirm the `salesforcedx**/test/playwright/**` glob also fires.
-- Confirm scope globs cover all 9 former locations via the two negative tests above (one src/, one test/).
-- commit: `test(eslint): enable playwright/no-page-pause rule - W-22888212`
+- `'playwright/no-page-pause': 'error'` to `rules:` of playwright-scoped block (~590, alongside `local/no-runtime-vscode-import`)
+- commit: `enable playwright/no-page-pause rule - W-22888212` (`cedee4a2a`)
+
+#### Negative test — EXECUTED, evidence recorded ([adversary:high])
+
+Method (non-destructive: temp `__negtest__.ts` files under each glob, not mutation of shipped source — keeps real tree untouched, no accidental commit of a re-added pause):
+```
+printf 'export const f = async (page: any) => {\n  await page.pause();\n};\n' \
+  > packages/playwright-vscode-ext/src/fixtures/__negtest__.ts
+printf '...same...' > packages/salesforcedx-vscode-apex-log/test/playwright/fixtures/__negtest__.ts
+npx eslint <each temp file>; rm -f <temp files>
+```
+Output (run 2026-06-10, tree at `cedee4a2a`):
+- baseline `npx eslint <src> <test>` → 0 `no-page-pause` (clean)
+- src/ glob `packages/playwright-vscode-ext/**/*.ts`:
+  `__negtest__.ts 2:9 error Unexpected use of page.pause()  playwright/no-page-pause` → FIRED
+- test/ glob `salesforcedx**/test/playwright/**`:
+  `__negtest__.ts 2:9 error Unexpected use of page.pause()  playwright/no-page-pause` → FIRED
+- `git status` after cleanup: temp files removed, no source mutation
+Conclusion: both glob branches reach their paths; all 9 former locations covered. Not asserted — observed.
 
 ## Skills to apply
 
@@ -58,6 +77,6 @@
 
 - `npx eslint <changed fixture files>` — passes; rule active, no violations. NOT e2e-covered.
 - `git grep -n "page.pause" -- 'packages/**/*.ts' ':!**/node_modules/**'` → 0 hits. NOT e2e-covered.
-- Coverage proof (Phase 3 negative tests) — re-add `page.pause()` at `playwright-vscode-ext/src/fixtures/createDesktopTest.ts` (src/ path) AND at one `test/playwright/fixtures/index.ts` → both error → revert. Confirms glob block reaches both src/ and test/ locations. NOT e2e-covered.
+- Coverage proof (Phase 3 negative test) — EXECUTED, see "Negative test — EXECUTED, evidence recorded" under Phase 3: temp violations under src/ and test/ globs both errored `playwright/no-page-pause`, baseline clean, temp files removed. Confirms glob block reaches both src/ and test/ locations. NOT e2e-covered.
 - Build/typecheck changed packages (afterEach removal may leave unused `testInfo` import — none expected). NOT e2e-covered.
 - e2e-covered: actual playwright test runs on branch CI confirm fixtures still load (afterEach removal doesn't break test setup); no manual run needed.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -590,7 +590,8 @@ export default [
       playwright: eslintPluginPlaywright
     },
     rules: {
-      'local/no-runtime-vscode-import': 'error'
+      'local/no-runtime-vscode-import': 'error',
+      'playwright/no-page-pause': 'error'
     }
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,7 @@ import functional from 'eslint-plugin-functional';
 import eslintPluginWorkspaces from 'eslint-plugin-workspaces';
 import effectPlugin from '@effect/eslint-plugin';
 import eslintPluginEslintPlugin from 'eslint-plugin-eslint-plugin';
+import eslintPluginPlaywright from 'eslint-plugin-playwright';
 import jsonPlugin from '@eslint/json';
 
 import htmlEslintPlugin from '@html-eslint/eslint-plugin';
@@ -585,7 +586,8 @@ export default [
     ],
     ignores: ['**/locators.ts'],
     plugins: {
-      local: localPlugin
+      local: localPlugin,
+      playwright: eslintPluginPlaywright
     },
     rules: {
       'local/no-runtime-vscode-import': 'error'

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,7 @@
         "eslint-plugin-jest-formatting": "3.1.0",
         "eslint-plugin-jsdoc": "50.6.9",
         "eslint-plugin-local-rules": "3.0.2",
+        "eslint-plugin-playwright": "^2.10.4",
         "eslint-plugin-prefer-arrow": "1.2.3",
         "eslint-plugin-unicorn": "64.0.0",
         "eslint-plugin-workspaces": "0.12.1",
@@ -19883,6 +19884,35 @@
       "integrity": "sha512-IWME7GIYHXogTkFsToLdBCQVJ0U4kbSuVyDT+nKoR4UgtnVrrVeNWuAZkdEu1nxkvi9nsPccGehEEF6dgA28IQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/eslint-plugin-playwright": {
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.10.4.tgz",
+      "integrity": "sha512-l0V/VxyqfFbtqCTxj5AdRn3Q6S/hIW4nKBnKZVleVbZ24N2My6Usj//ytX3dKKqAoSbvKck9YtSytfdZ5qjLuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globals": "^17.3.0"
+      },
+      "engines": {
+        "node": ">=16.9.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/eslint-plugin-playwright/node_modules/globals": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/eslint-plugin-prefer-arrow": {
       "version": "1.2.3",
@@ -50581,7 +50611,7 @@
         "@salesforce/salesforcedx-utils": "*",
         "@salesforce/salesforcedx-utils-vscode": "*",
         "@salesforce/source-deploy-retrieve": "^12.32.5",
-        "@salesforce/templates": "66.9.3",
+        "@salesforce/templates": "^66.9.3",
         "@salesforce/ts-types": "^2.0.12",
         "@salesforce/vscode-i18n": "*",
         "@salesforce/vscode-service-provider": "^1.5.0",
@@ -50764,7 +50794,7 @@
         "@salesforce/o11y-reporter": "^1.8.1",
         "@salesforce/source-deploy-retrieve": "^12.32.5",
         "@salesforce/source-tracking": "^7.8.16",
-        "@salesforce/templates": "66.9.3",
+        "@salesforce/templates": "^66.9.3",
         "@salesforce/vscode-i18n": "*",
         "@vscode/extension-telemetry": "^1.0.0",
         "effect": "^3.21.2",
@@ -50911,7 +50941,7 @@
         "@babel/preset-typescript": "^7.0.0",
         "@lwc/engine-dom": "^9.0.0",
         "@lwc/eslint-plugin-lwc": "^3.5.0",
-        "@lwc/jest-preset": "19.6.1",
+        "@lwc/jest-preset": "^19.6.1",
         "@lwc/rollup-plugin": "^9.0.0",
         "@lwc/synthetic-shadow": "^9.1.1",
         "@rollup/plugin-alias": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "eslint-plugin-jest-formatting": "3.1.0",
     "eslint-plugin-jsdoc": "50.6.9",
     "eslint-plugin-local-rules": "3.0.2",
+    "eslint-plugin-playwright": "^2.10.4",
     "eslint-plugin-prefer-arrow": "1.2.3",
     "eslint-plugin-unicorn": "64.0.0",
     "eslint-plugin-workspaces": "0.12.1",

--- a/packages/playwright-vscode-ext/src/fixtures/createDesktopTest.ts
+++ b/packages/playwright-vscode-ext/src/fixtures/createDesktopTest.ts
@@ -416,12 +416,6 @@ export const createDesktopTest = (options: CreateDesktopTestOptions) => {
       return;
     }
 
-    if (process.env.DEBUG_MODE && testInfo.status !== 'passed') {
-      console.log('\n🔍 DEBUG_MODE: Test failed - pausing to keep VS Code window open.');
-      console.log('Press Resume in Playwright Inspector or close VS Code window to continue.');
-      await page.pause();
-    }
-
     // Rename video with test name for easy identification
     const video = page.video();
     if (video) {

--- a/packages/playwright-vscode-ext/test/playwright/fixtures/index.ts
+++ b/packages/playwright-vscode-ext/test/playwright/fixtures/index.ts
@@ -13,12 +13,3 @@ const isDesktop = process.env.VSCODE_DESKTOP === '1';
 // Export the appropriate test based on environment (fixtures differ)
 // expect is the same for both, so just re-export it directly
 export const test = isDesktop ? desktopTest : webTest;
-
-// Keep browser open on test failure when in debug mode
-test.afterEach(async ({ page }, testInfo) => {
-  if (process.env.DEBUG_MODE && testInfo.status !== 'passed') {
-    console.log('\n🔍 DEBUG_MODE: Test failed - pausing to keep browser open.');
-    console.log('Press Resume in Playwright Inspector or close browser to continue.');
-    await page.pause();
-  }
-});

--- a/packages/salesforcedx-vscode-apex-log/test/playwright/fixtures/index.ts
+++ b/packages/salesforcedx-vscode-apex-log/test/playwright/fixtures/index.ts
@@ -11,15 +11,6 @@ import { desktopTest, emptyWorkspaceDesktopTest, multiPackageNoOrgDesktopTest, n
 
 const isDesktop = process.env.VSCODE_DESKTOP === '1';
 
-// Keep browser open on test failure when in debug mode
-webTest.afterEach(async ({ page }, testInfo) => {
-  if (process.env.DEBUG_MODE && testInfo.status !== 'passed') {
-    console.log('\n🔍 DEBUG_MODE: Test failed - pausing to keep browser open.');
-    console.log('Press Resume in Playwright Inspector or close browser to continue.');
-    await page.pause();
-  }
-});
-
 export const test = isDesktop ? desktopTest : webTest;
 export const emptyWorkspaceTest = isDesktop ? emptyWorkspaceDesktopTest : webTest;
 export const noOrgTest = isDesktop ? noOrgDesktopTest : webTest;

--- a/packages/salesforcedx-vscode-apex-testing/test/playwright/fixtures/index.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/playwright/fixtures/index.ts
@@ -11,15 +11,6 @@ import { desktopTest, emptyWorkspaceDesktopTest, noOrgDesktopTest } from './desk
 
 const isDesktop = process.env.VSCODE_DESKTOP === '1';
 
-// Keep browser open on test failure when in debug mode
-webTest.afterEach(async ({ page }, testInfo) => {
-  if (process.env.DEBUG_MODE && testInfo.status !== 'passed') {
-    console.log('\n🔍 DEBUG_MODE: Test failed - pausing to keep browser open.');
-    console.log('Press Resume in Playwright Inspector or close browser to continue.');
-    await page.pause();
-  }
-});
-
 // Export the appropriate test based on environment (fixtures differ)
 // expect is the same for both, so just re-export it directly
 export const test = isDesktop ? desktopTest : webTest;

--- a/packages/salesforcedx-vscode-lwc/test/playwright/fixtures/index.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/fixtures/index.ts
@@ -11,12 +11,4 @@ import { desktopTest } from './desktopFixtures';
 
 const isDesktop = process.env.VSCODE_DESKTOP === '1';
 
-webTest.afterEach(async ({ page }, testInfo) => {
-  if (process.env.DEBUG_MODE && testInfo.status !== 'passed') {
-    console.log('\n🔍 DEBUG_MODE: Test failed - pausing to keep browser open.');
-    console.log('Press Resume in Playwright Inspector or close browser to continue.');
-    await page.pause();
-  }
-});
-
 export const test = isDesktop ? desktopTest : webTest;

--- a/packages/salesforcedx-vscode-metadata/test/playwright/fixtures/index.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/fixtures/index.ts
@@ -16,15 +16,6 @@ import { webTrackingConflictTest } from './webConflictFixtures';
 
 const isDesktop = process.env.VSCODE_DESKTOP === '1';
 
-// Keep browser open on test failure when in debug mode
-webTest.afterEach(async ({ page }, testInfo) => {
-  if (process.env.DEBUG_MODE && testInfo.status !== 'passed') {
-    console.log('\n🔍 DEBUG_MODE: Test failed - pausing to keep browser open.');
-    console.log('Press Resume in Playwright Inspector or close browser to continue.');
-    await page.pause();
-  }
-});
-
 // Export the appropriate test based on environment (fixtures differ)
 // expect is the same for both, so just re-export it directly
 export const test = isDesktop ? desktopTest : webTest;

--- a/packages/salesforcedx-vscode-org-browser/test/playwright/fixtures/index.ts
+++ b/packages/salesforcedx-vscode-org-browser/test/playwright/fixtures/index.ts
@@ -13,12 +13,3 @@ const isDesktop = process.env.VSCODE_DESKTOP === '1';
 // Export the appropriate test based on environment (fixtures differ)
 // expect is the same for both, so just re-export it directly
 export const test = isDesktop ? desktopTest : webTest;
-
-// Keep browser open on test failure when in debug mode
-test.afterEach(async ({ page }, testInfo) => {
-  if (process.env.DEBUG_MODE && testInfo.status !== 'passed') {
-    console.log('\n🔍 DEBUG_MODE: Test failed - pausing to keep browser open.');
-    console.log('Press Resume in Playwright Inspector or close browser to continue.');
-    await page.pause();
-  }
-});

--- a/packages/salesforcedx-vscode-services/test/playwright/fixtures/index.ts
+++ b/packages/salesforcedx-vscode-services/test/playwright/fixtures/index.ts
@@ -12,12 +12,3 @@ const isDesktop = process.env.VSCODE_DESKTOP === '1';
 // Export the appropriate test based on environment (fixtures differ)
 // expect is the same for both, so just re-export it directly
 export const test = isDesktop ? webTest : webTest; // Desktop fixtures can be added later if needed
-
-// Keep browser open on test failure when in debug mode
-test.afterEach(async ({ page }, testInfo) => {
-  if (process.env.DEBUG_MODE && testInfo.status !== 'passed') {
-    console.log('\n🔍 DEBUG_MODE: Test failed - pausing to keep browser open.');
-    console.log('Press Resume in Playwright Inspector or close browser to continue.');
-    await page.pause();
-  }
-});

--- a/packages/salesforcedx-vscode-soql/test/playwright/fixtures/index.ts
+++ b/packages/salesforcedx-vscode-soql/test/playwright/fixtures/index.ts
@@ -10,15 +10,6 @@ import { desktopTest } from './desktopFixtures';
 
 const isDesktop = process.env.VSCODE_DESKTOP === '1';
 
-// Keep browser open on test failure when in debug mode
-webTest.afterEach(async ({ page }, testInfo) => {
-  if (process.env.DEBUG_MODE && testInfo.status !== 'passed') {
-    console.log('\nDEBUG_MODE: Test failed - pausing to keep browser open.');
-    console.log('Press Resume in Playwright Inspector or close browser to continue.');
-    await page.pause();
-  }
-});
-
 // Export the appropriate test based on environment (fixtures differ)
 // expect is the same for both, so just re-export it directly
 export const test = isDesktop ? desktopTest : webTest;


### PR DESCRIPTION
## Summary

- Remove 9 DEBUG_MODE-gated `page.pause()` calls from Playwright test fixtures
- Add eslint-plugin-playwright dependency and enable `playwright/no-page-pause` rule as error
- Part of parent WI W-21067614 (burn down eslint-plugin-playwright warnings)

## Plan

[.claude/plans/W-22888212.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-22888212-playwright-lint-no-page-pause/.claude/plans/W-22888212.md)

## Reviewer notes

- package-lock.json lines 50611/50794/50941 changed @salesforce/templates (2x) and @lwc/jest-preset from exact to caret versions. No corresponding package.json change in this diff — develop's lockfile was stale and npm install reconciled it against existing caret specs. Benign, no resolved-version change, but widens the diff beyond the eslint-plugin-playwright scope.

## Test plan

- [ ] `npx eslint <changed fixture files>` passes; rule active, no violations
- [ ] `git grep -n "page.pause" -- 'packages/**/*.ts' ':!**/node_modules/**'` returns 0 hits
- [ ] Coverage proof via negative test: temp violations under src/ and test/ globs both error `playwright/no-page-pause`, baseline clean
- [ ] Build/typecheck changed packages (afterEach removal doesn't leave unused imports)

### What issues does this PR fix or reference?

@W-22888212@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002bhD4oYAE/view