### PR TITLE
refactor(observability): consolidate pjson context and connection string calc - W-22815903

### DIFF
--- a/packages/salesforcedx-vscode-apex-testing/package.json
+++ b/packages/salesforcedx-vscode-apex-testing/package.json
@@ -20,7 +20,6 @@
   "o11yUploadEndpoint": "https://794testsite.my.site.com/byolwr/webruntime/log/metrics",
   "enableO11y": "true",
   "productFeatureId": "aJCEE0000000mLm4AI",
-  "aiKey": "ec3632a4-df47-47a4-98dc-8134cacbaf7e",
   "license": "BSD-3-Clause",
   "engines": {
     "vscode": "^1.90.0"

--- a/packages/salesforcedx-vscode-apex-testing/src/services/extensionProvider.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/services/extensionProvider.ts
@@ -44,16 +44,11 @@ export const buildAllServicesLayer = (context: ExtensionContext) =>
       // ErrorHandlerService depends on ChannelService, provide the extension's channel
       const channelLayer = api.services.ChannelServiceLayer(displayName);
       const errorHandlerWithChannel = Layer.provide(api.services.ErrorHandlerService.Default, channelLayer);
-
-      const config = api.services.getSdkLayerConfigFromContext(context);
-
-      config.enableCustomEventsFromSpans = true;
-
       return Layer.mergeAll(
         ExtensionProviderServiceLive,
         Layer.succeedContext(api.services.prebuiltServicesDependencies),
         api.services.ExtensionContextServiceLayer(context),
-        api.services.SdkLayerFor(config),
+        api.services.SdkLayerFor(context),
         channelLayer,
         errorHandlerWithChannel
       );

--- a/packages/salesforcedx-vscode-services/src/index.ts
+++ b/packages/salesforcedx-vscode-services/src/index.ts
@@ -35,7 +35,6 @@ import { SourceTrackingService } from './core/sourceTrackingService';
 import { TemplateService, TemplateType } from './core/templateService';
 import { TraceFlagService } from './core/traceFlagService';
 import { TransmogrifierService } from './core/transmogrifierService';
-import { setExtensionMode } from './observability/appInsights';
 import { annotateExtensionPackType } from './observability/extensionPackStatus';
 import { getSdkLayerConfigFromContext } from './observability/sdkLayerConfig';
 import { SdkLayerFor, ServicesSdkLayer } from './observability/spans';
@@ -219,8 +218,6 @@ const activationEffect = Effect.fn('activation:salesforcedx-vscode-services')(fu
   context: vscode.ExtensionContext
 ) {
   yield* (yield* ChannelService).appendToChannel(`${SERVICES_CHANNEL_NAME} extension is activating!`);
-  // Set extension mode for telemetry gating (blocks dev mode by default)
-  setExtensionMode(context.extensionMode);
   // do this first to prevent Connection issues.
   yield* updateTelemetryUserIds(context);
   const scope = yield* getExtensionScope();

--- a/packages/salesforcedx-vscode-services/src/observability/README.md
+++ b/packages/salesforcedx-vscode-services/src/observability/README.md
@@ -58,14 +58,13 @@ Node platform can route to **customEvents** table (matching Web) by enabling the
 ```typescript
 const config = api.services.getSdkLayerConfigFromContext(context);
 config.enableCustomEventsFromSpans = true;  // Routes Node spans to customEvents
-config.connectionString = "InstrumentationKey=...";  // optional: override at runtime (or bare UUID)
 
 const services = AllServicesLayer.pipe(
   Layer.provide(api.services.SdkLayerFor(config))
 );
 ```
 
-The connection string is resolved from your extension's `package.json` with precedence:
+The connection string is resolved from your extension's `package.json` (via `getSdkLayerConfigFromContext`) with precedence:
 1. `otelConnectionString` — dedicated OTEL field, full format, used as-is
 2. `aiKey` — legacy field; normalized from bare UUID to InstrumentationKey= format if needed
 3. Undefined — falls back to `DEFAULT_AI_CONNECTION_STRING`
@@ -229,18 +228,12 @@ import * as vscode from 'vscode';
 export const AllServicesLayer = Layer.unwrapEffect(
   Effect.gen(function* () {
     const api = yield* extensionProvider.getServicesApi;
-    const extension = vscode.extensions.getExtension(`salesforce.${EXTENSION_NAME}`);
-    const extensionVersion = extension?.packageJSON?.version ?? 'unknown';
-    const o11yEndpoint = process.env.O11Y_ENDPOINT ?? extension?.packageJSON?.o11yUploadEndpoint;
+    const context = vscode.extensions.getExtension(`salesforce.${EXTENSION_NAME}`)?.extensionContext;
+    const config = api.services.getSdkLayerConfigFromContext(context);  // connectionString auto-resolved (otelConnectionString → aiKey → DEFAULT_AI_CONNECTION_STRING)
 
     return Layer.mergeAll(
       // ... other service layers ...
-      api.services.SdkLayerFor({
-        extensionName: EXTENSION_NAME,
-        extensionVersion,
-        o11yEndpoint,
-        connectionString: extension?.packageJSON?.otelConnectionString || extension?.packageJSON?.aiKey  // optional: otelConnectionString preferred, then aiKey (auto-normalized)
-      })
+      api.services.SdkLayerFor(config)
       // ... other service layers ...
     );
   })

--- a/packages/salesforcedx-vscode-services/src/observability/appInsights.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/appInsights.ts
@@ -5,21 +5,13 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import * as Effect from 'effect/Effect';
 import { ExtensionMode, workspace } from 'vscode';
+import { getExtensionContext } from '../vscode/extensionContext';
 
-/** instrumention key / connection string for test-otel-effect */
+/** instrumentation key / connection string for test-otel-effect */
 export const DEFAULT_AI_CONNECTION_STRING =
   'InstrumentationKey=f5cbbeba-e06b-4657-b99c-62024c9d36bf;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/;ApplicationId=1485438c-5495-43dc-8c0a-b51e860b6cba';
-
-let _extensionMode: ExtensionMode | undefined; // eslint-disable-line functional/no-let
-
-/**
- * Set the extension mode for telemetry gating.
- * Called during extension activation to enable dev mode checks.
- */
-export const setExtensionMode = (mode: ExtensionMode): void => {
-  _extensionMode = mode;
-};
 
 export const isTelemetryExtensionConfigurationEnabled = (): boolean => {
   // Check VS Code telemetry settings
@@ -35,13 +27,13 @@ export const isTelemetryExtensionConfigurationEnabled = (): boolean => {
 
   // Block dev mode telemetry by default to prevent polluting production data
   // Can be overridden with salesforcedx-vscode-core.telemetry.allowDevMode setting
-  const isDevMode = _extensionMode !== undefined && _extensionMode !== ExtensionMode.Production;
-  if (isDevMode) {
-    const allowDevMode = workspace
-      .getConfiguration('salesforcedx-vscode-core')
-      .get<boolean>('telemetry.allowDevMode', false);
-    return allowDevMode;
-  }
-
-  return true;
+  const extensionMode = Effect.runSync(
+    Effect.gen(function* () {
+      const ctx = yield* getExtensionContext();
+      return ctx.extensionMode;
+    }).pipe(Effect.orElseSucceed(() => undefined))
+  );
+  return extensionMode !== undefined && extensionMode !== ExtensionMode.Production
+    ? workspace.getConfiguration('salesforcedx-vscode-core').get<boolean>('telemetry.allowDevMode', false)
+    : true;
 };

--- a/packages/salesforcedx-vscode-services/src/observability/sdkLayerConfig.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/sdkLayerConfig.ts
@@ -6,6 +6,7 @@
  */
 import * as vscode from 'vscode';
 import { ExtensionContext } from 'vscode';
+import { DEFAULT_AI_CONNECTION_STRING } from './appInsights';
 
 export type SdkLayerConfig = {
   extensionName: string;
@@ -16,8 +17,8 @@ export type SdkLayerConfig = {
   /**
    * Full Azure Monitor connection string for the OTEL path.
    * Expected format: "InstrumentationKey=...;IngestionEndpoint=..."
-   * Resolved from packageJSON: otelConnectionString preferred over aiKey (normalized).
-   * If undefined, NodeSdkLayerFor falls back to DEFAULT_AI_CONNECTION_STRING.
+   * Resolved from packageJSON: otelConnectionString preferred over aiKey (normalized),
+   * falling back to DEFAULT_AI_CONNECTION_STRING.
    */
   connectionString?: string;
 };
@@ -28,7 +29,7 @@ export type SdkLayerConfig = {
  * 2. aiKey — legacy field; normalized from bare UUID to InstrumentationKey= format if needed
  * 3. undefined — NodeSdkLayerFor falls back to DEFAULT_AI_CONNECTION_STRING
  */
-const resolveConnectionString = (packageJSON: Record<string, unknown>): string | undefined => {
+const resolveConnectionString = (packageJSON: ExtensionPackageJSON): string | undefined => {
   const otelConnectionString = packageJSON?.otelConnectionString;
   if (typeof otelConnectionString === 'string' && otelConnectionString) return otelConnectionString;
   const aiKey = packageJSON?.aiKey;
@@ -36,13 +37,26 @@ const resolveConnectionString = (packageJSON: Record<string, unknown>): string |
   return aiKey.includes('InstrumentationKey=') ? aiKey : `InstrumentationKey=${aiKey}`;
 };
 
-export const getSdkLayerConfigFromContext = (context: ExtensionContext): SdkLayerConfig => ({
-  extensionName: context.extension.packageJSON.name,
-  extensionVersion: context.extension.packageJSON.version,
-  o11yEndpoint: process.env.O11Y_ENDPOINT ?? context.extension.packageJSON?.o11yUploadEndpoint,
-  productFeatureId: context.extension.packageJSON?.productFeatureId,
-  enableCustomEventsFromSpans: context.extension.packageJSON?.enableCustomEventsFromSpans,
-  connectionString: resolveConnectionString(context.extension.packageJSON)
+type ExtensionPackageJSON = {
+  name: string;
+  version: string;
+  o11yUploadEndpoint?: string;
+  productFeatureId?: string;
+  enableCustomEventsFromSpans?: boolean;
+  otelConnectionString?: string;
+  aiKey?: string;
+};
+
+export const getSdkLayerConfigFromPackageJSON = (packageJSON: ExtensionPackageJSON): SdkLayerConfig => ({
+  extensionName: packageJSON.name,
+  extensionVersion: packageJSON.version,
+  o11yEndpoint: process.env.O11Y_ENDPOINT ?? packageJSON?.o11yUploadEndpoint,
+  productFeatureId: packageJSON?.productFeatureId,
+  enableCustomEventsFromSpans: packageJSON?.enableCustomEventsFromSpans,
+  connectionString: resolveConnectionString(packageJSON) ?? DEFAULT_AI_CONNECTION_STRING
 });
+
+export const getSdkLayerConfigFromContext = (context: ExtensionContext): SdkLayerConfig =>
+  getSdkLayerConfigFromPackageJSON(context.extension.packageJSON);
 export const isExtensionContext = (input: SdkLayerConfig | vscode.ExtensionContext): input is vscode.ExtensionContext =>
   'extension' in input;

--- a/packages/salesforcedx-vscode-services/src/observability/spans.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/spans.ts
@@ -5,7 +5,12 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import * as vscode from 'vscode';
-import { type SdkLayerConfig, getSdkLayerConfigFromContext, isExtensionContext } from './sdkLayerConfig';
+import {
+  type SdkLayerConfig,
+  getSdkLayerConfigFromContext,
+  getSdkLayerConfigFromPackageJSON,
+  isExtensionContext
+} from './sdkLayerConfig';
 import { NodeSdkLayerFor } from './spansNode';
 import { WebSdkLayerFor } from './spansWeb';
 
@@ -21,6 +26,11 @@ export const SdkLayerFor = (input: SdkLayerConfig | vscode.ExtensionContext) => 
 /** Pre-built SDK layer factory for the services extension itself */
 export const ServicesSdkLayer = () => {
   const extension = vscode.extensions.getExtension('salesforce.salesforcedx-vscode-services');
-  const extensionVersion = extension?.packageJSON?.version ?? 'unknown';
-  return SdkLayerFor({ extensionName: 'salesforcedx-vscode-services', extensionVersion });
+  return SdkLayerFor(
+    getSdkLayerConfigFromPackageJSON({
+      name: 'salesforcedx-vscode-services',
+      version: 'unknown',
+      ...extension?.packageJSON
+    })
+  );
 };

--- a/packages/salesforcedx-vscode-services/src/observability/spansNode.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/spansNode.ts
@@ -39,13 +39,10 @@ export const NodeSdkLayerFor = ({
   enableCustomEventsFromSpans,
   connectionString
 }: SdkLayerConfig) => {
-  // connectionString is already normalized by getSdkLayerConfigFromContext (otelConnectionString
-  // preferred over aiKey, bare UUIDs wrapped). This block is a safety net for SdkLayerConfig
-  // constructed directly (e.g. tests, ServicesSdkLayer) without going through that helper.
-  const resolvedConnectionString = connectionString ?? DEFAULT_AI_CONNECTION_STRING;
-  const effectiveConnectionString = resolvedConnectionString.includes('InstrumentationKey=')
-    ? resolvedConnectionString
-    : `InstrumentationKey=${resolvedConnectionString}`;
+  // connectionString is normalized (otelConnectionString preferred over aiKey, bare UUIDs wrapped)
+  // and defaulted by sdkLayerConfig.ts. This `?? DEFAULT` is a safety net for SdkLayerConfig
+  // constructed directly (e.g. tests) without going through those helpers.
+  const effectiveConnectionString = connectionString ?? DEFAULT_AI_CONNECTION_STRING;
 
   return NodeSdk.layer(() => ({
     resource: {

--- a/packages/salesforcedx-vscode-services/test/jest/observability/sdkLayerConfig.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/observability/sdkLayerConfig.test.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { DEFAULT_AI_CONNECTION_STRING } from '../../../src/observability/appInsights';
 import { getSdkLayerConfigFromContext } from '../../../src/observability/sdkLayerConfig';
 import type { ExtensionContext } from 'vscode';
 
@@ -47,8 +48,8 @@ describe('getSdkLayerConfigFromContext — connectionString resolution', () => {
     expect(config.connectionString).toBe(full);
   });
 
-  it('returns undefined when neither otelConnectionString nor aiKey are present', () => {
+  it('falls back to DEFAULT_AI_CONNECTION_STRING when neither otelConnectionString nor aiKey are present', () => {
     const config = getSdkLayerConfigFromContext(makeContext({ name: 'ext', version: '1.0.0' }));
-    expect(config.connectionString).toBeUndefined();
+    expect(config.connectionString).toBe(DEFAULT_AI_CONNECTION_STRING);
   });
 });


### PR DESCRIPTION
### What does this PR do?

Refactor on top of #7418. Consolidates connection-string resolution and extension-context access into the config layer, removing module-level state.

- **`sdkLayerConfig.ts`** — `resolveConnectionString` now defaults to `DEFAULT_AI_CONNECTION_STRING` so config carries a resolved value. Adds typed `ExtensionPackageJSON` and a `getSdkLayerConfigFromPackageJSON` helper; `getSdkLayerConfigFromContext` delegates to it.
- **`appInsights.ts`** — drops the module-level `_extensionMode` + `setExtensionMode` setter; dev-mode gating reads `extensionMode` from `getExtensionContext()` directly.
- **`spans.ts` / `spansNode.ts`** — `ServicesSdkLayer` builds config via `getSdkLayerConfigFromPackageJSON`; node layer's normalization block reduced to a `?? DEFAULT` safety net since config is already resolved.
- **`index.ts`** — removes the `setExtensionMode(context.extensionMode)` activation call.
- **README + test** — docs and the resolution test updated for the new default-fallback behavior.

### What issues does this PR fix or reference?

@W-22815903@
