### PR TITLE
chore(eslint): enable jest/no-deprecated-functions - W-22865157

### DIFF
--- a/.claude/plans/W-22865157.md
+++ b/.claude/plans/W-22865157.md
@@ -1,0 +1,32 @@
+# W-22865157 — Enable jest/no-deprecated-functions
+
+## Context
+
+- Goal: add `'jest/no-deprecated-functions': 'error'` to jest rules block in `eslint.config.mjs`.
+- Block at lines 539-575; siblings `jest/unbound-method` (561), `jest/no-focused-tests` (562).
+- Blocker W-11678119 (`jest/no-focused-tests`) already landed — present line 562.
+- Plugin `eslint-plugin-jest` 28.14.0 installed + wired for all test globs. No plugin add.
+- Verified: rule added temporarily, full fresh `npm run lint` (79 scripts) → 0 violations, exit 0. No code fixes needed.
+- Rule flags deprecated Jest APIs (e.g. `jest.requireActual` predecessors, `jest.genMockFromModule`); none in repo.
+
+## Phases
+
+### Phase 1 — add rule
+
+- Edit `eslint.config.mjs`: insert `'jest/no-deprecated-functions': 'error',` after `'jest/unbound-method': 'error',` (line 561).
+- Files: `eslint.config.mjs`
+- Commit: `chore(eslint): enable jest/no-deprecated-functions - W-22865157`
+
+No fix phase — zero violations confirmed.
+
+## Skills
+
+- typescript — ESLint configured for TS project
+- verification — confirm lint passes
+- wireit — lint runs via wireit; clear `.wireit` caches for fresh run
+
+## Verification
+
+- `npm run lint` → exit 0 (clear `.wireit` caches first for non-cached run).
+- Confirm `grep -n no-deprecated-functions eslint.config.mjs` → present, `error`.
+- Not e2e-covered (lint-only config change).

--- a/.claude/plans/W-22865157.md
+++ b/.claude/plans/W-22865157.md
@@ -4,9 +4,9 @@
 
 - Goal: add `'jest/no-deprecated-functions': 'error'` to jest rules block in `eslint.config.mjs`.
 - Block at lines 539-575; siblings `jest/unbound-method` (561), `jest/no-focused-tests` (562).
-- Blocker W-11678119 (`jest/no-focused-tests`) already landed — present line 562.
-- Plugin `eslint-plugin-jest` 28.14.0 installed + wired for all test globs. No plugin add.
-- Verified: rule added temporarily, full fresh `npm run lint` (79 scripts) → 0 violations, exit 0. No code fixes needed.
+- Blocker W-11678119 (`jest/no-focused-tests`) landed — present line 562.
+- Plugin `eslint-plugin-jest` 28.14.0 installed + wired for test globs. No add needed.
+- Verified: rule added temporarily, fresh `npm run lint` (79 scripts) → 0 violations, exit 0. No code fixes needed.
 - Rule flags deprecated Jest APIs (e.g. `jest.requireActual` predecessors, `jest.genMockFromModule`); none in repo.
 
 ## Phases
@@ -27,6 +27,6 @@ No fix phase — zero violations confirmed.
 
 ## Verification
 
-- `npm run lint` → exit 0 (clear `.wireit` caches first for non-cached run).
-- Confirm `grep -n no-deprecated-functions eslint.config.mjs` → present, `error`.
+- `npm run lint` → exit 0 (clear `.wireit` caches for fresh run).
+- `grep -n no-deprecated-functions eslint.config.mjs` → present, `error`.
 - Not e2e-covered (lint-only config change).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -559,6 +559,7 @@ export default [
       '@typescript-eslint/restrict-template-expressions': 'warn',
       '@typescript-eslint/unbound-method': 'off',
       'jest/unbound-method': 'error',
+      'jest/no-deprecated-functions': 'error',
       'jest/no-focused-tests': 'error',
       'jest/prefer-to-have-length': 'error',
       'jest/no-standalone-expect': 'error',


### PR DESCRIPTION
## Summary

- Added `jest/no-deprecated-functions` ESLint rule to catch usage of deprecated Jest APIs
- Zero violations in existing codebase—no code changes required
- Prevents future use of deprecated functions like `jest.genMockFromModule`, `jest.requireActual` predecessors

## Plan

[.claude/plans/W-22865157.md](.claude/plans/W-22865157.md)

## Test plan

- [x] Verify `npm run lint` exits 0
- [x] Confirm `grep -n no-deprecated-functions eslint.config.mjs` shows rule present at 'error'

## What issues does this PR fix or reference?

@W-22865157@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.my.salesforce.com/a07EE00002bc7AFYAY