### PR TITLE
test(lwc): replace waitForTimeout with tree-item state wait in lwcRunTests Test Explorer helper - W-22972995

### DIFF
--- a/.claude/plans/W-22972995.md
+++ b/.claude/plans/W-22972995.md
@@ -1,0 +1,39 @@
+# W-22972995 — LWC E2E: replace waitForTimeout in lwcRunTests Test Explorer helper
+
+## Context
+
+- File: `packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcRunTests.desktop.spec.ts`
+- `openAndRefreshTestExplorer` (lines 73-79): focus Test Explorer → `waitForTimeout(2000)` → `Test: Refresh Tests` → `waitForTimeout(3000)`
+- 5s too short on slow Windows runners → run clicks fire before test discovery done → ~90% LWC E2E failures on windows-latest; reruns pass
+- violates repo rule (`coding-playwright-tests.md`: never `waitForTimeout`)
+- Helper called by 3 tests (run-all, single-component, single-case); all `createLwc(page,'lwc1')` first → `lwc1` tree item is universal readiness signal
+- run-all test issues `Test: Run All Tests` right after helper w/ NO tree wait → main flake source
+- `expect` not yet imported in this spec; `testItem` helper (line 38) already matches `treeitem name /label/i`
+- Precedent: `lwcDebugTests.desktop.spec.ts` uses `expect(...).toPass` — but note that file's toPass callbacks throw explicitly / check state then throw (lines 46-52); do NOT nest a bare `expect(...).toBeVisible()` inside a toPass callback (throws on first miss, kills retry loop)
+
+## Phases
+
+### Phase 1 — state wait in openAndRefreshTestExplorer
+
+- add `expect` to `@playwright/test` import
+- drop both `waitForTimeout`; after `Test: Refresh Tests`, wait on tree item via web-first assertion with built-in retry:
+  `await expect(testItem(page, 'lwc1')).toBeVisible({ timeout: 30_000 });`
+  (reuse `testItem` helper; tree populated = readiness. `toBeVisible` polls internally — no `toPass` wrapper needed)
+- DO NOT use the nested form `await expect(async () => { await expect(testItem(page,'lwc1')).toBeVisible(); }).toPass({ timeout })` — the inner `toBeVisible()` throws immediately when the element is not yet visible, so `toPass` never gets a chance to retry; the helper would fail on first miss instead of waiting for discovery
+- run-all test: tree exists before `Test: Run All Tests`
+- per-caller `lwc1.waitFor({state:'visible'})` redundant after helper but leave (out of scope; harmless)
+
+commit: `test(lwc): replace waitForTimeout with tree-item state wait in lwcRunTests Test Explorer helper - W-22972995`
+
+## Skills to apply
+
+- playwright-e2e (waiting patterns, toPass)
+- typescript (const arrow, no let)
+- thermonuclear-code-quality-review (pre-commit)
+
+## Verification
+
+- `npx eslint` on spec file — no lint errors (e.g. floating promise, import)
+- `npx tsc`/compile typecheck spec — clean
+- grep: no `waitForTimeout` in `openAndRefreshTestExplorer`
+- e2e-covered: `packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcRunTests.desktop.spec.ts` runs on the `e2e-desktop-run-tests` job (matrix incl. windows-latest) defined in `.github/workflows/lwcPlaywrightE2E.yml:220-313` (spec invoked at lines 262/283; sequential `--last-failed` rerun at 290). Pass = first-attempt green on windows-latest with no rerun (verified by branch CI).

--- a/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcRunTests.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcRunTests.desktop.spec.ts
@@ -15,7 +15,7 @@
 
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import { type Page } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 import {
   closeWelcomeTabs,
   ensureSecondarySideBarHidden,
@@ -73,9 +73,10 @@ const waitForJestResults = async (workspaceDir: string, afterMs: number, timeout
 /** Focus the Test Explorer view and refresh test items. */
 const openAndRefreshTestExplorer = async (page: Page): Promise<void> => {
   await executeCommandWithCommandPalette(page, 'Testing: Focus on Test Explorer View');
-  await page.waitForTimeout(2000);
   await executeCommandWithCommandPalette(page, 'Test: Refresh Tests');
-  await page.waitForTimeout(3000);
+  // Tree populated with the lwc1 item = discovery done (all callers create lwc1 first).
+  // toBeVisible polls internally, so no waitForTimeout / toPass wrapper is needed.
+  await expect(testItem(page, 'lwc1')).toBeVisible({ timeout: 30_000 });
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replaced 5s `waitForTimeout` (2s + 3s) in `openAndRefreshTestExplorer` helper with state-based wait on `lwc1` tree item
- Helper now polls for Test Explorer tree readiness using `expect(...).toBeVisible()` with 30s timeout after `Test: Refresh Tests` command
- Eliminates ~90% flake rate on slow Windows runners where 5s was insufficient for test discovery

## Plan

See [.claude/plans/W-22972995.md](./.claude/plans/W-22972995.md)

## Reviewer notes

(none — all findings auto-fixed)

## Test plan

- [x] `npx eslint` on spec file — no lint errors (e.g. floating promise, import)
- [x] `npx tsc`/compile typecheck spec — clean
- [x] grep: no `waitForTimeout` in `openAndRefreshTestExplorer`
- [ ] CI: `e2e-desktop-run-tests` job passes first-attempt on windows-latest with no rerun

### What issues does this PR fix or reference?

@W-22972995@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.my.salesforce.com/a07EE00002c7MXSYA2