### PR TITLE
test(playwright): consolidate goToLineCol helper into shared playwright-vscode-ext package - W-23006294

### DIFF
--- a/.claude/plans/W-23006294.md
+++ b/.claude/plans/W-23006294.md
@@ -1,0 +1,48 @@
+# W-23006294 — consolidate goToLineCol into shared playwright-vscode-ext
+
+## Context
+
+- `goToLineCol(page, line, col)` duplicated byte-identical (modulo comment) in 2 test-util files
+- Both deps (`executeCommandWithCommandPalette`, `QUICK_INPUT_WIDGET`) already in shared ext pkg
+- Dup sites:
+  - `packages/salesforcedx-vscode-lwc/test/playwright/utils/lwcUtils.ts:291`
+  - `packages/salesforcedx-vscode-lightning/test/playwright/utils/auraLspUtils.ts:41`
+- Sig to preserve: `goToLineCol(page: Page, line: number, col: number): Promise<void>` — opens Go to Line/Column..., types `line:col`, Enter, waits widget hidden; 1-indexed
+- Util files stay (keep `waitForLwcLspReady`/`waitForAuraLspReady` + others); only `goToLineCol` removed from each
+- Add to `packages/playwright-vscode-ext/src/utils/fileHelpers.ts` near `replaceLineInOpenFile` (line 343); `executeCommandWithCommandPalette` + `Page` already imported there; add `QUICK_INPUT_WIDGET` to locators import (line 29)
+- Re-export from `src/index.ts` (fileHelpers export block ~line "replaceLineInOpenFile")
+
+## Consumers (5 specs + 2 utils)
+
+- lwc specs import from `../utils/lwcUtils`: lwcLspGoToDefinitionHtml, lwcLspAutocompletion, lwcLspHover
+- lightning specs import from `../utils/auraLspUtils`: auraLspGoToDefinition, auraLspAutocompletion
+- spec import lines bundle `goToLineCol` w/ other named imports (createLwc/openLwcFile/waitForLwcLspReady, waitForAuraLspReady) → split: keep local imports, add `goToLineCol` from `@salesforce/playwright-vscode-ext`
+
+## Phases (1 commit)
+
+### Phase 1 — add to shared pkg, delete dups, repoint imports
+
+- `fileHelpers.ts`: add `QUICK_INPUT_WIDGET` to `./locators` import (line 29); add `goToLineCol` export after `replaceLineInOpenFile`
+- `index.ts`: add `goToLineCol` to fileHelpers re-export block
+- `lwcUtils.ts`: delete `goToLineCol` (291-298)
+- `auraLspUtils.ts`: delete `goToLineCol` + its comment (36-48); drop now-unused `QUICK_INPUT_WIDGET` import if no other use (verify; `executeCommandWithCommandPalette` still used? check — remove unused)
+- 3 lwc specs: move `goToLineCol` out of `../utils/lwcUtils` import → add to existing `@salesforce/playwright-vscode-ext` import (if present) else new import
+- 2 lightning specs: same for `../utils/auraLspUtils`
+- verify no remaining `goToLineCol` defs outside shared pkg: `grep -rn "export const goToLineCol"`
+
+commit msg: `test(playwright): consolidate goToLineCol into shared playwright-vscode-ext - W-23006294`
+
+## Skills
+
+- playwright-e2e
+- typescript
+- packageJson (only if ext pkg build/export wiring needs touch — likely not)
+- concise
+
+## Verification
+
+- `grep -rn "export const goToLineCol" packages` → 1 hit (fileHelpers)
+- `grep -rn "goToLineCol" packages` → all spec/util imports resolve to shared pkg
+- lint each touched pkg (catch unused imports in auraLspUtils): `npx eslint <files>`
+- typecheck: compile playwright-vscode-ext + lwc + lightning test projects (tsc)
+- e2e-covered (do NOT run locally): 5 consuming specs validate runtime behavior — lwcLspGoToDefinitionHtml, lwcLspAutocompletion, lwcLspHover (lwc); auraLspGoToDefinition, auraLspAutocompletion (lightning). Run on branch CI.

--- a/packages/playwright-vscode-ext/src/index.ts
+++ b/packages/playwright-vscode-ext/src/index.ts
@@ -43,6 +43,7 @@ export {
   openFileFromExplorerTree,
   editAndSaveOpenFile as editOpenFile,
   replaceLineInOpenFile,
+  goToLineCol,
   setupMinimalOrgAndAuth,
   setupNonTrackingOrgAndAuth,
   createAndDeployApexTestClass

--- a/packages/playwright-vscode-ext/src/utils/fileHelpers.ts
+++ b/packages/playwright-vscode-ext/src/utils/fileHelpers.ts
@@ -26,7 +26,14 @@ import {
   waitForVSCodeWorkbench,
   waitForQuickInputFirstOption
 } from './helpers';
-import { DIRTY_EDITOR, EDITOR_WITH_URI, NOTIFICATION_LIST_ITEM, QUICK_INPUT_LIST_ROW, WORKBENCH } from './locators';
+import {
+  DIRTY_EDITOR,
+  EDITOR_WITH_URI,
+  NOTIFICATION_LIST_ITEM,
+  QUICK_INPUT_LIST_ROW,
+  QUICK_INPUT_WIDGET,
+  WORKBENCH
+} from './locators';
 import { activeQuickInputWidget } from './quickInput';
 import { disableMonacoAutoClosing, ensureSecondarySideBarHidden } from './workflows';
 
@@ -363,6 +370,19 @@ export const replaceLineInOpenFile = async (page: Page, lineNumber: number, newT
 
   await executeCommandWithCommandPalette(page, 'File: Save');
   await expect(page.locator(DIRTY_EDITOR).first()).not.toBeVisible({ timeout: 5000 });
+};
+
+/**
+ * Moves the editor cursor to a specific line and column using the Go to Line/Column command.
+ * Line and column are both 1-indexed.
+ */
+export const goToLineCol = async (page: Page, line: number, col: number): Promise<void> => {
+  await executeCommandWithCommandPalette(page, 'Go to Line/Column...');
+  const widget = page.locator(QUICK_INPUT_WIDGET);
+  await widget.waitFor({ state: 'visible', timeout: 5000 });
+  await page.keyboard.type(`${line}:${col}`);
+  await page.keyboard.press('Enter');
+  await widget.waitFor({ state: 'hidden', timeout: 5000 });
 };
 
 /** Edit the currently open file by adding a comment at the top */

--- a/packages/salesforcedx-vscode-lightning/test/playwright/specs/auraLspAutocompletion.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-lightning/test/playwright/specs/auraLspAutocompletion.desktop.spec.ts
@@ -11,6 +11,7 @@ import {
   EDITOR_WITH_URI,
   ensureSecondarySideBarHidden,
   executeCommandWithCommandPalette,
+  goToLineCol,
   openFileByName,
   saveScreenshot,
   setupConsoleMonitoring,
@@ -21,7 +22,7 @@ import {
 } from '@salesforce/playwright-vscode-ext';
 
 import { test } from '../fixtures';
-import { goToLineCol, waitForAuraLspReady } from '../utils/auraLspUtils';
+import { waitForAuraLspReady } from '../utils/auraLspUtils';
 
 // Migrated from WDIO `auraLsp.e2e.ts` "Autocompletion". Specs are independent (separate VS Code
 // session per spec), so the Aura LS re-indexes the pre-seeded aura1 bundle here. Types `<aura:appl`

--- a/packages/salesforcedx-vscode-lightning/test/playwright/specs/auraLspGoToDefinition.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-lightning/test/playwright/specs/auraLspGoToDefinition.desktop.spec.ts
@@ -11,6 +11,7 @@ import {
   EDITOR_WITH_URI,
   ensureSecondarySideBarHidden,
   executeCommandWithCommandPalette,
+  goToLineCol,
   openFileByName,
   saveScreenshot,
   setupConsoleMonitoring,
@@ -22,7 +23,7 @@ import {
 } from '@salesforce/playwright-vscode-ext';
 
 import { test } from '../fixtures';
-import { goToLineCol, waitForAuraLspReady } from '../utils/auraLspUtils';
+import { waitForAuraLspReady } from '../utils/auraLspUtils';
 
 // Migrated from WDIO `auraLsp.e2e.ts` "Go to Definition". The aura1 bundle is pre-seeded onto disk
 // before launch (fixtures/desktopFixtures.ts); the Aura LS indexes it on its startup scan, so no

--- a/packages/salesforcedx-vscode-lightning/test/playwright/utils/auraLspUtils.ts
+++ b/packages/salesforcedx-vscode-lightning/test/playwright/utils/auraLspUtils.ts
@@ -6,12 +6,7 @@
  */
 
 import { expect, type Page } from '@playwright/test';
-import {
-  executeCommandWithCommandPalette,
-  QUICK_INPUT_WIDGET,
-  STATUS_BAR_ITEM_LABEL,
-  WORKBENCH
-} from '@salesforce/playwright-vscode-ext';
+import { STATUS_BAR_ITEM_LABEL, WORKBENCH } from '@salesforce/playwright-vscode-ext';
 
 /** Text shown in the Aura language status item when the LSP has finished indexing. */
 const AURA_LSP_READY_TEXT = 'Indexing complete';
@@ -31,18 +26,4 @@ export const waitForAuraLspReady = async (page: Page, timeout = 120_000): Promis
     editorLanguageStatus.or(legacyStatusBarLabel).first(),
     `Aura LSP should show "${AURA_LSP_READY_TEXT}" when indexing is done`
   ).toBeVisible({ timeout });
-};
-
-/**
- * Moves the editor cursor to a specific line and column using the Go to Line/Column command.
- * Line and column are both 1-indexed. (Owned copy of `lwcUtils.goToLineCol`; lightning cannot
- * cross-import lwc-package test utils.)
- */
-export const goToLineCol = async (page: Page, line: number, col: number): Promise<void> => {
-  await executeCommandWithCommandPalette(page, 'Go to Line/Column...');
-  const widget = page.locator(QUICK_INPUT_WIDGET);
-  await widget.waitFor({ state: 'visible', timeout: 5000 });
-  await page.keyboard.type(`${line}:${col}`);
-  await page.keyboard.press('Enter');
-  await widget.waitFor({ state: 'hidden', timeout: 5000 });
 };

--- a/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcLspAutocompletion.headless.spec.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcLspAutocompletion.headless.spec.ts
@@ -11,12 +11,13 @@ import {
   closeWelcomeTabs,
   ensureSecondarySideBarHidden,
   executeCommandWithCommandPalette,
+  goToLineCol,
   setupConsoleMonitoring,
   validateNoCriticalErrors,
   waitForVSCodeWorkbench
 } from '@salesforce/playwright-vscode-ext';
 import { test } from '../fixtures';
-import { createLwc, goToLineCol, openLwcFile, waitForLwcLspReady } from '../utils/lwcUtils';
+import { createLwc, openLwcFile, waitForLwcLspReady } from '../utils/lwcUtils';
 import { disableDeployOnSaveWeb } from '../utils/lwcWebScratchAuth';
 
 test.beforeEach(async ({ page }) => {

--- a/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcLspGoToDefinitionHtml.headless.spec.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcLspGoToDefinitionHtml.headless.spec.ts
@@ -11,12 +11,13 @@ import {
   closeWelcomeTabs,
   ensureSecondarySideBarHidden,
   executeCommandWithCommandPalette,
+  goToLineCol,
   setupConsoleMonitoring,
   validateNoCriticalErrors,
   waitForVSCodeWorkbench
 } from '@salesforce/playwright-vscode-ext';
 import { test } from '../fixtures';
-import { createLwc, goToLineCol, openLwcFile, waitForLwcLspReady } from '../utils/lwcUtils';
+import { createLwc, openLwcFile, waitForLwcLspReady } from '../utils/lwcUtils';
 import { disableDeployOnSaveWeb } from '../utils/lwcWebScratchAuth';
 
 test.beforeEach(async ({ page }) => {

--- a/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcLspHover.headless.spec.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcLspHover.headless.spec.ts
@@ -16,13 +16,14 @@ import {
   EDITOR_WITH_URI,
   closeWelcomeTabs,
   ensureSecondarySideBarHidden,
+  goToLineCol,
   isDesktop,
   setupConsoleMonitoring,
   validateNoCriticalErrors,
   waitForVSCodeWorkbench
 } from '@salesforce/playwright-vscode-ext';
 import { test } from '../fixtures';
-import { createLwc, goToLineCol, openLwcFile, waitForLwcLspReady } from '../utils/lwcUtils';
+import { createLwc, openLwcFile, waitForLwcLspReady } from '../utils/lwcUtils';
 
 test.beforeEach(async ({ page }) => {
   await waitForVSCodeWorkbench(page);

--- a/packages/salesforcedx-vscode-lwc/test/playwright/utils/lwcUtils.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/utils/lwcUtils.ts
@@ -283,16 +283,3 @@ export const assertLwcSfdxTypingsGenerated = async (page: Page): Promise<void> =
     );
   }
 };
-
-/**
- * Moves the editor cursor to a specific line and column using the Go to Line/Column command.
- * Line and column are both 1-indexed.
- */
-export const goToLineCol = async (page: Page, line: number, col: number): Promise<void> => {
-  await executeCommandWithCommandPalette(page, 'Go to Line/Column...');
-  const widget = page.locator(QUICK_INPUT_WIDGET);
-  await widget.waitFor({ state: 'visible', timeout: 5000 });
-  await page.keyboard.type(`${line}:${col}`);
-  await page.keyboard.press('Enter');
-  await widget.waitFor({ state: 'hidden', timeout: 5000 });
-};


### PR DESCRIPTION
## Summary

- Deduplicated byte-identical `goToLineCol(page, line, col)` helper from lwc and lightning test utils into shared `@salesforce/playwright-vscode-ext` package
- Removed duplicate implementations from `lwcUtils.ts` and `auraLspUtils.ts`, updated 5 consuming e2e specs to import from shared package
- All dependencies (`executeCommandWithCommandPalette`, `QUICK_INPUT_WIDGET`) already available in shared package, enabling clean consolidation

## Plan

[W-23006294.md](.claude/plans/W-23006294.md)

### What issues does this PR fix or reference?

@W-23006294@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/a07EE00002cHyEg