### PR TITLE
chore(deps): bump handlebars to 4.7.9 to clear CVEs - W-22997506

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21615,9 +21615,9 @@
       "license": "MIT"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Refresh `package-lock.json` to pull handlebars **4.7.9** (was 4.7.8); clears CVE-2024-57446 and related.
- **No `package.json` change** — 4.7.9 already satisfies ts-jest@29.4.6's existing `handlebars: ^4.7.8` range. The lockfile was simply stale (4.7.9 published after it was generated).
- No `overrides` entry and no ts-jest bump needed.

## Why not the override / ts-jest bump?
handlebars enters only as a transitive dev dep of ts-jest (single resolution). Bumping ts-jest to 29.4.7+ is unrelated to handlebars and is blocked separately by a new TS151002 / `isolatedModules` diagnostic in 3 packages — tracked as a follow-up WI. This PR is the minimal CVE clearance.

## Test plan
- `npm update handlebars --package-lock-only` → 3-line lockfile diff
- `npm ls handlebars` → 4.7.9 (single resolution)
- CI (build + unit) green

## What issues does this PR fix or reference?
@W-22997506@