### PR TITLE
ci(apex-oas): skip e2e-desktop job (if: false) — A4V v4 broke OAS - W-22997620

### DIFF
--- a/.claude/plans/W-22997620.md
+++ b/.claude/plans/W-22997620.md
@@ -1,9 +1,9 @@
 # W-22997620 — Skip Apex OAS e2e job (if: false)
 
 ## Context
-- OAS broken by A4V v4 marketplace release.
+- A4V v4 marketplace release broke OAS.
 - PR #7462 (merged): fixture-level `oasDesktopTest.skip()` — job still spins runners, no-ops every spec.
-- Goal: skip whole `e2e-desktop` job → no runners.
+- Goal: skip `e2e-desktop` job → no runners.
 - Ref: PR #7455 (sm/skip-oas-e2e) did same.
 
 ## Phases
@@ -11,7 +11,7 @@
 ### Phase 1 — guard job
 - file: `.github/workflows/apexOasE2E.yml`
 - add `if: false` to `e2e-desktop` job (line ~39, before/after `runs-on`).
-- comment above: OAS broken by A4V v4 marketplace release; re-enable when fixed.
+- comment: OAS broken by A4V v4; re-enable when fixed.
 - commit msg: `ci(apex-oas): skip e2e-desktop job (if: false) — A4V v4 broke OAS - W-22997620`
 
 ## Skills
@@ -23,8 +23,8 @@
 ## Callers (workflow_call consumers)
 - `e2e.yml:75-80` job `playwright-apex-oas` → `uses: ./.github/workflows/apexOasE2E.yml`.
 - `playwrightE2EFullSuite.yml:48-52` job `apex-oas` → same `uses`.
-- No `needs:` references either caller job (grep confirmed) → no sibling/downstream job depends on apex-oas; a skipped called workflow cannot block the parent.
-- Reusable workflow whose only job is `if: false`: the caller job reports `success` (all-skipped reusable workflow ≠ failure), so parent matrix proceeds. Verify empirically (below), do not assume.
+- No `needs:` refs to caller jobs (grep confirmed) → no deps on apex-oas; a skipped called workflow cannot block the parent.
+- Reusable workflow w/ only job `if: false`: caller reports `success` (all-skipped ≠ failure), parent proceeds. Verify empirically (below).
 
 ## Verification
 - yaml lint / parse valid (no e2e coverage — workflow file).

--- a/.claude/plans/W-22997620.md
+++ b/.claude/plans/W-22997620.md
@@ -1,0 +1,36 @@
+# W-22997620 — Skip Apex OAS e2e job (if: false)
+
+## Context
+- OAS broken by A4V v4 marketplace release.
+- PR #7462 (merged): fixture-level `oasDesktopTest.skip()` — job still spins runners, no-ops every spec.
+- Goal: skip whole `e2e-desktop` job → no runners.
+- Ref: PR #7455 (sm/skip-oas-e2e) did same.
+
+## Phases
+
+### Phase 1 — guard job
+- file: `.github/workflows/apexOasE2E.yml`
+- add `if: false` to `e2e-desktop` job (line ~39, before/after `runs-on`).
+- comment above: OAS broken by A4V v4 marketplace release; re-enable when fixed.
+- commit msg: `ci(apex-oas): skip e2e-desktop job (if: false) — A4V v4 broke OAS - W-22997620`
+
+## Skills
+- concise (plan/doc edits)
+- feature-branch (branch hygiene)
+- pr-draft (PR)
+- playwright-e2e (apex-oas e2e workflow context)
+
+## Callers (workflow_call consumers)
+- `e2e.yml:75-80` job `playwright-apex-oas` → `uses: ./.github/workflows/apexOasE2E.yml`.
+- `playwrightE2EFullSuite.yml:48-52` job `apex-oas` → same `uses`.
+- No `needs:` references either caller job (grep confirmed) → no sibling/downstream job depends on apex-oas; a skipped called workflow cannot block the parent.
+- Reusable workflow whose only job is `if: false`: the caller job reports `success` (all-skipped reusable workflow ≠ failure), so parent matrix proceeds. Verify empirically (below), do not assume.
+
+## Verification
+- yaml lint / parse valid (no e2e coverage — workflow file).
+- confirm job-level `if: false`, not step-level.
+- standalone: push branch → `Apex OAS E2E` workflow (push trigger) shows `e2e-desktop` skipped, no runner allocated.
+- caller-level (the load-bearing check): from pushed branch, `gh workflow run playwrightE2EFullSuite.yml --ref <branch>` (full-suite caller, no `workflow_run` gate — simplest to trigger; e2e.yml's `playwright-apex-oas` has the same `uses` so behavior is identical). Then:
+  - `gh run watch <run-id>` / `gh run view <run-id>`: confirm the `apex-oas` caller job resolves to `success` (or `skipped`) — NOT `failure` — and the overall run is not failed by it.
+  - confirm sibling caller jobs (apex-testing, org-e2e, etc.) run unaffected.
+  - confirm no runner minutes consumed for apex-oas (skipped `e2e-desktop` allocates none).

--- a/.github/workflows/apexOasE2E.yml
+++ b/.github/workflows/apexOasE2E.yml
@@ -37,7 +37,7 @@ concurrency:
 
 jobs:
   e2e-desktop:
-    # OAS broken by A4V v4 marketplace release; re-enable when fixed.
+    # OAS broken by A4V v4 marketplace release; re-enable when fixed (tracked in W-22997620).
     if: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60

--- a/.github/workflows/apexOasE2E.yml
+++ b/.github/workflows/apexOasE2E.yml
@@ -37,6 +37,8 @@ concurrency:
 
 jobs:
   e2e-desktop:
+    # OAS broken by A4V v4 marketplace release; re-enable when fixed.
+    if: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:


### PR DESCRIPTION
## Summary
- Added `if: false` to `e2e-desktop` job in `.github/workflows/apexOasE2E.yml` to prevent runner allocation
- Temporary skip until A4V v4 marketplace OAS breakage is fixed
- Prevents wasted CI minutes while maintaining clean workflow runs

## Plan
[.claude/plans/W-22997620.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-22997620-skip-entire-apex-oas-e2e-job-if-false-a4/.claude/plans/W-22997620.md)

## Test plan
- Push branch and verify `Apex OAS E2E` workflow shows `e2e-desktop` skipped with no runner allocation
- Trigger `playwrightE2EFullSuite.yml` via `gh workflow run` and confirm:
  - The `apex-oas` caller job resolves to `success` or `skipped` (not `failure`)
  - Sibling caller jobs run unaffected
  - No runner minutes consumed for apex-oas

### What issues does this PR fix or reference?
@W-22997620@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cGO13YAG/view