### PR TITLE
feat(eslint): ban cross-barrel re-exports outside index.ts - W-23008174

### DIFF
--- a/.claude/plans/W-23008174.md
+++ b/.claude/plans/W-23008174.md
@@ -13,7 +13,7 @@
 - Wire `local/no-cross-barrel-reexport: 'error'` into `eslint.config.mjs` `**/*.ts` block (~L161, next to `no-self-barrel-import`).
 - index.ts barrel uses `export = plugin` (line `index.ts`) — naturally exempt.
 
-### 5 flagged files (verified) + migration (STRICT order: delete barrel > direct import at call sites > NEVER add to barrel) — IN SCOPE per WI (WI Details: "Migration — barrel preference (STRICT order)" + "5 files flagged" enumerated)
+### 5 flagged files (verified) + migration (STRICT: delete barrel > direct import > NEVER add to barrel) — IN SCOPE (WI Details: "Migration — barrel preference (STRICT order)" + "5 files flagged" enumerated)
 
 1. `packages/effect-ext-utils/src/extensionProvider.ts:12` — `export type { SalesforceVSCodeServicesApi } from 'salesforcedx-vscode-services'` (PR #7473 pattern; workspace pkg). Line 13 has same local `import type` — kept.
    - Re-exported again by `effect-ext-utils/src/index.ts:18` from `./extensionProvider`.
@@ -21,12 +21,12 @@
 2. `packages/salesforcedx-vscode-services/src/virtualFsProvider/templates/templates.ts:31` — `export { metadataDirs } from './metadataDirs'` (relative). Sole consumer `projectInit.ts:15` imports `{ TEMPLATES, metadataDirs }` from `./templates/templates`.
    - Migrate: delete L31; in `projectInit.ts` split import — `metadataDirs` from `./templates/metadataDirs`, `TEMPLATES` stays from `./templates/templates`.
 3. `packages/salesforcedx-vscode-soql/src/soql-model/model/model.ts:291` — `export * from './unmodeled'` (relative). Consumers = 5 test files importing `REASON_UNMODELED_*` from `.../soql-model/model/model`.
-   - Migrate: delete L291; repoint those test imports to `.../soql-model/model/unmodeled`. (`UnmodeledSyntaxReason` already imported locally L8 from `./unmodeled` — model.ts unaffected.)
+   - Delete L291; repoint test imports to `.../soql-model/model/unmodeled`. (`UnmodeledSyntaxReason` already imported locally L8 from `./unmodeled` — model.ts unaffected.)
    - Test files: `test/jest/soql-model/model/util.test.ts`, `.../impl/queryImpl.test.ts`, `.../impl/fieldSelectionImpl.test.ts`, `.../impl/fromImpl.test.ts`, `test/jest/soql-builder-ui/.../soqlUtils.test.ts`.
 4. `packages/salesforcedx-lwc-language-server/src/lwcServerNode.ts:18` — `export { findDynamicContent } from './baseServer'` (relative). Sole consumer `test/lwcServerNode.test.ts:142` imports `Server, { findDynamicContent }` from `../src/lwcServerNode`.
    - Migrate: delete L18; in test split — `findDynamicContent` from `../src/baseServer`, default `Server` stays from `../src/lwcServerNode`.
 5. `packages/salesforcedx-lightning-lsp-common/src/testSupport/testUtils.ts:877` — `export { createMockWorkspaceFindFilesConnection } from './mockWorkspaceFindFiles'` (relative). `testUtils.ts` = exported subpath `./testUtils` (30 own exports), NOT deletable. Consumers import via `@salesforce/salesforcedx-lightning-lsp-common/testUtils` (lwc + aura test files).
-   - No subpath for mockWorkspaceFindFiles. Migrate (option 2): add `./testSupport/mockWorkspaceFindFiles` export subpath to `package.json` (NOT a barrel — direct file), delete testUtils.ts:877, repoint consumers' `createMockWorkspaceFindFilesConnection` import to that subpath; other testUtils symbols stay on `/testUtils`.
+   - No subpath for mockWorkspaceFindFiles. Migrate: add `./testSupport/mockWorkspaceFindFiles` export subpath to `package.json` (NOT a barrel — direct file), delete testUtils.ts:877, repoint consumers' `createMockWorkspaceFindFilesConnection` import to that subpath; other testUtils symbols stay on `/testUtils`.
    - testUtils.ts:297 `export * from './something'` is inside a template-literal test fixture string — NOT a real re-export, won't flag.
 
 ## Phases
@@ -48,7 +48,7 @@
 - Run full lint; confirm 0 errors (because 2a removed them).
 - commit: `chore(eslint): enable no-cross-barrel-reexport as error - W-23008174`
 
-Order rationale: rule lands disabled (Phase 1) → migration removes all current violations (2a) → rule enabled as error (2b). Repo never sits in a committed state where the rule errors on un-migrated code.
+Rationale: rule lands disabled (Phase 1) → migration removes violations (2a) → rule enabled (2b). Repo never commits with rule errors on un-migrated code.
 
 ## Skills to apply
 - concise (plan + any .claude md)

--- a/.claude/plans/W-23008174.md
+++ b/.claude/plans/W-23008174.md
@@ -1,0 +1,63 @@
+# W-23008174 — ESLint rule: ban relative + workspace-pkg re-exports outside index.ts
+
+## Context
+
+- New local rule `no-cross-barrel-reexport` in `packages/eslint-local-rules`.
+- Bans `export {x} from '...'`, `export * from '...'`, `export type {x} from '...'` when:
+  - file is NOT named `index.ts` (any depth), AND
+  - specifier is RELATIVE (`./`, `../`, `.`, `..`) OR an internal workspace package.
+- ALLOW re-export from 3rd-party npm (jsforce, vscode-languageserver-protocol, @salesforce/templates, @salesforce/core) — deliberate API surface.
+- Workspace pkgs use 2 forms: unscoped `salesforcedx-vscode-*` AND scoped `@salesforce/*` (e.g. `@salesforce/vscode-services`, `@salesforce/soql-common`, `@salesforce/effect-ext-utils`). `@salesforce/` scope SHARED w/ 3rd-party (`@salesforce/templates`, `@salesforce/core`) → prefix-match WRONG. Must use actual workspace name set.
+- Workspace detection (DECIDED): rule accepts optional `knownWorkspacePackages: string[]` option. Default (option absent/empty) = fs self-discovery: walk up from `context.filename` to repo root `packages/`, read each `packages/*/package.json` `name`, build Set, memoize module-level. Pattern precedent: `commandMustBeInPackageJson` reads fs via `getPackageCommands(context.filename)`. RuleTester passes the explicit option → fully deterministic, no fixture pkg tree, no filename-under-`packages/` dependency. Subpath specifiers (`@salesforce/soql-model/model/model`) → match by pkg-name prefix vs the Set (split on `/`, scoped=first 2 segs, else first seg). Rationale for option (vs fixture-dir like `command-must-be-in-package-json`): this rule needs MANY workspace names; fabricating a multi-`packages/*/package.json` fixture tree is brittle vs one explicit array. Option also matches WI design note ("or pass as a rule option").
+- Pattern to copy: `src/noSelfBarrelImport.ts` (3 visitors: `ExportAllDeclaration`, `ExportNamedDeclaration`, + skip plain `ImportDeclaration` — imports out of scope). Test pattern: `test/no-self-barrel-import.test.ts` (`RuleTester`).
+- Wire `local/no-cross-barrel-reexport: 'error'` into `eslint.config.mjs` `**/*.ts` block (~L161, next to `no-self-barrel-import`).
+- index.ts barrel uses `export = plugin` (line `index.ts`) — naturally exempt.
+
+### 5 flagged files (verified) + migration (STRICT order: delete barrel > direct import at call sites > NEVER add to barrel) — IN SCOPE per WI (WI Details: "Migration — barrel preference (STRICT order)" + "5 files flagged" enumerated)
+
+1. `packages/effect-ext-utils/src/extensionProvider.ts:12` — `export type { SalesforceVSCodeServicesApi } from 'salesforcedx-vscode-services'` (PR #7473 pattern; workspace pkg). Line 13 has same local `import type` — kept.
+   - Re-exported again by `effect-ext-utils/src/index.ts:18` from `./extensionProvider`.
+   - Migrate: delete L12; change `index.ts:18` source `./extensionProvider` → `'salesforcedx-vscode-services'` (index.ts exempt + genuine API surface). No other consumer imports the type from extensionProvider.
+2. `packages/salesforcedx-vscode-services/src/virtualFsProvider/templates/templates.ts:31` — `export { metadataDirs } from './metadataDirs'` (relative). Sole consumer `projectInit.ts:15` imports `{ TEMPLATES, metadataDirs }` from `./templates/templates`.
+   - Migrate: delete L31; in `projectInit.ts` split import — `metadataDirs` from `./templates/metadataDirs`, `TEMPLATES` stays from `./templates/templates`.
+3. `packages/salesforcedx-vscode-soql/src/soql-model/model/model.ts:291` — `export * from './unmodeled'` (relative). Consumers = 5 test files importing `REASON_UNMODELED_*` from `.../soql-model/model/model`.
+   - Migrate: delete L291; repoint those test imports to `.../soql-model/model/unmodeled`. (`UnmodeledSyntaxReason` already imported locally L8 from `./unmodeled` — model.ts unaffected.)
+   - Test files: `test/jest/soql-model/model/util.test.ts`, `.../impl/queryImpl.test.ts`, `.../impl/fieldSelectionImpl.test.ts`, `.../impl/fromImpl.test.ts`, `test/jest/soql-builder-ui/.../soqlUtils.test.ts`.
+4. `packages/salesforcedx-lwc-language-server/src/lwcServerNode.ts:18` — `export { findDynamicContent } from './baseServer'` (relative). Sole consumer `test/lwcServerNode.test.ts:142` imports `Server, { findDynamicContent }` from `../src/lwcServerNode`.
+   - Migrate: delete L18; in test split — `findDynamicContent` from `../src/baseServer`, default `Server` stays from `../src/lwcServerNode`.
+5. `packages/salesforcedx-lightning-lsp-common/src/testSupport/testUtils.ts:877` — `export { createMockWorkspaceFindFilesConnection } from './mockWorkspaceFindFiles'` (relative). `testUtils.ts` = exported subpath `./testUtils` (30 own exports), NOT deletable. Consumers import via `@salesforce/salesforcedx-lightning-lsp-common/testUtils` (lwc + aura test files).
+   - No subpath for mockWorkspaceFindFiles. Migrate (option 2): add `./testSupport/mockWorkspaceFindFiles` export subpath to `package.json` (NOT a barrel — direct file), delete testUtils.ts:877, repoint consumers' `createMockWorkspaceFindFilesConnection` import to that subpath; other testUtils symbols stay on `/testUtils`.
+   - testUtils.ts:297 `export * from './something'` is inside a template-literal test fixture string — NOT a real re-export, won't flag.
+
+## Phases
+
+### Phase 1 — rule + unit test (rule NOT yet wired into eslint.config)
+- New `packages/eslint-local-rules/src/noCrossBarrelReexport.ts`: copy noSelfBarrelImport structure; visitors `ExportAllDeclaration` + `ExportNamedDeclaration` only (skip null source = local export). Report when relative OR workspace pkg, AND basename(filename) !== `index.ts`. Workspace Set resolution: `knownWorkspacePackages` option if provided/non-empty, else memoized fs walk (`packages/*/package.json` names). `meta.schema` declares the option (array of strings, `additionalProperties:false`), `defaultOptions: [{}]` — mirror `commandMustBeInPackageJson` schema/options shape.
+- Register in `src/index.ts` plugin `rules` map as `no-cross-barrel-reexport`.
+- New `test/no-cross-barrel-reexport.test.ts` (`RuleTester`): every case passes `options: [{ knownWorkspacePackages: ['salesforcedx-vscode-services', '@salesforce/vscode-services', ...] }]` → deterministic, NO fs, NO filename-under-`packages/` reliance. valid = 3rd-party re-export (`export { x } from 'jsforce'`, `@salesforce/core`, `@salesforce/templates` — confirm these are NOT in the option array), any re-export in `index.ts` (set `filename` ending `/index.ts`), plain imports; invalid = relative re-export in non-index, workspace-pkg re-export (`salesforcedx-vscode-services`, `@salesforce/vscode-services`), `export type`/`export *`. Also one valid case with NO option exercising fs default (filename under repo `packages/`) to cover the discovery path.
+- commit: `feat(eslint-local-rules): add no-cross-barrel-reexport rule - W-23008174`
+
+### Phase 2a — migrate 5 flagged files (rule still NOT wired; verify lint clean against the rule)
+- Apply 5 migrations above (delete re-exports; direct imports at call sites; subpath add for #5).
+- Verify each migrated pkg compiles (tsc) + affected jest suites pass.
+- Verify zero remaining violations: temporarily lint with the rule (e.g. one-off inline `--rule` run or local config toggle) OR grep-confirm no non-index `export ... from` to relative/workspace specifiers remain in the 5 pkgs. Do NOT commit any eslint.config change here.
+- commit: `refactor: replace cross-barrel re-exports with direct imports - W-23008174`
+
+### Phase 2b — wire rule as error (migration already landed → repo lints clean immediately)
+- `eslint.config.mjs`: add `'local/no-cross-barrel-reexport': 'error'` in `**/*.ts` rules block (~L161, next to `no-self-barrel-import`).
+- Run full lint; confirm 0 errors (because 2a removed them).
+- commit: `chore(eslint): enable no-cross-barrel-reexport as error - W-23008174`
+
+Order rationale: rule lands disabled (Phase 1) → migration removes all current violations (2a) → rule enabled as error (2b). Repo never sits in a committed state where the rule errors on un-migrated code.
+
+## Skills to apply
+- concise (plan + any .claude md)
+- typescript (rule impl, AST types from `@typescript-eslint/utils`)
+- packageJson (lsp-common exports subpath add, #5)
+- verification (run lint + unit tests)
+
+## Verification
+- After Phase 1: `npm run compile -w @salesforce/eslint-plugin-vscode-extensions` (rule must compile before eslint loads `out/index.js`); `npm test -w @salesforce/eslint-plugin-vscode-extensions` — new RuleTester passes (valid/invalid), all option-driven cases deterministic + the fs-default case green.
+- After Phase 2a (rule NOT yet wired): `tsc`/compile each migrated pkg — direct imports resolve, no broken refs; run affected jest suites: soql-model model/impl tests, lwcServerNode test, lwc/aura mockWorkspaceFindFiles consumers, vscode-services projectInit. Confirm no non-index relative/workspace re-exports remain in the 5 pkgs (one-off rule run or grep).
+- After Phase 2b: full lint passes with the rule at `error` (0 violations because 2a cleared them); sanity-check rule fires by temporarily reintroducing one re-export locally (do not commit) — confirm error, then revert.
+- Not e2e-covered (justified): rule + migration are lint/unit-only; no runtime/behavior change. RuleTester is the unit coverage; migrated files keep identical public API (same symbols, different import paths) so existing jest suites are the regression gate. No Playwright e2e on branch touches these; adding e2e would not exercise lint config or import-path refactors.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -159,6 +159,7 @@ export default [
       'local/no-vscode-quickpick-description-literals': 'error',
       'local/no-vscode-validateinput-literals': 'error',
       'local/no-self-barrel-import': 'error',
+      'local/no-cross-barrel-reexport': 'error',
       'workspaces/no-relative-imports': 'error',
       'unicorn/consistent-date-clone': 'error',
       'unicorn/consistent-empty-array-spread': 'error',

--- a/packages/effect-ext-utils/src/extensionProvider.ts
+++ b/packages/effect-ext-utils/src/extensionProvider.ts
@@ -9,7 +9,6 @@ import * as Context from 'effect/Context';
 import * as Data from 'effect/Data';
 import * as Effect from 'effect/Effect';
 // Import from the npm package (symlinked in workspace) - wireit ensures it's compiled first
-export type { SalesforceVSCodeServicesApi } from 'salesforcedx-vscode-services';
 import type { SalesforceVSCodeServicesApi } from 'salesforcedx-vscode-services';
 import * as vscode from 'vscode';
 

--- a/packages/effect-ext-utils/src/index.ts
+++ b/packages/effect-ext-utils/src/index.ts
@@ -15,7 +15,7 @@ export {
 export { buildAllServicesLayer } from './allServicesLayer';
 export { ExtensionPackageJsonSchema, type ExtensionPackageJson } from './extensionPackageJson';
 export { closeExtensionScope, getExtensionScope } from './extensionScope';
-export type { SalesforceVSCodeServicesApi } from './extensionProvider';
+export type { SalesforceVSCodeServicesApi } from 'salesforcedx-vscode-services';
 
 export { createTable } from './table';
 export type { Column, Row } from './table';

--- a/packages/eslint-local-rules/src/index.ts
+++ b/packages/eslint-local-rules/src/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { commandMustBeInPackageJson } from './commandMustBeInPackageJson';
+import { noCrossBarrelReexport } from './noCrossBarrelReexport';
 import { noDirectServicesImports } from './noDirectServicesImports';
 import { noDuplicateI18nValues } from './noDuplicateI18nValues';
 import { noDuplicatePlaywrightLocators } from './noDuplicatePlaywrightLocators';
@@ -45,6 +46,7 @@ const plugin = {
     'no-duplicate-playwright-locators': noDuplicatePlaywrightLocators,
     'no-direct-services-imports': noDirectServicesImports,
     'no-self-barrel-import': noSelfBarrelImport,
+    'no-cross-barrel-reexport': noCrossBarrelReexport,
     'no-effect-fn-wrapper': noEffectFnWrapper,
     'no-export-tagged-error-in-services': noExportTaggedErrorInServices,
     'no-runtime-vscode-import': noRuntimeVscodeImport,

--- a/packages/eslint-local-rules/src/noCrossBarrelReexport.ts
+++ b/packages/eslint-local-rules/src/noCrossBarrelReexport.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { TSESTree } from '@typescript-eslint/utils';
+import { RuleCreator } from '@typescript-eslint/utils/eslint-utils';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/** Relative specifiers: './x', '../x', '.', '..', '../..' etc. */
+const isRelative = (specifier: string): boolean =>
+  specifier === '.' || specifier === '..' || /^\.\.?\//.test(specifier);
+
+/** Extract the package-name prefix of a specifier (scoped = first 2 segments, else first). */
+const packageNameOf = (specifier: string): string => {
+  const segments = specifier.split('/');
+  return specifier.startsWith('@') ? segments.slice(0, 2).join('/') : segments[0];
+};
+
+/** Memoized fs self-discovery of workspace package names from each repo packages/<pkg>/package.json. */
+let discoveredWorkspacePackages: Set<string> | undefined;
+
+const discoverWorkspacePackages = (filePath: string): Set<string> => {
+  if (discoveredWorkspacePackages) return discoveredWorkspacePackages;
+
+  const parts = path.dirname(filePath).split(path.sep);
+  for (let i = parts.length; i > 0; i--) {
+    const packagesDir = path.join(parts.slice(0, i).join(path.sep), 'packages');
+    try {
+      const names = fs
+        .readdirSync(packagesDir, { withFileTypes: true })
+        .filter(entry => entry.isDirectory())
+        .map(entry => {
+          try {
+            const parsed = JSON.parse(fs.readFileSync(path.join(packagesDir, entry.name, 'package.json'), 'utf8')) as {
+              name?: string;
+            };
+            return parsed.name;
+          } catch {
+            return undefined;
+          }
+        })
+        .filter((name): name is string => typeof name === 'string');
+      if (names.length > 0) {
+        discoveredWorkspacePackages = new Set(names);
+        return discoveredWorkspacePackages;
+      }
+    } catch {
+      // Continue searching up
+    }
+  }
+
+  discoveredWorkspacePackages = new Set();
+  return discoveredWorkspacePackages;
+};
+
+type RuleOptions = [{ knownWorkspacePackages?: string[] }];
+
+export const noCrossBarrelReexport = RuleCreator.withoutDocs<RuleOptions, 'noCrossBarrelReexport'>({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow re-exporting from relative paths or internal workspace packages outside of index.ts barrel files'
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          knownWorkspacePackages: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Explicit list of workspace package names (overrides fs self-discovery)'
+          }
+        },
+        additionalProperties: false
+      }
+    ],
+    defaultOptions: [{}],
+    messages: {
+      noCrossBarrelReexport:
+        'Re-exporting from `{{source}}` is only allowed in index.ts barrels. Import directly from the file/package defining each export, or re-export from index.ts (3rd-party API surface re-exports are exempt).'
+    }
+  },
+  defaultOptions: [{}],
+  create: (context, [options]) => {
+    if (path.basename(context.filename) === 'index.ts') return {};
+
+    const workspacePackages =
+      options.knownWorkspacePackages && options.knownWorkspacePackages.length > 0
+        ? new Set(options.knownWorkspacePackages)
+        : discoverWorkspacePackages(context.filename);
+
+    const check = (node: TSESTree.ExportAllDeclaration | TSESTree.ExportNamedDeclaration): void => {
+      if (!node.source) return;
+      const source = node.source.value;
+      if (typeof source !== 'string') return;
+      if (!isRelative(source) && !workspacePackages.has(packageNameOf(source))) return;
+      context.report({ node, messageId: 'noCrossBarrelReexport', data: { source } });
+    };
+
+    return {
+      ExportAllDeclaration: check,
+      ExportNamedDeclaration: check
+    };
+  }
+});

--- a/packages/eslint-local-rules/test/no-cross-barrel-reexport.test.ts
+++ b/packages/eslint-local-rules/test/no-cross-barrel-reexport.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import * as path from 'node:path';
+import { noCrossBarrelReexport } from '../src/noCrossBarrelReexport';
+
+const ruleTester = new RuleTester();
+
+const options: [{ knownWorkspacePackages: string[] }] = [
+  {
+    knownWorkspacePackages: ['salesforcedx-vscode-services', '@salesforce/vscode-services', '@salesforce/soql-common']
+  }
+];
+
+// A real source file under repo `packages/` so the fs self-discovery path resolves this repo's workspace names.
+const repoFileUnderPackages = path.join(__dirname, '..', 'src', 'someFile.ts');
+
+ruleTester.run('no-cross-barrel-reexport', noCrossBarrelReexport, {
+  valid: [
+    // 3rd-party npm re-exports are deliberate API surface (NOT in the workspace option array)
+    { code: `export { foo } from 'jsforce';`, options },
+    { code: `export type { Foo } from '@salesforce/core';`, options },
+    { code: `export { bar } from '@salesforce/templates';`, options },
+    { code: `export * from 'vscode-languageserver-protocol';`, options },
+    // any re-export allowed in index.ts barrels (any depth)
+    {
+      code: `export { foo } from './foo';`,
+      filename: '/repo/packages/pkg/src/index.ts',
+      options
+    },
+    {
+      code: `export * from 'salesforcedx-vscode-services';`,
+      filename: '/repo/packages/pkg/src/sub/index.ts',
+      options
+    },
+    // plain imports are out of scope
+    { code: `import { foo } from './foo';`, options },
+    { code: `import { foo } from 'salesforcedx-vscode-services';`, options },
+    // local exports (no source) are fine
+    { code: `export const foo = 1;`, options },
+    { code: `const x = 1; export { x };`, options },
+    // fs-default case (NO option): 'jsforce' is 3rd-party, not a discovered workspace package
+    { code: `export { foo } from 'jsforce';`, filename: repoFileUnderPackages }
+  ],
+  invalid: [
+    {
+      code: `export { foo } from './foo';`,
+      filename: '/repo/packages/pkg/src/notIndex.ts',
+      options,
+      errors: [{ messageId: 'noCrossBarrelReexport', data: { source: './foo' } }]
+    },
+    {
+      code: `export * from '../sibling';`,
+      filename: '/repo/packages/pkg/src/notIndex.ts',
+      options,
+      errors: [{ messageId: 'noCrossBarrelReexport', data: { source: '../sibling' } }]
+    },
+    {
+      code: `export type { Foo } from '../sibling';`,
+      filename: '/repo/packages/pkg/src/notIndex.ts',
+      options,
+      errors: [{ messageId: 'noCrossBarrelReexport', data: { source: '../sibling' } }]
+    },
+    {
+      code: `export type { SalesforceVSCodeServicesApi } from 'salesforcedx-vscode-services';`,
+      filename: '/repo/packages/pkg/src/notIndex.ts',
+      options,
+      errors: [{ messageId: 'noCrossBarrelReexport', data: { source: 'salesforcedx-vscode-services' } }]
+    },
+    {
+      code: `export { x } from '@salesforce/vscode-services';`,
+      filename: '/repo/packages/pkg/src/notIndex.ts',
+      options,
+      errors: [{ messageId: 'noCrossBarrelReexport', data: { source: '@salesforce/vscode-services' } }]
+    },
+    // subpath of a workspace package matches by package-name prefix
+    {
+      code: `export * from '@salesforce/soql-common/model/model';`,
+      filename: '/repo/packages/pkg/src/notIndex.ts',
+      options,
+      errors: [{ messageId: 'noCrossBarrelReexport', data: { source: '@salesforce/soql-common/model/model' } }]
+    },
+    {
+      code: `export { foo } from '.';`,
+      filename: '/repo/packages/pkg/src/notIndex.ts',
+      options,
+      errors: [{ messageId: 'noCrossBarrelReexport', data: { source: '.' } }]
+    }
+  ]
+});

--- a/packages/salesforcedx-aura-language-server/test/aura-indexer/indexer.spec.ts
+++ b/packages/salesforcedx-aura-language-server/test/aura-indexer/indexer.spec.ts
@@ -7,11 +7,11 @@
 
 import { LspFileSystemAccessor, NormalizedPath, normalizePath } from '@salesforce/salesforcedx-lightning-lsp-common';
 import {
-  createMockWorkspaceFindFilesConnection,
   getSfdxWorkspaceRelativePaths,
   SFDX_WORKSPACE_ROOT,
   sfdxFileSystemAccessor
 } from '@salesforce/salesforcedx-lightning-lsp-common/testUtils';
+import { createMockWorkspaceFindFilesConnection } from '@salesforce/salesforcedx-lightning-lsp-common/testSupport/mockWorkspaceFindFiles';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { Connection } from 'vscode-languageserver';

--- a/packages/salesforcedx-lightning-lsp-common/package.json
+++ b/packages/salesforcedx-lightning-lsp-common/package.json
@@ -31,6 +31,11 @@
       "import": "./out/src/testSupport/testUtils.js",
       "require": "./out/src/testSupport/testUtils.js"
     },
+    "./testSupport/mockWorkspaceFindFiles": {
+      "types": "./out/src/testSupport/mockWorkspaceFindFiles.d.ts",
+      "import": "./out/src/testSupport/mockWorkspaceFindFiles.js",
+      "require": "./out/src/testSupport/mockWorkspaceFindFiles.js"
+    },
     "./providers/lspFileSystemAccessor": {
       "types": "./out/src/providers/lspFileSystemAccessor.d.ts",
       "import": "./out/src/providers/lspFileSystemAccessor.js",

--- a/packages/salesforcedx-lightning-lsp-common/src/testSupport/testUtils.ts
+++ b/packages/salesforcedx-lightning-lsp-common/src/testSupport/testUtils.ts
@@ -873,5 +873,3 @@ export const buildSfdxContentMap = (): Map<string, string> => {
 /** Relative paths (forward slashes) for the SFDX test workspace. Use with createMockWorkspaceFindFilesConnection(..., { relativePaths: getSfdxWorkspaceRelativePaths() }) when disk read is unavailable in test env. */
 export const getSfdxWorkspaceRelativePaths = (): string[] =>
   Object.keys(SFDX_WORKSPACE_STRUCTURE).map(p => p.replaceAll('\\', '/'));
-
-export { createMockWorkspaceFindFilesConnection } from './mockWorkspaceFindFiles';

--- a/packages/salesforcedx-lwc-language-server/src/lwcServerNode.ts
+++ b/packages/salesforcedx-lwc-language-server/src/lwcServerNode.ts
@@ -13,6 +13,3 @@ export default class Server extends BaseServer {
     return createConnection();
   }
 }
-
-// Re-export for tests
-export { findDynamicContent } from './baseServer';

--- a/packages/salesforcedx-lwc-language-server/test/componentIndexer.test.ts
+++ b/packages/salesforcedx-lwc-language-server/test/componentIndexer.test.ts
@@ -7,13 +7,13 @@
 import { normalizePath } from '@salesforce/salesforcedx-lightning-lsp-common';
 import {
   buildSfdxContentMap,
-  createMockWorkspaceFindFilesConnection,
   DIR_STAT,
   FILE_STAT,
   getSfdxWorkspaceRelativePaths,
   SFDX_WORKSPACE_ROOT,
   sfdxFileSystemAccessor
 } from '@salesforce/salesforcedx-lightning-lsp-common/testUtils';
+import { createMockWorkspaceFindFilesConnection } from '@salesforce/salesforcedx-lightning-lsp-common/testSupport/mockWorkspaceFindFiles';
 import * as path from 'node:path';
 import type { Connection } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';

--- a/packages/salesforcedx-lwc-language-server/test/lwcContext.test.ts
+++ b/packages/salesforcedx-lwc-language-server/test/lwcContext.test.ts
@@ -8,7 +8,6 @@
 import { normalizePath, NormalizedPath } from '@salesforce/salesforcedx-lightning-lsp-common';
 import {
   buildSfdxContentMap,
-  createMockWorkspaceFindFilesConnection,
   DIR_STAT,
   FILE_STAT,
   FORCE_APP_ROOT,
@@ -19,6 +18,7 @@ import {
   sfdxFileSystemAccessor,
   UTILS_ROOT
 } from '@salesforce/salesforcedx-lightning-lsp-common/testUtils';
+import { createMockWorkspaceFindFilesConnection } from '@salesforce/salesforcedx-lightning-lsp-common/testSupport/mockWorkspaceFindFiles';
 import { minimatch } from 'minimatch';
 import { join, resolve } from 'node:path';
 import { Connection } from 'vscode-languageserver';

--- a/packages/salesforcedx-lwc-language-server/test/lwcDataProvider.test.ts
+++ b/packages/salesforcedx-lwc-language-server/test/lwcDataProvider.test.ts
@@ -23,12 +23,12 @@ jest.mock('../src/resources/transformed-lwc-standard.json', () => {
 
 import { normalizePath } from '@salesforce/salesforcedx-lightning-lsp-common';
 import {
-  createMockWorkspaceFindFilesConnection,
   getSfdxWorkspaceRelativePaths,
   SFDX_WORKSPACE_ROOT,
   SFDX_WORKSPACE_STRUCTURE,
   sfdxFileSystemAccessor
 } from '@salesforce/salesforcedx-lightning-lsp-common/testUtils';
+import { createMockWorkspaceFindFilesConnection } from '@salesforce/salesforcedx-lightning-lsp-common/testSupport/mockWorkspaceFindFiles';
 import * as path from 'node:path';
 import type { Connection } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';

--- a/packages/salesforcedx-lwc-language-server/test/lwcServerNode.test.ts
+++ b/packages/salesforcedx-lwc-language-server/test/lwcServerNode.test.ts
@@ -114,12 +114,12 @@ import {
   WORKSPACE_STAT_REQUEST
 } from '@salesforce/salesforcedx-lightning-lsp-common';
 import {
-  createMockWorkspaceFindFilesConnection,
   getSfdxWorkspaceRelativePaths,
   SFDX_WORKSPACE_ROOT,
   SFDX_WORKSPACE_STRUCTURE,
   sfdxFileSystemAccessor
 } from '@salesforce/salesforcedx-lightning-lsp-common/testUtils';
+import { createMockWorkspaceFindFilesConnection } from '@salesforce/salesforcedx-lightning-lsp-common/testSupport/mockWorkspaceFindFiles';
 import * as path from 'node:path';
 import { getLanguageService } from 'vscode-html-languageservice';
 import {
@@ -138,8 +138,8 @@ import {
 } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
-import { BaseServer } from '../src/baseServer';
-import Server, { findDynamicContent } from '../src/lwcServerNode';
+import { BaseServer, findDynamicContent } from '../src/baseServer';
+import Server from '../src/lwcServerNode';
 
 // File paths and URIs
 const filename = path.join(SFDX_WORKSPACE_ROOT, 'force-app', 'main', 'default', 'lwc', 'todo', 'todo.html');

--- a/packages/salesforcedx-lwc-language-server/test/tag.test.ts
+++ b/packages/salesforcedx-lwc-language-server/test/tag.test.ts
@@ -7,13 +7,13 @@
 import { normalizePath } from '@salesforce/salesforcedx-lightning-lsp-common';
 import {
   buildSfdxContentMap,
-  createMockWorkspaceFindFilesConnection,
   DIR_STAT,
   FILE_STAT,
   getSfdxWorkspaceRelativePaths,
   SFDX_WORKSPACE_ROOT,
   sfdxFileSystemAccessor
 } from '@salesforce/salesforcedx-lightning-lsp-common/testUtils';
+import { createMockWorkspaceFindFilesConnection } from '@salesforce/salesforcedx-lightning-lsp-common/testSupport/mockWorkspaceFindFiles';
 import { join } from 'node:path';
 import type { Connection } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';

--- a/packages/salesforcedx-vscode-services/src/virtualFsProvider/projectInit.ts
+++ b/packages/salesforcedx-vscode-services/src/virtualFsProvider/projectInit.ts
@@ -12,7 +12,8 @@ import { sampleProjectName } from '../constants';
 import { unknownToErrorCause } from '../core/shared';
 import { fsPrefix } from './constants';
 import { FsProvider } from './fsTypes';
-import { TEMPLATES, metadataDirs } from './templates/templates';
+import { metadataDirs } from './templates/metadataDirs';
+import { TEMPLATES } from './templates/templates';
 import { VirtualFsProviderError } from './virtualFsProviderError';
 
 const sampleProjectPath = `${fsPrefix}:/${sampleProjectName}`;

--- a/packages/salesforcedx-vscode-services/src/virtualFsProvider/templates/templates.ts
+++ b/packages/salesforcedx-vscode-services/src/virtualFsProvider/templates/templates.ts
@@ -27,5 +27,3 @@ export const TEMPLATES = {
   'README.md': readme,
   'tsconfig.json': tsconfig
 };
-
-export { metadataDirs } from './metadataDirs';

--- a/packages/salesforcedx-vscode-soql/src/soql-model/model/model.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-model/model/model.ts
@@ -287,5 +287,3 @@ export type UnmodeledSyntax = SelectExpression &
     unmodeledSyntax: string;
     reason: UnmodeledSyntaxReason;
   };
-
-export * from './unmodeled';

--- a/packages/salesforcedx-vscode-soql/src/soql-model/serialization/deserializer.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-model/serialization/deserializer.ts
@@ -52,6 +52,15 @@ import {
   OrderByExpression,
   Query,
   RecordTrackingType,
+  Select,
+  UnmodeledSyntax,
+  Update,
+  Where,
+  With,
+  SelectExpression,
+  NullsOrder
+} from '../model/model';
+import {
   REASON_UNMODELED_ALIAS,
   REASON_UNMODELED_AS,
   REASON_UNMODELED_BIND,
@@ -73,15 +82,8 @@ import {
   REASON_UNMODELED_USING,
   REASON_UNMODELED_WITH,
   REASON_UNMODELED_GROUPBY,
-  Select,
-  UnmodeledSyntax,
-  UnmodeledSyntaxReason,
-  Update,
-  Where,
-  With,
-  SelectExpression,
-  NullsOrder
-} from '../model/model';
+  UnmodeledSyntaxReason
+} from '../model/unmodeled';
 import { SoqlModelUtils } from '../model/util';
 
 export const deserialize = (soqlSyntax: string): Query => {

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-builder-ui/modules/querybuilder/services/soqlUtils.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-builder-ui/modules/querybuilder/services/soqlUtils.test.ts
@@ -8,7 +8,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { EOL } from 'os';
-import { REASON_UNMODELED_COMPLEXGROUP, REASON_UNMODELED_GROUPBY } from '../../../../../../src/soql-model/model/model';
+import {
+  REASON_UNMODELED_COMPLEXGROUP,
+  REASON_UNMODELED_GROUPBY
+} from '../../../../../../src/soql-model/model/unmodeled';
 import {
   convertUiModelToSoql,
   convertSoqlToUiModel,

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-builder-ui/modules/querybuilder/services/telemetryUtils.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-builder-ui/modules/querybuilder/services/telemetryUtils.test.ts
@@ -2,7 +2,7 @@
 import {
   REASON_UNMODELED_FUNCTIONREFERENCE,
   REASON_UNMODELED_GROUPBY
-} from '../../../../../../src/soql-model/model/model';
+} from '../../../../../../src/soql-model/model/unmodeled';
 import { createQueryTelemetry } from '../../../../../../src/soql-builder-ui/modules/querybuilder/services/telemetryUtils';
 import { ToolingModelJson } from '../../../../../../src/soql-builder-ui/modules/querybuilder/services/toolingModelService';
 

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-model/deserializer.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-model/deserializer.test.ts
@@ -5,8 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { ErrorType } from '../../../src/soql-model/model/model';
 import {
-  ErrorType,
   REASON_UNMODELED_ALIAS,
   REASON_UNMODELED_BIND,
   REASON_UNMODELED_FUNCTIONREFERENCE,
@@ -23,7 +23,7 @@ import {
   REASON_UNMODELED_COMPLEXGROUP,
   REASON_UNMODELED_DISTANCECONDITION,
   REASON_UNMODELED_INSEMIJOINCONDITION
-} from '../../../src/soql-model/model/model';
+} from '../../../src/soql-model/model/unmodeled';
 import { deserialize } from '../../../src/soql-model/serialization/deserializer';
 
 const testQueryModel = {

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/impl/fieldSelectionImpl.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/impl/fieldSelectionImpl.test.ts
@@ -8,7 +8,7 @@
 import { FieldRefImpl } from '../../../../../src/soql-model/model/impl/fieldRefImpl';
 import { FieldSelectionImpl } from '../../../../../src/soql-model/model/impl/fieldSelectionImpl';
 import { UnmodeledSyntaxImpl } from '../../../../../src/soql-model/model/impl/unmodeledSyntaxImpl';
-import { REASON_UNMODELED_ALIAS } from '../../../../../src/soql-model/model/model';
+import { REASON_UNMODELED_ALIAS } from '../../../../../src/soql-model/model/unmodeled';
 
 describe('FieldSelectionImpl should', () => {
   it('store a field', () => {

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/impl/fromImpl.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/impl/fromImpl.test.ts
@@ -7,7 +7,7 @@
 
 import { FromImpl } from '../../../../../src/soql-model/model/impl/fromImpl';
 import { UnmodeledSyntaxImpl } from '../../../../../src/soql-model/model/impl/unmodeledSyntaxImpl';
-import { REASON_UNMODELED_AS, REASON_UNMODELED_USING } from '../../../../../src/soql-model/model/model';
+import { REASON_UNMODELED_AS, REASON_UNMODELED_USING } from '../../../../../src/soql-model/model/unmodeled';
 
 describe('FromImpl should', () => {
   it('store SObject name as a string', () => {

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/impl/queryImpl.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/impl/queryImpl.test.ts
@@ -16,15 +16,15 @@ import { QueryImpl } from '../../../../../src/soql-model/model/impl/queryImpl';
 import { SelectExprsImpl } from '../../../../../src/soql-model/model/impl/selectExprsImpl';
 import { UnmodeledSyntaxImpl } from '../../../../../src/soql-model/model/impl/unmodeledSyntaxImpl';
 import { WhereImpl } from '../../../../../src/soql-model/model/impl/whereImpl';
+import { ConditionOperator } from '../../../../../src/soql-model/model/model';
 import {
-  ConditionOperator,
   REASON_UNMODELED_BIND,
   REASON_UNMODELED_GROUPBY,
   REASON_UNMODELED_OFFSET,
   REASON_UNMODELED_RECORDTRACKING,
   REASON_UNMODELED_UPDATE,
   REASON_UNMODELED_WITH
-} from '../../../../../src/soql-model/model/model';
+} from '../../../../../src/soql-model/model/unmodeled';
 
 describe('QueryImpl should', () => {
   it('store query components as appropriate model objects', () => {

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/util.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-model/model/util.test.ts
@@ -18,14 +18,12 @@ import { NotConditionImpl } from '../../../../src/soql-model/model/impl/notCondi
 import { QueryImpl } from '../../../../src/soql-model/model/impl/queryImpl';
 import { SelectExprsImpl } from '../../../../src/soql-model/model/impl/selectExprsImpl';
 import { UnmodeledSyntaxImpl } from '../../../../src/soql-model/model/impl/unmodeledSyntaxImpl';
+import { AndOr, Condition, ConditionOperator } from '../../../../src/soql-model/model/model';
 import {
-  AndOr,
-  Condition,
-  ConditionOperator,
   REASON_UNMODELED_ALIAS,
   REASON_UNMODELED_CALCULATEDCONDITION,
   REASON_UNMODELED_FUNCTIONREFERENCE
-} from '../../../../src/soql-model/model/model';
+} from '../../../../src/soql-model/model/unmodeled';
 import { SoqlModelUtils } from '../../../../src/soql-model/model/util';
 
 const field = new FieldRefImpl('field');

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-model/serialization/deserializer.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-model/serialization/deserializer.test.ts
@@ -5,8 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { ErrorType } from '../../../../src/soql-model/model/model';
 import {
-  ErrorType,
   REASON_UNMODELED_ALIAS,
   REASON_UNMODELED_AS,
   REASON_UNMODELED_BIND,
@@ -23,7 +23,7 @@ import {
   REASON_UNMODELED_UPDATE,
   REASON_UNMODELED_USING,
   REASON_UNMODELED_WITH
-} from '../../../../src/soql-model/model/model';
+} from '../../../../src/soql-model/model/unmodeled';
 import { deserialize } from '../../../../src/soql-model/serialization/deserializer';
 
 const testQueryModel = {


### PR DESCRIPTION
## Summary
- New ESLint rule `local/no-cross-barrel-reexport` bans relative and workspace-package re-exports outside index.ts barrel files
- Migrated 5 flagged files by deleting intermediate re-exports and updating consumers to direct imports
- Added package.json export subpath for mockWorkspaceFindFiles to replace testUtils re-export

## Plan
.claude/plans/W-23008174.md

## Reviewer notes
- **Low:** package.json export-path inconsistency (packages/salesforcedx-lightning-lsp-common/package.json:34): `./testUtils` hides the testSupport/ dir while new `./testSupport/mockWorkspaceFindFiles` exposes it. Not applied — fix requires design decision (either `./mockWorkspaceFindFiles` or renaming `./testUtils` to `./testSupport/testUtils`), and the latter would change an existing public subpath consumed by lwc/aura test files. Both patterns work; no functional bug.
- **Low:** noCrossBarrelReexport.ts:30 uses `for (let i = parts.length; i > 0; i--)` (violates avoid-let preference). Not applied — the finding itself concludes the for-loop is acceptable given the fs-walk/early-termination context, and identical pattern exists in the already-merged commandMustBeInPackageJson.ts:33. Refactoring to functional reverse-iteration adds no value and breaks consistency with precedent.
- **Low:** noCrossBarrelReexport.ts module-level `discoveredWorkspacePackages` cache (lines 24/27) is never invalidated — stale in a long-lived ESLint server if a package is added/renamed mid-session, and keyed on nothing (not repo root). Not applied — working as intended, matches merged commandMustBeInPackageJson cache precedent; workaround is trivial (reload), explicit knownWorkspacePackages option bypasses it, CI unaffected.
- **Low:** noCrossBarrelReexport.ts:90 exempts any file named index.ts by basename only, so a deeply-nested non-barrel index.ts could bypass the rule. Not applied — explicitly by design per the plan (index.ts = barrel at any depth), matches repo convention; not a correctness/security hole.

## Test plan
- Inspect the new rule and its test cases in `packages/eslint-local-rules/src/noCrossBarrelReexport.ts` and `test/no-cross-barrel-reexport.test.ts` — verify valid/invalid case coverage and option-driven determinism
- Review each of the 5 migrated files and their consumers — confirm imports now point directly to source instead of intermediate barrels, and the API surface remains unchanged
- Verify the new mockWorkspaceFindFiles export subpath resolves correctly for lwc/aura test consumers

### What issues does this PR fix or reference?
@W-23008174@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.my.salesforce.com/a07EE00002cIXXF