### PR TITLE
fix(security): call local effect-language-service bin, not bare npx - W-23024070

### DIFF
--- a/.claude/hooks/verify-on-edit.sh
+++ b/.claude/hooks/verify-on-edit.sh
@@ -22,9 +22,13 @@ fi
 echo "[verify-on-edit] compile passed" >&2
 
 # Effect LS diagnostics: only on .ts edits. Surface warnings AND messages, not just errors.
-if [[ "$EDITED_FILE" == *.ts ]] && [ -f "$EDITED_FILE" ]; then
+# Invoke the locally-installed bin directly (never bare `npx`, which would
+# silently fetch+execute an unscoped registry typosquat if the local install
+# is missing). The package is a top-level devDep in package.json.
+EFFECT_LS="$ROOT/node_modules/.bin/effect-language-service"
+if [[ "$EDITED_FILE" == *.ts ]] && [ -f "$EDITED_FILE" ] && [ -x "$EFFECT_LS" ]; then
   echo "[verify-on-edit] running effect LS on $EDITED_FILE" >&2
-  if EFFECT_OUTPUT=$(npx effect-language-service diagnostics --file "$EDITED_FILE" 2>&1); then
+  if EFFECT_OUTPUT=$("$EFFECT_LS" diagnostics --file "$EDITED_FILE" 2>&1); then
     # Exit 0 = no errors. Check if there are any warnings/messages worth surfacing.
     SUMMARY=$(echo "$EFFECT_OUTPUT" | grep -E '^Checked .* files? out of' | head -1)
     # Format: "Checked N files out of M files. X errors, Y warnings and Z messages."

--- a/.claude/hooks/verify-stop.sh
+++ b/.claude/hooks/verify-stop.sh
@@ -49,11 +49,16 @@ rm -f "$SESSION_MARKER"
 run_step "compile" "npm run compile" && echo "[verify-stop] compile ok" >&2
 run_step "lint" "npm run lint" && echo "[verify-stop] lint ok" >&2
 
-# Effect LS: only uncommitted .ts files
+# Effect LS: only uncommitted .ts files.
+# Invoke the locally-installed bin directly (never bare `npx`, which would
+# silently fetch+execute an unscoped registry typosquat if the local install
+# is missing). The package is a top-level devDep in package.json.
+EFFECT_LS="$ROOT/node_modules/.bin/effect-language-service"
 ts_files=$(git diff --name-only HEAD 2>/dev/null | grep '\.ts$' || true)
 if [ -n "$ts_files" ]; then
+  [ -x "$EFFECT_LS" ] || fail "effect LS" "$EFFECT_LS not found — run npm install"
   for f in $ts_files; do
-    [ -f "$f" ] && run_step "effect LS ($f)" "npx effect-language-service diagnostics --file $f"
+    [ -f "$f" ] && run_step "effect LS ($f)" "\"$EFFECT_LS\" diagnostics --file $f"
   done
 fi
 [ -z "$ts_files" ] && echo "[verify-stop] effect LS skipped (no uncommitted .ts)" >&2


### PR DESCRIPTION
## What

The Stop hook (`verify-stop.sh`) and the post-edit hook (`verify-on-edit.sh`) ran `npx effect-language-service diagnostics`. When the local install is missing (fresh clone before `npm install`, dropped `node_modules/.bin` entry, or absent lockfile resolution), bare `npx` **silently fetches and executes the unscoped registry package** `effect-language-service`.

That unscoped name is currently a typosquat/dependency-confusion placeholder:
- `effect-language-service@1.0.0`
- description: **"Security research by AnupamAS01"**
- maintainer: `anupam936574+1@gmail.com`

So a hook that runs automatically on agent Stop could pull and run arbitrary third-party code.

## Fix

Invoke the locally-installed bin directly — `$ROOT/node_modules/.bin/effect-language-service` — so npm/npx never contacts the registry:
- `verify-stop.sh`: hard-fails the verification step if the local bin is missing (`run npm install`), rather than reaching out to the network.
- `verify-on-edit.sh`: skips the diagnostics block if the bin isn't present.

The scoped `@effect/language-service` is already a top-level `devDevependencies` entry in `package.json` (line 35), so the local bin exists after a normal install — no dependency change needed.

## Test

- `bash -n` clean on both hooks.
- Local bin resolves: `node_modules/.bin/effect-language-service` → `../@effect/language-service/cli.js`.

W-23024070

🤖 Generated with [Claude Code](https://claude.com/claude-code)