### PR TITLE
chore: bump esbuild to ^0.27.7 - W-23005355

### DIFF
--- a/.claude/plans/W-23005355.md
+++ b/.claude/plans/W-23005355.md
@@ -1,0 +1,48 @@
+# W-23005355 — Bump esbuild 0.27.4 -> 0.28.1
+
+## Context
+
+- `esbuild` declared once: root `package.json` line 70 (`"esbuild": "0.27.4"`), `devDependencies`.
+- npm workspaces + `package-lock.json`. No yarn/pnpm.
+- WI detail wrong: `packages/salesforcedx-vscode-apex-log/package.json` has NO esbuild dep — only references `esbuild.config.mjs` (a script file, not the dep). No edit there.
+- esbuild used for bundling all extensions via per-pkg `esbuild.config.mjs` + root `vscode:bundle` wireit script.
+- 0.28.0 breaking changes low-risk: fallback-download integrity hash, `with { type: 'text' }` import attrs, Go 1.25->1.26 compiler. No API surface used by configs affected.
+- Sibling `esbuild-plugin-*` deps (lines 71-74): pin stays. See peer-dep note below for `esbuild-plugins-node-modules-polyfill`.
+
+### Peer-dep conflict: esbuild-plugins-node-modules-polyfill (line 74)
+
+- `esbuild-plugins-node-modules-polyfill@1.8.1` declares peerDep `esbuild: '>=0.14.0 <=0.27.x'` (verified: `npm view esbuild-plugins-node-modules-polyfill@1.8.1 peerDependencies`).
+- Bumping esbuild to 0.28.1 violates this range -> `npm install` emits `EBADPEER` **warning** (not error; npm v7+ does not block install).
+- DO NOT bump the polyfill plugin to "fix" this: every published `1.8.2-next.*` (incl. `next` dist-tag `1.8.2-next.1e6068e.0` and the advocate-suggested `1.8.2-next.fcd2e35.0`) STILL pins `esbuild: '>=0.14.0 <=0.27.x'` (verified via `npm view`). No published version supports 0.28.x. A bump changes nothing and adds a prerelease dep for no benefit.
+- Plugin consumer: `scripts/bundling/web.mjs` line 1 (`nodeModulesPolyfillPlugin`, used line 133), imported by every web extension's `esbuild.config.mjs` (services, apex-log, metadata, apex-testing, lwc, soql, org-browser). The peer range is advisory; correctness is proven empirically by running the web bundle + web e2e against 0.28.1, not by satisfying the SemVer range.
+- Decision: keep `1.8.1`. Treat the EBADPEER warning as expected/benign. Verification below MUST prove the plugin functions against 0.28.1.
+
+## Phases
+
+### Phase 1 — bump + reinstall
+
+- edit root `package.json` line 70: `0.27.4` -> `0.28.1`
+- `npm install` to refresh `package-lock.json` (esbuild + platform binary subdeps)
+  - expect ONE `EBADPEER esbuild-plugins-node-modules-polyfill` warning — benign, see Context. Any OTHER peer/integrity error is a failure.
+- verify `node_modules/esbuild/package.json` version = 0.28.1
+- files: `package.json`, `package-lock.json`
+- commit: `chore: bump esbuild to 0.28.1 - W-23005355`
+
+## Skills to apply
+
+- packageJson — dep edit conventions
+- wireit — bundle script structure if build debug needed
+- verification — pre-push checks
+- typescript
+
+## Verification
+
+- `npm install` clean except the single expected `EBADPEER` polyfill warning (see Context); no integrity errors, no other peer failures.
+- `cat node_modules/esbuild/package.json | grep version` = 0.28.1
+- `npm run vscode:bundle` passes (all 16 extensions bundle). This runs each web extension's `esbuild.config.mjs`, which imports `scripts/bundling/web.mjs` -> exercises `nodeModulesPolyfillPlugin` against esbuild 0.28.1. A clean bundle is direct proof the peer-dep violation is harmless.
+- `npm run test:web` (Playwright web suite, e.g. `packages/salesforcedx-vscode-services` `test:web` at package.json line 224) runs the polyfilled web bundle in-browser — e2e proof the plugin output works at runtime, not just that bundling succeeded.
+
+### Coverage notes
+
+- Branch e2e exercises the runtime extension, not the bundler version directly; the targeted proof is `vscode:bundle` + `test:web` above.
+- CI gates this automatically: `simple-git-hooks` (package.json lines 431-433) wires `pre-commit -> npm run precommit` and `pre-push -> npm run prepush`. The `precommit` wireit target (lines 403-415) runs `compile` + `lint`; `prepush` (lines 416-421) runs `precommit` + `test`. So lint/typecheck/test are enforced on commit/push without a separate manual step — no part of the change ships unchecked.

--- a/.claude/plans/W-23005355.md
+++ b/.claude/plans/W-23005355.md
@@ -1,48 +1,30 @@
-# W-23005355 — Bump esbuild 0.27.4 -> 0.28.1
+# W-23005355 — Bump esbuild 0.27.4 -> ^0.27.7
 
 ## Context
 
-- `esbuild` declared once: root `package.json` line 70 (`"esbuild": "0.27.4"`), `devDependencies`.
-- npm workspaces + `package-lock.json`. No yarn/pnpm.
-- WI detail wrong: `packages/salesforcedx-vscode-apex-log/package.json` has NO esbuild dep — only references `esbuild.config.mjs` (a script file, not the dep). No edit there.
-- esbuild used for bundling all extensions via per-pkg `esbuild.config.mjs` + root `vscode:bundle` wireit script.
-- 0.28.0 breaking changes low-risk: fallback-download integrity hash, `with { type: 'text' }` import attrs, Go 1.25->1.26 compiler. No API surface used by configs affected.
-- Sibling `esbuild-plugin-*` deps (lines 71-74): pin stays. See peer-dep note below for `esbuild-plugins-node-modules-polyfill`.
+- `esbuild` declared once: root `package.json` (`devDependencies`). npm workspaces + `package-lock.json`.
+- esbuild bundles all extensions via per-pkg `esbuild.config.mjs` + root `vscode:bundle` wireit script.
+- WI detail wrong: `packages/salesforcedx-vscode-apex-log/package.json` has NO esbuild dep — only references `esbuild.config.mjs` (a script file). No edit there.
 
-### Peer-dep conflict: esbuild-plugins-node-modules-polyfill (line 74)
+### Retarget 0.28.1 -> ^0.27.7
 
-- `esbuild-plugins-node-modules-polyfill@1.8.1` declares peerDep `esbuild: '>=0.14.0 <=0.27.x'` (verified: `npm view esbuild-plugins-node-modules-polyfill@1.8.1 peerDependencies`).
-- Bumping esbuild to 0.28.1 violates this range -> `npm install` emits `EBADPEER` **warning** (not error; npm v7+ does not block install).
-- DO NOT bump the polyfill plugin to "fix" this: every published `1.8.2-next.*` (incl. `next` dist-tag `1.8.2-next.1e6068e.0` and the advocate-suggested `1.8.2-next.fcd2e35.0`) STILL pins `esbuild: '>=0.14.0 <=0.27.x'` (verified via `npm view`). No published version supports 0.28.x. A bump changes nothing and adds a prerelease dep for no benefit.
-- Plugin consumer: `scripts/bundling/web.mjs` line 1 (`nodeModulesPolyfillPlugin`, used line 133), imported by every web extension's `esbuild.config.mjs` (services, apex-log, metadata, apex-testing, lwc, soql, org-browser). The peer range is advisory; correctness is proven empirically by running the web bundle + web e2e against 0.28.1, not by satisfying the SemVer range.
-- Decision: keep `1.8.1`. Treat the EBADPEER warning as expected/benign. Verification below MUST prove the plugin functions against 0.28.1.
+- Original target 0.28.1 is **blocked**, not by min-release-age but by the repo's own `check:peer-deps` gate (`check-peer-dependencies`, runs on postinstall/precommit/prepush).
+- `esbuild-plugins-node-modules-polyfill@1.8.1` (consumed by `scripts/bundling/web.mjs`) pins peerDep `esbuild: '>=0.14.0 <=0.27.x'`. NO published version — incl. `next`/all `1.8.2-next.*` prereleases — supports 0.28.x (verified via `npm view`).
+- The gate treats this as a **hard error (exit 1)**, not a benign npm warning. Only knob is `--ignore <peer-name>`, which would mean `--ignore esbuild` repo-wide — weakens esbuild peer-checking and ships in the PR. Rejected.
+- Decision: bump to latest within the polyfill peer range. Latest 0.27.x is **0.27.7** (published 2026-04-02, passes min-release-age). Use caret `^0.27.7` (note: `.npmrc` `save-exact=true`, but caret is written explicitly).
 
 ## Phases
 
 ### Phase 1 — bump + reinstall
 
-- edit root `package.json` line 70: `0.27.4` -> `0.28.1`
-- `npm install` to refresh `package-lock.json` (esbuild + platform binary subdeps)
-  - expect ONE `EBADPEER esbuild-plugins-node-modules-polyfill` warning — benign, see Context. Any OTHER peer/integrity error is a failure.
-- verify `node_modules/esbuild/package.json` version = 0.28.1
+- edit root `package.json`: `"esbuild": "0.27.4"` -> `"esbuild": "^0.27.7"`
+- `npm install` to refresh `package-lock.json`
 - files: `package.json`, `package-lock.json`
-- commit: `chore: bump esbuild to 0.28.1 - W-23005355`
-
-## Skills to apply
-
-- packageJson — dep edit conventions
-- wireit — bundle script structure if build debug needed
-- verification — pre-push checks
-- typescript
+- commit: `chore: bump esbuild to ^0.27.7 - W-23005355`
 
 ## Verification
 
-- `npm install` clean except the single expected `EBADPEER` polyfill warning (see Context); no integrity errors, no other peer failures.
-- `cat node_modules/esbuild/package.json | grep version` = 0.28.1
-- `npm run vscode:bundle` passes (all 16 extensions bundle). This runs each web extension's `esbuild.config.mjs`, which imports `scripts/bundling/web.mjs` -> exercises `nodeModulesPolyfillPlugin` against esbuild 0.28.1. A clean bundle is direct proof the peer-dep violation is harmless.
-- `npm run test:web` (Playwright web suite, e.g. `packages/salesforcedx-vscode-services` `test:web` at package.json line 224) runs the polyfilled web bundle in-browser — e2e proof the plugin output works at runtime, not just that bundling succeeded.
-
-### Coverage notes
-
-- Branch e2e exercises the runtime extension, not the bundler version directly; the targeted proof is `vscode:bundle` + `test:web` above.
-- CI gates this automatically: `simple-git-hooks` (package.json lines 431-433) wires `pre-commit -> npm run precommit` and `pre-push -> npm run prepush`. The `precommit` wireit target (lines 403-415) runs `compile` + `lint`; `prepush` (lines 416-421) runs `precommit` + `test`. So lint/typecheck/test are enforced on commit/push without a separate manual step — no part of the change ships unchecked.
+- `npm install` clean — no peer/integrity errors; `check:peer-deps` passes (polyfill peer range `<=0.27.x` satisfied).
+- `node_modules/esbuild/package.json` version = 0.27.7.
+- `npm run vscode:bundle` passes (all 55 scripts) — exercises `nodeModulesPolyfillPlugin` against 0.27.7.
+- CI gates lint/typecheck/test via `simple-git-hooks` (`pre-commit -> precommit`, `pre-push -> prepush`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "cz-conventional-changelog": "3.3.0",
         "dpdm": "^3.14.0",
         "effect": "^3.21.2",
-        "esbuild": "0.27.4",
+        "esbuild": "^0.27.7",
         "esbuild-plugin-copy": "2.1.1",
         "esbuild-plugin-polyfill-node": "0.3.0",
         "esbuild-plugin-transform": "0.5.0",
@@ -3129,9 +3129,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -3146,9 +3146,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -3163,9 +3163,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -3180,9 +3180,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -3197,9 +3197,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -3214,9 +3214,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -3231,9 +3231,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -3248,9 +3248,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -3265,9 +3265,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -3282,9 +3282,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -3299,9 +3299,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -3316,9 +3316,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -3333,9 +3333,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -3350,9 +3350,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -3367,9 +3367,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -3384,9 +3384,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -3401,9 +3401,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -3418,9 +3418,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -3435,9 +3435,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -3452,9 +3452,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -3469,9 +3469,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -3486,9 +3486,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
@@ -3503,9 +3503,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -3520,9 +3520,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -3537,9 +3537,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -3554,9 +3554,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -18626,9 +18626,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
-      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -18639,32 +18639,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.4",
-        "@esbuild/android-arm": "0.27.4",
-        "@esbuild/android-arm64": "0.27.4",
-        "@esbuild/android-x64": "0.27.4",
-        "@esbuild/darwin-arm64": "0.27.4",
-        "@esbuild/darwin-x64": "0.27.4",
-        "@esbuild/freebsd-arm64": "0.27.4",
-        "@esbuild/freebsd-x64": "0.27.4",
-        "@esbuild/linux-arm": "0.27.4",
-        "@esbuild/linux-arm64": "0.27.4",
-        "@esbuild/linux-ia32": "0.27.4",
-        "@esbuild/linux-loong64": "0.27.4",
-        "@esbuild/linux-mips64el": "0.27.4",
-        "@esbuild/linux-ppc64": "0.27.4",
-        "@esbuild/linux-riscv64": "0.27.4",
-        "@esbuild/linux-s390x": "0.27.4",
-        "@esbuild/linux-x64": "0.27.4",
-        "@esbuild/netbsd-arm64": "0.27.4",
-        "@esbuild/netbsd-x64": "0.27.4",
-        "@esbuild/openbsd-arm64": "0.27.4",
-        "@esbuild/openbsd-x64": "0.27.4",
-        "@esbuild/openharmony-arm64": "0.27.4",
-        "@esbuild/sunos-x64": "0.27.4",
-        "@esbuild/win32-arm64": "0.27.4",
-        "@esbuild/win32-ia32": "0.27.4",
-        "@esbuild/win32-x64": "0.27.4"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/esbuild-plugin-copy": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "cz-conventional-changelog": "3.3.0",
     "dpdm": "^3.14.0",
     "effect": "^3.21.2",
-    "esbuild": "0.27.4",
+    "esbuild": "^0.27.7",
     "esbuild-plugin-copy": "2.1.1",
     "esbuild-plugin-polyfill-node": "0.3.0",
     "esbuild-plugin-transform": "0.5.0",


### PR DESCRIPTION
@W-23005355@

## What & why

Bumps `esbuild` from `0.27.4` to `^0.27.7` (latest 0.27.x).

**Retargeted from the WI's stated 0.28.1.** `esbuild-plugins-node-modules-polyfill@1.8.1` (consumed by `scripts/bundling/web.mjs` for every web extension bundle) pins peerDep `esbuild: >=0.14.0 <=0.27.x`, and **no published version — including all `next`/prerelease builds — supports esbuild 0.28.x** (verified via `npm view`). The repo's `check:peer-deps` gate (`check-peer-dependencies`, run on postinstall/precommit/prepush) enforces this peer range as a hard error, so 0.28.x cannot land until upstream ships 0.28 support. `^0.27.7` is the newest version inside the satisfiable range.

## Changes

- `package.json`: `esbuild` `0.27.4` → `^0.27.7`
- `package-lock.json`: esbuild + platform-binary subpackages bumped to 0.27.7 (version/integrity only)

## Verification

- `npm install` clean — `check:peer-deps` passes (peer range `<=0.27.x` satisfied)
- `npm run vscode:bundle` — all 55 scripts pass (exercises `nodeModulesPolyfillPlugin` at 0.27.7)
- precommit (compile + lint) and full test suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)