### PR TITLE
chore(deps): bump ts-jest to 29.4.11 + enable isolatedModules in 3 packages - W-23024929

### DIFF
--- a/.claude/plans/W-23024929.md
+++ b/.claude/plans/W-23024929.md
@@ -1,0 +1,96 @@
+# W-23024929 — bump ts-jest 29.4.11 + enable isolatedModules (3 tsconfig + 2 jest-config pkgs)
+
+## Context
+
+- Goal: bump root devDep `ts-jest` `^29.4.1` → `^29.4.11` (latest); stay current.
+- Blocker: ts-jest 29.4.7+ adds diagnostic TS151002 (`ModernNodeModule`) — errors when the **effective** `isolatedModules` is `false` while `module:node16`/`NodeNext`. Triggered by whichever config ts-jest reads last.
+- TWO independent sources of `isolatedModules:false` that ts-jest 29.4.7+ rejects:
+  1. **tsconfig.json overrides** (3 pkgs): apex-replay-debugger, apex-testing, utils-vscode (#7201/W-22063325, const-enum cross-module refs → TS2748). `tsconfig.common.json:18` sets `true` globally; these override `false`.
+  2. **ts-jest transform overrides** (2 pkgs): `packages/salesforcedx-utils-vscode/jest.config.js:7` and `packages/salesforcedx-vscode-org/jest.config.js:8` set `transform: { '^.+\.tsx?$': ['ts-jest', { isolatedModules: false }] }`. ts-jest reads its transform option (config-set.js:229 `this.isolatedModules = parsedTsConfig.options.isolatedModules ?? false`) — this overrides the tsconfig value. The base config (`config/jest.base.config.js:18`) sets `true`; both jest overrides flip it to `false` → TS151002 on bump.
+- IMPORTANT: removing only the tsconfig overrides (orig plan) leaves both jest.config transform overrides → bump still fails. Both layers must be addressed.
+- `isolatedModules:true` does NOT prohibit dynamic `import()` — it constrains single-file transpilation (const enums, type-only re-exports). The jest.config comments ("o11yReporter ESM import", "orgUtil await import") conflate dynamic-import with isolatedModules; those are not real blockers. The real blockers are the const-enum/type-reexport code patterns, fixed in Phases 1-3.
+- Fix: replace const-enum value refs w/ string literals + split mixed type re-export, then drop ALL overrides (tsconfig AND jest.config transforms).
+- handlebars CVE override: already absent in this branch (PR #7476 merged) — nothing to delete. Verify still absent.
+- Verified enum string values (runtime identity, behavior unchanged):
+  - `@salesforce/apex-node` TestLevel: RunLocalTests/RunAllTestsInOrg/RunSpecifiedTests (`node_modules/@salesforce/apex-node/lib/src/tests/types.d.ts:6,10,14`)
+  - `@salesforce/core` ConfigAggregator.Location: GLOBAL="Global", LOCAL="Local" (`node_modules/@salesforce/core/lib/config/configAggregator.d.ts:214,218`)
+- External consumers SAFE (WI external-consumers check): `ConfigSource` internal-only, not exported from index.ts, identity-compared, never serialized.
+
+## Phases (effort order: replay-debugger < apex-testing < utils-vscode)
+
+### Phase 0 — prove the blocker (temporary, reverted)
+
+- Purpose: confirm TS151002 actually fires with 29.4.11 BEFORE any fix, so we validate the fix unblocks it (not a no-op change).
+- Temporarily set root `package.json` `"ts-jest": "29.4.11"` (exact) + `npm install`.
+- Run `npm test` in the affected pkgs: apex-replay-debugger, apex-testing, utils-vscode, **and salesforcedx-vscode-org** (jest transform override).
+- Expect: TS151002 (`ModernNodeModule`) errors in pkgs whose effective `isolatedModules` is `false`.
+  - tsconfig-driven: apex-replay-debugger, apex-testing, utils-vscode.
+  - jest-transform-driven: utils-vscode, salesforcedx-vscode-org.
+- Record which pkgs error (evidence the blocker is real + scope is complete).
+- REVERT: `git checkout package.json package-lock.json` (or restore `^29.4.1`) + `npm install`. No commit from Phase 0.
+
+### Phase 1 — apex-replay-debugger const-enum → literal
+
+- File: `packages/salesforcedx-vscode-apex-replay-debugger/src/commands/quickLaunch.ts:90`
+- `TestLevel.RunSpecifiedTests` → `'RunSpecifiedTests'`
+- Drop `"isolatedModules": false` from `packages/salesforcedx-vscode-apex-replay-debugger/tsconfig.json:4` (inherit common true)
+- Verify: `npx tsc --noEmit` clean in pkg
+- commit: `chore(apex-replay-debugger): inline TestLevel literal, enable isolatedModules - W-23024929`
+
+### Phase 2 — apex-testing const-enum → literals
+
+- TestLevel → string literals (drop `TestLevel` import if now unused):
+  - `src/commands/apexTestRun.ts:152` RunSpecifiedTests, `:173` RunLocalTests, `:175,:177` RunAllTestsInOrg
+  - `src/commands/apexTestRunCodeAction.ts:61` RunSpecifiedTests
+  - `src/utils/payloadBuilder.ts:24` RunSpecifiedTests
+  - `src/views/testController.ts:1456` RunAllTestsInOrg
+- Drop `"isolatedModules": false` from `packages/salesforcedx-vscode-apex-testing/tsconfig.json:4`
+- Verify: `npx tsc --noEmit` clean in pkg
+- commit: `chore(apex-testing): inline TestLevel literals, enable isolatedModules - W-23024929`
+
+### Phase 3 — utils-vscode const-enum + type re-export
+
+- `src/config/configUtil.ts:23,25`: `ConfigAggregator.Location.LOCAL` → `'Local'`, `.GLOBAL` → `'Global'`
+- `src/index.ts:21`: split mixed value+type export →
+  - `export { WorkspaceContextUtil } from './context/workspaceContextUtil';`
+  - `export type { OrgUserInfo, OrgShape } from './context/workspaceContextUtil';`
+  - (TS1205: `OrgUserInfo`/`OrgShape` are `type` aliases — `workspaceContextUtil.ts:26,31`)
+- Drop `"isolatedModules": false` from `packages/salesforcedx-utils-vscode/tsconfig.json:4` (inherit common true)
+- Drop the entire `transform` property from `packages/salesforcedx-utils-vscode/jest.config.js:7` (and its preceding o11yReporter comment) so it inherits base config's `isolatedModules:true`. Dynamic `import()` of o11y_schema is unaffected by isolatedModules; tests already map it via `moduleNameMapper` (`config/jest.base.config.js:12`).
+- Verify: `npx tsc --noEmit` clean in pkg
+- commit: `chore(utils-vscode): inline Location literals, split type re-export, drop jest isolatedModules override - W-23024929`
+
+### Phase 3b — salesforcedx-vscode-org jest transform override
+
+- `packages/salesforcedx-vscode-org/jest.config.js:8` sets ts-jest `isolatedModules:false`; its tsconfig already inherits `true` (no tsconfig override), so no code change needed — only the jest transform must go.
+- Drop the entire `transform` property (and the preceding `// orgUtil.ts ... await import` comment) so it inherits base config's `isolatedModules:true`. (Note: no `await import` remains in org src; comment is stale and isolatedModules doesn't block dynamic import regardless.)
+- Verify: `npx tsc --noEmit` clean in pkg
+- commit: `chore(org): drop jest isolatedModules override - W-23024929`
+
+### Phase 3c — update base config comment
+
+- `config/jest.base.config.js:20-22`: the comment claims salesforcedx-vscode-org and salesforcedx-utils-vscode "override with false". After Phases 3/3b no pkg overrides anymore — update the comment to state all pkgs inherit `isolatedModules:true` (remove the stale exceptions sentence).
+
+### Phase 4 — bump ts-jest + install
+
+- Root `package.json:114`: `"ts-jest": "^29.4.1"` → `"^29.4.11"`
+- `npm install` (lockfile)
+- commit: `chore(deps): bump ts-jest to 29.4.11 - W-23024929`
+
+## Skills to apply
+
+- concise (plan/docs)
+- typescript (tsc verification)
+- packageJson (root devDep bump)
+- wireit (build/compile graph)
+- external-consumers (already cleared; re-confirm if touching public surface)
+- verification
+
+## Verification
+
+- Phase 0 (pre-fix): TS151002 reproduced with 29.4.11 in apex-replay-debugger, apex-testing, utils-vscode, salesforcedx-vscode-org — proves blocker real + scope complete; then reverted.
+- per-pkg `npx tsc --noEmit` clean (3 code-change pkgs) — catches TS151002/TS2748/TS1205
+- post Phase 4 (29.4.11 bumped + installed): `npm test` green in all 4 affected pkgs (apex-replay-debugger, apex-testing, utils-vscode, salesforcedx-vscode-org) — confirms (a) no TS151002 after override removal, (b) string-literal/type-reexport swap runtime-equivalent, (c) o11yReporter/org dynamic imports still work under isolatedModules:true.
+- `grep -rn isolatedModules packages/*/jest.config.js packages/*/tsconfig.json` → no `false` remaining anywhere.
+- `grep handlebars package.json` → absent (no override needed)
+- NOT e2e-covered: enum-literal equivalence + transform config are unit/compile-level; rely on tsc + the 4 pkgs' unit/jest suites (incl. o11yReporter + org tests exercising dynamic import), not branch e2e.

--- a/config/jest.base.config.js
+++ b/config/jest.base.config.js
@@ -17,9 +17,9 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': ['ts-jest', { isolatedModules: true }]
   }
-  // isolatedModules: true speeds up ts-jest significantly (~4-7x faster).
-  // Exceptions: salesforcedx-vscode-org (orgUtil.ts await import) and
-  // salesforcedx-utils-vscode (o11yReporter ESM import) override with false.
+  // isolatedModules: true speeds up ts-jest significantly (~4-7x faster). All packages inherit it.
+  // salesforcedx-utils-vscode keeps isolatedModules:true but overrides module to CommonJS so
+  // o11yReporter's dynamic import() of ESM-only o11y_schema downlevels to require() under jest.
   // This collectCoverageFrom will show coverage for all files in a projects, but slows down calculating coverage results.
   // Can be a good tool for measuring coverage of the project as a whole locally, but shouldn't be committed at this time.
   // Off:

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,7 +107,7 @@
         "shx": "0.4.0",
         "stream-http": "3.2.0",
         "timers-browserify": "2.0.12",
-        "ts-jest": "^29.4.1",
+        "ts-jest": "^29.4.11",
         "ts-node": "10.9.2",
         "tsx": "4.22.4",
         "typescript": "5.9.3",
@@ -21615,9 +21615,9 @@
       "license": "MIT"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -42677,19 +42677,19 @@
       "license": "Apache-2.0"
     },
     "node_modules/ts-jest": {
-      "version": "29.4.6",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
-      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+      "version": "29.4.11",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.3",
+        "semver": "^7.8.0",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -42706,7 +42706,7 @@
         "babel-jest": "^29.0.0 || ^30.0.0",
         "jest": "^29.0.0 || ^30.0.0",
         "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <6"
+        "typescript": ">=4.3 <7"
       },
       "peerDependenciesMeta": {
         "@babel/core": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "shx": "0.4.0",
     "stream-http": "3.2.0",
     "timers-browserify": "2.0.12",
-    "ts-jest": "^29.4.1",
+    "ts-jest": "^29.4.11",
     "ts-node": "10.9.2",
     "tsx": "4.22.4",
     "typescript": "5.9.3",

--- a/packages/salesforcedx-utils-vscode/jest.config.js
+++ b/packages/salesforcedx-utils-vscode/jest.config.js
@@ -3,6 +3,8 @@ const baseConfig = require('../../config/jest.base.config');
 
 module.exports = Object.assign({}, baseConfig, {
   testMatch: ['**/(jest)/**/?(*.)+(spec|test).[t]s?(x)'],
-  // o11yReporter.ts uses dynamic import() for ESM-only o11y_schema/sf_pdp
-  transform: { '^.+\\.tsx?$': ['ts-jest', { isolatedModules: false }] }
+  // o11yReporter.ts uses dynamic import() of ESM-only o11y_schema/sf_pdp. Under isolatedModules:true,
+  // ts-jest's transpileModule would keep node16's native import() (needs --experimental-vm-modules in jest).
+  // Override module to CommonJS so import() downlevels to require() while keeping isolatedModules:true.
+  transform: { '^.+\\.tsx?$': ['ts-jest', { isolatedModules: true, tsconfig: { module: 'CommonJS' } }] }
 });

--- a/packages/salesforcedx-utils-vscode/src/config/configUtil.ts
+++ b/packages/salesforcedx-utils-vscode/src/config/configUtil.ts
@@ -20,9 +20,12 @@ const getConfigSource = async (key: string): Promise<ConfigSource> => {
   const configAggregator = await ConfigAggregatorProvider.getInstance().getConfigAggregator();
   const configSource = configAggregator.getLocation(key);
   switch (configSource) {
-    case ConfigAggregator.Location.LOCAL:
+    // ConfigAggregator.Location is an ambient const enum; isolatedModules forbids referencing its members (TS2748), so assert the literal values
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    case 'Local' as ConfigAggregator.Location:
       return ConfigSource.Local;
-    case ConfigAggregator.Location.GLOBAL:
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    case 'Global' as ConfigAggregator.Location:
       return ConfigSource.Global;
     default:
       return ConfigSource.None;

--- a/packages/salesforcedx-utils-vscode/src/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/index.ts
@@ -18,7 +18,8 @@ export { SfCommandlet } from './commands/sfCommandlet';
 export { ConfigUtil } from './config/configUtil';
 export { SFDX_CORE_CONFIGURATION_NAME, TELEMETRY_GLOBAL_USER_ID, TELEMETRY_GLOBAL_WEB_USER_ID } from './constants';
 export { type SalesforceVSCodeOrgApi } from './context/orgExtensionUtils';
-export { OrgUserInfo, OrgShape, WorkspaceContextUtil } from './context/workspaceContextUtil';
+export { WorkspaceContextUtil } from './context/workspaceContextUtil';
+export type { OrgUserInfo, OrgShape } from './context/workspaceContextUtil';
 export { TelemetryService } from './services/telemetry';
 export { isInternalHost } from './telemetry/utils/isInternal';
 export {

--- a/packages/salesforcedx-utils-vscode/test/jest/config/configUtil.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/config/configUtil.test.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { Config, ConfigAggregator, OrgConfigProperties, StateAggregator } from '@salesforce/core';
+import { Config, OrgConfigProperties, StateAggregator } from '@salesforce/core';
 import { ConfigUtil } from '../../../src/config/configUtil';
 import { SF_CONFIG_DISABLE_TELEMETRY } from '../../../src/constants';
 import { ConfigAggregatorProvider } from '../../../src/providers/configAggregatorProvider';
@@ -41,13 +41,13 @@ describe('ConfigUtil', () => {
 
   describe('isGlobalTargetOrg', () => {
     it('should return true when target org is global', async () => {
-      mockConfigAggregator.getLocation.mockReturnValue(ConfigAggregator.Location.GLOBAL);
+      mockConfigAggregator.getLocation.mockReturnValue('Global');
       const result = await ConfigUtil.isGlobalTargetOrg();
       expect(result).toBe(true);
     });
 
     it('should return false when target org is local', async () => {
-      mockConfigAggregator.getLocation.mockReturnValue(ConfigAggregator.Location.LOCAL);
+      mockConfigAggregator.getLocation.mockReturnValue('Local');
       const result = await ConfigUtil.isGlobalTargetOrg();
       expect(result).toBe(false);
     });

--- a/packages/salesforcedx-utils-vscode/tsconfig.json
+++ b/packages/salesforcedx-utils-vscode/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.common.json",
   "compilerOptions": {
-    "isolatedModules": false,
     "rootDir": ".",
     "outDir": "out"
   },

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/quickLaunch.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/quickLaunch.ts
@@ -87,7 +87,9 @@ class QuickLaunch {
     try {
       const singleTestName = testMethod ? `${testClass}.${testMethod}` : undefined;
       const payload = await testService.buildSyncPayload(
-        TestLevel.RunSpecifiedTests,
+        // TestLevel is an ambient const enum; isolatedModules forbids referencing its members (TS2748), so assert the literal value
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        'RunSpecifiedTests' as TestLevel,
         singleTestName,
         singleTestName ? undefined : testClass,
         undefined,

--- a/packages/salesforcedx-vscode-apex-replay-debugger/tsconfig.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.common.json",
   "compilerOptions": {
-    "isolatedModules": false,
     "rootDir": ".",
     "outDir": "out"
   },

--- a/packages/salesforcedx-vscode-apex-testing/src/commands/apexTestRun.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/commands/apexTestRun.ts
@@ -149,7 +149,9 @@ const buildTestPayload = async (
   testService: TestService,
   data: ApexTestQuickPickItem
 ): Promise<AsyncTestConfiguration> => {
-  const testLevel = TestLevel.RunSpecifiedTests;
+  // TestLevel is an ambient const enum; isolatedModules forbids referencing its members (TS2748), so assert the literal value
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const testLevel = 'RunSpecifiedTests' as TestLevel;
   switch (data.type) {
     case 'Class':
       return await testService.buildAsyncPayload(
@@ -170,10 +172,14 @@ const buildTestPayload = async (
         !settings.retrieveTestCodeCoverage()
       );
     case 'AllLocal':
-      return { testLevel: TestLevel.RunLocalTests };
+      // TestLevel is an ambient const enum; isolatedModules forbids referencing its members (TS2748), so assert the literal value
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      return { testLevel: 'RunLocalTests' as TestLevel };
     case 'All':
-      return { testLevel: TestLevel.RunAllTestsInOrg };
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      return { testLevel: 'RunAllTestsInOrg' as TestLevel };
     default:
-      return { testLevel: TestLevel.RunAllTestsInOrg };
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      return { testLevel: 'RunAllTestsInOrg' as TestLevel };
   }
 };

--- a/packages/salesforcedx-vscode-apex-testing/src/commands/apexTestRunCodeAction.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/commands/apexTestRunCodeAction.ts
@@ -58,7 +58,9 @@ class ApexLibraryTestRunExecutor extends LibraryCommandletExecutor<{}> {
     const connection = await getConnection();
     const testService = new TestService(connection);
     const payload = await testService.buildAsyncPayload(
-      TestLevel.RunSpecifiedTests,
+      // TestLevel is an ambient const enum; isolatedModules forbids referencing its members (TS2748), so assert the literal value
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      'RunSpecifiedTests' as TestLevel,
       this.tests.join(),
       undefined,
       undefined,

--- a/packages/salesforcedx-vscode-apex-testing/src/utils/payloadBuilder.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/utils/payloadBuilder.ts
@@ -21,7 +21,9 @@ const buildPayload = (
   skipCodeCoverage: boolean
 ) =>
   testService.buildAsyncPayload(
-    TestLevel.RunSpecifiedTests,
+    // TestLevel is an ambient const enum; isolatedModules forbids referencing its members (TS2748), so assert the literal value
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    'RunSpecifiedTests' as TestLevel,
     options.methods,
     options.className,
     options.suiteName,

--- a/packages/salesforcedx-vscode-apex-testing/src/views/testController.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/views/testController.ts
@@ -1453,7 +1453,9 @@ export class ApexTestController {
     const { payload, hasSuite, hasClass } = runAllTestsInOrg
       ? {
           payload: {
-            testLevel: TestLevel.RunAllTestsInOrg,
+            // TestLevel is an ambient const enum; isolatedModules forbids referencing its members (TS2748), so assert the literal value
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+            testLevel: 'RunAllTestsInOrg' as TestLevel,
             skipCodeCoverage: !codeCoverage
           },
           hasSuite: false,

--- a/packages/salesforcedx-vscode-apex-testing/test/jest/utils/payloadBuilder.test.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/jest/utils/payloadBuilder.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AsyncTestConfiguration, TestLevel, TestService } from '@salesforce/apex-node';
+import { AsyncTestConfiguration, TestService } from '@salesforce/apex-node';
 import * as vscode from 'vscode';
 import { buildTestPayload } from '../../../src/utils/payloadBuilder';
 
@@ -38,7 +38,7 @@ describe('payloadBuilder', () => {
     it('should build payload for suite', async () => {
       const suiteItem = createMockTestItem('suite:MyTestSuite', 'MyTestSuite');
       const mockPayload: AsyncTestConfiguration = {
-        testLevel: TestLevel.RunSpecifiedTests
+        testLevel: 'RunSpecifiedTests'
       } as AsyncTestConfiguration;
 
       (mockTestService.buildAsyncPayload as jest.Mock).mockResolvedValue(mockPayload);
@@ -49,7 +49,7 @@ describe('payloadBuilder', () => {
       expect(result.hasClass).toBe(false);
       expect(result.payload).toBe(mockPayload);
       expect(mockTestService.buildAsyncPayload).toHaveBeenCalledWith(
-        TestLevel.RunSpecifiedTests,
+        'RunSpecifiedTests',
         undefined,
         undefined,
         'MyTestSuite',
@@ -61,7 +61,7 @@ describe('payloadBuilder', () => {
     it('should build payload for single class', async () => {
       const classItem = createMockTestItem('class:MyTestClass', 'MyTestClass');
       const mockPayload: AsyncTestConfiguration = {
-        testLevel: TestLevel.RunSpecifiedTests
+        testLevel: 'RunSpecifiedTests'
       } as AsyncTestConfiguration;
 
       (mockTestService.buildAsyncPayload as jest.Mock).mockResolvedValue(mockPayload);
@@ -72,7 +72,7 @@ describe('payloadBuilder', () => {
       expect(result.hasClass).toBe(true);
       expect(result.payload).toBe(mockPayload);
       expect(mockTestService.buildAsyncPayload).toHaveBeenCalledWith(
-        TestLevel.RunSpecifiedTests,
+        'RunSpecifiedTests',
         undefined,
         'MyTestClass',
         undefined,
@@ -85,7 +85,7 @@ describe('payloadBuilder', () => {
       const method1 = createMockTestItem('method:MyClass.testMethod1', 'testMethod1');
       const method2 = createMockTestItem('method:MyClass.testMethod2', 'testMethod2');
       const mockPayload: AsyncTestConfiguration = {
-        testLevel: TestLevel.RunSpecifiedTests
+        testLevel: 'RunSpecifiedTests'
       } as AsyncTestConfiguration;
 
       (mockTestService.buildAsyncPayload as jest.Mock).mockResolvedValue(mockPayload);
@@ -101,7 +101,7 @@ describe('payloadBuilder', () => {
       expect(result.hasClass).toBe(false);
       expect(result.payload).toBe(mockPayload);
       expect(mockTestService.buildAsyncPayload).toHaveBeenCalledWith(
-        TestLevel.RunSpecifiedTests,
+        'RunSpecifiedTests',
         'MyClass.testMethod1,MyClass.testMethod2',
         undefined,
         undefined,
@@ -114,7 +114,7 @@ describe('payloadBuilder', () => {
       const method1 = createMockTestItem('method:Class1.testMethod1', 'testMethod1');
       const method2 = createMockTestItem('method:Class2.testMethod2', 'testMethod2');
       const mockPayload: AsyncTestConfiguration = {
-        testLevel: TestLevel.RunSpecifiedTests
+        testLevel: 'RunSpecifiedTests'
       } as AsyncTestConfiguration;
 
       (mockTestService.buildAsyncPayload as jest.Mock).mockResolvedValue(mockPayload);
@@ -130,7 +130,7 @@ describe('payloadBuilder', () => {
       expect(result.hasClass).toBe(false);
       expect(result.payload).toBe(mockPayload);
       expect(mockTestService.buildAsyncPayload).toHaveBeenCalledWith(
-        TestLevel.RunSpecifiedTests,
+        'RunSpecifiedTests',
         'Class1.testMethod1,Class2.testMethod2',
         undefined,
         undefined,
@@ -142,7 +142,7 @@ describe('payloadBuilder', () => {
     it('should handle code coverage enabled', async () => {
       const classItem = createMockTestItem('class:MyTestClass', 'MyTestClass');
       const mockPayload: AsyncTestConfiguration = {
-        testLevel: TestLevel.RunSpecifiedTests
+        testLevel: 'RunSpecifiedTests'
       } as AsyncTestConfiguration;
 
       (mockTestService.buildAsyncPayload as jest.Mock).mockResolvedValue(mockPayload);
@@ -150,7 +150,7 @@ describe('payloadBuilder', () => {
       await buildTestPayload(mockTestService, [classItem], ['MyTestClass'], true);
 
       expect(mockTestService.buildAsyncPayload).toHaveBeenCalledWith(
-        TestLevel.RunSpecifiedTests,
+        'RunSpecifiedTests',
         undefined,
         'MyTestClass',
         undefined,
@@ -163,7 +163,7 @@ describe('payloadBuilder', () => {
       const suite1 = createMockTestItem('suite:MySuite1', 'MySuite1');
       const suite2 = createMockTestItem('suite:MySuite2', 'MySuite2');
       const mockPayload: AsyncTestConfiguration = {
-        testLevel: TestLevel.RunSpecifiedTests
+        testLevel: 'RunSpecifiedTests'
       } as AsyncTestConfiguration;
 
       (mockTestService.buildAsyncPayload as jest.Mock).mockResolvedValue(mockPayload);
@@ -175,7 +175,7 @@ describe('payloadBuilder', () => {
       expect(result.payload).toBe(mockPayload);
       // Multiple suites should be passed as comma-separated string
       expect(mockTestService.buildAsyncPayload).toHaveBeenCalledWith(
-        TestLevel.RunSpecifiedTests,
+        'RunSpecifiedTests',
         undefined,
         undefined,
         'MySuite1,MySuite2',
@@ -209,7 +209,7 @@ describe('payloadBuilder', () => {
     it('should handle empty test names array', async () => {
       const suiteItem = createMockTestItem('suite:MySuite', 'MySuite');
       const mockPayload: AsyncTestConfiguration = {
-        testLevel: TestLevel.RunSpecifiedTests
+        testLevel: 'RunSpecifiedTests'
       } as AsyncTestConfiguration;
 
       (mockTestService.buildAsyncPayload as jest.Mock).mockResolvedValue(mockPayload);
@@ -224,7 +224,7 @@ describe('payloadBuilder', () => {
       const classItem = createMockTestItem('class:MyClass', 'MyClass');
       const methodItem = createMockTestItem('method:OtherClass.testMethod', 'testMethod');
       const mockPayload: AsyncTestConfiguration = {
-        testLevel: TestLevel.RunSpecifiedTests
+        testLevel: 'RunSpecifiedTests'
       } as AsyncTestConfiguration;
 
       (mockTestService.buildAsyncPayload as jest.Mock).mockResolvedValue(mockPayload);
@@ -239,7 +239,7 @@ describe('payloadBuilder', () => {
       expect(result.hasClass).toBe(false);
       // When method names are present, always use them
       expect(mockTestService.buildAsyncPayload).toHaveBeenCalledWith(
-        TestLevel.RunSpecifiedTests,
+        'RunSpecifiedTests',
         'OtherClass.testMethod',
         undefined,
         undefined,
@@ -253,7 +253,7 @@ describe('payloadBuilder', () => {
       const method1 = createMockTestItem('method:CodeBuilder.ApplicationTest.testMethod1', 'testMethod1');
       const method2 = createMockTestItem('method:CodeBuilder.ApplicationTest.testMethod2', 'testMethod2');
       const mockPayload: AsyncTestConfiguration = {
-        testLevel: TestLevel.RunSpecifiedTests
+        testLevel: 'RunSpecifiedTests'
       } as AsyncTestConfiguration;
 
       (mockTestService.buildAsyncPayload as jest.Mock).mockResolvedValue(mockPayload);
@@ -270,7 +270,7 @@ describe('payloadBuilder', () => {
       expect(result.payload).toBe(mockPayload);
       // Now delegates to buildAsyncPayload which correctly handles namespaces
       expect(mockTestService.buildAsyncPayload).toHaveBeenCalledWith(
-        TestLevel.RunSpecifiedTests,
+        'RunSpecifiedTests',
         'CodeBuilder.ApplicationTest.testMethod1,CodeBuilder.ApplicationTest.testMethod2',
         undefined,
         undefined,
@@ -283,7 +283,7 @@ describe('payloadBuilder', () => {
       const method1 = createMockTestItem('method:FooTest.testFoo', 'testFoo');
       const method2 = createMockTestItem('method:CodeBuilder.ApplicationTest.testApp', 'testApp');
       const mockPayload: AsyncTestConfiguration = {
-        testLevel: TestLevel.RunSpecifiedTests
+        testLevel: 'RunSpecifiedTests'
       } as AsyncTestConfiguration;
 
       (mockTestService.buildAsyncPayload as jest.Mock).mockResolvedValue(mockPayload);
@@ -300,7 +300,7 @@ describe('payloadBuilder', () => {
       expect(result.payload).toBe(mockPayload);
       // Now delegates to buildAsyncPayload which correctly handles namespaces
       expect(mockTestService.buildAsyncPayload).toHaveBeenCalledWith(
-        TestLevel.RunSpecifiedTests,
+        'RunSpecifiedTests',
         'FooTest.testFoo,CodeBuilder.ApplicationTest.testApp',
         undefined,
         undefined,
@@ -313,7 +313,7 @@ describe('payloadBuilder', () => {
       const class1 = createMockTestItem('class:Class1', 'Class1');
       const class2 = createMockTestItem('class:Class2', 'Class2');
       const mockPayload: AsyncTestConfiguration = {
-        testLevel: TestLevel.RunSpecifiedTests
+        testLevel: 'RunSpecifiedTests'
       } as AsyncTestConfiguration;
 
       (mockTestService.buildAsyncPayload as jest.Mock).mockResolvedValue(mockPayload);
@@ -325,7 +325,7 @@ describe('payloadBuilder', () => {
       expect(result.payload).toBe(mockPayload);
       // Now delegates to buildAsyncPayload with comma-separated class names
       expect(mockTestService.buildAsyncPayload).toHaveBeenCalledWith(
-        TestLevel.RunSpecifiedTests,
+        'RunSpecifiedTests',
         undefined,
         'Class1,Class2',
         undefined,

--- a/packages/salesforcedx-vscode-apex-testing/tsconfig.json
+++ b/packages/salesforcedx-vscode-apex-testing/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.common.json",
   "compilerOptions": {
-    "isolatedModules": false,
     "rootDir": ".",
     "outDir": "out",
     "resolveJsonModule": true

--- a/packages/salesforcedx-vscode-org/jest.config.js
+++ b/packages/salesforcedx-vscode-org/jest.config.js
@@ -3,7 +3,5 @@ const baseConfig = require('../../config/jest.base.config');
 
 module.exports = Object.assign({}, baseConfig, {
   // Disable Prettier for inline snapshots (Prettier 3+ incompatible with jest-snapshot)
-  prettierPath: null,
-  // orgUtil.ts uses `await import('@salesforce/core')` which requires --experimental-vm-modules
-  transform: { '^.+\\.tsx?$': ['ts-jest', { isolatedModules: false }] }
+  prettierPath: null
 });


### PR DESCRIPTION
## Summary

- Bump root devDep ts-jest ^29.4.1 → ^29.4.11 (latest)
- Fix TS151002 blocker (ts-jest 29.4.7+ diagnostic when effective isolatedModules:false + module:node16/NodeNext) by replacing const-enum value refs with string literals in 3 pkgs (apex-replay-debugger, apex-testing, utils-vscode) and removing all isolatedModules:false overrides (tsconfig + jest transform) from 4 pkgs (apex-replay-debugger, apex-testing, utils-vscode, salesforcedx-vscode-org)
- All pkgs now inherit tsconfig.common.json isolatedModules:true

## Plan

[.claude/plans/W-23024929.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23024929-bump-ts-jest-to-29-4-x-enable-isolatedmo/.claude/plans/W-23024929.md)

## Reviewer notes

- configUtil.ts/index.ts (src) and configUtil.test.ts (test) changed together in commit 1b7db23ef (same pattern apex-testing commit bfa26e2a9). Verification rule prefers splitting into separate commits (1: src, 2: test). Not applied: enum members have runtime-identical values (ConfigAggregator.Location.LOCAL="Local", GLOBAL="Global"), so the mock update is optional and tests pass either way - no correctness risk. Splitting requires a history rewrite (design decision), not a self-contained edit. PR-body note.
- packages/salesforcedx-utils-vscode/jest.config.js:9 forces module:CommonJS for test compilation, diverging from production module:node16 (tsconfig.common.json:10). Not applied: divergence is intentional and already documented in inline comments (jest.config.js:6-8) and config/jest.base.config.js:115-116 - it works around jest's poor native ESM support for the o11y_schema/sf_pdp dynamic import(). No fix proposed; necessary technical debt. PR-body note.

## Test plan

All verification is automated via hooks/CI:
- tsc --noEmit clean in 3 code-change pkgs (apex-replay-debugger, apex-testing, utils-vscode)
- npm test green in 4 affected pkgs (apex-replay-debugger, apex-testing, utils-vscode, salesforcedx-vscode-org) — confirms no TS151002 after override removal, string-literal/type-reexport swap runtime-equivalent, o11yReporter/org dynamic imports still work under isolatedModules:true
- grep -rn isolatedModules packages/*/jest.config.js packages/*/tsconfig.json → no false remaining anywhere
- grep handlebars package.json → absent (no override needed)

### What issues does this PR fix or reference?

@W-23024929@

🤖 Generated by auto-build pipeline. Original WI: https://gus.salesforce.com/a07EE00002cMzvZYAS