### PR TITLE
chore(services): bump apiVersion + sourceApiVersion to 67.0 - W-23025928

### DIFF
--- a/.claude/plans/W-23025928.md
+++ b/.claude/plans/W-23025928.md
@@ -1,0 +1,32 @@
+# W-23025928 — Bump services ext apiVersion + sourceApiVersion to 67.0
+
+## Context
+
+Bump API version `64.0` -> `67.0` in `salesforcedx-vscode-services`.
+
+3 locations (all currently `64.0`):
+- `packages/salesforcedx-vscode-services/package.json:311` — `salesforce-web-console.apiVersion` default (named in WI)
+- `packages/salesforcedx-vscode-services/src/virtualFsProvider/templates/sfdxProject.ts:18` — `sourceApiVersion` (named in WI)
+- `packages/salesforcedx-vscode-services/src/vscode/settingsService.ts:20` — `FALLBACK_API_VERSION` (not named in WI; same contract — fallback when setting unset/empty; must match default)
+
+Line 219 of settingsService.ts is a JSDoc example (`'64.0'`) — cosmetic; update for consistency.
+
+## Phases
+
+### Phase 1 — bump all 3 version constants to 67.0
+Files:
+- `package.json` default `64.0` -> `67.0`
+- `sfdxProject.ts` `sourceApiVersion` `64.0` -> `67.0`
+- `settingsService.ts` `FALLBACK_API_VERSION` `64.0` -> `67.0`; JSDoc example -> `67.0`
+
+Commit: `chore(services): bump apiVersion + sourceApiVersion to 67.0 - W-23025928`
+
+## Skills to apply
+- packageJson — package.json edits
+- typescript — ts edits
+- verification
+
+## Verification
+- `grep -rn "64\.0" packages/salesforcedx-vscode-services/src packages/salesforcedx-vscode-services/package.json` -> no hits
+- compile/lint services pkg
+- no e2e coverage for these constants — manual grep is authoritative

--- a/packages/salesforcedx-vscode-services/package.json
+++ b/packages/salesforcedx-vscode-services/package.json
@@ -308,7 +308,7 @@
         },
         "salesforce-web-console.apiVersion": {
           "type": "string",
-          "default": "64.0",
+          "default": "67.0",
           "description": "%configuration.apiVersion.description%"
         },
         "salesforce-web-console.retrieveOnLoad": {

--- a/packages/salesforcedx-vscode-services/src/virtualFsProvider/templates/sfdxProject.ts
+++ b/packages/salesforcedx-vscode-services/src/virtualFsProvider/templates/sfdxProject.ts
@@ -15,6 +15,6 @@ export const sfdxProjectJson = [
   '	],',
   '	"namespace": "",',
   '	"sfdcLoginUrl": "https://login.salesforce.com",',
-  '	"sourceApiVersion": "64.0"',
+  '	"sourceApiVersion": "67.0"',
   '}'
 ];

--- a/packages/salesforcedx-vscode-services/src/vscode/settingsService.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/settingsService.ts
@@ -17,7 +17,7 @@ import {
 } from '../constants';
 import { unknownToErrorCause } from '../core/shared';
 
-const FALLBACK_API_VERSION = '64.0';
+const FALLBACK_API_VERSION = '67.0';
 
 export class SettingsError extends S.TaggedError<SettingsError>()('MissingSettingsError', {
   cause: S.Unknown,
@@ -216,7 +216,7 @@ export class SettingsService extends Effect.Service<SettingsService>()('Settings
       getInstanceUrl,
       /** Get the Salesforce access token from settings */
       getAccessToken,
-      /** Get the Salesforce API version from settings. In the form of '64.0' */
+      /** Get the Salesforce API version from settings. In the form of '67.0' */
       getApiVersion,
       /** Set the Salesforce instance URL in settings */
       setInstanceUrl,

--- a/packages/salesforcedx-vscode-services/test/jest/virtualFsProvider/sfdxProject.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/virtualFsProvider/sfdxProject.test.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { sfdxProjectJson } from '../../../src/virtualFsProvider/templates/sfdxProject';
+
+const API_VERSION = '67.0';
+
+const pkg = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../../package.json'), 'utf8'));
+
+describe('default API version constants stay in sync', () => {
+  it('sfdx-project.json template uses the expected sourceApiVersion', () => {
+    expect(sfdxProjectJson.join('\n')).toContain(`"sourceApiVersion": "${API_VERSION}"`);
+  });
+
+  it('package.json apiVersion setting defaults to the expected version', () => {
+    expect(pkg.contributes.configuration.properties['salesforce-web-console.apiVersion'].default).toBe(API_VERSION);
+  });
+});

--- a/packages/salesforcedx-vscode-services/test/jest/vscode/settingsService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/vscode/settingsService.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Effect from 'effect/Effect';
+import * as vscode from 'vscode';
+import { SettingsService } from '../../../src/vscode/settingsService';
+
+const FALLBACK_API_VERSION = '67.0';
+
+const mockGetConfiguration = (value: string | undefined): void => {
+  jest.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue({
+    get: () => value,
+    update: jest.fn()
+  } as unknown as vscode.WorkspaceConfiguration);
+};
+
+const runGetApiVersion = (): Promise<string> =>
+  Effect.runPromise(SettingsService.getApiVersion().pipe(Effect.provide(SettingsService.Default)));
+
+describe('SettingsService.getApiVersion', () => {
+  it('falls back to 67.0 when the setting is unset', async () => {
+    mockGetConfiguration(undefined);
+    expect(await runGetApiVersion()).toBe(FALLBACK_API_VERSION);
+  });
+
+  it('falls back to 67.0 when the setting is an empty string', async () => {
+    mockGetConfiguration('');
+    expect(await runGetApiVersion()).toBe(FALLBACK_API_VERSION);
+  });
+
+  it('returns the configured value when set', async () => {
+    mockGetConfiguration('63.0');
+    expect(await runGetApiVersion()).toBe('63.0');
+  });
+});


### PR DESCRIPTION
## Summary
- Bump API version from 64.0 to 67.0 in `salesforcedx-vscode-services`
- Update 3 constants: `salesforce-web-console.apiVersion` default, `sourceApiVersion` template, `FALLBACK_API_VERSION`
- Update JSDoc example for consistency

## Plan
[.claude/plans/W-23025928.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23025928-bump-services-ext-apiversion-sourceapive/.claude/plans/W-23025928.md)

## Test plan
- Run `grep -rn "64\.0" packages/salesforcedx-vscode-services/src packages/salesforcedx-vscode-services/package.json` to confirm no remaining 64.0 references

### What issues does this PR fix or reference?
@W-23025928@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cN05eYAC/view