### PR TITLE
fix(deps): bump picomatch to patched 2.3.2/4.0.4 - W-23034180

### DIFF
--- a/.claude/plans/W-23034180.md
+++ b/.claude/plans/W-23034180.md
@@ -2,13 +2,13 @@
 
 ## Context
 - Dependabot alert 280; CVE-2026-33672 medium; method injection in POSIX char classes.
-- Patched: `2.3.2`, `4.0.4` (both exist on registry; verified).
-- Lockfile-only bump. No package.json edit, no override. No runtime code change.
-- 7 install entries in `package-lock.json` (verified via grep of `node_modules/*picomatch` blocks):
+- Patched: `2.3.2`, `4.0.4` (both on registry)
+- Lockfile-only bump; no package.json/override/runtime changes
+- 7 install entries in `package-lock.json` (grep `node_modules/*picomatch`):
   - `2.3.1` x5: anymatch, jest-editor-support, jest-util, micromatch, readdirp (ranges `^2.0.4`/`^2.2.3`/`^2.3.1` all accept `2.3.2`).
-  - root `node_modules/picomatch` `4.0.3` (range `^4.0.2`/`^4.0.3` accept `4.0.4`).
-  - `npm/node_modules/tinyglobby/.../picomatch` already `4.0.4`, bundled — untouched, ignore.
-- Mutable vulnerable entries = 6 (5x `2.3.1`, 1x `4.0.3`); tinyglobby's `4.0.4` already patched.
+  - root `node_modules/picomatch` `4.0.3` (ranges `^4.0.2`/`^4.0.3` accept `4.0.4`)
+  - `npm/node_modules/tinyglobby/.../picomatch` already `4.0.4` (bundled) — ignore
+- Mutable vulnerable = 6 (5x `2.3.1`, 1x `4.0.3`); tinyglobby `4.0.4` patched
 - WI said 6 copies; actual = 7 entries, of which 6 are vulnerable+mutable (extra 2.3.1 in jest-editor-support; tinyglobby pre-patched 4.0.4).
 
 ## Phases
@@ -16,18 +16,18 @@
 ### Phase 1 — bump picomatch in lockfile
 - Run `npm update picomatch` (lockfile-only).
 - Confirm `package.json` unchanged (`git diff --quiet package.json`).
-- All 6 mutable entries re-resolve: 5x `2.3.1`→`2.3.2`, 1x `4.0.3`→`4.0.4`. tinyglobby `4.0.4` unchanged.
+- 6 mutable entries re-resolve: 5x `2.3.1`→`2.3.2`, 1x `4.0.3`→`4.0.4`; tinyglobby `4.0.4` unchanged
 - Commit msg: `fix(deps): bump picomatch to patched 2.3.2/4.0.4 - W-23034180`
 
 ## Skills to apply
-- concise — plan/doc style.
-- packageJson — confirm package.json deps untouched.
-- typescript — type checking.
+- concise — plan/doc style
+- packageJson — confirm package.json deps untouched
+- typescript — type checking
 
 ## Verification
-- `grep -A1 'node_modules/.*picomatch"' package-lock.json` — no `2.3.1` and no `4.0.3`; expect 5x `2.3.2`, 1x root `4.0.4`, 1x tinyglobby `4.0.4`.
-- `git diff --name-only` = `package-lock.json` only.
-- `npm ls picomatch` — no 2.3.1 / 4.0.3.
-- No e2e spec: lockfile-only change with no runtime code touched; coverage = CI `npm ci` + build succeeding. No spec exercises lockfile dependency resolution and none is needed.
-- CI install/build green.
-- Post-merge: dependabot alert 280 resolves.
+- `grep -A1 'node_modules/.*picomatch"' package-lock.json` — no `2.3.1`/`4.0.3`; expect 5x `2.3.2`, 1x root `4.0.4`, 1x tinyglobby `4.0.4`
+- `git diff --name-only` = `package-lock.json` only
+- `npm ls picomatch` — no `2.3.1`/`4.0.3`
+- No e2e spec: lockfile-only; no runtime code; coverage = CI `npm ci` + build. No spec exercises lockfile resolution; none needed
+- CI install/build green
+- Post-merge: dependabot alert 280 resolves

--- a/.claude/plans/W-23034180.md
+++ b/.claude/plans/W-23034180.md
@@ -1,0 +1,33 @@
+# W-23034180 — Fix picomatch glob-injection (GHSA-3v7f-55p6-f55p)
+
+## Context
+- Dependabot alert 280; CVE-2026-33672 medium; method injection in POSIX char classes.
+- Patched: `2.3.2`, `4.0.4` (both exist on registry; verified).
+- Lockfile-only bump. No package.json edit, no override. No runtime code change.
+- 7 install entries in `package-lock.json` (verified via grep of `node_modules/*picomatch` blocks):
+  - `2.3.1` x5: anymatch, jest-editor-support, jest-util, micromatch, readdirp (ranges `^2.0.4`/`^2.2.3`/`^2.3.1` all accept `2.3.2`).
+  - root `node_modules/picomatch` `4.0.3` (range `^4.0.2`/`^4.0.3` accept `4.0.4`).
+  - `npm/node_modules/tinyglobby/.../picomatch` already `4.0.4`, bundled — untouched, ignore.
+- Mutable vulnerable entries = 6 (5x `2.3.1`, 1x `4.0.3`); tinyglobby's `4.0.4` already patched.
+- WI said 6 copies; actual = 7 entries, of which 6 are vulnerable+mutable (extra 2.3.1 in jest-editor-support; tinyglobby pre-patched 4.0.4).
+
+## Phases
+
+### Phase 1 — bump picomatch in lockfile
+- Run `npm update picomatch` (lockfile-only).
+- Confirm `package.json` unchanged (`git diff --quiet package.json`).
+- All 6 mutable entries re-resolve: 5x `2.3.1`→`2.3.2`, 1x `4.0.3`→`4.0.4`. tinyglobby `4.0.4` unchanged.
+- Commit msg: `fix(deps): bump picomatch to patched 2.3.2/4.0.4 - W-23034180`
+
+## Skills to apply
+- concise — plan/doc style.
+- packageJson — confirm package.json deps untouched.
+- typescript — type checking.
+
+## Verification
+- `grep -A1 'node_modules/.*picomatch"' package-lock.json` — no `2.3.1` and no `4.0.3`; expect 5x `2.3.2`, 1x root `4.0.4`, 1x tinyglobby `4.0.4`.
+- `git diff --name-only` = `package-lock.json` only.
+- `npm ls picomatch` — no 2.3.1 / 4.0.3.
+- No e2e spec: lockfile-only change with no runtime code touched; coverage = CI `npm ci` + build succeeding. No spec exercises lockfile dependency resolution and none is needed.
+- CI install/build green.
+- Post-merge: dependabot alert 280 resolves.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12173,9 +12173,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -24229,9 +24229,9 @@
       }
     },
     "node_modules/jest-editor-support/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -25690,9 +25690,9 @@
       "license": "MIT"
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -27903,9 +27903,9 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -32203,9 +32203,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -37148,9 +37148,9 @@
       }
     },
     "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary
- Bump picomatch to patched versions 2.3.2/4.0.4 addressing GHSA-3v7f-55p6-f55p (CVE-2026-33672)
- Lockfile-only security fix; no package.json or runtime code changes
- 6 vulnerable entries updated: 5x 2.3.1→2.3.2, 1x 4.0.3→4.0.4

## Plan
[.claude/plans/W-23034180.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23034180-fix-picomatch-glob-injection-ghsa-3v7f-5/.claude/plans/W-23034180.md)

## Reviewer notes
- **Low:** Clean lockfile-only security bump. 6 picomatch install entries bumped to patched versions. Integrity hashes match npm registry; bundled tinyglobby/picomatch 4.0.4 correctly untouched; package.json unchanged; no runtime code modified. No defects found, no code change needed.

### What issues does this PR fix or reference?
@W-23034180@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cOdn3YAC/view