### PR TITLE
fix(apex-oas): bump spectral-core to 1.23.0 for minimatch ReDoS - W-23034164

### DIFF
--- a/.claude/plans/W-23034164.md
+++ b/.claude/plans/W-23034164.md
@@ -1,0 +1,40 @@
+# W-23034164 — Fix minimatch ReDoS (GHSA-7r86-cg39-jmmj)
+
+## Context
+
+- Dependabot alert 247: minimatch ReDoS (CVE-2026-27903, high)
+- Only vulnerable copy: `@stoplight/spectral-core@1.21.0` pins `minimatch 3.1.2` (needs >=3.1.3)
+- Confirmed in lock: single `minimatch 3.1.2` at `node_modules/@stoplight/spectral-core/node_modules/minimatch` (lock ~9410); all other minimatch 3.x = 3.1.5
+- Source pin: `packages/salesforcedx-vscode-apex-oas/package.json` dep `@stoplight/spectral-core: "1.21.0"`
+- 1.23.0 declares `minimatch ^3.1.4` → resolves 3.1.5
+
+## Phases
+
+### Phase 1 — bump spectral-core + reinstall
+
+- edit `packages/salesforcedx-vscode-apex-oas/package.json`: `@stoplight/spectral-core` `1.21.0` → `1.23.0`
+- check peer compat: `@stoplight/spectral-functions` 1.10.2, `@stoplight/spectral-rulesets` 1.22.0 declare `spectral-core ^1.19.x` — satisfied by 1.23.0
+- `npm install` (root) to regen `package-lock.json`
+- verify nested spectral-core minimatch now >=3.1.3; no `minimatch 3.1.2` remains
+- files: `packages/salesforcedx-vscode-apex-oas/package.json`, `package-lock.json`
+- commit: `fix(apex-oas): bump @stoplight/spectral-core to 1.23.0 for minimatch ReDoS GHSA-7r86-cg39-jmmj - W-23034164`
+
+## Skills to apply
+
+- typescript
+- packageJson — dep version rules
+- wireit — if scripts touched (not expected)
+- verification — verify approach
+
+## Verification
+
+- `grep -n 'minimatch-3' package-lock.json` → no 3.1.2; spectral-core nested copy >=3.1.5
+- `grep -n 'spectral-core' packages/salesforcedx-vscode-apex-oas/package.json` → 1.23.0
+- `npm ls @stoplight/spectral-core` → 1.23.0 resolved
+- build/compile apex-oas package — confirm no API break from minor bump (1.21→1.23)
+- spectral-core consumers in pkg: `src/oas/documentProcessorPipeline/ruleset.spectral.ts`, `src/oas/documentProcessorPipeline/oasValidationStep.ts`
+- run unit test exercising spectral validation (local, before PR):
+  - `cd packages/salesforcedx-vscode-apex-oas && npx jest test/jest/oas/documentProcessingPipeline/ruleset.spectral.test.ts`
+  - covers `ruleset.spectral.ts` (Spectral rules + Document parse via spectral-core) — confirms the bumped spectral-core still loads rulesets and validates
+- e2e (CI, not required locally): `packages/salesforcedx-vscode-apex-oas/test/playwright/specs/decomposedSimpleAccount.headless.spec.ts` exercises the full OAS generation pipeline including `oasValidationStep.ts` (the other spectral-core consumer); runs in CI on this branch, not gated locally
+- Dependabot alert 247 resolves post-merge (out-of-band, not local)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9360,9 +9360,9 @@
       }
     },
     "node_modules/@stoplight/spectral-core": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.21.0.tgz",
-      "integrity": "sha512-oj4e/FrDLUhBRocIW+lRMKlJ/q/rDZw61HkLbTFsdMd+f/FTkli2xHNB1YC6n1mrMKjjvy7XlUuFkC7XxtgbWw==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.23.0.tgz",
+      "integrity": "sha512-WvdgmiiJrjiMrcw7ByxfcYtUvAXNp2MhAfcEIXP3Mn8ZOVwyAWIsFjLlsE5zRqj0LuN8+7OQM/L+BMcHj6x/BQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/better-ajv-errors": "1.0.3",
@@ -9374,17 +9374,17 @@
         "@stoplight/types": "~13.6.0",
         "@types/es-aggregate-error": "^1.0.2",
         "@types/json-schema": "^7.0.11",
-        "ajv": "^8.17.1",
+        "ajv": "^8.18.0",
         "ajv-errors": "~3.0.0",
         "ajv-formats": "~2.1.1",
         "es-aggregate-error": "^1.0.7",
+        "expr-eval-fork": "^3.0.1",
         "jsonpath-plus": "^10.3.0",
-        "lodash": "~4.17.23",
+        "lodash": "^4.18.1",
         "lodash.topath": "^4.5.2",
-        "minimatch": "3.1.2",
+        "minimatch": "^3.1.4",
         "nimma": "0.2.3",
         "pony-cause": "^1.1.1",
-        "simple-eval": "1.0.1",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -9398,19 +9398,25 @@
       "license": "MIT"
     },
     "node_modules/@stoplight/spectral-core/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/@stoplight/spectral-core/node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/@stoplight/spectral-core/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -19469,6 +19475,15 @@
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/expr-eval-fork": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/expr-eval-fork/-/expr-eval-fork-3.0.3.tgz",
+      "integrity": "sha512-BhC+hbc5lIVjygr840n5DEkW3MQq7H9o+mc1/N7Z5uIiCFVyESLL5DIE7LNq4CYUNxy+XjA+3jRrL/h0Kt2xcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
     },
     "node_modules/exsolve": {
       "version": "1.0.8",
@@ -39057,18 +39072,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/simple-eval": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-eval/-/simple-eval-1.0.1.tgz",
-      "integrity": "sha512-LH7FpTAkeD+y5xQC4fzS+tFtaNlvt3Ib1zKzvhjv/Y+cioV4zIuw4IZr2yhRLu67CWL7FR9/6KXKnjRoZTvGGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "jsep": "^1.3.6"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/simple-get": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
@@ -44475,7 +44478,7 @@
         "@salesforce/effect-ext-utils": "*",
         "@salesforce/vscode-i18n": "*",
         "@salesforce/vscode-service-provider": "^1.5.0",
-        "@stoplight/spectral-core": "1.21.0",
+        "@stoplight/spectral-core": "1.23.0",
         "@stoplight/spectral-functions": "1.10.2",
         "@stoplight/spectral-rulesets": "1.22.0",
         "effect": "^3.21.2",

--- a/packages/salesforcedx-vscode-apex-oas/package.json
+++ b/packages/salesforcedx-vscode-apex-oas/package.json
@@ -33,7 +33,7 @@
     "@salesforce/vscode-i18n": "*",
     "effect": "^3.21.2",
     "@salesforce/vscode-service-provider": "^1.5.0",
-    "@stoplight/spectral-core": "1.21.0",
+    "@stoplight/spectral-core": "1.23.0",
     "@stoplight/spectral-functions": "1.10.2",
     "@stoplight/spectral-rulesets": "1.22.0",
     "ejs": "3.1.10",


### PR DESCRIPTION
## Summary

- Bump @stoplight/spectral-core from 1.21.0 to 1.23.0 to resolve transitive minimatch 3.1.2 vulnerability (CVE-2026-27903 / GHSA-7r86-cg39-jmmj ReDoS)
- Spectral-core 1.23.0 declares minimatch ^3.1.4, resolves to 3.1.5 (fix version >=3.1.3)
- No code changes required; peer dependencies (spectral-functions 1.10.2, spectral-rulesets 1.22.0) compatible with 1.23.0

## Plan

[.claude/plans/W-23034164.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23034164-fix-minimatch-redos-ghsa-7r86-cg39-jmmj/.claude/plans/W-23034164.md)

## Reviewer notes

- Security dependency bump verified: all minimatch 3.x copies in package-lock.json now 3.1.5; no 3.1.2 remains
- Peer/version compatibility confirmed: spectral-functions 1.10.2 and spectral-rulesets 1.22.0 both declare @stoplight/spectral-core ^1.19.4, satisfied by 1.23.0

## Test plan

- `grep -n 'minimatch-3' package-lock.json` confirms no 3.1.2; spectral-core nested copy >=3.1.5
- `npm ls @stoplight/spectral-core` confirms 1.23.0 resolved
- Run unit test: `cd packages/salesforcedx-vscode-apex-oas && npx jest test/jest/oas/documentProcessingPipeline/ruleset.spectral.test.ts` (covers spectral-core ruleset loading and validation)

## What issues does this PR fix or reference?

@W-23034164@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cOh3iYAC/view