### PR TITLE
chore(deps): bump handlebars 4.7.8 -> 4.7.9 to clear dependabot alerts - W-23037387

### DIFF
--- a/.claude/plans/W-23037387.md
+++ b/.claude/plans/W-23037387.md
@@ -1,0 +1,28 @@
+# W-23037387 — Fix handlebars vulns (4.7.8 → 4.7.9)
+
+## Context
+- Dependabot alerts 282,286,287,289,290,294,295 — handlebars 4.7.8 (1 critical, several high). All clear at 4.7.9.
+- handlebars = transitive dev dep; sole requirer `ts-jest` (`handlebars: ^4.7.8`), lockfile line ~41160.
+- 1 copy in lockfile (`node_modules/handlebars`, 4.7.8, line 20884). No direct dep in any package.json.
+- 4.7.9 within ^4.7.8 range → lockfile-only re-resolve. No package.json edit, no override.
+
+## Phases
+
+### Phase 1 — bump handlebars in lockfile
+- Run `npm update handlebars` (root). Re-resolves single copy 4.7.8 → 4.7.9.
+- Only `package-lock.json` changes (version + resolved + integrity).
+- File: `package-lock.json`
+- Commit: `chore(deps): bump handlebars 4.7.8 -> 4.7.9 to clear dependabot alerts - W-23037387`
+
+## Skills to apply
+- gha-dependabot — dependabot alert resolution pattern
+- packageJson — dep/lockfile conventions
+- typescript
+- verification
+
+## Verification
+- `grep -n '"node_modules/handlebars"' -A2 package-lock.json` → version 4.7.9.
+- No handlebars <4.7.9 anywhere: `grep -n '4.7.8' package-lock.json` shows no handlebars line.
+- `git diff --stat` → only package-lock.json touched.
+- `npm ls handlebars` → single 4.7.9, no errors.
+- Not e2e-covered (build-tooling dep; no runtime/e2e surface).

--- a/package-lock.json
+++ b/package-lock.json
@@ -20882,9 +20882,9 @@
       "license": "MIT"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Bump handlebars 4.7.8 → 4.7.9 to clear 7 dependabot alerts (1 critical, several high)
- Lockfile-only update via `npm update handlebars` (no package.json changes)
- Transitive dev dep via ts-jest; no runtime/e2e surface

## Plan
[.claude/plans/W-23037387.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23037387-fix-handlebars-vulns-4-7-8-4-7-9-via-npm/.claude/plans/W-23037387.md)

## Test plan
- Verify `grep -n '"node_modules/handlebars"' -A2 package-lock.json` shows version 4.7.9
- Confirm no handlebars <4.7.9 anywhere: `grep -n '4.7.8' package-lock.json` shows no handlebars line
- Confirm `git diff --stat` shows only package-lock.json touched
- Run `npm ls handlebars` to verify single 4.7.9, no errors

## What issues does this PR fix or reference?
@W-23037387@

🤖 Generated by auto-build pipeline. Original WI: https://gus.my.salesforce.com/a07EE00002cPEPm