### PR TITLE
fix(deps): npm update undici to clear cheerio-chain vulns - W-23037389

### DIFF
--- a/.claude/plans/W-23037389.md
+++ b/.claude/plans/W-23037389.md
@@ -1,0 +1,44 @@
+# W-23037389 — Fix undici vulns via npm update (cheerio chain)
+
+## Context
+
+- Dependabot alerts 261, 262, 265, 267: undici, transitive via cheerio. All four `manifest_path = package-lock.json`, all `state = open`.
+- Alerts span **two distinct undici chains** (verified via `gh api .../dependabot/alerts/<n>`):
+  - **7.x chain** — alerts 261 (GHSA-2mjp-6q6p-2qxm), 262 (GHSA-f269-vfmq-vjvj), 265 (GHSA-4992-7rv2-5pvq); range `>= 7.0.0, < 7.24.0`, first patched **7.24.0**. Source: `cheerio@1.2.0` (dev dep, via `@vscode/vsce`, `markdown-link-check`) declares `undici@^7.19.0`; lockfile resolves `node_modules/cheerio/node_modules/undici` = 7.22.0.
+  - **6.x chain** — alert 267 (GHSA-f269-vfmq-vjvj); range `>= 6.0.0, < 6.24.0`, first patched **6.24.0**. Source: `svgtofont@6.5.2` (devDep of `packages/salesforcedx-vscode-services`) -> `cheerio@1.0.0` -> `undici@6.23.0`.
+- Fix: lockfile-only, no override. `npm update undici` re-resolves **both** nested undici copies within their semver ranges (`^7.19.0` and `^6`), clearing all four alerts.
+- Out of scope (per WI): top-level `undici@5.29.0` (alerts 271/270/269/268/184) — pinned elsewhere, needs major bump/override, tracked separately.
+
+### Verified locally
+
+`npm update undici --package-lock-only` (node 24.16, npm 11.13):
+- `cheerio/node_modules/undici` 7.22.0 -> 7.27.2 (>= 7.24.0 -> clears 261, 262, 265)
+- `svgtofont/.../cheerio@1.0.0/node_modules/undici` 6.23.0 -> 6.26.0 (>= 6.24.0 -> clears 267; NOT incidental — directly tied to alert 267's `>= 6.0.0, < 6.24.0` range)
+- top-level `undici@5.29.0` **unchanged** (confirms scope note)
+- only file touched: `package-lock.json` (6 ins / 6 del)
+
+## Phases
+
+### Phase 1 — Bump nested undici (lockfile-only)
+
+- Run `npm update undici --package-lock-only`.
+- Only `package-lock.json` changes: nested undici 7.x (cheerio@1.2.0) **and** 6.x (svgtofont -> cheerio@1.0.0).
+- No `package.json` / override edits.
+- Files: `package-lock.json`
+- Commit: `fix(deps): npm update undici to clear cheerio-chain vulns - W-23037389`
+
+## Skills to apply
+
+- packageJson — dep/lockfile change conventions
+- gha-dependabot — confirm alert mapping/closure
+- verification
+- typescript
+
+## Verification
+
+- `git diff --stat` = only `package-lock.json`.
+- nested `cheerio@1.2.0/node_modules/undici` >= 7.24.0 (clears 261, 262, 265).
+- nested `svgtofont -> cheerio@1.0.0/.../undici` >= 6.24.0 (clears 267) — assert via `npm ls undici --all`.
+- top-level `undici@5.29.0` still present (out-of-scope, untouched).
+- `npm audit` / Dependabot: alerts 261, 262, 265, 267 cleared (CI/Dependabot-covered post-merge).
+- existing build/e2e on branch cover no regression from dev-dep bump.

--- a/.claude/plans/W-23037389.md
+++ b/.claude/plans/W-23037389.md
@@ -2,11 +2,11 @@
 
 ## Context
 
-- Dependabot alerts 261, 262, 265, 267: undici, transitive via cheerio. All four `manifest_path = package-lock.json`, all `state = open`.
+- Dependabot alerts 261, 262, 265, 267: undici, transitive via cheerio. All `manifest_path = package-lock.json`, `state = open`.
 - Alerts span **two distinct undici chains** (verified via `gh api .../dependabot/alerts/<n>`):
-  - **7.x chain** — alerts 261 (GHSA-2mjp-6q6p-2qxm), 262 (GHSA-f269-vfmq-vjvj), 265 (GHSA-4992-7rv2-5pvq); range `>= 7.0.0, < 7.24.0`, first patched **7.24.0**. Source: `cheerio@1.2.0` (dev dep, via `@vscode/vsce`, `markdown-link-check`) declares `undici@^7.19.0`; lockfile resolves `node_modules/cheerio/node_modules/undici` = 7.22.0.
+  - **7.x chain** — alerts 261 (GHSA-2mjp-6q6p-2qxm), 262 (GHSA-f269-vfmq-vjvj), 265 (GHSA-4992-7rv2-5pvq); range `>= 7.0.0, < 7.24.0`, first patched **7.24.0**. Source: `cheerio@1.2.0` (devDep via `@vscode/vsce`, `markdown-link-check`) declares `undici@^7.19.0`; lockfile resolves `node_modules/cheerio/node_modules/undici` = 7.22.0.
   - **6.x chain** — alert 267 (GHSA-f269-vfmq-vjvj); range `>= 6.0.0, < 6.24.0`, first patched **6.24.0**. Source: `svgtofont@6.5.2` (devDep of `packages/salesforcedx-vscode-services`) -> `cheerio@1.0.0` -> `undici@6.23.0`.
-- Fix: lockfile-only, no override. `npm update undici` re-resolves **both** nested undici copies within their semver ranges (`^7.19.0` and `^6`), clearing all four alerts.
+- Fix: lockfile-only. `npm update undici` re-resolves **both** nested undici copies within their semver ranges (`^7.19.0` and `^6`), clearing all four alerts.
 - Out of scope (per WI): top-level `undici@5.29.0` (alerts 271/270/269/268/184) — pinned elsewhere, needs major bump/override, tracked separately.
 
 ### Verified locally
@@ -23,7 +23,7 @@
 
 - Run `npm update undici --package-lock-only`.
 - Only `package-lock.json` changes: nested undici 7.x (cheerio@1.2.0) **and** 6.x (svgtofont -> cheerio@1.0.0).
-- No `package.json` / override edits.
+- No `package.json`/override edits.
 - Files: `package-lock.json`
 - Commit: `fix(deps): npm update undici to clear cheerio-chain vulns - W-23037389`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14842,9 +14842,9 @@
       }
     },
     "node_modules/cheerio/node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -40405,9 +40405,9 @@
       }
     },
     "node_modules/svgtofont/node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

- Bumps nested undici copies to patched versions (7.27.2, 6.26.0) via lockfile-only update
- Clears Dependabot alerts 261, 262, 265, 267 (cheerio transitive chains)
- No package.json edits; only lockfile touched

## Plan

[.claude/plans/W-23037389.md](.claude/plans/W-23037389.md)

### What issues does this PR fix or reference?

@W-23037389@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cP1RUYA0/view