### PR TITLE
fix(deps): update socks 2.8.7 -> 2.8.9 to clear ip-address vuln - W-23037391

### DIFF
--- a/.claude/plans/W-23037391.md
+++ b/.claude/plans/W-23037391.md
@@ -24,7 +24,7 @@ Fix: update `socks` to 2.8.9. socks@2.8.8+ declares `ip-address ^10.1.1` (verifi
 ### Phase 0 — prevent node-bin churn
 
 - Note current `node-bin-setup` / `node-bin-darwin-arm64` versions in `package-lock.json` before any update (capture exact `version`/`resolved`/`integrity` lines).
-- After Phase 1, restore them if removed (see Phase 1 cleanup). No package.json change for `node`.
+- After Phase 1, restore if removed. No `package.json` change for `node`.
 
 ### Phase 1 — update socks (re-resolves ip-address)
 
@@ -51,4 +51,4 @@ Fix: update `socks` to 2.8.9. socks@2.8.8+ declares `ip-address ^10.1.1` (verifi
 - `npm audit` → ip-address no longer listed.
 - `npm ci` clean (engine-strict, lockfile-version 3 integrity), then re-run `npm ls ip-address` → still 10.2.0 (confirms range now pins ≥ 10.1.1, not re-resolvable to 10.1.0).
 - Post-merge: Dependabot alert 311 clears (external, not locally verifiable).
-- Not e2e-covered (dependency/lockfile change; no runtime behavior).
+- Not e2e-covered (dep/lockfile change; no runtime behavior).

--- a/.claude/plans/W-23037391.md
+++ b/.claude/plans/W-23037391.md
@@ -1,0 +1,54 @@
+# W-23037391 — Fix ip-address vuln (10.1.0 → 10.2.0)
+
+## Context
+
+- Dependabot alert 311: `ip-address` 10.1.0, medium severity.
+- Lockfile state (verified):
+  - `node_modules/ip-address` = 10.1.0 (vulnerable) — pulled by root `socks` 2.8.7 (`ip-address ^10.0.1`).
+  - `node_modules/npm/node_modules/ip-address` = 10.2.0 (clean) — pulled by nested `socks` 2.8.9 (`^10.1.1`).
+- `socks` is transitive (not in package.json deps/devDeps). `node` is a devDep `^22.19.0`.
+- `.npmrc`: `save-exact=true`, `lockfile-version=3`, `engine-strict=true`.
+
+## Root-cause / correct fix
+
+`npm update ip-address` alone is WRONG. socks@2.8.7 declares `ip-address ^10.0.1`, which still permits 10.1.0 (verified: `npm info socks@2.8.7 dependencies` → `^10.0.1`). Bumping ip-address without bumping socks leaves the range unconstrained — a future `npm ci`/`npm install` can re-resolve back to 10.1.0.
+
+Fix: update `socks` to 2.8.9. socks@2.8.8+ declares `ip-address ^10.1.1` (verified: `npm info socks@2.8.8/2.8.9 dependencies` → `^10.1.1`), which excludes 10.1.0 and guarantees ip-address ≥ 10.1.1. Verified `npm update socks --dry-run` → `socks 2.8.7 => 2.8.9` AND `ip-address 10.1.0 => 10.2.0`.
+
+## Caveat: node-bin-* churn
+
+`npm update socks --dry-run` also lists `remove node-bin-darwin-arm64` / `remove node-bin-setup` — unrelated transient optional-binary churn from the `node` devDep. Must NOT land in the commit. Phase 0 pins these out to prevent the churn; Phase 1 verification asserts they are absent from the final diff.
+
+## Phases
+
+### Phase 0 — prevent node-bin churn
+
+- Note current `node-bin-setup` / `node-bin-darwin-arm64` versions in `package-lock.json` before any update (capture exact `version`/`resolved`/`integrity` lines).
+- After Phase 1, restore them if removed (see Phase 1 cleanup). No package.json change for `node`.
+
+### Phase 1 — update socks (re-resolves ip-address)
+
+- Run `npm update socks` in worktree root.
+- Inspect `git diff package-lock.json`: keep only socks 2.8.7→2.8.9 and ip-address 10.1.0→10.2.0 (+ integrity/resolved).
+- Revert any unrelated churn (node-bin-* removals, key ordering) via `git checkout -p` / manual restore from Phase 0 capture.
+- No `package.json` change. No `overrides`.
+- Commit msg: `fix(deps): update socks 2.8.7 -> 2.8.9 to clear ip-address vuln - W-23037391`
+
+## Skills to apply
+
+- `gha-dependabot` — dependabot-alert lockfile-fix workflow
+- `packageJson` — lockfile/dep conventions
+- `concise` — plan + any md
+- `typescript` — TypeScript conventions
+
+## Verification
+
+- `npm ls socks` → root socks at 2.8.9; no 2.8.7.
+- `npm ls ip-address` → single resolved copy at 10.2.0; no 10.1.0.
+- `node -e` over `package-lock.json`: 0 entries with `ip-address` version `10.1.0`; 0 entries with `socks` `2.8.7`.
+- `git diff package-lock.json | grep -E "node-bin-(setup|darwin-arm64)"` returns empty (no node-bin changes in commit).
+- `git diff package-lock.json` scoped to socks + ip-address only.
+- `npm audit` → ip-address no longer listed.
+- `npm ci` clean (engine-strict, lockfile-version 3 integrity), then re-run `npm ls ip-address` → still 10.2.0 (confirms range now pins ≥ 10.1.1, not re-resolvable to 10.1.0).
+- Post-merge: Dependabot alert 311 clears (external, not locally verifiable).
+- Not e2e-covered (dependency/lockfile change; no runtime behavior).

--- a/package-lock.json
+++ b/package-lock.json
@@ -22141,9 +22141,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -39376,12 +39376,12 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {


### PR DESCRIPTION
## Summary

- Updates socks from 2.8.7 to 2.8.9, which bumps its ip-address dependency range from ^10.0.1 to ^10.1.1, resolving Dependabot alert 311 (ip-address 10.1.0 medium severity)
- Prevents re-resolution of ip-address back to 10.1.0 by constraining socks' declared range

## Plan

[.claude/plans/W-23037391.md](.claude/plans/W-23037391.md)

## Test plan

- Verify npm ls socks shows 2.8.9 (no 2.8.7)
- Verify npm ls ip-address shows 10.2.0 (no 10.1.0)
- Verify package-lock.json has no 10.1.0 or 2.8.7 entries (node -e check)
- Verify git diff package-lock.json has no node-bin-* changes
- Verify npm audit no longer lists ip-address
- Verify npm ci clean run, then npm ls ip-address still 10.2.0 (confirms range constraint)

### What issues does this PR fix or reference?

@W-23037391@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cPEREYA4/view