### PR TITLE
feat: include Agentforce Vibes Autocomplete in both extension packs - W-23057893

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ You've caught us in the middle of a giant transition, so apologies for how confu
 
 This repo is owned by Extensions team (IDE Experience, aka IDE Foundations). You probably don't want your code here if you're building a new extension. You **might** want your code here if you're adding a feature that closely ties to something already here (ex: Apex or LWC).
 
-There are other extensions (code-analyzer, or the vibe coding extension) that live in other repos, then build/bundle/package/publish from their repo, and are included in one of our extension packs.
+There are other extensions (code-analyzer, the vibe coding extension, or vibes autocomplete) that live in other repos, then build/bundle/package/publish from their repo, and are included in one of our extension packs.
 
 Whether you intend to build a new extension, or a feature, or want to be included in the pack, it's worth talking to us in advance.
 

--- a/docs/architecture/ExtensionPacks.md
+++ b/docs/architecture/ExtensionPacks.md
@@ -7,7 +7,8 @@ There are two extensions in this repo that are extension packs. These allow cust
 the extensions from this repo plus
 
 - code analyzer
-- the vibe coding extension
+- the vibe coding extension (Agentforce Vibes)
+- vibes autocomplete
 
 ## packages/salesforcedx-vscode-expanded
 

--- a/packages/salesforcedx-vscode-expanded/README.md
+++ b/packages/salesforcedx-vscode-expanded/README.md
@@ -73,6 +73,8 @@ The Salesforce Extension Pack (Expanded) installs these Salesforce-developed ext
   This extension (`salesforce-vscode-slds`) simplifies working with the Salesforce Lightning Design System (SLDS). It provides code completion, syntax highlighting, and validation with recommended tokens and utility classes.
 - [Agentforce Vibes](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-einstein-gpt)
   This extension (`salesforcedx-einstein-gpt`) uses generative AI to make Salesforce development in Visual Studio Code richer with features such as a Dev Assistant that helps with writing, documenting, and understanding code. It also provides inline autocompletion, and test case generation for Apex and LWC code.
+- [Agentforce Vibes Autocomplete](https://marketplace.visualstudio.com/items?itemName=salesforce.agentforce-vibes-autocomplete)
+  This extension (`agentforce-vibes-autocomplete`) uses generative AI to provide inline code autocompletion for Salesforce development in Visual Studio Code.
 - [Salesforce Code Analyzer](https://marketplace.visualstudio.com/items?itemName=salesforce.sfdx-code-analyzer-vscode)
   This extension (`sfdx-code-analyzer-vscode`) scans your code using multiple rule engines to produce lists of violations that you can use to improve your code. v5 also includes all the functionality of the ESLint and Apex PMD extensions. Now, the Salesforce Code Analyzer extension statically analyzes both your Apex and JavaScript code to quickly find problems.
 - [Salesforce Live Preview](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-ui-preview)

--- a/packages/salesforcedx-vscode-expanded/package.json
+++ b/packages/salesforcedx-vscode-expanded/package.json
@@ -53,6 +53,7 @@
     "salesforce.salesforcedx-vscode-apex-oas",
     "salesforce.salesforcedx-vscode-apex-replay-debugger",
     "salesforce.salesforcedx-einstein-gpt",
+    "salesforce.agentforce-vibes-autocomplete",
     "salesforce.salesforcedx-vscode-core",
     "salesforce.salesforcedx-vscode-lightning",
     "salesforce.salesforcedx-vscode-org",

--- a/packages/salesforcedx-vscode/README.md
+++ b/packages/salesforcedx-vscode/README.md
@@ -74,6 +74,8 @@ The Salesforce Extension Pack installs these extensions.
   This extension (`salesforce-vscode-slds`) simplifies working with the Salesforce Lightning Design System (SLDS). It provides code completion, syntax highlighting, and validation with recommended tokens and utility classes.
 - [Agentforce Vibes](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-einstein-gpt)
   This extension (`salesforcedx-einstein-gpt`) uses generative AI to make Salesforce development in Visual Studio Code richer with features such as a Dev Assistant that helps with writing, documenting, and understanding code. It also provides inline autocompletion, and test case generation for Apex and LWC code.
+- [Agentforce Vibes Autocomplete](https://marketplace.visualstudio.com/items?itemName=salesforce.agentforce-vibes-autocomplete)
+  This extension (`agentforce-vibes-autocomplete`) uses generative AI to provide inline code autocompletion for Salesforce development in Visual Studio Code.
 - [Salesforce Code Analyzer](https://marketplace.visualstudio.com/items?itemName=salesforce.sfdx-code-analyzer-vscode)
   This extension (`sfdx-code-analyzer-vscode`) scans your code using multiple rule engines to produce lists of violations that you can use to improve your code. v5 also includes all the functionality of the ESLint and Apex PMD extensions. Now, the Salesforce Code Analyzer extension statically analyzes both your Apex and JavaScript code to quickly find problems.
 - [Salesforce Apex Language Server (Typescript)](https://marketplace.visualstudio.com/items?itemName=salesforce.apex-language-server-extension)

--- a/packages/salesforcedx-vscode/package.json
+++ b/packages/salesforcedx-vscode/package.json
@@ -53,6 +53,7 @@
     "salesforce.salesforcedx-vscode-apex-log",
     "salesforce.salesforcedx-vscode-apex-replay-debugger",
     "salesforce.salesforcedx-einstein-gpt",
+    "salesforce.agentforce-vibes-autocomplete",
     "salesforce.salesforcedx-vscode-core",
     "salesforce.salesforcedx-vscode-lightning",
     "salesforce.salesforcedx-vscode-org",


### PR DESCRIPTION
## What & Why

Includes the **Agentforce Vibes Autocomplete** extension (`salesforce.agentforce-vibes-autocomplete`) in both the standard Salesforce Extension Pack and the Expanded Extension Pack, so users can install it from either pack.

@W-23057893@

## Changes

- Added `salesforce.agentforce-vibes-autocomplete` to the `extensionPack` array in:
  - `packages/salesforcedx-vscode/package.json`
  - `packages/salesforcedx-vscode-expanded/package.json`
- Added matching "Included Extensions" entries to both packs' `README.md`.
- Updated `docs/README.md` and `docs/architecture/ExtensionPacks.md` to mention vibes autocomplete.

## Testing

- Validated both `package.json` files parse as valid JSON.
