### PR TITLE
docs: add work-item-sequencing skill for numbered epic planning - W-23067782

### DIFF
--- a/.claude/skills/gus-cli/SKILL.md
+++ b/.claude/skills/gus-cli/SKILL.md
@@ -85,6 +85,8 @@ Closed statuses: see ## Status\_\_c values. Use `LIMIT 50` (or 100) when queryin
 
 **Create:** Always set `Story_Points__c=2`, `Product_Tag__c=a1aB000000005G3IAI`, `RecordTypeId`. Include `Subject__c`, `Assignee__c`, `Scrum_Team__c=a00B0000000w9xPIAQ`, `Epic__c` (optional), `QA_Engineer__c` (optional), `Details__c` (optional). Leave `Sprint__c` blank; never modify it. **Details\_\_c:** write concisely—fragments/bullets, minimal words, no repetition (see .claude/skills/concise/SKILL.md).
 
+**Sequencing prefix:** When planning an epic or when the user states a dependency between work items, prefix `Subject__c` with a sequence number + space (e.g. `1.2 Add config loader`). See [work-item-sequencing](../work-item-sequencing/SKILL.md). Optional—skip for independent work.
+
 **`-v` + `--flags-dir` don't combine on create:** `-v` takes precedence; flags-dir values are dropped. Workaround: create without Details, then update with `--flags-dir` only.
 
 **Details\_\_c formatting (readable WI body):** Details\_\_c is a Rich Text Area (extraTypeInfo: richtextarea)—use HTML, not markdown. The `-v` flag parses space-separated key=value; use `--flags-dir` with a `values` file ([ref](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_flag_values_in_files.htm)):
@@ -173,6 +175,7 @@ When unsure which epic: ask the user.
 2. Query: `Epic__c = '<epicId>' AND Status__c NOT IN (...)` — use all values from ## Status\_\_c values "Closed (terminal)" and "Bug no-fix"
 3. Add `LIMIT 100`; order by Status\_\_c or Name
 4. Present as table: Name, Subject**c, Status**c, Assignee (or run separate query for assignee names)
+5. If any `Subject__c` carries a sequence-number prefix (`1`, `1.2`, …), compute ready/blocked per [work-item-sequencing](../work-item-sequencing/SKILL.md) instead of a flat list. "What's ready / unblocked in this epic?" routes there.
 
 ## Status\_\_c values
 

--- a/.claude/skills/work-item-sequencing/SKILL.md
+++ b/.claude/skills/work-item-sequencing/SKILL.md
@@ -5,13 +5,13 @@ description: Numbering convention for ordering GUS work items within an epic. Nu
 
 # Work Item Sequencing
 
-A numbering convention for expressing **order and parallelism** among work items inside a single epic. Numbers live as a prefix in `Subject__c` (space-delimited). Scope is per-epic; cross-epic dependencies are explained in the WI body prose, not encoded in numbers.
+Numbering convention for **order + parallelism** among work items in one epic. Number = prefix in `Subject__c`, space-delimited. Per-epic scope; cross-epic deps go in WI body prose, not numbers.
 
-This is a companion to [gus-cli](../gus-cli/SKILL.md), which owns the CLI mechanics (querying, creating, updating, statuses, IDs).
+Companion to [gus-cli](../gus-cli/SKILL.md) (CLI mechanics: query, create, update, statuses, IDs).
 
-## The convention
+## Convention
 
-Prefix the `Subject__c` with a dotted number and a single space:
+Prefix `Subject__c` with a dotted number + single space:
 
 ```
 1 Set up the runtime service
@@ -20,67 +20,54 @@ Prefix the `Subject__c` with a dotted number and a single space:
 1.2 Add config loader
 ```
 
-- **Sequential** — `1`, `2`, `3`: do in order. `2` does not start until `1` is done. `3` does not start until `2` is done.
-- **Parallel** — `1.1`, `1.2`, `1.3`: siblings sharing a parent prefix can all be worked at once, no waiting on each other.
-- **Gating between groups** — the next number at a level waits for **all** work under the prior numbers at that level. `2` does not start until `1` *and* every `1.x` (and `1.x.y`, …) are done.
-- **Arbitrary depth** — `1.1.1`, `1.1.2` nest the same way. One recursive rule (below) covers every level.
+- **Sequential** (`1`, `2`, `3`): in order. `2` waits on `1`; `3` waits on `2`.
+- **Parallel** (`1.1`, `1.2`): same-parent siblings, no waiting on each other.
+- **Group gating**: next number at a level waits for **all** work under prior numbers. `2` waits on `1` + every `1.x`/`1.x.y`.
+- **Arbitrary depth** (`1.1.1`, …): same recursive rule.
 
-### The one rule
+### The rule
 
-> A work item is **ready** when every work item that sorts before it at a shallower-or-equal ancestor level is done. Equivalently: siblings run in parallel; a sibling-group gates the next number at its parent level.
+> WI ready when every WI sorting before it (at shallower-or-equal ancestor level) is done. Siblings parallel; sibling-group gates next number at parent level.
 
-Walk it: `1.2` is ready once `1.1` and all of `1.1`'s descendants are done. `2` is ready once everything under `1` (`1`, `1.1`, `1.1.1`, `1.2`, …) is done.
+`1.2` ready once `1.1` + descendants done. `2` ready once everything under `1` done.
 
-### "Done"
+### Done
 
 Done = `Status__c` is **`Closed`** or **`Completed`**.
 
-`Fixed` is **not** done — Fixed usually means the PR is not merged yet. Do not treat Fixed, Ready for Review, QA In Progress, or any non-terminal status as satisfying a prerequisite.
+**`Fixed` is not done** — usually means PR not merged yet. Non-terminal statuses (Fixed, Ready for Review, QA In Progress) never satisfy a prerequisite. See [gus-cli ## Status\_\_c values](../gus-cli/SKILL.md#status__c-values).
 
-(See [gus-cli ## Status\_\_c values](../gus-cli/SKILL.md#status__c-values).)
+## When to number
 
-## When to use numbers
+Optional.
 
-Numbers are **optional**.
+- **Use**: epic-level planning, or when user states a dependency.
+- **Skip**: standalone work; don't renumber an epic of accumulated independent items.
 
-- **Use them** during epic-level planning, or whenever the user expresses a dependency between work items.
-- **Skip them** for standalone work. An epic that has accumulated independent work items over time does not need renumbering.
+**Unnumbered = no deps, nothing depends on it.** Always ready; never gates, never gated. Don't infer order from date/position — no number means independent.
 
-### Unnumbered work items
+## Assigning (planning)
 
-A work item with no numeric prefix has **no dependencies and nothing depends on it**. It is always ready. It never gates a numbered item and is never gated by one. Do not infer order from creation date, position, or anything else — absence of a number means independent.
+1. Lay out work items.
+2. Must-precede → sequential top-level (`1`, `2`).
+3. Parallel under a step → same parent, distinct suffix (`1.1`, `1.2`).
+4. Independent → leave unnumbered.
+5. Prefix `Subject__c` with number + space. Create via [gus-cli](../gus-cli/SKILL.md#work-items-adm_work__c).
 
-## Assigning numbers (during planning)
+Dense from 1 per group preferred; gaps harmless (sort is by value).
 
-When planning an epic with the user:
+## Reading ("what's ready/unblocked in this epic?")
 
-1. Lay out the work items.
-2. For any that must precede others, assign sequential top-level numbers (`1`, `2`, …).
-3. For work that can proceed in parallel under a step, give them the same parent with distinct child suffixes (`1.1`, `1.2`).
-4. Leave genuinely independent items unnumbered.
-5. Prefix each `Subject__c` with its number + a space. Create via [gus-cli](../gus-cli/SKILL.md#work-items-adm_work__c).
+1. Query epic WIs incl `Status__c`. Query **without** open-only filter — done prerequisites are Closed, which open-only excludes (see [gus-cli "What's unfinished in this epic"](../gus-cli/SKILL.md#compound-workflows)).
+2. Parse leading dotted number from each `Subject__c`. None → unnumbered.
+3. Readiness: unnumbered → ready; numbered → ready iff all prior-sorting ancestors done.
+4. Report 3 groups: **Ready now** (unblocked numbered + all unnumbered), **Blocked** (name blocking number), **Done** (optional).
 
-Keep numbers dense and starting at 1 within a group where practical, but gaps are harmless — sorting is by dotted-numeric value.
-
-## Reading a plan ("what's ready / what's unblocked in this epic?")
-
-1. Query the epic's open work items (see [gus-cli "What's unfinished in this epic"](../gus-cli/SKILL.md#compound-workflows)). Also include `Status__c` so done-ness can be computed. To know whether a prerequisite is done, query the epic's WIs **without** the open-only filter (a Closed prerequisite is excluded by the open-only query).
-2. Parse the leading dotted number from each `Subject__c`. No leading number → unnumbered (independent).
-3. Compute readiness with the one rule:
-   - Unnumbered → **ready**.
-   - Numbered → ready iff every WI that sorts before it at a shallower-or-equal ancestor level is done (`Closed`/`Completed`).
-4. Report three groups:
-   - **Ready now** — unblocked numbered items + all unnumbered items.
-   - **Blocked** — numbered items whose prerequisites are not all done; name the blocking number(s).
-   - **Done** — `Closed`/`Completed` (optional, for context).
-
-### Sorting
-
-Sort by dotted-numeric segments, comparing each segment as an integer (`1.2` before `1.10`), not lexically. Unnumbered items sort last (or list them separately).
+Sort by integer segments (`1.2` before `1.10`, not lexical). Unnumbered sort last.
 
 ## Edge cases
 
-- **Malformed prefix** (e.g. `1.` , `1..2`, `1.x`): treat as unnumbered and **flag it** to the user — likely a typo that meant to express a dependency.
-- **Duplicate numbers** (two WIs both `1.2`): allowed — they're parallel siblings, same as any sibling pair. No need to flag.
-- **Orphan child** (`1.1` exists but no `1`): the rule still works — `1.1` is gated only by anything sorting before it. Don't require a parent WI to exist.
-- **Number in `Subject__c` that isn't a sequence** (e.g. `W-12345 backport` or a version like `2.40 release`): only treat a leading `N` or `N.N…` followed by a space as a sequence number. When ambiguous, ask.
+- **Malformed** (`1.`, `1..2`, `1.x`): treat unnumbered + **flag** — likely typo'd dependency.
+- **Duplicate** (two `1.2`): allowed = parallel siblings. Don't flag.
+- **Orphan child** (`1.1`, no `1`): rule still holds; don't require parent to exist.
+- **Non-sequence number** (`W-12345 backport`, version `2.40 release`): only leading `N`/`N.N…` + space counts. Ambiguous → ask.

--- a/.claude/skills/work-item-sequencing/SKILL.md
+++ b/.claude/skills/work-item-sequencing/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: work-item-sequencing
+description: Numbering convention for ordering GUS work items within an epic. Numeric prefixes in Subject__c express sequencing (do X before Y) and parallelism. Use when planning an epic, when the user states a dependency between work items, or when asked what's unblocked/ready in an epic.
+---
+
+# Work Item Sequencing
+
+A numbering convention for expressing **order and parallelism** among work items inside a single epic. Numbers live as a prefix in `Subject__c` (space-delimited). Scope is per-epic; cross-epic dependencies are explained in the WI body prose, not encoded in numbers.
+
+This is a companion to [gus-cli](../gus-cli/SKILL.md), which owns the CLI mechanics (querying, creating, updating, statuses, IDs).
+
+## The convention
+
+Prefix the `Subject__c` with a dotted number and a single space:
+
+```
+1 Set up the runtime service
+2 Migrate the parser to the runtime
+1.1 Add config schema
+1.2 Add config loader
+```
+
+- **Sequential** — `1`, `2`, `3`: do in order. `2` does not start until `1` is done. `3` does not start until `2` is done.
+- **Parallel** — `1.1`, `1.2`, `1.3`: siblings sharing a parent prefix can all be worked at once, no waiting on each other.
+- **Gating between groups** — the next number at a level waits for **all** work under the prior numbers at that level. `2` does not start until `1` *and* every `1.x` (and `1.x.y`, …) are done.
+- **Arbitrary depth** — `1.1.1`, `1.1.2` nest the same way. One recursive rule (below) covers every level.
+
+### The one rule
+
+> A work item is **ready** when every work item that sorts before it at a shallower-or-equal ancestor level is done. Equivalently: siblings run in parallel; a sibling-group gates the next number at its parent level.
+
+Walk it: `1.2` is ready once `1.1` and all of `1.1`'s descendants are done. `2` is ready once everything under `1` (`1`, `1.1`, `1.1.1`, `1.2`, …) is done.
+
+### "Done"
+
+Done = `Status__c` is **`Closed`** or **`Completed`**.
+
+`Fixed` is **not** done — Fixed usually means the PR is not merged yet. Do not treat Fixed, Ready for Review, QA In Progress, or any non-terminal status as satisfying a prerequisite.
+
+(See [gus-cli ## Status\_\_c values](../gus-cli/SKILL.md#status__c-values).)
+
+## When to use numbers
+
+Numbers are **optional**.
+
+- **Use them** during epic-level planning, or whenever the user expresses a dependency between work items.
+- **Skip them** for standalone work. An epic that has accumulated independent work items over time does not need renumbering.
+
+### Unnumbered work items
+
+A work item with no numeric prefix has **no dependencies and nothing depends on it**. It is always ready. It never gates a numbered item and is never gated by one. Do not infer order from creation date, position, or anything else — absence of a number means independent.
+
+## Assigning numbers (during planning)
+
+When planning an epic with the user:
+
+1. Lay out the work items.
+2. For any that must precede others, assign sequential top-level numbers (`1`, `2`, …).
+3. For work that can proceed in parallel under a step, give them the same parent with distinct child suffixes (`1.1`, `1.2`).
+4. Leave genuinely independent items unnumbered.
+5. Prefix each `Subject__c` with its number + a space. Create via [gus-cli](../gus-cli/SKILL.md#work-items-adm_work__c).
+
+Keep numbers dense and starting at 1 within a group where practical, but gaps are harmless — sorting is by dotted-numeric value.
+
+## Reading a plan ("what's ready / what's unblocked in this epic?")
+
+1. Query the epic's open work items (see [gus-cli "What's unfinished in this epic"](../gus-cli/SKILL.md#compound-workflows)). Also include `Status__c` so done-ness can be computed. To know whether a prerequisite is done, query the epic's WIs **without** the open-only filter (a Closed prerequisite is excluded by the open-only query).
+2. Parse the leading dotted number from each `Subject__c`. No leading number → unnumbered (independent).
+3. Compute readiness with the one rule:
+   - Unnumbered → **ready**.
+   - Numbered → ready iff every WI that sorts before it at a shallower-or-equal ancestor level is done (`Closed`/`Completed`).
+4. Report three groups:
+   - **Ready now** — unblocked numbered items + all unnumbered items.
+   - **Blocked** — numbered items whose prerequisites are not all done; name the blocking number(s).
+   - **Done** — `Closed`/`Completed` (optional, for context).
+
+### Sorting
+
+Sort by dotted-numeric segments, comparing each segment as an integer (`1.2` before `1.10`), not lexically. Unnumbered items sort last (or list them separately).
+
+## Edge cases
+
+- **Malformed prefix** (e.g. `1.` , `1..2`, `1.x`): treat as unnumbered and **flag it** to the user — likely a typo that meant to express a dependency.
+- **Duplicate numbers** (two WIs both `1.2`): allowed — they're parallel siblings, same as any sibling pair. No need to flag.
+- **Orphan child** (`1.1` exists but no `1`): the rule still works — `1.1` is gated only by anything sorting before it. Don't require a parent WI to exist.
+- **Number in `Subject__c` that isn't a sequence** (e.g. `W-12345 backport` or a version like `2.40 release`): only treat a leading `N` or `N.N…` followed by a space as a sequence number. When ambiguous, ask.


### PR DESCRIPTION
### What does this PR do?

Adds a `work-item-sequencing` Claude skill documenting a numbering convention for ordering GUS work items within an epic.

- Numeric `Subject__c` prefixes express order + parallelism (e.g. `1`, `2`, `1.1`, `1.2`)
- Sequential top-level numbers gate each other; same-parent children run in parallel; arbitrary depth via one recursive rule
- Done = `Closed`/`Completed` (not `Fixed`)
- Unnumbered = independent (no deps, nothing depends on it)
- Wired into `gus-cli` create + epic-query workflows via pointers

### What issues does this PR fix or reference?
@W-23067782@
