### PR TITLE
fix(agents): use valid model id in playwright-e2e-monitor - W-23069757

### DIFF
--- a/.claude/agents/playwright-e2e-monitor.md
+++ b/.claude/agents/playwright-e2e-monitor.md
@@ -1,7 +1,7 @@
 ---
 name: playwright-e2e-monitor
 description: Monitor and analyze Playwright E2E test results from GitHub Actions. Use when users ask for playwright analysis on github actions or /analyze-e2e
-model: fast
+model: haiku
 ---
 
 Monitor running e2e playwright tests, download artifacts on failure, provide analysis.

--- a/.claude/plans/W-23069757.md
+++ b/.claude/plans/W-23069757.md
@@ -1,0 +1,26 @@
+# W-23069757 — Fix invalid model `fast` in playwright-e2e-monitor
+
+## Context
+
+- `.claude/agents/playwright-e2e-monitor.md:4` → `model: fast`
+- API rejects: `400 Invalid model name passed in model=fast`
+- Agent dies, 0 tool uses
+- Valid ids: opus/sonnet/haiku (or omit line → inherit session model)
+- Peer agents: gha-rerun.md, doc-maintenance.md = `haiku`; others = `sonnet`
+- Task = mechanical CI watch/download → `haiku` (matches gha-rerun)
+
+## Phases
+
+### Phase 1 — Set valid model id
+- Edit `.claude/agents/playwright-e2e-monitor.md` line 4: `model: fast` → `model: haiku`
+- Files: `.claude/agents/playwright-e2e-monitor.md`
+- Commit: `fix(agents): use valid model id in playwright-e2e-monitor frontmatter - W-23069757`
+
+## Skills to apply
+- typescript
+- concise (md edit)
+
+## Verification
+- `grep -n "^model:" .claude/agents/playwright-e2e-monitor.md` → `haiku`
+- no other agent frontmatter uses `model: fast` (grep clean)
+- not e2e-covered: agent frontmatter not exercised by branch e2e tests; verify manually via grep

--- a/.claude/plans/W-23069757.md
+++ b/.claude/plans/W-23069757.md
@@ -11,7 +11,7 @@
 
 ## Phases
 
-### Phase 1 — Set valid model id
+### Phase 1 — Set valid model
 - Edit `.claude/agents/playwright-e2e-monitor.md` line 4: `model: fast` → `model: haiku`
 - Files: `.claude/agents/playwright-e2e-monitor.md`
 - Commit: `fix(agents): use valid model id in playwright-e2e-monitor frontmatter - W-23069757`
@@ -23,4 +23,4 @@
 ## Verification
 - `grep -n "^model:" .claude/agents/playwright-e2e-monitor.md` → `haiku`
 - no other agent frontmatter uses `model: fast` (grep clean)
-- not e2e-covered: agent frontmatter not exercised by branch e2e tests; verify manually via grep
+- not e2e-covered: agent frontmatter untested; verify via grep


### PR DESCRIPTION
## Summary
- `.claude/agents/playwright-e2e-monitor.md` used invalid `model: fast` → 400 API error
- Changed to `model: haiku` (matches peer CI-watch agents like gha-rerun)

## Plan
[.claude/plans/W-23069757.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23069757-fix-invalid-model-fast-in-playwright-e2e/.claude/plans/W-23069757.md)

## Test plan
- `grep -n "^model:" .claude/agents/playwright-e2e-monitor.md` confirms `haiku`
- No other agent frontmatter uses `model: fast` (grep clean)

### What issues does this PR fix or reference?
@W-23069757@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cXJ53YAG/view