### PR TITLE
refactor(services): simpleExec object param w/ Duration timeout - W-23072534

### DIFF
--- a/.claude/plans/W-23072534.md
+++ b/.claude/plans/W-23072534.md
@@ -1,0 +1,73 @@
+# W-23072534 — TerminalService.simpleExec object param + Duration timeout
+
+## Context
+- `simpleExec(command, parse?, timeoutMs?)` → positional. Replace w/ single options object.
+- New sig: `simpleExec({ command, parse?, timeout? })`; `timeout: Duration.DurationInput`, default `Duration.millis(30_000)`; internally `Duration.toMillis`.
+- Callers: orgDelete.ts (timeout 120s), projectInfo.ts (command-only x2).
+- Test: orgDelete.test.ts assertions on positional args (lines 58, 67, 75-79).
+- Duration import convention: `import * as Duration from 'effect/Duration'`.
+
+## External-consumers (blast radius)
+`TerminalService` is on the public `SalesforceVSCodeServicesApi` surface (index.ts:142, `export type` at index.ts:479). Changing `simpleExec`'s signature is a breaking API change for external callers. Checked:
+- monorepo grep `simpleExec`: only callers are orgDelete.ts, projectInfo.ts, orgDelete.test.ts (all in-repo).
+- `gh` search `simpleExec org:forcedotcom` + `org:salesforcecli`: only this monorepo + its mirror repos (salesforcedx-vscode-ci-testing, vibes-poc) + `code-analyzer-core` `simpleExecutor` (unrelated class property, not TerminalService).
+- No external consumer calls `TerminalService.simpleExec`.
+
+**Decision:** breaking change is safe — no external consumer. No compatibility overload needed. Re-run the external-consumers check at build time (`gh` search may have new hits) before committing; if a new consumer appears, add an object/positional overload or document the break.
+
+## Phases
+
+### Phase 1 — source signature + non-test callers
+Change source only; do NOT touch the test yet (so tsc/jest break loudly on the stale positional mock assertions, proving the test catches the new shape).
+
+**Files:**
+- `packages/salesforcedx-vscode-services/src/terminal/terminalService.ts`
+  - sig → `simpleExec: ({ command, parse = s => s, timeout = Duration.millis(30_000) }: { command: string; parse?: (stdout: string) => string; timeout?: Duration.DurationInput })`
+  - `exec(command, { timeout: Duration.toMillis(timeout) })`
+  - add `import * as Duration from 'effect/Duration'`; update jsdoc (`timeout` not `timeoutMs`)
+- `packages/salesforcedx-vscode-org/src/commands/orgDelete.ts`
+  - `DELETE_TIMEOUT_MS = 120_000` → `DELETE_TIMEOUT = Duration.seconds(120)`; update comment (line 140)
+  - call (line 173) → `simpleExec({ command: \`sf ${deleteSubcommand}${targetOrgFlag} --no-prompt\`, parse: identity, timeout: DELETE_TIMEOUT })`
+  - add Duration import
+- `packages/salesforcedx-vscode-metadata/src/commands/projectInfo.ts`
+  - `simpleExec({ command: 'sf --version' })`, `simpleExec({ command: 'java --version' })` (lines 149-150)
+
+**Gate:** `tsc` org+services+metadata compile must PASS (source consistent). Run jest orgDelete.test.ts and confirm it FAILS on the stale positional `toHaveBeenCalledWith` — this proves the assertions are load-bearing and not false-green. Note: positional mock-arg assertions are JS-level, not type-checked, so tsc alone won't flag them; the jest run is the guard.
+
+### Phase 2 — test assertions to object shape
+**Files:**
+- `packages/salesforcedx-vscode-org/test/jest/commands/orgDelete.test.ts`
+  - 3 `toHaveBeenCalledWith` (lines 58, 67, 75-79) → single object arg: `{ command: '...', parse: expect.any(Function), timeout: Duration.seconds(120) }`
+  - add `import * as Duration from 'effect/Duration'`
+  - `Duration.seconds(120)` is a structural value; jest deep-equality matches it. Verify the assertion fails if `timeout` is omitted/wrong (sanity: the Phase-1 red proves lock-step).
+
+**Gate:** jest orgDelete.test.ts now PASSES against new shape.
+
+**Commit (after both phases):** `refactor(services): simpleExec object param w/ Duration timeout - W-23072534`
+
+## Skills
+- external-consumers (public API surface — breaking change blast radius)
+- effect-best-practices (Duration usage)
+- services-extension-consumption (API surface change consumed by org/metadata)
+- typescript
+- playwright-e2e (projectInfo spec exercises the changed path)
+- concise
+- verification
+
+## Verification
+- `simpleExec` grep: no remaining positional callers
+- compile: services, org, metadata packages
+- jest: orgDelete.test.ts (object-shape assertions; `Duration.seconds(120)` deep-equality)
+- lint changed files
+- re-run external-consumers `gh` search before commit (no new external caller)
+
+### E2E
+Two existing specs touch the changed packages:
+- `packages/salesforcedx-vscode-org/test/playwright/specs/orgDeleteCommandVisibility.desktop.spec.ts` — checks command *visibility* in the palette only; does NOT invoke delete, so does NOT exercise `simpleExec`. The exec call path is jest-covered (orgDelete.test.ts). Not required for this change, but run to confirm no regression in org desktop bundle.
+- `packages/salesforcedx-vscode-metadata/test/playwright/specs/projectInfo.headless.spec.ts` — runs "Generate Project Info", which calls `projectInfo.ts` → `simpleExec({ command: 'sf --version' })` / `simpleExec({ command: 'java --version' })`; the `## Environment` section assertion (spec line 76) depends on those exec results. **DOES exercise the new object-param call path. Required.**
+
+Run before PR (from repo root, no `cd`):
+- `npm run test:desktop -w salesforcedx-vscode-metadata -- --retries 0` (projectInfo.headless is desktop-gated via `isDesktop()`)
+- `npm run test:desktop -w salesforcedx-vscode-org -- --retries 0` (regression check on visibility spec)
+
+If projectInfo spec cannot run locally (no org/sf/java), document the blocker; the jest+compile gates plus the spec's `## Environment` dependency on simpleExec remain the evidence the path is wired correctly.

--- a/.claude/skills/services-extension-consumption/references/terminal-service.md
+++ b/.claude/skills/services-extension-consumption/references/terminal-service.md
@@ -2,15 +2,20 @@
 
 Runs shell commands and parses stdout. Desktop-only — fails with `TerminalServiceError` on web.
 
-## `simpleExec<A>`
+## `simpleExec`
 
 ```typescript
-simpleExec(command: string, parse?: (stdout: string) => A): Effect<A, TerminalServiceError>
+simpleExec(args: {
+  command: string;
+  parse?: (stdout: string) => string;
+  timeout?: Duration.DurationInput;
+}): Effect<string, TerminalServiceError>
 ```
 
+- single object param
 - `parse` optional — omit to get trimmed stdout as `string`
 - stdout trimmed before `parse` is called
-- 10 s timeout
+- `timeout` optional `Duration.DurationInput` (default 30 s); pass a larger Duration for long-running commands (e.g. org delete)
 - Traced with `TerminalService.simpleExec` span (`command` attribute)
 - On web: immediate `TerminalServiceError` (no exec attempted)
 
@@ -31,24 +36,21 @@ const version = yield* Effect.gen(function* () {
   const terminal = yield* api.services.TerminalService;
 
   // stdout is pre-trimmed; split "7.200.6 @salesforce/cli/..." → just the version token
-  return yield* terminal.simpleExec('sf --version', stdout => stdout.split(' ')[0]);
+  return yield* terminal.simpleExec({ command: 'sf --version', parse: stdout => stdout.split(' ')[0] });
 });
 // version: string
 ```
 
-Parse stdout into a typed value using the generic param `<A>`:
+Pass a longer `timeout` for slow commands:
 
 ```typescript
-type SfVersion = { major: number; minor: number; patch: number };
+import * as Duration from 'effect/Duration';
 
-const parsed = yield* Effect.gen(function* () {
+const result = yield* Effect.gen(function* () {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const terminal = yield* api.services.TerminalService;
 
-  return yield* terminal.simpleExec<SfVersion>('sf --version', stdout => {
-    const [major, minor, patch] = stdout.split('.').map(Number);
-    return { major, minor, patch };
-  });
+  return yield* terminal.simpleExec({ command: 'sf org delete scratch', timeout: Duration.minutes(2) });
 });
-// parsed: SfVersion
+// result: string
 ```

--- a/packages/salesforcedx-vscode-metadata/src/commands/projectInfo.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/projectInfo.ts
@@ -146,8 +146,8 @@ const gatherEnvironment = Effect.fn('gatherEnvironment')(function* () {
   const terminalService = yield* api.services.TerminalService;
   const [cliVersion, javaVersion] = yield* Effect.all(
     [
-      terminalService.simpleExec('sf --version').pipe(Effect.orElseSucceed(() => 'unknown')),
-      terminalService.simpleExec('java --version').pipe(
+      terminalService.simpleExec({ command: 'sf --version' }).pipe(Effect.orElseSucceed(() => 'unknown')),
+      terminalService.simpleExec({ command: 'java --version' }).pipe(
         Effect.map(out => out.split('\n')[0]?.trim() ?? out),
         Effect.orElseSucceed(() => 'unknown')
       )

--- a/packages/salesforcedx-vscode-org/src/commands/orgDelete.ts
+++ b/packages/salesforcedx-vscode-org/src/commands/orgDelete.ts
@@ -16,6 +16,7 @@ import {
   ContinueResponse,
   workspaceUtils
 } from '@salesforce/salesforcedx-utils-vscode';
+import * as Duration from 'effect/Duration';
 import * as Effect from 'effect/Effect';
 import { identity } from 'effect/Function';
 import * as Schema from 'effect/Schema';
@@ -138,7 +139,7 @@ class OrgDeleteExecutor extends LibraryCommandletExecutor<{ orgs: OrgToDelete[] 
 }
 
 /** sf org delete can take longer than the default 30s simpleExec timeout. */
-const DELETE_TIMEOUT_MS = 120_000;
+const DELETE_TIMEOUT = Duration.seconds(120);
 
 class OrgNotDeletableError extends Schema.TaggedError<OrgNotDeletableError>()('OrgNotDeletableError', {
   message: Schema.String
@@ -170,11 +171,11 @@ export const orgDeleteDefaultCommand = Effect.fn('orgDeleteDefaultCommand')(func
   // the extension-host cwd (simpleExec runs without a workspace cwd, unlike the picker-based runDeleteCli)
   const targetOrgFlag = orgInfo.username ? ` --target-org ${orgInfo.username}` : '';
   const terminalService = yield* api.services.TerminalService;
-  const output = yield* terminalService.simpleExec(
-    `sf ${deleteSubcommand}${targetOrgFlag} --no-prompt`,
-    identity,
-    DELETE_TIMEOUT_MS
-  );
+  const output = yield* terminalService.simpleExec({
+    command: `sf ${deleteSubcommand}${targetOrgFlag} --no-prompt`,
+    parse: identity,
+    timeout: DELETE_TIMEOUT
+  });
 
   const channel = yield* api.services.ChannelService;
   yield* channel.appendToChannel(output);

--- a/packages/salesforcedx-vscode-org/test/jest/commands/orgDelete.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/commands/orgDelete.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
+import * as Duration from 'effect/Duration';
 import * as Effect from 'effect/Effect';
 import * as Exit from 'effect/Exit';
 import * as SubscriptionRef from 'effect/SubscriptionRef';
@@ -55,7 +56,11 @@ describe('orgDeleteDefaultCommand', () => {
     const exit = await run({ orgId: '00D', isScratch: true }, true, simpleExec);
 
     expect(Exit.isSuccess(exit)).toBe(true);
-    expect(simpleExec).toHaveBeenCalledWith('sf org delete scratch --no-prompt', expect.any(Function), 120_000);
+    expect(simpleExec).toHaveBeenCalledWith({
+      command: 'sf org delete scratch --no-prompt',
+      parse: expect.any(Function),
+      timeout: Duration.seconds(120)
+    });
     expect(mockUpdateConfigAndStateAggregators).toHaveBeenCalledTimes(1);
   });
 
@@ -64,7 +69,11 @@ describe('orgDeleteDefaultCommand', () => {
     const exit = await run({ orgId: '00D', isSandbox: true }, true, simpleExec);
 
     expect(Exit.isSuccess(exit)).toBe(true);
-    expect(simpleExec).toHaveBeenCalledWith('sf org delete sandbox --no-prompt', expect.any(Function), 120_000);
+    expect(simpleExec).toHaveBeenCalledWith({
+      command: 'sf org delete sandbox --no-prompt',
+      parse: expect.any(Function),
+      timeout: Duration.seconds(120)
+    });
   });
 
   it('passes --target-org so delete does not depend on the extension-host cwd', async () => {
@@ -72,11 +81,11 @@ describe('orgDeleteDefaultCommand', () => {
     const exit = await run({ orgId: '00D', username: 'me@scratch.org', isScratch: true }, true, simpleExec);
 
     expect(Exit.isSuccess(exit)).toBe(true);
-    expect(simpleExec).toHaveBeenCalledWith(
-      'sf org delete scratch --target-org me@scratch.org --no-prompt',
-      expect.any(Function),
-      120_000
-    );
+    expect(simpleExec).toHaveBeenCalledWith({
+      command: 'sf org delete scratch --target-org me@scratch.org --no-prompt',
+      parse: expect.any(Function),
+      timeout: Duration.seconds(120)
+    });
   });
 
   it('fails with OrgNotDeletableError and does not exec for a non-scratch/non-sandbox default org', async () => {

--- a/packages/salesforcedx-vscode-services/src/terminal/terminalService.ts
+++ b/packages/salesforcedx-vscode-services/src/terminal/terminalService.ts
@@ -19,7 +19,7 @@ export class TerminalService extends Effect.Service<TerminalService>()('Terminal
   effect: Effect.succeed({
     /** Execute a shell command and parse its stdout. Desktop-only; fails with TerminalServiceError on web. stdout is trimmed before parsing.
      * `timeout` (default 30s) bounds the child process; pass a larger Duration for long-running commands (e.g. org delete). */
-    simpleExec: ({
+    simpleExec: Effect.fn('TerminalService.simpleExec')(function* ({
       command,
       parse = s => s,
       timeout = Duration.millis(30_000)
@@ -27,19 +27,20 @@ export class TerminalService extends Effect.Service<TerminalService>()('Terminal
       command: string;
       parse?: (stdout: string) => string;
       timeout?: Duration.DurationInput;
-    }) =>
-      process.env.ESBUILD_PLATFORM === 'web'
-        ? Effect.fail(new TerminalServiceError({ message: 'Not available on web', command }))
-        : Effect.tryPromise({
-            try: async () => {
-              const { exec } = await import('node:child_process');
-              const { promisify } = await import('node:util');
-              return promisify(exec)(command, { timeout: Duration.toMillis(timeout) });
-            },
-            catch: e => new TerminalServiceError({ message: e instanceof Error ? e.message : 'exec failed', command })
-          }).pipe(
-            Effect.map(result => parse(result.stdout.trim())),
-            Effect.withSpan('TerminalService.simpleExec', { attributes: { command } })
-          )
+    }) {
+      yield* Effect.annotateCurrentSpan('command', command);
+      if (process.env.ESBUILD_PLATFORM === 'web') {
+        return yield* Effect.fail(new TerminalServiceError({ message: 'Not available on web', command }));
+      }
+      const result = yield* Effect.tryPromise({
+        try: async () => {
+          const { exec } = await import('node:child_process');
+          const { promisify } = await import('node:util');
+          return promisify(exec)(command, { timeout: Duration.toMillis(timeout) });
+        },
+        catch: e => new TerminalServiceError({ message: e instanceof Error ? e.message : 'exec failed', command })
+      });
+      return parse(result.stdout.trim());
+    })
   })
 }) {}

--- a/packages/salesforcedx-vscode-services/src/terminal/terminalService.ts
+++ b/packages/salesforcedx-vscode-services/src/terminal/terminalService.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import * as Duration from 'effect/Duration';
 import * as Effect from 'effect/Effect';
 import * as Schema from 'effect/Schema';
 
@@ -17,15 +18,23 @@ export class TerminalService extends Effect.Service<TerminalService>()('Terminal
   accessors: false,
   effect: Effect.succeed({
     /** Execute a shell command and parse its stdout. Desktop-only; fails with TerminalServiceError on web. stdout is trimmed before parsing.
-     * `timeoutMs` (default 30_000) bounds the child process; pass a larger value for long-running commands (e.g. org delete). */
-    simpleExec: (command: string, parse: (stdout: string) => string = s => s, timeoutMs = 30_000) =>
+     * `timeout` (default 30s) bounds the child process; pass a larger Duration for long-running commands (e.g. org delete). */
+    simpleExec: ({
+      command,
+      parse = s => s,
+      timeout = Duration.millis(30_000)
+    }: {
+      command: string;
+      parse?: (stdout: string) => string;
+      timeout?: Duration.DurationInput;
+    }) =>
       process.env.ESBUILD_PLATFORM === 'web'
         ? Effect.fail(new TerminalServiceError({ message: 'Not available on web', command }))
         : Effect.tryPromise({
             try: async () => {
               const { exec } = await import('node:child_process');
               const { promisify } = await import('node:util');
-              return promisify(exec)(command, { timeout: timeoutMs });
+              return promisify(exec)(command, { timeout: Duration.toMillis(timeout) });
             },
             catch: e => new TerminalServiceError({ message: e instanceof Error ? e.message : 'exec failed', command })
           }).pipe(


### PR DESCRIPTION
## Summary

- Replace `simpleExec(command, parse?, timeoutMs?)` positional signature with `simpleExec({ command, parse?, timeout? })` options object
- `timeout` accepts `Duration.DurationInput` (Effect), defaulting to `Duration.millis(30_000)`; internally converted via `Duration.toMillis`
- Updated callers: `orgDelete.ts` (120 s delete timeout), `projectInfo.ts` (version checks); test assertions updated to object shape

## Plan

[.claude/plans/W-23072534.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23072534-refactor-terminalservice-simpleexec-to-o/.claude/plans/W-23072534.md)

## What issues does this PR fix or reference?

@W-23072534@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cY67cYAC/view