### PR TITLE
test(lwc): fix LWC rename input races and folder refresh lag - W-23073733

### DIFF
--- a/.claude/plans/W-23073733.md
+++ b/.claude/plans/W-23073733.md
@@ -1,0 +1,37 @@
+# W-23073733 — e2e: fix LWC rename input races + folder refresh lag
+
+## Context
+
+- Test: `packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcRename.headless.spec.ts`
+- CI run 27492599426 flakes, 2 modes:
+  - Ubuntu: `ControlOrMeta+a` + `keyboard.type()` truncates name (`enameLwcFinal...`, `meLwcFinal...`) — partial selection before focus settles on quick-input.
+  - macOS: folder treeitem not visible <10s though child files renamed (debounced watcher). Both visibility asserts (`:79` newFolder, `:102` finalFolder) use identical `toBeVisible({ timeout: 10_000 })` and flake the same way.
+- `activeQuickInputTextField` exported from `@salesforce/playwright-vscode-ext` (`src/index.ts:36`); returns `activeQuickInputWidget(page).locator('input.input')`. `.fill()` sets value atomically, no keystroke race.
+
+## Phases
+
+### Phase 1 — fix input races + folder refresh lag (1 commit)
+
+File: `packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcRename.headless.spec.ts`
+
+- Explorer rename: replace exactly the 2 lines `:68` (`keyboard.press('ControlOrMeta+a')`) + `:69` (`keyboard.type(newName)`) with a single `await activeQuickInputTextField(page).fill(newName, { force: true })`. Line `:70` (`keyboard.press('Enter')`) MUST remain unchanged — it is the submit and is NOT in the replace range.
+- Editor rename: replace exactly the 2 lines `:91` (`keyboard.press('ControlOrMeta+a')`) + `:92` (`keyboard.type(finalName)`) with `await activeQuickInputTextField(page).fill(finalName, { force: true })`. Line `:93` (`keyboard.press('Enter')`) MUST remain unchanged.
+- `.fill(value, { force: true })` is the established package idiom (`commands.ts:101,202`); sets value atomically, eliminating the select-all/type focus race.
+- Add `activeQuickInputTextField` to the existing import from `@salesforce/playwright-vscode-ext`.
+- `:79` newFolder visibility: wrap in `await expect(async () => { await expect(newFolder).toBeVisible(); }).toPass({ timeout: 20_000 })`.
+- `:102` finalFolder visibility: same `toPass({ timeout: 20_000 })` wrap — identical debounced-watcher flake recurs on the post-editor-rename assertion.
+
+Commit: `test(lwc): stabilize lwcRename input fill + folder refresh - W-23073733`
+
+## Skills
+
+- playwright-e2e — locator/quick-input conventions
+- typescript — type-correct edits to spec file
+- concise — plan + md style
+- analyze-e2e / gha-rerun — confirm green CI post-push
+
+## Verification
+
+- Local headless run (required): `npx playwright test lwcRename.headless.spec.ts` from the lwc package in the headless server (web workbench) context. Confirms `.fill()` reaches the active quick-input in the web-based workbench DOM (parity vs desktop), not just CI observation. `activeQuickInputTextField` already used by `.fill()` in this package's own headless specs (contextMenu/commandPalette headless), so the locator resolves in web workbench — local run confirms it for the rename flow specifically.
+- Local: `npx eslint` on changed file (lint clean).
+- CI: lwcRename passes no-retry on ubuntu + macOS (DoD) — via gha-rerun/analyze-e2e after push.

--- a/.claude/plans/W-23073733.md
+++ b/.claude/plans/W-23073733.md
@@ -14,8 +14,8 @@
 
 File: `packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcRename.headless.spec.ts`
 
-- Explorer rename: replace exactly the 2 lines `:68` (`keyboard.press('ControlOrMeta+a')`) + `:69` (`keyboard.type(newName)`) with a single `await activeQuickInputTextField(page).fill(newName, { force: true })`. Line `:70` (`keyboard.press('Enter')`) MUST remain unchanged — it is the submit and is NOT in the replace range.
-- Editor rename: replace exactly the 2 lines `:91` (`keyboard.press('ControlOrMeta+a')`) + `:92` (`keyboard.type(finalName)`) with `await activeQuickInputTextField(page).fill(finalName, { force: true })`. Line `:93` (`keyboard.press('Enter')`) MUST remain unchanged.
+- Explorer rename: replace `:68`–`:69` with `await activeQuickInputTextField(page).fill(newName, { force: true })`; keep `:70` (Enter).
+- Editor rename: replace `:91`–`:92` with `await activeQuickInputTextField(page).fill(finalName, { force: true })`; keep `:93` (Enter).
 - `.fill(value, { force: true })` is the established package idiom (`commands.ts:101,202`); sets value atomically, eliminating the select-all/type focus race.
 - Add `activeQuickInputTextField` to the existing import from `@salesforce/playwright-vscode-ext`.
 - `:79` newFolder visibility: wrap in `await expect(async () => { await expect(newFolder).toBeVisible(); }).toPass({ timeout: 20_000 })`.
@@ -32,6 +32,6 @@ Commit: `test(lwc): stabilize lwcRename input fill + folder refresh - W-23073733
 
 ## Verification
 
-- Local headless run (required): `npx playwright test lwcRename.headless.spec.ts` from the lwc package in the headless server (web workbench) context. Confirms `.fill()` reaches the active quick-input in the web-based workbench DOM (parity vs desktop), not just CI observation. `activeQuickInputTextField` already used by `.fill()` in this package's own headless specs (contextMenu/commandPalette headless), so the locator resolves in web workbench — local run confirms it for the rename flow specifically.
+- Local headless (from repo root): `WIREIT_CACHE=none npm run test:web -w salesforcedx-vscode-lwc -- --retries 0 lwcRename.headless.spec.ts` (confirms `.fill()` resolves in web workbench DOM).
 - Local: `npx eslint` on changed file (lint clean).
 - CI: lwcRename passes no-retry on ubuntu + macOS (DoD) — via gha-rerun/analyze-e2e after push.

--- a/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcRename.headless.spec.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcRename.headless.spec.ts
@@ -7,6 +7,7 @@
 
 import { expect } from '@playwright/test';
 import {
+  activeQuickInputTextField,
   activeQuickInputWidget,
   closeWelcomeTabs,
   ensureSecondarySideBarHidden,
@@ -64,9 +65,8 @@ test('LWC Rename: renames an existing bundle via explorer context menu', async (
     await activeQuickInputWidget(page).waitFor({ state: 'attached', timeout: 10_000 });
     await saveScreenshot(page, 'rename.context-menu-fired.png');
 
-    // Input box is pre-filled with the old name; select all + type new name
-    await page.keyboard.press('ControlOrMeta+a');
-    await page.keyboard.type(newName);
+    // Input box is pre-filled with the old name; fill atomically to avoid select-all/type focus race
+    await activeQuickInputTextField(page).fill(newName, { force: true });
     await page.keyboard.press('Enter');
     await saveScreenshot(page, 'rename.entered-new-name.png');
   });
@@ -76,7 +76,10 @@ test('LWC Rename: renames an existing bundle via explorer context menu', async (
       .locator('[role="treeitem"]')
       .filter({ hasText: new RegExp(`^${newName}$`, 'i') })
       .first();
-    await expect(newFolder).toBeVisible({ timeout: 10_000 });
+    // Debounced file watcher lags the tree refresh; poll until the renamed folder appears.
+    await expect(async () => {
+      await expect(newFolder).toBeVisible();
+    }).toPass({ timeout: 20_000 });
 
     const oldFolder = page.locator('[role="treeitem"]').filter({ hasText: new RegExp(`^${oldName}$`, 'i') });
     await expect(oldFolder).toHaveCount(0, { timeout: 5000 });
@@ -88,8 +91,7 @@ test('LWC Rename: renames an existing bundle via explorer context menu', async (
   await test.step('rename again via editor context menu', async () => {
     await executeEditorContextMenuCommand(page, packageNls.rename_lightning_component_text, `${newName}.js`);
     await activeQuickInputWidget(page).waitFor({ state: 'attached', timeout: 10_000 });
-    await page.keyboard.press('ControlOrMeta+a');
-    await page.keyboard.type(finalName);
+    await activeQuickInputTextField(page).fill(finalName, { force: true });
     await page.keyboard.press('Enter');
     await saveScreenshot(page, 'rename.editor-menu-fired.png');
   });
@@ -99,7 +101,10 @@ test('LWC Rename: renames an existing bundle via explorer context menu', async (
       .locator('[role="treeitem"]')
       .filter({ hasText: new RegExp(`^${finalName}$`, 'i') })
       .first();
-    await expect(finalFolder).toBeVisible({ timeout: 10_000 });
+    // Debounced file watcher lags the tree refresh; poll until the renamed folder appears.
+    await expect(async () => {
+      await expect(finalFolder).toBeVisible();
+    }).toPass({ timeout: 20_000 });
   });
 
   await validateNoCriticalErrors(test, consoleErrors, networkErrors);

--- a/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcRename.headless.spec.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcRename.headless.spec.ts
@@ -82,7 +82,8 @@ test('LWC Rename: renames an existing bundle via explorer context menu', async (
     }).toPass({ timeout: 20_000 });
 
     const oldFolder = page.locator('[role="treeitem"]').filter({ hasText: new RegExp(`^${oldName}$`, 'i') });
-    await expect(oldFolder).toHaveCount(0, { timeout: 5000 });
+    // Same debounced watcher lag can delay the old-name treeitem disappearing.
+    await expect(oldFolder).toHaveCount(0, { timeout: 20_000 });
     await saveScreenshot(page, 'rename.verify-tree.png');
   });
 


### PR DESCRIPTION
## Summary

- Replace `selectAll + keyboard.type()` with `activeQuickInputTextField(page).fill()` to atomically set rename input, eliminating partial-selection/focus race on Ubuntu
- Wrap both folder-treeitem visibility assertions in `toPass({ timeout: 20_000 })` to absorb debounced-watcher refresh lag on macOS
- Changes are confined to `lwcRename.headless.spec.ts`

## Plan

[.claude/plans/W-23073733.md](.claude/plans/W-23073733.md)

### What issues does this PR fix or reference?

@W-23073733@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cYWhxYAG/view