### PR TITLE
chore(soql): upgrade @rollup/plugin-terser to fix CVE-2026-34043 - W-23076514

### DIFF
--- a/.claude/plans/W-23076514.md
+++ b/.claude/plans/W-23076514.md
@@ -1,0 +1,34 @@
+# W-23076514 — Upgrade @rollup/plugin-terser (CVE-2026-34043)
+
+## Context
+
+- Dependabot alert 331: `serialize-javascript@6.0.2` DoS (CVE-2026-34043)
+- Path: `salesforcedx-vscode-soql` → `@rollup/plugin-terser@0.4.4` → `serialize-javascript@6.0.2`
+- Fix: bump devDep `@rollup/plugin-terser` `^0.4.0` → `^1.0.0`
+- v1.0.0 pulls `serialize-javascript@^7.0.3` (fixed major); CVE in 6.x
+- Compat verified:
+  - v1 peerDep `rollup ^4.0.0` matches package `rollup ^4.0.0`
+  - v1 engines `node>=20`; repo `node>=22.15.1` OK
+  - usage unchanged: `rollup.config.mjs:16,139` — `terser({ format:{comments:false}, maxWorkers:1 })`
+  - devDep only; not bundled/published
+
+## Phases
+
+### Phase 1 — bump + relock
+- `packages/salesforcedx-vscode-soql/package.json:63` `^0.4.0` → `^1.0.0`
+- root `npm install` to relock
+- confirm lockfile drops `serialize-javascript@6.x` on this path (now 3 refs)
+- commit: `chore(soql): upgrade @rollup/plugin-terser to ^1.0.0 to fix CVE-2026-34043 - W-23076514`
+
+## Skills to apply
+
+- packageJson — devDep rules
+- wireit — build scripts (no change expected)
+- typescript
+
+## Verification
+
+- `npm ls serialize-javascript` → no 6.x on soql path
+- `npm run build:soql-builder-ui` (rollup w/ terser) succeeds → confirms v1 API compat
+- `npm run vscode:bundle` (soql) succeeds
+- e2e-covered: soql builder UI behavior via `test:web`/`test:desktop` Playwright on branch

--- a/.claude/plans/W-23076514.md
+++ b/.claude/plans/W-23076514.md
@@ -4,13 +4,13 @@
 
 - Dependabot alert 331: `serialize-javascript@6.0.2` DoS (CVE-2026-34043)
 - Path: `salesforcedx-vscode-soql` → `@rollup/plugin-terser@0.4.4` → `serialize-javascript@6.0.2`
-- Fix: bump devDep `@rollup/plugin-terser` `^0.4.0` → `^1.0.0`
-- v1.0.0 pulls `serialize-javascript@^7.0.3` (fixed major); CVE in 6.x
+- Fix: bump `@rollup/plugin-terser` `^0.4.0` → `^1.0.0`
+- v1.0.0 pulls `serialize-javascript@^7.0.3` (CVE fixed in 7.x)
 - Compat verified:
-  - v1 peerDep `rollup ^4.0.0` matches package `rollup ^4.0.0`
+  - v1 peer `rollup ^4.0.0` matches package `rollup ^4.0.0`
   - v1 engines `node>=20`; repo `node>=22.15.1` OK
   - usage unchanged: `rollup.config.mjs:16,139` — `terser({ format:{comments:false}, maxWorkers:1 })`
-  - devDep only; not bundled/published
+  - devDep only
 
 ## Phases
 
@@ -29,6 +29,6 @@
 ## Verification
 
 - `npm ls serialize-javascript` → no 6.x on soql path
-- `npm run build:soql-builder-ui` (rollup w/ terser) succeeds → confirms v1 API compat
+- `npm run build:soql-builder-ui` (rollup/terser) succeeds → v1 API compat
 - `npm run vscode:bundle` (soql) succeeds
-- e2e-covered: soql builder UI behavior via `test:web`/`test:desktop` Playwright on branch
+- e2e: soql builder UI via `test:web`/`test:desktop` Playwright

--- a/package-lock.json
+++ b/package-lock.json
@@ -8168,6 +8168,29 @@
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@rollup/plugin-terser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-1.0.0.tgz",
+      "integrity": "sha512-FnCxhTBx6bMOYQrar6C8h3scPt8/JwIzw3+AJ2K++6guogH5fYaIFia+zZuhqv0eo1RN7W1Pz630SyvLbDjhtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "serialize-javascript": "^7.0.3",
+        "smob": "^1.0.0",
+        "terser": "^5.17.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
@@ -38815,13 +38838,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/set-blocking": {
@@ -44156,7 +44179,7 @@
         "@lwc/compiler": "9.0.3",
         "@lwc/errors": "9.0.3",
         "@lwc/metadata": "12.3.4",
-        "@lwc/template-compiler": "9.0.3",
+        "@lwc/template-compiler": "9.3.4",
         "@salesforce/apex": "^0.0.21",
         "@salesforce/label": "^0.0.21",
         "@salesforce/salesforcedx-lightning-lsp-common": "*",
@@ -44668,7 +44691,7 @@
         "@salesforce/salesforcedx-utils": "*",
         "@salesforce/salesforcedx-utils-vscode": "*",
         "@salesforce/source-deploy-retrieve": "^12.32.5",
-        "@salesforce/templates": "66.10.2",
+        "@salesforce/templates": "^66.10.2",
         "@salesforce/ts-types": "^2.0.12",
         "@salesforce/vscode-i18n": "*",
         "@salesforce/vscode-service-provider": "^1.5.0",
@@ -44850,7 +44873,7 @@
         "@salesforce/o11y-reporter": "^1.8.1",
         "@salesforce/source-deploy-retrieve": "^12.32.5",
         "@salesforce/source-tracking": "^7.8.16",
-        "@salesforce/templates": "66.10.2",
+        "@salesforce/templates": "^66.10.2",
         "@salesforce/vscode-i18n": "*",
         "@vscode/extension-telemetry": "^1.0.0",
         "effect": "^3.21.2",
@@ -45036,7 +45059,7 @@
         "@rollup/plugin-commonjs": "^29.0.0",
         "@rollup/plugin-inject": "^5.0.0",
         "@rollup/plugin-node-resolve": "^16.0.0",
-        "@rollup/plugin-terser": "^0.4.0",
+        "@rollup/plugin-terser": "^1.0.0",
         "@salesforce/eslint-config-lwc": "^4.1.2",
         "@salesforce/eslint-plugin-lightning": "^2.0.0",
         "@salesforce/playwright-vscode-ext": "*",
@@ -45174,29 +45197,6 @@
       },
       "peerDependencies": {
         "rollup": "^2.78.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "packages/salesforcedx-vscode-soql/node_modules/@rollup/plugin-terser": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
-      "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "serialize-javascript": "^6.0.1",
-        "smob": "^1.0.0",
-        "terser": "^5.17.4"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.0.0||^3.0.0||^4.0.0"
       },
       "peerDependenciesMeta": {
         "rollup": {

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -60,7 +60,7 @@
     "@rollup/plugin-commonjs": "^29.0.0",
     "@rollup/plugin-inject": "^5.0.0",
     "@rollup/plugin-node-resolve": "^16.0.0",
-    "@rollup/plugin-terser": "^0.4.0",
+    "@rollup/plugin-terser": "^1.0.0",
     "@salesforce/eslint-config-lwc": "^4.1.2",
     "@salesforce/eslint-plugin-lightning": "^2.0.0",
     "@salesforce/playwright-vscode-ext": "*",


### PR DESCRIPTION
## Summary

- Upgrade `@rollup/plugin-terser` from `^0.4.0` to `^1.0.0` in `salesforcedx-vscode-soql`
- Fixes CVE-2026-34043 (DoS) in transitive dependency `serialize-javascript@6.0.2`
- v1.0.0 pulls `serialize-javascript@^7.0.3` which resolves the vulnerability

## Plan

[.claude/plans/W-23076514.md](.claude/plans/W-23076514.md)

## Reviewer notes

- **Low:** package-lock.json bundles pre-existing dependency-desync corrections alongside the CVE fix. develop's package.json already declared @lwc/template-compiler 9.3.4 and @salesforce/templates ^66.10.2, but develop's lockfile was stale (9.0.3, 66.10.2). npm install for the terser bump silently synced these. Harmless, but mixes unrelated lockfile churn into a security-only PR. The only intentional change is @rollup/plugin-terser ^0.4.0 -> ^1.0.0 in packages/salesforcedx-vscode-soql/package.json.

## What issues does this PR fix or reference?

@W-23076514@

🤖 Generated by auto-build pipeline. Original WI: https://gus.my.salesforce.com/a07EE00002cZ9zZ