### PR TITLE
test(apex): Apex snippet insertion e2e - W-22917909

### DIFF
--- a/.claude/plans/W-22917909.md
+++ b/.claude/plans/W-22917909.md
@@ -3,7 +3,7 @@
 ## Context
 
 - Goal: desktop Playwright e2e for Apex snippet insertion. No Apex snippet e2e today.
-- Snippets ship in marketplace ext `salesforce.apex-language-server-extension` (repo forcedotcom/apex-language-support, `snippets/apex.json`). NOT in this monorepo.
+- Snippets in marketplace ext `salesforce.apex-language-server-extension` (repo forcedotcom/apex-language-support, `snippets/apex.json`). NOT in this monorepo.
 - Test body model: `packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcSnippets.headless.spec.ts`.
 - Fixture model: `packages/salesforcedx-vscode-apex-oas/test/playwright/fixtures/desktopFixtures.ts` (`marketplaceExtensions`, `disableOtherExtensions: false`).
 - Harness ready: `createDesktopTest` `marketplaceExtensions: string[]` → `code --install-extension <id> --force` (node_modules `@salesforce/playwright-vscode-ext/src/fixtures/createDesktopTest.ts` L54, L208/L359). VSIX mode (CI `E2E_FROM_VSIX=1`) installs into cache. `disableOtherExtensions: false` required — default `--disable-extensions` blocks marketplace ext. apex-oas precedent: single `createDesktopTest` w/ `marketplaceExtensions` + `disableOtherExtensions: false` (desktopFixtures.ts:19-33).
@@ -29,7 +29,7 @@
 
 ### release-testing doc
 
-- No in-repo "release-testing" doc found (`docs/`, `contributing/` searched). Doc is external (internal/Quip). Out-of-repo update tracked separately; flag in PR. No repo file to edit.
+- No in-repo "release-testing" doc (`docs/`, `contributing/` searched). Doc is external (internal/Quip). Out-of-repo update tracked separately; flag in PR. No repo file to edit.
 
 ## Phases
 
@@ -62,7 +62,7 @@ files:
 
 ## Verification
 
-The new spec IS the e2e coverage — must be run locally before PR (not just relied on in CI).
+New spec = e2e coverage — must be run locally before PR (not just relied on in CI).
 
 - Run locally before PR: `packages/salesforcedx-vscode-apex/test/playwright/specs/apexSnippets.desktop.spec.ts` via `npm run test:desktop` in apex pkg (needs `code`/vscode dl + marketplace install reachable). Confirms: marketplace ext `salesforce.apex-language-server-extension` installs + loads, `Snippets: Insert Snippet` picker shows `System Debug` (prefix `debug` matches fill), snippet inserts on blank line 7, saved editor text contains `System.debug()`, no critical console/network errs. Note: marketplace ext unpinned (latest); if breaking ver, may need skip (apex-oas precedent).
 - `npm run compile` / tsc clean in apex pkg (new fixture+spec typecheck).

--- a/.claude/plans/W-22917909.md
+++ b/.claude/plans/W-22917909.md
@@ -1,0 +1,71 @@
+# W-22917909 — e2e: Apex snippet insertion (desktop)
+
+## Context
+
+- Goal: desktop Playwright e2e for Apex snippet insertion. No Apex snippet e2e today.
+- Snippets ship in marketplace ext `salesforce.apex-language-server-extension` (repo forcedotcom/apex-language-support, `snippets/apex.json`). NOT in this monorepo.
+- Test body model: `packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcSnippets.headless.spec.ts`.
+- Fixture model: `packages/salesforcedx-vscode-apex-oas/test/playwright/fixtures/desktopFixtures.ts` (`marketplaceExtensions`, `disableOtherExtensions: false`).
+- Harness ready: `createDesktopTest` `marketplaceExtensions: string[]` → `code --install-extension <id> --force` (node_modules `@salesforce/playwright-vscode-ext/src/fixtures/createDesktopTest.ts` L54, L208/L359). VSIX mode (CI `E2E_FROM_VSIX=1`) installs into cache. `disableOtherExtensions: false` required — default `--disable-extensions` blocks marketplace ext. apex-oas precedent: single `createDesktopTest` w/ `marketplaceExtensions` + `disableOtherExtensions: false` (desktopFixtures.ts:19-33).
+- Scope: desktop only. Web cannot gallery-install (out of scope).
+
+### Existing apex fixture (do NOT duplicate)
+
+- `desktopFixtures.ts:50-65` `baseTest = createDesktopTest({...})` (NO marketplace).
+- `desktopFixtures.ts:70-87` `desktopTest = baseTest.extend<{ workspaceDir }>` ALREADY overrides `workspaceDir`, seeding `ExampleClass.cls`, `ExampleClassTest.cls`, `ExampleAnon.apex` on disk pre-launch.
+- `ExampleClassTest.cls` has a load-bearing blank line 7 (desktopFixtures.ts:35-45, comment at :33-34) — reuse it as the snippet insertion target. No new file, no second `workspaceDir` override.
+
+### Snippet facts (verified, raw apex.json main)
+
+- Picker label = JSON key `System Debug`; prefix `debug`; body `System.debug($0)`.
+- `contributes.snippets` registers `apex.json` for langs `apex` + `apex-anon`. `.cls` = `apex` → snippet available.
+- `$0` = final cursor (empty render) → saved text `System.debug()`. Matches WI assert.
+
+### CI
+
+- `.github/workflows/apexLspE2E.yml` runs all `test/playwright/specs/*.spec.ts` in this pkg on macos/ubuntu/windows, VSIX mode. New spec auto-picked-up. No workflow edit.
+- Existing apex fixture `desktopTest` lacks `marketplaceExtensions` → need dedicated fixture.
+- `playwright.config.desktop.ts`: `workers: 1`, `timeout: 360_000` (shared).
+
+### release-testing doc
+
+- No in-repo "release-testing" doc found (`docs/`, `contributing/` searched). Doc is external (internal/Quip). Out-of-repo update tracked separately; flag in PR. No repo file to edit.
+
+## Phases
+
+### Phase 1 — add snippet fixture + spec
+
+- In `packages/salesforcedx-vscode-apex/test/playwright/fixtures/desktopFixtures.ts`, add `snippetDesktopTest` WITHOUT a second `workspaceDir` override:
+  - `marketplaceExtensions` is a `createDesktopTest` arg, not extendable per-test → `snippetDesktopTest` is its own `createDesktopTest({ fixturesDir: __dirname, additionalExtensionDirs: ['salesforcedx-vscode-core'], marketplaceExtensions: ['salesforce.apex-language-server-extension'], disableOtherExtensions: false, userSettings })` (reuse same userSettings object as `baseTest`).
+  - Extract the existing `workspaceDir` seeding (currently inline at :71-86) into a reusable `seedWorkspaceFiles` extension fn (`{ workspaceDir: async ({ workspaceDir }, use) => {...} }`). Apply it to BOTH `desktopTest` and `snippetDesktopTest` via `.extend(seedWorkspaceFiles)`. One seeding definition; existing `desktopTest` behavior unchanged (same files, same blank line 7).
+  - Snippet target = pre-seeded `ExampleClassTest.cls` blank line 7. No new file.
+- Export `snippetTest` from `fixtures/index.ts` (`export { snippetDesktopTest as snippetTest }`), alongside existing `export { desktopTest as test }`.
+- New spec `packages/salesforcedx-vscode-apex/test/playwright/specs/apexSnippets.desktop.spec.ts`:
+  - import `{ snippetTest as test }` from `../fixtures`
+  - steps (model lwcSnippets): wait workbench → close welcome → `waitForWorkspaceReady` → `waitForExtensionsActivated` (marketplace ext load); `openFileByName(page, 'ExampleClassTest.cls')`; click editor (focus, snippets lang-scoped); position cursor on blank line 7 (deterministic insertion point — `Go to Line/Column` palette or arrow nav) so `System.debug()` lands in known location; `executeCommandWithCommandPalette('Snippets: Insert Snippet')`; quick-input fill `debug`; `waitForQuickInputFirstOption`; Enter; dismiss overlays; `File: Save`; assert collapsed editor text contains `System.debug()`.
+  - reuse local helpers from lwc spec (collapseEditorWhitespace, readActiveEditorDocumentText, dismissEditorOverlays) inlined (no shared util import across pkgs).
+  - `validateNoCriticalErrors` at end.
+
+commit: `test(apex): add desktop e2e for Apex snippet insertion - W-22917909`
+
+files:
+- `packages/salesforcedx-vscode-apex/test/playwright/fixtures/desktopFixtures.ts`
+- `packages/salesforcedx-vscode-apex/test/playwright/fixtures/index.ts`
+- `packages/salesforcedx-vscode-apex/test/playwright/specs/apexSnippets.desktop.spec.ts`
+
+## Skills to apply
+
+- playwright-e2e (coding-playwright-tests, iterating refs)
+- concise (this plan, any md)
+- typescript (spec/fixture style)
+- verification (pre-PR checks)
+
+## Verification
+
+The new spec IS the e2e coverage — must be run locally before PR (not just relied on in CI).
+
+- Run locally before PR: `packages/salesforcedx-vscode-apex/test/playwright/specs/apexSnippets.desktop.spec.ts` via `npm run test:desktop` in apex pkg (needs `code`/vscode dl + marketplace install reachable). Confirms: marketplace ext `salesforce.apex-language-server-extension` installs + loads, `Snippets: Insert Snippet` picker shows `System Debug` (prefix `debug` matches fill), snippet inserts on blank line 7, saved editor text contains `System.debug()`, no critical console/network errs. Note: marketplace ext unpinned (latest); if breaking ver, may need skip (apex-oas precedent).
+- `npm run compile` / tsc clean in apex pkg (new fixture+spec typecheck).
+- lint clean (eslint) on new/changed files.
+- CI apexLspE2E (3 OS, VSIX mode) re-runs this same spec post-merge; no workflow edit (auto-picked-up).
+- release-testing doc update: external, not in repo — flag in PR description.

--- a/packages/salesforcedx-vscode-apex/test/playwright/fixtures/desktopFixtures.ts
+++ b/packages/salesforcedx-vscode-apex/test/playwright/fixtures/desktopFixtures.ts
@@ -44,31 +44,45 @@ const EXAMPLE_CLASS_TEST = [
   '}'
 ].join('\n');
 
-// apexLsp specs do not exercise Push/Pull, so the workspace has no org. Files are pre-seeded
-// onto disk before Electron launches so the jorje LSP startup scan picks them up — drops the
-// WDIO Windows-only `reloadWindow` workaround.
+// Shared userSettings: apexLsp specs do not exercise Push/Pull, so the workspace has no org.
+const userSettings = {
+  'git.terminalAuthentication': false,
+  'git.autofetch': false,
+  // Prevent Go to Definition from opening a peek widget when the target file is already open
+  'editor.gotoLocation.multipleDefinitions': 'goto',
+  'editor.gotoLocation.multipleDeclarations': 'goto',
+  'editor.gotoLocation.multipleImplementations': 'goto',
+  'editor.gotoLocation.multipleTypeDefinitions': 'goto',
+  'editor.gotoLocation.multipleReferences': 'goto',
+  'editor.gotoLocation.alternativeDefinitionCommand': ''
+};
+
+// Files are pre-seeded onto disk before Electron launches so the jorje LSP startup scan picks
+// them up — drops the WDIO Windows-only `reloadWindow` workaround.
 const baseTest = createDesktopTest({
   fixturesDir: __dirname,
   additionalExtensionDirs: ['salesforcedx-vscode-core'],
   disableOtherExtensions: false,
-  userSettings: {
-    'git.terminalAuthentication': false,
-    'git.autofetch': false,
-    // Prevent Go to Definition from opening a peek widget when the target file is already open
-    'editor.gotoLocation.multipleDefinitions': 'goto',
-    'editor.gotoLocation.multipleDeclarations': 'goto',
-    'editor.gotoLocation.multipleImplementations': 'goto',
-    'editor.gotoLocation.multipleTypeDefinitions': 'goto',
-    'editor.gotoLocation.multipleReferences': 'goto',
-    'editor.gotoLocation.alternativeDefinitionCommand': ''
-  }
+  userSettings
 });
 
-// Override `workspaceDir` so ExampleClass.cls + ExampleClassTest.cls land on disk before
-// Electron is launched (which depends on workspaceDir). jorje scans the project at startup;
-// files written after launch require a window reload.
-export const desktopTest = baseTest.extend<{ workspaceDir: string }>({
-  workspaceDir: async ({ workspaceDir }, use) => {
+// Snippet spec needs the marketplace ext `salesforce.apex-language-server-extension` (ships
+// apex.json snippets). `marketplaceExtensions` is a createDesktopTest arg, not extendable
+// per-test — so this is its own createDesktopTest. `disableOtherExtensions: false` is required:
+// the default `--disable-extensions` would block the marketplace ext from loading.
+const snippetBaseTest = createDesktopTest({
+  fixturesDir: __dirname,
+  additionalExtensionDirs: ['salesforcedx-vscode-core'],
+  marketplaceExtensions: ['salesforce.apex-language-server-extension'],
+  disableOtherExtensions: false,
+  userSettings
+});
+
+// Override `workspaceDir` so files land on disk before Electron is launched (which depends on
+// workspaceDir). jorje scans the project at startup; files written after launch require a window
+// reload. Shared by both tests so the seeded files (incl. ExampleClassTest.cls blank line 7) match.
+const seedWorkspaceFiles = {
+  workspaceDir: async ({ workspaceDir }: { workspaceDir: string }, use: (dir: string) => Promise<void>) => {
     const classesDir = path.join(workspaceDir, 'force-app', 'main', 'default', 'classes');
     // Anonymous Apex lives at workspace-root `scripts/apex/` (Salesforce convention; the dir
     // templates scaffold). Not metadata — no `classes/` placement, no `-meta.xml`. jorje's
@@ -84,4 +98,8 @@ export const desktopTest = baseTest.extend<{ workspaceDir: string }>({
     ]);
     await use(workspaceDir);
   }
-});
+};
+
+export const desktopTest = baseTest.extend<{ workspaceDir: string }>(seedWorkspaceFiles);
+
+export const snippetDesktopTest = snippetBaseTest.extend<{ workspaceDir: string }>(seedWorkspaceFiles);

--- a/packages/salesforcedx-vscode-apex/test/playwright/fixtures/desktopFixtures.ts
+++ b/packages/salesforcedx-vscode-apex/test/playwright/fixtures/desktopFixtures.ts
@@ -82,7 +82,7 @@ const snippetBaseTest = createDesktopTest({
 // workspaceDir). jorje scans the project at startup; files written after launch require a window
 // reload. Shared by both tests so the seeded files (incl. ExampleClassTest.cls blank line 7) match.
 const seedWorkspaceFiles = {
-  workspaceDir: async ({ workspaceDir }: { workspaceDir: string }, use: (dir: string) => Promise<void>) => {
+  workspaceDir: async ({ workspaceDir }, use) => {
     const classesDir = path.join(workspaceDir, 'force-app', 'main', 'default', 'classes');
     // Anonymous Apex lives at workspace-root `scripts/apex/` (Salesforce convention; the dir
     // templates scaffold). Not metadata — no `classes/` placement, no `-meta.xml`. jorje's

--- a/packages/salesforcedx-vscode-apex/test/playwright/fixtures/desktopFixtures.ts
+++ b/packages/salesforcedx-vscode-apex/test/playwright/fixtures/desktopFixtures.ts
@@ -82,7 +82,7 @@ const snippetBaseTest = createDesktopTest({
 // workspaceDir). jorje scans the project at startup; files written after launch require a window
 // reload. Shared by both tests so the seeded files (incl. ExampleClassTest.cls blank line 7) match.
 const seedWorkspaceFiles = {
-  workspaceDir: async ({ workspaceDir }, use) => {
+  workspaceDir: async ({ workspaceDir }: { workspaceDir: string }, use: (r: string) => Promise<void>) => {
     const classesDir = path.join(workspaceDir, 'force-app', 'main', 'default', 'classes');
     // Anonymous Apex lives at workspace-root `scripts/apex/` (Salesforce convention; the dir
     // templates scaffold). Not metadata — no `classes/` placement, no `-meta.xml`. jorje's

--- a/packages/salesforcedx-vscode-apex/test/playwright/fixtures/index.ts
+++ b/packages/salesforcedx-vscode-apex/test/playwright/fixtures/index.ts
@@ -5,4 +5,4 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export { desktopTest as test } from './desktopFixtures';
+export { desktopTest as test, snippetDesktopTest as snippetTest } from './desktopFixtures';

--- a/packages/salesforcedx-vscode-apex/test/playwright/specs/apexSnippets.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex/test/playwright/specs/apexSnippets.desktop.spec.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect, type Page } from '@playwright/test';
+import {
+  closeWelcomeTabs,
+  EDITOR_WITH_URI,
+  executeCommandWithCommandPalette,
+  openFileByName,
+  QUICK_INPUT_WIDGET,
+  saveScreenshot,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  validateNoCriticalErrors,
+  waitForExtensionsActivated,
+  waitForQuickInputFirstOption,
+  waitForVSCodeWorkbench,
+  waitForWorkspaceReady
+} from '@salesforce/playwright-vscode-ext';
+
+import { snippetTest as test } from '../fixtures';
+
+/** Monaco may use NBSP; snippets can be one line or multiline — collapse for assertions. */
+const collapseEditorWhitespace = (text: string): string =>
+  text.replaceAll('\u00a0', ' ').replaceAll(/\s+/g, ' ').trim();
+
+const readActiveEditorDocumentText = async (page: Page): Promise<string> => {
+  const viewLines = page.locator(EDITOR_WITH_URI).first().locator('.view-lines').first();
+  await viewLines.waitFor({ state: 'visible', timeout: 10_000 });
+  const raw = await viewLines.textContent();
+  return raw ?? '';
+};
+
+/** Close suggest widget / snippet tab-stop UI so it is not merged into editor text reads. */
+const dismissEditorOverlays = async (page: Page): Promise<void> => {
+  await page.keyboard.press('Escape');
+  await page.keyboard.press('Escape');
+  await page
+    .locator('.suggest-widget')
+    .waitFor({ state: 'hidden', timeout: 3000 })
+    .catch(() => {});
+};
+
+test('Apex snippets: Insert Snippet applies System Debug in .cls', async ({ page }) => {
+  // timeout comes from playwright.config.desktop.ts (timeout: 360_000)
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  await test.step('wait for Salesforce project workspace + marketplace ext', async () => {
+    await waitForVSCodeWorkbench(page);
+    await closeWelcomeTabs(page);
+    await waitForWorkspaceReady(page);
+    // salesforce.apex-language-server-extension (marketplace) ships apex.json snippets; wait until
+    // no extension shows "Activating" so the snippet contribution is registered before insertion.
+    await waitForExtensionsActivated(page);
+    await saveScreenshot(page, 'apex-snippets.workspace-ready.png');
+  });
+
+  await test.step('open ExampleClassTest.cls and position cursor on blank line 7', async () => {
+    // ExampleClassTest.cls is pre-seeded (fixtures/desktopFixtures.ts) with a blank line 7 —
+    // the deterministic snippet insertion target.
+    await openFileByName(page, 'ExampleClassTest.cls');
+    const editor = page.locator(EDITOR_WITH_URI).first();
+    await editor.waitFor({ state: 'visible', timeout: 15_000 });
+    // Snippets are scoped to the active editor language; ensure the .cls editor (apex) has focus.
+    await editor.click();
+    // Move the cursor to the blank line 7 so `System.debug()` lands in a known location.
+    await executeCommandWithCommandPalette(page, 'Go to Line/Column...');
+    await page.keyboard.type('7:1');
+    await page.keyboard.press('Enter');
+    await saveScreenshot(page, 'apex-snippets.editor-open.png');
+  });
+
+  await test.step('insert System Debug snippet', async () => {
+    await executeCommandWithCommandPalette(page, 'Snippets: Insert Snippet');
+    const quickInput = page.locator(QUICK_INPUT_WIDGET);
+    await quickInput.waitFor({ state: 'visible', timeout: 15_000 });
+    // apex.json picker label = JSON key `System Debug`; prefix `debug` matches the fill.
+    await quickInput.locator('input.input').first().fill('debug');
+    await waitForQuickInputFirstOption(page, { optionVisibleTimeout: 10_000 });
+    await page.keyboard.press('Enter');
+    await quickInput.waitFor({ state: 'hidden', timeout: 10_000 }).catch(() => {});
+    await dismissEditorOverlays(page);
+    await saveScreenshot(page, 'apex-snippets.after-insert.png');
+  });
+
+  await test.step('save and assert snippet body', async () => {
+    await dismissEditorOverlays(page);
+    await executeCommandWithCommandPalette(page, 'File: Save');
+    // body `System.debug($0)`; `$0` is the final cursor (empty render) → saved text `System.debug()`.
+    const doc = collapseEditorWhitespace(await readActiveEditorDocumentText(page));
+    expect(doc).toContain('System.debug()');
+    await saveScreenshot(page, 'apex-snippets.saved.png');
+  });
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-apex/test/playwright/specs/apexSnippets.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex/test/playwright/specs/apexSnippets.desktop.spec.ts
@@ -10,6 +10,7 @@ import {
   closeWelcomeTabs,
   EDITOR_WITH_URI,
   executeCommandWithCommandPalette,
+  goToLineCol,
   openFileByName,
   QUICK_INPUT_WIDGET,
   saveScreenshot,
@@ -69,9 +70,10 @@ test('Apex snippets: Insert Snippet applies System Debug in .cls', async ({ page
     // Snippets are scoped to the active editor language; ensure the .cls editor (apex) has focus.
     await editor.click();
     // Move the cursor to the blank line 7 so `System.debug()` lands in a known location.
-    await executeCommandWithCommandPalette(page, 'Go to Line/Column...');
-    await page.keyboard.type('7:1');
-    await page.keyboard.press('Enter');
+    // goToLineCol waits for the Go to Line widget to open before typing and to close after
+    // Enter — the raw type/press sequence raced the widget and left the caret at EOF, so the
+    // snippet landed after the class-closing brace.
+    await goToLineCol(page, 7, 1);
     await saveScreenshot(page, 'apex-snippets.editor-open.png');
   });
 

--- a/packages/salesforcedx-vscode-apex/test/playwright/specs/apexSnippets.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex/test/playwright/specs/apexSnippets.desktop.spec.ts
@@ -92,8 +92,10 @@ test('Apex snippets: Insert Snippet applies System Debug in .cls', async ({ page
     await dismissEditorOverlays(page);
     await executeCommandWithCommandPalette(page, 'File: Save');
     // body `System.debug($0)`; `$0` is the final cursor (empty render) → saved text `System.debug()`.
+    // Assert it landed on blank line 7 (between the assertEquals and the class-closing brace) so a
+    // misfired Go to Line/Column navigation cannot silently pass on a line-agnostic substring match.
     const doc = collapseEditorWhitespace(await readActiveEditorDocumentText(page));
-    expect(doc).toContain('System.debug()');
+    expect(doc).toMatch(/SayHello should greet the name'\);\s*System\.debug\(\)\s*}/);
     await saveScreenshot(page, 'apex-snippets.saved.png');
   });
 

--- a/packages/salesforcedx-vscode-apex/test/playwright/specs/apexSnippets.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex/test/playwright/specs/apexSnippets.desktop.spec.ts
@@ -78,7 +78,14 @@ test('Apex snippets: Insert Snippet applies System Debug in .cls', async ({ page
   });
 
   await test.step('insert System Debug snippet', async () => {
-    await executeCommandWithCommandPalette(page, 'Snippets: Insert Snippet');
+    // preserveSelection: true skips openCommandPalette's workbench focus-click. The seeded file is
+    // only 9 lines in a tall editor pane, so that click lands in the empty area below the last line
+    // and moves the caret to EOF — the snippet then inserts after the class-closing brace instead
+    // of on blank line 7. goToLineCol already gave the editor keyboard focus, so skipping the click
+    // keeps the caret on line 7.
+    await executeCommandWithCommandPalette(page, 'Snippets: Insert Snippet', undefined, {
+      preserveSelection: true
+    });
     const quickInput = page.locator(QUICK_INPUT_WIDGET);
     await quickInput.waitFor({ state: 'visible', timeout: 15_000 });
     // apex.json picker label = JSON key `System Debug`; prefix `debug` matches the fill.


### PR DESCRIPTION
## Summary

- Desktop Playwright e2e for Apex snippet insertion (Insert Snippet → debug)
- Uses marketplace ext `salesforce.apex-language-server-extension` for `apex.json` snippets
- Reuses `ExampleClassTest.cls` blank line 7 from seeded workspace

## Plan

See [.claude/plans/W-22917909.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-22917909-e2e-apex-snippet-insertion-insert-snippe/.claude/plans/W-22917909.md)

## Reviewer notes

**Low:** `readActiveEditorDocumentText` reads Monaco `.view-lines` which virtualizes off-screen lines. Currently correct (ExampleClassTest.cls is 9 lines, well under Monaco's virtualization threshold); flagged as latent fragility only if the fixture grows to hundreds of lines. No code change — no present bug.

**Low:** marketplace ext `salesforce.apex-language-server-extension` installed unpinned (latest) via `code --install-extension --force`, making this e2e a 3rd-party-flakiness vector (apex-oas precedent: all specs skipped on A4V v4 breaking change). Not applied as a code change because pinning a `@version` is a design decision — would freeze coverage to a stale snippet version and require manual bumps; the deterministic `System.debug()` assertion fails fast on breaking changes and CI has retry/sequential fallback. Surface for reviewer to decide on pinning policy.

## Test plan

Automated e2e coverage added in:
- `packages/salesforcedx-vscode-apex/test/playwright/specs/apexSnippets.desktop.spec.ts`

## What issues does this PR fix or reference?

@W-22917909@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.my.salesforce.com/a07EE00002bqsOa