### PR TITLE
refactor(org): use shared buildAllServicesLayer in extensionProvider - W-23069592

### DIFF
--- a/.claude/plans/W-23069592.md
+++ b/.claude/plans/W-23069592.md
@@ -1,0 +1,56 @@
+# W-23069592 — 1.3 Use shared buildAllServicesLayer in org extensionProvider
+
+## Context
+
+- Org ext `extensionProvider.ts` has inline `buildAllServicesLayer` (lines 20-54), duplicate of shared `@salesforce/effect-ext-utils` export.
+- Diff vs shared: inline hardcodes `'Salesforce Org Management'` fallback; shared takes `fallbackDisplayName` param. Otherwise identical.
+- Pattern to mirror: core (`packages/salesforcedx-vscode-core/src/services/extensionProvider.ts`) — local `extensionProvider.ts` keeps only `AllServicesLayer`/`setAllServicesLayer`; imports `buildAllServicesLayer` from `@salesforce/effect-ext-utils`; does NOT re-export it; `index.ts` imports it from shared too and calls `buildAllServicesLayer(ctx, nls.localize('channel_name'))` (core index.ts:49).
+- Shared signature (`node_modules/@salesforce/effect-ext-utils/src/allServicesLayer.ts:27`): `buildAllServicesLayer(context: ExtensionContext, fallbackDisplayName: string)`. Pass `nls.localize('channel_name')` as `fallbackDisplayName`.
+- Org keeps extra runtime helpers: `OrgRuntime` type, `getOrgRuntime`, `resetOrgRuntimeForTesting` — stay in local file.
+- `nls.localize('channel_name')` = `'Salesforce Org Management'` (matches package.json `displayName`).
+- Gates picker + command WIs.
+
+Files:
+- `packages/salesforcedx-vscode-org/src/extensionProvider.ts`
+- `packages/salesforcedx-vscode-org/src/index.ts`
+- `packages/salesforcedx-vscode-org/test/jest/util/orgUtil.test.ts` (cast repoint)
+- `packages/salesforcedx-vscode-org/test/jest/commands/auth/orgLogout.test.ts` (cast repoint)
+- `packages/salesforcedx-vscode-org/test/jest/commands/auth/orgLogoutSelected.test.ts` (cast repoint)
+
+## Phases
+
+### Phase 1 — swap inline for shared helper (mirror core; no re-export)
+
+`extensionProvider.ts`:
+- Delete inline `buildAllServicesLayer` (lines 20-54) + `ExtensionProviderServiceLive`.
+- Import `buildAllServicesLayer` from `@salesforce/effect-ext-utils` (used by the `ReturnType<>` type refs in `AllServicesLayer`/`setAllServicesLayer`/`OrgRuntime`).
+- Do NOT re-export it (matches core; avoids re-exporting a third-party symbol as our own surface).
+- Drop now-unused imports: `ExtensionPackageJsonSchema`, `ExtensionProviderService`, `ExtensionPackageJson`, `getServicesApi`, `Effect`, `Schema`, `ExtensionContext`. `Layer` stays (used by `OrgRuntime` type via `Layer.Layer.Success`/`Layer.Layer.Error`).
+- Keep `AllServicesLayer`, `setAllServicesLayer`, `OrgRuntime` type, `getOrgRuntime`, `resetOrgRuntimeForTesting`, `ManagedRuntime` import.
+
+`index.ts`:
+- Line 29: change import to `import { AllServicesLayer, setAllServicesLayer } from './extensionProvider';` and add `buildAllServicesLayer` to the existing `@salesforce/effect-ext-utils` import (line 8).
+- Line 73: `setAllServicesLayer(buildAllServicesLayer(extensionContext, nls.localize('channel_name')));`.
+- Add `import { nls } from './messages';`.
+
+Test type casts — `buildAllServicesLayer` is no longer re-exported from `./extensionProvider`, so the 3 casts that resolve `ReturnType<typeof ...extensionProvider.buildAllServicesLayer>` will fail to resolve. Repoint them to the shared package:
+- `test/jest/util/orgUtil.test.ts:438` — `extensionProvider.buildAllServicesLayer` → import `buildAllServicesLayer` from `@salesforce/effect-ext-utils` and cast `ReturnType<typeof buildAllServicesLayer>` (namespace import `extensionProvider` still used for `getOrgRuntime` etc.).
+- `test/jest/commands/auth/orgLogout.test.ts:68` — `import('../../../../src/extensionProvider').buildAllServicesLayer` → `import('@salesforce/effect-ext-utils').buildAllServicesLayer`.
+- `test/jest/commands/auth/orgLogoutSelected.test.ts:79` — same repoint as orgLogout.
+
+commit msg: `refactor(org): use shared buildAllServicesLayer in extensionProvider - W-23069592`
+
+## Skills to apply
+
+- effect-best-practices
+- typescript
+- concise (plan/docs)
+- verification
+- playwright-e2e (channel-name e2e is orgPicker.desktop.spec.ts)
+
+## Verification
+
+- `npm run compile` (or package tsc) — type check; confirms removed imports resolve and the 3 repointed test casts resolve `ReturnType<typeof buildAllServicesLayer>` from `@salesforce/effect-ext-utils`.
+- Org jest: `orgUtil.test.ts`, `orgLogout.test.ts`, `orgLogoutSelected.test.ts` reference `buildAllServicesLayer`/`setAllServicesLayer`/`getOrgRuntime` — must pass.
+- lint (no unused imports left; `Layer` retained for `OrgRuntime` type).
+- Runtime channel name unchanged (`'Salesforce Org Management'`). E2E coverage: `packages/salesforcedx-vscode-org/test/playwright/specs/orgPicker.desktop.spec.ts` — `ORG_OUTPUT_CHANNEL = 'Salesforce Org Management'` (line 39), `selectOutputChannel(page, ORG_OUTPUT_CHANNEL)` + `waitForOutputChannelText` (lines 87-88) assert output renders under that exact channel name. If the fallback regressed, this spec fails to find the channel.

--- a/.claude/plans/W-23069592.md
+++ b/.claude/plans/W-23069592.md
@@ -3,12 +3,12 @@
 ## Context
 
 - Org ext `extensionProvider.ts` has inline `buildAllServicesLayer` (lines 20-54), duplicate of shared `@salesforce/effect-ext-utils` export.
-- Diff vs shared: inline hardcodes `'Salesforce Org Management'` fallback; shared takes `fallbackDisplayName` param. Otherwise identical.
+- Diff vs shared: inline hardcodes `'Salesforce Org Management'` fallback; shared takes `fallbackDisplayName` param.
 - Pattern to mirror: core (`packages/salesforcedx-vscode-core/src/services/extensionProvider.ts`) — local `extensionProvider.ts` keeps only `AllServicesLayer`/`setAllServicesLayer`; imports `buildAllServicesLayer` from `@salesforce/effect-ext-utils`; does NOT re-export it; `index.ts` imports it from shared too and calls `buildAllServicesLayer(ctx, nls.localize('channel_name'))` (core index.ts:49).
 - Shared signature (`node_modules/@salesforce/effect-ext-utils/src/allServicesLayer.ts:27`): `buildAllServicesLayer(context: ExtensionContext, fallbackDisplayName: string)`. Pass `nls.localize('channel_name')` as `fallbackDisplayName`.
 - Org keeps extra runtime helpers: `OrgRuntime` type, `getOrgRuntime`, `resetOrgRuntimeForTesting` — stay in local file.
 - `nls.localize('channel_name')` = `'Salesforce Org Management'` (matches package.json `displayName`).
-- Gates picker + command WIs.
+- Gates: picker + command WIs.
 
 Files:
 - `packages/salesforcedx-vscode-org/src/extensionProvider.ts`
@@ -22,9 +22,8 @@ Files:
 ### Phase 1 — swap inline for shared helper (mirror core; no re-export)
 
 `extensionProvider.ts`:
-- Delete inline `buildAllServicesLayer` (lines 20-54) + `ExtensionProviderServiceLive`.
-- Import `buildAllServicesLayer` from `@salesforce/effect-ext-utils` (used by the `ReturnType<>` type refs in `AllServicesLayer`/`setAllServicesLayer`/`OrgRuntime`).
-- Do NOT re-export it (matches core; avoids re-exporting a third-party symbol as our own surface).
+- Delete inline `buildAllServicesLayer` (lines 20-54), `ExtensionProviderServiceLive`.
+- Import `buildAllServicesLayer` from `@salesforce/effect-ext-utils` (used by the `ReturnType<>` type refs in `AllServicesLayer`/`setAllServicesLayer`/`OrgRuntime`); do NOT re-export it (matches core; avoids re-exporting a third-party symbol as our own surface).
 - Drop now-unused imports: `ExtensionPackageJsonSchema`, `ExtensionProviderService`, `ExtensionPackageJson`, `getServicesApi`, `Effect`, `Schema`, `ExtensionContext`. `Layer` stays (used by `OrgRuntime` type via `Layer.Layer.Success`/`Layer.Layer.Error`).
 - Keep `AllServicesLayer`, `setAllServicesLayer`, `OrgRuntime` type, `getOrgRuntime`, `resetOrgRuntimeForTesting`, `ManagedRuntime` import.
 
@@ -50,7 +49,7 @@ commit msg: `refactor(org): use shared buildAllServicesLayer in extensionProvide
 
 ## Verification
 
-- `npm run compile` (or package tsc) — type check; confirms removed imports resolve and the 3 repointed test casts resolve `ReturnType<typeof buildAllServicesLayer>` from `@salesforce/effect-ext-utils`.
+- `npm run compile` (or package tsc) — confirms removed imports + 3 repointed test casts resolve `ReturnType<typeof buildAllServicesLayer>` from `@salesforce/effect-ext-utils`.
 - Org jest: `orgUtil.test.ts`, `orgLogout.test.ts`, `orgLogoutSelected.test.ts` reference `buildAllServicesLayer`/`setAllServicesLayer`/`getOrgRuntime` — must pass.
 - lint (no unused imports left; `Layer` retained for `OrgRuntime` type).
 - Runtime channel name unchanged (`'Salesforce Org Management'`). E2E coverage: `packages/salesforcedx-vscode-org/test/playwright/specs/orgPicker.desktop.spec.ts` — `ORG_OUTPUT_CHANNEL = 'Salesforce Org Management'` (line 39), `selectOutputChannel(page, ORG_OUTPUT_CHANNEL)` + `waitForOutputChannelText` (lines 87-88) assert output renders under that exact channel name. If the fallback regressed, this spec fails to find the channel.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3030,6 +3030,38 @@
         "effect-language-service": "cli.js"
       }
     },
+    "node_modules/@effect/opentelemetry": {
+      "version": "0.63.0",
+      "resolved": "https://registry.npmjs.org/@effect/opentelemetry/-/opentelemetry-0.63.0.tgz",
+      "integrity": "sha512-2yUG2QWNATi1uKP0kwhaP5eLp+c5NDzAL3EOpIcGLBAC0cbXZrx4n9Qw/QwUKxpuV+pbhrBUPCiByyWAFKfuCw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@effect/platform": "^0.96.0",
+        "@opentelemetry/api": "^1.9",
+        "@opentelemetry/resources": "^2.0.0",
+        "@opentelemetry/sdk-logs": ">=0.203.0 <0.300.0",
+        "@opentelemetry/sdk-metrics": "^2.0.0",
+        "@opentelemetry/sdk-trace-base": "^2.0.0",
+        "@opentelemetry/sdk-trace-node": "^2.0.0",
+        "@opentelemetry/sdk-trace-web": "^2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "effect": "^3.21.0"
+      }
+    },
+    "node_modules/@effect/platform": {
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.96.1.tgz",
+      "integrity": "sha512-cjB1QZZYEP8JXCFNGvBLVi0T6YUBQTmOVEUA3SDbiQ6RUO+p6CE3eyD2vMWmrz5nE8yY5QSAuOV9v0boEcUv+A==",
+      "license": "MIT",
+      "dependencies": {
+        "find-my-way-ts": "^0.1.6",
+        "msgpackr": "^1.11.10",
+        "multipasta": "^0.2.7"
+      },
+      "peerDependencies": {
+        "effect": "^3.21.2"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
@@ -44825,8 +44857,10 @@
         "vscode-uri": "^3.0.8"
       },
       "devDependencies": {
+        "@effect/opentelemetry": "0.63.0",
         "@salesforce/playwright-vscode-ext": "*",
-        "jest-junit": "14.0.1"
+        "jest-junit": "14.0.1",
+        "salesforcedx-vscode-services": "*"
       },
       "engines": {
         "vscode": "^1.90.0"
@@ -44917,39 +44951,6 @@
         "ts-node": "^10.9.2"
       }
     },
-    "packages/salesforcedx-vscode-services-types/node_modules/@effect/opentelemetry": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@effect/opentelemetry/-/opentelemetry-0.63.0.tgz",
-      "integrity": "sha512-2yUG2QWNATi1uKP0kwhaP5eLp+c5NDzAL3EOpIcGLBAC0cbXZrx4n9Qw/QwUKxpuV+pbhrBUPCiByyWAFKfuCw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@effect/platform": "^0.96.0",
-        "@opentelemetry/api": "^1.9",
-        "@opentelemetry/resources": "^2.0.0",
-        "@opentelemetry/sdk-logs": ">=0.203.0 <0.300.0",
-        "@opentelemetry/sdk-metrics": "^2.0.0",
-        "@opentelemetry/sdk-trace-base": "^2.0.0",
-        "@opentelemetry/sdk-trace-node": "^2.0.0",
-        "@opentelemetry/sdk-trace-web": "^2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.33.0",
-        "effect": "^3.21.0"
-      }
-    },
-    "packages/salesforcedx-vscode-services-types/node_modules/@effect/platform": {
-      "version": "0.96.1",
-      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.96.1.tgz",
-      "integrity": "sha512-cjB1QZZYEP8JXCFNGvBLVi0T6YUBQTmOVEUA3SDbiQ6RUO+p6CE3eyD2vMWmrz5nE8yY5QSAuOV9v0boEcUv+A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "find-my-way-ts": "^0.1.6",
-        "msgpackr": "^1.11.10",
-        "multipasta": "^0.2.7"
-      },
-      "peerDependencies": {
-        "effect": "^3.21.2"
-      }
-    },
     "packages/salesforcedx-vscode-services-types/node_modules/@opentelemetry/core": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
@@ -44980,38 +44981,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "packages/salesforcedx-vscode-services/node_modules/@effect/opentelemetry": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@effect/opentelemetry/-/opentelemetry-0.63.0.tgz",
-      "integrity": "sha512-2yUG2QWNATi1uKP0kwhaP5eLp+c5NDzAL3EOpIcGLBAC0cbXZrx4n9Qw/QwUKxpuV+pbhrBUPCiByyWAFKfuCw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@effect/platform": "^0.96.0",
-        "@opentelemetry/api": "^1.9",
-        "@opentelemetry/resources": "^2.0.0",
-        "@opentelemetry/sdk-logs": ">=0.203.0 <0.300.0",
-        "@opentelemetry/sdk-metrics": "^2.0.0",
-        "@opentelemetry/sdk-trace-base": "^2.0.0",
-        "@opentelemetry/sdk-trace-node": "^2.0.0",
-        "@opentelemetry/sdk-trace-web": "^2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.33.0",
-        "effect": "^3.21.0"
-      }
-    },
-    "packages/salesforcedx-vscode-services/node_modules/@effect/platform": {
-      "version": "0.96.1",
-      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.96.1.tgz",
-      "integrity": "sha512-cjB1QZZYEP8JXCFNGvBLVi0T6YUBQTmOVEUA3SDbiQ6RUO+p6CE3eyD2vMWmrz5nE8yY5QSAuOV9v0boEcUv+A==",
-      "license": "MIT",
-      "dependencies": {
-        "find-my-way-ts": "^0.1.6",
-        "msgpackr": "^1.11.10",
-        "multipasta": "^0.2.7"
-      },
-      "peerDependencies": {
-        "effect": "^3.21.2"
       }
     },
     "packages/salesforcedx-vscode-services/node_modules/@opentelemetry/core": {

--- a/packages/salesforcedx-vscode-org/package.json
+++ b/packages/salesforcedx-vscode-org/package.json
@@ -38,8 +38,10 @@
     "vscode-uri": "^3.0.8"
   },
   "devDependencies": {
+    "@effect/opentelemetry": "0.63.0",
     "@salesforce/playwright-vscode-ext": "*",
-    "jest-junit": "14.0.1"
+    "jest-junit": "14.0.1",
+    "salesforcedx-vscode-services": "*"
   },
   "extensionDependencies": [
     "salesforce.salesforcedx-vscode-services"

--- a/packages/salesforcedx-vscode-org/src/extensionProvider.ts
+++ b/packages/salesforcedx-vscode-org/src/extensionProvider.ts
@@ -5,53 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import {
-  ExtensionPackageJsonSchema,
-  ExtensionProviderService,
-  type ExtensionPackageJson,
-  getServicesApi
-} from '@salesforce/effect-ext-utils';
-import * as Effect from 'effect/Effect';
+import { buildAllServicesLayer } from '@salesforce/effect-ext-utils';
 import * as Layer from 'effect/Layer';
 import * as ManagedRuntime from 'effect/ManagedRuntime';
-import * as Schema from 'effect/Schema';
-import type { ExtensionContext } from 'vscode';
-
-const ExtensionProviderServiceLive = Layer.effect(
-  ExtensionProviderService,
-  Effect.sync(() => ({
-    getServicesApi
-  }))
-);
-
-/**
- * Factory for a Layer that provides all services from the SalesforceVSCodeServicesApi.
- * Pass the ExtensionContext to include a working ExtensionContextServiceLayer.
- * When context is not provided, ExtensionContextService.Default is used (fails if getContext is called).
- */
-export const buildAllServicesLayer = (context: ExtensionContext) =>
-  Layer.unwrapEffect(
-    Effect.gen(function* () {
-      const extensionProvider = yield* ExtensionProviderService;
-      const api = yield* extensionProvider.getServicesApi;
-      const emptyPjson: ExtensionPackageJson = {};
-      const pjson = yield* Schema.decodeUnknown(ExtensionPackageJsonSchema)(context.extension.packageJSON).pipe(
-        Effect.catchAll(() => Effect.succeed(emptyPjson))
-      );
-      const displayName = pjson.displayName ?? 'Salesforce Org Management';
-      // ErrorHandlerService depends on ChannelService, provide the extension's channel
-      const channelLayer = api.services.ChannelServiceLayer(displayName);
-      const errorHandlerWithChannel = Layer.provide(api.services.ErrorHandlerService.Default, channelLayer);
-      return Layer.mergeAll(
-        Layer.succeedContext(api.services.prebuiltServicesDependencies),
-        ExtensionProviderServiceLive,
-        api.services.ExtensionContextServiceLayer(context),
-        api.services.SdkLayerFor(context),
-        channelLayer,
-        errorHandlerWithChannel
-      );
-    }).pipe(Effect.provide(ExtensionProviderServiceLive))
-  );
 
 /**
  * Layer that provides all services from the SalesforceVSCodeServicesApi.

--- a/packages/salesforcedx-vscode-org/src/index.ts
+++ b/packages/salesforcedx-vscode-org/src/index.ts
@@ -5,7 +5,12 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { closeExtensionScope, ExtensionProviderService, getExtensionScope } from '@salesforce/effect-ext-utils';
+import {
+  buildAllServicesLayer,
+  closeExtensionScope,
+  ExtensionProviderService,
+  getExtensionScope
+} from '@salesforce/effect-ext-utils';
 import type { SalesforceVSCodeOrgApi } from '@salesforce/salesforcedx-utils-vscode';
 import * as Effect from 'effect/Effect';
 import * as Scope from 'effect/Scope';
@@ -26,7 +31,8 @@ import {
 } from './commands';
 import { orgDeleteDefaultCommand } from './commands/orgDelete';
 import { ORG_OPEN_COMMAND } from './constants';
-import { AllServicesLayer, buildAllServicesLayer, setAllServicesLayer } from './extensionProvider';
+import { AllServicesLayer, setAllServicesLayer } from './extensionProvider';
+import { nls } from './messages';
 import { createOrgPicker, setDefaultOrg } from './orgPicker/orgList';
 import { checkForSoonToBeExpiredOrgs } from './util/orgUtil';
 
@@ -70,7 +76,7 @@ export const activate = async (extensionContext: vscode.ExtensionContext): Promi
   console.log('Salesforce Org Management extension activated');
 
   const extensionScope = Effect.runSync(getExtensionScope());
-  setAllServicesLayer(buildAllServicesLayer(extensionContext));
+  setAllServicesLayer(buildAllServicesLayer(extensionContext, nls.localize('channel_name')));
   await Effect.runPromise(
     activateEffect(extensionContext).pipe(Effect.provide(AllServicesLayer)).pipe(Scope.extend(extensionScope))
   );

--- a/packages/salesforcedx-vscode-org/src/index.ts
+++ b/packages/salesforcedx-vscode-org/src/index.ts
@@ -76,6 +76,7 @@ export const activate = async (extensionContext: vscode.ExtensionContext): Promi
   console.log('Salesforce Org Management extension activated');
 
   const extensionScope = Effect.runSync(getExtensionScope());
+  // fallbackDisplayName only fires if package.json displayName is absent; channel_name must match displayName ('Salesforce Org Management')
   setAllServicesLayer(buildAllServicesLayer(extensionContext, nls.localize('channel_name')));
   await Effect.runPromise(
     activateEffect(extensionContext).pipe(Effect.provide(AllServicesLayer)).pipe(Scope.extend(extensionScope))

--- a/packages/salesforcedx-vscode-org/test/jest/commands/auth/orgLogout.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/commands/auth/orgLogout.test.ts
@@ -65,7 +65,7 @@ describe('OrgLogoutDefault', () => {
 
     resetOrgRuntimeForTesting();
     setAllServicesLayer(
-      buildLayer() as ReturnType<typeof import('../../../../src/extensionProvider').buildAllServicesLayer>
+      buildLayer() as ReturnType<typeof import('@salesforce/effect-ext-utils').buildAllServicesLayer>
     );
   });
 

--- a/packages/salesforcedx-vscode-org/test/jest/commands/auth/orgLogoutSelected.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/commands/auth/orgLogoutSelected.test.ts
@@ -76,7 +76,7 @@ describe('OrgLogoutSelected', () => {
 
     resetOrgRuntimeForTesting();
     setAllServicesLayer(
-      buildLayer() as ReturnType<typeof import('../../../../src/extensionProvider').buildAllServicesLayer>
+      buildLayer() as ReturnType<typeof import('@salesforce/effect-ext-utils').buildAllServicesLayer>
     );
   });
 

--- a/packages/salesforcedx-vscode-org/test/jest/util/orgUtil.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/util/orgUtil.test.ts
@@ -7,6 +7,7 @@
 
 import { AuthInfo, Config, Org, StateAggregator, OrgConfigProperties } from '@salesforce/core';
 import {
+  buildAllServicesLayer,
   ExtensionProviderService,
   type ExtensionProviderService as ExtensionProviderServiceType
 } from '@salesforce/effect-ext-utils';
@@ -435,7 +436,7 @@ describe('updateConfigAndStateAggregators', () => {
     });
 
     resetOrgRuntimeForTesting();
-    setAllServicesLayer(layer as ReturnType<typeof extensionProvider.buildAllServicesLayer>);
+    setAllServicesLayer(layer as ReturnType<typeof buildAllServicesLayer>);
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

- Replace inline `buildAllServicesLayer` in org ext with shared `@salesforce/effect-ext-utils` export
- Mirror core pattern: local `extensionProvider.ts` no longer re-exports shared helper; `index.ts` imports it directly and passes `nls.localize('channel_name')` as fallback
- Repoint 3 test casts from local re-export to shared package

## Plan

[.claude/plans/W-23069592.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23069592-1-3-use-shared-buildallserviceslayer-in/.claude/plans/W-23069592.md)

## Test plan

- Verify channel name remains 'Salesforce Org Management' via `packages/salesforcedx-vscode-org/test/playwright/specs/orgPicker.desktop.spec.ts` (e2e assertions confirm output renders under the exact channel name)

### What issues does this PR fix or reference?

@W-23069592@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cX0StYAK/view