### PR TITLE
fix(apex-replay-debugger): expand nested related-object variables - W-11173323

### DIFF
--- a/.claude/plans/W-11173323.md
+++ b/.claude/plans/W-11173323.md
@@ -2,15 +2,15 @@
 
 ## Context
 
-- Origin: GitHub #4065. Replay-debugger only (live debugger has different data model: protocol `Value` vs `ApexVariableContainer`).
+- GitHub #4065. Replay-debugger only (live debugger: protocol `Value` vs `ApexVariableContainer`).
 - Symptom: VARIABLES panel + hover — nested related-object values (parent SObject rels, multi-level parent hierarchy, child subqueries) render `[object Object]`, not expandable.
-- Root cause: `packages/salesforcedx-apex-replay-debugger/src/states/variableAssignmentState.ts` `parseJSONAndPopulate` (L134-143). Non-string, non-ref value (nested object/array) → string-coerced `${varValue}` = `[object Object]`; container stays `variablesRef = 0`.
-- Correct pattern lives in `core/heapDumpService.ts` (`copyReferenceContainer` sets `variablesRef`; `createStringFromVarContainer` builds display string).
+- Root: `packages/salesforcedx-apex-replay-debugger/src/states/variableAssignmentState.ts` `parseJSONAndPopulate` (L134-143). Non-string, non-ref value (nested object/array) → string-coerced `${varValue}` = `[object Object]`; container stays `variablesRef = 0`.
+- Pattern in `core/heapDumpService.ts` (`copyReferenceContainer` sets `variablesRef`; `createStringFromVarContainer` builds display string).
 - `createStringFromVarContainer` is `private` in `heapDumpService.ts` (L275); deps: `isCollectionType` (private, L344) + `LC_APEX_PRIMITIVE_STRING` const.
 
 ### Data-model facts (verified)
 
-- VARIABLE_ASSIGNMENT JSON for nested SObject rels carries **no type metadata** — values are plain JSON: `{"Name":"MyObjectAccount"}`, `{"a":"0x..."}` (see existing fixtures `variableAssignmentState.test.ts` L113, L233, L248). No `attributes.type`. Confirms the type-loss decision below.
+- VARIABLE_ASSIGNMENT JSON for nested SObject rels carries **no type metadata** — values are plain JSON: `{"Name":"MyObjectAccount"}`, `{"a":"0x..."}` (see existing fixtures `variableAssignmentState.test.ts` L113, L233, L248). No `attributes.type`. Confirms type-loss decision below.
 - Child subqueries arrive as arrays of records. `typeof [] === 'object'`, so the existing else-branch must explicitly distinguish array vs object to key children correctly.
 
 ## Phases
@@ -19,26 +19,26 @@
 
 - New `src/core/variableContainerStrings.ts` exporting `createStringFromVarContainer(varContainer, visitedSet)` + helper `isCollectionType`. Operates on `ApexVariableContainer`. Pure (no `this`/`logContext`); `const` arrow fns, not `function`.
 - `heapDumpService.ts`: delete private `createStringFromVarContainer` + private `isCollectionType`; import directly from new module (no barrel); update 4 call sites (drop `this.`).
-- No behavior change; existing heap-dump tests cover.
+- No behavior change; existing tests cover.
 - commit: `refactor(apex-replay-debugger): extract createStringFromVarContainer to shared module - W-11173323`
 
 ### Phase 2 — fix nested non-primitive vals in parseJSONAndPopulate
 
 `variableAssignmentState.ts` `parseJSONAndPopulate` else-branch (L135-142). Today: `typeof varValue === 'string'` handled; everything else string-coerced. Replace the non-string handling:
 
-- **Primitive non-string** (number/boolean/null): keep current `${varValue}` coercion (correct — yields `3.14`, `true`).
+- **Primitive non-string** (number/boolean/null): keep `${varValue}` coercion (correct — yields `3.14`, `true`).
 - **Non-null object** (`varValue !== null && typeof varValue === 'object'`): build a nested expandable container.
   - `const nested = new ApexVariableContainer(key, '', '')` — see type decision below.
   - `nested.variablesRef = logContext.getVariableHandler().create(nested)` (nonzero ref → expandable twistie).
-  - Populate children by recursing on the **already-parsed** sub-value, not by re-stringify/re-parse. Add a private helper `populateFromParsed(parsedObj, container, logContext)` that holds the `Object.keys` loop body extracted from `parseJSONAndPopulate`; have `parseJSONAndPopulate` call it after `JSON.parse`. Recurse `populateFromParsed(varValue, nested, logContext)`. This avoids re-running `surroundBlobsWithQuotes`/re-`JSON.stringify` on inner values (no raw blobs in nested SObject rels, but re-stringify would mangle already-quoted strings).
-  - **Array branch** (`Array.isArray(varValue)`): same container creation, but iterate `varValue.entries()` — keys are the numeric index as string (`index.toString()`), value recursed the same way (object element → nested container, primitive element → primitive container). This handles child-subquery `records` arrays. Note `records` in subqueries is itself an object `{ "records": [...] }`, so an object container holding an array container holding per-record containers.
-  - Display string: `nested.value = createStringFromVarContainer(nested, new Set())` from Phase 1 module. With `type=''` and no `ref`, `createStringFromVarContainer` returns `nested.value` immediately (early-return at L277-278 when `!varContainer.ref`) — so set `nested.value` from the children **before** calling, or set a `ref` placeholder. Resolve during implementation: simplest is to give `nested` a synthetic ref-less object string built by joining child `name=value` pairs (mirror the `{...}` branch of `createStringFromVarContainer` for the no-ref case). Spelled out: because nested containers have no heap `ref`, `createStringFromVarContainer` will not recurse them. Decision: set `nested.value` to `''` and rely on the expand twistie (variablesRef) for the user to drill in — the panel shows children, not the coerced string. Confirm in Phase 4 e2e that twistie + children render and `[object Object]` is gone; the top-level value text being empty is acceptable (matches how `{}`-rooted containers already display).
+  - Populate children from parsed sub-value, not re-stringify/re-parse. Helper `populateFromParsed(parsedObj, container, logContext)` holds `Object.keys` loop body; call after `JSON.parse`. Recurse `populateFromParsed(varValue, nested, logContext)`. Avoids re-running `surroundBlobsWithQuotes`/re-`JSON.stringify` (would mangle quoted strings).
+  - **Array branch** (`Array.isArray(varValue)`): same container creation, iterate `varValue.entries()` — keys numeric index as string (`index.toString()`), value recursed same way (object → nested container, primitive → primitive container). Handles child-subquery `records` arrays. `records` is itself object `{ "records": [...] }`, so object container holding array container holding per-record containers.
+  - Display string: `nested.value = createStringFromVarContainer(nested, new Set())`. `type=''` + no `ref` → early-return at L277-278. Decision: set `nested.value = ''`, rely on expand twistie (variablesRef) for drill-in. Phase 4 e2e confirms twistie + children render, no `[object Object]`.
 - Keep string + heap-ref branches unchanged.
 - commit: `fix(apex-replay-debugger): expand nested related-object vars - W-11173323`
 
 #### Type decision (addresses type-loss finding)
 
-`type=''` for nested containers is **acceptable degradation**, documented in-code: VARIABLE_ASSIGNMENT JSON does not include nested SObject type info (verified — fixtures carry only field name/value, no `attributes.type`). The heap-dump path preserves types only because it reads them from a separate `HeapDumpExtentValue` source unavailable in the VARIABLE_ASSIGNMENT stream. `type=''` is already what the existing string/primitive nested containers use (L142, L80), so this is consistent, not a regression. Add a code comment citing this so future readers don't try to "fix" it.
+`type=''` for nested containers is **acceptable degradation**, documented in-code: VARIABLE_ASSIGNMENT JSON does not include nested SObject type info (verified — fixtures carry only field name/value, no `attributes.type`). Heap-dump path preserves types via separate `HeapDumpExtentValue` source unavailable in VARIABLE_ASSIGNMENT stream. `type=''` is already what the existing string/primitive nested containers use (L142, L80), consistent, not regression. Add a code comment citing this so future readers don't try to "fix" it.
 
 ### Phase 3 — unit tests
 
@@ -51,7 +51,7 @@
 
 ### Phase 4 — e2e coverage (addresses e2e finding)
 
-Add a VARIABLES-panel assertion to the desktop Playwright suite. Existing specs launch sessions but never assert panel content; this closes that gap for the actual user-facing symptom.
+Add VARIABLES-panel assertion to desktop Playwright suite. Existing specs launch sessions, never assert panel content; closes gap for user-facing symptom.
 
 - File: `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebugger.desktop.spec.ts` (extend; reuse existing org/trace-flag/exec-anon scaffolding).
 - New Apex class under test builds nested SObject rels in memory so they appear as locals at a breakpoint, e.g.:
@@ -60,9 +60,9 @@ Add a VARIABLES-panel assertion to the desktop Playwright suite. Existing specs 
   Contact c = new Contact(LastName='Bond', Account=a);
   System.debug(c); // breakpoint line
   ```
-  (rel must be populated so the log emits a nested-object VARIABLE_ASSIGNMENT; verify the generated `.log` actually contains a `{...}` nested assignment before asserting — if exec-anon locals don't serialize rels, fall back to a class method with the rel as a member so it serializes).
+  (rel must be populated for log to emit nested-object VARIABLE_ASSIGNMENT; verify `.log` contains `{...}` before asserting — if exec-anon locals don't serialize rels, use class method with rel as member).
 - Steps: deploy class → trace flag → exec → open log → set breakpoint on the `System.debug` line → launch replay with selected file → wait for debug toolbar (paused).
-- VARIABLES assertions (use `@salesforce/playwright-vscode-ext` debug helpers; confirm available selectors during implementation — the Variables view rows are `.debug-variables` / `.monaco-list-row` with `.expand`/`.collapsible` twisties):
+- VARIABLES assertions (use `@salesforce/playwright-vscode-ext` debug helpers; confirm selectors — Variables view rows: `.debug-variables` / `.monaco-list-row` with `.expand`/`.collapsible` twisties):
   1. Locate the nested variable row (the Contact/Account local).
   2. Assert its value text does **not** contain `[object Object]`.
   3. Assert it has an expand twistie (collapsible affordance present).

--- a/.claude/plans/W-11173323.md
+++ b/.claude/plans/W-11173323.md
@@ -1,0 +1,89 @@
+# W-11173323 — Replay debugger: nested related-object vars show `[object Object]`
+
+## Context
+
+- Origin: GitHub #4065. Replay-debugger only (live debugger has different data model: protocol `Value` vs `ApexVariableContainer`).
+- Symptom: VARIABLES panel + hover — nested related-object values (parent SObject rels, multi-level parent hierarchy, child subqueries) render `[object Object]`, not expandable.
+- Root cause: `packages/salesforcedx-apex-replay-debugger/src/states/variableAssignmentState.ts` `parseJSONAndPopulate` (L134-143). Non-string, non-ref value (nested object/array) → string-coerced `${varValue}` = `[object Object]`; container stays `variablesRef = 0`.
+- Correct pattern lives in `core/heapDumpService.ts` (`copyReferenceContainer` sets `variablesRef`; `createStringFromVarContainer` builds display string).
+- `createStringFromVarContainer` is `private` in `heapDumpService.ts` (L275); deps: `isCollectionType` (private, L344) + `LC_APEX_PRIMITIVE_STRING` const.
+
+### Data-model facts (verified)
+
+- VARIABLE_ASSIGNMENT JSON for nested SObject rels carries **no type metadata** — values are plain JSON: `{"Name":"MyObjectAccount"}`, `{"a":"0x..."}` (see existing fixtures `variableAssignmentState.test.ts` L113, L233, L248). No `attributes.type`. Confirms the type-loss decision below.
+- Child subqueries arrive as arrays of records. `typeof [] === 'object'`, so the existing else-branch must explicitly distinguish array vs object to key children correctly.
+
+## Phases
+
+### Phase 1 — extract shared `createStringFromVarContainer`
+
+- New `src/core/variableContainerStrings.ts` exporting `createStringFromVarContainer(varContainer, visitedSet)` + helper `isCollectionType`. Operates on `ApexVariableContainer`. Pure (no `this`/`logContext`); `const` arrow fns, not `function`.
+- `heapDumpService.ts`: delete private `createStringFromVarContainer` + private `isCollectionType`; import directly from new module (no barrel); update 4 call sites (drop `this.`).
+- No behavior change; existing heap-dump tests cover.
+- commit: `refactor(apex-replay-debugger): extract createStringFromVarContainer to shared module - W-11173323`
+
+### Phase 2 — fix nested non-primitive vals in parseJSONAndPopulate
+
+`variableAssignmentState.ts` `parseJSONAndPopulate` else-branch (L135-142). Today: `typeof varValue === 'string'` handled; everything else string-coerced. Replace the non-string handling:
+
+- **Primitive non-string** (number/boolean/null): keep current `${varValue}` coercion (correct — yields `3.14`, `true`).
+- **Non-null object** (`varValue !== null && typeof varValue === 'object'`): build a nested expandable container.
+  - `const nested = new ApexVariableContainer(key, '', '')` — see type decision below.
+  - `nested.variablesRef = logContext.getVariableHandler().create(nested)` (nonzero ref → expandable twistie).
+  - Populate children by recursing on the **already-parsed** sub-value, not by re-stringify/re-parse. Add a private helper `populateFromParsed(parsedObj, container, logContext)` that holds the `Object.keys` loop body extracted from `parseJSONAndPopulate`; have `parseJSONAndPopulate` call it after `JSON.parse`. Recurse `populateFromParsed(varValue, nested, logContext)`. This avoids re-running `surroundBlobsWithQuotes`/re-`JSON.stringify` on inner values (no raw blobs in nested SObject rels, but re-stringify would mangle already-quoted strings).
+  - **Array branch** (`Array.isArray(varValue)`): same container creation, but iterate `varValue.entries()` — keys are the numeric index as string (`index.toString()`), value recursed the same way (object element → nested container, primitive element → primitive container). This handles child-subquery `records` arrays. Note `records` in subqueries is itself an object `{ "records": [...] }`, so an object container holding an array container holding per-record containers.
+  - Display string: `nested.value = createStringFromVarContainer(nested, new Set())` from Phase 1 module. With `type=''` and no `ref`, `createStringFromVarContainer` returns `nested.value` immediately (early-return at L277-278 when `!varContainer.ref`) — so set `nested.value` from the children **before** calling, or set a `ref` placeholder. Resolve during implementation: simplest is to give `nested` a synthetic ref-less object string built by joining child `name=value` pairs (mirror the `{...}` branch of `createStringFromVarContainer` for the no-ref case). Spelled out: because nested containers have no heap `ref`, `createStringFromVarContainer` will not recurse them. Decision: set `nested.value` to `''` and rely on the expand twistie (variablesRef) for the user to drill in — the panel shows children, not the coerced string. Confirm in Phase 4 e2e that twistie + children render and `[object Object]` is gone; the top-level value text being empty is acceptable (matches how `{}`-rooted containers already display).
+- Keep string + heap-ref branches unchanged.
+- commit: `fix(apex-replay-debugger): expand nested related-object vars - W-11173323`
+
+#### Type decision (addresses type-loss finding)
+
+`type=''` for nested containers is **acceptable degradation**, documented in-code: VARIABLE_ASSIGNMENT JSON does not include nested SObject type info (verified — fixtures carry only field name/value, no `attributes.type`). The heap-dump path preserves types only because it reads them from a separate `HeapDumpExtentValue` source unavailable in the VARIABLE_ASSIGNMENT stream. `type=''` is already what the existing string/primitive nested containers use (L142, L80), so this is consistent, not a regression. Add a code comment citing this so future readers don't try to "fix" it.
+
+### Phase 3 — unit tests
+
+`test/unit/states/variableAssignmentState.test.ts`:
+- Multi-level parent fixture: `{"Name":"A","Parent":{"Name":"P","Parent":{"Name":"GP"}}}`.
+- Child-subquery fixture: `{"Name":"A","Contacts":{"records":[{"LastName":"X"},{"LastName":"Y"}]}}`.
+- Assert: every nested object/array container gets nonzero `variablesRef` (expandable); array container keyed by `'0'`,`'1'`; leaf primitives (`Name`, `LastName`) have correct quoted/coerced values; **no `value` field anywhere equals `'[object Object]'`** (walk the container tree).
+- Assert recursion does not re-quote already-quoted strings (regression guard for the parse-once refactor).
+- commit: `test(apex-replay-debugger): nested related-object expansion in replay debugger - W-11173323`
+
+### Phase 4 — e2e coverage (addresses e2e finding)
+
+Add a VARIABLES-panel assertion to the desktop Playwright suite. Existing specs launch sessions but never assert panel content; this closes that gap for the actual user-facing symptom.
+
+- File: `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebugger.desktop.spec.ts` (extend; reuse existing org/trace-flag/exec-anon scaffolding).
+- New Apex class under test builds nested SObject rels in memory so they appear as locals at a breakpoint, e.g.:
+  ```apex
+  Account a = new Account(Name='Acme');
+  Contact c = new Contact(LastName='Bond', Account=a);
+  System.debug(c); // breakpoint line
+  ```
+  (rel must be populated so the log emits a nested-object VARIABLE_ASSIGNMENT; verify the generated `.log` actually contains a `{...}` nested assignment before asserting — if exec-anon locals don't serialize rels, fall back to a class method with the rel as a member so it serializes).
+- Steps: deploy class → trace flag → exec → open log → set breakpoint on the `System.debug` line → launch replay with selected file → wait for debug toolbar (paused).
+- VARIABLES assertions (use `@salesforce/playwright-vscode-ext` debug helpers; confirm available selectors during implementation — the Variables view rows are `.debug-variables` / `.monaco-list-row` with `.expand`/`.collapsible` twisties):
+  1. Locate the nested variable row (the Contact/Account local).
+  2. Assert its value text does **not** contain `[object Object]`.
+  3. Assert it has an expand twistie (collapsible affordance present).
+  4. Expand it; assert a child property row (e.g. `Name` / `LastName`) becomes visible.
+  5. `saveScreenshot` of expanded VARIABLES panel.
+- Run via `playwright-e2e` skill conventions; gate on existing desktop-spec timeouts (`test.setTimeout(600_000)`).
+- commit: `test(apex-replay-debugger): e2e VARIABLES nested object expansion - W-11173323`
+
+## Skills to apply
+
+- playwright-e2e (Phase 4)
+- typescript
+- concise
+- changelog (user-facing fix — changelog entry at PR)
+- verification
+
+## Verification
+
+- `npm run compile` clean.
+- Unit tests pass: `variableAssignmentState.test.ts` (new + existing), `heapDumpService`, variable-handling (Phase 1 regression check).
+- Container-tree walk in unit test confirms no `value === '[object Object]'`.
+- Phase 4 e2e green: nested var expandable, child props visible, no `[object Object]`, screenshot saved.
+</content>
+</invoke>

--- a/packages/salesforcedx-apex-replay-debugger/src/core/heapDumpService.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/core/heapDumpService.ts
@@ -32,6 +32,7 @@ import {
   LC_APEX_PRIMITIVE_TIME
 } from '../constants';
 import { LogContext } from './logContext';
+import { createStringFromVarContainer, isCollectionType } from './variableContainerStrings';
 
 const isAddress = (value: any): boolean => typeof value === 'string' && value.startsWith(ADDRESS_PREFIX);
 
@@ -55,11 +56,6 @@ const PRIMITIVE_TYPES = new Set([
 
 const isPrimitiveType = (typeName: string): boolean => PRIMITIVE_TYPES.has(typeName.toLocaleLowerCase());
 
-const isCollectionType = (typeName: string): boolean =>
-  typeName.toLocaleLowerCase().startsWith('map<') ||
-  typeName.toLocaleLowerCase().startsWith('list<') ||
-  typeName.toLocaleLowerCase().startsWith('set<');
-
 // The typename can contain a bunch of nested types. If this is a collection of
 // collections then the collectionType won't be null.
 // typeName: the full typeName of the Map
@@ -77,63 +73,6 @@ const isTriggerExtent = (outerExtent: HeapDumpExtents): boolean =>
   outerExtent.extent[0].symbols !== null &&
   outerExtent.extent[0].symbols.length > 0 &&
   outerExtent.extent[0].symbols[0].startsWith(EXTENT_TRIGGER_PREFIX);
-
-// The way the variables are displayed in the variable's window is <varName>:<value>
-// and the value is basically a 'toString' of the variable. This is easy enough for
-// primitive types but for things like collections it ends up being something like
-// MyStrList: ('1','2','3') which when expanded looks like
-// MyStrList: ('1','2','3')
-//   0: '1'
-//   1: '2'
-//   2: '3'
-const createStringFromVarContainer = (varContainer: ApexVariableContainer, visitedSet: Set<string>): string => {
-  // If the varContainer isn't a reference or is a string references
-  if (!varContainer.ref || varContainer.type.toLowerCase() === LC_APEX_PRIMITIVE_STRING) {
-    return varContainer.value;
-  }
-
-  // If the varContainer is a ref and it's already been visited then return the string
-  if (varContainer.ref) {
-    if (visitedSet.has(varContainer.ref)) {
-      return 'already output';
-    } else {
-      visitedSet.add(varContainer.ref);
-    }
-  }
-  let returnString = '';
-  try {
-    // For a list or set the name string is going to end up being (<val1>,...<valX)
-    // For a objects, the name string is going to end up being <TypeName>: {<Name1>=<Value1>,...<NameX>=<ValueX>}
-    const isListOrSet =
-      varContainer.type.toLowerCase().startsWith('list<') || varContainer.type.toLowerCase().startsWith('set<');
-    // The live debugger, for collections, doesn't include their type in variable name/value
-    const containerType = isCollectionType(varContainer.type) ? '' : `${varContainer.type}:`;
-    returnString = isListOrSet ? '(' : `${containerType}{`;
-    let first = true;
-    // Loop through each of the container's variables to get the name/value combinations, calling to create
-    // the string if another collection is found.
-    for (const entry of Array.from(varContainer.variables.entries())) {
-      const valueAsApexVar = entry[1];
-      if (!first) {
-        returnString += ', ';
-      }
-      if (valueAsApexVar.ref) {
-        // if this is also a ref then create the string from that
-        returnString += createStringFromVarContainer(valueAsApexVar, visitedSet);
-      } else {
-        // otherwise get the name/value from the variable
-        returnString += isListOrSet ? valueAsApexVar.value : `${valueAsApexVar.name}=${valueAsApexVar.value}`;
-      }
-      first = false;
-    }
-    returnString += isListOrSet ? ')' : '}';
-  } finally {
-    if (varContainer.ref) {
-      visitedSet.delete(varContainer.ref);
-    }
-  }
-  return returnString;
-};
 
 export class HeapDumpService {
   private logContext: LogContext;

--- a/packages/salesforcedx-apex-replay-debugger/src/core/variableContainerStrings.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/core/variableContainerStrings.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { ApexVariableContainer } from '../adapter/variableContainer';
+import { LC_APEX_PRIMITIVE_STRING } from '../constants';
+
+export const isCollectionType = (typeName: string): boolean =>
+  typeName.toLocaleLowerCase().startsWith('map<') ||
+  typeName.toLocaleLowerCase().startsWith('list<') ||
+  typeName.toLocaleLowerCase().startsWith('set<');
+
+// The way the variables are displayed in the variable's window is <varName>:<value>
+// and the value is basically a 'toString' of the variable. This is easy enough for
+// primitive types but for things like collections it ends up being something like
+// MyStrList: ('1','2','3') which when expanded looks like
+// MyStrList: ('1','2','3')
+//   0: '1'
+//   1: '2'
+//   2: '3'
+/** build the display string for a variable container, recursing into nested references */
+export const createStringFromVarContainer = (varContainer: ApexVariableContainer, visitedSet: Set<string>): string => {
+  // If the varContainer isn't a reference or is a string references
+  if (!varContainer.ref || varContainer.type.toLowerCase() === LC_APEX_PRIMITIVE_STRING) {
+    return varContainer.value;
+  }
+
+  // If the varContainer is a ref and it's already been visited then return the string
+  if (varContainer.ref) {
+    if (visitedSet.has(varContainer.ref)) {
+      return 'already output';
+    } else {
+      visitedSet.add(varContainer.ref);
+    }
+  }
+  let returnString = '';
+  try {
+    // For a list or set the name string is going to end up being (<val1>,...<valX)
+    // For a objects, the name string is going to end up being <TypeName>: {<Name1>=<Value1>,...<NameX>=<ValueX>}
+    const isListOrSet =
+      varContainer.type.toLowerCase().startsWith('list<') || varContainer.type.toLowerCase().startsWith('set<');
+    // The live debugger, for collections, doesn't include their type in variable name/value
+    const containerType = isCollectionType(varContainer.type) ? '' : `${varContainer.type}:`;
+    returnString = isListOrSet ? '(' : `${containerType}{`;
+    let first = true;
+    // Loop through each of the container's variables to get the name/value combinations, calling to create
+    // the string if another collection is found.
+    for (const entry of Array.from(varContainer.variables.entries())) {
+      const valueAsApexVar = entry[1];
+      if (!first) {
+        returnString += ', ';
+      }
+      if (valueAsApexVar.ref) {
+        // if this is also a ref then create the string from that
+        returnString += createStringFromVarContainer(valueAsApexVar, visitedSet);
+      } else {
+        // otherwise get the name/value from the variable
+        returnString += isListOrSet ? valueAsApexVar.value : `${valueAsApexVar.name}=${valueAsApexVar.value}`;
+      }
+      first = false;
+    }
+    returnString += isListOrSet ? ')' : '}';
+  } finally {
+    if (varContainer.ref) {
+      visitedSet.delete(varContainer.ref);
+    }
+  }
+  return returnString;
+};

--- a/packages/salesforcedx-apex-replay-debugger/src/states/variableAssignmentState.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/states/variableAssignmentState.ts
@@ -126,27 +126,41 @@ export class VariableAssignmentState implements DebugLogState {
     try {
       const modifiedValue = logContext.getUtil().surroundBlobsWithQuotes(value);
       const obj = JSON.parse(modifiedValue);
-      Object.keys(obj).forEach(key => {
-        const refContainer = logContext.getRefsMap().get(String(obj[key]))!;
-        if (refContainer) {
-          const tmpContainer = this.copyReferenceContainer(refContainer, key, logContext);
-          container.variables.set(key, tmpContainer);
-        } else {
-          let varValue = obj[key];
-          if (typeof varValue === 'string') {
-            varValue = `'${varValue}'`;
-            varValue = logContext.getUtil().removeQuotesFromBlob(varValue);
-          } else {
-            varValue = `${varValue}`;
-          }
-          container.variables.set(key, new ApexVariableContainer(key, varValue, ''));
-        }
-      });
+      // Recurse on the already-parsed object so inner string values aren't re-quoted/re-stringified.
+      this.populateFromParsed(obj, container, logContext);
     } catch {
       container.value = value;
       container.variablesRef = 0;
       container.variables.clear();
     }
+  }
+
+  // Populate a container's children from an already-parsed JSON value (object or array).
+  // Operates on the parsed value directly to avoid re-running surroundBlobsWithQuotes /
+  // JSON.stringify on inner values (which would mangle already-quoted strings).
+  private populateFromParsed(parsed: any, container: ApexVariableContainer, logContext: LogContext) {
+    const keys: string[] = Array.isArray(parsed) ? parsed.map((_, index) => index.toString()) : Object.keys(parsed);
+    keys.forEach(key => {
+      const rawValue = parsed[key];
+      const refContainer = logContext.getRefsMap().get(String(rawValue))!;
+      if (refContainer) {
+        const tmpContainer = this.copyReferenceContainer(refContainer, key, logContext);
+        container.variables.set(key, tmpContainer);
+      } else if (rawValue !== null && typeof rawValue === 'object') {
+        // Nested object/array (parent SObject rel, multi-level hierarchy, or child subquery
+        // records). Build an expandable child container and recurse. type='' is acceptable:
+        // VARIABLE_ASSIGNMENT JSON carries no nested SObject type metadata (only field
+        // name/value), unlike the heap-dump path which reads types from a separate source.
+        const nested = new ApexVariableContainer(key, '', '');
+        container.variables.set(key, nested);
+        nested.variablesRef = logContext.getVariableHandler().create(nested);
+        this.populateFromParsed(rawValue, nested, logContext);
+      } else {
+        const varValue =
+          typeof rawValue === 'string' ? logContext.getUtil().removeQuotesFromBlob(`'${rawValue}'`) : `${rawValue}`;
+        container.variables.set(key, new ApexVariableContainer(key, varValue, ''));
+      }
+    });
   }
   private copyReferenceContainer(refContainer: ApexVariableContainer, varName: string, logContext: LogContext) {
     const tmpContainer = new ApexVariableContainer(varName, refContainer.value, refContainer.type, refContainer.ref);

--- a/packages/salesforcedx-apex-replay-debugger/src/states/variableAssignmentState.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/states/variableAssignmentState.ts
@@ -142,7 +142,7 @@ export class VariableAssignmentState implements DebugLogState {
     const keys: string[] = Array.isArray(parsed) ? parsed.map((_, index) => index.toString()) : Object.keys(parsed);
     keys.forEach(key => {
       const rawValue = parsed[key];
-      const refContainer = logContext.getRefsMap().get(String(rawValue))!;
+      const refContainer = logContext.getRefsMap().get(String(rawValue));
       if (refContainer) {
         const tmpContainer = this.copyReferenceContainer(refContainer, key, logContext);
         container.variables.set(key, tmpContainer);

--- a/packages/salesforcedx-apex-replay-debugger/test/unit/states/variableAssignmentState.test.ts
+++ b/packages/salesforcedx-apex-replay-debugger/test/unit/states/variableAssignmentState.test.ts
@@ -515,4 +515,99 @@ describe('Variable assignment event', () => {
       expect(container.variablesRef).toBe(0);
     });
   });
+
+  describe('Nested related-object expansion', () => {
+    const DUMMY_REF = '0x00000000';
+    const NESTED_SCOPE_BEGIN = 'fakeTime|VARIABLE_SCOPE_BEGIN|[8]|this|NestedClass|true|false';
+
+    // walk the container tree collecting every container
+    const walk = (container: ApexVariableContainer): ApexVariableContainer[] => [
+      container,
+      ...Array.from(container.variables.values()).flatMap(walk)
+    ];
+
+    beforeEach(() => {
+      const state = new FrameEntryState(['signature']);
+      context = new LogContext(launchRequestArgs, new ApexReplayDebug());
+      context.getFrames().push({ id: 0, name: 'execute_anonymous_apex' } as StackFrame);
+      frameEntryHandleResult = state.handle(context);
+      const beginState = new VariableBeginState(NESTED_SCOPE_BEGIN.split('|'));
+      beginState.handle(context);
+      getUriFromSignatureStub = jest
+        .spyOn(LogContext.prototype, 'getUriFromSignature')
+        .mockReturnValue(uriFromSignature);
+    });
+
+    afterEach(() => {
+      getUriFromSignatureStub.mockRestore();
+    });
+
+    const getThis = (): ApexVariableContainer => {
+      const frameInfo = context.getFrameHandler().get(context.getTopFrame()!.id);
+      assert(frameInfo);
+      return frameInfo.locals.get('this') as ApexVariableContainer;
+    };
+
+    it('Should expand a multi-level parent hierarchy without [object Object]', () => {
+      new VariableAssignmentState(`fakeTime|VARIABLE_ASSIGNMENT|[8]|this|{}|${DUMMY_REF}`.split('|')).handle(context);
+      const json = '{"Name":"A","Parent":{"Name":"P","Parent":{"Name":"GP"}}}';
+      new VariableAssignmentState(`fakeTime|VARIABLE_ASSIGNMENT|[10]|this.a|${json}|${DUMMY_REF}`.split('|')).handle(
+        context
+      );
+      const container = getThis();
+      const a = container.variables.get('a') as ApexVariableContainer;
+      expect(a.variablesRef).not.toBe(0);
+
+      const parent = a.variables.get('Parent') as ApexVariableContainer;
+      expect(parent.variablesRef).not.toBe(0);
+      expect((parent.variables.get('Name') as ApexVariableContainer).value).toBe("'P'");
+
+      const grandparent = parent.variables.get('Parent') as ApexVariableContainer;
+      expect(grandparent.variablesRef).not.toBe(0);
+      expect((grandparent.variables.get('Name') as ApexVariableContainer).value).toBe("'GP'");
+
+      // leaf primitive
+      expect((a.variables.get('Name') as ApexVariableContainer).value).toBe("'A'");
+      // no container value renders as [object Object]
+      expect(walk(container).every(c => c.value !== '[object Object]')).toBe(true);
+    });
+
+    it('Should expand a child subquery records array keyed by index', () => {
+      new VariableAssignmentState(`fakeTime|VARIABLE_ASSIGNMENT|[8]|this|{}|${DUMMY_REF}`.split('|')).handle(context);
+      const json = '{"Name":"A","Contacts":{"records":[{"LastName":"X"},{"LastName":"Y"}]}}';
+      new VariableAssignmentState(`fakeTime|VARIABLE_ASSIGNMENT|[10]|this.a|${json}|${DUMMY_REF}`.split('|')).handle(
+        context
+      );
+      const a = getThis().variables.get('a') as ApexVariableContainer;
+      const contacts = a.variables.get('Contacts') as ApexVariableContainer;
+      expect(contacts.variablesRef).not.toBe(0);
+
+      const records = contacts.variables.get('records') as ApexVariableContainer;
+      expect(records.variablesRef).not.toBe(0);
+      // array container keyed by numeric index strings
+      expect(Array.from(records.variables.keys())).toEqual(['0', '1']);
+
+      const first = records.variables.get('0') as ApexVariableContainer;
+      const second = records.variables.get('1') as ApexVariableContainer;
+      expect(first.variablesRef).not.toBe(0);
+      expect((first.variables.get('LastName') as ApexVariableContainer).value).toBe("'X'");
+      expect((second.variables.get('LastName') as ApexVariableContainer).value).toBe("'Y'");
+
+      expect(walk(getThis()).every(c => c.value !== '[object Object]')).toBe(true);
+    });
+
+    it('Should not re-quote already-quoted inner strings (parse-once regression guard)', () => {
+      new VariableAssignmentState(`fakeTime|VARIABLE_ASSIGNMENT|[8]|this|{}|${DUMMY_REF}`.split('|')).handle(context);
+      const json = '{"Name":"A","Parent":{"Name":"P"}}';
+      new VariableAssignmentState(`fakeTime|VARIABLE_ASSIGNMENT|[10]|this.a|${json}|${DUMMY_REF}`.split('|')).handle(
+        context
+      );
+      const a = getThis().variables.get('a') as ApexVariableContainer;
+      const parentName = (a.variables.get('Parent') as ApexVariableContainer).variables.get(
+        'Name'
+      ) as ApexVariableContainer;
+      // single-quoted once, not "''P''"
+      expect(parentName.value).toBe("'P'");
+    });
+  });
 });

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebuggerVariables.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebuggerVariables.desktop.spec.ts
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { expect } from '@playwright/test';
+import {
+  APEX_TRACE_FLAG_STATUS_BAR,
+  clearOutputChannel,
+  createApexClass,
+  EDITOR_WITH_URI,
+  ensureOutputPanelOpen,
+  ensureSecondarySideBarHidden,
+  executeCommandWithCommandPalette,
+  NOTIFICATION_LIST_ITEM,
+  openFileByName,
+  QUICK_INPUT_WIDGET,
+  removeAllDebugLevels,
+  saveScreenshot,
+  selectOutputChannel,
+  selectQuickInputOptionByTyping,
+  setupConsoleMonitoring,
+  setupMinimalOrgAndAuth,
+  setupNetworkMonitoring,
+  validateNoCriticalErrors,
+  waitForOutputChannelText,
+  waitForQuickInputFirstOption,
+  WORKBENCH
+} from '@salesforce/playwright-vscode-ext';
+
+import apexLogNls from 'salesforcedx-vscode-apex-log/package.nls.json';
+import metadataNls from 'salesforcedx-vscode-metadata/package.nls.json';
+import packageNls from '../../../package.nls.json';
+import { test } from '../fixtures';
+
+// Class that builds nested SObject relationships in memory so they serialize as a
+// nested-object VARIABLE_ASSIGNMENT (`{"Account":{"Name":"Acme"}}`) in the debug log.
+// System.debug on the line below is the breakpoint target.
+const nestedClassContent = [
+  'public with sharing class NestedRelExample {',
+  '  public static void build() {',
+  "    Account a = new Account(Name = 'Acme');",
+  "    Contact c = new Contact(LastName = 'Bond', Account = a);",
+  '    System.debug(c);',
+  '  }',
+  '}'
+].join('\n');
+
+test('Apex Replay Debugger: nested related-object VARIABLES expand (no [object Object])', async ({ page }) => {
+  test.setTimeout(600_000);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  await test.step('setup minimal org with NestedRelExample', async () => {
+    await setupMinimalOrgAndAuth(page);
+    await ensureSecondarySideBarHidden(page);
+    await createApexClass(page, 'NestedRelExample', nestedClassContent);
+    await ensureOutputPanelOpen(page);
+    await selectOutputChannel(page, 'Salesforce Metadata');
+    await executeCommandWithCommandPalette(
+      page,
+      metadataNls.project_deploy_start_ignore_conflicts_default_org_text as string
+    );
+    await waitForOutputChannelText(page, { expectedText: 'Starting metadata deployment', timeout: 90_000 });
+    await waitForOutputChannelText(page, { expectedText: 'Deployed Source', timeout: 120_000 });
+  });
+
+  await test.step('remove all debug levels so ReplayDebuggerLevels is auto-created', async () => {
+    await removeAllDebugLevels(page);
+  });
+
+  await test.step('create trace flag for current user', async () => {
+    await executeCommandWithCommandPalette(
+      page,
+      apexLogNls['apexLog.command.traceFlagsCreateForCurrentUser'] as string
+    );
+    const statusBar = page.locator(APEX_TRACE_FLAG_STATUS_BAR).filter({ hasText: /Tracing until/ });
+    await expect(statusBar).toBeVisible({ timeout: 60_000 });
+  });
+
+  await test.step('exec anon invoking NestedRelExample.build', async () => {
+    await ensureOutputPanelOpen(page);
+    await selectOutputChannel(page, 'Salesforce Apex Log');
+    await clearOutputChannel(page);
+
+    await executeCommandWithCommandPalette(page, apexLogNls['apexLog.command.createAnonymousApexScript'] as string);
+    await page.locator(QUICK_INPUT_WIDGET).waitFor({ state: 'visible', timeout: 10_000 });
+    await page.keyboard.type('RunNested');
+    await page.keyboard.press('Enter');
+    // Name InputBox transitions to a directory QuickPick (2 options) — accept the first
+    await waitForQuickInputFirstOption(page);
+    await page.keyboard.press('Enter');
+
+    await page
+      .locator('.tab')
+      .filter({ hasText: /RunNested\.apex/ })
+      .waitFor({ state: 'visible', timeout: 15_000 });
+    await openFileByName(page, 'RunNested.apex');
+    const editorArea = page.locator('.editor-instance .view-lines').first();
+    await editorArea.click({ force: true });
+    await page.keyboard.press('Control+a');
+    await page.keyboard.type('NestedRelExample.build();');
+
+    await page.keyboard.press('F1');
+    await selectQuickInputOptionByTyping(page, apexLogNls['apexLog.command.executeDocument'] as string);
+
+    const successNotification = page
+      .locator(NOTIFICATION_LIST_ITEM)
+      .filter({ hasText: /executed successfully/i })
+      .first();
+    await expect(successNotification).toBeVisible({ timeout: 30_000 });
+    await successNotification.getByRole('button', { name: /Open Log/i }).click();
+    const logTab = page.locator('.tab').filter({ hasText: /\.log$/ });
+    await expect(logTab).toBeVisible({ timeout: 10_000 });
+    await saveScreenshot(page, 'step.nested-exec-anon-done.png');
+  });
+
+  await test.step('set breakpoint on the System.debug line in NestedRelExample', async () => {
+    await openFileByName(page, 'NestedRelExample.cls');
+    const editor = page.locator(`${EDITOR_WITH_URI}[data-uri$="NestedRelExample.cls"]`);
+    await editor.waitFor({ state: 'visible', timeout: 15_000 });
+    const debugLine = editor.locator('.view-line').filter({ hasText: 'System.debug(c);' }).first();
+    await expect(debugLine).toBeVisible({ timeout: 15_000 });
+    await debugLine.click();
+    // F9 toggles a breakpoint at the current caret line
+    await page.keyboard.press('F9');
+    const breakpointGlyph = page.locator('div.codicon-debug-breakpoint');
+    await expect(breakpointGlyph.first()).toBeVisible({ timeout: 15_000 });
+  });
+
+  await test.step('launch replay debugger with selected log file and pause at breakpoint', async () => {
+    const logTab = page.locator('.tab').filter({ hasText: /\.log$/ });
+    await logTab.click({ force: true });
+    await executeCommandWithCommandPalette(page, packageNls.launch_apex_replay_debugger_with_selected_file as string);
+    // Replay pauses on entry first (debug toolbar appears)
+    await expect(page.locator('.debug-toolbar')).toBeVisible({ timeout: 30_000 });
+    // Continue (F5) to run to the breakpoint on the System.debug line where `c` is assigned
+    await page.keyboard.press('F5');
+    // Confirm we paused at NestedRelExample.cls line 5 (not entry) via the call stack frame
+    await executeCommandWithCommandPalette(page, 'View: Show Run and Debug');
+    const stackFrame = page.locator('.debug-call-stack .monaco-list-row').filter({ hasText: /NestedRelExample/ });
+    await expect(stackFrame.first()).toBeVisible({ timeout: 30_000 });
+    await saveScreenshot(page, 'step.replay-paused.png');
+  });
+
+  await test.step('assert nested local expands and renders no [object Object]', async () => {
+    // Launching replay does not open the Run and Debug viewlet — show it, then focus VARIABLES.
+    await executeCommandWithCommandPalette(page, 'View: Show Run and Debug');
+    await executeCommandWithCommandPalette(page, 'Run and Debug: Focus on Variables View');
+    const variablesView = page.locator(`${WORKBENCH} .debug-variables`);
+    await variablesView.waitFor({ state: 'visible', timeout: 30_000 });
+
+    // The replay Variables tree shows scope rows (Local/Static); expand any collapsed scope so
+    // the locals (Contact `c`) are rendered.
+    const collapsedScopes = variablesView.locator('.monaco-list-row[aria-expanded="false"]');
+    const collapsedCount = await collapsedScopes.count();
+    for (let i = 0; i < collapsedCount; i++) {
+      await collapsedScopes.nth(i).locator('.monaco-tl-twistie').click({ force: true });
+    }
+
+    // The Contact local `c` carries the nested Account relationship. Match the variable-name cell.
+    const nestedRow = variablesView
+      .locator('.monaco-list-row')
+      .filter({ has: page.locator('.monaco-highlighted-label', { hasText: /^c$/ }) })
+      .first();
+    await expect(nestedRow).toBeVisible({ timeout: 30_000 });
+
+    // Symptom assertion: nested value must not render as [object Object]
+    await expect(nestedRow).not.toContainText('[object Object]');
+
+    // Expand twistie present (collapsible affordance)
+    const twistie = nestedRow.locator('.monaco-tl-twistie');
+    await expect(twistie).toBeVisible({ timeout: 10_000 });
+
+    // Expand and confirm a child property row becomes visible
+    await twistie.click({ force: true });
+    const childRow = variablesView
+      .locator('.monaco-list-row')
+      .filter({ hasText: /LastName|Account/ })
+      .first();
+    await expect(childRow).toBeVisible({ timeout: 15_000 });
+
+    // No row anywhere renders [object Object]
+    await expect(variablesView.locator('.monaco-list-row', { hasText: '[object Object]' })).toHaveCount(0);
+    await saveScreenshot(page, 'step.nested-variables-expanded.png');
+  });
+
+  await test.step('continue and end debug session', async () => {
+    const toolbar = page.locator('.debug-toolbar');
+    await page.locator(`${WORKBENCH} .editor-instance .view-lines`).first().click({ force: true });
+    await page.keyboard.press('Escape');
+    await page.keyboard.press('F5');
+    await expect(toolbar).not.toBeVisible({ timeout: 45_000 });
+  });
+
+  await test.step('turn off trace flag', async () => {
+    await executeCommandWithCommandPalette(
+      page,
+      apexLogNls['apexLog.command.traceFlagsDeleteForCurrentUser'] as string
+    );
+    const statusBar = page.locator(APEX_TRACE_FLAG_STATUS_BAR).filter({ hasText: /No Tracing/ });
+    await expect(statusBar).toBeVisible({ timeout: 30_000 });
+  });
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebuggerVariables.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebuggerVariables.desktop.spec.ts
@@ -188,6 +188,7 @@ test('Apex Replay Debugger: nested related-object VARIABLES expand (no [object O
 
   await test.step('continue and end debug session', async () => {
     const toolbar = page.locator('.debug-toolbar');
+    // Click editor area to dismiss search-bar hover that can cover debug toolbar and block F5
     await page.locator(`${WORKBENCH} .editor-instance .view-lines`).first().click({ force: true });
     await page.keyboard.press('Escape');
     await page.keyboard.press('F5');

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebuggerVariables.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebuggerVariables.desktop.spec.ts
@@ -151,13 +151,17 @@ test('Apex Replay Debugger: nested related-object VARIABLES expand (no [object O
     const variablesView = page.locator(`${WORKBENCH} .debug-variables`);
     await variablesView.waitFor({ state: 'visible', timeout: 30_000 });
 
-    // The replay Variables tree shows scope rows (Local/Static); expand any collapsed scope so
-    // the locals (Contact `c`) are rendered.
-    const collapsedScopes = variablesView.locator('.monaco-list-row[aria-expanded="false"]');
-    const collapsedCount = await collapsedScopes.count();
-    for (let i = 0; i < collapsedCount; i++) {
-      await collapsedScopes.nth(i).locator('.monaco-tl-twistie').click({ force: true });
-    }
+    // The replay Variables tree shows scope rows (Local/Static); expand every collapsed scope so
+    // the locals (Contact `c`) are rendered. Always click the FIRST remaining collapsed row:
+    // clicking a twistie mutates the live NodeList, so an index-based loop (nth(i)) would target
+    // shifted rows and could re-collapse a scope. Driving the first-collapsed row to zero is stable.
+    const firstCollapsed = variablesView.locator('.monaco-list-row[aria-expanded="false"]').first();
+    await expect(async () => {
+      if (await firstCollapsed.isVisible()) {
+        await firstCollapsed.locator('.monaco-tl-twistie').click({ force: true });
+      }
+      await expect(firstCollapsed).toBeHidden();
+    }).toPass({ timeout: 30_000 });
 
     // The Contact local `c` carries the nested Account relationship. Match the variable-name cell.
     const nestedRow = variablesView
@@ -173,13 +177,18 @@ test('Apex Replay Debugger: nested related-object VARIABLES expand (no [object O
     const twistie = nestedRow.locator('.monaco-tl-twistie');
     await expect(twistie).toBeVisible({ timeout: 10_000 });
 
-    // Expand and confirm a child property row becomes visible
-    await twistie.click({ force: true });
+    // Expand `c` and confirm a child property row becomes visible. Select the row then press Right:
+    // on a monaco tree Right expands a collapsed row (never collapses an expanded one), so it's
+    // idempotent under CI timing where `c` may already be expanded. Re-drive until a child appears.
     const childRow = variablesView
       .locator('.monaco-list-row')
       .filter({ hasText: /LastName|Account/ })
       .first();
-    await expect(childRow).toBeVisible({ timeout: 15_000 });
+    await expect(async () => {
+      await nestedRow.click({ force: true });
+      await page.keyboard.press('ArrowRight');
+      await expect(childRow).toBeVisible({ timeout: 5000 });
+    }).toPass({ timeout: 30_000 });
 
     // No row anywhere renders [object Object]
     await expect(variablesView.locator('.monaco-list-row', { hasText: '[object Object]' })).toHaveCount(0);


### PR DESCRIPTION
## Summary

- Nested related-object variables (parent SObject relationships, multi-level parent hierarchies, child subqueries) now expand in VARIABLES panel and hover instead of showing `[object Object]`
- Extracted `createStringFromVarContainer` to shared module for reuse across heap-dump and variable-assignment paths
- Added unit tests for multi-level parent and child-subquery fixtures; added e2e test asserting VARIABLES panel expandability

## Plan

.claude/plans/W-11173323.md

## Reviewer notes

- variableAssignmentState.ts:141 `populateFromParsed(parsed: any)` — attempted tightening to `Record<string, unknown> | unknown[]` but eslint consistent-type-assertions forbids the `as` casts needed to string-index/recurse the union, yielding 2 new lint errors. `any` is allowed in this package (@typescript-eslint/no-explicit-any off) and matches existing heapDumpService.ts usage, so not a regression. Reverted; would need a refactor (e.g. type guards) to land cleanly.
- variableAssignmentState.ts:149 empty {}/[] becomes expandable container with zero children. Requires a UX design decision (render empty expandable vs collapse to leaf); cosmetic only and strictly better than the prior `[object Object]` leaf. Not auto-applied.
- variableContainerStrings.ts:48,63 `first` mutation. Verifier concluded the imperative pattern is clearer than a forced Array.map/join here due to conditional ref-checking, recursion, and multiple formatting modes. Functional refactor would reduce readability; left as-is.

## Test plan

- Open a replay debug log with nested related-object variables (parent SObject, multi-level hierarchy, child subquery)
- Verify VARIABLES panel shows expandable twisties (not `[object Object]`)
- Expand nested objects and confirm child properties are visible
- Verify hover over nested variables shows expandable structure

## What issues does this PR fix or reference?

#4065, @W-11173323@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.salesforce.com/a07EE00000xOW00YAG