### PR TITLE
feat(eslint): add no-vscode-show-text-document rule - W-23090041

### DIFF
--- a/.claude/plans/W-23090041.md
+++ b/.claude/plans/W-23090041.md
@@ -1,0 +1,72 @@
+# W-23090041 — Lint rule for fsService.showTextDocument adoption
+
+## Context
+
+- Goal: migrate `vscode.window.showTextDocument(...)` → `fsService.showTextDocument` (error-handled, in services).
+- `fsService.showTextDocument(filePath: string|URI, options?: vscode.TextDocumentShowOptions)` — `packages/salesforcedx-vscode-services/src/vscode/fsService.ts:102`. Effect; wraps vscode call w/ `FsServiceError`.
+- Consumers reach it via `api.services.FsService.showTextDocument(...)`; api = `(yield* ExtensionProviderService).getServicesApi` (see `packages/salesforcedx-vscode-soql/src/commands/dataQuery.ts:24`). Apply `services-extension-consumption` skill.
+- Existing AST helper `isVscodeWindowMethodCall(node, methodName)` — `packages/eslint-local-rules/src/astUtils.ts:42`; matches both `vscode.window.X` and `window.X`. Reuse.
+- Rule pattern model: `noVscodeUri.ts` (CallExpression detect, `RuleCreator.withoutDocs`, no autofix).
+- Exclusions wired in `eslint.config.mjs`, not rule. Concrete insertion points (verified against current file):
+  - Register `warn` globally: add `'local/no-vscode-show-text-document': 'warn'` to the `rules` object of the global block `files: ['**/*.ts']` (block starts line 101; rules object starts line 128, alongside `local/no-vscode-uri` line 129).
+  - Turn `off` for tests: add `'local/no-vscode-show-text-document': 'off'` inside the `rules` object of the test-override block. That block STARTS at line 740 (`files: ['packages/**/test/**/*.ts', ...]`); its `rules` object opens at line 758. Insert into that rules object.
+  - Turn `off` for services: the global block (line 101 `files: ['**/*.ts']`) DOES include the services package, so the `warn` applies to services. The services-specific block at line 701 only carries `local/no-export-tagged-error-in-services`. Add `'local/no-vscode-show-text-document': 'off'` to that existing services block's rules object (lines 702-704). No new block needed.
+- Violation sites (non-test, non-services), 5 files:
+  - `packages/salesforcedx-vscode-apex-log/src/commands/executeAnonymous.ts:55` — in `Effect.sync`; needs FsService access.
+  - `packages/salesforcedx-vscode-metadata/src/conflict/conflictView.ts:59` — `Effect.sync(() => void window.showTextDocument(...))`.
+  - `packages/salesforcedx-vscode-metadata/src/commands/projectInfo.ts:300` — in `Effect.sync`.
+  - `packages/salesforcedx-vscode-apex-testing/src/views/testController.ts:1104,1624` — raw `async/await` + `openTextDocument` then `showTextDocument`; hardest.
+  - `packages/salesforcedx-vscode-soql/src/commands/dataQuery.ts:61` — `.then()` chain; already has `api.services.FsService` adjacent (line 48).
+- "Warn only, no autofix" per WI; success = zero violations outside exclusions.
+
+## Phases
+
+### Phase 1 — rule + tests + wiring
+
+- New `packages/eslint-local-rules/src/noVscodeShowTextDocument.ts`: `CallExpression` → `isVscodeWindowMethodCall(node, 'showTextDocument')` → `context.report({ messageId: 'useFsService' })`. No fix. Msg: "Use fsService.showTextDocument instead of vscode.window.showTextDocument".
+- Register in `packages/eslint-local-rules/src/index.ts`: `'no-vscode-show-text-document': noVscodeShowTextDocument`.
+- `eslint.config.mjs` (three edits, per Context insertion points):
+  1. global block (line 101 / rules object line 128): add `'local/no-vscode-show-text-document': 'warn'` (near `local/no-vscode-uri` line 129).
+  2. test-override block (starts line 740, rules object line 758): add `'local/no-vscode-show-text-document': 'off'`.
+  3. services block (line 701, rules object lines 702-704): add `'local/no-vscode-show-text-document': 'off'` — required because the global `files: ['**/*.ts']` block already covers services.
+- Tests `packages/eslint-local-rules/test/no-vscode-show-text-document.test.ts` (model `no-vscode-uri.test.ts`):
+  - valid: `fsService.showTextDocument(uri)`; `api.services.FsService.showTextDocument(uri)`; test-file `vscode.window.showTextDocument` (filename `*.test.ts`) — note: RuleTester ignores eslint.config file-scoping, so test-file exclusion validated by config blocks not rule; assert rule itself flags regardless, exclusion = config. Document this.
+  - invalid: `vscode.window.showTextDocument(doc)`; `window.showTextDocument(doc)`; edge `const d = await vscode.workspace.openTextDocument(u); await vscode.window.showTextDocument(d)` → 1 error on show only.
+- commit: `feat(eslint): add no-vscode-show-text-document rule - W-23090041`
+
+### Phase 2 — migrate Effect.sync sites (3 files)
+
+- apex-log `executeAnonymous.ts`, metadata `conflictView.ts` + `projectInfo.ts`: replace `Effect.sync(() => void vscode.window.showTextDocument(uri))` → `yield* api.services.FsService.showTextDocument(uri, opts)` (obtain api per skill). Restructure surrounding `Effect.sync` callbacks to `Effect.gen`/yield where needed.
+- commit: `refactor: adopt fsService.showTextDocument in apex-log + metadata - W-23090041`
+
+### Phase 3 — migrate soql dataQuery.ts
+
+- `dataQuery.ts:60-61`: drop `.then()` chain; `yield* api.services.FsService.showTextDocument(fileUri)` (api already in scope line 45).
+- commit: `refactor(soql): adopt fsService.showTextDocument - W-23090041`
+
+### Phase 4 — migrate apex-testing testController.ts
+
+- Lines 1104, 1624: raw async fns w/ `openTextDocument` + `showTextDocument`. Replace `showTextDocument` w/ fsService via api inside Effect, or `runPromise` wrapper. Keep `openTextDocument` (out of scope; not error-handled equivalent). Verify editor-return value consumers (line 1624 assigns `editor`) still satisfied — `fsService.showTextDocument` returns `TextEditor`.
+- commit: `refactor(apex-testing): adopt fsService.showTextDocument - W-23090041`
+
+### Phase 5 — verification sweep
+
+- Text-search `window.showTextDocument` repo-wide → only tests + services package remain.
+- Text-search `workspace.openTextDocument` → review adjacent `showTextDocument`; fix false positives in rule/tests if found.
+- Run lint all packages → zero `no-vscode-show-text-document` outside exclusions.
+- commit: `test(eslint): verification sweep for showTextDocument - W-23090041` (only if rule/test tweaks needed; else fold into Phase 1)
+
+## Skills
+
+- `services-extension-consumption` — fsService access via api.
+- `typescript` — Effect/TS conventions.
+- `concise` — plan/docs.
+- `verification` — verify pass.
+
+## Verification
+
+- `yarn workspace @salesforce/eslint-local-rules test` (or jest for `no-vscode-show-text-document.test.ts`) — rule unit.
+- Lint full repo: `yarn lint` → no rule violations outside services + tests.
+- `tsc`/compile per migrated package (apex-log, metadata, soql, apex-testing) — Effect refactors type-check.
+- Text searches per Phase 5.
+- e2e-covered: runtime behavior of migrated commands (open log, conflict view, project info, soql CSV open, test class open) exercised by existing playwright specs in those packages — not manually re-verified here.

--- a/.claude/skills/services-extension-consumption/references/fs-service.md
+++ b/.claude/skills/services-extension-consumption/references/fs-service.md
@@ -129,6 +129,17 @@ const data = yield * api.services.FsService.readJSON(filePath, MyConfigSchema);
 
 Prefer the schema approach when customers might have corrupted JSON—validation fails with a clear error instead of silently returning bad data.
 
+### showTextDocument
+
+Open file in editor:
+
+```typescript
+const editor = yield * api.services.FsService.showTextDocument(filePath, options);
+// filePath: string | URI
+// options?: vscode.TextDocumentShowOptions
+// Returns: vscode.TextEditor
+```
+
 ### toUri
 
 Convert path to URI:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -127,6 +127,7 @@ export default [
     },
     rules: {
       'local/no-vscode-uri': 'error',
+      'local/no-vscode-show-text-document': 'warn',
       'local/command-must-be-in-package-json': [
         'error',
         {
@@ -700,7 +701,8 @@ export default [
     // salesforcedx-vscode-services exports errors for consumption by other packages — knip already sees them as used.
     files: ['packages/salesforcedx-vscode-services/**/*.ts'],
     rules: {
-      'local/no-export-tagged-error-in-services': 'error'
+      'local/no-export-tagged-error-in-services': 'error',
+      'local/no-vscode-show-text-document': 'off'
     }
   },
   {
@@ -756,6 +758,8 @@ export default [
       'packages/salesforcedx-vscode-visualforce/playwright*.ts'
     ],
     rules: {
+      'local/no-vscode-show-text-document': 'off',
+
       // Deactivate import-order for tests to allow for mock-before-import
       'effect/no-import-from-barrel-package': ['off'],
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -759,7 +759,6 @@ export default [
     ],
     rules: {
       'local/no-vscode-show-text-document': 'off',
-
       // Deactivate import-order for tests to allow for mock-before-import
       'effect/no-import-from-barrel-package': ['off'],
 

--- a/packages/eslint-local-rules/src/index.ts
+++ b/packages/eslint-local-rules/src/index.ts
@@ -19,6 +19,7 @@ import { noUnusedI18nMessages } from './noUnusedI18nMessages';
 import { noVscodeMessageLiterals } from './noVscodeMessageLiterals';
 import { noVscodeProgressTitleLiterals } from './noVscodeProgressTitleLiterals';
 import { noVscodeQuickpickDescriptionLiterals } from './noVscodeQuickpickDescriptionLiterals';
+import { noVscodeShowTextDocument } from './noVscodeShowTextDocument';
 import { noVscodeUri } from './noVscodeUri';
 import { noVscodeValidateInputLiterals } from './noVscodeValidateInputLiterals';
 import { packageJsonCommandRefs } from './packageJsonCommandRefs';
@@ -56,6 +57,7 @@ const plugin = {
     'no-vscode-message-literals': noVscodeMessageLiterals,
     'no-vscode-progress-title-literals': noVscodeProgressTitleLiterals,
     'no-vscode-quickpick-description-literals': noVscodeQuickpickDescriptionLiterals,
+    'no-vscode-show-text-document': noVscodeShowTextDocument,
     'no-vscode-uri': noVscodeUri,
     'no-vscode-validateinput-literals': noVscodeValidateInputLiterals,
     'package-json-i18n-descriptions': packageJsonI18nDescriptions,

--- a/packages/eslint-local-rules/src/noVscodeShowTextDocument.ts
+++ b/packages/eslint-local-rules/src/noVscodeShowTextDocument.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { TSESTree } from '@typescript-eslint/utils';
+import { RuleCreator } from '@typescript-eslint/utils/eslint-utils';
+import { isVscodeWindowMethodCall } from './astUtils';
+
+export const noVscodeShowTextDocument = RuleCreator.withoutDocs({
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Use fsService.showTextDocument instead of vscode.window.showTextDocument.'
+    },
+    schema: [],
+    messages: {
+      useFsService: 'Use fsService.showTextDocument instead of vscode.window.showTextDocument.'
+    }
+  },
+  defaultOptions: [],
+  create: context => ({
+    CallExpression: (node: TSESTree.CallExpression): void => {
+      if (isVscodeWindowMethodCall(node, 'showTextDocument')) {
+        context.report({ node: node.callee, messageId: 'useFsService' });
+      }
+    }
+  })
+});

--- a/packages/eslint-local-rules/test/no-vscode-show-text-document.test.ts
+++ b/packages/eslint-local-rules/test/no-vscode-show-text-document.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { noVscodeShowTextDocument } from '../src/noVscodeShowTextDocument';
+
+const ruleTester = new RuleTester();
+
+// NOTE: RuleTester ignores eslint.config file-scoping. The rule itself flags
+// `vscode.window.showTextDocument` everywhere; test-file / services-package
+// exclusions are enforced by the `off` overrides in eslint.config.mjs, not the rule.
+ruleTester.run('no-vscode-show-text-document', noVscodeShowTextDocument, {
+  valid: [
+    {
+      code: `const editor = fsService.showTextDocument(uri);`,
+      filename: 'packages/salesforcedx-vscode-apex-log/src/test.ts'
+    },
+    {
+      code: `const editor = yield* api.services.FsService.showTextDocument(uri);`,
+      filename: 'packages/salesforcedx-vscode-soql/src/commands/test.ts'
+    },
+    {
+      // unrelated window method — not flagged
+      code: `vscode.window.showInformationMessage('hi');`,
+      filename: 'packages/salesforcedx-vscode-metadata/src/test.ts'
+    }
+  ],
+  invalid: [
+    {
+      code: `vscode.window.showTextDocument(doc);`,
+      filename: 'packages/salesforcedx-vscode-metadata/src/test.ts',
+      errors: [{ messageId: 'useFsService' }]
+    },
+    {
+      code: `window.showTextDocument(doc);`,
+      filename: 'packages/salesforcedx-vscode-apex-log/src/test.ts',
+      errors: [{ messageId: 'useFsService' }]
+    },
+    {
+      // openTextDocument is allowed; only the show call is flagged → 1 error
+      code: `const d = await vscode.workspace.openTextDocument(u);
+await vscode.window.showTextDocument(d);`,
+      filename: 'packages/salesforcedx-vscode-apex-testing/src/test.ts',
+      errors: [{ messageId: 'useFsService' }]
+    }
+  ]
+});

--- a/packages/salesforcedx-vscode-apex-log/src/commands/executeAnonymous.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/commands/executeAnonymous.ts
@@ -9,7 +9,6 @@ import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import * as Effect from 'effect/Effect';
 import { type EditorService } from 'salesforcedx-vscode-services';
 import * as vscode from 'vscode';
-import { URI } from 'vscode-uri';
 import { saveExecResult } from '../logs/logStorage';
 import { nls } from '../messages';
 import { getRuntime } from '../services/runtime';
@@ -47,12 +46,15 @@ const executeAnonymous = Effect.fn('ApexLog.ExecuteAnonymous.executeAnonymous')(
     logBody
   );
   const logUri = yield* saveExecResult(context.text, result, logBody, logId);
-  const selected = yield* Effect.promise(() =>
-    vscode.window.showInformationMessage(nls.localize('exec_anon_success'), nls.localize('open_log'))
-  );
-  if (selected === nls.localize('open_log')) {
-    yield* api.services.FsService.showTextDocument(URI.parse(logUri.toString()));
-  }
+  yield* Effect.sync(() => {
+    void vscode.window
+      .showInformationMessage(nls.localize('exec_anon_success'), nls.localize('open_log'))
+      .then(selected => {
+        if (selected === nls.localize('open_log')) {
+          void getRuntime().runPromise(api.services.FsService.showTextDocument(logUri));
+        }
+      });
+  });
   return result;
 });
 

--- a/packages/salesforcedx-vscode-apex-log/src/commands/executeAnonymous.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/commands/executeAnonymous.ts
@@ -47,14 +47,12 @@ const executeAnonymous = Effect.fn('ApexLog.ExecuteAnonymous.executeAnonymous')(
     logBody
   );
   const logUri = yield* saveExecResult(context.text, result, logBody, logId);
-  yield* Effect.sync(() => {
-    void vscode.window
-      .showInformationMessage(nls.localize('exec_anon_success'), nls.localize('open_log'))
-      .then(
-        selected =>
-          selected === nls.localize('open_log') && void vscode.window.showTextDocument(URI.parse(logUri.toString()))
-      );
-  });
+  const selected = yield* Effect.promise(() =>
+    vscode.window.showInformationMessage(nls.localize('exec_anon_success'), nls.localize('open_log'))
+  );
+  if (selected === nls.localize('open_log')) {
+    yield* api.services.FsService.showTextDocument(URI.parse(logUri.toString()));
+  }
   return result;
 });
 

--- a/packages/salesforcedx-vscode-apex-testing/src/views/testController.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/views/testController.ts
@@ -1101,14 +1101,14 @@ export class ApexTestController {
       const retrievedFileUri = getRetrievedFileUri(result);
       if (retrievedFileUri) {
         await getApexTestingRuntime().runPromise(
-          Effect.gen(function* () {
+          Effect.fn('ApexTesting.openRetrievedFile')(function* () {
             const api = yield* (yield* ExtensionProviderService).getServicesApi;
             yield* api.services.FsService.showTextDocument(retrievedFileUri, {
               preview: false,
               viewColumn: vscode.ViewColumn.Active,
               preserveFocus: false
             });
-          })
+          })()
         );
         await closeEditorTabByUri(uri);
       }
@@ -1626,13 +1626,13 @@ const openOrgOnlyTest = async (test: vscode.TestItem): Promise<void> => {
   }
   const testUri = test.uri;
   const editor = await getApexTestingRuntime().runPromise(
-    Effect.gen(function* () {
+    Effect.fn('ApexTesting.openOrgOnlyTest')(function* () {
       const api = yield* (yield* ExtensionProviderService).getServicesApi;
       return yield* api.services.FsService.showTextDocument(testUri, {
         preview: false,
         viewColumn: vscode.ViewColumn.Active
       });
-    })
+    })()
   );
   if (isMethod(test.id) && test.range) {
     editor.selection = new vscode.Selection(test.range.start, test.range.start);

--- a/packages/salesforcedx-vscode-apex-testing/src/views/testController.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/views/testController.ts
@@ -1100,12 +1100,16 @@ export class ApexTestController {
 
       const retrievedFileUri = getRetrievedFileUri(result);
       if (retrievedFileUri) {
-        const document = await vscode.workspace.openTextDocument(retrievedFileUri);
-        await vscode.window.showTextDocument(document, {
-          preview: false,
-          viewColumn: vscode.ViewColumn.Active,
-          preserveFocus: false
-        });
+        await getApexTestingRuntime().runPromise(
+          Effect.gen(function* () {
+            const api = yield* (yield* ExtensionProviderService).getServicesApi;
+            yield* api.services.FsService.showTextDocument(retrievedFileUri, {
+              preview: false,
+              viewColumn: vscode.ViewColumn.Active,
+              preserveFocus: false
+            });
+          })
+        );
         await closeEditorTabByUri(uri);
       }
 
@@ -1620,11 +1624,16 @@ const openOrgOnlyTest = async (test: vscode.TestItem): Promise<void> => {
   if (!test.uri) {
     return;
   }
-  const document = await vscode.workspace.openTextDocument(test.uri);
-  const editor = await vscode.window.showTextDocument(document, {
-    preview: false,
-    viewColumn: vscode.ViewColumn.Active
-  });
+  const testUri = test.uri;
+  const editor = await getApexTestingRuntime().runPromise(
+    Effect.gen(function* () {
+      const api = yield* (yield* ExtensionProviderService).getServicesApi;
+      return yield* api.services.FsService.showTextDocument(testUri, {
+        preview: false,
+        viewColumn: vscode.ViewColumn.Active
+      });
+    })
+  );
   if (isMethod(test.id) && test.range) {
     editor.selection = new vscode.Selection(test.range.start, test.range.start);
     editor.revealRange(test.range, vscode.TextEditorRevealType.InCenter);

--- a/packages/salesforcedx-vscode-apex-testing/test/jest/views/testController.test.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/jest/views/testController.test.ts
@@ -868,15 +868,12 @@ describe('ApexTestController', () => {
 
       await controller.openOrgOnlyTest(classTestItem);
 
-      // Verify the underlying VS Code APIs were called
-      expect(vscode.workspace.openTextDocument).toHaveBeenCalled();
-      if ((vscode.workspace.openTextDocument as jest.Mock).mock.calls.length > 0) {
-        const openDocCall = (vscode.workspace.openTextDocument as jest.Mock).mock.calls[0][0];
-        expect(openDocCall).toBeDefined();
-        expect(openDocCall.toString()).toContain('sf-org-apex');
-        expect(openDocCall.toString()).toContain('OrgOnlyClass');
-        expect(vscode.window.showTextDocument).toHaveBeenCalled();
-      }
+      // fsService.showTextDocument opens the URI directly (no separate openTextDocument)
+      expect(vscode.window.showTextDocument).toHaveBeenCalled();
+      const showDocCall = (vscode.window.showTextDocument as jest.Mock).mock.calls[0][0];
+      expect(showDocCall).toBeDefined();
+      expect(showDocCall.toString()).toContain('sf-org-apex');
+      expect(showDocCall.toString()).toContain('OrgOnlyClass');
     });
 
     it('should open org-only method test and navigate to position', async () => {
@@ -913,8 +910,7 @@ describe('ApexTestController', () => {
 
       await controller.openOrgOnlyTest(methodTestItem);
 
-      // Verify the underlying VS Code APIs were called
-      expect(vscode.workspace.openTextDocument).toHaveBeenCalled();
+      // fsService.showTextDocument opens the URI directly
       expect(vscode.window.showTextDocument).toHaveBeenCalled();
       expect(mockEditor.revealRange).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -968,10 +964,10 @@ describe('ApexTestController', () => {
       expect(
         (extensionProvider as unknown as { __mockMetadataRetrieve: jest.Mock }).__mockMetadataRetrieve
       ).toHaveBeenCalledWith([{ type: 'ApexClass', fullName: 'OrgOnlyClass' }], { ignoreConflicts: true });
-      expect(vscode.workspace.openTextDocument).toHaveBeenCalledWith(
-        expect.objectContaining({ fsPath: orgOnlyClassFileUri.fsPath })
+      expect(vscode.window.showTextDocument).toHaveBeenCalledWith(
+        expect.objectContaining({ fsPath: orgOnlyClassFileUri.fsPath }),
+        expect.anything()
       );
-      expect(vscode.window.showTextDocument).toHaveBeenCalled();
       expect(refreshSpy).toHaveBeenCalled();
       expect(notificationService.showSuccessfulExecution).toHaveBeenCalled();
     });

--- a/packages/salesforcedx-vscode-metadata/src/commands/projectInfo.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/projectInfo.ts
@@ -292,15 +292,12 @@ const doProjectInfo = Effect.fn('doProjectInfo')(function* () {
 
   yield* api.services.FsService.safeWriteFile(outputUri, content);
 
-  yield* Effect.sync(() => {
-    void vscode.window
-      .showInformationMessage(nls.localize('project_info_written_message'), nls.localize('open_button'))
-      .then(selection => {
-        if (selection === nls.localize('open_button')) {
-          void vscode.window.showTextDocument(outputUri);
-        }
-      });
-  });
+  const selection = yield* Effect.promise(() =>
+    vscode.window.showInformationMessage(nls.localize('project_info_written_message'), nls.localize('open_button'))
+  );
+  if (selection === nls.localize('open_button')) {
+    yield* api.services.FsService.showTextDocument(outputUri);
+  }
 });
 
 export const projectInfoCommand = Effect.fn('projectInfoCommand')(function* () {

--- a/packages/salesforcedx-vscode-metadata/src/commands/projectInfo.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/projectInfo.ts
@@ -292,16 +292,19 @@ const doProjectInfo = Effect.fn('doProjectInfo')(function* () {
 
   yield* api.services.FsService.safeWriteFile(outputUri, content);
 
+  return outputUri;
+});
+
+export const projectInfoCommand = Effect.fn('projectInfoCommand')(function* () {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const promptService = yield* api.services.PromptService;
+  const outputUri = yield* doProjectInfo().pipe(
+    promptService.withProgress(nls.localize('project_info_gathering_progress'))
+  );
   const selection = yield* Effect.promise(() =>
     vscode.window.showInformationMessage(nls.localize('project_info_written_message'), nls.localize('open_button'))
   );
   if (selection === nls.localize('open_button')) {
     yield* api.services.FsService.showTextDocument(outputUri);
   }
-});
-
-export const projectInfoCommand = Effect.fn('projectInfoCommand')(function* () {
-  const api = yield* (yield* ExtensionProviderService).getServicesApi;
-  const promptService = yield* api.services.PromptService;
-  return yield* doProjectInfo().pipe(promptService.withProgress(nls.localize('project_info_gathering_progress')));
 });

--- a/packages/salesforcedx-vscode-metadata/src/conflict/conflictView.ts
+++ b/packages/salesforcedx-vscode-metadata/src/conflict/conflictView.ts
@@ -58,10 +58,10 @@ export const conflictDiffCommandEffect = (entry: DiffFilePair | ConflictTreeItem
 export const conflictOpenCommandEffect = (node: ConflictTreeItem) => {
   const pair = node?.pair;
   return pair
-    ? Effect.gen(function* () {
+    ? Effect.fn('conflictOpenCommandEffect')(function* () {
         const api = yield* (yield* ExtensionProviderService).getServicesApi;
         yield* api.services.FsService.showTextDocument(pair.localUri.uri);
-      })
+      })()
     : Effect.void;
 };
 

--- a/packages/salesforcedx-vscode-metadata/src/conflict/conflictView.ts
+++ b/packages/salesforcedx-vscode-metadata/src/conflict/conflictView.ts
@@ -6,6 +6,7 @@
  */
 /* eslint-disable functional/no-let -- module-level refs set during ensureConflictView */
 
+import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import * as Effect from 'effect/Effect';
 import * as SubscriptionRef from 'effect/SubscriptionRef';
 import * as vscode from 'vscode';
@@ -56,7 +57,12 @@ export const conflictDiffCommandEffect = (entry: DiffFilePair | ConflictTreeItem
 
 export const conflictOpenCommandEffect = (node: ConflictTreeItem) => {
   const pair = node?.pair;
-  return pair ? Effect.sync(() => void vscode.window.showTextDocument(pair.localUri.uri)) : Effect.void;
+  return pair
+    ? Effect.gen(function* () {
+        const api = yield* (yield* ExtensionProviderService).getServicesApi;
+        yield* api.services.FsService.showTextDocument(pair.localUri.uri);
+      })
+    : Effect.void;
 };
 
 /** Detect conflicts, populate tree, focus view. Used when status bar clicked with conflicts. */

--- a/packages/salesforcedx-vscode-soql/src/commands/dataQuery.ts
+++ b/packages/salesforcedx-vscode-soql/src/commands/dataQuery.ts
@@ -49,20 +49,15 @@ const saveResultsToCSV = Effect.fn('saveResultsToCSV')(function* (queryResult: Q
 
   // Show success message with clickable file link
   const openFileAction = nls.localize('data_query_open_file');
-  yield* Effect.promise(() =>
-    vscode.window
-      .showInformationMessage(
-        nls.localize('data_query_success_message', queryResult.totalSize, fileUri.fsPath),
-        openFileAction
-      )
-      .then(selection => {
-        if (selection === openFileAction) {
-          vscode.workspace.openTextDocument(fileUri).then(doc => {
-            vscode.window.showTextDocument(doc);
-          });
-        }
-      })
+  const selection = yield* Effect.promise(() =>
+    vscode.window.showInformationMessage(
+      nls.localize('data_query_success_message', queryResult.totalSize, fileUri.fsPath),
+      openFileAction
+    )
   );
+  if (selection === openFileAction) {
+    yield* api.services.FsService.showTextDocument(fileUri);
+  }
 });
 
 const executeDataQuery = Effect.fn('executeDataQuery')(function* (query: string, queryApi: 'REST' | 'TOOLING') {


### PR DESCRIPTION
## Summary

- New eslint rule `no-vscode-show-text-document` warns on `vscode.window.showTextDocument`, nudging migrations to `fsService.showTextDocument` (error-handled Effect-based wrapper).
- Migrated 5 usage sites (apex-log, metadata, soql, apex-testing) from bare vscode calls to `api.services.FsService.showTextDocument`.
- Rule enabled as `warn` globally, `off` for tests + services package.

## Plan

[.claude/plans/W-23090041.md](.claude/plans/W-23090041.md)

## Reviewer notes

- `noVscodeShowTextDocument.ts:26` flags bare `window.showTextDocument` (no `vscode.` prefix) via `isVscodeWindowMethodCall` (astUtils.ts:61-63), so it could theoretically false-positive on a local identifier named `window`. Verified as no-op in this codebase: 0 local `window` declarations in production code, and 5 sibling rules use the same helper without issue. No code change applied; informational only.
- Claim that bare-`window` matching is "consistent with existing no-vscode-uri behavior" is inaccurate (`noVscodeUri` requires the `vscode.` prefix), but the rule itself is intentional and matches established helper convention. No change needed; recorded for PR body.

## What issues does this PR fix or reference?

@W-23090041@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cdARCYA2/view