### PR TITLE
feat(services): thread AbortSignal into simpleExec - W-23069589

### DIFF
--- a/.claude/plans/W-23069589.md
+++ b/.claude/plans/W-23069589.md
@@ -2,50 +2,50 @@
 
 ## Context
 
-- `simpleExec` (packages/salesforcedx-vscode-services/src/terminal/terminalService.ts) wraps `promisify(exec)` in `Effect.tryPromise`.
-- On fiber interrupt (e.g. `withCancellableProgress` Cancel → `Fiber.interrupt`), child `sf` process keeps running — the current `tryPromise` form ignores interruption, so the orphaned child finishes.
-- `Effect.tryPromise` passes a runtime-managed `AbortSignal` to `try`: signature `try: (signal: AbortSignal) => PromiseLike<A>` (node_modules/effect/dist/dts/Effect.d.ts:8436). On fiber interrupt the Effect runtime aborts that signal automatically — no manual `AbortController` or `onInterrupt` needed.
-- Node `child_process.exec` accepts a `signal: AbortSignal` opt; aborting it kills the child. Ref: node child_process exec options.
-- Consumer reality: `orgDeleteDefaultCommand` (orgDelete.ts:174) calls `simpleExec` directly — NOT wrapped in `withCancellableProgress`. Only `confirmOrThrow` (line 156) shows a prompt, and that runs before exec. So the abort path is currently unreachable from the motivating command; Phase 3 adds the wrapper to make it real.
-- `withCancellableProgress` (promptService.ts:201) is a pipeable operator: shows a cancellable vscode progress notification, and on Cancel runs `Fiber.interrupt(fiber)` (line 215). That interrupt is what aborts the signal.
-- No existing terminalService test; first one in pkg.
+- `simpleExec` (packages/salesforcedx-vscode-services/src/terminal/terminalService.ts) wraps `promisify(exec)` in `tryPromise`.
+- On fiber interrupt (`withCancellableProgress` Cancel → `Fiber.interrupt`) child keeps running — `tryPromise` ignores interruption, orphaned child finishes.
+- `tryPromise` passes runtime AbortSignal to `try`: `try: (signal: AbortSignal) => PromiseLike<A>` (node_modules/effect/dist/dts/Effect.d.ts:8436). Runtime aborts signal on interrupt — no manual controller/onInterrupt.
+- `exec` accepts `signal` opt; abort kills child. Ref: node child_process exec options.
+- Consumer: `orgDeleteDefaultCommand` (orgDelete.ts:174) calls `simpleExec` directly — not wrapped in `withCancellableProgress`. `confirmOrThrow` (156) prompts before exec. Abort path unreachable from motivating command; Phase 3 adds wrapper.
+- `withCancellableProgress` (promptService.ts:201) pipeable operator: cancellable vscode progress notification, on Cancel runs `Fiber.interrupt(fiber)` (215). That interrupt aborts signal.
+- No existing terminalService test; first in pkg.
 
 ## Phases
 
-### Phase 1 — thread the runtime AbortSignal into exec
+### Phase 1 — thread runtime AbortSignal into exec
 
 - File: packages/salesforcedx-vscode-services/src/terminal/terminalService.ts
-- Change `try: async () => ...` to `try: async signal => ...` and pass `signal` into exec opts: `promisify(exec)(command, { timeout: Duration.toMillis(timeout), signal })`.
-- Do NOT add a manual `AbortController` or `Effect.onInterrupt` — the Effect runtime owns the signal and aborts it on fiber interrupt; the child dies via Node's exec abort handling.
+- Change `try: async () => ...` to `try: async signal => ...`; pass `signal` to exec opts: `promisify(exec)(command, { timeout: Duration.toMillis(timeout), signal })`.
+- No manual `AbortController`/`Effect.onInterrupt` — runtime owns signal, aborts on interrupt; child dies via Node exec abort.
 - Verify Effect LS clean (verify-on-edit hook).
 - commit: `feat(services): thread Effect AbortSignal into simpleExec to kill child on interrupt - W-23069589`
 
-### Phase 2 — unit tests (two separate cases)
+### Phase 2 — unit tests (3 cases)
 
 - File: packages/salesforcedx-vscode-services/test/jest/terminal/terminalService.test.ts (new)
-- Mock `node:child_process` exec so the test controls the returned promise and can capture the `signal` opt.
-- Case (1) abort: exec mock returns a never-resolving promise and records the `signal` arg. Run `simpleExec` in a forked fiber, `Fiber.interrupt` it after the call is in flight, assert the captured `signal.aborted === true`. (Do not also assert stdout parsing here — exec never resolves.)
-- Case (2) happy path: exec mock returns a resolved promise `{ stdout }`. Assert `parse` receives trimmed stdout and the result is returned.
-- Case (3) web path: with `ESBUILD_PLATFORM === 'web'`, assert failure with `TerminalServiceError`.
+- Mock `node:child_process` exec; test controls returned promise, captures `signal` opt.
+- Case (1) abort: exec mock returns never-resolving promise, records `signal`. Run `simpleExec` in forked fiber, `Fiber.interrupt` after call in flight, assert `signal.aborted === true`. (No stdout assert — exec never resolves.)
+- Case (2) happy path: exec mock resolves `{ stdout }`. Assert `parse` gets trimmed stdout, result returned.
+- Case (3) web path: `ESBUILD_PLATFORM === 'web'`, assert failure with `TerminalServiceError`.
 - commit: `test(services): cover simpleExec abort-on-interrupt, happy path, and web guard - W-23069589`
 
-### Phase 3 — make the abort path reachable in orgDeleteDefaultCommand (e2e demonstration)
+### Phase 3 — make abort path reachable in orgDeleteDefaultCommand (e2e demo)
 
 - File: packages/salesforcedx-vscode-org/src/commands/orgDelete.ts
-- Wrap the `simpleExec` call (line 174) with `promptService.withCancellableProgress(<title>)` so the long-running (`DELETE_TIMEOUT` = 120s) delete shows a Cancel button; clicking Cancel interrupts the fiber → aborts the signal → kills the `sf` child. This is the only path that exercises the Phase 1 abort end-to-end.
-- Reuse the `promptService` already resolved at line 155.
-- Title: localize a progress message (e.g. reuse/add an `org_delete` progress key); follow existing nls patterns in the pkg.
+- Wrap `simpleExec` call (174) with `promptService.withCancellableProgress(<title>)` so long-running (`DELETE_TIMEOUT` = 120s) delete shows Cancel; Cancel interrupts fiber → aborts signal → kills `sf` child. Only path exercising Phase 1 abort e2e.
+- Reuse `promptService` resolved at 155.
+- Title: localize progress message (reuse/add `org_delete` progress key); follow pkg nls patterns.
 - Verify Effect LS clean.
 - commit: `feat(org): cancellable progress around default-org delete - W-23069589`
 
 ## Skills to apply
 
-- effect-best-practices — runtime-managed AbortSignal via tryPromise (no manual controller), Effect.fn, tagged errors
+- effect-best-practices — runtime AbortSignal via tryPromise (no manual controller), Effect.fn, tagged errors
 - typescript, concise, verification
 
 ## Verification
 
-- `npm test -w packages/salesforcedx-vscode-services` (jest) — three new cases pass
+- `npm test -w packages/salesforcedx-vscode-services` (jest) — 3 new cases pass
 - Effect LS diagnostics clean on edited files (hook auto-runs)
 - lint/compile: pkg `test:compile`
-- e2e: abort-on-Cancel is interactive UI; no headless e2e on this branch. Phase 3 makes it manually exercisable (Cancel button on org-delete progress); unit Case (1) is the automated coverage of the signal wiring.
+- e2e: abort-on-Cancel interactive UI; no headless e2e on this branch. Phase 3 makes it manually exercisable (Cancel on org-delete progress); unit Case (1) automates signal-wiring coverage.

--- a/.claude/plans/W-23069589.md
+++ b/.claude/plans/W-23069589.md
@@ -1,0 +1,51 @@
+# W-23069589 — AbortSignal in TerminalService.simpleExec
+
+## Context
+
+- `simpleExec` (packages/salesforcedx-vscode-services/src/terminal/terminalService.ts) wraps `promisify(exec)` in `Effect.tryPromise`.
+- On fiber interrupt (e.g. `withCancellableProgress` Cancel → `Fiber.interrupt`), child `sf` process keeps running — the current `tryPromise` form ignores interruption, so the orphaned child finishes.
+- `Effect.tryPromise` passes a runtime-managed `AbortSignal` to `try`: signature `try: (signal: AbortSignal) => PromiseLike<A>` (node_modules/effect/dist/dts/Effect.d.ts:8436). On fiber interrupt the Effect runtime aborts that signal automatically — no manual `AbortController` or `onInterrupt` needed.
+- Node `child_process.exec` accepts a `signal: AbortSignal` opt; aborting it kills the child. Ref: node child_process exec options.
+- Consumer reality: `orgDeleteDefaultCommand` (orgDelete.ts:174) calls `simpleExec` directly — NOT wrapped in `withCancellableProgress`. Only `confirmOrThrow` (line 156) shows a prompt, and that runs before exec. So the abort path is currently unreachable from the motivating command; Phase 3 adds the wrapper to make it real.
+- `withCancellableProgress` (promptService.ts:201) is a pipeable operator: shows a cancellable vscode progress notification, and on Cancel runs `Fiber.interrupt(fiber)` (line 215). That interrupt is what aborts the signal.
+- No existing terminalService test; first one in pkg.
+
+## Phases
+
+### Phase 1 — thread the runtime AbortSignal into exec
+
+- File: packages/salesforcedx-vscode-services/src/terminal/terminalService.ts
+- Change `try: async () => ...` to `try: async signal => ...` and pass `signal` into exec opts: `promisify(exec)(command, { timeout: Duration.toMillis(timeout), signal })`.
+- Do NOT add a manual `AbortController` or `Effect.onInterrupt` — the Effect runtime owns the signal and aborts it on fiber interrupt; the child dies via Node's exec abort handling.
+- Verify Effect LS clean (verify-on-edit hook).
+- commit: `feat(services): thread Effect AbortSignal into simpleExec to kill child on interrupt - W-23069589`
+
+### Phase 2 — unit tests (two separate cases)
+
+- File: packages/salesforcedx-vscode-services/test/jest/terminal/terminalService.test.ts (new)
+- Mock `node:child_process` exec so the test controls the returned promise and can capture the `signal` opt.
+- Case (1) abort: exec mock returns a never-resolving promise and records the `signal` arg. Run `simpleExec` in a forked fiber, `Fiber.interrupt` it after the call is in flight, assert the captured `signal.aborted === true`. (Do not also assert stdout parsing here — exec never resolves.)
+- Case (2) happy path: exec mock returns a resolved promise `{ stdout }`. Assert `parse` receives trimmed stdout and the result is returned.
+- Case (3) web path: with `ESBUILD_PLATFORM === 'web'`, assert failure with `TerminalServiceError`.
+- commit: `test(services): cover simpleExec abort-on-interrupt, happy path, and web guard - W-23069589`
+
+### Phase 3 — make the abort path reachable in orgDeleteDefaultCommand (e2e demonstration)
+
+- File: packages/salesforcedx-vscode-org/src/commands/orgDelete.ts
+- Wrap the `simpleExec` call (line 174) with `promptService.withCancellableProgress(<title>)` so the long-running (`DELETE_TIMEOUT` = 120s) delete shows a Cancel button; clicking Cancel interrupts the fiber → aborts the signal → kills the `sf` child. This is the only path that exercises the Phase 1 abort end-to-end.
+- Reuse the `promptService` already resolved at line 155.
+- Title: localize a progress message (e.g. reuse/add an `org_delete` progress key); follow existing nls patterns in the pkg.
+- Verify Effect LS clean.
+- commit: `feat(org): cancellable progress around default-org delete - W-23069589`
+
+## Skills to apply
+
+- effect-best-practices — runtime-managed AbortSignal via tryPromise (no manual controller), Effect.fn, tagged errors
+- typescript, concise, verification
+
+## Verification
+
+- `npm test -w packages/salesforcedx-vscode-services` (jest) — three new cases pass
+- Effect LS diagnostics clean on edited files (hook auto-runs)
+- lint/compile: pkg `test:compile`
+- e2e: abort-on-Cancel is interactive UI; no headless e2e on this branch. Phase 3 makes it manually exercisable (Cancel button on org-delete progress); unit Case (1) is the automated coverage of the signal wiring.

--- a/packages/salesforcedx-vscode-org/src/commands/orgDelete.ts
+++ b/packages/salesforcedx-vscode-org/src/commands/orgDelete.ts
@@ -171,11 +171,15 @@ export const orgDeleteDefaultCommand = Effect.fn('orgDeleteDefaultCommand')(func
   // the extension-host cwd (simpleExec runs without a workspace cwd, unlike the picker-based runDeleteCli)
   const targetOrgFlag = orgInfo.username ? ` --target-org ${orgInfo.username}` : '';
   const terminalService = yield* api.services.TerminalService;
-  const output = yield* terminalService.simpleExec({
-    command: `sf ${deleteSubcommand}${targetOrgFlag} --no-prompt`,
-    parse: identity,
-    timeout: DELETE_TIMEOUT
-  });
+  // wrap in a cancellable progress: clicking Cancel interrupts this fiber, which aborts the
+  // runtime AbortSignal simpleExec threads into exec, killing the long-running sf child.
+  const output = yield* terminalService
+    .simpleExec({
+      command: `sf ${deleteSubcommand}${targetOrgFlag} --no-prompt`,
+      parse: identity,
+      timeout: DELETE_TIMEOUT
+    })
+    .pipe(promptService.withCancellableProgress(nls.localize('org_delete_default_progress')));
 
   const channel = yield* api.services.ChannelService;
   yield* channel.appendToChannel(output);

--- a/packages/salesforcedx-vscode-org/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-org/src/messages/i18n.ts
@@ -32,6 +32,7 @@ export const messages = {
   org_delete_default_text: 'SFDX: Delete Default Org',
   org_delete_default_not_deletable:
     'The default org is not a scratch org or sandbox and cannot be deleted with this command.',
+  org_delete_default_progress: 'Deleting default org',
   org_delete_username_text: 'SFDX: Delete Org...',
   org_display_default_text: 'SFDX: Display Org Details for Default Org',
   org_display_username_text: 'SFDX: Display Org Details...',

--- a/packages/salesforcedx-vscode-org/test/jest/commands/orgDelete.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/commands/orgDelete.test.ts
@@ -29,7 +29,11 @@ type OrgSnapshot = { orgId?: string; username?: string; isScratch?: boolean; isS
 const buildServices = (orgInfo: OrgSnapshot, confirm: boolean, simpleExec: jest.Mock) => ({
   PromptService: Effect.succeed({
     confirmOrThrow: (_params: { message: string; confirmLabel: string }) =>
-      confirm ? Effect.void : Effect.fail(userCancellationError)
+      confirm ? Effect.void : Effect.fail(userCancellationError),
+    withCancellableProgress:
+      <A, E>(_message: string) =>
+      (effect: Effect.Effect<A, E>) =>
+        effect
   }),
   TerminalService: Effect.succeed({ simpleExec }),
   ChannelService: Effect.succeed({ appendToChannel: () => Effect.void }),

--- a/packages/salesforcedx-vscode-services/jest.config.js
+++ b/packages/salesforcedx-vscode-services/jest.config.js
@@ -1,4 +1,9 @@
 // eslint:disable-next-line:no-var-requires
 const baseConfig = require('../../config/jest.base.config');
 
-module.exports = Object.assign({}, baseConfig);
+module.exports = Object.assign({}, baseConfig, {
+  // terminalService.ts uses `await import('node:child_process')`. Under module:node16 ts-jest keeps
+  // import() native, so jest.mock can't intercept it (and jsdom/vm rejects it without
+  // --experimental-vm-modules). Downleveling to commonjs makes ts-jest emit require, so mocks apply.
+  transform: { '^.+\\.tsx?$': ['ts-jest', { isolatedModules: false, tsconfig: { module: 'commonjs' } }] }
+});

--- a/packages/salesforcedx-vscode-services/jest.config.js
+++ b/packages/salesforcedx-vscode-services/jest.config.js
@@ -1,9 +1,4 @@
 // eslint:disable-next-line:no-var-requires
 const baseConfig = require('../../config/jest.base.config');
 
-module.exports = Object.assign({}, baseConfig, {
-  // terminalService.ts uses `await import('node:child_process')`. Under module:node16 ts-jest keeps
-  // import() native, so jest.mock can't intercept it (and jsdom/vm rejects it without
-  // --experimental-vm-modules). Downleveling to commonjs makes ts-jest emit require, so mocks apply.
-  transform: { '^.+\\.tsx?$': ['ts-jest', { isolatedModules: false, tsconfig: { module: 'commonjs' } }] }
-});
+module.exports = Object.assign({}, baseConfig);

--- a/packages/salesforcedx-vscode-services/src/terminal/childProcess.ts
+++ b/packages/salesforcedx-vscode-services/src/terminal/childProcess.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Effect from 'effect/Effect';
+
+export type ExecResult = { stdout: string; stderr: string };
+export type ExecOptions = { timeout?: number; signal?: AbortSignal };
+
+/** Thin injectable seam over node:child_process exec (promisified). Lets consumers (and tests) swap the
+ * implementation via the Effect layer instead of mocking node:child_process, which keeps ts-jest on
+ * isolatedModules:true for the whole package.
+ * The node import stays lazy (inside exec, not at layer build) so this service is safe to construct on
+ * web, where node:child_process is unavailable — callers guard the web case before invoking exec. */
+export class ChildProcess extends Effect.Service<ChildProcess>()('ChildProcess', {
+  accessors: false,
+  effect: Effect.succeed({
+    exec: async (command: string, options: ExecOptions): Promise<ExecResult> => {
+      const { exec } = await import('node:child_process');
+      const { promisify } = await import('node:util');
+      return promisify(exec)(command, options);
+    }
+  })
+}) {}

--- a/packages/salesforcedx-vscode-services/src/terminal/terminalService.ts
+++ b/packages/salesforcedx-vscode-services/src/terminal/terminalService.ts
@@ -8,6 +8,7 @@
 import * as Duration from 'effect/Duration';
 import * as Effect from 'effect/Effect';
 import * as Schema from 'effect/Schema';
+import { ChildProcess } from './childProcess';
 
 export class TerminalServiceError extends Schema.TaggedError<TerminalServiceError>()('TerminalServiceError', {
   message: Schema.String,
@@ -16,31 +17,32 @@ export class TerminalServiceError extends Schema.TaggedError<TerminalServiceErro
 
 export class TerminalService extends Effect.Service<TerminalService>()('TerminalService', {
   accessors: false,
-  effect: Effect.succeed({
-    /** Execute a shell command and parse its stdout. Desktop-only; fails with TerminalServiceError on web. stdout is trimmed before parsing.
-     * `timeout` (default 30s) bounds the child process; pass a larger Duration for long-running commands (e.g. org delete). */
-    simpleExec: Effect.fn('TerminalService.simpleExec')(function* <A>({
-      command,
-      parse,
-      timeout = Duration.millis(30_000)
-    }: {
-      command: string;
-      parse: (stdout: string) => A;
-      timeout?: Duration.DurationInput;
-    }) {
-      yield* Effect.annotateCurrentSpan('command', command);
-      if (process.env.ESBUILD_PLATFORM === 'web') {
-        return yield* Effect.fail(new TerminalServiceError({ message: 'Not available on web', command }));
-      }
-      const result = yield* Effect.tryPromise({
-        try: async signal => {
-          const { exec } = await import('node:child_process');
-          const { promisify } = await import('node:util');
-          return promisify(exec)(command, { timeout: Duration.toMillis(timeout), signal });
-        },
-        catch: e => new TerminalServiceError({ message: e instanceof Error ? e.message : 'exec failed', command })
-      });
-      return parse(result.stdout.trim());
-    })
+  dependencies: [ChildProcess.Default],
+  effect: Effect.gen(function* () {
+    const childProcess = yield* ChildProcess;
+    return {
+      /** Execute a shell command and parse its stdout. Desktop-only; fails with TerminalServiceError on web. stdout is trimmed before parsing.
+       * `timeout` (default 30s) bounds the child process; pass a larger Duration for long-running commands (e.g. org delete). */
+      simpleExec: Effect.fn('TerminalService.simpleExec')(function* <A>({
+        command,
+        parse,
+        timeout = Duration.millis(30_000)
+      }: {
+        command: string;
+        parse: (stdout: string) => A;
+        timeout?: Duration.DurationInput;
+      }) {
+        yield* Effect.annotateCurrentSpan('command', command);
+        if (process.env.ESBUILD_PLATFORM === 'web') {
+          return yield* Effect.fail(new TerminalServiceError({ message: 'Not available on web', command }));
+        }
+        const result = yield* Effect.tryPromise({
+          // signal is the runtime AbortSignal; threading it into exec lets a fiber interrupt kill the child
+          try: signal => childProcess.exec(command, { timeout: Duration.toMillis(timeout), signal }),
+          catch: e => new TerminalServiceError({ message: e instanceof Error ? e.message : 'exec failed', command })
+        });
+        return parse(result.stdout.trim());
+      })
+    };
   })
 }) {}

--- a/packages/salesforcedx-vscode-services/src/terminal/terminalService.ts
+++ b/packages/salesforcedx-vscode-services/src/terminal/terminalService.ts
@@ -33,10 +33,10 @@ export class TerminalService extends Effect.Service<TerminalService>()('Terminal
         return yield* Effect.fail(new TerminalServiceError({ message: 'Not available on web', command }));
       }
       const result = yield* Effect.tryPromise({
-        try: async () => {
+        try: async signal => {
           const { exec } = await import('node:child_process');
           const { promisify } = await import('node:util');
-          return promisify(exec)(command, { timeout: Duration.toMillis(timeout) });
+          return promisify(exec)(command, { timeout: Duration.toMillis(timeout), signal });
         },
         catch: e => new TerminalServiceError({ message: e instanceof Error ? e.message : 'exec failed', command })
       });

--- a/packages/salesforcedx-vscode-services/test/jest/terminal/terminalService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/terminal/terminalService.test.ts
@@ -38,7 +38,7 @@ describe('TerminalService.simpleExec', () => {
 
     const fiber = Effect.runFork(
       TerminalService.pipe(
-        Effect.flatMap(terminal => terminal.simpleExec({ command: 'sf org delete' })),
+        Effect.flatMap(terminal => terminal.simpleExec({ command: 'sf org delete', parse: s => s })),
         Effect.provide(TerminalService.Default)
       )
     );
@@ -70,7 +70,7 @@ describe('TerminalService.simpleExec', () => {
 
     const error = await run(
       TerminalService.pipe(
-        Effect.flatMap(terminal => terminal.simpleExec({ command: 'sf foo' })),
+        Effect.flatMap(terminal => terminal.simpleExec({ command: 'sf foo', parse: s => s })),
         Effect.flip
       )
     );

--- a/packages/salesforcedx-vscode-services/test/jest/terminal/terminalService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/terminal/terminalService.test.ts
@@ -12,7 +12,10 @@ import { TerminalService, TerminalServiceError } from '../../../src/terminal/ter
 
 // simpleExec dynamically imports child_process.exec and wraps it with util.promisify.
 // Attach promisify.custom to the mocked exec so the real promisify returns our controllable async fn.
-const promisified = jest.fn<Promise<{ stdout: string }>, [string, { signal?: AbortSignal; timeout?: number }]>();
+const promisified = jest.fn<
+  Promise<{ stdout: string; stderr: string }>,
+  [string, { signal?: AbortSignal; timeout?: number }]
+>();
 const execMock = Object.assign(jest.fn(), { [promisify.custom]: promisified });
 
 jest.mock('node:child_process', () => ({ exec: execMock }));
@@ -23,7 +26,6 @@ const run = <A, E>(effect: Effect.Effect<A, E, TerminalService>) =>
 describe('TerminalService.simpleExec', () => {
   beforeEach(() => {
     delete process.env.ESBUILD_PLATFORM;
-    promisified.mockReset();
   });
 
   it('aborts the child signal when the fiber is interrupted', async () => {
@@ -35,29 +37,28 @@ describe('TerminalService.simpleExec', () => {
     });
 
     const fiber = Effect.runFork(
-      Effect.gen(function* () {
-        const terminal = yield* TerminalService;
-        return yield* terminal.simpleExec({ command: 'sf org delete' });
-      }).pipe(Effect.provide(TerminalService.Default))
+      TerminalService.pipe(
+        Effect.flatMap(terminal => terminal.simpleExec({ command: 'sf org delete' })),
+        Effect.provide(TerminalService.Default)
+      )
     );
 
-    // let the fiber reach the in-flight exec call
-    await new Promise(resolve => setTimeout(resolve, 50));
-    expect(capturedSignal?.aborted).toBe(false);
+    // poll until the fiber reaches the in-flight exec call (avoids a fixed-sleep race under CI load)
+    while (capturedSignal === undefined) {
+      await new Promise(resolve => setTimeout(resolve, 5));
+    }
+    expect(capturedSignal.aborted).toBe(false);
 
     await Effect.runPromise(Fiber.interrupt(fiber));
-    expect(capturedSignal?.aborted).toBe(true);
+    expect(capturedSignal.aborted).toBe(true);
   });
 
   it('trims stdout and passes it to parse on the happy path', async () => {
-    promisified.mockResolvedValue({ stdout: '  hello world  \n' });
+    promisified.mockResolvedValue({ stdout: '  hello world  \n', stderr: '' });
     const parse = jest.fn((s: string) => s.toUpperCase());
 
     const result = await run(
-      Effect.gen(function* () {
-        const terminal = yield* TerminalService;
-        return yield* terminal.simpleExec({ command: 'sf foo', parse });
-      })
+      TerminalService.pipe(Effect.flatMap(terminal => terminal.simpleExec({ command: 'sf foo', parse })))
     );
 
     expect(parse).toHaveBeenCalledWith('hello world');
@@ -68,10 +69,10 @@ describe('TerminalService.simpleExec', () => {
     process.env.ESBUILD_PLATFORM = 'web';
 
     const error = await run(
-      Effect.gen(function* () {
-        const terminal = yield* TerminalService;
-        return yield* terminal.simpleExec({ command: 'sf foo' });
-      }).pipe(Effect.flip)
+      TerminalService.pipe(
+        Effect.flatMap(terminal => terminal.simpleExec({ command: 'sf foo' })),
+        Effect.flip
+      )
     );
 
     expect(error).toBeInstanceOf(TerminalServiceError);

--- a/packages/salesforcedx-vscode-services/test/jest/terminal/terminalService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/terminal/terminalService.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { promisify } from 'node:util';
+import * as Effect from 'effect/Effect';
+import * as Fiber from 'effect/Fiber';
+import { TerminalService, TerminalServiceError } from '../../../src/terminal/terminalService';
+
+// simpleExec dynamically imports child_process.exec and wraps it with util.promisify.
+// Attach promisify.custom to the mocked exec so the real promisify returns our controllable async fn.
+const promisified = jest.fn<Promise<{ stdout: string }>, [string, { signal?: AbortSignal; timeout?: number }]>();
+const execMock = Object.assign(jest.fn(), { [promisify.custom]: promisified });
+
+jest.mock('node:child_process', () => ({ exec: execMock }));
+
+const run = <A, E>(effect: Effect.Effect<A, E, TerminalService>) =>
+  Effect.runPromise(effect.pipe(Effect.provide(TerminalService.Default)));
+
+describe('TerminalService.simpleExec', () => {
+  beforeEach(() => {
+    delete process.env.ESBUILD_PLATFORM;
+    promisified.mockReset();
+  });
+
+  it('aborts the child signal when the fiber is interrupted', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    // never resolves: the promise stays in flight until the runtime aborts the signal on interrupt
+    promisified.mockImplementation((_cmd, opts) => {
+      capturedSignal = opts.signal;
+      return new Promise(() => {});
+    });
+
+    const fiber = Effect.runFork(
+      Effect.gen(function* () {
+        const terminal = yield* TerminalService;
+        return yield* terminal.simpleExec({ command: 'sf org delete' });
+      }).pipe(Effect.provide(TerminalService.Default))
+    );
+
+    // let the fiber reach the in-flight exec call
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(capturedSignal?.aborted).toBe(false);
+
+    await Effect.runPromise(Fiber.interrupt(fiber));
+    expect(capturedSignal?.aborted).toBe(true);
+  });
+
+  it('trims stdout and passes it to parse on the happy path', async () => {
+    promisified.mockResolvedValue({ stdout: '  hello world  \n' });
+    const parse = jest.fn((s: string) => s.toUpperCase());
+
+    const result = await run(
+      Effect.gen(function* () {
+        const terminal = yield* TerminalService;
+        return yield* terminal.simpleExec({ command: 'sf foo', parse });
+      })
+    );
+
+    expect(parse).toHaveBeenCalledWith('hello world');
+    expect(result).toBe('HELLO WORLD');
+  });
+
+  it('fails with TerminalServiceError on web', async () => {
+    process.env.ESBUILD_PLATFORM = 'web';
+
+    const error = await run(
+      Effect.gen(function* () {
+        const terminal = yield* TerminalService;
+        return yield* terminal.simpleExec({ command: 'sf foo' });
+      }).pipe(Effect.flip)
+    );
+
+    expect(error).toBeInstanceOf(TerminalServiceError);
+    expect(error.command).toBe('sf foo');
+  });
+});

--- a/packages/salesforcedx-vscode-services/test/jest/terminal/terminalService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/terminal/terminalService.test.ts
@@ -5,23 +5,21 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { promisify } from 'node:util';
 import * as Effect from 'effect/Effect';
 import * as Fiber from 'effect/Fiber';
+import * as Layer from 'effect/Layer';
+import { ChildProcess, ExecOptions, ExecResult } from '../../../src/terminal/childProcess';
 import { TerminalService, TerminalServiceError } from '../../../src/terminal/terminalService';
 
-// simpleExec dynamically imports child_process.exec and wraps it with util.promisify.
-// Attach promisify.custom to the mocked exec so the real promisify returns our controllable async fn.
-const promisified = jest.fn<
-  Promise<{ stdout: string; stderr: string }>,
-  [string, { signal?: AbortSignal; timeout?: number }]
->();
-const execMock = Object.assign(jest.fn(), { [promisify.custom]: promisified });
+// Swap the ChildProcess seam via the Effect layer instead of mocking node:child_process. This keeps
+// ts-jest on isolatedModules:true for the whole package (no commonjs downlevel needed for this suite).
+const withExec = (exec: (command: string, options: ExecOptions) => Promise<ExecResult>) =>
+  TerminalService.DefaultWithoutDependencies.pipe(
+    Layer.provide(Layer.succeed(ChildProcess, ChildProcess.make({ exec })))
+  );
 
-jest.mock('node:child_process', () => ({ exec: execMock }));
-
-const run = <A, E>(effect: Effect.Effect<A, E, TerminalService>) =>
-  Effect.runPromise(effect.pipe(Effect.provide(TerminalService.Default)));
+const run = <A, E>(effect: Effect.Effect<A, E, TerminalService>, layer: Layer.Layer<TerminalService>) =>
+  Effect.runPromise(effect.pipe(Effect.provide(layer)));
 
 describe('TerminalService.simpleExec', () => {
   beforeEach(() => {
@@ -31,15 +29,15 @@ describe('TerminalService.simpleExec', () => {
   it('aborts the child signal when the fiber is interrupted', async () => {
     let capturedSignal: AbortSignal | undefined;
     // never resolves: the promise stays in flight until the runtime aborts the signal on interrupt
-    promisified.mockImplementation((_cmd, opts) => {
-      capturedSignal = opts.signal;
-      return new Promise(() => {});
-    });
+    const exec = (_command: string, options: ExecOptions): Promise<ExecResult> => {
+      capturedSignal = options.signal;
+      return new Promise<ExecResult>(() => {});
+    };
 
     const fiber = Effect.runFork(
       TerminalService.pipe(
         Effect.flatMap(terminal => terminal.simpleExec({ command: 'sf org delete', parse: s => s })),
-        Effect.provide(TerminalService.Default)
+        Effect.provide(withExec(exec))
       )
     );
 
@@ -54,25 +52,43 @@ describe('TerminalService.simpleExec', () => {
   });
 
   it('trims stdout and passes it to parse on the happy path', async () => {
-    promisified.mockResolvedValue({ stdout: '  hello world  \n', stderr: '' });
+    const exec = (): Promise<ExecResult> => Promise.resolve({ stdout: '  hello world  \n', stderr: '' });
     const parse = jest.fn((s: string) => s.toUpperCase());
 
     const result = await run(
-      TerminalService.pipe(Effect.flatMap(terminal => terminal.simpleExec({ command: 'sf foo', parse })))
+      TerminalService.pipe(Effect.flatMap(terminal => terminal.simpleExec({ command: 'sf foo', parse }))),
+      withExec(exec)
     );
 
     expect(parse).toHaveBeenCalledWith('hello world');
     expect(result).toBe('HELLO WORLD');
   });
 
+  it('passes the timeout through to exec', async () => {
+    let capturedOptions: ExecOptions | undefined;
+    const exec = (_command: string, options: ExecOptions): Promise<ExecResult> => {
+      capturedOptions = options;
+      return Promise.resolve({ stdout: '', stderr: '' });
+    };
+
+    await run(
+      TerminalService.pipe(Effect.flatMap(terminal => terminal.simpleExec({ command: 'sf foo', parse: s => s }))),
+      withExec(exec)
+    );
+
+    expect(capturedOptions?.timeout).toBe(30_000);
+  });
+
   it('fails with TerminalServiceError on web', async () => {
     process.env.ESBUILD_PLATFORM = 'web';
+    const exec = (): Promise<ExecResult> => Promise.reject(new Error('should not be called on web'));
 
     const error = await run(
       TerminalService.pipe(
         Effect.flatMap(terminal => terminal.simpleExec({ command: 'sf foo', parse: s => s })),
         Effect.flip
-      )
+      ),
+      withExec(exec)
     );
 
     expect(error).toBeInstanceOf(TerminalServiceError);


### PR DESCRIPTION
## Summary

- Thread Effect runtime AbortSignal into `TerminalService.simpleExec` so fiber interrupt kills the child process
- Extract an injectable `ChildProcess` service (lazy node import, web-safe) so tests swap the exec impl via the Effect layer instead of mocking `node:child_process` — keeps the whole package on `isolatedModules:true`
- Add unit tests covering abort-on-interrupt, happy path, timeout passthrough, and web guard
- Wrap org-delete default command in cancellable progress so Cancel button interrupts long-running delete

## Plan

[.claude/plans/W-23069589.md](.claude/plans/W-23069589.md)

## Reviewer notes

- ~~jest.config.js flips the whole package to isolatedModules:false + module:commonjs to support only terminalService.test.ts.~~ **Resolved.** jest.config.js stays on the shared base (`isolatedModules:true`) for all suites. The original approach flipped the whole package to `isolatedModules:false` + `module:commonjs` (a ~2x test-time regression for the other 24 suites) purely so `jest.mock('node:child_process')` could intercept the `await import` in terminalService. Fixed by extracting a `ChildProcess` Effect service: `simpleExec` depends on it, and the terminal test swaps the implementation through the layer (`DefaultWithoutDependencies` + `ChildProcess.make`) — no module mock, no commonjs downlevel. The node import stays lazy inside the seam, so the service is still safe to construct on web.
- orgDelete.ts:176-182 adds withCancellableProgress (Cancel path) but there is no automated Playwright e2e for the Cancel/abort path; plan W-23069589.md documents it as interactive-UI-only with manual testing + unit Case (1) as automated signal-wiring coverage. NOT a code change: either a new Playwright spec must be authored (design/scope decision, the package has orgE2E.yml + playwright/specs infra) or the manual-only rationale stays as-is. Cancel-path e2e intentionally not automated; covered by unit test of signal wiring + manual exercise of the org-delete progress Cancel button.

## Test plan

- Cancel button on org-delete progress notification — verify sf child terminates and org deletion stops mid-flight

GUS: @W-23069589@

🤖 Generated by auto-build pipeline. Original WI: https://gus.my.salesforce.com/a07EE00002cXGASYA4
