### PR TITLE
chore(eslint): enable unicorn/prefer-hoisting-branch-code - W-23094922

### DIFF
--- a/.claude/plans/W-23094922.md
+++ b/.claude/plans/W-23094922.md
@@ -24,7 +24,7 @@
 
 ### Phase 1a — enable rule (config-only commit)
 
-- Insert `'unicorn/prefer-hoisting-branch-code': 'error',` in unicorn block after `prefer-export-from`, before `prefer-includes` (alpha-ish ordering).
+- Insert `'unicorn/prefer-hoisting-branch-code': 'error',` in unicorn block after `prefer-export-from`, before `prefer-includes`.
 - Only file changed: `eslint.config.mjs`.
 - `npm run lint` here will surface the full violation set (used to scope 1b).
 - Commit (config lands independently even if 1b blocked): `chore: enable unicorn/prefer-hoisting-branch-code in eslint.config.mjs`

--- a/.claude/plans/W-23094922.md
+++ b/.claude/plans/W-23094922.md
@@ -1,0 +1,62 @@
+# W-23094922 — Enable unicorn/prefer-hoisting-branch-code
+
+## Context
+
+- Rule: move code shared by all if/else-if/else branches out of branches. Reports only full chains ending in `else`, each branch keeping >=1 unique stmt. Compares stmts by token. ([v68.0.0 docs](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v68.0.0/docs/rules/prefer-hoisting-branch-code.md))
+- Fixable: 🔧 trailing shared code auto-fixed; 💡 leading shared code with side effects = suggestion only (hoisting before `if` runs before condition eval → behavior change). No-scope-change/no-comment-drop guards.
+- Config: single root `eslint.config.mjs`, unicorn block lines 165-208. Insert `'unicorn/prefer-hoisting-branch-code': 'error',` after `prefer-export-from` (line 194), before `prefer-includes`.
+
+### Prereq — version bump (BLOCKS everything; see Phase 0)
+
+- Rule absent in pinned `eslint-plugin-unicorn` `64.0.0` (`node_modules/eslint-plugin-unicorn/rules/` has no `prefer-hoisting-branch-code.js`; `node_modules/.../package.json` = `64.0.0`). Exists at v68.0.0.
+- Real dependency = **W-23094607 "Bump eslint-plugin-unicorn to v68.0.0"** (Ready for Review, commit `6e91c496f`, branch `origin/sm/W-23094607-bump-eslint-plugin-unicorn-to-v68-0-0`, NOT yet on `develop`). WI-stated dep W-23094920 = sequencing only.
+- Violation set unknowable until v68 installed (sandbox npm date-capped <2026-06-13; v68 unreachable in sandbox).
+
+## Phases
+
+### Phase 0 — rebase onto v68 bump (prereq, no behavior)
+
+- `git fetch origin`.
+- Rebase this branch onto `origin/sm/W-23094607-bump-eslint-plugin-unicorn-to-v68-0-0` (or onto `develop` once that PR merges — check `git merge-base --is-ancestor 6e91c496f develop` first).
+- `npm install` to materialize v68.
+- Verify: `grep eslint-plugin-unicorn package.json` → `^68` (or `68.x`); `node_modules/eslint-plugin-unicorn/package.json` version starts `68`; `node_modules/eslint-plugin-unicorn/rules/prefer-hoisting-branch-code.js` exists.
+- Gate: do NOT start Phase 1 until all three checks pass. If rebase produces conflicts in `package.json`/`package-lock.json`, take theirs for the unicorn bump, resolve, re-`npm install`.
+
+### Phase 1a — enable rule (config-only commit)
+
+- Insert `'unicorn/prefer-hoisting-branch-code': 'error',` in unicorn block after `prefer-export-from`, before `prefer-includes` (alpha-ish ordering).
+- Only file changed: `eslint.config.mjs`.
+- `npm run lint` here will surface the full violation set (used to scope 1b).
+- Commit (config lands independently even if 1b blocked): `chore: enable unicorn/prefer-hoisting-branch-code in eslint.config.mjs`
+
+### Phase 1b — apply fixes (source commit, enumerated)
+
+- `npm run lint -- --fix` → auto-fix 🔧 trailing shared code.
+- Resolve 💡 leading-code suggestions per-site: hoist when no side-effect/eval-order change; leave in branches when hoisting would change eval order/side-effect timing. Do NOT inline-disable an auto-fixable case (fix the code). Inline-disable only where the rule's hoist is genuinely unsafe, with one-line justification citing the eval-order risk.
+- Enumerate every changed source file in the commit body (list known only after Phase 1a lint run).
+- Commit: `refactor: apply unicorn/prefer-hoisting-branch-code fixes` — body lists files + splits "trailing auto-fixes" vs "leading hoists" vs "disabled (unsafe eval-order)".
+
+## Skills
+
+- concise
+- typescript
+- verification
+- feature-branch
+- effect-best-practices (only if a touched site sits inside an Effect pipeline — preserve generator/yield* order; hoisting must not move a `yield*` across a branch boundary that changes effect sequencing)
+
+## Verification
+
+- `npm run lint` clean (rule = error → 0 violations).
+- `npm run compile` clean for touched packages.
+- Touched sites: eval order + side-effect timing preserved (esp. leading-code fixes); branch-unique stmts unchanged. For Effect code, `yield*` ordering and short-circuit semantics unchanged.
+- Unit tests (`npm run test:unit`) for packages owning touched files — guard refactor regressions (run after Phase 1a enumerates files).
+
+### e2e
+
+- Nature: lint-only behavior-preserving refactor. The rule only hoists token-identical statements out of branches; no new code paths, no new behavior. No NEW *.spec.ts is warranted.
+- Guardrail (not new coverage): once Phase 1a enumerates touched files, map each to its owning package and run that package's existing desktop/headless specs to confirm the hoist didn't regress runtime. Likely affected packages (control-flow-heavy command/picker/service logic) and representative existing specs:
+  - `salesforcedx-vscode-org` → `packages/salesforcedx-vscode-org/test/playwright/specs/orgPicker.desktop.spec.ts`, `.../orgCommands.desktop.spec.ts`
+  - `salesforcedx-vscode-metadata` → `packages/salesforcedx-vscode-metadata/test/playwright/specs/deployOnSave.headless.spec.ts`, `.../sourceDiff.headless.spec.ts`
+  - `salesforcedx-vscode-apex-log` → `packages/salesforcedx-vscode-apex-log/test/playwright/specs/executeAnonymous.headless.spec.ts`, `.../traceFlagsCrud.headless.spec.ts`
+  - `salesforcedx-vscode-lightning` → `packages/salesforcedx-vscode-lightning/test/playwright/specs/auraTemplates.desktop.spec.ts`, `.../auraRename.desktop.spec.ts`
+- If Phase 1a shows zero violations in a listed package's source, drop that package's specs from the run. If violations land in packages not listed above, add that package's specs by the same package→spec mapping. Full repo e2e suite runs in branch CI regardless.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -211,6 +211,7 @@ export default [
         'error',
         {
           case: 'camelCase',
+          // v68 added directory-name checks; preserve prior file-only behavior
           checkDirectories: false
         }
       ],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -192,6 +192,7 @@ export default [
       'unicorn/prefer-class-fields': 'error',
       'unicorn/prefer-date-now': 'error',
       'unicorn/prefer-export-from': 'error',
+      'unicorn/prefer-hoisting-branch-code': 'error',
       'unicorn/prefer-includes': 'error',
       'unicorn/prefer-modern-math-apis': 'error',
       'unicorn/prefer-native-coercion-functions': 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -44455,7 +44455,7 @@
       },
       "peerDependencies": {
         "@eslint/json": ">=0.3.0",
-        "eslint": ">=8.0.0"
+        "eslint": ">=9.0.0"
       }
     },
     "packages/eslint-local-rules/node_modules/@typescript-eslint/project-service": {

--- a/packages/playwright-vscode-ext/src/utils/helpers.ts
+++ b/packages/playwright-vscode-ext/src/utils/helpers.ts
@@ -338,12 +338,11 @@ export const closeWelcomeTabs = async (page: Page): Promise<void> => {
         await dismissAllQuickInputWidgets(page);
       }
       await closeButton.click({ timeout: 5000, force: true });
-      await welcomeTab.waitFor({ state: 'detached', timeout: 10_000 });
     } else {
       // Fall back to keyboard shortcut
       await page.keyboard.press('Control+w');
-      await welcomeTab.waitFor({ state: 'detached', timeout: 10_000 });
     }
+    await welcomeTab.waitFor({ state: 'detached', timeout: 10_000 });
 
     // Verify tab was closed - locators automatically re-evaluate
     const remainingCount = await welcomeTabs.count();

--- a/packages/salesforcedx-apex-replay-debugger/src/core/logContext.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/core/logContext.ts
@@ -248,15 +248,12 @@ export class LogContext {
           heapDump.setOverlaySuccessResult(result as unknown as ApexExecutionOverlayResultCommandSuccess);
           return true;
         } catch (error) {
-          if (error instanceof Error && 'errorCode' in error && typeof error.errorCode === 'string') {
-            const errorMessage = nls.localize('heap_dump_error', error.message, error.errorCode, heapDump.toString());
-            this.session.errorToDebugConsole(errorMessage);
-            return false;
-          } else {
-            const errorMessage = `${String(error)}. ${heapDump.toString()}`;
-            this.session.errorToDebugConsole(errorMessage);
-            return false;
-          }
+          const errorMessage =
+            error instanceof Error && 'errorCode' in error && typeof error.errorCode === 'string'
+              ? nls.localize('heap_dump_error', error.message, error.errorCode, heapDump.toString())
+              : `${String(error)}. ${heapDump.toString()}`;
+          this.session.errorToDebugConsole(errorMessage);
+          return false;
         }
       }
     } catch (error) {

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
@@ -260,12 +260,11 @@ export const retrieveLineBreakpointInfo = async (): Promise<boolean> => {
       if (lineBpInfo?.length) {
         console.log(nls.localize('line_breakpoint_information_success'));
         breakpointUtil.createMappingsFromLineBreakpointInfo(lineBpInfo);
-        return true;
       } else {
         const errorMessage = nls.localize('no_line_breakpoint_information_for_current_project');
         writeToDebuggerOutputWindow(errorMessage, true, VSCodeWindowTypeEnum.Error);
-        return true;
       }
+      return true;
     }
   } else {
     const errorMessage = nls.localize('session_language_server_error_text');


### PR DESCRIPTION
## Summary

- Enable `unicorn/prefer-hoisting-branch-code` rule in `eslint.config.mjs`
- Apply automated fixes to hoist shared code out of if/else branches
- Includes prerequisite ESLint 9→10 + plugin upgrades (W-23094607)

## Plan

[.claude/plans/W-23094922.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23094922-enable-unicorn-prefer-hoisting-branch-co/.claude/plans/W-23094922.md)

## Reviewer notes

### High severity

**import/no-cycle silently non-functional for .ts** (eslint.config.mjs:381) — NOT applied; requires separate WI. Investigation: the finding's premise (rule silent) is correct, but its claim that pre-swap eslint-plugin-import would have caught cycles is FALSE. Empirically verified on develop (old plugin, no resolver settings): planted cycle_a.ts<->cycle_b.ts is NOT flagged either — pre-existing latent bug, not introduced by import→import-x swap. Complete fix needs: (1) eslint-import-resolver-typescript dep + `settings['import-x/resolver-next']=[createTypeScriptImportResolver()]`, AND (2) `settings['import-x/extensions']` + `import-x/parsers` for .ts (resolver alone insufficient — import-x's ExportMap/getFileExtensions defaults to only .js/.mjs/.cjs at node_modules/eslint-plugin-import-x/lib/index.cjs:453, so .ts files skipped even when resolved). With full fix, import/no-cycle correctly fires (verified). BLOCKING REASON it was reverted: the same resolver wiring re-activates import/no-extraneous-dependencies (line 390), which was equally-silently-broken before. Verified it then errors `'@types/vscode' should be listed in the project's dependencies` across hundreds of vscode-importing source files (sampled vscode-core/apex/soql index.ts) — @types/vscode is root devDependency and vscode is host-injected ambient module. Enabling resolution breaks lint repo-wide and requires design decision (scope/ignore vscode + @types/* for no-extraneous-dependencies, audit any real cycles surfaced) far beyond 'enable one unicorn rule' WI. Recommend dedicated dependency/lint-hardening WI.

### Medium severity

**PR scope exceeds stated purpose** — W-23094922 ('enable unicorn/prefer-hoisting-branch-code') bundles entire W-23094607 ESLint 9→10 upgrade + plugin swaps (commits fbf45ba57, 4960c3a56, be475f0e1, 6e91c496f). The W-23094607 plan preferred keeping eslint-plugin-import via overrides and taking import-x only as fallback; this branch took the riskier fallback without isolated review. Cannot be 'fixed' by editing code (would require rebasing/splitting the branch — git-history design decision). Recommend reviewer split or explicitly accept bundling.

### Low severity

- **dataQuery.ts:341** collectSubQueryFieldPaths param narrowed {totalSize;done;records}→{records} — behavior-safe but unrelated scope creep in unicorn dep-bump commit. PR-body note only; narrowing itself is sound cleanup (clearer contract), not worth reverting.
- **typeMapping.ts:209/255** use .at(0) to check first char vs '_'. Verified correct and idiomatic; .startsWith('_') marginally more explicit but does not justify churn.
- **declarationGenerator.ts:42** ternary technically redundant (''.charAt(0).toUpperCase()+''.slice(1)===''), but diff only changed str[0]→str.charAt(0), not ternary; simplifying removes explicit empty-string edge-case documentation for negligible gain.
- **lwcUtils.ts:163** componentName[0]→charAt(0) — finding validates already-correct change (charAt avoids TypeError on empty string).

## Test plan

No manual verification required. All verification gates automated:
- Lint (rule = error → 0 violations)
- TypeScript compilation for touched packages
- Unit tests for packages with modified source files
- Full e2e test suite in CI

## What issues does this PR fix or reference?

@W-23094922@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.salesforce.com/a07EE00002ceqRIYAY