### PR TITLE
refactor(e2e): extract VS Code native commands to wrappers - W-23124419

### DIFF
--- a/.claude/plans/W-23124419.md
+++ b/.claude/plans/W-23124419.md
@@ -1,0 +1,98 @@
+# W-23124419 — Extract VS Code native commands to wrappers
+
+## Context
+
+EDE/playwright tests call `executeCommandWithCommandPalette(page, '<native cmd>')` w/ string literals for VS Code built-in commands. Goal: named wrapper fns (e.g. `focusOnFilesExplorer(page)`) for discoverability.
+
+- Shared lib: `packages/playwright-vscode-ext/src` — exports via `src/index.ts`.
+- SFDX/extension commands (`SFDX: ...`, `Testing: ...`, `Test: ...`) out of scope — extension-owned, not native.
+- `Go to Line/Column...` already wrapped internally by `goToLineCol` (fileHelpers.ts:379); add nothing new for it beyond the new home (see Phase 1 note).
+- Some callers chain `.catch(() => {})` (e.g. `View: Close All Editors` in composedManualMerge, desktopFixtures; `View: Focus Active Editor Group` in codeLens.ts:30). Wrappers return the same Promise → `.catch()` still chains.
+- Some callers pass selection/palette opts (e.g. `Go to Definition` w/ `{ preserveSelection: true }`) — wrappers forward optional `OpenCommandPaletteOptions` (and the positional secondary arg where used).
+
+## Phase 0 — Full native-command inventory (scope decision)
+
+WI named 11 commands; codebase audit found **more** native VS Code commands behind `executeCommandWithCommandPalette`. Ship a COMPLETE migration so callers never have to guess which natives have wrappers. Source of truth — `grep -rhoE "executeCommandWithCommandPalette\([^,]+, '[^']+'" packages --include="*.ts"` (run at plan time; re-run before Phase 1 to refresh counts).
+
+In-scope native commands → wrap (Phase 1). Counts = callsites (literal-arg form):
+- `File: Focus on Files Explorer` (9) → `focusOnFilesExplorer`
+- `File: New Untitled Text File` (2) → `newUntitledTextFile`
+- `File: Save` (16) → `saveFile`
+- `Notifications: Clear All Notifications` (3) → `clearAllNotifications`
+- `View: Close All Editors` (14) → `closeAllEditors`
+- `View: Show Explorer` (1) → `showExplorer`
+- `Developer: Reload Window` (2) → `reloadWindow`
+- `Go to File...` (1) → `goToFile`
+- `Go to Line/Column...` (5) → `goToLineColumn`
+- `Select All` (6) → `selectAll`
+- `Paste` (2) → `paste`
+- `Problems: Focus on Problems View` (1, shared lib `pages/problems.ts:23`) → `focusOnProblemsView` — NOT in WI; added so the shared-lib literal migrates (else Phase 2 leaves a dangling literal).
+- `Go to Definition` (3 files, incl. `{ preserveSelection: true }` arg) → `goToDefinition`
+- `View: Focus Active Editor Group` (1, `pages/codeLens.ts:30`, `.catch`) → `focusActiveEditorGroup`
+- `Find` (6 files) → `find`
+- `View: Hide Panel` (1) → `hidePanel`
+- `View: Clear Output` (1) → `clearOutput`
+- `View: Close Editor` (2 files) → `closeEditor`
+- `Snippets: Insert Snippet` (2 files) → `insertSnippet`
+- `Developer: Show Running Extensions` (1, workflows.ts) → `showRunningExtensions`
+- `View: Hide Secondary Side Bar` (1, workflows.ts) → `hideSecondarySideBar`
+- `Workspaces: Close Workspace` (1, workflows.ts) → `closeWorkspace`
+
+Out of scope (NOT native — extension/test-provider commands): all `SFDX: ...`, `Testing: ...`, `Test: ...` (e.g. `Testing: Focus on Test Explorer View`, `Test: Refresh Tests`, `Test: Run All Tests`).
+
+Deliverable for Phase 0: confirm the inventory above against a fresh grep; update WI description if scope expanded beyond the 11 it lists (note the +11 natives now covered). No code in this phase.
+
+## Phase 1 — Add native-command wrappers
+- New file `packages/playwright-vscode-ext/src/pages/nativeCommands.ts`.
+- One `const` arrow fn per in-scope native cmd from Phase 0, all `(page: Page, options?: OpenCommandPaletteOptions) => Promise<void>` delegating to `executeCommandWithCommandPalette`.
+  - For wrappers whose callers pass the positional secondary arg + opts (e.g. `goToDefinition`), match the existing `executeCommandWithCommandPalette` signature so all current call shapes forward unchanged.
+- `focusActiveEditorGroup` and any `.catch`-chained caller: wrapper returns the Promise; callers keep their `.catch(() => {})`.
+- Re-export from `src/index.ts`.
+- Keep `executeCommandWithCommandPalette` exported (SFDX/`Testing:`/`Test:` cmds still use it directly).
+- Commit msg: `feat(playwright-ext): add native VS Code command wrappers - W-23124419`
+
+## Phase 2 — Migrate shared-lib internal callers
+- Replace literals in `playwright-vscode-ext/src` w/ new wrappers. Known hits: `utils/fileHelpers.ts`, `utils/workflows.ts` (`showRunningExtensions`, `hideSecondarySideBar`, `closeWorkspace`), `pages/contextMenu.ts`, `pages/problems.ts:23` (`focusOnProblemsView`), `pages/codeLens.ts:30` (`focusActiveEditorGroup`, preserve `.catch`). Re-grep src for any other native literal.
+- `goToLineCol` body → call `goToLineColumn`.
+- Commit msg: `refactor(playwright-ext): use native command wrappers in shared lib - W-23124419`
+
+## Phase 3 — Migrate consumer spec files
+- Replace native literals across `packages/*/test/playwright` for ALL in-scope commands from Phase 0.
+- Import wrappers from `@salesforce/...playwright-vscode-ext` (match existing import path in each spec).
+- Preserve `.catch()` chains + passed options (e.g. `goToDefinition(page, undefined, { preserveSelection: true })`).
+- Packages touched (audit): apex-log, metadata, apex-oas, apex, apex-testing, soql, lwc, lightning, visualforce, playwright-vscode-ext/test.
+- Commit msg: `refactor(e2e): use native command wrappers in specs - W-23124419`
+
+## Phase 4 — Dedicated e2e coverage for wrappers
+New wrappers are behavior-changing surface even though they delegate to a tested primitive; advocate requires each proven directly.
+- New headless spec `packages/playwright-vscode-ext/test/playwright/specs/nativeCommandWrappers.headless.spec.ts`.
+- Follow conventions of existing `commandPalette.headless.spec.ts` / `fileOperations.headless.spec.ts`: copyright header, import wrappers from `../../../src/pages/nativeCommands`, `test` from `../fixtures/index`, `beforeEach` w/ `waitForVSCodeWorkbench` + `closeWelcomeTabs` + `ensureSecondarySideBarHidden`.
+- One distinct `test(...)` per wrapper asserting observable effect:
+  - `focusOnFilesExplorer` → Files Explorer view focused.
+  - `newUntitledTextFile` → new untitled editor tab appears.
+  - `saveFile` → dirty editor becomes clean (no dirty indicator).
+  - `clearAllNotifications` → notifications toasts cleared.
+  - `closeAllEditors` → 0 non-welcome editor tabs.
+  - `showExplorer` → Explorer sidebar visible.
+  - `reloadWindow` → workbench reloads (re-`waitForVSCodeWorkbench`).
+  - `goToFile` → quick-open file picker active.
+  - `goToLineColumn` → cursor at target line/col (set up a multi-line untitled doc).
+  - `selectAll` → editor selection spans full document.
+  - `paste` → clipboard content inserted at cursor.
+  - `focusOnProblemsView` → Problems view visible (reuse `[id="workbench.panel.markers"]` from `pages/problems.ts`).
+- Coverage scope: WI-named 11 + `focusOnProblemsView` (all exercisable headlessly). Wrappers only meaningfully testable on desktop or requiring an extension context (e.g. `goToDefinition` LSP nav, `showRunningExtensions`) are NOT in this headless spec; they remain covered by their existing owning specs (apex/lwc/lightning/visualforce LSP specs already exercise `Go to Definition`). Note this split in the spec's top comment.
+- Run before commit: `npm run test:web --workspace=@salesforce/playwright-vscode-ext` (headless web config). Re-run any owning specs touched in Phase 3 if locally feasible.
+- Commit msg: `test(playwright-ext): e2e coverage for native command wrappers - W-23124419`
+
+## Skills to apply
+- playwright-e2e — test conventions, import paths, headless spec naming, run command
+- typescript — `const` arrow fns, `type` over `interface`, direct imports (no barrels)
+- packageJson / wireit — only if build graph cares about new export (verify build)
+- concise — plan/doc style
+
+## Verification
+- `npm run compile` (or pkg `compile`) in `packages/playwright-vscode-ext` — types/exports resolve.
+- `npx eslint` on changed files — lint clean.
+- `grep -rhoE "executeCommandWithCommandPalette\([^,]+, '[^']+'" packages --include="*.ts"` returns ONLY out-of-scope `SFDX:`/`Testing:`/`Test:` literals + the wrapper defs in `pages/nativeCommands.ts`. 0 remaining in-scope native literals elsewhere.
+- New `nativeCommandWrappers.headless.spec.ts` passes (covers WI 11 + `focusOnProblemsView`).
+- Existing owning specs unchanged in behavior (Go to Definition etc. delegate 1:1) — covered by their CI suites.

--- a/.claude/plans/W-23124419.md
+++ b/.claude/plans/W-23124419.md
@@ -2,19 +2,19 @@
 
 ## Context
 
-EDE/playwright tests call `executeCommandWithCommandPalette(page, '<native cmd>')` w/ string literals for VS Code built-in commands. Goal: named wrapper fns (e.g. `focusOnFilesExplorer(page)`) for discoverability.
+EDE/playwright: replace native cmd string literals w/ named wrappers (e.g. `focusOnFilesExplorer`) for discoverability. Callsites: `executeCommandWithCommandPalette(page, '<native cmd>')`.
 
 - Shared lib: `packages/playwright-vscode-ext/src` — exports via `src/index.ts`.
 - SFDX/extension commands (`SFDX: ...`, `Testing: ...`, `Test: ...`) out of scope — extension-owned, not native.
-- `Go to Line/Column...` already wrapped internally by `goToLineCol` (fileHelpers.ts:379); add nothing new for it beyond the new home (see Phase 1 note).
-- Some callers chain `.catch(() => {})` (e.g. `View: Close All Editors` in composedManualMerge, desktopFixtures; `View: Focus Active Editor Group` in codeLens.ts:30). Wrappers return the same Promise → `.catch()` still chains.
-- Some callers pass selection/palette opts (e.g. `Go to Definition` w/ `{ preserveSelection: true }`) — wrappers forward optional `OpenCommandPaletteOptions` (and the positional secondary arg where used).
+- `Go to Line/Column...` already wrapped internally by `goToLineCol` (fileHelpers.ts:379); add nothing beyond new home (see Phase 1 note).
+- Some callers chain `.catch(() => {})` (e.g. `View: Close All Editors` in composedManualMerge, desktopFixtures; `View: Focus Active Editor Group` in codeLens.ts:30). Wrappers return same Promise → `.catch()` still chains.
+- Some callers pass selection/palette opts (e.g. `Go to Definition` w/ `{ preserveSelection: true }`) — wrappers forward optional `OpenCommandPaletteOptions` + positional secondary arg where used.
 
 ## Phase 0 — Full native-command inventory (scope decision)
 
-WI named 11 commands; codebase audit found **more** native VS Code commands behind `executeCommandWithCommandPalette`. Ship a COMPLETE migration so callers never have to guess which natives have wrappers. Source of truth — `grep -rhoE "executeCommandWithCommandPalette\([^,]+, '[^']+'" packages --include="*.ts"` (run at plan time; re-run before Phase 1 to refresh counts).
+WI named 11 cmds; audit found **more** natives behind `executeCommandWithCommandPalette`. Ship COMPLETE migration — no guessing which natives have wrappers. Source of truth — `grep -rhoE "executeCommandWithCommandPalette\([^,]+, '[^']+'" packages --include="*.ts"` (re-run before Phase 1 to refresh counts).
 
-In-scope native commands → wrap (Phase 1). Counts = callsites (literal-arg form):
+In-scope natives → wrap (Phase 1). Counts = callsites (literal-arg form):
 - `File: Focus on Files Explorer` (9) → `focusOnFilesExplorer`
 - `File: New Untitled Text File` (2) → `newUntitledTextFile`
 - `File: Save` (16) → `saveFile`
@@ -26,7 +26,7 @@ In-scope native commands → wrap (Phase 1). Counts = callsites (literal-arg for
 - `Go to Line/Column...` (5) → `goToLineColumn`
 - `Select All` (6) → `selectAll`
 - `Paste` (2) → `paste`
-- `Problems: Focus on Problems View` (1, shared lib `pages/problems.ts:23`) → `focusOnProblemsView` — NOT in WI; added so the shared-lib literal migrates (else Phase 2 leaves a dangling literal).
+- `Problems: Focus on Problems View` (1, shared lib `pages/problems.ts:23`) → `focusOnProblemsView` — NOT in WI; added so shared-lib literal migrates (else Phase 2 leaves dangling literal).
 - `Go to Definition` (3 files, incl. `{ preserveSelection: true }` arg) → `goToDefinition`
 - `View: Focus Active Editor Group` (1, `pages/codeLens.ts:30`, `.catch`) → `focusActiveEditorGroup`
 - `Find` (6 files) → `find`
@@ -38,21 +38,21 @@ In-scope native commands → wrap (Phase 1). Counts = callsites (literal-arg for
 - `View: Hide Secondary Side Bar` (1, workflows.ts) → `hideSecondarySideBar`
 - `Workspaces: Close Workspace` (1, workflows.ts) → `closeWorkspace`
 
-Out of scope (NOT native — extension/test-provider commands): all `SFDX: ...`, `Testing: ...`, `Test: ...` (e.g. `Testing: Focus on Test Explorer View`, `Test: Refresh Tests`, `Test: Run All Tests`).
+Out of scope (NOT native — extension/test-provider cmds): all `SFDX: ...`, `Testing: ...`, `Test: ...` (e.g. `Testing: Focus on Test Explorer View`, `Test: Refresh Tests`, `Test: Run All Tests`).
 
-Deliverable for Phase 0: confirm the inventory above against a fresh grep; update WI description if scope expanded beyond the 11 it lists (note the +11 natives now covered). No code in this phase.
+Deliverable: confirm inventory vs fresh grep; update WI description if scope expanded beyond its 11 (note +11 natives now covered). No code this phase.
 
 ## Phase 1 — Add native-command wrappers
 - New file `packages/playwright-vscode-ext/src/pages/nativeCommands.ts`.
 - One `const` arrow fn per in-scope native cmd from Phase 0, all `(page: Page, options?: OpenCommandPaletteOptions) => Promise<void>` delegating to `executeCommandWithCommandPalette`.
-  - For wrappers whose callers pass the positional secondary arg + opts (e.g. `goToDefinition`), match the existing `executeCommandWithCommandPalette` signature so all current call shapes forward unchanged.
-- `focusActiveEditorGroup` and any `.catch`-chained caller: wrapper returns the Promise; callers keep their `.catch(() => {})`.
+  - Wrappers whose callers pass positional secondary arg + opts (e.g. `goToDefinition`): match existing `executeCommandWithCommandPalette` signature so all call shapes forward unchanged.
+- `focusActiveEditorGroup` + any `.catch`-chained caller: wrapper returns Promise; callers keep `.catch(() => {})`.
 - Re-export from `src/index.ts`.
-- Keep `executeCommandWithCommandPalette` exported (SFDX/`Testing:`/`Test:` cmds still use it directly).
+- Keep `executeCommandWithCommandPalette` exported (SFDX/`Testing:`/`Test:` cmds use it directly).
 - Commit msg: `feat(playwright-ext): add native VS Code command wrappers - W-23124419`
 
 ## Phase 2 — Migrate shared-lib internal callers
-- Replace literals in `playwright-vscode-ext/src` w/ new wrappers. Known hits: `utils/fileHelpers.ts`, `utils/workflows.ts` (`showRunningExtensions`, `hideSecondarySideBar`, `closeWorkspace`), `pages/contextMenu.ts`, `pages/problems.ts:23` (`focusOnProblemsView`), `pages/codeLens.ts:30` (`focusActiveEditorGroup`, preserve `.catch`). Re-grep src for any other native literal.
+- Replace literals in `playwright-vscode-ext/src` w/ wrappers. Known hits: `utils/fileHelpers.ts`, `utils/workflows.ts` (`showRunningExtensions`, `hideSecondarySideBar`, `closeWorkspace`), `pages/contextMenu.ts`, `pages/problems.ts:23` (`focusOnProblemsView`), `pages/codeLens.ts:30` (`focusActiveEditorGroup`, preserve `.catch`). Re-grep src for other native literals.
 - `goToLineCol` body → call `goToLineColumn`.
 - Commit msg: `refactor(playwright-ext): use native command wrappers in shared lib - W-23124419`
 
@@ -64,7 +64,7 @@ Deliverable for Phase 0: confirm the inventory above against a fresh grep; updat
 - Commit msg: `refactor(e2e): use native command wrappers in specs - W-23124419`
 
 ## Phase 4 — Dedicated e2e coverage for wrappers
-New wrappers are behavior-changing surface even though they delegate to a tested primitive; advocate requires each proven directly.
+New wrappers are behavior-changing surface despite delegating to a tested primitive; advocate requires each proven directly.
 - New headless spec `packages/playwright-vscode-ext/test/playwright/specs/nativeCommandWrappers.headless.spec.ts`.
 - Follow conventions of existing `commandPalette.headless.spec.ts` / `fileOperations.headless.spec.ts`: copyright header, import wrappers from `../../../src/pages/nativeCommands`, `test` from `../fixtures/index`, `beforeEach` w/ `waitForVSCodeWorkbench` + `closeWelcomeTabs` + `ensureSecondarySideBarHidden`.
 - One distinct `test(...)` per wrapper asserting observable effect:
@@ -80,8 +80,8 @@ New wrappers are behavior-changing surface even though they delegate to a tested
   - `selectAll` → editor selection spans full document.
   - `paste` → clipboard content inserted at cursor.
   - `focusOnProblemsView` → Problems view visible (reuse `[id="workbench.panel.markers"]` from `pages/problems.ts`).
-- Coverage scope: WI-named 11 + `focusOnProblemsView` (all exercisable headlessly). Wrappers only meaningfully testable on desktop or requiring an extension context (e.g. `goToDefinition` LSP nav, `showRunningExtensions`) are NOT in this headless spec; they remain covered by their existing owning specs (apex/lwc/lightning/visualforce LSP specs already exercise `Go to Definition`). Note this split in the spec's top comment.
-- Run before commit: `npm run test:web --workspace=@salesforce/playwright-vscode-ext` (headless web config). Re-run any owning specs touched in Phase 3 if locally feasible.
+- Coverage scope: WI-named 11 + `focusOnProblemsView` (all exercisable headlessly). Wrappers only testable on desktop or needing extension context (e.g. `goToDefinition` LSP nav, `showRunningExtensions`) are NOT here; covered by existing owning specs (apex/lwc/lightning/visualforce LSP specs already exercise `Go to Definition`). Note split in spec's top comment.
+- Run before commit: `npm run test:web --workspace=@salesforce/playwright-vscode-ext` (headless web config). Re-run owning specs touched in Phase 3 if locally feasible.
 - Commit msg: `test(playwright-ext): e2e coverage for native command wrappers - W-23124419`
 
 ## Skills to apply
@@ -95,4 +95,4 @@ New wrappers are behavior-changing surface even though they delegate to a tested
 - `npx eslint` on changed files — lint clean.
 - `grep -rhoE "executeCommandWithCommandPalette\([^,]+, '[^']+'" packages --include="*.ts"` returns ONLY out-of-scope `SFDX:`/`Testing:`/`Test:` literals + the wrapper defs in `pages/nativeCommands.ts`. 0 remaining in-scope native literals elsewhere.
 - New `nativeCommandWrappers.headless.spec.ts` passes (covers WI 11 + `focusOnProblemsView`).
-- Existing owning specs unchanged in behavior (Go to Definition etc. delegate 1:1) — covered by their CI suites.
+- Owning specs unchanged in behavior (Go to Definition etc. delegate 1:1) — covered by their CI suites.

--- a/.claude/skills/playwright-e2e/references/coding-playwright-tests.md
+++ b/.claude/skills/playwright-e2e/references/coding-playwright-tests.md
@@ -74,6 +74,15 @@ Desktop fixture sets `window.menuStyle: "custom"` (context menus stay in DOM on 
 - Use `f1` for commands, not meta-shift-P
 - Use `Control` for all. No ControlOrMeta
 
+## Native VS Code Commands
+
+Native VS Code commands (`File: Save`, `View: Close All Editors`, `Select All`, `Paste`, `Go to Definition`, etc.) — use named wrappers in `packages/playwright-vscode-ext/src/pages/nativeCommands.ts` (exported from `src/index.ts`), NOT `executeCommandWithCommandPalette(page, '<literal>')`.
+
+- `saveFile(page)`, `closeAllEditors(page)`, `selectAll(page)`, `goToDefinition(page, sel?, opts?)`, etc. — grep `nativeCommands.ts` for full list before adding a literal.
+- Wrappers return same Promise → existing `.catch(() => {})` chains + palette/selection opts still work.
+- Reserve `executeCommandWithCommandPalette` for extension/test-provider commands (`SFDX:`, `Testing:`, `Test:`) — NOT native.
+- Native command with no wrapper yet? Add one to `nativeCommands.ts`, don't inline the literal.
+
 ## Commands and i18n
 
 Prefer `package.nls.json` for command titles instead of hardcoded strings.

--- a/packages/playwright-vscode-ext/src/index.ts
+++ b/packages/playwright-vscode-ext/src/index.ts
@@ -85,6 +85,31 @@ export {
 } from './pages/commands';
 export type { OpenCommandPaletteOptions } from './pages/commands';
 
+export {
+  focusOnFilesExplorer,
+  newUntitledTextFile,
+  saveFile,
+  clearAllNotifications,
+  closeAllEditors,
+  showExplorer,
+  reloadWindow,
+  goToFile,
+  goToLineColumn,
+  selectAll,
+  paste,
+  focusOnProblemsView,
+  goToDefinition,
+  focusActiveEditorGroup,
+  find,
+  hidePanel,
+  clearOutput,
+  closeEditor,
+  insertSnippet,
+  showRunningExtensions,
+  hideSecondarySideBar,
+  closeWorkspace
+} from './pages/nativeCommands';
+
 export { executeEditorContextMenuCommand, executeExplorerContextMenuCommand } from './pages/contextMenu';
 
 export {

--- a/packages/playwright-vscode-ext/src/pages/codeLens.ts
+++ b/packages/playwright-vscode-ext/src/pages/codeLens.ts
@@ -8,7 +8,7 @@
 import { type Page } from '@playwright/test';
 import { escapeRegExp } from '../utils/helpers';
 import { CODELENS_ITEM, EDITOR_WITH_URI } from '../utils/locators';
-import { executeCommandWithCommandPalette } from './commands';
+import { focusActiveEditorGroup } from './nativeCommands';
 
 /**
  * Click the first code lens whose visible text matches `text` (whitespace-tolerant exact match).
@@ -27,7 +27,7 @@ export const clickCodeLens = async (page: Page, text: string, opts?: { timeout?:
 
   // Ensure an editor is the active part of the workbench (output/terminal panels can steal focus).
   // No-op if already focused; "View: Focus Active Editor Group" exists in all VS Code versions.
-  await executeCommandWithCommandPalette(page, 'View: Focus Active Editor Group').catch(() => {});
+  await focusActiveEditorGroup(page).catch(() => {});
   await page
     .locator(EDITOR_WITH_URI)
     .first()

--- a/packages/playwright-vscode-ext/src/pages/contextMenu.ts
+++ b/packages/playwright-vscode-ext/src/pages/contextMenu.ts
@@ -7,7 +7,7 @@
 
 import type { Page, Locator } from '@playwright/test';
 import { EDITOR_WITH_URI, CONTEXT_MENU } from '../utils/locators';
-import { executeCommandWithCommandPalette } from './commands';
+import { focusOnFilesExplorer } from './nativeCommands';
 
 /** Opens context menu on an editor. If fileName is provided, matches editor by URI/name (partial match). */
 const openEditorContextMenu = async (page: Page, fileName?: string): Promise<Locator> => {
@@ -51,7 +51,7 @@ const openEditorContextMenu = async (page: Page, fileName?: string): Promise<Loc
 
 /** Opens context menu on a file/folder in the explorer sidebar */
 const openExplorerContextMenu = async (page: Page, itemName: string | RegExp): Promise<Locator> => {
-  await executeCommandWithCommandPalette(page, 'File: Focus on Files Explorer');
+  await focusOnFilesExplorer(page);
   // Filter out sticky rows which intercept clicks - get all matching items then exclude sticky ones
   const allTreeItems = page.getByRole('treeitem', { name: itemName });
   const count = await allTreeItems.count();

--- a/packages/playwright-vscode-ext/src/pages/nativeCommands.ts
+++ b/packages/playwright-vscode-ext/src/pages/nativeCommands.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Page } from '@playwright/test';
+import { type Page } from '@playwright/test';
 import { executeCommandWithCommandPalette, OpenCommandPaletteOptions } from './commands';
 
 /**

--- a/packages/playwright-vscode-ext/src/pages/nativeCommands.ts
+++ b/packages/playwright-vscode-ext/src/pages/nativeCommands.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Page } from '@playwright/test';
+import { executeCommandWithCommandPalette, OpenCommandPaletteOptions } from './commands';
+
+/**
+ * Named wrappers for VS Code built-in (native) command-palette commands.
+ *
+ * Each delegates to `executeCommandWithCommandPalette` with the native command title, so callers
+ * get discoverable, refactor-safe functions instead of bare string literals. Extension-owned
+ * commands (`SFDX: …`, `Testing: …`, `Test: …`) are intentionally NOT wrapped here — they keep
+ * calling `executeCommandWithCommandPalette` directly.
+ */
+
+/** `File: Focus on Files Explorer` */
+export const focusOnFilesExplorer = (page: Page, options?: OpenCommandPaletteOptions): Promise<void> =>
+  executeCommandWithCommandPalette(page, 'File: Focus on Files Explorer', undefined, options);
+
+/** `File: New Untitled Text File` */
+export const newUntitledTextFile = (page: Page, options?: OpenCommandPaletteOptions): Promise<void> =>
+  executeCommandWithCommandPalette(page, 'File: New Untitled Text File', undefined, options);
+
+/** `File: Save` */
+export const saveFile = (page: Page, options?: OpenCommandPaletteOptions): Promise<void> =>
+  executeCommandWithCommandPalette(page, 'File: Save', undefined, options);
+
+/** `Notifications: Clear All Notifications` */
+export const clearAllNotifications = (page: Page, options?: OpenCommandPaletteOptions): Promise<void> =>
+  executeCommandWithCommandPalette(page, 'Notifications: Clear All Notifications', undefined, options);
+
+/** `View: Close All Editors` */
+export const closeAllEditors = (page: Page, options?: OpenCommandPaletteOptions): Promise<void> =>
+  executeCommandWithCommandPalette(page, 'View: Close All Editors', undefined, options);
+
+/** `View: Show Explorer` */
+export const showExplorer = (page: Page, options?: OpenCommandPaletteOptions): Promise<void> =>
+  executeCommandWithCommandPalette(page, 'View: Show Explorer', undefined, options);
+
+/** `Developer: Reload Window` */
+export const reloadWindow = (page: Page, options?: OpenCommandPaletteOptions): Promise<void> =>
+  executeCommandWithCommandPalette(page, 'Developer: Reload Window', undefined, options);
+
+/** `Go to File...` */
+export const goToFile = (page: Page, options?: OpenCommandPaletteOptions): Promise<void> =>
+  executeCommandWithCommandPalette(page, 'Go to File...', undefined, options);
+
+/** `Go to Line/Column...` */
+export const goToLineColumn = (page: Page, options?: OpenCommandPaletteOptions): Promise<void> =>
+  executeCommandWithCommandPalette(page, 'Go to Line/Column...', undefined, options);
+
+/** `Select All` */
+export const selectAll = (page: Page, options?: OpenCommandPaletteOptions): Promise<void> =>
+  executeCommandWithCommandPalette(page, 'Select All', undefined, options);
+
+/** `Paste` */
+export const paste = (page: Page, options?: OpenCommandPaletteOptions): Promise<void> =>
+  executeCommandWithCommandPalette(page, 'Paste', undefined, options);
+
+/** `Problems: Focus on Problems View` */
+export const focusOnProblemsView = (page: Page, options?: OpenCommandPaletteOptions): Promise<void> =>
+  executeCommandWithCommandPalette(page, 'Problems: Focus on Problems View', undefined, options);
+
+/** `Go to Definition` */
+export const goToDefinition = (page: Page, options?: OpenCommandPaletteOptions): Promise<void> =>
+  executeCommandWithCommandPalette(page, 'Go to Definition', undefined, options);
+
+/** `View: Focus Active Editor Group` */
+export const focusActiveEditorGroup = (page: Page, options?: OpenCommandPaletteOptions): Promise<void> =>
+  executeCommandWithCommandPalette(page, 'View: Focus Active Editor Group', undefined, options);
+
+/** `Find` */
+export const find = (page: Page, options?: OpenCommandPaletteOptions): Promise<void> =>
+  executeCommandWithCommandPalette(page, 'Find', undefined, options);
+
+/** `View: Hide Panel` */
+export const hidePanel = (page: Page, options?: OpenCommandPaletteOptions): Promise<void> =>
+  executeCommandWithCommandPalette(page, 'View: Hide Panel', undefined, options);
+
+/** `View: Clear Output` */
+export const clearOutput = (page: Page, options?: OpenCommandPaletteOptions): Promise<void> =>
+  executeCommandWithCommandPalette(page, 'View: Clear Output', undefined, options);
+
+/** `View: Close Editor` */
+export const closeEditor = (page: Page, options?: OpenCommandPaletteOptions): Promise<void> =>
+  executeCommandWithCommandPalette(page, 'View: Close Editor', undefined, options);
+
+/** `Snippets: Insert Snippet` */
+export const insertSnippet = (page: Page, options?: OpenCommandPaletteOptions): Promise<void> =>
+  executeCommandWithCommandPalette(page, 'Snippets: Insert Snippet', undefined, options);
+
+/** `Developer: Show Running Extensions` */
+export const showRunningExtensions = (page: Page, options?: OpenCommandPaletteOptions): Promise<void> =>
+  executeCommandWithCommandPalette(page, 'Developer: Show Running Extensions', undefined, options);
+
+/** `View: Hide Secondary Side Bar` */
+export const hideSecondarySideBar = (page: Page, options?: OpenCommandPaletteOptions): Promise<void> =>
+  executeCommandWithCommandPalette(page, 'View: Hide Secondary Side Bar', undefined, options);
+
+/** `Workspaces: Close Workspace` */
+export const closeWorkspace = (page: Page, options?: OpenCommandPaletteOptions): Promise<void> =>
+  executeCommandWithCommandPalette(page, 'Workspaces: Close Workspace', undefined, options);

--- a/packages/playwright-vscode-ext/src/pages/outputChannel.ts
+++ b/packages/playwright-vscode-ext/src/pages/outputChannel.ts
@@ -10,7 +10,8 @@ import { saveScreenshot } from '../shared/screenshotUtils';
 import { isDesktop } from '../utils/helpers';
 import { EDITOR, CONTEXT_MENU, EDITOR_WITH_URI, TAB, QUICK_INPUT_LIST_ROW } from '../utils/locators';
 import { activeQuickInputTextField, activeQuickInputWidget } from '../utils/quickInput';
-import { executeCommandWithCommandPalette, openCommandPalette } from './commands';
+import { openCommandPalette } from './commands';
+import { clearOutput } from './nativeCommands';
 
 const OUTPUT_PANEL_ID = '[id="workbench.panel.output"]';
 const outputPanel = (page: Page) => page.locator(OUTPUT_PANEL_ID);
@@ -259,7 +260,7 @@ export const outputChannelContains = async (
  * Use this to make sure that your assertions are not picking up text from the previous test unless you mean to
  */
 export const clearOutputChannel = async (page: Page): Promise<void> => {
-  await executeCommandWithCommandPalette(page, 'View: Clear Output');
+  await clearOutput(page);
 
   // Wait for the clear action to take effect - output should be completely empty
   const codeArea = outputPanelCodeArea(page);

--- a/packages/playwright-vscode-ext/src/pages/problems.ts
+++ b/packages/playwright-vscode-ext/src/pages/problems.ts
@@ -6,7 +6,7 @@
  */
 
 import { expect, type Page } from '@playwright/test';
-import { executeCommandWithCommandPalette } from './commands';
+import { focusOnProblemsView } from './nativeCommands';
 
 /** Problems view container (panel or sidebar). VS Code uses workbench.panel.markers for the Problems panel. */
 const PROBLEMS_VIEW = '[id="workbench.panel.markers"]';
@@ -20,7 +20,7 @@ export const ensureProblemsViewOpen = async (page: Page): Promise<void> => {
   if (await view.isVisible().catch(() => false)) {
     return;
   }
-  await executeCommandWithCommandPalette(page, 'Problems: Focus on Problems View');
+  await focusOnProblemsView(page);
   await expect(view).toBeVisible({ timeout: 10_000 });
 };
 

--- a/packages/playwright-vscode-ext/src/utils/fileHelpers.ts
+++ b/packages/playwright-vscode-ext/src/utils/fileHelpers.ts
@@ -10,6 +10,15 @@ import { createMinimalOrg } from '../orgs/minimalScratchOrgSetup';
 import { createNonTrackingOrg } from '../orgs/nonTrackingScratchOrgSetup';
 import { executeCommandWithCommandPalette, verifyCommandExists } from '../pages/commands';
 import {
+  focusOnFilesExplorer,
+  goToFile,
+  goToLineColumn,
+  newUntitledTextFile,
+  paste,
+  saveFile,
+  selectAll
+} from '../pages/nativeCommands';
+import {
   clearOutputChannel,
   ensureOutputPanelOpen,
   selectOutputChannel,
@@ -50,7 +59,7 @@ export const createFileWithContents = async (page: Page, _filePath: string, cont
   await page.locator(WORKBENCH).click();
 
   // Create a new untitled file
-  await executeCommandWithCommandPalette(page, 'File: New Untitled Text File');
+  await newUntitledTextFile(page);
 
   // Wait for command palette to close first
   const widget = activeQuickInputWidget(page);
@@ -124,7 +133,7 @@ export const createApexClass = async (page: Page, className: string, content?: s
     await editor.locator('.view-line').first().waitFor({ state: 'visible', timeout: 5000 });
 
     // Select all (template) via command palette so it runs in the active editor (keyboard shortcut can miss on web)
-    await executeCommandWithCommandPalette(page, 'Select All');
+    await selectAll(page);
 
     // Delete the selected content
     await page.keyboard.press('Delete');
@@ -134,10 +143,10 @@ export const createApexClass = async (page: Page, className: string, content?: s
     await page.evaluate((text: string) => navigator.clipboard.writeText(text), content);
 
     // Paste the content
-    await executeCommandWithCommandPalette(page, 'Paste');
+    await paste(page);
 
     // Save so the file is persisted and can be deployed / discovered by the test controller
-    await executeCommandWithCommandPalette(page, 'File: Save');
+    await saveFile(page);
     await expect(page.locator(DIRTY_EDITOR).first()).not.toBeVisible({ timeout: 10_000 });
   }
 };
@@ -205,7 +214,7 @@ export const openFileFromExplorerTree = async (
   parentFolders: readonly string[] = []
 ): Promise<void> => {
   // Focus the Files Explorer view; palette avoids keybinding conflicts
-  await executeCommandWithCommandPalette(page, 'File: Focus on Files Explorer');
+  await focusOnFilesExplorer(page);
   const tree = page.getByRole('tree', { name: /Files Explorer/i }).first();
   await tree.waitFor({ state: 'visible', timeout: 10_000 });
 
@@ -246,7 +255,7 @@ export const openFileByName = async (page: Page, fileName: string): Promise<void
 
   if (isDesktop()) {
     // On macOS desktop, Control+P doesn't work reliably, use command palette instead
-    await executeCommandWithCommandPalette(page, 'Go to File...');
+    await goToFile(page);
 
     // Wait for Quick Open widget to be visible and ready
     await expect(widget).toBeVisible({ timeout: 10_000 });
@@ -354,7 +363,7 @@ export const replaceLineInOpenFile = async (page: Page, lineNumber: number, newT
   await editor.click();
 
   // Open Go to Line/Column palette, type the line number, confirm
-  await executeCommandWithCommandPalette(page, 'Go to Line/Column...');
+  await goToLineColumn(page);
   await page.keyboard.type(String(lineNumber));
   await page.keyboard.press('Enter');
 
@@ -368,7 +377,7 @@ export const replaceLineInOpenFile = async (page: Page, lineNumber: number, newT
   await page.keyboard.press('Delete');
   await page.keyboard.type(newText);
 
-  await executeCommandWithCommandPalette(page, 'File: Save');
+  await saveFile(page);
   await expect(page.locator(DIRTY_EDITOR).first()).not.toBeVisible({ timeout: 5000 });
 };
 
@@ -377,7 +386,7 @@ export const replaceLineInOpenFile = async (page: Page, lineNumber: number, newT
  * Line and column are both 1-indexed.
  */
 export const goToLineCol = async (page: Page, line: number, col: number): Promise<void> => {
-  await executeCommandWithCommandPalette(page, 'Go to Line/Column...');
+  await goToLineColumn(page);
   const widget = page.locator(QUICK_INPUT_WIDGET);
   await widget.waitFor({ state: 'visible', timeout: 5000 });
   await page.keyboard.type(`${line}:${col}`);
@@ -409,7 +418,7 @@ export const editAndSaveOpenFile = async (page: Page, comment: string): Promise<
   await page.keyboard.type(`// ${comment}`);
 
   // Save file
-  await executeCommandWithCommandPalette(page, 'File: Save');
+  await saveFile(page);
   await expect(page.locator(DIRTY_EDITOR).first()).not.toBeVisible({ timeout: 5000 });
 };
 

--- a/packages/playwright-vscode-ext/src/utils/workflows.ts
+++ b/packages/playwright-vscode-ext/src/utils/workflows.ts
@@ -7,6 +7,7 @@
 
 import { expect, type Page } from '@playwright/test';
 import { executeCommandWithCommandPalette } from '../pages/commands';
+import { closeAllEditors, closeWorkspace, hideSecondarySideBar, showRunningExtensions } from '../pages/nativeCommands';
 import { upsertSettings } from '../pages/settings';
 import {
   closeSettingsTab,
@@ -72,7 +73,7 @@ export const disableMonacoAutoClosing = async (page: Page): Promise<void> => {
  * @param timeout - Maximum ms to wait for all extensions to activate (default 120 000).
  */
 export const waitForExtensionsActivated = async (page: Page, timeout = 120_000): Promise<void> => {
-  await executeCommandWithCommandPalette(page, 'Developer: Show Running Extensions');
+  await showRunningExtensions(page);
 
   // The editor container gets class "runtime-extensions-editor" via createEditor()
   const editor = page.locator('.runtime-extensions-editor');
@@ -88,7 +89,7 @@ export const waitForExtensionsActivated = async (page: Page, timeout = 120_000):
 
   // Close the Running Extensions tab via command palette (cross-platform, no hover needed)
   const tab = page.getByRole('tab', { name: /Running Extensions/i });
-  await executeCommandWithCommandPalette(page, 'View: Close All Editors');
+  await closeAllEditors(page);
   await tab.waitFor({ state: 'detached', timeout: 5000 }).catch(() => {});
 };
 
@@ -111,7 +112,7 @@ export const ensureSecondarySideBarHidden = async (page: Page): Promise<void> =>
     // Focus workbench before opening palette (avoids F1/keystrokes going to auxiliary bar chat input)
     await page.locator(WORKBENCH).click({ timeout: 5000, force: true });
     // Use the explicit Hide command (not Toggle) to ensure we're hiding
-    await executeCommandWithCommandPalette(page, 'View: Hide Secondary Side Bar');
+    await hideSecondarySideBar(page);
 
     // Wait for it to actually hide
     await auxiliaryBar.waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {
@@ -125,7 +126,7 @@ export const ensureSecondarySideBarHidden = async (page: Page): Promise<void> =>
  * Call after {@link waitForVSCodeWorkbench} / {@link closeWelcomeTabs} / {@link ensureSecondarySideBarHidden} if needed.
  */
 export const closeWorkspaceToEmptyWindow = async (page: Page): Promise<void> => {
-  await executeCommandWithCommandPalette(page, 'Workspaces: Close Workspace');
+  await closeWorkspace(page);
   await waitForVSCodeWorkbench(page);
 };
 

--- a/packages/playwright-vscode-ext/test/playwright/specs/commandPalette.headless.spec.ts
+++ b/packages/playwright-vscode-ext/test/playwright/specs/commandPalette.headless.spec.ts
@@ -6,7 +6,8 @@
  */
 
 import { expect } from '@playwright/test';
-import { executeCommandWithCommandPalette, openCommandPalette } from '../../../src/pages/commands';
+import { openCommandPalette } from '../../../src/pages/commands';
+import { closeAllEditors, newUntitledTextFile, saveFile } from '../../../src/pages/nativeCommands';
 import { waitForVSCodeWorkbench, closeWelcomeTabs, isMacDesktop, isDesktop } from '../../../src/utils/helpers';
 import { ensureSecondarySideBarHidden } from '../../../src/utils/workflows';
 import { WORKBENCH } from '../../../src/utils/locators';
@@ -30,7 +31,7 @@ test.describe('Command Palette', () => {
 
   test('should execute command via command palette', async ({ page }) => {
     await test.step('Execute "View: Close All Editors" command', async () => {
-      await executeCommandWithCommandPalette(page, 'View: Close All Editors');
+      await closeAllEditors(page);
       // Wait for tabs to close - command execution may take a moment
       // Filter out welcome tabs as they may reopen - we're testing that editor tabs close
       const tabs = page.locator('.tabs-container .tab').filter({ hasNotText: /Welcome|Walkthrough/i });
@@ -64,7 +65,7 @@ test.describe('Command Palette', () => {
     test.skip(!isDesktop(), 'File: Save test only runs on desktop');
 
     await test.step('Create new untitled file', async () => {
-      await executeCommandWithCommandPalette(page, 'File: New Untitled Text File');
+      await newUntitledTextFile(page);
       // Wait for new editor to open
       const editor = page.locator('.editor-instance').first();
       await expect(editor).toBeVisible({ timeout: 5000 });
@@ -78,7 +79,7 @@ test.describe('Command Palette', () => {
     });
 
     await test.step('Save file using command palette', async () => {
-      await executeCommandWithCommandPalette(page, 'File: Save');
+      await saveFile(page);
       // Command palette should execute File: Save
       // Note: In test environment, this may trigger save dialog or auto-save depending on settings
       // We're testing that the command executes without error

--- a/packages/playwright-vscode-ext/test/playwright/specs/nativeCommandWrappers.headless.spec.ts
+++ b/packages/playwright-vscode-ext/test/playwright/specs/nativeCommandWrappers.headless.spec.ts
@@ -20,6 +20,7 @@ import {
   selectAll,
   showExplorer
 } from '../../../src/pages/nativeCommands';
+import { openFileByName } from '../../../src/utils/fileHelpers';
 import { waitForVSCodeWorkbench, closeWelcomeTabs, isDesktop } from '../../../src/utils/helpers';
 import { EDITOR_WITH_URI, QUICK_INPUT_WIDGET, TAB, WORKBENCH } from '../../../src/utils/locators';
 import { ensureSecondarySideBarHidden } from '../../../src/utils/workflows';
@@ -52,16 +53,22 @@ test.describe('Native command wrappers', () => {
   });
 
   test('saveFile clears the dirty indicator', async ({ page }) => {
-    // Untitled docs have no backing path, so `File: Save` opens a save-as dialog. On web headless
-    // there is no real filesystem to save to, so the doc can never become clean — same reason
-    // commandPalette.headless.spec.ts skips its File: Save assertion off desktop.
-    test.skip(!isDesktop(), 'Saving an untitled doc requires a real filesystem (desktop only)');
+    // `File: Save` only writes a backed file. An untitled doc has no path, so Save opens a
+    // (never-handled) save-as dialog and the tab stays dirty — open a real workspace file instead.
+    // Web Quick Open can't find files that were never opened in the editor, so this is desktop-only —
+    // same reason commandPalette.headless.spec.ts skips its File: Save assertion off desktop.
+    test.skip(!isDesktop(), 'Saving requires a real on-disk file (desktop only)');
 
-    await newUntitledTextFile(page);
+    // sfdx-project.json is scaffolded into every desktop workspace by createTestWorkspace.
+    await openFileByName(page, 'sfdx-project.json');
     const editor = page.locator(EDITOR_WITH_URI).first();
     await expect(editor).toBeVisible({ timeout: 10_000 });
     await editor.click();
-    await page.keyboard.type('dirty content');
+    // Append a blank line so the doc is dirty without breaking JSON (nothing reads it after).
+    await goToLineColumn(page);
+    await page.keyboard.type('1:1');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('\n');
     // The unsaved-changes marker lives on the editor tab (`.tab.dirty`), not the editor body.
     const dirtyTab = page.locator(`${WORKBENCH} .tabs-container .tab.dirty`);
     await expect(dirtyTab).toBeVisible({ timeout: 10_000 });

--- a/packages/playwright-vscode-ext/test/playwright/specs/nativeCommandWrappers.headless.spec.ts
+++ b/packages/playwright-vscode-ext/test/playwright/specs/nativeCommandWrappers.headless.spec.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from '@playwright/test';
+import {
+  clearAllNotifications,
+  closeAllEditors,
+  focusOnFilesExplorer,
+  focusOnProblemsView,
+  goToFile,
+  goToLineColumn,
+  newUntitledTextFile,
+  paste,
+  reloadWindow,
+  saveFile,
+  selectAll,
+  showExplorer
+} from '../../../src/pages/nativeCommands';
+import { waitForVSCodeWorkbench, closeWelcomeTabs, isDesktop } from '../../../src/utils/helpers';
+import { EDITOR_WITH_URI, QUICK_INPUT_WIDGET, TAB, WORKBENCH } from '../../../src/utils/locators';
+import { ensureSecondarySideBarHidden } from '../../../src/utils/workflows';
+import { test } from '../fixtures/index';
+
+// Coverage scope: the 11 WI-named native wrappers + `focusOnProblemsView`, all exercisable headlessly.
+// Wrappers that need a desktop context or an extension (`goToDefinition` LSP nav,
+// `showRunningExtensions`, `hideSecondarySideBar`, `closeWorkspace`, `closeEditor`, `find`,
+// `hidePanel`, `clearOutput`, `insertSnippet`, `focusActiveEditorGroup`) are NOT here — they
+// remain covered by their owning specs (apex/lwc/lightning/visualforce LSP + snippet/soql specs).
+
+const PROBLEMS_VIEW = '[id="workbench.panel.markers"]';
+const NON_WELCOME_TAB = `${TAB}:not(:has-text("Welcome")):not(:has-text("Walkthrough"))`;
+
+test.describe('Native command wrappers', () => {
+  test.beforeEach(async ({ page }) => {
+    await waitForVSCodeWorkbench(page);
+    await closeWelcomeTabs(page);
+    await ensureSecondarySideBarHidden(page);
+  });
+
+  test('focusOnFilesExplorer focuses the Files Explorer view', async ({ page }) => {
+    await focusOnFilesExplorer(page);
+    await expect(page.getByRole('tree', { name: /Files Explorer/i }).first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('newUntitledTextFile opens a new untitled editor', async ({ page }) => {
+    await newUntitledTextFile(page);
+    await expect(page.locator(TAB).filter({ hasText: /Untitled-\d+/ })).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('saveFile clears the dirty indicator', async ({ page }) => {
+    // Untitled docs have no backing path, so `File: Save` opens a save-as dialog. On web headless
+    // there is no real filesystem to save to, so the doc can never become clean — same reason
+    // commandPalette.headless.spec.ts skips its File: Save assertion off desktop.
+    test.skip(!isDesktop(), 'Saving an untitled doc requires a real filesystem (desktop only)');
+
+    await newUntitledTextFile(page);
+    const editor = page.locator(EDITOR_WITH_URI).first();
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+    await editor.click();
+    await page.keyboard.type('dirty content');
+    // The unsaved-changes marker lives on the editor tab (`.tab.dirty`), not the editor body.
+    const dirtyTab = page.locator(`${WORKBENCH} .tabs-container .tab.dirty`);
+    await expect(dirtyTab).toBeVisible({ timeout: 10_000 });
+
+    await saveFile(page);
+    await expect(dirtyTab).not.toBeVisible({ timeout: 10_000 });
+  });
+
+  test('clearAllNotifications leaves no notification toasts', async ({ page }) => {
+    // The wrapper is idempotent: with no toasts it is a no-op, with toasts present it dismisses
+    // them. Either way the observable post-condition is zero notification list items.
+    await clearAllNotifications(page);
+    await expect(page.locator(`${WORKBENCH} .notification-list-item`)).toHaveCount(0, { timeout: 10_000 });
+  });
+
+  test('closeAllEditors closes all non-welcome editor tabs', async ({ page }) => {
+    await newUntitledTextFile(page);
+    await expect(page.locator(NON_WELCOME_TAB)).not.toHaveCount(0, { timeout: 10_000 });
+
+    await closeAllEditors(page);
+    await expect(page.locator(NON_WELCOME_TAB)).toHaveCount(0, { timeout: 10_000 });
+  });
+
+  test('showExplorer reveals the Explorer sidebar', async ({ page }) => {
+    await showExplorer(page);
+    await expect(page.getByRole('tree', { name: /Files Explorer/i }).first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('reloadWindow reloads the workbench', async ({ page }) => {
+    await reloadWindow(page);
+    // After reload the workbench re-initializes; waiting for it again proves the command took effect.
+    await waitForVSCodeWorkbench(page);
+    await expect(page.locator(WORKBENCH)).toBeVisible({ timeout: 30_000 });
+  });
+
+  test('goToFile opens the Quick Open file picker', async ({ page }) => {
+    await goToFile(page);
+    const widget = page.locator(QUICK_INPUT_WIDGET);
+    await expect(widget).toBeVisible({ timeout: 10_000 });
+    // Quick Open file picker leaves the input empty (no leading ">" command prefix).
+    await expect(widget.locator('input.input')).toHaveValue('', { timeout: 5000 });
+  });
+
+  test('goToLineColumn moves the cursor to the target line/column', async ({ page }) => {
+    await newUntitledTextFile(page);
+    const editor = page.locator(EDITOR_WITH_URI).first();
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+    await editor.click();
+    await page.keyboard.type('line one\nline two\nline three');
+
+    await goToLineColumn(page);
+    await page.keyboard.type('2:3');
+    await page.keyboard.press('Enter');
+
+    // Status bar reflects the cursor position as "Ln 2, Col 3".
+    await expect(page.locator(`${WORKBENCH} .statusbar-item`).filter({ hasText: /Ln 2, Col 3/ })).toBeVisible({
+      timeout: 10_000
+    });
+  });
+
+  test('selectAll selects the entire document', async ({ page }) => {
+    await newUntitledTextFile(page);
+    const editor = page.locator(EDITOR_WITH_URI).first();
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+    await editor.click();
+    await page.keyboard.type('alpha beta gamma');
+
+    await selectAll(page);
+    // Replacing the selection with a single character proves the whole document was selected.
+    await page.keyboard.type('X');
+    await expect(editor).toContainText('X');
+    await expect(editor).not.toContainText('alpha');
+  });
+
+  test('paste inserts clipboard content at the cursor', async ({ page }) => {
+    await newUntitledTextFile(page);
+    const editor = page.locator(EDITOR_WITH_URI).first();
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+    await editor.click();
+
+    // Web headless: clipboard is per-browser-context (not the shared OS clipboard), so writing then
+    // pasting within this single test does not race other workers.
+    const clipboardText = 'pasted-via-wrapper';
+    await page.evaluate((text: string) => navigator.clipboard.writeText(text), clipboardText);
+
+    await paste(page);
+    await expect(editor).toContainText(clipboardText, { timeout: 10_000 });
+  });
+
+  test('focusOnProblemsView reveals the Problems view', async ({ page }) => {
+    await focusOnProblemsView(page);
+    await expect(page.locator(PROBLEMS_VIEW)).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/packages/salesforcedx-vscode-apex-log/test/playwright/specs/executeAnonymous.headless.spec.ts
+++ b/packages/salesforcedx-vscode-apex-log/test/playwright/specs/executeAnonymous.headless.spec.ts
@@ -8,14 +8,16 @@
 import { expect } from '@playwright/test';
 
 import {
+  closeEditor,
+  EDITOR_WITH_URI,
   ensureOutputPanelOpen,
   ensureSecondarySideBarHidden,
   executeCommandWithCommandPalette,
   expectProblemsCountAtLeast,
-  EDITOR_WITH_URI,
   NOTIFICATION_LIST_ITEM,
   QUICK_INPUT_WIDGET,
   saveScreenshot,
+  selectAll,
   selectOutputChannel,
   setupConsoleMonitoring,
   setupMinimalOrgAndAuth,
@@ -23,8 +25,8 @@ import {
   TAB,
   validateNoCriticalErrors,
   verifyCommandExists,
-  waitForQuickInputFirstOption,
-  waitForOutputChannelText
+  waitForOutputChannelText,
+  waitForQuickInputFirstOption
 } from '@salesforce/playwright-vscode-ext';
 
 import packageNls from '../../../package.nls.json';
@@ -66,7 +68,7 @@ test('Execute Anonymous Apex: document, selection, script creation, compile erro
     const editor = page.locator(EDITOR_WITH_URI).first();
     await editor.click();
     await editor.locator('.view-line').first().waitFor({ state: 'visible', timeout: 5000 });
-    await executeCommandWithCommandPalette(page, 'Select All');
+    await selectAll(page);
     await page.keyboard.press('Delete');
     await page.keyboard.type("System.debug('hello');\nSystem.debug('selection');");
     await executeCommandWithCommandPalette(page, packageNls['apexLog.command.executeDocument']);
@@ -84,7 +86,7 @@ test('Execute Anonymous Apex: document, selection, script creation, compile erro
     await expect(logTab).toBeVisible({ timeout: 10_000 });
     await saveScreenshot(page, 'exec-document.success.png');
     // Close debug.log so the .apex file is active for the next step (execute anonymous requires editorLangId apex)
-    await executeCommandWithCommandPalette(page, 'View: Close Editor');
+    await closeEditor(page);
     await expect(logTab).not.toBeVisible({ timeout: 5000 });
   });
 
@@ -130,14 +132,14 @@ test('Execute Anonymous Apex: document, selection, script creation, compile erro
     await expect(logTab).toBeVisible({ timeout: 10_000 });
     await saveScreenshot(page, 'exec-selection.success.png');
     // Close debug.log so the .apex file is active for the next step
-    await executeCommandWithCommandPalette(page, 'View: Close Editor');
+    await closeEditor(page);
     await expect(logTab).not.toBeVisible({ timeout: 5000 });
   });
 
   await test.step('execute with compile error and verify error notification', async () => {
     const editor = page.locator(EDITOR_WITH_URI).first();
     await editor.click();
-    await executeCommandWithCommandPalette(page, 'Select All');
+    await selectAll(page);
     await page.keyboard.press('Delete');
     await page.keyboard.type("Integer x = 'bad';");
     await executeCommandWithCommandPalette(page, packageNls['apexLog.command.executeDocument']);
@@ -153,7 +155,7 @@ test('Execute Anonymous Apex: document, selection, script creation, compile erro
     await expectProblemsCountAtLeast(page, 1, { timeout: 15_000 });
     const editor = page.locator(EDITOR_WITH_URI).first();
     await editor.click();
-    await executeCommandWithCommandPalette(page, 'Select All');
+    await selectAll(page);
     await page.keyboard.press('Delete');
     await page.keyboard.type("System.debug('fixed');");
     await executeCommandWithCommandPalette(page, packageNls['apexLog.command.executeDocument']);

--- a/packages/salesforcedx-vscode-apex-log/test/playwright/specs/logRetrieval.headless.spec.ts
+++ b/packages/salesforcedx-vscode-apex-log/test/playwright/specs/logRetrieval.headless.spec.ts
@@ -16,10 +16,12 @@ import {
   QUICK_INPUT_WIDGET,
   removeAllDebugLevels,
   saveScreenshot,
+  selectAll,
   selectFirstQuickInputOption,
   setupConsoleMonitoring,
   setupMinimalOrgAndAuth,
   setupNetworkMonitoring,
+  showExplorer,
   TAB,
   validateNoCriticalErrors,
   verifyCommandExists,
@@ -78,7 +80,7 @@ test('Log retrieval: get logs, open folder', async ({ page }) => {
     await editor.waitFor({ state: 'visible', timeout: 15_000 });
     await editor.click();
     await editor.locator('.view-line').first().waitFor({ state: 'visible', timeout: 5000 });
-    await executeCommandWithCommandPalette(page, 'Select All');
+    await selectAll(page);
     await page.keyboard.press('Delete');
     await page.keyboard.type("System.debug('logtest');");
     await executeCommandWithCommandPalette(page, packageNls['apexLog.command.executeDocument']);
@@ -117,7 +119,7 @@ test('Log retrieval: get logs, open folder', async ({ page }) => {
     const explorerHeading = page.getByRole('heading', { name: 'Explorer' }).first();
     const isExplorerVisible = await explorerHeading.isVisible().catch(() => false);
     if (!isExplorerVisible) {
-      await executeCommandWithCommandPalette(page, 'View: Show Explorer');
+      await showExplorer(page);
     }
     await expect(explorerHeading).toBeVisible({ timeout: 10_000 });
     await executeCommandWithCommandPalette(page, packageNls['apexLog.command.openLogsFolder']);

--- a/packages/salesforcedx-vscode-apex-log/test/playwright/specs/traceFlagsCrud.headless.spec.ts
+++ b/packages/salesforcedx-vscode-apex-log/test/playwright/specs/traceFlagsCrud.headless.spec.ts
@@ -13,6 +13,7 @@ import {
   EDITOR_WITH_URI,
   ensureSecondarySideBarHidden,
   executeCommandWithCommandPalette,
+  find,
   QUICK_INPUT_WIDGET,
   removeAllDebugLevels,
   saveScreenshot,
@@ -32,7 +33,7 @@ import { waitForTraceFlagStatusBar } from '../helpers';
 const findInEditor = async (page: Page, query: string): Promise<void> => {
   const editor = page.locator(EDITOR_WITH_URI).first();
   await editor.click();
-  await executeCommandWithCommandPalette(page, 'Find');
+  await find(page);
   const findInput = page.getByRole('textbox', { name: 'Find' });
   await expect(findInput).toBeVisible({ timeout: 10_000 });
   await findInput.fill(query);

--- a/packages/salesforcedx-vscode-apex-log/test/playwright/specs/traceFlagsForOtherUser.headless.spec.ts
+++ b/packages/salesforcedx-vscode-apex-log/test/playwright/specs/traceFlagsForOtherUser.headless.spec.ts
@@ -12,13 +12,14 @@ import {
   EDITOR_WITH_URI,
   ensureSecondarySideBarHidden,
   executeCommandWithCommandPalette,
+  find,
   QUICK_INPUT_LIST_ROW,
   QUICK_INPUT_WIDGET,
+  removeAllDebugLevels,
   saveScreenshot,
   setupConsoleMonitoring,
   setupMinimalOrgAndAuth,
   setupNetworkMonitoring,
-  removeAllDebugLevels,
   validateNoCriticalErrors,
   verifyCommandExists,
   waitForQuickInputFirstOption
@@ -31,7 +32,7 @@ import { test } from '../fixtures';
 const findInEditor = async (page: Page, query: string): Promise<void> => {
   const editor = page.locator(EDITOR_WITH_URI).first();
   await editor.click();
-  await executeCommandWithCommandPalette(page, 'Find');
+  await find(page);
   const findInput = page.getByRole('textbox', { name: 'Find' });
   await expect(findInput).toBeVisible({ timeout: 10_000 });
   await findInput.fill(query);

--- a/packages/salesforcedx-vscode-apex-oas/test/playwright/fixtures/desktopFixtures.ts
+++ b/packages/salesforcedx-vscode-apex-oas/test/playwright/fixtures/desktopFixtures.ts
@@ -5,7 +5,11 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { createDesktopTest, executeCommandWithCommandPalette, MINIMAL_ORG_ALIAS } from '@salesforce/playwright-vscode-ext';
+import {
+  closeAllEditors,
+  createDesktopTest,
+  MINIMAL_ORG_ALIAS
+} from '@salesforce/playwright-vscode-ext';
 
 const A4V_EXTENSION_ID = 'salesforce.salesforcedx-einstein-gpt';
 
@@ -46,5 +50,5 @@ oasDesktopTest.beforeEach(() => {
 // Match metadata specs: close editors at end so the next test starts clean and final state is tidy.
 oasDesktopTest.afterEach(async ({ page }) => {
   if (!page) return;
-  await executeCommandWithCommandPalette(page, 'View: Close All Editors').catch(() => {});
+  await closeAllEditors(page).catch(() => {});
 });

--- a/packages/salesforcedx-vscode-apex-oas/test/playwright/specs/composedManualMerge.headless.spec.ts
+++ b/packages/salesforcedx-vscode-apex-oas/test/playwright/specs/composedManualMerge.headless.spec.ts
@@ -8,6 +8,7 @@
 import { test } from '../fixtures';
 import { expect } from '@playwright/test';
 import {
+  closeAllEditors,
   createApexClass,
   executeCommandWithCommandPalette,
   openFileByName,
@@ -59,7 +60,7 @@ test('OAS: composed mode → manual merge produces diff editor + timestamped ESR
   });
 
   await test.step('second generation: manual merge', async () => {
-    await executeCommandWithCommandPalette(page, 'View: Close All Editors').catch(() => {});
+    await closeAllEditors(page).catch(() => {});
     await openFileByName(page, 'CaseManager.cls');
     await executeCommandWithCommandPalette(page, 'SFDX: Create OpenAPI Document from This Class');
     await confirmEsrFolderPrompt(page);

--- a/packages/salesforcedx-vscode-apex-oas/test/playwright/specs/composedOverwrite.headless.spec.ts
+++ b/packages/salesforcedx-vscode-apex-oas/test/playwright/specs/composedOverwrite.headless.spec.ts
@@ -15,6 +15,7 @@ import {
   expectProblemsCount,
   NOTIFICATION_LIST_ITEM,
   openFileByName,
+  reloadWindow,
   selectOutputChannel,
   setupConsoleMonitoring,
   setupNetworkMonitoring,
@@ -46,7 +47,7 @@ test('OAS: composed mode → overwrite → revalidate → deploy', async ({ page
     // OAS source emits `registrationProviderAsset` (API >=66.0). Default fixture is 64.0.
     // Must reload so source-deploy-retrieve picks up the new sourceApiVersion before deploy.
     await setWorkspaceApiVersion(workspaceDir);
-    await executeCommandWithCommandPalette(page, 'Developer: Reload Window');
+    await reloadWindow(page);
   });
 
   await test.step('wait for A4V + OAS commands available', async () => {

--- a/packages/salesforcedx-vscode-apex-oas/test/playwright/specs/decomposedSimpleAccount.headless.spec.ts
+++ b/packages/salesforcedx-vscode-apex-oas/test/playwright/specs/decomposedSimpleAccount.headless.spec.ts
@@ -15,6 +15,7 @@ import {
   expectProblemsCount,
   NOTIFICATION_LIST_ITEM,
   openFileByName,
+  reloadWindow,
   selectOutputChannel,
   setupConsoleMonitoring,
   setupNetworkMonitoring,
@@ -48,7 +49,7 @@ test('OAS: decomposed mode opens YAML+XML, validates, deploys', async ({ page, w
 
   await test.step('switch project to decomposed-ESR mode and reload', async () => {
     await writeWorkspaceFile(workspaceDir, 'sfdx-project.json', getSfdxProjectJson());
-    await executeCommandWithCommandPalette(page, 'Developer: Reload Window');
+    await reloadWindow(page);
   });
 
   await test.step('wait for A4V + OAS commands available after reload', async () => {

--- a/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/orgOnlyClassRetrieve.headless.spec.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/orgOnlyClassRetrieve.headless.spec.ts
@@ -11,15 +11,15 @@ import * as path from 'node:path';
 import { expect } from '@playwright/test';
 import {
   clickCodeLens,
+  closeAllEditors,
   createAndDeployApexTestClass,
   EDITOR_WITH_URI,
   ensureSecondarySideBarHidden,
-  executeCommandWithCommandPalette,
   isDesktop,
   saveScreenshot,
   setupConsoleMonitoring,
-  setupNonTrackingOrgAndAuth,
   setupNetworkMonitoring,
+  setupNonTrackingOrgAndAuth,
   validateNoCriticalErrors
 } from '@salesforce/playwright-vscode-ext';
 
@@ -82,7 +82,7 @@ public class ${className} {
       // `createApexClass` (setup) left the on-disk `.cls` open in a preview editor; deleting the
       // file does not close that tab. A leftover active editor keeps the test-item click from
       // navigating to the `apex-testing:` virtual doc, so close all editors first.
-      await executeCommandWithCommandPalette(page, 'View: Close All Editors');
+      await closeAllEditors(page);
       const panel = await openTestExplorerAndDiscover(page);
       const classItem = panel.locator(TEST_EXPLORER_TREE_ITEM).filter({ hasText: new RegExp(className, 'i') });
       await classItem.first().waitFor({ state: 'visible', timeout: 60_000 });

--- a/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/runApexTestsFailAndFix.headless.spec.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/runApexTestsFailAndFix.headless.spec.ts
@@ -8,6 +8,7 @@
 import { expect, type Page } from '@playwright/test';
 import {
   acceptNotification,
+  clearAllNotifications,
   clearOutputChannel,
   createAndDeployApexTestClass,
   deployCurrentSourceToOrg,
@@ -21,8 +22,8 @@ import {
   selectOutputChannel,
   selectQuickInputOptionByTyping,
   setupConsoleMonitoring,
-  setupNonTrackingOrgAndAuth,
   setupNetworkMonitoring,
+  setupNonTrackingOrgAndAuth,
   validateNoCriticalErrors,
   waitForNotification,
   waitForOutputChannelText,
@@ -135,7 +136,7 @@ const runAccountServiceTestViaPalette = async (page: Page): Promise<void> => {
       await executeCommandWithCommandPalette(page, CMD_TOGGLE_MAXIMIZED_PANEL);
       // Clear all notifications so the failing run's "Apex test report is ready" toast doesn't
       // get re-matched (and possibly re-clicked) when we verify the passing-run notification.
-      await executeCommandWithCommandPalette(page, 'Notifications: Clear All Notifications');
+      await clearAllNotifications(page);
     });
 
     await test.step('clear Salesforce Metadata channel before redeploy', async () => {

--- a/packages/salesforcedx-vscode-apex/test/playwright/specs/apexLsp.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex/test/playwright/specs/apexLsp.desktop.spec.ts
@@ -8,9 +8,10 @@
 import { expect } from '@playwright/test';
 import {
   EDITOR_WITH_URI,
-  executeCommandWithCommandPalette,
+  goToLineColumn,
   openFileByName,
   openFileFromExplorerTree,
+  saveFile,
   saveScreenshot,
   setupConsoleMonitoring,
   setupNetworkMonitoring,
@@ -85,7 +86,7 @@ test('Apex LSP: indexing, go-to-definition, autocompletion', async ({ page, work
     await expect(testTab).toHaveAttribute('aria-selected', 'true', { timeout: 10_000 });
     // Line 7 is blank per fixture layout (desktopFixtures.ts:37) — load-bearing for autocompletion test.
     // Insert "\tExampleClass.say" at line 7 col 1 to trigger autocompletion.
-    await executeCommandWithCommandPalette(page, 'Go to Line/Column...');
+    await goToLineColumn(page);
     await page.keyboard.type('7:1');
     await page.keyboard.press('Enter');
     await page.keyboard.type('\tExampleClass.say');
@@ -98,11 +99,11 @@ test('Apex LSP: indexing, go-to-definition, autocompletion', async ({ page, work
     // Type the argument; the completion inserted `SayHello(name)` with `name` selected as snippet placeholder.
     await page.keyboard.type("'Jack");
     // Position at col 38 (after `);`) and append `;` to mirror WDIO line 165.
-    await executeCommandWithCommandPalette(page, 'Go to Line/Column...');
+    await goToLineColumn(page);
     await page.keyboard.type('7:38');
     await page.keyboard.press('Enter');
     await page.keyboard.type(';');
-    await executeCommandWithCommandPalette(page, 'File: Save');
+    await saveFile(page);
 
     const editor = page.locator(`${EDITOR_WITH_URI}[data-uri$="ExampleClassTest.cls"]`).first();
     const lineSeven = editor.locator('.view-line').nth(6);
@@ -124,7 +125,7 @@ test('Apex LSP: indexing, go-to-definition, autocompletion', async ({ page, work
     // Whether anonymous Apex resolves project ApexClass symbols through the same jorje LSP is not
     // runtime-confirmed locally (see .claude/plans/W-22918963.md "Symbol-resolution risk"); CI is the
     // verification path for this assertion.
-    await executeCommandWithCommandPalette(page, 'Go to Line/Column...');
+    await goToLineColumn(page);
     await page.keyboard.type('2:1');
     await page.keyboard.press('Enter');
     await page.keyboard.type('ExampleClass.say');

--- a/packages/salesforcedx-vscode-apex/test/playwright/specs/apexSnippets.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex/test/playwright/specs/apexSnippets.desktop.spec.ts
@@ -9,10 +9,11 @@ import { expect, type Page } from '@playwright/test';
 import {
   closeWelcomeTabs,
   EDITOR_WITH_URI,
-  executeCommandWithCommandPalette,
   goToLineCol,
+  insertSnippet,
   openFileByName,
   QUICK_INPUT_WIDGET,
+  saveFile,
   saveScreenshot,
   setupConsoleMonitoring,
   setupNetworkMonitoring,
@@ -83,7 +84,7 @@ test('Apex snippets: Insert Snippet applies System Debug in .cls', async ({ page
     // and moves the caret to EOF — the snippet then inserts after the class-closing brace instead
     // of on blank line 7. goToLineCol already gave the editor keyboard focus, so skipping the click
     // keeps the caret on line 7.
-    await executeCommandWithCommandPalette(page, 'Snippets: Insert Snippet', undefined, {
+    await insertSnippet(page, {
       preserveSelection: true
     });
     const quickInput = page.locator(QUICK_INPUT_WIDGET);
@@ -99,7 +100,7 @@ test('Apex snippets: Insert Snippet applies System Debug in .cls', async ({ page
 
   await test.step('save and assert snippet body', async () => {
     await dismissEditorOverlays(page);
-    await executeCommandWithCommandPalette(page, 'File: Save');
+    await saveFile(page);
     // body `System.debug($0)`; `$0` is the final cursor (empty render) → saved text `System.debug()`.
     // Assert it landed on blank line 7 (between the assertEquals and the class-closing brace) so a
     // misfired Go to Line/Column navigation cannot silently pass on a line-agnostic substring match.

--- a/packages/salesforcedx-vscode-lightning/test/playwright/specs/auraLspAutocompletion.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-lightning/test/playwright/specs/auraLspAutocompletion.desktop.spec.ts
@@ -10,9 +10,9 @@ import {
   closeWelcomeTabs,
   EDITOR_WITH_URI,
   ensureSecondarySideBarHidden,
-  executeCommandWithCommandPalette,
   goToLineCol,
   openFileByName,
+  saveFile,
   saveScreenshot,
   setupConsoleMonitoring,
   setupNetworkMonitoring,
@@ -62,7 +62,7 @@ test('Aura LSP: autocompletion', async ({ page }) => {
 
     // Close the tag and save (mirrors WDIO `typeText('>')` + `save()`).
     await page.keyboard.type('>');
-    await executeCommandWithCommandPalette(page, 'File: Save');
+    await saveFile(page);
   });
 
   await test.step('verify aura:application was inserted on L2', async () => {

--- a/packages/salesforcedx-vscode-lightning/test/playwright/specs/auraLspGoToDefinition.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-lightning/test/playwright/specs/auraLspGoToDefinition.desktop.spec.ts
@@ -10,7 +10,7 @@ import {
   closeWelcomeTabs,
   EDITOR_WITH_URI,
   ensureSecondarySideBarHidden,
-  executeCommandWithCommandPalette,
+  goToDefinition,
   goToLineCol,
   openFileByName,
   saveScreenshot,
@@ -75,7 +75,7 @@ test('Aura LSP: go to definition', async ({ page }) => {
     // shortcut). `preserveSelection` keeps the 8:15 cursor placed above — otherwise the palette's
     // workbench focus-click re-parks the cursor at end-of-document (below the last line of this
     // 10-line file) and Go to Definition resolves nothing.
-    await executeCommandWithCommandPalette(page, 'Go to Definition', undefined, { preserveSelection: true });
+    await goToDefinition(page, { preserveSelection: true });
 
     // PRIMARY: the VS Code status-bar selection item reports the cursor position. The Aura LS
     // resolves the def to the `simpleNewContact` name-attribute value range on L3

--- a/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcLspAutocompletion.headless.spec.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcLspAutocompletion.headless.spec.ts
@@ -6,12 +6,12 @@
  */
 import { expect } from '@playwright/test';
 import {
+  closeWelcomeTabs,
   DIRTY_EDITOR,
   EDITOR_WITH_URI,
-  closeWelcomeTabs,
   ensureSecondarySideBarHidden,
-  executeCommandWithCommandPalette,
   goToLineCol,
+  saveFile,
   setupConsoleMonitoring,
   validateNoCriticalErrors,
   waitForVSCodeWorkbench
@@ -77,7 +77,7 @@ test('LWC LSP provides autocompletion for lightning-* base components in HTML te
 
     // Close the tag and save
     await page.keyboard.type('>');
-    await executeCommandWithCommandPalette(page, 'File: Save');
+    await saveFile(page);
     await expect(
       page.locator(DIRTY_EDITOR).first(),
       'HTML editor should be saved after inserting suggestion'

--- a/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcLspGoToDefinitionHtml.headless.spec.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcLspGoToDefinitionHtml.headless.spec.ts
@@ -6,13 +6,13 @@
  */
 import { expect } from '@playwright/test';
 import {
-  EDITOR_WITH_URI,
-  TAB,
   closeWelcomeTabs,
+  EDITOR_WITH_URI,
   ensureSecondarySideBarHidden,
-  executeCommandWithCommandPalette,
+  goToDefinition,
   goToLineCol,
   setupConsoleMonitoring,
+  TAB,
   validateNoCriticalErrors,
   waitForVSCodeWorkbench
 } from '@salesforce/playwright-vscode-ext';
@@ -49,7 +49,7 @@ test('LWC LSP Go to Definition navigates from HTML property binding to JS class 
   });
 
   await test.step('execute Go to Definition', async () => {
-    await executeCommandWithCommandPalette(page, 'Go to Definition');
+    await goToDefinition(page);
   });
 
   await test.step('verify navigation targets gtdHtmlComp.js (class field location)', async () => {

--- a/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcSnippets.headless.spec.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcSnippets.headless.spec.ts
@@ -11,10 +11,12 @@ import {
   closeWelcomeTabs,
   EDITOR_WITH_URI,
   ensureSecondarySideBarHidden,
-  executeCommandWithCommandPalette,
+  insertSnippet,
+  isDesktop,
   openFileByName,
   openFileFromExplorerTree,
   QUICK_INPUT_WIDGET,
+  saveFile,
   saveScreenshot,
   setupConsoleMonitoring,
   setupNetworkMonitoring,
@@ -23,8 +25,7 @@ import {
   waitForExtensionsActivated,
   waitForQuickInputFirstOption,
   waitForVSCodeWorkbench,
-  waitForWorkspaceReady,
-  isDesktop
+  waitForWorkspaceReady
 } from '@salesforce/playwright-vscode-ext';
 
 import { test } from '../fixtures';
@@ -104,7 +105,7 @@ test('LWC snippets: Insert Snippet applies lwc-button in HTML', async ({ page },
     // Snippets are scoped to the active editor language; ensure HTML editor has focus (web CI can leave focus elsewhere after palette use).
     const editor = page.locator(EDITOR_WITH_URI).first();
     await editor.click();
-    await executeCommandWithCommandPalette(page, 'Snippets: Insert Snippet');
+    await insertSnippet(page);
     const quickInput = page.locator(QUICK_INPUT_WIDGET);
     await quickInput.waitFor({ state: 'visible', timeout: 15_000 });
     await quickInput.locator('input.input').first().fill('lwc-button');
@@ -117,7 +118,7 @@ test('LWC snippets: Insert Snippet applies lwc-button in HTML', async ({ page },
 
   await test.step('save and assert HTML snippet body', async () => {
     await dismissEditorOverlays(page);
-    await executeCommandWithCommandPalette(page, 'File: Save');
+    await saveFile(page);
     const doc = collapseEditorWhitespace(await readActiveEditorDocumentText(page));
     expect(doc).toContain('<lightning-button');
     expect(doc).toContain('variant="base"');
@@ -177,7 +178,7 @@ test('LWC snippets: JS completion inserts lwc-event body', async ({ page }, test
 
   await test.step('save and assert JS snippet body', async () => {
     await dismissEditorOverlays(page);
-    await executeCommandWithCommandPalette(page, 'File: Save');
+    await saveFile(page);
     const doc = collapseEditorWhitespace(await readActiveEditorDocumentText(page));
     expect(doc).toContain('this.dispatchEvent(new CustomEvent("event-name"));');
     await saveScreenshot(page, 'lwc-snippets-js.saved.png');

--- a/packages/salesforcedx-vscode-lwc/test/playwright/utils/lwcUtils.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/utils/lwcUtils.ts
@@ -6,19 +6,23 @@
  */
 import { expect, type Locator, type Page } from '@playwright/test';
 import {
+  closeWelcomeTabs,
   DIRTY_EDITOR,
   EDITOR_WITH_URI,
-  QUICK_INPUT_LIST_ROW,
-  QUICK_INPUT_WIDGET,
-  STATUS_BAR_ITEM_LABEL,
-  WORKBENCH,
-  closeWelcomeTabs,
   ensureSecondarySideBarHidden,
   executeCommandWithCommandPalette,
+  focusOnFilesExplorer,
   isDesktop,
   openFileByName,
+  paste,
+  QUICK_INPUT_LIST_ROW,
+  QUICK_INPUT_WIDGET,
+  saveFile,
+  selectAll,
+  STATUS_BAR_ITEM_LABEL,
   verifyCommandExists,
-  waitForQuickInputFirstOption
+  waitForQuickInputFirstOption,
+  WORKBENCH
 } from '@salesforce/playwright-vscode-ext';
 import lwcPackageNls from '../../../package.nls.json';
 import { LWC_GTD_HTML_COMP_SEED_HTML, LWC_GTD_HTML_COMP_SEED_JS } from './createLwcTestWorkspace';
@@ -33,11 +37,11 @@ const replaceEditorContentAndSave = async (
 ): Promise<void> => {
   await editor.click();
   await editor.locator('.view-line').first().waitFor({ state: 'visible', timeout: 5000 });
-  await executeCommandWithCommandPalette(page, 'Select All');
+  await selectAll(page);
   await page.keyboard.press('Delete');
   await page.evaluate((t: string) => navigator.clipboard.writeText(t), content);
-  await executeCommandWithCommandPalette(page, 'Paste');
-  await executeCommandWithCommandPalette(page, 'File: Save');
+  await paste(page);
+  await saveFile(page);
   await expect(page.locator(DIRTY_EDITOR).first(), 'editor should be saved (no dirty indicator)').not.toBeVisible({
     timeout: 10_000
   });
@@ -139,7 +143,7 @@ const clickWebExplorerTreeitemExact = async (page: Page, fileName: string): Prom
  * the file in Files Explorer so the editor opens reliably in E2E.
  */
 const openLwcFileViaExplorer = async (page: Page, fileName: string): Promise<void> => {
-  await executeCommandWithCommandPalette(page, 'File: Focus on Files Explorer');
+  await focusOnFilesExplorer(page);
   await expandExplorerPathToLwcFile(page, fileName);
   await clickWebExplorerTreeitemExact(page, fileName);
 };
@@ -247,7 +251,7 @@ export const openSfdxCustomComponentsJson = async (page: Page): Promise<void> =>
   await (isDesktop()
     ? openFileByName(page, fileName)
     : expect(async () => {
-        await executeCommandWithCommandPalette(page, 'File: Focus on Files Explorer');
+        await focusOnFilesExplorer(page);
         await expandWebExplorerSegments(page, ['.sfdx', 'indexes', 'lwc']);
         await clickWebExplorerTreeitemExact(page, fileName);
       }).toPass({ timeout: 90_000 }));
@@ -271,7 +275,7 @@ export const assertLwcSfdxTypingsGenerated = async (page: Page): Promise<void> =
     return;
   }
 
-  await executeCommandWithCommandPalette(page, 'File: Focus on Files Explorer');
+  await focusOnFilesExplorer(page);
   await expandWebExplorerSegments(page, ['.sfdx', 'typings', 'lwc']);
   for (const { file, header } of LWC_SFDX_GENERATED_TYPINGS_EXPECTATIONS) {
     await clickWebExplorerTreeitemExact(page, file);

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/analyticsTemplates.headless.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/analyticsTemplates.headless.spec.ts
@@ -8,20 +8,22 @@
 import { test } from '../fixtures';
 import { expect, type Page } from '@playwright/test';
 import {
-  setupConsoleMonitoring,
-  setupNetworkMonitoring,
-  waitForVSCodeWorkbench,
-  waitForWorkspaceReady,
-  verifyCommandExists,
+  activeQuickInputWidget,
+  closeAllEditors,
   closeWelcomeTabs,
+  EDITOR,
+  ensureSecondarySideBarHidden,
   executeCommandWithCommandPalette,
   executeExplorerContextMenuCommand,
-  validateNoCriticalErrors,
+  focusOnFilesExplorer,
   saveScreenshot,
-  activeQuickInputWidget,
-  ensureSecondarySideBarHidden,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  validateNoCriticalErrors,
+  verifyCommandExists,
   waitForQuickInputFirstOption,
-  EDITOR
+  waitForVSCodeWorkbench,
+  waitForWorkspaceReady
 } from '@salesforce/playwright-vscode-ext';
 import packageNls from '../../../package.nls.json';
 
@@ -49,7 +51,7 @@ const verifyGeneratedTemplate = async (page: Page, name: string) => {
     timeout: 10_000
   });
 
-  await executeCommandWithCommandPalette(page, 'File: Focus on Files Explorer');
+  await focusOnFilesExplorer(page);
   await Promise.all(
     expectedFiles.map(file =>
       expect(
@@ -87,7 +89,7 @@ test('Analytics Templates: creates sample template via command palette and explo
 
   await test.step('create analytics template via explorer context menu', async () => {
     const name = `AnalyticsExplorer${Date.now()}`;
-    await executeCommandWithCommandPalette(page, 'View: Close All Editors');
+    await closeAllEditors(page);
     await executeExplorerContextMenuCommand(page, /^waveTemplates\b/, packageNls.analytics_generate_template_text);
     await enterTemplateName(page, name);
     await verifyGeneratedTemplate(page, name);

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/deployManifest.headless.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/deployManifest.headless.spec.ts
@@ -8,25 +8,26 @@
 import { test } from '../fixtures';
 import { expect } from '@playwright/test';
 import {
-  setupConsoleMonitoring,
-  setupNetworkMonitoring,
-  waitForVSCodeWorkbench,
+  activeQuickInputWidget,
+  captureOutputChannelDetails,
+  closeAllEditors,
   closeWelcomeTabs,
-  createMinimalOrg,
-  upsertScratchOrgAuthFieldsToSettings,
-  upsertSettings,
   createApexClass,
+  createMinimalOrg,
   editOpenFile,
-  openFileByName,
+  EDITOR,
+  ensureSecondarySideBarHidden,
+  executeCommandWithCommandPalette,
   executeEditorContextMenuCommand,
   executeExplorerContextMenuCommand,
-  executeCommandWithCommandPalette,
-  validateNoCriticalErrors,
-  captureOutputChannelDetails,
   NOTIFICATION_LIST_ITEM,
-  EDITOR,
-  activeQuickInputWidget,
-  ensureSecondarySideBarHidden
+  openFileByName,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  upsertScratchOrgAuthFieldsToSettings,
+  upsertSettings,
+  validateNoCriticalErrors,
+  waitForVSCodeWorkbench
 } from '@salesforce/playwright-vscode-ext';
 import { SourceTrackingStatusBarPage } from '../pages/sourceTrackingStatusBarPage';
 import { waitForDeployProgressNotificationToAppear } from '../pages/notifications';
@@ -147,7 +148,7 @@ test('Deploy Manifest: deploys via all entry points', async ({ page }) => {
 
   await test.step('2. Explorer context menu (file)', async () => {
     // Close any open editors to ensure clean state
-    await executeCommandWithCommandPalette(page, 'View: Close All Editors');
+    await closeAllEditors(page);
 
     // Edit apex class again to create new local change
     await openFileByName(page, `${className}.cls`);

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/deploySourcePath.headless.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/deploySourcePath.headless.spec.ts
@@ -8,24 +8,24 @@
 import { test } from '../fixtures';
 import { expect } from '@playwright/test';
 import {
-  setupConsoleMonitoring,
-  setupNetworkMonitoring,
-  waitForVSCodeWorkbench,
+  closeAllEditors,
   closeWelcomeTabs,
-  createMinimalOrg,
-  upsertScratchOrgAuthFieldsToSettings,
-  upsertSettings,
   createApexClass,
+  createMinimalOrg,
   editOpenFile,
-  openFileByName,
-  executeCommandWithCommandPalette,
+  EDITOR,
+  ensureSecondarySideBarHidden,
   executeEditorContextMenuCommand,
   executeExplorerContextMenuCommand,
-  saveScreenshot,
-  validateNoCriticalErrors,
-  EDITOR,
   NOTIFICATION_LIST_ITEM,
-  ensureSecondarySideBarHidden
+  openFileByName,
+  saveScreenshot,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  upsertScratchOrgAuthFieldsToSettings,
+  upsertSettings,
+  validateNoCriticalErrors,
+  waitForVSCodeWorkbench
 } from '@salesforce/playwright-vscode-ext';
 import { SourceTrackingStatusBarPage } from '../pages/sourceTrackingStatusBarPage';
 import { waitForDeployProgressNotificationToAppear } from '../pages/notifications';
@@ -67,7 +67,7 @@ test('Deploy Source Path: deploys via all entry points', async ({ page }) => {
     await saveScreenshot(page, 'step1.after-create-class.png');
 
     // Close any open editors to ensure clean state
-    await executeCommandWithCommandPalette(page, 'View: Close All Editors');
+    await closeAllEditors(page);
     await saveScreenshot(page, 'step1.after-close-editors.png');
 
     // Edit class to create new local change
@@ -102,7 +102,7 @@ test('Deploy Source Path: deploys via all entry points', async ({ page }) => {
 
   await test.step('2. Explorer context menu (file)', async () => {
     // Close any open editors to ensure clean state
-    await executeCommandWithCommandPalette(page, 'View: Close All Editors');
+    await closeAllEditors(page);
     await saveScreenshot(page, 'step2.after-close-editors.png');
 
     // Ensure status bar is ready and file is synced (local=0) after step 1 deploy
@@ -177,7 +177,7 @@ test('Deploy Source Path: deploys via all entry points', async ({ page }) => {
 
   await test.step('3. Explorer context menu (directory)', async () => {
     // Close any open editors to ensure clean state
-    await executeCommandWithCommandPalette(page, 'View: Close All Editors');
+    await closeAllEditors(page);
     await saveScreenshot(page, 'step3.after-close-editors.png');
 
     // Ensure status bar is ready and file is synced (local=0) after step 2 deploy

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/editorWatcher.headless.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/editorWatcher.headless.spec.ts
@@ -8,20 +8,20 @@
 import { test } from '../fixtures';
 import { expect } from '@playwright/test';
 import {
+  closeWelcomeTabs,
+  createApexClass,
+  createMinimalOrg,
+  EDITOR_WITH_URI,
+  ensureSecondarySideBarHidden,
+  focusOnFilesExplorer,
+  saveScreenshot,
   setupConsoleMonitoring,
   setupNetworkMonitoring,
-  waitForVSCodeWorkbench,
-  closeWelcomeTabs,
-  createMinimalOrg,
   upsertScratchOrgAuthFieldsToSettings,
-  createApexClass,
-  verifyCommandExists,
-  verifyCommandDoesNotExist,
-  saveScreenshot,
   validateNoCriticalErrors,
-  EDITOR_WITH_URI,
-  executeCommandWithCommandPalette,
-  ensureSecondarySideBarHidden
+  verifyCommandDoesNotExist,
+  verifyCommandExists,
+  waitForVSCodeWorkbench
 } from '@salesforce/playwright-vscode-ext';
 import { SourceTrackingStatusBarPage } from '../pages/sourceTrackingStatusBarPage';
 import packageNls from '../../../package.nls.json';
@@ -73,7 +73,7 @@ test('EditorWatcher: deploy commands show/hide based on active editor location',
 
   await test.step('open sfdx-project.json (not in package directory)', async () => {
     // Focus explorer and click on sfdx-project.json to open it
-    await executeCommandWithCommandPalette(page, 'File: Focus on Files Explorer');
+    await focusOnFilesExplorer(page);
 
     // Find and click the sfdx-project.json file in the explorer tree
     const projectFile = page.getByRole('treeitem', { name: /sfdx-project\.json/ });

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/generateManifest.headless.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/generateManifest.headless.spec.ts
@@ -8,21 +8,22 @@
 import { test } from '../fixtures';
 import { expect } from '@playwright/test';
 import {
-  setupConsoleMonitoring,
-  setupNetworkMonitoring,
-  waitForVSCodeWorkbench,
+  activeQuickInputWidget,
+  closeAllEditors,
   closeWelcomeTabs,
-  createMinimalOrg,
-  upsertScratchOrgAuthFieldsToSettings,
   createApexClass,
+  createMinimalOrg,
+  EDITOR,
+  ensureSecondarySideBarHidden,
   executeEditorContextMenuCommand,
   executeExplorerContextMenuCommand,
-  executeCommandWithCommandPalette,
-  validateNoCriticalErrors,
+  focusOnFilesExplorer,
   saveScreenshot,
-  EDITOR,
-  activeQuickInputWidget,
-  ensureSecondarySideBarHidden
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  upsertScratchOrgAuthFieldsToSettings,
+  validateNoCriticalErrors,
+  waitForVSCodeWorkbench
 } from '@salesforce/playwright-vscode-ext';
 import { SourceTrackingStatusBarPage } from '../pages/sourceTrackingStatusBarPage';
 import packageNls from '../../../package.nls.json';
@@ -75,13 +76,13 @@ test('Generate Manifest: generates via context menu entry points', async ({ page
     await saveScreenshot(page, 'step1.manifest-opened.png');
 
     // Assert manifest file exists in explorer - focus explorer first, then look for file
-    await executeCommandWithCommandPalette(page, 'File: Focus on Files Explorer');
+    await focusOnFilesExplorer(page);
     const manifestFile = page.getByRole('treeitem', { name: /package\.xml/i });
     await expect(manifestFile).toBeVisible({ timeout: 10_000 });
     await saveScreenshot(page, 'step1.manifest-in-explorer.png');
 
     // Close editors to prepare for next step
-    await executeCommandWithCommandPalette(page, 'View: Close All Editors');
+    await closeAllEditors(page);
     await saveScreenshot(page, 'step1.after-close-editors.png');
   });
 
@@ -108,7 +109,7 @@ test('Generate Manifest: generates via context menu entry points', async ({ page
     await saveScreenshot(page, 'step2.manifest-opened.png');
 
     // Assert manifest file exists in explorer - focus explorer first, then look for file
-    await executeCommandWithCommandPalette(page, 'File: Focus on Files Explorer');
+    await focusOnFilesExplorer(page);
     const manifestFile = page.getByRole('treeitem', { name: /package2\.xml/i });
     await expect(manifestFile).toBeVisible({ timeout: 10_000 });
     await saveScreenshot(page, 'step2.manifest-in-explorer.png');

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/retrieveInManifest.headless.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/retrieveInManifest.headless.spec.ts
@@ -8,26 +8,27 @@
 import { test } from '../fixtures';
 import { expect } from '@playwright/test';
 import {
-  setupConsoleMonitoring,
-  setupNetworkMonitoring,
-  waitForVSCodeWorkbench,
+  activeQuickInputWidget,
+  closeAllEditors,
   closeWelcomeTabs,
-  createMinimalOrg,
-  upsertScratchOrgAuthFieldsToSettings,
   createApexClass,
-  openFileByName,
+  createMinimalOrg,
+  EDITOR,
+  ensureOutputPanelOpen,
+  ensureSecondarySideBarHidden,
+  executeCommandWithCommandPalette,
   executeEditorContextMenuCommand,
   executeExplorerContextMenuCommand,
-  executeCommandWithCommandPalette,
-  validateNoCriticalErrors,
-  saveScreenshot,
-  ensureOutputPanelOpen,
-  selectOutputChannel,
-  waitForOutputChannelText,
-  EDITOR,
-  activeQuickInputWidget,
   NOTIFICATION_LIST_ITEM,
-  ensureSecondarySideBarHidden
+  openFileByName,
+  saveScreenshot,
+  selectOutputChannel,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  upsertScratchOrgAuthFieldsToSettings,
+  validateNoCriticalErrors,
+  waitForOutputChannelText,
+  waitForVSCodeWorkbench
 } from '@salesforce/playwright-vscode-ext';
 import { SourceTrackingStatusBarPage } from '../pages/sourceTrackingStatusBarPage';
 import { waitForDeployProgressNotificationToAppear } from '../pages/notifications';
@@ -135,7 +136,7 @@ test('Retrieve In Manifest: retrieves via all entry points', async ({ page }) =>
 
   await test.step('2. Explorer context menu (file)', async () => {
     // Close any open editors to ensure clean state
-    await executeCommandWithCommandPalette(page, 'View: Close All Editors');
+    await closeAllEditors(page);
 
     // Prepare output channel
     await ensureOutputPanelOpen(page);

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/sourceDiff.headless.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/sourceDiff.headless.spec.ts
@@ -8,27 +8,28 @@
 import { test } from '../fixtures';
 import { expect, Page } from '@playwright/test';
 import {
+  clearOutputChannel,
+  closeAllEditors,
+  closeWelcomeTabs,
+  createApexClass,
+  createMinimalOrg,
+  editOpenFile,
+  ensureOutputPanelOpen,
+  ensureSecondarySideBarHidden,
+  executeCommandWithCommandPalette,
+  executeExplorerContextMenuCommand,
+  openFileByName,
+  outputChannelContains,
+  saveScreenshot,
+  selectOutputChannel,
   setupConsoleMonitoring,
   setupNetworkMonitoring,
-  waitForVSCodeWorkbench,
-  closeWelcomeTabs,
-  createMinimalOrg,
   upsertScratchOrgAuthFieldsToSettings,
   upsertSettings,
-  createApexClass,
-  editOpenFile,
-  openFileByName,
-  executeCommandWithCommandPalette,
-  verifyCommandExists,
-  executeExplorerContextMenuCommand,
-  saveScreenshot,
   validateNoCriticalErrors,
-  ensureOutputPanelOpen,
-  selectOutputChannel,
-  clearOutputChannel,
+  verifyCommandExists,
   waitForOutputChannelText,
-  outputChannelContains,
-  ensureSecondarySideBarHidden
+  waitForVSCodeWorkbench
 } from '@salesforce/playwright-vscode-ext';
 import { SourceTrackingStatusBarPage } from '../pages/sourceTrackingStatusBarPage';
 import { waitForDeployProgressNotificationToAppear } from '../pages/notifications';
@@ -114,7 +115,7 @@ test('Source Diff: diff shows diff editor', async ({ page }) => {
   });
 
   await test.step('create local change and diff via command palette', async () => {
-    await executeCommandWithCommandPalette(page, 'View: Close All Editors');
+    await closeAllEditors(page);
 
     await openFileByName(page, `${classNamePalette}.cls`);
 
@@ -137,7 +138,7 @@ test('Source Diff: diff shows diff editor', async ({ page }) => {
   });
 
   await test.step('create local change and diff via explorer context menu', async () => {
-    await executeCommandWithCommandPalette(page, 'View: Close All Editors');
+    await closeAllEditors(page);
 
     await openFileByName(page, `${classNamePalette}.cls`);
 

--- a/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-builder.spec.ts
+++ b/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-builder.spec.ts
@@ -8,8 +8,11 @@
 import { expect } from '@playwright/test';
 import {
   activeQuickInputWidget,
+  closeEditor,
   ensureSecondarySideBarHidden,
   executeCommandWithCommandPalette,
+  hidePanel,
+  saveFile,
   saveScreenshot,
   selectOutputChannel,
   setupConsoleMonitoring,
@@ -131,7 +134,7 @@ test('SOQL Builder: build query, run, get plan, toggle round-trip', async ({ pag
     ).toContainText("SELECT Id, Name FROM Account WHERE Name != 'Test' ORDER BY Name DESC LIMIT 10");
     await saveScreenshot(page, 'step2.query-preview-verified.png');
 
-    await executeCommandWithCommandPalette(page, 'File: Save');
+    await saveFile(page);
     await saveScreenshot(page, 'step2.query-saved.png');
   });
 
@@ -149,7 +152,7 @@ test('SOQL Builder: build query, run, get plan, toggle round-trip', async ({ pag
 
     // Close the results panel so only one webview iframe exists when interacting with the builder next
     await resultsTab.click();
-    await executeCommandWithCommandPalette(page, 'View: Close Editor');
+    await closeEditor(page);
     await expect(resultsTab, 'SOQL Query Results tab should be closed').not.toBeVisible({ timeout: 10_000 });
   });
 
@@ -172,7 +175,7 @@ test('SOQL Builder: build query, run, get plan, toggle round-trip', async ({ pag
     });
     await saveScreenshot(page, 'step4.query-plan-output-verified.png');
 
-    await executeCommandWithCommandPalette(page, 'View: Hide Panel');
+    await hidePanel(page);
   });
 
   await test.step('toggle from SOQL Builder to Text Editor', async () => {

--- a/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-query-plan.spec.ts
+++ b/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-query-plan.spec.ts
@@ -12,6 +12,7 @@ import {
   ensureSecondarySideBarHidden,
   executeCommandWithCommandPalette,
   QUICK_INPUT_WIDGET,
+  saveFile,
   saveScreenshot,
   selectOutputChannel,
   setupConsoleMonitoring,
@@ -69,7 +70,7 @@ test('SOQL Query Plan: code lens, current file, selected text via command palett
     // Type the query into the empty editor (file opens focused and ready for input)
     await page.locator(EDITOR).first().click();
     await page.keyboard.type(SOQL_QUERY);
-    await executeCommandWithCommandPalette(page, 'File: Save');
+    await saveFile(page);
     await saveScreenshot(page, 'step1.query-saved.png');
   });
 

--- a/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-run-query.spec.ts
+++ b/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-run-query.spec.ts
@@ -12,6 +12,7 @@ import {
   ensureSecondarySideBarHidden,
   executeCommandWithCommandPalette,
   QUICK_INPUT_WIDGET,
+  saveFile,
   saveScreenshot,
   selectOutputChannel,
   selectQuickInputOption,
@@ -69,7 +70,7 @@ test('SOQL Run Query: code lens, current file, selected text via command palette
     // Type the query into the empty editor (file opens focused and ready for input)
     await page.locator(EDITOR).first().click();
     await page.keyboard.type(SOQL_QUERY);
-    await executeCommandWithCommandPalette(page, 'File: Save');
+    await saveFile(page);
     await saveScreenshot(page, 'step1.query-saved.png');
   });
 
@@ -178,7 +179,7 @@ test('SOQL Run Query: code lens, current file, selected text via command palette
       timeout: 5000
     });
     await page.keyboard.type('SELECT Id, Name FROM ApexClass LIMIT 5');
-    await executeCommandWithCommandPalette(page, 'File: Save');
+    await saveFile(page);
     await saveScreenshot(page, 'step5.tooling-query-saved.png');
 
     const runQueryLens = page.getByRole('button', { name: 'Run Query' });

--- a/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-save-query-results.spec.ts
+++ b/packages/salesforcedx-vscode-soql/test/playwright/specs/soql-save-query-results.spec.ts
@@ -7,6 +7,7 @@
 
 import { expect, type FrameLocator } from '@playwright/test';
 import {
+  clearAllNotifications,
   EDITOR,
   ensureSecondarySideBarHidden,
   executeCommandWithCommandPalette,
@@ -14,6 +15,7 @@ import {
   hasTitle,
   isDesktop,
   QUICK_INPUT_WIDGET,
+  saveFile,
   saveScreenshot,
   setupConsoleMonitoring,
   setupMinimalOrgAndAuth,
@@ -133,7 +135,7 @@ test('SOQL Builder: save query results to CSV and JSON', async ({ page }) => {
     ).toContainText(SOQL_QUERY);
     await saveScreenshot(page, 'save.query-built.png');
 
-    await executeCommandWithCommandPalette(page, 'File: Save');
+    await saveFile(page);
   });
 
   await test.step('run query from SOQL Builder', async () => {
@@ -154,7 +156,7 @@ test('SOQL Builder: save query results to CSV and JSON', async ({ page }) => {
     await acceptSaveTarget(page, 'csv');
     await waitForNotification(page, /We saved the results as:.*\.csv/, { timeout: 30_000 });
     await saveScreenshot(page, 'save.csv-notification.png');
-    await executeCommandWithCommandPalette(page, 'Notifications: Clear All Notifications');
+    await clearAllNotifications(page);
   });
 
   await test.step('verify CSV file contents', async () => {
@@ -176,7 +178,7 @@ test('SOQL Builder: save query results to CSV and JSON', async ({ page }) => {
     await acceptSaveTarget(page, 'json');
     await waitForNotification(page, /We saved the results as:.*\.json/, { timeout: 30_000 });
     await saveScreenshot(page, 'save.json-notification.png');
-    await executeCommandWithCommandPalette(page, 'Notifications: Clear All Notifications');
+    await clearAllNotifications(page);
   });
 
   await test.step('verify JSON file contents', async () => {


### PR DESCRIPTION
## Summary

- Replace native VS Code command string literals (`'File: Save'`, etc.) with named wrapper functions (`saveFile()`) for discoverability
- Add 22 native command wrappers in `playwright-vscode-ext/src/pages/nativeCommands.ts`
- Migrate all in-scope callsites (shared lib + consumer specs) from `executeCommandWithCommandPalette(page, '<literal>')` to wrappers

## Plan

See [.claude/plans/W-23124419.md](.claude/plans/W-23124419.md)

## What issues does this PR fix or reference?

@W-23124419@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cnuqqYAA/view