### PR TITLE
fix(trace-flags): status bar icon should not reflect trace flags created for other users - W-23127627

### DIFF
--- a/packages/salesforcedx-vscode-apex-log/src/statusBar/traceFlagStatusBar.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/statusBar/traceFlagStatusBar.ts
@@ -118,8 +118,8 @@ const refresh = Effect.fn('ApexLog.traceFlagStatusBar.refresh', { root: true })(
 ) {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const ref = yield* api.services.TargetOrgRef();
-  const { orgId } = yield* SubscriptionRef.get(ref);
-  if (!orgId) {
+  const { orgId, userId } = yield* SubscriptionRef.get(ref);
+  if (!orgId || !userId) {
     return statusBarItem.hide();
   }
   const traceFlagsRef = yield* CurrentTraceFlags;
@@ -129,26 +129,23 @@ const refresh = Effect.fn('ApexLog.traceFlagStatusBar.refresh', { root: true })(
 
   const collectorRef = yield* LogCollectorStateRef;
   const collectorState = yield* SubscriptionRef.get(collectorRef);
-  const { userId } = yield* SubscriptionRef.get(ref);
   statusBarItem.tooltip = buildTooltip(activeRecords, collectorState, userId);
   statusBarItem.text = getStatusBarText(collectorState, selectCurrentUserFlag(activeRecords, userId));
   statusBarItem.show();
 });
 
-const hasCurrentUserTraceFlag = (records: TraceFlagItem[], userId: string | undefined) =>
-  Boolean(userId && records.some(r => r.logType === 'DEVELOPER_LOG' && r.tracedEntityId === userId));
+const hasCurrentUserTraceFlag = (records: TraceFlagItem[], userId: string) =>
+  records.some(r => r.logType === 'DEVELOPER_LOG' && r.tracedEntityId === userId);
 
 /** Returns the first trace flag (any type) for the current user, or undefined if none is active. */
-export const selectCurrentUserFlag = (
-  records: TraceFlagItem[],
-  userId: string | undefined
-): TraceFlagItem | undefined => (userId ? records.find(r => r.tracedEntityId === userId) : undefined);
+export const selectCurrentUserFlag = (records: TraceFlagItem[], userId: string): TraceFlagItem | undefined =>
+  records.find(r => r.tracedEntityId === userId);
 
 /** Build the tooltip for the status bar item */
 const buildTooltip = (
   activeRecords: TraceFlagItem[],
   collectorState: LogCollectorState,
-  userId: string | undefined
+  userId: string
 ): vscode.MarkdownString => {
   const byKey = LOG_TYPE_ORDER.reduce<Record<(typeof LOG_TYPE_ORDER)[number], TraceFlagItem[]>>(
     (acc, key) => ({

--- a/packages/salesforcedx-vscode-apex-log/src/statusBar/traceFlagStatusBar.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/statusBar/traceFlagStatusBar.ts
@@ -131,12 +131,19 @@ const refresh = Effect.fn('ApexLog.traceFlagStatusBar.refresh', { root: true })(
   const collectorState = yield* SubscriptionRef.get(collectorRef);
   const { userId } = yield* SubscriptionRef.get(ref);
   statusBarItem.tooltip = buildTooltip(activeRecords, collectorState, userId);
-  statusBarItem.text = getStatusBarText(collectorState, activeRecords[0]);
+  statusBarItem.text = getStatusBarText(collectorState, selectCurrentUserFlag(activeRecords, userId));
   statusBarItem.show();
 });
 
 const hasCurrentUserTraceFlag = (records: TraceFlagItem[], userId: string | undefined) =>
   Boolean(userId && records.some(r => r.logType === 'DEVELOPER_LOG' && r.tracedEntityId === userId));
+
+/** Returns the current user's own DEVELOPER_LOG trace flag, or undefined if none is active. */
+export const selectCurrentUserFlag = (
+  records: TraceFlagItem[],
+  userId: string | undefined
+): TraceFlagItem | undefined =>
+  userId ? records.find(r => r.logType === 'DEVELOPER_LOG' && r.tracedEntityId === userId) : undefined;
 
 /** Build the tooltip for the status bar item */
 const buildTooltip = (

--- a/packages/salesforcedx-vscode-apex-log/src/statusBar/traceFlagStatusBar.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/statusBar/traceFlagStatusBar.ts
@@ -138,12 +138,11 @@ const refresh = Effect.fn('ApexLog.traceFlagStatusBar.refresh', { root: true })(
 const hasCurrentUserTraceFlag = (records: TraceFlagItem[], userId: string | undefined) =>
   Boolean(userId && records.some(r => r.logType === 'DEVELOPER_LOG' && r.tracedEntityId === userId));
 
-/** Returns the current user's own DEVELOPER_LOG trace flag, or undefined if none is active. */
+/** Returns the first trace flag (any type) for the current user, or undefined if none is active. */
 export const selectCurrentUserFlag = (
   records: TraceFlagItem[],
   userId: string | undefined
-): TraceFlagItem | undefined =>
-  userId ? records.find(r => r.logType === 'DEVELOPER_LOG' && r.tracedEntityId === userId) : undefined;
+): TraceFlagItem | undefined => (userId ? records.find(r => r.tracedEntityId === userId) : undefined);
 
 /** Build the tooltip for the status bar item */
 const buildTooltip = (

--- a/packages/salesforcedx-vscode-apex-log/test/unit/statusBar/traceFlagStatusBar.test.ts
+++ b/packages/salesforcedx-vscode-apex-log/test/unit/statusBar/traceFlagStatusBar.test.ts
@@ -31,11 +31,6 @@ describe('selectCurrentUserFlag', () => {
     expect(selectCurrentUserFlag([], CURRENT_USER)).toBeUndefined();
   });
 
-  it('returns undefined when userId is undefined', () => {
-    const flag = makeFlag('DEVELOPER_LOG', CURRENT_USER);
-    expect(selectCurrentUserFlag([flag], undefined)).toBeUndefined();
-  });
-
   it('returns the DEVELOPER_LOG flag for the current user', () => {
     const flag = makeFlag('DEVELOPER_LOG', CURRENT_USER);
     expect(selectCurrentUserFlag([flag], CURRENT_USER)).toBe(flag);

--- a/packages/salesforcedx-vscode-apex-log/test/unit/statusBar/traceFlagStatusBar.test.ts
+++ b/packages/salesforcedx-vscode-apex-log/test/unit/statusBar/traceFlagStatusBar.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import type { TraceFlagItem } from 'salesforcedx-vscode-services';
+import { selectCurrentUserFlag } from '../../../src/statusBar/traceFlagStatusBar';
+
+const future = new Date(Date.now() + 60_000);
+
+const makeFlag = (
+  logType: TraceFlagItem['logType'],
+  tracedEntityId: string,
+  overrides: Partial<TraceFlagItem> = {}
+): TraceFlagItem => ({
+  id: `id-${logType}-${tracedEntityId}`,
+  logType,
+  tracedEntityId,
+  expirationDate: future,
+  isActive: true,
+  ...overrides
+});
+
+const CURRENT_USER = '005CURRENT';
+const OTHER_USER = '005OTHER';
+
+describe('selectCurrentUserFlag', () => {
+  it('returns undefined when records are empty', () => {
+    expect(selectCurrentUserFlag([], CURRENT_USER)).toBeUndefined();
+  });
+
+  it('returns undefined when userId is undefined', () => {
+    const flag = makeFlag('DEVELOPER_LOG', CURRENT_USER);
+    expect(selectCurrentUserFlag([flag], undefined)).toBeUndefined();
+  });
+
+  it('returns the DEVELOPER_LOG flag for the current user', () => {
+    const flag = makeFlag('DEVELOPER_LOG', CURRENT_USER);
+    expect(selectCurrentUserFlag([flag], CURRENT_USER)).toBe(flag);
+  });
+
+  it('ignores DEVELOPER_LOG flags belonging to another user', () => {
+    const otherFlag = makeFlag('DEVELOPER_LOG', OTHER_USER);
+    expect(selectCurrentUserFlag([otherFlag], CURRENT_USER)).toBeUndefined();
+  });
+
+  it('ignores USER_DEBUG flags for the current user', () => {
+    const userDebugFlag = makeFlag('USER_DEBUG', CURRENT_USER);
+    expect(selectCurrentUserFlag([userDebugFlag], CURRENT_USER)).toBeUndefined();
+  });
+
+  it('returns current user DEVELOPER_LOG even when another user has one with a later expiry', () => {
+    const currentFlag = makeFlag('DEVELOPER_LOG', CURRENT_USER, {
+      expirationDate: new Date(Date.now() + 60_000)
+    });
+    const otherFlag = makeFlag('DEVELOPER_LOG', OTHER_USER, {
+      expirationDate: new Date(Date.now() + 3_600_000)
+    });
+    // records sorted by expiry desc — other user's flag comes first
+    expect(selectCurrentUserFlag([otherFlag, currentFlag], CURRENT_USER)).toBe(currentFlag);
+  });
+
+  it('returns undefined when current user only has USER_DEBUG flag and another user has DEVELOPER_LOG', () => {
+    const currentUserDebug = makeFlag('USER_DEBUG', CURRENT_USER);
+    const otherDevLog = makeFlag('DEVELOPER_LOG', OTHER_USER);
+    expect(selectCurrentUserFlag([otherDevLog, currentUserDebug], CURRENT_USER)).toBeUndefined();
+  });
+});

--- a/packages/salesforcedx-vscode-apex-log/test/unit/statusBar/traceFlagStatusBar.test.ts
+++ b/packages/salesforcedx-vscode-apex-log/test/unit/statusBar/traceFlagStatusBar.test.ts
@@ -46,12 +46,12 @@ describe('selectCurrentUserFlag', () => {
     expect(selectCurrentUserFlag([otherFlag], CURRENT_USER)).toBeUndefined();
   });
 
-  it('ignores USER_DEBUG flags for the current user', () => {
+  it('returns USER_DEBUG flags for the current user', () => {
     const userDebugFlag = makeFlag('USER_DEBUG', CURRENT_USER);
-    expect(selectCurrentUserFlag([userDebugFlag], CURRENT_USER)).toBeUndefined();
+    expect(selectCurrentUserFlag([userDebugFlag], CURRENT_USER)).toBe(userDebugFlag);
   });
 
-  it('returns current user DEVELOPER_LOG even when another user has one with a later expiry', () => {
+  it('returns current user flag even when another user has one with a later expiry', () => {
     const currentFlag = makeFlag('DEVELOPER_LOG', CURRENT_USER, {
       expirationDate: new Date(Date.now() + 60_000)
     });
@@ -62,9 +62,9 @@ describe('selectCurrentUserFlag', () => {
     expect(selectCurrentUserFlag([otherFlag, currentFlag], CURRENT_USER)).toBe(currentFlag);
   });
 
-  it('returns undefined when current user only has USER_DEBUG flag and another user has DEVELOPER_LOG', () => {
+  it('returns current user USER_DEBUG flag even when another user has DEVELOPER_LOG', () => {
     const currentUserDebug = makeFlag('USER_DEBUG', CURRENT_USER);
     const otherDevLog = makeFlag('DEVELOPER_LOG', OTHER_USER);
-    expect(selectCurrentUserFlag([otherDevLog, currentUserDebug], CURRENT_USER)).toBeUndefined();
+    expect(selectCurrentUserFlag([otherDevLog, currentUserDebug], CURRENT_USER)).toBe(currentUserDebug);
   });
 });


### PR DESCRIPTION
### What does this PR do?
Fixes a bug where trace flags that I create for other users are appearing in status bar icon.  Only trace flags tracking the current user should be reflected in the status bar.

### What issues does this PR fix or reference?
@W-23127627@

### Functionality Before
The status bar icon tracks the trace flag with the latest expiration date, even if it belongs to another user.

### Functionality After
The status bar icon only tracks the trace flag for the current user.
