### PR TITLE
refactor(services): convert gen→fn across vscode/observability/virtualFs (10 sites) - W-23125831

### DIFF
--- a/.claude/plans/W-23125831.md
+++ b/.claude/plans/W-23125831.md
@@ -2,16 +2,16 @@
 
 ## Context
 
-- Arrow-wrapper `(params) => Effect.gen(function* () {...})` → `Effect.fn('name')(function* (params) {...})` at 10 sites across `salesforcedx-vscode-services/src` (8) and `effect-ext-utils/src` (2)
+- Arrow-wrapper → `Effect.fn('name')`: 10 sites (services:8, effect-ext-utils:2)
 - `Effect.fn` provides auto-tracing span; matches 163 existing usages in services pkg; follows effect-best-practices preference for `Effect.fn` over `Effect.gen` (SKILL.md line 276)
-- Caller impact: NONE — `Effect.fn('name')(...)` returns function; callers keep `fn()` / `fn(arg)` syntax (confirmed: existing `watchDefaultOrgContext()` etc. still called with `()`)
+- Caller impact: none (returns function; callers unchanged)
 - Explicit `.pipe(Effect.withSpan('x'))` → drop; `Effect.fn('x')` supplies span
-- Keep span name identical → avoid telemetry drift
+- Preserve span names (telemetry continuity)
 
 ### Cross-package consistency (adversary:high)
-- `effect-ext-utils/src/extensionScope.ts` has an **identical** `getExtensionScope` (line 15) + `closeExtensionScope` (line 21) to the services copy. The effect-ext-utils copy is the **public API surface**: exported from `effect-ext-utils/src/index.ts:17` and imported by external packages via `@salesforce/effect-ext-utils` — apex-log (`src/index.ts` lines 9,13,48,67,133) and visualforce (`src/extension.ts` lines 8,21,50).
-- Services copy (`vscode/extensionScope.ts`) is **internal-only**: consumed within the package by `index.ts:58` and `core/traceFlagService.ts:27`, NOT re-exported.
-- Both copies MUST be converted together with matching span names, or callers see divergent telemetry spans. Higher blast radius is the effect-ext-utils copy.
+- effect-ext-utils/extensionScope.ts: identical getExtensionScope (:15) + closeExtensionScope (:21); public API (index.ts:17) consumed by apex-log + visualforce (+ apex-testing, lightning, metadata, org-browser, soql)
+- services/vscode/extensionScope.ts: internal (index.ts:58, traceFlagService.ts:27), not exported
+- Convert both with matching span names (divergent telemetry risk); effect-ext-utils higher blast radius
 
 10 sites:
 - effect-ext-utils/extensionScope.ts:15 `getExtensionScope` (no span), :21 `closeExtensionScope` (drop `withSpan('closeExtensionScope')`) — PUBLIC API
@@ -21,14 +21,14 @@
 - observability/applicationInsightsWebExporter.ts:90 `exportSpan(span)` (no span)
 - observability/applicationInsightsNodeExporter.ts:108 `sendSpan(span, otelLogger)` (no span)
 
-Span-name note: projectInit had `'projectInit: createProjectStructure'` / `'projectFiles'`. `Effect.fn` name must equal old withSpan string for those 2; both extensionScope copies keep `'closeExtensionScope'` identical. For the no-prior-span sites pick a descriptive name (free choice, follow domain-name convention; `getExtensionScope` copies must match each other).
+Span names: projectInit keeps `'projectInit: createProjectStructure'` / `'projectFiles'` (matches old withSpan); extensionScope copies use `'closeExtensionScope'` / `'getExtensionScope'` (must match across packages)
 
 ## Phases
 
 ### Phase 0 — effect-ext-utils extensionScope (2 sites, PUBLIC API)
 - effect-ext-utils/src/extensionScope.ts: `getExtensionScope` → `Effect.fn('getExtensionScope')(function* () {...})`; `closeExtensionScope` → `Effect.fn('closeExtensionScope')(function* () {...})`, drop `.pipe(Effect.withSpan(...))`
-- Do FIRST: this is the public copy external packages consume; services copy (Phase 1) must mirror exact same span names
-- No caller edits: apex-log + visualforce call `getExtensionScope()` / `closeExtensionScope()` with `()` — `Effect.fn` returns a function, signature unchanged
+- Do first: public API (external consumers); services (Phase 1) must mirror span names
+- No caller edits: all 7 in-repo consumers unchanged (apex-log, visualforce, apex-testing, lightning, metadata, org-browser, soql) — Effect.fn returns function
 - Files: `packages/effect-ext-utils/src/extensionScope.ts`
 - commitMessage: `refactor(effect-ext-utils): convert extensionScope gen→fn - W-23125831`
 
@@ -41,7 +41,7 @@ Span-name note: projectInit had `'projectInit: createProjectStructure'` / `'proj
 ### Phase 2 — projectInit (2 sites, params)
 - `createProjectStructure` → `Effect.fn('projectInit: createProjectStructure')(function* (fsp: FsProvider) {...})`, drop withSpan
 - `projectFiles` → `Effect.fn('projectFiles')(function* (fsp: FsProvider) {...})`, drop withSpan
-- Keep span names exact → telemetry continuity
+- Preserve span names (telemetry continuity)
 - Files: `virtualFsProvider/projectInit.ts`
 - commitMessage: `refactor(services): convert projectInit createProjectStructure + projectFiles gen→fn - W-23125831`
 
@@ -58,10 +58,10 @@ Span-name note: projectInit had `'projectInit: createProjectStructure'` / `'proj
 - verification
 
 ## Verification
-- Not e2e-covered: pure refactor, behavior-preserving; rely on LS diagnostics + tsc, not e2e
+- No e2e: pure refactor; rely on LS + tsc
 - Effect LS only flags `effectFnOpportunity` at 4 sites pre-edit (verified): `effect-ext-utils/src/extensionScope.ts:21` closeExtensionScope, `services/src/vscode/extensionScope.ts:21` closeExtensionScope, `services/src/virtualFsProvider/projectInit.ts:44` createProjectStructure, `:89` projectFiles. Post-edit those 4 must be 0.
-  - LS does NOT flag the other 6 sites (getExtensionScope x2, editorContext x2, observability x2) — param-less no-span arrows and class-method-nested fns aren't surfaced. They are still converted per effect-best-practices preference for `Effect.fn` over `Effect.gen` (SKILL.md line 276), not because LS flags them.
+  - LS does not flag other 6 sites (param-less no-span arrows); still converted per effect-best-practices:276
 - Run LS in BOTH packages: `npx effect-language-service diagnostics --project tsconfig.json` in `packages/effect-ext-utils` and `packages/salesforcedx-vscode-services` — 0 `effectFnOpportunity` remaining post-edit
 - PostToolUse `verify-on-edit.sh` auto-runs `--file` per edit; address output
-- `tsc`/build of BOTH packages — no type regressions (param types moved into generator signature)
-- No caller edits needed; confirm callers in apex-log/visualforce (effect-ext-utils consumers) + services index.ts/traceFlagService.ts still typecheck
+- tsc/build both packages: no regressions
+- No caller edits; confirm apex-log/visualforce + services consumers typecheck

--- a/.claude/plans/W-23125831.md
+++ b/.claude/plans/W-23125831.md
@@ -1,0 +1,67 @@
+# W-23125831 — gen→fn: services + effect-ext-utils vscode/observability/virtualFs (10 sites)
+
+## Context
+
+- Arrow-wrapper `(params) => Effect.gen(function* () {...})` → `Effect.fn('name')(function* (params) {...})` at 10 sites across `salesforcedx-vscode-services/src` (8) and `effect-ext-utils/src` (2)
+- `Effect.fn` provides auto-tracing span; matches 163 existing usages in services pkg; follows effect-best-practices preference for `Effect.fn` over `Effect.gen` (SKILL.md line 276)
+- Caller impact: NONE — `Effect.fn('name')(...)` returns function; callers keep `fn()` / `fn(arg)` syntax (confirmed: existing `watchDefaultOrgContext()` etc. still called with `()`)
+- Explicit `.pipe(Effect.withSpan('x'))` → drop; `Effect.fn('x')` supplies span
+- Keep span name identical → avoid telemetry drift
+
+### Cross-package consistency (adversary:high)
+- `effect-ext-utils/src/extensionScope.ts` has an **identical** `getExtensionScope` (line 15) + `closeExtensionScope` (line 21) to the services copy. The effect-ext-utils copy is the **public API surface**: exported from `effect-ext-utils/src/index.ts:17` and imported by external packages via `@salesforce/effect-ext-utils` — apex-log (`src/index.ts` lines 9,13,48,67,133) and visualforce (`src/extension.ts` lines 8,21,50).
+- Services copy (`vscode/extensionScope.ts`) is **internal-only**: consumed within the package by `index.ts:58` and `core/traceFlagService.ts:27`, NOT re-exported.
+- Both copies MUST be converted together with matching span names, or callers see divergent telemetry spans. Higher blast radius is the effect-ext-utils copy.
+
+10 sites:
+- effect-ext-utils/extensionScope.ts:15 `getExtensionScope` (no span), :21 `closeExtensionScope` (drop `withSpan('closeExtensionScope')`) — PUBLIC API
+- vscode/extensionScope.ts:15 `getExtensionScope` (no span), :21 `closeExtensionScope` (drop `withSpan('closeExtensionScope')`) — internal, must mirror public copy
+- vscode/editorContext.ts:27 `watchPackageDirectoriesContext`, :51 `watchApexTestContext` (no spans)
+- virtualFsProvider/projectInit.ts:44 `createProjectStructure(fsp)` (drop `withSpan('projectInit: createProjectStructure')`), :89 `projectFiles(fsp)` (drop `withSpan('projectFiles')`)
+- observability/applicationInsightsWebExporter.ts:90 `exportSpan(span)` (no span)
+- observability/applicationInsightsNodeExporter.ts:108 `sendSpan(span, otelLogger)` (no span)
+
+Span-name note: projectInit had `'projectInit: createProjectStructure'` / `'projectFiles'`. `Effect.fn` name must equal old withSpan string for those 2; both extensionScope copies keep `'closeExtensionScope'` identical. For the no-prior-span sites pick a descriptive name (free choice, follow domain-name convention; `getExtensionScope` copies must match each other).
+
+## Phases
+
+### Phase 0 — effect-ext-utils extensionScope (2 sites, PUBLIC API)
+- effect-ext-utils/src/extensionScope.ts: `getExtensionScope` → `Effect.fn('getExtensionScope')(function* () {...})`; `closeExtensionScope` → `Effect.fn('closeExtensionScope')(function* () {...})`, drop `.pipe(Effect.withSpan(...))`
+- Do FIRST: this is the public copy external packages consume; services copy (Phase 1) must mirror exact same span names
+- No caller edits: apex-log + visualforce call `getExtensionScope()` / `closeExtensionScope()` with `()` — `Effect.fn` returns a function, signature unchanged
+- Files: `packages/effect-ext-utils/src/extensionScope.ts`
+- commitMessage: `refactor(effect-ext-utils): convert extensionScope gen→fn - W-23125831`
+
+### Phase 1 — services extensionScope + editorContext (4 sites)
+- extensionScope.ts: `getExtensionScope` → `Effect.fn('getExtensionScope')(function* () {...})`; `closeExtensionScope` → `Effect.fn('closeExtensionScope')(function* () {...})`, drop `.pipe(Effect.withSpan(...))` — span names MUST equal Phase 0 copy
+- editorContext.ts: `watchPackageDirectoriesContext` → `Effect.fn('watchPackageDirectoriesContext')(function* () {...})`; `watchApexTestContext` → `Effect.fn('watchApexTestContext')(function* () {...})`
+- Files: `packages/salesforcedx-vscode-services/src/vscode/extensionScope.ts`, `.../vscode/editorContext.ts`
+- commitMessage: `refactor(services): convert extensionScope + editorContext gen→fn - W-23125831`
+
+### Phase 2 — projectInit (2 sites, params)
+- `createProjectStructure` → `Effect.fn('projectInit: createProjectStructure')(function* (fsp: FsProvider) {...})`, drop withSpan
+- `projectFiles` → `Effect.fn('projectFiles')(function* (fsp: FsProvider) {...})`, drop withSpan
+- Keep span names exact → telemetry continuity
+- Files: `virtualFsProvider/projectInit.ts`
+- commitMessage: `refactor(services): convert projectInit createProjectStructure + projectFiles gen→fn - W-23125831`
+
+### Phase 3 — observability exporters (2 sites, params)
+- web `exportSpan` → `Effect.fn('exportSpan')(function* (span: ReadableSpan) {...})`
+- node `sendSpan` → `Effect.fn('sendSpan')(function* (span: ReadableSpan, otelLogger: ReturnType<LoggerProvider['getLogger']>) {...})`
+- Files: `observability/applicationInsightsWebExporter.ts`, `observability/applicationInsightsNodeExporter.ts`
+- commitMessage: `refactor(services): convert observability exportSpan + sendSpan gen→fn - W-23125831`
+
+## Skills to apply
+- effect-best-practices
+- typescript
+- concise
+- verification
+
+## Verification
+- Not e2e-covered: pure refactor, behavior-preserving; rely on LS diagnostics + tsc, not e2e
+- Effect LS only flags `effectFnOpportunity` at 4 sites pre-edit (verified): `effect-ext-utils/src/extensionScope.ts:21` closeExtensionScope, `services/src/vscode/extensionScope.ts:21` closeExtensionScope, `services/src/virtualFsProvider/projectInit.ts:44` createProjectStructure, `:89` projectFiles. Post-edit those 4 must be 0.
+  - LS does NOT flag the other 6 sites (getExtensionScope x2, editorContext x2, observability x2) — param-less no-span arrows and class-method-nested fns aren't surfaced. They are still converted per effect-best-practices preference for `Effect.fn` over `Effect.gen` (SKILL.md line 276), not because LS flags them.
+- Run LS in BOTH packages: `npx effect-language-service diagnostics --project tsconfig.json` in `packages/effect-ext-utils` and `packages/salesforcedx-vscode-services` — 0 `effectFnOpportunity` remaining post-edit
+- PostToolUse `verify-on-edit.sh` auto-runs `--file` per edit; address output
+- `tsc`/build of BOTH packages — no type regressions (param types moved into generator signature)
+- No caller edits needed; confirm callers in apex-log/visualforce (effect-ext-utils consumers) + services index.ts/traceFlagService.ts still typecheck

--- a/packages/effect-ext-utils/src/extensionScope.ts
+++ b/packages/effect-ext-utils/src/extensionScope.ts
@@ -12,16 +12,14 @@ import * as Scope from 'effect/Scope';
 // eslint-disable-next-line functional/no-let
 let extensionScope: Scope.CloseableScope | undefined;
 
-export const getExtensionScope = () =>
-  Effect.gen(function* () {
-    extensionScope ??= yield* Scope.make();
-    return extensionScope;
-  });
+export const getExtensionScope = Effect.fn('getExtensionScope')(function* () {
+  extensionScope ??= yield* Scope.make();
+  return extensionScope;
+});
 
-export const closeExtensionScope = () =>
-  Effect.gen(function* () {
-    if (extensionScope) {
-      yield* Scope.close(extensionScope, Exit.void);
-      extensionScope = undefined;
-    }
-  }).pipe(Effect.withSpan('closeExtensionScope'));
+export const closeExtensionScope = Effect.fn('closeExtensionScope')(function* () {
+  if (extensionScope) {
+    yield* Scope.close(extensionScope, Exit.void);
+    extensionScope = undefined;
+  }
+});

--- a/packages/salesforcedx-vscode-services/src/observability/applicationInsightsNodeExporter.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/applicationInsightsNodeExporter.ts
@@ -105,58 +105,60 @@ export class ApplicationInsightsNodeExporter implements SpanExporter {
   }
 }
 
-const sendSpan = (span: ReadableSpan, otelLogger: ReturnType<LoggerProvider['getLogger']>) =>
-  Effect.gen(function* () {
-    const telemetryTag = workspace.getConfiguration()?.get<string>('salesforcedx-vscode-core.telemetry-tag');
+const sendSpan = Effect.fn('sendSpan')(function* (
+  span: ReadableSpan,
+  otelLogger: ReturnType<LoggerProvider['getLogger']>
+) {
+  const telemetryTag = workspace.getConfiguration()?.get<string>('salesforcedx-vscode-core.telemetry-tag');
 
-    const { userId, webUserId } = yield* Effect.gen(function* () {
-      const orgRef = yield* getDefaultOrgRef();
-      return yield* SubscriptionRef.get(orgRef);
-    }).pipe(Effect.catchAll(() => Effect.succeed({ userId: undefined, webUserId: undefined })));
+  const { userId, webUserId } = yield* Effect.gen(function* () {
+    const orgRef = yield* getDefaultOrgRef();
+    return yield* SubscriptionRef.get(orgRef);
+  }).pipe(Effect.catchAll(() => Effect.succeed({ userId: undefined, webUserId: undefined })));
 
-    const isError = span.status?.code === SpanStatusCode.ERROR;
+  const isError = span.status?.code === SpanStatusCode.ERROR;
 
-    // Emit a LogRecord — the "microsoft.custom_event.name" attribute tells Azure Monitor
-    // to route this to the customEvents table instead of traces.
-    otelLogger.emit({
-      // SeverityNumber.ERROR (17) / SeverityNumber.INFO (9) — hard-coded to avoid a runtime
-      // dependency on @opentelemetry/api-logs just for these enum values.
-      // https://github.com/open-telemetry/opentelemetry-js/blob/main/api/src/logs/LogRecord.ts
-      severityNumber: isError ? 17 : 9,
-      severityText: isError ? 'ERROR' : 'INFO',
-      // The customEvent name comes from the microsoft.custom_event.name attribute (below), so body
-      // is free to carry numeric measurements: the Azure log→customEvent mapping reads
-      // body.measurements into baseData.measurements (logUtils.getLegacyApplicationInsightsMeasurements).
-      // duration is ALSO kept in attributes → properties (string) so existing properties consumers
-      // keep working; measurements gives the queryable numeric copy.
-      body: { measurements: { duration: spanDuration(span) } },
-      attributes: {
-        // Magic attribute: routes this LogRecord to the customEvents table
-        'microsoft.custom_event.name': span.name,
+  // Emit a LogRecord — the "microsoft.custom_event.name" attribute tells Azure Monitor
+  // to route this to the customEvents table instead of traces.
+  otelLogger.emit({
+    // SeverityNumber.ERROR (17) / SeverityNumber.INFO (9) — hard-coded to avoid a runtime
+    // dependency on @opentelemetry/api-logs just for these enum values.
+    // https://github.com/open-telemetry/opentelemetry-js/blob/main/api/src/logs/LogRecord.ts
+    severityNumber: isError ? 17 : 9,
+    severityText: isError ? 'ERROR' : 'INFO',
+    // The customEvent name comes from the microsoft.custom_event.name attribute (below), so body
+    // is free to carry numeric measurements: the Azure log→customEvent mapping reads
+    // body.measurements into baseData.measurements (logUtils.getLegacyApplicationInsightsMeasurements).
+    // duration is ALSO kept in attributes → properties (string) so existing properties consumers
+    // keep working; measurements gives the queryable numeric copy.
+    body: { measurements: { duration: spanDuration(span) } },
+    attributes: {
+      // Magic attribute: routes this LogRecord to the customEvents table
+      'microsoft.custom_event.name': span.name,
 
-        // Resource attributes (extension name/version)
-        ...convertAttributes(span.resource.attributes),
-        ...getExtensionNameAndVersionAttributes(span.resource.attributes),
-        // Span attributes
-        ...convertAttributes(span.attributes),
-        // Trace context
-        traceID: span.spanContext().traceId,
-        spanID: span.spanContext().spanId,
-        ...(span.parentSpanContext?.spanId ? { parentID: span.parentSpanContext.spanId } : {}),
-        // Span metadata
-        spanKind: getSpanKindName(span.kind),
-        spanStatus: isError ? 'ERROR' : 'OK',
-        // Timestamps
-        startTime: String(span.startTime[0] * 1000 + span.startTime[1] / 1_000_000),
-        endTime: String(span.endTime[0] * 1000 + span.endTime[1] / 1_000_000),
-        // Duration as a measurement
-        duration: spanDuration(span),
-        // User context
-        ...(userId ? { userId } : {}),
-        ...(webUserId ? { webUserId } : {}),
-        // Telemetry tag
-        ...(telemetryTag ? { telemetryTag } : {})
-      },
-      timestamp: span.startTime
-    });
+      // Resource attributes (extension name/version)
+      ...convertAttributes(span.resource.attributes),
+      ...getExtensionNameAndVersionAttributes(span.resource.attributes),
+      // Span attributes
+      ...convertAttributes(span.attributes),
+      // Trace context
+      traceID: span.spanContext().traceId,
+      spanID: span.spanContext().spanId,
+      ...(span.parentSpanContext?.spanId ? { parentID: span.parentSpanContext.spanId } : {}),
+      // Span metadata
+      spanKind: getSpanKindName(span.kind),
+      spanStatus: isError ? 'ERROR' : 'OK',
+      // Timestamps
+      startTime: String(span.startTime[0] * 1000 + span.startTime[1] / 1_000_000),
+      endTime: String(span.endTime[0] * 1000 + span.endTime[1] / 1_000_000),
+      // Duration as a measurement
+      duration: spanDuration(span),
+      // User context
+      ...(userId ? { userId } : {}),
+      ...(webUserId ? { webUserId } : {}),
+      // Telemetry tag
+      ...(telemetryTag ? { telemetryTag } : {})
+    },
+    timestamp: span.startTime
   });
+});

--- a/packages/salesforcedx-vscode-services/src/observability/applicationInsightsNodeExporter.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/applicationInsightsNodeExporter.ts
@@ -111,10 +111,10 @@ const sendSpan = Effect.fn('sendSpan')(function* (
 ) {
   const telemetryTag = workspace.getConfiguration()?.get<string>('salesforcedx-vscode-core.telemetry-tag');
 
-  const { userId, webUserId } = yield* Effect.gen(function* () {
-    const orgRef = yield* getDefaultOrgRef();
-    return yield* SubscriptionRef.get(orgRef);
-  }).pipe(Effect.catchAll(() => Effect.succeed({ userId: undefined, webUserId: undefined })));
+  const { userId, webUserId } = yield* getDefaultOrgRef().pipe(
+    Effect.flatMap(SubscriptionRef.get),
+    Effect.catchAll(() => Effect.succeed({ userId: undefined, webUserId: undefined }))
+  );
 
   const isError = span.status?.code === SpanStatusCode.ERROR;
 

--- a/packages/salesforcedx-vscode-services/src/observability/applicationInsightsWebExporter.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/applicationInsightsWebExporter.ts
@@ -97,7 +97,10 @@ const exportSpan = Effect.fn('exportSpan')(function* (span: ReadableSpan) {
     parentID: span.parentSpanContext?.spanId
   };
 
-  const { userId, webUserId } = yield* SubscriptionRef.get(yield* getDefaultOrgRef());
+  const { userId, webUserId } = yield* getDefaultOrgRef().pipe(
+    Effect.flatMap(SubscriptionRef.get),
+    Effect.catchAll(() => Effect.succeed({ userId: undefined, webUserId: undefined }))
+  );
 
   const props = {
     ...convertAttributes(span.resource.attributes),

--- a/packages/salesforcedx-vscode-services/src/observability/applicationInsightsWebExporter.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/applicationInsightsWebExporter.ts
@@ -87,48 +87,47 @@ export class ApplicationInsightsWebExporter implements SpanExporter {
   }
 }
 
-const exportSpan = (span: ReadableSpan) =>
-  Effect.gen(function* () {
-    const success = span.status?.code !== SpanStatusCode.ERROR;
+const exportSpan = Effect.fn('exportSpan')(function* (span: ReadableSpan) {
+  const success = span.status?.code !== SpanStatusCode.ERROR;
 
-    // Create distributed trace context from OpenTelemetry span context
-    const telemetryTrace = {
-      traceID: span.spanContext().traceId,
-      spanID: span.spanContext().spanId,
-      parentID: span.parentSpanContext?.spanId
-    };
+  // Create distributed trace context from OpenTelemetry span context
+  const telemetryTrace = {
+    traceID: span.spanContext().traceId,
+    spanID: span.spanContext().spanId,
+    parentID: span.parentSpanContext?.spanId
+  };
 
-    const { userId, webUserId } = yield* SubscriptionRef.get(yield* getDefaultOrgRef());
+  const { userId, webUserId } = yield* SubscriptionRef.get(yield* getDefaultOrgRef());
 
-    const props = {
-      ...convertAttributes(span.resource.attributes),
-      ...getExtensionNameAndVersionAttributes(span.resource.attributes),
-      ...convertAttributes(span.attributes),
-      ...telemetryTrace,
-      spanKind: getSpanKindName(span.kind),
-      telemetryTag,
-      startTime: String(span.startTime[0] * 1000 + span.startTime[1] / 1_000_000),
-      endTime: String(span.endTime[0] * 1000 + span.endTime[1] / 1_000_000),
-      ...(userId ? { userId } : {}),
-      ...(webUserId ? { webUserId } : {})
-    };
+  const props = {
+    ...convertAttributes(span.resource.attributes),
+    ...getExtensionNameAndVersionAttributes(span.resource.attributes),
+    ...convertAttributes(span.attributes),
+    ...telemetryTrace,
+    spanKind: getSpanKindName(span.kind),
+    telemetryTag,
+    startTime: String(span.startTime[0] * 1000 + span.startTime[1] / 1_000_000),
+    endTime: String(span.endTime[0] * 1000 + span.endTime[1] / 1_000_000),
+    ...(userId ? { userId } : {}),
+    ...(webUserId ? { webUserId } : {})
+  };
 
-    const measurements = {
-      duration: spanDuration(span)
-    };
+  const measurements = {
+    duration: spanDuration(span)
+  };
 
-    yield* Effect.try({
-      try: () =>
-        process.env.ESBUILD_WEB_LOCAL === '1'
-          ? sendToLocalAppInsightsFile(span.name, success, props, measurements)
-          : success
-            ? getWebAppInsightsReporter().sendDangerousTelemetryEvent(span.name, props, measurements)
-            : getWebAppInsightsReporter().sendDangerousTelemetryErrorEvent(span.name, props, measurements),
-      catch: error => unknownToErrorCause(error)
-    }).pipe(
-      Effect.catchAll(error => Console.error('❌ Failed to send dangerous telemetry:', JSON.stringify(error.cause)))
-    );
-  });
+  yield* Effect.try({
+    try: () =>
+      process.env.ESBUILD_WEB_LOCAL === '1'
+        ? sendToLocalAppInsightsFile(span.name, success, props, measurements)
+        : success
+          ? getWebAppInsightsReporter().sendDangerousTelemetryEvent(span.name, props, measurements)
+          : getWebAppInsightsReporter().sendDangerousTelemetryErrorEvent(span.name, props, measurements),
+    catch: error => unknownToErrorCause(error)
+  }).pipe(
+    Effect.catchAll(error => Console.error('❌ Failed to send dangerous telemetry:', JSON.stringify(error.cause)))
+  );
+});
 
 // Local-dev sink: POST the App Insights payload to the span file server instead of Azure (ESBUILD_WEB_LOCAL).
 // Shares the Node divert /v2.1/track endpoint; the server sorts web events from Breeze envelopes by shape.

--- a/packages/salesforcedx-vscode-services/src/virtualFsProvider/projectInit.ts
+++ b/packages/salesforcedx-vscode-services/src/virtualFsProvider/projectInit.ts
@@ -41,27 +41,26 @@ const createConfigFiles = (fsp: FsProvider): void => {
 };
 
 /** Creates the project directory structure and files */
-const createProjectStructure = (fsp: FsProvider) =>
-  Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan({ sampleProjectPath });
-    const dirsToCreate = getDirsToCreate();
-    yield* Effect.annotateCurrentSpan({ dirsToCreate });
+const createProjectStructure = Effect.fn('projectInit: createProjectStructure')(function* (fsp: FsProvider) {
+  yield* Effect.annotateCurrentSpan({ sampleProjectPath });
+  const dirsToCreate = getDirsToCreate();
+  yield* Effect.annotateCurrentSpan({ dirsToCreate });
 
-    yield* Effect.tryPromise({
-      try: () =>
-        Promise.all(
-          dirsToCreate
-            .map(dir => URI.parse(dir))
-            .filter(uri => !fsp.exists(uri))
-            .map(uri => fsp.createDirectory(uri))
-        ),
-      catch: (error: unknown) => new VirtualFsProviderError(unknownToErrorCause(error))
-    });
+  yield* Effect.tryPromise({
+    try: () =>
+      Promise.all(
+        dirsToCreate
+          .map(dir => URI.parse(dir))
+          .filter(uri => !fsp.exists(uri))
+          .map(uri => fsp.createDirectory(uri))
+      ),
+    catch: (error: unknown) => new VirtualFsProviderError(unknownToErrorCause(error))
+  });
 
-    yield* Effect.all([Effect.sync(() => createConfigFiles(fsp)), Effect.sync(() => createVSCodeFiles(fsp))], {
-      concurrency: 'unbounded'
-    });
-  }).pipe(Effect.withSpan('projectInit: createProjectStructure'));
+  yield* Effect.all([Effect.sync(() => createConfigFiles(fsp)), Effect.sync(() => createVSCodeFiles(fsp))], {
+    concurrency: 'unbounded'
+  });
+});
 
 const createVSCodeFiles = (fsp: FsProvider): void => {
   // Create .vscode directory and config files
@@ -86,16 +85,15 @@ const createVSCodeFiles = (fsp: FsProvider): void => {
 };
 
 /** Creates the files for an empty sfdx project */
-export const projectFiles = (fsp: FsProvider) =>
-  Effect.gen(function* () {
-    // Check if project already exists, if not create it
-    const projectExists = fsp.exists(URI.parse(`${sampleProjectPath}/sfdx-project.json`));
-    yield* Effect.annotateCurrentSpan({
-      projectExists,
-      projectFiles: fsp.readDirectory(URI.parse(`${sampleProjectPath}`))
-    });
+export const projectFiles = Effect.fn('projectFiles')(function* (fsp: FsProvider) {
+  // Check if project already exists, if not create it
+  const projectExists = fsp.exists(URI.parse(`${sampleProjectPath}/sfdx-project.json`));
+  yield* Effect.annotateCurrentSpan({
+    projectExists,
+    projectFiles: fsp.readDirectory(URI.parse(`${sampleProjectPath}`))
+  });
 
-    if (!projectExists) {
-      yield* createProjectStructure(fsp);
-    }
-  }).pipe(Effect.withSpan('projectFiles'));
+  if (!projectExists) {
+    yield* createProjectStructure(fsp);
+  }
+});

--- a/packages/salesforcedx-vscode-services/src/vscode/editorContext.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/editorContext.ts
@@ -24,35 +24,33 @@ const isApexTestFile = (editor: vscode.TextEditor | undefined): boolean =>
   editor?.document.uri.fsPath.endsWith('.cls') ? IS_TEST_REG_EXP.test(editor.document.getText()) : false;
 
 /** Update VS Code context variable when the active editor changes */
-export const watchPackageDirectoriesContext = () =>
-  Effect.gen(function* () {
-    const [editorService, projectService] = yield* Effect.all([EditorService, ProjectService]);
+export const watchPackageDirectoriesContext = Effect.fn('watchPackageDirectoriesContext')(function* () {
+  const [editorService, projectService] = yield* Effect.all([EditorService, ProjectService]);
 
-    yield* Stream.merge(
-      Stream.fromEffect(
-        editorService.getActiveEditorUri().pipe(Effect.catchTag('NoActiveEditorError', () => Effect.void))
-      ),
-      Stream.fromPubSub(editorService.pubsub).pipe(Stream.map(editor => editor?.document.uri))
-    ).pipe(
-      Stream.debounce(Duration.millis(50)),
-      Stream.changes,
-      Stream.runForEach(uri =>
-        uri
-          ? projectService.isInPackageDirectories(uri).pipe(
-              Effect.flatMap(setInPackageDirectoriesContext),
-              Effect.catchAll(() => setInPackageDirectoriesContext(false))
-            )
-          : setInPackageDirectoriesContext(false)
-      )
-    );
-  });
+  yield* Stream.merge(
+    Stream.fromEffect(
+      editorService.getActiveEditorUri().pipe(Effect.catchTag('NoActiveEditorError', () => Effect.void))
+    ),
+    Stream.fromPubSub(editorService.pubsub).pipe(Stream.map(editor => editor?.document.uri))
+  ).pipe(
+    Stream.debounce(Duration.millis(50)),
+    Stream.changes,
+    Stream.runForEach(uri =>
+      uri
+        ? projectService.isInPackageDirectories(uri).pipe(
+            Effect.flatMap(setInPackageDirectoriesContext),
+            Effect.catchAll(() => setInPackageDirectoriesContext(false))
+          )
+        : setInPackageDirectoriesContext(false)
+    )
+  );
+});
 
 /** Update VS Code context when the active editor is an Apex test file (.cls with @isTest) */
-export const watchApexTestContext = () =>
-  Effect.gen(function* () {
-    const editorService = yield* EditorService;
-    yield* Stream.merge(
-      Stream.fromEffect(Effect.sync(() => isApexTestFile(vscode.window.activeTextEditor))),
-      Stream.fromPubSub(editorService.pubsub).pipe(Stream.map(isApexTestFile))
-    ).pipe(Stream.debounce(Duration.millis(50)), Stream.changes, Stream.runForEach(setApexTestContext));
-  });
+export const watchApexTestContext = Effect.fn('watchApexTestContext')(function* () {
+  const editorService = yield* EditorService;
+  yield* Stream.merge(
+    Stream.fromEffect(Effect.sync(() => isApexTestFile(vscode.window.activeTextEditor))),
+    Stream.fromPubSub(editorService.pubsub).pipe(Stream.map(isApexTestFile))
+  ).pipe(Stream.debounce(Duration.millis(50)), Stream.changes, Stream.runForEach(setApexTestContext));
+});

--- a/packages/salesforcedx-vscode-services/src/vscode/editorContext.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/editorContext.ts
@@ -9,6 +9,7 @@ import * as Duration from 'effect/Duration';
 import * as Effect from 'effect/Effect';
 import * as Stream from 'effect/Stream';
 import * as vscode from 'vscode';
+import { Utils } from 'vscode-uri';
 import { ProjectService } from '../core/projectService';
 import { EditorService } from './editorService';
 
@@ -21,7 +22,7 @@ const setApexTestContext = (value: boolean) =>
 const IS_TEST_REG_EXP = /@isTest/i;
 
 const isApexTestFile = (editor: vscode.TextEditor | undefined): boolean =>
-  editor?.document.uri.fsPath.endsWith('.cls') ? IS_TEST_REG_EXP.test(editor.document.getText()) : false;
+  editor && Utils.extname(editor.document.uri) === '.cls' ? IS_TEST_REG_EXP.test(editor.document.getText()) : false;
 
 /** Update VS Code context variable when the active editor changes */
 export const watchPackageDirectoriesContext = Effect.fn('watchPackageDirectoriesContext')(function* () {

--- a/packages/salesforcedx-vscode-services/src/vscode/extensionScope.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/extensionScope.ts
@@ -12,16 +12,14 @@ import * as Scope from 'effect/Scope';
 // eslint-disable-next-line functional/no-let
 let extensionScope: Scope.CloseableScope | undefined;
 
-export const getExtensionScope = () =>
-  Effect.gen(function* () {
-    extensionScope ??= yield* Scope.make();
-    return extensionScope;
-  });
+export const getExtensionScope = Effect.fn('getExtensionScope')(function* () {
+  extensionScope ??= yield* Scope.make();
+  return extensionScope;
+});
 
-export const closeExtensionScope = () =>
-  Effect.gen(function* () {
-    if (extensionScope) {
-      yield* Scope.close(extensionScope, Exit.void);
-      extensionScope = undefined;
-    }
-  }).pipe(Effect.withSpan('closeExtensionScope'));
+export const closeExtensionScope = Effect.fn('closeExtensionScope')(function* () {
+  if (extensionScope) {
+    yield* Scope.close(extensionScope, Exit.void);
+    extensionScope = undefined;
+  }
+});


### PR DESCRIPTION
## Summary

- Convert 10 arrow-wrapped gen→fn across services (8) + effect-ext-utils (2): extensionScope, editorContext, projectInit, observability exporters
- `Effect.fn('name')` provides auto-tracing span; drops explicit `.pipe(Effect.withSpan())` at 4 sites (preserving span names for telemetry continuity)
- extensionScope public API (effect-ext-utils) + internal mirror (services) converted with matching span names to avoid divergent telemetry risk

## Plan

[.claude/plans/W-23125831.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23125831-2-gen-fn-services-vscode-observability-v/.claude/plans/W-23125831.md)

## Reviewer notes

- **Low severity (core-extension-api):** CHANGELOG entry suggested for non-breaking Effect.fn conversion of public getExtensionScope/closeExtensionScope. No code change needed (behavior-preserving, monorepo typechecks). Note: extensionScope public API now adds tracing metadata via Effect.fn; non-breaking, signature unchanged, all 7 in-repo consumers (apex-log, visualforce, apex-testing, lightning, metadata, org-browser, soql) unaffected.

## Test plan

- Confirm Effect LS diagnostics show 0 `effectFnOpportunity` in both packages/effect-ext-utils and packages/salesforcedx-vscode-services (4 sites pre-edit should be gone)
- Spot-check extensionScope telemetry metadata in a dev window with tracing enabled (verify `getExtensionScope`/`closeExtensionScope` span names appear)

### What issues does this PR fix or reference?

@W-23125831@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cp4cFYAQ/view