### PR TITLE
fix(flakiness): cluster and filter on retry rate, enforce [ai-auto] tag - W-23128001

### DIFF
--- a/.claude/plans/W-23128001.md
+++ b/.claude/plans/W-23128001.md
@@ -4,7 +4,7 @@
 
 `.claude/workflows/flakiness-review.js`. 2 bugs:
 
-1. **Retry-masked flake slips through.** Cluster stage groups only hard run-level failures; filter marks cluster resolved off 1 green run. Ignores `testMetrics.retryRate` already collected (Phase 2). Evidence 2026-06-22: LWC rename (86% retry), Aura rename (67%), LWC LSP hover (67%), Apex Test Suite (57%) all marked resolved — 1 green run, no hard fail.
+1. **Retry-masked flake slips through.** Cluster groups hard run-level failures; filter marks cluster resolved on 1 green run. Ignores `testMetrics.retryRate` collected in Phase 2. Evidence 2026-06-22: LWC rename (86% retry), Aura rename (67%), LWC LSP hover (67%), Apex Test Suite (57%) all marked resolved — 1 green run, no hard fail.
 2. **[ai-auto] tag soft.** Only prompt instruction in Draft phase; drafts can omit → can't opt into auto-build-wi.
 
 DoD:
@@ -19,11 +19,11 @@ DoD:
 
 `.claude/workflows/flakiness-review.js`
 
-- `CLUSTERS_SCHEMA` (L69–88): add `retryRate` (number) + `source` (string `failure`|`retryRate`) to `properties`. Add BOTH to `required` (L77) so agent cannot silently omit: `required: ['testName', 'errorPattern', 'runIds', 'count', 'retryMasked', 'source', 'retryRate']`. Keep `retryMasked`.
-- Cluster agent (L321–344): `metricsData` is computed at L310 (before the cluster call), so pass `metricsData.testMetrics` JSON into the prompt the same way the filter agent embeds data (L377/L380 pattern: `${JSON.stringify(metricsData.testMetrics, null, 2)}` under a `## Per-test retry metrics` heading). The join is done BY THE CLUSTER AGENT, not post-processing code — there is no deterministic code step here. Add prompt instructions:
+- `CLUSTERS_SCHEMA` (L69–88): add `retryRate` (number) + `source` (string `failure`|`retryRate`) to `properties`. Add BOTH to `required` (L77) so agent must include: `required: ['testName', 'errorPattern', 'runIds', 'count', 'retryMasked', 'source', 'retryRate']`. Keep `retryMasked`.
+- Cluster agent (L321–344): `metricsData` is computed at L310 (before the cluster call), so pass `metricsData.testMetrics` JSON into the prompt the same way the filter agent embeds data (L377/L380 pattern: `${JSON.stringify(metricsData.testMetrics, null, 2)}` under a `## Per-test retry metrics` heading). Agent joins; no deterministic code step. Add prompt instructions:
   - For every cluster emitted, set `retryRate` by looking up the cluster's `testName` in the provided testMetrics array (match on `testName`); if absent, `retryRate: 0`.
   - Always set `source`: `'failure'` for run-level-failure clusters, `'retryRate'` for retry-threshold clusters.
-  - Also emit a cluster for any testMetrics entry with `retryRate >= ${RETRY_RATE_THRESHOLD} AND totalRuns >= ${RETRY_MIN_RUNS}` even with 0 hard failures: `source: 'retryRate'`, `retryMasked: true`, `count` = `retryCount`, `runIds` = best-available run ids for that test (empty array if none).
+  - Emit a cluster for any testMetrics entry with `retryRate >= ${RETRY_RATE_THRESHOLD} AND totalRuns >= ${RETRY_MIN_RUNS}` even with 0 hard failures: `source: 'retryRate'`, `retryMasked: true`, `count` = `retryCount`, `runIds` = best-available run ids for that test (empty array if none).
 - Constants (~L40): add `const RETRY_RATE_THRESHOLD = 0.5`, `const RETRY_MIN_RUNS = 4`; interpolate both into the prompt strings (Phase 1 cluster + Phase 2 filter).
 
 commit: `feat(flakiness): cluster on retryRate threshold - W-23128001`
@@ -32,10 +32,10 @@ commit: `feat(flakiness): cluster on retryRate threshold - W-23128001`
 
 `.claude/workflows/flakiness-review.js`
 
-Resolution is agent-driven (the `resolvedResult` agent at L373–399 emits `activeClusterIndices`); there is no deterministic resolve code to amend. The fix is entirely in the prompt string + adding metrics data.
+Resolution agent-driven (`resolvedResult` L373–399 emits `activeClusterIndices`); no deterministic code to amend. Fix via prompt string + metrics data.
 
-- Filter agent (L373–399): testMetrics is NOT currently passed (only clusters L377 + runs L380). Add a new `## Per-test retry metrics` section embedding `${JSON.stringify(metricsData.testMetrics, null, 2)}`.
-- The criteria at L384–386 are inside the template-literal prompt string (not executable code). Edit that string:
+- Filter agent (L373–399): testMetrics not passed (only clusters L377 + runs L380). Add a new `## Per-test retry metrics` section embedding `${JSON.stringify(metricsData.testMetrics, null, 2)}`.
+- Criteria L384–386 in prompt string (not code). Edit that string:
   - Add a new override rule before the BOTH-conditions block: "A cluster is NOT resolved if testMetrics for its `testName` shows `retryRate >= ${RETRY_RATE_THRESHOLD}` over `totalRuns >= ${RETRY_MIN_RUNS}`, even if recent runs show conclusion==success — run-level green masks per-test retry flake. Such clusters are always active."
   - Tighten condition 2 (L386): recent-window runs must be `conclusion==success` AND `attempt==1` AND the cluster's test shows no per-test retries in testMetrics.
 
@@ -45,16 +45,16 @@ commit: `fix(flakiness): high-retry green run not marked resolved - W-23128001`
 
 `.claude/workflows/flakiness-review.js`
 
-- Place normalization BETWEEN the agent call (returns at L663) and the early-return guard (L665–667) — the guard `if (!wiDraftsResult || !wiDraftsResult.drafts.length) return` halts execution, so code after it never runs on the bail path; code after it on the happy path is fine too, but the guard short-circuits on empty. Insert immediately after L663:
+- Place normalization between agent call (L663) and guard (L665–667) — guard halts on empty. Insert immediately after L663:
   ```js
   if (wiDraftsResult && wiDraftsResult.drafts) {
     wiDraftsResult.drafts = wiDraftsResult.drafts.map(d => ({
       ...d,
-      subject: /^\[ai-auto\]/i.test(d.subject.trimStart()) ? d.subject : `[ai-auto] ${d.subject.trimStart()}`,
+      subject: /^\[ai-auto\]/i.test((d.subject ?? '').trimStart()) ? d.subject : `[ai-auto] ${(d.subject ?? '').trimStart()}`,
     }))
   }
   ```
-  Reassigning `wiDraftsResult.drafts` makes downstream uses (report L708, return L784) consume normalized subjects automatically.
+  Reassigning `wiDraftsResult.drafts` updates downstream uses (L708, L784).
 - Keep Draft prompt instruction at L650 (belt+suspenders).
 
 commit: `fix(flakiness): deterministically enforce [ai-auto] subject prefix - W-23128001`

--- a/.claude/plans/W-23128001.md
+++ b/.claude/plans/W-23128001.md
@@ -1,0 +1,78 @@
+# W-23128001 — flakiness-review: cluster+filter on retryRate, enforce [ai-auto]
+
+## Context
+
+`.claude/workflows/flakiness-review.js`. 2 bugs:
+
+1. **Retry-masked flake slips through.** Cluster stage groups only hard run-level failures; filter marks cluster resolved off 1 green run. Ignores `testMetrics.retryRate` already collected (Phase 2). Evidence 2026-06-22: LWC rename (86% retry), Aura rename (67%), LWC LSP hover (67%), Apex Test Suite (57%) all marked resolved — 1 green run, no hard fail.
+2. **[ai-auto] tag soft.** Only prompt instruction in Draft phase; drafts can omit → can't opt into auto-build-wi.
+
+DoD:
+- retryRate feeds cluster + filter stages.
+- High-retry green run NOT resolved.
+- retryRate >=0.5 over N>=4 runs = own cluster source.
+- Every draft subject deterministically gets `[ai-auto]` prefix (code, not prompt).
+
+## Phases
+
+### Phase 1 — retryRate into cluster stage + threshold source
+
+`.claude/workflows/flakiness-review.js`
+
+- `CLUSTERS_SCHEMA` (L69–88): add `retryRate` (number) + `source` (string `failure`|`retryRate`) to `properties`. Add BOTH to `required` (L77) so agent cannot silently omit: `required: ['testName', 'errorPattern', 'runIds', 'count', 'retryMasked', 'source', 'retryRate']`. Keep `retryMasked`.
+- Cluster agent (L321–344): `metricsData` is computed at L310 (before the cluster call), so pass `metricsData.testMetrics` JSON into the prompt the same way the filter agent embeds data (L377/L380 pattern: `${JSON.stringify(metricsData.testMetrics, null, 2)}` under a `## Per-test retry metrics` heading). The join is done BY THE CLUSTER AGENT, not post-processing code — there is no deterministic code step here. Add prompt instructions:
+  - For every cluster emitted, set `retryRate` by looking up the cluster's `testName` in the provided testMetrics array (match on `testName`); if absent, `retryRate: 0`.
+  - Always set `source`: `'failure'` for run-level-failure clusters, `'retryRate'` for retry-threshold clusters.
+  - Also emit a cluster for any testMetrics entry with `retryRate >= ${RETRY_RATE_THRESHOLD} AND totalRuns >= ${RETRY_MIN_RUNS}` even with 0 hard failures: `source: 'retryRate'`, `retryMasked: true`, `count` = `retryCount`, `runIds` = best-available run ids for that test (empty array if none).
+- Constants (~L40): add `const RETRY_RATE_THRESHOLD = 0.5`, `const RETRY_MIN_RUNS = 4`; interpolate both into the prompt strings (Phase 1 cluster + Phase 2 filter).
+
+commit: `feat(flakiness): cluster on retryRate threshold - W-23128001`
+
+### Phase 2 — filter stage respects retries
+
+`.claude/workflows/flakiness-review.js`
+
+Resolution is agent-driven (the `resolvedResult` agent at L373–399 emits `activeClusterIndices`); there is no deterministic resolve code to amend. The fix is entirely in the prompt string + adding metrics data.
+
+- Filter agent (L373–399): testMetrics is NOT currently passed (only clusters L377 + runs L380). Add a new `## Per-test retry metrics` section embedding `${JSON.stringify(metricsData.testMetrics, null, 2)}`.
+- The criteria at L384–386 are inside the template-literal prompt string (not executable code). Edit that string:
+  - Add a new override rule before the BOTH-conditions block: "A cluster is NOT resolved if testMetrics for its `testName` shows `retryRate >= ${RETRY_RATE_THRESHOLD}` over `totalRuns >= ${RETRY_MIN_RUNS}`, even if recent runs show conclusion==success — run-level green masks per-test retry flake. Such clusters are always active."
+  - Tighten condition 2 (L386): recent-window runs must be `conclusion==success` AND `attempt==1` AND the cluster's test shows no per-test retries in testMetrics.
+
+commit: `fix(flakiness): high-retry green run not marked resolved - W-23128001`
+
+### Phase 3 — enforce [ai-auto] tag deterministically
+
+`.claude/workflows/flakiness-review.js`
+
+- Place normalization BETWEEN the agent call (returns at L663) and the early-return guard (L665–667) — the guard `if (!wiDraftsResult || !wiDraftsResult.drafts.length) return` halts execution, so code after it never runs on the bail path; code after it on the happy path is fine too, but the guard short-circuits on empty. Insert immediately after L663:
+  ```js
+  if (wiDraftsResult && wiDraftsResult.drafts) {
+    wiDraftsResult.drafts = wiDraftsResult.drafts.map(d => ({
+      ...d,
+      subject: /^\[ai-auto\]/i.test(d.subject.trimStart()) ? d.subject : `[ai-auto] ${d.subject.trimStart()}`,
+    }))
+  }
+  ```
+  Reassigning `wiDraftsResult.drafts` makes downstream uses (report L708, return L784) consume normalized subjects automatically.
+- Keep Draft prompt instruction at L650 (belt+suspenders).
+
+commit: `fix(flakiness): deterministically enforce [ai-auto] subject prefix - W-23128001`
+
+## Skills to apply
+
+- concise — plan + any md edits
+- typescript
+- verification — final check
+
+## Verification
+
+- No e2e harness on this branch for the workflow JS — manual/static only.
+- `node --check .claude/workflows/flakiness-review.js` parses.
+- Read-back:
+  - `CLUSTERS_SCHEMA.required` includes `source` AND `retryRate` (L77); `properties` has both.
+  - Cluster prompt (Phase 1) embeds `metricsData.testMetrics` JSON and instructs join-by-testName; references `RETRY_RATE_THRESHOLD`/`RETRY_MIN_RUNS`.
+  - Filter prompt (Phase 2) embeds `metricsData.testMetrics` JSON and has the high-retry-not-resolved override rule.
+  - Normalize block sits after L663 agent call and BEFORE the L665 guard; reassigns `wiDraftsResult.drafts`.
+- Logic spot-check: subject `e2e: foo` → `[ai-auto] e2e: foo`; `[ai-auto] e2e: foo` unchanged; ` e2e: foo` (leading space) → `[ai-auto] e2e: foo`.
+- No eslint-disable added (auto-memory rule).

--- a/.claude/workflows/flakiness-review.js
+++ b/.claude/workflows/flakiness-review.js
@@ -405,7 +405,7 @@ A cluster is trending-resolved if BOTH:
 1. Its most recent failure (latest runId) is from the first half of the lookback window (older than ${Math.floor(DAYS / 2)} days ago), AND
 2. The workflow runs in the second half of the window all show conclusion=="success" AND attempt==1 (no reruns) AND the cluster's test shows no per-test retries in testMetrics
 
-Also treat as resolved if the failure pattern is clearly tied to a known-fixed external cause:
+Also treat as resolved if the failure pattern is clearly tied to a known-fixed external cause (the high-retry rule above still takes precedence — a cluster meeting it is NEVER resolved even if these conditions match):
 - Playwright version bumps (test failures mentioning "locator" or "element" API changes that then disappear)
 - VS Code version bumps (failures mentioning chromium, vscode api, extension activation that then disappear)
 - Any cluster whose runIds are all older than 2 days and haven't recurred
@@ -446,6 +446,12 @@ const [artifactFindings, priorWisResult] = await parallel([
     topClusters,
     async (cluster, _orig, i) => {
       const runId = cluster.runIds[0]
+      // retryRate-source clusters may have no run ids (no hard failure to attach
+      // artifacts to). Skip artifact download rather than interpolate `undefined`
+      // into the gh command and prompt.
+      if (!runId) {
+        return `No run ids for cluster "${cluster.testName}" (source: ${cluster.source}, retry-masked: ${cluster.retryMasked}) — no artifacts to download. Evidence is the per-test retry rate (${cluster.retryRate}); no run-level failure exists.`
+      }
       return agent(
         `Download and analyze CI artifacts for a flaky test cluster in ${REPO}.
 
@@ -687,7 +693,7 @@ Return the draft list.`,
 if (wiDraftsResult && wiDraftsResult.drafts) {
   wiDraftsResult.drafts = wiDraftsResult.drafts.map(d => ({
     ...d,
-    subject: /^\[ai-auto\]/i.test(d.subject.trimStart()) ? d.subject : `[ai-auto] ${d.subject.trimStart()}`,
+    subject: /^\[ai-auto\]/i.test((d.subject ?? '').trimStart()) ? d.subject : `[ai-auto] ${(d.subject ?? '').trimStart()}`,
   }))
 }
 

--- a/.claude/workflows/flakiness-review.js
+++ b/.claude/workflows/flakiness-review.js
@@ -394,11 +394,16 @@ ${JSON.stringify(clustersResult.clusters, null, 2)}
 ## All runs (with dates and conclusions)
 ${JSON.stringify(runsResult.runs, null, 2)}
 
+## Per-test retry metrics
+${JSON.stringify(metricsData.testMetrics, null, 2)}
+
 ## Lookback window: ${DAYS} days
+
+A cluster is NEVER resolved if testMetrics for its \`testName\` shows \`retryRate >= ${RETRY_RATE_THRESHOLD}\` over \`totalRuns >= ${RETRY_MIN_RUNS}\`, even if recent runs show conclusion=="success" — a run-level green result masks per-test retry flake. Such clusters are always active. Check this rule FIRST.
 
 A cluster is trending-resolved if BOTH:
 1. Its most recent failure (latest runId) is from the first half of the lookback window (older than ${Math.floor(DAYS / 2)} days ago), AND
-2. The workflow runs in the second half of the window all show conclusion=="success" and attempt==1 (no reruns)
+2. The workflow runs in the second half of the window all show conclusion=="success" AND attempt==1 (no reruns) AND the cluster's test shows no per-test retries in testMetrics
 
 Also treat as resolved if the failure pattern is clearly tied to a known-fixed external cause:
 - Playwright version bumps (test failures mentioning "locator" or "element" API changes that then disappear)

--- a/.claude/workflows/flakiness-review.js
+++ b/.claude/workflows/flakiness-review.js
@@ -40,6 +40,10 @@ const ARTIFACTS_ROOT = '.e2e-artifacts'
 const MAX_ARTIFACT_CLUSTERS = 5
 // Min failure appearances across runs to be worth investigating
 const MIN_FAILURE_COUNT = 2
+// Per-test retry rate at/above which a test is its own cluster (retry-masked flake)
+const RETRY_RATE_THRESHOLD = 0.5
+// Min runs a test needs before its retryRate is trusted
+const RETRY_MIN_RUNS = 4
 
 // =====================================================================
 // SCHEMAS
@@ -74,13 +78,15 @@ const CLUSTERS_SCHEMA = {
       type: 'array',
       items: {
         type: 'object',
-        required: ['testName', 'errorPattern', 'runIds', 'count', 'retryMasked'],
+        required: ['testName', 'errorPattern', 'runIds', 'count', 'retryMasked', 'source', 'retryRate'],
         properties: {
           testName: { type: 'string' },
           errorPattern: { type: 'string' },
           runIds: { type: 'array', items: { type: 'string' } },
           count: { type: 'number' },
           retryMasked: { type: 'boolean' },
+          source: { type: 'string', enum: ['failure', 'retryRate'] },
+          retryRate: { type: 'number' },
         },
       },
     },
@@ -339,6 +345,15 @@ find ${ARTIFACTS_ROOT}/develop/<run-id> -name "*.json" | xargs grep -l '"status"
 \`\`\`
 
 Group failures by: test name + error message pattern (first 120 chars of the error). A test that appears with the same error pattern across ${MIN_FAILURE_COUNT}+ runs is a cluster. Also flag any test that only passes after retries (retryMasked=true).
+
+## Per-test retry metrics
+${JSON.stringify(metricsData.testMetrics, null, 2)}
+
+For EVERY cluster you emit:
+- Set \`retryRate\` by looking up the cluster's \`testName\` in the testMetrics array above (match on \`testName\`); if absent, \`retryRate: 0\`.
+- Set \`source\`: \`'failure'\` for run-level-failure clusters, \`'retryRate'\` for retry-threshold clusters (below).
+
+Also emit a cluster for ANY testMetrics entry with \`retryRate >= ${RETRY_RATE_THRESHOLD}\` AND \`totalRuns >= ${RETRY_MIN_RUNS}\`, even with 0 hard failures — retries mask a green run-level result. For such clusters: \`source: 'retryRate'\`, \`retryMasked: true\`, \`count\` = that entry's \`retryCount\`, \`runIds\` = best-available run ids for the test (empty array if none), \`errorPattern\` = brief note that this is retry-masked flake.
 
 Sort clusters by count descending. Return top clusters.`,
   { label: 'cluster:failures', phase: 'Cluster failures', schema: CLUSTERS_SCHEMA }

--- a/.claude/workflows/flakiness-review.js
+++ b/.claude/workflows/flakiness-review.js
@@ -682,6 +682,15 @@ Return the draft list.`,
   { label: 'draft:wis', phase: 'Draft WIs', schema: WI_DRAFTS_SCHEMA }
 )
 
+// Deterministically enforce [ai-auto] prefix so drafts can opt into auto-build-wi
+// regardless of what the agent emitted. Reassigning .drafts updates report + return.
+if (wiDraftsResult && wiDraftsResult.drafts) {
+  wiDraftsResult.drafts = wiDraftsResult.drafts.map(d => ({
+    ...d,
+    subject: /^\[ai-auto\]/i.test(d.subject.trimStart()) ? d.subject : `[ai-auto] ${d.subject.trimStart()}`,
+  }))
+}
+
 if (!wiDraftsResult || !wiDraftsResult.drafts.length) {
   log('No WI drafts produced.')
   return { hypotheses: confirmedHypotheses, refuted: refutedSummary, wis: [] }


### PR DESCRIPTION
## Summary

- Cluster stage now creates clusters for tests with retryRate >= 0.5 over >= 4 runs, even with no hard failures
- Filter stage no longer marks high-retry tests as resolved when recent runs show success — per-test retries now prevent resolution
- Draft WI subjects deterministically get `[ai-auto]` prefix via code normalization, not prompt alone

## Plan

[.claude/plans/W-23128001.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23128001-flakiness-review-workflow-cluster-filter/.claude/plans/W-23128001.md)

## Reviewer notes

- **Low severity**: CLUSTERS_SCHEMA fields `source` and `retryRate` (.claude/workflows/flakiness-review.js:88-89) are required in the schema but never read by JS code (only consumed by LLM-prompt reasoning). This is intentional for an LLM workflow — the fields are agent-reasoning metadata, not dead weight. The finding's secondary 'DoD unmet' claim was verified false (the plan explicitly states the join is agent-driven, not deterministic). No edit needed.

## Test plan

- `node --check .claude/workflows/flakiness-review.js` parses
- Read-back verify:
  - `CLUSTERS_SCHEMA.required` includes `source` AND `retryRate` (L77); `properties` has both
  - Cluster prompt (Phase 1) embeds `metricsData.testMetrics` JSON and instructs join-by-testName; references `RETRY_RATE_THRESHOLD`/`RETRY_MIN_RUNS`
  - Filter prompt (Phase 2) embeds `metricsData.testMetrics` JSON and has the high-retry-not-resolved override rule
  - Normalize block sits after L663 agent call and BEFORE the L665 guard; reassigns `wiDraftsResult.drafts`
- Logic spot-check: subject `e2e: foo` → `[ai-auto] e2e: foo`; `[ai-auto] e2e: foo` unchanged; ` e2e: foo` (leading space) → `[ai-auto] e2e: foo`

### What issues does this PR fix or reference?

@W-23128001@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002coGJOYA2/view