### PR TITLE
docs(skills): add web-extension authoring skill - W-23129149

### DIFF
--- a/.claude/plans/W-23129149.md
+++ b/.claude/plans/W-23129149.md
@@ -5,7 +5,7 @@
 - New skill: how to author/web-enable a VS Code extension feature (VS Code for Web / Code Builder Web)
 - Problem: web guidance scattered across ~8 docs; no single router
 - Role: index/router — link existing docs, do NOT restate (per WI + concise skill)
-- Length target: `paths` skill (~18 lines body)
+- Length target: `paths` skill (~18 lines)
 - Out of scope: expand ADR 0013, lint rule for inline `process.env.ESBUILD_PLATFORM`
 
 ### Source docs (link, don't duplicate)
@@ -19,7 +19,7 @@
 - `.claude/skills/services-extension-consumption/references/fs-service.md` — `FsService` (desktop+web; web paths default `memfs://`)
 - `.claude/skills/packageJson/SKILL.md` — `browser` field
 - `.claude/skills/playwright-e2e/SKILL.md` — web testing, `test:web`
-- memfs fs model — inline in Testing section (3 lines, see Phase 1.7); do NOT link `web-e2e-memfs-fs-model` memory (lives in user-global `.claude/memory`, not the worktree — link would break)
+- memfs fs model — inline in Testing section (3 lines, Phase 1.7); do NOT link `web-e2e-memfs-fs-model` memory (lives in user-global `.claude/memory`, not the worktree — link would break)
 
 ### Web gaps + alternatives (table content)
 
@@ -39,7 +39,7 @@
 ### Phase 1 — add skill (single commit)
 
 - File: `.claude/skills/web-extension-authoring/SKILL.md`
-- Frontmatter: `name`, `description` (trigger on web-enabling a feature, browser field, ESBUILD_PLATFORM, web bundle, memfs, runs on web)
+- Frontmatter: `name`, `description` (trigger on web-enabling a feature, browser field, ESBUILD_PLATFORM, web bundle, memfs)
 - Body sections (tight, links only):
   1. Scope — web-enabling/authoring an extension feature
   2. Not on web → alternative (the 6-row table above)
@@ -63,6 +63,6 @@
 - not e2e-covered (docs-only skill; no e2e on branch)
 - frontmatter valid YAML; `name` matches dir `web-extension-authoring`
 - every linked path resolves from skill dir: ADR 0008/0009/0010/0012/0013, Build.md, paths/packageJson/playwright-e2e SKILL.md, fs-service.md, a `*deliberately-not-web.md`
-- NO link to `web-e2e-memfs-fs-model` memory (user-global, would break); memfs model inlined in Testing instead
+- NO link to `web-e2e-memfs-fs-model` memory (user-global, would break); inline in Testing
 - length ≤ ~1.5× paths skill body; no restated doc content (links only)
 - concise style: bullets/fragments, numerals, no full prose paragraphs

--- a/.claude/plans/W-23129149.md
+++ b/.claude/plans/W-23129149.md
@@ -1,0 +1,68 @@
+# W-23129149 — web-extension authoring skill
+
+## Context
+
+- New skill: how to author/web-enable a VS Code extension feature (VS Code for Web / Code Builder Web)
+- Problem: web guidance scattered across ~8 docs; no single router
+- Role: index/router — link existing docs, do NOT restate (per WI + concise skill)
+- Length target: `paths` skill (~18 lines body)
+- Out of scope: expand ADR 0013, lint rule for inline `process.env.ESBUILD_PLATFORM`
+
+### Source docs (link, don't duplicate)
+
+- `docs/adr/0009-reduce-cli-deps-web-no-cli.md` — web must avoid CLI; `terminalService` fails on web
+- `docs/adr/0010-web-support-libs-in-process.md` — mechanism: libs in-process, memfs+IndexedDB via `workspace.fs`; per-extension web status list
+- `docs/adr/0008-services-sole-host-heavy-deps.md` — services hosts heavy deps; others route through API
+- `docs/adr/0013-dual-target-bundle-time-split.md` — `ESBUILD_PLATFORM` two-bundle tree-shake
+- `docs/Build.md` — `ESBUILD_PLATFORM` define mechanics, `browser` entry `dist/web/index.js`, web bundling (no externals but `vscode`), polyfills, `onFileSystem:memfs` activation, run:web, asset manifest
+- `.claude/skills/paths/SKILL.md` — vscode-uri over node:path (memfs)
+- `.claude/skills/services-extension-consumption/references/fs-service.md` — `FsService` (desktop+web; web paths default `memfs://`)
+- `.claude/skills/packageJson/SKILL.md` — `browser` field
+- `.claude/skills/playwright-e2e/SKILL.md` — web testing, `test:web`
+- memfs fs model — inline in Testing section (3 lines, see Phase 1.7); do NOT link `web-e2e-memfs-fs-model` memory (lives in user-global `.claude/memory`, not the worktree — link would break)
+
+### Web gaps + alternatives (table content)
+
+- `child_process` / `terminalService` → in-process libs (ADR 0009/0010)
+- native `fs` → `FsService` / virtual fs provider (memfs)
+- the CLI → services API (Connection from injected auth)
+- `workspace.findFiles` glob → traverse `FsService.readDirectoryWithTypes` / SDR ComponentSetService
+- `node:path` → vscode-uri `Utils` (paths skill)
+- appInsights v2 → otel spans (ADR 0012)
+
+### Existing opt-out ADR pattern
+
+- `packages/*/docs/adr/*deliberately-not-web.md` (org 0002, apex 0001, apex-oas 0001)
+
+## Phases
+
+### Phase 1 — add skill (single commit)
+
+- File: `.claude/skills/web-extension-authoring/SKILL.md`
+- Frontmatter: `name`, `description` (trigger on web-enabling a feature, browser field, ESBUILD_PLATFORM, web bundle, memfs, runs on web)
+- Body sections (tight, links only):
+  1. Scope — web-enabling/authoring an extension feature
+  2. Not on web → alternative (the 6-row table above)
+  3. Bundle split — link ADR 0013 + Build.md `ESBUILD_PLATFORM`; note inline-literal `process.env.ESBUILD_PLATFORM` requirement (don't assign to const/prop)
+  4. package.json — `browser`=`dist/web/index.js`, `onFileSystem:memfs` activation; link Build.md + packageJson skill
+  5. Paths — vscode-uri/memfs; link paths skill
+  6. Per-package opt-out — `docs/adr/*deliberately-not-web.md`; link org 0002 example
+  7. Testing — link playwright-e2e skill; inline memfs model (~3 lines): web Playwright runs in `memfs:/` workspace (scheme `memfs`), NOT a `vscode-test-web` mount; `FsProvider.writeFile` hits the same `@salesforce/core/fs` polyfill `SfProject.resolve` reads, so editor writes reach the SfProject fs; `.headless.spec.ts` runs both web+desktop, reserve Node fs/path for `.desktop.spec.ts`
+- commitMessage (title + body):
+  - title: `docs(skills): add web-extension authoring skill - W-23129149`
+  - body: `Consolidates scattered web-authoring guidance (Build.md, ADRs 0008/0009/0010/0013, paths/services/packageJson skills) into single router. Devs web-enabling features now have one entry point instead of hunting ~8 docs.`
+
+## Skills to apply
+
+- concise — fragments, numerals, no repetition, links not restatement
+- packageJson, paths, playwright-e2e — cross-link targets (verify their relative paths resolve)
+- typescript
+
+## Verification
+
+- not e2e-covered (docs-only skill; no e2e on branch)
+- frontmatter valid YAML; `name` matches dir `web-extension-authoring`
+- every linked path resolves from skill dir: ADR 0008/0009/0010/0012/0013, Build.md, paths/packageJson/playwright-e2e SKILL.md, fs-service.md, a `*deliberately-not-web.md`
+- NO link to `web-e2e-memfs-fs-model` memory (user-global, would break); memfs model inlined in Testing instead
+- length ≤ ~1.5× paths skill body; no restated doc content (links only)
+- concise style: bullets/fragments, numerals, no full prose paragraphs

--- a/.claude/skills/web-extension-authoring/SKILL.md
+++ b/.claude/skills/web-extension-authoring/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: web-extension-authoring
+description: Author/web-enable a VS Code extension feature (VS Code for Web / Code Builder). Use when adding a browser field, splitting a dual-target web bundle, gating on ESBUILD_PLATFORM, using memfs/workspace.fs, or making a feature run on web.
+---
+
+# Web extension authoring
+
+Scope: web-enabling/authoring an extension feature (browser host, no Node, no CLI). Router only — follow links.
+
+## Not on web → alternative
+
+| Not on web | Use |
+| --- | --- |
+| `child_process` / `terminalService` | in-process libs ([ADR 0009](../../../docs/adr/0009-reduce-cli-deps-web-no-cli.md), [ADR 0010](../../../docs/adr/0010-web-support-libs-in-process.md)) |
+| native `fs` | `FsService` / memfs provider ([fs-service](../services-extension-consumption/references/fs-service.md)) |
+| the CLI | services API (Connection from injected auth, [ADR 0008](../../../docs/adr/0008-services-sole-host-heavy-deps.md)) |
+| `workspace.findFiles` glob | `FsService.readDirectoryWithTypes` traverse / SDR ComponentSetService |
+| `node:path` | vscode-uri `Utils` ([paths](../paths/SKILL.md)) |
+| appInsights v2 | otel spans ([ADR 0012](../../../docs/adr/0012-spans-only-observability.md)) |
+
+## Bundle split
+
+- Two-bundle tree-shake on `ESBUILD_PLATFORM`: [ADR 0013](../../../docs/adr/0013-dual-target-bundle-time-split.md), [Build.md](../../../docs/Build.md)
+- Use inline literal `process.env.ESBUILD_PLATFORM` at the branch — never assign to const/prop (breaks dead-branch elimination)
+
+## package.json
+
+- `browser`=`dist/web/index.js` (web host entry); `onFileSystem:memfs` activation (`workspaceContains` doesn't fire for memfs)
+- [Build.md](../../../docs/Build.md), [packageJson](../packageJson/SKILL.md)
+
+## Paths
+
+- vscode-uri `Utils`, memfs scheme — [paths](../paths/SKILL.md)
+
+## Per-package opt-out
+
+- Deliberate desktop-only: add `docs/adr/*deliberately-not-web.md` ([org 0002 example](../../../packages/salesforcedx-vscode-org/docs/adr/0002-deliberately-not-web.md))
+
+## Testing
+
+- [playwright-e2e](../playwright-e2e/SKILL.md), `test:web`
+- Web Playwright runs in a `memfs:/` workspace (scheme `memfs`), NOT a `vscode-test-web` mount
+- `FsProvider.writeFile` hits the same `@salesforce/core/fs` polyfill `SfProject.resolve` reads — editor writes reach the SfProject fs
+- `.headless.spec.ts` runs web+desktop; reserve Node fs/path for `.desktop.spec.ts`

--- a/.claude/skills/web-extension-authoring/SKILL.md
+++ b/.claude/skills/web-extension-authoring/SKILL.md
@@ -21,7 +21,7 @@ Scope: web-enabling/authoring an extension feature (browser host, no Node, no CL
 ## Bundle split
 
 - Two-bundle tree-shake on `ESBUILD_PLATFORM`: [ADR 0013](../../../docs/adr/0013-dual-target-bundle-time-split.md), [Build.md](../../../docs/Build.md)
-- Use inline literal `process.env.ESBUILD_PLATFORM` at the branch — never assign to const/prop (breaks dead-branch elimination)
+- Use inline literal `process.env.ESBUILD_PLATFORM` — never assign to const/prop (breaks dead-branch elimination)
 
 ## package.json
 
@@ -39,6 +39,6 @@ Scope: web-enabling/authoring an extension feature (browser host, no Node, no CL
 ## Testing
 
 - [playwright-e2e](../playwright-e2e/SKILL.md), `test:web`
-- Web Playwright runs in a `memfs:/` workspace (scheme `memfs`), NOT a `vscode-test-web` mount
+- Web Playwright runs in a `memfs:/dx-project` workspace (scheme `memfs`), NOT a `vscode-test-web` mount
 - `FsProvider.writeFile` hits the same `@salesforce/core/fs` polyfill `SfProject.resolve` reads — editor writes reach the SfProject fs
 - `.headless.spec.ts` runs web+desktop; reserve Node fs/path for `.desktop.spec.ts`


### PR DESCRIPTION
## Summary

- Consolidates web-authoring guidance (Build.md, ADRs 0008/0009/0010/0013, paths/services/packageJson skills) into single router
- Devs web-enabling features now have one entry point instead of hunting ~8 docs
- Covers web gaps + alternatives, bundle split, package.json browser field, memfs paths, opt-out ADRs, testing

## Plan

[.claude/plans/W-23129149.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23129149-add-web-extension-authoring-skill/.claude/plans/W-23129149.md)

## What issues does this PR fix or reference?

@W-23129149@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cpSwmYAE/view