### PR TITLE
chore(eslint): enable unicorn/prefer-boolean-return - W-23094887

### DIFF
--- a/.claude/plans/W-23094887.md
+++ b/.claude/plans/W-23094887.md
@@ -1,0 +1,38 @@
+# W-23094887 — Enable unicorn/prefer-boolean-return
+
+## Context
+- Enable `unicorn/prefer-boolean-return`: return boolean expr directly vs if/return-true + return-false.
+- Rule fixable: `code`. Won't autofix when comments inside or test not provably boolean (wraps in `Boolean()`).
+- Depends: W-23094607 merged (orchestrator-sequenced; code here independent).
+- Add rule to `eslint.config.mjs` main `**/*.ts` block, near other `unicorn/*` (after `unicorn/prefer-at`).
+- Prior pattern: single `chore(eslint): enable unicorn/<rule>` commit (see 38cbba745).
+
+## Scope (verified via lint)
+8 violations, 7 files. 7 autofix, 1 manual.
+- autofix: `salesforcedx-apex-debugger/src/adapter/apexDebug.ts:989`, `.../core/streamingService.ts:51,95`, `salesforcedx-apex-replay-debugger/src/states/frameStateUtil.ts:98`, `salesforcedx-lightning-lsp-common/src/types/packageJson.ts:36`, `salesforcedx-vscode-apex-replay-debugger/src/breakpoints/checkpointService.ts:663`, `salesforcedx-vscode-metadata/src/services/deployOnSaveService.ts:48`
+- manual: `salesforcedx-aura-language-server/src/tern-server/stringUtil.ts:16` — `isAlphaNumberic`; 3 consecutive `if(...) return true` w/ inline comments (`// numeric`, `// alpha`, `// _ and -`), trailing `return false`. Rule skips (comment loss). Collapse to single boolean OR expr; keep comments.
+
+## Phases
+
+### Phase 1 — enable rule + fix violations
+- Add `'unicorn/prefer-boolean-return': 'error'` after line `'unicorn/prefer-at': 'error',` in `eslint.config.mjs`.
+- Build local rules first (config imports `packages/eslint-local-rules/out/index.js`): `npx tsc --pretty` in that pkg, else eslint fails ERR_MODULE_NOT_FOUND.
+- Autofix 7: `eslint <files> --fix --rule '{"unicorn/prefer-boolean-return":"error"}'` (scope `--rule` so only this rule's fixes land).
+- Manual fix `stringUtil.ts` `isAlphaNumberic`: `return (code > 47 && code < 58) || (code > 64 && code < 91) || (code > 96 && code < 123) || code === 95 || code === 45;` — preserve comments as inline/trailing.
+- deployOnSaveService.ts is Effect file; autofix `if(!x.endsWith('.apex')) return false; return true` → `return !basename.endsWith('.apex')`; preceding guards unaffected. Confirm `functional/*` still clean.
+- commit: `chore(eslint): enable unicorn/prefer-boolean-return - W-23094887`
+- files: `eslint.config.mjs`, 7 source files above
+
+## Skills
+- concise (plan/docs style)
+- verification (lint/compile gates)
+- typescript (manual rewrite correctness)
+- changelog (lint-only chore; confirm if entry needed — prior unicorn enables had none)
+
+## Verification
+- `eslint.config.mjs` change does NOT need e2e; no runtime behavior change (pure lint refactor).
+- `npx eslint 'packages/**/*.ts'` (NODE_OPTIONS max-old-space 8192+) → 0 `prefer-boolean-return`.
+- Compile affected pkgs (tsc/wireit) — green.
+- Spot-check `stringUtil.ts` rewrite preserves comments + truth table (numeric/alpha/`_`/`-`).
+- Unit tests for touched pkgs (apex-debugger, apex-replay-debugger, metadata, lightning-lsp-common) — green.
+- Playwright (required: touched `salesforcedx-vscode-metadata/src/services/deployOnSaveService.ts`, in verification skill's e2e package list): `npm run test:desktop -w salesforcedx-vscode-metadata -- --retries 0 packages/salesforcedx-vscode-metadata/test/playwright/specs/deployOnSave.headless.spec.ts` — confirm deploy-on-save logic preserved (the `shouldDeployOnSave` boolean refactor must not change which files trigger deploy).

--- a/.claude/plans/W-23094887.md
+++ b/.claude/plans/W-23094887.md
@@ -2,13 +2,13 @@
 
 ## Context
 - Enable `unicorn/prefer-boolean-return`: return boolean expr directly vs if/return-true + return-false.
-- Rule fixable: `code`. Won't autofix when comments inside or test not provably boolean (wraps in `Boolean()`).
-- Depends: W-23094607 merged (orchestrator-sequenced; code here independent).
-- Add rule to `eslint.config.mjs` main `**/*.ts` block, near other `unicorn/*` (after `unicorn/prefer-at`).
-- Prior pattern: single `chore(eslint): enable unicorn/<rule>` commit (see 38cbba745).
+- Rule fixable: `code`. Skips when comments inside or test not provably boolean (wraps in `Boolean()`).
+- Depends: W-23094607 merged (orchestrator-sequenced; code independent).
+- Add to `eslint.config.mjs` `**/*.ts` block after `unicorn/prefer-at`.
+- Prior pattern: single `chore(eslint): enable unicorn/<rule>` commit (38cbba745).
 
 ## Scope (verified via lint)
-8 violations, 7 files. 7 autofix, 1 manual.
+8 violations, 7 files: 7 autofix, 1 manual.
 - autofix: `salesforcedx-apex-debugger/src/adapter/apexDebug.ts:989`, `.../core/streamingService.ts:51,95`, `salesforcedx-apex-replay-debugger/src/states/frameStateUtil.ts:98`, `salesforcedx-lightning-lsp-common/src/types/packageJson.ts:36`, `salesforcedx-vscode-apex-replay-debugger/src/breakpoints/checkpointService.ts:663`, `salesforcedx-vscode-metadata/src/services/deployOnSaveService.ts:48`
 - manual: `salesforcedx-aura-language-server/src/tern-server/stringUtil.ts:16` — `isAlphaNumberic`; 3 consecutive `if(...) return true` w/ inline comments (`// numeric`, `// alpha`, `// _ and -`), trailing `return false`. Rule skips (comment loss). Collapse to single boolean OR expr; keep comments.
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -186,6 +186,7 @@ export default [
       'unicorn/no-useless-switch-case': 'error',
       'unicorn/numeric-separators-style': 'error',
       'unicorn/prefer-at': 'error',
+      'unicorn/prefer-boolean-return': 'error',
       'unicorn/prefer-array-find': 'error',
       'unicorn/prefer-array-flat': 'error',
       'unicorn/prefer-array-flat-map': 'error',

--- a/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
+++ b/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
@@ -986,10 +986,7 @@ export class ApexDebug extends LoggingDebugSession {
   }
 
   private hasStackFrames(response: DebuggerResponse): boolean {
-    if (response.stateResponse?.state?.stack?.stackFrame?.length > 0) {
-      return true;
-    }
-    return false;
+    return response.stateResponse?.state?.stack?.stackFrame?.length > 0;
   }
 
   protected async customRequest(command: string, response: DebugProtocol.Response, args: any): Promise<void> {

--- a/packages/salesforcedx-apex-debugger/src/core/streamingService.ts
+++ b/packages/salesforcedx-apex-debugger/src/core/streamingService.ts
@@ -48,10 +48,7 @@ export class StreamingService {
 
   public hasProcessedEvent(type: ApexDebuggerEventType, replayId: number): boolean {
     const client = this.getClient(type);
-    if (client && replayId > client.getReplayId()) {
-      return false;
-    }
-    return true;
+    return !(client && replayId > client.getReplayId());
   }
 
   public markEventProcessed(type: ApexDebuggerEventType, replayId: number): void {
@@ -92,9 +89,6 @@ export class StreamingService {
   }
 
   public isReady(): boolean {
-    if (this.systemEventClient?.isConnected() && this.userEventClient?.isConnected()) {
-      return true;
-    }
-    return false;
+    return Boolean(this.systemEventClient?.isConnected() && this.userEventClient?.isConnected());
   }
 }

--- a/packages/salesforcedx-apex-replay-debugger/src/states/frameStateUtil.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/states/frameStateUtil.ts
@@ -95,6 +95,6 @@ export class FrameStateUtil {
   public static isExtraneousVFGetterOrSetterLogLine(logLine: string): boolean {
     const getMatch = ' get\\((.*)\\)';
     const setMatch = ' set\\((.*)\\)';
-    return !(logLine.match(getMatch) == null && logLine.match(setMatch) == null);
+    return logLine.match(getMatch) !== null || logLine.match(setMatch) !== null;
   }
 }

--- a/packages/salesforcedx-apex-replay-debugger/src/states/frameStateUtil.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/states/frameStateUtil.ts
@@ -95,9 +95,6 @@ export class FrameStateUtil {
   public static isExtraneousVFGetterOrSetterLogLine(logLine: string): boolean {
     const getMatch = ' get\\((.*)\\)';
     const setMatch = ' set\\((.*)\\)';
-    if (logLine.match(getMatch) == null && logLine.match(setMatch) == null) {
-      return false;
-    }
-    return true;
+    return !(logLine.match(getMatch) == null && logLine.match(setMatch) == null);
   }
 }

--- a/packages/salesforcedx-aura-language-server/src/tern-server/stringUtil.ts
+++ b/packages/salesforcedx-aura-language-server/src/tern-server/stringUtil.ts
@@ -4,21 +4,12 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-const isAlphaNumberic = (code: number): boolean => {
-    if (code > 47 && code < 58) {
-        // numeric
-        return true;
-    }
-    if ((code > 64 && code < 91) || (code > 96 && code < 123)) {
-        // alpha
-        return true;
-    }
-    if (code === 95 || code === 45) {
-        // _ and -
-        return true;
-    }
-    return false;
-};
+const isAlphaNumberic = (code: number): boolean =>
+    (code > 47 && code < 58) || // numeric
+    (code > 64 && code < 91) || // alpha
+    (code > 96 && code < 123) ||
+    code === 95 || // _ and -
+    code === 45;
 
 export const findWord = (str: string, offset: number): { start: number; end: number } | undefined => {
     let start = -1;

--- a/packages/salesforcedx-lightning-lsp-common/src/types/packageJson.ts
+++ b/packages/salesforcedx-lightning-lsp-common/src/types/packageJson.ts
@@ -33,5 +33,5 @@ export const isPackageJson = (value: unknown): value is PackageJson => {
   if ('dependencies' in value && !isStringRecord(value.dependencies)) {
     return false;
   }
-  return !('devDependencies' in value && !isStringRecord(value.devDependencies));
+  return !('devDependencies' in value) || isStringRecord(value.devDependencies);
 };

--- a/packages/salesforcedx-lightning-lsp-common/src/types/packageJson.ts
+++ b/packages/salesforcedx-lightning-lsp-common/src/types/packageJson.ts
@@ -33,8 +33,5 @@ export const isPackageJson = (value: unknown): value is PackageJson => {
   if ('dependencies' in value && !isStringRecord(value.dependencies)) {
     return false;
   }
-  if ('devDependencies' in value && !isStringRecord(value.devDependencies)) {
-    return false;
-  }
-  return true;
+  return !('devDependencies' in value && !isStringRecord(value.devDependencies));
 };

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/breakpoints/checkpointService.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/breakpoints/checkpointService.ts
@@ -660,10 +660,7 @@ export const sfCreateCheckpoints = async (): Promise<boolean> => {
     });
     creatingCheckpoints = false;
   }
-  if (updateError) {
-    return false;
-  }
-  return true;
+  return !updateError;
 };
 
 // A couple of important notes about this command's processing

--- a/packages/salesforcedx-vscode-metadata/src/services/deployOnSaveService.ts
+++ b/packages/salesforcedx-vscode-metadata/src/services/deployOnSaveService.ts
@@ -45,9 +45,7 @@ export const shouldDeploy = Effect.fn('deployOnSave:shouldDeploy')(function* (ur
   if (basename.endsWith('.soql')) return false;
 
   // Exclude anonymous apex files
-  if (basename.endsWith('.apex')) return false;
-
-  return true;
+  return !basename.endsWith('.apex');
 });
 
 /** Deploy queued files using MetadataDeployService */


### PR DESCRIPTION
## Summary
- Enable `unicorn/prefer-boolean-return` rule: return boolean expressions directly instead of if/return-true + return-false pattern
- Fix 8 violations across 7 files (7 autofix, 1 manual refactor preserving inline comments)
- Lint-only change; no runtime behavior affected

## Plan
[.claude/plans/W-23094887.md](.claude/plans/W-23094887.md)

## Test plan
- Run `npm run test:desktop -w salesforcedx-vscode-metadata -- --retries 0 packages/salesforcedx-vscode-metadata/test/playwright/specs/deployOnSave.headless.spec.ts` to confirm deploy-on-save logic preserved (the `shouldDeployOnSave` boolean refactor must not change which files trigger deploy)
- Spot-check `stringUtil.ts` `isAlphaNumberic` rewrite preserves comments and truth table (numeric/alpha/`_`/`-`)

### What issues does this PR fix or reference?
@W-23094887@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cerrpYAA/view