### PR TITLE
refactor(metadata): gen->fn generateManifest helpers - W-23125833

### DIFF
--- a/.claude/plans/W-23125833.md
+++ b/.claude/plans/W-23125833.md
@@ -1,0 +1,44 @@
+# W-23125833 — gen→fn: metadata generateManifest (2 sites)
+
+## Context
+
+`packages/salesforcedx-vscode-metadata/src/commands/generateManifest.ts` — 2 arrow-wrapper `=> Effect.gen` helpers. Convert to `Effect.fn("name")`, params in generator.
+
+- `:40 generateManifestFromUris(uris: URI[])`
+- `:48 saveManifestFile(workspacePath, fileName, packageXML)`
+
+`generateManifestCommand` (:67) already uses `Effect.fn` — target pattern. Triggers `effectFnOpportunity` LS diagnostic.
+
+## Phases
+
+### 1. Convert both helpers to Effect.fn
+
+`generateManifestFromUris`:
+```ts
+const generateManifestFromUris = Effect.fn('generateManifestFromUris')(function* (uris: URI[]) {
+```
+
+`saveManifestFile`:
+```ts
+const saveManifestFile = Effect.fn('saveManifestFile')(function* (
+  workspacePath: URI,
+  fileName: string,
+  packageXML: string
+) {
+```
+
+Drop arrow wrapper + `=> Effect.gen(function* () {`; move params into generator. Call sites (:96, :101) unchanged — signatures identical.
+
+Commit: `refactor(metadata): gen->fn generateManifest helpers - W-23125833`
+
+## Skills
+
+- effect-best-practices (gen→fn, span-name rule)
+- concise
+
+## Verification
+
+- `npx effect-language-service diagnostics --project tsconfig.json` (metadata pkg) — no `effectFnOpportunity` for these 2
+- `npx tsc --noEmit` / build
+- eslint (`local/require-effect-fn-span-name`, `local/no-effect-fn-wrapper`)
+- behavior: e2e-covered (command exercised by metadata e2e)

--- a/.claude/plans/W-23125833.md
+++ b/.claude/plans/W-23125833.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-`packages/salesforcedx-vscode-metadata/src/commands/generateManifest.ts` — 2 arrow-wrapper `=> Effect.gen` helpers. Convert to `Effect.fn("name")`, params in generator.
+`packages/salesforcedx-vscode-metadata/src/commands/generateManifest.ts` — 2 arrow-wrapper `=> Effect.gen` helpers → convert to `Effect.fn("name")`, params in generator
 
 - `:40 generateManifestFromUris(uris: URI[])`
 - `:48 saveManifestFile(workspacePath, fileName, packageXML)`
@@ -27,7 +27,7 @@ const saveManifestFile = Effect.fn('saveManifestFile')(function* (
 ) {
 ```
 
-Drop arrow wrapper + `=> Effect.gen(function* () {`; move params into generator. Call sites (:96, :101) unchanged — signatures identical.
+Drop arrow wrapper + `=> Effect.gen(function* () {`; move params to generator. Call sites (:96, :101) unchanged — signatures identical.
 
 Commit: `refactor(metadata): gen->fn generateManifest helpers - W-23125833`
 

--- a/packages/salesforcedx-vscode-metadata/src/commands/generateManifest.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/generateManifest.ts
@@ -38,9 +38,9 @@ const promptForFileName = Effect.fn('promptForFileName')(function* () {
 });
 
 const generateManifestFromUris = Effect.fn('generateManifestFromUris')(function* (uris: URI[]) {
+  yield* Effect.annotateCurrentSpan('uriCount', uris.length);
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
-  const componentSetService = yield* api.services.ComponentSetService;
-  const componentSet = yield* componentSetService.getComponentSetFromUris(Array.from(uris));
+  const componentSet = yield* api.services.ComponentSetService.getComponentSetFromUris(Array.from(uris));
   return yield* Effect.promise(() => componentSet.getPackageXml());
 });
 
@@ -49,9 +49,10 @@ const saveManifestFile = Effect.fn('saveManifestFile')(function* (
   fileName: string,
   packageXML: string
 ) {
+  yield* Effect.annotateCurrentSpan('fileName', fileName);
+  yield* Effect.annotateCurrentSpan('workspacePath', workspacePath.toString());
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const channelService = yield* api.services.ChannelService;
-  const fsService = yield* api.services.FsService;
   const promptService = yield* api.services.PromptService;
   // Build manifest directory path
   const manifestFileUri = Utils.joinPath(workspacePath, 'manifest', fileName);
@@ -61,7 +62,7 @@ const saveManifestFile = Effect.fn('saveManifestFile')(function* (
   yield* api.services.FsService.safeWriteFile(manifestFileUri, packageXML);
   yield* channelService.appendToChannel(`Manifest file created: ${manifestFileUri.toString()}`);
 
-  yield* fsService.showTextDocument(manifestFileUri);
+  yield* api.services.FsService.showTextDocument(manifestFileUri);
 
   return manifestFileUri;
 });

--- a/packages/salesforcedx-vscode-metadata/src/commands/generateManifest.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/generateManifest.ts
@@ -37,32 +37,34 @@ const promptForFileName = Effect.fn('promptForFileName')(function* () {
   );
 });
 
-const generateManifestFromUris = (uris: URI[]) =>
-  Effect.gen(function* () {
-    const api = yield* (yield* ExtensionProviderService).getServicesApi;
-    const componentSetService = yield* api.services.ComponentSetService;
-    const componentSet = yield* componentSetService.getComponentSetFromUris(Array.from(uris));
-    return yield* Effect.promise(() => componentSet.getPackageXml());
-  });
+const generateManifestFromUris = Effect.fn('generateManifestFromUris')(function* (uris: URI[]) {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const componentSetService = yield* api.services.ComponentSetService;
+  const componentSet = yield* componentSetService.getComponentSetFromUris(Array.from(uris));
+  return yield* Effect.promise(() => componentSet.getPackageXml());
+});
 
-const saveManifestFile = (workspacePath: URI, fileName: string, packageXML: string) =>
-  Effect.gen(function* () {
-    const api = yield* (yield* ExtensionProviderService).getServicesApi;
-    const channelService = yield* api.services.ChannelService;
-    const fsService = yield* api.services.FsService;
-    const promptService = yield* api.services.PromptService;
-    // Build manifest directory path
-    const manifestFileUri = Utils.joinPath(workspacePath, 'manifest', fileName);
+const saveManifestFile = Effect.fn('saveManifestFile')(function* (
+  workspacePath: URI,
+  fileName: string,
+  packageXML: string
+) {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const channelService = yield* api.services.ChannelService;
+  const fsService = yield* api.services.FsService;
+  const promptService = yield* api.services.PromptService;
+  // Build manifest directory path
+  const manifestFileUri = Utils.joinPath(workspacePath, 'manifest', fileName);
 
-    yield* promptService.ensureMetadataOverwriteOrThrow({ uris: [manifestFileUri] });
+  yield* promptService.ensureMetadataOverwriteOrThrow({ uris: [manifestFileUri] });
 
-    yield* api.services.FsService.safeWriteFile(manifestFileUri, packageXML);
-    yield* channelService.appendToChannel(`Manifest file created: ${manifestFileUri.toString()}`);
+  yield* api.services.FsService.safeWriteFile(manifestFileUri, packageXML);
+  yield* channelService.appendToChannel(`Manifest file created: ${manifestFileUri.toString()}`);
 
-    yield* fsService.showTextDocument(manifestFileUri);
+  yield* fsService.showTextDocument(manifestFileUri);
 
-    return manifestFileUri;
-  });
+  return manifestFileUri;
+});
 
 export const generateManifestCommand = Effect.fn('generateManifest')(function* (
   sourceUri: URI | undefined,


### PR DESCRIPTION
## Summary
- Converts 2 arrow-wrapper `=> Effect.gen` helpers to `Effect.fn("name")` pattern in `generateManifest.ts`
- Moves parameters from wrapper signature to generator function signature (`generateManifestFromUris`, `saveManifestFile`)

## Plan
[.claude/plans/W-23125833.md](.claude/plans/W-23125833.md)

## Reviewer notes
- Finding (line 53/55) claimed ChannelService and PromptService should use the accessor pattern (api.services.ChannelService.appendToChannel / api.services.PromptService.ensureMetadataOverwriteOrThrow). This DOES NOT COMPILE — those service classes are defined without `accessors: true` (packages/salesforcedx-vscode-services/src/vscode/channelService.ts:14 and src/vscode/prompts/promptService.ts:33), so the static methods do not exist on the tag (TS2339, plus a cascading TS2345 at index.ts:87). The verified-finding premise was incorrect for these two services. Kept the variable pattern (yield* api.services.ChannelService / PromptService then call) for both. The compilable accessor conversions (ComponentSetService getComponentSetFromUris, FsService showTextDocument matching pre-existing FsService.safeWriteFile) WERE applied, resolving the line-61 FsService inconsistency finding. All other findings applied; pre-commit compile/lint/knip/circular-deps passed.

## What issues does this PR fix or reference?
@W-23125833@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cp56pYAA/view