### PR TITLE
test(lightning): wait for settling URI in editor context-menu rename - W-23073729

### DIFF
--- a/.claude/plans/W-23073729.md
+++ b/.claude/plans/W-23073729.md
@@ -17,7 +17,7 @@ Aura old racy (auraRename:82-96):
 - `ControlOrMeta+a` + `keyboard.type` (lines 85-86) — select-all/type focus race
 - `toBeVisible({ timeout: 10_000 })`, no poll (line 96)
 
-Shared root: `executeEditorContextMenuCommand` (contextMenu.ts:128) opens editor menu by `data-uri` substring (openEditorContextMenu:13-41). The fileName match is a **synchronous for-loop snapshot** (`count()` then `getAttribute` per editor, :22-35): it reads the editor list ONCE with no retry. For static-path callers (deploy/retrieve/manifest pass `manifest/package.xml`, `${className}.cls` — editor already open) the matching editor exists instantly so the snapshot finds it. For the 2nd-rename callers, the renamed `data-uri` is still settling when the snapshot runs → no match (throws) or matches a stale tab. Plus `selectContextMenuItem` keyboard-Enter then a best-effort menu-hidden wait whose catch (:122) hides whether the command actually fired.
+Shared root: `executeEditorContextMenuCommand` (contextMenu.ts:128) opens editor menu by `data-uri` substring (openEditorContextMenu:13-41). The fileName match is a **synchronous for-loop snapshot** (`count()` then `getAttribute` per editor, :22-35): it reads the editor list ONCE with no retry. For static-path callers (deploy/retrieve/manifest pass `manifest/package.xml`, `${className}.cls` — editor already open) editor exists instantly, snapshot finds it. For the 2nd-rename callers, the renamed `data-uri` is still settling when the snapshot runs → no match (throws) or matches a stale tab. Plus `selectContextMenuItem` keyboard-Enter then a best-effort menu-hidden wait whose catch (:122) hides whether the command actually fired.
 
 ### Caller inventory (must not regress)
 
@@ -41,9 +41,9 @@ Helpers: `activeQuickInputTextField` (quickInput.ts:21), `EDITOR_WITH_URI`/`CONT
 
 ### Phase 1 — harden openEditorContextMenu fileName match (settling URI only)
 
-`contextMenu.ts:13-50`. Goal: settling renamed URI gets a bounded wait; static-path callers keep instant-match semantics; behavior of `selectContextMenuItem` (shared with explorer callers) is unchanged.
+`contextMenu.ts:13-50`. Goal: settling renamed URI → bounded wait; static-path callers → instant match; `selectContextMenuItem` behavior unchanged.
 
-**Match: replace imperative snapshot with auto-retrying locator (NOT expect.poll over the loop).** Playwright CSS attribute-substring locators auto-retry on `waitFor`/`click`, giving instant resolve when the editor is already open AND bounded wait when the URI is still settling — the exact behavioral split the findings require, without changing static-path callers.
+**Match: auto-retrying locator (not expect.poll).** CSS attribute-substring locators auto-retry: instant when open, bounded wait when settling — the exact behavioral split the findings require, without changing static-path callers.
 
 - delete the for-loop (:22-41); build the target as one locator:
   `const editor = fileName ? page.locator(`${EDITOR_WITH_URI}${cssAttrSubstring('data-uri', fileName)}`).first() : page.locator(EDITOR_WITH_URI).first();`
@@ -79,12 +79,10 @@ commit: `test(lightning): back-port lwc rename mitigations to aura 2nd rename - 
 
 ## Verification
 
-- e2e-covered (the fix): run lwc + aura rename specs locally, repeat N to confirm flake gone.
-  - `npm run test:desktop` in salesforcedx-vscode-lightning (Aura) + salesforcedx-vscode-lwc (LWC).
-- e2e-covered (regression — REQUIRED, the helper change is global): run every fileName-path caller spec to prove the locator swap keeps instant-match for pre-open editors. Findings flag these specifically; running only rename specs is insufficient.
+- Run lwc + aura rename specs locally, repeat N to confirm flake gone: `npm run test:desktop` in salesforcedx-vscode-lightning (Aura) + salesforcedx-vscode-lwc (LWC).
+- Run every fileName-path caller spec (REQUIRED — helper change is global): prove locator swap keeps instant-match for pre-open editors. Rename specs alone insufficient.
   - `salesforcedx-vscode-metadata`: `deploySourcePath`, `deployManifest`, `generateManifest`, `retrieveInManifest`, `nonTrackingOrgDeployRetrieveManifest`.
-  - no-fileName path sanity: `apex-oas/contextMenuEditor`, `playwright-vscode-ext/contextMenu.headless`.
-  - if any metadata spec gains noticeable latency or a "not visible" throw, the substring-escape or `.first()` selection is wrong — fix before merge.
-- not e2e-covered:
-  - typecheck/lint `playwright-vscode-ext` (helper change) — `npm run compile` + eslint.
-  - confirm `selectContextMenuItem` is byte-for-byte unchanged (explorer callers depend on its instant-close tolerance).
+  - No-fileName path sanity: `apex-oas/contextMenuEditor`, `playwright-vscode-ext/contextMenu.headless`.
+  - Any added latency or "not visible" throw → substring-escape or `.first()` selection wrong; fix before merge.
+- Typecheck/lint `playwright-vscode-ext`: `npm run compile` + eslint.
+- Confirm `selectContextMenuItem` byte-for-byte unchanged (explorer callers depend on instant-close tolerance).

--- a/.claude/plans/W-23073729.md
+++ b/.claude/plans/W-23073729.md
@@ -1,0 +1,90 @@
+# W-23073729 — E2E flake: LWC/Aura 2nd rename (editor context-menu) race
+
+## Context
+
+2nd rename via editor context-menu intermittently no-ops; renamed treeitem never appears.
+
+- LWC `lwcRename.headless.spec.ts` retryRate 86% (flakes thru `toPass(20s)`).
+- Aura `auraRename.desktop.spec.ts` HARD-FAILS — LWC mitigations never back-ported.
+
+Already-fixed LWC (lwcRename:92-108):
+
+- atomic `activeQuickInputTextField(page).fill(finalName, { force: true })` (line 95)
+- `toPass({ timeout: 20_000 })` poll on renamed treeitem (line 106)
+
+Aura old racy (auraRename:82-96):
+
+- `ControlOrMeta+a` + `keyboard.type` (lines 85-86) — select-all/type focus race
+- `toBeVisible({ timeout: 10_000 })`, no poll (line 96)
+
+Shared root: `executeEditorContextMenuCommand` (contextMenu.ts:128) opens editor menu by `data-uri` substring (openEditorContextMenu:13-41). The fileName match is a **synchronous for-loop snapshot** (`count()` then `getAttribute` per editor, :22-35): it reads the editor list ONCE with no retry. For static-path callers (deploy/retrieve/manifest pass `manifest/package.xml`, `${className}.cls` — editor already open) the matching editor exists instantly so the snapshot finds it. For the 2nd-rename callers, the renamed `data-uri` is still settling when the snapshot runs → no match (throws) or matches a stale tab. Plus `selectContextMenuItem` keyboard-Enter then a best-effort menu-hidden wait whose catch (:122) hides whether the command actually fired.
+
+### Caller inventory (must not regress)
+
+`executeEditorContextMenuCommand` callers — only the fileName-match path changes; the no-fileName `.first()` path (apex-oas :53) is untouched:
+
+- static-path (editor pre-open, expects instant match): `deploySourcePath`, `deployManifest`, `generateManifest`, `retrieveInManifest` (x2), `nonTrackingOrgDeployRetrieveManifest` (x2) — all in `salesforcedx-vscode-metadata`
+- no-fileName (`.first()`): `apex-oas/contextMenuEditor` (:53), `playwright-vscode-ext/contextMenu.headless` (:34)
+- settling-URI (the flake): `lwcRename` (:93), `auraRename` (:83)
+
+`selectContextMenuItem` is also reached by `executeExplorerContextMenuCommand` (all explorer-menu callers) — any change here is global.
+
+Files:
+
+- `packages/salesforcedx-vscode-lightning/test/playwright/specs/auraRename.desktop.spec.ts`
+- `packages/playwright-vscode-ext/src/pages/contextMenu.ts`
+- (ref only) `packages/salesforcedx-vscode-lwc/test/playwright/specs/lwcRename.headless.spec.ts`
+
+Helpers: `activeQuickInputTextField` (quickInput.ts:21), `EDITOR_WITH_URI`/`CONTEXT_MENU` (locators.ts).
+
+## Phases
+
+### Phase 1 — harden openEditorContextMenu fileName match (settling URI only)
+
+`contextMenu.ts:13-50`. Goal: settling renamed URI gets a bounded wait; static-path callers keep instant-match semantics; behavior of `selectContextMenuItem` (shared with explorer callers) is unchanged.
+
+**Match: replace imperative snapshot with auto-retrying locator (NOT expect.poll over the loop).** Playwright CSS attribute-substring locators auto-retry on `waitFor`/`click`, giving instant resolve when the editor is already open AND bounded wait when the URI is still settling — the exact behavioral split the findings require, without changing static-path callers.
+
+- delete the for-loop (:22-41); build the target as one locator:
+  `const editor = fileName ? page.locator(`${EDITOR_WITH_URI}${cssAttrSubstring('data-uri', fileName)}`).first() : page.locator(EDITOR_WITH_URI).first();`
+  where `data-uri*="<escaped>"` mirrors the old `dataUri.includes(fileName)` substring semantics. fileName values are paths (`manifest/package.xml`, `${newName}.js`, `${newName}.cmp`) — escape `"`/`\` for the CSS string, or use Playwright `getByXxx`-style escaping; no fileName contains quotes today but escape anyway.
+- keep the existing `await editor.waitFor({ state: 'visible', timeout: 10_000 })` (:45) — this is now the single auto-retry point: instant for static-path callers (editor already visible), waits up-to-10s for the renamed URI to attach+settle.
+- timeout semantics to document in the plan/PR: static-path callers resolve on first poll (no added latency); settling-URI callers retry up to 10s then throw a clear "editor not visible" error. The OLD error string ("No editor found … Available data-uris") is lost — preserve diagnostics by catching the `waitFor` timeout and rethrowing with `${fileName}` + a list of currently-present `data-uri`s (one extra `count()`/`getAttribute` pass, only on failure).
+- the `EDITOR_WITH_URI.first().waitFor` pre-wait (:16-17) becomes redundant (the combined locator's waitFor covers it) — remove it to avoid a stale first-editor wait masking the targeted wait.
+
+**Menu-fired signal: do NOT throw inside the shared helper.** Findings are correct that dropping the catch at :122 throws for any instant-close caller (explorer + editor, 10+ specs) and there is no in-helper way to distinguish "closed instantly = OK" from "never opened = fail". The helper has no caller-specific success signal to assert on. So:
+
+- leave `selectContextMenuItem` menu-hidden wait + catch (:122-124) unchanged (still best-effort, non-throwing) — global safety, no regression risk.
+- move the real "command fired" assertion to the rename callers, which DO have a deterministic side-effect: the rename quick-input widget. Both rename specs already call `await activeQuickInputWidget(page).waitFor({ state: 'attached', timeout: 10_000 })` immediately after (lwcRename:94, auraRename:84) — that IS the assertion that the editor menu fired. Phase 2 ensures aura has it (it does) and that it fails loud (it already throws on timeout). No new assertion needed; document that the quick-input wait is the menu-fired proof.
+
+commit: `test(e2e): editor context-menu match waits for settling URI - W-23073729`
+
+### Phase 2 — back-port LWC mitigations to Aura
+
+`auraRename.desktop.spec.ts:82-96`
+
+- line 85-86 → atomic fill: replace `ControlOrMeta+a` + `keyboard.type(finalName)` with `activeQuickInputTextField(page).fill(finalName, { force: true })`; import `activeQuickInputTextField`
+- line 96 → `toPass({ timeout: 20_000 })` poll on `finalFolder` visible (mirror lwcRename:106-108)
+- optionally harden 1st-rename block (63-64) same way for consistency — only if low-risk
+
+commit: `test(lightning): back-port lwc rename mitigations to aura 2nd rename - W-23073729`
+
+## Skills to apply
+
+- playwright-e2e (running/iterating/analyze CI)
+- analyze-e2e (CI run inspection)
+- concise (any md)
+- verification
+- typescript
+
+## Verification
+
+- e2e-covered (the fix): run lwc + aura rename specs locally, repeat N to confirm flake gone.
+  - `npm run test:desktop` in salesforcedx-vscode-lightning (Aura) + salesforcedx-vscode-lwc (LWC).
+- e2e-covered (regression — REQUIRED, the helper change is global): run every fileName-path caller spec to prove the locator swap keeps instant-match for pre-open editors. Findings flag these specifically; running only rename specs is insufficient.
+  - `salesforcedx-vscode-metadata`: `deploySourcePath`, `deployManifest`, `generateManifest`, `retrieveInManifest`, `nonTrackingOrgDeployRetrieveManifest`.
+  - no-fileName path sanity: `apex-oas/contextMenuEditor`, `playwright-vscode-ext/contextMenu.headless`.
+  - if any metadata spec gains noticeable latency or a "not visible" throw, the substring-escape or `.first()` selection is wrong — fix before merge.
+- not e2e-covered:
+  - typecheck/lint `playwright-vscode-ext` (helper change) — `npm run compile` + eslint.
+  - confirm `selectContextMenuItem` is byte-for-byte unchanged (explorer callers depend on its instant-close tolerance).

--- a/packages/playwright-vscode-ext/src/pages/contextMenu.ts
+++ b/packages/playwright-vscode-ext/src/pages/contextMenu.ts
@@ -29,7 +29,8 @@ const openEditorContextMenu = async (page: Page, fileName?: string): Promise<Loc
       await Promise.all(Array.from({ length: count }, (_, i) => allEditors.nth(i).getAttribute('data-uri')))
     ).filter((uri): uri is string => uri !== null);
     throw new Error(
-      `No editor found with fileName containing "${fileName}". Available data-uris: ${dataUris.join(', ')}`
+      `No editor found with fileName containing "${fileName}". Available data-uris: ${dataUris.join(', ')}`,
+      { cause }
     );
   });
   await editor.click({ button: 'right' });

--- a/packages/playwright-vscode-ext/src/pages/contextMenu.ts
+++ b/packages/playwright-vscode-ext/src/pages/contextMenu.ts
@@ -9,40 +9,29 @@ import type { Page, Locator } from '@playwright/test';
 import { EDITOR_WITH_URI, CONTEXT_MENU } from '../utils/locators';
 import { executeCommandWithCommandPalette } from './commands';
 
+/** Escape a value for use inside a double-quoted CSS attribute selector string. */
+const escapeCssAttrValue = (value: string): string => value.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+
 /** Opens context menu on an editor. If fileName is provided, matches editor by URI/name (partial match). */
 const openEditorContextMenu = async (page: Page, fileName?: string): Promise<Locator> => {
-  let editor: Locator;
-  if (fileName) {
-    // Wait for at least one editor to be visible first
-    await page.locator(EDITOR_WITH_URI).first().waitFor({ state: 'visible', timeout: 10_000 });
-
-    // Try to find editor by matching fileName in data-uri
-    // Check all editors and find one that matches
+  // Build the target as one auto-retrying locator. The data-uri substring match mirrors the old
+  // `dataUri.includes(fileName)` semantics. waitFor resolves instantly when the editor is already
+  // open (static-path callers) and waits up-to-10s while a renamed URI is still settling.
+  const editor = fileName
+    ? page.locator(`${EDITOR_WITH_URI}[data-uri*="${escapeCssAttrValue(fileName)}"]`).first()
+    : page.locator(EDITOR_WITH_URI).first();
+  await editor.waitFor({ state: 'visible', timeout: 10_000 }).catch(async (cause: unknown) => {
+    if (!fileName) throw cause;
+    // Preserve the old diagnostics: list currently-present data-uris (only on failure).
     const allEditors = page.locator(EDITOR_WITH_URI);
     const count = await allEditors.count();
-    let foundEditor: Locator | undefined;
-    const dataUris: string[] = [];
-    for (let i = 0; i < count; i++) {
-      const editorLocator = allEditors.nth(i);
-      const dataUri = await editorLocator.getAttribute('data-uri');
-      if (dataUri) {
-        dataUris.push(dataUri);
-        if (dataUri.includes(fileName)) {
-          foundEditor = editorLocator;
-          break;
-        }
-      }
-    }
-    if (!foundEditor) {
-      throw new Error(
-        `No editor found with fileName containing "${fileName}". Available data-uris: ${dataUris.join(', ')}`
-      );
-    }
-    editor = foundEditor;
-  } else {
-    editor = page.locator(EDITOR_WITH_URI).first();
-  }
-  await editor.waitFor({ state: 'visible', timeout: 10_000 });
+    const dataUris = (
+      await Promise.all(Array.from({ length: count }, (_, i) => allEditors.nth(i).getAttribute('data-uri')))
+    ).filter((uri): uri is string => uri !== null);
+    throw new Error(
+      `No editor found with fileName containing "${fileName}". Available data-uris: ${dataUris.join(', ')}`
+    );
+  });
   await editor.click({ button: 'right' });
   const contextMenu = page.locator(CONTEXT_MENU);
   await contextMenu.waitFor({ state: 'visible', timeout: 5000 });

--- a/packages/salesforcedx-vscode-lightning/test/playwright/specs/auraRename.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-lightning/test/playwright/specs/auraRename.desktop.spec.ts
@@ -8,6 +8,7 @@
 import { test } from '../fixtures';
 import { expect } from '@playwright/test';
 import {
+  activeQuickInputTextField,
   activeQuickInputWidget,
   setupConsoleMonitoring,
   setupNetworkMonitoring,
@@ -60,8 +61,8 @@ test.describe('Aura Rename (Desktop Only)', () => {
       );
       await activeQuickInputWidget(page).waitFor({ state: 'attached', timeout: 10_000 });
       await saveScreenshot(page, 'auraRename.menu-fired.png');
-      await page.keyboard.press('ControlOrMeta+a');
-      await page.keyboard.type(newName);
+      // Input box is pre-filled with the old name; fill atomically to avoid select-all/type focus race
+      await activeQuickInputTextField(page).fill(newName, { force: true });
       await page.keyboard.press('Enter');
       await saveScreenshot(page, 'auraRename.entered-new-name.png');
     });
@@ -82,8 +83,8 @@ test.describe('Aura Rename (Desktop Only)', () => {
     await test.step('rename again via editor context menu', async () => {
       await executeEditorContextMenuCommand(page, packageNls.rename_lightning_component_text, `${newName}.cmp`);
       await activeQuickInputWidget(page).waitFor({ state: 'attached', timeout: 10_000 });
-      await page.keyboard.press('ControlOrMeta+a');
-      await page.keyboard.type(finalName);
+      // Input box is pre-filled with the old name; fill atomically to avoid select-all/type focus race
+      await activeQuickInputTextField(page).fill(finalName, { force: true });
       await page.keyboard.press('Enter');
       await saveScreenshot(page, 'auraRename.editor-menu-fired.png');
     });
@@ -93,7 +94,10 @@ test.describe('Aura Rename (Desktop Only)', () => {
         .locator('[role="treeitem"]')
         .filter({ hasText: new RegExp(`^${finalName}$`, 'i') })
         .first();
-      await expect(finalFolder).toBeVisible({ timeout: 10_000 });
+      // Debounced file watcher lags the tree refresh; poll until the renamed folder appears.
+      await expect(async () => {
+        await expect(finalFolder).toBeVisible();
+      }).toPass({ timeout: 20_000 });
     });
 
     await validateNoCriticalErrors(test, consoleErrors, networkErrors);


### PR DESCRIPTION
## Summary

- Replace synchronous editor snapshot with auto-retrying locator in `openEditorContextMenu` — instant for static-path callers, waits up-to-10s for settling URIs (2nd rename).
- Back-port atomic quick-input fill + `toPass` poll from LWC to Aura 2nd-rename block — eliminate select-all/type focus race.
- Preserve diagnostic list of available `data-uri`s on match timeout.

## Plan

[.claude/plans/W-23073729.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23073729-e2e-flake-lwc-aura-rename-existing-bundl/.claude/plans/W-23073729.md)

## Reviewer notes

- **contextMenu.ts error-message timeout-hint (playwright-e2e finding):** NOT applied. The finding's own rationale concludes it adds minimal/redundant value — the existing 'Available data-uris' list already distinguishes no-editors (empty) from wrong-fileName (non-empty); 'within 10s' is an implementation detail. Skipped to avoid adding commentary the verification itself deemed redundant.
- **contextMenu.ts CSS-escaping comment (playwright-e2e finding):** NOT applied. The finding's rationale concludes the comment adds minimal value — existing doc at line 12 already signals 'for use inside a double-quoted CSS attribute selector string'; single quotes/brackets are not special inside double-quoted CSS attribute values so no escaping gap exists; documenting 'current callers pass paths' is speculative usage commentary. Skipped to avoid speculative noise the verification argued against.

## Test plan

- Run every fileName-path caller spec to prove locator swap keeps instant-match for pre-open editors (helper change is global): `deploySourcePath`, `deployManifest`, `generateManifest`, `retrieveInManifest`, `nonTrackingOrgDeployRetrieveManifest` in salesforcedx-vscode-metadata; no-fileName path sanity `apex-oas/contextMenuEditor`, `playwright-vscode-ext/contextMenu.headless`.

### What issues does this PR fix or reference?

@W-23073729@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cYK97YAG/view