### PR TITLE
feat(eslint): add no-inline-esbuild-platform rule - W-23129250

### DIFF
--- a/.claude/plans/W-23129250.md
+++ b/.claude/plans/W-23129250.md
@@ -2,26 +2,20 @@
 
 ## Context
 
-- ADR 0013: web/node split at bundle time. esbuild `define` replaces `process.env.ESBUILD_PLATFORM` literal so dead branches tree-shake.
-- Assigning to var/prop/destructure defeats strip → node-only code (child_process, CLI, appInsights v2) leaks into web bundle. Silent: compiles + bundles, bloats/breaks at runtime.
-- New rule: `process.env.ESBUILD_PLATFORM` only allowed as inline literal inside comparison (`=== 'web'`/`!== 'web'`) or ternary test. Flag assignment to const/let/var, obj/class prop, destructure.
-- Test files manipulate env: set (`= 'web'`), delete, and save-restore read (`const originalPlatform = process.env.ESBUILD_PLATFORM` — seedTelemetryIdentities.test.ts:38). The save-restore read into a const IS rule-flaggable, so `off` for test files is required, not just for set/delete. → `off` override in config (precedent: `no-vscode-show-text-document` uses config off-blocks, not rule logic).
-- Verified: no test spec body uses ESBUILD_PLATFORM as an inline-stripped branch (the rule's purpose); test reads are setup/teardown plumbing only. Existing test-files override block (`packages/**/test/**/*.ts`, `**/__tests__/**/*.ts`) is correct scope — no need to narrow to jest setup files.
-- Precedent rule: `packages/eslint-local-rules/src/noVscodeShowTextDocument.ts` + test + `src/index.ts` registry + 3 wiring spots in `eslint.config.mjs`.
+- ADR 0013: esbuild `define` strips `process.env.ESBUILD_PLATFORM` literal → dead-branch tree-shake. Assigning to var/prop/destructure defeats strip → node code leaks to web bundle. Rule: allow only inline in comparison/ternary; flag assignment/destructure.
+- Test files set/delete/save-restore env (seedTelemetryIdentities.test.ts:38). Save-restore read = rule-flaggable → `off` override in config (precedent: no-vscode-show-text-document).
+- Verified: no test spec uses ESBUILD_PLATFORM for inline-stripped branches; test reads = setup/teardown only. Existing override block (`packages/**/test/**/*.ts`, `**/__tests__/**/*.ts`) = correct scope.
+- Precedent: `packages/eslint-local-rules/src/noVscodeShowTextDocument.ts` + test + `src/index.ts` registry + 3 wiring spots in `eslint.config.mjs`.
 - Build pipeline: wireit `compile` (tsc → `out/`); config imports `./packages/eslint-local-rules/out/index.js`. Test: jest via ts-jest, `RuleTester`.
 
-### Existing violations (enumerated)
+### Existing violations
 
-- Repo-wide grep: 40 `ESBUILD_PLATFORM` matches across packages (services, metadata, utils, lwc, soql, apex). Audited each:
-  - **39 are NOT violations**: inline comparisons (`=== 'web'`, `!== 'web'`) in `if`/ternary/return — exactly what the rule allows (services index.ts/connectionService.ts:167/169/172/212/configService.ts:67/templateService.ts/terminalService.ts/cliTelemetry.ts/seedTelemetryIdentities.ts/appInsights.ts/spans.ts/indexedDbStorage.ts/fsService.ts/uriUtils.ts; metadata index.ts/helpers.ts; utils cliConfiguration.ts; lwc; soql; lwc-language-server), test-file set/delete/save-restore (off via config), and one comment-only mention (fsProviderRef.ts:10).
-  - **1 real violation**: `packages/salesforcedx-utils-vscode/src/telemetry/reporters/appInsights.ts:24` — `const isWebMode = process.env.ESBUILD_PLATFORM === 'web';` used at lines 66/138/176/208. Must inline at each use to pass rule.
-- Conclusion: WI scope = add rule + fix the single utils violation. No follow-up WI needed (no other src code extracts the literal). Phase 2 confirms via repo-wide eslint run after rule is wired (not assumption).
+- Grep: 40 matches. 39 = inline comparisons (allowed) or test plumbing (off via config). 1 violation: appInsights.ts:24 `const isWebMode = process.env.ESBUILD_PLATFORM === 'web'` used at 66/138/176/208. Must inline.
+- Scope: add rule + fix appInsights.ts. Phase 2 confirms via repo-wide lint.
 
 ### Detection (AST)
 
-- Match `MemberExpression`: `process.env.ESBUILD_PLATFORM` (object = `process.env` member, property = `ESBUILD_PLATFORM` Identifier).
-- Allowed parent: `BinaryExpression` (`===`/`!==`/`==`/`!=`) where node is operand. (Ternary test = BinaryExpr inside ConditionalExpression → already covered; bare `cond ? :` with raw env as test would be assignment-shaped, flag.)
-- Flag otherwise: `VariableDeclarator.init`, `Property.value`, `PropertyDefinition.value` (class prop), `AssignmentExpression.right`, destructuring (`process.env` accessed via ObjectPattern — separate: `const { ESBUILD_PLATFORM } = process.env`).
+- Match `MemberExpression`: `process.env.ESBUILD_PLATFORM`. Allow parent `BinaryExpression` (`===`/`!==`/`==`/`!=`) with string-literal sibling operand. Flag: `VariableDeclarator.init`, `Property.value`, `PropertyDefinition.value`, `AssignmentExpression.right`, destructure (`ObjectPattern`).
 - Single messageId `inlineLiteral`.
 
 ## Phases
@@ -32,7 +26,7 @@
 - Visitors: `MemberExpression` (process.env.ESBUILD_PLATFORM outside allowed comparison/ternary test) + `ObjectPattern`/destructure case on `process.env`.
 - Add `test/no-inline-esbuild-platform.test.ts`: valid = `=== 'web'`, `!== 'web'`, ternary test, inside `if`; invalid = const assign, let, class prop, object prop, destructure, plain reference. Note re config off-blocks for tests.
 - Register in `src/index.ts` (import + `rules` entry).
-- Wire `eslint.config.mjs`: add `'local/no-inline-esbuild-platform': 'error'` to main rules block (~L128); add `'off'` to test-files relaxation block (L763-781, `files` glob `packages/**/test/**/*.ts` + `**/__tests__/**/*.ts`) so jest env set/delete/save-restore allowed (scope matches existing precedent — no narrowing needed, verified no spec body has inline-stripped branches); README entry under `## Rules`.
+- Wire eslint.config.mjs: add error to main rules (~L128); off to test-files block (L763-781, packages/**/test/**/*.ts + **/__tests__/**/*.ts). README entry.
 - Commit: `feat(eslint): add no-inline-esbuild-platform rule - W-23129250`
 
 Files:
@@ -45,9 +39,7 @@ Files:
 
 ### Phase 2 — fix existing violation
 
-- After Phase 1 rule is wired, run eslint repo-wide to discover ALL flagged files (don't assume the audit is exhaustive — let the rule confirm). Expectation from audit: exactly 1 file (appInsights.ts).
-- `appInsights.ts`: delete `const isWebMode` (L24); inline `process.env.ESBUILD_PLATFORM === 'web'` at L66/138/176/208.
-- Re-run repo-wide lint to confirm 0 remaining violations. If the rule surfaces any unanticipated violation beyond appInsights.ts, fix it in this WI (rule must not ship firing on existing code).
+- Run repo-wide lint. Expect 1 file (appInsights.ts). Delete const isWebMode (L24); inline at 66/138/176/208. Re-run → 0 violations. Fix any unanticipated violations in this WI.
 - Commit: `refactor(utils): inline ESBUILD_PLATFORM, drop isWebMode const - W-23129250`
 
 Files:

--- a/.claude/plans/W-23129250.md
+++ b/.claude/plans/W-23129250.md
@@ -1,0 +1,67 @@
+# W-23129250 — eslint rule: inline-literal ESBUILD_PLATFORM
+
+## Context
+
+- ADR 0013: web/node split at bundle time. esbuild `define` replaces `process.env.ESBUILD_PLATFORM` literal so dead branches tree-shake.
+- Assigning to var/prop/destructure defeats strip → node-only code (child_process, CLI, appInsights v2) leaks into web bundle. Silent: compiles + bundles, bloats/breaks at runtime.
+- New rule: `process.env.ESBUILD_PLATFORM` only allowed as inline literal inside comparison (`=== 'web'`/`!== 'web'`) or ternary test. Flag assignment to const/let/var, obj/class prop, destructure.
+- Test files manipulate env: set (`= 'web'`), delete, and save-restore read (`const originalPlatform = process.env.ESBUILD_PLATFORM` — seedTelemetryIdentities.test.ts:38). The save-restore read into a const IS rule-flaggable, so `off` for test files is required, not just for set/delete. → `off` override in config (precedent: `no-vscode-show-text-document` uses config off-blocks, not rule logic).
+- Verified: no test spec body uses ESBUILD_PLATFORM as an inline-stripped branch (the rule's purpose); test reads are setup/teardown plumbing only. Existing test-files override block (`packages/**/test/**/*.ts`, `**/__tests__/**/*.ts`) is correct scope — no need to narrow to jest setup files.
+- Precedent rule: `packages/eslint-local-rules/src/noVscodeShowTextDocument.ts` + test + `src/index.ts` registry + 3 wiring spots in `eslint.config.mjs`.
+- Build pipeline: wireit `compile` (tsc → `out/`); config imports `./packages/eslint-local-rules/out/index.js`. Test: jest via ts-jest, `RuleTester`.
+
+### Existing violations (enumerated)
+
+- Repo-wide grep: 40 `ESBUILD_PLATFORM` matches across packages (services, metadata, utils, lwc, soql, apex). Audited each:
+  - **39 are NOT violations**: inline comparisons (`=== 'web'`, `!== 'web'`) in `if`/ternary/return — exactly what the rule allows (services index.ts/connectionService.ts:167/169/172/212/configService.ts:67/templateService.ts/terminalService.ts/cliTelemetry.ts/seedTelemetryIdentities.ts/appInsights.ts/spans.ts/indexedDbStorage.ts/fsService.ts/uriUtils.ts; metadata index.ts/helpers.ts; utils cliConfiguration.ts; lwc; soql; lwc-language-server), test-file set/delete/save-restore (off via config), and one comment-only mention (fsProviderRef.ts:10).
+  - **1 real violation**: `packages/salesforcedx-utils-vscode/src/telemetry/reporters/appInsights.ts:24` — `const isWebMode = process.env.ESBUILD_PLATFORM === 'web';` used at lines 66/138/176/208. Must inline at each use to pass rule.
+- Conclusion: WI scope = add rule + fix the single utils violation. No follow-up WI needed (no other src code extracts the literal). Phase 2 confirms via repo-wide eslint run after rule is wired (not assumption).
+
+### Detection (AST)
+
+- Match `MemberExpression`: `process.env.ESBUILD_PLATFORM` (object = `process.env` member, property = `ESBUILD_PLATFORM` Identifier).
+- Allowed parent: `BinaryExpression` (`===`/`!==`/`==`/`!=`) where node is operand. (Ternary test = BinaryExpr inside ConditionalExpression → already covered; bare `cond ? :` with raw env as test would be assignment-shaped, flag.)
+- Flag otherwise: `VariableDeclarator.init`, `Property.value`, `PropertyDefinition.value` (class prop), `AssignmentExpression.right`, destructuring (`process.env` accessed via ObjectPattern — separate: `const { ESBUILD_PLATFORM } = process.env`).
+- Single messageId `inlineLiteral`.
+
+## Phases
+
+### Phase 1 — rule + tests + wiring
+
+- Add `packages/eslint-local-rules/src/noInlineEsbuildPlatform.ts`. `RuleCreator.withoutDocs`, `type: 'problem'`, follow `noVscodeShowTextDocument` shape. AST helper inline or in `astUtils.ts` (predicate `isEsbuildPlatformAccess`).
+- Visitors: `MemberExpression` (process.env.ESBUILD_PLATFORM outside allowed comparison/ternary test) + `ObjectPattern`/destructure case on `process.env`.
+- Add `test/no-inline-esbuild-platform.test.ts`: valid = `=== 'web'`, `!== 'web'`, ternary test, inside `if`; invalid = const assign, let, class prop, object prop, destructure, plain reference. Note re config off-blocks for tests.
+- Register in `src/index.ts` (import + `rules` entry).
+- Wire `eslint.config.mjs`: add `'local/no-inline-esbuild-platform': 'error'` to main rules block (~L128); add `'off'` to test-files relaxation block (L763-781, `files` glob `packages/**/test/**/*.ts` + `**/__tests__/**/*.ts`) so jest env set/delete/save-restore allowed (scope matches existing precedent — no narrowing needed, verified no spec body has inline-stripped branches); README entry under `## Rules`.
+- Commit: `feat(eslint): add no-inline-esbuild-platform rule - W-23129250`
+
+Files:
+- `packages/eslint-local-rules/src/noInlineEsbuildPlatform.ts`
+- `packages/eslint-local-rules/src/astUtils.ts` (maybe)
+- `packages/eslint-local-rules/src/index.ts`
+- `packages/eslint-local-rules/test/no-inline-esbuild-platform.test.ts`
+- `eslint.config.mjs`
+- `packages/eslint-local-rules/README.md`
+
+### Phase 2 — fix existing violation
+
+- After Phase 1 rule is wired, run eslint repo-wide to discover ALL flagged files (don't assume the audit is exhaustive — let the rule confirm). Expectation from audit: exactly 1 file (appInsights.ts).
+- `appInsights.ts`: delete `const isWebMode` (L24); inline `process.env.ESBUILD_PLATFORM === 'web'` at L66/138/176/208.
+- Re-run repo-wide lint to confirm 0 remaining violations. If the rule surfaces any unanticipated violation beyond appInsights.ts, fix it in this WI (rule must not ship firing on existing code).
+- Commit: `refactor(utils): inline ESBUILD_PLATFORM, drop isWebMode const - W-23129250`
+
+Files:
+- `packages/salesforcedx-utils-vscode/src/telemetry/reporters/appInsights.ts`
+
+## Skills
+
+- typescript
+- verification
+
+## Verification
+
+- `cd packages/eslint-local-rules && npm run test` — RuleTester valid/invalid pass.
+- `npm run compile` in eslint-local-rules → `out/index.js` includes rule (config imports compiled output).
+- Repo-wide lint (all packages, not just services+utils): 0 violations after Phase 2 fix. Run rule against entire `packages/**/src` to prove no flagged file is missed.
+- Sanity: temporarily add `const x = process.env.ESBUILD_PLATFORM` in a src file → lint errors; revert. (manual, optional)
+- Not e2e-covered (lint-only rule; no runtime/playwright impact).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -128,6 +128,7 @@ export default [
     rules: {
       'local/no-vscode-uri': 'error',
       'local/no-vscode-show-text-document': 'warn',
+      'local/no-inline-esbuild-platform': 'error',
       'local/command-must-be-in-package-json': [
         'error',
         {
@@ -762,6 +763,8 @@ export default [
     ],
     rules: {
       'local/no-vscode-show-text-document': 'off',
+      // Tests set/delete/save-restore process.env.ESBUILD_PLATFORM as jest setup/teardown plumbing
+      'local/no-inline-esbuild-platform': 'off',
       // Deactivate import-order for tests to allow for mock-before-import
       'effect/no-import-from-barrel-package': ['off'],
 

--- a/packages/eslint-local-rules/README.md
+++ b/packages/eslint-local-rules/README.md
@@ -32,7 +32,7 @@ The rule allows template literals that contain `nls.localize()` calls.
 
 ### no-inline-esbuild-platform
 
-Enforces that `process.env.ESBUILD_PLATFORM` is used only as an inline literal inside a comparison (`=== 'web'` / `!== 'web'`, including ternary tests). esbuild's `define` replaces the literal at bundle time so dead branches tree-shake (ADR 0013); assigning it to a variable, object/class property, or destructuring it defeats the strip and leaks node-only code into the web bundle.
+Enforces that `process.env.ESBUILD_PLATFORM` is compared inline against a string literal (e.g. `=== 'web'` / `!== 'web'`, including ternary tests). esbuild's `define` replaces the literal at bundle time so `'web' === 'web'` constant-folds and dead branches tree-shake (ADR 0013); assigning it to a variable, object/class property, destructuring it, or comparing against a non-literal (`=== someVar`) defeats the strip and leaks node-only code into the web bundle.
 
 **Bad:**
 
@@ -40,6 +40,7 @@ Enforces that `process.env.ESBUILD_PLATFORM` is used only as an inline literal i
 const isWebMode = process.env.ESBUILD_PLATFORM === 'web';
 const { ESBUILD_PLATFORM } = process.env;
 doThing(process.env.ESBUILD_PLATFORM);
+if (process.env.ESBUILD_PLATFORM === someVar) { ... }
 ```
 
 **Good:**

--- a/packages/eslint-local-rules/README.md
+++ b/packages/eslint-local-rules/README.md
@@ -30,6 +30,27 @@ vscode.window.showErrorMessage(`${nls.localize('prefix')} - ${details}`);
 
 The rule allows template literals that contain `nls.localize()` calls.
 
+### no-inline-esbuild-platform
+
+Enforces that `process.env.ESBUILD_PLATFORM` is used only as an inline literal inside a comparison (`=== 'web'` / `!== 'web'`, including ternary tests). esbuild's `define` replaces the literal at bundle time so dead branches tree-shake (ADR 0013); assigning it to a variable, object/class property, or destructuring it defeats the strip and leaks node-only code into the web bundle.
+
+**Bad:**
+
+```typescript
+const isWebMode = process.env.ESBUILD_PLATFORM === 'web';
+const { ESBUILD_PLATFORM } = process.env;
+doThing(process.env.ESBUILD_PLATFORM);
+```
+
+**Good:**
+
+```typescript
+if (process.env.ESBUILD_PLATFORM === 'web') { ... }
+const reporter = process.env.ESBUILD_PLATFORM === 'web' ? webReporter : nodeReporter;
+```
+
+Test files set/delete/save-restore the env var as jest plumbing; that is allowed via an `off` override in `eslint.config.mjs`, not the rule.
+
 ### package-json-i18n-descriptions
 
 Enforces that user-facing strings in `package.json` `contributes` sections use i18n placeholders (`%key%`) and that those keys exist in the sibling `package.nls.json` file.

--- a/packages/eslint-local-rules/src/astUtils.ts
+++ b/packages/eslint-local-rules/src/astUtils.ts
@@ -64,6 +64,25 @@ export const isVscodeWindowMethodCall = (
   return false;
 };
 
+/** Type predicate: node is the `process.env.ESBUILD_PLATFORM` member expression. */
+export const isEsbuildPlatformAccess = (node: TSESTree.Node): node is TSESTree.MemberExpression =>
+  node.type === AST_NODE_TYPES.MemberExpression &&
+  node.property.type === AST_NODE_TYPES.Identifier &&
+  node.property.name === 'ESBUILD_PLATFORM' &&
+  node.object.type === AST_NODE_TYPES.MemberExpression &&
+  node.object.property.type === AST_NODE_TYPES.Identifier &&
+  node.object.property.name === 'env' &&
+  node.object.object.type === AST_NODE_TYPES.Identifier &&
+  node.object.object.name === 'process';
+
+/** Type predicate: node is `process.env` (member expression). */
+export const isProcessEnvAccess = (node: TSESTree.Node): node is TSESTree.MemberExpression =>
+  node.type === AST_NODE_TYPES.MemberExpression &&
+  node.property.type === AST_NODE_TYPES.Identifier &&
+  node.property.name === 'env' &&
+  node.object.type === AST_NODE_TYPES.Identifier &&
+  node.object.name === 'process';
+
 /** Find a property by name in an ObjectExpression */
 export const findObjectProperty = (obj: TSESTree.ObjectExpression, name: string): TSESTree.Property | undefined =>
   obj.properties.find(

--- a/packages/eslint-local-rules/src/index.ts
+++ b/packages/eslint-local-rules/src/index.ts
@@ -14,6 +14,7 @@ import { noEffectFnWrapper } from './noEffectFnWrapper';
 import { noEffectServiceAccessorCalls } from './noEffectServiceAccessorCalls';
 import { noExplicitEffectReturnType } from './noExplicitEffectReturnType';
 import { noExportTaggedErrorInServices } from './noExportTaggedErrorInServices';
+import { noInlineEsbuildPlatform } from './noInlineEsbuildPlatform';
 import { noRuntimeVscodeImport } from './noRuntimeVscodeImport';
 import { noSelfBarrelImport } from './noSelfBarrelImport';
 import { noUnusedI18nMessages } from './noUnusedI18nMessages';
@@ -53,6 +54,7 @@ const plugin: TSESLint.FlatConfig.Plugin = {
     'require-effect-fn-span-name': requireEffectFnSpanName,
     'no-effect-service-accessor-calls': noEffectServiceAccessorCalls,
     'no-explicit-effect-return-type': noExplicitEffectReturnType,
+    'no-inline-esbuild-platform': noInlineEsbuildPlatform,
     'no-unused-i18n-messages': noUnusedI18nMessages,
     'query-builder-html-i18n-keys': queryBuilderHtmlI18nKeys,
     'no-vscode-message-literals': noVscodeMessageLiterals,

--- a/packages/eslint-local-rules/src/noInlineEsbuildPlatform.ts
+++ b/packages/eslint-local-rules/src/noInlineEsbuildPlatform.ts
@@ -12,8 +12,14 @@ import { isEsbuildPlatformAccess, isProcessEnvAccess } from './astUtils';
 // Only a binary comparison lets esbuild `define` strip the dead branch (ADR 0013).
 const COMPARISON_OPERATORS = new Set(['===', '!==', '==', '!=']);
 
-const isAllowedComparison = (node: TSESTree.MemberExpression): boolean =>
-  node.parent.type === AST_NODE_TYPES.BinaryExpression && COMPARISON_OPERATORS.has(node.parent.operator);
+// Allowed only when compared against a string literal: esbuild folds `'web' === 'web'`,
+// not `'web' === someVar`, so a non-literal operand leaves the dead branch in the bundle.
+const isAllowedComparison = (node: TSESTree.MemberExpression): boolean => {
+  const parent = node.parent;
+  if (parent.type !== AST_NODE_TYPES.BinaryExpression || !COMPARISON_OPERATORS.has(parent.operator)) return false;
+  const sibling = parent.left === node ? parent.right : parent.left;
+  return sibling.type === AST_NODE_TYPES.Literal && typeof sibling.value === 'string';
+};
 
 export const noInlineEsbuildPlatform = RuleCreator.withoutDocs({
   meta: {
@@ -25,7 +31,7 @@ export const noInlineEsbuildPlatform = RuleCreator.withoutDocs({
     schema: [],
     messages: {
       inlineLiteral:
-        'process.env.ESBUILD_PLATFORM must be used inline in a comparison (=== / !== "web"). Assigning it to a variable, property, or destructuring it defeats esbuild dead-branch stripping (ADR 0013).'
+        'process.env.ESBUILD_PLATFORM must be used inline in a comparison against a string literal (e.g. === "web"). Assigning it to a variable, property, destructuring it, or comparing against a non-literal defeats esbuild dead-branch stripping (ADR 0013).'
     }
   },
   defaultOptions: [],
@@ -35,10 +41,16 @@ export const noInlineEsbuildPlatform = RuleCreator.withoutDocs({
         context.report({ node, messageId: 'inlineLiteral' });
       }
     },
-    // `const { ESBUILD_PLATFORM } = process.env` extracts the literal into a binding.
+    // `const { ESBUILD_PLATFORM } = process.env` (or assignment-pattern
+    // `({ ESBUILD_PLATFORM } = process.env)`) extracts the literal into a binding.
     ObjectPattern: (node: TSESTree.ObjectPattern): void => {
-      if (node.parent.type !== AST_NODE_TYPES.VariableDeclarator || !node.parent.init) return;
-      if (!isProcessEnvAccess(node.parent.init)) return;
+      const source =
+        node.parent.type === AST_NODE_TYPES.VariableDeclarator
+          ? node.parent.init
+          : node.parent.type === AST_NODE_TYPES.AssignmentExpression
+            ? node.parent.right
+            : undefined;
+      if (!source || !isProcessEnvAccess(source)) return;
       const destructured = node.properties.find(
         (prop): prop is TSESTree.Property =>
           prop.type === AST_NODE_TYPES.Property &&

--- a/packages/eslint-local-rules/src/noInlineEsbuildPlatform.ts
+++ b/packages/eslint-local-rules/src/noInlineEsbuildPlatform.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
+import { RuleCreator } from '@typescript-eslint/utils/eslint-utils';
+import { isEsbuildPlatformAccess, isProcessEnvAccess } from './astUtils';
+
+// Only a binary comparison lets esbuild `define` strip the dead branch (ADR 0013).
+const COMPARISON_OPERATORS = new Set(['===', '!==', '==', '!=']);
+
+const isAllowedComparison = (node: TSESTree.MemberExpression): boolean =>
+  node.parent.type === AST_NODE_TYPES.BinaryExpression && COMPARISON_OPERATORS.has(node.parent.operator);
+
+export const noInlineEsbuildPlatform = RuleCreator.withoutDocs({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Use process.env.ESBUILD_PLATFORM only as an inline literal in a comparison so esbuild can strip the dead branch.'
+    },
+    schema: [],
+    messages: {
+      inlineLiteral:
+        'process.env.ESBUILD_PLATFORM must be used inline in a comparison (=== / !== "web"). Assigning it to a variable, property, or destructuring it defeats esbuild dead-branch stripping (ADR 0013).'
+    }
+  },
+  defaultOptions: [],
+  create: context => ({
+    MemberExpression: (node: TSESTree.MemberExpression): void => {
+      if (isEsbuildPlatformAccess(node) && !isAllowedComparison(node)) {
+        context.report({ node, messageId: 'inlineLiteral' });
+      }
+    },
+    // `const { ESBUILD_PLATFORM } = process.env` extracts the literal into a binding.
+    ObjectPattern: (node: TSESTree.ObjectPattern): void => {
+      if (node.parent.type !== AST_NODE_TYPES.VariableDeclarator || !node.parent.init) return;
+      if (!isProcessEnvAccess(node.parent.init)) return;
+      const destructured = node.properties.find(
+        (prop): prop is TSESTree.Property =>
+          prop.type === AST_NODE_TYPES.Property &&
+          prop.key.type === AST_NODE_TYPES.Identifier &&
+          prop.key.name === 'ESBUILD_PLATFORM'
+      );
+      if (destructured) {
+        context.report({ node: destructured, messageId: 'inlineLiteral' });
+      }
+    }
+  })
+});

--- a/packages/eslint-local-rules/test/no-inline-esbuild-platform.test.ts
+++ b/packages/eslint-local-rules/test/no-inline-esbuild-platform.test.ts
@@ -80,6 +80,36 @@ ruleTester.run('no-inline-esbuild-platform', noInlineEsbuildPlatform, {
       code: `platform = process.env.ESBUILD_PLATFORM;`,
       filename: 'packages/salesforcedx-vscode-services/src/test.ts',
       errors: [{ messageId: 'inlineLiteral' }]
+    },
+    {
+      // assignment-pattern destructure — esbuild cannot strip a binding extraction
+      code: `let p; ({ ESBUILD_PLATFORM: p } = process.env);`,
+      filename: 'packages/salesforcedx-vscode-services/src/test.ts',
+      errors: [{ messageId: 'inlineLiteral' }]
+    },
+    {
+      // comparison against a non-literal — esbuild cannot constant-fold, dead branch survives
+      code: `if (process.env.ESBUILD_PLATFORM === someVar) { doWeb(); }`,
+      filename: 'packages/salesforcedx-vscode-services/src/test.ts',
+      errors: [{ messageId: 'inlineLiteral' }]
+    },
+    {
+      // negation — not a literal comparison
+      code: `if (!process.env.ESBUILD_PLATFORM) { doNode(); }`,
+      filename: 'packages/salesforcedx-vscode-services/src/test.ts',
+      errors: [{ messageId: 'inlineLiteral' }]
+    },
+    {
+      // nullish coalesce — not a literal comparison
+      code: `const p = process.env.ESBUILD_PLATFORM ?? 'node';`,
+      filename: 'packages/salesforcedx-vscode-services/src/test.ts',
+      errors: [{ messageId: 'inlineLiteral' }]
+    },
+    {
+      // switch discriminant — not a literal comparison
+      code: `switch (process.env.ESBUILD_PLATFORM) { case 'web': doWeb(); }`,
+      filename: 'packages/salesforcedx-vscode-services/src/test.ts',
+      errors: [{ messageId: 'inlineLiteral' }]
     }
   ]
 });

--- a/packages/eslint-local-rules/test/no-inline-esbuild-platform.test.ts
+++ b/packages/eslint-local-rules/test/no-inline-esbuild-platform.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { noInlineEsbuildPlatform } from '../src/noInlineEsbuildPlatform';
+
+const ruleTester = new RuleTester();
+
+// NOTE: RuleTester ignores eslint.config file-scoping. The rule flags any
+// non-inline use of process.env.ESBUILD_PLATFORM everywhere; test-file
+// set/delete/save-restore plumbing is allowed via the `off` override in
+// eslint.config.mjs (packages/**/test/**/*.ts, **/__tests__/**/*.ts), not the rule.
+ruleTester.run('no-inline-esbuild-platform', noInlineEsbuildPlatform, {
+  valid: [
+    {
+      code: `if (process.env.ESBUILD_PLATFORM === 'web') { doWeb(); }`,
+      filename: 'packages/salesforcedx-vscode-services/src/test.ts'
+    },
+    {
+      code: `if (process.env.ESBUILD_PLATFORM !== 'web') { doNode(); }`,
+      filename: 'packages/salesforcedx-vscode-services/src/test.ts'
+    },
+    {
+      // ternary test = BinaryExpression operand
+      code: `const reporter = process.env.ESBUILD_PLATFORM === 'web' ? webReporter : nodeReporter;`,
+      filename: 'packages/salesforcedx-utils-vscode/src/test.ts'
+    },
+    {
+      code: `return process.env.ESBUILD_PLATFORM === 'web';`,
+      filename: 'packages/salesforcedx-vscode-services/src/test.ts'
+    },
+    {
+      // unrelated env var — not flagged
+      code: `const x = process.env.NODE_ENV;`,
+      filename: 'packages/salesforcedx-vscode-services/src/test.ts'
+    },
+    {
+      // unrelated destructure — not flagged
+      code: `const { NODE_ENV } = process.env;`,
+      filename: 'packages/salesforcedx-vscode-services/src/test.ts'
+    }
+  ],
+  invalid: [
+    {
+      code: `const platform = process.env.ESBUILD_PLATFORM;`,
+      filename: 'packages/salesforcedx-vscode-services/src/test.ts',
+      errors: [{ messageId: 'inlineLiteral' }]
+    },
+    {
+      code: `let platform = process.env.ESBUILD_PLATFORM;`,
+      filename: 'packages/salesforcedx-vscode-services/src/test.ts',
+      errors: [{ messageId: 'inlineLiteral' }]
+    },
+    {
+      code: `const config = { platform: process.env.ESBUILD_PLATFORM };`,
+      filename: 'packages/salesforcedx-vscode-services/src/test.ts',
+      errors: [{ messageId: 'inlineLiteral' }]
+    },
+    {
+      code: `class C { platform = process.env.ESBUILD_PLATFORM; }`,
+      filename: 'packages/salesforcedx-vscode-services/src/test.ts',
+      errors: [{ messageId: 'inlineLiteral' }]
+    },
+    {
+      code: `const { ESBUILD_PLATFORM } = process.env;`,
+      filename: 'packages/salesforcedx-vscode-services/src/test.ts',
+      errors: [{ messageId: 'inlineLiteral' }]
+    },
+    {
+      code: `doThing(process.env.ESBUILD_PLATFORM);`,
+      filename: 'packages/salesforcedx-vscode-services/src/test.ts',
+      errors: [{ messageId: 'inlineLiteral' }]
+    },
+    {
+      // assignment to existing variable
+      code: `platform = process.env.ESBUILD_PLATFORM;`,
+      filename: 'packages/salesforcedx-vscode-services/src/test.ts',
+      errors: [{ messageId: 'inlineLiteral' }]
+    }
+  ]
+});

--- a/packages/salesforcedx-utils-vscode/src/telemetry/reporters/appInsights.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/reporters/appInsights.ts
@@ -21,8 +21,6 @@ if (process.env.ESBUILD_PLATFORM !== 'web') {
   appInsights = require('applicationinsights');
 }
 
-const isWebMode = process.env.ESBUILD_PLATFORM === 'web';
-
 export class AppInsights
   extends Disposable
   implements TelemetryReporter, TelemetryReporterWithModifiableUserProperties
@@ -63,7 +61,7 @@ export class AppInsights
     if (this.userOptIn !== config.get<boolean>(AppInsights.TELEMETRY_CONFIG_ENABLED_ID, true)) {
       this.userOptIn = config.get<boolean>(AppInsights.TELEMETRY_CONFIG_ENABLED_ID, true);
       if (this.userOptIn) {
-        if (isWebMode) {
+        if (process.env.ESBUILD_PLATFORM === 'web') {
           this.createWebReporter();
         } else {
           this.createAppInsightsClient(key);
@@ -135,7 +133,7 @@ export class AppInsights
     const baseProps = getBaseProps();
     const finalProps = this.applyTelemetryTag({ ...baseProps, ...properties, webUserId: this.webUserId });
 
-    if (isWebMode) {
+    if (process.env.ESBUILD_PLATFORM === 'web') {
       if (this.webReporter) {
         try {
           // Add extension metadata to properties for web mode
@@ -173,7 +171,7 @@ export class AppInsights
     const baseProps = getBaseProps();
     const finalProps = this.applyTelemetryTag({ ...baseProps, webUserId: this.webUserId });
 
-    if (isWebMode) {
+    if (process.env.ESBUILD_PLATFORM === 'web') {
       if (this.webReporter) {
         try {
           const properties = {
@@ -205,7 +203,7 @@ export class AppInsights
   }
 
   public dispose(): Promise<any> {
-    if (isWebMode) {
+    if (process.env.ESBUILD_PLATFORM === 'web') {
       if (this.webReporter) {
         this.webReporter = undefined;
         return Promise.resolve(void 0);


### PR DESCRIPTION
## Summary

- Added custom eslint rule `no-inline-esbuild-platform` to enforce inline literal usage of `process.env.ESBUILD_PLATFORM` in comparisons/ternaries, preventing assignment/destructure that defeats esbuild dead-branch tree-shaking (ADR 0013).
- Inlined existing violation in appInsights.ts — replaced `const isWebMode` with direct comparisons at use sites.
- Rule wired in eslint.config.mjs (error in src, off in test files); includes RuleTester coverage.

## Plan

[.claude/plans/W-23129250.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23129250-eslint-rule-inline-literal-esbuild-platf/.claude/plans/W-23129250.md)

## Reviewer notes

- **Low-severity typescript finding (noInlineEsbuildPlatform.ts:15, inline isAllowedComparison):** NOT applied. The helper now contains a 3-statement literal-RHS check (added for the medium-severity fix); inlining it into the negated condition at the call site would produce a hard-to-parse double-negation over a multi-part expression. The finding's own rationale flags this readability cost as the reason it stayed low/marginal. Keeping the named helper is the clearer choice — a design judgment, so surfaced rather than mechanically applied.

## Test plan

- Run `cd packages/eslint-local-rules && npm run test` — RuleTester valid/invalid pass.
- Run `npm run compile` in eslint-local-rules → `out/index.js` includes rule (config imports compiled output).
- Repo-wide lint (all packages, not just services+utils): 0 violations after Phase 2 fix. Run rule against entire `packages/**/src` to prove no flagged file is missed.
- Sanity (optional): temporarily add `const x = process.env.ESBUILD_PLATFORM` in a src file → lint errors; revert.

### What issues does this PR fix or reference?

@W-23129250@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cpkFDYAY/view