### PR TITLE
chore(lint): enable unicorn/no-boolean-sort-comparator - W-23094890

### DIFF
--- a/.claude/plans/W-23094890.md
+++ b/.claude/plans/W-23094890.md
@@ -1,0 +1,32 @@
+# W-23094890 — Enable unicorn/no-boolean-sort-comparator
+
+## Context
+
+- Enable `unicorn/no-boolean-sort-comparator` in `eslint.config.mjs`.
+- Rule: bans comparators returning boolean (yields 1/0, never negative → wrong sort).
+- Plugin `eslint-plugin-unicorn@68.0.0` already installed; rule file present (`node_modules/eslint-plugin-unicorn/rules/no-boolean-sort-comparator.js`).
+- Dep W-23094888 (adds unicorn rule block to config) is NOT yet on `origin/develop`: `git branch -r --contains d07266c19 | grep develop` empty, and d07266c19 is only a plan commit (`chore: plan for W-23094888`). The unicorn block exists in this worktree only. BLOCKER: W-23094888 must merge to develop before this lands. Before implementation, re-verify with `git log origin/develop --oneline | grep -i W-23094888` and cite the develop SHA; rebase this work on it.
+- Scanned all `packages/*/src` + `test` w/ rule temporarily on: **0 violations**.
+- No code fixes needed — config-only change.
+- Note: `.sort((a,b)=> a>b ? 1 : -1)` (lwcTestController) is a ternary, not boolean return → rule allows.
+
+## Phases
+
+### Phase 1 — enable rule
+
+- `eslint.config.mjs`: add `'unicorn/no-boolean-sort-comparator': 'error',` in its alphabetical slot — after `'unicorn/no-array-sort'`, before `'unicorn/no-empty-file'`. (In this worktree those are lines 171 and 172; re-confirm by grep after rebasing on develop rather than trusting line numbers.)
+- No source changes (0 violations).
+- Commit: `chore(lint): enable unicorn/no-boolean-sort-comparator - W-23094890`
+- Files: `eslint.config.mjs`
+
+## Skills
+
+- typescript
+- packageJson — n/a (no dep change; plugin present)
+- verification
+
+## Verification
+
+- `npm run lint` clean (or scoped per-package eslint).
+- Confirms 0 violations introduced.
+- Not e2e-covered (lint-config change; CI lint gate covers).

--- a/.claude/plans/W-23094890.md
+++ b/.claude/plans/W-23094890.md
@@ -5,16 +5,16 @@
 - Enable `unicorn/no-boolean-sort-comparator` in `eslint.config.mjs`.
 - Rule: bans comparators returning boolean (yields 1/0, never negative → wrong sort).
 - Plugin `eslint-plugin-unicorn@68.0.0` already installed; rule file present (`node_modules/eslint-plugin-unicorn/rules/no-boolean-sort-comparator.js`).
-- Dep W-23094888 (adds unicorn rule block to config) is NOT yet on `origin/develop`: `git branch -r --contains d07266c19 | grep develop` empty, and d07266c19 is only a plan commit (`chore: plan for W-23094888`). The unicorn block exists in this worktree only. BLOCKER: W-23094888 must merge to develop before this lands. Before implementation, re-verify with `git log origin/develop --oneline | grep -i W-23094888` and cite the develop SHA; rebase this work on it.
+- Unicorn rule block already on `origin/develop` (`git show origin/develop:eslint.config.mjs` shows `unicorn/no-array-sort` / `unicorn/no-empty-file`). No blocker; proceed.
 - Scanned all `packages/*/src` + `test` w/ rule temporarily on: **0 violations**.
 - No code fixes needed — config-only change.
-- Note: `.sort((a,b)=> a>b ? 1 : -1)` (lwcTestController) is a ternary, not boolean return → rule allows.
+- Note: `.sort((a,b)=> a>b ? 1 : -1)` (lwcTestController) is ternary, not boolean → rule allows.
 
 ## Phases
 
 ### Phase 1 — enable rule
 
-- `eslint.config.mjs`: add `'unicorn/no-boolean-sort-comparator': 'error',` in its alphabetical slot — after `'unicorn/no-array-sort'`, before `'unicorn/no-empty-file'`. (In this worktree those are lines 171 and 172; re-confirm by grep after rebasing on develop rather than trusting line numbers.)
+- `eslint.config.mjs`: add `'unicorn/no-boolean-sort-comparator': 'error',` alphabetically — after `'unicorn/no-array-sort'`, before `'unicorn/no-empty-file'`. (Lines 171-172 in worktree; re-confirm via grep after rebase on develop vs trusting line numbers.)
 - No source changes (0 violations).
 - Commit: `chore(lint): enable unicorn/no-boolean-sort-comparator - W-23094890`
 - Files: `eslint.config.mjs`
@@ -22,11 +22,12 @@
 ## Skills
 
 - typescript
-- packageJson — n/a (no dep change; plugin present)
+- packageJson — n/a (no dep change, plugin present)
 - verification
 
 ## Verification
 
+- Unicorn block on develop: `git show origin/develop:eslint.config.mjs | grep -c unicorn/` > 0.
 - `npm run lint` clean (or scoped per-package eslint).
 - Confirms 0 violations introduced.
 - Not e2e-covered (lint-config change; CI lint gate covers).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -169,6 +169,7 @@ export default [
       'unicorn/explicit-length-check': 'error',
       'unicorn/no-array-reverse': 'error',
       'unicorn/no-array-sort': 'error',
+      'unicorn/no-boolean-sort-comparator': 'error',
       'unicorn/no-empty-file': 'error',
       'unicorn/no-immediate-mutation': 'error',
       'unicorn/no-instanceof-builtins': 'error',


### PR DESCRIPTION
## Summary

- Enable `unicorn/no-boolean-sort-comparator` ESLint rule in `eslint.config.mjs`
- Rule prevents boolean-returning comparators (which yield 1/0, missing negative values for proper sorting)
- Zero violations found across all packages — config-only change

## Plan

[.claude/plans/W-23094890.md](.claude/plans/W-23094890.md)

### What issues does this PR fix or reference?

@W-23094890@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cezPcYAI/view