### PR TITLE
build(eslint): enable unicorn/no-duplicate-logical-operands - W-23094903

### DIFF
--- a/.claude/plans/W-23094903.md
+++ b/.claude/plans/W-23094903.md
@@ -1,0 +1,25 @@
+# W-23094903 — Enable unicorn/no-duplicate-logical-operands
+
+## Context
+- Enable `unicorn/no-duplicate-logical-operands` (error). Bans duplicate operands in `&&`/`||`.
+- `eslint-plugin-unicorn@68` (`node_modules/eslint-plugin-unicorn/rules/no-duplicate-logical-operands.js`).
+- eslint.config.mjs:166-210 — unicorn rules block; insert alphabetically (after `no-array-sort`, before `no-empty-file`).
+- Depends: W-23094902 (merged, on `develop`).
+- Repo scan w/ rule on: 0 violations.
+
+## Done when
+- `unicorn/no-duplicate-logical-operands` enabled at error level in eslint.config.mjs.
+- `npm run lint` passes clean.
+
+## Phases
+
+### Phase 1 — enable rule
+- eslint.config.mjs: add `'unicorn/no-duplicate-logical-operands': 'error',` in unicorn block (alpha order).
+- commit msg: `build(eslint): enable unicorn/no-duplicate-logical-operands - W-23094903`
+
+## Skills
+- typescript
+
+## Verification
+- `npx eslint .` → 0 errors.
+- Not e2e-covered (lint-only config change).

--- a/.claude/plans/W-23094903.md
+++ b/.claude/plans/W-23094903.md
@@ -21,5 +21,5 @@
 - typescript
 
 ## Verification
-- `npx eslint .` → 0 errors.
+- `npm run lint` → 0 errors (shards across packages; `npx eslint .` OOMs on the full tree).
 - Not e2e-covered (lint-only config change).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -169,6 +169,7 @@ export default [
       'unicorn/explicit-length-check': 'error',
       'unicorn/no-array-reverse': 'error',
       'unicorn/no-array-sort': 'error',
+      'unicorn/no-duplicate-logical-operands': 'error',
       'unicorn/no-empty-file': 'error',
       'unicorn/no-immediate-mutation': 'error',
       'unicorn/no-instanceof-builtins': 'error',


### PR DESCRIPTION
## Summary
- Enable `unicorn/no-duplicate-logical-operands` ESLint rule at error level
- Bans duplicate operands in `&&`/`||` expressions
- Zero existing violations found in codebase

## Plan
[.claude/plans/W-23094903.md](.claude/plans/W-23094903.md)

### What issues does this PR fix or reference?
@W-23094903@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.my.salesforce.com/a07EE00002cfB14