### PR TITLE
refactor(lwc,core): add Effect tracing spans to lazy resolvers - W-23125840

### DIFF
--- a/.claude/plans/W-23125840.md
+++ b/.claude/plans/W-23125840.md
@@ -2,15 +2,15 @@
 
 ## Context
 
-WI: convert arrow-wrapped `=> Effect.gen` to traced form across 3 packages, 4 sites.
+Convert arrow-wrapped `=> Effect.gen` to traced form — 3 packages, 4 sites.
 
 Reality check (verified in worktree):
 - effect-ext-utils/src/extensionScope.ts:15 `getExtensionScope`, :20 `closeExtensionScope` — ALREADY `Effect.fn(...)`. Done in 0352cca46 (W-23125831). No work.
 - lwc/src/channel/index.ts:13 `getChannelService` and core/src/util/orgAuthInfoExtensions.ts:13 `getConnection` — `() => getRuntime().runPromise(Effect.gen(...))`. Outer fn returns `Promise`, not `Effect` → `Effect.fn` does NOT apply (Effect.fn wraps gens into Effects).
 
-Precedent 468cf256c (W-23125836, orgUtil.ts): same `runPromise(Effect.gen())` shape. Transform applied = inline gen + `.pipe(Effect.withSpan('Name'))`. That is the real "gen→fn / withSpan inside" intent here.
+Precedent 468cf256c (W-23125836, orgUtil.ts): same `runPromise(Effect.gen())` shape. Transform = inline gen + `.pipe(Effect.withSpan('Name'))`.
 
-Remaining work: 3 gens — add `Effect.withSpan` to inline gens.
+Remaining: add `Effect.withSpan` to 3 inline gens:
 - lwc/src/channel/index.ts:13 `getChannelService` — 1 gen.
 - core/src/util/orgAuthInfoExtensions.ts:13 `getConnection` — 1 gen; :23 `getUserId` inline gen (TargetOrgRef lookup) — 1 gen. `getAuthFields` calls `getConnection`, no separate gen.
 
@@ -22,7 +22,7 @@ Remaining work: 3 gens — add `Effect.withSpan` to inline gens.
 - core/src/util/orgAuthInfoExtensions.ts:
   - `getConnection` gen (:15-18) → `.pipe(Effect.withSpan('OrgAuthInfoExtensions.getConnection'))`
   - `getUserId` inline gen (:24-29) → `.pipe(Effect.withSpan('OrgAuthInfoExtensions.getUserId'))`
-- gens already inline in `runPromise(...)`; only add `.pipe(...)`.
+- gens inline in `runPromise(...)`; add `.pipe(...)` only.
 
 Commit: `refactor(lwc,core): withSpan on getChannelService + getConnection + getUserId - W-23125840`
 
@@ -38,7 +38,7 @@ Commit: `refactor(lwc,core): withSpan on getChannelService + getConnection + get
   - `cd packages/salesforcedx-vscode-lwc && npx effect-language-service diagnostics --project tsconfig.json`
   - `cd packages/salesforcedx-vscode-core && npx effect-language-service diagnostics --project tsconfig.json`
   - effect-ext-utils: skip — no change.
-- expect no new `effectFnOpportunity` for these sites (Promise wrappers don't trigger it).
+- expect no new `effectFnOpportunity` (Promise wrappers exempt).
 - tsc per package (compile clean).
 - core: confirm 2 distinct spans (`getConnection`, `getUserId`) added — grep `withSpan('OrgAuthInfoExtensions` → 2 hits.
-- not e2e-covered (internal lazy resolvers); no behavior change — pure tracing add.
+- not e2e-covered (internal lazy resolvers); pure tracing — no behavior change.

--- a/.claude/plans/W-23125840.md
+++ b/.claude/plans/W-23125840.md
@@ -1,0 +1,44 @@
+# W-23125840 — gen→fn: effect-ext-utils + lwc + core (4 sites)
+
+## Context
+
+WI: convert arrow-wrapped `=> Effect.gen` to traced form across 3 packages, 4 sites.
+
+Reality check (verified in worktree):
+- effect-ext-utils/src/extensionScope.ts:15 `getExtensionScope`, :20 `closeExtensionScope` — ALREADY `Effect.fn(...)`. Done in 0352cca46 (W-23125831). No work.
+- lwc/src/channel/index.ts:13 `getChannelService` and core/src/util/orgAuthInfoExtensions.ts:13 `getConnection` — `() => getRuntime().runPromise(Effect.gen(...))`. Outer fn returns `Promise`, not `Effect` → `Effect.fn` does NOT apply (Effect.fn wraps gens into Effects).
+
+Precedent 468cf256c (W-23125836, orgUtil.ts): same `runPromise(Effect.gen())` shape. Transform applied = inline gen + `.pipe(Effect.withSpan('Name'))`. That is the real "gen→fn / withSpan inside" intent here.
+
+Remaining work: 3 gens — add `Effect.withSpan` to inline gens.
+- lwc/src/channel/index.ts:13 `getChannelService` — 1 gen.
+- core/src/util/orgAuthInfoExtensions.ts:13 `getConnection` — 1 gen; :23 `getUserId` inline gen (TargetOrgRef lookup) — 1 gen. `getAuthFields` calls `getConnection`, no separate gen.
+
+## Phases
+
+### Phase 1 — add withSpan to lwc + core runPromise gens
+
+- lwc/src/channel/index.ts: `getChannelService` gen → `.pipe(Effect.withSpan('LwcChannel.getChannelService'))`
+- core/src/util/orgAuthInfoExtensions.ts:
+  - `getConnection` gen (:15-18) → `.pipe(Effect.withSpan('OrgAuthInfoExtensions.getConnection'))`
+  - `getUserId` inline gen (:24-29) → `.pipe(Effect.withSpan('OrgAuthInfoExtensions.getUserId'))`
+- gens already inline in `runPromise(...)`; only add `.pipe(...)`.
+
+Commit: `refactor(lwc,core): withSpan on getChannelService + getConnection + getUserId - W-23125840`
+
+## Skills to apply
+
+- effect-best-practices — Effect.fn vs gen rule; gen valid here (Promise wrapper, not effect-returning); withSpan for tracing
+- concise — plan style
+- typescript — build check
+
+## Verification
+
+- per-package effect LS (WI-mandated):
+  - `cd packages/salesforcedx-vscode-lwc && npx effect-language-service diagnostics --project tsconfig.json`
+  - `cd packages/salesforcedx-vscode-core && npx effect-language-service diagnostics --project tsconfig.json`
+  - effect-ext-utils: skip — no change.
+- expect no new `effectFnOpportunity` for these sites (Promise wrappers don't trigger it).
+- tsc per package (compile clean).
+- core: confirm 2 distinct spans (`getConnection`, `getUserId`) added — grep `withSpan('OrgAuthInfoExtensions` → 2 hits.
+- not e2e-covered (internal lazy resolvers); no behavior change — pure tracing add.

--- a/packages/salesforcedx-vscode-core/src/util/orgAuthInfoExtensions.ts
+++ b/packages/salesforcedx-vscode-core/src/util/orgAuthInfoExtensions.ts
@@ -15,7 +15,7 @@ const getConnection = () =>
     Effect.gen(function* () {
       const api = yield* (yield* ExtensionProviderService).getServicesApi;
       return yield* api.services.ConnectionService.getConnection();
-    })
+    }).pipe(Effect.withSpan('OrgAuthInfoExtensions.getConnection'))
   );
 
 /** Get the user ID, preferring the cached TargetOrgRef before falling back to a connection */
@@ -26,7 +26,7 @@ export const getUserId = async (): Promise<string | undefined> => {
       const ref = yield* api.services.TargetOrgRef();
       const { userId } = yield* SubscriptionRef.get(ref);
       return userId;
-    })
+    }).pipe(Effect.withSpan('OrgAuthInfoExtensions.getUserId'))
   );
   if (refUserId) return refUserId;
 

--- a/packages/salesforcedx-vscode-lwc/src/channel/index.ts
+++ b/packages/salesforcedx-vscode-lwc/src/channel/index.ts
@@ -15,7 +15,7 @@ const getChannelService = () =>
     Effect.gen(function* () {
       const api = yield* (yield* ExtensionProviderService).getServicesApi;
       return yield* api.services.ChannelService;
-    })
+    }).pipe(Effect.withSpan('LwcChannel.getChannelService'))
   );
 
 let _channelService: Awaited<ReturnType<typeof getChannelService>> | undefined;


### PR DESCRIPTION
## Summary
- Add `Effect.withSpan` to 3 inline Effect.gen calls across lwc and core packages (getChannelService, getConnection, getUserId)
- Pure tracing enhancement — no behavior change

## Plan
[.claude/plans/W-23125840.md](.claude/plans/W-23125840.md)

## What issues does this PR fix or reference?
@W-23125840@

🤖 Generated by auto-build pipeline. Original WI: https://gus.my.salesforce.com/a07EE00002co7ZyYAI