### PR TITLE
chore(eslint): enable unicorn/prefer-while-loop-condition - W-23094927

### DIFF
--- a/.claude/plans/W-23094927.md
+++ b/.claude/plans/W-23094927.md
@@ -3,7 +3,7 @@
 ## Context
 - Enable `unicorn/prefer-while-loop-condition` (`error`) in `eslint.config.mjs`.
 - Rule: prefer condition in `while` over infinite loop + immediate `break`.
-- No code dependency on W-23094925 (prefer-promise-with-resolvers, PR #7556, still DRAFT): independent rules, no shared edits. Branch off develop; no rebase needed.
+- Independent of W-23094925 (PR #7556 DRAFT); branch from develop.
 - Unicorn v68 (`node_modules/eslint-plugin-unicorn`); rule fixable: `code`.
 - Verified zero violations: only `while(true)`/`for(;;)` matches sit in already-ignored paths:
   - `salesforcedx-visualforce-markup-language-server/src/**` (eslint.config.mjs:47)

--- a/.claude/plans/W-23094927.md
+++ b/.claude/plans/W-23094927.md
@@ -1,0 +1,30 @@
+# W-23094927 — enable unicorn/prefer-while-loop-condition
+
+## Context
+- Enable `unicorn/prefer-while-loop-condition` (`error`) in `eslint.config.mjs`.
+- Rule: prefer condition in `while` over infinite loop + immediate `break`.
+- No code dependency on W-23094925 (prefer-promise-with-resolvers, PR #7556, still DRAFT): independent rules, no shared edits. Branch off develop; no rebase needed.
+- Unicorn v68 (`node_modules/eslint-plugin-unicorn`); rule fixable: `code`.
+- Verified zero violations: only `while(true)`/`for(;;)` matches sit in already-ignored paths:
+  - `salesforcedx-visualforce-markup-language-server/src/**` (eslint.config.mjs:47)
+  - `salesforcedx-aura-language-server/src/tern/**` (:48)
+  - `salesforcedx-vscode-lightning/src/resources/**` (:51)
+- Pure config flip, no source edits.
+
+## Phases
+
+### Phase 1 — enable rule
+- `eslint.config.mjs`: add `'unicorn/prefer-while-loop-condition': 'error'` in unicorn block (after :219 `prefer-simple-condition-first`).
+- Files: `eslint.config.mjs`
+- Commit: `chore(eslint): enable unicorn/prefer-while-loop-condition - W-23094927`
+
+## Skills
+- concise (plan/md)
+- packageJson (n/a — no manifest change)
+- typescript
+- verification
+
+## Verification
+- `npx eslint --rule '{"unicorn/prefer-while-loop-condition":"error"}' "packages/**/*.{ts,js}"` → 0 violations (confirmed pre-write).
+- `npm run lint` clean.
+- Not e2e-covered (lint-config-only change).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -217,6 +217,7 @@ export default [
       'unicorn/prefer-structured-clone': 'error',
       'unicorn/prefer-ternary': ['error'],
       'unicorn/prefer-simple-condition-first': 'error',
+      'unicorn/prefer-while-loop-condition': 'error',
       'unicorn/filename-case': [
         'error',
         {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -214,9 +214,9 @@ export default [
       'unicorn/prefer-single-call': 'error',
       'unicorn/prefer-string-replace-all': 'error',
       'unicorn/prefer-string-starts-ends-with': 'error',
+      'unicorn/prefer-simple-condition-first': 'error',
       'unicorn/prefer-structured-clone': 'error',
       'unicorn/prefer-ternary': ['error'],
-      'unicorn/prefer-simple-condition-first': 'error',
       'unicorn/prefer-while-loop-condition': 'error',
       'unicorn/filename-case': [
         'error',


### PR DESCRIPTION
## Summary

- Enables `unicorn/prefer-while-loop-condition` as `error` in `eslint.config.mjs`.
- Rule enforces using a condition in `while` instead of `while(true)` + immediate `break`; zero existing violations confirmed pre-merge.
- Pure config flip — no source edits required.

## Plan

[.claude/plans/W-23094927.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23094927-enable-unicorn-prefer-while-loop-conditi/.claude/plans/W-23094927.md)

## Reviewer notes

- `eslint.config.mjs:220`: structural confirmation only (single-line config flip, rule present in eslint-plugin-unicorn@68, lint passes) — no defect.

### What issues does this PR fix or reference?
@W-23094927@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cf1jXYAQ/view