### PR TITLE
refactor(apex-log): pickTraceFlag as Effect with considerUndefinedAsCancellation - W-23128627

### DIFF
--- a/packages/salesforcedx-vscode-apex-log/src/commands/traceflags/traceflagsCommands.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/commands/traceflags/traceflagsCommands.ts
@@ -13,6 +13,7 @@ import * as SubscriptionRef from 'effect/SubscriptionRef';
 import type { DebugLevelItem } from 'salesforcedx-vscode-services';
 import * as vscode from 'vscode';
 import { nls } from '../../messages';
+import { isTraceFlagActive } from '../../traceFlags/traceFlagActive';
 import {
   pickDebugLevel,
   pickLogLevel,
@@ -225,14 +226,12 @@ export const deleteTraceFlagForIdCommand = Effect.fn('ApexLog.Command.deleteTrac
   const resolvedId =
     traceFlagId ??
     (yield* Effect.gen(function* () {
-      const flags = yield* traceFlagService.getTraceFlags();
-      const result = yield* Effect.promise(() => pickTraceFlag(flags));
-      if (result.kind === 'noActive') {
+      const active = (yield* traceFlagService.getTraceFlags()).filter(isTraceFlagActive);
+      if (active.length === 0) {
         yield* noActiveFlagsInfo();
         return undefined;
       }
-      if (result.kind === 'cancelled') return undefined;
-      return result.traceFlagId;
+      return yield* pickTraceFlag(active);
     }));
   if (!resolvedId) return;
   yield* traceFlagService.deleteTraceFlag(resolvedId);

--- a/packages/salesforcedx-vscode-apex-log/src/commands/traceflags/traceflagsCommands.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/commands/traceflags/traceflagsCommands.ts
@@ -10,7 +10,7 @@ import * as Duration from 'effect/Duration';
 import * as Effect from 'effect/Effect';
 import * as Option from 'effect/Option';
 import * as SubscriptionRef from 'effect/SubscriptionRef';
-import type { DebugLevelItem } from 'salesforcedx-vscode-services';
+import type { DebugLevelItem, TraceFlagItem } from 'salesforcedx-vscode-services';
 import * as vscode from 'vscode';
 import { nls } from '../../messages';
 import { isTraceFlagActive } from '../../traceFlags/traceFlagActive';
@@ -28,9 +28,7 @@ import { createTraceFlagsUri } from '../../traceFlags/traceFlagsContentProvider'
 const noOrgWarning = () => Effect.promise(() => vscode.window.showWarningMessage(nls.localize('trace_flags_no_org')));
 
 const noActiveFlagsInfo = () =>
-  Effect.sync(() => {
-    void vscode.window.showInformationMessage(nls.localize('trace_flags_none_active'));
-  });
+  Effect.promise(() => vscode.window.showInformationMessage(nls.localize('trace_flags_none_active')));
 
 /** Resolves { api, orgId, userId? }. Shows warning and returns None when org (or userId if required) is missing. */
 const requireOrgContext = Effect.fn('ApexLog.requireOrgContext')(function* (opts?: { requireUserId?: boolean }) {
@@ -215,6 +213,16 @@ export const createLogLevelCommand = Effect.fn('ApexLog.Command.createLogLevel')
   );
 });
 
+/** Resolve a trace flag id via QuickPick over the active subset of `flags`; shows an info message and returns undefined when none are active. */
+const promptForActiveTraceFlagId = Effect.fn('ApexLog.promptForActiveTraceFlagId')(function* (flags: TraceFlagItem[]) {
+  const active = flags.filter(isTraceFlagActive);
+  if (active.length === 0) {
+    yield* noActiveFlagsInfo();
+    return undefined;
+  }
+  return yield* pickTraceFlag(active);
+});
+
 /** Delete trace flag by Id, refresh virtual doc. When no Id is provided (e.g. command palette), prompts via QuickPick. */
 export const deleteTraceFlagForIdCommand = Effect.fn('ApexLog.Command.deleteTraceFlagForId')(function* (
   traceFlagId?: string
@@ -223,16 +231,7 @@ export const deleteTraceFlagForIdCommand = Effect.fn('ApexLog.Command.deleteTrac
   if (Option.isNone(ctx)) return;
   const { api, orgId } = ctx.value;
   const traceFlagService = yield* api.services.TraceFlagService;
-  const resolvedId =
-    traceFlagId ??
-    (yield* Effect.gen(function* () {
-      const active = (yield* traceFlagService.getTraceFlags()).filter(isTraceFlagActive);
-      if (active.length === 0) {
-        yield* noActiveFlagsInfo();
-        return undefined;
-      }
-      return yield* pickTraceFlag(active);
-    }));
+  const resolvedId = traceFlagId ?? (yield* promptForActiveTraceFlagId(yield* traceFlagService.getTraceFlags()));
   if (!resolvedId) return;
   yield* traceFlagService.deleteTraceFlag(resolvedId);
   yield* refreshTraceFlagsView(orgId);

--- a/packages/salesforcedx-vscode-apex-log/src/commands/traceflags/traceflagsCommands.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/commands/traceflags/traceflagsCommands.ts
@@ -27,9 +27,6 @@ import { createTraceFlagsUri } from '../../traceFlags/traceFlagsContentProvider'
 
 const noOrgWarning = () => Effect.promise(() => vscode.window.showWarningMessage(nls.localize('trace_flags_no_org')));
 
-const noActiveFlagsInfo = () =>
-  Effect.promise(() => vscode.window.showInformationMessage(nls.localize('trace_flags_none_active')));
-
 /** Resolves { api, orgId, userId? }. Shows warning and returns None when org (or userId if required) is missing. */
 const requireOrgContext = Effect.fn('ApexLog.requireOrgContext')(function* (opts?: { requireUserId?: boolean }) {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
@@ -89,7 +86,7 @@ export const deleteTraceFlagForCurrentUserCommand = Effect.fn('ApexLog.Command.d
     const traceFlagService = yield* api.services.TraceFlagService;
     const existing = yield* traceFlagService.getTraceFlagForUser(userId!);
     if (Option.isNone(existing)) {
-      yield* noActiveFlagsInfo();
+      yield* Effect.promise(() => vscode.window.showInformationMessage(nls.localize('trace_flags_none_active')));
       return;
     }
     yield* traceFlagService.deleteTraceFlag(existing.value.id);
@@ -217,7 +214,7 @@ export const createLogLevelCommand = Effect.fn('ApexLog.Command.createLogLevel')
 const promptForActiveTraceFlagId = Effect.fn('ApexLog.promptForActiveTraceFlagId')(function* (flags: TraceFlagItem[]) {
   const active = flags.filter(isTraceFlagActive);
   if (active.length === 0) {
-    yield* noActiveFlagsInfo();
+    yield* Effect.promise(() => vscode.window.showInformationMessage(nls.localize('trace_flags_none_active')));
     return undefined;
   }
   return yield* pickTraceFlag(active);

--- a/packages/salesforcedx-vscode-apex-log/src/traceFlags/traceFlagJsonSync.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/traceFlags/traceFlagJsonSync.ts
@@ -17,7 +17,6 @@ import * as Stream from 'effect/Stream';
 import type { DebugLevelItem, TraceFlagItem } from 'salesforcedx-vscode-services';
 import * as vscode from 'vscode';
 import { nls } from '../messages';
-import { isTraceFlagActive } from './traceFlagActive';
 import { TraceFlagsContentProviderService } from './traceFlagsContentProvider';
 
 export const readDefaultDurationMinutes = Effect.fn('ApexLog.readDefaultDurationMinutes')(function* () {
@@ -146,28 +145,25 @@ type DebugLevelQuickPickItem = vscode.QuickPickItem & { debugLevelId: string };
 
 export type TraceFlagQuickPickItem = vscode.QuickPickItem & { traceFlagId: string };
 
-export type PickTraceFlagResult =
-  | { kind: 'noActive' }
-  | { kind: 'cancelled' }
-  | { kind: 'picked'; traceFlagId: string };
-
-/** Show a QuickPick of active trace flags. Returns a discriminated result indicating whether no active flags exist, user cancelled, or a flag was picked. */
-export const pickTraceFlag = async (items: TraceFlagItem[]): Promise<PickTraceFlagResult> => {
-  const active = items.filter(isTraceFlagActive);
-  if (active.length === 0) {
-    return { kind: 'noActive' };
-  }
-  const picked = await vscode.window.showQuickPick<TraceFlagQuickPickItem>(
-    active.map(tf => ({
-      label: tf.tracedEntityName ?? tf.tracedEntityId ?? tf.id,
-      description: tf.logType,
-      detail: `Expires ${tf.expirationDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`,
-      traceFlagId: tf.id
-    })),
-    { placeHolder: nls.localize('trace_flag_pick_trace_flag') }
+/** Show a QuickPick of the given (already active) trace flags; resolves to the picked flag's id.
+ * Fails with UserCancellationError when the user dismisses the picker. Caller must pass a non-empty list. */
+export const pickTraceFlag = Effect.fn('ApexLog.pickTraceFlag')(function* (active: TraceFlagItem[]) {
+  const promptService = yield* (yield* (yield* ExtensionProviderService).getServicesApi).services.PromptService;
+  return yield* Effect.promise(() =>
+    vscode.window.showQuickPick<TraceFlagQuickPickItem>(
+      active.map(tf => ({
+        label: tf.tracedEntityName ?? tf.tracedEntityId ?? tf.id,
+        description: tf.logType,
+        detail: `Expires ${tf.expirationDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`,
+        traceFlagId: tf.id
+      })),
+      { placeHolder: nls.localize('trace_flag_pick_trace_flag') }
+    )
+  ).pipe(
+    Effect.flatMap(promptService.considerUndefinedAsCancellation),
+    Effect.map(picked => picked.traceFlagId)
   );
-  return picked ? { kind: 'picked', traceFlagId: picked.traceFlagId } : { kind: 'cancelled' };
-};
+});
 
 /** Show a QuickPick of org DebugLevels. */
 export const pickDebugLevel = async (items: DebugLevelItem[]): Promise<DebugLevelQuickPickItem | undefined> =>

--- a/packages/salesforcedx-vscode-apex-log/test/unit/traceFlags/pickTraceFlag.test.ts
+++ b/packages/salesforcedx-vscode-apex-log/test/unit/traceFlags/pickTraceFlag.test.ts
@@ -5,6 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
+import * as Effect from 'effect/Effect';
+import * as Exit from 'effect/Exit';
+import { isString } from 'effect/Predicate';
 import type { TraceFlagItem } from 'salesforcedx-vscode-services';
 import * as vscode from 'vscode';
 import { pickTraceFlag, type TraceFlagQuickPickItem } from '../../../src/traceFlags/traceFlagJsonSync';
@@ -13,55 +17,58 @@ const makeFlag = (id: string, overrides: Partial<TraceFlagItem> = {}): TraceFlag
   id,
   logType: 'DEVELOPER_LOG',
   expirationDate: new Date(Date.now() + 60_000),
-  // isActive is a schema field but isTraceFlagActive checks expirationDate against Date.now(), not this boolean
   isActive: true,
   ...overrides
 });
 
 const ACTIVE = makeFlag('tf-active');
-const EXPIRED = makeFlag('tf-expired', { expirationDate: new Date(Date.now() - 1000) });
+
+// Mirrors PromptService.considerUndefinedAsCancellation so the pipe under test exercises the real cancellation path.
+const considerUndefinedAsCancellation = <T>(value: T | undefined) =>
+  value === undefined || (isString(value) && value.trim().length === 0)
+    ? Effect.fail({ _tag: 'UserCancellationError', message: 'User cancelled' })
+    : Effect.succeed(value);
+
+const run = (active: TraceFlagItem[]) =>
+  Effect.runPromiseExit(
+    pickTraceFlag(active).pipe(
+      Effect.provideService(ExtensionProviderService, {
+        getServicesApi: Effect.succeed({
+          services: { PromptService: Effect.succeed({ considerUndefinedAsCancellation }) }
+        })
+      } as unknown as ExtensionProviderService)
+    ) as unknown as Effect.Effect<string, { _tag: string }, never>
+  );
 
 describe('pickTraceFlag', () => {
-  it('returns noActive when there are no active flags', async () => {
-    const result = await pickTraceFlag([EXPIRED]);
-    expect(result).toEqual({ kind: 'noActive' });
-    expect(vscode.window.showQuickPick).not.toHaveBeenCalled();
-  });
-
-  it('returns noActive when the items array is empty', async () => {
-    const result = await pickTraceFlag([]);
-    expect(result).toEqual({ kind: 'noActive' });
-    expect(vscode.window.showQuickPick).not.toHaveBeenCalled();
-  });
-
-  it('calls showQuickPick with active flags and returns picked result', async () => {
+  it('calls showQuickPick with the given flags and resolves the picked traceFlagId', async () => {
     const mockPick: TraceFlagQuickPickItem = { label: ACTIVE.id, traceFlagId: ACTIVE.id };
     jest.mocked(vscode.window.showQuickPick).mockResolvedValue(mockPick as never);
 
-    const result = await pickTraceFlag([ACTIVE, EXPIRED]);
+    const exit = await run([ACTIVE]);
 
     expect(vscode.window.showQuickPick).toHaveBeenCalledTimes(1);
     const [items] = jest.mocked(vscode.window.showQuickPick).mock.calls[0];
-    expect(Array.isArray(items)).toBe(true);
     const typedItems = items as unknown as TraceFlagQuickPickItem[];
     expect(typedItems.map(i => i.traceFlagId)).toEqual([ACTIVE.id]);
-    expect(result).toEqual({ kind: 'picked', traceFlagId: ACTIVE.id });
+    expect(exit).toStrictEqual(Exit.succeed(ACTIVE.id));
   });
 
-  it('returns cancelled when user cancels the QuickPick', async () => {
+  it('fails with UserCancellationError when the user dismisses the QuickPick', async () => {
     jest.mocked(vscode.window.showQuickPick).mockResolvedValue(undefined);
 
-    const result = await pickTraceFlag([ACTIVE]);
+    const exit = await run([ACTIVE]);
 
     expect(vscode.window.showQuickPick).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({ kind: 'cancelled' });
+    expect(Exit.isFailure(exit)).toBe(true);
+    expect(Exit.isFailure(exit) && exit.cause).toMatchObject({ error: { _tag: 'UserCancellationError' } });
   });
 
   it('uses tracedEntityName as the label when available', async () => {
     const flagWithName = makeFlag('tf-named', { tracedEntityName: 'Alice Smith', tracedEntityId: '005ALICE' });
     jest.mocked(vscode.window.showQuickPick).mockResolvedValue(undefined);
 
-    await pickTraceFlag([flagWithName]);
+    await run([flagWithName]);
 
     const [items] = jest.mocked(vscode.window.showQuickPick).mock.calls[0];
     const typedItems = items as unknown as TraceFlagQuickPickItem[];
@@ -73,7 +80,7 @@ describe('pickTraceFlag', () => {
     const flagNoName = makeFlag('tf-noid', { tracedEntityId: '005XYZ' });
     jest.mocked(vscode.window.showQuickPick).mockResolvedValue(undefined);
 
-    await pickTraceFlag([flagNoName]);
+    await run([flagNoName]);
 
     const [items] = jest.mocked(vscode.window.showQuickPick).mock.calls[0];
     const typedItems = items as unknown as TraceFlagQuickPickItem[];
@@ -84,7 +91,7 @@ describe('pickTraceFlag', () => {
     const flagIdOnly = makeFlag('tf-idonly');
     jest.mocked(vscode.window.showQuickPick).mockResolvedValue(undefined);
 
-    await pickTraceFlag([flagIdOnly]);
+    await run([flagIdOnly]);
 
     const [items] = jest.mocked(vscode.window.showQuickPick).mock.calls[0];
     const typedItems = items as unknown as TraceFlagQuickPickItem[];

--- a/packages/salesforcedx-vscode-apex-log/test/unit/traceFlags/pickTraceFlag.test.ts
+++ b/packages/salesforcedx-vscode-apex-log/test/unit/traceFlags/pickTraceFlag.test.ts
@@ -51,6 +51,8 @@ describe('pickTraceFlag', () => {
     const [items] = jest.mocked(vscode.window.showQuickPick).mock.calls[0];
     const typedItems = items as unknown as TraceFlagQuickPickItem[];
     expect(typedItems.map(i => i.traceFlagId)).toEqual([ACTIVE.id]);
+    expect(typedItems[0].description).toBe(ACTIVE.logType);
+    expect(typedItems[0].detail).toMatch(/^Expires /);
     expect(exit).toStrictEqual(Exit.succeed(ACTIVE.id));
   });
 
@@ -64,37 +66,19 @@ describe('pickTraceFlag', () => {
     expect(Exit.isFailure(exit) && exit.cause).toMatchObject({ error: { _tag: 'UserCancellationError' } });
   });
 
-  it('uses tracedEntityName as the label when available', async () => {
-    const flagWithName = makeFlag('tf-named', { tracedEntityName: 'Alice Smith', tracedEntityId: '005ALICE' });
+  it.each([
+    ['tracedEntityName', { tracedEntityName: 'Alice Smith', tracedEntityId: '005ALICE' }, 'Alice Smith'],
+    ['tracedEntityId when name absent', { tracedEntityId: '005XYZ' }, '005XYZ'],
+    ['tf.id when name and entityId absent', {}, 'tf-label']
+  ])('labels the item with %s', async (_desc, overrides, expectedLabel) => {
+    const flag = makeFlag('tf-label', overrides);
     jest.mocked(vscode.window.showQuickPick).mockResolvedValue(undefined);
 
-    await run([flagWithName]);
+    await run([flag]);
 
     const [items] = jest.mocked(vscode.window.showQuickPick).mock.calls[0];
     const typedItems = items as unknown as TraceFlagQuickPickItem[];
-    expect(typedItems[0].label).toBe('Alice Smith');
-    expect(typedItems[0].traceFlagId).toBe('tf-named');
-  });
-
-  it('falls back to tracedEntityId when tracedEntityName is absent', async () => {
-    const flagNoName = makeFlag('tf-noid', { tracedEntityId: '005XYZ' });
-    jest.mocked(vscode.window.showQuickPick).mockResolvedValue(undefined);
-
-    await run([flagNoName]);
-
-    const [items] = jest.mocked(vscode.window.showQuickPick).mock.calls[0];
-    const typedItems = items as unknown as TraceFlagQuickPickItem[];
-    expect(typedItems[0].label).toBe('005XYZ');
-  });
-
-  it('falls back to tf.id when both tracedEntityName and tracedEntityId are absent', async () => {
-    const flagIdOnly = makeFlag('tf-idonly');
-    jest.mocked(vscode.window.showQuickPick).mockResolvedValue(undefined);
-
-    await run([flagIdOnly]);
-
-    const [items] = jest.mocked(vscode.window.showQuickPick).mock.calls[0];
-    const typedItems = items as unknown as TraceFlagQuickPickItem[];
-    expect(typedItems[0].label).toBe('tf-idonly');
+    expect(typedItems[0].label).toBe(expectedLabel);
+    expect(typedItems[0].traceFlagId).toBe('tf-label');
   });
 });


### PR DESCRIPTION
### What does this PR do?

Refactors `pickTraceFlag` from a `Promise<PickTraceFlagResult>` discriminated union into an Effect that fails with `UserCancellationError` on dismiss.

- `pickTraceFlag` is now a conditional-free pipe: `showQuickPick → considerUndefinedAsCancellation → map(traceFlagId)`. Returns `Effect<string, UserCancellationError, ...>`.
- Deletes the `PickTraceFlagResult` (`noActive`/`cancelled`/`picked`) union. Cancellation flows through the standard `UserCancellationError` path that `registerCommandWithLayer` catches silently.
- Caller (`deleteTraceFlagForIdCommand`) owns the `isTraceFlagActive` filter + empty check via extracted `promptForActiveTraceFlagId` helper — picker never receives an empty list.
- `noActiveFlagsInfo` uses `Effect.promise` (consistent with sibling `noOrgWarning`).
- Unit test reworked to run the Effect through a stubbed `ExtensionProviderService`/`PromptService` (matches `orgDelete.test.ts` precedent); asserts picked id, cancellation, and label/description/detail mapping.

### What issues does this PR fix or reference?

@W-23128627@

🤖 Generated with [Claude Code](https://claude.com/claude-code)