### PR TITLE
chore(eslint): enable unicorn/prefer-single-replace - W-23094932

### DIFF
--- a/.claude/plans/W-23094932.md
+++ b/.claude/plans/W-23094932.md
@@ -1,0 +1,39 @@
+# W-23094932 — enable unicorn/prefer-single-replace
+
+## Context
+
+- Rule: `unicorn/prefer-single-replace` — combine chained single-char global replacements into 1 `replaceAll(/[..]/g, ...)`.
+- unicorn v68 installed; rule file `node_modules/eslint-plugin-unicorn/rules/prefer-single-replace.js` exists.
+- Config: `eslint.config.mjs` line ~214 `'unicorn/prefer-single-call'`; insert new rule alphabetically (before `prefer-string-replace-all`).
+- Trigger criteria (verified in rule src): chained `.replaceAll('x',R)` (string, 1 char) or `.replace(/x/g,R)` (single literal char, only g/m/s flags); ALL links share identical string-literal replacement `R`; `R` must not include any searched char; no `$\`` / `$'`.
+- Pattern matches prior WIs (W-23094920/891/898): single config line via `chore(eslint): enable ...` commit.
+- Dependency W-23094931: only a plan commit on develop, not merged. Proceeding per task instruction.
+
+## Violations
+
+- Audited via temp rule injection + targeted eslint + grep.
+- 17 chained-`.replace` sites in linted src; none qualify:
+  - `.ts` candidates: multi-char strings, non-`g` regex, or differing replacement values.
+  - 3 chained `.replaceAll`: `contextMenu.ts` (differing R), `traceFlagJsonSync.ts` (`\W+` multi-char), `newlineUtils.ts` (`\r\n` multi-char) — none trigger.
+  - resource `.js` (aura/visualforce) ignored by eslint config (verified: "File ignored").
+- Net: 0 code changes. Config-only.
+
+## Phases
+
+### Phase 1 — enable rule
+
+- `eslint.config.mjs`: add `'unicorn/prefer-single-replace': 'error',` after `prefer-single-call`.
+- No source refactors (0 violations).
+- Commit: `chore(eslint): enable unicorn/prefer-single-replace - W-23094932`
+
+## Skills
+
+- packageJson — n/a (no dep change; unicorn already present)
+- typescript — eslint config edit touches TypeScript conventions
+- verification
+
+## Verification
+
+- `npm run lint` (or per-pkg lint) clean — 0 new errors.
+- Build local rules first if `packages/eslint-local-rules/out/index.js` missing (config import fails otherwise).
+- Not e2e-covered; lint is the gate.

--- a/.claude/plans/W-23094932.md
+++ b/.claude/plans/W-23094932.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-- Rule: `unicorn/prefer-single-replace` — combine chained single-char global replacements into 1 `replaceAll(/[..]/g, ...)`.
+- Rule: `unicorn/prefer-single-replace` — chains same-replacement single-char replaces into `replaceAll(/[..]/g, ...)`.
 - unicorn v68 installed; rule file `node_modules/eslint-plugin-unicorn/rules/prefer-single-replace.js` exists.
 - Config: `eslint.config.mjs` line ~214 `'unicorn/prefer-single-call'`; insert new rule alphabetically (before `prefer-string-replace-all`).
 - Trigger criteria (verified in rule src): chained `.replaceAll('x',R)` (string, 1 char) or `.replace(/x/g,R)` (single literal char, only g/m/s flags); ALL links share identical string-literal replacement `R`; `R` must not include any searched char; no `$\`` / `$'`.
@@ -16,7 +16,6 @@
   - `.ts` candidates: multi-char strings, non-`g` regex, or differing replacement values.
   - 3 chained `.replaceAll`: `contextMenu.ts` (differing R), `traceFlagJsonSync.ts` (`\W+` multi-char), `newlineUtils.ts` (`\r\n` multi-char) — none trigger.
   - resource `.js` (aura/visualforce) ignored by eslint config (verified: "File ignored").
-- Net: 0 code changes. Config-only.
 
 ## Phases
 
@@ -28,8 +27,8 @@
 
 ## Skills
 
-- packageJson — n/a (no dep change; unicorn already present)
-- typescript — eslint config edit touches TypeScript conventions
+- packageJson — n/a
+- typescript — eslint config
 - verification
 
 ## Verification

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -212,6 +212,7 @@ export default [
       'unicorn/prefer-set-has': 'error',
       'unicorn/prefer-set-size': 'error',
       'unicorn/prefer-single-call': 'error',
+      'unicorn/prefer-single-replace': 'error',
       'unicorn/prefer-string-replace-all': 'error',
       'unicorn/prefer-string-starts-ends-with': 'error',
       'unicorn/prefer-structured-clone': 'error',


### PR DESCRIPTION
## Summary

- Enables `unicorn/prefer-single-replace` ESLint rule (errors on chained single-char replaces that can be merged into one `replaceAll(/[..]/g, ...)`)
- Audited all 17 chained-replace sites in linted source; zero violations found, so no source changes required
- Config line inserted alphabetically after `prefer-single-call` in `eslint.config.mjs`

## Plan

[.claude/plans/W-23094932.md](.claude/plans/W-23094932.md)

### What issues does this PR fix or reference?

@W-23094932@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cf5LBYAY/view