### PR TITLE
docs(gus-cli): use --json flag and jq for CLI tips

### DIFF
--- a/.claude/skills/gus-cli/SKILL.md
+++ b/.claude/skills/gus-cli/SKILL.md
@@ -203,6 +203,6 @@ When completing a work item, use `Closed`.
 
 ## CLI tips
 
-- `--result-format json` for parseable output
-- Strip CLI version warning before JSON parse (`tail -1` or parse last object)
+- `--json` for parseable output (not `--result-format json`)
+- Parse with `jq`, not python
 - `sf data create record` / `sf data update record` for single-record writes


### PR DESCRIPTION
### What issues does this PR fix or reference?

[skip-validate-pr]

### Changes

- Replace `--result-format json` with `--json` in CLI tips
- Replace "parse with python" guidance with "parse with jq"