### PR TITLE
chore(eslint): enable unicorn/no-array-sort-for-min-max - W-23094888

### DIFF
--- a/.claude/plans/W-23094888.md
+++ b/.claude/plans/W-23094888.md
@@ -1,22 +1,22 @@
 # W-23094888 — Enable unicorn/no-array-sort-for-min-max
 
 ## Context
-- Enable `unicorn/no-array-sort-for-min-max`: disallow `[...].sort()[0]` to find min/max; prefer `Math.min`/`Math.max`.
+- Enable `unicorn/no-array-sort-for-min-max`: disallow `[...].sort()[0]` for min/max; prefer `Math.min`/`Math.max`.
 - Rule exists in `eslint-plugin-unicorn` v68 (`node_modules/.../rules/no-array-sort-for-min-max.js`).
 - Depends W-23094887 (`prefer-boolean-return`) — already merged (commit afef5779a).
 - Add to `eslint.config.mjs` `**/*.ts` block, alphabetical: between `unicorn/no-array-sort` (172) and `unicorn/no-boolean-sort-comparator` (173).
 - Prior pattern: single `chore(eslint): enable unicorn/<rule>` commit (e.g. 48f4e16aa, afef5779a).
 
 ## Scope (verified via lint)
-- 0 violations across repo. Confirmed: built `packages/eslint-local-rules` (`npx tsc`), enabled rule, `NODE_OPTIONS=--max-old-space-size=8192 npx eslint .` → 0 `no-array-sort-for-min-max` hits.
-- Pre-existing 217 errors (unused vars in `scripts/`, xsd parsing errors not in tsconfig) — unrelated, present w/o this rule.
+- 0 violations across repo. Built `packages/eslint-local-rules`, enabled rule, ran eslint → 0 `no-array-sort-for-min-max` hits.
+- Pre-existing 217 errors (unused vars `scripts/`, xsd parsing) — unrelated.
 - No-op enablement: config-only, no source fixes.
 
 ## Phases
 
 ### Phase 1 — enable rule
 - Add `'unicorn/no-array-sort-for-min-max': 'error',` after `'unicorn/no-array-sort': 'error',` line in `eslint.config.mjs`.
-- Build local rules first (`packages/eslint-local-rules`: `npx tsc`), else eslint ERR_MODULE_NOT_FOUND.
+- Build local rules first (`packages/eslint-local-rules`), else ERR_MODULE_NOT_FOUND.
 - files: `eslint.config.mjs`
 - commit: `chore(eslint): enable unicorn/no-array-sort-for-min-max - W-23094888`
 
@@ -28,5 +28,4 @@
 
 ## Verification
 - No e2e/runtime impact: pure lint config, 0 source changes.
-- `NODE_OPTIONS=--max-old-space-size=8192 npx eslint .` → 0 `no-array-sort-for-min-max`; error count unchanged vs baseline (217 pre-existing).
 - No unit/Playwright needed — no source touched.

--- a/.claude/plans/W-23094888.md
+++ b/.claude/plans/W-23094888.md
@@ -1,0 +1,32 @@
+# W-23094888 — Enable unicorn/no-array-sort-for-min-max
+
+## Context
+- Enable `unicorn/no-array-sort-for-min-max`: disallow `[...].sort()[0]` to find min/max; prefer `Math.min`/`Math.max`.
+- Rule exists in `eslint-plugin-unicorn` v68 (`node_modules/.../rules/no-array-sort-for-min-max.js`).
+- Depends W-23094887 (`prefer-boolean-return`) — already merged (commit afef5779a).
+- Add to `eslint.config.mjs` `**/*.ts` block, alphabetical: between `unicorn/no-array-sort` (172) and `unicorn/no-boolean-sort-comparator` (173).
+- Prior pattern: single `chore(eslint): enable unicorn/<rule>` commit (e.g. 48f4e16aa, afef5779a).
+
+## Scope (verified via lint)
+- 0 violations across repo. Confirmed: built `packages/eslint-local-rules` (`npx tsc`), enabled rule, `NODE_OPTIONS=--max-old-space-size=8192 npx eslint .` → 0 `no-array-sort-for-min-max` hits.
+- Pre-existing 217 errors (unused vars in `scripts/`, xsd parsing errors not in tsconfig) — unrelated, present w/o this rule.
+- No-op enablement: config-only, no source fixes.
+
+## Phases
+
+### Phase 1 — enable rule
+- Add `'unicorn/no-array-sort-for-min-max': 'error',` after `'unicorn/no-array-sort': 'error',` line in `eslint.config.mjs`.
+- Build local rules first (`packages/eslint-local-rules`: `npx tsc`), else eslint ERR_MODULE_NOT_FOUND.
+- files: `eslint.config.mjs`
+- commit: `chore(eslint): enable unicorn/no-array-sort-for-min-max - W-23094888`
+
+## Skills
+- concise (plan/docs style)
+- typescript (eslint.config.mjs governs TS files)
+- verification (lint gate)
+- changelog (lint-only chore; prior unicorn enables had no entry — confirm none needed)
+
+## Verification
+- No e2e/runtime impact: pure lint config, 0 source changes.
+- `NODE_OPTIONS=--max-old-space-size=8192 npx eslint .` → 0 `no-array-sort-for-min-max`; error count unchanged vs baseline (217 pre-existing).
+- No unit/Playwright needed — no source touched.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -170,6 +170,7 @@ export default [
       'unicorn/explicit-length-check': 'error',
       'unicorn/no-array-reverse': 'error',
       'unicorn/no-array-sort': 'error',
+      'unicorn/no-array-sort-for-min-max': 'error',
       'unicorn/no-boolean-sort-comparator': 'error',
       'unicorn/no-chained-comparison': 'error',
       'unicorn/no-constant-zero-expression': 'error',


### PR DESCRIPTION
## Summary

- Enables `unicorn/no-array-sort-for-min-max` ESLint rule (disallows `[...].sort()[0]` pattern in favour of `Math.min`/`Math.max`)
- Config-only change — 0 violations found across repo; no source fixes required
- Placed alphabetically between `unicorn/no-array-sort` and `unicorn/no-boolean-sort-comparator` in `eslint.config.mjs`

## Plan

[.claude/plans/W-23094888.md](.claude/plans/W-23094888.md)

### What issues does this PR fix or reference?

@W-23094888@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cf1xXYAQ/view