### PR TITLE
docs(gus-cli): match [ai-auto] on title only; note Epic Description__c not filterable

### DIFF
--- a/.claude/skills/gus-cli/SKILL.md
+++ b/.claude/skills/gus-cli/SKILL.md
@@ -132,6 +132,8 @@ sf data query --query "SELECT Id, Name, Description__c FROM ADM_Epic__c WHERE Te
 
 Closed = `Health__c` in ('Completed', 'Canceled'). Use `Description__c` when populated to match work to epic.
 
+**`Description__c` is not filterable in SOQL** — `WHERE`/`LIKE` on it errors `field 'Description__c' can not be filtered in a query call`. To match an epic by text, fetch all open epics and match on `Name`, or post-filter `Description__c` client-side (e.g. with jq). Only `SELECT` it.
+
 ## Epic guide: which work items go where
 
 Use to pick the right Epic\_\_c when creating work. Query epics first; match by Name/Description. Key epics:
@@ -163,9 +165,9 @@ When unsure which epic: ask the user.
 
 `[ai-auto]` in `Subject__c` or `Details__c` opts a WI into the [auto-build-wi workflow](../../workflows/auto-build-wi.js) (claim → plan → build → review → draft PR). See [workflows/README.md](../../workflows/README.md).
 
-- Add only on explicit user request; prefer `Subject__c`
+- Add only on explicit user request; only `Subject__c` (title), never `Details__c`
 - Skip for WIs needing design/coordination
-- Query: `(Subject__c LIKE '%[ai-auto]%' OR Details__c LIKE '%[ai-auto]%')`
+- Query: `Subject__c LIKE '%[ai-auto]%'`
 
 ## Compound workflows
 


### PR DESCRIPTION
Docs-only update to the `gus-cli` skill.

- **`[ai-auto]` matches title only**: the opt-in query drops the `Details__c LIKE` clause and now matches `Subject__c LIKE '%[ai-auto]%'` only, avoiding scans over long rich-text fields. The guidance bullet now says title-only.
- **`ADM_Epic__c.Description__c` is not filterable**: documented that SOQL `WHERE`/`LIKE` on `Description__c` errors (`field 'Description__c' can not be filtered in a query call`). To match an epic by text, fetch open epics and match `Name`, or post-filter client-side.

Note: the `auto-build-wi.js` workflow already queries `Subject__c` only — no change needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)