### PR TITLE
fix(auto-build-wi): treat GUS no-fix statuses (Duplicate, etc.) as terminal

### DIFF
--- a/.claude/skills/gus-cli/SKILL.md
+++ b/.claude/skills/gus-cli/SKILL.md
@@ -82,6 +82,8 @@ Objects: `ADM_Work__c`, `ADM_Epic__c` (not ADM_Theme\_\_c).
 
 Closed statuses: see ## Status\_\_c values. Use `LIMIT 50` (or 100) when querying team or epic work.
 
+**Open-WI queries must ALSO exclude the "Bug no-fix" terminals**: `Duplicate`, `Inactive`, `Never`, `Not a bug`, `Not Reproducible`, `Rejected`, `Eng Internal`. Terminal despite no "Closed" prefix — omit them and a `Duplicate` WI wrongly shows as open.
+
 **Create:** Always set `Story_Points__c=2`, `Product_Tag__c=a1aB000000005G3IAI`, `RecordTypeId`. Include `Subject__c`, `Assignee__c`, `Scrum_Team__c=a00B0000000w9xPIAQ`, `Epic__c` (optional), `QA_Engineer__c` (optional), `Details__c` (optional). Leave `Sprint__c` blank; never modify it. **Details\_\_c:** write concisely—fragments/bullets, minimal words, no repetition (see .claude/skills/concise/SKILL.md).
 
 **`Details__c` ≥20 chars required.** `Details__c` (field label "Description") has a User Story validation rule: <20 chars → create fails with `Description must be at least 20 characters to submit a User Story`. Despite docs marking it optional, treat as required on create. Note: `Description__c` is a DIFFERENT field (label "Comment", unvalidated)—don't confuse them; the validated body field is `Details__c`.
@@ -194,6 +196,8 @@ When unsure which epic: ask the user.
 
 When creating/updating, only use New,In Progress,Ready for Review,QA In Progress,Fixed,Waiting,Closed
 When completing a work item, use `Closed`.
+
+To mark a WI as a duplicate: set `Status__c='Duplicate'` + link the original via `Related_Work__c` (label "Duplicate Of"). `Closed - Duplicate` does NOT persist here — a trigger reverts it to `Duplicate` — so use `Duplicate` directly. `Duplicate` is terminal (treat like Closed) for open/unfinished queries.
 
 **Flow:** New → Acknowledged → Triaged → In Progress → Ready for Review → Fixed → QA In Progress → Completed/Closed
 

--- a/.claude/workflows/auto-build-wi.js
+++ b/.claude/workflows/auto-build-wi.js
@@ -326,8 +326,15 @@ const hasPrUrl = details =>
 // A blocker is "satisfied" only once its work has actually merged — i.e. the WI
 // reached a terminal closed/completed status. 'Ready for Review' / 'Fixed' mean
 // the PR exists but hasn't merged, so a dependency in those states is NOT met.
+// GUS "Bug no-fix" terminal statuses — terminal like Closed/Completed, but the
+// label carries no "Closed" prefix. `Duplicate` is the canonical state for a
+// duplicate WI (the `Closed - Duplicate` status does not persist — a GUS trigger
+// reverts it to `Duplicate`), so the sequencing/dependency gates must count it as done.
+const NO_FIX_TERMINAL = new Set([
+  'Duplicate', 'Inactive', 'Never', 'Not a bug', 'Not Reproducible', 'Rejected', 'Eng Internal',
+])
 const isBlockerSatisfied = status =>
-  status === 'Completed' || status.startsWith('Closed')
+  status === 'Completed' || status.startsWith('Closed') || NO_FIX_TERMINAL.has(status)
 
 // A PR whose ONLY changed file is its own plan (or otherwise empty) has no
 // implementation — the Build phase no-op'd but reported 'done'. Such a PR still


### PR DESCRIPTION
The auto-build-wi sequencing/dependency gate uses `isBlockerSatisfied` to decide whether a prerequisite WI is "done". It counted only `Completed` or `Closed*` statuses, so a sibling WI marked `Duplicate` wrongly blocked a ready WI.

In this GUS org, `Duplicate` is the canonical terminal state for a duplicate WI — the `Closed - Duplicate` status does not persist (a trigger reverts it to `Duplicate`). The same applies to the other GUS "Bug no-fix" terminal statuses, which lack a "Closed" prefix but are terminal.

## Changes
- **`.claude/workflows/auto-build-wi.js`**: add a `NO_FIX_TERMINAL` Set (Duplicate, Inactive, Never, Not a bug, Not Reproducible, Rejected, Eng Internal) and have `isBlockerSatisfied` treat those as done alongside `Completed`/`Closed*`. Used by both the hard-dependency gate and the numeric-sequencing gate.
- **`.claude/skills/gus-cli/SKILL.md`**: note that open-WI queries must also exclude the Bug-no-fix terminals; document marking a WI as a duplicate via `Status__c=Duplicate` + `Related_Work__c` (and that `Closed - Duplicate` reverts via trigger).

No behavior change beyond treating the no-fix statuses as terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)