### PR TITLE
chore(eslint): enable unicorn/no-collection-bracket-access - W-23094893

### DIFF
--- a/.claude/plans/W-23094893.md
+++ b/.claude/plans/W-23094893.md
@@ -12,7 +12,6 @@
 
 ### Phase 1 — enable rule
 - `eslint.config.mjs`: add `'unicorn/no-collection-bracket-access': 'error',` after `no-chained-comparison`
-- no source fixes (0 violations)
 - commit: `chore(eslint): enable unicorn/no-collection-bracket-access - W-23094893`
 
 ## Skills

--- a/.claude/plans/W-23094893.md
+++ b/.claude/plans/W-23094893.md
@@ -1,0 +1,25 @@
+# W-23094893 — Enable unicorn/no-collection-bracket-access
+
+## Context
+- Disallow bracket notation on Map/Set/WeakMap/WeakSet (sets obj prop, not entry)
+- eslint-plugin-unicorn v68; rule exists; suggestions-only (no autofix)
+- Dep W-23094891 (no-chained-comparison): Closed/merged — unblocked
+- Config: root `eslint.config.mjs`, unicorn rules block, alphabetical
+- Insert after `unicorn/no-chained-comparison` (line 175), before `unicorn/no-constant-zero-expression`
+- Probe (rule temporarily enabled, lint `packages/**/*.ts`): 0 violations — no code fixes needed
+
+## Phases
+
+### Phase 1 — enable rule
+- `eslint.config.mjs`: add `'unicorn/no-collection-bracket-access': 'error',` after `no-chained-comparison`
+- no source fixes (0 violations)
+- commit: `chore(eslint): enable unicorn/no-collection-bracket-access - W-23094893`
+
+## Skills
+- concise (plan/docs)
+- typescript
+- verification
+
+## Verification
+- `npm run lint` clean (root) — exercises rule across all pkg lint deps
+- not e2e-covered (lint-only change)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -173,6 +173,7 @@ export default [
       'unicorn/no-array-sort-for-min-max': 'error',
       'unicorn/no-boolean-sort-comparator': 'error',
       'unicorn/no-chained-comparison': 'error',
+      'unicorn/no-collection-bracket-access': 'error',
       'unicorn/no-constant-zero-expression': 'error',
       'unicorn/no-double-comparison': 'error',
       'unicorn/no-duplicate-if-branches': 'error',


### PR DESCRIPTION
## Summary

- Enables `unicorn/no-collection-bracket-access` ESLint rule at `error` severity across all packages
- Rule disallows bracket notation on `Map`/`Set`/`WeakMap`/`WeakSet` (which sets an object property, not a collection entry)
- Zero pre-existing violations — no code changes required, config-only

## Plan

[.claude/plans/W-23094893.md](.claude/plans/W-23094893.md)

### What issues does this PR fix or reference?

@W-23094893@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cfAMdYAM/view