### PR TITLE
refactor(org): migrate org pickers and auth gatherers to Effect and PromptService - W-23069593

### DIFF
--- a/.claude/plans/W-23069593.md
+++ b/.claude/plans/W-23069593.md
@@ -1,0 +1,82 @@
+# W-23069593 — Migrate org pickers + auth gatherers to Effect + PromptService
+
+## Context
+
+- Sequence WI 2; consumes 1.2 (`ConnectionService.listAllAuthorizations`) + 1.3 (`PromptService.considerUndefinedAsCancellation`). Both already landed:
+  - `connectionService.ts:251` `ConnectionService.listAllAuthorizations` wraps `AuthInfo.listAllAuthorizations`, returns `FailedToListAuthorizationsError`.
+  - `promptService.ts:82` `considerUndefinedAsCancellation` — undefined/empty-string → `UserCancellationError`.
+- Targets (pkg `salesforcedx-vscode-org`):
+  - `parameterGatherers/selectOrgForDisplay.ts` — single-pick, `{username}`.
+  - `parameterGatherers/selectDeletableOrg.ts` — multi-pick scratch/sandbox + confirm, `{orgs}`.
+  - `parameterGatherers/selectOrgsForLogout.ts` — multi-pick + confirm, `{usernames}`.
+  - `commands/auth/authParamsGatherer.ts` — `AuthParamsGatherer` / `AccessTokenParamsGatherer` / `ScratchOrgLogoutParamsGatherer`.
+  - `orgPicker/orgList.ts` — `setDefaultOrg` + `buildOrgQuickPickItems` list building.
+- Picker callers (4) all call `AuthInfo.listAllAuthorizations()` direct via the same `Promise.all([getDefaultOrgConfiguration, AuthInfo.listAllAuthorizations, readAliasesByUsernameFromDisk])` prelude + alias-supplement map:
+  - `selectOrgForDisplay.ts:20`, `selectDeletableOrg.ts:24`, `selectOrgsForLogout.ts:20`, `orgPicker/orgList.ts:190`.
+- `orgUtil.ts:264` (`removeExpiredAndDeletedOrgs`) + `orgUtil.ts:442` (`displayRemainingOrgs`) ALSO call `AuthInfo.listAllAuthorizations()` but are NOT picker callers — explicitly OUT OF SCOPE for this WI (no picker, no `considerUndefinedAsCancellation`). `orgUtil.ts:47` already has an Effect `tryPromise` wrapper; leave it.
+- Effect access in pkg: `getOrgRuntime().runPromise(effect)` (`extensionProvider.ts`); api via `(yield* ExtensionProviderService).getServicesApi`; `api.services.ConnectionService` + `api.services.PromptService` (`index.ts:116,387`).
+- Gatherers stay `ParametersGatherer<T>` (sync `gather()` consumed by `SfCommandlet`) — wrap Effect body, `runPromise`, map `UserCancellationError` → `{type:'CANCEL'}`.
+- Migrated reference: `apex-log/createApexClass.ts:28-53` — `Effect.promise(showQuickPick)` → `Effect.flatMap(promptService.considerUndefinedAsCancellation)`.
+
+## Phases
+
+### Phase 1 — shared Effect auth-list helper
+
+- `orgUtil.ts`: add `Effect.fn('orgUtil.getFreshAuthorizations')(function* () { … })` yielding `(yield* ExtensionProviderService).getServicesApi` → `ConnectionService.listAllAuthorizations` + `getDefaultOrgConfiguration` + `readAliasesByUsernameFromDisk`, returns `{defaultConfig, freshAuthorizations}` (alias-supplement map centralized). Span name required per require-effect-fn-span-name.
+- This helper is consumed by the 3 parameterGatherers (Phase 2) + `orgPicker/orgList.ts` `setDefaultOrg` (Phase 3). It does NOT touch `removeExpiredAndDeletedOrgs` (`:264`) or `displayRemainingOrgs` (`:442`) — those are out of scope (see Context); leave their `AuthInfo.listAllAuthorizations` calls intact.
+- Keep `buildOrgQuickPickItems`/`isOrgItem` signatures unchanged.
+- commit: `refactor(org): shared Effect auth-list helper yielding ConnectionService - W-23069593`
+
+### Phase 2 — migrate 3 org pickers
+
+- `selectOrgForDisplay.ts:20`, `selectDeletableOrg.ts:24`, `selectOrgsForLogout.ts:20`: `gather()` body = `getOrgRuntime().runPromise(Effect.gen…)`.
+  - yield `getFreshAuthorizations`; `Effect.promise(showQuickPick(...))` → `considerUndefinedAsCancellation`.
+  - SINGLE-pick (`selectOrgForDisplay`): `considerUndefinedAsCancellation` alone is correct (`undefined` on Esc).
+  - MULTI-pick (`selectDeletableOrg`, `selectOrgsForLogout`): `considerUndefinedAsCancellation` does NOT catch the empty-array cancel path — `[]` is neither `undefined` nor a string (promptService.ts:85 `value === undefined || (isString(value) && value.trim().length === 0)`), so `considerUndefinedAsCancellation([])` returns `Effect.succeed([])` and would CONTINUE with zero orgs. Add an explicit empty-array guard BEFORE the confirm step: `Effect.flatMap(arr => arr === undefined || arr.length === 0 ? Effect.fail(new UserCancellationError()) : Effect.succeed(arr))` (covers both the Esc-`undefined` and pick-nothing-`[]` cases). Then the confirm modal's negative answer also → `UserCancellationError`.
+  - catch `UserCancellationError` → `{type:'CANCEL'}`; map success → `{type:'CONTINUE', data}`.
+- Drop direct `AuthInfo` import where now unused.
+- commit: `refactor(org): pickers yield ConnectionService + considerUndefinedAsCancellation - W-23069593`
+
+### Phase 3 — migrate setDefaultOrg (orgPicker/orgList.ts)
+
+- `orgPicker/orgList.ts:190` `setDefaultOrg`: same Effect body via `getFreshAuthorizations`; `[...ACTION_ITEMS, ...buildOrgQuickPickItems(freshAuthorizations, defaultConfig)]`; `considerUndefinedAsCancellation` on selection (single-pick, no empty-array concern); commandId branch + config-set branch preserved.
+- UPDATE Jest mock: `test/jest/orgPicker/orgList.test.ts:105` mocks `jest.spyOn(AuthInfo, 'listAllAuthorizations')` (`listAllAuthorizationsMock`). After migration the call path goes through `ConnectionService` (not `AuthInfo` direct), so that spy no longer intercepts and `setDefaultOrg` tests would pass vacuously with stale empty data. Replace the `AuthInfo.listAllAuthorizations` spy with a `ConnectionService`-backed mock — mock `getOrgRuntime()` (or supply a `TestLayer` providing a `ConnectionService` whose `listAllAuthorizations` returns the fixture auths) so the data-loading path is actually exercised. Verify the existing assertions still see the seeded orgs (i.e. tests fail if the mock returns nothing).
+- commit: `refactor(org): setDefaultOrg yields ConnectionService - W-23069593`
+
+### Phase 4 — migrate authParamsGatherer
+
+- `AuthParamsGatherer`/`AccessTokenParamsGatherer`/`ScratchOrgLogoutParamsGatherer`: Effect body, `considerUndefinedAsCancellation` on each `showInputBox`/`showQuickPick`/confirm; keep programmatic-`instanceUrl` skip, alias-default `DEFAULT_ALIAS`, reauth-alias logic.
+  - `getProjectLoginUrl` (`authParamsGatherer.ts:194`) is currently bare `Effect.gen(function* () {…})` and is a cross-codebase fn (consumed at `:102`, `:120`). Convert to `Effect.fn('AuthParamsGatherer.getProjectLoginUrl')(function* () {…})` — require-effect-fn-span-name (only shared pipes / service bodies may stay `Effect.gen`; this is a standalone fn). Callers (`getOrgRuntime().runPromise(getProjectLoginUrl)`) need the trailing `()` since `Effect.fn` returns a function: call `getProjectLoginUrl()` at both sites.
+- commit: `refactor(org): auth gatherers use PromptService considerUndefinedAsCancellation - W-23069593`
+
+### Phase 5 — orgPickers e2e spec
+
+- CREATE `test/playwright/specs/orgPickers.desktop.spec.ts` — it does NOT exist yet (specs dir has only `orgCommands`, `orgDeleteCommandVisibility`, `orgPicker`, `telemetryIdentitySeeding`). `orgPicker.desktop.spec.ts` covers `setDefaultOrg` only. Do NOT mark `selectOrgForDisplay`/`selectDeletableOrg`/`selectOrgsForLogout` e2e-covered until this file exists and passes.
+- Fixture: `orgDesktopMinimalDefaultTest` from `desktopFixtures.ts` — sets `minimalTestOrg` (a SCRATCH org, alias `MINIMAL_ORG_ALIAS`) as default. Scratch ⇒ `isScratch === true` ⇒ `sf:default_org_deletable` satisfied (precedent: `orgDeleteCommandVisibility.desktop.spec.ts:19`), and `sf:has_target_org` + `sf:project_opened` satisfied.
+- Command invocation: drive via the command palette by title (same pattern as `orgPicker.desktop.spec.ts` / `orgDeleteCommandVisibility.desktop.spec.ts` — open palette, type the `nls` title, select). Use `packageNls` titles, not raw command IDs. Gate on an activation command first (`verifyCommandExists`) to avoid slow-startup false negatives.
+- Cover:
+  - DISPLAY: `sf.org.display.username` (palette "SFDX: Display Org Details for...", when `sf:project_opened && sf:has_target_org`) → `selectOrgForDisplay` lists the seeded org, pick, assert output-channel table.
+  - DELETE: `sf.org.delete.username` (palette "SFDX: Delete...", when `sf:project_opened`) → this is the picker (`SelectDeletableOrg`) variant per `index.ts:46` → `orgDelete` → `orgDelete.ts:195` `new SelectDeletableOrg()`. NOTE the `default` variant (`sf.org.delete.default`, when `sf:default_org_deletable`) bypasses the picker (`orgDeleteDefaultCommand`) — do NOT use it for this picker spec. Assert `selectDeletableOrg` multi-pick lists the scratch org, then confirm modal. To avoid actually deleting the fixture org, cancel at the confirm modal (Esc/No) and assert CANCEL (no deletion); positive-delete is optional/separate.
+  - LOGOUT: `sf.org.logout.all` (palette "SFDX: Log Out from All Authorized Orgs") → `orgLogoutAll` (`index.ts:55`) → `orgLogout.ts:71` `new SelectOrgsForLogout()` is the multi-pick picker + confirm. (`sf.org.logout.default` bypasses the picker — do not use.) Cancel at confirm to avoid logging out the fixture org.
+  - Cancel paths: Esc on each picker → no error toast (assert CANCEL mapping). For multi-pick, also cover picking nothing then Enter (`[]` empty-array → CANCEL via Phase 2 guard).
+- Reuse helpers: `selectOrgInPicker`, `expectOrgPickerListsOrg`, `selectQuickInputOptionByTyping`, `verifyCommandExists`, `waitForNotification`, `selectOutputChannel`.
+- commit: `test(org): e2e spec for org pickers - W-23069593`
+
+## Skills to apply
+
+- effect-best-practices — `Effect.fn`/`Effect.gen`, tagged-error flow, no `runPromise` inside Effect.
+- playwright-e2e — Phase 5 spec authoring + iteration.
+- services-extension-consumption — `getServicesApi` access pattern.
+- typescript — strict types, no `any`.
+- verification — pre-PR gates.
+- concise — plan/doc style.
+
+## Verification
+
+- e2e-covered ONLY once `orgPickers.desktop.spec.ts` exists and passes (Phase 5). Until the file exists, the three pickers are NOT e2e-covered — do not mark them so. Covers: picker lists org, display/delete/logout pick + confirm flows, Esc cancel, empty-array cancel (multi-pick).
+- Not e2e-covered:
+  - `wireit` typecheck + lint on `salesforcedx-vscode-org` + `salesforcedx-vscode-services`.
+  - Jest: `selectOrgForDisplay`/`selectDeletableOrg`/`selectOrgsForLogout`/`authParamsGatherer.test.ts` pass; `test/jest/orgPicker/orgList.test.ts` UPDATED so the `AuthInfo.listAllAuthorizations` spy (`:105`) is replaced by a `ConnectionService`/`getOrgRuntime` mock (Phase 3) — confirm the test fails if that mock returns nothing (guards against vacuous pass).
+  - grep: no remaining `AuthInfo.listAllAuthorizations` in the 3 pickers or `orgPicker/orgList.ts` `setDefaultOrg`. EXPECTED to remain: `orgUtil.ts:264` (`removeExpiredAndDeletedOrgs`), `orgUtil.ts:442` (`displayRemainingOrgs`), `orgUtil.ts:47` (existing Effect wrapper) — all out of scope.
+  - confirm `UserCancellationError` → `CANCEL` mapping (not surfaced as error toast), including multi-pick empty-array `[]` path.
+  - confirm `getProjectLoginUrl` is `Effect.fn` with span name and both call sites use `getProjectLoginUrl()`.

--- a/.claude/plans/W-23069593.md
+++ b/.claude/plans/W-23069593.md
@@ -23,7 +23,7 @@
 ### Phase 1 — shared Effect auth-list helper
 
 - `orgUtil.ts`: add `Effect.fn('orgUtil.getFreshAuthorizations')(function* () { … })` yielding `(yield* ExtensionProviderService).getServicesApi` → `ConnectionService.listAllAuthorizations` + `getDefaultOrgConfiguration` + `readAliasesByUsernameFromDisk`, returns `{defaultConfig, freshAuthorizations}` (alias-supplement map centralized). Span name required per require-effect-fn-span-name.
-- This helper is consumed by the 3 parameterGatherers (Phase 2) + `orgPicker/orgList.ts` `setDefaultOrg` (Phase 3). It does NOT touch `removeExpiredAndDeletedOrgs` (`:264`) or `displayRemainingOrgs` (`:442`) — those are out of scope (see Context); leave their `AuthInfo.listAllAuthorizations` calls intact.
+- Consumed by the 3 parameterGatherers (Phase 2) + `setDefaultOrg` (Phase 3).
 - Keep `buildOrgQuickPickItems`/`isOrgItem` signatures unchanged.
 - commit: `refactor(org): shared Effect auth-list helper yielding ConnectionService - W-23069593`
 
@@ -32,7 +32,7 @@
 - `selectOrgForDisplay.ts:20`, `selectDeletableOrg.ts:24`, `selectOrgsForLogout.ts:20`: `gather()` body = `getOrgRuntime().runPromise(Effect.gen…)`.
   - yield `getFreshAuthorizations`; `Effect.promise(showQuickPick(...))` → `considerUndefinedAsCancellation`.
   - SINGLE-pick (`selectOrgForDisplay`): `considerUndefinedAsCancellation` alone is correct (`undefined` on Esc).
-  - MULTI-pick (`selectDeletableOrg`, `selectOrgsForLogout`): `considerUndefinedAsCancellation` does NOT catch the empty-array cancel path — `[]` is neither `undefined` nor a string (promptService.ts:85 `value === undefined || (isString(value) && value.trim().length === 0)`), so `considerUndefinedAsCancellation([])` returns `Effect.succeed([])` and would CONTINUE with zero orgs. Add an explicit empty-array guard BEFORE the confirm step: `Effect.flatMap(arr => arr === undefined || arr.length === 0 ? Effect.fail(new UserCancellationError()) : Effect.succeed(arr))` (covers both the Esc-`undefined` and pick-nothing-`[]` cases). Then the confirm modal's negative answer also → `UserCancellationError`.
+  - MULTI-pick: guard empty-array before confirm — `[]` passes `considerUndefinedAsCancellation` (promptService.ts:85 only checks undefined/string); use `considerEmptySelectionAsCancellation` (undefined/`[]` → `UserCancellationError`).
   - catch `UserCancellationError` → `{type:'CANCEL'}`; map success → `{type:'CONTINUE', data}`.
 - Drop direct `AuthInfo` import where now unused.
 - commit: `refactor(org): pickers yield ConnectionService + considerUndefinedAsCancellation - W-23069593`
@@ -40,7 +40,7 @@
 ### Phase 3 — migrate setDefaultOrg (orgPicker/orgList.ts)
 
 - `orgPicker/orgList.ts:190` `setDefaultOrg`: same Effect body via `getFreshAuthorizations`; `[...ACTION_ITEMS, ...buildOrgQuickPickItems(freshAuthorizations, defaultConfig)]`; `considerUndefinedAsCancellation` on selection (single-pick, no empty-array concern); commandId branch + config-set branch preserved.
-- UPDATE Jest mock: `test/jest/orgPicker/orgList.test.ts:105` mocks `jest.spyOn(AuthInfo, 'listAllAuthorizations')` (`listAllAuthorizationsMock`). After migration the call path goes through `ConnectionService` (not `AuthInfo` direct), so that spy no longer intercepts and `setDefaultOrg` tests would pass vacuously with stale empty data. Replace the `AuthInfo.listAllAuthorizations` spy with a `ConnectionService`-backed mock — mock `getOrgRuntime()` (or supply a `TestLayer` providing a `ConnectionService` whose `listAllAuthorizations` returns the fixture auths) so the data-loading path is actually exercised. Verify the existing assertions still see the seeded orgs (i.e. tests fail if the mock returns nothing).
+- UPDATE `orgList.test.ts:105`: replace `AuthInfo.listAllAuthorizations` spy with `ConnectionService`/`getOrgRuntime` mock; confirm test fails if mock returns nothing.
 - commit: `refactor(org): setDefaultOrg yields ConnectionService - W-23069593`
 
 ### Phase 4 — migrate authParamsGatherer
@@ -51,9 +51,9 @@
 
 ### Phase 5 — orgPickers e2e spec
 
-- CREATE `test/playwright/specs/orgPickers.desktop.spec.ts` — it does NOT exist yet (specs dir has only `orgCommands`, `orgDeleteCommandVisibility`, `orgPicker`, `telemetryIdentitySeeding`). `orgPicker.desktop.spec.ts` covers `setDefaultOrg` only. Do NOT mark `selectOrgForDisplay`/`selectDeletableOrg`/`selectOrgsForLogout` e2e-covered until this file exists and passes.
+- CREATE `test/playwright/specs/orgPickers.desktop.spec.ts` (new; existing specs: `orgCommands`, `orgDeleteCommandVisibility`, `orgPicker`, `telemetryIdentitySeeding`). `orgPicker.desktop.spec.ts` covers `setDefaultOrg` only.
 - Fixture: `orgDesktopMinimalDefaultTest` from `desktopFixtures.ts` — sets `minimalTestOrg` (a SCRATCH org, alias `MINIMAL_ORG_ALIAS`) as default. Scratch ⇒ `isScratch === true` ⇒ `sf:default_org_deletable` satisfied (precedent: `orgDeleteCommandVisibility.desktop.spec.ts:19`), and `sf:has_target_org` + `sf:project_opened` satisfied.
-- Command invocation: drive via the command palette by title (same pattern as `orgPicker.desktop.spec.ts` / `orgDeleteCommandVisibility.desktop.spec.ts` — open palette, type the `nls` title, select). Use `packageNls` titles, not raw command IDs. Gate on an activation command first (`verifyCommandExists`) to avoid slow-startup false negatives.
+- Invoke via palette title (`packageNls`); gate on `verifyCommandExists` before each.
 - Cover:
   - DISPLAY: `sf.org.display.username` (palette "SFDX: Display Org Details for...", when `sf:project_opened && sf:has_target_org`) → `selectOrgForDisplay` lists the seeded org, pick, assert output-channel table.
   - DELETE: `sf.org.delete.username` (palette "SFDX: Delete...", when `sf:project_opened`) → this is the picker (`SelectDeletableOrg`) variant per `index.ts:46` → `orgDelete` → `orgDelete.ts:195` `new SelectDeletableOrg()`. NOTE the `default` variant (`sf.org.delete.default`, when `sf:default_org_deletable`) bypasses the picker (`orgDeleteDefaultCommand`) — do NOT use it for this picker spec. Assert `selectDeletableOrg` multi-pick lists the scratch org, then confirm modal. To avoid actually deleting the fixture org, cancel at the confirm modal (Esc/No) and assert CANCEL (no deletion); positive-delete is optional/separate.
@@ -73,7 +73,7 @@
 
 ## Verification
 
-- e2e-covered ONLY once `orgPickers.desktop.spec.ts` exists and passes (Phase 5). Until the file exists, the three pickers are NOT e2e-covered — do not mark them so. Covers: picker lists org, display/delete/logout pick + confirm flows, Esc cancel, empty-array cancel (multi-pick).
+- e2e-covered only after `orgPickers.desktop.spec.ts` passes. Covers: picker lists org, display/delete/logout flows, Esc cancel, empty-array cancel.
 - Not e2e-covered:
   - `wireit` typecheck + lint on `salesforcedx-vscode-org` + `salesforcedx-vscode-services`.
   - Jest: `selectOrgForDisplay`/`selectDeletableOrg`/`selectOrgsForLogout`/`authParamsGatherer.test.ts` pass; `test/jest/orgPicker/orgList.test.ts` UPDATED so the `AuthInfo.listAllAuthorizations` spy (`:105`) is replaced by a `ConnectionService`/`getOrgRuntime` mock (Phase 3) — confirm the test fails if that mock returns nothing (guards against vacuous pass).

--- a/packages/salesforcedx-vscode-org/src/commands/auth/authParamsGatherer.ts
+++ b/packages/salesforcedx-vscode-org/src/commands/auth/authParamsGatherer.ts
@@ -9,8 +9,8 @@ import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import { CancelResponse, ContinueResponse, ParametersGatherer } from '@salesforce/salesforcedx-utils-vscode';
 import * as Effect from 'effect/Effect';
 import * as vscode from 'vscode';
-import { getOrgRuntime } from '../../extensionProvider';
 import { nls } from '../../messages';
+import { runGatherer } from '../../parameterGatherers/runGatherer';
 
 export const DEFAULT_ALIAS = 'vscodeOrg';
 const PRODUCTION_URL = 'https://login.salesforce.com';
@@ -88,6 +88,64 @@ const buildOrgTypes = (projectUrl: string | undefined): Record<string, vscode.Qu
       )
   );
 
+const gatherAuthParams = Effect.fn('AuthParamsGatherer.gather')(function* (params: {
+  readonly instanceUrl: string | undefined;
+  readonly reauthAliasOrUsername: string | undefined;
+}) {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const promptService = yield* api.services.PromptService;
+  const skipAlias = params.instanceUrl !== undefined;
+
+  // allow passing in the instance url programmatically instead of via quick pick
+  const instanceUrl =
+    params.instanceUrl ??
+    (yield* Effect.gen(function* () {
+      const projectUrl = yield* getProjectLoginUrl();
+      const orgTypes = buildOrgTypes(projectUrl);
+      const selection = yield* Effect.promise(() => vscode.window.showQuickPick(Object.values(orgTypes))).pipe(
+        Effect.flatMap(promptService.considerUndefinedAsCancellation)
+      );
+
+      const orgType = selection.label;
+      if (orgType === orgTypes.custom?.label) {
+        return yield* Effect.promise(() =>
+          vscode.window.showInputBox({
+            prompt: nls.localize('parameter_gatherer_enter_custom_url'),
+            placeHolder: PRODUCTION_URL,
+            validateInput: validateUrl
+          })
+        ).pipe(Effect.flatMap(promptService.considerUndefinedAsCancellation));
+      }
+      if (orgType === orgTypes.project?.label) {
+        return projectUrl;
+      }
+      // Dispatch on the localized label, not a hardcoded English literal.
+      return orgType === orgTypes.sandbox?.label ? SANDBOX_URL : PRODUCTION_URL;
+    }));
+
+  const reauthLabel = params.reauthAliasOrUsername?.trim();
+  // Closing the dialog (ESC/cancel) will cancel the operation; hitting enter with no alias defaults to 'vscodeOrg'
+  const alias = skipAlias
+    ? reauthLabel && reauthLabel.length > 0
+      ? reauthLabel
+      : `reauth-${DEFAULT_ALIAS}`
+    : yield* Effect.promise(() =>
+        vscode.window.showInputBox({
+          prompt: nls.localize('parameter_gatherer_enter_alias_name'),
+          placeHolder: DEFAULT_ALIAS
+        })
+      ).pipe(
+        // empty string is a valid "use default alias" answer, so only undefined (Esc) cancels
+        Effect.flatMap(value =>
+          value === undefined ? new api.services.UserCancellationError({}) : Effect.succeed(value)
+        )
+      );
+  return {
+    alias: alias || DEFAULT_ALIAS,
+    loginUrl: instanceUrl ?? PRODUCTION_URL
+  };
+});
+
 export class AuthParamsGatherer implements ParametersGatherer<AuthParams> {
   constructor(
     public instanceUrl: string | undefined,
@@ -96,104 +154,55 @@ export class AuthParamsGatherer implements ParametersGatherer<AuthParams> {
   ) {}
 
   public async gather(): Promise<CancelResponse | ContinueResponse<AuthParams>> {
-    const self = this;
-    return getOrgRuntime().runPromise(
-      Effect.gen(function* () {
-        const api = yield* (yield* ExtensionProviderService).getServicesApi;
-        const promptService = yield* api.services.PromptService;
-        const skipAlias = self.instanceUrl !== undefined;
-        // allow passing in the instance url programmatically instead of via quick pick
-        if (!self.instanceUrl) {
-          const orgTypes = buildOrgTypes(yield* getProjectLoginUrl());
-          const selection = yield* Effect.promise(() => vscode.window.showQuickPick(Object.values(orgTypes))).pipe(
-            Effect.flatMap(promptService.considerUndefinedAsCancellation)
-          );
-
-          const orgType = selection.label;
-          if (orgType === orgTypes.custom?.label) {
-            self.instanceUrl = yield* Effect.promise(() =>
-              vscode.window.showInputBox({
-                prompt: nls.localize('parameter_gatherer_enter_custom_url'),
-                placeHolder: PRODUCTION_URL,
-                validateInput: validateUrl
-              })
-            ).pipe(Effect.flatMap(promptService.considerUndefinedAsCancellation));
-          } else if (orgType === orgTypes.project?.label) {
-            self.instanceUrl = yield* getProjectLoginUrl();
-          } else {
-            self.instanceUrl = orgType === 'Sandbox' ? SANDBOX_URL : PRODUCTION_URL;
-          }
-        }
-
-        const reauthLabel = self.reauthAliasOrUsername?.trim();
-        // Closing the dialog (ESC/cancel) will cancel the operation; hitting enter with no alias defaults to 'vscodeOrg'
-        const alias = skipAlias
-          ? reauthLabel && reauthLabel.length > 0
-            ? reauthLabel
-            : `reauth-${DEFAULT_ALIAS}`
-          : yield* Effect.promise(() =>
-              vscode.window.showInputBox({
-                prompt: nls.localize('parameter_gatherer_enter_alias_name'),
-                placeHolder: DEFAULT_ALIAS
-              })
-            ).pipe(
-              // empty string is a valid "use default alias" answer, so only undefined (Esc) cancels
-              Effect.flatMap(value =>
-                value === undefined ? new api.services.UserCancellationError({}) : Effect.succeed(value)
-              )
-            );
-        return {
-          alias: alias || DEFAULT_ALIAS,
-          loginUrl: self.instanceUrl ?? PRODUCTION_URL
-        };
-      }).pipe(
-        Effect.map((data): ContinueResponse<AuthParams> => ({ type: 'CONTINUE', data })),
-        Effect.catchTag(
-          'UserCancellationError',
-          (): Effect.Effect<CancelResponse> => Effect.succeed({ type: 'CANCEL' })
-        )
-      )
+    return runGatherer(
+      gatherAuthParams({ instanceUrl: this.instanceUrl, reauthAliasOrUsername: this.reauthAliasOrUsername })
     );
   }
 }
+
+const gatherAccessTokenParams = Effect.fn('AccessTokenParamsGatherer.gather')(function* () {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const promptService = yield* api.services.PromptService;
+
+  const instanceUrl = yield* Effect.promise(inputInstanceUrl).pipe(
+    Effect.flatMap(promptService.considerUndefinedAsCancellation)
+  );
+
+  // empty string is a valid "use default alias" answer, so only undefined (Esc) cancels
+  const alias = yield* Effect.promise(inputAlias).pipe(
+    Effect.flatMap(value => (value === undefined ? new api.services.UserCancellationError({}) : Effect.succeed(value)))
+  );
+
+  const accessToken = yield* Effect.promise(inputAccessToken).pipe(
+    Effect.flatMap(promptService.considerUndefinedAsCancellation)
+  );
+
+  return {
+    accessToken,
+    alias: alias || DEFAULT_ALIAS,
+    instanceUrl
+  };
+});
 
 export class AccessTokenParamsGatherer implements ParametersGatherer<AccessTokenParams> {
   public async gather(): Promise<CancelResponse | ContinueResponse<AccessTokenParams>> {
-    return getOrgRuntime().runPromise(
-      Effect.gen(function* () {
-        const api = yield* (yield* ExtensionProviderService).getServicesApi;
-        const promptService = yield* api.services.PromptService;
-
-        const instanceUrl = yield* Effect.promise(inputInstanceUrl).pipe(
-          Effect.flatMap(promptService.considerUndefinedAsCancellation)
-        );
-
-        // empty string is a valid "use default alias" answer, so only undefined (Esc) cancels
-        const alias = yield* Effect.promise(inputAlias).pipe(
-          Effect.flatMap(value =>
-            value === undefined ? new api.services.UserCancellationError({}) : Effect.succeed(value)
-          )
-        );
-
-        const accessToken = yield* Effect.promise(inputAccessToken).pipe(
-          Effect.flatMap(promptService.considerUndefinedAsCancellation)
-        );
-
-        return {
-          accessToken,
-          alias: alias || DEFAULT_ALIAS,
-          instanceUrl
-        };
-      }).pipe(
-        Effect.map((data): ContinueResponse<AccessTokenParams> => ({ type: 'CONTINUE', data })),
-        Effect.catchTag(
-          'UserCancellationError',
-          (): Effect.Effect<CancelResponse> => Effect.succeed({ type: 'CANCEL' })
-        )
-      )
-    );
+    return runGatherer(gatherAccessTokenParams());
   }
 }
+
+const gatherScratchOrgLogout = Effect.fn('ScratchOrgLogoutParamsGatherer.gather')(function* (params: {
+  readonly username: string;
+  readonly alias: string | undefined;
+}) {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const promptService = yield* api.services.PromptService;
+
+  yield* promptService.confirmOrThrow({
+    message: nls.localize('org_logout_scratch_prompt', params.alias ?? params.username),
+    confirmLabel: nls.localize('org_logout_scratch_logout')
+  });
+  return params.username;
+});
 
 export class ScratchOrgLogoutParamsGatherer implements ParametersGatherer<string> {
   constructor(
@@ -202,28 +211,7 @@ export class ScratchOrgLogoutParamsGatherer implements ParametersGatherer<string
   ) {}
 
   public async gather(): Promise<CancelResponse | ContinueResponse<string>> {
-    const self = this;
-    return getOrgRuntime().runPromise(
-      Effect.gen(function* () {
-        const api = yield* (yield* ExtensionProviderService).getServicesApi;
-        const prompt = nls.localize('org_logout_scratch_prompt', self.alias ?? self.username);
-        const logoutResponse = nls.localize('org_logout_scratch_logout');
-
-        const confirm = yield* Effect.promise(() =>
-          vscode.window.showInformationMessage(prompt, { modal: true }, logoutResponse)
-        );
-        if (confirm !== logoutResponse) {
-          return yield* new api.services.UserCancellationError({});
-        }
-        return self.username;
-      }).pipe(
-        Effect.map((data): ContinueResponse<string> => ({ type: 'CONTINUE', data })),
-        Effect.catchTag(
-          'UserCancellationError',
-          (): Effect.Effect<CancelResponse> => Effect.succeed({ type: 'CANCEL' })
-        )
-      )
-    );
+    return runGatherer(gatherScratchOrgLogout({ username: this.username, alias: this.alias }));
   }
 }
 

--- a/packages/salesforcedx-vscode-org/src/commands/auth/authParamsGatherer.ts
+++ b/packages/salesforcedx-vscode-org/src/commands/auth/authParamsGatherer.ts
@@ -96,83 +96,102 @@ export class AuthParamsGatherer implements ParametersGatherer<AuthParams> {
   ) {}
 
   public async gather(): Promise<CancelResponse | ContinueResponse<AuthParams>> {
-    const skipAlias = this.instanceUrl !== undefined;
-    // allow passing in the instance url programmatically instead of via quick pick
-    if (!this.instanceUrl) {
-      const orgTypes = buildOrgTypes(await getOrgRuntime().runPromise(getProjectLoginUrl));
-      const selection = await vscode.window.showQuickPick(Object.values(orgTypes));
-      if (!selection) {
-        return { type: 'CANCEL' };
-      }
+    const self = this;
+    return getOrgRuntime().runPromise(
+      Effect.gen(function* () {
+        const api = yield* (yield* ExtensionProviderService).getServicesApi;
+        const promptService = yield* api.services.PromptService;
+        const skipAlias = self.instanceUrl !== undefined;
+        // allow passing in the instance url programmatically instead of via quick pick
+        if (!self.instanceUrl) {
+          const orgTypes = buildOrgTypes(yield* getProjectLoginUrl());
+          const selection = yield* Effect.promise(() => vscode.window.showQuickPick(Object.values(orgTypes))).pipe(
+            Effect.flatMap(promptService.considerUndefinedAsCancellation)
+          );
 
-      const orgType = selection.label;
-      if (orgType === orgTypes.custom?.label) {
-        const customUrlInputOptions = {
-          prompt: nls.localize('parameter_gatherer_enter_custom_url'),
-          placeHolder: PRODUCTION_URL,
-          validateInput: validateUrl
-        };
-        this.instanceUrl = await vscode.window.showInputBox(customUrlInputOptions);
-        if (this.instanceUrl === undefined) {
-          return { type: 'CANCEL' };
+          const orgType = selection.label;
+          if (orgType === orgTypes.custom?.label) {
+            self.instanceUrl = yield* Effect.promise(() =>
+              vscode.window.showInputBox({
+                prompt: nls.localize('parameter_gatherer_enter_custom_url'),
+                placeHolder: PRODUCTION_URL,
+                validateInput: validateUrl
+              })
+            ).pipe(Effect.flatMap(promptService.considerUndefinedAsCancellation));
+          } else if (orgType === orgTypes.project?.label) {
+            self.instanceUrl = yield* getProjectLoginUrl();
+          } else {
+            self.instanceUrl = orgType === 'Sandbox' ? SANDBOX_URL : PRODUCTION_URL;
+          }
         }
-      } else if (orgType === orgTypes.project?.label) {
-        this.instanceUrl = await getOrgRuntime().runPromise(getProjectLoginUrl);
-      } else {
-        this.instanceUrl = orgType === 'Sandbox' ? SANDBOX_URL : PRODUCTION_URL;
-      }
-    }
 
-    const reauthLabel = this.reauthAliasOrUsername?.trim();
-    const alias = skipAlias
-      ? reauthLabel && reauthLabel.length > 0
-        ? reauthLabel
-        : `reauth-${DEFAULT_ALIAS}`
-      : await vscode.window.showInputBox({
-          prompt: nls.localize('parameter_gatherer_enter_alias_name'),
-          placeHolder: DEFAULT_ALIAS
-        });
-    // Closing the dialog (ESC/cancel) will cancel the operation
-    if (alias === undefined) {
-      return { type: 'CANCEL' };
-    }
-    // Hitting enter with no alias will default the alias to 'vscodeOrg'
-    return {
-      type: 'CONTINUE',
-      data: {
-        alias: alias || DEFAULT_ALIAS,
-        loginUrl: this.instanceUrl ?? PRODUCTION_URL
-      }
-    };
+        const reauthLabel = self.reauthAliasOrUsername?.trim();
+        // Closing the dialog (ESC/cancel) will cancel the operation; hitting enter with no alias defaults to 'vscodeOrg'
+        const alias = skipAlias
+          ? reauthLabel && reauthLabel.length > 0
+            ? reauthLabel
+            : `reauth-${DEFAULT_ALIAS}`
+          : yield* Effect.promise(() =>
+              vscode.window.showInputBox({
+                prompt: nls.localize('parameter_gatherer_enter_alias_name'),
+                placeHolder: DEFAULT_ALIAS
+              })
+            ).pipe(
+              // empty string is a valid "use default alias" answer, so only undefined (Esc) cancels
+              Effect.flatMap(value =>
+                value === undefined ? new api.services.UserCancellationError({}) : Effect.succeed(value)
+              )
+            );
+        return {
+          alias: alias || DEFAULT_ALIAS,
+          loginUrl: self.instanceUrl ?? PRODUCTION_URL
+        };
+      }).pipe(
+        Effect.map((data): ContinueResponse<AuthParams> => ({ type: 'CONTINUE', data })),
+        Effect.catchTag(
+          'UserCancellationError',
+          (): Effect.Effect<CancelResponse> => Effect.succeed({ type: 'CANCEL' })
+        )
+      )
+    );
   }
 }
 
 export class AccessTokenParamsGatherer implements ParametersGatherer<AccessTokenParams> {
   public async gather(): Promise<CancelResponse | ContinueResponse<AccessTokenParams>> {
-    const instanceUrl = await inputInstanceUrl();
-    if (instanceUrl === undefined) {
-      return { type: 'CANCEL' };
-    }
+    return getOrgRuntime().runPromise(
+      Effect.gen(function* () {
+        const api = yield* (yield* ExtensionProviderService).getServicesApi;
+        const promptService = yield* api.services.PromptService;
 
-    const alias = await inputAlias();
-    // Closing the dialog (ESC/cancel) will cancel the operation
-    if (alias === undefined) {
-      return { type: 'CANCEL' };
-    }
+        const instanceUrl = yield* Effect.promise(inputInstanceUrl).pipe(
+          Effect.flatMap(promptService.considerUndefinedAsCancellation)
+        );
 
-    const accessToken = await inputAccessToken();
-    if (accessToken === undefined) {
-      return { type: 'CANCEL' };
-    }
-    // Hitting enter with no alias will default the alias to 'vscodeOrg'
-    return {
-      type: 'CONTINUE',
-      data: {
-        accessToken,
-        alias: alias || DEFAULT_ALIAS,
-        instanceUrl
-      }
-    };
+        // empty string is a valid "use default alias" answer, so only undefined (Esc) cancels
+        const alias = yield* Effect.promise(inputAlias).pipe(
+          Effect.flatMap(value =>
+            value === undefined ? new api.services.UserCancellationError({}) : Effect.succeed(value)
+          )
+        );
+
+        const accessToken = yield* Effect.promise(inputAccessToken).pipe(
+          Effect.flatMap(promptService.considerUndefinedAsCancellation)
+        );
+
+        return {
+          accessToken,
+          alias: alias || DEFAULT_ALIAS,
+          instanceUrl
+        };
+      }).pipe(
+        Effect.map((data): ContinueResponse<AccessTokenParams> => ({ type: 'CONTINUE', data })),
+        Effect.catchTag(
+          'UserCancellationError',
+          (): Effect.Effect<CancelResponse> => Effect.succeed({ type: 'CANCEL' })
+        )
+      )
+    );
   }
 }
 
@@ -183,15 +202,32 @@ export class ScratchOrgLogoutParamsGatherer implements ParametersGatherer<string
   ) {}
 
   public async gather(): Promise<CancelResponse | ContinueResponse<string>> {
-    const prompt = nls.localize('org_logout_scratch_prompt', this.alias ?? this.username);
-    const logoutResponse = nls.localize('org_logout_scratch_logout');
+    const self = this;
+    return getOrgRuntime().runPromise(
+      Effect.gen(function* () {
+        const api = yield* (yield* ExtensionProviderService).getServicesApi;
+        const prompt = nls.localize('org_logout_scratch_prompt', self.alias ?? self.username);
+        const logoutResponse = nls.localize('org_logout_scratch_logout');
 
-    const confirm = await vscode.window.showInformationMessage(prompt, { modal: true }, logoutResponse);
-    return confirm === logoutResponse ? { type: 'CONTINUE', data: this.username } : { type: 'CANCEL' };
+        const confirm = yield* Effect.promise(() =>
+          vscode.window.showInformationMessage(prompt, { modal: true }, logoutResponse)
+        );
+        if (confirm !== logoutResponse) {
+          return yield* new api.services.UserCancellationError({});
+        }
+        return self.username;
+      }).pipe(
+        Effect.map((data): ContinueResponse<string> => ({ type: 'CONTINUE', data })),
+        Effect.catchTag(
+          'UserCancellationError',
+          (): Effect.Effect<CancelResponse> => Effect.succeed({ type: 'CANCEL' })
+        )
+      )
+    );
   }
 }
 
-const getProjectLoginUrl = Effect.gen(function* () {
+const getProjectLoginUrl = Effect.fn('AuthParamsGatherer.getProjectLoginUrl')(function* () {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const project = yield* api.services.ProjectService.getSfProject();
   const projectJson = yield* Effect.tryPromise(() => project.retrieveSfProjectJson());

--- a/packages/salesforcedx-vscode-org/src/extensionProvider.ts
+++ b/packages/salesforcedx-vscode-org/src/extensionProvider.ts
@@ -25,8 +25,11 @@ export const setAllServicesLayer = (layer: ReturnType<typeof buildAllServicesLay
  * Single persistent runtime for org extension Effect executions.
  * Built once on first use to avoid rebuilding services across commands.
  */
+/** Services provided by the org runtime (the `R` channel an Effect may require when run via {@link getOrgRuntime}). */
+export type OrgRuntimeContext = Layer.Layer.Success<ReturnType<typeof buildAllServicesLayer>>;
+
 type OrgRuntime = ManagedRuntime.ManagedRuntime<
-  Layer.Layer.Success<ReturnType<typeof buildAllServicesLayer>>,
+  OrgRuntimeContext,
   Layer.Layer.Error<ReturnType<typeof buildAllServicesLayer>>
 >;
 let _orgRuntime: OrgRuntime | undefined;

--- a/packages/salesforcedx-vscode-org/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-org/src/orgPicker/orgList.ts
@@ -185,31 +185,33 @@ export const buildOrgQuickPickItems = (
   });
 };
 
+const setDefaultOrgEffect = Effect.fn('OrgList.setDefaultOrg')(function* () {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const promptService = yield* api.services.PromptService;
+  const { defaultConfig, freshAuthorizations } = yield* getFreshAuthorizations();
+
+  const quickPickList = [...ACTION_ITEMS, ...buildOrgQuickPickItems(freshAuthorizations, defaultConfig)];
+
+  const selection: OrgQuickPickItem = yield* Effect.promise(() =>
+    vscode.window.showQuickPick(quickPickList, {
+      placeHolder: nls.localize('org_select_text'),
+      matchOnDescription: true,
+      matchOnDetail: true
+    })
+  ).pipe(Effect.flatMap(promptService.considerUndefinedAsCancellation));
+
+  if (selection.commandId) {
+    vscode.commands.executeCommand(selection.commandId);
+    return;
+  }
+
+  const usernameOrAlias = selection.orgAlias ?? selection.orgUsername ?? '';
+  vscode.commands.executeCommand('sf.config.set', usernameOrAlias);
+});
+
 export const setDefaultOrg = async (): Promise<CancelResponse | ContinueResponse<{}>> =>
   getOrgRuntime().runPromise(
-    Effect.gen(function* () {
-      const api = yield* (yield* ExtensionProviderService).getServicesApi;
-      const promptService = yield* api.services.PromptService;
-      const { defaultConfig, freshAuthorizations } = yield* getFreshAuthorizations();
-
-      const quickPickList = [...ACTION_ITEMS, ...buildOrgQuickPickItems(freshAuthorizations, defaultConfig)];
-
-      const selection: OrgQuickPickItem = yield* Effect.promise(() =>
-        vscode.window.showQuickPick(quickPickList, {
-          placeHolder: nls.localize('org_select_text'),
-          matchOnDescription: true,
-          matchOnDetail: true
-        })
-      ).pipe(Effect.flatMap(promptService.considerUndefinedAsCancellation));
-
-      if (selection.commandId) {
-        vscode.commands.executeCommand(selection.commandId);
-        return;
-      }
-
-      const usernameOrAlias = selection.orgAlias ?? selection.orgUsername ?? '';
-      vscode.commands.executeCommand('sf.config.set', usernameOrAlias);
-    }).pipe(
+    setDefaultOrgEffect().pipe(
       Effect.map((): ContinueResponse<{}> => ({ type: 'CONTINUE', data: {} })),
       Effect.catchTag('UserCancellationError', (): Effect.Effect<CancelResponse> => Effect.succeed({ type: 'CANCEL' }))
     )

--- a/packages/salesforcedx-vscode-org/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-org/src/orgPicker/orgList.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { AuthInfo, OrgAuthorization } from '@salesforce/core';
+import { OrgAuthorization } from '@salesforce/core';
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import { CancelResponse, ContinueResponse } from '@salesforce/salesforcedx-utils-vscode';
 import { ICONS, type DefaultOrgInfoSchema } from '@salesforce/vscode-services';
@@ -14,12 +14,13 @@ import * as Order from 'effect/Order';
 import * as Stream from 'effect/Stream';
 import * as vscode from 'vscode';
 import { ORG_OPEN_COMMAND } from '../constants';
+import { getOrgRuntime } from '../extensionProvider';
 import { nls } from '../messages';
 import {
   determineOrgMarkers,
   getAuthFieldsFor,
   getDefaultOrgConfiguration,
-  readAliasesByUsernameFromDisk
+  getFreshAuthorizations
 } from '../util/orgUtil';
 
 type OrgType = 'DevHub' | 'Sandbox' | 'Scratch' | 'Org';
@@ -184,40 +185,35 @@ export const buildOrgQuickPickItems = (
   });
 };
 
-export const setDefaultOrg = async (): Promise<CancelResponse | ContinueResponse<{}>> => {
-  const [defaultConfig, authorizations, aliasesByUsername] = await Promise.all([
-    getDefaultOrgConfiguration(),
-    AuthInfo.listAllAuthorizations(),
-    readAliasesByUsernameFromDisk()
-  ]);
+export const setDefaultOrg = async (): Promise<CancelResponse | ContinueResponse<{}>> =>
+  getOrgRuntime().runPromise(
+    Effect.gen(function* () {
+      const api = yield* (yield* ExtensionProviderService).getServicesApi;
+      const promptService = yield* api.services.PromptService;
+      const { defaultConfig, freshAuthorizations } = yield* getFreshAuthorizations();
 
-  // Supplement stale StateAggregator alias data with fresh disk data
-  const freshAuthorizations = authorizations.map(org =>
-    org.aliases?.length ? org : { ...org, aliases: aliasesByUsername.get(org.username) ?? [] }
+      const quickPickList = [...ACTION_ITEMS, ...buildOrgQuickPickItems(freshAuthorizations, defaultConfig)];
+
+      const selection: OrgQuickPickItem = yield* Effect.promise(() =>
+        vscode.window.showQuickPick(quickPickList, {
+          placeHolder: nls.localize('org_select_text'),
+          matchOnDescription: true,
+          matchOnDetail: true
+        })
+      ).pipe(Effect.flatMap(promptService.considerUndefinedAsCancellation));
+
+      if (selection.commandId) {
+        vscode.commands.executeCommand(selection.commandId);
+        return;
+      }
+
+      const usernameOrAlias = selection.orgAlias ?? selection.orgUsername ?? '';
+      vscode.commands.executeCommand('sf.config.set', usernameOrAlias);
+    }).pipe(
+      Effect.map((): ContinueResponse<{}> => ({ type: 'CONTINUE', data: {} })),
+      Effect.catchTag('UserCancellationError', (): Effect.Effect<CancelResponse> => Effect.succeed({ type: 'CANCEL' }))
+    )
   );
-
-  const quickPickList = [...ACTION_ITEMS, ...buildOrgQuickPickItems(freshAuthorizations, defaultConfig)];
-
-  const selection = await vscode.window.showQuickPick(quickPickList, {
-    placeHolder: nls.localize('org_select_text'),
-    matchOnDescription: true,
-    matchOnDetail: true
-  });
-
-  if (!selection) {
-    return { type: 'CANCEL' };
-  }
-
-  const orgItem: OrgQuickPickItem = selection;
-  if (orgItem.commandId) {
-    vscode.commands.executeCommand(orgItem.commandId);
-    return { type: 'CONTINUE', data: {} };
-  }
-
-  const usernameOrAlias = orgItem.orgAlias ?? orgItem.orgUsername ?? '';
-  vscode.commands.executeCommand('sf.config.set', usernameOrAlias);
-  return { type: 'CONTINUE', data: {} };
-};
 
 /** Create and initialize OrgList with Effect-based TargetOrgRef watching */
 export const createOrgPicker = Effect.fn('OrgPicker.createOrgPicker')(function* () {

--- a/packages/salesforcedx-vscode-org/src/parameterGatherers/runGatherer.ts
+++ b/packages/salesforcedx-vscode-org/src/parameterGatherers/runGatherer.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { CancelResponse, ContinueResponse } from '@salesforce/salesforcedx-utils-vscode';
+import * as Effect from 'effect/Effect';
+import type { UserCancellationError } from 'salesforcedx-vscode-services';
+import { getOrgRuntime, OrgRuntimeContext } from '../extensionProvider';
+
+/**
+ * Run a gatherer Effect through the org runtime, mapping success to `ContinueResponse<T>` and any
+ * `UserCancellationError` to `CancelResponse`. Other errors reject the returned promise (matching the
+ * pre-refactor behavior where only the cancellation tag was caught). Collapses the CONTINUE/CANCEL
+ * plumbing every `ParametersGatherer` would otherwise repeat.
+ */
+export const runGatherer = <T, E>(
+  effect: Effect.Effect<T, E | UserCancellationError, OrgRuntimeContext>
+): Promise<CancelResponse | ContinueResponse<T>> =>
+  getOrgRuntime().runPromise(
+    effect.pipe(
+      Effect.map((data): ContinueResponse<T> => ({ type: 'CONTINUE', data })),
+      Effect.catchTag('UserCancellationError', (): Effect.Effect<CancelResponse> => Effect.succeed({ type: 'CANCEL' }))
+    )
+  );

--- a/packages/salesforcedx-vscode-org/src/parameterGatherers/selectDeletableOrg.ts
+++ b/packages/salesforcedx-vscode-org/src/parameterGatherers/selectDeletableOrg.ts
@@ -5,12 +5,15 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthInfo, OrgAuthorization } from '@salesforce/core';
+import { OrgAuthorization } from '@salesforce/core';
+import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import type { CancelResponse, ContinueResponse, ParametersGatherer } from '@salesforce/salesforcedx-utils-vscode';
+import * as Effect from 'effect/Effect';
 import * as vscode from 'vscode';
+import { getOrgRuntime } from '../extensionProvider';
 import { nls } from '../messages';
 import { buildOrgQuickPickItems, isOrgItem } from '../orgPicker/orgList';
-import { getDefaultOrgConfiguration, readAliasesByUsernameFromDisk } from '../util/orgUtil';
+import { getFreshAuthorizations } from '../util/orgUtil';
 
 export type OrgToDelete = { username: string; orgType: 'scratch' | 'sandbox' };
 
@@ -19,50 +22,60 @@ const isDeletable = (org: OrgAuthorization): boolean => org.isScratchOrg === tru
 /** Multi-select QuickPick filtered to scratch orgs and sandboxes with a delete confirmation. */
 export class SelectDeletableOrg implements ParametersGatherer<{ orgs: OrgToDelete[] }> {
   public async gather(): Promise<CancelResponse | ContinueResponse<{ orgs: OrgToDelete[] }>> {
-    const [defaultConfig, authorizations, aliasesByUsername] = await Promise.all([
-      getDefaultOrgConfiguration(),
-      AuthInfo.listAllAuthorizations(),
-      readAliasesByUsernameFromDisk()
-    ]);
+    return getOrgRuntime().runPromise(
+      Effect.gen(function* () {
+        const api = yield* (yield* ExtensionProviderService).getServicesApi;
+        const { defaultConfig, freshAuthorizations } = yield* getFreshAuthorizations();
 
-    const freshAuthorizations = authorizations.map(org =>
-      org.aliases?.length ? org : { ...org, aliases: aliasesByUsername.get(org.username) ?? [] }
+        const items = buildOrgQuickPickItems(freshAuthorizations, defaultConfig, isDeletable);
+        const selections = yield* Effect.promise(() =>
+          vscode.window.showQuickPick(items, {
+            placeHolder: nls.localize('org_delete_select_orgs_placeholder'),
+            canPickMany: true,
+            matchOnDescription: true,
+            matchOnDetail: true
+          })
+        ).pipe(
+          // Multi-pick: considerUndefinedAsCancellation does not catch the empty-array (pick-nothing) cancel.
+          Effect.flatMap(selected =>
+            selected === undefined || selected.length === 0
+              ? new api.services.UserCancellationError({})
+              : Effect.succeed(selected)
+          )
+        );
+
+        const targetOrgs: OrgToDelete[] = selections.filter(isOrgItem).flatMap(s => {
+          if (!s.orgUsername) return [];
+          const auth = freshAuthorizations.find(o => o.username === s.orgUsername);
+          const orgType = auth?.isScratchOrg === true ? 'scratch' : 'sandbox';
+          return [{ username: s.orgUsername, orgType }];
+        });
+
+        if (targetOrgs.length === 0) {
+          return yield* new api.services.UserCancellationError({});
+        }
+
+        const confirmLabel = nls.localize('org_delete_confirm_label');
+        const confirm = yield* Effect.promise(() =>
+          vscode.window.showInformationMessage(
+            nls.localize('org_delete_confirm_prompt', targetOrgs.length),
+            { modal: true },
+            confirmLabel
+          )
+        );
+
+        if (confirm !== confirmLabel) {
+          return yield* new api.services.UserCancellationError({});
+        }
+
+        return { orgs: targetOrgs };
+      }).pipe(
+        Effect.map((data): ContinueResponse<{ orgs: OrgToDelete[] }> => ({ type: 'CONTINUE', data })),
+        Effect.catchTag(
+          'UserCancellationError',
+          (): Effect.Effect<CancelResponse> => Effect.succeed({ type: 'CANCEL' })
+        )
+      )
     );
-
-    const items = buildOrgQuickPickItems(freshAuthorizations, defaultConfig, isDeletable);
-    const selections = await vscode.window.showQuickPick(items, {
-      placeHolder: nls.localize('org_delete_select_orgs_placeholder'),
-      canPickMany: true,
-      matchOnDescription: true,
-      matchOnDetail: true
-    });
-
-    if (!selections || selections.length === 0) {
-      return { type: 'CANCEL' };
-    }
-
-    const targetOrgs: OrgToDelete[] = selections.filter(isOrgItem).flatMap(s => {
-      if (!s.orgUsername) return [];
-      const auth = freshAuthorizations.find(o => o.username === s.orgUsername);
-      const orgType = auth?.isScratchOrg === true ? 'scratch' : 'sandbox';
-      return [{ username: s.orgUsername, orgType }];
-    });
-
-    if (targetOrgs.length === 0) {
-      return { type: 'CANCEL' };
-    }
-
-    const confirmLabel = nls.localize('org_delete_confirm_label');
-    const confirm = await vscode.window.showInformationMessage(
-      nls.localize('org_delete_confirm_prompt', targetOrgs.length),
-      { modal: true },
-      confirmLabel
-    );
-
-    if (confirm !== confirmLabel) {
-      return { type: 'CANCEL' };
-    }
-
-    return { type: 'CONTINUE', data: { orgs: targetOrgs } };
   }
 }

--- a/packages/salesforcedx-vscode-org/src/parameterGatherers/selectDeletableOrg.ts
+++ b/packages/salesforcedx-vscode-org/src/parameterGatherers/selectDeletableOrg.ts
@@ -10,72 +10,52 @@ import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import type { CancelResponse, ContinueResponse, ParametersGatherer } from '@salesforce/salesforcedx-utils-vscode';
 import * as Effect from 'effect/Effect';
 import * as vscode from 'vscode';
-import { getOrgRuntime } from '../extensionProvider';
 import { nls } from '../messages';
 import { buildOrgQuickPickItems, isOrgItem } from '../orgPicker/orgList';
 import { getFreshAuthorizations } from '../util/orgUtil';
+import { runGatherer } from './runGatherer';
 
 export type OrgToDelete = { username: string; orgType: 'scratch' | 'sandbox' };
 
 const isDeletable = (org: OrgAuthorization): boolean => org.isScratchOrg === true || org.isSandbox === true;
 
+const gather = Effect.fn('SelectDeletableOrg.gather')(function* () {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const promptService = yield* api.services.PromptService;
+  const { defaultConfig, freshAuthorizations } = yield* getFreshAuthorizations();
+
+  const items = buildOrgQuickPickItems(freshAuthorizations, defaultConfig, isDeletable);
+  const selections = yield* Effect.promise(() =>
+    vscode.window.showQuickPick(items, {
+      placeHolder: nls.localize('org_delete_select_orgs_placeholder'),
+      canPickMany: true,
+      matchOnDescription: true,
+      matchOnDetail: true
+    })
+  ).pipe(Effect.flatMap(promptService.considerEmptySelectionAsCancellation));
+
+  const targetOrgs: OrgToDelete[] = selections.filter(isOrgItem).flatMap(s => {
+    if (!s.orgUsername) return [];
+    const auth = freshAuthorizations.find(o => o.username === s.orgUsername);
+    const orgType = auth?.isScratchOrg === true ? 'scratch' : 'sandbox';
+    return [{ username: s.orgUsername, orgType }];
+  });
+
+  if (targetOrgs.length === 0) {
+    return yield* new api.services.UserCancellationError({});
+  }
+
+  yield* promptService.confirmOrThrow({
+    message: nls.localize('org_delete_confirm_prompt', targetOrgs.length),
+    confirmLabel: nls.localize('org_delete_confirm_label')
+  });
+
+  return { orgs: targetOrgs };
+});
+
 /** Multi-select QuickPick filtered to scratch orgs and sandboxes with a delete confirmation. */
 export class SelectDeletableOrg implements ParametersGatherer<{ orgs: OrgToDelete[] }> {
   public async gather(): Promise<CancelResponse | ContinueResponse<{ orgs: OrgToDelete[] }>> {
-    return getOrgRuntime().runPromise(
-      Effect.gen(function* () {
-        const api = yield* (yield* ExtensionProviderService).getServicesApi;
-        const { defaultConfig, freshAuthorizations } = yield* getFreshAuthorizations();
-
-        const items = buildOrgQuickPickItems(freshAuthorizations, defaultConfig, isDeletable);
-        const selections = yield* Effect.promise(() =>
-          vscode.window.showQuickPick(items, {
-            placeHolder: nls.localize('org_delete_select_orgs_placeholder'),
-            canPickMany: true,
-            matchOnDescription: true,
-            matchOnDetail: true
-          })
-        ).pipe(
-          // Multi-pick: considerUndefinedAsCancellation does not catch the empty-array (pick-nothing) cancel.
-          Effect.flatMap(selected =>
-            selected === undefined || selected.length === 0
-              ? new api.services.UserCancellationError({})
-              : Effect.succeed(selected)
-          )
-        );
-
-        const targetOrgs: OrgToDelete[] = selections.filter(isOrgItem).flatMap(s => {
-          if (!s.orgUsername) return [];
-          const auth = freshAuthorizations.find(o => o.username === s.orgUsername);
-          const orgType = auth?.isScratchOrg === true ? 'scratch' : 'sandbox';
-          return [{ username: s.orgUsername, orgType }];
-        });
-
-        if (targetOrgs.length === 0) {
-          return yield* new api.services.UserCancellationError({});
-        }
-
-        const confirmLabel = nls.localize('org_delete_confirm_label');
-        const confirm = yield* Effect.promise(() =>
-          vscode.window.showInformationMessage(
-            nls.localize('org_delete_confirm_prompt', targetOrgs.length),
-            { modal: true },
-            confirmLabel
-          )
-        );
-
-        if (confirm !== confirmLabel) {
-          return yield* new api.services.UserCancellationError({});
-        }
-
-        return { orgs: targetOrgs };
-      }).pipe(
-        Effect.map((data): ContinueResponse<{ orgs: OrgToDelete[] }> => ({ type: 'CONTINUE', data })),
-        Effect.catchTag(
-          'UserCancellationError',
-          (): Effect.Effect<CancelResponse> => Effect.succeed({ type: 'CANCEL' })
-        )
-      )
-    );
+    return runGatherer(gather());
   }
 }

--- a/packages/salesforcedx-vscode-org/src/parameterGatherers/selectOrgForDisplay.ts
+++ b/packages/salesforcedx-vscode-org/src/parameterGatherers/selectOrgForDisplay.ts
@@ -5,37 +5,45 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthInfo } from '@salesforce/core';
+import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import type { CancelResponse, ContinueResponse, ParametersGatherer } from '@salesforce/salesforcedx-utils-vscode';
+import * as Effect from 'effect/Effect';
 import * as vscode from 'vscode';
+import { getOrgRuntime } from '../extensionProvider';
 import { nls } from '../messages';
 import { buildOrgQuickPickItems, isOrgItem } from '../orgPicker/orgList';
-import { getDefaultOrgConfiguration, readAliasesByUsernameFromDisk } from '../util/orgUtil';
+import { getFreshAuthorizations } from '../util/orgUtil';
 
 /** QuickPick that shows all authenticated orgs for the user to pick one to display info for. */
 export class SelectOrgForDisplay implements ParametersGatherer<{ username: string }> {
   public async gather(): Promise<CancelResponse | ContinueResponse<{ username: string }>> {
-    const [defaultConfig, authorizations, aliasesByUsername] = await Promise.all([
-      getDefaultOrgConfiguration(),
-      AuthInfo.listAllAuthorizations(),
-      readAliasesByUsernameFromDisk()
-    ]);
+    return getOrgRuntime().runPromise(
+      Effect.gen(function* () {
+        const api = yield* (yield* ExtensionProviderService).getServicesApi;
+        const promptService = yield* api.services.PromptService;
+        const { defaultConfig, freshAuthorizations } = yield* getFreshAuthorizations();
 
-    const freshAuthorizations = authorizations.map(org =>
-      org.aliases?.length ? org : { ...org, aliases: aliasesByUsername.get(org.username) ?? [] }
+        const items = buildOrgQuickPickItems(freshAuthorizations, defaultConfig);
+        const selection = yield* Effect.promise(() =>
+          vscode.window.showQuickPick(items, {
+            placeHolder: nls.localize('org_select_text'),
+            matchOnDescription: true,
+            matchOnDetail: true
+          })
+        ).pipe(Effect.flatMap(promptService.considerUndefinedAsCancellation));
+
+        if (!isOrgItem(selection) || !selection.orgUsername) {
+          return yield* new api.services.UserCancellationError({});
+        }
+
+        return { username: selection.orgUsername };
+      }).pipe(
+        Effect.map((data): ContinueResponse<{ username: string }> => ({ type: 'CONTINUE', data })),
+        Effect.catchTag(
+          'UserCancellationError',
+          (): Effect.Effect<CancelResponse> => Effect.succeed({ type: 'CANCEL' })
+        )
+      )
     );
-
-    const items = buildOrgQuickPickItems(freshAuthorizations, defaultConfig);
-    const selection = await vscode.window.showQuickPick(items, {
-      placeHolder: nls.localize('org_select_text'),
-      matchOnDescription: true,
-      matchOnDetail: true
-    });
-
-    if (!selection || !isOrgItem(selection) || !selection.orgUsername) {
-      return { type: 'CANCEL' };
-    }
-
-    return { type: 'CONTINUE', data: { username: selection.orgUsername } };
   }
 }

--- a/packages/salesforcedx-vscode-org/src/parameterGatherers/selectOrgForDisplay.ts
+++ b/packages/salesforcedx-vscode-org/src/parameterGatherers/selectOrgForDisplay.ts
@@ -9,41 +9,35 @@ import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import type { CancelResponse, ContinueResponse, ParametersGatherer } from '@salesforce/salesforcedx-utils-vscode';
 import * as Effect from 'effect/Effect';
 import * as vscode from 'vscode';
-import { getOrgRuntime } from '../extensionProvider';
 import { nls } from '../messages';
 import { buildOrgQuickPickItems, isOrgItem } from '../orgPicker/orgList';
 import { getFreshAuthorizations } from '../util/orgUtil';
+import { runGatherer } from './runGatherer';
+
+const gather = Effect.fn('SelectOrgForDisplay.gather')(function* () {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const promptService = yield* api.services.PromptService;
+  const { defaultConfig, freshAuthorizations } = yield* getFreshAuthorizations();
+
+  const items = buildOrgQuickPickItems(freshAuthorizations, defaultConfig);
+  const selection = yield* Effect.promise(() =>
+    vscode.window.showQuickPick(items, {
+      placeHolder: nls.localize('org_select_text'),
+      matchOnDescription: true,
+      matchOnDetail: true
+    })
+  ).pipe(Effect.flatMap(promptService.considerUndefinedAsCancellation));
+
+  if (!isOrgItem(selection) || !selection.orgUsername) {
+    return yield* new api.services.UserCancellationError({});
+  }
+
+  return { username: selection.orgUsername };
+});
 
 /** QuickPick that shows all authenticated orgs for the user to pick one to display info for. */
 export class SelectOrgForDisplay implements ParametersGatherer<{ username: string }> {
   public async gather(): Promise<CancelResponse | ContinueResponse<{ username: string }>> {
-    return getOrgRuntime().runPromise(
-      Effect.gen(function* () {
-        const api = yield* (yield* ExtensionProviderService).getServicesApi;
-        const promptService = yield* api.services.PromptService;
-        const { defaultConfig, freshAuthorizations } = yield* getFreshAuthorizations();
-
-        const items = buildOrgQuickPickItems(freshAuthorizations, defaultConfig);
-        const selection = yield* Effect.promise(() =>
-          vscode.window.showQuickPick(items, {
-            placeHolder: nls.localize('org_select_text'),
-            matchOnDescription: true,
-            matchOnDetail: true
-          })
-        ).pipe(Effect.flatMap(promptService.considerUndefinedAsCancellation));
-
-        if (!isOrgItem(selection) || !selection.orgUsername) {
-          return yield* new api.services.UserCancellationError({});
-        }
-
-        return { username: selection.orgUsername };
-      }).pipe(
-        Effect.map((data): ContinueResponse<{ username: string }> => ({ type: 'CONTINUE', data })),
-        Effect.catchTag(
-          'UserCancellationError',
-          (): Effect.Effect<CancelResponse> => Effect.succeed({ type: 'CANCEL' })
-        )
-      )
-    );
+    return runGatherer(gather());
   }
 }

--- a/packages/salesforcedx-vscode-org/src/parameterGatherers/selectOrgsForLogout.ts
+++ b/packages/salesforcedx-vscode-org/src/parameterGatherers/selectOrgsForLogout.ts
@@ -9,69 +9,49 @@ import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import type { CancelResponse, ContinueResponse, ParametersGatherer } from '@salesforce/salesforcedx-utils-vscode';
 import * as Effect from 'effect/Effect';
 import * as vscode from 'vscode';
-import { getOrgRuntime } from '../extensionProvider';
 import { nls } from '../messages';
 import { buildOrgQuickPickItems, isOrgItem } from '../orgPicker/orgList';
 import { getFreshAuthorizations } from '../util/orgUtil';
+import { runGatherer } from './runGatherer';
+
+const gather = Effect.fn('SelectOrgsForLogout.gather')(function* () {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const promptService = yield* api.services.PromptService;
+  const { defaultConfig, freshAuthorizations } = yield* getFreshAuthorizations();
+
+  const items = buildOrgQuickPickItems(freshAuthorizations, defaultConfig);
+
+  const selections = yield* Effect.promise(() =>
+    vscode.window.showQuickPick(items, {
+      placeHolder: nls.localize('org_logout_select_orgs_placeholder'),
+      canPickMany: true,
+      matchOnDescription: true,
+      matchOnDetail: true
+    })
+  ).pipe(Effect.flatMap(promptService.considerEmptySelectionAsCancellation));
+
+  const targetAuthorizations = freshAuthorizations.filter(org =>
+    selections.some(s => isOrgItem(s) && s.orgUsername === org.username)
+  );
+
+  if (targetAuthorizations.length === 0) {
+    return yield* new api.services.UserCancellationError({});
+  }
+
+  const hasScratchOrSandbox = targetAuthorizations.some(org => org.isScratchOrg === true || org.isSandbox === true);
+  const count = String(targetAuthorizations.length);
+  const prompt = hasScratchOrSandbox
+    ? nls.localize('org_logout_confirm_scratch_prompt', count)
+    : nls.localize('org_logout_confirm_prompt', count);
+
+  yield* promptService.confirmOrThrow({ message: prompt, confirmLabel: nls.localize('org_logout_scratch_logout') });
+
+  return { usernames: targetAuthorizations.map(org => org.username) };
+});
 
 /** Multi-select QuickPick for logout with a confirmation modal before proceeding. */
 export class SelectOrgsForLogout implements ParametersGatherer<{ usernames: string[] }> {
   public async gather(): Promise<CancelResponse | ContinueResponse<{ usernames: string[] }>> {
-    return getOrgRuntime().runPromise(
-      Effect.gen(function* () {
-        const api = yield* (yield* ExtensionProviderService).getServicesApi;
-        const { defaultConfig, freshAuthorizations } = yield* getFreshAuthorizations();
-
-        const items = buildOrgQuickPickItems(freshAuthorizations, defaultConfig);
-
-        const selections = yield* Effect.promise(() =>
-          vscode.window.showQuickPick(items, {
-            placeHolder: nls.localize('org_logout_select_orgs_placeholder'),
-            canPickMany: true,
-            matchOnDescription: true,
-            matchOnDetail: true
-          })
-        ).pipe(
-          // Multi-pick: considerUndefinedAsCancellation does not catch the empty-array (pick-nothing) cancel.
-          Effect.flatMap(selected =>
-            selected === undefined || selected.length === 0
-              ? new api.services.UserCancellationError({})
-              : Effect.succeed(selected)
-          )
-        );
-
-        const targetAuthorizations = freshAuthorizations.filter(org =>
-          selections.some(s => isOrgItem(s) && s.orgUsername === org.username)
-        );
-
-        if (targetAuthorizations.length === 0) {
-          return yield* new api.services.UserCancellationError({});
-        }
-
-        const hasScratchOrSandbox = targetAuthorizations.some(
-          org => org.isScratchOrg === true || org.isSandbox === true
-        );
-        const count = String(targetAuthorizations.length);
-        const prompt = hasScratchOrSandbox
-          ? nls.localize('org_logout_confirm_scratch_prompt', count)
-          : nls.localize('org_logout_confirm_prompt', count);
-
-        const confirmLabel = nls.localize('org_logout_scratch_logout');
-        const confirm = yield* Effect.promise(() =>
-          vscode.window.showInformationMessage(prompt, { modal: true }, confirmLabel)
-        );
-        if (confirm !== confirmLabel) {
-          return yield* new api.services.UserCancellationError({});
-        }
-
-        return { usernames: targetAuthorizations.map(org => org.username) };
-      }).pipe(
-        Effect.map((data): ContinueResponse<{ usernames: string[] }> => ({ type: 'CONTINUE', data })),
-        Effect.catchTag(
-          'UserCancellationError',
-          (): Effect.Effect<CancelResponse> => Effect.succeed({ type: 'CANCEL' })
-        )
-      )
-    );
+    return runGatherer(gather());
   }
 }

--- a/packages/salesforcedx-vscode-org/src/parameterGatherers/selectOrgsForLogout.ts
+++ b/packages/salesforcedx-vscode-org/src/parameterGatherers/selectOrgsForLogout.ts
@@ -5,59 +5,73 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthInfo, OrgAuthorization } from '@salesforce/core';
+import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import type { CancelResponse, ContinueResponse, ParametersGatherer } from '@salesforce/salesforcedx-utils-vscode';
+import * as Effect from 'effect/Effect';
 import * as vscode from 'vscode';
+import { getOrgRuntime } from '../extensionProvider';
 import { nls } from '../messages';
 import { buildOrgQuickPickItems, isOrgItem } from '../orgPicker/orgList';
-import { getDefaultOrgConfiguration, readAliasesByUsernameFromDisk } from '../util/orgUtil';
+import { getFreshAuthorizations } from '../util/orgUtil';
 
 /** Multi-select QuickPick for logout with a confirmation modal before proceeding. */
 export class SelectOrgsForLogout implements ParametersGatherer<{ usernames: string[] }> {
   public async gather(): Promise<CancelResponse | ContinueResponse<{ usernames: string[] }>> {
-    const [defaultConfig, authorizations, aliasesByUsername] = await Promise.all([
-      getDefaultOrgConfiguration(),
-      AuthInfo.listAllAuthorizations(),
-      readAliasesByUsernameFromDisk()
-    ]);
+    return getOrgRuntime().runPromise(
+      Effect.gen(function* () {
+        const api = yield* (yield* ExtensionProviderService).getServicesApi;
+        const { defaultConfig, freshAuthorizations } = yield* getFreshAuthorizations();
 
-    const freshAuthorizations: OrgAuthorization[] = authorizations.map(org =>
-      org.aliases?.length ? org : { ...org, aliases: aliasesByUsername.get(org.username) ?? [] }
+        const items = buildOrgQuickPickItems(freshAuthorizations, defaultConfig);
+
+        const selections = yield* Effect.promise(() =>
+          vscode.window.showQuickPick(items, {
+            placeHolder: nls.localize('org_logout_select_orgs_placeholder'),
+            canPickMany: true,
+            matchOnDescription: true,
+            matchOnDetail: true
+          })
+        ).pipe(
+          // Multi-pick: considerUndefinedAsCancellation does not catch the empty-array (pick-nothing) cancel.
+          Effect.flatMap(selected =>
+            selected === undefined || selected.length === 0
+              ? new api.services.UserCancellationError({})
+              : Effect.succeed(selected)
+          )
+        );
+
+        const targetAuthorizations = freshAuthorizations.filter(org =>
+          selections.some(s => isOrgItem(s) && s.orgUsername === org.username)
+        );
+
+        if (targetAuthorizations.length === 0) {
+          return yield* new api.services.UserCancellationError({});
+        }
+
+        const hasScratchOrSandbox = targetAuthorizations.some(
+          org => org.isScratchOrg === true || org.isSandbox === true
+        );
+        const count = String(targetAuthorizations.length);
+        const prompt = hasScratchOrSandbox
+          ? nls.localize('org_logout_confirm_scratch_prompt', count)
+          : nls.localize('org_logout_confirm_prompt', count);
+
+        const confirmLabel = nls.localize('org_logout_scratch_logout');
+        const confirm = yield* Effect.promise(() =>
+          vscode.window.showInformationMessage(prompt, { modal: true }, confirmLabel)
+        );
+        if (confirm !== confirmLabel) {
+          return yield* new api.services.UserCancellationError({});
+        }
+
+        return { usernames: targetAuthorizations.map(org => org.username) };
+      }).pipe(
+        Effect.map((data): ContinueResponse<{ usernames: string[] }> => ({ type: 'CONTINUE', data })),
+        Effect.catchTag(
+          'UserCancellationError',
+          (): Effect.Effect<CancelResponse> => Effect.succeed({ type: 'CANCEL' })
+        )
+      )
     );
-
-    const items = buildOrgQuickPickItems(freshAuthorizations, defaultConfig);
-
-    const selections = await vscode.window.showQuickPick(items, {
-      placeHolder: nls.localize('org_logout_select_orgs_placeholder'),
-      canPickMany: true,
-      matchOnDescription: true,
-      matchOnDetail: true
-    });
-
-    if (!selections || selections.length === 0) {
-      return { type: 'CANCEL' };
-    }
-
-    const targetAuthorizations = freshAuthorizations.filter(org =>
-      selections.some(s => isOrgItem(s) && s.orgUsername === org.username)
-    );
-
-    if (targetAuthorizations.length === 0) {
-      return { type: 'CANCEL' };
-    }
-
-    const hasScratchOrSandbox = targetAuthorizations.some(org => org.isScratchOrg === true || org.isSandbox === true);
-    const count = String(targetAuthorizations.length);
-    const prompt = hasScratchOrSandbox
-      ? nls.localize('org_logout_confirm_scratch_prompt', count)
-      : nls.localize('org_logout_confirm_prompt', count);
-
-    const confirmLabel = nls.localize('org_logout_scratch_logout');
-    const confirm = await vscode.window.showInformationMessage(prompt, { modal: true }, confirmLabel);
-    if (confirm !== confirmLabel) {
-      return { type: 'CANCEL' };
-    }
-
-    return { type: 'CONTINUE', data: { usernames: targetAuthorizations.map(org => org.username) } };
   }
 }

--- a/packages/salesforcedx-vscode-org/src/util/orgUtil.ts
+++ b/packages/salesforcedx-vscode-org/src/util/orgUtil.ts
@@ -295,35 +295,36 @@ type DefaultOrgConfig = {
  * Returns the resolved username for a given alias, or the input if it is already a username.
  * Uses AliasService (reads alias.json via FsService, bypassing StateAggregator cache).
  */
+const resolveUsernameFromAliasEffect = Effect.fn('OrgUtil.resolveUsernameFromAlias')(function* (
+  aliasOrUsername: string
+) {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const aliasService = yield* api.services.AliasService;
+  const opt = yield* aliasService.getUsernameFromAlias(aliasOrUsername);
+  return Option.getOrElse(opt, () => aliasOrUsername);
+});
+
+/** Promise wrapper for {@link resolveUsernameFromAliasEffect}. */
 export const resolveUsernameFromAlias = async (aliasOrUsername: string): Promise<string> =>
-  getOrgRuntime().runPromise(
-    Effect.gen(function* () {
-      const api = yield* (yield* ExtensionProviderService).getServicesApi;
-      const aliasService = yield* api.services.AliasService;
-      const opt = yield* aliasService.getUsernameFromAlias(aliasOrUsername);
-      return Option.getOrElse(opt, () => aliasOrUsername);
-    }).pipe(Effect.withSpan('OrgUtil.resolveUsernameFromAlias'))
-  );
+  getOrgRuntime().runPromise(resolveUsernameFromAliasEffect(aliasOrUsername));
 
 /**
  * Returns a map of username → aliases[]. Used to supplement stale StateAggregator data in the org picker.
  * Uses AliasService (reads alias.json via FsService, bypassing StateAggregator cache).
  */
+const readAliasesByUsernameFromDiskEffect = Effect.fn('OrgUtil.readAliasesByUsernameFromDisk')(function* () {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const aliasService = yield* api.services.AliasService;
+  const orgs = yield* aliasService.getAllAliases();
+  return Object.entries(orgs).reduce((result, [alias, username]) => {
+    result.set(username, [...(result.get(username) ?? []), alias]);
+    return result;
+  }, new Map<string, string[]>());
+});
+
+/** Promise wrapper for {@link readAliasesByUsernameFromDiskEffect}. */
 export const readAliasesByUsernameFromDisk = async (): Promise<Map<string, string[]>> =>
-  getOrgRuntime().runPromise(
-    Effect.gen(function* () {
-      const api = yield* (yield* ExtensionProviderService).getServicesApi;
-      const aliasService = yield* api.services.AliasService;
-      const orgs = yield* aliasService.getAllAliases();
-      const result = new Map<string, string[]>();
-      for (const [alias, username] of Object.entries(orgs)) {
-        const existing = result.get(username) ?? [];
-        existing.push(alias);
-        result.set(username, existing);
-      }
-      return result;
-    }).pipe(Effect.withSpan('OrgUtil.readAliasesByUsernameFromDisk'))
-  );
+  getOrgRuntime().runPromise(readAliasesByUsernameFromDiskEffect());
 
 /**
  * Loads default-org config + fresh org authorizations (alias-supplemented from disk) in one Effect.
@@ -333,13 +334,13 @@ export const readAliasesByUsernameFromDisk = async (): Promise<Map<string, strin
 export const getFreshAuthorizations = Effect.fn('orgUtil.getFreshAuthorizations')(function* () {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const [defaultConfig, authorizations, aliasesByUsername] = yield* Effect.all([
-    Effect.promise(() => getDefaultOrgConfiguration()),
+    getDefaultOrgConfigurationEffect(),
     api.services.ConnectionService.listAllAuthorizations(),
-    Effect.promise(() => readAliasesByUsernameFromDisk())
+    readAliasesByUsernameFromDiskEffect()
   ]);
 
   // Supplement stale StateAggregator alias data with fresh disk data
-  const freshAuthorizations: OrgAuthorization[] = authorizations.map(org =>
+  const freshAuthorizations = authorizations.map(org =>
     org.aliases?.length ? org : { ...org, aliases: aliasesByUsername.get(org.username) ?? [] }
   );
 
@@ -347,18 +348,24 @@ export const getFreshAuthorizations = Effect.fn('orgUtil.getFreshAuthorizations'
 });
 
 /** Get default org and devhub configuration */
-export const getDefaultOrgConfiguration = async (): Promise<DefaultOrgConfig> => {
-  const configAggregator = await getOrgRuntime().runPromise(getConfigAggregatorEffect);
+const getDefaultOrgConfigurationEffect = Effect.fn('OrgUtil.getDefaultOrgConfiguration')(function* () {
+  const configAggregator = yield* getConfigAggregatorEffect;
   const defaultDevHubProperty = configAggregator.getPropertyValue<string>(OrgConfigProperties.TARGET_DEV_HUB);
   const defaultOrgProperty = configAggregator.getPropertyValue<string>(OrgConfigProperties.TARGET_ORG);
 
   return {
     defaultDevHubProperty,
     defaultOrgProperty,
-    defaultDevHubUsername: defaultDevHubProperty ? await resolveUsernameFromAlias(defaultDevHubProperty) : undefined,
-    defaultOrgUsername: defaultOrgProperty ? await resolveUsernameFromAlias(defaultOrgProperty) : undefined
-  };
-};
+    defaultDevHubUsername: defaultDevHubProperty
+      ? yield* resolveUsernameFromAliasEffect(defaultDevHubProperty)
+      : undefined,
+    defaultOrgUsername: defaultOrgProperty ? yield* resolveUsernameFromAliasEffect(defaultOrgProperty) : undefined
+  } satisfies DefaultOrgConfig;
+});
+
+/** Promise wrapper for {@link getDefaultOrgConfigurationEffect}. */
+export const getDefaultOrgConfiguration = async (): Promise<DefaultOrgConfig> =>
+  getOrgRuntime().runPromise(getDefaultOrgConfigurationEffect());
 
 /** Determine the type of org (DevHub, Sandbox, Org, or Scratch) */
 const determineOrgType = (orgAuth: OrgAuthorization, authFields: AuthFields): string => {

--- a/packages/salesforcedx-vscode-org/src/util/orgUtil.ts
+++ b/packages/salesforcedx-vscode-org/src/util/orgUtil.ts
@@ -325,6 +325,27 @@ export const readAliasesByUsernameFromDisk = async (): Promise<Map<string, strin
     }).pipe(Effect.withSpan('OrgUtil.readAliasesByUsernameFromDisk'))
   );
 
+/**
+ * Loads default-org config + fresh org authorizations (alias-supplemented from disk) in one Effect.
+ * Authorizations come from `ConnectionService.listAllAuthorizations` (wraps `AuthInfo.listAllAuthorizations`).
+ * Consumed by the org pickers and `setDefaultOrg`.
+ */
+export const getFreshAuthorizations = Effect.fn('orgUtil.getFreshAuthorizations')(function* () {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const [defaultConfig, authorizations, aliasesByUsername] = yield* Effect.all([
+    Effect.promise(() => getDefaultOrgConfiguration()),
+    api.services.ConnectionService.listAllAuthorizations(),
+    Effect.promise(() => readAliasesByUsernameFromDisk())
+  ]);
+
+  // Supplement stale StateAggregator alias data with fresh disk data
+  const freshAuthorizations: OrgAuthorization[] = authorizations.map(org =>
+    org.aliases?.length ? org : { ...org, aliases: aliasesByUsername.get(org.username) ?? [] }
+  );
+
+  return { defaultConfig, freshAuthorizations };
+});
+
 /** Get default org and devhub configuration */
 export const getDefaultOrgConfiguration = async (): Promise<DefaultOrgConfig> => {
   const configAggregator = await getOrgRuntime().runPromise(getConfigAggregatorEffect);

--- a/packages/salesforcedx-vscode-org/test/jest/commands/auth/authParamsGatherer.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/commands/auth/authParamsGatherer.test.ts
@@ -5,9 +5,50 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import {
+  ExtensionProviderService,
+  type ExtensionProviderService as ExtensionProviderServiceType
+} from '@salesforce/effect-ext-utils';
+import type { SalesforceVSCodeServicesApi } from '@salesforce/vscode-services';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
 import { AuthParamsGatherer, DEFAULT_ALIAS } from '../../../../src/commands/auth/authParamsGatherer';
+import { resetOrgRuntimeForTesting, setAllServicesLayer } from '../../../../src/extensionProvider';
+
+/** Cancels iff the value is undefined / empty string, mirroring PromptService.considerUndefinedAsCancellation. */
+class UserCancellationError extends Error {
+  public readonly _tag = 'UserCancellationError';
+}
+const considerUndefinedAsCancellation = <T>(value: T | undefined): Effect.Effect<T, UserCancellationError> =>
+  value === undefined || (typeof value === 'string' && value.trim().length === 0)
+    ? Effect.fail(new UserCancellationError())
+    : Effect.succeed(value);
 
 describe('AuthParamsGatherer', () => {
+  const buildLayer = () => {
+    const mockServicesApi = {
+      services: {
+        // PromptService has accessors:false, so consumers `yield*` the service first
+        PromptService: Effect.succeed({ considerUndefinedAsCancellation }),
+        UserCancellationError
+      }
+    } as unknown as SalesforceVSCodeServicesApi;
+    return Layer.succeed(ExtensionProviderService, {
+      getServicesApi: Effect.succeed(mockServicesApi) as ExtensionProviderServiceType['getServicesApi']
+    });
+  };
+
+  beforeEach(() => {
+    resetOrgRuntimeForTesting();
+    setAllServicesLayer(
+      buildLayer() as ReturnType<typeof import('@salesforce/effect-ext-utils').buildAllServicesLayer>
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   describe('programmatic instance URL (access-token re-auth flow)', () => {
     const instanceUrl = 'https://demo.my.salesforce.com';
 

--- a/packages/salesforcedx-vscode-org/test/jest/commands/auth/authParamsGatherer.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/commands/auth/authParamsGatherer.test.ts
@@ -12,24 +12,26 @@ import {
 import type { SalesforceVSCodeServicesApi } from '@salesforce/vscode-services';
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
-import { AuthParamsGatherer, DEFAULT_ALIAS } from '../../../../src/commands/auth/authParamsGatherer';
+import * as vscode from 'vscode';
+import {
+  AccessTokenParamsGatherer,
+  AuthParamsGatherer,
+  DEFAULT_ALIAS,
+  ScratchOrgLogoutParamsGatherer
+} from '../../../../src/commands/auth/authParamsGatherer';
 import { resetOrgRuntimeForTesting, setAllServicesLayer } from '../../../../src/extensionProvider';
-
-/** Cancels iff the value is undefined / empty string, mirroring PromptService.considerUndefinedAsCancellation. */
-class UserCancellationError extends Error {
-  public readonly _tag = 'UserCancellationError';
-}
-const considerUndefinedAsCancellation = <T>(value: T | undefined): Effect.Effect<T, UserCancellationError> =>
-  value === undefined || (typeof value === 'string' && value.trim().length === 0)
-    ? Effect.fail(new UserCancellationError())
-    : Effect.succeed(value);
+import {
+  considerUndefinedAsCancellation,
+  makeConfirmOrThrow,
+  UserCancellationError
+} from '../../testHelpers/promptServiceStub';
 
 describe('AuthParamsGatherer', () => {
-  const buildLayer = () => {
+  const buildLayer = (confirm = true) => {
     const mockServicesApi = {
       services: {
         // PromptService has accessors:false, so consumers `yield*` the service first
-        PromptService: Effect.succeed({ considerUndefinedAsCancellation }),
+        PromptService: Effect.succeed({ considerUndefinedAsCancellation, confirmOrThrow: makeConfirmOrThrow(confirm) }),
         UserCancellationError
       }
     } as unknown as SalesforceVSCodeServicesApi;
@@ -38,11 +40,15 @@ describe('AuthParamsGatherer', () => {
     });
   };
 
-  beforeEach(() => {
+  const useLayer = (confirm = true): void => {
     resetOrgRuntimeForTesting();
     setAllServicesLayer(
-      buildLayer() as ReturnType<typeof import('@salesforce/effect-ext-utils').buildAllServicesLayer>
+      buildLayer(confirm) as ReturnType<typeof import('@salesforce/effect-ext-utils').buildAllServicesLayer>
     );
+  };
+
+  beforeEach(() => {
+    useLayer();
   });
 
   afterEach(() => {
@@ -86,6 +92,65 @@ describe('AuthParamsGatherer', () => {
         type: 'CONTINUE',
         data: { alias: `reauth-${DEFAULT_ALIAS}`, loginUrl: instanceUrl }
       });
+    });
+  });
+
+  describe('AccessTokenParamsGatherer', () => {
+    const instanceUrl = 'https://demo.my.salesforce.com';
+    const accessToken = 'token123';
+
+    it('CONTINUE happy path with explicit alias', async () => {
+      jest
+        .spyOn(vscode.window, 'showInputBox')
+        .mockResolvedValueOnce(instanceUrl)
+        .mockResolvedValueOnce('myAlias')
+        .mockResolvedValueOnce(accessToken);
+
+      const result = await new AccessTokenParamsGatherer().gather();
+
+      expect(result).toEqual({ type: 'CONTINUE', data: { alias: 'myAlias', instanceUrl, accessToken } });
+    });
+
+    it('empty-string alias defaults to DEFAULT_ALIAS', async () => {
+      jest
+        .spyOn(vscode.window, 'showInputBox')
+        .mockResolvedValueOnce(instanceUrl)
+        .mockResolvedValueOnce('')
+        .mockResolvedValueOnce(accessToken);
+
+      const result = await new AccessTokenParamsGatherer().gather();
+
+      expect(result).toEqual({ type: 'CONTINUE', data: { alias: DEFAULT_ALIAS, instanceUrl, accessToken } });
+    });
+
+    it('CANCEL when instance URL prompt is dismissed (undefined)', async () => {
+      jest.spyOn(vscode.window, 'showInputBox').mockResolvedValueOnce(undefined);
+
+      const result = await new AccessTokenParamsGatherer().gather();
+
+      expect(result).toEqual({ type: 'CANCEL' });
+    });
+
+    it('CANCEL when alias prompt is dismissed (undefined)', async () => {
+      jest.spyOn(vscode.window, 'showInputBox').mockResolvedValueOnce(instanceUrl).mockResolvedValueOnce(undefined);
+
+      const result = await new AccessTokenParamsGatherer().gather();
+
+      expect(result).toEqual({ type: 'CANCEL' });
+    });
+  });
+
+  describe('ScratchOrgLogoutParamsGatherer', () => {
+    it('CONTINUE with the username when confirmed', async () => {
+      useLayer(true);
+      const result = await new ScratchOrgLogoutParamsGatherer('user@example.com', 'myScratch').gather();
+      expect(result).toEqual({ type: 'CONTINUE', data: 'user@example.com' });
+    });
+
+    it('CANCEL when the confirmation is dismissed', async () => {
+      useLayer(false);
+      const result = await new ScratchOrgLogoutParamsGatherer('user@example.com', 'myScratch').gather();
+      expect(result).toEqual({ type: 'CANCEL' });
     });
   });
 });

--- a/packages/salesforcedx-vscode-org/test/jest/orgPicker/orgList.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/orgPicker/orgList.test.ts
@@ -4,13 +4,29 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { AuthInfo, OrgAuthorization } from '@salesforce/core';
-import { ICONS } from '@salesforce/vscode-services';
+import { OrgAuthorization } from '@salesforce/core';
+import {
+  ExtensionProviderService,
+  type ExtensionProviderService as ExtensionProviderServiceType
+} from '@salesforce/effect-ext-utils';
+import { ICONS, type SalesforceVSCodeServicesApi } from '@salesforce/vscode-services';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
 import * as vscode from 'vscode';
+import { resetOrgRuntimeForTesting, setAllServicesLayer } from '../../../src/extensionProvider';
 import { nls } from '../../../src/messages';
 import * as orgListModule from '../../../src/orgPicker/orgList';
 import { authorizationsToQuickPickItems } from '../../../src/orgPicker/orgList';
 import * as orgUtil from '../../../src/util/orgUtil';
+
+/** Cancels iff the value is undefined / empty string, mirroring PromptService.considerUndefinedAsCancellation. */
+class UserCancellationError extends Error {
+  public readonly _tag = 'UserCancellationError';
+}
+const considerUndefinedAsCancellation = <T>(value: T | undefined): Effect.Effect<T, UserCancellationError> =>
+  value === undefined || (typeof value === 'string' && value.trim().length === 0)
+    ? Effect.fail(new UserCancellationError())
+    : Effect.succeed(value);
 
 describe('OrgList tests', () => {
   const createOrgAuthorization = (overrides: Partial<OrgAuthorization> = {}): OrgAuthorization => ({
@@ -90,7 +106,7 @@ describe('OrgList tests', () => {
     describe('setDefaultOrg tests', () => {
       let showQuickPickMock: jest.SpyInstance;
       let executeCommandMock: jest.SpyInstance;
-      let listAllAuthorizationsMock: jest.SpyInstance;
+      let listAllAuthorizationsMock: jest.Mock;
       let getDefaultOrgConfigurationMock: jest.SpyInstance;
       const defaultConfig = {
         defaultDevHubProperty: undefined,
@@ -99,14 +115,35 @@ describe('OrgList tests', () => {
         defaultOrgUsername: undefined
       };
 
+      const buildLayer = () => {
+        const mockServicesApi = {
+          services: {
+            // setDefaultOrg loads orgs through ConnectionService (not AuthInfo direct) post-migration
+            ConnectionService: {
+              listAllAuthorizations: listAllAuthorizationsMock
+            },
+            // PromptService has accessors:false, so consumers `yield*` the service first
+            PromptService: Effect.succeed({ considerUndefinedAsCancellation })
+          }
+        } as unknown as SalesforceVSCodeServicesApi;
+        return Layer.succeed(ExtensionProviderService, {
+          getServicesApi: Effect.succeed(mockServicesApi) as ExtensionProviderServiceType['getServicesApi']
+        });
+      };
+
       beforeEach(() => {
         showQuickPickMock = jest.spyOn(vscode.window, 'showQuickPick');
         executeCommandMock = jest.spyOn(vscode.commands, 'executeCommand');
-        listAllAuthorizationsMock = jest.spyOn(AuthInfo, 'listAllAuthorizations');
+        // ConnectionService.listAllAuthorizations returns an Effect; default to the seeded (empty) list
+        listAllAuthorizationsMock = jest.fn().mockReturnValue(Effect.succeed([] as OrgAuthorization[]));
         getDefaultOrgConfigurationMock = jest.spyOn(orgUtil, 'getDefaultOrgConfiguration');
         jest.spyOn(orgUtil, 'readAliasesByUsernameFromDisk').mockResolvedValue(new Map());
-        listAllAuthorizationsMock.mockResolvedValue([]);
         getDefaultOrgConfigurationMock.mockResolvedValue(defaultConfig);
+
+        resetOrgRuntimeForTesting();
+        setAllServicesLayer(
+          buildLayer() as ReturnType<typeof import('@salesforce/effect-ext-utils').buildAllServicesLayer>
+        );
       });
 
       afterEach(() => {
@@ -181,6 +218,40 @@ describe('OrgList tests', () => {
 
           expect(result).toEqual({ type: 'CANCEL' });
           expect(executeCommandMock).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('org selection (data-loading path via ConnectionService)', () => {
+        const seededOrg = createOrgAuthorization({ username: 'seeded@example.com', aliases: ['SeededOrg'] });
+
+        beforeEach(() => {
+          listAllAuthorizationsMock.mockReturnValue(Effect.succeed([seededOrg]));
+        });
+
+        it('lists the seeded org from ConnectionService in the picker', async () => {
+          showQuickPickMock.mockResolvedValueOnce(undefined);
+
+          await orgListModule.setDefaultOrg();
+
+          // The list passed to showQuickPick must contain the org loaded via ConnectionService.
+          // (Fails if the mock returns nothing — guards against a vacuous pass.)
+          const items = showQuickPickMock.mock.calls[0][0] as Array<{ orgUsername?: string }>;
+          expect(items.some(i => i.orgUsername === 'seeded@example.com')).toBe(true);
+          expect(listAllAuthorizationsMock).toHaveBeenCalledTimes(1);
+        });
+
+        it('sets the picked org as default via sf.config.set', async () => {
+          showQuickPickMock.mockResolvedValueOnce({
+            label: '$(cloud) SeededOrg',
+            orgUsername: 'seeded@example.com',
+            orgAlias: 'SeededOrg',
+            orgType: 'Org'
+          });
+
+          const result = await orgListModule.setDefaultOrg();
+
+          expect(result).toEqual({ type: 'CONTINUE', data: {} });
+          expect(executeCommandMock).toHaveBeenCalledWith('sf.config.set', 'SeededOrg');
         });
       });
     });

--- a/packages/salesforcedx-vscode-org/test/jest/orgPicker/orgList.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/orgPicker/orgList.test.ts
@@ -12,21 +12,14 @@ import {
 import { ICONS, type SalesforceVSCodeServicesApi } from '@salesforce/vscode-services';
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
+import * as Option from 'effect/Option';
 import * as vscode from 'vscode';
 import { resetOrgRuntimeForTesting, setAllServicesLayer } from '../../../src/extensionProvider';
 import { nls } from '../../../src/messages';
 import * as orgListModule from '../../../src/orgPicker/orgList';
 import { authorizationsToQuickPickItems } from '../../../src/orgPicker/orgList';
 import * as orgUtil from '../../../src/util/orgUtil';
-
-/** Cancels iff the value is undefined / empty string, mirroring PromptService.considerUndefinedAsCancellation. */
-class UserCancellationError extends Error {
-  public readonly _tag = 'UserCancellationError';
-}
-const considerUndefinedAsCancellation = <T>(value: T | undefined): Effect.Effect<T, UserCancellationError> =>
-  value === undefined || (typeof value === 'string' && value.trim().length === 0)
-    ? Effect.fail(new UserCancellationError())
-    : Effect.succeed(value);
+import { considerUndefinedAsCancellation } from '../testHelpers/promptServiceStub';
 
 describe('OrgList tests', () => {
   const createOrgAuthorization = (overrides: Partial<OrgAuthorization> = {}): OrgAuthorization => ({
@@ -107,13 +100,6 @@ describe('OrgList tests', () => {
       let showQuickPickMock: jest.SpyInstance;
       let executeCommandMock: jest.SpyInstance;
       let listAllAuthorizationsMock: jest.Mock;
-      let getDefaultOrgConfigurationMock: jest.SpyInstance;
-      const defaultConfig = {
-        defaultDevHubProperty: undefined,
-        defaultOrgProperty: undefined,
-        defaultDevHubUsername: undefined,
-        defaultOrgUsername: undefined
-      };
 
       const buildLayer = () => {
         const mockServicesApi = {
@@ -122,6 +108,15 @@ describe('OrgList tests', () => {
             ConnectionService: {
               listAllAuthorizations: listAllAuthorizationsMock
             },
+            // getFreshAuthorizations yields ConfigService (default-org config) + AliasService (disk aliases)
+            // through getOrgRuntime; stub both so the data-loading path runs against fakes (no real I/O).
+            ConfigService: Effect.succeed({
+              getConfigAggregator: () => Effect.succeed({ getPropertyValue: () => undefined })
+            }),
+            AliasService: Effect.succeed({
+              getAllAliases: () => Effect.succeed({}),
+              getUsernameFromAlias: () => Effect.succeed(Option.none())
+            }),
             // PromptService has accessors:false, so consumers `yield*` the service first
             PromptService: Effect.succeed({ considerUndefinedAsCancellation })
           }
@@ -136,9 +131,6 @@ describe('OrgList tests', () => {
         executeCommandMock = jest.spyOn(vscode.commands, 'executeCommand');
         // ConnectionService.listAllAuthorizations returns an Effect; default to the seeded (empty) list
         listAllAuthorizationsMock = jest.fn().mockReturnValue(Effect.succeed([] as OrgAuthorization[]));
-        getDefaultOrgConfigurationMock = jest.spyOn(orgUtil, 'getDefaultOrgConfiguration');
-        jest.spyOn(orgUtil, 'readAliasesByUsernameFromDisk').mockResolvedValue(new Map());
-        getDefaultOrgConfigurationMock.mockResolvedValue(defaultConfig);
 
         resetOrgRuntimeForTesting();
         setAllServicesLayer(

--- a/packages/salesforcedx-vscode-org/test/jest/testHelpers/promptServiceStub.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/testHelpers/promptServiceStub.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Effect from 'effect/Effect';
+import { isString } from 'effect/Predicate';
+// Real tagged error so `new UserCancellationError({})` is yieldable in Effect and `Effect.catchTag` matches.
+import { UserCancellationError } from 'salesforcedx-vscode-services/src/vscode/prompts/promptService';
+
+export { UserCancellationError } from 'salesforcedx-vscode-services/src/vscode/prompts/promptService';
+
+/** Stub of `PromptService.considerUndefinedAsCancellation`. Uses `isString` to match the production
+ * predicate (promptService.ts) and avoid silent drift. */
+export const considerUndefinedAsCancellation = <T>(value: T | undefined): Effect.Effect<T, UserCancellationError> =>
+  value === undefined || (isString(value) && value.trim().length === 0)
+    ? Effect.fail(new UserCancellationError())
+    : Effect.succeed(value);
+
+/** Stub of `PromptService.confirmOrThrow`: `confirm: true` resolves, `false` fails with cancellation. */
+export const makeConfirmOrThrow =
+  (confirm: boolean) =>
+  (_params: { readonly message: string; readonly confirmLabel: string }): Effect.Effect<void, UserCancellationError> =>
+    confirm ? Effect.void : Effect.fail(new UserCancellationError());

--- a/packages/salesforcedx-vscode-org/test/playwright/specs/orgPickers.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-org/test/playwright/specs/orgPickers.desktop.spec.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from '@playwright/test';
+import {
+  activeQuickInputWidget,
+  closeWelcomeTabs,
+  createMinimalOrg,
+  ensureSecondarySideBarHidden,
+  executeCommandWithCommandPalette,
+  expectOrgPickerListsOrg,
+  MINIMAL_ORG_ALIAS,
+  QUICK_INPUT_LIST_ROW,
+  QUICK_INPUT_WIDGET,
+  selectOrgInPicker,
+  selectOutputChannel,
+  upsertScratchOrgAuthFieldsToSettings,
+  verifyCommandExists,
+  waitForOutputChannelText,
+  waitForVSCodeWorkbench
+} from '@salesforce/playwright-vscode-ext';
+import packageNls from '../../../package.nls.json';
+import { orgDesktopMinimalDefaultTest as test } from '../fixtures/desktopFixtures';
+
+// `channel_name` from salesforcedx-vscode-org/src/messages/i18n.ts (orgDisplay writes its table here).
+const ORG_OUTPUT_CHANNEL = 'Salesforce Org Management';
+
+// Exercises the three migrated org pickers (Effect + PromptService.considerUndefinedAsCancellation):
+//   - selectOrgForDisplay (single-pick)  -> sf.org.display.username
+//   - selectDeletableOrg (multi-pick + confirm) -> sf.org.delete.username
+//   - selectOrgsForLogout (multi-pick + confirm) -> sf.org.logout.all
+// plus the cancel mappings: Esc (UserCancellationError -> CANCEL) and multi-pick "pick nothing" ([] -> CANCEL).
+// The fixture sets a SCRATCH org (MINIMAL_ORG_ALIAS) as default, satisfying sf:project_opened +
+// sf:has_target_org + sf:default_org_deletable. We cancel at every confirm modal so the fixture org
+// is never actually deleted or logged out.
+test('org pickers: display, delete, logout pick + confirm + cancel flows', async ({ page }) => {
+  test.setTimeout(180_000);
+
+  await test.step('setup scratch default org', async () => {
+    const createResult = await createMinimalOrg();
+    await waitForVSCodeWorkbench(page);
+    await closeWelcomeTabs(page);
+    await ensureSecondarySideBarHidden(page);
+    await upsertScratchOrgAuthFieldsToSettings(page, createResult);
+  });
+
+  // Gate on an always-present activation command so we don't false-negative on slow startup.
+  await test.step('verify extension is activated', async () => {
+    await verifyCommandExists(page, packageNls.org_login_web_authorize_org_text, 60_000);
+  });
+
+  await test.step('DISPLAY: selectOrgForDisplay lists the org, pick it, assert output table', async () => {
+    await executeCommandWithCommandPalette(page, packageNls.org_display_username_text);
+    // selectOrgForDisplay (single-pick) lists the seeded scratch org.
+    await expectOrgPickerListsOrg(page, MINIMAL_ORG_ALIAS);
+    await selectOrgInPicker(page, MINIMAL_ORG_ALIAS);
+    // orgDisplay renders a table containing the org's Username row to the output channel.
+    await selectOutputChannel(page, ORG_OUTPUT_CHANNEL);
+    await waitForOutputChannelText(page, { expectedText: 'Username' });
+  });
+
+  await test.step('DISPLAY cancel: Esc on the picker maps to CANCEL (no error toast)', async () => {
+    await executeCommandWithCommandPalette(page, packageNls.org_display_username_text);
+    await expectOrgPickerListsOrg(page, MINIMAL_ORG_ALIAS);
+    await page.keyboard.press('Escape');
+    await expect(page.locator(QUICK_INPUT_WIDGET)).toBeHidden({ timeout: 10_000 });
+    await expectNoErrorNotification(page);
+  });
+
+  await test.step('DELETE: selectDeletableOrg multi-pick lists the scratch org, then cancel confirm', async () => {
+    // sf.org.delete.username routes to the SelectDeletableOrg picker (index.ts -> orgDelete -> new SelectDeletableOrg()).
+    await executeCommandWithCommandPalette(page, packageNls.org_delete_username_text);
+    await expectOrgPickerListsOrg(page, MINIMAL_ORG_ALIAS);
+    // Toggle the scratch org row (canPickMany), then accept to reach the confirm modal.
+    await toggleMultiPickRow(page, MINIMAL_ORG_ALIAS);
+    await page.keyboard.press('Enter');
+    // Cancel the confirm modal so the fixture org is NOT deleted; this maps to CANCEL.
+    await page.keyboard.press('Escape');
+    await expectNoErrorNotification(page);
+  });
+
+  await test.step('DELETE cancel: multi-pick pick-nothing + Enter ([] empty-array) maps to CANCEL', async () => {
+    await executeCommandWithCommandPalette(page, packageNls.org_delete_username_text);
+    await expectOrgPickerListsOrg(page, MINIMAL_ORG_ALIAS);
+    // Accept with nothing selected -> [] -> Phase 2 empty-array guard -> CANCEL (no confirm modal).
+    await page.keyboard.press('Enter');
+    await expect(page.locator(QUICK_INPUT_WIDGET)).toBeHidden({ timeout: 10_000 });
+    await expectNoErrorNotification(page);
+  });
+
+  await test.step('LOGOUT: selectOrgsForLogout multi-pick lists the org, then cancel confirm', async () => {
+    // sf.org.logout.all routes to the SelectOrgsForLogout picker (index.ts -> orgLogoutAll -> new SelectOrgsForLogout()).
+    await executeCommandWithCommandPalette(page, packageNls.org_logout_all_text);
+    await expectOrgPickerListsOrg(page, MINIMAL_ORG_ALIAS);
+    await toggleMultiPickRow(page, MINIMAL_ORG_ALIAS);
+    await page.keyboard.press('Enter');
+    // Cancel the confirm modal so the fixture org is NOT logged out; this maps to CANCEL.
+    await page.keyboard.press('Escape');
+    await expectNoErrorNotification(page);
+  });
+
+  await test.step('LOGOUT cancel: Esc on the picker maps to CANCEL', async () => {
+    await executeCommandWithCommandPalette(page, packageNls.org_logout_all_text);
+    await expectOrgPickerListsOrg(page, MINIMAL_ORG_ALIAS);
+    await page.keyboard.press('Escape');
+    await expect(page.locator(QUICK_INPUT_WIDGET)).toBeHidden({ timeout: 10_000 });
+    await expectNoErrorNotification(page);
+  });
+});
+
+/** Toggle a `canPickMany` quick-pick row's checkbox by typing the alias and clicking the matching org row. */
+const toggleMultiPickRow = async (page: import('@playwright/test').Page, alias: string): Promise<void> => {
+  await page.keyboard.type(alias);
+  const row = activeQuickInputWidget(page)
+    .locator(QUICK_INPUT_LIST_ROW)
+    .filter({ hasText: alias })
+    .filter({ hasNotText: 'SFDX:' })
+    .first();
+  await row.waitFor({ state: 'visible', timeout: 10_000 });
+  await row.click({ force: true });
+};
+
+/** Assert no error toast surfaced (UserCancellationError must map to CANCEL, never an error notification). */
+const expectNoErrorNotification = async (page: import('@playwright/test').Page): Promise<void> => {
+  await expect(
+    page.locator('.notification-toast').filter({ has: page.locator('.codicon-error') }),
+    'a CANCEL flow must not surface an error notification'
+  ).toHaveCount(0);
+};

--- a/packages/salesforcedx-vscode-org/test/playwright/specs/orgPickers.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-org/test/playwright/specs/orgPickers.desktop.spec.ts
@@ -14,6 +14,7 @@ import {
   executeCommandWithCommandPalette,
   expectOrgPickerListsOrg,
   MINIMAL_ORG_ALIAS,
+  NOTIFICATION_LIST_ITEM,
   QUICK_INPUT_LIST_ROW,
   QUICK_INPUT_WIDGET,
   selectOrgInPicker,
@@ -127,7 +128,7 @@ const toggleMultiPickRow = async (page: import('@playwright/test').Page, alias: 
 /** Assert no error toast surfaced (UserCancellationError must map to CANCEL, never an error notification). */
 const expectNoErrorNotification = async (page: import('@playwright/test').Page): Promise<void> => {
   await expect(
-    page.locator('.notification-toast').filter({ has: page.locator('.codicon-error') }),
+    page.locator(NOTIFICATION_LIST_ITEM).filter({ has: page.locator('.codicon-error') }),
     'a CANCEL flow must not surface an error notification'
   ).toHaveCount(0);
 };

--- a/packages/salesforcedx-vscode-services/src/vscode/prompts/promptService.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/prompts/promptService.ts
@@ -86,6 +86,14 @@ export class PromptService extends Effect.Service<PromptService>()('PromptServic
         ? Effect.fail(new UserCancellationError())
         : Effect.succeed(value);
 
+    /** Multi-pick sibling of {@link considerUndefinedAsCancellation}: treats `undefined` (Esc) AND an empty
+     * selection array (picked nothing then accepted) as cancellation. `canPickMany` quick picks resolve to
+     * `[]` on pick-nothing, which `considerUndefinedAsCancellation` would let through. */
+    const considerEmptySelectionAsCancellation: <T>(
+      value: readonly T[] | undefined
+    ) => Effect.Effect<readonly T[], UserCancellationError, never> = value =>
+      value === undefined || value.length === 0 ? Effect.fail(new UserCancellationError()) : Effect.succeed(value);
+
     /** BFS search for all directories named `folderName` under `rootUri`. Swallows read errors on any subtree. */
     const findFoldersByName = (rootUri: URI, folderName: string) => {
       const init: { queue: URI[]; results: URI[] } = { queue: [rootUri], results: [] };
@@ -241,6 +249,8 @@ export class PromptService extends Effect.Service<PromptService>()('PromptServic
       /** If `value` is undefined (or an empty trimmed string), fail with {@link UserCancellationError}.
        * Otherwise, return `value` with `undefined` removed from its type. */
       considerUndefinedAsCancellation,
+      /** Multi-pick sibling: treats `undefined` (Esc) AND an empty selection array as {@link UserCancellationError}. */
+      considerEmptySelectionAsCancellation,
       /** Prompt user to select output directory from available package directories, or choose a custom one. */
       promptForOutputDir,
       /** Pipeable operator: ties a vscode progress notification lifetime to an Effect. */

--- a/scripts/setup-jest.ts
+++ b/scripts/setup-jest.ts
@@ -225,6 +225,10 @@ const getMockVSCode = () => {
       Left: 1,
       Right: 2
     },
+    QuickPickItemKind: {
+      Separator: -1,
+      Default: 0
+    },
     ThemeColor: jest.fn(),
     window: {
       activeTextEditor: jest.fn(),


### PR DESCRIPTION
## Summary

- Migrates `selectOrgForDisplay`, `selectDeletableOrg`, `selectOrgsForLogout`, `setDefaultOrg`, and auth gatherers (`AuthParamsGatherer`, `AccessTokenParamsGatherer`, `ScratchOrgLogoutParamsGatherer`) from direct `AuthInfo.listAllAuthorizations` calls to a shared `getFreshAuthorizations` Effect helper via `ConnectionService`
- Replaces raw `showQuickPick`/`showInputBox` promise chains with `PromptService.considerUndefinedAsCancellation` (and `considerEmptySelectionAsCancellation` for multi-pick), mapping `UserCancellationError` → `{type:'CANCEL'}` consistently
- Adds e2e spec `orgPickers.desktop.spec.ts` covering display/delete/logout picker flows, Esc-cancel paths, and empty-array cancel for multi-pick

## Plan

See [`.claude/plans/W-23069593.md`](.claude/plans/W-23069593.md)

### What issues does this PR fix or reference?

@W-23069593@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cXBu2YAG/view