### PR TITLE
fix(apex-oas): bump @stoplight/spectral-rulesets to 1.22.4 (lodash CVE-2026-2950) - W-23161119

### DIFF
--- a/.claude/plans/W-23161119.md
+++ b/.claude/plans/W-23161119.md
@@ -29,4 +29,6 @@
 - spectral-rulesets lock entry == 1.22.4
 - apex-oas compile passes
 - jest spec directly exercising Spectral core + custom ruleset passes: `npm --workspace packages/salesforcedx-vscode-apex-oas test -- ruleset.spectral.test` (spec at `packages/salesforcedx-vscode-apex-oas/test/jest/oas/documentProcessingPipeline/ruleset.spectral.test.ts` imports `@stoplight/spectral-core` + `src/oas/documentProcessorPipeline/ruleset.spectral`, runs `spectral.setRuleset(ruleset)` + `spectral.run`)
-- org-gated e2e (`decomposedSimpleAccount.headless.spec.ts` et al. — 9 `*.headless.spec.ts` specs under `packages/salesforcedx-vscode-apex-oas/test/playwright/specs/`) validates the spectral path (e.g. `decomposedSimpleAccount` asserts `expectProblemsCount(page, 0)` after `SFDX: Validate OpenAPI Document`) but requires a scratch org; CI `apexOasE2E.yml` gates the PR. No local pre-PR e2e required.
+- org-gated e2e: 9 `*.headless.spec.ts` specs under `packages/salesforcedx-vscode-apex-oas/test/playwright/specs/` validate the spectral path
+- e.g. `decomposedSimpleAccount.headless.spec.ts` asserts `expectProblemsCount(page, 0)` after `SFDX: Validate OpenAPI Document`
+- requires a scratch org; CI `apexOasE2E.yml` gates the PR — no local pre-PR e2e needed

--- a/.claude/plans/W-23161119.md
+++ b/.claude/plans/W-23161119.md
@@ -1,0 +1,32 @@
+# W-23161119: bump @stoplight/spectral-rulesets 1.22.0 -> 1.22.4
+
+## Context
+
+- Dependabot alert 297: lodash <=4.17.23 prototype pollution via `_.unset`/`_.omit` (CVE-2026-2950, GHSA-f23m-r3pf-42rh). Patched 4.18.0.
+- `@stoplight/spectral-rulesets@1.22.0` deps lodash `~4.17.21` -> root-hoisted lodash pinned 4.17.23 (only vuln copy; nested spectral-core/functions copies already 4.18.1).
+- `1.22.4` deps lodash `^4.18.1` (verified via `npm view`). lodash 4.18.1 published.
+- Single repo ref: `packages/salesforcedx-vscode-apex-oas/package.json`.
+
+## Phases
+
+### Phase 1: bump dep + regenerate lock
+
+- edit `packages/salesforcedx-vscode-apex-oas/package.json` dep `@stoplight/spectral-rulesets` `1.22.0` -> `1.22.4`
+- `npm install` from root (workspace) -> regenerate `package-lock.json`; root lodash hoists 4.17.23 -> 4.18.1
+- files: `packages/salesforcedx-vscode-apex-oas/package.json`, `package-lock.json`
+- commit: `fix(apex-oas): bump @stoplight/spectral-rulesets to 1.22.4 (lodash CVE-2026-2950) - W-23161119`
+
+## Skills to apply
+
+- packageJson — dep edit conventions
+- typescript — TS conventions
+- verification — confirm done
+
+## Verification
+
+- `node -e "..."` on `package-lock.json`: root `node_modules/lodash` version == `4.18.1`
+- `npm audit` lodash vuln gone
+- spectral-rulesets lock entry == 1.22.4
+- apex-oas compile passes
+- jest spec directly exercising Spectral core + custom ruleset passes: `npm --workspace packages/salesforcedx-vscode-apex-oas test -- ruleset.spectral.test` (spec at `packages/salesforcedx-vscode-apex-oas/test/jest/oas/documentProcessingPipeline/ruleset.spectral.test.ts` imports `@stoplight/spectral-core` + `src/oas/documentProcessorPipeline/ruleset.spectral`, runs `spectral.setRuleset(ruleset)` + `spectral.run`)
+- org-gated e2e (`decomposedSimpleAccount.headless.spec.ts` et al. — 9 `*.headless.spec.ts` specs under `packages/salesforcedx-vscode-apex-oas/test/playwright/specs/`) validates the spectral path (e.g. `decomposedSimpleAccount` asserts `expectProblemsCount(page, 0)` after `SFDX: Validate OpenAPI Document`) but requires a scratch org; CI `apexOasE2E.yml` gates the PR. No local pre-PR e2e required.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9520,12 +9520,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/@stoplight/spectral-core/node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
-    },
     "node_modules/@stoplight/spectral-core/node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -9575,12 +9569,6 @@
         "node": "^16.20 || ^18.18 || >= 20.17"
       }
     },
-    "node_modules/@stoplight/spectral-functions/node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
-    },
     "node_modules/@stoplight/spectral-parsers": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@stoplight/spectral-parsers/-/spectral-parsers-1.0.5.tgz",
@@ -9626,25 +9614,25 @@
       }
     },
     "node_modules/@stoplight/spectral-rulesets": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.22.0.tgz",
-      "integrity": "sha512-l2EY2jiKKLsvnPfGy+pXC0LeGsbJzcQP5G/AojHgf+cwN//VYxW1Wvv4WKFx/CLmLxc42mJYF2juwWofjWYNIQ==",
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.22.4.tgz",
+      "integrity": "sha512-Lwr4DVg8aEqiBcm2CMQAP1FIBmLP9Y8Z2st7jvbxzv3fXmThdafVMy6CrydWH46T4Wotm+UuBJFnqJd9H4RQZQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/specs": "^6.8.0",
         "@stoplight/better-ajv-errors": "1.0.3",
         "@stoplight/json": "^3.17.0",
-        "@stoplight/spectral-core": "^1.19.4",
+        "@stoplight/spectral-core": "1.23.0",
         "@stoplight/spectral-formats": "^1.8.1",
         "@stoplight/spectral-functions": "^1.9.1",
         "@stoplight/spectral-runtime": "^1.1.2",
         "@stoplight/types": "^13.6.0",
         "@types/json-schema": "^7.0.7",
-        "ajv": "^8.17.1",
+        "ajv": "^8.18.0",
         "ajv-formats": "~2.1.1",
         "json-schema-traverse": "^1.0.0",
         "leven": "3.1.0",
-        "lodash": "~4.17.21",
+        "lodash": "^4.18.1",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -9849,13 +9837,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@textlint/linter-formatter/node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -27124,9 +27105,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -44902,7 +44883,7 @@
         "@salesforce/vscode-service-provider": "^1.5.0",
         "@stoplight/spectral-core": "1.23.0",
         "@stoplight/spectral-functions": "1.10.2",
-        "@stoplight/spectral-rulesets": "1.22.0",
+        "@stoplight/spectral-rulesets": "1.22.4",
         "effect": "^3.21.2",
         "ejs": "3.1.10",
         "fast-xml-parser": "^5.7.1",

--- a/packages/salesforcedx-vscode-apex-oas/package.json
+++ b/packages/salesforcedx-vscode-apex-oas/package.json
@@ -35,7 +35,7 @@
     "@salesforce/vscode-service-provider": "^1.5.0",
     "@stoplight/spectral-core": "1.23.0",
     "@stoplight/spectral-functions": "1.10.2",
-    "@stoplight/spectral-rulesets": "1.22.0",
+    "@stoplight/spectral-rulesets": "1.22.4",
     "ejs": "3.1.10",
     "fast-xml-parser": "^5.7.1",
     "jsonpath-plus": "10.4.0",


### PR DESCRIPTION
## Summary

- Bumps `@stoplight/spectral-rulesets` from 1.22.0 to 1.22.4 in `packages/salesforcedx-vscode-apex-oas`
- Resolves lodash prototype pollution CVE-2026-2950 (GHSA-f23m-r3pf-42rh); root-hoisted lodash moves from 4.17.23 to 4.18.1
- `package-lock.json` regenerated; no API or behaviour changes

## Plan

[.claude/plans/W-23161119.md](.claude/plans/W-23161119.md)

### What issues does this PR fix or reference?

@W-23161119@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002d0UXmYAM/view