### PR TITLE
chore(eslint): enable unicorn/no-impossible-length-comparison - W-23094904

### DIFF
--- a/.claude/plans/W-23094904.md
+++ b/.claude/plans/W-23094904.md
@@ -1,0 +1,26 @@
+# W-23094904 — Enable unicorn/no-impossible-length-comparison
+
+## Context
+- Disallow comparing `.length`/`.size` vs negative numbers (always false/true)
+- Rule docs: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-impossible-length-comparison.md
+- Dep W-23094903 merged (sibling rule enabled in d38e967a6)
+- Config: single flat-config file `eslint.config.mjs`, unicorn block ~L167-225
+- unicorn plugin v68 — rule present
+- Verified: rule already added at L183; full `npx eslint .` → 0 violations, no code fixes needed
+
+## Phases
+
+### Phase 1 — enable rule
+- Add `'unicorn/no-impossible-length-comparison': 'error'` to unicorn block in `eslint.config.mjs` (alphabetical, after `no-immediate-mutation`)
+- No source violations → no code changes
+- Files: `eslint.config.mjs`
+- Commit: `chore(eslint): enable unicorn/no-impossible-length-comparison - W-23094904`
+
+## Skills to apply
+- concise (plan/docs)
+- typescript
+- verification
+
+## Verification
+- `npx eslint .` → clean, no `no-impossible-length-comparison` errors (confirmed: 0)
+- No e2e coverage relevant (lint-only config change)

--- a/.claude/plans/W-23094904.md
+++ b/.claude/plans/W-23094904.md
@@ -1,7 +1,7 @@
 # W-23094904 — Enable unicorn/no-impossible-length-comparison
 
 ## Context
-- Disallow comparing `.length`/`.size` vs negative numbers (always false/true)
+- `.length`/`.size` vs negative — always false/true
 - Rule docs: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-impossible-length-comparison.md
 - Dep W-23094903 merged (sibling rule enabled in d38e967a6)
 - Config: single flat-config file `eslint.config.mjs`, unicorn block ~L167-225
@@ -12,7 +12,6 @@
 
 ### Phase 1 — enable rule
 - Add `'unicorn/no-impossible-length-comparison': 'error'` to unicorn block in `eslint.config.mjs` (alphabetical, after `no-immediate-mutation`)
-- No source violations → no code changes
 - Files: `eslint.config.mjs`
 - Commit: `chore(eslint): enable unicorn/no-impossible-length-comparison - W-23094904`
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -180,6 +180,7 @@ export default [
       'unicorn/no-duplicate-logical-operands': 'error',
       'unicorn/no-empty-file': 'error',
       'unicorn/no-immediate-mutation': 'error',
+      'unicorn/no-impossible-length-comparison': 'error',
       'unicorn/no-instanceof-builtins': 'error',
       'unicorn/no-single-promise-in-promise-methods': 'error',
       'unicorn/no-static-only-class': 'error',


### PR DESCRIPTION
## Summary

- Enables `unicorn/no-impossible-length-comparison` ESLint rule (error severity) in the unicorn block of `eslint.config.mjs`
- Rule is alphabetically placed after `no-immediate-mutation`; zero source violations confirmed (`npx eslint .` clean)
- No code changes needed — config-only addition

## Plan

See [.claude/plans/W-23094904.md](.claude/plans/W-23094904.md)

## Reviewer notes

- `eslint.config.mjs:183` finding was a positive confirmation (rule correctly enabled, alphabetically placed, 0 source violations) — no code change required.

### What issues does this PR fix or reference?

@W-23094904@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cexm5YAA/view