### PR TITLE
chore: bump @actions/core to ^2.0.3 for GHSA-v9p9-hfj2-hcw8 - W-23163017

### DIFF
--- a/.claude/plans/W-23163017.md
+++ b/.claude/plans/W-23163017.md
@@ -1,0 +1,36 @@
+# W-23163017 — bump @actions/core to 2.0.3 (GHSA-v9p9-hfj2-hcw8)
+
+## Context
+- GHSA-v9p9-hfj2-hcw8 / CVE-2026-2229 (high): undici <6.24.0 unhandled exception in WebSocket client
+- vuln path: `undici@5.29.0` ← `@actions/http-client@2.2.3` ← `@actions/core@1.11.1`
+- root `package.json` deps: `@actions/core ^1.11.0`
+- fix: bump → `^2.0.3` (pulls http-client ^3.0.2 → undici ^6.23.0); `npm install`
+- consumers: `.github/actions/{new-issue,validate-issue,check-feature-request}/src/index.ts` `require("@actions/core")` at runtime, resolved from root `node_modules` (no per-action node_modules); compiled lib committed via `compile:github-actions` wireit (`tsc` per action)
+- API surface used: `core.setOutput` (+ getInput/setFailed per WI) — unchanged in 2.0.3
+- 2.0.3 stays CJS (3.0.0 ESM-only); node20 runtime OK
+- 1 of 2 for this GHSA; sibling WI = `@actions/github`. undici@5.29.0 fully gone only after both land
+- transitive churn: `@actions/core@1.11.1` declares `@actions/exec ^1.1.1`; 2.0.3 declares `@actions/exec ^2.0.0` (which declares `@actions/io ^2.0.0`, io has no deps). Lockfile currently has top-level `exec@1.1.1` (package-lock.json:136) + `io@1.1.3` (line 170) — `core` is their SOLE dependent (only requirement sites: package-lock.json:132 core→exec, :142 exec→io). `@actions/github` does NOT depend on exec/io (its deps: undici/@octokit*/http-client). So `npm install` upgrades both in place to exec@2.x + io@2.x; no nested copy, no version conflict (nothing requires exec@1.x once core moves to ^2.0.0)
+
+## Phases
+
+### Phase 1 — bump dep + lockfile + recompile actions
+- edit root `package.json`: `@actions/core` `^1.11.0` → `^2.0.3`
+- `npm install` (regen `package-lock.json`)
+- `npm run compile:github-actions` (recompile lib; confirms no API break, refresh committed lib if output differs)
+- stage: `package.json`, `package-lock.json` (will include exec 1.1.1→2.x + io 1.1.3→2.x upgrades), any changed `.github/actions/*/lib/*.js`
+- commit msg: `chore: bump @actions/core to ^2.0.3 for GHSA-v9p9-hfj2-hcw8 - W-23163017`
+
+## Skills to apply
+- packageJson — root dep edit
+- wireit — `compile:github-actions` recompile
+- typescript — tsc compile of `.github/actions/*/src/index.ts`; check API surface unchanged
+- verification
+
+## Verification
+- lockfile: `@actions/http-client` >=3.0.2; resolved undici for that path >=6.24.0 (`node -e` over package-lock packages)
+- `@actions/core` resolves 2.0.3.x
+- lockfile: `@actions/exec` >=2.0.0 and `@actions/io` >=2.0.0 (top-level, single copy — `grep '"@actions/exec"\|"@actions/io"'` shows only core→exec + exec→io requirement sites); confirm no remaining `exec@1.x`/`io@1.x` entries
+- `npm run compile:github-actions` exits 0 (no API break); git diff on lib minimal/none
+- `npm run check:actions` passes
+- NOT covered by branch e2e (CI tooling dep, not extension runtime)
+- note: undici@5.29.0 persists until sibling `@actions/github` WI lands — expected, not a failure here

--- a/.claude/plans/W-23163017.md
+++ b/.claude/plans/W-23163017.md
@@ -9,7 +9,7 @@
 - API surface used: `core.setOutput` (+ getInput/setFailed per WI) — unchanged in 2.0.3
 - 2.0.3 stays CJS (3.0.0 ESM-only); node20 runtime OK
 - 1 of 2 for this GHSA; sibling WI = `@actions/github`. undici@5.29.0 fully gone only after both land
-- transitive churn: `@actions/core@1.11.1` declares `@actions/exec ^1.1.1`; 2.0.3 declares `@actions/exec ^2.0.0` (which declares `@actions/io ^2.0.0`, io has no deps). Lockfile currently has top-level `exec@1.1.1` (package-lock.json:136) + `io@1.1.3` (line 170) — `core` is their SOLE dependent (only requirement sites: package-lock.json:132 core→exec, :142 exec→io). `@actions/github` does NOT depend on exec/io (its deps: undici/@octokit*/http-client). So `npm install` upgrades both in place to exec@2.x + io@2.x; no nested copy, no version conflict (nothing requires exec@1.x once core moves to ^2.0.0)
+- transitive churn: `@actions/exec` 1.1.1→2.x + `@actions/io` 1.1.3→2.x; both upgraded in place (sole dependent is core); no version conflict, no nested copy
 
 ## Phases
 
@@ -33,4 +33,4 @@
 - `npm run compile:github-actions` exits 0 (no API break); git diff on lib minimal/none
 - `npm run check:actions` passes
 - NOT covered by branch e2e (CI tooling dep, not extension runtime)
-- note: undici@5.29.0 persists until sibling `@actions/github` WI lands — expected, not a failure here
+- undici@5.29.0 persists until sibling `@actions/github` WI lands — expected

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@actions/core": "^1.11.0",
+        "@actions/core": "^2.0.3",
         "@actions/github": "^6.0.0",
         "@salesforce/o11y-reporter": "^1.8.1",
         "@salesforce/vscode-service-provider": "1.5.0",
@@ -124,22 +124,41 @@
       "license": "GPL-3.0-only"
     },
     "node_modules/@actions/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-2.0.3.tgz",
+      "integrity": "sha512-Od9Thc3T1mQJYddvVPM4QGiLUewdh+3txmDYHHxoNdkqysR1MbCT+rFOtNUxYAz+7+6RIsqipVahY2GJqGPyxA==",
       "license": "MIT",
       "dependencies": {
-        "@actions/exec": "^1.1.1",
-        "@actions/http-client": "^2.0.1"
+        "@actions/exec": "^2.0.0",
+        "@actions/http-client": "^3.0.2"
+      }
+    },
+    "node_modules/@actions/core/node_modules/@actions/http-client": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-3.0.2.tgz",
+      "integrity": "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==",
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/core/node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/@actions/exec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
-      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-2.0.0.tgz",
+      "integrity": "sha512-k8ngrX2voJ/RIN6r9xB82NVqKpnMRtxDoiO+g3olkIUpQNqjArXrCQceduQZCQj3P3xm32pChRLqRrtXTlqhIw==",
       "license": "MIT",
       "dependencies": {
-        "@actions/io": "^1.0.1"
+        "@actions/io": "^2.0.0"
       }
     },
     "node_modules/@actions/github": {
@@ -168,9 +187,9 @@
       }
     },
     "node_modules/@actions/io": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
-      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-2.0.0.tgz",
+      "integrity": "sha512-Jv33IN09XLO+0HS79aaODsvIRyduiF7NY/F6LYeK5oeUmrsz7aFdRphQjFoESF4jS7lMauDOttKALcpapVDIAg==",
       "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "node": ">=22.15.1"
   },
   "dependencies": {
-    "@actions/core": "^1.11.0",
+    "@actions/core": "^2.0.3",
     "@actions/github": "^6.0.0",
     "@salesforce/o11y-reporter": "^1.8.1",
     "@salesforce/vscode-service-provider": "1.5.0",


### PR DESCRIPTION
## Summary

- Bumps `@actions/core` from `^1.11.0` to `^2.0.3` to resolve GHSA-v9p9-hfj2-hcw8 (undici WebSocket unhandled exception, high severity)
- Transitively upgrades `@actions/exec` and `@actions/io` to 2.x; no API surface changes affecting the three GitHub Actions consumers
- This is 1 of 2 WIs for this GHSA; `undici@5.29.0` fully removed only after sibling `@actions/github` WI lands

## Plan

[.claude/plans/W-23163017.md](.claude/plans/W-23163017.md)

## Reviewer notes

- `package.json:18`: positive verification only — pure dependency bump (`@actions/core ^1.11.0→^2.0.3`), no code-quality issues.
- `package-lock.json:146`: GHSA-v9p9 fix correctly applied via nested `undici@6.27.0`; top-level `undici@5.29.0` via `@actions/github` is the sibling WI's scope.
- `.claude/plans/W-23163017.md:13`: `exec`/`io` upgraded in place to 2.0.0, zero lib drift, no direct consumers.

### What issues does this PR fix or reference?

@W-23163017@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002d1tMfYAI/view