### PR TITLE
fix(security): bump @salesforce/o11y-reporter to 1.8.4 for protobufjs CVE - W-23164386

### DIFF
--- a/.claude/plans/W-23164386.md
+++ b/.claude/plans/W-23164386.md
@@ -2,12 +2,12 @@
 
 ## Context
 
-- GHSA-xq3m-2v4x-88gg / CVE-2026-41242 (critical). protobufjs <7.5.5 vulnerable; patched 7.5.5.
+- GHSA-xq3m-2v4x-88gg / CVE-2026-41242 (critical). protobufjs <7.5.5 vuln; patched 7.5.5
 - Transitive chain: `@salesforce/o11y-reporter -> o11y -> protobufjs`.
 - Declared `^1.8.1` in: salesforcedx-utils-vscode, salesforcedx-vscode-core, salesforcedx-vscode-services.
 - Current lock: o11y-reporter 1.8.2 -> o11y 258.22.0 -> protobufjs 7.2.6 (vuln).
 - Target: 1.8.4 -> o11y ^264.5.0 -> protobufjs 7.5.5.
-- Case 2 fix: `^1.8.1` already allows 1.8.4 -> no package.json edit. Only package-lock.json changes.
+- Case 2 fix: `^1.8.1` allows 1.8.4 -> no package.json edit. package-lock.json only
 - No major crossing (1.8.2 -> 1.8.4).
 - Only 1 vuln protobufjs in lock (`node_modules/o11y/node_modules/protobufjs` @ 7.2.6); no other consumers.
 
@@ -34,4 +34,4 @@
 - `grep 'protobufjs-7.5.5' package-lock.json` -> present
 - `grep '7.2.6' package-lock.json` -> absent
 - 3 package.json still `^1.8.1` (unchanged)
-- no e2e coverage — lockfile-only dependency bump, no new behavior. CI covers protobufjs usage via existing e2e that initialize the telemetry service at extension activation (`packages/salesforcedx-vscode-core/src/index.ts`; O11yReporter constructed in `packages/salesforcedx-utils-vscode/src/telemetry/reporters/determineReporters.ts` line 69 via `initializeO11yReporter`, line 54). Transitive dep bump only; the same activation path that already runs in every e2e run exercises the patched protobufjs.
+- no e2e — lockfile-only dep bump, no new behavior. CI covers protobufjs via existing e2e (telemetry service init at extension activation: `packages/salesforcedx-vscode-core/src/index.ts`; O11yReporter constructed in `packages/salesforcedx-utils-vscode/src/telemetry/reporters/determineReporters.ts:69` via `initializeO11yReporter:54`)

--- a/.claude/plans/W-23164386.md
+++ b/.claude/plans/W-23164386.md
@@ -1,0 +1,37 @@
+# W-23164386 — update @salesforce/o11y-reporter to 1.8.4
+
+## Context
+
+- GHSA-xq3m-2v4x-88gg / CVE-2026-41242 (critical). protobufjs <7.5.5 vulnerable; patched 7.5.5.
+- Transitive chain: `@salesforce/o11y-reporter -> o11y -> protobufjs`.
+- Declared `^1.8.1` in: salesforcedx-utils-vscode, salesforcedx-vscode-core, salesforcedx-vscode-services.
+- Current lock: o11y-reporter 1.8.2 -> o11y 258.22.0 -> protobufjs 7.2.6 (vuln).
+- Target: 1.8.4 -> o11y ^264.5.0 -> protobufjs 7.5.5.
+- Case 2 fix: `^1.8.1` already allows 1.8.4 -> no package.json edit. Only package-lock.json changes.
+- No major crossing (1.8.2 -> 1.8.4).
+- Only 1 vuln protobufjs in lock (`node_modules/o11y/node_modules/protobufjs` @ 7.2.6); no other consumers.
+
+## Phases
+
+### Phase 1 — bump transitive dep via npm update
+
+- run at repo root: `npm update @salesforce/o11y-reporter`
+- verify lock updated; no package.json change expected
+- if package.json drifts, revert (`git checkout` the 3 package.json) — lock-only change
+- commit msg: `fix(security): bump @salesforce/o11y-reporter to 1.8.4 for protobufjs CVE-2026-41242 - W-23164386`
+
+## Skills to apply
+
+- dependabot-alerts (transitive bump workflow)
+- packageJson (no decl change, version range)
+- typescript
+- verification
+
+## Verification
+
+- `git diff --stat` -> only package-lock.json changed
+- `grep '@salesforce/o11y-reporter/-/o11y-reporter-1.8.4' package-lock.json` -> present
+- `grep 'protobufjs-7.5.5' package-lock.json` -> present
+- `grep '7.2.6' package-lock.json` -> absent
+- 3 package.json still `^1.8.1` (unchanged)
+- no e2e coverage — lockfile-only dependency bump, no new behavior. CI covers protobufjs usage via existing e2e that initialize the telemetry service at extension activation (`packages/salesforcedx-vscode-core/src/index.ts`; O11yReporter constructed in `packages/salesforcedx-utils-vscode/src/telemetry/reporters/determineReporters.ts` line 69 via `initializeO11yReporter`, line 54). Transitive dep bump only; the same activation path that already runs in every e2e run exercises the patched protobufjs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8130,25 +8130,24 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
@@ -8158,9 +8157,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -8879,22 +8878,22 @@
       "license": "MIT"
     },
     "node_modules/@salesforce/o11y-reporter": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@salesforce/o11y-reporter/-/o11y-reporter-1.8.2.tgz",
-      "integrity": "sha512-6Z4L/4C//f5OboxVVK0rRZCo7sRn5REI6e6O8o4cqmJNKiKhn2GzLft6Jfqa9sk46YOXn5ok4yJ6HGQUJZ1gPg==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@salesforce/o11y-reporter/-/o11y-reporter-1.8.4.tgz",
+      "integrity": "sha512-lI2QKKs1idr5aZW6caeSnd+jO1+/JFT/k1BTJ1jbK9P0Juo+FaSu8E7Wuz64Zd2mUIEasT55bC9q+pX3JSbSpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "o11y": "^258.7.0",
-        "o11y_schema": "256.154.0"
+        "o11y": "^264.5.0",
+        "o11y_schema": "260.5.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@salesforce/o11y-reporter/node_modules/o11y_schema": {
-      "version": "256.154.0",
-      "resolved": "https://registry.npmjs.org/o11y_schema/-/o11y_schema-256.154.0.tgz",
-      "integrity": "sha512-czvU/9cibyZptbr0gLJSM70U7zLlhWC2D2L5e9nOG84Wnqmn4F5YzVjrH1ZQzAzDbBbtbeU6WTS3F/SHqtMQ5g==",
+      "version": "260.5.0",
+      "resolved": "https://registry.npmjs.org/o11y_schema/-/o11y_schema-260.5.0.tgz",
+      "integrity": "sha512-0qrtqE394CODoPovUBdQQ2efHls6Z2xP6jvLitEGKSEj1KcCyeBLx2dHwTUtv66zwZTKjSp27QLFF4PZhengEQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@salesforce/playwright-vscode-ext": {
@@ -31139,14 +31138,14 @@
       }
     },
     "node_modules/o11y": {
-      "version": "258.22.0",
-      "resolved": "https://registry.npmjs.org/o11y/-/o11y-258.22.0.tgz",
-      "integrity": "sha512-HVWyrTgv1Tx0mk7XtZp2IE/ZaiBxcL07g62ptMDLFaTwAbvKnemveX8llcF4PmK66kZdZwD8E5Jd4fQvkNJBSw==",
+      "version": "264.6.0",
+      "resolved": "https://registry.npmjs.org/o11y/-/o11y-264.6.0.tgz",
+      "integrity": "sha512-v3x29+PphNaORbOrYi6ucsx391hwJk+mxf4XGGoRB6+BcI0W3/fhazaXBCBtEZOnU2YDLgpFd8B4CzCmBFiKFQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "o11y_schema": "254.44.0",
-        "protobufjs": "7.2.6",
-        "web-vitals": "3.5.2"
+        "o11y_schema": "260.5.0",
+        "protobufjs": "7.5.5",
+        "web-vitals": "^5.1.0"
       }
     },
     "node_modules/o11y_schema": {
@@ -31156,34 +31155,10 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/o11y/node_modules/o11y_schema": {
-      "version": "254.44.0",
-      "resolved": "https://registry.npmjs.org/o11y_schema/-/o11y_schema-254.44.0.tgz",
-      "integrity": "sha512-qcwaZsTyl/NFRoyjXk5ZObfjb773wYM5wxDbHSJNkQDBxX96RjUS/Df0M1rSbsmJWPOuYiV4EkvIOEPMm8V86g==",
+      "version": "260.5.0",
+      "resolved": "https://registry.npmjs.org/o11y_schema/-/o11y_schema-260.5.0.tgz",
+      "integrity": "sha512-0qrtqE394CODoPovUBdQQ2efHls6Z2xP6jvLitEGKSEj1KcCyeBLx2dHwTUtv66zwZTKjSp27QLFF4PZhengEQ==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/o11y/node_modules/protobufjs": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
-      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -37204,6 +37179,30 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/proxy-agent": {
       "version": "6.5.0",
@@ -43497,9 +43496,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.2.tgz",
-      "integrity": "sha512-c0rhqNcHXRkY/ogGDJQxZ9Im9D19hDihbzSQJrsioex+KnFgmMzBiy57Z1EjkhX/+OjyBpclDCzz2ITtjokFmg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
       "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {


### PR DESCRIPTION
## Summary

- Bumps @salesforce/o11y-reporter from 1.8.2 to 1.8.4 to resolve protobufjs CVE-2026-41242 (critical severity)
- Updates transitive dependency protobufjs from 7.2.6 (vulnerable) to 7.5.5 (patched)
- Lock-only change; package.json declarations unchanged (existing `^1.8.1` range accommodates 1.8.4)

## Plan

[.claude/plans/W-23164386.md](.claude/plans/W-23164386.md)

### What issues does this PR fix or reference?

@W-23164386@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002d2akjYAA/view