### PR TITLE
docs(apex-testing): glossary + discovery/test-API ADRs - W-23165780

### DIFF
--- a/.claude/plans/W-23165780.md
+++ b/.claude/plans/W-23165780.md
@@ -1,0 +1,72 @@
+# W-23165780 — apex-testing glossary + discovery/test-API ADRs
+
+## Context
+
+- docs-only; no source files; sibling of 1.1
+- new `packages/salesforcedx-vscode-apex-testing/CONTEXT.md` — glossary only
+- new ADRs 0002 (test discovery API), 0003 (VS Code Test API over TreeView)
+- root `CONTEXT-MAP.md` gains apex-testing row
+- ADR 0001 (codelens delegate) already on #7565 branch — reference via relative link, do NOT duplicate
+- all md authored in /concise style
+
+### Grounding (cited, for accurate glossary/ADR content)
+
+- org-only vs in-workspace tags: `views/testController.ts:94-96` (`org-only`, `in-workspace` TestTags)
+- TestController shell (OO class wrapping `vscode.tests.createTestController`): `views/testController.ts:71,92`
+- discovery API = Tooling REST Test Discovery (`>= v65.0`, org connection required): `testDiscovery/testDiscovery.ts:14-29`
+- runnable = tests discovered in org; undeployed project classes are absent from the org → absent from the tree until deployed (no in-code deploy gate; user-workflow knowledge — no grep hit for `deploy` in run logic, run handlers `testController.ts:1007-1034,1191`)
+- `retrieveOrgOnlyClass` (`testController.ts:1075-1128`) = org→workspace RETRIEVE (`MetadataRetrieveService.retrieve`), NOT a deploy; backs editing an org-only class locally. Do NOT cite as deploy-before-run evidence
+- discovery VFS: scheme `apex-testing`, `apex-testing:/orgs/<orgKey>/classes/*.cls` virtual editor for org-only: `discoveryVfs/apexTestingDiscoveryFs.ts:15,28-32`; store `discoveryVfs/apexTestDiscoveryStore.ts:40`
+- delegate command: see existing ADR 0001 (`docs/adr/0001-codelens-delegate-commands.md` on #7565)
+- namespace/package grouping (namespace → package 2GP/1GP/unpackaged tree): `testController.ts:875,909-951`; `views/orgTestItems.ts` (`buildNamespacePackageStructure`)
+- existing ADR format precedent: `packages/salesforcedx-vscode-org/docs/adr/0001-lift-and-shift-pre-effect.md` (H1 = decision sentence, prose, relative links)
+- existing CONTEXT.md format: `packages/salesforcedx-vscode-org/CONTEXT.md` (`# X Context` → `## Glossary` → `### term` bullets)
+- CONTEXT-MAP row format: `CONTEXT-MAP.md:5-8`
+
+## Phases
+
+### Phase 1 — CONTEXT.md + CONTEXT-MAP row + ADRs
+
+single commit (docs-only, cohesive)
+
+1. `packages/salesforcedx-vscode-apex-testing/CONTEXT.md`
+   - `# salesforcedx-vscode-apex-testing Context` → `## Glossary` → `### term` per org CONTEXT.md shape
+   - terms (glossary only, no how-to):
+     - **org-only test** — in org, not in workspace; `org-only` TestTag; debug unsupported; retrieve (`MetadataRetrieveService.retrieve`, org→workspace) to edit locally
+     - **project test** — in workspace; `in-workspace` TestTag; runs against the org's copy; undeployed classes absent from tree (no in-code deploy gate)
+     - **TestController shell** — `ApexTestController` OO class wrapping `vscode.tests.createTestController`; class shell forced by Test API object model
+     - **discovery VFS** — `apex-testing:` scheme; `/orgs/<orgKey>/classes/<FullName>.cls`; read-only virtual editor backing org-only classes
+     - **delegate command** — LS-emitted `*.delegate` lens IDs → real targets; see ADR 0001
+     - **namespace/package grouping** — tree: namespace → package (2GP/1GP/unpackaged) → class → method
+2. `CONTEXT-MAP.md` — insert row before the `salesforcedx-vscode-services` row (existing rows are NOT alpha-sorted; `apex-testing` < `org` < `services`, so it goes first among the package rows):
+   - `- [salesforcedx-vscode-apex-testing](./packages/salesforcedx-vscode-apex-testing/CONTEXT.md) — apex test glossary (org-only vs project test, discovery VFS, TestController shell, namespace/package grouping)`
+3. `packages/salesforcedx-vscode-apex-testing/docs/adr/0002-test-discovery-api.md`
+   - H1 = decision sentence: discovery via org-based Tooling Test Discovery API, not Apex LS (Jorje) workspace scan
+   - was: Jorje workspace discovery; now (2025/2026): org Test Discovery API (`>= v65.0`)
+   - runnable = tests discovered in the org; undeployed project classes don't appear in the tree until deployed (org-discovery consequence, no enforced deploy step)
+   - trade-off: discovery needs live org connection (no offline tree)
+4. `packages/salesforcedx-vscode-apex-testing/docs/adr/0003-vscode-test-api-over-treeview.md`
+   - H1 = decision sentence: custom TreeView → VS Code Test API
+   - drivers: web rewrite; bundled wins — filtering (org-only vs project), search box, namespace/package tree
+   - trade-off: Test API object model forces class shell (`ApexTestController`)
+   - cross-ref ADR 0002 (discovery) + ADR 0001 (delegate) via relative links
+
+commit: `docs(apex-testing): glossary + discovery/test-API ADRs - W-23165780`
+
+## Skills to apply
+
+- **concise** — every md word; fragments, numerals, cut repetition
+- **paths** — relative links between CONTEXT-MAP ↔ CONTEXT.md ↔ ADRs (match `../../../../docs/` depth precedent)
+- **typescript** — file naming and casing conventions (required even for docs-only work)
+
+## Verification
+
+- not e2e-covered (docs-only; no e2e on branch)
+- `git diff --stat` = only the 4 md paths (3 new + CONTEXT-MAP)
+- CONTEXT-MAP: apex-testing row sits immediately before `salesforcedx-vscode-services` (first package row)
+- no ADR/glossary text claims a deploy-before-run gate; org-only wording says "retrieve to edit", not "deploy"
+- markdown links resolve: `ls` each relative target from file dir (ADR 0001 link valid only post-#7565 merge — note as known cross-branch ref)
+- ADRs do NOT restate ADR 0001 delegate mechanics — reference only
+- CONTEXT.md = glossary only (no procedures/how-to)
+- /concise self-check: no full sentences in bullets, numerals, no repetition
+- `npm run lint`/markdownlint if configured for docs

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -4,6 +4,7 @@
 
 - [Playwright e2e](./CONTEXT.md) — Playwright spec/helper conventions (root, until a narrower home exists)
 - [AI tooling](./.claude/CONTEXT.md) — skills, workflows, commands under `.claude/`
+- [salesforcedx-vscode-apex-testing](./packages/salesforcedx-vscode-apex-testing/CONTEXT.md) — apex test glossary (org-only vs project test, discovery VFS, TestController shell, namespace/package grouping)
 - [salesforcedx-vscode-services](./packages/salesforcedx-vscode-services/CONTEXT.md) — services extension glossary (HashableUri, etc.)
 - [salesforcedx-vscode-org](./packages/salesforcedx-vscode-org/CONTEXT.md) — org extension glossary (deletable org, `sf:default_org_deletable`, delete-default vs picker)
 

--- a/packages/salesforcedx-vscode-apex-testing/CONTEXT.md
+++ b/packages/salesforcedx-vscode-apex-testing/CONTEXT.md
@@ -1,0 +1,34 @@
+# salesforcedx-vscode-apex-testing Context
+
+## Glossary
+
+### org-only test
+
+- in org, not in workspace; `org-only` TestTag
+- debug unsupported
+- retrieve (`MetadataRetrieveService.retrieve`, org→workspace) to edit locally — retrieve, not deploy
+
+### project test
+
+- in workspace; `in-workspace` TestTag
+- runs against the org's copy
+- undeployed classes absent from tree (org-discovery consequence; no in-code deploy gate)
+
+### TestController shell
+
+- `ApexTestController` OO class wrapping `vscode.tests.createTestController`
+- class shell forced by the Test API object model
+
+### discovery VFS
+
+- `apex-testing:` scheme; `/orgs/<orgKey>/classes/<FullName>.cls`
+- read-only virtual editor backing org-only classes
+
+### delegate command
+
+- LS-emitted `*.delegate` lens IDs → real targets
+- see [ADR 0001](./docs/adr/0001-codelens-delegate-commands.md)
+
+### namespace/package grouping
+
+- tree: namespace → package (2GP/1GP/unpackaged) → class → method

--- a/packages/salesforcedx-vscode-apex-testing/docs/adr/0002-test-discovery-api.md
+++ b/packages/salesforcedx-vscode-apex-testing/docs/adr/0002-test-discovery-api.md
@@ -1,0 +1,7 @@
+# Discover Apex tests via the org's Tooling Test Discovery API, not an Apex LS (Jorje) workspace scan
+
+Was: Jorje workspace discovery — tests sourced from the local Apex language server's project scan. Now (2025/2026): the org-based Tooling REST Test Discovery API (`>= v65.0`), keyed on a live org connection.
+
+Consequence: runnable = tests discovered in the org. Undeployed project classes are absent from the org, so they don't appear in the tree until deployed — an org-discovery consequence, not an enforced deploy step (no in-code deploy gate).
+
+Trade-off: discovery needs a live org connection — no offline tree.

--- a/packages/salesforcedx-vscode-apex-testing/docs/adr/0002-test-discovery-api.md
+++ b/packages/salesforcedx-vscode-apex-testing/docs/adr/0002-test-discovery-api.md
@@ -1,7 +1,13 @@
 # Discover Apex tests via the org's Tooling Test Discovery API, not an Apex LS (Jorje) workspace scan
 
-Was: Jorje workspace discovery — tests sourced from the local Apex language server's project scan. Now (2025/2026): the org-based Tooling REST Test Discovery API (`>= v65.0`), keyed on a live org connection.
+- was: Jorje workspace discovery (local Apex LS project scan)
+- now: org-based Tooling REST Test Discovery API (`>= v65.0`); requires live org connection
 
-Consequence: runnable = tests discovered in the org. Undeployed project classes are absent from the org, so they don't appear in the tree until deployed — an org-discovery consequence, not an enforced deploy step (no in-code deploy gate).
+Consequence:
 
-Trade-off: discovery needs a live org connection — no offline tree.
+- runnable = tests discovered in the org
+- undeployed project classes absent from tree until deployed (org-discovery consequence; no in-code deploy gate)
+
+Trade-off:
+
+- discovery needs live org connection — no offline tree

--- a/packages/salesforcedx-vscode-apex-testing/docs/adr/0003-vscode-test-api-over-treeview.md
+++ b/packages/salesforcedx-vscode-apex-testing/docs/adr/0003-vscode-test-api-over-treeview.md
@@ -1,7 +1,9 @@
 # Surface Apex tests through the VS Code Test API, not a custom TreeView
 
-Drivers: web rewrite; bundled Test API wins for free — filtering (org-only vs project via TestTags), search box, namespace/package tree ([ADR 0002](./0002-test-discovery-api.md) feeds the items).
+- drivers: web rewrite; bundled Test API — filtering (org-only vs project via TestTags), search box, namespace/package tree ([ADR 0002](./0002-test-discovery-api.md) feeds the items)
 
-Trade-off: the Test API object model forces a class shell (`ApexTestController` wrapping `vscode.tests.createTestController`).
+Trade-off:
 
-Delegate-command lens routing is unchanged — see [ADR 0001](./0001-codelens-delegate-commands.md).
+- Test API object model forces a class shell (`ApexTestController` wrapping `vscode.tests.createTestController`)
+
+- delegate-command lens routing unchanged — see [ADR 0001](./0001-codelens-delegate-commands.md)

--- a/packages/salesforcedx-vscode-apex-testing/docs/adr/0003-vscode-test-api-over-treeview.md
+++ b/packages/salesforcedx-vscode-apex-testing/docs/adr/0003-vscode-test-api-over-treeview.md
@@ -1,0 +1,7 @@
+# Surface Apex tests through the VS Code Test API, not a custom TreeView
+
+Drivers: web rewrite; bundled Test API wins for free — filtering (org-only vs project via TestTags), search box, namespace/package tree ([ADR 0002](./0002-test-discovery-api.md) feeds the items).
+
+Trade-off: the Test API object model forces a class shell (`ApexTestController` wrapping `vscode.tests.createTestController`).
+
+Delegate-command lens routing is unchanged — see [ADR 0001](./0001-codelens-delegate-commands.md).


### PR DESCRIPTION
## Summary

- New `packages/salesforcedx-vscode-apex-testing/CONTEXT.md` — glossary for org-only vs project tests, discovery VFS, TestController shell, namespace/package grouping, delegate command
- New ADRs 0002 (test discovery via Tooling REST API over Jorje workspace scan) and 0003 (VS Code Test API over custom TreeView)
- `CONTEXT-MAP.md` gains apex-testing row

## Plan

[.claude/plans/W-23165780.md](.claude/plans/W-23165780.md)

## Reviewer notes

- `CONTEXT.md:30` and ADR 0003 link to `./docs/adr/0001-codelens-delegate-commands.md` which does not exist on `origin/develop` — it ships on PR #7565 (codelens-delegate-commands ADR 0001). **Merge this PR AFTER #7565**, else the two ADR-0001 relative links ship broken. No CI markdown-link check gates this.

### What issues does this PR fix or reference?

@W-23165780@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002d30KRYAY/view