### PR TITLE
refactor(apex-testing): TrySubjectIdError to Schema.TaggedError - W-23165787

### DIFF
--- a/.claude/plans/W-23165787.md
+++ b/.claude/plans/W-23165787.md
@@ -3,11 +3,11 @@
 ## Context
 
 - `packageResolution.ts:65-69` — `TrySubjectIdError` plain `class extends Error`. Last plain-Error subclass in apex-testing src.
-- Used internal-only as control-flow signal: `throw new TrySubjectIdError()` (line 267) → caught `error instanceof TrySubjectIdError` (line 291) inside Promise-based `resolvePackage2Members`. Never escapes to callers (testController.ts).
-- Goal: convert to `Schema.TaggedError` w/ `message` field, matching apex-log `commandErrors.ts:10` pattern (`Schema.TaggedError<Self>()('Tag', { message: Schema.String })`).
+- Used internal-only as control-flow signal: `throw new TrySubjectIdError()` (line 267) → caught `error instanceof TrySubjectIdError` (line 291) inside Promise-based `resolvePackage2Members`. never escapes to callers (testController.ts)
+- convert to `Schema.TaggedError` w/ `message` field, matching apex-log `commandErrors.ts:10` pattern (`Schema.TaggedError<Self>()('Tag', { message: Schema.String })`).
 - `Schema.TaggedError` extends `YieldableError` extends `Error` (node_modules/effect/dist/dts/Cause.d.ts:281) → `instanceof` + `throw` still valid; adds `_tag` so `catchTag` usable in WI4 Effect pipelines.
 - WI references `WorkspaceFolderError` / `apexTestRunCodeAction.ts:28` — stale; neither exists. Real exemplar: apex-log `commandErrors.ts`.
-- AC tension: "raised via Effect.fail not throw" — `resolvePackage2Members` is async Promise, not Effect. Full Effect.fail/catchTag conversion = WI4 (prereq note: tagged error must exist so WI4 can `catchTag`). This WI delivers the tagged type + `_tag`; keep `throw`/`instanceof` flow (smallest change, "touches only packageResolution.ts").
+- AC tension: "raised via Effect.fail not throw" — `resolvePackage2Members` is async Promise, not Effect. Full Effect.fail/catchTag conversion = WI4 (prereq note: tagged error must exist so WI4 can `catchTag`). This WI delivers the tagged type + `_tag`; keep `throw`/`instanceof` flow.
 
 ## Phases
 
@@ -29,7 +29,7 @@
 ### Phase 2 (only if needed) — test assertion
 
 - existing `packageResolution.test.ts` triggers TrySubjic path via mocked no-such-column errors; never constructs the error → likely no change.
-- add only if a new observable assertion warranted (e.g. tagged-error path coverage). Else skip — keep src+test in separate commits per verification rule.
+- add only if new assertion warranted. else skip.
 - files: `packages/salesforcedx-vscode-apex-testing/test/jest/testDiscovery/packageResolution.test.ts`
 - commit: `test(apex-testing): cover SubjectId fallback tagged-error path - W-23165787`
 

--- a/.claude/plans/W-23165787.md
+++ b/.claude/plans/W-23165787.md
@@ -1,0 +1,52 @@
+# W-23165787 — TrySubjectIdError -> Schema.TaggedError
+
+## Context
+
+- `packageResolution.ts:65-69` — `TrySubjectIdError` plain `class extends Error`. Last plain-Error subclass in apex-testing src.
+- Used internal-only as control-flow signal: `throw new TrySubjectIdError()` (line 267) → caught `error instanceof TrySubjectIdError` (line 291) inside Promise-based `resolvePackage2Members`. Never escapes to callers (testController.ts).
+- Goal: convert to `Schema.TaggedError` w/ `message` field, matching apex-log `commandErrors.ts:10` pattern (`Schema.TaggedError<Self>()('Tag', { message: Schema.String })`).
+- `Schema.TaggedError` extends `YieldableError` extends `Error` (node_modules/effect/dist/dts/Cause.d.ts:281) → `instanceof` + `throw` still valid; adds `_tag` so `catchTag` usable in WI4 Effect pipelines.
+- WI references `WorkspaceFolderError` / `apexTestRunCodeAction.ts:28` — stale; neither exists. Real exemplar: apex-log `commandErrors.ts`.
+- AC tension: "raised via Effect.fail not throw" — `resolvePackage2Members` is async Promise, not Effect. Full Effect.fail/catchTag conversion = WI4 (prereq note: tagged error must exist so WI4 can `catchTag`). This WI delivers the tagged type + `_tag`; keep `throw`/`instanceof` flow (smallest change, "touches only packageResolution.ts").
+
+## Phases
+
+### Phase 1 — TrySubjectIdError -> Schema.TaggedError
+
+- add `import * as Schema from 'effect/Schema'`
+- replace class (lines 65-70):
+  ```ts
+  class TrySubjectIdError extends Schema.TaggedError<TrySubjectIdError>()('TrySubjectIdError', {
+    message: Schema.String
+  }) {}
+  ```
+- update throw (line 267): `throw new TrySubjectIdError({ message: 'TrySubjectId' })`
+- keep `instanceof TrySubjectIdError` catch (line 291) — valid, extends Error
+- effect LS may flag `globalErrorInEffectCatch` etc — address per hook output
+- files: `packages/salesforcedx-vscode-apex-testing/src/testDiscovery/packageResolution.ts`
+- commit: `refactor(apex-testing): TrySubjectIdError to Schema.TaggedError - W-23165787`
+
+### Phase 2 (only if needed) — test assertion
+
+- existing `packageResolution.test.ts` triggers TrySubjic path via mocked no-such-column errors; never constructs the error → likely no change.
+- add only if a new observable assertion warranted (e.g. tagged-error path coverage). Else skip — keep src+test in separate commits per verification rule.
+- files: `packages/salesforcedx-vscode-apex-testing/test/jest/testDiscovery/packageResolution.test.ts`
+- commit: `test(apex-testing): cover SubjectId fallback tagged-error path - W-23165787`
+
+## Skills
+
+- effect-best-practices — Schema.TaggedError w/ message field
+- ts4023-effect-errors — error in Effect channel export; but TrySubjic is internal-only, never in exported Effect signature → likely no export/`@ExportTaggedError` needed. Verify compile.
+- typescript — file naming + coding standards for TypeScript source changes
+- concise — plan/docs
+- verification
+
+## Verification
+
+(stop hook auto-runs compile, lint, effect LS, test, bundle, knip)
+
+- compile passes — no TS4023 (error internal, not in any exported Effect channel)
+- knip — TrySubjic stays non-exported (used same file) → no new unused-export flag
+- jest `packageResolution.test.ts` green — SubjectId-fallback + InstalledSubscriberPackage cases unchanged
+- grep: no `extends Error` plain subclass remains in apex-testing src
+- not e2e-covered: pure unit logic; no Playwright needed

--- a/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/packageResolution.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/packageResolution.ts
@@ -8,7 +8,6 @@
 import type { Package2MemberRecord, ResolvedPackageInfo } from './schemas';
 import type { Connection } from '@salesforce/core';
 import type { InstalledSubscriberPackage, Package2 } from '@salesforce/types/tooling';
-import * as Schema from 'effect/Schema';
 
 const PACKAGE2_MEMBER_BATCH_SIZE = 200;
 
@@ -63,9 +62,12 @@ const isNoSuchColumnForField = (error: unknown, field: string): boolean => {
 };
 
 /** Thrown when MetadataComponentId is not available so caller should try SubjectId. */
-class TrySubjectIdError extends Schema.TaggedError<TrySubjectIdError>()('TrySubjectIdError', {
-  message: Schema.String
-}) {}
+class TrySubjectIdError extends Error {
+  constructor() {
+    super('TrySubjectId');
+    this.name = 'TrySubjectIdError';
+  }
+}
 
 const getComponentId = (m: Package2MemberRecord): string | undefined => m.MetadataComponentId ?? m.SubjectId;
 
@@ -262,7 +264,7 @@ export const resolvePackage2Members = async (
         }
       } catch (error) {
         if (field === 'MetadataComponentId' && isNoSuchColumnForField(error, 'MetadataComponentId')) {
-          throw new TrySubjectIdError({ message: 'TrySubjectId' });
+          throw new TrySubjectIdError();
         }
         if (isPackage2UnavailableError(error)) {
           packageResolutionUnavailableOrgs.add(cacheKey);

--- a/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/packageResolution.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/packageResolution.ts
@@ -8,6 +8,7 @@
 import type { Package2MemberRecord, ResolvedPackageInfo } from './schemas';
 import type { Connection } from '@salesforce/core';
 import type { InstalledSubscriberPackage, Package2 } from '@salesforce/types/tooling';
+import * as Schema from 'effect/Schema';
 
 const PACKAGE2_MEMBER_BATCH_SIZE = 200;
 
@@ -62,12 +63,9 @@ const isNoSuchColumnForField = (error: unknown, field: string): boolean => {
 };
 
 /** Thrown when MetadataComponentId is not available so caller should try SubjectId. */
-class TrySubjectIdError extends Error {
-  constructor() {
-    super('TrySubjectId');
-    this.name = 'TrySubjectIdError';
-  }
-}
+class TrySubjectIdError extends Schema.TaggedError<TrySubjectIdError>()('TrySubjectIdError', {
+  message: Schema.String
+}) {}
 
 const getComponentId = (m: Package2MemberRecord): string | undefined => m.MetadataComponentId ?? m.SubjectId;
 
@@ -264,7 +262,7 @@ export const resolvePackage2Members = async (
         }
       } catch (error) {
         if (field === 'MetadataComponentId' && isNoSuchColumnForField(error, 'MetadataComponentId')) {
-          throw new TrySubjectIdError();
+          throw new TrySubjectIdError({ message: 'TrySubjectId' });
         }
         if (isPackage2UnavailableError(error)) {
           packageResolutionUnavailableOrgs.add(cacheKey);


### PR DESCRIPTION
## Summary

- Converts `TrySubjectIdError` from a plain `class extends Error` to `Schema.TaggedError`, the last plain-Error subclass in apex-testing src
- Adds `_tag` discriminant so future WI4 Effect pipelines can use `catchTag`; `throw`/`instanceof` flow preserved (Promise-based context, not Effect)
- No callers outside `packageResolution.ts`; purely internal control-flow signal

## Plan

[.claude/plans/W-23165787.md](.claude/plans/W-23165787.md)

### What issues does this PR fix or reference?

@W-23165787@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002d30liYAA/view