### PR TITLE
docs(auto-build-wi): close WI only on merged PR, not bare closed - W-23167310

### DIFF
--- a/.claude/workflows/auto-build-wi.js
+++ b/.claude/workflows/auto-build-wi.js
@@ -558,7 +558,7 @@ Return ONLY the structured result.`
 
 const closeMergedPrompt = (r, identity) => {
   const { wt, branch } = pathsFor(identity, r.wi)
-  return `WI ${r.wi.name} has its PR (${r.wi.prUrl}) ${r.prState.state} on GitHub. Close out.
+  return `WI ${r.wi.name} has its PR (${r.wi.prUrl}) merged on GitHub. Close out.
 
 Steps (idempotent):
 1. If WI Status__c is not already a closed terminal value, update:
@@ -1076,9 +1076,15 @@ const monitorInFlight = async identity => {
     async result => {
       if (!result || result.action === 'no-pr-restart') return result
       const { prState } = result
-      if (prState.state === 'merged' || prState.state === 'closed') {
+      // Only MERGED means the WI's work shipped — close it out. A bare CLOSED PR is NOT a
+      // completion signal: a WI may carry 2+ PR URLs in Details__c (an abandoned first attempt
+      // plus the live PR), and URL extraction can match the abandoned one. Closing the WI on
+      // its CLOSED state would strand the live PR (it drops out of the monitor query and never
+      // gets flipped draft→ready). So a closed-not-merged PR falls through to 'wait'.
+      if (prState.state === 'merged') {
         return { ...result, decision: 'close-wi' }
       }
+      if (prState.state === 'closed') return { ...result, decision: 'wait' }
       // A green PR whose ONLY change is its own plan file has no implementation — the
       // Build phase no-op'd but reported 'done', and a docs-only diff trivially passes CI.
       // Refuse to open it for review; bounce the WI for human takeover instead. (Catches


### PR DESCRIPTION
## Summary

- auto-build-wi monitor closed a WI whenever its PR state was `merged` **or** `closed`
- A WI may legitimately carry 2+ PR URLs in `Details__c` (abandoned first attempt + live PR) — URL extraction can match the abandoned one
- When that abandoned PR is closed on GitHub, the WI got auto-closed (bare `Status__c='Closed'`, no resolution) and the live PR was stranded in draft: it dropped out of the monitor query, so the "Open for review" stage never ran `gh pr ready`
- Fix: only `merged` triggers `close-wi`; `closed`-not-merged falls through to `wait`. 2-URL `Details__c` is valid and unchanged.

## Repro

W-23125840 had PRs 7557 (abandoned) + 7561 (live). 7557 closed → WI auto-closed → 7561 stuck draft despite green CI.

### What issues does this PR fix or reference?

@W-23167310@

🤖 Generated with [Claude Code](https://claude.com/claude-code)