### PR TITLE
chore(eslint): enable unicorn/no-invalid-character-comparison - W-23094906

### DIFF
--- a/.claude/plans/W-23094906.md
+++ b/.claude/plans/W-23094906.md
@@ -22,5 +22,5 @@
 - verification
 
 ## Verification
-- `NODE_OPTIONS=--max-old-space-size=8192 npx eslint .` → 0 `no-invalid-character-comparison` errors (confirmed)
-- No e2e coverage relevant (lint-only config change)
+- `NODE_OPTIONS=--max-old-space-size=8192 npx eslint .` → 0 `no-invalid-character-comparison` errors
+- No e2e needed (lint config only)

--- a/.claude/plans/W-23094906.md
+++ b/.claude/plans/W-23094906.md
@@ -1,0 +1,26 @@
+# W-23094906 — Enable unicorn/no-invalid-character-comparison
+
+## Context
+- Disallow comparing single char vs multi-char string (never equal)
+- Rule docs: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-invalid-character-comparison.md
+- Dep W-23094904 merged (488699124)
+- Config: single flat-config `eslint.config.mjs`, unicorn block ~L167-225
+- unicorn v68 — rule present (`node_modules/eslint-plugin-unicorn/rules/no-invalid-character-comparison.js`)
+- Verified: rule enabled + full `npx eslint .` → 0 rule violations, no code fixes needed
+  - 217 pre-existing errors unrelated (0 from this rule); needs `NODE_OPTIONS=--max-old-space-size=8192`
+
+## Phases
+
+### Phase 1 — enable rule
+- Add `'unicorn/no-invalid-character-comparison': 'error'` to unicorn block in `eslint.config.mjs` (alphabetical, after `no-instanceof-builtins`)
+- Files: `eslint.config.mjs`
+- Commit: `chore(eslint): enable unicorn/no-invalid-character-comparison - W-23094906`
+
+## Skills to apply
+- concise (plan/docs)
+- typescript
+- verification
+
+## Verification
+- `NODE_OPTIONS=--max-old-space-size=8192 npx eslint .` → 0 `no-invalid-character-comparison` errors (confirmed)
+- No e2e coverage relevant (lint-only config change)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -182,6 +182,7 @@ export default [
       'unicorn/no-immediate-mutation': 'error',
       'unicorn/no-impossible-length-comparison': 'error',
       'unicorn/no-instanceof-builtins': 'error',
+      'unicorn/no-invalid-character-comparison': 'error',
       'unicorn/no-single-promise-in-promise-methods': 'error',
       'unicorn/no-static-only-class': 'error',
       'unicorn/no-typeof-undefined': 'error',


### PR DESCRIPTION
## Summary

- Enables ESLint rule `unicorn/no-invalid-character-comparison` at `error` level in `eslint.config.mjs`
- Rule prevents comparing a single-character string against a multi-character string (always `false`)
- No code changes needed — verified 0 violations across the codebase

## Plan

[.claude/plans/W-23094906.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23094906-4-enable-unicorn-no-invalid-character-co/.claude/plans/W-23094906.md)

### What issues does this PR fix or reference?

@W-23094906@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cf6TAYAY/view