### PR TITLE
chore(deps): bump @salesforce/o11y-reporter to 1.8.5 and o11y_schema to 264.89.0 - W-23172827

### DIFF
--- a/.claude/plans/W-23172827.md
+++ b/.claude/plans/W-23172827.md
@@ -1,0 +1,48 @@
+# W-23172827 — Bump @salesforce/o11y-reporter + o11y_schema
+
+## Context
+
+- Bump `@salesforce/o11y-reporter` `^1.8.1` → `^1.8.5`
+- Bump `o11y_schema` `^260.65.0` → `^264.89.0`
+- Both target versions confirmed in npm registry
+- `o11y-reporter` refs (4 pjson):
+  - root `package.json:18`
+  - `salesforcedx-utils-vscode/package.json:15`
+  - `salesforcedx-vscode-services/package.json:44`
+  - `salesforcedx-vscode-core/package.json:33` (dep) + `:71` (legacy `packaging.packageUpdates.dependencies`)
+- `o11y_schema` refs (2 pjson): utils-vscode `:23`, services `:52`
+- single root `package-lock.json` (workspaces); no per-pkg lockfiles
+- lockfile currently resolves `@salesforce/o11y-reporter` to **1.8.2** (range `^1.8.1` already floats above 1.8.1) and `o11y_schema` to **260.65.0**; `^1.8.1` strings in pjson are the unbumped input ranges, not a lock mismatch
+- `o11y_schema` consumed at runtime via dynamic `import('o11y_schema/sf_pdp')` in:
+  - `salesforcedx-vscode-services/src/observability/o11ySpanExporter.ts:29`
+  - `salesforcedx-utils-vscode/src/telemetry/reporters/o11yReporter.ts:22`
+  - 4-minor jump (260→264) is NOT a pure no-behavior bump: a missing/renamed `pdpEventSchema` export surfaces only at runtime → e2e required
+
+## Phases
+
+### Phase 1 — bump versions + lockfile
+
+- edit 4 pjson: o11y-reporter `^1.8.1`→`^1.8.5` (incl. core `:71` packageUpdates entry, keep parity w/ dep)
+- edit 2 pjson: o11y_schema `^260.65.0`→`^264.89.0`
+- post-edit, pjson ranges read `^1.8.5` / `^264.89.0` (the `^` ranges stay; only the floor changes)
+- `npm install` → update `package-lock.json`
+- commit: `chore: bump @salesforce/o11y-reporter to ^1.8.5 and o11y_schema to ^264.89.0 - W-23172827`
+
+## Skills to apply
+
+- packageJson — pjson conventions
+- typescript — type/interface conventions when editing package.json files; verify tsc compilation of affected packages
+- wireit — if install touches scripts (unlikely)
+- verification — final gate
+
+## Verification
+
+- `git diff` shows only 6 version edits + lockfile
+- `npm install` clean exit
+- lockfile resolves o11y-reporter **>= 1.8.5** and o11y_schema **>= 264.89.0** for the top-level `node_modules/@salesforce/o11y-reporter` and `node_modules/o11y_schema` entries (check resolved versions, NOT absence of `1.8.1`/`260.65.0` strings — `^1.8.5` floats and nested transitive copies may differ)
+  - check: `node -e "const l=require('./package-lock.json'); console.log(l.packages['node_modules/@salesforce/o11y-reporter'].version, l.packages['node_modules/o11y_schema'].version)"`
+- typecheck/build affected pkgs (utils-vscode, core, services) — compile-only
+- Playwright (services is a listed Playwright package; the 260→264 schema jump is consumed via runtime dynamic import, so a broken `o11y_schema/sf_pdp` export would NOT show at compile time):
+  - `npm run test:web -w salesforcedx-vscode-services -- --retries 0`
+  - covers `retrieveOnLoadEmpty.headless.spec.ts`, `retrieveOnLoadMetadata.headless.spec.ts`, `retrieveOnLoadRetry.headless.spec.ts` — all use `setupConsoleMonitoring`, so a failed dynamic import of `o11y_schema/sf_pdp` surfaces as a console error and fails the spec
+  - NOTE: services has no `test:desktop` script and no desktop playwright config (only `playwright.config.web.ts`); all three specs are `.headless` (web). Do NOT add a `test:desktop -w salesforcedx-vscode-services` step — it would error (script does not exist)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@salesforce/o11y-reporter": "^1.8.1",
+        "@salesforce/o11y-reporter": "^1.8.5",
         "@salesforce/vscode-service-provider": "1.5.0",
         "jsforce": "^3.10.16",
         "memfs": "^4.32.0",
@@ -8120,25 +8120,24 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
@@ -8148,9 +8147,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -8869,23 +8868,17 @@
       "license": "MIT"
     },
     "node_modules/@salesforce/o11y-reporter": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@salesforce/o11y-reporter/-/o11y-reporter-1.8.2.tgz",
-      "integrity": "sha512-6Z4L/4C//f5OboxVVK0rRZCo7sRn5REI6e6O8o4cqmJNKiKhn2GzLft6Jfqa9sk46YOXn5ok4yJ6HGQUJZ1gPg==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@salesforce/o11y-reporter/-/o11y-reporter-1.8.5.tgz",
+      "integrity": "sha512-XYtfHHwa/z9jFC3P1QU1hE3mhT5WsMB7hpC9um3Av9Iz74K8sGPaMVFQdkZ/Wy44t4dmGLum4pTtCbfmW42i0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "o11y": "^258.7.0",
-        "o11y_schema": "256.154.0"
+        "o11y": "^264.18.0",
+        "o11y_schema": "^264.84.0"
       },
       "engines": {
         "node": ">=20"
       }
-    },
-    "node_modules/@salesforce/o11y-reporter/node_modules/o11y_schema": {
-      "version": "256.154.0",
-      "resolved": "https://registry.npmjs.org/o11y_schema/-/o11y_schema-256.154.0.tgz",
-      "integrity": "sha512-czvU/9cibyZptbr0gLJSM70U7zLlhWC2D2L5e9nOG84Wnqmn4F5YzVjrH1ZQzAzDbBbtbeU6WTS3F/SHqtMQ5g==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/@salesforce/playwright-vscode-ext": {
       "resolved": "packages/playwright-vscode-ext",
@@ -30910,51 +30903,27 @@
       }
     },
     "node_modules/o11y": {
-      "version": "258.22.0",
-      "resolved": "https://registry.npmjs.org/o11y/-/o11y-258.22.0.tgz",
-      "integrity": "sha512-HVWyrTgv1Tx0mk7XtZp2IE/ZaiBxcL07g62ptMDLFaTwAbvKnemveX8llcF4PmK66kZdZwD8E5Jd4fQvkNJBSw==",
+      "version": "264.20.0",
+      "resolved": "https://registry.npmjs.org/o11y/-/o11y-264.20.0.tgz",
+      "integrity": "sha512-QmwrEv2CYNzEIOnArYP1522vbNuB+KTAWu4K+8174bZ5ua2aSFMQW0Q7MLLcl6QrekMBTRt/HmL4sNL5pnr5xg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "o11y_schema": "254.44.0",
-        "protobufjs": "7.2.6",
-        "web-vitals": "3.5.2"
+        "o11y_schema": "260.5.0",
+        "protobufjs": "7.5.6",
+        "web-vitals": "^5.1.0"
       }
     },
     "node_modules/o11y_schema": {
-      "version": "260.65.0",
-      "resolved": "https://registry.npmjs.org/o11y_schema/-/o11y_schema-260.65.0.tgz",
-      "integrity": "sha512-F3VWPhiDHH+L170X4Tt2cfqzlpXGbtowWPz+Npam3yB3KGBUIHA9paRG7FWZKv9wNcxrtQXgIZemmffVQTm3jg==",
+      "version": "264.89.0",
+      "resolved": "https://registry.npmjs.org/o11y_schema/-/o11y_schema-264.89.0.tgz",
+      "integrity": "sha512-etZYHb9oWZJU8jBxT3mq3nIXuVFyuv/3TxDYbsY5gsT/6h6a1P9nKIFsdO8qMibw/h7XAB6t/4cvV/KM8tK3Qw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/o11y/node_modules/o11y_schema": {
-      "version": "254.44.0",
-      "resolved": "https://registry.npmjs.org/o11y_schema/-/o11y_schema-254.44.0.tgz",
-      "integrity": "sha512-qcwaZsTyl/NFRoyjXk5ZObfjb773wYM5wxDbHSJNkQDBxX96RjUS/Df0M1rSbsmJWPOuYiV4EkvIOEPMm8V86g==",
+      "version": "260.5.0",
+      "resolved": "https://registry.npmjs.org/o11y_schema/-/o11y_schema-260.5.0.tgz",
+      "integrity": "sha512-0qrtqE394CODoPovUBdQQ2efHls6Z2xP6jvLitEGKSEj1KcCyeBLx2dHwTUtv66zwZTKjSp27QLFF4PZhengEQ==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/o11y/node_modules/protobufjs": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
-      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -36965,6 +36934,30 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/proxy-agent": {
       "version": "6.5.0",
@@ -43248,9 +43241,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.2.tgz",
-      "integrity": "sha512-c0rhqNcHXRkY/ogGDJQxZ9Im9D19hDihbzSQJrsioex+KnFgmMzBiy57Z1EjkhX/+OjyBpclDCzz2ITtjokFmg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
       "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
@@ -44517,7 +44510,7 @@
       "dependencies": {
         "@salesforce/core": "^8.31.0",
         "@salesforce/effect-ext-utils": "*",
-        "@salesforce/o11y-reporter": "^1.8.1",
+        "@salesforce/o11y-reporter": "^1.8.5",
         "@salesforce/salesforcedx-utils": "*",
         "@salesforce/vscode-i18n": "*",
         "@salesforce/vscode-service-provider": "^1.5.0",
@@ -44525,7 +44518,7 @@
         "applicationinsights": "1.0.7",
         "cross-spawn": "7.0.6",
         "effect": "^3.21.2",
-        "o11y_schema": "^260.65.0",
+        "o11y_schema": "^264.89.0",
         "rxjs": "^7.8.2",
         "tree-kill": "^1.1.0",
         "vscode-uri": "^3.1.0",
@@ -44729,7 +44722,7 @@
       "dependencies": {
         "@salesforce/core": "^8.31.0",
         "@salesforce/effect-ext-utils": "*",
-        "@salesforce/o11y-reporter": "^1.8.1",
+        "@salesforce/o11y-reporter": "^1.8.5",
         "@salesforce/salesforcedx-utils": "*",
         "@salesforce/salesforcedx-utils-vscode": "*",
         "@salesforce/source-deploy-retrieve": "^12.32.5",
@@ -44914,7 +44907,7 @@
         "@opentelemetry/sdk-trace-node": "2.7.1",
         "@opentelemetry/sdk-trace-web": "2.8.0",
         "@salesforce/core": "^8.31.0",
-        "@salesforce/o11y-reporter": "^1.8.1",
+        "@salesforce/o11y-reporter": "^1.8.5",
         "@salesforce/source-deploy-retrieve": "^12.32.5",
         "@salesforce/source-tracking": "^7.8.16",
         "@salesforce/templates": "^66.10.2",
@@ -44922,7 +44915,7 @@
         "@vscode/extension-telemetry": "^1.0.0",
         "effect": "^3.21.2",
         "jsforce": "^3.10.16",
-        "o11y_schema": "^260.65.0",
+        "o11y_schema": "^264.89.0",
         "vscode-uri": "^3.1.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "node": ">=22.15.1"
   },
   "dependencies": {
-    "@salesforce/o11y-reporter": "^1.8.1",
+    "@salesforce/o11y-reporter": "^1.8.5",
     "@salesforce/vscode-service-provider": "1.5.0",
     "jsforce": "^3.10.16",
     "memfs": "^4.32.0",

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@salesforce/core": "^8.31.0",
     "@salesforce/effect-ext-utils": "*",
-    "@salesforce/o11y-reporter": "^1.8.1",
+    "@salesforce/o11y-reporter": "^1.8.5",
     "@salesforce/salesforcedx-utils": "*",
     "@salesforce/vscode-i18n": "*",
     "@salesforce/vscode-service-provider": "^1.5.0",
@@ -20,7 +20,7 @@
     "applicationinsights": "1.0.7",
     "cross-spawn": "7.0.6",
     "effect": "^3.21.2",
-    "o11y_schema": "^260.65.0",
+    "o11y_schema": "^264.89.0",
     "rxjs": "^7.8.2",
     "tree-kill": "^1.1.0",
     "vscode-uri": "^3.1.0",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@salesforce/core": "^8.31.0",
     "@salesforce/effect-ext-utils": "*",
-    "@salesforce/o11y-reporter": "^1.8.1",
+    "@salesforce/o11y-reporter": "^1.8.5",
     "@salesforce/salesforcedx-utils": "*",
     "@salesforce/salesforcedx-utils-vscode": "*",
     "@salesforce/source-deploy-retrieve": "^12.32.5",
@@ -68,7 +68,7 @@
       "main": "dist/src/index.js",
       "dependencies": {
         "applicationinsights": "1.0.7",
-        "@salesforce/o11y-reporter": "^1.8.1"
+        "@salesforce/o11y-reporter": "^1.8.5"
       },
       "devDependencies": {}
     }

--- a/packages/salesforcedx-vscode-services/package.json
+++ b/packages/salesforcedx-vscode-services/package.json
@@ -41,7 +41,7 @@
     "@opentelemetry/sdk-trace-node": "2.7.1",
     "@opentelemetry/sdk-trace-web": "2.8.0",
     "@salesforce/core": "^8.31.0",
-    "@salesforce/o11y-reporter": "^1.8.1",
+    "@salesforce/o11y-reporter": "^1.8.5",
     "@salesforce/source-deploy-retrieve": "^12.32.5",
     "@salesforce/source-tracking": "^7.8.16",
     "@salesforce/templates": "^66.10.2",
@@ -49,7 +49,7 @@
     "@vscode/extension-telemetry": "^1.0.0",
     "effect": "^3.21.2",
     "jsforce": "^3.10.16",
-    "o11y_schema": "^260.65.0",
+    "o11y_schema": "^264.89.0",
     "vscode-uri": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### What does this PR do?

Bump `@salesforce/o11y-reporter` from `^1.8.1` to `^1.8.5` and `o11y_schema` from `^260.65.0` to `^264.89.0` across root, `salesforcedx-utils-vscode`, `salesforcedx-vscode-core`, `salesforcedx-vscode-services`. Updated `package-lock.json`.

### What issues does this PR fix or reference?

@W-23172827@

🤖 Generated with [Claude Code](https://claude.com/claude-code)