### PR TITLE
chore(e2e): remove stale WDIO references from e2e tests - W-23195324

### DIFF
--- a/.claude/plans/W-23195324.md
+++ b/.claude/plans/W-23195324.md
@@ -24,7 +24,7 @@
 
 ### Phase 1 — strip stale WDIO refs from e2e comments
 
-- Edit all 18 comments per dispositions above. Comment-only diff.
+- 18 comment-only edits per dispositions above.
 - Files:
   - `packages/salesforcedx-vscode-org/test/playwright/specs/orgPicker.desktop.spec.ts`
   - `packages/playwright-vscode-ext/src/pages/statusBar.ts`
@@ -46,6 +46,6 @@
 ## Verification
 
 - `grep -rin "wdio\|webdriver" packages --include="*.ts" | grep -v node_modules` → 0 hits in test/playwright + playwright-vscode-ext (non-e2e hits in lightning aura resources `Test_private.js`, `scripts/xsd` out of scope)
-- lint changed files (comment-only, low risk): `npx eslint <files>`
-- no behavior change → e2e specs unaffected; not re-running e2e (covered on branch)
+- lint changed files: `npx eslint <files>`
+- comment-only; no e2e re-run needed
 - visual reread: each edited comment still explains current non-obvious behavior, no dangling refs

--- a/.claude/plans/W-23195324.md
+++ b/.claude/plans/W-23195324.md
@@ -1,0 +1,51 @@
+# W-23195324 — Remove stale WDIO references from e2e tests
+
+## Context
+
+- e2e tests now Playwright (`packages/*/test/playwright`, `packages/playwright-vscode-ext`); WDIO removed.
+- Comments still ref removed WDIO code: "WDIO it #N", "mirrors WDIO `foo`", "drops the WDIO X workaround", "Migrated from WDIO `auraLsp.e2e.ts`".
+- Stale = archaeology vs deleted WDIO source. Each comment usually = WDIO ref + current-behavior note.
+- Goal: strip WDIO ref, keep current-behavior explanation. Drop comment entirely only if WDIO ref was its sole content.
+- 18 hits, 7 files. No code/logic changes — comments only.
+
+### Hits (file : line : disposition)
+
+- `salesforcedx-vscode-org/.../orgPicker.desktop.spec.ts` : 61,68,69,79,95,96,126,135,153 : strip "WDIO it #N"/"WDIO waits"/"mirroring WDIO"/"WDIO did this via testSetup.tearDown()"; keep behavior
+- `playwright-vscode-ext/src/pages/statusBar.ts` : 15,53,54 : strip "mirroring the WDIO `getStatusBarItemWhichIncludes`"/"ports WDIO's check"/"mirrors the WDIO `aria-label.includes`"; keep "no stable DOM id → match by label", "labels carry icon prefix → substring"
+- `salesforcedx-vscode-apex/.../apexLspUtils.ts` : 33,137 : strip "Drops the WDIO `'254'` fallback"→keep "missing dir = LSP never started, fail fast"; strip "matches WDIO `verifyLspStatus(...)`"→keep "fails fast if restart ignored"
+- `salesforcedx-vscode-apex/.../apexLsp.desktop.spec.ts` : 101 : strip "to mirror WDIO line 165"; keep "col 38 (after `);`) append `;`"
+- `salesforcedx-vscode-apex/.../fixtures/desktopFixtures.ts` : 61 : strip "drops the WDIO Windows-only `reloadWindow` workaround"; keep pre-seed/jorje scan rationale
+- `salesforcedx-vscode-lightning/.../auraLspGoToDefinition.desktop.spec.ts` : 28,60,71,84 : strip "Migrated from WDIO `auraLsp.e2e.ts`"/"Mirrors WDIO `moveCursorWithFallback`"/"Matches WDIO `executeQuickPick`"/"matches WDIO `getCoordinates()`→[3,27]"; keep within-file nav, focus, preserveSelection, exact-coord rationale
+- `salesforcedx-vscode-lightning/.../auraLspAutocompletion.desktop.spec.ts` : 27,54,63 : strip "Migrated from WDIO"/"mirrors WDIO `typeTextAt`"/"mirrors WDIO `typeText('>')`+`save()`"; keep behavior
+- `salesforcedx-vscode-lightning/.../fixtures/desktopFixtures.ts` : 40 : strip "drops the WDIO `reloadWindow` workaround"; keep pre-seed rationale
+- `salesforcedx-vscode-apex-replay-debugger/.../debugApexTests.desktop.spec.ts` : 51 : strip "mirrors the WDIO StaleElementReferenceError handling in the source spec"; keep "tree re-render invalidates refs → retry/force-click"
+
+## Phases
+
+### Phase 1 — strip stale WDIO refs from e2e comments
+
+- Edit all 18 comments per dispositions above. Comment-only diff.
+- Files:
+  - `packages/salesforcedx-vscode-org/test/playwright/specs/orgPicker.desktop.spec.ts`
+  - `packages/playwright-vscode-ext/src/pages/statusBar.ts`
+  - `packages/salesforcedx-vscode-apex/test/playwright/utils/apexLspUtils.ts`
+  - `packages/salesforcedx-vscode-apex/test/playwright/specs/apexLsp.desktop.spec.ts`
+  - `packages/salesforcedx-vscode-apex/test/playwright/fixtures/desktopFixtures.ts`
+  - `packages/salesforcedx-vscode-lightning/test/playwright/specs/auraLspGoToDefinition.desktop.spec.ts`
+  - `packages/salesforcedx-vscode-lightning/test/playwright/specs/auraLspAutocompletion.desktop.spec.ts`
+  - `packages/salesforcedx-vscode-lightning/test/playwright/fixtures/desktopFixtures.ts`
+  - `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/debugApexTests.desktop.spec.ts`
+- commit: `chore(e2e): remove stale WDIO references from e2e test comments - W-23195324`
+
+## Skills to apply
+
+- typescript — .ts file edits
+- playwright-e2e — e2e test conventions
+- verification — final check
+
+## Verification
+
+- `grep -rin "wdio\|webdriver" packages --include="*.ts" | grep -v node_modules` → 0 hits in test/playwright + playwright-vscode-ext (non-e2e hits in lightning aura resources `Test_private.js`, `scripts/xsd` out of scope)
+- lint changed files (comment-only, low risk): `npx eslint <files>`
+- no behavior change → e2e specs unaffected; not re-running e2e (covered on branch)
+- visual reread: each edited comment still explains current non-obvious behavior, no dangling refs

--- a/packages/playwright-vscode-ext/src/pages/statusBar.ts
+++ b/packages/playwright-vscode-ext/src/pages/statusBar.ts
@@ -13,8 +13,8 @@ import { activeQuickInputWidget } from '../utils/quickInput';
 /**
  * Locate the org-picker / default-org status bar item by its rendered label text. The org-picker item
  * has no stable DOM id, so we find it by the visible label (`STATUS_BAR_ITEM_LABEL` + `hasText`).
- * `currentText` is the label the
- * item currently shows ("No Default Org Set" before an org is set, then the org alias).
+ * `currentText` is the label the item currently shows ("No Default Org Set" before an org is set,
+ * then the org alias).
  * `.first()`: only the org-picker item shows a user alias; other Salesforce status-bar items render
  * fixed icons/text that cannot contain the alias, so the first label match is the org-picker item.
  */

--- a/packages/playwright-vscode-ext/src/pages/statusBar.ts
+++ b/packages/playwright-vscode-ext/src/pages/statusBar.ts
@@ -12,8 +12,8 @@ import { activeQuickInputWidget } from '../utils/quickInput';
 
 /**
  * Locate the org-picker / default-org status bar item by its rendered label text. The org-picker item
- * has no stable DOM id, so — mirroring the WDIO `getStatusBarItemWhichIncludes` aria-label match — we
- * find it by the visible label (`STATUS_BAR_ITEM_LABEL` + `hasText`). `currentText` is the label the
+ * has no stable DOM id, so we find it by the visible label (`STATUS_BAR_ITEM_LABEL` + `hasText`).
+ * `currentText` is the label the
  * item currently shows ("No Default Org Set" before an org is set, then the org alias).
  * `.first()`: only the org-picker item shows a user alias; other Salesforce status-bar items render
  * fixed icons/text that cannot contain the alias, so the first label match is the org-picker item.
@@ -50,9 +50,8 @@ export const expectOrgPickerStatusBar = async (
 };
 
 /**
- * Assert the open org picker lists all `actionLabels` SFDX action commands (ports WDIO's check of the
- * 5 `ACTION_ITEMS`). Labels carry an icon prefix, so this matches on substring — mirrors the WDIO
- * `aria-label.includes` check.
+ * Assert the open org picker lists all `actionLabels` SFDX action commands (the 5 `ACTION_ITEMS`).
+ * Labels carry an icon prefix, so this matches on substring.
  */
 export const expectOrgPickerActionItems = async (
   page: Page,

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/debugApexTests.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/debugApexTests.desktop.spec.ts
@@ -48,7 +48,7 @@ const continueDebugSession = async (page: Page, maxContinues = 2): Promise<void>
 /**
  * Clicks a Test Explorer tree row's "Debug Test" action button using the retry/force-click pattern.
  * Clicking a tree row re-renders the tree (selection highlight + action buttons), invalidating element
- * refs — mirrors the WDIO StaleElementReferenceError handling in the source spec.
+ * refs — retry/force-click to tolerate the stale refs.
  */
 const debugTestFromTreeItem = async (page: Page, name: RegExp): Promise<void> => {
   const item = page.getByRole('treeitem', { name });

--- a/packages/salesforcedx-vscode-apex/test/playwright/fixtures/desktopFixtures.ts
+++ b/packages/salesforcedx-vscode-apex/test/playwright/fixtures/desktopFixtures.ts
@@ -58,7 +58,7 @@ const userSettings = {
 };
 
 // Files are pre-seeded onto disk before Electron launches so the jorje LSP startup scan picks
-// them up — drops the WDIO Windows-only `reloadWindow` workaround.
+// them up.
 const baseTest = createDesktopTest({
   fixturesDir: __dirname,
   additionalExtensionDirs: ['salesforcedx-vscode-core'],

--- a/packages/salesforcedx-vscode-apex/test/playwright/specs/apexLsp.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex/test/playwright/specs/apexLsp.desktop.spec.ts
@@ -98,7 +98,7 @@ test('Apex LSP: indexing, go-to-definition, autocompletion', async ({ page, work
 
     // Type the argument; the completion inserted `SayHello(name)` with `name` selected as snippet placeholder.
     await page.keyboard.type("'Jack");
-    // Position at col 38 (after `);`) and append `;` to mirror WDIO line 165.
+    // Position at col 38 (after `);`) and append `;`.
     await goToLineColumn(page);
     await page.keyboard.type('7:38');
     await page.keyboard.press('Enter');

--- a/packages/salesforcedx-vscode-apex/test/playwright/utils/apexLspUtils.ts
+++ b/packages/salesforcedx-vscode-apex/test/playwright/utils/apexLspUtils.ts
@@ -30,8 +30,8 @@ const PRELUDE_STARTING = 'Apex Prelude Service STARTING';
 
 /**
  * Locate the `<release>` directory under `.sfdx/tools/` (e.g. `254`, `262`). The Apex LSP creates
- * one such directory at the API version it was built against. Drops the WDIO `'254'` fallback
- * because a missing dir means the LSP never finished startup — failing fast surfaces that.
+ * one such directory at the API version it was built against. A missing dir means the LSP never
+ * finished startup — failing fast surfaces that.
  */
 export const findReleaseDir = (workspaceDir: string): string => {
   const toolsDir = path.join(workspaceDir, '.sfdx', 'tools');
@@ -134,8 +134,8 @@ type TriggerLspRestartOptions = {
  * Drive a full restart cycle: clear output → invoke restart → verify intermediate "restarting" state →
  * await Prelude STARTING → await indexing complete + StandardApexLibrary on disk.
  *
- * The intermediate `restarting` button check (matches WDIO `verifyLspStatus(LSP_STATUS.restarting)`)
- * fails fast if the restart command was ignored — important because the next two waits could
+ * The intermediate `restarting` button check fails fast if the restart command was ignored —
+ * important because the next two waits could
  * otherwise spuriously pass against the prior session's state.
  */
 export const triggerLspRestart = async (

--- a/packages/salesforcedx-vscode-apex/test/playwright/utils/apexLspUtils.ts
+++ b/packages/salesforcedx-vscode-apex/test/playwright/utils/apexLspUtils.ts
@@ -135,8 +135,8 @@ type TriggerLspRestartOptions = {
  * await Prelude STARTING → await indexing complete + StandardApexLibrary on disk.
  *
  * The intermediate `restarting` button check fails fast if the restart command was ignored —
- * important because the next two waits could
- * otherwise spuriously pass against the prior session's state.
+ * important because the next two waits could otherwise spuriously pass against the prior
+ * session's state.
  */
 export const triggerLspRestart = async (
   page: Page,

--- a/packages/salesforcedx-vscode-lightning/test/playwright/fixtures/desktopFixtures.ts
+++ b/packages/salesforcedx-vscode-lightning/test/playwright/fixtures/desktopFixtures.ts
@@ -37,7 +37,7 @@ const AURA_CMP_META = [
 
 // aura LSP specs do not exercise Push/Pull, so the workspace has no org. The aura1 bundle is
 // pre-seeded onto disk before Electron launches so the Aura Language Server's startup scan picks
-// it up — drops the WDIO `reloadWindow` workaround.
+// it up.
 const baseTest = createDesktopTest({
   fixturesDir: __dirname,
   additionalExtensionDirs: ['salesforcedx-vscode-core'],

--- a/packages/salesforcedx-vscode-lightning/test/playwright/specs/auraLspAutocompletion.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-lightning/test/playwright/specs/auraLspAutocompletion.desktop.spec.ts
@@ -24,8 +24,8 @@ import {
 import { test } from '../fixtures';
 import { waitForAuraLspReady } from '../utils/auraLspUtils';
 
-// Migrated from WDIO `auraLsp.e2e.ts` "Autocompletion". Specs are independent (separate VS Code
-// session per spec), so the Aura LS re-indexes the pre-seeded aura1 bundle here. Types `<aura:appl`
+// Specs are independent (separate VS Code session per spec), so the Aura LS re-indexes the
+// pre-seeded aura1 bundle here. Types `<aura:appl`
 // at L2 C1 (the blank tab line in the seeded `aura1.cmp`), selects the `aura:application`
 // completion, and asserts it was inserted.
 test('Aura LSP: autocompletion', async ({ page }) => {
@@ -51,7 +51,7 @@ test('Aura LSP: autocompletion', async ({ page }) => {
 
   await test.step('type <aura:appl and select the aura:application completion', async () => {
     // L2 is the blank tab line per the seeded layout (fixtures/desktopFixtures.ts) — load-bearing
-    // typing target, mirrors WDIO `typeTextAt(2, 1, '<aura:appl')`.
+    // typing target.
     await goToLineCol(page, 2, 1);
     await page.keyboard.type('<aura:appl');
 
@@ -60,7 +60,7 @@ test('Aura LSP: autocompletion', async ({ page }) => {
     await expect(firstRow).toHaveAttribute('aria-label', /aura:application/, { timeout: 30_000 });
     await firstRow.click();
 
-    // Close the tag and save (mirrors WDIO `typeText('>')` + `save()`).
+    // Close the tag and save.
     await page.keyboard.type('>');
     await saveFile(page);
   });

--- a/packages/salesforcedx-vscode-lightning/test/playwright/specs/auraLspAutocompletion.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-lightning/test/playwright/specs/auraLspAutocompletion.desktop.spec.ts
@@ -25,9 +25,8 @@ import { test } from '../fixtures';
 import { waitForAuraLspReady } from '../utils/auraLspUtils';
 
 // Specs are independent (separate VS Code session per spec), so the Aura LS re-indexes the
-// pre-seeded aura1 bundle here. Types `<aura:appl`
-// at L2 C1 (the blank tab line in the seeded `aura1.cmp`), selects the `aura:application`
-// completion, and asserts it was inserted.
+// pre-seeded aura1 bundle here. Types `<aura:appl` at L2 C1 (the blank tab line in the seeded
+// `aura1.cmp`), selects the `aura:application` completion, and asserts it was inserted.
 test('Aura LSP: autocompletion', async ({ page }) => {
   const consoleErrors = setupConsoleMonitoring(page);
   const networkErrors = setupNetworkMonitoring(page);

--- a/packages/salesforcedx-vscode-lightning/test/playwright/specs/auraLspGoToDefinition.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-lightning/test/playwright/specs/auraLspGoToDefinition.desktop.spec.ts
@@ -57,9 +57,9 @@ test('Aura LSP: go to definition', async ({ page }) => {
 
   await test.step('position cursor on the simpleNewContact reference (L8)', async () => {
     // Place the cursor inside `simpleNewContact` on the ref line (8:15). Click the editor first so
-    // it owns focus before the command-palette
-    // cursor placement (mirrors lwcLspGoToDefinitionHtml precedent); without focus, the
-    // subsequent Go to Definition runs against a stale/unfocused editor and resolves nothing.
+    // it owns focus before the command-palette cursor placement (mirrors lwcLspGoToDefinitionHtml
+    // precedent); without focus, the subsequent Go to Definition runs against a stale/unfocused
+    // editor and resolves nothing.
     await page.locator(`${EDITOR_WITH_URI}[data-uri$="aura1.cmp"]`).first().click();
     await goToLineCol(page, 8, 15);
     await expect(positionItem).toContainText(/Ln 8, Col 15/, { timeout: 10_000 });
@@ -68,8 +68,8 @@ test('Aura LSP: go to definition', async ({ page }) => {
 
   await test.step('Go to Definition lands on the attribute definition (L3)', async () => {
     // Within-file nav (no new tab), so no Ctrl+Click (apex used Ctrl+Click only for its
-    // cross-file nav). LSP readiness already
-    // synced by `waitForAuraLspReady`. Use the command palette (lwcLspGoToDefinitionHtml precedent)
+    // cross-file nav). LSP readiness already synced by `waitForAuraLspReady`. Use the command
+    // palette (lwcLspGoToDefinitionHtml precedent)
     // rather than F12, which is more host/environment-sensitive (can be intercepted as a global
     // shortcut). `preserveSelection` keeps the 8:15 cursor placed above — otherwise the palette's
     // workbench focus-click re-parks the cursor at end-of-document (below the last line of this

--- a/packages/salesforcedx-vscode-lightning/test/playwright/specs/auraLspGoToDefinition.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-lightning/test/playwright/specs/auraLspGoToDefinition.desktop.spec.ts
@@ -25,9 +25,8 @@ import {
 import { test } from '../fixtures';
 import { waitForAuraLspReady } from '../utils/auraLspUtils';
 
-// Migrated from WDIO `auraLsp.e2e.ts` "Go to Definition". The aura1 bundle is pre-seeded onto disk
-// before launch (fixtures/desktopFixtures.ts); the Aura LS indexes it on its startup scan, so no
-// `reloadWindow` workaround is needed. Go to Definition here is WITHIN-file: ref site L8
+// The aura1 bundle is pre-seeded onto disk before launch (fixtures/desktopFixtures.ts); the Aura LS
+// indexes it on its startup scan. Go to Definition here is WITHIN-file: ref site L8
 // `{!v.simpleNewContact}` → def site L3 `<aura:attribute name="simpleNewContact" …/>`.
 //
 // The Go to Definition command MUST run with `preserveSelection: true`. Without it,
@@ -57,8 +56,8 @@ test('Aura LSP: go to definition', async ({ page }) => {
   const positionItem = page.locator(WORKBENCH).getByRole('button', { name: /Ln \d+, Col \d+/ });
 
   await test.step('position cursor on the simpleNewContact reference (L8)', async () => {
-    // Mirrors WDIO `moveCursorWithFallback(textEditor, 8, 15)` — cursor inside `simpleNewContact`
-    // on the ref line. Click the editor first so it owns focus before the command-palette
+    // Place the cursor inside `simpleNewContact` on the ref line (8:15). Click the editor first so
+    // it owns focus before the command-palette
     // cursor placement (mirrors lwcLspGoToDefinitionHtml precedent); without focus, the
     // subsequent Go to Definition runs against a stale/unfocused editor and resolves nothing.
     await page.locator(`${EDITOR_WITH_URI}[data-uri$="aura1.cmp"]`).first().click();
@@ -68,8 +67,8 @@ test('Aura LSP: go to definition', async ({ page }) => {
   });
 
   await test.step('Go to Definition lands on the attribute definition (L3)', async () => {
-    // Matches WDIO `executeQuickPick('Go to Definition')`. Within-file nav (no new tab), so
-    // no Ctrl+Click (apex used Ctrl+Click only for its cross-file nav). LSP readiness already
+    // Within-file nav (no new tab), so no Ctrl+Click (apex used Ctrl+Click only for its
+    // cross-file nav). LSP readiness already
     // synced by `waitForAuraLspReady`. Use the command palette (lwcLspGoToDefinitionHtml precedent)
     // rather than F12, which is more host/environment-sensitive (can be intercepted as a global
     // shortcut). `preserveSelection` keeps the 8:15 cursor placed above — otherwise the palette's
@@ -81,8 +80,7 @@ test('Aura LSP: go to definition', async ({ page }) => {
     // resolves the def to the `simpleNewContact` name-attribute value range on L3
     // (`getAuraBindingTemplateDeclaration`); Go to Definition selects that range and places the
     // cursor at its END. Local run 2026-06-12 (test:desktop, VS Code 1.124.2): status bar read
-    // exactly `Ln 3, Col 27` — matches WDIO `getCoordinates()` → [3, 27], so the assertion is
-    // locked to the exact value.
+    // exactly `Ln 3, Col 27`, so the assertion is locked to the exact value.
     await expect(positionItem).toContainText(/Ln 3, Col 27/, { timeout: 15_000 });
 
     // SECONDARY (defense): aura1.cmp is still the active tab — confirms within-file nav (no spurious

--- a/packages/salesforcedx-vscode-org/test/playwright/specs/orgPicker.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-org/test/playwright/specs/orgPicker.desktop.spec.ts
@@ -58,17 +58,16 @@ test('org picker: set default org, create scratch org, switch default org', asyn
   await closeWelcomeTabs(page);
   await ensureSecondarySideBarHidden(page);
 
-  // WDIO it #1: initial state shows "No Default Org Set". Dev hub is already globally auth'd in CI
+  // Initial state shows "No Default Org Set". Dev hub is already globally auth'd in CI
   // (orgE2E.yml --set-default-dev-hub); read its alias rather than re-authorizing via UI.
   const devHubAlias = await getTargetDevHub();
   await test.step('status bar shows No Default Org Set', async () => {
     await expectOrgPickerStatusBar(page, NO_DEFAULT_ORG);
   });
 
-  // WDIO it #2: open the picker via the status bar, verify the 5 action items, select the dev hub.
-  // WDIO waits for the `SFDX: Set a Default Org successfully ran` toast, then also asserts the
-  // deterministic signals (output-channel config table + status bar). Port both: wait for the toast
-  // (with a generous timeout since it auto-collapses) and then the persistent signals below.
+  // Open the picker via the status bar, verify the 5 action items, select the dev hub. Wait for the
+  // `SFDX: Set a Default Org successfully ran` toast (with a generous timeout since it auto-collapses)
+  // and then the persistent deterministic signals (output-channel config table + status bar) below.
   await test.step('set dev hub as default org via picker', async () => {
     await clickOrgPickerStatusBar(page, NO_DEFAULT_ORG);
     await expectOrgPickerActionItems(page, PICKER_ACTION_ITEMS);
@@ -76,7 +75,7 @@ test('org picker: set default org, create scratch org, switch default org', asyn
     await waitForNotification(page, SET_DEFAULT_ORG_RAN);
   });
 
-  // WDIO it #2 (output assertion): sf config was actually written, not just the status bar updated.
+  // Output assertion: sf config was actually written, not just the status bar updated.
   // configSet.ts renders a `createTable` whose cells are padded to each column's max width and joined
   // with two spaces, e.g. `target-org  hub    true`. Build the expected row with that same padding so
   // the substring match is exact regardless of the alias length (output search is substring, not regex).
@@ -92,9 +91,9 @@ test('org picker: set default org, create scratch org, switch default org', asyn
     await expectOrgPickerStatusBar(page, devHubAlias);
   });
 
-  // WDIO it #3: create a default scratch org via the picker's 3 prompts (def file, alias, days).
-  // Alias is dynamic and captured for reuse, mirroring WDIO's `scratchOrgAliasName`. Include the
-  // worker index + a random suffix so parallel workers can never collide on the same timestamp.
+  // Create a default scratch org via the picker's 3 prompts (def file, alias, days). Alias is
+  // dynamic and captured for reuse; include the worker index + a random suffix so parallel workers
+  // can never collide on the same timestamp.
   const scratchAlias = `TempScratchOrg_${Date.now()}_${testInfo.workerIndex}_${Math.random().toString(36).slice(2)}`;
   await test.step('create a default scratch org', async () => {
     await clickOrgPickerStatusBar(page, devHubAlias);
@@ -123,8 +122,8 @@ test('org picker: set default org, create scratch org, switch default org', asyn
     await page.keyboard.press('Enter');
   });
 
-  // `--set-default` makes the new org the default. WDIO waits for the create command's success
-  // notification (multi-minute command); port that, then assert the persistent status-bar signal.
+  // `--set-default` makes the new org the default. Wait for the create command's success
+  // notification (multi-minute command), then assert the persistent status-bar signal.
   await test.step('scratch org create completes and is auto-set as default', async () => {
     await waitForNotification(page, CREATE_SCRATCH_ORG_RAN, { timeout: 600_000 });
     // The success notification signals the command finished; the status bar updates within seconds, so
@@ -132,8 +131,8 @@ test('org picker: set default org, create scratch org, switch default org', asyn
     await expectOrgPickerStatusBar(page, scratchAlias, { timeout: 30_000 });
   });
 
-  // WDIO it #4: switch default org back and forth. No window reload — `setDefaultOrg` re-reads auth
-  // state from disk on every picker open (orgList.ts AuthInfo.listAllAuthorizations + disk aliases).
+  // Switch default org back and forth. No window reload — `setDefaultOrg` re-reads auth state from
+  // disk on every picker open (orgList.ts AuthInfo.listAllAuthorizations + disk aliases).
   await test.step('switch default org back to dev hub', async () => {
     await clickOrgPickerStatusBar(page, scratchAlias);
     // Staleness guard: confirm the freshly created scratch org appears without a reload.
@@ -150,8 +149,8 @@ test('org picker: set default org, create scratch org, switch default org', asyn
     await expectOrgPickerStatusBar(page, scratchAlias);
   });
 
-  // Clean up the scratch org created above (WDIO did this via testSetup.tearDown()). Best-effort:
-  // the org auto-expires in 1 day and a nightly cron sweeps leftovers, but deleting here avoids
+  // Clean up the scratch org created above. Best-effort: the org auto-expires in 1 day and a
+  // nightly cron sweeps leftovers, but deleting here avoids
   // leaking a real org on every run. Guarded so a delete failure doesn't fail a passing test.
   await test.step('delete the created scratch org', async () => {
     await execAsync(`sf org delete scratch --target-org ${scratchAlias} --no-prompt`, { env }).catch(

--- a/packages/salesforcedx-vscode-org/test/playwright/specs/orgPicker.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-org/test/playwright/specs/orgPicker.desktop.spec.ts
@@ -131,8 +131,8 @@ test('org picker: set default org, create scratch org, switch default org', asyn
     await expectOrgPickerStatusBar(page, scratchAlias, { timeout: 30_000 });
   });
 
-  // Switch default org back and forth. No window reload — `setDefaultOrg` re-reads auth state from
-  // disk on every picker open (orgList.ts AuthInfo.listAllAuthorizations + disk aliases).
+  // Switch default org back and forth. No window reload — `setDefaultOrg` re-reads auth state
+  // from disk on every picker open (orgList.ts AuthInfo.listAllAuthorizations + disk aliases).
   await test.step('switch default org back to dev hub', async () => {
     await clickOrgPickerStatusBar(page, scratchAlias);
     // Staleness guard: confirm the freshly created scratch org appears without a reload.
@@ -150,8 +150,8 @@ test('org picker: set default org, create scratch org, switch default org', asyn
   });
 
   // Clean up the scratch org created above. Best-effort: the org auto-expires in 1 day and a
-  // nightly cron sweeps leftovers, but deleting here avoids
-  // leaking a real org on every run. Guarded so a delete failure doesn't fail a passing test.
+  // nightly cron sweeps leftovers, but deleting here avoids leaking a real org on every run.
+  // Guarded so a delete failure doesn't fail a passing test.
   await test.step('delete the created scratch org', async () => {
     await execAsync(`sf org delete scratch --target-org ${scratchAlias} --no-prompt`, { env }).catch(
       (error: unknown) => {


### PR DESCRIPTION
## Summary

- Stripped stale WDIO references from comments in 9 e2e test/utility files (comment-only changes, no logic altered).
- Preserved the current-behavior explanations that accompanied each WDIO ref.
- Comments whose sole content was a WDIO reference were dropped entirely.

## Plan

[.claude/plans/W-23195324.md](.claude/plans/W-23195324.md)

## Reviewer notes

- **low:** Stale 'mirrors the WDIO' text survives only in a wireit build-cache artifact (`packages/playwright-vscode-ext/.wireit/.../out/pages/statusBar.d.ts`), not in any source file. Harmless and regenerated on next compile; no code change needed.

### What issues does this PR fix or reference?

@W-23195324@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002dF2OcYAK/view