### PR TITLE
ci: pin Salesforce CLI version via SF_CLI_VERSION GHA variable - W-23202080

### DIFF
--- a/.github/workflows/apexLogE2E.yml
+++ b/.github/workflows/apexLogE2E.yml
@@ -84,7 +84,7 @@ jobs:
         uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           max_attempts: 3
-          command: npm i -g @salesforce/cli
+          command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
       - name: Auth to dev hub (global)
@@ -214,7 +214,7 @@ jobs:
         uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           max_attempts: 3
-          command: npm i -g @salesforce/cli
+          command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
       - name: Auth to dev hub (global)

--- a/.github/workflows/apexOasE2E.yml
+++ b/.github/workflows/apexOasE2E.yml
@@ -98,7 +98,7 @@ jobs:
         uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           max_attempts: 3
-          command: npm i -g @salesforce/cli
+          command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
       - name: Auth to dev hub (global)

--- a/.github/workflows/apexReplayDebuggerE2E.yml
+++ b/.github/workflows/apexReplayDebuggerE2E.yml
@@ -95,7 +95,7 @@ jobs:
         uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           max_attempts: 3
-          command: npm i -g @salesforce/cli
+          command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
       - name: Auth to dev hub (global)

--- a/.github/workflows/apexTestingE2E.yml
+++ b/.github/workflows/apexTestingE2E.yml
@@ -84,7 +84,7 @@ jobs:
         uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           max_attempts: 3
-          command: npm i -g @salesforce/cli
+          command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
       - name: Auth to dev hub (global)
@@ -237,7 +237,7 @@ jobs:
         uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           max_attempts: 3
-          command: npm i -g @salesforce/cli
+          command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
       - name: Auth to dev hub (global)

--- a/.github/workflows/cleanupDeletedScratchOrgs.yml
+++ b/.github/workflows/cleanupDeletedScratchOrgs.yml
@@ -26,7 +26,7 @@ jobs:
         uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           max_attempts: 3
-          command: npm install -g @salesforce/cli
+          command: npm install -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
       - name: Verify Salesforce CLI

--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -98,7 +98,7 @@ jobs:
         uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           max_attempts: 3
-          command: npm i -g @salesforce/cli
+          command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
       - name: Auth to dev hub (global)

--- a/.github/workflows/metadataE2E.yml
+++ b/.github/workflows/metadataE2E.yml
@@ -88,7 +88,7 @@ jobs:
         uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           max_attempts: 3
-          command: npm i -g @salesforce/cli
+          command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
       - name: Clone dreamhouse
@@ -260,7 +260,7 @@ jobs:
         uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           max_attempts: 3
-          command: npm i -g @salesforce/cli
+          command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
       - name: Auth to dev hub (global)
@@ -419,7 +419,7 @@ jobs:
       - name: Install Salesforce CLI
         if: steps.try-run.outcome == 'failure'
         run: |
-          npm i -g @salesforce/cli
+          npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
 
       - name: Auth to dev hub (global)
         if: steps.try-run.outcome == 'failure'
@@ -552,7 +552,7 @@ jobs:
       - name: Install Salesforce CLI
         if: steps.try-run.outcome == 'failure'
         run: |
-          npm i -g @salesforce/cli
+          npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
 
       - name: Auth to dev hub (global)
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/orgBrowserE2E.yml
+++ b/.github/workflows/orgBrowserE2E.yml
@@ -89,7 +89,7 @@ jobs:
         uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           max_attempts: 3
-          command: npm i -g @salesforce/cli
+          command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
       - name: Clone dreamhouse
@@ -236,7 +236,7 @@ jobs:
         uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           max_attempts: 3
-          command: npm i -g @salesforce/cli
+          command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
       - name: Install Playwright browsers and OS deps

--- a/.github/workflows/orgE2E.yml
+++ b/.github/workflows/orgE2E.yml
@@ -95,7 +95,7 @@ jobs:
         uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           max_attempts: 3
-          command: npm i -g @salesforce/cli
+          command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
       - name: Generate minimal project

--- a/.github/workflows/servicesE2E.yml
+++ b/.github/workflows/servicesE2E.yml
@@ -83,7 +83,7 @@ jobs:
         uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           max_attempts: 3
-          command: npm i -g @salesforce/cli
+          command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
       - name: Install Playwright browsers and OS deps

--- a/.github/workflows/soqlE2E.yml
+++ b/.github/workflows/soqlE2E.yml
@@ -84,7 +84,7 @@ jobs:
         uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           max_attempts: 3
-          command: npm i -g @salesforce/cli
+          command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
       - name: Auth to dev hub (global)
@@ -224,7 +224,7 @@ jobs:
         uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           max_attempts: 3
-          command: npm i -g @salesforce/cli
+          command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
       - name: Auth to dev hub (global)


### PR DESCRIPTION
### What does this PR do?

Parameterizes the `@salesforce/cli` global install across **18 install sites in 11 E2E workflows** so the CLI version can be pinned from a repo-level GitHub Actions variable instead of always pulling `latest`.

Install command becomes:

```
npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
```

**The `SF_CLI_VERSION` variable:**
- Set it under **Settings → Secrets and variables → Actions → Variables** (already set by the repo admin).
- Pin a specific version (e.g. `2.110.6`) to lock all E2E workflows to that CLI build — useful when a `latest` CLI release breaks tests, or to reproduce CI against a known-good version.
- When the variable is **empty or unset**, the `|| 'latest'` fallback preserves the previous behavior (install the newest published CLI).
- No workflow edits needed to change the pinned version — update the variable and re-run.

**Workflows touched:** coreE2E, soqlE2E, orgE2E, orgBrowserE2E, servicesE2E, apexReplayDebuggerE2E, apexTestingE2E, apexLogE2E, apexOasE2E, metadataE2E, cleanupDeletedScratchOrgs.

Workflows that don't install the CLI (no org/scratch needed) are unchanged: apexLspE2E, auraE2E, visualforceE2E, lwcPlaywrightE2E, playwrightVscodeExtE2E.

### What issues does this PR fix or reference?
@W-23202080@