### PR TITLE
fix(flakiness-review): match End to End Tests workflow + warn on 0-match scan - W-23196267

### DIFF
--- a/.claude/plans/W-23196267.md
+++ b/.claude/plans/W-23196267.md
@@ -1,0 +1,49 @@
+# W-23196267 — flakiness-review scan misses "End to End Tests" workflow
+
+## Context
+
+- File: `.claude/workflows/flakiness-review.js` (single-file workflow script; no imports/TS/tests — see workflows/README.md).
+- Phase 1 "Scan CI runs" filters `gh run list` by jq regex `test("Playwright|E2E|e2e"; "i")` (line 224).
+- Real aggregator workflow `End to End Tests` (id 55532814) has no Playwright/E2E/e2e substring (spaces, no "e2e") → never matches. It runs all suites incl `playwright-soql / e2e-desktop (windows-latest)` which fails daily.
+- Old regex `Playwright|E2E|e2e` matches 14 live workflows (verified `gh workflow list`): the 12 `* E2E (Playwright)` suites + `Playwright E2E Full Suite` + `Playwright VS Code Ext E2E Tests`. NO `Publish*` workflow contains E2E/Playwright — the WI's "npm-publish false positive" claim is wrong. The real gap: old regex misses `End to End Tests` (aggregator) + `Nightly Build Develop`/`Nightly Build Main`.
+- New regex MUST preserve all 14 old matches. The earlier draft `End to End|E2E \(Playwright\)|Nightly Build` silently DROPPED `Playwright E2E Full Suite` and `Playwright VS Code Ext E2E Tests` (no `E2E (Playwright)` substring) — rejected.
+- Final regex: `End to End|Nightly Build|(Playwright|E2E)(?!.*Publish)`. Verified live against all 49 workflow names:
+  - matches: 14 old + `End to End Tests` + `Nightly Build Develop` + `Nightly Build Main` = 17 (superset of old, zero regression).
+  - excludes: every `Publish*` workflow (lookahead is defensive — none match today, future-proofs a hypothetical `Publish ... E2E`).
+  - `"End to End Tests" | test("Playwright|E2E|e2e";"i")` → false; same name vs new regex → true.
+- Job names confirm pattern `e2e-desktop`/`e2e-web` (e.g. `playwright-soql / e2e-desktop (windows-latest)`).
+- Only downstream use of the regex match is line 224; rest reads `workflowName` from runs data.
+- Guard already at lines 233-236 (0 runs → log + early return) but message reads as benign ("nothing to analyze") — doesn't flag a possibly-broken filter.
+
+## Phases
+
+### Phase 1 — broaden workflow filter + harden 0-match guard
+
+`.claude/workflows/flakiness-review.js`
+
+- Line 224 jq: replace `Playwright|E2E|e2e` with `End to End|Nightly Build|(Playwright|E2E)(?!.*Publish)`. Final bash line:
+  `--jq '[.[] | select(.workflowName | test("End to End|Nightly Build|(Playwright|E2E)(?!.*Publish)"; "i"))]'`
+  This is inside a markdown `bash` fence within a JS template literal; the regex is single-quoted (`--jq '...'`) and contains no single-quote/backtick, so no template-literal escaping is needed. The group `(Playwright|E2E)` and lookahead `(?!.*Publish)` are regex syntax inside the `test()` string arg — NOT jq `\(...)` interpolation — so they pass through verbatim (confirmed by live jq run).
+- Keep `e2e-desktop|e2e-web` job-name angle in a code comment as the source-of-truth signal.
+- Add comment above the `gh run list` block documenting why substring `e2e` was wrong (the `End to End Tests` aggregator name).
+- Lines 233-236 guard: keep early return but change `log` to a WARN-style message — explicitly state filter matched 0 real E2E workflows, list the regex used, so a bad filter surfaces instead of reading "all stable".
+- Optional: log matched workflow names (`runsResult.runs` distinct `workflowName`) so future regex drift is visible in run output.
+
+commit message: `fix(flakiness-review): match "End to End Tests" workflow + warn on 0-match scan - W-23196267`
+
+## Skills to apply
+
+- concise — plan + any md.
+- typescript — file is `.js` but follows project TS conventions (const declarations, template literals, no mutation).
+- verification — empirical jq checks against live workflow names.
+
+## Verification
+
+(no e2e tests on branch — this is a workflow script, not product code)
+
+- jq sanity (runnable, actual regex): `gh workflow list --all --json name | jq -r '[.[] | select(.name | test("End to End|Nightly Build|(Playwright|E2E)(?!.*Publish)"; "i"))][].name' | sort` → must list all 12 `* E2E (Playwright)` suites + `Playwright E2E Full Suite` + `Playwright VS Code Ext E2E Tests` + `End to End Tests` + `Nightly Build Develop` + `Nightly Build Main` (17 total); zero `Publish*` names. Already verified live 2026-06-26.
+- no-regression check: new-regex match set ⊇ old-regex match set:
+  `gh workflow list --all --json name | jq -r '.[].name | select(test("Playwright|E2E|e2e";"i"))' | sort > /tmp/old; gh workflow list --all --json name | jq -r '.[].name | select(test("End to End|Nightly Build|(Playwright|E2E)(?!.*Publish)";"i"))' | sort > /tmp/new; comm -23 /tmp/old /tmp/new` → empty (no old match lost).
+- confirm old regex misses target: `echo '"End to End Tests"' | jq 'test("Playwright|E2E|e2e";"i")'` → false; `echo '"End to End Tests"' | jq 'test("End to End|Nightly Build|(Playwright|E2E)(?!.*Publish)";"i")'` → true.
+- spot-check a recent `End to End Tests` run id surfaces (run 28224648848 = failure on 2026-06-26) so failures are now in scope.
+- review edited script: regex sits in `--jq '...'` single-quotes inside the `bash` fence; confirm no stray backtick/single-quote breaks the JS template literal.

--- a/.claude/plans/W-23196267.md
+++ b/.claude/plans/W-23196267.md
@@ -5,11 +5,11 @@
 - File: `.claude/workflows/flakiness-review.js` (single-file workflow script; no imports/TS/tests — see workflows/README.md).
 - Phase 1 "Scan CI runs" filters `gh run list` by jq regex `test("Playwright|E2E|e2e"; "i")` (line 224).
 - Real aggregator workflow `End to End Tests` (id 55532814) has no Playwright/E2E/e2e substring (spaces, no "e2e") → never matches. It runs all suites incl `playwright-soql / e2e-desktop (windows-latest)` which fails daily.
-- Old regex `Playwright|E2E|e2e` matches 14 live workflows (verified `gh workflow list`): the 12 `* E2E (Playwright)` suites + `Playwright E2E Full Suite` + `Playwright VS Code Ext E2E Tests`. NO `Publish*` workflow contains E2E/Playwright — the WI's "npm-publish false positive" claim is wrong. The real gap: old regex misses `End to End Tests` (aggregator) + `Nightly Build Develop`/`Nightly Build Main`.
-- New regex MUST preserve all 14 old matches. The earlier draft `End to End|E2E \(Playwright\)|Nightly Build` silently DROPPED `Playwright E2E Full Suite` and `Playwright VS Code Ext E2E Tests` (no `E2E (Playwright)` substring) — rejected.
-- Final regex: `End to End|Nightly Build|(Playwright|E2E)(?!.*Publish)`. Verified live against all 49 workflow names:
-  - matches: 14 old + `End to End Tests` + `Nightly Build Develop` + `Nightly Build Main` = 17 (superset of old, zero regression).
-  - excludes: every `Publish*` workflow (lookahead is defensive — none match today, future-proofs a hypothetical `Publish ... E2E`).
+- Old regex matches 14 live workflows: 12 `* E2E (Playwright)` + `Playwright E2E Full Suite` + `Playwright VS Code Ext E2E Tests`. No `Publish*` workflow contains E2E/Playwright — WI's "npm-publish false positive" claim is wrong. Real gap: old regex misses `End to End Tests` aggregator.
+- New regex MUST preserve all 14 old matches. Earlier draft `End to End|E2E \(Playwright\)|Nightly Build` dropped `Playwright E2E Full Suite` + `Playwright VS Code Ext E2E Tests` — rejected.
+- Final regex: `End to End|Playwright|E2E`. Verified live against all 49 workflow names:
+  - matches: 14 old + `End to End Tests` = 15 (superset of old, zero regression).
+  - `Nightly Build *` excluded — calls `buildAndTest.yml`, no Playwright/E2E jobs, no playwright-report artifacts for Phase 2.
   - `"End to End Tests" | test("Playwright|E2E|e2e";"i")` → false; same name vs new regex → true.
 - Job names confirm pattern `e2e-desktop`/`e2e-web` (e.g. `playwright-soql / e2e-desktop (windows-latest)`).
 - Only downstream use of the regex match is line 224; rest reads `workflowName` from runs data.
@@ -21,9 +21,9 @@
 
 `.claude/workflows/flakiness-review.js`
 
-- Line 224 jq: replace `Playwright|E2E|e2e` with `End to End|Nightly Build|(Playwright|E2E)(?!.*Publish)`. Final bash line:
-  `--jq '[.[] | select(.workflowName | test("End to End|Nightly Build|(Playwright|E2E)(?!.*Publish)"; "i"))]'`
-  This is inside a markdown `bash` fence within a JS template literal; the regex is single-quoted (`--jq '...'`) and contains no single-quote/backtick, so no template-literal escaping is needed. The group `(Playwright|E2E)` and lookahead `(?!.*Publish)` are regex syntax inside the `test()` string arg — NOT jq `\(...)` interpolation — so they pass through verbatim (confirmed by live jq run).
+- Line 224 jq: replace `Playwright|E2E|e2e` with `End to End|Playwright|E2E`, sourced from a `WORKFLOW_NAME_REGEX` const shared by the jq prompt + 0-match WARNING (no drift). Final bash line:
+  `--jq '[.[] | select(.workflowName | test("${WORKFLOW_NAME_REGEX}"; "i"))]'`
+  (confirmed live; the regex is single-quoted in `--jq '...'`, no template-literal escaping needed)
 - Keep `e2e-desktop|e2e-web` job-name angle in a code comment as the source-of-truth signal.
 - Add comment above the `gh run list` block documenting why substring `e2e` was wrong (the `End to End Tests` aggregator name).
 - Lines 233-236 guard: keep early return but change `log` to a WARN-style message — explicitly state filter matched 0 real E2E workflows, list the regex used, so a bad filter surfaces instead of reading "all stable".
@@ -33,17 +33,17 @@ commit message: `fix(flakiness-review): match "End to End Tests" workflow + warn
 
 ## Skills to apply
 
-- concise — plan + any md.
-- typescript — file is `.js` but follows project TS conventions (const declarations, template literals, no mutation).
-- verification — empirical jq checks against live workflow names.
+- concise
+- typescript
+- verification
 
 ## Verification
 
 (no e2e tests on branch — this is a workflow script, not product code)
 
-- jq sanity (runnable, actual regex): `gh workflow list --all --json name | jq -r '[.[] | select(.name | test("End to End|Nightly Build|(Playwright|E2E)(?!.*Publish)"; "i"))][].name' | sort` → must list all 12 `* E2E (Playwright)` suites + `Playwright E2E Full Suite` + `Playwright VS Code Ext E2E Tests` + `End to End Tests` + `Nightly Build Develop` + `Nightly Build Main` (17 total); zero `Publish*` names. Already verified live 2026-06-26.
-- no-regression check: new-regex match set ⊇ old-regex match set:
-  `gh workflow list --all --json name | jq -r '.[].name | select(test("Playwright|E2E|e2e";"i"))' | sort > /tmp/old; gh workflow list --all --json name | jq -r '.[].name | select(test("End to End|Nightly Build|(Playwright|E2E)(?!.*Publish)";"i"))' | sort > /tmp/new; comm -23 /tmp/old /tmp/new` → empty (no old match lost).
-- confirm old regex misses target: `echo '"End to End Tests"' | jq 'test("Playwright|E2E|e2e";"i")'` → false; `echo '"End to End Tests"' | jq 'test("End to End|Nightly Build|(Playwright|E2E)(?!.*Publish)";"i")'` → true.
+- jq sanity: `gh workflow list --all --json name | jq -r '[.[] | select(.name | test("End to End|Playwright|E2E"; "i"))][].name' | sort` → 15 names (12 `* E2E (Playwright)` + `Playwright E2E Full Suite` + `Playwright VS Code Ext E2E Tests` + `End to End Tests`); zero `Nightly Build`/`Publish*`. Verified live 2026-06-26.
+- no-regression check: new ⊇ old:
+  `gh workflow list --all --json name | jq -r '.[].name | select(test("Playwright|E2E|e2e";"i"))' | sort > /tmp/old; gh workflow list --all --json name | jq -r '.[].name | select(test("End to End|Playwright|E2E";"i"))' | sort > /tmp/new; comm -23 /tmp/old /tmp/new` → empty.
+- confirm old regex misses target: `echo '"End to End Tests"' | jq 'test("Playwright|E2E|e2e";"i")'` → false; vs new regex → true.
 - spot-check a recent `End to End Tests` run id surfaces (run 28224648848 = failure on 2026-06-26) so failures are now in scope.
 - review edited script: regex sits in `--jq '...'` single-quotes inside the `bash` fence; confirm no stray backtick/single-quote breaks the JS template literal.

--- a/.claude/workflows/flakiness-review.js
+++ b/.claude/workflows/flakiness-review.js
@@ -212,6 +212,10 @@ const WI_DRAFTS_SCHEMA = {
 // PHASE 1: SCAN CI RUNS
 // =====================================================================
 
+// Single source of truth for the workflowName filter, shared between the
+// gh run list --jq below and the 0-match WARNING so they cannot drift.
+const WORKFLOW_NAME_REGEX = 'End to End|Playwright|E2E'
+
 phase('Scan CI runs')
 
 const runsResult = await agent(
@@ -224,11 +228,10 @@ Run this command and parse the output:
 # playwright-soql / e2e-desktop (windows-latest) suite, so a naive "e2e"
 # substring match silently drops it. Job names (e2e-desktop / e2e-web) are the
 # source-of-truth E2E signal, but gh run list filters on workflowName only.
-# Regex matches: "End to End Tests" + "Nightly Build *" + every "*Playwright*"/
-# "*E2E*" workflow, while the (?!.*Publish) lookahead excludes any Publish* run.
+# Regex matches: "End to End Tests" + every "*Playwright*"/"*E2E*" workflow.
 gh run list --repo ${REPO} --branch develop --limit 200 \\
   --json databaseId,workflowName,conclusion,createdAt,attempt \\
-  --jq '[.[] | select(.workflowName | test("End to End|Nightly Build|(Playwright|E2E)(?!.*Publish)"; "i"))]'
+  --jq '[.[] | select(.workflowName | test("${WORKFLOW_NAME_REGEX}"; "i"))]'
 \`\`\`
 
 For each run, also check if it was re-attempted (attempt > 1) — that's a strong signal of flakiness even if the final conclusion is "success".
@@ -239,19 +242,14 @@ Return all runs from the last ${DAYS} days (filter by createdAt). Include runs w
 
 if (!runsResult || !runsResult.runs.length) {
   log(
-    `WARNING: filter matched 0 E2E workflows in the last ${DAYS} days. ` +
-      `develop almost always has E2E runs, so this likely means the workflowName ` +
-      `regex is stale — NOT that CI is stable. Regex used: ` +
-      `test("End to End|Nightly Build|(Playwright|E2E)(?!.*Publish)"; "i"). ` +
-      `Compare against \`gh workflow list --all --json name\` and update the filter.`
+    `WARNING: filter matched 0 E2E workflows in the last ${DAYS} days. develop almost always has E2E runs, so this likely means the workflowName regex is stale — NOT that CI is stable. Regex used: test("${WORKFLOW_NAME_REGEX}"; "i"). Compare against \`gh workflow list --all --json name\` and update the filter.`
   )
   return { hypotheses: [], wis: [] }
 }
 
 const matchedWorkflows = [...new Set(runsResult.runs.map((r) => r.workflowName))].sort()
 log(
-  `Found ${runsResult.runs.length} E2E runs across ${matchedWorkflows.length} workflows: ` +
-    `${matchedWorkflows.join(', ')}. Collecting metrics...`
+  `Found ${runsResult.runs.length} E2E runs across ${matchedWorkflows.length} workflows: ${matchedWorkflows.join(', ')}. Collecting metrics...`
 )
 
 // =====================================================================

--- a/.claude/workflows/flakiness-review.js
+++ b/.claude/workflows/flakiness-review.js
@@ -219,9 +219,16 @@ const runsResult = await agent(
 
 Run this command and parse the output:
 \`\`\`bash
+# Filter to E2E workflows by name. The aggregator workflow is literally named
+# "End to End Tests" (no "e2e"/"E2E" substring) and runs the daily-failing
+# playwright-soql / e2e-desktop (windows-latest) suite, so a naive "e2e"
+# substring match silently drops it. Job names (e2e-desktop / e2e-web) are the
+# source-of-truth E2E signal, but gh run list filters on workflowName only.
+# Regex matches: "End to End Tests" + "Nightly Build *" + every "*Playwright*"/
+# "*E2E*" workflow, while the (?!.*Publish) lookahead excludes any Publish* run.
 gh run list --repo ${REPO} --branch develop --limit 200 \\
   --json databaseId,workflowName,conclusion,createdAt,attempt \\
-  --jq '[.[] | select(.workflowName | test("Playwright|E2E|e2e"; "i"))]'
+  --jq '[.[] | select(.workflowName | test("End to End|Nightly Build|(Playwright|E2E)(?!.*Publish)"; "i"))]'
 \`\`\`
 
 For each run, also check if it was re-attempted (attempt > 1) — that's a strong signal of flakiness even if the final conclusion is "success".
@@ -231,11 +238,21 @@ Return all runs from the last ${DAYS} days (filter by createdAt). Include runs w
 )
 
 if (!runsResult || !runsResult.runs.length) {
-  log('No Playwright E2E runs found in the last ' + DAYS + ' days — nothing to analyze.')
+  log(
+    `WARNING: filter matched 0 E2E workflows in the last ${DAYS} days. ` +
+      `develop almost always has E2E runs, so this likely means the workflowName ` +
+      `regex is stale — NOT that CI is stable. Regex used: ` +
+      `test("End to End|Nightly Build|(Playwright|E2E)(?!.*Publish)"; "i"). ` +
+      `Compare against \`gh workflow list --all --json name\` and update the filter.`
+  )
   return { hypotheses: [], wis: [] }
 }
 
-log(`Found ${runsResult.runs.length} E2E runs. Collecting metrics...`)
+const matchedWorkflows = [...new Set(runsResult.runs.map((r) => r.workflowName))].sort()
+log(
+  `Found ${runsResult.runs.length} E2E runs across ${matchedWorkflows.length} workflows: ` +
+    `${matchedWorkflows.join(', ')}. Collecting metrics...`
+)
 
 // =====================================================================
 // PHASE 2: COLLECT METRICS


### PR DESCRIPTION
## Summary

- The flakiness-review workflow's jq filter used regex `Playwright|E2E|e2e`, which never matched the `End to End Tests` aggregator workflow (no Playwright/E2E substring in its name).
- Replaced filter regex with `End to End|Playwright|E2E` — a strict superset: all 14 previously matched workflows plus `End to End Tests` (15 total, verified live).
- Hardened the 0-match guard to emit a WARNING with the regex used instead of a silent "nothing to analyze" log, so future filter drift surfaces immediately.

## Plan

[.claude/plans/W-23196267.md](.claude/plans/W-23196267.md)

### What issues does this PR fix or reference?

@W-23196267@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002dFusVYAS/view