### PR TITLE
chore(deps): bump actions/setup-node from v4 to v6 across all workflows - W-23201856

### DIFF
--- a/.claude/plans/W-23201856.md
+++ b/.claude/plans/W-23201856.md
@@ -2,7 +2,7 @@
 
 ## Context
 - 49 usages of `actions/setup-node@v4` across 32 workflow files in `.github/workflows/`
-- Uniform pattern: `node-version` (`vars.NODE_VERSION || 'lts/*'`) + `cache: npm`
+- Mixed patterns: `node-version` is `'22.22.3'`, `'lts/*'`, or `vars.NODE_VERSION || 'lts/*'`; `cache: npm` present in most but absent in some (e.g. validateNewIssues.yml)
 - v4→v6 safe here:
   - no `always-auth` (removed v6.1.0) — confirmed absent
   - auto-cache needs `packageManager` in package.json — absent, so `cache: npm` still required, unchanged
@@ -19,10 +19,9 @@
 ## Skills
 - gha-dependabot — GHA pin-bump conventions
 - concise — plan/doc style
-- typescript — TypeScript project standards
 
 ## Verification
 - `grep -rc "actions/setup-node@v4" .github/workflows/` → 0
 - `grep -rc "actions/setup-node@v6" .github/workflows/` → 49 total
 - YAML still valid (no `with:` block changes)
-- runtime correctness: validated by existing CI on branch (each workflow runs setup-node) — e2e-covered
+- runtime: CI on branch validates (each workflow runs setup-node)

--- a/.claude/plans/W-23201856.md
+++ b/.claude/plans/W-23201856.md
@@ -1,0 +1,28 @@
+# W-23201856 — Bump actions/setup-node @v4 → @v6
+
+## Context
+- 49 usages of `actions/setup-node@v4` across 32 workflow files in `.github/workflows/`
+- Uniform pattern: `node-version` (`vars.NODE_VERSION || 'lts/*'`) + `cache: npm`
+- v4→v6 safe here:
+  - no `always-auth` (removed v6.1.0) — confirmed absent
+  - auto-cache needs `packageManager` in package.json — absent, so `cache: npm` still required, unchanged
+  - `node-version` stays explicit — test Node unchanged
+- Mechanical pin bump only
+
+## Phases
+
+### Phase 1 — bump all @v4 → @v6
+- find/replace `actions/setup-node@v4` → `actions/setup-node@v6` across all 32 files
+- verify 0 remaining `@v4`, 49 `@v6`
+- commit: `chore(deps): bump actions/setup-node from v4 to v6 across workflows - W-23201856`
+
+## Skills
+- gha-dependabot — GHA pin-bump conventions
+- concise — plan/doc style
+- typescript — TypeScript project standards
+
+## Verification
+- `grep -rc "actions/setup-node@v4" .github/workflows/` → 0
+- `grep -rc "actions/setup-node@v6" .github/workflows/` → 49 total
+- YAML still valid (no `with:` block changes)
+- runtime correctness: validated by existing CI on branch (each workflow runs setup-node) — e2e-covered

--- a/.github/workflows/apexLogE2E.yml
+++ b/.github/workflows/apexLogE2E.yml
@@ -54,7 +54,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'
@@ -183,7 +183,7 @@ jobs:
         run: echo "::notice::VS Code version=${PLAYWRIGHT_VSCODE_VERSION}"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'

--- a/.github/workflows/apexLspE2E.yml
+++ b/.github/workflows/apexLspE2E.yml
@@ -64,7 +64,7 @@ jobs:
         run: echo "::notice::VS Code version=${PLAYWRIGHT_VSCODE_VERSION}"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'

--- a/.github/workflows/apexOasE2E.yml
+++ b/.github/workflows/apexOasE2E.yml
@@ -68,7 +68,7 @@ jobs:
         run: echo "::notice::VS Code version=${PLAYWRIGHT_VSCODE_VERSION}"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'

--- a/.github/workflows/apexReplayDebuggerE2E.yml
+++ b/.github/workflows/apexReplayDebuggerE2E.yml
@@ -68,7 +68,7 @@ jobs:
         run: echo "::notice::VS Code version=${PLAYWRIGHT_VSCODE_VERSION}"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'

--- a/.github/workflows/apexTestingE2E.yml
+++ b/.github/workflows/apexTestingE2E.yml
@@ -54,7 +54,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'
@@ -207,7 +207,7 @@ jobs:
         run: echo "::notice::VS Code version=${PLAYWRIGHT_VSCODE_VERSION}"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'

--- a/.github/workflows/auraE2E.yml
+++ b/.github/workflows/auraE2E.yml
@@ -64,7 +64,7 @@ jobs:
         run: echo "::notice::VS Code version=${PLAYWRIGHT_VSCODE_VERSION}"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'

--- a/.github/workflows/buildAll.yml
+++ b/.github/workflows/buildAll.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
           cache: npm

--- a/.github/workflows/cleanupDeletedScratchOrgs.yml
+++ b/.github/workflows/cleanupDeletedScratchOrgs.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
           cache: npm

--- a/.github/workflows/copyrightYearBump.yml
+++ b/.github/workflows/copyrightYearBump.yml
@@ -20,7 +20,7 @@ jobs:
           ref: develop
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
           cache: npm

--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -68,7 +68,7 @@ jobs:
         run: echo "::notice::VS Code version=${PLAYWRIGHT_VSCODE_VERSION}"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'

--- a/.github/workflows/createAndTestBetaReleaseBranch.yml
+++ b/.github/workflows/createAndTestBetaReleaseBranch.yml
@@ -22,7 +22,7 @@ jobs:
           ssh-strict: false
           token: ${{ secrets.IDEE_GH_TOKEN }}
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
       - uses: ./.github/actions/gitConfig

--- a/.github/workflows/createReleaseBranch.yml
+++ b/.github/workflows/createReleaseBranch.yml
@@ -38,7 +38,7 @@ jobs:
           ssh-strict: false
           token: ${{ secrets.IDEE_GH_TOKEN }}
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
       - uses: ./.github/actions/gitConfig

--- a/.github/workflows/generateChangelog.yml
+++ b/.github/workflows/generateChangelog.yml
@@ -16,7 +16,7 @@ jobs:
           token: ${{ secrets.IDEE_GH_TOKEN }}
           fetch-depth: '0' # Fetching tags will fail if it is not 0
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
       - uses: ./.github/actions/gitConfig

--- a/.github/workflows/generateXsdForMetadataTypes.yml
+++ b/.github/workflows/generateXsdForMetadataTypes.yml
@@ -19,7 +19,7 @@ jobs:
           ref: ${{ github.event.ref }}
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
           cache: npm

--- a/.github/workflows/lwcPlaywrightE2E.yml
+++ b/.github/workflows/lwcPlaywrightE2E.yml
@@ -50,7 +50,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'
@@ -153,7 +153,7 @@ jobs:
         run: echo "::notice::VS Code version=${PLAYWRIGHT_VSCODE_VERSION}"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'
@@ -250,7 +250,7 @@ jobs:
         run: echo "::notice::VS Code version=${PLAYWRIGHT_VSCODE_VERSION}"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'
@@ -347,7 +347,7 @@ jobs:
         run: echo "::notice::VS Code version=${PLAYWRIGHT_VSCODE_VERSION}"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'

--- a/.github/workflows/metadataE2E.yml
+++ b/.github/workflows/metadataE2E.yml
@@ -56,7 +56,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'
@@ -228,7 +228,7 @@ jobs:
         run: echo "::notice::VS Code version=${PLAYWRIGHT_VSCODE_VERSION}"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'
@@ -396,7 +396,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'
@@ -527,7 +527,7 @@ jobs:
         run: echo "::notice::VS Code version=${PLAYWRIGHT_VSCODE_VERSION}"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'

--- a/.github/workflows/orgBrowserE2E.yml
+++ b/.github/workflows/orgBrowserE2E.yml
@@ -54,7 +54,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'
@@ -200,7 +200,7 @@ jobs:
         run: echo "::notice::VS Code version=${PLAYWRIGHT_VSCODE_VERSION}"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'

--- a/.github/workflows/orgE2E.yml
+++ b/.github/workflows/orgE2E.yml
@@ -65,7 +65,7 @@ jobs:
         run: echo "::notice::VS Code version=${PLAYWRIGHT_VSCODE_VERSION}"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'

--- a/.github/workflows/playwrightVscodeExtE2E.yml
+++ b/.github/workflows/playwrightVscodeExtE2E.yml
@@ -48,7 +48,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'
@@ -151,7 +151,7 @@ jobs:
         run: echo "::notice::VS Code version=${PLAYWRIGHT_VSCODE_VERSION}"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'

--- a/.github/workflows/publishBetaRelease.yml
+++ b/.github/workflows/publishBetaRelease.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
       - uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main

--- a/.github/workflows/publishOpenVSX.yml
+++ b/.github/workflows/publishOpenVSX.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           ref: 'main'
           token: ${{ secrets.IDEE_GH_TOKEN }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
       - name: downloadExtensionsFromRelease

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           ref: 'main'
           token: ${{ secrets.IDEE_GH_TOKEN }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
       - name: downloadExtensionsFromRelease

--- a/.github/workflows/reportInstalls.yml
+++ b/.github/workflows/reportInstalls.yml
@@ -12,7 +12,7 @@ jobs:
       OVSX_PAT: ${{ secrets.IDEE_OVSX_PAT }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
           cache: npm

--- a/.github/workflows/servicesE2E.yml
+++ b/.github/workflows/servicesE2E.yml
@@ -54,7 +54,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'

--- a/.github/workflows/soqlE2E.yml
+++ b/.github/workflows/soqlE2E.yml
@@ -54,7 +54,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'
@@ -193,7 +193,7 @@ jobs:
         run: echo "::notice::VS Code version=${PLAYWRIGHT_VSCODE_VERSION}"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'

--- a/.github/workflows/tagAndRelease.yml
+++ b/.github/workflows/tagAndRelease.yml
@@ -19,7 +19,7 @@ jobs:
           ref: 'main'
           token: ${{ secrets.IDEE_GH_TOKEN }}
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
       - uses: ./.github/actions/gitConfig

--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
           cache: npm

--- a/.github/workflows/unitTestsWindows.yml
+++ b/.github/workflows/unitTestsWindows.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
           cache: 'npm'

--- a/.github/workflows/validateNewIssues.yml
+++ b/.github/workflows/validateNewIssues.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
       - name: Install dependencies
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
       - name: Install dependencies
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
       - name: Install dependencies

--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
           cache: npm
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
           cache: npm

--- a/.github/workflows/validateUpdatedIssues.yml
+++ b/.github/workflows/validateUpdatedIssues.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
       - name: Install dependencies
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
       - name: Install dependencies
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
       - name: Install dependencies
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
       - name: Install dependencies

--- a/.github/workflows/visualforceE2E.yml
+++ b/.github/workflows/visualforceE2E.yml
@@ -61,7 +61,7 @@ jobs:
         run: echo "::notice::VS Code version=${PLAYWRIGHT_VSCODE_VERSION}"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.3'
           cache: 'npm'


### PR DESCRIPTION
## Summary

- Bumps all 49 `actions/setup-node@v4` usages to `@v6` across 32 workflow files in `.github/workflows/`
- Mechanical pin bump only — no changes to `node-version`, `cache`, or any other `with:` fields
- v6 is safe here: `always-auth` (removed in v6.1.0) is not used; `cache: npm` stays explicit since no `packageManager` in package.json

## Plan

[.claude/plans/W-23201856.md](.claude/plans/W-23201856.md)

## Reviewer notes

- **low:** `setup-node` node-version values vary across the codebase (`'22.22.3'`, `'lts/*'`, `vars.NODE_VERSION || 'lts/*'`). The v4→v6 bump is uniform and correct (49 instances now @v6, 0 remaining @v4); the underlying node-version inconsistency predates this PR and is out of scope, but the bump is a natural moment to consider normalizing in a follow-up.

### What issues does this PR fix or reference?

@W-23201856@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002dGiliYAC/view