### PR TITLE
chore(eslint): enable unicorn/no-unnecessary-boolean-comparison - W-23094911

### DIFF
--- a/.claude/plans/W-23094911.md
+++ b/.claude/plans/W-23094911.md
@@ -1,0 +1,43 @@
+# W-23094911 — enable unicorn/no-unnecessary-boolean-comparison
+
+## Context
+
+- Enable `unicorn/no-unnecessary-boolean-comparison`: ban `=== true` / `=== false` / `!== ...` vs boolean literals.
+- Dep W-23094908 merged (commit 2c56006b1) — unblocked.
+- Rule autofixable (`fixable: 'code'`, node_modules/eslint-plugin-unicorn/rules/no-unnecessary-boolean-comparison.js:122).
+- Probe (rule temp-added, full `packages/**/*.ts` lint): 6 violations, 4 files. `eslint --fix` clears all; 0 remaining.
+- Affected files + fixes verified semantically correct (each operand known boolean):
+  - packages/eslint-local-rules/src/packageJsonNoDefaultTrue.ts (`=== true` → drop)
+  - packages/eslint-local-rules/src/requireEffectFnSpanName.ts (`=== true` → drop)
+  - packages/salesforcedx-lightning-lsp-common/src/baseContext.ts (3x `=== true` → drop)
+  - packages/salesforcedx-vscode-metadata/src/shared/retrieve/retrieveOutcome.ts (`=== false` → `!`)
+- Insertion point: eslint.config.mjs, alpha order, between `no-typeof-undefined` (L191) and `no-unused-properties` (L192).
+
+## Phases
+
+### Phase 1 — enable rule + autofix violations (single commit)
+
+- Add `'unicorn/no-unnecessary-boolean-comparison': 'error',` to eslint.config.mjs after `no-typeof-undefined`.
+- Run `npx eslint --fix` on 4 affected files (or full lint --fix).
+- Files:
+  - eslint.config.mjs
+  - packages/eslint-local-rules/src/packageJsonNoDefaultTrue.ts
+  - packages/eslint-local-rules/src/requireEffectFnSpanName.ts
+  - packages/salesforcedx-lightning-lsp-common/src/baseContext.ts
+  - packages/salesforcedx-vscode-metadata/src/shared/retrieve/retrieveOutcome.ts
+- Commit: `chore(eslint): enable unicorn/no-unnecessary-boolean-comparison - W-23094911`
+
+## Skills to apply
+
+- concise (plan/docs)
+- packageJson (touches eslint-local-rules/packageJsonNoDefaultTrue.ts only as autofix target — no manifest change)
+- typescript (modifies .ts source files)
+- verification
+
+## Verification
+
+- `npx eslint "packages/**/*.ts"` → 0 `no-unnecessary-boolean-comparison` errors (needs `NODE_OPTIONS=--max-old-space-size=8192`; build eslint-local-rules first via `tsc` in packages/eslint-local-rules).
+- eslint-local-rules autofixed → run its jest: `packageJsonNoDefaultTrue` + `requireEffectFnSpanName` tests still green.
+- baseContext.ts fix touches jsconfig/tsconfig skip logic — covered by lightning-lsp-common unit tests.
+- retrieveOutcome.ts `retrieveHasErrors` — covered by metadata unit/e2e on branch.
+- Confirm clean tree pre-commit (probe reverted).

--- a/.claude/plans/W-23094911.md
+++ b/.claude/plans/W-23094911.md
@@ -18,7 +18,7 @@
 ### Phase 1 — enable rule + autofix violations (single commit)
 
 - Add `'unicorn/no-unnecessary-boolean-comparison': 'error',` to eslint.config.mjs after `no-typeof-undefined`.
-- Run `npx eslint --fix` on 4 affected files (or full lint --fix).
+- Run `npx eslint --fix` on 4 affected files.
 - Files:
   - eslint.config.mjs
   - packages/eslint-local-rules/src/packageJsonNoDefaultTrue.ts
@@ -30,14 +30,14 @@
 ## Skills to apply
 
 - concise (plan/docs)
-- packageJson (touches eslint-local-rules/packageJsonNoDefaultTrue.ts only as autofix target — no manifest change)
+- packageJson (autofix target only — no manifest change)
 - typescript (modifies .ts source files)
 - verification
 
 ## Verification
 
-- `npx eslint "packages/**/*.ts"` → 0 `no-unnecessary-boolean-comparison` errors (needs `NODE_OPTIONS=--max-old-space-size=8192`; build eslint-local-rules first via `tsc` in packages/eslint-local-rules).
-- eslint-local-rules autofixed → run its jest: `packageJsonNoDefaultTrue` + `requireEffectFnSpanName` tests still green.
-- baseContext.ts fix touches jsconfig/tsconfig skip logic — covered by lightning-lsp-common unit tests.
+- `npx eslint "packages/**/*.ts"` → 0 errors; needs `NODE_OPTIONS=--max-old-space-size=8192`; build eslint-local-rules first (tsc).
+- eslint-local-rules autofixed → jest: `packageJsonNoDefaultTrue` + `requireEffectFnSpanName` pass.
+- baseContext.ts — covered by lightning-lsp-common unit tests.
 - retrieveOutcome.ts `retrieveHasErrors` — covered by metadata unit/e2e on branch.
 - Confirm clean tree pre-commit (probe reverted).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -189,6 +189,7 @@ export default [
       'unicorn/no-single-promise-in-promise-methods': 'error',
       'unicorn/no-static-only-class': 'error',
       'unicorn/no-typeof-undefined': 'error',
+      'unicorn/no-unnecessary-boolean-comparison': 'error',
       'unicorn/no-unused-properties': 'error',
       'unicorn/no-useless-collection-argument': 'error',
       'unicorn/no-useless-error-capture-stack-trace': 'error',

--- a/packages/eslint-local-rules/src/packageJsonNoDefaultTrue.ts
+++ b/packages/eslint-local-rules/src/packageJsonNoDefaultTrue.ts
@@ -140,7 +140,7 @@ export const packageJsonNoDefaultTrue: Rule.RuleModule = {
           }
 
           // Check if this is a boolean type with default: true
-          if (typeNode && isBooleanType(typeNode) && defaultNode?.type === 'Boolean' && defaultNode.value === true) {
+          if (typeNode && isBooleanType(typeNode) && defaultNode?.type === 'Boolean' && defaultNode.value) {
             context.report({
               node: defaultMemberNode as unknown as Rule.Node,
               messageId: 'defaultTrue',

--- a/packages/eslint-local-rules/src/requireEffectFnSpanName.ts
+++ b/packages/eslint-local-rules/src/requireEffectFnSpanName.ts
@@ -19,7 +19,7 @@ const isEffectFnDirectCall = (
   if (prop.type !== AST_NODE_TYPES.Identifier || prop.name !== 'fn') return false;
 
   const arg = node.arguments[0];
-  return arg?.type === AST_NODE_TYPES.FunctionExpression && arg.generator === true;
+  return arg?.type === AST_NODE_TYPES.FunctionExpression && arg.generator;
 };
 
 export const requireEffectFnSpanName = RuleCreator.withoutDocs({

--- a/packages/salesforcedx-lightning-lsp-common/src/baseContext.ts
+++ b/packages/salesforcedx-lightning-lsp-common/src/baseContext.ts
@@ -357,7 +357,7 @@ export abstract class BaseWorkspaceContext {
       const tsconfigPath = path.join(modulesDir, 'tsconfig.json');
       try {
         const fileStat = await this.fileSystemAccessor.getFileStat(tsconfigPath);
-        if (fileStat?.type === 'file' && fileStat?.exists === true) {
+        if (fileStat?.type === 'file' && fileStat?.exists) {
           continue;
         }
       } catch {
@@ -371,7 +371,7 @@ export abstract class BaseWorkspaceContext {
         let jsconfigExists = false;
         try {
           const fileStat = await this.fileSystemAccessor.getFileStat(jsconfigPath);
-          if (fileStat?.type === 'file' && fileStat?.exists === true) {
+          if (fileStat?.type === 'file' && fileStat?.exists) {
             jsconfigExists = true;
           }
         } catch {
@@ -478,7 +478,7 @@ export abstract class BaseWorkspaceContext {
       // Skip if tsconfig.json already exists
       const tsconfigPath = path.join(modulesDir, 'tsconfig.json');
       const fileStat = await this.fileSystemAccessor.getFileStat(tsconfigPath);
-      if (fileStat?.type === 'file' && fileStat?.exists === true) {
+      if (fileStat?.type === 'file' && fileStat?.exists) {
         // Skip writing jsconfig when tsconfig.json already exists (as per test expectation)
       } else {
         try {

--- a/packages/salesforcedx-vscode-metadata/src/shared/retrieve/retrieveOutcome.ts
+++ b/packages/salesforcedx-vscode-metadata/src/shared/retrieve/retrieveOutcome.ts
@@ -42,7 +42,7 @@ export const retrieveHasErrors = Effect.fn('retrieveHasErrors')(function* (resul
   if (resp === undefined) {
     return false;
   }
-  if (resp.success === false) {
+  if (!resp.success) {
     return true;
   }
   return RETRIEVE_FAILURE_STATUSES.has(toRequestStatus(resp.status));

--- a/packages/salesforcedx-vscode-metadata/src/sobjects/sobjectFilter.ts
+++ b/packages/salesforcedx-vscode-metadata/src/sobjects/sobjectFilter.ts
@@ -11,8 +11,8 @@ import { SObjectCategory, SObjectRefreshSource } from './types/general';
 /** filter out standard or custom if necessary and handle the "required" sobject types */
 export const sobjectTypeFilter =
   (category: SObjectCategory, source: SObjectRefreshSource) => (sobject: SObjectShortDescription) => {
-    const isCustomObject = sobject.custom === true && category === 'CUSTOM';
-    const isStandardObject = sobject.custom === false && category === 'STANDARD';
+    const isCustomObject = sobject.custom && category === 'CUSTOM';
+    const isStandardObject = !sobject.custom && category === 'STANDARD';
 
     return (
       (category === 'ALL' && source === 'manual') ||


### PR DESCRIPTION
## Summary

- Enable `unicorn/no-unnecessary-boolean-comparison` ESLint rule to ban redundant `=== true` / `=== false` comparisons against boolean literals
- Apply autofix across 5 files (8 sites): drop `=== true` and convert `=== false` to `!` where operands are strictly boolean
- 29 surviving `=== true`/`=== false` comparisons correctly left untouched (operands are `boolean | undefined`)

## Plan

[.claude/plans/W-23094911.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23094911-6-enable-unicorn-no-unnecessary-boolean/.claude/plans/W-23094911.md)

## Reviewer notes

- No code changes needed. The PR cleanly enables `unicorn/no-unnecessary-boolean-comparison` and applies its autofix. All 8 transformed operands verified strictly boolean (non-optional), so `=== true`→truthy and `=== false`→`!` are runtime- and type-identical. Description count in plan is slightly off (8 removals across 5 files, not '6 sites, 4 files') but no code defect.
- The 29 surviving `=== true`/`=== false` comparisons in src are correctly left untouched because they target `boolean | undefined` operands where `=== true` is semantically distinct from truthiness; the rule does not flag those. Scoping is complete.

### What issues does this PR fix or reference?

@W-23094911@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cesmNYAQ/view