### PR TITLE
build(deps): add eslint-plugin-playwright  - W-21067614

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,6 +16,7 @@ import eslintPluginJestFormatting from 'eslint-plugin-jest-formatting';
 import eslintPluginPreferArrow from 'eslint-plugin-prefer-arrow';
 import eslintConfigPrettier from 'eslint-config-prettier/flat';
 import eslintPluginJest from 'eslint-plugin-jest';
+import eslintPluginPlaywright from 'eslint-plugin-playwright';
 import eslintPluginUnicorn from 'eslint-plugin-unicorn';
 import eslintPluginBarrelFiles from 'eslint-plugin-barrel-files';
 import functional from 'eslint-plugin-functional';
@@ -926,6 +927,14 @@ export default [
     rules: {
       'local/query-builder-html-i18n-keys': 'error'
     }
+  },
+  {
+    // Register eslint-plugin-playwright for the e2e specs but enable NO rules yet.
+    // Individual playwright/* rules are turned on (and their violations fixed) in
+    // separate follow-up WIs, one rule at a time.
+    files: ['packages/salesforcedx**/test/playwright/**/*.ts', 'packages/playwright-vscode-ext/**/*.ts'],
+    plugins: { playwright: eslintPluginPlaywright },
+    rules: {}
   },
   eslintConfigPrettier
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,7 @@
         "eslint-plugin-jest-formatting": "3.1.0",
         "eslint-plugin-jsdoc": "63.0.2",
         "eslint-plugin-local-rules": "3.0.2",
+        "eslint-plugin-playwright": "2.10.4",
         "eslint-plugin-prefer-arrow": "1.2.3",
         "eslint-plugin-unicorn": "68.0.0",
         "eslint-plugin-workspaces": "0.12.1",
@@ -18731,6 +18732,35 @@
       "integrity": "sha512-IWME7GIYHXogTkFsToLdBCQVJ0U4kbSuVyDT+nKoR4UgtnVrrVeNWuAZkdEu1nxkvi9nsPccGehEEF6dgA28IQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/eslint-plugin-playwright": {
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.10.4.tgz",
+      "integrity": "sha512-l0V/VxyqfFbtqCTxj5AdRn3Q6S/hIW4nKBnKZVleVbZ24N2My6Usj//ytX3dKKqAoSbvKck9YtSytfdZ5qjLuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globals": "^17.3.0"
+      },
+      "engines": {
+        "node": ">=16.9.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/eslint-plugin-playwright/node_modules/globals": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/eslint-plugin-prefer-arrow": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "eslint-plugin-jest-formatting": "3.1.0",
     "eslint-plugin-jsdoc": "63.0.2",
     "eslint-plugin-local-rules": "3.0.2",
+    "eslint-plugin-playwright": "2.10.4",
     "eslint-plugin-prefer-arrow": "1.2.3",
     "eslint-plugin-unicorn": "68.0.0",
     "eslint-plugin-workspaces": "0.12.1",


### PR DESCRIPTION
## Summary

- Adds `eslint-plugin-playwright@2.10.4` to root `devDependencies`
- Registers the plugin in `eslint.config.mjs` covering playwright globs with **no rules enabled** — individual `playwright/*` rules will be turned on (and violations fixed) in separate follow-up WIs, one rule at a time

### What issues does this PR fix or reference?

@W-21067614@