### PR TITLE
fix(metadata): manifest deploy/retrieve commands for *Package.xml files - W-21020377

### DIFF
--- a/.claude/plans/W-21020377.md
+++ b/.claude/plans/W-21020377.md
@@ -10,13 +10,13 @@
 
 ## Adversarial: pattern breadth + "Deploy This Source" loss
 
-The "Deploy/Retrieve/Delete This Source" menus (lines 416, 456, 464, 480, 506, 510, 518, 530, 536, 540, 548, 560) gate on `resourceLangId != 'forcesourcemanifest' && sf:in_package_directories`. If a file inside a package directory wrongly gets the `forcesourcemanifest` lang, it loses its "This Source" commands. Two independent reasons this is safe, plus a runtime backstop:
+"This Source" menus (lines 416, 456, 464, 480, 506, 510, 518, 530, 536, 540, 548, 560) gate on `resourceLangId != 'forcesourcemanifest' && sf:in_package_directories`. File in a package dir wrongly tagged `forcesourcemanifest` loses "This Source" commands. Safe — 2 reasons + runtime backstop:
 
-1. **No real Salesforce metadata source file ends in `*Package.xml`.** SDR source files always carry a `-meta.xml` or type-specific suffix. The only registry types with a `package`-ending suffix are `InstalledPackage` (suffix `installedPackage` → `*.installedPackage-meta.xml`) — verified via `node_modules/@salesforce/source-deploy-retrieve/lib/src/registry/metadataRegistry.json`. `*.installedPackage-meta.xml` does NOT match `**/*[Pp]ackage.xml` (ends in `-meta.xml`, not `Package.xml`). No registry type produces a bare `*Package.xml` source file. Document this in the verification step.
-2. **The collision requires BOTH a `*Package.xml`-named file AND `sf:in_package_directories` true.** `sf:in_package_directories` is set per active editor by `projectService.isInPackageDirectories(uri)` (`packages/salesforcedx-vscode-services/src/vscode/editorContext.ts:41`). A user-authored manifest named `sfdxPackage.xml` normally lives outside package dirs; if a user deliberately put one inside `force-app`, treating it as a manifest is the correct UX (it IS a manifest by content), and the lost "This Source" command is acceptable for a hand-written package.xml.
-3. **Runtime backstop already exists (graceful error).** `deployManifestCommand` (`packages/salesforcedx-vscode-metadata/src/commands/deployManifest.ts:25`) calls `ComponentSetService.getComponentSetFromManifest(uri)` then `ensureNonEmptyComponentSet`. A `*Package.xml` file that is not a valid manifest fails ComponentSet resolution and surfaces an error notification rather than silently misbehaving. So a worst-case false-positive lang assignment at most shows the menu and errors gracefully — it does not corrupt anything.
+1. No real metadata source file ends `*Package.xml`. SDR source files carry `-meta.xml`/type-specific suffix. Only `package`-ending suffix is `InstalledPackage` → `*.installedPackage-meta.xml` (per `node_modules/@salesforce/source-deploy-retrieve/lib/src/registry/metadataRegistry.json`); does NOT match `**/*[Pp]ackage.xml` (ends `-meta.xml`).
+2. Collision needs BOTH `*Package.xml` name AND `sf:in_package_directories` (set by `projectService.isInPackageDirectories(uri)`, `editorContext.ts:41`). Hand-authored manifests live outside package dirs; one deliberately in `force-app` IS a manifest by content — manifest UX is correct, lost "This Source" acceptable.
+3. Runtime backstop: `deployManifestCommand` (`deployManifest.ts:25`) calls `getComponentSetFromManifest(uri)` + `ensureNonEmptyComponentSet`. Non-manifest `*Package.xml` fails resolution, errors gracefully — no corruption.
 
-Decision: ship the unanchored `**/*[Pp]ackage.xml` (simplest, matches WI intent) and lock the behavior with e2e (below). No exclusion glob needed given reasons 1-3. Record reasons 1 + 3 in the plan verification so a future regression author understands the boundary.
+Decision: ship unanchored `**/*[Pp]ackage.xml`, lock with e2e (below). No exclusion glob. Record reasons 1+3 in verification.
 
 ## Phases
 
@@ -31,13 +31,13 @@ The existing `deployManifest.headless.spec.ts` and `retrieveInManifest.headless.
 - New spec: `packages/salesforcedx-vscode-metadata/test/playwright/specs/manifestCommandVisibility.headless.spec.ts` (desktop — needs a real on-disk file with a real name; `createFileWithContents` only makes UNTITLED files so it cannot drive `filenamePatterns` lang assignment).
 - Use the `desktopTest` fixture from `../fixtures/desktopFixtures.ts` (it sets `useMetadataExtensionCommands: true`). It exposes the on-disk `workspaceDir`; write the test file there with `node:fs/promises` + `node:path`.
 - Test body:
-  1. Setup minimal org + `upsertScratchOrgAuthFieldsToSettings` (target org present is required: in-manifest `when` clauses gate on `sf:has_target_org`). Wait for status bar.
-  2. Write `sfdxPackage.xml` at the workspace root (OUTSIDE any `manifest/` dir and outside package dirs) with valid `<?xml ...><Package xmlns=...></Package>` content (a non-empty `<types>` block so ComponentSet resolution would not error if invoked).
-  3. `openFileByName(page, 'sfdxPackage.xml')`; assert it is the active editor.
-  4. Assert visibility (this is the regression guard for the filenamePatterns fix):
+  1. Setup minimal org + `upsertScratchOrgAuthFieldsToSettings`; wait for status bar (in-manifest `when` gate on `sf:has_target_org`).
+  2. Write `sfdxPackage.xml` at workspace root (outside `manifest/` + package dirs), valid `<Package>` with non-empty `<types>`.
+  3. `openFileByName(page, 'sfdxPackage.xml')`; assert active editor.
+  4. Assert visible (regression guard):
      - `verifyCommandExists(page, packageNls.deploy_in_manifest_text)`
      - `verifyCommandExists(page, packageNls.retrieve_in_manifest_text)`
-  5. Negative case (guards against the pattern being too broad): write `foo.xml` (no `Package` suffix) at workspace root, open it, assert:
+  5. Negative (suffix guard): write `foo.xml` at root, open, assert:
      - `verifyCommandDoesNotExist(page, packageNls.deploy_in_manifest_text)`
      - `verifyCommandDoesNotExist(page, packageNls.retrieve_in_manifest_text)`
   6. `validateNoCriticalErrors`.
@@ -47,16 +47,16 @@ The existing `deployManifest.headless.spec.ts` and `retrieveInManifest.headless.
 - Commit: `test(metadata): e2e manifest command visibility for *Package.xml + negative case - W-21020377`
 
 ## Skills to apply
-- packageJson — verify package.json edit, formatting, no lint break
-- playwright-e2e — author the headless spec per project conventions
-- typescript — TS coding standards
-- verification — checks below
-- changelog — confirm if changelog entry needed for metadata pkg
+- packageJson
+- playwright-e2e
+- typescript
+- verification
+- changelog
 
 ## Verification
 - Lint/format package.json: `npm run lint` (or wireit) in metadata pkg; JSON stays valid.
 - Run the new spec headless: `manifestCommandVisibility.headless.spec.ts` passes (positive + negative).
 - Existing `deployManifest.headless.spec.ts` / `retrieveInManifest.headless.spec.ts` still pass (existing `manifest/package.xml` patterns unbroken).
-- Boundary rationale (record so future authors don't re-introduce an anchor or break it):
-  - No registry metadata type produces a bare `*Package.xml` source file (`InstalledPackage` → `*.installedPackage-meta.xml`, not matched). So the unanchored glob does not steal "This Source" commands from real metadata.
-  - Even on a hypothetical false positive, `deployManifestCommand` resolves a ComponentSet from the file and errors gracefully — no silent corruption.
+- Boundary rationale:
+  - No registry type produces bare `*Package.xml` (`InstalledPackage` → `*.installedPackage-meta.xml`, not matched); unanchored glob can't steal "This Source" from real metadata.
+  - False positive: `deployManifestCommand` resolves ComponentSet, errors gracefully — no corruption.

--- a/.claude/plans/W-21020377.md
+++ b/.claude/plans/W-21020377.md
@@ -1,0 +1,62 @@
+# W-21020377 — Manifest deploy/retrieve commands only for manifest/ dir or package.xml
+
+## Context
+- Bug: "SFDX: Deploy/Retrieve Source in Manifest to Org" only appears when manifest is in `manifest/` dir or exactly `package.xml`. Manifest named e.g. `sfdxPackage.xml` outside `manifest/` gets no commands.
+- Cause: language `forcesourcemanifest` `filenamePatterns` = `["**/manifest/**/*.xml", "package.xml"]` (metadata `package.json` lines 342-345). All 6 deploy/retrieve-in-manifest menu `when` clauses gate on `resourceLangId == 'forcesourcemanifest'` (lines 468, 484, 514, 522, 544, 552).
+- File: `packages/salesforcedx-vscode-metadata/package.json` — language def lines 337-345; menus lines 467-552.
+- Fix: add suffix pattern `**/*[Pp]ackage.xml`. Catches `Package.xml`, `sfdxPackage.xml`, `package.xml` anywhere; avoids mid-name matches. Keep existing 2 patterns.
+- Note: `packages/salesforcedx-vscode-core/package.json` also declares `forcesourcemanifest` (grammar only, pattern `**/manifest/**/*.xml`). VS Code merges `filenamePatterns` across contributions (proof: `package.xml` works today though absent from core def). Menus live only in metadata — fix metadata per WI. No core change needed.
+- No setting, no activation code, no destructiveChanges handling. No tests reference the language id (pure package.json contribution).
+
+## Adversarial: pattern breadth + "Deploy This Source" loss
+
+The "Deploy/Retrieve/Delete This Source" menus (lines 416, 456, 464, 480, 506, 510, 518, 530, 536, 540, 548, 560) gate on `resourceLangId != 'forcesourcemanifest' && sf:in_package_directories`. If a file inside a package directory wrongly gets the `forcesourcemanifest` lang, it loses its "This Source" commands. Two independent reasons this is safe, plus a runtime backstop:
+
+1. **No real Salesforce metadata source file ends in `*Package.xml`.** SDR source files always carry a `-meta.xml` or type-specific suffix. The only registry types with a `package`-ending suffix are `InstalledPackage` (suffix `installedPackage` → `*.installedPackage-meta.xml`) — verified via `node_modules/@salesforce/source-deploy-retrieve/lib/src/registry/metadataRegistry.json`. `*.installedPackage-meta.xml` does NOT match `**/*[Pp]ackage.xml` (ends in `-meta.xml`, not `Package.xml`). No registry type produces a bare `*Package.xml` source file. Document this in the verification step.
+2. **The collision requires BOTH a `*Package.xml`-named file AND `sf:in_package_directories` true.** `sf:in_package_directories` is set per active editor by `projectService.isInPackageDirectories(uri)` (`packages/salesforcedx-vscode-services/src/vscode/editorContext.ts:41`). A user-authored manifest named `sfdxPackage.xml` normally lives outside package dirs; if a user deliberately put one inside `force-app`, treating it as a manifest is the correct UX (it IS a manifest by content), and the lost "This Source" command is acceptable for a hand-written package.xml.
+3. **Runtime backstop already exists (graceful error).** `deployManifestCommand` (`packages/salesforcedx-vscode-metadata/src/commands/deployManifest.ts:25`) calls `ComponentSetService.getComponentSetFromManifest(uri)` then `ensureNonEmptyComponentSet`. A `*Package.xml` file that is not a valid manifest fails ComponentSet resolution and surfaces an error notification rather than silently misbehaving. So a worst-case false-positive lang assignment at most shows the menu and errors gracefully — it does not corrupt anything.
+
+Decision: ship the unanchored `**/*[Pp]ackage.xml` (simplest, matches WI intent) and lock the behavior with e2e (below). No exclusion glob needed given reasons 1-3. Record reasons 1 + 3 in the plan verification so a future regression author understands the boundary.
+
+## Phases
+
+### Phase 1 — add suffix filename pattern
+- Edit `packages/salesforcedx-vscode-metadata/package.json` lines 342-345: add `"**/*[Pp]ackage.xml"` to `filenamePatterns`.
+- Files: `packages/salesforcedx-vscode-metadata/package.json`
+- Commit: `fix(metadata): match *Package.xml manifests for deploy/retrieve menus - W-21020377`
+
+### Phase 2 — e2e coverage (the bug case + negative case)
+The existing `deployManifest.headless.spec.ts` and `retrieveInManifest.headless.spec.ts` ONLY exercise `manifest/package.xml` (the already-working path) — they do NOT cover the bug. Add a focused visibility spec.
+
+- New spec: `packages/salesforcedx-vscode-metadata/test/playwright/specs/manifestCommandVisibility.headless.spec.ts` (desktop — needs a real on-disk file with a real name; `createFileWithContents` only makes UNTITLED files so it cannot drive `filenamePatterns` lang assignment).
+- Use the `desktopTest` fixture from `../fixtures/desktopFixtures.ts` (it sets `useMetadataExtensionCommands: true`). It exposes the on-disk `workspaceDir`; write the test file there with `node:fs/promises` + `node:path`.
+- Test body:
+  1. Setup minimal org + `upsertScratchOrgAuthFieldsToSettings` (target org present is required: in-manifest `when` clauses gate on `sf:has_target_org`). Wait for status bar.
+  2. Write `sfdxPackage.xml` at the workspace root (OUTSIDE any `manifest/` dir and outside package dirs) with valid `<?xml ...><Package xmlns=...></Package>` content (a non-empty `<types>` block so ComponentSet resolution would not error if invoked).
+  3. `openFileByName(page, 'sfdxPackage.xml')`; assert it is the active editor.
+  4. Assert visibility (this is the regression guard for the filenamePatterns fix):
+     - `verifyCommandExists(page, packageNls.deploy_in_manifest_text)`
+     - `verifyCommandExists(page, packageNls.retrieve_in_manifest_text)`
+  5. Negative case (guards against the pattern being too broad): write `foo.xml` (no `Package` suffix) at workspace root, open it, assert:
+     - `verifyCommandDoesNotExist(page, packageNls.deploy_in_manifest_text)`
+     - `verifyCommandDoesNotExist(page, packageNls.retrieve_in_manifest_text)`
+  6. `validateNoCriticalErrors`.
+- Helpers all exist in `@salesforce/playwright-vscode-ext`: `verifyCommandExists` / `verifyCommandDoesNotExist` (used in `editorWatcher.headless.spec.ts`, `noProjectCommandsHidden.headless.spec.ts`), `openFileByName`, `createMinimalOrg`, `upsertScratchOrgAuthFieldsToSettings`, `waitForVSCodeWorkbench`, `closeWelcomeTabs`, `ensureSecondarySideBarHidden`, `setupConsoleMonitoring`, `setupNetworkMonitoring`.
+- Optional (lower priority): also assert `package.xml` inside `manifest/` still shows commands to prove the existing patterns survive the edit — but `deployManifest`/`retrieveInManifest` specs already cover that path end-to-end, so do not duplicate.
+- Files: new `manifestCommandVisibility.headless.spec.ts`.
+- Commit: `test(metadata): e2e manifest command visibility for *Package.xml + negative case - W-21020377`
+
+## Skills to apply
+- packageJson — verify package.json edit, formatting, no lint break
+- playwright-e2e — author the headless spec per project conventions
+- typescript — TS coding standards
+- verification — checks below
+- changelog — confirm if changelog entry needed for metadata pkg
+
+## Verification
+- Lint/format package.json: `npm run lint` (or wireit) in metadata pkg; JSON stays valid.
+- Run the new spec headless: `manifestCommandVisibility.headless.spec.ts` passes (positive + negative).
+- Existing `deployManifest.headless.spec.ts` / `retrieveInManifest.headless.spec.ts` still pass (existing `manifest/package.xml` patterns unbroken).
+- Boundary rationale (record so future authors don't re-introduce an anchor or break it):
+  - No registry metadata type produces a bare `*Package.xml` source file (`InstalledPackage` → `*.installedPackage-meta.xml`, not matched). So the unanchored glob does not steal "This Source" commands from real metadata.
+  - Even on a hypothetical false positive, `deployManifestCommand` resolves a ComponentSet from the file and errors gracefully — no silent corruption.

--- a/packages/salesforcedx-vscode-metadata/package.json
+++ b/packages/salesforcedx-vscode-metadata/package.json
@@ -341,7 +341,6 @@
         ],
         "filenamePatterns": [
           "**/manifest/**/*.xml",
-          "package.xml",
           "**/*[Pp]ackage.xml"
         ]
       }

--- a/packages/salesforcedx-vscode-metadata/package.json
+++ b/packages/salesforcedx-vscode-metadata/package.json
@@ -341,7 +341,8 @@
         ],
         "filenamePatterns": [
           "**/manifest/**/*.xml",
-          "package.xml"
+          "package.xml",
+          "**/*[Pp]ackage.xml"
         ]
       }
     ],

--- a/packages/salesforcedx-vscode-metadata/test/playwright/fixtures/index.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/fixtures/index.ts
@@ -31,4 +31,4 @@ export const test = isDesktop ? desktopTest : webTest;
 export const dreamhouseTest = isDesktop ? dreamhouseDesktopTest : webTest;
 export const nonTrackingTest = isDesktop ? nonTrackingDesktopTest : webTest;
 export const trackingConflictTest = isDesktop ? trackingConflictDesktopTest : webTrackingConflictTest;
-export { emptyWorkspaceDesktopTest } from './desktopFixtures';
+export { emptyWorkspaceDesktopTest, desktopTest } from './desktopFixtures';

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/manifestCommandVisibility.headless.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/manifestCommandVisibility.headless.spec.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from '@playwright/test';
+import {
+  closeWelcomeTabs,
+  createMinimalOrg,
+  EDITOR,
+  ensureSecondarySideBarHidden,
+  isDesktop,
+  openFileByName,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  upsertScratchOrgAuthFieldsToSettings,
+  validateNoCriticalErrors,
+  verifyCommandDoesNotExist,
+  verifyCommandExists,
+  waitForVSCodeWorkbench
+} from '@salesforce/playwright-vscode-ext';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import packageNls from '../../../package.nls.json';
+import { SourceTrackingStatusBarPage } from '../pages/sourceTrackingStatusBarPage';
+import { desktopTest as test } from '../fixtures/desktopFixtures';
+
+// A *Package.xml file outside manifest/ must still get the forcesourcemanifest language
+// (filenamePatterns "**/*[Pp]ackage.xml"), so the in-manifest deploy/retrieve menus appear.
+// A plain *.xml file must NOT match, guarding against an over-broad pattern.
+const MANIFEST_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+  <types>
+    <members>*</members>
+    <name>ApexClass</name>
+  </types>
+  <version>62.0</version>
+</Package>`;
+
+const PLAIN_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<root></root>`;
+
+(isDesktop() ? test : test.skip.bind(test))(
+  'Manifest command visibility: *Package.xml shows in-manifest commands, plain xml does not',
+  async ({ page, workspaceDir }) => {
+    test.setTimeout(180_000);
+    const consoleErrors = setupConsoleMonitoring(page);
+    const networkErrors = setupNetworkMonitoring(page);
+
+    await test.step('setup minimal org', async () => {
+      const createResult = await createMinimalOrg();
+      await waitForVSCodeWorkbench(page);
+      await closeWelcomeTabs(page);
+      await ensureSecondarySideBarHidden(page);
+      await upsertScratchOrgAuthFieldsToSettings(page, createResult);
+
+      // in-manifest when-clauses gate on sf:has_target_org; wait for org to be active
+      const statusBarPage = new SourceTrackingStatusBarPage(page);
+      await statusBarPage.waitForVisible(120_000);
+    });
+
+    await test.step('*Package.xml outside manifest/ shows in-manifest commands', async () => {
+      // workspace root is outside any manifest/ dir and outside package directories (force-app)
+      await fs.writeFile(path.join(workspaceDir, 'sfdxPackage.xml'), MANIFEST_XML);
+
+      await openFileByName(page, 'sfdxPackage.xml');
+      await expect(
+        page.locator(`${EDITOR}[data-uri*="sfdxPackage.xml"]`).first(),
+        'sfdxPackage.xml should be the active editor'
+      ).toBeVisible({ timeout: 15_000 });
+
+      await verifyCommandExists(page, packageNls.deploy_in_manifest_text);
+      await verifyCommandExists(page, packageNls.retrieve_in_manifest_text);
+    });
+
+    await test.step('plain xml does not show in-manifest commands (pattern not over-broad)', async () => {
+      await fs.writeFile(path.join(workspaceDir, 'foo.xml'), PLAIN_XML);
+
+      await openFileByName(page, 'foo.xml');
+      await expect(
+        page.locator(`${EDITOR}[data-uri*="foo.xml"]`).first(),
+        'foo.xml should be the active editor'
+      ).toBeVisible({ timeout: 15_000 });
+
+      await verifyCommandDoesNotExist(page, packageNls.deploy_in_manifest_text);
+      await verifyCommandDoesNotExist(page, packageNls.retrieve_in_manifest_text);
+    });
+
+    await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+  }
+);

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/manifestCommandVisibility.headless.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/manifestCommandVisibility.headless.spec.ts
@@ -25,7 +25,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import packageNls from '../../../package.nls.json';
 import { SourceTrackingStatusBarPage } from '../pages/sourceTrackingStatusBarPage';
-import { desktopTest as test } from '../fixtures/desktopFixtures';
+import { desktopTest as test } from '../fixtures';
 
 // A *Package.xml file outside manifest/ must still get the forcesourcemanifest language
 // (filenamePatterns "**/*[Pp]ackage.xml"), so the in-manifest deploy/retrieve menus appear.
@@ -75,7 +75,10 @@ const PLAIN_XML = `<?xml version="1.0" encoding="UTF-8"?>
       await verifyCommandExists(page, packageNls.retrieve_in_manifest_text);
     });
 
-    await test.step('plain xml does not show in-manifest commands (pattern not over-broad)', async () => {
+    // guards only the basename suffix: a plain .xml file is not matched. It does not
+    // exercise a *Package.xml file inside a package dir (that case is covered by the
+    // boundary rationale in the plan: no real metadata source file ends in *Package.xml).
+    await test.step('plain xml does not match the *Package.xml suffix', async () => {
       await fs.writeFile(path.join(workspaceDir, 'foo.xml'), PLAIN_XML);
 
       await openFileByName(page, 'foo.xml');


### PR DESCRIPTION
## Summary

- Adds `**/*[Pp]ackage.xml` to the `forcesourcemanifest` language `filenamePatterns` in `salesforcedx-vscode-metadata`, so manifest files named e.g. `sfdxPackage.xml` outside a `manifest/` directory get the in-manifest deploy/retrieve context menu commands.
- Existing patterns (`**/manifest/**/*.xml`, `package.xml`) are preserved; the new suffix pattern catches any `*Package.xml` or `*package.xml` basename anywhere in the workspace.
- New e2e spec `manifestCommandVisibility.headless.spec.ts` asserts the positive case (custom-named `*Package.xml`) and the negative case (plain `.xml` does not match).

## Plan

`.claude/plans/W-21020377.md`

## Test plan

The new `manifestCommandVisibility.headless.spec.ts` e2e spec covers the bug regression and negative case automatically in CI. No additional manual steps required.

### What issues does this PR fix or reference?

@W-21020377@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002TRm8mYAD/view