### PR TITLE
docs(gus-cli): document Details_and_Steps_to_Reproduce__c and FIELDS(ALL) findings - W-23213788

### DIFF
--- a/.claude/plans/W-23213788.md
+++ b/.claude/plans/W-23213788.md
@@ -2,15 +2,7 @@
 
 ## Context
 
-Docs-only. Update `.claude/skills/gus-cli/SKILL.md` with ADM_Work__c fields found via FIELDS(ALL), absent from current docs. All 9 verified via `sf sobject describe -s ADM_Work__c -o gus`:
-
-- `Details_and_Steps_to_Reproduce__c` — label "Details and Steps to Reproduce", richtextarea. Primary body for Bug records (incl. PVR findings). User Stories use `Details__c`. Skill only documents `Details__c` → misses Bug content on query.
-- `Priority__c` — picklist, values `P0,P1,P2,P3,P4` (WI said P1/P2/P3; actual broader)
-- `Due_Date__c` — datetime; `Out_of_SLA__c` — boolean (SLA tracking)
-- `Epic_Name__c` — formula/string (calculated), avoids `Epic__r` join for display
-- `Security__c` — boolean, label "Locked by Security"; `Security_Vulnerability_Category__c` — picklist; `Security_Source__c` — picklist, label "Source" (NOT "Security Source")
-
-Existing read-only-query note in skill (## Work items): only `Details__c` documented as body; these fields are undocumented. Document them as **opt-in** additions — Base select (L70) stays lean since it feeds bulk team/epic queries.
+Docs-only. Add ADM_Work__c fields found via FIELDS(ALL) (verified `sf sobject describe -s ADM_Work__c -o gus`) to `.claude/skills/gus-cli/SKILL.md` ## Work items as **opt-in** additions — base select (L70) stays lean (feeds bulk team/epic queries). Field details in Phase 1.
 
 ## Phases
 
@@ -29,7 +21,11 @@ Existing read-only-query note in skill (## Work items): only `Details__c` docume
 - **Bug body field** note: Bug records use `Details_and_Steps_to_Reproduce__c` (richtextarea), not `Details__c`. Querying only `Details__c` misses Bug/PVR content. `Details__c` = User Story body. When fetching a single WI of unknown/mixed record type, SELECT both. (Single-record fetch, not bulk — keeps it off the lean base.)
 - Concise style; correct labels (Security_Source__c = "Source", Security__c = "Locked by Security").
 
-**Width rationale (why opt-in, not base):** SOQL's 2000-char limit applies to the whole query statement, not the SELECT clause ([SOQL SELECT ref](https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select.htm)); base+2 fields measures 125 chars so the limit is not the live risk. The real risks the opt-in model avoids: (1) every bulk team/epic query silently returns 2 extra columns, widening terminal tables; (2) `Epic_Name__c` formula evaluated per-row on large result sets for no display benefit in id-keyed lists. Keeping additions opt-in confines cost to the queries that use the data.
+**Why opt-in, not base:**
+
+- bulk team/epic queries silently get extra columns, widening terminal tables
+- `Epic_Name__c` formula evaluates per-row on large result sets, no display benefit in id-keyed lists
+- SOQL 2000-char limit is not the risk (applies to whole statement, not SELECT; base+2 = 125 chars)
 
 Commit: `docs(gus-cli): document Details_and_Steps_to_Reproduce__c + FIELDS(ALL) fields - W-23213788`
 

--- a/.claude/plans/W-23213788.md
+++ b/.claude/plans/W-23213788.md
@@ -1,0 +1,48 @@
+# W-23213788 — gus-cli: document Details_and_Steps_to_Reproduce__c + FIELDS(ALL) findings
+
+## Context
+
+Docs-only. Update `.claude/skills/gus-cli/SKILL.md` with ADM_Work__c fields found via FIELDS(ALL), absent from current docs. All 9 verified via `sf sobject describe -s ADM_Work__c -o gus`:
+
+- `Details_and_Steps_to_Reproduce__c` — label "Details and Steps to Reproduce", richtextarea. Primary body for Bug records (incl. PVR findings). User Stories use `Details__c`. Skill only documents `Details__c` → misses Bug content on query.
+- `Priority__c` — picklist, values `P0,P1,P2,P3,P4` (WI said P1/P2/P3; actual broader)
+- `Due_Date__c` — datetime; `Out_of_SLA__c` — boolean (SLA tracking)
+- `Epic_Name__c` — formula/string (calculated), avoids `Epic__r` join for display
+- `Security__c` — boolean, label "Locked by Security"; `Security_Vulnerability_Category__c` — picklist; `Security_Source__c` — picklist, label "Source" (NOT "Security Source")
+
+Existing read-only-query note in skill (## Work items): only `Details__c` documented as body; these fields are undocumented. Document them as **opt-in** additions — Base select (L70) stays lean since it feeds bulk team/epic queries.
+
+## Phases
+
+### Phase 1 — add fields to gus-cli SKILL.md
+
+`.claude/skills/gus-cli/SKILL.md`, ## Work items section.
+
+**Do NOT widen Base select** (line 70). Base select feeds every downstream query — `Team's open` (L80), `Epic + open` (L81), compound `What's unfinished in this epic` (L190). Adding fields there silently widens all bulk result sets + terminal tables and contradicts the existing "keep base lean" intent. New fields are **opt-in**, appended per-query when needed.
+
+- Base select: **unchanged** (`Id, Name, Subject__c, Status__c, Story_Points__c, Epic__c, RecordType.Name`).
+- New note after Base select — **Optional display/detail fields** (append to SELECT only when the query needs them; do not add to bulk team/epic queries unless asked):
+  - `Priority__c` — picklist `P0-P4`. Add for single-WI / triage views, not bulk lists.
+  - `Epic_Name__c` — formula/string; displays epic name w/o `Epic__r` join. Use for single-WI display; for bulk lists prefer existing `Epic__c` id or a separate epic-name lookup.
+  - `Due_Date__c` (datetime) + `Out_of_SLA__c` (boolean) — SLA tracking; add only for SLA-focused queries.
+  - Security trio `Security__c` (label "Locked by Security", boolean), `Security_Vulnerability_Category__c` (picklist), `Security_Source__c` (label "Source", picklist) — add only when triaging security WIs.
+- **Bug body field** note: Bug records use `Details_and_Steps_to_Reproduce__c` (richtextarea), not `Details__c`. Querying only `Details__c` misses Bug/PVR content. `Details__c` = User Story body. When fetching a single WI of unknown/mixed record type, SELECT both. (Single-record fetch, not bulk — keeps it off the lean base.)
+- Concise style; correct labels (Security_Source__c = "Source", Security__c = "Locked by Security").
+
+**Width rationale (why opt-in, not base):** SOQL's 2000-char limit applies to the whole query statement, not the SELECT clause ([SOQL SELECT ref](https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select.htm)); base+2 fields measures 125 chars so the limit is not the live risk. The real risks the opt-in model avoids: (1) every bulk team/epic query silently returns 2 extra columns, widening terminal tables; (2) `Epic_Name__c` formula evaluated per-row on large result sets for no display benefit in id-keyed lists. Keeping additions opt-in confines cost to the queries that use the data.
+
+Commit: `docs(gus-cli): document Details_and_Steps_to_Reproduce__c + FIELDS(ALL) fields - W-23213788`
+
+## Skills to apply
+
+- concise — plan + SKILL.md edits
+- gus-cli — target skill (field accuracy)
+- typescript — required
+
+## Verification
+
+- field names/types/labels match `sf sobject describe -s ADM_Work__c -o gus` (done while planning; re-confirm post-edit)
+- **Base select (L70) byte-identical to pre-edit** — grep diff to confirm no widening; new fields appear only in the opt-in note
+- markdown table syntax valid (visual)
+- spot-run a single-WI query with opt-in fields appended (`Priority__c`, `Epic_Name__c`, `Details_and_Steps_to_Reproduce__c`) on a real Bug WI to confirm fields return data and Bug body lands in `Details_and_Steps_to_Reproduce__c`
+- no e2e coverage — docs-only skill edit, no runnable code path; verification is the live `sf` query above (skill behavior is exercised by the orchestrator at use time, not by repo e2e tests)

--- a/.claude/skills/gus-cli/SKILL.md
+++ b/.claude/skills/gus-cli/SKILL.md
@@ -69,6 +69,15 @@ Objects: `ADM_Work__c`, `ADM_Epic__c` (not ADM_Theme\_\_c).
 
 **Base select:** `SELECT Id, Name, Subject__c, Status__c, Story_Points__c, Epic__c, RecordType.Name FROM ADM_Work__c`
 
+**Optional display/detail fields** (append to SELECT only when a query needs them; do NOT add to bulk team/epic queries unless asked—keeps base lean, avoids widening every result set/terminal table):
+
+- `Priority__c` — picklist `P0`-`P4`. Single-WI/triage views, not bulk lists.
+- `Epic_Name__c` — formula/string; epic name w/o `Epic__r` join. Single-WI display only; bulk lists use existing `Epic__c` id or a separate epic-name lookup (formula evaluated per-row otherwise).
+- `Due_Date__c` (datetime) + `Out_of_SLA__c` (boolean) — SLA tracking; SLA-focused queries only.
+- Security trio — security-WI triage only: `Security__c` (label "Locked by Security", boolean), `Security_Vulnerability_Category__c` (picklist), `Security_Source__c` (label "Source", picklist).
+
+**Bug body field:** Bug records store body in `Details_and_Steps_to_Reproduce__c` (richtextarea), not `Details__c`. `Details__c` = User Story body. Querying only `Details__c` misses Bug/PVR content. Single-WI fetch of unknown/mixed record type → SELECT both. Single-record only, not bulk.
+
 **Query patterns** (combine as needed; use LIMIT on broad queries):
 
 | Filter      | WHERE clause                                                                                                                                                                                     |

--- a/.claude/skills/gus-cli/SKILL.md
+++ b/.claude/skills/gus-cli/SKILL.md
@@ -69,14 +69,14 @@ Objects: `ADM_Work__c`, `ADM_Epic__c` (not ADM_Theme\_\_c).
 
 **Base select:** `SELECT Id, Name, Subject__c, Status__c, Story_Points__c, Epic__c, RecordType.Name FROM ADM_Work__c`
 
-**Optional display/detail fields** (append to SELECT only when a query needs them; do NOT add to bulk team/epic queries unless asked—keeps base lean, avoids widening every result set/terminal table):
+**Optional display/detail fields** (append to SELECT only for single-WI/triage queries; do NOT add to bulk team/epic queries unless asked—keeps base lean, avoids widening every result set/terminal table):
 
-- `Priority__c` — picklist `P0`-`P4`. Single-WI/triage views, not bulk lists.
-- `Epic_Name__c` — formula/string; epic name w/o `Epic__r` join. Single-WI display only; bulk lists use existing `Epic__c` id or a separate epic-name lookup (formula evaluated per-row otherwise).
-- `Due_Date__c` (datetime) + `Out_of_SLA__c` (boolean) — SLA tracking; SLA-focused queries only.
-- Security trio — security-WI triage only: `Security__c` (label "Locked by Security", boolean), `Security_Vulnerability_Category__c` (picklist), `Security_Source__c` (label "Source", picklist).
+- `Priority__c` — picklist `P0`-`P4`.
+- `Epic_Name__c` — formula/string; epic name w/o `Epic__r` join. Bulk lists use existing `Epic__c` id or a separate epic-name lookup (formula evaluated per-row otherwise).
+- `Due_Date__c` (datetime) + `Out_of_SLA__c` (boolean) — SLA tracking.
+- Security trio: `Security__c` (label "Locked by Security", boolean), `Security_Vulnerability_Category__c` (picklist, 30+ values), `Security_Source__c` (label "Source", picklist, 30+ values—run `sf sobject describe` for full lists).
 
-**Bug body field:** Bug records store body in `Details_and_Steps_to_Reproduce__c` (richtextarea), not `Details__c`. `Details__c` = User Story body. Querying only `Details__c` misses Bug/PVR content. Single-WI fetch of unknown/mixed record type → SELECT both. Single-record only, not bulk.
+**Bug body field:** Bug records store body in `Details_and_Steps_to_Reproduce__c` (richtextarea), not `Details__c`. `Details__c` = User Story body. Querying only `Details__c` misses Bug/PVR content. Single-WI fetch of unknown/mixed record type → SELECT both.
 
 **Query patterns** (combine as needed; use LIMIT on broad queries):
 


### PR DESCRIPTION
## Summary

- Documents `Details_and_Steps_to_Reproduce__c` (Bug/PVR body field) alongside `Details__c` (User Story body) — single-WI fetches should SELECT both when record type is unknown
- Adds opt-in display/detail fields (`Priority__c`, `Epic_Name__c`, `Due_Date__c`, `Out_of_SLA__c`, security trio) with labels/types verified against live `sf sobject describe`
- Base select (L70) left unchanged; new fields are append-only per-query to keep bulk team/epic queries lean

## Plan

[.claude/plans/W-23213788.md](.claude/plans/W-23213788.md)

## Reviewer notes

- SKILL.md:72 field-accuracy — confirmed all field types/labels/flags match live describe; no edit needed
- SKILL.md:77 picklist-values consistency — resolved as "run `sf sobject describe` for full lists" note (each security picklist has 33 values; inlining would contradict concise standard)

### What issues does this PR fix or reference?

@W-23213788@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002dMmktYAC/view