### PR TITLE
chore(eslint): enable unicorn/no-useless-delete-check - W-23094915

### DIFF
--- a/.claude/plans/W-23094915.md
+++ b/.claude/plans/W-23094915.md
@@ -5,7 +5,7 @@
 - Flags existence-check before delete: `if (map.has(k)) map.delete(k)`, `if (obj.x) delete obj.x`, `cond && delete x`
 - Dep W-23094914 merged (commit 78e116995, `no-useless-compound-assignment`)
 - Config: `eslint.config.mjs`, rules block alphabetical; slot between `no-useless-compound-assignment` (line 195) + `no-useless-error-capture-stack-trace` (line 196)
-- Probe: rule added, eslint run per-package across all `src` + `test` dirs → **0 violations**. Config-only change, no code fixes.
+- Probe: rule added, eslint run per-package across all `src` + `test` dirs → **0 violations**.
 
 ## Phases
 
@@ -17,7 +17,7 @@
 - concise (this plan)
 - typescript
 - verification
-- packageJson (none expected — no pkg changes)
+- packageJson (no changes)
 
 ## Verification
 - `eslint-local-rules` built (`npm run compile` in `packages/eslint-local-rules`) before lint runs

--- a/.claude/plans/W-23094915.md
+++ b/.claude/plans/W-23094915.md
@@ -1,0 +1,25 @@
+# W-23094915 — enable unicorn/no-useless-delete-check
+
+## Context
+- Enable `unicorn/no-useless-delete-check` (eslint-plugin-unicorn 68.0.0, rule exists: `node_modules/eslint-plugin-unicorn/rules/no-useless-delete-check.js`)
+- Flags existence-check before delete: `if (map.has(k)) map.delete(k)`, `if (obj.x) delete obj.x`, `cond && delete x`
+- Dep W-23094914 merged (commit 78e116995, `no-useless-compound-assignment`)
+- Config: `eslint.config.mjs`, rules block alphabetical; slot between `no-useless-compound-assignment` (line 195) + `no-useless-error-capture-stack-trace` (line 196)
+- Probe: rule added, eslint run per-package across all `src` + `test` dirs → **0 violations**. Config-only change, no code fixes.
+
+## Phases
+
+### Phase 1 — enable rule
+- `eslint.config.mjs`: add `'unicorn/no-useless-delete-check': 'error',` after line 195
+- commit: `chore(eslint): enable unicorn/no-useless-delete-check - W-23094915`
+
+## Skills to apply
+- concise (this plan)
+- typescript
+- verification
+- packageJson (none expected — no pkg changes)
+
+## Verification
+- `eslint-local-rules` built (`npm run compile` in `packages/eslint-local-rules`) before lint runs
+- lint clean repo-wide (probe confirmed 0 violations); CI lint job on branch covers full run
+- not e2e-covered — pure lint-config change

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -193,6 +193,7 @@ export default [
       'unicorn/no-unused-properties': 'error',
       'unicorn/no-useless-collection-argument': 'error',
       'unicorn/no-useless-compound-assignment': 'error',
+      'unicorn/no-useless-delete-check': 'error',
       'unicorn/no-useless-error-capture-stack-trace': 'error',
       'unicorn/no-useless-fallback-in-spread': 'error',
       'unicorn/no-useless-iterator-to-array': 'error',


### PR DESCRIPTION
## Summary

- Enables `unicorn/no-useless-delete-check` ESLint rule (eslint-plugin-unicorn 68.0.0)
- Flags redundant existence-checks before `delete` calls (e.g. `if (map.has(k)) map.delete(k)`)
- Zero violations found across all packages — pure config addition

## Plan

[.claude/plans/W-23094915.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23094915-8-enable-unicorn-no-useless-delete-check/.claude/plans/W-23094915.md)

### What issues does this PR fix or reference?

@W-23094915@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cfCMXYA2/view