### PR TITLE
refactor(org): verify sf.set.default.org picker backed by ConnectionService - W-23069616

### DIFF
--- a/.claude/plans/W-23069616.md
+++ b/.claude/plans/W-23069616.md
@@ -2,14 +2,14 @@
 
 ## Context
 
-- WI goal: status bar picker (`sf.set.default.org`) → Effect, backed by `ConnectionService.listAllAuthorizations` instead of direct `AuthInfo` call in `orgList.ts`.
+- Status bar picker (`sf.set.default.org`) → Effect; backed by `ConnectionService.listAllAuthorizations`, not direct `AuthInfo` in `orgList.ts`.
 - Gated by WI 3 (services available). Met.
-- **Core already shipped** in predecessor commit f4bf62251 (W-23069593, org pickers → Effect + PromptService):
-  - `orgPicker/orgList.ts` `setDefaultOrgEffect` = Effect-based, no `AuthInfo` import.
+- **Core shipped** in f4bf62251 (W-23069593):
+  - `orgPicker/orgList.ts` `setDefaultOrgImpl` = Effect-based, no `AuthInfo` import.
   - reads orgs via `getFreshAuthorizations` (`util/orgUtil.ts:334`) → `api.services.ConnectionService.listAllAuthorizations()` (`util/orgUtil.ts:338`).
   - service def: `salesforcedx-vscode-services/src/core/connectionService.ts:251`.
   - wired: `index.ts:67` `sf.set.default.org` → `setDefaultOrg`.
-- Remaining direct `AuthInfo.listAllAuthorizations` in `orgUtil.ts` (47, 264, 470) belong to other flows (expiry warning, org-list-clean, org list table) — NOT picker; out of scope.
+- Remaining `AuthInfo.listAllAuthorizations` in `orgUtil.ts` (47, 264, 470): expiry warning / org-list-clean / table — not picker; out of scope.
 - This WI = verify migration holds; no new picker code expected.
 
 ## Phases
@@ -18,8 +18,8 @@
 
 - Confirm picker path uses service only; no `AuthInfo` in `orgPicker/orgList.ts` (currently none).
 - Run org pkg jest (`orgList.test.ts`, picker) + typecheck/lint.
-- Run desktop e2e locally (see Verification) and record pass/fail in WI; do NOT defer e2e to branch CI.
-- WI satisfied by f4bf62251 (no picker code change). Commit must touch a non-`.claude/**` file so CI/orgE2E actually fire and gate the branch — `.claude/**`-only commits hit orgE2E.yml `paths-ignore` (lines 22-23) and orgPicker.desktop.spec.ts never runs. Add a one-line clarifying comment to `packages/salesforcedx-vscode-org/src/orgPicker/orgList.ts` near `setDefaultOrgEffect` (e.g. note service-backed source) so the commit carries a real source diff.
+- Desktop e2e locally (see Verification); record pass/fail in WI — don't defer to branch CI.
+- WI satisfied by f4bf62251 (no picker code change). Commit must touch a non-`.claude/**` file so orgE2E fires (see Verification). Carry a real source diff.
 - commitMessage: `refactor(org): verify sf.set.default.org picker backed by ConnectionService - W-23069616`
 
 ## Skills to apply
@@ -34,7 +34,7 @@
 
 - e2e (REQUIRED, run locally — branch CI alone insufficient): the spec covering this WI is `test/playwright/specs/orgPicker.desktop.spec.ts`, test `org picker: set default org, create scratch org, switch default org` (sole test, line 53). Run:
   `npm run test:desktop -w salesforcedx-vscode-org -- --retries 0`
-  needs auth (`SFDX_AUTH_URL`/dev hub) + scratch org like orgE2E.yml env (`MINIMAL_ORG_ALIAS=minimalTestOrg`, `SF_TEMP_SHOW_SECRETS=true`). Record pass/fail in WI. Reason can't rely solely on CI: `.claude/**`-only commit is skipped by orgE2E.yml `paths-ignore`, so orgPicker.desktop.spec.ts would never run on the branch.
+  requires auth (`SFDX_AUTH_URL`/dev hub), scratch org (`MINIMAL_ORG_ALIAS=minimalTestOrg`, `SF_TEMP_SHOW_SECRETS=true`). Record pass/fail in WI. Note: `.claude/**`-only commits skipped by orgE2E.yml `paths-ignore`.
 - CI gate: ensure the verify commit includes a non-`.claude/**` source change (Phase 1 comment touch on `orgList.ts`) so orgE2E.yml push trigger fires as defense-in-depth on top of the local run.
 - unit: `packages/salesforcedx-vscode-org` jest — `test/jest/orgPicker/orgList.test.ts`.
 - grep guard: 0 `AuthInfo` in `src/orgPicker/orgList.ts`.

--- a/.claude/plans/W-23069616.md
+++ b/.claude/plans/W-23069616.md
@@ -1,0 +1,41 @@
+# W-23069616 — 4.11 Migrate sf.set.default.org to services
+
+## Context
+
+- WI goal: status bar picker (`sf.set.default.org`) → Effect, backed by `ConnectionService.listAllAuthorizations` instead of direct `AuthInfo` call in `orgList.ts`.
+- Gated by WI 3 (services available). Met.
+- **Core already shipped** in predecessor commit f4bf62251 (W-23069593, org pickers → Effect + PromptService):
+  - `orgPicker/orgList.ts` `setDefaultOrgEffect` = Effect-based, no `AuthInfo` import.
+  - reads orgs via `getFreshAuthorizations` (`util/orgUtil.ts:334`) → `api.services.ConnectionService.listAllAuthorizations()` (`util/orgUtil.ts:338`).
+  - service def: `salesforcedx-vscode-services/src/core/connectionService.ts:251`.
+  - wired: `index.ts:67` `sf.set.default.org` → `setDefaultOrg`.
+- Remaining direct `AuthInfo.listAllAuthorizations` in `orgUtil.ts` (47, 264, 470) belong to other flows (expiry warning, org-list-clean, org list table) — NOT picker; out of scope.
+- This WI = verify migration holds; no new picker code expected.
+
+## Phases
+
+### Phase 1 — verify + guard (likely no-op)
+
+- Confirm picker path uses service only; no `AuthInfo` in `orgPicker/orgList.ts` (currently none).
+- Run org pkg jest (`orgList.test.ts`, picker) + typecheck/lint.
+- Run desktop e2e locally (see Verification) and record pass/fail in WI; do NOT defer e2e to branch CI.
+- WI satisfied by f4bf62251 (no picker code change). Commit must touch a non-`.claude/**` file so CI/orgE2E actually fire and gate the branch — `.claude/**`-only commits hit orgE2E.yml `paths-ignore` (lines 22-23) and orgPicker.desktop.spec.ts never runs. Add a one-line clarifying comment to `packages/salesforcedx-vscode-org/src/orgPicker/orgList.ts` near `setDefaultOrgEffect` (e.g. note service-backed source) so the commit carries a real source diff.
+- commitMessage: `refactor(org): verify sf.set.default.org picker backed by ConnectionService - W-23069616`
+
+## Skills to apply
+
+- effect-best-practices
+- typescript
+- playwright-e2e (e2e interpretation only; don't author)
+- verification
+- concise
+
+## Verification
+
+- e2e (REQUIRED, run locally — branch CI alone insufficient): the spec covering this WI is `test/playwright/specs/orgPicker.desktop.spec.ts`, test `org picker: set default org, create scratch org, switch default org` (sole test, line 53). Run:
+  `npm run test:desktop -w salesforcedx-vscode-org -- --retries 0`
+  needs auth (`SFDX_AUTH_URL`/dev hub) + scratch org like orgE2E.yml env (`MINIMAL_ORG_ALIAS=minimalTestOrg`, `SF_TEMP_SHOW_SECRETS=true`). Record pass/fail in WI. Reason can't rely solely on CI: `.claude/**`-only commit is skipped by orgE2E.yml `paths-ignore`, so orgPicker.desktop.spec.ts would never run on the branch.
+- CI gate: ensure the verify commit includes a non-`.claude/**` source change (Phase 1 comment touch on `orgList.ts`) so orgE2E.yml push trigger fires as defense-in-depth on top of the local run.
+- unit: `packages/salesforcedx-vscode-org` jest — `test/jest/orgPicker/orgList.test.ts`.
+- grep guard: 0 `AuthInfo` in `src/orgPicker/orgList.ts`.
+- typecheck + lint org pkg.

--- a/packages/salesforcedx-vscode-org/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-org/src/orgPicker/orgList.ts
@@ -185,8 +185,7 @@ export const buildOrgQuickPickItems = (
   });
 };
 
-// Orgs are sourced via getFreshAuthorizations → ConnectionService.listAllAuthorizations (no direct AuthInfo).
-const setDefaultOrgEffect = Effect.fn('OrgList.setDefaultOrg')(function* () {
+const setDefaultOrgImpl = Effect.fn('OrgList.setDefaultOrg')(function* () {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const promptService = yield* api.services.PromptService;
   const { defaultConfig, freshAuthorizations } = yield* getFreshAuthorizations();
@@ -202,17 +201,18 @@ const setDefaultOrgEffect = Effect.fn('OrgList.setDefaultOrg')(function* () {
   ).pipe(Effect.flatMap(promptService.considerUndefinedAsCancellation));
 
   if (selection.commandId) {
-    vscode.commands.executeCommand(selection.commandId);
+    const { commandId } = selection;
+    yield* Effect.promise(() => Promise.resolve(vscode.commands.executeCommand(commandId)));
     return;
   }
 
   const usernameOrAlias = selection.orgAlias ?? selection.orgUsername ?? '';
-  vscode.commands.executeCommand('sf.config.set', usernameOrAlias);
+  yield* Effect.promise(() => Promise.resolve(vscode.commands.executeCommand('sf.config.set', usernameOrAlias)));
 });
 
 export const setDefaultOrg = async (): Promise<CancelResponse | ContinueResponse<{}>> =>
   getOrgRuntime().runPromise(
-    setDefaultOrgEffect().pipe(
+    setDefaultOrgImpl().pipe(
       Effect.map((): ContinueResponse<{}> => ({ type: 'CONTINUE', data: {} })),
       Effect.catchTag('UserCancellationError', (): Effect.Effect<CancelResponse> => Effect.succeed({ type: 'CANCEL' }))
     )

--- a/packages/salesforcedx-vscode-org/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-org/src/orgPicker/orgList.ts
@@ -210,12 +210,11 @@ const setDefaultOrgImpl = Effect.fn('OrgList.setDefaultOrg')(function* () {
   yield* Effect.promise(() => Promise.resolve(vscode.commands.executeCommand('sf.config.set', usernameOrAlias)));
 });
 
-export const setDefaultOrg = async (): Promise<CancelResponse | ContinueResponse<{}>> =>
-  getOrgRuntime().runPromise(
-    setDefaultOrgImpl().pipe(
-      Effect.map((): ContinueResponse<{}> => ({ type: 'CONTINUE', data: {} })),
-      Effect.catchTag('UserCancellationError', (): Effect.Effect<CancelResponse> => Effect.succeed({ type: 'CANCEL' }))
-    )
+export const setDefaultOrg = (): Promise<CancelResponse | ContinueResponse<{}>> =>
+  setDefaultOrgImpl().pipe(
+    Effect.map((): ContinueResponse<{}> => ({ type: 'CONTINUE', data: {} })),
+    Effect.catchTag('UserCancellationError', (): Effect.Effect<CancelResponse> => Effect.succeed({ type: 'CANCEL' })),
+    getOrgRuntime().runPromise
   );
 
 /** Create and initialize OrgList with Effect-based TargetOrgRef watching */

--- a/packages/salesforcedx-vscode-org/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-org/src/orgPicker/orgList.ts
@@ -185,6 +185,7 @@ export const buildOrgQuickPickItems = (
   });
 };
 
+// Orgs are sourced via getFreshAuthorizations → ConnectionService.listAllAuthorizations (no direct AuthInfo).
 const setDefaultOrgEffect = Effect.fn('OrgList.setDefaultOrg')(function* () {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const promptService = yield* api.services.PromptService;


### PR DESCRIPTION
## Summary

- Verifies `sf.set.default.org` picker path uses `ConnectionService.listAllAuthorizations` (via `getFreshAuthorizations`), with zero direct `AuthInfo` imports in `orgPicker/orgList.ts`
- High review findings applied: renamed Effect fn for clarity, yielded `executeCommand` inside Effect pipeline
- Core migration shipped in predecessor f4bf62251 (W-23069593); this WI provides the verify commit with genuine source diff so orgE2E.yml fires

## Plan

[.claude/plans/W-23069616.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23069616-4-11-migrate-sf-set-default-org-to-servi/.claude/plans/W-23069616.md)

## Reviewer notes

- **medium** — `orgList.ts:151 isOrgExpired`: lifting to `Effect.fn` would break three jest tests at `test/jest/orgPicker/orgList.test.ts:68,81,92` which call `await orgListModule.isOrgExpired(...)` directly; converting requires rewriting those tests to run the Effect. Design decision with public-signature change — surfaced, not auto-applied.
- **low** — `orgList.ts:196 Effect.promise(showQuickPick)` routes rejection to die not fail (untyped). Downgraded to low: vscode `showQuickPick` is a Thenable that resolves `undefined` on cancel and does not reject, so there is no live defect path. Choosing a domain error type is a design decision.
- **medium** — PR body notes the high/low code findings provide genuine source changes (Effect fn rename + yielded `executeCommand`), so the diff is no longer contrived padding. The stale negative-assertion comment was removed. Durable no-AuthInfo invariant (eslint `no-restricted-imports` vs prose comment) and fixing the path-filter config remain repo-policy decisions out of scope for this WI.

## Test plan

- Run desktop Playwright e2e locally (branch CI alone insufficient — orgE2E.yml skips `.claude/**`-only commits):
  ```
  npm run test:desktop -w salesforcedx-vscode-org -- --retries 0
  ```
  Requires `SFDX_AUTH_URL` / dev hub, scratch org (`MINIMAL_ORG_ALIAS=minimalTestOrg`, `SF_TEMP_SHOW_SECRETS=true`). Spec: `test/playwright/specs/orgPicker.desktop.spec.ts` — `org picker: set default org, create scratch org, switch default org`. Record pass/fail in WI before close.

### What issues does this PR fix or reference?

@W-23069616@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cX69vYAC/view