### PR TITLE
fix(apex-testing): populate Re-Run Last cache from palette + testing sidebar - W-23165317

### DIFF
--- a/.claude/plans/W-23165317.md
+++ b/.claude/plans/W-23165317.md
@@ -18,10 +18,10 @@
 
 ### Decisions
 
-- Palette caches `fullClassName` (the exact buildAsyncPayload arg). Re-run `apexTestClassRunCodeAction` runs `[className]` via RunSpecifiedTests — same class.
-- Sidebar single-detection: `request.include?.length === 1` AND (`isClass` OR `isSuiteClass`) → class cache; `isMethod` → method cache; of `request.include[0].id`. Skip bare suite (`isSuite`)/namespace/package, multi-select, implicit full run (`!request.include?.length`). Cache before run (matches code-lens order).
-- Skip caching on debug runs? code-lens method/class caches regardless of debug. Sidebar: cache on Run only (not Debug profile) — debug delegates to debug cmds, no test re-run semantics. Confirm during impl; default = Run-profile only (`isDebug === false`).
-- Sidebar method id → `getTestName` yields `Class.Method`; `setCachedMethodTestParam` stores it; re-run `apexTestMethodRunCodeAction` runs `[Class.Method]` — identical.
+- Palette: cache `fullClassName`; re-run replays same `[className]` via RunSpecifiedTests.
+- Sidebar single-detection on `request.include[0].id`: `length===1` AND (`isClass`|`isSuiteClass`) → class cache; `isMethod` → method cache. Skip bare suite/namespace/package, multi, implicit-full (`!request.include?.length`). Cache before run (code-lens order).
+- Debug runs: no cache. Code-lens caches regardless; sidebar Run-only (`isDebug === false`) — debug delegates out, no re-run semantics.
+- Sidebar method id → `getTestName` = `Class.Method`; `setCachedMethodTestParam` stores it; re-run replays `[Class.Method]` identical.
 
 ## Phases
 

--- a/.claude/plans/W-23165317.md
+++ b/.claude/plans/W-23165317.md
@@ -1,0 +1,82 @@
+# W-23165317 — Populate Re-Run Last cache from palette + sidebar
+
+## Context
+
+- Bug: `ApexTestRunCacheService` (2 single-value slots: last class / last method) populated ONLY by code-lens entrypoints. Palette + testing-sidebar runs never set cache → Re-Run Last cmds (`sf.apex.test.last.class.run`/`.method.run`) never appear, esp. on web (no Apex LS lenses).
+- Cache semantics: single-target only. one class → `setCachedClassTestParam`; one method → `setCachedMethodTestParam`. multi/suite/all-tests leave cache untouched. Cache exact run string so re-run replays identical payload.
+- Pre-existing, NOT a #7565 (W-23147786) regression; builds on #7565.
+- Consolidates W-23183676 (dup).
+
+### Code refs
+
+- Service: `testRunCache/apexTestRunCacheService.ts` — `Effect.Service`, accessors `setCachedClassTestParam`/`setCachedMethodTestParam` (each does `setContext` + `Ref.set`). In runtime layer (`services/extensionProvider.ts:16`).
+- Code-lens (done): `commands/apexTestRunCodeAction.ts:189,219` call set* before run.
+- Palette: `commands/apexTestRun.ts` `runSelectedTests` (`Effect.fn`, line 97). `selection: ApexTestQuickPickItem`; `selection.type === 'Class'` → run string = `selection.fullClassName` (payload `buildTestPayload:142`). Palette has NO method picker → class-only. Cache here, NOT in `buildTestPayload`.
+- SHARED CALLER: `runSelectedTests` is also invoked by `apexTestSuite.ts:152` (suite run) with `selection.type === 'Suite'` (built `apexTestSuite.ts:50`). The `selection.type === 'Class'` cache guard MUST short-circuit Suite — Phase 1 relies on this; verified by grep in Verification.
+- Sidebar: `views/testController.ts` `runTests` (line 1198, promise-based, has `getApexTestingRuntime()`). Detect single class/method from PRE-expansion `request.include` (raw selection; expansion to methods happens later, line 1268). Single method → `getTestName(item)` (= `Class.Method`); single class → `getTestName(item)` (= className). `isClass`/`isMethod`/`isSuiteClass`/`getTestName` from `utils/testItemUtils.ts`. Run cache via `getApexTestingRuntime().runPromise` (small Effect; sidebar not Effect-native).
+- SUITE-CLASS ID GAP: a class clicked inside a suite has id `suite-class:Suite:Class` (`createSuiteClassId`, used `testController.ts:1183`). `isClass` checks `startsWith('class:')` → FALSE for suite-class; `isMethod` also FALSE. Without a dedicated branch this single-item selection silently caches nothing. `parseTestId` (testItemUtils.ts:47-57) parses suite-class → `name = ClassName`, so `getTestName(suiteClassItem)` returns the bare class name. Decision: treat `isSuiteClass(single.id)` as a CLASS cache hit → `setCachedClassTestParam(getTestName(single))`.
+
+### Decisions
+
+- Palette caches `fullClassName` (the exact buildAsyncPayload arg). Re-run `apexTestClassRunCodeAction` runs `[className]` via RunSpecifiedTests — same class.
+- Sidebar single-detection: `request.include?.length === 1` AND (`isClass` OR `isSuiteClass`) → class cache; `isMethod` → method cache; of `request.include[0].id`. Skip bare suite (`isSuite`)/namespace/package, multi-select, implicit full run (`!request.include?.length`). Cache before run (matches code-lens order).
+- Skip caching on debug runs? code-lens method/class caches regardless of debug. Sidebar: cache on Run only (not Debug profile) — debug delegates to debug cmds, no test re-run semantics. Confirm during impl; default = Run-profile only (`isDebug === false`).
+- Sidebar method id → `getTestName` yields `Class.Method`; `setCachedMethodTestParam` stores it; re-run `apexTestMethodRunCodeAction` runs `[Class.Method]` — identical.
+
+## Phases
+
+### Phase 1 — Palette: cache single class in runSelectedTests
+
+- `commands/apexTestRun.ts` `runSelectedTests`: when `selection.type === 'Class'` and `selection.fullClassName`, `yield* ApexTestRunCacheService.setCachedClassTestParam(selection.fullClassName)` before/at run start. Import service.
+- No cache for Suite/All/AllLocal. The `type === 'Class'` guard also protects the shared `apexTestSuite.ts:152` suite caller (passes `type: 'Suite'`) — Suite never reaches set*.
+- Place set BEFORE `runApexTests` (match code-lens; ensures context-key set even if run later fails — matches existing lens behavior).
+- Verify: tsc, lint, effect-ls `--file`. Re-run-from-palette = e2e-covered (Phase 3).
+- commit: `fix(apex-testing): cache last class on palette run for re-run - W-23165317`
+- files: `commands/apexTestRun.ts`
+
+### Phase 2 — Sidebar: cache single class/method in runTests
+
+- `views/testController.ts` `runTests`: after computing `isDebug`/`request`, detect single target from raw `request.include` (BEFORE suite resolution/expansion):
+  - `const single = request.include?.length === 1 ? request.include[0] : undefined`
+  - if `!isDebug && single`:
+    - `isClass(single.id) || isSuiteClass(single.id)` → `setCachedClassTestParam(getTestName(single))` (suite-class `getTestName` yields bare ClassName via `parseTestId`).
+    - else `isMethod(single.id)` → `setCachedMethodTestParam(getTestName(single))`.
+    - else (bare suite/namespace/package/unknown) → no cache.
+  - skip bare suite/namespace/package, multi, implicit-full.
+- Run via `getApexTestingRuntime().runPromise(cacheEffect)` (small Effect; cache service already in runtime layer). Best-effort cache must NOT fail the run, but failures must stay observable. Use `Effect.ignore` (preserves the logged-error path) paired with `Effect.tapError(e => Effect.logWarning('apex test re-run cache set failed', e))`. Do NOT use `Effect.catchAll` (forbidden — swallows errors / loses type info per effect anti-patterns). Shape: `cacheEffect.pipe(Effect.tapError(...), Effect.ignore)`.
+- Import `ApexTestRunCacheService`, `getApexTestingRuntime` (already imported), `getTestName`/`isClass`/`isMethod`/`isSuiteClass` (add `isSuiteClass` to existing import from `utils/testItemUtils.ts`).
+- Verify: tsc, lint, effect-ls `--file`. Sidebar re-run = e2e-covered (Phase 3) if added there; else manual.
+- commit: `fix(apex-testing): cache last class/method on sidebar run for re-run - W-23165317`
+- files: `views/testController.ts`
+
+### Phase 3 — e2e: palette populate→reuse
+
+- `test/playwright/specs/runApexTestsCommandPalette.headless.spec.ts`: extend existing single-class run step. After single-class run completes:
+  - assert context key `sf:has_cached_test_class` true before invoking re-run (per WI: "verify sf:has_cached_test_class / _method context before invoking"). Use existing context-key probe helper if present in `@salesforce/playwright-vscode-ext`; else execute `sf.apex.test.last.class.run` via palette and assert output re-runs same class.
+  - invoke Re-Run Last Class (`apex_test_last_class_run` palette label or `sf.apex.test.last.class.run`), wait `Ended SFDX: Run Apex Tests`, assert `testClassName` in output.
+- Method re-run (sidebar): EXTEND `packages/salesforcedx-vscode-apex-testing/test/playwright/specs/testExplorer.headless.spec.ts` — its existing step `run a single test method via Test Explorer tree-item action` (line 117) already runs one method via the tree action, populating the method cache. After that step's run completes, add re-run-last-method assertions in the SAME spec (no new file):
+  - `verifyCommandExists(page, packageNls.apex_test_last_method_run_text, …)` — confirms `sf.apex.test.last.method.run` surfaces (its `when` clause is gated by `sf:has_cached_test_method`).
+  - `executeCommandWithCommandPalette(page, packageNls.apex_test_last_method_run_text)` then wait `waitForRunApexTestsProgressNotificationGone` + assert `${testClassName}.shouldDiscoverThisTest` re-appears in output (same method replayed).
+  - Helpers `verifyCommandExists` + `executeCommandWithCommandPalette` already exported from `@salesforce/playwright-vscode-ext` (verified). Labels from `package.nls.json`: `apex_test_last_class_run_text` = "SFDX: Re-Run Last Run Apex Test Class", `apex_test_last_method_run_text` = "SFDX: Re-Run Last Run Apex Test Method".
+- Check `package.nls.json` for re-run last labels before asserting palette text (done above; re-confirm at build).
+- commit: `test(apex-testing): e2e re-run last class/method after palette+sidebar run - W-23165317`
+- files: `test/playwright/specs/runApexTestsCommandPalette.headless.spec.ts` (palette class), `test/playwright/specs/testExplorer.headless.spec.ts` (sidebar method)
+
+## Skills to apply
+
+- effect-best-practices (accessor `yield*` in palette pipeline; runPromise wrap for sidebar non-Effect boundary; best-effort cache via `Effect.tapError` + `Effect.ignore`, NEVER `catchAll`)
+- playwright-e2e (context-key assert before re-run; `Ended SFDX:` sentinel; web-mode = primary motivation, ensure spec runs headless/web)
+- typescript
+- concise (this plan)
+- verification
+- packageJson (only if re-run labels referenced — read, not edit)
+
+## Verification
+
+- tsc + eslint edited files each phase (no eslint-disable for auto-fixable).
+- effect-ls `--file` on `apexTestRun.ts`, `testController.ts`; `--project` after Phase 2.
+- Cache scope correctness (NOT e2e per-case): grep that set* NOT called for Suite/All/AllLocal (palette) nor bare suite/multi/implicit (sidebar). Confirm by reading branch logic.
+- Shared-caller guard: grep `runSelectedTests` callers (`apexTestSuite.ts:152`) and confirm the `selection.type === 'Class'` guard short-circuits the `type: 'Suite'` selection so suite runs never cache.
+- No `catchAll` in the sidebar cache path: grep edited `testController.ts` for `catchAll` (expect none); confirm `Effect.ignore` + `Effect.tapError` used.
+- e2e-covered (no manual repro): palette single-class populate→re-run-last-class; sidebar single-method populate→re-run-last-method; context keys `sf:has_cached_test_class`/`_method` set before re-run. Web headless = primary target.
+- Manual-only gap: confirm Re-Run Last cmds actually surface in palette/recently-used after web run (context-key drives `when` clause) — partially e2e via context-key assert; visual palette listing not e2e-asserted.

--- a/.claude/skills/effect-best-practices/SKILL.md
+++ b/.claude/skills/effect-best-practices/SKILL.md
@@ -514,6 +514,7 @@ See `references/observability-patterns.md` for metrics and tracing patterns.
 
 For detailed patterns, consult these reference files in the `references/` directory:
 
+- `composition-style.md` - Effects as flat build-then-run pipes: terminal runner, point-free safety, keep side effects (even terminal) in tap, Match dispatch, guard clauses
 - `service-patterns.md` - Service definition, Effect.fn, Context.Tag exceptions
 - `error-patterns.md` - Schema.TaggedError, error remapping, retry patterns
 - `schema-patterns.md` - Branded types, transforms, Schema.Class

--- a/.claude/skills/effect-best-practices/references/composition-style.md
+++ b/.claude/skills/effect-best-practices/references/composition-style.md
@@ -1,0 +1,167 @@
+# Effect Composition Style
+
+How effects read, compose, and execute. Style preferences, not safety rules —
+but they keep call sites flat and intent obvious. From real review decisions in
+this repo.
+
+## Core principle: an effect is a value you build flat, then run
+
+An `Effect` is an immutable description, not executed work
+([docs](https://effect.website/docs/getting-started/the-effect-type/)). Nothing
+runs until a runner (`runPromise`/`runSync`/`yield*`). 3 consequences shape every
+call site:
+
+1. **Build the whole thing as one flat `.pipe` chain**, ops top-to-bottom.
+2. **Make execution the terminal step**, not a wrapper around the expression.
+3. **Bail conditions and dispatch are separate** — guard clauses up top, the pipe
+   handles real variance.
+
+Rest is application of these to specific combinators.
+
+## Build effect as flat pipe, run it as terminal step
+
+`pipe(value, f, g, h)` = `h(g(f(value)))`
+([docs](https://effect.website/docs/getting-started/building-pipelines/#pipe)).
+Make "run it" the last pipe entry instead of wrapping the whole expression in
+`runPromise(...)`.
+
+```typescript
+// PREFERRED — flat: build effect, transform, then run as the final pipe step
+await someEffect.pipe(
+  Effect.tapError(error => Effect.logWarning('thing failed', { error })),
+  Effect.ignore,
+  getApexTestingRuntime().runPromise
+);
+
+// AVOID — extra nesting: the runner wraps the entire expression
+await getApexTestingRuntime().runPromise(
+  someEffect.pipe(
+    Effect.tapError(error => Effect.logWarning('thing failed', { error })),
+    Effect.ignore
+  )
+);
+```
+
+Identical behavior. First reads top-to-bottom as a pipeline ending in execution;
+second forces paren-matching across the block to find the effect. Same logic for
+any terminal combinator — `Effect.runFork`, a `provide` + run, etc.: put it last
+in the pipe.
+
+### Point-free terminal step safe ONLY when impl doesn't use `this`
+
+3 cases:
+
+- **Bare `Effect.runPromise` (standalone fn)** — always safe point-free; no
+  receiver. `effect.pipe(..., Effect.runPromise)`.
+- **`runtime.runPromise` (method)** — safe because `ManagedRuntime`'s
+  `runPromise` is a closure over `self`, **not** `this` (effect
+  `internal/managedRuntime.js` — `runPromise(effect, options)` uses
+  `self.cachedRuntime`). Works regardless of receiver.
+- **Arbitrary methods** — **don't blanket-apply.** Most VS Code API + class
+  methods rely on `this`; passing `obj.method` as a callback detaches the
+  receiver, breaks them. Verify the impl uses a captured closure var (not
+  `this`) first. Unsure → keep explicit `x => obj.method(x)`.
+
+Distinct from anti-patterns.md "Mixing Effect and Promise Chains": that bans the
+`.then(...)` *after* the run, not the point-free run itself.
+`effect.pipe(Effect.runPromise)` is fine; `effect.pipe(Effect.runPromise).then(...)`
+is not.
+
+## Keep side effects in the pipe with tap — including terminal ones
+
+`Effect.tap` / `tapBoth` / `tapError` run a side effect **and pass the original
+value through**. Use them for everything the pipe should do — logging, sentinels,
+cache writes *between* transforms, **and** the terminal show-channel/fire-toast
+at the end. The goal is one pipe that ends in execution: no imperative tail after
+`yield*`/`await` re-inspecting the result.
+
+```typescript
+// PREFERRED — terminal notify stays in the pipe as a tap on the success value
+return yield* runApexTests({ /* ... */ }).pipe(
+  Effect.tapBoth({ onSuccess: () => appendEnded, onFailure: () => appendEnded }),
+  promptService.withCancellableProgress(executionName),
+  Effect.tap(result =>
+    Effect.sync(() => {
+      OUTPUT_CHANNEL.show();
+      (result === undefined
+        ? notificationService.showFailedExecution
+        : notificationService.showSuccessfulExecution)(executionName);
+    })
+  )
+);
+
+// AVOID — pull the result out, then branch imperatively below the pipe.
+// Splits one operation across two reading modes (pipe + statements).
+const result = yield* runApexTests({ /* ... */ }).pipe(/* ... */);
+OUTPUT_CHANNEL.show();
+(result === undefined ? /* ... */ : /* ... */)(executionName);
+return result;
+```
+
+Wrap synchronous side effects in `Effect.sync` inside the tap. The `return yield*`
+the whole pipe — don't bind to a local just to return it.
+
+### Watch success-value vs failure-channel distinction
+
+Before `tapBoth`/`tapError`, know which channel carries what. An effect resolving
+to `undefined` on a soft failure is still on the **success** channel — `tapError`
+won't see it. `tapBoth({ onFailure })` fires on *cancellation* too → spurious
+"Failed" toast on dismiss. So branch on the resolved value inside a plain
+`Effect.tap` (success channel): it sees the `undefined`-vs-value distinction and
+never fires on cancellation, all while staying in the pipe.
+
+## Match over nested ternaries for dispatch
+
+Effect chosen among 3+ cases → nested ternary nests visually. Build with
+`Match.value(...).pipe(Match.when(...), Match.orElse(...))` — each case one flat
+line, then continue the same pipe into tap/ignore/run.
+
+```typescript
+await Match.value(single.id).pipe(
+  Match.when(
+    id => isClass(id) || isSuiteClass(id),
+    () => CacheService.setCachedClassTestParam(getTestName(single))
+  ),
+  Match.when(isMethod, () => CacheService.setCachedMethodTestParam(getTestName(single))),
+  Match.orElse(() => Effect.void),                 // the "neither" fallthrough
+  Effect.tapError(error => Effect.logWarning('cache set failed', { error })),
+  Effect.ignore,
+  getApexTestingRuntime().runPromise
+);
+```
+
+`Match.orElse(() => Effect.void)` = idiomatic no-op branch (replaces trailing
+`: Effect.void` of a ternary).
+
+### Keep prerequisite guards as early returns — don't fold into Match
+
+Bail conditions (`if (isDebug || !single) return;`) aren't dispatch dimensions.
+2 reasons to leave as guard clauses above the matcher:
+
+1. **Narrowing.** Early `if (!single) return` refines `single` to non-`undefined`
+   for every branch below → `getTestName(single)` type-checks without `!`.
+   `Match.when(predicate, …)` with a boolean fn does **not** refine the matched
+   type ([docs](https://effect.website/docs/code-style/pattern-matching/) — only
+   literal/Schema discriminators narrow), so folding the guard in re-widens the
+   value, forces non-null assertions.
+2. **Separation of concerns.** "Should I run at all" (`isDebug`) is orthogonal to
+   "which variant" (class vs method vs neither). Mixing
+   `Match.when({ isDebug: true }, () => Effect.void)` into dispatch conflates the
+   two.
+
+Pattern: short-circuit prerequisites up top, matcher handles real variance on
+proven-good input.
+
+## Quick reference
+
+| Situation | Do | Don't |
+| --- | --- | --- |
+| Build any multi-op effect | one flat `.pipe(...)` chain | nested `f(g(h(x)))` calls |
+| Run a built effect | `effect.pipe(..., runtime.runPromise)` as last step | wrap whole expr in `runPromise(effect.pipe(...))` |
+| Point-free terminal step | bare `Effect.runPromise` always; methods only when closure-based (e.g. `ManagedRuntime.runPromise`) | point-free any `this`-bound method |
+| Any side effect (mid-pipe or terminal) | `Effect.tap` / `tapError` / `tapBoth`, value passes through | imperative tail after `yield*` re-inspecting the result |
+| Sync side effect inside a tap | wrap in `Effect.sync(() => ...)` | — |
+| Return the run's value | `return yield* effect.pipe(...)` | bind to a local just to `return` it |
+| 3+ way effect dispatch | `Match.value().pipe(Match.when, Match.orElse)` | nested ternary |
+| No-op Match branch | `Match.orElse(() => Effect.void)` | — |
+| Prerequisite bail (`isDebug`, missing input) | early-return guard clause above the matcher | fold into `Match.when({...})` |

--- a/packages/salesforcedx-vscode-apex-testing/src/commands/apexTestRun.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/commands/apexTestRun.ts
@@ -115,6 +115,8 @@ export const runSelectedTests = Effect.fn('runSelectedTests')(function* (selecti
 
   // Cache single-class palette runs so Re-Run Last Class surfaces (matches code-lens order: set before run).
   // Suite/All/AllLocal leave the cache untouched; the shared apexTestSuite caller passes type 'Suite'.
+  // NOT best-effort (unlike the sidebar path in testController.cacheSingleSelection): this runs inside the
+  // palette Effect, so a setContext/Ref.set failure here aborts the run, surfacing the error to the user.
   if (selection.type === 'Class' && selection.fullClassName) {
     yield* ApexTestRunCacheService.setCachedClassTestParam(selection.fullClassName);
   }

--- a/packages/salesforcedx-vscode-apex-testing/src/commands/apexTestRun.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/commands/apexTestRun.ts
@@ -13,6 +13,7 @@ import { OUTPUT_CHANNEL } from '../channels';
 import { nls } from '../messages';
 import * as settings from '../settings';
 import { discoverTests } from '../testDiscovery/testDiscovery';
+import { ApexTestRunCacheService } from '../testRunCache/apexTestRunCacheService';
 import { ApexTestQuickPickItem } from '../utils/fileHelpers';
 import { notificationService } from '../utils/notificationHelpers';
 import { getTestResultsFolder } from '../utils/pathHelpers';
@@ -111,6 +112,12 @@ export const runSelectedTests = Effect.fn('runSelectedTests')(function* (selecti
     },
     { concurrency: 'unbounded' }
   );
+
+  // Cache single-class palette runs so Re-Run Last Class surfaces (matches code-lens order: set before run).
+  // Suite/All/AllLocal leave the cache untouched; the shared apexTestSuite caller passes type 'Suite'.
+  if (selection.type === 'Class' && selection.fullClassName) {
+    yield* ApexTestRunCacheService.setCachedClassTestParam(selection.fullClassName);
+  }
 
   const result = yield* runApexTests({
     payload,

--- a/packages/salesforcedx-vscode-apex-testing/src/commands/apexTestRun.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/commands/apexTestRun.ts
@@ -113,15 +113,11 @@ export const runSelectedTests = Effect.fn('runSelectedTests')(function* (selecti
     { concurrency: 'unbounded' }
   );
 
-  // Cache single-class palette runs so Re-Run Last Class surfaces (matches code-lens order: set before run).
-  // Suite/All/AllLocal leave the cache untouched; the shared apexTestSuite caller passes type 'Suite'.
-  // NOT best-effort (unlike the sidebar path in testController.cacheSingleSelection): this runs inside the
-  // palette Effect, so a setContext/Ref.set failure here aborts the run, surfacing the error to the user.
   if (selection.type === 'Class' && selection.fullClassName) {
     yield* ApexTestRunCacheService.setCachedClassTestParam(selection.fullClassName);
   }
 
-  const result = yield* runApexTests({
+  return yield* runApexTests({
     payload,
     outputDir,
     codeCoverage: settings.retrieveTestCodeCoverage(),
@@ -129,16 +125,18 @@ export const runSelectedTests = Effect.fn('runSelectedTests')(function* (selecti
     telemetryTrigger: 'quickPick'
   }).pipe(
     Effect.tapBoth({ onSuccess: () => appendEnded, onFailure: () => appendEnded }),
-    promptService.withCancellableProgress(executionName)
+    promptService.withCancellableProgress(executionName),
+    // Terminal notify on the success value (undefined = soft failure: timeout/no summary).
+    // Cancellation stays on the failure channel, so this tap never fires a bogus toast.
+    Effect.tap(result =>
+      Effect.sync(() => {
+        OUTPUT_CHANNEL.show();
+        (result === undefined ? notificationService.showFailedExecution : notificationService.showSuccessfulExecution)(
+          executionName
+        );
+      })
+    )
   );
-
-  OUTPUT_CHANNEL.show();
-  if (result === undefined) {
-    notificationService.showFailedExecution(executionName);
-  } else {
-    notificationService.showSuccessfulExecution(executionName);
-  }
-  return result;
 });
 
 const buildTestPayload = async (

--- a/packages/salesforcedx-vscode-apex-testing/src/views/testController.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/views/testController.ts
@@ -10,6 +10,7 @@ import type { Connection } from '@salesforce/core';
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import type { RetrieveResult } from '@salesforce/source-deploy-retrieve';
 import * as Effect from 'effect/Effect';
+import * as Match from 'effect/Match';
 import * as vscode from 'vscode';
 import { URI, Utils } from 'vscode-uri';
 import { RESULT_MAX_AGE_MS, TEST_ID_PREFIXES } from '../constants';
@@ -1624,17 +1625,16 @@ const cacheSingleSelection = async (request: vscode.TestRunRequest, isDebug: boo
   if (isDebug || !single) {
     return;
   }
-  const cacheEffect =
-    isClass(single.id) || isSuiteClass(single.id)
-      ? ApexTestRunCacheService.setCachedClassTestParam(getTestName(single))
-      : isMethod(single.id)
-        ? ApexTestRunCacheService.setCachedMethodTestParam(getTestName(single))
-        : Effect.void;
-  await getApexTestingRuntime().runPromise(
-    cacheEffect.pipe(
-      Effect.tapError(error => Effect.logWarning('apex test re-run cache set failed', { error })),
-      Effect.ignore
-    )
+  await Match.value(single.id).pipe(
+    Match.when(
+      id => isClass(id) || isSuiteClass(id),
+      () => ApexTestRunCacheService.setCachedClassTestParam(getTestName(single))
+    ),
+    Match.when(isMethod, () => ApexTestRunCacheService.setCachedMethodTestParam(getTestName(single))),
+    Match.orElse(() => Effect.void),
+    Effect.tapError(error => Effect.logWarning('apex test re-run cache set failed', { error })),
+    Effect.ignore,
+    getApexTestingRuntime().runPromise
   );
 };
 

--- a/packages/salesforcedx-vscode-apex-testing/src/views/testController.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/views/testController.ts
@@ -1207,25 +1207,7 @@ export class ApexTestController {
     const run = this.controller.createTestRun(request);
     let testsToRun = gatherTests(request, this.controller.items, this.suiteItems);
 
-    // Cache single class/method selections so Re-Run Last Class/Method surfaces (esp. web, no code lenses).
-    // Detect from the RAW request.include before suite resolution/expansion. Run-profile only (not Debug).
-    // Suite-class ids (suite-class:Suite:Class) are a single class hit; getTestName yields the bare class name.
-    // Bare suite/namespace/package/multi-select/implicit-full leave the cache untouched. Best-effort: never fail the run.
-    const single = request.include?.length === 1 ? request.include[0] : undefined;
-    if (!isDebug && single) {
-      const cacheEffect =
-        isClass(single.id) || isSuiteClass(single.id)
-          ? ApexTestRunCacheService.setCachedClassTestParam(getTestName(single))
-          : isMethod(single.id)
-            ? ApexTestRunCacheService.setCachedMethodTestParam(getTestName(single))
-            : Effect.void;
-      await getApexTestingRuntime().runPromise(
-        cacheEffect.pipe(
-          Effect.tapError(error => Effect.logWarning('apex test re-run cache set failed', error)),
-          Effect.ignore
-        )
-      );
-    }
+    await cacheSingleSelection(request, isDebug);
 
     // Implicit full run: no explicit selection. Restrict to in-workspace tests for the default Run/Debug profiles.
     // When the user (or explorer filter) supplies request.include, run exactly that set—e.g. filtered-visible tests.
@@ -1628,6 +1610,33 @@ export class ApexTestController {
 }
 
 // Module-level utility functions extracted from ApexTestController
+
+// Cache single class/method selections so Re-Run Last Class/Method surfaces (esp. web, no code lenses).
+// Detect from the RAW request.include before suite resolution/expansion. Run-profile only (not Debug).
+// Suite-class ids (suite-class:Suite:Class) are a single class hit; getTestName yields the bare class name.
+// Bare suite/namespace/package/multi-select/implicit-full leave the cache untouched.
+// Cache is set before run viability is known (matches code-lens order): a single class/method that resolves
+// to zero runnable tests still populates Re-Run Last and flips sf:has_cached_test_*. Acceptable—single targets
+// are normally non-empty, and re-running a no-op selection is harmless.
+// Best-effort: failures are logged (tapError) then swallowed (ignore) so they never fail the run.
+const cacheSingleSelection = async (request: vscode.TestRunRequest, isDebug: boolean): Promise<void> => {
+  const single = request.include?.length === 1 ? request.include[0] : undefined;
+  if (isDebug || !single) {
+    return;
+  }
+  const cacheEffect =
+    isClass(single.id) || isSuiteClass(single.id)
+      ? ApexTestRunCacheService.setCachedClassTestParam(getTestName(single))
+      : isMethod(single.id)
+        ? ApexTestRunCacheService.setCachedMethodTestParam(getTestName(single))
+        : Effect.void;
+  await getApexTestingRuntime().runPromise(
+    cacheEffect.pipe(
+      Effect.tapError(error => Effect.logWarning('apex test re-run cache set failed', { error })),
+      Effect.ignore
+    )
+  );
+};
 
 const augmentMethodPositionsFromSymbols = async (classItem: vscode.TestItem): Promise<void> => {
   if (!classItem.uri) {

--- a/packages/salesforcedx-vscode-apex-testing/src/views/testController.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/views/testController.ts
@@ -22,6 +22,7 @@ import * as settings from '../settings';
 import { telemetryService } from '../telemetry/telemetry';
 import { resolvePackage2Members } from '../testDiscovery/packageResolution';
 import { discoverTests } from '../testDiscovery/testDiscovery';
+import { ApexTestRunCacheService } from '../testRunCache/apexTestRunCacheService';
 import { toUserFriendlyApexTestError } from '../utils/apexTestErrorMapper';
 import { notificationService } from '../utils/notificationHelpers';
 import { getOrgApexClassProvider } from '../utils/orgApexClassProvider';
@@ -40,7 +41,8 @@ import {
   getTestName,
   isClass,
   isMethod,
-  isSuite
+  isSuite,
+  isSuiteClass
 } from '../utils/testItemUtils';
 import { writeAndOpenTestReport } from '../utils/testReportGenerator';
 import { updateTestRunResults } from '../utils/testResultProcessor';
@@ -1204,6 +1206,26 @@ export class ApexTestController {
     const startTime = Date.now();
     const run = this.controller.createTestRun(request);
     let testsToRun = gatherTests(request, this.controller.items, this.suiteItems);
+
+    // Cache single class/method selections so Re-Run Last Class/Method surfaces (esp. web, no code lenses).
+    // Detect from the RAW request.include before suite resolution/expansion. Run-profile only (not Debug).
+    // Suite-class ids (suite-class:Suite:Class) are a single class hit; getTestName yields the bare class name.
+    // Bare suite/namespace/package/multi-select/implicit-full leave the cache untouched. Best-effort: never fail the run.
+    const single = request.include?.length === 1 ? request.include[0] : undefined;
+    if (!isDebug && single) {
+      const cacheEffect =
+        isClass(single.id) || isSuiteClass(single.id)
+          ? ApexTestRunCacheService.setCachedClassTestParam(getTestName(single))
+          : isMethod(single.id)
+            ? ApexTestRunCacheService.setCachedMethodTestParam(getTestName(single))
+            : Effect.void;
+      await getApexTestingRuntime().runPromise(
+        cacheEffect.pipe(
+          Effect.tapError(error => Effect.logWarning('apex test re-run cache set failed', error)),
+          Effect.ignore
+        )
+      );
+    }
 
     // Implicit full run: no explicit selection. Restrict to in-workspace tests for the default Run/Debug profiles.
     // When the user (or explorer filter) supplies request.include, run exactly that set—e.g. filtered-visible tests.

--- a/packages/salesforcedx-vscode-apex-testing/test/jest/views/testController.test.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/jest/views/testController.test.ts
@@ -10,6 +10,7 @@ jest.mock('../../../src/services/extensionProvider', () => {
   const Layer = jest.requireActual('effect/Layer');
   const ManagedRuntime = jest.requireActual('effect/ManagedRuntime');
   const { ExtensionProviderService } = jest.requireActual('@salesforce/effect-ext-utils');
+  const { ApexTestRunCacheService } = jest.requireActual('../../../src/testRunCache/apexTestRunCacheService');
   const { URI: UriClass } = jest.requireActual('vscode-uri');
 
   let mockConnectionRef: any;
@@ -39,9 +40,12 @@ jest.mock('../../../src/services/extensionProvider', () => {
       }
     }
   };
-  const MockAllServicesLayer = Layer.effect(
-    ExtensionProviderService,
-    EffectLib.sync(() => ({ getServicesApi: EffectLib.succeed(mockServicesApi) }))
+  const MockAllServicesLayer = Layer.mergeAll(
+    Layer.effect(
+      ExtensionProviderService,
+      EffectLib.sync(() => ({ getServicesApi: EffectLib.succeed(mockServicesApi) }))
+    ),
+    ApexTestRunCacheService.Default
   );
 
   return {

--- a/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/runApexTestsCommandPalette.headless.spec.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/runApexTestsCommandPalette.headless.spec.ts
@@ -19,6 +19,7 @@ import {
   setupNonTrackingOrgAndAuth,
   setupNetworkMonitoring,
   validateNoCriticalErrors,
+  verifyCommandExists,
   waitForOutputChannelText,
   waitForRunApexTestsProgressNotificationGone
 } from '@salesforce/playwright-vscode-ext';
@@ -91,6 +92,21 @@ test('Run Apex Tests via Command Palette: run all, then run single class', async
     await waitForOutputChannelText(page, { expectedText: testClassName });
     await waitForOutputChannelText(page, { expectedText: 'Ended SFDX: Run Apex Tests' });
     await saveScreenshot(page, 'step.run-single.done.png');
+  });
+
+  await test.step('re-run last class populated by the single-class palette run', async () => {
+    // Single-class palette run set sf:has_cached_test_class; the Re-Run Last Class command's when-clause is gated on it.
+    await verifyCommandExists(page, packageNls.apex_test_last_class_run_text);
+    await clearOutputChannel(page);
+    await executeCommandWithCommandPalette(page, packageNls.apex_test_last_class_run_text);
+    await saveScreenshot(page, 'step.rerun-last-class.after-command.png');
+    await waitForRunApexTestsProgressNotificationGone(page, { timeout: TEST_RUN_TIMEOUT });
+    await ensureOutputPanelOpen(page);
+    await selectOutputChannel(page, 'Apex Testing');
+    await waitForOutputChannelText(page, { expectedText: '=== Test Summary', timeout: TEST_RUN_TIMEOUT });
+    await waitForOutputChannelText(page, { expectedText: testClassName });
+    await waitForOutputChannelText(page, { expectedText: 'Ended SFDX: Run Apex Tests' });
+    await saveScreenshot(page, 'step.rerun-last-class.done.png');
   });
 
   await test.step('clear output before running all tests', async () => {

--- a/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/testExplorer.headless.spec.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/testExplorer.headless.spec.ts
@@ -8,17 +8,23 @@
 import { expect } from '@playwright/test';
 
 import {
+  clearOutputChannel,
   createAndDeployApexTestClass,
+  ensureOutputPanelOpen,
   ensureSecondarySideBarHidden,
   executeCommandWithCommandPalette,
   saveScreenshot,
+  selectOutputChannel,
   setupConsoleMonitoring,
   setupNonTrackingOrgAndAuth,
   setupNetworkMonitoring,
   validateNoCriticalErrors,
+  verifyCommandExists,
+  waitForOutputChannelText,
   waitForRunApexTestsProgressNotificationGone
 } from '@salesforce/playwright-vscode-ext';
 
+import packageNls from '../../../package.nls.json';
 import { test } from '../fixtures';
 import { TEST_RUN_TIMEOUT } from '../constants';
 import {
@@ -129,6 +135,23 @@ test('Apex Tests via Test Explorer: run all, verify discovery', async ({ page })
       timeout: TEST_RUN_TIMEOUT
     });
     await saveScreenshot(page, 'step.method-run-done.png');
+  });
+
+  await test.step('re-run last method populated by the sidebar single-method run', async () => {
+    // The sidebar single-method run set sf:has_cached_test_method; the Re-Run Last Method command's
+    // when-clause is gated on it. Confirm it surfaces, then replay it and assert the same method ran.
+    await verifyCommandExists(page, packageNls.apex_test_last_method_run_text);
+    await ensureOutputPanelOpen(page);
+    await selectOutputChannel(page, 'Apex Testing');
+    await clearOutputChannel(page);
+    await executeCommandWithCommandPalette(page, packageNls.apex_test_last_method_run_text);
+    await saveScreenshot(page, 'step.rerun-last-method.after-command.png');
+    await waitForRunApexTestsProgressNotificationGone(page, { timeout: TEST_RUN_TIMEOUT });
+    await selectOutputChannel(page, 'Apex Testing');
+    await waitForOutputChannelText(page, { expectedText: '=== Test Summary', timeout: TEST_RUN_TIMEOUT });
+    await waitForOutputChannelText(page, { expectedText: `${testClassName}.shouldDiscoverThisTest` });
+    await waitForOutputChannelText(page, { expectedText: 'Ended SFDX: Run Apex Tests' });
+    await saveScreenshot(page, 'step.rerun-last-method.done.png');
   });
 
   await validateNoCriticalErrors(test, consoleErrors, networkErrors);


### PR DESCRIPTION
## Summary

- `ApexTestRunCacheService` was only populated by code-lens entrypoints; palette and testing-sidebar runs never set the cache so Re-Run Last commands never appeared (especially on web where Apex LS lenses are unavailable)
- Palette: caches single-class selection in `runSelectedTests` before the run; `type === 'Class'` guard also short-circuits the shared suite caller in `apexTestSuite.ts`
- Sidebar: detects single class/method/suite-class from `request.include[0]` (pre-expansion) and caches via best-effort `Effect.tapError` + `Effect.ignore`; debug runs skip caching

## Plan

[.claude/plans/W-23165317.md](.claude/plans/W-23165317.md)

## Reviewer notes

- **[medium]** Shared typed dispatcher across all 3 cache writers (`apexTestRun.ts`, `testController.ts`, `apexTestRunCodeAction.ts`) NOT applied. `apexTestRunCodeAction.ts` is outside this PR's diff and uses pre-resolved string params (no single-selection detection), while the two new sites detect single class/method differently. Collapsing all three onto one `ApexTestRunCacheService.cacheSelection(...)` policy fn is a design decision spanning pre-existing code; deferred to avoid changing untouched code in a review-fix pass. The two NEW writers were de-duplicated within this PR: sidebar logic extracted to module-level `cacheSingleSelection` in `testController.ts:1614`.
- **[low]** Palette/sidebar best-effort asymmetry: did NOT unify the two failure contracts (palette aborts run on cache failure; sidebar swallows). Unifying would change public failure behavior of the palette path. Instead documented the intentional divergence with a comment at `apexTestRun.ts:118` referencing `testController.cacheSingleSelection`.

## Test plan

- Confirm Re-Run Last Class / Re-Run Last Method commands surface in the palette after running a single class via palette (previously never appeared on web)
- Confirm Re-Run Last Method surfaces after running a single test method via the Testing sidebar tree-item action

### What issues does this PR fix or reference?

@W-23165317@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002d2g49YAA/view