### PR TITLE
fix(org): sf.org.open discriminate CLI response on status, not 'result' key - W-23230588

### DIFF
--- a/packages/salesforcedx-vscode-org/src/commands/orgOpen.ts
+++ b/packages/salesforcedx-vscode-org/src/commands/orgOpen.ts
@@ -25,6 +25,7 @@ export class OrgOpenParseError extends Schema.TaggedError<OrgOpenParseError>()('
 
 const OrgOpenSuccess = Schema.Struct({
   _tag: Schema.Literal('OrgOpenSuccess'),
+  status: Schema.Literal(0),
   result: Schema.Struct({
     orgId: Schema.String,
     url: Schema.String,
@@ -32,10 +33,10 @@ const OrgOpenSuccess = Schema.Struct({
   })
 });
 
-/** sf prints `{ status: 1, message }` on failure; preserve the old channel-message behavior. */
+/** sf prints `{ status: <non-zero>, message }` on failure; preserve the old channel-message behavior. */
 const OrgOpenFailure = Schema.Struct({
   _tag: Schema.Literal('OrgOpenFailure'),
-  status: Schema.Literal(1),
+  status: Schema.Number,
   message: Schema.String
 });
 
@@ -45,10 +46,11 @@ type OrgOpenSuccess = Schema.Schema.Type<typeof OrgOpenSuccess>;
 type OrgOpenFailure = Schema.Schema.Type<typeof OrgOpenFailure>;
 
 /**
- * Decodes the sf CLI JSON from stdout. The CLI emits `{ result }` (success) or `{ status, message }`
- * (failure) — neither carries a `_tag`. `RawObject` parses stdout to a plain object so the `'result' in raw`
- * test can inject the discriminant before the tagged-union decode; all downstream dispatch is on `_tag` via
- * Match. Malformed/unexpected shape maps to a tagged error rather than escaping as a defect.
+ * Decodes the sf CLI JSON from stdout. The CLI emits `{ status: 0, result }` (success) or
+ * `{ status: <non-zero>, message }` (failure) — neither carries a `_tag`. `RawObject` parses stdout to a
+ * plain object so the authoritative `status` field can inject the discriminant before the tagged-union decode;
+ * all downstream dispatch is on `_tag` via Match. Malformed/unexpected shape maps to a tagged error rather
+ * than escaping as a defect.
  */
 const RawObject = Schema.parseJson(Schema.Record({ key: Schema.String, value: Schema.Unknown }));
 /**
@@ -59,7 +61,7 @@ const RawObject = Schema.parseJson(Schema.Record({ key: Schema.String, value: Sc
 const sanitizeJson = (stdout: string) => stdout.substring(stdout.indexOf('{'), stdout.lastIndexOf('}') + 1);
 const decodeOrgOpenResponse = (stdout: string) =>
   Schema.decodeUnknown(RawObject)(sanitizeJson(stdout)).pipe(
-    Effect.map(raw => ({ ...raw, _tag: 'result' in raw ? 'OrgOpenSuccess' : 'OrgOpenFailure' })),
+    Effect.map(raw => ({ ...raw, _tag: raw.status === 0 ? 'OrgOpenSuccess' : 'OrgOpenFailure' })),
     Effect.flatMap(tagged => Schema.decodeUnknown(OrgOpenResponse)(tagged)),
     Effect.mapError(error => new OrgOpenParseError({ message: `Failed to parse org open response: ${error.message}` }))
   );
@@ -107,7 +109,7 @@ export const orgOpenCommand = Effect.fn('orgOpenCommand')(function* () {
     yield* channel.showChannel;
   });
 
-  // failure branch: sf prints `{ status: 1, message }` — surface the message to the channel
+  // failure branch: sf prints `{ status: <non-zero>, message }` — surface the message to the channel
   const handleOrgOpenFailure = Effect.fn('orgOpenCommand.handleFailure')(function* ({ message }: OrgOpenFailure) {
     yield* channel.appendToChannel(message);
     yield* channel.showChannel;

--- a/packages/salesforcedx-vscode-org/src/commands/orgOpen.ts
+++ b/packages/salesforcedx-vscode-org/src/commands/orgOpen.ts
@@ -33,7 +33,7 @@ const OrgOpenSuccess = Schema.Struct({
   })
 });
 
-/** sf prints `{ status: <non-zero>, message }` on failure; preserve the old channel-message behavior. */
+/** sf failure shape: `{ status: <non-zero>, message }`. */
 const OrgOpenFailure = Schema.Struct({
   _tag: Schema.Literal('OrgOpenFailure'),
   status: Schema.Number,
@@ -46,11 +46,8 @@ type OrgOpenSuccess = Schema.Schema.Type<typeof OrgOpenSuccess>;
 type OrgOpenFailure = Schema.Schema.Type<typeof OrgOpenFailure>;
 
 /**
- * Decodes the sf CLI JSON from stdout. The CLI emits `{ status: 0, result }` (success) or
- * `{ status: <non-zero>, message }` (failure) — neither carries a `_tag`. `RawObject` parses stdout to a
- * plain object so the authoritative `status` field can inject the discriminant before the tagged-union decode;
- * all downstream dispatch is on `_tag` via Match. Malformed/unexpected shape maps to a tagged error rather
- * than escaping as a defect.
+ * Decode sf CLI JSON. Inject `_tag` from `status` (0 = success) before the union decode, since the
+ * raw shapes carry no discriminant. Malformed shape → tagged error, not a defect.
  */
 const RawObject = Schema.parseJson(Schema.Record({ key: Schema.String, value: Schema.Unknown }));
 /**
@@ -109,7 +106,6 @@ export const orgOpenCommand = Effect.fn('orgOpenCommand')(function* () {
     yield* channel.showChannel;
   });
 
-  // failure branch: sf prints `{ status: <non-zero>, message }` — surface the message to the channel
   const handleOrgOpenFailure = Effect.fn('orgOpenCommand.handleFailure')(function* ({ message }: OrgOpenFailure) {
     yield* channel.appendToChannel(message);
     yield* channel.showChannel;

--- a/packages/salesforcedx-vscode-org/test/jest/commands/orgOpen.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/commands/orgOpen.test.ts
@@ -158,6 +158,26 @@ describe('orgOpenCommand', () => {
     expect(show).toHaveBeenCalledTimes(1);
   });
 
+  it('surfaces the message for a non-1 failure status (e.g. NoDefaultEnvError status 68)', async () => {
+    // discrimination is on `status === 0`, not `status === 1`; any non-zero status takes the failure branch
+    // and surfaces the CLI message (parity with the old parser, which returned `.message` for any non-zero status).
+    const failureStdout = JSON.stringify({ status: 68, message: 'No default environment found' });
+    const simpleExec = jest.fn(() => Effect.succeed(failureStdout));
+    const appendToChannel = jest.fn();
+    const exit = await run({
+      isProject: true,
+      orgInfo: { username: 'me@scratch.org' },
+      simpleExec,
+      appendToChannel,
+      show
+    });
+
+    expect(Exit.isSuccess(exit)).toBe(true);
+    expect(appendToChannel).toHaveBeenCalledWith('No default environment found');
+    expect(openExternal).not.toHaveBeenCalled();
+    expect(show).toHaveBeenCalledTimes(1);
+  });
+
   it('opens the url when stdout is prefixed with a CLI warning (expiration notice)', async () => {
     // sf can prepend non-JSON warning lines to stdout even with --json + SF_JSON_TO_STDOUT (seen on macOS CI);
     // the parse adapter must slice out the JSON object rather than choke on the prefix.


### PR DESCRIPTION
## What

`sf.org.open`'s response decoder (added in W-23069601 / #7595) discriminated success vs failure on `'result' in raw` and typed failure `status` as `Schema.Literal(1)`. Non-1 error statuses (e.g. `NoDefaultEnvError` = 68) match **neither** union member, so the user sees an opaque `OrgOpenParseError` instead of the CLI's own error message.

## Fix

- Discriminate on `status === 0` (success) vs non-zero (failure)
- Failure `status` is now `Schema.Number` (was `Literal(1)`); success carries `status: Literal(0)`
- Adds a non-1-status decode test

## Origin

Found during review of W-23203227 (#7611). #7595 is already merged, so this is extracted to its own PR off `develop` to ship independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)