### PR TITLE
docs(skills): add i18n-messages skill - placeholder semantics + style guide - W-23234337

### DIFF
--- a/.claude/plans/W-23234337.md
+++ b/.claude/plans/W-23234337.md
@@ -4,7 +4,7 @@
 
 - New skill `.claude/skills/i18n-messages/SKILL.md`: editing extension i18n message files (`packages/*/src/messages/i18n.ts`) + their consumers.
 - Scope: messages file + code consuming those messages. NOT `package.json`/`package.nls.json` nls, NOT unrelated code.
-- Origin: PR 7621 review flagged `Removed %n orgs: %s` — `%n` not substituted. Already fixed on branch (`i18n.ts:46` = `Removed %d orgs: %s`); skill encodes the rule so it doesn't recur.
+- Origin: PR 7621 review flagged `Removed %n orgs: %s` — `%n` not substituted. fixed: `i18n.ts:46` now `%d`; skill prevents recurrence.
 
 ### Substitution mechanism (cited)
 
@@ -19,11 +19,11 @@
 | Surface | Source | Cap | Punct |
 |---|---|---|---|
 | Command title | `package.nls.json` `*_text` e.g. `SFDX: Create a Default Scratch Org...` | Title Case, `SFDX:` prefix | no period (`...` for further-input ok) |
-| QuickPick/InputBox placeholder | `i18n.ts:71,77` `Select orgs to log out from` | sentence | none |
-| Confirm prompt | `i18n.ts:72` `Permanently delete %d org(s)? This cannot be undone.` | sentence | terminal `.`/`?` |
+| QuickPick/InputBox placeholder | `i18n.ts:72,78` `Select orgs to log out from` | sentence | none |
+| Confirm prompt | `i18n.ts:73` `Permanently delete %d org(s)? This cannot be undone.` | sentence | terminal `.`/`?` |
 | Notification (show*Message) | `i18n.ts:100` `Warning: One or more...days.` | sentence | terminal `.` |
-| Button/action label | `i18n.ts:73,74` `Delete`, `Logout` | Title Case | none |
-| Tree/status-bar label+tooltip | `i18n.ts:103,104` `Open Default Org in Browser` | Title Case | none |
+| Button/action label | `i18n.ts:74,75` `Delete`, `Logout` | Title Case | none |
+| Tree/status-bar label+tooltip | `i18n.ts:103` `Open Default Org in Browser` | Title Case | none |
 | Log/channel line | sentence | sentence | `.` |
 | Validation error | sentence, no `Error:` prefix | sentence | terminal `.` |
 
@@ -58,7 +58,7 @@
 ## Verification
 
 - Manual: `node -e` confirm token behavior (done; cite in skill).
-- Manual: `grep -n` re-verify EVERY `i18n.ts`/`message.ts` file:line in skill before commit (`grep -n org_delete_select_orgs_placeholder packages/salesforcedx-vscode-org/src/messages/i18n.ts` etc). Confirmed at plan time: placeholder 71/77, confirm prompt 72, Delete 73, Logout 74, notification 100, tree/status-bar 103/104, `message.ts` 39/50. No `Remove` button exists; line 48 is command title.
+- Manual: `grep -n` re-verify EVERY `i18n.ts`/`message.ts` file:line in skill before commit (`grep -n org_delete_select_orgs_placeholder packages/salesforcedx-vscode-org/src/messages/i18n.ts` etc). Confirmed at plan time: placeholder 72/78, confirm prompt 73, Delete 74, Logout 75, notification 100, tree/status-bar 103, `message.ts` 39/50. No `Remove` button exists; line 48 is command title.
 - Manual: frontmatter parses — skill appears in available-skills after reload.
 - No e2e: docs-only, no runtime code changed; no e2e coverage applicable.
 - No lint/build impact (markdown only).

--- a/.claude/plans/W-23234337.md
+++ b/.claude/plans/W-23234337.md
@@ -1,0 +1,64 @@
+# W-23234337 — i18n-messages skill
+
+## Context
+
+- New skill `.claude/skills/i18n-messages/SKILL.md`: editing extension i18n message files (`packages/*/src/messages/i18n.ts`) + their consumers.
+- Scope: messages file + code consuming those messages. NOT `package.json`/`package.nls.json` nls, NOT unrelated code.
+- Origin: PR 7621 review flagged `Removed %n orgs: %s` — `%n` not substituted. Already fixed on branch (`i18n.ts:46` = `Removed %d orgs: %s`); skill encodes the rule so it doesn't recur.
+
+### Substitution mechanism (cited)
+
+- `nls.localize(key, ...args)` → `Localization.localize` → `Message.localize`.
+- `packages/salesforcedx-vscode-i18n/src/i18n/message.ts:50`: `format(possibleLabel, ...labelArgs)` from `node:util` (import L7) does substitution.
+- `message.ts:39`: arg-count check regex `/%[sdifj%]/g` (`%%` excluded L40). Mismatch logs + trims extra args (L41-48); does NOT add missing.
+- Supported tokens = `node:util.format`. Verified empirically (`node -e`): `%s` str, `%d` num, `%i` int (truncates float: 3.7→3), `%f` float, `%j` JSON, `%o`/`%O` object, `%c` CSS(ignored), `%%` literal `%`. `%n` → renders literal `%n` (NOT substituted).
+- Counts → `%d`. Strings → `%s`. Integer-only → `%i`. Regex only knows `%[sdifj]`+`%%`; `%o %O %c` substitute but escape arg-count validation — note as gotcha.
+
+### Per-surface style (empirical, from `salesforcedx-vscode-org`)
+
+| Surface | Source | Cap | Punct |
+|---|---|---|---|
+| Command title | `package.nls.json` `*_text` e.g. `SFDX: Create a Default Scratch Org...` | Title Case, `SFDX:` prefix | no period (`...` for further-input ok) |
+| QuickPick/InputBox placeholder | `i18n.ts:71,77` `Select orgs to log out from` | sentence | none |
+| Confirm prompt | `i18n.ts:72` `Permanently delete %d org(s)? This cannot be undone.` | sentence | terminal `.`/`?` |
+| Notification (show*Message) | `i18n.ts:100` `Warning: One or more...days.` | sentence | terminal `.` |
+| Button/action label | `i18n.ts:73,74` `Delete`, `Logout` | Title Case | none |
+| Tree/status-bar label+tooltip | `i18n.ts:103,104` `Open Default Org in Browser` | Title Case | none |
+| Log/channel line | sentence | sentence | `.` |
+| Validation error | sentence, no `Error:` prefix | sentence | terminal `.` |
+
+- Redundant `Error:`/`Warning:` prefixes: API supplies severity. `i18n.ts:100` has `Warning:` literal — note as anti-pattern; new strings omit. (Don't edit existing — out of scope.)
+
+### Reuse directive
+
+- Don't add msg already in `package.nls.json` (`grep` it first). Reuse.
+
+## Phases
+
+### Phase 1 — author skill (one commit)
+
+- Create `.claude/skills/i18n-messages/SKILL.md`.
+- Frontmatter: `name: i18n-messages`; `description` w/ trigger (editing `i18n.ts` / adding `nls.localize` strings).
+- Sections:
+  - Placeholder semantics: token table (`%s %d %i %f %j %o %O %c %%`, `%n` unsupported), cite `message.ts:39,50`, arg-count gotcha (`%o/%O/%c` skip validation), "count→%d, string→%s".
+  - Reuse directive: check `package.nls.json` before adding.
+  - Per-surface style table (above).
+  - No redundant `Error:`/`Warning:` prefix (cite `vscode-window-messages` skill).
+  - Scope guard: messages + consumers only.
+  - Cross-ref `vscode-window-messages` skill (overlap on notifications/buttons); don't duplicate API guidance.
+- Follow `writing-great-skills` + `concise` style; mirror existing skill frontmatter (`paths`/`vscode-window-messages`).
+- Commit: `docs(skills): add i18n-messages skill - placeholder semantics + style guide - W-23234337`
+
+## Skills to apply
+
+- concise — skill prose
+- vscode-window-messages — cross-ref, avoid dup
+- typescript — verify any code snippets compile-valid
+
+## Verification
+
+- Manual: `node -e` confirm token behavior (done; cite in skill).
+- Manual: `grep -n` re-verify EVERY `i18n.ts`/`message.ts` file:line in skill before commit (`grep -n org_delete_select_orgs_placeholder packages/salesforcedx-vscode-org/src/messages/i18n.ts` etc). Confirmed at plan time: placeholder 71/77, confirm prompt 72, Delete 73, Logout 74, notification 100, tree/status-bar 103/104, `message.ts` 39/50. No `Remove` button exists; line 48 is command title.
+- Manual: frontmatter parses — skill appears in available-skills after reload.
+- No e2e: docs-only, no runtime code changed; no e2e coverage applicable.
+- No lint/build impact (markdown only).

--- a/.claude/skills/i18n-messages/SKILL.md
+++ b/.claude/skills/i18n-messages/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: i18n-messages
+description: Editing extension i18n message files and their consumers. Use when editing packages/*/src/messages/i18n.ts, adding/changing nls.localize strings, or choosing placeholder tokens (%s/%d/...).
+---
+
+# i18n Messages
+
+Scope: `packages/*/src/messages/i18n.ts` + code consuming those messages via `nls.localize`. NOT `package.json`/`package.nls.json` nls strings (command titles etc.), NOT unrelated code.
+
+## Placeholder semantics
+
+`nls.localize(key, ...args)` substitutes via `node:util.format` — `packages/salesforcedx-vscode-i18n/src/i18n/message.ts:50` (`return format(possibleLabel, ...labelArgs)`).
+
+| Token | Use | Behavior (`node:util.format`) |
+|---|---|---|
+| `%s` | string | string |
+| `%d` | count/number | number as-is (`3.7`→`3.7`, no truncation) |
+| `%i` | integer | truncates float (`3.7`→`3`) |
+| `%f` | float | float |
+| `%j` | value | JSON |
+| `%o` `%O` | value | inspected object |
+| `%c` | — | CSS directive, no output |
+| `%%` | literal `%` | `%` only when args present; bare string keeps `%%` |
+| `%n` | NONE | unsupported — renders literal `%n`, NOT substituted |
+
+Default: counts → `%d`, strings → `%s`. (Origin: `Removed %n orgs` shipped literal `%n`.)
+
+### Arg-count gotcha
+
+`message.ts:39` counts specifiers with `/%[sdifj%]/g` (`%%` excluded, L40). On mismatch it logs and trims extra args (L41-48); missing args are NOT filled — trailing unmatched tokens render literally.
+
+- `%o` `%O` `%c` substitute at runtime but are NOT in that regex → they escape arg-count validation. Avoid relying on them; prefer `%s`/`%d`/`%j`.
+- `%n` is not counted and not a real token → expected-count is off by what you intended and the `%n` prints literally.
+
+## Reuse first
+
+Before adding a string, `grep` `package.nls.json` for an existing equivalent and reuse it. Don't duplicate.
+
+## Per-surface style
+
+Empirical, from `salesforcedx-vscode-org` (`src/messages/i18n.ts`, `package.nls.json`):
+
+| Surface | Example | Cap | Punctuation |
+|---|---|---|---|
+| Command title (`package.nls.json` `*_text`) | `SFDX: Create a Default Scratch Org...` | Title Case, `SFDX:` prefix | none (`...` ok for further input) |
+| QuickPick/InputBox placeholder | `i18n.ts:72` `Select scratch orgs and sandboxes to delete` | sentence | none |
+| Confirm prompt | `i18n.ts:73` `Permanently delete %d org(s)? This cannot be undone.` | sentence | terminal `.`/`?` |
+| Notification (`show*Message`) | `i18n.ts:100` `... orgs expire in the next %d days. ...` | sentence | terminal `.` |
+| Button/action label | `i18n.ts:74,75` `Delete`, `Logout` | Title Case | none |
+| Tree/status-bar label+tooltip | `i18n.ts:103` `Open Default Org in Browser` | Title Case | none |
+| Log/channel line | — | sentence | `.` |
+| Validation error | — | sentence | terminal `.` |
+
+## No severity prefix
+
+Don't prefix new strings with `Error:`/`Warning:` — the `show*Message` API supplies severity. `i18n.ts:100` (`Warning: One or more...`) is a legacy anti-pattern; don't copy it, and don't edit it (out of scope). See `vscode-window-messages`.
+
+## Cross-ref
+
+`vscode-window-messages` covers the notification/button API (which `show*Message`, return values, Effect, modal). This skill is the message *text*. Don't duplicate API guidance here.

--- a/.claude/skills/i18n-messages/SKILL.md
+++ b/.claude/skills/i18n-messages/SKILL.md
@@ -5,7 +5,10 @@ description: Editing extension i18n message files and their consumers. Use when 
 
 # i18n Messages
 
-Scope: `packages/*/src/messages/i18n.ts` + code consuming those messages via `nls.localize`. NOT `package.json`/`package.nls.json` nls strings (command titles etc.), NOT unrelated code.
+Scope:
+- `packages/*/src/messages/i18n.ts` + code consuming those messages via `nls.localize`
+- NOT `package.json`/`package.nls.json` nls strings (command titles etc.)
+- NOT unrelated code
 
 ## Placeholder semantics
 
@@ -20,7 +23,7 @@ Scope: `packages/*/src/messages/i18n.ts` + code consuming those messages via `nl
 | `%j` | value | JSON |
 | `%o` `%O` | value | inspected object |
 | `%c` | — | CSS directive, no output |
-| `%%` | literal `%` | `%` only when args present; bare string keeps `%%` |
+| `%%` | literal `%` | `%` only when args present; bare string skips `format()` (`message.ts:37` `args.length > 0` guard) and keeps `%%` |
 | `%n` | NONE | unsupported — renders literal `%n`, NOT substituted |
 
 Default: counts → `%d`, strings → `%s`. (Origin: `Removed %n orgs` shipped literal `%n`.)
@@ -34,11 +37,11 @@ Default: counts → `%d`, strings → `%s`. (Origin: `Removed %n orgs` shipped l
 
 ## Reuse first
 
-Before adding a string, `grep` `package.nls.json` for an existing equivalent and reuse it. Don't duplicate.
+`grep` `package.nls.json` for an existing equivalent before adding — reuse, don't duplicate.
 
 ## Per-surface style
 
-Empirical, from `salesforcedx-vscode-org` (`src/messages/i18n.ts`, `package.nls.json`):
+From `salesforcedx-vscode-org` (`src/messages/i18n.ts`, `package.nls.json`):
 
 | Surface | Example | Cap | Punctuation |
 |---|---|---|---|


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/i18n-messages/SKILL.md`: a new Claude Code skill covering i18n message file editing in `packages/*/src/messages/i18n.ts`
- Documents placeholder token semantics (`%s %d %i %f %j %o %O %c %%`; `%n` unsupported), arg-count validation behavior, and per-surface capitalization/punctuation rules
- Includes reuse directive (grep `package.nls.json` before adding), scope guard, and cross-ref to `vscode-window-messages` skill

## Plan

[`.claude/plans/W-23234337.md`](.claude/plans/W-23234337.md)

## Reviewer notes

- Low: plan file is committed as a permanent repo artifact restating SKILL.md content; whether plans belong in the ship branch is a workflow/design decision left to the author.

## What issues does this PR fix or reference?

@W-23234337@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002dSdLaYAK/view