### PR TITLE
docs(skills): improve packageJson and paths skill descriptions - W-23241236

### DIFF
--- a/.claude/plans/W-23241236.md
+++ b/.claude/plans/W-23241236.md
@@ -1,0 +1,72 @@
+# W-23241236 — Skill review: improve packageJson + paths skills
+
+## Context
+
+- Review `/packageJson` + `/paths` skills against mattpocock writing-great-skills ([source](https://github.com/mattpocock/skills/tree/main/skills/productivity/writing-great-skills) — criteria inlined below; do not depend on URL at build time)
+- Both model-invoked (no `disable-model-invocation`) → description = trigger branches; body pays context load every turn
+- Both small (packageJson 60 lines, paths 19) → no file-split/progressive-disclosure needed; fix description, leading words, no-ops, co-location, duplication
+- Precedent: recent `docs(<skill>): progressive-disclosure refactor` commits (gus-cli W-23238332, pr-draft W-23238395) — match prefix + one-commit-per-skill
+
+### Evaluation criteria (authoritative, inlined — build step checks against THIS, not the URL)
+
+C1. Leading word — description front-loads the trigger noun/verb (first word carries selection weight).
+C2. Trigger branches — description enumerates the concrete situations that should fire the skill (file/import/symbol names), not a vague topic.
+C3. No-ops — every body line earns its context cost; cut lines that restate model default behavior or repo-agnostic advice.
+C4. Co-location — related guidance lives in one skill; cross-topic detail is a pointer to the owning skill, not duplicated.
+C5. Duplication — single source of truth; no rule repeated across skills or within the body.
+
+### Criteria → skill mapping
+
+packageJson `.claude/skills/packageJson/SKILL.md`:
+- C1 leading word: FAIL — description starts "Guidelines for…"; front-load to lead with package.json. FIX in Phase 1.
+- C2 trigger branches: FAIL — "package.json files in packages" is a topic, no branches. Add: editing/reviewing package.json (name, types, browser, files, dependencies, devDependencies, scripts, contributes). FIX in Phase 1.
+- C3 no-ops: PASS (material) — rules are repo-specific; keep. Still no-op-test each line in Phase 1 and cut any that slip through.
+- C4 co-location: PASS — `scripts` → wireit pointer is correct; keep.
+- C5 duplication: PASS — no cross-skill repeat found; reconfirm via grep in Phase 1.
+- minor: inconsistent fragments vs sentences → concise style pass.
+
+paths `.claude/skills/paths/SKILL.md`:
+- ALWAYS-APPLICABLE — `paths` is hardcoded in `review-diff.js` `ALWAYS_APPLICABLE_SKILLS` (line 29) and documented in `workflows/README.md:270`. It is injected unconditionally on every review, never auto-selected by description match. Description edits are therefore cosmetic for selection — they CANNOT break (or improve) auto-selection. See Phase 2 risk note.
+- C1 leading word: PASS — "Prefer vscode-uri over node:path" front-loads the verb. Keep.
+- C2 trigger branches: PASS — has node:path, path.join/basename/dirname/resolve. Cosmetic only (always-applicable). Optionally add memfs/URI.file if it sharpens human-facing intent.
+- C3 no-ops: PASS — body tight; no-op-test each line in Phase 2 anyway.
+- C4 co-location: PASS — services-extension-consumption pointer correct; verify it resolves.
+- C5 duplication: PASS.
+- minor: tighten wording.
+
+## Phases
+
+### Phase 1 — packageJson: description triggers + prune
+- rewrite description: front-load leading word, list trigger branches (editing/reviewing package.json: name, types, browser, files, dependencies, devDependencies, scripts, contributes)
+- no-op test each line; cut/collapse any default-behavior or duplicated lines
+- enforce concise style (fragments, numerals, drop filler)
+- keep eslint-rules section co-located; keep wireit pointer
+- preserve any anchors other skills link to (grep first)
+- files: `.claude/skills/packageJson/SKILL.md`
+- commit: `docs(packageJson): trigger-rich description + prune - W-23241236`
+
+### Phase 2 — paths: tighten + verify
+- RISK / always-applicable: `paths` is hardcoded in `review-diff.js` `ALWAYS_APPLICABLE_SKILLS` (line 29) + `workflows/README.md:270`. It is always injected, never auto-selected by description. So description changes here are cosmetic for selection and cannot break the < 20-line small-diff path. Constraint: do NOT remove the hardcode, and keep the description trigger-rich so a future maintainer who removes the hardcode still gets correct auto-selection.
+- add a one-line note in SKILL.md (or frontmatter comment) recording the always-applicable status, so a future editor knows the description is load-bearing only if the hardcode is removed
+- call out the always-applicable status in the commit message
+- no-op test each line; tighten wording
+- confirm description trigger branches sufficient (optionally add memfs/URI.file — cosmetic, sharpens human intent only)
+- verify pointers (`services-extension-consumption`) resolve
+- concise style pass
+- files: `.claude/skills/paths/SKILL.md`
+- commit: `docs(paths): prune + verify pointers (note: always-applicable, hardcoded in review-diff) - W-23241236`
+
+## Skills to apply
+
+- concise — style for all SKILL.md edits
+- packageJson, paths — the subjects under review
+- typescript — TS coding standards referenced by packageJson/paths skills
+
+## Verification
+
+- not e2e-covered (docs-only; no e2e on branch)
+- `grep -rn "packageJson/SKILL\|paths/SKILL\|#anchor" .claude/` → confirm no inbound links/anchors broken
+- pointer targets exist: `.claude/skills/wireit/SKILL.md`, `.claude/skills/services-extension-consumption/SKILL.md`
+- frontmatter valid: `name` + `description` present, YAML parses
+- manual read-through vs inlined criteria C1–C5 (above, not the URL): each skill passes its mapped row
+- `paths` hardcode intact: `grep -n "ALWAYS_APPLICABLE_SKILLS" .claude/workflows/review-diff.js` still lists `'paths'`; README:270 unchanged

--- a/.claude/plans/W-23241236.md
+++ b/.claude/plans/W-23241236.md
@@ -28,8 +28,8 @@ packageJson `.claude/skills/packageJson/SKILL.md`:
 paths `.claude/skills/paths/SKILL.md`:
 - ALWAYS-APPLICABLE — `paths` is hardcoded in `review-diff.js` `ALWAYS_APPLICABLE_SKILLS` (line 29) and documented in `workflows/README.md:270`. It is injected unconditionally on every review, never auto-selected by description match. Description edits are therefore cosmetic for selection — they CANNOT break (or improve) auto-selection. See Phase 2 risk note.
 - C1 leading word: PASS — "Prefer vscode-uri over node:path" front-loads the verb. Keep.
-- C2 trigger branches: PASS — has node:path, path.join/basename/dirname/resolve. Cosmetic only (always-applicable). Optionally add memfs/URI.file if it sharpens human-facing intent.
-- C3 no-ops: PASS — body tight; no-op-test each line in Phase 2 anyway.
+- C2 trigger branches: PASS — has node:path, path.join/basename/dirname/resolve. Cosmetic only (always-applicable). Add memfs/URI.file to sharpen human intent (cosmetic only).
+- C3 no-ops: PASS — body tight; no-op-test each line in Phase 2.
 - C4 co-location: PASS — services-extension-consumption pointer correct; verify it resolves.
 - C5 duplication: PASS.
 - minor: tighten wording.
@@ -46,11 +46,11 @@ paths `.claude/skills/paths/SKILL.md`:
 - commit: `docs(packageJson): trigger-rich description + prune - W-23241236`
 
 ### Phase 2 — paths: tighten + verify
-- RISK / always-applicable: `paths` is hardcoded in `review-diff.js` `ALWAYS_APPLICABLE_SKILLS` (line 29) + `workflows/README.md:270`. It is always injected, never auto-selected by description. So description changes here are cosmetic for selection and cannot break the < 20-line small-diff path. Constraint: do NOT remove the hardcode, and keep the description trigger-rich so a future maintainer who removes the hardcode still gets correct auto-selection.
-- add a one-line note in SKILL.md (or frontmatter comment) recording the always-applicable status, so a future editor knows the description is load-bearing only if the hardcode is removed
+- RISK: see always-applicable note above. Constraint: do NOT remove the hardcode, and keep the description trigger-rich so a future maintainer who removes the hardcode still gets correct auto-selection.
+- add a one-line note recording the always-applicable status, so a future editor knows the description is load-bearing only if the hardcode is removed
 - call out the always-applicable status in the commit message
 - no-op test each line; tighten wording
-- confirm description trigger branches sufficient (optionally add memfs/URI.file — cosmetic, sharpens human intent only)
+- confirm description trigger branches sufficient (add memfs/URI.file — cosmetic, sharpens human intent only)
 - verify pointers (`services-extension-consumption`) resolve
 - concise style pass
 - files: `.claude/skills/paths/SKILL.md`
@@ -64,7 +64,7 @@ paths `.claude/skills/paths/SKILL.md`:
 
 ## Verification
 
-- not e2e-covered (docs-only; no e2e on branch)
+- not e2e-covered (docs-only; no e2e on branch). stop-hook checks (compile/lint/knip) not applicable — docs-only.
 - `grep -rn "packageJson/SKILL\|paths/SKILL\|#anchor" .claude/` → confirm no inbound links/anchors broken
 - pointer targets exist: `.claude/skills/wireit/SKILL.md`, `.claude/skills/services-extension-consumption/SKILL.md`
 - frontmatter valid: `name` + `description` present, YAML parses

--- a/.claude/skills/packageJson/SKILL.md
+++ b/.claude/skills/packageJson/SKILL.md
@@ -1,27 +1,26 @@
 ---
 name: packageJson
-description: Guidelines for package.json files in packages
+description: package.json conventions for this repo. Use when editing/reviewing a package.json — name, types, browser, files, dependencies, devDependencies, packaging, scripts, or vscode contributes.
 ---
 
-## Name
+## name
 
-any package that's not an npm package should be named @salesforce/foo (whether it actually published to npm or not)
-any package that publishes a vscode extension should be named salesforcedx-vscode-foo
-don't rename packages, but do tell the user when stuff doesn't match the rules
+- non-npm package → `@salesforce/foo` (whether published or not)
+- vscode-extension package → `salesforcedx-vscode-foo`
+- don't rename; flag mismatches to the user
 
 ## types
 
-on an extension, you only need a `types` prop if your extension will be an extensionDependency of some other extension.
-
-probably not necessary for non-extension packages.
+- extension: needed only if it's an extensionDependency of another extension
+- non-extension package: not needed
 
 ## browser
 
-only for web-enabled extensions. Must point to a bundled dist file
+- web-enabled extensions only; must point to a bundled dist file
 
-## npm packages
+## files
 
-packages that publish to npm should have a `files` property in the package.json
+- packages that publish to npm need a `files` prop
 
 ## scripts
 
@@ -29,24 +28,24 @@ See [wireit skill](.claude/skills/wireit/SKILL.md)
 
 ## dependencies
 
-use `*` as the version for anything that's another package in this repo
-there should be no dependency on salesforcedx-vscode-services. extensionDependency is ok, devDependency is ok.
+- another package in this repo → version `*`
+- no dependency on salesforcedx-vscode-services (extensionDependency / devDependency ok)
 
 ## devDependencies
 
-packages should not duplicate devDependencies that exist at the top level of the repo.
+- don't duplicate devDependencies already at repo top level
 
 ## packaging
 
-The `packaging` property is legacy vsce packaging script (modifying pjson during package time). Avoid creating it, we eventually want them all gone.
+- legacy vsce script (mutates pjson at package time); don't create new ones, want them gone
 
 ## vscode "contributes"
 
-### Tips
+### tips
 
-- anything in `commands` will appear in command palette. If you don't want that, you have to `never` or use some `when` under commandPalette
-- commands need a unique ID, 2 extensions contributing the same config will produce a UI warning
-- never create a "default:true" boolean configuration (it's hard to override user/workspace)
+- `commands` show in command palette by default; suppress via `never`/`when` under `commandPalette`
+- commands need a unique ID; 2 extensions with the same config → UI warning
+- never a `default:true` boolean config (hard to override user/workspace)
 
 ### ESLint rules
 

--- a/.claude/skills/packageJson/SKILL.md
+++ b/.claude/skills/packageJson/SKILL.md
@@ -24,7 +24,7 @@ description: package.json conventions for this repo. Use when editing/reviewing 
 
 ## scripts
 
-See [wireit skill](.claude/skills/wireit/SKILL.md)
+See [wireit skill](../wireit/SKILL.md)
 
 ## dependencies
 

--- a/.claude/skills/paths/SKILL.md
+++ b/.claude/skills/paths/SKILL.md
@@ -1,18 +1,20 @@
 ---
 name: paths
-description: Prefer vscode-uri over node:path. Use when .ts files in /src import from node:path or use path.join, path.basename, path.dirname, path.resolve.
+description: Prefer vscode-uri over node:path. Use when .ts files in /src import node:path or use path.join/basename/dirname/resolve, URI.file, or memfs paths.
 ---
+
+<!-- always-applicable: hardcoded in .claude/workflows/review-diff.js ALWAYS_APPLICABLE_SKILLS; injected on every review regardless of description match. Description triggers are load-bearing only if that hardcode is removed. -->
 
 # Paths
 
 Scope: .ts files in /src
 
-- Prefer vscode-uri URIs over paths (file, memfs; cross-platform; FsService/workspace.fs accept URIs)
-- Use `Utils` from vscode-uri instead of node:path:
+- prefer vscode-uri URIs over paths (file, memfs; cross-platform; FsService/workspace.fs accept URIs)
+- `Utils` from vscode-uri instead of node:path:
   - `Utils.joinPath(baseUri, 'a', 'b')` — path.join
   - `Utils.basename(uri)`, `Utils.dirname(uri)`, `Utils.extname(uri)` — path.\*
   - `Utils.resolvePath(baseUri, 'rel')` — path.resolve
 - URI↔path via FsService: `toUri(filePath)` / `uriToPath(uri)` (Effect; extensions with salesforcedx-vscode-services)
-- Raw path→URI: `URI.file(path)` or `toUri` for memfs in web
+- raw path→URI: `URI.file(path)`, or `toUri` for memfs in web
 - FsService setup: [services-extension-consumption](../services-extension-consumption/SKILL.md)
-- Exit hatch: build scripts, esbuild configs, tests, desktop-only extension, host-FS-only tooling → node:path ok
+- exit hatch: build scripts, esbuild configs, tests, desktop-only extension, host-FS-only tooling → node:path ok

--- a/.claude/skills/paths/SKILL.md
+++ b/.claude/skills/paths/SKILL.md
@@ -3,8 +3,6 @@ name: paths
 description: Prefer vscode-uri over node:path. Use when .ts files in /src import node:path or use path.join/basename/dirname/resolve, URI.file, or memfs paths.
 ---
 
-<!-- always-applicable: hardcoded in .claude/workflows/review-diff.js ALWAYS_APPLICABLE_SKILLS; injected on every review regardless of description match. Description triggers are load-bearing only if that hardcode is removed. -->
-
 # Paths
 
 Scope: .ts files in /src

--- a/.claude/workflows/review-diff.js
+++ b/.claude/workflows/review-diff.js
@@ -26,6 +26,7 @@ const label = (typeof _a === 'object' && _a.label) || wt.split('/').pop() || 'di
 // =====================================================================
 
 const SMALL_DIFF_LINES = 20
+// these skills inject on every review regardless of description match; their description triggers are load-bearing only if removed from this list
 const ALWAYS_APPLICABLE_SKILLS = ['typescript', 'concise', 'paths']
 const SKILLS_DIR = '.claude/skills'
 // Skills not relevant to code review of a diff — operational workflows or environmental setup.


### PR DESCRIPTION
## Summary

- Rewrites `packageJson` skill description to front-load trigger noun and enumerate concrete trigger branches (C1/C2 fix)
- Prunes `packageJson` body for no-op lines; enforces concise style throughout
- Tightens `paths` skill wording; adds always-applicable status note; verifies pointers resolve

## Plan

[.claude/plans/W-23241236.md](.claude/plans/W-23241236.md)

## Reviewer notes

No outstanding findings.

### What issues does this PR fix or reference?

@W-23241236@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.my.salesforce.com/a07EE00002dTzeCYAS