### PR TITLE
docs(skills): improve typescript and icons-src skills - W-23241237

### DIFF
--- a/.claude/plans/W-23241237.md
+++ b/.claude/plans/W-23241237.md
@@ -10,7 +10,7 @@
 
 - description weak: no trigger phrasing → unreliable model-invocation
 - "including file naming rules" → KEEP file-naming as an explicit trigger, do NOT drop it
-  - body line 16 (`.ts filenames: camelCase, no hyphens, no leading capitals`) gives the *rule content*, but the description is what the model matches for invocation. A request like "what should I name this .ts file?" / "rename to fix casing" needs the trigger to mention naming or invocation misses (body rules only load *after* invocation, so they cannot help select the skill). Body specificity ≠ invocation trigger.
+  - body rules load post-invocation → body specificity ≠ invocation trigger
   - decision: rewrite description to front-load authoring/review/refactor triggers AND retain a file-naming trigger phrase (reworded from "including file naming rules" to be a real trigger, not trailing sediment)
 - body = flat rule list → fine per guidance (flat reference acceptable)
 - DoD: description front-loads triggers (.ts/.tsx authoring, refactor, file naming); body rules unchanged unless duplication found
@@ -28,7 +28,7 @@
 ### Phase 1 — typescript skill description + sediment
 
 - rewrite frontmatter `description` w/ trigger phrasing: writing/reviewing/refactoring .ts/.tsx code AND naming/renaming .ts files (casing)
-- KEEP file-naming as a trigger (reworded to a real trigger phrase, not trailing "including … rules" sediment); do NOT drop it — model invocation for naming-only requests depends on it (body rules load only post-invocation)
+- KEEP file-naming trigger (reworded); model invocation for naming-only requests depends on description, not body
 - e.g. `description: TypeScript coding standards — apply when writing, reviewing, or refactoring .ts/.tsx, or naming/renaming .ts files (camelCase casing).`
 - no body rule changes (rules earn load as authoring guidance)
 - file: `.claude/skills/typescript/SKILL.md`
@@ -39,7 +39,7 @@
 - collapse duplicate icons.json format: keep dedicated "icons.json Format" section as single source; Workflow step 2 → pointer/short ref
 - add checkable completion criterion per Workflow step (e.g. "build:icons updates contributes.icons — verify diff")
 - fix verification path → `npm run test -w salesforcedx-vscode-services` runs `test/jest/vscode/iconConsistency.test.ts`
-  - VALIDATED: `test` script = wireit → `command: jest` (dep `test:compile`); jest base `testMatch: **/(unit|jest)/**/?(*.)+(spec|test).ts?(x)`; `npx jest --listTests` includes `.../test/jest/vscode/iconConsistency.test.ts`. Command genuinely executes the file (not just file-exists).
+  - VALIDATED: wireit→jest; listTests confirms iconConsistency.test.ts executes
 - trim Workflow↔Artifacts-table prose overlap; table stays canonical
 - file: `.claude/skills/icons-src/SKILL.md`
 - commit: `docs(skills): dedupe icons-src + add checkable step criteria - W-23241237`
@@ -55,5 +55,5 @@
 - not e2e-covered (docs/skill files only; no branch e2e)
 - `git diff` review both SKILL.md vs great-skills pruning checklist: single source of truth, no-op test, triggers present
 - confirm icons-src paths/commands still real: `media/icons-src/`, `build:icons` script, `ICONS`/`ICON_DESCRIPTION_KEYS` in `mediaService.ts` (all verified exist)
-- before committing Phase 2, RUN `npm run test -w salesforcedx-vscode-services` (or at minimum `npx jest --listTests | grep iconConsistency` in the package dir) and capture output proving the script executes `iconConsistency.test.ts` — existence ≠ execution. Already validated during planning (wireit→jest, listTests hit); re-confirm at implementation since skill text now points users at this exact command.
+- re-confirm at implementation: existence ≠ execution
 - markdown renders (links resolve: vscode-window-messages relative link in typescript skill)

--- a/.claude/plans/W-23241237.md
+++ b/.claude/plans/W-23241237.md
@@ -1,0 +1,59 @@
+# W-23241237 — Skill review: typescript + icons-src
+
+## Context
+
+- Review 2 skills vs [mattpocock writing-great-skills](https://github.com/mattpocock/skills/tree/main/skills/productivity/writing-great-skills)
+- Criteria: predictability; rich trigger descriptions for model-invoked; single source of truth (no duplication); checkable+exhaustive completion criteria; no-op test; collapse via ladder; leading words
+- Targets: `.claude/skills/typescript/SKILL.md`, `.claude/skills/icons-src/SKILL.md`
+
+### Findings — typescript
+
+- description weak: no trigger phrasing → unreliable model-invocation
+- "including file naming rules" → KEEP file-naming as an explicit trigger, do NOT drop it
+  - body line 16 (`.ts filenames: camelCase, no hyphens, no leading capitals`) gives the *rule content*, but the description is what the model matches for invocation. A request like "what should I name this .ts file?" / "rename to fix casing" needs the trigger to mention naming or invocation misses (body rules only load *after* invocation, so they cannot help select the skill). Body specificity ≠ invocation trigger.
+  - decision: rewrite description to front-load authoring/review/refactor triggers AND retain a file-naming trigger phrase (reworded from "including file naming rules" to be a real trigger, not trailing sediment)
+- body = flat rule list → fine per guidance (flat reference acceptable)
+- DoD: description front-loads triggers (.ts/.tsx authoring, refactor, file naming); body rules unchanged unless duplication found
+
+### Findings — icons-src
+
+- description: good triggers, keep
+- duplication: icons.json format documented 2x (Workflow step 2 + "icons.json Format" section) → collapse to single source
+- Workflow steps lack checkable completion criteria
+- verification test path imprecise: actual = `test/jest/vscode/iconConsistency.test.ts`
+- "Artifacts" table partially restates Workflow → keep table (canonical add/remove map), trim Workflow prose overlap
+
+## Phases
+
+### Phase 1 — typescript skill description + sediment
+
+- rewrite frontmatter `description` w/ trigger phrasing: writing/reviewing/refactoring .ts/.tsx code AND naming/renaming .ts files (casing)
+- KEEP file-naming as a trigger (reworded to a real trigger phrase, not trailing "including … rules" sediment); do NOT drop it — model invocation for naming-only requests depends on it (body rules load only post-invocation)
+- e.g. `description: TypeScript coding standards — apply when writing, reviewing, or refactoring .ts/.tsx, or naming/renaming .ts files (camelCase casing).`
+- no body rule changes (rules earn load as authoring guidance)
+- file: `.claude/skills/typescript/SKILL.md`
+- commit: `docs(skills): harden typescript skill description for invocation - W-23241237`
+
+### Phase 2 — icons-src dedup + precise criteria
+
+- collapse duplicate icons.json format: keep dedicated "icons.json Format" section as single source; Workflow step 2 → pointer/short ref
+- add checkable completion criterion per Workflow step (e.g. "build:icons updates contributes.icons — verify diff")
+- fix verification path → `npm run test -w salesforcedx-vscode-services` runs `test/jest/vscode/iconConsistency.test.ts`
+  - VALIDATED: `test` script = wireit → `command: jest` (dep `test:compile`); jest base `testMatch: **/(unit|jest)/**/?(*.)+(spec|test).ts?(x)`; `npx jest --listTests` includes `.../test/jest/vscode/iconConsistency.test.ts`. Command genuinely executes the file (not just file-exists).
+- trim Workflow↔Artifacts-table prose overlap; table stays canonical
+- file: `.claude/skills/icons-src/SKILL.md`
+- commit: `docs(skills): dedupe icons-src + add checkable step criteria - W-23241237`
+
+## Skills to apply
+
+- concise — all SKILL.md edits
+- typescript — governs .md files in `.claude/skills/`
+- (reference only) writing-great-skills criteria
+
+## Verification
+
+- not e2e-covered (docs/skill files only; no branch e2e)
+- `git diff` review both SKILL.md vs great-skills pruning checklist: single source of truth, no-op test, triggers present
+- confirm icons-src paths/commands still real: `media/icons-src/`, `build:icons` script, `ICONS`/`ICON_DESCRIPTION_KEYS` in `mediaService.ts` (all verified exist)
+- before committing Phase 2, RUN `npm run test -w salesforcedx-vscode-services` (or at minimum `npx jest --listTests | grep iconConsistency` in the package dir) and capture output proving the script executes `iconConsistency.test.ts` — existence ≠ execution. Already validated during planning (wireit→jest, listTests hit); re-confirm at implementation since skill text now points users at this exact command.
+- markdown renders (links resolve: vscode-window-messages relative link in typescript skill)

--- a/.claude/skills/icons-src/SKILL.md
+++ b/.claude/skills/icons-src/SKILL.md
@@ -38,7 +38,7 @@ External sources (Wikipedia, Illustrator, etc.) may be too complex for font gene
 
 1. **Add SVG** — `media/icons-src/<name>.svg` (name = lowercase, no spaces). Done: file matches [SVG Requirements](#svg-requirements)
 2. **Add manifest entry** — append to `media/icons-src/icons.json` per [icons.json Format](#iconsjson-format). Done: key + `id` + `description` present
-3. **Run build** — `npm run build:icons -w salesforcedx-vscode-services`. Done: `contributes.icons` in package.json + `resources/icons-font/*` updated — verify `git diff`
+3. **Run build** — `npm run build:icons -w salesforcedx-vscode-services`. Done: auto-generated artifacts updated — verify `git diff` (see [Artifacts](#artifacts-that-change-addremove))
 4. **Add ICONS constant** — `src/vscode/mediaService.ts`: `ICONS` + `ICON_DESCRIPTION_KEYS`; add i18n key in messages if needed. Done: new icon in both maps, compiles
 5. **Regenerate types** — if services-types consumes ICONS, run its generate script. Done: `icons.ts` includes new icon
 

--- a/.claude/skills/icons-src/SKILL.md
+++ b/.claude/skills/icons-src/SKILL.md
@@ -36,16 +36,11 @@ External sources (Wikipedia, Illustrator, etc.) may be too complex for font gene
 
 ## Workflow
 
-1. **Add SVG** — `media/icons-src/<name>.svg` (name = lowercase, no spaces)
-2. **Add manifest entry** — `media/icons-src/icons.json`:
-
-   ```json
-   "<name>": { "id": "sf-org-<id>", "description": "..." }
-   ```
-
-3. **Run build** — `npm run build:icons -w salesforcedx-vscode-services` (updates `contributes.icons` in package.json)
-4. **Add ICONS constant** — `src/vscode/mediaService.ts` and `ICON_DESCRIPTION_KEYS`; add i18n key in messages if needed
-5. **Regenerate types** — if services-types consumes ICONS, run its generate script
+1. **Add SVG** — `media/icons-src/<name>.svg` (name = lowercase, no spaces). Done: file matches [SVG Requirements](#svg-requirements)
+2. **Add manifest entry** — append to `media/icons-src/icons.json` per [icons.json Format](#iconsjson-format). Done: key + `id` + `description` present
+3. **Run build** — `npm run build:icons -w salesforcedx-vscode-services`. Done: `contributes.icons` in package.json + `resources/icons-font/*` updated — verify `git diff`
+4. **Add ICONS constant** — `src/vscode/mediaService.ts`: `ICONS` + `ICON_DESCRIPTION_KEYS`; add i18n key in messages if needed. Done: new icon in both maps, compiles
+5. **Regenerate types** — if services-types consumes ICONS, run its generate script. Done: `icons.ts` includes new icon
 
 ## icons.json Format
 

--- a/.claude/skills/typescript/SKILL.md
+++ b/.claude/skills/typescript/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: typescript
-description: TypeScript coding standards and conventions including file naming rules
+description: TypeScript coding standards — apply when writing, reviewing, or refactoring .ts/.tsx, or naming/renaming .ts files (camelCase casing).
 ---
 
 - no barrel files


### PR DESCRIPTION
## Summary

- Rewrote `typescript` skill description to front-load authoring/review/refactor/.ts file-naming triggers for reliable model invocation
- Collapsed duplicate `icons.json` format docs in `icons-src` to single source; added checkable completion criteria per workflow step; fixed test path to `test/jest/vscode/iconConsistency.test.ts`
- Applied concise/overlap review pass across both skills

## Plan

[.claude/plans/W-23241237.md](.claude/plans/W-23241237.md)

### What issues does this PR fix or reference?

@W-23241237@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002dUIoTYAW/view