### PR TITLE
ci: add workflow to close pending-release issues after marketplace publish - W-23236874

### DIFF
--- a/.claude/plans/W-23236874.md
+++ b/.claude/plans/W-23236874.md
@@ -1,0 +1,47 @@
+# W-23236874 — Add GH Actions workflow to close "pending release" issues after marketplace publish
+
+## Context
+
+- On successful marketplace publish (`publishVSCode.yml`), auto-close issues labeled `pending release` with a version comment.
+- Trigger workflow name (for `workflow_run`): exactly `Publish in Microsoft Marketplace`.
+- Version source: `package.json` on `main` — same path used by `publishVSCode.yml`.
+- **Deployment constraint**: The `workflow_run` trigger only fires when the workflow file exists on the repository's default branch. The default branch is `develop`. This means the new workflow file must be merged to `develop` before it takes effect. The first marketplace publish after merge is the first live trigger.
+- **Upstream compatibility**: `publishVSCode.yml` is triggered by `release` (type `released`) and `workflow_dispatch` — it is NOT a reusable workflow (no `workflow_call` trigger). `workflow_run` does fire for workflows triggered by `release` events, so this combination is valid.
+
+## Phases
+
+### Phase 1 — add closePendingReleaseIssues workflow
+
+New file: `.github/workflows/closePendingReleaseIssues.yml`
+
+- Trigger: `workflow_run` on `Publish in Microsoft Marketplace`, type `completed`
+- Guard: `if: github.event.workflow_run.conclusion == 'success'`
+- Steps:
+  1. Checkout `main` (need `package.json` for version)
+  2. Extract version from `packages/salesforcedx-vscode/package.json`
+  3. Use `gh issue list` with `--limit 500` to list open issues with label `pending release` (default limit is 30, which would silently skip issues beyond that count)
+  4. Loop over all results; for each: post comment "Released in v{VERSION} of the Salesforce Extensions for VSCode." then close
+- Permissions: `issues: write`
+- Uses `GITHUB_TOKEN` (default, sufficient for same-repo issues)
+
+PR target: `develop` (the repository default branch; required for `workflow_run` to activate).
+
+Commit: `feat: add workflow to close pending-release issues after marketplace publish - W-23236874`
+
+## Skills to apply
+
+- concise — plan + workflow file
+- feature-branch — PR targets `develop`
+- typescript — any `.ts` helper scripts or typing added alongside the workflow
+
+## Verification
+
+- YAML lint passes (`actionlint` or manual review of syntax)
+- Workflow name string matches `publishVSCode.yml` `name:` field exactly ("Publish in Microsoft Marketplace")
+- Confirm `publishVSCode.yml` is NOT a reusable workflow: it has no `workflow_call` trigger (only `release` and `workflow_dispatch`), so `workflow_run` will fire for it. This is required because GitHub does not fire `workflow_run` for reusable workflows invoked via `workflow_call`.
+- `gh issue list` call includes `--limit 500` to avoid the default 30-result cap silently dropping issues
+- Version extraction path matches `publishVSCode.yml` (`packages/salesforcedx-vscode/package.json`)
+- Comment text matches AC: "Released in vXX.YY.Z of the Salesforce Extensions for VSCode."
+- Label filter: `pending release` (space, not hyphen)
+- PR targets `develop` — the workflow file must exist on the default branch for the trigger to activate
+- No e2e coverage — GH Actions workflow only testable via live trigger; verify via dry-run review and actionlint

--- a/.claude/plans/W-23236874.md
+++ b/.claude/plans/W-23236874.md
@@ -5,7 +5,7 @@
 - On successful marketplace publish (`publishVSCode.yml`), auto-close issues labeled `pending release` with a version comment.
 - Trigger workflow name (for `workflow_run`): exactly `Publish in Microsoft Marketplace`.
 - Version source: `package.json` on `main` — same path used by `publishVSCode.yml`.
-- **Deployment constraint**: The `workflow_run` trigger only fires when the workflow file exists on the repository's default branch. The default branch is `develop`. This means the new workflow file must be merged to `develop` before it takes effect. The first marketplace publish after merge is the first live trigger.
+- **Deployment constraint**: The `workflow_run` trigger only fires when the workflow file exists on the repository's default branch. The default branch is `develop`. Workflow file must exist on `develop` before it activates. First publish after merge is the first live trigger.
 - **Upstream compatibility**: `publishVSCode.yml` is triggered by `release` (type `released`) and `workflow_dispatch` — it is NOT a reusable workflow (no `workflow_call` trigger). `workflow_run` does fire for workflows triggered by `release` events, so this combination is valid.
 
 ## Phases
@@ -19,7 +19,7 @@ New file: `.github/workflows/closePendingReleaseIssues.yml`
 - Steps:
   1. Checkout `main` (need `package.json` for version)
   2. Extract version from `packages/salesforcedx-vscode/package.json`
-  3. Use `gh issue list` with `--limit 500` to list open issues with label `pending release` (default limit is 30, which would silently skip issues beyond that count)
+  3. Use `gh issue list` with `--limit 500` to list open issues with label `pending release` (default 30 silently drops extras)
   4. Loop over all results; for each: post comment "Released in v{VERSION} of the Salesforce Extensions for VSCode." then close
 - Permissions: `issues: write`
 - Uses `GITHUB_TOKEN` (default, sufficient for same-repo issues)
@@ -38,7 +38,7 @@ Commit: `feat: add workflow to close pending-release issues after marketplace pu
 
 - YAML lint passes (`actionlint` or manual review of syntax)
 - Workflow name string matches `publishVSCode.yml` `name:` field exactly ("Publish in Microsoft Marketplace")
-- Confirm `publishVSCode.yml` is NOT a reusable workflow: it has no `workflow_call` trigger (only `release` and `workflow_dispatch`), so `workflow_run` will fire for it. This is required because GitHub does not fire `workflow_run` for reusable workflows invoked via `workflow_call`.
+- `publishVSCode.yml` has no `workflow_call` trigger → `workflow_run` fires for it.
 - `gh issue list` call includes `--limit 500` to avoid the default 30-result cap silently dropping issues
 - Version extraction path matches `publishVSCode.yml` (`packages/salesforcedx-vscode/package.json`)
 - Comment text matches AC: "Released in vXX.YY.Z of the Salesforce Extensions for VSCode."

--- a/.github/workflows/closePendingReleaseIssues.yml
+++ b/.github/workflows/closePendingReleaseIssues.yml
@@ -6,6 +6,7 @@ on:
     types: [completed]
 
 permissions:
+  contents: read
   issues: write
 
 jobs:
@@ -22,6 +23,10 @@ jobs:
         id: version
         run: |
           VERSION=$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "::error::Invalid version extracted: '$VERSION'"
+            exit 1
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Close issues labeled "pending release"
@@ -30,7 +35,8 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           ISSUES=$(gh issue list --label "pending release" --state open --json number --jq '.[].number' --limit 500)
+          echo "Found $(echo $ISSUES | wc -w | tr -d ' ') issue(s) to close."
           for ISSUE in $ISSUES; do
-            gh issue comment "$ISSUE" --body "Released in v${VERSION} of the Salesforce Extensions for VSCode."
-            gh issue close "$ISSUE"
+            gh issue comment "$ISSUE" --body "Released in v${VERSION} of the Salesforce Extensions for VSCode." || echo "::warning::Failed to comment on issue #$ISSUE"
+            gh issue close "$ISSUE" || echo "::warning::Failed to close issue #$ISSUE"
           done

--- a/.github/workflows/closePendingReleaseIssues.yml
+++ b/.github/workflows/closePendingReleaseIssues.yml
@@ -1,6 +1,7 @@
 name: Close Pending Release Issues
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows: ['Publish in Microsoft Marketplace']
     types: [completed]

--- a/.github/workflows/closePendingReleaseIssues.yml
+++ b/.github/workflows/closePendingReleaseIssues.yml
@@ -1,0 +1,36 @@
+name: Close Pending Release Issues
+
+on:
+  workflow_run:
+    workflows: ['Publish in Microsoft Marketplace']
+    types: [completed]
+
+permissions:
+  issues: write
+
+jobs:
+  close-pending-release-issues:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Extract version from package.json
+        id: version
+        run: |
+          VERSION=$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Close issues labeled "pending release"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          ISSUES=$(gh issue list --label "pending release" --state open --json number --jq '.[].number' --limit 500)
+          for ISSUE in $ISSUES; do
+            gh issue comment "$ISSUE" --body "Released in v${VERSION} of the Salesforce Extensions for VSCode."
+            gh issue close "$ISSUE"
+          done


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/closePendingReleaseIssues.yml` that triggers on successful completion of the `Publish in Microsoft Marketplace` workflow
- For each open issue labeled `pending release`, posts a release comment ("Released in vX.Y.Z of the Salesforce Extensions for VSCode.") and closes the issue
- Uses `--limit 500` on `gh issue list` to avoid the default 30-result cap silently dropping issues

## Plan

[`.claude/plans/W-23236874.md`](.claude/plans/W-23236874.md)

## Reviewer notes

- **low**: `.claude/plans/W-23236874.md` is a process artifact with no runtime value committed to the repo. However, prior plan files also exist in git history following the same convention. Removing it is a design decision about whether to continue or stop tracking plan files in this repository.

### What issues does this PR fix or reference?

@W-23236874@

🤖 Generated by auto-build pipeline. Original WI: https://gus.my.salesforce.com/a07EE00002dT1W8YAK