### PR TITLE
ci: fix closePendingReleaseIssues.yml so that manual dispatch is not skipped + modify workflow to also close discussions - W-23236874

### DIFF
--- a/.github/workflows/closePendingReleaseIssues.yml
+++ b/.github/workflows/closePendingReleaseIssues.yml
@@ -48,16 +48,18 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          DISCUSSIONS=$(gh discussion list --label "pending release" --state open --json number,id --limit 500)
+          DISCUSSIONS=$(gh discussion list --label "pending release" --state open --json number,id,title --limit 500)
           echo "Found $(echo "$DISCUSSIONS" | jq '.discussions | length') discussion(s) to close."
           echo "$DISCUSSIONS" | jq -c '.discussions[]' | while read -r D; do
             NUMBER=$(echo "$D" | jq -r '.number')
             ID=$(echo "$D" | jq -r '.id')
+            TITLE=$(echo "$D" | jq -r '.title')
             gh discussion comment "$NUMBER" --body "Released in v${VERSION} of the Salesforce Extensions for VSCode." \
               || echo "::warning::Failed to comment on discussion #$NUMBER"
             gh api graphql -f query='
               mutation($id: ID!) {
                 closeDiscussion(input: {discussionId: $id}) { discussion { id } }
               }' -f id="$ID" > /dev/null \
+              && echo "✓ Closed discussion ${GITHUB_REPOSITORY}#${NUMBER} (${TITLE})" \
               || echo "::warning::Failed to close discussion #$NUMBER"
           done

--- a/.github/workflows/closePendingReleaseIssues.yml
+++ b/.github/workflows/closePendingReleaseIssues.yml
@@ -49,8 +49,8 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           DISCUSSIONS=$(gh discussion list --label "pending release" --state open --json number,id --limit 500)
-          echo "Found $(echo "$DISCUSSIONS" | jq 'length') discussion(s) to close."
-          echo "$DISCUSSIONS" | jq -c '.[]' | while read -r D; do
+          echo "Found $(echo "$DISCUSSIONS" | jq '.discussions | length') discussion(s) to close."
+          echo "$DISCUSSIONS" | jq -c '.discussions[]' | while read -r D; do
             NUMBER=$(echo "$D" | jq -r '.number')
             ID=$(echo "$D" | jq -r '.id')
             gh discussion comment "$NUMBER" --body "Released in v${VERSION} of the Salesforce Extensions for VSCode." \

--- a/.github/workflows/closePendingReleaseIssues.yml
+++ b/.github/workflows/closePendingReleaseIssues.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   issues: write
+  discussions: write
 
 jobs:
   close-pending-release-issues:
@@ -40,4 +41,23 @@ jobs:
           for ISSUE in $ISSUES; do
             gh issue comment "$ISSUE" --body "Released in v${VERSION} of the Salesforce Extensions for VSCode." || echo "::warning::Failed to comment on issue #$ISSUE"
             gh issue close "$ISSUE" || echo "::warning::Failed to close issue #$ISSUE"
+          done
+
+      - name: Close discussions labeled "pending release"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          DISCUSSIONS=$(gh discussion list --label "pending release" --state open --json number,id --limit 500)
+          echo "Found $(echo "$DISCUSSIONS" | jq 'length') discussion(s) to close."
+          echo "$DISCUSSIONS" | jq -c '.[]' | while read -r D; do
+            NUMBER=$(echo "$D" | jq -r '.number')
+            ID=$(echo "$D" | jq -r '.id')
+            gh discussion comment "$NUMBER" --body "Released in v${VERSION} of the Salesforce Extensions for VSCode." \
+              || echo "::warning::Failed to comment on discussion #$NUMBER"
+            gh api graphql -f query='
+              mutation($id: ID!) {
+                closeDiscussion(input: {discussionId: $id}) { discussion { id } }
+              }' -f id="$ID" > /dev/null \
+              || echo "::warning::Failed to close discussion #$NUMBER"
           done

--- a/.github/workflows/closePendingReleaseIssues.yml
+++ b/.github/workflows/closePendingReleaseIssues.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   close-pending-release-issues:
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main

--- a/contributing/publishing.md
+++ b/contributing/publishing.md
@@ -106,7 +106,7 @@ Full details on the CBW release lifecycle, CDN caching, and rollback procedures 
 
 ## Closing Shipped GitHub Issues
 
-Issues labeled `pending release` are automatically closed after successful publish to the MS Marketplace. The `closePendingReleaseIssues.yml` workflow posts a comment with the release version and closes the issue. You can also trigger this manually via the **Close Pending Release Issues** workflow if needed.
+Issues and discussions labeled `pending release` are automatically closed after successful publish to MS Marketplace. The `closePendingReleaseIssues.yml` workflow posts a comment with the release version and closes both. Trigger manually via **Close Pending Release Issues** workflow if needed.
 
 After a release, run the [`/shipped-issues`](../.claude/skills/shipped-issues/SKILL.md) Claude skill to close open GitHub issues whose linked GUS work items are closed and whose issue numbers appear in the published `CHANGELOG.md`.
 

--- a/contributing/publishing.md
+++ b/contributing/publishing.md
@@ -106,6 +106,8 @@ Full details on the CBW release lifecycle, CDN caching, and rollback procedures 
 
 ## Closing Shipped GitHub Issues
 
+Issues labeled `pending release` are automatically closed after successful publish to the MS Marketplace. The `closePendingReleaseIssues.yml` workflow posts a comment with the release version and closes the issue. You can also trigger this manually via the **Close Pending Release Issues** workflow if needed.
+
 After a release, run the [`/shipped-issues`](../.claude/skills/shipped-issues/SKILL.md) Claude skill to close open GitHub issues whose linked GUS work items are closed and whose issue numbers appear in the published `CHANGELOG.md`.
 
 ## Troubleshooting


### PR DESCRIPTION
### What does this PR do?
Follow-up PR to fix issues with the **closePendingReleaseIssues.yml** workflow after merging #7641 to develop and testing it on release v67.3.0.

### What issues does this PR fix or reference?
@W-23236874@
