### PR TITLE
refactor(lightning): remove utils-vscode TelemetryService + dep - W-23262187

### DIFF
--- a/.claude/plans/W-23262187.md
+++ b/.claude/plans/W-23262187.md
@@ -25,7 +25,7 @@
 
 - `package.json`: rm `@salesforce/salesforcedx-utils-vscode` from `dependencies` (37) + wireit `compile.dependencies` (`../salesforcedx-utils-vscode:compile`, ~110).
 - `package-lock.json`: regenerate via `npm install` at repo root — drops `"@salesforce/salesforcedx-utils-vscode": "*"` from the `packages/salesforcedx-vscode-lightning` deps block (currently line 45041). Commit lock changes with the package.json edit.
-- Mirror precedent commit `54056529a` (lwc), which changed both `package.json` AND `package-lock.json` together.
+- Precedent: `54056529a` (lwc) — changed both together.
 - files: `packages/salesforcedx-vscode-lightning/package.json`, `package-lock.json`
 - commit: `chore(lightning): remove utils-vscode dep - W-23262187`
 
@@ -45,4 +45,4 @@
 - lint: `npm run lint` in pkg.
 - Verify build graph still resolves after wireit dep removal (compile from clean).
 - `git diff package-lock.json` shows only the lightning utils-vscode dep removed (no unrelated churn).
-- e2e: no lightning spec asserts activation telemetry or span emission — the 4 desktop specs (`auraLspAutocompletion`, `auraRename`, `auraTemplates`, `auraLspGoToDefinition`) only exercise LSP behavior post-activation. A broken `activate()` (bad import/dep removal) would surface as failures across all 4. Primary verification = `tsc` + `lint` + a manual `npm run test:desktop -w packages/salesforcedx-vscode-lightning` run on branch. No claim of telemetry-span coverage.
+- e2e: no lightning spec asserts activation telemetry/span. 4 desktop specs (`auraLspAutocompletion`, `auraRename`, `auraTemplates`, `auraLspGoToDefinition`) only exercise post-activation LSP behavior — broken `activate()` would fail all 4. Primary verification: `tsc` + `lint` + manual `npm run test:desktop -w packages/salesforcedx-vscode-lightning`.

--- a/.claude/plans/W-23262187.md
+++ b/.claude/plans/W-23262187.md
@@ -1,0 +1,48 @@
+# W-23262187 — Remove utils-vscode TelemetryService + dep from lightning (aura) ext
+
+## Context
+
+- Mirror merged PR #7630 (apex-testing end-state): span-based telemetry, no shim.
+- `salesforcedx-vscode-lightning` still consumes `@salesforce/salesforcedx-utils-vscode` solely for `TelemetryService`.
+- Telemetry already inited via `SdkLayerFor(context)` in `src/services/extensionProvider.ts:41` (OTel-first). `TelemetryService.initializeService` redundant.
+- 3 refs, all `src/index.ts`:
+  - `16` — `import { TelemetryService }`
+  - `109` — `initializeService(extensionContext)` (redundant)
+  - `211` — `sendExtensionDeactivationEvent()`
+- No utils-vscode refs in `test/`.
+- Ref deactivate (apex-testing `index.ts:225`): drops deactivation event, just `closeExtensionScope()`. Adopt same (drop, no `withSpan`).
+
+## Phases
+
+### Phase 1 — Drop TelemetryService from index.ts
+
+- `src/index.ts`: rm import (16), rm `initializeService` Effect.promise line (109), rm `sendExtensionDeactivationEvent()` (211).
+- deactivate keeps `console.log` + `closeExtensionScope()` only.
+- files: `packages/salesforcedx-vscode-lightning/src/index.ts`
+- commit: `refactor(lightning): drop utils-vscode TelemetryService, telemetry via span - W-23262187`
+
+### Phase 2 — Remove utils-vscode dep
+
+- `package.json`: rm `@salesforce/salesforcedx-utils-vscode` from `dependencies` (37) + wireit `compile.dependencies` (`../salesforcedx-utils-vscode:compile`, ~110).
+- `package-lock.json`: regenerate via `npm install` at repo root — drops `"@salesforce/salesforcedx-utils-vscode": "*"` from the `packages/salesforcedx-vscode-lightning` deps block (currently line 45041). Commit lock changes with the package.json edit.
+- Mirror precedent commit `54056529a` (lwc), which changed both `package.json` AND `package-lock.json` together.
+- files: `packages/salesforcedx-vscode-lightning/package.json`, `package-lock.json`
+- commit: `chore(lightning): remove utils-vscode dep - W-23262187`
+
+## Skills to apply
+
+- `services-extension-consumption` — SdkLayerFor/telemetry wiring
+- `span-file-export` — verify span emission
+- `packageJson` / `wireit` — dep + build-graph edits
+- `effect-best-practices` — deactivate Effect shape
+- `typescript` — index.ts edits
+- `verification`
+
+## Verification
+
+- `tsc` compile: `npm run compile -p packages/salesforcedx-vscode-lightning` (or wireit compile) — passes, no utils-vscode.
+- `grep -rn "utils-vscode\|TelemetryService" packages/salesforcedx-vscode-lightning/src` — 0 hits.
+- lint: `npm run lint` in pkg.
+- Verify build graph still resolves after wireit dep removal (compile from clean).
+- `git diff package-lock.json` shows only the lightning utils-vscode dep removed (no unrelated churn).
+- e2e: no lightning spec asserts activation telemetry or span emission — the 4 desktop specs (`auraLspAutocompletion`, `auraRename`, `auraTemplates`, `auraLspGoToDefinition`) only exercise LSP behavior post-activation. A broken `activate()` (bad import/dep removal) would surface as failures across all 4. Primary verification = `tsc` + `lint` + a manual `npm run test:desktop -w packages/salesforcedx-vscode-lightning` run on branch. No claim of telemetry-span coverage.

--- a/package-lock.json
+++ b/package-lock.json
@@ -45033,7 +45033,6 @@
         "@salesforce/effect-ext-utils": "*",
         "@salesforce/salesforcedx-aura-language-server": "*",
         "@salesforce/salesforcedx-lightning-lsp-common": "*",
-        "@salesforce/salesforcedx-utils-vscode": "*",
         "@salesforce/vscode-i18n": "*",
         "acorn": "^6.0.0",
         "acorn-loose": "^6.0.0",

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -34,7 +34,6 @@
     "@salesforce/effect-ext-utils": "*",
     "@salesforce/salesforcedx-aura-language-server": "*",
     "@salesforce/salesforcedx-lightning-lsp-common": "*",
-    "@salesforce/salesforcedx-utils-vscode": "*",
     "@salesforce/vscode-i18n": "*",
     "acorn": "^6.0.0",
     "acorn-loose": "^6.0.0",
@@ -107,7 +106,6 @@
       "command": "tsc --pretty",
       "dependencies": [
         "../effect-ext-utils:compile",
-        "../salesforcedx-utils-vscode:compile",
         "../salesforcedx-vscode-i18n:compile",
         "../salesforcedx-vscode-services:compile",
         "../salesforcedx-aura-language-server:compile",

--- a/packages/salesforcedx-vscode-lightning/src/index.ts
+++ b/packages/salesforcedx-vscode-lightning/src/index.ts
@@ -13,7 +13,6 @@ import {
 } from '@salesforce/salesforcedx-lightning-lsp-common/applyEditHandler';
 import { detectWorkspaceType } from '@salesforce/salesforcedx-lightning-lsp-common/detectWorkspaceTypeVscode';
 import { registerWorkspaceReadFileHandler } from '@salesforce/salesforcedx-lightning-lsp-common/workspaceReadFileHandler';
-import { TelemetryService } from '@salesforce/salesforcedx-utils-vscode';
 import * as Effect from 'effect/Effect';
 import * as Scope from 'effect/Scope';
 import { log } from 'node:console';
@@ -104,9 +103,6 @@ export const activateEffect = Effect.fn('activation:salesforcedx-vscode-lightnin
     );
     return;
   }
-
-  // Initialize telemetry service
-  yield* Effect.promise(() => TelemetryService.getInstance().initializeService(extensionContext));
 
   // Start the Aura Language Server
   // TODO: derive the path from extensionUri instead of pjson
@@ -208,6 +204,5 @@ export const activateEffect = Effect.fn('activation:salesforcedx-vscode-lightnin
 
 export const deactivate = async (): Promise<void> => {
   console.log('Aura Components Extension Deactivated');
-  TelemetryService.getInstance().sendExtensionDeactivationEvent();
   await getRuntime().runPromise(closeExtensionScope());
 };


### PR DESCRIPTION
## Summary
- Removed the `salesforcedx-utils-vscode` `TelemetryService` usage from `salesforcedx-vscode-lightning` — telemetry is already handled OTel-first via `SdkLayerFor(context)` in `extensionProvider.ts`, making the old init/deactivation calls redundant.
- Dropped the `@salesforce/salesforcedx-utils-vscode` dependency from the lightning package (`package.json` + wireit `compile.dependencies`) and regenerated `package-lock.json`.
- Mirrors the merged apex-testing precedent (#7630): span-based telemetry, no shim.

## Plan
[.claude/plans/W-23262187.md](../blob/sm/W-23262187-remove-utils-vscode-telemetryservice-dep/.claude/plans/W-23262187.md)

### What issues does this PR fix or reference?
@W-23262187@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002dcdIeYAI/view