### PR TITLE
chore(apex-testing): drop stale utils-vscode wireit compile dep - W-23262192

### DIFF
--- a/.claude/plans/W-23262192.md
+++ b/.claude/plans/W-23262192.md
@@ -1,0 +1,29 @@
+# W-23262192 — Remove stale utils-vscode wireit compile dep from apex-testing
+
+## Context
+
+- `wireit.compile.dependencies` in `packages/salesforcedx-vscode-apex-testing/package.json` still lists `../salesforcedx-utils-vscode:compile` (line 74; WI said 73).
+- utils-vscode NOT in `dependencies`/`devDependencies` → wireit dep stale (per wireit skill: compile dep only if pkg is dep/devDep).
+- No src import; only stale comment ref in `src/utils/notificationHelpers.ts:13` ("Replaces notificationService from @salesforce/salesforcedx-utils-vscode") — leave, not runtime.
+- Deps block already dropped PR #7630 (W-23165781). This wireit entry = last cruft.
+- Fully drops apex-testing as utils-vscode consumer.
+
+## Phases
+
+### Phase 1 — drop stale wireit dep
+- Delete line `"../salesforcedx-utils-vscode:compile",` from `wireit.compile.dependencies`.
+- File: `packages/salesforcedx-vscode-apex-testing/package.json`
+- Commit: `chore(apex-testing): drop stale utils-vscode wireit compile dep - W-23262192`
+
+## Skills to apply
+
+- wireit — compile dep valid only when pkg is package.json dep/devDep
+- packageJson — package.json edit conventions
+- typescript — coding standards/conventions for the .ts/.json edit
+
+## Verification
+
+- `grep -rn salesforcedx-utils-vscode packages/salesforcedx-vscode-apex-testing/` → no wireit/dep hits (comment ref only, expected)
+- `npm run compile -w salesforcedx-vscode-apex-testing` (WIREIT_CACHE=none) → passes
+- lint clean
+- e2e-covered: extension build/activation via existing apex-testing playwright web+desktop suites on branch

--- a/packages/salesforcedx-vscode-apex-testing/package.json
+++ b/packages/salesforcedx-vscode-apex-testing/package.json
@@ -71,7 +71,6 @@
       "dependencies": [
         "../salesforcedx-apex:compile",
         "../salesforcedx-utils:compile",
-        "../salesforcedx-utils-vscode:compile",
         "../salesforcedx-vscode-i18n:compile",
         "../effect-ext-utils:compile",
         "../salesforcedx-vscode-services:compile"


### PR DESCRIPTION
## Summary
- Removed stale `../salesforcedx-utils-vscode:compile` entry from `wireit.compile.dependencies` in `packages/salesforcedx-vscode-apex-testing/package.json`.
- utils-vscode is not a `dependencies`/`devDependencies` entry for apex-testing, so the wireit compile dep was invalid cruft left after PR #7630 removed the actual package dependency.
- Fully drops apex-testing as a utils-vscode consumer.

## Plan
.claude/plans/W-23262192.md

## Test plan
- `grep -rn salesforcedx-utils-vscode packages/salesforcedx-vscode-apex-testing/` returns no wireit/dependency hits (only an unrelated code comment).

### What issues does this PR fix or reference?
@W-23262192@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002dcEuXYAU/view