### PR TITLE
build(eslint): enable unicorn/no-useless-logical-operand - W-23094916

### DIFF
--- a/.claude/plans/W-23094916.md
+++ b/.claude/plans/W-23094916.md
@@ -1,0 +1,25 @@
+# W-23094916 — Enable unicorn/no-useless-logical-operand
+
+## Context
+- Enable `unicorn/no-useless-logical-operand` (error). Bans useless boolean literals in `&&`/`||` (e.g. `x && true`).
+- `eslint-plugin-unicorn@68` (`node_modules/eslint-plugin-unicorn/rules/no-useless-logical-operand.js`).
+- eslint.config.mjs:170-233 — unicorn rules block; insert alpha (after `no-useless-length-check` L201, before `no-useless-promise-resolve-reject` L202).
+- Depends: W-23094915 (`no-useless-length-check`, already merged — L201 present).
+- Repo scan w/ rule on (src + test + scripts): 0 violations.
+
+## Done when
+- `unicorn/no-useless-logical-operand: 'error'` in eslint.config.mjs.
+- `npm run lint` clean.
+
+## Phases
+
+### Phase 1 — enable rule
+- eslint.config.mjs: add `'unicorn/no-useless-logical-operand': 'error',` in unicorn block (alpha).
+- commit: `build(eslint): enable unicorn/no-useless-logical-operand - W-23094916`
+
+## Skills
+- typescript
+
+## Verification
+- `npm run lint` → 0 errors (sharded; `npx eslint .` OOMs full tree).
+- Not e2e-covered (lint-only config change).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -199,6 +199,7 @@ export default [
       'unicorn/no-useless-fallback-in-spread': 'error',
       'unicorn/no-useless-iterator-to-array': 'error',
       'unicorn/no-useless-length-check': 'error',
+      'unicorn/no-useless-logical-operand': 'error',
       'unicorn/no-useless-promise-resolve-reject': 'error',
       'unicorn/no-useless-spread': 'error',
       'unicorn/no-useless-switch-case': 'error',


### PR DESCRIPTION
## Summary
- Enable `unicorn/no-useless-logical-operand` (error) in eslint.config.mjs, which bans useless boolean literals in `&&`/`||` (e.g. `x && true`).
- Repo scan with the rule on (src + test + scripts) found 0 violations, so no other code changes needed.

## Plan
.claude/plans/W-23094916.md

## Test plan
- `npm run lint` passes (enforced by CI).

### What issues does this PR fix or reference?
@W-23094916@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002ceuI0YAI/view