### PR TITLE
ci(hooks): block git push when node_modules missing - W-23270584

### DIFF
--- a/.claude/hooks/block-no-verify.sh
+++ b/.claude/hooks/block-no-verify.sh
@@ -2,10 +2,7 @@
 # Block git with --no-verify. PreToolUse hook (matcher: Bash).
 # Reads tool input on stdin and inspects the .command field.
 # https://code.claude.com/docs/en/hooks.md
-input=$(cat)
-tool_name=$(echo "$input" | jq -r '.tool_name // empty')
-[[ "$tool_name" != "Bash" ]] && exit 0
-command=$(echo "$input" | jq -r '.tool_input.command // .command // empty')
+source "$(dirname "${BASH_SOURCE[0]}")/lib/bash-hook-preamble.sh"
 [[ "$command" =~ git.*--no-verify ]] && cat <<'EOF'
 {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"git with --no-verify is blocked. Run without --no-verify so hooks run."}}
 EOF

--- a/.claude/hooks/block-push-no-deps.sh
+++ b/.claude/hooks/block-push-no-deps.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Block `git push` when node_modules is missing at the target repo root.
+# PreToolUse hook (matcher: Bash). Without deps, local lint/compile hooks
+# error (`wireit: command not found`) instead of catching issues, so a push
+# ships unverified code (see PR 7634 incident).
+# https://code.claude.com/docs/en/hooks.md
+input=$(cat)
+tool_name=$(echo "$input" | jq -r '.tool_name // empty')
+[[ "$tool_name" != "Bash" ]] && exit 0
+command=$(echo "$input" | jq -r '.tool_input.command // .command // empty')
+cwd=$(echo "$input" | jq -r '.cwd // empty')
+[[ -z "$cwd" ]] && cwd="$PWD"
+
+# Detect `push` at the git-subcommand position (not bag-of-tokens): after an
+# optional `-C <dir>` and any global flags. Value-taking flags (`-c name=val`,
+# `--namespace ns`) put the value in a separate token, so allow an optional
+# non-dash value token after each flag before the `push` subcommand.
+cmd_no_cdir=$(echo "$command" | sed -E 's/git[[:space:]]+-C[[:space:]]+[^[:space:]]+/git/')
+[[ "$cmd_no_cdir" =~ git[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-[:space:]][^[:space:]]*[[:space:]]+)?)*push([[:space:]]|$) ]] || exit 0
+
+# Resolve target dir in priority order.
+dir=""
+# 1. leading `cd <dir> &&|;` prefix (strip leading VAR=val assignments first).
+normalized=$(echo "$command" | sed -E 's/^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*//')
+if [[ "$normalized" =~ ^cd[[:space:]]+([^\;\&]+) ]]; then
+  cd_dir="${BASH_REMATCH[1]}"
+  cd_dir="${cd_dir%"${cd_dir##*[![:space:]]}"}" # trim trailing space
+  cd_dir="${cd_dir#\"}"; cd_dir="${cd_dir%\"}"
+  cd_dir="${cd_dir#\'}"; cd_dir="${cd_dir%\'}"
+  [[ "$cd_dir" == /* ]] && dir="$cd_dir" || dir="$cwd/$cd_dir"
+fi
+# 2. `git -C <dir>` flag.
+if [[ -z "$dir" && "$command" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
+  cdir="${BASH_REMATCH[1]}"
+  cdir="${cdir#\"}"; cdir="${cdir%\"}"
+  cdir="${cdir#\'}"; cdir="${cdir%\'}"
+  [[ "$cdir" == /* ]] && dir="$cdir" || dir="$cwd/$cdir"
+fi
+# 3. payload .cwd, else $PWD.
+[[ -z "$dir" ]] && dir="$cwd"
+
+root=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)
+[[ -z "$root" ]] && exit 0 # not a repo; let git error
+{ [[ -d "$root/node_modules" ]] || [[ -L "$root/node_modules" ]]; } && exit 0
+
+cat <<EOF
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"node_modules missing at $root — local lint/compile hooks can't run, so a push would ship unverified code. Run 'npm install' at the repo root, then push."}}
+EOF
+exit 0

--- a/.claude/hooks/block-push-no-deps.sh
+++ b/.claude/hooks/block-push-no-deps.sh
@@ -4,46 +4,72 @@
 # error (`wireit: command not found`) instead of catching issues, so a push
 # ships unverified code (see PR 7634 incident).
 # https://code.claude.com/docs/en/hooks.md
-input=$(cat)
-tool_name=$(echo "$input" | jq -r '.tool_name // empty')
-[[ "$tool_name" != "Bash" ]] && exit 0
-command=$(echo "$input" | jq -r '.tool_input.command // .command // empty')
-cwd=$(echo "$input" | jq -r '.cwd // empty')
-[[ -z "$cwd" ]] && cwd="$PWD"
+source "$(dirname "${BASH_SOURCE[0]}")/lib/bash-hook-preamble.sh"
 
-# Detect `push` at the git-subcommand position (not bag-of-tokens): after an
-# optional `-C <dir>` and any global flags. Value-taking flags (`-c name=val`,
-# `--namespace ns`) put the value in a separate token, so allow an optional
-# non-dash value token after each flag before the `push` subcommand.
-cmd_no_cdir=$(echo "$command" | sed -E 's/git[[:space:]]+-C[[:space:]]+[^[:space:]]+/git/')
-[[ "$cmd_no_cdir" =~ git[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-[:space:]][^[:space:]]*[[:space:]]+)?)*push([[:space:]]|$) ]] || exit 0
+# Split a compound command into segments on shell separators (&& || ; | &),
+# then evaluate each segment against its own effective directory. This ties
+# push-detection and dir-resolution to the SAME subcommand: a sibling
+# `git -C <dir> status` can no longer hijack the dir a bare `git push` uses,
+# and sequential `cd`s track the dir the push actually runs in.
+segments=$(echo "$command" | sed -E 's/(\|\||&&|[;|&])/\n/g')
 
-# Resolve target dir in priority order.
-dir=""
-# 1. leading `cd <dir> &&|;` prefix (strip leading VAR=val assignments first).
-normalized=$(echo "$command" | sed -E 's/^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*//')
-if [[ "$normalized" =~ ^cd[[:space:]]+([^\;\&]+) ]]; then
-  cd_dir="${BASH_REMATCH[1]}"
-  cd_dir="${cd_dir%"${cd_dir##*[![:space:]]}"}" # trim trailing space
-  cd_dir="${cd_dir#\"}"; cd_dir="${cd_dir%\"}"
-  cd_dir="${cd_dir#\'}"; cd_dir="${cd_dir%\'}"
-  [[ "$cd_dir" == /* ]] && dir="$cd_dir" || dir="$cwd/$cd_dir"
-fi
-# 2. `git -C <dir>` flag.
-if [[ -z "$dir" && "$command" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
-  cdir="${BASH_REMATCH[1]}"
-  cdir="${cdir#\"}"; cdir="${cdir%\"}"
-  cdir="${cdir#\'}"; cdir="${cdir%\'}"
-  [[ "$cdir" == /* ]] && dir="$cdir" || dir="$cwd/$cdir"
-fi
-# 3. payload .cwd, else $PWD.
-[[ -z "$dir" ]] && dir="$cwd"
+# Effective dir tracked across segments, seeded from payload cwd.
+eff_dir="$cwd"
 
-root=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)
-[[ -z "$root" ]] && exit 0 # not a repo; let git error
-{ [[ -d "$root/node_modules" ]] || [[ -L "$root/node_modules" ]]; } && exit 0
+is_push_segment() {
+  # `push` at the git-subcommand position (not bag-of-tokens): after an
+  # optional `-C <dir>` and any global flags. Value-taking flags (`-c x=y`,
+  # `--namespace ns`) put the value in a separate token, so allow an optional
+  # non-dash value token after each flag before the `push` subcommand.
+  local seg no_cdir
+  seg="$1"
+  no_cdir=$(echo "$seg" | sed -E 's/git[[:space:]]+-C[[:space:]]+[^[:space:]]+/git/')
+  [[ "$no_cdir" =~ git[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-[:space:]][^[:space:]]*[[:space:]]+)?)*push([[:space:]]|$) ]]
+}
 
-cat <<EOF
+# Word-split a token respecting quotes/escapes/$VAR via the shell, so paths
+# like `cd "$HOME/x"` or `cd /a\ b` resolve correctly (bespoke quote-stripping
+# only handled one flat layer). eval is safe: input is Claude's own tool call.
+first_word_after() {
+  local seg keyword rest words
+  seg="$1"; keyword="$2"
+  [[ "$seg" =~ (^|[[:space:]])"$keyword"[[:space:]]+(.*) ]] || return 1
+  rest="${BASH_REMATCH[2]}"
+  eval "words=($rest)" 2>/dev/null || return 1
+  [[ -n "${words[0]}" ]] && printf '%s' "${words[0]}"
+}
+
+check_dir() {
+  local dir root
+  dir="$1"
+  [[ "$dir" != /* ]] && dir="$cwd/$dir"
+  root=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)
+  [[ -z "$root" ]] && return 0 # not a repo; let git error
+  { [[ -d "$root/node_modules" ]] || [[ -L "$root/node_modules" ]]; } && return 0
+  cat <<EOF
 {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"node_modules missing at $root — local lint/compile hooks can't run, so a push would ship unverified code. Run 'npm install' at the repo root, then push."}}
 EOF
+  exit 0
+}
+
+while IFS= read -r seg; do
+  # Strip leading VAR=val assignments (mirror platform if-matcher normalization).
+  seg=$(echo "$seg" | sed -E 's/^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*//')
+
+  # A `cd` segment updates the effective dir for subsequent segments.
+  if cd_target=$(first_word_after "$seg" cd); then
+    [[ "$cd_target" == /* ]] && eff_dir="$cd_target" || eff_dir="$eff_dir/$cd_target"
+    continue
+  fi
+
+  is_push_segment "$seg" || continue
+
+  # Segment-local `git -C <dir>` wins over the tracked effective dir.
+  if git_c=$(first_word_after "$seg" '-C'); then
+    check_dir "$git_c"
+  else
+    check_dir "$eff_dir"
+  fi
+done <<< "$segments"
+
 exit 0

--- a/.claude/hooks/lib/bash-hook-preamble.sh
+++ b/.claude/hooks/lib/bash-hook-preamble.sh
@@ -1,0 +1,9 @@
+# Shared preamble for Bash PreToolUse hooks. Source it, then use $command.
+# Reads stdin JSON, gates on tool_name==Bash, sets $command and $cwd.
+# https://code.claude.com/docs/en/hooks.md
+input=$(cat)
+tool_name=$(echo "$input" | jq -r '.tool_name // empty')
+[[ "$tool_name" != "Bash" ]] && exit 0
+command=$(echo "$input" | jq -r '.tool_input.command // .command // empty')
+cwd=$(echo "$input" | jq -r '.cwd // empty')
+[[ -z "$cwd" ]] && cwd="$PWD"

--- a/.claude/plans/W-23270584.md
+++ b/.claude/plans/W-23270584.md
@@ -5,8 +5,8 @@
 - `verify-stop.sh` Stop hook runs lint/compile/test, but:
   1. fires only end-of-turn — mid-turn push bypasses
   2. in worktree w/o `node_modules`, `npm run lint` errors `wireit: command not found` before linting
-- Incident: PR 7634 pushed eslint errors (`local/package-json-command-refs` + `import/order`), only caught in CI. No deps locally + Husky skipped.
-- Fix: new PreToolUse Bash hook denies `git push` when `node_modules` absent at target repo root.
+- Incident: PR 7634 pushed eslint errors (`local/package-json-command-refs` + `import/order`), only caught in CI — no deps locally, Husky skipped.
+- Fix: new PreToolUse Bash hook; deny push when `node_modules` absent at target root.
 - Mirror `.claude/hooks/block-no-verify.sh` (stdin parse, deny-JSON shape).
 
 ## Phases

--- a/.claude/plans/W-23270584.md
+++ b/.claude/plans/W-23270584.md
@@ -1,0 +1,59 @@
+# W-23270584 — block-push-no-deps PreToolUse hook
+
+## Context
+
+- `verify-stop.sh` Stop hook runs lint/compile/test, but:
+  1. fires only end-of-turn — mid-turn push bypasses
+  2. in worktree w/o `node_modules`, `npm run lint` errors `wireit: command not found` before linting
+- Incident: PR 7634 pushed eslint errors (`local/package-json-command-refs` + `import/order`), only caught in CI. No deps locally + Husky skipped.
+- Fix: new PreToolUse Bash hook denies `git push` when `node_modules` absent at target repo root.
+- Mirror `.claude/hooks/block-no-verify.sh` (stdin parse, deny-JSON shape).
+
+## Phases
+
+### Phase 1 — add hook + wire-up (one commit)
+
+**Files:** `.claude/hooks/block-push-no-deps.sh` (new), `.claude/settings.json`
+
+`block-push-no-deps.sh`:
+- read stdin JSON
+- `tool_name=$(jq -r '.tool_name // empty')`; `!= Bash` => exit 0
+- `command=$(jq -r '.tool_input.command // .command // empty')`
+- detect push at the git-subcommand position, NOT bag-of-tokens. Regex `git[[:space:]]+(-[^[:space:]]+[[:space:]]+)*push([[:space:]]|$)` after stripping any leading `-C <dir>` — global flags (`-c x=y`, `--no-pager`) allowed before `push`; NO match => exit 0.
+  - rationale: `git commit -m "push fix"` contains tokens `git` + `push` but subcommand is `commit`, must allow (acceptance criterion).
+- resolve target dir, in priority order:
+  1. leading `cd <dir> &&` / `cd <dir> ;` prefix in the command (agent pattern: fresh hook process never sees the cwd change; `.cwd`/`$PWD` reflect pre-`cd` session cwd). Strip leading `VAR=val` assignments first (mirror platform `if`-matcher normalization per hooks.md), then match `^[[:space:]]*cd[[:space:]]+([^;&]+)`. Trim/unquote the dir; relative dirs resolved against `.cwd`.
+  2. `git -C <dir>` flag if present.
+  3. payload `.cwd`, else `$PWD`.
+- `root=$(git -C "<dir>" rev-parse --show-toplevel 2>/dev/null)`; empty (not a repo) => exit 0 (let git error)
+- `root/node_modules` exists as dir OR symlink (`[[ -d ]] || [[ -L ]]`) => exit 0 (allow)
+- else emit deny JSON: `hookSpecificOutput` w/ `hookEventName=PreToolUse`, `permissionDecision=deny`, `permissionDecisionReason` = missing deps + run `npm install`
+- `chmod +x`
+
+`.claude/settings.json`:
+- append `{type:command, command:${CLAUDE_PROJECT_DIR}/.claude/hooks/block-push-no-deps.sh}` to EXISTING PreToolUse `Bash` matcher `hooks` array (after block-no-verify.sh)
+- no new matcher block
+
+**Commit:** `feat(hooks): block git push when node_modules missing - W-23270584`
+
+## Skills
+
+- concise — plan + any md
+- typescript — file naming conventions apply repo-wide
+- verification — manual hook checks
+
+## Verification
+
+Feed synthetic hook JSON on stdin, assert stdout (not e2e-covered — no branch e2e for `.claude` hooks):
+
+- push from dir w/o `node_modules` (git `-C` a depless worktree) => deny JSON printed
+- push from repo w/ `node_modules` => empty stdout (allow)
+- non-push git (`git status`, `git commit`) => empty stdout (allow)
+- `git commit -m "push fix for lint"` (both tokens present, subcommand=commit) => empty stdout (allow) — guards against bag-of-tokens false-deny
+- `git -c core.hooksPath=x push` (global flag before push) => detected as push
+- `git -C <other-worktree> push` resolves that worktree root, not cwd (point `-C` at depless dir while cwd has deps => deny)
+- `cd <depless-dir> && npm run lint && git push` (payload `.cwd` points at a deps-having dir) => resolves depless-dir root => deny — the incident scenario
+- `cd <deps-dir> && git push` from a depless `.cwd` => allow (cd overrides pre-cd cwd)
+- non-Bash tool_name => empty stdout
+- `jq . .claude/settings.json` => valid
+- `bash -n block-push-no-deps.sh` => syntax ok; file executable

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -38,6 +38,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/block-no-verify.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/block-push-no-deps.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Add `block-push-no-deps.sh` PreToolUse Bash hook: denies `git push` when `node_modules` is missing at the resolved target repo root, since local lint/compile hooks can't run without deps and would let unverified code ship (PR 7634 incident).
- Detect `push` at the actual git-subcommand position (not bag-of-tokens) and resolve the effective target dir per shell segment (`cd`, `git -C`, payload `cwd`), so sibling commands or worktree switches can't dodge the check.
- Extract shared stdin-parsing preamble (`lib/bash-hook-preamble.sh`) and reuse it in `block-no-verify.sh`; wire the new hook into the existing PreToolUse `Bash` matcher in `.claude/settings.json`.

## Plan
.claude/plans/W-23270584.md

## Test plan
- Feed synthetic PreToolUse JSON on stdin to `block-push-no-deps.sh` and confirm deny/allow output for: push from a dir without `node_modules`; push from a dir with `node_modules`; non-push git commands (`git status`, `git commit -m "push fix"`); global-flag pushes (`git -c core.hooksPath=x push`); `git -C <depless-dir> push`; `cd <depless-dir> && ... && git push`; `cd <deps-dir> && git push` from a depless cwd; non-Bash `tool_name`.
- `jq . .claude/settings.json` validates; `bash -n block-push-no-deps.sh` syntax-checks; hook file is executable.

### What issues does this PR fix or reference?
@W-23270584@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002denIgYAI/view
