### PR TITLE
build(eslint): enable unicorn/no-xor-as-exponentiation - W-23094919

### DIFF
--- a/.claude/plans/W-23094919.md
+++ b/.claude/plans/W-23094919.md
@@ -1,0 +1,25 @@
+# W-23094919 — Enable unicorn/no-xor-as-exponentiation
+
+## Context
+- Enable `unicorn/no-xor-as-exponentiation`: flags `^` between decimal int literals (bitwise XOR mistaken for exponent).
+- Dep W-23094916 merged (f860730b9).
+- Config: `eslint.config.mjs`, unicorn block alphabetical (~L170-260).
+- Rule present in `node_modules/eslint-plugin-unicorn/rules/no-xor-as-exponentiation.js`.
+- No numeric `^` in src (checked); all `^` = regex/strings/version ranges. Zero violations expected.
+
+## Phases
+
+### Phase 1 — enable rule
+- Add `'unicorn/no-xor-as-exponentiation': 'error',` after L205 (`no-useless-switch-case`), before `numeric-separators-style` (alpha order).
+- File: `eslint.config.mjs`
+- Commit: `build(eslint): enable unicorn/no-xor-as-exponentiation - W-23094919`
+
+## Skills to apply
+- typescript (eslint.config.mjs / TS lint rule change)
+- concise (plan/docs)
+- packageJson (only if dep changes — none expected)
+
+## Verification
+- `yarn eslint eslint.config.mjs` — config parses.
+- `yarn lint` (or workspace lint) — clean, no new violations.
+- Not e2e-covered; lint-only change.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -203,6 +203,7 @@ export default [
       'unicorn/no-useless-promise-resolve-reject': 'error',
       'unicorn/no-useless-spread': 'error',
       'unicorn/no-useless-switch-case': 'error',
+      'unicorn/no-xor-as-exponentiation': 'error',
       'unicorn/numeric-separators-style': 'error',
       'unicorn/prefer-array-find': 'error',
       'unicorn/prefer-array-flat': 'error',


### PR DESCRIPTION
## Summary
- Enable `unicorn/no-xor-as-exponentiation` lint rule (flags `^` between decimal int literals mistaken for exponentiation).
- No existing violations in src — all `^` usages are regex/strings/version ranges.

## Plan
[.claude/plans/W-23094919.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23094919-10-enable-unicorn-no-xor-as-exponentiati/.claude/plans/W-23094919.md)

### What issues does this PR fix or reference?
@W-23094919@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cetc7YAA/view