### PR TITLE
build(eslint): enable unicorn/prefer-url-can-parse - W-23094931

### DIFF
--- a/.claude/plans/W-23094931.md
+++ b/.claude/plans/W-23094931.md
@@ -1,0 +1,25 @@
+# W-23094931 — Enable unicorn/prefer-url-can-parse
+
+## Context
+- Enable `unicorn/prefer-url-can-parse`: prefer `URL.canParse()` over `new URL()` in try/catch for validation.
+- Dep W-23094927 merged (b439174b1).
+- Config: `eslint.config.mjs`, unicorn block alphabetical (~L170-235).
+- Rule in eslint-plugin-unicorn 68.0.0 (installed).
+- Scanned all pkg src+test with rule on: **0 violations**. `new URL()` uses (indexedDbStorage, bootstrapCmd) not in validation try/catch → not flagged. Pure config enablement.
+
+## Phases
+
+### Phase 1 — enable rule
+- Add `'unicorn/prefer-url-can-parse': 'error',` in alpha order (after `prefer-structured-clone` L233, before `prefer-ternary` L234).
+- File: `eslint.config.mjs`
+- Commit: `build(eslint): enable unicorn/prefer-url-can-parse - W-23094931`
+
+## Skills to apply
+- typescript (eslint.config.mjs rule change)
+- concise (plan/docs)
+- packageJson (only if dep changes — none)
+
+## Verification
+- `yarn eslint eslint.config.mjs` — config parses.
+- `yarn lint` — clean, no new violations.
+- Not e2e-covered; lint-only.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -232,6 +232,7 @@ export default [
       'unicorn/prefer-simple-condition-first': 'error',
       'unicorn/prefer-structured-clone': 'error',
       'unicorn/prefer-ternary': ['error'],
+      'unicorn/prefer-url-can-parse': 'error',
       'unicorn/prefer-while-loop-condition': 'error',
       'unicorn/filename-case': [
         'error',


### PR DESCRIPTION
## Summary
- Enable `unicorn/prefer-url-can-parse` lint rule (prefer `URL.canParse()` over `new URL()` in try/catch for validation).
- Pure config enablement — 0 violations in existing codebase.

## Plan
.claude/plans/W-23094931.md

### What issues does this PR fix or reference?
@W-23094931@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cfBSCYA2/view