### PR TITLE
fix(apex-log): drop traceFlagStatusBar.refresh from production telemetry - W-23290053

### DIFF
--- a/.claude/plans/W-23290053.md
+++ b/.claude/plans/W-23290053.md
@@ -17,7 +17,7 @@
 - Commit: `fix(apex-log): drop traceFlagStatusBar.refresh from production telemetry - W-23290053`
 
 ### Phase 2 — unit-test the telemetryIgnore gate (new coverage)
-- No test currently exercises `isSpanValidForProductionTelemetry`; `spanUtils.ts` has zero test coverage. Add it so the safety net actually exists.
+- No test currently exercises `isSpanValidForProductionTelemetry`; `spanUtils.ts` has 0 test coverage. Add coverage.
 - New file: `packages/salesforcedx-vscode-services/test/jest/observability/spanUtils.test.ts` (matches existing jest layout, e.g. `spanTransformProcessor.test.ts`)
 - `isSpanValidForProductionTelemetry` is exported + pure — test with a minimal `ReadableSpan`-shaped stub (only `attributes` + `parentSpanContext` are read):
   - `telemetryIgnore: true` on a top-level span → returns `false` (the behavior this plan relies on)
@@ -36,4 +36,4 @@
 - typecheck + lint pass (`npm run compile` / eslint on apex-log + services pkgs)
 - existing `traceFlagStatusBar.test.ts` still green (no refresh-span assertions)
 - manual/optional: query-app-insights post-ship — confirm span count drops (not gated in CI)
-- not e2e-covered: telemetry export happens in the SDK exporter pipeline, not observable through the extension-host e2e harness; no e2e/integration test references traceFlagStatusBar telemetry. Correctness of the gate is covered by the Phase 2 unit test; span-count reduction is confirmed via App Insights query.
+- not e2e-covered: telemetry export = SDK exporter pipeline, not visible to extension-host e2e harness; no e2e/integration test refs traceFlagStatusBar telemetry. gate correctness = Phase 2 unit test.

--- a/.claude/plans/W-23290053.md
+++ b/.claude/plans/W-23290053.md
@@ -1,0 +1,39 @@
+# W-23290053 — Throttle ApexLog.traceFlagStatusBar.refresh telemetry span
+
+## Context
+- App Insights noise: `ApexLog.traceFlagStatusBar.refresh` = 21.9M spans/24h (~18% ingestion, ~57% deps table)
+- Source: `packages/salesforcedx-vscode-apex-log/src/statusBar/traceFlagStatusBar.ts:116` — `refresh` wrapped `Effect.fn('ApexLog.traceFlagStatusBar.refresh', { root: true })`
+- `root: true` → top-level span → passes `isSpanValidForProductionTelemetry` (`packages/salesforcedx-vscode-services/src/observability/spanUtils.ts:20`) → exported to App Insights
+- Fires per stream tick (org change, pubsub, flag change, collector change, 1-min poll) after 300ms debounce; every tick emits span regardless of render diff
+- Precedent: `sourceTrackingStatusBar.ts:22` — identical status-bar refresh already tagged `telemetryIgnore: true`; same for `logAutoCollect.ts:37`, `deployOnSaveService.ts:55`, `executeAnonymousService.ts:191`
+- `telemetryIgnore: true` → `isTelemetryIgnored` true → span dropped from production telemetry (kept for local span-file capture/traces)
+
+## Phases
+
+### Phase 1 — tag refresh span telemetryIgnore
+- Edit `traceFlagStatusBar.ts:116`: `Effect.fn('ApexLog.traceFlagStatusBar.refresh', { root: true, attributes: { telemetryIgnore: true } })`
+- Matches sourceTrackingStatusBar pattern
+- Files: `packages/salesforcedx-vscode-apex-log/src/statusBar/traceFlagStatusBar.ts`
+- Commit: `fix(apex-log): drop traceFlagStatusBar.refresh from production telemetry - W-23290053`
+
+### Phase 2 — unit-test the telemetryIgnore gate (new coverage)
+- No test currently exercises `isSpanValidForProductionTelemetry`; `spanUtils.ts` has zero test coverage. Add it so the safety net actually exists.
+- New file: `packages/salesforcedx-vscode-services/test/jest/observability/spanUtils.test.ts` (matches existing jest layout, e.g. `spanTransformProcessor.test.ts`)
+- `isSpanValidForProductionTelemetry` is exported + pure — test with a minimal `ReadableSpan`-shaped stub (only `attributes` + `parentSpanContext` are read):
+  - `telemetryIgnore: true` on a top-level span → returns `false` (the behavior this plan relies on)
+  - top-level span without `telemetryIgnore` → returns `true` (guards against over-suppression / regression of the gate)
+  - `command` attr present but `telemetryIgnore: true` → returns `false` (ignore wins over command)
+- Commit: `test(services): cover isSpanValidForProductionTelemetry telemetryIgnore gate - W-23290053`
+
+## Skills to apply
+- typescript — coding standards for .ts edit + new test
+- effect-best-practices — verify `Effect.fn` opts shape
+- span-file-export — confirm ignored spans still captured locally, only prod-excluded
+- verification — build/lint/test gate
+
+## Verification
+- Phase 2 jest test asserts the `telemetryIgnore` gate directly (the real safety net; not previously present)
+- typecheck + lint pass (`npm run compile` / eslint on apex-log + services pkgs)
+- existing `traceFlagStatusBar.test.ts` still green (no refresh-span assertions)
+- manual/optional: query-app-insights post-ship — confirm span count drops (not gated in CI)
+- not e2e-covered: telemetry export happens in the SDK exporter pipeline, not observable through the extension-host e2e harness; no e2e/integration test references traceFlagStatusBar telemetry. Correctness of the gate is covered by the Phase 2 unit test; span-count reduction is confirmed via App Insights query.

--- a/packages/salesforcedx-vscode-apex-log/src/statusBar/traceFlagStatusBar.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/statusBar/traceFlagStatusBar.ts
@@ -113,26 +113,26 @@ export const createTraceFlagStatusBar = () =>
     yield* Effect.sleep(Duration.infinity);
   });
 
-const refresh = Effect.fn('ApexLog.traceFlagStatusBar.refresh', { root: true })(function* (
-  statusBarItem: vscode.StatusBarItem
-) {
-  const api = yield* (yield* ExtensionProviderService).getServicesApi;
-  const ref = yield* api.services.TargetOrgRef();
-  const { orgId, userId } = yield* SubscriptionRef.get(ref);
-  if (!orgId || !userId) {
-    return statusBarItem.hide();
-  }
-  const traceFlagsRef = yield* CurrentTraceFlags;
-  const activeRecords = (yield* SubscriptionRef.get(traceFlagsRef))
-    .filter(isTraceFlagActive)
-    .toSorted(byExpirationDesc);
+const refresh = Effect.fn('ApexLog.traceFlagStatusBar.refresh', { root: true, attributes: { telemetryIgnore: true } })(
+  function* (statusBarItem: vscode.StatusBarItem) {
+    const api = yield* (yield* ExtensionProviderService).getServicesApi;
+    const ref = yield* api.services.TargetOrgRef();
+    const { orgId, userId } = yield* SubscriptionRef.get(ref);
+    if (!orgId || !userId) {
+      return statusBarItem.hide();
+    }
+    const traceFlagsRef = yield* CurrentTraceFlags;
+    const activeRecords = (yield* SubscriptionRef.get(traceFlagsRef))
+      .filter(isTraceFlagActive)
+      .toSorted(byExpirationDesc);
 
-  const collectorRef = yield* LogCollectorStateRef;
-  const collectorState = yield* SubscriptionRef.get(collectorRef);
-  statusBarItem.tooltip = buildTooltip(activeRecords, collectorState, userId);
-  statusBarItem.text = getStatusBarText(collectorState, selectCurrentUserFlag(activeRecords, userId));
-  statusBarItem.show();
-});
+    const collectorRef = yield* LogCollectorStateRef;
+    const collectorState = yield* SubscriptionRef.get(collectorRef);
+    statusBarItem.tooltip = buildTooltip(activeRecords, collectorState, userId);
+    statusBarItem.text = getStatusBarText(collectorState, selectCurrentUserFlag(activeRecords, userId));
+    statusBarItem.show();
+  }
+);
 
 const hasCurrentUserTraceFlag = (records: TraceFlagItem[], userId: string) =>
   records.some(r => r.logType === 'DEVELOPER_LOG' && r.tracedEntityId === userId);

--- a/packages/salesforcedx-vscode-services/test/jest/observability/spanUtils.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/observability/spanUtils.test.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { type Attributes } from '@opentelemetry/api';
+import { type ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { isSpanValidForProductionTelemetry } from '../../../src/observability/spanUtils';
+
+// isSpanValidForProductionTelemetry only reads attributes + parentSpanContext (undefined => top-level)
+const makeSpan = (attributes: Attributes): ReadableSpan =>
+  ({ attributes, parentSpanContext: undefined }) as unknown as ReadableSpan;
+
+describe('isSpanValidForProductionTelemetry', () => {
+  it('drops a top-level span flagged telemetryIgnore', () => {
+    expect(isSpanValidForProductionTelemetry(makeSpan({ telemetryIgnore: true }))).toBe(false);
+  });
+
+  it('keeps a top-level span without telemetryIgnore', () => {
+    expect(isSpanValidForProductionTelemetry(makeSpan({}))).toBe(true);
+  });
+
+  it('drops a command span flagged telemetryIgnore (ignore wins over command)', () => {
+    expect(isSpanValidForProductionTelemetry(makeSpan({ command: 'sf.some.command', telemetryIgnore: true }))).toBe(
+      false
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `ApexLog.traceFlagStatusBar.refresh` emitted a top-level span on every status-bar refresh tick (org change, pubsub, flag change, collector change, 1-min poll), accounting for ~21.9M spans/24h (~18% ingestion, ~57% deps table) in App Insights.
- Tag the span `telemetryIgnore: true`, matching existing precedent (`sourceTrackingStatusBar.ts`, `logAutoCollect.ts`, `deployOnSaveService.ts`, `executeAnonymousService.ts`) so it's dropped from production telemetry but still captured for local span-file traces.
- Add unit coverage for `isSpanValidForProductionTelemetry`'s `telemetryIgnore` gate, which previously had zero test coverage.

## Plan
[.claude/plans/W-23290053.md](../blob/sm/W-23290053-throttle-apexlog-traceflagstatusbar-refr/.claude/plans/W-23290053.md)

## Test plan
- Manual/optional post-ship: query App Insights to confirm the span count for `ApexLog.traceFlagStatusBar.refresh` drops (not gated in CI).

### What issues does this PR fix or reference?
@W-23290053@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002dnDA0YAM/view