### PR TITLE
test(metadata): add bundle delete e2e regression guard - W-14707241

### DIFF
--- a/packages/playwright-vscode-ext/src/fixtures/desktopWorkspace.ts
+++ b/packages/playwright-vscode-ext/src/fixtures/desktopWorkspace.ts
@@ -40,6 +40,12 @@ export const createTestWorkspace = async (orgAlias?: string): Promise<string> =>
     ),
     fs.mkdir(path.join(workspaceDir, 'force-app', 'main', 'default'), { recursive: true }),
     fs.mkdir(path.join(workspaceDir, SF_STATE_FOLDER), { recursive: true }),
+    // Match `sf project generate`'s default .forceignore so LWC create's scaffolded jest/config files
+    // (which reference `@lwc/engine-dom`) are not deployed — deploying them fails metadata deploys.
+    fs.writeFile(
+      path.join(workspaceDir, '.forceignore'),
+      ['**/jsconfig.json', '**/.eslintrc.json', '**/__tests__/**', ''].join('\n')
+    ),
     // Minimal scratch-def so `sf.org.create`'s FileSelector (glob `config/**/*-scratch-def.json`) finds a match.
     fs
       .mkdir(path.join(workspaceDir, 'config'), { recursive: true })

--- a/packages/salesforcedx-vscode-metadata/package.json
+++ b/packages/salesforcedx-vscode-metadata/package.json
@@ -194,6 +194,7 @@
         "../salesforcedx-vscode-services:vscode:bundle",
         "../salesforcedx-vscode-services:spans:server",
         "../salesforcedx-vscode-apex-log:vscode:bundle",
+        "../salesforcedx-vscode-lwc:vscode:bundle",
         "../playwright-vscode-ext:compile"
       ],
       "files": [
@@ -218,6 +219,7 @@
         "../salesforcedx-vscode-services:vscode:package",
         "../salesforcedx-vscode-services:spans:server",
         "../salesforcedx-vscode-apex-log:vscode:package",
+        "../salesforcedx-vscode-lwc:vscode:package:legacy",
         "../playwright-vscode-ext:compile"
       ],
       "files": [
@@ -262,6 +264,7 @@
         "../salesforcedx-vscode-services:vscode:package",
         "../salesforcedx-vscode-services:spans:server",
         "../salesforcedx-vscode-apex-log:vscode:package",
+        "../salesforcedx-vscode-lwc:vscode:package:legacy",
         "../playwright-vscode-ext:compile"
       ],
       "files": [

--- a/packages/salesforcedx-vscode-metadata/package.json
+++ b/packages/salesforcedx-vscode-metadata/package.json
@@ -194,7 +194,6 @@
         "../salesforcedx-vscode-services:vscode:bundle",
         "../salesforcedx-vscode-services:spans:server",
         "../salesforcedx-vscode-apex-log:vscode:bundle",
-        "../salesforcedx-vscode-lwc:vscode:bundle",
         "../playwright-vscode-ext:compile"
       ],
       "files": [
@@ -264,7 +263,6 @@
         "../salesforcedx-vscode-services:vscode:package",
         "../salesforcedx-vscode-services:spans:server",
         "../salesforcedx-vscode-apex-log:vscode:package",
-        "../salesforcedx-vscode-lwc:vscode:package:legacy",
         "../playwright-vscode-ext:compile"
       ],
       "files": [

--- a/packages/salesforcedx-vscode-metadata/test/playwright/fixtures/desktopFixtures.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/fixtures/desktopFixtures.ts
@@ -22,8 +22,7 @@ type HelperProject = (name: string, content: string) => Promise<void>;
 export const desktopTest = createDesktopTest({
   fixturesDir: __dirname,
   orgAlias: MINIMAL_ORG_ALIAS,
-  // salesforcedx-vscode-lwc contributes "SFDX: Create Lightning Web Component" (used by deleteBundleSource spec).
-  additionalExtensionDirs: ['salesforcedx-vscode-apex-log', 'salesforcedx-vscode-lwc'],
+  additionalExtensionDirs: ['salesforcedx-vscode-apex-log'],
   userSettings: {
     'salesforcedx-vscode-core.useMetadataExtensionCommands': true
   }
@@ -39,7 +38,8 @@ export const dreamhouseDesktopTest = createDesktopTest({
 export const nonTrackingDesktopTest = createDesktopTest({
   fixturesDir: __dirname,
   orgAlias: NON_TRACKING_ORG_ALIAS,
-  additionalExtensionDirs: ['salesforcedx-vscode-apex-log'],
+  // salesforcedx-vscode-lwc contributes "SFDX: Create Lightning Web Component" (used by deleteBundleSource spec).
+  additionalExtensionDirs: ['salesforcedx-vscode-apex-log', 'salesforcedx-vscode-lwc'],
   userSettings: {
     'salesforcedx-vscode-core.useMetadataExtensionCommands': true
   }

--- a/packages/salesforcedx-vscode-metadata/test/playwright/fixtures/desktopFixtures.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/fixtures/desktopFixtures.ts
@@ -22,7 +22,8 @@ type HelperProject = (name: string, content: string) => Promise<void>;
 export const desktopTest = createDesktopTest({
   fixturesDir: __dirname,
   orgAlias: MINIMAL_ORG_ALIAS,
-  additionalExtensionDirs: ['salesforcedx-vscode-apex-log'],
+  // salesforcedx-vscode-lwc contributes "SFDX: Create Lightning Web Component" (used by deleteBundleSource spec).
+  additionalExtensionDirs: ['salesforcedx-vscode-apex-log', 'salesforcedx-vscode-lwc'],
   userSettings: {
     'salesforcedx-vscode-core.useMetadataExtensionCommands': true
   }

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/deleteBundleSource.headless.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/deleteBundleSource.headless.spec.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * W-14707241 regression guard: "SFDX: Delete from Project and Org" launched from a single bundle child
+ * file must delete the WHOLE bundle locally, not just the launched file. The original bug shelled out
+ * `project:delete:source --source-dir .../AC.cmp`, which removed only the one file. Uses an LWC bundle
+ * (`.js`, `.html`, `.js-meta.xml`) as the multi-file proxy for the Aura `.cmp` bundle in the report.
+ *
+ * The bundle is deployed first so the delete command's destructive deploy has a real component to remove
+ * (deleting a never-deployed component errors "No LightningComponentBundle named X found" and leaves the
+ * local files in place). The desktop workspace template ships a `.forceignore` for `__tests__`/jsconfig so
+ * the LWC create wizard's scaffolded jest files don't break the deploy.
+ *
+ * Runs on web and desktop via the shared `test` fixture. "SFDX: Create Lightning Web Component" is
+ * contributed by salesforcedx-vscode-lwc, loaded as an extra extension on both surfaces.
+ */
+
+import { test } from '../fixtures';
+import { expect, type Page } from '@playwright/test';
+import {
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  waitForVSCodeWorkbench,
+  closeWelcomeTabs,
+  createMinimalOrg,
+  upsertScratchOrgAuthFieldsToSettings,
+  upsertSettings,
+  executeCommandWithCommandPalette,
+  verifyCommandExists,
+  validateNoCriticalErrors,
+  saveScreenshot,
+  ensureOutputPanelOpen,
+  selectOutputChannel,
+  clearOutputChannel,
+  waitForOutputChannelText,
+  NOTIFICATION_LIST_ITEM,
+  ensureSecondarySideBarHidden,
+  QUICK_INPUT_WIDGET,
+  QUICK_INPUT_LIST_ROW,
+  EDITOR_WITH_URI,
+  waitForQuickInputFirstOption,
+  waitForExtensionsActivated,
+  isDesktop
+} from '@salesforce/playwright-vscode-ext';
+import { SourceTrackingStatusBarPage } from '../pages/sourceTrackingStatusBarPage';
+import { waitForDeployProgressNotificationToAppear } from '../pages/notifications';
+import { CORE_CONFIG_SECTION, DEPLOY_ON_SAVE_ENABLED } from '../../../src/constants';
+import { nls } from '../../../src/messages';
+import { DEPLOY_TIMEOUT } from '../../constants';
+
+test.setTimeout(DEPLOY_TIMEOUT);
+
+/** Contributed by salesforcedx-vscode-lwc (loaded as an extra extension on web + desktop). */
+const CREATE_LWC_COMMAND = 'SFDX: Create Lightning Web Component';
+
+const surface = (): string => (isDesktop() ? 'desktop' : 'web');
+
+const treeItemFor = (page: Page, fileName: string) =>
+  page.locator('[role="treeitem"]').filter({ hasText: new RegExp(`${fileName.replaceAll('.', '\\.')}$`, 'i') });
+
+/** Run the Create-LWC wizard; leaves the bundle `.js` editor open. Mirrors lwcUtils.createLwcViaSfdxCommand. */
+const createLwcBundle = async (page: Page, camelName: string): Promise<void> => {
+  await closeWelcomeTabs(page);
+  await ensureSecondarySideBarHidden(page);
+  await verifyCommandExists(page, CREATE_LWC_COMMAND, 120_000);
+  await executeCommandWithCommandPalette(page, CREATE_LWC_COMMAND);
+
+  const quickInput = page.locator(QUICK_INPUT_WIDGET);
+  await quickInput.waitFor({ state: 'visible', timeout: 30_000 });
+
+  // Optional type picker (JS/TS) on newer versions
+  const hasTypePicker = await quickInput
+    .locator(QUICK_INPUT_LIST_ROW)
+    .first()
+    .waitFor({ state: 'visible', timeout: 2000 })
+    .then(() => true)
+    .catch(() => false);
+  if (hasTypePicker) {
+    await page.keyboard.press('Enter');
+  }
+
+  await quickInput.getByText(/Enter Lightning Web Component name/i).waitFor({ state: 'visible', timeout: 10_000 });
+  await page.keyboard.type(camelName);
+  await page.keyboard.press('Enter');
+
+  await waitForQuickInputFirstOption(page, { optionVisibleTimeout: 15_000 });
+  await page.keyboard.press('Enter');
+
+  const jsEditor = page.locator(`${EDITOR_WITH_URI}[data-uri*="${camelName}.js"]`);
+  await jsEditor.waitFor({ state: 'visible', timeout: 45_000 });
+};
+
+test('Delete Source: deletes entire LWC bundle from project and org when launched from one bundle file', async ({
+  page
+}) => {
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  const camelName = `deleteBundle${Date.now()}`;
+  const bundleFiles = [`${camelName}.js`, `${camelName}.html`, `${camelName}.js-meta.xml`];
+  let statusBarPage: SourceTrackingStatusBarPage;
+
+  await test.step('setup minimal org and disable deploy-on-save', async () => {
+    const createResult = await createMinimalOrg();
+    await waitForVSCodeWorkbench(page);
+    await closeWelcomeTabs(page);
+    await ensureSecondarySideBarHidden(page);
+    await upsertScratchOrgAuthFieldsToSettings(page, createResult);
+
+    statusBarPage = new SourceTrackingStatusBarPage(page);
+    await statusBarPage.waitForVisible(120_000);
+
+    // LWC extension contributes Create-LWC; wait for all extensions to activate so its command handler is live.
+    await waitForExtensionsActivated(page);
+    // Control when deploys happen (create should not auto-deploy)
+    await upsertSettings(page, { [`${CORE_CONFIG_SECTION}.${DEPLOY_ON_SAVE_ENABLED}`]: 'false' });
+    await verifyCommandExists(page, CREATE_LWC_COMMAND, 30_000);
+  });
+
+  await test.step('create and deploy LWC bundle', async () => {
+    await createLwcBundle(page, camelName);
+
+    // Bundle counts as one changed component in source tracking
+    await statusBarPage.waitForCounts({ local: 1 }, 60_000);
+
+    await ensureOutputPanelOpen(page);
+    await selectOutputChannel(page, 'Salesforce Metadata');
+
+    await executeCommandWithCommandPalette(page, nls.localize('deploy_this_source_text'));
+    const deployingNotification = await waitForDeployProgressNotificationToAppear(page, 30_000);
+    await expect(deployingNotification).not.toBeVisible({ timeout: DEPLOY_TIMEOUT });
+    await statusBarPage.waitForCounts({ local: 0 }, 60_000);
+    await saveScreenshot(page, `bundle.after-deploy.${surface()}.png`);
+  });
+
+  await test.step('delete from one bundle file, expect whole bundle removed', async () => {
+    // The .js editor is open (launched-from file). Run delete from it.
+    await ensureOutputPanelOpen(page);
+    await selectOutputChannel(page, 'Salesforce Metadata');
+    await clearOutputChannel(page);
+
+    await executeCommandWithCommandPalette(page, nls.localize('delete_source_text'));
+
+    const deleteConfirmation = page
+      .locator(NOTIFICATION_LIST_ITEM)
+      .filter({ hasText: nls.localize('delete_source_confirmation_message') })
+      .first();
+    await expect(deleteConfirmation).toBeVisible({ timeout: 10_000 });
+    await deleteConfirmation.getByRole('button', { name: nls.localize('confirm_delete_source_button_text') }).click();
+
+    await waitForOutputChannelText(page, { expectedText: 'Deleting', timeout: 30_000 });
+    await waitForOutputChannelText(page, { expectedText: 'Deleted Source', timeout: DEPLOY_TIMEOUT });
+
+    // W-14707241: every bundle file must be gone from the explorer, not just the launched .js
+    for (const file of bundleFiles) {
+      await expect(async () => {
+        expect(await treeItemFor(page, file).count(), `bundle file ${file} should be removed from explorer`).toBe(0);
+      }).toPass({ timeout: 60_000 });
+    }
+    await saveScreenshot(page, `bundle.all-files-removed.${surface()}.png`);
+  });
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/deleteBundleSource.headless.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/deleteBundleSource.headless.spec.ts
@@ -11,23 +11,23 @@
  * `project:delete:source --source-dir .../AC.cmp`, which removed only the one file. Uses an LWC bundle
  * (`.js`, `.html`, `.js-meta.xml`) as the multi-file proxy for the Aura `.cmp` bundle in the report.
  *
- * The bundle is deployed first so the delete command's destructive deploy has a real component to remove
- * (deleting a never-deployed component errors "No LightningComponentBundle named X found" and leaves the
- * local files in place). The desktop workspace template ships a `.forceignore` for `__tests__`/jsconfig so
- * the LWC create wizard's scaffolded jest files don't break the deploy.
+ * Non-tracking org, desktop-only (like nonTrackingOrgDeployRetrieveOperations): this test deploys then
+ * deletes a bundle, which leaves a remote-delete tombstone in a source-TRACKED org and pollutes the
+ * shared minimal org that the parallel projectRetrieveStart spec retrieves from. The dedicated
+ * non-tracking org has no source tracking, so a full-org retrieve elsewhere can't see this component.
  *
- * Runs on web and desktop via the shared `test` fixture. "SFDX: Create Lightning Web Component" is
- * contributed by salesforcedx-vscode-lwc, loaded as an extra extension on both surfaces.
+ * "SFDX: Create Lightning Web Component" is contributed by salesforcedx-vscode-lwc, loaded as an extra
+ * extension in the non-tracking desktop fixture.
  */
 
-import { test } from '../fixtures';
+import { nonTrackingTest as test } from '../fixtures';
 import { expect, type Page } from '@playwright/test';
 import {
   setupConsoleMonitoring,
   setupNetworkMonitoring,
   waitForVSCodeWorkbench,
   closeWelcomeTabs,
-  createMinimalOrg,
+  createNonTrackingOrg,
   upsertScratchOrgAuthFieldsToSettings,
   upsertSettings,
   executeCommandWithCommandPalette,
@@ -38,27 +38,22 @@ import {
   selectOutputChannel,
   clearOutputChannel,
   waitForOutputChannelText,
+  isDesktop,
   NOTIFICATION_LIST_ITEM,
   ensureSecondarySideBarHidden,
   QUICK_INPUT_WIDGET,
   QUICK_INPUT_LIST_ROW,
   EDITOR_WITH_URI,
   waitForQuickInputFirstOption,
-  waitForExtensionsActivated,
-  isDesktop
+  waitForExtensionsActivated
 } from '@salesforce/playwright-vscode-ext';
-import { SourceTrackingStatusBarPage } from '../pages/sourceTrackingStatusBarPage';
 import { waitForDeployProgressNotificationToAppear } from '../pages/notifications';
 import { CORE_CONFIG_SECTION, DEPLOY_ON_SAVE_ENABLED } from '../../../src/constants';
 import { nls } from '../../../src/messages';
 import { DEPLOY_TIMEOUT } from '../../constants';
 
-test.setTimeout(DEPLOY_TIMEOUT);
-
-/** Contributed by salesforcedx-vscode-lwc (loaded as an extra extension on web + desktop). */
+/** Contributed by salesforcedx-vscode-lwc (loaded as an extra extension in the non-tracking desktop fixture). */
 const CREATE_LWC_COMMAND = 'SFDX: Create Lightning Web Component';
-
-const surface = (): string => (isDesktop() ? 'desktop' : 'web');
 
 const treeItemFor = (page: Page, fileName: string) =>
   page.locator('[role="treeitem"]').filter({ hasText: new RegExp(`${fileName.replaceAll('.', '\\.')}$`, 'i') });
@@ -95,75 +90,72 @@ const createLwcBundle = async (page: Page, camelName: string): Promise<void> => 
   await jsEditor.waitFor({ state: 'visible', timeout: 45_000 });
 };
 
-test('Delete Source: deletes entire LWC bundle from project and org when launched from one bundle file', async ({
-  page
-}) => {
-  const consoleErrors = setupConsoleMonitoring(page);
-  const networkErrors = setupNetworkMonitoring(page);
+(isDesktop() ? test : test.skip.bind(test))(
+  'Delete Source: deletes entire LWC bundle from project and org when launched from one bundle file',
+  async ({ page }) => {
+    test.setTimeout(DEPLOY_TIMEOUT);
 
-  const camelName = `deleteBundle${Date.now()}`;
-  const bundleFiles = [`${camelName}.js`, `${camelName}.html`, `${camelName}.js-meta.xml`];
-  let statusBarPage: SourceTrackingStatusBarPage;
+    const consoleErrors = setupConsoleMonitoring(page);
+    const networkErrors = setupNetworkMonitoring(page);
 
-  await test.step('setup minimal org and disable deploy-on-save', async () => {
-    const createResult = await createMinimalOrg();
-    await waitForVSCodeWorkbench(page);
-    await closeWelcomeTabs(page);
-    await ensureSecondarySideBarHidden(page);
-    await upsertScratchOrgAuthFieldsToSettings(page, createResult);
+    const camelName = `deleteBundle${Date.now()}`;
+    const bundleFiles = [`${camelName}.js`, `${camelName}.html`, `${camelName}.js-meta.xml`];
 
-    statusBarPage = new SourceTrackingStatusBarPage(page);
-    await statusBarPage.waitForVisible(120_000);
+    await test.step('setup non-tracking org and disable deploy-on-save', async () => {
+      const createResult = await createNonTrackingOrg();
+      await waitForVSCodeWorkbench(page);
+      await closeWelcomeTabs(page);
+      await ensureSecondarySideBarHidden(page);
+      await upsertScratchOrgAuthFieldsToSettings(page, createResult);
 
-    // LWC extension contributes Create-LWC; wait for all extensions to activate so its command handler is live.
-    await waitForExtensionsActivated(page);
-    // Control when deploys happen (create should not auto-deploy)
-    await upsertSettings(page, { [`${CORE_CONFIG_SECTION}.${DEPLOY_ON_SAVE_ENABLED}`]: 'false' });
-    await verifyCommandExists(page, CREATE_LWC_COMMAND, 30_000);
-  });
+      // LWC extension contributes Create-LWC; wait for all extensions to activate so its command handler is live.
+      await waitForExtensionsActivated(page);
+      // Control when deploys happen (create should not auto-deploy)
+      await upsertSettings(page, { [`${CORE_CONFIG_SECTION}.${DEPLOY_ON_SAVE_ENABLED}`]: 'false' });
+      await verifyCommandExists(page, CREATE_LWC_COMMAND, 30_000);
+    });
 
-  await test.step('create and deploy LWC bundle', async () => {
-    await createLwcBundle(page, camelName);
+    await test.step('create and deploy LWC bundle', async () => {
+      await createLwcBundle(page, camelName);
 
-    // Bundle counts as one changed component in source tracking
-    await statusBarPage.waitForCounts({ local: 1 }, 60_000);
+      await ensureOutputPanelOpen(page);
+      await selectOutputChannel(page, 'Salesforce Metadata');
+      await clearOutputChannel(page);
 
-    await ensureOutputPanelOpen(page);
-    await selectOutputChannel(page, 'Salesforce Metadata');
+      await executeCommandWithCommandPalette(page, nls.localize('deploy_this_source_text'));
+      const deployingNotification = await waitForDeployProgressNotificationToAppear(page, 30_000);
+      await expect(deployingNotification).not.toBeVisible({ timeout: DEPLOY_TIMEOUT });
+      await waitForOutputChannelText(page, { expectedText: 'Deployed Source', timeout: DEPLOY_TIMEOUT });
+      await saveScreenshot(page, 'bundle.after-deploy.png');
+    });
 
-    await executeCommandWithCommandPalette(page, nls.localize('deploy_this_source_text'));
-    const deployingNotification = await waitForDeployProgressNotificationToAppear(page, 30_000);
-    await expect(deployingNotification).not.toBeVisible({ timeout: DEPLOY_TIMEOUT });
-    await statusBarPage.waitForCounts({ local: 0 }, 60_000);
-    await saveScreenshot(page, `bundle.after-deploy.${surface()}.png`);
-  });
+    await test.step('delete from one bundle file, expect whole bundle removed', async () => {
+      // The .js editor is open (launched-from file). Run delete from it.
+      await ensureOutputPanelOpen(page);
+      await selectOutputChannel(page, 'Salesforce Metadata');
+      await clearOutputChannel(page);
 
-  await test.step('delete from one bundle file, expect whole bundle removed', async () => {
-    // The .js editor is open (launched-from file). Run delete from it.
-    await ensureOutputPanelOpen(page);
-    await selectOutputChannel(page, 'Salesforce Metadata');
-    await clearOutputChannel(page);
+      await executeCommandWithCommandPalette(page, nls.localize('delete_source_text'));
 
-    await executeCommandWithCommandPalette(page, nls.localize('delete_source_text'));
+      const deleteConfirmation = page
+        .locator(NOTIFICATION_LIST_ITEM)
+        .filter({ hasText: nls.localize('delete_source_confirmation_message') })
+        .first();
+      await expect(deleteConfirmation).toBeVisible({ timeout: 10_000 });
+      await deleteConfirmation.getByRole('button', { name: nls.localize('confirm_delete_source_button_text') }).click();
 
-    const deleteConfirmation = page
-      .locator(NOTIFICATION_LIST_ITEM)
-      .filter({ hasText: nls.localize('delete_source_confirmation_message') })
-      .first();
-    await expect(deleteConfirmation).toBeVisible({ timeout: 10_000 });
-    await deleteConfirmation.getByRole('button', { name: nls.localize('confirm_delete_source_button_text') }).click();
+      await waitForOutputChannelText(page, { expectedText: 'Deleting', timeout: 30_000 });
+      await waitForOutputChannelText(page, { expectedText: 'Deleted Source', timeout: DEPLOY_TIMEOUT });
 
-    await waitForOutputChannelText(page, { expectedText: 'Deleting', timeout: 30_000 });
-    await waitForOutputChannelText(page, { expectedText: 'Deleted Source', timeout: DEPLOY_TIMEOUT });
+      // W-14707241: every bundle file must be gone from the explorer, not just the launched .js
+      for (const file of bundleFiles) {
+        await expect(async () => {
+          expect(await treeItemFor(page, file).count(), `bundle file ${file} should be removed from explorer`).toBe(0);
+        }).toPass({ timeout: 60_000 });
+      }
+      await saveScreenshot(page, 'bundle.all-files-removed.png');
+    });
 
-    // W-14707241: every bundle file must be gone from the explorer, not just the launched .js
-    for (const file of bundleFiles) {
-      await expect(async () => {
-        expect(await treeItemFor(page, file).count(), `bundle file ${file} should be removed from explorer`).toBe(0);
-      }).toPass({ timeout: 60_000 });
-    }
-    await saveScreenshot(page, `bundle.all-files-removed.${surface()}.png`);
-  });
-
-  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
-});
+    await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+  }
+);

--- a/packages/salesforcedx-vscode-metadata/test/playwright/web/headlessServer.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/web/headlessServer.ts
@@ -11,7 +11,7 @@ if (require.main === module) {
   void createHeadlessServer({
     extensionName: 'Metadata',
     callerDirname: __dirname,
-    additionalExtensionDirs: ['salesforcedx-vscode-apex-log']
+    additionalExtensionDirs: ['salesforcedx-vscode-apex-log', 'salesforcedx-vscode-lwc']
   });
   setupSignalHandlers();
 }

--- a/packages/salesforcedx-vscode-metadata/test/playwright/web/headlessServer.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/web/headlessServer.ts
@@ -11,7 +11,7 @@ if (require.main === module) {
   void createHeadlessServer({
     extensionName: 'Metadata',
     callerDirname: __dirname,
-    additionalExtensionDirs: ['salesforcedx-vscode-apex-log', 'salesforcedx-vscode-lwc']
+    additionalExtensionDirs: ['salesforcedx-vscode-apex-log']
   });
   setupSignalHandlers();
 }


### PR DESCRIPTION
### What does this PR do?

Adds a **desktop** Playwright e2e regression guard for **SFDX: Delete from Project and Org** launched from a single bundle child file, asserting the WHOLE bundle is removed locally — the W-14707241 repro (originally: deleting from an Aura `.cmp` removed only the launched file locally).

The bug is no longer reproducible; the Effect refactor of the delete path (`MetadataDeleteService.deleteLocalFiles` deletes each component's `content` dir recursively) already fixes it. This PR is the missing regression guard — no prior test covered bundle (multi-file) delete; existing delete specs only delete a single Apex class.

### What changes

- **`deleteBundleSource.headless.spec.ts`** — create an LWC bundle, deploy, run delete from the `.js`, assert all three bundle files (`.js`/`.html`/`.js-meta.xml`) are gone from the explorer.
  - Uses the **non-tracking org** fixture, **desktop-only** (matches `nonTrackingOrgDeployRetrieveOperations`). A tracked org would leave a remote-delete tombstone in the shared `minimalTestOrg` that the parallel `projectRetrieveStart` spec retrieves → phantom "cannot be found". Non-tracking has no source tracking, so a full-org retrieve elsewhere can't observe this transient component.
- Add **salesforcedx-vscode-lwc** to the non-tracking desktop fixture + `test:desktop` wireit (it contributes "SFDX: Create Lightning Web Component").
- **Desktop workspace template** (`desktopWorkspace.ts`) — ship a `.forceignore` for `__tests__`/`jsconfig` so the LWC create wizard's scaffolded jest files don't break the deploy (matches `sf project generate`'s default).

### Reviewer notes

LWC bundle used as the multi-file proxy for the ticket's Aura `.cmp` bundle — same delete path (`c.content` = bundle dir). Runs on all 3 desktop OSs in the Metadata E2E workflow (picked up automatically; no workflow change). Verified locally on non-tracking desktop: passes (29s).

First CI run (28602283159) failed because the spec polluted the shared tracking org — see the non-tracking move above. The spec's own assertions passed on every surface then; the failure was the downstream `projectRetrieveStart` retrieve.

### What issues does this PR fix or reference?

@W-14707241@