### PR TITLE
test(eslint-local-rules): enforce single effect version + companion peer ranges - W-23290052

### DIFF
--- a/.claude/plans/W-23290052.md
+++ b/.claude/plans/W-23290052.md
@@ -6,7 +6,7 @@
 - Root cause: `effect/dist/esm/internal/fiberRuntime.js:1143` warns when value tag `_V` !== runtime `getCurrentVersion()` = DUPLICATE-COPY problem, not semver-range.
 - Source already aligned: all 19 workspace pkgs declare `effect ^3.21.2`; 1 hoisted copy (`node_modules/effect@3.21.2`); 0 nested copies today. Field skew (3.19/3.20/3.21) = older shipped release trains — no lint retro-fixes those.
 - Goal: prevent regression + catch a 2nd resolved copy going forward. NO exact-pin, NO npm overrides — enforce via consistency TEST only.
-- Constraint: NO new dep. Use `glob` (root devDep) + `semver` (root dep), both hoisted + resolvable from `packages/eslint-local-rules`.
+- Constraint: NO new dep. Use `node:fs` `globSync` (stable Node 22.17+/24 = dev+CI runtime; engines floor is VS Code runtime, N/A to a dev-only test) + `semver` (root dep, hoisted + resolvable from `packages/eslint-local-rules`).
 
 ### Placement decision
 - Home = `packages/eslint-local-rules/test/` as a standalone jest test (NOT an eslint rule — cross-pkg fs invariant doesn't fit eslint single-file model).
@@ -31,7 +31,7 @@
   1. **specs identical**: glob `packages/*/package.json` from repo root; collect `effect` from deps+devDeps; assert all distinct specs === 1 (msg lists offenders).
   2. **one resolved copy**: glob `**/node_modules/effect/package.json` from repo root (root + nested `packages/*/node_modules`); read `.version`; assert distinct set size === 1. Guards npm un-hoist on conflict — the ONLY dup-copy trigger. NOT top-level-only, NOT `require.resolve` (misses un-hoisted copy).
   3. **companion peers satisfied**: glob `**/node_modules/@effect/*/package.json`; for each w/ `peerDependencies.effect`, assert resolved effect version `semver.satisfies` peer range (msg names pkg+range). Skips `@effect/*` w/o effect peer (eslint-plugin, language-service).
-- Use `glob` sync + `node:fs`/`node:path`; dedupe glob results across resolved copies by version string.
+- Use `fs.globSync` + `node:path`; dedupe glob results across resolved copies by version string.
 - Verify: `npm run test --workspace packages/eslint-local-rules` (or wireit `eslint-local-rules:test`) green.
 - Commit: `test(eslint-local-rules): enforce single effect version + companion peer ranges - W-23290052`
 

--- a/.claude/plans/W-23290052.md
+++ b/.claude/plans/W-23290052.md
@@ -1,0 +1,51 @@
+# W-23290052 — Align Effect dep versions across VSCode extensions
+
+## Context
+
+- App Insights (test-otel-effect) hit 100GB daily cap. Effect logs "Executing an Effect versioned X with a Runtime of version Y" on every exec when 2 `effect` copies load in 1 process → 56.3M traces/24h.
+- Root cause: `effect/dist/esm/internal/fiberRuntime.js:1143` warns when value tag `_V` !== runtime `getCurrentVersion()` = DUPLICATE-COPY problem, not semver-range.
+- Source already aligned: all 19 workspace pkgs declare `effect ^3.21.2`; 1 hoisted copy (`node_modules/effect@3.21.2`); 0 nested copies today. Field skew (3.19/3.20/3.21) = older shipped release trains — no lint retro-fixes those.
+- Goal: prevent regression + catch a 2nd resolved copy going forward. NO exact-pin, NO npm overrides — enforce via consistency TEST only.
+- Constraint: NO new dep. Use `glob` (root devDep) + `semver` (root dep), both hoisted + resolvable from `packages/eslint-local-rules`.
+
+### Placement decision
+- Home = `packages/eslint-local-rules/test/` as a standalone jest test (NOT an eslint rule — cross-pkg fs invariant doesn't fit eslint single-file model).
+- Precedent: `packageJsonWebVscodeignore.test.ts`, `vscodeignoreContributesConflict.test.ts` already glob fs / read sibling pkgs in this dir.
+- Runs in existing `eslint-local-rules:test` wireit job (already in root `wireit.test.dependencies`) → CI-enforced. No wireit wiring needed.
+- `path.resolve(__dirname, '../../..')` = repo root from test file.
+
+### @effect companion peers (source of truth — verified in installed node_modules)
+- `@effect/opentelemetry@0.63.0` peer `effect` `^3.21.0`
+- `@effect/platform@0.96.1` peer `effect` `^3.21.2`
+- (`@effect/eslint-plugin`, `@effect/language-service` = tooling, no effect peer / not runtime — skip via peer-range presence check, not hardcoded allowlist)
+
+### Non-goals / already-handled (do NOT rely on for CI)
+- `@effect/language-service` tsconfig plugin (`tsconfig.common.json:24`) = editor/tsserver only, NOT tsc/CI.
+- Bundle-dupe (esbuild inlining 2 copies w/ 1 installed) = out of scope; WI marks post-build banner check OPTIONAL — omit.
+
+## Phases
+
+### Phase 1 — consistency test
+- New file `packages/eslint-local-rules/test/effectVersionConsistency.test.ts`.
+- 3 assertions:
+  1. **specs identical**: glob `packages/*/package.json` from repo root; collect `effect` from deps+devDeps; assert all distinct specs === 1 (msg lists offenders).
+  2. **one resolved copy**: glob `**/node_modules/effect/package.json` from repo root (root + nested `packages/*/node_modules`); read `.version`; assert distinct set size === 1. Guards npm un-hoist on conflict — the ONLY dup-copy trigger. NOT top-level-only, NOT `require.resolve` (misses un-hoisted copy).
+  3. **companion peers satisfied**: glob `**/node_modules/@effect/*/package.json`; for each w/ `peerDependencies.effect`, assert resolved effect version `semver.satisfies` peer range (msg names pkg+range). Skips `@effect/*` w/o effect peer (eslint-plugin, language-service).
+- Use `glob` sync + `node:fs`/`node:path`; dedupe glob results across resolved copies by version string.
+- Verify: `npm run test --workspace packages/eslint-local-rules` (or wireit `eslint-local-rules:test`) green.
+- Commit: `test(eslint-local-rules): enforce single effect version + companion peer ranges - W-23290052`
+
+## Skills to apply
+- concise (plan + any md)
+- typescript (new .ts test file: effectVersionConsistency.test.ts)
+- packageJson (dep-version conventions, caret rule)
+- effect-best-practices (context on effect runtime/version dup)
+- verification (final gate)
+- unit-test-critic (test quality: real invariant, no tautology)
+
+## Verification
+- `npm run compile --workspace packages/eslint-local-rules` (test:compile via tsc passes — new file typechecks).
+- `npm run test --workspace packages/eslint-local-rules` → new test green against current tree (1 spec, 1 copy, peers satisfied).
+- Negative check (local, revert after): temporarily change 1 pkg `effect` spec to `^3.20.0` OR drop a fake `packages/x/node_modules/effect/package.json@3.20.0` → assertion 1/2 fails. Confirms test catches regression, not tautology.
+- `npm run lint --workspace packages/eslint-local-rules` (header + eslint on new test file).
+- NOT e2e-covered: no e2e touches dep-graph invariants — all verification is unit/CI here.

--- a/packages/eslint-local-rules/package.json
+++ b/packages/eslint-local-rules/package.json
@@ -124,6 +124,9 @@
   "devDependencies": {
     "@types/eslint": "^9.0.0",
     "@types/estree": "^1.0.0",
-    "@typescript-eslint/rule-tester": "^8.62.0"
+    "@types/semver": "7.5.8",
+    "@typescript-eslint/rule-tester": "^8.62.0",
+    "glob": "11.1.0",
+    "semver": "^7.5.4"
   }
 }

--- a/packages/eslint-local-rules/package.json
+++ b/packages/eslint-local-rules/package.json
@@ -126,7 +126,6 @@
     "@types/estree": "^1.0.0",
     "@types/semver": "7.5.8",
     "@typescript-eslint/rule-tester": "^8.62.0",
-    "glob": "11.1.0",
     "semver": "^7.5.4"
   }
 }

--- a/packages/eslint-local-rules/test/effectVersionConsistency.test.ts
+++ b/packages/eslint-local-rules/test/effectVersionConsistency.test.ts
@@ -8,7 +8,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { globSync } from 'glob';
 import * as semver from 'semver';
 
 // Two loaded `effect` copies in one process warn on every exec (fiberRuntime version check),
@@ -29,7 +28,7 @@ const readJson = (relative: string): PackageJson =>
 
 describe('effect version consistency', () => {
   it('declares one effect spec across all workspace packages', () => {
-    const offenders = globSync('packages/*/package.json', { cwd: REPO_ROOT }).flatMap(file => {
+    const offenders = fs.globSync('packages/*/package.json', { cwd: REPO_ROOT }).flatMap(file => {
       const pkg = readJson(file);
       // collect both blocks so a deps/devDeps skew within one package is not masked
       return [pkg.dependencies?.effect, pkg.devDependencies?.effect]
@@ -45,27 +44,30 @@ describe('effect version consistency', () => {
 
   it('resolves exactly one effect version in node_modules', () => {
     const versions = new Set(
-      globSync('**/node_modules/effect/package.json', {
-        cwd: REPO_ROOT,
-        ignore: '**/node_modules/**/node_modules/**/node_modules/**'
-      }).map(file => readJson(file).version)
+      fs
+        .globSync('**/node_modules/effect/package.json', {
+          cwd: REPO_ROOT,
+          exclude: ['**/node_modules/**/node_modules/**/node_modules/**']
+        })
+        .map(file => readJson(file).version)
     );
     expect([...versions]).toHaveLength(1);
   });
 
   it('satisfies @effect companion peer ranges', () => {
     const resolvedEffect = readJson(
-      globSync('**/node_modules/effect/package.json', {
+      fs.globSync('**/node_modules/effect/package.json', {
         cwd: REPO_ROOT,
-        ignore: '**/node_modules/**/node_modules/**/node_modules/**'
+        exclude: ['**/node_modules/**/node_modules/**/node_modules/**']
       })[0]
     ).version;
     if (resolvedEffect === undefined) throw new Error('no resolved effect copy');
 
-    const violations = globSync('**/node_modules/@effect/*/package.json', {
-      cwd: REPO_ROOT,
-      ignore: '**/node_modules/**/node_modules/**'
-    })
+    const violations = fs
+      .globSync('**/node_modules/@effect/*/package.json', {
+        cwd: REPO_ROOT,
+        exclude: ['**/node_modules/**/node_modules/**']
+      })
       .map(readJson)
       .map(pkg => ({ pkg, peer: pkg.peerDependencies?.effect }))
       .filter((entry): entry is { pkg: PackageJson; peer: string } => entry.peer !== undefined)

--- a/packages/eslint-local-rules/test/effectVersionConsistency.test.ts
+++ b/packages/eslint-local-rules/test/effectVersionConsistency.test.ts
@@ -29,9 +29,13 @@ const readJson = (relative: string): PackageJson =>
 
 describe('effect version consistency', () => {
   it('declares one effect spec across all workspace packages', () => {
-    const offenders = globSync('packages/*/package.json', { cwd: REPO_ROOT })
-      .map(file => ({ file, spec: (pkg => pkg.dependencies?.effect ?? pkg.devDependencies?.effect)(readJson(file)) }))
-      .filter((entry): entry is { file: string; spec: string } => entry.spec !== undefined);
+    const offenders = globSync('packages/*/package.json', { cwd: REPO_ROOT }).flatMap(file => {
+      const pkg = readJson(file);
+      // collect both blocks so a deps/devDeps skew within one package is not masked
+      return [pkg.dependencies?.effect, pkg.devDependencies?.effect]
+        .filter((spec): spec is string => spec !== undefined)
+        .map(spec => ({ file, spec }));
+    });
 
     // on failure jest prints every offending file:spec so the skew is obvious
     const byFile = offenders.map(entry => `${entry.file}: ${entry.spec}`);

--- a/packages/eslint-local-rules/test/effectVersionConsistency.test.ts
+++ b/packages/eslint-local-rules/test/effectVersionConsistency.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { globSync } from 'glob';
+import * as semver from 'semver';
+
+// Two loaded `effect` copies in one process warn on every exec (fiberRuntime version check),
+// flooding telemetry. Guard: source specs identical, one resolved copy, companion peers satisfied.
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+
+type PackageJson = {
+  name?: string;
+  version?: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+};
+
+const readJson = (relative: string): PackageJson =>
+  JSON.parse(fs.readFileSync(path.join(REPO_ROOT, relative), 'utf-8')) as PackageJson;
+
+describe('effect version consistency', () => {
+  it('declares one effect spec across all workspace packages', () => {
+    const offenders = globSync('packages/*/package.json', { cwd: REPO_ROOT })
+      .map(file => ({ file, spec: (pkg => pkg.dependencies?.effect ?? pkg.devDependencies?.effect)(readJson(file)) }))
+      .filter((entry): entry is { file: string; spec: string } => entry.spec !== undefined);
+
+    // on failure jest prints every offending file:spec so the skew is obvious
+    const byFile = offenders.map(entry => `${entry.file}: ${entry.spec}`);
+    const distinctSpecs = new Set(offenders.map(entry => entry.spec));
+    expect(distinctSpecs.size === 1 ? [] : byFile).toEqual([]);
+  });
+
+  it('resolves exactly one effect version in node_modules', () => {
+    const versions = new Set(
+      globSync('**/node_modules/effect/package.json', {
+        cwd: REPO_ROOT,
+        ignore: '**/node_modules/**/node_modules/**/node_modules/**'
+      }).map(file => readJson(file).version)
+    );
+    expect([...versions]).toHaveLength(1);
+  });
+
+  it('satisfies @effect companion peer ranges', () => {
+    const resolvedEffect = readJson(
+      globSync('**/node_modules/effect/package.json', {
+        cwd: REPO_ROOT,
+        ignore: '**/node_modules/**/node_modules/**/node_modules/**'
+      })[0]
+    ).version;
+    if (resolvedEffect === undefined) throw new Error('no resolved effect copy');
+
+    const violations = globSync('**/node_modules/@effect/*/package.json', {
+      cwd: REPO_ROOT,
+      ignore: '**/node_modules/**/node_modules/**'
+    })
+      .map(readJson)
+      .map(pkg => ({ pkg, peer: pkg.peerDependencies?.effect }))
+      .filter((entry): entry is { pkg: PackageJson; peer: string } => entry.peer !== undefined)
+      .filter(entry => !semver.satisfies(resolvedEffect, entry.peer))
+      .map(
+        entry => `${entry.pkg.name ?? '(unnamed)'} peer effect ${entry.peer} not satisfied by effect@${resolvedEffect}`
+      );
+
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- App Insights hit a 100GB daily trace cap from Effect logging a runtime-version-mismatch warning on every exec, caused by 2 loaded copies of `effect` in one process.
- Source is already aligned (19 workspace pkgs on `effect ^3.21.2`, 1 hoisted copy today) — this PR adds a regression guard, not a fix to current state.
- New jest test in `packages/eslint-local-rules/test/effectVersionConsistency.test.ts` asserts: (1) all workspace `package.json` `effect` specs are identical, (2) exactly one resolved `effect` copy exists under `node_modules`, (3) installed `@effect/*` companion peers are satisfied by the resolved `effect` version. Runs in the existing `eslint-local-rules:test` wireit job, already CI-enforced.

## Plan
.claude/plans/W-23290052.md

### What issues does this PR fix or reference?
@W-23290052@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002dn6oQYAQ/view