### PR TITLE
fix(trace-flags): change status bar icon to No Tracing when the debug level associated with the current user's trace flag is removed - W-23291238

### DIFF
--- a/packages/salesforcedx-vscode-services/src/core/traceFlagService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/traceFlagService.ts
@@ -283,6 +283,8 @@ export class TraceFlagService extends Effect.Service<TraceFlagService>()('TraceF
           return new DebugLevelDeleteError({ message: `Failed to delete debug level: ${cause.message}`, cause: error });
         }
       });
+      const flags = yield* getTraceFlags().pipe(Effect.catchAll(() => Effect.succeed([])));
+      yield* PubSub.publish(traceFlagsChanged, flags);
     });
 
     const createTraceFlag = Effect.fn('TraceFlagService.createTraceFlag')(function* (


### PR DESCRIPTION
### What does this PR do?
When a debug level is removed, all trace flags with that debug level are automatically also removed.  This includes trace flags tracking the current user.  When the trace flag tracking the current user is automatically removed via the debug level removal process, the status bar icon should change back to "No Tracing" instead of continuing to display the expiration date of the now-gone trace flag.

### What issues does this PR fix or reference?
@W-23291238@

### Functionality Before
Status bar icon continued to display the expiration date of the trace flag despite it being deleted.

### Functionality After
Status bar icon switches to "No Tracing" when the trace flag it was tracking is deleted.
