### PR TITLE
perf(org-browser): resolve effect ESM to shrink bundle (POC) - W-23293744

### DIFF
--- a/.claude/plans/W-23293744.md
+++ b/.claude/plans/W-23293744.md
@@ -7,7 +7,10 @@
   - effect `package.json` exports order: `types` → `import` (esm) → `default` (cjs). Has `exports` map + `sideEffects:[]`.
   - org-browser entry `out/src/index.js` = CJS (tsconfig `module:node16`, no `type:module`) → `require('effect')` → esbuild picks `require`/`default` condition → `dist/cjs/*`.
   - `dist/cjs/Schema.js:163` `require("./FastCheck.js")` = unconditional eval, blocks tree-shake.
-  - `dist/esm/Schema.js:21` `import * as fastCheck_ from "./FastCheck.js"` + `sideEffects:[]` = mostly droppable, but NOT fully. `effect/FastCheck.js` does `export * from "fast-check"` (barrel re-export, not per-symbol), and `dist/esm/Schema.js` references `fastCheck_.array(...)` at module scope inside `nonEmptyChunkArbitrary` (a still-reachable helper). esbuild tree-shaker can drop most, not all.
+  - `dist/esm/Schema.js:21` imports FastCheck.js + `sideEffects:[]` → mostly droppable, not fully.
+    - `effect/FastCheck.js` barrel re-exports fast-check (`export *`, not per-symbol).
+    - `fastCheck_.array(...)` still reachable via `nonEmptyChunkArbitrary`.
+    - Tree-shaker drops most, not all.
   - fast-check = 4.1M on disk; ~235KB bundled (~16% node bundle per WI).
   - MEASURED in this worktree (real build): baseline `dist/index.js`=1,447,135B, fast-check bytesInOutput=235,160. After `conditions:['import']`: `dist/index.js`=698,929B, fast-check bytesInOutput=47,212. So fast-check shrinks ~80% (235KB→~47KB node; ~224KB→~52KB web), NOT eliminated. Partial reduction is the success bar.
 - Mechanism: pkg has `exports` map → esbuild uses **conditions**, not `mainFields`. Add `conditions:['import']` → esm resolves.
@@ -27,7 +30,7 @@
 - Commit msg: `chore(org-browser): record baseline bundle metafile sizes - W-23293744`
 
 ### Phase 2 — Add import condition, rebuild, diff
-- Edit `packages/salesforcedx-vscode-org-browser/esbuild.config.mjs`: add `conditions:['import']` to nodeBuild + browserBuild config objects (local override, spread after `...nodeConfig`/`...commonConfigBrowser`).
+- Edit `packages/salesforcedx-vscode-org-browser/esbuild.config.mjs`: add shared `effectEsmOverride` (`conditions:['import','module','default']`) spread into nodeBuild + browserBuild after `...nodeConfig`/`...commonConfigBrowser`.
 - Rebuild. Diff metafiles:
   - confirm effect now resolves `dist/esm/*`.
   - measure REMAINING fast-check bytesInOutput (expect ~47KB node / ~52KB web, down from ~235KB / ~224KB — partial, not zero).
@@ -68,7 +71,7 @@
 
 ## Verdict — ACHIEVED
 
-Local `conditions:['import']` on org-browser node + browser esbuild configs → effect resolves `dist/esm/*` (was `dist/cjs/*`), tree-shaker drops ~80% of fast-check. Output stays CJS (no `import.meta` / ESM syntax).
+Local `effectEsmOverride` (`conditions:['import','module','default']`) on org-browser node + browser esbuild configs → effect resolves `dist/esm/*` (was `dist/cjs/*`), tree-shaker drops ~80% of fast-check. Output stays CJS (no `import.meta` / ESM syntax).
 
 | metric | before | after | delta |
 | --- | --- | --- | --- |
@@ -82,4 +85,4 @@ fast-check reduced ~80%, NOT eliminated (`effect/FastCheck.js` barrel re-export 
 Playwright: `test:web` all green (headless specs), `test:desktop` 4/4 green (incl. scratch describe on packaged VSIX).
 
 ### Shared-config promotion — DEFERRED
-Kept local-only. POC scope is org-browser; `nodeConfig`/`commonConfigBrowser` feed 16 packages, so promoting `conditions:['import']` needs a full rebuild + regression pass across all consumers (effect dual-package hazard for any that mix cjs/esm effect). Follow-up WI for global rollout.
+Kept local-only. POC scope is org-browser; `nodeConfig`/`commonConfigBrowser` feed 16 packages, so promoting `effectEsmOverride` needs a full rebuild + regression pass across all consumers (effect dual-package hazard for any that mix cjs/esm effect). Follow-up WI for global rollout.

--- a/.claude/plans/W-23293744.md
+++ b/.claude/plans/W-23293744.md
@@ -65,3 +65,21 @@
   - `npm run test:web -w salesforcedx-vscode-org-browser` — headless specs: `orgBrowser.folderedReport.headless.spec.ts`, `orgBrowser.customTab.headless.spec.ts`, `orgBrowser.customObject.headless.spec.ts`.
   - `npm run test:desktop -w salesforcedx-vscode-org-browser` — scratch-org spec: `orgBrowser.describe.scratch.spec.ts` (needs a scratch org / desktop VS Code).
   - Rationale: swapping effect cjs→esm can shift dual-package/runtime behavior; e2e confirms org-browser tree, describe, custom object/tab, and foldered report still work.
+
+## Verdict — ACHIEVED
+
+Local `conditions:['import']` on org-browser node + browser esbuild configs → effect resolves `dist/esm/*` (was `dist/cjs/*`), tree-shaker drops ~80% of fast-check. Output stays CJS (no `import.meta` / ESM syntax).
+
+| metric | before | after | delta |
+| --- | --- | --- | --- |
+| node `dist/index.js` | 1,447,135B | 698,929B | -51.7% |
+| node fast-check bytesInOutput | 234,890B | 47,189B | -79.9% |
+| web `dist/web/index.js` | 1,422,362B | 719,525B | -49.4% |
+| web fast-check bytesInOutput | 223,587B | 51,876B | -76.8% |
+
+fast-check reduced ~80%, NOT eliminated (`effect/FastCheck.js` barrel re-export + reachable `fastCheck_.array` in `nonEmptyChunkArbitrary`).
+
+Playwright: `test:web` all green (headless specs), `test:desktop` 4/4 green (incl. scratch describe on packaged VSIX).
+
+### Shared-config promotion — DEFERRED
+Kept local-only. POC scope is org-browser; `nodeConfig`/`commonConfigBrowser` feed 16 packages, so promoting `conditions:['import']` needs a full rebuild + regression pass across all consumers (effect dual-package hazard for any that mix cjs/esm effect). Follow-up WI for global rollout.

--- a/.claude/plans/W-23293744.md
+++ b/.claude/plans/W-23293744.md
@@ -1,0 +1,67 @@
+# W-23293744 [POC] Shrink org-browser bundle via esbuild ESM resolution of effect
+
+## Context
+
+- Goal: shrink `salesforcedx-vscode-org-browser` bundle. Make esbuild resolve effect ESM build so unused submodules (esp fast-check) tree-shake out. NOT ESM output migration.
+- Root cause confirmed:
+  - effect `package.json` exports order: `types` → `import` (esm) → `default` (cjs). Has `exports` map + `sideEffects:[]`.
+  - org-browser entry `out/src/index.js` = CJS (tsconfig `module:node16`, no `type:module`) → `require('effect')` → esbuild picks `require`/`default` condition → `dist/cjs/*`.
+  - `dist/cjs/Schema.js:163` `require("./FastCheck.js")` = unconditional eval, blocks tree-shake.
+  - `dist/esm/Schema.js:21` `import * as fastCheck_ from "./FastCheck.js"` + `sideEffects:[]` = mostly droppable, but NOT fully. `effect/FastCheck.js` does `export * from "fast-check"` (barrel re-export, not per-symbol), and `dist/esm/Schema.js` references `fastCheck_.array(...)` at module scope inside `nonEmptyChunkArbitrary` (a still-reachable helper). esbuild tree-shaker can drop most, not all.
+  - fast-check = 4.1M on disk; ~235KB bundled (~16% node bundle per WI).
+  - MEASURED in this worktree (real build): baseline `dist/index.js`=1,447,135B, fast-check bytesInOutput=235,160. After `conditions:['import']`: `dist/index.js`=698,929B, fast-check bytesInOutput=47,212. So fast-check shrinks ~80% (235KB→~47KB node; ~224KB→~52KB web), NOT eliminated. Partial reduction is the success bar.
+- Mechanism: pkg has `exports` map → esbuild uses **conditions**, not `mainFields`. Add `conditions:['import']` → esm resolves.
+- `mainFields` only fallback (no `exports`); web's existing `mainFields:['browser','module','main']` does NOT force effect esm (effect has `exports`, no `browser` field).
+- Shared config risk: `nodeConfig` (scripts/bundling/node.mjs) + `commonConfigBrowser` (web.mjs) consumed by 16 packages. Global edit affects all. POC scopes locally to org-browser first.
+- Output format stays CJS (web-worker no ESM — VS Code #130367). Node-ESM output = non-goal.
+- Metafiles already emitted: `dist/node-metafile.json`, `dist/browser-metafile.json`.
+- Files: `packages/salesforcedx-vscode-org-browser/esbuild.config.mjs`; maybe `scripts/bundling/node.mjs`, `scripts/bundling/web.mjs`.
+
+## Phases
+
+### Phase 1 — Baseline measure
+- Build org-browser: `npm run vscode:bundle -w salesforcedx-vscode-org-browser` (or wireit).
+- Record byte sizes: `dist/index.js` (node), `dist/web/index.js` (web).
+- From metafiles: confirm effect resolves `dist/cjs/*`; confirm fast-check + effect/FastCheck present in inputs; capture bytes.
+- No code change; measurement only (skip commit or commit metafile snapshot note).
+- Commit msg: `chore(org-browser): record baseline bundle metafile sizes - W-23293744`
+
+### Phase 2 — Add import condition, rebuild, diff
+- Edit `packages/salesforcedx-vscode-org-browser/esbuild.config.mjs`: add `conditions:['import']` to nodeBuild + browserBuild config objects (local override, spread after `...nodeConfig`/`...commonConfigBrowser`).
+- Rebuild. Diff metafiles:
+  - confirm effect now resolves `dist/esm/*`.
+  - measure REMAINING fast-check bytesInOutput (expect ~47KB node / ~52KB web, down from ~235KB / ~224KB — partial, not zero).
+  - record new node + web byte sizes.
+- Done-when: fast-check bytesInOutput drops ~80% AND total `dist/index.js` roughly halves (measured baseline 1,447,135B → ~698,929B). NOT "fast-check absent". Report the delta as numbers, not a yes/no.
+- Verify no breakage: build succeeds, no `require-resolve-not-external` / `unsupported-dynamic-import` errors; no `import.meta` in CJS output (esbuild rewrites; grep output).
+- Commit msg: `perf(org-browser): resolve effect ESM to tree-shake fast-check - W-23293744`
+
+### Phase 3 — Verdict + optional shared-config promotion
+- If size dropped: decide whether to promote `conditions:['import']` to shared `scripts/bundling/node.mjs` (nodeConfig) — rebuild ALL consuming packages, spot-check no regressions/effect-dual-package breakage.
+- If local-only kept: leave shared configs untouched; document why.
+- Write PR body: before/after bytes (node AND web), fast-check bytesInOutput before→after (e.g. 235KB→47KB, ~80% reduction — NOT "eliminated"), clear verdict ACHIEVED/NOT with numbers.
+- Commit msg: `docs(org-browser): esbuild effect-esm POC verdict - W-23293744`
+
+## Skills to apply
+
+- packageJson — any package.json edits
+- wireit — bundle task deps/outputs
+- typescript — .ts config/source edits and naming conventions
+- verification — build + size diff evidence; flags org-browser as Playwright-gated
+- playwright-e2e — running test:web + test:desktop specs for org-browser
+- concise — plan + PR body
+- pr-draft — PR body with required before/after numbers + verdict
+
+## Verification
+
+- Build succeeds: `npm run vscode:bundle -w salesforcedx-vscode-org-browser` (both node + web outputs).
+- Metafile diff: effect resolves `dist/esm/*` post-change (was `dist/cjs/*`).
+- fast-check bytesInOutput REDUCED (~80%, not absent) in post-change metafile; number recorded.
+- Byte size: node `dist/index.js` and web `dist/web/index.js` before vs after recorded.
+- No esbuild errors (dynamic-import, require-resolve).
+- Smoke: grep bundled output has no stray `import.meta` / ESM syntax (format still CJS).
+- If shared-config promoted: rebuild all 16 consumers, no new build failures.
+- Playwright (REQUIRED — org-browser is a Playwright-gated package per verification skill; effect ESM resolution changes runtime code, not just build-time size). Both suites cover the same 4 spec files in `test/playwright/specs/`; run each locally, all green before PR:
+  - `npm run test:web -w salesforcedx-vscode-org-browser` — headless specs: `orgBrowser.folderedReport.headless.spec.ts`, `orgBrowser.customTab.headless.spec.ts`, `orgBrowser.customObject.headless.spec.ts`.
+  - `npm run test:desktop -w salesforcedx-vscode-org-browser` — scratch-org spec: `orgBrowser.describe.scratch.spec.ts` (needs a scratch org / desktop VS Code).
+  - Rationale: swapping effect cjs→esm can shift dual-package/runtime behavior; e2e confirms org-browser tree, describe, custom object/tab, and foldered report still work.

--- a/packages/salesforcedx-vscode-org-browser/esbuild.config.mjs
+++ b/packages/salesforcedx-vscode-org-browser/esbuild.config.mjs
@@ -9,8 +9,11 @@ import { nodeConfig } from '../../scripts/bundling/node.mjs';
 import { commonConfigBrowser } from '../../scripts/bundling/web.mjs';
 import { writeFile } from 'fs/promises';
 
+// local override: force esbuild to resolve effect's ESM build so unused
+// submodules (e.g. fast-check via Schema) tree-shake out. output stays CJS.
 const nodeBuild = await build({
   ...nodeConfig,
+  conditions: ['import'],
   entryPoints: ['./out/src/index.js'],
   outdir: './dist',
   plugins: [...(nodeConfig.plugins ?? [])],
@@ -20,6 +23,7 @@ const nodeBuild = await build({
 // Browser build (browser environment)
 const browserBuild = await build({
   ...commonConfigBrowser,
+  conditions: ['import'],
   external: ['vscode'],
   entryPoints: ['./out/src/index.js'],
   outdir: './dist/web',

--- a/packages/salesforcedx-vscode-org-browser/esbuild.config.mjs
+++ b/packages/salesforcedx-vscode-org-browser/esbuild.config.mjs
@@ -10,10 +10,13 @@ import { commonConfigBrowser } from '../../scripts/bundling/web.mjs';
 import { writeFile } from 'fs/promises';
 
 // local override: force esbuild to resolve effect's ESM build so unused
-// submodules (e.g. fast-check via Schema) tree-shake out. output stays CJS.
+// submodules (e.g. fast-check via Schema) tree-shake out.
+// output format (cjs) comes from nodeConfig/commonConfigBrowser, not here.
+const effectEsmOverride = { conditions: ['import', 'module', 'default'] };
+
 const nodeBuild = await build({
   ...nodeConfig,
-  conditions: ['import'],
+  ...effectEsmOverride,
   entryPoints: ['./out/src/index.js'],
   outdir: './dist',
   plugins: [...(nodeConfig.plugins ?? [])],
@@ -23,7 +26,7 @@ const nodeBuild = await build({
 // Browser build (browser environment)
 const browserBuild = await build({
   ...commonConfigBrowser,
-  conditions: ['import'],
+  ...effectEsmOverride,
   external: ['vscode'],
   entryPoints: ['./out/src/index.js'],
   outdir: './dist/web',


### PR DESCRIPTION
## Summary
- POC: esbuild resolves `effect`'s ESM build (`conditions:['import','module','default']`) instead of CJS for org-browser, letting the tree-shaker drop most of the bundled `fast-check` dependency.
- Node `dist/index.js`: 1,447,135B → 698,929B (-51.7%); fast-check bytesInOutput 234,890B → 47,189B (-79.9%).
- Web `dist/web/index.js`: 1,422,362B → 719,525B (-49.4%); fast-check bytesInOutput 223,587B → 51,876B (-76.8%). Output stays CJS (no `import.meta`/ESM syntax leaked). Change scoped locally to org-browser; shared bundling config (16 consumers) left untouched pending follow-up WI.

## Plan
.claude/plans/W-23293744.md

### What issues does this PR fix or reference?
@W-23293744@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002dnRRSYA2/view
