### PR TITLE
fix: get rid of old broken command SFDX: Execute Anonymous Apex with Currently Selected Text + rename debug command to SFDX: Debug Anonymous Apex with Editor's Selected Text for consistency - W-23329171

### DIFF
--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -200,6 +200,7 @@
     "onCommand:extension.replay-debugger.getLogFileName",
     "onCommand:sf.launch.replay.debugger.logfile",
     "onCommand:sf.launch.replay.debugger.logfile.path",
+    "onCommand:sf.apex.debug.document",
     "onCommand:sf.launch.apex.replay.debugger.with.current.file"
   ],
   "main": "./dist/index.js",
@@ -230,6 +231,10 @@
         {
           "command": "sf.test.view.debugSingleTest",
           "when": "false"
+        },
+        {
+          "command": "sf.apex.debug.document",
+          "when": "sf:project_opened && editorLangId == 'apex'"
         },
         {
           "command": "sf.launch.apex.replay.debugger.with.current.file",
@@ -301,6 +306,10 @@
           "light": "resources/light/debug.svg",
           "dark": "resources/dark/debug.svg"
         }
+      },
+      {
+        "command": "sf.apex.debug.document",
+        "title": "%apex_debug_document_text%"
       },
       {
         "command": "sf.launch.apex.replay.debugger.with.current.file",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -200,8 +200,6 @@
     "onCommand:extension.replay-debugger.getLogFileName",
     "onCommand:sf.launch.replay.debugger.logfile",
     "onCommand:sf.launch.replay.debugger.logfile.path",
-    "onCommand:sf.anon.apex.debug.delegate",
-    "onCommand:sf.apex.debug.document",
     "onCommand:sf.launch.apex.replay.debugger.with.current.file"
   ],
   "main": "./dist/index.js",
@@ -232,14 +230,6 @@
         {
           "command": "sf.test.view.debugSingleTest",
           "when": "false"
-        },
-        {
-          "command": "sf.anon.apex.debug.delegate",
-          "when": "sf:project_opened && editorLangId == 'apex'"
-        },
-        {
-          "command": "sf.apex.debug.document",
-          "when": "sf:project_opened && editorLangId == 'apex'"
         },
         {
           "command": "sf.launch.apex.replay.debugger.with.current.file",
@@ -311,14 +301,6 @@
           "light": "resources/light/debug.svg",
           "dark": "resources/dark/debug.svg"
         }
-      },
-      {
-        "command": "sf.anon.apex.debug.delegate",
-        "title": "%anon_apex_execute_selection_text%"
-      },
-      {
-        "command": "sf.apex.debug.document",
-        "title": "%apex_debug_document_text%"
       },
       {
         "command": "sf.launch.apex.replay.debugger.with.current.file",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -200,7 +200,7 @@
     "onCommand:extension.replay-debugger.getLogFileName",
     "onCommand:sf.launch.replay.debugger.logfile",
     "onCommand:sf.launch.replay.debugger.logfile.path",
-    "onCommand:sf.apex.debug.document",
+    "onCommand:sf.anon.apex.debug.delegate",
     "onCommand:sf.launch.apex.replay.debugger.with.current.file"
   ],
   "main": "./dist/index.js",
@@ -233,7 +233,7 @@
           "when": "false"
         },
         {
-          "command": "sf.apex.debug.document",
+          "command": "sf.anon.apex.debug.delegate",
           "when": "sf:project_opened && editorLangId == 'apex'"
         },
         {
@@ -308,7 +308,7 @@
         }
       },
       {
-        "command": "sf.apex.debug.document",
+        "command": "sf.anon.apex.debug.delegate",
         "title": "%apex_debug_document_text%"
       },
       {

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -234,7 +234,7 @@
         },
         {
           "command": "sf.anon.apex.debug.delegate",
-          "when": "sf:project_opened && editorLangId == 'apex'"
+          "when": "sf:project_opened && (editorLangId == 'apex' || editorLangId == 'apex-anon') && sf:has_target_org"
         },
         {
           "command": "sf.launch.apex.replay.debugger.with.current.file",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.nls.ja.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.nls.ja.json
@@ -5,7 +5,7 @@
   "launch_snippet_name": "Apex Replay Debugger を起動",
   "launch_from_last_log_file": "SFDX: 最新のログファイルで Apex Replay Debugger を起動",
   "launch_apex_replay_debugger_with_selected_file": "SFDX: 選択されたファイルで Apex リプレイデバッガを起動",
-  "apex_debug_document_text": "SFDX: Anonymous Apex をデバッグ",
+  "apex_debug_document_text": "SFDX: エディタの選択したテキストで Anonymous Apex をデバッグ",
   "logfile_text": "ワークスペースフォルダ内の Apex デバッグログファイル(*.log) のパス。",
   "stop_on_entry_text": "起動後にデバッガを停止する。もし false に設定した場合、デバッガはブレークポイントにヒットするまで実行されます。",
   "trace_text": "診断出力を生成します。これを true、false、またはカンマで区切った 1 つ以上のセレクタに設定できます。セレクタには、'all' (非常に詳細な出力。true と同等)、'protocol'、'logfile'、'launch'、'breakpoints' があります。",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.nls.ja.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.nls.ja.json
@@ -5,8 +5,6 @@
   "launch_snippet_name": "Apex Replay Debugger を起動",
   "launch_from_last_log_file": "SFDX: 最新のログファイルで Apex Replay Debugger を起動",
   "launch_apex_replay_debugger_with_selected_file": "SFDX: 選択されたファイルで Apex リプレイデバッガを起動",
-  "anon_apex_execute_selection_text": "SFDX: 選択したテキストで Anonymous Apex を実行",
-  "apex_debug_document_text": "SFDX: Anonymous Apex をデバッグ",
   "logfile_text": "ワークスペースフォルダ内の Apex デバッグログファイル(*.log) のパス。",
   "stop_on_entry_text": "起動後にデバッガを停止する。もし false に設定した場合、デバッガはブレークポイントにヒットするまで実行されます。",
   "trace_text": "診断出力を生成します。これを true、false、またはカンマで区切った 1 つ以上のセレクタに設定できます。セレクタには、'all' (非常に詳細な出力。true と同等)、'protocol'、'logfile'、'launch'、'breakpoints' があります。",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.nls.ja.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.nls.ja.json
@@ -5,6 +5,7 @@
   "launch_snippet_name": "Apex Replay Debugger を起動",
   "launch_from_last_log_file": "SFDX: 最新のログファイルで Apex Replay Debugger を起動",
   "launch_apex_replay_debugger_with_selected_file": "SFDX: 選択されたファイルで Apex リプレイデバッガを起動",
+  "apex_debug_document_text": "SFDX: Anonymous Apex をデバッグ",
   "logfile_text": "ワークスペースフォルダ内の Apex デバッグログファイル(*.log) のパス。",
   "stop_on_entry_text": "起動後にデバッガを停止する。もし false に設定した場合、デバッガはブレークポイントにヒットするまで実行されます。",
   "trace_text": "診断出力を生成します。これを true、false、またはカンマで区切った 1 つ以上のセレクタに設定できます。セレクタには、'all' (非常に詳細な出力。true と同等)、'protocol'、'logfile'、'launch'、'breakpoints' があります。",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.nls.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.nls.json
@@ -6,6 +6,7 @@
   "launch_snippet_name": "Launch Apex Replay Debugger",
   "launch_from_last_log_file": "SFDX: Launch Apex Replay Debugger with Last Log File",
   "launch_apex_replay_debugger_with_selected_file": "SFDX: Launch Apex Replay Debugger with Selected File",
+  "apex_debug_document_text": "SFDX: Debug Anonymous Apex",
   "logfile_text": "Path to an Apex Debug Log file (*.log) in the workspace folder.",
   "stop_on_entry_text": "Stop the debugger after launching. If false, the debugger will run until it hits a breakpoint.",
   "trace_text": "Produce diagnostic output. You can set this to true, false, or one or more selectors separated with commas. Selectors include 'all' (very detailed output; the equivalent of true), 'protocol', 'logfile', 'launch', 'breakpoints'.",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.nls.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.nls.json
@@ -6,7 +6,7 @@
   "launch_snippet_name": "Launch Apex Replay Debugger",
   "launch_from_last_log_file": "SFDX: Launch Apex Replay Debugger with Last Log File",
   "launch_apex_replay_debugger_with_selected_file": "SFDX: Launch Apex Replay Debugger with Selected File",
-  "apex_debug_document_text": "SFDX: Debug Anonymous Apex",
+  "apex_debug_document_text": "SFDX: Debug Anonymous Apex with Editor's Selected Text",
   "logfile_text": "Path to an Apex Debug Log file (*.log) in the workspace folder.",
   "stop_on_entry_text": "Stop the debugger after launching. If false, the debugger will run until it hits a breakpoint.",
   "trace_text": "Produce diagnostic output. You can set this to true, false, or one or more selectors separated with commas. Selectors include 'all' (very detailed output; the equivalent of true), 'protocol', 'logfile', 'launch', 'breakpoints'.",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.nls.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.nls.json
@@ -6,8 +6,6 @@
   "launch_snippet_name": "Launch Apex Replay Debugger",
   "launch_from_last_log_file": "SFDX: Launch Apex Replay Debugger with Last Log File",
   "launch_apex_replay_debugger_with_selected_file": "SFDX: Launch Apex Replay Debugger with Selected File",
-  "anon_apex_execute_selection_text": "SFDX: Execute Anonymous Apex with Currently Selected Text",
-  "apex_debug_document_text": "SFDX: Debug Anonymous Apex",
   "logfile_text": "Path to an Apex Debug Log file (*.log) in the workspace folder.",
   "stop_on_entry_text": "Stop the debugger after launching. If false, the debugger will run until it hits a breakpoint.",
   "trace_text": "Produce diagnostic output. You can set this to true, false, or one or more selectors separated with commas. Selectors include 'all' (very detailed output; the equivalent of true), 'protocol', 'logfile', 'launch', 'breakpoints'.",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
@@ -111,7 +111,7 @@ const registerCommands = async (extensionContext: vscode.ExtensionContext): Prom
   const sfCreateCheckpointsCmd = vscode.commands.registerCommand('sf.create.checkpoints', sfCreateCheckpoints);
   const sfToggleCheckpointCmd = vscode.commands.registerCommand('sf.toggle.checkpoint', sfToggleCheckpoint);
 
-  const anonApexDebugDocumentCmd = vscode.commands.registerCommand('sf.apex.debug.document', anonApexDebug);
+  const anonApexDebugDelegateCmd = vscode.commands.registerCommand('sf.anon.apex.debug.delegate', anonApexDebug);
 
   const launchApexReplayDebuggerWithCurrentFileCmd = vscode.commands.registerCommand(
     'sf.launch.apex.replay.debugger.with.current.file',
@@ -125,7 +125,7 @@ const registerCommands = async (extensionContext: vscode.ExtensionContext): Prom
     launchFromLastLogFileCmd,
     sfCreateCheckpointsCmd,
     sfToggleCheckpointCmd,
-    anonApexDebugDocumentCmd,
+    anonApexDebugDelegateCmd,
     launchApexReplayDebuggerWithCurrentFileCmd
   );
 };

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
@@ -32,7 +32,6 @@ import {
   sfToggleCheckpoint
 } from './breakpoints/checkpointService';
 import { channelService } from './channels';
-import { anonApexDebug } from './commands/anonApexDebug';
 import { launchApexReplayDebuggerWithCurrentFile } from './commands/launchApexReplayDebuggerWithCurrentFile';
 import { launchFromLogFile } from './commands/launchFromLogFile';
 import { setupAndDebugTests } from './commands/quickLaunch';
@@ -111,8 +110,6 @@ const registerCommands = async (extensionContext: vscode.ExtensionContext): Prom
   const sfCreateCheckpointsCmd = vscode.commands.registerCommand('sf.create.checkpoints', sfCreateCheckpoints);
   const sfToggleCheckpointCmd = vscode.commands.registerCommand('sf.toggle.checkpoint', sfToggleCheckpoint);
 
-  const anonApexDebugDelegateCmd = vscode.commands.registerCommand('sf.anon.apex.debug.delegate', anonApexDebug);
-  const anonApexDebugDocumentCmd = vscode.commands.registerCommand('sf.apex.debug.document', anonApexDebug);
   const launchApexReplayDebuggerWithCurrentFileCmd = vscode.commands.registerCommand(
     'sf.launch.apex.replay.debugger.with.current.file',
     launchApexReplayDebuggerWithCurrentFile
@@ -125,8 +122,6 @@ const registerCommands = async (extensionContext: vscode.ExtensionContext): Prom
     launchFromLastLogFileCmd,
     sfCreateCheckpointsCmd,
     sfToggleCheckpointCmd,
-    anonApexDebugDelegateCmd,
-    anonApexDebugDocumentCmd,
     launchApexReplayDebuggerWithCurrentFileCmd
   );
 };

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
@@ -32,6 +32,7 @@ import {
   sfToggleCheckpoint
 } from './breakpoints/checkpointService';
 import { channelService } from './channels';
+import { anonApexDebug } from './commands/anonApexDebug';
 import { launchApexReplayDebuggerWithCurrentFile } from './commands/launchApexReplayDebuggerWithCurrentFile';
 import { launchFromLogFile } from './commands/launchFromLogFile';
 import { setupAndDebugTests } from './commands/quickLaunch';
@@ -110,6 +111,8 @@ const registerCommands = async (extensionContext: vscode.ExtensionContext): Prom
   const sfCreateCheckpointsCmd = vscode.commands.registerCommand('sf.create.checkpoints', sfCreateCheckpoints);
   const sfToggleCheckpointCmd = vscode.commands.registerCommand('sf.toggle.checkpoint', sfToggleCheckpoint);
 
+  const anonApexDebugDocumentCmd = vscode.commands.registerCommand('sf.apex.debug.document', anonApexDebug);
+
   const launchApexReplayDebuggerWithCurrentFileCmd = vscode.commands.registerCommand(
     'sf.launch.apex.replay.debugger.with.current.file',
     launchApexReplayDebuggerWithCurrentFile
@@ -122,6 +125,7 @@ const registerCommands = async (extensionContext: vscode.ExtensionContext): Prom
     launchFromLastLogFileCmd,
     sfCreateCheckpointsCmd,
     sfToggleCheckpointCmd,
+    anonApexDebugDocumentCmd,
     launchApexReplayDebuggerWithCurrentFileCmd
   );
 };


### PR DESCRIPTION
### What does this PR do?
1. Earlier this year we migrated the Anonymous Apex functionality from the Apex Replay Debugger extension to the Apex Log extension. With this change, executing Anonymous Apex on highlighted text via command palette is now handled by the **SFDX: Execute Anonymous Apex with Editor's Selected Text** command in the Apex Log extension. However, the old commands **SFDX: Execute Anonymous Apex with Currently Selected Text** was not unwired from the Apex Replay Debugger extension, leaving it as a broken command with no functionality.  This PR gets rid of the dead command so that it's no longer present in the command palette.
2. Rename the **SFDX: Debug Anonymous Apex** command to **SFDX: Debug Anonymous Apex with Editor's Selected Text** for consistency with the execute command.
3. **SFDX: Debug Anonymous Apex with Editor's Selected Text** works when highlighting text in an Anonymous Apex (.apex) file, in addition to regular Apex (.cls) files.  This matches the behavior of the **SFDX: Execute Anonymous Apex with Editor's Selected Text** command.

### What issues does this PR fix or reference?
@W-23329171@
