### PR TITLE
fix: correct handling of log levels to be able to debug Anonymous Apex - W-23339705

### DIFF
--- a/.claude/skills/playwright-e2e/references/coding-playwright-tests.md
+++ b/.claude/skills/playwright-e2e/references/coding-playwright-tests.md
@@ -110,6 +110,22 @@ Prefer `package.nls.json` for command titles instead of hardcoded strings.
 - Pattern: `import packageNls from '../../../package.nls.json'` (adjust path for package root)
 - Use for `executeCommandWithCommandPalette`, `executeExplorerContextMenuCommand`, `executeEditorContextMenuCommand`, `verifyCommandExists`, and `waitForOutputChannelText` expectedText (e.g. `Ended ${packageNls.deploy_this_source_text}`)
 
+## Commands with Editor Selection
+
+Selection-guarded commands (e.g., debug/execute from selection) require editor focus + selection. Preserve both with `preserveSelection: true`:
+
+```typescript
+// Setup selection first (ensure editor has focus)
+await page.keyboard.press('Control+a');
+
+// Open palette — preserve selection
+await executeCommandWithCommandPalette(page, commandTitle, undefined, {
+  preserveSelection: true
+});
+```
+
+Without it: palette open blurs editor, clears selection, hides selection-guarded commands.
+
 ## Clicking Code Lenses
 
 Use `clickCodeLens(page, text, opts?)` for code lens actions.
@@ -118,6 +134,18 @@ Use `clickCodeLens(page, text, opts?)` for code lens actions.
 - **Apex callers** — pass longer timeout (e.g. `{ timeout: 180_000 }`) to account for Apex Language Server indexing
 - Helper returns on first lens with visible text matching (whitespace-tolerant exact match)
 - Limitation: can't disambiguate multiple lenses with identical labels in same file — caller must scope the search (e.g. navigate to specific line first)
+
+## Output Panel and Debug Sessions
+
+Debug sessions that open extension-specific output channels can hang or behave unexpectedly if a non-debug output panel is already visible. Before launching debug sessions, close the panel with `hidePanel(page)`.
+
+```typescript
+// Before debug session startup
+await hidePanel(page);
+await clickCodeLens(page, 'Debug'); // or run debug command
+```
+
+Use `ensureOutputPanelOpen(page)` to prepare output during setup; close before each debug trigger to prevent interference.
 
 ## Notifications and Toast Messages
 

--- a/packages/salesforcedx-apex-replay-debugger/src/core/logContext.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/core/logContext.ts
@@ -107,7 +107,9 @@ export class LogContext {
       this.logLines &&
       this.logLines.length > 0 &&
       this.logLines[0].match(
-        /(\d{2}.*APEX_CODE,FINEST;.*VISUALFORCE,FINER;.*|\d{2}.*APEX_CODE,FINEST;.*VISUALFORCE,FINEST;.*)/
+        // Matches logs with APEX_CODE,FINEST and VISUALFORCE at FINER or FINEST level.
+        // The optional semicolons (;?) handle cases where Visualforce is the last category.
+        /(\d{2}.*APEX_CODE,FINEST;.*VISUALFORCE,FINER;?.*|\d{2}.*APEX_CODE,FINEST;.*VISUALFORCE,FINEST;?.*)/
       ) !== null
     );
   }

--- a/packages/salesforcedx-apex/src/execute/utils.ts
+++ b/packages/salesforcedx-apex/src/execute/utils.ts
@@ -16,6 +16,7 @@ const xmlCharMap: { [key: string]: string } = {
 
 const escapeXml = (data: string): string => data.replaceAll(/[<>&'\"]/g, (char: string) => xmlCharMap[char]);
 
+// Encodes request body with SOAP envelope and explicit DebuggingHeader: Apex_code=Finest, Visualforce=Finer
 export function encodeBody(accessToken: string, data: string): string {
   const escapedData = escapeXml(data);
 
@@ -27,7 +28,10 @@ xmlns:apex="http://soap.sforce.com/2006/08/apex">
         <cmd:SessionHeader>
             <cmd:sessionId>${accessToken}</cmd:sessionId>
         </cmd:SessionHeader>
-        <apex:DebuggingHeader><apex:debugLevel>DEBUGONLY</apex:debugLevel></apex:DebuggingHeader>
+        <apex:DebuggingHeader>
+            <apex:categories><apex:category>Apex_code</apex:category><apex:level>Finest</apex:level></apex:categories>
+            <apex:categories><apex:category>Visualforce</apex:category><apex:level>Finer</apex:level></apex:categories>
+        </apex:DebuggingHeader>
     </env:Header>
     <env:Body>
         <${action} xmlns="http://soap.sforce.com/2006/08/apex">

--- a/packages/salesforcedx-apex/test/execute/utils.test.ts
+++ b/packages/salesforcedx-apex/test/execute/utils.test.ts
@@ -10,7 +10,10 @@ import { encodeBody } from '../../src/execute/utils';
 describe('encodeBody for execute request', () => {
   const accessToken = '0000000000x189';
   let actionBody = 'System.assert(true);';
-  const debugHeader = '<apex:DebuggingHeader><apex:debugLevel>DEBUGONLY</apex:debugLevel></apex:DebuggingHeader>';
+  const debugHeader = `<apex:DebuggingHeader>
+            <apex:categories><apex:category>Apex_code</apex:category><apex:level>Finest</apex:level></apex:categories>
+            <apex:categories><apex:category>Visualforce</apex:category><apex:level>Finer</apex:level></apex:categories>
+        </apex:DebuggingHeader>`;
   const action = 'executeAnonymous';
   const expectedBody = `<env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/debugAnonymousApex.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/debugAnonymousApex.desktop.spec.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { expect, type Page } from '@playwright/test';
+import {
+  clickCodeLens,
+  ensureOutputPanelOpen,
+  ensureSecondarySideBarHidden,
+  executeCommandWithCommandPalette,
+  openFileByName,
+  QUICK_INPUT_WIDGET,
+  saveScreenshot,
+  setupConsoleMonitoring,
+  setupMinimalOrgAndAuth,
+  setupNetworkMonitoring,
+  validateNoCriticalErrors,
+  waitForQuickInputFirstOption,
+  WORKBENCH
+} from '@salesforce/playwright-vscode-ext';
+
+import apexLogNls from 'salesforcedx-vscode-apex-log/package.nls.json';
+import packageNls from '../../../package.nls.json';
+import { test } from '../fixtures';
+
+/** Continue debug session (dismiss hover, Escape, then F5). Repeats until session ends. */
+const continueDebugSession = async (page: Page, maxContinues = 2): Promise<void> => {
+  const toolbar = page.locator('.debug-toolbar');
+  for (let i = 0; i < maxContinues; i++) {
+    await toolbar.waitFor({ state: 'visible', timeout: 15_000 });
+    await page.locator(`${WORKBENCH} .editor-instance .view-lines`).first().click({ force: true });
+    await page.keyboard.press('Escape');
+    await page.keyboard.press('F5');
+    const sessionEnded = await expect(toolbar)
+      .not.toBeVisible({ timeout: 30_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (sessionEnded) break;
+  }
+  await expect(toolbar).not.toBeVisible({ timeout: 45_000 });
+};
+
+/** Creates a named .apex script file via the command palette and returns with the file open. */
+const createAndOpenApexScript = async (page: Page, name: string, content: string): Promise<void> => {
+  await executeCommandWithCommandPalette(page, apexLogNls['apexLog.command.createAnonymousApexScript'] as string);
+  await page.locator(QUICK_INPUT_WIDGET).waitFor({ state: 'visible', timeout: 10_000 });
+  await page.keyboard.type(name);
+  await page.keyboard.press('Enter');
+  await waitForQuickInputFirstOption(page);
+  await page.keyboard.press('Enter');
+
+  await page
+    .locator('.tab')
+    .filter({ hasText: new RegExp(`${name}\\.apex`) })
+    .waitFor({ state: 'visible', timeout: 15_000 });
+  await openFileByName(page, `${name}.apex`);
+
+  // Populate the .apex file with test content
+  const editorArea = page.locator('.editor-instance .view-lines').first();
+  await editorArea.click({ force: true });
+  await page.keyboard.press('Control+a');
+  await page.keyboard.type(content);
+  await page.keyboard.press('Control+s');
+};
+
+const ANON_APEX_CONTENT = "System.debug('hello from anonymous apex');";
+const ANON_APEX_SCRIPT_NAME = 'DebugAnonApex';
+
+test('Debug Anonymous Apex: Debug code lens, Launch with Selected File, and Debug with Selected Text', async ({
+  page
+}) => {
+  test.setTimeout(600_000);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  await test.step('setup minimal org and create shared anonymous apex script', async () => {
+    await setupMinimalOrgAndAuth(page);
+    await ensureSecondarySideBarHidden(page);
+    await ensureOutputPanelOpen(page);
+    await createAndOpenApexScript(page, ANON_APEX_SCRIPT_NAME, ANON_APEX_CONTENT);
+    await saveScreenshot(page, 'setup.script-open.png');
+  });
+
+  // ── Case 1: "Debug" code lens ──────────────────────────────────────────────
+  await test.step('click "Debug" code lens — debugger must launch and complete', async () => {
+    await openFileByName(page, `${ANON_APEX_SCRIPT_NAME}.apex`);
+    // The Apex LS renders "Execute | Debug" above .apex files; click the "Debug" link
+    // Long timeout covers Apex LS cold-start indexing before code lenses appear
+    await clickCodeLens(page, 'Debug', { timeout: 120_000 });
+    await continueDebugSession(page);
+    await saveScreenshot(page, 'step.debug-codelens.session-ended.png');
+  });
+
+  // ── Case 2: "Launch Apex Replay Debugger with Selected File" on .apex ─────
+  await test.step('"Launch Apex Replay Debugger with Selected File" on .apex — debugger must launch and complete', async () => {
+    await openFileByName(page, `${ANON_APEX_SCRIPT_NAME}.apex`);
+    await executeCommandWithCommandPalette(page, packageNls.launch_apex_replay_debugger_with_selected_file as string);
+    await continueDebugSession(page);
+    await saveScreenshot(page, 'step.launch-selected.session-ended.png');
+  });
+
+  // ── Case 3: "Debug Anonymous Apex with Editor's Selected Text" ─────────────
+  await test.step('select all text and run "Debug Anonymous Apex with Editor\'s Selected Text"', async () => {
+    await openFileByName(page, `${ANON_APEX_SCRIPT_NAME}.apex`);
+
+    // Select the entire file contents — keep editor focus so editorHasSelection is true
+    const editorArea = page.locator('.editor-instance .view-lines').first();
+    await editorArea.click({ force: true });
+    await page.keyboard.press('Control+a');
+
+    await executeCommandWithCommandPalette(page, packageNls.apex_debug_document_text as string, undefined, {
+      preserveSelection: true
+    });
+
+    await continueDebugSession(page);
+    await saveScreenshot(page, 'step.debug-selection.session-ended.png');
+  });
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-services/src/core/executeAnonymousService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/executeAnonymousService.ts
@@ -29,6 +29,7 @@ const XML_CHAR_MAP: Record<string, string> = {
 
 const escapeXml = (data: string): string => data.replaceAll(/[<>&'"]/g, char => XML_CHAR_MAP[char] ?? char);
 
+// Builds SOAP request body with explicit DebuggingHeader categories: Apex_code=Finest, Visualforce=Finer
 const buildSoapBody = (accessToken: string, apexCode: string): string => {
   const escaped = escapeXml(apexCode);
   return `<env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
@@ -39,7 +40,10 @@ xmlns:apex="http://soap.sforce.com/2006/08/apex">
         <cmd:SessionHeader>
             <cmd:sessionId>${accessToken}</cmd:sessionId>
         </cmd:SessionHeader>
-        <apex:DebuggingHeader><apex:debugLevel>DEBUGONLY</apex:debugLevel></apex:DebuggingHeader>
+        <apex:DebuggingHeader>
+            <apex:categories><apex:category>Apex_code</apex:category><apex:level>Finest</apex:level></apex:categories>
+            <apex:categories><apex:category>Visualforce</apex:category><apex:level>Finer</apex:level></apex:categories>
+        </apex:DebuggingHeader>
     </env:Header>
     <env:Body>
         <executeAnonymous xmlns="http://soap.sforce.com/2006/08/apex">


### PR DESCRIPTION
### What does this PR do?
When debugging Anonymous Apex, I was seeing this error:
<img width="2032" height="1162" alt="Screenshot 2026-07-06 at 8 12 13 PM" src="https://github.com/user-attachments/assets/1d8526e3-4bb1-44eb-a4b4-64f7aec4aa7e" />

This was happening in all 3 methods where Anonymous Apex could be debugged:
1. The "Debug" code lens at the top of Anonymous Apex files
2. **SFDX: Launch Apex Replay Debugger with Selected File** when run on an Anonymous Apex file
3. **SFDX: Debug Anonymous Apex with Editor's Selected Text** when highlighting Apex code in regular Apex and Anonymous Apex files and trying to debug it

**Root cause 1:** `executeAnonymousService.ts` and `salesforcedx-apex/execute/utils.ts` both sent SOAP `DebuggingHeader` with `DEBUGONLY` preset, which does not include `APEX_CODE` or `VISUALFORCE` categories in the returned log header.

**Root cause 2:** `logContext.meetsLogLevelRequirements()` regex required a trailing semicolon after `VISUALFORCE,FINER` — but when Visualforce is the last category (as it is when only two categories are specified), there is no trailing semicolon.

Fix: Changed both SOAP bodies to use explicit `Apex_code=Finest, Visualforce=Finer` categories; made trailing semicolon optional `(;?)` in the validation regex.

### What issues does this PR fix or reference?
@W-23339705@