### PR TITLE
chore(deps): bump @salesforce/core from 8.32.0 to 8.32.2 W-23349530

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8317,9 +8317,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8334,9 +8331,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8351,9 +8345,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8368,9 +8359,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8385,9 +8373,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8402,9 +8387,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8419,9 +8401,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8436,9 +8415,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8453,9 +8429,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8470,9 +8443,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8487,9 +8457,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8504,9 +8471,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8521,9 +8485,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8650,9 +8611,9 @@
       }
     },
     "node_modules/@salesforce/core": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-8.32.0.tgz",
-      "integrity": "sha512-aqzGyDLjvXr7/pHTbDLcXiPGnU45McAxPRoxyM8Iki0EBPCuOQvZkf2mc+4zcHlG0gJUMpnJ7nJnHtm7ivCq0A==",
+      "version": "8.32.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-8.32.2.tgz",
+      "integrity": "sha512-IenGtnr68o1Pg8WDA5XUDeuqTmdCbAyLCAU1hdbIcqM3kyEfvyaHgou0/KfEx6EokCxJ4MZFJ6MmjL8dY53XGQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jsforce/jsforce-node": "^3.10.17",
@@ -10801,9 +10762,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10818,9 +10776,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10835,9 +10790,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10852,9 +10804,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10869,9 +10818,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10886,9 +10832,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10903,9 +10846,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10920,9 +10860,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10937,9 +10874,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10954,9 +10888,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -44164,7 +44164,7 @@
         "@vscode/test-web": "^0.0.78"
       },
       "devDependencies": {
-        "@salesforce/core": "^8.32.0"
+        "@salesforce/core": "^8.32.2"
       }
     },
     "packages/salesforcedx-apex": {
@@ -44173,7 +44173,7 @@
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "^8.32.0",
+        "@salesforce/core": "^8.32.2",
         "@salesforce/kit": "^3.2.6",
         "@salesforce/ts-types": "^2.0.10",
         "fast-glob": "^3.3.2",
@@ -44200,7 +44200,7 @@
       "version": "65.7.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "^8.32.0",
+        "@salesforce/core": "^8.32.2",
         "@salesforce/salesforcedx-utils": "*",
         "@salesforce/vscode-i18n": "*",
         "@vscode/debugadapter": "1.68.0",
@@ -44226,7 +44226,7 @@
       "version": "65.7.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "^8.32.0",
+        "@salesforce/core": "^8.32.2",
         "@salesforce/salesforcedx-utils": "*",
         "@salesforce/vscode-i18n": "*",
         "@vscode/debugadapter": "1.68.0",
@@ -44648,7 +44648,7 @@
       "version": "65.7.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "^8.32.0",
+        "@salesforce/core": "^8.32.2",
         "@salesforce/effect-ext-utils": "*",
         "@salesforce/o11y-reporter": "^1.8.5",
         "@salesforce/salesforcedx-utils": "*",
@@ -44723,7 +44723,7 @@
         "vscode-uri": "^3.1.0"
       },
       "devDependencies": {
-        "@salesforce/core": "^8.32.0",
+        "@salesforce/core": "^8.32.2",
         "@salesforce/playwright-vscode-ext": "*",
         "salesforcedx-vscode-core": "*",
         "salesforcedx-vscode-services": "*"
@@ -44737,7 +44737,7 @@
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "^8.32.0",
+        "@salesforce/core": "^8.32.2",
         "@salesforce/effect-ext-utils": "*",
         "@salesforce/salesforcedx-apex-debugger": "*",
         "@salesforce/salesforcedx-utils": "*",
@@ -44768,7 +44768,7 @@
         "vscode-uri": "^3.1.0"
       },
       "devDependencies": {
-        "@salesforce/core": "^8.32.0",
+        "@salesforce/core": "^8.32.2",
         "@salesforce/playwright-vscode-ext": "*",
         "salesforcedx-vscode-services": "*"
       },
@@ -44884,7 +44884,7 @@
       },
       "devDependencies": {
         "@playwright/test": "*",
-        "@salesforce/core": "^8.32.0",
+        "@salesforce/core": "^8.32.2",
         "@salesforce/playwright-vscode-ext": "*",
         "salesforcedx-vscode-apex": "*",
         "salesforcedx-vscode-core": "*",
@@ -44921,7 +44921,7 @@
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "^8.32.0",
+        "@salesforce/core": "^8.32.2",
         "@salesforce/effect-ext-utils": "*",
         "@salesforce/o11y-reporter": "^1.8.5",
         "@salesforce/salesforcedx-utils": "*",
@@ -45049,7 +45049,7 @@
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "^8.32.0",
+        "@salesforce/core": "^8.32.2",
         "@salesforce/effect-ext-utils": "*",
         "@salesforce/salesforcedx-utils-vscode": "*",
         "@salesforce/vscode-i18n": "*",
@@ -45078,7 +45078,7 @@
         "vscode-uri": "^3.1.0"
       },
       "devDependencies": {
-        "@salesforce/core": "^8.32.0",
+        "@salesforce/core": "^8.32.2",
         "@salesforce/playwright-vscode-ext": "*",
         "@salesforce/source-deploy-retrieve": "^12.32.5",
         "salesforcedx-vscode-services": "*"
@@ -45104,7 +45104,7 @@
         "@opentelemetry/sdk-trace-base": "2.7.1",
         "@opentelemetry/sdk-trace-node": "2.7.1",
         "@opentelemetry/sdk-trace-web": "2.8.0",
-        "@salesforce/core": "^8.32.0",
+        "@salesforce/core": "^8.32.2",
         "@salesforce/o11y-reporter": "^1.8.5",
         "@salesforce/source-deploy-retrieve": "^12.32.5",
         "@salesforce/source-tracking": "^7.8.16",
@@ -45139,7 +45139,7 @@
         "@opentelemetry/sdk-trace-base": "2.7.1",
         "@opentelemetry/sdk-trace-node": "2.7.1",
         "@opentelemetry/sdk-trace-web": "2.8.0",
-        "@salesforce/core": "^8.32.0",
+        "@salesforce/core": "^8.32.2",
         "@salesforce/source-deploy-retrieve": "^12.32.5",
         "@salesforce/source-tracking": "^7.8.16",
         "@types/vscode": "^1.90.0",
@@ -45204,7 +45204,7 @@
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "^8.32.0",
+        "@salesforce/core": "^8.32.2",
         "@salesforce/effect-ext-utils": "*",
         "@salesforce/soql-common": "*",
         "@salesforce/soql-language-server": "^1.1.0",

--- a/packages/playwright-vscode-ext/package.json
+++ b/packages/playwright-vscode-ext/package.json
@@ -38,7 +38,7 @@
     "@vscode/test-web": "^0.0.78"
   },
   "devDependencies": {
-    "@salesforce/core": "^8.32.0"
+    "@salesforce/core": "^8.32.2"
   },
   "scripts": {
     "check:circular-deps": "wireit",

--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -13,7 +13,7 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/core": "^8.32.0",
+    "@salesforce/core": "^8.32.2",
     "@salesforce/salesforcedx-utils": "*",
     "@salesforce/vscode-i18n": "*",
     "@vscode/debugadapter": "1.68.0",

--- a/packages/salesforcedx-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-apex-replay-debugger/package.json
@@ -14,7 +14,7 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/core": "^8.32.0",
+    "@salesforce/core": "^8.32.2",
     "@salesforce/salesforcedx-utils": "*",
     "@salesforce/vscode-i18n": "*",
     "@vscode/debugadapter": "1.68.0",

--- a/packages/salesforcedx-apex/package.json
+++ b/packages/salesforcedx-apex/package.json
@@ -17,7 +17,7 @@
     }
   },
   "dependencies": {
-    "@salesforce/core": "^8.32.0",
+    "@salesforce/core": "^8.32.2",
     "@salesforce/kit": "^3.2.6",
     "@salesforce/ts-types": "^2.0.10",
     "fast-glob": "^3.3.2",

--- a/packages/salesforcedx-utils-vscode/package.json
+++ b/packages/salesforcedx-utils-vscode/package.json
@@ -10,7 +10,7 @@
   ],
   "main": "out/src",
   "dependencies": {
-    "@salesforce/core": "^8.32.0",
+    "@salesforce/core": "^8.32.2",
     "@salesforce/effect-ext-utils": "*",
     "@salesforce/o11y-reporter": "^1.8.5",
     "@salesforce/salesforcedx-utils": "*",

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -28,7 +28,7 @@
     "Debuggers"
   ],
   "dependencies": {
-    "@salesforce/core": "^8.32.0",
+    "@salesforce/core": "^8.32.2",
     "@salesforce/effect-ext-utils": "*",
     "@salesforce/salesforcedx-apex-debugger": "*",
     "@salesforce/salesforcedx-utils": "*",

--- a/packages/salesforcedx-vscode-apex-log/package.json
+++ b/packages/salesforcedx-vscode-apex-log/package.json
@@ -34,7 +34,7 @@
     "vscode-uri": "^3.1.0"
   },
   "devDependencies": {
-    "@salesforce/core": "^8.32.0",
+    "@salesforce/core": "^8.32.2",
     "@salesforce/playwright-vscode-ext": "*",
     "salesforcedx-vscode-services": "*"
   },

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@playwright/test": "*",
-    "@salesforce/core": "^8.32.0",
+    "@salesforce/core": "^8.32.2",
     "@salesforce/playwright-vscode-ext": "*",
     "salesforcedx-vscode-apex": "*",
     "salesforcedx-vscode-core": "*",

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -39,7 +39,7 @@
     "vscode-uri": "^3.1.0"
   },
   "devDependencies": {
-    "@salesforce/core": "^8.32.0",
+    "@salesforce/core": "^8.32.2",
     "@salesforce/playwright-vscode-ext": "*",
     "salesforcedx-vscode-core": "*",
     "salesforcedx-vscode-services": "*"

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -28,7 +28,7 @@
     "Other"
   ],
   "dependencies": {
-    "@salesforce/core": "^8.32.0",
+    "@salesforce/core": "^8.32.2",
     "@salesforce/effect-ext-utils": "*",
     "@salesforce/o11y-reporter": "^1.8.5",
     "@salesforce/salesforcedx-utils": "*",

--- a/packages/salesforcedx-vscode-org-browser/package.json
+++ b/packages/salesforcedx-vscode-org-browser/package.json
@@ -34,7 +34,7 @@
     "vscode-uri": "^3.1.0"
   },
   "devDependencies": {
-    "@salesforce/core": "^8.32.0",
+    "@salesforce/core": "^8.32.2",
     "@salesforce/playwright-vscode-ext": "*",
     "@salesforce/source-deploy-retrieve": "^12.32.5",
     "salesforcedx-vscode-services": "*"

--- a/packages/salesforcedx-vscode-org/package.json
+++ b/packages/salesforcedx-vscode-org/package.json
@@ -28,7 +28,7 @@
     "Other"
   ],
   "dependencies": {
-    "@salesforce/core": "^8.32.0",
+    "@salesforce/core": "^8.32.2",
     "@salesforce/effect-ext-utils": "*",
     "@salesforce/salesforcedx-utils-vscode": "*",
     "@salesforce/vscode-services": "*",

--- a/packages/salesforcedx-vscode-services-types/package.json
+++ b/packages/salesforcedx-vscode-services-types/package.json
@@ -75,7 +75,7 @@
     "@opentelemetry/sdk-trace-base": "2.7.1",
     "@opentelemetry/sdk-trace-node": "2.7.1",
     "@opentelemetry/sdk-trace-web": "2.8.0",
-    "@salesforce/core": "^8.32.0",
+    "@salesforce/core": "^8.32.2",
     "@salesforce/source-deploy-retrieve": "^12.32.5",
     "@salesforce/source-tracking": "^7.8.16",
     "@types/vscode": "^1.90.0",

--- a/packages/salesforcedx-vscode-services/package.json
+++ b/packages/salesforcedx-vscode-services/package.json
@@ -40,7 +40,7 @@
     "@opentelemetry/sdk-trace-base": "2.7.1",
     "@opentelemetry/sdk-trace-node": "2.7.1",
     "@opentelemetry/sdk-trace-web": "2.8.0",
-    "@salesforce/core": "^8.32.0",
+    "@salesforce/core": "^8.32.2",
     "@salesforce/o11y-reporter": "^1.8.5",
     "@salesforce/source-deploy-retrieve": "^12.32.5",
     "@salesforce/source-tracking": "^7.8.16",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -35,7 +35,7 @@
     "soql builder"
   ],
   "dependencies": {
-    "@salesforce/core": "^8.32.0",
+    "@salesforce/core": "^8.32.2",
     "@salesforce/effect-ext-utils": "*",
     "effect": "^3.21.2",
     "@salesforce/soql-common": "*",


### PR DESCRIPTION
## Summary
- Bumps `@salesforce/core` from 8.32.0 to 8.32.2
- Picks up forcedotcom/sfdx-core#1310 (W-23299190), which removes a double slash in the request URL built by `determineIfDevHub` in `authInfo.ts`

## Work item
@W-23349530@

## Test plan
- [ ] CI green (lint/build/test)