### PR TITLE
chore(soql): @salesforce/core devDependency (type-only) - W-23354450

### DIFF
--- a/.claude/plans/W-23354450.md
+++ b/.claude/plans/W-23354450.md
@@ -1,0 +1,32 @@
+# W-23354450 — @salesforce/core devDependency in soql
+
+## Context
+
+- All `@salesforce/core` refs in soql = `import type { Connection }`; erased at compile
+  - `src/types.ts:7`, `src/services/org.ts:8`, `src/editor/queryRunner.ts:9`, `test/jest/editor/queryRunner.test.ts:8`
+- No runtime require/import; esbuild only externalizes `vscode` → core never in bundle closure
+- Type-only ⇒ runtime never needs pkg ⇒ move to devDependencies
+
+## Phases
+
+### Phase 1 — move core to devDependencies
+- `packages/salesforcedx-vscode-soql/package.json`: delete `@salesforce/core` from `dependencies`, add to `devDependencies` (alpha-adjacent; keep `^8.32.2`)
+- commit: `chore(soql): @salesforce/core devDependency (type-only) - W-23354450`
+
+## Skills
+
+- packageJson — dep vs devDep conventions
+- wireit — build graph
+- typescript — type-only import conventions
+- verification
+
+## Verification
+
+- `npm run compile` (soql) — tsc passes, type import resolves from devDep
+- `npm run vscode:bundle` (soql) — bundle succeeds; grep `dist/` for `@salesforce/core` → absent
+- `npm run test` (soql jest) — type-only test import unaffected
+- e2e-covered (already wired into `vscode:bundle` wireit graph): `test:web` / `test:desktop` run these Playwright specs in `packages/salesforcedx-vscode-soql/test/playwright/specs/`:
+  - `soql-run-query.spec.ts` — MUST pass; exercises `queryRunner.ts` (`Connection`-typed call site at `src/editor/queryRunner.ts:23`), the file most likely to regress if the devDep move leaves a runtime gap
+  - `soql-save-query-results.spec.ts`
+  - `soql-query-plan.spec.ts`
+  - `soql-builder.spec.ts`

--- a/package-lock.json
+++ b/package-lock.json
@@ -45204,7 +45204,6 @@
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "^8.32.2",
         "@salesforce/effect-ext-utils": "*",
         "@salesforce/soql-common": "*",
         "@salesforce/soql-language-server": "^1.1.0",
@@ -45230,6 +45229,7 @@
         "@rollup/plugin-inject": "^5.0.0",
         "@rollup/plugin-node-resolve": "^16.0.0",
         "@rollup/plugin-terser": "^1.0.0",
+        "@salesforce/core": "^8.32.2",
         "@salesforce/eslint-config-lwc": "^4.1.2",
         "@salesforce/eslint-plugin-lightning": "^2.0.0",
         "@salesforce/playwright-vscode-ext": "*",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -35,7 +35,6 @@
     "soql builder"
   ],
   "dependencies": {
-    "@salesforce/core": "^8.32.2",
     "@salesforce/effect-ext-utils": "*",
     "effect": "^3.21.2",
     "@salesforce/soql-common": "*",
@@ -61,6 +60,7 @@
     "@rollup/plugin-inject": "^5.0.0",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@rollup/plugin-terser": "^1.0.0",
+    "@salesforce/core": "^8.32.2",
     "@salesforce/eslint-config-lwc": "^4.1.2",
     "@salesforce/eslint-plugin-lightning": "^2.0.0",
     "@salesforce/playwright-vscode-ext": "*",


### PR DESCRIPTION
## Summary
- `@salesforce/core` refs in `salesforcedx-vscode-soql` are all `import type { Connection }` (type-only, erased at compile) — no runtime require/import exists
- esbuild only externalizes `vscode`; core was never actually in the bundle closure
- Move `@salesforce/core` from `dependencies` to `devDependencies` in `packages/salesforcedx-vscode-soql/package.json`

## Plan
[.claude/plans/W-23354450.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23354450-make-salesforce-core-a-devdependency-in/.claude/plans/W-23354450.md)

### What issues does this PR fix or reference?
@W-23354450@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eBDYlYAO/view
