### PR TITLE
refactor(org): migrate sf.org.logout.default to services - W-23069609

### DIFF
--- a/.claude/plans/W-23069609.md
+++ b/.claude/plans/W-23069609.md
@@ -15,7 +15,11 @@
 - Downstream e2e depends on title `SFDX: Log Out from Default Org` (`org_logout_default_text`) + scratch confirm `Logout` (`org_logout_scratch_logout`): apex-testing `clearOnLogout.headless.spec.ts` L43-45, L107. Keep behavior + titles.
 - No-default-org branch: `notificationService.showInformationMessage(org_logout_no_default_org)` — keep via `Effect.sync`.
 - Reuse `resolveTargetOrg` (TargetOrgRef) for username/isScratch/aliases.
-- CRITICAL — do NOT delete the in-process ref clear. The default path ALWAYS logs out the org `resolveTargetOrg()` just read as the current default, so removeAuth unsets that exact target-org config key. `updateConfigAndStateAggregatorsEffect()` (orgUtil.ts:121-140) then calls `ConnectionService.getConnection().pipe(Effect.catchAll(() => Effect.void))` (L139) — it SWALLOWS the failure and does NOT `clearDefaultOrgRef`, unlike configFileWatcher.ts:43 (`Effect.catchAll(() => clearDefaultOrgRef())`). Post-removeAuth getConnection fails with NoTargetOrgConfiguredError and is silently dropped → the ref never clears → the clearOnLogout tree/virtual-doc never clear. This is the exact regression #7624 diagnosed twice (commit 91e3d387d body: "no getConnection/clearDefaultOrgRef fires post-logout within the 60s window"; follow-up "only clear target-org ref when logged-out org was the target"). Keep an explicit, deterministic clear composed into the single Effect chain: `isCurrentTargetOrg(username, aliases)` BEFORE removeAuth, `ConfigService.unsetTargetOrg()` AFTER (mirroring current `OrgLogoutDefault.run` L156-171). The all-path e2e does NOT cover this — orgPickers logs out THROWAWAY while MINIMAL stays default (orgPickers.desktop.spec.ts:130-146), so it never exercises "logged-out org is also the current default".
+- CRITICAL — do NOT delete the in-process ref clear.
+  - root cause: default path ALWAYS logs out the org `resolveTargetOrg()` read as current default → removeAuth unsets that target-org key. `updateConfigAndStateAggregatorsEffect()` (orgUtil.ts:121-140) calls `ConnectionService.getConnection().pipe(Effect.catchAll(() => Effect.void))` (L139) — SWALLOWS failure, does NOT `clearDefaultOrgRef` (unlike configFileWatcher.ts:43). Post-removeAuth getConnection fails NoTargetOrgConfiguredError, silently dropped → ref never clears → clearOnLogout tree/virtual-doc never clear.
+  - regression: #7624, diagnosed twice (91e3d387d body: "no getConnection/clearDefaultOrgRef fires post-logout within 60s window"; follow-up: "only clear target-org ref when logged-out org was the target").
+  - fix: explicit deterministic clear in the single Effect chain — `isCurrentTargetOrg(username, aliases)` BEFORE removeAuth, `ConfigService.unsetTargetOrg()` AFTER (mirrors current `OrgLogoutDefault.run` L156-171).
+  - gap: all-path e2e does NOT cover this — orgPickers logs out THROWAWAY, MINIMAL stays default (orgPickers.desktop.spec.ts:130-146), never exercises "logged-out org is also current default".
 
 ## Phases
 
@@ -57,9 +61,15 @@ commit: `test(org): cover orgLogoutDefaultCommand effect - W-23069609`
 
 ### Phase 3 — e2e
 
-- Keep apex-testing `clearOnLogout.headless.spec.ts` green — it covers UI tree-clear + virtual-doc close on default logout, and (given the CRITICAL ref-clear note) is the real regression guard for the in-process ref clear. NOT a rubber stamp: this spec is the one that failed twice in #7624 when the ref didn't clear. Confirm it stays green under the migrated command.
-- COMMIT (unconditional, WI ask): add a new `test.step` to orgPickers.desktop.spec.ts, `LOGOUT DEFAULT real: confirm removes auth for the default org`, modeled on the existing L129-140 `LOGOUT real` step but for `sf.org.logout.default` (`packageNls.org_logout_default_text`). It must run `sf org list --json` via the existing `expectOrgLoggedOut(alias)` helper to durably assert AuthRemover actually ran on the default path — no spec does this today (clearOnLogout asserts UI only; orgPickers L129-140 exercises logout.all, not .default).
-  - Use a dedicated throwaway org set AS the default so this exercises the "logged-out org is the current default" path. Options: set the throwaway as target-org for this step (so removeAuth unsets the current default), OR add a second throwaway. Do NOT log out MINIMAL_ORG_ALIAS (shared with siblings / relied on by earlier cancel steps). Sequence this step after the existing throwaway logout, or seed a distinct alias, so remaining steps still have MINIMAL authed. Confirm the scratch modal (`org_logout_scratch_logout` = 'Logout') since throwaway is a scratch org.
+- Keep apex-testing `clearOnLogout.headless.spec.ts` green — ref-clear regression guard, see Context CRITICAL. NOT a rubber stamp: failed twice in #7624 when ref didn't clear. Confirm green under migrated command.
+- COMMIT (unconditional, WI ask): add `test.step` to orgPickers.desktop.spec.ts:
+  - step name: `LOGOUT DEFAULT real: confirm removes auth for the default org`, modeled on L129-140 `LOGOUT real` but for `sf.org.logout.default` (`packageNls.org_logout_default_text`).
+  - assertion: run `sf org list --json` via `expectOrgLoggedOut(alias)` — durably asserts AuthRemover ran on default path.
+  - gap it closes: no spec does this today (clearOnLogout asserts UI only; orgPickers L129-140 exercises logout.all, not .default).
+  - throwaway org set AS default → exercises "logged-out org is current default" path. Options:
+    - set throwaway as target-org for this step (removeAuth unsets current default), OR
+    - add a second throwaway.
+  - do NOT log out MINIMAL_ORG_ALIAS (shared / relied on by earlier cancel steps). Sequence after existing throwaway logout, or seed distinct alias, so MINIMAL stays authed. Confirm scratch modal (`org_logout_scratch_logout` = 'Logout') since throwaway is scratch.
 
 commit: `test(org): e2e default-org logout removes auth - W-23069609`
 

--- a/.claude/plans/W-23069609.md
+++ b/.claude/plans/W-23069609.md
@@ -1,0 +1,82 @@
+# W-23069609 — Migrate sf.org.logout.default to services
+
+## Context
+
+- WI 5, sibling of #7624 (sf.org.logout.all, W-23069610, merged). Model exactly on it.
+- Target: `packages/salesforcedx-vscode-org/src/commands/auth/orgLogout.ts`.
+- Current default path still uses commandlet machinery:
+  - `orgLogoutDefault` builds `SfCommandlet(sfProjectPreconditionChecker, gatherer, OrgLogoutDefault)`.
+  - `OrgLogoutDefault extends LibraryCommandletExecutor`.
+  - `SimpleGatherer` (inline) + `ScratchOrgLogoutParamsGatherer` gatherers.
+  - manual `checkIsCurrentTargetOrg` (before removeAuth) + `clearTargetOrgRef` (after). NOT redundant — see refresh note below; this must be PRESERVED in the migration.
+- All path (`orgLogoutAllCommand`) already migrated — reuse its shapes: `removeAuth` helper, `OrgLogoutError`, `updateConfigAndStateAggregatorsEffect`, `AuthRemover.create({projectPath, skipCache:true})`, `confirmOrThrow`, `catchTag('UserCancellationError')`.
+- Registration: today `registerCommands()` uses raw `vscode.commands.registerCommand('sf.org.logout.default', orgLogoutDefault)` (index.ts L42/74). Move to `registerCommand(...)` (registerCommandWithLayer(AllServicesLayer)) block L79-90.
+- MUST NOT use SfCommandlet / LibraryCommandletExecutor / CommandletExecutor.
+- Downstream e2e depends on title `SFDX: Log Out from Default Org` (`org_logout_default_text`) + scratch confirm `Logout` (`org_logout_scratch_logout`): apex-testing `clearOnLogout.headless.spec.ts` L43-45, L107. Keep behavior + titles.
+- No-default-org branch: `notificationService.showInformationMessage(org_logout_no_default_org)` — keep via `Effect.sync`.
+- Reuse `resolveTargetOrg` (TargetOrgRef) for username/isScratch/aliases.
+- CRITICAL — do NOT delete the in-process ref clear. The default path ALWAYS logs out the org `resolveTargetOrg()` just read as the current default, so removeAuth unsets that exact target-org config key. `updateConfigAndStateAggregatorsEffect()` (orgUtil.ts:121-140) then calls `ConnectionService.getConnection().pipe(Effect.catchAll(() => Effect.void))` (L139) — it SWALLOWS the failure and does NOT `clearDefaultOrgRef`, unlike configFileWatcher.ts:43 (`Effect.catchAll(() => clearDefaultOrgRef())`). Post-removeAuth getConnection fails with NoTargetOrgConfiguredError and is silently dropped → the ref never clears → the clearOnLogout tree/virtual-doc never clear. This is the exact regression #7624 diagnosed twice (commit 91e3d387d body: "no getConnection/clearDefaultOrgRef fires post-logout within the 60s window"; follow-up "only clear target-org ref when logged-out org was the target"). Keep an explicit, deterministic clear composed into the single Effect chain: `isCurrentTargetOrg(username, aliases)` BEFORE removeAuth, `ConfigService.unsetTargetOrg()` AFTER (mirroring current `OrgLogoutDefault.run` L156-171). The all-path e2e does NOT cover this — orgPickers logs out THROWAWAY while MINIMAL stays default (orgPickers.desktop.spec.ts:130-146), so it never exercises "logged-out org is also the current default".
+
+## Phases
+
+### Phase 1 — migrate command to Effect
+
+- New `orgLogoutDefaultCommand = Effect.fn('orgLogoutDefaultCommand')(function*(){...}, catchTag('UserCancellationError', ()=>Effect.void))`:
+  - precondition `api.services.ProjectService.getSfProject()`.
+  - `resolveTargetOrg()` → username/isScratch/aliases.
+  - no username → `Effect.sync(() => void notificationService.showInformationMessage(nls.localize('org_logout_no_default_org')))`; return.
+  - scratch → `promptService.confirmOrThrow({ message: org_logout_scratch_prompt(alias??username), confirmLabel: org_logout_scratch_logout })`.
+  - `wasTargetOrg = yield* checkIsCurrentTargetOrg(username, aliases)` BEFORE removeAuth (after removeAuth the target-org config is gone, so the check must precede it — mirrors current L156-157).
+  - `getWorkspaceInfoOrThrow()` → projectPath; `AuthRemover.create({projectPath, skipCache:true})` (Effect.tryPromise → OrgLogoutError).
+  - `removeAuth(authRemover, username)` (reuse existing helper).
+  - `updateConfigAndStateAggregatorsEffect()`.
+  - `if (wasTargetOrg) yield* clearTargetOrgRef()` — deterministic in-process ref clear, since the refresh helper swallows the post-logout getConnection failure and won't clear it (see Context CRITICAL note). Keep both `checkIsCurrentTargetOrg` + `clearTargetOrgRef` Effect helpers.
+- Delete ONLY `OrgLogoutDefault`, `orgLogoutDefault`, `SimpleGatherer`. KEEP `checkIsCurrentTargetOrg` + `clearTargetOrgRef` (now composed into the Effect chain instead of `getOrgRuntime().runPromise`).
+- Drop now-unused imports: `LibraryCommandletExecutor`, `ParametersGatherer`, `SfCommandlet`, `ContinueResponse`, `notificationService`(keep — used by no-default branch), `workspaceUtils`, `sfProjectPreconditionChecker`, `SubscriptionRef`(keep — resolveTargetOrg stays), `OUTPUT_CHANNEL`, `getOrgRuntime`, `telemetryService`, `ScratchOrgLogoutParamsGatherer`, `getFreshAuthorizations`(keep — used by all).
+- Update `commands/index.ts` export `orgLogoutDefault` → `orgLogoutDefaultCommand`.
+- Add `ORG_LOGOUT_DEFAULT_COMMAND = 'sf.org.logout.default'` to `constants.ts` (mirror ORG_LOGOUT_ALL_COMMAND).
+- `index.ts`: drop `registerCommands()` raw registration (whole fn if now empty); register `ORG_LOGOUT_DEFAULT_COMMAND` via `registerCommand(...)` block.
+- Verify `ScratchOrgLogoutParamsGatherer` unused elsewhere; if so delete it + `SimpleGatherer` need; keep authParamsGatherer if other gatherers remain.
+
+commit: `refactor(org): migrate sf.org.logout.default to services - W-23069609`
+
+### Phase 2 — jest tests
+
+- Rewrite `test/jest/commands/auth/orgLogout.test.ts` around `orgLogoutDefaultCommand`, modeled on `orgLogoutAll.test.ts` (Exit-based, mock ExtensionProviderService + AuthRemover).
+- Cases:
+  - non-scratch default (isCurrentTargetOrg true): removeAuth(username) + refresh + `unsetTargetOrg` called once; success. (carries forward orgLogout.test.ts:65-73 — the ref-clear assertion that guards #7624; DO NOT drop it.)
+  - logged-out org is NOT the current target (isCurrentTargetOrg false): removeAuth + refresh, `unsetTargetOrg` NOT called (mirrors current L75-84). Note: for the default command username always == current target, but assert the guard so the ref-clear can't fire on a non-target.
+  - scratch default + confirm accepted: removeAuth + refresh + ref clear.
+  - scratch + confirm declined (UserCancellationError): no removeAuth, no refresh, no ref clear, success (no-op).
+  - no default org: info message, no removeAuth/refresh/ref clear, success.
+  - no project: FailedToResolveSfProjectError, no removeAuth.
+  - removeAuth rejects → OrgLogoutError failure, no refresh, no ref clear.
+- Mock `TargetOrgRef` (resolveTargetOrg source), `ConfigService.isCurrentTargetOrg` + `unsetTargetOrg`, AuthRemover.
+
+commit: `test(org): cover orgLogoutDefaultCommand effect - W-23069609`
+
+### Phase 3 — e2e
+
+- Keep apex-testing `clearOnLogout.headless.spec.ts` green — it covers UI tree-clear + virtual-doc close on default logout, and (given the CRITICAL ref-clear note) is the real regression guard for the in-process ref clear. NOT a rubber stamp: this spec is the one that failed twice in #7624 when the ref didn't clear. Confirm it stays green under the migrated command.
+- COMMIT (unconditional, WI ask): add a new `test.step` to orgPickers.desktop.spec.ts, `LOGOUT DEFAULT real: confirm removes auth for the default org`, modeled on the existing L129-140 `LOGOUT real` step but for `sf.org.logout.default` (`packageNls.org_logout_default_text`). It must run `sf org list --json` via the existing `expectOrgLoggedOut(alias)` helper to durably assert AuthRemover actually ran on the default path — no spec does this today (clearOnLogout asserts UI only; orgPickers L129-140 exercises logout.all, not .default).
+  - Use a dedicated throwaway org set AS the default so this exercises the "logged-out org is the current default" path. Options: set the throwaway as target-org for this step (so removeAuth unsets the current default), OR add a second throwaway. Do NOT log out MINIMAL_ORG_ALIAS (shared with siblings / relied on by earlier cancel steps). Sequence this step after the existing throwaway logout, or seed a distinct alias, so remaining steps still have MINIMAL authed. Confirm the scratch modal (`org_logout_scratch_logout` = 'Logout') since throwaway is a scratch org.
+
+commit: `test(org): e2e default-org logout removes auth - W-23069609`
+
+## Skills to apply
+
+- effect-best-practices (Effect.fn, TaggedError, catchTag, no runPromise nesting)
+- concise (this plan + comments)
+- playwright-e2e (Phase 3)
+- i18n-messages (only if new keys; reuse existing → likely none)
+- typescript / verification
+- services-extension-consumption (registerCommandWithLayer)
+
+## Verification
+
+- `npx effect-language-service diagnostics --file .../orgLogout.ts` clean (no effectFnOpportunity/globalErrorInEffectCatch).
+- typecheck + lint: no `let`, no barrel, direct imports; no residual SfCommandlet/LibraryCommandletExecutor/CommandletExecutor imports (`grep`).
+- jest orgLogout suite green (Phase 2), INCLUDING the `unsetTargetOrg`-called + not-called cases (ref-clear regression guard for #7624).
+- grep confirms `sf.org.logout.default` registered via registerCommandWithLayer block, not raw registerCommand.
+- confirm `org_logout_default_text` + `org_logout_scratch_logout` titles unchanged (downstream e2e depends).
+- e2e: clearOnLogout.headless (tree-clear + virtual-doc close = ref-clear regression guard) and the new orgPickers.desktop default-logout removal step (CLI-verified via `sf org list --json`) must both pass. These are the coverage that catches the swallowed-getConnection ref-clear failure mode — treat as required gates, not rubber stamps.

--- a/.github/workflows/orgE2E.yml
+++ b/.github/workflows/orgE2E.yml
@@ -51,6 +51,8 @@ jobs:
       # Dedicated throwaway org for the real-logout step; pre-seeded so tryUseExistingOrg hits and
       # createThrowawayOrg never reaches requireOrgInCI. The test logs it out; CI re-seeds each run.
       THROWAWAY_ORG_ALIAS: logoutThrowawayOrg
+      # Second throwaway, set AS default and logged out by the logout.default step (W-23069609).
+      DEFAULT_LOGOUT_ORG_ALIAS: logoutDefaultThrowawayOrg
       SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL_E2E }}
       # sf CLI hides authFields from `sf org create scratch --json` output by default; tests need them.
       SF_TEMP_SHOW_SECRETS: true
@@ -132,6 +134,15 @@ jobs:
           sf org create scratch -y 1 -f config/project-scratch-def.json -a "$THROWAWAY_ORG_ALIAS" --json
         working-directory: minimal-project
 
+      - name: create default-logout throwaway scratch org
+        if: steps.try-run.outcome == 'failure'
+        # pre-seeds DEFAULT_LOGOUT_ORG_ALIAS so the logout.default step's createThrowawayOrg fast-paths.
+        # This org is set as default and logged out by the test.
+        shell: bash
+        run: |
+          sf org create scratch -y 1 -f config/project-scratch-def.json -a "$DEFAULT_LOGOUT_ORG_ALIAS" --json
+        working-directory: minimal-project
+
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
         uses: salesforcecli/github-workflows/.github/actions/retry@main
@@ -191,3 +202,5 @@ jobs:
           sf org delete scratch -o "$MINIMAL_ORG_ALIAS" --no-prompt || true
           # best-effort: the real-logout test logs this org out (not delete); reap the scratch org here.
           sf org delete scratch -o "$THROWAWAY_ORG_ALIAS" --no-prompt || true
+          # logout.default test logs this org out too; reap it here.
+          sf org delete scratch -o "$DEFAULT_LOGOUT_ORG_ALIAS" --no-prompt || true

--- a/packages/salesforcedx-vscode-org/src/commands/auth/authParamsGatherer.ts
+++ b/packages/salesforcedx-vscode-org/src/commands/auth/authParamsGatherer.ts
@@ -6,11 +6,9 @@
  */
 
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
-import { CancelResponse, ContinueResponse, ParametersGatherer } from '@salesforce/salesforcedx-utils-vscode';
 import * as Effect from 'effect/Effect';
 import * as vscode from 'vscode';
 import { nls } from '../../messages';
-import { runGatherer } from '../../parameterGatherers/runGatherer';
 import { validateAliasInput } from '../../util/orgAlias';
 
 export const DEFAULT_ALIAS = 'vscodeOrg';
@@ -159,31 +157,6 @@ export const gatherAccessTokenParams = Effect.fn('AccessTokenParamsGatherer.gath
     instanceUrl
   };
 });
-
-const gatherScratchOrgLogout = Effect.fn('ScratchOrgLogoutParamsGatherer.gather')(function* (params: {
-  readonly username: string;
-  readonly alias: string | undefined;
-}) {
-  const api = yield* (yield* ExtensionProviderService).getServicesApi;
-  const promptService = yield* api.services.PromptService;
-
-  yield* promptService.confirmOrThrow({
-    message: nls.localize('org_logout_scratch_prompt', params.alias ?? params.username),
-    confirmLabel: nls.localize('org_logout_scratch_logout')
-  });
-  return params.username;
-});
-
-export class ScratchOrgLogoutParamsGatherer implements ParametersGatherer<string> {
-  constructor(
-    public readonly username: string,
-    public readonly alias?: string
-  ) {}
-
-  public async gather(): Promise<CancelResponse | ContinueResponse<string>> {
-    return runGatherer(gatherScratchOrgLogout({ username: this.username, alias: this.alias }));
-  }
-}
 
 const getProjectLoginUrl = Effect.fn('AuthParamsGatherer.getProjectLoginUrl')(function* () {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;

--- a/packages/salesforcedx-vscode-org/src/commands/auth/orgLogout.ts
+++ b/packages/salesforcedx-vscode-org/src/commands/auth/orgLogout.ts
@@ -7,7 +7,6 @@
 
 import { AuthRemover } from '@salesforce/core';
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
-import { notificationService } from '@salesforce/salesforcedx-utils-vscode';
 import * as Effect from 'effect/Effect';
 import * as Schema from 'effect/Schema';
 import * as SubscriptionRef from 'effect/SubscriptionRef';
@@ -28,19 +27,35 @@ export class OrgLogoutError extends Schema.TaggedError<OrgLogoutError>()('OrgLog
 }) {}
 
 /**
- * Logs out a single org via a shared `AuthRemover`. `AuthRemover.removeAuth` already calls
+ * Logs out a single org via an `AuthRemover`. `AuthRemover.removeAuth` already calls
  * `unsetConfigValues` + `unsetAliases` (node_modules/@salesforce/core/lib/org/authRemover.js L50-54),
  * which unsets every global+local config key matching the username/aliases — covering target-org AND
- * target-dev-hub. No separate alias/config-unset calls are needed here. The `AuthRemover` is created
- * once in `orgLogoutAllCommand` and reused (each `.create()` does a full disk read of all org files).
- * The remover is built with an explicit `projectPath` so the local config is resolved from the
- * workspace rather than `process.cwd()` (which the extension host must not be relied on to set).
+ * target-dev-hub. No separate alias/config-unset calls are needed here. See `createAuthRemover` for
+ * how the remover itself is built (shared per command, explicit `projectPath`, `skipCache`).
  */
 const removeAuth = Effect.fn('orgLogoutAllCommand.removeAuth')(function* (authRemover: AuthRemover, username: string) {
   yield* Effect.annotateCurrentSpan('username', username);
   yield* Effect.tryPromise({
     try: () => authRemover.removeAuth(username),
     catch: cause => new OrgLogoutError({ username, message: `Failed to log out of ${username}`, cause: String(cause) })
+  });
+});
+
+/**
+ * Builds one `AuthRemover` per command (not per org): each `.create()` reloads ConfigAggregator + reads
+ * all org files from disk (authRemover.js L92-97), so per-org creation repeats that I/O. `projectPath`
+ * resolves local config from the workspace rather than `process.cwd()` (the extension host must not be
+ * relied on to set it); `skipCache` forces a disk re-read so removeAuth unsets the current target-org
+ * rather than a stale cached value. `seedUsername` labels the failure if `.create()` rejects.
+ */
+const createAuthRemover = Effect.fn('orgLogout.createAuthRemover')(function* (
+  projectPath: string,
+  seedUsername: string
+) {
+  return yield* Effect.tryPromise({
+    try: () => AuthRemover.create({ projectPath, skipCache: true }),
+    catch: cause =>
+      new OrgLogoutError({ username: seedUsername, message: 'Failed to initialize AuthRemover', cause: String(cause) })
   });
 });
 
@@ -100,19 +115,7 @@ export const orgLogoutAllCommand = Effect.fn('orgLogoutAllCommand')(
     const usernames = yield* selectOrgsForLogout();
     // resolve the workspace path so AuthRemover unsets local config dir-explicitly (no process.cwd reliance)
     const { fsPath: projectPath } = yield* api.services.WorkspaceService.getWorkspaceInfoOrThrow();
-    // One shared AuthRemover for all orgs: each .create() reloads ConfigAggregator + reads all org
-    // files from disk (authRemover.js L92-97), so creating per-org would repeat that I/O N times.
-    const authRemover = yield* Effect.tryPromise({
-      // skipCache: the extension holds a long-lived cached ConfigAggregator; force a disk re-read
-      // so removeAuth unsets the current target-org rather than a stale cached value.
-      try: () => AuthRemover.create({ projectPath, skipCache: true }),
-      catch: cause =>
-        new OrgLogoutError({
-          username: usernames[0],
-          message: 'Failed to initialize AuthRemover',
-          cause: String(cause)
-        })
-    });
+    const authRemover = yield* createAuthRemover(projectPath, usernames[0]);
     // Sequential (no concurrency): AuthRemover writes to shared on-disk config/alias/state files;
     // the library itself serializes removals to avoid a ConfigFile collision bug (authRemover.js L64-65).
     yield* Effect.forEach(usernames, username => removeAuth(authRemover, username), { discard: true });
@@ -135,8 +138,8 @@ export const orgLogoutDefaultCommand = Effect.fn('orgLogoutDefaultCommand')(
 
     const { username, isScratch, aliases } = yield* resolveTargetOrg();
     if (!username) {
-      return yield* Effect.sync(() =>
-        notificationService.showInformationMessage(nls.localize('org_logout_no_default_org'))
+      return yield* Effect.sync(
+        () => void vscode.window.showInformationMessage(nls.localize('org_logout_no_default_org'))
       );
     }
 
@@ -151,44 +154,24 @@ export const orgLogoutDefaultCommand = Effect.fn('orgLogoutDefaultCommand')(
     }
 
     // check BEFORE removeAuth: after it unsets config the target-org is already gone
-    const wasTargetOrg = yield* checkIsCurrentTargetOrg(username, aliases);
+    const wasTargetOrg = yield* api.services.ConfigService.isCurrentTargetOrg(username, aliases);
 
-    // projectPath resolves local config from the workspace, not process.cwd(); skipCache forces a
-    // disk re-read so removeAuth (unsetConfigValues + unsetAliases, authRemover.js L50-54) unsets the
-    // current target-org rather than a stale cached value
     const { fsPath: projectPath } = yield* api.services.WorkspaceService.getWorkspaceInfoOrThrow();
-    const authRemover = yield* Effect.tryPromise({
-      try: () => AuthRemover.create({ projectPath, skipCache: true }),
-      catch: cause =>
-        new OrgLogoutError({ username, message: 'Failed to initialize AuthRemover', cause: String(cause) })
-    });
+    const authRemover = yield* createAuthRemover(projectPath, username);
     yield* removeAuth(authRemover, username);
     yield* updateConfigAndStateAggregatorsEffect();
 
     // removeAuth writes config.json but updateConfigAndStateAggregatorsEffect swallows the post-logout
     // getConnection failure and never clears the in-process defaultOrgRef; clear it here deterministically
     // (W-23069610). Only when the logged-out org was the target — logging out another org must not clear it.
+    // unsetTargetOrg unsets local target-org + clears defaultOrgRef synchronously (configService.ts).
     if (wasTargetOrg) {
-      yield* clearTargetOrgRef();
+      yield* api.services.ConfigService.unsetTargetOrg();
     }
   },
   // Declined scratch confirm is intentional; swallow it. All other errors surface to ErrorHandlerService.
   Effect.catchTag('UserCancellationError', () => Effect.void)
 );
-
-const checkIsCurrentTargetOrg = Effect.fn('OrgLogout.checkIsCurrentTargetOrg')(function* (
-  username: string,
-  aliases: readonly string[]
-) {
-  const api = yield* (yield* ExtensionProviderService).getServicesApi;
-  return yield* api.services.ConfigService.isCurrentTargetOrg(username, aliases);
-});
-
-// unsetTargetOrg unsets local target-org + clears defaultOrgRef synchronously (configService.ts)
-const clearTargetOrgRef = Effect.fn('OrgLogout.clearTargetOrgRef')(function* () {
-  const api = yield* (yield* ExtensionProviderService).getServicesApi;
-  yield* api.services.ConfigService.unsetTargetOrg();
-});
 
 const resolveTargetOrg = Effect.fn('OrgLogout.resolveTargetOrg')(function* () {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;

--- a/packages/salesforcedx-vscode-org/src/commands/auth/orgLogout.ts
+++ b/packages/salesforcedx-vscode-org/src/commands/auth/orgLogout.ts
@@ -6,36 +6,15 @@
  */
 
 import { AuthRemover } from '@salesforce/core';
-import { ExtensionProviderService, sfProjectPreconditionChecker } from '@salesforce/effect-ext-utils';
-import {
-  ContinueResponse,
-  LibraryCommandletExecutor,
-  ParametersGatherer,
-  SfCommandlet,
-  notificationService,
-  workspaceUtils
-} from '@salesforce/salesforcedx-utils-vscode';
+import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
+import { notificationService } from '@salesforce/salesforcedx-utils-vscode';
 import * as Effect from 'effect/Effect';
 import * as Schema from 'effect/Schema';
 import * as SubscriptionRef from 'effect/SubscriptionRef';
 import * as vscode from 'vscode';
-import { OUTPUT_CHANNEL } from '../../channels';
-import { getOrgRuntime } from '../../extensionProvider';
 import { nls } from '../../messages';
 import { buildOrgQuickPickItems, isOrgItem } from '../../orgPicker/orgList';
-import { telemetryService } from '../../telemetry';
 import { getFreshAuthorizations, updateConfigAndStateAggregatorsEffect } from '../../util/orgUtil';
-import { ScratchOrgLogoutParamsGatherer } from './authParamsGatherer';
-// SimpleGatherer - need to inline this small utility
-class SimpleGatherer<T> implements ParametersGatherer<T> {
-  private data: T;
-  constructor(data: T) {
-    this.data = data;
-  }
-  public gather(): Promise<ContinueResponse<T>> {
-    return Promise.resolve({ type: 'CONTINUE', data: this.data });
-  }
-}
 
 /**
  * Raised when `AuthRemover.removeAuth` rejects for an org. Uses `Effect.tryPromise` so the core
@@ -143,56 +122,59 @@ export const orgLogoutAllCommand = Effect.fn('orgLogoutAllCommand')(
   Effect.catchTag('UserCancellationError', () => Effect.void)
 );
 
-export class OrgLogoutDefault extends LibraryCommandletExecutor<string> {
-  private readonly orgAliases: readonly string[];
+/**
+ * Effect command for `sf.org.logout.default`: log out the current default org.
+ * No default org is an intentional no-op (info message). Scratch orgs require a confirm modal
+ * (declining is a no-op cancellation). Every other failure propagates to ErrorHandlerService.
+ */
+export const orgLogoutDefaultCommand = Effect.fn('orgLogoutDefaultCommand')(
+  function* () {
+    const api = yield* (yield* ExtensionProviderService).getServicesApi;
+    // precondition: typed FailedToResolveSfProjectError (rendered by ErrorHandlerService) when no project
+    yield* api.services.ProjectService.getSfProject();
 
-  constructor(aliases: readonly string[] = []) {
-    super(nls.localize('org_logout_default_text'), 'org_logout_default', OUTPUT_CHANNEL);
-    this.orgAliases = aliases;
-  }
-
-  public async run(response: ContinueResponse<string>): Promise<boolean> {
-    try {
-      // check BEFORE removeAuth: after it unsets config the target-org is already gone
-      const wasTargetOrg = await getOrgRuntime().runPromise(checkIsCurrentTargetOrg(response.data, this.orgAliases));
-      // projectPath resolves local config from the workspace, not process.cwd(); skipCache forces a
-      // disk re-read so removeAuth (unsetConfigValues + unsetAliases, authRemover.js L50-54) unsets the
-      // current target-org rather than a stale cached value
-      const authRemover = await AuthRemover.create({
-        projectPath: workspaceUtils.getRootWorkspacePath(),
-        skipCache: true
-      });
-      await authRemover.removeAuth(response.data);
-      // removeAuth writes config.json but never clears the in-process defaultOrgRef; the config-file
-      // watcher backstop is unreliable within the command window, so clear it here (W-23069610). Only
-      // when the logged-out org was the target — logging out another org must not clear the ref.
-      if (wasTargetOrg) {
-        await getOrgRuntime().runPromise(clearTargetOrgRef());
-      }
-    } catch (e) {
-      const err = e instanceof Error ? e : new Error(String(e));
-      telemetryService.sendException('org_logout_default', `Error: name = ${err.name} message = ${err.message}`);
-      return false;
+    const { username, isScratch, aliases } = yield* resolveTargetOrg();
+    if (!username) {
+      return yield* Effect.sync(() =>
+        notificationService.showInformationMessage(nls.localize('org_logout_no_default_org'))
+      );
     }
-    return true;
-  }
-}
 
-export const orgLogoutDefault = async () => {
-  const { username, isScratch, aliases } = await getOrgRuntime().runPromise(resolveTargetOrg());
-  if (username) {
-    // confirm logout for scratch orgs due to special considerations:
-    // https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_auth_logout.htm
-    const logoutCommandlet = new SfCommandlet(
-      sfProjectPreconditionChecker,
-      isScratch ? new ScratchOrgLogoutParamsGatherer(username, aliases[0]) : new SimpleGatherer<string>(username),
-      new OrgLogoutDefault(aliases)
-    );
-    await logoutCommandlet.run();
-  } else {
-    void notificationService.showInformationMessage(nls.localize('org_logout_no_default_org'));
-  }
-};
+    if (isScratch) {
+      // confirm logout for scratch orgs due to special considerations:
+      // https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_auth_logout.htm
+      const promptService = yield* api.services.PromptService;
+      yield* promptService.confirmOrThrow({
+        message: nls.localize('org_logout_scratch_prompt', aliases[0] ?? username),
+        confirmLabel: nls.localize('org_logout_scratch_logout')
+      });
+    }
+
+    // check BEFORE removeAuth: after it unsets config the target-org is already gone
+    const wasTargetOrg = yield* checkIsCurrentTargetOrg(username, aliases);
+
+    // projectPath resolves local config from the workspace, not process.cwd(); skipCache forces a
+    // disk re-read so removeAuth (unsetConfigValues + unsetAliases, authRemover.js L50-54) unsets the
+    // current target-org rather than a stale cached value
+    const { fsPath: projectPath } = yield* api.services.WorkspaceService.getWorkspaceInfoOrThrow();
+    const authRemover = yield* Effect.tryPromise({
+      try: () => AuthRemover.create({ projectPath, skipCache: true }),
+      catch: cause =>
+        new OrgLogoutError({ username, message: 'Failed to initialize AuthRemover', cause: String(cause) })
+    });
+    yield* removeAuth(authRemover, username);
+    yield* updateConfigAndStateAggregatorsEffect();
+
+    // removeAuth writes config.json but updateConfigAndStateAggregatorsEffect swallows the post-logout
+    // getConnection failure and never clears the in-process defaultOrgRef; clear it here deterministically
+    // (W-23069610). Only when the logged-out org was the target — logging out another org must not clear it.
+    if (wasTargetOrg) {
+      yield* clearTargetOrgRef();
+    }
+  },
+  // Declined scratch confirm is intentional; swallow it. All other errors surface to ErrorHandlerService.
+  Effect.catchTag('UserCancellationError', () => Effect.void)
+);
 
 const checkIsCurrentTargetOrg = Effect.fn('OrgLogout.checkIsCurrentTargetOrg')(function* (
   username: string,

--- a/packages/salesforcedx-vscode-org/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-org/src/commands/index.ts
@@ -7,4 +7,4 @@
 
 export { orgListCleanCommand } from './orgList';
 export { orgLoginWebCommand } from './auth/orgLoginWeb';
-export { orgLogoutAllCommand, orgLogoutDefault } from './auth/orgLogout';
+export { orgLogoutAllCommand, orgLogoutDefaultCommand } from './auth/orgLogout';

--- a/packages/salesforcedx-vscode-org/src/constants.ts
+++ b/packages/salesforcedx-vscode-org/src/constants.ts
@@ -8,6 +8,7 @@
 // Commands
 export const ORG_OPEN_COMMAND = 'sf.org.open';
 export const ORG_LOGOUT_ALL_COMMAND = 'sf.org.logout.all';
+export const ORG_LOGOUT_DEFAULT_COMMAND = 'sf.org.logout.default';
 export const ORG_LOGIN_WEB_COMMAND = 'sf.org.login.web';
 export const ORG_DISPLAY_DEFAULT_COMMAND = 'sf.org.display.default';
 export const ORG_LOGIN_ACCESS_TOKEN_COMMAND = 'sf.org.login.access.token';

--- a/packages/salesforcedx-vscode-org/src/index.ts
+++ b/packages/salesforcedx-vscode-org/src/index.ts
@@ -16,7 +16,7 @@ import * as Effect from 'effect/Effect';
 import * as Scope from 'effect/Scope';
 import * as vscode from 'vscode';
 import { channelService, OUTPUT_CHANNEL } from './channels';
-import { orgListCleanCommand, orgLoginWebCommand, orgLogoutAllCommand, orgLogoutDefault } from './commands';
+import { orgListCleanCommand, orgLoginWebCommand, orgLogoutAllCommand, orgLogoutDefaultCommand } from './commands';
 import { orgLoginAccessTokenCommand } from './commands/auth/orgLoginAccessToken';
 import { orgLoginWebDevHubCommand } from './commands/auth/orgLoginWebDevHub';
 import { orgCreateCommand } from './commands/orgCreate';
@@ -30,16 +30,13 @@ import {
   ORG_LOGIN_WEB_COMMAND,
   ORG_LOGIN_WEB_DEV_HUB,
   ORG_LOGOUT_ALL_COMMAND,
+  ORG_LOGOUT_DEFAULT_COMMAND,
   ORG_OPEN_COMMAND
 } from './constants';
 import { AllServicesLayer, getOrgRuntime, setAllServicesLayer } from './extensionProvider';
 import { nls } from './messages';
 import { createOrgPicker, setDefaultOrg } from './orgPicker/orgList';
 import { checkForSoonToBeExpiredOrgs } from './util/orgUtil';
-
-/** Register all org/auth commands */
-const registerCommands = (): vscode.Disposable =>
-  vscode.Disposable.from(vscode.commands.registerCommand('sf.org.logout.default', orgLogoutDefault));
 
 /** Initialize org picker and org status bar */
 const initializeStatusBarItems = Effect.gen(function* () {
@@ -71,7 +68,7 @@ const activateEffect = Effect.fn('activation:salesforcedx-vscode-org')(function*
   extensionContext: vscode.ExtensionContext
 ) {
   // Register output channel
-  extensionContext.subscriptions.push(OUTPUT_CHANNEL, registerCommands());
+  extensionContext.subscriptions.push(OUTPUT_CHANNEL);
 
   // Register Effect-based commands with AllServicesLayer for proper tracing
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
@@ -84,6 +81,7 @@ const activateEffect = Effect.fn('activation:salesforcedx-vscode-org')(function*
   yield* registerCommand(ORG_LOGIN_WEB_COMMAND, orgLoginWebCommand);
   yield* registerCommand(ORG_LOGIN_WEB_DEV_HUB, orgLoginWebDevHubCommand);
   yield* registerCommand(ORG_LOGOUT_ALL_COMMAND, orgLogoutAllCommand);
+  yield* registerCommand(ORG_LOGOUT_DEFAULT_COMMAND, orgLogoutDefaultCommand);
   yield* registerCommand(ORG_DISPLAY_DEFAULT_COMMAND, orgDisplayDefaultCommand);
   yield* registerCommand(ORG_LOGIN_ACCESS_TOKEN_COMMAND, orgLoginAccessTokenCommand);
   yield* registerCommand(ORG_DISPLAY_USERNAME_COMMAND, orgDisplayUsernameCommand);

--- a/packages/salesforcedx-vscode-org/test/jest/commands/auth/authParamsGatherer.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/commands/auth/authParamsGatherer.test.ts
@@ -16,8 +16,7 @@ import * as vscode from 'vscode';
 import {
   DEFAULT_ALIAS,
   gatherAccessTokenParams,
-  gatherAuthParams,
-  ScratchOrgLogoutParamsGatherer
+  gatherAuthParams
 } from '../../../../src/commands/auth/authParamsGatherer';
 import { resetOrgRuntimeForTesting, setAllServicesLayer } from '../../../../src/extensionProvider';
 import { nls } from '../../../../src/messages';
@@ -156,20 +155,6 @@ describe('AuthParamsGatherer', () => {
       expect(validateAlias?.('bad;alias')).toBe(nls.localize('error_invalid_org_alias'));
       expect(validateAlias?.('GoodAlias')).toBeUndefined();
       expect(validateAlias?.('')).toBeUndefined();
-    });
-  });
-
-  describe('ScratchOrgLogoutParamsGatherer', () => {
-    it('CONTINUE with the username when confirmed', async () => {
-      useLayer(true);
-      const result = await new ScratchOrgLogoutParamsGatherer('user@example.com', 'myScratch').gather();
-      expect(result).toEqual({ type: 'CONTINUE', data: 'user@example.com' });
-    });
-
-    it('CANCEL when the confirmation is dismissed', async () => {
-      useLayer(false);
-      const result = await new ScratchOrgLogoutParamsGatherer('user@example.com', 'myScratch').gather();
-      expect(result).toEqual({ type: 'CANCEL' });
     });
   });
 });

--- a/packages/salesforcedx-vscode-org/test/jest/commands/auth/orgLogout.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/commands/auth/orgLogout.test.ts
@@ -6,91 +6,185 @@
  */
 
 import { AuthRemover } from '@salesforce/core';
-import {
-  ExtensionProviderService,
-  type ExtensionProviderService as ExtensionProviderServiceType
-} from '@salesforce/effect-ext-utils';
-import type { SalesforceVSCodeServicesApi } from '@salesforce/vscode-services';
+import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
+import { notificationService } from '@salesforce/salesforcedx-utils-vscode';
 import * as Effect from 'effect/Effect';
-import * as Layer from 'effect/Layer';
-import { OrgLogoutDefault } from '../../../../src/commands/auth/orgLogout';
-import { resetOrgRuntimeForTesting, setAllServicesLayer } from '../../../../src/extensionProvider';
+import * as Exit from 'effect/Exit';
+import * as SubscriptionRef from 'effect/SubscriptionRef';
+import { orgLogoutDefaultCommand } from '../../../../src/commands/auth/orgLogout';
+import { makeConfirmOrThrow, UserCancellationError } from '../../testHelpers/promptServiceStub';
 
-jest.mock('../../../../src/telemetry', () => ({
-  telemetryService: { sendException: jest.fn() }
+const mockUpdateConfigAndStateAggregatorsEffect = jest.fn<Effect.Effect<void, never, never>, []>(() => Effect.void);
+jest.mock('../../../../src/util/orgUtil', () => ({
+  updateConfigAndStateAggregatorsEffect: () => mockUpdateConfigAndStateAggregatorsEffect()
 }));
 
-jest.mock('../../../../src/channels', () => ({
-  OUTPUT_CHANNEL: {}
-}));
+type OrgSnapshot = { username?: string; isScratch?: boolean; aliases?: readonly string[] };
 
-describe('OrgLogoutDefault', () => {
+const buildServices = (opts: {
+  isProject: boolean;
+  confirm: boolean;
+  orgInfo: OrgSnapshot;
+  isCurrentTargetOrg: boolean;
+  unsetTargetOrg: jest.Mock;
+}) => ({
+  ProjectService: {
+    getSfProject: () =>
+      opts.isProject ? Effect.succeed({}) : Effect.fail({ _tag: 'FailedToResolveSfProjectError' as const })
+  },
+  PromptService: Effect.succeed({ confirmOrThrow: makeConfirmOrThrow(opts.confirm) }),
+  WorkspaceService: {
+    getWorkspaceInfoOrThrow: () => Effect.succeed({ fsPath: '/workspace' })
+  },
+  ConfigService: {
+    isCurrentTargetOrg: () => Effect.succeed(opts.isCurrentTargetOrg),
+    unsetTargetOrg: opts.unsetTargetOrg
+  },
+  TargetOrgRef: () => SubscriptionRef.make(opts.orgInfo),
+  UserCancellationError
+});
+
+const run = (opts: {
+  isProject: boolean;
+  confirm: boolean;
+  orgInfo: OrgSnapshot;
+  isCurrentTargetOrg?: boolean;
+  unsetTargetOrg: jest.Mock;
+}) =>
+  Effect.runPromiseExit(
+    orgLogoutDefaultCommand().pipe(
+      Effect.provideService(ExtensionProviderService, {
+        getServicesApi: Effect.succeed({ services: buildServices({ isCurrentTargetOrg: true, ...opts }) })
+      } as unknown as ExtensionProviderService)
+    ) as Effect.Effect<void, unknown, never>
+  );
+
+describe('orgLogoutDefaultCommand', () => {
   let removeAuthMock: jest.Mock;
   let unsetTargetOrgMock: jest.Mock;
-  let isCurrentTargetOrgMock: jest.Mock;
-
-  const buildLayer = () => {
-    const mockServicesApi = {
-      services: {
-        ConfigService: {
-          isCurrentTargetOrg: isCurrentTargetOrgMock,
-          unsetTargetOrg: unsetTargetOrgMock
-        }
-      }
-    } as unknown as SalesforceVSCodeServicesApi;
-    return Layer.succeed(ExtensionProviderService, {
-      getServicesApi: Effect.succeed(mockServicesApi) as ExtensionProviderServiceType['getServicesApi']
-    });
-  };
+  let showInformationMessageMock: jest.SpyInstance;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     removeAuthMock = jest.fn().mockResolvedValue(undefined);
     jest.spyOn(AuthRemover, 'create').mockResolvedValue({
       removeAuth: removeAuthMock
     } as unknown as AuthRemover);
-
     unsetTargetOrgMock = jest.fn().mockReturnValue(Effect.void);
-    isCurrentTargetOrgMock = jest.fn().mockReturnValue(Effect.succeed(true));
-
-    resetOrgRuntimeForTesting();
-    setAllServicesLayer(
-      buildLayer() as ReturnType<typeof import('@salesforce/effect-ext-utils').buildAllServicesLayer>
-    );
+    mockUpdateConfigAndStateAggregatorsEffect.mockReturnValue(Effect.void);
+    showInformationMessageMock = jest.spyOn(notificationService, 'showInformationMessage').mockResolvedValue(undefined);
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
-  it('clears the target-org ref in-process when the logged-out org was the target', async () => {
+  it('logs out a non-scratch default org, refreshes, and clears the target-org ref', async () => {
     const username = 'user@example.com';
-    const result = await new OrgLogoutDefault().run({ type: 'CONTINUE', data: username });
+    const exit = await run({
+      isProject: true,
+      confirm: true,
+      orgInfo: { username, aliases: ['myOrg'] },
+      unsetTargetOrg: unsetTargetOrgMock
+    });
 
-    expect(result).toBe(true);
+    expect(Exit.isSuccess(exit)).toBe(true);
+    expect(AuthRemover.create).toHaveBeenCalledWith({ projectPath: '/workspace', skipCache: true });
     expect(removeAuthMock).toHaveBeenCalledWith(username);
-    // in-process ref clear (not the async config-file watcher) is what clears the apex-testing tree
+    expect(mockUpdateConfigAndStateAggregatorsEffect).toHaveBeenCalledTimes(1);
+    // in-process ref clear (not the async config-file watcher) is what clears the apex-testing tree (#7624)
     expect(unsetTargetOrgMock).toHaveBeenCalledTimes(1);
   });
 
-  it('does not clear the ref when the logged-out org was not the target', async () => {
-    isCurrentTargetOrgMock.mockReturnValue(Effect.succeed(false));
-    const username = 'other@example.com';
-    const result = await new OrgLogoutDefault().run({ type: 'CONTINUE', data: username });
+  it('does not clear the ref when the logged-out org was not the current target', async () => {
+    const username = 'user@example.com';
+    const exit = await run({
+      isProject: true,
+      confirm: true,
+      orgInfo: { username },
+      isCurrentTargetOrg: false,
+      unsetTargetOrg: unsetTargetOrgMock
+    });
 
-    expect(result).toBe(true);
+    expect(Exit.isSuccess(exit)).toBe(true);
     expect(removeAuthMock).toHaveBeenCalledWith(username);
+    expect(mockUpdateConfigAndStateAggregatorsEffect).toHaveBeenCalledTimes(1);
     // logging out a non-target org must leave the current target-org (and its ref) intact
     expect(unsetTargetOrgMock).not.toHaveBeenCalled();
   });
 
-  it('returns false and does not throw when removeAuth rejects', async () => {
-    const username = 'user@example.com';
-    removeAuthMock.mockRejectedValue(new Error('removal failed'));
+  it('logs out a scratch default org after the confirm prompt is accepted', async () => {
+    const username = 'scratch@example.com';
+    const exit = await run({
+      isProject: true,
+      confirm: true,
+      orgInfo: { username, isScratch: true, aliases: ['myScratch'] },
+      unsetTargetOrg: unsetTargetOrgMock
+    });
 
-    const result = await new OrgLogoutDefault().run({ type: 'CONTINUE', data: username });
-
-    expect(result).toBe(false);
+    expect(Exit.isSuccess(exit)).toBe(true);
     expect(removeAuthMock).toHaveBeenCalledWith(username);
+    expect(mockUpdateConfigAndStateAggregatorsEffect).toHaveBeenCalledTimes(1);
+    expect(unsetTargetOrgMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels (no removeAuth/refresh/ref-clear) when the scratch confirm modal is declined', async () => {
+    const exit = await run({
+      isProject: true,
+      confirm: false,
+      orgInfo: { username: 'scratch@example.com', isScratch: true },
+      unsetTargetOrg: unsetTargetOrgMock
+    });
+
+    // cancellation is caught and turned into a no-op success
+    expect(Exit.isSuccess(exit)).toBe(true);
+    expect(removeAuthMock).not.toHaveBeenCalled();
+    expect(mockUpdateConfigAndStateAggregatorsEffect).not.toHaveBeenCalled();
+    expect(unsetTargetOrgMock).not.toHaveBeenCalled();
+  });
+
+  it('shows an info message (no removeAuth/refresh/ref-clear) when there is no default org', async () => {
+    const exit = await run({
+      isProject: true,
+      confirm: true,
+      orgInfo: {},
+      unsetTargetOrg: unsetTargetOrgMock
+    });
+
+    expect(Exit.isSuccess(exit)).toBe(true);
+    expect(showInformationMessageMock).toHaveBeenCalledTimes(1);
+    expect(removeAuthMock).not.toHaveBeenCalled();
+    expect(mockUpdateConfigAndStateAggregatorsEffect).not.toHaveBeenCalled();
+    expect(unsetTargetOrgMock).not.toHaveBeenCalled();
+  });
+
+  it('fails the precondition (no removeAuth) when not in a project', async () => {
+    const exit = await run({
+      isProject: false,
+      confirm: true,
+      orgInfo: { username: 'user@example.com' },
+      unsetTargetOrg: unsetTargetOrgMock
+    });
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) expect(JSON.stringify(exit.cause)).toContain('FailedToResolveSfProjectError');
+    expect(removeAuthMock).not.toHaveBeenCalled();
+    expect(mockUpdateConfigAndStateAggregatorsEffect).not.toHaveBeenCalled();
+    expect(unsetTargetOrgMock).not.toHaveBeenCalled();
+  });
+
+  it('fails with OrgLogoutError (no refresh/ref-clear) when removeAuth rejects', async () => {
+    removeAuthMock.mockRejectedValue(new Error('removal failed'));
+    const exit = await run({
+      isProject: true,
+      confirm: true,
+      orgInfo: { username: 'user@example.com' },
+      unsetTargetOrg: unsetTargetOrgMock
+    });
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) expect(JSON.stringify(exit.cause)).toContain('OrgLogoutError');
+    expect(mockUpdateConfigAndStateAggregatorsEffect).not.toHaveBeenCalled();
     expect(unsetTargetOrgMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/salesforcedx-vscode-org/test/jest/commands/auth/orgLogout.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/commands/auth/orgLogout.test.ts
@@ -7,10 +7,10 @@
 
 import { AuthRemover } from '@salesforce/core';
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
-import { notificationService } from '@salesforce/salesforcedx-utils-vscode';
 import * as Effect from 'effect/Effect';
 import * as Exit from 'effect/Exit';
 import * as SubscriptionRef from 'effect/SubscriptionRef';
+import * as vscode from 'vscode';
 import { orgLogoutDefaultCommand } from '../../../../src/commands/auth/orgLogout';
 import { makeConfirmOrThrow, UserCancellationError } from '../../testHelpers/promptServiceStub';
 
@@ -62,7 +62,7 @@ const run = (opts: {
 describe('orgLogoutDefaultCommand', () => {
   let removeAuthMock: jest.Mock;
   let unsetTargetOrgMock: jest.Mock;
-  let showInformationMessageMock: jest.SpyInstance;
+  let showInformationMessageMock: jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -72,7 +72,8 @@ describe('orgLogoutDefaultCommand', () => {
     } as unknown as AuthRemover);
     unsetTargetOrgMock = jest.fn().mockReturnValue(Effect.void);
     mockUpdateConfigAndStateAggregatorsEffect.mockReturnValue(Effect.void);
-    showInformationMessageMock = jest.spyOn(notificationService, 'showInformationMessage').mockResolvedValue(undefined);
+    showInformationMessageMock = vscode.window.showInformationMessage as unknown as jest.Mock;
+    showInformationMessageMock.mockResolvedValue(undefined);
   });
 
   afterEach(() => {

--- a/packages/salesforcedx-vscode-org/test/playwright/specs/orgPickers.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-org/test/playwright/specs/orgPickers.desktop.spec.ts
@@ -8,6 +8,7 @@
 import { expect } from '@playwright/test';
 import {
   activeQuickInputWidget,
+  clickOrgPickerStatusBar,
   closeWelcomeTabs,
   createMinimalOrg,
   createThrowawayOrg,
@@ -16,6 +17,7 @@ import {
   execAsync,
   executeCommandWithCommandPalette,
   expectOrgPickerListsOrg,
+  expectOrgPickerStatusBar,
   MINIMAL_ORG_ALIAS,
   NOTIFICATION_LIST_ITEM,
   QUICK_INPUT_LIST_ROW,
@@ -34,6 +36,12 @@ import { orgDesktopMinimalDefaultTest as test } from '../fixtures/desktopFixture
 // `channel_name` from salesforcedx-vscode-org/src/messages/i18n.ts (orgDisplay writes its table here).
 const ORG_OUTPUT_CHANNEL = 'Salesforce Org Management';
 
+// Second throwaway org for the default-logout step: set AS the workspace default, then logged out via
+// sf.org.logout.default. Distinct from THROWAWAY_ORG_ALIAS (consumed by the logout.all step) and never
+// MINIMAL_ORG_ALIAS. This exercises the "logged-out org is also the current default" path (the in-process
+// ref clear that clearOnLogout guards, W-23069609) — the logout.all step never sets its org as default.
+const DEFAULT_LOGOUT_ORG_ALIAS = 'logoutDefaultThrowawayOrg';
+
 // Exercises the three migrated org pickers (Effect + PromptService.considerUndefinedAsCancellation):
 //   - selectOrgForDisplay (single-pick)  -> sf.org.display.username
 //   - selectDeletableOrg (multi-pick + confirm) -> sf.org.delete.username
@@ -46,11 +54,13 @@ const ORG_OUTPUT_CHANNEL = 'Salesforce Org Management';
 test('org pickers: display, delete, logout pick + confirm + cancel flows', async ({ page }) => {
   test.setTimeout(180_000);
 
-  await test.step('setup scratch default org + throwaway logout org', async () => {
+  await test.step('setup scratch default org + throwaway logout orgs', async () => {
     const createResult = await createMinimalOrg();
-    // Dedicated throwaway org for the real-logout step; never MINIMAL_ORG_ALIAS (shared with siblings
+    // Dedicated throwaway org for the real logout.all step; never MINIMAL_ORG_ALIAS (shared with siblings
     // + relied on staying authed by the cancel steps). Authed on disk so the logout picker lists it.
     await createThrowawayOrg();
+    // Second throwaway for the logout.default step (set AS default, then logged out).
+    await createThrowawayOrg(DEFAULT_LOGOUT_ORG_ALIAS);
     await waitForVSCodeWorkbench(page);
     await closeWelcomeTabs(page);
     await ensureSecondarySideBarHidden(page);
@@ -150,6 +160,26 @@ test('org pickers: display, delete, logout pick + confirm + cancel flows', async
     ).toHaveCount(0, { timeout: 15_000 });
     await page.keyboard.press('Escape');
     await expect(page.locator(QUICK_INPUT_WIDGET)).toBeHidden({ timeout: 10_000 });
+  });
+
+  // Real logout of the CURRENT DEFAULT org via sf.org.logout.default (W-23069609). Set the dedicated
+  // second throwaway AS the default first (so removeAuth unsets the current default — the path that
+  // must clear the in-process ref), confirm the scratch modal, then assert removal durably via the CLI.
+  // Sequenced last: it leaves the workspace with no default org. MINIMAL_ORG_ALIAS stays authed.
+  await test.step('LOGOUT DEFAULT real: confirm removes auth for the default org', async () => {
+    // Switch default from the fixture's MINIMAL org to the throwaway via the picker.
+    await clickOrgPickerStatusBar(page, MINIMAL_ORG_ALIAS);
+    await expectOrgPickerListsOrg(page, DEFAULT_LOGOUT_ORG_ALIAS);
+    await selectOrgInPicker(page, DEFAULT_LOGOUT_ORG_ALIAS);
+    await expectOrgPickerStatusBar(page, DEFAULT_LOGOUT_ORG_ALIAS);
+
+    await executeCommandWithCommandPalette(page, packageNls.org_logout_default_text);
+    // Throwaway is a scratch org -> confirm the scratch modal (do NOT Escape) so removeAuth runs.
+    await clickModalButton(page, 'Logout');
+    await expectNoErrorNotification(page);
+
+    // Durable signal: poll the CLI until the default org is no longer authorized.
+    await expectOrgLoggedOut(DEFAULT_LOGOUT_ORG_ALIAS);
   });
 });
 


### PR DESCRIPTION
## Summary

- Migrate `sf.org.logout.default` off `SfCommandlet`/`LibraryCommandletExecutor` to an Effect command (`orgLogoutDefaultCommand`), mirroring the already-migrated `sf.org.logout.all` (#7624).
- Preserve the pre-existing `checkIsCurrentTargetOrg` → `removeAuth` → `unsetTargetOrg` ordering so the in-process default-org ref is deterministically cleared when the logged-out org was the current target (guards the #7624 regression where the post-logout `getConnection` failure is silently swallowed).
- Register `sf.org.logout.default` via `registerCommandWithLayer(AllServicesLayer)` instead of a raw `vscode.commands.registerCommand`; delete `OrgLogoutDefault`, `orgLogoutDefault`, `SimpleGatherer`.

## Plan

See [.claude/plans/W-23069609.md](../blob/sm/W-23069609-5-migrate-sf-org-logout-default-to-servi/.claude/plans/W-23069609.md)

### What issues does this PR fix or reference?
@W-23069609@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cXGbpYAG/view
