### PR TITLE
feat(org): gate orgDisplay sensitive-info behind modal confirm - W-23230633

### DIFF
--- a/.claude/plans/W-23230633.md
+++ b/.claude/plans/W-23230633.md
@@ -1,0 +1,62 @@
+# W-23230633 — orgDisplay sensitive-info warning as modal confirmation
+
+## Context
+
+- `orgDisplay.ts` prints `ACCESS_WARNING` (hardcoded template literal, L15-17) via `channel.appendToChannel` before org table (`writeOrgInfoToChannel`, L54-61). Both commands (`orgDisplayDefaultCommand`, `orgDisplayUsernameCommand`) call it.
+- Goal: promote warning to modal confirm gate; Cancel aborts, no org info shown.
+- Modal helper already exists: `PromptService.confirmOrThrow({message, confirmLabel})` — modal `showWarningMessage`, fails `UserCancellationError` on dismiss (`packages/salesforcedx-vscode-services/src/vscode/prompts/promptService.ts:71-80`). Used by `selectDeletableOrg.ts:47`.
+- `registerCommandWithLayer` already swallows `UserCancellationError` → Cancel = silent no-op (`registerCommand.ts:38`). No command-boundary change needed.
+- i18n rules: no `Warning:` prefix (severity supplied by `showWarningMessage`); keep doc link (`.claude/skills/i18n-messages/SKILL.md:57-59`).
+- TWO shipping e2e specs hit the now-gated `writeOrgInfoToChannel` and both use `orgDesktopMinimalDefaultTest` (fixture routes `confirmOrThrow` modal to DOM, `desktopFixtures.ts:27-28`):
+  - `orgPickers.desktop.spec.ts:65-77` — `org_display_username_text` → `orgDisplayUsernameCommand`; asserts `Username` table + `Warning:` line. Local `clickModalButton` helper exists (spec L157).
+  - `orgDisplay.desktop.spec.ts:44-53` — `org_display_default_text` → `orgDisplayDefaultCommand`; runs command then waits for `Connected Status` table with NO modal handling. Will hang behind the undismissed modal after Phase 1 ships. No local modal-click helper — must add one (pattern: `clickModalDialogButton` in `orgDeleteUsername.desktop.spec.ts:112-115`, `.monaco-dialog-box, .dialog-shadow`).
+
+## Phases
+
+### Phase 1 — modal gate + i18n + unit tests
+
+- `messages/i18n.ts`: add
+  - `org_display_access_warning` = warning text minus `Warning:` prefix, keep `sfdx_dev_auth_web_flow` doc link
+  - `org_display_continue_label` = `Continue`
+- `commands/orgDisplay.ts`:
+  - delete `ACCESS_WARNING` const + `appendToChannel(warning)` + blank-line append
+  - in `writeOrgInfoToChannel` (shared gate): before table append, `yield* (yield* api.services.PromptService).confirmOrThrow({ message: nls.localize('org_display_access_warning'), confirmLabel: nls.localize('org_display_continue_label') })`
+  - import `nls` from `../messages`
+- `test/jest/commands/orgDisplay.test.ts`:
+  - add `PromptService.confirmOrThrow` to `buildServices` mock (param: confirm vs cancel)
+  - drop output-channel warning assertions (L169); assert `appendToChannel` first call = table now
+  - new case: confirm-declined → `UserCancellationError`, no `appendToChannel`/`show`
+  - update success cases to provide confirming mock
+
+commit: `feat(org): gate orgDisplay sensitive-info behind modal confirm - W-23230633`
+
+### Phase 2 — e2e specs (BOTH callers of the gated write)
+
+Both specs need the `nls` import (`import { nls } from '../../../src/messages';`, pattern `deleteSource.headless.spec.ts:32`) — `org_display_continue_label` lives in `src/messages/i18n.ts`, not `package.nls.json`, so read via `nls`, not `packageNls`/literal.
+
+- `test/playwright/specs/orgPickers.desktop.spec.ts` DISPLAY step (L65-77):
+  - after `selectOrgInPicker`, `clickModalButton(page, nls.localize('org_display_continue_label'))` (helper already at spec L157)
+  - remove output-channel `Warning:` assertion (L73-77); keep `Username` table assertion (now gated behind confirm)
+  - add DISPLAY cancel-modal step: pick org → Escape modal → `expectNoErrorNotification`, no table
+
+- `test/playwright/specs/orgDisplay.desktop.spec.ts` (L44-53):
+  - between `run Display Org Details for Default Org` and `assert org table in output channel`, click the Continue modal — add a local `clickModalDialogButton` helper (copy `orgDeleteUsername.desktop.spec.ts:112-115`, `.monaco-dialog-box, .dialog-shadow`, `Page` type) since none is exported; call `clickModalDialogButton(page, nls.localize('org_display_continue_label'))`
+  - keep the `Connected Status` table assertion (now gated behind confirm)
+  - the modal is routed to DOM by the shared `orgDesktopMinimalDefaultTest` fixture (`desktopFixtures.ts:27-28`), same as orgPickers
+
+commit: `test(org): drive orgDisplay modal confirm in e2e - W-23230633`
+
+## Skills to apply
+
+- i18n-messages — key naming, no `Warning:` prefix, doc-link retention
+- vscode-window-messages — modal via `confirmOrThrow` (no explicit Cancel button)
+- services-extension-consumption — `api.services.PromptService`
+- playwright-e2e — modal click/cancel flow
+- typescript / verification
+
+## Verification
+
+- `npm run compile` (pkg salesforcedx-vscode-org) — types
+- `npm run lint` — `no-vscode-message-literals`, no hardcoded literal
+- jest `orgDisplay.test.ts` — confirm-shown, confirm-declined-aborts, no-project short-circuit
+- e2e-covered (branch, not run locally): modal Continue → table shown; Escape modal → no table, no error toast. BOTH `orgPickers.desktop.spec.ts` (username path) AND `orgDisplay.desktop.spec.ts` (default path) must click Continue before their table assertions — the default-org spec regresses (hangs on undismissed modal) if left untouched

--- a/.claude/plans/W-23230633.md
+++ b/.claude/plans/W-23230633.md
@@ -7,7 +7,7 @@
 - Modal helper already exists: `PromptService.confirmOrThrow({message, confirmLabel})` — modal `showWarningMessage`, fails `UserCancellationError` on dismiss (`packages/salesforcedx-vscode-services/src/vscode/prompts/promptService.ts:71-80`). Used by `selectDeletableOrg.ts:47`.
 - `registerCommandWithLayer` already swallows `UserCancellationError` → Cancel = silent no-op (`registerCommand.ts:38`). No command-boundary change needed.
 - i18n rules: no `Warning:` prefix (severity supplied by `showWarningMessage`); keep doc link (`.claude/skills/i18n-messages/SKILL.md:57-59`).
-- TWO shipping e2e specs hit the now-gated `writeOrgInfoToChannel` and both use `orgDesktopMinimalDefaultTest` (fixture routes `confirmOrThrow` modal to DOM, `desktopFixtures.ts:27-28`):
+- 2 shipping e2e specs hit the now-gated `writeOrgInfoToChannel` and both use `orgDesktopMinimalDefaultTest` (fixture routes `confirmOrThrow` modal to DOM, `desktopFixtures.ts:27-28`):
   - `orgPickers.desktop.spec.ts:65-77` — `org_display_username_text` → `orgDisplayUsernameCommand`; asserts `Username` table + `Warning:` line. Local `clickModalButton` helper exists (spec L157).
   - `orgDisplay.desktop.spec.ts:44-53` — `org_display_default_text` → `orgDisplayDefaultCommand`; runs command then waits for `Connected Status` table with NO modal handling. Will hang behind the undismissed modal after Phase 1 ships. No local modal-click helper — must add one (pattern: `clickModalDialogButton` in `orgDeleteUsername.desktop.spec.ts:112-115`, `.monaco-dialog-box, .dialog-shadow`).
 

--- a/packages/salesforcedx-vscode-org/src/commands/orgDisplay.ts
+++ b/packages/salesforcedx-vscode-org/src/commands/orgDisplay.ts
@@ -52,6 +52,7 @@ const writeOrgInfoToChannel = Effect.fn('orgDisplay.writeOrgInfoToChannel')(func
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   yield* (yield* api.services.PromptService).confirmOrThrow({
     message: nls.localize('org_display_access_warning'),
+    detail: nls.localize('org_display_access_warning_detail'),
     confirmLabel: nls.localize('org_display_continue_label')
   });
   const channel = yield* api.services.ChannelService;

--- a/packages/salesforcedx-vscode-org/src/commands/orgDisplay.ts
+++ b/packages/salesforcedx-vscode-org/src/commands/orgDisplay.ts
@@ -62,7 +62,8 @@ const writeOrgInfoToChannel = Effect.fn('orgDisplay.writeOrgInfoToChannel')(func
 /**
  * Effect command for `sf.org.display.default`: derive the default org's `Connection` via
  * `ConnectionService.getConnection()` (no username resolution — the connection carries the
- * username), derive `OrgInfo` from it, and write the warning + details table to the channel.
+ * username), derive `OrgInfo` from it, then gate the details table behind the modal sensitive-info
+ * confirmation before writing it to the channel.
  */
 export const orgDisplayDefaultCommand = Effect.fn('orgDisplayDefaultCommand')(function* () {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
@@ -78,9 +79,9 @@ export const orgDisplayDefaultCommand = Effect.fn('orgDisplayDefaultCommand')(fu
 });
 
 /**
- * Effect command for `sf.org.display.username`: pick an authed org, then write its details table
- * (preceded by the sensitive-info warning) to the output channel. Resolves `OrgInfo` for the
- * picked username directly (ConnectionService only resolves the default org).
+ * Effect command for `sf.org.display.username`: pick an authed org, then gate its details table
+ * behind the modal sensitive-info confirmation before writing it to the output channel. Resolves
+ * `OrgInfo` for the picked username directly (ConnectionService only resolves the default org).
  */
 export const orgDisplayUsernameCommand = Effect.fn('orgDisplayUsernameCommand')(function* () {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;

--- a/packages/salesforcedx-vscode-org/src/commands/orgDisplay.ts
+++ b/packages/salesforcedx-vscode-org/src/commands/orgDisplay.ts
@@ -7,14 +7,10 @@
 
 import { Column, createTable, ExtensionProviderService, Row } from '@salesforce/effect-ext-utils';
 import * as Effect from 'effect/Effect';
+import { nls } from '../messages';
 import { gatherOrgForDisplay } from '../parameterGatherers/selectOrgForDisplay';
 import { OrgInfo } from '../types/orgInfo';
 import { getOrgInfoEffect, orgInfoFromConnection } from '../util/orgDisplay';
-
-/** Shared sensitive-info warning shown before the org-details table (both display paths). */
-const ACCESS_WARNING = `Warning: This command will expose sensitive information that allows for subsequent activity using your current authenticated session.
-Sharing this information is equivalent to logging someone in under the current credential, resulting in unintended access and escalation of privilege.
-For additional information, please review the authorization section of the https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_auth_web_flow.htm.`;
 
 const formatOrgInfoAsTable = (orgInfo: OrgInfo): string => {
   const columns: Column[] = [
@@ -50,12 +46,15 @@ const formatOrgInfoAsTable = (orgInfo: OrgInfo): string => {
   return createTable(rows, columns, 'Org Description');
 };
 
-/** Write the sensitive-info warning followed by the org-details table to the output channel. */
+/** Gate the org-details table behind a modal sensitive-info confirmation; Cancel aborts with
+ * UserCancellationError (silently swallowed at the command boundary), so no org info is shown. */
 const writeOrgInfoToChannel = Effect.fn('orgDisplay.writeOrgInfoToChannel')(function* (orgInfo: OrgInfo) {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  yield* (yield* api.services.PromptService).confirmOrThrow({
+    message: nls.localize('org_display_access_warning'),
+    confirmLabel: nls.localize('org_display_continue_label')
+  });
   const channel = yield* api.services.ChannelService;
-  yield* channel.appendToChannel(ACCESS_WARNING);
-  yield* channel.appendToChannel('');
   yield* channel.appendToChannel(formatOrgInfoAsTable(orgInfo));
   yield* channel.showChannel;
 });

--- a/packages/salesforcedx-vscode-org/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-org/src/messages/i18n.ts
@@ -34,6 +34,10 @@ export const messages = {
     'The default org is not a scratch org or sandbox and cannot be deleted with this command.',
   org_delete_default_progress: 'Deleting default org',
   org_delete_username_text: 'SFDX: Delete Org...',
+  org_display_access_warning: `This command will expose sensitive information that allows for subsequent activity using your current authenticated session.
+Sharing this information is equivalent to logging someone in under the current credential, resulting in unintended access and escalation of privilege.
+For additional information, please review the authorization section of the https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_auth_web_flow.htm.`,
+  org_display_continue_label: 'Continue',
   org_display_default_text: 'SFDX: Display Org Details for Default Org',
   org_display_username_text: 'SFDX: Display Org Details...',
   org_expired: 'Expired',

--- a/packages/salesforcedx-vscode-org/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-org/src/messages/i18n.ts
@@ -34,9 +34,11 @@ export const messages = {
     'The default org is not a scratch org or sandbox and cannot be deleted with this command.',
   org_delete_default_progress: 'Deleting default org',
   org_delete_username_text: 'SFDX: Delete Org...',
-  org_display_access_warning: `This command will expose sensitive information that allows for subsequent activity using your current authenticated session.
-Sharing this information is equivalent to logging someone in under the current credential, resulting in unintended access and escalation of privilege.
-For additional information, please review the authorization section of the https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_auth_web_flow.htm.`,
+  org_display_access_warning:
+    'This command will expose sensitive information that allows for subsequent activity using your current authenticated session.',
+  org_display_access_warning_detail: `Sharing this information is equivalent to logging someone in under the current credential, resulting in unintended access and escalation of privilege.
+
+For additional information, please review the authorization section of https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_auth_web_flow.htm.`,
   org_display_continue_label: 'Continue',
   org_display_default_text: 'SFDX: Display Org Details for Default Org',
   org_display_username_text: 'SFDX: Display Org Details...',

--- a/packages/salesforcedx-vscode-org/test/jest/commands/orgDisplay.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/commands/orgDisplay.test.ts
@@ -49,17 +49,25 @@ const UserCancellationError = class extends Error {
   public readonly _tag = 'UserCancellationError';
 };
 
-const buildServices = (opts: {
+type CommandOpts = {
   isProject: boolean;
   getConnection: Effect.Effect<Connection, unknown>;
   appendToChannel: jest.Mock;
   show: jest.Mock;
-}) => ({
+  /** whether the modal sensitive-info confirm is accepted (default true); false → UserCancellationError */
+  confirm?: boolean;
+};
+
+const buildServices = (opts: CommandOpts) => ({
   ProjectService: {
     getSfProject: () =>
       opts.isProject ? Effect.succeed({}) : Effect.fail({ _tag: 'FailedToResolveSfProjectError' as const })
   },
   ConnectionService: { getConnection: () => opts.getConnection },
+  PromptService: Effect.succeed({
+    confirmOrThrow: () =>
+      opts.confirm === false ? Effect.fail(new UserCancellationError()) : Effect.succeed(undefined)
+  }),
   ChannelService: Effect.succeed({
     appendToChannel: (msg: string) =>
       Effect.sync(() => {
@@ -75,15 +83,7 @@ const buildServices = (opts: {
 // org-info/picker helpers add Alias/Channel/Connection/Project services); those are satisfied at
 // runtime by the jest-mocked modules, so widen the command's R to ExtensionProviderService for the
 // type-only provide and erase the remaining R via the final cast.
-const runCommand = (
-  command: typeof orgDisplayDefaultCommand | typeof orgDisplayUsernameCommand,
-  opts: {
-    isProject: boolean;
-    getConnection: Effect.Effect<Connection, unknown>;
-    appendToChannel: jest.Mock;
-    show: jest.Mock;
-  }
-) =>
+const runCommand = (command: typeof orgDisplayDefaultCommand | typeof orgDisplayUsernameCommand, opts: CommandOpts) =>
   Effect.runPromiseExit(
     (command() as Effect.Effect<void, unknown, ExtensionProviderService>).pipe(
       Effect.provideService(ExtensionProviderService, {
@@ -98,7 +98,7 @@ describe('orgDisplayDefaultCommand', () => {
     orgInfoFromConnection.mockImplementation(() => Effect.succeed(ORG_INFO));
   });
 
-  it('derives org info from the default connection, appends warning + table, shows the channel', async () => {
+  it('derives org info from the default connection, appends the table after confirm, shows the channel', async () => {
     const appendToChannel = jest.fn();
     const show = jest.fn();
     const exit = await runCommand(orgDisplayDefaultCommand, {
@@ -109,9 +109,27 @@ describe('orgDisplayDefaultCommand', () => {
     });
 
     expect(Exit.isSuccess(exit)).toBe(true);
-    // a stable, unconditional row of the rendered table proves orgInfo flowed into formatOrgInfoAsTable
-    expect(appendToChannel).toHaveBeenCalledWith(expect.stringContaining('Connected Status'));
+    // table is now the first channel write (no leading warning line); a stable, unconditional row
+    // proves orgInfo flowed into formatOrgInfoAsTable
+    expect(appendToChannel.mock.calls[0][0]).toContain('Connected Status');
     expect(show).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts with UserCancellationError when the sensitive-info modal is declined: no append, no show', async () => {
+    const appendToChannel = jest.fn();
+    const show = jest.fn();
+    const exit = await runCommand(orgDisplayDefaultCommand, {
+      isProject: true,
+      getConnection: Effect.succeed(FAKE_CONN),
+      appendToChannel,
+      show,
+      confirm: false
+    });
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) expect(JSON.stringify(exit.cause)).toContain('UserCancellationError');
+    expect(appendToChannel).not.toHaveBeenCalled();
+    expect(show).not.toHaveBeenCalled();
   });
 
   it('short-circuits on no project: no getConnection, no append', async () => {
@@ -151,7 +169,7 @@ describe('orgDisplayUsernameCommand', () => {
     getOrgInfoEffect.mockImplementation(() => Effect.succeed(ORG_INFO));
   });
 
-  it('picks an org, fetches org info, writes the warning + table, and shows the channel', async () => {
+  it('picks an org, fetches org info, writes the table after confirm, and shows the channel', async () => {
     gatherOrgForDisplay.mockReturnValue(Effect.succeed({ username: 'me@scratch.org' }));
     const appendToChannel = jest.fn();
     const show = jest.fn();
@@ -165,10 +183,28 @@ describe('orgDisplayUsernameCommand', () => {
 
     expect(Exit.isSuccess(exit)).toBe(true);
     expect(getOrgInfoEffect).toHaveBeenCalledWith('me@scratch.org');
-    // warning is the first channel write, then the rendered table (contains the Username row)
-    expect(appendToChannel.mock.calls[0][0]).toContain('Warning: This command will expose sensitive information');
-    expect(appendToChannel.mock.calls.some(([msg]) => String(msg).includes('Username'))).toBe(true);
+    // table is the first (and only) channel write, containing the Username row
+    expect(appendToChannel.mock.calls[0][0]).toContain('Username');
     expect(show).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts with UserCancellationError when the sensitive-info modal is declined: no append, no show', async () => {
+    gatherOrgForDisplay.mockReturnValue(Effect.succeed({ username: 'me@scratch.org' }));
+    const appendToChannel = jest.fn();
+    const show = jest.fn();
+
+    const exit = await runCommand(orgDisplayUsernameCommand, {
+      isProject: true,
+      getConnection: Effect.succeed(FAKE_CONN),
+      appendToChannel,
+      show,
+      confirm: false
+    });
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) expect(JSON.stringify(exit.cause)).toContain('UserCancellationError');
+    expect(appendToChannel).not.toHaveBeenCalled();
+    expect(show).not.toHaveBeenCalled();
   });
 
   it('propagates UserCancellationError (no channel writes) when the picker is cancelled', async () => {

--- a/packages/salesforcedx-vscode-org/test/jest/testHelpers/promptServiceStub.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/testHelpers/promptServiceStub.ts
@@ -19,8 +19,13 @@ export const considerUndefinedAsCancellation = <T>(value: T | undefined): Effect
     ? Effect.fail(new UserCancellationError())
     : Effect.succeed(value);
 
-/** Stub of `PromptService.confirmOrThrow`: `confirm: true` resolves, `false` fails with cancellation. */
+/** Stub of `PromptService.confirmOrThrow`: `confirm: true` resolves, `false` fails with cancellation.
+ * Params: `message`, `confirmLabel`, optional `detail`. */
 export const makeConfirmOrThrow =
   (confirm: boolean) =>
-  (_params: { readonly message: string; readonly confirmLabel: string }): Effect.Effect<void, UserCancellationError> =>
+  (_params: {
+    readonly message: string;
+    readonly confirmLabel: string;
+    readonly detail?: string;
+  }): Effect.Effect<void, UserCancellationError> =>
     confirm ? Effect.void : Effect.fail(new UserCancellationError());

--- a/packages/salesforcedx-vscode-org/test/playwright/specs/orgDisplay.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-org/test/playwright/specs/orgDisplay.desktop.spec.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { expect, type Page } from '@playwright/test';
 import {
   closeWelcomeTabs,
   createMinimalOrg,
@@ -16,6 +17,7 @@ import {
   waitForVSCodeWorkbench
 } from '@salesforce/playwright-vscode-ext';
 import packageNls from '../../../package.nls.json';
+import { nls } from '../../../src/messages';
 import { orgDesktopMinimalDefaultTest as test } from '../fixtures/desktopFixtures';
 
 // e2e-COVERED: SFDX: Display Org Details for Default Org against a real scratch default org.
@@ -45,6 +47,11 @@ test('org extension: SFDX: Display Org Details for Default Org logs the org tabl
     await executeCommandWithCommandPalette(page, packageNls.org_display_default_text);
   });
 
+  await test.step('confirm the sensitive-info modal', async () => {
+    // the sensitive-info modal now gates the table; confirm it (Continue) so the table is written.
+    await clickModalDialogButton(page, nls.localize('org_display_continue_label'));
+  });
+
   await test.step('assert org table in output channel', async () => {
     await selectOutputChannel(page, 'Salesforce Org Management');
     // 'Connected Status' is an unconditional row of formatOrgInfoAsTable; its presence proves
@@ -52,3 +59,14 @@ test('org extension: SFDX: Display Org Details for Default Org logs the org tabl
     await waitForOutputChannelText(page, { expectedText: 'Connected Status', timeout: 60_000 });
   });
 });
+
+/** Click a modal-dialog button by its label. `window.dialogStyle: custom` (fixture) renders the modal as
+ * DOM (.monaco-dialog-box) so Playwright can click it; native Electron dialogs are inaccessible. */
+const clickModalDialogButton = async (page: Page, label: string, timeout = 10_000): Promise<void> => {
+  const dialogButton = page
+    .locator('.monaco-dialog-box, .dialog-shadow')
+    .getByRole('button', { name: label, exact: true })
+    .first();
+  await expect(dialogButton).toBeVisible({ timeout });
+  await dialogButton.click();
+};

--- a/packages/salesforcedx-vscode-org/test/playwright/specs/orgDisplay.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-org/test/playwright/specs/orgDisplay.desktop.spec.ts
@@ -5,8 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { expect, type Page } from '@playwright/test';
 import {
+  clickModalDialogButton,
   closeWelcomeTabs,
   createMinimalOrg,
   ensureSecondarySideBarHidden,
@@ -49,7 +49,7 @@ test('org extension: SFDX: Display Org Details for Default Org logs the org tabl
 
   await test.step('confirm the sensitive-info modal', async () => {
     // the sensitive-info modal now gates the table; confirm it (Continue) so the table is written.
-    await clickModalDialogButton(page, nls.localize('org_display_continue_label'));
+    await clickModalDialogButton(page, nls.localize('org_display_continue_label'), 10_000);
   });
 
   await test.step('assert org table in output channel', async () => {
@@ -59,14 +59,3 @@ test('org extension: SFDX: Display Org Details for Default Org logs the org tabl
     await waitForOutputChannelText(page, { expectedText: 'Connected Status', timeout: 60_000 });
   });
 });
-
-/** Click a modal-dialog button by its label. `window.dialogStyle: custom` (fixture) renders the modal as
- * DOM (.monaco-dialog-box) so Playwright can click it; native Electron dialogs are inaccessible. */
-const clickModalDialogButton = async (page: Page, label: string, timeout = 10_000): Promise<void> => {
-  const dialogButton = page
-    .locator('.monaco-dialog-box, .dialog-shadow')
-    .getByRole('button', { name: label, exact: true })
-    .first();
-  await expect(dialogButton).toBeVisible({ timeout });
-  await dialogButton.click();
-};

--- a/packages/salesforcedx-vscode-org/test/playwright/specs/orgPickers.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-org/test/playwright/specs/orgPickers.desktop.spec.ts
@@ -31,6 +31,7 @@ import {
   waitForVSCodeWorkbench
 } from '@salesforce/playwright-vscode-ext';
 import packageNls from '../../../package.nls.json';
+import { nls } from '../../../src/messages';
 import { orgDesktopMinimalDefaultTest as test } from '../fixtures/desktopFixtures';
 
 // `channel_name` from salesforcedx-vscode-org/src/messages/i18n.ts (orgDisplay writes its table here).
@@ -72,18 +73,25 @@ test('org pickers: display, delete, logout pick + confirm + cancel flows', async
     await verifyCommandExists(page, packageNls.org_login_web_authorize_org_text, 60_000);
   });
 
-  await test.step('DISPLAY: selectOrgForDisplay lists the org, pick it, assert output table', async () => {
+  await test.step('DISPLAY: selectOrgForDisplay lists the org, pick it, confirm modal, assert output table', async () => {
     await executeCommandWithCommandPalette(page, packageNls.org_display_username_text);
     // selectOrgForDisplay (single-pick) lists the seeded scratch org.
     await expectOrgPickerListsOrg(page, MINIMAL_ORG_ALIAS);
     await selectOrgInPicker(page, MINIMAL_ORG_ALIAS);
+    // sensitive-info modal now gates the table; confirm it (Continue) so the table is written.
+    await clickModalButton(page, nls.localize('org_display_continue_label'));
     // orgDisplay renders a table containing the org's Username row to the output channel.
     await selectOutputChannel(page, ORG_OUTPUT_CHANNEL);
     await waitForOutputChannelText(page, { expectedText: 'Username' });
-    // and the sensitive-info warning (ACCESS_WARNING) precedes the table — warning-path coverage.
-    await waitForOutputChannelText(page, {
-      expectedText: 'Warning: This command will expose sensitive information'
-    });
+  });
+
+  await test.step('DISPLAY cancel modal: Esc on the sensitive-info modal maps to CANCEL (no error toast, no table)', async () => {
+    await executeCommandWithCommandPalette(page, packageNls.org_display_username_text);
+    await expectOrgPickerListsOrg(page, MINIMAL_ORG_ALIAS);
+    await selectOrgInPicker(page, MINIMAL_ORG_ALIAS);
+    // dismiss the sensitive-info modal -> UserCancellationError -> CANCEL, no org info shown.
+    await page.keyboard.press('Escape');
+    await expectNoErrorNotification(page);
   });
 
   await test.step('DISPLAY cancel: Esc on the picker maps to CANCEL (no error toast)', async () => {

--- a/packages/salesforcedx-vscode-org/test/playwright/specs/orgPickers.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-org/test/playwright/specs/orgPickers.desktop.spec.ts
@@ -8,6 +8,7 @@
 import { expect } from '@playwright/test';
 import {
   activeQuickInputWidget,
+  clickModalDialogButton,
   clickOrgPickerStatusBar,
   closeWelcomeTabs,
   createMinimalOrg,
@@ -79,7 +80,7 @@ test('org pickers: display, delete, logout pick + confirm + cancel flows', async
     await expectOrgPickerListsOrg(page, MINIMAL_ORG_ALIAS);
     await selectOrgInPicker(page, MINIMAL_ORG_ALIAS);
     // sensitive-info modal now gates the table; confirm it (Continue) so the table is written.
-    await clickModalButton(page, nls.localize('org_display_continue_label'));
+    await clickModalDialogButton(page, nls.localize('org_display_continue_label'), 10_000);
     // orgDisplay renders a table containing the org's Username row to the output channel.
     await selectOutputChannel(page, ORG_OUTPUT_CHANNEL);
     await waitForOutputChannelText(page, { expectedText: 'Username' });
@@ -150,7 +151,7 @@ test('org pickers: display, delete, logout pick + confirm + cancel flows', async
     await toggleMultiPickRow(page, THROWAWAY_ORG_ALIAS);
     await page.keyboard.press('Enter');
     // CONFIRM (not cancel): click the modal's confirm button so the logout proceeds.
-    await clickModalButton(page, 'Logout');
+    await clickModalDialogButton(page, 'Logout', 10_000);
     await expectNoErrorNotification(page);
 
     // Primary durable signal: poll the CLI until the throwaway org is no longer authorized.
@@ -183,20 +184,13 @@ test('org pickers: display, delete, logout pick + confirm + cancel flows', async
 
     await executeCommandWithCommandPalette(page, packageNls.org_logout_default_text);
     // Throwaway is a scratch org -> confirm the scratch modal (do NOT Escape) so removeAuth runs.
-    await clickModalButton(page, 'Logout');
+    await clickModalDialogButton(page, 'Logout', 10_000);
     await expectNoErrorNotification(page);
 
     // Durable signal: poll the CLI until the default org is no longer authorized.
     await expectOrgLoggedOut(DEFAULT_LOGOUT_ORG_ALIAS);
   });
 });
-
-/** Click a button (e.g. the confirm action) in a VS Code custom-style modal dialog. */
-const clickModalButton = async (page: import('@playwright/test').Page, label: string): Promise<void> => {
-  const button = page.locator('.monaco-dialog-box').getByRole('button', { name: label }).first();
-  await button.waitFor({ state: 'visible', timeout: 10_000 });
-  await button.click();
-};
 
 /** Poll the CLI until the alias is no longer authorized (durable, non-racy removal signal). */
 const expectOrgLoggedOut = async (alias: string, timeoutMs = 30_000): Promise<void> => {

--- a/packages/salesforcedx-vscode-services/src/vscode/prompts/promptService.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/prompts/promptService.ts
@@ -71,9 +71,10 @@ export class PromptService extends Effect.Service<PromptService>()('PromptServic
     const confirmOrThrow = Effect.fn('PromptService.confirmOrThrow')(function* (params: {
       readonly message: string;
       readonly confirmLabel: string;
+      readonly detail?: string;
     }) {
       const choice = yield* Effect.promise(() =>
-        vscode.window.showWarningMessage(params.message, { modal: true }, params.confirmLabel)
+        vscode.window.showWarningMessage(params.message, { modal: true, detail: params.detail }, params.confirmLabel)
       );
       if (choice !== params.confirmLabel)
         return yield* new UserCancellationError({ message: 'User cancelled confirmation' });


### PR DESCRIPTION
### What does this PR do?

## Summary
- Promote the orgDisplay `ACCESS_WARNING` from a plain output-channel line to a modal confirmation gate (`PromptService.confirmOrThrow`) before writing org info to the channel.
- Cancel dismisses silently (no org table shown, no error) via existing `UserCancellationError` handling in `registerCommandWithLayer`.
- Update `orgDisplayUsernameCommand`/`orgDisplayDefaultCommand` jest coverage and both affected e2e specs (`orgPickers.desktop.spec.ts`, `orgDisplay.desktop.spec.ts`) to click the Continue modal before asserting the org table.

## Plan
See [.claude/plans/W-23230633.md](../blob/sm/W-23230633-5-show-orgdisplay-sensitive-info-warning/.claude/plans/W-23230633.md)

### What issues does this PR fix or reference?
@W-23230633@

### Functionality Before
`orgDisplay` printed a static `ACCESS_WARNING` line to the output channel before the org table — easy to miss.

### Functionality After
`orgDisplay` shows a modal warning; user must click Continue to proceed (Cancel aborts, no info shown).