### PR TITLE
ci: run check:knip in validatePR - W-23277534

### DIFF
--- a/.claude/plans/W-23277534.md
+++ b/.claude/plans/W-23277534.md
@@ -1,0 +1,53 @@
+# W-23277534 — Run check:knip in CI (validatePR)
+
+## Context
+
+- `check:knip` runs locally only (husky `precommit` wireit + verify-stop hook), NOT in CI
+- `validatePR.yml` `code-quality` job = `lint` + `check:actions` only → knip drift merges undetected
+- `check:knip` wireit task deps on `compile` (`package.json:378-391`); cmd `npx knip --include exports,types,nsExports,nsTypes --no-config-hints`
+- confirmed green on develop (39 scripts, ✅)
+
+### Branch protection reality (critical)
+
+- Adding a job to `validatePR.yml` does NOT gate merges. GitHub blocks merges only for job contexts listed in `repos/.../branches/develop/protection/required_status_checks.contexts`.
+- Current contexts: `pr-validation / pr-validation`, `build-and-test / build-all / build-all`, `build-and-test / unit-tests / windows-unit-tests / windows-unit-tests`, `build-and-test / unit-tests / linux-unit-tests / linux-unit-tests`, `code-quality`.
+- Proof the new job alone is insufficient: sibling `validate-actions` (added `.github/workflows/validatePR.yml:31`, commit be6c3dcdd) is NOT in that list → it runs but does not block.
+- Therefore the WI AC "gate PRs to develop" requires an admin change to the branch protection, separate from the YAML edit.
+
+## Phases
+
+### Phase 1 — add check-knip job
+
+- edit `.github/workflows/validatePR.yml`
+- new job `check-knip`, parallel w/ `code-quality` + `validate-actions`
+- steps mirror existing jobs: `actions/checkout@v4`, `actions/setup-node@v6` (node-version var, cache npm), `npmInstallWithRetries@main`, then `npm run check:knip`
+- wireit pulls `compile` transitively → no explicit compile step
+- commit msg: `ci: run check:knip in validatePR - W-23277534`
+
+### Phase 2 — make it required (admin follow-up)
+
+- After the job has run green at least once on a real PR (context name must exist before GH will accept it), add `check-knip` to branch protection required checks.
+- Admin action (repo admin token required):
+  `gh api repos/forcedotcom/salesforcedx-vscode/branches/develop/protection/required_status_checks --method PATCH -f 'contexts[]=check-knip'`
+  (or add via repo Settings → Branches → develop → Require status checks).
+- Preserve existing contexts — PATCH merges/replaces the `contexts` array, so include all current entries when using the UI/full-payload form to avoid dropping the others.
+- This is a MANUAL follow-up outside our write access. Call it out explicitly in the PR description as a required post-merge admin step, otherwise the "gate PRs" AC is unmet.
+- Also note in PR: pre-existing gap that `validate-actions` is likewise not required (same admin fix candidate, but out of scope for this WI).
+
+## Skills to apply
+
+- wireit — confirm task graph (`check:knip` → `compile`)
+- typescript — required by review rules, even for this YAML-only change
+- verification — final check
+
+## Verification
+
+- YAML valid: job indentation matches siblings; run `npm run check:actions` (actionlint)
+- `npm run check:knip` green on branch (done pre-plan)
+- **AC "job fails on knip violations"** — prove red, not just green:
+  - on a throwaway commit, add a deliberately-unused export (e.g. `export const __knipCanary = 1` in a source file not imported anywhere)
+  - run `WIREIT_CACHE=none npx knip --include exports,types,nsExports,nsTypes --no-config-hints` locally → confirm NON-ZERO exit + the canary flagged as unused export
+  - push the throwaway commit to a scratch PR, confirm the `check-knip` job goes RED in GH Actions
+  - revert the canary; confirm job returns green
+- Post-merge: confirm `check-knip` appears in `required_status_checks.contexts` (Phase 2) — the only proof the PR is actually gated
+- not e2e-covered (CI-config change; no runtime surface)

--- a/.claude/plans/W-23277534.md
+++ b/.claude/plans/W-23277534.md
@@ -9,7 +9,7 @@
 
 ### Branch protection reality (critical)
 
-- Adding a job to `validatePR.yml` does NOT gate merges. GitHub blocks merges only for job contexts listed in `repos/.../branches/develop/protection/required_status_checks.contexts`.
+- Adding a job to `validatePR.yml` doesn't gate merges — GitHub blocks only for contexts listed in `required_status_checks.contexts`.
 - Current contexts: `pr-validation / pr-validation`, `build-and-test / build-all / build-all`, `build-and-test / unit-tests / windows-unit-tests / windows-unit-tests`, `build-and-test / unit-tests / linux-unit-tests / linux-unit-tests`, `code-quality`.
 - Proof the new job alone is insufficient: sibling `validate-actions` (added `.github/workflows/validatePR.yml:31`, commit be6c3dcdd) is NOT in that list → it runs but does not block.
 - Therefore the WI AC "gate PRs to develop" requires an admin change to the branch protection, separate from the YAML edit.
@@ -30,8 +30,8 @@
 - Admin action (repo admin token required):
   `gh api repos/forcedotcom/salesforcedx-vscode/branches/develop/protection/required_status_checks --method PATCH -f 'contexts[]=check-knip'`
   (or add via repo Settings → Branches → develop → Require status checks).
-- Preserve existing contexts — PATCH merges/replaces the `contexts` array, so include all current entries when using the UI/full-payload form to avoid dropping the others.
-- This is a MANUAL follow-up outside our write access. Call it out explicitly in the PR description as a required post-merge admin step, otherwise the "gate PRs" AC is unmet.
+- Preserve existing contexts — PATCH replaces the array; include all current entries (UI/full-payload) to avoid dropping others.
+- MANUAL follow-up (outside our write access) — call out in PR description as required post-merge admin step, else "gate PRs" AC unmet.
 - Also note in PR: pre-existing gap that `validate-actions` is likewise not required (same admin fix candidate, but out of scope for this WI).
 
 ## Skills to apply

--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -42,3 +42,14 @@ jobs:
       - uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
       - name: Validate GitHub Actions
         run: npm run check:actions
+  check-knip:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
+          cache: npm
+      - uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
+      - name: Check knip
+        run: npm run check:knip

--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
           cache: npm
+      - uses: google/wireit@setup-github-actions-caching/v2
       - uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
       - name: Check knip
         run: npm run check:knip


### PR DESCRIPTION
## Summary
- Add a `check-knip` job to `validatePR.yml`, running in parallel with `code-quality`/`validate-actions`, mirroring their checkout/setup-node/npmInstallWithRetries steps then `npm run check:knip` (wireit pulls in `compile` transitively).
- New job alone does not gate merges: `check-knip` isn't in `required_status_checks.contexts`, same pre-existing gap as `validate-actions`. Adding it there is an admin action outside this PR's write access, needed once the job has run green on a real PR.

## Plan
See `.claude/plans/W-23277534.md`.

## Test plan
- Once merged and green at least once, an admin adds `check-knip` to branch protection `required_status_checks.contexts` (preserving existing entries) — only proof the AC "gate PRs to develop" is met.
- On a throwaway commit/PR, add a deliberately-unused export and confirm the `check-knip` job goes red in GH Actions, then revert and confirm green.

### What issues does this PR fix or reference?
@W-23277534@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002dhL8sYAE/view
