### PR TITLE
refactor(replay-debugger): remove direct dependency on salesforcedx-vscode-core - W-23336192

### DIFF
--- a/.claude/plans/W-23336192.md
+++ b/.claude/plans/W-23336192.md
@@ -3,7 +3,7 @@
 ## Context
 - ADR 0006 (core API frozen/sunset) + ADR 0005 (services API = contract)
 - apex-log already did same migration (pattern ref)
-- Bug fix, not just cleanup: replay debugger's `WorkspaceContext.getInstance().initialize(extensionContext)` (src/index.ts:207) races core's own `setImmediate` init. `initialize` memoizes via `initializationPromise ??=` (core workspaceContext.ts:44-46) — only 1st caller's ctx kept. If replay wins race, core's `coreExtensionContext` unset → `handleTelemetryUpdate()` no-ops on org change. Removing redundant call fixes it.
+- Bug fix, not just cleanup: replay debugger's `WorkspaceContext.getInstance().initialize(extensionContext)` (src/index.ts:207) races core's own `setImmediate` init. `initialize` memoizes via `initializationPromise ??=` (core workspaceContext.ts:44-46) — only 1st caller's ctx kept. If replay wins race, core's `coreExtensionContext` unset → `handleTelemetryUpdate()` no-ops on org change — removing redundant call fixes it.
 - All core refs confined to src/index.ts + package.json. desktopFixtures.ts refs = out of scope (apex-log/apex still need core installed transitively).
 
 ## Bug mechanics (what the test must pin)
@@ -32,7 +32,7 @@ package.json:
 `packages/salesforcedx-vscode-core/test/jest/context/workspaceContext.test.ts`:
 - add `describe('handleTelemetryUpdate telemetry refresh on org change')` proving the bug fix (mock `refreshAllExtensionReporters` from `@salesforce/salesforcedx-utils-vscode`):
   - RED-before-fix / GREEN-after case: `initialize(coreCtx)` where `coreCtx.extension.id === 'salesforce.salesforcedx-vscode-core'` → invoke `(wc as any).handleTelemetryUpdate()` → assert `refreshAllExtensionReporters` called with `coreCtx`. This is the case the removed replay race broke: when replay's initialize won, core's ctx was never the memoized one.
-  - guard case documenting the old failure mode: `initialize(replayCtx)` where `replayCtx.extension.id === 'salesforce.salesforcedx-vscode-apex-replay-debugger'` → `handleTelemetryUpdate()` → assert `refreshAllExtensionReporters` NOT called (coreExtensionContext stayed unset). Comment: pre-fix, replay winning the initialize race left core in exactly this no-op state; post-fix only core calls initialize so this branch is unreachable in prod.
+  - guard case documenting the old failure mode: `initialize(replayCtx)` where `replayCtx.extension.id === 'salesforce.salesforcedx-vscode-apex-replay-debugger'` → `handleTelemetryUpdate()` → assert `refreshAllExtensionReporters` NOT called (coreExtensionContext stayed unset). Comment: non-core ctx → coreExtensionContext unset → no-op.
   - use `WorkspaceContext.getInstance(true)` to force fresh instance so `initializationPromise`/`coreExtensionContext` reset per test.
 
 commit msg: `refactor(replay-debugger): remove direct dependency on salesforcedx-vscode-core - W-23336192`

--- a/.claude/plans/W-23336192.md
+++ b/.claude/plans/W-23336192.md
@@ -1,0 +1,58 @@
+# W-23336192 — Remove apex-replay-debugger dep on vscode-core
+
+## Context
+- ADR 0006 (core API frozen/sunset) + ADR 0005 (services API = contract)
+- apex-log already did same migration (pattern ref)
+- Bug fix, not just cleanup: replay debugger's `WorkspaceContext.getInstance().initialize(extensionContext)` (src/index.ts:207) races core's own `setImmediate` init. `initialize` memoizes via `initializationPromise ??=` (core workspaceContext.ts:44-46) — only 1st caller's ctx kept. If replay wins race, core's `coreExtensionContext` unset → `handleTelemetryUpdate()` no-ops on org change. Removing redundant call fixes it.
+- All core refs confined to src/index.ts + package.json. desktopFixtures.ts refs = out of scope (apex-log/apex still need core installed transitively).
+
+## Bug mechanics (what the test must pin)
+- replay's L207 calls `initialize(extensionContext)` with replay's OWN ctx → `extension.id === 'salesforce.salesforcedx-vscode-apex-replay-debugger'`, NOT core.
+- core workspaceContext `_doInitialize` (L49-52) only sets `coreExtensionContext` when `extension.id === 'salesforce.salesforcedx-vscode-core'`.
+- `initialize` memoizes via `initializationPromise ??=` (L45). If replay wins race, memoized ctx = replay's → `coreExtensionContext` never set → `handleTelemetryUpdate` (L93-96) no-ops (`refreshAllExtensionReporters` never called) on every org change.
+- Fix = remove replay's initialize call so only core's `activate()` calls `initialize`, guaranteeing coreExtensionContext set.
+
+## Phases
+
+### Phase 1 (single commit) — strip core coupling + regression test
+`packages/salesforcedx-vscode-apex-replay-debugger/`
+
+src/index.ts:
+- del `import type { SalesforceVSCodeCoreApi }` (L23)
+- del `salesforceCoreExtension` lookup + throw (L56-61)
+- del core activate-if-inactive block (L198-200)
+- del `WorkspaceContext.getInstance().initialize(extensionContext)` + surrounding `Effect.promise` (L205-208) — no replacement
+
+package.json:
+- del `salesforce.salesforcedx-vscode-core` from extensionDependencies (L53)
+- del `salesforcedx-vscode-core` devDependency (L46)
+- del wireit compile dep `../salesforcedx-vscode-core:compile` (L81)
+- del wireit test:desktop dep `../salesforcedx-vscode-core:vscode:package:legacy` (L184)
+
+`packages/salesforcedx-vscode-core/test/jest/context/workspaceContext.test.ts`:
+- add `describe('handleTelemetryUpdate telemetry refresh on org change')` proving the bug fix (mock `refreshAllExtensionReporters` from `@salesforce/salesforcedx-utils-vscode`):
+  - RED-before-fix / GREEN-after case: `initialize(coreCtx)` where `coreCtx.extension.id === 'salesforce.salesforcedx-vscode-core'` → invoke `(wc as any).handleTelemetryUpdate()` → assert `refreshAllExtensionReporters` called with `coreCtx`. This is the case the removed replay race broke: when replay's initialize won, core's ctx was never the memoized one.
+  - guard case documenting the old failure mode: `initialize(replayCtx)` where `replayCtx.extension.id === 'salesforce.salesforcedx-vscode-apex-replay-debugger'` → `handleTelemetryUpdate()` → assert `refreshAllExtensionReporters` NOT called (coreExtensionContext stayed unset). Comment: pre-fix, replay winning the initialize race left core in exactly this no-op state; post-fix only core calls initialize so this branch is unreachable in prod.
+  - use `WorkspaceContext.getInstance(true)` to force fresh instance so `initializationPromise`/`coreExtensionContext` reset per test.
+
+commit msg: `refactor(replay-debugger): remove direct dependency on salesforcedx-vscode-core - W-23336192`
+
+## Skills
+- typescript — src/index.ts edits
+- packageJson — dep/wireit edits
+- wireit — verify dep graph still valid
+- services-extension-consumption — confirm no services API needed as replacement
+- verification — run compile/lint/test
+- playwright-e2e — test:desktop still green
+
+## Verification
+- `npm run compile` (package) — passes
+- `npm run lint` (package) — passes
+- core jest bug-fix test: `npm run test -w salesforcedx-vscode-core -- workspaceContext` — new handleTelemetryUpdate cases pass; confirm the core-ctx case FAILS if you revert `_doInitialize`'s `coreExtensionContext = extensionContext` assignment (proves it pins the fix)
+- replay jest: `npm run test -w salesforcedx-vscode-apex-replay-debugger` — passes
+- grep: no `salesforcedx-vscode-core`/`SalesforceVSCodeCoreApi` in src/
+- grep package.json: no core in dep/devDep/extensionDependencies/wireit
+- e2e (run locally BEFORE PR, per playwright-e2e skill) — these exercise the replay activation path that lost the core initialize call; run all four:
+  - `npm run test:desktop -w salesforcedx-vscode-apex-replay-debugger`
+  - specs covered: `test/playwright/specs/apexReplayDebugger.desktop.spec.ts`, `checkpoints.desktop.spec.ts`, `apexReplayDebuggerVariables.desktop.spec.ts`, `debugApexTests.desktop.spec.ts`
+  - regression check: replay extension still activates + debug session starts with core no longer an extensionDependency

--- a/.claude/skills/external-consumers/SKILL.md
+++ b/.claude/skills/external-consumers/SKILL.md
@@ -80,7 +80,6 @@ Always grep for `\.exports\.\w+` across the full monorepo, not just `coreExtensi
 |---------|-------|------------------|
 | apex | `coreExtensionUtils.ts`, `index.ts`, `languageServer.ts` | `.WorkspaceContext`, `.services.TelemetryService`, `.getAuthFields` |
 | apex-debugger | `coreExtensionUtils.ts`, `index.ts`, `debugConfigurationProvider.ts` | `.channelService`, `.SfCommandlet`, `.telemetryService`, `.SfCommandletExecutor` |
-| apex-replay-debugger | `index.ts`, `checkpointService.ts`, `quickLaunch.ts`, `debugConfigurationProvider.ts` | `.services.WorkspaceContext`, `.getUserId` |
 | utils-vscode | `authUtils.ts`, `workspaceContextUtil.ts`, `telemetryUtils.ts` | `.sharedAuthState`, `.channelService`, `.getSharedTelemetryUserId` (phantom — not on API type) |
 
 ## Keeping current

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -43,14 +43,12 @@
     "@salesforce/core": "^8.32.2",
     "@salesforce/playwright-vscode-ext": "*",
     "salesforcedx-vscode-apex": "*",
-    "salesforcedx-vscode-core": "*",
     "salesforcedx-vscode-metadata": "*",
     "salesforcedx-vscode-services": "*"
   },
   "extensionDependencies": [
     "salesforce.salesforcedx-vscode-apex",
     "salesforce.salesforcedx-vscode-apex-log",
-    "salesforce.salesforcedx-vscode-core",
     "salesforce.salesforcedx-vscode-services"
   ],
   "scripts": {
@@ -78,7 +76,6 @@
         "../salesforcedx-vscode-apex-log:compile",
         "../salesforcedx-vscode-i18n:compile",
         "../salesforcedx-vscode-apex:compile",
-        "../salesforcedx-vscode-core:compile",
         "../salesforcedx-vscode-services:compile",
         "../effect-ext-utils:compile",
         "../salesforcedx-vscode-metadata:compile"
@@ -181,7 +178,6 @@
       "dependencies": [
         "vscode:package",
         "../salesforcedx-vscode-services:vscode:package",
-        "../salesforcedx-vscode-core:vscode:package:legacy",
         "../salesforcedx-vscode-apex:vscode:package",
         "../salesforcedx-vscode-apex-log:vscode:package",
         "../salesforcedx-vscode-apex-testing:vscode:package",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
@@ -20,7 +20,6 @@ import { TelemetryService } from '@salesforce/salesforcedx-utils-vscode';
 import * as Effect from 'effect/Effect';
 import * as path from 'node:path';
 import type { ApexVSCodeApi } from 'salesforcedx-vscode-apex';
-import type { SalesforceVSCodeCoreApi } from 'salesforcedx-vscode-core';
 import * as vscode from 'vscode';
 import { URI } from 'vscode-uri';
 import { getDialogStartingPath } from './activation/getDialogStartingPath';
@@ -51,13 +50,6 @@ export enum VSCodeWindowTypeEnum {
   Error = 1,
   Informational = 2,
   Warning = 3
-}
-
-const salesforceCoreExtension = vscode.extensions.getExtension<SalesforceVSCodeCoreApi>(
-  'salesforce.salesforcedx-vscode-core'
-);
-if (!salesforceCoreExtension) {
-  throw new Error('Salesforce Core Extension not initialized');
 }
 
 const salesforceApexExtension = vscode.extensions.getExtension<ApexVSCodeApi>('salesforce.salesforcedx-vscode-apex');
@@ -194,18 +186,10 @@ export const activateEffect = Effect.fn('activation:salesforcedx-vscode-apex-rep
   const checkpointsView = vscode.window.registerTreeDataProvider('sf.view.checkpoint', checkpointService);
   const breakpointsSub = vscode.debug.onDidChangeBreakpoints(processBreakpointChangedForCheckpoints);
 
-  // Activate Salesforce Core and Apex Extensions
-  if (!salesforceCoreExtension.isActive) {
-    yield* Effect.promise(() => salesforceCoreExtension.activate());
-  }
+  // Activate Salesforce Apex Extension
   if (!salesforceApexExtension.isActive) {
     yield* Effect.promise(() => salesforceApexExtension.activate());
   }
-
-  // Workspace Context
-  yield* Effect.promise(() =>
-    salesforceCoreExtension.exports.services.WorkspaceContext.getInstance().initialize(extensionContext)
-  );
 
   // Debug Tests command
   const debugTests = vscode.commands.registerCommand('sf.test.view.debugTests', async (test: { name: string }) => {

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/fixtures/desktopFixtures.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/fixtures/desktopFixtures.ts
@@ -11,7 +11,6 @@ export const desktopTest = createDesktopTest({
   fixturesDir: __dirname,
   orgAlias: MINIMAL_ORG_ALIAS,
   additionalExtensionDirs: [
-    'salesforcedx-vscode-core',
     'salesforcedx-vscode-apex',
     'salesforcedx-vscode-apex-log',
     'salesforcedx-vscode-apex-testing',

--- a/packages/salesforcedx-vscode-core/test/jest/context/workspaceContext.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/context/workspaceContext.test.ts
@@ -29,6 +29,11 @@ jest.mock('../../../src/context/workspaceOrgShape', () => ({
   getOrgShape: (...args: any[]) => getOrgShapeMock(...args)
 }));
 
+const makeWorkspaceContextUtilStub = () => ({
+  onOrgChange: jest.fn(),
+  initialize: jest.fn().mockResolvedValue(undefined)
+});
+
 describe('workspaceContext', () => {
   describe('handleOrgShapeChange', () => {
     const mockOrgUserInfo: OrgUserInfo = { username: 'test-username' };
@@ -144,10 +149,7 @@ describe('workspaceContext', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-      mockWorkspaceContextUtil = {
-        onOrgChange: jest.fn(),
-        initialize: jest.fn().mockResolvedValue(undefined)
-      };
+      mockWorkspaceContextUtil = makeWorkspaceContextUtilStub();
       jest.spyOn(WorkspaceContextUtil, 'getInstance').mockReturnValue(mockWorkspaceContextUtil);
       mockRunPromise.mockResolvedValue(mockConnection);
 
@@ -213,14 +215,10 @@ describe('workspaceContext', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-      jest.spyOn(WorkspaceContextUtil, 'getInstance').mockReturnValue({
-        onOrgChange: jest.fn(),
-        initialize: jest.fn().mockResolvedValue(undefined)
-      } as any);
+      jest.spyOn(WorkspaceContextUtil, 'getInstance').mockReturnValue(makeWorkspaceContextUtilStub() as any);
     });
 
-    // core's own activate() initialized with core ctx → refreshers run on org change.
-    // This is the case the removed replay initialize race broke (replay winning left core ctx unset).
+    // documents _doInitialize id-gating: core ctx → coreExtensionContext set → refreshers run.
     it('refreshes all extension reporters when initialized with core context', async () => {
       const workspaceContext = WorkspaceContext.getInstance(true);
       await workspaceContext.initialize(coreCtx);
@@ -230,8 +228,7 @@ describe('workspaceContext', () => {
       expect(refreshAllExtensionReportersMock).toHaveBeenCalledWith(coreCtx);
     });
 
-    // Pre-fix, replay winning the initialize race left core in exactly this no-op state.
-    // Post-fix only core calls initialize so this branch is unreachable in prod.
+    // non-core ctx → coreExtensionContext stays unset → refreshers no-op.
     it('does not refresh reporters when initialized with a non-core (replay) context', async () => {
       const workspaceContext = WorkspaceContext.getInstance(true);
       await workspaceContext.initialize(replayCtx);

--- a/packages/salesforcedx-vscode-core/test/jest/context/workspaceContext.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/context/workspaceContext.test.ts
@@ -4,8 +4,20 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { OrgUserInfo, OrgShape, WorkspaceContextUtil } from '@salesforce/salesforcedx-utils-vscode';
+import {
+  OrgUserInfo,
+  OrgShape,
+  WorkspaceContextUtil,
+  refreshAllExtensionReporters
+} from '@salesforce/salesforcedx-utils-vscode';
 import { WorkspaceContext } from '../../../src/context';
+
+jest.mock('@salesforce/salesforcedx-utils-vscode', () => ({
+  ...jest.requireActual('@salesforce/salesforcedx-utils-vscode'),
+  refreshAllExtensionReporters: jest.fn().mockResolvedValue(undefined)
+}));
+
+const refreshAllExtensionReportersMock = refreshAllExtensionReporters as jest.Mock;
 
 const mockRunPromise = jest.fn();
 jest.mock('../../../src/services/runtime', () => ({
@@ -189,6 +201,44 @@ describe('workspaceContext', () => {
       expect(conn2).toBe(mockConnection);
       expect(conn3).toBe(mockConnection);
       expect(mockRunPromise).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('handleTelemetryUpdate telemetry refresh on org change', () => {
+    const coreCtx = { extension: { id: 'salesforce.salesforcedx-vscode-core' }, subscriptions: [] } as any;
+    const replayCtx = {
+      extension: { id: 'salesforce.salesforcedx-vscode-apex-replay-debugger' },
+      subscriptions: []
+    } as any;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      jest.spyOn(WorkspaceContextUtil, 'getInstance').mockReturnValue({
+        onOrgChange: jest.fn(),
+        initialize: jest.fn().mockResolvedValue(undefined)
+      } as any);
+    });
+
+    // core's own activate() initialized with core ctx → refreshers run on org change.
+    // This is the case the removed replay initialize race broke (replay winning left core ctx unset).
+    it('refreshes all extension reporters when initialized with core context', async () => {
+      const workspaceContext = WorkspaceContext.getInstance(true);
+      await workspaceContext.initialize(coreCtx);
+
+      await (workspaceContext as any).handleTelemetryUpdate();
+
+      expect(refreshAllExtensionReportersMock).toHaveBeenCalledWith(coreCtx);
+    });
+
+    // Pre-fix, replay winning the initialize race left core in exactly this no-op state.
+    // Post-fix only core calls initialize so this branch is unreachable in prod.
+    it('does not refresh reporters when initialized with a non-core (replay) context', async () => {
+      const workspaceContext = WorkspaceContext.getInstance(true);
+      await workspaceContext.initialize(replayCtx);
+
+      await (workspaceContext as any).handleTelemetryUpdate();
+
+      expect(refreshAllExtensionReportersMock).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?

## Summary
- Removes `salesforcedx-vscode-apex-replay-debugger`'s direct dependency on `salesforcedx-vscode-core` (dep/devDep/extensionDependencies/wireit + `src/index.ts` core-API lookup and activation-if-inactive block), per ADR 0006 (core API frozen/sunset) and ADR 0005 (services API is the contract) — same pattern already applied to `salesforcedx-vscode-apex-log`.
- Bug fix, not just cleanup: replay's redundant `WorkspaceContext.getInstance().initialize(extensionContext)` call raced core's own `setImmediate` init; `initialize` memoizes on first caller's context, so if replay won the race, core's `coreExtensionContext` was never set and `handleTelemetryUpdate()` silently no-op'd on every org change. Removing the call guarantees only core's `activate()` seeds the singleton.
- Adds a regression test in `packages/salesforcedx-vscode-core/test/jest/context/workspaceContext.test.ts` pinning `handleTelemetryUpdate`'s behavior for core-vs-non-core initializer contexts.

## Plan
[.claude/plans/W-23336192.md](../blob/sm/W-23336192-remove-salesforcedx-vscode-apex-replay-d/.claude/plans/W-23336192.md)

## Reviewer notes
- `workspaceContext.test.ts` core-package tests fixed misleading RED/GREEN comments (now describe the actual `_doInitialize` id-gating behavior they cover), but they cannot detect a future re-introduction of replay's removed `WorkspaceContext.getInstance().initialize()` call, since that call lived in `salesforcedx-vscode-apex-replay-debugger/src/index.ts`'s activation path. A true regression guard for that would need an activation-level test in the replay package (mocking the core API/extension lookup) — a test-design choice deferred as out of scope for this change.

### What issues does this PR fix or reference?
#, @W-23336192@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002e5w0NYAQ/view