### PR TITLE
docs(apex): add ADR to migrate telemetry to Effect spans/logs - W-23348766

### DIFF
--- a/.claude/plans/W-23348766.md
+++ b/.claude/plans/W-23348766.md
@@ -1,0 +1,56 @@
+# W-23348766 — ADR: migrate Apex ext telemetry to Effect spans
+
+## Context
+
+- Docs-only WI. Record decision; blocks all Apex telemetry migration WIs.
+- Move Apex ext off core `services.TelemetryService` event API → **Effect spans** via services OTEL layer. Production destination is **spans only** (span attributes), per root ADR-0012 (`docs/adr/0012-spans-only-observability.md`): "there are no separate metrics or logs pipelines for new code."
+- Logs are NOT a production channel. `Effect.logDebug`/`logError` are local-console/OTLP debug aids only (services README ~line 352: appear in console when Effect log level = Debug). Never model any telemetry destination as an "error log" that ships to AppInsights/O11y.
+- Current event-API call sites (`packages/salesforcedx-vscode-apex/src`):
+  - `languageServer.ts:105` `sendEventData('apexLSPSettings', undefined, { maxHeapSize })`
+  - `languageServer.ts:134` `sendException(LSP_ERR=…'apexLSPError', err.error)` (createServer catch)
+  - `languageServer.ts:156` `sendEventData('apexLSPLog', props, measures)` (client.onTelemetry, gated by `isApexLspTelemetryAllowed`)
+  - `index.ts:121` `sendExtensionDeactivationEvent()` (deactivate)
+  - also present, migrate-later: `languageUtils/index.ts` apexTestDiscovery{Start,End}; `languageClientManager.ts` apexLSPRestart, apexLSPStartup
+- Export model (services `observability/README.md` lines 21, 197-200): only top-level + command spans reach AppInsights/O11y. Two annotation helpers: `annotateRootSpan` from `@salesforce/effect-ext-utils` (walks to trace root, reaches AppInsights/O11y from anywhere); `Effect.annotateCurrentSpan` (current span only, local-debug unless that span is itself top-level/command).
+- `apexLSPLog` volume: `client.onTelemetry` fires per Jorje feature event; `apexLspTelemetryAllowlist.ts:16-65` enumerates 40+ Jorje features, `BLOCKED_APEX_LSP_TELEMETRY_FEATURES` (lines 74-108) strips per-request/high-volume paths (Hover, Completion, CodeLens, etc.) precisely to bound AppInsights volume. The migration must preserve that volume bound — the export mechanism choice below is the load-bearing decision this ADR settles.
+- Existing ADRs: apex `0001-deliberately-not-web.md`; format = H1 title + terse bullets (see apex-testing `0002`, `0003`). Next number = `0002`.
+
+## Phases
+
+### Phase 1 — write ADR-0002
+
+- File: `packages/salesforcedx-vscode-apex/docs/adr/0002-telemetry-to-effect-spans.md`
+- H1 decision title + bullets (match sibling ADR style; NOT concise-skill — ADR is human doc, full but terse).
+- Content:
+  - Decision: retire core `TelemetryService` event API (`sendEventData`/`sendException`/`sendExtensionDeactivationEvent`) in Apex ext; emit via **Effect spans** through services OTEL layer. Production telemetry is **span attributes only** — no logs pipeline.
+  - Cite ADR-0012 (`../../../../docs/adr/0012-spans-only-observability.md` relative from apex ADR dir; verify depth): spans-only, no metrics/logs pipelines for new code. State that `Effect.logDebug`/`logError` are local-debug only and are NOT a telemetry destination.
+  - Event→span map (all destinations are spans/span-attributes, never logs):
+    - `apexLSPSettings` (maxHeapSize) → attribute on the server-startup span (via `annotateRootSpan` if emitted below a top-level span, so it reaches AppInsights).
+    - `apexLSPError` (`LSP_ERR`) → the enclosing span **fails** (Effect error propagates), recording error status/attributes on that span. It becomes an error span, not an error log.
+    - deactivation → attribute on / dedicated deactivate span.
+    - `apexLSPLog` (per-feature, allowlist-gated) → **see explicit mechanism decision below**.
+  - `apexLSPLog` export mechanism — DECIDE explicitly (this is the WI's purpose; leaving open defeats "blocks all migration WIs"):
+    - Do NOT make each `apexLSPLog` event a new top-level span. Top-level spans ship to AppInsights automatically; 40+ allowlisted Jorje features firing repeatedly would reintroduce exactly the volume the `BLOCKED_APEX_LSP_TELEMETRY_FEATURES` allowlist exists to suppress.
+    - Decision: attach `apexLSPLog` data as attributes on the existing long-lived language-client/activation span via `annotateRootSpan`, keeping the `isApexLspTelemetryAllowed` allowlist gate at the `client.onTelemetry` boundary before annotating. This preserves the volume bound (one long-lived span, not N spans) while still reaching AppInsights.
+    - Note attribute-collision risk: repeated features annotating the same root span overwrite same-keyed attributes; migration WIs must namespace keys (e.g. by feature) or aggregate. Flag as a downstream constraint, not solved here.
+  - Export rule: only top-level + command spans ship to AppInsights/O11y; per-event data reaches them only via `annotateRootSpan` (not `Effect.annotateCurrentSpan`, which is local-only unless the current span is itself top-level/command). Cite services `observability/README.md` lines 21, 197-200.
+  - Consequence: downstream dashboards/queries keyed on old event names (`apexLSPSettings`, `apexLSPLog`, `apexLSPError`, deactivation) break; acceptable per team.
+  - Scope note: blocks migration WIs; test-discovery + LSP restart/startup events migrate under those.
+- Link relatively to root ADR-0012, services observability README, effect-ext-utils `annotateRootSpan`.
+- Commit: `docs(apex): ADR migrate telemetry to Effect spans/logs - W-23348766`
+
+## Skills to apply
+
+- `concise` — plan file only (ADR itself is human doc, terse-but-prose per sibling ADRs).
+- `effect-ext-utils`/services `observability/README.md` — verify `annotateRootSpan` + export-filter claims.
+- `typescript` — docs-only WI, but ADR cites/links call sites in `.ts` files (`languageServer.ts`, `index.ts`, `languageUtils/index.ts`, `languageClientManager.ts`); apply to check those references/symbols still match current source before citing line numbers.
+- No other code/e2e skills — docs-only.
+
+## Verification
+
+- No e2e coverage (docs-only; nothing to run on branch).
+- File exists, correct path/number (`0002-…`), no clash with `0001`.
+- Links resolve (relative paths to root ADR-0012, services README, effect-ext-utils src). Verify ADR-0012 relative depth (`../../../../docs/adr/0012-...` from apex ADR dir).
+- ADR-0012 consistency: ADR-0002 says spans-only, never frames logs as a production destination; `apexLSPError`→failing span (not "error log"); `apexLSPLog` export mechanism explicitly decided (root-span annotation, not per-event top-level span) with volume rationale.
+- Claims match code: event names + call sites (grep), export-filter behavior (README lines 21, 197-200), allowlist size/intent (`apexLspTelemetryAllowlist.ts:16-65,74-108`).
+- `npm run lint` if md linted; else visual review.

--- a/.claude/plans/W-23348766.md
+++ b/.claude/plans/W-23348766.md
@@ -29,7 +29,7 @@
     - `apexLSPError` (`LSP_ERR`) → the enclosing span **fails** (Effect error propagates), recording error status/attributes on that span. It becomes an error span, not an error log.
     - deactivation → attribute on / dedicated deactivate span.
     - `apexLSPLog` (per-feature, allowlist-gated) → **see explicit mechanism decision below**.
-  - `apexLSPLog` export mechanism — DECIDE explicitly (this is the WI's purpose; leaving open defeats "blocks all migration WIs"):
+  - `apexLSPLog` export mechanism — DECIDE explicitly (load-bearing; this WI must not leave it open):
     - Do NOT make each `apexLSPLog` event a new top-level span. Top-level spans ship to AppInsights automatically; 40+ allowlisted Jorje features firing repeatedly would reintroduce exactly the volume the `BLOCKED_APEX_LSP_TELEMETRY_FEATURES` allowlist exists to suppress.
     - Decision: attach `apexLSPLog` data as attributes on the existing long-lived language-client/activation span via `annotateRootSpan`, keeping the `isApexLspTelemetryAllowed` allowlist gate at the `client.onTelemetry` boundary before annotating. This preserves the volume bound (one long-lived span, not N spans) while still reaching AppInsights.
     - Note attribute-collision risk: repeated features annotating the same root span overwrite same-keyed attributes; migration WIs must namespace keys (e.g. by feature) or aggregate. Flag as a downstream constraint, not solved here.

--- a/packages/salesforcedx-vscode-apex/docs/adr/0002-telemetry-to-effect-spans.md
+++ b/packages/salesforcedx-vscode-apex/docs/adr/0002-telemetry-to-effect-spans.md
@@ -20,7 +20,7 @@ All destinations below are spans / span attributes. No entry is a "log".
 
 ## `apexLSPLog` export mechanism (the decision this ADR settles)
 
-`client.onTelemetry` fires once per Jorje feature event. `apexLspTelemetryAllowlist.ts` enumerates the Jorje feature names (`JORJE_LSP_TELEMETRY_FEATURES_FROM_SOURCE`, lines 16-67), and `BLOCKED_APEX_LSP_TELEMETRY_FEATURES` (lines 74-108) strips the per-request / high-volume paths — hover, completion strategies, document lifecycle, etc. — so that only lower-volume features flow to App Insights via `isApexLspTelemetryAllowed` (line 119). This volume bound is load-bearing and the migration must preserve it.
+`client.onTelemetry` fires once per Jorje feature event. `apexLspTelemetryAllowlist.ts` enumerates the Jorje feature names (`JORJE_LSP_TELEMETRY_FEATURES_FROM_SOURCE`, lines 16-65), and `BLOCKED_APEX_LSP_TELEMETRY_FEATURES` (lines 74-108) strips the per-request / high-volume paths — hover, completion strategies, document lifecycle, etc. — so that only lower-volume features flow to App Insights via `isApexLspTelemetryAllowed` (line 119). This volume bound is load-bearing and the migration must preserve it.
 
 - **Do NOT make each `apexLSPLog` event its own top-level span.** Top-level spans ship to App Insights automatically; the many allowlisted features firing repeatedly would reintroduce exactly the volume the blocked-features list exists to suppress.
 

--- a/packages/salesforcedx-vscode-apex/docs/adr/0002-telemetry-to-effect-spans.md
+++ b/packages/salesforcedx-vscode-apex/docs/adr/0002-telemetry-to-effect-spans.md
@@ -1,0 +1,35 @@
+# Migrate Apex extension telemetry from the core event API to Effect spans
+
+The Apex extension will retire the legacy core `TelemetryService` event API — `sendEventData`, `sendException`, `sendExtensionDeactivationEvent` — and emit telemetry as **Effect spans** through the services OTEL layer instead. This ADR records the decision and the per-event migration shape; the individual call-site migrations happen under downstream WIs that this one unblocks.
+
+- **Production telemetry is span attributes only.** Per the repo root [ADR-0012](../../../../docs/adr/0012-spans-only-observability.md), all new telemetry flows through OpenTelemetry spans — there are no separate metrics or logs pipelines for new code. Nothing in this migration may model a telemetry destination as a "log". `Effect.logDebug` / `Effect.logError` are local-console / OTLP debug aids only (visible when the Effect log level is Debug); they are **not** a channel to App Insights or O11y and must never be used as a stand-in for the retired event API.
+
+- **Export model.** Only top-level spans and command spans ship to App Insights and O11y; all spans reach the local console / OTLP debug exporters. See the services [observability README](../../../salesforcedx-vscode-services/src/observability/README.md) (routing key points at line 21; the two annotation helpers and the export filter around lines 195-200). Per-event data reaches App Insights only via `annotateRootSpan` from [`@salesforce/effect-ext-utils`](../../../effect-ext-utils/src/annotateRootSpan.ts), which walks to the trace root. `Effect.annotateCurrentSpan` writes the current span only and is local-debug unless that span is itself top-level or a command span.
+
+## Event → span map
+
+All destinations below are spans / span attributes. No entry is a "log".
+
+- **`apexLSPSettings`** (`languageServer.ts:105`, `maxHeapSize` measure) → an attribute on the server-startup span. Use `annotateRootSpan` when emitted below a top-level span so it reaches App Insights.
+
+- **`apexLSPError`** (`languageServer.ts:134`, `sendException(LSP_ERR, …)`; `LSP_ERR = 'apexLSPError'` in `constants.ts:13`) → the enclosing Effect **fails**, so the enclosing span records error status and attributes and becomes an **error span**. It is not an error log.
+
+- **deactivation** (`index.ts:121`, `sendExtensionDeactivationEvent()`) → an attribute on, or a dedicated, deactivate span.
+
+- **`apexLSPLog`** (`languageServer.ts:156`, per-Jorje-feature, allowlist-gated) → see the explicit mechanism decision below.
+
+## `apexLSPLog` export mechanism (the decision this ADR settles)
+
+`client.onTelemetry` fires once per Jorje feature event. `apexLspTelemetryAllowlist.ts` enumerates the Jorje feature names (`JORJE_LSP_TELEMETRY_FEATURES_FROM_SOURCE`, lines 16-67), and `BLOCKED_APEX_LSP_TELEMETRY_FEATURES` (lines 74-108) strips the per-request / high-volume paths — hover, completion strategies, document lifecycle, etc. — so that only lower-volume features flow to App Insights via `isApexLspTelemetryAllowed` (line 119). This volume bound is load-bearing and the migration must preserve it.
+
+- **Do NOT make each `apexLSPLog` event its own top-level span.** Top-level spans ship to App Insights automatically; the many allowlisted features firing repeatedly would reintroduce exactly the volume the blocked-features list exists to suppress.
+
+- **Decision:** attach `apexLSPLog` data as **attributes on the existing long-lived language-client / activation span via `annotateRootSpan`**. Keep the `isApexLspTelemetryAllowed` allowlist gate at the `client.onTelemetry` boundary, before annotating. This is one long-lived span rather than N spans, so the volume bound is preserved while the data still reaches App Insights.
+
+- **Downstream constraint (not solved here):** repeated features annotating the same root span overwrite same-keyed attributes. Migration WIs must namespace keys (for example by feature) or aggregate before annotating.
+
+## Consequences
+
+- Downstream dashboards and queries keyed on the old event names — `apexLSPSettings`, `apexLSPLog`, `apexLSPError`, and the deactivation event — break. Accepted per team.
+
+- **Scope:** this ADR blocks the Apex telemetry migration WIs. The remaining event-API call sites — `apexTestDiscoveryStart` / `apexTestDiscoveryEnd` (`languageUtils/index.ts`), `apexLSPRestart` and `apexLSPStartup` (`languageUtils/languageClientManager.ts`) — migrate under those WIs following the same span model.

--- a/packages/salesforcedx-vscode-apex/docs/adr/0002-telemetry-to-effect-spans.md
+++ b/packages/salesforcedx-vscode-apex/docs/adr/0002-telemetry-to-effect-spans.md
@@ -1,35 +1,12 @@
 # Migrate Apex extension telemetry from the core event API to Effect spans
 
-The Apex extension will retire the legacy core `TelemetryService` event API — `sendEventData`, `sendException`, `sendExtensionDeactivationEvent` — and emit telemetry as **Effect spans** through the services OTEL layer instead. This ADR records the decision and the per-event migration shape; the individual call-site migrations happen under downstream WIs that this one unblocks.
+The Apex extension will retire the legacy core `TelemetryService` event API — `sendEventData`, `sendException`, `sendExtensionDeactivationEvent` — and emit telemetry as Effect spans through the services OTEL layer instead. Per the repo root [ADR-0012](../../../../docs/adr/0012-spans-only-observability.md), production telemetry is span attributes only: there is no logs pipeline for new code, so `Effect.logDebug` / `logError` are local-debug aids, not a replacement for the retired events. Per-event data reaches App Insights only via `annotateRootSpan` from [`@salesforce/effect-ext-utils`](../../../effect-ext-utils/src/annotateRootSpan.ts) — only top-level and command spans export (see the services [observability README](../../../salesforcedx-vscode-services/src/observability/README.md)).
 
-- **Production telemetry is span attributes only.** Per the repo root [ADR-0012](../../../../docs/adr/0012-spans-only-observability.md), all new telemetry flows through OpenTelemetry spans — there are no separate metrics or logs pipelines for new code. Nothing in this migration may model a telemetry destination as a "log". `Effect.logDebug` / `Effect.logError` are local-console / OTLP debug aids only (visible when the Effect log level is Debug); they are **not** a channel to App Insights or O11y and must never be used as a stand-in for the retired event API.
+## The `apexLSPLog` decision
 
-- **Export model.** Only top-level spans and command spans ship to App Insights and O11y; all spans reach the local console / OTLP debug exporters. See the services [observability README](../../../salesforcedx-vscode-services/src/observability/README.md) (routing key points at line 21; the two annotation helpers and the export filter around lines 195-200). Per-event data reaches App Insights only via `annotateRootSpan` from [`@salesforce/effect-ext-utils`](../../../effect-ext-utils/src/annotateRootSpan.ts), which walks to the trace root. `Effect.annotateCurrentSpan` writes the current span only and is local-debug unless that span is itself top-level or a command span.
-
-## Event → span map
-
-All destinations below are spans / span attributes. No entry is a "log".
-
-- **`apexLSPSettings`** (`languageServer.ts:105`, `maxHeapSize` measure) → an attribute on the server-startup span. Use `annotateRootSpan` when emitted below a top-level span so it reaches App Insights.
-
-- **`apexLSPError`** (`languageServer.ts:134`, `sendException(LSP_ERR, …)`; `LSP_ERR = 'apexLSPError'` in `constants.ts:13`) → the enclosing Effect **fails**, so the enclosing span records error status and attributes and becomes an **error span**. It is not an error log.
-
-- **deactivation** (`index.ts:121`, `sendExtensionDeactivationEvent()`) → an attribute on, or a dedicated, deactivate span.
-
-- **`apexLSPLog`** (`languageServer.ts:156`, per-Jorje-feature, allowlist-gated) → see the explicit mechanism decision below.
-
-## `apexLSPLog` export mechanism (the decision this ADR settles)
-
-`client.onTelemetry` fires once per Jorje feature event. `apexLspTelemetryAllowlist.ts` enumerates the Jorje feature names (`JORJE_LSP_TELEMETRY_FEATURES_FROM_SOURCE`, lines 16-65), and `BLOCKED_APEX_LSP_TELEMETRY_FEATURES` (lines 74-108) strips the per-request / high-volume paths — hover, completion strategies, document lifecycle, etc. — so that only lower-volume features flow to App Insights via `isApexLspTelemetryAllowed` (line 119). This volume bound is load-bearing and the migration must preserve it.
-
-- **Do NOT make each `apexLSPLog` event its own top-level span.** Top-level spans ship to App Insights automatically; the many allowlisted features firing repeatedly would reintroduce exactly the volume the blocked-features list exists to suppress.
-
-- **Decision:** attach `apexLSPLog` data as **attributes on the existing long-lived language-client / activation span via `annotateRootSpan`**. Keep the `isApexLspTelemetryAllowed` allowlist gate at the `client.onTelemetry` boundary, before annotating. This is one long-lived span rather than N spans, so the volume bound is preserved while the data still reaches App Insights.
-
-- **Downstream constraint (not solved here):** repeated features annotating the same root span overwrite same-keyed attributes. Migration WIs must namespace keys (for example by feature) or aggregate before annotating.
+The one non-obvious choice this ADR settles: `apexLSPLog` fires once per Jorje feature event, and its allowlist (`apexLspTelemetryAllowlist.ts`) exists to bound App Insights volume. Do **not** make each event its own top-level span — that auto-exports and reinstates exactly the volume the allowlist suppresses. Instead annotate the existing long-lived language-client span via `annotateRootSpan`, keeping the allowlist gate at the `client.onTelemetry` boundary: one span, not N.
 
 ## Consequences
 
-- Downstream dashboards and queries keyed on the old event names — `apexLSPSettings`, `apexLSPLog`, `apexLSPError`, and the deactivation event — break. Accepted per team.
-
-- **Scope:** this ADR blocks the Apex telemetry migration WIs. The remaining event-API call sites — `apexTestDiscoveryStart` / `apexTestDiscoveryEnd` (`languageUtils/index.ts`), `apexLSPRestart` and `apexLSPStartup` (`languageUtils/languageClientManager.ts`) — migrate under those WIs following the same span model.
+- Downstream dashboards keyed on the old event names (`apexLSPSettings`, `apexLSPLog`, `apexLSPError`, deactivation) break. Accepted per team.
+- This ADR unblocks the per-call-site migration WIs; those settle their own event→span mapping and attribute-key details.


### PR DESCRIPTION
### What does this PR do?

## Summary
- Adds ADR-0002 deciding to retire core `TelemetryService` event API (`sendEventData`/`sendException`/`sendExtensionDeactivationEvent`) in the Apex extension in favor of Effect spans via the services OTEL layer, per root ADR-0012 (spans-only observability).
- Settles the one load-bearing choice: `apexLSPLog` (fired per allowlisted Jorje feature) attaches as attributes on the long-lived language-client span via `annotateRootSpan` rather than becoming a new top-level span per event — preserving the volume bound the allowlist enforces.
- Docs-only WI; unblocks the downstream Apex telemetry migration work items, which settle their own event→span mapping and attribute-key details.

## Plan
.claude/plans/W-23348766.md

## Reviewer notes
- ADR trimmed to decision-record altitude per `.claude/skills/grill-me/ADR-FORMAT.md` — dropped per-event call-site line numbers, allowlist internals, and downstream attribute-key constraints (all downstream-WI material). Kept the decision, spans-only rationale, the `annotateRootSpan` export rule, and the `apexLSPLog` span-vs-attribute choice.
- **[high, design-decision]** ADR-0002 (`packages/salesforcedx-vscode-apex/docs/adr/0002-telemetry-to-effect-spans.md:7`) prescribes attaching `apexLSPLog` data via `annotateRootSpan` to a "long-lived language-client span," but no such long-lived Effect span currently exists (the activation span `Effect.fn` at `index.ts:52` ends when `activateEffect` resolves), and the emit site (`client.onTelemetry`, a plain async VS Code callback) runs outside any Effect fiber — so `annotateRootSpan` would no-op via its `NoSuchElementException` catch and never reach App Insights. Implementing this requires re-deciding the export mechanism (a real long-lived Effect span with the callback run inside its fiber, or aggregate-then-emit) — left to the follow-up migration WI, not resolved here.

### What issues does this PR fix or reference?
@W-23348766@

### Functionality Before
N/A — docs-only (no ADR-0002 existed for telemetry migration).

### Functionality After
N/A — adds `packages/salesforcedx-vscode-apex/docs/adr/0002-telemetry-to-effect-spans.md` recording the decision.

## Test plan
- Confirm relative links in the ADR resolve: root ADR-0012 (`../../../../docs/adr/0012-spans-only-observability.md`), services `observability/README.md`, `effect-ext-utils` `annotateRootSpan`.
- Confirm the file is numbered `0002-` with no clash against `0001-deliberately-not-web.md`.

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002e9kTuYAI/view
