### PR TITLE
perf(review-plan): speed up plan-adversary via warm-start prompt + evidence budget - W-23355256

### DIFF
--- a/.claude/agents/plan-adversary.md
+++ b/.claude/agents/plan-adversary.md
@@ -8,6 +8,13 @@ Adversarial plan reviewer. Plans land before code. Find failure modes — regres
 
 Don't rewrite. Don't soften. Punch list to address before build.
 
+## Evidence budget
+
+- Start from the handed-in cited-file list + CONTEXT map. Reserve grep/find for concepts those pointers don't cover.
+- `grep -rn` once per concept across a package; never re-run an already-searched pattern.
+- Batch related patterns into one alternation (`grep -rnE 'a|b|c'`).
+- No `git show` / `find -maxdepth 2` to re-discover package layout — the pointers already name it.
+
 ## Rules
 
 - file:line (or plan quote) evidence per finding.

--- a/.claude/plans/W-23355256.md
+++ b/.claude/plans/W-23355256.md
@@ -3,8 +3,8 @@
 ## Context
 
 - `plan-adversary` = long pole of review-plan phase. Baseline W-20992510: 42m18s / 121.8k tok, 3x next agent.
-- **Which invocation produced the baseline:** auto-build-wi's pre-Build `Plan` phase. `auto-build-wi.js:1686-1697` runs `runPlan` → `reviewAndCommitPlan` (the review-plan workflow, which runs plan-adversary) → `runBuild`, in that order. The adversary runs BEFORE any code is written. `review-plan.js` also commits the plan file only at the END of the workflow (the `commitMessage` step), AFTER the adversary fan-out — so at adversary time `git diff origin/develop...HEAD` is empty (no code, not even the plan commit yet). This is the exact scenario the WI names ("long pole of the review-plan phase (auto-build-wi)").
-- **Consequence for the original fix 1+3:** a branch-diff / diff-derived-CONTEXT.md scheme is a near no-op for the target scenario, because there is no diff. The real cold-start cost is the adversary re-discovering **pre-existing** code the plan discusses: it Reads the plan, then cold-explores the repo (75 Bash calls, same greps ~8x, `git show origin/<branch>` ~8x, `find -maxdepth 2` package discovery) to locate the files the plan already cites and the packages it touches.
+- **Baseline invocation:** auto-build-wi pre-Build `Plan` phase. `auto-build-wi.js:1686-1697` runs `runPlan` → `reviewAndCommitPlan` (review-plan workflow, runs plan-adversary) → `runBuild`. Adversary runs before any code written; plan file commits only at workflow end (`commitMessage` step), after adversary fan-out — so `git diff origin/develop...HEAD` is empty at adversary time.
+- **Consequence for original fix 1+3:** branch-diff scheme ≈ no-op for target scenario — no diff exists. Real cold-start cost: adversary re-discovers **pre-existing** code the plan cites — Reads plan, then cold-explores repo (75 Bash calls, same greps ~8x, `git show origin/<branch>` ~8x, `find -maxdepth 2`) to locate files/packages the plan already names.
 - **Corrected lever:** warm the adversary against the code the plan *references*, not against a (nonexistent) branch diff. Sources that ARE populated pre-Build:
   - the plan's own `file:line` citations and `packages/<pkg>/...` path mentions,
   - the WI Subject/Details (already interpolated as text, but not turned into read-these-first pointers),
@@ -16,23 +16,17 @@
 
 ## Phases
 
-### Phase 1 — prime the adversary with plan-referenced code pointers (fixes 1 + 3, corrected)
+### Phase 1 — warm-start directive in the adversary prompt (fixes 1 + 3, corrected)
 
 File: `.claude/workflows/review-plan.js`
 
-- Add `base` arg: `(typeof _a === 'object' && _a.base) || 'origin/develop'` (used only by the standalone/re-plan diff branch below).
-- Add `PRIME_SCHEMA`: `{ pkgs: string[], files: string[], diff: string }`.
-- Add a single haiku `primePrompt` run ONCE before the parallel fan-out. It Reads `${planPath}` (relative to `${wt}`) and extracts:
-  - `files`: every repo-relative path cited in the plan (from `file:line` citations and `packages/...`/`src/...` mentions),
-  - `pkgs`: the distinct `packages/<pkg>` roots those paths fall under.
-  - It ALSO runs `git diff --name-only ${base}...HEAD` and `git diff ${base}...HEAD` from `${wt}` and returns the body as `diff` (empty in the auto-build-wi pre-Build case; populated for a standalone re-plan against a branch with code). If diff body > ~60k chars, return `diff: "<truncated — run git diff ${base}...HEAD>"`; union any diff file paths into `files`/`pkgs`.
-- In JS, from `pkgs` derive candidate `packages/<pkg>/CONTEXT.md` paths (dedupe, pure `map`/`filter`, no exec). This is the primary warm-pointer set — it works pre-Build because it comes from the plan text, not the diff.
-- Interpolate into `adversaryPlanReviewPrompt`:
-  - "Read these first, before any grep/find — start warm": `${wt}/CONTEXT-MAP.md` + the derived pkg `CONTEXT.md` paths + the plan-cited `files` list.
-  - the branch `diff` body when non-empty (labeled as the standalone-run case), else omit / note "no diff yet (pre-build plan stage) — the plan's cited files above are your map".
-  - directive: use the handed-in file list + CONTEXT pointers to jump straight to the cited code; do not `find`/`git show` to re-discover package layout or the files the plan already names.
+- No separate prime agent, `PRIME_SCHEMA`, `base` arg, or diff plumbing — the adversary sees the plan's `file:line` citations on its own first Read, so file/pkg discovery is a prompt directive, not a pre-pass.
+- In `adversaryPlanReviewPrompt`, add a "start warm — before any grep/find" block:
+  - Read `${wt}/CONTEXT-MAP.md`.
+  - Read the plan's cited existing files + `packages/<pkg>/CONTEXT.md` for every package the plan cites. Skip files the plan proposes to create (don't exist yet pre-Build).
+  - Do not `find`/`git show` to re-discover package layout or the files the plan already names.
 
-Commit: `perf(review-plan): prime plan-adversary with plan-referenced code pointers`
+Commit: `perf(review-plan): warm-start plan-adversary via prompt directive`
 
 ### Phase 2 — cap redundant greps in plan-adversary (fix 2)
 
@@ -57,7 +51,6 @@ Commit: `perf(plan-adversary): cap redundant evidence greps`
 Not e2e-covered: `.claude/` tooling, no Playwright surface.
 
 - `node --check .claude/workflows/review-plan.js` passes.
-- **Primary path (auto-build-wi pre-Build, empty diff)** — the scenario that owns the baseline. Rerun the adversary on a plan that cites several existing files across ≥1 package, with an empty branch diff. Confirm the prime agent extracts the cited files + pkgs, JS derives the right `CONTEXT.md` paths, and the adversary prompt hands them in. Compare adversary wall-clock + tokens vs 42m/121.8k — the drop must come from the plan-derived pointers (diff is empty), proving fixes 1+3 apply to the named scenario.
-- **Standalone re-plan path (branch has code)** — diff non-empty; confirm the diff body is inlined (or truncated) and its paths union into the pointer set.
+- **Primary path (auto-build-wi pre-Build)** — scenario that owns the baseline. Rerun the adversary on a plan that cites several existing files across ≥1 package. Confirm it Reads the cited files + pkg `CONTEXT.md` up front (not cold grep/find). Compare adversary wall-clock + tokens vs 42m/121.8k, proving fixes 1+3 apply to the named scenario.
 - Finding parity: same severities/citations as baseline (no quality regression).
-- Degenerate plan (no file citations, empty diff): prompt still hands `CONTEXT-MAP.md`; interpolation degrades gracefully (empty file-list/pkg-CONTEXT set).
+- Degenerate plan (no file citations): prompt still directs `CONTEXT-MAP.md` read; degrades gracefully.

--- a/.claude/plans/W-23355256.md
+++ b/.claude/plans/W-23355256.md
@@ -1,0 +1,63 @@
+# W-23355256 — speed up plan-adversary
+
+## Context
+
+- `plan-adversary` = long pole of review-plan phase. Baseline W-20992510: 42m18s / 121.8k tok, 3x next agent.
+- **Which invocation produced the baseline:** auto-build-wi's pre-Build `Plan` phase. `auto-build-wi.js:1686-1697` runs `runPlan` → `reviewAndCommitPlan` (the review-plan workflow, which runs plan-adversary) → `runBuild`, in that order. The adversary runs BEFORE any code is written. `review-plan.js` also commits the plan file only at the END of the workflow (the `commitMessage` step), AFTER the adversary fan-out — so at adversary time `git diff origin/develop...HEAD` is empty (no code, not even the plan commit yet). This is the exact scenario the WI names ("long pole of the review-plan phase (auto-build-wi)").
+- **Consequence for the original fix 1+3:** a branch-diff / diff-derived-CONTEXT.md scheme is a near no-op for the target scenario, because there is no diff. The real cold-start cost is the adversary re-discovering **pre-existing** code the plan discusses: it Reads the plan, then cold-explores the repo (75 Bash calls, same greps ~8x, `git show origin/<branch>` ~8x, `find -maxdepth 2` package discovery) to locate the files the plan already cites and the packages it touches.
+- **Corrected lever:** warm the adversary against the code the plan *references*, not against a (nonexistent) branch diff. Sources that ARE populated pre-Build:
+  - the plan's own `file:line` citations and `packages/<pkg>/...` path mentions,
+  - the WI Subject/Details (already interpolated as text, but not turned into read-these-first pointers),
+  - `CONTEXT-MAP.md` + the package `CONTEXT.md` files for the packages the plan touches.
+- Constraints:
+  - Workflow scripts can't exec shell or `require`/`fs` (`review-plan.js:27`) — any plan parsing / git read is delegated to a haiku agent (pattern: `review-diff.js` `diffPrompt`).
+  - `adversaryPlanReviewPrompt` at `review-plan.js` interpolates `subject`/`details` only; no `base` arg.
+  - `CONTEXT-MAP.md` at repo root lists each package `CONTEXT.md`; 3 pkg `CONTEXT.md` exist today.
+
+## Phases
+
+### Phase 1 — prime the adversary with plan-referenced code pointers (fixes 1 + 3, corrected)
+
+File: `.claude/workflows/review-plan.js`
+
+- Add `base` arg: `(typeof _a === 'object' && _a.base) || 'origin/develop'` (used only by the standalone/re-plan diff branch below).
+- Add `PRIME_SCHEMA`: `{ pkgs: string[], files: string[], diff: string }`.
+- Add a single haiku `primePrompt` run ONCE before the parallel fan-out. It Reads `${planPath}` (relative to `${wt}`) and extracts:
+  - `files`: every repo-relative path cited in the plan (from `file:line` citations and `packages/...`/`src/...` mentions),
+  - `pkgs`: the distinct `packages/<pkg>` roots those paths fall under.
+  - It ALSO runs `git diff --name-only ${base}...HEAD` and `git diff ${base}...HEAD` from `${wt}` and returns the body as `diff` (empty in the auto-build-wi pre-Build case; populated for a standalone re-plan against a branch with code). If diff body > ~60k chars, return `diff: "<truncated — run git diff ${base}...HEAD>"`; union any diff file paths into `files`/`pkgs`.
+- In JS, from `pkgs` derive candidate `packages/<pkg>/CONTEXT.md` paths (dedupe, pure `map`/`filter`, no exec). This is the primary warm-pointer set — it works pre-Build because it comes from the plan text, not the diff.
+- Interpolate into `adversaryPlanReviewPrompt`:
+  - "Read these first, before any grep/find — start warm": `${wt}/CONTEXT-MAP.md` + the derived pkg `CONTEXT.md` paths + the plan-cited `files` list.
+  - the branch `diff` body when non-empty (labeled as the standalone-run case), else omit / note "no diff yet (pre-build plan stage) — the plan's cited files above are your map".
+  - directive: use the handed-in file list + CONTEXT pointers to jump straight to the cited code; do not `find`/`git show` to re-discover package layout or the files the plan already names.
+
+Commit: `perf(review-plan): prime plan-adversary with plan-referenced code pointers`
+
+### Phase 2 — cap redundant greps in plan-adversary (fix 2)
+
+File: `.claude/agents/plan-adversary.md`
+
+- Add `## Evidence budget` section:
+  - grep -rn once per concept across a package; never re-run an already-searched pattern.
+  - batch related patterns into one alternation (`grep -rnE 'a|b|c'`).
+  - start from the handed-in cited-file list + CONTEXT map; reserve grep/find for concepts the pointers don't cover. No `git show` / `find -maxdepth 2` to re-discover package layout.
+- Keep failure-mode checks unchanged (finding-quality invariant).
+
+Commit: `perf(plan-adversary): cap redundant evidence greps`
+
+## Skills to apply
+
+- concise — plan + agent md
+- typescript — workflow-script edits (`.js`)
+- verification — confirm materialized speedup
+
+## Verification
+
+Not e2e-covered: `.claude/` tooling, no Playwright surface.
+
+- `node --check .claude/workflows/review-plan.js` passes.
+- **Primary path (auto-build-wi pre-Build, empty diff)** — the scenario that owns the baseline. Rerun the adversary on a plan that cites several existing files across ≥1 package, with an empty branch diff. Confirm the prime agent extracts the cited files + pkgs, JS derives the right `CONTEXT.md` paths, and the adversary prompt hands them in. Compare adversary wall-clock + tokens vs 42m/121.8k — the drop must come from the plan-derived pointers (diff is empty), proving fixes 1+3 apply to the named scenario.
+- **Standalone re-plan path (branch has code)** — diff non-empty; confirm the diff body is inlined (or truncated) and its paths union into the pointer set.
+- Finding parity: same severities/citations as baseline (no quality regression).
+- Degenerate plan (no file citations, empty diff): prompt still hands `CONTEXT-MAP.md`; interpolation degrades gracefully (empty file-list/pkg-CONTEXT set).

--- a/.claude/workflows/review-plan.js
+++ b/.claude/workflows/review-plan.js
@@ -13,8 +13,6 @@ export const meta = {
 const _a = args || {}
 const planPath = typeof _a === 'string' ? _a.trim() : _a.planPath
 const wt = (typeof _a === 'object' && _a.wt) || '.'
-// used only by the prime agent's standalone/re-plan diff branch; empty in the auto-build-wi pre-Build case
-const base = (typeof _a === 'object' && _a.base) || 'origin/develop'
 const subject = (typeof _a === 'object' && _a.subject) || ''
 const details = (typeof _a === 'object' && _a.details) || ''
 const commitMessage = typeof _a === 'object' ? _a.commitMessage : undefined
@@ -108,16 +106,6 @@ const OK_SCHEMA = {
   properties: { ok: { type: 'boolean' }, detail: { type: ['string', 'null'] } },
 }
 
-const PRIME_SCHEMA = {
-  type: 'object',
-  required: ['pkgs', 'files', 'diff'],
-  properties: {
-    pkgs: { type: 'array', items: { type: 'string' } },
-    files: { type: 'array', items: { type: 'string' } },
-    diff: { type: 'string' },
-  },
-}
-
 // =====================================================================
 // PROMPTS
 // =====================================================================
@@ -153,30 +141,18 @@ ${details || '(empty)'}
 
 Return ONLY the structured result.`
 
-const primePrompt = `Read the plan at ${planPath} (relative to ${wt}) and extract the code it references, so a downstream reviewer can start warm.
-
-Do BOTH:
-1. Parse the plan text. Collect every repo-relative path it cites — from \`file:line\` citations and any \`packages/...\` / \`src/...\` mention. Put them in \`files\` (paths only, drop the :line suffix, dedupe). Derive \`pkgs\`: the distinct \`packages/<pkg>\` roots those paths fall under (e.g. \`packages/foo/src/x.ts\` → \`packages/foo\`).
-2. From ${wt}, run \`git diff --name-only ${base}...HEAD\` and \`git diff ${base}...HEAD\`. Return the full diff body as \`diff\`. Empty stdout → \`diff: ""\` (expected in the pre-build plan stage). If the diff body exceeds ~60000 chars, return \`diff: "<truncated — run git diff ${base}...HEAD>"\` instead of the body. Union any diff file paths into \`files\` and their package roots into \`pkgs\`.
-
-Return ONLY the structured result {pkgs, files, diff}.`
-
-const adversaryPlanReviewPrompt = (pointers, diff) => `Adversarially review the plan at ${planPath} (relative to ${wt}).
+const adversaryPlanReviewPrompt = `Adversarially review the plan at ${planPath} (relative to ${wt}).
 
 WI Subject: ${subject}
 WI Details:
 ${details || '(empty)'}
 
-Read these first, before any grep/find — start warm:
-${pointers}
+Start warm — before any grep/find:
+- Read ${wt}/CONTEXT-MAP.md.
+- The plan cites the code it discusses via \`file:line\` citations and \`packages/...\` / \`src/...\` mentions. Read those existing cited files, and the \`packages/<pkg>/CONTEXT.md\` for every package the plan cites, to jump straight to the code. (New files the plan proposes to create won't exist yet — skip those.)
 
-Use the handed-in file list + CONTEXT pointers to jump straight to the code the plan cites. Do NOT \`find\` / \`git show\` to re-discover package layout or the files the plan already names.
+Do NOT \`find\` / \`git show\` to re-discover package layout or the files the plan already names.
 
-${
-  diff
-    ? `Branch diff (standalone re-plan case — code already on the branch):\n${diff}\n`
-    : `No diff yet (pre-build plan stage) — the plan's cited files above are your map.\n`
-}
 ADR consistency check. Read the ADRs under ${wt}/docs/adr/ (repo-wide) plus any ${wt}/packages/*/docs/adr/ for packages the plan touches. A recorded ADR is binding by default (Status frontmatter is optional; an ADR without an explicit Proposed/Rejected/Deprecated/Superseded marker is Accepted). Then:
 - Flag (finding) any plan step that contradicts an ADR's decision, or re-proposes an alternative an ADR explicitly rejected/superseded. Cite the ADR file in 'evidence'.
 - Flag (finding) any decision the plan implies that WOULD warrant a new ADR — per ${wt}/.claude/skills/grill-me/ADR-FORMAT.md "When to offer" (all three gates: hard to reverse, surprising without context, real trade-off) — when the plan does not already sequence an ADR-writing step. Suggest sequencing the ADR first (see work-item-sequencing "ADRs sequence first").
@@ -221,28 +197,6 @@ if (!planReview.approved) {
   })
 }
 
-// Prime the adversary with the code the plan references (pre-build: no diff, so
-// the plan-cited files + package CONTEXT.md are the warm-start map).
-const prime = await agent(primePrompt, {
-  schema: PRIME_SCHEMA,
-  label: `prime-${label}`,
-  phase: 'Plan review',
-  model: 'haiku',
-})
-
-const primeFiles = ((prime && prime.files) || []).map(f => f.trim()).filter(Boolean)
-const primePkgs = ((prime && prime.pkgs) || []).map(p => p.trim()).filter(Boolean)
-const primeDiff = (prime && prime.diff) || ''
-const pkgContexts = [...new Set(primePkgs)].map(p => `${wt}/${p}/CONTEXT.md`)
-
-const pointers = [
-  `${wt}/CONTEXT-MAP.md`,
-  ...pkgContexts,
-  ...primeFiles.map(f => `${wt}/${f}`),
-]
-  .map(p => `- ${p}`)
-  .join('\n')
-
 const [effectPlanReview, e2ePlanReview, adversaryPlanReview] = await parallel([
   () =>
     agent(effectPlanReviewPrompt, {
@@ -259,7 +213,7 @@ const [effectPlanReview, e2ePlanReview, adversaryPlanReview] = await parallel([
       agentType: 'e2e-advocate',
     }),
   () =>
-    agent(adversaryPlanReviewPrompt(pointers, primeDiff), {
+    agent(adversaryPlanReviewPrompt, {
       schema: PLAN_ADVERSARY_SCHEMA,
       label: `adversary-plan-${label}`,
       phase: 'Plan review',

--- a/.claude/workflows/review-plan.js
+++ b/.claude/workflows/review-plan.js
@@ -13,6 +13,8 @@ export const meta = {
 const _a = args || {}
 const planPath = typeof _a === 'string' ? _a.trim() : _a.planPath
 const wt = (typeof _a === 'object' && _a.wt) || '.'
+// used only by the prime agent's standalone/re-plan diff branch; empty in the auto-build-wi pre-Build case
+const base = (typeof _a === 'object' && _a.base) || 'origin/develop'
 const subject = (typeof _a === 'object' && _a.subject) || ''
 const details = (typeof _a === 'object' && _a.details) || ''
 const commitMessage = typeof _a === 'object' ? _a.commitMessage : undefined
@@ -106,6 +108,16 @@ const OK_SCHEMA = {
   properties: { ok: { type: 'boolean' }, detail: { type: ['string', 'null'] } },
 }
 
+const PRIME_SCHEMA = {
+  type: 'object',
+  required: ['pkgs', 'files', 'diff'],
+  properties: {
+    pkgs: { type: 'array', items: { type: 'string' } },
+    files: { type: 'array', items: { type: 'string' } },
+    diff: { type: 'string' },
+  },
+}
+
 // =====================================================================
 // PROMPTS
 // =====================================================================
@@ -141,12 +153,30 @@ ${details || '(empty)'}
 
 Return ONLY the structured result.`
 
-const adversaryPlanReviewPrompt = `Adversarially review the plan at ${planPath} (relative to ${wt}).
+const primePrompt = `Read the plan at ${planPath} (relative to ${wt}) and extract the code it references, so a downstream reviewer can start warm.
+
+Do BOTH:
+1. Parse the plan text. Collect every repo-relative path it cites — from \`file:line\` citations and any \`packages/...\` / \`src/...\` mention. Put them in \`files\` (paths only, drop the :line suffix, dedupe). Derive \`pkgs\`: the distinct \`packages/<pkg>\` roots those paths fall under (e.g. \`packages/foo/src/x.ts\` → \`packages/foo\`).
+2. From ${wt}, run \`git diff --name-only ${base}...HEAD\` and \`git diff ${base}...HEAD\`. Return the full diff body as \`diff\`. Empty stdout → \`diff: ""\` (expected in the pre-build plan stage). If the diff body exceeds ~60000 chars, return \`diff: "<truncated — run git diff ${base}...HEAD>"\` instead of the body. Union any diff file paths into \`files\` and their package roots into \`pkgs\`.
+
+Return ONLY the structured result {pkgs, files, diff}.`
+
+const adversaryPlanReviewPrompt = (pointers, diff) => `Adversarially review the plan at ${planPath} (relative to ${wt}).
 
 WI Subject: ${subject}
 WI Details:
 ${details || '(empty)'}
 
+Read these first, before any grep/find — start warm:
+${pointers}
+
+Use the handed-in file list + CONTEXT pointers to jump straight to the code the plan cites. Do NOT \`find\` / \`git show\` to re-discover package layout or the files the plan already names.
+
+${
+  diff
+    ? `Branch diff (standalone re-plan case — code already on the branch):\n${diff}\n`
+    : `No diff yet (pre-build plan stage) — the plan's cited files above are your map.\n`
+}
 ADR consistency check. Read the ADRs under ${wt}/docs/adr/ (repo-wide) plus any ${wt}/packages/*/docs/adr/ for packages the plan touches. A recorded ADR is binding by default (Status frontmatter is optional; an ADR without an explicit Proposed/Rejected/Deprecated/Superseded marker is Accepted). Then:
 - Flag (finding) any plan step that contradicts an ADR's decision, or re-proposes an alternative an ADR explicitly rejected/superseded. Cite the ADR file in 'evidence'.
 - Flag (finding) any decision the plan implies that WOULD warrant a new ADR — per ${wt}/.claude/skills/grill-me/ADR-FORMAT.md "When to offer" (all three gates: hard to reverse, surprising without context, real trade-off) — when the plan does not already sequence an ADR-writing step. Suggest sequencing the ADR first (see work-item-sequencing "ADRs sequence first").
@@ -191,6 +221,28 @@ if (!planReview.approved) {
   })
 }
 
+// Prime the adversary with the code the plan references (pre-build: no diff, so
+// the plan-cited files + package CONTEXT.md are the warm-start map).
+const prime = await agent(primePrompt, {
+  schema: PRIME_SCHEMA,
+  label: `prime-${label}`,
+  phase: 'Plan review',
+  model: 'haiku',
+})
+
+const primeFiles = ((prime && prime.files) || []).map(f => f.trim()).filter(Boolean)
+const primePkgs = ((prime && prime.pkgs) || []).map(p => p.trim()).filter(Boolean)
+const primeDiff = (prime && prime.diff) || ''
+const pkgContexts = [...new Set(primePkgs)].map(p => `${wt}/${p}/CONTEXT.md`)
+
+const pointers = [
+  `${wt}/CONTEXT-MAP.md`,
+  ...pkgContexts,
+  ...primeFiles.map(f => `${wt}/${f}`),
+]
+  .map(p => `- ${p}`)
+  .join('\n')
+
 const [effectPlanReview, e2ePlanReview, adversaryPlanReview] = await parallel([
   () =>
     agent(effectPlanReviewPrompt, {
@@ -207,7 +259,7 @@ const [effectPlanReview, e2ePlanReview, adversaryPlanReview] = await parallel([
       agentType: 'e2e-advocate',
     }),
   () =>
-    agent(adversaryPlanReviewPrompt, {
+    agent(adversaryPlanReviewPrompt(pointers, primeDiff), {
       schema: PLAN_ADVERSARY_SCHEMA,
       label: `adversary-plan-${label}`,
       phase: 'Plan review',


### PR DESCRIPTION
## Summary
- Warm-start `plan-adversary` via a prompt directive in `adversaryPlanReviewPrompt` (`.claude/workflows/review-plan.js`) — Read `CONTEXT-MAP.md` + the plan's cited files/pkg `CONTEXT.md` before any grep/find, instead of cold-exploring the repo.
- Add an "Evidence budget" section to `.claude/agents/plan-adversary.md`: grep once per concept per package, batch patterns into one alternation, no repeat `git show`/`find -maxdepth 2` for layout already known from cited files/CONTEXT map.
- No separate prime agent or branch-diff plumbing — the pre-Build diff is always empty at adversary time, so that approach was dropped in favor of the prompt-directive fix (see commit history).

## Plan
.claude/plans/W-23355256.md

## Test plan
- Rerun `plan-adversary` on a plan citing several existing files across ≥1 package; confirm it Reads cited files + pkg `CONTEXT.md` up front (not cold grep/find), and compare wall-clock/tokens vs the W-20992510 baseline (42m18s / 121.8k tok).
- Confirm finding parity (same severities/citations) vs baseline — no quality regression.
- Confirm graceful degradation on a plan with no file citations (still directs `CONTEXT-MAP.md` read).

### What issues does this PR fix or reference?
@W-23355256@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eCHxtYAG/view