### PR TITLE
fix: remove dead getOrgApiVersion + FlagParameter exports from utils-vscode - W-23355254

### DIFF
--- a/.claude/plans/W-23355254.md
+++ b/.claude/plans/W-23355254.md
@@ -1,0 +1,42 @@
+# W-23355254 — remove dead getOrgApiVersion + FlagParameter exports
+
+## Context
+
+Dead exports in `packages/salesforcedx-utils-vscode/src/index.ts`:
+
+- `getOrgApiVersion` (`util/authInfo.ts:91`) — 0 in-repo callers. Last external caller (apex-oas `apexActionController.ts`) removed in a6b850738 (#7351).
+- `FlagParameter<T>` type (`commands/parameterGatherers.ts:8`) — 0 in-repo uses beyond own def + index re-export. External ui-preview hit was its own vendored copy.
+
+gh code search confirms no external consumer (ci-testing mirror + unrelated same-name symbols excluded).
+
+Cascade: removing `getOrgApiVersion` orphans local helpers `getConnection` (sole caller `authInfo.ts:93`) + `getUsername` (sole caller line 79) + `@salesforce/core` imports `AuthInfo`, `Connection`, `StateAggregator` (line 7). All must go to avoid no-unused-vars.
+
+No test refs to either symbol.
+
+## Phases
+
+### Phase 1 — remove both dead exports + orphaned helpers
+
+- `index.ts`: drop `getOrgApiVersion` from `./util/authInfo` export (line 37); drop `type FlagParameter` from `./commands/parameterGatherers` export block (lines 11-15 → keep `CompositeParametersGatherer`, `EmptyParametersGatherer`).
+- `authInfo.ts`: delete `getOrgApiVersion` fn (85-109), orphaned `getConnection` (74-83), `getUsername` (69-72), and `@salesforce/core` import line 7. Keep `getTargetOrgOrAlias`, `getTargetDevHubOrAlias`, `displayMessage`, enum.
+- `parameterGatherers.ts`: delete `FlagParameter<T>` type (8-10).
+
+commit: `fix: remove dead getOrgApiVersion + FlagParameter exports from utils-vscode - W-23355254`
+
+files:
+- `packages/salesforcedx-utils-vscode/src/index.ts`
+- `packages/salesforcedx-utils-vscode/src/util/authInfo.ts`
+- `packages/salesforcedx-utils-vscode/src/commands/parameterGatherers.ts`
+
+## Skills
+
+- concise — plan/doc style
+- typescript — verify no-unused-vars after import prune
+- external-consumers — confirmed via gh search (done)
+
+## Verification
+
+- `grep -rn "getOrgApiVersion\|FlagParameter" packages/ --include="*.ts"` → 0 hits
+- lint/typecheck salesforcedx-utils-vscode (no orphaned imports/vars)
+- build salesforcedx-utils-vscode
+- not e2e-covered — pure dead-code removal, no runtime behavior

--- a/packages/salesforcedx-utils-vscode/src/commands/parameterGatherers.ts
+++ b/packages/salesforcedx-utils-vscode/src/commands/parameterGatherers.ts
@@ -5,10 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export type FlagParameter<T> = {
-  flag?: T;
-};
-
 export type ContinueResponse<T> = {
   type: 'CONTINUE';
   data: T;

--- a/packages/salesforcedx-utils-vscode/src/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/index.ts
@@ -8,11 +8,7 @@
 export { ChannelService } from './commands/channelService';
 export { notificationService } from './commands/notificationService';
 export { ProgressNotification } from './commands/progressNotification';
-export {
-  CompositeParametersGatherer,
-  EmptyParametersGatherer,
-  type FlagParameter
-} from './commands/parameterGatherers';
+export { CompositeParametersGatherer, EmptyParametersGatherer } from './commands/parameterGatherers';
 export { SfCommandletExecutor, LibraryCommandletExecutor } from './commands/commandletExecutors';
 export { SfCommandlet } from './commands/sfCommandlet';
 export { ConfigUtil } from './config/configUtil';
@@ -34,7 +30,7 @@ export { fileExtensionsMatch, projectPaths } from './helpers/paths';
 export { errorToString } from './helpers/errorUtils';
 export { updateUserIDOnTelemetryReporters as refreshAllExtensionReporters } from './helpers/telemetryUtils';
 export type { SharedAuthState } from './helpers/authUtils';
-export { getTargetOrgOrAlias, getTargetDevHubOrAlias, getOrgApiVersion } from './util/authInfo';
+export { getTargetOrgOrAlias, getTargetDevHubOrAlias } from './util/authInfo';
 export { hasRootWorkspace, workspaceUtils } from './workspaces/workspaceUtils';
 export { CliCommandExecutor } from './cli/commandExecutor';
 

--- a/packages/salesforcedx-utils-vscode/src/util/authInfo.ts
+++ b/packages/salesforcedx-utils-vscode/src/util/authInfo.ts
@@ -4,7 +4,6 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { AuthInfo, Connection, StateAggregator } from '@salesforce/core';
 import * as vscode from 'vscode';
 import { notificationService } from '../commands/notificationService';
 import { ConfigSource, ConfigUtil } from '../config/configUtil';
@@ -62,48 +61,6 @@ export const getTargetDevHubOrAlias = async (
     if (err instanceof Error) {
       telemetryService.sendException('get_target_dev_hub_alias', err.message);
     }
-    return undefined;
-  }
-};
-
-const getUsername = async (usernameOrAlias: string): Promise<string> => {
-  const info = await StateAggregator.getInstance();
-  return info.aliases.getUsername(usernameOrAlias) ?? usernameOrAlias;
-};
-
-const getConnection = async (usernameOrAlias?: string): Promise<Connection> => {
-  const resolved = usernameOrAlias ?? (await getTargetOrgOrAlias(true));
-  if (!resolved) {
-    throw new Error(nls.localize('error_no_target_org'));
-  }
-  const username = await getUsername(resolved);
-  return await Connection.create({
-    authInfo: await AuthInfo.create({ username })
-  });
-};
-
-/**
- * Gets the org API version as a numeric value.
- * Uses instanceApiVersion (max supported API version) from auth fields if available,
- * otherwise falls back to the connection's configured API version.
- * @returns The org API version as a number, or undefined if unable to retrieve.
- */
-export const getOrgApiVersion = async (): Promise<number | undefined> => {
-  try {
-    const connection = await getConnection();
-    const authFields = connection.getAuthInfoFields();
-
-    // Prefer instanceApiVersion (max supported API version) if available
-    const instanceApiVersion = authFields.instanceApiVersion;
-    if (instanceApiVersion) {
-      return parseFloat(instanceApiVersion);
-    }
-
-    // Fallback to the connection's configured API version
-    const apiVersion = connection.getApiVersion();
-    return apiVersion ? parseFloat(apiVersion) : undefined;
-  } catch (err) {
-    console.error('Failed to retrieve org version:', err);
     return undefined;
   }
 };


### PR DESCRIPTION
## Summary
- Remove dead `getOrgApiVersion` export from `authInfo.ts` (0 in-repo callers; last external caller removed in #7351) and its now-orphaned helpers `getConnection`/`getUsername` plus unused `@salesforce/core` imports.
- Remove dead `FlagParameter<T>` type export from `parameterGatherers.ts` (0 in-repo uses beyond its own definition/re-export).
- Drop both from `packages/salesforcedx-utils-vscode/src/index.ts`.

## Plan
.claude/plans/W-23355254.md

### What issues does this PR fix or reference?
@W-23355254@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eBiQkYAK/view