### PR TITLE
perf(apex-log): shrink bundle via esbuild ESM resolution of effect - W-23313203

### DIFF
--- a/.claude/plans/W-23313203.md
+++ b/.claude/plans/W-23313203.md
@@ -31,7 +31,7 @@
 
 ## Verification
 
-Swapping effect's cjs->esm resolution is a runtime module-resolution change, not just a byte-count change (ADR 0021: baking the override "silently alters resolution for all... node consumers"). Sibling org-browser PR (989283d10, W-23293744) made re-running both existing Playwright suites the explicit acceptance criterion for the identical override. apex-log ships real Playwright desktop+web specs that exercise the exact effect submodules being re-resolved — run them, no new test authoring.
+Effect ESM swap = runtime resolution change, not just byte-count (ADR 0021: override alters resolution for all node consumers). Sibling org-browser PR (989283d10, W-23293744) set re-running both Playwright suites as acceptance criterion for identical override. apex-log has real desktop+web specs exercising the re-resolved effect submodules — run them, no new tests.
 
 ### Build/bundle (non-e2e)
 
@@ -43,7 +43,7 @@ Swapping effect's cjs->esm resolution is a runtime module-resolution change, not
 
 ### e2e (required before PR)
 
-Existing specs exercise `effect/Schema` (src/schemas/traceFlagsSchema.ts:9), `effect/Schedule` + `effect/Stream` (src/traceFlagCleanupScheduler.ts:11-12, drives autoCollection), plus `effect/Effect` + `ExtensionProviderService` runtime paths (src/logs/logAutoCollect.ts, src/statusBar/traceFlagStatusBar.ts, src/commands/executeAnonymous.ts). A broken ESM entry surfaces at activation/runtime, which build-size measurement cannot catch.
+Specs exercise `effect/Schema` (src/schemas/traceFlagsSchema.ts:9), `effect/Schedule` + `effect/Stream` (src/traceFlagCleanupScheduler.ts:11-12, drives autoCollection), `effect/Effect` + `ExtensionProviderService` runtime paths (src/logs/logAutoCollect.ts, src/statusBar/traceFlagStatusBar.ts, src/commands/executeAnonymous.ts). Broken ESM entry only surfaces at activation/runtime — build-size checks miss it.
 
 - `npm run test:desktop -w salesforcedx-vscode-apex-log` — required. Covers Schema/Schedule/Stream/Effect runtime paths via traceFlagsCrud, traceFlagExpiry, traceFlagsForOtherUser, autoCollection, logRetrieval, executeAnonymous headless specs. [e2e]
 - `npm run test:web -w salesforcedx-vscode-apex-log` — required. Matches sibling W-23293744 acceptance criterion (both suites). Note: browser build is unchanged by this plan, but run per the established acceptance pattern to confirm no regression. [e2e]

--- a/.claude/plans/W-23313203.md
+++ b/.claude/plans/W-23313203.md
@@ -1,0 +1,50 @@
+# W-23313203 — Shrink apex-log bundle via esbuild ESM resolution of effect
+
+## Context
+
+- Apply effect ESM conditions override to `salesforcedx-vscode-apex-log` node (desktop) esbuild build only.
+- Pattern from W-23293744 / W-23313202 (apex-debugger, #7692).
+- Shared infra already on develop: `scripts/bundling/effect.mjs` (`effectEsmConditions`), `docs/adr/0021-effect-esm-condition-override-scope.md`, `dist/*-metafile.json` exclusion in apex-log `.vscodeignore`. Do NOT recreate.
+- apex-log deps `effect` (package.json:33); already writes `dist/node-metafile.json`.
+- Target: `packages/salesforcedx-vscode-apex-log/esbuild.config.mjs` `nodeBuild` config only. Browser build unchanged (keeps `effectSecretScannerWorkaroundPlugin`).
+- `effectEsmConditions = { conditions: ['import','module','default'] }`; output stays CJS (from `nodeConfig`).
+
+## Phases
+
+### Phase 1 — resolve effect ESM in apex-log node build
+
+- Import `effectEsmConditions` from `../../scripts/bundling/effect.mjs`.
+- Spread `...effectEsmConditions` into `nodeBuild` build config (after `...nodeConfig`).
+- Build; capture before/after `dist/index.js` bytes + % via `dist/node-metafile.json`.
+- If vsce secret-scanner pattern now hits node output, add `effectSecretScannerWorkaroundPlugin` to node `plugins` (browser already has it). Otherwise leave node plugins as-is.
+- commit: `perf(apex-log): resolve effect ESM to shrink bundle - W-23313203`
+- files: `packages/salesforcedx-vscode-apex-log/esbuild.config.mjs`
+
+## Skills
+
+- concise — plan + any md
+- typescript — esbuild.config.mjs is TS-adjacent build tooling
+- wireit — build via package script
+- pr-draft — PR body w/ before/after node dist size + % (match W-23293744 format)
+- packageJson — if touching package.json (not expected)
+- playwright-e2e — running existing apex-log test:desktop + test:web suites
+
+## Verification
+
+Swapping effect's cjs->esm resolution is a runtime module-resolution change, not just a byte-count change (ADR 0021: baking the override "silently alters resolution for all... node consumers"). Sibling org-browser PR (989283d10, W-23293744) made re-running both existing Playwright suites the explicit acceptance criterion for the identical override. apex-log ships real Playwright desktop+web specs that exercise the exact effect submodules being re-resolved — run them, no new test authoring.
+
+### Build/bundle (non-e2e)
+
+- `npm run build` (or bundle script) in apex-log; passes. [non-e2e]
+- Before/after `dist/index.js` byte size + % reduction from `dist/node-metafile.json` — record for PR. [non-e2e]
+- Confirm effect resolves `dist/esm/*` not `dist/cjs/*` in metafile. [non-e2e]
+- Output format still CJS (grep bundle / metafile). [non-e2e]
+- `npx vsce package` (or CI VSIX step) succeeds — no Sendgrid secret-scanner false positive on node output. [non-e2e]
+
+### e2e (required before PR)
+
+Existing specs exercise `effect/Schema` (src/schemas/traceFlagsSchema.ts:9), `effect/Schedule` + `effect/Stream` (src/traceFlagCleanupScheduler.ts:11-12, drives autoCollection), plus `effect/Effect` + `ExtensionProviderService` runtime paths (src/logs/logAutoCollect.ts, src/statusBar/traceFlagStatusBar.ts, src/commands/executeAnonymous.ts). A broken ESM entry surfaces at activation/runtime, which build-size measurement cannot catch.
+
+- `npm run test:desktop -w salesforcedx-vscode-apex-log` — required. Covers Schema/Schedule/Stream/Effect runtime paths via traceFlagsCrud, traceFlagExpiry, traceFlagsForOtherUser, autoCollection, logRetrieval, executeAnonymous headless specs. [e2e]
+- `npm run test:web -w salesforcedx-vscode-apex-log` — required. Matches sibling W-23293744 acceptance criterion (both suites). Note: browser build is unchanged by this plan, but run per the established acceptance pattern to confirm no regression. [e2e]
+- Both suites must pass before opening the PR. No new specs to author.

--- a/packages/salesforcedx-vscode-apex-log/esbuild.config.mjs
+++ b/packages/salesforcedx-vscode-apex-log/esbuild.config.mjs
@@ -6,6 +6,7 @@
  */
 import { build } from 'esbuild';
 import { nodeConfig } from '../../scripts/bundling/node.mjs';
+import { effectEsmConditions } from '../../scripts/bundling/effect.mjs';
 import { commonConfigBrowser } from '../../scripts/bundling/web.mjs';
 import { writeFile } from 'fs/promises';
 import fs from 'node:fs';
@@ -27,6 +28,7 @@ const effectSecretScannerWorkaroundPlugin = () => ({
 
 const nodeBuild = await build({
   ...nodeConfig,
+  ...effectEsmConditions,
   entryPoints: ['./out/src/index.js'],
   outdir: './dist',
   plugins: [...(nodeConfig.plugins ?? [])],

--- a/packages/salesforcedx-vscode-apex-log/package.json
+++ b/packages/salesforcedx-vscode-apex-log/package.json
@@ -101,6 +101,7 @@
         "esbuild.config.mjs",
         "../../scripts/bundling/node.mjs",
         "../../scripts/bundling/web.mjs",
+        "../../scripts/bundling/effect.mjs",
         "out/**"
       ],
       "output": [
@@ -118,6 +119,7 @@
         "esbuild.config.mjs",
         "../../scripts/bundling/node.mjs",
         "../../scripts/bundling/web.mjs",
+        "../../scripts/bundling/effect.mjs",
         "out/**"
       ],
       "output": [


### PR DESCRIPTION
## Summary
- Applies the node-build-only effect ESM conditions override (from W-23293744/W-23313202) to `salesforcedx-vscode-apex-log`'s `esbuild.config.mjs`, so esbuild resolves `effect`'s ESM build for the desktop bundle.
- Node `dist/index.js`: 1,481,368B -> 750,092B (-49.4%). Output stays CJS; effect now resolves `dist/esm/*` instead of `dist/cjs/*`.
- Browser build is intentionally unchanged (see Reviewer notes).

## Plan
[.claude/plans/W-23313203.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23313203-3-shrink-apex-log-bundle-via-esbuild-esm/.claude/plans/W-23313203.md)

## Reviewer notes
- `esbuild.config.mjs` applies `effectEsmConditions` only to the node build; the browser build (~1.45MB, largest apex-log artifact) still resolves effect via CJS. This is a deliberate scope decision recorded in the plan (unvalidated for browser + coupled to `effectSecretScannerWorkaroundPlugin`'s effect-internal file-path filter), not an oversight. Sibling `org-browser` PR applied the override to both node and browser builds; a follow-up WI could do the same here if validated.

### What issues does this PR fix or reference?
@W-23313203@

### Functionality Before
apex-log's desktop bundle resolved `effect`'s CJS build.

### Functionality After
apex-log's desktop bundle resolves `effect`'s ESM build (via shared `effectEsmConditions`), letting esbuild tree-shake unused submodules; `dist/index.js` shrinks ~49.4%.

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002dxxOgYAI/view