### PR TITLE
ci: change closePendingReleaseIssues.yml to grab issues from the changelog instead of checking the "pending release" tag - W-23236874

### DIFF
--- a/.github/workflows/closePendingReleaseIssues.yml
+++ b/.github/workflows/closePendingReleaseIssues.yml
@@ -31,35 +31,92 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Close issues labeled "pending release"
+      - name: Parse issues and discussions from changelog
+        id: parse
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # Extract the changelog section for this version (between its heading and the next one)
+          CHANGELOG_SECTION=$(awk "
+            /^# ${VERSION}/{found=1; next}
+            found && /^# [0-9]/{exit}
+            found{print}
+          " packages/salesforcedx-vscode/CHANGELOG.md)
+
+          if [[ -z "$CHANGELOG_SECTION" ]]; then
+            echo "::warning::No changelog section found for version ${VERSION}"
+          fi
+
+          ISSUE_NUMBERS=$(echo "$CHANGELOG_SECTION" | grep -oP 'issues/\K[0-9]+' | sort -u | tr '\n' ' ')
+          DISCUSSION_NUMBERS=$(echo "$CHANGELOG_SECTION" | grep -oP 'discussions/\K[0-9]+' | sort -u | tr '\n' ' ')
+
+          echo "Issues referenced in changelog: ${ISSUE_NUMBERS:-none}"
+          echo "Discussions referenced in changelog: ${DISCUSSION_NUMBERS:-none}"
+
+          echo "issues=${ISSUE_NUMBERS}" >> "$GITHUB_OUTPUT"
+          echo "discussions=${DISCUSSION_NUMBERS}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on and close issues from changelog
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
+          ISSUE_NUMBERS: ${{ steps.parse.outputs.issues }}
         run: |
-          ISSUES=$(gh issue list --label "pending release" --state open --json number --jq '.[].number' --limit 500)
-          echo "Found $(echo $ISSUES | wc -w | tr -d ' ') issue(s) to close."
-          for ISSUE in $ISSUES; do
-            gh issue comment "$ISSUE" --body "Released in v${VERSION} of the Salesforce Extensions for VSCode." || echo "::warning::Failed to comment on issue #$ISSUE"
-            gh issue close "$ISSUE" || echo "::warning::Failed to close issue #$ISSUE"
+          for ISSUE in $ISSUE_NUMBERS; do
+            STATE=$(gh issue view "$ISSUE" --json state --jq '.state' 2>/dev/null || echo "NOT_FOUND")
+            if [[ "$STATE" == "NOT_FOUND" ]]; then
+              echo "::warning::Issue #$ISSUE not found, skipping"
+              continue
+            fi
+            gh issue comment "$ISSUE" --body "Released in v${VERSION} of the Salesforce Extensions for VSCode." \
+              || echo "::warning::Failed to comment on issue #$ISSUE"
+            if [[ "$STATE" == "OPEN" ]]; then
+              gh issue close "$ISSUE" \
+                && echo "✓ Closed issue #${ISSUE}" \
+                || echo "::warning::Failed to close issue #$ISSUE"
+            else
+              echo "Issue #${ISSUE} is already ${STATE} — comment posted, skipping close"
+            fi
           done
 
-      - name: Close discussions labeled "pending release"
+      - name: Comment on and close discussions from changelog
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
+          DISCUSSION_NUMBERS: ${{ steps.parse.outputs.discussions }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
         run: |
-          DISCUSSIONS=$(gh discussion list --label "pending release" --state open --json number,id,title --limit 500)
-          echo "Found $(echo "$DISCUSSIONS" | jq '.discussions | length') discussion(s) to close."
-          echo "$DISCUSSIONS" | jq -c '.discussions[]' | while read -r D; do
-            NUMBER=$(echo "$D" | jq -r '.number')
-            ID=$(echo "$D" | jq -r '.id')
-            TITLE=$(echo "$D" | jq -r '.title')
-            gh discussion comment "$NUMBER" --body "Released in v${VERSION} of the Salesforce Extensions for VSCode." \
-              || echo "::warning::Failed to comment on discussion #$NUMBER"
-            gh api graphql -f query='
-              mutation($id: ID!) {
-                closeDiscussion(input: {discussionId: $id}) { discussion { id } }
-              }' -f id="$ID" > /dev/null \
-              && echo "✓ Closed discussion ${GITHUB_REPOSITORY}#${NUMBER} (${TITLE})" \
-              || echo "::warning::Failed to close discussion #$NUMBER"
+          for DISC_NUM in $DISCUSSION_NUMBERS; do
+            DISC_DATA=$(gh api graphql -f query='
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  discussion(number: $number) {
+                    id
+                    closed
+                  }
+                }
+              }' -f owner="$REPO_OWNER" -f repo="$REPO_NAME" -F number="$DISC_NUM" 2>/dev/null || echo '{}')
+
+            DISC_ID=$(echo "$DISC_DATA" | jq -r '.data.repository.discussion.id // empty')
+            DISC_CLOSED=$(echo "$DISC_DATA" | jq -r '.data.repository.discussion.closed // "true"')
+
+            if [[ -z "$DISC_ID" ]]; then
+              echo "::warning::Discussion #$DISC_NUM not found or inaccessible, skipping"
+              continue
+            fi
+
+            gh discussion comment "$DISC_NUM" --body "Released in v${VERSION} of the Salesforce Extensions for VSCode." \
+              || echo "::warning::Failed to comment on discussion #$DISC_NUM"
+
+            if [[ "$DISC_CLOSED" == "false" ]]; then
+              gh api graphql -f query='
+                mutation($id: ID!) {
+                  closeDiscussion(input: {discussionId: $id}) { discussion { id } }
+                }' -f id="$DISC_ID" > /dev/null \
+                && echo "✓ Closed discussion #${DISC_NUM}" \
+                || echo "::warning::Failed to close discussion #$DISC_NUM"
+            else
+              echo "Discussion #${DISC_NUM} is already closed — comment posted, skipping close"
+            fi
           done

--- a/contributing/publishing.md
+++ b/contributing/publishing.md
@@ -106,7 +106,7 @@ Full details on the CBW release lifecycle, CDN caching, and rollback procedures 
 
 ## Closing Shipped GitHub Issues
 
-Issues and discussions labeled `pending release` are automatically closed after successful publish to MS Marketplace. The `closePendingReleaseIssues.yml` workflow posts a comment with the release version and closes both. Trigger manually via **Close Pending Release Issues** workflow if needed.
+After successful publish to MS Marketplace, the `closePendingReleaseIssues.yml` workflow automatically closes issues and discussions referenced in `CHANGELOG.md`. It parses the changelog for the current release version, extracts issue and discussion numbers, posts a comment with the release version, and closes any still-open items (leaving already-closed ones with the comment only). Trigger manually via **Close Pending Release Issues** workflow if needed.
 
 After a release, run the [`/shipped-issues`](../.claude/skills/shipped-issues/SKILL.md) Claude skill to close open GitHub issues whose linked GUS work items are closed and whose issue numbers appear in the published `CHANGELOG.md`.
 


### PR DESCRIPTION
### What does this PR do?
Some of our Github Issue/PR pairs are setup such that the issue is automatically closed as soon as the PR is merged.  The old implementation of the **closePendingReleaseIssues.yml** GHA workflow checks for _open issues_ with the "pending release" tag mentioned in the changelog and closes them with the comment `Released in v${VERSION} of the Salesforce Extensions for VSCode.` That implementation causes issues closed automatically by PRs to be skipped, so the release comment is not posted.

This PR changes the workflow to gather issues to close and comment **fully based on the changelog**.  It parses the changelog to get a list of issues handled by the latest release, regardless of whether the issue is tagged with "pending release".  It then comments `Released in v${VERSION} of the Salesforce Extensions for VSCode.` on **all the issues in that list** and closes the ones that are still open.

By making this change, all issues released in the current week receive the `Released in v${VERSION} of the Salesforce Extensions for VSCode.` regardless of whether they were closed immediately upon PR merge or left open to be closed upon release.

Successful workflow run: https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/28955827915/job/85914386020
Already closed issue commented by the workflow: https://github.com/forcedotcom/salesforcedx-vscode/issues/7632

### What issues does this PR fix or reference?
@W-23236874@