### PR TITLE
refactor(apex-testing): model discovery types as Option, drop empty-string sentinels - W-23173047

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44887,7 +44887,6 @@
         "@salesforce/core": "^8.32.2",
         "@salesforce/playwright-vscode-ext": "*",
         "salesforcedx-vscode-apex": "*",
-        "salesforcedx-vscode-core": "*",
         "salesforcedx-vscode-metadata": "*",
         "salesforcedx-vscode-services": "*"
       },

--- a/packages/salesforcedx-vscode-apex-testing/src/commands/apexTestRun.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/commands/apexTestRun.ts
@@ -46,7 +46,7 @@ const selectTests = Effect.fn('apexTestRun.selectTests')(function* () {
               .map(
                 (cls): ApexTestQuickPickItem => ({
                   label: cls.name,
-                  description: Option.getOrElse(cls.namespacePrefix, () => ''),
+                  description: Option.getOrUndefined(cls.namespacePrefix),
                   type: 'Class' as const,
                   fullClassName: getFullClassName(cls)
                 })

--- a/packages/salesforcedx-vscode-apex-testing/src/commands/apexTestRun.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/commands/apexTestRun.ts
@@ -8,6 +8,7 @@
 import { AsyncTestConfiguration, TestLevel, TestService } from '@salesforce/apex-node';
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import * as Effect from 'effect/Effect';
+import * as Option from 'effect/Option';
 import { window } from 'vscode';
 import { nls } from '../messages';
 import * as settings from '../settings';
@@ -45,7 +46,7 @@ const selectTests = Effect.fn('apexTestRun.selectTests')(function* () {
               .map(
                 (cls): ApexTestQuickPickItem => ({
                   label: cls.name,
-                  description: cls.namespacePrefix ?? '',
+                  description: Option.getOrElse(cls.namespacePrefix, () => ''),
                   type: 'Class' as const,
                   fullClassName: getFullClassName(cls)
                 })

--- a/packages/salesforcedx-vscode-apex-testing/src/commands/apexTestSuite.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/commands/apexTestSuite.ts
@@ -28,7 +28,7 @@ const listApexClassItems = Effect.fn('apexTestSuite.listApexClassItems')(functio
     .map(
       (cls): ApexTestQuickPickItem => ({
         label: cls.name,
-        description: Option.getOrElse(cls.namespacePrefix, () => ''),
+        description: Option.getOrUndefined(cls.namespacePrefix),
         type: 'Class',
         fullClassName: getFullClassName(cls)
       })

--- a/packages/salesforcedx-vscode-apex-testing/src/commands/apexTestSuite.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/commands/apexTestSuite.ts
@@ -8,6 +8,7 @@
 import { TestService } from '@salesforce/apex-node';
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import * as Effect from 'effect/Effect';
+import * as Option from 'effect/Option';
 import * as vscode from 'vscode';
 import { nls } from '../messages';
 import { MessageKey } from '../messages/i18n';
@@ -27,7 +28,7 @@ const listApexClassItems = Effect.fn('apexTestSuite.listApexClassItems')(functio
     .map(
       (cls): ApexTestQuickPickItem => ({
         label: cls.name,
-        description: cls.namespacePrefix ?? '',
+        description: Option.getOrElse(cls.namespacePrefix, () => ''),
         type: 'Class',
         fullClassName: getFullClassName(cls)
       })

--- a/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/packageResolution.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/packageResolution.ts
@@ -8,6 +8,7 @@
 import type { Package2MemberRecord, ResolvedPackageInfo } from './schemas';
 import type { Connection } from '@salesforce/core';
 import type { InstalledSubscriberPackage, Package2 } from '@salesforce/types/tooling';
+import * as Option from 'effect/Option';
 
 const PACKAGE2_MEMBER_BATCH_SIZE = 200;
 
@@ -82,7 +83,7 @@ const getComponentId = (m: Package2MemberRecord): string | undefined => m.Metada
  */
 const resolveFromInstalledSubscriberPackages = async (
   connection: Connection,
-  classIdToNamespace: Map<string, string>
+  classIdToNamespace: Map<string, Option.Option<string>>
 ): Promise<Map<string, ResolvedPackageInfo>> => {
   const result = new Map<string, ResolvedPackageInfo>();
   if (classIdToNamespace.size === 0) {
@@ -106,9 +107,8 @@ const resolveFromInstalledSubscriberPackages = async (
     }
     const noNsClassIdsAssigned: string[] = [];
     for (const [classId, namespacePrefix] of classIdToNamespace) {
-      const ns = (namespacePrefix ?? '').trim();
-      if (ns !== '') {
-        const pkg = byNamespace.get(ns);
+      if (Option.isSome(namespacePrefix)) {
+        const pkg = byNamespace.get(namespacePrefix.value);
         if (pkg?.SubscriberPackage?.Name != null && pkg.SubscriberPackageId) {
           result.set(classId, {
             package2Id: pkg.SubscriberPackageId,
@@ -209,7 +209,7 @@ const getUnpackagedApexClassIds = async (connection: Connection, classIds: strin
 export const resolvePackage2Members = async (
   connection: Connection,
   apexClassIds: string[],
-  classIdToNamespace?: Map<string, string>,
+  classIdToNamespace?: Map<string, Option.Option<string>>,
   orgInfo?: PackageResolutionOrgInfo
 ): Promise<Map<string, ResolvedPackageInfo>> => {
   const validIds = apexClassIds.filter(id => typeof id === 'string' && id.length > 0);

--- a/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/schemas.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/schemas.ts
@@ -68,8 +68,7 @@ export type DiscoverTestsOptions = {
   namespacePrefix?: string;
 };
 
-// Package resolution: use WSDL-generated types from @salesforce/types (forcedotcom/wsdl)
-/** Package2Member query result; wsdl type omits MetadataComponentId and Package2Id for some API versions. */
+/** Package2Member (WSDL-generated, @salesforce/types); wsdl type omits MetadataComponentId and Package2Id for some API versions. */
 export type Package2MemberRecord = Package2Member & {
   MetadataComponentId?: string;
   Package2Id?: string;

--- a/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/schemas.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/schemas.ts
@@ -41,7 +41,7 @@ export const ToolingTestClass = Schema.Struct({
 export type ToolingTestClass = Schema.Schema.Type<typeof ToolingTestClass>;
 
 /** Raw Tooling REST shape (pre-decode): `id`/`namespacePrefix` are plain strings, possibly `""`. */
-export type ToolingTestClassWire = Schema.Schema.Encoded<typeof ToolingTestClass>;
+type ToolingTestClassWire = Schema.Schema.Encoded<typeof ToolingTestClass>;
 
 export type TestDiscoveryResult = {
   classes: ToolingTestClass[];

--- a/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/schemas.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/schemas.ts
@@ -7,7 +7,6 @@
 /* eslint-disable jsdoc/check-indentation */
 
 import type { Package2Member } from '@salesforce/types/tooling';
-import * as Option from 'effect/Option';
 import * as Schema from 'effect/Schema';
 
 const ToolingTestMethod = Schema.Struct({
@@ -17,25 +16,14 @@ const ToolingTestMethod = Schema.Struct({
 });
 
 /**
- * Wire `""` sentinel ⇄ domain `Option<string>`: decode `""` (or whitespace-only) → `Option.none()`, any
- * other string → `Option.some(s)`; encode back to the raw string (`none` → `""`). Lives at the parse
- * boundary so the domain type never carries an empty-string "missing" sentinel. Trimming keeps a
- * whitespace-only prefix collapsing to the default/local namespace, matching the prior `.trim()` guards.
- */
-const OptionFromEmptyString = Schema.transform(Schema.String, Schema.OptionFromSelf(Schema.String), {
-  strict: true,
-  decode: s => (s.trim() === '' ? Option.none() : Option.some(s)),
-  encode: Option.getOrElse(() => '')
-});
-
-/**
- * Normalized domain test class. `id` absent (some flow tests) = `Option.none`; `namespacePrefix` none =
- * default Apex namespace, `Option.some('FlowTesting[.Namespace]')` = flow test.
+ * Normalized domain test class. `OptionFromNonEmptyTrimmedString` maps the wire `""` sentinel ⇄
+ * `Option<string>` at the parse boundary. `id` absent (some flow tests) = `Option.none`; `namespacePrefix`
+ * none = default Apex namespace, `Option.some('FlowTesting[.Namespace]')` = flow test.
  */
 export const ToolingTestClass = Schema.Struct({
-  id: OptionFromEmptyString,
+  id: Schema.OptionFromNonEmptyTrimmedString,
   name: Schema.String,
-  namespacePrefix: OptionFromEmptyString,
+  namespacePrefix: Schema.OptionFromNonEmptyTrimmedString,
   testMethods: Schema.Array(ToolingTestMethod)
 });
 export type ToolingTestClass = Schema.Schema.Type<typeof ToolingTestClass>;

--- a/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/schemas.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/schemas.ts
@@ -6,20 +6,40 @@
  */
 /* eslint-disable jsdoc/check-indentation */
 
-type ToolingTestMethod = {
-  name: string;
-  line?: number;
-  column?: number;
-};
+import * as Option from 'effect/Option';
+import * as Schema from 'effect/Schema';
 
-// Single authoritative shape for test classes (matches Tooling REST response)
-export type ToolingTestClass = {
-  id: string; // may be "" for some flow tests
-  name: string;
-  // For Apex tests this is "" (default) or a namespace; for flow tests it follows "FlowTesting[.Namespace]"
-  namespacePrefix: string;
-  testMethods: ToolingTestMethod[];
-};
+const ToolingTestMethod = Schema.Struct({
+  name: Schema.String,
+  line: Schema.optional(Schema.Number),
+  column: Schema.optional(Schema.Number)
+});
+
+/**
+ * Wire `""` sentinel ⇄ domain `Option<string>`: decode `""` → `Option.none()`, any other string →
+ * `Option.some(s)`; encode back to the raw string (`none` → `""`). Lives at the parse boundary so the
+ * domain type never carries an empty-string "missing" sentinel.
+ */
+const OptionFromEmptyString = Schema.transform(Schema.String, Schema.OptionFromSelf(Schema.String), {
+  strict: true,
+  decode: s => (s === '' ? Option.none() : Option.some(s)),
+  encode: Option.getOrElse(() => '')
+});
+
+/**
+ * Normalized domain test class. `id` absent (some flow tests) = `Option.none`; `namespacePrefix` none =
+ * default Apex namespace, `Option.some('FlowTesting[.Namespace]')` = flow test.
+ */
+export const ToolingTestClass = Schema.Struct({
+  id: OptionFromEmptyString,
+  name: Schema.String,
+  namespacePrefix: OptionFromEmptyString,
+  testMethods: Schema.Array(ToolingTestMethod)
+});
+export type ToolingTestClass = Schema.Schema.Type<typeof ToolingTestClass>;
+
+/** Raw Tooling REST shape (pre-decode): `id`/`namespacePrefix` are plain strings, possibly `""`. */
+export type ToolingTestClassWire = Schema.Schema.Encoded<typeof ToolingTestClass>;
 
 export type TestDiscoveryResult = {
   classes: ToolingTestClass[];
@@ -27,7 +47,7 @@ export type TestDiscoveryResult = {
 
 // Tooling REST /tooling/tests response types
 export type ToolingTestsPage = {
-  apexTestClasses: ToolingTestClass[]; // [] if none
+  apexTestClasses: ToolingTestClassWire[]; // [] if none
   size: number;
   nextRecordsUrl: string | null;
   testSetSignature: string;

--- a/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/schemas.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/schemas.ts
@@ -17,13 +17,14 @@ const ToolingTestMethod = Schema.Struct({
 });
 
 /**
- * Wire `""` sentinel ⇄ domain `Option<string>`: decode `""` → `Option.none()`, any other string →
- * `Option.some(s)`; encode back to the raw string (`none` → `""`). Lives at the parse boundary so the
- * domain type never carries an empty-string "missing" sentinel.
+ * Wire `""` sentinel ⇄ domain `Option<string>`: decode `""` (or whitespace-only) → `Option.none()`, any
+ * other string → `Option.some(s)`; encode back to the raw string (`none` → `""`). Lives at the parse
+ * boundary so the domain type never carries an empty-string "missing" sentinel. Trimming keeps a
+ * whitespace-only prefix collapsing to the default/local namespace, matching the prior `.trim()` guards.
  */
 const OptionFromEmptyString = Schema.transform(Schema.String, Schema.OptionFromSelf(Schema.String), {
   strict: true,
-  decode: s => (s === '' ? Option.none() : Option.some(s)),
+  decode: s => (s.trim() === '' ? Option.none() : Option.some(s)),
   encode: Option.getOrElse(() => '')
 });
 

--- a/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/schemas.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/schemas.ts
@@ -6,6 +6,7 @@
  */
 /* eslint-disable jsdoc/check-indentation */
 
+import type { Package2Member } from '@salesforce/types/tooling';
 import * as Option from 'effect/Option';
 import * as Schema from 'effect/Schema';
 
@@ -67,8 +68,6 @@ export type DiscoverTestsOptions = {
 };
 
 // Package resolution: use WSDL-generated types from @salesforce/types (forcedotcom/wsdl)
-import type { Package2Member } from '@salesforce/types/tooling';
-
 /** Package2Member query result; wsdl type omits MetadataComponentId and Package2Id for some API versions. */
 export type Package2MemberRecord = Package2Member & {
   MetadataComponentId?: string;

--- a/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/testDiscovery.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/testDiscovery.ts
@@ -5,12 +5,11 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import type { DiscoverTestsOptions, TestDiscoveryResult, ToolingTestsPage } from './schemas';
-import { ToolingTestClass } from './schemas';
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import * as Effect from 'effect/Effect';
 import type * as Either from 'effect/Either';
 import * as Schema from 'effect/Schema';
+import { type DiscoverTestsOptions, type TestDiscoveryResult, type ToolingTestsPage, ToolingTestClass } from './schemas';
 
 /**
  * Discover Apex test classes and methods using the Tooling REST Test Discovery API.

--- a/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/testDiscovery.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/testDiscovery.ts
@@ -6,6 +6,7 @@
  */
 
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
+import * as Array from 'effect/Array';
 import * as Effect from 'effect/Effect';
 import type * as Either from 'effect/Either';
 import * as Schema from 'effect/Schema';
@@ -72,12 +73,20 @@ export const discoverTests = (options: DiscoverTestsOptions = {}) =>
       if (pageResult._tag === 'Right') {
         const page: ToolingTestsPage = pageResult.right;
         if (page?.apexTestClasses?.length) {
-          // Decode the wire `""` sentinel to Option.none() at the parse boundary; a ParseError maps onto
-          // the same failure channel as a fetch failure.
-          const decoded = yield* Schema.decodeUnknown(Schema.Array(ToolingTestClass))(page.apexTestClasses).pipe(
-            Effect.mapError(error => new Error(`Failed to decode test discovery page: ${error.message}`))
+          // Decode the wire `""` sentinel to Option.none() at the parse boundary. Decode per-record so a
+          // single malformed record degrades to a partial result (mirroring the 431 path) instead of
+          // aborting the entire discovery.
+          const decodeRecord = Schema.decodeUnknown(ToolingTestClass);
+          const results = yield* Effect.forEach(page.apexTestClasses, record =>
+            Effect.either(decodeRecord(record))
           );
-          classes.push(...decoded);
+          classes.push(...Array.getRights(results));
+          const failures = Array.getLefts(results);
+          if (failures.length > 0) {
+            yield* Effect.logWarning(
+              `Skipped ${failures.length} malformed test discovery record(s): ${failures.map(e => e.message).join('; ')}`
+            );
+          }
         }
         nextUrl = page?.nextRecordsUrl ?? undefined;
       }

--- a/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/testDiscovery.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/testDiscovery.ts
@@ -5,10 +5,12 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import type { DiscoverTestsOptions, ToolingTestClass, TestDiscoveryResult, ToolingTestsPage } from './schemas';
+import type { DiscoverTestsOptions, TestDiscoveryResult, ToolingTestsPage } from './schemas';
+import { ToolingTestClass } from './schemas';
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import * as Effect from 'effect/Effect';
 import type * as Either from 'effect/Either';
+import * as Schema from 'effect/Schema';
 
 /**
  * Discover Apex test classes and methods using the Tooling REST Test Discovery API.
@@ -71,7 +73,12 @@ export const discoverTests = (options: DiscoverTestsOptions = {}) =>
       if (pageResult._tag === 'Right') {
         const page: ToolingTestsPage = pageResult.right;
         if (page?.apexTestClasses?.length) {
-          classes.push(...page.apexTestClasses);
+          // Decode the wire `""` sentinel to Option.none() at the parse boundary; a ParseError maps onto
+          // the same failure channel as a fetch failure.
+          const decoded = yield* Schema.decodeUnknown(Schema.Array(ToolingTestClass))(page.apexTestClasses).pipe(
+            Effect.mapError(error => new Error(`Failed to decode test discovery page: ${error.message}`))
+          );
+          classes.push(...decoded);
         }
         nextUrl = page?.nextRecordsUrl ?? undefined;
       }

--- a/packages/salesforcedx-vscode-apex-testing/src/utils/testUtils.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/utils/testUtils.ts
@@ -9,6 +9,7 @@ import type { ToolingTestClass } from '../testDiscovery/schemas';
 import { TestResult } from '@salesforce/apex-node';
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import * as Effect from 'effect/Effect';
+import * as Option from 'effect/Option';
 import * as vscode from 'vscode';
 import { URI, Utils } from 'vscode-uri';
 import { getApexTestingRuntime } from '../services/extensionProvider';
@@ -17,9 +18,9 @@ import { ApexTestMethod } from '../views/lspConverter';
 import { getFullClassName } from './toolingTestClassHelpers';
 
 /**
- * Checks if a ToolingTestClass has a non-empty namespace prefix
+ * Checks if a ToolingTestClass has a namespace prefix
  */
-const hasNamespace = (cls: ToolingTestClass): boolean => (cls.namespacePrefix?.trim() ?? '') !== '';
+const hasNamespace = (cls: ToolingTestClass): boolean => Option.isSome(cls.namespacePrefix);
 
 /**
  * Fetch tests from the Tooling API Test Discovery endpoint

--- a/packages/salesforcedx-vscode-apex-testing/src/utils/toolingTestClassHelpers.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/utils/toolingTestClassHelpers.ts
@@ -6,14 +6,16 @@
  */
 
 import type { ToolingTestClass } from '../testDiscovery/schemas';
+import * as Option from 'effect/Option';
 
 /**
  * Builds a full class name from a ToolingTestClass, including namespace prefix if present
  */
 export const getFullClassName = (cls: ToolingTestClass): string =>
-  cls.namespacePrefix ? `${cls.namespacePrefix}.${cls.name}` : cls.name;
+  Option.match(cls.namespacePrefix, { onNone: () => cls.name, onSome: ns => `${ns}.${cls.name}` });
 
 /**
  * Checks if a ToolingTestClass is a Flow test (Flow tests have namespacePrefix starting with 'FlowTesting')
  */
-export const isFlowTest = (cls: ToolingTestClass): boolean => cls.namespacePrefix?.startsWith('FlowTesting') ?? false;
+export const isFlowTest = (cls: ToolingTestClass): boolean =>
+  Option.exists(cls.namespacePrefix, ns => ns.startsWith('FlowTesting'));

--- a/packages/salesforcedx-vscode-apex-testing/src/views/apexTestTreeService.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/views/apexTestTreeService.ts
@@ -8,6 +8,7 @@
 import type { ToolingTestClass } from '../testDiscovery/schemas';
 import type { Connection } from '@salesforce/core';
 import { ExtensionProviderService, getMessageFromError } from '@salesforce/effect-ext-utils';
+import * as Array from 'effect/Array';
 import * as Deferred from 'effect/Deferred';
 import * as Effect from 'effect/Effect';
 import * as HashSet from 'effect/HashSet';
@@ -364,9 +365,7 @@ export class ApexTestTreeService extends Effect.Service<ApexTestTreeService>()('
         catch: e => new DiscoveryError({ message: toUserFriendlyApexTestError(e) })
       });
 
-      const classIds = apexClasses
-        .map(cls => cls.id)
-        .filter((id): id is string => typeof id === 'string' && id.length > 0);
+      const classIds = Array.getSomes(apexClasses.map(cls => cls.id));
       const [connection, orgInfo] = yield* Effect.all(
         [
           Effect.try({

--- a/packages/salesforcedx-vscode-apex-testing/src/views/apexTestTreeService.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/views/apexTestTreeService.ts
@@ -365,7 +365,6 @@ export class ApexTestTreeService extends Effect.Service<ApexTestTreeService>()('
         catch: e => new DiscoveryError({ message: toUserFriendlyApexTestError(e) })
       });
 
-      const classIds = Array.getSomes(apexClasses.map(cls => cls.id));
       const [connection, orgInfo] = yield* Effect.all(
         [
           Effect.try({
@@ -383,7 +382,13 @@ export class ApexTestTreeService extends Effect.Service<ApexTestTreeService>()('
       if (!orgInfo.orgId) return;
       const orgKey = orgInfo.orgId;
       const classIdToPackage = yield* Effect.tryPromise({
-        try: () => resolvePackage2Members(connection, classIds, buildClassIdToNamespace(apexClasses), orgInfo),
+        try: () =>
+          resolvePackage2Members(
+            connection,
+            Array.getSomes(apexClasses.map(cls => cls.id)),
+            buildClassIdToNamespace(apexClasses),
+            orgInfo
+          ),
         catch: e => new PackageResolutionError({ message: getMessageFromError(e) })
       });
 

--- a/packages/salesforcedx-vscode-apex-testing/src/views/orgTestItems.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/views/orgTestItems.ts
@@ -135,6 +135,16 @@ export const isNonEmptyClassEntriesList = (list: ClassEntry[] | undefined): list
   list !== undefined && Array.isNonEmptyArray(list) && Array.isNonEmptyArray(list[0].entries);
 
 /**
+ * Resolves package info for an Option-wrapped class id against the id→package map.
+ * `none` id or missing map entry → `undefined`.
+ */
+export const resolvePackageInfoForClassId = (
+  id: Option.Option<string>,
+  classIdToPackage: Map<string, ResolvedPackageInfo>
+): ResolvedPackageInfo | undefined =>
+  Option.getOrUndefined(Option.flatMapNullable(id, classId => classIdToPackage.get(classId)));
+
+/**
  * Returns the display label and stable ID for a package node in the Test Explorer.
  * Handles unpackaged, 1GP (namespaced), and 2GP (including Unlocked suffix when applicable).
  * Requires classEntriesList to be non-empty with non-empty entries.
@@ -158,7 +168,7 @@ export const getPackageLabelAndId = (
     };
   }
   const firstClass = classEntriesList[0].entries[0];
-  const info = Option.getOrUndefined(Option.flatMap(firstClass.id, id => Option.fromNullable(classIdToPackage.get(id))));
+  const info = resolvePackageInfoForClassId(firstClass.id, classIdToPackage);
   const baseName = info?.packageName ?? pkgKey;
   const packageLabel =
     info?.containerOptions === 'Unlocked'

--- a/packages/salesforcedx-vscode-apex-testing/src/views/orgTestItems.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/views/orgTestItems.ts
@@ -35,15 +35,8 @@ type NamespacePackageStructure = Map<string, Map<string, ClassEntry[]>>;
  * Builds a map from Apex class ID to namespace prefix for the given test classes.
  * Used when resolving package membership (e.g. InstalledSubscriberPackage fallback in subscriber orgs).
  */
-export const buildClassIdToNamespace = (apexClasses: ToolingTestClass[]): Map<string, Option.Option<string>> => {
-  const map = new Map<string, Option.Option<string>>();
-  for (const cls of apexClasses) {
-    if (Option.isSome(cls.id)) {
-      map.set(cls.id.value, cls.namespacePrefix);
-    }
-  }
-  return map;
-};
+export const buildClassIdToNamespace = (apexClasses: ToolingTestClass[]): Map<string, Option.Option<string>> =>
+  new Map(apexClasses.flatMap(cls => (Option.isSome(cls.id) ? [[cls.id.value, cls.namespacePrefix] as const] : [])));
 
 /**
  * Groups test classes by namespace and package (2GP / 1GP / unpackaged).

--- a/packages/salesforcedx-vscode-apex-testing/src/views/orgTestItems.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/views/orgTestItems.ts
@@ -7,6 +7,7 @@
 
 import type { ResolvedPackageInfo, ToolingTestClass } from '../testDiscovery/schemas';
 import * as Array from 'effect/Array';
+import * as Option from 'effect/Option';
 import * as vscode from 'vscode';
 import type { URI } from 'vscode-uri';
 import { LOCAL_NAMESPACE_KEY, UNPACKAGED_PACKAGE_ID, UNPACKAGED_PACKAGE_KEY } from '../constants';
@@ -37,8 +38,8 @@ type NamespacePackageStructure = Map<string, Map<string, ClassEntry[]>>;
 export const buildClassIdToNamespace = (apexClasses: ToolingTestClass[]): Map<string, string> => {
   const map = new Map<string, string>();
   for (const cls of apexClasses) {
-    if (cls.id && typeof cls.id === 'string') {
-      map.set(cls.id, (cls.namespacePrefix ?? '').trim());
+    if (Option.isSome(cls.id)) {
+      map.set(cls.id.value, Option.getOrElse(cls.namespacePrefix, () => ''));
     }
   }
   return map;
@@ -83,10 +84,9 @@ export const buildNamespacePackageStructure = (
 
   for (const cls of apexClasses) {
     const fullClassName = getFullClassName(cls);
-    const namespaceLabel = (cls.namespacePrefix ?? '').trim();
-    const namespaceKey = namespaceLabel === '' ? LOCAL_NAMESPACE_KEY : namespaceLabel;
-    const pkgInfo = cls.id ? classIdToPackage.get(cls.id) : undefined;
-    const pkgKey = pkgInfo?.package2Id ?? (namespaceLabel !== '' ? '1gp' : UNPACKAGED_PACKAGE_KEY);
+    const namespaceKey = Option.match(cls.namespacePrefix, { onNone: () => LOCAL_NAMESPACE_KEY, onSome: ns => ns });
+    const pkgInfo = Option.match(cls.id, { onNone: () => undefined, onSome: id => classIdToPackage.get(id) });
+    const pkgKey = pkgInfo?.package2Id ?? (Option.isSome(cls.namespacePrefix) ? '1gp' : UNPACKAGED_PACKAGE_KEY);
     addToPackage(namespaceKey, pkgKey, fullClassName, Array.make(cls));
   }
 
@@ -158,7 +158,7 @@ export const getPackageLabelAndId = (
     };
   }
   const firstClass = classEntriesList[0].entries[0];
-  const info = firstClass.id ? classIdToPackage.get(firstClass.id) : undefined;
+  const info = Option.getOrUndefined(Option.flatMap(firstClass.id, id => Option.fromNullable(classIdToPackage.get(id))));
   const baseName = info?.packageName ?? pkgKey;
   const packageLabel =
     info?.containerOptions === 'Unlocked'

--- a/packages/salesforcedx-vscode-apex-testing/src/views/orgTestItems.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/views/orgTestItems.ts
@@ -35,11 +35,11 @@ type NamespacePackageStructure = Map<string, Map<string, ClassEntry[]>>;
  * Builds a map from Apex class ID to namespace prefix for the given test classes.
  * Used when resolving package membership (e.g. InstalledSubscriberPackage fallback in subscriber orgs).
  */
-export const buildClassIdToNamespace = (apexClasses: ToolingTestClass[]): Map<string, string> => {
-  const map = new Map<string, string>();
+export const buildClassIdToNamespace = (apexClasses: ToolingTestClass[]): Map<string, Option.Option<string>> => {
+  const map = new Map<string, Option.Option<string>>();
   for (const cls of apexClasses) {
     if (Option.isSome(cls.id)) {
-      map.set(cls.id.value, Option.getOrElse(cls.namespacePrefix, () => ''));
+      map.set(cls.id.value, cls.namespacePrefix);
     }
   }
   return map;

--- a/packages/salesforcedx-vscode-apex-testing/src/views/testController.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/views/testController.ts
@@ -43,7 +43,8 @@ import {
   buildClassIdToNamespace,
   buildNamespacePackageStructure,
   createClassAndMethodsFactory,
-  getNamespaceDisplayLabel
+  getNamespaceDisplayLabel,
+  resolvePackageInfoForClassId
 } from './orgTestItems';
 
 const TEST_CONTROLLER_ID = 'sf.apex.testController';
@@ -461,9 +462,7 @@ export class ApexTestController {
 
           // Find or create package node
           const classEntry = classEntriesList[0];
-          const info = Option.getOrUndefined(
-            Option.flatMap(classEntry.entries[0].id, id => Option.fromNullable(classIdToPackage.get(id)))
-          );
+          const info = resolvePackageInfoForClassId(classEntry.entries[0].id, classIdToPackage);
           const packageLabel = info?.packageName ?? _pkgKey;
           const pkgNodeId = `${nsKey}/${_pkgKey}`;
           let packageItem: vscode.TestItem | undefined;

--- a/packages/salesforcedx-vscode-apex-testing/src/views/testController.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/views/testController.ts
@@ -9,8 +9,10 @@ import { TestResult, TestService } from '@salesforce/apex-node';
 import type { Connection } from '@salesforce/core';
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import type { RetrieveResult } from '@salesforce/source-deploy-retrieve';
+import * as Array from 'effect/Array';
 import * as Effect from 'effect/Effect';
 import * as Equal from 'effect/Equal';
+import * as Option from 'effect/Option';
 import * as vscode from 'vscode';
 import { URI } from 'vscode-uri';
 import { getConnection, getDefaultOrgInfo } from '../coreExtensionUtils';
@@ -239,10 +241,7 @@ export class ApexTestController {
   }
 
   private async fetchClassBodiesByFullName(classes: ToolingTestClass[]): Promise<Map<string, string>> {
-    const classIds = classes
-      .map(cls => cls.id)
-      .filter((id): id is string => typeof id === 'string' && id.length > 0)
-      .toSorted();
+    const classIds = Array.getSomes(classes.map(cls => cls.id)).toSorted();
     const bodyByFullName = new Map<string, string>();
     if (classIds.length === 0) {
       return bodyByFullName;
@@ -422,7 +421,7 @@ export class ApexTestController {
 
   private async addClassToTree(cls: ToolingTestClass, classNameToUri: Map<string, URI>, orgKey: string): Promise<void> {
     const [connection, orgInfo] = await Promise.all([this.getConnection(), getDefaultOrgInfo()]);
-    const classIds = cls.id ? [cls.id] : [];
+    const classIds = Option.match(cls.id, { onNone: () => [], onSome: id => [id] });
     const classIdToPackage = await resolvePackage2Members(
       connection,
       classIds,
@@ -462,7 +461,9 @@ export class ApexTestController {
 
           // Find or create package node
           const classEntry = classEntriesList[0];
-          const info = classEntry.entries[0].id ? classIdToPackage.get(classEntry.entries[0].id) : undefined;
+          const info = Option.getOrUndefined(
+            Option.flatMap(classEntry.entries[0].id, id => Option.fromNullable(classIdToPackage.get(id)))
+          );
           const packageLabel = info?.packageName ?? _pkgKey;
           const pkgNodeId = `${nsKey}/${_pkgKey}`;
           let packageItem: vscode.TestItem | undefined;

--- a/packages/salesforcedx-vscode-apex-testing/test/jest/discoveryVfs/apexTestDiscoveryService.test.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/jest/discoveryVfs/apexTestDiscoveryService.test.ts
@@ -8,6 +8,7 @@
 import * as Effect from 'effect/Effect';
 import * as Exit from 'effect/Exit';
 import * as Layer from 'effect/Layer';
+import * as Option from 'effect/Option';
 import { ApexTestDiscoveryService } from '../../../src/discoveryVfs/apexTestDiscoveryService';
 import { ApexTestingDiscoveryFsProviderTag } from '../../../src/discoveryVfs/apexTestDiscoveryFsProviderTag';
 import {
@@ -25,9 +26,9 @@ const decoder = new TextDecoder();
 const throwsWithCode = (fn: () => unknown, code: string) => expect(fn).toThrow(expect.objectContaining({ code }));
 
 const classOf = (name: string, methods: string[]): ToolingTestClass => ({
-  id: `id-${name}`,
+  id: Option.some(`id-${name}`),
   name,
-  namespacePrefix: '',
+  namespacePrefix: Option.none(),
   testMethods: methods.map(m => ({ name: m }))
 });
 

--- a/packages/salesforcedx-vscode-apex-testing/test/jest/testDiscovery/packageResolution.test.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/jest/testDiscovery/packageResolution.test.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Connection } from '@salesforce/core';
+import * as Option from 'effect/Option';
 import {
   resetPackageResolutionState,
   getPackageResolutionCacheKey,
@@ -222,9 +223,9 @@ describe('packageResolution', () => {
             }
           ]
         });
-      const classIdToNamespace = new Map<string, string>([
-        [classId, 'taf'],
-        ['01p000000000002AAA', '']
+      const classIdToNamespace = new Map<string, Option.Option<string>>([
+        [classId, Option.some('taf')],
+        ['01p000000000002AAA', Option.none()]
       ]);
       const result = await resolvePackage2Members(
         mockConnection as Connection,
@@ -261,7 +262,7 @@ describe('packageResolution', () => {
         .mockResolvedValueOnce({
           records: [{ Id: classId, ManageableState: 'installedEditable' }]
         });
-      const classIdToNamespace = new Map<string, string>([[classId, '']]);
+      const classIdToNamespace = new Map<string, Option.Option<string>>([[classId, Option.none()]]);
       const result = await resolvePackage2Members(mockConnection as Connection, [classId], classIdToNamespace);
       expect(result.size).toBe(1);
       const info = result.get(classId);
@@ -298,9 +299,9 @@ describe('packageResolution', () => {
             { Id: unpackagedId, ManageableState: null }
           ]
         });
-      const classIdToNamespace = new Map<string, string>([
-        [installedId, ''],
-        [unpackagedId, '']
+      const classIdToNamespace = new Map<string, Option.Option<string>>([
+        [installedId, Option.none()],
+        [unpackagedId, Option.none()]
       ]);
       const result = await resolvePackage2Members(
         mockConnection as Connection,
@@ -334,7 +335,7 @@ describe('packageResolution', () => {
         .mockResolvedValueOnce({
           records: [{ Id: classId, ManageableState: 'installedEditable' }]
         });
-      const classIdToNamespace = new Map<string, string>([[classId, '']]);
+      const classIdToNamespace = new Map<string, Option.Option<string>>([[classId, Option.none()]]);
       const first = await resolvePackage2Members(mockConnection as Connection, [classId], classIdToNamespace);
       expect(first.size).toBe(1);
       expect(first.get(classId)?.packageName).toBe('Trigger Actions Framework');

--- a/packages/salesforcedx-vscode-apex-testing/test/jest/testDiscovery/testDiscovery.test.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/jest/testDiscovery/testDiscovery.test.ts
@@ -47,6 +47,7 @@ jest.mock('../../../src/services/extensionProvider', () => {
   };
 });
 
+import * as Option from 'effect/Option';
 import * as extensionProvider from '../../../src/services/extensionProvider';
 import { discoverTests } from '../../../src/testDiscovery/testDiscovery';
 
@@ -95,6 +96,23 @@ describe('TestDiscovery', () => {
     expect(result.classes[0].testMethods).toHaveLength(2);
     expect(result.classes[1].name).toBe('OtherClass');
     expect(result.classes[1].testMethods).toHaveLength(1);
+  });
+
+  it('decodes wire "" sentinels to Option.none() and non-empty prefixes to Option.some()', async () => {
+    (mockConnection.request as jest.Mock).mockResolvedValueOnce({
+      apexTestClasses: [
+        { id: '', name: 'DefaultNsClass', namespacePrefix: '', testMethods: [{ name: 'testOne' }] },
+        { id: '01pFLOW', name: 'FlowClass', namespacePrefix: 'FlowTesting', testMethods: [{ name: 'testTwo' }] }
+      ],
+      nextRecordsUrl: null
+    });
+
+    const result = await extensionProvider.getApexTestingRuntime().runPromise(discoverTests());
+
+    expect(result.classes[0].id).toEqual(Option.none());
+    expect(result.classes[0].namespacePrefix).toEqual(Option.none());
+    expect(result.classes[1].id).toEqual(Option.some('01pFLOW'));
+    expect(result.classes[1].namespacePrefix).toEqual(Option.some('FlowTesting'));
   });
 
   it('gracefully returns empty when API returns no classes', async () => {

--- a/packages/salesforcedx-vscode-apex-testing/test/jest/utils/toolingTestClassHelpers.test.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/jest/utils/toolingTestClassHelpers.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Option from 'effect/Option';
+import type { ToolingTestClass } from '../../../src/testDiscovery/schemas';
+import { getFullClassName, isFlowTest } from '../../../src/utils/toolingTestClassHelpers';
+
+const classWith = (namespacePrefix: Option.Option<string>, name = 'MyClass'): ToolingTestClass => ({
+  id: Option.none(),
+  name,
+  namespacePrefix,
+  testMethods: []
+});
+
+describe('isFlowTest', () => {
+  it('is true for a bare FlowTesting namespace', () => {
+    expect(isFlowTest(classWith(Option.some('FlowTesting')))).toBe(true);
+  });
+
+  it('is true for a FlowTesting.<Namespace> prefix', () => {
+    expect(isFlowTest(classWith(Option.some('FlowTesting.MyNs')))).toBe(true);
+  });
+
+  it('is false for a non-flow Apex namespace', () => {
+    expect(isFlowTest(classWith(Option.some('MyNs')))).toBe(false);
+  });
+
+  it('is false for a default Apex namespace (absent, post-normalization)', () => {
+    expect(isFlowTest(classWith(Option.none()))).toBe(false);
+  });
+});
+
+describe('getFullClassName', () => {
+  it('prefixes the namespace when present', () => {
+    expect(getFullClassName(classWith(Option.some('MyNs'), 'Acct'))).toBe('MyNs.Acct');
+  });
+
+  it('returns the bare class name when the namespace is absent', () => {
+    expect(getFullClassName(classWith(Option.none(), 'Acct'))).toBe('Acct');
+  });
+});

--- a/packages/salesforcedx-vscode-apex-testing/test/jest/views/orgTestItems.test.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/jest/views/orgTestItems.test.ts
@@ -5,9 +5,11 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import type { ResolvedPackageInfo } from '../../../src/testDiscovery/schemas';
+import type { ResolvedPackageInfo, ToolingTestClass } from '../../../src/testDiscovery/schemas';
+import * as Option from 'effect/Option';
 import { LOCAL_NAMESPACE_KEY, UNPACKAGED_PACKAGE_ID, UNPACKAGED_PACKAGE_KEY } from '../../../src/constants';
 import {
+  buildNamespacePackageStructure,
   getNamespaceDisplayLabel,
   getPackageKeysOrdered,
   getPackageLabelAndId,
@@ -16,8 +18,14 @@ import {
 
 const makeClassEntry = (id?: string) => ({
   fullClassName: 'TestClass',
-  entries: [{ id, name: 'TestClass', namespacePrefix: '' }] as any
+  entries: [{ id: Option.fromNullable(id), name: 'TestClass', namespacePrefix: Option.none() }] as any
 });
+
+const domainClass = (
+  name: string,
+  namespacePrefix: Option.Option<string>,
+  id: Option.Option<string> = Option.none()
+): ToolingTestClass => ({ id, name, namespacePrefix, testMethods: [{ name: 'testOne' }] });
 
 describe('sortNamespaceKeys', () => {
   it('places local namespace first when it is the only key', () => {
@@ -122,6 +130,20 @@ describe('getPackageLabelAndId', () => {
   it('falls back to pkgKey when class has no ID', () => {
     const result = getPackageLabelAndId('ns', 'fallbackKey', [makeClassEntry(undefined)] as any, new Map());
     expect(result.packageLabel).toBe('fallbackKey');
+  });
+});
+
+describe('buildNamespacePackageStructure', () => {
+  it('groups a Flow class under its FlowTesting namespace key and an Apex default-ns class under LOCAL_NAMESPACE_KEY', () => {
+    const flowClass = domainClass('FlowTest', Option.some('FlowTesting'));
+    const apexClass = domainClass('ApexTest', Option.none());
+    const structure = buildNamespacePackageStructure([flowClass, apexClass], new Map());
+
+    expect([...structure.keys()].toSorted()).toEqual(['FlowTesting', LOCAL_NAMESPACE_KEY].toSorted());
+    const flowGroup = structure.get('FlowTesting');
+    const localGroup = structure.get(LOCAL_NAMESPACE_KEY);
+    expect(flowGroup && [...flowGroup.values()].flat().map(e => e.fullClassName)).toEqual(['FlowTesting.FlowTest']);
+    expect(localGroup && [...localGroup.values()].flat().map(e => e.fullClassName)).toEqual(['ApexTest']);
   });
 });
 

--- a/packages/salesforcedx-vscode-apex-testing/test/jest/views/testController.test.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/jest/views/testController.test.ts
@@ -191,6 +191,7 @@ import * as extensionProvider from '../../../src/services/extensionProvider';
 import * as orgApexClassProvider from '../../../src/utils/orgApexClassProvider';
 import * as testUtils from '../../../src/utils/testUtils';
 import * as EffectModule from 'effect/Effect';
+import * as Option from 'effect/Option';
 import { ApexTestController, closeForeignApexTestingTabs, getTestController } from '../../../src/views/testController';
 
 // The tree maps live in ApexTestTreeService Refs; read the live Map through the mock runtime (same path
@@ -542,18 +543,18 @@ describe('ApexTestController', () => {
     it('should discover tests and populate test items', async () => {
       const mockClasses = [
         {
-          id: '01p000000000001AAA',
+          id: Option.some('01p000000000001AAA'),
           name: 'TestClass1',
-          namespacePrefix: '',
+          namespacePrefix: Option.none(),
           testMethods: [
             { name: 'testMethod1', line: 1, column: 0 },
             { name: 'testMethod2', line: 2, column: 0 }
           ]
         },
         {
-          id: '01p000000000002AAA',
+          id: Option.some('01p000000000002AAA'),
           name: 'TestClass2',
-          namespacePrefix: '',
+          namespacePrefix: Option.none(),
           testMethods: [{ name: 'testMethod3', line: 1, column: 0 }]
         }
       ];
@@ -600,9 +601,9 @@ describe('ApexTestController', () => {
     it('should tag tests that exist in org but not in local workspace', async () => {
       const mockClasses = [
         {
-          id: '01p000000000001AAA',
+          id: Option.some('01p000000000001AAA'),
           name: 'OrgOnlyClass',
-          namespacePrefix: '',
+          namespacePrefix: Option.none(),
           testMethods: [{ name: 'testMethod1', line: 1, column: 0 }]
         }
       ];
@@ -1061,7 +1062,9 @@ describe('ApexTestController', () => {
       // Mock discovery to return the same class with same method
       discoverTestsSpyLocal.mockReturnValue(
         Effect.succeed({
-          classes: [{ id: '01p123', name: 'MyTestClass', namespacePrefix: '', testMethods: [{ name: 'testMethod1' }] }]
+          classes: [
+            { id: Option.some('01p123'), name: 'MyTestClass', namespacePrefix: Option.none(), testMethods: [{ name: 'testMethod1' }] }
+          ]
         })
       );
 

--- a/plans/W-23173047.md
+++ b/plans/W-23173047.md
@@ -59,10 +59,10 @@ Replace `?? ''` / `.trim() === ''` / truthiness with `Option.*`:
   - `isFlowTest` → `Option.exists(cls.namespacePrefix, ns => ns.startsWith('FlowTesting'))`
 - `testUtils.ts`: `hasNamespace` → `Option.isSome(cls.namespacePrefix)` (drop `.trim()`)
 - `orgTestItems.ts`:
-  - `buildClassIdToNamespace` → iterate only `Option.isSome(cls.id)`; value = `Option.getOrElse(cls.namespacePrefix, () => '')`
+  - `buildClassIdToNamespace` → `new Map(...flatMap...)` (imperative Map builder → constructor form); iterate only `Option.isSome(cls.id)`; map values stay `Option<string>` (not unwrapped)
   - `buildNamespacePackageStructure`: `namespaceKey = Option.match(cls.namespacePrefix, { onNone: () => LOCAL_NAMESPACE_KEY, onSome: ns => ns })`; `pkgInfo` lookup gated on `Option.isSome(cls.id)`; `pkgKey` default uses the same `isSome` check instead of `namespaceLabel !== ''`
   - `getPackageLabelAndId`: `info = Option.flatMap(firstClass.id, id => Option.fromNullable(classIdToPackage.get(id)))` then `Option.getOrUndefined` (or `Option.match`) for label
-- `testController.ts` / `apexTestTreeService.ts`: id collection → `Array.getSomes(classes.map(cls => cls.id))` (drops the `filter((id): id is string => ...)` guards); `addClassToTree` classIds → `Option.match(cls.id, { onNone: () => [], onSome: id => [id] })`
+- `testController.ts` / `apexTestTreeService.ts`: id collection → `Array.getSomes(classes.map(cls => cls.id))` (drops the `filter((id): id is string => ...)` guards, inlined at call sites); `addClassToTree` classIds → `Option.match(cls.id, { onNone: () => [], onSome: id => [id] })`
 - `apexTestSuite.ts` / `apexTestRun.ts`: `description: Option.getOrElse(cls.namespacePrefix, () => '')` (vscode QuickPick requires string)
 - commit: `refactor(apex-testing): update discovery consumers to Option-based id/namespacePrefix`
 

--- a/plans/W-23173047.md
+++ b/plans/W-23173047.md
@@ -10,7 +10,7 @@ Type hides state. Consumers guard w/ `?? ''`, `.trim() === ''`, `cls.id ?` truth
 
 Fix: model absence with `Option<string>` in the domain type, per project effect-best-practices
 (`.claude/skills/effect-best-practices/SKILL.md` line 41; anti-patterns.md forbids `null`/`undefined`
-+ "missing" sentinels in domain types). The WI description named `Option` as the alternative — adopt it.
++ "missing" sentinels in domain types). WI description named `Option`; adopted.
 Decode the wire `""` sentinel to `Option.none()` at the parse boundary via `Schema.transform`.
 Sequenced last (7) — ripples to all discovery/execution consumers.
 
@@ -19,9 +19,9 @@ Sequenced last (7) — ripples to all discovery/execution consumers.
   `ToolingTestsPage.apexTestClasses` is typed `ToolingTestClassWire[]`.
 - `ToolingTestClass` — normalized domain type, `id: Option.Option<string>` /
   `namespacePrefix: Option.Option<string>`. Consumed across ~8 files below.
-- Because the push target (`classes: ToolingTestClass[]`) and `page.apexTestClasses`
-  (`ToolingTestClassWire[]`) are now distinct types, `classes.push(...page.apexTestClasses)` becomes a
-  **compile error** — omitting the decode is a type error, not a silent runtime regression.
+- Push target (`classes: ToolingTestClass[]`) vs `page.apexTestClasses` (`ToolingTestClassWire[]`) now
+  distinct types → `classes.push(...page.apexTestClasses)` = **compile error** (type error, not silent
+  runtime regression).
 
 ### Schema boundary (W-23165787 direction)
 No runtime `Schema.Struct` for `ToolingTestClass` exists yet (only `ToolingTestsPage` is typed, not
@@ -49,7 +49,7 @@ Note: `testController.ts`/`apexTestExecutionService.ts` `.id` on `vscode.TestIte
   - `ToolingTestsPage.apexTestClasses: ToolingTestClassWire[]`.
   - Update comments: `id` absent (flow tests) = `Option.none`; `namespacePrefix` none = default Apex ns; some `FlowTesting[.Namespace]` = flow.
 - `testDiscovery.ts`: at the push site (line 73-74), decode wire → domain before collecting:
-  `const decoded = yield* Schema.decodeUnknown(Schema.Array(ToolingTestClass))(page.apexTestClasses)` then `classes.push(...decoded)` — map the `ParseError` onto the existing failure channel (wrap in the same `Error` used at line 55, or a tagged error). `classes` stays `ToolingTestClass[]`; the type mismatch with the raw wire array is what forces the decode.
+  `const decoded = yield* Schema.decodeUnknown(Schema.Array(ToolingTestClass))(page.apexTestClasses)` then `classes.push(...decoded)` — map the `ParseError` onto the existing failure channel (wrap in the same `Error` used at line 55, or a tagged error). `classes` stays `ToolingTestClass[]`.
 - commit: `refactor(apex-testing): model ToolingTestClass id/namespacePrefix as Option`
 
 ### Phase 2 — consumers (Option idioms, no sentinels)

--- a/plans/W-23173047.md
+++ b/plans/W-23173047.md
@@ -1,0 +1,111 @@
+# W-23173047 — Make discovery types express state; drop empty-string sentinels
+
+## Context
+
+`packages/salesforcedx-vscode-apex-testing/src/testDiscovery/schemas.ts` `ToolingTestClass`:
+- `id: string` — `""` for some flow tests (absence encoded as empty string)
+- `namespacePrefix: string` — `""` = default Apex namespace; `FlowTesting[.Namespace]` = flow
+
+Type hides state. Consumers guard w/ `?? ''`, `.trim() === ''`, `cls.id ?` truthiness.
+
+Fix: model absence with `Option<string>` in the domain type, per project effect-best-practices
+(`.claude/skills/effect-best-practices/SKILL.md` line 41; anti-patterns.md forbids `null`/`undefined`
++ "missing" sentinels in domain types). The WI description named `Option` as the alternative — adopt it.
+Decode the wire `""` sentinel to `Option.none()` at the parse boundary via `Schema.transform`.
+Sequenced last (7) — ripples to all discovery/execution consumers.
+
+### Domain vs wire distinction (both findings)
+- `ToolingTestClassWire` — raw REST shape, `id: string` / `namespacePrefix: string` (may be `""`).
+  `ToolingTestsPage.apexTestClasses` is typed `ToolingTestClassWire[]`.
+- `ToolingTestClass` — normalized domain type, `id: Option.Option<string>` /
+  `namespacePrefix: Option.Option<string>`. Consumed across ~8 files below.
+- Because the push target (`classes: ToolingTestClass[]`) and `page.apexTestClasses`
+  (`ToolingTestClassWire[]`) are now distinct types, `classes.push(...page.apexTestClasses)` becomes a
+  **compile error** — omitting the decode is a type error, not a silent runtime regression.
+
+### Schema boundary (W-23165787 direction)
+No runtime `Schema.Struct` for `ToolingTestClass` exists yet (only `ToolingTestsPage` is typed, not
+validated). This WI introduces one so the `"" → Option.none()` mapping lives in a `Schema.transform`
+at the decode boundary. Package already imports `effect/Schema`, `effect/Option`, `effect/Array`.
+
+Consumers (all in `packages/salesforcedx-vscode-apex-testing/src`):
+- `testDiscovery/testDiscovery.ts` — parse boundary (Tooling REST → decode → `ToolingTestClass[]`)
+- `utils/toolingTestClassHelpers.ts` — `getFullClassName`, `isFlowTest`
+- `utils/testUtils.ts` — `hasNamespace`, `convertApiToApexTestMethods`
+- `views/orgTestItems.ts` — `buildClassIdToNamespace`, `buildNamespacePackageStructure`, `getPackageLabelAndId`
+- `views/testController.ts` — `fetchClassBodiesByFullName` (`.map(cls => cls.id)`), `addClassToTree` (`cls.id ? [cls.id] : []`)
+- `views/apexTestTreeService.ts` — `classIds` collection (`.map(cls => cls.id).filter(...)`)
+- `commands/apexTestSuite.ts`, `commands/apexTestRun.ts` — `cls.namespacePrefix ?? ''` (QuickPick description)
+
+Note: `testController.ts`/`apexTestExecutionService.ts` `.id` on `vscode.TestItem` (unrelated) — leave.
+
+## Phases
+
+### Phase 1 — domain type (Option) + Schema decode boundary
+- `schemas.ts`:
+  - Add reusable `OptionFromEmptyString = Schema.transform(Schema.String, Schema.OptionFromSelf(Schema.String), { strict: true, decode: s => (s === '' ? Option.none() : Option.some(s)), encode: Option.getOrElse(() => '') })`.
+  - Define `ToolingTestClass` as a `Schema.Struct` — `id: OptionFromEmptyString`, `name: Schema.String`, `namespacePrefix: OptionFromEmptyString`, `testMethods: Schema.Array(<ToolingTestMethod schema>)`; export `type ToolingTestClass = Schema.Schema.Type<typeof ToolingTestClass>` (domain: Option fields).
+  - Add `type ToolingTestClassWire` = `Schema.Schema.Encoded<typeof ToolingTestClass>` (raw: `id: string` / `namespacePrefix: string`).
+  - `ToolingTestsPage.apexTestClasses: ToolingTestClassWire[]`.
+  - Update comments: `id` absent (flow tests) = `Option.none`; `namespacePrefix` none = default Apex ns; some `FlowTesting[.Namespace]` = flow.
+- `testDiscovery.ts`: at the push site (line 73-74), decode wire → domain before collecting:
+  `const decoded = yield* Schema.decodeUnknown(Schema.Array(ToolingTestClass))(page.apexTestClasses)` then `classes.push(...decoded)` — map the `ParseError` onto the existing failure channel (wrap in the same `Error` used at line 55, or a tagged error). `classes` stays `ToolingTestClass[]`; the type mismatch with the raw wire array is what forces the decode.
+- commit: `refactor(apex-testing): model ToolingTestClass id/namespacePrefix as Option`
+
+### Phase 2 — consumers (Option idioms, no sentinels)
+Replace `?? ''` / `.trim() === ''` / truthiness with `Option.*`:
+- `toolingTestClassHelpers.ts`:
+  - `getFullClassName` → `Option.match(cls.namespacePrefix, { onNone: () => cls.name, onSome: ns => \`${ns}.${cls.name}\` })`
+  - `isFlowTest` → `Option.exists(cls.namespacePrefix, ns => ns.startsWith('FlowTesting'))`
+- `testUtils.ts`: `hasNamespace` → `Option.isSome(cls.namespacePrefix)` (drop `.trim()`)
+- `orgTestItems.ts`:
+  - `buildClassIdToNamespace` → iterate only `Option.isSome(cls.id)`; value = `Option.getOrElse(cls.namespacePrefix, () => '')`
+  - `buildNamespacePackageStructure`: `namespaceKey = Option.match(cls.namespacePrefix, { onNone: () => LOCAL_NAMESPACE_KEY, onSome: ns => ns })`; `pkgInfo` lookup gated on `Option.isSome(cls.id)`; `pkgKey` default uses the same `isSome` check instead of `namespaceLabel !== ''`
+  - `getPackageLabelAndId`: `info = Option.flatMap(firstClass.id, id => Option.fromNullable(classIdToPackage.get(id)))` then `Option.getOrUndefined` (or `Option.match`) for label
+- `testController.ts` / `apexTestTreeService.ts`: id collection → `Array.getSomes(classes.map(cls => cls.id))` (drops the `filter((id): id is string => ...)` guards); `addClassToTree` classIds → `Option.match(cls.id, { onNone: () => [], onSome: id => [id] })`
+- `apexTestSuite.ts` / `apexTestRun.ts`: `description: Option.getOrElse(cls.namespacePrefix, () => '')` (vscode QuickPick requires string)
+- commit: `refactor(apex-testing): update discovery consumers to Option-based id/namespacePrefix`
+
+### Phase 3 — tests + fixtures
+- **New `test/jest/utils/toolingTestClassHelpers.test.ts`** — this Apex-vs-Flow boundary currently has
+  ZERO coverage (grep `isFlowTest|FlowTesting` in test → no hits). Cover:
+  - `isFlowTest` true for `namespacePrefix: Option.some('FlowTesting')` and `Option.some('FlowTesting.MyNs')`; false for `Option.some('MyNs')` (Apex ns) and `Option.none()` (default Apex — the post-normalization absent case)
+  - `getFullClassName` for `Option.some(ns)` (`ns.Class`) vs `Option.none()` (bare `Class`)
+- **`test/jest/views/orgTestItems.test.ts`** — add a `buildNamespacePackageStructure` case mixing a
+  Flow class (`namespacePrefix: Option.some('FlowTesting')`) and an Apex default-ns class
+  (`namespacePrefix: Option.none()`), asserting the Flow class groups under its `FlowTesting` namespace
+  key and the Apex class under `LOCAL_NAMESPACE_KEY`. This is the flow-vs-apex grouping assertion; it is
+  NOT covered by any e2e spec (see Verification).
+- **Domain `ToolingTestClass` fixtures** → `Option.some(...)` / `Option.none()`:
+  - `test/jest/discoveryVfs/apexTestDiscoveryService.test.ts` (`classOf` helper: `id: Option.some(...)`, `''` ns → `Option.none()`)
+  - `test/jest/views/orgTestItems.test.ts`, `test/jest/views/testController.test.ts` — audit each construction: keep raw-string shape for API-mock/wire fixtures (page-level `apexTestClasses` responses), switch to Option only for direct domain `ToolingTestClass` fixtures
+- **`test/jest/testDiscovery/testDiscovery.test.ts`** — the `apexTestClasses` in the mocked REST
+  response stay wire (raw strings, incl. existing `id: '01pABC'` etc.). Add a case: wire response with
+  `id: ''` and `namespacePrefix: ''` decodes to `id: Option.none()` / `namespacePrefix: Option.none()`;
+  wire `namespacePrefix: 'FlowTesting'` decodes to `Option.some('FlowTesting')`.
+- **NOT touched** (do not appear in plan's original list by mistake): `testResultProcessor.test.ts` /
+  `testReportGenerator.test.ts` use `apexClass.namespacePrefix` (apex-node `TestResult`, `null`), and
+  `packageResolution.test.ts` uses `ResolvedPackageInfo.namespacePrefix` — none construct
+  `ToolingTestClass`; leave them.
+- commit: `test(apex-testing): Option fixtures + flow-vs-apex + normalization coverage`
+
+## Skills to apply
+- typescript
+- effect-best-practices — Option in domain types (line 41), `Schema.transform` decode boundary, `Option.match`/`Option.exists`/`Option.getOrElse` over truthiness
+- unit-test-critic (Phase 3)
+- concise (comments)
+- verification
+
+## Verification
+- `npm run compile -w packages/salesforcedx-vscode-apex-testing` — tsc catches all consumer breakage AND the wire-vs-domain push mismatch (proves the decode is not skippable)
+- `npx effect-language-service diagnostics --file src/testDiscovery/schemas.ts` (and the touched consumers)
+- `npm run lint -w packages/salesforcedx-vscode-apex-testing`
+- `npm test -w packages/salesforcedx-vscode-apex-testing` — must include the new
+  `test/jest/utils/toolingTestClassHelpers.test.ts` and the `orgTestItems` flow-vs-apex grouping case
+- Manual grep: no remaining `namespacePrefix: ''` / `id: ''` sentinel on domain `ToolingTestClass` in src
+- e2e (existing specs, run via `test:e2e` on branch — cited paths, no new spec added):
+  - tree rendering + discovery: `packages/salesforcedx-vscode-apex-testing/test/playwright/specs/testExplorer.headless.spec.ts`
+  - discovery persistence (VFS/org-only round-trip): `packages/salesforcedx-vscode-apex-testing/test/playwright/specs/orgOnlyClassRetrieve.headless.spec.ts` and `packages/salesforcedx-vscode-apex-testing/test/playwright/specs/staleTestResultsRestoration.headless.spec.ts`
+  - flow-vs-apex namespace grouping: NO e2e spec exercises Flow-prefixed `namespacePrefix` (grep
+    `FlowTesting` across `test/playwright` → no hits). This boundary is covered by the Phase 3 jest
+    cases above, NOT by e2e.


### PR DESCRIPTION
### What does this PR do?

- `ToolingTestClass.id`/`namespacePrefix` now `Option.Option<string>` in the domain type instead of `string` with `""` as an absence sentinel; wire shape (`ToolingTestClassWire`) keeps raw strings, decoded via a `Schema.transform` boundary in `testDiscovery.ts`.
- Updates all ~8 consumers (`toolingTestClassHelpers`, `testUtils`, `orgTestItems`, `testController`, `apexTestTreeService`, `apexTestSuite`, `apexTestRun`) to use `Option.match`/`Option.exists`/`Option.getOrElse`/`Array.getSomes` instead of `?? ''`, `.trim() === ''`, or truthiness checks.
- Adds jest coverage for the flow-vs-apex namespace boundary (previously untested) and Option-based fixtures/normalization.

Plan: [plans/W-23173047.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23173047-7-make-discovery-types-express-state-dro/plans/W-23173047.md)

### What issues does this PR fix or reference?
@W-23173047@

### Functionality Before
N/A — internal type refactor, no user-visible behavior change.

### Functionality After
N/A — internal type refactor, no user-visible behavior change.

### Test plan
- `npm run compile -w packages/salesforcedx-vscode-apex-testing`
- `npx effect-language-service diagnostics --file src/testDiscovery/schemas.ts` (and touched consumers)
- `npm run lint -w packages/salesforcedx-vscode-apex-testing`
- `npm test -w packages/salesforcedx-vscode-apex-testing`
- Manual grep: no remaining `namespacePrefix: ''` / `id: ''` sentinel on domain `ToolingTestClass` in src
- e2e (existing specs, not modified on this branch — run to confirm no regression):
  - tree rendering + discovery: `packages/salesforcedx-vscode-apex-testing/test/playwright/specs/testExplorer.headless.spec.ts`
  - discovery persistence (VFS/org-only round-trip): `packages/salesforcedx-vscode-apex-testing/test/playwright/specs/orgOnlyClassRetrieve.headless.spec.ts` and `.../staleTestResultsRestoration.headless.spec.ts`
  - flow-vs-apex namespace grouping: no e2e spec exercises this; covered by new jest cases in `toolingTestClassHelpers.test.ts` and `orgTestItems.test.ts`

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002d8GHwYAM/view