### PR TITLE
refactor(org): drop ConfigAggregatorProvider reload from orgUtil - W-23355450

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44271,7 +44271,7 @@
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.2.0",
-        "json-stream-stringify": "3.1.7"
+        "json-stream-stringify": "^3.1.7"
       },
       "devDependencies": {
         "@jsforce/jsforce-node": "^3.10.18",
@@ -44852,7 +44852,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/effect-ext-utils": "*",
-        "@salesforce/types": "1.8.0",
+        "@salesforce/types": "^1.8.0",
         "@salesforce/vscode-i18n": "*",
         "effect": "^3.21.2",
         "vscode-uri": "^3.1.0"
@@ -44977,7 +44977,6 @@
         "@salesforce/core": "^8.32.2",
         "@salesforce/playwright-vscode-ext": "*",
         "salesforcedx-vscode-apex": "*",
-        "salesforcedx-vscode-core": "*",
         "salesforcedx-vscode-metadata": "*",
         "salesforcedx-vscode-services": "*"
       },
@@ -44992,7 +44991,7 @@
       "dependencies": {
         "@salesforce/apex-node": "*",
         "@salesforce/effect-ext-utils": "*",
-        "@salesforce/types": "1.8.0",
+        "@salesforce/types": "^1.8.0",
         "@salesforce/vscode-i18n": "*",
         "effect": "^3.21.2",
         "vscode-uri": "^3.1.0"
@@ -45127,7 +45126,7 @@
         "@salesforce/playwright-vscode-ext": "*",
         "@salesforce/source-deploy-retrieve": "^12.32.5",
         "@salesforce/source-tracking": "^7.8.16",
-        "@salesforce/types": "1.8.0",
+        "@salesforce/types": "^1.8.0",
         "salesforcedx-vscode-services": "*"
       },
       "engines": {

--- a/packages/salesforcedx-vscode-org/src/util/orgUtil.ts
+++ b/packages/salesforcedx-vscode-org/src/util/orgUtil.ts
@@ -117,11 +117,8 @@ export const updateConfigAndStateAggregatorsEffect = Effect.fn('updateConfigAndS
   // Force the StateAggregator to drop ALL cached instances (incl. the default used by
   // AuthInfo.listAllAuthorizations) so this config file change is accounted for.
   yield* Effect.tryPromise({
-    try: async () => {
-      await StateAggregator.clearInstanceAsync();
-    },
-    catch: cause =>
-      new AggregatorReloadError({ message: 'Failed to reload config/state aggregators', cause: String(cause) })
+    try: () => StateAggregator.clearInstanceAsync(),
+    catch: cause => new AggregatorReloadError({ message: 'Failed to reload state aggregator', cause: String(cause) })
   });
   yield* api.services.ConfigService.invalidateConfigAggregator();
   yield* api.services.ConnectionService.invalidateCachedConnections();

--- a/packages/salesforcedx-vscode-org/src/util/orgUtil.ts
+++ b/packages/salesforcedx-vscode-org/src/util/orgUtil.ts
@@ -7,7 +7,7 @@
 
 import { AuthFields, AuthInfo, AuthRemover, Org, OrgAuthorization, StateAggregator } from '@salesforce/core';
 import { Column, createTable, Row, ExtensionProviderService } from '@salesforce/effect-ext-utils';
-import { notificationService, ConfigAggregatorProvider } from '@salesforce/salesforcedx-utils-vscode';
+import { notificationService } from '@salesforce/salesforcedx-utils-vscode';
 import { ICONS } from '@salesforce/vscode-services';
 import { Effect, Stream, SubscriptionRef } from 'effect';
 import * as Chunk from 'effect/Chunk';
@@ -21,7 +21,7 @@ import { nls } from '../messages';
 const DAYS_BEFORE_EXPIRE = 5;
 
 /**
- * Raised when reloading the on-disk ConfigAggregator / StateAggregator caches rejects.
+ * Raised when reloading the on-disk StateAggregator cache rejects.
  * Surfaces a real message to ErrorHandlerService instead of escaping as a defect.
  * @ExportTaggedError
  */
@@ -105,7 +105,7 @@ export const getAuthFieldsFor = async (username: string): Promise<AuthFields> =>
 };
 /**
  * Effect form of {@link updateConfigAndStateAggregators}. Reloads the on-disk
- * ConfigAggregator + StateAggregator caches, then invalidates the services-api config/connection
+ * StateAggregator cache, then invalidates the services-api config/connection
  * caches and re-fetches the connection. Exported so Effect commands can `yield*` it directly
  * instead of bouncing through the async wrapper (which re-enters the runtime via runPromise).
  */
@@ -114,12 +114,10 @@ export const updateConfigAndStateAggregatorsEffect = Effect.fn('updateConfigAndS
   attributes: { telemetryIgnore: true }
 })(function* () {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
-  // Force the ConfigAggregatorProvider to reload its stored ConfigAggregators and the
-  // StateAggregator to drop ALL cached instances (incl. the default used by
+  // Force the StateAggregator to drop ALL cached instances (incl. the default used by
   // AuthInfo.listAllAuthorizations) so this config file change is accounted for.
   yield* Effect.tryPromise({
     try: async () => {
-      await ConfigAggregatorProvider.getInstance().reloadConfigAggregators();
       await StateAggregator.clearInstanceAsync();
     },
     catch: cause =>

--- a/packages/salesforcedx-vscode-org/test/jest/util/orgUtil.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/util/orgUtil.test.ts
@@ -11,7 +11,7 @@ import {
   ExtensionProviderService,
   type ExtensionProviderService as ExtensionProviderServiceType
 } from '@salesforce/effect-ext-utils';
-import { ConfigUtil, notificationService, ConfigAggregatorProvider } from '@salesforce/salesforcedx-utils-vscode';
+import { ConfigUtil, notificationService } from '@salesforce/salesforcedx-utils-vscode';
 import type { SalesforceVSCodeServicesApi } from '@salesforce/vscode-services';
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
@@ -329,9 +329,6 @@ describe('updateConfigAndStateAggregators', () => {
     jest.restoreAllMocks();
     resetOrgRuntimeForTesting();
 
-    jest.spyOn(ConfigAggregatorProvider, 'getInstance').mockReturnValue({
-      reloadConfigAggregators: jest.fn()
-    } as any);
     jest.spyOn(StateAggregator, 'clearInstanceAsync').mockResolvedValue();
     (vscode.commands.executeCommand as jest.Mock).mockResolvedValue(undefined);
 

--- a/packages/salesforcedx-vscode-org/test/jest/util/orgUtil.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/util/orgUtil.test.ts
@@ -364,6 +364,7 @@ describe('updateConfigAndStateAggregators', () => {
   it('should call getConnection after invalidating caches to refresh TargetOrgRef', async () => {
     await updateConfigAndStateAggregators();
 
+    expect(StateAggregator.clearInstanceAsync).toHaveBeenCalled();
     expect(invalidateConfigAggregatorMock).toHaveBeenCalled();
     expect(invalidateCachedConnectionsMock).toHaveBeenCalled();
     expect(getConnectionMock).toHaveBeenCalled();
@@ -373,6 +374,7 @@ describe('updateConfigAndStateAggregators', () => {
     getConnectionMock.mockReturnValue(Effect.fail(new Error('No target org configured')));
 
     await expect(updateConfigAndStateAggregators()).resolves.toBeUndefined();
+    expect(StateAggregator.clearInstanceAsync).toHaveBeenCalled();
     expect(invalidateConfigAggregatorMock).toHaveBeenCalled();
     expect(invalidateCachedConnectionsMock).toHaveBeenCalled();
     expect(getConnectionMock).toHaveBeenCalled();

--- a/plans/W-23355450.md
+++ b/plans/W-23355450.md
@@ -1,0 +1,49 @@
+# W-23355450 — Remove ConfigAggregatorProvider from orgUtil.ts
+
+## Context
+
+- Drop legacy `ConfigAggregatorProvider.getInstance().reloadConfigAggregators()` (utils-vscode singleton) from `updateConfigAndStateAggregatorsEffect` in `packages/salesforcedx-vscode-org/src/util/orgUtil.ts`
+- Drop `ConfigAggregatorProvider` import (line 10, shared w/ `notificationService`)
+- Reload `StateAggregator` only (keep `StateAggregator.clearInstanceAsync()`)
+- Fix stale comment (lines 117-119) + JSDoc (lines 106-111) referencing ConfigAggregator reload
+- Safe: org ext reads config via `ConfigService`; Effect calls `ConfigService.invalidateConfigAggregator()` (line 128); no sync ConfigUtil reader in org cmd flow; `workspaceContextUtil` config.json watcher covers cross-ext refresh
+
+## Phases
+
+### Phase 1 — src change
+
+`packages/salesforcedx-vscode-org/src/util/orgUtil.ts`
+
+- import (line 10): `notificationService, ConfigAggregatorProvider` → `notificationService`
+- tryPromise block (lines 120-127): remove `await ConfigAggregatorProvider.getInstance().reloadConfigAggregators();`; keep `StateAggregator.clearInstanceAsync()`
+- comment lines 117-119: reword → StateAggregator drop only (drop ConfigAggregator mention)
+- JSDoc lines 106-111: "Reloads on-disk ConfigAggregator + StateAggregator caches" → StateAggregator cache only
+- `AggregatorReloadError` (lines 23-31): keep — still wraps StateAggregator reject
+
+commit: `refactor(org): drop ConfigAggregatorProvider reload from updateConfigAndStateAggregators - W-23355450`
+
+### Phase 2 — jest update
+
+`packages/salesforcedx-vscode-org/test/jest/util/orgUtil.test.ts`
+
+- import (line 14): drop `ConfigAggregatorProvider` (keep `ConfigUtil`, `notificationService`)
+- `beforeEach` (lines 332-334): drop `jest.spyOn(ConfigAggregatorProvider, 'getInstance')...` mock
+- keep `StateAggregator.clearInstanceAsync` spy (line 335)
+- existing suite assertions unchanged (invalidateConfigAggregator/invalidateCachedConnections/getConnection)
+
+commit: `test(org): drop ConfigAggregatorProvider mock from orgUtil updateConfigAndStateAggregators suite - W-23355450`
+
+## Skills to apply
+
+- effect-best-practices — Effect.fn/tryPromise shape
+- typescript
+- unit-test-critic — jest suite edits
+- verification
+
+## Verification
+
+- `node --check` n/a (TS)
+- typecheck/lint org pkg
+- jest `orgUtil.test.ts` `updateConfigAndStateAggregators` suite (2 cases) — src-covered here
+- grep: 0 remaining `ConfigAggregatorProvider` refs in org pkg
+- e2e-covered (branch, do not run locally): Playwright `orgDeleteUsername.desktop.spec.ts` picker-refresh assertion


### PR DESCRIPTION
### What does this PR do?
- Drops the legacy `ConfigAggregatorProvider.getInstance().reloadConfigAggregators()` call (utils-vscode singleton) from `updateConfigAndStateAggregatorsEffect` in `orgUtil.ts`, plus its import.
- Reloads `StateAggregator` only; fixes the stale comment/JSDoc that referenced ConfigAggregator reload.
- Safe because the org extension reads config only via `ConfigService` (already invalidated in the same Effect), there's no sync `ConfigUtil` reader in the org command flow, and `workspaceContextUtil`'s config.json watcher covers cross-extension refresh.

## Plan
[plans/W-23355450.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23355450-9-remove-configaggregatorprovider-from-o/plans/W-23355450.md)

## Reviewer notes
- low: `orgUtil.test.ts` `beforeEach` stacks 5 mocks (over the 3+ testability threshold) because `StateAggregator.clearInstanceAsync` is a static import call rather than routed through the injected `ExtensionProviderService`/services Layer like `ConfigService`/`ConnectionService`. Fix would route `StateAggregator` through the services Layer (precedent at `connectionService.ts:259`), but that's a cross-package service-boundary design change, not a self-contained edit — skipped. Pre-existing debt, not introduced by this PR.

## Test plan
- [ ] typecheck/lint org package
- [ ] jest `orgUtil.test.ts` `updateConfigAndStateAggregators` suite (2 cases)
- [ ] grep: 0 remaining `ConfigAggregatorProvider` refs in org package

### What issues does this PR fix or reference?
@W-23355450@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eC9RCYA0/view
