### PR TITLE
perf(apex-testing): shrink apex-testing bundle via esbuild ESM resolution of effect - W-23313206

### DIFF
--- a/packages/salesforcedx-vscode-apex-testing/esbuild.config.mjs
+++ b/packages/salesforcedx-vscode-apex-testing/esbuild.config.mjs
@@ -6,12 +6,14 @@
  */
 import { build } from 'esbuild';
 import { nodeConfig } from '../../scripts/bundling/node.mjs';
+import { effectEsmConditions } from '../../scripts/bundling/effect.mjs';
 import { commonConfigBrowser } from '../../scripts/bundling/web.mjs';
 import { writeFile } from 'fs/promises';
 
 // Desktop build (Node.js environment)
 const nodeBuild = await build({
   ...nodeConfig,
+  ...effectEsmConditions,
   entryPoints: ['./out/src/index.js'],
   outdir: './dist',
   plugins: nodeConfig.plugins ?? [],

--- a/plans/W-23313206.md
+++ b/plans/W-23313206.md
@@ -1,0 +1,56 @@
+# W-23313206 [6] Shrink apex-testing bundle via esbuild ESM resolution of effect
+
+## Context
+
+- Goal: shrink `salesforcedx-vscode-apex-testing` **node/desktop** bundle. Force esbuild to resolve effect ESM build so unused submodules (esp fast-check via `effect/Schema`) tree-shake out. NOT ESM output migration.
+- Prior art / source of truth: shared constant `effectEsmConditions` in `scripts/bundling/effect.mjs` (exported const, line 12: `{ conditions: ['import','module','default'] }`). Extracted in commit `792ec7206` (W-23313202), which refactored the earlier local-copy pattern (org-browser PR #7675) into the shared constant. Governed by `docs/adr/0021-effect-esm-condition-override-scope.md`: shared opt-in constant, spread per-package, **not** baked into `nodeConfig`. ADR explicitly **rejects** "Local copy per package" ("3+ near-identical override blocks drift independently") — do NOT author a new local literal.
+- Consume it exactly like siblings do: `import { effectEsmConditions } from '../../scripts/bundling/effect.mjs'` then `...effectEsmConditions` after `...nodeConfig`. Matching precedent: `packages/salesforcedx-vscode-apex-debugger/esbuild.config.mjs` (import line 8, spread line 14), plus apex-log, apex-oas, org-browser — all already merged ancestors of this branch. Output format stays CJS (comes from `nodeConfig`).
+- Scope diff vs siblings: org-browser spread into node **and** browser. This WI = **desktop/node bundle only** (per WI text). Do NOT add override to browserBuild (match apex-debugger, which spreads into nodeBuild only).
+- apex-testing confirmed uses effect:
+  - `src/discoveryVfs/apexTestDiscoveryService.ts`, `src/utils/apexTestExecutionErrors.ts` → `import * as Schema from 'effect/Schema'` (Schema.js unconditionally `require`s FastCheck.js in cjs → blocks tree-shake).
+  - `package.json` dep `"effect": "^3.21.2"`; no direct fast-check dep (pulled transitively).
+- Mechanism: effect pkg has `exports` map → esbuild uses **conditions** not `mainFields`. `conditions:['import',...]` → resolves `dist/esm/*` (has `sideEffects:[]`) → tree-shaker drops most fast-check. Reduced ~80%, NOT eliminated (`effect/FastCheck.js` barrel re-export + reachable `fastCheck_.array`).
+- Target file: `packages/salesforcedx-vscode-apex-testing/esbuild.config.mjs` (nodeBuild lines 13-19). Emits `dist/node-metafile.json` already.
+- Node output = `dist/index.js` (outdir `./dist`, entry `./out/src/index.js`).
+- Build: `npm run vscode:bundle -w salesforcedx-vscode-apex-testing` (wireit; requires deps `services`/`core`/`metadata` bundled first).
+- PR body MUST report before/after node dist size + percent reduction, matching W-23293744 table format.
+
+## Phases
+
+### Phase 1 — Baseline measure
+- Build apex-testing node bundle. Record `dist/index.js` byte size.
+- From `dist/node-metafile.json`: confirm effect resolves `dist/cjs/*`; capture fast-check `bytesInOutput`.
+- No code change (measurement only).
+- Commit msg: `chore(apex-testing): record baseline node bundle metafile sizes - W-23313206`
+
+### Phase 2 — Add import condition (node only), rebuild, diff
+- Edit `esbuild.config.mjs`: add `import { effectEsmConditions } from '../../scripts/bundling/effect.mjs';` and spread `...effectEsmConditions` into `nodeBuild` immediately after `...nodeConfig` — exactly matching `packages/salesforcedx-vscode-apex-debugger/esbuild.config.mjs` (import line 8, spread line 14). Do NOT define a local literal (ADR-0021 rejects it). Do NOT touch browserBuild.
+- Rebuild. Diff metafile: confirm effect now `dist/esm/*`; measure remaining fast-check `bytesInOutput` (expect ~80% drop, partial not zero); record new `dist/index.js` size.
+- Done-when: fast-check `bytesInOutput` drops materially AND node `dist/index.js` shrinks. Report as numbers.
+- Verify build clean: no `require-resolve-not-external` / `unsupported-dynamic-import`; no `import.meta`/ESM syntax in cjs output (grep).
+- Commit msg: `perf(apex-testing): resolve effect ESM to tree-shake fast-check (node) - W-23313206`
+
+### Phase 3 — PR body verdict
+- Write PR body matching W-23293744 format: before/after node `dist/index.js` bytes + %, fast-check `bytesInOutput` before→after + %, verdict ACHIEVED/NOT with numbers. Node-only (state web untouched, why).
+- Commit msg: `docs(apex-testing): esbuild effect-esm node verdict - W-23313206`
+
+## Skills to apply
+
+- typescript — code edits (esbuild.config.mjs, ts sources)
+- effect-best-practices — effect resolution/dual-package context
+- packageJson — any package.json edits
+- wireit — bundle task deps/outputs
+- verification — build + size-diff evidence; Playwright-gated pkg
+- playwright-e2e — apex-testing headless spec suite
+- concise — plan + PR body
+- pr-draft — PR body w/ required before/after numbers + verdict
+
+## Verification
+
+- Build succeeds: `npm run vscode:bundle -w salesforcedx-vscode-apex-testing`.
+- Metafile diff: effect resolves `dist/esm/*` post-change (was `dist/cjs/*`).
+- fast-check `bytesInOutput` reduced (~80%, not absent); number recorded.
+- Node `dist/index.js` before vs after recorded + % reduction.
+- No esbuild errors (dynamic-import, require-resolve); grep bundled output = no stray `import.meta`/ESM syntax (format still CJS).
+- Web bundle unchanged (browserBuild untouched) — spot-check `dist/web/index.js` size stable.
+- Playwright regression guard — REQUIRED local run before PR (matches W-23313202 Phase 2, which mandated a local Playwright re-run for this identical cjs→esm effect-resolution mechanism). Run `npm run test:desktop -w salesforcedx-vscode-apex-testing`; all specs green. The cjs→esm effect swap changes how `effect/Schema`-derived tagged errors resolve at runtime, so exercise the specs most likely to hit Schema-decoded errors: `apexTestSuite.headless.spec.ts` and `runApexTestsFailAndFix.headless.spec.ts` (fail/fix path decodes test-result + error schemas). Node-only change → `test:desktop` is the relevant gate (web bundle untouched). Full headless suite (13 specs in `test/playwright/specs/`) is the safety net; the branch e2e gate is a backstop, not a substitute for the local run.

--- a/plans/W-23313206.md
+++ b/plans/W-23313206.md
@@ -54,3 +54,19 @@
 - No esbuild errors (dynamic-import, require-resolve); grep bundled output = no stray `import.meta`/ESM syntax (format still CJS).
 - Web bundle unchanged (browserBuild untouched) — spot-check `dist/web/index.js` size stable.
 - Playwright regression guard — REQUIRED local run before PR (matches W-23313202 Phase 2, which mandated a local Playwright re-run for this identical cjs→esm effect-resolution mechanism). Run `npm run test:desktop -w salesforcedx-vscode-apex-testing`; all specs green. The cjs→esm effect swap changes how `effect/Schema`-derived tagged errors resolve at runtime, so exercise the specs most likely to hit Schema-decoded errors: `apexTestSuite.headless.spec.ts` and `runApexTestsFailAndFix.headless.spec.ts` (fail/fix path decodes test-result + error schemas). Node-only change → `test:desktop` is the relevant gate (web bundle untouched). Full headless suite (13 specs in `test/playwright/specs/`) is the safety net; the branch e2e gate is a backstop, not a substitute for the local run.
+
+## Verdict — ACHIEVED
+
+Node/desktop bundle only; browserBuild left untouched (WI is desktop-scoped, matching apex-debugger which spreads `effectEsmConditions` into nodeBuild only). Output format stays CJS.
+
+| Metric | Before (cjs) | After (esm) | Delta |
+|--------|-------------:|------------:|------:|
+| node `dist/index.js` | 4,842,726 B | 3,968,180 B | -874,546 B (-18.1%) |
+| fast-check `bytesInOutput` | 236,679 B | 47,542 B | -189,137 B (-79.9%) |
+| effect inputs | 252 cjs / 0 esm | 0 cjs / 252 esm | resolved `dist/esm/*` |
+| web `dist/web/index.js` | 5,382,007 B | 5,382,007 B | unchanged (untouched) |
+
+- fast-check reduced ~80%, **not eliminated** (`effect/FastCheck.js` barrel re-export + reachable `fastCheck_.array` remain).
+- CJS output verified: no `import.meta`, no top-level ESM `import`/`export` syntax; no `require-resolve-not-external` / `unsupported-dynamic-import` esbuild errors.
+- Web untouched: browserBuild has no `effectEsmConditions` spread; `dist/web/index.js` byte-identical.
+- Runtime gate: `npm run test:desktop -w salesforcedx-vscode-apex-testing` — all 13 headless specs green (incl. `apexTestSuite` + `runApexTestsFailAndFix` Schema-decoded error paths).


### PR DESCRIPTION
## Summary

- Force esbuild to resolve `effect`'s ESM build (not CJS) in the `salesforcedx-vscode-apex-testing` node/desktop bundle, via the shared `effectEsmConditions` constant from `scripts/bundling/effect.mjs` (ADR-0021), matching the apex-debugger precedent.
- Node `dist/index.js`: 4,842,726 B → 3,968,180 B (**-18.1%**); fast-check `bytesInOutput`: 236,679 B → 47,542 B (**-79.9%**, not eliminated — `effect/FastCheck.js` barrel + reachable `fastCheck_.array` remain).
- Node-only scope: `browserBuild` untouched, output format stays CJS; `dist/web/index.js` is byte-identical.

## Plan

[plans/W-23313206.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23313206-6-shrink-apex-testing-bundle-via-esbuild/plans/W-23313206.md)

## Test plan

- [x] `npm run vscode:bundle -w salesforcedx-vscode-apex-testing` builds clean (no `require-resolve-not-external` / `unsupported-dynamic-import`).
- [x] `dist/node-metafile.json` confirms effect resolves `dist/esm/*` (was `dist/cjs/*`).
- [x] fast-check `bytesInOutput` reduced ~80% (236,679 B → 47,542 B), not absent.
- [x] Node `dist/index.js` size recorded before/after (-18.1%).
- [x] Grep bundled output for stray `import.meta` / ESM `import`/`export` syntax — none (format still CJS).
- [x] Web bundle spot-check: `dist/web/index.js` size stable (byte-identical, browserBuild untouched).
- [x] Playwright regression guard: `npm run test:desktop -w salesforcedx-vscode-apex-testing` — all 13 headless specs green, incl. `apexTestSuite.headless.spec.ts` and `runApexTestsFailAndFix.headless.spec.ts` (Schema-decoded error paths).

### What issues does this PR fix or reference?
@W-23313206@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002dxJY9YAM/view