### PR TITLE
fix(ci): revert background/wait parallelization in E2E + publish workflows - W-23195710

### DIFF
--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -111,9 +111,7 @@ jobs:
           retry_wait_seconds: 30
 
       - name: Install Playwright browsers and OS deps
-        id: playwright
         if: steps.try-run.outcome == 'failure'
-        background: true
         uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           max_attempts: 3
@@ -132,10 +130,6 @@ jobs:
         run: |
           sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$MINIMAL_ORG_ALIAS" --json --wait 30
         working-directory: minimal-project
-
-      - name: Wait for Playwright install
-        if: steps.try-run.outcome == 'failure'
-        wait: playwright
 
       - name: Run Core E2E tests (parallel)
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/publishOpenVSX.yml
+++ b/.github/workflows/publishOpenVSX.yml
@@ -57,17 +57,13 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
-      # background: overlaps the slow release download; waited on before publish (needs node_modules)
       - uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
-        id: npm-install
-        background: true
       - name: downloadExtensionsFromRelease
         run: |
           mkdir ./extensions
           gh release download v${{ env.PUBLISH_VERSION }} -D ./extensions
       - name: Display downloaded vsix files
         run: ls -R ./extensions
-      - wait: npm-install
       - uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           command: |

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -78,10 +78,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
-      # background: overlaps the slow release download; waited on before validate-vsix (needs node_modules)
       - uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
-        id: npm-install
-        background: true
       - name: downloadExtensionsFromRelease
         run: |
           mkdir ./extensions
@@ -94,8 +91,6 @@ jobs:
           NAMES=$(node scripts/parse-extension-names.js ./extensions)
           echo "names=$NAMES" >> "$GITHUB_OUTPUT"
           echo "Published extensions: $NAMES"
-      # validate-vsix imports glob/jszip → gate it on npm-install completing
-      - wait: npm-install
       - name: Validate VSIX OPC Part URIs
         run: node scripts/validate-vsix-opc.mjs ./extensions
       - uses: salesforcecli/github-workflows/.github/actions/retry@main


### PR DESCRIPTION
### What does this PR do?

Two recent PRs added GitHub's `background:`/`wait:` step syntax to parallelize slow CI legs:
- **#7676** (W-23195710) → `coreE2E.yml`
- **#7681** (W-23195719) → `publishVSCode.yml`, `publishOpenVSX.yml`

That syntax matches the GitHub [workflow-syntax docs for `wait`/`background` steps](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepswait) — a `wait` step performs no work, takes no `run`/`uses`, and *"always runs and does not support the `if` conditional."* Nonetheless GitHub's parser **rejects bare `wait:` steps for this repo**: pushes produce a **0s startup failure** with zero jobs and no check-run.

**Impact:**
- `coreE2E.yml` — silently stopped appearing on PRs (startup failures create no check-run). It was the only E2E workflow affected.
- `publishVSCode.yml` / `publishOpenVSX.yml` — **not yet exercised.** The last successful publish (v67.4.0, Jul 6) ran off a release branch that forked before #7681 merged to develop. The next release-triggered publish would pick up the broken syntax and fail at startup, blocking the release.

**Verified on this branch (coreE2E):**
- commit with `background`/`wait` → run shows as path `.github/workflows/coreE2E.yml`, 0s, failure (startup reject)
- commit with the revert → run shows as **`Core E2E (Playwright)`** and actually executes jobs

Fix: revert all three to sequential form (remove `background:`, `id:`, and the `wait:` steps). Parallelization can be revisited once background/wait step support is confirmed live for this repo.

### What issues does this PR fix or reference?
@W-23195710@, @W-23195719@