### PR TITLE
perf(core): shrink core bundle via esbuild ESM resolution of effect - W-23313208

### DIFF
--- a/packages/salesforcedx-vscode-core/.vscodeignore
+++ b/packages/salesforcedx-vscode-core/.vscodeignore
@@ -4,6 +4,7 @@
 .circular-deps.json
 .eslintcache
 **/*.map
+dist/*-metafile.json
 
 # ignore unused rxjs code
 node_modules/rxjs/src/**

--- a/packages/salesforcedx-vscode-core/esbuild.config.mjs
+++ b/packages/salesforcedx-vscode-core/esbuild.config.mjs
@@ -5,7 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { nodeConfig } from '../../scripts/bundling/node.mjs';
+import { effectEsmConditions } from '../../scripts/bundling/effect.mjs';
 import { build } from 'esbuild';
+import { writeFile } from 'fs/promises';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -43,13 +45,17 @@ const rootTemplates = path.join(__dirname, '..', '..', 'node_modules', '@salesfo
 const srcTemplatesPath = fs.existsSync(packageTemplates) ? packageTemplates : rootTemplates;
 const destTemplatesPath = path.join(__dirname, 'dist', 'templates');
 
-await build({
+const nodeBuild = await build({
   ...nodeConfig,
+  ...effectEsmConditions,
   entryPoints: ['./src/index.ts'],
   outdir: 'dist/src',
   external: [...nodeConfig.external, 'applicationinsights'],
-  minify: true
+  minify: true,
+  metafile: true
 });
+
+await writeFile('dist/node-metafile.json', JSON.stringify(nodeBuild.metafile, null, 2));
 
 if (fs.existsSync(srcTemplatesPath)) {
   copyFiles(srcTemplatesPath, destTemplatesPath);

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -132,8 +132,7 @@
         "out/**"
       ],
       "output": [
-        "dist",
-        "dist/node-metafile.json"
+        "dist"
       ]
     },
     "test": {

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -128,10 +128,12 @@
       "files": [
         "esbuild.config.mjs",
         "../../scripts/bundling/node.mjs",
+        "../../scripts/bundling/effect.mjs",
         "out/**"
       ],
       "output": [
-        "dist"
+        "dist",
+        "dist/node-metafile.json"
       ]
     },
     "test": {

--- a/plans/W-23313208.md
+++ b/plans/W-23313208.md
@@ -54,5 +54,3 @@ Core = largest effect consumer (services, org, commands runtime). Re-resolved ef
 - `npm run test:desktop -w salesforcedx-vscode-core` — required. Covers activation + effect-backed command/services paths. [e2e]
 - Core has no browser build → no test:web. [e2e]
 - Must pass before opening PR. No new specs.
-</content>
-</invoke>

--- a/plans/W-23313208.md
+++ b/plans/W-23313208.md
@@ -1,0 +1,58 @@
+# W-23313208 — Shrink core bundle via esbuild ESM resolution of effect
+
+## Context
+
+- Apply effect ESM conditions override to `salesforcedx-vscode-core` node (desktop) esbuild build only.
+- Pattern from W-23293744 / W-23313202 (apex-debugger #7692) / W-23313203 (apex-log #7703).
+- Shared infra already on branch: `scripts/bundling/effect.mjs` (`effectEsmConditions = { conditions: ['import','module','default'] }`), `docs/adr/0021-effect-esm-condition-override-scope.md`. Do NOT recreate.
+- core deps `effect` (package.json:42) + `@salesforce/effect-ext-utils`.
+- effect exports: `import`→`dist/esm/index.js`, `default`→`dist/cjs`. Override picks esm so unused submodules tree-shake. Output stays CJS (from `nodeConfig.format`).
+- Core esbuild differs from siblings: node-only (NO browser build), `entryPoints: ./src/index.ts`, `outdir: dist/src`, `external: [...nodeConfig.external,'applicationinsights']`, `minify:true`, template-copy logic, NO metafile write today.
+- `nodeConfig` supplies `format:cjs`, `platform:node`, `external:['vscode']`, minify.
+
+## Phases
+
+### Phase 1 — resolve effect ESM in core node build
+
+- Import `effectEsmConditions` from `../../scripts/bundling/effect.mjs`.
+- Spread `...effectEsmConditions` into `build({...})` after `...nodeConfig`.
+- Add `metafile: true`; capture returned build → `writeFile('dist/node-metafile.json', ...)` (needs `import { writeFile } from 'fs/promises'`; assign `build(...)` to const). Match sibling metafile-based size reporting.
+- wireit `vscode:bundle.files`: add `../../scripts/bundling/effect.mjs`; add `dist/node-metafile.json` to output (dir `dist` already covers, but list explicitly per debugger).
+- `.vscodeignore`: add `dist/*-metafile.json` (exclude metafile from VSIX; core lacks it — debugger #7692 has it).
+- Build; record before/after `dist/src/index.js` bytes + % reduction from metafile.
+- Verify metafile resolves effect `dist/esm/*` not `dist/cjs/*`; output still CJS.
+- If vsce secret-scanner false-positives on node output, add workaround plugin (siblings only added on browser; core node likely unaffected — check, don't preemptively add).
+- commit: `perf(core): resolve effect ESM to shrink bundle - W-23313208`
+- files: `packages/salesforcedx-vscode-core/esbuild.config.mjs`, `packages/salesforcedx-vscode-core/package.json`, `packages/salesforcedx-vscode-core/.vscodeignore`
+
+## Skills
+
+- concise — plan + md
+- typescript — esbuild.config.mjs build tooling
+- wireit — bundle via package script; keep files/output arrays correct
+- packageJson — wireit edits
+- pr-draft — PR body: before/after node dist size + % (match W-23293744 format)
+- effect-best-practices — effect resolution change awareness
+- playwright-e2e — core desktop suite
+
+## Verification
+
+Effect ESM swap = runtime resolution change, not just byte-count (ADR 0021: alters resolution for all node consumers). Sibling W-23293744: Playwright rerun = acceptance for identical override. Broken ESM entry surfaces only at activation/runtime — size checks miss it.
+
+### Build/bundle (non-e2e)
+
+- `npm run bundle -w salesforcedx-vscode-core` (or `vscode:bundle`) passes. [non-e2e]
+- Before/after `dist/src/index.js` bytes + % from `dist/node-metafile.json` — record for PR. [non-e2e]
+- Metafile shows effect from `dist/esm/*`, not `dist/cjs/*`. [non-e2e]
+- Output format still CJS (grep bundle head / metafile). [non-e2e]
+- VSIX package step succeeds; metafile excluded via `.vscodeignore`; no secret-scanner false positive. [non-e2e]
+
+### e2e (required before PR)
+
+Core = largest effect consumer (services, org, commands runtime). Re-resolved effect submodules only exercised at activation/runtime.
+
+- `npm run test:desktop -w salesforcedx-vscode-core` — required. Covers activation + effect-backed command/services paths. [e2e]
+- Core has no browser build → no test:web. [e2e]
+- Must pass before opening PR. No new specs.
+</content>
+</invoke>


### PR DESCRIPTION
## Summary

- Apply the `effect` ESM-conditions override (`scripts/bundling/effect.mjs`) to the `salesforcedx-vscode-core` node/desktop esbuild build only, so effect resolves `dist/esm/*` instead of `dist/cjs/*`, letting unused submodules tree-shake out of the bundle.
- Add `metafile: true` to the core node build and write `dist/node-metafile.json` for size reporting, matching the pattern used in sibling packages (W-23293744, apex-debugger #7692, apex-log #7703).
- Exclude the new metafile from the packaged VSIX via `.vscodeignore` (`dist/*-metafile.json`); output format remains CJS.

## Plan

[plans/W-23313208.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23313208-8-shrink-core-bundle-via-esbuild-esm-res/plans/W-23313208.md)

## Test plan

- [ ] `npm run bundle -w salesforcedx-vscode-core` (or `vscode:bundle`) passes.
- [ ] Before/after `dist/src/index.js` bytes + % reduction, recorded from `dist/node-metafile.json`.
- [ ] Metafile shows effect resolved from `dist/esm/*`, not `dist/cjs/*`.
- [ ] Output format still CJS (grep bundle head / metafile).
- [ ] VSIX package step succeeds; metafile excluded via `.vscodeignore`; no secret-scanner false positive.
- [ ] `npm run test:desktop -w salesforcedx-vscode-core` passes — covers activation + effect-backed command/services paths (core has no browser build, so no test:web).

### What issues does this PR fix or reference?
@W-23313208@

## GUS

W-23313208

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002dxEISYA2/view

