### PR TITLE
perf(lightning): resolve effect ESM to shrink bundle - W-23313209

### DIFF
--- a/packages/salesforcedx-vscode-lightning/.vscodeignore
+++ b/packages/salesforcedx-vscode-lightning/.vscodeignore
@@ -1,6 +1,7 @@
 .vscode/**
 .vscode-test/**
 .wireit/**
+dist/*-metafile.json
 out/test/**
 test/**
 src/**

--- a/packages/salesforcedx-vscode-lightning/esbuild.config.mjs
+++ b/packages/salesforcedx-vscode-lightning/esbuild.config.mjs
@@ -5,15 +5,21 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { nodeConfig } from '../../scripts/bundling/node.mjs';
+import { effectEsmConditions } from '../../scripts/bundling/effect.mjs';
 import { build } from 'esbuild';
 import { cpSync, existsSync } from 'fs';
+import { writeFile } from 'fs/promises';
 
-await build({
+const nodeBuild = await build({
   ...nodeConfig,
+  ...effectEsmConditions,
   external: ['vscode'],
   entryPoints: ['./src/index.ts'],
-  outdir: 'dist'
+  outdir: 'dist',
+  metafile: true
 });
+
+await writeFile('dist/node-metafile.json', JSON.stringify(nodeBuild.metafile, null, 2));
 
 // Bundle the Aura language server to ensure consistency between dev and packaged versions
 // This matches the pattern used by LWC, Visualforce and SOQL extensions

--- a/packages/salesforcedx-vscode-lightning/package.json
+++ b/packages/salesforcedx-vscode-lightning/package.json
@@ -193,6 +193,7 @@
       "files": [
         "esbuild.config.mjs",
         "../../scripts/bundling/node.mjs",
+        "../../scripts/bundling/effect.mjs",
         "out/**"
       ],
       "output": [

--- a/plans/W-23313209.md
+++ b/plans/W-23313209.md
@@ -1,0 +1,77 @@
+# W-23313209 — shrink lightning bundle via effect ESM resolution
+
+## Context
+
+- Goal: apply opt-in `effectEsmConditions` override to `salesforcedx-vscode-lightning` node bundle so `effect` resolves `dist/esm/*` (not cjs), letting tree-shaker drop unused submodules (fast-check via Schema). Output stays CJS.
+- Pattern established: W-23293744 (org-browser POC + ADR 0021), replicated in apex-debugger (#7692), apex-log (#7703), apex-oas, apex-replay-debugger, apex, core, apex-testing.
+- lightning is node-only (no web bundle). `esbuild.config.mjs` has 2 builds: main (`src/index.ts` -> `dist`, spreads `nodeConfig`) + auraServer (`../salesforcedx-aura-language-server/out/src/server.js` -> `dist/auraServer.js`, does NOT spread nodeConfig).
+- Scope: desktop/main bundle ONLY (per W-23293744). auraServer untouched — no `effect` dep, distinct concern.
+- lightning depends on `effect@^3.21.2` + `@salesforce/effect-ext-utils`; used across src/index.ts + commands.
+- Shared constant: `scripts/bundling/effect.mjs` exports `effectEsmConditions = { conditions: ['import','module','default'] }`. Already exists — no new infra.
+- Blast-radius audit (ADR-0021: `conditions` re-resolves EVERY dep with a dual export map in the bundle, not just effect — matches W-23313207 apex audit). Audited lightning's main-bundle deps:
+  - `effect` — dual (`import: dist/esm/index.js` / `default: dist/cjs/index.js`). Target dep; re-resolves cjs→esm (the shrink lever).
+  - `vscode-uri` — **genuine dual split** (`import: ./lib/esm/index.mjs` / `require: ./lib/umd/index.js` — different module). Direct dep (`package.json:45`), imported as `URI`/`Utils` in `src/index.ts:28` + 5 command files (`createAuraApp/Component/Event/Interface.ts`, `renameAura.ts`) — the aura generate/rename hot path. WILL re-resolve esm under the override → MUST be verified, not assumed inert.
+  - `@salesforce/effect-ext-utils` (`main: out/src/index.js`, no `exports`/`module`), `vscode-languageclient` (`main`-only, no `exports`), `applicationinsights` (`main`-only) — resolve identically with/without override; inert.
+  - `acorn` (dual export map), `acorn-loose`, `acorn-walk`, `vscode-html-languageservice` (has `module` field) — NOT imported from main-bundle `src/` (confirmed via grep); reachable only from auraServer, which is untouched. Inert for this build.
+  - Net blast radius = effect (intended) + vscode-uri (must verify).
+- PR body must report before/after `dist/index.js` bytes + % reduction (node), matching W-23293744 format.
+
+## Phases
+
+### Phase 1 — record baseline
+
+- Build current lightning bundle, capture `dist/index.js` size + fast-check `bytesInOutput`.
+- Temporarily add `metafile: true` to main build if needed to read fast-check bytes; capture numbers for commit body.
+- Commit msg: `chore(lightning): record baseline bundle metafile sizes - W-23313209`
+- (optional — may fold into Phase 2 commit body instead of separate commit, matching apex-debugger which had no separate baseline commit)
+
+### Phase 2 — apply override + emit metafile
+
+- `packages/salesforcedx-vscode-lightning/esbuild.config.mjs`:
+  - import `effectEsmConditions` from `../../scripts/bundling/effect.mjs`
+  - import `writeFile` from `fs/promises`
+  - main build: capture as `const nodeBuild = await build({...})`; spread `...effectEsmConditions` after `...nodeConfig`; add `metafile: true`
+  - after build: `await writeFile('dist/node-metafile.json', JSON.stringify(nodeBuild.metafile, null, 2))`
+  - auraServer build: unchanged
+- `packages/salesforcedx-vscode-lightning/.vscodeignore`: add `dist/*-metafile.json` (prevent shipping metafile in VSIX — matches apex-debugger fix)
+- `packages/salesforcedx-vscode-lightning/package.json`: add `../../scripts/bundling/effect.mjs` to the `vscode:bundle` wireit `files` array (currently lines ~193-197: `esbuild.config.mjs`, `../../scripts/bundling/node.mjs`, `out/**`). Cache-invalidation fix: without it, wireit won't rebuild when the shared effect constant changes. Every sibling needed this as a review round-trip (apex-oas commit d34044f71, apex-log ac6e0a032, apex-replay-debugger 9910bb2d3, apex follow-up 53b33f2ca) — do it up front.
+- Commit msg (body carries before/after per W-23293744 format):
+  `perf(lightning): resolve effect ESM to shrink bundle - W-23313209`
+
+Files:
+- `packages/salesforcedx-vscode-lightning/esbuild.config.mjs`
+- `packages/salesforcedx-vscode-lightning/.vscodeignore`
+- `packages/salesforcedx-vscode-lightning/package.json` (wireit `vscode:bundle.files`)
+
+## Skills to apply
+
+- concise — plan + commit bodies
+- effect-best-practices — context on effect/fast-check tree-shaking
+- typescript — esbuild.config.mjs edits
+- packageJson / paths — if VSIX file globs need adjusting
+- verification — build + verify output CJS, no import.meta
+- playwright-e2e — required local `test:desktop` run (4 aura specs) before PR
+- pr-draft — PR body format matching W-23293744 (before/after bytes, %)
+
+## Verification
+
+### Build/bundle (non-e2e)
+
+- `npm run vscode:bundle -w salesforcedx-vscode-lightning` green — build succeeds; no `require-resolve-not-external` / `unsupported-dynamic-import` errors.
+- effect resolves `dist/esm/*`: grep `node-metafile.json` inputs for `effect/dist/esm` (not `dist/cjs`).
+- Per-dep blast-radius diff (before/after metafile `inputs`, required before claiming shrink): record `vscode-uri` re-resolve `bytesInOutput` delta (esm entry may differ; net still a win via fast-check drop); confirm no other main-bundle dep's resolved input path changed (acorn*/vscode-html-languageservice must stay absent — they're auraServer-only).
+- output stays CJS: grep `dist/index.js` — no `import.meta`, no ESM `export`/top-level `import` syntax.
+- before/after `dist/index.js` bytes + % reduction recorded (for PR body).
+- fast-check `bytesInOutput` reduced (~80% in prior packages) — from metafile.
+- VSIX excludes `dist/*-metafile.json` — confirm via `.vscodeignore` glob.
+
+### e2e (REQUIRED local run before PR)
+
+- `npm run test:desktop -w salesforcedx-vscode-lightning` — REQUIRED local run before opening PR (matches every sibling in this epic: W-23313202 Phase 2 mandated a local Playwright re-run for this identical cjs→esm effect-resolution mechanism; W-23313205 'Suite must pass before opening PR'; W-23313206 L56; W-23313207 L54 `test:desktop` required). Branch CI e2e gate is a backstop, NOT a substitute for the local run — the exact 'no local run' gap prior sibling WIs were required to close.
+- All 4 existing aura desktop specs green — they directly exercise the re-resolved effect/effect-ext-utils runtime paths (src/index.ts, commands/*.ts, services/extensionProvider.ts import effect submodules):
+  - `auraLspAutocompletion.desktop.spec.ts`
+  - `auraRename.desktop.spec.ts`
+  - `auraTemplates.desktop.spec.ts`
+  - `auraLspGoToDefinition.desktop.spec.ts`
+- vscode-uri re-resolve confirmation: `auraRename.desktop.spec.ts` + the generate/templates specs drive `URI`/`Utils` on the aura generate/rename path (`renameAura.ts:22`, `createAura*.ts`), giving runtime coverage of vscode-uri's post-override esm resolution. Existing specs — no new authoring.
+- No web/browser build in lightning config (node-only) — no `test:web`.

--- a/plans/W-23313209.md
+++ b/plans/W-23313209.md
@@ -34,7 +34,10 @@
   - after build: `await writeFile('dist/node-metafile.json', JSON.stringify(nodeBuild.metafile, null, 2))`
   - auraServer build: unchanged
 - `packages/salesforcedx-vscode-lightning/.vscodeignore`: add `dist/*-metafile.json` (prevent shipping metafile in VSIX — matches apex-debugger fix)
-- `packages/salesforcedx-vscode-lightning/package.json`: add `../../scripts/bundling/effect.mjs` to the `vscode:bundle` wireit `files` array (currently lines ~193-197: `esbuild.config.mjs`, `../../scripts/bundling/node.mjs`, `out/**`). Cache-invalidation fix: without it, wireit won't rebuild when the shared effect constant changes. Every sibling needed this as a review round-trip (apex-oas commit d34044f71, apex-log ac6e0a032, apex-replay-debugger 9910bb2d3, apex follow-up 53b33f2ca) — do it up front.
+- `packages/salesforcedx-vscode-lightning/package.json`:
+  - what: add `../../scripts/bundling/effect.mjs` to `vscode:bundle` wireit `files` array (currently ~lines 193-197: `esbuild.config.mjs`, `../../scripts/bundling/node.mjs`, `out/**`)
+  - why: cache-invalidation — without it wireit won't rebuild when the shared effect constant changes
+  - evidence: every sibling needed this as a review round-trip (apex-oas d34044f71, apex-log ac6e0a032, apex-replay-debugger 9910bb2d3, apex 53b33f2ca) — do it up front
 - Commit msg (body carries before/after per W-23293744 format):
   `perf(lightning): resolve effect ESM to shrink bundle - W-23313209`
 


### PR DESCRIPTION
### What does this PR do?

## Summary
- Apply `effectEsmConditions` override to the `salesforcedx-vscode-lightning` node bundle so `effect` resolves `dist/esm/*` (not cjs), letting the tree-shaker drop unused submodules (fast-check via Schema). Output stays CJS.
- `dist/index.js`: 1,807,557 -> 971,726 bytes (-46.2%); fast-check `bytesInOutput`: 235,284 -> 47,281 (-79.9%). `vscode-uri` re-resolves umd+esm (23,793) -> esm-only (11,460), net -12,333. `acorn*`/`vscode-html-languageservice` remain absent (auraServer-only, untouched).
- Emit `dist/node-metafile.json` for blast-radius auditing; excluded from VSIX via `.vscodeignore`; added `scripts/bundling/effect.mjs` to the `vscode:bundle` wireit `files` for cache invalidation.

## Plan
[plans/W-23313209.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23313209-9-shrink-lightning-bundle-via-esbuild-es/plans/W-23313209.md)

## Test plan
- `npm run vscode:bundle -w salesforcedx-vscode-lightning` green — build succeeds; no `require-resolve-not-external` / `unsupported-dynamic-import` errors.
- effect resolves `dist/esm/*`: grep `node-metafile.json` inputs for `effect/dist/esm` (not `dist/cjs`).
- Per-dep blast-radius diff (before/after metafile `inputs`): `vscode-uri` re-resolve `bytesInOutput` delta recorded (net win via fast-check drop); confirm no other main-bundle dep's resolved input path changed (acorn*/vscode-html-languageservice stay absent — auraServer-only).
- output stays CJS: grep `dist/index.js` — no `import.meta`, no ESM `export`/top-level `import` syntax.
- before/after `dist/index.js` bytes + % reduction recorded (see Summary).
- fast-check `bytesInOutput` reduced (~80%) — from metafile.
- VSIX excludes `dist/*-metafile.json` — confirmed via `.vscodeignore` glob.
- `npm run test:desktop -w salesforcedx-vscode-lightning` — all 4 existing aura desktop specs green locally (7 tests): `auraLspAutocompletion.desktop.spec.ts`, `auraRename.desktop.spec.ts`, `auraTemplates.desktop.spec.ts`, `auraLspGoToDefinition.desktop.spec.ts`. Covers re-resolved effect/effect-ext-utils runtime paths and `vscode-uri` esm resolution on the aura generate/rename path.
- No web/browser build in lightning config (node-only) — no `test:web`.

### What issues does this PR fix or reference?
@W-23313209@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002dx8cIYAQ/view
