### PR TITLE
perf(apex): resolve effect ESM to shrink bundle - W-23313207

### DIFF
--- a/packages/salesforcedx-vscode-apex/esbuild.config.mjs
+++ b/packages/salesforcedx-vscode-apex/esbuild.config.mjs
@@ -7,10 +7,12 @@
 import { build } from 'esbuild';
 import copy from 'esbuild-plugin-copy';
 import { nodeConfig } from '../../scripts/bundling/node.mjs';
+import { effectEsmConditions } from '../../scripts/bundling/effect.mjs';
 import { writeFile } from 'fs/promises';
 
 const nodeBuild = await build({
   ...nodeConfig,
+  ...effectEsmConditions,
   entryPoints: ['./out/src/index.js'],
   outdir: './dist',
   plugins: [

--- a/packages/salesforcedx-vscode-apex/package.json
+++ b/packages/salesforcedx-vscode-apex/package.json
@@ -150,6 +150,7 @@
       "files": [
         "esbuild.config.mjs",
         "../../scripts/bundling/node.mjs",
+        "../../scripts/bundling/effect.mjs",
         "out/**"
       ],
       "output": [


### PR DESCRIPTION
### What does this PR do?

## Summary
- Spread `effectEsmConditions` (from `scripts/bundling/effect.mjs`) into the apex node esbuild `nodeBuild` config so `effect` resolves its `dist/esm/*` tree vs `dist/cjs/*`, tree-shaking unused code (e.g. fast-check via Schema) and shrinking `dist/index.js`.
- Node `dist/index.js`: 5,822,651 B → 4,841,090 B (-16.9%). Blast radius limited to `effect` + `vscode-uri` (measured on the original branch; see #7717).
- Added `scripts/bundling/effect.mjs` to the `vscode:bundle` wireit `files` list for apex so cache invalidation picks up changes to that shared module.

## Why this PR exists
Redo of #7717, which was accidentally merged into `main` instead of `develop`. `main` is being reset to the `v67.4.0` release point to remove that out-of-band merge; this PR lands the intended apex change on `develop` the same way its siblings (#7714, #7715) did.

### What issues does this PR fix or reference?
@W-23313207@