### PR TITLE
perf(metadata): shrink metadata bundle via esbuild ESM resolution of effect - W-23313212

### DIFF
--- a/packages/salesforcedx-vscode-metadata/esbuild.config.mjs
+++ b/packages/salesforcedx-vscode-metadata/esbuild.config.mjs
@@ -6,11 +6,13 @@
  */
 import { build } from 'esbuild';
 import { nodeConfig } from '../../scripts/bundling/node.mjs';
+import { effectEsmConditions } from '../../scripts/bundling/effect.mjs';
 import { commonConfigBrowser } from '../../scripts/bundling/web.mjs';
 import { writeFile } from 'fs/promises';
 
 const nodeBuild = await build({
   ...nodeConfig,
+  ...effectEsmConditions,
   entryPoints: ['./out/src/index.js'],
   outdir: './dist',
   plugins: [...(nodeConfig.plugins ?? [])],

--- a/packages/salesforcedx-vscode-metadata/package.json
+++ b/packages/salesforcedx-vscode-metadata/package.json
@@ -95,6 +95,7 @@
       "files": [
         "esbuild.config.mjs",
         "../../scripts/bundling/node.mjs",
+        "../../scripts/bundling/effect.mjs",
         "../../scripts/bundling/web.mjs",
         "out/**",
         "package.json"

--- a/packages/salesforcedx-vscode-metadata/package.json
+++ b/packages/salesforcedx-vscode-metadata/package.json
@@ -114,6 +114,7 @@
       "files": [
         "esbuild.config.mjs",
         "../../scripts/bundling/node.mjs",
+        "../../scripts/bundling/effect.mjs",
         "../../scripts/bundling/web.mjs",
         "out/**",
         "package.json"

--- a/plans/W-23313212.md
+++ b/plans/W-23313212.md
@@ -15,9 +15,8 @@
 
 ### Phase 1 — record baseline
 
-- `cd packages/salesforcedx-vscode-metadata`
-- ensure compiled: `npm run compile` (from repo root wireit)
-- run `node ./esbuild.config.mjs`
+- ensure compiled: `npm run compile -w salesforcedx-vscode-metadata`
+- rebuild: `npm run vscode:bundle -w salesforcedx-vscode-metadata`
 - record from `dist/node-metafile.json` + `dist`: node `dist/index.js` bytes, effect input count (cjs vs esm), web bytes
 - capture numbers for use in Phase 2 commit body only — no metafile in git: apex-testing committed baseline separately; metadata has none, stays out of git
 - no file change in this phase → no standalone commit; baseline numbers fold into the Phase 2 commit body (before/after diff needs both anyway)
@@ -45,7 +44,7 @@
 
 ### Phase 3 — wireit cache invalidation
 
-- add `"../../scripts/bundling/effect.mjs"` to `vscode:bundle` `files[]` in `packages/salesforcedx-vscode-metadata/package.json` (after `node.mjs`)
+- add `"../../scripts/bundling/effect.mjs"` to both `vscode:bundle` and `vscode:bundle:local` `files[]` in `packages/salesforcedx-vscode-metadata/package.json` (after `node.mjs`)
 - prevents stale bundle when helper changes (review finding on apex, commit 53b33f2ca)
 - files: `packages/salesforcedx-vscode-metadata/package.json`
 - commit msg: `fix(metadata): add effect.mjs to vscode:bundle wireit files - W-23313212`
@@ -70,7 +69,9 @@
 
 ### Required local desktop e2e before PR
 
-The cjs→esm effect-resolution swap is a runtime resolution change; size/CJS checks can't catch a broken ESM entry or a mis-decoded Schema at activation. Sibling WIs in this epic (W-23313207 apex, W-23313209 lightning, W-23313206 apex-testing, W-23313210 lwc, W-23313205 apex-replay-debugger) all mandate a local `test:desktop` run before PR; branch CI e2e is a backstop, NOT a substitute. Both suites must pass locally before opening the PR:
+- cjs→esm resolution swap: size/CJS checks miss broken ESM entry or mis-decoded Schema at activation
+- sibling WIs (W-23313207 apex, W-23313209 lightning, W-23313206 apex-testing, W-23313210 lwc, W-23313205 apex-replay-debugger) mandate local `test:desktop`; branch CI is backstop, not substitute
+- both suites required locally before PR:
 
 - `npm run test:desktop -w salesforcedx-vscode-metadata` — REQUIRED. Exercises the effect/Schema decode paths touched by the ESM-condition change. At-risk specs:
   - `packageInstall.headless.spec.ts` — hits `Schema.TaggedError` in `commands/packageInstall.ts`

--- a/plans/W-23313212.md
+++ b/plans/W-23313212.md
@@ -1,0 +1,81 @@
+# W-23313212 — Shrink metadata bundle via esbuild ESM resolution of effect
+
+## Context
+
+- Target: `packages/salesforcedx-vscode-metadata/esbuild.config.mjs`
+- Apply node-build-only `effectEsmConditions` override (per W-23293744 / ADR 0021)
+- Precedents merged: apex-testing (W-23313206), apex-log, apex-oas, apex-replay-debugger, apex-debugger, core, lwc, lightning, apex
+- Helper: `scripts/bundling/effect.mjs` exports `effectEsmConditions = { conditions: ['import','module','default'] }`
+- Mechanism: spread into nodeBuild (after `nodeConfig`) → esbuild resolves effect `dist/esm/*` (sideEffects:[]) → tree-shakes unused submodules; output stays CJS
+- Scope: node/desktop bundle ONLY; browserBuild untouched
+- PR must report before/after node `dist` size + % reduction (W-23293744 format)
+- Current metadata config: nodeBuild spreads `nodeConfig` + `metafile:true`, plugins `[...(nodeConfig.plugins ?? [])]`; writes `dist/node-metafile.json`
+
+## Phases
+
+### Phase 1 — record baseline
+
+- `cd packages/salesforcedx-vscode-metadata`
+- ensure compiled: `npm run compile` (from repo root wireit)
+- run `node ./esbuild.config.mjs`
+- record from `dist/node-metafile.json` + `dist`: node `dist/index.js` bytes, effect input count (cjs vs esm), web bytes
+- capture numbers for use in Phase 2 commit body only — no metafile in git: apex-testing committed baseline separately; metadata has none, stays out of git
+- no file change in this phase → no standalone commit; baseline numbers fold into the Phase 2 commit body (before/after diff needs both anyway)
+
+### Phase 2 — apply effect ESM override
+
+- import `effectEsmConditions` from `../../scripts/bundling/effect.mjs`
+- spread `...effectEsmConditions` into nodeBuild after `...nodeConfig`
+- leave browserBuild unchanged
+- rebuild, record after numbers + % drop
+- files: `packages/salesforcedx-vscode-metadata/esbuild.config.mjs`
+- commit msg:
+  ```
+  perf(metadata): resolve effect ESM to shrink bundle - W-23313212
+
+  Spread effectEsmConditions into nodeBuild (after nodeConfig) so esbuild
+  resolves effect dist/esm/* (sideEffects:[]) and tree-shakes unused
+  submodules. Node/desktop bundle only; browserBuild untouched. Output CJS.
+
+  - node dist/index.js: <before> -> <after> bytes (~<pct>% drop)
+  - effect inputs: now <n> esm, 0 cjs
+  - web dist/web/index.js: <bytes> (unchanged)
+  - CJS output verified: no import.meta, no top-level ESM syntax
+  ```
+
+### Phase 3 — wireit cache invalidation
+
+- add `"../../scripts/bundling/effect.mjs"` to `vscode:bundle` `files[]` in `packages/salesforcedx-vscode-metadata/package.json` (after `node.mjs`)
+- prevents stale bundle when helper changes (review finding on apex, commit 53b33f2ca)
+- files: `packages/salesforcedx-vscode-metadata/package.json`
+- commit msg: `fix(metadata): add effect.mjs to vscode:bundle wireit files - W-23313212`
+
+## Skills to apply
+
+- concise (plan/docs)
+- effect-best-practices (context only; no runtime code change)
+- wireit (Phase 3 files[] semantics)
+- pr-draft (PR body format matching W-23293744)
+- packageJson (Phase 3 edit)
+- typescript (esbuild.config.mjs edits)
+
+## Verification
+
+- `node --check packages/salesforcedx-vscode-metadata/esbuild.config.mjs`
+- rebuild: `node ./esbuild.config.mjs` succeeds
+- node `dist/index.js` smaller vs baseline; % recorded
+- effect inputs = all esm, 0 cjs (grep `dist/node-metafile.json`)
+- web `dist/web/index.js` byte-identical (unchanged)
+- CJS output intact: no `import.meta`, no top-level `import`/`export` in `dist/index.js`
+
+### Required local desktop e2e before PR
+
+The cjs→esm effect-resolution swap is a runtime resolution change; size/CJS checks can't catch a broken ESM entry or a mis-decoded Schema at activation. Sibling WIs in this epic (W-23313207 apex, W-23313209 lightning, W-23313206 apex-testing, W-23313210 lwc, W-23313205 apex-replay-debugger) all mandate a local `test:desktop` run before PR; branch CI e2e is a backstop, NOT a substitute. Both suites must pass locally before opening the PR:
+
+- `npm run test:desktop -w salesforcedx-vscode-metadata` — REQUIRED. Exercises the effect/Schema decode paths touched by the ESM-condition change. At-risk specs:
+  - `packageInstall.headless.spec.ts` — hits `Schema.TaggedError` in `commands/packageInstall.ts`
+  - `sourceDiff.headless.spec.ts` / `sourceDiffMultiple.headless.spec.ts` — exercise `diffTypes.ts` `Schema.declare`/`Schema.Struct`
+- `npm run test:desktop:conflicts -w salesforcedx-vscode-metadata` — REQUIRED. `conflict/resultStorage.ts:46` defines `StoredResultJsonSchema = Schema.parseJson(StoredResultSchema)` (Schema decode, wrapped in `Effect.fn` at lines 104/120/190) — a direct runtime decode path. Specs that exercise it:
+  - `specs-conflicts/tracking/deploy-conflict.spec.ts`, `retrieve-conflict.spec.ts`, `disabled-conflict-detection.spec.ts`
+  - `specs-conflicts/non-tracking/deploy-conflict.spec.ts`, `retrieve-conflict.spec.ts`
+- Watch for the vsce secret-scanner false positive on node output flagged by W-23313205 during this identical override.


### PR DESCRIPTION
## Summary

- Force esbuild to resolve `effect`'s ESM build (not CJS) in the `salesforcedx-vscode-metadata` node/desktop bundle, via the shared `effectEsmConditions` constant from `scripts/bundling/effect.mjs` (ADR-0021), matching the apex-testing/apex/lwc/lightning precedents.
- Node `dist/index.js`: 2,482,792 B → 1,752,636 B (**-29.4%**); effect inputs now 251 esm, 0 cjs.
- Node-only scope: `browserBuild` untouched, output format stays CJS; `dist/web/index.js` byte-identical (2,457,956 B). Added `effect.mjs` to both `vscode:bundle` and `vscode:bundle:local` wireit `files[]` for cache invalidation.

## Plan

[plans/W-23313212.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23313212-11-shrink-metadata-bundle-via-esbuild-es/plans/W-23313212.md)

## Test plan

- [x] `node --check packages/salesforcedx-vscode-metadata/esbuild.config.mjs`
- [x] Rebuild: `node ./esbuild.config.mjs` succeeds
- [x] Node `dist/index.js` smaller vs baseline; % drop recorded (-29.4%)
- [x] Effect inputs = all esm, 0 cjs (confirmed via `dist/node-metafile.json`)
- [x] Web `dist/web/index.js` byte-identical (unchanged)
- [x] CJS output intact: no `import.meta`, no top-level `import`/`export` in `dist/index.js`
- [x] `npm run test:desktop -w salesforcedx-vscode-metadata` — required local desktop e2e; exercises effect/Schema decode paths (`packageInstall.headless.spec.ts`, `sourceDiff.headless.spec.ts`, `sourceDiffMultiple.headless.spec.ts`)
- [x] `npm run test:desktop:conflicts -w salesforcedx-vscode-metadata` — required local desktop e2e; exercises `conflict/resultStorage.ts` Schema decode path via conflict specs

### What issues does this PR fix or reference?
@W-23313212@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002dyIlyYAE/view