### PR TITLE
perf(org): resolve effect ESM to shrink bundle - W-23313213

### DIFF
--- a/packages/salesforcedx-vscode-org/esbuild.config.mjs
+++ b/packages/salesforcedx-vscode-org/esbuild.config.mjs
@@ -6,10 +6,12 @@
  */
 import { build } from 'esbuild';
 import { nodeConfig } from '../../scripts/bundling/node.mjs';
+import { effectEsmConditions } from '../../scripts/bundling/effect.mjs';
 import { writeFile } from 'fs/promises';
 
 const nodeBuild = await build({
   ...nodeConfig,
+  ...effectEsmConditions,
   entryPoints: ['./out/src/index.js'],
   outdir: './dist',
   plugins: [...(nodeConfig.plugins ?? [])],

--- a/packages/salesforcedx-vscode-org/package.json
+++ b/packages/salesforcedx-vscode-org/package.json
@@ -88,6 +88,7 @@
       "files": [
         "esbuild.config.mjs",
         "../../scripts/bundling/node.mjs",
+        "../../scripts/bundling/effect.mjs",
         "out/**"
       ],
       "output": [

--- a/plans/W-23313213.md
+++ b/plans/W-23313213.md
@@ -1,0 +1,65 @@
+# W-23313213 — Shrink org bundle via esbuild ESM resolution of effect
+
+## Context
+
+- Apply effect ESM conditions override to `salesforcedx-vscode-org` node (desktop) esbuild only.
+- Pattern: W-23293744 (org-browser POC #7675); siblings W-23313212 (metadata), W-23313207 (apex #7721), W-23313208 (core), W-23313210 (lwc).
+- Shared infra already on branch — do NOT recreate: `scripts/bundling/effect.mjs` (`effectEsmConditions = { conditions: ['import','module','default'] }`), `docs/adr/0021-effect-esm-condition-override-scope.md`.
+- Extension deps `effect` (^3.21.2); `src/index.ts` + commands/parameterGatherers/util/orgPicker import `effect/*`.
+- Target: `packages/salesforcedx-vscode-org/esbuild.config.mjs`, single `nodeBuild` (entry `./out/src/index.js` → `dist`).
+- Config = node-only, NO browser build. Already emits `dist/node-metafile.json`; `dist/*-metafile.json` in `.vscodeignore`.
+- Override changes runtime resolution (effect `dist/esm/*` vs `dist/cjs/*`); output stays CJS from `nodeConfig`.
+- Size = `dist/index.js` bytes; effect input count from metafile (esm vs cjs).
+
+## Phases
+
+### Phase 1 — record baseline (before any code change)
+
+- ensure compiled: `npm run compile -w salesforcedx-vscode-org`
+- rebuild current bundle: `npm run vscode:bundle -w salesforcedx-vscode-org`
+- record BEFORE numbers, prior to the esbuild.config.mjs edit: `dist/index.js` bytes (stat) + effect input count (cjs vs esm) from `dist/node-metafile.json`
+- no file change here → no standalone commit; baseline bytes fold into the Phase 2 commit body (before/after diff needs both). Metafile stays out of git (`dist/*-metafile.json` in `.vscodeignore`).
+
+### Phase 2 — resolve effect ESM in org node build
+
+- Import `effectEsmConditions` from `../../scripts/bundling/effect.mjs`.
+- Spread `...effectEsmConditions` into `nodeBuild` config (after `...nodeConfig`).
+- Add `../../scripts/bundling/effect.mjs` to `vscode:bundle` wireit `files` — cache invalidation.
+- No `vscode:bundle:local` on org — skip.
+- rebuild, record AFTER bytes + % drop for commit/PR body.
+- commit: `perf(org): resolve effect ESM to shrink bundle - W-23313213`
+- files: `packages/salesforcedx-vscode-org/esbuild.config.mjs`, `packages/salesforcedx-vscode-org/package.json`
+
+## Skills
+
+- concise — plan + md
+- typescript — esbuild tooling
+- wireit — files-input update for cache
+- packageJson — wireit files edit
+- pr-draft — PR body: before/after `dist/index.js` bytes + % (match W-23293744 format)
+- playwright-e2e — org `test:desktop`
+
+## Verification
+
+- Override = runtime resolution change (ADR 0021), not byte count alone.
+- Broken ESM entry surfaces at activation/runtime — size checks miss it.
+
+### Build/bundle (non-e2e)
+
+- Baseline captured in Phase 1 (before edit); after-change bytes recorded in Phase 2. Report before/after + % reduction in PR body. [non-e2e]
+- `dist/node-metafile.json`: effect inputs now `dist/esm/*`, 0 cjs. [non-e2e]
+- Output still CJS: grep bundle — no `import.meta`, no top-level ESM. [non-e2e]
+- `node --check esbuild.config.mjs`. [non-e2e]
+
+### e2e (required before PR)
+
+- cjs→esm resolution swap: size/CJS checks miss a broken ESM entry or mis-decoded Schema at activation. The re-resolved effect submodules load only at runtime, so desktop e2e is the gate.
+- `npm run test:desktop -w salesforcedx-vscode-org` — REQUIRED. Suite passes before opening PR.
+- At-risk specs (all in `packages/salesforcedx-vscode-org/test/playwright/specs/`) and the effect/Schema call sites they exercise:
+  - `orgDisplay.desktop.spec.ts` — `util/orgDisplay.ts` `getOrgInfoEffect` (`Effect.fn`), `NoUsernameError`/`OrgInfoConnectionError` (`Schema.TaggedError`), and the CLI-JSON decode in `util/cliJson.ts` (`Schema.parseJson` + `Schema.decodeUnknown`) — direct runtime decode path.
+  - `orgListClean.desktop.spec.ts` / `orgPicker.desktop.spec.ts` / `orgPickers.desktop.spec.ts` — `orgPicker/orgList.ts` `createOrgPicker`/`setDefaultOrg` (`Effect.fn`, `Effect.forkDaemon`, `Stream`) + `cliJson.ts` decode of org lists.
+  - `orgOpen.desktop.spec.ts` — `commands/orgOpen.ts` effect pipeline.
+  - `orgDeleteUsername.desktop.spec.ts` / `orgDeleteCommandVisibility.desktop.spec.ts` — `commands/orgDelete.ts` + `parameterGatherers/selectDeletableOrg.ts`.
+  - `orgLoginAccessToken.desktop.spec.ts` / `orgLoginWeb.desktop.spec.ts` — `commands/auth/*` effect flows.
+  - `orgCommands.desktop.spec.ts` — general command activation.
+  - `telemetryIdentitySeeding.desktop.spec.ts` — `index.ts` `activateEffect` (`Effect.runSync`, `Effect.forkIn`/`forkDaemon`) + `util/orgUtil.ts` `checkForSoonToBeExpiredOrgs` (`Effect.fn`, `AggregatorReloadError` = `Schema.TaggedError`) run at activation.


### PR DESCRIPTION
### What does this PR do?
Spreads `effectEsmConditions` into the `salesforcedx-vscode-org` node esbuild config so `effect` resolves to its ESM (`dist/esm/*`) submodules instead of CJS, letting unused submodules tree-shake out. Output remains CJS (no `import.meta`, no top-level ESM) — only the resolution condition changes.

- `dist/index.js`: 5,750,671 → 5,060,350 bytes (-690,321, -12.0%)
- `effect` inputs in `dist/node-metafile.json`: cjs 361 → 0, esm 0 → 361
- Added `../../scripts/bundling/effect.mjs` to the `vscode:bundle` wireit `files` list for cache invalidation

### What issues does this PR fix or reference?
@W-23313213@

### Functionality Before
N/A — internal bundling change, no user-visible behavior change.

### Functionality After
N/A — internal bundling change, no user-visible behavior change.

## Plan
plans/W-23313213.md

## Test plan
- [ ] `dist/node-metafile.json`: effect inputs now `dist/esm/*`, 0 cjs
- [ ] Output still CJS: grep bundle — no `import.meta`, no top-level ESM
- [ ] `node --check esbuild.config.mjs`
- [ ] `npm run test:desktop -w salesforcedx-vscode-org` — REQUIRED, suite passes before opening PR (at-risk specs: `orgDisplay.desktop.spec.ts`, `orgListClean.desktop.spec.ts`, `orgPicker.desktop.spec.ts`, `orgPickers.desktop.spec.ts`, `orgOpen.desktop.spec.ts`, `orgDeleteUsername.desktop.spec.ts`, `orgDeleteCommandVisibility.desktop.spec.ts`, `orgLoginAccessToken.desktop.spec.ts`, `orgLoginWeb.desktop.spec.ts`, `orgCommands.desktop.spec.ts`, `telemetryIdentitySeeding.desktop.spec.ts`)

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002dyKKfYAM/view