### PR TITLE
build(deps): bump @salesforce/source-deploy-retrieve to 12.37.0 - W-23397001

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8880,12 +8880,12 @@
       "link": true
     },
     "node_modules/@salesforce/source-deploy-retrieve": {
-      "version": "12.35.10",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.35.10.tgz",
-      "integrity": "sha512-njg3pt0aqwUF5xCleO6wMN45+AIbhpG9xOExWz3io+Qy2uWW75WoHdcj3ZTZFLKqyHBc2NNSfDJc+QYEnJccGg==",
+      "version": "12.37.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.37.0.tgz",
+      "integrity": "sha512-t8c+hOG3G8d8SozvZo+HK38R3HkYT8eEO9INi4Aum4LWP0nZDDqt0PbU8j8YLWLPixWfhoaHb+Wzp92xn3RY2A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@salesforce/core": "^8.30.3",
+        "@salesforce/core": "^8.31.4",
         "@salesforce/kit": "^3.2.4",
         "@salesforce/ts-types": "^2.0.12",
         "@salesforce/types": "^1.6.0",
@@ -8898,7 +8898,7 @@
         "mime": "2.6.0",
         "minimatch": "^9.0.9",
         "proxy-agent": "^6.5.0",
-        "yaml": "^2.8.3"
+        "yaml": "^2.9.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -44998,7 +44998,7 @@
       },
       "devDependencies": {
         "@salesforce/playwright-vscode-ext": "*",
-        "@salesforce/source-deploy-retrieve": "^12.32.5",
+        "@salesforce/source-deploy-retrieve": "^12.37.0",
         "salesforcedx-vscode-services": "*"
       },
       "engines": {
@@ -45015,7 +45015,7 @@
         "@salesforce/o11y-reporter": "^1.8.5",
         "@salesforce/salesforcedx-utils": "*",
         "@salesforce/salesforcedx-utils-vscode": "*",
-        "@salesforce/source-deploy-retrieve": "^12.32.5",
+        "@salesforce/source-deploy-retrieve": "^12.37.0",
         "@salesforce/templates": "^66.10.4",
         "@salesforce/ts-types": "^2.0.12",
         "@salesforce/vscode-i18n": "*",
@@ -45124,7 +45124,7 @@
       },
       "devDependencies": {
         "@salesforce/playwright-vscode-ext": "*",
-        "@salesforce/source-deploy-retrieve": "^12.32.5",
+        "@salesforce/source-deploy-retrieve": "^12.37.0",
         "@salesforce/source-tracking": "^7.8.16",
         "@salesforce/types": "^1.8.0",
         "salesforcedx-vscode-services": "*"
@@ -45169,7 +45169,7 @@
       "devDependencies": {
         "@salesforce/core": "^8.32.2",
         "@salesforce/playwright-vscode-ext": "*",
-        "@salesforce/source-deploy-retrieve": "^12.32.5",
+        "@salesforce/source-deploy-retrieve": "^12.37.0",
         "salesforcedx-vscode-services": "*"
       },
       "engines": {
@@ -45195,7 +45195,7 @@
         "@opentelemetry/sdk-trace-web": "2.8.0",
         "@salesforce/core": "^8.32.2",
         "@salesforce/o11y-reporter": "^1.8.5",
-        "@salesforce/source-deploy-retrieve": "^12.32.5",
+        "@salesforce/source-deploy-retrieve": "^12.37.0",
         "@salesforce/source-tracking": "^7.8.16",
         "@salesforce/templates": "^66.10.4",
         "@salesforce/vscode-i18n": "*",
@@ -45229,7 +45229,7 @@
         "@opentelemetry/sdk-trace-node": "2.7.1",
         "@opentelemetry/sdk-trace-web": "2.8.0",
         "@salesforce/core": "^8.32.2",
-        "@salesforce/source-deploy-retrieve": "^12.32.5",
+        "@salesforce/source-deploy-retrieve": "^12.37.0",
         "@salesforce/source-tracking": "^7.8.16",
         "@types/vscode": "^1.90.0",
         "effect": "^3.21.2",

--- a/packages/salesforcedx-vscode-apex-testing/package.json
+++ b/packages/salesforcedx-vscode-apex-testing/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@salesforce/playwright-vscode-ext": "*",
-    "@salesforce/source-deploy-retrieve": "^12.32.5",
+    "@salesforce/source-deploy-retrieve": "^12.37.0",
     "salesforcedx-vscode-services": "*"
   },
   "extensionDependencies": [

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -33,7 +33,7 @@
     "@salesforce/o11y-reporter": "^1.8.5",
     "@salesforce/salesforcedx-utils": "*",
     "@salesforce/salesforcedx-utils-vscode": "*",
-    "@salesforce/source-deploy-retrieve": "^12.32.5",
+    "@salesforce/source-deploy-retrieve": "^12.37.0",
     "@salesforce/templates": "^66.10.4",
     "@salesforce/ts-types": "^2.0.12",
     "@salesforce/vscode-i18n": "*",

--- a/packages/salesforcedx-vscode-metadata/package.json
+++ b/packages/salesforcedx-vscode-metadata/package.json
@@ -34,7 +34,7 @@
     "vscode-uri": "^3.1.0"
   },
   "devDependencies": {
-    "@salesforce/source-deploy-retrieve": "^12.32.5",
+    "@salesforce/source-deploy-retrieve": "^12.37.0",
     "@salesforce/source-tracking": "^7.8.16",
     "@salesforce/types": "^1.8.0",
     "@salesforce/playwright-vscode-ext": "*",

--- a/packages/salesforcedx-vscode-org-browser/package.json
+++ b/packages/salesforcedx-vscode-org-browser/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@salesforce/core": "^8.32.2",
     "@salesforce/playwright-vscode-ext": "*",
-    "@salesforce/source-deploy-retrieve": "^12.32.5",
+    "@salesforce/source-deploy-retrieve": "^12.37.0",
     "salesforcedx-vscode-services": "*"
   },
   "extensionDependencies": [

--- a/packages/salesforcedx-vscode-services-types/package.json
+++ b/packages/salesforcedx-vscode-services-types/package.json
@@ -76,7 +76,7 @@
     "@opentelemetry/sdk-trace-node": "2.7.1",
     "@opentelemetry/sdk-trace-web": "2.8.0",
     "@salesforce/core": "^8.32.2",
-    "@salesforce/source-deploy-retrieve": "^12.32.5",
+    "@salesforce/source-deploy-retrieve": "^12.37.0",
     "@salesforce/source-tracking": "^7.8.16",
     "@types/vscode": "^1.90.0",
     "effect": "^3.21.2",

--- a/packages/salesforcedx-vscode-services/package.json
+++ b/packages/salesforcedx-vscode-services/package.json
@@ -42,7 +42,7 @@
     "@opentelemetry/sdk-trace-web": "2.8.0",
     "@salesforce/core": "^8.32.2",
     "@salesforce/o11y-reporter": "^1.8.5",
-    "@salesforce/source-deploy-retrieve": "^12.32.5",
+    "@salesforce/source-deploy-retrieve": "^12.37.0",
     "@salesforce/source-tracking": "^7.8.16",
     "@salesforce/templates": "^66.10.4",
     "@salesforce/vscode-i18n": "*",


### PR DESCRIPTION
## What does this PR do?

Bumps `@salesforce/source-deploy-retrieve` from `^12.32.5` to `^12.37.0` across multiple packages to add support for the UiWidgetBundle metadata object.

## What issues does this PR fix or reference?

@W-23397001@

## Before

Packages used `@salesforce/source-deploy-retrieve` `^12.32.5`, which lacked UiWidgetBundle support.

## After

Packages now use `@salesforce/source-deploy-retrieve` `^12.37.0`, enabling UiWidgetBundle metadata operations.