### PR TITLE
refactor(apex): remove redundant WorkspaceContext.initialize call - W-23348776

### DIFF
--- a/.claude/skills/external-consumers/SKILL.md
+++ b/.claude/skills/external-consumers/SKILL.md
@@ -78,7 +78,7 @@ Always grep for `\.exports\.\w+` across the full monorepo, not just `coreExtensi
 
 | Package | Files | Members accessed |
 |---------|-------|------------------|
-| apex | `coreExtensionUtils.ts`, `index.ts`, `languageServer.ts` | `.WorkspaceContext`, `.services.TelemetryService`, `.getAuthFields` |
+| apex | `coreExtensionUtils.ts`, `index.ts`, `languageServer.ts` | `.services.TelemetryService`, `.getAuthFields` |
 | apex-debugger | `coreExtensionUtils.ts`, `index.ts`, `debugConfigurationProvider.ts` | `.channelService`, `.SfCommandlet`, `.telemetryService`, `.SfCommandletExecutor` |
 | utils-vscode | `authUtils.ts`, `workspaceContextUtil.ts`, `telemetryUtils.ts` | `.sharedAuthState`, `.channelService`, `.getSharedTelemetryUserId` (phantom — not on API type) |
 

--- a/packages/salesforcedx-vscode-apex/src/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/index.ts
@@ -53,7 +53,6 @@ export const activateEffect = Effect.fn('activation:salesforcedx-vscode-apex')(f
   context: vscode.ExtensionContext
 ) {
   const vscodeCoreExtension = yield* Effect.promise(() => getVscodeCoreExtension());
-  const workspaceContext = vscodeCoreExtension.exports.WorkspaceContext.getInstance();
 
   // Telemetry
   const pjson = yield* Schema.decodeUnknown(ExtensionPackageJsonSchema)(context.extension.packageJSON).pipe(
@@ -69,9 +68,6 @@ export const activateEffect = Effect.fn('activation:salesforcedx-vscode-apex')(f
   // fails with the typed NoWorkspaceOpenError from WorkspaceService when no workspace is open
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   yield* (yield* api.services.WorkspaceService).getWorkspaceInfoOrThrow();
-
-  // Workspace Context
-  yield* Effect.promise(() => workspaceContext.initialize(context));
 
   // start the language server and client
   const languageServerStatusBarItem = new ApexLSPStatusBarItem();

--- a/packages/salesforcedx-vscode-apex/test/jest/index.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/index.test.ts
@@ -7,13 +7,11 @@
 import * as vscode from 'vscode';
 
 // Mock vscode.extensions.getExtension before any imports that trigger src/index.ts
-const mockWorkspaceContext = { initialize: jest.fn() };
 const mockTelemetryService = {
   initializeService: jest.fn(),
   sendExtensionDeactivationEvent: jest.fn()
 };
 const mockCoreExports = {
-  WorkspaceContext: { getInstance: () => mockWorkspaceContext },
   services: { TelemetryService: { getInstance: () => mockTelemetryService } }
 };
 const mockExtension = { exports: mockCoreExports, isActive: true };

--- a/plans/W-23348776.md
+++ b/plans/W-23348776.md
@@ -1,0 +1,38 @@
+# W-23348776 — Remove redundant WorkspaceContext.initialize from Apex activation
+
+## Context
+
+- File: `packages/salesforcedx-vscode-apex/src/index.ts`
+- Core (extensionDependency) activates first, initializes `WorkspaceContext` singleton
+- `initialize` idempotent; apex passes own context → telemetry side-effect (guarded on core ext id) never fires for apex
+- Apex never reads username/orgId/onOrgChange → safe to drop
+- NOTE: WI cites "index.ts:55-56,74" but line 55 (`getVscodeCoreExtension`) still needed for telemetry (line 62). Only remove:
+  - L56 `const workspaceContext = vscodeCoreExtension.exports.WorkspaceContext.getInstance();`
+  - L73-74 `// Workspace Context` comment + `yield* Effect.promise(() => workspaceContext.initialize(context));`
+- Keep `vscodeCoreExtension` binding
+
+## Phases
+
+### Phase 1 — remove call + dead test mock
+
+- src/index.ts: delete `workspaceContext` const (L56) + `// Workspace Context` + `initialize` call (L73-74)
+- test/jest/index.test.ts: drop now-unused `mockWorkspaceContext` (L10) + `WorkspaceContext: { getInstance: ... }` (L16) from `mockCoreExports`
+- commit: `refactor(apex): drop redundant WorkspaceContext.initialize from activation - W-23348776`
+
+## Skills to apply
+
+- concise (plan/docs)
+- typescript
+- core-extension-api (core ext consumption boundary)
+- unit-test-critic (test mock removal)
+- verification
+
+## Verification
+
+- `node --check` n/a (TS)
+- typecheck/lint apex pkg
+- jest `index.test.ts` — activate tests pass (no-workspace throw, telemetry-fail throw), no core-init race
+- grep confirms 0 remaining `WorkspaceContext`/`workspaceContext` refs in apex src
+- e2e activation gate: `packages/salesforcedx-vscode-apex/test/playwright/specs/apexLsp.desktop.spec.ts` — `waitForApexLspReady` only resolves if `activateEffect` completes (LSP client is created at index.ts L79, downstream of the removed WorkspaceContext step); if the removal broke activation, LSP never becomes ready and this spec fails. Same gate in apexLspHover/apexLspRestart/apexSnippets desktop specs.
+- COVERAGE GAP (do not overclaim): no spec asserts on WorkspaceContext init count or apex-vs-core activation ordering, and jest `index.test.ts` mocks `getExtension` synchronously so it cannot surface a timing/ordering regression. This change is safe without new ordering coverage because it *removes* a redundant idempotent call (core already inits the singleton first; apex never reads username/orgId/onOrgChange — see Context) rather than reordering activation. No new activation-ordering behavior is introduced, so no new ordering spec is required.
+- run the apexLsp.desktop.spec on this branch before merge (do not skip as "branch e2e"); confirm green

--- a/plans/W-23348776.md
+++ b/plans/W-23348776.md
@@ -6,7 +6,7 @@
 - Core (extensionDependency) activates first, initializes `WorkspaceContext` singleton
 - `initialize` idempotent; apex passes own context → telemetry side-effect (guarded on core ext id) never fires for apex
 - Apex never reads username/orgId/onOrgChange → safe to drop
-- NOTE: WI cites "index.ts:55-56,74" but line 55 (`getVscodeCoreExtension`) still needed for telemetry (line 62). Only remove:
+- NOTE: WI cites L55-56,74 but L55 (`getVscodeCoreExtension`) still needed for telemetry (L62) — remove only:
   - L56 `const workspaceContext = vscodeCoreExtension.exports.WorkspaceContext.getInstance();`
   - L73-74 `// Workspace Context` comment + `yield* Effect.promise(() => workspaceContext.initialize(context));`
 - Keep `vscodeCoreExtension` binding
@@ -33,6 +33,6 @@
 - typecheck/lint apex pkg
 - jest `index.test.ts` — activate tests pass (no-workspace throw, telemetry-fail throw), no core-init race
 - grep confirms 0 remaining `WorkspaceContext`/`workspaceContext` refs in apex src
-- e2e activation gate: `packages/salesforcedx-vscode-apex/test/playwright/specs/apexLsp.desktop.spec.ts` — `waitForApexLspReady` only resolves if `activateEffect` completes (LSP client is created at index.ts L79, downstream of the removed WorkspaceContext step); if the removal broke activation, LSP never becomes ready and this spec fails. Same gate in apexLspHover/apexLspRestart/apexSnippets desktop specs.
-- COVERAGE GAP (do not overclaim): no spec asserts on WorkspaceContext init count or apex-vs-core activation ordering, and jest `index.test.ts` mocks `getExtension` synchronously so it cannot surface a timing/ordering regression. This change is safe without new ordering coverage because it *removes* a redundant idempotent call (core already inits the singleton first; apex never reads username/orgId/onOrgChange — see Context) rather than reordering activation. No new activation-ordering behavior is introduced, so no new ordering spec is required.
+- e2e activation gate: `packages/salesforcedx-vscode-apex/test/playwright/specs/apexLsp.desktop.spec.ts` — `waitForApexLspReady` only resolves if `activateEffect` completes (LSP client created L79, downstream of removed step); broken activation → spec never goes ready, fails. Same gate in apexLspHover/apexLspRestart/apexSnippets desktop specs.
+- COVERAGE GAP: no spec asserts WorkspaceContext init count/ordering; jest `index.test.ts` mocks `getExtension` synchronously so can't catch timing regressions. Safe: call removed, not reordered — apex never reads username/orgId/onOrgChange (see Context).
 - run the apexLsp.desktop.spec on this branch before merge (do not skip as "branch e2e"); confirm green


### PR DESCRIPTION
## Summary

- Removed the redundant `WorkspaceContext.getInstance()` + `.initialize(context)` call from Apex activation (`packages/salesforcedx-vscode-apex/src/index.ts`)
- Core (an extensionDependency) already initializes the singleton on its own activation before Apex runs; `initialize` is idempotent and Apex never reads username/orgId/onOrgChange
- Dropped the now-unused `mockWorkspaceContext` test stub in `index.test.ts`

## Plan

See [plans/W-23348776.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23348776-4-remove-redundant-workspacecontext-init/plans/W-23348776.md)

## Reviewer notes

- **Low:** Commit touches both `src` (`index.ts`) and `test` (`index.test.ts`), technically pairing a src change with a test change. No action taken — the removed test stub `mockWorkspaceContext` is never asserted on (inert stub only), so this is a zero-risk mechanical pairing; splitting the PR gives no reviewer benefit.

## Test plan

- typecheck/lint apex package
- jest `index.test.ts` — activate tests pass (no-workspace throw, telemetry-fail throw), no core-init race
- grep confirms 0 remaining `WorkspaceContext`/`workspaceContext` refs in apex src
- Not e2e-covered on this branch: `apexLsp.desktop.spec.ts` (and apexLspHover/apexLspRestart/apexSnippets desktop specs) gate activation via `waitForApexLspReady`; run before merge to confirm green
- COVERAGE GAP: no spec asserts WorkspaceContext init count/ordering; jest mocks `getExtension` synchronously so timing regressions aren't caught. Considered safe: call removed, not reordered — Apex never reads username/orgId/onOrgChange

### What issues does this PR fix or reference?

@W-23348776@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002e9pgKYAQ/view
