### PR TITLE
refactor(apex): migrate langServer org-namespace read to services ConnectionService - W-23348771

### DIFF
--- a/.claude/plans/W-23348771.md
+++ b/.claude/plans/W-23348771.md
@@ -30,8 +30,15 @@
 - `npm run compile` (or wireit) in apex pkg — typecheck, confirm no unused import.
 - eslint apex pkg — no lint errors.
 - Jest: `namespaceLensRewriter.test.ts`, `index.test.ts` still pass (no logic change to rewriter).
-- e2e (local pre-PR run): behavior-preserving read-source swap. Only changes where `nsFromOrg` is read (`getAuthFields().namespacePrefix` → `ConnectionService.getConnection().getAuthInfoFields().namespacePrefix`); both delegate to the same services `ConnectionService` auth-file read, and the `nsFromOrg`/`nsFromProject` values fed to `rewriteNamespaceLens` are unchanged. Regression backstop for the `provideCodeLenses` `Promise.all` plumbing touched here — run these locally before PR:
-  - `packages/salesforcedx-vscode-apex-testing/test/playwright/specs/runApexTestsCodeLens.headless.spec.ts` — clicks 'Run All Tests'/'Run Test' lenses; these don't render if the `Promise.all` rejects, so a broken org-namespace read fails the spec.
-  - codeLens clicks in `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/{debugApexTests,apexReplayDebugger}.desktop.spec.ts`.
+- e2e (local pre-PR run): behavior-preserving read-source swap.
+  - Only changes where `nsFromOrg` is read (`getAuthFields().namespacePrefix` → `ConnectionService.getConnection().getAuthInfoFields().namespacePrefix`) — same auth-file read per Context line 7.
+  - `nsFromOrg`/`nsFromProject` fed to `rewriteNamespaceLens` unchanged.
+  - Regression backstop for the `provideCodeLenses` `Promise.all` plumbing touched here — run these locally before PR:
+    - `packages/salesforcedx-vscode-apex-testing/test/playwright/specs/runApexTestsCodeLens.headless.spec.ts` — clicks 'Run All Tests'/'Run Test' lenses; these don't render if the `Promise.all` rejects, so a broken org-namespace read fails the spec.
+    - codeLens clicks in `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/{debugApexTests,apexReplayDebugger}.desktop.spec.ts`.
   - No new/changed observable behavior → no new named spec required.
-- Pre-existing gap (NOT introduced by this WI, non-blocking): the namespace-rewrite branch of `rewriteNamespaceLens` is untested e2e — every scratch-org fixture (`packages/playwright-vscode-ext/src/orgs/{minimalScratchOrgSetup,nonTrackingScratchOrgSetup}.ts`) sets `namespace: ''`, so the rewrite path (which consumes the migrated org namespace) never fires. Jest `packages/salesforcedx-vscode-apex/test/jest/namespaceLensRewriter.test.ts` covers the pure rewrite fn. This WI leaves that gap as-is.
+- Pre-existing gap (NOT introduced here, non-blocking):
+  - namespace-rewrite branch of `rewriteNamespaceLens` untested e2e.
+  - All scratch-org fixtures (`packages/playwright-vscode-ext/src/orgs/{minimalScratchOrgSetup,nonTrackingScratchOrgSetup}.ts`) set `namespace: ''` → rewrite path never fires.
+  - Jest `packages/salesforcedx-vscode-apex/test/jest/namespaceLensRewriter.test.ts` covers the pure fn.
+  - Left as-is.

--- a/.claude/plans/W-23348771.md
+++ b/.claude/plans/W-23348771.md
@@ -1,0 +1,37 @@
+# W-23348771 — Migrate langServer org-namespace read to services ConnectionService
+
+## Context
+- File: `packages/salesforcedx-vscode-apex/src/languageServer.ts`
+- `provideCodeLenses` reads org namespace via `vscodeCoreExtension.exports.getAuthFields().namespacePrefix` (line 242).
+- Replace w/ services `ConnectionService.getConnection().getAuthInfoFields().namespacePrefix`.
+- Behavior-identical: `getAuthFields` in core already delegates to `api.services.ConnectionService.getConnection().getAuthInfoFields()` (`orgAuthInfoExtensions.ts:38-41`) — auth-file read, no live query.
+- Mirror sibling `getNamespaceFromProject` (line 228-232, PR #7677): Effect.fn via `(yield* ExtensionProviderService).getServicesApi` → `api.services.ConnectionService`.
+- `getVscodeCoreExtension` (import line 23) used ONLY at 239/242 → drop import after migration.
+- `namespacePrefix` type `string | null` → coerce `?? undefined` (matches existing).
+
+## Phases
+
+### Phase 1 — migrate namespace-from-org read to ConnectionService
+- Add `getNamespaceFromOrg` Effect.fn mirroring `getNamespaceFromProject`:
+  - `const api = yield* (yield* ExtensionProviderService).getServicesApi;`
+  - `const conn = yield* api.services.ConnectionService.getConnection();`
+  - `return conn.getAuthInfoFields().namespacePrefix ?? undefined;`
+- In `provideCodeLenses`: swap line 242 for `getRuntime().runPromise(getNamespaceFromOrg())`.
+- Remove `getVscodeCoreExtension()` call (239) + import (23) — now unused.
+- Commit: `refactor(apex): migrate langServer org namespace read to services ConnectionService - W-23348771`
+
+## Skills to apply
+- services-extension-consumption — `getServicesApi` / `api.services.*` pattern
+- effect-best-practices — Effect.fn, generator style
+- typescript — build/lint
+- verification — pre-commit checks
+
+## Verification
+- `npm run compile` (or wireit) in apex pkg — typecheck, confirm no unused import.
+- eslint apex pkg — no lint errors.
+- Jest: `namespaceLensRewriter.test.ts`, `index.test.ts` still pass (no logic change to rewriter).
+- e2e (local pre-PR run): behavior-preserving read-source swap. Only changes where `nsFromOrg` is read (`getAuthFields().namespacePrefix` → `ConnectionService.getConnection().getAuthInfoFields().namespacePrefix`); both delegate to the same services `ConnectionService` auth-file read, and the `nsFromOrg`/`nsFromProject` values fed to `rewriteNamespaceLens` are unchanged. Regression backstop for the `provideCodeLenses` `Promise.all` plumbing touched here — run these locally before PR:
+  - `packages/salesforcedx-vscode-apex-testing/test/playwright/specs/runApexTestsCodeLens.headless.spec.ts` — clicks 'Run All Tests'/'Run Test' lenses; these don't render if the `Promise.all` rejects, so a broken org-namespace read fails the spec.
+  - codeLens clicks in `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/{debugApexTests,apexReplayDebugger}.desktop.spec.ts`.
+  - No new/changed observable behavior → no new named spec required.
+- Pre-existing gap (NOT introduced by this WI, non-blocking): the namespace-rewrite branch of `rewriteNamespaceLens` is untested e2e — every scratch-org fixture (`packages/playwright-vscode-ext/src/orgs/{minimalScratchOrgSetup,nonTrackingScratchOrgSetup}.ts`) sets `namespace: ''`, so the rewrite path (which consumes the migrated org namespace) never fires. Jest `packages/salesforcedx-vscode-apex/test/jest/namespaceLensRewriter.test.ts` covers the pure rewrite fn. This WI leaves that gap as-is.

--- a/packages/salesforcedx-vscode-apex/src/languageServer.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageServer.ts
@@ -224,16 +224,16 @@ const buildClientOptions = async (outputChannel?: vscode.OutputChannel): Promise
   return options;
 };
 
-const getNamespaceFromProject = Effect.fn('apex.provideCodeLenses.getNamespaceFromProject')(function* () {
+const getNamespaces = Effect.fn('apex.provideCodeLenses.getNamespaces')(function* () {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
-  const project = yield* api.services.ProjectService.getSfProject();
-  return project.getSfProjectJson().getContents().namespace;
-});
-
-const getNamespaceFromOrg = Effect.fn('apex.provideCodeLenses.getNamespaceFromOrg')(function* () {
-  const api = yield* (yield* ExtensionProviderService).getServicesApi;
-  const conn = yield* api.services.ConnectionService.getConnection();
-  return conn.getAuthInfoFields().namespacePrefix ?? undefined;
+  const [conn, project] = yield* Effect.all(
+    [api.services.ConnectionService.getConnection(), api.services.ProjectService.getSfProject()],
+    { concurrency: 'unbounded' }
+  );
+  return {
+    nsFromOrg: conn.getAuthInfoFields().namespacePrefix ?? undefined,
+    nsFromProject: project.getSfProjectJson().getContents().namespace
+  };
 });
 
 const provideCodeLenses = async (
@@ -241,9 +241,8 @@ const provideCodeLenses = async (
   token: vscode.CancellationToken,
   next: ProvideCodeLensesSignature
 ) => {
-  const [nsFromOrg, nsFromProject, lenses] = await Promise.all([
-    getRuntime().runPromise(getNamespaceFromOrg()),
-    getRuntime().runPromise(getNamespaceFromProject()),
+  const [{ nsFromOrg, nsFromProject }, lenses] = await Promise.all([
+    getRuntime().runPromise(getNamespaces()),
     next(document, token)
   ]);
   return lenses?.map(rewriteNamespaceLens(nsFromOrg)(nsFromProject));

--- a/packages/salesforcedx-vscode-apex/src/languageServer.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageServer.ts
@@ -20,7 +20,6 @@ import { URI } from 'vscode-uri';
 import { ApexErrorHandler } from './apexErrorHandler';
 import { ApexLanguageClient } from './apexLanguageClient';
 import { LSP_ERR, UBER_JAR_NAME } from './constants';
-import { getVscodeCoreExtension } from './coreExtensionUtils';
 import { soqlMiddleware } from './embeddedSoql';
 import { buildMetadataRegistryScanConfig } from './languageServerScanConfig';
 import { nls } from './messages';
@@ -231,15 +230,19 @@ const getNamespaceFromProject = Effect.fn('apex.provideCodeLenses.getNamespaceFr
   return project.getSfProjectJson().getContents().namespace;
 });
 
+const getNamespaceFromOrg = Effect.fn('apex.provideCodeLenses.getNamespaceFromOrg')(function* () {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const conn = yield* api.services.ConnectionService.getConnection();
+  return conn.getAuthInfoFields().namespacePrefix ?? undefined;
+});
+
 const provideCodeLenses = async (
   document: vscode.TextDocument,
   token: vscode.CancellationToken,
   next: ProvideCodeLensesSignature
 ) => {
-  const vscodeCoreExtension = await getVscodeCoreExtension();
   const [nsFromOrg, nsFromProject, lenses] = await Promise.all([
-    // convert null to undefined
-    vscodeCoreExtension.exports.getAuthFields().then(fields => fields.namespacePrefix ?? undefined),
+    getRuntime().runPromise(getNamespaceFromOrg()),
     getRuntime().runPromise(getNamespaceFromProject()),
     next(document, token)
   ]);


### PR DESCRIPTION
<!--- PR title: refactor(apex): migrate langServer org-namespace read to services ConnectionService - W-23348771 --->

### What does this PR do?

## Summary
- `languageServer.ts` `provideCodeLenses` now reads org namespace via `ConnectionService.getConnection().getAuthInfoFields().namespacePrefix` instead of `vscodeCoreExtension.exports.getAuthFields()`.
- Behavior-identical: both paths read the same auth-file `namespacePrefix`, no live org query.
- Drops the now-unused `getVscodeCoreExtension` import/call; mirrors the sibling `getNamespaceFromProject` pattern (#7677).

## Plan
[.claude/plans/W-23348771.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23348771-3-repo-forcedotcom-salesforcedx-vscode-m/.claude/plans/W-23348771.md)

### What issues does this PR fix or reference?
@W-23348771@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002e9Ff2YAE/view
