### PR TITLE
fix(auto-build-wi): epic-siblings sequencing query truncates at LIMIT 200 - W-23402143

### DIFF
--- a/.claude/workflows/auto-build-wi.js
+++ b/.claude/workflows/auto-build-wi.js
@@ -793,15 +793,16 @@ HARD RULES:
 - Do NOT run any other queries. Zero records is valid — return {records: []}.
 - Do NOT modify the WHERE clause or transform fields.`
 
-// Numeric-sequencing gate: fetch every WI in the given epics so we can read their dotted
+// Numeric-sequencing gate: fetch every WI in ONE epic so we can read their dotted
 // Subject__c prefixes + Status. NO open-only filter — a satisfied prerequisite is Closed,
-// which an open-only WHERE would hide (skill ## Reading, step 1).
-const epicSiblingsQueryPrompt = epicIds =>
+// which an open-only WHERE would hide (skill ## Reading, step 1). Queried per-epic (not
+// batched across epics) — a single combined query capped at LIMIT 200 can fill entirely
+// from one large epic and silently return zero rows for another, making that epic's
+// unfinished siblings invisible to the gate.
+const epicSiblingsQueryPrompt = epicId =>
   `Run EXACTLY ONE SOQL query — the one below — and return its records.
 
-sf data query --query "SELECT Name, Subject__c, Status__c, Epic__c FROM ADM_Work__c WHERE Epic__c IN (${epicIds
-    .map(id => `'${id}'`)
-    .join(',')}) LIMIT 200" -o gus --result-format json
+sf data query --query "SELECT Name, Subject__c, Status__c, Epic__c FROM ADM_Work__c WHERE Epic__c = '${epicId}' LIMIT 200" -o gus --result-format json
 
 Return {records: <result.records, verbatim>}.
 
@@ -1383,24 +1384,30 @@ const pickCandidate = async (identity, inFlightWis) => {
   // same-first-segment siblings (1.1, 1.2) run in PARALLEL. So gate on the TOP segment only —
   // a candidate is blocked iff its epic still holds an UNFINISHED WI with a strictly-smaller
   // leading integer (done = Closed/Completed, reusing isBlockerSatisfied). Unnumbered
-  // candidates are always ready; candidates without an epic can't be sequenced. One batched
-  // query per the distinct epics in play, fetched WITHOUT an open-only filter so Closed
-  // prerequisites are visible.
+  // candidates are always ready; candidates without an epic can't be sequenced. One query PER
+  // distinct epic in play (not batched — a shared LIMIT 200 across epics can silently starve
+  // a large epic of its own rows), fetched WITHOUT an open-only filter so Closed prerequisites
+  // are visible.
   const seqCandidates = candidateList
     .map(c => ({ c, seq: parseSequence(c.subject) }))
     .filter(({ c, seq }) => seq && c.epicId)
   const seqEpicIds = [...new Set(seqCandidates.map(({ c }) => c.epicId))]
   if (seqEpicIds.length) {
-    const epicRaw = await agent(epicSiblingsQueryPrompt(seqEpicIds), {
-      schema: EPIC_WI_RECORDS_SCHEMA,
-      label: 'query-epic-siblings',
-      phase: 'Pick candidate',
-      model: 'haiku',
-    })
+    const epicRawByEpic = await parallel(
+      seqEpicIds.map(epicId => () =>
+        agent(epicSiblingsQueryPrompt(epicId), {
+          schema: EPIC_WI_RECORDS_SCHEMA,
+          label: `query-epic-siblings-${epicId}`,
+          phase: 'Pick candidate',
+          model: 'haiku',
+        })
+      )
+    )
+    const epicRecords = epicRawByEpic.filter(Boolean).flatMap(r => r.records || [])
     // Per epic: the smallest top-level integer among UNFINISHED numbered WIs. A candidate
     // whose own top segment exceeds that minimum is gated behind unfinished earlier work.
     // Unnumbered WIs neither gate nor are gated; done (Closed/Completed) WIs don't gate.
-    const minUnfinishedTopByEpic = (epicRaw.records || [])
+    const minUnfinishedTopByEpic = epicRecords
       .map(r => ({ epicId: r.Epic__c || '', top: topSegment(parseSequence(r.Subject__c)), status: r.Status__c || '' }))
       .filter(r => r.top !== null && !isBlockerSatisfied(r.status))
       .reduce((m, r) => {


### PR DESCRIPTION
### What does this PR do?

## Summary
- `epicSiblingsQueryPrompt` batched every candidate epic into one SOQL query capped at a single `LIMIT 200`. When the combined result set across epics exceeded 200 rows, some requested epics got zero rows back — silently, with no truncation signal.
- Downstream, the numeric-sequencing gate's `minUnfinishedTopByEpic` map had no entry for a truncated-out epic, so it read "no rows" as "no unfinished siblings" and let a higher-numbered (lower-priority) WI through even though an earlier-numbered sibling in the same epic was still unfinished.
- Concretely: W-23348771 (subject prefix "3") was picked and claimed by an `/auto-build-wi` tick while W-23348768 ("2", same epic) was still `Status = New`.
- Fix: query epic-siblings per-epic (each with its own `LIMIT 200`, fetched in parallel) instead of one batched query across all epics, so a large result set for one epic can't crowd out another epic's rows.

## Test plan
- [x] `node --check .claude/workflows/auto-build-wi.js` — syntax valid
- [x] Manual read-through: confirmed `epicSiblingsQueryPrompt` now takes a single `epicId`, the call site fans out via `parallel()` over `seqEpicIds`, and results are flattened before feeding `minUnfinishedTopByEpic` — behavior for the single-epic case is unchanged
- [x] Full repo `precommit`/`prepush` wireit pipeline (build/lint/test) green

### What issues does this PR fix or reference?
@W-23402143@

### Functionality Before
`/auto-build-wi`'s numeric-sequencing gate silently passed candidates when their epic's sibling rows were crowded out of a batched, LIMIT-200 query — could claim/build a lower-priority WI ahead of an unfinished earlier-numbered sibling.

### Functionality After
Sequencing gate queries each epic separately, so truncation in one epic can't blind the gate to another epic's unfinished work.