### PR TITLE
fix(observability): gate telemetry exporters per-export instead of per-Layer - W-23369387

### DIFF
--- a/.claude/plans/W-23369387.md
+++ b/.claude/plans/W-23369387.md
@@ -1,0 +1,133 @@
+# W-23369387 — move telemetry-enabled check to per-export gate
+
+## Context
+
+- Bug: toggling `salesforcedx-vscode-core.telemetry.enabled` mid-session = no effect until reload (OTEL span-exporter path).
+- Root cause: `isTelemetryExtensionConfigurationEnabled()` (observability/appInsights.ts) called at Layer-build time to decide whether exporter enters `spanProcessor` array. Array frozen at build; nothing re-adds excluded exporter.
+- 4 construction-time call sites:
+  - `spansNode.ts:78` — App Insights (dependencies via `FilteredAzureMonitorTraceExporter`, or customEvents via `ApplicationInsightsNodeExporter`)
+  - `spansNode.ts:101` — O11y (has `localhost` bypass)
+  - `spansWeb.ts:33` — App Insights web
+  - `spansWeb.ts:36` — O11y (web, `localhost` bypass)
+- Exporters (all per-span filter via `isSpanValidForProductionTelemetry`):
+  - `FilteredAzureMonitorTraceExporter` (spansNode.ts) — dependencies
+  - `ApplicationInsightsNodeExporter` — customEvents
+  - `ApplicationInsightsWebExporter`
+  - `O11ySpanExporter`
+- O11y localhost bypass must survive: O11y emits to localhost even when telemetry off (dev). O11y stores `this.endpoint`.
+- No import cycle: spanUtils → appInsights (appInsights doesn't import spanUtils). appInsights already imports vscode; web bundle already imports appInsights.
+- Dev/test: `isTelemetryExtensionConfigurationEnabled()` returns true (isLocalDivertMode short-circuit, appInsights.ts:40-42), so local divert unaffected.
+- AC: all 4 fixed in ONE PR (partial = one exporter silently broken) → single branch.
+
+### CRITICAL: Statsbeat — construction-time network side effect (why NOT "always construct")
+
+- Node App Insights exporters trigger **Azure Statsbeat background network reporting at construction, not at export**:
+  - `AzureMonitorTraceExporter` ctor builds `HttpSender` (node_modules/@azure/monitor-opentelemetry-exporter/dist/commonjs/export/trace.js:26).
+  - `ApplicationInsightsNodeExporter` ctor builds `AzureMonitorLogExporterWrapper` → `AzureMonitorLogExporter`, whose ctor builds `HttpSender` (…/export/log.js).
+  - `AzureMonitorBaseExporter` ctor sets `trackStatsbeat = !isStatsbeatExporter && !process.env['APPLICATION_INSIGHTS_NO_STATSBEAT']` (…/export/base.js:53) → true by default.
+  - `BaseSender` ctor (…/platform/nodejs/baseSender.js:25-37) then calls `NetworkStatsbeatMetrics.getInstance` / `LongIntervalStatsbeatMetrics.getInstance`, which schedule `PeriodicExportingMetricReader` network exports to Azure every 15 min / 1 day (…/export/statsbeat/networkStatsbeatMetrics.js:28-34).
+- Consequence: a naive "always construct, early-return inside `export()`" makes telemetry-**disabled** users emit background Statsbeat network egress to Microsoft that never happened before (today these exporters aren't constructed while disabled). Early-return runs too late — the ctor side effect already fired.
+- No per-exporter option disables Statsbeat — `trackStatsbeat` is fed only by `isStatsbeatExporter` (private 2nd ctor arg, not exposed) and the process-global env var `APPLICATION_INSIGHTS_NO_STATSBEAT`. Setting a global env var is a cross-consumer side effect (rejected).
+- O11y and web are NOT affected: `O11ySpanExporter` ctor only calls `O11yService.getInstance` (no network; net init deferred to `ensureInitialized` inside export); web reporter is a lazy singleton (`getWebAppInsightsReporter`, constructed on first send).
+- **Fix = lazy construction + per-export gate in one wrapper.** Keep prior "no construction while disabled" behavior (→ no Statsbeat while disabled), AND make the gate re-check per export so mid-session enable works. Construct the real exporter on the first *enabled* export, cache thereafter.
+
+## Phases
+
+### Phase 1 — gated + lazy exporter wrapper (all 4 sites)
+
+Commit: `fix(observability): gate telemetry exporters per-export not per-Layer - W-23369387`
+
+Files:
+
+- `packages/salesforcedx-vscode-services/src/observability/spanUtils.ts`
+  - import `isTelemetryExtensionConfigurationEnabled` from `./appInsights`
+  - add per-batch export gate (localhost bypass for O11y dev sink):
+    ```
+    /** Per-export telemetry gate; checked fresh each batch → honors mid-session toggle.
+        o11yEndpoint localhost bypasses the setting (dev sink). */
+    export const isProductionTelemetryExportEnabled = (o11yEndpoint?: string): boolean =>
+      Boolean(o11yEndpoint?.includes('localhost')) || isTelemetryExtensionConfigurationEnabled();
+    ```
+  - keep `isSpanValidForProductionTelemetry` pure (span-level filter unchanged)
+
+- new `packages/salesforcedx-vscode-services/src/observability/gatedSpanExporter.ts`
+  - `GatedSpanExporter implements SpanExporter` — single place that (a) gates per export, (b) lazily constructs + caches the delegate on first enabled export → NO delegate ctor runs while disabled (no Statsbeat/network setup):
+    ```
+    export class GatedSpanExporter implements SpanExporter {
+      private delegate: SpanExporter | undefined;
+      constructor(private readonly make: () => SpanExporter, private readonly o11yEndpoint?: string) {}
+      public export(spans: ReadableSpan[], cb: (r: ExportResult) => void): void {
+        if (!isProductionTelemetryExportEnabled(this.o11yEndpoint)) {
+          cb({ code: ExportResultCode.SUCCESS });
+          return;
+        }
+        (this.delegate ??= this.make()).export(spans, cb);
+      }
+      public shutdown(): Promise<void> { return this.delegate?.shutdown() ?? Promise.resolve(); }
+    }
+    ```
+  - `SpanExporter` has no `forceFlush` (that's on `SpanProcessor`) → only `export` + `shutdown` needed.
+
+- `spansNode.ts`
+  - :78 → AI processor ALWAYS in array, wrapped: `new SpanTransformProcessor(new GatedSpanExporter(() => enableCustomEventsFromSpans ? new ApplicationInsightsNodeExporter(...) : new FilteredAzureMonitorTraceExporter(...)))`. Delegate ctor (and its Statsbeat) fires only on first enabled export.
+  - :101 → O11y processor ALWAYS in array when `o11yEndpoint` present: `new SpanTransformProcessor(new GatedSpanExporter(() => new O11ySpanExporter(extensionName, o11yEndpoint, productFeatureId), o11yEndpoint))`. Drop enabled/localhost from build condition (gate + localhost bypass now live in the wrapper).
+  - drop now-unused `isTelemetryExtensionConfigurationEnabled` import
+  - keep the `enableCustomEventsFromSpans || localIngestionEndpoint ? undefined : {exportTimeout/maxQueue}` processor options selection (moves onto the wrapping SpanTransformProcessor unchanged)
+
+- `spansWeb.ts`
+  - :33 → `ApplicationInsightsWebExporter` ALWAYS in array via `GatedSpanExporter` (web reporter already lazy, so gate alone suffices, but use same wrapper for uniformity)
+  - :36 → O11y always when `o11yEndpoint` present, `GatedSpanExporter(..., o11yEndpoint)`
+  - drop `isTelemetryExtensionConfigurationEnabled` import
+
+- Exporters' own `export()` stay unchanged — gating centralized in `GatedSpanExporter`, avoids duplicated early-returns.
+
+- `packages/salesforcedx-vscode-services/src/observability/README.md` — update line ~343/346: enabled now checked per-export (mid-session toggle takes effect, no reload); AI exporter delegate lazily constructed on first enabled export so telemetry-disabled sessions do NO Azure/Statsbeat network setup.
+
+Gate + lazy check = once per `export()` batch (not per-span) → no perf regression.
+
+### Phase 2 — unit tests
+
+Commit: `test(observability): per-export telemetry gate + lazy construct honors mid-session toggle - W-23369387`
+
+Files:
+
+- `test/jest/observability/spanUtils.test.ts` — `isProductionTelemetryExportEnabled`: localhost bypass returns true when disabled; returns enabled value otherwise (spy `workspace.getConfiguration`).
+
+- new `test/jest/observability/gatedSpanExporter.test.ts` — the Statsbeat-regression guard:
+  - disabled → `export()` returns `SUCCESS` AND `make` factory NEVER called (spy) → proves NO delegate/Statsbeat construction while disabled (the assertion the injected-fake-sender fixture could not make).
+  - enabled → `make` called exactly once; second enabled export does NOT re-call `make` (cached delegate); delegate.export receives spans.
+  - localhost `o11yEndpoint` + disabled setting → `make` called (bypass), delegate.export invoked.
+  - `shutdown()` before any export → resolves without constructing delegate.
+  - spy `workspace.getConfiguration` for enabled/disabled; `make` is a `jest.fn(() => fakeExporter)`.
+
+- `test/jest/observability/spansNode.test.ts` — keep existing `FilteredAzureMonitorTraceExporter` `_OTELRESOURCE_` tests (unchanged; they construct the real exporter directly and inject a fake sender). No new gate assertions here — gate behavior lives in gatedSpanExporter.test.ts.
+
+- default jest vscode mock `getConfiguration().get => true` → enabled path; per-test `jest.spyOn(workspace,'getConfiguration')` for disabled.
+
+Note: 2 commits, single PR/branch (AC "one PR") — both ship together.
+
+## Skills to apply
+
+- concise (plan + any md)
+- effect-best-practices (exporter `export()` is Effect; wrapper stays synchronous SpanExporter contract)
+- typescript
+- span-file-export (observability exporters/local divert)
+- unit-test-critic (Phase 2 assertions meaningful, not tautological — esp. the `make`-not-called Statsbeat guard)
+- playwright-e2e (e2e feasibility assessment below)
+- verification
+
+## Verification
+
+- `npm run test -w salesforcedx-vscode-services` (jest) — new + existing obs tests
+- `npm run compile -w salesforcedx-vscode-services` / typecheck — no unused imports
+- lint (unused `isTelemetryExtensionConfigurationEnabled` imports removed from spansNode/spansWeb)
+
+### E2e for the mid-session toggle (AC) — infeasible in harness; documented for sign-off
+
+- The AC behavior (toggle `telemetry.enabled` → gate output flips, no reload) CANNOT be exercised e2e:
+  - `isTelemetryExtensionConfigurationEnabled()` short-circuits to `true` via `isLocalDivertMode()` BEFORE reading the setting (appInsights.ts:40-42) whenever extensionMode is Development/Test.
+  - Playwright launches the extension via `--extensionDevelopmentPath` = `ExtensionMode.Development` → the gate is force-true regardless of the setting, so toggling the setting in an e2e can't change exporter behavior.
+  - The existing telemetry e2e (`packages/salesforcedx-vscode-org/test/playwright/specs/telemetryIdentitySeeding.desktop.spec.ts`) observes only the FILE exporter (`~/.sf/vscode-spans/`), which is gated by `getFileTraces`, not the production telemetry gate → cannot assert the toggle transition.
+  - No production-mode e2e harness exists; adding a test-only bypass of the divert force-true would risk leaking real telemetry to Azure (rejected).
+- Coverage instead: Phase 2 unit gate assertions (disabled→SUCCESS+no emit+no construct, enabled→emit+construct-once, per-batch re-check) directly prove the toggle-honoring behavior at the gate.
+- ACTION: flag this e2e infeasibility to reviewer for explicit sign-off in the PR body (do not silently defer).

--- a/.claude/plans/W-23369387.md
+++ b/.claude/plans/W-23369387.md
@@ -17,7 +17,7 @@
 - O11y localhost bypass must survive: O11y emits to localhost even when telemetry off (dev). O11y stores `this.endpoint`.
 - No import cycle: spanUtils → appInsights (appInsights doesn't import spanUtils). appInsights already imports vscode; web bundle already imports appInsights.
 - Dev/test: `isTelemetryExtensionConfigurationEnabled()` returns true (isLocalDivertMode short-circuit, appInsights.ts:40-42), so local divert unaffected.
-- AC: all 4 fixed in ONE PR (partial = one exporter silently broken) → single branch.
+- AC: all 4 fixed in 1 PR (partial = 1 exporter silently broken) → single branch.
 
 ### CRITICAL: Statsbeat — construction-time network side effect (why NOT "always construct")
 
@@ -29,7 +29,7 @@
 - Consequence: a naive "always construct, early-return inside `export()`" makes telemetry-**disabled** users emit background Statsbeat network egress to Microsoft that never happened before (today these exporters aren't constructed while disabled). Early-return runs too late — the ctor side effect already fired.
 - No per-exporter option disables Statsbeat — `trackStatsbeat` is fed only by `isStatsbeatExporter` (private 2nd ctor arg, not exposed) and the process-global env var `APPLICATION_INSIGHTS_NO_STATSBEAT`. Setting a global env var is a cross-consumer side effect (rejected).
 - O11y and web are NOT affected: `O11ySpanExporter` ctor only calls `O11yService.getInstance` (no network; net init deferred to `ensureInitialized` inside export); web reporter is a lazy singleton (`getWebAppInsightsReporter`, constructed on first send).
-- **Fix = lazy construction + per-export gate in one wrapper.** Keep prior "no construction while disabled" behavior (→ no Statsbeat while disabled), AND make the gate re-check per export so mid-session enable works. Construct the real exporter on the first *enabled* export, cache thereafter.
+- **Fix = lazy construction + per-export gate in 1 wrapper.** Keep prior "no construction while disabled" behavior (→ no Statsbeat while disabled), AND make the gate re-check per export so mid-session enable works. Construct the real exporter on the first *enabled* export, cache thereafter.
 
 ## Phases
 
@@ -104,7 +104,7 @@ Files:
 
 - default jest vscode mock `getConfiguration().get => true` → enabled path; per-test `jest.spyOn(workspace,'getConfiguration')` for disabled.
 
-Note: 2 commits, single PR/branch (AC "one PR") — both ship together.
+Note: 2 commits, single PR/branch (AC "1 PR") — both ship together.
 
 ## Skills to apply
 

--- a/packages/salesforcedx-vscode-services/src/observability/README.md
+++ b/packages/salesforcedx-vscode-services/src/observability/README.md
@@ -343,6 +343,8 @@ These settings must be enabled for App Insights and O11y to work:
 - `salesforcedx-vscode-core.telemetry.enabled` - Extension telemetry toggle (must be true for App Insights/O11y)
 - `salesforcedx-vscode-core.telemetry.allowDevMode` - Dev mode telemetry override (default: false)
 
+These are checked per export (via `GatedSpanExporter`), not once at Layer build, so toggling `telemetry.enabled` mid-session takes effect without a reload. The App Insights delegate exporter is constructed lazily on the first enabled export, so a telemetry-disabled session does no Azure/Statsbeat network setup.
+
 **Dev Mode Note**: On Node, dev/test mode auto-diverts App Insights to localhost (see [Inspecting App Insights Envelopes Locally](#inspecting-app-insights-envelopes-locally)) — telemetry is force-enabled there since it provably cannot reach Azure. On Web, telemetry behavior follows standard VS Code telemetry settings.
 
 ## Local Debugging

--- a/packages/salesforcedx-vscode-services/src/observability/appInsights.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/appInsights.ts
@@ -37,7 +37,7 @@ const isDevOrTestMode = (): boolean =>
 const isLocalDivertMode = (): boolean =>
   process.env.ESBUILD_PLATFORM === 'web' ? process.env.ESBUILD_WEB_LOCAL === '1' : isDevOrTestMode();
 
-export const isTelemetryExtensionConfigurationEnabled = (): boolean => {
+const isTelemetryExtensionConfigurationEnabled = (): boolean => {
   // Node dev/test: always emit; everything is diverted to a local endpoint, never Azure.
   if (isLocalDivertMode()) {
     return true;
@@ -61,3 +61,8 @@ export const isTelemetryExtensionConfigurationEnabled = (): boolean => {
     ? workspace.getConfiguration('salesforcedx-vscode-core').get<boolean>('telemetry.allowDevMode', false)
     : true;
 };
+
+/** Per-export telemetry gate; checked fresh each batch → honors mid-session toggle.
+    o11yEndpoint localhost bypasses the setting (dev sink). */
+export const isProductionTelemetryExportEnabled = (o11yEndpoint?: string): boolean =>
+  Boolean(o11yEndpoint?.includes('localhost')) || isTelemetryExtensionConfigurationEnabled();

--- a/packages/salesforcedx-vscode-services/src/observability/gatedSpanExporter.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/gatedSpanExporter.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { ExportResult, ExportResultCode } from '@opentelemetry/core';
+import { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
+import { isProductionTelemetryExportEnabled } from './spanUtils';
+
+/**
+ * Wraps a real SpanExporter with a per-export telemetry gate. The gate is re-checked
+ * on every export batch so toggling `telemetry.enabled` mid-session takes effect without
+ * a reload. The delegate exporter is constructed lazily on the first enabled export and
+ * cached, so a telemetry-disabled session never runs the delegate ctor (avoids Azure
+ * Statsbeat / network setup that some exporter ctors trigger).
+ */
+export class GatedSpanExporter implements SpanExporter {
+  private delegate: SpanExporter | undefined;
+
+  constructor(
+    private readonly make: () => SpanExporter,
+    private readonly o11yEndpoint?: string
+  ) {}
+
+  public export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
+    if (!isProductionTelemetryExportEnabled(this.o11yEndpoint)) {
+      resultCallback({ code: ExportResultCode.SUCCESS });
+      return;
+    }
+    (this.delegate ??= this.make()).export(spans, resultCallback);
+  }
+
+  public shutdown(): Promise<void> {
+    return this.delegate?.shutdown() ?? Promise.resolve();
+  }
+}

--- a/packages/salesforcedx-vscode-services/src/observability/gatedSpanExporter.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/gatedSpanExporter.ts
@@ -6,13 +6,12 @@
  */
 import { ExportResult, ExportResultCode } from '@opentelemetry/core';
 import { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
-import { isProductionTelemetryExportEnabled } from './spanUtils';
 
 /**
- * Wraps a real SpanExporter with a per-export telemetry gate. The gate is re-checked
+ * Wraps a real SpanExporter with a per-export gate. The `isEnabled` predicate is re-checked
  * on every export batch so toggling `telemetry.enabled` mid-session takes effect without
  * a reload. The delegate exporter is constructed lazily on the first enabled export and
- * cached, so a telemetry-disabled session never runs the delegate ctor (avoids Azure
+ * cached, so a disabled session never runs the delegate ctor (avoids Azure
  * Statsbeat / network setup that some exporter ctors trigger).
  */
 export class GatedSpanExporter implements SpanExporter {
@@ -20,11 +19,11 @@ export class GatedSpanExporter implements SpanExporter {
 
   constructor(
     private readonly make: () => SpanExporter,
-    private readonly o11yEndpoint?: string
+    private readonly isEnabled: () => boolean
   ) {}
 
   public export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
-    if (!isProductionTelemetryExportEnabled(this.o11yEndpoint)) {
+    if (!this.isEnabled()) {
       resultCallback({ code: ExportResultCode.SUCCESS });
       return;
     }

--- a/packages/salesforcedx-vscode-services/src/observability/spanTransformProcessor.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/spanTransformProcessor.ts
@@ -14,14 +14,17 @@ import { getDefaultOrgRef } from '../core/defaultOrgRef';
 
 /** Custom span processor that transforms spans before they're exported */
 export class SpanTransformProcessor extends BatchSpanProcessor {
-  // eslint-disable-next-line @typescript-eslint/no-useless-constructor
-  constructor(exporter: SpanExporter, options?: BufferConfig) {
+  private readonly shouldEnrich: () => boolean;
+
+  constructor(exporter: SpanExporter, options?: BufferConfig, shouldEnrich: () => boolean = () => true) {
     super(exporter, options);
+    this.shouldEnrich = shouldEnrich;
   }
 
   public onStart(span: Span, parentContext: Context): void {
-    // for top level spans, add additional attributes
-    if (!span.parentSpanContext) {
+    // for top level spans, add additional attributes — skipped when the exporter gate is disabled
+    // (the enrichment would be computed per-span then discarded by the gated exporter)
+    if (!span.parentSpanContext && this.shouldEnrich()) {
       const resourceAttrs = span.resource.attributes;
       const extensionName = resourceAttrs['extension.name'];
       const extensionVersion = resourceAttrs['extension.version'];

--- a/packages/salesforcedx-vscode-services/src/observability/spanUtils.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/spanUtils.ts
@@ -6,6 +6,12 @@
  */
 import { type Attributes, type HrTime } from '@opentelemetry/api';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { isTelemetryExtensionConfigurationEnabled } from './appInsights';
+
+/** Per-export telemetry gate; checked fresh each batch → honors mid-session toggle.
+    o11yEndpoint localhost bypasses the setting (dev sink). */
+export const isProductionTelemetryExportEnabled = (o11yEndpoint?: string): boolean =>
+  Boolean(o11yEndpoint?.includes('localhost')) || isTelemetryExtensionConfigurationEnabled();
 
 /** Check if a span is a top-level span (has no parent) */
 const isTopLevelSpan = (span: ReadableSpan): boolean => span.parentSpanContext === undefined;

--- a/packages/salesforcedx-vscode-services/src/observability/spanUtils.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/spanUtils.ts
@@ -6,12 +6,6 @@
  */
 import { type Attributes, type HrTime } from '@opentelemetry/api';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
-import { isTelemetryExtensionConfigurationEnabled } from './appInsights';
-
-/** Per-export telemetry gate; checked fresh each batch → honors mid-session toggle.
-    o11yEndpoint localhost bypasses the setting (dev sink). */
-export const isProductionTelemetryExportEnabled = (o11yEndpoint?: string): boolean =>
-  Boolean(o11yEndpoint?.includes('localhost')) || isTelemetryExtensionConfigurationEnabled();
 
 /** Check if a span is a top-level span (has no parent) */
 const isTopLevelSpan = (span: ReadableSpan): boolean => span.parentSpanContext === undefined;

--- a/packages/salesforcedx-vscode-services/src/observability/spansNode.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/spansNode.ts
@@ -16,8 +16,9 @@ import { Global } from '@salesforce/core/global';
 import * as Layer from 'effect/Layer';
 import * as Logger from 'effect/Logger';
 import { join } from 'node:path';
-import { DEFAULT_AI_CONNECTION_STRING, isTelemetryExtensionConfigurationEnabled } from './appInsights';
+import { DEFAULT_AI_CONNECTION_STRING } from './appInsights';
 import { ApplicationInsightsNodeExporter } from './applicationInsightsNodeExporter';
+import { GatedSpanExporter } from './gatedSpanExporter';
 import { makeLocalEnvelopeSender } from './localEnvelopeSender';
 import { getConsoleTracesEnabled, getFileTracesEnabled, getLocalTracesEnabled, getLogLevel } from './localTracing';
 import { O11ySpanExporter } from './o11ySpanExporter';
@@ -75,31 +76,41 @@ export const NodeSdkLayerFor = ({
     },
     spanProcessor: [
       ...(getConsoleTracesEnabled() ? [new SpanTransformProcessor(new ConsoleSpanExporter())] : []),
-      ...(isTelemetryExtensionConfigurationEnabled()
+      // AI processor always present; GatedSpanExporter re-checks the telemetry setting per export
+      // (mid-session toggle) and lazily constructs the delegate on first enabled export so a
+      // disabled session runs no delegate ctor (no Azure Statsbeat/network setup).
+      new SpanTransformProcessor(
+        new GatedSpanExporter(() =>
+          enableCustomEventsFromSpans
+            ? // customEvents path (LogRecord-based); localIngestionEndpoint diverts to local server in dev/test
+              new ApplicationInsightsNodeExporter(effectiveConnectionString, localIngestionEndpoint)
+            : // dependencies path; localIngestionEndpoint diverts to local server in dev/test
+              new FilteredAzureMonitorTraceExporter(
+                {
+                  connectionString: effectiveConnectionString,
+                  storageDirectory: join(Global.SF_DIR, 'vscode-extensions-telemetry')
+                },
+                localIngestionEndpoint
+              )
+        ),
+        enableCustomEventsFromSpans || localIngestionEndpoint
+          ? undefined
+          : {
+              exportTimeoutMillis: 15_000,
+              maxQueueSize: 1000
+            }
+      ),
+      // O11y processor present whenever an endpoint is configured; the gate (localhost bypass +
+      // telemetry setting) now lives in GatedSpanExporter and is re-checked per export.
+      ...(o11yEndpoint
         ? [
             new SpanTransformProcessor(
-              enableCustomEventsFromSpans
-                ? // customEvents path (LogRecord-based); localIngestionEndpoint diverts to local server in dev/test
-                  new ApplicationInsightsNodeExporter(effectiveConnectionString, localIngestionEndpoint)
-                : // dependencies path; localIngestionEndpoint diverts to local server in dev/test
-                  new FilteredAzureMonitorTraceExporter(
-                    {
-                      connectionString: effectiveConnectionString,
-                      storageDirectory: join(Global.SF_DIR, 'vscode-extensions-telemetry')
-                    },
-                    localIngestionEndpoint
-                  ),
-              enableCustomEventsFromSpans || localIngestionEndpoint
-                ? undefined
-                : {
-                    exportTimeoutMillis: 15_000,
-                    maxQueueSize: 1000
-                  }
+              new GatedSpanExporter(
+                () => new O11ySpanExporter(extensionName, o11yEndpoint, productFeatureId),
+                o11yEndpoint
+              )
             )
           ]
-        : []),
-      ...(o11yEndpoint && (o11yEndpoint.includes('localhost') || isTelemetryExtensionConfigurationEnabled())
-        ? [new SpanTransformProcessor(new O11ySpanExporter(extensionName, o11yEndpoint, productFeatureId))]
         : []),
       ...(getLocalTracesEnabled() ? [new SpanTransformProcessor(new OTLPTraceExporter())] : []),
       ...(getFileTracesEnabled() ? [new SpanTransformProcessor(new OtlpFileSpanExporterNode())] : [])

--- a/packages/salesforcedx-vscode-services/src/observability/spansNode.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/spansNode.ts
@@ -16,7 +16,7 @@ import { Global } from '@salesforce/core/global';
 import * as Layer from 'effect/Layer';
 import * as Logger from 'effect/Logger';
 import { join } from 'node:path';
-import { DEFAULT_AI_CONNECTION_STRING } from './appInsights';
+import { DEFAULT_AI_CONNECTION_STRING, isProductionTelemetryExportEnabled } from './appInsights';
 import { ApplicationInsightsNodeExporter } from './applicationInsightsNodeExporter';
 import { GatedSpanExporter } from './gatedSpanExporter';
 import { makeLocalEnvelopeSender } from './localEnvelopeSender';
@@ -80,25 +80,29 @@ export const NodeSdkLayerFor = ({
       // (mid-session toggle) and lazily constructs the delegate on first enabled export so a
       // disabled session runs no delegate ctor (no Azure Statsbeat/network setup).
       new SpanTransformProcessor(
-        new GatedSpanExporter(() =>
-          enableCustomEventsFromSpans
-            ? // customEvents path (LogRecord-based); localIngestionEndpoint diverts to local server in dev/test
-              new ApplicationInsightsNodeExporter(effectiveConnectionString, localIngestionEndpoint)
-            : // dependencies path; localIngestionEndpoint diverts to local server in dev/test
-              new FilteredAzureMonitorTraceExporter(
-                {
-                  connectionString: effectiveConnectionString,
-                  storageDirectory: join(Global.SF_DIR, 'vscode-extensions-telemetry')
-                },
-                localIngestionEndpoint
-              )
+        new GatedSpanExporter(
+          () =>
+            enableCustomEventsFromSpans
+              ? // customEvents path (LogRecord-based); localIngestionEndpoint diverts to local server in dev/test
+                new ApplicationInsightsNodeExporter(effectiveConnectionString, localIngestionEndpoint)
+              : // dependencies path; localIngestionEndpoint diverts to local server in dev/test
+                new FilteredAzureMonitorTraceExporter(
+                  {
+                    connectionString: effectiveConnectionString,
+                    storageDirectory: join(Global.SF_DIR, 'vscode-extensions-telemetry')
+                  },
+                  localIngestionEndpoint
+                ),
+          () => isProductionTelemetryExportEnabled()
         ),
         enableCustomEventsFromSpans || localIngestionEndpoint
           ? undefined
           : {
               exportTimeoutMillis: 15_000,
               maxQueueSize: 1000
-            }
+            },
+        // skip per-span attribute enrichment when the gate is disabled (attrs would be discarded)
+        () => isProductionTelemetryExportEnabled()
       ),
       // O11y processor present whenever an endpoint is configured; the gate (localhost bypass +
       // telemetry setting) now lives in GatedSpanExporter and is re-checked per export.
@@ -107,8 +111,10 @@ export const NodeSdkLayerFor = ({
             new SpanTransformProcessor(
               new GatedSpanExporter(
                 () => new O11ySpanExporter(extensionName, o11yEndpoint, productFeatureId),
-                o11yEndpoint
-              )
+                () => isProductionTelemetryExportEnabled(o11yEndpoint)
+              ),
+              undefined,
+              () => isProductionTelemetryExportEnabled(o11yEndpoint)
             )
           ]
         : []),

--- a/packages/salesforcedx-vscode-services/src/observability/spansWeb.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/spansWeb.ts
@@ -8,6 +8,7 @@ import type { SdkLayerConfig } from './sdkLayerConfig';
 import { WebSdk } from '@effect/opentelemetry';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-web';
+import { isProductionTelemetryExportEnabled } from './appInsights';
 import { ApplicationInsightsWebExporter } from './applicationInsightsWebExporter';
 import { GatedSpanExporter } from './gatedSpanExporter';
 import { getConsoleTracesEnabled, getLocalTracesEnabled, getFileTracesEnabled } from './localTracing';
@@ -31,15 +32,25 @@ export const WebSdkLayerFor = ({ extensionName, extensionVersion, o11yEndpoint, 
     spanProcessor: [
       ...(getConsoleTracesEnabled() ? [new SpanTransformProcessor(new ConsoleSpanExporter())] : []),
       // AI processor always present; GatedSpanExporter re-checks the telemetry setting per export (mid-session toggle)
-      new SpanTransformProcessor(new GatedSpanExporter(() => new ApplicationInsightsWebExporter())),
+      new SpanTransformProcessor(
+        new GatedSpanExporter(
+          () => new ApplicationInsightsWebExporter(),
+          () => isProductionTelemetryExportEnabled()
+        ),
+        undefined,
+        // skip per-span attribute enrichment when the gate is disabled (attrs would be discarded)
+        () => isProductionTelemetryExportEnabled()
+      ),
       // O11y processor present whenever an endpoint is configured; gate (localhost bypass + telemetry setting) lives in the wrapper
       ...(o11yEndpoint
         ? [
             new SpanTransformProcessor(
               new GatedSpanExporter(
                 () => new O11ySpanExporter(extensionName, o11yEndpoint, productFeatureId),
-                o11yEndpoint
-              )
+                () => isProductionTelemetryExportEnabled(o11yEndpoint)
+              ),
+              undefined,
+              () => isProductionTelemetryExportEnabled(o11yEndpoint)
             )
           ]
         : []),

--- a/packages/salesforcedx-vscode-services/src/observability/spansWeb.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/spansWeb.ts
@@ -8,8 +8,8 @@ import type { SdkLayerConfig } from './sdkLayerConfig';
 import { WebSdk } from '@effect/opentelemetry';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-web';
-import { isTelemetryExtensionConfigurationEnabled } from './appInsights';
 import { ApplicationInsightsWebExporter } from './applicationInsightsWebExporter';
+import { GatedSpanExporter } from './gatedSpanExporter';
 import { getConsoleTracesEnabled, getLocalTracesEnabled, getFileTracesEnabled } from './localTracing';
 import { O11ySpanExporter } from './o11ySpanExporter';
 import { OtlpFileSpanExporterWeb } from './otlpFileSpanExporterWeb';
@@ -30,11 +30,18 @@ export const WebSdkLayerFor = ({ extensionName, extensionVersion, o11yEndpoint, 
     },
     spanProcessor: [
       ...(getConsoleTracesEnabled() ? [new SpanTransformProcessor(new ConsoleSpanExporter())] : []),
-      ...(isTelemetryExtensionConfigurationEnabled()
-        ? [new SpanTransformProcessor(new ApplicationInsightsWebExporter())]
-        : []),
-      ...(o11yEndpoint && (o11yEndpoint.includes('localhost') || isTelemetryExtensionConfigurationEnabled())
-        ? [new SpanTransformProcessor(new O11ySpanExporter(extensionName, o11yEndpoint, productFeatureId))]
+      // AI processor always present; GatedSpanExporter re-checks the telemetry setting per export (mid-session toggle)
+      new SpanTransformProcessor(new GatedSpanExporter(() => new ApplicationInsightsWebExporter())),
+      // O11y processor present whenever an endpoint is configured; gate (localhost bypass + telemetry setting) lives in the wrapper
+      ...(o11yEndpoint
+        ? [
+            new SpanTransformProcessor(
+              new GatedSpanExporter(
+                () => new O11ySpanExporter(extensionName, o11yEndpoint, productFeatureId),
+                o11yEndpoint
+              )
+            )
+          ]
         : []),
       ...(getLocalTracesEnabled() ? [new SpanTransformProcessor(new OTLPTraceExporter())] : []),
       ...(getFileTracesEnabled() ? [new SpanTransformProcessor(new OtlpFileSpanExporterWeb())] : [])

--- a/packages/salesforcedx-vscode-services/test/jest/observability/gatedSpanExporter.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/observability/gatedSpanExporter.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { ExportResult, ExportResultCode } from '@opentelemetry/core';
+import { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
+import { workspace } from 'vscode';
+import { GatedSpanExporter } from '../../../src/observability/gatedSpanExporter';
+
+// isTelemetryExtensionConfigurationEnabled reads config.get; spy so tests are independent of the
+// default mock (resetMocks clears the shared spy between tests, so set it explicitly each time).
+const spyTelemetry = (enabled: boolean): void => {
+  jest.spyOn(workspace, 'getConfiguration').mockReturnValue({
+    get: () => enabled
+  } as unknown as ReturnType<typeof workspace.getConfiguration>);
+};
+const disableTelemetry = (): void => spyTelemetry(false);
+const enableTelemetry = (): void => spyTelemetry(true);
+
+const spans = [{ name: 'span' } as unknown as ReadableSpan];
+
+const makeFakeExporter = (): SpanExporter & { export: jest.Mock; shutdown: jest.Mock } => ({
+  export: jest.fn((_spans: ReadableSpan[], cb: (r: ExportResult) => void) => cb({ code: ExportResultCode.SUCCESS })),
+  shutdown: jest.fn().mockResolvedValue(undefined)
+});
+
+describe('GatedSpanExporter', () => {
+  it('disabled: returns SUCCESS and NEVER constructs the delegate (no Statsbeat/network setup)', () => {
+    disableTelemetry();
+    const make = jest.fn(makeFakeExporter);
+    const exporter = new GatedSpanExporter(make);
+
+    const cb = jest.fn();
+    exporter.export(spans, cb);
+
+    expect(cb).toHaveBeenCalledWith({ code: ExportResultCode.SUCCESS });
+    // the assertion the injected-fake-sender fixture could not make: delegate ctor never runs
+    expect(make).not.toHaveBeenCalled();
+  });
+
+  it('enabled: constructs the delegate once, caches it, and forwards spans on each export', () => {
+    enableTelemetry();
+    const fake = makeFakeExporter();
+    const make = jest.fn(() => fake);
+    const exporter = new GatedSpanExporter(make);
+
+    exporter.export(spans, jest.fn());
+    exporter.export(spans, jest.fn());
+
+    expect(make).toHaveBeenCalledTimes(1);
+    expect(fake.export).toHaveBeenCalledTimes(2);
+    expect(fake.export.mock.calls[0][0]).toBe(spans);
+  });
+
+  it('localhost o11yEndpoint bypasses a disabled setting: constructs delegate and forwards', () => {
+    disableTelemetry();
+    const fake = makeFakeExporter();
+    const make = jest.fn(() => fake);
+    const exporter = new GatedSpanExporter(make, 'http://localhost:4318');
+
+    exporter.export(spans, jest.fn());
+
+    expect(make).toHaveBeenCalledTimes(1);
+    expect(fake.export).toHaveBeenCalledTimes(1);
+  });
+
+  it('shutdown before any export resolves without constructing the delegate', async () => {
+    const make = jest.fn(makeFakeExporter);
+    const exporter = new GatedSpanExporter(make);
+
+    await expect(exporter.shutdown()).resolves.toBeUndefined();
+    expect(make).not.toHaveBeenCalled();
+  });
+
+  it('shutdown after an enabled export delegates to the constructed exporter', async () => {
+    enableTelemetry();
+    const fake = makeFakeExporter();
+    const exporter = new GatedSpanExporter(() => fake);
+
+    exporter.export(spans, jest.fn());
+    await exporter.shutdown();
+
+    expect(fake.shutdown).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/salesforcedx-vscode-services/test/jest/observability/gatedSpanExporter.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/observability/gatedSpanExporter.test.ts
@@ -7,18 +7,11 @@
 
 import { ExportResult, ExportResultCode } from '@opentelemetry/core';
 import { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
-import { workspace } from 'vscode';
 import { GatedSpanExporter } from '../../../src/observability/gatedSpanExporter';
 
-// isTelemetryExtensionConfigurationEnabled reads config.get; spy so tests are independent of the
-// default mock (resetMocks clears the shared spy between tests, so set it explicitly each time).
-const spyTelemetry = (enabled: boolean): void => {
-  jest.spyOn(workspace, 'getConfiguration').mockReturnValue({
-    get: () => enabled
-  } as unknown as ReturnType<typeof workspace.getConfiguration>);
-};
-const disableTelemetry = (): void => spyTelemetry(false);
-const enableTelemetry = (): void => spyTelemetry(true);
+// GatedSpanExporter is decoupled from telemetry config: the gate is an injected predicate.
+const enabled = (): boolean => true;
+const disabled = (): boolean => false;
 
 const spans = [{ name: 'span' } as unknown as ReadableSpan];
 
@@ -29,9 +22,8 @@ const makeFakeExporter = (): SpanExporter & { export: jest.Mock; shutdown: jest.
 
 describe('GatedSpanExporter', () => {
   it('disabled: returns SUCCESS and NEVER constructs the delegate (no Statsbeat/network setup)', () => {
-    disableTelemetry();
     const make = jest.fn(makeFakeExporter);
-    const exporter = new GatedSpanExporter(make);
+    const exporter = new GatedSpanExporter(make, disabled);
 
     const cb = jest.fn();
     exporter.export(spans, cb);
@@ -42,10 +34,9 @@ describe('GatedSpanExporter', () => {
   });
 
   it('enabled: constructs the delegate once, caches it, and forwards spans on each export', () => {
-    enableTelemetry();
     const fake = makeFakeExporter();
     const make = jest.fn(() => fake);
-    const exporter = new GatedSpanExporter(make);
+    const exporter = new GatedSpanExporter(make, enabled);
 
     exporter.export(spans, jest.fn());
     exporter.export(spans, jest.fn());
@@ -55,30 +46,33 @@ describe('GatedSpanExporter', () => {
     expect(fake.export.mock.calls[0][0]).toBe(spans);
   });
 
-  it('localhost o11yEndpoint bypasses a disabled setting: constructs delegate and forwards', () => {
-    disableTelemetry();
+  it('re-checks the gate per export: enabled then disabled stops forwarding without re-construct', () => {
     const fake = makeFakeExporter();
     const make = jest.fn(() => fake);
-    const exporter = new GatedSpanExporter(make, 'http://localhost:4318');
+    let on = true;
+    const exporter = new GatedSpanExporter(make, () => on);
 
     exporter.export(spans, jest.fn());
+    on = false;
+    const cb = jest.fn();
+    exporter.export(spans, cb);
 
     expect(make).toHaveBeenCalledTimes(1);
     expect(fake.export).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith({ code: ExportResultCode.SUCCESS });
   });
 
   it('shutdown before any export resolves without constructing the delegate', async () => {
     const make = jest.fn(makeFakeExporter);
-    const exporter = new GatedSpanExporter(make);
+    const exporter = new GatedSpanExporter(make, enabled);
 
     await expect(exporter.shutdown()).resolves.toBeUndefined();
     expect(make).not.toHaveBeenCalled();
   });
 
   it('shutdown after an enabled export delegates to the constructed exporter', async () => {
-    enableTelemetry();
     const fake = makeFakeExporter();
-    const exporter = new GatedSpanExporter(() => fake);
+    const exporter = new GatedSpanExporter(() => fake, enabled);
 
     exporter.export(spans, jest.fn());
     await exporter.shutdown();

--- a/packages/salesforcedx-vscode-services/test/jest/observability/spanUtils.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/observability/spanUtils.test.ts
@@ -7,7 +7,18 @@
 
 import { type Attributes } from '@opentelemetry/api';
 import { type ReadableSpan } from '@opentelemetry/sdk-trace-base';
-import { isSpanValidForProductionTelemetry } from '../../../src/observability/spanUtils';
+import { workspace } from 'vscode';
+import {
+  isProductionTelemetryExportEnabled,
+  isSpanValidForProductionTelemetry
+} from '../../../src/observability/spanUtils';
+
+// isTelemetryExtensionConfigurationEnabled reads the config; force telemetry off by returning falsy `get`.
+const spyConfigDisabled = (): void => {
+  jest.spyOn(workspace, 'getConfiguration').mockReturnValue({
+    get: () => false
+  } as unknown as ReturnType<typeof workspace.getConfiguration>);
+};
 
 // isSpanValidForProductionTelemetry only reads attributes + parentSpanContext (undefined => top-level)
 const makeSpan = (attributes: Attributes): ReadableSpan =>
@@ -26,5 +37,27 @@ describe('isSpanValidForProductionTelemetry', () => {
     expect(isSpanValidForProductionTelemetry(makeSpan({ command: 'sf.some.command', telemetryIgnore: true }))).toBe(
       false
     );
+  });
+});
+
+describe('isProductionTelemetryExportEnabled', () => {
+  it('returns the telemetry setting value (true) when enabled and no localhost bypass', () => {
+    // default jest vscode mock: getConfiguration().get => true
+    expect(isProductionTelemetryExportEnabled()).toBe(true);
+  });
+
+  it('returns false when the telemetry setting is disabled and no localhost bypass', () => {
+    spyConfigDisabled();
+    expect(isProductionTelemetryExportEnabled()).toBe(false);
+  });
+
+  it('bypasses a disabled setting when o11yEndpoint is localhost (dev sink)', () => {
+    spyConfigDisabled();
+    expect(isProductionTelemetryExportEnabled('http://localhost:4318')).toBe(true);
+  });
+
+  it('does not bypass for a non-localhost o11yEndpoint when disabled', () => {
+    spyConfigDisabled();
+    expect(isProductionTelemetryExportEnabled('https://o11y.salesforce.com')).toBe(false);
   });
 });

--- a/packages/salesforcedx-vscode-services/test/jest/observability/spanUtils.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/observability/spanUtils.test.ts
@@ -8,15 +8,14 @@
 import { type Attributes } from '@opentelemetry/api';
 import { type ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { workspace } from 'vscode';
-import {
-  isProductionTelemetryExportEnabled,
-  isSpanValidForProductionTelemetry
-} from '../../../src/observability/spanUtils';
+import { isProductionTelemetryExportEnabled } from '../../../src/observability/appInsights';
+import { isSpanValidForProductionTelemetry } from '../../../src/observability/spanUtils';
 
-// isTelemetryExtensionConfigurationEnabled reads the config; force telemetry off by returning falsy `get`.
-const spyConfigDisabled = (): void => {
+// isTelemetryExtensionConfigurationEnabled reads config.get; spy explicitly each test so results are
+// independent of the shared default mock (resetMocks clears the spy between tests).
+const spyConfig = (enabled: boolean): void => {
   jest.spyOn(workspace, 'getConfiguration').mockReturnValue({
-    get: () => false
+    get: () => enabled
   } as unknown as ReturnType<typeof workspace.getConfiguration>);
 };
 
@@ -42,22 +41,22 @@ describe('isSpanValidForProductionTelemetry', () => {
 
 describe('isProductionTelemetryExportEnabled', () => {
   it('returns the telemetry setting value (true) when enabled and no localhost bypass', () => {
-    // default jest vscode mock: getConfiguration().get => true
+    spyConfig(true);
     expect(isProductionTelemetryExportEnabled()).toBe(true);
   });
 
   it('returns false when the telemetry setting is disabled and no localhost bypass', () => {
-    spyConfigDisabled();
+    spyConfig(false);
     expect(isProductionTelemetryExportEnabled()).toBe(false);
   });
 
   it('bypasses a disabled setting when o11yEndpoint is localhost (dev sink)', () => {
-    spyConfigDisabled();
+    spyConfig(false);
     expect(isProductionTelemetryExportEnabled('http://localhost:4318')).toBe(true);
   });
 
   it('does not bypass for a non-localhost o11yEndpoint when disabled', () => {
-    spyConfigDisabled();
+    spyConfig(false);
     expect(isProductionTelemetryExportEnabled('https://o11y.salesforce.com')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Moved the `telemetry.enabled` check from Layer-construction time to a per-export gate (`isProductionTelemetryExportEnabled` in `spanUtils.ts`), so toggling the setting mid-session now takes effect immediately at all 4 exporter call sites (App Insights + O11y, node + web) instead of requiring a reload.
- Added `GatedSpanExporter` — a single wrapper that gates per export batch AND lazily constructs the real delegate exporter only on the first *enabled* export. This preserves today's behavior of never constructing the Azure App Insights exporters while telemetry is disabled, avoiding Statsbeat background network reporting that fires at exporter-construction time (not export time).
- O11y's localhost dev-sink bypass is preserved in the wrapper (`o11yEndpoint` param), independent of the telemetry setting.

## Plan

[.claude/plans/W-23369387.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23369387-repo-forcedotcom-salesforcedx-vscode-mov/.claude/plans/W-23369387.md)

## Reviewer notes

- **Low:** `appInsights.ts`: `isTelemetryExtensionConfigurationEnabled` changed from exported to module-private — it's now only consumed inside `appInsights.ts`/`spanUtils.ts` after `spansNode.ts`/`spansWeb.ts` stopped calling it directly, so de-exporting satisfies knip. No other consumers.
- The AC's mid-session-toggle behavior can't be exercised e2e: `isTelemetryExtensionConfigurationEnabled()` short-circuits true whenever `extensionMode` is Development/Test (the divert-mode check), which is how Playwright always launches the extension — so toggling the setting in an e2e can't change exporter behavior. Coverage is via the new unit tests in `gatedSpanExporter.test.ts` (disabled → no delegate construction, enabled → construct-once-then-cache, per-batch re-check). Flagging for explicit reviewer sign-off per the plan.

### What issues does this PR fix or reference?
@W-23369387@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/a07EE00002eG6sEYAS/view
