### PR TITLE
chore(effect-ext-utils): enforce consistent-type-imports - W-23371026

### DIFF
--- a/.claude/plans/W-23371026.md
+++ b/.claude/plans/W-23371026.md
@@ -5,7 +5,7 @@
 - Enforce `@typescript-eslint/consistent-type-imports` on `packages/effect-ext-utils/**/*.ts`.
 - Config: `{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }`.
 - `fixStyle` MUST be `inline-type-imports` — repo `no-duplicate-imports` (eslint.config.mjs:489) lacks `allowSeparateTypeImports`; separate `import type` line + value line = duplicate.
-- Rule not currently set anywhere in eslint.config.mjs (grep: 0 hits).
+- Rule not set in eslint.config.mjs (grep: 0 hits).
 - Existing Effect override block eslint.config.mjs:669-736 already lists `packages/effect-ext-utils/**/*.ts`.
 - 15 `.ts` files in pkg (src+test). Lint: `eslint --cache .` via wireit (package.json:89).
 - Split from closed W-23354585 / PR #7702 (repo-wide too large).
@@ -18,7 +18,7 @@
   ```
   '@typescript-eslint/consistent-type-imports': ['error', { prefer: 'type-imports', fixStyle: 'inline-type-imports' }]
   ```
-  - place near existing Effect block (~line 736), separate block per WI intent.
+  - place near Effect block (~line 736), separate block per WI intent.
 - Run `eslint --fix` scoped to pkg: `npx eslint --fix packages/effect-ext-utils`.
 - Review diff: inline `type` qualifiers on named imports; no new separate `import type` lines; no `no-duplicate-imports` violations.
 - commit msg: `chore(effect-ext-utils): enforce consistent-type-imports - W-23371026`

--- a/.claude/plans/W-23371026.md
+++ b/.claude/plans/W-23371026.md
@@ -1,0 +1,38 @@
+# W-23371026 — consistent-type-imports for effect-ext-utils
+
+## Context
+
+- Enforce `@typescript-eslint/consistent-type-imports` on `packages/effect-ext-utils/**/*.ts`.
+- Config: `{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }`.
+- `fixStyle` MUST be `inline-type-imports` — repo `no-duplicate-imports` (eslint.config.mjs:489) lacks `allowSeparateTypeImports`; separate `import type` line + value line = duplicate.
+- Rule not currently set anywhere in eslint.config.mjs (grep: 0 hits).
+- Existing Effect override block eslint.config.mjs:669-736 already lists `packages/effect-ext-utils/**/*.ts`.
+- 15 `.ts` files in pkg (src+test). Lint: `eslint --cache .` via wireit (package.json:89).
+- Split from closed W-23354585 / PR #7702 (repo-wide too large).
+
+## Phases
+
+### Phase 1 — add rule + apply fixes
+
+- Add package-scoped override block to `eslint.config.mjs` for `packages/effect-ext-utils/**/*.ts`:
+  ```
+  '@typescript-eslint/consistent-type-imports': ['error', { prefer: 'type-imports', fixStyle: 'inline-type-imports' }]
+  ```
+  - place near existing Effect block (~line 736), separate block per WI intent.
+- Run `eslint --fix` scoped to pkg: `npx eslint --fix packages/effect-ext-utils`.
+- Review diff: inline `type` qualifiers on named imports; no new separate `import type` lines; no `no-duplicate-imports` violations.
+- commit msg: `chore(effect-ext-utils): enforce consistent-type-imports - W-23371026`
+
+## Skills to apply
+
+- typescript
+- effect-best-practices (import style, no barrel)
+- verification
+- packageJson (n/a unless pkg dep touched — skip)
+
+## Verification
+
+- `npx eslint packages/effect-ext-utils` — clean, 0 errors (esp. no-duplicate-imports).
+- `npm run compile -w packages/effect-ext-utils` (or wireit compile) — types still resolve after inline-type qualifiers.
+- diff review: only import-line changes, no logic churn.
+- No e2e coverage — lint/type change, verify locally.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -735,6 +735,16 @@ export default [
     }
   },
   {
+    // consistent-type-imports for effect-ext-utils (inline to avoid no-duplicate-imports)
+    files: ['packages/effect-ext-utils/**/*.ts'],
+    rules: {
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        { prefer: 'type-imports', fixStyle: 'inline-type-imports' }
+      ]
+    }
+  },
+  {
     // class-methods-use-this for packages not yet using Effect
     files: [
       'packages/salesforcedx-vscode-apex-oas/**/*.ts',

--- a/packages/effect-ext-utils/src/messages/i18n.ja.ts
+++ b/packages/effect-ext-utils/src/messages/i18n.ja.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { MessageKey } from './i18n';
+import { type MessageKey } from './i18n';
 
 export const messages: Partial<Record<MessageKey, string>> = {
   predicates_no_folder_opened_text:

--- a/packages/effect-ext-utils/test/jest/table.test.ts
+++ b/packages/effect-ext-utils/test/jest/table.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Column, createTable, Row } from '../../src/table';
+import { type Column, createTable, type Row } from '../../src/table';
 
 // Find column boundaries by looking for separator pattern '  ' (2 spaces)
 const findColumnStarts = (line: string): number[] => {


### PR DESCRIPTION
## Summary
- Add `@typescript-eslint/consistent-type-imports` override (`prefer: type-imports`, `fixStyle: inline-type-imports`) scoped to `packages/effect-ext-utils/**/*.ts`.
- `--fix` inlined `type` qualifiers on affected imports; no separate `import type` lines (avoids `no-duplicate-imports` conflict since the repo's rule lacks `allowSeparateTypeImports`).
- No logic changes — import-line churn only.

## Plan
.claude/plans/W-23371026.md

### What issues does this PR fix or reference?
@W-23371026@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eGP9ZYAW/view