### PR TITLE
fix(org): expiry-soon check must not steal focus from open quick input - W-23424950

### DIFF
--- a/packages/salesforcedx-vscode-org/src/channels/index.ts
+++ b/packages/salesforcedx-vscode-org/src/channels/index.ts
@@ -5,12 +5,23 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { ChannelService } from '@salesforce/salesforcedx-utils-vscode';
-import * as vscode from 'vscode';
-import { nls } from '../messages';
+import type * as vscode from 'vscode';
 
-const channelName = nls.localize('channel_name');
+// Legacy wrapper over the ONE OutputChannel the Effect layer owns (wired at activation via setOrgChannel).
+// Avoids a second same-named channel — VS Code doesn't dedupe by name.
 
-export const channelService = ChannelService.getInstance(channelName);
+let channelServiceRef: ChannelService | undefined;
 
-/** Same channel as {@link channelService}; safe to pass to `extensionContext.subscriptions.push`. */
-export const OUTPUT_CHANNEL: vscode.OutputChannel = ChannelService.getChannel(channelName);
+/** Wire the legacy ChannelService wrapper to the Effect layer's OutputChannel. Call once at activation. */
+export const setOrgChannel = (channel: vscode.OutputChannel): ChannelService => {
+  channelServiceRef = new ChannelService(channel);
+  return channelServiceRef;
+};
+
+/** Legacy channel wrapper (appendLine/showChannelOutput/...). Throws if accessed before activation wires it. */
+export const getOrgChannelService = (): ChannelService => {
+  if (!channelServiceRef) {
+    throw new Error('Org output channel accessed before activation (setOrgChannel not called)');
+  }
+  return channelServiceRef;
+};

--- a/packages/salesforcedx-vscode-org/src/commands/orgDelete.ts
+++ b/packages/salesforcedx-vscode-org/src/commands/orgDelete.ts
@@ -12,7 +12,7 @@ import { identity } from 'effect/Function';
 import { isError } from 'effect/Predicate';
 import * as Schema from 'effect/Schema';
 import * as SubscriptionRef from 'effect/SubscriptionRef';
-import { channelService } from '../channels';
+import { getOrgChannelService } from '../channels';
 import { nls } from '../messages';
 import { gather, OrgToDelete } from '../parameterGatherers/selectDeletableOrg';
 import { ConfigRefreshError, updateConfigAndStateAggregators } from '../util/orgUtil';
@@ -68,7 +68,7 @@ export const orgDeleteDefaultCommand = Effect.fn('orgDeleteDefaultCommand')(func
   const channel = yield* api.services.ChannelService;
   yield* channel.appendToChannel(output);
   yield* Effect.sync(() => {
-    channelService.showChannelOutput();
+    getOrgChannelService().showChannelOutput();
   });
 
   yield* Effect.tryPromise({

--- a/packages/salesforcedx-vscode-org/src/index.ts
+++ b/packages/salesforcedx-vscode-org/src/index.ts
@@ -15,7 +15,7 @@ import type { SalesforceVSCodeOrgApi } from '@salesforce/salesforcedx-utils-vsco
 import * as Effect from 'effect/Effect';
 import * as Scope from 'effect/Scope';
 import * as vscode from 'vscode';
-import { channelService, OUTPUT_CHANNEL } from './channels';
+import { getOrgChannelService, setOrgChannel } from './channels';
 import { orgListCleanCommand, orgLoginWebCommand, orgLogoutAllCommand, orgLogoutDefaultCommand } from './commands';
 import { orgLoginAccessTokenCommand } from './commands/auth/orgLoginAccessToken';
 import { orgLoginWebDevHubCommand } from './commands/auth/orgLoginWebDevHub';
@@ -59,7 +59,7 @@ export const activate = async (extensionContext: vscode.ExtensionContext): Promi
   await activateEffect(extensionContext).pipe(Scope.extend(extensionScope), getOrgRuntime().runPromise);
 
   const api: SalesforceVSCodeOrgApi = {
-    channelService
+    channelService: getOrgChannelService()
   };
   return api;
 };
@@ -67,11 +67,13 @@ export const activate = async (extensionContext: vscode.ExtensionContext): Promi
 const activateEffect = Effect.fn('activation:salesforcedx-vscode-org')(function* (
   extensionContext: vscode.ExtensionContext
 ) {
-  // Register output channel
-  extensionContext.subscriptions.push(OUTPUT_CHANNEL);
-
   // Register Effect-based commands with AllServicesLayer for proper tracing
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
+
+  // Wire the legacy wrapper to the Effect channel so only one 'Salesforce Org Management' channel exists.
+  const orgChannel = yield* (yield* api.services.ChannelService).getChannel;
+  setOrgChannel(orgChannel);
+  extensionContext.subscriptions.push(orgChannel);
   const registerCommand = api.services.registerCommandWithLayer(AllServicesLayer);
   yield* registerCommand('sf.org.create', orgCreateCommand);
   yield* registerCommand('sf.org.delete.default', orgDeleteDefaultCommand);

--- a/packages/salesforcedx-vscode-org/src/util/orgUtil.ts
+++ b/packages/salesforcedx-vscode-org/src/util/orgUtil.ts
@@ -7,13 +7,13 @@
 
 import { AuthFields, AuthInfo, AuthRemover, OrgAuthorization, StateAggregator } from '@salesforce/core';
 import { Column, createTable, Row, ExtensionProviderService } from '@salesforce/effect-ext-utils';
-import { notificationService } from '@salesforce/salesforcedx-utils-vscode';
 import { ICONS } from '@salesforce/vscode-services';
 import { Effect, Stream, SubscriptionRef } from 'effect';
 import * as Chunk from 'effect/Chunk';
 import * as Option from 'effect/Option';
 import { isError, isNotUndefined, isString } from 'effect/Predicate';
 import * as Schema from 'effect/Schema';
+import * as vscode from 'vscode';
 import { getOrgRuntime } from '../extensionProvider';
 import { nls } from '../messages';
 
@@ -92,7 +92,7 @@ export const checkForSoonToBeExpiredOrgs = Effect.fn('OrgUtil.checkForSoonToBeEx
     Stream.tap(o =>
       // special warning about when default orgs expire
       defaultOrgRef.username && o.username === defaultOrgRef.username && orgIsExpired(o)
-        ? Effect.sync(() => void notificationService.showWarningMessage(nls.localize('default_org_expired')))
+        ? Effect.sync(() => void vscode.window.showWarningMessage(nls.localize('default_org_expired')))
         : Effect.void
     ),
     // Filter out the expired orgs.
@@ -110,10 +110,6 @@ export const checkForSoonToBeExpiredOrgs = Effect.fn('OrgUtil.checkForSoonToBeEx
     return;
   }
 
-  notificationService.showWarningMessage(
-    nls.localize('pending_org_expiration_notification_message', DAYS_BEFORE_EXPIRE)
-  );
-
   yield* channel.appendToChannel(
     nls.localize(
       'pending_org_expiration_output_channel_message',
@@ -121,7 +117,19 @@ export const checkForSoonToBeExpiredOrgs = Effect.fn('OrgUtil.checkForSoonToBeEx
       Chunk.toArray(results).join('\n\n')
     )
   );
-  yield* channel.showChannel;
+
+  // Runs unbidden (forkDaemon), so must not reveal the channel: focus-out cancels an open picker.
+  // Offer Show Output; reveal only on click.
+  const showOutputText = nls.localize('org_login_web_show_output_button_text');
+  const selection = yield* Effect.promise(() =>
+    vscode.window.showWarningMessage(
+      nls.localize('pending_org_expiration_notification_message', DAYS_BEFORE_EXPIRE),
+      showOutputText
+    )
+  );
+  if (selection === showOutputText) {
+    yield* channel.showChannel;
+  }
 });
 
 /** Fetch AuthFields for a username. Leaf Promise (`AuthInfo.create`/`getFields`); no runtime re-entry. */

--- a/packages/salesforcedx-vscode-org/test/jest/commands/orgDelete.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/commands/orgDelete.test.ts
@@ -16,8 +16,8 @@ import { orgDeleteDefaultCommand, orgDeleteUsernameCommand } from '../../../src/
 import type { OrgToDelete } from '../../../src/parameterGatherers/selectDeletableOrg';
 
 jest.mock('../../../src/channels', () => ({
-  channelService: { appendLine: jest.fn(), showChannelOutput: jest.fn() },
-  OUTPUT_CHANNEL: {}
+  getOrgChannelService: () => ({ appendLine: jest.fn(), showChannelOutput: jest.fn() }),
+  setOrgChannel: jest.fn()
 }));
 
 const mockUpdateConfigAndStateAggregators = jest.fn<Promise<void>, []>();

--- a/packages/salesforcedx-vscode-org/test/jest/util/orgUtil.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/util/orgUtil.test.ts
@@ -11,7 +11,7 @@ import {
   ExtensionProviderService,
   type ExtensionProviderService as ExtensionProviderServiceType
 } from '@salesforce/effect-ext-utils';
-import { ConfigUtil, notificationService } from '@salesforce/salesforcedx-utils-vscode';
+import { ConfigUtil } from '@salesforce/salesforcedx-utils-vscode';
 import type { SalesforceVSCodeServicesApi } from '@salesforce/vscode-services';
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
@@ -93,7 +93,10 @@ describe('orgUtil tests', () => {
         }
       }
     } as any);
-    showWarningMessageSpy = jest.spyOn(notificationService, 'showWarningMessage').mockImplementation(jest.fn());
+    // The expiry-soon warning is now a direct vscode.window.showWarningMessage with a Show Output action.
+    // Default the return to undefined (user dismissed without clicking) so the channel reveal stays gated;
+    // tests that assert the reveal set a resolved value matching the button label.
+    showWarningMessageSpy = jest.spyOn(vscode.window, 'showWarningMessage').mockResolvedValue(undefined);
     appendToChannelMock = jest.fn();
     showChannelMock = jest.fn();
     listAllAuthorizationsSpy = jest.spyOn(AuthInfo, 'listAllAuthorizations');
@@ -191,7 +194,9 @@ describe('orgUtil tests', () => {
     expect(authInfoCreateSpy).toHaveBeenCalled();
   });
 
-  it('should display a notification when the scratch org is about to expire', async () => {
+  it('reveals the Output panel only when the user clicks Show Output on the expiry warning', async () => {
+    // Simulate the user clicking the Show Output action on the warning toast.
+    showWarningMessageSpy.mockResolvedValue(nls.localize('org_login_web_show_output_button_text'));
     listAllAuthorizationsSpy.mockResolvedValue([
       {
         isDevHub: false,
@@ -282,7 +287,9 @@ describe('orgUtil tests', () => {
     expect(appendToChannelMock.mock.calls[0][0]).toContain('foo');
     expect(appendToChannelMock.mock.calls[0][0]).toContain(orgName2);
     expect(appendToChannelMock.mock.calls[0][0]).toContain('bar');
-    expect(showChannelMock).toHaveBeenCalled();
+    // Default spy return is undefined (user dismissed the toast) → the panel must not be revealed.
+    // This is the fix: the background check must never steal focus by auto-revealing the Output panel.
+    expect(showChannelMock).not.toHaveBeenCalled();
   });
 
   it('should display notifications for both an expired org and an org about to expire', async () => {
@@ -344,7 +351,8 @@ describe('orgUtil tests', () => {
     // Assert that the notifications for both orgs are displayed
     expect(showWarningMessageSpy).toHaveBeenCalledTimes(2);
     expect(appendToChannelMock).toHaveBeenCalled();
-    expect(showChannelMock).toHaveBeenCalled();
+    // Neither toast was clicked (default undefined) → the panel stays hidden; no focus steal.
+    expect(showChannelMock).not.toHaveBeenCalled();
 
     // Verify the specific calls
     const calls = showWarningMessageSpy.mock.calls.map(call => call[0]);


### PR DESCRIPTION
### What does this PR do?

Fixes the root cause of the flaky macOS org-picker Playwright e2e, plus a duplicate-output-channel bug surfaced while verifying that fix.

**Fix 1 — org picker focus-steal (the reported flake).** `checkForSoonToBeExpiredOrgs`, forked as a background daemon at activation (`salesforcedx-vscode-org/src/index.ts`), unconditionally called `channel.showChannel` (= `channel.show()`, no `preserveFocus`) whenever a scratch org expires within 5 days — revealing **and focusing** the Output panel. VS Code hides an open quick input on focus-out unless `ignoreFocusOut` is set (`workbench.desktop.main.js`: `onDidBlur(() => !ignoreFocusOut && !options.ignoreFocusOut() && this.hide(1))`). The org picker calls `showQuickPick` with no `ignoreFocusOut`, so the daemon's reveal blurred the open picker → VS Code cancelled it → `showQuickPick` resolved `undefined` → `considerUndefinedAsCancellation` threw "User cancelled". The picker vanished before its rows rendered — the `orgPicker.desktop`/`orgPickers.desktop` failure signature. (Failing-run evidence: 10/12 `setDefaultOrg` spans = "User cancelled"; the failure video showed the focused Output panel + "orgs expire in the next 5 days".)

Fix: surface a **Show Output** action on the expiry warning toast (direct `vscode.window.showWarningMessage`, dropping the legacy `notificationService`) and reveal the channel only if the user clicks it — mirroring `executeOrgLoginWeb`'s port-conflict pattern. The `appendToChannel` write stays unconditional.

**Fix 2 — duplicate "Salesforce Org Management" output channel.** The org extension created **two** channels of that name: the legacy one in `channels/index.ts` (`ChannelService.getInstance`, exposed as the public `SalesforceVSCodeOrgApi.channelService` and used by `orgDelete`'s reveal) and the Effect services-layer one (`ChannelServiceLayer(displayName)`, used by migrated commands). VS Code doesn't dedupe by name, so both appeared in the Output dropdown — a latent bug (`orgDelete` wrote to the Effect channel but revealed the legacy one) that also flaked `orgListClean`/`orgDisplay` (strict-mode "resolved to 2 elements"). Fix 1 shifted channel timing enough to make this pre-existing duplicate break deterministically, so it's fixed here: the legacy wrapper is now built over the **single** `OutputChannel` the Effect layer owns (`setOrgChannel` at activation), so exactly one channel is registered. Only the org extension had this double-creation.

### What issues does this PR fix or reference?
@W-23424950@

### Functionality Before
- Background "orgs expire soon" check stole focus (revealed + focused the Output panel unbidden), cancelling any open quick input (e.g. the org picker).
- Two identical "Salesforce Org Management" entries in the Output dropdown; org-delete output written to one channel but the other revealed.

### Functionality After
- Expiry warning offers a **Show Output** button; the panel is revealed only on click. Nothing steals focus.
- Exactly one "Salesforce Org Management" channel; writes and reveals hit the same channel.

### Reviewer notes
- **Verified locally on VS Code 1.128.0 (before/after, identical conditions with soon-to-expire scratch orgs present):**
  - Focus-steal: unfixed fails both org-picker specs with the exact CI signature (`.quick-input-widget` hidden / `.monaco-list-row` never renders); fixed passes.
  - Duplicate channel: on develop `orgListClean` passes on timing luck; after Fix 1 it failed deterministically; after Fix 2 `orgListClean` passes and `orgDisplay`'s `selectOutputChannel` assertion passes.
  - `orgPickers.desktop` ran 3/3 locally (raw, no retries); 175/175 org unit tests pass.
- **CI (Org E2E, two fresh cold-cache runs, attempt 1, no reruns):** both macOS + Windows green. macOS (this WI's target) was fully clean (13/13) on the second run. A single command-palette-open flake (`executeCommandWithCommandPalette`, the generic 30s retry helper) appeared once per run and moved between OSes run-to-run — a pre-existing, low-rate, OS-agnostic palette race unrelated to these changes, absorbed by Playwright's retry.