### PR TITLE
build(apex): add test:compile wireit target - W-23052132

### DIFF
--- a/.claude/plans/W-23052132.md
+++ b/.claude/plans/W-23052132.md
@@ -1,0 +1,43 @@
+# W-23052132 — 3.1 Convert salesforcedx-apex to jest + wireit
+
+## Context
+
+- Target: `packages/salesforcedx-apex` (repo forcedotcom/salesforcedx-vscode).
+- Prereq W-23051181 (migration commit `52eec5b07`) ALREADY did most of this WI:
+  - `jest.config.js` (extends `config/jest.base.config.js`; TZ pin, ts-jest `isolatedModules:false`, `test/tsconfig.json`).
+  - wireit `compile`/`test`/`lint`/`check:circular-deps` + npm scripts.
+  - mocha/nyc/mocha-snap removed; no `.mocharc`/`.nycrc`; no `mocha|chai|nyc` refs in src/test.
+  - snapshots ported to jest `toMatchSnapshot` → `test/tests/__snapshots__/*.snap` (writeResultFiles, writeAsyncResultsToFile). Verified passing (18 snaps).
+- Remaining delta vs reference shape WI names (`salesforcedx-vscode-i18n`, `salesforcedx-utils`): apex missing **`test:compile`** target. Its `test` deps `compile` directly; ref pkgs interpose `test:compile` (`tsc -p test/tsconfig.json`) for full test-file typecheck.
+- `test/tsconfig.json` exists, typechecks clean (`tsc -p test/tsconfig.json` exit 0).
+- soql-common lacks `test:compile`; WI target list explicitly includes it → follow i18n/utils.
+
+## Definition of done
+
+apex wireit shape = i18n/utils: `compile` → `test:compile` → `test`; `lint` deps compile+circular-deps. Build/test/lint green.
+
+## Phases
+
+### Phase 1 — add test:compile target
+- `packages/salesforcedx-apex/package.json`:
+  - add npm script `"test:compile": "wireit"`.
+  - wireit `test:compile`: `command: "tsc -p test/tsconfig.json"`, `dependencies: ["compile"]`, `files: ["test/**/*.ts","test/tsconfig.json"]`, `output: []` (match utils).
+  - rewire `test.dependencies`: `["compile"]` → `["test:compile"]`.
+- dead-code cleanup: drop stale `.nyc_output` lines in `packages/salesforcedx-apex/.gitignore` (nyc gone).
+- commit: `build(apex): add test:compile wireit target, drop nyc gitignore - W-23052132`
+
+## Skills to apply
+
+- wireit — target shape, dep ordering, files/output caching.
+- typescript — test:compile tsc invocation, tsconfig wiring.
+- concise — plan + any md.
+- verification — confirm targets run/cache.
+
+## Verification
+
+- `npm run test:compile -w packages/salesforcedx-apex` (WIREIT_CACHE=none) → typecheck clean.
+- `npm test -w packages/salesforcedx-apex` → jest green incl. snapshot suites; confirm `test:compile` ran as dep.
+- `npm run compile -w packages/salesforcedx-apex` green.
+- `npm run lint -w packages/salesforcedx-apex` green.
+- re-run `test` → wireit cache hit (no recompile) confirms caching.
+- Not e2e-covered: apex is a lib pkg, no branch e2e specs.

--- a/packages/salesforcedx-apex/.gitignore
+++ b/packages/salesforcedx-apex/.gitignore
@@ -18,8 +18,6 @@ xunit.xml
 junit-custom.xml
 path
 
-# nyc test coverage
-.nyc_output
 /test-results
 
 # Eclipse
@@ -46,9 +44,6 @@ lib-cov
 # Coverage directory used by tools like istanbul
 coverage
 *.lcov
-
-# nyc test coverage
-.nyc_output
 
 # Grunt intermediate storage (https://gruntjs.com/creating-plugins#storing-task-files)
 .grunt

--- a/packages/salesforcedx-apex/package.json
+++ b/packages/salesforcedx-apex/package.json
@@ -52,6 +52,7 @@
     "lint": "wireit",
     "check:circular-deps": "wireit",
     "clean": "shx rm -rf node_modules lib dist coverage .wireit .eslintcache .circular-deps.json",
+    "test:compile": "wireit",
     "test": "wireit"
   },
   "wireit": {
@@ -68,10 +69,21 @@
         "lib/**"
       ]
     },
+    "test:compile": {
+      "command": "tsc -p test/tsconfig.json",
+      "dependencies": [
+        "compile"
+      ],
+      "files": [
+        "test/**/*.ts",
+        "test/tsconfig.json"
+      ],
+      "output": []
+    },
     "test": {
       "command": "jest",
       "dependencies": [
-        "compile"
+        "test:compile"
       ],
       "files": [
         "src/**/*.ts",


### PR DESCRIPTION
### What does this PR do?

## Summary
- Adds `test:compile` wireit target to `packages/salesforcedx-apex` (`tsc -p test/tsconfig.json`), matching the `compile` → `test:compile` → `test` shape used by `salesforcedx-vscode-i18n`/`salesforcedx-utils`.
- Rewires `test.dependencies` from `["compile"]` to `["test:compile"]` so test-file typechecking runs before jest.
- Drops stale `.nyc_output` line from `packages/salesforcedx-apex/.gitignore` (nyc already removed in prereq W-23051181).

## Plan
[.claude/plans/W-23052132.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23052132-3-1-convert-salesforcedx-apex-to-jest-wi/.claude/plans/W-23052132.md)

### What issues does this PR fix or reference?
@W-23052132@

### Functionality Before
apex missing `test:compile`; `test` depended directly on `compile`, so test-file typecheck errors were not caught before jest ran.

### Functionality After
apex wireit shape matches i18n/utils reference: `compile` → `test:compile` → `test`.

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cSX7DYAW/view