### PR TITLE
build(apex): align salesforcedx-apex build output dir (lib/ to out/) with monorepo convention - W-23166333

### DIFF
--- a/.claude/plans/W-23166333.md
+++ b/.claude/plans/W-23166333.md
@@ -4,7 +4,7 @@
 
 - `packages/salesforcedx-apex` (`@salesforce/apex-node`) emits to `lib/`; monorepo convention = `out/`.
 - Vendored, NOT npm-published from this repo (no publish workflow; repo v67.5.0 ≠ npm v8.4.35). Only in-repo consumers → safe to rename.
-- Deep-import compat is the only reason for `lib/`. Sole consumer: `apexTestRunCodeAction.ts:8` `import { ApexDiagnostic } from '@salesforce/apex-node/lib/src/utils'`.
+- Deep-import compat = only reason for `lib/`. Sole consumer: `apexTestRunCodeAction.ts:8` `import { ApexDiagnostic } from '@salesforce/apex-node/lib/src/utils'`.
   - `ApexDiagnostic` already re-exported from main entry (`src/index.ts:58`) → drop deep import, use bare `@salesforce/apex-node`.
 - `eslint.config.mjs:42-43` carries `packages/salesforcedx-apex/lib/**` ignore + comment — remove once out/ aligned (`**/out/**` already ignored, line 40).
 - Artifact refs to `lib`: `tsconfig.json` outDir; `package.json` main/types/exports(`.`+`./lib/src/utils`)/files/clean/wireit `compile.output`.
@@ -47,7 +47,7 @@ Commit: `chore(eslint): drop salesforcedx-apex lib/ ignore exemption - W-2316633
 
 ## Verification
 
-- Stop hook covers: compile (proves `out/src/index.js` emit + wireit cache match), lint (proves eslint exemption removal + no lint of out/), vscode:bundle (proves apex-testing bundles apex-node), knip.
+- Stop hook: compile (proves `out/src/index.js` emit + wireit cache match), lint (proves eslint exemption removal + no lint of out/), vscode:bundle (proves apex-testing bundles apex-node), knip.
 - Manual (hook-uncovered): after compile, confirm `ls packages/salesforcedx-apex/out/src/index.js` exists and no stale `lib/` emitted; re-run `npm run compile -w packages/salesforcedx-apex` → wireit reports cached/fresh (proves output glob matches).
 - Deep-import removal proven by apex-testing compile green.
 - No e2e coverage on branch.

--- a/.claude/plans/W-23166333.md
+++ b/.claude/plans/W-23166333.md
@@ -1,0 +1,53 @@
+# W-23166333 — align salesforcedx-apex build output lib/ → out/
+
+## Context
+
+- `packages/salesforcedx-apex` (`@salesforce/apex-node`) emits to `lib/`; monorepo convention = `out/`.
+- Vendored, NOT npm-published from this repo (no publish workflow; repo v67.5.0 ≠ npm v8.4.35). Only in-repo consumers → safe to rename.
+- Deep-import compat is the only reason for `lib/`. Sole consumer: `apexTestRunCodeAction.ts:8` `import { ApexDiagnostic } from '@salesforce/apex-node/lib/src/utils'`.
+  - `ApexDiagnostic` already re-exported from main entry (`src/index.ts:58`) → drop deep import, use bare `@salesforce/apex-node`.
+- `eslint.config.mjs:42-43` carries `packages/salesforcedx-apex/lib/**` ignore + comment — remove once out/ aligned (`**/out/**` already ignored, line 40).
+- Artifact refs to `lib`: `tsconfig.json` outDir; `package.json` main/types/exports(`.`+`./lib/src/utils`)/files/clean/wireit `compile.output`.
+- Package `.gitignore` already ignores `out/` (and `lib/`); drop dead `lib/` line.
+- No path-mappings, esbuild aliases, or bundling refs to apex `lib/`.
+
+## Phases
+
+### Phase 1 — rename build dir + fix consumer
+
+Files:
+- `packages/salesforcedx-apex/tsconfig.json` — `outDir: "lib"` → `"out"`
+- `packages/salesforcedx-apex/package.json`:
+  - `main` `lib/src/index.js` → `out/src/index.js`
+  - `types` `lib/src/index.d.ts` → `out/src/index.d.ts`
+  - `exports["."]` types/default `./lib/...` → `./out/...`
+  - drop `exports["./lib/src/utils"]` entry (deep-import subpath; no remaining consumer)
+  - `files` `["lib/src"]` → `["out/src"]`
+  - `clean` script `rm -rf ... lib ...` → `out`
+  - wireit `compile.output` `["lib/**"]` → `["out/**"]`
+- `packages/salesforcedx-apex/.gitignore` — drop `lib/` line (out/ already present)
+- `packages/salesforcedx-vscode-apex-testing/src/commands/apexTestRunCodeAction.ts:8` — merge `ApexDiagnostic` into bare `@salesforce/apex-node` import (line 7); drop deep import line
+
+Commit: `build(apex): align output dir lib/ → out/ (tsconfig, package fields, wireit); bare-import ApexDiagnostic - W-23166333`
+
+### Phase 2 — drop eslint lib/ ignore exemption
+
+Files:
+- `eslint.config.mjs` — remove lines 42-43 (`packages/salesforcedx-apex/lib/**` + preceding comment)
+
+Commit: `chore(eslint): drop salesforcedx-apex lib/ ignore exemption - W-23166333`
+
+## Skills
+
+- packageJson — main/types/exports/files conventions
+- wireit — compile.output must match tsc emit dir (mismatch = no caching)
+- external-consumers — confirmed apex-node not published externally; in-repo only
+- typescript — tsconfig.json outDir edit, bare-import merge in apexTestRunCodeAction.ts
+- verification
+
+## Verification
+
+- Stop hook covers: compile (proves `out/src/index.js` emit + wireit cache match), lint (proves eslint exemption removal + no lint of out/), vscode:bundle (proves apex-testing bundles apex-node), knip.
+- Manual (hook-uncovered): after compile, confirm `ls packages/salesforcedx-apex/out/src/index.js` exists and no stale `lib/` emitted; re-run `npm run compile -w packages/salesforcedx-apex` → wireit reports cached/fresh (proves output glob matches).
+- Deep-import removal proven by apex-testing compile green.
+- No e2e coverage on branch.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,8 +39,6 @@ export default [
     ignores: [
       '**/out/**',
       '**/dist/**',
-      // salesforcedx-apex emits to lib/ (deep-import compat) instead of out/; don't lint build output
-      'packages/salesforcedx-apex/lib/**',
       '**/packages/**/coverage',
       '**/test-workspaces/**',
       '**/*.d.ts',

--- a/packages/salesforcedx-apex/.gitignore
+++ b/packages/salesforcedx-apex/.gitignore
@@ -1,7 +1,6 @@
 # TypeScript generated files
 dist/
 out/
-lib/
 tmp/
 
 # Logs

--- a/packages/salesforcedx-apex/package.json
+++ b/packages/salesforcedx-apex/package.json
@@ -4,16 +4,12 @@
   "version": "67.5.0",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/salesforcedx-apex/issues",
-  "main": "lib/src/index.js",
-  "types": "lib/src/index.d.ts",
+  "main": "out/src/index.js",
+  "types": "out/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./lib/src/index.d.ts",
-      "default": "./lib/src/index.js"
-    },
-    "./lib/src/utils": {
-      "types": "./lib/src/utils/index.d.ts",
-      "default": "./lib/src/utils/index.js"
+      "types": "./out/src/index.d.ts",
+      "default": "./out/src/index.js"
     }
   },
   "dependencies": {
@@ -44,14 +40,14 @@
     "salesforcedx"
   ],
   "files": [
-    "lib/src"
+    "out/src"
   ],
   "scripts": {
     "preinstall": "node ../../scripts/require-root-install.js",
     "compile": "wireit",
     "lint": "wireit",
     "check:circular-deps": "wireit",
-    "clean": "shx rm -rf node_modules lib dist coverage .wireit .eslintcache .circular-deps.json",
+    "clean": "shx rm -rf node_modules out dist coverage .wireit .eslintcache .circular-deps.json",
     "test:compile": "wireit",
     "test": "wireit"
   },
@@ -66,7 +62,7 @@
         "package.json"
       ],
       "output": [
-        "lib/**"
+        "out/**"
       ]
     },
     "test:compile": {

--- a/packages/salesforcedx-apex/tsconfig.json
+++ b/packages/salesforcedx-apex/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.common.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "lib",
+    "outDir": "out",
     "experimentalDecorators": true,
     "isolatedModules": false,
     "preserveConstEnums": true

--- a/packages/salesforcedx-vscode-apex-testing/src/commands/apexTestRunCodeAction.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/commands/apexTestRunCodeAction.ts
@@ -4,8 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { ApexTestResultData, TestLevel, TestResult } from '@salesforce/apex-node';
-import { ApexDiagnostic } from '@salesforce/apex-node/lib/src/utils';
+import { type ApexDiagnostic, ApexTestResultData, TestLevel, TestResult } from '@salesforce/apex-node';
 import { type NamedPackageDir } from '@salesforce/core';
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import * as Effect from 'effect/Effect';


### PR DESCRIPTION
### What does this PR do?

## Summary
- Renamed `salesforcedx-apex` build output dir `lib/` → `out/` to match monorepo convention (tsconfig `outDir`, package.json `main`/`types`/`exports`/`files`/`clean`/wireit `compile.output`, `.gitignore`).
- Dropped the sole deep-import consumer (`apexTestRunCodeAction.ts`'s `@salesforce/apex-node/lib/src/utils`) in favor of the bare `@salesforce/apex-node` entry, which already re-exports `ApexDiagnostic`.
- Removed the now-dead `packages/salesforcedx-apex/lib/**` eslint ignore exemption.

## Plan
.claude/plans/W-23166333.md

### What issues does this PR fix or reference?
@W-23166333@

## Test plan
- `ls packages/salesforcedx-apex/out/src/index.js` exists; no stale `lib/` emitted after compile.
- Re-run `npm run compile -w packages/salesforcedx-apex` reports wireit cache hit (output glob matches emit dir).

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002d3DZDYA2/view