### PR TITLE
chore(apex-testing): enable local/no-explicit-effect-return-type - W-23354481

### DIFF
--- a/.claude/skills/effect-best-practices/references/anti-patterns.md
+++ b/.claude/skills/effect-best-practices/references/anti-patterns.md
@@ -136,7 +136,7 @@ export class UserService extends Effect.Service<UserService>()("UserService", {
 **Correct:**
 ```typescript
 const findById = Effect.fn("UserService.findById")(
-    function* (id: UserId): Effect.Effect<User, UserNotFoundError> {
+    function* (id: UserId) {
         // ...
     }
 )

--- a/.claude/skills/effect-best-practices/references/service-patterns.md
+++ b/.claude/skills/effect-best-practices/references/service-patterns.md
@@ -225,7 +225,7 @@ Services should return `Effect` types, never `Promise`:
 ```typescript
 // CORRECT
 const findById = Effect.fn("UserService.findById")(
-    function* (id: UserId): Effect.Effect<User, UserNotFoundError> {
+    function* (id: UserId) {
         // ...
     }
 )
@@ -241,7 +241,7 @@ const findById = async (id: UserId): Promise<User> => {
 ```typescript
 // CORRECT - findById can fail, findByIdOption returns Option
 const findById = Effect.fn("UserService.findById")(
-    function* (id: UserId): Effect.Effect<User, UserNotFoundError> {
+    function* (id: UserId) {
         const maybeUser = yield* repo.findById(id)
         return yield* Option.match(maybeUser, {
             onNone: () => Effect.fail(new UserNotFoundError({ userId: id, message: "Not found" })),
@@ -251,7 +251,7 @@ const findById = Effect.fn("UserService.findById")(
 )
 
 const findByIdOption = Effect.fn("UserService.findByIdOption")(
-    function* (id: UserId): Effect.Effect<Option<User>> {
+    function* (id: UserId) {
         return yield* repo.findById(id)
     }
 )

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -764,8 +764,8 @@ export default [
   },
   {
     // class-methods-use-this for packages not yet using Effect
+    // (apex-oas omitted: covered by the Effect-services block above, which sets both rules)
     files: [
-      'packages/salesforcedx-vscode-apex-oas/**/*.ts',
       'packages/salesforcedx-vscode-apex-testing/**/*.ts',
       'packages/salesforcedx-vscode-soql/**/*.ts',
       'packages/soql-common/**/*.ts',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -772,7 +772,8 @@ export default [
       'packages/soql-model/**/*.ts'
     ],
     rules: {
-      'class-methods-use-this': 'error'
+      'class-methods-use-this': 'error',
+      'local/no-explicit-effect-return-type': 'error'
     }
   },
   {

--- a/plans/W-23354481.md
+++ b/plans/W-23354481.md
@@ -5,14 +5,14 @@
 - Guard-rail WI. 0 code changes to src; enable rule only.
 - `local/no-explicit-effect-return-type`: bans explicit `): Effect.Effect<...>` / `: Effect<...>` return annotations; lets TS infer. Fixable. Source: `packages/eslint-local-rules/src/noExplicitEffectReturnType.ts`.
 - apex-testing uses Effect (services/*.ts) but has 0 explicit Effect return-type annotations. Verified: `grep -rnE '\)\s*:\s*Effect(\.Effect)?\s*<' packages/salesforcedx-vscode-apex-testing/src` → 0 matches.
-- Rule NOT currently applied to apex-testing. apex-testing absent from Effect override block (`eslint.config.mjs` lines 689-698); present only in class-methods-use-this (769) + barrel-files (803) blocks.
+- Rule NOT applied to apex-testing; absent from Effect override block (`eslint.config.mjs` lines 689-698), present only in class-methods-use-this (769) + barrel-files (803) blocks.
 - Enabling the full Effect block for apex-testing would trip other rules (functional/no-let, no-throw, etc.) — out of scope. Add targeted single-rule override instead.
 
 ## Phases
 
 ### Phase 1 — add targeted override
 
-- `eslint.config.mjs`: add `'local/no-explicit-effect-return-type': 'error'` to the existing apex-testing class-methods-use-this override block's rules (files list already includes `packages/salesforcedx-vscode-apex-testing/**/*.ts`, line 769; rules at lines 774-776).
+- `eslint.config.mjs`: add `'local/no-explicit-effect-return-type': 'error'` to the shared class-methods-use-this override block's rules (files list already includes `packages/salesforcedx-vscode-apex-testing/**/*.ts`). NOTE: shared block also covers soql, soql-common, soql-model — rule now enforced there too (all verified 0 violations). apex-oas dropped from this block (already covered by Effect-services block).
 - No src changes (0 violations).
 - Commit: `chore(apex-testing): enable local/no-explicit-effect-return-type - W-23354481`
 
@@ -26,8 +26,8 @@
 ## Verification
 
 - `node --check` N/A (mjs config) — use eslint self-load.
-- Baseline has 2 pre-existing UNRELATED errors: `@typescript-eslint/prefer-nullish-coalescing` at `testResultProcessor.ts:143` (`1301 problems (2 errors, 1299 warnings)` on HEAD before change). Do NOT fix these — out of scope. Do NOT assert a blanket `0 errors`.
-- Scoped check: `cd packages/salesforcedx-vscode-apex-testing && npx eslint --no-cache 'src/**/*.ts'`. Pass criterion: grep output for `local/no-explicit-effect-return-type` → 0 matches (no NEW errors from this rule). Error count staying at 2 (both `prefer-nullish-coalescing`) confirms the rule added no violations.
+- 2 pre-existing UNRELATED errors: `prefer-nullish-coalescing` @ `testResultProcessor.ts:143` (`1301 problems (2 errors, 1299 warnings)` on HEAD before change) — out of scope, don't fix; don't claim blanket `0 errors`.
+- Scoped check: `cd packages/salesforcedx-vscode-apex-testing && npx eslint --no-cache 'src/**/*.ts'`. Pass: grep for `local/no-explicit-effect-return-type` → 0 matches; error count stays at 2 (both `prefer-nullish-coalescing`) → rule added no violations.
 - Sanity: temporarily add `): Effect.Effect<void>` annotation to one src fn, rerun lint → expect a `local/no-explicit-effect-return-type` error (grep confirms rule fires); revert.
-- Not e2e-covered: this is lint-config only; no playwright/e2e exercises it. No runtime surface to drive.
+- Not e2e-covered: lint-config only, no playwright/e2e exercise, no runtime surface to drive.
 </content>

--- a/plans/W-23354481.md
+++ b/plans/W-23354481.md
@@ -1,0 +1,33 @@
+# W-23354481 — Enable `local/no-explicit-effect-return-type` for apex-testing
+
+## Context
+
+- Guard-rail WI. 0 code changes to src; enable rule only.
+- `local/no-explicit-effect-return-type`: bans explicit `): Effect.Effect<...>` / `: Effect<...>` return annotations; lets TS infer. Fixable. Source: `packages/eslint-local-rules/src/noExplicitEffectReturnType.ts`.
+- apex-testing uses Effect (services/*.ts) but has 0 explicit Effect return-type annotations. Verified: `grep -rnE '\)\s*:\s*Effect(\.Effect)?\s*<' packages/salesforcedx-vscode-apex-testing/src` → 0 matches.
+- Rule NOT currently applied to apex-testing. apex-testing absent from Effect override block (`eslint.config.mjs` lines 689-698); present only in class-methods-use-this (769) + barrel-files (803) blocks.
+- Enabling the full Effect block for apex-testing would trip other rules (functional/no-let, no-throw, etc.) — out of scope. Add targeted single-rule override instead.
+
+## Phases
+
+### Phase 1 — add targeted override
+
+- `eslint.config.mjs`: add `'local/no-explicit-effect-return-type': 'error'` to the existing apex-testing class-methods-use-this override block's rules (files list already includes `packages/salesforcedx-vscode-apex-testing/**/*.ts`, line 769; rules at lines 774-776).
+- No src changes (0 violations).
+- Commit: `chore(apex-testing): enable local/no-explicit-effect-return-type - W-23354481`
+
+## Skills to apply
+
+- concise (plan/doc style)
+- typescript
+- effect-best-practices (rule intent)
+- packageJson (if any lint wiring touched — none expected)
+
+## Verification
+
+- `node --check` N/A (mjs config) — use eslint self-load.
+- Baseline has 2 pre-existing UNRELATED errors: `@typescript-eslint/prefer-nullish-coalescing` at `testResultProcessor.ts:143` (`1301 problems (2 errors, 1299 warnings)` on HEAD before change). Do NOT fix these — out of scope. Do NOT assert a blanket `0 errors`.
+- Scoped check: `cd packages/salesforcedx-vscode-apex-testing && npx eslint --no-cache 'src/**/*.ts'`. Pass criterion: grep output for `local/no-explicit-effect-return-type` → 0 matches (no NEW errors from this rule). Error count staying at 2 (both `prefer-nullish-coalescing`) confirms the rule added no violations.
+- Sanity: temporarily add `): Effect.Effect<void>` annotation to one src fn, rerun lint → expect a `local/no-explicit-effect-return-type` error (grep confirms rule fires); revert.
+- Not e2e-covered: this is lint-config only; no playwright/e2e exercises it. No runtime surface to drive.
+</content>


### PR DESCRIPTION
## Summary

- Adds `local/no-explicit-effect-return-type` to the shared `class-methods-use-this` override block in `eslint.config.mjs`, which already targets `apex-testing`.
- Guard-rail only — 0 src changes; apex-testing has 0 explicit `Effect.Effect<...>` return-type annotations today, so the new rule fires 0 violations.
- Same override block also covers `soql`, `soql-common`, `soql-model` (each verified 0 violations); `apex-oas` dropped from this block since it's already covered by the Effect-services override.

## Plan

See [plans/W-23354481.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23354481-8-2-enable-local-no-explicit-effect-retu/plans/W-23354481.md)

## Reviewer notes

- Commit `3a890b83fd` is titled `chore(apex-testing)` but the shared eslint override block also newly enforces `local/no-explicit-effect-return-type` for `soql`, `soql-common`, `soql-model` (all verified 0 violations). Not a code bug — the plan (Phase 1) documents the broader scope; flagging here in case the title should mention the extra packages.

## Test plan

- [x] `cd packages/salesforcedx-vscode-apex-testing && npx eslint --no-cache 'src/**/*.ts'` — grep for `local/no-explicit-effect-return-type` → 0 matches; error count unchanged at 2 (both pre-existing, unrelated `prefer-nullish-coalescing` in `testResultProcessor.ts:143`)
- [x] Sanity check: temporarily added `): Effect.Effect<void>` to one src fn, reran lint → confirmed `local/no-explicit-effect-return-type` fires; reverted
- Not e2e-covered: lint-config only change, no runtime surface to drive (no playwright/e2e exercise expected)

### What issues does this PR fix or reference?
@W-23354481@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eArGcYAK/view
