### PR TITLE
chore(apex-testing): flip no-explicit-any off->error - W-23354483

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -809,6 +809,14 @@ export default [
     }
   },
   {
+    // no-explicit-any enforced for apex-testing src (W-23354483).
+    // Scoped to src/** so the later test-files block keeps it off for tests.
+    files: ['packages/salesforcedx-vscode-apex-testing/src/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error'
+    }
+  },
+  {
     // Prevent direct imports from services extension (except in services package itself)
     // Only applies to src directories, not test directories
     files: ['packages/**/src/**/*.ts'],

--- a/plans/W-23354483.md
+++ b/plans/W-23354483.md
@@ -5,9 +5,9 @@
 - Flip `@typescript-eslint/no-explicit-any` off→error, scope = `salesforcedx-vscode-apex-testing` src
 - Root config: `eslint.config.mjs`
   - base block (line 102, `**/*.ts`) sets rule `off` (line 352)
-  - Effect-pkgs block (line 689) sets `error` — apex-testing NOT listed (also enables functional/* rules apex-testing not ready for; do NOT add there)
+  - Effect-pkgs block (line 689) sets `error` — apex-testing NOT listed (also enables functional/* rules — not ready; skip)
   - test-files block (line 822) sets `off` (line 857) — keep; scope new override to `src/**` only, no ordering conflict
-- Blockers 5/6/7 already cleaned all sites: forced-on eslint on `apex-testing/src/**/*.ts` = 0 `no-explicit-any` violations (verified). WI "1 site" already gone; task now config-only
+- Blockers 5/6/7 cleaned all sites: forced-on eslint on `apex-testing/src/**/*.ts` = 0 `no-explicit-any` violations (verified) — task now config-only
 - No `eslint-disable ...no-explicit-any` comments in pkg
 
 ## Phases
@@ -30,7 +30,7 @@ commit: `chore(apex-testing): flip no-explicit-any off->error - W-23354483`
 
 ## Verification
 
-- `node --check` n/a (config is `.mjs` w/ imports; instead:)
+- `node --check`: n/a — `.mjs` w/ imports
 - build local rules first: `npx tsc -p packages/eslint-local-rules/tsconfig.json` (out/index.js needed by config)
 - lint: `npx eslint 'packages/salesforcedx-vscode-apex-testing/src/**/*.ts'` → 0 `no-explicit-any` errors
 - confirm rule active: eslint reports `no-explicit-any` as error (not warning) if any reintroduced

--- a/plans/W-23354483.md
+++ b/plans/W-23354483.md
@@ -1,0 +1,37 @@
+# W-23354483 — no-explicit-any error for apex-testing
+
+## Context
+
+- Flip `@typescript-eslint/no-explicit-any` off→error, scope = `salesforcedx-vscode-apex-testing` src
+- Root config: `eslint.config.mjs`
+  - base block (line 102, `**/*.ts`) sets rule `off` (line 352)
+  - Effect-pkgs block (line 689) sets `error` — apex-testing NOT listed (also enables functional/* rules apex-testing not ready for; do NOT add there)
+  - test-files block (line 822) sets `off` (line 857) — keep; scope new override to `src/**` only, no ordering conflict
+- Blockers 5/6/7 already cleaned all sites: forced-on eslint on `apex-testing/src/**/*.ts` = 0 `no-explicit-any` violations (verified). WI "1 site" already gone; task now config-only
+- No `eslint-disable ...no-explicit-any` comments in pkg
+
+## Phases
+
+### Phase 1 — flip rule
+
+`eslint.config.mjs`
+
+- add override block (near existing apex-testing blocks ~765/800):
+  - `files: ['packages/salesforcedx-vscode-apex-testing/src/**/*.ts']`
+  - `rules: { '@typescript-eslint/no-explicit-any': 'error' }`
+- src-scoped: test files stay `off` via later block (822/857)
+
+commit: `chore(apex-testing): flip no-explicit-any off->error - W-23354483`
+
+## Skills to apply
+
+- typescript
+- verification
+
+## Verification
+
+- `node --check` n/a (config is `.mjs` w/ imports; instead:)
+- build local rules first: `npx tsc -p packages/eslint-local-rules/tsconfig.json` (out/index.js needed by config)
+- lint: `npx eslint 'packages/salesforcedx-vscode-apex-testing/src/**/*.ts'` → 0 `no-explicit-any` errors
+- confirm rule active: eslint reports `no-explicit-any` as error (not warning) if any reintroduced
+- no e2e coverage relevant (lint-config change)


### PR DESCRIPTION
## Summary
- Flip `@typescript-eslint/no-explicit-any` from off to error, scoped to `packages/salesforcedx-vscode-apex-testing/src/**/*.ts`
- Added a new override block in `eslint.config.mjs` (test files remain exempt via existing later block)
- Verified 0 `no-explicit-any` violations in current `src/` — this is a config-only change

## Plan
plans/W-23354483.md

## Test plan
- `npx tsc -p packages/eslint-local-rules/tsconfig.json` builds local rules cleanly
- `npx eslint 'packages/salesforcedx-vscode-apex-testing/src/**/*.ts'` reports 0 `no-explicit-any` errors
- Confirm rule enforcement: eslint reports `no-explicit-any` as an error (not warning) if reintroduced
- No e2e coverage needed — lint-config-only change

### What issues does this PR fix or reference?
@W-23354483@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eBFWyYAO/view
