### PR TITLE
build: wire effect-language-service diagnostics into precommit + CI - W-23429440

### DIFF
--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -54,3 +54,15 @@ jobs:
       - uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
       - name: Check knip
         run: npm run check:knip
+  check-effect-diagnostics:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
+          cache: npm
+      - uses: google/wireit@setup-github-actions-caching/v2
+      - uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
+      - name: Check Effect LS diagnostics
+        run: npm run check:effect-diagnostics

--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -56,6 +56,7 @@ jobs:
         run: npm run check:knip
   check-effect-diagnostics:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6

--- a/config/effect-diagnostics.json
+++ b/config/effect-diagnostics.json
@@ -1,0 +1,4 @@
+{
+  "$comment": "Effect LS diagnostics ratchet. scripts/effect-diagnostics.mjs fails the build only on findings whose rule name is listed in enforcedRules (any severity). Sibling WIs append a rule name here after fixing all its sites. Empty list = nothing enforced (exit 0).",
+  "enforcedRules": []
+}

--- a/package.json
+++ b/package.json
@@ -399,6 +399,7 @@
       "files": [
         "packages/*/src/**/*.ts",
         "packages/*/tsconfig.json",
+        "packages/*/package.json",
         "tsconfig.common.json",
         "config/effect-diagnostics.json",
         "scripts/effect-diagnostics.mjs"

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "check:actions": "wireit",
     "check:format:staged": "wireit",
     "check:knip": "wireit",
+    "check:effect-diagnostics": "wireit",
     "check:branch": "wireit",
     "precommit": "wireit",
     "prepush": "wireit",
@@ -387,6 +388,20 @@
         "tsconfig*.json",
         "packages/*/tsconfig*.json",
         "packages/*/src/**/*.ts"
+      ],
+      "output": []
+    },
+    "check:effect-diagnostics": {
+      "command": "node scripts/effect-diagnostics.mjs",
+      "dependencies": [
+        "compile"
+      ],
+      "files": [
+        "packages/*/src/**/*.ts",
+        "packages/*/tsconfig.json",
+        "tsconfig.common.json",
+        "config/effect-diagnostics.json",
+        "scripts/effect-diagnostics.mjs"
       ],
       "output": []
     },

--- a/package.json
+++ b/package.json
@@ -421,7 +421,8 @@
         "check:package-lock",
         "check:lock-sync",
         "check:actions",
-        "check:knip"
+        "check:knip",
+        "check:effect-diagnostics"
       ]
     },
     "prepush": {

--- a/plans/W-23429440.md
+++ b/plans/W-23429440.md
@@ -1,0 +1,58 @@
+# W-23429440 — Wire effect-language-service diagnostics into precommit + CI
+
+## Context
+
+- Epic "Effect LS diagnostics: enforce in CI". This = WI #1 (foundation): build plumbing only.
+- Siblings #2-15 each fix+enforce ONE rule; #15 enforces all zero-finding rules. They populate the enforced-rule list; WI #1 ships it EMPTY (green today).
+- Plugin `@effect/language-service` (^0.86.2) already configured in `tsconfig.common.json` `compilerOptions.plugins`. CLI at `node_modules/@effect/language-service/cli.js`, bin `effect-language-service`.
+- `effect-language-service diagnostics --project <tsconfig> --format json` emits `{diagnostics:[{file,line,column,severity,name,message,...}]}`. CLI honors tsconfig plugin `diagnosticSeverity` (verified). `--format github-actions` emits `::warning file=...` annotations.
+- ~1-2s/pkg. Effect-adopting pkgs w/ src: effect-ext-utils, salesforcedx-utils-vscode, salesforcedx-vscode-{core,apex,apex-debugger,apex-replay-debugger,apex-oas,apex-testing,apex-log,lwc,lightning,soql,metadata,org,org-browser,visualforce,services}, salesforcedx-lightning-lsp-common.
+- Edge: `salesforcedx-vscode-services-types` has NO src `.ts` → CLI throws `NoFilesToCheckError` exit 1 → must skip.
+- CRITICAL — CLI requires compiled cross-package types. On a fresh/uncompiled tree, cross-package imports (`@salesforce/effect-ext-utils`, etc.) resolve to `unknown` (TS2307), spawning phantom `missingEffectContext`/`missingLayerContext` findings on ~8 pkgs. After `npm run compile` builds `out/*.d.ts`, the identical command reports 0 such errors on all 17 pkgs. ∴ `check:effect-diagnostics` MUST depend on `compile` (mirror `check:knip`), else it reads stale/missing `.d.ts` and poisons the findings-by-rule signal that siblings #2-15 consume.
+- Current findings (unenforced, must NOT gate) — measured AFTER `npm run compile`: the earlier "6 pkgs w/ errors" baseline was an artifact of an uncompiled tree, NOT real Effect-typing debt. Post-compile true baseline TBD (re-measure in Phase 1); warnings+messages across services/effect-ext-utils/etc. remain. CLI default exit counts errors → cannot rely on CLI exit code.
+
+### Design: runner-controlled ratchet (not CLI exit code / not tsconfig severity)
+
+- Runner parses JSON, filters findings to `name ∈ enforcedRules` (config), fails only on those. Ignores all else. Decouples from CLI exit semantics + unreliable `*:off` wildcard (verified partial).
+- `config/effect-diagnostics.json`: `{ "enforcedRules": [] }`. Siblings append rule name after fixing. Empty → exit 0 today.
+- Any enforced-rule finding (any severity) → fail. Uniform per-rule gating.
+
+## Phases
+
+### Phase 1 — runner script + enforced config
+
+- New `config/effect-diagnostics.json`: `{ "$comment": "...", "enforcedRules": [] }`.
+- New `scripts/effect-diagnostics.mjs` (ESM, matches `scripts/*.mjs` convention):
+  - Discover pkgs: glob `packages/*/package.json`; keep if deps/devDeps has `effect` or `@effect/*` AND `packages/<p>/tsconfig.json` exists AND `packages/<p>/src` has `.ts`. Skips services-types.
+  - Per pkg: spawn `node <cli> diagnostics --project <tsconfig> --format json`; parse stdout JSON; on `NoFilesToCheckError`/nonzero-without-json → skip w/ note.
+  - Filter findings → `enforcedRules`. Collect across pkgs.
+  - Print: enforced violations as `::error file=..,line=..,col=..::<name> <message>` (github-actions fmt) when `GITHUB_ACTIONS`, else `text`. Summary line.
+  - Exit 1 iff ≥1 enforced violation; else 0. Print note "N rules enforced" so empty-list state is legible.
+- Add npm script `check:effect-diagnostics` + wireit entry: `command: node scripts/effect-diagnostics.mjs`, `dependencies: ["compile"]` (REQUIRED — CLI reads cross-package `out/*.d.ts`; without it wireit may race compile in precommit's parallel dep set and CI has no compile step), `files: [packages/*/src/**/*.ts, packages/*/tsconfig.json, tsconfig.common.json, config/effect-diagnostics.json, scripts/effect-diagnostics.mjs]`, `output: []`.
+- Before writing the runner, run `npm run compile` then re-measure true post-compile baseline; record it here so siblings #2-15 read a clean findings-by-rule signal.
+- commit: `feat(effect): add effect-language-service diagnostics ratchet runner (empty enforced set) - W-23429440`
+
+### Phase 2 — wire into precommit + CI
+
+- `package.json` `wireit.precommit.dependencies`: add `check:effect-diagnostics`.
+- `.github/workflows/validatePR.yml`: new job `check-effect-diagnostics` (mirror `check-knip`: checkout, setup-node, wireit cache, npmInstallWithRetries, `npm run check:effect-diagnostics`). No explicit compile step needed — wireit's `dependencies: ["compile"]` runs it (same as check-knip's CI job).
+- commit: `feat(effect): enforce effect-language-service diagnostics in precommit + validatePR CI - W-23429440`
+
+## Skills to apply
+
+- concise — plan/doc style
+- effect-best-practices — CLI invocation reference (`diagnostics --project`), rule names
+- wireit — add cached target correctly (files/output/deps)
+- work-item-sequencing — WI #1 = plumbing; enforced list stays empty for siblings
+- typescript / paths — script conventions
+
+## Verification
+
+- `node scripts/effect-diagnostics.mjs` (after compile) → exit 0, prints "0 rules enforced", skips services-types.
+- Fresh-tree guard: `rm -rf packages/*/out && npm run check:effect-diagnostics` (wireit) → compile runs first via dep, findings show NO phantom `missingEffectContext`/`missingLayerContext` from cross-package `unknown`. Confirms dep edge works.
+- Temp add `"lazyPromiseInEffectSync"` to `enforcedRules` → exit 1, lists effect-ext-utils + services sites; revert → exit 0.
+- `npm run check:effect-diagnostics` (wireit) passes; re-run cached (no src change) skips.
+- `npm run precommit` green (includes new dep).
+- `npm run check:actions` passes (validatePR.yml valid).
+- `npm run check:knip` — confirm `scripts/effect-diagnostics.mjs`/`config/*.json` not flagged unused; add knip ignore if needed.
+- No e2e coverage — tooling/CI change, no runtime surface; not e2e-covered.

--- a/plans/W-23429440.md
+++ b/plans/W-23429440.md
@@ -9,7 +9,21 @@
 - ~1-2s/pkg. Effect-adopting pkgs w/ src: effect-ext-utils, salesforcedx-utils-vscode, salesforcedx-vscode-{core,apex,apex-debugger,apex-replay-debugger,apex-oas,apex-testing,apex-log,lwc,lightning,soql,metadata,org,org-browser,visualforce,services}, salesforcedx-lightning-lsp-common.
 - Edge: `salesforcedx-vscode-services-types` has NO src `.ts` → CLI throws `NoFilesToCheckError` exit 1 → must skip.
 - CRITICAL — CLI requires compiled cross-package types. On a fresh/uncompiled tree, cross-package imports (`@salesforce/effect-ext-utils`, etc.) resolve to `unknown` (TS2307), spawning phantom `missingEffectContext`/`missingLayerContext` findings on ~8 pkgs. After `npm run compile` builds `out/*.d.ts`, the identical command reports 0 such errors on all 17 pkgs. ∴ `check:effect-diagnostics` MUST depend on `compile` (mirror `check:knip`), else it reads stale/missing `.d.ts` and poisons the findings-by-rule signal that siblings #2-15 consume.
-- Current findings (unenforced, must NOT gate) — measured AFTER `npm run compile`: the earlier "6 pkgs w/ errors" baseline was an artifact of an uncompiled tree, NOT real Effect-typing debt. Post-compile true baseline TBD (re-measure in Phase 1); warnings+messages across services/effect-ext-utils/etc. remain. CLI default exit counts errors → cannot rely on CLI exit code.
+- Current findings (unenforced, must NOT gate) — measured AFTER `npm run compile`: the earlier "6 pkgs w/ errors" baseline was an artifact of an uncompiled tree, NOT real Effect-typing debt. NO phantom `missingEffectContext`/`missingLayerContext` on the compiled tree, confirming the compile dep is what suppresses cross-package `unknown`. CLI default exit counts errors → cannot rely on CLI exit code.
+- Post-compile true baseline (2026-07-14), findings-by-rule per pkg (all unenforced today):
+  - effect-ext-utils, salesforcedx-utils-vscode, salesforcedx-vscode-apex, salesforcedx-vscode-apex-debugger, salesforcedx-vscode-apex-replay-debugger, salesforcedx-vscode-org, salesforcedx-vscode-services-types, salesforcedx-vscode-visualforce → clean
+  - salesforcedx-lightning-lsp-common → globalErrorInEffectFailure:1
+  - salesforcedx-vscode-apex-log → unnecessaryFailYieldableError:1, effectSucceedWithVoid:1, globalErrorInEffectCatch:1, globalErrorInEffectFailure:1
+  - salesforcedx-vscode-apex-oas → effectSucceedWithVoid:1
+  - salesforcedx-vscode-apex-testing → globalErrorInEffectFailure:2, effectSucceedWithVoid:3, globalErrorInEffectCatch:1, effectFnIife:2
+  - salesforcedx-vscode-core → effectSucceedWithVoid:1
+  - salesforcedx-vscode-lightning → runEffectInsideEffect:1
+  - salesforcedx-vscode-lwc → catchUnfailableEffect:1, unknownInEffectCatch:2
+  - salesforcedx-vscode-metadata → effectFnIife:1, runEffectInsideEffect:1
+  - salesforcedx-vscode-org-browser → returnEffectInGen:1, unnecessaryFailYieldableError:1, effectSucceedWithVoid:1
+  - salesforcedx-vscode-services → catchUnfailableEffect:6, effectSucceedWithVoid:9, runEffectInsideEffect:6, unnecessaryFailYieldableError:1, globalErrorInEffectFailure:2, lazyPromiseInEffectSync:4, unsupportedServiceAccessors:2, unnecessaryEffectGen:1
+  - salesforcedx-vscode-soql → tryCatchInEffectGen:2, globalErrorInEffectFailure:2, lazyPromiseInEffectSync:2, unnecessaryPipeChain:1, effectSucceedWithVoid:2
+  - Note: `salesforcedx-vscode-services-types` now HAS 2 src `.ts` files and reports 0 findings (plan's earlier NoFilesToCheckError edge no longer applies); runner still guards nonzero-without-JSON defensively.
 
 ### Design: runner-controlled ratchet (not CLI exit code / not tsconfig severity)
 

--- a/scripts/effect-diagnostics.mjs
+++ b/scripts/effect-diagnostics.mjs
@@ -1,0 +1,80 @@
+import fs from 'fs';
+import path from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { glob } from 'glob';
+
+// Effect LS diagnostics ratchet.
+// Runs @effect/language-service `diagnostics` on every Effect-adopting package,
+// then fails ONLY on findings whose rule name is listed in config/effect-diagnostics.json
+// `enforcedRules` (any severity). Everything else is reported informationally.
+// Decoupled from the CLI exit code (which counts errors) so per-rule gating is uniform.
+// Requires a compiled tree: cross-package imports resolve to `unknown` (TS2307) without
+// `out/*.d.ts`, spawning phantom findings — the wireit `dependencies: ["compile"]` guarantees it.
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const cli = path.join(repoRoot, 'node_modules', '@effect', 'language-service', 'cli.js');
+const configPath = path.join(repoRoot, 'config', 'effect-diagnostics.json');
+
+const enforcedRules = JSON.parse(fs.readFileSync(configPath, 'utf8')).enforcedRules;
+const enforcedSet = new Set(enforcedRules);
+
+// Discover packages: an Effect dependency + a tsconfig + at least one src .ts file.
+const packageJsonPaths = (await glob('packages/*/package.json', { cwd: repoRoot })).sort();
+
+const hasEffectDep = pkg => {
+  const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+  return Object.keys(deps).some(name => name === 'effect' || name.startsWith('@effect/'));
+};
+
+const discoveredPackages = packageJsonPaths.flatMap(relPkgJson => {
+  const pkgDir = path.join(repoRoot, path.dirname(relPkgJson));
+  const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, relPkgJson), 'utf8'));
+  const tsconfig = path.join(pkgDir, 'tsconfig.json');
+  const hasTsconfig = fs.existsSync(tsconfig);
+  const hasSrcTs = fs.existsSync(path.join(pkgDir, 'src')) && glob.sync('src/**/*.ts', { cwd: pkgDir }).length > 0;
+  return hasEffectDep(pkg) && hasTsconfig && hasSrcTs ? [{ name: path.basename(pkgDir), tsconfig }] : [];
+});
+
+// Run the CLI per package; parse JSON. On NoFilesToCheckError / nonzero-without-JSON, skip with a note.
+const runPackage = ({ name, tsconfig }) => {
+  const result = spawnSync('node', [cli, 'diagnostics', '--project', tsconfig, '--format', 'json'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024
+  });
+  const parsed = (() => {
+    try {
+      return JSON.parse(result.stdout);
+    } catch {
+      return undefined;
+    }
+  })();
+  return parsed === undefined
+    ? { name, skipped: true, reason: (result.stderr || result.stdout || `exit ${result.status}`).trim().split('\n')[0] }
+    : { name, diagnostics: parsed.diagnostics ?? [] };
+};
+
+const results = discoveredPackages.map(runPackage);
+
+const skipped = results.filter(r => r.skipped);
+const violations = results
+  .filter(r => !r.skipped)
+  .flatMap(r => r.diagnostics.filter(d => enforcedSet.has(d.name)));
+
+const isGithubActions = process.env.GITHUB_ACTIONS === 'true';
+
+skipped.forEach(r => console.log(`skip ${r.name}: ${r.reason}`));
+
+violations.forEach(d =>
+  console.log(
+    isGithubActions
+      ? `::error file=${d.file},line=${d.line},col=${d.column}::${d.name} ${d.message}`
+      : `${d.file}:${d.line}:${d.column} ${d.name} — ${d.message}`
+  )
+);
+
+console.log(`${enforcedRules.length} rules enforced${enforcedRules.length > 0 ? ` (${enforcedRules.join(', ')})` : ''}`);
+console.log(`${discoveredPackages.length} packages checked, ${skipped.length} skipped, ${violations.length} enforced violation(s)`);
+
+process.exit(violations.length > 0 ? 1 : 0);

--- a/scripts/effect-diagnostics.mjs
+++ b/scripts/effect-diagnostics.mjs
@@ -9,6 +9,8 @@ import { glob } from 'glob';
 // then fails ONLY on findings whose rule name is listed in config/effect-diagnostics.json
 // `enforcedRules` (any severity). Everything else is reported informationally.
 // Decoupled from the CLI exit code (which counts errors) so per-rule gating is uniform.
+// A CLI invocation that can't be parsed as JSON for any reason other than an empty-package
+// NoFilesToCheckError fails the gate — a broken run must never silently drop enforced findings.
 // Requires a compiled tree: cross-package imports resolve to `unknown` (TS2307) without
 // `out/*.d.ts`, spawning phantom findings — the wireit `dependencies: ["compile"]` guarantees it.
 
@@ -17,10 +19,19 @@ const cli = path.join(repoRoot, 'node_modules', '@effect', 'language-service', '
 const configPath = path.join(repoRoot, 'config', 'effect-diagnostics.json');
 
 const enforcedRules = JSON.parse(fs.readFileSync(configPath, 'utf8')).enforcedRules;
+if (!Array.isArray(enforcedRules)) {
+  console.error(
+    `config/effect-diagnostics.json: "enforcedRules" must be an array of rule names (got ${JSON.stringify(enforcedRules)})`
+  );
+  process.exit(1);
+}
 const enforcedSet = new Set(enforcedRules);
 
+// Per-package CLI budget: bound a hung/runaway invocation instead of hanging the whole CI job.
+const perPackageTimeoutMs = 5 * 60 * 1000;
+
 // Discover packages: an Effect dependency + a tsconfig + at least one src .ts file.
-const packageJsonPaths = (await glob('packages/*/package.json', { cwd: repoRoot })).sort();
+const packageJsonPaths = glob.sync('packages/*/package.json', { cwd: repoRoot }).sort();
 
 const hasEffectDep = pkg => {
   const deps = { ...pkg.dependencies, ...pkg.devDependencies };
@@ -36,12 +47,17 @@ const discoveredPackages = packageJsonPaths.flatMap(relPkgJson => {
   return hasEffectDep(pkg) && hasTsconfig && hasSrcTs ? [{ name: path.basename(pkgDir), tsconfig }] : [];
 });
 
-// Run the CLI per package; parse JSON. On NoFilesToCheckError / nonzero-without-JSON, skip with a note.
+// Run the CLI per package; parse JSON.
+// - Valid JSON -> diagnostics.
+// - NoFilesToCheckError (a package with no analyzable files) -> benign skip.
+// - Anything else (crash, timeout, maxBuffer overflow, non-JSON output) -> hard failure
+//   that fails the gate, so a broken invocation can never silently drop enforced findings.
 const runPackage = ({ name, tsconfig }) => {
   const result = spawnSync('node', [cli, 'diagnostics', '--project', tsconfig, '--format', 'json'], {
     cwd: repoRoot,
     encoding: 'utf8',
-    maxBuffer: 64 * 1024 * 1024
+    maxBuffer: 64 * 1024 * 1024,
+    timeout: perPackageTimeoutMs
   });
   const parsed = (() => {
     try {
@@ -50,21 +66,39 @@ const runPackage = ({ name, tsconfig }) => {
       return undefined;
     }
   })();
-  return parsed === undefined
-    ? { name, skipped: true, reason: (result.stderr || result.stdout || `exit ${result.status}`).trim().split('\n')[0] }
-    : { name, diagnostics: parsed.diagnostics ?? [] };
+  if (parsed !== undefined) return { name, diagnostics: parsed.diagnostics ?? [] };
+  const rawError = (result.stderr || result.stdout || '').trim();
+  const benignSkip = result.error === undefined && rawError.includes('NoFilesToCheckError');
+  return benignSkip
+    ? { name, skipped: true, reason: rawError.split('\n')[0] || 'NoFilesToCheckError' }
+    : {
+        name,
+        failed: true,
+        detail:
+          rawError ||
+          (result.error ? `${result.error.code ?? result.error.message}` : `exit ${result.status}`)
+      };
 };
 
 const results = discoveredPackages.map(runPackage);
 
 const skipped = results.filter(r => r.skipped);
+const failed = results.filter(r => r.failed);
 const violations = results
-  .filter(r => !r.skipped)
+  .filter(r => !r.skipped && !r.failed)
   .flatMap(r => r.diagnostics.filter(d => enforcedSet.has(d.name)));
 
 const isGithubActions = process.env.GITHUB_ACTIONS === 'true';
 
 skipped.forEach(r => console.log(`skip ${r.name}: ${r.reason}`));
+
+failed.forEach(r =>
+  console.log(
+    isGithubActions
+      ? `::error::effect-diagnostics failed to run on ${r.name}: ${r.detail}`
+      : `FAIL ${r.name}: ${r.detail}`
+  )
+);
 
 violations.forEach(d =>
   console.log(
@@ -75,6 +109,8 @@ violations.forEach(d =>
 );
 
 console.log(`${enforcedRules.length} rules enforced${enforcedRules.length > 0 ? ` (${enforcedRules.join(', ')})` : ''}`);
-console.log(`${discoveredPackages.length} packages checked, ${skipped.length} skipped, ${violations.length} enforced violation(s)`);
+console.log(
+  `${discoveredPackages.length} packages checked, ${skipped.length} skipped, ${failed.length} failed, ${violations.length} enforced violation(s)`
+);
 
-process.exit(violations.length > 0 ? 1 : 0);
+process.exit(violations.length > 0 || failed.length > 0 ? 1 : 0);


### PR DESCRIPTION
### What does this PR do?

- Adds `scripts/effect-diagnostics.mjs`, a runner-controlled ratchet that discovers Effect-adopting packages, runs `effect-language-service diagnostics --format json` per package, and fails only on findings matching `config/effect-diagnostics.json`'s `enforcedRules` (currently empty — green today).
- Wires `check:effect-diagnostics` into `package.json` wireit (depends on `compile`, so cross-package `.d.ts` are built before diagnostics run, avoiding phantom `missingEffectContext`/`missingLayerContext` findings) and into `wireit.precommit.dependencies`.
- Adds a `check-effect-diagnostics` job to `.github/workflows/validatePR.yml`, mirroring the `check-knip` job pattern.
- Follow-up hardening: declares `packages/*/package.json` as a wireit input and hardens the gate against false-green skips when the CLI exits nonzero without JSON output.

Plan: [plans/W-23429440.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23429440-1-wire-effect-language-service-diagnosti/plans/W-23429440.md)

### What issues does this PR fix or reference?
@W-23429440@

### Functionality Before

No Effect-language-service diagnostics ran in precommit or CI.

### Functionality After

`check:effect-diagnostics` runs in precommit and CI with an empty enforced-rule list (no gating yet — plumbing only; sibling WIs populate the enforced list per-rule).

### Test plan

- [ ] `node scripts/effect-diagnostics.mjs` (after `npm run compile`) exits 0, prints "0 rules enforced", skips `salesforcedx-vscode-services-types` handling correctly
- [ ] Fresh-tree guard: `rm -rf packages/*/out && npm run check:effect-diagnostics` — compile runs first via wireit dep; no phantom `missingEffectContext`/`missingLayerContext` findings
- [ ] Temporarily add `lazyPromiseInEffectSync` to `enforcedRules` in `config/effect-diagnostics.json` → exit 1, lists `effect-ext-utils` + `salesforcedx-vscode-services` sites; revert → exit 0
- [ ] `npm run check:effect-diagnostics` (wireit) passes; re-run cached with no src changes is skipped
- [ ] `npm run precommit` green (includes new dependency)
- [ ] `npm run check:actions` passes (validates `validatePR.yml`)
- [ ] `npm run check:knip` — confirm `scripts/effect-diagnostics.mjs`/`config/*.json` are not flagged as unused

No e2e coverage needed — tooling/CI change only, no runtime surface.

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eeEhVYAU/view