### PR TITLE
refactor(apex): migrate langServer org namespace read to services ConnectionService - W-23348771

### DIFF
--- a/.claude/skills/external-consumers/SKILL.md
+++ b/.claude/skills/external-consumers/SKILL.md
@@ -78,7 +78,6 @@ Always grep for `\.exports\.\w+` across the full monorepo, not just `coreExtensi
 
 | Package | Files | Members accessed |
 |---------|-------|------------------|
-| apex | `languageServer.ts` | `.getAuthFields` |
 | apex-debugger | `coreExtensionUtils.ts`, `index.ts`, `debugConfigurationProvider.ts` | `.channelService`, `.SfCommandlet`, `.telemetryService`, `.SfCommandletExecutor` |
 | utils-vscode | `authUtils.ts`, `workspaceContextUtil.ts`, `telemetryUtils.ts` | `.sharedAuthState`, `.channelService`, `.getSharedTelemetryUserId` (phantom — not on API type) |
 

--- a/packages/salesforcedx-vscode-apex/src/languageServer.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageServer.ts
@@ -26,7 +26,6 @@ import { URI } from 'vscode-uri';
 import { ApexErrorHandler } from './apexErrorHandler';
 import { ApexLanguageClient } from './apexLanguageClient';
 import { LSP_ERR, UBER_JAR_NAME } from './constants';
-import { getVscodeCoreExtension } from './coreExtensionUtils';
 import { soqlMiddleware } from './embeddedSoql';
 import { buildMetadataRegistryScanConfig } from './languageServerScanConfig';
 import { nls } from './messages';
@@ -259,10 +258,17 @@ const buildClientOptions = async (outputChannel?: vscode.OutputChannel): Promise
   return options;
 };
 
-const getNamespaceFromProject = Effect.fn('apex.provideCodeLenses.getNamespaceFromProject')(function* () {
+const getNamespaces = Effect.fn('apex.provideCodeLenses.getNamespaces')(function* () {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
-  const project = yield* api.services.ProjectService.getSfProject();
-  return project.getSfProjectJson().getContents().namespace;
+  const [conn, project] = yield* Effect.all(
+    [api.services.ConnectionService.getConnection(), api.services.ProjectService.getSfProject()],
+    { concurrency: 'unbounded' }
+  );
+  return {
+    // convert null to undefined
+    nsFromOrg: conn.getAuthInfoFields().namespacePrefix ?? undefined,
+    nsFromProject: project.getSfProjectJson().getContents().namespace
+  };
 });
 
 const provideCodeLenses = async (
@@ -270,11 +276,8 @@ const provideCodeLenses = async (
   token: vscode.CancellationToken,
   next: ProvideCodeLensesSignature
 ) => {
-  const vscodeCoreExtension = await getVscodeCoreExtension();
-  const [nsFromOrg, nsFromProject, lenses] = await Promise.all([
-    // convert null to undefined
-    vscodeCoreExtension.exports.getAuthFields().then(fields => fields.namespacePrefix ?? undefined),
-    getRuntime().runPromise(getNamespaceFromProject()),
+  const [{ nsFromOrg, nsFromProject }, lenses] = await Promise.all([
+    getRuntime().runPromise(getNamespaces()),
     next(document, token)
   ]);
   return lenses?.map(rewriteNamespaceLens(nsFromOrg)(nsFromProject));

--- a/plans/W-23348771.md
+++ b/plans/W-23348771.md
@@ -1,0 +1,41 @@
+# W-23348771 — Migrate langServer org-namespace read to services ConnectionService
+
+## Context
+- File: `packages/salesforcedx-vscode-apex/src/languageServer.ts`
+- `provideCodeLenses` (268-281) reads org namespace via `vscodeCoreExtension.exports.getAuthFields().then(f => f.namespacePrefix ?? undefined)` (276).
+- Replace w/ services `ConnectionService.getConnection().getAuthInfoFields().namespacePrefix`.
+- Behavior-identical: core `getAuthFields` already delegates to `connection.getAuthInfoFields()` (`orgAuthInfoExtensions.ts:38-41`) — auth-file read, no live query.
+- Mirror sibling `getNamespaceFromProject` Effect.fn (262-266, PR #7677): `(yield* ExtensionProviderService).getServicesApi` → `api.services.*`.
+- ConnectionService reachable via same api: `api.services.ConnectionService.getConnection()` (used in metadata/apex-log pkgs, e.g. `packageInstall.ts:79`).
+- `getVscodeCoreExtension` (import 29) used ONLY at 273/276 → drop import after migration.
+- `namespacePrefix` type `string | null` → `?? undefined` (matches existing).
+- Reference impl: PR #7734 (CLOSED) — merges both reads into 1 `getNamespaces` Effect.fn, parallel via `Effect.all` `concurrency: 'unbounded'`.
+
+## Phases
+
+### Phase 1 — migrate org-namespace read to ConnectionService
+- Rename `getNamespaceFromProject` → `getNamespaces`; fetch both ns in parallel:
+  - `const api = yield* (yield* ExtensionProviderService).getServicesApi;`
+  - `const [conn, project] = yield* Effect.all([api.services.ConnectionService.getConnection(), api.services.ProjectService.getSfProject()], { concurrency: 'unbounded' });`
+  - return `{ nsFromOrg: conn.getAuthInfoFields().namespacePrefix ?? undefined, nsFromProject: project.getSfProjectJson().getContents().namespace }`.
+- `provideCodeLenses`: `Promise.all([getRuntime().runPromise(getNamespaces()), next(document, token)])`; destructure `[{ nsFromOrg, nsFromProject }, lenses]`.
+- Drop `getVscodeCoreExtension()` call (273) + import (29) — now unused.
+- `Effect` already imported.
+- Commit: `refactor(apex): migrate langServer org namespace read to services ConnectionService - W-23348771`
+
+## Skills to apply
+- services-extension-consumption — `getServicesApi` / `api.services.*` pattern
+- effect-best-practices — Effect.fn, Effect.all, generator style
+- typescript — build/lint
+- verification — pre-commit checks
+
+## Verification
+- `npm run compile` (wireit) apex pkg — typecheck; confirm no unused `getVscodeCoreExtension` import.
+- eslint apex pkg — no errors.
+- Jest `namespaceLensRewriter.test.ts` — unchanged (pure fn), still passes.
+- e2e-covered (run locally pre-PR; behavior-preserving read-source swap):
+  - `nsFromOrg`/`nsFromProject` fed to `rewriteNamespaceLens` unchanged → lens render unaffected.
+  - `packages/salesforcedx-vscode-apex-testing/test/playwright/specs/runApexTestsCodeLens.headless.spec.ts` — 'Run All Tests'/'Run Test' lenses don't render if `Promise.all` rejects → broken ns read fails spec.
+  - `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/{debugApexTests,apexReplayDebugger}.desktop.spec.ts` — codeLens clicks.
+  - No new observable behavior → no new named spec.
+- Pre-existing gap (NOT introduced here, non-blocking): namespace-rewrite branch untested e2e — scratch-org fixtures (`packages/playwright-vscode-ext/src/orgs/{minimalScratchOrgSetup,nonTrackingScratchOrgSetup}.ts`) set `namespace: ''` → rewrite path never fires; jest covers pure fn. Leave as-is.


### PR DESCRIPTION
### What does this PR do?

## Summary
- `languageServer.ts` `provideCodeLenses` now reads org namespace via `ConnectionService.getConnection().getAuthInfoFields().namespacePrefix` instead of `getVscodeCoreExtension().exports.getAuthFields()`.
- Merges the org-namespace and project-namespace reads into one `getNamespaces` Effect.fn, fetched in parallel via `Effect.all({ concurrency: 'unbounded' })` (renamed from `getNamespaceFromProject`).
- Drops the now-unused `getVscodeCoreExtension` import; behavior-preserving (core's `getAuthFields` already delegated to `connection.getAuthInfoFields()`).

## Plan
See [plans/W-23348771.md](../blob/sm/W-23348771-3-migrate-langserver-org-namespace-read/plans/W-23348771.md) for context and phase details.

## Test plan
- [ ] `npm run compile` (apex pkg) — typecheck; confirm no unused `getVscodeCoreExtension` import
- [ ] eslint apex pkg — no errors
- [ ] Jest `namespaceLensRewriter.test.ts` — unchanged pure fn, still passes
- [ ] Local pre-PR e2e sanity (no new named spec; behavior-preserving read-source swap):
  - `packages/salesforcedx-vscode-apex-testing/test/playwright/specs/runApexTestsCodeLens.headless.spec.ts`
  - `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/{debugApexTests,apexReplayDebugger}.desktop.spec.ts`

### What issues does this PR fix or reference?
@W-23348771@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002e9Ff2YAE/view
