### PR TITLE
chore(apex-testing): enable consistent-type-definitions type - W-23354484

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -811,10 +811,12 @@ export default [
   },
   {
     // no-explicit-any enforced for apex-testing src (W-23354483).
+    // consistent-type-definitions type enforced for apex-testing src (W-23354484).
     // Scoped to src/** so the later test-files block keeps it off for tests.
     files: ['packages/salesforcedx-vscode-apex-testing/src/**/*.ts'],
     rules: {
-      '@typescript-eslint/no-explicit-any': 'error'
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/consistent-type-definitions': ['error', 'type']
     }
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44252,7 +44252,6 @@
     "packages/salesforcedx-apex": {
       "name": "@salesforce/apex-node",
       "version": "67.5.0",
-      "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/core": "^8.32.2",

--- a/packages/salesforcedx-vscode-apex-testing/src/utils/testItemUtils.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/utils/testItemUtils.ts
@@ -9,12 +9,12 @@ import { SUITE_PARENT_ID, TEST_ID_PREFIXES } from '../constants';
 
 type TestItemType = 'suite' | 'class' | 'method' | 'suite-class' | 'namespace' | 'package' | 'unknown';
 
-interface TestIdInfo {
+type TestIdInfo = {
   type: TestItemType;
   name: string;
   suiteName?: string;
   className?: string;
-}
+};
 
 /**
  * Parses a test item ID and returns information about its type and name

--- a/packages/salesforcedx-vscode-apex-testing/src/views/orgTestItems.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/views/orgTestItems.ts
@@ -175,7 +175,7 @@ export const getPackageLabelAndId = (
 /**
  * Context required to create class and method TestItems. Passed to createClassAndMethodsFactory.
  */
-interface CreateClassAndMethodsContext {
+type CreateClassAndMethodsContext = {
   controller: vscode.TestController;
   classItems: Map<string, vscode.TestItem>;
   methodItems: Map<string, vscode.TestItem>;
@@ -183,7 +183,7 @@ interface CreateClassAndMethodsContext {
   orgKey: string;
   orgOnlyTag: vscode.TestTag | undefined;
   inWorkspaceTag: vscode.TestTag | undefined;
-}
+};
 
 /**
  * Returns a function that creates a class TestItem and its method TestItems, and registers them in the given maps.

--- a/plans/W-23354484.md
+++ b/plans/W-23354484.md
@@ -9,7 +9,7 @@
   - `src/utils/testItemUtils.ts:12` `TestIdInfo`
   - `src/views/orgTestItems.ts:178` `CreateClassAndMethodsContext`
 - Both in `src/`; none in `test/`. Scope rule to `src/**` (matches sibling blocks).
-- `member-delimiter-style` already enforces trailing `;` — both decls already semicolon-delimited, no delimiter churn.
+- `member-delimiter-style` enforces trailing `;`; both decls already semicolon-delimited — no churn.
 
 ## Phases
 
@@ -30,7 +30,8 @@
 
 ## Verification
 
-- `npm run lint -w packages/salesforcedx-vscode-apex-testing` — 0 errors; confirms rule active + no remaining interface decls. (not e2e-covered)
-- `npm run compile -w packages/salesforcedx-vscode-apex-testing` (or `tsc --noEmit`) — type-check post-conversion. (not e2e-covered)
-- grep `interface ` in `packages/salesforcedx-vscode-apex-testing/src` -> empty. (not e2e-covered)
+- Not e2e-covered (lint, compile, grep below):
+- `npm run lint -w packages/salesforcedx-vscode-apex-testing` — 0 errors; confirms rule active + no remaining interface decls.
+- `npm run compile -w packages/salesforcedx-vscode-apex-testing` (or `tsc --noEmit`) — type-check post-conversion.
+- grep `interface ` in `packages/salesforcedx-vscode-apex-testing/src` -> empty.
 - Runtime behavior unchanged (type-only edit); existing jest/playwright e2e on branch cover functionality.

--- a/plans/W-23354484.md
+++ b/plans/W-23354484.md
@@ -1,0 +1,36 @@
+# W-23354484 — consistent-type-definitions:[error,type] for apex-testing
+
+## Context
+
+- Enable `@typescript-eslint/consistent-type-definitions: [error, type]` scoped to apex-testing.
+- Global rule currently `off` (`eslint.config.mjs:299`).
+- Sibling WIs (W-23354483 no-explicit-any, W-23354481 no-explicit-effect-return-type) already added apex-testing-scoped override blocks — same pattern.
+- Interface decls to flip -> `type` (WI estimated 3; actual 2):
+  - `src/utils/testItemUtils.ts:12` `TestIdInfo`
+  - `src/views/orgTestItems.ts:178` `CreateClassAndMethodsContext`
+- Both in `src/`; none in `test/`. Scope rule to `src/**` (matches sibling blocks).
+- `member-delimiter-style` already enforces trailing `;` — both decls already semicolon-delimited, no delimiter churn.
+
+## Phases
+
+### Phase 1 — flip interfaces to type + enable rule
+
+- `src/utils/testItemUtils.ts:12`: `interface TestIdInfo {` -> `type TestIdInfo = {`
+- `src/views/orgTestItems.ts:178`: `interface CreateClassAndMethodsContext {` -> `type CreateClassAndMethodsContext = {`
+- `eslint.config.mjs`: add to existing apex-testing `src/**` block (near line 815) or new block:
+  `'@typescript-eslint/consistent-type-definitions': ['error', 'type']`
+- 1 commit.
+- commit msg: `chore(apex-testing): enable consistent-type-definitions type - W-23354484`
+
+## Skills to apply
+
+- typescript — type vs interface syntax
+- verification — lint gate
+- concise — plan/commit style
+
+## Verification
+
+- `npm run lint -w packages/salesforcedx-vscode-apex-testing` — 0 errors; confirms rule active + no remaining interface decls. (not e2e-covered)
+- `npm run compile -w packages/salesforcedx-vscode-apex-testing` (or `tsc --noEmit`) — type-check post-conversion. (not e2e-covered)
+- grep `interface ` in `packages/salesforcedx-vscode-apex-testing/src` -> empty. (not e2e-covered)
+- Runtime behavior unchanged (type-only edit); existing jest/playwright e2e on branch cover functionality.


### PR DESCRIPTION
## Summary
- Enable `@typescript-eslint/consistent-type-definitions: [error, type]` scoped to `apex-testing` `src/**`, matching the pattern already used by sibling WIs (no-explicit-any, no-explicit-effect-return-type).
- Flip the two remaining `interface` declarations in that package to `type`: `TestIdInfo` (`src/utils/testItemUtils.ts`) and `CreateClassAndMethodsContext` (`src/views/orgTestItems.ts`).
- Type-only change; no runtime behavior difference.

## Plan
[plans/W-23354484.md](plans/W-23354484.md)

## Reviewer notes
- `package-lock.json`: unrelated one-line fix bundled in this diff. Commit `c012020403` removed a stale `hasInstallScript: true` from the `salesforcedx-apex` lockfile entry. Root cause is an earlier commit (`5fb64dc0bc`) that removed the `preinstall` script from `packages/salesforcedx-apex/package.json` without regenerating the lockfile. The correction is legitimate (not reverted) but not part of this WI's scope — flagging for visibility.

## Test plan
Not e2e-covered by this branch (no e2e/*.e2e.* files touched) — verify manually:
- [ ] `npm run lint -w packages/salesforcedx-vscode-apex-testing` — 0 errors; confirms rule active and no remaining `interface` decls
- [ ] `npm run compile -w packages/salesforcedx-vscode-apex-testing` (or `tsc --noEmit`) — type-check post-conversion
- [ ] `grep -r "interface " packages/salesforcedx-vscode-apex-testing/src` — empty
- [ ] Existing jest/playwright e2e suites still pass (functionality unchanged; type-only edit)

### What issues does this PR fix or reference?
@W-23354484@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eBKPxYAO/view
