### PR TITLE
chore(apex-testing): flip prefer-property-signatures off->error - W-23354485

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -810,18 +810,12 @@ export default [
     }
   },
   {
-    // no-explicit-any enforced for apex-testing src (W-23354483).
-    // Scoped to src/** so the later test-files block keeps it off for tests.
+    // no-explicit-any (W-23354483) and prefer-property-signatures (W-23354485)
+    // enforced for apex-testing src.
+    // Scoped to src/** so the later test-files block keeps them off for tests.
     files: ['packages/salesforcedx-vscode-apex-testing/src/**/*.ts'],
     rules: {
-      '@typescript-eslint/no-explicit-any': 'error'
-    }
-  },
-  {
-    // prefer-property-signatures enforced for apex-testing src (W-23354485).
-    // Scoped to src/** so the later test-files block keeps it off for tests.
-    files: ['packages/salesforcedx-vscode-apex-testing/src/**/*.ts'],
-    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
       'functional/prefer-property-signatures': 'error'
     }
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -818,6 +818,14 @@ export default [
     }
   },
   {
+    // prefer-property-signatures enforced for apex-testing src (W-23354485).
+    // Scoped to src/** so the later test-files block keeps it off for tests.
+    files: ['packages/salesforcedx-vscode-apex-testing/src/**/*.ts'],
+    rules: {
+      'functional/prefer-property-signatures': 'error'
+    }
+  },
+  {
     // Prevent direct imports from services extension (except in services package itself)
     // Only applies to src directories, not test directories
     files: ['packages/**/src/**/*.ts'],

--- a/plans/W-23354485.md
+++ b/plans/W-23354485.md
@@ -1,0 +1,39 @@
+# W-23354485 — functional/prefer-property-signatures error for apex-testing
+
+## Context
+
+- Enable `functional/prefer-property-signatures` off→error, scope = `salesforcedx-vscode-apex-testing` src
+- Method signatures in types → property signatures. Pairs w/ 8.4 (no-explicit-any, `ea01bbb752`). Blocked by 5/6/7 (done)
+- Root config: `eslint.config.mjs`
+  - Effect-pkgs block (line 689) sets rule `error` (line 707) — apex-testing NOT listed
+  - test-files block (line 831) sets `off` (line 864) — keep; scope new override `src/**` only → test files stay off, no ordering conflict
+  - W-23354483 no-explicit-any src block at 812-819 — same pattern, add sibling
+- Forced-on lint on `apex-testing/src/**/*.ts` = 0 `prefer-property-signatures` violations (verified) → config-only
+- No `eslint-disable ...prefer-property-signatures` comments in pkg
+- Pre-existing (baseline, out of scope): 2 `prefer-nullish-coalescing` errors in `src/utils/testResultProcessor.ts:143`
+
+## Phases
+
+### Phase 1 — flip rule
+
+`eslint.config.mjs`
+
+- add override block after no-explicit-any block (~819):
+  - `files: ['packages/salesforcedx-vscode-apex-testing/src/**/*.ts']`
+  - `rules: { 'functional/prefer-property-signatures': 'error' }`
+- src-scoped: test files stay `off` via later block (831/864)
+
+commit: `chore(apex-testing): flip prefer-property-signatures off->error - W-23354485`
+
+## Skills to apply
+
+- typescript
+- verification
+
+## Verification
+
+- `node --check`: n/a — `.mjs` w/ imports
+- build local rules first: `npx tsc -p packages/eslint-local-rules/tsconfig.json` (out/index.js needed by config)
+- lint: `npx eslint 'packages/salesforcedx-vscode-apex-testing/src/**/*.ts'` → 0 `prefer-property-signatures` errors (2 baseline `prefer-nullish-coalescing` unrelated)
+- confirm rule active: eslint reports `prefer-property-signatures` error if any method-sig reintroduced
+- no e2e coverage relevant (lint-config change)


### PR DESCRIPTION
## Summary
- Flip `functional/prefer-property-signatures` from `off` to `error` for `salesforcedx-vscode-apex-testing` src files.
- Merges into the existing `no-explicit-any` (W-23354483) override block since both are scoped to the same `src/**` files.
- Config-only change: 0 violations in the package, so no source-file edits needed.

## Plan
See [plans/W-23354485.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23354485-8-5-functional-prefer-property-signature/plans/W-23354485.md)

## Test plan
- [ ] Build local eslint rules: `npx tsc -p packages/eslint-local-rules/tsconfig.json`
- [ ] Lint apex-testing src: `npx eslint 'packages/salesforcedx-vscode-apex-testing/src/**/*.ts'` → 0 `prefer-property-signatures` errors (2 pre-existing `prefer-nullish-coalescing` errors in `testResultProcessor.ts:143` are baseline/out of scope)
- [ ] Confirm rule is active: reintroducing a method signature in a type under `src/**` should produce a `prefer-property-signatures` error

### What issues does this PR fix or reference?
@W-23354485@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eBKRZYA4/view
