### PR TITLE
chore(apex-testing): enable local/no-successive-annotate-current-span - W-23354487

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -773,7 +773,8 @@ export default [
     ],
     rules: {
       'class-methods-use-this': 'error',
-      'local/no-explicit-effect-return-type': 'error'
+      'local/no-explicit-effect-return-type': 'error',
+      'local/no-successive-annotate-current-span': 'error'
     }
   },
   {

--- a/plans/W-23354487.md
+++ b/plans/W-23354487.md
@@ -19,7 +19,7 @@
 ### Phase 1 — enable rule for apex-testing
 
 - Add `'local/no-successive-annotate-current-span': 'error'` to an apex-testing-scoped block in `eslint.config.mjs`.
-  - Add to existing block `:765-778` (files already include apex-testing `**/*.ts`), OR new dedicated block. Prefer existing `:765` block — same files glob, min churn.
+  - Add to existing block `:765-778` (files already include apex-testing `**/*.ts`) rather than a new block — same files glob, min churn.
 - No source edits expected (no adjacent pairs).
 - Run `npx eslint packages/salesforcedx-vscode-apex-testing` (after `npm run compile -w packages/eslint-local-rules`; out/ needed); apply `--fix` if violations surface.
 - Files: `eslint.config.mjs`

--- a/plans/W-23354487.md
+++ b/plans/W-23354487.md
@@ -1,0 +1,39 @@
+# W-23354487 — enable local/no-successive-annotate-current-span for apex-testing
+
+## Context
+
+- Rule `local/no-successive-annotate-current-span` (autofixable) merges adjacent `Effect.annotateCurrentSpan` runs.
+- Defined: `packages/eslint-local-rules/src/noSuccessiveAnnotateCurrentSpan.ts`; registered in `src/index.ts`.
+- Currently `error` only in Effect-package block `eslint.config.mjs:689-763` — apex-testing NOT in that `files` list.
+- WI: flip on for `salesforcedx-vscode-apex-testing`.
+- 5 `annotateCurrentSpan` sites (verified):
+  - `src/utils/testReportGenerator.ts:110`
+  - `src/commands/apexTestRunUtils.ts:88`, `:134`
+  - `src/views/apexTestExecutionService.ts:260` (tap), `:434` (gen)
+- NO adjacent pairs: each site separated by intervening statements or in distinct functions/pipes. Nothing to merge. Rule flip lints clean.
+- Precedent: per-rule apex-testing blocks already exist (`no-explicit-any` at `eslint.config.mjs:812-819`; `class-methods-use-this`+`no-explicit-effect-return-type` at `:765-778`).
+- Blocked-by 5/6/7 already landed (recent commits W-23354481, W-23354483).
+
+## Phases
+
+### Phase 1 — enable rule for apex-testing
+
+- Add `'local/no-successive-annotate-current-span': 'error'` to an apex-testing-scoped block in `eslint.config.mjs`.
+  - Add to existing block `:765-778` (files already include apex-testing `**/*.ts`), OR new dedicated block. Prefer existing `:765` block — same files glob, min churn.
+- No source edits expected (no adjacent pairs).
+- Run `npx eslint packages/salesforcedx-vscode-apex-testing` (after `npm run compile -w packages/eslint-local-rules`; out/ needed); apply `--fix` if violations surface.
+- Files: `eslint.config.mjs`
+- Commit: `chore(apex-testing): enable local/no-successive-annotate-current-span - W-23354487`
+
+## Skills to apply
+
+- concise (plan/docs)
+- typescript (if any source merge needed)
+- verification
+
+## Verification
+
+- `npm run compile -w packages/eslint-local-rules` (build rule `out/`; eslint.config imports it).
+- `npx eslint packages/salesforcedx-vscode-apex-testing` — 0 errors (confirms flip clean, no unmerged runs).
+- Rule unit tests unchanged — already pass on branch (`packages/eslint-local-rules/test/no-successive-annotate-current-span.test.ts`).
+- No e2e coverage relevant (lint-config change; no runtime behavior).


### PR DESCRIPTION
### What does this PR do?

## Summary
- Enables `local/no-successive-annotate-current-span` for `salesforcedx-vscode-apex-testing` by adding it to the existing apex-testing-scoped ESLint block (`eslint.config.mjs:765-778`), same block that already carries `class-methods-use-this` and `local/no-explicit-effect-return-type`.
- No source edits needed — the 5 `Effect.annotateCurrentSpan` call sites in apex-testing have no adjacent runs to merge, so the flip lints clean.

## Plan
[plans/W-23354487.md](../blob/sm/W-23354487-8-6-local-no-successive-annotate-current/plans/W-23354487.md)

## Reviewer notes
- (low) The shared block at `eslint.config.mjs:765-778` also covers `salesforcedx-vscode-soql`, `soql-common`, and `soql-model` (files glob at `:769-772`), so the rule's effective scope is broader than the apex-testing-only framing in the plan/commit message. Not narrowed to an apex-testing-only block intentionally — that would reverse the plan's deliberate min-churn decision and depart from existing repo precedent (this identical 4-package block already carries `class-methods-use-this` and `local/no-explicit-effect-return-type` under the same apex-testing-titled commit convention). Zero functional risk today: the soql packages have no `annotateCurrentSpan` usage.

## Test plan
- [ ] `npm run compile -w packages/eslint-local-rules` (builds rule `out/`; eslint config imports it)
- [ ] `npx eslint packages/salesforcedx-vscode-apex-testing` — expect 0 errors (confirms flip is clean, no unmerged runs)
- [ ] Rule unit tests (`packages/eslint-local-rules/test/no-successive-annotate-current-span.test.ts`) already pass on branch, unchanged

### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @W-23354487@