### PR TITLE
feat(utils-vscode): widen services identity bridge to carry org fields - W-23451940

### DIFF
--- a/packages/salesforcedx-utils-vscode/src/context/workspaceOrgShape.ts
+++ b/packages/salesforcedx-utils-vscode/src/context/workspaceOrgShape.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { OrgShape } from './workspaceContextUtil';
+
+export type OrgShapeInfo = { isScratch?: boolean; isSandbox?: boolean; alias?: string; username?: string };
+
+/**
+ * Maps DefaultOrgInfo fields from `defaultOrgRef` to an OrgShape literal.
+ * Precedence: Scratch > Sandbox > Production (when alias or username known) > Undefined.
+ * Exported for unit-test coverage of the precedence mapping.
+ */
+export const shapeFrom = (info: OrgShapeInfo): OrgShape => {
+  if (info.isScratch) return 'Scratch';
+  if (info.isSandbox) return 'Sandbox';
+  if (info.alias ?? info.username) return 'Production';
+  return 'Undefined';
+};

--- a/packages/salesforcedx-utils-vscode/src/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/index.ts
@@ -12,6 +12,7 @@ export { ConfigUtil } from './config/configUtil';
 export { SFDX_CORE_CONFIGURATION_NAME, TELEMETRY_GLOBAL_USER_ID, TELEMETRY_GLOBAL_WEB_USER_ID } from './constants';
 export { type SalesforceVSCodeOrgApi } from './context/orgExtensionUtils';
 export { OrgUserInfo, OrgShape, WorkspaceContextUtil } from './context/workspaceContextUtil';
+export { shapeFrom, type OrgShapeInfo } from './context/workspaceOrgShape';
 export { TelemetryService } from './services/telemetry';
 export { isInternalHost } from './telemetry/utils/isInternal';
 export {

--- a/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
+++ b/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
@@ -18,8 +18,6 @@ import { isString } from 'effect/Predicate';
 import * as SubscriptionRef from 'effect/SubscriptionRef';
 import { ExtensionContext, ExtensionMode, workspace } from 'vscode';
 import { ChannelService } from '../commands/channelService';
-import { OrgShape } from '../context/workspaceContextUtil';
-import { shapeFrom } from '../context/workspaceOrgShape';
 import {
   DEFAULT_AIKEY,
   SFDX_CORE_CONFIGURATION_NAME,
@@ -27,11 +25,15 @@ import {
   SFDX_EXTENSION_PACK_NAME,
   UNAUTHENTICATED_USER
 } from '../constants';
+import { OrgShape } from '../context/workspaceContextUtil';
+import { shapeFrom } from '../context/workspaceOrgShape';
 import { errorToString } from '../helpers/errorUtils';
 import { disableCLITelemetry, isCLITelemetryAllowed } from '../telemetry/cliConfiguration';
 import { AppInsights } from '../telemetry/reporters/appInsights';
 import { determineReporters, initializeO11yReporter } from '../telemetry/reporters/determineReporters';
+import { LogStream } from '../telemetry/reporters/logStream';
 import { O11yReporter } from '../telemetry/reporters/o11yReporter';
+import { TelemetryFile } from '../telemetry/reporters/telemetryFile';
 import { TelemetryReporterConfig } from '../telemetry/reporters/telemetryReporterConfig';
 import { extensionPackageJsonSchema } from '../telemetry/schema';
 import { isInternalHost } from '../telemetry/utils/isInternal';
@@ -256,9 +258,10 @@ export class TelemetryService implements TelemetryServiceInterface {
     }
 
     // Sourced from services-owned identity; webUserId always defined (UNAUTHENTICATED_USER until auth).
-    const { cliId, webUserId } = await this.getIdentityFromServices();
+    const { cliId, webUserId, orgId, orgShape, devHubId, orgEdition } = await this.getIdentityFromServices();
     this.warnDegradedSession(cliId);
     const userId = cliId ?? '';
+    const orgIdentity = { orgId, orgShape, devHubId, orgEdition };
 
     // priority: extension specific one, OR core default one, OR original one
     const { productFeatureId: thisExtensionPftId } = extensionPackageJsonSchema.parse(
@@ -268,10 +271,15 @@ export class TelemetryService implements TelemetryServiceInterface {
       extensionContext.extension.packageJSON
     );
     this.reporters
+      .filter(r => r instanceof TelemetryFile || r instanceof LogStream)
+      // TelemetryFile/LogStream lack userId/webUserId — cache org identity only.
+      .map(r => (r.orgIdentity = orgIdentity));
+    this.reporters
       .filter(r => r instanceof AppInsights || r instanceof O11yReporter)
       .map(r => {
         r.userId = userId;
         r.webUserId = webUserId;
+        r.orgIdentity = orgIdentity;
         return r;
       })
       .filter(r => r instanceof O11yReporter)

--- a/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
+++ b/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
@@ -25,7 +25,6 @@ import {
   SFDX_EXTENSION_PACK_NAME,
   UNAUTHENTICATED_USER
 } from '../constants';
-import { OrgShape } from '../context/workspaceContextUtil';
 import { shapeFrom } from '../context/workspaceOrgShape';
 import { errorToString } from '../helpers/errorUtils';
 import { disableCLITelemetry, isCLITelemetryAllowed } from '../telemetry/cliConfiguration';
@@ -34,18 +33,14 @@ import { determineReporters, initializeO11yReporter } from '../telemetry/reporte
 import { LogStream } from '../telemetry/reporters/logStream';
 import { O11yReporter } from '../telemetry/reporters/o11yReporter';
 import { TelemetryFile } from '../telemetry/reporters/telemetryFile';
-import { TelemetryReporterConfig } from '../telemetry/reporters/telemetryReporterConfig';
+import { OrgIdentity, TelemetryReporterConfig } from '../telemetry/reporters/telemetryReporterConfig';
 import { extensionPackageJsonSchema } from '../telemetry/schema';
 import { isInternalHost } from '../telemetry/utils/isInternal';
 
 type IdentityFromServices = {
   cliId: string | undefined;
   webUserId: string;
-  orgId?: string;
-  orgShape?: OrgShape;
-  devHubId?: string;
-  orgEdition?: string;
-};
+} & OrgIdentity;
 
 const FALLBACK_IDENTITY: IdentityFromServices = {
   cliId: undefined,
@@ -270,22 +265,23 @@ export class TelemetryService implements TelemetryServiceInterface {
     const { productFeatureId: coreEtensionPftId } = extensionPackageJsonSchema.parse(
       extensionContext.extension.packageJSON
     );
+    // fresh object per reporter — avoid aliasing one shared-mutable orgIdentity across instances
     this.reporters
       .filter(r => r instanceof TelemetryFile || r instanceof LogStream)
       // TelemetryFile/LogStream lack userId/webUserId — cache org identity only.
-      .map(r => (r.orgIdentity = orgIdentity));
+      .forEach(r => (r.orgIdentity = { ...orgIdentity }));
     this.reporters
       .filter(r => r instanceof AppInsights || r instanceof O11yReporter)
-      .map(r => {
+      .forEach(r => {
         r.userId = userId;
         r.webUserId = webUserId;
-        r.orgIdentity = orgIdentity;
-        return r;
-      })
+        r.orgIdentity = { ...orgIdentity };
+      });
+    this.reporters
       .filter(r => r instanceof O11yReporter)
       // don't overwrite PFT if already set
       .filter(r => r.productFeatureId === undefined)
-      .map(r => (r.productFeatureId = thisExtensionPftId ?? coreEtensionPftId));
+      .forEach(r => (r.productFeatureId = thisExtensionPftId ?? coreEtensionPftId));
   }
 
   public async isTelemetryEnabled(): Promise<boolean> {

--- a/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
+++ b/packages/salesforcedx-utils-vscode/src/services/telemetry.ts
@@ -18,6 +18,8 @@ import { isString } from 'effect/Predicate';
 import * as SubscriptionRef from 'effect/SubscriptionRef';
 import { ExtensionContext, ExtensionMode, workspace } from 'vscode';
 import { ChannelService } from '../commands/channelService';
+import { OrgShape } from '../context/workspaceContextUtil';
+import { shapeFrom } from '../context/workspaceOrgShape';
 import {
   DEFAULT_AIKEY,
   SFDX_CORE_CONFIGURATION_NAME,
@@ -37,11 +39,19 @@ import { isInternalHost } from '../telemetry/utils/isInternal';
 type IdentityFromServices = {
   cliId: string | undefined;
   webUserId: string;
+  orgId?: string;
+  orgShape?: OrgShape;
+  devHubId?: string;
+  orgEdition?: string;
 };
 
 const FALLBACK_IDENTITY: IdentityFromServices = {
   cliId: undefined,
-  webUserId: UNAUTHENTICATED_USER
+  webUserId: UNAUTHENTICATED_USER,
+  orgId: undefined,
+  orgShape: undefined,
+  devHubId: undefined,
+  orgEdition: undefined
 };
 
 const fallback = Effect.succeed(FALLBACK_IDENTITY);
@@ -53,9 +63,23 @@ const fetchIdentityFromServices = (): Promise<IdentityFromServices> =>
       Effect.flatMap(api => api.services.TargetOrgRef()),
       Effect.flatMap(SubscriptionRef.get),
       Effect.map(
-        ({ cliId, webUserId }): IdentityFromServices => ({
+        ({
           cliId,
-          webUserId: webUserId ?? UNAUTHENTICATED_USER
+          webUserId,
+          orgId,
+          isScratch,
+          isSandbox,
+          orgEdition,
+          devHubOrgId,
+          alias,
+          username
+        }): IdentityFromServices => ({
+          cliId,
+          webUserId: webUserId ?? UNAUTHENTICATED_USER,
+          orgId,
+          orgShape: shapeFrom({ isScratch, isSandbox, alias, username }),
+          devHubId: devHubOrgId,
+          orgEdition
         })
       ),
       Effect.tapError(e => Effect.log(`getIdentityFromServices error: ${String(e)}`)),

--- a/packages/salesforcedx-utils-vscode/src/telemetry/reporters/appInsights.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/reporters/appInsights.ts
@@ -3,7 +3,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import type { TelemetryReporterWithModifiableUserProperties } from './telemetryReporterConfig';
+import type { OrgIdentity, TelemetryReporterWithModifiableUserProperties } from './telemetryReporterConfig';
 import type { TelemetryReporter } from '@salesforce/vscode-service-provider';
 import { TelemetryReporter as VSCodeTelemetryReporter } from '@vscode/extension-telemetry';
 import { Disposable, env, workspace } from 'vscode';
@@ -38,6 +38,8 @@ export class AppInsights
 
   // user defined tag to add to properties that is defined via setting
   private telemetryTag: string | undefined;
+
+  public orgIdentity?: OrgIdentity;
 
   constructor(
     private extensionId: string,

--- a/packages/salesforcedx-utils-vscode/src/telemetry/reporters/logStream.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/reporters/logStream.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import type { OrgIdentity } from './telemetryReporterConfig';
 import type { TelemetryReporter } from '@salesforce/vscode-service-provider';
 import * as path from 'node:path';
 import { Disposable, workspace } from 'vscode';
@@ -15,6 +16,7 @@ import { WorkspaceContextUtil } from '../../context/workspaceContextUtil';
  * Represents a telemetry reporter that logs telemetry events to a file.
  */
 export class LogStream extends Disposable implements TelemetryReporter {
+  public orgIdentity?: OrgIdentity;
   private toDispose: Disposable[] = [];
   private logUri: URI;
   private buffer: string = '';

--- a/packages/salesforcedx-utils-vscode/src/telemetry/reporters/o11yReporter.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/reporters/o11yReporter.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import type { TelemetryReporterWithModifiableUserProperties } from './telemetryReporterConfig';
+import type { OrgIdentity, TelemetryReporterWithModifiableUserProperties } from './telemetryReporterConfig';
 import { O11yService } from '@salesforce/o11y-reporter';
 import type { TelemetryReporter } from '@salesforce/vscode-service-provider';
 import { Disposable, env, workspace } from 'vscode';
@@ -29,6 +29,7 @@ export class O11yReporter
   implements TelemetryReporter, TelemetryReporterWithModifiableUserProperties
 {
   public productFeatureId: string | undefined;
+  public orgIdentity?: OrgIdentity;
   private userOptIn: boolean = false;
   private o11yUploadEndpoint: string;
   private toDispose: Disposable[] = [];

--- a/packages/salesforcedx-utils-vscode/src/telemetry/reporters/telemetryFile.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/reporters/telemetryFile.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import type { OrgIdentity } from './telemetryReporterConfig';
 import type { TelemetryReporter } from '@salesforce/vscode-service-provider';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
@@ -16,6 +17,7 @@ import { getRootWorkspacePath } from '../../workspaces/workspaceUtils';
  * Represents a telemetry file that logs telemetry events by appending to a local file.
  */
 export class TelemetryFile implements TelemetryReporter {
+  public orgIdentity?: OrgIdentity;
   private fileUri: URI;
   private buffer: string = '';
 

--- a/packages/salesforcedx-utils-vscode/src/telemetry/reporters/telemetryReporterConfig.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/reporters/telemetryReporterConfig.ts
@@ -4,6 +4,16 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import type { OrgShape } from '../../context/workspaceContextUtil';
+
+/** Org identity fields carried on the services identity bridge, cached onto reporters. */
+export type OrgIdentity = {
+  orgId?: string;
+  orgShape?: OrgShape;
+  devHubId?: string;
+  orgEdition?: string;
+};
+
 export type TelemetryReporterConfig = {
   extName: string;
   version: string;
@@ -15,4 +25,6 @@ export type TelemetryReporterConfig = {
 };
 
 /** update existing telemetry reporters with new user ID and web user ID */
-export type TelemetryReporterWithModifiableUserProperties = Pick<TelemetryReporterConfig, 'userId' | 'webUserId'>;
+export type TelemetryReporterWithModifiableUserProperties = Pick<TelemetryReporterConfig, 'userId' | 'webUserId'> & {
+  orgIdentity?: OrgIdentity;
+};

--- a/packages/salesforcedx-utils-vscode/test/jest/context/workspaceOrgShape.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/context/workspaceOrgShape.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { shapeFrom } from '../../../src/context/workspaceOrgShape';
+
+describe('shapeFrom', () => {
+  it('returns Scratch when isScratch true', () => {
+    expect(shapeFrom({ isScratch: true })).toBe('Scratch');
+  });
+
+  it('returns Sandbox when isSandbox true and isScratch false', () => {
+    expect(shapeFrom({ isSandbox: true })).toBe('Sandbox');
+  });
+
+  it('prefers Scratch over Sandbox when both flags set (precedence)', () => {
+    expect(shapeFrom({ isScratch: true, isSandbox: true })).toBe('Scratch');
+  });
+
+  it('returns Production when alias is set', () => {
+    expect(shapeFrom({ alias: 'my-org' })).toBe('Production');
+  });
+
+  it('returns Production when only username is set', () => {
+    expect(shapeFrom({ username: 'user@example.com' })).toBe('Production');
+  });
+
+  it('returns Undefined when nothing is populated', () => {
+    expect(shapeFrom({})).toBe('Undefined');
+  });
+});

--- a/packages/salesforcedx-utils-vscode/test/jest/services/getIdentityFromServices.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/services/getIdentityFromServices.test.ts
@@ -16,7 +16,18 @@ const InvalidServicesApiError = class extends Error {
   public readonly _tag = 'InvalidServicesApiError';
 };
 
-type OrgInfoShape = { cliId?: string; userId?: string; webUserId?: string };
+type OrgInfoShape = {
+  cliId?: string;
+  userId?: string;
+  webUserId?: string;
+  orgId?: string;
+  isScratch?: boolean;
+  isSandbox?: boolean;
+  orgEdition?: string;
+  devHubOrgId?: string;
+  alias?: string;
+  username?: string;
+};
 const makeRef = (info: OrgInfoShape) => Effect.runSync(SubscriptionRef.make<OrgInfoShape>(info));
 
 const mockApiState = {
@@ -65,7 +76,34 @@ describe('TelemetryService.getIdentityFromServices', () => {
   it('returns identity from defaultOrgRef on happy path', async () => {
     mockApiState.ref = makeRef({ cliId: 'cli', userId: 'soql', webUserId: 'sha' });
     const result = await new TelemetryService().getIdentityFromServices();
-    expect(result).toEqual({ cliId: 'cli', webUserId: 'sha' });
+    // bare mock has no org fields -> shapeFrom yields 'Undefined' (a defined key toEqual won't ignore)
+    expect(result).toEqual(expect.objectContaining({ cliId: 'cli', webUserId: 'sha', orgShape: 'Undefined' }));
+  });
+
+  it('derives orgShape Production from alias via shapeFrom wiring', async () => {
+    mockApiState.ref = makeRef({ cliId: 'cli', webUserId: 'sha', alias: 'my-org' });
+    const result = await new TelemetryService().getIdentityFromServices();
+    expect(result.orgShape).toBe('Production');
+  });
+
+  it('derives orgShape Scratch and propagates org fields through the bridge', async () => {
+    mockApiState.ref = makeRef({
+      cliId: 'cli',
+      webUserId: 'sha',
+      isScratch: true,
+      orgId: '00Dxx',
+      devHubOrgId: '00Dhub',
+      orgEdition: 'Developer Edition'
+    });
+    const result = await new TelemetryService().getIdentityFromServices();
+    expect(result).toEqual(
+      expect.objectContaining({
+        orgShape: 'Scratch',
+        orgId: '00Dxx',
+        devHubId: '00Dhub',
+        orgEdition: 'Developer Edition'
+      })
+    );
   });
 
   it('falls back webUserId to UNAUTHENTICATED_USER when missing', async () => {

--- a/packages/salesforcedx-utils-vscode/test/jest/telemetry/telemetry.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/telemetry/telemetry.test.ts
@@ -359,7 +359,12 @@ describe('Telemetry', () => {
     });
 
     describe('updateReporters caches org identity', () => {
-      const orgIdentity = { orgId: '00Dxx', orgShape: 'Scratch', devHubId: '00Dhub', orgEdition: 'Developer Edition' };
+      const orgIdentity = {
+        orgId: '00Dxx',
+        orgShape: 'Scratch' as const,
+        devHubId: '00Dhub',
+        orgEdition: 'Developer Edition'
+      };
       // Object.create(prototype) so `instanceof` matches without running heavy constructors.
       const appInsights = Object.assign(Object.create(AppInsights.prototype), { userId: '', webUserId: '' });
       const o11y = Object.assign(Object.create(O11yReporter.prototype), { userId: '', webUserId: '' });
@@ -377,7 +382,7 @@ describe('Telemetry', () => {
           cliId: 'cli',
           webUserId: 'sha',
           ...orgIdentity
-        } as any);
+        });
       });
 
       it('sets orgIdentity on every reporter class', async () => {

--- a/packages/salesforcedx-utils-vscode/test/jest/telemetry/telemetry.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/telemetry/telemetry.test.ts
@@ -7,9 +7,13 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
 import { TelemetryServiceInterface } from '@salesforce/vscode-service-provider';
-import { workspace } from 'vscode';
+import { ExtensionContext, workspace } from 'vscode';
 import { SFDX_CORE_EXTENSION_NAME } from '../../../src/constants';
 import { TelemetryService, TelemetryServiceProvider } from '../../../src/services/telemetry';
+import { AppInsights } from '../../../src/telemetry/reporters/appInsights';
+import { LogStream } from '../../../src/telemetry/reporters/logStream';
+import { O11yReporter } from '../../../src/telemetry/reporters/o11yReporter';
+import { TelemetryFile } from '../../../src/telemetry/reporters/telemetryFile';
 
 describe('Telemetry', () => {
   describe('Telemetry Service Provider', () => {
@@ -351,6 +355,38 @@ describe('Telemetry', () => {
             customMetric: 42
           })
         );
+      });
+    });
+
+    describe('updateReporters caches org identity', () => {
+      const orgIdentity = { orgId: '00Dxx', orgShape: 'Scratch', devHubId: '00Dhub', orgEdition: 'Developer Edition' };
+      // Object.create(prototype) so `instanceof` matches without running heavy constructors.
+      const appInsights = Object.assign(Object.create(AppInsights.prototype), { userId: '', webUserId: '' });
+      const o11y = Object.assign(Object.create(O11yReporter.prototype), { userId: '', webUserId: '' });
+      const telemetryFile = Object.create(TelemetryFile.prototype);
+      const logStream = Object.create(LogStream.prototype);
+      const extensionContext = {
+        extension: { packageJSON: { name: 'salesforcedx-vscode-core', version: '1.0.0' } }
+      } as unknown as ExtensionContext;
+
+      beforeEach(() => {
+        (instance as any).reporters = [appInsights, o11y, telemetryFile, logStream];
+        (instance as any).extensionContext = extensionContext;
+        jest.spyOn(instance, 'isTelemetryEnabled').mockResolvedValue(true);
+        jest.spyOn(instance, 'getIdentityFromServices').mockResolvedValue({
+          cliId: 'cli',
+          webUserId: 'sha',
+          ...orgIdentity
+        } as any);
+      });
+
+      it('sets orgIdentity on every reporter class', async () => {
+        await instance.updateReporters(extensionContext);
+
+        expect(appInsights.orgIdentity).toEqual(orgIdentity);
+        expect(o11y.orgIdentity).toEqual(orgIdentity);
+        expect(telemetryFile.orgIdentity).toEqual(orgIdentity);
+        expect(logStream.orgIdentity).toEqual(orgIdentity);
       });
     });
 

--- a/packages/salesforcedx-vscode-core/src/context/workspaceOrgShape.ts
+++ b/packages/salesforcedx-vscode-core/src/context/workspaceOrgShape.ts
@@ -21,6 +21,3 @@ const getOrgShapeEffect = Effect.fn('workspaceOrgShape.getOrgShape')(function* (
 
 export const getOrgShape = async (_username: string): Promise<OrgShape> =>
   getRuntime().runPromise(getOrgShapeEffect().pipe(Effect.catchAll(() => Effect.succeed<OrgShape>('Undefined'))));
-
-// Re-exported so existing core test import (`../../../src/context/workspaceOrgShape`) stays green.
-export { type OrgShape, shapeFrom } from '@salesforce/salesforcedx-utils-vscode';

--- a/packages/salesforcedx-vscode-core/src/context/workspaceOrgShape.ts
+++ b/packages/salesforcedx-vscode-core/src/context/workspaceOrgShape.ts
@@ -6,24 +6,13 @@
  */
 
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
-import { OrgShape } from '@salesforce/salesforcedx-utils-vscode';
+import { OrgShape, shapeFrom } from '@salesforce/salesforcedx-utils-vscode';
 import * as Effect from 'effect/Effect';
 import { getRuntime } from '../services/runtime';
 import { getDefaultOrgInfo } from './defaultOrgInfo';
 
-type OrgShapeInfo = { isScratch?: boolean; isSandbox?: boolean; alias?: string; username?: string };
-
-/**
- * Maps DefaultOrgInfo fields from `defaultOrgRef` to an OrgShape literal.
- * Precedence: Scratch > Sandbox > Production (when alias or username known) > Undefined.
- * Exported for unit-test coverage of the precedence mapping.
- */
-export const shapeFrom = (info: OrgShapeInfo): OrgShape => {
-  if (info.isScratch) return 'Scratch';
-  if (info.isSandbox) return 'Sandbox';
-  if (info.alias ?? info.username) return 'Production';
-  return 'Undefined';
-};
+// Re-exported so existing core test import (`../../../src/context/workspaceOrgShape`) stays green.
+export { shapeFrom };
 
 const getOrgShapeEffect = Effect.fn('workspaceOrgShape.getOrgShape')(function* () {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;

--- a/packages/salesforcedx-vscode-core/src/context/workspaceOrgShape.ts
+++ b/packages/salesforcedx-vscode-core/src/context/workspaceOrgShape.ts
@@ -11,9 +11,6 @@ import * as Effect from 'effect/Effect';
 import { getRuntime } from '../services/runtime';
 import { getDefaultOrgInfo } from './defaultOrgInfo';
 
-// Re-exported so existing core test import (`../../../src/context/workspaceOrgShape`) stays green.
-export { shapeFrom };
-
 const getOrgShapeEffect = Effect.fn('workspaceOrgShape.getOrgShape')(function* () {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const { isEmpty } = yield* api.services.WorkspaceService.getWorkspaceInfo();
@@ -24,3 +21,6 @@ const getOrgShapeEffect = Effect.fn('workspaceOrgShape.getOrgShape')(function* (
 
 export const getOrgShape = async (_username: string): Promise<OrgShape> =>
   getRuntime().runPromise(getOrgShapeEffect().pipe(Effect.catchAll(() => Effect.succeed<OrgShape>('Undefined'))));
+
+// Re-exported so existing core test import (`../../../src/context/workspaceOrgShape`) stays green.
+export { type OrgShape, shapeFrom } from '@salesforce/salesforcedx-utils-vscode';

--- a/packages/salesforcedx-vscode-core/test/jest/context/workspaceOrgShape.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/context/workspaceOrgShape.test.ts
@@ -6,7 +6,7 @@
  */
 import * as Effect from 'effect/Effect';
 import { getDefaultOrgInfo } from '../../../src/context/defaultOrgInfo';
-import { getOrgShape, shapeFrom } from '../../../src/context/workspaceOrgShape';
+import { getOrgShape } from '../../../src/context/workspaceOrgShape';
 
 // Mutable workspace info the WorkspaceService mock returns; tests flip `isEmpty`.
 const mockWorkspaceInfo = { isEmpty: false };
@@ -76,31 +76,5 @@ describe('getOrgShape', () => {
     getDefaultOrgInfoMock.mockReturnValue(Effect.fail(new Error('TargetOrgRef unavailable')));
 
     expect(await getOrgShape(username)).toBe('Undefined');
-  });
-});
-
-describe('shapeFrom', () => {
-  it('returns Scratch when isScratch true', () => {
-    expect(shapeFrom({ isScratch: true })).toBe('Scratch');
-  });
-
-  it('returns Sandbox when isSandbox true and isScratch false', () => {
-    expect(shapeFrom({ isSandbox: true })).toBe('Sandbox');
-  });
-
-  it('prefers Scratch over Sandbox when both flags set (precedence)', () => {
-    expect(shapeFrom({ isScratch: true, isSandbox: true })).toBe('Scratch');
-  });
-
-  it('returns Production when alias is set', () => {
-    expect(shapeFrom({ alias: 'my-org' })).toBe('Production');
-  });
-
-  it('returns Production when only username is set', () => {
-    expect(shapeFrom({ username: 'user@example.com' })).toBe('Production');
-  });
-
-  it('returns Undefined when nothing is populated', () => {
-    expect(shapeFrom({})).toBe('Undefined');
   });
 });

--- a/plans/W-23451940.md
+++ b/plans/W-23451940.md
@@ -11,7 +11,7 @@
   - o11yReporter.ts 121-124, 163-166; appInsights.ts `getBaseProps` 253-257; telemetryFile.ts 77-85; logStream.ts 48/63 (orgId only).
 - `TargetOrgRef` value = `DefaultOrgInfoSchema` (services/core/schemas/defaultOrgInfo.ts): has `orgId?`, `isScratch?`, `isSandbox?`, `orgEdition?`, `devHubOrgId?`.
 - `shapeFrom` pure mapper currently in core `context/workspaceOrgShape.ts:21-26`; unit-tested in core `test/jest/context/workspaceOrgShape.test.ts`. Uses `OrgShape` type (already exported from utils-vscode `context/workspaceContextUtil.ts:25`).
-- Additive: old util-pull + new bridge-pull coexist. No reader touched this WI.
+- Additive: util-pull + bridge-pull coexist; no reader touched.
 
 ## Phases
 
@@ -31,7 +31,7 @@
 - Import `shapeFrom` + `OrgShape` from `../context/workspaceOrgShape` / `../context/workspaceContextUtil`.
 - **Update `getIdentityFromServices.test.ts` for the widened shape** (see finding — two exact-equality assertions break because `shapeFrom` never returns undefined, so `orgShape: 'Undefined'` is always present on the real fetch path):
   - Line 19 `OrgInfoShape`: add `orgId?`, `isScratch?`, `isSandbox?`, `orgEdition?`, `devHubOrgId?`, `alias?`, `username?` so mocks can drive org fields.
-  - Lines 65-69 happy-path: replace `toEqual({ cliId: 'cli', webUserId: 'sha' })` — bare mock now yields `orgShape: 'Undefined'` (a defined key `toEqual` will not ignore). Use `expect.objectContaining({ cliId: 'cli', webUserId: 'sha' })`, or assert full object incl. `orgShape: 'Undefined'`, `orgId/devHubId/orgEdition: undefined`.
+  - Lines 65-69 happy-path: bare mock -> `orgShape: 'Undefined'`; `toEqual` won't ignore defined keys -> use `expect.objectContaining({ cliId: 'cli', webUserId: 'sha' })`, or assert full object incl. `orgShape: 'Undefined'`, `orgId/devHubId/orgEdition: undefined`.
   - Lines 71-75: unaffected (`.webUserId` only) — leave.
   - Lines 77-87 degraded paths: `toEqual({ cliId: undefined, webUserId: UNAUTHENTICATED_USER })` still holds (`FALLBACK_IDENTITY` new fields are `undefined`, ignored by `toEqual`) — leave, but confirm green.
   - Add a Production-org case: mock ref with `alias: 'my-org'` (or `username`), assert `orgShape: 'Production'`. This exercises the actual `fetchIdentityFromServices` -> `shapeFrom` wiring (the Phase-1 isolated shapeFrom tests use hand-built inputs and would mask the alias/username omission).
@@ -44,8 +44,6 @@
 - `updateReporters` (246-256): in existing AppInsights|O11y `.map`, also set `r.orgIdentity = { orgId, orgShape, devHubId, orgEdition }` from destructured identity. Extend to TelemetryFile + LogStream (widen `.filter`), setting `orgIdentity` (they lack userId/webUserId — set only orgIdentity).
 - Destructure org fields from `getIdentityFromServices()` (235).
 - Commit: `feat(utils-vscode): cache org identity onto telemetry reporters`
-
-> Note: 3 commits total — Phase 1 refactor, Phase 2 feat (bridge/fetch), Phase 3 feat (reporters).
 
 ## Skills to apply
 - concise (plan/docs)

--- a/plans/W-23451940.md
+++ b/plans/W-23451940.md
@@ -1,0 +1,67 @@
+# W-23451940 — Widen services identity bridge to carry org fields
+
+## Context
+
+- Baseline: post-PR-7687 (present: HEAD `50b83a46ee`).
+- Telemetry identity bridge lives in `salesforcedx-utils-vscode/src/services/telemetry.ts`.
+  - `IdentityFromServices` type (36-45): `cliId`, `webUserId` only.
+  - `fetchIdentityFromServices` (50-67): reads `TargetOrgRef` -> `SubscriptionRef.get` -> maps `cliId`/`webUserId`.
+  - `updateReporters` (229-257): caches `userId`/`webUserId` onto AppInsights + O11y reporters.
+- Reporters today read org fields from `WorkspaceContextUtil` (util-pull):
+  - o11yReporter.ts 121-124, 163-166; appInsights.ts `getBaseProps` 253-257; telemetryFile.ts 77-85; logStream.ts 48/63 (orgId only).
+- `TargetOrgRef` value = `DefaultOrgInfoSchema` (services/core/schemas/defaultOrgInfo.ts): has `orgId?`, `isScratch?`, `isSandbox?`, `orgEdition?`, `devHubOrgId?`.
+- `shapeFrom` pure mapper currently in core `context/workspaceOrgShape.ts:21-26`; unit-tested in core `test/jest/context/workspaceOrgShape.test.ts`. Uses `OrgShape` type (already exported from utils-vscode `context/workspaceContextUtil.ts:25`).
+- Additive: old util-pull + new bridge-pull coexist. No reader touched this WI.
+
+## Phases
+
+### Phase 1 — Relocate `shapeFrom` into utils-vscode (unit-tested)
+- New `salesforcedx-utils-vscode/src/context/workspaceOrgShape.ts`: export `shapeFrom` + `OrgShapeInfo` type (copy 14-26 from core). Import `OrgShape` from `./workspaceContextUtil` (same pkg; avoid self barrel).
+- Export `shapeFrom` from utils-vscode `src/index.ts`.
+- Core `context/workspaceOrgShape.ts`: drop local `shapeFrom`/`OrgShapeInfo`; import `shapeFrom` from `@salesforce/salesforcedx-utils-vscode`; re-export it so existing core test import (`../../../src/context/workspaceOrgShape`) stays green. Keep `getOrgShapeEffect`/`getOrgShape`.
+- New utils-vscode jest test `test/jest/context/workspaceOrgShape.test.ts`: port 6 `shapeFrom` cases (Scratch/Sandbox/precedence/Production-alias/Production-username/Undefined).
+- Commit: `refactor(utils-vscode): relocate shapeFrom mapper into utils-vscode`
+
+### Phase 2 — Widen bridge type + fetch
+- `IdentityFromServices` (telemetry.ts 37-40): add `orgId?: string`, `orgShape?: OrgShape`, `devHubId?: string`, `orgEdition?: string`.
+- `FALLBACK_IDENTITY` (42-45): new fields `undefined`.
+- `fetchIdentityFromServices` map (55-60): read `orgId`, `isScratch`, `isSandbox`, `orgEdition`, `devHubOrgId`, **`alias`, `username`** off `SubscriptionRef.get` value; map `devHubOrgId -> devHubId`; derive `orgShape` via `shapeFrom({ isScratch, isSandbox, alias, username })`.
+  - `alias`/`username` are mandatory inputs to `shapeFrom`: its Production branch is `if (info.alias ?? info.username) return 'Production'` (workspaceOrgShape.ts:24). Omitting them misclassifies every authenticated production org as `'Undefined'`. Both fields exist on `DefaultOrgInfoSchema` (services/core/schemas/defaultOrgInfo.ts:15-16).
+  - `alias`/`username` feed `shapeFrom` only; they are NOT added to `IdentityFromServices` (bridge carries `orgShape`, not raw alias/username).
+- Import `shapeFrom` + `OrgShape` from `../context/workspaceOrgShape` / `../context/workspaceContextUtil`.
+- **Update `getIdentityFromServices.test.ts` for the widened shape** (see finding — two exact-equality assertions break because `shapeFrom` never returns undefined, so `orgShape: 'Undefined'` is always present on the real fetch path):
+  - Line 19 `OrgInfoShape`: add `orgId?`, `isScratch?`, `isSandbox?`, `orgEdition?`, `devHubOrgId?`, `alias?`, `username?` so mocks can drive org fields.
+  - Lines 65-69 happy-path: replace `toEqual({ cliId: 'cli', webUserId: 'sha' })` — bare mock now yields `orgShape: 'Undefined'` (a defined key `toEqual` will not ignore). Use `expect.objectContaining({ cliId: 'cli', webUserId: 'sha' })`, or assert full object incl. `orgShape: 'Undefined'`, `orgId/devHubId/orgEdition: undefined`.
+  - Lines 71-75: unaffected (`.webUserId` only) — leave.
+  - Lines 77-87 degraded paths: `toEqual({ cliId: undefined, webUserId: UNAUTHENTICATED_USER })` still holds (`FALLBACK_IDENTITY` new fields are `undefined`, ignored by `toEqual`) — leave, but confirm green.
+  - Add a Production-org case: mock ref with `alias: 'my-org'` (or `username`), assert `orgShape: 'Production'`. This exercises the actual `fetchIdentityFromServices` -> `shapeFrom` wiring (the Phase-1 isolated shapeFrom tests use hand-built inputs and would mask the alias/username omission).
+  - Add a Scratch case: mock `isScratch: true`, assert `orgShape: 'Scratch'` propagates through the bridge.
+- Commit: `feat(utils-vscode): widen services identity bridge to carry org fields`
+
+### Phase 3 — Cache org fields onto reporters
+- Add `orgIdentity?: { orgId?; orgShape?; devHubId?; orgEdition? }` field to reporter classes: AppInsights, O11yReporter, TelemetryFile, LogStream (single object field per WI; readers untouched, so field only, no read).
+- Add `orgIdentity` to `TelemetryReporterWithModifiableUserProperties` (telemetryReporterConfig.ts).
+- `updateReporters` (246-256): in existing AppInsights|O11y `.map`, also set `r.orgIdentity = { orgId, orgShape, devHubId, orgEdition }` from destructured identity. Extend to TelemetryFile + LogStream (widen `.filter`), setting `orgIdentity` (they lack userId/webUserId — set only orgIdentity).
+- Destructure org fields from `getIdentityFromServices()` (235).
+- Commit: `feat(utils-vscode): cache org identity onto telemetry reporters`
+
+> Note: 3 commits total — Phase 1 refactor, Phase 2 feat (bridge/fetch), Phase 3 feat (reporters).
+
+## Skills to apply
+- concise (plan/docs)
+- typescript (type widening, `type` not interface, undefined not null)
+- unit-test-critic / verification (shapeFrom tests)
+- i18n-messages — n/a (no user strings)
+- core-extension-api / services-extension-consumption — confirm `TargetOrgRef` value fields
+
+## Verification
+- `node --check` n/a (TS).
+- Build: wireit `compile` in salesforcedx-utils-vscode + salesforcedx-vscode-core (shapeFrom move crosses pkg boundary).
+- Jest green:
+  - utils-vscode new `workspaceOrgShape.test.ts` (shapeFrom 6 cases).
+  - core `workspaceOrgShape.test.ts` still passes via re-export.
+  - utils-vscode `getIdentityFromServices.test.ts` — happy-path assertion updated for widened shape (`orgShape: 'Undefined'` on bare mock); new Production + Scratch cases exercise `fetchIdentityFromServices -> shapeFrom` wiring (incl. alias/username fields); degraded-path assertions confirmed still green.
+  - utils-vscode `telemetry.test.ts` (bridge/updateReporters) — assert org fields cached.
+- Type-check: `IdentityFromServices` widened; reporter `orgIdentity` field compiles.
+- Grep: no reader (o11y/appInsights/telemetryFile/logStream send paths) changed — util-pull intact.
+- e2e-covered: none specific; org-field telemetry emission not exercised by branch e2e (readers untouched this WI).


### PR DESCRIPTION
## Summary
- Relocate `shapeFrom` org-shape mapper into `salesforcedx-utils-vscode` (shared, unit-tested; core re-exports for backward compat).
- Widen the services identity bridge (`IdentityFromServices` / `fetchIdentityFromServices`) to carry `orgId`, `orgShape`, `devHubId`, `orgEdition` alongside the existing `cliId`/`webUserId`.
- Cache the widened org identity onto AppInsights, O11yReporter, TelemetryFile, and LogStream reporters (write-only staging field; existing readers still pull org fields from `WorkspaceContextUtil`, untouched by this WI).

## Plan
[plans/W-23451940.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23451940-1-widen-services-identity-bridge-to-carr/plans/W-23451940.md)

## Reviewer notes
- `appInsights.ts:42` (+`o11yReporter.ts:32`, `telemetryFile.ts:20`, `logStream.ts:19`): `orgIdentity?: OrgIdentity` field duplicated across 4 unrelated reporter classes with copy-pasted comment. A shared base/mixin or WeakMap side-table is speculative generality for a hypothetical 5th reporter and spans 4 files with no shared base (AppInsights/O11yReporter extend `Disposable`; TelemetryFile/LogStream do not). Design decision, not applied.
- `telemetry.ts` `updateReporters` still does 3 filter passes over `this.reporters` with instanceof-based dispatch. Converted discard-value `.map()` side effects to `forEach`; the larger single-pass reporter-kind dispatch restructure is left for the reviewer.
- `telemetry.ts:264/276/282`: `orgIdentity` is a write-only cache — no reporter reads it yet (all still pull org fields from `WorkspaceContextUtil`). Intentional staged plumbing per the plan (readers untouched this WI); flagging future drift risk between cached `orgIdentity` and live util-pull.
- `telemetry.test.ts:363-367` fabricates 4 reporters via `Object.create(prototype)` to satisfy instanceof dispatch in `updateReporters`. Extracting a `patchForReporter`/lookup table would require adding a discriminant field to the 4 reporter classes — production refactor beyond this WI scope, not applied.
- `salesforcedx-utils-vscode/test/jest/context/workspaceOrgShape.test.ts` `describe('shapeFrom')` duplicates the identical 6-case block already in `salesforcedx-vscode-core/test/jest/context/workspaceOrgShape.test.ts` now that core re-exports `shapeFrom`. Trimming the core copy touches another package's tests and is arguably a re-export smoke check; ambiguous ownership, not applied.
- Commits `402743f` and `9ee1b39` mix `/src` and `/test` changes with real behavior. Splitting requires history rewrite; per documented precedent (`.claude/plans/W-23069611.md:37`) this is relaxed for behavioral migrations where an existing test assertion must change in lockstep to stay green — the case here.
- `IdentityFromServices`/`OrgIdentity` use bare `?:` optional fields for `orgId`/`orgShape`/`devHubId`/`orgEdition` rather than `Option<T>`. Consistent with the pre-existing convention in the same file and the upstream `Schema.optional` source of truth (`string | undefined`, not `Option`); broader architectural refactor, not applied.

## Test plan
- [ ] `wireit compile` green in `salesforcedx-utils-vscode` and `salesforcedx-vscode-core` (shapeFrom move crosses package boundary)
- [ ] Jest green: new utils-vscode `workspaceOrgShape.test.ts` (shapeFrom, 6 cases)
- [ ] Jest green: core `workspaceOrgShape.test.ts` still passes via re-export
- [ ] Jest green: utils-vscode `getIdentityFromServices.test.ts` — happy-path assertion updated for widened shape (`orgShape: 'Undefined'` on bare mock); new Production + Scratch cases exercise `fetchIdentityFromServices -> shapeFrom` wiring (incl. alias/username); degraded-path assertions still green
- [ ] Jest green: utils-vscode `telemetry.test.ts` (bridge/`updateReporters`) — org fields cached on all 4 reporter types
- [ ] Type-check: `IdentityFromServices` widened; reporter `orgIdentity` field compiles
- [ ] Grep-confirm: no reader (o11y/appInsights/telemetryFile/logStream send paths) changed — util-pull intact

### What issues does this PR fix or reference?
@W-23451940@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002elbzPYAQ/view
