### PR TITLE
fix(services): fix + enforce lazyPromiseInEffectSync - W-23429441

### DIFF
--- a/config/effect-diagnostics.json
+++ b/config/effect-diagnostics.json
@@ -1,4 +1,4 @@
 {
   "$comment": "Effect LS diagnostics ratchet. scripts/effect-diagnostics.mjs fails the build only on findings whose rule name is listed in enforcedRules (any severity). Sibling WIs append a rule name here after fixing all its sites. Empty list = nothing enforced (exit 0).",
-  "enforcedRules": []
+  "enforcedRules": ["lazyPromiseInEffectSync"]
 }

--- a/packages/salesforcedx-vscode-services/src/vscode/editorService.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/editorService.ts
@@ -23,7 +23,11 @@ export class EditorService extends Effect.Service<EditorService>()('EditorServic
       Effect.runSync(PubSub.publish(editorPubSub, editor));
     });
     Effect.runSync(PubSub.publish(editorPubSub, vscode.window.activeTextEditor));
-    yield* Effect.addFinalizer(() => Effect.sync(() => disposable?.dispose()));
+    yield* Effect.addFinalizer(() =>
+      Effect.sync(() => {
+        disposable?.dispose();
+      })
+    );
 
     /** Get URI from active editor, fails with NoActiveEditorError if none */
     const getActiveEditorUri = Effect.fn('EditorService.getActiveEditorUri')(function* () {

--- a/packages/salesforcedx-vscode-services/src/vscode/extensionsService.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/extensionsService.ts
@@ -26,7 +26,11 @@ export class ExtensionsService extends Effect.Service<ExtensionsService>()('Exte
     const disposable = vscode.extensions.onDidChange(() => {
       Effect.runSync(SubscriptionRef.set(ref, snapshotInstalledIds()));
     });
-    yield* Effect.addFinalizer(() => Effect.sync(() => disposable.dispose()));
+    yield* Effect.addFinalizer(() =>
+      Effect.sync(() => {
+        disposable.dispose();
+      })
+    );
 
     const changes: Stream.Stream<ReadonlySet<string>> = ref.changes;
     const get = SubscriptionRef.get(ref);

--- a/packages/salesforcedx-vscode-services/src/vscode/fileWatcherService.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/fileWatcherService.ts
@@ -26,7 +26,10 @@ export const FileWatcherLayer = Layer.scopedDiscard(
           watcher.onDidChange(uri => emit.single({ type: 'change', uri }));
           watcher.onDidDelete(uri => emit.single({ type: 'delete', uri }));
         }).pipe(Stream.runForEach(event => PubSub.publish(pubsub, event).pipe(Effect.catchAll(() => Effect.void)))),
-      watcher => Effect.sync(() => watcher.dispose()).pipe(Effect.withSpan('disposing file watcher'))
+      watcher =>
+        Effect.sync(() => {
+          watcher.dispose();
+        }).pipe(Effect.withSpan('disposing file watcher'))
     ).pipe(Effect.forkScoped);
 
     yield* channel.appendToChannel('FileWatcherService started successfully');

--- a/packages/salesforcedx-vscode-services/src/vscode/settingsWatcherService.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/settingsWatcherService.ts
@@ -18,7 +18,9 @@ export const SettingsWatcherLayer = Layer.scopedDiscard(
 
     yield* Stream.async<vscode.ConfigurationChangeEvent>(emit => {
       const disposable = vscode.workspace.onDidChangeConfiguration(event => emit.single(event));
-      return Effect.sync(() => disposable.dispose()).pipe(Effect.withSpan('disposing configuration change watcher'));
+      return Effect.sync(() => {
+        disposable.dispose();
+      }).pipe(Effect.withSpan('disposing configuration change watcher'));
     }).pipe(
       Stream.runForEach(event => PubSub.publish(pubsub, event)),
       Effect.forkScoped

--- a/packages/salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts
+++ b/packages/salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts
@@ -99,7 +99,9 @@ export class SOQLEditorInstance {
         const disposable = webviewPanel.webview.onDidReceiveMessage((event: SoqlEditorEvent) => {
           void emit.single(event);
         });
-        return Effect.sync(() => disposable.dispose());
+        return Effect.sync(() => {
+          disposable.dispose();
+        });
       }).pipe(
         Stream.mapEffect(
           event =>

--- a/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataViewService.ts
+++ b/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataViewService.ts
@@ -167,7 +167,9 @@ export class QueryDataViewService {
         const disposable = panel.webview.onDidReceiveMessage((event: DataViewEvent) => {
           void emit.single(event);
         });
-        return Effect.sync(() => disposable.dispose());
+        return Effect.sync(() => {
+          disposable.dispose();
+        });
       }).pipe(
         Stream.mapEffect(
           event =>

--- a/plans/W-23429441.md
+++ b/plans/W-23429441.md
@@ -1,0 +1,52 @@
+# W-23429441 — Fix + enforce lazyPromiseInEffectSync
+
+## Context
+
+- Effect LS rule `lazyPromiseInEffectSync`: warns when `Effect.sync` thunk returns a Promise; wants `Effect.promise`/`tryPromise`.
+- 6 findings, all `Effect.sync(() => x.dispose())`.
+- Root cause: `vscode.Disposable.dispose(): any` (node_modules/@types/vscode/index.d.ts:1705, :7714). `any` assignable to `Promise`, so thunk-returns-Promise fires. Sibling `statusBarItem.dispose(): void` sites NOT flagged (traceFlagStatusBar, sourceTrackingStatusBar, orgList) — leave alone.
+- Fix: block-body thunk `() => { x.dispose(); }` → returns `void`, not `any`. NOT `Effect.promise` (dispose is sync).
+- Enforcement: WI says "tsconfig.common.json diagnosticSeverity" but no such block exists. Real gate = ratchet `config/effect-diagnostics.json` `enforcedRules` (run by `scripts/effect-diagnostics.mjs`, wired via `check:effect-diagnostics`). Promote by appending rule name there.
+
+### Overlap check (WI-required)
+
+- No `local/` custom ESLint rule (no eslint local dir).
+- `effect-best-practices` SKILL.md: no `lazyPromiseInEffectSync` coverage.
+- Nothing to retire/dedupe.
+
+### Sites
+
+- salesforcedx-vscode-services/src/vscode/editorService.ts:26
+- salesforcedx-vscode-services/src/vscode/extensionsService.ts:29
+- salesforcedx-vscode-services/src/vscode/fileWatcherService.ts:29
+- salesforcedx-vscode-services/src/vscode/settingsWatcherService.ts:21
+- salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts:101
+- salesforcedx-vscode-soql/src/queryDataView/queryDataViewService.ts:170
+
+## Phases
+
+### Phase 1 — Fix 6 sites
+
+- Wrap each dispose thunk in block body: `Effect.sync(() => { disposable.dispose(); })` (keep `?.` where present in editorService).
+- Preserve `.pipe(Effect.withSpan(...))` on fileWatcher/settingsWatcher.
+- Files: editorService.ts, extensionsService.ts, fileWatcherService.ts, settingsWatcherService.ts, soqlEditorInstance.ts, queryDataViewService.ts.
+- Commit: `fix: silence lazyPromiseInEffectSync on vscode dispose thunks`
+
+### Phase 2 — Enforce
+
+- Append `"lazyPromiseInEffectSync"` to `enforcedRules` in `config/effect-diagnostics.json`.
+- Commit: `feat: enforce lazyPromiseInEffectSync in effect-diagnostics ratchet`
+
+## Skills
+
+- effect-best-practices
+- typescript
+- concise (plan only)
+- verification
+
+## Verification
+
+- `node scripts/effect-diagnostics.mjs` → 0 `lazyPromiseInEffectSync` findings, exit 0.
+- `npm run compile` (services + soql) clean — thunk still typed, no regressions.
+- Confirm no NEW enforced-rule finding elsewhere once rule added (ratchet scans all Effect pkgs).
+- No e2e coverage for this; all checks are static.


### PR DESCRIPTION
### What does this PR do?

- Wraps 6 `Effect.sync(() => x.dispose())` dispose thunks (services + soql packages) in a block body so they type as `void`, not `any` — `vscode.Disposable.dispose(): any` was tripping the Effect LS `lazyPromiseInEffectSync` rule.
- Promotes `lazyPromiseInEffectSync` into `enforcedRules` in `config/effect-diagnostics.json` so the ratchet blocks future regressions.

### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @W-23429441@

## Plan
See [plans/W-23429441.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23429441-2-fix-enforce-lazypromiseineffectsync/plans/W-23429441.md)

## Reviewer notes
- low: DRY suggestion to extract the `Effect.sync(() => { d.dispose(); })` thunk into a shared `disposeSync` helper — not applied. The 2 soql call sites only `import type` from salesforcedx-vscode-services today, so a shared value export would add new public API surface and a real cross-package runtime dependency. Author already declined further dedup in the plan's overlap-check, and the newly-enforced lint rule already guards against drift.

## Test plan
- [ ] `node scripts/effect-diagnostics.mjs` → 0 `lazyPromiseInEffectSync` findings, exit 0
- [ ] `npm run compile` (services + soql) clean — thunk still typed, no regressions
- [ ] Confirm no new enforced-rule finding elsewhere once rule added (ratchet scans all Effect packages)
- [ ] No e2e coverage needed — all checks are static

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eeS2RYAU/view