### PR TITLE
fix(visualforce): hover matches mixed-case tags (pageBlock, outputField) - W-23459711

### DIFF
--- a/packages/salesforcedx-visualforce-markup-language-server/src/parser/htmlTags.ts
+++ b/packages/salesforcedx-visualforce-markup-language-server/src/parser/htmlTags.ts
@@ -46,12 +46,15 @@ export function isEmptyElement(e: string): boolean {
   );
 }
 
+export type TagEntry = { tag: string; label: string };
+export type AttributeEntry = { attribute: string; type: string };
+
 export type IHTMLTagProvider = {
   getId(): string;
   isApplicable(languageId: string);
-  collectTags(collector: (tag: string, label: string) => void): void;
-  collectAttributes(tag: string, collector: (attribute: string, type: string) => void): void;
-  collectValues(tag: string, attribute: string, collector: (value: string) => void): void;
+  getTags(): TagEntry[];
+  getAttributes(tag: string): AttributeEntry[];
+  getValues(tag: string, attribute: string): string[];
 };
 
 type ITagSet = {
@@ -1132,93 +1135,52 @@ export function getHTML5TagProvider(): IHTMLTagProvider {
   return {
     getId: () => 'html5',
     isApplicable: () => true,
-    collectTags: (collector: (tag: string, label: string) => void) => collectTagsDefault(collector, HTML_TAGS),
-    collectAttributes: (tag: string, collector: (attribute: string, type: string) => void) => {
-      if (HTML_TAGS[tag]) {
-        collectAttributesDefault(tag, collector, HTML_TAGS, globalAttributes);
-        eventHandlers.forEach(handler => {
-          collector(handler, 'event');
-        });
-      }
-    },
-    collectValues: (tag: string, attribute: string, collector: (value: string) => void) =>
-      collectValuesDefault(tag, attribute, collector, HTML_TAGS, globalAttributes, valueSets)
+    getTags: () => getTagsDefault(HTML_TAGS),
+    getAttributes: (tag: string) =>
+      HTML_TAGS[tag]
+        ? [
+            ...getAttributesDefault(tag, HTML_TAGS, globalAttributes),
+            ...eventHandlers.map(handler => ({ attribute: handler, type: 'event' }))
+          ]
+        : [],
+    getValues: (tag: string, attribute: string) =>
+      getValuesDefault(tag, attribute, HTML_TAGS, globalAttributes, valueSets)
   };
 }
 
-function collectTagsDefault(collector: (tag: string, label: string) => void, tagSet: ITagSet): void {
-  for (const tag in tagSet) {
-    if (tagSet.hasOwnProperty(tag)) {
-      collector(tag, tagSet[tag].documentation);
-    }
-  }
+function getTagsDefault(tagSet: ITagSet): TagEntry[] {
+  return Object.keys(tagSet).map(tag => ({ tag, label: tagSet[tag].documentation }));
 }
 
-function collectAttributesDefault(
-  tag: string,
-  collector: (attribute: string, type: string) => void,
-  tagSet: ITagSet,
-  globalAttributes: string[]
-): void {
-  globalAttributes.forEach(attr => {
+function getAttributesDefault(tag: string, tagSet: ITagSet, globalAttributes: string[]): AttributeEntry[] {
+  const toEntry = (attr: string): AttributeEntry => {
     const segments = attr.split(':');
-    collector(segments[0], segments[1]);
-  });
-  if (tag) {
-    const tags = tagSet[tag];
-    if (tags) {
-      const attributes = tags.attributes;
-      if (attributes) {
-        attributes.forEach(attr => {
-          const segments = attr.split(':');
-          collector(segments[0], segments[1]);
-        });
-      }
-    }
-  }
+    return { attribute: segments[0], type: segments[1] };
+  };
+  const tagAttributes = tag && tagSet[tag] && tagSet[tag].attributes ? tagSet[tag].attributes : [];
+  return [...globalAttributes, ...tagAttributes].map(toEntry);
 }
 
-export function collectValuesDefault(
+export function getValuesDefault(
   tag: string,
   attribute: string,
-  collector: (value: string) => void,
   tagSet: ITagSet,
   globalAttributes: string[],
   valueSets: IValueSets,
   customTags?: { [tag: string]: string[] }
-): void {
+): string[] {
   const prefix = attribute + ':';
-  const processAttributes = (attributes: string[]) => {
-    attributes.forEach(attr => {
+  const processAttributes = (attributes: string[]): string[] =>
+    attributes.reduce<string[]>((acc, attr) => {
       if (attr.length > prefix.length && strings.startsWithCaseInsentively(attr, prefix)) {
         const typeInfo = attr.substr(prefix.length);
-        if (typeInfo === 'v') {
-          collector(attribute);
-        } else {
-          const values = valueSets[typeInfo];
-          if (values) {
-            values.forEach(collector);
-          }
-        }
+        return typeInfo === 'v' ? [...acc, attribute] : [...acc, ...(valueSets[typeInfo] ?? [])];
       }
-    });
-  };
-  if (tag) {
-    const tags = tagSet[tag];
-    if (tags) {
-      const attributes = tags.attributes;
-      if (attributes) {
-        processAttributes(attributes);
-      }
-    }
-  }
-  processAttributes(globalAttributes);
-  if (customTags) {
-    const customTagAttributes = customTags[tag];
-    if (customTagAttributes) {
-      processAttributes(customTagAttributes);
-    }
-  }
+      return acc;
+    }, []);
+  const tagAttributes = tag && tagSet[tag] && tagSet[tag].attributes ? tagSet[tag].attributes : [];
+  const customTagAttributes = customTags && customTags[tag] ? customTags[tag] : [];
+  return [...processAttributes(tagAttributes), ...processAttributes(globalAttributes), ...processAttributes(customTagAttributes)];
 }
 /*!
 END THIRD PARTY

--- a/packages/salesforcedx-visualforce-markup-language-server/src/parser/htmlTags.ts
+++ b/packages/salesforcedx-visualforce-markup-language-server/src/parser/htmlTags.ts
@@ -1171,13 +1171,13 @@ export function getValuesDefault(
 ): string[] {
   const prefix = attribute + ':';
   const processAttributes = (attributes: string[]): string[] =>
-    attributes.reduce<string[]>((acc, attr) => {
+    attributes.flatMap(attr => {
       if (attr.length > prefix.length && strings.startsWithCaseInsentively(attr, prefix)) {
         const typeInfo = attr.substr(prefix.length);
-        return typeInfo === 'v' ? [...acc, attribute] : [...acc, ...(valueSets[typeInfo] ?? [])];
+        return typeInfo === 'v' ? [attribute] : (valueSets[typeInfo] ?? []);
       }
-      return acc;
-    }, []);
+      return [];
+    });
   const tagAttributes = tag && tagSet[tag] && tagSet[tag].attributes ? tagSet[tag].attributes : [];
   const customTagAttributes = customTags && customTags[tag] ? customTags[tag] : [];
   return [...processAttributes(tagAttributes), ...processAttributes(globalAttributes), ...processAttributes(customTagAttributes)];

--- a/packages/salesforcedx-visualforce-markup-language-server/src/parser/visualforceTags.ts
+++ b/packages/salesforcedx-visualforce-markup-language-server/src/parser/visualforceTags.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { collectValuesDefault, IHTMLTagProvider, IValueSets, TagSpecification } from './htmlTags';
+import { AttributeEntry, getValuesDefault, IHTMLTagProvider, IValueSets, TagEntry, TagSpecification } from './htmlTags';
 
 class VisualforceTagSpecification extends TagSpecification {
   public readonly label: string;
@@ -26,30 +26,20 @@ export function getVisualforceTagProvider(): IHTMLTagProvider {
   return {
     getId: () => 'visualforce',
     isApplicable: languageId => languageId === 'visualforce',
-    collectTags: (collector: (tag: string, label: string) => void) => {
-      for (const tag in VISUALFORCE_TAGS) {
-        if (VISUALFORCE_TAGS.hasOwnProperty(tag)) {
-          collector(VISUALFORCE_TAGS[tag].label, VISUALFORCE_TAGS[tag].documentation);
-        }
-      }
+    getTags: (): TagEntry[] =>
+      Object.keys(VISUALFORCE_TAGS).map(tag => ({
+        tag: VISUALFORCE_TAGS[tag].label,
+        label: VISUALFORCE_TAGS[tag].documentation
+      })),
+    getAttributes: (tag: string): AttributeEntry[] => {
+      const attributes = tag && VISUALFORCE_TAGS[tag] ? VISUALFORCE_TAGS[tag].attributes : undefined;
+      return (attributes ?? []).map(attr => {
+        const segments = attr.split(':');
+        return { attribute: segments[0], type: segments[1] };
+      });
     },
-    collectAttributes: (tag: string, collector: (attribute: string, type: string) => void) => {
-      if (tag) {
-        const tags = VISUALFORCE_TAGS[tag];
-        if (tags) {
-          const attributes = tags.attributes;
-          if (attributes) {
-            attributes.forEach(attr => {
-              const segments = attr.split(':');
-              collector(segments[0], segments[1]);
-            });
-          }
-        }
-      }
-    },
-    collectValues: (tag: string, attribute: string, collector: (value: string) => void) => {
-      collectValuesDefault(tag, attribute, collector, VISUALFORCE_TAGS, [], valueSets);
-    }
+    getValues: (tag: string, attribute: string): string[] =>
+      getValuesDefault(tag, attribute, VISUALFORCE_TAGS, [], valueSets)
   };
 }
 

--- a/packages/salesforcedx-visualforce-markup-language-server/src/services/htmlCompletion.ts
+++ b/packages/salesforcedx-visualforce-markup-language-server/src/services/htmlCompletion.ts
@@ -60,7 +60,7 @@ export function doComplete(
   function collectOpenTagSuggestions(afterOpenBracket: number, tagNameEnd?: number): CompletionList {
     const range = getReplaceRange(afterOpenBracket, tagNameEnd);
     tagProviders.forEach(provider => {
-      provider.collectTags((tag, label) => {
+      provider.getTags().forEach(({ tag, label }) => {
         result.items.push({
           label: tag,
           kind: CompletionItemKind.Property,
@@ -126,7 +126,7 @@ export function doComplete(
     }
 
     tagProviders.forEach(provider => {
-      provider.collectTags((tag, label) => {
+      provider.getTags().forEach(({ tag, label }) => {
         result.items.push({
           label: '/' + tag,
           kind: CompletionItemKind.Property,
@@ -175,7 +175,7 @@ export function doComplete(
       : '="$1"';
     const tag = currentTag.toLowerCase();
     tagProviders.forEach(provider => {
-      provider.collectAttributes(tag, (attribute, type) => {
+      provider.getAttributes(tag).forEach(({ attribute, type }) => {
         let codeSnippet = attribute;
         if (type !== 'v' && value.length) {
           codeSnippet = codeSnippet + value;
@@ -210,7 +210,7 @@ export function doComplete(
     const tag = currentTag.toLowerCase();
     const attribute = currentAttributeName.toLowerCase();
     tagProviders.forEach(provider => {
-      provider.collectValues(tag, attribute, value => {
+      provider.getValues(tag, attribute).forEach(value => {
         const insertText = addQuotes ? '"' + value + '"' : value;
         result.items.push({
           label: value,

--- a/packages/salesforcedx-visualforce-markup-language-server/src/services/htmlHover.ts
+++ b/packages/salesforcedx-visualforce-markup-language-server/src/services/htmlHover.ts
@@ -19,18 +19,13 @@ export function doHover(document: TextDocument, position: Position, htmlDocument
   function getTagHover(tag: string, range: Range, open: boolean): Hover {
     tag = tag.toLowerCase();
     for (const provider of tagProviders) {
-      let hover: Hover;
-      provider.collectTags((t, label) => {
-        if (t === tag) {
-          const tagLabel = open ? '<' + tag + '>' : '</' + tag + '>';
-          hover = {
-            contents: [{ language: 'html', value: tagLabel }, MarkedString.fromPlainText(label)],
-            range
-          };
-        }
-      });
-      if (hover) {
-        return hover;
+      const entry = provider.getTags().find(e => e.tag === tag);
+      if (entry) {
+        const tagLabel = open ? '<' + tag + '>' : '</' + tag + '>';
+        return {
+          contents: [{ language: 'html', value: tagLabel }, MarkedString.fromPlainText(entry.label)],
+          range
+        };
       }
     }
     return void 0;

--- a/packages/salesforcedx-visualforce-markup-language-server/src/services/htmlHover.ts
+++ b/packages/salesforcedx-visualforce-markup-language-server/src/services/htmlHover.ts
@@ -17,11 +17,11 @@ export function doHover(document: TextDocument, position: Position, htmlDocument
   }
   const tagProviders = allTagProviders.filter(p => p.isApplicable(document.languageId));
   function getTagHover(tag: string, range: Range, open: boolean): Hover {
-    tag = tag.toLowerCase();
+    const lowerTag = tag.toLowerCase();
     for (const provider of tagProviders) {
-      const entry = provider.getTags().find(e => e.tag === tag);
+      const entry = provider.getTags().find(e => e.tag.toLowerCase() === lowerTag);
       if (entry) {
-        const tagLabel = open ? '<' + tag + '>' : '</' + tag + '>';
+        const tagLabel = open ? '<' + entry.tag + '>' : '</' + entry.tag + '>';
         return {
           contents: [{ language: 'html', value: tagLabel }, MarkedString.fromPlainText(entry.label)],
           range

--- a/packages/salesforcedx-visualforce-markup-language-server/test/jest/hover.test.ts
+++ b/packages/salesforcedx-visualforce-markup-language-server/test/jest/hover.test.ts
@@ -27,6 +27,25 @@ describe('HTML Hover', () => {
     expect(hover && document.offsetAt(hover.range.start)).toBe(expectedHoverOffset);
   };
 
+  const assertVisualforceHover = (
+    value: string,
+    expectedHoverLabel: string | undefined,
+    expectedHoverOffset: number | undefined
+  ): void => {
+    const offset = value.indexOf('|');
+    value = value.substr(0, offset) + value.substr(offset + 1);
+
+    const document = TextDocument.create('test://test/test.page', 'visualforce', 0, value);
+
+    const position = document.positionAt(offset);
+    const ls = htmlLanguageService.getLanguageService();
+    const htmlDoc = ls.parseHTMLDocument(document);
+
+    const hover = ls.doHover(document, position, htmlDoc);
+    expect(hover?.contents[0].value).toBe(expectedHoverLabel);
+    expect(hover && document.offsetAt(hover.range.start)).toBe(expectedHoverOffset);
+  };
+
   test('Single', () => {
     assertHover('|<html></html>', undefined, undefined);
     assertHover('<|html></html>', '<html>', 1);
@@ -41,5 +60,12 @@ describe('HTML Hover', () => {
     assertHover('<html></htm|l>', '</html>', 8);
     assertHover('<html></html|>', '</html>', 8);
     assertHover('<html></html>|', undefined, undefined);
+  });
+
+  test('Visualforce mixed-case tags render original case', () => {
+    assertVisualforceHover('<apex:pageBl|ock></apex:pageBlock>', '<apex:pageBlock>', 1);
+    assertVisualforceHover('<apex:pageBlock></apex:pageBl|ock>', '</apex:pageBlock>', 18);
+    assertVisualforceHover('<apex:outputFi|eld></apex:outputField>', '<apex:outputField>', 1);
+    assertVisualforceHover('<apex:outputField></apex:outputFi|eld>', '</apex:outputField>', 20);
   });
 });

--- a/packages/salesforcedx-visualforce-markup-language-server/test/jest/hover.test.ts
+++ b/packages/salesforcedx-visualforce-markup-language-server/test/jest/hover.test.ts
@@ -8,43 +8,25 @@ import { TextDocument } from 'vscode-languageserver-types';
 import * as htmlLanguageService from '../../src';
 
 describe('HTML Hover', () => {
-  const assertHover = (
-    value: string,
-    expectedHoverLabel: string | undefined,
-    expectedHoverOffset: number | undefined
-  ): void => {
-    const offset = value.indexOf('|');
-    value = value.substr(0, offset) + value.substr(offset + 1);
+  const assertHoverFor =
+    (uri: string, languageId: string) =>
+    (value: string, expectedHoverLabel: string | undefined, expectedHoverOffset: number | undefined): void => {
+      const offset = value.indexOf('|');
+      value = value.substr(0, offset) + value.substr(offset + 1);
 
-    const document = TextDocument.create('test://test/test.html', 'html', 0, value);
+      const document = TextDocument.create(uri, languageId, 0, value);
 
-    const position = document.positionAt(offset);
-    const ls = htmlLanguageService.getLanguageService();
-    const htmlDoc = ls.parseHTMLDocument(document);
+      const position = document.positionAt(offset);
+      const ls = htmlLanguageService.getLanguageService();
+      const htmlDoc = ls.parseHTMLDocument(document);
 
-    const hover = ls.doHover(document, position, htmlDoc);
-    expect(hover?.contents[0].value).toBe(expectedHoverLabel);
-    expect(hover && document.offsetAt(hover.range.start)).toBe(expectedHoverOffset);
-  };
+      const hover = ls.doHover(document, position, htmlDoc);
+      expect(hover?.contents[0].value).toBe(expectedHoverLabel);
+      expect(hover && document.offsetAt(hover.range.start)).toBe(expectedHoverOffset);
+    };
 
-  const assertVisualforceHover = (
-    value: string,
-    expectedHoverLabel: string | undefined,
-    expectedHoverOffset: number | undefined
-  ): void => {
-    const offset = value.indexOf('|');
-    value = value.substr(0, offset) + value.substr(offset + 1);
-
-    const document = TextDocument.create('test://test/test.page', 'visualforce', 0, value);
-
-    const position = document.positionAt(offset);
-    const ls = htmlLanguageService.getLanguageService();
-    const htmlDoc = ls.parseHTMLDocument(document);
-
-    const hover = ls.doHover(document, position, htmlDoc);
-    expect(hover?.contents[0].value).toBe(expectedHoverLabel);
-    expect(hover && document.offsetAt(hover.range.start)).toBe(expectedHoverOffset);
-  };
+  const assertHover = assertHoverFor('test://test/test.html', 'html');
+  const assertVisualforceHover = assertHoverFor('test://test/test.page', 'visualforce');
 
   test('Single', () => {
     assertHover('|<html></html>', undefined, undefined);

--- a/packages/salesforcedx-vscode-visualforce/test/playwright/specs/visualforceLsp.headless.spec.ts
+++ b/packages/salesforcedx-vscode-visualforce/test/playwright/specs/visualforceLsp.headless.spec.ts
@@ -95,6 +95,53 @@ test.describe('Visualforce LSP', () => {
     });
   });
 
+  test('provides hover for mixed-case apex tags in .page files', async ({ page }) => {
+    test.setTimeout(3 * 60 * 1000);
+
+    const name = `LspHoverPage${Date.now()}`;
+
+    await test.step('seed and open a .page file', async () => {
+      await seedAndOpenPage(page, name);
+    });
+
+    await test.step('type page content with mixed-case apex tags', async () => {
+      await page.keyboard.type('<apex:pageBlock></apex:pageBlock>\n<apex:outputField/>');
+    });
+
+    const editor = page.locator(`${EDITOR_WITH_URI}[data-uri$="${name}.page"]`);
+
+    // Cold-LSP race: the first hover can land before the LS is ready and never re-triggers. Poll:
+    // clear any open hover, move the pointer off the token so the next hover() is a genuine pointer
+    // transition that re-drives the provider, then assert the card shows the original-case tag.
+    const assertHover = async (tagName: string): Promise<void> => {
+      const tagToken = editor
+        .locator('.view-lines span')
+        .filter({ hasText: new RegExp(`^${tagName}$`) })
+        .first();
+      await tagToken.waitFor({ state: 'visible', timeout: 10_000 });
+      await expect(async () => {
+        await page.keyboard.press('Escape');
+        const editorBox = await editor.boundingBox();
+        await page.mouse.move((editorBox?.x ?? 0) + 10, (editorBox?.y ?? 0) + (editorBox?.height ?? 0) - 10);
+        await tagToken.hover();
+        await expect(
+          page.locator('.monaco-hover:not(.hidden)').filter({ hasText: tagName }),
+          `Visualforce LSP hover card should show ${tagName}`
+        ).toBeVisible({ timeout: 3000 });
+      }).toPass({ timeout: 45_000 });
+    };
+
+    await test.step('hover apex:pageBlock and verify the hover card', async () => {
+      await assertHover('apex:pageBlock');
+      await saveScreenshot(page, 'vf-lsp-hover.pageBlock.png');
+    });
+
+    await test.step('hover apex:outputField and verify the hover card', async () => {
+      await assertHover('apex:outputField');
+      await saveScreenshot(page, 'vf-lsp-hover.outputField.png');
+    });
+  });
+
   // TODO: Go to Definition is not implemented in the Visualforce language server — documented gap carried over
   // from the deleted visualforceLsp.desktop.spec.ts. Add a spec here when the LS gains definition support.
 

--- a/plans/W-23459711.md
+++ b/plans/W-23459711.md
@@ -1,0 +1,62 @@
+# W-23459711 — Fix VF hover mixed-case tags + array-returning tag providers
+
+## Context
+
+Pkg: `packages/salesforcedx-visualforce-markup-language-server`.
+
+Bug: hover on VF mixed-case tags (`apex:pageBlock`, `apex:outputField`) returns nothing.
+- `services/htmlHover.ts:20` lowercases `tag`, then `collectTags` callback compares `t === tag` (`:24`).
+- VF `getVisualforceTagProvider.collectTags` (`parser/visualforceTags.ts:32`) emits mixed-case `.label` (`apex:pageBlock`) as `t` → never `=== 'apex:pageblock'`.
+- HTML5 works: `collectTagsDefault` (`htmlTags.ts:1152`) emits lowercase keys.
+
+Provider API (`IHTMLTagProvider`, `htmlTags.ts:49-55`): `collectTags/collectAttributes/collectValues` = callback-collector. Callers: `htmlHover.ts`, `htmlCompletion.ts` (`:63,129,178,213`). Refactor to array-returning: caller-side `.find`/case-insensitive match becomes trivial; removes collector closures.
+
+Node tag from parser = raw scanner text (`htmlParser.ts:93`), not lowercased.
+
+No e2e hover coverage yet: `packages/salesforcedx-vscode-visualforce/test/playwright/specs/*` has no hover assertions (only `visualforceLsp.headless.spec.ts` autocompletion + a documented GtD gap). The cross-platform `visualforceLsp.headless.spec.ts` (`test.describe('Visualforce LSP')`, runs desktop + web via `../fixtures`) is the file to extend — no `visualforceLsp.desktop.spec.ts` / `FOO_PAGE_CONTENT` fixture exists; it seeds an empty `.page` via `seedAndOpenPage` and types markup. Hover-assert pattern to mirror: `apexLspHover.desktop.spec.ts:29-44` and `lwcLspHover.headless.spec.ts:57-83` (poll re-hover for cold-LSP race, assert `.monaco-hover:not(.hidden)` filtered by expected text).
+
+## Behavior decision (acceptance criterion)
+
+Hover label MUST render the provider's original-case tag: `<apex:pageBlock>` open / `</apex:pageBlock>` close (WI = "fix hover for pageBlock, outputField" → show correct case). Current `htmlHover.ts:25` builds `tagLabel` from the already-lowercased `tag` var, which would render `<apex:pageblock>` — wrong. Build `tagLabel` from the matched provider entry's original-case tag. Jest + e2e assert the exact mixed-case string, not an either/or.
+
+## Phases
+
+### Phase 1 — Refactor tag providers to array-returning
+- `htmlTags.ts`:
+  - `IHTMLTagProvider`: `getTags(): {tag,label}[]`, `getAttributes(tag): {attribute,type}[]`, `getValues(tag,attribute): string[]`.
+  - default helpers → return arrays (`collectTagsDefault`→`getTagsDefault`, etc); `collectValuesDefault` push→array.
+  - html5 provider methods return arrays.
+- `visualforceTags.ts`: VF provider methods return arrays; `getValuesDefault` call.
+- Callers map over arrays:
+  - `htmlCompletion.ts:63,129,178,213` `provider.collectX(cb)` → `provider.getX(...).forEach`/`map`.
+  - `htmlHover.ts` `collectTags(cb)` → `getTags()`.
+- Behavior-preserving (bug still present).
+- Verify: `tsc` compile clean, existing jest green.
+- Commit: `refactor(visualforce): array-returning tag providers`
+
+### Phase 2 — Fix mixed-case hover match + jest tests
+- `htmlHover.ts`: match case-insensitively — `getTags().find(e => e.tag.toLowerCase() === tag)`; build `tagLabel` from the matched entry's original-case `e.tag` (NOT the lowercased `tag` var). Open → `<${e.tag}>`, close → `</${e.tag}>`. Preserves HTML5 lowercase (entries already lowercase) while fixing VF mixed-case.
+- Add jest cases to `test/jest/hover.test.ts`: VF doc (`TextDocument.create('test://test/test.page', 'visualforce', 0, value)` — mirror `completion.test.ts:60`). Assert exact labels:
+  - `<apex:pageBl|ock></apex:pageBlock>` → `<apex:pageBlock>` + range
+  - open + close for `apex:outputField` → `<apex:outputField>` / `</apex:outputField>`
+  - Existing HTML5 `Single` test still asserts lowercase `<html>` (regression guard).
+- Commit: `fix(visualforce): hover matches mixed-case tags (pageBlock, outputField)`
+
+### Phase 3 — Playwright e2e hover spec
+- Extend `packages/salesforcedx-vscode-visualforce/test/playwright/specs/visualforceLsp.headless.spec.ts` (cross-platform desktop + web) — add a `test('provides hover for mixed-case apex tags in .page files')` inside the existing `test.describe('Visualforce LSP')`.
+- Reuse `seedAndOpenPage`; type page content containing `<apex:pageBlock></apex:pageBlock>` and `<apex:outputField/>` (the WI's two tags).
+- Hover the `apex:pageBlock` tag-name token; mirror `apexLspHover.desktop.spec.ts:29-44` / `lwcLspHover.headless.spec.ts:57-83`: poll re-hover (Escape + pointer-off + `.hover()`) for cold-LSP race, assert `page.locator('.monaco-hover:not(.hidden)').filter({ hasText: 'apex:pageBlock' })` visible. Repeat for `apex:outputField`.
+- Keep `validateNoCriticalErrors` in `afterEach`.
+- Commit: `test(visualforce): e2e hover for mixed-case apex tags`
+
+## Skills to apply
+- concise (plan/docs)
+- typescript
+- unit-test-critic (Phase 2 tests)
+- i18n-messages (only if user-facing strings touched — none expected)
+
+## Verification
+- `npm run compile -w packages/salesforcedx-visualforce-markup-language-server` (tsc)
+- `npm test -w packages/salesforcedx-visualforce-markup-language-server` (jest: hover mixed-case + HTML5 regression + completion)
+- lint pkg
+- Playwright hover spec (Phase 3) green on desktop config for `visualforceLsp.headless.spec.ts` — hover card shows `apex:pageBlock` / `apex:outputField` mixed-case.


### PR DESCRIPTION
## Summary
- Fix Visualforce hover returning nothing for mixed-case tags (`apex:pageBlock`, `apex:outputField`) — `htmlHover.ts` now matches case-insensitively and renders the provider's original-case tag in the hover label.
- Refactor `IHTMLTagProvider` (`collectTags`/`collectAttributes`/`collectValues` callback API → array-returning `getTags`/`getAttributes`/`getValues`), updating HTML5 and Visualforce providers plus `htmlCompletion.ts`/`htmlHover.ts` callers.
- Add jest coverage for mixed-case VF hover (with an HTML5 lowercase regression guard) and a Playwright e2e hover spec for `apex:pageBlock` / `apex:outputField`.

## Plan
[plans/W-23459711.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23459711-1-1-fix-visualforce-hover-match-for-mixe/plans/W-23459711.md)

## Reviewer notes
- skill:playwright-e2e (`visualforceLsp.headless.spec.ts:98`) — `assertHover` closure duplicates the hover-token-and-assert pattern in `apexLspHover.desktop.spec.ts` and the toPass/Escape/mouse-move retry wrapper in `lwcLspHover.headless.spec.ts` (3 copies total). Fix = extract a shared `hoverTokenAndAssertCard` helper into `packages/playwright-vscode-ext`. Not applied: design decision spanning multiple packages/specs (helper signature, optional retry wrapper, where it lives); test-only DRY nit with zero functional impact.
- skill:playwright-e2e (`visualforceLsp.headless.spec.ts:45`) — second test (`'provides hover...'`) added to a file that already holds the autocompletion test, violating the "one test per file" convention. Not applied: design decision; the two tests are tightly coupled (same feature, shared `beforeEach` + `seedAndOpenPage` helper) so splitting duplicates setup for no functional gain, and 11 other specs in the repo already deviate from this unenforced convention.
- thermo (`htmlHover.ts:22`) — `provider.getTags().find(...)` materializes the full ~150-object tag array per provider on each hover (two arrays per Visualforce hover) vs the old zero-allocation callback API. Not applied: this is the intentional array-returning-provider API introduced by this PR's core refactor; reverting to a callback/streaming API is a public-API design decision, and the regression is a bounded few-hundred small objects only on debounced hover events.
- thermo (`visualforceLsp.headless.spec.ts:105`) — types literal open+close tags without disabling `visualforce.autoClosingTags` (default true), so the LS smart-tag-close feature can inject duplicate closing tags mid-typing on slow CI runners; the hover assertion never validates the editor buffer, so a duplicated-content regression could pass silently. Not applied: ambiguous fix — the existing `disableMonacoAutoClosing` helper only covers `editor.autoClosing*` settings, NOT `visualforce.autoClosingTags`, so remediation needs either a new setting-toggle helper or an added buffer-content assertion (which could itself flake); requires a design decision.

## Test plan
- `npm run compile -w packages/salesforcedx-visualforce-markup-language-server` (tsc)
- `npm test -w packages/salesforcedx-visualforce-markup-language-server` (jest: hover mixed-case + HTML5 regression + completion)
- lint pkg
- Playwright hover spec (Phase 3) green on desktop config for `visualforceLsp.headless.spec.ts` — hover card shows `apex:pageBlock` / `apex:outputField` mixed-case.

### What issues does this PR fix or reference?
@W-23459711@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002er5I5YAI/view