### PR TITLE
refactor(utils-vscode): appInsights/telemetryFile read cached org identity - W-23451942

### DIFF
--- a/.claude/skills/playwright-e2e/SKILL.md
+++ b/.claude/skills/playwright-e2e/SKILL.md
@@ -49,6 +49,21 @@ Available local + CI/GHA.
 
 See `.claude/skills/span-file-export/SKILL.md` for enable/OTLP vs file.
 
+## Telemetry inspection (diagnostic tests)
+
+Desktop tests can inspect both telemetry pipelines on-disk for diagnostic/integration testing:
+
+1. **O11y spans** — produced by services Effect pipeline; written to `~/.sf/vscode-spans/*.jsonl` (auto-enabled)
+2. **AppInsights events** — produced by class-based TelemetryFile reporter when `localTelemetryLogging` is enabled; written to `{workspace}/salesforcedx-vscode-core-telemetry.json` (AppInsights shape, real client inert in dev/test)
+
+**Fixture setup:** Enable both pipelines by passing `additionalExtensionDirs: ['salesforcedx-vscode-core']` (for core extension + TelemetryFile reporter) and `userSettings: { 'telemetry.telemetryLevel': 'all', 'salesforcedx-vscode-core.advanced.localTelemetryLogging': 'true' }` to `createDesktopTest`. Launch against a real scratch org (e.g., `orgAlias: MINIMAL_ORG_ALIAS`) so org-identity attributes populate in both pipelines.
+
+**Reading artifacts:**
+- Spans: parse `~/.sf/vscode-spans/*.jsonl` line-by-line with `JSON.parse`
+- AppInsights events: file contains comma-separated pretty JSON objects; wrap in `[]` and strip trailing comma to parse: `JSON.parse(`[${raw.trim().replace(/,\s*$/, '')}]`)`
+
+**Pattern:** Run command, capture artifacts, reload window to flush TelemetryFile buffer (fires deactivationEvent), then assert event/span presence + attributes. See `packages/salesforcedx-vscode-lightning/test/playwright/specs/telemetryOutput.desktop.spec.ts` for example.
+
 ## Checking for Scratch Orgs
 
 If you aren't sure if orgs are set up locally,

--- a/.claude/skills/playwright-e2e/references/coding-playwright-tests.md
+++ b/.claude/skills/playwright-e2e/references/coding-playwright-tests.md
@@ -45,6 +45,8 @@ await setWorkspaceApiVersion(workspaceDir, '66.0');
 
 **Desktop-only tests** (`.headless.spec.ts` file naming or `createDesktopTest` fixture) may poll fs directly for durable success signals (e.g., `waitForEsrFile` checks on-disk artifacts) instead of flaky UI toast assertions.
 
+**Desktop diagnostic tests (inspecting telemetry):** When testing telemetry output, create custom fixtures with `additionalExtensionDirs: ['salesforcedx-vscode-core']` + `userSettings: { 'telemetry.telemetryLevel': 'all', '…localTelemetryLogging': 'true' }` + real scratch org. Polls on-disk telemetry artifacts (O11y spans + AppInsights-shaped events) for integration testing. Example: `packages/salesforcedx-vscode-lightning/test/playwright/fixtures/telemetryFixtures.ts`.
+
 ## Web headless (`createHeadlessServer`)
 
 - Virtual `folderPath` mount: Node `fs` does not see project files; use `folderUri` (`file://…`) or `.vscode/vscode-extension-test-disk-root.txt` (disk root) when services must resolve `SfProject` — see JSDoc on `packages/playwright-vscode-ext/src/web/createHeadlessServer.ts`

--- a/.claude/skills/playwright-e2e/references/coding-playwright-tests.md
+++ b/.claude/skills/playwright-e2e/references/coding-playwright-tests.md
@@ -45,7 +45,7 @@ await setWorkspaceApiVersion(workspaceDir, '66.0');
 
 **Desktop-only tests** (`.headless.spec.ts` file naming or `createDesktopTest` fixture) may poll fs directly for durable success signals (e.g., `waitForEsrFile` checks on-disk artifacts) instead of flaky UI toast assertions.
 
-**Desktop diagnostic tests (inspecting telemetry):** When testing telemetry output, create custom fixtures with `additionalExtensionDirs: ['salesforcedx-vscode-core']` + `userSettings: { 'telemetry.telemetryLevel': 'all', '…localTelemetryLogging': 'true' }` + real scratch org. Polls on-disk telemetry artifacts (O11y spans + AppInsights-shaped events) for integration testing. Example: `packages/salesforcedx-vscode-lightning/test/playwright/fixtures/telemetryFixtures.ts`.
+**Desktop diagnostic tests (inspecting telemetry):** Custom fixtures poll on-disk telemetry artifacts (O11y spans + AppInsights-shaped events) for integration testing. Setup + read recipe: [SKILL — Telemetry inspection](../SKILL.md#telemetry-inspection-diagnostic-tests). Fixture example: `packages/salesforcedx-vscode-lightning/test/playwright/fixtures/telemetryFixtures.ts`.
 
 ## Web headless (`createHeadlessServer`)
 

--- a/.github/workflows/auraE2E.yml
+++ b/.github/workflows/auraE2E.yml
@@ -40,8 +40,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     env:
+      MINIMAL_ORG_ALIAS: minimalTestOrg
+      SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL_E2E }}
       VSCODE_DESKTOP: 1
       E2E_FROM_VSIX: 1
+      # sf CLI hides authFields from `sf org create scratch --json` output by default; tests need them.
+      SF_TEMP_SHOW_SECRETS: true
       PLAYWRIGHT_VSCODE_VERSION: ${{ github.event_name != 'push' &&
         inputs.vscode_version != '' && inputs.vscode_version ||
         vars.PLAYWRIGHT_VSCODE_VERSION }}
@@ -84,9 +88,28 @@ jobs:
         env:
           CI: 1
           VSCODE_DESKTOP: 1
+          MINIMAL_ORG_ALIAS: minimalTestOrg
           E2E_NO_RETRIES: 1
         run: |
           ${{ matrix.test_runner_prefix }}npm run test:desktop -w ${{ matrix.package }} -- --reporter=html
+
+      # Only run expensive setup when try-run failed (cache miss). On cache hit we never reach these steps.
+      - name: Install Salesforce CLI
+        if: steps.try-run.outcome == 'failure'
+        uses: salesforcecli/github-workflows/.github/actions/retry@main
+        with:
+          max_attempts: 3
+          command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
+          retry_wait_seconds: 30
+
+      - name: Auth to dev hub (global)
+        if: steps.try-run.outcome == 'failure'
+        uses: salesforcecli/github-workflows/.github/actions/retry@main
+        with:
+          max_attempts: 3
+          command: bash -c 'echo "$SFDX_AUTH_URL" | sf org login sfdx-url
+            --set-default-dev-hub --alias hub --sfdx-url-stdin'
+          retry_wait_seconds: 30
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
@@ -96,6 +119,19 @@ jobs:
           command: npx playwright install chromium --with-deps
           retry_wait_seconds: 60
 
+      - name: Generate minimal project
+        if: steps.try-run.outcome == 'failure'
+        shell: bash
+        run: sf project generate -n minimal-project
+
+      - name: create scratch org
+        if: steps.try-run.outcome == 'failure'
+        # the telemetry spec expects a scratch org with a certain alias so org-identity props populate
+        shell: bash
+        run: |
+          sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$MINIMAL_ORG_ALIAS" --json --wait 30
+        working-directory: minimal-project
+
       - name: Run E2E tests (parallel)
         if: steps.try-run.outcome == 'failure'
         id: parallel-run
@@ -103,6 +139,7 @@ jobs:
         env:
           CI: 1
           VSCODE_DESKTOP: 1
+          MINIMAL_ORG_ALIAS: minimalTestOrg
         run: |
           ${{ matrix.test_runner_prefix }}npm run test:desktop -w ${{ matrix.package }} -- --reporter=html
 
@@ -112,6 +149,7 @@ jobs:
         env:
           CI: 1
           VSCODE_DESKTOP: 1
+          MINIMAL_ORG_ALIAS: minimalTestOrg
           PLAYWRIGHT_WORKERS: 1
         run: |
           ${{ matrix.test_runner_prefix }}npm run test:desktop -w ${{ matrix.package }} -- --last-failed --reporter=html
@@ -138,3 +176,10 @@ jobs:
           name: playwright-test-results-${{ matrix.package }}-desktop-${{ matrix.os }}
           path: packages/${{ matrix.package }}/test-results
           if-no-files-found: ignore
+
+      - name: Cleanup scratch orgs
+        if: always() && steps.try-run.outcome == 'failure'
+        continue-on-error: true
+        shell: bash
+        run: |
+          sf org delete scratch -o "$MINIMAL_ORG_ALIAS" --no-prompt || true

--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -91,9 +91,21 @@ If using the New services extension, use `registerCommandWithLayer` from the ser
 
 Commands registered this way get automatic spans, which go to all the configured telemetry destinations (o11y, appInsights, local docker, etc). See [services-extension-consumption skill](../.claude/skills/services-extension-consumption/SKILL.md)
 
+## Testing Telemetry
+
+Desktop E2E tests can inspect both telemetry pipelines on-disk to verify event emission + attributes:
+
+- **O11y spans** (Effect pipeline) → `~/.sf/vscode-spans/*.jsonl` (JSONL format, auto-enabled)
+- **AppInsights events** (TelemetryFile) → `{workspace}/salesforcedx-vscode-core-telemetry.json` (comma-separated JSON objects)
+
+Enable both: `createDesktopTest({ additionalExtensionDirs: ['salesforcedx-vscode-core'], userSettings: { 'telemetry.telemetryLevel': 'all', 'salesforcedx-vscode-core.advanced.localTelemetryLogging': 'true' } })` + real org (e.g. MINIMAL_ORG_ALIAS). Run command, reload window to flush TelemetryFile buffer, then assert on-disk artifacts for presence + expected attributes.
+
+See `.claude/skills/playwright-e2e/SKILL.md#telemetry-inspection-diagnostic-tests` and `packages/salesforcedx-vscode-lightning/test/playwright/specs/telemetryOutput.desktop.spec.ts` for example.
+
 ## See Also
 
 - [services-extension-consumption](../.claude/skills/services-extension-consumption/SKILL.md) - Consuming salesforcedx-vscode-services API
 - [Observability README](../packages/salesforcedx-vscode-services/src/observability/README.md) - OpenTelemetry with Effect documentation
 - [Extensions - Logging](./architecture/Extensions.md#logging) - console and outputChannel logging options
 - [contributing/telemetry.md](../contributing/telemetry.md) - telemetry implementation details for this repo
+- [Playwright E2E testing](../docs/Testing.md#end-to-end-testing) - E2E test guidelines

--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -95,12 +95,10 @@ Commands registered this way get automatic spans, which go to all the configured
 
 Desktop E2E tests can inspect both telemetry pipelines on-disk to verify event emission + attributes:
 
-- **O11y spans** (Effect pipeline) → `~/.sf/vscode-spans/*.jsonl` (JSONL format, auto-enabled)
-- **AppInsights events** (TelemetryFile) → `{workspace}/salesforcedx-vscode-core-telemetry.json` (comma-separated JSON objects)
+- **O11y spans** (Effect pipeline) → `~/.sf/vscode-spans/*.jsonl`
+- **AppInsights events** (TelemetryFile) → `{workspace}/salesforcedx-vscode-core-telemetry.json`
 
-Enable both: `createDesktopTest({ additionalExtensionDirs: ['salesforcedx-vscode-core'], userSettings: { 'telemetry.telemetryLevel': 'all', 'salesforcedx-vscode-core.advanced.localTelemetryLogging': 'true' } })` + real org (e.g. MINIMAL_ORG_ALIAS). Run command, reload window to flush TelemetryFile buffer, then assert on-disk artifacts for presence + expected attributes.
-
-See `.claude/skills/playwright-e2e/SKILL.md#telemetry-inspection-diagnostic-tests` and `packages/salesforcedx-vscode-lightning/test/playwright/specs/telemetryOutput.desktop.spec.ts` for example.
+Fixture setup + read/assert recipe: [playwright-e2e SKILL — Telemetry inspection](../.claude/skills/playwright-e2e/SKILL.md#telemetry-inspection-diagnostic-tests). Example: `packages/salesforcedx-vscode-lightning/test/playwright/specs/telemetryOutput.desktop.spec.ts`.
 
 ## See Also
 
@@ -108,4 +106,4 @@ See `.claude/skills/playwright-e2e/SKILL.md#telemetry-inspection-diagnostic-test
 - [Observability README](../packages/salesforcedx-vscode-services/src/observability/README.md) - OpenTelemetry with Effect documentation
 - [Extensions - Logging](./architecture/Extensions.md#logging) - console and outputChannel logging options
 - [contributing/telemetry.md](../contributing/telemetry.md) - telemetry implementation details for this repo
-- [Playwright E2E testing](../docs/Testing.md#end-to-end-testing) - E2E test guidelines
+- [Playwright E2E testing](./Testing.md#end-to-end-testing) - E2E test guidelines

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -50,6 +50,7 @@ pros
 - records videos
 - works on the web (with vscode-test-web) so a single test runs everywhere
 - nice debug mode (step through the test steps)
+- desktop tests can inspect on-disk telemetry artifacts (O11y spans + AppInsights events) for integration testing
 
 cons
 
@@ -79,5 +80,6 @@ When the VSCode UI changes, you might have to update your e2e tests. And you mig
 ## See Also
 
 - [Build](./Build.md) - use packaged vsix for e2e tests
+- [Telemetry](./Telemetry.md) - telemetry implementation + testing telemetry output
 - [contributing/tests.md](../contributing/tests.md) - jest setup and running tests
 - [contributing/e2e-instructions.md](../contributing/e2e-instructions.md) - Playwright e2e instructions

--- a/docs/telemetry-common-attributes-proposal.md
+++ b/docs/telemetry-common-attributes-proposal.md
@@ -31,12 +31,12 @@ Note: `orgShape` is **not** emitted in this pipeline. The O11y span exporter (`o
 ### `salesforcedx-utils-vscode` (class-based, event properties)
 
 | Existing Attribute | Values | Emitted By | Present in O11y? |
-|--------------------|--------|------------|-----------------|
-| `orgShape` | `"Scratch"` / `"Sandbox"` / `"Production"` / `""` | `appInsights.ts` `getBaseProps()` | **Yes** (also in `o11yReporter.ts`) |
+| ---- | ---- | ---- | ---- |
+| `orgShape` | `"Scratch"` / `"Sandbox"` / `"Production"` (omitted if empty) | Multiple reporters | **Yes** |
 
-Both `appInsights.ts` and `o11yReporter.ts` read `orgShape` from `WorkspaceContextUtil.getInstance().orgShape` and include it as an event property.
+Both `appInsights.ts` and `o11yReporter.ts` read from `WorkspaceContextUtil.getInstance().orgShape`; `appInsights.ts` and `telemetryFile.ts` additionally read from cached `orgIdentity` (bridge-pulled). Empty values are omitted from event properties.
 
-**Logic**: `orgShape === "Production"` directly identifies prod orgs.
+**Logic**: When present, `orgShape === "Production"` directly identifies prod orgs.
 
 ### Assessment
 

--- a/docs/telemetry-properties-comparison.md
+++ b/docs/telemetry-properties-comparison.md
@@ -32,12 +32,13 @@ For *why* `userId`, `webUserId`, and the SOQL user ID coexist and how each maps 
 | Property Key | vscode-utils | services | Notes |
 |---|---|---|---|
 | `orgId` | `WorkspaceContextUtil.orgId` | `DefaultOrgRef.orgId` | Same concept, different source object |
-| `orgShape` | `WorkspaceContextUtil.orgShape` ('Scratch'/'Sandbox'/'Production'/'Undefined') | **NOT SET** | **MISMATCH** - services uses `isScratch`/`isSandbox` booleans instead |
+| `orgShape` | `WorkspaceContextUtil.orgShape` ('Scratch'/'Sandbox'/'Production'; omitted if empty) | **NOT SET** | **MISMATCH** - services uses `isScratch`/`isSandbox` booleans instead |
 | `isScratch` | **NOT SET** | `DefaultOrgRef.isScratch` as `'true'`/`'false'` | **MISMATCH** - vscode-utils uses `orgShape` enum |
 | `isSandbox` | **NOT SET** | `DefaultOrgRef.isSandbox` as `'true'`/`'false'` | **MISMATCH** - vscode-utils uses `orgShape` enum |
 | `tracksSource` | **NOT SET** | `DefaultOrgRef.tracksSource` as `'true'`/`'false'` | **MISMATCH** - missing in vscode-utils |
-| `devHubId` | `WorkspaceContextUtil.devHubId` | — | Key name differs (see below) |
+| `devHubId` | `WorkspaceContextUtil.devHubId` (omitted if empty) | — | Key name differs (see below) |
 | `devHubOrgId` | — | `DefaultOrgRef.devHubOrgId` | **MISMATCH** - different key name from vscode-utils `devHubId` |
+| `orgEdition` | `WorkspaceContextUtil.orgEdition` (omitted if empty) | `DefaultOrgRef.orgEdition` (via span attributes) | Same value |
 | `userId` | Constructor param (CLI telemetry ID or random hash) | `DefaultOrgRef.cliId` | Same value, different wiring |
 | `webUserId` | Constructor param + per-event override | `DefaultOrgRef.webUserId` | Same value |
 | `telemetryTag` | VS Code config `salesforcedx-vscode-core.telemetry-tag` | VS Code config `salesforcedx-vscode-core.telemetry-tag` | Same |

--- a/packages/salesforcedx-utils-vscode/src/telemetry/reporters/appInsights.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/reporters/appInsights.ts
@@ -7,7 +7,6 @@ import type { OrgIdentity, TelemetryReporterWithModifiableUserProperties } from 
 import type { TelemetryReporter } from '@salesforce/vscode-service-provider';
 import { TelemetryReporter as VSCodeTelemetryReporter } from '@vscode/extension-telemetry';
 import { Disposable, env, workspace } from 'vscode';
-import { WorkspaceContextUtil } from '../../context/workspaceContextUtil';
 import { isInternalHost } from '../utils/isInternal';
 import { getCommonProperties, getInternalProperties } from './telemetryUtils';
 
@@ -132,7 +131,7 @@ export class AppInsights
       return;
     }
 
-    const baseProps = getBaseProps();
+    const baseProps = this.getBaseProps();
     const finalProps = this.applyTelemetryTag({ ...baseProps, ...properties, webUserId: this.webUserId });
 
     if (process.env.ESBUILD_PLATFORM === 'web') {
@@ -170,7 +169,7 @@ export class AppInsights
       return;
     }
 
-    const baseProps = getBaseProps();
+    const baseProps = this.getBaseProps();
     const finalProps = this.applyTelemetryTag({ ...baseProps, webUserId: this.webUserId });
 
     if (process.env.ESBUILD_PLATFORM === 'web') {
@@ -250,10 +249,9 @@ export class AppInsights
   } {
     return this.telemetryTag ? { ...properties, telemetryTag: this.telemetryTag } : properties;
   }
-}
 
-const getBaseProps = (): Record<string, string> => {
-  const context = WorkspaceContextUtil.getInstance();
-  const { orgId = '', orgShape = '', devHubId = '', orgEdition = '' } = context;
-  return orgId ? { orgId, orgShape, devHubId, ...(orgEdition ? { orgEdition } : {}) } : {};
-};
+  private getBaseProps(): Record<string, string> {
+    const { orgId = '', orgShape = '', devHubId = '', orgEdition = '' } = this.orgIdentity ?? {};
+    return orgId ? { orgId, orgShape, devHubId, ...(orgEdition ? { orgEdition } : {}) } : {};
+  }
+}

--- a/packages/salesforcedx-utils-vscode/src/telemetry/reporters/appInsights.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/reporters/appInsights.ts
@@ -8,7 +8,7 @@ import type { TelemetryReporter } from '@salesforce/vscode-service-provider';
 import { TelemetryReporter as VSCodeTelemetryReporter } from '@vscode/extension-telemetry';
 import { Disposable, env, workspace } from 'vscode';
 import { isInternalHost } from '../utils/isInternal';
-import { getCommonProperties, getInternalProperties } from './telemetryUtils';
+import { getCommonProperties, getInternalProperties, getOrgIdentityProps } from './telemetryUtils';
 
 /** Same connection string as telemetry (salesforcedx-vscode-services observability). */
 const DEFAULT_AI_CONNECTION_STRING: string =
@@ -131,7 +131,7 @@ export class AppInsights
       return;
     }
 
-    const baseProps = this.getBaseProps();
+    const baseProps = getOrgIdentityProps(this.orgIdentity);
     const finalProps = this.applyTelemetryTag({ ...baseProps, ...properties, webUserId: this.webUserId });
 
     if (process.env.ESBUILD_PLATFORM === 'web') {
@@ -169,7 +169,7 @@ export class AppInsights
       return;
     }
 
-    const baseProps = this.getBaseProps();
+    const baseProps = getOrgIdentityProps(this.orgIdentity);
     const finalProps = this.applyTelemetryTag({ ...baseProps, webUserId: this.webUserId });
 
     if (process.env.ESBUILD_PLATFORM === 'web') {
@@ -248,10 +248,5 @@ export class AppInsights
     [key: string]: string;
   } {
     return this.telemetryTag ? { ...properties, telemetryTag: this.telemetryTag } : properties;
-  }
-
-  private getBaseProps(): Record<string, string> {
-    const { orgId = '', orgShape = '', devHubId = '', orgEdition = '' } = this.orgIdentity ?? {};
-    return orgId ? { orgId, orgShape, devHubId, ...(orgEdition ? { orgEdition } : {}) } : {};
   }
 }

--- a/packages/salesforcedx-utils-vscode/src/telemetry/reporters/telemetryFile.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/reporters/telemetryFile.ts
@@ -11,6 +11,7 @@ import * as vscode from 'vscode';
 import { URI } from 'vscode-uri';
 import { LOCAL_TELEMETRY_FILE } from '../../constants';
 import { getRootWorkspacePath } from '../../workspaces/workspaceUtils';
+import { getOrgIdentityProps } from './telemetryUtils';
 
 /**
  * Represents a telemetry file that logs telemetry events by appending to a local file.
@@ -34,7 +35,7 @@ export class TelemetryFile implements TelemetryReporter {
     properties?: { [key: string]: string },
     measurements?: { [key: string]: number }
   ): void {
-    const baseProps = this.getBaseProps();
+    const baseProps = getOrgIdentityProps(this.orgIdentity);
     void this.writeToFile(eventName, { ...baseProps, ...properties, ...measurements });
   }
 
@@ -73,11 +74,6 @@ export class TelemetryFile implements TelemetryReporter {
     const content = `${JSON.stringify({ timestamp, command, data }, null, 2)},`;
     this.buffer += content;
     await this.flushBuffer();
-  }
-
-  private getBaseProps(): Record<string, string> {
-    const { orgId = '', orgShape = '', devHubId = '', orgEdition = '' } = this.orgIdentity ?? {};
-    return orgId ? { orgId, orgShape, devHubId, ...(orgEdition ? { orgEdition } : {}) } : {};
   }
 
   private async flushBuffer(): Promise<void> {

--- a/packages/salesforcedx-utils-vscode/src/telemetry/reporters/telemetryFile.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/reporters/telemetryFile.ts
@@ -10,7 +10,6 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { URI } from 'vscode-uri';
 import { LOCAL_TELEMETRY_FILE } from '../../constants';
-import { WorkspaceContextUtil } from '../../context/workspaceContextUtil';
 import { getRootWorkspacePath } from '../../workspaces/workspaceUtils';
 
 /**
@@ -77,13 +76,8 @@ export class TelemetryFile implements TelemetryReporter {
   }
 
   private getBaseProps(): Record<string, string> {
-    try {
-      const context = WorkspaceContextUtil.getInstance();
-      const { orgId = '', orgShape = '', devHubId = '', orgEdition = '' } = context;
-      return orgId ? { orgId, orgShape, devHubId, ...(orgEdition ? { orgEdition } : {}) } : {};
-    } catch {
-      return {};
-    }
+    const { orgId = '', orgShape = '', devHubId = '', orgEdition = '' } = this.orgIdentity ?? {};
+    return orgId ? { orgId, orgShape, devHubId, ...(orgEdition ? { orgEdition } : {}) } : {};
   }
 
   private async flushBuffer(): Promise<void> {

--- a/packages/salesforcedx-utils-vscode/src/telemetry/reporters/telemetryUtils.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/reporters/telemetryUtils.ts
@@ -8,6 +8,12 @@
 import * as os from 'node:os';
 import { env, UIKind, version } from 'vscode';
 import { CommonProperties, InternalProperties } from './loggingProperties';
+import type { OrgIdentity } from './telemetryReporterConfig';
+
+export const getOrgIdentityProps = (orgIdentity?: OrgIdentity): Record<string, string> => {
+  const { orgId = '', orgShape = '', devHubId = '', orgEdition = '' } = orgIdentity ?? {};
+  return orgId ? { orgId, orgShape, devHubId, ...(orgEdition ? { orgEdition } : {}) } : {};
+};
 
 export const getCommonProperties = (extensionId: string, extensionVersion: string): CommonProperties => {
   const commonProperties: CommonProperties = {

--- a/packages/salesforcedx-utils-vscode/src/telemetry/reporters/telemetryUtils.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/reporters/telemetryUtils.ts
@@ -11,8 +11,15 @@ import { env, UIKind, version } from 'vscode';
 import { CommonProperties, InternalProperties } from './loggingProperties';
 
 export const getOrgIdentityProps = (orgIdentity?: OrgIdentity): Record<string, string> => {
-  const { orgId = '', orgShape = '', devHubId = '', orgEdition = '' } = orgIdentity ?? {};
-  return orgId ? { orgId, orgShape, devHubId, ...(orgEdition ? { orgEdition } : {}) } : {};
+  const { orgId, orgShape, devHubId, orgEdition } = orgIdentity ?? {};
+  return orgId
+    ? {
+        orgId,
+        ...(orgShape ? { orgShape } : {}),
+        ...(devHubId ? { devHubId } : {}),
+        ...(orgEdition ? { orgEdition } : {})
+      }
+    : {};
 };
 
 export const getCommonProperties = (extensionId: string, extensionVersion: string): CommonProperties => {

--- a/packages/salesforcedx-utils-vscode/src/telemetry/reporters/telemetryUtils.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/reporters/telemetryUtils.ts
@@ -5,10 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import type { OrgIdentity } from './telemetryReporterConfig';
 import * as os from 'node:os';
 import { env, UIKind, version } from 'vscode';
 import { CommonProperties, InternalProperties } from './loggingProperties';
-import type { OrgIdentity } from './telemetryReporterConfig';
 
 export const getOrgIdentityProps = (orgIdentity?: OrgIdentity): Record<string, string> => {
   const { orgId = '', orgShape = '', devHubId = '', orgEdition = '' } = orgIdentity ?? {};

--- a/packages/salesforcedx-utils-vscode/test/jest/telemetry/reporters/__snapshots__/appInsights.test.ts.snap
+++ b/packages/salesforcedx-utils-vscode/test/jest/telemetry/reporters/__snapshots__/appInsights.test.ts.snap
@@ -5,9 +5,7 @@ exports[`AppInsights sendTelemetryEvent and sendExceptionEvent should send orgId
   "exception": [anExtensionId/Dummy Exception: a dummy exception occurred],
   "measurements": undefined,
   "properties": {
-    "devHubId": "",
     "orgId": "000dummyOrgId",
-    "orgShape": "",
     "webUserId": "test-webUser",
   },
 }
@@ -18,9 +16,7 @@ exports[`AppInsights sendTelemetryEvent and sendExceptionEvent should send telem
   "measurements": {},
   "name": "anExtensionId/Dummy Telemetry Event",
   "properties": {
-    "devHubId": "",
     "orgId": "000dummyOrgId",
-    "orgShape": "",
     "webUserId": "test-webUser",
   },
 }

--- a/packages/salesforcedx-utils-vscode/test/jest/telemetry/reporters/appInsights.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/telemetry/reporters/appInsights.test.ts
@@ -48,12 +48,40 @@ describe('AppInsights', () => {
     });
 
     it('should send orgId to appInsightsClient.trackException', () => {
+      appInsights = new AppInsights(fakeExtensionId, fakeExtensionVersion, '', fakeUserId, 'test-webUser', false);
+      appInsights.orgIdentity = { devHubId: '', orgId: dummyOrgId };
+      (appInsights as any).userOptIn = true;
+      (appInsights as any).appInsightsClient = {
+        trackException: trackExceptionMock,
+        trackEvent: trackEventMock
+      };
+
       // Act
       appInsights.sendExceptionEvent('Dummy Exception', 'a dummy exception occurred');
 
       // Assert
       expect(trackExceptionMock).toHaveBeenCalledTimes(1);
       expect(trackExceptionMock.mock.calls[0][0]).toMatchSnapshot();
+    });
+
+    it('should omit org properties when orgIdentity is unset', () => {
+      appInsights = new AppInsights(fakeExtensionId, fakeExtensionVersion, '', fakeUserId, 'test-webUser', false);
+      (appInsights as any).userOptIn = true;
+      (appInsights as any).appInsightsClient = {
+        trackException: trackExceptionMock,
+        trackEvent: trackEventMock
+      };
+
+      appInsights.sendTelemetryEvent('No Org Event', {}, {});
+      appInsights.sendExceptionEvent('No Org Exception', 'an exception with no org');
+
+      const eventProps = trackEventMock.mock.calls[0][0].properties;
+      const exceptionProps = trackExceptionMock.mock.calls[0][0].properties;
+      [eventProps, exceptionProps].forEach(props => {
+        expect(props.orgId).toBeUndefined();
+        expect(props.orgShape).toBeUndefined();
+        expect(props.devHubId).toBeUndefined();
+      });
     });
 
     it('should include orgEdition in event properties when available', () => {

--- a/packages/salesforcedx-utils-vscode/test/jest/telemetry/reporters/appInsights.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/telemetry/reporters/appInsights.test.ts
@@ -6,7 +6,6 @@
  */
 import * as os from 'node:os';
 import { workspace } from 'vscode';
-import { WorkspaceContextUtil } from '../../../../src';
 import { AppInsights } from '../../../../src/telemetry/reporters/appInsights';
 import { CommonProperties, InternalProperties } from '../../../../src/telemetry/reporters/loggingProperties';
 import { getCommonProperties, getInternalProperties } from '../../../../src/telemetry/reporters/telemetryUtils';
@@ -18,7 +17,6 @@ describe('AppInsights', () => {
   const fakeKey = 'testKey';
 
   describe('sendTelemetryEvent and sendExceptionEvent', () => {
-    let getInstanceMock: jest.SpyInstance;
     const dummyOrgId = '000dummyOrgId';
     const getMock = jest.fn().mockReturnValueOnce(true);
     const fakeConfig: any = { get: getMock };
@@ -28,17 +26,13 @@ describe('AppInsights', () => {
     const trackEventMock = jest.fn();
 
     beforeEach(() => {
-      // Arrange
-      getInstanceMock = jest
-        .spyOn(WorkspaceContextUtil, 'getInstance')
-        .mockReturnValue({ devHubId: '', orgId: dummyOrgId, orgShape: '' } as any);
-
       jest.spyOn(workspace, 'getConfiguration').mockReturnValue(fakeConfig);
       jest.spyOn(AppInsights.prototype as any, 'updateUserOptIn').mockReturnValue('');
     });
 
     it('should send telemetry data to appInsightsClient.trackEvent', () => {
       appInsights = new AppInsights(fakeExtensionId, fakeExtensionVersion, '', fakeUserId, 'test-webUser', false);
+      appInsights.orgIdentity = { devHubId: '', orgId: dummyOrgId };
       (appInsights as any).userOptIn = true;
       (appInsights as any).appInsightsClient = {
         trackException: trackExceptionMock,
@@ -49,7 +43,6 @@ describe('AppInsights', () => {
       appInsights.sendTelemetryEvent('Dummy Telemetry Event', {}, {});
 
       // Assert
-      expect(getInstanceMock).toHaveBeenCalledTimes(1);
       expect(trackEventMock).toHaveBeenCalledTimes(1);
       expect(trackEventMock.mock.calls[0][0]).toMatchSnapshot();
     });
@@ -59,20 +52,13 @@ describe('AppInsights', () => {
       appInsights.sendExceptionEvent('Dummy Exception', 'a dummy exception occurred');
 
       // Assert
-      expect(getInstanceMock).toHaveBeenCalledTimes(1);
       expect(trackExceptionMock).toHaveBeenCalledTimes(1);
       expect(trackExceptionMock.mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('should include orgEdition in event properties when available', () => {
-      getInstanceMock.mockReturnValue({
-        devHubId: '',
-        orgId: dummyOrgId,
-        orgShape: 'Production',
-        orgEdition: 'Enterprise Edition'
-      });
-
       appInsights = new AppInsights(fakeExtensionId, fakeExtensionVersion, '', fakeUserId, 'test-webUser', false);
+      appInsights.orgIdentity = { orgId: dummyOrgId, orgShape: 'Production', orgEdition: 'Enterprise Edition' };
       (appInsights as any).userOptIn = true;
       (appInsights as any).appInsightsClient = {
         trackException: trackExceptionMock,

--- a/packages/salesforcedx-utils-vscode/test/jest/telemetry/reporters/telemetryFile.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/telemetry/reporters/telemetryFile.test.ts
@@ -58,6 +58,21 @@ describe('TelemetryFile', () => {
     });
   });
 
+  it('should merge cached orgIdentity props into the telemetry event', () => {
+    const eventName = 'testEvent';
+    const properties = { key1: 'value1' };
+    telemetryFile.orgIdentity = { orgId: '00Ddummy', orgShape: 'Production', devHubId: '00Ddevhub' };
+
+    telemetryFile.sendTelemetryEvent(eventName, properties);
+
+    expect(writeToFileMock).toHaveBeenCalledWith(eventName, {
+      orgId: '00Ddummy',
+      orgShape: 'Production',
+      devHubId: '00Ddevhub',
+      ...properties
+    });
+  });
+
   it('should append the exception event to the telemetry file', () => {
     const exceptionName = 'testException';
     const exceptionMessage = 'Test exception message';

--- a/packages/salesforcedx-vscode-lightning/test/playwright/fixtures/telemetryFixtures.ts
+++ b/packages/salesforcedx-vscode-lightning/test/playwright/fixtures/telemetryFixtures.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { createDesktopTest, MINIMAL_ORG_ALIAS } from '@salesforce/playwright-vscode-ext';
+
+// Lightning depends on the CORE extension (not just services), so this fixture loads core and
+// launches with a real minimal org so org-identity telemetry props (orgId, isScratch, orgShape,
+// orgEdition, …) get populated in BOTH pipelines.
+//
+// The default desktop fixture sets telemetry.telemetryLevel:'off', which prevents ANY reporter
+// (including the local TelemetryFile) from being instantiated. We flip it back on and turn on
+// localTelemetryLogging so the class-based pipeline's events are diverted to
+// {workspace}/salesforcedx-vscode-core-telemetry.json (the AppInsights event *shape*, since the
+// real AppInsights client is never created in dev/test mode — see determineReporters.ts).
+//
+// enableFileTraces stays true (fixture default) so the services Effect/O11y pipeline keeps writing
+// spans to ~/.sf/vscode-spans/*.jsonl.
+export const telemetryDesktopTest = createDesktopTest({
+  fixturesDir: __dirname,
+  orgAlias: MINIMAL_ORG_ALIAS,
+  additionalExtensionDirs: ['salesforcedx-vscode-core'],
+  disableOtherExtensions: false,
+  userSettings: {
+    'telemetry.telemetryLevel': 'all',
+    'salesforcedx-vscode-core.telemetry.enabled': true,
+    'salesforcedx-vscode-core.advanced.localTelemetryLogging': 'true',
+    'salesforcedx-vscode-lightning.advanced.localTelemetryLogging': 'true'
+  }
+});

--- a/packages/salesforcedx-vscode-lightning/test/playwright/specs/telemetryOutput.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-lightning/test/playwright/specs/telemetryOutput.desktop.spec.ts
@@ -132,18 +132,23 @@ test('telemetry output: o11y spans + AppInsights-shape events from a core-depend
   });
 
   await test.step('dump o11y spans + org-identity attributes', async () => {
+    // The default-org ref that stamps org-identity is populated asynchronously (maybeUpdateDefaultOrgRef
+    // runs in a forkDaemon after the first connection), and only core's SDK ever connects to the org —
+    // lightning's command span never carries orgId. So wait for the orgId-bearing root span (a core span
+    // like workspaceOrgShape.getOrgShape) to flush, not merely for any span.
     const rows = await waitFor(
       () => readAllSpanRows(),
-      r => r.length > 0,
-      'no o11y spans flushed yet'
+      r => r.some(s => s.attributes?.orgId !== undefined),
+      'no orgId-enriched o11y span flushed yet'
     );
 
     const spanNames = [...new Set(rows.map(s => s.name))].toSorted();
     console.log('=== O11Y SPAN NAMES THIS SESSION ===');
     console.log(JSON.stringify(spanNames, null, 2));
 
-    // The org-identity attributes are stamped on every root span by spanTransformProcessor. Pull them
-    // off whichever span carries them (the command span if present, else any enriched root span).
+    // The org-identity attributes are stamped on every root span by spanTransformProcessor once the org
+    // ref is populated. Pull them off the span that actually carries orgId (pre-auth root spans — e.g.
+    // the activation span — only ever have webUserId/cliId/telemetryTag).
     const orgAttrKeys = [
       'orgId',
       'devHubOrgId',
@@ -155,7 +160,7 @@ test('telemetry output: o11y spans + AppInsights-shape events from a core-depend
       'cliId',
       'webUserId'
     ];
-    const enriched = rows.find(s => orgAttrKeys.some(k => s.attributes?.[k] !== undefined));
+    const enriched = rows.find(s => s.attributes?.orgId !== undefined);
     const orgAttrs: Record<string, unknown> = Object.fromEntries(
       orgAttrKeys.map(k => [k, enriched?.attributes?.[k]] as const).filter(([, v]) => v !== undefined)
     );

--- a/packages/salesforcedx-vscode-lightning/test/playwright/specs/telemetryOutput.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-lightning/test/playwright/specs/telemetryOutput.desktop.spec.ts
@@ -7,17 +7,35 @@
 
 /*
  * DIAGNOSTIC spec: run a core-backed command from a package that depends on the CORE extension
- * (lightning), then dump what each telemetry pipeline emits.
+ * (lightning), then dump what the telemetry pipeline emits and — when local capture servers are
+ * running — verify the actual on-the-wire payloads.
  *
- * Two pipelines, two on-disk sinks (both class-based reporters — AppInsights, O11yReporter — are
- * INERT in dev/test mode; determineReporters.ts returns only TelemetryFile, and only when
- * localTelemetryLogging is on. So the observable AppInsights *shape* comes from TelemetryFile):
+ * The real telemetry is the services observability pipeline (Effect spans). ONE enriched span feeds
+ * multiple exporters (spansNode.ts): the file exporter, the O11y exporter, and the AppInsights
+ * exporter. What this spec observes:
  *
- *   1. O11y / services (Effect spans)  → ~/.sf/vscode-spans/*.jsonl  (enableFileTraces, on by default)
- *   2. AppInsights shape (TelemetryFile) → {workspace}/salesforcedx-vscode-core-telemetry.json
+ *   1. Span file (always on)       → ~/.sf/vscode-spans/*.jsonl  (enableFileTraces; synchronous, always captured)
+ *   2. AppInsights Breeze envelopes → POST http://localhost:3003/v2.1/track  → ~/.sf/vscode-appinsights/appinsights-*.jsonl
  *
- * The telemetry fixture flips telemetry.telemetryLevel back to 'all' + localTelemetryLogging 'true'
- * and launches against a minimal org so org-identity props (orgId, isScratch, orgEdition, …) populate.
+ * (2) requires the capture server to be running, else the async POST is dropped:
+ *   npm run spans:server -w salesforcedx-vscode-services   # AppInsights on :3003
+ * In dev/test the AppInsights transport auto-diverts to :3003 (appInsights.ts isLocalDivertMode force-enables
+ * telemetry — provably cannot reach Azure). Verified envelopes carry the command span
+ * (sf.lightning.generate.aura.component) with full org identity incl. orgEdition.
+ *
+ * O11y is NOT locally capturable when an org is present: the o11y-reporter uploader prefers
+ * getConnectionMethod().requestPost(path, body) — it POSTs THROUGH the org connection to the org's
+ * /services/data/vXX/connect/proxy/ui-telemetry, only falling back to O11Y_ENDPOINT when there is no
+ * connection. But its payload is provably the SAME enriched span: o11ySpanExporter builds
+ * { name: span.name, properties: convertAttributes(span.attributes) + identity } from the exact span
+ * dumped below. So the span dump IS the O11y payload; only the transport (org proxy) differs.
+ *
+ * The legacy class reporters (AppInsights/O11yReporter/TelemetryFile in utils-vscode) are INERT in
+ * dev/test (determineReporters returns only TelemetryFile, gated on an undeclared localTelemetryLogging
+ * setting) — best-effort dumped at the end, normally empty.
+ *
+ * The fixture flips telemetry.telemetryLevel back to 'all' and launches against a minimal org so
+ * org-identity props (orgId, isScratch, orgEdition, …) populate on the enriched root spans.
  */
 
 import { expect } from '@playwright/test';
@@ -123,6 +141,14 @@ test('telemetry output: o11y spans + AppInsights-shape events from a core-depend
     await page.locator(EDITOR_WITH_URI).first().waitFor({ state: 'visible', timeout: 30_000 });
   });
 
+  await test.step('settle: let the AppInsights batch flush the command span while extension is live', async () => {
+    // The AppInsights network exporter batches on BatchSpanProcessor's default scheduledDelay (5s) and
+    // an immediate reload tears the extension host down before that fires, dropping the async POST to
+    // localhost:3003 (the SYNCHRONOUS file exporter still captures). Wait out ~2x the batch delay so
+    // the command span is exported to a live capture server. (Diagnostic only; CI runs with no listener.)
+    await page.waitForTimeout(10_000);
+  });
+
   await test.step('reload to flush buffered spans + class-telemetry (deactivationEvent)', async () => {
     // Reload ends the extension scopes: services flushes its BatchSpanProcessor buffer to
     // ~/.sf/vscode-spans/*.jsonl, and core's deactivate() calls sendExtensionDeactivationEvent() +
@@ -146,9 +172,8 @@ test('telemetry output: o11y spans + AppInsights-shape events from a core-depend
     console.log('=== O11Y SPAN NAMES THIS SESSION ===');
     console.log(JSON.stringify(spanNames, null, 2));
 
-    // The org-identity attributes are stamped on every root span by spanTransformProcessor once the org
-    // ref is populated. Pull them off the span that actually carries orgId (pre-auth root spans — e.g.
-    // the activation span — only ever have webUserId/cliId/telemetryTag).
+    // Org-identity is enriched ONLY onto ROOT spans by spanTransformProcessor (`!span.parentSpanContext`).
+    // Child spans carry no orgId. So target a span that actually has orgId — prefer the command span.
     const orgAttrKeys = [
       'orgId',
       'devHubOrgId',
@@ -160,27 +185,30 @@ test('telemetry output: o11y spans + AppInsights-shape events from a core-depend
       'cliId',
       'webUserId'
     ];
-    const enriched = rows.find(s => s.attributes?.orgId !== undefined);
+    const commandSpan = rows.find(s => s.name === 'sf.lightning.generate.aura.component');
+    // Prefer the command span IF it carries orgId (it does once the default-org ref is populated), else
+    // fall back to any orgId-bearing root span (e.g. a core span like workspaceOrgShape.getOrgShape).
+    const enriched =
+      commandSpan?.attributes?.orgId !== undefined ? commandSpan : rows.find(s => s.attributes?.orgId !== undefined);
     const orgAttrs: Record<string, unknown> = Object.fromEntries(
       orgAttrKeys.map(k => [k, enriched?.attributes?.[k]] as const).filter(([, v]) => v !== undefined)
     );
     console.log('=== O11Y ORG-IDENTITY ATTRIBUTES (from span:', enriched?.name, ') ===');
     console.log(JSON.stringify(orgAttrs, null, 2));
 
-    // The FULL attribute set on this enriched span is exactly what BOTH downstream exporters send:
-    // the O11y exporter AND the AppInsights customEvents exporter (ApplicationInsightsNodeExporter)
-    // consume the same enriched span (see spansNode.ts). The common.* keys exist specifically for
-    // the AppInsights side. Only the transport differs — in dev/test AppInsights diverts to
-    // localhost:3003, so nothing lands on disk; this dump is the payload it would send.
+    // The FULL attribute set on this enriched span is exactly what the downstream exporters send. The
+    // O11y exporter AND the AppInsights exporter (ApplicationInsightsNodeExporter) both consume the
+    // same enriched span (see spansNode.ts); the common.* keys exist for the AppInsights side. In
+    // dev/test AppInsights diverts over HTTP to localhost:3003 — run `npm run spans:server
+    // -w salesforcedx-vscode-services` to capture the actual Breeze envelopes to ~/.sf/vscode-appinsights/.
     console.log('=== FULL ENRICHED SPAN ATTRIBUTES (what O11y AND AppInsights receive) ===');
     console.log(JSON.stringify(enriched?.attributes, null, 2));
 
-    const commandSpan = rows.find(s => s.name === 'sf.lightning.generate.aura.component');
     console.log('=== O11Y COMMAND SPAN (sf.lightning.generate.aura.component) ===');
     console.log(commandSpan ? JSON.stringify(commandSpan, null, 2) : 'not flushed to file this run');
 
     expect(enriched?.attributes?.telemetryTag, 'e2e spans should carry the telemetry-tag').toBe('e2e-test');
-    expect(orgAttrs.orgId, 'org-identity should populate from the minimal org').toBeDefined();
+    expect(orgAttrs.orgId, 'org-identity should populate on the enriched root span').toBeDefined();
   });
 
   await test.step('dump legacy class-reporter events (TelemetryFile), if any', async () => {

--- a/packages/salesforcedx-vscode-lightning/test/playwright/specs/telemetryOutput.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-lightning/test/playwright/specs/telemetryOutput.desktop.spec.ts
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * DIAGNOSTIC spec: run a core-backed command from a package that depends on the CORE extension
+ * (lightning), then dump what each telemetry pipeline emits.
+ *
+ * Two pipelines, two on-disk sinks (both class-based reporters — AppInsights, O11yReporter — are
+ * INERT in dev/test mode; determineReporters.ts returns only TelemetryFile, and only when
+ * localTelemetryLogging is on. So the observable AppInsights *shape* comes from TelemetryFile):
+ *
+ *   1. O11y / services (Effect spans)  → ~/.sf/vscode-spans/*.jsonl  (enableFileTraces, on by default)
+ *   2. AppInsights shape (TelemetryFile) → {workspace}/salesforcedx-vscode-core-telemetry.json
+ *
+ * The telemetry fixture flips telemetry.telemetryLevel back to 'all' + localTelemetryLogging 'true'
+ * and launches against a minimal org so org-identity props (orgId, isScratch, orgEdition, …) populate.
+ */
+
+import { expect } from '@playwright/test';
+import {
+  closeWelcomeTabs,
+  ensureSecondarySideBarHidden,
+  executeCommandWithCommandPalette,
+  reloadWindow,
+  verifyCommandExists,
+  waitForQuickInputFirstOption,
+  waitForVSCodeWorkbench,
+  waitForWorkspaceReady,
+  EDITOR_WITH_URI,
+  QUICK_INPUT_WIDGET
+} from '@salesforce/playwright-vscode-ext';
+import * as Data from 'effect/Data';
+import * as Duration from 'effect/Duration';
+import * as Effect from 'effect/Effect';
+import * as Schedule from 'effect/Schedule';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import packageNls from '../../../package.nls.json';
+import { telemetryDesktopTest as test } from '../fixtures/telemetryFixtures';
+
+const SPANS_DIR = path.join(os.homedir(), '.sf', 'vscode-spans');
+const CORE_TELEMETRY_FILE = 'salesforcedx-vscode-core-telemetry.json';
+
+type SpanRow = { kind?: string; name?: string; attributes?: Record<string, unknown>; durationMs?: number };
+
+// The core ext and lightning ext each bundle their own services SDK, so each writes to its OWN
+// timestamped {SPANS_DIR}/*.jsonl. And BatchSpanProcessor buffers — a root command span isn't on
+// disk until an interval flush or (reliably) window reload/deactivate. So: reload first, then read
+// the UNION of all span files rather than guessing a single newest one.
+const readAllSpanRows = async (): Promise<SpanRow[]> => {
+  const entries = await fs.readdir(SPANS_DIR).catch(() => [] as string[]);
+  const files = entries.filter(name => name.endsWith('.jsonl'));
+  const perFile = await Promise.all(
+    files.map(async file => {
+      const contents = await fs.readFile(path.join(SPANS_DIR, file), 'utf-8').catch(() => '');
+      return contents
+        .split('\n')
+        .filter(Boolean)
+        .map(line => JSON.parse(line) as SpanRow)
+        .filter(row => row.kind === 'span');
+    })
+  );
+  return perFile.flat();
+};
+
+class NotReadyError extends Data.TaggedError('NotReadyError')<{ readonly message: string }> {}
+
+const waitFor = <A>(read: () => Promise<A>, predicate: (a: A) => boolean, message: string): Promise<A> =>
+  Effect.runPromise(
+    Effect.tryPromise({
+      try: async () => {
+        const value = await read();
+        if (!predicate(value)) throw new NotReadyError({ message });
+        return value;
+      },
+      catch: () => new NotReadyError({ message })
+    }).pipe(Effect.retry(Schedule.spaced(Duration.seconds(1))), Effect.timeout(Duration.seconds(90)))
+  );
+
+// TelemetryFile writes a trailing-comma-separated list of pretty JSON objects (not valid JSON as a
+// whole). Wrap in [] and strip the trailing comma to parse the events it captured.
+const readTelemetryFileEvents = async (
+  workspaceDir: string
+): Promise<Array<{ command: string; data: Record<string, unknown> }>> => {
+  const raw = await fs.readFile(path.join(workspaceDir, CORE_TELEMETRY_FILE), 'utf-8').catch(() => '');
+  if (!raw.trim()) return [];
+  return JSON.parse(`[${raw.trim().replace(/,\s*$/, '')}]`) as Array<{
+    command: string;
+    data: Record<string, unknown>;
+  }>;
+};
+
+test('telemetry output: o11y spans + AppInsights-shape events from a core-dependent command', async ({
+  page,
+  workspaceDir
+}) => {
+  test.setTimeout(360_000);
+
+  await test.step('workbench ready', async () => {
+    await waitForVSCodeWorkbench(page);
+    await closeWelcomeTabs(page);
+    await ensureSecondarySideBarHidden(page);
+    await waitForWorkspaceReady(page);
+  });
+
+  await test.step('run a core-backed command (Create Aura Component)', async () => {
+    const command = packageNls.lightning_generate_aura_component_text;
+    await verifyCommandExists(page, command, 60_000);
+    await executeCommandWithCommandPalette(page, command);
+
+    const quickInput = page.locator(QUICK_INPUT_WIDGET);
+    await quickInput.waitFor({ state: 'visible', timeout: 30_000 });
+    await page.keyboard.type('TelemetryProbeCmp');
+    await page.keyboard.press('Enter');
+    await waitForQuickInputFirstOption(page);
+    await page.keyboard.press('Enter');
+
+    await page.locator(EDITOR_WITH_URI).first().waitFor({ state: 'visible', timeout: 30_000 });
+  });
+
+  await test.step('reload to flush buffered spans + class-telemetry (deactivationEvent)', async () => {
+    // Reload ends the extension scopes: services flushes its BatchSpanProcessor buffer to
+    // ~/.sf/vscode-spans/*.jsonl, and core's deactivate() calls sendExtensionDeactivationEvent() +
+    // dispose(), flushing TelemetryFile's buffer to {workspace}/salesforcedx-vscode-core-telemetry.json.
+    await reloadWindow(page);
+    await waitForVSCodeWorkbench(page);
+  });
+
+  await test.step('dump o11y spans + org-identity attributes', async () => {
+    const rows = await waitFor(
+      () => readAllSpanRows(),
+      r => r.length > 0,
+      'no o11y spans flushed yet'
+    );
+
+    const spanNames = [...new Set(rows.map(s => s.name))].toSorted();
+    console.log('=== O11Y SPAN NAMES THIS SESSION ===');
+    console.log(JSON.stringify(spanNames, null, 2));
+
+    // The org-identity attributes are stamped on every root span by spanTransformProcessor. Pull them
+    // off whichever span carries them (the command span if present, else any enriched root span).
+    const orgAttrKeys = [
+      'orgId',
+      'devHubOrgId',
+      'isScratch',
+      'isSandbox',
+      'tracksSource',
+      'orgEdition',
+      'telemetryTag',
+      'cliId',
+      'webUserId'
+    ];
+    const enriched = rows.find(s => orgAttrKeys.some(k => s.attributes?.[k] !== undefined));
+    const orgAttrs: Record<string, unknown> = Object.fromEntries(
+      orgAttrKeys.map(k => [k, enriched?.attributes?.[k]] as const).filter(([, v]) => v !== undefined)
+    );
+    console.log('=== O11Y ORG-IDENTITY ATTRIBUTES (from span:', enriched?.name, ') ===');
+    console.log(JSON.stringify(orgAttrs, null, 2));
+
+    // The FULL attribute set on this enriched span is exactly what BOTH downstream exporters send:
+    // the O11y exporter AND the AppInsights customEvents exporter (ApplicationInsightsNodeExporter)
+    // consume the same enriched span (see spansNode.ts). The common.* keys exist specifically for
+    // the AppInsights side. Only the transport differs — in dev/test AppInsights diverts to
+    // localhost:3003, so nothing lands on disk; this dump is the payload it would send.
+    console.log('=== FULL ENRICHED SPAN ATTRIBUTES (what O11y AND AppInsights receive) ===');
+    console.log(JSON.stringify(enriched?.attributes, null, 2));
+
+    const commandSpan = rows.find(s => s.name === 'sf.lightning.generate.aura.component');
+    console.log('=== O11Y COMMAND SPAN (sf.lightning.generate.aura.component) ===');
+    console.log(commandSpan ? JSON.stringify(commandSpan, null, 2) : 'not flushed to file this run');
+
+    expect(enriched?.attributes?.telemetryTag, 'e2e spans should carry the telemetry-tag').toBe('e2e-test');
+    expect(orgAttrs.orgId, 'org-identity should populate from the minimal org').toBeDefined();
+  });
+
+  await test.step('dump legacy class-reporter events (TelemetryFile), if any', async () => {
+    // The legacy class-based reporters (AppInsights/O11yReporter/TelemetryFile in utils-vscode) are
+    // INERT in dev/test: determineReporters returns only TelemetryFile, gated on localTelemetryLogging,
+    // and even that setting is undeclared in package.json. So this file is usually absent. Best-effort
+    // dump — do NOT fail the run on its absence; the span pipeline above is the source of truth.
+    const events = await readTelemetryFileEvents(workspaceDir);
+    console.log('=== LEGACY TelemetryFile EVENTS (salesforcedx-vscode-core-telemetry.json) ===');
+    console.log(
+      events.length > 0 ? JSON.stringify(events, null, 2) : 'none — legacy class reporters inert in test mode'
+    );
+  });
+
+  // No validateNoCriticalErrors: this is a diagnostic dump, not a product-behavior assertion, and
+  // enabling telemetry can surface unrelated network noise from the reporters.
+});

--- a/packages/salesforcedx-vscode-services/scripts/spanFileServer.ts
+++ b/packages/salesforcedx-vscode-services/scripts/spanFileServer.ts
@@ -19,9 +19,13 @@ const SPANS_DIR = join(homedir(), '.sf', 'vscode-spans');
 // App Insights envelopes (what the Azure Monitor exporter would POST to /v2.1/track) land here,
 // kept separate from spans so the actual telemetry payload can be inspected on its own.
 const APP_INSIGHTS_DIR = join(homedir(), '.sf', 'vscode-appinsights');
+// O11y events (what O11ySpanExporter would upload through the org connection) land here in dev/test,
+// diverted to POST /o11y so the O11y payload can be inspected locally alongside App Insights.
+const O11Y_DIR = join(homedir(), '.sf', 'vscode-o11y');
 
 const filePaths = new Map<string, string>();
 const otlpFilePathHolder: { value: string | undefined } = { value: undefined };
+const o11yFilePathHolder: { value: string | undefined } = { value: undefined };
 const trackFilePathHolders: Record<'node' | 'web', { value: string | undefined }> = {
   node: { value: undefined },
   web: { value: undefined }
@@ -42,6 +46,14 @@ const getOtlpFilePath = (): string => {
     otlpFilePathHolder.value = join(SPANS_DIR, `otlp-${timestamp}.jsonl`);
   }
   return otlpFilePathHolder.value;
+};
+
+const getO11yFilePath = (): string => {
+  if (!o11yFilePathHolder.value) {
+    const timestamp = new Date().toISOString().replaceAll(/[:.]/g, '-');
+    o11yFilePathHolder.value = join(O11Y_DIR, `o11y-${timestamp}.jsonl`);
+  }
+  return o11yFilePathHolder.value;
 };
 
 // Node Breeze envelopes → appinsights-*.jsonl; web extension-telemetry events → appinsights-web-*.jsonl.
@@ -72,7 +84,7 @@ const handleRequest = (req: http.IncomingMessage, res: http.ServerResponse): voi
     return;
   }
 
-  const validUrls = ['/spans', '/otlp-spans', '/v2.1/track'];
+  const validUrls = ['/spans', '/otlp-spans', '/v2.1/track', '/o11y'];
   if (req.method !== 'POST' || !validUrls.includes(req.url ?? '')) {
     send(res, 404, JSON.stringify({ error: `POST ${validUrls.join(', ')} only` }));
     return;
@@ -93,6 +105,11 @@ const handleRequest = (req: http.IncomingMessage, res: http.ServerResponse): voi
 
       if (req.url === '/otlp-spans') {
         handleOtlpSpans(body, res);
+        return;
+      }
+
+      if (req.url === '/o11y') {
+        handleO11y(body, res);
         return;
       }
 
@@ -132,6 +149,26 @@ const handleOtlpSpans = (body: string, res: http.ServerResponse): void => {
 };
 
 /**
+ * Receives O11y events diverted in dev/test (POST /o11y from O11ySpanExporter's local divert). Each
+ * event is the payload O11ySpanExporter would upload through the org connection:
+ * { name, success, properties, measurements }. Writes one event per line to ~/.sf/vscode-o11y/.
+ */
+const handleO11y = (body: string, res: http.ServerResponse): void => {
+  const parsed = JSON.parse(body) as { extensionName?: string; events?: unknown[] };
+  const { events } = parsed;
+
+  if (!Array.isArray(events)) {
+    send(res, 400, JSON.stringify({ error: 'Expected { extensionName: string, events: object[] }' }));
+    return;
+  }
+
+  mkdirSync(O11Y_DIR, { recursive: true });
+  const content = events.map(e => JSON.stringify(e)).join('\n') + (events.length > 0 ? '\n' : '');
+  if (content.trim()) appendFileSync(getO11yFilePath(), content);
+  send(res, 200, JSON.stringify({ success: true }));
+};
+
+/**
  * Receives the App Insights telemetry both platforms would POST to Azure and writes it to
  * ~/.sf/vscode-appinsights/. Sorts the two shapes the local divert can produce:
  * Node sends gzipped newline-delimited Breeze envelopes (each has a `data.baseType`) → appinsights-*;
@@ -161,7 +198,8 @@ const server = http.createServer(handleRequest);
 const onListening = (): void => {
   console.log(`Span file server listening on http://localhost:${PORT}`);
   console.log(`Spans → ${SPANS_DIR}`);
-  console.log(`App Insights telemetry (POST /v2.1/track, Node + web) → ${APP_INSIGHTS_DIR}\n`);
+  console.log(`App Insights telemetry (POST /v2.1/track, Node + web) → ${APP_INSIGHTS_DIR}`);
+  console.log(`O11y events (POST /o11y, dev/test divert) → ${O11Y_DIR}\n`);
 };
 
 server.listen(PORT, onListening);

--- a/packages/salesforcedx-vscode-services/src/observability/o11ySpanExporter.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/o11ySpanExporter.ts
@@ -41,6 +41,24 @@ const getConnection = () =>
     )
   );
 
+/** Build the O11y event payload for a span — the exact shape passed to o11yService.logEvent. */
+const toEvent = (span: ReadableSpan, identity: { userId?: string; cliId?: string; webUserId?: string }) => ({
+  name: span.name,
+  success: span.status?.code !== SpanStatusCode.ERROR,
+  properties: {
+    ...convertAttributes(span.resource.attributes),
+    ...getExtensionNameAndVersionAttributes(span.resource.attributes),
+    ...convertAttributes(span.attributes),
+    traceID: span.spanContext().traceId,
+    spanID: span.spanContext().spanId,
+    parentID: span.parentSpanContext?.spanId,
+    ...(identity.userId ? { userId: identity.userId } : {}),
+    ...(identity.cliId ? { cliId: identity.cliId } : {}),
+    ...(identity.webUserId ? { webUserId: identity.webUserId } : {})
+  },
+  measurements: { duration: spanDuration(span) }
+});
+
 /**
  * OpenTelemetry span exporter that sends spans to O11y using @salesforce/o11y-reporter.
  * Only exports top-level spans to avoid noise.
@@ -53,7 +71,13 @@ export class O11ySpanExporter implements SpanExporter {
   constructor(
     private extensionName: string,
     private endpoint: string,
-    private productFeatureId?: string
+    private productFeatureId?: string,
+    // Dev/test only: when set, O11y events are POSTed to `${localIngestionEndpoint}/o11y` (the span
+    // file server) instead of uploaded to O11y. Mirrors the App Insights local divert so both
+    // pipelines are inspectable locally. The real o11y-reporter upload goes THROUGH the org connection
+    // (getConnectionMethod().requestPost), so it can't be diverted by endpoint alone — we short-circuit
+    // logEvent here instead. See sdkLayerConfig.resolveLocalIngestionEndpoint.
+    private localIngestionEndpoint?: string
   ) {
     this.o11yService = O11yService.getInstance(extensionName);
   }
@@ -74,6 +98,12 @@ export class O11ySpanExporter implements SpanExporter {
   }
 
   public export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
+    // Dev/test local divert: POST the same event payloads to the span file server's /o11y route instead
+    // of uploading through the org connection. Skips ensureInitialized() (which needs the connection).
+    if (this.localIngestionEndpoint) {
+      void this.exportLocal(spans, resultCallback);
+      return;
+    }
     void Effect.runPromise(
       Effect.tryPromise({
         try: async () => {
@@ -84,21 +114,7 @@ export class O11ySpanExporter implements SpanExporter {
             Effect.runSync
           );
           spans.filter(isSpanValidForProductionTelemetry).forEach(span => {
-            const success = span.status?.code !== SpanStatusCode.ERROR;
-            const props = {
-              ...convertAttributes(span.resource.attributes),
-              ...getExtensionNameAndVersionAttributes(span.resource.attributes),
-              ...convertAttributes(span.attributes),
-              traceID: span.spanContext().traceId,
-              spanID: span.spanContext().spanId,
-              parentID: span.parentSpanContext?.spanId,
-              ...(userId ? { userId } : {}),
-              ...(cliId ? { cliId } : {}),
-              ...(webUserId ? { webUserId } : {})
-            };
-            const measurements = {
-              duration: spanDuration(span)
-            };
+            const { success, properties: props, measurements } = toEvent(span, { userId, cliId, webUserId });
 
             if (success) {
               this.o11yService.logEvent({
@@ -147,7 +163,44 @@ export class O11ySpanExporter implements SpanExporter {
     );
   }
 
+  /** Dev/test: POST valid spans' O11y event payloads to the span file server's /o11y route. */
+  private async exportLocal(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): Promise<void> {
+    const valid = spans.filter(isSpanValidForProductionTelemetry);
+    if (valid.length === 0) {
+      resultCallback({ code: ExportResultCode.SUCCESS });
+      return;
+    }
+    // Identity may be unavailable pre-runtime; default to empty rather than throwing (diagnostic sink).
+    const identity = isServicesRuntimeReady()
+      ? getDefaultOrgRef().pipe(Effect.flatMap(SubscriptionRef.get), Effect.runSync)
+      : {};
+    const events = valid.map(span => toEvent(span, identity));
+    // eslint-disable-next-line functional/no-try-statements -- network boundary
+    try {
+      const res = await fetch(`${this.localIngestionEndpoint!.replace(/\/$/, '')}/o11y`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ extensionName: this.extensionName, events })
+      });
+      resultCallback(
+        res.ok
+          ? { code: ExportResultCode.SUCCESS }
+          : { code: ExportResultCode.FAILED, error: new Error(`local /o11y responded ${res.status}`) }
+      );
+    } catch (error) {
+      console.error('O11ySpanExporter local divert failed:', error);
+      resultCallback({
+        code: ExportResultCode.FAILED,
+        error: error instanceof Error ? error : new Error(String(error))
+      });
+    }
+  }
+
   public shutdown(): Promise<void> {
+    // In local-divert mode nothing is buffered in o11yService (we POST directly), so no flush needed.
+    if (this.localIngestionEndpoint) {
+      return Promise.resolve();
+    }
     // forceFlush drains buffer at read time; if runtime unpublished, drained spans lost.
     // On web, this fires before setServicesRuntime runs. Skip flush until runtime ready;
     // post-activation autobatch uploads buffered spans then.

--- a/packages/salesforcedx-vscode-services/src/observability/spansNode.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/spansNode.ts
@@ -110,7 +110,9 @@ export const NodeSdkLayerFor = ({
         ? [
             new SpanTransformProcessor(
               new GatedSpanExporter(
-                () => new O11ySpanExporter(extensionName, o11yEndpoint, productFeatureId),
+                // localIngestionEndpoint (dev/test) diverts O11y events to the local span file server's
+                // /o11y route instead of uploading through the org connection — mirrors the AI divert.
+                () => new O11ySpanExporter(extensionName, o11yEndpoint, productFeatureId, localIngestionEndpoint),
                 () => isProductionTelemetryExportEnabled(o11yEndpoint)
               ),
               undefined,

--- a/plans/W-23451942.md
+++ b/plans/W-23451942.md
@@ -15,10 +15,10 @@
 
 ### Phase 1 — appInsights + telemetryFile read cached orgIdentity
 - appInsights.ts:
-  - Convert module `getBaseProps` -> private method reading `this.orgIdentity` (`const { orgId = '', orgShape = '', devHubId = '', orgEdition = '' } = this.orgIdentity ?? {}`); same conditional return shape. Callers 135/173 -> `this.getBaseProps()`.
+  - Convert module `getBaseProps` -> private method reading `this.orgIdentity` (`const { orgId = '', orgShape = '', devHubId = '', orgEdition = '' } = this.orgIdentity ?? {}`). Callers 135/173 -> `this.getBaseProps()`.
   - Drop `WorkspaceContextUtil` import (10).
 - telemetryFile.ts:
-  - Rewrite `getBaseProps` body: source from `this.orgIdentity ?? {}` (drop try/catch — no throw now); same return shape.
+  - Rewrite `getBaseProps` body: source from `this.orgIdentity ?? {}` (drop try/catch — no throw now).
   - Drop `WorkspaceContextUtil` import (13).
 - Tests:
   - appInsights.test.ts: replace `WorkspaceContextUtil.getInstance` mock (30-38) w/ setting `appInsights.orgIdentity` per case; drop `getInstanceMock` decl (21) + call-count asserts (52, 62). Also drop now-dead `WorkspaceContextUtil` import (9) — its sole use is the removed spy; noUnusedLocals (tsconfig.common.json:22, inherited via test/tsconfig.json) would else fail compile. orgEdition case (67-87): mock uses `getInstanceMock.mockReturnValue` at 68 — replace w/ setting `appInsights.orgIdentity = { orgId, orgShape:'Production', orgEdition:'Enterprise Edition' }` after construct. Snapshots hold (same props).
@@ -29,7 +29,6 @@
 - concise (plan)
 - typescript (undefined not null, object spread, method over module fn)
 - unit-test-critic / verification (reporter tests, snapshots)
-- i18n-messages — n/a (no user strings)
 
 ## Verification
 - Build: wireit `compile` salesforcedx-utils-vscode.

--- a/plans/W-23451942.md
+++ b/plans/W-23451942.md
@@ -1,0 +1,42 @@
+# W-23451942 — appInsights/telemetryFile read cached org identity
+
+## Context
+
+- Seq "2" in identity-bridge migration. Prior WI W-23451940 (HEAD `503e0d30b0`) added `orgIdentity?: OrgIdentity` field to all 4 reporters + caches it via `updateReporters` (telemetry.ts 259-279). Field written, not yet read.
+- This WI: appInsights + telemetryFile **read** `this.orgIdentity` (bridge-pull) instead of `WorkspaceContextUtil.getInstance()` (util-pull). Scope = those 2 reporters only (subject names them); o11yReporter + logStream untouched.
+- `OrgIdentity` type (telemetryReporterConfig.ts 10-15): `orgId?`, `orgShape?: OrgShape`, `devHubId?`, `orgEdition?`.
+- Current org-prop derivation (both to replace):
+  - appInsights.ts: module-scope `getBaseProps` (255-259) reads WorkspaceContextUtil; called 135 (event) + 173 (exception).
+  - telemetryFile.ts: private method `getBaseProps` (79-87) reads WorkspaceContextUtil (try/catch -> `{}`); called 38.
+- Shape returned unchanged: `orgId ? { orgId, orgShape, devHubId, ...(orgEdition ? { orgEdition } : {}) } : {}`.
+- `WorkspaceContextUtil` import removed from both files (sole usage is getBaseProps).
+
+## Phases
+
+### Phase 1 — appInsights + telemetryFile read cached orgIdentity
+- appInsights.ts:
+  - Convert module `getBaseProps` -> private method reading `this.orgIdentity` (`const { orgId = '', orgShape = '', devHubId = '', orgEdition = '' } = this.orgIdentity ?? {}`); same conditional return shape. Callers 135/173 -> `this.getBaseProps()`.
+  - Drop `WorkspaceContextUtil` import (10).
+- telemetryFile.ts:
+  - Rewrite `getBaseProps` body: source from `this.orgIdentity ?? {}` (drop try/catch — no throw now); same return shape.
+  - Drop `WorkspaceContextUtil` import (13).
+- Tests:
+  - appInsights.test.ts: replace `WorkspaceContextUtil.getInstance` mock (30-38) w/ setting `appInsights.orgIdentity` per case; drop `getInstanceMock` decl (21) + call-count asserts (52, 62). Also drop now-dead `WorkspaceContextUtil` import (9) — its sole use is the removed spy; noUnusedLocals (tsconfig.common.json:22, inherited via test/tsconfig.json) would else fail compile. orgEdition case (67-87): mock uses `getInstanceMock.mockReturnValue` at 68 — replace w/ setting `appInsights.orgIdentity = { orgId, orgShape:'Production', orgEdition:'Enterprise Edition' }` after construct. Snapshots hold (same props).
+  - telemetryFile.test.ts: existing cases pass as-is (`orgIdentity` undefined -> `{}`); add case setting `orgIdentity` -> asserts org props merged into writeToFile.
+- Commit: `refactor(utils-vscode): appInsights/telemetryFile read cached org identity - W-23451942`
+
+## Skills to apply
+- concise (plan)
+- typescript (undefined not null, object spread, method over module fn)
+- unit-test-critic / verification (reporter tests, snapshots)
+- i18n-messages — n/a (no user strings)
+
+## Verification
+- Build: wireit `compile` salesforcedx-utils-vscode.
+- Jest green:
+  - appInsights.test.ts — snapshots unchanged; orgIdentity-driven props; getInstance mock/asserts + `WorkspaceContextUtil` import removed (noUnusedLocals clean).
+  - telemetryFile.test.ts — undefined-orgIdentity default `{}`; new populated-orgIdentity case.
+  - telemetry.test.ts updateReporters — still caches (write side, unchanged).
+- Grep: `WorkspaceContextUtil` absent from appInsights.ts + telemetryFile.ts; still present in o11yReporter.ts + logStream.ts (untouched).
+- Type-check: getBaseProps returns `Record<string,string>`; orgShape (OrgShape) coerces to string prop.
+- e2e-covered: none — reporter send paths not exercised by branch e2e; org-field emission validated by unit tests only.


### PR DESCRIPTION
### What does this PR do?

- `AppInsights` and `TelemetryFile` reporters now read org identity from cached `this.orgIdentity` (set async by `updateReporters`) instead of a live `WorkspaceContextUtil.getInstance()` call at send-time.
- Extracts shared `getOrgIdentityProps` helper into `telemetryUtils.ts`, used by both reporters (dedupes the previously-duplicated orgId/orgShape/devHubId/orgEdition derivation logic).
- `o11yReporter` and `logStream` are intentionally untouched in this WI; they still read `WorkspaceContextUtil` live.

### What issues does this PR fix or reference?
@W-23451942@

### Functionality Before

### Functionality After

## Plan
[plans/W-23451942.md](plans/W-23451942.md)

## Reviewer notes
- Informational (no code change; intentional per migration plan seq 2): events sent before the first `updateReporters` completes, or during the async gap on any org-change, emit with no org fields where the old live-read code would have populated them. Data-completeness window only, no crash.
- Informational (no code change; matches plan scope): during an org-switch race, `appInsights`/`telemetryFile` (cached) can carry divergent org identity from `o11yReporter`/`logStream` (still live) within the same logical event batch. Resolves when a follow-up WI migrates the remaining two reporters.

## Test plan
- [ ] Build: wireit `compile` for `salesforcedx-utils-vscode`
- [ ] Jest green: `appInsights.test.ts` — snapshots unchanged; org props driven by `orgIdentity`; `WorkspaceContextUtil` mock/asserts removed
- [ ] Jest green: `telemetryFile.test.ts` — undefined-`orgIdentity` defaults to `{}`; new populated-`orgIdentity` case passes
- [ ] Jest green: `telemetry.test.ts` `updateReporters` — cache-write side still passes (unchanged)
- [ ] Grep: `WorkspaceContextUtil` absent from `appInsights.ts` + `telemetryFile.ts`; still present in `o11yReporter.ts` + `logStream.ts`