### PR TITLE
chore(apex-testing): enable effect/no-import-from-barrel-package - W-23354479

### DIFF
--- a/.claude/plans/W-23354479.md
+++ b/.claude/plans/W-23354479.md
@@ -1,0 +1,32 @@
+# W-23354479 — Enable effect/no-import-from-barrel-package for apex-testing
+
+## Context
+
+- Guard-rail. 0 bare `from 'effect'` imports in apex-testing src today → zero code churn.
+- Prevents future barrel imports (`import { Effect } from 'effect'`).
+- Config: `eslint.config.mjs`.
+  - Existing apex-testing src override block: lines ~818-832 (`packages/salesforcedx-vscode-apex-testing/src/**/*.ts`) — holds sibling WI rules (no-explicit-any, consistent-type-definitions, prefer-property-signatures, prefer-arrow).
+  - Effect-services block ~700 already uses `'effect/no-import-from-barrel-package': ['error', { packageNames: ['effect'] }]` — copy shape.
+  - Test-files block line 866 sets rule `['off']` for all `test/**` → apex-testing tests unaffected.
+- Blocked by 5/6/7 (W-23165785/786, W-23173047) — those rules already present in block, so unblocked.
+
+## Phases
+
+### Phase 1 — add rule to apex-testing src override
+
+- Edit `eslint.config.mjs` apex-testing src block (~818): add
+  `'effect/no-import-from-barrel-package': ['error', { packageNames: ['effect'] }],`
+- No src changes (0 offending imports).
+- Commit: `chore(apex-testing): enable effect/no-import-from-barrel-package - W-23354479`
+
+## Skills to apply
+
+- packageJson — n/a (no pkg change) but consult if lint wiring touched
+- typescript — coding standards for the edited `.ts` config file
+- verification — lint-only change; no runtime surface
+
+## Verification
+
+- `npm run lint -w packages/salesforcedx-vscode-apex-testing` → green (proves 0 violations + config valid).
+- Optional proof rule active: temp add `import { Effect } from 'effect'` to a src file, re-lint → error, revert.
+- No e2e coverage (lint-only guard-rail).

--- a/.claude/plans/W-23354479.md
+++ b/.claude/plans/W-23354479.md
@@ -2,13 +2,13 @@
 
 ## Context
 
-- Guard-rail. 0 bare `from 'effect'` imports in apex-testing src today → zero code churn.
+- Guard-rail. 0 bare `from 'effect'` imports in apex-testing src today → 0 code churn.
 - Prevents future barrel imports (`import { Effect } from 'effect'`).
 - Config: `eslint.config.mjs`.
   - Existing apex-testing src override block: lines ~818-832 (`packages/salesforcedx-vscode-apex-testing/src/**/*.ts`) — holds sibling WI rules (no-explicit-any, consistent-type-definitions, prefer-property-signatures, prefer-arrow).
   - Effect-services block ~700 already uses `'effect/no-import-from-barrel-package': ['error', { packageNames: ['effect'] }]` — copy shape.
   - Test-files block line 866 sets rule `['off']` for all `test/**` → apex-testing tests unaffected.
-- Blocked by 5/6/7 (W-23165785/786, W-23173047) — those rules already present in block, so unblocked.
+- Blocked by 5/6/7 (W-23165785/786, W-23173047) — rules already present in block -> unblocked.
 
 ## Phases
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -820,6 +820,7 @@ export default [
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
       'functional/prefer-property-signatures': 'error',
+      'effect/no-import-from-barrel-package': ['error', { packageNames: ['effect'] }],
       'prefer-arrow/prefer-arrow-functions': [
         'error',
         {


### PR DESCRIPTION
## Summary
- Adds `effect/no-import-from-barrel-package` to the apex-testing `src` ESLint override, matching the existing effect-services block.
- Guard-rail only: 0 existing barrel imports of `effect` in apex-testing src, so no source changes.

## Plan
See [.claude/plans/W-23354479.md](.claude/plans/W-23354479.md).

### What issues does this PR fix or reference?
@W-23354479@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eB6PIYA0/view