### PR TITLE
refactor: adopt Predicate.isRecord for object guards in effect packages - W-23358837

### DIFF
--- a/.claude/plans/W-23358837.md
+++ b/.claude/plans/W-23358837.md
@@ -1,0 +1,64 @@
+# W-23358837 — Adopt Predicate.isRecord for object guards (effect pkgs)
+
+## Context
+
+- Collapse `typeof x === 'object' && x !== null` (± `!Array.isArray(x)`) → `Predicate.isRecord`.
+- `effect` semantics: `isRecord = typeof x === 'object' && x !== null && !Array.isArray(x)` (Predicate.js:632). `isReadonlyRecord` = alias.
+- Scope: pkgs already importing `effect`. All target files confirmed importing/depending on `effect`.
+- Sites (WI line refs approximate — actual below):
+  - `salesforcedx-vscode-services/src/vscode/errorHandlerService.ts`: `hasActions` (16-17), `hasCause` (20), `getBaseMessage` inline (44), `isMetadataCompletedWithErrorsSummaryError` negated (34).
+  - `salesforcedx-vscode-services/src/vscode/hashableUri.ts`: `hasObjectProp` outer (29) + inner `Object(u)[key]` check.
+  - `salesforcedx-vscode-services/src/core/executeAnonymousService.ts`: `hasSoapEnvelope` (~96). NOTE `toStringOrNull` (89) is `typeof v==='object' ? null` — NOT a record guard, skip.
+  - `salesforcedx-vscode-soql/src/editor/queryRunner.ts`: `hasMessage` (17-18).
+  - `salesforcedx-vscode-soql/src/commands/dataQuery.ts`: local `isRecord` (163-164) `Boolean(record) && typeof===object && !Array.isArray`, used 10× (116,168,179,273,281,347,392,421,488,536).
+  - `salesforcedx-vscode-metadata/src/shared/diff/diffTypes.ts`: `isHashableUri` negated (15) + inner (17). (metadata `refreshSObjects.ts` has NO object guards.)
+  - `salesforcedx-vscode-apex-testing/src/utils/apexTestErrorMapper.ts`: `error && typeof===object` (53), `first` (62), `body` w/ `!Array.isArray` (69).
+  - `salesforcedx-vscode-core/src/commands/refreshSObjects.ts`: `extractErrorMessage` (23) — `typeof error === 'object' && error !== null`.
+- Behavior note: sites w/o existing `!Array.isArray` gain array-exclusion. All are property-presence guards (`'actions' in`, `'message' in`, `.scheme`, etc.) — array inputs never carry those; narrowing is safe. `apexTestErrorMapper` body-check + `dataQuery` local already exclude arrays → exact match.
+- `dataQuery.ts` local `isRecord` truthiness diff: `Boolean(record)` vs effect's `x !== null`. For any `typeof === 'object'` value, `Boolean` is true except `null`; `null` fails both the local (`Boolean(null)`) and effect (`null !== null`) forms. Non-object primitives are excluded by `typeof` in both. ⇒ **no-op** — the local guard's domain (records vs everything else) is identical to effect's. Safe to delegate.
+
+## Phases
+
+### Phase 1 — Adopt isRecord across 8 files (1 commit)
+
+- Replace each guard's `typeof x === 'object' && x !== null` clause w/ `isRecord(x)`; drop redundant `!Array.isArray` where present.
+- Negated forms (`isMetadataCompletedWithErrorsSummaryError`, `isHashableUri`): `!isRecord(x)`.
+- Add `isRecord` to existing `from 'effect/Predicate'` import (merge, keep `isError`/`isString`).
+- Files:
+  - errorHandlerService.ts, hashableUri.ts, executeAnonymousService.ts (services)
+  - queryRunner.ts, dataQuery.ts (soql)
+  - diffTypes.ts (metadata)
+  - apexTestErrorMapper.ts (apex-testing)
+  - refreshSObjects.ts (core)
+- Keep existing comments.
+- `hashableUri.ts` inner `typeof Object(u)[key] === 'object' && ...!== null`: replace w/ `isRecord(Object(u)[key])`.
+- executeAnonymousService imports `effect/Predicate`? add import (currently 2 effect imports, no Predicate) — add `import { isRecord } from 'effect/Predicate'`.
+- `dataQuery.ts`: delete local `const isRecord = ...` (163-164), add `isRecord` to `import { isRecord } from 'effect/Predicate'` (currently imports `Effect` from `effect/Effect`, no Predicate import — add one). All 10 call sites (`.filter(isRecord)`, `isSubQueryResult`, `isNestedRelationshipObject`, `formatNestedDisplayValue`, etc.) unchanged — same signature `(x: unknown) => x is Record<string, unknown>`.
+- `refreshSObjects.ts`: `extractErrorMessage` line 23 → `if (isRecord(error))`. `isError`/`isString` already imported from `effect/Predicate` — merge `isRecord` in.
+
+commit: `refactor: adopt Predicate.isRecord for object guards in effect packages - W-23358837`
+
+### Phase 2 — Close coverage gap on refreshSObjects.extractErrorMessage (same commit)
+
+- **Gap**: `refreshSObjects.ts` has NO jest test anywhere under `packages/salesforcedx-vscode-core/test` (grep for refreshSObjects/extractErrorMessage/initSObjectDefinitions → nothing). The guard being migrated is in `extractErrorMessage`, which is currently un-covered — cannot claim regression coverage.
+- `extractErrorMessage` is not exported (only `initSObjectDefinitions` is). To test the migrated `isRecord` branch directly:
+  - Export `extractErrorMessage` from `refreshSObjects.ts` (widen to named export; keep `initSObjectDefinitions`).
+  - Add `packages/salesforcedx-vscode-core/test/jest/commands/refreshSObjects.test.ts` covering the guard branches: `Error` instance → `.message`; `{ error: Error }` → nested message; `{ message: string }` → message; array input (e.g. `[]`) → falls through to `String(error)` (proves `!Array.isArray` narrowing — array must NOT match the record branch); primitive (string/number/undefined/null) → `String(error)`.
+  - dataQuery.ts local-`isRecord` migration is already covered by `dataQuery.test.ts` (convertToCSV/generateTableOutput bad-data cases exercise `.filter(isRecord)` + `isSubQueryResult` on arrays/nulls) — no new soql test needed; verify those cases still pass.
+
+## Skills
+
+- effect-best-practices — confirm isRecord idiom
+- typescript — type-guard narrowing preserved
+- concise — plan/doc style
+- verification — pre-commit checks
+
+## Verification
+
+- `typecheck` all 5 touched pkgs (services, soql, metadata, apex-testing, core) — narrowing must still satisfy `is X` predicates; dataQuery `Record<string, unknown>` narrows unchanged.
+- unit tests (jest) for touched pkgs:
+  - NEW `refreshSObjects.test.ts` (see Phase 2) — proves extractErrorMessage guard incl. array-exclusion.
+  - existing `dataQuery.test.ts` — regression on convertToCSV/generateTableOutput bad-data (array/null records) via delegated `isRecord`.
+  - services/metadata/apex-testing existing guards' tests.
+- lint (no unused `isError`/`isString`; import merge clean; no lingering local `isRecord`).
+- No e2e coverage relevant (pure internal guards + display formatting already unit-covered). No e2e-covered items.

--- a/.claude/plans/W-23358837.md
+++ b/.claude/plans/W-23358837.md
@@ -14,8 +14,8 @@
   - `salesforcedx-vscode-metadata/src/shared/diff/diffTypes.ts`: `isHashableUri` negated (15) + inner (17). (metadata `refreshSObjects.ts` has NO object guards.)
   - `salesforcedx-vscode-apex-testing/src/utils/apexTestErrorMapper.ts`: `error && typeof===object` (53), `first` (62), `body` w/ `!Array.isArray` (69).
   - `salesforcedx-vscode-core/src/commands/refreshSObjects.ts`: `extractErrorMessage` (23) — `typeof error === 'object' && error !== null`.
-- Behavior note: sites w/o existing `!Array.isArray` gain array-exclusion. All are property-presence guards (`'actions' in`, `'message' in`, `.scheme`, etc.) — array inputs never carry those; narrowing is safe. `apexTestErrorMapper` body-check + `dataQuery` local already exclude arrays → exact match.
-- `dataQuery.ts` local `isRecord` truthiness diff: `Boolean(record)` vs effect's `x !== null`. For any `typeof === 'object'` value, `Boolean` is true except `null`; `null` fails both the local (`Boolean(null)`) and effect (`null !== null`) forms. Non-object primitives are excluded by `typeof` in both. ⇒ **no-op** — the local guard's domain (records vs everything else) is identical to effect's. Safe to delegate.
+- Behavior note: sites w/o `!Array.isArray` gain array-exclusion — all property-presence guards (`'actions' in`, `'message' in`, `.scheme`, etc.), array inputs never carry those keys → safe. `apexTestErrorMapper` body-check + `dataQuery` local already exclude arrays → exact match.
+- `dataQuery.ts` local `isRecord` truthiness diff: `Boolean(record)` vs effect's `x !== null` — only differ on `null`, which both forms reject; non-object primitives excluded by `typeof` in both ⇒ **no-op**, safe to delegate.
 
 ## Phases
 
@@ -40,7 +40,7 @@ commit: `refactor: adopt Predicate.isRecord for object guards in effect packages
 
 ### Phase 2 — Close coverage gap on refreshSObjects.extractErrorMessage (same commit)
 
-- **Gap**: `refreshSObjects.ts` has NO jest test anywhere under `packages/salesforcedx-vscode-core/test` (grep for refreshSObjects/extractErrorMessage/initSObjectDefinitions → nothing). The guard being migrated is in `extractErrorMessage`, which is currently un-covered — cannot claim regression coverage.
+- **Gap**: `refreshSObjects.ts` has NO jest test under `packages/salesforcedx-vscode-core/test` (grep refreshSObjects/extractErrorMessage/initSObjectDefinitions → nothing) → migrated guard in `extractErrorMessage` un-covered, no regression coverage.
 - `extractErrorMessage` is not exported (only `initSObjectDefinitions` is). To test the migrated `isRecord` branch directly:
   - Export `extractErrorMessage` from `refreshSObjects.ts` (widen to named export; keep `initSObjectDefinitions`).
   - Add `packages/salesforcedx-vscode-core/test/jest/commands/refreshSObjects.test.ts` covering the guard branches: `Error` instance → `.message`; `{ error: Error }` → nested message; `{ message: string }` → message; array input (e.g. `[]`) → falls through to `String(error)` (proves `!Array.isArray` narrowing — array must NOT match the record branch); primitive (string/number/undefined/null) → `String(error)`.

--- a/packages/salesforcedx-vscode-apex-testing/src/utils/apexTestErrorMapper.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/utils/apexTestErrorMapper.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { isError, isString } from 'effect/Predicate';
+import { isError, isRecord, isString } from 'effect/Predicate';
 import { nls } from '../messages';
 
 /** Common Salesforce API / connection error patterns that should be mapped to user-friendly messages */
@@ -50,7 +50,7 @@ const getRawMessage = (error: unknown): string => {
   if (isString(error)) {
     return error;
   }
-  if (error && typeof error === 'object') {
+  if (isRecord(error)) {
     const msg = getMessageFromObject(error);
     if (msg !== undefined) {
       return msg;
@@ -59,14 +59,14 @@ const getRawMessage = (error: unknown): string => {
     const body: unknown = Object.getOwnPropertyDescriptor(error, 'body')?.value;
     if (Array.isArray(body) && body.length > 0) {
       const first: unknown = body[0];
-      if (first !== null && typeof first === 'object') {
+      if (isRecord(first)) {
         const firstMsg = getMessageFromObject(first);
         if (firstMsg !== undefined) {
           return firstMsg;
         }
       }
     }
-    if (body !== null && typeof body === 'object' && !Array.isArray(body)) {
+    if (isRecord(body)) {
       const bodyMsg = getMessageFromObject(body);
       if (bodyMsg !== undefined) {
         return bodyMsg;

--- a/packages/salesforcedx-vscode-core/src/commands/refreshSObjects.ts
+++ b/packages/salesforcedx-vscode-core/src/commands/refreshSObjects.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { fileOrFolderExists } from '@salesforce/salesforcedx-utils-vscode';
-import { isError, isString } from 'effect/Predicate';
+import { isError, isRecord, isString } from 'effect/Predicate';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { telemetryService } from '../telemetry';
@@ -18,9 +18,9 @@ const getSObjectsDirectory = (projectPath: string) => path.join(projectPath, '.s
 const getStandardSObjectsDirectory = (projectPath: string) =>
   path.join(projectPath, '.sfdx', 'tools', SOBJECTS_DIR, STANDARDOBJECTS_DIR);
 
-const extractErrorMessage = (error: unknown): string => {
+export const extractErrorMessage = (error: unknown): string => {
   if (isError(error)) return error.message;
-  if (typeof error === 'object' && error !== null) {
+  if (isRecord(error)) {
     if ('error' in error && isError(error.error)) return error.error.message;
     if ('message' in error && isString(error.message)) return error.message;
   }

--- a/packages/salesforcedx-vscode-core/test/jest/commands/refreshSObjects.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/commands/refreshSObjects.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { extractErrorMessage } from '../../../src/commands/refreshSObjects';
+
+describe('extractErrorMessage', () => {
+  it('returns the message of an Error instance', () => {
+    expect(extractErrorMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it('returns the nested error message from { error: Error }', () => {
+    expect(extractErrorMessage({ error: new Error('nested') })).toBe('nested');
+  });
+
+  it('returns the message from { message: string }', () => {
+    expect(extractErrorMessage({ message: 'plain' })).toBe('plain');
+  });
+
+  it('does not treat an array as a record (array-exclusion) and falls through to String()', () => {
+    expect(extractErrorMessage([])).toBe('');
+  });
+
+  it.each([
+    ['a string primitive', 'oops', 'oops'],
+    ['a number primitive', 42, '42'],
+    ['undefined', undefined, 'undefined'],
+    ['null', null, 'null']
+  ])('stringifies %s', (_label, input, expected) => {
+    expect(extractErrorMessage(input)).toBe(expected);
+  });
+});

--- a/packages/salesforcedx-vscode-metadata/src/shared/diff/diffTypes.ts
+++ b/packages/salesforcedx-vscode-metadata/src/shared/diff/diffTypes.ts
@@ -6,15 +6,15 @@
  */
 
 import * as Data from 'effect/Data';
-import { isString } from 'effect/Predicate';
+import { isRecord, isString } from 'effect/Predicate';
 import * as Schema from 'effect/Schema';
 import type { HashableUri } from 'salesforcedx-vscode-services';
 
 /** Cross-bundle safe: HashableUri from services extension fails instanceof URI in metadata bundle. Use structural check. */
 const isHashableUri = (u: unknown): u is HashableUri => {
-  if (u === null || typeof u !== 'object' || !('uri' in u)) return false;
+  if (!isRecord(u) || !('uri' in u)) return false;
   const inner = Object(u).uri;
-  return inner !== null && typeof inner === 'object' && isString(inner.scheme);
+  return isRecord(inner) && isString(inner.scheme);
 };
 
 const HashableUriSchema = Schema.declare<HashableUri>(isHashableUri);

--- a/packages/salesforcedx-vscode-services/src/core/executeAnonymousService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/executeAnonymousService.ts
@@ -6,7 +6,7 @@
  */
 
 import * as Effect from 'effect/Effect';
-import { isString } from 'effect/Predicate';
+import { isRecord, isString } from 'effect/Predicate';
 import type { ExecuteAnonymousResult } from 'jsforce/lib/api/tooling';
 import * as vscode from 'vscode';
 import type { URI } from 'vscode-uri';
@@ -92,8 +92,7 @@ type ParseSoapResult =
   | { success: true; result: ExecuteAnonymousResult; logBody: string }
   | { success: false; error: string };
 
-const hasSoapEnvelope = (obj: unknown): obj is SoapResponseShape =>
-  obj !== null && typeof obj === 'object' && 'soapenv:Envelope' in obj;
+const hasSoapEnvelope = (obj: unknown): obj is SoapResponseShape => isRecord(obj) && 'soapenv:Envelope' in obj;
 
 export const parseSoapResponse = (raw: unknown): ParseSoapResult => {
   const envelope = hasSoapEnvelope(raw) ? raw['soapenv:Envelope'] : undefined;

--- a/packages/salesforcedx-vscode-services/src/vscode/errorHandlerService.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/errorHandlerService.ts
@@ -7,17 +7,17 @@
 
 import * as Cause from 'effect/Cause';
 import * as Effect from 'effect/Effect';
-import { isError, isString } from 'effect/Predicate';
+import { isError, isRecord, isString } from 'effect/Predicate';
 import * as vscode from 'vscode';
 import { nls } from '../messages';
 import { ChannelService } from './channelService';
 
 /** Type guard for errors with actions array (e.g., SfError) */
 const hasActions = (e: unknown): e is { actions: string[] } =>
-  typeof e === 'object' && e !== null && 'actions' in e && Array.isArray(e.actions);
+  isRecord(e) && 'actions' in e && Array.isArray(e.actions);
 
 /** Type guard for errors with a cause property */
-const hasCause = (e: unknown): e is { cause: unknown } => typeof e === 'object' && e !== null && 'cause' in e;
+const hasCause = (e: unknown): e is { cause: unknown } => isRecord(e) && 'cause' in e;
 
 /** Recursively extract actions from error chain */
 const getActions = (error: unknown): string[] => {
@@ -31,7 +31,7 @@ const getActions = (error: unknown): string[] => {
 /** Get the base error message, preferring inner cause message */
 /** Deploy/retrieve partial failures already log details via formatDeployOutput/formatRetrieveOutput; avoid duplicating the summary in the channel. */
 const isMetadataCompletedWithErrorsSummaryError = (error: unknown): boolean => {
-  if (typeof error !== 'object' || error === null || !('_tag' in error)) return false;
+  if (!isRecord(error) || !('_tag' in error)) return false;
   const tag = Reflect.get(error, '_tag');
   return tag === 'DeployCompletedWithErrorsError' || tag === 'RetrieveCompletedWithErrorsError';
 };
@@ -41,7 +41,7 @@ const getBaseMessage = (error: unknown): string => {
     const innerCause = hasCause(error) ? error.cause : undefined;
     return isError(innerCause) ? getBaseMessage(innerCause) : error.message;
   }
-  if (typeof error === 'object' && error !== null && 'message' in error) {
+  if (isRecord(error) && 'message' in error) {
     const msg = Reflect.get(error, 'message');
     if (isString(msg)) return msg;
   }

--- a/packages/salesforcedx-vscode-services/src/vscode/hashableUri.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/hashableUri.ts
@@ -7,7 +7,7 @@
 import * as Equal from 'effect/Equal';
 import { dual } from 'effect/Function';
 import * as Hash from 'effect/Hash';
-import { isString } from 'effect/Predicate';
+import { isRecord, isString } from 'effect/Predicate';
 import { URI } from 'vscode-uri';
 
 /**
@@ -26,7 +26,7 @@ export type HashableUri = {
 type UriChange = Parameters<URI['with']>[0];
 
 const hasObjectProp = <K extends string>(u: unknown, key: K): u is Record<K, object> =>
-  u !== null && typeof u === 'object' && key in u && typeof Object(u)[key] === 'object' && Object(u)[key] !== null;
+  isRecord(u) && key in u && isRecord(Object(u)[key]);
 
 /**
  * Structural cross-bundle check: any value with a `uri` field that looks like a URI AND carries

--- a/packages/salesforcedx-vscode-soql/src/commands/dataQuery.ts
+++ b/packages/salesforcedx-vscode-soql/src/commands/dataQuery.ts
@@ -8,6 +8,7 @@ import type { QueryResult } from '../types';
 import { Column, createTable, ExtensionProviderService, Row } from '@salesforce/effect-ext-utils';
 import type { JsonMap } from '@salesforce/ts-types';
 import * as Effect from 'effect/Effect';
+import { isRecord } from 'effect/Predicate';
 import * as vscode from 'vscode';
 import { Utils } from 'vscode-uri';
 import { stripAllRows } from '../editor/allRows';
@@ -159,9 +160,6 @@ export const generateTableOutput = (records: QueryResult<JsonMap>['records'], ti
 
   return createTable(tableRows, columns, title);
 };
-
-const isRecord = (record: unknown): record is Record<string, unknown> =>
-  Boolean(record) && typeof record === 'object' && !Array.isArray(record);
 
 /** Checks if a value is a Salesforce sub-query result (e.g. SELECT … FROM Contacts) */
 const isSubQueryResult = (value: unknown): value is { totalSize: number; done: boolean; records: unknown[] } => {

--- a/packages/salesforcedx-vscode-soql/src/commands/dataQuery.ts
+++ b/packages/salesforcedx-vscode-soql/src/commands/dataQuery.ts
@@ -531,7 +531,7 @@ const formatNestedDisplayValue = (value: unknown, depthRemaining: number): strin
     const joined = value.map(v => formatNestedDisplayValue(v, depthRemaining)).join(',');
     return joined.length > 50 ? `${joined.substring(0, 47)}...` : joined;
   }
-  if (typeof value === 'object' && isRecord(value)) {
+  if (isRecord(value)) {
     if (depthRemaining <= 0) {
       return '[Object]';
     }

--- a/packages/salesforcedx-vscode-soql/src/editor/queryRunner.ts
+++ b/packages/salesforcedx-vscode-soql/src/editor/queryRunner.ts
@@ -9,13 +9,12 @@ import type { QueryResult } from '../types';
 import type { Connection } from '@salesforce/core';
 import * as soqlComments from '@salesforce/soql-common/soqlComments';
 import type { JsonMap } from '@salesforce/ts-types';
-import { isError } from 'effect/Predicate';
+import { isError, isRecord } from 'effect/Predicate';
 import * as vscode from 'vscode';
 import { nls } from '../messages';
 import { stripAllRows } from './allRows';
 
-const hasMessage = (obj: unknown): obj is { message: unknown } =>
-  typeof obj === 'object' && obj !== null && 'message' in obj;
+const hasMessage = (obj: unknown): obj is { message: unknown } => isRecord(obj) && 'message' in obj;
 
 const getErrorMessage = (error: unknown): string =>
   isError(error) ? error.message : hasMessage(error) ? String(error.message) : String(error);


### PR DESCRIPTION
### What does this PR do?

## Summary
- Collapse `typeof x === 'object' && x !== null` (± `!Array.isArray(x)`) guards to `Predicate.isRecord` across 8 files in services, soql, metadata, apex-testing, and core packages.
- Delete `dataQuery.ts`'s local `isRecord` reimplementation, delegating to the effect predicate (10 call sites unchanged).
- Add jest coverage for `refreshSObjects.extractErrorMessage`'s migrated guard, closing a prior test gap (widens it to a named export for testability).

## Plan
.claude/plans/W-23358837.md

## Reviewer notes
- `refreshSObjects.ts` widens `extractErrorMessage` from module-private to a named export solely for the new jest test. Alternative would be testing via the public `initSObjectDefinitions` or an internal test entry point. Design trade-off, not a defect.
- Commit 58aa1c648 changes both `src/commands/refreshSObjects.ts` (export widening) and adds a new test file in the same commit — commit-hygiene note, no functional issue.

### What issues does this PR fix or reference?
@W-23358837@

### Functionality Before
N/A — internal refactor, no behavior change (guards are semantically equivalent; see plan's behavior-note section).

### Functionality After
N/A — internal refactor, no behavior change.

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eDKRMYA4/view