### PR TITLE
test(visualforce): run visualforceTemplates e2e on web - W-23358905

### DIFF
--- a/.claude/plans/W-23358905.md
+++ b/.claude/plans/W-23358905.md
@@ -1,0 +1,46 @@
+# W-23358905 — Run visualforceTemplates e2e on web
+
+## Context
+
+- Goal: make desktop-only VF template spec run on web + desktop.
+- Current: `packages/salesforcedx-vscode-visualforce/test/playwright/specs/visualforceTemplates.desktop.spec.ts` — 2 tests (Create VF Page, Create VF Component) via command palette → name → output-dir → assert `.page`/`.component` + `-meta.xml` in explorer.
+- All web infra already landed (WI 4, WI 1):
+  - `playwright.config.web.ts` globs `specs/`, ignores `*.desktop.spec.ts`.
+  - `fixtures/index.ts` resolves `test` desktop/web by `VSCODE_DESKTOP`.
+  - `web/headlessServer.ts` loads `salesforcedx-vscode-metadata` extra dir (VF wizards need it).
+  - `test:web` wireit bundles services + metadata + VF; `visualforceE2E.yml` has `e2e-web` job.
+  - `WEB_TEMPLATE_PREFIXES` incl. visualforcepage/component (commit 0acc7e7d0) → TemplateService web-ready.
+- VF ext: `browser: ./dist/web/index.js`, activates `onLanguage:visualforce`, registers `sf.visualforce.generate.page`/`.component`.
+- Precedent: `visualforceLsp.headless.spec.ts` (same pkg), `analyticsTemplates.headless.spec.ts` (metadata) — cross-platform template gen on web via memfs.
+
+## Phases
+
+### Phase 1 — migrate VF templates spec desktop → headless (web-robust)
+
+- Rename `visualforceTemplates.desktop.spec.ts` → `visualforceTemplates.headless.spec.ts` (git mv).
+- Drop "(Desktop Only)" from describe title.
+- Web-robustness (mirror analytics/lsp headless patterns):
+  - `QUICK_INPUT_WIDGET` → `activeQuickInputWidget(page)` (avoids stale/multi widget race).
+  - editor assert: `${EDITOR_WITH_URI}[data-uri$="${name}.page"]` (precise, not `.first()`).
+  - `closeAllEditors` between Page + Component steps (shared memfs workspace across web tests).
+  - keep `waitForQuickInputFirstOption` before output-dir Enter.
+- Confirm activation: opening generated `.page`/`.component` triggers `onLanguage:visualforce` — already covered by editor-open assert.
+- Verify no other spec references old filename.
+
+commit: `test(visualforce): run visualforceTemplates e2e on web - W-23358905`
+
+## Skills to apply
+
+- playwright-e2e (writing/running/debugging; web memfs model)
+- typescript (spec file edits)
+- concise (plan + any md)
+- verification
+
+## Verification
+
+- e2e-covered (branch CI): VF Page + Component gen on **web** (`e2e-web` job, `visualforceE2E.yml`) AND desktop (`e2e-desktop`) — the spec itself is the proof.
+- Local (not e2e-covered):
+  - `npm run test:web -w salesforcedx-vscode-visualforce` — green, both tests.
+  - `npm run test:desktop -w salesforcedx-vscode-visualforce` — regression, still green.
+  - lint/compile: `npm run lint -w salesforcedx-vscode-visualforce`.
+- grep: no lingering ref to `visualforceTemplates.desktop`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -44324,7 +44324,6 @@
       "devDependencies": {
         "@salesforce/core": "^8.32.2",
         "@salesforce/playwright-vscode-ext": "*",
-        "salesforcedx-vscode-core": "*",
         "salesforcedx-vscode-services": "*"
       },
       "engines": {

--- a/packages/salesforcedx-vscode-visualforce/test/playwright/specs/visualforceTemplates.headless.spec.ts
+++ b/packages/salesforcedx-vscode-visualforce/test/playwright/specs/visualforceTemplates.headless.spec.ts
@@ -59,10 +59,14 @@ test.describe('Visualforce Templates', () => {
       const editor = page.locator(`${EDITOR_WITH_URI}[data-uri$="${name}.${extension}"]`);
       await editor.waitFor({ state: 'visible', timeout: 30_000 });
 
-      for (const file of [`${name}.${extension}`, `${name}.${extension}-meta.xml`]) {
-        const explorerFile = page.locator('[role="treeitem"]').filter({ hasText: new RegExp(`${file}$`, 'i') });
-        await expect(explorerFile, `${file} should be visible in explorer`).toBeVisible({ timeout: 15_000 });
-      }
+      await Promise.all(
+        [`${name}.${extension}`, `${name}.${extension}-meta.xml`].map(file => {
+          const explorerFile = page
+            .locator('[role="treeitem"]')
+            .filter({ hasText: new RegExp(`${file.replaceAll('.', '\\.')}$`, 'i') });
+          return expect(explorerFile, `${file} should be visible in explorer`).toBeVisible({ timeout: 15_000 });
+        })
+      );
       await saveScreenshot(page, `vf-${name}-created.png`);
     });
   };

--- a/packages/salesforcedx-vscode-visualforce/test/playwright/specs/visualforceTemplates.headless.spec.ts
+++ b/packages/salesforcedx-vscode-visualforce/test/playwright/specs/visualforceTemplates.headless.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { test } from '../fixtures';
-import { expect } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 import {
   setupConsoleMonitoring,
   setupNetworkMonitoring,
@@ -14,17 +14,22 @@ import {
   waitForWorkspaceReady,
   verifyCommandExists,
   closeWelcomeTabs,
+  closeAllEditors,
   executeCommandWithCommandPalette,
   validateNoCriticalErrors,
   saveScreenshot,
-  QUICK_INPUT_WIDGET,
+  activeQuickInputWidget,
   EDITOR_WITH_URI,
   ensureSecondarySideBarHidden,
   waitForQuickInputFirstOption
 } from '@salesforce/playwright-vscode-ext';
 import packageNls from '../../../package.nls.json';
 
-test.describe('Visualforce Templates (Desktop Only)', () => {
+// Single cross-platform source of truth for Visualforce template generation.
+// Runs on desktop (playwright.config.desktop.ts globs specs/) AND web (playwright.config.web.ts) —
+// the `../fixtures` index resolves `test` to the desktop or web fixture by VSCODE_DESKTOP.
+
+test.describe('Visualforce Templates', () => {
   test.beforeEach(async ({ page }) => {
     setupConsoleMonitoring(page);
     setupNetworkMonitoring(page);
@@ -34,12 +39,16 @@ test.describe('Visualforce Templates (Desktop Only)', () => {
     await waitForWorkspaceReady(page);
   });
 
-  const createVisualforceTemplate = async (page: any, command: string, name: string, expectedFiles: string[]) => {
+  // Generate a VF template via command palette → name → output-dir, then assert the generated file
+  // opens in an editor (opening `.page`/`.component` triggers `onLanguage:visualforce` activation)
+  // and both files land in the explorer. Shared memfs workspace across web tests → close editors first.
+  const createVisualforceTemplate = async (page: Page, command: string, name: string, extension: string) => {
     await test.step(`Create Visualforce ${name}`, async () => {
+      await closeAllEditors(page);
       await verifyCommandExists(page, command, 30_000);
       await executeCommandWithCommandPalette(page, command);
 
-      const quickInput = page.locator(QUICK_INPUT_WIDGET);
+      const quickInput = activeQuickInputWidget(page);
       await quickInput.waitFor({ state: 'visible', timeout: 30_000 });
       await page.keyboard.type(name);
       await page.keyboard.press('Enter');
@@ -47,11 +56,12 @@ test.describe('Visualforce Templates (Desktop Only)', () => {
       await waitForQuickInputFirstOption(page);
       await page.keyboard.press('Enter');
 
-      await page.locator(EDITOR_WITH_URI).first().waitFor({ state: 'visible', timeout: 15_000 });
+      const editor = page.locator(`${EDITOR_WITH_URI}[data-uri$="${name}.${extension}"]`);
+      await editor.waitFor({ state: 'visible', timeout: 30_000 });
 
-      for (const file of expectedFiles) {
+      for (const file of [`${name}.${extension}`, `${name}.${extension}-meta.xml`]) {
         const explorerFile = page.locator('[role="treeitem"]').filter({ hasText: new RegExp(`${file}$`, 'i') });
-        await expect(explorerFile).toBeVisible();
+        await expect(explorerFile, `${file} should be visible in explorer`).toBeVisible({ timeout: 15_000 });
       }
       await saveScreenshot(page, `vf-${name}-created.png`);
     });
@@ -59,18 +69,12 @@ test.describe('Visualforce Templates (Desktop Only)', () => {
 
   test('Create Visualforce Page', async ({ page }) => {
     const name = `VFPage${Date.now()}`;
-    await createVisualforceTemplate(page, packageNls.visualforce_generate_page_text, name, [
-      `${name}.page`,
-      `${name}.page-meta.xml`
-    ]);
+    await createVisualforceTemplate(page, packageNls.visualforce_generate_page_text, name, 'page');
   });
 
   test('Create Visualforce Component', async ({ page }) => {
     const name = `VFCmp${Date.now()}`;
-    await createVisualforceTemplate(page, packageNls.visualforce_generate_component_text, name, [
-      `${name}.component`,
-      `${name}.component-meta.xml`
-    ]);
+    await createVisualforceTemplate(page, packageNls.visualforce_generate_component_text, name, 'component');
   });
 
   test.afterEach(async ({ page }) => {


### PR DESCRIPTION
## Summary
- Migrate `visualforceTemplates.desktop.spec.ts` to `visualforceTemplates.headless.spec.ts` so VF Page/Component generation runs on both web and desktop.
- Web-robustness fixes mirroring existing headless specs: `activeQuickInputWidget(page)` instead of raw `QUICK_INPUT_WIDGET`, precise editor-uri assertions, `closeAllEditors` between the Page and Component steps (shared memfs workspace on web).
- Address low-severity review findings from initial pass.

## Plan
.claude/plans/W-23358905.md

## Test plan
- e2e-web and e2e-desktop CI jobs (`visualforceE2E.yml`) exercise the renamed spec directly — no additional manual verification needed.

### What issues does this PR fix or reference?
@W-23358905@