### PR TITLE
refactor(utils-vscode): drop dead barrel exports - W-23372685

### DIFF
--- a/.claude/plans/W-23372685.md
+++ b/.claude/plans/W-23372685.md
@@ -1,0 +1,39 @@
+# W-23372685 — Remove dead exports from salesforcedx-utils-vscode barrel
+
+## Context
+
+Pkg `@salesforce/salesforcedx-utils-vscode`. 3 fns + 1 re-export dead externally. Verified via grep (`packages/*/src`, `packages/*/test`) + `gh` search `org:forcedotcom`/`org:salesforcecli` — no importer names these from the pkg.
+
+- `readDirectory` (src/helpers/fs.ts:73) — 0 callers; test-only. Other `readDirectory` hits = FsService/vfs providers, unrelated.
+- `stat` (src/helpers/fs.ts:88) — 0 callers; test-only.
+- `getTargetOrgOrAlias` standalone (src/util/authInfo.ts:15) — 0 callers. Distinct from `ConfigUtil.getTargetOrgOrAlias` static (KEEP; ui-preview uses it). No dedicated test file.
+- `SettingsService` re-export (src/index.ts:35) — class used internally (channelService.ts:12,42). Drop re-export only; keep class.
+
+Barrel `src/index.ts`: `readDirectory`+`stat` in fs group (lines 21,24); `getTargetOrgOrAlias` line 30; `SettingsService` line 35.
+
+## Phases
+
+### Phase 1 — drop dead fns + barrel re-exports + orphan tests
+
+- src/helpers/fs.ts: rm `readDirectory` (68-81), `stat` (83-95).
+- src/util/authInfo.ts: rm standalone `getTargetOrgOrAlias` (14-34). Keep `getTargetDevHubOrAlias`, `displayMessage`, enum. Check `isError` import still used (yes — getTargetDevHubOrAlias catch).
+- src/index.ts: drop `readDirectory`,`stat` from fs export group (keep createDirectory/fileOrFolderExists/readFile/safeDelete/writeFile); `getTargetOrgOrAlias` from authInfo line (keep getTargetDevHubOrAlias); drop `SettingsService` line 35.
+- test/jest/helpers/fs.test.ts: rm `readDirectory` import + describe (129-146); `stat` import + describe (148-162).
+- No standalone-authInfo test to remove (getTargetDevHubOrAlias may have tests — leave).
+
+commit: `refactor(utils-vscode): drop dead barrel exports readDirectory/stat/getTargetOrgOrAlias + SettingsService re-export - W-23372685`
+
+## Skills
+
+- concise — plan/doc style
+- external-consumers — done: gh-verified no external importer; ui-preview uses ConfigUtil static, not standalone
+- typescript — post-edit compile/lint
+- verification
+
+## Verification
+
+- `npm run compile -w @salesforce/salesforcedx-utils-vscode` — barrel + src typecheck
+- `npm run lint -w @salesforce/salesforcedx-utils-vscode` — unused-import check (isError still used)
+- `npm run test -w @salesforce/salesforcedx-utils-vscode` — fs.test.ts passes w/o removed describes
+- grep sanity: `grep -rn "getTargetOrgOrAlias\b" packages/*/src | grep -v ConfigUtil` → only authInfo gone
+- not e2e-covered (pure export removal; no runtime behavior change)

--- a/package-lock.json
+++ b/package-lock.json
@@ -44324,7 +44324,6 @@
       "devDependencies": {
         "@salesforce/core": "^8.32.2",
         "@salesforce/playwright-vscode-ext": "*",
-        "salesforcedx-vscode-core": "*",
         "salesforcedx-vscode-services": "*"
       },
       "engines": {

--- a/packages/salesforcedx-utils-vscode/src/helpers/fs.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/fs.ts
@@ -65,35 +65,6 @@ export const createDirectory = async (dirPath: string): Promise<void> => {
   }
 };
 
-/**
- * Reads a directory's contents
- * @param dirPath The path to the directory
- * @returns Array of file/directory names
- */
-export const readDirectory = async (dirPath: string): Promise<string[]> => {
-  try {
-    const uri = URI.file(dirPath);
-    const entries = await vscode.workspace.fs.readDirectory(uri);
-    return entries.map(([name]) => name);
-  } catch (error) {
-    throw new Error(`Failed to read directory ${dirPath}: ${isError(error) ? error.message : String(error)}`);
-  }
-};
-
-/**
- * Gets file stats
- * @param filePath The path to the file
- * @returns File stats including size, creation time, and modification time
- */
-export const stat = async (filePath: string): Promise<vscode.FileStat> => {
-  try {
-    const uri = URI.file(filePath);
-    return await vscode.workspace.fs.stat(uri);
-  } catch (error) {
-    throw new Error(`Failed to get file stats for ${filePath}: ${isError(error) ? error.message : String(error)}`);
-  }
-};
-
 export const safeDelete = async (
   filePath: string,
   options?: { recursive?: boolean; useTrash?: boolean }

--- a/packages/salesforcedx-utils-vscode/src/index.ts
+++ b/packages/salesforcedx-utils-vscode/src/index.ts
@@ -15,22 +15,13 @@ export { OrgUserInfo, OrgShape, WorkspaceContextUtil } from './context/workspace
 export { shapeFrom, type OrgShapeInfo } from './context/workspaceOrgShape';
 export { TelemetryService } from './services/telemetry';
 export { isInternalHost } from './telemetry/utils/isInternal';
-export {
-  createDirectory,
-  fileOrFolderExists,
-  readDirectory,
-  readFile,
-  safeDelete,
-  stat,
-  writeFile
-} from './helpers/fs';
+export { createDirectory, fileOrFolderExists, readFile, safeDelete, writeFile } from './helpers/fs';
 export { fileExtensionsMatch, projectPaths } from './helpers/paths';
 export { errorToString } from './helpers/errorUtils';
 export { updateUserIDOnTelemetryReporters as refreshAllExtensionReporters } from './helpers/telemetryUtils';
-export { getTargetOrgOrAlias, getTargetDevHubOrAlias } from './util/authInfo';
+export { getTargetDevHubOrAlias } from './util/authInfo';
 export { hasRootWorkspace, workspaceUtils } from './workspaces/workspaceUtils';
 
 export type { ContinueResponse, CancelResponse, ParametersGatherer } from './commands/parameterGatherers';
 export { ConfigAggregatorProvider } from './providers/configAggregatorProvider';
-export { SettingsService } from './settings/settingsService';
 export { code2ProtocolConverter } from './languageClients/conversion';

--- a/packages/salesforcedx-utils-vscode/src/messages/i18n.ts
+++ b/packages/salesforcedx-utils-vscode/src/messages/i18n.ts
@@ -32,9 +32,7 @@ export const messages = {
   channel_end_with_sfdx_not_found:
     'Salesforce CLI is not installed. Install it from https://developer.salesforce.com/tools/salesforcecli',
   channel_end_with_error: 'ended with error %s',
-  channel_end: 'Ended',
-  warning_using_global_username:
-    'No target org found in the local project config; using the global target org. Run "SFDX: Authorize an Org" to set the username for the local project config.'
+  channel_end: 'Ended'
 } as const;
 
 export type MessageKey = keyof typeof messages;

--- a/packages/salesforcedx-utils-vscode/src/util/authInfo.ts
+++ b/packages/salesforcedx-utils-vscode/src/util/authInfo.ts
@@ -11,28 +11,6 @@ import { ConfigSource, ConfigUtil } from '../config/configUtil';
 import { nls } from '../messages/messages';
 import { telemetryService } from '../services/telemetry';
 
-/** Get the target org or alias, optionally showing warnings */
-export const getTargetOrgOrAlias = async (enableWarning: boolean): Promise<string | undefined> => {
-  try {
-    const targetOrgOrAlias = await ConfigUtil.getTargetOrgOrAlias();
-    if (!targetOrgOrAlias) {
-      displayMessage(nls.localize('error_no_target_org'), enableWarning, VSCodeWindowTypeEnum.Informational);
-      return undefined;
-    } else {
-      if (await ConfigUtil.isGlobalTargetOrg()) {
-        displayMessage(nls.localize('warning_using_global_username'), enableWarning, VSCodeWindowTypeEnum.Warning);
-      }
-    }
-
-    return targetOrgOrAlias;
-  } catch (err) {
-    if (isError(err)) {
-      telemetryService.sendException('get_target_org_alias', err.message);
-    }
-    return undefined;
-  }
-};
-
 /** Get the target Dev Hub or alias, optionally showing warnings */
 export const getTargetDevHubOrAlias = async (
   enableWarning: boolean,

--- a/packages/salesforcedx-utils-vscode/test/jest/helpers/fs.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/helpers/fs.test.ts
@@ -6,15 +6,7 @@
  */
 import * as vscode from 'vscode';
 import { URI } from 'vscode-uri';
-import {
-  readFile,
-  writeFile,
-  fileOrFolderExists,
-  createDirectory,
-  readDirectory,
-  stat,
-  safeDelete
-} from '../../../src/helpers/fs';
+import { readFile, writeFile, fileOrFolderExists, createDirectory, safeDelete } from '../../../src/helpers/fs';
 
 jest.mock('vscode');
 describe('file system utilities', () => {
@@ -123,41 +115,6 @@ describe('file system utilities', () => {
       (vscode.workspace.fs.createDirectory as jest.Mock).mockRejectedValue(mockError);
 
       await expect(createDirectory('/test/path')).rejects.toThrow('Failed to create directory /test/path: Test error');
-    });
-  });
-
-  describe('readDirectory', () => {
-    it('should read directory contents successfully', async () => {
-      const mockEntries: [string, vscode.FileType][] = [
-        ['file1.txt', vscode.FileType.File],
-        ['dir1', vscode.FileType.Directory]
-      ];
-      (vscode.workspace.fs.readDirectory as jest.Mock).mockResolvedValue(mockEntries);
-
-      const result = await readDirectory('/test/path');
-      expect(result).toEqual(['file1.txt', 'dir1']);
-    });
-
-    it('should throw error when read fails', async () => {
-      (vscode.workspace.fs.readDirectory as jest.Mock).mockRejectedValue(mockError);
-
-      await expect(readDirectory('/test/path')).rejects.toThrow('Failed to read directory /test/path: Test error');
-    });
-  });
-
-  describe('stat', () => {
-    it('should get file stats successfully', async () => {
-      const mockStats = { type: vscode.FileType.File, size: 100, ctime: 123, mtime: 456 };
-      (vscode.workspace.fs.stat as jest.Mock).mockResolvedValue(mockStats);
-
-      const result = await stat('/test/path');
-      expect(result).toEqual(mockStats);
-    });
-
-    it('should throw error when stat fails', async () => {
-      (vscode.workspace.fs.stat as jest.Mock).mockRejectedValue(mockError);
-
-      await expect(stat('/test/path')).rejects.toThrow('Failed to get file stats for /test/path: Test error');
     });
   });
 


### PR DESCRIPTION
## Summary
- Remove `readDirectory`/`stat` from `helpers/fs.ts` (0 external callers, test-only)
- Remove standalone `getTargetOrgOrAlias` from `util/authInfo.ts` (0 callers; distinct from kept `ConfigUtil.getTargetOrgOrAlias` static)
- Drop `SettingsService` re-export from the `salesforcedx-utils-vscode` barrel (`src/index.ts`); class stays, used internally by `channelService.ts`

## Plan
.claude/plans/W-23372685.md

### What issues does this PR fix or reference?
@W-23372685@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eHNmXYAW/view