### PR TITLE
refactor(services): route FsProvider effects through shared runtime - W-23382880

### DIFF
--- a/.claude/plans/W-23382880.md
+++ b/.claude/plans/W-23382880.md
@@ -12,7 +12,7 @@
   - `readOnly` set only in protected-org mode, `fileSystemSetup.ts:83`, AFTER `projectFiles` (71). During setup `readOnly` is empty.
   - `isItReadOnlyEffect` early-returns `false` when `readOnlyTypes.length === 0` → setup-time FS ops (projectFiles writes) never need services.
   - Real read-only checks fire only post-activation editor ops → runtime ready.
-- COVERAGE GAP (adversary-confirmed): no test exercises the read-only branch. All 101 headless web specs run with `protectedOrg` unset (default false, package.json:295) → `readOnly` empty → every stat/write/delete/rename hits the `readOnlyTypes.length === 0` short-circuit (fileSystemProvider.ts:49) and never resolves services. No playwright spec sets `protectedOrg` (grep: 0 matches). No jest test touches `isItReadOnly`/`FsProvider` read-only. `setServicesRuntime` is unused in services tests. So the current inline `Effect.provide(isItReadOnlyLayer)` path AND the new `getServicesRuntime`-routed path both ship untested. Phase 2 adds that coverage.
+- COVERAGE GAP (adversary-confirmed): no test exercises the read-only branch. All 101 headless web specs run with `protectedOrg` unset (default false, package.json:295) → `readOnly` empty → every stat/write/delete/rename hits the `readOnlyTypes.length === 0` short-circuit (fileSystemProvider.ts:49) and never resolves services. No playwright spec sets `protectedOrg` (grep: 0 matches). No jest test touches `isItReadOnly`/`FsProvider` read-only → both paths untested; Phase 2 closes it.
 
 ## Phases
 
@@ -32,14 +32,14 @@
 ### Phase 2 — jest cover the runtime-routed read-only branch (mandatory, closes coverage gap)
 
 - New `test/jest/virtualFsProvider/fileSystemProvider.test.ts`.
-- Build a real runtime `ManagedRuntime.make(isItReadOnlyLayer)` (MetadataRegistryService + WorkspaceService), `setServicesRuntime(runtime)` in `beforeAll`, `disposeServicesRuntime` in `afterAll` → drives the `isServicesRuntimeReady() === true` branch (the actual new behavior).
+- Build a real runtime `ManagedRuntime.make(isItReadOnlyLayer)` (MetadataRegistryService + WorkspaceService); spy `isServicesRuntimeReady`→true + `getServicesRuntime`→that runtime → drives the runtime-ready branch. Assert `getServicesRuntime` was called so a mutant deleting the branch fails.
 - Seed memfs (via `@salesforce/core/fs` used by FsProvider) with an ApexClass file, e.g. `MyClass.cls`.
 - Set `provider.readOnly = [registryAccess.getTypeByName('ApexClass')]` (mirror fileSystemSetup.ts:83).
 - Assert:
   - `stat` on `MyClass.cls` URI → `permissions === vscode.FilePermission.Readonly` (runtime-routed true path).
   - `writeFile` / `delete` / `rename` on that URI → reject `FileSystemError.NoPermissions` (runtime-routed true path on all 4 mutators).
   - stat/write on a non-Apex suffix (e.g. `foo.txt`) → NOT read-only (suffix-miss + short-circuit still correct with runtime present).
-- Add ONE test asserting the not-ready fallback: `disposeServicesRuntime` (runtime undefined) + non-empty `readOnly` → still resolves via `isItReadOnlyLayer` fallback, returns read-only. Guards the defensive branch in Phase 1.
+- Add ONE test asserting the not-ready fallback: no runtime published (`isServicesRuntimeReady()` false by default) + non-empty `readOnly` → still resolves via `isItReadOnlyLayer` fallback, returns read-only. Guards the defensive branch in Phase 1.
 - Reuse vscode jest mock pattern from `apexTestingDiscoveryFsProvider.test.ts` (FileChangeType/FilePermission/FileSystemError stubs).
 - Files: `packages/salesforcedx-vscode-services/test/jest/virtualFsProvider/fileSystemProvider.test.ts`
 - Commit: `test(services): cover FsProvider runtime-routed + fallback read-only paths - W-23382880`
@@ -58,4 +58,4 @@
 - typecheck + lint services package.
 - jest services package green, INCLUDING new `fileSystemProvider.test.ts` (Phase 2) — this is the primary proof the runtime-routed branch works.
 - New jest asserts both branches: runtime-ready (`setServicesRuntime` → `stat`/`writeFile`/`delete`/`rename` on ApexClass URI) and not-ready fallback. Without this the new code path ships untested (adversary finding).
-- e2e: 101 headless web specs run with `protectedOrg` unset → they exercise ONLY the `readOnlyTypes.length === 0` short-circuit, NOT the runtime-routed branch. They are a regression guard for the hot path (unchanged), NOT coverage of this change. No new e2e added: protected-org is a web-console deployment mode with no spec harness to set the setting; jest (Phase 2) covers the new branch directly. Accepted: no e2e for protected-org NoPermissions; jest is the coverage of record.
+- e2e: the 101 headless web specs (protectedOrg unset) cover only the short-circuit hot path; protected-org has no spec harness to set the setting, so jest (Phase 2) is the coverage of record for the runtime-routed branch.

--- a/.claude/plans/W-23382880.md
+++ b/.claude/plans/W-23382880.md
@@ -1,0 +1,61 @@
+# W-23382880: Route FsProvider effects through shared services runtime
+
+## Context
+
+- `FsProvider` (`packages/salesforcedx-vscode-services/src/virtualFsProvider/fileSystemProvider.ts`) impls `vscode.FileSystemProvider`, called imperatively by VS Code.
+- Read-only checks run `isItReadOnlyEffect(...).pipe(Effect.provide(isItReadOnlyLayer), Effect.runSync)` at lines 83, 124, 151, 159 (stat/writeFile/delete/rename).
+- `isItReadOnlyLayer = Layer.mergeAll(MetadataRegistryService.Default, WorkspaceService.Default)` = build recipe → every FS op rebuilds both services, discards them. Hot-path cold build; never shares activation-built cache.
+- Dep W-20992510 MERGED (50b83a46e). Shared accessor exists: `servicesRuntime.ts` → `getServicesRuntime` / `isServicesRuntimeReady` / `setServicesRuntime`. o11y exporter (`observability/o11ySpanExporter.ts:37`) is the reference consumer.
+- Runtime published at `index.ts:341` (`setServicesRuntime(ManagedRuntime.make(Layer.succeedContext(builtContext)))`), after `buildWithScope` (334). `globalLayers` (servicesLayers.ts:63,72) includes MetadataRegistryService + WorkspaceService → both resolve via runtime.
+- Timing (WI open question, resolved):
+  - FsProvider constructed in `fileSystemSetup` (index.ts:302), BEFORE runtime published (341).
+  - `readOnly` set only in protected-org mode, `fileSystemSetup.ts:83`, AFTER `projectFiles` (71). During setup `readOnly` is empty.
+  - `isItReadOnlyEffect` early-returns `false` when `readOnlyTypes.length === 0` → setup-time FS ops (projectFiles writes) never need services.
+  - Real read-only checks fire only post-activation editor ops → runtime ready.
+- COVERAGE GAP (adversary-confirmed): no test exercises the read-only branch. All 101 headless web specs run with `protectedOrg` unset (default false, package.json:295) → `readOnly` empty → every stat/write/delete/rename hits the `readOnlyTypes.length === 0` short-circuit (fileSystemProvider.ts:49) and never resolves services. No playwright spec sets `protectedOrg` (grep: 0 matches). No jest test touches `isItReadOnly`/`FsProvider` read-only. `setServicesRuntime` is unused in services tests. So the current inline `Effect.provide(isItReadOnlyLayer)` path AND the new `getServicesRuntime`-routed path both ship untested. Phase 2 adds that coverage.
+
+## Phases
+
+### Phase 1 — route read-only checks through shared runtime
+
+- Add module helper `isItReadOnly(readOnlyTypes: MetadataType[], uri: URI): boolean`:
+  - short-circuit: `readOnlyTypes.length === 0` → `false` (no runtime dep; covers hot path + setup timing).
+  - runtime ready → `Effect.runSync(getServicesRuntime()).runSync(isItReadOnlyEffect(readOnlyTypes, uri))` (reuses activation-built instances). `runSync` on `getServicesRuntime` safe under `isServicesRuntimeReady` guard.
+  - not ready (defensive; non-empty readOnly pre-runtime) → fallback current `Effect.provide(isItReadOnlyLayer), Effect.runSync`.
+- Replace 4 inline `.pipe(Effect.provide(isItReadOnlyLayer), Effect.runSync)` sites (83/124/151/159) with `isItReadOnly(this.readOnly, uri)`.
+- Keep `isItReadOnlyLayer` export — still used by `index.ts:309` (fileSystemSetup provide) + fallback branch.
+- Drop debug `console.log` (lines 55-59) in `isItReadOnlyEffect` (effect-best-practices: no `console.log`).
+- Import `getServicesRuntime`, `isServicesRuntimeReady` from `../servicesRuntime`.
+- Files: `packages/salesforcedx-vscode-services/src/virtualFsProvider/fileSystemProvider.ts`
+- Commit: `refactor(services): route FsProvider read-only checks through shared runtime - W-23382880`
+
+### Phase 2 — jest cover the runtime-routed read-only branch (mandatory, closes coverage gap)
+
+- New `test/jest/virtualFsProvider/fileSystemProvider.test.ts`.
+- Build a real runtime `ManagedRuntime.make(isItReadOnlyLayer)` (MetadataRegistryService + WorkspaceService), `setServicesRuntime(runtime)` in `beforeAll`, `disposeServicesRuntime` in `afterAll` → drives the `isServicesRuntimeReady() === true` branch (the actual new behavior).
+- Seed memfs (via `@salesforce/core/fs` used by FsProvider) with an ApexClass file, e.g. `MyClass.cls`.
+- Set `provider.readOnly = [registryAccess.getTypeByName('ApexClass')]` (mirror fileSystemSetup.ts:83).
+- Assert:
+  - `stat` on `MyClass.cls` URI → `permissions === vscode.FilePermission.Readonly` (runtime-routed true path).
+  - `writeFile` / `delete` / `rename` on that URI → reject `FileSystemError.NoPermissions` (runtime-routed true path on all 4 mutators).
+  - stat/write on a non-Apex suffix (e.g. `foo.txt`) → NOT read-only (suffix-miss + short-circuit still correct with runtime present).
+- Add ONE test asserting the not-ready fallback: `disposeServicesRuntime` (runtime undefined) + non-empty `readOnly` → still resolves via `isItReadOnlyLayer` fallback, returns read-only. Guards the defensive branch in Phase 1.
+- Reuse vscode jest mock pattern from `apexTestingDiscoveryFsProvider.test.ts` (FileChangeType/FilePermission/FileSystemError stubs).
+- Files: `packages/salesforcedx-vscode-services/test/jest/virtualFsProvider/fileSystemProvider.test.ts`
+- Commit: `test(services): cover FsProvider runtime-routed + fallback read-only paths - W-23382880`
+
+## Skills to apply
+
+- effect-best-practices — runtime accessor pattern, no `console.log`, Effect.fn; run `effect-language-service diagnostics --file` (PostToolUse hook auto-runs).
+- services-extension-consumption — shared runtime semantics.
+- typescript — refactoring `fileSystemProvider.ts`.
+- verification — drive an FS op, not just typecheck.
+- concise — this plan + any doc edits.
+
+## Verification
+
+- `effect-language-service diagnostics --file fileSystemProvider.ts` clean (hook).
+- typecheck + lint services package.
+- jest services package green, INCLUDING new `fileSystemProvider.test.ts` (Phase 2) — this is the primary proof the runtime-routed branch works.
+- New jest asserts both branches: runtime-ready (`setServicesRuntime` → `stat`/`writeFile`/`delete`/`rename` on ApexClass URI) and not-ready fallback. Without this the new code path ships untested (adversary finding).
+- e2e: 101 headless web specs run with `protectedOrg` unset → they exercise ONLY the `readOnlyTypes.length === 0` short-circuit, NOT the runtime-routed branch. They are a regression guard for the hot path (unchanged), NOT coverage of this change. No new e2e added: protected-org is a web-console deployment mode with no spec harness to set the setting; jest (Phase 2) covers the new branch directly. Accepted: no e2e for protected-org NoPermissions; jest is the coverage of record.

--- a/package-lock.json
+++ b/package-lock.json
@@ -44324,7 +44324,6 @@
       "devDependencies": {
         "@salesforce/core": "^8.32.2",
         "@salesforce/playwright-vscode-ext": "*",
-        "salesforcedx-vscode-core": "*",
         "salesforcedx-vscode-services": "*"
       },
       "engines": {
@@ -44718,6 +44717,7 @@
       },
       "devDependencies": {
         "@salesforce/playwright-vscode-ext": "*",
+        "memfs": "^4.38.1",
         "svgtofont": "^6.5.2"
       },
       "engines": {

--- a/packages/salesforcedx-vscode-services/package.json
+++ b/packages/salesforcedx-vscode-services/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@salesforce/playwright-vscode-ext": "*",
+    "memfs": "^4.38.1",
     "svgtofont": "^6.5.2"
   },
   "scripts": {

--- a/packages/salesforcedx-vscode-services/src/virtualFsProvider/fileSystemProvider.ts
+++ b/packages/salesforcedx-vscode-services/src/virtualFsProvider/fileSystemProvider.ts
@@ -22,6 +22,7 @@ import * as vscode from 'vscode';
 import { Utils, type URI } from 'vscode-uri';
 import { MetadataRegistryService } from '../core/metadataRegistryService';
 import { unknownToErrorCause } from '../core/shared';
+import { getServicesRuntime, isServicesRuntimeReady } from '../servicesRuntime';
 import { joinPathWithBase } from '../vscode/uriUtils';
 import { WorkspaceService } from '../vscode/workspaceService';
 import { emitter } from './memfsWatcher';
@@ -52,16 +53,24 @@ const isItReadOnlyEffect = Effect.fn('isItReadOnly')(function* (readOnlyTypes: M
   const registryAccess = yield* MetadataRegistryService.getRegistryAccess();
   const metadataType = registryAccess.getTypeBySuffix(suffix);
   if (!metadataType) return false;
-  console.log(
-    'metadataType',
-    metadataType.id,
-    readOnlyTypes.some(opt => opt.id === metadataType.id)
-  );
   return readOnlyTypes.some(opt => opt.id === metadataType.id);
 });
 
 /** Layer required to run isItReadOnly*/
 export const isItReadOnlyLayer = Layer.mergeAll(MetadataRegistryService.Default, WorkspaceService.Default);
+
+/**
+ * Synchronous read-only check for the imperative FS boundary.
+ * - empty readOnly → false without touching the runtime (hot path + setup-time timing).
+ * - runtime ready → reuse activation-built services (shared caches).
+ * - runtime not ready (defensive: non-empty readOnly before publish) → build a throwaway graph.
+ */
+const isItReadOnly = (readOnlyTypes: MetadataType[], uri: URI): boolean =>
+  readOnlyTypes.length === 0
+    ? false
+    : isServicesRuntimeReady()
+      ? Effect.runSync(getServicesRuntime()).runSync(isItReadOnlyEffect(readOnlyTypes, uri))
+      : isItReadOnlyEffect(readOnlyTypes, uri).pipe(Effect.provide(isItReadOnlyLayer), Effect.runSync);
 
 export class FsProvider implements vscode.FileSystemProvider {
   public readonly onDidChangeFile: vscode.Event<vscode.FileChangeEvent[]> = emitter.event;
@@ -80,9 +89,7 @@ export class FsProvider implements vscode.FileSystemProvider {
         ctime: stats.ctimeMs,
         mtime: stats.mtimeMs,
         size: stats.size,
-        ...(isItReadOnlyEffect(this.readOnly, uri).pipe(Effect.provide(isItReadOnlyLayer), Effect.runSync)
-          ? { permissions: vscode.FilePermission.Readonly }
-          : {})
+        ...(isItReadOnly(this.readOnly, uri) ? { permissions: vscode.FilePermission.Readonly } : {})
       };
     } catch (error) {
       return handleFileSystemError(error, uri);
@@ -121,7 +128,7 @@ export class FsProvider implements vscode.FileSystemProvider {
     content: Uint8Array,
     options: { create: boolean; overwrite: boolean }
   ): Promise<void> {
-    if (isItReadOnlyEffect(this.readOnly, uri).pipe(Effect.provide(isItReadOnlyLayer), Effect.runSync)) {
+    if (isItReadOnly(this.readOnly, uri)) {
       throw vscode.FileSystemError.NoPermissions(uri);
     }
     const program = Effect.sync(() => {
@@ -148,7 +155,7 @@ export class FsProvider implements vscode.FileSystemProvider {
   }
 
   public async delete(uri: URI, options: { recursive: boolean }): Promise<void> {
-    if (isItReadOnlyEffect(this.readOnly, uri).pipe(Effect.provide(isItReadOnlyLayer), Effect.runSync)) {
+    if (isItReadOnly(this.readOnly, uri)) {
       throw vscode.FileSystemError.NoPermissions(uri);
     }
     await fs.promises.rm(uri.path, { recursive: options.recursive, force: true });
@@ -156,7 +163,7 @@ export class FsProvider implements vscode.FileSystemProvider {
   }
 
   public async rename(oldUri: URI, newUri: URI, options: { overwrite: boolean }): Promise<void> {
-    if (isItReadOnlyEffect(this.readOnly, oldUri).pipe(Effect.provide(isItReadOnlyLayer), Effect.runSync)) {
+    if (isItReadOnly(this.readOnly, oldUri)) {
       throw vscode.FileSystemError.NoPermissions(oldUri);
     }
     if (!options.overwrite && this.exists(newUri)) {

--- a/packages/salesforcedx-vscode-services/src/virtualFsProvider/fileSystemProvider.ts
+++ b/packages/salesforcedx-vscode-services/src/virtualFsProvider/fileSystemProvider.ts
@@ -46,7 +46,7 @@ const suffixFromPath = (uri: URI): string | undefined => {
 };
 
 /** Effect that uses MetadataRegistryService (cached) to resolve metadata type from URI */
-const isItReadOnlyEffect = Effect.fn('isItReadOnly')(function* (readOnlyTypes: MetadataType[], uri: URI) {
+const checkIsReadOnly = Effect.fn('isItReadOnly')(function* (readOnlyTypes: MetadataType[], uri: URI) {
   if (readOnlyTypes.length === 0) return false;
   const suffix = suffixFromPath(uri);
   if (!suffix) return false;
@@ -65,12 +65,15 @@ export const isItReadOnlyLayer = Layer.mergeAll(MetadataRegistryService.Default,
  * - runtime ready → reuse activation-built services (shared caches).
  * - runtime not ready (defensive: non-empty readOnly before publish) → build a throwaway graph.
  */
-const isItReadOnly = (readOnlyTypes: MetadataType[], uri: URI): boolean =>
-  readOnlyTypes.length === 0
-    ? false
-    : isServicesRuntimeReady()
-      ? Effect.runSync(getServicesRuntime()).runSync(isItReadOnlyEffect(readOnlyTypes, uri))
-      : isItReadOnlyEffect(readOnlyTypes, uri).pipe(Effect.provide(isItReadOnlyLayer), Effect.runSync);
+const isItReadOnly = (readOnlyTypes: MetadataType[], uri: URI): boolean => {
+  if (readOnlyTypes.length === 0) return false;
+  return isServicesRuntimeReady()
+    ? getServicesRuntime().pipe(
+        Effect.map(runtime => runtime.runSync(checkIsReadOnly(readOnlyTypes, uri))),
+        Effect.runSync
+      )
+    : checkIsReadOnly(readOnlyTypes, uri).pipe(Effect.provide(isItReadOnlyLayer), Effect.runSync);
+};
 
 export class FsProvider implements vscode.FileSystemProvider {
   public readonly onDidChangeFile: vscode.Event<vscode.FileChangeEvent[]> = emitter.event;

--- a/packages/salesforcedx-vscode-services/test/jest/virtualFsProvider/fileSystemProvider.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/virtualFsProvider/fileSystemProvider.test.ts
@@ -7,14 +7,16 @@
 
 import { RegistryAccess } from '@salesforce/source-deploy-retrieve';
 import * as Effect from 'effect/Effect';
+import type * as Layer from 'effect/Layer';
 import * as ManagedRuntime from 'effect/ManagedRuntime';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import * as vscode from 'vscode';
 import { URI } from 'vscode-uri';
-import { disposeServicesRuntime, setServicesRuntime } from '../../../src/servicesRuntime';
+import * as servicesRuntime from '../../../src/servicesRuntime';
 import { FsProvider, isItReadOnlyLayer } from '../../../src/virtualFsProvider/fileSystemProvider';
+
+const vscode = require('vscode');
 
 const registryAccess = new RegistryAccess();
 
@@ -38,49 +40,64 @@ describe('FsProvider read-only checks', () => {
   const txtUri = (): URI => URI.file(path.join(workspaceDir, 'foo.txt'));
 
   describe('runtime-ready (routed through shared runtime)', () => {
+    let runtime: ManagedRuntime.ManagedRuntime<Layer.Layer.Success<typeof isItReadOnlyLayer>, never>;
+    let getRuntimeSpy: jest.SpyInstance;
+
     beforeAll(() => {
-      // shared runtime built from the same layer the fallback uses; drives isServicesRuntimeReady() === true
-      setServicesRuntime(ManagedRuntime.make(isItReadOnlyLayer) as never);
+      runtime = ManagedRuntime.make(isItReadOnlyLayer);
     });
 
     afterAll(async () => {
-      await Effect.runPromise(disposeServicesRuntime());
+      await Effect.runPromise(runtime.disposeEffect);
     });
 
-    it('stat marks a read-only metadata type Readonly', async () => {
+    // resetMocks wipes spies between tests, so re-arm each test. getRuntimeSpy proves the
+    // runtime-ready branch actually consumed the shared runtime (mutating it away fails these).
+    beforeEach(() => {
+      jest.spyOn(servicesRuntime, 'isServicesRuntimeReady').mockReturnValue(true);
+      getRuntimeSpy = jest
+        .spyOn(servicesRuntime, 'getServicesRuntime')
+        .mockReturnValue(Effect.succeed(runtime) as ReturnType<typeof servicesRuntime.getServicesRuntime>);
+    });
+
+    it('stat marks a read-only metadata type Readonly via the shared runtime', async () => {
       const provider = new FsProvider();
       provider.readOnly = [registryAccess.getTypeByName('ApexClass')];
 
       const stat = await provider.stat(clsUri());
 
       expect(stat.permissions).toBe(vscode.FilePermission.Readonly);
+      expect(getRuntimeSpy).toHaveBeenCalled();
     });
 
-    it('writeFile rejects a read-only metadata type', async () => {
+    it('writeFile rejects a read-only metadata type via the shared runtime', async () => {
       const provider = new FsProvider();
       provider.readOnly = [registryAccess.getTypeByName('ApexClass')];
 
       await expect(
         provider.writeFile(clsUri(), new TextEncoder().encode('x'), { create: false, overwrite: true })
       ).rejects.toMatchObject({ code: 'NoPermissions' });
+      expect(getRuntimeSpy).toHaveBeenCalled();
     });
 
-    it('delete rejects a read-only metadata type', async () => {
+    it('delete rejects a read-only metadata type via the shared runtime', async () => {
       const provider = new FsProvider();
       provider.readOnly = [registryAccess.getTypeByName('ApexClass')];
 
       await expect(provider.delete(clsUri(), { recursive: false })).rejects.toMatchObject({
         code: 'NoPermissions'
       });
+      expect(getRuntimeSpy).toHaveBeenCalled();
     });
 
-    it('rename rejects a read-only metadata type', async () => {
+    it('rename rejects a read-only metadata type via the shared runtime', async () => {
       const provider = new FsProvider();
       provider.readOnly = [registryAccess.getTypeByName('ApexClass')];
 
       await expect(
         provider.rename(clsUri(), URI.file(path.join(workspaceDir, 'Renamed.cls')), { overwrite: true })
       ).rejects.toMatchObject({ code: 'NoPermissions' });
+      expect(getRuntimeSpy).toHaveBeenCalled();
     });
 
     it('does not mark a non-metadata suffix Readonly', async () => {
@@ -98,14 +115,13 @@ describe('FsProvider read-only checks', () => {
       const stat = await provider.stat(clsUri());
 
       expect(stat.permissions).toBeUndefined();
+      // empty readOnly short-circuits before the runtime is ever consulted
+      expect(getRuntimeSpy).not.toHaveBeenCalled();
     });
   });
 
   describe('runtime not ready (fallback layer)', () => {
-    beforeAll(async () => {
-      await Effect.runPromise(disposeServicesRuntime());
-    });
-
+    // isServicesRuntimeReady() is false by default (no runtime published) → fallback branch
     it('still resolves read-only via the fallback layer', async () => {
       const provider = new FsProvider();
       provider.readOnly = [registryAccess.getTypeByName('ApexClass')];

--- a/packages/salesforcedx-vscode-services/test/jest/virtualFsProvider/fileSystemProvider.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/virtualFsProvider/fileSystemProvider.test.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { RegistryAccess } from '@salesforce/source-deploy-retrieve';
+import * as Effect from 'effect/Effect';
+import * as ManagedRuntime from 'effect/ManagedRuntime';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import { URI } from 'vscode-uri';
+import { disposeServicesRuntime, setServicesRuntime } from '../../../src/servicesRuntime';
+import { FsProvider, isItReadOnlyLayer } from '../../../src/virtualFsProvider/fileSystemProvider';
+
+const registryAccess = new RegistryAccess();
+
+describe('FsProvider read-only checks', () => {
+  let workspaceDir: string;
+
+  beforeAll(() => {
+    workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fsp-'));
+    fs.writeFileSync(path.join(workspaceDir, 'MyClass.cls'), 'public class MyClass {}');
+    fs.writeFileSync(path.join(workspaceDir, 'foo.txt'), 'plain');
+    vscode.workspace.workspaceFolders = [
+      {
+        uri: { scheme: 'file', fsPath: workspaceDir, toString: (): string => `file://${workspaceDir}` },
+        name: 'ws',
+        index: 0
+      }
+    ] as unknown as typeof vscode.workspace.workspaceFolders;
+  });
+
+  const clsUri = (): URI => URI.file(path.join(workspaceDir, 'MyClass.cls'));
+  const txtUri = (): URI => URI.file(path.join(workspaceDir, 'foo.txt'));
+
+  describe('runtime-ready (routed through shared runtime)', () => {
+    beforeAll(() => {
+      // shared runtime built from the same layer the fallback uses; drives isServicesRuntimeReady() === true
+      setServicesRuntime(ManagedRuntime.make(isItReadOnlyLayer) as never);
+    });
+
+    afterAll(async () => {
+      await Effect.runPromise(disposeServicesRuntime());
+    });
+
+    it('stat marks a read-only metadata type Readonly', async () => {
+      const provider = new FsProvider();
+      provider.readOnly = [registryAccess.getTypeByName('ApexClass')];
+
+      const stat = await provider.stat(clsUri());
+
+      expect(stat.permissions).toBe(vscode.FilePermission.Readonly);
+    });
+
+    it('writeFile rejects a read-only metadata type', async () => {
+      const provider = new FsProvider();
+      provider.readOnly = [registryAccess.getTypeByName('ApexClass')];
+
+      await expect(
+        provider.writeFile(clsUri(), new TextEncoder().encode('x'), { create: false, overwrite: true })
+      ).rejects.toMatchObject({ code: 'NoPermissions' });
+    });
+
+    it('delete rejects a read-only metadata type', async () => {
+      const provider = new FsProvider();
+      provider.readOnly = [registryAccess.getTypeByName('ApexClass')];
+
+      await expect(provider.delete(clsUri(), { recursive: false })).rejects.toMatchObject({
+        code: 'NoPermissions'
+      });
+    });
+
+    it('rename rejects a read-only metadata type', async () => {
+      const provider = new FsProvider();
+      provider.readOnly = [registryAccess.getTypeByName('ApexClass')];
+
+      await expect(
+        provider.rename(clsUri(), URI.file(path.join(workspaceDir, 'Renamed.cls')), { overwrite: true })
+      ).rejects.toMatchObject({ code: 'NoPermissions' });
+    });
+
+    it('does not mark a non-metadata suffix Readonly', async () => {
+      const provider = new FsProvider();
+      provider.readOnly = [registryAccess.getTypeByName('ApexClass')];
+
+      const stat = await provider.stat(txtUri());
+
+      expect(stat.permissions).toBeUndefined();
+    });
+
+    it('does not mark anything Readonly when readOnly is empty (short-circuit)', async () => {
+      const provider = new FsProvider();
+
+      const stat = await provider.stat(clsUri());
+
+      expect(stat.permissions).toBeUndefined();
+    });
+  });
+
+  describe('runtime not ready (fallback layer)', () => {
+    beforeAll(async () => {
+      await Effect.runPromise(disposeServicesRuntime());
+    });
+
+    it('still resolves read-only via the fallback layer', async () => {
+      const provider = new FsProvider();
+      provider.readOnly = [registryAccess.getTypeByName('ApexClass')];
+
+      const stat = await provider.stat(clsUri());
+
+      expect(stat.permissions).toBe(vscode.FilePermission.Readonly);
+    });
+  });
+});

--- a/packages/salesforcedx-vscode-services/test/jest/virtualFsProvider/fileSystemProvider.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/virtualFsProvider/fileSystemProvider.test.ts
@@ -5,13 +5,12 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { fs, resetFs, setFs } from '@salesforce/core/fs';
 import { RegistryAccess } from '@salesforce/source-deploy-retrieve';
 import * as Effect from 'effect/Effect';
 import type * as Layer from 'effect/Layer';
 import * as ManagedRuntime from 'effect/ManagedRuntime';
-import * as fs from 'node:fs';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import { createFsFromVolume, Volume } from 'memfs';
 import { URI } from 'vscode-uri';
 import * as servicesRuntime from '../../../src/servicesRuntime';
 import { FsProvider, isItReadOnlyLayer } from '../../../src/virtualFsProvider/fileSystemProvider';
@@ -20,13 +19,22 @@ const vscode = require('vscode');
 
 const registryAccess = new RegistryAccess();
 
-describe('FsProvider read-only checks', () => {
-  let workspaceDir: string;
+// POSIX workspace path so uri.path is drive-less and identical across platforms.
+// The provider addresses files by uri.path (memfs/web semantics), so on Windows a
+// URI.file(os.tmpdir()) path like /c:/... would resolve against the current drive
+// (D:\C:\...) and ENOENT. Back the provider with memfs (as the web build does).
+const workspaceDir = '/dx-project';
 
+describe('FsProvider read-only checks', () => {
   beforeAll(() => {
-    workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fsp-'));
-    fs.writeFileSync(path.join(workspaceDir, 'MyClass.cls'), 'public class MyClass {}');
-    fs.writeFileSync(path.join(workspaceDir, 'foo.txt'), 'plain');
+    setFs(
+      createFsFromVolume(
+        Volume.fromJSON({
+          [`${workspaceDir}/MyClass.cls`]: 'public class MyClass {}',
+          [`${workspaceDir}/foo.txt`]: 'plain'
+        })
+      ) as unknown as typeof fs
+    );
     vscode.workspace.workspaceFolders = [
       {
         uri: { scheme: 'file', fsPath: workspaceDir, toString: (): string => `file://${workspaceDir}` },
@@ -36,8 +44,12 @@ describe('FsProvider read-only checks', () => {
     ] as unknown as typeof vscode.workspace.workspaceFolders;
   });
 
-  const clsUri = (): URI => URI.file(path.join(workspaceDir, 'MyClass.cls'));
-  const txtUri = (): URI => URI.file(path.join(workspaceDir, 'foo.txt'));
+  afterAll(() => {
+    resetFs();
+  });
+
+  const clsUri = (): URI => URI.file(`${workspaceDir}/MyClass.cls`);
+  const txtUri = (): URI => URI.file(`${workspaceDir}/foo.txt`);
 
   describe('runtime-ready (routed through shared runtime)', () => {
     let runtime: ManagedRuntime.ManagedRuntime<Layer.Layer.Success<typeof isItReadOnlyLayer>, never>;
@@ -95,7 +107,7 @@ describe('FsProvider read-only checks', () => {
       provider.readOnly = [registryAccess.getTypeByName('ApexClass')];
 
       await expect(
-        provider.rename(clsUri(), URI.file(path.join(workspaceDir, 'Renamed.cls')), { overwrite: true })
+        provider.rename(clsUri(), URI.file(`${workspaceDir}/Renamed.cls`), { overwrite: true })
       ).rejects.toMatchObject({ code: 'NoPermissions' });
       expect(getRuntimeSpy).toHaveBeenCalled();
     });

--- a/scripts/setup-jest.ts
+++ b/scripts/setup-jest.ts
@@ -346,6 +346,9 @@ const getMockVSCode = () => {
       File: 1,
       Directory: 2
     },
+    FilePermission: {
+      Readonly: 1
+    },
     FileChangeType: {
       Changed: 1,
       Created: 2,


### PR DESCRIPTION
## Summary

- Route `FsProvider` read-only checks (stat/writeFile/delete/rename) through the shared services runtime instead of rebuilding `isItReadOnlyLayer` on every hot-path FS op.
- Add `isItReadOnly` helper: short-circuits when `readOnlyTypes` is empty, resolves via `getServicesRuntime()` once ready, falls back to the old per-call layer build for the pre-runtime edge case.
- Drop debug `console.log` from `isItReadOnlyEffect`; add jest coverage for both the runtime-routed and fallback read-only paths (previously untested).

## Plan

.claude/plans/W-23382880.md

## Reviewer notes

- low, design-decision: the not-ready fallback branch in `isItReadOnly` (fileSystemProvider.ts:73) is likely unreachable in production — `readOnly` is empty during setup, and the runtime is ready for all post-activation ops. Left in place (comment-labeled "defensive") rather than removed, since removing it changes behavior on a genuine pre-runtime edge; flagging for reviewer judgment call.

### What issues does this PR fix or reference?
@W-23382880@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eK4c9YAC/view