### PR TITLE
ci(publishOpenVSX): poll OpenVSX after publish, fail CI on timeout - W-23427112

### DIFF
--- a/.claude/plans/W-23427112.md
+++ b/.claude/plans/W-23427112.md
@@ -32,8 +32,8 @@
 
 ### Phase 2 — make the step exercisable in real Actions (same commit)
 
-- Add `workflow_dispatch.inputs.verify_only` (boolean, default `false`, description "Skip re-publish; only download release + poll OpenVSX for the main version"). Doubles as a permanent operator button to re-check whether the last release actually landed (serves the WI's own goal), same spirit as the existing manual-dispatch button.
-- Guard the retry `ovsx publish` step with `if: ${{ !inputs.verify_only }}` — on a `release` event `inputs.verify_only` is null → falsy → `!null` = true → publish still runs; on dispatch with `verify_only=true` publish is skipped. (Confirms boolean-input null-safety; note existing line 82 already reads `inputs.ctc` on release events without error.)
+- Add `workflow_dispatch.inputs.verify_only` (boolean, default `false`, description "Skip re-publish; only download release + poll OpenVSX for the main version"). Also a permanent recheck button for the last release, same spirit as existing manual dispatch.
+- Guard the retry `ovsx publish` step with `if: ${{ !inputs.verify_only }}` — null → falsy on release events, so publish still runs; `verify_only=true` on dispatch skips it (line 82 already reads `inputs.ctc` similarly).
 - Poll step (Phase 1) runs unconditionally, so a `verify_only` dispatch downloads the release vsix, skips republish, and polls the already-published main version → all confirmed → step passes.
 - Also honor `POLL_TIMEOUT` / `POLL_INTERVAL` env (Phase 1) so a fail-path dispatch can be exercised in seconds, not 10 min. Hardcode nothing that blocks override.
 
@@ -41,8 +41,7 @@
 
 - concise — this plan file + any doc
 - verification — validate yaml + shell logic before commit
-- effect-best-practices — n/a to this diff (YAML/bash only), noted per unconditional review criterion; no Effect surface touched.
-- typescript — n/a (YAML/bash only), noted per unconditional review criterion.
+- effect-best-practices, typescript — n/a (YAML/bash only)
 
 ## Verification
 
@@ -50,7 +49,7 @@ Local (fast, pre-push):
 - `actionlint .github/workflows/publishOpenVSX.yml` — syntax + `inputs`/`if` expression validity.
 - Local dry-run of poll shell block against live OpenVSX with `POLL_TIMEOUT`/`POLL_INTERVAL` overridden: confirmed id (present version) exits 0 fast; fabricated missing id/version loops then fails after short TIMEOUT. Verified exit-code behavior manually (present=0, missing=1).
 
-Real GitHub Actions (required gate before merge — closes the adversary finding: env interpolation into bash, `$GITHUB_OUTPUT` contract from `prepare-environment-from-main`, and `gh` release-download auth context only exist inside the runner):
+Real GitHub Actions (required gate — env interpolation, `$GITHUB_OUTPUT` contract, `gh` auth only exist in-runner):
 - Push branch, then `gh workflow run publishOpenVSX.yml --ref <branch> -f verify_only=true`.
 - Watch the run (`gh run watch`); confirm in real runtime:
   - `prepare-environment-from-main` emits `PUBLISH_VERSION` via `$GITHUB_OUTPUT` and it interpolates into the `publish` job env.

--- a/.claude/plans/W-23427112.md
+++ b/.claude/plans/W-23427112.md
@@ -1,0 +1,61 @@
+# W-23427112 — Poll OpenVSX post-publish, fail CI if version never lands
+
+## Context
+
+- `ovsx publish` returns success on any 2xx + prints `Published`; OpenVSX indexing is async server-side. Extension can "publish" yet never land.
+- `salesforcedx-vscode-services` stuck at 66.12.3 (2026-05-20); 6 releases logged `SUCCESSFULLY published` but never appeared. CI never re-checks → stays green.
+- Fix = CI guardrail only (root-cause tracked separately). Add post-publish poll to `.github/workflows/publishOpenVSX.yml`.
+- File: `.github/workflows/publishOpenVSX.yml`, `publish` job (currently ends at retry `ovsx publish` step, line ~67-70).
+- Facts verified locally (ovsx 0.10.12, in `node_modules/.bin`):
+  - `ovsx get salesforce.<name> --metadata -v <version>` → exit 0 if version present, exit 1 if `no published version matching`.
+  - All 17 extensions publisher = `salesforce`.
+  - Published vsix already downloaded to `./extensions/` in publish job; asset names = `<extName>-<version>.vsix`.
+  - Ext id = `salesforce.` + basename minus `-<PUBLISH_VERSION>.vsix`.
+- Workflow triggers: `release: types: [released]` and `workflow_dispatch` (both run on `main` via hardcoded `ref: 'main'`). No branch e2e exists — the poll step would otherwise first execute in real Actions during a production release (high blast radius).
+
+## Phases
+
+### Phase 1 — add post-publish verification step (one commit)
+
+- New step in `publish` job, after retry publish step. `name: Verify published versions landed on OpenVSX`.
+- Logic (bash):
+  - derive ext ids from `./extensions/*.vsix`: `salesforce.$(basename "$f" "-$PUBLISH_VERSION.vsix")`.
+  - config via env so tests can override: `TIMEOUT="${POLL_TIMEOUT:-600}"` (~10 min), `INTERVAL="${POLL_INTERVAL:-30}"`, deadline = now + TIMEOUT.
+  - loop until all ids confirmed OR deadline passed:
+    - for each not-yet-confirmed id: `npx ovsx get "$id" --metadata -v "$PUBLISH_VERSION"` (discard output); exit 0 → mark confirmed.
+    - all confirmed → break success.
+    - else `sleep $INTERVAL`.
+  - after loop: if any unconfirmed → `echo "::error::"` per missing id + `exit 1`; else echo success.
+  - do NOT fail on first miss — only after deadline (tolerates indexing lag per WI).
+- `-p "$OVSX_PAT"` not needed for `get` (public read); keep step envless of PAT — verified get works unauthenticated.
+- commit msg: `ci(publishOpenVSX): poll OpenVSX until published versions land, fail on timeout - W-23427112`
+
+### Phase 2 — make the step exercisable in real Actions (same commit)
+
+- Add `workflow_dispatch.inputs.verify_only` (boolean, default `false`, description "Skip re-publish; only download release + poll OpenVSX for the main version"). Doubles as a permanent operator button to re-check whether the last release actually landed (serves the WI's own goal), same spirit as the existing manual-dispatch button.
+- Guard the retry `ovsx publish` step with `if: ${{ !inputs.verify_only }}` — on a `release` event `inputs.verify_only` is null → falsy → `!null` = true → publish still runs; on dispatch with `verify_only=true` publish is skipped. (Confirms boolean-input null-safety; note existing line 82 already reads `inputs.ctc` on release events without error.)
+- Poll step (Phase 1) runs unconditionally, so a `verify_only` dispatch downloads the release vsix, skips republish, and polls the already-published main version → all confirmed → step passes.
+- Also honor `POLL_TIMEOUT` / `POLL_INTERVAL` env (Phase 1) so a fail-path dispatch can be exercised in seconds, not 10 min. Hardcode nothing that blocks override.
+
+## Skills to apply
+
+- concise — this plan file + any doc
+- verification — validate yaml + shell logic before commit
+- effect-best-practices — n/a to this diff (YAML/bash only), noted per unconditional review criterion; no Effect surface touched.
+- typescript — n/a (YAML/bash only), noted per unconditional review criterion.
+
+## Verification
+
+Local (fast, pre-push):
+- `actionlint .github/workflows/publishOpenVSX.yml` — syntax + `inputs`/`if` expression validity.
+- Local dry-run of poll shell block against live OpenVSX with `POLL_TIMEOUT`/`POLL_INTERVAL` overridden: confirmed id (present version) exits 0 fast; fabricated missing id/version loops then fails after short TIMEOUT. Verified exit-code behavior manually (present=0, missing=1).
+
+Real GitHub Actions (required gate before merge — closes the adversary finding: env interpolation into bash, `$GITHUB_OUTPUT` contract from `prepare-environment-from-main`, and `gh` release-download auth context only exist inside the runner):
+- Push branch, then `gh workflow run publishOpenVSX.yml --ref <branch> -f verify_only=true`.
+- Watch the run (`gh run watch`); confirm in real runtime:
+  - `prepare-environment-from-main` emits `PUBLISH_VERSION` via `$GITHUB_OUTPUT` and it interpolates into the `publish` job env.
+  - `gh release download v<version>` authenticates and populates `./extensions/`.
+  - retry publish step is SKIPPED (verify_only guard works, no accidental republish).
+  - new poll step parses, derives ext ids, runs `ovsx get`, and PASSES against the already-published main version.
+- Fail-path in real Actions (cheap): dispatch again with a short `POLL_TIMEOUT` (e.g. temporarily via env or a fabricated-version input) to observe the loop time out → `::error::` per missing id → step exits 1. Confirms the failing exit code actually fails the job in the runner, not just locally.
+- Only after both real-Actions runs pass, merge — so the step never first executes during a production `release` event.

--- a/.github/workflows/publishOpenVSX.yml
+++ b/.github/workflows/publishOpenVSX.yml
@@ -75,6 +75,10 @@ jobs:
           command: |
             cmd=$(find ./extensions -type f -name "*.vsix" -print0 | xargs -0 -I {} printf 'npx ovsx publish --skip-duplicate "%s" -p "%s" && ' '{}' "${OVSX_PAT}" | sed 's/ && $//') && [ -n "$cmd" ] && eval "$cmd" && echo "SUCCESSFULLY published"
       - name: Verify published versions landed on OpenVSX
+        env:
+          POLL_TIMEOUT: '5'
+          POLL_INTERVAL: '2'
+          PUBLISH_VERSION: '999.999.999'
         run: |
           TIMEOUT="${POLL_TIMEOUT:-600}"
           INTERVAL="${POLL_INTERVAL:-30}"

--- a/.github/workflows/publishOpenVSX.yml
+++ b/.github/workflows/publishOpenVSX.yml
@@ -6,6 +6,11 @@ on:
     types: [released]
   #  Button for publishing main branch in case there is a failure on the release.
   workflow_dispatch:
+    inputs:
+      verify_only:
+        description: 'Skip re-publish; only download release + poll OpenVSX for the main version'
+        type: boolean
+        default: false
 
 jobs:
   prepare-environment-from-main:
@@ -64,10 +69,41 @@ jobs:
           gh release download v${{ env.PUBLISH_VERSION }} -D ./extensions
       - name: Display downloaded vsix files
         run: ls -R ./extensions
-      - uses: salesforcecli/github-workflows/.github/actions/retry@main
+      - if: ${{ !inputs.verify_only }}
+        uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           command: |
             cmd=$(find ./extensions -type f -name "*.vsix" -print0 | xargs -0 -I {} printf 'npx ovsx publish --skip-duplicate "%s" -p "%s" && ' '{}' "${OVSX_PAT}" | sed 's/ && $//') && [ -n "$cmd" ] && eval "$cmd" && echo "SUCCESSFULLY published"
+      - name: Verify published versions landed on OpenVSX
+        run: |
+          TIMEOUT="${POLL_TIMEOUT:-600}"
+          INTERVAL="${POLL_INTERVAL:-30}"
+          deadline=$(( $(date +%s) + TIMEOUT ))
+          pending=()
+          for f in ./extensions/*.vsix; do
+            pending+=("salesforce.$(basename "$f" "-$PUBLISH_VERSION.vsix")")
+          done
+          while :; do
+            still=()
+            for id in "${pending[@]}"; do
+              if npx ovsx get "$id" --metadata -v "$PUBLISH_VERSION" >/dev/null 2>&1; then
+                echo "confirmed $id@$PUBLISH_VERSION"
+              else
+                still+=("$id")
+              fi
+            done
+            pending=("${still[@]}")
+            [ "${#pending[@]}" -eq 0 ] && break
+            [ "$(date +%s)" -ge "$deadline" ] && break
+            sleep "$INTERVAL"
+          done
+          if [ "${#pending[@]}" -gt 0 ]; then
+            for id in "${pending[@]}"; do
+              echo "::error::$id@$PUBLISH_VERSION never landed on OpenVSX"
+            done
+            exit 1
+          fi
+          echo "All published versions landed on OpenVSX"
 
   ctcCloseSuccess:
     needs: [ctc-open, publish]

--- a/.github/workflows/publishOpenVSX.yml
+++ b/.github/workflows/publishOpenVSX.yml
@@ -79,10 +79,15 @@ jobs:
           TIMEOUT="${POLL_TIMEOUT:-600}"
           INTERVAL="${POLL_INTERVAL:-30}"
           deadline=$(( $(date +%s) + TIMEOUT ))
+          shopt -s nullglob
           pending=()
           for f in ./extensions/*.vsix; do
             pending+=("salesforce.$(basename "$f" "-$PUBLISH_VERSION.vsix")")
           done
+          if [ "${#pending[@]}" -eq 0 ]; then
+            echo "::error::no vsix files found in ./extensions — nothing to verify"
+            exit 1
+          fi
           while :; do
             still=()
             for id in "${pending[@]}"; do

--- a/.github/workflows/publishOpenVSX.yml
+++ b/.github/workflows/publishOpenVSX.yml
@@ -75,10 +75,6 @@ jobs:
           command: |
             cmd=$(find ./extensions -type f -name "*.vsix" -print0 | xargs -0 -I {} printf 'npx ovsx publish --skip-duplicate "%s" -p "%s" && ' '{}' "${OVSX_PAT}" | sed 's/ && $//') && [ -n "$cmd" ] && eval "$cmd" && echo "SUCCESSFULLY published"
       - name: Verify published versions landed on OpenVSX
-        env:
-          POLL_TIMEOUT: '5'
-          POLL_INTERVAL: '2'
-          PUBLISH_VERSION: '999.999.999'
         run: |
           TIMEOUT="${POLL_TIMEOUT:-600}"
           INTERVAL="${POLL_INTERVAL:-30}"


### PR DESCRIPTION
## Summary

- `ovsx publish` returns success on any 2xx even though OpenVSX indexing is async; `salesforcedx-vscode-services` has been stuck at 66.12.3 since 2026-05-20 across 6 "successful" releases, undetected because CI never re-checks.
- Add a post-publish poll step to `.github/workflows/publishOpenVSX.yml`: derives ext ids from the downloaded vsix files, polls `ovsx get <id> --metadata -v <version>` on an interval, fails the job only after a timeout (default 600s) if any version never lands.
- Add `workflow_dispatch.inputs.verify_only` to exercise the poll against an already-published release without republishing, plus `POLL_TIMEOUT`/`POLL_INTERVAL` env overrides for fast fail-path testing in real Actions.
- Fail fast (no timeout burn) when no vsix files are found in the publish job.

## Plan

.claude/plans/W-23427112.md

## Reviewer notes

- low: `publishOpenVSX.yml:79` — hardcoded 600s `TIMEOUT` plus unauthenticated `ovsx get` polls of up to 17 extensions are rate-limit-sensitive; a real release whose OpenVSX indexing exceeds 600s, or an open-vsx.org rate-limit, will fail the publish job. This is the WI's intended tradeoff (fail-if-not-landed); no code change made — monitor after the first production release and revisit TIMEOUT/backoff if false failures occur.

## Test plan

- [ ] `gh workflow run publishOpenVSX.yml --ref sm/W-23427112-poll-openvsx-after-publish-fail-ci-if-ve -f verify_only=true`; watch the run and confirm: `PUBLISH_VERSION` output interpolates into the `publish` job env, `gh release download` populates `./extensions/`, the retry-publish step is skipped, and the new poll step passes against the already-published version.
- [ ] Dispatch again with a short `POLL_TIMEOUT` against a fabricated/missing version to confirm the poll loop times out, emits `::error::` per missing id, and the step actually exits 1 in the runner (not just locally).
- [ ] Only merge after both real-Actions runs above pass — this step must not first execute during a production `release` event.

### What issues does this PR fix or reference?
@W-23427112@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002edjRvYAI/view