### PR TITLE
fix(apex-testing): gate showAllMethods vs testLevel on API v68 - W-23428145

### DIFF
--- a/.claude/plans/W-23428145.md
+++ b/.claude/plans/W-23428145.md
@@ -32,9 +32,9 @@ commit: `fix(apex-testing): gate showAllMethods vs testLevel on API v68 - W-2342
 
 ### Phase 2 — e2e private-class visibility gate (one commit)
 
-The gap the advocate flagged: the live e2e (`testExplorer.headless.spec.ts`) deploys a `public class`, so it never exercises the load-bearing behavior — private `@isTest` classes appearing in discovery. That is exactly what the WI proved is real on v67 (showAllMethods=true → 4 private classes; omitted → 0) and what must hold on v68 via `testLevel=RunAllTestsInOrg`.
+The gap the advocate flagged: the live e2e deploys a `public class`, never exercising private-class visibility. WI proved this is real on v67 (showAllMethods=true → 4 private classes; omitted → 0); must hold on v68 via `testLevel=RunAllTestsInOrg`.
 
-`discoverTests` hits the org's live Tooling `/tooling/tests` API on the discovery path (`apexTestTreeService.ts:772,1114`); the desktop connection version = the org's release (jsforce default), so this spec already drives the real server on whatever version CI scratch orgs run. Making it assert private-class visibility turns it into a real behavior gate that fires automatically the moment CI orgs advance to v68 — no code change needed then.
+`discoverTests` hits org's live Tooling `/tooling/tests` API (`apexTestTreeService.ts:772,1114`); desktop connection version = org release (jsforce default) → spec already drives real server at CI org version. Asserting private-class visibility here = automatic v68 gate once CI orgs advance, no code change needed.
 
 - Edit `testExplorer.headless.spec.ts`: change the deployed class from `public class` to `@isTest`/`private class` (drop the `public` keyword — mirror `runApexTestsFailAndFix`'s `private class AccountServiceTest`). Keep both `@isTest` methods.
   - This makes the "verify discovery" assertions (tree item for the class + its methods appear) prove private-class visibility end-to-end against the live org. If discovery silently returned 0 classes (the failure mode), the tree-item `waitFor` times out and the spec fails — the gate the WI wants.
@@ -63,4 +63,4 @@ Manual pre-merge smoke (the v68 branch cannot be CI-gated until a v68+ org exist
 - Get a v68+ org: `sf org create scratch --release preview` (preview instances run the next release; if preview is still v67 during the release window, use a v68 sandbox/prerelease org). Confirm `sf org display --json` reports apiVersion >= 68.0.
 - Auth it, deploy a PRIVATE `@isTest` class (e.g. `private class Foo`), open Test Explorer, Refresh Tests, and confirm the private class + its methods appear in the tree (discovery returned them, not 0 classes).
 - Capture the outbound request URL (span file `~/.sf/vscode-spans/` span `apex-test-discovery`, or a `connection.request` log) and confirm it carries `testLevel=RunAllTestsInOrg` and omits `showAllMethods`.
-- This is the only check that proves Core's documented default actually yields private-class visibility on v68 rather than assuming omission-equivalence. Record the org version + result in the PR before merge. If no v68+ org is obtainable at merge time, state that explicitly in the PR and flag the residual risk (the jest cases only prove URL shape).
+- Only check proving Core's default actually yields private-class visibility on v68 (not just omission-equivalence assumption). Record org version + result in PR. If no v68+ org at merge, state that + flag residual risk (jest cases only prove URL shape).

--- a/.claude/plans/W-23428145.md
+++ b/.claude/plans/W-23428145.md
@@ -1,0 +1,66 @@
+# W-23428145 — Fix Test Discovery API rejecting showAllMethods on v68+
+
+## Context
+
+- `testDiscovery.ts` hardcodes `showAllMethods=true`. Core removed param at API v68.0+/264 → 400 reject.
+- v67.0 and below: keep `showAllMethods=true` (load-bearing; v67 dreamhouse test proves private-class visibility needs it).
+- v68.0+: omit `showAllMethods`, send `testLevel=RunAllTestsInOrg` explicitly (unconditional, independent of `namespacePrefix`).
+- Keep `/tooling/tests` path. Do NOT switch to `/tooling/apexTestDiscovery`.
+- Gate on raw numeric `Math.max(connectionApiVersion, minApiVersion)` (before `.toFixed(1)`) vs new `testLevelMinApiVersion = 68.0`. No re-parse of formatted `apiVersion` string.
+- Files: `packages/salesforcedx-vscode-apex-testing/src/testDiscovery/testDiscovery.ts:25-40`; test `packages/salesforcedx-vscode-apex-testing/test/jest/testDiscovery/testDiscovery.test.ts`.
+
+## Phases
+
+### Phase 1 — gate query param on apiVersion + tests (one commit)
+
+`testDiscovery.ts`:
+- add const `testLevelMinApiVersion = 68.0` near `minApiVersion`.
+- capture numeric: `const effectiveApiVersion = Number.isFinite(connectionApiVersion) ? Math.max(connectionApiVersion, minApiVersion) : minApiVersion;`
+- `apiVersion = effectiveApiVersion.toFixed(1)`.
+- replace lines 39-40 branch: if `effectiveApiVersion >= testLevelMinApiVersion` → `qp.set('testLevel', 'RunAllTestsInOrg')`; else → `qp.set('showAllMethods', 'true')`.
+- keep `namespacePrefix` block unchanged.
+
+`testDiscovery.test.ts`:
+- existing v61/v65 cases unchanged (still <68).
+- add: connection `getApiVersion` → `68.0` → URL omits `showAllMethods`, contains `testLevel=RunAllTestsInOrg`.
+- add: connection → `67.9` → `showAllMethods=true`, no `testLevel` (boundary, just under 68).
+- add: connection → `69.0` (above gate) → still `testLevel=RunAllTestsInOrg`, no `showAllMethods` — proves gate is `>=`, not `== 68`.
+- per-test connection version: set via `__setMockConnection` with a mock overriding `getApiVersion`; existing `beforeEach` re-sets the default v61 mock, so cases are isolated.
+- these are URL-shape assertions only. They prove the branch selection, NOT that v68 servers honor `testLevel=RunAllTestsInOrg` for private-class visibility — see Verification.
+
+commit: `fix(apex-testing): gate showAllMethods vs testLevel on API v68 - W-23428145`
+
+### Phase 2 — e2e private-class visibility gate (one commit)
+
+The gap the advocate flagged: the live e2e (`testExplorer.headless.spec.ts`) deploys a `public class`, so it never exercises the load-bearing behavior — private `@isTest` classes appearing in discovery. That is exactly what the WI proved is real on v67 (showAllMethods=true → 4 private classes; omitted → 0) and what must hold on v68 via `testLevel=RunAllTestsInOrg`.
+
+`discoverTests` hits the org's live Tooling `/tooling/tests` API on the discovery path (`apexTestTreeService.ts:772,1114`); the desktop connection version = the org's release (jsforce default), so this spec already drives the real server on whatever version CI scratch orgs run. Making it assert private-class visibility turns it into a real behavior gate that fires automatically the moment CI orgs advance to v68 — no code change needed then.
+
+- Edit `testExplorer.headless.spec.ts`: change the deployed class from `public class` to `@isTest`/`private class` (drop the `public` keyword — mirror `runApexTestsFailAndFix`'s `private class AccountServiceTest`). Keep both `@isTest` methods.
+  - This makes the "verify discovery" assertions (tree item for the class + its methods appear) prove private-class visibility end-to-end against the live org. If discovery silently returned 0 classes (the failure mode), the tree-item `waitFor` times out and the spec fails — the gate the WI wants.
+- Do NOT add a separate spec or new org; reuse the existing non-tracking org + discovery step. No behavior fork on API version in the spec — the branch is chosen inside `discoverTests` from the live connection version.
+
+commit: `test(apex-testing): assert private test class discovery in e2e - W-23428145`
+
+## Skills to apply
+
+- typescript — Effect idioms, `const`, no `let` (build param branch as expression, not mutation).
+- effect-best-practices — the `discoverTests` gen stays as-is; only the qp branch changes.
+- playwright-e2e — Phase 2 spec edit; reuse non-tracking org, no new fixture.
+- i18n-messages — n/a (no user-facing strings)
+- concise — this plan
+- verification — jest + e2e run + manual v68 smoke.
+
+## Verification
+
+Automated (CI-gating today):
+- `npm run compile` (or package tsc) — types.
+- jest: `packages/salesforcedx-vscode-apex-testing` testDiscovery suite — new v68/v67.9/v69 cases + unchanged v61/v65.
+- lint: `npm run lint` scoped to package.
+- e2e: `testExplorer.headless.spec.ts` (desktop + web) now deploys a PRIVATE test class and asserts it discovers — proves private-class visibility against the live org (currently v67, so this locks the v67 `showAllMethods` branch). Becomes the automatic v68 gate once CI orgs advance to v68.
+
+Manual pre-merge smoke (the v68 branch cannot be CI-gated until a v68+ org exists):
+- Get a v68+ org: `sf org create scratch --release preview` (preview instances run the next release; if preview is still v67 during the release window, use a v68 sandbox/prerelease org). Confirm `sf org display --json` reports apiVersion >= 68.0.
+- Auth it, deploy a PRIVATE `@isTest` class (e.g. `private class Foo`), open Test Explorer, Refresh Tests, and confirm the private class + its methods appear in the tree (discovery returned them, not 0 classes).
+- Capture the outbound request URL (span file `~/.sf/vscode-spans/` span `apex-test-discovery`, or a `connection.request` log) and confirm it carries `testLevel=RunAllTestsInOrg` and omits `showAllMethods`.
+- This is the only check that proves Core's documented default actually yields private-class visibility on v68 rather than assuming omission-equivalence. Record the org version + result in the PR before merge. If no v68+ org is obtainable at merge time, state that explicitly in the PR and flag the residual risk (the jest cases only prove URL shape).

--- a/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/testDiscovery.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/testDiscovery.ts
@@ -23,7 +23,6 @@ import {
  * Docs: https://developer.salesforce.com/docs/atlas.en-us.api_tooling.meta/api_tooling/intro_rest_resources_testing_discovery.htm
  */
 const minApiVersion = 65.0;
-// v68.0+ removed `showAllMethods`; send `testLevel=RunAllTestsInOrg` instead (Core default) to keep private-class visibility.
 const testLevelMinApiVersion = 68.0;
 
 export const discoverTests = (options: DiscoverTestsOptions = {}) =>

--- a/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/testDiscovery.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/testDiscovery.ts
@@ -23,6 +23,8 @@ import {
  * Docs: https://developer.salesforce.com/docs/atlas.en-us.api_tooling.meta/api_tooling/intro_rest_resources_testing_discovery.htm
  */
 const minApiVersion = 65.0;
+// v68.0+ removed `showAllMethods`; send `testLevel=RunAllTestsInOrg` instead (Core default) to keep private-class visibility.
+const testLevelMinApiVersion = 68.0;
 
 export const discoverTests = (options: DiscoverTestsOptions = {}) =>
   Effect.gen(function* () {
@@ -31,13 +33,18 @@ export const discoverTests = (options: DiscoverTestsOptions = {}) =>
 
     const connectionApiVersion = parseFloat(connection.getApiVersion());
     // Ensure we use an API version that supports the Test Discovery API (>= 65.0)
-    const apiVersion = (
-      Number.isFinite(connectionApiVersion) ? Math.max(connectionApiVersion, minApiVersion) : minApiVersion
-    ).toFixed(1);
+    const effectiveApiVersion = Number.isFinite(connectionApiVersion)
+      ? Math.max(connectionApiVersion, minApiVersion)
+      : minApiVersion;
+    const apiVersion = effectiveApiVersion.toFixed(1);
     const basePath = `/services/data/v${apiVersion}/tooling/tests`;
     const qp = new URLSearchParams();
-    // Always show all methods (both consumers use this)
-    qp.set('showAllMethods', 'true');
+    // v68.0+ rejects `showAllMethods`; `testLevel=RunAllTestsInOrg` is Core's replacement default that keeps private-class visibility.
+    if (effectiveApiVersion >= testLevelMinApiVersion) {
+      qp.set('testLevel', 'RunAllTestsInOrg');
+    } else {
+      qp.set('showAllMethods', 'true');
+    }
     if (options?.namespacePrefix) {
       qp.set('namespacePrefix', options.namespacePrefix);
     }

--- a/packages/salesforcedx-vscode-apex-testing/test/jest/testDiscovery/testDiscovery.test.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/jest/testDiscovery/testDiscovery.test.ts
@@ -128,7 +128,7 @@ describe('TestDiscovery', () => {
     );
   });
 
-  it('uses minimum API version 65.0 and always sets showAllMethods=true', async () => {
+  it('uses minimum API version 65.0 and sets showAllMethods=true below v68', async () => {
     (mockConnection.request as jest.Mock).mockResolvedValueOnce({ apexTestClasses: [], nextRecordsUrl: null });
     await extensionProvider.getApexTestingRuntime().runPromise(discoverTests());
     expect(mockConnection.request).toHaveBeenCalledTimes(1);

--- a/packages/salesforcedx-vscode-apex-testing/test/jest/testDiscovery/testDiscovery.test.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/jest/testDiscovery/testDiscovery.test.ts
@@ -139,6 +139,34 @@ describe('TestDiscovery', () => {
     expect(firstCallArg.url).not.toContain('namespacePrefix=');
   });
 
+  it('omits showAllMethods and sets testLevel=RunAllTestsInOrg on v68.0', async () => {
+    (extensionProvider as any).__setMockConnection({ ...mockConnection, getApiVersion: () => '68.0' });
+    (mockConnection.request as jest.Mock).mockResolvedValueOnce({ apexTestClasses: [], nextRecordsUrl: null });
+    await extensionProvider.getApexTestingRuntime().runPromise(discoverTests());
+    const firstCallArg = (mockConnection.request as jest.Mock).mock.calls[0][0];
+    expect(firstCallArg.url).toMatch(/^\/services\/data\/v68\.0\/tooling\/tests\?/);
+    expect(firstCallArg.url).toContain('testLevel=RunAllTestsInOrg');
+    expect(firstCallArg.url).not.toContain('showAllMethods');
+  });
+
+  it('keeps showAllMethods=true just under the gate on v67.9', async () => {
+    (extensionProvider as any).__setMockConnection({ ...mockConnection, getApiVersion: () => '67.9' });
+    (mockConnection.request as jest.Mock).mockResolvedValueOnce({ apexTestClasses: [], nextRecordsUrl: null });
+    await extensionProvider.getApexTestingRuntime().runPromise(discoverTests());
+    const firstCallArg = (mockConnection.request as jest.Mock).mock.calls[0][0];
+    expect(firstCallArg.url).toContain('showAllMethods=true');
+    expect(firstCallArg.url).not.toContain('testLevel');
+  });
+
+  it('sets testLevel=RunAllTestsInOrg above the gate on v69.0 (>=, not ==68)', async () => {
+    (extensionProvider as any).__setMockConnection({ ...mockConnection, getApiVersion: () => '69.0' });
+    (mockConnection.request as jest.Mock).mockResolvedValueOnce({ apexTestClasses: [], nextRecordsUrl: null });
+    await extensionProvider.getApexTestingRuntime().runPromise(discoverTests());
+    const firstCallArg = (mockConnection.request as jest.Mock).mock.calls[0][0];
+    expect(firstCallArg.url).toContain('testLevel=RunAllTestsInOrg');
+    expect(firstCallArg.url).not.toContain('showAllMethods');
+  });
+
   it('passes namespacePrefix when provided', async () => {
     (mockConnection.request as jest.Mock).mockResolvedValueOnce({ apexTestClasses: [], nextRecordsUrl: null });
     await extensionProvider.getApexTestingRuntime().runPromise(discoverTests({ namespacePrefix: 'MyNS' }));

--- a/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/testExplorer.headless.spec.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/testExplorer.headless.spec.ts
@@ -51,7 +51,8 @@ test('Apex Tests via Test Explorer: run all, verify discovery', async ({ page })
     testClassName = `ExplorerTestClass${Date.now()}`;
     const testClassContent = [
       '@isTest',
-      `public class ${testClassName} {`,
+      // private (no `public`): exercises private-class visibility in discovery — the load-bearing behavior gated on API version (W-23428145).
+      `private class ${testClassName} {`,
       '\t@isTest',
       '\tstatic void shouldDiscoverThisTest() {',
       "\t\tSystem.assertEquals(1, 1, 'Discovery test should pass');",


### PR DESCRIPTION
### What does this PR do?

## Summary
- `testDiscovery.ts` hardcoded `showAllMethods=true`, which Core rejects on API v68.0+/264 (400 error).
- Gate the query param on the connection's effective API version: v67.x and below keep `showAllMethods=true` (load-bearing for private-class visibility); v68.0+ omit it and send `testLevel=RunAllTestsInOrg` instead.
- Extend `testExplorer.headless.spec.ts` to deploy a `private class` (was `public`) so the live e2e proves private-class visibility against whichever API version the CI org runs — becomes an automatic v68+ gate once CI orgs advance.

## Plan
See [.claude/plans/W-23428145.md](../blob/develop/.claude/plans/W-23428145.md) for full context and phase breakdown.

## Reviewer notes
- **medium**: the v68 branch (RunAllTestsInOrg preserving private-class visibility) is unverified — CI orgs currently run v67, so the new jest cases only assert URL shape (that `testLevel=RunAllTestsInOrg` is sent and `showAllMethods` is omitted), not server behavior. Needs a manual v68+ org smoke test before merge; see Test plan below.
- **low**: commit `3598322` changes `src` and `test` together in one commit, deviating from the usual "don't mix src+test in one commit" convention. Rewriting branch history to split it was judged riskier than leaving it — noting as a commit-hygiene deviation rather than fixing.
- **low**: `testDiscovery.test.ts` adds three more `(extensionProvider as any).__setMockConnection(...)` casts, matching the pre-existing pattern at line 64. Removing the `any` would require a typed accessor on the jest mock factory (which is `any` throughout) — a design choice, not a mechanical fix.

## Test plan
- [ ] Get a v68+ org (`sf org create scratch --release preview`, or a v68 sandbox/prerelease org). Confirm `sf org display --json` reports `apiVersion >= 68.0`.
- [ ] Deploy a private `@isTest` class (e.g. `private class Foo`), open Test Explorer, Refresh Tests, and confirm the private class + its methods appear in the tree (proves discovery didn't silently return 0 classes).
- [ ] Capture the outbound request (span file `~/.sf/vscode-spans/`, span `apex-test-discovery`, or a `connection.request` log) and confirm it carries `testLevel=RunAllTestsInOrg` and omits `showAllMethods`.
- [ ] Record the org API version + result in this PR before merge. If no v68+ org is available at merge time, state that explicitly and flag the residual risk (jest cases only prove URL shape, not server-side visibility behavior).

### What issues does this PR fix or reference?
@W-23428145@

### Functionality Before
`discoverTests` always sent `showAllMethods=true`; on API v68+ Core rejects the param with a 400.

### Functionality After
`discoverTests` sends `showAllMethods=true` on API < v68, and `testLevel=RunAllTestsInOrg` on API >= v68, matching what Core's Test Discovery endpoint accepts per version.

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002edvQKYAY/view
