### PR TITLE
chore(effect): enforce globalErrorInEffectCatch + dedupe skill - W-23429451

### DIFF
--- a/.claude/plans/W-23429451.md
+++ b/.claude/plans/W-23429451.md
@@ -1,0 +1,32 @@
+# W-23429451 — Fix + enforce globalErrorInEffectCatch
+
+## Context
+
+Effect LS rule `globalErrorInEffectCatch`: global `Error` constructed in a catch handler; use tagged error. Sibling of merged `globalErrorInEffectFailure` WI (#7810, `09a8d3420`).
+
+Both WI-named sites ALREADY FIXED by #7810 (in this worktree's base):
+- `salesforcedx-vscode-apex-log/src/traceFlags/traceFlagJsonSync.ts` — `tryPromise` `catch` → `new UserSearchError(...)` (was `new Error('search failed')`)
+- `salesforcedx-vscode-apex-testing/src/testDiscovery/testDiscovery.ts` — `tryPromise` `catch` → `new TestDiscoveryFetchError(...)`
+
+WI line #s (74, 53) stale/pre-refactor. Repo-wide LS scan (all effect pkgs): **0 `globalErrorInEffectCatch` findings**. `openLogsFolder.ts:24` `new Error(String(e))` is a `cause:` value, not the failure — rule doesn't flag it (confirmed 0).
+
+Remaining work = promote rule + dedupe skill. No code fix needed. Ratchet: `config/effect-diagnostics.json` `enforcedRules` (currently `lazyPromiseInEffectSync`, `runEffectInsideEffect`, `globalErrorInEffectFailure`) gated by `scripts/effect-diagnostics.mjs` (CI `check:effect-diagnostics`). Mirrors prior sibling WIs.
+
+## Phases
+
+### Phase 1 — enforce + skill dedupe
+- Append `"globalErrorInEffectCatch"` to `enforcedRules` in `config/effect-diagnostics.json`.
+- anti-patterns.md: fold into the existing `globalErrorInEffectFailure` FORBIDDEN block as one entry covering both failure-channel + catch-handler variants (config-enforced, build fails on hit; `new Error` in `tryPromise`/`tryCatch`/`catchAll` handler → `Schema.TaggedError`).
+- SKILL.md line 20: `Catch`/`Failure` already both named; update parenthetical so both marked config-enforced (currently only `Failure` is). Dedupe → single pointer at rule.
+- Files: `config/effect-diagnostics.json`, `.claude/skills/effect-best-practices/references/anti-patterns.md`, `.claude/skills/effect-best-practices/SKILL.md`
+- Commit: `chore(effect): enforce globalErrorInEffectCatch + dedupe skill - W-23429451`
+
+## Skills to apply
+- effect-best-practices — rule semantics, tagged-error patterns
+- typescript — reviewing/editing any touched .ts
+- concise — plan + md edits
+
+## Verification
+- `npm run check:effect-diagnostics` — gate passes w/ rule enforced, 0 findings. Primary DoD. (Ratchet needs compiled `out/*.d.ts`; wireit dep `compile` supplies.)
+- `git grep -n "globalErrorInEffectCatch" config/ .claude/skills/` — rule listed, skill deduped.
+- No unit/e2e: no code change. Named-site behavior already covered by #7810's tests/e2e (SOSL picker happy path `traceFlagsForOtherUser.headless.spec.ts`; `testDiscovery.test.ts:126` `toThrow` on fetch error).

--- a/.claude/skills/effect-best-practices/SKILL.md
+++ b/.claude/skills/effect-best-practices/SKILL.md
@@ -17,7 +17,7 @@ npx effect-language-service diagnostics --project tsconfig.json
 ```
 
 - The PostToolUse `verify-on-edit.sh` hook auto-runs `--file <edited>` on every `.ts` Edit/Write and surfaces output as `followup_message`. Address what it reports.
-- **Address warnings AND messages, not just errors.** Common findings: `effectFnOpportunity` (gen→fn), `unnecessaryFailYieldableError` (yield error directly), `effectSucceedWithVoid` (`Effect.succeed(undefined)` → `Effect.void`), `globalErrorInEffectCatch`/`Failure` (use tagged error, not `new Error`; `Failure` is config-enforced — see `references/anti-patterns.md`).
+- **Address warnings AND messages, not just errors.** Common findings: `effectFnOpportunity` (gen→fn), `unnecessaryFailYieldableError` (yield error directly), `effectSucceedWithVoid` (`Effect.succeed(undefined)` → `Effect.void`), `globalErrorInEffectCatch`/`Failure` (use tagged error, not `new Error`; both config-enforced — see `references/anti-patterns.md`).
 - After a batch of edits, run `--project tsconfig.json` for the affected package to catch cross-file issues.
 - `effect-language-service quickfixes` shows proposed code changes.
 

--- a/.claude/skills/effect-best-practices/references/anti-patterns.md
+++ b/.claude/skills/effect-best-practices/references/anti-patterns.md
@@ -8,9 +8,9 @@ Enforced by Effect LS rule `runEffectInsideEffect` (in `config/effect-diagnostic
 
 Direct-in-gen: `yield*` instead of `Effect.run*`. In a vscode callback: capture `const runtime = yield* Effect.runtime()` in the enclosing gen, then `Runtime.run*(runtime)(...)` — keep the original method (`runSync`/`runPromise`/`runFork`), never downgrade to fire-and-forget. Pattern ref: `packages/salesforcedx-vscode-services/src/core/lifecycleWarningListener.ts`.
 
-## FORBIDDEN: Global Error in Effect Failure Channel
+## FORBIDDEN: Global Error in Effect Failure Channel / Catch Handler
 
-Enforced by Effect LS rule `globalErrorInEffectFailure` (in `config/effect-diagnostics.json` `enforcedRules`; build fails on any hit). A `new Error(...)` in a failure channel (`Effect.fail`, `Effect.async<A, Error>`, `tryPromise`/`tryCatch` `catch`, `Stream.fromAsyncIterable` error map) can't be discriminated by `catchTag`. Use a `Schema.TaggedError` with a `message` field (colocate module-local; export only when it crosses a package `.d.ts` boundary — see `ts4023-effect-errors`).
+Enforced by Effect LS rules `globalErrorInEffectFailure` + `globalErrorInEffectCatch` (in `config/effect-diagnostics.json` `enforcedRules`; build fails on any hit). A `new Error(...)` in a failure channel (`Effect.fail`, `Effect.async<A, Error>`) or in a catch handler (`tryPromise`/`tryCatch` `catch`, `catchAll`, `Stream.fromAsyncIterable` error map) can't be discriminated by `catchTag`. Use a `Schema.TaggedError` with a `message` field (colocate module-local; export only when it crosses a package `.d.ts` boundary — see `ts4023-effect-errors`).
 
 ## FORBIDDEN: throw Inside Effect.gen
 

--- a/.claude/skills/effect-best-practices/references/anti-patterns.md
+++ b/.claude/skills/effect-best-practices/references/anti-patterns.md
@@ -10,7 +10,7 @@ Direct-in-gen: `yield*` instead of `Effect.run*`. In a vscode callback: capture 
 
 ## FORBIDDEN: Global Error in Effect Failure Channel / Catch Handler
 
-Enforced by Effect LS rules `globalErrorInEffectFailure` + `globalErrorInEffectCatch` (in `config/effect-diagnostics.json` `enforcedRules`; build fails on any hit). A `new Error(...)` in a failure channel (`Effect.fail`, `Effect.async<A, Error>`) or in a catch handler (`tryPromise`/`tryCatch` `catch`, `catchAll`, `Stream.fromAsyncIterable` error map) can't be discriminated by `catchTag`. Use a `Schema.TaggedError` with a `message` field (colocate module-local; export only when it crosses a package `.d.ts` boundary — see `ts4023-effect-errors`).
+Enforced by Effect LS rules `globalErrorInEffectFailure` + `globalErrorInEffectCatch` (in `config/effect-diagnostics.json` `enforcedRules`; build fails on any hit). A `new Error(...)` in an E-channel position — a failure channel or catch callback whose result flows to `E` (`Effect.fail`, `Effect.async<A, Error>`, `catchAll`, `Stream.fromAsyncIterable` error map), caught by `globalErrorInEffectFailure` — or in a `try*` catch handler (`tryPromise`/`try`/`tryMap`/`tryMapPromise` `catch`), caught by `globalErrorInEffectCatch`, can't be discriminated by `catchTag`. Use a `Schema.TaggedError` with a `message` field (colocate module-local; export only when it crosses a package `.d.ts` boundary — see `ts4023-effect-errors`).
 
 ## FORBIDDEN: throw Inside Effect.gen
 

--- a/config/effect-diagnostics.json
+++ b/config/effect-diagnostics.json
@@ -1,4 +1,9 @@
 {
   "$comment": "Effect LS diagnostics ratchet. scripts/effect-diagnostics.mjs fails the build only on findings whose rule name is listed in enforcedRules (any severity). Sibling WIs append a rule name here after fixing all its sites. Empty list = nothing enforced (exit 0).",
-  "enforcedRules": ["lazyPromiseInEffectSync", "runEffectInsideEffect", "globalErrorInEffectFailure"]
+  "enforcedRules": [
+    "lazyPromiseInEffectSync",
+    "runEffectInsideEffect",
+    "globalErrorInEffectFailure",
+    "globalErrorInEffectCatch"
+  ]
 }


### PR DESCRIPTION
## Summary
- Add `globalErrorInEffectCatch` to `enforcedRules` in `config/effect-diagnostics.json` (ratchet, CI `check:effect-diagnostics`)
- Fold the catch-handler variant into the existing `globalErrorInEffectFailure` FORBIDDEN block in `anti-patterns.md` (config-enforced, covers both failure-channel + catch-handler `new Error`)
- Dedupe `effect-best-practices/SKILL.md` parenthetical so both `Catch`/`Failure` are marked config-enforced

## Plan
.claude/plans/W-23429451.md

## Test plan
- `npm run check:effect-diagnostics` — gate passes with the rule enforced, 0 findings (repo-wide scan confirmed both prior WI-named sites already fixed by #7810; no remaining violations)

### What issues does this PR fix or reference?
@W-23429451@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002ee411YAA/view