### PR TITLE
fix(apex-debugger): SFDX: Stop Apex Debugger Session uses the ISV Debugger SID and URL to determine the org when in an ISV Debugger project - W-23516769

### DIFF
--- a/packages/salesforcedx-vscode-apex-debugger/src/commands/debuggerStop.ts
+++ b/packages/salesforcedx-vscode-apex-debugger/src/commands/debuggerStop.ts
@@ -4,7 +4,9 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { AuthInfo, Connection } from '@salesforce/core';
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
+import { SF_CONFIG_ISV_DEBUGGER_SID, SF_CONFIG_ISV_DEBUGGER_URL } from '@salesforce/salesforcedx-apex-debugger';
 import * as Array from 'effect/Array';
 import * as Effect from 'effect/Effect';
 import * as Option from 'effect/Option';
@@ -53,7 +55,21 @@ export const debuggerStop = Effect.fn('debuggerStop')(function* () {
   // with the migrated org commands and the old sfProjectPreconditionChecker gate).
   yield* api.services.ProjectService.getSfProject();
 
-  const conn = yield* api.services.ConnectionService.getConnection();
+  // ISV Debugger projects authenticate via org-isv-debugger-sid/url stored in project-local config,
+  // not a target-org — getConnection() would fail with NoTargetOrgConfiguredError for these projects.
+  const configAggregator = yield* api.services.ConfigService.getConfigAggregator();
+  const isvSid = configAggregator.getPropertyValue<string>(SF_CONFIG_ISV_DEBUGGER_SID);
+  const isvUrl = configAggregator.getPropertyValue<string>(SF_CONFIG_ISV_DEBUGGER_URL);
+
+  const conn = yield* isvSid && isvUrl
+    ? Effect.tryPromise({
+        try: () =>
+          AuthInfo.create({ accessTokenOptions: { accessToken: isvSid, loginUrl: isvUrl, instanceUrl: isvUrl } }).then(
+            authInfo => Connection.create({ authInfo })
+          ),
+        catch: e => new DebuggerSessionQueryError({ message: isError(e) ? e.message : String(e) })
+      })
+    : api.services.ConnectionService.getConnection();
 
   // LIMIT 1 → Array.head is None (nothing to stop) or Some(the session to detach).
   yield* Effect.tryPromise({

--- a/packages/salesforcedx-vscode-apex-debugger/test/jest/commands/debuggerStop.test.ts
+++ b/packages/salesforcedx-vscode-apex-debugger/test/jest/commands/debuggerStop.test.ts
@@ -5,11 +5,17 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { AuthInfo, Connection } from '@salesforce/core';
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
 import * as vscode from 'vscode';
 import { debuggerStop, DebuggerSessionQueryError } from '../../../src/commands/debuggerStop';
+
+jest.mock('@salesforce/core', () => ({
+  AuthInfo: { create: jest.fn() },
+  Connection: { create: jest.fn() }
+}));
 
 type QueryResult = { records: { Id: string }[] };
 
@@ -20,12 +26,20 @@ const makeConnection = (queryImpl: () => Promise<QueryResult>) => {
   return { conn: { tooling: { query: queryImpl, sobject } }, update, sobject };
 };
 
-// Provide the real ExtensionProviderService tag with a mock services api (ConnectionService + ChannelService).
-const providerLayer = (conn: unknown) =>
+const makeConfigService = (isvSid?: string, isvUrl?: string) => ({
+  getConfigAggregator: () =>
+    Effect.succeed({
+      getPropertyValue: (key: string) => (key.includes('sid') ? isvSid : key.includes('url') ? isvUrl : undefined)
+    })
+});
+
+// Provide the real ExtensionProviderService tag with a mock services api.
+const providerLayer = (conn: unknown, isvSid?: string, isvUrl?: string) =>
   Layer.succeed(ExtensionProviderService, {
     getServicesApi: Effect.succeed({
       services: {
         ProjectService: { getSfProject: () => Effect.void },
+        ConfigService: makeConfigService(isvSid, isvUrl),
         ConnectionService: { getConnection: () => Effect.succeed(conn) },
         // withProgress is a pipeable operator; the mock passes the wrapped effect through unchanged.
         PromptService: Effect.succeed({
@@ -40,8 +54,10 @@ const providerLayer = (conn: unknown) =>
 
 // providerLayer satisfies ConnectionService/ChannelService at runtime, but the api's typed accessors re-add
 // them to the effect's R channel; cast R away since the layer fully provides them.
-const run = (conn: unknown) =>
-  Effect.runPromise(debuggerStop().pipe(Effect.provide(providerLayer(conn))) as Effect.Effect<void, unknown, never>);
+const run = (conn: unknown, isvSid?: string, isvUrl?: string) =>
+  Effect.runPromise(
+    debuggerStop().pipe(Effect.provide(providerLayer(conn, isvSid, isvUrl))) as Effect.Effect<void, unknown, never>
+  );
 
 const runFlipped = (conn: unknown) =>
   Effect.runPromise(
@@ -74,5 +90,26 @@ describe('debuggerStop', () => {
     const error = await runFlipped(conn);
     expect(error).toBeInstanceOf(DebuggerSessionQueryError);
     expect(update).not.toHaveBeenCalled();
+  });
+
+  it('builds an ISV connection from org-isv-debugger-sid/url when present instead of using target-org', async () => {
+    const { conn, sobject, update } = makeConnection(() => Promise.resolve({ records: [{ Id: '07aXX0000000002' }] }));
+    const mockAuthInfo = {};
+    (AuthInfo.create as jest.Mock).mockResolvedValue(mockAuthInfo);
+    (Connection.create as jest.Mock).mockResolvedValue(conn);
+
+    await run(undefined, 'fakeSessionId', 'https://na1.salesforce.com');
+
+    expect(AuthInfo.create).toHaveBeenCalledWith({
+      accessTokenOptions: {
+        accessToken: 'fakeSessionId',
+        loginUrl: 'https://na1.salesforce.com',
+        instanceUrl: 'https://na1.salesforce.com'
+      }
+    });
+    expect(Connection.create).toHaveBeenCalledWith({ authInfo: mockAuthInfo });
+    expect(sobject).toHaveBeenCalledWith('ApexDebuggerSession');
+    expect(update).toHaveBeenCalledWith({ Id: '07aXX0000000002', Status: 'Detach' });
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('Apex Debugger session stopped.');
   });
 });


### PR DESCRIPTION
### What does this PR do?
This PR fixes a bug where **SFDX: Stop Apex Debugger Session** was producing a "No target org configured" error notification instead of stopping the current Apex Interactive Debugger session.

### What issues does this PR fix or reference?
@W-23516769@

### Functionality Before
No session available:
<img width="2032" height="1162" alt="no target org configured 1" src="https://github.com/user-attachments/assets/54da85bd-b69b-44c9-bbef-47ecc08e4c17" />

Session available:
<img width="2032" height="1162" alt="no target org configured 2" src="https://github.com/user-attachments/assets/320277a5-ef1a-4972-b46c-ac2988fc7aa8" />

### Functionality After
No session available:
<img width="2032" height="1162" alt="no apex debugger session found" src="https://github.com/user-attachments/assets/db973a3e-d8ce-4cae-ad51-a6521d5186c9" />

Session available:
<img width="2032" height="1162" alt="apex debugger session stopped" src="https://github.com/user-attachments/assets/ed9b94b7-f2d9-47da-940c-b7c29a245e4f" />