### PR TITLE
refactor(apex): replace fileOrFolderExists with services FsService in requirements - W-23348838

### DIFF
--- a/.claude/plans/W-23348838.md
+++ b/.claude/plans/W-23348838.md
@@ -1,0 +1,75 @@
+# W-23348838 — Replace fileOrFolderExists w/ services FsService (apex requirements.ts)
+
+## Context
+
+- 3 call sites, all `packages/salesforcedx-vscode-apex/src/requirements.ts`:
+  - `validateJavaInstallation` L57 `binDir`, L66 `binaryPath`
+  - `checkJavaRuntime` L108 `expandedHome`
+- Import to drop: `import { fileOrFolderExists } from '@salesforce/salesforcedx-utils-vscode'` (L11). Sole utils-vscode import in file.
+- Old impl (`salesforcedx-utils-vscode/src/helpers/fs.ts:45`): `fs.stat(URI.file(p))` try/catch → bool. **Never throws.**
+- Services equiv (`salesforcedx-vscode-services/src/vscode/fsService.ts:88`): `FsService.fileOrFolderExists` — Effect.fn, `.pipe(Effect.catchAll(() => Effect.succeed(false)))` ⇒ error channel `never` (stat failure ⇒ false, like old).
+- Access: `api = yield* (yield* ExtensionProviderService).getServicesApi` then `api.services.FsService.fileOrFolderExists(p)`. Run via `getRuntime().runPromise(...)`.
+  - `getRuntime` from `./services/runtime` (present). `ExtensionProviderService` from `@salesforce/effect-ext-utils`. `Effect` from `effect/Effect`. None yet imported in requirements.ts.
+  - Pattern refs: `languageServerOrphanHandler.ts:73`, `languageClientManager.ts:68-88`.
+- Apex declares `extensionDependencies: ["salesforce.salesforcedx-vscode-services"]` (package.json) ⇒ services always present when requirements runs.
+
+### New failure channel (must handle)
+
+- Only `getServicesApi` adds errors: `ServicesExtensionNotFoundError | InvalidServicesApiError` (`effect-ext-utils/src/extensionProvider.ts:17-18`). `FsService.fileOrFolderExists` itself = `never`.
+- Old fn never threw; `checkJavaRuntime` calls it via `await` inside `new Promise(async (resolve,reject)=>...)` executor (L108) — a throw there ⇒ unsettled Promise **hang** (executor rejection ignored). Preserve no-throw contract.
+- Fix: helper swallows both tags → `Effect.succeed(false)` (mirrors orphan-handler posture, `languageServerOrphanHandler.ts:133-140`). Unreachable in practice (hard dep); false ⇒ existing localized reject (`java_bin_missing` / `java_binary_missing` / `source_missing`) not a hang. Error channel ⇒ `never`, so `runPromise` never rejects.
+
+### Design (minimal; keep functions async)
+
+- Add module helper. Use `Effect.fn` (business-logic effect, single fresh helper per call — `.gen` is only for a shared effect w/ common `.pipe` across multiple consumers; peer refs all use `Effect.fn`: `findOrphanedProcesses` languageServerOrphanHandler.ts:71, `removeApexDbEffect` languageClientManager.ts:67, `activation` apex-log/src/index.ts:55). Span name required by eslint-local-rule `requireEffectFnSpanName`; also gets tracing free.
+  ```ts
+  const fileOrFolderExistsEffect = Effect.fn('requirements.fileOrFolderExists')(
+    function* (p: string) {
+      const api = yield* (yield* ExtensionProviderService).getServicesApi;
+      return yield* api.services.FsService.fileOrFolderExists(p);
+    }
+  );
+
+  const fileOrFolderExists = (p: string): Promise<boolean> =>
+    getRuntime().runPromise(
+      fileOrFolderExistsEffect(p).pipe(
+        Effect.catchTags({
+          ServicesExtensionNotFoundError: () => Effect.succeed(false),
+          InvalidServicesApiError: () => Effect.succeed(false)
+        })
+      )
+    );
+  ```
+- Thin `Promise` wrapper keeps same name ⇒ 3 call sites unchanged (`await fileOrFolderExists(x)`). No Effect conversion of the 3 async fns (findJavaHome-callback `new Promise` wrapper untouched — out of WI scope).
+
+## Phases
+
+### Phase 1 — swap utils-vscode fileOrFolderExists → FsService via local helper (1 commit)
+
+`src/requirements.ts`:
+- drop L11 utils-vscode import.
+- add imports: `ExtensionProviderService` (`@salesforce/effect-ext-utils`), `* as Effect` (`effect/Effect`), `getRuntime` (`./services/runtime`).
+- add helper above `resolveRequirements` (see Design): `fileOrFolderExistsEffect` (Effect.fn) + thin `fileOrFolderExists` Promise wrapper. 3 call sites unchanged.
+
+`test/jest/languageUtils/requirements.test.ts`:
+- utils-vscode mock (L18-41): remove `fileOrFolderExists: jest.fn()` (keep `LocalizationService`, `LOCALE_JA`).
+- drop `import { fileOrFolderExists }` (L8) + `(fileOrFolderExists as jest.Mock).mockResolvedValue(true)` (L106).
+- mock `../../../src/services/runtime`: `getRuntime` → `{ runPromise: (eff) => Effect.runPromise(eff.pipe(Effect.provideService(ExtensionProviderService, { getServicesApi: Effect.succeed({ services: { FsService: { fileOrFolderExists: () => Effect.succeed(true) } } }) }))) }`. (real getRuntime builds AllServicesLayer — unset in unit test → must mock.) Stub-api pattern: `languageServerOrphanHandler.test.ts:90-97`; runtime-mock pattern: `languageServer.test.ts:18-20`.
+- only `Should allow valid java runtime path outside the project` (L104) exercises fs → needs `true`. Other tests hit `checkJavaVersion` (no fs).
+
+Commit msg: `refactor(apex): replace fileOrFolderExists with services FsService in requirements - W-23348838`
+
+## Skills to apply
+
+- services-extension-consumption — getServicesApi / `api.services.FsService`, runtime vs provide, catchTags on extension errors, test stub
+- effect-best-practices — catchTags, error-channel `never`
+- typescript
+- verification
+
+## Verification
+
+- `npm run compile` (apex) — types; confirm helper error channel `never` (else runPromise reject type leaks).
+- `npm run lint` (apex) — no utils-vscode `fileOrFolderExists` residue, import order.
+- jest `requirements.test.ts` — valid-runtime path resolves (fs stub true); Java-version tests still green.
+- grep: 0 `fileOrFolderExists` from `@salesforce/salesforcedx-utils-vscode` in `src/requirements.ts`.
+- E2E covered on this branch: `test/playwright/specs/apexLsp.desktop.spec.ts:37` `waitForApexLspReady` needs the real LSP to start (real JVM) ⇒ `languageServer.ts:82 await requirements.resolveRequirements()` must succeed against real Java paths, exercising `checkJavaRuntime`/`validateJavaInstallation` and all 3 `fileOrFolderExists` call sites. Also `apexLspRestart`/`apexLspHover` specs (both call `waitForApexLspReady`). `.github/workflows/apexLspE2E.yml` triggers on `push: branches-ignore: [main, develop]` (no path filter) ⇒ runs on this feature branch. Confirm green before merge.

--- a/packages/salesforcedx-vscode-apex/src/requirements.ts
+++ b/packages/salesforcedx-vscode-apex/src/requirements.ts
@@ -31,21 +31,24 @@ type RequirementsData = {
   java_memory: number | null;
 };
 
-const fileOrFolderExistsEffect = Effect.fn('requirements.fileOrFolderExists')(function* (p: string) {
+const checkFileOrFolderExists = Effect.fn('requirements.fileOrFolderExists')(function* (p: string) {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   return yield* api.services.FsService.fileOrFolderExists(p);
 });
 
 // Thin Promise wrapper so the 3 call sites stay `await fileOrFolderExists(x)`. Swallows the two
-// getServicesApi tags → false (services is a hard extension dep, so unreachable in practice); error
-// channel resolves to never, keeping the old no-throw contract (a throw in checkJavaRuntime's Promise
-// executor would hang instead of reject).
+// getServicesApi tags → false (services is a hard extension dep, so unreachable in practice) but logs
+// a warning so a genuine outage is distinguishable from a legitimately-missing path; error channel
+// resolves to never, keeping the old no-throw contract (a throw in checkJavaRuntime's Promise executor
+// would hang instead of reject).
 const fileOrFolderExists = (p: string): Promise<boolean> =>
   getRuntime().runPromise(
-    fileOrFolderExistsEffect(p).pipe(
+    checkFileOrFolderExists(p).pipe(
       Effect.catchTags({
-        ServicesExtensionNotFoundError: () => Effect.succeed(false),
-        InvalidServicesApiError: () => Effect.succeed(false)
+        ServicesExtensionNotFoundError: e =>
+          Effect.logWarning('services extension unavailable for fileOrFolderExists', e).pipe(Effect.as(false)),
+        InvalidServicesApiError: e =>
+          Effect.logWarning('invalid services API for fileOrFolderExists', e).pipe(Effect.as(false))
       })
     )
   );

--- a/packages/salesforcedx-vscode-apex/src/requirements.ts
+++ b/packages/salesforcedx-vscode-apex/src/requirements.ts
@@ -8,7 +8,8 @@
 // From https://github.com/redhat-developer/vscode-java
 // Original version licensed under the Eclipse Public License (EPL)
 
-import { fileOrFolderExists } from '@salesforce/salesforcedx-utils-vscode';
+import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
+import * as Effect from 'effect/Effect';
 import { isString } from 'effect/Predicate';
 import * as cp from 'node:child_process';
 import { homedir } from 'node:os';
@@ -16,6 +17,7 @@ import * as path from 'node:path';
 import { workspace } from 'vscode';
 import { SET_JAVA_DOC_LINK } from './constants';
 import { nls } from './messages';
+import { getRuntime } from './services/runtime';
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -28,6 +30,25 @@ type RequirementsData = {
   java_home: string;
   java_memory: number | null;
 };
+
+const fileOrFolderExistsEffect = Effect.fn('requirements.fileOrFolderExists')(function* (p: string) {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  return yield* api.services.FsService.fileOrFolderExists(p);
+});
+
+// Thin Promise wrapper so the 3 call sites stay `await fileOrFolderExists(x)`. Swallows the two
+// getServicesApi tags → false (services is a hard extension dep, so unreachable in practice); error
+// channel resolves to never, keeping the old no-throw contract (a throw in checkJavaRuntime's Promise
+// executor would hang instead of reject).
+const fileOrFolderExists = (p: string): Promise<boolean> =>
+  getRuntime().runPromise(
+    fileOrFolderExistsEffect(p).pipe(
+      Effect.catchTags({
+        ServicesExtensionNotFoundError: () => Effect.succeed(false),
+        InvalidServicesApiError: () => Effect.succeed(false)
+      })
+    )
+  );
 
 /**
  * Resolves the requirements needed to run the extension.

--- a/packages/salesforcedx-vscode-apex/test/jest/languageUtils/requirements.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/languageUtils/requirements.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
+import { ExtensionProviderService, ServicesExtensionNotFoundError } from '@salesforce/effect-ext-utils';
 import * as Effect from 'effect/Effect';
 import { fail } from 'node:assert';
 import * as cp from 'node:child_process';
@@ -59,18 +59,26 @@ jest.mock('vscode', () => ({
   }
 }));
 
+// jest.fns so individual tests can reconfigure the false / error branches via mockReturnValue.
+const mockFileOrFolderExists = jest.fn((_p: string) => Effect.succeed(true));
+const succeedApi = (): ExtensionProviderService['getServicesApi'] =>
+  Effect.succeed({
+    services: { FsService: { fileOrFolderExists: mockFileOrFolderExists } }
+  }) as unknown as ExtensionProviderService['getServicesApi'];
+const mockGetServicesApi = jest.fn(succeedApi);
+
 // Mock the services runtime: real getRuntime builds AllServicesLayer (unset in unit tests), so run
-// effects against a stub ExtensionProviderService whose FsService.fileOrFolderExists always yields true.
+// effects against a stub ExtensionProviderService whose getServicesApi / FsService are jest.fns.
 jest.mock('../../../src/services/runtime', () => ({
   getRuntime: () => ({
-    runPromise: (eff: any) =>
+    runPromise: (eff: Effect.Effect<boolean, never, ExtensionProviderService>): Promise<boolean> =>
       Effect.runPromise(
         eff.pipe(
           Effect.provideService(ExtensionProviderService, {
-            getServicesApi: Effect.succeed({
-              services: { FsService: { fileOrFolderExists: () => Effect.succeed(true) } }
-            })
-          })
+            get getServicesApi() {
+              return mockGetServicesApi();
+            }
+          } as unknown as ExtensionProviderService)
         )
       )
   })
@@ -99,6 +107,8 @@ describe('Java Requirements Test', () => {
   let execFileSpy: jest.SpyInstance;
 
   beforeEach(() => {
+    mockFileOrFolderExists.mockReturnValue(Effect.succeed(true));
+    mockGetServicesApi.mockImplementation(succeedApi);
     getConfigMock = jest.fn();
     jest.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue({
       get: getConfigMock,
@@ -126,6 +136,34 @@ describe('Java Requirements Test', () => {
       });
       const requirements = await resolveRequirements();
       expect(requirements.java_home).toContain(jdk);
+    });
+
+    it('Should reject when the configured java home path does not exist', async () => {
+      getConfigMock.mockImplementation((key: string) => (key === JAVA_HOME_KEY ? runtimePath : undefined));
+      mockFileOrFolderExists.mockReturnValue(Effect.succeed(false));
+      try {
+        await resolveRequirements();
+        fail('Should have thrown when the java home path does not exist');
+      } catch (err) {
+        expect(err).toEqual(
+          nls.localize('source_missing_text', nls.localize('source_java_home_setting_text'), SET_JAVA_DOC_LINK)
+        );
+      }
+    });
+
+    it('Should treat a services-extension failure as a missing path (catchTags → false)', async () => {
+      getConfigMock.mockImplementation((key: string) => (key === JAVA_HOME_KEY ? runtimePath : undefined));
+      mockGetServicesApi.mockReturnValue(
+        Effect.fail(new ServicesExtensionNotFoundError()) as unknown as ExtensionProviderService['getServicesApi']
+      );
+      try {
+        await resolveRequirements();
+        fail('Should have rejected when the services extension is unavailable');
+      } catch (err) {
+        expect(err).toEqual(
+          nls.localize('source_missing_text', nls.localize('source_java_home_setting_text'), SET_JAVA_DOC_LINK)
+        );
+      }
     });
 
     it('Should not support Java 8', async () => {

--- a/packages/salesforcedx-vscode-apex/test/jest/languageUtils/requirements.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/languageUtils/requirements.test.ts
@@ -45,6 +45,9 @@ jest.mock('vscode', () => ({
   workspace: {
     getConfiguration: jest.fn()
   },
+  env: {
+    language: 'en'
+  },
   Position: class MockPosition {
     constructor(
       public line: number,

--- a/packages/salesforcedx-vscode-apex/test/jest/languageUtils/requirements.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/languageUtils/requirements.test.ts
@@ -5,7 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { fileOrFolderExists } from '@salesforce/salesforcedx-utils-vscode';
+import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
+import * as Effect from 'effect/Effect';
 import { fail } from 'node:assert';
 import * as cp from 'node:child_process';
 import * as path from 'node:path';
@@ -16,7 +17,6 @@ import { checkJavaVersion, JAVA_HOME_KEY, resolveRequirements } from '../../../s
 
 // Mock VS Code file utilities
 jest.mock('@salesforce/salesforcedx-utils-vscode', () => ({
-  fileOrFolderExists: jest.fn(),
   LocalizationService: {
     getInstance: jest.fn().mockReturnValue({
       messageBundleManager: {
@@ -57,6 +57,23 @@ jest.mock('vscode', () => ({
       public end: any
     ) {}
   }
+}));
+
+// Mock the services runtime: real getRuntime builds AllServicesLayer (unset in unit tests), so run
+// effects against a stub ExtensionProviderService whose FsService.fileOrFolderExists always yields true.
+jest.mock('../../../src/services/runtime', () => ({
+  getRuntime: () => ({
+    runPromise: (eff: any) =>
+      Effect.runPromise(
+        eff.pipe(
+          Effect.provideService(ExtensionProviderService, {
+            getServicesApi: Effect.succeed({
+              services: { FsService: { fileOrFolderExists: () => Effect.succeed(true) } }
+            })
+          })
+        )
+      )
+  })
 }));
 
 // Mock find-java-home module
@@ -103,7 +120,6 @@ describe('Java Requirements Test', () => {
   describe('Cross-platform tests', () => {
     it('Should allow valid java runtime path outside the project', async () => {
       getConfigMock.mockImplementation((key: string) => (key === JAVA_HOME_KEY ? runtimePath : undefined));
-      (fileOrFolderExists as jest.Mock).mockResolvedValue(true);
       execFileSpy.mockImplementation((...args) => {
         const cb = args.at(-1);
         cb('', '', 'java.version = 11.0.0');


### PR DESCRIPTION
## Summary
- Replaced `fileOrFolderExists` from `@salesforce/salesforcedx-utils-vscode` with `FsService.fileOrFolderExists` from the services extension (via `getServicesApi`), across all 3 call sites in `requirements.ts` (`validateJavaInstallation`, `checkJavaRuntime`).
- Added an `Effect.fn` helper + thin `Promise` wrapper preserving the old no-throw contract; extension-provider errors (`ServicesExtensionNotFoundError` / `InvalidServicesApiError`) are caught and mapped to `false`, matching the prior try/catch-based fs check.
- Updated `requirements.test.ts` to mock the services runtime instead of the utils-vscode fs helper, and added coverage for the missing-path and services-extension-failure branches.

## Plan
[.claude/plans/W-23348838.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23348838-8-replace-fileorfolderexists-with-servic/.claude/plans/W-23348838.md)

## Reviewer notes
- thermo (requirements.ts:43): emerging duplication of the `getServicesApi` + `catchTags(ServicesExtensionNotFoundError, InvalidServicesApiError)` → default-value Promise-bridge pattern across 3 apex sites (`requirements.ts`, `languageClientManager.ts:311-323`, `languageServerOrphanHandler.ts:132-141`). Not yet worth extracting; flag only so a 4th occurrence triggers a canonical `servicesOrDefault` helper. No code change.
- unit-test-critic (requirements.test.ts:19): file has 5 `jest.mock()` calls, crossing the 3+ testability-smell threshold. Suggested remedy is to inject the FS-existence check as a parameter into `checkJavaRuntime`/`validateJavaInstallation` rather than mocking the services runtime module. Partially mitigated (`FsService.fileOrFolderExists` + `getServicesApi` are now reconfigurable jest.fns), but the full DI refactor changes src function signatures and is left as an open design choice.

## Test plan
- [ ] Confirm `apexLspE2E` GitHub Actions workflow is green on this branch before merge — it exercises `resolveRequirements()` (and all 3 `fileOrFolderExists` call sites) against a real JVM via `waitForApexLspReady` (`apexLsp.desktop.spec.ts`, `apexLspRestart`, `apexLspHover`).

### What issues does this PR fix or reference?
@W-23348838@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002e9cBwYAI/view
