### PR TITLE
chore(effect): fix + enforce catchUnfailableEffect - W-23429452

### DIFF
--- a/.claude/plans/W-23429452.md
+++ b/.claude/plans/W-23429452.md
@@ -17,7 +17,7 @@
 - Sibling ratchet commits for style: W-23429468, W-23429451, W-23429441.
 
 ### alias.ts unsetAliases — caller/error-channel analysis (adversary:high)
-- **No production callers.** grep of `packages/**/src` for `unsetAliases`: only the `alias.ts` definition. `connectionService.ts` + `aliasFileWatcher.ts` call `getAliasesFromUsername`, not unset. `orgLogout.ts:31` is a *comment* documenting that core's `AuthRemover.removeAuth` internally calls its own `unsetConfigValues`/`unsetAliases` (node_modules/@salesforce/core authRemover.js) — it does NOT call `AliasService.unsetAliases`. So there is no org-logout flow that would surface an error from this method.
+- **No production callers.** grep of `packages/**/src` for `unsetAliases`: only the `alias.ts` definition. `connectionService.ts` + `aliasFileWatcher.ts` call `getAliasesFromUsername`, not unset. `orgLogout.ts:31` is a *comment* documenting that core's `AuthRemover.removeAuth` internally calls its own `unsetConfigValues`/`unsetAliases` (node_modules/@salesforce/core authRemover.js) — it does NOT call `AliasService.unsetAliases`. No org-logout flow surfaces an error here.
 - **Behavior unchanged — swallow stays live, external signature stays `Effect<void, never>`.** Contract is documented idempotent ("no-op if alias already removed"); keep swallowing. Do NOT invent a bespoke `AliasUnsetError` that is immediately discarded (dead ceremony, and would leave `unknownInEffectCatch` clean but adds an unused type). Use single-arg `Effect.tryPromise(() => sa.aliases.unsetAndSave(alias))` → failure channel becomes `UnknownException` (real channel → makes `catchAll` live, resolving the rule), then `.pipe(Effect.catchAll(() => Effect.void))` swallows it back to `never`.
 - **Error channel type:** `UnknownException` (from `Effect.tryPromise`), fully swallowed → external channel `never` (unchanged from today's `Effect.promise` version).
 - **Mocks/tests need NO change:** `connectionService.test.ts:60,271` + `aliasFileWatcher.test.ts:40` mock `unsetAliases: () => Effect.void`; external signature stays `Effect<void, never>` so these remain type-valid. Verify by compiling the services package (Phase 1 verify) — no mock edits expected.
@@ -50,6 +50,5 @@
 ## Verification
 - Per-package LS diagnostics (services, lwc): 0 `catchUnfailableEffect`.
 - `npm run check:effect-diagnostics` (gate) exits 0 with rule enforced.
-- Compile + unit tests for touched packages (services, lwc) — no runtime behavior change (dead branches / defect→typed). Confirms `unsetAliases: () => Effect.void` mocks (connectionService.test, aliasFileWatcher.test) still satisfy the `Effect<void, never>` signature (no mock edits).
-- `unsetAliases` behavior: swallow preserved (idempotent contract); external channel `never` unchanged, so no caller can newly surface an error — `unsetAliases` has zero production callers regardless.
-- No e2e coverage on branch for these paths, and none warranted: no product behavior changes (dead branches removed / defect→typed-then-swallowed), and `unsetAliases` is uncalled in src. Correctness = static (LS) + compile + existing unit tests.
+- Compile + unit tests for touched packages (services, lwc) — no runtime behavior change (dead branches / defect→typed). `unsetAliases` swallow/signature/caller analysis: see analysis section above (mocks stay valid, no edits).
+- No e2e needed: no behavior change (dead branches removed / defect→typed-then-swallowed), see analysis. Correctness via LS + compile + unit tests.

--- a/.claude/plans/W-23429452.md
+++ b/.claude/plans/W-23429452.md
@@ -1,0 +1,55 @@
+# W-23429452 — Fix + enforce catchUnfailableEffect
+
+## Context
+
+- Effect LS rule `catchUnfailableEffect`: catch branch on an Effect w/ no failure channel → dead code.
+- Ratchet lives in `config/effect-diagnostics.json` `enforcedRules` (script `scripts/effect-diagnostics.mjs`, wireit `check:effect-diagnostics`, CI `validatePR.yml`). Enforce = append rule name.
+- WI listed 8 sites; `testDiscovery.ts:61` now clean (0 findings, resolved by prior refactor f8813b887). 7 live sites verified via `npx effect-language-service diagnostics --file`:
+  - lwc/src/index.ts:150
+  - services/src/core/alias.ts:67
+  - services/src/observability/applicationInsightsNodeExporter.ts:93,116
+  - services/src/observability/applicationInsightsWebExporter.ts:71,102
+  - services/src/vscode/fileWatcherService.ts:28
+- OVERLAP: no custom eslint rule/skill; built-in LS rule + JSON ratchet. Confirmed.
+- Fix strategy per site:
+  - Dead catch on non-failing Effect → **remove catchAll**, use effect directly (fileWatcher `PubSub.publish`; exporter `getDefaultOrgRef→SubscriptionRef.get` at :116/:102; exporter `Effect.all(sendSpan)`/`Stream.runDrain` success-map keeps, FAILED branch dead → drop).
+  - Catch intended to swallow a real reject → convert `Effect.promise` → `Effect.tryPromise({try,catch})` so failure channel is real (lwc dynamic `import()`; alias `unsetAndSave`).
+- Sibling ratchet commits for style: W-23429468, W-23429451, W-23429441.
+
+### alias.ts unsetAliases — caller/error-channel analysis (adversary:high)
+- **No production callers.** grep of `packages/**/src` for `unsetAliases`: only the `alias.ts` definition. `connectionService.ts` + `aliasFileWatcher.ts` call `getAliasesFromUsername`, not unset. `orgLogout.ts:31` is a *comment* documenting that core's `AuthRemover.removeAuth` internally calls its own `unsetConfigValues`/`unsetAliases` (node_modules/@salesforce/core authRemover.js) — it does NOT call `AliasService.unsetAliases`. So there is no org-logout flow that would surface an error from this method.
+- **Behavior unchanged — swallow stays live, external signature stays `Effect<void, never>`.** Contract is documented idempotent ("no-op if alias already removed"); keep swallowing. Do NOT invent a bespoke `AliasUnsetError` that is immediately discarded (dead ceremony, and would leave `unknownInEffectCatch` clean but adds an unused type). Use single-arg `Effect.tryPromise(() => sa.aliases.unsetAndSave(alias))` → failure channel becomes `UnknownException` (real channel → makes `catchAll` live, resolving the rule), then `.pipe(Effect.catchAll(() => Effect.void))` swallows it back to `never`.
+- **Error channel type:** `UnknownException` (from `Effect.tryPromise`), fully swallowed → external channel `never` (unchanged from today's `Effect.promise` version).
+- **Mocks/tests need NO change:** `connectionService.test.ts:60,271` + `aliasFileWatcher.test.ts:40` mock `unsetAliases: () => Effect.void`; external signature stays `Effect<void, never>` so these remain type-valid. Verify by compiling the services package (Phase 1 verify) — no mock edits expected.
+
+## Phases
+
+### Phase 1 — fix services sites (6)
+- `applicationInsightsNodeExporter.ts` :93 remove dead `catchAll`+FAILED branch (Effect.all(sendSpan) can't fail) → keep SUCCESS map; :116 drop `catchAll(succeed defaults)`, yield ref directly.
+- `applicationInsightsWebExporter.ts` :71 same as node :93; :102 same as node :116.
+- `alias.ts` :67 `Effect.promise(unsetAndSave)`→single-arg `Effect.tryPromise(() => sa.aliases.unsetAndSave(alias))` (failure channel `UnknownException`) `.pipe(Effect.catchAll(() => Effect.void))` — idempotent swallow now live, external sig stays `Effect<void, never>`, no bespoke error type, no mock/caller changes (see analysis above).
+- `fileWatcherService.ts` :28 drop `catchAll(void)` on `PubSub.publish` (never fails).
+- Verify: `npx effect-language-service diagnostics --project packages/salesforcedx-vscode-services/tsconfig.json` → 0 `catchUnfailableEffect`.
+- Commit: `fix(services): resolve catchUnfailableEffect dead catches - W-23429452`
+
+### Phase 2 — fix lwc site (1)
+- `index.ts` :143 `Effect.promise(()=>import('./testSupport/index.js'))`→`Effect.tryPromise` (catch narrows to typed err) so load-fail `catchAll`→channel is live. Addresses adjacent `unknownInEffectCatch` if trivial.
+- Verify: LS `--file` → 0 `catchUnfailableEffect`.
+- Commit: `fix(lwc): typed tryPromise for lazy testSupport import - W-23429452`
+
+### Phase 3 — enforce ratchet
+- Append `"catchUnfailableEffect"` to `config/effect-diagnostics.json` enforcedRules.
+- Verify: `npm run check:effect-diagnostics` exits 0.
+- Commit: `chore(effect): enforce catchUnfailableEffect - W-23429452`
+
+## Skills to apply
+- effect-best-practices (catch sparingly, tryPromise vs promise, tagged errors)
+- typescript
+- verification
+
+## Verification
+- Per-package LS diagnostics (services, lwc): 0 `catchUnfailableEffect`.
+- `npm run check:effect-diagnostics` (gate) exits 0 with rule enforced.
+- Compile + unit tests for touched packages (services, lwc) — no runtime behavior change (dead branches / defect→typed). Confirms `unsetAliases: () => Effect.void` mocks (connectionService.test, aliasFileWatcher.test) still satisfy the `Effect<void, never>` signature (no mock edits).
+- `unsetAliases` behavior: swallow preserved (idempotent contract); external channel `never` unchanged, so no caller can newly surface an error — `unsetAliases` has zero production callers regardless.
+- No e2e coverage on branch for these paths, and none warranted: no product behavior changes (dead branches removed / defect→typed-then-swallowed), and `unsetAliases` is uncalled in src. Correctness = static (LS) + compile + existing unit tests.

--- a/config/effect-diagnostics.json
+++ b/config/effect-diagnostics.json
@@ -4,6 +4,7 @@
     "lazyPromiseInEffectSync",
     "runEffectInsideEffect",
     "globalErrorInEffectFailure",
-    "globalErrorInEffectCatch"
+    "globalErrorInEffectCatch",
+    "catchUnfailableEffect"
   ]
 }

--- a/packages/salesforcedx-vscode-lwc/src/index.ts
+++ b/packages/salesforcedx-vscode-lwc/src/index.ts
@@ -140,7 +140,7 @@ export const activateEffect = Effect.fn('activation:salesforcedx-vscode-lwc')(fu
 
   // Activate Test support (skip in web mode - test execution requires Node.js/terminal)
   if (process.env.ESBUILD_PLATFORM !== 'web') {
-    yield* Effect.promise(() => import('./testSupport/index.js')).pipe(
+    yield* Effect.tryPromise(() => import('./testSupport/index.js')).pipe(
       // Lazy load test support to avoid bundling jest-editor-support in web mode
       Effect.tap(testSupport =>
         testSupport.shouldActivateLwcTestSupport(workspaceType)

--- a/packages/salesforcedx-vscode-services/src/core/alias.ts
+++ b/packages/salesforcedx-vscode-services/src/core/alias.ts
@@ -64,7 +64,7 @@ export class AliasService extends Effect.Service<AliasService>()('AliasService',
       const sa = yield* Effect.promise(() => StateAggregator.getInstance());
       yield* Effect.forEach(
         aliases,
-        alias => Effect.tryPromise(() => sa.aliases.unsetAndSave(alias)).pipe(Effect.catchAll(() => Effect.void)),
+        alias => Effect.tryPromise(() => sa.aliases.unsetAndSave(alias)).pipe(Effect.ignore),
         { discard: true }
       );
     });

--- a/packages/salesforcedx-vscode-services/src/core/alias.ts
+++ b/packages/salesforcedx-vscode-services/src/core/alias.ts
@@ -64,7 +64,7 @@ export class AliasService extends Effect.Service<AliasService>()('AliasService',
       const sa = yield* Effect.promise(() => StateAggregator.getInstance());
       yield* Effect.forEach(
         aliases,
-        alias => Effect.promise(() => sa.aliases.unsetAndSave(alias)).pipe(Effect.catchAll(() => Effect.void)),
+        alias => Effect.tryPromise(() => sa.aliases.unsetAndSave(alias)).pipe(Effect.catchAll(() => Effect.void)),
         { discard: true }
       );
     });

--- a/packages/salesforcedx-vscode-services/src/observability/applicationInsightsNodeExporter.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/applicationInsightsNodeExporter.ts
@@ -89,12 +89,6 @@ export class ApplicationInsightsNodeExporter implements SpanExporter {
       Effect.all(validSpans.map(span => sendSpan(span, otelLogger))).pipe(
         Effect.map(() => {
           resultCallback({ code: ExportResultCode.SUCCESS });
-        }),
-        Effect.catchAll(error => {
-          console.error('ApplicationInsightsNodeExporter export failed:', error);
-          return Effect.sync(() => {
-            resultCallback({ code: ExportResultCode.FAILED });
-          });
         })
       )
     );
@@ -111,10 +105,7 @@ const sendSpan = Effect.fn('sendSpan')(function* (
 ) {
   const telemetryTag = workspace.getConfiguration()?.get<string>('salesforcedx-vscode-core.telemetry-tag');
 
-  const { userId, webUserId } = yield* getDefaultOrgRef().pipe(
-    Effect.flatMap(SubscriptionRef.get),
-    Effect.catchAll(() => Effect.succeed({ userId: undefined, webUserId: undefined }))
-  );
+  const { userId, webUserId } = yield* getDefaultOrgRef().pipe(Effect.flatMap(SubscriptionRef.get));
 
   const isError = span.status?.code === SpanStatusCode.ERROR;
 

--- a/packages/salesforcedx-vscode-services/src/observability/applicationInsightsWebExporter.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/applicationInsightsWebExporter.ts
@@ -67,15 +67,6 @@ export class ApplicationInsightsWebExporter implements SpanExporter {
         Stream.runDrain,
         Effect.map(() => {
           resultCallback({ code: ExportResultCode.SUCCESS });
-        }),
-        Effect.catchAll(error => {
-          console.error('ApplicationInsightsWebExporter export failed:', error);
-          return Effect.sync(() => {
-            resultCallback({
-              code: ExportResultCode.FAILED,
-              error: unknownToErrorCause(error).cause
-            });
-          });
         })
       )
     );
@@ -97,10 +88,7 @@ const exportSpan = Effect.fn('exportSpan')(function* (span: ReadableSpan) {
     parentID: span.parentSpanContext?.spanId
   };
 
-  const { userId, webUserId } = yield* getDefaultOrgRef().pipe(
-    Effect.flatMap(SubscriptionRef.get),
-    Effect.catchAll(() => Effect.succeed({ userId: undefined, webUserId: undefined }))
-  );
+  const { userId, webUserId } = yield* getDefaultOrgRef().pipe(Effect.flatMap(SubscriptionRef.get));
 
   const props = {
     ...convertAttributes(span.resource.attributes),

--- a/packages/salesforcedx-vscode-services/src/vscode/fileWatcherService.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/fileWatcherService.ts
@@ -25,7 +25,7 @@ export const FileWatcherLayer = Layer.scopedDiscard(
           watcher.onDidCreate(uri => emit.single({ type: 'create', uri }));
           watcher.onDidChange(uri => emit.single({ type: 'change', uri }));
           watcher.onDidDelete(uri => emit.single({ type: 'delete', uri }));
-        }).pipe(Stream.runForEach(event => PubSub.publish(pubsub, event).pipe(Effect.catchAll(() => Effect.void)))),
+        }).pipe(Stream.runForEach(event => PubSub.publish(pubsub, event))),
       watcher =>
         Effect.sync(() => {
           watcher.dispose();


### PR DESCRIPTION
### What does this PR do?

## Summary
- Fix all 6 remaining `catchUnfailableEffect` dead-catch findings in `services` and `lwc`: remove no-op `catchAll` on non-failing Effects, and convert `Effect.promise` → `Effect.tryPromise` where the catch swallows a real rejection (alias unset, lazy testSupport import).
- Enforce the `catchUnfailableEffect` rule in `config/effect-diagnostics.json` `enforcedRules` so CI's `validatePR` ratchet catches regressions going forward.
- No behavior change: dead branches removed, defects converted to typed+swallowed errors; external signatures unchanged.

## Plan
[.claude/plans/W-23429452.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23429452-6-fix-enforce-catchunfailableeffect-repo/.claude/plans/W-23429452.md)

### What issues does this PR fix or reference?
@W-23429452@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eeT6TYAU/view
