### PR TITLE
chore(deps): upgrade TypeScript 5.9.3 -> 6.0.3 - W-23356230

### DIFF
--- a/.claude/plans/W-23356230.md
+++ b/.claude/plans/W-23356230.md
@@ -1,0 +1,63 @@
+# W-23356230 — Upgrade TypeScript 5.9.3 → 6.0.3
+
+## Context
+- Monorepo-wide TS bump 5.9.3 → 6.0.3. No behavior change beyond TS6-forced.
+- ts-jest peer `>=4.3 <6` blocks TS6 install; 29.4.11 allows `>=4.3 <7`.
+- Prior runs applied deps/config cleanly but rolled back at gate on TS6-forced tooling errors. This plan folds in tooling fixes (items 4-6).
+- Current: root `ts-jest ^29.4.1` (line 110), `typescript 5.9.3` (line 113); visualforce-ls dep `typescript 5.9.3` (line 12); tsconfig.common `esModuleInterop: false` (line 12).
+- gh-action tsconfigs use `files:` (not `include`), each `outDir ./lib`, src under `src/`.
+- lwc-ls tsconfig: no rootDir; includes `jest/*.ts` + `typings/*.d.ts` outside src → TS5011 names `./jest` as common dir. `.` not `./src` (./src → TS6059). Mirrors sibling test-pkg convention.
+- Verified avail: typescript@6.0.3, ts-jest@29.4.11.
+
+## Phases
+
+### Phase 1 — ts-jest bump + verify install
+- root package.json: `ts-jest` `^29.4.1` → `29.4.11`.
+- `npm install` — confirm no peer conflict (TS still 5.9.3).
+- commit: `chore(deps): bump ts-jest to 29.4.11 for TS6 peer range - W-23356230`
+
+### Phase 2 — typescript bump both manifests + config
+- root package.json: `typescript` `5.9.3` → `6.0.3`.
+- packages/salesforcedx-visualforce-language-server/package.json dependencies: `typescript` `5.9.3` → `6.0.3` (runtime import src/modes/javascriptMode.ts:23; lockstep w/ root).
+- tsconfig.common.json compilerOptions: add `"ignoreDeprecations": "6.0"` (silences esModuleInterop:false TS6 deprecation; value unchanged).
+- `npm install` — confirm 6.0.3 in package-lock for root + visualforce-ls.
+- commit: `chore(deps): bump typescript to 6.0.3 + ignoreDeprecations - W-23356230`
+
+### Phase 3 — TS6-forced tooling + tsconfig fixes
+- root package.json wireit:
+  - `check:package-lock` command → `ts-node --project scripts/tsconfig.json scripts/package-lock.validation.ts`
+  - `check:actions` command → `ts-node --project scripts/tsconfig.json scripts/validateActions.ts`
+- scripts/tsconfig.json compilerOptions: add `"types": ["node"]`.
+  - (`--project` alone does NOT clear TS2591 on node builtins — verified empirically w/ typescript@6.0.3: `ts-node --project scripts/tsconfig.json scripts/package-lock.validation.ts` still throws `TS2591: Cannot find name 'node:assert'`. scripts/tsconfig.json extends bare `../tsconfig.json` (`{files:[],include:[]}`) so no `types` inherited; `@tsconfig/node22` (via tsconfig.common) not in its extends chain. Adding `"types": ["node"]` is what makes it pass.)
+- .github/actions/{new-issue,validate-issue,check-feature-request}/tsconfig.json compilerOptions: add `"rootDir": "./src"` (TS6 TS5011).
+- packages/salesforcedx-lwc-language-server/tsconfig.json compilerOptions: add `"rootDir": "."` (NOT ./src; test/jest/typings outside src).
+- commit: `fix(build): TS6 tooling + rootDir conformance - W-23356230`
+
+## Skills
+- typescript (TS6 error semantics)
+- packageJson (dep edits)
+- wireit (check:* command edits)
+- verification (gate discipline)
+
+## Verification (run in order, zero new errors each step)
+1. Phase 1: `npm install` — no peer dep error.
+2. Phase 2: `npm install` — 6.0.3 in package-lock for root + visualforce-ls.
+3. Per pkg: `npx tsc -p packages/<pkg>/tsconfig.json --noEmit` — 0 errors. Watch: aura-ls side-effect import ternServer.ts:35 (TS6 noUncheckedSideEffectImports); visualforce-ls typescript default-import.
+4. `npm run precommit` — clean.
+5. Full jest suite — 0 new failures. Confirm lwc-ls = 10/10 suites (item-6 gate; per-pkg tsc --noEmit will NOT surface, jest does).
+
+Not e2e-covered: all steps above are local gate/tsc/jest, not branch e2e. No e2e overlap.
+
+## Rollback
+- Items 4-6 (ts-node --project + scripts/tsconfig.json types:["node"], actions rootDir, lwc-ls rootDir) IN SCOPE — do NOT roll back.
+- Roll back only if NEW error needs beyond prescribed: any import-syntax change, esModuleInterop flip, OTHER packages/*/tsconfig edit, module/moduleResolution change, or file outside list below. Then STOP, revert all, comment WI w/ specific error(s).
+
+## Files expected to change
+- package.json (root) — ts-jest, typescript, check:package-lock + check:actions
+- scripts/tsconfig.json — add `"types": ["node"]`
+- package-lock.json — regenerated
+- packages/salesforcedx-visualforce-language-server/package.json — typescript
+- tsconfig.common.json — ignoreDeprecations
+- .github/actions/{new-issue,validate-issue,check-feature-request}/tsconfig.json — rootDir
+- packages/salesforcedx-lwc-language-server/tsconfig.json — rootDir=.
+- Nothing else.

--- a/.claude/plans/W-23356230.md
+++ b/.claude/plans/W-23356230.md
@@ -3,7 +3,7 @@
 ## Context
 - Monorepo-wide TS bump 5.9.3 → 6.0.3. No behavior change beyond TS6-forced.
 - ts-jest peer `>=4.3 <6` blocks TS6 install; 29.4.11 allows `>=4.3 <7`.
-- Prior runs applied deps/config cleanly but rolled back at gate on TS6-forced tooling errors. This plan folds in tooling fixes (items 4-6).
+- Prior runs: deps/config clean, rolled back at gate on TS6-forced tooling errors; folds in fixes (items 4-6).
 - Current: root `ts-jest ^29.4.1` (line 110), `typescript 5.9.3` (line 113); visualforce-ls dep `typescript 5.9.3` (line 12); tsconfig.common `esModuleInterop: false` (line 12).
 - gh-action tsconfigs use `files:` (not `include`), each `outDir ./lib`, src under `src/`.
 - lwc-ls tsconfig: no rootDir; includes `jest/*.ts` + `typings/*.d.ts` outside src → TS5011 names `./jest` as common dir. `.` not `./src` (./src → TS6059). Mirrors sibling test-pkg convention.
@@ -28,7 +28,7 @@
   - `check:package-lock` command → `ts-node --project scripts/tsconfig.json scripts/package-lock.validation.ts`
   - `check:actions` command → `ts-node --project scripts/tsconfig.json scripts/validateActions.ts`
 - scripts/tsconfig.json compilerOptions: add `"types": ["node"]`.
-  - (`--project` alone does NOT clear TS2591 on node builtins — verified empirically w/ typescript@6.0.3: `ts-node --project scripts/tsconfig.json scripts/package-lock.validation.ts` still throws `TS2591: Cannot find name 'node:assert'`. scripts/tsconfig.json extends bare `../tsconfig.json` (`{files:[],include:[]}`) so no `types` inherited; `@tsconfig/node22` (via tsconfig.common) not in its extends chain. Adding `"types": ["node"]` is what makes it pass.)
+  - (`--project` alone leaves TS2591 on node builtins w/ typescript@6.0.3 — scripts/tsconfig.json extends bare `../tsconfig.json` (`{files:[],include:[]}`), no `types` inherited; `types:[node]` fixes it.)
 - .github/actions/{new-issue,validate-issue,check-feature-request}/tsconfig.json compilerOptions: add `"rootDir": "./src"` (TS6 TS5011).
 - packages/salesforcedx-lwc-language-server/tsconfig.json compilerOptions: add `"rootDir": "."` (NOT ./src; test/jest/typings outside src).
 - commit: `fix(build): TS6 tooling + rootDir conformance - W-23356230`

--- a/.github/actions/check-feature-request/tsconfig.json
+++ b/.github/actions/check-feature-request/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../../tsconfig.common.json",
   "compilerOptions": {
     "outDir": "./lib",
+    "rootDir": "./src",
     // @actions/github@8 ships type declarations that deep-import `@octokit/core/dist-types/types`,
     // a subpath @octokit/core@7 no longer exposes via its `exports` map. Under moduleResolution Node16
     // this fails to resolve and collapses the Octokit type to `any`. Map it to the on-disk declaration.

--- a/.github/actions/new-issue/tsconfig.json
+++ b/.github/actions/new-issue/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../../tsconfig.common.json",
   "compilerOptions": {
     "outDir": "./lib",
+    "rootDir": "./src",
     // @actions/github@8 ships type declarations that deep-import `@octokit/core/dist-types/types`,
     // a subpath @octokit/core@7 no longer exposes via its `exports` map. Under moduleResolution Node16
     // this fails to resolve and collapses the Octokit type to `any`. Map it to the on-disk declaration.

--- a/.github/actions/validate-issue/tsconfig.json
+++ b/.github/actions/validate-issue/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../../tsconfig.common.json",
   "compilerOptions": {
     "outDir": "./lib",
+    "rootDir": "./src",
     "lib": [
       "ES2021"
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,7 +103,7 @@
         "shx": "0.4.0",
         "stream-http": "3.2.0",
         "timers-browserify": "2.0.12",
-        "ts-jest": "^29.4.1",
+        "ts-jest": "29.4.11",
         "ts-node": "10.9.2",
         "tsx": "4.22.4",
         "typescript": "5.9.3",
@@ -41741,19 +41741,19 @@
       "license": "Apache-2.0"
     },
     "node_modules/ts-jest": {
-      "version": "29.4.6",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
-      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+      "version": "29.4.11",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.3",
+        "semver": "^7.8.0",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -41770,7 +41770,7 @@
         "babel-jest": "^29.0.0 || ^30.0.0",
         "jest": "^29.0.0 || ^30.0.0",
         "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <6"
+        "typescript": ">=4.3 <7"
       },
       "peerDependenciesMeta": {
         "@babel/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,7 @@
         "ts-jest": "29.4.11",
         "ts-node": "10.9.2",
         "tsx": "4.22.4",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "typescript-eslint": "^8.62.0",
         "util": "0.12.5",
         "wireit": "^0.14.12",
@@ -17277,6 +17277,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dpdm/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/dpdm/node_modules/wrap-ansi": {
@@ -42197,9 +42211,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -44274,7 +44288,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/salesforcedx-visualforce-markup-language-server": "*",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "vscode-css-languageservice": "^6.3.7",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-protocol": "^3.17.5",

--- a/package.json
+++ b/package.json
@@ -351,7 +351,7 @@
       "output": []
     },
     "check:package-lock": {
-      "command": "ts-node scripts/package-lock.validation.ts",
+      "command": "ts-node --project scripts/tsconfig.json scripts/package-lock.validation.ts",
       "files": [
         "package-lock.json",
         "scripts/package-lock.validation.ts"
@@ -367,7 +367,7 @@
       "output": []
     },
     "check:actions": {
-      "command": "ts-node scripts/validateActions.ts",
+      "command": "ts-node --project scripts/tsconfig.json scripts/validateActions.ts",
       "files": [
         "scripts/validateActions.ts",
         "scripts/tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -354,7 +354,8 @@
       "command": "ts-node --project scripts/tsconfig.json scripts/package-lock.validation.ts",
       "files": [
         "package-lock.json",
-        "scripts/package-lock.validation.ts"
+        "scripts/package-lock.validation.ts",
+        "scripts/tsconfig.json"
       ],
       "output": []
     },

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "shx": "0.4.0",
     "stream-http": "3.2.0",
     "timers-browserify": "2.0.12",
-    "ts-jest": "^29.4.1",
+    "ts-jest": "29.4.11",
     "ts-node": "10.9.2",
     "tsx": "4.22.4",
     "typescript": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "ts-jest": "29.4.11",
     "ts-node": "10.9.2",
     "tsx": "4.22.4",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "typescript-eslint": "^8.62.0",
     "util": "0.12.5",
     "wireit": "^0.14.12",

--- a/packages/salesforcedx-lwc-language-server/tsconfig.json
+++ b/packages/salesforcedx-lwc-language-server/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.common.json",
   "compilerOptions": {
     "outDir": "./out",
-    "rootDir": ".",
     "esModuleInterop": true, // is needed because the code uses a default import from a CommonJS comment-parser module
     "strictNullChecks": true,
     "skipLibCheck": true

--- a/packages/salesforcedx-lwc-language-server/tsconfig.json
+++ b/packages/salesforcedx-lwc-language-server/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.common.json",
   "compilerOptions": {
     "outDir": "./out",
+    "rootDir": ".",
     "esModuleInterop": true, // is needed because the code uses a default import from a CommonJS comment-parser module
     "strictNullChecks": true,
     "skipLibCheck": true

--- a/packages/salesforcedx-visualforce-language-server/package.json
+++ b/packages/salesforcedx-visualforce-language-server/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@salesforce/salesforcedx-visualforce-markup-language-server": "*",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vscode-css-languageservice": "^6.3.7",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-protocol": "^3.17.5",

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -9,7 +9,8 @@
     "target": "ES2023",
     "module": "Node16",
     "moduleResolution": "Node16",
-    "lib": ["ES2023", "DOM"]
+    "lib": ["ES2023", "DOM"],
+    "types": ["node"]
   },
   "include": ["*.ts"]
 }

--- a/tsconfig.common.json
+++ b/tsconfig.common.json
@@ -10,6 +10,7 @@
     "module": "node16",
     "moduleResolution": "Node16",
     "esModuleInterop": false,
+    "ignoreDeprecations": "6.0",
     "resolveJsonModule": true,
     "sourceMap": true,
     "types": ["jest", "node"],


### PR DESCRIPTION
## Summary
- Bump TypeScript 5.9.3 -> 6.0.3 (root + visualforce-language-server) and ts-jest to 29.4.11 for the TS6 peer range.
- Add `ignoreDeprecations: "6.0"` to tsconfig.common.json to silence the forced `esModuleInterop: false` deprecation without changing behavior.
- Fix TS6-forced tooling errors: `types: ["node"]` on scripts/tsconfig.json, `rootDir` on GH action tsconfigs and salesforcedx-lwc-language-server tsconfig (TS5011).

## Plan
[.claude/plans/W-23356230.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23356230-upgrade-typescript-5-9-3-6-0-3-repo-forc/.claude/plans/W-23356230.md)

### What issues does this PR fix or reference?
@W-23356230@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eBpZPYA0/view
