### PR TITLE
feat(lint): steer instanceof Error to effect/Predicate isError - W-23416944

### DIFF
--- a/.claude/plans/W-23416944.md
+++ b/.claude/plans/W-23416944.md
@@ -10,16 +10,15 @@
 
 ### Mechanism: opt-in allowlist, NOT repo-wide-block + per-package opt-out
 
-Rejected the original per-package `no-restricted-syntax: off` approach. Audited every package in `package.json` `wireit.lint.dependencies` (31 pkgs) against `grep '"effect"' packages/*/package.json`: **13 linted packages lack an `effect` dep** (`salesforcedx-utils`, `salesforcedx-vscode-i18n`, `soql-common`, `soql-model`, `salesforcedx-apex`, `salesforcedx-apex-debugger`, `salesforcedx-apex-replay-debugger`, `salesforcedx-visualforce-markup-language-server`, `salesforcedx-visualforce-language-server`, `playwright-vscode-ext`, `salesforcedx-aura-language-server`, `salesforcedx-lwc-language-server`, `eslint-local-rules`). An opt-out list must name all 13 (plus stay in sync as packages are added) or it silently breaks lint pointing at an unimportable `effect/Predicate` API.
-
-Opt-in is correct and fails safe: apply the rule ONLY to effect-enabled packages via a dedicated `files:` block. Forgetting to add a new effect package = a missed lint (harmless); a repo-wide rule forgetting a non-effect package = broken lint (harmful). This satisfies the WI criterion by construction, not by an enumerated exclusion.
+- rejected per-package `no-restricted-syntax: off` opt-out. audit of `wireit.lint.dependencies` (31 pkgs) vs `grep '"effect"' packages/*/package.json` → **13 linted pkgs lack `effect`** (`salesforcedx-utils`, `salesforcedx-vscode-i18n`, `soql-common`, `soql-model`, `salesforcedx-apex`, `salesforcedx-apex-debugger`, `salesforcedx-apex-replay-debugger`, `salesforcedx-visualforce-markup-language-server`, `salesforcedx-visualforce-language-server`, `playwright-vscode-ext`, `salesforcedx-aura-language-server`, `salesforcedx-lwc-language-server`, `eslint-local-rules`). opt-out list must enumerate all 13 + stay synced or lint silently breaks pointing at unimportable `effect/Predicate`.
+- opt-in fails safe: rule applies ONLY to effect pkgs via dedicated `files:` block. missed new effect pkg = missed lint (harmless); repo-wide rule missing a non-effect pkg = broken lint (harmful). satisfies WI criterion by construction, not enumerated exclusion.
 
 **Effect-enabled packages (19, verified via grep — the allowlist):**
 `effect-ext-utils`, `salesforcedx-lightning-lsp-common`, `salesforcedx-utils-vscode`, `salesforcedx-vscode-apex`, `salesforcedx-vscode-apex-debugger`, `salesforcedx-vscode-apex-log`, `salesforcedx-vscode-apex-oas`, `salesforcedx-vscode-apex-replay-debugger`, `salesforcedx-vscode-apex-testing`, `salesforcedx-vscode-core`, `salesforcedx-vscode-lightning`, `salesforcedx-vscode-lwc`, `salesforcedx-vscode-metadata`, `salesforcedx-vscode-org`, `salesforcedx-vscode-org-browser`, `salesforcedx-vscode-services`, `salesforcedx-vscode-services-types`, `salesforcedx-vscode-soql`, `salesforcedx-vscode-visualforce`.
 
 ### Preserving the existing `process.hrtime` guard
 
-`no-restricted-syntax` already exists once (`eslint.config.mjs:502`, base `**/*.ts` block, `process.hrtime` entry). Flat-config replaces the whole rule array per matching object (does NOT merge array elements) — so a second block re-specifying `no-restricted-syntax` for effect pkgs would drop `process.hrtime` there unless it repeats that entry.
+- flat-config replaces rule array per block (no merge). `no-restricted-syntax` already at `eslint.config.mjs:502` (base `**/*.ts`, `process.hrtime`) — 2nd block for effect pkgs would drop `process.hrtime` unless it repeats that entry.
 
 Solution (no duplication, no regression): hoist both selectors to shared `const`s at top of `eslint.config.mjs`:
 - `const noHrtime = { selector: "MemberExpression[object.name='process'][property.name='hrtime']", message: '…performance.now()…' }`
@@ -28,13 +27,13 @@ Solution (no duplication, no regression): hoist both selectors to shared `const`
 - base `**/*.ts` block (`:502`): `'no-restricted-syntax': ['error', noHrtime]` (unchanged behavior — hrtime stays repo-wide, incl. non-effect pkgs and all test files)
 - new opt-in block (effect pkgs): `'no-restricted-syntax': ['error', noHrtime, noInstanceofError]`
 
-Net: `process.hrtime` guard preserved everywhere (the original plan silently dropped it for 4 pkgs — that regression is gone). `instanceof Error` guarded only in effect-pkg non-test src.
+- net: `process.hrtime` guarded everywhere; `instanceof Error` guarded only in effect-pkg non-test src.
 
 ### Test-file exemption via `ignores`, not extra off-blocks
 
 The opt-in block's `ignores` excludes tests, so `isError` never fires in tests and hrtime (inherited from base block) is untouched. No edits to the existing test blocks needed. `ignores`:
 `packages/**/test/**/*.ts`, `packages/**/__tests__/**/*.ts`, `packages/**/*.spec.ts`, `packages/**/*.test.ts`, `packages/**/playwright*.ts`.
-Verified this covers the effect-pkg test hits (apex-testing `test/jest/**`, vscode-org `test/jest/**`). Non-effect-pkg test hit (lwc-language-server) is outside the allowlist entirely.
+- covers effect-pkg test hits (apex-testing, vscode-org `test/jest/**`); lwc-language-server hit already excluded (no effect dep).
 
 ### Hits to fix (effect-enabled, non-test, would break)
 

--- a/.claude/plans/W-23416944.md
+++ b/.claude/plans/W-23416944.md
@@ -1,0 +1,77 @@
+# W-23416944: ESLint rule — steer `instanceof Error` → `isError` (effect/Predicate)
+
+## Context
+
+- Follow-up to PR #7744 (W-23358835): migrated ~65 `x instanceof Error` → `isError(x)` from `effect/Predicate`.
+- Goal: `no-restricted-syntax` entry steering new code to predicate.
+- WI binding criterion: **rule must NOT apply to packages without an `effect` dependency** (`isError` unimportable there).
+- Selector: `BinaryExpression[operator='instanceof'][right.name='Error']`. Verified: matches `error instanceof Error`; does NOT match `x instanceof ErrorNode` (soql-model, no effect dep anyway) — no false positive.
+- Severity `error`. Message: `Use isError(x) from 'effect/Predicate' instead of x instanceof Error.`
+
+### Mechanism: opt-in allowlist, NOT repo-wide-block + per-package opt-out
+
+Rejected the original per-package `no-restricted-syntax: off` approach. Audited every package in `package.json` `wireit.lint.dependencies` (31 pkgs) against `grep '"effect"' packages/*/package.json`: **13 linted packages lack an `effect` dep** (`salesforcedx-utils`, `salesforcedx-vscode-i18n`, `soql-common`, `soql-model`, `salesforcedx-apex`, `salesforcedx-apex-debugger`, `salesforcedx-apex-replay-debugger`, `salesforcedx-visualforce-markup-language-server`, `salesforcedx-visualforce-language-server`, `playwright-vscode-ext`, `salesforcedx-aura-language-server`, `salesforcedx-lwc-language-server`, `eslint-local-rules`). An opt-out list must name all 13 (plus stay in sync as packages are added) or it silently breaks lint pointing at an unimportable `effect/Predicate` API.
+
+Opt-in is correct and fails safe: apply the rule ONLY to effect-enabled packages via a dedicated `files:` block. Forgetting to add a new effect package = a missed lint (harmless); a repo-wide rule forgetting a non-effect package = broken lint (harmful). This satisfies the WI criterion by construction, not by an enumerated exclusion.
+
+**Effect-enabled packages (19, verified via grep — the allowlist):**
+`effect-ext-utils`, `salesforcedx-lightning-lsp-common`, `salesforcedx-utils-vscode`, `salesforcedx-vscode-apex`, `salesforcedx-vscode-apex-debugger`, `salesforcedx-vscode-apex-log`, `salesforcedx-vscode-apex-oas`, `salesforcedx-vscode-apex-replay-debugger`, `salesforcedx-vscode-apex-testing`, `salesforcedx-vscode-core`, `salesforcedx-vscode-lightning`, `salesforcedx-vscode-lwc`, `salesforcedx-vscode-metadata`, `salesforcedx-vscode-org`, `salesforcedx-vscode-org-browser`, `salesforcedx-vscode-services`, `salesforcedx-vscode-services-types`, `salesforcedx-vscode-soql`, `salesforcedx-vscode-visualforce`.
+
+### Preserving the existing `process.hrtime` guard
+
+`no-restricted-syntax` already exists once (`eslint.config.mjs:502`, base `**/*.ts` block, `process.hrtime` entry). Flat-config replaces the whole rule array per matching object (does NOT merge array elements) — so a second block re-specifying `no-restricted-syntax` for effect pkgs would drop `process.hrtime` there unless it repeats that entry.
+
+Solution (no duplication, no regression): hoist both selectors to shared `const`s at top of `eslint.config.mjs`:
+- `const noHrtime = { selector: "MemberExpression[object.name='process'][property.name='hrtime']", message: '…performance.now()…' }`
+- `const noInstanceofError = { selector: "BinaryExpression[operator='instanceof'][right.name='Error']", message: "Use isError(x) from 'effect/Predicate' instead of x instanceof Error." }`
+
+- base `**/*.ts` block (`:502`): `'no-restricted-syntax': ['error', noHrtime]` (unchanged behavior — hrtime stays repo-wide, incl. non-effect pkgs and all test files)
+- new opt-in block (effect pkgs): `'no-restricted-syntax': ['error', noHrtime, noInstanceofError]`
+
+Net: `process.hrtime` guard preserved everywhere (the original plan silently dropped it for 4 pkgs — that regression is gone). `instanceof Error` guarded only in effect-pkg non-test src.
+
+### Test-file exemption via `ignores`, not extra off-blocks
+
+The opt-in block's `ignores` excludes tests, so `isError` never fires in tests and hrtime (inherited from base block) is untouched. No edits to the existing test blocks needed. `ignores`:
+`packages/**/test/**/*.ts`, `packages/**/__tests__/**/*.ts`, `packages/**/*.spec.ts`, `packages/**/*.test.ts`, `packages/**/playwright*.ts`.
+Verified this covers the effect-pkg test hits (apex-testing `test/jest/**`, vscode-org `test/jest/**`). Non-effect-pkg test hit (lwc-language-server) is outside the allowlist entirely.
+
+### Hits to fix (effect-enabled, non-test, would break)
+
+Only 3 files (all effect pkgs, non-test) — the other `instanceof Error` hits fall in non-effect packages (auto-exempt by allowlist) or `.js`/test files:
+- `salesforcedx-vscode-services/src/observability/o11ySpanExporter.ts:194` — already imports `{ isString }` from `effect/Predicate`; add `isError` (alphabetize `{ isError, isString }`).
+- `salesforcedx-vscode-apex-replay-debugger/src/services/heapDumpOverlayFetch.ts:43` — add `import { isError } from 'effect/Predicate'`.
+- `salesforcedx-vscode-services/scripts/o11yDebugServer.ts:73,91` — in effect-pkg glob (`salesforcedx-vscode-services/**/*.ts`), not in test ignores; add import + fix both.
+
+Pattern: `error instanceof Error ? …` → `isError(error) ? …`.
+
+Non-hits confirmed exempt: `playwright-vscode-ext`, `salesforcedx-apex-debugger`, `salesforcedx-aura-language-server`, `salesforcedx-lwc-language-server` (no effect dep → not in allowlist); `soql-model` `instanceof ErrorNode` (selector mismatch + no effect dep); `salesforcedx-vscode-lightning/.../Logger.js` (`.js`, base block is `**/*.ts`).
+
+## Phases
+
+### Phase 1 (single commit): add shared consts, opt-in rule block, fix hits
+
+commit msg: `feat(lint): steer instanceof Error to effect/Predicate isError - W-23416944`
+
+- `eslint.config.mjs`:
+  - hoist `noHrtime` + `noInstanceofError` consts near top (after existing top-level consts ~`:34`)
+  - base `**/*.ts` block (`:502`): reference `['error', noHrtime]`
+  - add new opt-in config object (place after the base block) with `files:` = 19 effect pkgs (`packages/<pkg>/**/*.ts`), `ignores:` = test globs above, `rules: { 'no-restricted-syntax': ['error', noHrtime, noInstanceofError] }`
+- fix 3 files → `isError`, add/extend `effect/Predicate` imports (alphabetize named imports)
+
+## Skills
+
+- effect-best-practices (isError predicate)
+- typescript (editing .ts files, import ordering)
+- packageJson (effect-dep audit — done: 19 effect pkgs, 13 non-effect linted pkgs)
+- verification (lint gate)
+
+## Verification
+
+- `npm run lint` clean against develop (WI acceptance gate; lint-only, not e2e-covered)
+- spot-checks (prove opt-in scoping + no regression):
+  1. scratch `x instanceof Error` in an effect pkg `src/` → `npx eslint` errors
+  2. same in a non-effect pkg (e.g. `salesforcedx-apex/src`) → clean (no unimportable-API error)
+  3. same in an effect pkg `test/` file → clean (ignored)
+  4. scratch `process.hrtime()` in a non-effect pkg → still errors (guard preserved, no regression)
+- no runtime/e2e impact (lint-only + trivial predicate swap)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,6 +39,8 @@ const noHrtime = {
   message: 'Do not use process.hrtime(). Use globalThis.performance.now() instead.'
 };
 const noInstanceofError = {
+  // keys on the bare identifier `Error`: assumes the global; won't match `ns.Error`
+  // (MemberExpression) and would also fire on a locally-named `Error` — accepted for a nudge.
   selector: "BinaryExpression[operator='instanceof'][right.name='Error']",
   message: "Use isError(x) from 'effect/Predicate' instead of x instanceof Error."
 };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,6 +34,15 @@ const localPlugin = { processors: localProcessors, rules: localRules };
 
 const currentYear = new Date().getFullYear();
 
+const noHrtime = {
+  selector: "MemberExpression[object.name='process'][property.name='hrtime']",
+  message: 'Do not use process.hrtime(). Use globalThis.performance.now() instead.'
+};
+const noInstanceofError = {
+  selector: "BinaryExpression[operator='instanceof'][right.name='Error']",
+  message: "Use isError(x) from 'effect/Predicate' instead of x instanceof Error."
+};
+
 export default [
   {
     ignores: [
@@ -499,13 +508,7 @@ export default [
       'no-invalid-this': 'off',
       'no-new-wrappers': 'error',
       'no-param-reassign': 'error',
-      'no-restricted-syntax': [
-        'error',
-        {
-          selector: "MemberExpression[object.name='process'][property.name='hrtime']",
-          message: 'Do not use process.hrtime(). Use globalThis.performance.now() instead.'
-        }
-      ],
+      'no-restricted-syntax': ['error', noHrtime],
       'no-shadow': 'off',
       'no-self-assign': 'error',
       'no-self-compare': 'error',
@@ -542,6 +545,43 @@ export default [
       ],
       'use-isnan': 'error',
       'valid-typeof': 'off'
+    }
+  },
+  {
+    // Opt-in: steer `x instanceof Error` to isError(x) from effect/Predicate.
+    // Scoped to effect-enabled packages only — non-effect packages can't import
+    // effect/Predicate, so applying it there would point at an unimportable API.
+    files: [
+      'packages/effect-ext-utils/**/*.ts',
+      'packages/salesforcedx-lightning-lsp-common/**/*.ts',
+      'packages/salesforcedx-utils-vscode/**/*.ts',
+      'packages/salesforcedx-vscode-apex/**/*.ts',
+      'packages/salesforcedx-vscode-apex-debugger/**/*.ts',
+      'packages/salesforcedx-vscode-apex-log/**/*.ts',
+      'packages/salesforcedx-vscode-apex-oas/**/*.ts',
+      'packages/salesforcedx-vscode-apex-replay-debugger/**/*.ts',
+      'packages/salesforcedx-vscode-apex-testing/**/*.ts',
+      'packages/salesforcedx-vscode-core/**/*.ts',
+      'packages/salesforcedx-vscode-lightning/**/*.ts',
+      'packages/salesforcedx-vscode-lwc/**/*.ts',
+      'packages/salesforcedx-vscode-metadata/**/*.ts',
+      'packages/salesforcedx-vscode-org/**/*.ts',
+      'packages/salesforcedx-vscode-org-browser/**/*.ts',
+      'packages/salesforcedx-vscode-services/**/*.ts',
+      'packages/salesforcedx-vscode-services-types/**/*.ts',
+      'packages/salesforcedx-vscode-soql/**/*.ts',
+      'packages/salesforcedx-vscode-visualforce/**/*.ts'
+    ],
+    ignores: [
+      'packages/**/test/**/*.ts',
+      'packages/**/__tests__/**/*.ts',
+      'packages/**/*.spec.ts',
+      'packages/**/*.test.ts',
+      'packages/**/playwright*.ts'
+    ],
+    rules: {
+      // repeat noHrtime: flat config replaces the whole array, so re-specify to keep the hrtime guard
+      'no-restricted-syntax': ['error', noHrtime, noInstanceofError]
     }
   },
   {

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/services/heapDumpOverlayFetch.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/services/heapDumpOverlayFetch.ts
@@ -16,6 +16,7 @@ import * as Arr from 'effect/Array';
 import * as Chunk from 'effect/Chunk';
 import * as Effect from 'effect/Effect';
 import { pipe } from 'effect/Function';
+import { isError } from 'effect/Predicate';
 import * as S from 'effect/Schema';
 import * as Stream from 'effect/Stream';
 
@@ -40,7 +41,7 @@ const runOverlayQuery = Effect.fn('heapDumpOverlayFetch.runOverlayQuery')(functi
     catch: error =>
       new HeapDumpOverlayFetchError({
         cause: error,
-        message: `Failed to fetch heap dump overlay results: ${error instanceof Error ? error.message : String(error)}`
+        message: `Failed to fetch heap dump overlay results: ${isError(error) ? error.message : String(error)}`
       })
   });
   const byId = new Map(result.records.map(record => [record.Id, record]));

--- a/packages/salesforcedx-vscode-services/scripts/o11yDebugServer.ts
+++ b/packages/salesforcedx-vscode-services/scripts/o11yDebugServer.ts
@@ -6,6 +6,7 @@
  */
 
 import * as Effect from 'effect/Effect';
+import { isError } from 'effect/Predicate';
 import * as http from 'node:http';
 
 const PORT = 3002;
@@ -70,7 +71,7 @@ const extractJsonObjects = (str: string): string[] => {
 const parseBody = (body: string) =>
   Effect.try({
     try: () => JSON.parse(body),
-    catch: error => (error instanceof Error ? error : new Error(String(error)))
+    catch: error => (isError(error) ? error : new Error(String(error)))
   }).pipe(
     Effect.flatMap(parsed => {
       if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
@@ -88,7 +89,7 @@ const decodeBase64Env = (base64Env: string) =>
       const asString = decoded.toString('utf-8');
       return extractJsonObjects(asString);
     },
-    catch: error => (error instanceof Error ? error : new Error(String(error)))
+    catch: error => (isError(error) ? error : new Error(String(error)))
   });
 
 const logRequest = (method: string | undefined, url: string | undefined, headers: http.IncomingHttpHeaders): void => {

--- a/packages/salesforcedx-vscode-services/src/observability/o11ySpanExporter.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/o11ySpanExporter.ts
@@ -9,7 +9,7 @@ import { ExportResult, ExportResultCode } from '@opentelemetry/core';
 import { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
 import { O11yService } from '@salesforce/o11y-reporter';
 import * as Effect from 'effect/Effect';
-import { isString } from 'effect/Predicate';
+import { isError, isString } from 'effect/Predicate';
 import * as SubscriptionRef from 'effect/SubscriptionRef';
 import { ConnectionService } from '../core/connectionService';
 import { getDefaultOrgRef } from '../core/defaultOrgRef';
@@ -191,7 +191,7 @@ export class O11ySpanExporter implements SpanExporter {
       console.error('O11ySpanExporter local divert failed:', error);
       resultCallback({
         code: ExportResultCode.FAILED,
-        error: error instanceof Error ? error : new Error(String(error))
+        error: isError(error) ? error : new Error(String(error))
       });
     }
   }


### PR DESCRIPTION
### What does this PR do?

## Summary
- Adds a `no-restricted-syntax` block that steers `x instanceof Error` to `isError(x)` from `effect/Predicate`, scoped opt-in to the 19 packages with an `effect` dependency (fail-safe: a missed effect pkg is a missed lint, not a broken one).
- Preserves the existing repo-wide `process.hrtime` guard by hoisting both selectors to shared consts, avoiding flat-config block-replacement dropping it.
- Fixes the 3 non-test hits in effect packages (`o11ySpanExporter.ts`, `heapDumpOverlayFetch.ts`, `o11yDebugServer.ts`) to use `isError`.

## Plan
[.claude/plans/W-23416944.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23416944-add-eslint-rule-steer-instanceof-error-t/.claude/plans/W-23416944.md)

## Reviewer notes
- `eslint.config.mjs:554` — the 19-package effect allowlist is hardcoded rather than derived from `package.json` effect deps at config-eval time. Deliberate: hardcoded enumeration is fail-safe (missed effect pkg = missed lint, harmless); deriving via fs was rejected as fail-closed (broken lint on drift).
- `eslint.config.mjs:728` — two independently-maintained "effect packages" lists now coexist (new instanceof block, 19 pkgs, blanket globs; pre-existing Effect-specific block, 9 pkgs with intentionally narrower globs, e.g. lightning scoped to `src/services` + `src/commands`). Collapsing to one source requires reconciling deliberately-different glob scopes — a design decision, not a mechanical edit.

## Test plan
Manual scoping spot-checks (rule correctness not exercised by the existing lint pass over unchanged code):
- [ ] scratch `x instanceof Error` in an effect pkg `src/` file → `npx eslint` errors
- [ ] same in a non-effect pkg (e.g. `salesforcedx-apex/src`) → clean (no unimportable-API error)
- [ ] same in an effect pkg `test/` file → clean (ignored)
- [ ] scratch `process.hrtime()` in a non-effect pkg → still errors (guard preserved, no regression)

### What issues does this PR fix or reference?
@W-23416944@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002ea9IVYAY/view
