### PR TITLE
docs(skills): require --paginate for dependabot-alerts listing

### DIFF
--- a/.claude/skills/dependabot-alerts/SKILL.md
+++ b/.claude/skills/dependabot-alerts/SKILL.md
@@ -16,7 +16,7 @@ Triage open Dependabot **security alerts** into GUS work items. Output is **work
 
 ## Input
 
-- Bare invocation → list open alerts: `gh api repos/forcedotcom/salesforcedx-vscode/dependabot/alerts --jq '[.[] | select(.state=="open")]'`
+- Bare invocation → list open alerts: `gh api repos/forcedotcom/salesforcedx-vscode/dependabot/alerts --paginate --jq '[.[] | select(.state=="open")]' | jq -s add`. **`--paginate` is required** — the API defaults to 30/page and silently returns only page 1 without it (e.g. 33 open alerts, not the ~14 page 1 shows).
 - User-specified package / GHSA / CVE → act on that alert only.
 
 (Repo is a monorepo, workspaces `packages/*`. npm 11.)


### PR DESCRIPTION
## Summary
- The `/dependabot-alerts` skill's bare-invocation `gh api` call had no `--paginate`, so it silently returned only page 1 (30 items) of the alerts list.
- Just hit this live: repo has 33 open alerts, first query showed 14.

## Test plan
- Docs-only change; no code paths affected.
- Ran the updated command against forcedotcom/salesforcedx-vscode and confirmed it returns all 33 open alerts vs. 14 without `--paginate`.