### PR TITLE
chore(extensions): remove salesforcedx-vscode-media from Expanded pack - W-23527832

### DIFF
--- a/packages/salesforcedx-vscode-expanded/package.json
+++ b/packages/salesforcedx-vscode-expanded/package.json
@@ -60,7 +60,6 @@
     "salesforce.salesforcedx-vscode-org-browser",
     "salesforce.salesforcedx-vscode-visualforce",
     "salesforce.salesforcedx-vscode-lwc",
-    "salesforce.salesforcedx-vscode-media",
     "salesforce.salesforcedx-vscode-metadata",
     "salesforce.salesforcedx-vscode-soql",
     "salesforce.salesforcedx-vscode-services",


### PR DESCRIPTION
### What does this PR do?

Removes `salesforce.salesforcedx-vscode-media` from the `extensionPack` array in the Salesforce Extension Pack (Expanded).

The extension's Marketplace page returns HTTP 404 — it is unlisted/deprecated — so bundling it in the Expanded pack references an install target that no longer exists.

### What issues does this PR fix or reference?

@W-23527832@
