### PR TITLE
docs(external-consumers): correct einstein-gpt consumer status

### DIFF
--- a/.claude/skills/external-consumers/SKILL.md
+++ b/.claude/skills/external-consumers/SKILL.md
@@ -34,6 +34,20 @@ gh api -X GET "search/code?q=SYMBOL+org:salesforcecli&per_page=30" \
 
 Rate limit ~30 req/min on search API. Use contents API for targeted reads.
 
+### ⚠️ Code search only indexes the DEFAULT branch
+
+`search/code` never sees non-default branches ([GitHub docs](https://docs.github.com/en/search-github/github-code-search/about-github-code-search)). A repo whose shipping extension lives on a release branch (see einstein-gpt below) returns **zero hits** even when it heavily consumes core. Zero search hits ≠ no consumer. Confirm a repo's shipping branch (check `.github/workflows/*release*.yml` for the `ref:` it checks out), then walk that branch's tree + read files directly:
+
+```bash
+# find the ref the release workflow builds from
+gh api repos/forcedotcom/REPO/contents/.github/workflows --jq '.[].name'
+gh api "repos/forcedotcom/REPO/contents/.github/workflows/RELEASE.yml" --jq '.content' | base64 -d | grep -n 'ref:'
+
+# list a non-default branch's files, then read the ones you care about
+gh api "repos/forcedotcom/REPO/git/trees/BRANCH?recursive=1" --jq '.tree[].path'
+gh api "repos/forcedotcom/REPO/contents/PATH?ref=BRANCH" --jq '.content' | base64 -d
+```
+
 ## Direct core API consumers (`SalesforceVSCodeCoreApi`)
 
 Via `vscode.extensions.getExtension('salesforce.salesforcedx-vscode-core').exports`:
@@ -43,6 +57,9 @@ Via `vscode.extensions.getExtension('salesforce.salesforcedx-vscode-core').expor
 | [vscode-agents](https://github.com/forcedotcom/vscode-agents) | Public | `services.{ChannelService,TelemetryService,WorkspaceContext}` |
 | [metadata-visualizer](https://github.com/forcedotcom/salesforce-metadata-visualizer) | **Private** | `services.TelemetryService` |
 | [code-analyzer](https://github.com/forcedotcom/sfdx-code-analyzer-vscode) | Public | `services.WorkspaceContext` (direct), telemetry via service-provider |
+| [einstein-gpt](https://github.com/forcedotcom/salesforcedx-vscode-einstein-gpt) (Agentforce Vibes Autocomplete — see note) | **Private** | `services.{ChannelService,WorkspaceContext,SalesforceProjectConfig,CommandEventDispatcher}`, `workspaceContextUtils.getOrgShape` |
+
+> **einstein-gpt ships from a non-default branch.** The published extension `salesforce.agentforce-vibes-autocomplete` (VS Marketplace, ~27k installs) is built from branch **`afv-v3.0-iac`**, not `main` (its `.github/workflows/iac-release.yml` checks out `ref: afv-v3.0-iac`; `main` is now an unrelated `packages/` monorepo). On `afv-v3.0-iac` the extension **hard-depends on core**: `extensionDependencies` includes `salesforce.salesforcedx-vscode-core`, `MINIMUM_REQUIRED_VERSION_CORE_EXTENSION = '60.13.0'`, and `src/services/CoreExtensionService.ts` **throws** `CommandEventDispatcher not found` at activation if core omits it. **Do not remove `CommandEventDispatcher` / `onRefreshSObjectsCommandCompletion` (`sf.internal.sobjectrefresh.complete`) from core's API** — it is a live contract. Because code search skips non-default branches, `main`-only sweeps show zero hits and falsely read as "core dep dropped"; always inspect `afv-v3.0-iac` directly.
 
 ## `@salesforce/vscode-service-provider` consumers
 
@@ -63,7 +80,6 @@ Via `vscode.extensions.getExtension('salesforce.salesforcedx-vscode-core').expor
 
 | Repo | Notes |
 |------|-------|
-| [einstein-gpt](https://github.com/forcedotcom/salesforcedx-vscode-einstein-gpt) | **Private**. Now the Agentforce Vibes monorepo (`packages/`, pnpm). extensionDependency = `salesforcedx-vscode-services` only; dropped core. Direct core API (`services.{ChannelService,WorkspaceContext,SalesforceProjectConfig,CommandEventDispatcher}`, `getOrgShape`) all dead. Still uses `@salesforce/vscode-service-provider` `ServiceType.Telemetry` (see below). |
 | [slds](https://github.com/forcedotcom/salesforcedx-vscode-slds) | No extensionDep, no getExtension. In same extension pack. |
 | [apex-language-support](https://github.com/forcedotcom/apex-language-support) | Experimental. String refs only in tests/comments. |
 | apex-oas (in-repo) | extensionDependency = `salesforcedx-vscode-apex` + `salesforcedx-vscode-services`; no core dep. Reads project/registry/fs via services-extension `api.services.*`. Only cross-extension `.exports` use is apex's `.languageClientManager`. |
@@ -84,8 +100,9 @@ Always grep for `\.exports\.\w+` across the full monorepo, not just `coreExtensi
 
 ## Keeping current
 
-Verified 2026-07-02. Before asserting "nobody uses X":
+Verified 2026-07-21. Before asserting "nobody uses X":
 1. Grep monorepo for `\.exports\.MEMBER` — catches direct access outside wrapper files
 2. Search `org:forcedotcom` and `org:salesforcecli` via `gh api`
 3. Read private repos via contents API
-4. Check `extensionPack` in `salesforcedx-vscode` and `salesforcedx-vscode-expanded` for new extensions
+4. **For repos that ship from a non-default branch (e.g. einstein-gpt → `afv-v3.0-iac`), inspect that branch directly — code search misses it** (see the ⚠️ above)
+5. Check `extensionPack` in `salesforcedx-vscode` and `salesforcedx-vscode-expanded` for new extensions


### PR DESCRIPTION
### What does this PR do?

Corrects the `/external-consumers` skill's record for **einstein-gpt** (Agentforce for Developers / Agentforce Vibes Autocomplete).

The prior entry said the repo "dropped core" with `services.{ChannelService,WorkspaceContext,SalesforceProjectConfig,CommandEventDispatcher}` + `getOrgShape` "all dead." That was derived from searching only `main`. The shipping extension `salesforce.agentforce-vibes-autocomplete` (VS Marketplace, ~27k installs) is actually built from branch **`afv-v3.0-iac`** — its `.github/workflows/iac-release.yml` checks out `ref: afv-v3.0-iac`, while `main` is now an unrelated `packages/` monorepo.

On `afv-v3.0-iac` the extension **still hard-depends on core**:
- `extensionDependencies` includes `salesforce.salesforcedx-vscode-core`
- `MINIMUM_REQUIRED_VERSION_CORE_EXTENSION = '60.13.0'`
- `src/services/CoreExtensionService.ts` **throws** `CommandEventDispatcher not found` at activation if core omits it

So `CommandEventDispatcher` / `onRefreshSObjectsCommandCompletion` (`sf.internal.sobjectrefresh.complete`) is a **live contract**, not dead code.

Changes:
- Move einstein-gpt to the direct core API consumers table with the members it uses
- Add a warning that the completion contract must not be removed from core's API
- Add a ⚠️ section + `gh` recipes explaining that GitHub code search **only indexes the default branch**, and how to find a repo's shipping branch and read it directly
- Bump the "verified" date to 2026-07-21

### What issues does this PR fix or reference?
N/A — internal skill documentation.

[skip-validate-pr]