### PR TITLE
chore(effect): fix + enforce tryCatchInEffectGen - W-23429469

### DIFF
--- a/.claude/plans/W-23429469.md
+++ b/.claude/plans/W-23429469.md
@@ -21,7 +21,7 @@ OVERLAP CHECK: `effect-best-practices` anti-patterns.md has "throw Inside Effect
 ### Phase 1 — fix both sites
 Files: `packages/salesforcedx-vscode-soql/src/commands/dataQuery.ts`, `packages/salesforcedx-vscode-soql/src/commands/queryPlan.ts`
 
-- dataQuery `executeDataQuery`: drop try/catch. Build try-body as pipe; `.pipe(Effect.catchAllCause(cause => channelService.appendToChannel(formatErrorMessage(Cause.squash(cause))).pipe(Effect.andThen(Effect.sync(() => vscChannel.show())))))`.
+- dataQuery `executeDataQuery`: drop try/catch. Success path keeps `showChannel` as a concurrent member of `Effect.all` (NOT `ensuring`): the body's `saveResultsToCSV` awaits a `showInformationMessage(..., openFileAction)` prompt that never resolves without user action, so `ensuring` would gate the panel behind an unresolved prompt (e2e OUTPUT_PANEL 30s timeout, W-23429469 CI). Error path: `.pipe(Effect.catchAllCause(cause => channelService.appendToChannel(formatErrorMessage(Cause.squash(cause))).pipe(Effect.andThen(channelService.showChannel))))`.
 - **Export `executeDataQuery`** (currently `const executeDataQuery` at dataQuery.ts:66, not exported) so Phase 1b can drive its error path directly — matches `executeQueryPlan` (already exported, queryPlan.ts:77). Trivial `export const` change; wrappers `dataQuery`/`dataQueryDocument` unchanged.
 - queryPlan `executeQueryPlan`: drop try/catch/finally. try-body `.pipe(Effect.catchAllCause(cause => channelService.appendToChannel(formatErrorMessage(Cause.squash(cause)))), Effect.ensuring(Effect.sync(() => vscChannel.show())))`.
 - Import `* as Cause from 'effect/Cause'` both files.

--- a/.claude/plans/W-23429469.md
+++ b/.claude/plans/W-23429469.md
@@ -1,0 +1,64 @@
+# W-23429469 — Fix + enforce tryCatchInEffectGen
+
+## Context
+
+Effect LS rule `tryCatchInEffectGen`: try/catch inside `Effect.gen` — use Effect error channel instead. 2 sites (verified project-wide scan, only these):
+
+- `salesforcedx-vscode-soql/src/commands/dataQuery.ts:76` — `executeDataQuery`, try/catch, catch → `appendToChannel(formatErrorMessage(error))` + `vscChannel.show()`
+- `salesforcedx-vscode-soql/src/commands/queryPlan.ts:87` — `executeQueryPlan`, try/catch/finally, catch → `appendToChannel(formatErrorMessage(error))`, finally → `vscChannel.show()`
+
+Key mechanics:
+- Query failures = **defects** not typed E: `runSoqlQuery`/`connection.request` use `Effect.promise`, reject → defect (node_modules/effect Effect.d.ts:5207 "treated as a defect"). Current try/catch catches them via generator rethrow. Preserving fix must catch defects too → `Effect.catchAllCause` + `Cause.squash` (Cause.d.ts:1199), not `catchAll`.
+- Package precedent: `soqlEditorInstance.ts:140-142`, `queryDataViewService.ts:114` already use `catchAllCause` + `Cause.squash`.
+- queryPlan `finally` (always run `vscChannel.show()`) → `Effect.ensuring`.
+
+Enforce: append `tryCatchInEffectGen` to `config/effect-diagnostics.json` `enforcedRules` (ratchet; `scripts/effect-diagnostics.mjs` fails build on listed rules). Pattern per sibling W-23429452 (90bc07a1a).
+
+OVERLAP CHECK: `effect-best-practices` anti-patterns.md has "throw Inside Effect.gen" but not try/catch; SKILL.md enforced-rules list (line 20) omits `tryCatchInEffectGen`. Dedup = point skill at now-enforced LS rule, no duplicate prose.
+
+## Phases
+
+### Phase 1 — fix both sites
+Files: `packages/salesforcedx-vscode-soql/src/commands/dataQuery.ts`, `packages/salesforcedx-vscode-soql/src/commands/queryPlan.ts`
+
+- dataQuery `executeDataQuery`: drop try/catch. Build try-body as pipe; `.pipe(Effect.catchAllCause(cause => channelService.appendToChannel(formatErrorMessage(Cause.squash(cause))).pipe(Effect.andThen(Effect.sync(() => vscChannel.show())))))`.
+- **Export `executeDataQuery`** (currently `const executeDataQuery` at dataQuery.ts:66, not exported) so Phase 1b can drive its error path directly — matches `executeQueryPlan` (already exported, queryPlan.ts:77). Trivial `export const` change; wrappers `dataQuery`/`dataQueryDocument` unchanged.
+- queryPlan `executeQueryPlan`: drop try/catch/finally. try-body `.pipe(Effect.catchAllCause(cause => channelService.appendToChannel(formatErrorMessage(Cause.squash(cause)))), Effect.ensuring(Effect.sync(() => vscChannel.show())))`.
+- Import `* as Cause from 'effect/Cause'` both files.
+- Preserve behavior: error → format+append; queryPlan always shows channel; dataQuery shows channel only on error (matches current catch).
+
+Commit: `fix(soql): replace try/catch in Effect.gen with catchAllCause - W-23429469`
+
+### Phase 1b — jest error-path coverage (prove behavior preservation)
+Files: `packages/salesforcedx-vscode-soql/test/jest/commands/dataQuery.test.ts`, `packages/salesforcedx-vscode-soql/test/jest/commands/queryPlan.test.ts`
+
+Gap: `catchAllCause` replaces the try/catch, but NO current jest test drives `executeDataQuery`/`executeQueryPlan` through a failure. dataQuery.test.ts imports only pure fns + `runSoqlQuery` (no `executeDataQuery`); queryPlan.test.ts tests only `formatQueryPlanResults` (never `executeQueryPlan`). Unverified without these tests; adding to regression-lock core behavior.
+
+- **Channel mock must record calls**: existing `mockChannel.appendToChannel` returns `Effect.void` without capturing (dataQuery.test.ts:11). For error-path assertions use a `jest.fn` wrapper: `appendToChannel: jest.fn((msg: string) => Effect.void)` and a shared `show: jest.fn()` inside `getChannel: Effect.succeed({ show })`. Existing `beforeEach(jest.clearAllMocks())` in the `displayTableResults` block is the precedent — scope the new describe blocks with their own clear.
+- dataQuery: run `executeDataQuery('SELECT ...', 'REST')` with a provider whose `connection.query` **rejects** (`jest.fn().mockRejectedValue(new Error('boom'))`) → `runSoqlQuery`'s `Effect.promise` becomes a defect → `catchAllCause`+`Cause.squash` path. Provide `ExtensionProviderService`/`ConnectionService`/`ChannelService` via `Effect.provideService` (same wiring as the `runSoqlQuery ALL ROWS` block, lines 715-770). Assert: `appendToChannel` called with `formatErrorMessage(<squashed error>)` (i.e. `nls.localize('data_query_error_message', 'Error: boom')`) AND `show` called exactly once. Add a happy-path counterpart asserting `show` still called once + `data_query_complete` appended (dataQuery shows channel on success too — verifies `catchAllCause` didn't swallow success).
+- queryPlan: `executeQueryPlan` already exported. Drive with `connection.request` rejecting → assert `appendToChannel(formatErrorMessage(...))` AND `show` called once (via `Effect.ensuring`). Add a defect-during-success-path check: `show` still fires once even when `request` resolves (ensuring = finally). queryPlan.test.ts currently mocks nothing service-side; add a `getServicesApi`-shaped provider mock (`servicesApi.services.ConnectionService.getConnection` + `ChannelService`), mirroring dataQuery's provider shape.
+- Assert `show` call count == 1 in both to lock the "show once" semantics `Effect.ensuring`/andThen must preserve (guards against double-show regressions).
+
+Commit: fold into Phase 1 commit (tests + fix together) or `test(soql): cover executeDataQuery/executeQueryPlan error path - W-23429469`.
+
+### Phase 2 — enforce + skill dedup
+Files: `config/effect-diagnostics.json`, `.claude/skills/effect-best-practices/references/anti-patterns.md`, `.claude/skills/effect-best-practices/SKILL.md`
+
+- config: add `"tryCatchInEffectGen"` to `enforcedRules`.
+- anti-patterns.md: under "FORBIDDEN: throw Inside Effect.gen", note try/catch also forbidden, enforced by LS `tryCatchInEffectGen` (config-enforced); correct = `catchAllCause`+`Cause.squash` / `catchTag` / `Effect.try`. No prose duplication.
+- SKILL.md line 20: add `tryCatchInEffectGen` to config-enforced rule mention.
+
+Commit: `chore(effect): enforce tryCatchInEffectGen - W-23429469`
+
+## Skills to apply
+- effect-best-practices (catchAllCause/Cause.squash, error channel)
+- concise (plan + anti-patterns/SKILL edits)
+- typescript
+- verification
+- playwright-e2e (locate/interpret the soql-run-query + soql-query-plan specs as the happy-path regression check)
+
+## Verification
+- `npx effect-language-service diagnostics --file <each>` → 0 `tryCatchInEffectGen`
+- `node scripts/effect-diagnostics.mjs` → pass (needs compiled tree first: `wireit compile` for soql pkg; else phantom `lazyPromiseInEffectSync` at dataQuery.ts:93 from uncompiled cross-pkg `unknown`)
+- jest: `salesforcedx-vscode-soql` (dataQuery.test.ts, queryPlan.test.ts) — Phase 1b error-path + show-once tests pass; asserts `catchAllCause`/`ensuring` match old try/catch semantics
+- e2e happy-path regression (pre-existing, no changes needed): `packages/salesforcedx-vscode-soql/test/playwright/specs/soql-run-query.spec.ts` drives `executeDataQuery` via code lens + palette, asserts `QUERY_COMPLETE_TEXT` ("records returned") and `vscChannel.show()`-triggered `OUTPUT_PANEL` visibility (spec lines 36-39, 94-96). `soql-query-plan.spec.ts` drives `executeQueryPlan`, asserts `PLAN_COMPLETE_TEXT` + `finally`/`ensuring`-triggered panel visibility (spec lines 35-38, 86-88). These confirm `catchAllCause`/`ensuring` refactor keeps the panel opening on success. No dedicated error-path e2e exists → covered by Phase 1b jest instead.

--- a/.claude/skills/effect-best-practices/SKILL.md
+++ b/.claude/skills/effect-best-practices/SKILL.md
@@ -17,7 +17,7 @@ npx effect-language-service diagnostics --project tsconfig.json
 ```
 
 - The PostToolUse `verify-on-edit.sh` hook auto-runs `--file <edited>` on every `.ts` Edit/Write and surfaces output as `followup_message`. Address what it reports.
-- **Address warnings AND messages, not just errors.** Common findings: `effectFnOpportunity` (gen→fn), `unnecessaryFailYieldableError` (yield error directly), `effectSucceedWithVoid` (`Effect.succeed(undefined)` → `Effect.void`), `globalErrorInEffectCatch`/`Failure` (use tagged error, not `new Error`; both config-enforced — see `references/anti-patterns.md`).
+- **Address warnings AND messages, not just errors.** Common findings: `effectFnOpportunity` (gen→fn), `unnecessaryFailYieldableError` (yield error directly), `effectSucceedWithVoid` (`Effect.succeed(undefined)` → `Effect.void`), `globalErrorInEffectCatch`/`Failure` (use tagged error, not `new Error`; both config-enforced — see `references/anti-patterns.md`); `tryCatchInEffectGen` (config-enforced; try/catch in `Effect.gen` → `catchAllCause`+`Cause.squash`/`catchTag`).
 - After a batch of edits, run `--project tsconfig.json` for the affected package to catch cross-file issues.
 - `effect-language-service quickfixes` shows proposed code changes.
 

--- a/.claude/skills/effect-best-practices/references/anti-patterns.md
+++ b/.claude/skills/effect-best-practices/references/anti-patterns.md
@@ -38,6 +38,8 @@ yield* Effect.gen(function* () {
 })
 ```
 
+`try/catch` inside `Effect.gen` is equally forbidden — enforced by LS rule `tryCatchInEffectGen` (config-enforced). Catches thrown JS; misses failures/defects in the Effect error channel. Correct: `catchTag`/`catchTags` for typed E; `catchAllCause` + `Cause.squash` when defects must be caught too (e.g. rejected `Effect.promise`); `Effect.try`/`tryPromise` to wrap throwing sync/async at the boundary.
+
 ## FORBIDDEN: catchAll Losing Type Information
 
 ```typescript

--- a/config/effect-diagnostics.json
+++ b/config/effect-diagnostics.json
@@ -5,6 +5,7 @@
     "runEffectInsideEffect",
     "globalErrorInEffectFailure",
     "globalErrorInEffectCatch",
-    "catchUnfailableEffect"
+    "catchUnfailableEffect",
+    "tryCatchInEffectGen"
   ]
 }

--- a/packages/salesforcedx-vscode-soql/src/commands/dataQuery.ts
+++ b/packages/salesforcedx-vscode-soql/src/commands/dataQuery.ts
@@ -7,6 +7,7 @@
 import type { QueryResult } from '../types';
 import { Column, createTable, ExtensionProviderService, Row } from '@salesforce/effect-ext-utils';
 import type { JsonMap } from '@salesforce/ts-types';
+import * as Cause from 'effect/Cause';
 import * as Effect from 'effect/Effect';
 import { isRecord } from 'effect/Predicate';
 import * as vscode from 'vscode';
@@ -63,7 +64,7 @@ const saveResultsToCSV = Effect.fn('saveResultsToCSV')(function* (queryResult: Q
   }
 });
 
-const executeDataQuery = Effect.fn('executeDataQuery')(function* (query: string, queryApi: 'REST' | 'TOOLING') {
+export const executeDataQuery = Effect.fn('executeDataQuery')(function* (query: string, queryApi: 'REST' | 'TOOLING') {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const channelService = yield* api.services.ChannelService;
 
@@ -71,9 +72,7 @@ const executeDataQuery = Effect.fn('executeDataQuery')(function* (query: string,
     yield* channelService.clearChannel;
   }
 
-  const vscChannel = yield* channelService.getChannel;
-
-  try {
+  yield* Effect.gen(function* () {
     const queryResult = yield* runSoqlQuery(query, queryApi === 'TOOLING');
     const truncated = queryResult.records.length > 0 && queryResult.totalSize > queryResult.records.length;
     const statusMessage = truncated
@@ -86,18 +85,13 @@ const executeDataQuery = Effect.fn('executeDataQuery')(function* (query: string,
         )
       : nls.localize('data_query_complete', queryResult.totalSize);
     yield* Effect.all(
-      [
-        displayTableResults(queryResult),
-        channelService.appendToChannel(statusMessage),
-        saveResultsToCSV(queryResult),
-        Effect.sync(() => vscChannel.show())
-      ],
+      [displayTableResults(queryResult), channelService.appendToChannel(statusMessage), saveResultsToCSV(queryResult)],
       { concurrency: 'unbounded' }
     );
-  } catch (error) {
-    yield* channelService.appendToChannel(formatErrorMessage(error));
-    vscChannel.show();
-  }
+  }).pipe(
+    Effect.catchAllCause(cause => channelService.appendToChannel(formatErrorMessage(Cause.squash(cause)))),
+    Effect.ensuring(channelService.showChannel)
+  );
 });
 
 export const dataQuery = Effect.fn('sf.data.query')(function* () {

--- a/packages/salesforcedx-vscode-soql/src/commands/dataQuery.ts
+++ b/packages/salesforcedx-vscode-soql/src/commands/dataQuery.ts
@@ -84,13 +84,25 @@ export const executeDataQuery = Effect.fn('executeDataQuery')(function* (query: 
           queryResult.records.length
         )
       : nls.localize('data_query_complete', queryResult.totalSize);
+    // showChannel runs concurrently, not after: saveResultsToCSV awaits a
+    // showInformationMessage prompt that never resolves without user action,
+    // so gating show behind this Effect.all (e.g. via ensuring) never reveals
+    // the panel.
     yield* Effect.all(
-      [displayTableResults(queryResult), channelService.appendToChannel(statusMessage), saveResultsToCSV(queryResult)],
+      [
+        displayTableResults(queryResult),
+        channelService.appendToChannel(statusMessage),
+        saveResultsToCSV(queryResult),
+        channelService.showChannel
+      ],
       { concurrency: 'unbounded' }
     );
   }).pipe(
-    Effect.catchAllCause(cause => channelService.appendToChannel(formatErrorMessage(Cause.squash(cause)))),
-    Effect.ensuring(channelService.showChannel)
+    Effect.catchAllCause(cause =>
+      channelService
+        .appendToChannel(formatErrorMessage(Cause.squash(cause)))
+        .pipe(Effect.andThen(channelService.showChannel))
+    )
   );
 });
 

--- a/packages/salesforcedx-vscode-soql/src/commands/queryPlan.ts
+++ b/packages/salesforcedx-vscode-soql/src/commands/queryPlan.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { Column, createTable, getServicesApi, Row } from '@salesforce/effect-ext-utils';
+import * as Cause from 'effect/Cause';
 import * as Chunk from 'effect/Chunk';
 import * as Effect from 'effect/Effect';
 import * as HashSet from 'effect/HashSet';
@@ -82,9 +83,7 @@ export const executeQueryPlan = Effect.fn('executeQueryPlan')(function* (query: 
     yield* channelService.clearChannel;
   }
 
-  const vscChannel = yield* channelService.getChannel;
-
-  try {
+  yield* Effect.gen(function* () {
     const connection = yield* servicesApi.services.ConnectionService.getConnection();
     yield* channelService.appendToChannel(nls.localize('query_plan_running', nls.localize('REST_API')));
 
@@ -96,11 +95,10 @@ export const executeQueryPlan = Effect.fn('executeQueryPlan')(function* (query: 
     );
     yield* channelService.appendToChannel(`\n${formatQueryPlanResults(result)}\n`);
     yield* channelService.appendToChannel(nls.localize('query_plan_complete'));
-  } catch (error) {
-    yield* channelService.appendToChannel(formatErrorMessage(error));
-  } finally {
-    vscChannel.show();
-  }
+  }).pipe(
+    Effect.catchAllCause(cause => channelService.appendToChannel(formatErrorMessage(Cause.squash(cause)))),
+    Effect.ensuring(channelService.showChannel)
+  );
 });
 
 export const queryPlan = Effect.fn('sf.data.query.explain')(function* () {

--- a/packages/salesforcedx-vscode-soql/test/jest/commands/dataQuery.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/commands/dataQuery.test.ts
@@ -24,7 +24,11 @@ jest.mock('@salesforce/effect-ext-utils', () => jest.requireActual('@salesforce/
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import { ChannelService } from 'salesforcedx-vscode-services/out/src/vscode/channelService';
 import { ConnectionService } from 'salesforcedx-vscode-services/out/src/core/connectionService';
+import { FsService } from 'salesforcedx-vscode-services/out/src/vscode/fsService';
+import { WorkspaceService } from 'salesforcedx-vscode-services/out/src/vscode/workspaceService';
 import type { SalesforceVSCodeServicesApi } from 'salesforcedx-vscode-services';
+import * as vscode from 'vscode';
+import { URI } from 'vscode-uri';
 import {
   convertToCSV,
   escapeCSVField,
@@ -33,6 +37,7 @@ import {
   generateTableOutput,
   displayTableResults,
   convertQueryResultToCSV,
+  executeDataQuery,
   runSoqlQuery
 } from '../../../src/commands/dataQuery';
 import { formatErrorMessage } from '../../../src/commands/queryUtils';
@@ -955,6 +960,61 @@ describe('DataQuery Pure Functions', () => {
 
       const result = formatFieldValueForDisplay(obj);
       expect(result).toBe('Test, computed value');
+    });
+  });
+
+  describe('executeDataQuery', () => {
+    beforeEach(() => {
+      (vscode.window.showInformationMessage as jest.Mock).mockResolvedValue(undefined);
+    });
+
+    const makeProvider = (query: jest.Mock) => {
+      const show = jest.fn();
+      const appendToChannel = jest.fn((_msg: string) => Effect.void);
+      const channel = {
+        appendToChannel,
+        clearChannel: Effect.void,
+        getChannel: Effect.succeed({ show }),
+        showChannel: Effect.sync(() => show())
+      };
+      const provider = {
+        getServicesApi: Effect.succeed({
+          services: {
+            ConnectionService: { getConnection: () => Effect.succeed({ query, tooling: { query } }) },
+            ChannelService: Effect.succeed(channel),
+            WorkspaceService: { getWorkspaceInfoOrThrow: () => Effect.succeed({ uri: URI.file('/ws') }) },
+            FsService: { writeFile: () => Effect.void, showTextDocument: () => Effect.void }
+          }
+        } as unknown as SalesforceVSCodeServicesApi)
+      };
+      return { provider, show, appendToChannel };
+    };
+
+    const run = (query: jest.Mock) => {
+      const { provider, show, appendToChannel } = makeProvider(query);
+      return Effect.runPromise(
+        executeDataQuery('SELECT Id FROM Account', 'REST').pipe(
+          Effect.provideService(ExtensionProviderService, provider),
+          Effect.provideService(ChannelService, {} as unknown as ChannelService),
+          Effect.provideService(ConnectionService, {} as unknown as ConnectionService),
+          Effect.provideService(FsService, {} as unknown as FsService),
+          Effect.provideService(WorkspaceService, {} as unknown as WorkspaceService)
+        )
+      ).then(() => ({ show, appendToChannel }));
+    };
+
+    it('routes a query rejection through catchAllCause: appends formatted error and shows channel once', async () => {
+      const query = jest.fn().mockRejectedValue(new Error('boom'));
+      const { show, appendToChannel } = await run(query);
+      expect(appendToChannel).toHaveBeenCalledWith(nls.localize('data_query_error_message', 'boom'));
+      expect(show).toHaveBeenCalledTimes(1);
+    });
+
+    it('appends completion message and shows channel once on success', async () => {
+      const query = jest.fn().mockResolvedValue({ records: [{ Id: '001' }], totalSize: 1, done: true });
+      const { show, appendToChannel } = await run(query);
+      expect(appendToChannel).toHaveBeenCalledWith(nls.localize('data_query_complete', 1));
+      expect(show).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/salesforcedx-vscode-soql/test/jest/commands/queryPlan.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/commands/queryPlan.test.ts
@@ -5,8 +5,13 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import * as Effect from 'effect/Effect';
 import * as Schema from 'effect/Schema';
-import { formatQueryPlanResults, QueryPlanResponse } from '../../../src/commands/queryPlan';
+import { ChannelService } from 'salesforcedx-vscode-services/out/src/vscode/channelService';
+import { ConnectionService } from 'salesforcedx-vscode-services/out/src/core/connectionService';
+import * as vscode from 'vscode';
+import { executeQueryPlan, formatQueryPlanResults, QueryPlanResponse } from '../../../src/commands/queryPlan';
+import { formatErrorMessage } from '../../../src/commands/queryUtils';
 import { nls } from '../../../src/messages';
 
 const decode = Schema.decodeUnknownSync(QueryPlanResponse);
@@ -55,5 +60,53 @@ describe('formatQueryPlanResults', () => {
   it('returns no-plans message for empty plans', () => {
     const result = formatQueryPlanResults({ plans: [] });
     expect(result).toBe(nls.localize('query_plan_no_plans'));
+  });
+});
+
+describe('executeQueryPlan', () => {
+  const setup = (request: jest.Mock) => {
+    const show = jest.fn();
+    const appendToChannel = jest.fn((_msg: string) => Effect.void);
+    const servicesApi = {
+      services: {
+        ConnectionService: { getConnection: () => Effect.succeed({ request }) },
+        ChannelService: Effect.succeed({
+          appendToChannel,
+          clearChannel: Effect.void,
+          getChannel: Effect.succeed({ show }),
+          showChannel: Effect.sync(() => show())
+        })
+      }
+    };
+    (vscode.extensions.getExtension as jest.Mock).mockReturnValue({ isActive: true, exports: servicesApi });
+    return { show, appendToChannel };
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('routes a request rejection through catchAllCause and shows channel once via ensuring', async () => {
+    const { show, appendToChannel } = setup(jest.fn().mockRejectedValue(new Error('boom')));
+    await Effect.runPromise(
+      executeQueryPlan('SELECT Id FROM Account').pipe(
+        Effect.provideService(ChannelService, {} as unknown as ChannelService),
+        Effect.provideService(ConnectionService, {} as unknown as ConnectionService)
+      )
+    );
+    expect(appendToChannel).toHaveBeenCalledWith(formatErrorMessage(new Error('boom')));
+    expect(show).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows channel exactly once on success (ensuring runs like finally)', async () => {
+    const { show, appendToChannel } = setup(jest.fn().mockResolvedValue({ plans: [] }));
+    await Effect.runPromise(
+      executeQueryPlan('SELECT Id FROM Account').pipe(
+        Effect.provideService(ChannelService, {} as unknown as ChannelService),
+        Effect.provideService(ConnectionService, {} as unknown as ConnectionService)
+      )
+    );
+    expect(appendToChannel).toHaveBeenCalledWith(nls.localize('query_plan_complete'));
+    expect(show).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
### What does this PR do?
- Fixes `tryCatchInEffectGen` violations in `dataQuery.ts`/`queryPlan.ts`: replaces try/catch inside `Effect.gen` with `Effect.catchAllCause` + `Cause.squash` (query failures are defects via `Effect.promise`).
- `dataQuery` success path shows the Output panel via a concurrent `showChannel` member of the `Effect.all` (NOT `Effect.ensuring`): `saveResultsToCSV` awaits a `showInformationMessage` action prompt that never resolves without user input, so `ensuring` would gate the panel behind the unresolved prompt and left the panel closed (SOQL Run Query e2e OUTPUT_PANEL timeout on all 3 OSes). Error path shows the channel after appending the formatted error. `queryPlan` (no blocking prompt in its body) keeps `Effect.ensuring`.
- Adds jest coverage driving `executeDataQuery`/`executeQueryPlan` through the error path, locking "show channel once" semantics.
- Enforces `tryCatchInEffectGen` in `config/effect-diagnostics.json` (ratchet) and dedups `effect-best-practices` skill docs to point at the enforced LS rule.

### Reviewer notes
- `showChannel` on the `dataQuery` success path must stay concurrent, not `ensuring` — the CSV save prompt would otherwise block the panel from opening.

## Plan
[.claude/plans/W-23429469.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23429469-7-fix-enforce-trycatchineffectgen-repo-f/.claude/plans/W-23429469.md)

### What issues does this PR fix or reference?
@W-23429469@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002edNgeYAE/view