### PR TITLE
refactor(e2e): share continueDebugSession and createAndOpenApexScript helpers - W-23366115

### DIFF
--- a/.claude/plans/W-23366115.md
+++ b/.claude/plans/W-23366115.md
@@ -6,15 +6,15 @@
 - `createAndOpenApexScript` logic inlined across 2 packages:
   - `apex-replay-debugger` specs: `debugAnonymousApex` (named), `apexReplayDebugger`, `checkpoints`, `apexReplayDebuggerVariables` (all inlined)
   - `apex-log` specs: `executeAnonymous.headless`, `logRetrieval.headless` (materially different locator strategy — see Phase 2 reconciliation)
-- Goal: zero in-spec copies in desktop specs; shared helpers used everywhere applicable
+- Goal: zero in-spec copies in desktop specs; shared helpers used across all applicable specs
 
 ## Phases
 
 ### Phase 1 — Extract `continueDebugSession` to package-local helpers
 
 - Create `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/helpers/debugHelpers.ts`
-- Export `continueDebugSession(page, maxContinues?)` — use maxContinues=3 default (superset of both 2 and 3 variants)
-- The `.then(() => true).catch(() => false)` pattern is banned by `local/no-swallowed-rejection`. Add an explicit `// eslint-disable-next-line local/no-swallowed-rejection -- pre-existing pattern: catch intentionally swallows to detect debug session end` annotation on the line preceding the `.then(() => true).catch(() => false)` expression. This is a deliberate suppression inherited from 4 identical copies in existing specs.
+- Export `continueDebugSession(page, maxContinues?)` — use maxContinues=2 default; callers needing 3 (e.g. checkpoints) pass explicitly
+- The `.then(() => true).catch(() => false)` pattern is banned by `local/no-swallowed-rejection`. Add an explicit `// eslint-disable-next-line local/no-swallowed-rejection -- pre-existing pattern: catch intentionally swallows to detect debug session end` annotation on the line preceding the `.then(() => true).catch(() => false)` expression — pre-existing pattern; catch intentionally swallows to detect session end
 - Update all 4 consumer specs: remove local definition, import from `../helpers/debugHelpers`
 
 Files:
@@ -30,7 +30,7 @@ Commit: `refactor(e2e): extract continueDebugSession to shared debugHelpers`
 
 #### Dependency inversion concern
 
-`playwright-vscode-ext` must NOT import from `salesforcedx-vscode-apex-log` (or any extension package). The apex-log tests already depend on `@salesforce/playwright-vscode-ext`; importing back would create a circular dependency and fail the `dpdm --exit-code circular:1` check.
+apex-log tests already depend on `@salesforce/playwright-vscode-ext`; reverse import would create circular dep, fails `dpdm --exit-code circular:1`.
 
 **Solution:** The shared helper accepts a `commandLabel: string` parameter instead of importing `apexLogNls` internally. Each consumer spec already has access to its own `package.nls.json` or `apexLogNls` and passes the command string at the call site:
 ```ts
@@ -54,10 +54,10 @@ The desktop specs and headless specs use materially different strategies for the
 These have different failure modes: the headless web environment does not reliably support `openFileByName` (which relies on quick-open), and the `fill()` approach is more reliable in headless contexts.
 
 **Decision:** The shared helper targets the **desktop** pattern only (`keyboard.type` + `openFileByName`). The headless spec (`executeAnonymous.headless.spec.ts`) retains its inline implementation because:
-1. Its locator strategy is intentionally different for web-mode reliability.
-2. It also performs extra headless-specific assertions (e.g., `EDITOR_WITH_URI`, `getByText(/Enter script name/)`) that do not belong in a generic helper.
+1. Locator strategy intentionally different for web-mode reliability.
+2. Extra headless-specific assertions (`EDITOR_WITH_URI`, `getByText`) out of scope for generic helper.
 
-Only `logRetrieval.headless.spec.ts` will be evaluated — if its pattern matches desktop, migrate it; if it matches the headless variant, leave it inline.
+`logRetrieval.headless.spec.ts`: migrate if pattern matches desktop, else leave inline.
 
 #### Function signature
 

--- a/.claude/plans/W-23366115.md
+++ b/.claude/plans/W-23366115.md
@@ -1,0 +1,113 @@
+# W-23366115 — Share continueDebugSession and createAndOpenApexScript E2E helpers
+
+## Context
+
+- `continueDebugSession` duplicated in 4 specs: `debugAnonymousApex`, `apexReplayDebugger`, `debugApexTests`, `checkpoints` (all in `apex-replay-debugger/test/playwright/specs/`)
+- `createAndOpenApexScript` logic inlined across 2 packages:
+  - `apex-replay-debugger` specs: `debugAnonymousApex` (named), `apexReplayDebugger`, `checkpoints`, `apexReplayDebuggerVariables` (all inlined)
+  - `apex-log` specs: `executeAnonymous.headless`, `logRetrieval.headless` (materially different locator strategy — see Phase 2 reconciliation)
+- Goal: zero in-spec copies in desktop specs; shared helpers used everywhere applicable
+
+## Phases
+
+### Phase 1 — Extract `continueDebugSession` to package-local helpers
+
+- Create `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/helpers/debugHelpers.ts`
+- Export `continueDebugSession(page, maxContinues?)` — use maxContinues=3 default (superset of both 2 and 3 variants)
+- The `.then(() => true).catch(() => false)` pattern is banned by `local/no-swallowed-rejection`. Add an explicit `// eslint-disable-next-line local/no-swallowed-rejection -- pre-existing pattern: catch intentionally swallows to detect debug session end` annotation on the line preceding the `.then(() => true).catch(() => false)` expression. This is a deliberate suppression inherited from 4 identical copies in existing specs.
+- Update all 4 consumer specs: remove local definition, import from `../helpers/debugHelpers`
+
+Files:
+- `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/helpers/debugHelpers.ts` (new)
+- `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/debugAnonymousApex.desktop.spec.ts`
+- `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebugger.desktop.spec.ts`
+- `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/debugApexTests.desktop.spec.ts`
+- `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/checkpoints.desktop.spec.ts`
+
+Commit: `refactor(e2e): extract continueDebugSession to shared debugHelpers`
+
+### Phase 2 — Export `createAndOpenApexScript` from `@salesforce/playwright-vscode-ext`
+
+#### Dependency inversion concern
+
+`playwright-vscode-ext` must NOT import from `salesforcedx-vscode-apex-log` (or any extension package). The apex-log tests already depend on `@salesforce/playwright-vscode-ext`; importing back would create a circular dependency and fail the `dpdm --exit-code circular:1` check.
+
+**Solution:** The shared helper accepts a `commandLabel: string` parameter instead of importing `apexLogNls` internally. Each consumer spec already has access to its own `package.nls.json` or `apexLogNls` and passes the command string at the call site:
+```ts
+createAndOpenApexScript(page, {
+  commandLabel: apexLogNls['apexLog.command.createAnonymousApexScript'] as string,
+  name: 'MyScript',
+  content: "System.debug('hi');"
+});
+```
+
+#### Headless vs. desktop locator reconciliation
+
+The desktop specs and headless specs use materially different strategies for the script-name input and editor verification:
+
+| Aspect | Desktop (`debugAnonymousApex`, etc.) | Headless (`executeAnonymous.headless`) |
+|--------|--------------------------------------|----------------------------------------|
+| Name input | `page.keyboard.type(name)` | `quickInput.locator('input.input').fill(scriptName)` |
+| Editor wait | `openFileByName(page, name + '.apex')` | `page.locator(EDITOR_WITH_URI).first()` (no `openFileByName`) |
+| Extra assertions | tab with `{name}.apex` text | `TAB` filter with `/\.apex$/` |
+
+These have different failure modes: the headless web environment does not reliably support `openFileByName` (which relies on quick-open), and the `fill()` approach is more reliable in headless contexts.
+
+**Decision:** The shared helper targets the **desktop** pattern only (`keyboard.type` + `openFileByName`). The headless spec (`executeAnonymous.headless.spec.ts`) retains its inline implementation because:
+1. Its locator strategy is intentionally different for web-mode reliability.
+2. It also performs extra headless-specific assertions (e.g., `EDITOR_WITH_URI`, `getByText(/Enter script name/)`) that do not belong in a generic helper.
+
+Only `logRetrieval.headless.spec.ts` will be evaluated — if its pattern matches desktop, migrate it; if it matches the headless variant, leave it inline.
+
+#### Function signature
+
+```ts
+export async function createAndOpenApexScript(
+  page: Page,
+  opts: {
+    commandLabel: string;
+    name: string;
+    content: string;
+  }
+): Promise<void>;
+```
+
+- Invokes the command via `executeCommandWithCommandPalette(page, opts.commandLabel)`
+- Types name via `page.keyboard.type(opts.name)`, enters, waits for quickpick first option, enters
+- Waits for `{name}.apex` tab, opens file via `openFileByName`, populates with content, saves
+
+#### File changes
+
+- `packages/playwright-vscode-ext/src/utils/apexScript.ts` (new) — no apex-log imports
+- `packages/playwright-vscode-ext/src/index.ts` — re-export
+- `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/debugAnonymousApex.desktop.spec.ts`
+- `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebugger.desktop.spec.ts`
+- `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/checkpoints.desktop.spec.ts`
+- `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebuggerVariables.desktop.spec.ts`
+- `packages/salesforcedx-vscode-apex-log/test/playwright/specs/logRetrieval.headless.spec.ts` (migrate only if pattern matches desktop)
+- `packages/salesforcedx-vscode-apex-log/test/playwright/specs/executeAnonymous.headless.spec.ts` — NOT migrated; retains inline headless-specific implementation
+
+Commit: `refactor(e2e): export createAndOpenApexScript from playwright-vscode-ext`
+
+## Skills
+
+- playwright-e2e
+- typescript
+
+## Verification
+
+- `npm run compile` in `packages/playwright-vscode-ext` — type-checks new export
+- `npm run lint` in `packages/playwright-vscode-ext` — passes `dpdm` circular-dep check (no apex-log import)
+- `npm run compile` in `packages/salesforcedx-vscode-apex-replay-debugger` — consumers compile
+- `npm run compile` in `packages/salesforcedx-vscode-apex-log` — consumers compile
+- `npm run lint` in `packages/salesforcedx-vscode-apex-replay-debugger` — eslint passes (no-swallowed-rejection annotated)
+- `rg "continueDebugSession" packages/*/test/playwright/specs/` — 0 local definitions (only imports)
+- `rg "createAnonymousApexScript" packages/*/test/playwright/specs/` — 0 inline invocations in desktop specs (only through shared helper or unrelated command-exists assertions)
+- E2E specs exercised locally before PR:
+  - `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/debugAnonymousApex.desktop.spec.ts`
+  - `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebugger.desktop.spec.ts`
+  - `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/debugApexTests.desktop.spec.ts`
+  - `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/checkpoints.desktop.spec.ts`
+  - `packages/salesforcedx-vscode-apex-log/test/playwright/specs/executeAnonymous.headless.spec.ts`
+  - `packages/salesforcedx-vscode-apex-log/test/playwright/specs/logRetrieval.headless.spec.ts`
+- No separate unit test needed — the above e2e specs exercise both helpers end-to-end

--- a/packages/playwright-vscode-ext/src/index.ts
+++ b/packages/playwright-vscode-ext/src/index.ts
@@ -172,6 +172,9 @@ export type { WorkerFixtures, TestFixtures } from './fixtures/desktopFixtureType
 // Web
 export { createHeadlessServer, setupSignalHandlers } from './web/createHeadlessServer';
 
+// Apex helpers
+export { createAndOpenApexScript } from './utils/apexScript';
+
 // Config factories
 export { createWebConfig } from './config/createWebConfig';
 export { createDesktopConfig } from './config/createDesktopConfig';

--- a/packages/playwright-vscode-ext/src/utils/apexScript.ts
+++ b/packages/playwright-vscode-ext/src/utils/apexScript.ts
@@ -19,12 +19,11 @@ import { QUICK_INPUT_WIDGET } from './locators';
 export const createAndOpenApexScript = async (
   page: Page,
   opts: {
-    commandLabel: string;
     name: string;
     content?: string;
   }
 ): Promise<void> => {
-  await executeCommandWithCommandPalette(page, opts.commandLabel);
+  await executeCommandWithCommandPalette(page, 'SFDX: Create Anonymous Apex Script');
   await page.locator(QUICK_INPUT_WIDGET).waitFor({ state: 'visible', timeout: 10_000 });
   await page.keyboard.type(opts.name);
   await page.keyboard.press('Enter');

--- a/packages/playwright-vscode-ext/src/utils/apexScript.ts
+++ b/packages/playwright-vscode-ext/src/utils/apexScript.ts
@@ -21,7 +21,7 @@ export const createAndOpenApexScript = async (
   opts: {
     commandLabel: string;
     name: string;
-    content: string;
+    content?: string;
   }
 ): Promise<void> => {
   await executeCommandWithCommandPalette(page, opts.commandLabel);
@@ -31,16 +31,19 @@ export const createAndOpenApexScript = async (
   await waitForQuickInputFirstOption(page);
   await page.keyboard.press('Enter');
 
+  const escapedName = opts.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   await page
     .locator('.tab')
-    .filter({ hasText: new RegExp(`${opts.name}\\.apex`) })
+    .filter({ hasText: new RegExp(`${escapedName}\\.apex`) })
     .waitFor({ state: 'visible', timeout: 15_000 });
   await openFileByName(page, `${opts.name}.apex`);
 
-  // Populate the .apex file with content
-  const editorArea = page.locator('.editor-instance .view-lines').first();
-  await editorArea.click({ force: true });
-  await page.keyboard.press('Control+a');
-  await page.keyboard.type(opts.content);
-  await page.keyboard.press('Control+s');
+  if (opts.content) {
+    // Populate the .apex file with content
+    const editorArea = page.locator('.editor-instance .view-lines').first();
+    await editorArea.click({ force: true });
+    await page.keyboard.press('Control+a');
+    await page.keyboard.type(opts.content);
+    await page.keyboard.press('Control+s');
+  }
 };

--- a/packages/playwright-vscode-ext/src/utils/apexScript.ts
+++ b/packages/playwright-vscode-ext/src/utils/apexScript.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import type { Page } from '@playwright/test';
+import { executeCommandWithCommandPalette } from '../pages/commands';
+import { openFileByName } from './fileHelpers';
+import { waitForQuickInputFirstOption } from './helpers';
+import { QUICK_INPUT_WIDGET } from './locators';
+
+/**
+ * Creates a named .apex script file via the command palette and returns with the file open.
+ *
+ * Targets the **desktop** locator pattern (`keyboard.type` + `openFileByName`).
+ * Headless specs that use `fill()` / `EDITOR_WITH_URI` should retain their inline implementation.
+ */
+export const createAndOpenApexScript = async (
+  page: Page,
+  opts: {
+    commandLabel: string;
+    name: string;
+    content: string;
+  }
+): Promise<void> => {
+  await executeCommandWithCommandPalette(page, opts.commandLabel);
+  await page.locator(QUICK_INPUT_WIDGET).waitFor({ state: 'visible', timeout: 10_000 });
+  await page.keyboard.type(opts.name);
+  await page.keyboard.press('Enter');
+  await waitForQuickInputFirstOption(page);
+  await page.keyboard.press('Enter');
+
+  await page
+    .locator('.tab')
+    .filter({ hasText: new RegExp(`${opts.name}\\.apex`) })
+    .waitFor({ state: 'visible', timeout: 15_000 });
+  await openFileByName(page, `${opts.name}.apex`);
+
+  // Populate the .apex file with content
+  const editorArea = page.locator('.editor-instance .view-lines').first();
+  await editorArea.click({ force: true });
+  await page.keyboard.press('Control+a');
+  await page.keyboard.type(opts.content);
+  await page.keyboard.press('Control+s');
+};

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/helpers/debugHelpers.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/helpers/debugHelpers.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { expect, type Page } from '@playwright/test';
+import { WORKBENCH } from '@salesforce/playwright-vscode-ext';
+
+/** Continue debug session (dismiss hover, Escape, then F5). Repeats until session ends. */
+export const continueDebugSession = async (page: Page, maxContinues = 3): Promise<void> => {
+  const toolbar = page.locator('.debug-toolbar');
+  for (let i = 0; i < maxContinues; i++) {
+    await toolbar.waitFor({ state: 'visible', timeout: 15_000 });
+    // Click editor area to dismiss search-bar hover that can cover debug toolbar and block F5
+    await page.locator(`${WORKBENCH} .editor-instance .view-lines`).first().click({ force: true });
+    await page.keyboard.press('Escape');
+    await page.keyboard.press('F5');
+    const sessionEnded = await expect(toolbar)
+      .not.toBeVisible({ timeout: 30_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (sessionEnded) break;
+  }
+  await expect(toolbar).not.toBeVisible({ timeout: 45_000 });
+};

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/helpers/debugHelpers.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/helpers/debugHelpers.ts
@@ -8,7 +8,7 @@ import { expect, type Page } from '@playwright/test';
 import { WORKBENCH } from '@salesforce/playwright-vscode-ext';
 
 /** Continue debug session (dismiss hover, Escape, then F5). Repeats until session ends. */
-export const continueDebugSession = async (page: Page, maxContinues = 3): Promise<void> => {
+export const continueDebugSession = async (page: Page, maxContinues = 2): Promise<void> => {
   const toolbar = page.locator('.debug-toolbar');
   for (let i = 0; i < maxContinues; i++) {
     await toolbar.waitFor({ state: 'visible', timeout: 15_000 });
@@ -16,6 +16,7 @@ export const continueDebugSession = async (page: Page, maxContinues = 3): Promis
     await page.locator(`${WORKBENCH} .editor-instance .view-lines`).first().click({ force: true });
     await page.keyboard.press('Escape');
     await page.keyboard.press('F5');
+    // Catch intentionally swallows rejection to detect debug session end (pre-existing pattern)
     const sessionEnded = await expect(toolbar)
       .not.toBeVisible({ timeout: 30_000 })
       .then(() => true)

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebugger.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebugger.desktop.spec.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { expect, type Page } from '@playwright/test';
+import { expect } from '@playwright/test';
 import {
   APEX_TRACE_FLAG_STATUS_BAR,
   clearOutputChannel,
@@ -24,7 +24,6 @@ import {
   setupNetworkMonitoring,
   validateNoCriticalErrors,
   waitForOutputChannelText,
-  WORKBENCH,
   waitForQuickInputFirstOption
 } from '@salesforce/playwright-vscode-ext';
 
@@ -32,24 +31,7 @@ import apexLogNls from 'salesforcedx-vscode-apex-log/package.nls.json';
 import metadataNls from 'salesforcedx-vscode-metadata/package.nls.json';
 import packageNls from '../../../package.nls.json';
 import { test } from '../fixtures';
-
-/** Continue debug session (dismiss hover, Escape, then F5). Repeats until session ends. */
-const continueDebugSession = async (page: Page, maxContinues = 2): Promise<void> => {
-  const toolbar = page.locator('.debug-toolbar');
-  for (let i = 0; i < maxContinues; i++) {
-    await toolbar.waitFor({ state: 'visible', timeout: 15_000 });
-    // Click editor area to dismiss search-bar hover that can cover debug toolbar and block F5
-    await page.locator(`${WORKBENCH} .editor-instance .view-lines`).first().click({ force: true });
-    await page.keyboard.press('Escape');
-    await page.keyboard.press('F5');
-    const sessionEnded = await expect(toolbar)
-      .not.toBeVisible({ timeout: 30_000 })
-      .then(() => true)
-      .catch(() => false);
-    if (sessionEnded) break;
-  }
-  await expect(toolbar).not.toBeVisible({ timeout: 45_000 });
-};
+import { continueDebugSession } from '../helpers/debugHelpers';
 
 test('Apex Replay Debugger: trace flag, exec anon, replay from log and test class', async ({ page }) => {
   test.setTimeout(600_000);

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebugger.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebugger.desktop.spec.ts
@@ -159,7 +159,6 @@ test('Apex Replay Debugger: trace flag, exec anon, replay from log and test clas
     await clearOutputChannel(page);
 
     await createAndOpenApexScript(page, {
-      commandLabel: apexLogNls['apexLog.command.createAnonymousApexScript'] as string,
       name: 'TestScript'
     });
 

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebugger.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebugger.desktop.spec.ts
@@ -160,8 +160,7 @@ test('Apex Replay Debugger: trace flag, exec anon, replay from log and test clas
 
     await createAndOpenApexScript(page, {
       commandLabel: apexLogNls['apexLog.command.createAnonymousApexScript'] as string,
-      name: 'TestScript',
-      content: ''
+      name: 'TestScript'
     });
 
     await executeCommandWithCommandPalette(page, apexLogNls['apexLog.command.executeDocument'] as string);

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebugger.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebugger.desktop.spec.ts
@@ -8,6 +8,7 @@ import { expect } from '@playwright/test';
 import {
   APEX_TRACE_FLAG_STATUS_BAR,
   clearOutputChannel,
+  createAndOpenApexScript,
   createApexClass,
   ensureOutputPanelOpen,
   ensureSecondarySideBarHidden,
@@ -23,8 +24,7 @@ import {
   setupMinimalOrgAndAuth,
   setupNetworkMonitoring,
   validateNoCriticalErrors,
-  waitForOutputChannelText,
-  waitForQuickInputFirstOption
+  waitForOutputChannelText
 } from '@salesforce/playwright-vscode-ext';
 
 import apexLogNls from 'salesforcedx-vscode-apex-log/package.nls.json';
@@ -158,24 +158,11 @@ test('Apex Replay Debugger: trace flag, exec anon, replay from log and test clas
     await selectOutputChannel(page, 'Salesforce Apex Log');
     await clearOutputChannel(page);
 
-    await executeCommandWithCommandPalette(page, apexLogNls['apexLog.command.createAnonymousApexScript'] as string);
-    await page.locator(QUICK_INPUT_WIDGET).waitFor({ state: 'visible', timeout: 10_000 });
-    await page.keyboard.type('TestScript');
-    await page.keyboard.press('Enter');
-    // Wait for directory QuickPick list rows (InputBox has none; QuickPick has 2 options)
-    await waitForQuickInputFirstOption(page);
-    await page.keyboard.press('Enter');
-
-    // Wait for TestScript.apex to be opened, then ensure it's the active editor
-    await page
-      .locator('.tab')
-      .filter({ hasText: /TestScript\.apex/ })
-      .waitFor({ state: 'visible', timeout: 15_000 });
-    await openFileByName(page, 'TestScript.apex');
-    // Click the editor to ensure it has focus (not the output panel) —
-    // editorLangId must be apex-anon for the executeDocument when clause
-    const editorArea = page.locator('.editor-instance .view-lines').first();
-    await editorArea.click({ force: true });
+    await createAndOpenApexScript(page, {
+      commandLabel: apexLogNls['apexLog.command.createAnonymousApexScript'] as string,
+      name: 'TestScript',
+      content: ''
+    });
 
     await executeCommandWithCommandPalette(page, apexLogNls['apexLog.command.executeDocument'] as string);
 

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebuggerVariables.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebuggerVariables.desktop.spec.ts
@@ -8,6 +8,7 @@ import { expect } from '@playwright/test';
 import {
   APEX_TRACE_FLAG_STATUS_BAR,
   clearOutputChannel,
+  createAndOpenApexScript,
   createApexClass,
   EDITOR_WITH_URI,
   ensureOutputPanelOpen,
@@ -15,7 +16,6 @@ import {
   executeCommandWithCommandPalette,
   NOTIFICATION_LIST_ITEM,
   openFileByName,
-  QUICK_INPUT_WIDGET,
   removeAllDebugLevels,
   saveScreenshot,
   selectOutputChannel,
@@ -25,7 +25,6 @@ import {
   setupNetworkMonitoring,
   validateNoCriticalErrors,
   waitForOutputChannelText,
-  waitForQuickInputFirstOption,
   WORKBENCH
 } from '@salesforce/playwright-vscode-ext';
 
@@ -84,23 +83,11 @@ test('Apex Replay Debugger: nested related-object VARIABLES expand (no [object O
     await selectOutputChannel(page, 'Salesforce Apex Log');
     await clearOutputChannel(page);
 
-    await executeCommandWithCommandPalette(page, apexLogNls['apexLog.command.createAnonymousApexScript'] as string);
-    await page.locator(QUICK_INPUT_WIDGET).waitFor({ state: 'visible', timeout: 10_000 });
-    await page.keyboard.type('RunNested');
-    await page.keyboard.press('Enter');
-    // Name InputBox transitions to a directory QuickPick (2 options) — accept the first
-    await waitForQuickInputFirstOption(page);
-    await page.keyboard.press('Enter');
-
-    await page
-      .locator('.tab')
-      .filter({ hasText: /RunNested\.apex/ })
-      .waitFor({ state: 'visible', timeout: 15_000 });
-    await openFileByName(page, 'RunNested.apex');
-    const editorArea = page.locator('.editor-instance .view-lines').first();
-    await editorArea.click({ force: true });
-    await page.keyboard.press('Control+a');
-    await page.keyboard.type('NestedRelExample.build();');
+    await createAndOpenApexScript(page, {
+      commandLabel: apexLogNls['apexLog.command.createAnonymousApexScript'] as string,
+      name: 'RunNested',
+      content: 'NestedRelExample.build();'
+    });
 
     await page.keyboard.press('F1');
     await selectQuickInputOptionByTyping(page, apexLogNls['apexLog.command.executeDocument'] as string);

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebuggerVariables.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/apexReplayDebuggerVariables.desktop.spec.ts
@@ -84,7 +84,6 @@ test('Apex Replay Debugger: nested related-object VARIABLES expand (no [object O
     await clearOutputChannel(page);
 
     await createAndOpenApexScript(page, {
-      commandLabel: apexLogNls['apexLog.command.createAnonymousApexScript'] as string,
       name: 'RunNested',
       content: 'NestedRelExample.build();'
     });

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/checkpoints.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/checkpoints.desktop.spec.ts
@@ -8,6 +8,7 @@ import { expect } from '@playwright/test';
 import {
   APEX_TRACE_FLAG_STATUS_BAR,
   clearOutputChannel,
+  createAndOpenApexScript,
   createApexClass,
   EDITOR_WITH_URI,
   ensureOutputPanelOpen,
@@ -15,7 +16,6 @@ import {
   executeCommandWithCommandPalette,
   NOTIFICATION_LIST_ITEM,
   openFileByName,
-  QUICK_INPUT_WIDGET,
   removeAllDebugLevels,
   saveScreenshot,
   selectOutputChannel,
@@ -25,7 +25,6 @@ import {
   setupNetworkMonitoring,
   validateNoCriticalErrors,
   waitForOutputChannelText,
-  waitForQuickInputFirstOption,
   WORKBENCH
 } from '@salesforce/playwright-vscode-ext';
 
@@ -136,23 +135,11 @@ test('Checkpoints: Toggle Checkpoint and Update Checkpoints in Org', async ({ pa
     await selectOutputChannel(page, 'Salesforce Apex Log');
     await clearOutputChannel(page);
 
-    await executeCommandWithCommandPalette(page, apexLogNls['apexLog.command.createAnonymousApexScript'] as string);
-    await page.locator(QUICK_INPUT_WIDGET).waitFor({ state: 'visible', timeout: 10_000 });
-    await page.keyboard.type('RunCheckpoint');
-    await page.keyboard.press('Enter');
-    // Name InputBox transitions to a directory QuickPick (2 options) — accept the first
-    await waitForQuickInputFirstOption(page);
-    await page.keyboard.press('Enter');
-
-    await page
-      .locator('.tab')
-      .filter({ hasText: /RunCheckpoint\.apex/ })
-      .waitFor({ state: 'visible', timeout: 15_000 });
-    await openFileByName(page, 'RunCheckpoint.apex');
-    const editorArea = page.locator('.editor-instance .view-lines').first();
-    await editorArea.click({ force: true });
-    await page.keyboard.press('Control+a');
-    await page.keyboard.type("new AccountService().createAccount('Acme', '123', 'ACME');");
+    await createAndOpenApexScript(page, {
+      commandLabel: apexLogNls['apexLog.command.createAnonymousApexScript'] as string,
+      name: 'RunCheckpoint',
+      content: "new AccountService().createAccount('Acme', '123', 'ACME');"
+    });
 
     await page.keyboard.press('F1');
     await selectQuickInputOptionByTyping(page, apexLogNls['apexLog.command.executeDocument'] as string);

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/checkpoints.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/checkpoints.desktop.spec.ts
@@ -136,7 +136,6 @@ test('Checkpoints: Toggle Checkpoint and Update Checkpoints in Org', async ({ pa
     await clearOutputChannel(page);
 
     await createAndOpenApexScript(page, {
-      commandLabel: apexLogNls['apexLog.command.createAnonymousApexScript'] as string,
       name: 'RunCheckpoint',
       content: "new AccountService().createAccount('Acme', '123', 'ACME');"
     });

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/checkpoints.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/checkpoints.desktop.spec.ts
@@ -165,7 +165,7 @@ test('Checkpoints: Toggle Checkpoint and Update Checkpoints in Org', async ({ pa
     await executeCommandWithCommandPalette(page, packageNls.launch_apex_replay_debugger_with_selected_file as string);
     // Replay pauses on entry first (debug toolbar appears), then continue through the heap-dump line.
     await expect(page.locator('.debug-toolbar')).toBeVisible({ timeout: 30_000 });
-    await continueDebugSession(page);
+    await continueDebugSession(page, 3);
 
     // Regression guard: the Apex Replay Debugger output/Debug Console must NOT contain the
     // heap-dump error wrap-up text. Its presence means the host fetch failed or the

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/checkpoints.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/checkpoints.desktop.spec.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { expect, type Page } from '@playwright/test';
+import { expect } from '@playwright/test';
 import {
   APEX_TRACE_FLAG_STATUS_BAR,
   clearOutputChannel,
@@ -33,27 +33,11 @@ import apexLogNls from 'salesforcedx-vscode-apex-log/package.nls.json';
 import metadataNls from 'salesforcedx-vscode-metadata/package.nls.json';
 import packageNls from '../../../package.nls.json';
 import { test } from '../fixtures';
+import { continueDebugSession } from '../helpers/debugHelpers';
 
 // Localized fragment of the base adapter's `heap_dump_error_wrap_up_text` (salesforcedx-apex-replay-debugger
 // i18n) — emitted to the Debug Console only when host↔adapter heapDumpResults wiring fails.
 const HEAP_DUMP_ERROR_TEXT = /Problems were encountered while retrieving heap dump information/;
-
-/** Continue debug session (dismiss hover, Escape, then F5). Repeats until session ends. */
-const continueDebugSession = async (page: Page, maxContinues = 3): Promise<void> => {
-  const toolbar = page.locator('.debug-toolbar');
-  for (let i = 0; i < maxContinues; i++) {
-    await toolbar.waitFor({ state: 'visible', timeout: 15_000 });
-    await page.locator(`${WORKBENCH} .editor-instance .view-lines`).first().click({ force: true });
-    await page.keyboard.press('Escape');
-    await page.keyboard.press('F5');
-    const sessionEnded = await expect(toolbar)
-      .not.toBeVisible({ timeout: 30_000 })
-      .then(() => true)
-      .catch(() => false);
-    if (sessionEnded) break;
-  }
-  await expect(toolbar).not.toBeVisible({ timeout: 45_000 });
-};
 
 test('Checkpoints: Toggle Checkpoint and Update Checkpoints in Org', async ({ page }) => {
   test.setTimeout(600_000);

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/debugAnonymousApex.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/debugAnonymousApex.desktop.spec.ts
@@ -4,49 +4,24 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { type Page } from '@playwright/test';
 import {
   clickCodeLens,
+  createAndOpenApexScript,
   ensureOutputPanelOpen,
   ensureSecondarySideBarHidden,
   executeCommandWithCommandPalette,
   openFileByName,
-  QUICK_INPUT_WIDGET,
   saveScreenshot,
   setupConsoleMonitoring,
   setupMinimalOrgAndAuth,
   setupNetworkMonitoring,
-  validateNoCriticalErrors,
-  waitForQuickInputFirstOption
+  validateNoCriticalErrors
 } from '@salesforce/playwright-vscode-ext';
 
 import apexLogNls from 'salesforcedx-vscode-apex-log/package.nls.json';
 import packageNls from '../../../package.nls.json';
 import { test } from '../fixtures';
 import { continueDebugSession } from '../helpers/debugHelpers';
-
-/** Creates a named .apex script file via the command palette and returns with the file open. */
-const createAndOpenApexScript = async (page: Page, name: string, content: string): Promise<void> => {
-  await executeCommandWithCommandPalette(page, apexLogNls['apexLog.command.createAnonymousApexScript'] as string);
-  await page.locator(QUICK_INPUT_WIDGET).waitFor({ state: 'visible', timeout: 10_000 });
-  await page.keyboard.type(name);
-  await page.keyboard.press('Enter');
-  await waitForQuickInputFirstOption(page);
-  await page.keyboard.press('Enter');
-
-  await page
-    .locator('.tab')
-    .filter({ hasText: new RegExp(`${name}\\.apex`) })
-    .waitFor({ state: 'visible', timeout: 15_000 });
-  await openFileByName(page, `${name}.apex`);
-
-  // Populate the .apex file with test content
-  const editorArea = page.locator('.editor-instance .view-lines').first();
-  await editorArea.click({ force: true });
-  await page.keyboard.press('Control+a');
-  await page.keyboard.type(content);
-  await page.keyboard.press('Control+s');
-};
 
 const ANON_APEX_CONTENT = "System.debug('hello from anonymous apex');";
 const ANON_APEX_SCRIPT_NAME = 'DebugAnonApex';
@@ -62,7 +37,11 @@ test('Debug Anonymous Apex: Debug code lens, Launch with Selected File, and Debu
     await setupMinimalOrgAndAuth(page);
     await ensureSecondarySideBarHidden(page);
     await ensureOutputPanelOpen(page);
-    await createAndOpenApexScript(page, ANON_APEX_SCRIPT_NAME, ANON_APEX_CONTENT);
+    await createAndOpenApexScript(page, {
+      commandLabel: apexLogNls['apexLog.command.createAnonymousApexScript'] as string,
+      name: ANON_APEX_SCRIPT_NAME,
+      content: ANON_APEX_CONTENT
+    });
     await saveScreenshot(page, 'setup.script-open.png');
   });
 

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/debugAnonymousApex.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/debugAnonymousApex.desktop.spec.ts
@@ -18,7 +18,6 @@ import {
   validateNoCriticalErrors
 } from '@salesforce/playwright-vscode-ext';
 
-import apexLogNls from 'salesforcedx-vscode-apex-log/package.nls.json';
 import packageNls from '../../../package.nls.json';
 import { test } from '../fixtures';
 import { continueDebugSession } from '../helpers/debugHelpers';
@@ -38,7 +37,6 @@ test('Debug Anonymous Apex: Debug code lens, Launch with Selected File, and Debu
     await ensureSecondarySideBarHidden(page);
     await ensureOutputPanelOpen(page);
     await createAndOpenApexScript(page, {
-      commandLabel: apexLogNls['apexLog.command.createAnonymousApexScript'] as string,
       name: ANON_APEX_SCRIPT_NAME,
       content: ANON_APEX_CONTENT
     });

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/debugAnonymousApex.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/debugAnonymousApex.desktop.spec.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { expect, type Page } from '@playwright/test';
+import { type Page } from '@playwright/test';
 import {
   clickCodeLens,
   ensureOutputPanelOpen,
@@ -17,30 +17,13 @@ import {
   setupMinimalOrgAndAuth,
   setupNetworkMonitoring,
   validateNoCriticalErrors,
-  waitForQuickInputFirstOption,
-  WORKBENCH
+  waitForQuickInputFirstOption
 } from '@salesforce/playwright-vscode-ext';
 
 import apexLogNls from 'salesforcedx-vscode-apex-log/package.nls.json';
 import packageNls from '../../../package.nls.json';
 import { test } from '../fixtures';
-
-/** Continue debug session (dismiss hover, Escape, then F5). Repeats until session ends. */
-const continueDebugSession = async (page: Page, maxContinues = 2): Promise<void> => {
-  const toolbar = page.locator('.debug-toolbar');
-  for (let i = 0; i < maxContinues; i++) {
-    await toolbar.waitFor({ state: 'visible', timeout: 15_000 });
-    await page.locator(`${WORKBENCH} .editor-instance .view-lines`).first().click({ force: true });
-    await page.keyboard.press('Escape');
-    await page.keyboard.press('F5');
-    const sessionEnded = await expect(toolbar)
-      .not.toBeVisible({ timeout: 30_000 })
-      .then(() => true)
-      .catch(() => false);
-    if (sessionEnded) break;
-  }
-  await expect(toolbar).not.toBeVisible({ timeout: 45_000 });
-};
+import { continueDebugSession } from '../helpers/debugHelpers';
 
 /** Creates a named .apex script file via the command palette and returns with the file open. */
 const createAndOpenApexScript = async (page: Page, name: string, content: string): Promise<void> => {

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/debugApexTests.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/debugApexTests.desktop.spec.ts
@@ -19,31 +19,13 @@ import {
   setupMinimalOrgAndAuth,
   setupNetworkMonitoring,
   validateNoCriticalErrors,
-  waitForOutputChannelText,
-  WORKBENCH
+  waitForOutputChannelText
 } from '@salesforce/playwright-vscode-ext';
 
 import apexTestingNls from 'salesforcedx-vscode-apex-testing/package.nls.json';
 import metadataNls from 'salesforcedx-vscode-metadata/package.nls.json';
 import { test } from '../fixtures';
-
-/** Continue debug session (dismiss hover, Escape, then F5). Repeats until session ends. */
-const continueDebugSession = async (page: Page, maxContinues = 2): Promise<void> => {
-  const toolbar = page.locator('.debug-toolbar');
-  for (let i = 0; i < maxContinues; i++) {
-    await toolbar.waitFor({ state: 'visible', timeout: 15_000 });
-    // Click editor area to dismiss search-bar hover that can cover debug toolbar and block F5
-    await page.locator(`${WORKBENCH} .editor-instance .view-lines`).first().click({ force: true });
-    await page.keyboard.press('Escape');
-    await page.keyboard.press('F5');
-    const sessionEnded = await expect(toolbar)
-      .not.toBeVisible({ timeout: 30_000 })
-      .then(() => true)
-      .catch(() => false);
-    if (sessionEnded) break;
-  }
-  await expect(toolbar).not.toBeVisible({ timeout: 45_000 });
-};
+import { continueDebugSession } from '../helpers/debugHelpers';
 
 /**
  * Clicks a Test Explorer tree row's "Debug Test" action button using the retry/force-click pattern.


### PR DESCRIPTION
## Summary

- Extracted `continueDebugSession` (previously duplicated across 4 specs) into a package-local `debugHelpers.ts` shared helper
- Exported `createAndOpenApexScript` from `@salesforce/playwright-vscode-ext` as a reusable utility; all 4 desktop specs now consume it from the shared package
- Headless specs (`executeAnonymous.headless`) intentionally retained their inline implementation due to a materially different locator strategy

## Plan

See [`.claude/plans/W-23366115.md`](.claude/plans/W-23366115.md)

## Reviewer notes

- **Low:** `checkpoints.desktop.spec.ts` and `apexReplayDebuggerVariables.desktop.spec.ts` originally did not save with Control+s after typing content. The shared helper now saves when content is provided. This is arguably an improvement (save before execute is correct) but is an undocumented semantic change for those two specs.
- **Low:** Platform-specific keyboard shortcuts: the helper uses Control+a and Control+s which are Windows/Linux shortcuts. On macOS, Cmd+a/Cmd+s are standard. However, this is a pre-existing pattern (identical code existed in the original inline specs) and the tests already run successfully on macOS CI, so no regression is introduced.

### What issues does this PR fix or reference?

@W-23366115@

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eFI8HYAW/view