### PR TITLE
chore(services): remove debug console.log from virtualFsProvider services - W-23429789

### DIFF
--- a/packages/salesforcedx-vscode-services/src/virtualFsProvider/fileSystemSetup.ts
+++ b/packages/salesforcedx-vscode-services/src/virtualFsProvider/fileSystemSetup.ts
@@ -76,7 +76,6 @@ export const fileSystemSetup = Effect.fn('fileSystemSetup')(function* (context: 
   const settingsService = yield* SettingsService;
 
   if (yield* settingsService.getValue('salesforce-web-console', 'protectedOrg', false)) {
-    console.log('protected org');
     vscode.commands.executeCommand('setContext', 'sf:protectedOrg', true);
     const registryAccess = yield* MetadataRegistryService.getRegistryAccess();
     // protected org: make apex read only

--- a/packages/salesforcedx-vscode-services/src/vscode/configWatcher.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/configWatcher.ts
@@ -22,8 +22,6 @@ import { SettingsChangePubSub } from './settingsChangePubSub';
 
 /** Watches settings changes and triggers appropriate effects */
 export const watchSettingsService = Effect.fn('watchSettingsService')(function* () {
-  console.log('watchSettingsService starting');
-
   const [settingsChangePubSub, channelService] = yield* Effect.all([SettingsChangePubSub, ChannelService], {
     concurrency: 'unbounded'
   });
@@ -45,7 +43,6 @@ export const watchSettingsService = Effect.fn('watchSettingsService')(function* 
     Stream.tap(() => channelService.appendToChannel(`ConfigChanged: ${RETRIEVE_ON_LOAD_KEY}`)),
     Stream.runForEach(() => retrieveOnLoadEffect())
   );
-  console.log('watchSettingsService started');
 });
 
 const authSettings = [INSTANCE_URL_KEY, ACCESS_TOKEN_KEY, API_VERSION_KEY].map(


### PR DESCRIPTION
## Summary
- Removed 3 leftover debug `console.log` calls from `salesforcedx-vscode-services` (Effect code should not log via `console.log`)
- `configWatcher.ts`: dropped `watchSettingsService starting`/`started` logs
- `fileSystemSetup.ts`: dropped `protected org` log; surrounding `setContext`/readOnly logic unchanged

## Plan
[.claude/plans/W-23429789.md](../blob/develop/.claude/plans/W-23429789.md)

### What issues does this PR fix or reference?
@W-23429789@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eePkaYAE/view