### PR TITLE
fix(apex-testing): SFDX: Edit Apex Test Suite correctly renders the list of classes in the current suite when the classes have namespaces - W-23531661

### DIFF
--- a/packages/salesforcedx-vscode-apex-testing/src/commands/apexTestSuite.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/commands/apexTestSuite.ts
@@ -137,7 +137,8 @@ const gatherEditOptions = Effect.fn('apexTestSuite.gatherEditOptions')(function*
   const membershipByClassId = new Map(memberships.records.map(r => [r.ApexClassId, r.Id]));
 
   // Query ApexClass IDs for all classes to match against membership records
-  const classNames = allClasses.map(cls => `'${(cls.fullClassName ?? cls.label).replaceAll("'", "''")}'`).join(',');
+  // Use cls.label (= ApexClass.Name, without namespace) not fullClassName — the Name column never contains the namespace prefix
+  const classNames = allClasses.map(cls => `'${cls.label.replaceAll("'", "''")}'`).join(',');
   const classIdResult = yield* Effect.tryPromise(() =>
     connection.tooling.query<{ Id: string; Name: string; NamespacePrefix?: string | null }>(
       `SELECT Id, Name, NamespacePrefix FROM ApexClass WHERE Name IN (${classNames})`


### PR DESCRIPTION
### What does this PR do?
When a user runs **SFDX: Edit Apex Test Suite**, they see a list of all the available Apex tests in the org, with the ones already in the suite checked.  However, there was a bug in the previous code in the handling of Apex tests containing namespaces.  When deciding which boxes to check, the code runs `SELECT Id, Name, NamespacePrefix FROM ApexClass WHERE Name IN (${classNames})`.  Previously, the Apex test classes with namespaces were being stored as `namespace.fileName`, but `Name` is just the filename unless there happens to be two Apex test classes that share the same filename - then in that case we get lucky and it's stored as `namespace.fileName` to distinguish between the two.

This PR fixes the bug to grab just the filename when initially building `classNames` and bring back the namespace later when building the qualified names afterwards.

### What issues does this PR fix or reference?
@W-23531661@