### PR TITLE
feat(org): add sf.unset.default.org command to clear target-org - W-23336284

### DIFF
--- a/.claude/plans/W-23336284.md
+++ b/.claude/plans/W-23336284.md
@@ -1,0 +1,119 @@
+# W-23336284 - Add VSCode command to unset default org
+
+## Context
+
+- `ConfigService.unsetTargetOrg()` already exists in `salesforcedx-vscode-services/src/core/configService.ts`
+- Need new command `sf.unset.default.org` in `packages/salesforcedx-vscode-org`
+- Pattern: register via `registerCommandWithLayer(AllServicesLayer)` in `index.ts`
+- Command palette entry via `package.json` contributes.commands + activationEvents
+- NLS strings in `package.nls.json` / `package.nls.ja.json`
+- The `sf:has_target_org` context key (set by `services/src/vscode/context.ts:24`) reactively clears
+  when the default org is unset, enabling auto-hide of the command from the palette post-execution.
+
+## Phases
+
+### Phase 1: Add command implementation + registration
+
+- Create `packages/salesforcedx-vscode-org/src/commands/unsetDefaultOrg.ts`
+  - Effect function calling `api.services.ConfigService.unsetTargetOrg()`
+  - Show info message on success
+- Add constant `UNSET_DEFAULT_ORG_COMMAND = 'sf.unset.default.org'` to `constants.ts`
+- Register in `index.ts` inside the `activateEffect` function (lines 77-89 pattern), alongside the
+  other `registerCommand(...)` calls. Rationale: `sf.set.default.org` is registered in
+  `initializeStatusBarItems` because it is tightly coupled to the org picker lifecycle; the new
+  unset command has no such coupling and belongs with the other standalone commands in `activateEffect`.
+- Add NLS key `config_unset_org_text` to `package.nls.json` + `package.nls.ja.json`
+- Add to `package.json`:
+  - `contributes.commands` entry with title referencing `%config_unset_org_text%`
+  - `contributes.menus.commandPalette` entry with `when: sf:project_opened && sf:has_target_org`
+    (matches `sf.org.logout.default` pattern at package.json:231 — command is only actionable when
+    a default org exists; after execution the context key clears and the command auto-hides)
+- Add i18n message key for success notification in `messages/i18n.ts`
+
+**Commit**: `feat(org): add sf.unset.default.org command to clear target-org - W-23336284`
+
+**Files**:
+- `packages/salesforcedx-vscode-org/src/commands/unsetDefaultOrg.ts` (new)
+- `packages/salesforcedx-vscode-org/src/commands/index.ts` (export)
+- `packages/salesforcedx-vscode-org/src/constants.ts`
+- `packages/salesforcedx-vscode-org/src/index.ts`
+- `packages/salesforcedx-vscode-org/package.json`
+- `packages/salesforcedx-vscode-org/package.nls.json`
+- `packages/salesforcedx-vscode-org/package.nls.ja.json`
+- `packages/salesforcedx-vscode-org/src/messages/i18n.ts`
+
+### Phase 2: Add unit test
+
+- Jest test for `unsetDefaultOrgCommand`
+- Mock `ConfigService.unsetTargetOrg()`, verify it's called
+- Verify info message shown
+
+**Commit**: `test(org): unit test for sf.unset.default.org command - W-23336284`
+
+**Files**:
+- `packages/salesforcedx-vscode-org/test/jest/commands/unsetDefaultOrg.test.ts` (new)
+
+### Phase 3: Add e2e Playwright coverage
+
+Two concrete e2e assertions are required:
+
+1. **Command palette visibility** — extend `orgCommands.desktop.spec.ts` with a new `test.step`:
+   ```ts
+   await test.step('Unset a Default Org', async () => {
+     await verifyCommandExists(page, packageNls.config_unset_org_text, 60_000);
+   });
+   ```
+   This verifies the new NLS key resolves and the command is visible in the command palette when
+   `sf:project_opened` is true. The existing spec fixture already opens a project, satisfying the
+   `sf:project_opened` precondition. Note: `sf:has_target_org` must also be true for the command
+   to appear; the spec fixture has a dev hub set as default org (via CI auth), satisfying this.
+
+2. **Status bar transition after execution** — extend `orgPickers.desktop.spec.ts` with a new
+   `test.step` at the end of the existing test (after the LOGOUT DEFAULT step which already leaves
+   the workspace with a default org unset). Insert a step BEFORE the LOGOUT DEFAULT step that:
+   - Asserts the status bar shows the current default org alias (already done by prior steps)
+   - Executes `sf.unset.default.org` via `executeCommandWithCommandPalette(page, packageNls.config_unset_org_text)`
+   - Asserts `expectOrgPickerStatusBar(page, 'No Default Org Set')`
+   - Re-sets the default org (via the picker) so subsequent steps are unaffected
+
+   Alternatively, add a dedicated step after the LOGOUT DEFAULT step (which already cleared the
+   default) that re-sets the default via the picker, then executes the unset command:
+   ```ts
+   await test.step('UNSET DEFAULT: command clears the default org and status bar reflects it', async () => {
+     // Re-set MINIMAL_ORG_ALIAS as default so we can unset it
+     await clickOrgPickerStatusBar(page, 'No Default Org Set');
+     await expectOrgPickerListsOrg(page, MINIMAL_ORG_ALIAS);
+     await selectOrgInPicker(page, MINIMAL_ORG_ALIAS);
+     await expectOrgPickerStatusBar(page, MINIMAL_ORG_ALIAS);
+
+     // Execute the unset command
+     await executeCommandWithCommandPalette(page, packageNls.config_unset_org_text);
+
+     // Status bar should reflect no default org
+     await expectOrgPickerStatusBar(page, 'No Default Org Set');
+   });
+   ```
+
+**Commit**: `test(org): e2e coverage for sf.unset.default.org command visibility and status bar - W-23336284`
+
+**Files**:
+- `packages/salesforcedx-vscode-org/test/playwright/specs/orgCommands.desktop.spec.ts`
+- `packages/salesforcedx-vscode-org/test/playwright/specs/orgPickers.desktop.spec.ts`
+
+## Skills to apply
+
+- i18n-messages
+- services-extension-consumption
+- core-extension-api
+- typescript
+- playwright-e2e
+- verification
+
+## Verification
+
+- `npm run test:jest` in `packages/salesforcedx-vscode-org` passes
+- `npm run compile` in `packages/salesforcedx-vscode-org` passes
+- Command appears in `package.json` contributes.commands with `when: sf:project_opened && sf:has_target_org`
+- e2e: `orgCommands.desktop.spec.ts` includes a `test.step` calling `verifyCommandExists(page, packageNls.config_unset_org_text, 60_000)`
+- e2e: `orgPickers.desktop.spec.ts` includes a `test.step` that executes `sf.unset.default.org` via command palette and asserts `expectOrgPickerStatusBar(page, 'No Default Org Set')`
+- Command registered in `activateEffect` function (not `initializeStatusBarItems`)

--- a/packages/salesforcedx-vscode-org/package.json
+++ b/packages/salesforcedx-vscode-org/package.json
@@ -261,6 +261,10 @@
         {
           "command": "sf.set.default.org",
           "when": "sf:project_opened"
+        },
+        {
+          "command": "sf.unset.default.org",
+          "when": "sf:project_opened && sf:has_target_org"
         }
       ]
     },
@@ -316,6 +320,10 @@
       {
         "command": "sf.set.default.org",
         "title": "%config_set_org_text%"
+      },
+      {
+        "command": "sf.unset.default.org",
+        "title": "%config_unset_org_text%"
       }
     ]
   }

--- a/packages/salesforcedx-vscode-org/package.nls.ja.json
+++ b/packages/salesforcedx-vscode-org/package.nls.ja.json
@@ -14,7 +14,7 @@
   "org_logout_default_text": "SFDX: Log Out from Default Org",
   "org_open_default_scratch_org_text": "SFDX: Open Default Org",
   "org_select_text": "Select an org to set as default",
-  "config_unset_org_text": "SFDX: デフォルト組織の設定解除",
+  "config_unset_org_text": "SFDX: Unset a Default Org",
   "status_bar_open_org_tooltip": "Open Default Org in Browser",
   "status_bar_org_picker_tooltip": "Change your default org"
 }

--- a/packages/salesforcedx-vscode-org/package.nls.ja.json
+++ b/packages/salesforcedx-vscode-org/package.nls.ja.json
@@ -14,6 +14,7 @@
   "org_logout_default_text": "SFDX: Log Out from Default Org",
   "org_open_default_scratch_org_text": "SFDX: Open Default Org",
   "org_select_text": "Select an org to set as default",
+  "config_unset_org_text": "SFDX: デフォルト組織の設定解除",
   "status_bar_open_org_tooltip": "Open Default Org in Browser",
   "status_bar_org_picker_tooltip": "Change your default org"
 }

--- a/packages/salesforcedx-vscode-org/package.nls.json
+++ b/packages/salesforcedx-vscode-org/package.nls.json
@@ -14,6 +14,7 @@
   "org_logout_default_text": "SFDX: Log Out from Default Org",
   "org_open_default_scratch_org_text": "SFDX: Open Default Org",
   "org_select_text": "Select an org to set as default",
+  "config_unset_org_text": "SFDX: Unset Default Org",
   "status_bar_open_org_tooltip": "Open Default Org in Browser",
   "status_bar_org_picker_tooltip": "Change your default org"
 }

--- a/packages/salesforcedx-vscode-org/src/commands/index.ts
+++ b/packages/salesforcedx-vscode-org/src/commands/index.ts
@@ -8,3 +8,4 @@
 export { orgListCleanCommand } from './orgList';
 export { orgLoginWebCommand } from './auth/orgLoginWeb';
 export { orgLogoutAllCommand, orgLogoutDefaultCommand } from './auth/orgLogout';
+export { unsetDefaultOrgCommand } from './unsetDefaultOrg';

--- a/packages/salesforcedx-vscode-org/src/commands/unsetDefaultOrg.ts
+++ b/packages/salesforcedx-vscode-org/src/commands/unsetDefaultOrg.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
+import { notificationService } from '@salesforce/salesforcedx-utils-vscode';
+import * as Effect from 'effect/Effect';
+import { nls } from '../messages';
+
+/**
+ * Effect command for `sf.unset.default.org`: clears the current target-org from local config and
+ * reactively updates the status bar. The `sf:has_target_org` context key clears automatically,
+ * hiding this command from the palette post-execution.
+ */
+export const unsetDefaultOrgCommand = Effect.fn('unsetDefaultOrgCommand')(function* () {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  yield* api.services.ConfigService.unsetTargetOrg();
+  yield* Effect.sync(() => void notificationService.showInformationMessage(nls.localize('unset_default_org_success')));
+});

--- a/packages/salesforcedx-vscode-org/src/commands/unsetDefaultOrg.ts
+++ b/packages/salesforcedx-vscode-org/src/commands/unsetDefaultOrg.ts
@@ -6,8 +6,8 @@
  */
 
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
-import { notificationService } from '@salesforce/salesforcedx-utils-vscode';
 import * as Effect from 'effect/Effect';
+import * as vscode from 'vscode';
 import { nls } from '../messages';
 
 /**
@@ -18,5 +18,7 @@ import { nls } from '../messages';
 export const unsetDefaultOrgCommand = Effect.fn('unsetDefaultOrgCommand')(function* () {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   yield* api.services.ConfigService.unsetTargetOrg();
-  yield* Effect.sync(() => void notificationService.showInformationMessage(nls.localize('unset_default_org_success')));
+  yield* Effect.promise(() => vscode.window.showInformationMessage(nls.localize('unset_default_org_success'))).pipe(
+    Effect.ignore
+  );
 });

--- a/packages/salesforcedx-vscode-org/src/constants.ts
+++ b/packages/salesforcedx-vscode-org/src/constants.ts
@@ -14,3 +14,4 @@ export const ORG_DISPLAY_DEFAULT_COMMAND = 'sf.org.display.default';
 export const ORG_LOGIN_ACCESS_TOKEN_COMMAND = 'sf.org.login.access.token';
 export const ORG_DISPLAY_USERNAME_COMMAND = 'sf.org.display.username';
 export const ORG_LOGIN_WEB_DEV_HUB = 'sf.org.login.web.dev.hub';
+export const UNSET_DEFAULT_ORG_COMMAND = 'sf.unset.default.org';

--- a/packages/salesforcedx-vscode-org/src/index.ts
+++ b/packages/salesforcedx-vscode-org/src/index.ts
@@ -16,7 +16,13 @@ import * as Effect from 'effect/Effect';
 import * as Scope from 'effect/Scope';
 import * as vscode from 'vscode';
 import { getOrgChannelService, setOrgChannel } from './channels';
-import { orgListCleanCommand, orgLoginWebCommand, orgLogoutAllCommand, orgLogoutDefaultCommand } from './commands';
+import {
+  orgListCleanCommand,
+  orgLoginWebCommand,
+  orgLogoutAllCommand,
+  orgLogoutDefaultCommand,
+  unsetDefaultOrgCommand
+} from './commands';
 import { orgLoginAccessTokenCommand } from './commands/auth/orgLoginAccessToken';
 import { orgLoginWebDevHubCommand } from './commands/auth/orgLoginWebDevHub';
 import { orgCreateCommand } from './commands/orgCreate';
@@ -31,7 +37,8 @@ import {
   ORG_LOGIN_WEB_DEV_HUB,
   ORG_LOGOUT_ALL_COMMAND,
   ORG_LOGOUT_DEFAULT_COMMAND,
-  ORG_OPEN_COMMAND
+  ORG_OPEN_COMMAND,
+  UNSET_DEFAULT_ORG_COMMAND
 } from './constants';
 import { AllServicesLayer, getOrgRuntime, setAllServicesLayer } from './extensionProvider';
 import { nls } from './messages';
@@ -87,6 +94,7 @@ const activateEffect = Effect.fn('activation:salesforcedx-vscode-org')(function*
   yield* registerCommand(ORG_DISPLAY_DEFAULT_COMMAND, orgDisplayDefaultCommand);
   yield* registerCommand(ORG_LOGIN_ACCESS_TOKEN_COMMAND, orgLoginAccessTokenCommand);
   yield* registerCommand(ORG_DISPLAY_USERNAME_COMMAND, orgDisplayUsernameCommand);
+  yield* registerCommand(UNSET_DEFAULT_ORG_COMMAND, unsetDefaultOrgCommand);
 
   // Initialize org picker and status bar
   yield* initializeStatusBarItems;

--- a/packages/salesforcedx-vscode-org/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-org/src/messages/i18n.ts
@@ -102,5 +102,6 @@ For additional information, please review the authorization section of https://d
   pending_org_expiration_output_channel_message:
     'Warning: The following orgs expire in the next %d days:\n\n%s\n\nIf these orgs contain critical data or settings, back them up before the org expires.',
   status_bar_open_org_tooltip: 'Open Default Org in Browser',
-  status_bar_org_picker_tooltip: 'Change Default Org'
+  status_bar_org_picker_tooltip: 'Change Default Org',
+  unset_default_org_success: 'Successfully unset the default org.'
 } as const;

--- a/packages/salesforcedx-vscode-org/test/jest/commands/unsetDefaultOrg.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/commands/unsetDefaultOrg.test.ts
@@ -10,6 +10,7 @@ import * as Effect from 'effect/Effect';
 import * as Exit from 'effect/Exit';
 import * as vscode from 'vscode';
 import { unsetDefaultOrgCommand } from '../../../src/commands/unsetDefaultOrg';
+import { nls } from '../../../src/messages';
 
 describe('unsetDefaultOrgCommand', () => {
   let unsetTargetOrgMock: jest.Mock;
@@ -43,7 +44,7 @@ describe('unsetDefaultOrgCommand', () => {
     expect(Exit.isSuccess(exit)).toBe(true);
     expect(unsetTargetOrgMock).toHaveBeenCalledTimes(1);
     expect(showInformationMessageMock).toHaveBeenCalledTimes(1);
-    expect(showInformationMessageMock).toHaveBeenCalledWith('Successfully unset the default org.');
+    expect(showInformationMessageMock).toHaveBeenCalledWith(nls.localize('unset_default_org_success'));
   });
 
   it('propagates failure when unsetTargetOrg fails', async () => {

--- a/packages/salesforcedx-vscode-org/test/jest/commands/unsetDefaultOrg.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/commands/unsetDefaultOrg.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
+import * as Effect from 'effect/Effect';
+import * as Exit from 'effect/Exit';
+import * as vscode from 'vscode';
+import { unsetDefaultOrgCommand } from '../../../src/commands/unsetDefaultOrg';
+
+describe('unsetDefaultOrgCommand', () => {
+  let unsetTargetOrgMock: jest.Mock;
+  let showInformationMessageMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    unsetTargetOrgMock = jest.fn().mockReturnValue(Effect.void);
+    showInformationMessageMock = vscode.window.showInformationMessage as unknown as jest.Mock;
+    showInformationMessageMock.mockResolvedValue(undefined);
+  });
+
+  const run = (opts: { unsetTargetOrg: jest.Mock }) =>
+    Effect.runPromiseExit(
+      unsetDefaultOrgCommand().pipe(
+        Effect.provideService(ExtensionProviderService, {
+          getServicesApi: Effect.succeed({
+            services: {
+              ConfigService: {
+                unsetTargetOrg: opts.unsetTargetOrg
+              }
+            }
+          })
+        } as unknown as ExtensionProviderService)
+      ) as Effect.Effect<void, unknown, never>
+    );
+
+  it('calls ConfigService.unsetTargetOrg and shows a success notification', async () => {
+    const exit = await run({ unsetTargetOrg: unsetTargetOrgMock });
+
+    expect(Exit.isSuccess(exit)).toBe(true);
+    expect(unsetTargetOrgMock).toHaveBeenCalledTimes(1);
+    expect(showInformationMessageMock).toHaveBeenCalledTimes(1);
+    expect(showInformationMessageMock).toHaveBeenCalledWith('Successfully unset the default org.');
+  });
+
+  it('propagates failure when unsetTargetOrg fails', async () => {
+    unsetTargetOrgMock = jest.fn().mockReturnValue(Effect.fail({ _tag: 'ConfigWriteError', message: 'write failed' }));
+    const exit = await run({ unsetTargetOrg: unsetTargetOrgMock });
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    expect(showInformationMessageMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/salesforcedx-vscode-org/test/playwright/specs/orgCommands.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-org/test/playwright/specs/orgCommands.desktop.spec.ts
@@ -32,4 +32,8 @@ test('org extension: SFDX org commands appear in palette when project is open', 
   await test.step('Set a Default Org', async () => {
     await verifyCommandExists(page, packageNls.config_set_org_text, 60_000);
   });
+
+  await test.step('Unset a Default Org', async () => {
+    await verifyCommandExists(page, packageNls.config_unset_org_text, 60_000);
+  });
 });

--- a/packages/salesforcedx-vscode-org/test/playwright/specs/orgCommands.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-org/test/playwright/specs/orgCommands.desktop.spec.ts
@@ -12,7 +12,7 @@ import {
   waitForVSCodeWorkbench
 } from '@salesforce/playwright-vscode-ext';
 import packageNls from '../../../package.nls.json';
-import { orgDesktopTest as test } from '../fixtures/desktopFixtures';
+import { orgDesktopMinimalDefaultTest as test } from '../fixtures/desktopFixtures';
 
 test('org extension: SFDX org commands appear in palette when project is open', async ({ page }) => {
   test.setTimeout(120_000);

--- a/packages/salesforcedx-vscode-org/test/playwright/specs/orgPickers.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-org/test/playwright/specs/orgPickers.desktop.spec.ts
@@ -192,6 +192,20 @@ test('org pickers: display, delete, logout pick + confirm + cancel flows', async
     // Durable signal: poll the CLI until the default org is no longer authorized.
     await expectOrgLoggedOut(DEFAULT_LOGOUT_ORG_ALIAS);
   });
+
+  await test.step('UNSET DEFAULT: command clears the default org and status bar reflects it', async () => {
+    // Re-set MINIMAL_ORG_ALIAS as default so we can unset it
+    await clickOrgPickerStatusBar(page, 'No Default Org Set');
+    await expectOrgPickerListsOrg(page, MINIMAL_ORG_ALIAS);
+    await selectOrgInPicker(page, MINIMAL_ORG_ALIAS);
+    await expectOrgPickerStatusBar(page, MINIMAL_ORG_ALIAS);
+
+    // Execute the unset command
+    await executeCommandWithCommandPalette(page, packageNls.config_unset_org_text);
+
+    // Status bar should reflect no default org
+    await expectOrgPickerStatusBar(page, 'No Default Org Set');
+  });
 });
 
 /** Poll the CLI until the alias is no longer authorized (durable, non-racy removal signal). */


### PR DESCRIPTION
## Summary

- Adds a new `sf.unset.default.org` VS Code command to `salesforcedx-vscode-org` that calls `ConfigService.unsetTargetOrg()` via the services API
- Command appears in the command palette only when `sf:project_opened && sf:has_target_org` — it auto-hides after execution as the context key clears reactively
- Includes unit test (Jest) and e2e Playwright coverage (command palette visibility + status bar transition)

## Test plan

- [ ] `npm run test:jest` in `packages/salesforcedx-vscode-org` passes (184 tests)
- [ ] `npm run compile` in `packages/salesforcedx-vscode-org` passes
- [ ] e2e: `orgCommands.desktop.spec.ts` — command visible in palette via `verifyCommandExists`
- [ ] e2e: `orgPickers.desktop.spec.ts` — executing command clears status bar to `No Default Org Set`

🤖 Generated with [Claude Code](https://claude.com/claude-code)