### PR TITLE
chore(core): remove dead findParentMetadataType from metadataHoverProvider - W-23446403

### DIFF
--- a/.claude/plans/W-23446403.md
+++ b/.claude/plans/W-23446403.md
@@ -1,0 +1,27 @@
+# W-23446403 — Remove dead findParentMetadataType
+
+## Context
+
+- `findParentMetadataType` (src/metadataSupport/metadataHoverProvider.ts:103-142, incl JSDoc) — 0 prod callers
+- superseded by `findParentMetadataTypeWithLayers` (called lines 277, 308)
+- only caller: own test block, test/jest/metadataSupport/metadataHoverProvider.test.ts:357-417 (`describe('findParentMetadataType')`, 4 tests) + import line 15
+- not in SalesforceVSCodeCoreApi surface — no external-consumer risk
+
+## Phases
+
+### Phase 1 — delete function + tests
+- src: remove JSDoc + `findParentMetadataType` (lines 103-142)
+- test: drop `findParentMetadataType` from import (line 15), keep `findParentMetadataTypeWithLayers`
+- test: delete `describe('findParentMetadataType')` block (lines 357-417)
+- commit: `chore(core): remove dead findParentMetadataType from metadataHoverProvider - W-23446403`
+
+## Skills
+- concise (plan/docs)
+- typescript
+- verification
+
+## Verification
+- `npx jest metadataHoverProvider` (core) — passes, no ref to removed fn
+- `npm run check:knip` — no new unused-export
+- `npx eslint` on both touched files — clean
+- no e2e coverage relevant

--- a/packages/salesforcedx-vscode-core/src/metadataSupport/metadataHoverProvider.ts
+++ b/packages/salesforcedx-vscode-core/src/metadataSupport/metadataHoverProvider.ts
@@ -101,47 +101,6 @@ export const extractMetadataType = (
 };
 
 /**
- * Find the parent metadata type by scanning upward from current line
- */
-export const findParentMetadataType = (
-  document: vscode.TextDocument,
-  startLine: number,
-  documentationService: MetadataDocumentationService
-): string | null => {
-  for (let i = startLine; i >= 0; i--) {
-    const line = document.lineAt(i).text;
-    const xmlElementRegex = /<([\w:]+)(\s|>)/g;
-    let match;
-
-    while ((match = xmlElementRegex.exec(line)) !== null) {
-      const elementName = match[1];
-      const cleanElementName = elementName.includes(':') ? elementName.split(':')[1] : elementName;
-
-      // Check if this is a valid Salesforce metadata type
-      if (documentationService.isValidMetadataType(cleanElementName)) {
-        return cleanElementName;
-      }
-    }
-
-    // Also check for multi-line elements (when closing > is on next line)
-    const multiLineElementRegex = /<([\w:]+)$/g;
-    let multiLineMatch;
-
-    while ((multiLineMatch = multiLineElementRegex.exec(line)) !== null) {
-      const elementName = multiLineMatch[1];
-      const cleanElementName = elementName.includes(':') ? elementName.split(':')[1] : elementName;
-
-      // Check if this is a valid Salesforce metadata type
-      if (documentationService.isValidMetadataType(cleanElementName)) {
-        return cleanElementName;
-      }
-    }
-  }
-
-  return null;
-};
-
-/**
  * Find the parent metadata type and all intermediate layers by scanning upward from current line
  */
 export const findParentMetadataTypeWithLayers = (

--- a/packages/salesforcedx-vscode-core/test/jest/metadataSupport/metadataHoverProvider.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/metadataSupport/metadataHoverProvider.test.ts
@@ -12,7 +12,6 @@ import {
   isMetadataFile,
   extractMetadataType,
   extractFieldInfo,
-  findParentMetadataType,
   findParentMetadataTypeWithLayers
 } from '../../../src/metadataSupport/metadataHoverProvider';
 
@@ -351,68 +350,6 @@ describe('MetadataHoverProvider', () => {
         metadataType: 'Flow',
         intermediateLayers: ['decisions', 'rules', 'conditions']
       });
-    });
-  });
-
-  describe('findParentMetadataType', () => {
-    it('should find parent metadata type from current line', () => {
-      const mockDocService = createMockDocumentationService(new Set(['ApexClass', 'CustomObject', 'Flow']));
-      const content = `<?xml version="1.0" encoding="UTF-8"?>
-<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
-    <label>Test Object</label>
-    <enableActivities>true</enableActivities>
-</CustomObject>`;
-
-      const document = createMockDocument('TestObject__c.object-meta.xml', content);
-
-      const result = findParentMetadataType(document, 3, mockDocService);
-
-      expect(result).toBe('CustomObject');
-    });
-
-    it('should find parent metadata type from multiple lines above', () => {
-      const mockDocService = createMockDocumentationService(new Set(['ApexClass', 'CustomObject', 'Flow']));
-      const content = `<?xml version="1.0" encoding="UTF-8"?>
-<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>59.0</apiVersion>
-    <description>Test description</description>
-
-    <status>Active</status>
-</ApexClass>`;
-
-      const document = createMockDocument('TestClass.cls-meta.xml', content);
-
-      const result = findParentMetadataType(document, 5, mockDocService);
-
-      expect(result).toBe('ApexClass');
-    });
-
-    it('should handle namespaced parent elements', () => {
-      const mockDocService = createMockDocumentationService(new Set(['ApexClass', 'CustomObject', 'Flow']));
-      const content = `<?xml version="1.0" encoding="UTF-8"?>
-<tns:Flow xmlns:tns="http://soap.sforce.com/2006/04/metadata">
-    <tns:status>Active</tns:status>
-</tns:Flow>`;
-
-      const document = createMockDocument('TestFlow.flow-meta.xml', content);
-
-      const result = findParentMetadataType(document, 2, mockDocService);
-
-      expect(result).toBe('Flow');
-    });
-
-    it('should return null when no parent metadata type found', () => {
-      const mockDocService = createMockDocumentationService(new Set(['ApexClass', 'CustomObject', 'Flow']));
-      const content = `<?xml version="1.0" encoding="UTF-8"?>
-<root>
-    <someField>value</someField>
-</root>`;
-
-      const document = createMockDocument('test.xml', content);
-
-      const result = findParentMetadataType(document, 2, mockDocService);
-
-      expect(result).toBeNull();
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

## Summary
- Removes dead `findParentMetadataType` from `metadataHoverProvider.ts` — 0 prod callers, superseded by `findParentMetadataTypeWithLayers`
- Drops its associated test block and now-unused import in `metadataHoverProvider.test.ts`

## Plan
[.claude/plans/W-23446403.md](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23446403-remove-dead-findparentmetadatatype-from/.claude/plans/W-23446403.md)

### What issues does this PR fix or reference?
@W-23446403@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002ekMx5YAE/view
