### PR TITLE
refactor(utils-vscode): remove dead projectPaths members - W-23446597

### DIFF
--- a/.claude/plans/W-23446597.md
+++ b/.claude/plans/W-23446597.md
@@ -1,0 +1,47 @@
+# W-23446597 — Remove test-only projectPaths members
+
+## Context
+
+- File: `packages/salesforcedx-utils-vscode/src/helpers/paths.ts`
+- Dead `projectPaths` members (only unit-test callers): `metadataFolder`, `testResultsFolder`, `apexLanguageServerDatabase`, `lwcTestResultsFolder`
+- `relativeStateFolder`/`relativeToolsFolder` from WI: NOT present in file — skip
+- Keep (prod callers): `stateFolder`, `apexTestResultsFolder`, `debugLogsFolder`, `salesforceProjectConfig`
+- `toolsFolder`: no external callers; used by survivors `apexTestResultsFolder` + `debugLogsFolder` → keep private, drop from exported `projectPaths` object
+- Safe: package unpublished (npm 404); `projectPaths` not in core `.exports` nor `@salesforce/vscode-service-provider`
+- Constants only feeding removed members: `ORGS`, `METADATA`, `APEX_DB`, `LWC` — no external importers (grep: test file only) → remove
+- Constants still used by survivors: `TOOLS`, `TEST_RESULTS`, `APEX`, `DEBUG`, `LOGS`, `SFDX_CONFIG_FILE` → keep
+- After removing `metadataFolder`: `WorkspaceContextUtil` import unused → remove
+- Test file: `packages/salesforcedx-utils-vscode/test/jest/helpers/paths.test.ts` (198 lines); drop dead describe blocks + `toolsFolder` describe (references dropped export) + unused constant imports
+
+## Phases
+
+### Phase 1 — remove dead members, private toolsFolder, prune constants + tests
+
+`paths.ts`:
+- delete fns `metadataFolder`, `testResultsFolder`, `apexLanguageServerDatabase`, `lwcTestResultsFolder`
+- delete their entries from `projectPaths` object; also drop `toolsFolder` from object (keep fn as private `const`)
+- delete constant exports `ORGS`, `METADATA`, `APEX_DB`, `LWC`
+- delete now-unused `WorkspaceContextUtil` import
+
+`paths.test.ts`:
+- delete describe blocks: `metadataFolder`, `apexLanguageServerDatabase`, `lwcTestResultsFolder`, `testResultsFolder`, `toolsFolder`
+- prune imports: drop `WorkspaceContextUtil`, `APEX_DB`, `LWC`, `METADATA`, `ORGS`; drop `FAKE_WORKSPACE_INSTANCE` if orphaned
+- keep imports still referenced: `APEX`, `DEBUG`, `LOGS`, `SFDX_CONFIG_FILE`, `TEST_RESULTS`, `TOOLS`
+
+Files: `packages/salesforcedx-utils-vscode/src/helpers/paths.ts`, `packages/salesforcedx-utils-vscode/test/jest/helpers/paths.test.ts`
+
+Commit: `refactor(utils-vscode): remove dead projectPaths members - W-23446597`
+
+## Skills
+
+- paths — file is `/src`; keep node:path usage as-is (helper computes state-folder paths, not editor I/O); no new URI work needed
+- typescript — verify no unused imports/exports after prune
+- concise — this plan + any docs
+
+## Verification
+
+- `npm run compile` (or package tsc) — no unused-symbol / TS errors
+- jest: `packages/salesforcedx-utils-vscode` paths.test.ts green
+- eslint paths.ts + test (no unused imports)
+- grep repo: zero non-test refs to removed members/constants (done in planning; re-confirm post-edit)
+- not e2e-covered — pure lib prune, unit-only

--- a/packages/salesforcedx-utils-vscode/src/helpers/paths.ts
+++ b/packages/salesforcedx-utils-vscode/src/helpers/paths.ts
@@ -8,18 +8,13 @@
 import { Global } from '@salesforce/core/global';
 import * as path from 'node:path';
 import { URI } from 'vscode-uri';
-import { WorkspaceContextUtil } from '../context/workspaceContextUtil';
 import { workspaceUtils } from '../workspaces/workspaceUtils';
 
-export const ORGS = 'orgs';
-export const METADATA = 'metadata';
 export const TOOLS = 'tools';
 export const TEST_RESULTS = 'testresults';
 export const APEX = 'apex';
 export const DEBUG = 'debug';
 export const LOGS = 'logs';
-export const APEX_DB = 'apex.db';
-export const LWC = 'lwc';
 export const SFDX_CONFIG_FILE = 'sfdx-config.json';
 
 export const fileExtensionsMatch = (sourceUri: URI, targetExtension: string): boolean => {
@@ -30,30 +25,9 @@ export const fileExtensionsMatch = (sourceUri: URI, targetExtension: string): bo
 const stateFolder = (): string =>
   workspaceUtils.hasRootWorkspace() ? path.join(workspaceUtils.getRootWorkspacePath(), Global.SFDX_STATE_FOLDER) : '';
 
-const metadataFolder = (): string => {
-  const username = WorkspaceContextUtil.getInstance().username;
-  const pathToMetadataFolder = path.join(projectPaths.stateFolder(), ORGS, String(username), METADATA);
-  return pathToMetadataFolder;
-};
-
 const apexTestResultsFolder = (): string => {
   const pathToApexTestResultsFolder = path.join(toolsFolder(), TEST_RESULTS, APEX);
   return pathToApexTestResultsFolder;
-};
-
-const apexLanguageServerDatabase = (): string => {
-  const pathToApexLangServerDb = path.join(toolsFolder(), APEX_DB);
-  return pathToApexLangServerDb;
-};
-
-const lwcTestResultsFolder = (): string => {
-  const pathToLwcTestResultsFolder = path.join(testResultsFolder(), LWC);
-  return pathToLwcTestResultsFolder;
-};
-
-const testResultsFolder = (): string => {
-  const pathToTestResultsFolder = path.join(toolsFolder(), TEST_RESULTS);
-  return pathToTestResultsFolder;
 };
 
 const debugLogsFolder = (): string => {
@@ -73,12 +47,7 @@ const toolsFolder = (): string => {
 
 export const projectPaths = {
   stateFolder,
-  metadataFolder,
-  testResultsFolder,
   apexTestResultsFolder,
-  apexLanguageServerDatabase,
   debugLogsFolder,
-  salesforceProjectConfig,
-  toolsFolder,
-  lwcTestResultsFolder
+  salesforceProjectConfig
 };

--- a/packages/salesforcedx-utils-vscode/test/jest/helpers/paths.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/helpers/paths.test.ts
@@ -7,17 +7,12 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { URI } from 'vscode-uri';
-import { WorkspaceContextUtil } from '../../../src/context/workspaceContextUtil';
 import {
   projectPaths,
   fileExtensionsMatch,
   APEX,
-  APEX_DB,
   DEBUG,
   LOGS,
-  LWC,
-  METADATA,
-  ORGS,
   SFDX_CONFIG_FILE,
   TEST_RESULTS,
   TOOLS
@@ -36,7 +31,6 @@ jest.mock('@salesforce/source-tracking', () => ({}));
 describe('test project paths', () => {
   const hasRootWorkspaceStub = jest.spyOn(workspaceUtils, 'hasRootWorkspace');
   const FAKE_WORKSPACE = '/here/is/a/fake/path/to/';
-  const FAKE_WORKSPACE_INSTANCE: any = {};
   const FAKE_STATE_FOLDER = '.sfdx';
   const FAKE_PATH_TO_STATE_FOLDER = path.join(FAKE_WORKSPACE, FAKE_STATE_FOLDER);
 
@@ -72,38 +66,6 @@ describe('test project paths', () => {
     });
   });
 
-  describe('test toolsFolder', () => {
-    beforeEach(() => {
-      jest.spyOn(projectPaths, 'stateFolder').mockReturnValue(FAKE_WORKSPACE);
-    });
-    it('should be defined', () => {
-      expect(projectPaths.toolsFolder).toBeDefined();
-    });
-
-    it('should return a path to the tools folder based on root workspace', () => {
-      const toolsFolder = projectPaths.toolsFolder();
-      expect(toolsFolder).toEqual(path.join(FAKE_WORKSPACE, TOOLS));
-    });
-  });
-
-  describe('test metadataFolder', () => {
-    beforeEach(() => {
-      FAKE_WORKSPACE_INSTANCE.username = 'fakeUsername';
-      jest.spyOn(projectPaths, 'stateFolder').mockReturnValue(FAKE_WORKSPACE);
-
-      jest.spyOn(WorkspaceContextUtil, 'getInstance').mockReturnValue(FAKE_WORKSPACE_INSTANCE);
-    });
-    it('should be defined', () => {
-      expect(projectPaths.metadataFolder).toBeDefined();
-    });
-
-    it('should return a path to the metadata folder based on root workspace', () => {
-      const metadataFolder = projectPaths.metadataFolder();
-      const username = FAKE_WORKSPACE_INSTANCE.username;
-      expect(metadataFolder).toEqual(path.join(FAKE_WORKSPACE, ORGS, username, METADATA));
-    });
-  });
-
   describe('test apexTestResultsFolder', () => {
     beforeEach(() => {
       jest.spyOn(projectPaths, 'stateFolder').mockReturnValue(FAKE_WORKSPACE);
@@ -115,48 +77,6 @@ describe('test project paths', () => {
     it('should return a path to the apex test results folder based on root workspace', () => {
       const apexTestResultsFolder = projectPaths.apexTestResultsFolder();
       expect(apexTestResultsFolder).toEqual(path.join(FAKE_WORKSPACE, TOOLS, TEST_RESULTS, APEX));
-    });
-  });
-
-  describe('test apexLanguageServerDatabase', () => {
-    beforeEach(() => {
-      jest.spyOn(projectPaths, 'stateFolder').mockReturnValue(FAKE_WORKSPACE);
-    });
-    it('should be defined', () => {
-      expect(projectPaths.apexLanguageServerDatabase).toBeDefined();
-    });
-
-    it('should return a path to the apex Language Server Database folder based on root workspace', () => {
-      const apexLanguageServerDatabase = projectPaths.apexLanguageServerDatabase();
-      expect(apexLanguageServerDatabase).toEqual(path.join(FAKE_WORKSPACE, TOOLS, APEX_DB));
-    });
-  });
-
-  describe('test lwcTestResultsFolder', () => {
-    beforeEach(() => {
-      jest.spyOn(projectPaths, 'stateFolder').mockReturnValue(FAKE_WORKSPACE);
-    });
-    it('should be defined', () => {
-      expect(projectPaths.lwcTestResultsFolder).toBeDefined();
-    });
-
-    it('should return a path to the lwc Test Results Folder based on root workspace', () => {
-      const lwcTestResultsFolder = projectPaths.lwcTestResultsFolder();
-      expect(lwcTestResultsFolder).toEqual(path.join(FAKE_WORKSPACE, TOOLS, TEST_RESULTS, LWC));
-    });
-  });
-
-  describe('test testResultsFolder', () => {
-    beforeEach(() => {
-      jest.spyOn(projectPaths, 'stateFolder').mockReturnValue(FAKE_WORKSPACE);
-    });
-    it('should be defined', () => {
-      expect(projectPaths.testResultsFolder).toBeDefined();
-    });
-
-    it('should return a path to the  Test Results Folder based on root workspace', () => {
-      const testResultsFolder = projectPaths.testResultsFolder();
-      expect(testResultsFolder).toEqual(path.join(FAKE_WORKSPACE, TOOLS, TEST_RESULTS));
     });
   });
 


### PR DESCRIPTION
## Summary

- Removed dead `projectPaths` members (`metadataFolder`, `testResultsFolder`, `apexLanguageServerDatabase`, `lwcTestResultsFolder`) with no production callers, only unit tests
- Made `toolsFolder` a private helper (still used internally by `apexTestResultsFolder`/`debugLogsFolder`), dropped from the exported `projectPaths` object
- Pruned now-unused constants (`ORGS`, `METADATA`, `APEX_DB`, `LWC`), the unused `WorkspaceContextUtil` import, and corresponding dead test describe blocks

## Plan

.claude/plans/W-23446597.md

## Test plan

No manual verification steps — this is a pure lib prune covered entirely by existing unit tests, compile, and lint (all enforced by CI).

### What issues does this PR fix or reference?
@W-23446597@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002ejxxxYAA/view