### PR TITLE
fix(lwc): display Jest runtime errors instead of "no output" message W-23540480

### DIFF
--- a/packages/salesforcedx-vscode-lwc/src/testSupport/testExplorer/lwcTestController.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/testExplorer/lwcTestController.ts
@@ -596,6 +596,20 @@ class LwcTestController {
       // remaining short/long (8.3) path divergence back to the discovery URI that keys the items.
       const testUri = this.resolveDiscoveryUri(URI.file(normalizeJestFsPath(fileResult.name)));
       const fileItem = this.fileItems.get(createFileId(testUri));
+
+      // When assertionResults is empty and there's a runtime error message, mark file and all its children as errored
+      if (fileResult.assertionResults.length === 0 && fileResult.message && fileItem) {
+        // Strip ANSI escape codes from Jest's error message
+        const cleanMessage = fileResult.message.replaceAll(/\x1b\[[0-9;]*m/g, '');
+        const errorMessage = new vscode.TestMessage(cleanMessage);
+        run.errored(fileItem, errorMessage);
+        // Mark all child test items as errored since the suite failed to run
+        fileItem.children.forEach(child => {
+          run.errored(child, errorMessage);
+        });
+        continue;
+      }
+
       for (const assertion of fileResult.assertionResults) {
         const id = createCaseId(testUri, assertion.title, assertion.ancestorTitles);
         const caseItem = this.caseItems.get(id);

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/testExplorer/testResultsOutput.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/testExplorer/testResultsOutput.ts
@@ -75,8 +75,14 @@ export const appendTestResultsOutput = (
     run.appendOutput(toCrlf(`${fileBadge(fileResult)}  ${formatPrettyPath(relPath)}${durationSuffix}`));
 
     const fileItem = lookup.findFileItem(testUri);
-    const tree = buildDescribeTree(fileResult.assertionResults);
-    renderDescribeNode(run, testUri, tree, 1, fileItem, lookup);
+
+    // When assertionResults is empty but message exists, show the runtime error
+    if (fileResult.assertionResults.length === 0 && fileResult.message) {
+      run.appendOutput(toCrlf(`  ${fileResult.message}`), undefined, fileItem);
+    } else {
+      const tree = buildDescribeTree(fileResult.assertionResults);
+      renderDescribeNode(run, testUri, tree, 1, fileItem, lookup);
+    }
     run.appendOutput('\r\n');
   }
 

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/types/index.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/types/index.ts
@@ -108,6 +108,7 @@ type LwcJestTestResultStatus = 'passed' | 'failed' | 'pending' | 'skipped' | 'to
 
 /**
  * Jest Test File Result
+ * @property {string} message - Optional runtime error message when test suite fails to run before assertions can be collected
  */
 export type LwcJestTestFileResult = {
   status: 'passed' | 'failed';
@@ -115,6 +116,7 @@ export type LwcJestTestFileResult = {
   endTime: number;
   name: string;
   assertionResults: LwcJestTestAssertionResult[];
+  message?: string; // Runtime error message when test suite fails to run
 };
 
 /**


### PR DESCRIPTION
When Jest fails to run a test suite before collecting assertions (e.g., module resolution errors, syntax errors), the test explorer was showing generic "test case did not report any output" messages with no context.

Jest provides the error details in the message field when assertionResults is empty, but this was being ignored.

Changes:
- Add optional message field to LwcJestTestFileResult type to capture runtime errors from Jest output
- Display the runtime error message in Test Results panel when assertions array is empty
- Mark test file and child items as errored with the cleaned error message (ANSI codes stripped) instead of leaving them without output

Users now see the actual error (e.g., "Test suite failed to run: Cannot find module 'c/foo'...") instead of a generic "no output" message, making debugging much easier.

<!--- PR title: <type>(optional scope): <description> - W-XXXXXXXX — append GUS work item at the end (space, hyphen, space, W-). Conventional commits: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?

### What issues does this PR fix or reference?
#[7788](https://github.com/forcedotcom/salesforcedx-vscode/issues/7788), @W-23540480@

### Functionality Before
When tests were unable to run, we should false positives and message like 'No test results produced'

### Functionality After
We show message that we tests were unable to run with a popup.
