### PR TITLE
feat(ci): add GHA workflow to tag linked issues/discussions 'pending release' on PR merge - W-23351778

### DIFF
--- a/.claude/plans/W-23351778.md
+++ b/.claude/plans/W-23351778.md
@@ -10,21 +10,21 @@
 
 ### Trigger: `pull_request_target` (not `pull_request`)
 
-**Rationale:** The `pull_request` event from a forked PR gives GITHUB_TOKEN read-only permissions regardless of declared `permissions:` block. Since this workflow needs `issues: write` and GraphQL label mutations, it would silently 403 on fork PRs. Using `pull_request_target` types `[closed]` runs in the base-repo context with the full write token. This is safe because the workflow never checks out or executes PR code — it only reads `github.event.pull_request.body` (an event payload field) and calls GitHub APIs.
+**Why:** `pull_request` from fork → read-only GITHUB_TOKEN regardless of `permissions:` block; `pull_request_target` runs in base-repo context with write token. Safe: no PR code checked out or executed.
 
-Alternative considered: `IDEE_GH_TOKEN` (used in validateNewIssues.yml, publishVSCode.yml). Rejected because `pull_request_target` is the simpler, secret-free solution when the workflow does not need to run PR-supplied code.
+Alt: `IDEE_GH_TOKEN` (validateNewIssues.yml, publishVSCode.yml) — rejected; `pull_request_target` simpler, no secret needed.
 
 ### Parsing: full URLs and short references
 
-The PR template (`.github/PULL_REQUEST_TEMPLATE.md:7`) uses the `#NNN` shorthand. The workflow must parse both:
+PR template (`.github/PULL_REQUEST_TEMPLATE.md:7`) uses `#NNN`; parse both:
 - Full URLs: `github.com/{owner}/{repo}/issues/NNN`, `github.com/{owner}/{repo}/discussions/NNN`
-- Short references: bare `#NNN` and keyword-prefixed forms `Closes #NNN`, `Fixes #NNN`, `Resolves #NNN` (case-insensitive, singular and plural forms)
+- Short references: keyword-prefixed forms `Closes #NNN`, `Fixes #NNN`, `Resolves #NNN` (case-insensitive, singular forms); bare `#NNN` without keyword not matched to avoid false positives
 
-Short references are ambiguous (could be issue or discussion). The workflow resolves them by first attempting `gh issue view`; if that fails (not found), it falls back to querying as a discussion via GraphQL.
+Short refs: ambiguous (issue or discussion). Resolve: try `gh issue view`; fallback to GraphQL discussion query.
 
 ### Label node ID fetch for discussions
 
-The `addLabelsToLabelable` GraphQL mutation requires both the labelable node ID (discussion) and the label node ID. The workflow must explicitly query the `pending release` label's node ID via `repository.label(name:)` before attempting the mutation. If the label does not exist, the workflow emits a `::warning::` and skips discussion labeling (mirroring the error-guard pattern from closePendingReleaseIssues.yml:104-107).
+`addLabelsToLabelable` needs labelable node ID + label node ID. Query `repository.label(name:)` first. If label missing: emit `::warning::`, skip discussion labeling (mirrors closePendingReleaseIssues.yml:104-107).
 
 ## Phases
 
@@ -38,7 +38,7 @@ The `addLabelsToLabelable` GraphQL mutation requires both the labelable node ID 
   1. **Parse PR body for linked issues and discussions:**
      - Extract full issue URLs: `grep -oP 'github\.com/${{ github.repository }}/issues/\K[0-9]+'`
      - Extract full discussion URLs: `grep -oP 'github\.com/${{ github.repository }}/discussions/\K[0-9]+'`
-     - Extract short references (bare `#NNN` and keyword-prefixed): `grep -oiP '(?:closes|close|fixes|fix|resolves|resolve)?\s*#\K[0-9]+'`
+     - Extract keyword-prefixed short references: `grep -oiP '(?:closes|close|fixes|fix|resolves|resolve)\s*#\K[0-9]+'`
      - Deduplicate all numbers; classify full-URL matches as known-issue or known-discussion; short-ref numbers go into an "unresolved" set for runtime type detection
   2. **Label issues:** For each known-issue number and each unresolved number that `gh issue view $N` succeeds on: `gh issue edit $N --add-label "pending release"`
   3. **Fetch `pending release` label node ID:**
@@ -83,8 +83,8 @@ The `addLabelsToLabelable` GraphQL mutation requires both the labelable node ID 
 
 ## Verification
 
-- Run `.github/scripts/test-parse-pending-release.sh` — asserts all supported PR body patterns produce correct issue/discussion numbers
-- Existing `check:actions` task (`validateActions.ts` in validatePR.yml:34) already lints all workflow YAMLs including the new one; no separate `actionlint` invocation needed
-- Manual dry-run: open a test PR on the repo with `workflow_dispatch` is not applicable since `pull_request_target` cannot be dispatched, but the parse script provides equivalent confidence for the regex logic
+- `.github/scripts/test-parse-pending-release.sh` — validates regex against all supported PR body patterns
+- `check:actions` (`validateActions.ts` in validatePR.yml:34) lints all workflow YAMLs including the new one
+- Manual dry-run: N/A (`pull_request_target` not dispatchable); parse script provides equivalent regex confidence
 - Fork-PR safety: confirmed by trigger choice (`pull_request_target` runs in base context with write token); no checkout of fork code occurs
 - e2e: exercised by any real PR merge that references an issue or discussion; first merge after deployment serves as integration validation

--- a/.claude/plans/W-23351778.md
+++ b/.claude/plans/W-23351778.md
@@ -1,0 +1,90 @@
+# W-23351778 — GHA: tag linked issues/discussions "pending release" on PR merge
+
+## Context
+
+- `closePendingReleaseIssues.yml` closes issues/discussions labeled `pending release` after publish
+- upstream counterpart: applies the label when a PR merges
+- `pending release` label already used in validateNewIssues, validateUpdatedIssues guards
+
+## Design Decisions
+
+### Trigger: `pull_request_target` (not `pull_request`)
+
+**Rationale:** The `pull_request` event from a forked PR gives GITHUB_TOKEN read-only permissions regardless of declared `permissions:` block. Since this workflow needs `issues: write` and GraphQL label mutations, it would silently 403 on fork PRs. Using `pull_request_target` types `[closed]` runs in the base-repo context with the full write token. This is safe because the workflow never checks out or executes PR code — it only reads `github.event.pull_request.body` (an event payload field) and calls GitHub APIs.
+
+Alternative considered: `IDEE_GH_TOKEN` (used in validateNewIssues.yml, publishVSCode.yml). Rejected because `pull_request_target` is the simpler, secret-free solution when the workflow does not need to run PR-supplied code.
+
+### Parsing: full URLs and short references
+
+The PR template (`.github/PULL_REQUEST_TEMPLATE.md:7`) uses the `#NNN` shorthand. The workflow must parse both:
+- Full URLs: `github.com/{owner}/{repo}/issues/NNN`, `github.com/{owner}/{repo}/discussions/NNN`
+- Short references: bare `#NNN` and keyword-prefixed forms `Closes #NNN`, `Fixes #NNN`, `Resolves #NNN` (case-insensitive, singular and plural forms)
+
+Short references are ambiguous (could be issue or discussion). The workflow resolves them by first attempting `gh issue view`; if that fails (not found), it falls back to querying as a discussion via GraphQL.
+
+### Label node ID fetch for discussions
+
+The `addLabelsToLabelable` GraphQL mutation requires both the labelable node ID (discussion) and the label node ID. The workflow must explicitly query the `pending release` label's node ID via `repository.label(name:)` before attempting the mutation. If the label does not exist, the workflow emits a `::warning::` and skips discussion labeling (mirroring the error-guard pattern from closePendingReleaseIssues.yml:104-107).
+
+## Phases
+
+### Phase 1: Add workflow file
+
+- Create `.github/workflows/tagPendingRelease.yml`
+- Trigger: `pull_request_target` types `[closed]`
+- Job guard: `if: github.event.pull_request.merged == true`
+- Permissions: `issues: write`, `discussions: write`, `contents: read`
+- Steps:
+  1. **Parse PR body for linked issues and discussions:**
+     - Extract full issue URLs: `grep -oP 'github\.com/${{ github.repository }}/issues/\K[0-9]+'`
+     - Extract full discussion URLs: `grep -oP 'github\.com/${{ github.repository }}/discussions/\K[0-9]+'`
+     - Extract short references (bare `#NNN` and keyword-prefixed): `grep -oiP '(?:closes|close|fixes|fix|resolves|resolve)?\s*#\K[0-9]+'`
+     - Deduplicate all numbers; classify full-URL matches as known-issue or known-discussion; short-ref numbers go into an "unresolved" set for runtime type detection
+  2. **Label issues:** For each known-issue number and each unresolved number that `gh issue view $N` succeeds on: `gh issue edit $N --add-label "pending release"`
+  3. **Fetch `pending release` label node ID:**
+     - Query: `repository(owner:, name:) { label(name: "pending release") { id } }`
+     - If null: emit `::warning::Label 'pending release' not found in repository, skipping discussion labeling` and skip step 4
+  4. **Label discussions:** For each known-discussion number and each unresolved number that was not found as an issue:
+     - Fetch discussion node ID via `repository.discussion(number:)` GraphQL query
+     - If null: emit `::warning::Discussion #N not found or inaccessible, skipping` and continue
+     - Call `addLabelsToLabelable(input: {labelableId: $DISC_ID, labelIds: [$LABEL_ID]})` mutation
+     - On failure: emit `::warning::Failed to label discussion #N` and continue
+- No-op (success, no warnings) if no links found
+
+**Commit:** `feat(ci): add workflow to label linked issues/discussions "pending release" on PR merge - W-23351778`
+
+**Files:**
+- `.github/workflows/tagPendingRelease.yml`
+
+### Phase 2: Add parse verification script
+
+- Create `.github/scripts/test-parse-pending-release.sh`
+- A standalone bash script that exercises the grep/regex parsing logic from Phase 1 against known PR body strings
+- Test cases:
+  - Full issue URL: `https://github.com/forcedotcom/salesforcedx-vscode/issues/123`
+  - Full discussion URL: `https://github.com/forcedotcom/salesforcedx-vscode/discussions/456`
+  - Bare short ref: `#789`
+  - Keyword-prefixed short refs: `Closes #100`, `Fixes #200`, `Resolves #300`, `fixes #400`
+  - Mixed body with multiple refs and prose text
+  - Body with no refs (should produce empty output)
+  - Body with refs to other repos (should be excluded from full-URL matches, included from short-ref matches since short refs are repo-local)
+- Script exits 0 on all assertions passing, exits 1 with diff output on failure
+- Runnable locally: `bash .github/scripts/test-parse-pending-release.sh`
+
+**Commit:** `test(ci): add parse verification script for tagPendingRelease regex - W-23351778`
+
+**Files:**
+- `.github/scripts/test-parse-pending-release.sh`
+
+## Skills
+
+- `typescript`
+- `verification`
+
+## Verification
+
+- Run `.github/scripts/test-parse-pending-release.sh` — asserts all supported PR body patterns produce correct issue/discussion numbers
+- Existing `check:actions` task (`validateActions.ts` in validatePR.yml:34) already lints all workflow YAMLs including the new one; no separate `actionlint` invocation needed
+- Manual dry-run: open a test PR on the repo with `workflow_dispatch` is not applicable since `pull_request_target` cannot be dispatched, but the parse script provides equivalent confidence for the regex logic
+- Fork-PR safety: confirmed by trigger choice (`pull_request_target` runs in base context with write token); no checkout of fork code occurs
+- e2e: exercised by any real PR merge that references an issue or discussion; first merge after deployment serves as integration validation

--- a/.github/scripts/test-parse-pending-release.sh
+++ b/.github/scripts/test-parse-pending-release.sh
@@ -28,7 +28,7 @@ parse_body() {
   DISC_NUMS=$(echo "$PR_BODY" | REPO="$REPO" perl -ne 'my $r = quotemeta($ENV{REPO}); while (/github\.com\/$r\/discussions\/(\d+)/g) { print "$1\n" }' | sort -u | tr '\n' ' ' || true)
 
   local SHORT_REFS
-  SHORT_REFS=$(echo "$PR_BODY" | perl -ne 'while (/(?:closes|close|fixes|fix|resolves|resolve)?\s*#(\d+)/gi) { print "$1\n" }' | sort -u | tr '\n' ' ' || true)
+  SHORT_REFS=$(echo "$PR_BODY" | perl -ne 'while (/(?:closes|close|fixes|fix|resolves|resolve)\s*#(\d+)/gi) { print "$1\n" }' | sort -u | tr '\n' ' ' || true)
 
   local UNRESOLVED=""
   for NUM in $SHORT_REFS; do
@@ -95,12 +95,12 @@ assert_eq "Full discussion URL" "issues=
 discussions=456
 unresolved=" "$RESULT"
 
-# --- Test 3: Bare short ref ---
+# --- Test 3: Bare short ref (no keyword — not matched) ---
 BODY="#789"
 RESULT=$(parse_body "$BODY" "$REPO")
-assert_eq "Bare short ref" "issues=
+assert_eq "Bare short ref not matched without keyword" "issues=
 discussions=
-unresolved=789" "$RESULT"
+unresolved=" "$RESULT"
 
 # --- Test 4: Keyword-prefixed short refs ---
 BODY="Closes #100

--- a/.github/scripts/test-parse-pending-release.sh
+++ b/.github/scripts/test-parse-pending-release.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Verification script for tagPendingRelease.yml regex parsing logic.
+# Exercises the grep patterns against known PR body strings to validate
+# that issue/discussion numbers are extracted correctly.
+#
+# Usage: bash .github/scripts/test-parse-pending-release.sh
+# Exits 0 on success, 1 on failure with diff output.
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+# --- Helper ---
+# Runs the same parse logic as the workflow and outputs three lines:
+#   issues=<space-separated sorted numbers>
+#   discussions=<space-separated sorted numbers>
+#   unresolved=<space-separated sorted numbers>
+parse_body() {
+  local PR_BODY="$1"
+  local REPO="$2"
+
+  # Use perl for portability (macOS grep lacks -P; workflow runs on ubuntu where grep -P works)
+  local ISSUE_NUMS
+  ISSUE_NUMS=$(echo "$PR_BODY" | REPO="$REPO" perl -ne 'my $r = quotemeta($ENV{REPO}); while (/github\.com\/$r\/issues\/(\d+)/g) { print "$1\n" }' | sort -u | tr '\n' ' ' || true)
+
+  local DISC_NUMS
+  DISC_NUMS=$(echo "$PR_BODY" | REPO="$REPO" perl -ne 'my $r = quotemeta($ENV{REPO}); while (/github\.com\/$r\/discussions\/(\d+)/g) { print "$1\n" }' | sort -u | tr '\n' ' ' || true)
+
+  local SHORT_REFS
+  SHORT_REFS=$(echo "$PR_BODY" | perl -ne 'while (/(?:closes|close|fixes|fix|resolves|resolve)?\s*#(\d+)/gi) { print "$1\n" }' | sort -u | tr '\n' ' ' || true)
+
+  local UNRESOLVED=""
+  for NUM in $SHORT_REFS; do
+    local ALREADY_KNOWN=false
+    for I in $ISSUE_NUMS; do
+      if [[ "$NUM" == "$I" ]]; then
+        ALREADY_KNOWN=true
+        break
+      fi
+    done
+    if [[ "$ALREADY_KNOWN" == "false" ]]; then
+      for D in $DISC_NUMS; do
+        if [[ "$NUM" == "$D" ]]; then
+          ALREADY_KNOWN=true
+          break
+        fi
+      done
+    fi
+    if [[ "$ALREADY_KNOWN" == "false" ]]; then
+      UNRESOLVED="$UNRESOLVED $NUM"
+    fi
+  done
+  UNRESOLVED=$(echo "$UNRESOLVED" | xargs -n1 2>/dev/null | sort -u | tr '\n' ' ' || true)
+
+  # Trim trailing whitespace
+  ISSUE_NUMS=$(echo "$ISSUE_NUMS" | xargs)
+  DISC_NUMS=$(echo "$DISC_NUMS" | xargs)
+  UNRESOLVED=$(echo "$UNRESOLVED" | xargs)
+
+  echo "issues=${ISSUE_NUMS}"
+  echo "discussions=${DISC_NUMS}"
+  echo "unresolved=${UNRESOLVED}"
+}
+
+assert_eq() {
+  local test_name="$1"
+  local expected="$2"
+  local actual="$3"
+
+  if [[ "$expected" == "$actual" ]]; then
+    echo "PASS: $test_name"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $test_name"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+REPO="forcedotcom/salesforcedx-vscode"
+
+# --- Test 1: Full issue URL ---
+BODY="Fixed https://github.com/forcedotcom/salesforcedx-vscode/issues/123"
+RESULT=$(parse_body "$BODY" "$REPO")
+assert_eq "Full issue URL" "issues=123
+discussions=
+unresolved=" "$RESULT"
+
+# --- Test 2: Full discussion URL ---
+BODY="See https://github.com/forcedotcom/salesforcedx-vscode/discussions/456"
+RESULT=$(parse_body "$BODY" "$REPO")
+assert_eq "Full discussion URL" "issues=
+discussions=456
+unresolved=" "$RESULT"
+
+# --- Test 3: Bare short ref ---
+BODY="#789"
+RESULT=$(parse_body "$BODY" "$REPO")
+assert_eq "Bare short ref" "issues=
+discussions=
+unresolved=789" "$RESULT"
+
+# --- Test 4: Keyword-prefixed short refs ---
+BODY="Closes #100
+Fixes #200
+Resolves #300
+fixes #400"
+RESULT=$(parse_body "$BODY" "$REPO")
+assert_eq "Keyword-prefixed short refs" "issues=
+discussions=
+unresolved=100 200 300 400" "$RESULT"
+
+# --- Test 5: Mixed body with multiple refs ---
+BODY="### What does this PR do?
+Implements feature X.
+
+### What issues does this PR fix or reference?
+Closes #100, https://github.com/forcedotcom/salesforcedx-vscode/issues/200
+Also see https://github.com/forcedotcom/salesforcedx-vscode/discussions/300
+
+Some other text with no refs here."
+RESULT=$(parse_body "$BODY" "$REPO")
+assert_eq "Mixed body with multiple refs" "issues=200
+discussions=300
+unresolved=100" "$RESULT"
+
+# --- Test 6: Body with no refs ---
+BODY="This PR refactors the build system.
+No issues or discussions linked."
+RESULT=$(parse_body "$BODY" "$REPO")
+assert_eq "Body with no refs" "issues=
+discussions=
+unresolved=" "$RESULT"
+
+# --- Test 7: Refs to other repos (full URLs excluded, short refs included) ---
+BODY="Related: https://github.com/other-org/other-repo/issues/999
+Also fixes #50"
+RESULT=$(parse_body "$BODY" "$REPO")
+assert_eq "Other repo full URL excluded, short ref included" "issues=
+discussions=
+unresolved=50" "$RESULT"
+
+# --- Test 8: Deduplication of full URL + short ref for same number ---
+BODY="Fixes #123
+https://github.com/forcedotcom/salesforcedx-vscode/issues/123"
+RESULT=$(parse_body "$BODY" "$REPO")
+assert_eq "Deduplicated full URL and short ref" "issues=123
+discussions=
+unresolved=" "$RESULT"
+
+# --- Test 9: Close/Fix/Resolve singular forms ---
+BODY="close #10
+fix #20
+resolve #30"
+RESULT=$(parse_body "$BODY" "$REPO")
+assert_eq "Singular keyword forms" "issues=
+discussions=
+unresolved=10 20 30" "$RESULT"
+
+# --- Test 10: Discussion URL deduplication with short ref ---
+BODY="https://github.com/forcedotcom/salesforcedx-vscode/discussions/456
+#456"
+RESULT=$(parse_body "$BODY" "$REPO")
+assert_eq "Discussion URL dedup with short ref" "issues=
+discussions=456
+unresolved=" "$RESULT"
+
+# --- Summary ---
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi

--- a/.github/workflows/tagPendingRelease.yml
+++ b/.github/workflows/tagPendingRelease.yml
@@ -1,0 +1,162 @@
+name: Tag Linked Issues/Discussions Pending Release
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: write
+  discussions: write
+
+jobs:
+  tag-pending-release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse PR body for linked issues and discussions
+        id: parse
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [[ -z "$PR_BODY" ]]; then
+            echo "No PR body found, nothing to do."
+            echo "issues=" >> "$GITHUB_OUTPUT"
+            echo "discussions=" >> "$GITHUB_OUTPUT"
+            echo "unresolved=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Extract full issue URLs for this repo
+          ISSUE_NUMS=$(echo "$PR_BODY" | grep -oP "github\.com/${REPO}/issues/\K[0-9]+" | sort -u | tr '\n' ' ')
+
+          # Extract full discussion URLs for this repo
+          DISC_NUMS=$(echo "$PR_BODY" | grep -oP "github\.com/${REPO}/discussions/\K[0-9]+" | sort -u | tr '\n' ' ')
+
+          # Extract short references: bare #NNN and keyword-prefixed forms
+          SHORT_REFS=$(echo "$PR_BODY" | grep -oiP '(?:closes|close|fixes|fix|resolves|resolve)?\s*#\K[0-9]+' | sort -u | tr '\n' ' ')
+
+          # Determine unresolved numbers (short refs that aren't already classified)
+          UNRESOLVED=""
+          for NUM in $SHORT_REFS; do
+            ALREADY_KNOWN=false
+            for I in $ISSUE_NUMS; do
+              if [[ "$NUM" == "$I" ]]; then
+                ALREADY_KNOWN=true
+                break
+              fi
+            done
+            if [[ "$ALREADY_KNOWN" == "false" ]]; then
+              for D in $DISC_NUMS; do
+                if [[ "$NUM" == "$D" ]]; then
+                  ALREADY_KNOWN=true
+                  break
+                fi
+              done
+            fi
+            if [[ "$ALREADY_KNOWN" == "false" ]]; then
+              UNRESOLVED="$UNRESOLVED $NUM"
+            fi
+          done
+          UNRESOLVED=$(echo "$UNRESOLVED" | xargs -n1 2>/dev/null | sort -u | tr '\n' ' ')
+
+          echo "Parsed issue numbers: ${ISSUE_NUMS:-none}"
+          echo "Parsed discussion numbers: ${DISC_NUMS:-none}"
+          echo "Unresolved short refs: ${UNRESOLVED:-none}"
+
+          echo "issues=${ISSUE_NUMS}" >> "$GITHUB_OUTPUT"
+          echo "discussions=${DISC_NUMS}" >> "$GITHUB_OUTPUT"
+          echo "unresolved=${UNRESOLVED}" >> "$GITHUB_OUTPUT"
+
+      - name: Label issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBERS: ${{ steps.parse.outputs.issues }}
+          UNRESOLVED: ${{ steps.parse.outputs.unresolved }}
+        run: |
+          LABELED_ISSUES=""
+
+          # Label known issues
+          for ISSUE in $ISSUE_NUMBERS; do
+            gh issue edit "$ISSUE" --add-label "pending release" \
+              && echo "Labeled issue #${ISSUE}" \
+              || echo "::warning::Failed to label issue #$ISSUE"
+            LABELED_ISSUES="$LABELED_ISSUES $ISSUE"
+          done
+
+          # Attempt to label unresolved refs as issues
+          REMAINING=""
+          for NUM in $UNRESOLVED; do
+            if gh issue view "$NUM" --json number --jq '.number' > /dev/null 2>&1; then
+              gh issue edit "$NUM" --add-label "pending release" \
+                && echo "Labeled issue #${NUM}" \
+                || echo "::warning::Failed to label issue #$NUM"
+              LABELED_ISSUES="$LABELED_ISSUES $NUM"
+            else
+              REMAINING="$REMAINING $NUM"
+            fi
+          done
+
+          echo "remaining_for_discussions=$(echo $REMAINING | xargs)" >> "$GITHUB_OUTPUT"
+        id: label_issues
+
+      - name: Fetch pending release label node ID
+        id: fetch_label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          LABEL_ID=$(gh api graphql -f query='
+            query($owner: String!, $repo: String!) {
+              repository(owner: $owner, name: $repo) {
+                label(name: "pending release") {
+                  id
+                }
+              }
+            }' -f owner="$REPO_OWNER" -f repo="$REPO_NAME" --jq '.data.repository.label.id' 2>/dev/null || echo "")
+
+          if [[ -z "$LABEL_ID" ]]; then
+            echo "::warning::Label 'pending release' not found in repository, skipping discussion labeling"
+            echo "label_id=" >> "$GITHUB_OUTPUT"
+          else
+            echo "label_id=${LABEL_ID}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Label discussions
+        if: steps.fetch_label.outputs.label_id != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LABEL_ID: ${{ steps.fetch_label.outputs.label_id }}
+          DISCUSSION_NUMBERS: ${{ steps.parse.outputs.discussions }}
+          REMAINING: ${{ steps.label_issues.outputs.remaining_for_discussions }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          ALL_DISC_NUMS="$DISCUSSION_NUMBERS $REMAINING"
+
+          for DISC_NUM in $ALL_DISC_NUMS; do
+            [[ -z "$DISC_NUM" ]] && continue
+
+            DISC_ID=$(gh api graphql -f query='
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  discussion(number: $number) {
+                    id
+                  }
+                }
+              }' -f owner="$REPO_OWNER" -f repo="$REPO_NAME" -F number="$DISC_NUM" \
+              --jq '.data.repository.discussion.id' 2>/dev/null || echo "")
+
+            if [[ -z "$DISC_ID" ]]; then
+              echo "::warning::Discussion #$DISC_NUM not found or inaccessible, skipping"
+              continue
+            fi
+
+            jq -n --arg labelableId "$DISC_ID" --arg labelId "$LABEL_ID" \
+              '{query: "mutation($labelableId: ID!, $labelIds: [ID!]!) { addLabelsToLabelable(input: {labelableId: $labelableId, labelIds: $labelIds}) { labelable { __typename } } }", variables: {labelableId: $labelableId, labelIds: [$labelId]}}' \
+              | gh api graphql --input - > /dev/null 2>&1 \
+              && echo "Labeled discussion #${DISC_NUM}" \
+              || echo "::warning::Failed to label discussion #$DISC_NUM"
+          done

--- a/.github/workflows/tagPendingRelease.yml
+++ b/.github/workflows/tagPendingRelease.yml
@@ -29,13 +29,13 @@ jobs:
           fi
 
           # Extract full issue URLs for this repo
-          ISSUE_NUMS=$(echo "$PR_BODY" | grep -oP "github\.com/${REPO}/issues/\K[0-9]+" | sort -u | tr '\n' ' ')
+          ISSUE_NUMS=$(echo "$PR_BODY" | grep -oP "github\.com/${REPO}/issues/\K[0-9]+" | sort -u | xargs)
 
           # Extract full discussion URLs for this repo
-          DISC_NUMS=$(echo "$PR_BODY" | grep -oP "github\.com/${REPO}/discussions/\K[0-9]+" | sort -u | tr '\n' ' ')
+          DISC_NUMS=$(echo "$PR_BODY" | grep -oP "github\.com/${REPO}/discussions/\K[0-9]+" | sort -u | xargs)
 
-          # Extract short references: bare #NNN and keyword-prefixed forms
-          SHORT_REFS=$(echo "$PR_BODY" | grep -oiP '(?:closes|close|fixes|fix|resolves|resolve)?\s*#\K[0-9]+' | sort -u | tr '\n' ' ')
+          # Extract keyword-prefixed short references (Closes #NNN, Fixes #NNN, etc.)
+          SHORT_REFS=$(echo "$PR_BODY" | grep -oiP '(?:closes|close|fixes|fix|resolves|resolve)\s*#\K[0-9]+' | sort -u | xargs)
 
           # Determine unresolved numbers (short refs that aren't already classified)
           UNRESOLVED=""
@@ -59,7 +59,7 @@ jobs:
               UNRESOLVED="$UNRESOLVED $NUM"
             fi
           done
-          UNRESOLVED=$(echo "$UNRESOLVED" | xargs -n1 2>/dev/null | sort -u | tr '\n' ' ')
+          UNRESOLVED=$(echo "$UNRESOLVED" | xargs -n1 2>/dev/null | sort -u | xargs)
 
           echo "Parsed issue numbers: ${ISSUE_NUMS:-none}"
           echo "Parsed discussion numbers: ${DISC_NUMS:-none}"
@@ -70,19 +70,17 @@ jobs:
           echo "unresolved=${UNRESOLVED}" >> "$GITHUB_OUTPUT"
 
       - name: Label issues
+        if: steps.parse.outputs.issues != '' || steps.parse.outputs.unresolved != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBERS: ${{ steps.parse.outputs.issues }}
           UNRESOLVED: ${{ steps.parse.outputs.unresolved }}
         run: |
-          LABELED_ISSUES=""
-
           # Label known issues
           for ISSUE in $ISSUE_NUMBERS; do
             gh issue edit "$ISSUE" --add-label "pending release" \
               && echo "Labeled issue #${ISSUE}" \
               || echo "::warning::Failed to label issue #$ISSUE"
-            LABELED_ISSUES="$LABELED_ISSUES $ISSUE"
           done
 
           # Attempt to label unresolved refs as issues
@@ -92,13 +90,12 @@ jobs:
               gh issue edit "$NUM" --add-label "pending release" \
                 && echo "Labeled issue #${NUM}" \
                 || echo "::warning::Failed to label issue #$NUM"
-              LABELED_ISSUES="$LABELED_ISSUES $NUM"
             else
               REMAINING="$REMAINING $NUM"
             fi
           done
 
-          echo "remaining_for_discussions=$(echo $REMAINING | xargs)" >> "$GITHUB_OUTPUT"
+          echo "remaining_for_discussions=$(echo "$REMAINING" | xargs)" >> "$GITHUB_OUTPUT"
         id: label_issues
 
       - name: Fetch pending release label node ID


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/tagPendingRelease.yml` triggered on `pull_request_target` (closed+merged) to apply the `pending release` label to issues and discussions linked in the PR body
- Parses full GitHub issue/discussion URLs and keyword-prefixed short references (`Closes #NNN`, `Fixes #NNN`, `Resolves #NNN`); bare `#NNN` without a keyword is intentionally excluded to avoid false positives
- Adds `.github/scripts/test-parse-pending-release.sh` to verify regex parsing logic against a comprehensive set of PR body patterns

## Plan

[.claude/plans/W-23351778.md](.claude/plans/W-23351778.md)

## Reviewer notes

- **medium:** The test script (`.github/scripts/test-parse-pending-release.sh`) re-implements the workflow's `grep -P` patterns in Perl for macOS portability. A structural divergence remains: changes to the workflow grep patterns won't automatically be caught by the tests. Options to close this gap: extract parsing into a shared script called by both, run tests in a Docker ubuntu image where `grep -P` is available, or use `perl` in the workflow itself. Deferred as a design decision for reviewer input.

## What issues does this PR fix or reference?

@W-23351778@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eABMBYA4/view