### PR TITLE
fix(lwc): remove redundant @property JSDoc from LwcJestTestFileResult - W-23559837

### DIFF
--- a/.claude/plans/W-23559837.md
+++ b/.claude/plans/W-23559837.md
@@ -3,15 +3,15 @@
 ## Context
 
 - `packages/salesforcedx-vscode-lwc/src/testSupport/types/index.ts:109-112`
-- JSDoc `@property` tag duplicates inline comment on `message` field (line 119)
+- JSDoc `@property` tag duplicates inline `message` comment (line 119)
 - Inline comment sufficient; `@property` adds no value
 
 ## Phases
 
 ### Phase 1: Remove @property annotation
 
-- Remove `@property {string} message - ...` line from JSDoc block (line 111)
-- Keep block as single-line `/** Jest Test File Result */`
+- Remove `@property {string} message - ...` from JSDoc (line 111)
+- Keep as single-line `/** Jest Test File Result */`
 
 **Files:** `packages/salesforcedx-vscode-lwc/src/testSupport/types/index.ts`
 

--- a/.claude/plans/W-23559837.md
+++ b/.claude/plans/W-23559837.md
@@ -1,0 +1,28 @@
+# W-23559837: Remove redundant JSDoc @property from LwcJestTestFileResult
+
+## Context
+
+- `packages/salesforcedx-vscode-lwc/src/testSupport/types/index.ts:109-112`
+- JSDoc `@property` tag duplicates inline comment on `message` field (line 119)
+- Inline comment sufficient; `@property` adds no value
+
+## Phases
+
+### Phase 1: Remove @property annotation
+
+- Remove `@property {string} message - ...` line from JSDoc block (line 111)
+- Keep block as single-line `/** Jest Test File Result */`
+
+**Files:** `packages/salesforcedx-vscode-lwc/src/testSupport/types/index.ts`
+
+**Commit:** `fix(lwc): remove redundant @property JSDoc from LwcJestTestFileResult - W-23559837`
+
+## Skills
+
+- typescript (compile check)
+
+## Verification
+
+- `npx tsc --noEmit -p packages/salesforcedx-vscode-lwc/tsconfig.json` passes
+- No behavior change; type-only cleanup
+- e2e-covered: N/A (no runtime impact)

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/types/index.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/types/index.ts
@@ -106,10 +106,7 @@ export type LwcJestTestResults = {
  */
 type LwcJestTestResultStatus = 'passed' | 'failed' | 'pending' | 'skipped' | 'todo' | 'disabled';
 
-/**
- * Jest Test File Result
- * @property {string} message - Optional runtime error message when test suite fails to run before assertions can be collected
- */
+/** Jest Test File Result */
 export type LwcJestTestFileResult = {
   status: 'passed' | 'failed';
   startTime: number;

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/types/index.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/types/index.ts
@@ -113,7 +113,7 @@ export type LwcJestTestFileResult = {
   endTime: number;
   name: string;
   assertionResults: LwcJestTestAssertionResult[];
-  message?: string; // Runtime error message when test suite fails to run
+  message?: string; // Runtime error message when test suite fails to run before assertions can be collected
 };
 
 /**


### PR DESCRIPTION
## Summary

- Removed redundant JSDoc `@property` annotation from `LwcJestTestFileResult` type that duplicated the inline comment for the `message` field
- Simplified JSDoc to single-line format while preserving complete documentation in the inline comment

## Plan

[.claude/plans/W-23559837.md](.claude/plans/W-23559837.md)

## Reviewer notes

- **Medium severity (not auto-fixed):** Types `LwcJestTestResults`, `LwcJestTestFileResult`, and `LwcJestTestAssertionResult` are JSON-deserialized with unsafe casts at `lwcTestController.ts:696` and `testResultsWatcher.ts:22`. Should use `Schema.Struct` for validation at the boundary per effect-advocate guidance. Requires deciding failure-handling strategy (Effect error channel vs. silent fallback) and touches 3 files (`types/index.ts` + both consumers). *Blocked by: design-decision*

## What issues does this PR fix or reference?

@W-23559837@

---

🤖 Generated by auto-build pipeline. Original WI: https://gus.my.salesforce.com/a07EE00002fc0HzYAI