### PR TITLE
chore(effect): extend effect barrel-import lint to vscode-org and vscode-soql - W-23443764

### DIFF
--- a/.claude/plans/W-23443764.md
+++ b/.claude/plans/W-23443764.md
@@ -32,7 +32,7 @@
   ```
   - ONLY this rule. NO functional/* (WI: those pkgs not ready).
   - Later test/playwright blocks (L886) already turn it off for those files — desired.
-- Two org barrel imports, two treatments (rule autofix only emits a fix when `node.specifiers.length === 1` — node_modules/@effect/eslint-plugin/src/rules/no-import-from-barrel-package.ts L61-71, verified):
+- 2 org barrel imports, 2 treatments (rule autofix only emits a fix when `node.specifiers.length === 1` — node_modules/@effect/eslint-plugin/src/rules/no-import-from-barrel-package.ts L61-71, verified):
   - `orgList.ts` L10 `import { Duration } from 'effect';` — single specifier → `eslint --fix` rewrites to `import * as Duration from 'effect/Duration'`. (Its L11-13 `Effect`/`Order`/`Stream` are already deep imports, pre-existing, untouched.)
   - `orgUtil.ts` L11 `import { Effect, Stream, SubscriptionRef } from 'effect';` — 3 specifiers → `--fix` leaves it unchanged (3 errors remain). MANUAL split into 3 deep imports (same mechanical treatment as Phase 2 soql), sorted with existing `Chunk`/`Option`/`Predicate`/`Schema` deep imports:
     `import * as Effect from 'effect/Effect'` / `import * as Stream from 'effect/Stream'` / `import * as SubscriptionRef from 'effect/SubscriptionRef'`

--- a/.claude/plans/W-23443764.md
+++ b/.claude/plans/W-23443764.md
@@ -1,0 +1,71 @@
+# W-23443764 — extend effect barrel-import lint to vscode-org + vscode-soql
+
+## Context
+
+- Follow-up to PR #7756. Barrel `import {X} from 'effect'` → out/ CJS eager-requires every submodule; esbuild can't tree-shake. WI: ~1.5MB soql web bundle bloat.
+- `effect/no-import-from-barrel-package` rule exists (eslint.config.mjs L745, `@effect/eslint-plugin`) but scoped to Effect-services allowlist (L733-743) — org/soql not covered.
+- Global `no-restricted-imports` `@effect/platform` guard: L475-484.
+- 7 barrel imports (grep-confirmed):
+  - org (NOT ignored): `src/orgPicker/orgList.ts` L10 `{ Duration }` (single-specifier → autofixable); `src/util/orgUtil.ts` L11 `{ Effect, Stream, SubscriptionRef }` (3-specifier → NOT autofixable, manual split)
+  - soql (see KEY FINDING): `soql-builder-ui/modules/querybuilder/app/app.ts` L14; `.../services/toolingSDK.ts` L9; `.../services/toolingModelService.ts` L9; `.../services/message/iMessageService.ts` L9; `.../services/message/vscodeMessageService.ts` L9
+
+### KEY FINDING — WI premise wrong for 5 soql files
+
+- All 5 soql targets under `soql-builder-ui/**` = **globally ignored** (eslint.config.mjs L70-71, LWC webview). Verified: `eslint <file>` → "File ignored".
+- Consequence: a `files:['...soql...']` block does NOT lint them; `eslint --fix` can't rewrite them.
+- Un-ignoring surfaces 55 errors + 26 warnings from unrelated rules (header wrong-year, import/order, import/no-extraneous-dependencies, consistent-type-assertions, unicorn/*, filename-case toolingSDK→toolingSdk, no-shadow…). WI explicitly forbids that scope creep.
+- Resolution: rewrite the 5 soql imports **manually** (deep namespace, mechanical) → bundle win intact (esbuild reads actual imports, not eslint). These 5 stay lint-unenforced (inherent: LWC files intentionally ignored).
+- Lint block still valuable: enforces barrel rule on org src + non-ignored soql src (editor/commands/services/telemetry/etc.), preventing future regressions there.
+
+### Deep-import shape (house style, already present orgList.ts L11-13)
+
+`import * as Effect from 'effect/Effect'`. All needed subpaths exist in node_modules/effect/dist/dts (Effect, Layer, ManagedRuntime, Stream, Match, SubscriptionRef, Context, Duration, Order — verified).
+
+## Phases
+
+### Phase 1 — narrow lint block + org imports (autofix + manual split)
+
+- Add config block to eslint.config.mjs (place after Effect-services block ~L799):
+  ```
+  { files: ['packages/salesforcedx-vscode-org/**/*.ts', 'packages/salesforcedx-vscode-soql/**/*.ts'],
+    rules: { 'effect/no-import-from-barrel-package': ['error', { packageNames: ['effect'] }] } }
+  ```
+  - ONLY this rule. NO functional/* (WI: those pkgs not ready).
+  - Later test/playwright blocks (L886) already turn it off for those files — desired.
+- Two org barrel imports, two treatments (rule autofix only emits a fix when `node.specifiers.length === 1` — node_modules/@effect/eslint-plugin/src/rules/no-import-from-barrel-package.ts L61-71, verified):
+  - `orgList.ts` L10 `import { Duration } from 'effect';` — single specifier → `eslint --fix` rewrites to `import * as Duration from 'effect/Duration'`. (Its L11-13 `Effect`/`Order`/`Stream` are already deep imports, pre-existing, untouched.)
+  - `orgUtil.ts` L11 `import { Effect, Stream, SubscriptionRef } from 'effect';` — 3 specifiers → `--fix` leaves it unchanged (3 errors remain). MANUAL split into 3 deep imports (same mechanical treatment as Phase 2 soql), sorted with existing `Chunk`/`Option`/`Predicate`/`Schema` deep imports:
+    `import * as Effect from 'effect/Effect'` / `import * as Stream from 'effect/Stream'` / `import * as SubscriptionRef from 'effect/SubscriptionRef'`
+- Run `eslint --fix packages/salesforcedx-vscode-org/**/*.ts` (fixes orgList.ts + import-order), then hand-edit orgUtil.ts, then re-run `eslint --fix` on orgUtil.ts to settle import-order. Confirm 0 barrel errors on both files before commit (do not rely on `--fix` alone for orgUtil.ts).
+- commit: `chore(effect): enforce effect barrel-import lint on vscode-org + vscode-soql - W-23443764`
+- files: eslint.config.mjs, packages/salesforcedx-vscode-org/src/util/orgUtil.ts, packages/salesforcedx-vscode-org/src/orgPicker/orgList.ts
+
+### Phase 2 — manual rewrite 5 soql-builder-ui imports
+
+- Hand-edit (globally ignored → no --fix). Split each barrel into deep namespace imports, sorted:
+  - app.ts L14 `{Effect,Layer,ManagedRuntime,Stream}` → 4 deep
+  - toolingSDK.ts L9 `{Effect,Match,SubscriptionRef}` → 3
+  - toolingModelService.ts L9 `{Effect,Stream,SubscriptionRef}` → 3
+  - iMessageService.ts L9 `{Context}` → 1
+  - vscodeMessageService.ts L9 `{Layer}` → 1
+- Usage (`Effect.foo` etc.) unchanged. Keep existing comments/headers.
+- commit: `perf(soql): deep-import effect in soql-builder-ui to drop bundle bloat - W-23443764`
+- files: 5 soql-builder-ui files above
+
+## Skills to apply
+
+- concise (plan + any md)
+- typescript (Phase 1/2 edit .ts files)
+- effect-best-practices (deep-import namespace convention)
+- verification (lint + typecheck gates)
+- pr-draft (title `- W-XXXXXXXX`, GUS ref)
+- wireit (lint via `../../node_modules/.bin/eslint --color .`; local-rules must compile first)
+
+## Verification
+
+- Enforcement proof (WI-required), org: temp-add BOTH `import {Effect} from 'effect'` + `import {FetchHttpClient} from '@effect/platform'` to a non-test org src file → `eslint` → confirm barrel rule + no-restricted-imports both fire → revert.
+- Enforcement proof, soql: temp-add same 2 lines to a **non-ignored** soql src file (e.g. `src/editor/allRows.ts` — verified NOT ignored). NOTE: cannot use soql-builder-ui file (globally ignored). Confirm both fire → revert.
+- Full `npm run lint` clean (no --max-warnings; pre-existing warnings tolerated). Must build eslint-local-rules first (`npm run compile -w packages/eslint-local-rules`).
+- `npm run compile` typecheck clean (org + soql).
+- Optional: esbuild before/after on soql web bundle (`vscode:bundle`, esbuild.config.mjs) → confirm ~1.5MB delta.
+- No e2e coverage for this change — all verification manual/CI lint+typecheck.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -800,6 +800,8 @@ export default [
   {
     // Enforce effect deep-imports (no barrel) on vscode-org + vscode-soql to keep esbuild tree-shaking (W-23443764).
     // Only this rule — those packages aren't ready for the full functional/* set above.
+    // NOTE: soql-builder-ui/**/*.ts is globally ignored (see ignores above), so these webview LWC files
+    // are NOT enforced here — their effect imports were deep-imported manually and stay unenforced.
     files: ['packages/salesforcedx-vscode-org/**/*.ts', 'packages/salesforcedx-vscode-soql/**/*.ts'],
     rules: {
       'effect/no-import-from-barrel-package': ['error', { packageNames: ['effect'] }]

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -798,6 +798,14 @@ export default [
     }
   },
   {
+    // Enforce effect deep-imports (no barrel) on vscode-org + vscode-soql to keep esbuild tree-shaking (W-23443764).
+    // Only this rule — those packages aren't ready for the full functional/* set above.
+    files: ['packages/salesforcedx-vscode-org/**/*.ts', 'packages/salesforcedx-vscode-soql/**/*.ts'],
+    rules: {
+      'effect/no-import-from-barrel-package': ['error', { packageNames: ['effect'] }]
+    }
+  },
+  {
     // consistent-type-imports for effect-ext-utils (inline to avoid no-duplicate-imports)
     files: ['packages/effect-ext-utils/**/*.ts'],
     rules: {

--- a/packages/salesforcedx-vscode-org/src/orgPicker/orgList.ts
+++ b/packages/salesforcedx-vscode-org/src/orgPicker/orgList.ts
@@ -7,7 +7,7 @@
 import { OrgAuthorization } from '@salesforce/core';
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import { ICONS, type DefaultOrgInfoSchema } from '@salesforce/vscode-services';
-import { Duration } from 'effect';
+import * as Duration from 'effect/Duration';
 import * as Effect from 'effect/Effect';
 import * as Order from 'effect/Order';
 import * as Stream from 'effect/Stream';

--- a/packages/salesforcedx-vscode-org/src/util/orgUtil.ts
+++ b/packages/salesforcedx-vscode-org/src/util/orgUtil.ts
@@ -8,11 +8,13 @@
 import { AuthFields, AuthInfo, AuthRemover, OrgAuthorization, StateAggregator } from '@salesforce/core';
 import { Column, createTable, Row, ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import { ICONS } from '@salesforce/vscode-services';
-import { Effect, Stream, SubscriptionRef } from 'effect';
 import * as Chunk from 'effect/Chunk';
+import * as Effect from 'effect/Effect';
 import * as Option from 'effect/Option';
 import { isError, isNotUndefined, isString } from 'effect/Predicate';
 import * as Schema from 'effect/Schema';
+import * as Stream from 'effect/Stream';
+import * as SubscriptionRef from 'effect/SubscriptionRef';
 import * as vscode from 'vscode';
 import { getOrgRuntime } from '../extensionProvider';
 import { nls } from '../messages';

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/app/app.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/app/app.ts
@@ -11,7 +11,10 @@ import { JsonMap } from '@salesforce/ts-types';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { messages } from 'querybuilder/messages';
-import { Effect, Layer, ManagedRuntime, Stream } from 'effect';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+import * as ManagedRuntime from 'effect/ManagedRuntime';
+import * as Stream from 'effect/Stream';
 import { ToolingSDK } from '../services/toolingSDK';
 import { ToolingModelService, toolingModelTemplate } from '../services/toolingModelService';
 import { MessageService, IMessageService } from '../services/message/iMessageService';

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/services/message/iMessageService.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/services/message/iMessageService.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import { Context } from 'effect';
+import * as Context from 'effect/Context';
 import { JsonMap } from '@salesforce/ts-types';
 import { SoqlEditorEvent } from './soqlEditorEvent';
 

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/services/message/vscodeMessageService.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/services/message/vscodeMessageService.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import { Layer } from 'effect';
+import * as Layer from 'effect/Layer';
 import { JsonMap } from '@salesforce/ts-types';
 import { getVscode } from '../globals';
 import { MessageService, IMessageService } from './iMessageService';

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/services/toolingModelService.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/services/toolingModelService.ts
@@ -6,7 +6,9 @@
  *
  */
 
-import { Effect, Stream, SubscriptionRef } from 'effect';
+import * as Effect from 'effect/Effect';
+import * as Stream from 'effect/Stream';
+import * as SubscriptionRef from 'effect/SubscriptionRef';
 import { AndOr } from '@salesforce/soql-model';
 import { JsonMap } from '@salesforce/ts-types';
 import { convertUiModelToSoql, convertSoqlToUiModel } from '../services/soqlUtils';

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/services/toolingSDK.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/services/toolingSDK.ts
@@ -6,7 +6,9 @@
  *
  */
 
-import { Effect, Match, SubscriptionRef } from 'effect';
+import * as Effect from 'effect/Effect';
+import * as Match from 'effect/Match';
+import * as SubscriptionRef from 'effect/SubscriptionRef';
 import { MessageService } from './message/iMessageService';
 import { MessageType, SObjectMetadata, SoqlEditorEvent } from './message/soqlEditorEvent';
 


### PR DESCRIPTION
## Summary

- Extend `effect/no-import-from-barrel-package` lint rule to `salesforcedx-vscode-org` and non-ignored `salesforcedx-vscode-soql` sources, preventing future barrel-import regressions (`eslint.config.mjs`).
- Fix the 2 org barrel imports found (`orgList.ts` autofixed, `orgUtil.ts` manually split into deep imports).
- Manually rewrite 5 `soql-builder-ui` barrel imports to deep imports — these files are globally ignored by eslint (LWC webview), so the lint rule can't cover them, but the deep-import rewrite still drops the ~1.5MB soql web bundle bloat caused by eager barrel `require`s.

## Plan

.claude/plans/W-23443764.md

## Reviewer notes

- `eslint.config.mjs:800` barrel-rule block and the pre-existing soql block at L821 are two adjacent soql-targeting overrides, not consolidated: L821 excludes vscode-org and enforces distinct rules (class-methods-use-this, local/no-explicit-effect-return-type, etc.), so a clean merge would change scope. Left as-is — defensible, not a blocker.

## Test plan

- [ ] Confirm `effect/no-import-from-barrel-package` fires on vscode-org: temp-add `import {Effect} from 'effect'` to a non-test org src file, run eslint, confirm error, then revert.
- [ ] Confirm same rule fires on a non-ignored soql src file (e.g. `src/editor/allRows.ts`), then revert.
- [ ] Optional: compare `vscode:bundle` output size for soql web bundle before/after to confirm the ~1.5MB reduction.

### What issues does this PR fix or reference?
@W-23443764@

---
🤖 Generated by auto-build pipeline. Original WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002ejxdWYAQ/view
