### PR TITLE
fix(org): allow hyphens in org alias validation - W-23491095

### DIFF
--- a/packages/salesforcedx-vscode-org/src/commands/orgCreate.ts
+++ b/packages/salesforcedx-vscode-org/src/commands/orgCreate.ts
@@ -16,7 +16,7 @@ import * as vscode from 'vscode';
 import { Utils } from 'vscode-uri';
 import { nls } from '../messages';
 import { decodeTaggedCliResponse } from '../util/cliJson';
-import { isAlphaNumSpaceString } from '../util/orgAlias';
+import { isValidOrgAlias } from '../util/orgAlias';
 import { updateConfigAndStateAggregators } from '../util/orgUtil';
 
 const isInteger = (value: string | undefined): boolean =>
@@ -105,12 +105,12 @@ const gatherOrgCreateInputs = Effect.fn('orgCreateCommand.gatherInputs')(functio
   // clears it (validation then rejects it); Esc → undefined → considerUndefinedAsCancellation.
   const { uri } = yield* api.services.WorkspaceService.getWorkspaceInfo();
   const folderName = Utils.basename(uri).replaceAll(/\W/g, '');
-  const defaultAlias = isAlphaNumSpaceString(folderName) ? folderName : DEFAULT_ALIAS;
+  const defaultAlias = isValidOrgAlias(folderName) ? folderName : DEFAULT_ALIAS;
   const alias = yield* Effect.promise(() =>
     vscode.window.showInputBox({
       prompt: nls.localize('parameter_gatherer_enter_alias_name'),
       value: defaultAlias,
-      validateInput: value => (isAlphaNumSpaceString(value) ? undefined : nls.localize('error_invalid_org_alias'))
+      validateInput: value => (isValidOrgAlias(value) ? undefined : nls.localize('error_invalid_org_alias'))
     })
   ).pipe(Effect.flatMap(promptService.considerUndefinedAsCancellation));
 
@@ -156,7 +156,7 @@ export const orgCreateCommand = Effect.fn('orgCreateCommand')(function* () {
   const promptService = yield* api.services.PromptService;
   const terminalService = yield* api.services.TerminalService;
   // wrap in a cancellable progress: clicking Cancel interrupts this fiber, aborting the sf child.
-  // quote alias: validateInput (isAlphaNumSpaceString) permits embedded spaces, and childProcess.exec runs
+  // quote alias: validateInput (isValidOrgAlias) permits embedded spaces, and childProcess.exec runs
   // via /bin/sh -c, so an unquoted `--alias my org` would word-split. days is digits-only (no quoting needed).
   const command = `sf org create scratch --definition-file "${defFilePath}" --alias "${alias}" --duration-days ${days} --set-default --json`;
   const stdout = yield* terminalService

--- a/packages/salesforcedx-vscode-org/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-org/src/messages/i18n.ts
@@ -18,7 +18,7 @@ export const messages = {
   channel_name: 'Salesforce Org Management',
   default_org_expired:
     'Your default org has expired. Some of the command palette commands may no longer work. Switch your default org and try again.',
-  error_invalid_org_alias: 'Alias can only contain underscores, spaces and alphanumeric characters.',
+  error_invalid_org_alias: 'Alias can only contain underscores, hyphens, spaces and alphanumeric characters.',
   error_invalid_expiration_days: 'Number of days should be between 1 and 30',
   error_no_scratch_def:
     'No scratch definition files found. These files must be in the "config" folder and end with "-scratch-def.json". See [Scratch Org Definition File](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_scratch_orgs_def_file.htm) for help.',

--- a/packages/salesforcedx-vscode-org/src/util/orgAlias.ts
+++ b/packages/salesforcedx-vscode-org/src/util/orgAlias.ts
@@ -11,6 +11,14 @@ import { nls } from '../messages';
 export const isAlphaNumSpaceString = (value: string | undefined): boolean =>
   value !== undefined && /^\w+( *\w*)*$/.test(value);
 
+/**
+ * Org alias validator: underscores, hyphens, spaces, and alphanumerics only. Hyphens are common in org
+ * aliases (issues/7794) and carry no shell-injection risk since the alias is always double-quoted before
+ * interpolation into the CLI command; all other metachars stay rejected.
+ */
+export const isValidOrgAlias = (value: string | undefined): boolean =>
+  value !== undefined && /^[\w-]+( *[\w-]*)*$/.test(value);
+
 /** showInputBox validateInput for an org alias: empty = use default. */
 export const validateAliasInput = (value: string): string | undefined =>
-  isAlphaNumSpaceString(value) || value === '' ? undefined : nls.localize('error_invalid_org_alias');
+  isValidOrgAlias(value) || value === '' ? undefined : nls.localize('error_invalid_org_alias');

--- a/packages/salesforcedx-vscode-org/test/jest/commands/auth/authParamsGatherer.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/commands/auth/authParamsGatherer.test.ts
@@ -148,10 +148,11 @@ describe('AuthParamsGatherer', () => {
       expect(validateUrl?.('https://x.com; touch /tmp/pwned')).toBe(nls.localize('auth_invalid_url'));
       expect(validateUrl?.('https://my.salesforce.com')).toBeUndefined();
 
-      // second prompt = alias: rejects shell metachars, accepts alphanumeric and empty (use default)
+      // second prompt = alias: rejects shell metachars, accepts alphanumeric, hyphens, and empty (use default)
       const validateAlias = spy.mock.calls[1][0]?.validateInput?.bind(undefined);
       expect(validateAlias?.('bad;alias')).toBe(nls.localize('error_invalid_org_alias'));
       expect(validateAlias?.('GoodAlias')).toBeUndefined();
+      expect(validateAlias?.('my-scratch-org')).toBeUndefined();
       expect(validateAlias?.('')).toBeUndefined();
     });
   });

--- a/packages/salesforcedx-vscode-org/test/jest/commands/orgCreate.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/commands/orgCreate.test.ts
@@ -33,6 +33,7 @@ jest.mock('@salesforce/salesforcedx-utils-vscode', () => ({
 
 // imported after mocks so the command picks up the mocked utils module
 import { orgCreateCommand } from '../../../src/commands/orgCreate';
+import { nls } from '../../../src/messages';
 
 class UserCancellationError extends Schema.TaggedError<UserCancellationError>()('UserCancellationError', {
   message: Schema.optional(Schema.String)
@@ -172,6 +173,19 @@ describe('orgCreateCommand', () => {
           'sf org create scratch --definition-file "/repo/config/project-scratch-def.json" --alias "myproject" --duration-days 7 --set-default --json'
       })
     );
+  });
+
+  it('wires alias validateInput that accepts hyphens/alphanumerics and rejects shell metachars', async () => {
+    showInputBox.mockResolvedValueOnce('my-scratch-org').mockResolvedValueOnce('7');
+
+    await run({ devHub: 'devhub@org', simpleExec, appendToChannel, show });
+
+    // first prompt = alias
+    const aliasOptions = showInputBox.mock.calls[0][0] as vscode.InputBoxOptions | undefined;
+    const validateAlias = aliasOptions?.validateInput?.bind(undefined);
+    expect(validateAlias?.('my-scratch-org')).toBeUndefined();
+    expect(validateAlias?.('GoodAlias')).toBeUndefined();
+    expect(validateAlias?.('bad;alias')).toBe(nls.localize('error_invalid_org_alias'));
   });
 
   it('cancels (no exec) when the def-file picker is dismissed', async () => {

--- a/packages/salesforcedx-vscode-org/test/jest/util/orgAlias.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/util/orgAlias.test.ts
@@ -5,14 +5,14 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { isAlphaNumSpaceString, validateAliasInput } from '../../../src/util/orgAlias';
+import { isAlphaNumSpaceString, isValidOrgAlias, validateAliasInput } from '../../../src/util/orgAlias';
 
 describe('isAlphaNumSpaceString', () => {
   it.each(['MyOrg', 'org123', 'my org', 'snake_case', 'a b c', 'Org_1 Org_2'])('accepts %p', value => {
     expect(isAlphaNumSpaceString(value)).toBe(true);
   });
 
-  it.each(['my;org', 'a|b', 'x&y', 'cost$', 'rm -rf', '`x`', '"q"', '$(x)', ''])('rejects %p', value => {
+  it.each(['my;org', 'a|b', 'x&y', 'cost$', 'rm -rf', '`x`', '"q"', '$(x)', '', 'my-org'])('rejects %p', value => {
     expect(isAlphaNumSpaceString(value)).toBe(false);
   });
 
@@ -21,10 +21,32 @@ describe('isAlphaNumSpaceString', () => {
   });
 });
 
-describe('validateAliasInput', () => {
-  it.each(['MyOrg', 'org123', 'my org', 'snake_case', ''])('returns undefined (valid) for %p', value => {
-    expect(validateAliasInput(value)).toBeUndefined();
+describe('isValidOrgAlias', () => {
+  it.each(['MyOrg', 'org123', 'my org', 'snake_case', 'a b c', 'Org_1 Org_2', 'my-org', 'my-scratch-org', 'a-b c-d'])(
+    'accepts %p',
+    value => {
+      expect(isValidOrgAlias(value)).toBe(true);
+    }
+  );
+
+  // 'rm -rf' is intentionally NOT rejected here: hyphens are allowed, and it's alphanumerics + spaces +
+  // hyphens with no shell metachars, so it's a valid (if odd) alias — safe inside the double-quoted CLI arg.
+  it.each(['my;org', 'a|b', 'x&y', 'cost$', '`x`', '"q"', '$(x)', ''])('rejects %p', value => {
+    expect(isValidOrgAlias(value)).toBe(false);
   });
+
+  it('rejects undefined', () => {
+    expect(isValidOrgAlias(undefined)).toBe(false);
+  });
+});
+
+describe('validateAliasInput', () => {
+  it.each(['MyOrg', 'org123', 'my org', 'snake_case', 'my-org', 'my-scratch-org', ''])(
+    'returns undefined (valid) for %p',
+    value => {
+      expect(validateAliasInput(value)).toBeUndefined();
+    }
+  );
 
   it.each(['my;org', 'a|b', 'x&y', 'cost$', '`x`', '$(x)'])('returns an error message for %p', value => {
     expect(validateAliasInput(value)).toBeTruthy();


### PR DESCRIPTION
@W-23491095@

Fixes #7794

## What

Authenticating or aliasing an org with a hyphen (e.g. `my-scratch-org`) failed with:

> Alias can only contain underscores, spaces and alphanumeric characters.

Root cause: `isAlphaNumSpaceString` in `packages/salesforcedx-vscode-org/src/util/orgAlias.ts` uses `/^\w+( *\w*)*$/`, which rejects hyphens. Both the shared auth alias prompt (`SFDX: Authorize an Org`, `Authorize a Dev Hub`, `Authorize an Org using Session ID`) and the scratch org create alias prompt broke identically.

## How

Rather than widening the generically-named `isAlphaNumSpaceString` (still used as a strict alphanumeric+space check), added an alias-specific validator:

- **new** `isValidOrgAlias` in `orgAlias.ts` — `/^[\w-]+( *[\w-]*)*$/`
- `validateAliasInput` (wired into the shared auth alias `showInputBox` in `authParamsGatherer.ts`) now uses it
- `orgCreate.ts` uses it for both the alias `validateInput` and the `defaultAlias` derived from the workspace folder name
- `error_invalid_org_alias` message now mentions hyphens

## Why this is safe

- plugin-auth's `alias` flag is a plain `Flags.string` with no format validator — no CLI contract is being violated
- `@salesforce/core`'s `AliasAccessor` stores aliases as arbitrary string map keys, no character restriction
- the alias value is always double-quoted before shell interpolation (`orgLoginWeb.ts`, `orgLoginWebDevHub.ts`, `orgLoginAccessToken.ts`, `orgCreate.ts`), so a hyphen carries no injection risk; all other shell metacharacters remain rejected

## Tests

`test/jest/util/orgAlias.test.ts` (new `isValidOrgAlias` suite + hyphen cases, plus a case pinning that `isAlphaNumSpaceString` still rejects hyphens), `test/jest/commands/auth/authParamsGatherer.test.ts`, and `test/jest/commands/orgCreate.test.ts` (new test asserting the alias `validateInput` accepts hyphens and still rejects metachars).

All 195 tests in `salesforcedx-vscode-org` pass; lint and compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)