### PR TITLE
chore(agents): add comment-audit step to doc-maintenance workflow

### DIFF
--- a/.claude/agents/doc-maintenance.md
+++ b/.claude/agents/doc-maintenance.md
@@ -32,9 +32,10 @@ ALWAYS operate inside the parent's current working directory. NEVER edit absolut
 ## Workflow
 
 1. `git diff HEAD` (or session context) to identify recent changes
-2. Cross-reference docs: docs/, .claude/skills/, .claude/agents/, .cursor/rules/, contributing/, packages/\*\*/README.md
-3. Fix issues directly (edit files)
-4. Report what was fixed (for transparency)
+2. Comment audit: for each changed \*.ts/\*.tsx hunk, re-read the comment lines on/adjacent to it; fix stale ones per Responsibility 1
+3. Cross-reference docs: docs/, .claude/skills/, .claude/agents/, .cursor/rules/, contributing/, packages/\*\*/README.md
+4. Fix issues directly (edit files)
+5. Report what was fixed, AND explicitly state comment-audit result even if clean (e.g. "comments checked, none stale") — do not report doc status only
 
 ## Style
 


### PR DESCRIPTION
## Summary
- `doc-maintenance` agent's Workflow section never included a step for the comment-audit work described in Responsibility 1, so runs skipped checking comments on changed `*.ts`/`*.tsx` hunks and reported only doc status.
- Added an explicit comment-audit step to Workflow, and require the report to state comment-audit status even when clean.

## Test plan
- [ ] Trigger doc-maintenance on a diff with a stale comment and confirm it's flagged/fixed
- [ ] Confirm report mentions comment-audit result even when no doc changes are needed