### PR TITLE
ci(workflows): fix doc-only auto-merge scan gate self-deadlock

### DIFF
--- a/.github/workflows/docOnlyAutoMerge.yml
+++ b/.github/workflows/docOnlyAutoMerge.yml
@@ -30,7 +30,7 @@ jobs:
   auto-merge:
     runs-on: ubuntu-latest
     # Bound the scan-wait job well under the 6h default so a hung poll can't hold a runner.
-    timeout-minutes: 70
+    timeout-minutes: 40
     env:
       GH_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
       REPO: ${{ github.repository }}
@@ -111,9 +111,9 @@ jobs:
           # rows present before treating "no running rows" as settled.
           expected='["SAST","Credential Scanning Analysis"]'
           # SAST usually posts ~1 min after Credential Scanning but can lag badly — on
-          # #7867 it arrived 36 min after the credential scan. Wait an hour before
-          # giving up so a slow AST queue still auto-merges.
-          for _ in $(seq 1 120); do # ~60 min @ 30s
+          # #7867 it arrived 36 min after the credential scan. Wait 30 min for the scans
+          # to show up and settle; past that, merge anyway (see below).
+          for _ in $(seq 1 60); do # 30 min @ 30s
             # statusCheckRollup is null right after PR-open (no checks registered yet);
             # normalize to [] inside jq so it doesn't crash — empty → not-present → keep polling.
             rollup=$(gh pr view "$PR" --repo "$REPO" --json statusCheckRollup -q '.statusCheckRollup')
@@ -141,10 +141,10 @@ jobs:
             fi
             sleep 30
           done
-          # A scan that never posts (AST service miss) is not a security signal — leave the
-          # PR for a human to merge instead of a permanently red check on a doc-only PR.
-          echo "scans never settled within the window — no auto-merge, merge manually"
-          echo "ok=false" >>"$GITHUB_OUTPUT"
+          # 30 min with no scan failure observed: a scan that never posts is an AST-service
+          # miss, not a security signal, and these are markdown-only diffs. Merge anyway.
+          echo "scans did not settle within 30 min and none failed — merging anyway"
+          echo "ok=true" >>"$GITHUB_OUTPUT"
 
       - name: Squash-merge (admin bypass)
         if: steps.checks.outputs.ok == 'true'

--- a/.github/workflows/docOnlyAutoMerge.yml
+++ b/.github/workflows/docOnlyAutoMerge.yml
@@ -29,6 +29,8 @@ concurrency:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
+    # Bound the scan-wait job well under the 6h default so a hung poll can't hold a runner.
+    timeout-minutes: 70
     env:
       GH_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
       REPO: ${{ github.repository }}
@@ -108,7 +110,10 @@ jobs:
           # empty-rollup race (poll passes before scans queue): require BOTH scan
           # rows present before treating "no running rows" as settled.
           expected='["SAST","Credential Scanning Analysis"]'
-          for _ in $(seq 1 20); do # ~5 min @ 15s; scans normally post within ~1 min
+          # SAST usually posts ~1 min after Credential Scanning but can lag badly — on
+          # #7867 it arrived 36 min after the credential scan. Wait an hour before
+          # giving up so a slow AST queue still auto-merges.
+          for _ in $(seq 1 120); do # ~60 min @ 30s
             # statusCheckRollup is null right after PR-open (no checks registered yet);
             # normalize to [] inside jq so it doesn't crash — empty → not-present → keep polling.
             rollup=$(gh pr view "$PR" --repo "$REPO" --json statusCheckRollup -q '.statusCheckRollup')
@@ -134,7 +139,7 @@ jobs:
             if [ "$present" = "true" ] && [ "$running" = "false" ]; then
               echo "scans present and settled"; echo "ok=true" >>"$GITHUB_OUTPUT"; exit 0
             fi
-            sleep 15
+            sleep 30
           done
           # A scan that never posts (AST service miss) is not a security signal — leave the
           # PR for a human to merge instead of a permanently red check on a doc-only PR.

--- a/.github/workflows/docOnlyAutoMerge.yml
+++ b/.github/workflows/docOnlyAutoMerge.yml
@@ -97,6 +97,10 @@ jobs:
       - name: Gate — security scans present and settled
         id: checks
         if: steps.prstate.outputs.ok == 'true'
+        env:
+          # Own run id — this job's check run is in the rollup and is in_progress for as
+          # long as it polls, so counting it as "running" would never settle (deadlock).
+          SELF_RUN: ${{ github.run_id }}
         run: |
           set -euo pipefail
           # Required-check workflows are paths-ignore'd on doc-only PRs → their
@@ -104,12 +108,14 @@ jobs:
           # empty-rollup race (poll passes before scans queue): require BOTH scan
           # rows present before treating "no running rows" as settled.
           expected='["SAST","Credential Scanning Analysis"]'
-          for _ in $(seq 1 40); do # ~10 min @ 15s
+          for _ in $(seq 1 20); do # ~5 min @ 15s; scans normally post within ~1 min
             # statusCheckRollup is null right after PR-open (no checks registered yet);
             # normalize to [] inside jq so it doesn't crash — empty → not-present → keep polling.
             rollup=$(gh pr view "$PR" --repo "$REPO" --json statusCheckRollup -q '.statusCheckRollup')
-            read -r failure present running < <(echo "$rollup" | jq -r --argjson exp "$expected" '
-              (. // []) as $rows
+            read -r failure present running < <(echo "$rollup" | jq -r --argjson exp "$expected" --arg self "$SELF_RUN" '
+              # Drop this run own rows by detailsUrl (.../actions/runs/<id>/job/<id>).
+              # StatusContext rows have no detailsUrl → "" → kept.
+              [ (. // [])[] | select(((.detailsUrl // "") | contains("/actions/runs/" + $self + "/")) | not) ] as $rows
               | def outcome: (.conclusion // .state // "PENDING") | ascii_upcase;
               def name: (.name // .context // "");
               def isRunning:
@@ -130,8 +136,10 @@ jobs:
             fi
             sleep 15
           done
-          echo "timed out waiting for security scans to settle — fail safe, no merge"
-          exit 1
+          # A scan that never posts (AST service miss) is not a security signal — leave the
+          # PR for a human to merge instead of a permanently red check on a doc-only PR.
+          echo "scans never settled within the window — no auto-merge, merge manually"
+          echo "ok=false" >>"$GITHUB_OUTPUT"
 
       - name: Squash-merge (admin bypass)
         if: steps.checks.outputs.ok == 'true'


### PR DESCRIPTION
## What

Two problems kept the doc-only auto-merge gate from ever passing.

**1. The gate waited on itself.** `Gate — security scans present and settled` reads the PR's full `statusCheckRollup`, which **includes this job's own `auto-merge` check run**. That row is `in_progress` for as long as the gate polls, so `running` was never `false`. Every doc-only PR burned the full window and then `exit 1`.

Evidence — [run 30125221615](https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/30125221615) on #7867, 40 identical polls while every other row was already green:

```
poll: failure=false present=false running=true
...
timed out waiting for security scans to settle — fail safe, no merge
```

**2. A missing scan blocked the merge forever.** On #7867 `Credential Scanning Analysis` completed at 20:44:57 and `SAST` did not post until **21:21:08 — 36 minutes later**. The 10-minute window couldn't have caught it even without bug 1, and the outcome was a red check plus a manual merge.

## Changes

- Exclude own rows from the rollup by `detailsUrl` containing `/actions/runs/${{ github.run_id }}/`. Keyed on `run_id`, not the job name, so renaming the job can't silently reintroduce the deadlock. `StatusContext` rows have no `detailsUrl` → `""` → kept.
- Wait **30 min** (60 polls @ 30s) for `SAST` + `Credential Scanning Analysis` to post and settle, up from 10 min.
- **If they still haven't settled at 30 min and none has failed, merge anyway** (`ok=true`, logged loudly). A scan row that never appears is an AST-service miss, not a security signal, and these diffs are markdown-only.
- `timeout-minutes: 40` on the job, so a hung poll can't sit on a runner for the 6h default.

Unchanged: any scan row reporting FAILURE/CANCELLED/TIMED_OUT/ERROR/ACTION_REQUIRED/STARTUP_FAILURE aborts with `exit 1` and no merge, at any point in the window.

## Reviewer notes

- Deliberate trade-off in the 30-min path: a scan still *running* at the 30-minute mark is treated the same as one that never posted, so a failure it would have reported later is not seen. Bounded to markdown-only diffs by gate 1 (`(^|/)CONTEXT\.md$|^CONTEXT-MAP\.md$|(^|/)docs/.*\.md$|^\.claude/.*\.md$`), from ide-foundations members only.
- `SAST` timing on comparable markdown-only PRs, for the record: #7834 +75s, #7826 +80s, #7824 +73s after the credential scan. #7867 at +36m is the outlier.
- The alternative to a long poll is an `on: check_run` re-entry (re-evaluate when a scan completes, no idle runner). Not done here — it widens the trigger surface of an admin-token workflow, and runners are free on a public repo. Happy to switch if reviewers prefer it.
- jq validated against real payloads: #7867's rollup with self excluded → `failure=false present=false running=false`; #7834's rollup → `failure=false present=true running=false` (merges); `null` rollup → no crash.
- `npm run check:actions` passes; YAML parses.
- This PR touches `.github/workflows/**`, so it is not doc-only and bails at gate 1 — it can't auto-merge itself.

[skip-validate-pr] — CI-only fix to a workflow landed in #7853, no work item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
