### PR TITLE
ci(workflows): filter Doc-Only Auto-Merge trigger to doc paths

### DIFF
--- a/.github/workflows/docOnlyAutoMerge.yml
+++ b/.github/workflows/docOnlyAutoMerge.yml
@@ -12,6 +12,17 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
     branches: [develop]
+    # Don't start a runner on code-only PRs. paths is OR ("any changed file
+    # matches"), so a docs+code PR still triggers — the file-set gate below is
+    # what rejects those. `**` matches `/`, so `docs/**.md` (not docs/**/*.md)
+    # is needed to catch docs/foo.md as well as docs/a/b.md.
+    paths:
+      - CONTEXT.md
+      - CONTEXT-MAP.md
+      - '**/CONTEXT.md'
+      - 'docs/**.md'
+      - '**/docs/**.md'
+      - '.claude/**.md'
 
 # Same-repo branch (team members push to origin, not forks) → org secrets available.
 # NOT pull_request_target — avoids running untrusted head with secrets.


### PR DESCRIPTION
### What does this PR do?

`docOnlyAutoMerge.yml` triggered on **every** `pull_request` to `develop` and leaned on its first step ("Gate — doc-only file set") to no-op. So every code PR started a runner just to `gh api` a file list and exit — e.g. [#7871](https://github.com/forcedotcom/salesforcedx-vscode/pull/7871), a `package.json`/lockfile-only dependabot bump.

Adds a trigger-level `paths:` filter mirroring the gate's line-54 allowlist, so code-only PRs never queue a job.

Reviewer notes:

- **The gate step stays.** `paths` is OR-semantics ("any changed file matches"), so a PR touching `docs/foo.md` *and* `src/bar.ts` still triggers — only the `grep -Ev` rejects it. The filter removes wasted runs, not the safety check.
- **`docs/**.md`, not `docs/**/*.md`.** `**` matches `/` in GitHub path filters, so the `*.md` form misses top-level `docs/foo.md`. The `**.md` form covers both depths.
- **`.claude/**.md` keeps `.claude/**/*.js` out**, matching the existing header comment and the gate regex.
- This workflow is not a required check, so filtering it out of code PRs can't block a merge.

Drive-by observation, not fixed here: on dependabot-authored PRs the gate step failed rather than skipping — those runs read from the Dependabot secret store, so `secrets.IDEE_GH_TOKEN` resolves empty and `gh` exits 4. The `paths:` filter makes it moot for lockfile bumps (dependabot never touches doc paths), so no actor guard added.

### What issues does this PR fix or reference?

None. CI-hygiene cleanup surfaced while reviewing #7871. `[skip-validate-pr]`