### PR TITLE
fix(effect): replace Effect.fn IIFEs with Effect.gen + enforce effectFnIife - W-23429473

### DIFF
--- a/.claude/plans/W-23429473.md
+++ b/.claude/plans/W-23429473.md
@@ -1,0 +1,48 @@
+# W-23429473 — fix + enforce `effectFnIife`
+
+## Context
+
+- Effect LS rule `effectFnIife` (warning, group `antipattern`, code 46): `Effect.fn`/`Effect.fnUntraced` immediately invoked. LS message prescribes the fix: `Effect.gen(function* () {...}).pipe(Effect.withSpan('<old span name>'))`.
+- Enforcement ratchet: `config/effect-diagnostics.json` `enforcedRules`; runner fails on any listed-rule finding at any severity. Pattern per `cf075f7dbf` (`unnecessaryFailYieldableError`).
+- Measured findings on the compiled tree (2026-07-24) — **2**, not the WI's 3; `testController.ts:850` was removed by `f8813b8877` (thin-shell refactor):
+  - `salesforcedx-vscode-apex-testing/src/views/testController.ts:406` — span `ApexTesting.openOrgOnlyTest`, inside `runPromise(...)`, closes over `testUri`.
+  - `salesforcedx-vscode-metadata/src/conflict/conflictView.ts:61` — span `conflictOpenCommandEffect`, ternary branch, closes over `pair`.
+- Repo-wide AST scan for `Effect.fn(...)(...)( ...)` over `packages/*/src` finds only these two, so the rule is green everywhere else.
+- `Effect.gen(...).pipe(Effect.withSpan(...))` is established in-repo (`apexTestExecutionService.ts:476`, `metadataTypeTreeProvider.ts:345`, `metadataRegistryService.ts:24`). Both target files already `import * as Effect from 'effect/Effect'`.
+
+### Overlap check: `local/no-effect-fn-wrapper` is NOT subsumed
+
+| | trigger | fix |
+| --- | --- | --- |
+| `local/no-effect-fn-wrapper` | arrow function whose body returns `Effect.fn(...)(function*)` — with **or without** trailing invoke | hoist arrow params into the generator, delete the arrow |
+| LS `effectFnIife` | **any** immediate invocation of `Effect.fn(...)(...)`, wherever it sits | → `Effect.gen` + `withSpan` |
+
+- Non-IIFE arrow wrappers (`(id) => Effect.fn(n)(function* () { ...id... })`, `eslint.config.mjs:167`, SKILL.md:253) are invisible to `effectFnIife`, and no other LS rule covers them (`effectFnOpportunity` targets arrows returning an *Effect*; these return a *function*). ∴ keep the custom rule.
+- The custom rule's `trailingInvoke` branch **is** strictly subsumed (LS flags the same shape plus the both-have-params case the custom rule skips), and its autofix is wrong: it hoists the arrow param but keeps `()`, turning `(sel) => Effect.fn(n)(function* () {…sel…})()` into `Effect.fn(n)(function* (sel) {…})()` — an `Effect` (not a function) invoked with zero args, so `sel` is `undefined` and callers stop type-checking. Retire that branch only; `effectFnIife` owns IIFEs. No in-repo site exercises it.
+
+## Phases
+
+### 1. Fix both IIFE sites + enforce
+
+- `testController.ts:406`: `Effect.fn('ApexTesting.openOrgOnlyTest')(function* () {…})()` → `Effect.gen(function* () {…}).pipe(Effect.withSpan('ApexTesting.openOrgOnlyTest'))`.
+- `conflictView.ts:61`: same shape, span `conflictOpenCommandEffect`.
+- `config/effect-diagnostics.json`: append `"effectFnIife"` to `enforcedRules`.
+
+### 2. Retire the overlapping custom-rule branch
+
+- `packages/eslint-local-rules/src/noEffectFnWrapper.ts`: drop `unwrapInvokedEffectFn`, the `trailingInvoke` flag, and the `suffix`; keep arrow-wrapper detection + fix.
+- `test/no-effect-fn-wrapper.test.ts`: move the trailing-invoke case to `valid` with a comment naming `effectFnIife` as its owner.
+- `.claude/skills/effect-best-practices/SKILL.md`: note the IIFE form is `effectFnIife`-enforced and belongs in the common-findings list.
+- commit: `fix(effect): replace Effect.fn IIFEs with Effect.gen + enforce effectFnIife - W-23429473`
+
+## Skills
+
+- effect-best-practices (rule guidance + SKILL edit), typescript, concise (this plan), verification
+
+## Verification
+
+- `node scripts/effect-diagnostics.mjs` → 0 `effectFnIife` findings across all Effect packages (needs compiled `out/`).
+- `npm run lint` on eslint-local-rules + both touched packages; eslint-local-rules jest suite (rule-tester) green.
+- compile clean: `Effect.gen(...).pipe(withSpan)` keeps the exact `Effect<A, E, R>` of the old IIFE, so `runPromise`/ternary types are unchanged.
+- Behavior: identical modulo span creation site (span still named the same, now via `withSpan`).
+  - `openOrgOnlyTest` ← Test Explorer opening an org-only test; `conflictOpenCommandEffect` ← conflict-view item click. Both covered only by manual/e2e paths; no unit test asserts the span name.

--- a/.claude/skills/effect-best-practices/SKILL.md
+++ b/.claude/skills/effect-best-practices/SKILL.md
@@ -17,7 +17,7 @@ npx effect-language-service diagnostics --project tsconfig.json
 ```
 
 - The PostToolUse `verify-on-edit.sh` hook auto-runs `--file <edited>` on every `.ts` Edit/Write and surfaces output as `followup_message`. Address what it reports.
-- **Address warnings AND messages, not just errors.** Common findings: `effectFnOpportunity` (gen→fn), `unnecessaryFailYieldableError` (yield error directly), `effectSucceedWithVoid` (`Effect.succeed(undefined)` → `Effect.void`), `globalErrorInEffectCatch`/`Failure` (use tagged error, not `new Error`; both config-enforced — see `references/anti-patterns.md`); `tryCatchInEffectGen` (config-enforced; try/catch in `Effect.gen` → `catchAllCause`+`Cause.squash`/`catchTag`).
+- **Address warnings AND messages, not just errors.** Common findings: `effectFnOpportunity` (gen→fn), `unnecessaryFailYieldableError` (yield error directly), `effectSucceedWithVoid` (`Effect.succeed(undefined)` → `Effect.void`), `globalErrorInEffectCatch`/`Failure` (use tagged error, not `new Error`; both config-enforced — see `references/anti-patterns.md`); `tryCatchInEffectGen` (config-enforced; try/catch in `Effect.gen` → `catchAllCause`+`Cause.squash`/`catchTag`); `effectFnIife` (config-enforced; immediately-invoked `Effect.fn` → `Effect.gen` + piped `Effect.withSpan`).
 - After a batch of edits, run `--project tsconfig.json` for the affected package to catch cross-file issues.
 - `effect-language-service quickfixes` shows proposed code changes.
 
@@ -255,6 +255,16 @@ const findByIdBad = (id: UserId) =>
   Effect.fn('UserService.findById')(function* () {
     yield* repo.findById(id); // id from closure
   });
+
+// WRONG - Effect.fn invoked immediately (config-enforced effectFnIife). Effect.fn builds a reusable
+// function; for one-shot use write Effect.gen and keep the span with a piped withSpan.
+const opened = Effect.fn('FsService.open')(function* () {
+  yield* fs.showTextDocument(uri);
+})();
+// CORRECT
+const openedOk = Effect.gen(function* () {
+  yield* fs.showTextDocument(uri);
+}).pipe(Effect.withSpan('FsService.open'));
 
 // Naming: Don't append Effect. For commands use FooCommand; for helpers/lifecycle use domain names.
 // WRONG: logGetEffect, executeAnonymousDocumentEffect, activateEffect

--- a/config/effect-diagnostics.json
+++ b/config/effect-diagnostics.json
@@ -9,6 +9,7 @@
     "tryCatchInEffectGen",
     "unknownInEffectCatch",
     "effectSucceedWithVoid",
-    "unnecessaryFailYieldableError"
+    "unnecessaryFailYieldableError",
+    "effectFnIife"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -43402,9 +43402,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/packages/eslint-local-rules/README.md
+++ b/packages/eslint-local-rules/README.md
@@ -52,6 +52,30 @@ const reporter = process.env.ESBUILD_PLATFORM === 'web' ? webReporter : nodeRepo
 
 Test files set/delete/save-restore the env var as jest plumbing; that is allowed via an `off` override in `eslint.config.mjs`, not the rule.
 
+### no-effect-fn-wrapper
+
+Enforces that an arrow function wrapping an `Effect.fn` call hoists its params into the generator, where they become typed arguments instead of closure captures. The wrapper arrow then disappears.
+
+**Bad:**
+
+```typescript
+// params on wrapper arrow, generator has none (closure capture)
+const findById = (id: UserId) =>
+  Effect.fn('UserService.findById')(function* () {
+    yield* repo.findById(id); // id from closure
+  });
+```
+
+**Good:**
+
+```typescript
+const findById = Effect.fn('UserService.findById')(function* (id: UserId) {
+  yield* repo.findById(id);
+});
+```
+
+Note: Immediately-invoked `Effect.fn` calls (e.g. `Effect.fn('x')(function* (){})()`) are flagged by the Effect Language Service rule `effectFnIife` (config-enforced in `config/effect-diagnostics.json`), not this rule. Use `Effect.gen(...).pipe(Effect.withSpan(...))` for one-shot effects.
+
 ### no-successive-annotate-current-span
 
 Enforces that back-to-back `Effect.annotateCurrentSpan` calls are merged into a single call. Each call opens and annotates the current span independently, so two or more adjacent calls do redundant work that a single object-argument call expresses more cheaply. The rule detects two forms: consecutive `yield* Effect.annotateCurrentSpan(...)` statements inside a generator, and consecutive `Effect.tap(x => Effect.annotateCurrentSpan(...))` arguments inside one `.pipe(...)` chain. Any intervening statement or non-annotate `.tap` breaks the run, so only genuinely successive calls are flagged. Array forms (`Effect.all`/`forEach`) and `andThen` chains are out of scope.

--- a/packages/eslint-local-rules/src/noEffectFnWrapper.ts
+++ b/packages/eslint-local-rules/src/noEffectFnWrapper.ts
@@ -38,15 +38,6 @@ const getBodyExpression = (body: TSESTree.ArrowFunctionExpression['body']): TSES
   return undefined;
 };
 
-const unwrapInvokedEffectFn = (
-  node: TSESTree.CallExpression
-): { effectFnCall: TSESTree.CallExpression; trailingInvoke: boolean } | undefined => {
-  const callee = node.callee;
-  if (callee.type !== AST_NODE_TYPES.CallExpression) return undefined;
-  const gen = isEffectFnCall(callee);
-  return gen !== undefined ? { effectFnCall: callee, trailingInvoke: true } : undefined;
-};
-
 export const noEffectFnWrapper = RuleCreator.withoutDocs({
   meta: {
     type: 'problem',
@@ -63,22 +54,12 @@ export const noEffectFnWrapper = RuleCreator.withoutDocs({
   defaultOptions: [],
   create: context => ({
     ArrowFunctionExpression: (node: TSESTree.ArrowFunctionExpression): void => {
-      const bodyExpr = getBodyExpression(node.body);
-      if (!bodyExpr) return;
+      const effectFnCall = getBodyExpression(node.body);
+      if (!effectFnCall) return;
 
-      let effectFnCall: TSESTree.CallExpression;
-      let trailingInvoke = false;
-
-      const innerGen = isEffectFnCall(bodyExpr);
-      if (innerGen !== undefined) {
-        effectFnCall = bodyExpr;
-      } else {
-        const unwrapped = unwrapInvokedEffectFn(bodyExpr);
-        if (!unwrapped) return;
-        effectFnCall = unwrapped.effectFnCall;
-        trailingInvoke = unwrapped.trailingInvoke;
-      }
-
+      // Only a body that IS the Effect.fn call matches. An immediately-invoked one
+      // (`() => Effect.fn(n)(function* () {})()`) belongs to the Effect LS rule `effectFnIife`,
+      // enforced via config/effect-diagnostics.json, which rewrites it to Effect.gen.
       const gen = isEffectFnCall(effectFnCall);
       if (!gen) return;
 
@@ -103,9 +84,7 @@ export const noEffectFnWrapper = RuleCreator.withoutDocs({
               ? node.params.map(p => sourceCode.getText(p)).join(', ')
               : gen.params.map(p => sourceCode.getText(p)).join(', ');
           const newGen = `function* (${paramsText}) {${genBody}}`;
-          const newEffectFnCall = `Effect.fn(${fnName})(${newGen})`;
-          const suffix = trailingInvoke ? '()' : '';
-          return fixer.replaceTextRange(node.range, `${newEffectFnCall}${suffix}`);
+          return fixer.replaceTextRange(node.range, `Effect.fn(${fnName})(${newGen})`);
         }
       });
     }

--- a/packages/eslint-local-rules/test/no-effect-fn-wrapper.test.ts
+++ b/packages/eslint-local-rules/test/no-effect-fn-wrapper.test.ts
@@ -38,6 +38,15 @@ const createNode = (projectComponentSet: unknown) => (element: { name: string })
     return \`\${element.name}.\${field.id}\`;
   });`,
       filename: 'packages/salesforcedx-vscode-org-browser/src/tree/customField.ts'
+    },
+    {
+      // Immediately-invoked Effect.fn belongs to the Effect LS rule `effectFnIife`, not this rule.
+      code: `import * as Effect from 'effect/Effect';
+const getText = (sel: boolean) =>
+  Effect.fn('EditorService.getText')(function* () {
+    return sel;
+  })();`,
+      filename: 'packages/salesforcedx-vscode-services/src/test.ts'
     }
   ],
   invalid: [
@@ -59,19 +68,6 @@ const findById = (id: string) =>
 const findById = Effect.fn('UserService.findById')(function* (id: string) {
     return id;
   });`,
-      filename: 'packages/salesforcedx-vscode-services/src/test.ts',
-      errors: [{ messageId: 'noEffectFnWrapper' }]
-    },
-    {
-      code: `import * as Effect from 'effect/Effect';
-const getText = (sel: boolean) =>
-  Effect.fn('EditorService.getText')(function* () {
-    return sel;
-  })();`,
-      output: `import * as Effect from 'effect/Effect';
-const getText = Effect.fn('EditorService.getText')(function* (sel: boolean) {
-    return sel;
-  })();`,
       filename: 'packages/salesforcedx-vscode-services/src/test.ts',
       errors: [{ messageId: 'noEffectFnWrapper' }]
     }

--- a/packages/salesforcedx-vscode-apex-testing/src/views/testController.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/views/testController.ts
@@ -403,13 +403,13 @@ const openOrgOnlyTest = async (test: vscode.TestItem): Promise<void> => {
   }
   const testUri = test.uri;
   const editor = await getApexTestingRuntime().runPromise(
-    Effect.fn('ApexTesting.openOrgOnlyTest')(function* () {
+    Effect.gen(function* () {
       const api = yield* (yield* ExtensionProviderService).getServicesApi;
       return yield* api.services.FsService.showTextDocument(testUri, {
         preview: false,
         viewColumn: vscode.ViewColumn.Active
       });
-    })()
+    }).pipe(Effect.withSpan('ApexTesting.openOrgOnlyTest'))
   );
   if (isMethod(test.id) && test.range) {
     editor.selection = new vscode.Selection(test.range.start, test.range.start);

--- a/packages/salesforcedx-vscode-metadata/src/conflict/conflictView.ts
+++ b/packages/salesforcedx-vscode-metadata/src/conflict/conflictView.ts
@@ -58,10 +58,10 @@ export const conflictDiffCommandEffect = (entry: DiffFilePair | ConflictTreeItem
 export const conflictOpenCommandEffect = (node: ConflictTreeItem) => {
   const pair = node?.pair;
   return pair
-    ? Effect.fn('conflictOpenCommandEffect')(function* () {
+    ? Effect.gen(function* () {
         const api = yield* (yield* ExtensionProviderService).getServicesApi;
         yield* api.services.FsService.showTextDocument(pair.localUri.uri);
-      })()
+      }).pipe(Effect.withSpan('conflictOpenCommandEffect'))
     : Effect.void;
 };
 


### PR DESCRIPTION
## What

Effect LS rule `effectFnIife`: `Effect.fn` builds a *reusable* function, so invoking it immediately is pointless indirection. Both in-repo sites now use `Effect.gen(...)` with the span preserved by a piped `Effect.withSpan(...)` — the fix the diagnostic itself prescribes:

- `salesforcedx-vscode-apex-testing/src/views/testController.ts:406` (span `ApexTesting.openOrgOnlyTest`)
- `salesforcedx-vscode-metadata/src/conflict/conflictView.ts:61` (span `conflictOpenCommandEffect`)

`effectFnIife` is appended to `config/effect-diagnostics.json` `enforcedRules`, so the ratchet now fails the build on any new site.

The WI listed 3 findings; `testController.ts:850` was already removed by #7736 (thin-shell refactor). A repo-wide AST scan for immediately-invoked `Effect.fn`/`Effect.fnUntraced` confirms only the two above existed.

## Overlap check: `local/no-effect-fn-wrapper` is kept, its IIFE branch retired

| | trigger | fix |
| --- | --- | --- |
| `local/no-effect-fn-wrapper` | arrow function whose body returns `Effect.fn(...)(function*)` | hoist arrow params into the generator, drop the arrow |
| LS `effectFnIife` | any immediate invocation of `Effect.fn(...)`, wherever it sits | → `Effect.gen` + piped `withSpan` |

Non-IIFE arrow wrappers (`(id) => Effect.fn(n)(function* () { ...id... })`) are invisible to `effectFnIife`, and no other LS rule covers them (`effectFnOpportunity` targets arrows returning an *Effect*; these return a *function*). So the custom rule stays.

Its `trailingInvoke` branch, however, **is** strictly subsumed — and its autofix was wrong: it hoisted the arrow param but kept the trailing `()`, turning `(sel) => Effect.fn(n)(function* () {…sel…})()` into `Effect.fn(n)(function* (sel) {…})()` — an `Effect` (not a function) invoked with zero args, so `sel` was `undefined` and callers stopped type-checking. That branch is removed; `effectFnIife` owns IIFEs. No in-repo site exercised it.

## Verification

- `node scripts/effect-diagnostics.mjs` → 19 packages, **0 enforced violations** with `effectFnIife` enforced
- `npm run compile`, `npm run lint` clean
- `eslint-local-rules` jest: 302 passed (trailing-invoke case moved to `valid`, commented with its new owner)
- `salesforcedx-vscode-apex-testing` jest 317 passed / `salesforcedx-vscode-metadata` jest 122 passed
- Behavior unchanged: `Effect.fn` ends in the same `withSpan(effect, name)` call, so span name/parenting and the `A, E, R` channels are identical

## Docs

- `.claude/skills/effect-best-practices/SKILL.md`: `effectFnIife` added to the common-findings list + a WRONG/CORRECT example
- `packages/eslint-local-rules/README.md`: documents `no-effect-fn-wrapper` and its boundary with `effectFnIife`

@W-23429473@
