### PR TITLE
chore(deps): bump @lwc/metadata to 13.1.0 for GHSA-qx2v-qp2m-jg93 - W-23527223

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6109,16 +6109,16 @@
       }
     },
     "node_modules/@lwc/metadata": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@lwc/metadata/-/metadata-12.3.4.tgz",
-      "integrity": "sha512-90+AW7d+txJYAoa5Be+FR5KtppzVOB4pT9bV1OJatZedz79b0JtP/NJGIxItLJHB8mKwb2bAyuzNibysoaM6AA==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@lwc/metadata/-/metadata-13.1.0.tgz",
+      "integrity": "sha512-qshh9vO/KG03etyhtUGIMIryyhjW4++5dy17njAKui1qptcSBJtA3bExAVkgU15RwOBCMp7MCQS5ykwG/xSIew==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@babel/parser": "~7.26.2",
-        "@babel/traverse": "~7.25.9",
-        "@babel/types": "~7.26.0",
-        "@lwc/sfdc-compiler-utils": "12.3.4",
-        "postcss": "~8.4.49",
+        "@babel/parser": "~7.27.5",
+        "@babel/traverse": "~7.27.4",
+        "@babel/types": "~7.27.6",
+        "@lwc/sfdc-compiler-utils": "13.1.0",
+        "postcss": "~8.5.5",
         "postcss-selector-parser": "~6.1.2",
         "postcss-value-parser": "~4.2.0"
       },
@@ -6131,12 +6131,12 @@
       }
     },
     "node_modules/@lwc/metadata/node_modules/@babel/parser": {
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
-      "integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
+      "version": "7.27.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.7.tgz",
+      "integrity": "sha512-qnzXzDXdr/po3bOTbTIQZ7+TxNKxpkN5IifVLXS+r7qwynkZfPyjZfE7hCXbo7IoO9TNcSyibgONsf2HauUd3Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.10"
+        "@babel/types": "^7.27.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -6146,16 +6146,16 @@
       }
     },
     "node_modules/@lwc/metadata/node_modules/@babel/traverse": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.9.tgz",
-      "integrity": "sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==",
+      "version": "7.27.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.7.tgz",
+      "integrity": "sha512-X6ZlfR/O/s5EQ/SnUSLzr+6kGnkg8HXGMzpgsMsrJVcfDtH1vIp6ctCN4eZ1LS5c0+te5Cb6Y514fASjMRJ1nw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.25.9",
-        "@babel/generator": "^7.25.9",
-        "@babel/parser": "^7.25.9",
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.25.9",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.27.5",
+        "@babel/parser": "^7.27.7",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.27.7",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -6164,13 +6164,13 @@
       }
     },
     "node_modules/@lwc/metadata/node_modules/@babel/types": {
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
-      "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
+      "version": "7.27.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.7.tgz",
+      "integrity": "sha512-8OLQgDScAOHXnAz2cV+RfzzNMipuLVBz2biuAJFMV9bfkNf393je3VM8CLkjQodW5+iWsSJdSgSWT6rsZoXHPw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -6183,6 +6183,34 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@lwc/metadata/node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/@lwc/module-resolver": {
@@ -6626,9 +6654,9 @@
       }
     },
     "node_modules/@lwc/sfdc-compiler-utils": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@lwc/sfdc-compiler-utils/-/sfdc-compiler-utils-12.3.4.tgz",
-      "integrity": "sha512-AtP9XBzCnrGreJFunohDGD3ZkdT7VTCBs+EncCJPxD2Ej7pRKXX242d5A/TTfi8sp656FuZ6M/jleMNvIyXlKg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@lwc/sfdc-compiler-utils/-/sfdc-compiler-utils-13.1.0.tgz",
+      "integrity": "sha512-PanZL6cIxXcYveRU6mmkwVpBz3i/5WfGko0X0WUbYOs4dN5N7StNYX5oCV4hBPj5vmVKmYsxP3zsMuSBur4fmQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "engines": {
         "node": ">=14"
@@ -6708,9 +6736,9 @@
       }
     },
     "node_modules/@lwc/style-compiler/node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -32879,6 +32907,7 @@
       "version": "8.4.49",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
       "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -43843,7 +43872,7 @@
       "dependencies": {
         "@lwc/compiler": "9.0.3",
         "@lwc/errors": "9.0.3",
-        "@lwc/metadata": "12.3.4",
+        "@lwc/metadata": "13.1.0",
         "@lwc/template-compiler": "9.3.4",
         "@salesforce/apex": "^0.0.21",
         "@salesforce/label": "^0.0.21",
@@ -44085,9 +44114,9 @@
       }
     },
     "packages/salesforcedx-lwc-language-server/node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -44104,7 +44133,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/packages/salesforcedx-lwc-language-server/package.json
+++ b/packages/salesforcedx-lwc-language-server/package.json
@@ -80,7 +80,7 @@
   "dependencies": {
     "@lwc/compiler": "9.0.3",
     "@lwc/errors": "9.0.3",
-    "@lwc/metadata": "12.3.4",
+    "@lwc/metadata": "13.1.0",
     "@lwc/template-compiler": "9.3.4",
     "@salesforce/apex": "^0.0.21",
     "@salesforce/label": "^0.0.21",


### PR DESCRIPTION
### What does this PR do?

Remediates **GHSA-qx2v-qp2m-jg93** (medium, postcss line-return parsing DoS, fixed in postcss 8.5.10) in prod dependency scope.

- `packages/salesforcedx-lwc-language-server/package.json`: `@lwc/metadata` 12.3.4 → 13.1.0. 12.3.4 pins `postcss@~8.4.49`; 13.1.0 is the lowest release that moves to `postcss@~8.5.5` (every 13.0.x patch still pins ~8.4.49).
- `package-lock.json`: also refreshed postcss under `@lwc/style-compiler@9.0.3` — the other prod-scope path — whose `~8.5.6` range already allowed a patched release but was resolved to the vulnerable 8.5.8. No `package.json` change for that path.

Both prod-scope postcss entries now resolve to `8.5.19`. Remaining postcss entries in the lockfile are dev-scope only.

Major bump 12 → 13 is type-safe for this repo: every type consumed (`BundleConfig`, `ScriptFile`, `collectBundleMetadata`, `Class`, `ClassMethod`, `ClassProperty`, `WireDecorator`, `LwcDecorator`, `SourceLocation`, `Value`) is unchanged; the only `.d.ts` change in the package is `dist/errors/errors.d.ts`, which this repo does not import. Module format (CJS), engines (node >=14) and peer deps (`@lwc/errors >=8`, `@lwc/template-compiler >=8`) are unchanged and still satisfied.

Verification: `check-peer-dependencies` clean, full-repo `compile` clean, `@salesforce/salesforcedx-lwc-language-server` tests 129/129 pass (including `typeMapping` + `compiler` suites that call `collectBundleMetadata` against the new version), `salesforcedx-vscode-lwc` tests 49/49 pass, lint 0 errors.

### What issues does this PR fix or reference?
@W-23527223@
