### PR TITLE
refactor(services): own sf:code_builder_enabled context key - W-23462778

### DIFF
--- a/packages/salesforcedx-vscode-core/src/index.ts
+++ b/packages/salesforcedx-vscode-core/src/index.ts
@@ -88,10 +88,6 @@ export const activateEffect = Effect.fn('activation:salesforcedx-vscode-core')(f
   // Context — ProjectService.isSalesforceProject() sets sf:project_opened as a side effect
   const salesforceProjectOpened = yield* servicesApi.services.ProjectService.isSalesforceProject();
 
-  // Set Code Builder context
-  const codeBuilderEnabled = process.env.CODE_BUILDER === 'true';
-  void vscode.commands.executeCommand('setContext', 'sf:code_builder_enabled', codeBuilderEnabled);
-
   if (salesforceProjectOpened) {
     yield* Effect.promise(() => initializeProject(extensionContext));
   }

--- a/packages/salesforcedx-vscode-services/src/index.ts
+++ b/packages/salesforcedx-vscode-services/src/index.ts
@@ -282,6 +282,10 @@ const activationEffect = Effect.fn('activation:salesforcedx-vscode-services')(fu
   // set sf:internal_dev context so internal commands are visible in explorer menus when enabled
   const internalDev = yield* SettingsService.getInternalDev();
   yield* Effect.promise(() => vscode.commands.executeCommand('setContext', 'sf:internal_dev', internalDev));
+  // set sf:code_builder_enabled context so Code Builder-only commands are visible on web
+  yield* Effect.promise(() =>
+    vscode.commands.executeCommand('setContext', 'sf:code_builder_enabled', process.env.CODE_BUILDER === 'true')
+  );
 });
 
 /**


### PR DESCRIPTION
### What does this PR do?

Moves the `sf:code_builder_enabled` VS Code context key setter from `salesforcedx-vscode-core` activation into `salesforcedx-vscode-services` activation, next to the sibling `sf:internal_dev` / `sf:project_opened` setters.

- One-shot read of `process.env.CODE_BUILDER === 'true'`, no core dependencies, so it belongs with the other context keys services already owns.
- Set **blocking** (not forked) before services activation resolves, since `when` clauses on lazy-loaded extensions are evaluated by VS Code at startup — same as the sibling keys.
- Services activates on `*`, so the key is now also set in workspaces without an `sfdx-project.json`, where core never activated (previously the key stayed unset there).

Consumers are unchanged — `when` clauses in `salesforcedx-vscode-metadata`, `salesforcedx-vscode-core`, and `salesforcedx-vscode-apex-debugger` package.json.

### What issues does this PR fix or reference?
@W-23462778@
