### PR TITLE
feat(services): inject SFDX_TOOL env var for sf commands in TerminalService - W-23476812

### DIFF
--- a/.claude/skills/services-extension-consumption/references/terminal-service.md
+++ b/.claude/skills/services-extension-consumption/references/terminal-service.md
@@ -9,6 +9,8 @@ simpleExec(args: {
   command: string;
   parse?: (stdout: string) => string;
   timeout?: Duration.DurationInput;
+  env?: Record<string, string>;
+  cwd?: string;
 }): Effect<string, TerminalServiceError>
 ```
 
@@ -16,6 +18,9 @@ simpleExec(args: {
 - `parse` optional — omit to get trimmed stdout as `string`
 - stdout trimmed before `parse` is called
 - `timeout` optional `Duration.DurationInput` (default 30 s); pass a larger Duration for long-running commands (e.g. org delete)
+- `env` optional — overrides/augments child process environment (merged over `process.env`)
+- `cwd` optional — sets child working directory (omitted → uses extension-host process.cwd())
+- `sf ` commands auto-inject `SF_JSON_TO_STDOUT=true` + `FORCE_COLOR=0` + `SFDX_TOOL='salesforce-vscode-extensions'` (caller `env` overrides win)
 - Traced with `TerminalService.simpleExec` span (`command` attribute)
 - On web: immediate `TerminalServiceError` (no exec attempted)
 

--- a/packages/salesforcedx-vscode-services/src/terminal/terminalService.ts
+++ b/packages/salesforcedx-vscode-services/src/terminal/terminalService.ts
@@ -37,8 +37,9 @@ export class TerminalService extends Effect.Service<TerminalService>()('Terminal
      * `env` overrides/augments the child's environment (merged over `process.env` in childProcess).
      * `cwd` sets the child's working directory (omitted → node uses the extension-host process.cwd()); needed for
      * cwd-dependent flows like project-local `config set`/`project generate`/relative-manifest retrieves.
-     * `sf ` commands get `SF_JSON_TO_STDOUT=true` + `FORCE_COLOR=0` injected automatically (a caller `env` of the
-     * same key still wins) so every sf consumer gets clean, color-free JSON stdout without repeating the flags. */
+     * `sf ` commands get `SF_JSON_TO_STDOUT=true` + `FORCE_COLOR=0` + `SFDX_TOOL` injected automatically (a caller
+     * `env` of the same key still wins) so every sf consumer gets clean, color-free JSON stdout, attributed to these
+     * extensions, without repeating the flags. */
     const simpleExec = Effect.fn('TerminalService.simpleExec')(function* <A>({
       command,
       parse,
@@ -53,8 +54,12 @@ export class TerminalService extends Effect.Service<TerminalService>()('Terminal
       cwd?: string;
     }) {
       // FORCE_COLOR=0 strips the ANSI escapes sf wraps JSON in (else JSON.parse breaks); SF_JSON_TO_STDOUT keeps
-      // the payload on stdout. Caller env merges on top so an explicit override still wins.
-      const sfEnv = command.startsWith('sf ') ? { SF_JSON_TO_STDOUT: 'true', FORCE_COLOR: '0' } : undefined;
+      // the payload on stdout; SFDX_TOOL is read by @salesforce/plugin-telemetry to attribute the invocation to
+      // these extensions (same literal as TELEMETRY_HEADER, which the legacy cliCommandExecutor sets).
+      // Caller env merges on top so an explicit override still wins.
+      const sfEnv = command.startsWith('sf ')
+        ? { SF_JSON_TO_STDOUT: 'true', FORCE_COLOR: '0', SFDX_TOOL: 'salesforce-vscode-extensions' }
+        : undefined;
       const mergedEnv = sfEnv || env ? { ...sfEnv, ...env } : undefined;
       yield* Effect.annotateCurrentSpan('command', command);
       // annotate which env keys were set (keys only — never values, to avoid leaking secrets)

--- a/packages/salesforcedx-vscode-services/test/jest/terminal/terminalService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/terminal/terminalService.test.ts
@@ -96,19 +96,23 @@ describe('TerminalService.simpleExec', () => {
       withExec(capturingExec(capture))
     );
 
-    // non-sf command: caller env passes through with no SF_JSON_TO_STDOUT/FORCE_COLOR injected. (The
+    // non-sf command: caller env passes through with no SF_JSON_TO_STDOUT/FORCE_COLOR/SFDX_TOOL injected. (The
     // `{ ...process.env, ...env }` merge lives in resolveExecOptions, covered in childProcess.test.ts.)
     expect(capture.options?.env).toEqual({ FOO: 'bar' });
   });
 
-  it('auto-injects SF_JSON_TO_STDOUT + FORCE_COLOR for sf commands', async () => {
+  it('auto-injects SF_JSON_TO_STDOUT + FORCE_COLOR + SFDX_TOOL for sf commands', async () => {
     const capture: { options?: ExecOptions } = {};
     await run(
       TerminalService.pipe(Effect.flatMap(terminal => terminal.simpleExec({ command: 'sf org open', parse: s => s }))),
       withExec(capturingExec(capture))
     );
 
-    expect(capture.options?.env).toEqual({ SF_JSON_TO_STDOUT: 'true', FORCE_COLOR: '0' });
+    expect(capture.options?.env).toEqual({
+      SF_JSON_TO_STDOUT: 'true',
+      FORCE_COLOR: '0',
+      SFDX_TOOL: 'salesforce-vscode-extensions'
+    });
   });
 
   it('lets a caller env override the auto-injected sf env', async () => {
@@ -122,8 +126,13 @@ describe('TerminalService.simpleExec', () => {
       withExec(capturingExec(capture))
     );
 
-    // caller FORCE_COLOR wins over the injected '0'; injected SF_JSON_TO_STDOUT and caller EXTRA both present
-    expect(capture.options?.env).toEqual({ SF_JSON_TO_STDOUT: 'true', FORCE_COLOR: '1', EXTRA: 'x' });
+    // caller FORCE_COLOR wins over the injected '0'; injected SF_JSON_TO_STDOUT/SFDX_TOOL and caller EXTRA all present
+    expect(capture.options?.env).toEqual({
+      SF_JSON_TO_STDOUT: 'true',
+      FORCE_COLOR: '1',
+      SFDX_TOOL: 'salesforce-vscode-extensions',
+      EXTRA: 'x'
+    });
   });
 
   it('does not inject sf env for non-sf commands without a caller env', async () => {


### PR DESCRIPTION
@W-23476812@

## What

`TerminalService.simpleExec` already injects `SF_JSON_TO_STDOUT=true` + `FORCE_COLOR=0` for any command starting with `sf `. This adds a third injected var: `SFDX_TOOL='salesforce-vscode-extensions'`.

## Why

`@salesforce/plugin-telemetry` (in the sf CLI) reads `process.env.SFDX_TOOL` to attribute CLI invocations to the calling client. The legacy `cliCommandExecutor.ts` already sets the same value (`packages/salesforcedx-apex-debugger/src/core/cliCommandExecutor.ts:26`, from `TELEMETRY_HEADER` in `packages/salesforcedx-utils/src/constants.ts:9`), so `sf` calls routed through `TerminalService` were losing that attribution.

## Notes

- The literal string is inlined rather than importing `TELEMETRY_HEADER` from `@salesforce/salesforcedx-utils` — `salesforcedx-vscode-services` has no dependency on that legacy package, and one string constant does not justify a new dependency edge. **No new package dependency.**
- Caller-supplied `env` still wins over any injected key (existing behavior, covered by test).
- Updated the two tests asserting the injected env shape, plus the `simpleExec` JSDoc/inline comment and the `services-extension-consumption` skill reference.

## Verification

- `npm run compile` ✅
- `npm run lint` ✅ (2 pre-existing warnings in `spansNode.ts`, untouched)
- `npm test` (salesforcedx-vscode-services): 32 suites / 260 tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)