### PR TITLE
fix(skills): use jq instead of python3 for JSON parsing

### DIFF
--- a/.claude/skills/gus-cli/epics.md
+++ b/.claude/skills/gus-cli/epics.md
@@ -55,7 +55,7 @@ PROD=a1aB000000005G3IAI; RT=0129000000006gDAAQ; ASSIGN=005B0000000GIODIA4
 create() { # $1=Subject  $2=Details (>=20 chars)
   sf data create record -s ADM_Work__c -o gus \
     -v "Subject__c='$1' Details__c='$2' Story_Points__c=2 Product_Tag__c=$PROD RecordTypeId=$RT Epic__c=$EPIC Scrum_Team__c=$TEAM Assignee__c=$ASSIGN" \
-    --json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['result']['id'] if d.get('status')==0 else 'ERR')"
+    --json 2>/dev/null | jq -r 'if .status == 0 then .result.id else "ERR" end'
 }
 create "1.0 [ai-auto] First task" "Description, at least twenty chars."
 create "1.1 [ai-auto] Second task" "Another, also twenty-plus chars."

--- a/.claude/skills/playwright-e2e/references/analyze-e2e.md
+++ b/.claude/skills/playwright-e2e/references/analyze-e2e.md
@@ -62,14 +62,10 @@ ls -lt .e2e-artifacts/*/*/playwright-test-results-*/spans/*.jsonl
 Read spans compact JSON:
 
 ```bash
-python3 - <<'PY'
-import glob, json
-for path in glob.glob('.e2e-artifacts/*/*/playwright-test-results-*/spans/*.jsonl'):
-    print(f'### {path}')
-    with open(path, encoding='utf-8') as f:
-        for line in f:
-            print(json.dumps(json.loads(line), separators=(',', ':')))
-PY
+for f in .e2e-artifacts/*/*/playwright-test-results-*/spans/*.jsonl; do
+  echo "### $f"
+  jq -c '.' "$f"
+done
 ```
 
 ## Run ID


### PR DESCRIPTION
## Summary
- `gus-cli/epics.md` and `playwright-e2e/references/analyze-e2e.md` used `python3` one-liners to parse JSON, inconsistent with this repo's jq-only convention for CLI JSON parsing.
- Replaced both with equivalent `jq` commands.

## Test plan
- [x] Verified `jq -r 'if .status == 0 then .result.id else "ERR" end'` against sample `{"status":0,"result":{"id":"..."}}` and `{"status":1}` payloads
- [x] Verified the `jq -c '.'` loop against real `spans/*.jsonl` files in `.e2e-artifacts/`