### PR TITLE
refactor(apex-replay-debugger): migrate fs helpers to FsService - W-23465460

### DIFF
--- a/.claude/plans/W-23465460.md
+++ b/.claude/plans/W-23465460.md
@@ -1,0 +1,30 @@
+# W-23465460 — Migrate ARD fs helpers to FsService
+
+Replace `@salesforce/salesforcedx-utils-vscode` fs helpers in `salesforcedx-vscode-apex-replay-debugger` with `api.services.FsService` (Effect-based, web-compatible).
+
+## Sites
+
+| File                                            | Was                                          | Becomes                                 |
+| ----------------------------------------------- | -------------------------------------------- | --------------------------------------- |
+| `src/adapter/debugConfigurationProvider.ts`     | `readFile` x2 (await, in async class method)  | `FsService.readFile` via `getRuntime()` |
+| `src/activation/getDialogStartingPath.ts`       | `Effect.promise(() => fileOrFolderExists())`  | `FsService.fileOrFolderExists`          |
+| `src/commands/anonApexDebug.ts`                 | `createDirectory` + `writeFile`, `readFile`   | `FsService.safeWriteFile`, `readFile`   |
+
+## Changes
+
+1. **getDialogStartingPath.ts** — already an `Effect.fn` with `api` in scope; swap both `Effect.promise(() => fileOrFolderExists(p))` for `yield* api.services.FsService.fileOrFolderExists(p)`. Accessor never fails (internal `catchAll` → `false`), so error channel is unchanged. Keep `projectPaths`.
+2. **anonApexDebug.ts** — convert `saveLogFile`/`launchReplayDebugger` from `async` to `Effect.fn` (call sites already inside `executeAnonApexDebug`). `createDirectory(dirname) + writeFile` collapses to `safeWriteFile` (it creates the parent dir). `Effect.promise(() => readFile(...))` → `yield* api.services.FsService.readFile(...)`. `executeCommand` via `Effect.promise` per repo precedent.
+3. **debugConfigurationProvider.ts** — `asyncDebugConfig` stays promise-based; add an `Effect.fn` reader run through the existing `getRuntime()`. Keep the surrounding try/catch so the user-facing `Failed to read (selected) log file` messages are unchanged.
+
+`FsServiceError` becomes a typed failure instead of a rejected promise inside `Effect.promise`; both surface through the same outer `.catch` / `try`, so user-visible behavior is unchanged.
+
+## Tests
+
+- `test/jest/activation/getDialogStartingPath.test.ts` mocks `vscode.workspace.fs.stat` and provides `WorkspaceService`; add `FsService` (real class + `FsService.Default`) to the mocked api so the accessor resolves. `FsService.fileOrFolderExists` calls the same mocked `stat`, so assertions hold.
+- `test/jest/commands/anonApexDebug.test.ts` covers only the pure date helpers — untouched.
+
+## Verification
+
+1. compile, lint, effect LS, jest, bundle, knip (stop hook)
+2. `effect-advocate` on the diff
+3. draft PR with `- W-23465460` title suffix + `@W-23465460@` body marker

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/activation/getDialogStartingPath.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/activation/getDialogStartingPath.ts
@@ -6,7 +6,7 @@
  */
 
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
-import { projectPaths, fileOrFolderExists } from '@salesforce/salesforcedx-utils-vscode';
+import { projectPaths } from '@salesforce/salesforcedx-utils-vscode';
 import * as Effect from 'effect/Effect';
 import * as vscode from 'vscode';
 import { URI } from 'vscode-uri';
@@ -21,14 +21,14 @@ export const getDialogStartingPath = Effect.fn('ApexReplayDebugger.getDialogStar
   // If the user has already selected a document through getLogFileName then
   // use that path if it still exists.
   const pathToLastOpenedLogFolder = getLastOpenedLogFolder(extContext);
-  if (pathToLastOpenedLogFolder && (yield* Effect.promise(() => fileOrFolderExists(pathToLastOpenedLogFolder)))) {
+  if (pathToLastOpenedLogFolder && (yield* api.services.FsService.fileOrFolderExists(pathToLastOpenedLogFolder))) {
     return getUriFor(pathToLastOpenedLogFolder);
   }
   // If lastOpenedLogFolder isn't defined or doesn't exist then use the
   // same directory that the SFDX download logs command would download to
   // if it exists.
   const pathToWorkspaceLogsFolder = projectPaths.debugLogsFolder();
-  if (yield* Effect.promise(() => fileOrFolderExists(pathToWorkspaceLogsFolder))) {
+  if (yield* api.services.FsService.fileOrFolderExists(pathToWorkspaceLogsFolder)) {
     return getUriFor(pathToWorkspaceLogsFolder);
   }
   // If all else fails, fallback to the .sfdx directory in the workspace

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
@@ -83,7 +83,9 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
         delete config.logFile;
       } catch (error) {
         console.error('Failed to read log file:', error);
-        throw new Error(`Failed to read log file: ${error}`);
+        // errorToString keeps the single-line message; interpolating the runPromise rejection would
+        // paste Effect's multi-line pretty-printed cause (with stack) into the modal dialog.
+        throw new Error(`Failed to read log file: ${errorToString(error)}`);
       }
     } else if (config.logFile === '${command:AskForLogFileName}') {
       // User needs to select a file
@@ -100,7 +102,7 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
         }
       } catch (error) {
         console.error('Failed to read selected log file:', error);
-        throw new Error(`Failed to read selected log file: ${error}`);
+        throw new Error(`Failed to read selected log file: ${errorToString(error)}`);
       }
     }
 

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
@@ -5,8 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import type { HeapDumpResult } from '@salesforce/salesforcedx-apex-replay-debugger';
-import { errorToString, readFile } from '@salesforce/salesforcedx-utils-vscode';
+import { errorToString } from '@salesforce/salesforcedx-utils-vscode';
 import * as Effect from 'effect/Effect';
 import { isString } from 'effect/Predicate';
 import type { ApexVSCodeApi } from 'salesforcedx-vscode-apex';
@@ -75,7 +76,7 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
     if (config.logFile && config.logFile !== '${command:AskForLogFileName}') {
       // Direct file path provided
       try {
-        config.logFileContents = await readFile(config.logFile);
+        config.logFileContents = await getRuntime().runPromise(readLogFile(config.logFile));
         config.logFilePath = config.logFile;
         config.logFileName = getBasename(config.logFile);
         // Remove logFile since we're now using logFileContents
@@ -89,7 +90,7 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
       try {
         const logFilePath = await vscode.commands.executeCommand('extension.replay-debugger.getLogFileName');
         if (logFilePath && isString(logFilePath)) {
-          config.logFileContents = await readFile(logFilePath);
+          config.logFileContents = await getRuntime().runPromise(readLogFile(logFilePath));
           config.logFilePath = logFilePath;
           config.logFileName = getBasename(logFilePath);
           // Remove logFile since we're now using logFileContents
@@ -133,6 +134,15 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
     }
   }
 }
+
+/**
+ * Reads a log file through FsService so desktop and web (virtual fs) both work.
+ * Fails with FsServiceError; the promise-based callers keep their own error handling.
+ */
+const readLogFile = Effect.fn('ApexReplayDebugger.readLogFile')(function* (filePath: string) {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  return yield* api.services.FsService.readFile(filePath);
+});
 
 /**
  * Resolves the target-org connection and batch-fetches overlay results for every heap dump in the log.

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/anonApexDebug.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/anonApexDebug.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
-import { projectPaths, createDirectory, readFile, writeFile } from '@salesforce/salesforcedx-utils-vscode';
+import { projectPaths } from '@salesforce/salesforcedx-utils-vscode';
 import * as Effect from 'effect/Effect';
 import * as path from 'node:path';
 import { format } from 'node:util';
@@ -33,19 +33,20 @@ const getLogFilePath = (): string => {
   return path.join(outputDir, `${localDateFormatted}.log`);
 };
 
-const saveLogFile = async (logFilePath: string, logs?: string): Promise<boolean> => {
+/** safeWriteFile creates the parent directory, so no separate createDirectory call is needed. */
+const saveLogFile = Effect.fn('ApexReplayDebugger.saveLogFile')(function* (logFilePath: string, logs?: string) {
   if (!logFilePath || !logs) return false;
-  await createDirectory(path.dirname(logFilePath));
-  await writeFile(logFilePath, logs);
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  yield* api.services.FsService.safeWriteFile(logFilePath, logs);
   return true;
-};
+});
 
-const launchReplayDebugger = async (logs?: string): Promise<boolean> => {
+const launchReplayDebugger = Effect.fn('ApexReplayDebugger.launchReplayDebugger')(function* (logs?: string) {
   const logFilePath = getLogFilePath();
-  if (!logFilePath || !logs || !(await saveLogFile(logFilePath, logs))) return false;
-  await vscode.commands.executeCommand('sf.launch.replay.debugger.logfile.path', logFilePath);
+  if (!logFilePath || !logs || !(yield* saveLogFile(logFilePath, logs))) return false;
+  yield* Effect.promise(() => vscode.commands.executeCommand('sf.launch.replay.debugger.logfile.path', logFilePath));
   return true;
-};
+});
 
 type AnonApexContext =
   | { kind: 'code'; apexCode: string; selectionRange?: vscode.Range; documentUri: URI }
@@ -79,10 +80,10 @@ const executeAnonApexDebug = Effect.fn('ApexReplayDebugger.executeAnonApexDebug'
   const ctx = yield* getAnonApexContext();
   if (!ctx) return false;
 
-  const code = ctx.kind === 'code' ? ctx.apexCode : yield* Effect.promise(() => readFile(ctx.filePath));
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const code = ctx.kind === 'code' ? ctx.apexCode : yield* api.services.FsService.readFile(ctx.filePath);
   if (!code) return false;
 
-  const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const { result, logBody } = yield* api.services.ExecuteAnonymousService.executeAndRetrieveLog(code);
   yield* api.services.ExecuteAnonymousService.reportExecResult(
     result,
@@ -92,7 +93,7 @@ const executeAnonApexDebug = Effect.fn('ApexReplayDebugger.executeAnonApexDebug'
 
   if (!result.compiled || !result.success) return false;
 
-  return yield* Effect.promise(() => launchReplayDebugger(logBody ?? undefined));
+  return yield* launchReplayDebugger(logBody ?? undefined);
 });
 
 export const anonApexDebug = async (): Promise<void> => {

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/jest/activation/getDialogStartingPath.test.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/jest/activation/getDialogStartingPath.test.ts
@@ -7,6 +7,7 @@
 
 import { ExtensionProviderService, type SalesforceVSCodeServicesApi } from '@salesforce/effect-ext-utils';
 import { projectPaths } from '@salesforce/salesforcedx-utils-vscode';
+import { FsService } from 'salesforcedx-vscode-services/src/vscode/fsService';
 import { WorkspaceService } from 'salesforcedx-vscode-services/src/vscode/workspaceService';
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
@@ -18,16 +19,20 @@ import { LAST_OPENED_LOG_FOLDER_KEY } from '../../../src/debuggerConstants';
 jest.mock('vscode');
 
 /**
- * The source calls the static accessor `api.services.WorkspaceService.getWorkspaceInfo()`, which reads
- * `WorkspaceService` from context. Provide the real class through the api plus a mock service instance so
- * the accessor resolves and the effect's requirements are satisfied.
+ * The source calls the static accessors `api.services.WorkspaceService.getWorkspaceInfo()` and
+ * `api.services.FsService.fileOrFolderExists()`, which read their services from context. Provide the real
+ * classes through the api plus service instances so the accessors resolve and the effect's requirements are
+ * satisfied. FsService uses the real implementation — it calls the mocked `vscode.workspace.fs.stat`.
  */
 const provideWorkspace = (isEmpty: boolean) => {
   const info = { path: '/mock', fsPath: '/mock', isEmpty, isVirtualFs: false, cwd: '/mock' } as const;
   return Layer.mergeAll(
     Layer.succeed(ExtensionProviderService, {
-      getServicesApi: Effect.succeed({ services: { WorkspaceService } } as unknown as SalesforceVSCodeServicesApi)
+      getServicesApi: Effect.succeed({
+        services: { WorkspaceService, FsService }
+      } as unknown as SalesforceVSCodeServicesApi)
     }),
+    FsService.Default,
     Layer.succeed(
       WorkspaceService,
       new WorkspaceService({


### PR DESCRIPTION
@W-23465460@

## What

Replaces the `@salesforce/salesforcedx-utils-vscode` fs helpers in `salesforcedx-vscode-apex-replay-debugger` with the Effect-based `api.services.FsService` from `salesforcedx-vscode-services`.

| File | Was | Now |
| --- | --- | --- |
| `src/adapter/debugConfigurationProvider.ts` | `readFile` x2 | `FsService.readFile` through the existing `getRuntime()` |
| `src/activation/getDialogStartingPath.ts` | `Effect.promise(() => fileOrFolderExists())` x2 | `FsService.fileOrFolderExists` |
| `src/commands/anonApexDebug.ts` | `createDirectory` + `writeFile`, `readFile` | `FsService.safeWriteFile`, `FsService.readFile` |

## Notes

- `safeWriteFile` creates the parent directory itself, so the separate `createDirectory` call is gone (the old `writeFile` helper also created it, making that call redundant already).
- `saveLogFile` / `launchReplayDebugger` become `Effect.fn`s — their only caller is already an Effect, removing two `Effect.promise` bridges.
- `FsService` resolves paths via `toUri` (handles `memfs://` in web); the utils helpers always assumed `URI.file`.
- User-visible error messages are unchanged: `FsServiceError` surfaces through the same `try`/`catch` and `.catch` handlers that previously caught the helpers' rejections.
- `getDialogStartingPath` jest test now provides `FsService.Default`; it exercises the real implementation against the already-mocked `vscode.workspace.fs.stat`.

## Verification

- `compile`, `lint` (0 errors), `check:effect-diagnostics` (0 violations), `check:knip`, `vscode:bundle`
- `jest` for the package: 3 suites / 15 tests pass
- `effect-advocate` review: one naming finding on the changed lines, fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Supersedes #7874 (head branch renamed `ms/W-23465460-2-migrate-ard-fs-helpers-to-fsservice` → `sm/W-23465460-2-migrate-ard-fs-helpers-to-fsservice` to match the runner owner prefix; GitHub cannot move a PR head, so this PR replaces it).
