### PR TITLE
ci(workflows): merge XSD auto-update PR as svc-idee-bot

### DIFF
--- a/.github/workflows/generateXsdForMetadataTypes.yml
+++ b/.github/workflows/generateXsdForMetadataTypes.yml
@@ -109,13 +109,16 @@ jobs:
         if: steps.create-pr.outputs.pr_url != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IDEE_GH_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
           PR_URL: ${{ steps.create-pr.outputs.pr_url }}
           BRANCH: ${{ steps.create-pr.outputs.branch }}
           HAS_CONTENT_CHANGES: ${{ steps.create-pr.outputs.has_content_changes }}
         run: |
           if [ "$HAS_CONTENT_CHANGES" == "true" ]; then
             echo "Real content changes detected in metadata_types_map_scraped.json. Auto-merging PR..."
-            gh pr merge "$PR_URL" --squash --delete-branch
+            # develop requires 1 code-owner review + status checks that never run on this
+            # bot branch; svc-idee-bot is repo admin so --admin bypasses both.
+            GH_TOKEN="$IDEE_GH_TOKEN" gh pr merge "$PR_URL" --squash --admin --delete-branch
           else
             echo "Only timestamp changes detected in salesforce_metadata_api_common.xsd. Closing PR..."
             gh pr close "$PR_URL" --comment "Closing: only a timestamp change was detected in \`salesforce_metadata_api_common.xsd\` with no real metadata content updates."


### PR DESCRIPTION
## Summary
- The XSD auto-update workflow's merge step used the default `GITHUB_TOKEN`, which belongs to `github-actions[bot]` — a bot with no repo permission and no branch-protection bypass. Every run failed to merge: "Waiting on code owner review from forcedotcom/ide-experience. 5 of 5 required status checks are expected." (see run https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/30204131603/job/89799124772)
- Route the merge through `IDEE_GH_TOKEN` (svc-idee-bot, repo admin) with `--admin`, the same bypass pattern `docOnlyAutoMerge.yml` already uses.

## Test plan
- [ ] Manually dispatch "Generate XSD for Metadata Types" and confirm the resulting PR merges automatically when content changes are detected

[skip-validate-pr]