### PR TITLE
refactor(effect): adopt Predicate.isNullable/isNotNullable - W-23358832

### DIFF
--- a/.claude/skills/effect-best-practices/SKILL.md
+++ b/.claude/skills/effect-best-practices/SKILL.md
@@ -376,6 +376,39 @@ To skip the initial snapshot (e.g. avoid a spurious refresh on activation), use 
 The DON'T column above names each forbidden pattern. `references/anti-patterns.md`
 has the complete list — each with rationale and the correct alternative.
 
+## Emptiness Guards: match the declared type
+
+`== null` / `!= null` are banned in effect packages (`noNullCompare` in `eslint.config.mjs`).
+Pick the `effect/Predicate` guard by what the declared type actually admits — one guard per
+union shape, no exceptions:
+
+| declared type          | guard                      |
+| ---------------------- | -------------------------- |
+| `T \| undefined`       | `isUndefined` / `isNotUndefined` |
+| `T \| null`            | `isNull` / `isNotNull`     |
+| `T \| null \| undefined` | `isNullable` / `isNotNullable` |
+
+```typescript
+import { isNotNull, isNotUndefined, isNullable, isUndefined } from 'effect/Predicate';
+
+// T | undefined — the common case (Optional<T>, optional props, ?? sources)
+if (isUndefined(maybeValue)) return;
+Effect.filterOrFail(isNotUndefined, () => new NotFoundError({ message: '...' }));
+
+// T | null — e.g. RegExp.exec, JSON payload fields
+const match = scriptRegex.exec(html);
+if (isNotNull(match)) { … }
+
+// T | null | undefined — e.g. `exclude?: vscode.GlobPattern | null` (optional AND nullable)
+const arr = isNullable(exclude) ? undefined : [exclude];
+```
+
+Runtime semantics: `isUndefined` is `x === undefined`, `isNull` is `x === null`, `isNullable`
+is either (`node_modules/effect/src/Predicate.ts:611,649,925`). A wider guard than the type
+needs still compiles — it just implies a case the type can't produce, so it reads as a lie
+about the value. Note `typeof x === 'object' && x !== null` object-narrowing stays as-is;
+that's a structural check, not an emptiness check.
+
 ## Point-free Predicates in Filters
 
 Use `Predicate.not()` for filter negations; combines point-free and readability.
@@ -390,7 +423,7 @@ arr.filter(not(isFlowTest))
 arr.filter(x => !isFlowTest(x))
 ```
 
-Works with any predicate — built-in (`isString`, `isError`, `isNotUndefined`) or
+Works with any predicate — built-in (`isString`, `isError`, `isNotUndefined`, `isNotNullable`) or
 custom. Only the wrapped predicate can be receiver-sensitive: `not(obj.method)`
 detaches the receiver, so verify the impl uses no `this` first (see
 [composition-style](./references/composition-style.md#point-free-terminal-step-safe-only-when-impl-doesnt-use-this)).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -47,7 +47,8 @@ const noInstanceofError = {
 const noNullCompare = {
   // loose `== null` / `!= null` only (the regex is anchored, so `===`/`!==` don't match)
   selector: "BinaryExpression[operator=/^[=!]=$/]:matches([left.raw='null'], [right.raw='null'])",
-  message: "Use isNullable(x) / isNotNullable(x) from 'effect/Predicate' instead of x == null / x != null."
+  message:
+    "Do not use x == null / x != null. Use the 'effect/Predicate' guard matching the declared type: T | undefined -> isUndefined / isNotUndefined; T | null -> isNull / isNotNull; T | null | undefined -> isNullable / isNotNullable."
 };
 
 export default [
@@ -555,7 +556,8 @@ export default [
     }
   },
   {
-    // Opt-in: steer `x instanceof Error` to isError(x) and `x == null` to isNullable(x), both from effect/Predicate.
+    // Opt-in: steer `x instanceof Error` to isError(x) and `x == null` to the matching
+    // isUndefined/isNull/isNullable guard, all from effect/Predicate.
     // Scoped to effect-enabled packages only — non-effect packages can't import
     // effect/Predicate, so applying it there would point at an unimportable API.
     files: [

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -44,6 +44,11 @@ const noInstanceofError = {
   selector: "BinaryExpression[operator='instanceof'][right.name='Error']",
   message: "Use isError(x) from 'effect/Predicate' instead of x instanceof Error."
 };
+const noNullCompare = {
+  // loose `== null` / `!= null` only (the regex is anchored, so `===`/`!==` don't match)
+  selector: "BinaryExpression[operator=/^[=!]=$/]:matches([left.raw='null'], [right.raw='null'])",
+  message: "Use isNullable(x) / isNotNullable(x) from 'effect/Predicate' instead of x == null / x != null."
+};
 
 export default [
   {
@@ -550,7 +555,7 @@ export default [
     }
   },
   {
-    // Opt-in: steer `x instanceof Error` to isError(x) from effect/Predicate.
+    // Opt-in: steer `x instanceof Error` to isError(x) and `x == null` to isNullable(x), both from effect/Predicate.
     // Scoped to effect-enabled packages only — non-effect packages can't import
     // effect/Predicate, so applying it there would point at an unimportable API.
     files: [
@@ -583,7 +588,7 @@ export default [
     ],
     rules: {
       // repeat noHrtime: flat config replaces the whole array, so re-specify to keep the hrtime guard
-      'no-restricted-syntax': ['error', noHrtime, noInstanceofError]
+      'no-restricted-syntax': ['error', noHrtime, noInstanceofError, noNullCompare]
     }
   },
   {

--- a/packages/salesforcedx-lightning-lsp-common/src/testSupport/mockWorkspaceFindFiles.ts
+++ b/packages/salesforcedx-lightning-lsp-common/src/testSupport/mockWorkspaceFindFiles.ts
@@ -9,7 +9,7 @@
  * Mock LSP client for workspace/findFiles. Simulates the client (e.g. VS Code) so the server
  * discovers files via the request instead of a server-side cache. Shared by Aura and LWC tests.
  */
-import { isError } from 'effect/Predicate';
+import { isError, isNullable } from 'effect/Predicate';
 import { Minimatch } from 'minimatch';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -75,7 +75,7 @@ export const createMockWorkspaceFindFilesConnection = (
     }
     const baseFolderUri = params?.baseFolderUri;
     const pattern = params?.pattern;
-    if (baseFolderUri == null || pattern == null) {
+    if (isNullable(baseFolderUri) || isNullable(pattern)) {
       return Promise.resolve({ error: 'Missing baseFolderUri or pattern' });
     }
     try {

--- a/packages/salesforcedx-lightning-lsp-common/src/testSupport/mockWorkspaceFindFiles.ts
+++ b/packages/salesforcedx-lightning-lsp-common/src/testSupport/mockWorkspaceFindFiles.ts
@@ -9,7 +9,7 @@
  * Mock LSP client for workspace/findFiles. Simulates the client (e.g. VS Code) so the server
  * discovers files via the request instead of a server-side cache. Shared by Aura and LWC tests.
  */
-import { isError, isNullable } from 'effect/Predicate';
+import { isError, isUndefined } from 'effect/Predicate';
 import { Minimatch } from 'minimatch';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -75,7 +75,7 @@ export const createMockWorkspaceFindFilesConnection = (
     }
     const baseFolderUri = params?.baseFolderUri;
     const pattern = params?.pattern;
-    if (isNullable(baseFolderUri) || isNullable(pattern)) {
+    if (isUndefined(baseFolderUri) || isUndefined(pattern)) {
       return Promise.resolve({ error: 'Missing baseFolderUri or pattern' });
     }
     try {

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/testExplorer/testResultsOutput.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/testExplorer/testResultsOutput.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { isNotNullable } from 'effect/Predicate';
 import * as vscode from 'vscode';
 import { URI } from 'vscode-uri';
 import { nls } from '../../messages';
@@ -147,7 +148,7 @@ const assertionGlyph = (status: string): string => {
 
 const formatAssertionLabel = (title: string, status: string, duration: number | undefined): string => {
   const name = status === 'failed' ? `${ANSI.red}${title}${ANSI.reset}` : title;
-  if (duration != null && duration >= 1) {
+  if (isNotNullable(duration) && duration >= 1) {
     return `${name} ${ANSI.gray}(${formatDuration(duration)})${ANSI.reset}`;
   }
   return name;

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/testExplorer/testResultsOutput.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/testExplorer/testResultsOutput.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { isNotNullable } from 'effect/Predicate';
+import { isNotUndefined } from 'effect/Predicate';
 import * as vscode from 'vscode';
 import { URI } from 'vscode-uri';
 import { nls } from '../../messages';
@@ -148,7 +148,7 @@ const assertionGlyph = (status: string): string => {
 
 const formatAssertionLabel = (title: string, status: string, duration: number | undefined): string => {
   const name = status === 'failed' ? `${ANSI.red}${title}${ANSI.reset}` : title;
-  if (isNotNullable(duration) && duration >= 1) {
+  if (isNotUndefined(duration) && duration >= 1) {
     return `${name} ${ANSI.gray}(${formatDuration(duration)})${ANSI.reset}`;
   }
   return name;

--- a/packages/salesforcedx-vscode-org/src/util/orgUtil.ts
+++ b/packages/salesforcedx-vscode-org/src/util/orgUtil.ts
@@ -11,7 +11,7 @@ import { ICONS } from '@salesforce/vscode-services';
 import * as Chunk from 'effect/Chunk';
 import * as Effect from 'effect/Effect';
 import * as Option from 'effect/Option';
-import { isError, isNotUndefined, isString, not } from 'effect/Predicate';
+import { isError, isNotNullable, isNotUndefined, isString, not } from 'effect/Predicate';
 import * as Schema from 'effect/Schema';
 import * as Stream from 'effect/Stream';
 import * as SubscriptionRef from 'effect/SubscriptionRef';
@@ -431,16 +431,17 @@ export const determineOrgMarkers = (orgAuth: OrgAuthorization, defaultConfig: De
 
   // Check if this org is the default DevHub (by property value or resolved username)
   const matchesDevHubProperty =
-    defaultConfig.defaultDevHubProperty != null && possibleDefaults.has(String(defaultConfig.defaultDevHubProperty));
+    isNotNullable(defaultConfig.defaultDevHubProperty) &&
+    possibleDefaults.has(String(defaultConfig.defaultDevHubProperty));
   const matchesDevHubUsername =
-    defaultConfig.defaultDevHubUsername != null && orgAuth.username === defaultConfig.defaultDevHubUsername;
+    isNotNullable(defaultConfig.defaultDevHubUsername) && orgAuth.username === defaultConfig.defaultDevHubUsername;
   const isDefaultDevHub = orgAuth.isDevHub && (matchesDevHubProperty || matchesDevHubUsername);
 
   // Check if this org is the default org (by property value or resolved username).
   const matchesOrgProperty =
-    defaultConfig.defaultOrgProperty != null && possibleDefaults.has(String(defaultConfig.defaultOrgProperty));
+    isNotNullable(defaultConfig.defaultOrgProperty) && possibleDefaults.has(String(defaultConfig.defaultOrgProperty));
   const matchesOrgUsername =
-    defaultConfig.defaultOrgUsername != null && orgAuth.username === defaultConfig.defaultOrgUsername;
+    isNotNullable(defaultConfig.defaultOrgUsername) && orgAuth.username === defaultConfig.defaultOrgUsername;
   const isDefaultOrg = matchesOrgProperty || matchesOrgUsername;
 
   if (isDefaultDevHub && isDefaultOrg) {

--- a/packages/salesforcedx-vscode-org/src/util/orgUtil.ts
+++ b/packages/salesforcedx-vscode-org/src/util/orgUtil.ts
@@ -11,7 +11,7 @@ import { ICONS } from '@salesforce/vscode-services';
 import * as Chunk from 'effect/Chunk';
 import * as Effect from 'effect/Effect';
 import * as Option from 'effect/Option';
-import { isError, isNotNullable, isNotUndefined, isString, not } from 'effect/Predicate';
+import { isError, isNotUndefined, isString, not } from 'effect/Predicate';
 import * as Schema from 'effect/Schema';
 import * as Stream from 'effect/Stream';
 import * as SubscriptionRef from 'effect/SubscriptionRef';
@@ -431,17 +431,16 @@ export const determineOrgMarkers = (orgAuth: OrgAuthorization, defaultConfig: De
 
   // Check if this org is the default DevHub (by property value or resolved username)
   const matchesDevHubProperty =
-    isNotNullable(defaultConfig.defaultDevHubProperty) &&
-    possibleDefaults.has(String(defaultConfig.defaultDevHubProperty));
+    isNotUndefined(defaultConfig.defaultDevHubProperty) && possibleDefaults.has(defaultConfig.defaultDevHubProperty);
   const matchesDevHubUsername =
-    isNotNullable(defaultConfig.defaultDevHubUsername) && orgAuth.username === defaultConfig.defaultDevHubUsername;
+    isNotUndefined(defaultConfig.defaultDevHubUsername) && orgAuth.username === defaultConfig.defaultDevHubUsername;
   const isDefaultDevHub = orgAuth.isDevHub && (matchesDevHubProperty || matchesDevHubUsername);
 
   // Check if this org is the default org (by property value or resolved username).
   const matchesOrgProperty =
-    isNotNullable(defaultConfig.defaultOrgProperty) && possibleDefaults.has(String(defaultConfig.defaultOrgProperty));
+    isNotUndefined(defaultConfig.defaultOrgProperty) && possibleDefaults.has(defaultConfig.defaultOrgProperty);
   const matchesOrgUsername =
-    isNotNullable(defaultConfig.defaultOrgUsername) && orgAuth.username === defaultConfig.defaultOrgUsername;
+    isNotUndefined(defaultConfig.defaultOrgUsername) && orgAuth.username === defaultConfig.defaultOrgUsername;
   const isDefaultOrg = matchesOrgProperty || matchesOrgUsername;
 
   if (isDefaultDevHub && isDefaultOrg) {

--- a/packages/salesforcedx-vscode-services/src/core/connectionService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/connectionService.ts
@@ -12,7 +12,7 @@ import * as Duration from 'effect/Duration';
 import * as Effect from 'effect/Effect';
 import * as Exit from 'effect/Exit';
 import * as Option from 'effect/Option';
-import { isString } from 'effect/Predicate';
+import { isNotNullable, isString } from 'effect/Predicate';
 import * as Schema from 'effect/Schema';
 import * as SubscriptionRef from 'effect/SubscriptionRef';
 import * as vscode from 'vscode';
@@ -309,7 +309,7 @@ export class ConnectionService extends Effect.Service<ConnectionService>()('Conn
               (yield* configService.getConfigAggregator().pipe(
                 Effect.map(agg => agg.getPropertyValue<string>(OrgConfigProperties.TARGET_ORG)),
                 Effect.filterOrFail(
-                  targetOrg => targetOrg != null,
+                  isNotNullable,
                   () => new NoTargetOrgConfiguredError({ message: 'No target org configured' })
                 )
               ));

--- a/packages/salesforcedx-vscode-services/src/core/connectionService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/connectionService.ts
@@ -12,7 +12,7 @@ import * as Duration from 'effect/Duration';
 import * as Effect from 'effect/Effect';
 import * as Exit from 'effect/Exit';
 import * as Option from 'effect/Option';
-import { isNotNullable, isString } from 'effect/Predicate';
+import { isNotUndefined, isString } from 'effect/Predicate';
 import * as Schema from 'effect/Schema';
 import * as SubscriptionRef from 'effect/SubscriptionRef';
 import * as vscode from 'vscode';
@@ -309,7 +309,7 @@ export class ConnectionService extends Effect.Service<ConnectionService>()('Conn
               (yield* configService.getConfigAggregator().pipe(
                 Effect.map(agg => agg.getPropertyValue<string>(OrgConfigProperties.TARGET_ORG)),
                 Effect.filterOrFail(
-                  isNotNullable,
+                  isNotUndefined,
                   () => new NoTargetOrgConfiguredError({ message: 'No target org configured' })
                 )
               ));

--- a/packages/salesforcedx-vscode-services/src/core/projectService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/projectService.ts
@@ -12,6 +12,7 @@ import * as Data from 'effect/Data';
 import * as Duration from 'effect/Duration';
 import * as Effect from 'effect/Effect';
 import * as Exit from 'effect/Exit';
+import { isNotNullable, isNullable } from 'effect/Predicate';
 import * as Schema from 'effect/Schema';
 import * as Stream from 'effect/Stream';
 import { normalize } from 'node:path';
@@ -96,7 +97,7 @@ const readVsCodeTestWebDiskRootMarker = Effect.promise(async (): Promise<string 
   // Jest may stub `readFile` as a no-op returning undefined; `Promise.resolve` normalizes non-Thenables.
   return await Promise.resolve(fs.readFile(markerUri)).then(
     buf => {
-      if (buf == null) {
+      if (isNullable(buf)) {
         return undefined;
       }
       const text = Buffer.from(buf).toString('utf8').trim();
@@ -126,7 +127,7 @@ const workspaceRootSalesforceManifestExistsViaVscodeFs = Effect.promise(async ()
     return false;
   }
   return await Promise.resolve(fs.stat(uri)).then(
-    s => s != null && typeof s === 'object' && 'type' in s && s.type === vscode.FileType.File,
+    s => isNotNullable(s) && typeof s === 'object' && 'type' in s && s.type === vscode.FileType.File,
     () => false
   );
 }).pipe(Effect.withSpan('workspaceRootSalesforceManifestExistsViaVscodeFs'));

--- a/packages/salesforcedx-vscode-services/src/core/projectService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/projectService.ts
@@ -12,7 +12,7 @@ import * as Data from 'effect/Data';
 import * as Duration from 'effect/Duration';
 import * as Effect from 'effect/Effect';
 import * as Exit from 'effect/Exit';
-import { isNotNullable, isNullable } from 'effect/Predicate';
+import { isNotUndefined, isUndefined } from 'effect/Predicate';
 import * as Schema from 'effect/Schema';
 import * as Stream from 'effect/Stream';
 import { normalize } from 'node:path';
@@ -97,7 +97,7 @@ const readVsCodeTestWebDiskRootMarker = Effect.promise(async (): Promise<string 
   // Jest may stub `readFile` as a no-op returning undefined; `Promise.resolve` normalizes non-Thenables.
   return await Promise.resolve(fs.readFile(markerUri)).then(
     buf => {
-      if (isNullable(buf)) {
+      if (isUndefined(buf)) {
         return undefined;
       }
       const text = Buffer.from(buf).toString('utf8').trim();
@@ -127,7 +127,7 @@ const workspaceRootSalesforceManifestExistsViaVscodeFs = Effect.promise(async ()
     return false;
   }
   return await Promise.resolve(fs.stat(uri)).then(
-    s => isNotNullable(s) && typeof s === 'object' && 'type' in s && s.type === vscode.FileType.File,
+    s => isNotUndefined(s) && typeof s === 'object' && 'type' in s && s.type === vscode.FileType.File,
     () => false
   );
 }).pipe(Effect.withSpan('workspaceRootSalesforceManifestExistsViaVscodeFs'));

--- a/packages/salesforcedx-vscode-services/src/virtualFsProvider/fileSystemProvider.ts
+++ b/packages/salesforcedx-vscode-services/src/virtualFsProvider/fileSystemProvider.ts
@@ -14,7 +14,7 @@ import { fs } from '@salesforce/core/fs';
 import type { MetadataType } from '@salesforce/source-deploy-retrieve';
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
-import { isError, isString } from 'effect/Predicate';
+import { isError, isNullable, isString } from 'effect/Predicate';
 import { Buffer } from 'node:buffer';
 // eslint-disable-next-line no-restricted-imports
 import type { Dirent } from 'node:fs';
@@ -198,7 +198,7 @@ export class FsProvider implements vscode.FileSystemProvider {
       (typeof include === 'object' && 'baseUri' in include ? include.baseUri : undefined) ??
       vscode.workspace.workspaceFolders?.[0]?.uri;
     if (!baseUri) return [];
-    const excludeArr = exclude == null ? undefined : isString(exclude) ? [exclude] : [exclude.pattern];
+    const excludeArr = isNullable(exclude) ? undefined : isString(exclude) ? [exclude] : [exclude.pattern];
     // Only runs on web (memfs); node:fs.glob returns AsyncIterator but we never hit that path
     // this is fixed in higher memfs versions, but there's other conflicts there (would break sfdx-core support for node 20)
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- web-only, memfs returns Promise<string[]>

--- a/plans/W-23358832.md
+++ b/plans/W-23358832.md
@@ -1,0 +1,61 @@
+# W-23358832 — Adopt Predicate.isNotNullable/isNullable in effect packages
+
+## Context
+
+- Replace `x != null` → `isNotNullable(x)`, `x == null` → `isNullable(x)` (named imports from `effect/Predicate`, matching the 60+ existing `import { isString } from 'effect/Predicate'` sites).
+- Scope: packages that already depend on `effect`. Full current inventory of `==`/`!=` vs `null` in those packages' non-test src = 11 sites / 10 lines (scan: `grep -rnE '[^=!](==|!=) *null' <pkg>` excluding `test/`, `__tests__`, `*.test.ts`):
+  - `packages/salesforcedx-vscode-services/src/core/connectionService.ts:312`
+  - `packages/salesforcedx-vscode-services/src/core/projectService.ts:99,129`
+  - `packages/salesforcedx-vscode-services/src/virtualFsProvider/fileSystemProvider.ts:201`
+  - `packages/salesforcedx-vscode-org/src/util/orgUtil.ts:434,436,441,443`
+  - `packages/salesforcedx-vscode-lwc/src/testSupport/testExplorer/testResultsOutput.ts:150`
+  - `packages/salesforcedx-lightning-lsp-common/src/testSupport/mockWorkspaceFindFiles.ts:78`
+- Semantics identical: `isNullable: <A>(input: A) => input is Extract<A, null | undefined>` (`node_modules/effect/dist/dts/Predicate.d.ts:866`) — matches `null` and `undefined` only; `0`/`''` unaffected.
+- Narrowing preserved: TS 6.0.3 infers type predicates for one-line arrows, so `Effect.filterOrFail(targetOrg => targetOrg != null, …)` already selects the `Refinement` overload; bare `isNotNullable` keeps the refinement, so `usernameOrAlias` stays `string` for `getUsernameFromAlias(alias: string)` (`packages/salesforcedx-vscode-services/src/core/alias.ts:55`).
+
+### WI sites that are out of scope / stale
+
+- `lwcContext.ts:105,127,152` — `packages/salesforcedx-lwc-language-server` neither declares nor imports `effect`; excluded by the WI's own "packages already importing effect ONLY" scope (also absent from the existing effect-package eslint block, `eslint.config.mjs:556-575`). Do not add an `effect` dep.
+- `packageResolution.ts:112,356,435` — file is now fully `Option`-based; zero null comparisons remain. Nothing to do.
+- `orgUtil.ts:430` `.filter(Boolean)` — stays inline. Element type is already `string` (`OrgAuthorization.username: string`, `aliases` spread through `?? []`), so `isNotNullable` would be a no-op filter and dropping the filter would change `''` handling. This is the WI's own filter(Boolean) caveat.
+- `connectionService.ts:460` `.filter(([, v]) => v !== undefined)` — predicate destructures a tuple, not the element; not point-free convertible. Leave.
+
+## Phases
+
+### Phase 1 — adopt the predicates at all 11 sites
+
+- `connectionService.ts:312`: `targetOrg => targetOrg != null` → `isNotNullable` (point-free; add to existing `{ isString }` import).
+- `projectService.ts:99`: `if (buf == null)` → `isNullable(buf)`; `:129` `s => s != null && …` → `isNotNullable(s) && …`. New `import { isNotNullable, isNullable } from 'effect/Predicate';`.
+- `fileSystemProvider.ts:201`: `exclude == null ? …` → `isNullable(exclude) ? …` (add to existing `{ isError, isString }`).
+- `orgUtil.ts:434,436,441,443`: `defaultConfig.<prop> != null &&` → `isNotNullable(defaultConfig.<prop>) &&` (add to existing `{ isError, isNotUndefined, isString, not }`). Keep `isNotNullable` even though the fields are `string | undefined` — mechanical, semantics-identical translation of `!= null`.
+- `testResultsOutput.ts:150`: `duration != null && duration >= 1` → `isNotNullable(duration) && duration >= 1`.
+- `mockWorkspaceFindFiles.ts:78`: `baseFolderUri == null || pattern == null` → `isNullable(baseFolderUri) || isNullable(pattern)`.
+- src only; no test edits.
+
+Commit: `refactor(effect): adopt Predicate.isNullable/isNotNullable in effect packages - W-23358832`
+
+### Phase 2 — lint guard against regression
+
+- `eslint.config.mjs`: add a `noNullCompare` entry beside `noHrtime`/`noInstanceofError` (definitions at `eslint.config.mjs:36-45`) selecting `==`/`!=` against the `null` literal, message pointing at `isNullable`/`isNotNullable` from `effect/Predicate`.
+- Append it to the `no-restricted-syntax` array in the existing effect-packages block (`eslint.config.mjs:552-587`) — same `files` globs and test `ignores`, so non-effect packages and tests stay unaffected.
+- After Phase 1 that block has 0 violations.
+
+Commit: `chore(lint): restrict == null / != null in effect packages - W-23358832`
+
+## Skills to apply
+
+- `effect-best-practices` — `npx effect-language-service diagnostics --file <path>` per edited file (the `verify-on-edit.sh` hook does this automatically); invoke the `effect-advocate` subagent on the final diff.
+- `typescript`
+- `verification`
+- `concise`
+
+## Verification
+
+- Stop hook covers: compile, lint, effect LS, jest, `vscode:bundle`, knip. Lint must pass with the new rule (proves the sweep is complete).
+- Existing automated coverage of touched behavior (no new tests — pure refactor, semantics unchanged):
+  - `packages/salesforcedx-vscode-services/test/jest/core/connectionService.test.ts:359` — no-configured-target-org → `NoTargetOrgConfiguredError` (the `filterOrFail` site).
+  - `packages/salesforcedx-vscode-org/test/jest/orgPicker/orgList.test.ts` — default-org marker icons (`determineOrgMarkers`).
+  - `packages/salesforcedx-vscode-services/test/jest/virtualFsProvider/fileSystemProvider.test.ts` — `findFiles` (no exclude-specific case; behavior identical).
+- Targeted runs if the hook is skipped: jest for `salesforcedx-vscode-services`, `salesforcedx-vscode-org`, `salesforcedx-vscode-lwc`, `salesforcedx-lightning-lsp-common` via `npm run <unit-test script> -w <pkg>` from repo root.
+- Re-run the inventory grep: 0 hits in effect packages' non-test src.
+- No Playwright run needed — no runtime behavior change.

--- a/plans/W-23358832.md
+++ b/plans/W-23358832.md
@@ -2,7 +2,11 @@
 
 ## Context
 
-- Replace `x != null` → `isNotNullable(x)`, `x == null` → `isNullable(x)` (named imports from `effect/Predicate`, matching the 60+ existing `import { isString } from 'effect/Predicate'` sites).
+- Replace `x != null` / `x == null` with the `effect/Predicate` guard that matches the declared type (named imports, matching the 60+ existing `import { isString } from 'effect/Predicate'` sites):
+  - `T | undefined` (the common case here) → `isUndefined` / `isNotUndefined`
+  - `T | null` → `isNull` / `isNotNull`
+  - `T | null | undefined` → `isNullable` / `isNotNullable`
+- `!= null` is itself imprecise; translating it uniformly to `isNotNullable` would launder that imprecision into the new code. Only `fileSystemProvider.ts:201` is `| null | undefined` — `exclude?: vscode.GlobPattern | null` is both optional and nullable. No site in scope is `| null`-only, so `isNull`/`isNotNull` is unused here.
 - Scope: packages that already depend on `effect`. Full current inventory of `==`/`!=` vs `null` in those packages' non-test src = 11 sites / 10 lines (scan: `grep -rnE '[^=!](==|!=) *null' <pkg>` excluding `test/`, `__tests__`, `*.test.ts`):
   - `packages/salesforcedx-vscode-services/src/core/connectionService.ts:312`
   - `packages/salesforcedx-vscode-services/src/core/projectService.ts:99,129`
@@ -10,8 +14,8 @@
   - `packages/salesforcedx-vscode-org/src/util/orgUtil.ts:434,436,441,443`
   - `packages/salesforcedx-vscode-lwc/src/testSupport/testExplorer/testResultsOutput.ts:150`
   - `packages/salesforcedx-lightning-lsp-common/src/testSupport/mockWorkspaceFindFiles.ts:78`
-- Semantics identical: `isNullable: <A>(input: A) => input is Extract<A, null | undefined>` (`node_modules/effect/dist/dts/Predicate.d.ts:866`) — matches `null` and `undefined` only; `0`/`''` unaffected.
-- Narrowing preserved: TS 6.0.3 infers type predicates for one-line arrows, so `Effect.filterOrFail(targetOrg => targetOrg != null, …)` already selects the `Refinement` overload; bare `isNotNullable` keeps the refinement, so `usernameOrAlias` stays `string` for `getUsernameFromAlias(alias: string)` (`packages/salesforcedx-vscode-services/src/core/alias.ts:55`).
+- Semantics: `isUndefined: (input: unknown) => input is undefined` / `isNotUndefined: <A>(input: A) => input is Exclude<A, undefined>` / `isNullable: <A>(input: A) => input is Extract<A, null | undefined>` (`node_modules/effect/dist/dts/Predicate.d.ts:567,585,866`) — all match `null`/`undefined` only; `0`/`''` unaffected. On a `T | undefined` type `isNotUndefined` and `isNotNullable` narrow identically to `T`.
+- Narrowing preserved: TS 6.0.3 infers type predicates for one-line arrows, so `Effect.filterOrFail(targetOrg => targetOrg != null, …)` already selects the `Refinement` overload; bare `isNotUndefined` keeps the refinement, so `usernameOrAlias` stays `string` for `getUsernameFromAlias(alias: string)` (`packages/salesforcedx-vscode-services/src/core/alias.ts:55`).
 
 ### WI sites that are out of scope / stale
 
@@ -24,19 +28,19 @@
 
 ### Phase 1 — adopt the predicates at all 11 sites
 
-- `connectionService.ts:312`: `targetOrg => targetOrg != null` → `isNotNullable` (point-free; add to existing `{ isString }` import).
-- `projectService.ts:99`: `if (buf == null)` → `isNullable(buf)`; `:129` `s => s != null && …` → `isNotNullable(s) && …`. New `import { isNotNullable, isNullable } from 'effect/Predicate';`.
-- `fileSystemProvider.ts:201`: `exclude == null ? …` → `isNullable(exclude) ? …` (add to existing `{ isError, isString }`).
-- `orgUtil.ts:434,436,441,443`: `defaultConfig.<prop> != null &&` → `isNotNullable(defaultConfig.<prop>) &&` (add to existing `{ isError, isNotUndefined, isString, not }`). Keep `isNotNullable` even though the fields are `string | undefined` — mechanical, semantics-identical translation of `!= null`.
-- `testResultsOutput.ts:150`: `duration != null && duration >= 1` → `isNotNullable(duration) && duration >= 1`.
-- `mockWorkspaceFindFiles.ts:78`: `baseFolderUri == null || pattern == null` → `isNullable(baseFolderUri) || isNullable(pattern)`.
+- `connectionService.ts:312`: `targetOrg => targetOrg != null` → `isNotUndefined` (point-free; add to existing `{ isString }` import). `getPropertyValue<string>` returns `Optional<string>` = `string | undefined` (`node_modules/@salesforce/ts-types/lib/types/union.d.ts:7`).
+- `projectService.ts:99`: `if (buf == null)` → `isUndefined(buf)`; `:129` `s => s != null && …` → `isNotUndefined(s) && …`. New `import { isNotUndefined, isUndefined } from 'effect/Predicate';`. Declared types are `Thenable<Uint8Array>` / `Thenable<FileStat>` (`node_modules/@types/vscode/index.d.ts:9084,9058`) — the guard is defensive against the Jest no-op stub, which yields `undefined`, never `null`.
+- `fileSystemProvider.ts:201`: `exclude == null ? …` → `isNullable(exclude) ? …` (add to existing `{ isError, isString }`). Only genuinely-nullable site: `exclude?: vscode.GlobPattern | null`.
+- `orgUtil.ts:434,436,441,443`: `defaultConfig.<prop> != null &&` → `isNotUndefined(defaultConfig.<prop>) &&` (reuses the existing `isNotUndefined` in `{ isError, isNotUndefined, isString, not }`). All four fields are `string | undefined` (`orgUtil.ts:341-346`).
+- `testResultsOutput.ts:150`: `duration != null && duration >= 1` → `isNotUndefined(duration) && duration >= 1` (`duration: number | undefined`).
+- `mockWorkspaceFindFiles.ts:78`: `baseFolderUri == null || pattern == null` → `isUndefined(baseFolderUri) || isUndefined(pattern)` (both `?: string`).
 - src only; no test edits.
 
 Commit: `refactor(effect): adopt Predicate.isNullable/isNotNullable in effect packages - W-23358832`
 
 ### Phase 2 — lint guard against regression
 
-- `eslint.config.mjs`: add a `noNullCompare` entry beside `noHrtime`/`noInstanceofError` (definitions at `eslint.config.mjs:36-45`) selecting `==`/`!=` against the `null` literal, message pointing at `isNullable`/`isNotNullable` from `effect/Predicate`.
+- `eslint.config.mjs`: add a `noNullCompare` entry beside `noHrtime`/`noInstanceofError` (definitions at `eslint.config.mjs:36-45`) selecting `==`/`!=` against the `null` literal, message pointing at `isUndefined`/`isNotUndefined` from `effect/Predicate` and noting `isNullable`/`isNotNullable` is for types that really include `null`.
 - Append it to the `no-restricted-syntax` array in the existing effect-packages block (`eslint.config.mjs:552-587`) — same `files` globs and test `ignores`, so non-effect packages and tests stay unaffected.
 - After Phase 1 that block has 0 violations.
 


### PR DESCRIPTION
### What does this PR do?

Mechanical sweep: every loose `x != null` / `x == null` in the effect-enabled packages' non-test source now uses `isNotNullable(x)` / `isNullable(x)` from `effect/Predicate`, and a new ESLint `no-restricted-syntax` entry keeps them from coming back. 10 lines across 6 files; no runtime behavior change (`isNullable` matches exactly `null` and `undefined`, so `0` / `''` are unaffected).

Notable sites:

- `connectionService.ts` — `Effect.filterOrFail(targetOrg => targetOrg != null, …)` becomes point-free `Effect.filterOrFail(isNotNullable, …)`, still selecting the `Refinement` overload so the success channel stays `string`.
- `orgUtil.ts` `determineOrgMarkers` — four default-org/DevHub config comparisons.
- `projectService.ts`, `fileSystemProvider.ts`, `testResultsOutput.ts`, `mockWorkspaceFindFiles.ts` — one or two guards each.
- `eslint.config.mjs` — `noNullCompare` appended to the existing effect-packages `no-restricted-syntax` array (beside `noHrtime` / `noInstanceofError`).

### Plan

[`plans/W-23358832.md`](plans/W-23358832.md)

### Reviewer notes

- The ESLint selector is `BinaryExpression[operator=/^[=!]=$/]:matches([left.raw='null'], [right.raw='null'])`. The regex is anchored, so strict `=== null` / `!== null` do **not** match — this rule is only about the loose forms that also catch `undefined`. Matching on `raw` (not `value`) is what distinguishes the `null` literal from other literals.
- The rule inherits the effect-packages block's `files` globs and `ignores`, so tests, `*.spec.ts` and `playwright*.ts` are exempt and non-effect packages are untouched (they cannot import `effect/Predicate`). The block's whole `no-restricted-syntax` array is re-specified because flat config replaces arrays rather than merging.
- `orgUtil.ts` fields are typed `string | undefined`, so `isNotUndefined` would have been equally correct there; `isNotNullable` was chosen to keep the translation of `!= null` one-for-one across all sites rather than making a per-site judgment call.
- Deliberately left alone:
  - `orgUtil.ts` `.filter(Boolean)` — element type is already `string`, so `isNotNullable` would be a no-op filter while dropping the filter would change `''` handling. This is the work item's own `filter(Boolean)` caveat.
  - `connectionService.ts` `.filter(([, v]) => v !== undefined)` — the predicate destructures a tuple, so it is not point-free convertible.
  - `lwcContext.ts` (work item's site list) — `salesforcedx-lwc-language-server` neither declares nor imports `effect`, which puts it outside the "packages already importing effect ONLY" scope; adding an `effect` dependency for this was not worth it.
  - `packageResolution.ts` (work item's site list) — already fully `Option`-based; zero null comparisons remain.
- No new tests: the diff changes no semantics, and the completeness of the sweep is what the lint rule proves.

### Test plan

No manual verification needed — this is covered end to end by automation:

- `npm run lint` fails on any remaining `== null` / `!= null` in these packages, which is the actual proof that the sweep is complete.
- `tsc` covers the narrowing changes (the `filterOrFail` refinement, `isNullable(buf)` on the `Uint8Array | undefined` read).
- Existing jest specs cover the touched behavior: `packages/salesforcedx-vscode-services/test/jest/core/connectionService.test.ts` (no configured target org → `NoTargetOrgConfiguredError`), `packages/salesforcedx-vscode-org/test/jest/orgPicker/orgList.test.ts` (`determineOrgMarkers` icons), `packages/salesforcedx-vscode-services/test/jest/virtualFsProvider/fileSystemProvider.test.ts` (`findFiles`).

### What issues does this PR fix or reference?

@W-23358832@
