### PR TITLE
ci(workflows): cache Playwright browser binaries in E2E workflows - W-23485440

### DIFF
--- a/.github/actions/cache-playwright-browsers/action.yml
+++ b/.github/actions/cache-playwright-browsers/action.yml
@@ -3,11 +3,23 @@ description: Restore the Playwright browser registry, install chromium (browsers
 runs:
   using: composite
   steps:
+    - name: Resolve registry dir and cache key
+      id: vars
+      shell: bash
+      run: |
+        case "$RUNNER_OS" in
+          Windows) dir='~\AppData\Local\ms-playwright' ;;
+          macOS) dir='~/Library/Caches/ms-playwright' ;;
+          *) dir='~/.cache/ms-playwright' ;;
+        esac
+        version=$(node -p "require('playwright-core/package.json').version")
+        echo "path=$dir" >> "$GITHUB_OUTPUT"
+        echo "key=playwright-$RUNNER_OS-$RUNNER_ARCH-$version" >> "$GITHUB_OUTPUT"
     - uses: actions/cache/restore@v4
       id: restore
       with:
-        path: ${{ runner.os == 'Windows' && '~\AppData\Local\ms-playwright' || runner.os == 'macOS' && '~/Library/Caches/ms-playwright' || '~/.cache/ms-playwright' }}
-        key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package-lock.json') }}
+        path: ${{ steps.vars.outputs.path }}
+        key: ${{ steps.vars.outputs.key }}
     - name: Install OS deps (cache hit)
       if: steps.restore.outputs.cache-hit == 'true'
       uses: salesforcecli/github-workflows/.github/actions/retry@main
@@ -25,5 +37,5 @@ runs:
     - uses: actions/cache/save@v4
       if: steps.restore.outputs.cache-hit != 'true'
       with:
-        path: ${{ runner.os == 'Windows' && '~\AppData\Local\ms-playwright' || runner.os == 'macOS' && '~/Library/Caches/ms-playwright' || '~/.cache/ms-playwright' }}
-        key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package-lock.json') }}
+        path: ${{ steps.vars.outputs.path }}
+        key: ${{ steps.vars.outputs.key }}

--- a/.github/actions/cache-playwright-browsers/action.yml
+++ b/.github/actions/cache-playwright-browsers/action.yml
@@ -1,0 +1,29 @@
+name: Cache Playwright Browsers
+description: Restore the Playwright browser registry, install chromium (browsers + OS deps on miss, OS deps only on hit), save after install
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache/restore@v4
+      id: restore
+      with:
+        path: ${{ runner.os == 'Windows' && '~\AppData\Local\ms-playwright' || runner.os == 'macOS' && '~/Library/Caches/ms-playwright' || '~/.cache/ms-playwright' }}
+        key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package-lock.json') }}
+    - name: Install OS deps (cache hit)
+      if: steps.restore.outputs.cache-hit == 'true'
+      uses: salesforcecli/github-workflows/.github/actions/retry@main
+      with:
+        max_attempts: 3
+        command: npx playwright install-deps chromium
+        retry_wait_seconds: 60
+    - name: Install browsers and OS deps (cache miss)
+      if: steps.restore.outputs.cache-hit != 'true'
+      uses: salesforcecli/github-workflows/.github/actions/retry@main
+      with:
+        max_attempts: 3
+        command: npx playwright install chromium --with-deps
+        retry_wait_seconds: 60
+    - uses: actions/cache/save@v4
+      if: steps.restore.outputs.cache-hit != 'true'
+      with:
+        path: ${{ runner.os == 'Windows' && '~\AppData\Local\ms-playwright' || runner.os == 'macOS' && '~/Library/Caches/ms-playwright' || '~/.cache/ms-playwright' }}
+        key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/apexDebuggerE2E.yml
+++ b/.github/workflows/apexDebuggerE2E.yml
@@ -126,11 +126,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Run Apex Debugger E2E tests (parallel)
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/apexLogE2E.yml
+++ b/.github/workflows/apexLogE2E.yml
@@ -102,11 +102,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Generate minimal project
         if: steps.try-run.outcome == 'failure'
@@ -232,11 +228,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Generate minimal project
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/apexLspE2E.yml
+++ b/.github/workflows/apexLspE2E.yml
@@ -93,11 +93,7 @@ jobs:
       # Only install Playwright on cache miss. apex LSP specs do not exercise an org, so no CLI/scratch-org setup is required.
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Run Apex LSP E2E tests (parallel)
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/apexOasE2E.yml
+++ b/.github/workflows/apexOasE2E.yml
@@ -116,11 +116,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Generate minimal project
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/apexReplayDebuggerE2E.yml
+++ b/.github/workflows/apexReplayDebuggerE2E.yml
@@ -113,11 +113,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Generate minimal project
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/apexTestingE2E.yml
+++ b/.github/workflows/apexTestingE2E.yml
@@ -102,11 +102,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Generate non-tracking project
         if: steps.try-run.outcome == 'failure'
@@ -255,11 +251,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Generate non-tracking project
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/auraE2E.yml
+++ b/.github/workflows/auraE2E.yml
@@ -117,11 +117,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Generate minimal project
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -116,11 +116,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Generate minimal project
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/lwcPlaywrightE2E.yml
+++ b/.github/workflows/lwcPlaywrightE2E.yml
@@ -84,11 +84,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Run LWC Playwright web tests (parallel)
         if: steps.try-run.outcome == 'failure'
@@ -183,11 +179,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Run LWC Playwright desktop tests (parallel)
         if: steps.try-run.outcome == 'failure'
@@ -280,11 +272,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Run LWC run-tests desktop (parallel)
         if: steps.try-run.outcome == 'failure'
@@ -377,11 +365,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Run LWC debug-tests desktop (parallel)
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/metadataE2E.yml
+++ b/.github/workflows/metadataE2E.yml
@@ -115,11 +115,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: create scratch org and set up dreamhouse
         if: steps.try-run.outcome == 'failure'
@@ -278,11 +274,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Clone dreamhouse
         if: steps.try-run.outcome == 'failure'
@@ -433,11 +425,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Generate minimal project
         if: steps.try-run.outcome == 'failure'
@@ -566,11 +554,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Generate minimal project
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/orgBrowserE2E.yml
+++ b/.github/workflows/orgBrowserE2E.yml
@@ -116,11 +116,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: create scratch org and set up dreamhouse
         if: steps.try-run.outcome == 'failure'
@@ -245,11 +241,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Clone dreamhouse
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/orgE2E.yml
+++ b/.github/workflows/orgE2E.yml
@@ -149,11 +149,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Run Org E2E tests (parallel)
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/playwrightVscodeExtE2E.yml
+++ b/.github/workflows/playwrightVscodeExtE2E.yml
@@ -82,11 +82,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Run Playwright web tests (parallel)
         if: steps.try-run.outcome == 'failure'
@@ -186,11 +182,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Run Playwright desktop tests (parallel)
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/servicesE2E.yml
+++ b/.github/workflows/servicesE2E.yml
@@ -92,11 +92,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Generate minimal project
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/soqlE2E.yml
+++ b/.github/workflows/soqlE2E.yml
@@ -102,11 +102,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Generate minimal project
         if: steps.try-run.outcome == 'failure'
@@ -242,11 +238,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Generate minimal project
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/visualforceE2E.yml
+++ b/.github/workflows/visualforceE2E.yml
@@ -86,11 +86,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Run Visualforce Playwright web tests (parallel)
         if: steps.try-run.outcome == 'failure'
@@ -192,11 +188,7 @@ jobs:
 
       - name: Install Playwright browsers and OS deps
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        uses: ./.github/actions/cache-playwright-browsers
 
       - name: Run Visualforce E2E tests (parallel)
         if: steps.try-run.outcome == 'failure'

--- a/plans/W-23485440.md
+++ b/plans/W-23485440.md
@@ -12,7 +12,7 @@
   So `path` and `key` must both branch on `runner.os`. WI text names only the Linux path — insufficient for 2/3 of the matrix.
 - `install-deps` is safe everywhere (same source, `Registry.installDeps`): win32 -> `install_media_pack.ps1`, linux -> apt, darwin -> returns undefined (no-op). Same work `--with-deps` does today, so hit-path parity holds on all 3 OSes.
 - apt libs from `--with-deps` are NOT inside the cache dir -> `install-deps` still required on every cache hit (Linux). That is the WI's design and it is correct.
-- `playwright@^1.60.0` is a root devDependency; single root `package-lock.json` -> `hashFiles('package-lock.json')` is a valid (coarse) proxy for the pinned playwright version.
+- `playwright@^1.60.0` is a root devDependency. Key on the **resolved** playwright version (`node -p "require('playwright-core/package.json').version"`, read after `npmInstallWithRetries`, which precedes the action at all 28 sites) rather than `hashFiles('package-lock.json')`: the lockfile hash mints a fresh ~750 MB triple (3 OSes x ~249 MB) per lockfile revision (9 distinct hashes live today, plus dependabot churn) into a repo cache already at 10.7 GB against a 10 GB quota, evicting the small wireit entries the try-run gate depends on. Version key = one entry per OS, changing only on a real Playwright bump.
 - Validator: `npm run check:actions` (`scripts/validateActions.ts`) globs `.github/workflows/*.{yml,yaml}` **and** `.github/actions/*/action.{yml,yaml}` — new action is covered. `.github/` is prettier-ignored (`.prettierignore:7`), so no format step.
 - No ADR touches CI caching; ADR 0014 (Playwright over WDIO) unaffected. No doc/skill describes the install step, so nothing to update.
 
@@ -28,10 +28,11 @@
 ### Phase 1 — Composite action
 
 - New `.github/actions/cache-playwright-browsers/action.yml`, `using: composite`, no inputs. Steps:
-  1. `actions/cache/restore@v4` (`id: restore`) — `path` and `key` both `runner.os`-branched (3 dirs per Context); key shape `playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package-lock.json') }}`.
-  2. hit (`steps.restore.outputs.cache-hit == 'true'`) -> `npx playwright install-deps chromium` via `salesforcecli/github-workflows/.github/actions/retry@main`, same `max_attempts: 3` / `retry_wait_seconds: 60` as today.
-  3. miss (`!= 'true'`) -> `npx playwright install chromium --with-deps`, same retry wrapper.
-  4. `actions/cache/save@v4` when `cache-hit != 'true'`, same `path`/`key` as restore. Runs after the install, so the dir is populated.
+  1. Leading `shell: bash` step (`id: vars`) resolves the per-OS registry dir (3 dirs per Context) and the key `playwright-$RUNNER_OS-$RUNNER_ARCH-<resolved playwright version>` **once**, into `$GITHUB_OUTPUT` — restore and save both read `steps.vars.outputs.*`, so path/key cannot drift between them.
+  2. `actions/cache/restore@v4` (`id: restore`) with `path`/`key` from `steps.vars`.
+  3. hit (`steps.restore.outputs.cache-hit == 'true'`) -> `npx playwright install-deps chromium` via `salesforcecli/github-workflows/.github/actions/retry@main`, same `max_attempts: 3` / `retry_wait_seconds: 60` as today.
+  4. miss (`!= 'true'`) -> `npx playwright install chromium --with-deps`, same retry wrapper.
+  5. `actions/cache/save@v4` when `cache-hit != 'true'`, same `steps.vars` `path`/`key` as restore. Runs after the install, so the dir is populated.
 - `name` + `description` follow the sibling actions' one-line style.
 - Nested composite (retry action inside this composite) is supported by actions/runner; reusing the retry action keeps flaky-download behavior identical.
 - Commit msg: `ci(actions): add cache-playwright-browsers composite action - W-23485440`
@@ -58,8 +59,8 @@ No automated test on the branch covers GHA behavior; `validateActions` is schema
 
 - **Static (local):** `npm run check:actions` passes — validates the new `action.yml` plus all 16 edited workflows.
 - **Static (local):** `grep -r "playwright install chromium --with-deps" .github/workflows` -> 0 hits; `grep -rc "cache-playwright-browsers" .github/workflows` -> 28 across 16 files; every one retains `if: steps.try-run.outcome == 'failure'`.
-- **CI miss path (first push):** on each OS (ubuntu from `servicesE2E`, macos + windows from `apexDebuggerE2E`) confirm restore logs a miss, `install ... --with-deps` runs, `install-deps` step skipped, save logs `Cache saved with key: playwright-<OS>-<ARCH>-<hash>`, tests still pass.
-- **CI hit path (second run, lockfile unchanged):** restore logs exact hit, `install-deps` runs, `install --with-deps` skipped, save skipped, tests still pass on all 3 OSes. Record install-step wall clock before vs after per OS — the WI's payoff number.
+- **CI miss path (first push):** on each OS (ubuntu from `servicesE2E`, macos + windows from `apexDebuggerE2E`) confirm restore logs a miss, `install ... --with-deps` runs, `install-deps` step skipped, save logs `Cache saved with key: playwright-<OS>-<ARCH>-<playwright version>`, tests still pass.
+- **CI hit path (second run, playwright version unchanged):** restore logs exact hit, `install-deps` runs, `install --with-deps` skipped, save skipped, tests still pass on all 3 OSes. Record install-step wall clock before vs after per OS — the WI's payoff number. Linux specifically: `install-deps` (apt) is unavoidable on the hit path, so the only Linux saving is cache-restore vs CDN download of the same ~249 MB; if the measurement shows no Linux win, gate the cache steps to `runner.os != 'Linux'` in a follow-up.
 - **Concurrency noise:** first push fires many jobs racing the same 3 keys; `actions/cache/save` emits "Unable to reserve cache ..." for losers. Confirm warnings only, no job fails on them.
 - **Cache footprint:** record the 3 saved entry sizes from the repo Actions cache list. Flag in the PR if the added total meaningfully pressures the 10GB repo budget shared with the wireit / `.vscode-test` / npm caches, since evicting wireit entries would undo the try-run fast path.
 

--- a/plans/W-23485440.md
+++ b/plans/W-23485440.md
@@ -1,0 +1,66 @@
+# W-23485440 [ai-auto] Cache Playwright browser binaries in E2E workflows
+
+## Context
+
+- 28 steps across 16 E2E workflows run `npx playwright install chromium --with-deps` (wrapped in `salesforcecli/github-workflows/.github/actions/retry@main`, `max_attempts: 3`, `retry_wait_seconds: 60`). Every wireit-cache-miss run re-downloads chromium + headless shell + ffmpeg.
+- Each site is gated `if: steps.try-run.outcome == 'failure'` — the "try tests first, only pay for setup on wireit miss" pattern. Gate must survive.
+- Fix: composite action mirroring `.github/actions/cache-vscode-web` / `cache-vscode-desktop`. Unlike those, the cache dir is empty until the install runs, so the action must **own** the install (restore -> install -> save), not just wrap the cache.
+- Runner spread (verified): ubuntu-latest, macos-latest, windows-latest. Registry dir is per-OS (`node_modules/playwright-core/lib/coreBundle.js`, `defaultRegistryDirectory`):
+  - linux `$XDG_CACHE_HOME` else `~/.cache` -> `~/.cache/ms-playwright`
+  - darwin `~/Library/Caches/ms-playwright`
+  - win32 `$LOCALAPPDATA` else `~/AppData/Local` -> `~\AppData\Local\ms-playwright`
+  So `path` and `key` must both branch on `runner.os`. WI text names only the Linux path — insufficient for 2/3 of the matrix.
+- `install-deps` is safe everywhere (same source, `Registry.installDeps`): win32 -> `install_media_pack.ps1`, linux -> apt, darwin -> returns undefined (no-op). Same work `--with-deps` does today, so hit-path parity holds on all 3 OSes.
+- apt libs from `--with-deps` are NOT inside the cache dir -> `install-deps` still required on every cache hit (Linux). That is the WI's design and it is correct.
+- `playwright@^1.60.0` is a root devDependency; single root `package-lock.json` -> `hashFiles('package-lock.json')` is a valid (coarse) proxy for the pinned playwright version.
+- Validator: `npm run check:actions` (`scripts/validateActions.ts`) globs `.github/workflows/*.{yml,yaml}` **and** `.github/actions/*/action.{yml,yaml}` — new action is covered. `.github/` is prettier-ignored (`.prettierignore:7`), so no format step.
+- No ADR touches CI caching; ADR 0014 (Playwright over WDIO) unaffected. No doc/skill describes the install step, so nothing to update.
+
+### Decisions (single approach, no fallbacks)
+
+- **No `restore-keys`.** A partial hit restores a stale chromium revision the pinned playwright cannot use; `cache-hit` would be `false`, so the miss branch downloads anyway — zero benefit, and stale revisions bloat the saved archive.
+- **No `PLAYWRIGHT_BROWSERS_PATH`.** Would let one literal path serve all OSes, but the env var must also be live for the `try-run` step preceding the action; splitting install location from run location across steps is a desync hazard. Use the per-OS default dir.
+- Key includes `runner.os` + `runner.arch` (macos-latest is ARM64, others X64) — binaries are platform-specific and the cache keyspace is repo-global.
+- Zero action inputs — every call site installs `chromium`.
+
+## Phases
+
+### Phase 1 — Composite action
+
+- New `.github/actions/cache-playwright-browsers/action.yml`, `using: composite`, no inputs. Steps:
+  1. `actions/cache/restore@v4` (`id: restore`) — `path` and `key` both `runner.os`-branched (3 dirs per Context); key shape `playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package-lock.json') }}`.
+  2. hit (`steps.restore.outputs.cache-hit == 'true'`) -> `npx playwright install-deps chromium` via `salesforcecli/github-workflows/.github/actions/retry@main`, same `max_attempts: 3` / `retry_wait_seconds: 60` as today.
+  3. miss (`!= 'true'`) -> `npx playwright install chromium --with-deps`, same retry wrapper.
+  4. `actions/cache/save@v4` when `cache-hit != 'true'`, same `path`/`key` as restore. Runs after the install, so the dir is populated.
+- `name` + `description` follow the sibling actions' one-line style.
+- Nested composite (retry action inside this composite) is supported by actions/runner; reusing the retry action keeps flaky-download behavior identical.
+- Commit msg: `ci(actions): add cache-playwright-browsers composite action - W-23485440`
+
+### Phase 2 — Swap all 28 call sites
+
+- In each of `.github/workflows/{apexDebugger,apexLog,apexLsp,apexOas,apexReplayDebugger,apexTesting,aura,core,lwcPlaywright,metadata,orgBrowser,org,playwrightVscodeExt,services,soql,visualforce}E2E.yml`: replace the retry-wrapped install step body with `uses: ./.github/actions/cache-playwright-browsers`, dropping the `with:` block.
+- Keep each step's `name: Install Playwright browsers and OS deps` and its `if: steps.try-run.outcome == 'failure'` verbatim; keep step position (sites differ — some sit after `cache-vscode-*`, some between CLI/org setup steps).
+- Every affected job already has `actions/checkout` first, required for a local `./` action.
+- Commit msg: `ci(workflows): cache Playwright browsers in E2E workflows - W-23485440`
+
+## Skills to apply
+
+- verification — CI-only change; prove hit and miss paths from real runs, not by reasoning
+- playwright-e2e — E2E workflow structure, try-run gate semantics, `--last-failed` retry steps
+- wireit — `check:actions` task inputs; why the try-run gate exists
+- concise — plan + PR body
+- pr-draft — PR body: before/after install-step duration per OS, cache sizes, hit/miss log excerpts
+- work-item-sequencing — none pending; standalone
+
+## Verification
+
+No automated test on the branch covers GHA behavior; `validateActions` is schema-only. Runtime proof comes from CI runs.
+
+- **Static (local):** `npm run check:actions` passes — validates the new `action.yml` plus all 16 edited workflows.
+- **Static (local):** `grep -r "playwright install chromium --with-deps" .github/workflows` -> 0 hits; `grep -rc "cache-playwright-browsers" .github/workflows` -> 28 across 16 files; every one retains `if: steps.try-run.outcome == 'failure'`.
+- **CI miss path (first push):** on each OS (ubuntu from `servicesE2E`, macos + windows from `apexDebuggerE2E`) confirm restore logs a miss, `install ... --with-deps` runs, `install-deps` step skipped, save logs `Cache saved with key: playwright-<OS>-<ARCH>-<hash>`, tests still pass.
+- **CI hit path (second run, lockfile unchanged):** restore logs exact hit, `install-deps` runs, `install --with-deps` skipped, save skipped, tests still pass on all 3 OSes. Record install-step wall clock before vs after per OS — the WI's payoff number.
+- **Concurrency noise:** first push fires many jobs racing the same 3 keys; `actions/cache/save` emits "Unable to reserve cache ..." for losers. Confirm warnings only, no job fails on them.
+- **Cache footprint:** record the 3 saved entry sizes from the repo Actions cache list. Flag in the PR if the added total meaningfully pressures the 10GB repo budget shared with the wireit / `.vscode-test` / npm caches, since evicting wireit entries would undo the try-run fast path.
+
+_No instruction-shaped content in the work item; nothing to report._


### PR DESCRIPTION
### What does this PR do?

E2E jobs stop re-downloading Chromium from the Playwright CDN on every run. The 28 retry-wrapped `npx playwright install chromium --with-deps` steps across 16 E2E workflows now call one composite action, `./.github/actions/cache-playwright-browsers`, which restores the per-OS Playwright registry from the Actions cache, installs only what the cache did not provide (OS deps on a hit, browsers + OS deps on a miss), and saves after a miss.

Behavior details:

- Cache key is `playwright-$RUNNER_OS-$RUNNER_ARCH-<resolved playwright-core version>`, so one entry per OS/arch that rotates only on a real Playwright bump — not per lockfile revision.
- Registry dir branches on `runner.os` (`~/.cache/ms-playwright`, `~/Library/Caches/ms-playwright`, `~\AppData\Local\ms-playwright`); path and key are resolved once in a leading step and read from `steps.vars.outputs.*` by both restore and save, so they cannot drift.
- The existing `if: steps.try-run.outcome == 'failure'` gate is preserved verbatim at all 28 call sites, and the `retry@main` wrapper (`max_attempts: 3`, `retry_wait_seconds: 60`) still wraps both install variants, so flaky-download handling is unchanged.

### What issues does this PR fix or reference?

@W-23485440@

Plan: [`plans/W-23485440.md`](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23485440-cache-playwright-browser-binaries-in-e2e/plans/W-23485440.md)

### Reviewer notes

- **No `restore-keys`.** A partial hit restores a Chromium revision the pinned Playwright cannot use, `cache-hit` would be `false`, and the miss branch downloads anyway — no benefit, plus stale revisions bloat the saved archive.
- **No `PLAYWRIGHT_BROWSERS_PATH`.** One literal path for all OSes would be simpler, but the env var would also have to be live for the `try-run` step that precedes the action; splitting install location from run location across steps is a desync hazard. Per-OS default dirs instead.
- **Key on resolved version, not `hashFiles('package-lock.json')`.** The lockfile hash would mint a fresh ~750 MB triple (3 OSes x ~249 MB) per lockfile revision into a repo cache already near its 10 GB quota, evicting the small wireit entries the `try-run` fast path depends on.
- **Linux hit path still pays apt.** `--with-deps` apt libs live outside the registry dir, so `install-deps` runs on every Linux hit; the Linux saving is cache-restore vs CDN download of the same ~249 MB, nothing more. A verified review finding proposed gating the cache steps to `runner.os != 'Linux'`; not applied because it contradicts the plan's explicit decision to cache on all three matrix OSes. The finding's own alternative was taken instead: measure per-OS install-step wall clock on the hit path and drop Linux caching in a follow-up if it does not win. See the test plan.
- **Nested composite** — the `retry@main` action is used inside this composite, which actions/runner supports; it keeps retry semantics identical to what the workflows had inline.
- **Zero inputs** — every call site installs `chromium`, so the action takes no inputs.

### Test plan

`npm run check:actions` is already enforced by `validatePR.yml` and covers the new `action.yml` plus the 16 edited workflows. Nothing on this branch can assert GHA runtime behavior — the validator is schema-only — so the hit/miss proof has to come from real workflow runs. The push to this branch triggers the E2E workflows (`push: branches-ignore: [main, develop]`).

1. **Miss path (this first push).** In `Services E2E` (ubuntu) and `Apex Debugger E2E` (macos + windows), inside the `Install Playwright browsers and OS deps` step: restore reports a miss, `Install browsers and OS deps (cache miss)` runs, `Install OS deps (cache hit)` is skipped, save logs `Cache saved with key: playwright-<OS>-<ARCH>-<version>`, and the E2E tests still pass.
2. **Hit path (re-run after the first push completes, Playwright version unchanged).** Restore reports an exact key hit, `Install OS deps (cache hit)` runs, the miss step and save are skipped, tests still pass on all three OSes.
3. **Record install-step wall clock, before vs after, per OS** — that is the payoff number. Compare Linux hit-path duration against the pre-change CDN download; if Linux shows no win, gate the cache steps to `runner.os != 'Linux'` in a follow-up.
4. **Concurrency noise.** The first push races many jobs against the same 3 keys, so `actions/cache/save` will emit `Unable to reserve cache ...` for the losers. Confirm those are warnings only and no job fails on them.
5. **Cache footprint.** Read the 3 new entry sizes from the repo Actions cache list and confirm the added total does not pressure the 10 GB repo budget shared with the wireit / `.vscode-test` / npm caches — evicting wireit entries would undo the `try-run` fast path.

### References

- Work item: W-23485440 — Cache Playwright browser binaries in E2E workflows
- Plan: `plans/W-23485440.md` (committed on this branch)
- No ADR affected; ADR 0014 (Playwright over WDIO) is unrelated to CI caching.
