### PR TITLE
ci: set retention-days on Playwright artifact uploads - W-23485442

### DIFF
--- a/.claude/skills/playwright-e2e/references/analyze-e2e.md
+++ b/.claude/skills/playwright-e2e/references/analyze-e2e.md
@@ -27,7 +27,7 @@ Organized by branch and run ID.
 - `gh run download <run-id> -D <directory>` - Download artifacts
 - `gh run view <run-id> --web` - Open in browser
 
-E2E artifacts expire 14 days after the run (`retention-days: 14` in the workflows) — nothing to download from older runs.
+E2E artifacts expire 14 days after the run (see `retention-days` in the workflows) — nothing to download from older runs.
 
 ## Artifact location (mandatory)
 

--- a/.claude/skills/playwright-e2e/references/analyze-e2e.md
+++ b/.claude/skills/playwright-e2e/references/analyze-e2e.md
@@ -27,6 +27,8 @@ Organized by branch and run ID.
 - `gh run download <run-id> -D <directory>` - Download artifacts
 - `gh run view <run-id> --web` - Open in browser
 
+E2E artifacts expire 14 days after the run (`retention-days: 14` in the workflows) — nothing to download from older runs.
+
 ## Artifact location (mandatory)
 
 **Always use `.e2e-artifacts/` as the root** — gitignored. Never use a variant name (e.g. `.e2e-artifacts-win/`).

--- a/.claude/workflows/flakiness-review.js
+++ b/.claude/workflows/flakiness-review.js
@@ -32,6 +32,8 @@ export const meta = {
 
 log('Flakiness review started — expect 30–60 minutes. Use /workflows to watch progress.')
 
+// CI artifacts expire 14 days after a run (retention-days in the E2E workflows); a
+//   longer lookback has no artifact evidence for the older part — unavailable, not "not flaky"
 const DAYS = (args && args.days) || 7
 const EDE_EPIC_ID = 'a3QEE000002AZ8D2AW'
 const REPO = 'forcedotcom/salesforcedx-vscode'
@@ -334,6 +336,8 @@ For each run with conclusion=="failure" OR hadRetries==true, download the playwr
 # carry a non-numeric suffix (e.g. <run-id>-extra) — keep the numeric run id.
 gh run download <run-id> --repo ${REPO} -D ${ARTIFACTS_ROOT}/develop/<run-id> --pattern "playwright-report*" 2>/dev/null || true
 \`\`\`
+
+Artifacts expire 14 days after the run (retention-days in the E2E workflows) and the download failure is swallowed, so runs older than that yield no report: mark them "artifacts expired — evidence unavailable", never "no flakiness".
 
 Each \`playwright-report*/index.html\` embeds a base64-encoded zip whose \`report.json\` holds per-test results: \`files[].tests[]{title, path, outcome, results[]}\`. \`outcome\` is one of expected|flaky|unexpected|skipped (\`flaky\` = passed only after retries = retry-masked). Decode + aggregate with bash + jq (no python):
 

--- a/.github/workflows/apexDebuggerE2E.yml
+++ b/.github/workflows/apexDebuggerE2E.yml
@@ -166,6 +166,7 @@ jobs:
           name: playwright-report-apex-debugger-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-apex-debugger/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright test results
         if: always()
@@ -174,6 +175,7 @@ jobs:
           name: playwright-test-results-apex-debugger-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-apex-debugger/test-results
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Cleanup scratch org
         if: always() && steps.try-run.outcome == 'failure'

--- a/.github/workflows/apexLogE2E.yml
+++ b/.github/workflows/apexLogE2E.yml
@@ -143,6 +143,7 @@ jobs:
           name: playwright-report-apex-log-web
           path: packages/salesforcedx-vscode-apex-log/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright Test Results
         if: always()
@@ -151,6 +152,7 @@ jobs:
           name: playwright-test-results-apex-log-web
           path: packages/salesforcedx-vscode-apex-log/test-results
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Cleanup scratch org
         if: always() && steps.try-run.outcome == 'failure'
@@ -274,6 +276,7 @@ jobs:
           name: playwright-report-apex-log-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-apex-log/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright Test Results
         if: always()
@@ -282,6 +285,7 @@ jobs:
           name: playwright-test-results-apex-log-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-apex-log/test-results
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Cleanup scratch org
         if: always() && steps.try-run.outcome == 'failure'

--- a/.github/workflows/apexLspE2E.yml
+++ b/.github/workflows/apexLspE2E.yml
@@ -130,6 +130,7 @@ jobs:
           name: playwright-report-apex-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-apex/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright Test Results
         if: always()
@@ -138,4 +139,5 @@ jobs:
           name: playwright-test-results-apex-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-apex/test-results
           if-no-files-found: ignore
+          retention-days: 14
 

--- a/.github/workflows/apexOasE2E.yml
+++ b/.github/workflows/apexOasE2E.yml
@@ -178,6 +178,7 @@ jobs:
           name: playwright-report-apex-oas-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-apex-oas/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright Test Results
         if: always()
@@ -186,6 +187,7 @@ jobs:
           name: playwright-test-results-apex-oas-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-apex-oas/test-results
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Cleanup scratch org
         if: always() && steps.try-run.outcome == 'failure'

--- a/.github/workflows/apexReplayDebuggerE2E.yml
+++ b/.github/workflows/apexReplayDebuggerE2E.yml
@@ -167,6 +167,7 @@ jobs:
           name: playwright-report-apex-replay-debugger-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-apex-replay-debugger/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright Test Results
         if: always()
@@ -175,6 +176,7 @@ jobs:
           name: playwright-test-results-apex-replay-debugger-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-apex-replay-debugger/test-results
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Cleanup scratch org
         if: always() && steps.try-run.outcome == 'failure'

--- a/.github/workflows/apexTestingE2E.yml
+++ b/.github/workflows/apexTestingE2E.yml
@@ -185,6 +185,7 @@ jobs:
           name: playwright-report-apex-testing-web
           path: packages/salesforcedx-vscode-apex-testing/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright Test Results
         if: always()
@@ -193,6 +194,7 @@ jobs:
           name: playwright-test-results-apex-testing-web
           path: packages/salesforcedx-vscode-apex-testing/test-results
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Cleanup scratch org
         if: always() && steps.try-run.outcome == 'failure'
@@ -360,6 +362,7 @@ jobs:
           name: playwright-report-apex-testing-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-apex-testing/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright Test Results
         if: always()
@@ -368,6 +371,7 @@ jobs:
           name: playwright-test-results-apex-testing-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-apex-testing/test-results
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Cleanup scratch org
         if: always() && steps.try-run.outcome == 'failure'

--- a/.github/workflows/auraE2E.yml
+++ b/.github/workflows/auraE2E.yml
@@ -172,6 +172,7 @@ jobs:
           name: playwright-report-${{ matrix.package }}-desktop-${{ matrix.os }}
           path: packages/${{ matrix.package }}/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright Test Results
         if: always()
@@ -180,6 +181,7 @@ jobs:
           name: playwright-test-results-${{ matrix.package }}-desktop-${{ matrix.os }}
           path: packages/${{ matrix.package }}/test-results
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Cleanup scratch orgs
         if: always() && steps.try-run.outcome == 'failure'

--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -169,6 +169,7 @@ jobs:
           name: playwright-report-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-core/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright Test Results
         if: always()
@@ -177,6 +178,7 @@ jobs:
           name: playwright-test-results-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-core/test-results
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Cleanup scratch orgs
         if: always() && steps.try-run.outcome == 'failure'

--- a/.github/workflows/lwcPlaywrightE2E.yml
+++ b/.github/workflows/lwcPlaywrightE2E.yml
@@ -121,6 +121,7 @@ jobs:
           name: playwright-report-lwc-web
           path: packages/salesforcedx-vscode-lwc/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright test results
         if: always()
@@ -129,6 +130,7 @@ jobs:
           name: playwright-test-results-lwc-web
           path: packages/salesforcedx-vscode-lwc/test-results
           if-no-files-found: ignore
+          retention-days: 14
 
   # ─── Desktop: LSP / headless specs ───────────────────────────────────────────────────────
 
@@ -218,6 +220,7 @@ jobs:
           name: playwright-report-lwc-desktop-lsp-${{ matrix.os }}
           path: packages/salesforcedx-vscode-lwc/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright test results
         if: always()
@@ -226,6 +229,7 @@ jobs:
           name: playwright-test-results-lwc-desktop-lsp-${{ matrix.os }}
           path: packages/salesforcedx-vscode-lwc/test-results
           if-no-files-found: ignore
+          retention-days: 14
 
   # ─── Desktop: Run Tests ───────────────────────────────────────────────────────────────────
 
@@ -315,6 +319,7 @@ jobs:
           name: playwright-report-lwc-desktop-run-tests-${{ matrix.os }}
           path: packages/salesforcedx-vscode-lwc/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright test results
         if: always()
@@ -323,6 +328,7 @@ jobs:
           name: playwright-test-results-lwc-desktop-run-tests-${{ matrix.os }}
           path: packages/salesforcedx-vscode-lwc/test-results
           if-no-files-found: ignore
+          retention-days: 14
 
   # ─── Desktop: Debug Tests ─────────────────────────────────────────────────────────────────
 
@@ -412,6 +418,7 @@ jobs:
           name: playwright-report-lwc-desktop-debug-tests-${{ matrix.os }}
           path: packages/salesforcedx-vscode-lwc/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright test results
         if: always()
@@ -420,3 +427,4 @@ jobs:
           name: playwright-test-results-lwc-desktop-debug-tests-${{ matrix.os }}
           path: packages/salesforcedx-vscode-lwc/test-results
           if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/metadataE2E.yml
+++ b/.github/workflows/metadataE2E.yml
@@ -182,6 +182,7 @@ jobs:
           name: playwright-report-web
           path: packages/salesforcedx-vscode-metadata/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright Test Results
         if: always()
@@ -190,6 +191,7 @@ jobs:
           name: playwright-test-results-web
           path: packages/salesforcedx-vscode-metadata/test-results
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Cleanup scratch orgs
         if: always() && steps.try-run.outcome == 'failure'
@@ -367,6 +369,7 @@ jobs:
           name: playwright-report-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-metadata/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright Test Results
         if: always()
@@ -375,6 +378,7 @@ jobs:
           name: playwright-test-results-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-metadata/test-results
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Cleanup scratch orgs
         if: always() && steps.try-run.outcome == 'failure'
@@ -483,6 +487,7 @@ jobs:
           name: playwright-report-conflicts-web
           path: packages/salesforcedx-vscode-metadata/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright Test Results
         if: always()
@@ -491,6 +496,7 @@ jobs:
           name: playwright-test-results-conflicts-web
           path: packages/salesforcedx-vscode-metadata/test-results
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Cleanup scratch orgs
         if: always() && steps.try-run.outcome == 'failure'
@@ -632,6 +638,7 @@ jobs:
           name: playwright-report-conflicts-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-metadata/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright Test Results
         if: always()
@@ -640,6 +647,7 @@ jobs:
           name: playwright-test-results-conflicts-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-metadata/test-results
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Cleanup scratch orgs
         if: always() && steps.try-run.outcome == 'failure'

--- a/.github/workflows/orgBrowserE2E.yml
+++ b/.github/workflows/orgBrowserE2E.yml
@@ -166,6 +166,7 @@ jobs:
           name: playwright-report
           path: packages/salesforcedx-vscode-org-browser/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Cleanup scratch org
         if: always() && steps.try-run.outcome == 'failure'
@@ -315,6 +316,7 @@ jobs:
           name: playwright-report-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-org-browser/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright Test Results
         if: always()
@@ -323,6 +325,7 @@ jobs:
           name: playwright-test-results-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-org-browser/test-results
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Cleanup scratch org
         if: always() && steps.try-run.outcome == 'failure'

--- a/.github/workflows/orgE2E.yml
+++ b/.github/workflows/orgE2E.yml
@@ -189,6 +189,7 @@ jobs:
           name: playwright-report-org-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-org/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright test results
         if: always()
@@ -197,6 +198,7 @@ jobs:
           name: playwright-test-results-org-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-org/test-results
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Cleanup scratch org
         if: always() && steps.try-run.outcome == 'failure'

--- a/.github/workflows/playwrightVscodeExtE2E.yml
+++ b/.github/workflows/playwrightVscodeExtE2E.yml
@@ -120,6 +120,7 @@ jobs:
           name: playwright-report-web
           path: packages/playwright-vscode-ext/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright test results
         if: always()
@@ -128,6 +129,7 @@ jobs:
           name: playwright-test-results-web
           path: packages/playwright-vscode-ext/test-results
           if-no-files-found: ignore
+          retention-days: 14
 
   e2e-desktop:
     runs-on: ${{ matrix.os }}
@@ -224,6 +226,7 @@ jobs:
           name: playwright-report-desktop-${{ matrix.os }}
           path: packages/playwright-vscode-ext/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright test results
         if: always()
@@ -232,3 +235,4 @@ jobs:
           name: playwright-test-results-desktop-${{ matrix.os }}
           path: packages/playwright-vscode-ext/test-results
           if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/servicesE2E.yml
+++ b/.github/workflows/servicesE2E.yml
@@ -152,6 +152,7 @@ jobs:
           name: playwright-report-web
           path: packages/salesforcedx-vscode-services/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright Test Results
         if: always()
@@ -160,6 +161,7 @@ jobs:
           name: playwright-test-results-web
           path: packages/salesforcedx-vscode-services/test-results
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Cleanup scratch org
         if: always() && steps.try-run.outcome == 'failure'

--- a/.github/workflows/soqlE2E.yml
+++ b/.github/workflows/soqlE2E.yml
@@ -154,6 +154,7 @@ jobs:
           name: playwright-report-soql-web
           path: packages/salesforcedx-vscode-soql/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright Test Results
         if: always()
@@ -162,6 +163,7 @@ jobs:
           name: playwright-test-results-soql-web
           path: packages/salesforcedx-vscode-soql/test-results
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Cleanup scratch org
         if: always() && steps.try-run.outcome == 'failure'
@@ -296,6 +298,7 @@ jobs:
           name: playwright-report-soql-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-soql/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright Test Results
         if: always()
@@ -304,6 +307,7 @@ jobs:
           name: playwright-test-results-soql-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-soql/test-results
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Cleanup scratch org
         if: always() && steps.try-run.outcome == 'failure'

--- a/.github/workflows/visualforceE2E.yml
+++ b/.github/workflows/visualforceE2E.yml
@@ -124,6 +124,7 @@ jobs:
           name: playwright-report-visualforce-web
           path: packages/salesforcedx-vscode-visualforce/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright test results
         if: always()
@@ -132,6 +133,7 @@ jobs:
           name: playwright-test-results-visualforce-web
           path: packages/salesforcedx-vscode-visualforce/test-results
           if-no-files-found: ignore
+          retention-days: 14
 
   # ─── Desktop ──────────────────────────────────────────────────────────────────────────────
 
@@ -232,6 +234,7 @@ jobs:
           name: playwright-report-visualforce-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-visualforce/playwright-report
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Playwright Test Results
         if: always()
@@ -240,3 +243,4 @@ jobs:
           name: playwright-test-results-visualforce-desktop-${{ matrix.os }}
           path: packages/salesforcedx-vscode-visualforce/test-results
           if-no-files-found: ignore
+          retention-days: 14

--- a/plans/W-23485442.md
+++ b/plans/W-23485442.md
@@ -1,0 +1,44 @@
+# W-23485442 — Set retention-days on Playwright artifact uploads
+
+## Context
+
+- 55 `actions/upload-artifact@v4` steps in 16 `.github/workflows/*E2E.yml` files upload `playwright-report*` / `playwright-test-results*`; none set `retention-days` → silently inherits repo/org default.
+- Deliberate value wanted: 14 days. Enough to triage a failed run; caps storage from a large matrix (desktop x 3 OS x many packages).
+- No release-branch-only E2E workflow exists → no 30-day tier. Every E2E workflow triggers on `push: branches-ignore: [main, develop]` + `workflow_call` (from `e2e.yml`, `playwrightE2EFullSuite.yml`) + `workflow_dispatch`; same retention for all callers.
+- Out of scope (not Playwright artifacts; feed release/publish + cross-workflow `download-artifact` consumers): `buildAll.yml`, `publishBetaRelease.yml`, `generateXsdForMetadataTypes.yml`.
+- `.github/**` is prettier-ignored (`.prettierignore`) → no formatter constraint; no actionlint in repo.
+- No ADR governs CI artifacts; ADR 0014 (playwright-over-legacy-e2e) unaffected.
+
+## Phases
+
+### Phase 1 — `retention-days: 14` on every E2E Playwright upload
+
+- Files (upload-step counts): `apexDebuggerE2E.yml` 2, `apexLogE2E.yml` 4, `apexLspE2E.yml` 2, `apexOasE2E.yml` 2, `apexReplayDebuggerE2E.yml` 2, `apexTestingE2E.yml` 4, `auraE2E.yml` 2, `coreE2E.yml` 2, `lwcPlaywrightE2E.yml` 8, `metadataE2E.yml` 8, `orgBrowserE2E.yml` 3, `orgE2E.yml` 2, `playwrightVscodeExtE2E.yml` 4, `servicesE2E.yml` 2, `soqlE2E.yml` 4, `visualforceE2E.yml` 4 = 55.
+- All 55 blocks end with `if-no-files-found: ignore`; add `retention-days: 14` as next line, same 10-space indent under `with:`.
+- Additions only — no reordering, no other key edits, no non-E2E workflow touched.
+
+commitMessage: `ci: retain playwright E2E artifacts 14 days`
+
+### Phase 2 — note expiry in E2E-analysis reference
+
+- `.claude/skills/playwright-e2e/references/analyze-e2e.md`: near the `gh run download` command list, state artifacts expire 14 days after the run, so older runs can't be downloaded.
+- Follow `.claude/skills/concise/SKILL.md` style (fragment, not prose paragraph).
+
+commitMessage: `docs(playwright-e2e): note 14-day artifact expiry`
+
+## Skills to apply
+
+- `.claude/skills/playwright-e2e/SKILL.md` — E2E workflow/artifact conventions.
+- `.claude/skills/concise/SKILL.md` — doc edit style.
+- `.claude/skills/verification/SKILL.md` — prove done before handoff.
+
+## Verification
+
+No automated tests cover workflow YAML (none exist on branch); checks are mechanical:
+
+1. `grep -c 'retention-days: 14' .github/workflows/*E2E.yml` → per-file counts match Phase 1 table; total 55.
+2. Every upload block covered: scan the 4 lines after each `uses: actions/upload-artifact@v4` in `*E2E.yml`, assert `retention-days: 14` in all 55.
+3. No stray edits: `git diff --stat` = 16 workflow files + 1 md; workflow diff insertions only (`git diff -U0 -- .github/workflows | grep '^-[^-]'` empty); `git diff --name-only` excludes `buildAll.yml`, `publishBetaRelease.yml`, `generateXsdForMetadataTypes.yml`.
+4. YAML still parses: `node -e` loop over the 16 files using `js-yaml` (`node_modules/js-yaml` 4.1.1) `load()`, no throw.
+5. Value legal: integer ≤ 90 (GitHub max).
+6. Push branch; one E2E run completes and its artifacts report ~14-day expiry: `gh api repos/:owner/:repo/actions/runs/<id>/artifacts --jq '.artifacts[]|{name,created_at,expires_at}'`.


### PR DESCRIPTION
### What does this PR do?

Playwright E2E artifacts now expire in 14 days instead of 90. `retention-days: 14` added to all 55 `actions/upload-artifact@v4` steps that upload `playwright-report*` / `playwright-test-results*`, across the 16 `.github/workflows/*E2E.yml` files.

Nothing set `retention-days` before, so every upload inherited the repo default. That default is currently 90 days — an artifact created `2026-07-27T19:15:50Z` in this repo reports `expires_at: 2026-10-25` (`gh api repos/forcedotcom/salesforcedx-vscode/actions/artifacts`). 14 days is long enough to triage a failed run and caps storage from a matrix that is desktop x 3 OS x many packages.

Two docs follow the new expiry so E2E-analysis agents don't misread an expired artifact as a clean run:

- `.claude/skills/playwright-e2e/references/analyze-e2e.md` — note next to the `gh run download` commands.
- `.claude/workflows/flakiness-review.js` — the 7-day default lookback is now explained by the retention window, and the prompt tells the reviewer to mark runs older than 14 days "artifacts expired — evidence unavailable", never "no flakiness" (that script swallows the `gh run download` failure with `|| true`).

Additions only: 105 inserted lines, 0 deleted lines under `.github/workflows` (`git diff -U0 -- .github/workflows | grep '^-[^-]'` is empty). No step reordered, no other key edited.

### Plan

[`plans/W-23485442.md`](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23485442-set-retention-days-on-playwright-artifac/plans/W-23485442.md)

### Reviewer notes

- **One uniform literal, not a per-repo knob.** A review pass flagged that `retention-days: ${{ vars.PLAYWRIGHT_ARTIFACT_RETENTION_DAYS || 14 }}` would make the value overridable. Deliberately not done: the plan commits to a uniform literal and its verification step greps per-file counts of `retention-days: 14`, which the expression form would break, and this repo does not use `vars.` for plain numeric CI knobs (`timeout-minutes` is a literal everywhere; existing `vars.` usage is version pins). If a per-repo override is ever wanted it is one sed across these 16 files.
- **Same value for every caller.** Each E2E workflow is reachable three ways — `push: branches-ignore: [main, develop]`, `workflow_call` (from `e2e.yml` and `playwrightE2EFullSuite.yml`), and `workflow_dispatch` — and there is no release-branch-only E2E workflow, so there is no case that wants a longer tier. `retention-days` is per-step anyway, not per-trigger, so a differentiated policy would need an input plumbed through both callers.
- **Non-Playwright uploads untouched on purpose.** `buildAll.yml`, `publishBetaRelease.yml`, and `generateXsdForMetadataTypes.yml` feed release/publish jobs and cross-workflow `download-artifact` consumers; shortening those risks breaking a pipeline and is out of scope. `git diff --name-only` confirms none is in the diff.
- **14 is legal.** `actions/upload-artifact`'s README: "Artifacts are retained for 90 days by default. You can specify a shorter retention period using the `retention-days` input… The retention period must be between 1 and 90 inclusive."
- **No formatter or linter covers these files.** `.github/` is listed in `.prettierignore:7`, and the repo has no actionlint (grep for `actionlint` across `.github` and `package.json` returns nothing), so indentation of the added lines was matched by hand to the sibling keys (10 spaces under `with:`).

### Test plan

No automated tests cover workflow YAML — the repo has no GitHub Actions config test harness, and none was added for a one-key addition. Mechanical checks, all run on this branch:

- Count: `grep -c 'retention-days: 14' .github/workflows/*E2E.yml` → 2/4/2/2/2/4/2/2/8/8/3/2/4/2/4/4, total **55**, matching the plan's per-file table. `grep -h 'retention-days'` shows exactly one distinct line (`retention-days: 14`, 55x) — no typo'd variant.
- Coverage: every `uses: actions/upload-artifact@v4` in `*E2E.yml` is accounted for — per-file `upload-artifact` count equals per-file `retention-days: 14` count in all 16 files, so no upload step was missed and none was double-added.
- Parse: `js-yaml` (4.1.1, from `node_modules`) `load()` over all 16 modified workflows — 16 parsed, 0 failures.
- End-to-end confirmation (**not yet observable**, needs a completed run): the push kicked off the E2E workflows on this branch. Once one finishes, `gh api repos/:owner/:repo/actions/runs/<id>/artifacts --jq '.artifacts[]|{name,created_at,expires_at}'` should show `expires_at` ~14 days after `created_at` rather than ~90. At time of writing those runs are still in progress, so this is the one item a reviewer should re-check rather than take on faith.

### What issues does this PR fix or reference?

@W-23485442@

### References

- Work item W-23485442
- `actions/upload-artifact` `retention-days` input: https://github.com/actions/upload-artifact#retention-period
- No ADR governs CI artifact retention; ADR 0014 (playwright-over-legacy-e2e) is unaffected.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
