### PR TITLE
refactor(effect): fix + enforce missedPipeableOpportunity - W-23520538

### DIFF
--- a/.claude/skills/effect-best-practices/references/composition-style.md
+++ b/.claude/skills/effect-best-practices/references/composition-style.md
@@ -12,21 +12,28 @@ runs until a runner (`runPromise`/`runSync`/`yield*`). 3 consequences shape ever
 call site:
 
 1. **Build the whole thing as one flat `.pipe` chain**, ops top-to-bottom.
-2. **Make execution the terminal step**, not a wrapper around the expression.
+2. **Make execution the terminal step**, not a wrapper around the expression —
+   config-enforced by `missedPipeableOpportunity`.
 3. **Bail conditions and dispatch are separate** — guard clauses up top, the pipe
    handles real variance.
 4. **No single-use intermediate vars.** A value read once is a pipe step, not a
-   `const`. Plain value (not yet an Effect) → seed a standalone `pipe(value, …)`;
-   don't bury it as a nested call arg (`f(g(x))`) — that hides the step. Keep the
-   `const` only when the value is read ≥2×.
+   `const`; keep the `const` only when read ≥2×. Plain value (not yet an Effect) →
+   seed a standalone `pipe(value, …)`. The nested-call-arg half (`f(g(x))`) is
+   config-enforced by `missedPipeableOpportunity`, which fires at ≥2 pipeable
+   call-kind transformations; judgment remains for what the pipe's subject should
+   be — hoist a named `const` over inverting a reused schema combinator
+   (`Schema.optional(Schema.Array(x))` stays a call; the repo has 0
+   `X.pipe(Schema.optional)` sites).
 
 Rest is application of these to specific combinators.
 
 ## Build effect as flat pipe, run it as terminal step
 
 `pipe(value, f, g, h)` = `h(g(f(value)))`
-([docs](https://effect.website/docs/getting-started/building-pipelines/#pipe)).
-Make "run it" the last pipe entry instead of wrapping the whole expression in
+([docs](https://effect.website/docs/getting-started/building-pipelines/#pipe)) —
+so steps apply **inner-first**: unwrapping `outer(inner(x))` gives
+`x.pipe(inner, outer)`. Config-enforced by `missedPipeableOpportunity`. Make
+"run it" the last pipe entry instead of wrapping the whole expression in
 `runPromise(...)`.
 
 ```typescript
@@ -46,10 +53,11 @@ await getApexTestingRuntime().runPromise(
 );
 ```
 
-Identical behavior. First reads top-to-bottom as a pipeline ending in execution;
-second forces paren-matching across the block to find the effect. Same logic for
-any terminal combinator — `Effect.runFork`, a `provide` + run, etc.: put it last
-in the pipe.
+Identical behavior. Same for any terminal combinator — `Effect.runFork`,
+`Effect.fork`, `Effect.exit`, a `provide` + run, an outer `semaphore.withPermits`:
+put it last. Nested wrappers unwrap inner-first, so
+`a.withPermits(1)(b.withPermits(1)(X))` → `X.pipe(b.withPermits(1), a.withPermits(1))`
+— order inverts, permit nesting is preserved.
 
 ### Point-free terminal step safe ONLY when impl doesn't use `this`
 
@@ -262,8 +270,9 @@ Target only nesting that **exists to sequence steps** or **repeats verbatim**.
 
 | Situation | Do | Don't |
 | --- | --- | --- |
-| Build any multi-op effect | one flat `.pipe(...)` chain — merged steps as siblings, dropping any the merge makes dead; config-enforced by `unnecessaryPipeChain`, which fires wherever a pipe's subject is itself a pipe — method or function form, callbacks included; only a nested pipe over a *different* subject stays judgment | `x.pipe(a).pipe(b)`, `pipe(pipe(x, a), b)`; nested `f(g(h(x)))` calls |
-| Run a built effect | `effect.pipe(..., runtime.runPromise)` as last step | wrap whole expr in `runPromise(effect.pipe(...))` |
+| Build any multi-op effect | one flat `.pipe(...)` chain — merged steps as siblings, dropping any the merge makes dead; config-enforced by `unnecessaryPipeChain`, which fires wherever a pipe's subject is itself a pipe — method or function form, callbacks included; only a nested pipe over a *different* subject stays judgment | `x.pipe(a).pipe(b)`, `pipe(pipe(x, a), b)` |
+| Run a built effect / any nested `f(g(pipeable))` | `pipeable.pipe(g, f)` — inner-first, terminal step last; config-enforced by `missedPipeableOpportunity` at ≥2 pipeable transformations | wrap whole expr in `runPromise(effect.pipe(...))` |
+| Nested reused schema combinator (`Schema.optional(Schema.Array(x))`) | hoist a named `const` for the inner schema | invert to `x.pipe(Schema.Array, Schema.optional)` — 0 repo precedent |
 | Point-free terminal step | bare `Effect.runPromise` always; methods only when closure-based (e.g. `ManagedRuntime.runPromise`) | point-free any `this`-bound method |
 | Any side effect (mid-pipe or terminal) | `Effect.tap` / `tapError` / `tapBoth`, value passes through | imperative tail after `yield*` re-inspecting the result |
 | Sync side effect inside a tap | wrap in `Effect.sync(() => ...)` | — |

--- a/.claude/skills/effect-best-practices/references/diagnostics-findings.md
+++ b/.claude/skills/effect-best-practices/references/diagnostics-findings.md
@@ -2,7 +2,7 @@
 
 Repo's chosen fix per rule — the LS message and quickfix say what's wrong, this says what we do about it. Which rules gate the build is not tracked here: `config/effect-diagnostics.json` `enforcedRules` is the only list (`npm run check:effect-diagnostics` fails on any rule in it, any severity). Fix unlisted findings too — each becomes enforced by a later WI.
 
-Many rules ship `default: "off"` upstream (`@effect/language-service/schema.json`) — an `off` rule reports nothing, so a name in `enforcedRules` gates nothing until `tsconfig.common.json` `diagnosticSeverity` pins it to `error`. Pinned there today: `floatingEffect`, `globalRandom`, `globalRandomInEffect`, `globalFetchInEffect`, `globalTimersInEffect`.
+Many rules ship `default: "off"` upstream (`@effect/language-service/schema.json`) — an `off` rule reports nothing, so a name in `enforcedRules` gates nothing until `tsconfig.common.json` `diagnosticSeverity` pins it to `error`. Pinned there today: `floatingEffect`, `globalRandom`, `globalRandomInEffect`, `globalFetchInEffect`, `globalTimersInEffect`, `missedPipeableOpportunity`.
 
 | Rule | Finding | Fix |
 | --- | --- | --- |
@@ -19,3 +19,4 @@ Many rules ship `default: "off"` upstream (`@effect/language-service/schema.json
 | `globalRandom` / `globalRandomInEffect` | `Math.random()` (outside Effect / inside Effect) | `Random.next`, `Random.nextInt` |
 | `globalFetchInEffect` | global `fetch(...)` inside Effect | `@effect/platform` `HttpClient` |
 | `globalTimersInEffect` | `setTimeout`/`setInterval` inside Effect | `Effect.sleep`, `Effect.repeat`/`Effect.schedule` |
+| `missedPipeableOpportunity` | nested Effect/Schema calls `f(g(pipeable))` — fires at ≥2 pipeable call-kind transformations | `pipeable.pipe(g, f)` — steps apply inner-first, so the terminal step (`runPromise`, `fork`, outer semaphore) lands last. Inner call a reused schema combinator (`Schema.optional(Schema.Array(x))`) → hoist a named `const` instead; the repo has 0 `X.pipe(Schema.optional)` sites. Never take the quickfix blind: it reflows to 4-space, collapses long chains, and moves preceding comments into the pipe's args |

--- a/config/effect-diagnostics.json
+++ b/config/effect-diagnostics.json
@@ -18,6 +18,7 @@
     "globalRandom",
     "globalRandomInEffect",
     "globalFetchInEffect",
-    "globalTimersInEffect"
+    "globalTimersInEffect",
+    "missedPipeableOpportunity"
   ]
 }

--- a/packages/effect-ext-utils/test/jest/annotateRootSpan.test.ts
+++ b/packages/effect-ext-utils/test/jest/annotateRootSpan.test.ts
@@ -78,7 +78,7 @@ describe('annotateRootSpan', () => {
   });
 
   it('no-ops without throwing when there is no current span', async () => {
-    await expect(Effect.runPromise(annotateRootSpan('marker', 'value-c'))).resolves.toBeUndefined();
+    await expect(annotateRootSpan('marker', 'value-c').pipe(Effect.runPromise)).resolves.toBeUndefined();
   });
 
   it('no-ops when the chain dead-ends at an ExternalSpan', async () => {

--- a/packages/salesforcedx-vscode-apex-log/src/logs/logAutoCollect.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/logs/logAutoCollect.ts
@@ -124,13 +124,12 @@ export const createLogAutoCollect = Effect.fn('ApexLog.createLogAutoCollect')(fu
   const pollIntervalRef = yield* SubscriptionRef.make(Duration.seconds(pollIntervalSeconds));
 
   // watch the setting to update poll freq
-  yield* Effect.fork(
-    Stream.fromPubSub(settingsChangePubSub).pipe(
-      Stream.filter(event => event.affectsConfiguration('salesforcedx-vscode-apex-log.logPollIntervalSeconds')),
-      Stream.runForEach(() =>
-        getPollIntervalSeconds().pipe(Effect.flatMap(s => SubscriptionRef.set(pollIntervalRef, Duration.seconds(s))))
-      )
-    )
+  yield* Stream.fromPubSub(settingsChangePubSub).pipe(
+    Stream.filter(event => event.affectsConfiguration('salesforcedx-vscode-apex-log.logPollIntervalSeconds')),
+    Stream.runForEach(() =>
+      getPollIntervalSeconds().pipe(Effect.flatMap(s => SubscriptionRef.set(pollIntervalRef, Duration.seconds(s))))
+    ),
+    Effect.fork
   );
 
   // when the org changes, clear the knownIds
@@ -146,7 +145,11 @@ export const createLogAutoCollect = Effect.fn('ApexLog.createLogAutoCollect')(fu
   const dynamicPollStream = pollIntervalRef.changes.pipe(
     Stream.filter(d => Duration.greaterThan(d, Duration.zero)), // 0 means don't poll
     Stream.flatMap(
-      interval => Stream.fromSchedule(Schedule.spaced(interval)).pipe(Stream.filter(() => vscode.window.state.active)),
+      interval =>
+        Schedule.spaced(interval).pipe(
+          Stream.fromSchedule,
+          Stream.filter(() => vscode.window.state.active)
+        ),
       // With switch: true: When the interval changes, the previous schedule stream is interrupted and a new one starts.
       // So changing the poll interval immediately replaces the old schedule with the new one instead of stacking them.
       { switch: true }

--- a/packages/salesforcedx-vscode-apex-log/src/schemas/traceFlagsSchema.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/schemas/traceFlagsSchema.ts
@@ -54,40 +54,41 @@ const DebugLevelItemStruct = Schema.Struct({
   )
 });
 
+const DebugLevelItemArray = Schema.Array(DebugLevelItemStruct);
+
 const isRecord = (x: unknown): x is Record<string, unknown> => typeof x === 'object' && x !== null && !Array.isArray(x);
 
 /** Build trace-flags JSON schemas from the shared TraceFlagItemStruct (provided by services API at runtime, or directly in build scripts). The struct already carries debugLevelName from the TraceFlag→DebugLevel relationship join. */
 export const buildTraceFlagsSchemas = <A, I>(itemStruct: Schema.Schema<A, I, never>) => {
+  /** Shared by every logType group below — one array schema, annotated per group. */
+  const ItemArray = Schema.Array(itemStruct);
+
   const TraceFlagsByLogTypeSchema = Schema.Struct({
     DEVELOPER_LOG: Schema.optional(
-      Schema.Array(itemStruct).pipe(
+      ItemArray.pipe(
         Schema.annotations({
           description: 'Standard debug logs for users. Captures Apex execution, database operations, and system events.'
         })
       )
     ),
     USER_DEBUG: Schema.optional(
-      Schema.Array(itemStruct).pipe(
+      ItemArray.pipe(
         Schema.annotations({
           description: 'User debug statements (System.debug). Captures output from Debug.log() and similar.'
         })
       )
     ),
     CLASS_TRACING: Schema.optional(
-      Schema.Array(itemStruct).pipe(
+      ItemArray.pipe(
         Schema.annotations({
           description: 'Apex class execution traces. Used for profiling and debugging specific classes.'
         })
       )
     ),
     TRIGGERS: Schema.optional(
-      Schema.Array(itemStruct).pipe(
-        Schema.annotations({ description: 'Apex trigger execution traces. TracedEntityId prefix 01q.' })
-      )
+      ItemArray.pipe(Schema.annotations({ description: 'Apex trigger execution traces. TracedEntityId prefix 01q.' }))
     ),
-    OTHER: Schema.optional(
-      Schema.Array(itemStruct).pipe(Schema.annotations({ description: 'Other trace flag types.' }))
-    )
+    OTHER: Schema.optional(ItemArray.pipe(Schema.annotations({ description: 'Other trace flag types.' })))
   });
 
   /** Schema for trace flags virtual doc - used for decode/encode and JSON Schema generation. traceFlags grouped by logType, active only. defaultDurationMinutes now in workspace config. */
@@ -95,9 +96,7 @@ export const buildTraceFlagsSchemas = <A, I>(itemStruct: Schema.Schema<A, I, nev
     defaultDebugLevels: Schema.optional(Schema.Record({ key: Schema.String, value: DebugLevelSchema })),
     traceFlags: Schema.optional(TraceFlagsByLogTypeSchema),
     debugLevels: Schema.optional(
-      Schema.Array(DebugLevelItemStruct).pipe(
-        Schema.annotations({ description: 'All DebugLevel records from the org.' })
-      )
+      DebugLevelItemArray.pipe(Schema.annotations({ description: 'All DebugLevel records from the org.' }))
     )
   }).pipe(Schema.annotations({ jsonSchema: { title: 'Trace Flags Configuration' } }));
 

--- a/packages/salesforcedx-vscode-apex-log/src/statusBar/traceFlagStatusBar.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/statusBar/traceFlagStatusBar.ts
@@ -98,7 +98,7 @@ export const createTraceFlagStatusBar = () =>
           // so the footer clears within a minute of expiry without a manual toggle or reload. Unlike the
           // cleanup scheduler (which hits the org), this is a cheap local re-render, so it is NOT gated on
           // window.state.active — the footer must clear at expiry even while the window is unfocused.
-          Stream.fromSchedule(Schedule.fixed(Duration.minutes(1))).pipe(Stream.as(undefined))
+          Schedule.fixed(Duration.minutes(1)).pipe(Stream.fromSchedule, Stream.as(undefined))
         ],
         {
           concurrency: 'unbounded'

--- a/packages/salesforcedx-vscode-apex-log/src/traceFlagCleanupScheduler.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/traceFlagCleanupScheduler.ts
@@ -31,11 +31,11 @@ export const traceFlagCleanupScheduler = Effect.fn('traceFlagCleanupScheduler')(
     )
   );
 
-  yield* Effect.fork(
-    Stream.fromSchedule(Schedule.fixed(Duration.minutes(5))).pipe(
-      Stream.filter(() => vscode.window.state.active),
-      Stream.runForEach(() => cleanup)
-    )
+  yield* Schedule.fixed(Duration.minutes(5)).pipe(
+    Stream.fromSchedule,
+    Stream.filter(() => vscode.window.state.active),
+    Stream.runForEach(() => cleanup),
+    Effect.fork
   );
   yield* Effect.sleep(Duration.infinity);
 });

--- a/packages/salesforcedx-vscode-apex-log/src/traceFlags/traceFlagJsonSync.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/traceFlags/traceFlagJsonSync.ts
@@ -135,12 +135,11 @@ export const pickOrgUser = Effect.fn('ApexLog.pickOrgUser')(function* (currentUs
   picker.onDidAccept(() => accept(picker.activeItems[0]));
   picker.onDidHide(() => accept(undefined));
 
-  yield* Effect.fork(
-    Stream.fromQueue(queue).pipe(
-      Stream.debounce(Duration.millis(SOSL_DEBOUNCE_MS)),
-      Stream.filter(s => s.length >= SOSL_MIN_CHARS),
-      Stream.runForEach(term => searchUsersEffect(term, picker, conn, currentUserId))
-    )
+  yield* Stream.fromQueue(queue).pipe(
+    Stream.debounce(Duration.millis(SOSL_DEBOUNCE_MS)),
+    Stream.filter(s => s.length >= SOSL_MIN_CHARS),
+    Stream.runForEach(term => searchUsersEffect(term, picker, conn, currentUserId)),
+    Effect.fork
   );
   picker.show();
 

--- a/packages/salesforcedx-vscode-apex-oas/test/jest/oas/generationStrategy/buildPromptUtils.test.ts
+++ b/packages/salesforcedx-vscode-apex-oas/test/jest/oas/generationStrategy/buildPromptUtils.test.ts
@@ -55,7 +55,7 @@ public void myMethod() {
     `;
     const methodsDocSymbolMap = new Map<string, DocumentSymbol>();
     await expect(
-      Effect.runPromise(getMethodImplementation(methodName, doc, methodsDocSymbolMap))
+      getMethodImplementation(methodName, doc, methodsDocSymbolMap).pipe(Effect.runPromise)
     ).rejects.toBeDefined();
   });
 });

--- a/packages/salesforcedx-vscode-apex-oas/test/jest/oas/generationStrategy/formatUtils.test.ts
+++ b/packages/salesforcedx-vscode-apex-oas/test/jest/oas/generationStrategy/formatUtils.test.ts
@@ -198,7 +198,9 @@ describe('getMethodTypeFromAnnotation', () => {
       ]
     ]);
 
-    await expect(Effect.runPromise(getMethodTypeFromAnnotation(methodName, methodsContextMap))).rejects.toBeDefined();
+    await expect(
+      getMethodTypeFromAnnotation(methodName, methodsContextMap).pipe(Effect.runPromise)
+    ).rejects.toBeDefined();
   });
 });
 

--- a/packages/salesforcedx-vscode-apex-oas/test/jest/oas/oasUtils.test.ts
+++ b/packages/salesforcedx-vscode-apex-oas/test/jest/oas/oasUtils.test.ts
@@ -684,7 +684,7 @@ describe('cleanupGeneratedDoc', () => {
 
   it('should fail for invalid JSON object', async () => {
     const doc = 'invalid json';
-    await expect(Effect.runPromise(cleanupGeneratedDoc(doc))).rejects.toBeDefined();
+    await expect(cleanupGeneratedDoc(doc).pipe(Effect.runPromise)).rejects.toBeDefined();
   });
 
   it('should strip markdown code fences with json language identifier', async () => {

--- a/packages/salesforcedx-vscode-apex-oas/test/jest/oas/promptGenerationOrchestrator.test.ts
+++ b/packages/salesforcedx-vscode-apex-oas/test/jest/oas/promptGenerationOrchestrator.test.ts
@@ -52,19 +52,17 @@ describe('promptGenerationOrchestrator pure helpers', () => {
 
     it('fails when all zero', async () => {
       await expect(
-        Effect.runPromise(
-          getLeastCallsStrategy(
-            buildBids([
-              ['ApexRest', 0],
-              ['AuraEnabled', 0]
-            ])
-          )
-        )
+        getLeastCallsStrategy(
+          buildBids([
+            ['ApexRest', 0],
+            ['AuraEnabled', 0]
+          ])
+        ).pipe(Effect.runPromise)
       ).rejects.toBeDefined();
     });
 
     it('fails for empty bids', async () => {
-      await expect(Effect.runPromise(getLeastCallsStrategy(new Map()))).rejects.toBeDefined();
+      await expect(getLeastCallsStrategy(new Map()).pipe(Effect.runPromise)).rejects.toBeDefined();
     });
   });
 
@@ -83,14 +81,12 @@ describe('promptGenerationOrchestrator pure helpers', () => {
 
     it('fails when all zero', async () => {
       await expect(
-        Effect.runPromise(
-          getMostCallsStrategy(
-            buildBids([
-              ['ApexRest', 0],
-              ['AuraEnabled', 0]
-            ])
-          )
-        )
+        getMostCallsStrategy(
+          buildBids([
+            ['ApexRest', 0],
+            ['AuraEnabled', 0]
+          ])
+        ).pipe(Effect.runPromise)
       ).rejects.toBeDefined();
     });
   });

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
@@ -154,15 +154,16 @@ const readLogFile = Effect.fn('ApexReplayDebugger.readLogFile')(function* (fileP
 const resolveHeapDumpResults = (logFileContents: string): Promise<HeapDumpResult[]> => {
   // Org/connection resolution failures keep the localized org-info label; a HeapDumpOverlayFetchError
   // is a batch-request failure, so it surfaces its own message rather than being mislabeled as org-info.
-  const orgInfoError = (error: unknown): HeapDumpResult[] => [
-    { heapDumpId: '', error: `${nls.localize('unable_to_retrieve_org_info')} : ${errorToString(error)}` }
-  ];
+  const orgInfoError = (error: unknown): Effect.Effect<HeapDumpResult[]> =>
+    Effect.succeed([
+      { heapDumpId: '', error: `${nls.localize('unable_to_retrieve_org_info')} : ${errorToString(error)}` }
+    ]);
   return fetchHeapDumpOverlayResults(logFileContents).pipe(
     Effect.catchTag('HeapDumpOverlayFetchError', error =>
       Effect.succeed<HeapDumpResult[]>([{ heapDumpId: '', error: errorToString(error) }])
     ),
     // Everything else (org/connection resolution failures) keeps the localized org-info label.
-    Effect.catchAll(error => Effect.succeed(orgInfoError(error))),
+    Effect.catchAll(orgInfoError),
     getRuntime().runPromise
   );
 };

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/breakpoints/checkpointService.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/breakpoints/checkpointService.ts
@@ -421,55 +421,43 @@ const lock = Effect.runSync(Effect.makeSemaphore(1));
 export const processBreakpointChangedForCheckpoints = (
   breakpointsChangedEvent: vscode.BreakpointsChangeEvent
 ): void => {
-  Effect.runSync(
-    lock.withPermits(1)(
-      Effect.sync(() => {
-        breakpointsChangedEvent.removed
-          .filter(isSourceBreakpoint)
-          .filter(isCheckpoint)
-          .map(bp => checkpointService.deleteCheckpointNodeIfExists(bp.id));
-      })
-    )
-  );
+  Effect.sync(() => {
+    breakpointsChangedEvent.removed
+      .filter(isSourceBreakpoint)
+      .filter(isCheckpoint)
+      .map(bp => checkpointService.deleteCheckpointNodeIfExists(bp.id));
+  }).pipe(lock.withPermits(1), Effect.runSync);
 
-  Effect.runSync(
-    lock.withPermits(1)(
-      Effect.sync(() => {
-        const sourceBreakpoints = breakpointsChangedEvent.changed.filter(isSourceBreakpoint);
-        sourceBreakpoints.filter(isCheckpoint).map(bp => {
-          const checkpointOverlayAction = parseCheckpointInfoFromBreakpoint(bp);
-          const uri = code2ProtocolConverter(bp.location.uri);
-          const filename = uri.substring(uri.lastIndexOf('/') + 1);
-          const theNode = checkpointService.returnCheckpointNodeIfAlreadyExists(bp.id);
-          if (theNode) {
-            theNode.updateCheckpoint(bp.enabled, uri, filename, checkpointOverlayAction);
-          } else {
-            // else if the node didn't exist then create it
-            checkpointService.createCheckpointNode(bp.id, bp.enabled, uri, filename, checkpointOverlayAction);
-          }
-        });
-        // The breakpoint is no longer a SourceBreakpoint or is no longer a checkpoint. Call to delete it if it exists
-        sourceBreakpoints.filter(isNotCheckpoint).map(bp => checkpointService.deleteCheckpointNodeIfExists(bp.id));
-      })
-    )
-  );
+  Effect.sync(() => {
+    const sourceBreakpoints = breakpointsChangedEvent.changed.filter(isSourceBreakpoint);
+    sourceBreakpoints.filter(isCheckpoint).map(bp => {
+      const checkpointOverlayAction = parseCheckpointInfoFromBreakpoint(bp);
+      const uri = code2ProtocolConverter(bp.location.uri);
+      const filename = uri.substring(uri.lastIndexOf('/') + 1);
+      const theNode = checkpointService.returnCheckpointNodeIfAlreadyExists(bp.id);
+      if (theNode) {
+        theNode.updateCheckpoint(bp.enabled, uri, filename, checkpointOverlayAction);
+      } else {
+        // else if the node didn't exist then create it
+        checkpointService.createCheckpointNode(bp.id, bp.enabled, uri, filename, checkpointOverlayAction);
+      }
+    });
+    // The breakpoint is no longer a SourceBreakpoint or is no longer a checkpoint. Call to delete it if it exists
+    sourceBreakpoints.filter(isNotCheckpoint).map(bp => checkpointService.deleteCheckpointNodeIfExists(bp.id));
+  }).pipe(lock.withPermits(1), Effect.runSync);
 
-  Effect.runSync(
-    lock.withPermits(1)(
-      Effect.sync(() => {
-        breakpointsChangedEvent.added
-          .filter(isSourceBreakpoint)
-          .filter(isCheckpoint)
-          .map(bp => {
-            const checkpointOverlayAction = parseCheckpointInfoFromBreakpoint(bp);
+  Effect.sync(() => {
+    breakpointsChangedEvent.added
+      .filter(isSourceBreakpoint)
+      .filter(isCheckpoint)
+      .map(bp => {
+        const checkpointOverlayAction = parseCheckpointInfoFromBreakpoint(bp);
 
-            const uri = code2ProtocolConverter(bp.location.uri);
-            const filename = uri.substring(uri.lastIndexOf('/') + 1);
-            checkpointService.createCheckpointNode(bp.id, bp.enabled, uri, filename, checkpointOverlayAction);
-          });
-      })
-    )
-  );
+        const uri = code2ProtocolConverter(bp.location.uri);
+        const filename = uri.substring(uri.lastIndexOf('/') + 1);
+        checkpointService.createCheckpointNode(bp.id, bp.enabled, uri, filename, checkpointOverlayAction);
+      });
+  }).pipe(lock.withPermits(1), Effect.runSync);
 };
 
 const parseCheckpointInfoFromBreakpoint = (breakpoint: vscode.SourceBreakpoint): ApexExecutionOverlayAction => {
@@ -556,105 +544,101 @@ export const sfCreateCheckpoints = async (): Promise<boolean> => {
   try {
     // The lock is necessary here to prevent the user from deleting the underlying breakpoint
     // attached to the checkpoint while they're being uploaded into the org.
-    await Effect.runPromise(
-      lock.withPermits(1)(
-        Effect.promise(async () => {
-          writeToDebuggerOutputWindow(`${nls.localize('long_command_start')} ${localizedProgressMessage}`);
-          await vscode.window.withProgress(
-            {
-              location: vscode.ProgressLocation.Notification,
-              title: localizedProgressMessage,
-              cancellable: false
-            },
+    await Effect.promise(async () => {
+      writeToDebuggerOutputWindow(`${nls.localize('long_command_start')} ${localizedProgressMessage}`);
+      await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: localizedProgressMessage,
+          cancellable: false
+        },
 
-            async (progress, _token) => {
-              writeToDebuggerOutputWindow(
-                `${localizedProgressMessage}, ${nls.localize('checkpoint_creation_status_org_info')}`
-              );
-              progress.report({
-                increment: 0,
-                message: localizedProgressMessage
-              });
-              const connection = await getConnection();
-              if (!connection) {
-                updateError = true;
-                return false;
-              }
-
-              writeToDebuggerOutputWindow(
-                `${localizedProgressMessage}, ${nls.localize('checkpoint_creation_status_source_line_info')}`
-              );
-              progress.report({
-                increment: 20,
-                message: localizedProgressMessage
-              });
-              const sourceLineInfoRetrieved: boolean = await retrieveLineBreakpointInfo();
-              // If we didn't get the source line information that'll be reported at that time, just return
-              if (!sourceLineInfoRetrieved) {
-                updateError = true;
-                return false;
-              }
-
-              // There can be a max of five active checkpoints
-              if (!checkpointService.hasFiveOrLessActiveCheckpoints()) {
-                updateError = true;
-                return false;
-              }
-
-              writeToDebuggerOutputWindow(
-                `${localizedProgressMessage}, ${nls.localize('checkpoint_creation_status_setting_typeref')}`
-              );
-              progress.report({
-                increment: 50,
-                message: localizedProgressMessage
-              });
-              // For the active checkpoints set the typeRefs using the source/line info
-              if (!setTypeRefsForEnabledCheckpoints()) {
-                updateError = true;
-                return false;
-              }
-
-              writeToDebuggerOutputWindow(
-                `${localizedProgressMessage}, ${nls.localize('checkpoint_creation_status_clearing_existing_checkpoints')}`
-              );
-              progress.report({
-                increment: 50,
-                message: localizedProgressMessage
-              });
-              // remove any existing checkpoints on the server
-              const allRemoved: boolean = await clearExistingCheckpoints();
-              if (!allRemoved) {
-                updateError = true;
-                return false;
-              }
-
-              writeToDebuggerOutputWindow(
-                `${localizedProgressMessage}, ${nls.localize('checkpoint_creation_status_uploading_checkpoints')}`
-              );
-              progress.report({
-                increment: 70,
-                message: localizedProgressMessage
-              });
-              updateError = (
-                await Promise.allSettled(
-                  (checkpointService.getChildren() as CheckpointNode[])
-                    .filter(cpNode => cpNode.isCheckpointEnabled())
-                    .map(cpNode => executeCreateApexExecutionOverlayActionCommand(cpNode))
-                )
-              ).some(promise => promise.status === 'rejected');
-
-              progress.report({
-                increment: 100,
-                message: localizedProgressMessage
-              });
-              writeToDebuggerOutputWindow(
-                `${localizedProgressMessage}, ${nls.localize('checkpoint_creation_status_processing_complete_success')}`
-              );
-            }
+        async (progress, _token) => {
+          writeToDebuggerOutputWindow(
+            `${localizedProgressMessage}, ${nls.localize('checkpoint_creation_status_org_info')}`
           );
-        })
-      )
-    );
+          progress.report({
+            increment: 0,
+            message: localizedProgressMessage
+          });
+          const connection = await getConnection();
+          if (!connection) {
+            updateError = true;
+            return false;
+          }
+
+          writeToDebuggerOutputWindow(
+            `${localizedProgressMessage}, ${nls.localize('checkpoint_creation_status_source_line_info')}`
+          );
+          progress.report({
+            increment: 20,
+            message: localizedProgressMessage
+          });
+          const sourceLineInfoRetrieved: boolean = await retrieveLineBreakpointInfo();
+          // If we didn't get the source line information that'll be reported at that time, just return
+          if (!sourceLineInfoRetrieved) {
+            updateError = true;
+            return false;
+          }
+
+          // There can be a max of five active checkpoints
+          if (!checkpointService.hasFiveOrLessActiveCheckpoints()) {
+            updateError = true;
+            return false;
+          }
+
+          writeToDebuggerOutputWindow(
+            `${localizedProgressMessage}, ${nls.localize('checkpoint_creation_status_setting_typeref')}`
+          );
+          progress.report({
+            increment: 50,
+            message: localizedProgressMessage
+          });
+          // For the active checkpoints set the typeRefs using the source/line info
+          if (!setTypeRefsForEnabledCheckpoints()) {
+            updateError = true;
+            return false;
+          }
+
+          writeToDebuggerOutputWindow(
+            `${localizedProgressMessage}, ${nls.localize('checkpoint_creation_status_clearing_existing_checkpoints')}`
+          );
+          progress.report({
+            increment: 50,
+            message: localizedProgressMessage
+          });
+          // remove any existing checkpoints on the server
+          const allRemoved: boolean = await clearExistingCheckpoints();
+          if (!allRemoved) {
+            updateError = true;
+            return false;
+          }
+
+          writeToDebuggerOutputWindow(
+            `${localizedProgressMessage}, ${nls.localize('checkpoint_creation_status_uploading_checkpoints')}`
+          );
+          progress.report({
+            increment: 70,
+            message: localizedProgressMessage
+          });
+          updateError = (
+            await Promise.allSettled(
+              (checkpointService.getChildren() as CheckpointNode[])
+                .filter(cpNode => cpNode.isCheckpointEnabled())
+                .map(cpNode => executeCreateApexExecutionOverlayActionCommand(cpNode))
+            )
+          ).some(promise => promise.status === 'rejected');
+
+          progress.report({
+            increment: 100,
+            message: localizedProgressMessage
+          });
+          writeToDebuggerOutputWindow(
+            `${localizedProgressMessage}, ${nls.localize('checkpoint_creation_status_processing_complete_success')}`
+          );
+        }
+      );
+    }).pipe(lock.withPermits(1), Effect.runPromise);
   } finally {
     writeToDebuggerOutputWindow(`${nls.localize('long_command_end')} ${localizedProgressMessage}`);
     let errorMsg = '';

--- a/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/packageResolution.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/testDiscovery/packageResolution.ts
@@ -190,7 +190,7 @@ const resolveFromInstalledSubscriberPackages = Effect.fn(
     )
   );
   const noNamespacePackages = rows.filter(row =>
-    Option.isNone(trimmedNamespace(row.SubscriberPackage.NamespacePrefix))
+    trimmedNamespace(row.SubscriberPackage.NamespacePrefix).pipe(Option.isNone)
   );
 
   const entries = [...classIdToNamespace.entries()];

--- a/packages/salesforcedx-vscode-apex-testing/test/jest/discoveryVfs/apexTestDiscoveryService.test.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/jest/discoveryVfs/apexTestDiscoveryService.test.ts
@@ -48,7 +48,7 @@ const run = <A, E>(
 const runExit = <A, E>(
   serviceLayer: Layer.Layer<ApexTestDiscoveryService>,
   effect: Effect.Effect<A, E, ApexTestDiscoveryService>
-) => Effect.runPromise(Effect.exit(Effect.provide(effect, serviceLayer)));
+) => effect.pipe(Effect.provide(serviceLayer), Effect.exit, Effect.runPromise);
 
 const readClassBody = (provider: ApexTestingDiscoveryFsProvider, orgKey: string, fullClassName: string): string =>
   decoder.decode(provider.readFile(getApexTestingClassUri(orgKey, fullClassName)));

--- a/packages/salesforcedx-vscode-apex/src/languageServer.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageServer.ts
@@ -143,7 +143,7 @@ const protocol2CodeConverter = (value: string) => URI.parse(value);
 // One long-lived ROOT span per client lifetime. `apexLSPLog` is high-volume; per ADR-0002 we write
 // attrs onto this single span, not N top-level spans. Held in a Ref<Option> (Effect primitive for
 // shared mutable state) with its child scope so a restart can flush the prior span before the next.
-const clientSpanRef = Effect.runSync(Ref.make(Option.none<{ scope: Scope.CloseableScope; span: Tracer.Span }>()));
+const clientSpanRef = Option.none<{ scope: Scope.CloseableScope; span: Tracer.Span }>().pipe(Ref.make, Effect.runSync);
 
 // Runs on first activation AND every restart: close the prior child scope (flushes prior span) before
 // forking the next — exactly ONE live client span (ADR-0002). Forked from the extension scope so

--- a/packages/salesforcedx-vscode-metadata/src/services/deployOnSaveService.ts
+++ b/packages/salesforcedx-vscode-metadata/src/services/deployOnSaveService.ts
@@ -143,7 +143,9 @@ export const createDeployOnSaveService = Effect.fn('deployOnSave:createDeployOnS
     Stream.filterEffect(api.services.ProjectService.isInPackageDirectories),
     Stream.groupedWithin(10_000, Duration.millis(ENQUEUE_DELAY_MS)),
     Stream.runForEach(chunk =>
-      deployQueuedFiles(Chunk.toReadonlyArray(chunk)).pipe(
+      chunk.pipe(
+        Chunk.toReadonlyArray,
+        deployQueuedFiles,
         Effect.catchAll(error => handleDeployError(error)),
         Effect.catchAll(() => Effect.void)
       )

--- a/packages/salesforcedx-vscode-metadata/src/statusBar/sourceTrackingStatusBar.ts
+++ b/packages/salesforcedx-vscode-metadata/src/statusBar/sourceTrackingStatusBar.ts
@@ -117,13 +117,12 @@ export const createSourceTrackingStatusBar = Effect.fn('createSourceTrackingStat
   const pollIntervalRef = yield* SubscriptionRef.make(Duration.seconds(getPollingIntervalSeconds()));
 
   // Watch setting changes to update poll frequency dynamically
-  yield* Effect.fork(
-    Stream.fromPubSub(settingsChangePubSub).pipe(
-      Stream.filter(event =>
-        event.affectsConfiguration('salesforcedx-vscode-metadata.sourceTracking.pollingIntervalSeconds')
-      ),
-      Stream.runForEach(() => SubscriptionRef.set(pollIntervalRef, Duration.seconds(getPollingIntervalSeconds())))
-    )
+  yield* Stream.fromPubSub(settingsChangePubSub).pipe(
+    Stream.filter(event =>
+      event.affectsConfiguration('salesforcedx-vscode-metadata.sourceTracking.pollingIntervalSeconds')
+    ),
+    Stream.runForEach(() => SubscriptionRef.set(pollIntervalRef, Duration.seconds(getPollingIntervalSeconds()))),
+    Effect.fork
   );
 
   // Watch conflict detection setting changes to trigger immediate refresh
@@ -152,7 +151,11 @@ export const createSourceTrackingStatusBar = Effect.fn('createSourceTrackingStat
   const dynamicPollStream = pollIntervalRef.changes.pipe(
     Stream.filter(d => Duration.greaterThan(d, Duration.zero)), // 0 means don't poll
     Stream.flatMap(
-      interval => Stream.fromSchedule(Schedule.fixed(interval)).pipe(Stream.filter(() => vscode.window.state.active)),
+      interval =>
+        Schedule.fixed(interval).pipe(
+          Stream.fromSchedule,
+          Stream.filter(() => vscode.window.state.active)
+        ),
       { switch: true } // Restart schedule when interval changes
     )
   );

--- a/packages/salesforcedx-vscode-metadata/src/utils/withPreparationProgress.ts
+++ b/packages/salesforcedx-vscode-metadata/src/utils/withPreparationProgress.ts
@@ -112,7 +112,7 @@ export const withPreparationProgress =
                 return cs;
               });
 
-              const exit = await Runtime.runPromise(runtime)(Effect.exit(pipeline));
+              const exit = await pipeline.pipe(Effect.exit, Runtime.runPromise(runtime));
               resume(Exit.isSuccess(exit) ? Effect.succeed(exit.value) : Effect.failCause(exit.cause));
             }
           );

--- a/packages/salesforcedx-vscode-metadata/test/jest/commands/refreshSObjects.test.ts
+++ b/packages/salesforcedx-vscode-metadata/test/jest/commands/refreshSObjects.test.ts
@@ -56,7 +56,7 @@ const runCommand = (source?: Parameters<typeof refreshSObjectsCommand>[0]) =>
     refreshSObjectsCommand(source).pipe(
       Effect.catchTag('UserCancellationError', () => Effect.void),
       Effect.catchAllCause(cause =>
-        Effect.sync(() => void vscode.window.showErrorMessage(getErrorMessage(Cause.squash(cause))))
+        Effect.sync(() => void vscode.window.showErrorMessage(cause.pipe(Cause.squash, getErrorMessage)))
       ),
       Effect.provideService(ExtensionProviderService, createMockExtensionProvider())
     ) as Effect.Effect<unknown, never, never>

--- a/packages/salesforcedx-vscode-metadata/test/jest/conflict/resultStorage.test.ts
+++ b/packages/salesforcedx-vscode-metadata/test/jest/conflict/resultStorage.test.ts
@@ -138,7 +138,7 @@ describe('buildTimestampIndexFromDir', () => {
     expect(DateTime.toEpochMillis(stored!)).toBe(new Date('2024-02-01T00:00:00.000Z').getTime());
 
     // Older file should have been deleted; newer file kept
-    const deleted = Effect.runSync(Ref.get(deletedRef));
+    const deleted = Ref.get(deletedRef).pipe(Effect.runSync);
     expect(deleted).toContain(older.toString());
     expect(deleted).not.toContain(newer.toString());
   });
@@ -161,7 +161,7 @@ describe('buildTimestampIndexFromDir', () => {
     await runWithMocks(buildTimestampIndexFromDir(DIR), makeMockFs(files, deletedRef));
 
     // ClassB only exists in older file, so older file must be kept
-    const deleted = Effect.runSync(Ref.get(deletedRef));
+    const deleted = Ref.get(deletedRef).pipe(Effect.runSync);
     expect(deleted).not.toContain(older.toString());
     expect(deleted).not.toContain(newer.toString());
   });
@@ -183,7 +183,7 @@ describe('buildTimestampIndexFromDir', () => {
     expect(index.get('CustomObject:Account__c')).toBeDefined();
 
     // Malformed file has no rows → stale → deleted
-    const deleted = Effect.runSync(Ref.get(deletedRef));
+    const deleted = Ref.get(deletedRef).pipe(Effect.runSync);
     expect(deleted).toContain(bad.toString());
     expect(deleted).not.toContain(good.toString());
   });
@@ -218,7 +218,7 @@ describe('buildTimestampIndexFromDir', () => {
 
     expect(index.size).toBe(1);
     expect(readCalls).not.toContain(txtFile.toString());
-    const deleted = Effect.runSync(Ref.get(deletedRef));
+    const deleted = Ref.get(deletedRef).pipe(Effect.runSync);
     expect(deleted).not.toContain(txtFile.toString());
   });
 

--- a/packages/salesforcedx-vscode-org-browser/src/index.ts
+++ b/packages/salesforcedx-vscode-org-browser/src/index.ts
@@ -208,23 +208,22 @@ const openFilterTextPicker = Effect.fn('OrgBrowser.openFilterTextPicker')(functi
   );
 
   // Live filtering: update tree as user types
-  yield* Effect.fork(
-    Stream.fromQueue(queue).pipe(
-      Stream.debounce(Duration.millis(150)),
-      Stream.runForEach(value =>
-        Effect.gen(function* () {
-          const { typeFilter, componentFilter, typeIsRegex, componentIsRegex } = parseFilterValue(value);
-          treeProvider.setTextFilter(typeFilter, componentFilter, typeIsRegex, componentIsRegex);
-          yield* Effect.promise(() =>
-            vscode.commands.executeCommand(
-              'setContext',
-              'sf:orgBrowser.textFilterActive',
-              isNotUndefined(typeFilter) || isNotUndefined(componentFilter)
-            )
-          );
-        })
-      )
-    )
+  yield* Stream.fromQueue(queue).pipe(
+    Stream.debounce(Duration.millis(150)),
+    Stream.runForEach(value =>
+      Effect.gen(function* () {
+        const { typeFilter, componentFilter, typeIsRegex, componentIsRegex } = parseFilterValue(value);
+        treeProvider.setTextFilter(typeFilter, componentFilter, typeIsRegex, componentIsRegex);
+        yield* Effect.promise(() =>
+          vscode.commands.executeCommand(
+            'setContext',
+            'sf:orgBrowser.textFilterActive',
+            isNotUndefined(typeFilter) || isNotUndefined(componentFilter)
+          )
+        );
+      })
+    ),
+    Effect.fork
   );
 
   picker.show();

--- a/packages/salesforcedx-vscode-services/src/core/metadataDeployService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/metadataDeployService.ts
@@ -117,7 +117,7 @@ export class MetadataDeployService extends Effect.Service<MetadataDeployService>
               async (_, token) => {
                 token.onCancellationRequested(async () => {
                   await deployOperation.cancel();
-                  await Runtime.runPromise(runtime)(Fiber.interrupt(deployFiber));
+                  await Fiber.interrupt(deployFiber).pipe(Runtime.runPromise(runtime));
                 });
                 return await deployOperation.pollStatus();
               }

--- a/packages/salesforcedx-vscode-services/src/core/metadataRetrieveService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/metadataRetrieveService.ts
@@ -142,7 +142,7 @@ export class MetadataRetrieveService extends Effect.Service<MetadataRetrieveServ
             async (_, token) => {
               token.onCancellationRequested(async () => {
                 await retrieveOperation.cancel();
-                await Runtime.runPromise(runtime)(Fiber.interrupt(retrieveFiber));
+                await Fiber.interrupt(retrieveFiber).pipe(Runtime.runPromise(runtime));
               });
               await retrieveOperation.start();
               return await retrieveOperation.pollStatus();

--- a/packages/salesforcedx-vscode-services/src/core/schemas/defaultOrgInfo.ts
+++ b/packages/salesforcedx-vscode-services/src/core/schemas/defaultOrgInfo.ts
@@ -8,8 +8,10 @@
 import * as Schema from 'effect/Schema';
 import { CliId } from '../../observability/cliTelemetry';
 
+const StringArray = Schema.Array(Schema.String);
+
 export const DefaultOrgInfoSchema = Schema.Struct({
-  aliases: Schema.optional(Schema.Array(Schema.String)),
+  aliases: Schema.optional(StringArray),
   orgId: Schema.optional(Schema.String),
   devHubOrgId: Schema.optional(Schema.String),
   username: Schema.optional(Schema.String),

--- a/packages/salesforcedx-vscode-services/src/core/schemas/traceFlagSchemas.ts
+++ b/packages/salesforcedx-vscode-services/src/core/schemas/traceFlagSchemas.ts
@@ -22,6 +22,9 @@ const ToolingTraceFlagDebugLevel = Schema.Struct({
   DeveloperName: Schema.optional(NullableString)
 });
 
+/** DebugLevel relationship is null when the referenced DebugLevel is missing/inaccessible. */
+const NullableToolingTraceFlagDebugLevel = Schema.NullOr(ToolingTraceFlagDebugLevel);
+
 /** Tooling API record shape from TraceFlag query. TracedEntityName is injected by getTraceFlags when resolving entity names. */
 const ToolingTraceFlagRecordSchema = Schema.Struct({
   Id: Schema.String,
@@ -29,7 +32,7 @@ const ToolingTraceFlagRecordSchema = Schema.Struct({
   StartDate: Schema.optional(NullableString),
   ExpirationDate: Schema.String,
   DebugLevelId: Schema.optional(NullableString),
-  DebugLevel: Schema.optional(Schema.NullOr(ToolingTraceFlagDebugLevel)),
+  DebugLevel: Schema.optional(NullableToolingTraceFlagDebugLevel),
   TracedEntityId: Schema.optional(NullableString),
   TracedEntityName: Schema.optional(NullableString)
 });

--- a/packages/salesforcedx-vscode-services/src/core/sourceTrackingService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/sourceTrackingService.ts
@@ -281,60 +281,56 @@ export class SourceTrackingService extends Effect.Service<SourceTrackingService>
       function* () {
         const tracking = yield* getOrCreateTracking();
 
-        return yield* localSemaphore.withPermits(1)(
-          remoteSemaphore.withPermits(1)(
-            Effect.gen(function* () {
-              yield* rereadBoth(tracking);
+        return yield* Effect.gen(function* () {
+          yield* rereadBoth(tracking);
 
-              // Get all remote deletes as ChangeResult before applying — works even when local files don't exist
-              const allRemoteDeletes = yield* Effect.tryPromise({
-                try: () => tracking.getChanges({ origin: 'remote', state: 'delete', format: 'ChangeResult' }),
-                catch: toSourceTrackingError
-              });
+          // Get all remote deletes as ChangeResult before applying — works even when local files don't exist
+          const allRemoteDeletes = yield* Effect.tryPromise({
+            try: () => tracking.getChanges({ origin: 'remote', state: 'delete', format: 'ChangeResult' }),
+            catch: toSourceTrackingError
+          });
 
-              const result = yield* Effect.tryPromise({
-                try: () => tracking.maybeApplyRemoteDeletesToLocal(true),
-                catch: toSourceTrackingError
-              }).pipe(Effect.withSpan('STL.MaybeApplyRemoteDeletesToLocal'));
+          const result = yield* Effect.tryPromise({
+            try: () => tracking.maybeApplyRemoteDeletesToLocal(true),
+            catch: toSourceTrackingError
+          }).pipe(Effect.withSpan('STL.MaybeApplyRemoteDeletesToLocal'));
 
-              // STL only calls updateRemoteTracking for deletes it could resolve to local files.
-              // For deletes with no local file, manually acknowledge them so they leave tracking.
-              const handledTypeNames = HashSet.fromIterable(
-                result.fileResponsesFromDelete.map(r => Data.struct({ type: r.type, fullName: r.fullName }))
-              );
+          // STL only calls updateRemoteTracking for deletes it could resolve to local files.
+          // For deletes with no local file, manually acknowledge them so they leave tracking.
+          const handledTypeNames = HashSet.fromIterable(
+            result.fileResponsesFromDelete.map(r => Data.struct({ type: r.type, fullName: r.fullName }))
+          );
 
-              const unhandled = allRemoteDeletes
-                .filter(isResolvedChangeResult)
-                .filter(c => !HashSet.has(handledTypeNames, Data.struct({ type: c.type, fullName: c.name })));
+          const unhandled = allRemoteDeletes
+            .filter(isResolvedChangeResult)
+            .filter(c => !HashSet.has(handledTypeNames, Data.struct({ type: c.type, fullName: c.name })));
 
-              if (unhandled.length > 0) {
-                yield* Effect.tryPromise({
-                  try: () =>
-                    tracking.updateRemoteTracking(
-                      unhandled.map(c => ({ type: c.type, fullName: c.name, state: ComponentStatus.Deleted })),
-                      true // skipPolling — same as STL's deleteFilesAndUpdateTracking
-                    ),
-                  catch: toSourceTrackingError
-                }).pipe(Effect.withSpan('STL.AcknowledgeUnhandledRemoteDeletes'));
-              }
+          if (unhandled.length > 0) {
+            yield* Effect.tryPromise({
+              try: () =>
+                tracking.updateRemoteTracking(
+                  unhandled.map(c => ({ type: c.type, fullName: c.name, state: ComponentStatus.Deleted })),
+                  true // skipPolling — same as STL's deleteFilesAndUpdateTracking
+                ),
+              catch: toSourceTrackingError
+            }).pipe(Effect.withSpan('STL.AcknowledgeUnhandledRemoteDeletes'));
+          }
 
-              // Surface unhandled deletes as synthetic FileResponse entries so the output channel
-              // shows them even when there was no local file to delete.
-              // filePath is empty string (falsy) so formatRetrieveOutput falls back to fullName for display.
-              const syntheticDeletes: FileResponse[] = unhandled.map(c => ({
-                type: c.type,
-                fullName: c.name,
-                state: ComponentStatus.Deleted,
-                filePath: ''
-              }));
+          // Surface unhandled deletes as synthetic FileResponse entries so the output channel
+          // shows them even when there was no local file to delete.
+          // filePath is empty string (falsy) so formatRetrieveOutput falls back to fullName for display.
+          const syntheticDeletes: FileResponse[] = unhandled.map(c => ({
+            type: c.type,
+            fullName: c.name,
+            state: ComponentStatus.Deleted,
+            filePath: ''
+          }));
 
-              return {
-                componentSetFromNonDeletes: result.componentSetFromNonDeletes,
-                fileResponsesFromDelete: [...result.fileResponsesFromDelete, ...syntheticDeletes]
-              };
-            })
-          )
-        );
+          return {
+            componentSetFromNonDeletes: result.componentSetFromNonDeletes,
+            fileResponsesFromDelete: [...result.fileResponsesFromDelete, ...syntheticDeletes]
+          };
+        }).pipe(remoteSemaphore.withPermits(1), localSemaphore.withPermits(1));
       }
     );
 
@@ -342,17 +338,13 @@ export class SourceTrackingService extends Effect.Service<SourceTrackingService>
     const getConflicts = Effect.fn('SourceTrackingService.getConflicts')(function* () {
       const tracking = yield* getOrCreateTracking();
 
-      return yield* localSemaphore.withPermits(1)(
-        remoteSemaphore.withPermits(1)(
-          Effect.gen(function* () {
-            yield* rereadBoth(tracking);
-            return yield* Effect.tryPromise({
-              try: () => tracking.getConflicts(),
-              catch: toSourceTrackingError
-            }).pipe(Effect.withSpan('STL.GetConflicts'));
-          })
-        )
-      );
+      return yield* Effect.gen(function* () {
+        yield* rereadBoth(tracking);
+        return yield* Effect.tryPromise({
+          try: () => tracking.getConflicts(),
+          catch: toSourceTrackingError
+        }).pipe(Effect.withSpan('STL.GetConflicts'));
+      }).pipe(remoteSemaphore.withPermits(1), localSemaphore.withPermits(1));
     });
 
     /** Check for conflicts and display them in the channel, failing if conflicts are found (both tracking files) */
@@ -394,16 +386,14 @@ export class SourceTrackingService extends Effect.Service<SourceTrackingService>
         }
 
         const tracking = yield* getOrCreateTracking();
-        return yield* localSemaphore.withPermits(1)(
-          remoteSemaphore.withPermits(1)(
-            Effect.tryPromise({
-              try: () => tracking.updateTrackingFromRetrieve(result),
-              catch: toSourceTrackingError
-            }).pipe(
-              Effect.withSpan('STL.UpdateTrackingFromRetrieve'),
-              Effect.tapError(error => Effect.logError(error))
-            )
-          )
+        return yield* Effect.tryPromise({
+          try: () => tracking.updateTrackingFromRetrieve(result),
+          catch: toSourceTrackingError
+        }).pipe(
+          Effect.withSpan('STL.UpdateTrackingFromRetrieve'),
+          Effect.tapError(error => Effect.logError(error)),
+          remoteSemaphore.withPermits(1),
+          localSemaphore.withPermits(1)
         );
       }
     );
@@ -421,16 +411,14 @@ export class SourceTrackingService extends Effect.Service<SourceTrackingService>
       const tracking = yield* getOrCreateTracking();
       return yield* Effect.all(
         [
-          localSemaphore.withPermits(1)(
-            remoteSemaphore.withPermits(1)(
-              Effect.tryPromise({
-                try: () => tracking.updateTrackingFromDeploy(result),
-                catch: toSourceTrackingError
-              }).pipe(
-                Effect.withSpan('STL.UpdateTrackingFromDeploy'),
-                Effect.tapError(error => Effect.logError(error))
-              )
-            )
+          Effect.tryPromise({
+            try: () => tracking.updateTrackingFromDeploy(result),
+            catch: toSourceTrackingError
+          }).pipe(
+            Effect.withSpan('STL.UpdateTrackingFromDeploy'),
+            Effect.tapError(error => Effect.logError(error)),
+            remoteSemaphore.withPermits(1),
+            localSemaphore.withPermits(1)
           ),
           Effect.annotateCurrentSpan({ files: result.getFileResponses().map(r => r.filePath) })
         ],

--- a/packages/salesforcedx-vscode-services/src/core/templateService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/templateService.ts
@@ -94,7 +94,9 @@ class MissingProjectSourceApiVersionError extends Schema.TaggedError<MissingProj
   { message: Schema.String }
 ) {}
 
-const TemplateManifestSchema = Schema.parseJson(Schema.Array(Schema.String));
+const StringArraySchema = Schema.Array(Schema.String);
+
+const TemplateManifestSchema = Schema.parseJson(StringArraySchema);
 
 const getExtensionUri = Effect.fn('getExtensionUri')(function* () {
   const ext = vscode.extensions.getExtension('salesforce.salesforcedx-vscode-services');

--- a/packages/salesforcedx-vscode-services/src/index.ts
+++ b/packages/salesforcedx-vscode-services/src/index.ts
@@ -342,7 +342,7 @@ export const activate = async (context: vscode.ExtensionContext): Promise<Salesf
   // reauth cache) instead of Effect.provide(ConnectionService.Default), which builds a private
   // ConnectionService with its own reauth cache (a duplicate reauth modal on desktop). The exporter
   // fails fast until this is set, so it never blocks activation waiting on it.
-  setServicesRuntime(ManagedRuntime.make(Layer.succeedContext(builtContext)));
+  builtContext.pipe(Layer.succeedContext, ManagedRuntime.make, setServicesRuntime);
 
   await activationEffect(context).pipe(
     Effect.provide(builtContext),

--- a/packages/salesforcedx-vscode-services/src/observability/cliTelemetry.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/cliTelemetry.ts
@@ -54,7 +54,7 @@ const cliIdEffect =
     : fetchCliIdFromCli().pipe(Effect.map(Option.fromNullable));
 
 // memo wrapper built once at module scope; the inner sf telemetry effect runs at most once per session and is shared across all getCliId() calls
-const cachedCliId = Effect.runSync(Effect.cached(cliIdEffect));
+const cachedCliId = cliIdEffect.pipe(Effect.cached, Effect.runSync);
 
 /** Get the CLI ID from sf telemetry. Memoized at module scope so the CLI runs once per session. Returns Option.none() on web or when CLI unavailable. */
 export const getCliId = () => cachedCliId;

--- a/packages/salesforcedx-vscode-services/src/virtualFsProvider/fileSystemProvider.ts
+++ b/packages/salesforcedx-vscode-services/src/virtualFsProvider/fileSystemProvider.ts
@@ -152,7 +152,7 @@ export class FsProvider implements vscode.FileSystemProvider {
       )
     );
 
-    await Effect.runPromise(Effect.scoped(program));
+    await program.pipe(Effect.scoped, Effect.runPromise);
 
     emitter.fire([{ type: vscode.FileChangeType.Changed, uri }]);
   }

--- a/packages/salesforcedx-vscode-services/src/virtualFsProvider/indexedDbStorage.ts
+++ b/packages/salesforcedx-vscode-services/src/virtualFsProvider/indexedDbStorage.ts
@@ -184,7 +184,7 @@ const IndexedDBStorageServicesNoop: Layer.Layer<IndexedDBStorageService, never> 
 // Expose a single, memoized layer instance to ensure one shared IndexedDB connection only if web.  Otherwise, use a dummy layer.
 export const IndexedDBStorageServiceShared =
   process.env.ESBUILD_PLATFORM === 'web'
-    ? Layer.unwrapEffect(Layer.memoize(IndexedDBStorageService.Default))
+    ? IndexedDBStorageService.Default.pipe(Layer.memoize, Layer.unwrapEffect)
     : IndexedDBStorageServicesNoop;
 
 const writeFileWithOrWithoutDir = (entry: SerializedFileWithPath): void => {

--- a/packages/salesforcedx-vscode-services/src/vscode/configWatcher.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/configWatcher.ts
@@ -27,13 +27,12 @@ export const watchSettingsService = Effect.fn('watchSettingsService')(function* 
   });
 
   // watches auth settings
-  yield* Effect.fork(
-    Stream.fromPubSub(settingsChangePubSub).pipe(
-      Stream.filter(event => authSettings.some(s => event.affectsConfiguration(s))),
-      Stream.debounce(Duration.millis(100)),
-      Stream.tap(() => channelService.appendToChannel('ConfigChanged: Web Auth')),
-      Stream.runForEach(() => ConnectionService.getConnection().pipe(Effect.catchAll(() => Effect.void))) // it's possible for the connection to fail and that's ok.  Some other event will try to get a connection and display a real error
-    )
+  yield* Stream.fromPubSub(settingsChangePubSub).pipe(
+    Stream.filter(event => authSettings.some(s => event.affectsConfiguration(s))),
+    Stream.debounce(Duration.millis(100)),
+    Stream.tap(() => channelService.appendToChannel('ConfigChanged: Web Auth')),
+    Stream.runForEach(() => ConnectionService.getConnection().pipe(Effect.catchAll(() => Effect.void))), // it's possible for the connection to fail and that's ok.  Some other event will try to get a connection and display a real error
+    Effect.fork
   );
 
   // watch retrieveOnLoad setting

--- a/packages/salesforcedx-vscode-services/src/vscode/prompts/promptService.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/prompts/promptService.ts
@@ -236,8 +236,9 @@ export class PromptService extends Effect.Service<PromptService>()('PromptServic
                     Deferred.fail(cancelDeferred, new UserCancellationError({ message: 'User cancelled progress' }))
                   )
               );
-              const exit = await Runtime.runPromise(runtime)(
-                Effect.exit(Effect.raceFirst(build(progress, token), Deferred.await(cancelDeferred)))
+              const exit = await Effect.raceFirst(build(progress, token), Deferred.await(cancelDeferred)).pipe(
+                Effect.exit,
+                Runtime.runPromise(runtime)
               );
               resume(Exit.isSuccess(exit) ? Effect.succeed(exit.value) : Effect.failCause(exit.cause));
             });

--- a/packages/salesforcedx-vscode-services/test/jest/core/traceFlagService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/traceFlagService.test.ts
@@ -90,8 +90,10 @@ const runScoped = <A, E>(
   prog: Effect.Effect<A, E, TraceFlagService | Scope.Scope>,
   layer: Layer.Layer<ConnectionService>
 ) =>
-  Effect.runPromise(
-    Effect.scoped(prog).pipe(Effect.provide(Layer.provide(TraceFlagService.DefaultWithoutDependencies, layer)))
+  prog.pipe(
+    Effect.scoped,
+    Effect.provide(Layer.provide(TraceFlagService.DefaultWithoutDependencies, layer)),
+    Effect.runPromise
   );
 
 describe('TraceFlagService.getTraceFlags id->name cache', () => {
@@ -486,26 +488,26 @@ describe('TraceFlagService.createDebugLevel', () => {
       create: jest.fn(async (_type, _payload) => ({ success: true }))
     });
 
-    const exit = await Effect.runPromiseExit(
-      Effect.scoped(
-        Effect.gen(function* () {
-          const svc = yield* TraceFlagService;
-          return yield* svc.createDebugLevel({
-            DeveloperName: 'X',
-            MasterLabel: 'X',
-            ApexCode: 'NONE',
-            ApexProfiling: 'NONE',
-            Callout: 'NONE',
-            Database: 'NONE',
-            Nba: 'NONE',
-            System: 'NONE',
-            Validation: 'NONE',
-            Visualforce: 'NONE',
-            Wave: 'NONE',
-            Workflow: 'NONE'
-          });
-        })
-      ).pipe(Effect.provide(Layer.provide(TraceFlagService.DefaultWithoutDependencies, layer)))
+    const exit = await Effect.gen(function* () {
+      const svc = yield* TraceFlagService;
+      return yield* svc.createDebugLevel({
+        DeveloperName: 'X',
+        MasterLabel: 'X',
+        ApexCode: 'NONE',
+        ApexProfiling: 'NONE',
+        Callout: 'NONE',
+        Database: 'NONE',
+        Nba: 'NONE',
+        System: 'NONE',
+        Validation: 'NONE',
+        Visualforce: 'NONE',
+        Wave: 'NONE',
+        Workflow: 'NONE'
+      });
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(Layer.provide(TraceFlagService.DefaultWithoutDependencies, layer)),
+      Effect.runPromiseExit
     );
 
     expect(exit._tag).toBe('Failure');
@@ -518,26 +520,26 @@ describe('TraceFlagService.createDebugLevel', () => {
       })
     });
 
-    const exit = await Effect.runPromiseExit(
-      Effect.scoped(
-        Effect.gen(function* () {
-          const svc = yield* TraceFlagService;
-          return yield* svc.createDebugLevel({
-            DeveloperName: 'X',
-            MasterLabel: 'X',
-            ApexCode: 'NONE',
-            ApexProfiling: 'NONE',
-            Callout: 'NONE',
-            Database: 'NONE',
-            Nba: 'NONE',
-            System: 'NONE',
-            Validation: 'NONE',
-            Visualforce: 'NONE',
-            Wave: 'NONE',
-            Workflow: 'NONE'
-          });
-        })
-      ).pipe(Effect.provide(Layer.provide(TraceFlagService.DefaultWithoutDependencies, layer)))
+    const exit = await Effect.gen(function* () {
+      const svc = yield* TraceFlagService;
+      return yield* svc.createDebugLevel({
+        DeveloperName: 'X',
+        MasterLabel: 'X',
+        ApexCode: 'NONE',
+        ApexProfiling: 'NONE',
+        Callout: 'NONE',
+        Database: 'NONE',
+        Nba: 'NONE',
+        System: 'NONE',
+        Validation: 'NONE',
+        Visualforce: 'NONE',
+        Wave: 'NONE',
+        Workflow: 'NONE'
+      });
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(Layer.provide(TraceFlagService.DefaultWithoutDependencies, layer)),
+      Effect.runPromiseExit
     );
 
     expect(exit._tag).toBe('Failure');
@@ -570,13 +572,13 @@ describe('TraceFlagService.deleteDebugLevel', () => {
       })
     });
 
-    const exit = await Effect.runPromiseExit(
-      Effect.scoped(
-        Effect.gen(function* () {
-          const svc = yield* TraceFlagService;
-          yield* svc.deleteDebugLevel('dl-9');
-        })
-      ).pipe(Effect.provide(Layer.provide(TraceFlagService.DefaultWithoutDependencies, layer)))
+    const exit = await Effect.gen(function* () {
+      const svc = yield* TraceFlagService;
+      yield* svc.deleteDebugLevel('dl-9');
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(Layer.provide(TraceFlagService.DefaultWithoutDependencies, layer)),
+      Effect.runPromiseExit
     );
 
     expect(exit._tag).toBe('Failure');

--- a/packages/salesforcedx-vscode-services/test/jest/fsService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/fsService.test.ts
@@ -20,7 +20,7 @@ const writeAndGetError = async (): Promise<FsServiceError | undefined> => {
     Effect.flatMap(FsService, fs => fs.writeFile('/out/foo.json', 'x')).pipe(Effect.provide(FsService.Default))
   );
   if (!Exit.isFailure(exit)) return undefined;
-  return Option.getOrUndefined(Cause.failureOption(exit.cause)) as FsServiceError | undefined;
+  return exit.cause.pipe(Cause.failureOption, Option.getOrUndefined) as FsServiceError | undefined;
 };
 
 describe('FsServiceError.message', () => {

--- a/packages/salesforcedx-vscode-services/test/jest/index.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/index.test.ts
@@ -285,8 +285,9 @@ describe('Extension', () => {
     // Test that projectFiles works correctly with proper mocking
     // The function should succeed when dependencies are properly mocked
     await expect(
-      Effect.runPromise(
-        Effect.provide(projectFiles(mockFsProvider), Layer.mergeAll(SettingsService.Default, WorkspaceService.Default))
+      projectFiles(mockFsProvider).pipe(
+        Effect.provide(Layer.mergeAll(SettingsService.Default, WorkspaceService.Default)),
+        Effect.runPromise
       )
     ).resolves.toBeUndefined();
   });

--- a/packages/salesforcedx-vscode-services/test/jest/observability/seedTelemetryIdentities.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/observability/seedTelemetryIdentities.test.ts
@@ -56,7 +56,7 @@ describe('seedTelemetryIdentities', () => {
     await Effect.runPromise(seedTelemetryIdentities().pipe(Effect.provide(layer)));
 
     const ref = await Effect.runPromise(getDefaultOrgRef());
-    const info = await Effect.runPromise(SubscriptionRef.get(ref));
+    const info = await SubscriptionRef.get(ref).pipe(Effect.runPromise);
     expect(info.cliId).toBe(PERSISTED_CLI_ID);
     expect(info.webUserId).toBe(UNAUTHENTICATED_USER);
     expect(update).toHaveBeenCalledWith('telemetryWebUserId', UNAUTHENTICATED_USER);
@@ -109,7 +109,7 @@ describe('seedTelemetryIdentities', () => {
 
     expect(update).not.toHaveBeenCalledWith('telemetryWebUserId', expect.anything());
     const ref = await Effect.runPromise(getDefaultOrgRef());
-    const info = await Effect.runPromise(SubscriptionRef.get(ref));
+    const info = await SubscriptionRef.get(ref).pipe(Effect.runPromise);
     expect(info.webUserId).toBe('sha256-existing');
   });
 });

--- a/packages/salesforcedx-vscode-services/test/jest/terminal/terminalService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/terminal/terminalService.test.ts
@@ -96,7 +96,7 @@ describe('TerminalService.simpleExec', () => {
     }
     expect(capturedSignal.aborted).toBe(false);
 
-    await Effect.runPromise(Fiber.interrupt(fiber));
+    await Fiber.interrupt(fiber).pipe(Effect.runPromise);
     expect(capturedSignal.aborted).toBe(true);
   });
 

--- a/packages/salesforcedx-vscode-soql/src/commands/dataQuery.ts
+++ b/packages/salesforcedx-vscode-soql/src/commands/dataQuery.ts
@@ -99,9 +99,12 @@ export const executeDataQuery = Effect.fn('executeDataQuery')(function* (query: 
     );
   }).pipe(
     Effect.catchAllCause(cause =>
-      channelService
-        .appendToChannel(formatErrorMessage(Cause.squash(cause)))
-        .pipe(Effect.andThen(channelService.showChannel))
+      cause.pipe(
+        Cause.squash,
+        formatErrorMessage,
+        channelService.appendToChannel,
+        Effect.andThen(channelService.showChannel)
+      )
     )
   );
 });

--- a/packages/salesforcedx-vscode-soql/src/commands/queryPlan.ts
+++ b/packages/salesforcedx-vscode-soql/src/commands/queryPlan.ts
@@ -96,7 +96,7 @@ export const executeQueryPlan = Effect.fn('executeQueryPlan')(function* (query: 
     yield* channelService.appendToChannel(`\n${formatQueryPlanResults(result)}\n`);
     yield* channelService.appendToChannel(nls.localize('query_plan_complete'));
   }).pipe(
-    Effect.catchAllCause(cause => channelService.appendToChannel(formatErrorMessage(Cause.squash(cause)))),
+    Effect.catchAllCause(cause => cause.pipe(Cause.squash, formatErrorMessage, channelService.appendToChannel)),
     Effect.ensuring(channelService.showChannel)
   );
 });

--- a/packages/salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts
+++ b/packages/salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts
@@ -113,7 +113,7 @@ export class SOQLEditorInstance {
         Stream.runDrain
       )
     );
-    this.subscriptions.push({ dispose: () => Effect.runFork(Fiber.interrupt(messageFiber)) });
+    this.subscriptions.push({ dispose: () => Fiber.interrupt(messageFiber).pipe(Effect.runFork) });
 
     const { onConnectionChanged, onNoDefaultOrg } = this;
     const connectionFiber = getSoqlRuntime().runFork(
@@ -127,7 +127,7 @@ export class SOQLEditorInstance {
         );
       })
     );
-    this.subscriptions.push({ dispose: () => Effect.runFork(Fiber.interrupt(connectionFiber)) });
+    this.subscriptions.push({ dispose: () => Fiber.interrupt(connectionFiber).pipe(Effect.runFork) });
 
     webviewPanel.onDidDispose(this.dispose, this, this.subscriptions);
   }

--- a/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataViewService.ts
+++ b/packages/salesforcedx-vscode-soql/src/queryDataView/queryDataViewService.ts
@@ -181,7 +181,7 @@ export class QueryDataViewService {
         Stream.runDrain
       )
     );
-    this.subscriptions.push({ dispose: () => Effect.runFork(Fiber.interrupt(messageFiber)) });
+    this.subscriptions.push({ dispose: () => Fiber.interrupt(messageFiber).pipe(Effect.runFork) });
 
     return this.currentPanel.webview;
   }

--- a/plans/W-23520538.md
+++ b/plans/W-23520538.md
@@ -1,0 +1,151 @@
+# W-23520538 — 16 Fix + enforce missedPipeableOpportunity
+
+## Context
+
+- Epic "Effect LS diagnostics: enforce in CI". WI #1 (W-23429440) shipped the ratchet: `scripts/effect-diagnostics.mjs` fails only on findings whose rule is in `config/effect-diagnostics.json` `enforcedRules` (any severity). 18 enforced today (latest sibling: 5 zero-finding rules, W-23429481).
+- Rule `missedPipeableOpportunity` (LS 0.86.2, code 26, group `style`, fixable): flags nested Effect/Schema calls `f(g(pipeable))` that read as `pipeable.pipe(g, f)`.
+- **Default `off`** (`node_modules/@effect/language-service/schema.json` → `missedPipeableOpportunity.default: "off"`). So this needs BOTH edits, per the config's own `$comment`: pin `"error"` in `tsconfig.common.json` `diagnosticSeverity` **and** append to `enforcedRules`. Name-only = silent no-op.
+- Fires when a piping flow has ≥ `pipeableMinArgCount` (default 2) call-kind transformations whose callees are safely pipeable (`transform.js:8424`, `:8475`).
+
+### Measured 2026-07-27 (compiled tree, LS 0.86.2)
+
+`node node_modules/@effect/language-service/cli.js diagnostics --project <tsconfig> --format json --lspconfig '{"diagnosticSeverity":{"missedPipeableOpportunity":"warning"}}'` over all 32 `packages/*/tsconfig.json`:
+
+**src: 43 findings / 8 packages** — WI said 41; soql is 5 not 3 (WI missed `commands/dataQuery.ts:102`, `commands/queryPlan.ts:99`). Per package: services 15, apex-log 11, apex-replay-debugger 5, soql 5, metadata 4, apex-testing 1, apex 1, org-browser 1. Only other repo findings: the 2 pre-existing `unsupportedServiceAccessors` in services (`vscode/fsService.ts:121`, `vscode/settingsService.ts:43`) — no enforced rule covers them, leave alone.
+
+**test: 22 more findings / 5 packages** — every `packages/*/test/tsconfig.json` extends its package tsconfig, so the pin is inherited. The ratchet only globs `src/**/*.ts` (`scripts/effect-diagnostics.mjs:46`), so these never gate — but they light up as red squiggles in every editor. WI-15 precedent (W-23429481) fixed the inherited-pin test fallout in the same commit rather than shipping editor noise. Per package: services 9, apex-oas 6, metadata 5, apex-testing 1, effect-ext-utils 1.
+
+Full site list is in the phases below (line numbers are current HEAD `fd747317f9`; several differ from the WI's — WI's apex-log `logAutoCollect 118,138` is actually 127,149; `traceFlagJsonSync 137` is 138; ard `debugConfigurationProvider 153` is 165; services `index 341` is 345, `cliTelemetry 55` is 57, `fileSystemProvider 145` is 155, `indexedDbStorage 183` is 187, `promptService 241` is 239, `configWatcher 32` is 30).
+
+### Contract verified end to end
+
+Scratch-pinned `warning` in `tsconfig.common.json` + appended the rule to `enforcedRules` → `node scripts/effect-diagnostics.mjs` exits 1, prints `19 rules enforced`, `43 enforced violation(s)`, one `file:line:col` per site. Reverted; tree clean. So the gate is real, not a no-op.
+
+### TRIAGE (the WI's "decide keep-vs-fix") — outcome: fix all 43, suppress none
+
+The WI flags 5 sites as possible keeps: inline multi-line block subjects at checkpointService 424/435/457 and sourceTrackingService 284/345. Trial-applied a hand fix at each cluster, re-measured, typechecked — **all read fine and all clear the rule**, so nothing is kept:
+
+- **checkpointService 424/435/457/559** — `Effect.runSync(lock.withPermits(1)(Effect.sync(() => {…})))` → `Effect.sync(() => {…}).pipe(lock.withPermits(1), Effect.runSync)`. The block body stays a block; only the two wrappers move to the tail. Trial at :424 → apex-replay-debugger drops 5→4, `tsc -p` exit 0. This is exactly the repo's own core principle 2 ("make execution the terminal step, not a wrapper around the expression", `composition-style.md`), so the fix *improves* these sites.
+- **sourceTrackingService 284/345/397/424** — double semaphore: `localSemaphore.withPermits(1)(remoteSemaphore.withPermits(1)(X))` → `X.pipe(remoteSemaphore.withPermits(1), localSemaphore.withPermits(1))`. Order inverts in the pipe because `pipe(x, f, g) === g(f(x))` — inner-first. Trial at :345 → finding cleared, `tsc -p` exit 0, permit nesting order preserved.
+
+So there is no keep-list and no suppression comment in this WI. (`@effect-diagnostics-next-line` / `:skip-file` do work through the CLI — verified by scratch-inserting one at apex `languageServer.ts:146`, finding vanished — but nothing here needs one.)
+
+### Do NOT use `pipeableMinArgCount` to shrink the work
+
+The LS exposes `pipeableMinArgCount` (default 2). Measured: `3` → 2 src findings, `4` → 0. Raising it would "pass" the gate while enforcing essentially nothing. Leave it at its default; the deliverable is 43 real fixes.
+
+### Do NOT blanket-apply the LS quick-fix
+
+`missedPipeableOpportunity_fix` is auto-fixable, but `cli.js quickfixes` previews show it produces worse-or-wrong output on a third of the sites — it reflows to 4-space indent (repo is prettier `printWidth: 120`, 2-space), collapses whole chains onto one 300+ char line, and **relocates preceding comments into the pipe's argument list**:
+
+- `apex-log/statusBar/traceFlagStatusBar.ts:101` — the 4-line comment above the stream lands *inside* `Schedule.fixed(…).pipe(<comment>, Stream.fromSchedule, …)`.
+- `services/index.ts:345` — same, the 5-line reauth-cache comment is swallowed into `ManagedRuntime.make, <comment>, setServicesRuntime`.
+- `soql/commands/dataQuery.ts:102` — inverts to `Effect.andThen(channelService.showChannel)(channelService.appendToChannel(cause.pipe(…)))`, i.e. *adds* a nested call. Strictly worse than the input.
+
+Hand-edit every site. Use the quickfix preview only to confirm which subject the rule wants.
+
+### Fix idioms (each trial-applied + `tsc -p` clean)
+
+1. **Terminal step into the pipe** — `Effect.fork(Stream.fromPubSub(x).pipe(a, b))` → `Stream.fromPubSub(x).pipe(a, b, Effect.fork)`. Covers the `Effect.fork` / `runSync` / `runPromise` / `runFork` / `Runtime.runPromise(runtime)` wrappers. Trial at `services/vscode/configWatcher.ts:30` → cleared, `tsc` 0. Repo core principle 2.
+2. **Hoist a named const for a reused combinator** — `Schema.optional(Schema.Array(itemStruct))` ×5 → one `const ItemArray = Schema.Array(itemStruct)` then `Schema.optional(ItemArray)`. Clears the finding (only 1 call-kind transformation left) **without** inverting to the unidiomatic `itemStruct.pipe(Schema.Array, Schema.optional)`. Trial on all 6 `traceFlagsSchema.ts` sites → apex-log 11→5, `tsc -p` exit 0. Preferred for the schema cluster: repo has 89 `Schema.optional(Schema.X)` call sites and **0** `X.pipe(Schema.optional)`, so inverting would introduce a style with no precedent.
+3. **Unwrap nested wrappers to pipe tail** — the semaphore + `Effect.exit` cases (idiom above; remember inner-first order).
+4. **Plain 2-step data-first pipe** — `Option.isNone(trimmedNamespace(x))` → `trimmedNamespace(x).pipe(Option.isNone)`. Trial at `apex-testing/testDiscovery/packageResolution.ts:193` → apex-testing 1→0, `tsc` 0.
+5. **Test sites** — same idiom 1: `expect(Effect.runPromise(eff))` → `expect(eff.pipe(Effect.runPromise))`. Trial at `effect-ext-utils/test/jest/annotateRootSpan.test.ts:81` → cleared.
+
+Point-free receiver check before using idiom 1/4 on a method (`composition-style.md` §"Point-free terminal step safe ONLY when impl doesn't use `this`"): `channelService.appendToChannel` is a closure over the captured `channel` var, not `this` (`services/src/vscode/channelService.ts:26`, `:54`), so point-free is safe there. `Runtime.runPromise(runtime)` is already applied, so safe.
+
+### Coverage map for the semantic rewrites (measured 2026-07-27, searched not assumed)
+
+The three riskiest edits have **zero jest coverage**:
+
+- `grep -rln 'sourceTrackingService\|checkpointService\|configWatcher' --include='*.test.ts' packages/` → one hit only, `salesforcedx-vscode-org-browser/test/jest/index.test.ts`, whose `describe` is `describe.skip` (line 255) and which stubs `SourceTrackingService.Default` as an opaque mock — never calls the semaphore-wrapped methods.
+- `grep -rn 'watchSettingsService' packages/*/test` → 0 hits.
+- No jest file imports `checkpointService.ts`; `apex-replay-debugger/test/jest/` is 4 files (`getDialogStartingPath`, `anonApexDebug`, `heapDumpOverlayFetch`, `channels/index`) and none touch `lock.withPermits`.
+
+Where the real coverage lives (each spec named in Verification):
+
+| edit | covering spec | runner + org |
+| --- | --- | --- |
+| `checkpointService.ts:424/435/457` (`processBreakpointChangedForCheckpoints`), `:559` (`sfCreateCheckpoints`) | `packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/checkpoints.desktop.spec.ts` — the "toggle checkpoint" step drives the three breakpoint-changed locks; the "update checkpoints in org" step drives the `:559` lock through all 6 progress steps | `npm run test:desktop -w salesforcedx-vscode-apex-replay-debugger` (desktop-only package, no web config); `minimalTestOrg` |
+| `sourceTrackingService.ts:284` (`maybeApplyRemoteDeletesToLocal`), `:345` (`getConflicts`), `:397` (`maybeUpdateTrackingFromRetrieve`), `:424` (`maybeUpdateTrackingFromDeploy`) | `packages/salesforcedx-vscode-metadata/test/playwright/specs/`: `projectRetrieveStart.headless.spec.ts` (`src/commands/retrieveStart/projectRetrieveStart.ts:26` calls `maybeApplyRemoteDeletesToLocal`), `deployOnSave.headless.spec.ts` (`src/services/deployOnSaveService.ts:73` → `getConflicts`), `sourceDiff.headless.spec.ts` (`src/conflict/conflictDetection.ts:33` → `getConflicts`), `projectDeployStart.headless.spec.ts` + `sourceTrackingStatusBar.headless.spec.ts`; `:397`/`:424` are reached via `services/src/core/metadataRetrieveService.ts:174,199,228` and `metadataDeployService.ts:153` | `npm run test:web -w salesforcedx-vscode-metadata` (project `parallel`) and `npm run test:web:conflicts -w salesforcedx-vscode-metadata` (`specs-conflicts/tracking/*`, another `getConflicts` path); `minimalTestOrg` + `orgBrowserDreamhouseTestOrg` (status-bar spec uses `dreamhouseTest`) |
+| `configWatcher.ts:30` (auth-settings `Effect.fork`) | **no automated coverage anywhere.** `watchSettingsService` only runs on web (`services/src/index.ts:237` gates on `ESBUILD_PLATFORM === 'web'`, defined at `scripts/bundling/web.mjs:62`). The three `packages/salesforcedx-vscode-services/test/playwright/specs/retrieveOnLoad*.headless.spec.ts` specs execute the function but assert only the *second* stream's output (`Retrieving metadata on load`); the string `ConfigChanged: Web Auth` appears in no test | `npm run test:web -w salesforcedx-vscode-services` exercises the function but proves nothing about the edited fork — see the explicit flag in Verification |
+
+### Overlap / dedupe
+
+- `references/composition-style.md` core principle 4 already carries this rule's shape as prose judgment: "don't bury it as a nested call arg (`f(g(x))`) — that hides the step". Principle 2 ("make execution the terminal step") is the other half. Mark both machine-enforced; keep the judgment remainder (when to hoist a `const`, receiver safety, `Effect.try` lifting) — no rule covers those.
+- `references/diagnostics-findings.md` is the per-rule finding→fix table; add a row.
+- No `local/` ESLint rule overlaps. Nothing to retire.
+
+## Phases
+
+### Phase 1 — fix the 15 services src sites
+
+- `packages/salesforcedx-vscode-services/src/`, idiom per Context:
+  - idiom 1 (terminal into pipe): `index.ts:345` (`setServicesRuntime` last — keep the 5-line comment above the statement, do not let it migrate into the pipe), `core/metadataDeployService.ts:120`, `core/metadataRetrieveService.ts:145`, `observability/cliTelemetry.ts:57`, `virtualFsProvider/fileSystemProvider.ts:155`, `virtualFsProvider/indexedDbStorage.ts:187`, `vscode/configWatcher.ts:30`, `vscode/prompts/promptService.ts:239`.
+  - idiom 3 (double semaphore → pipe tail, inner-first): `core/sourceTrackingService.ts:284`, `:345`, `:397`, `:424`.
+  - idiom 2 (hoist named const, do NOT invert to `X.pipe(Schema.optional)`): `core/schemas/defaultOrgInfo.ts:12`, `core/schemas/traceFlagSchemas.ts:32`, `core/templateService.ts:97`.
+- `vscode/configWatcher.ts:30` has **no automated coverage** (Coverage map). Keep the edit to the minimum shape change — move `Effect.fork` to the pipe tail, touch nothing else in the stream — and read the diff back against the original nesting; that review is the only check available.
+- Leave the 2 `unsupportedServiceAccessors` findings alone.
+- Re-measure services with the `--lspconfig` command from Context → 0 `missedPipeableOpportunity`.
+- commit: `fix(services): pipe-style nested Effect/Schema calls - W-23520538`
+
+### Phase 2 — fix the 16 apex-log + apex-replay-debugger src sites
+
+- `packages/salesforcedx-vscode-apex-log/src/` (11): idiom 2 for the 6 `schemas/traceFlagsSchema.ts` sites (62/69/76/83/88 share `Schema.Array(itemStruct)`; 97 is `Schema.Array(DebugLevelItemStruct)`); idiom 1 for `traceFlagCleanupScheduler.ts:34`, `logs/logAutoCollect.ts:127`, `:149`, `traceFlags/traceFlagJsonSync.ts:138`, `statusBar/traceFlagStatusBar.ts:101` — the last one's 4-line comment must stay above the stream expression, not inside the pipe args.
+- `packages/salesforcedx-vscode-apex-replay-debugger/src/` (5): idiom 1 for `breakpoints/checkpointService.ts:424`, `:435`, `:457`, `:559` (block bodies stay blocks; `lock.withPermits(1)` then `Effect.runSync` as tail steps) and `adapter/debugConfigurationProvider.ts:165`.
+- commit: `fix(apex-log,apex-replay-debugger): pipe-style nested Effect/Schema calls - W-23520538`
+
+### Phase 3 — fix the remaining 12 src sites
+
+- `packages/salesforcedx-vscode-metadata/src/` (4): `services/deployOnSaveService.ts:146`, `statusBar/sourceTrackingStatusBar.ts:120`, `:155`, `utils/withPreparationProgress.ts:115`.
+- `packages/salesforcedx-vscode-soql/src/` (5): `commands/dataQuery.ts:102`, `commands/queryPlan.ts:99` (both `Cause.squash` → `formatErrorMessage`; do NOT take the quickfix, it re-nests), `editor/soqlEditorInstance.ts:116`, `:130`, `queryDataView/queryDataViewService.ts:184`.
+- `packages/salesforcedx-vscode-apex/src/languageServer.ts:146`, `packages/salesforcedx-vscode-apex-testing/src/testDiscovery/packageResolution.ts:193`, `packages/salesforcedx-vscode-org-browser/src/index.ts:211`.
+- commit: `fix(metadata,soql,apex,apex-testing,org-browser): pipe-style nested Effect/Schema calls - W-23520538`
+
+### Phase 4 — fix the 22 inherited-pin test sites
+
+- Idiom 5 throughout; these don't gate but the pin makes them editor errors.
+- `salesforcedx-vscode-services/test/jest/`: `fsService.test.ts:23`, `index.test.ts:287`, `core/traceFlagService.test.ts:93`, `:489`, `:521`, `:573`, `observability/seedTelemetryIdentities.test.ts:59`, `:112`, `terminal/terminalService.test.ts:99`.
+- `salesforcedx-vscode-apex-oas/test/jest/oas/`: `oasUtils.test.ts:687`, `promptGenerationOrchestrator.test.ts:54`, `:67`, `:85`, `generationStrategy/buildPromptUtils.test.ts:57`, `formatUtils.test.ts:201`.
+- `salesforcedx-vscode-metadata/test/jest/`: `commands/refreshSObjects.test.ts:59`, `conflict/resultStorage.test.ts:141`, `:164`, `:186`, `:221`.
+- `salesforcedx-vscode-apex-testing/test/jest/discoveryVfs/apexTestDiscoveryService.test.ts:51`, `effect-ext-utils/test/jest/annotateRootSpan.test.ts:81`.
+- Assertions and expected values unchanged — pure call-shape edits; the suites must pass untouched.
+- commit: `test(effect): pipe-style nested Effect calls in inherited-pin test sites - W-23520538`
+
+### Phase 5 — pin + enforce the rule, dedupe the skill docs
+
+- `tsconfig.common.json`: add `"missedPipeableOpportunity": "error"` to the existing `@effect/language-service` plugin `diagnosticSeverity` block (6 entries). Leave `pipeableMinArgCount` unset. Prettier will reflow — run it, don't hand-format.
+- `config/effect-diagnostics.json`: append `"missedPipeableOpportunity"` to `enforcedRules` (19 total).
+- `.claude/skills/effect-best-practices/references/diagnostics-findings.md`: add the row, keeping the table's shape — finding: nested Effect/Schema calls `f(g(pipeable))`; fix: `pipeable.pipe(g, f)`, terminal step last; note the hoist-a-`const` alternative when the inner call is a reused schema combinator, and that pipe steps apply inner-first. Add the rule to the file's list of `diagnosticSeverity`-pinned rules.
+- `.claude/skills/effect-best-practices/references/composition-style.md`: annotate core principles 2 and 4 as config-enforced by `missedPipeableOpportunity`; strip prose that only restates the enforced shape. Keep the receiver-safety and `Effect.try`-lifting judgment content. Apply `concise`; no new examples.
+- commit: `chore(effect): pin + enforce missedPipeableOpportunity - W-23520538`
+
+## Skills to apply
+
+- effect-best-practices — rule semantics, LS CLI invocation, the docs being deduped
+- concise — skill-doc edits
+- typescript — per-package conventions
+- work-item-sequencing — 1 rule per sibling WI; touch only this rule's config entry
+- playwright-e2e — the named specs are the real safety net; run/iterate rules (`WIREIT_CACHE=none`, env stripping, background runs, required scratch-org aliases)
+- verification — run the checks below before handoff
+
+## Verification
+
+- `npm run compile` first (the CLI reads cross-package `out/*.d.ts`; missing decls spawn phantom findings), then `npm run check:effect-diagnostics` → exit 0, reports **19 rules enforced**, 19 packages checked, 0 skipped, 0 failed, **0 enforced violation(s)**.
+- Per-package src re-measure after each fix phase, with the `--lspconfig` command in Context: the phase's packages report 0 `missedPipeableOpportunity`, and services still reports only its 2 pre-existing `unsupportedServiceAccessors`. No finding of any other rule appears.
+- Test-side: `node node_modules/@effect/language-service/cli.js diagnostics --project packages/<pkg>/test/tsconfig.json --format json` on the 5 packages from Phase 4 → 0 `missedPipeableOpportunity`, confirming no editor noise from the inherited pin.
+- Negative control (the gate is the deliverable; silent no-op is the failure mode): after Phase 5, re-nest one fixed site (e.g. `apex/src/languageServer.ts:146` back to `Effect.runSync(Ref.make(…))`) → `npm run check:effect-diagnostics` exits 1 naming `missedPipeableOpportunity` + that file:line; revert; `git status` clean.
+- Two-edit contract proof: remove *only* the `tsconfig.common.json` severity while leaving the name in `enforcedRules`, re-add that same scratch re-nesting → gate exits 0 (rule silent, since upstream default is `off`). Confirms the pin is load-bearing; restore both.
+- Behavior-preservation on the risky rewrites, since these are semantic reorderings not formatting. Jest is **not** the safety net here — no jest suite imports `sourceTrackingService.ts`, `checkpointService.ts`, or `configWatcher.ts` (Coverage map). Required runs before handoff:
+  - `npm run test:desktop -w salesforcedx-vscode-apex-replay-debugger -- --retries 0 test/playwright/specs/checkpoints.desktop.spec.ts` (needs `minimalTestOrg`) → both `test.step`s pass, i.e. the toggle-checkpoint gutter glyph appears and `Ended SFDX: Update Checkpoints in Org` reaches the output channel. This is the only check on the `lock.withPermits` unwrap at `:424/:435/:457/:559`.
+  - `npm run test:web -w salesforcedx-vscode-metadata -- --retries 0 test/playwright/specs/projectRetrieveStart.headless.spec.ts test/playwright/specs/projectDeployStart.headless.spec.ts test/playwright/specs/deployOnSave.headless.spec.ts test/playwright/specs/sourceDiff.headless.spec.ts test/playwright/specs/sourceTrackingStatusBar.headless.spec.ts` plus `npm run test:web:conflicts -w salesforcedx-vscode-metadata` (needs `minimalTestOrg` + `orgBrowserDreamhouseTestOrg`) → green. This is the only check on the double-semaphore reorder at `sourceTrackingService.ts:284/:345/:397/:424`; a wrong permit order deadlocks or interleaves and these specs hang or report stale tracking state.
+  - Prefix both with `WIREIT_CACHE=none` (wireit's cache key ignores CLI args) and strip the inherited VS Code env vars per `.claude/skills/playwright-e2e/references/iterating-playwright-tests.md` when running from an extension-host shell; run in background, never block >30s.
+  - `npm run test:web -w salesforcedx-vscode-services -- --retries 0` (the 3 `retrieveOnLoad*` specs) → green. **Flag at handoff:** these do not assert the auth-settings fork edited at `configWatcher.ts:30` — that line has no automated coverage in the repo, and the substitute is diff review of the single moved `Effect.fork`, nothing more. State this in the PR body rather than implying the suite covers it.
+  - `npx jest` on `salesforcedx-vscode-services`, `salesforcedx-vscode-metadata`, `salesforcedx-vscode-soql`, `salesforcedx-vscode-apex`, `salesforcedx-vscode-apex-testing`, `salesforcedx-vscode-apex-oas`, `salesforcedx-vscode-apex-log`, `effect-ext-utils` → green, no snapshot churn. Scope claim: this covers the Phase 4 test-file edits and the sites that do have jest reach (`promptService.ts:239` → `test/jest/vscode/prompts/promptService.test.ts`, `fileSystemProvider.ts:155` → `test/jest/virtualFsProvider/fileSystemProvider.test.ts`, `templateService.ts:97` → `test/jest/core/templateService.test.ts`, `soqlEditorInstance.ts` → `test/jest/editor/soqlEditorProvider.test.ts`, `packageResolution.ts:193` → `test/jest/testDiscovery/packageResolution.test.ts`, `languageServer.ts:146` → `test/jest/languageServer.test.ts`). It says nothing about the three files above.
+  - Read back each semaphore/`withPermits` rewrite and confirm the pipe's inner-first order reproduces the original nesting (`pipe(x, f, g) === g(f(x))`).
+  - `traceFlagsSchema` hoists: `resources/traceFlags.schema.json` is generated (gitignored, `compile` runs `scripts/generateTraceFlagsSchema.ts`). Snapshot the file before Phase 2, re-run `npm run compile -w salesforcedx-vscode-apex-log`, `diff` → byte-identical. Also run `npm run test:web -w salesforcedx-vscode-apex-log -- --retries 0 test/playwright/specs/traceFlagsCrud.headless.spec.ts` (the only thing that exercises `buildTraceFlagsSchemas` encode/decode end to end, via `traceFlagsContentProvider.ts:68` and `traceFlagsCodeLensProvider.ts:43`) → green; `apex-log`'s jest is a single `traceFlags/traceFlagsContentProvider.test.ts` that never calls `buildTraceFlagsSchemas`.
+  - `debugConfigurationProvider.ts:165` (`getRuntime().runPromise` to tail): the edited function is `resolveHeapDumpResults`, called from `resolveDebugConfiguration` (`:110`). `checkpoints.desktop.spec.ts`'s "launch replay against the heap-dump log" step asserts the adapter received `heapDumpResults` (zero Debug Console rows matching `heap_dump_error_wrap_up_text`), so the same required run above covers it; `test/jest/services/heapDumpOverlayFetch.test.ts` covers only the inner effect, not the moved tail.
+- `npx tsc -p packages/<pkg>/tsconfig.json --noEmit` per touched package → exit 0 (also implied by `npm run compile`).
+- `npx prettier --check` on every edited file; `npm run lint` → no new errors/warnings on edited files.
+- No comment was relocated into a pipe argument list: `git diff` review of `traceFlagStatusBar.ts`, `services/index.ts`, `configWatcher.ts`, `dataQuery.ts`.
+- `npm run precommit` green (includes `check:effect-diagnostics`).

--- a/tsconfig.common.json
+++ b/tsconfig.common.json
@@ -31,7 +31,8 @@
           "globalRandom": "error",
           "globalRandomInEffect": "error",
           "globalFetchInEffect": "error",
-          "globalTimersInEffect": "error"
+          "globalTimersInEffect": "error",
+          "missedPipeableOpportunity": "error"
         }
       },
       { "name": "@salesforce/vscode-i18n/tsPlugin" }


### PR DESCRIPTION
### What does this PR do?

Fixes all 43 real `missedPipeableOpportunity` findings repo-wide, then pins and enforces the rule so it can't regress. Nested Effect/Schema calls like `f(g(pipeable))` become `pipeable.pipe(g, f)`, with the terminal step (`Effect.runSync`, `Effect.fork`, semaphore `withPermits`, etc.) moved to the pipe tail — this is a call-shape rewrite only, no semantics change.

- **src (43 sites / 8 packages)**: services (15), apex-log (11), apex-replay-debugger (5), soql (5), metadata (4), apex-testing (1), apex (1), org-browser (1). Idioms used: terminal-step-into-pipe (`Effect.fork`/`runSync`/`runPromise` wrappers), hoisting a named `const` for a reused Schema combinator (the `traceFlagsSchema.ts` cluster — avoids introducing an unprecedented `X.pipe(Schema.optional)` style), unwrapping nested semaphore wrappers to the pipe tail (inner-first order preserved: `pipe(x, f, g) === g(f(x))`), and plain 2-step data-first pipes.
- **test (22 more sites / 5 packages)**: these don't gate the ratchet (`scripts/effect-diagnostics.mjs` only globs `src/**/*.ts`) but every `test/tsconfig.json` inherits the pin, so they were red-squiggling in-editor. Fixed for editor cleanliness, same idiom, assertions untouched.
- **Config**: `tsconfig.common.json` pins `missedPipeableOpportunity: "error"` in the `@effect/language-service` plugin's `diagnosticSeverity` block (rule ships `default: "off"` upstream); `config/effect-diagnostics.json` appends the rule to `enforcedRules` (19 total). Both edits are required — the rule needs the severity pin or its `enforcedRules` entry is a silent no-op.
- Docs: `.claude/skills/effect-best-practices/references/diagnostics-findings.md` gains the finding→fix row; `composition-style.md` marks core principles 2 and 4 as now machine-enforced and trims the prose that only restated the enforced shape.
- The LS's own auto-quickfix was **not** used — it reflows to 4-space indent (repo is 2-space/printWidth 120), collapses chains onto one long line, and on several sites relocates a preceding comment into the pipe's argument list (`traceFlagStatusBar.ts`, `services/index.ts`, `soql/dataQuery.ts`). Every site was hand-edited instead.

### Plan

[`plans/W-23520538.md`](https://github.com/forcedotcom/salesforcedx-vscode/blob/sm/W-23520538-16-fix-enforce-missedpipeableopportunity/plans/W-23520538.md)

### Reviewer notes

- **The WI's site count and line numbers were stale.** Actual measurement: 43 src findings, not 41 — soql is 5, not 3 (WI missed `dataQuery.ts:102` and `queryPlan.ts:99`). Several other line numbers had drifted from what the WI cited; the plan's Context section lists the corrections.
- **No sites were suppressed or kept as-is.** The WI flagged `checkpointService.ts` and `sourceTrackingService.ts` as candidates for a keep-list (inline multi-line block subjects). All were trial-fixed, re-measured, and typechecked clean, so every one of the 43 was fixed — no `@effect-diagnostics-next-line`/`:skip-file` comment anywhere in this diff.
- **Double-semaphore reorder in `sourceTrackingService.ts` (`:284/:345/:397/:424`) and the `checkpointService.ts` lock unwraps (`:424/:435/:457/:559`) have zero jest coverage** — no jest file imports either module. These were verified only by: (1) read-back of pipe inner-first order against the original nesting, and (2) the targeted Playwright specs named in the Test plan below. Treat those specs as load-bearing for this PR, not incidental.
- **`configWatcher.ts:30` (the auth-settings `Effect.fork`) has no automated coverage in the repo at all** — it only runs on the web bundle, and the specs that do execute the function assert on a different, unrelated stream's output. The substitute is diff review of the single moved `Effect.fork`; nothing else changed on that line.
- **`traceFlagsSchema.ts`**: 5 of the 6 sites shared `Schema.Array(itemStruct)`, hoisted to one named const rather than inverted to `itemStruct.pipe(Schema.Array, Schema.optional)` — the repo has 89 `Schema.optional(Schema.X)` call sites and 0 of the inverted form, so inverting would introduce a style with no precedent. Confirmed the generated `resources/traceFlags.schema.json` (gitignored, built by `scripts/generateTraceFlagsSchema.ts`) is byte-identical before/after.
- **Comment placement was checked by hand** on every site the plan flagged as quickfix-corrupting (`traceFlagStatusBar.ts:101`, `services/index.ts:345`, `configWatcher.ts:30`, `soql/dataQuery.ts:102`) — no comment moved into a pipe argument list.
- No findings were verified-and-deferred; nothing in this diff was left out.

### What issues does this PR fix or reference?
@W-23520538@

### Test plan

Most of this is covered by CI:

- `check-effect-diagnostics` in `.github/workflows/validatePR.yml` runs `npm run check:effect-diagnostics` — the gate this PR extends to 19 enforced rules, 0 violations.
- `code-quality` in the same workflow runs `npm run lint`; prettier and `tsc` run as part of `precommit`/`compile`. All edited files pass with no new errors.
- `unitTestsWindows.yml` / the standard jest run cover the Phase 4 test-file edits and every src site jest actually reaches (`promptService.ts`, `fileSystemProvider.ts`, `templateService.ts`, `soqlEditorInstance.ts`, `packageResolution.ts`, `languageServer.ts`, `traceFlagsSchema.ts`'s consumers) — green, no snapshot churn.

Not covered by CI, and worth a manual look before merge:

- The `sourceTrackingService.ts` double-semaphore reorder and the `checkpointService.ts` lock unwraps have no jest coverage. This repo's Playwright suite (not run automatically on every PR) is the real check: `salesforcedx-vscode-apex-replay-debugger`'s `checkpoints.desktop.spec.ts` (needs `minimalTestOrg`) for the checkpoint locks; `salesforcedx-vscode-metadata`'s `projectRetrieveStart.headless.spec.ts`, `deployOnSave.headless.spec.ts`, `sourceDiff.headless.spec.ts`, `projectDeployStart.headless.spec.ts`, `sourceTrackingStatusBar.headless.spec.ts` plus `test:web:conflicts` (needs `minimalTestOrg` + `orgBrowserDreamhouseTestOrg`) for the semaphore reorder.
- `configWatcher.ts:30` has no automated coverage anywhere (see Reviewer notes) — if reviewing, diff-review that single line change directly.
- If you want to see the ratchet actually bite: re-nest any fixed site (e.g. put `languageServer.ts:146` back to `Effect.runSync(Ref.make(...))`) and run `npm run compile && npm run check:effect-diagnostics` — should exit 1 naming `missedPipeableOpportunity` and the file:line.

### References

- Work item W-23520538
- `@effect/language-service` 0.86.2 — `missedPipeableOpportunity` (code 26, group `style`), default `off` per `node_modules/@effect/language-service/schema.json`
- Epic "Effect LS diagnostics: enforce in CI"; ratchet introduced by W-23429440; sibling W-23429481 (#7907) fixed the same inherited-pin test pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)
