### PR TITLE
fix(playwright): support renamed macOS VS Code executable - W-23630140

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "@types/xml2js": "0.4.14",
         "@typescript-eslint/eslint-plugin": "^8.65.0",
         "@typescript-eslint/parser": "^8.65.0",
-        "@vscode/test-electron": "2.5.2",
+        "@vscode/test-electron": "3.1.0",
         "@vscode/test-web": "^0.0.81",
         "@vscode/vsce": "3.5.0",
         "acorn": "8.15.0",
@@ -11290,9 +11290,9 @@
       "license": "MIT"
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+      "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
       "license": "MIT",
       "dependencies": {
         "http-proxy-agent": "^7.0.2",
@@ -11302,7 +11302,7 @@
         "semver": "^7.6.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@vscode/test-electron/node_modules/https-proxy-agent": {
@@ -43947,7 +43947,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@playwright/test": "^1.60.0",
-        "@vscode/test-electron": "2.5.2",
+        "@vscode/test-electron": "3.1.0",
         "@vscode/test-web": "^0.0.81"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@types/xml2js": "0.4.14",
     "@typescript-eslint/eslint-plugin": "^8.65.0",
     "@typescript-eslint/parser": "^8.65.0",
-    "@vscode/test-electron": "2.5.2",
+    "@vscode/test-electron": "3.1.0",
     "@vscode/test-web": "^0.0.81",
     "@vscode/vsce": "3.5.0",
     "acorn": "8.15.0",

--- a/packages/playwright-vscode-ext/package.json
+++ b/packages/playwright-vscode-ext/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@playwright/test": "^1.60.0",
-    "@vscode/test-electron": "2.5.2",
+    "@vscode/test-electron": "3.1.0",
     "@vscode/test-web": "^0.0.81"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- upgrade `@vscode/test-electron` from 2.5.2 to 3.1.0
- support VS Code 1.131 macOS bundles after removal of the legacy `Contents/MacOS/Electron` executable alias
- keep the root and Playwright helper dependency declarations synchronized

## Testing

- `npm run lint -w @salesforce/playwright-vscode-ext`
- `npm run compile -w @salesforce/playwright-vscode-ext`
- local macOS desktop launch resolves VS Code 1.131 through `Contents/MacOS/Code`; 43 tests passed and 1 skipped, with one unrelated dirty-indicator timing failure
- the identical dependency patch passed Core E2E on macOS, Ubuntu, and Windows: https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/30459201815
- repository pre-commit and pre-push workflows

Work item: https://gus.lightning.force.com/a07EE00002g6PJYYA2 @W-23630140@