### PR TITLE
refactor(apex): orphan handler follow-ups — dedupe kill path, inter-check delay, harden settings persist - W-23251304

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/languageServerOrphanHandler.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageServerOrphanHandler.ts
@@ -142,23 +142,9 @@ const findOrphanedProcessesSafe = Effect.fn('apex.orphan.findOrphanedSafe')(func
   );
 });
 
-export const checkAndResolveOrphanedLanguageServers = Effect.fn('apex.orphan.checkAndResolve')(function* (
-  numTries = 3
-) {
-  // Check up to numTries times: processes may self-exit between checks
-  // (e.g. a previous session's LSP completing its own graceful shutdown).
-  let confirmedOrphans: ProcessDetail[] = [];
-  for (let i = 1; i <= numTries; i++) {
-    confirmedOrphans = yield* findOrphanedProcessesSafe();
-    if (confirmedOrphans.length === 0) {
-      yield* annotateRootSpan('orphanCount', 0);
-      return;
-    }
-  }
-  yield* annotateRootSpan('orphanCount', confirmedOrphans.length);
-
-  // When auto-terminate is enabled, silently kill orphans without prompting.
-  const autoTerminate = yield* Effect.gen(function* () {
+/** Read the auto-terminate setting; any failure (missing setting / services unavailable) degrades to false. */
+const isAutoTerminateEnabled = Effect.fn('apex.orphan.isAutoTerminateEnabled')(function* () {
+  return yield* Effect.gen(function* () {
     const api = yield* (yield* ExtensionProviderService).getServicesApi;
     return yield* (yield* api.services.SettingsService).getValue<boolean>(
       APEX_SETTINGS_SECTION,
@@ -173,24 +159,41 @@ export const checkAndResolveOrphanedLanguageServers = Effect.fn('apex.orphan.che
       InvalidServicesApiError: () => Effect.succeed(false)
     })
   );
+});
 
-  if (autoTerminate) {
-    yield* annotateRootSpan('didTerminate', 1);
-    yield* Effect.forEach(confirmedOrphans, killOne, { concurrency: 1 });
-    return;
+export const checkAndResolveOrphanedLanguageServers = Effect.fn('apex.orphan.checkAndResolve')(function* (
+  numTries = 3,
+  delayBetweenTriesMs = 2000
+) {
+  // Check up to numTries times, pausing between checks: a process may self-exit between checks
+  // (e.g. a previous session's LSP completing its own graceful shutdown, which can take a second
+  // or more). The delay gives that shutdown time to finish so an already-exiting server isn't
+  // mistaken for a confirmed orphan. Runs on a background fiber, so the wait never blocks activation.
+  let confirmedOrphans: ProcessDetail[] = [];
+  for (let i = 1; i <= numTries; i++) {
+    if (i > 1) {
+      yield* Effect.sleep(delayBetweenTriesMs);
+    }
+    confirmedOrphans = yield* findOrphanedProcessesSafe();
+    if (confirmedOrphans.length === 0) {
+      yield* annotateRootSpan('orphanCount', 0);
+      return;
+    }
   }
+  yield* annotateRootSpan('orphanCount', confirmedOrphans.length);
 
-  const shouldTerminate = yield* getResolutionForOrphanProcesses(confirmedOrphans).pipe(
-    Effect.catchTag('UserCancellationError', () => Effect.succeed(false))
-  );
+  // When auto-terminate is enabled, kill silently; otherwise ask the user.
+  const shouldTerminate = (yield* isAutoTerminateEnabled())
+    ? true
+    : yield* getResolutionForOrphanProcesses(confirmedOrphans).pipe(
+        Effect.catchTag('UserCancellationError', () => Effect.succeed(false))
+      );
 
   yield* annotateRootSpan('didTerminate', shouldTerminate ? 1 : 0);
 
-  if (!shouldTerminate) {
-    return;
+  if (shouldTerminate) {
+    yield* Effect.forEach(confirmedOrphans, killOne, { concurrency: 1 });
   }
-
-  yield* Effect.forEach(confirmedOrphans, killOne, { concurrency: 1 });
 });
 
 /** 'continue' = re-prompt (user asked to view the process table); boolean = terminal decision */
@@ -295,12 +298,18 @@ const alwaysAutoTerminateConfirmation = Effect.fn('apex.orphan.alwaysAutoTermina
   if (choice !== nls.localize('confirm')) {
     return false;
   }
-  const api = yield* (yield* ExtensionProviderService).getServicesApi;
-  // Intentional: swallow MissingSettingsError after recording telemetry — graceful degradation
-  // ensures the kill still proceeds even if the setting write fails to persist.
-  yield* (yield* api.services.SettingsService)
-    .setValue(APEX_SETTINGS_SECTION, AUTO_TERMINATE_KEY, true)
-    .pipe(Effect.catchTag('MissingSettingsError', e => annotateRootSpan('settingsWriteError', e.message)));
+  // Persist the setting, then kill. Any failure — write error or services unavailable — is recorded
+  // but non-fatal: the user already confirmed, so the kill proceeds regardless of whether the write stuck.
+  yield* Effect.gen(function* () {
+    const api = yield* (yield* ExtensionProviderService).getServicesApi;
+    yield* (yield* api.services.SettingsService).setValue(APEX_SETTINGS_SECTION, AUTO_TERMINATE_KEY, true);
+  }).pipe(
+    Effect.catchTags({
+      MissingSettingsError: e => annotateRootSpan('settingsWriteError', e.message),
+      ServicesExtensionNotFoundError: e => annotateRootSpan('settingsWriteError', String(e)),
+      InvalidServicesApiError: e => annotateRootSpan('settingsWriteError', e.cause?.message ?? String(e))
+    })
+  );
   return true;
 });
 

--- a/packages/salesforcedx-vscode-apex/test/jest/languageServerOrphanHandler.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/languageServerOrphanHandler.test.ts
@@ -147,7 +147,9 @@ const run = (
   const { checkAndResolveOrphanedLanguageServers, Provider } = loadHandler('darwin');
   return Effect.runPromise(
     (
-      checkAndResolveOrphanedLanguageServers().pipe(provide(Provider, responses, settingsStub)) as Effect.Effect<void>
+      checkAndResolveOrphanedLanguageServers(3, 0).pipe(
+        provide(Provider, responses, settingsStub)
+      ) as Effect.Effect<void>
     ).pipe(captureRoot(holder))
   );
 };
@@ -174,7 +176,7 @@ const runWithClock = (
     Effect.gen(function* () {
       holder.root = yield* Effect.currentSpan;
       const fiber = yield* Effect.fork(
-        checkAndResolveOrphanedLanguageServers().pipe(provide(Provider, responses, settingsStub))
+        checkAndResolveOrphanedLanguageServers(3, 0).pipe(provide(Provider, responses, settingsStub))
       );
       yield* TestClock.adjust(Duration.seconds(KILL_RETRY_TOTAL_SECONDS + 1));
       return yield* Fiber.join(fiber);
@@ -268,7 +270,7 @@ describe('languageServerOrphanHandler', () => {
       }
     };
     await Effect.runPromise(
-      checkAndResolveOrphanedLanguageServers().pipe(
+      checkAndResolveOrphanedLanguageServers(3, 0).pipe(
         Effect.provideService(Provider, { getServicesApi: Effect.succeed(api) } as unknown as ExtensionProviderService)
       ) as Effect.Effect<void>
     );


### PR DESCRIPTION
### What does this PR do?

Follow-up review fixes on top of #7643 (targets that branch, not `develop`).

- **Dedupe the kill path.** The auto-terminate arm and the user-prompt arm both ended in an identical `Effect.forEach(confirmedOrphans, killOne, …)`. Collapsed into a single `shouldTerminate` boolean so orphans are killed in exactly one place. Extracted the setting read into an `isAutoTerminateEnabled` helper.
- **Wait between orphan re-checks.** `checkAndResolveOrphanedLanguageServers` gains a `delayBetweenTriesMs` parameter (default `2000`). Without a gap, the three checks fired within milliseconds, so a previous session's LSP still completing its (JVM, ~1s+) graceful shutdown was observed as orphaned on every try and still triggered a false-positive prompt. The delay spans the shutdown window; it runs on a background fiber, so activation is never blocked.
- **Harden the settings persist.** `alwaysAutoTerminateConfirmation` re-resolves `getServicesApi` but only caught `MissingSettingsError`. A `ServicesExtensionNotFoundError` / `InvalidServicesApiError` from that resolution would escape and fail the fiber, so the kill would *not* proceed — contradicting the "graceful degradation ensures the kill still proceeds" intent. Now all three tags are recorded on the span and swallowed; the kill proceeds after the user confirms.

### Functionality Before

- Two separate `killOne` loops for the auto-terminate vs. prompt paths.
- Orphan re-checks ran back-to-back, so a gracefully-shutting-down LSP from the prior session could still be flagged as an orphan.
- If services were unavailable when persisting the setting after the user confirmed, the fiber failed and the kill was skipped.

### Functionality After

- Single kill site gated by one `shouldTerminate` boolean.
- Re-checks pause (default 2s) so an exiting server is seen gone and no prompt appears.
- Setting-persist failures of any kind are recorded but non-fatal; the confirmed kill always proceeds.

### What issues does this PR fix or reference?

@W-23251304@

---

Tests: all 14 `languageServerOrphanHandler` jest tests pass; helpers inject `0`ms delay to keep runs fast. Typecheck clean.