### PR TITLE
fix(security): bump @salesforce/templates to ^66.15.3 to prevent malicious templates - W-23595931

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9157,9 +9157,9 @@
       }
     },
     "node_modules/@salesforce/templates": {
-      "version": "66.13.4",
-      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-66.13.4.tgz",
-      "integrity": "sha512-5oiSM1jBbGHd1ianBYOxuOPvaOhkDERzw0O5ILg0PNsQUfs4erd3XTWRQWAJQgsmgzh40BF3DoU/Dzu/efv48Q==",
+      "version": "66.13.5",
+      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-66.13.5.tgz",
+      "integrity": "sha512-KooKEUjAYhzX6F9kWyV6eB81Nw9UaIYV0rYHitgdqSJ1JZN/vnqCuryuEM47Hss8d3xuE7cF2IFTrF9YLVS+DA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/kit": "^3.2.6",
@@ -44704,7 +44704,7 @@
         "@salesforce/o11y-reporter": "^1.8.5",
         "@salesforce/salesforcedx-utils-vscode": "*",
         "@salesforce/source-deploy-retrieve": "^12.37.2",
-        "@salesforce/templates": "^66.13.4",
+        "@salesforce/templates": "^66.13.5",
         "@salesforce/ts-types": "^2.0.12",
         "@salesforce/vscode-i18n": "*",
         "@salesforce/vscode-service-provider": "^1.5.0",
@@ -44885,7 +44885,7 @@
         "@salesforce/o11y-reporter": "^1.8.5",
         "@salesforce/source-deploy-retrieve": "^12.37.2",
         "@salesforce/source-tracking": "^7.8.16",
-        "@salesforce/templates": "^66.13.4",
+        "@salesforce/templates": "^66.13.5",
         "@salesforce/vscode-i18n": "*",
         "@vscode/extension-telemetry": "^1.0.0",
         "effect": "^3.21.2",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -33,7 +33,7 @@
     "@salesforce/o11y-reporter": "^1.8.5",
     "@salesforce/salesforcedx-utils-vscode": "*",
     "@salesforce/source-deploy-retrieve": "^12.37.2",
-    "@salesforce/templates": "^66.13.4",
+    "@salesforce/templates": "^66.13.5",
     "@salesforce/ts-types": "^2.0.12",
     "@salesforce/vscode-i18n": "*",
     "@salesforce/vscode-service-provider": "^1.5.0",

--- a/packages/salesforcedx-vscode-services/package.json
+++ b/packages/salesforcedx-vscode-services/package.json
@@ -44,7 +44,7 @@
     "@salesforce/o11y-reporter": "^1.8.5",
     "@salesforce/source-deploy-retrieve": "^12.37.2",
     "@salesforce/source-tracking": "^7.8.16",
-    "@salesforce/templates": "^66.13.4",
+    "@salesforce/templates": "^66.13.5",
     "@salesforce/vscode-i18n": "*",
     "@vscode/extension-telemetry": "^1.0.0",
     "effect": "^3.21.2",


### PR DESCRIPTION
### What does this PR do?
Paired with https://github.com/forcedotcom/salesforcedx-templates/pull/875 to get the latest version of the shared library that contains the fix into the main extensions repo.

### What issues does this PR fix or reference?
@W-23595931@
