### PR TITLE
fix(ci): exclude nightly tags when finding previous release

### DIFF
--- a/scripts/create-release-notes.ts
+++ b/scripts/create-release-notes.ts
@@ -42,11 +42,23 @@ function getCurrentRemoteReleaseBranch(): string {
  */
 function getPreviousRemoteReleaseBranch(): string {
   logger('\nStep 2: Getting latest tag to compare last published version');
-  // Match only top-level extension release tags (e.g. v66.5.4), excluding
-  // subpackage tags like `vscode-i18n-v66.7.0` or `soql-common-v2.0.0`.
-  const latestReleasedTag = execSync("git describe --tags --abbrev=0 --match 'v[0-9]*'", {
+  // Match only top-level extension release tags (e.g. v66.5.4), excluding:
+  // - subpackage tags like `vscode-i18n-v66.7.0` or `soql-common-v2.0.0`
+  // - nightly prerelease tags like `v67.7.2-nightly.develop.20260803`
+  // Get all matching tags, sorted by version, then filter out nightly tags
+  const allTags = execSync("git tag --list 'v[0-9]*' --sort=-version:refname", {
     encoding: 'utf8'
-  }).trim();
+  })
+    .trim()
+    .split('\n')
+    .filter(tag => tag && !tag.includes('-nightly.'));
+
+  if (allTags.length === 0) {
+    console.error('No stable release tags found');
+    process.exit(1);
+  }
+
+  const latestReleasedTag = allTags[0];
   const latestReleasedBranchName = `${constants.REMOTE_RELEASE_BRANCH_PREFIX_NO_VERSION}/${latestReleasedTag}`;
   validateReleaseBranch(latestReleasedBranchName);
   return latestReleasedBranchName;


### PR DESCRIPTION
The changelog generation script was failing because git describe was returning nightly prerelease tags (e.g., v67.7.2-nightly.develop.20260803) which don't have corresponding release branches.

Changed getPreviousRemoteReleaseBranch() to:
- Use git tag --list with --sort=-version:refname for all v* tags
- Filter out tags containing '-nightly.' to exclude prerelease versions
- Fall back to the first stable release tag

This fixes the "Create Release Branch" workflow failure where the script attempted to compare against a non-existent nightly release branch.

Related: #7790 (nightly prerelease workflow)

<!--- PR title: <type>(optional scope): <description> - W-XXXXXXXX — append GUS work item at the end (space, hyphen, space, W-). Conventional commits: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?

### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @<Insert GUS WI>@

### Functionality Before
<insert gif and/or summary>

### Functionality After
<insert gif and/or summary>
