### PR TITLE
refactor(services): simplify execute anonymous SOAP namespaces - W-23693396

### DIFF
--- a/.claude/plans/W-23580889.md
+++ b/.claude/plans/W-23580889.md
@@ -1,0 +1,58 @@
+# W-23580889: Replace ARD anonymous-Apex sentinels
+
+## Approach
+
+Convert `sf.anon.apex.debug.delegate` to a runtime-registered Effect command. Read the active editor once through `EditorService.getActiveEditorContext(true)`, execute its current selection or full in-memory document text, and let typed service failures reach the standard command boundary. Keep compile/runtime-result reporting and launch behavior, but use `void` command completion rather than boolean success sentinels.
+
+## Evidence
+
+- `packages/salesforcedx-vscode-apex-replay-debugger/src/commands/anonApexDebug.ts:41-90` defines the duplicate editor context union/helper, checks an empty workspace, reads saved files from disk, and returns `undefined`/`false` sentinels.
+- `packages/salesforcedx-vscode-services/src/vscode/editorService.ts:54-68` returns text, document URI, and selection start coordinates, or fails with `NoActiveEditorError`.
+- `packages/salesforcedx-vscode-services/src/core/projectService.ts:215-225` builds the debug-log folder from `WorkspaceService.getWorkspaceInfoOrThrow()`, so no separate workspace guard or new log-storage helper is required.
+- `packages/salesforcedx-vscode-services/src/vscode/registerCommand.ts:58-77` runs commands on the shared runtime, silently handles `UserCancellationError`, and routes all other typed failures, including `NoActiveEditorError` and `NoWorkspaceOpenError`, through `ErrorHandlerService`.
+- `packages/salesforcedx-vscode-apex-log/src/commands/executeAnonymous.ts:49-71` is the matching `EditorService` plus `PromptService.withProgress` command pattern.
+
+## Phases
+
+### Phase 1: Make anonymous Apex debugging one Effect command
+
+- Refactor `packages/salesforcedx-vscode-apex-replay-debugger/src/commands/anonApexDebug.ts` to export an `Effect.fn` command instead of an async `withProgress`/`runPromise` boundary.
+- Delete `AnonApexContext` and `getAnonApexContext`; call `api.services.EditorService.getActiveEditorContext(true)` so a non-empty selection is used and all other editors supply their current full document text.
+- Pass `context.text`, `context.documentUri`, and `context.selectionRange?.startLine` directly to execute/report operations. Remove the dirty/untitled/file branches, `FsService.readFile`, and their URI conversion imports.
+- Resolve `PromptService` and wrap execution, result reporting, successful log save, and replay-debugger launch with `withProgress(nls.localize('apex_execute_text'))`; show the existing localized success notification afterward so the spinner settles before user interaction.
+- Preserve unsuccessful compile/runtime reporting without launching the debugger or showing the success notification. Remove boolean returns from `launchReplayDebugger` and command flow; service and command failures remain typed Effect failures.
+- Keep `ProjectService.getDebugLogsFolder()` for log placement because it already fails through `getWorkspaceInfoOrThrow()`; remove only the redundant up-front `getWorkspaceInfo().isEmpty` check.
+
+### Phase 2: Register the Effect boundary
+
+- Convert `registerCommands` in `packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts` to `Effect.fn`, resolve the services API there, create `registerCommandWithRuntime(getRuntime())`, and register `sf.anon.apex.debug.delegate` with the Effect command. Update `activateEffect` to yield this registration effect.
+- Preserve the other imperative registrations and returned disposable. Update `launchApexReplayDebuggerWithCurrentFile.ts` to invoke the delegate through `vscode.commands.executeCommand` for anonymous Apex files, avoiding a second runtime boundary and keeping command error handling centralized.
+- Retain existing localized success/progress messages. Remove the command-specific catch/error notification path; standard `ErrorHandlerService` displays typed failures, while runtime registration owns `UserCancellationError`.
+
+### Phase 3: Verify readiness
+
+- Keep `test/jest/commands/anonApexDebug.test.ts` unchanged: it covers only retained pure date helpers, and repository policy excludes simultaneous `/src` and `/test` changes for this source refactor.
+- Run `npm run test -w salesforcedx-vscode-apex-replay-debugger` for the retained helper coverage and package compile dependency.
+- Run `npm run check:dupes`; inspect findings involving changed code.
+- Run `effect-advocate` against the diff, then run Effect Language Service diagnostics for the changed TypeScript files.
+- Run the repository readiness hook; require compile, lint, Effect diagnostics, Jest, VS Code bundle, and knip to pass before implementation is reported complete.
+- Inspect the final diff for removal of `getAnonApexContext`, `AnonApexContext`, direct `vscode.window.withProgress`, the command-level `.catch()`, `FsService.readFile`, and boolean command sentinels.
+
+## Applicable Skills
+
+- `concise`: focused tracked plan.
+- `typescript`: inferred editor context, imports, and `void` command flow.
+- `effect-best-practices`: `Effect.fn`, typed failure propagation, and Effect diagnostics.
+- `services-extension-consumption`: `EditorService`, `PromptService`, shared runtime registration, and existing `ProjectService` behavior.
+- `vscode-window-messages`: preserve localized success notification semantics while removing bespoke error display.
+- `verification`: source/test separation, focused Jest, duplicate detection, and readiness gates.
+
+## Verification
+
+- `npm run test -w salesforcedx-vscode-apex-replay-debugger`
+- `npm run check:dupes`
+- Effect advocate review and Effect Language Service diagnostics for changed TypeScript files
+- Repository readiness hook: compile, lint, Effect diagnostics, tests, `vscode:bundle`, and knip
+- Final scoped diff and `git diff --check -- .claude/plans/W-23580889.md`
+
+<!-- opencode-plan-evidence:{"planPath":".claude/plans/W-23580889.md","observedRevision":"2026-08-03T20:57:53.000+0000","summary":{"phases":["Refactor ARD anonymous-Apex debugging into one Effect command using `EditorService.getActiveEditorContext(true)`, in-memory editor text, `PromptService.withProgress`, typed failures, and void completion instead of context/boolean sentinels.","Convert command registration to Effect, register through `registerCommandWithRuntime(getRuntime())`, and route the current-file anonymous-Apex path through the registered delegate so standard cancellation and error handling own the boundary.","Keep the source-only test boundary; run focused Jest, duplicate detection, Effect review/diagnostics, final diff checks, and repository readiness hooks after implementation."],"skills":["concise","typescript","effect-best-practices","services-extension-consumption","vscode-window-messages","verification"],"verification":["Inspected the ARD command and registration, current-file caller, EditorService, ProjectService, standard command registrar/error handler, apex-log precedent, package scripts, existing tests, and repository readiness hook implementation.","Updated and reread `.claude/plans/W-23580889.md`; synchronized its tracked evidence to revision `2026-08-03T20:57:53.000+0000`.","Plan requires focused Jest, duplicate detection, Effect review/diagnostics, final diff inspection, and passing repository readiness hooks before implementation is reported complete."]}} -->

--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,7 @@ packages/salesforcedx-vscode-services/resources/
 .edit-marker
 npm-packages-offline-cache/
 .prettier-cache
+graphify-out/
 
 # Claude Code worktrees
 .claude/worktrees/

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/anonApexDebug.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/anonApexDebug.ts
@@ -10,7 +10,6 @@ import { format } from 'node:util';
 import * as vscode from 'vscode';
 import { URI, Utils } from 'vscode-uri';
 import { nls } from '../messages';
-import { getRuntime } from '../services/runtime';
 
 export const makeDoubleDigit = (currentDigit: number): string => format('%d', currentDigit).padStart(2, '0');
 
@@ -27,80 +26,40 @@ export const getYYYYMMddHHmmssDateFormat = (localUTCDate: Date): string => {
 /** safeWriteFile creates the parent directory, so no separate createDirectory call is needed. */
 const launchReplayDebugger = Effect.fn('ApexReplayDebugger.launchReplayDebugger')(function* (
   logFilePath: URI,
-  logs?: string
+  logs: string
 ) {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
-  if (!logs) return false;
   yield* api.services.FsService.safeWriteFile(logFilePath, logs);
   yield* Effect.promise(() =>
     vscode.commands.executeCommand('sf.launch.replay.debugger.logfile.path', logFilePath.fsPath)
   );
-  return true;
 });
 
-type AnonApexContext =
-  | { kind: 'code'; apexCode: string; selectionRange?: vscode.Range; documentUri: URI }
-  | { kind: 'file'; filePath: string; documentUri: URI };
-
-const getAnonApexContext = Effect.fn('ApexReplayDebugger.getAnonApexContext')(function* () {
+export const anonApexDebugCommand = Effect.fn('ApexReplayDebugger.Command.anonApexDebug')(function* () {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
-  const { isEmpty } = yield* api.services.WorkspaceService.getWorkspaceInfo();
-  if (isEmpty) return undefined;
-  const editor = vscode.window.activeTextEditor;
-  if (!editor) return undefined;
-  const document = editor.document;
-  if (!editor.selection.isEmpty || document.isUntitled || document.isDirty) {
-    return {
-      kind: 'code',
-      apexCode: !editor.selection.isEmpty ? document.getText(editor.selection) : document.getText(),
-      selectionRange: !editor.selection.isEmpty
-        ? new vscode.Range(editor.selection.start, editor.selection.end)
-        : undefined,
-      documentUri: URI.parse(document.uri.toString())
-    } satisfies AnonApexContext;
-  }
-  return {
-    kind: 'file',
-    filePath: document.uri.fsPath,
-    documentUri: URI.file(document.uri.fsPath)
-  } satisfies AnonApexContext;
+  const promptService = yield* api.services.PromptService;
+  const context = yield* api.services.EditorService.getActiveEditorContext(true);
+  const executionResult = yield* Effect.gen(function* () {
+    const { result, logBody } = yield* api.services.ExecuteAnonymousService.executeAndRetrieveLog(context.text);
+    yield* api.services.ExecuteAnonymousService.reportExecResult(
+      result,
+      context.documentUri,
+      context.selectionRange?.startLine
+    );
+
+    if (result.compiled && result.success) {
+      const logFilePath = Utils.joinPath(
+        yield* api.services.ProjectService.getDebugLogsFolder(),
+        `${getYYYYMMddHHmmssDateFormat(new Date())}.log`
+      );
+      yield* launchReplayDebugger(logFilePath, logBody);
+    }
+    return result;
+  }).pipe(promptService.withProgress(nls.localize('apex_execute_text')));
+
+  yield* Effect.sync(() => {
+    if (executionResult.compiled && executionResult.success) {
+      void vscode.window.showInformationMessage(nls.localize('apex_execute_debug_success'));
+    }
+  });
 });
-
-const executeAnonApexDebug = Effect.fn('ApexReplayDebugger.executeAnonApexDebug')(function* () {
-  const ctx = yield* getAnonApexContext();
-  if (!ctx) return false;
-
-  const api = yield* (yield* ExtensionProviderService).getServicesApi;
-  const code = ctx.kind === 'code' ? ctx.apexCode : yield* api.services.FsService.readFile(ctx.filePath);
-  if (!code) return false;
-
-  const { result, logBody } = yield* api.services.ExecuteAnonymousService.executeAndRetrieveLog(code);
-  yield* api.services.ExecuteAnonymousService.reportExecResult(
-    result,
-    ctx.documentUri,
-    ctx.kind === 'code' ? ctx.selectionRange?.start.line : undefined
-  );
-
-  if (!result.compiled || !result.success) return false;
-
-  const logFilePath = Utils.joinPath(
-    yield* api.services.ProjectService.getDebugLogsFolder(),
-    `${getYYYYMMddHHmmssDateFormat(new Date())}.log`
-  );
-  return yield* launchReplayDebugger(logFilePath, logBody ?? undefined);
-});
-
-export const anonApexDebug = async (): Promise<void> => {
-  const success = await vscode.window.withProgress(
-    { location: vscode.ProgressLocation.Notification, title: nls.localize('apex_execute_text'), cancellable: false },
-    () =>
-      getRuntime()
-        .runPromise(executeAnonApexDebug())
-        .catch((error: unknown) => {
-          void vscode.window.showErrorMessage(nls.localize('apex_execute_debug_failed', String(error)));
-        })
-  );
-  if (success) {
-    void vscode.window.showInformationMessage(nls.localize('apex_execute_debug_success'));
-  }
-};

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/launchApexReplayDebuggerWithCurrentFile.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/launchApexReplayDebuggerWithCurrentFile.ts
@@ -9,7 +9,6 @@ import { basename } from 'node:path';
 import * as vscode from 'vscode';
 import { URI, Utils } from 'vscode-uri';
 import { nls } from '../messages';
-import { anonApexDebug } from './anonApexDebug';
 
 export const launchApexReplayDebuggerWithCurrentFile = async () => {
   const editor = vscode.window.activeTextEditor;
@@ -62,7 +61,7 @@ const getApexTestClassName = (document: vscode.TextDocument): string | undefined
 
 const launchAnonymousApexReplayDebugger = async () => {
   if (!(await sfProjectPreconditionChecker.check())) return;
-  await anonApexDebug();
+  await vscode.commands.executeCommand('sf.anon.apex.debug.delegate');
 };
 
 const launchApexReplayDebugger = async (apexTestClassName: string) => {

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
@@ -6,7 +6,7 @@
  */
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 
-import { buildAllServicesLayer } from '@salesforce/effect-ext-utils';
+import { buildAllServicesLayer, ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import {
   MetricError,
   MetricGeneral,
@@ -31,7 +31,7 @@ import {
   sfToggleCheckpoint
 } from './breakpoints/checkpointService';
 import { appendAndShowChannelOutput, getDebuggerOutputChannel } from './channels';
-import { anonApexDebug } from './commands/anonApexDebug';
+import { anonApexDebugCommand } from './commands/anonApexDebug';
 import { launchApexReplayDebuggerWithCurrentFile } from './commands/launchApexReplayDebuggerWithCurrentFile';
 import { launchFromLogFile } from './commands/launchFromLogFile';
 import { setupAndDebugTests } from './commands/quickLaunch';
@@ -57,8 +57,12 @@ if (!salesforceApexExtension) {
   throw new Error('Salesforce Apex Extension not initialized');
 }
 
-const registerCommands = async (extensionContext: vscode.ExtensionContext): Promise<vscode.Disposable> => {
-  const dialogStartingPathUri = await getRuntime().runPromise(getDialogStartingPath(extensionContext));
+const registerCommands = Effect.fn('ApexReplayDebugger.registerCommands')(function* (
+  extensionContext: vscode.ExtensionContext
+) {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const registerCommand = api.services.registerCommandWithRuntime(getRuntime());
+  const dialogStartingPathUri = yield* getDialogStartingPath(extensionContext);
   const promptForLogCmd = vscode.commands.registerCommand('extension.replay-debugger.getLogFileName', async () => {
     const fileUris: URI[] | undefined = await vscode.window.showOpenDialog({
       canSelectFiles: true,
@@ -103,7 +107,7 @@ const registerCommands = async (extensionContext: vscode.ExtensionContext): Prom
   const sfCreateCheckpointsCmd = vscode.commands.registerCommand('sf.create.checkpoints', sfCreateCheckpoints);
   const sfToggleCheckpointCmd = vscode.commands.registerCommand('sf.toggle.checkpoint', sfToggleCheckpoint);
 
-  const anonApexDebugDelegateCmd = vscode.commands.registerCommand('sf.anon.apex.debug.delegate', anonApexDebug);
+  yield* registerCommand('sf.anon.apex.debug.delegate', anonApexDebugCommand);
 
   const launchApexReplayDebuggerWithCurrentFileCmd = vscode.commands.registerCommand(
     'sf.launch.apex.replay.debugger.with.current.file',
@@ -117,10 +121,9 @@ const registerCommands = async (extensionContext: vscode.ExtensionContext): Prom
     launchFromLastLogFileCmd,
     sfCreateCheckpointsCmd,
     sfToggleCheckpointCmd,
-    anonApexDebugDelegateCmd,
     launchApexReplayDebuggerWithCurrentFileCmd
   );
-};
+});
 
 export const updateLastOpened = (extensionContext: vscode.ExtensionContext, logPath: string) => {
   extensionContext.workspaceState.update(LAST_OPENED_LOG_KEY, logPath);
@@ -177,7 +180,7 @@ export const activate = async (extensionContext: vscode.ExtensionContext) => {
 export const activateEffect = Effect.fn('activation:salesforcedx-vscode-apex-replay-debugger')(function* (
   extensionContext: vscode.ExtensionContext
 ) {
-  const commands = yield* Effect.promise(() => registerCommands(extensionContext));
+  const commands = yield* registerCommands(extensionContext);
   const debugHandlers = registerDebugHandlers();
   const debugConfigProvider = vscode.debug.registerDebugConfigurationProvider(
     'apex-replay',

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/messages/i18n.ja.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/messages/i18n.ja.ts
@@ -58,6 +58,5 @@ export const messages: Partial<Record<MessageKey, string>> = {
   debug_test_no_debug_log: 'テスト結果に関連するデバッグログが見つかりませんでした',
   channel_name: 'Apex Replay デバッガ',
   apex_execute_text: '匿名 Apex を実行',
-  apex_execute_debug_failed: '匿名 Apex の実行に失敗しました: %s',
   apex_execute_debug_success: 'Anonymous Apex が正常に実行されました'
 };

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/messages/i18n.ts
@@ -53,7 +53,6 @@ export const messages = {
   debug_test_no_debug_log: 'No debug log associated with test results',
   channel_name: 'Apex Replay Debugger',
   apex_execute_text: 'Execute Anonymous Apex',
-  apex_execute_debug_failed: 'Execute anonymous failed: %s',
   apex_execute_debug_success: 'Execute Anonymous Apex successfully ran',
   unable_to_locate_editor: 'You can run this command only on a source file.',
   unable_to_locate_document: 'You can run this command only on a source file.',

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/editorWatcher.headless.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/editorWatcher.headless.spec.ts
@@ -14,6 +14,7 @@ import {
   EDITOR_WITH_URI,
   ensureSecondarySideBarHidden,
   focusOnFilesExplorer,
+  openFileFromExplorerTree,
   saveScreenshot,
   setupConsoleMonitoring,
   setupNetworkMonitoring,
@@ -72,13 +73,10 @@ test('EditorWatcher: deploy commands show/hide based on active editor location',
   });
 
   await test.step('open sfdx-project.json (not in package directory)', async () => {
-    // Focus explorer and click on sfdx-project.json to open it
+    // The expanded metadata tree pushes root files outside the virtualized DOM.
     await focusOnFilesExplorer(page);
-
-    // Find and click the sfdx-project.json file in the explorer tree
-    const projectFile = page.getByRole('treeitem', { name: /sfdx-project\.json/ });
-    await projectFile.waitFor({ state: 'visible', timeout: 10_000 });
-    await projectFile.dblclick();
+    await page.keyboard.press('End');
+    await openFileFromExplorerTree(page, 'sfdx-project.json');
 
     // Verify it's the active editor
     const editor = page.locator(EDITOR_WITH_URI).first();

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/packageInstall.headless.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/packageInstall.headless.spec.ts
@@ -18,7 +18,9 @@ import {
   validateNoCriticalErrors,
   ensureSecondarySideBarHidden,
   saveScreenshot,
+  activeQuickInputTextField,
   activeQuickInputWidget,
+  selectQuickInputOption,
   NOTIFICATION_LIST_ITEM
 } from '@salesforce/playwright-vscode-ext';
 import packageNls from '../../../package.nls.json';
@@ -52,14 +54,19 @@ test('Install Package: posts PackageInstallRequest and polls until success', asy
   await test.step('skip installation key', async () => {
     const keyInput = activeQuickInputWidget(page);
     await keyInput.waitFor({ state: 'visible', timeout: 30_000 });
-    await page.keyboard.press('Enter');
+    await expect(page.getByRole('progressbar')).not.toBeVisible({ timeout: 30_000 });
+    await activeQuickInputTextField(page).press('Enter');
+    await keyInput.getByRole('option', { name: messages.package_install_poll_yes }).waitFor({
+      state: 'visible',
+      timeout: 30_000
+    });
     await saveScreenshot(page, 'step2.after-key.png');
   });
 
   await test.step('select Yes to wait for completion', async () => {
-    const pollPick = activeQuickInputWidget(page);
-    await pollPick.waitFor({ state: 'visible', timeout: 30_000 });
-    await pollPick.getByRole('option', { name: messages.package_install_poll_yes }).first().click();
+    await selectQuickInputOption(page, messages.package_install_poll_yes, {
+      quickInputVisibleTimeout: 30_000
+    });
     await saveScreenshot(page, 'step3.after-poll-choice.png');
   });
 

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/retrieveStaleApiVersion.headless.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/retrieveStaleApiVersion.headless.spec.ts
@@ -15,6 +15,8 @@ import {
   createMinimalOrg,
   upsertScratchOrgAuthFieldsToSettings,
   createApexClass,
+  focusOnFilesExplorer,
+  openFileFromExplorerTree,
   openFileByName,
   executeCommandWithCommandPalette,
   activeQuickInputWidget,
@@ -54,10 +56,9 @@ const projectJson = (sourceApiVersion: string): string =>
 
 /** Open sfdx-project.json from the Explorer and overwrite its full contents with `sourceApiVersion`, then save. */
 const writeProjectApiVersion = async (page: Page, sourceApiVersion: string) => {
-  await executeCommandWithCommandPalette(page, 'File: Focus on Files Explorer');
-  const projectFile = page.getByRole('treeitem', { name: /sfdx-project\.json/ });
-  await projectFile.waitFor({ state: 'visible', timeout: 10_000 });
-  await projectFile.dblclick();
+  await focusOnFilesExplorer(page);
+  await page.keyboard.press('End');
+  await openFileFromExplorerTree(page, 'sfdx-project.json');
 
   const editor = page.locator(`${EDITOR}[data-uri$="sfdx-project.json"]`).first();
   await editor.waitFor({ state: 'visible', timeout: 10_000 });

--- a/packages/salesforcedx-vscode-services/src/core/executeAnonymousService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/executeAnonymousService.ts
@@ -35,18 +35,16 @@ const escapeXml = (data: string): string => data.replaceAll(/[<>&'"]/g, char => 
 const buildSoapBody = (accessToken: string, apexCode: string): string => {
   const escaped = escapeXml(apexCode);
   return `<env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"
-xmlns:cmd="http://soap.sforce.com/2006/08/apex"
-xmlns:apex="http://soap.sforce.com/2006/08/apex">
-    <env:Header>
-        <cmd:SessionHeader>
-            <cmd:sessionId>${accessToken}</cmd:sessionId>
-        </cmd:SessionHeader>
-        <apex:DebuggingHeader>
-            <apex:categories><apex:category>Apex_code</apex:category><apex:level>Finest</apex:level></apex:categories>
-            <apex:categories><apex:category>Visualforce</apex:category><apex:level>Finer</apex:level></apex:categories>
-            <apex:categories><apex:category>Apex_profiling</apex:category><apex:level>Info</apex:level></apex:categories>
-        </apex:DebuggingHeader>
+xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+    <env:Header xmlns="http://soap.sforce.com/2006/08/apex">
+        <SessionHeader>
+            <sessionId>${accessToken}</sessionId>
+        </SessionHeader>
+        <DebuggingHeader>
+            <categories><category>Apex_code</category><level>Finest</level></categories>
+            <categories><category>Visualforce</category><level>Finer</level></categories>
+            <categories><category>Apex_profiling</category><level>Info</level></categories>
+        </DebuggingHeader>
     </env:Header>
     <env:Body>
         <executeAnonymous xmlns="http://soap.sforce.com/2006/08/apex">


### PR DESCRIPTION
### What does this PR do?
- Uses the Apex SOAP namespace as the default namespace for execute-anonymous headers.
- Removes redundant `cmd` and `apex` prefixes while preserving the SOAP expanded names.
- Ignores generated `graphify-out` directories.

### How was this verified?
- `npm run compile -w salesforcedx-vscode-services`
- `npm run vscode:bundle -w salesforcedx-vscode-services`
- `npm run test -w salesforcedx-vscode-services -- --runInBand test/jest/core/executeAnonymousService.test.ts`
- `npm run lint -w salesforcedx-vscode-services`
- `npm run check:knip`
- Full pre-push verification

### What issues does this PR fix or reference?
@W-23693396@