### PR TITLE
fix: standardize git identity configuration across publish workflows - W-23732279

### DIFF
--- a/.github/workflows/NIGHTLY-BUILDS.md
+++ b/.github/workflows/NIGHTLY-BUILDS.md
@@ -34,6 +34,7 @@ For published releases, `scripts/parse-extension-names.js` dynamically extracts 
 
 `nightly.yml` delegates to shared reusable workflow:
 - **Workflow**: `salesforcecli/github-workflows/.github/workflows/vscode-publish-extensions.yml@main`
+- **Git Identity**: `get-git-identity` job queries `getGithubUserInfo` action; provides username/email to publish job
 - **Scripts**: Downloaded at runtime (not stored locally)
 - **Actions**: check-ci-status, calculate-artifact-name, publish-vsix
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -110,9 +110,21 @@ jobs:
 
           echo "extensions=$EXTENSIONS" >> $GITHUB_OUTPUT
 
+  get-git-identity:
+    runs-on: ubuntu-latest
+    outputs:
+      username: ${{ steps.github-user-info.outputs.username }}
+      email: ${{ steps.github-user-info.outputs.email }}
+    steps:
+      - name: Get Github user info
+        id: github-user-info
+        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@main
+        with:
+          SVC_CLI_BOT_GITHUB_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
+
   nightly-release:
-    needs: build-extension-list
-    uses: salesforcecli/github-workflows/.github/workflows/vscode-publish-extensions.yml@feat/configurable-git-identity
+    needs: [build-extension-list, get-git-identity]
+    uses: salesforcecli/github-workflows/.github/workflows/vscode-publish-extensions.yml@main
     with:
       branch: ${{ github.event.inputs.branch || 'develop' }}
       extensions: ${{ needs.build-extension-list.outputs.extensions }}
@@ -120,6 +132,6 @@ jobs:
       pre-release: 'true'
       version-bump: 'auto'
       dry-run: ${{ github.event.inputs.dry-run || false }}
-      git-user-name: 'Release Bot'
-      git-user-email: 'svc_idee_bot@salesforce.com'
+      git-user-name: ${{ needs.get-git-identity.outputs.username }}
+      git-user-email: ${{ needs.get-git-identity.outputs.email }}
     secrets: inherit

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -112,7 +112,7 @@ jobs:
 
   nightly-release:
     needs: build-extension-list
-    uses: salesforcecli/github-workflows/.github/workflows/vscode-publish-extensions.yml@main
+    uses: salesforcecli/github-workflows/.github/workflows/vscode-publish-extensions.yml@feat/configurable-git-identity
     with:
       branch: ${{ github.event.inputs.branch || 'develop' }}
       extensions: ${{ needs.build-extension-list.outputs.extensions }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -120,4 +120,6 @@ jobs:
       pre-release: 'true'
       version-bump: 'auto'
       dry-run: ${{ github.event.inputs.dry-run || false }}
+      git-user-name: 'Release Bot'
+      git-user-email: 'svc_idee_bot@salesforce.com'
     secrets: inherit

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -160,8 +160,20 @@ jobs:
       - name: Validate VSIX OPC Part URIs
         run: node scripts/validate-vsix-opc.mjs ./extensions
 
+  get-git-identity:
+    runs-on: ubuntu-latest
+    outputs:
+      username: ${{ steps.github-user-info.outputs.username }}
+      email: ${{ steps.github-user-info.outputs.email }}
+    steps:
+      - name: Get Github user info
+        id: github-user-info
+        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@main
+        with:
+          SVC_CLI_BOT_GITHUB_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
+
   publish:
-    needs: ['ctc-open', 'prepare-environment-from-main', 'build-extension-list', 'validate-vsix']
+    needs: ['ctc-open', 'prepare-environment-from-main', 'build-extension-list', 'validate-vsix', 'get-git-identity']
     uses: salesforcecli/github-workflows/.github/workflows/vscode-publish-extensions.yml@main
     with:
       branch: 'main'
@@ -170,6 +182,8 @@ jobs:
       pre-release: 'false'  # Stable releases (even minor versions)
       version-bump: 'none'  # Version already set in release
       dry-run: false  # Publish to marketplace
+      git-user-name: ${{ needs.get-git-identity.outputs.username }}
+      git-user-email: ${{ needs.get-git-identity.outputs.email }}
     secrets: inherit
 
   ctcCloseSuccess:

--- a/package.json
+++ b/package.json
@@ -366,10 +366,7 @@
       "dependencies": [
         "vscode:package:modern:prerelease",
         "vscode:package:legacy:prerelease"
-      ],
-      "env": {
-        "WIREIT_PARALLEL": "1"
-      }
+      ]
     },
     "run:web": {
       "command": "npx vscode-test-web --browserType=chromium --browserOption=--disable-web-security --browserOption=--remote-debugging-port=9222 --extensionDevelopmentPath packages/salesforcedx-vscode-services --extensionPath packages/salesforcedx-vscode-apex-log --extensionPath packages/salesforcedx-vscode-org-browser --extensionPath packages/salesforcedx-vscode-lwc --extensionPath packages/salesforcedx-vscode-metadata --extensionPath packages/salesforcedx-vscode-apex-testing --extensionPath packages/salesforcedx-vscode-soql --open-devtools --port 3001 --quality stable --verbose --printServerLog",


### PR DESCRIPTION
### What does this PR do?

Standardizes git identity configuration across nightly and production release workflows by using the `getGithubUserInfo` action pattern instead of hardcoded credentials.

### What issues does this PR fix or reference?
@W-23732279@

### Changes

**Nightly Workflow (`.github/workflows/nightly.yml`):**
- Added `get-git-identity` job that fetches Release Bot credentials dynamically via `getGithubUserInfo` action
- Replaced hardcoded git identity with outputs from `get-git-identity` job
- Updated workflow reference from feature branch to `@main` (depends on salesforcecli/github-workflows#168)

**Production Release Workflow (`.github/workflows/publishVSCode.yml`):**
- Added `get-git-identity` job using same `getGithubUserInfo` pattern
- Added `git-user-name` and `git-user-email` parameters to publish job

**Documentation (`.github/workflows/NIGHTLY-BUILDS.md`):**
- Updated architecture section to document new `get-git-identity` job

**Package Configuration (`package.json`):**
- Removed invalid `WIREIT_PARALLEL` env from `vscode:package:prerelease` task (wireit doesn't allow env on dependency-only tasks)

### Why?

This change ensures consistent Release Bot identity across all release workflows with a single point of maintenance, matching the pattern already used by:
- `publishEslintPlugin.yml`
- `publishPlaywrightVscodeExt.yml`
- `publishI18nPackage.yml`
- `publishSoqlCommon.yml`

Previously, `nightly.yml` hardcoded the identity and `publishVSCode.yml` didn't configure it at all, leading to inconsistent commit authorship between nightly and production releases.

### Functionality Before

- **Nightly releases**: Hardcoded 'Release Bot <svc_idee_bot@salesforce.com>' identity (not maintainable)
- **Production releases**: Used default 'GitHub Action <action@github.com>' identity (inconsistent with nightly)
- **Package.json**: Invalid wireit config caused warnings

### Functionality After

- **Nightly releases**: Dynamically fetches Release Bot identity from `IDEE_GH_TOKEN`
- **Production releases**: Also uses Release Bot identity (consistent authorship)
- **Single maintenance point**: Update credentials in one place (the token), all workflows reflect changes
- **Package.json**: Clean wireit configuration without warnings