### PR TITLE
docs(gus-cli): standardize ai-auto subject tags

### DIFF
--- a/.claude/skills/gus-cli/SKILL.md
+++ b/.claude/skills/gus-cli/SKILL.md
@@ -147,10 +147,13 @@ When unsure which epic: ask the user.
 
 ## `[ai-auto]` tag
 
-`[ai-auto]` in `Subject__c` or `Details__c` opts a WI into the [auto-build-wi workflow](../../workflows/auto-build-wi.js) (claim → plan → build → review → draft PR). See [workflows/README.md](../../workflows/README.md).
+`[ai-auto]` in `Subject__c` opts a WI into the [auto-build-wi workflow](../../workflows/auto-build-wi.js) (claim → plan → build → review → draft PR). See [workflows/README.md](../../workflows/README.md).
 
 - Add only on explicit user request; only `Subject__c` (title), never `Details__c`
 - Skip for WIs needing design/coordination
+- End the subject with the bracketed repository slug, then `[ai-auto]`: `<subject> [owner/repo] [ai-auto]`
+- Derive `owner/repo` from the target repository's git remote; example: `Upgrade Tabulator [forcedotcom/salesforcedx-vscode] [ai-auto]`
+- Keep any sequencing prefix at the front: `1 Upgrade Tabulator [forcedotcom/salesforcedx-vscode] [ai-auto]`
 - Query: `Subject__c LIKE '%[ai-auto]%'`
 
 ## Compound workflows

--- a/.claude/skills/gus-cli/epics.md
+++ b/.claude/skills/gus-cli/epics.md
@@ -57,8 +57,8 @@ create() { # $1=Subject  $2=Details (>=20 chars)
     -v "Subject__c='$1' Details__c='$2' Story_Points__c=2 Product_Tag__c=$PROD RecordTypeId=$RT Epic__c=$EPIC Scrum_Team__c=$TEAM Assignee__c=$ASSIGN" \
     --json 2>/dev/null | jq -r 'if .status == 0 then .result.id else "ERR" end'
 }
-create "1.0 [ai-auto] First task" "Description, at least twenty chars."
-create "1.1 [ai-auto] Second task" "Another, also twenty-plus chars."
+create "1.0 First task [forcedotcom/salesforcedx-vscode] [ai-auto]" "Description, at least twenty chars."
+create "1.1 Second task [forcedotcom/salesforcedx-vscode] [ai-auto]" "Another, also twenty-plus chars."
 ```
 
 Confirm count + W-numbers after: `SELECT Name, Subject__c FROM ADM_Work__c WHERE Epic__c='<epicId>'`.


### PR DESCRIPTION
### What issues does this PR fix or reference?
[skip-validate-pr]

### What changes were made?
- require the repository slug before the trailing `[ai-auto]` subject tag
- derive `owner/repo` from the target git remote
- update sequenced bulk-create examples
- clarify that `Details__c` never opts a WI into AI auto