### PR TITLE
fix(anon-apex): allow breakpoints to be set when file language is Anonymous Apex - W-23751891

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44464,7 +44464,7 @@
       }
     },
     "packages/salesforcedx-vscode": {
-      "version": "67.9.2",
+      "version": "67.9.3",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -44472,7 +44472,7 @@
       }
     },
     "packages/salesforcedx-vscode-apex": {
-      "version": "67.9.2",
+      "version": "67.9.3",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -44495,7 +44495,7 @@
       }
     },
     "packages/salesforcedx-vscode-apex-debugger": {
-      "version": "67.9.2",
+      "version": "67.9.3",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -44518,7 +44518,7 @@
       }
     },
     "packages/salesforcedx-vscode-apex-log": {
-      "version": "67.9.2",
+      "version": "67.9.3",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -44538,7 +44538,7 @@
       }
     },
     "packages/salesforcedx-vscode-apex-oas": {
-      "version": "67.9.2",
+      "version": "67.9.3",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -44629,7 +44629,7 @@
       }
     },
     "packages/salesforcedx-vscode-apex-replay-debugger": {
-      "version": "67.9.2",
+      "version": "67.9.3",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -44656,7 +44656,7 @@
       }
     },
     "packages/salesforcedx-vscode-apex-testing": {
-      "version": "67.9.2",
+      "version": "67.9.3",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -44677,7 +44677,7 @@
       }
     },
     "packages/salesforcedx-vscode-core": {
-      "version": "67.9.2",
+      "version": "67.9.3",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -44705,7 +44705,7 @@
       }
     },
     "packages/salesforcedx-vscode-expanded": {
-      "version": "67.9.2",
+      "version": "67.9.3",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -44718,7 +44718,7 @@
       "license": "BSD-3-Clause"
     },
     "packages/salesforcedx-vscode-lightning": {
-      "version": "67.9.2",
+      "version": "67.9.3",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -44756,7 +44756,7 @@
       }
     },
     "packages/salesforcedx-vscode-lwc": {
-      "version": "67.9.2",
+      "version": "67.9.3",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -44783,7 +44783,7 @@
       }
     },
     "packages/salesforcedx-vscode-metadata": {
-      "version": "67.9.2",
+      "version": "67.9.3",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -44804,7 +44804,7 @@
       }
     },
     "packages/salesforcedx-vscode-org": {
-      "version": "67.9.2",
+      "version": "67.9.3",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -44827,7 +44827,7 @@
       }
     },
     "packages/salesforcedx-vscode-org-browser": {
-      "version": "67.9.2",
+      "version": "67.9.3",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -44847,7 +44847,7 @@
       }
     },
     "packages/salesforcedx-vscode-services": {
-      "version": "67.9.2",
+      "version": "67.9.3",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -44912,25 +44912,8 @@
         "ts-node": "^10.9.2"
       }
     },
-    "packages/salesforcedx-vscode-services-types/node_modules/shx": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
-      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.3",
-        "shelljs": "^0.8.5"
-      },
-      "bin": {
-        "shx": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "packages/salesforcedx-vscode-soql": {
-      "version": "67.9.2",
+      "version": "67.9.3",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -45130,7 +45113,7 @@
       "license": "MIT"
     },
     "packages/salesforcedx-vscode-visualforce": {
-      "version": "67.9.2",
+      "version": "67.9.3",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/packages/salesforcedx-vscode-apex-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-debugger/package.json
@@ -230,6 +230,9 @@
     "breakpoints": [
       {
         "language": "apex"
+      },
+      {
+        "language": "apex-anon"
       }
     ],
     "configuration": {

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -225,6 +225,9 @@
     "breakpoints": [
       {
         "language": "apex"
+      },
+      {
+        "language": "apex-anon"
       }
     ],
     "menus": {

--- a/packages/salesforcedx-vscode-services-types/package.json
+++ b/packages/salesforcedx-vscode-services-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/vscode-services",
-  "version": "67.9.2",
+  "version": "67.9.3",
   "description": "TypeScript type definitions for Salesforce VS Code Services extension API",
   "author": "Salesforce",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
### What does this PR do?
When the language of a file is Anonymous Apex, users could not set breakpoints because according to **packages/salesforcedx-vscode-apex-debugger/package.json** and **packages/salesforcedx-vscode-apex-replay-debugger/package.json**, breakpoints are limited to language Apex.  However, users do want to debug Anonymous Apex, so they should be able to set breakpoints there.  This PR allows breakpoints to be set in Anonymous Apex files.

### What issues does this PR fix or reference?
@W-23751891@

### Functionality Before
```
  "contributes": {
    "breakpoints": [
      {
        "language": "apex"
      }
    ],
```

### Functionality After
```
  "contributes": {
    "breakpoints": [
      {
        "language": "apex"
      },
      {
        "language": "apex-anon"
      }
    ],
```
