### PR TITLE
refactor(services): scope notification lifecycle - W-23549971

### DIFF
--- a/.claude/skills/effect-best-practices/SKILL.md
+++ b/.claude/skills/effect-best-practices/SKILL.md
@@ -45,6 +45,7 @@ npx effect-language-service diagnostics --project tsconfig.json
 | Atom State        | `Atom.keepAlive` for global state                        | Forgetting keepAlive for persistent state                        |
 | Atom Updates      | `useAtomSet` in React components                         | `Atom.update` imperatively from React                            |
 | Atom Cleanup      | `get.addFinalizer()` for side effects                    | Missing cleanup for event listeners                              |
+| Resource Cleanup  | Scoped service/layer + `Effect.addFinalizer`             | Returning `dispose`; delegating Effect-owned resources to callers |
 | Atom Results      | `Result.builder` with `onErrorTag`                       | Ignoring loading/error states                                    |
 | Grouping          | `Arr.groupBy` (effect/Array)                             | `Object.groupBy`, whose `Partial<Record>` forces a filter        |
 
@@ -303,6 +304,25 @@ const AppLive = Layer.mergeAll(
 ```
 
 See `references/layer-patterns.md` for testing layers and config-dependent layers.
+
+### Effect-Owned Resources
+
+Resources created inside an Effect service/layer belong to its scope. Prefer `scoped` plus
+`Effect.addFinalizer` or `Effect.acquireRelease`; don't expose `dispose` or delegate cleanup to a host lifecycle.
+
+```typescript
+export class StatusService extends Effect.Service<StatusService>()('StatusService', {
+  accessors: true,
+  scoped: Effect.gen(function* () {
+    const item = vscode.window.createStatusBarItem();
+    yield* Effect.addFinalizer(() => Effect.sync(() => item.dispose()));
+    return { show: Effect.sync(() => item.show()) };
+  })
+}) {}
+```
+
+The layer owner must close its scope. A `ManagedRuntime` owns its layers' scopes; dispose it during extension
+deactivation. Use `context.subscriptions` only for resources created outside Effect ownership.
 
 ## Option Handling
 

--- a/.claude/skills/services-extension-consumption/SKILL.md
+++ b/.claude/skills/services-extension-consumption/SKILL.md
@@ -74,9 +74,36 @@ Legacy inline pattern (still present in `metadata`, `org`, `org-browser`, `light
 ## Runtime vs provide
 
 - **Do**: Build `ManagedRuntime.make(AllServicesLayer)` and export `getRuntime()`.
+- **Do**: Export runtime disposal, clear the memo, and call it during extension deactivation.
 - **Do**: Use `getRuntime().runPromise(effect)` / `runFork(effect)` for ad-hoc execution.
 - **Don't**: Use `Effect.provide(AllServicesLayer)` at call sites — use the runtime instead.
 - **Exception**: `registerCommandWithLayer(AllServicesLayer)` — pass the Layer; runtime captured at registration time (avoids re-providing on each invocation).
+
+```typescript
+export const disposeRuntime = async (): Promise<void> => {
+  if (_runtime) {
+    await _runtime.dispose();
+    _runtime = undefined;
+  }
+};
+
+export const deactivate = async (): Promise<void> => {
+  await getRuntime().runPromise(deactivation()).finally(disposeRuntime);
+};
+```
+
+## Resource Lifecycle
+
+Prefer Effect scope ownership for resources created inside Effect services/layers:
+
+- Define resource-owning services with `scoped`.
+- Register VS Code `Disposable`s with `Effect.addFinalizer`.
+- Attach long-lived fibers to the owning scope with `Effect.forkIn`.
+- Dispose the owning `ManagedRuntime` on deactivation so layer finalizers run.
+- Don't expose `runDispose`/`dispose` solely for consumers to add to `context.subscriptions`.
+- Keep `context.subscriptions` for resources created outside an Effect scope.
+
+Allocation and cleanup stay together. See `../effect-best-practices/SKILL.md#effect-owned-resources`.
 
 ## Registering Commands
 
@@ -326,6 +353,7 @@ For direct service mocking (no accessor), use `Layer.succeed(Service, mockImpl)`
 - `ChannelServiceLayer` before `ErrorHandlerService`
 - Pass `context` to `SdkLayerFor` (extracts name/version from ExtensionContext)
 - `Effect.forkIn(..., yield* getExtensionScope())` for watcher cleanup on deactivation
+- Scoped services own their VS Code disposables via finalizers; runtime disposal runs them
 - `registerCommandWithLayer` for all commands (tracing + error handling)
 - Use `getRuntime().runPromise` / `runFork` instead of `Effect.provide(AllServicesLayer)` for execution
 

--- a/.claude/skills/services-extension-consumption/references/notification-mode-api.md
+++ b/.claude/skills/services-extension-consumption/references/notification-mode-api.md
@@ -25,7 +25,8 @@ const layer = api.services.NotificationModeService.Default(
 yield* program.pipe(Effect.provide(layer));
 ```
 
-`Default(extensionSection, statusBarId, statusBarName)` returns the per-extension layer. Add its service disposal to the extension context subscriptions.
+`Default(extensionSection, statusBarId, statusBarName)` returns a scoped per-extension layer. Its status item,
+registered command, and timer are released when the owning runtime is disposed.
 
 ## showSuccessNotification
 
@@ -72,7 +73,9 @@ const location = yield* service.getProgressLocation(commandKey);
 
 ## Lifecycle
 
-Yield the service during activation and add `{ dispose: service.runDispose }` to `context.subscriptions`.
+The service owns its VS Code resources through Effect finalizers. Don't add a notification disposable to
+`context.subscriptions`. Dispose the `ManagedRuntime` during extension deactivation; see the parent skill's
+Resource Lifecycle section.
 
 ## Mode types
 

--- a/packages/salesforcedx-vscode-apex-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-debugger/src/index.ts
@@ -34,7 +34,7 @@ import { isvDebugBootstrap } from './commands/isvdebugging/bootstrapCmd';
 import { getActiveApexExtension } from './context/apexExtension';
 import { nls } from './messages';
 import { AllServicesLayer, buildAllServicesLayer, setAllServicesLayer } from './services/extensionProvider';
-import { getRuntime } from './services/runtime';
+import { disposeRuntime, getRuntime } from './services/runtime';
 import { getTelemetryService } from './utils/coreExtensionUtils';
 
 const cachedExceptionBreakpoints: Map<string, ExceptionBreakpointItem> = new Map();
@@ -242,7 +242,6 @@ export const activateEffect = Effect.fn('activation:salesforcedx-vscode-apex-deb
   extensionContext: vscode.ExtensionContext
 ) {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
-  const notificationMode = yield* api.services.NotificationModeService;
   yield* Effect.sync(() => {
     const commands = registerCommands();
     const debugHandlers = registerDebugHandlers();
@@ -251,8 +250,7 @@ export const activateEffect = Effect.fn('activation:salesforcedx-vscode-apex-deb
       commands,
       fileWatchers,
       debugHandlers,
-      vscode.debug.registerDebugConfigurationProvider('apex', new DebugConfigurationProvider()),
-      { dispose: () => notificationMode.runDispose() }
+      vscode.debug.registerDebugConfigurationProvider('apex', new DebugConfigurationProvider())
     );
   });
 
@@ -267,8 +265,11 @@ export const activateEffect = Effect.fn('activation:salesforcedx-vscode-apex-deb
 });
 
 export const deactivate = async () => {
-  console.log('Apex Debugger Extension Deactivated');
-  // Send deactivation event using shared service if available
-  const telemetryService = await getTelemetryService();
-  telemetryService.sendExtensionDeactivationEvent();
+  await getTelemetryService()
+    .then(telemetryService => {
+      console.log('Apex Debugger Extension Deactivated');
+      // Send deactivation event using shared service if available
+      telemetryService.sendExtensionDeactivationEvent();
+    })
+    .finally(disposeRuntime);
 };

--- a/packages/salesforcedx-vscode-apex-debugger/src/services/runtime.ts
+++ b/packages/salesforcedx-vscode-apex-debugger/src/services/runtime.ts
@@ -14,3 +14,10 @@ export const getRuntime = () => {
   _apexDebuggerRuntime ??= createApexDebuggerRuntime();
   return _apexDebuggerRuntime;
 };
+
+export const disposeRuntime = async (): Promise<void> => {
+  if (_apexDebuggerRuntime) {
+    await _apexDebuggerRuntime.dispose();
+    _apexDebuggerRuntime = undefined;
+  }
+};

--- a/packages/salesforcedx-vscode-apex-debugger/test/jest/activation.test.ts
+++ b/packages/salesforcedx-vscode-apex-debugger/test/jest/activation.test.ts
@@ -21,8 +21,7 @@ jest.mock('../../src/utils/coreExtensionUtils', () => ({
 const registerCommandWithLayer = jest.fn();
 const notificationMode = {
   getProgressLocation: () => Effect.succeed(vscode.ProgressLocation.Notification),
-  showSuccessNotification: () => Effect.void,
-  runDispose: jest.fn()
+  showSuccessNotification: () => Effect.void
 } as unknown as NotificationModeService;
 
 const extensionProviderLayer = () =>

--- a/packages/salesforcedx-vscode-apex-debugger/test/jest/commands/debuggerStop.test.ts
+++ b/packages/salesforcedx-vscode-apex-debugger/test/jest/commands/debuggerStop.test.ts
@@ -24,8 +24,7 @@ const getProgressLocation = jest.fn(() => Effect.succeed(15 /* vscode.ProgressLo
 const showSuccessNotification = jest.fn(() => Effect.void);
 const notificationMode = {
   getProgressLocation,
-  showSuccessNotification,
-  runDispose: jest.fn()
+  showSuccessNotification
 } as unknown as NotificationModeService;
 
 // Fake jsforce Connection: `tooling.query` returns the seeded records; `tooling.sobject(...).update` is a spy.

--- a/packages/salesforcedx-vscode-apex-log/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/index.ts
@@ -38,7 +38,7 @@ import {
 import { createLogAutoCollect } from './logs/logAutoCollect';
 import { CurrentTraceFlags } from './services/apexLogState';
 import { buildAllServicesLayer } from './services/extensionProvider';
-import { getRuntime, setAllServicesLayer } from './services/runtime';
+import { disposeRuntime, getRuntime, setAllServicesLayer } from './services/runtime';
 import { createTraceFlagStatusBar } from './statusBar/traceFlagStatusBar';
 import { traceFlagCleanupScheduler } from './traceFlagCleanupScheduler';
 import { registerTraceFlagsCodeLensProvider } from './traceFlags/traceFlagsCodeLensProvider';
@@ -50,7 +50,9 @@ export const activate = async (context: vscode.ExtensionContext): Promise<void> 
   await getRuntime().runPromise(activation(context).pipe(Scope.extend(extensionScope)));
 };
 
-export const deactivate = async (): Promise<void> => getRuntime().runPromise(deactivation());
+export const deactivate = async (): Promise<void> => {
+  await getRuntime().runPromise(deactivation()).finally(disposeRuntime);
+};
 
 const activation = Effect.fn('activation')(function* (context: vscode.ExtensionContext) {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
@@ -62,9 +64,6 @@ const activation = Effect.fn('activation')(function* (context: vscode.ExtensionC
   yield* api.services.ChannelService.pipe(
     Effect.flatMap(svc => svc.appendToChannel(`${displayName} extension activating`))
   );
-  const notificationMode = yield* api.services.NotificationModeService;
-  yield* Effect.sync(() => context.subscriptions.push({ dispose: () => notificationMode.runDispose() }));
-
   const registerCommand = api.services.registerCommandWithRuntime(getRuntime());
   const scope = yield* getExtensionScope();
 

--- a/packages/salesforcedx-vscode-apex-log/src/services/runtime.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/services/runtime.ts
@@ -27,3 +27,10 @@ export const setAllServicesLayer = (layer: ServicesLayer): void => {
 let _apexLogRuntime: ApexLogRuntime | undefined;
 
 export const getRuntime = (): ApexLogRuntime => (_apexLogRuntime ??= ManagedRuntime.make(allServicesLayer));
+
+export const disposeRuntime = async (): Promise<void> => {
+  if (_apexLogRuntime) {
+    await _apexLogRuntime.dispose();
+    _apexLogRuntime = undefined;
+  }
+};

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
@@ -6,7 +6,6 @@
  */
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 
-import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import {
   MetricError,
   MetricGeneral,
@@ -44,7 +43,7 @@ import {
 } from './debuggerConstants';
 import { nls } from './messages';
 import { buildAllServicesLayer, setAllServicesLayer } from './services/extensionProvider';
-import { getRuntime } from './services/runtime';
+import { disposeRuntime, getRuntime } from './services/runtime';
 
 export enum VSCodeWindowTypeEnum {
   Error = 1,
@@ -177,7 +176,6 @@ export const activate = async (extensionContext: vscode.ExtensionContext) => {
 export const activateEffect = Effect.fn('activation:salesforcedx-vscode-apex-replay-debugger')(function* (
   extensionContext: vscode.ExtensionContext
 ) {
-  const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const commands = yield* Effect.promise(() => registerCommands(extensionContext));
   const debugHandlers = registerDebugHandlers();
   const debugConfigProvider = vscode.debug.registerDebugConfigurationProvider(
@@ -206,7 +204,6 @@ export const activateEffect = Effect.fn('activation:salesforcedx-vscode-apex-rep
     await setupAndDebugTests(namespace ? `${namespace}.${className}` : className, method);
   });
 
-  const notificationMode = yield* api.services.NotificationModeService;
   extensionContext.subscriptions.push(
     debuggerChannel,
     commands,
@@ -215,8 +212,7 @@ export const activateEffect = Effect.fn('activation:salesforcedx-vscode-apex-rep
     checkpointsView,
     breakpointsSub,
     debugTests,
-    debugTest,
-    { dispose: () => notificationMode.runDispose() }
+    debugTest
   );
 
   // Telemetry
@@ -289,8 +285,12 @@ export const writeToDebuggerOutputWindow = (
   }
 };
 
-export const deactivate = () => {
-  console.log('Apex Replay Debugger Extension Deactivated');
-  // Send deactivation event using shared service
-  TelemetryService.getInstance().sendExtensionDeactivationEvent();
+export const deactivate = async () => {
+  await Promise.resolve()
+    .then(() => {
+      console.log('Apex Replay Debugger Extension Deactivated');
+      // Send deactivation event using shared service
+      TelemetryService.getInstance().sendExtensionDeactivationEvent();
+    })
+    .finally(disposeRuntime);
 };

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/services/runtime.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/services/runtime.ts
@@ -14,3 +14,10 @@ export const getRuntime = () => {
   _replayDebuggerRuntime ??= createReplayDebuggerRuntime();
   return _replayDebuggerRuntime;
 };
+
+export const disposeRuntime = async (): Promise<void> => {
+  if (_replayDebuggerRuntime) {
+    await _replayDebuggerRuntime.dispose();
+    _replayDebuggerRuntime = undefined;
+  }
+};

--- a/packages/salesforcedx-vscode-metadata/src/index.ts
+++ b/packages/salesforcedx-vscode-metadata/src/index.ts
@@ -38,6 +38,7 @@ import { createDeployOnSaveService } from './services/deployOnSaveService';
 import {
   AllServicesLayer,
   buildAllServicesLayer,
+  disposeMetadataRuntime,
   getMetadataRuntime,
   setAllServicesLayer
 } from './services/extensionProvider';
@@ -49,16 +50,15 @@ export const activate = async (context: vscode.ExtensionContext): Promise<void> 
   await getMetadataRuntime().runPromise(activateEffect(context).pipe(Scope.extend(extensionScope)));
 };
 
-export const deactivate = async (): Promise<void> => getMetadataRuntime().runPromise(deactivateEffect());
+export const deactivate = async (): Promise<void> => {
+  await getMetadataRuntime().runPromise(deactivateEffect()).finally(disposeMetadataRuntime);
+};
 
 /** Activate the metadata extension */
 export const activateEffect = Effect.fn(`activation:${EXTENSION_NAME}`)(function* (context: vscode.ExtensionContext) {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const svc = yield* api.services.ChannelService;
   yield* svc.appendToChannel('Salesforce Metadata extension activating');
-  const notificationMode = yield* api.services.NotificationModeService;
-  yield* Effect.sync(() => context.subscriptions.push({ dispose: () => notificationMode.runDispose() }));
-
   // Create registerCommand pre-loaded with AllServicesLayer for proper tracing
   const registerCommand = api.services.registerCommandWithLayer(AllServicesLayer);
   const projectGenerateCommands =

--- a/packages/salesforcedx-vscode-metadata/src/services/extensionProvider.ts
+++ b/packages/salesforcedx-vscode-metadata/src/services/extensionProvider.ts
@@ -82,3 +82,10 @@ type MetadataRuntime = ManagedRuntime.ManagedRuntime<
 // eslint-disable-next-line functional/no-let
 let _metadataRuntime: MetadataRuntime | undefined;
 export const getMetadataRuntime = () => (_metadataRuntime ??= ManagedRuntime.make(AllServicesLayer));
+
+export const disposeMetadataRuntime = async (): Promise<void> => {
+  if (_metadataRuntime) {
+    await _metadataRuntime.dispose();
+    _metadataRuntime = undefined;
+  }
+};

--- a/packages/salesforcedx-vscode-metadata/test/jest/utils/withPreparationProgress.test.ts
+++ b/packages/salesforcedx-vscode-metadata/test/jest/utils/withPreparationProgress.test.ts
@@ -34,8 +34,7 @@ const createMockExtensionProvider = () =>
 
 const notificationMode = {
   getProgressLocation: () => Effect.succeed(vscode.ProgressLocation.Notification),
-  showSuccessNotification: () => Effect.void,
-  runDispose: jest.fn()
+  showSuccessNotification: () => Effect.void
 } as unknown as NotificationModeService;
 
 const provideServices = (e: Effect.Effect<unknown, unknown, unknown>) =>

--- a/packages/salesforcedx-vscode-org-browser/src/index.ts
+++ b/packages/salesforcedx-vscode-org-browser/src/index.ts
@@ -21,7 +21,12 @@ import * as vscode from 'vscode';
 import { retrieveEffect } from './commands/retrieveMetadata';
 import { EXTENSION_NAME, TREE_VIEW_ID } from './constants';
 import { nls } from './messages';
-import { buildAllServicesLayer, getOrgBrowserRuntime, setAllServicesLayer } from './services/extensionProvider';
+import {
+  buildAllServicesLayer,
+  disposeOrgBrowserRuntime,
+  getOrgBrowserRuntime,
+  setAllServicesLayer
+} from './services/extensionProvider';
 import { MetadataTypeTreeProvider } from './tree/metadataTypeTreeProvider';
 import { OrgBrowserTreeItem } from './tree/orgBrowserNode';
 import { matchesPattern, MAX_TYPES_FOR_COMPONENT_PREFETCH } from './utils/wildcardPattern';
@@ -231,16 +236,15 @@ export const activate = async (context: vscode.ExtensionContext): Promise<void> 
   await getOrgBrowserRuntime().runPromise(activateEffect(context).pipe(Scope.extend(extensionScope)));
 };
 
-export const deactivate = async (): Promise<void> => getOrgBrowserRuntime().runPromise(deactivateEffect());
+export const deactivate = async (): Promise<void> => {
+  await getOrgBrowserRuntime().runPromise(deactivateEffect()).finally(disposeOrgBrowserRuntime);
+};
 
 // export for testing
 export const activateEffect = Effect.fn(`activation:${EXTENSION_NAME}`)(function* (context: vscode.ExtensionContext) {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const svc = yield* api.services.ChannelService;
   yield* svc.appendToChannel('Salesforce Org Browser extension activating');
-  const notificationMode = yield* api.services.NotificationModeService;
-  yield* Effect.sync(() => context.subscriptions.push({ dispose: () => notificationMode.runDispose() }));
-
   // get a connection to initiate the ref
   yield* api.services.ConnectionService.getConnection();
   // wait for the target org ref to have an orgId

--- a/packages/salesforcedx-vscode-org-browser/src/services/extensionProvider.ts
+++ b/packages/salesforcedx-vscode-org-browser/src/services/extensionProvider.ts
@@ -50,3 +50,10 @@ type OrgBrowserRuntime = ManagedRuntime.ManagedRuntime<
 // eslint-disable-next-line functional/no-let
 let _orgBrowserRuntime: OrgBrowserRuntime | undefined;
 export const getOrgBrowserRuntime = () => (_orgBrowserRuntime ??= ManagedRuntime.make(AllServicesLayer));
+
+export const disposeOrgBrowserRuntime = async (): Promise<void> => {
+  if (_orgBrowserRuntime) {
+    await _orgBrowserRuntime.dispose();
+    _orgBrowserRuntime = undefined;
+  }
+};

--- a/packages/salesforcedx-vscode-org-browser/test/jest/index.test.ts
+++ b/packages/salesforcedx-vscode-org-browser/test/jest/index.test.ts
@@ -278,8 +278,7 @@ describe.skip('Extension', () => {
             MockOrgBrowserRetrieveServiceLayer,
             Layer.succeed(NotificationModeService, {
               getProgressLocation: () => Effect.succeed(vscode.ProgressLocation.Notification),
-              showSuccessNotification: () => Effect.void,
-              runDispose: jest.fn()
+              showSuccessNotification: () => Effect.void
             } as unknown as NotificationModeService)
           )
         )

--- a/packages/salesforcedx-vscode-services/src/vscode/notificationModeService.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/notificationModeService.ts
@@ -117,11 +117,13 @@ const applyForceShow = (mode: ProgressAndSuccessMode): ProgressAndSuccessMode =>
 /** Per-extension service for notification settings, progress placement, and success notifications. */
 export class NotificationModeService extends Effect.Service<NotificationModeService>()('NotificationModeService', {
   accessors: true,
-  effect: (extensionSection: string, statusBarId: string, statusBarName: string) =>
+  scoped: (extensionSection: string, statusBarId: string, statusBarName: string) =>
     Effect.gen(function* () {
+      const scope = yield* Effect.scope;
       const item = yield* Effect.sync(() =>
         vscode.window.createStatusBarItem(statusBarId, vscode.StatusBarAlignment.Left, 44)
       );
+      yield* Effect.addFinalizer(() => Effect.sync(() => item.dispose()));
       item.name = statusBarName;
 
       const pendingToastRef = yield* Ref.make<Option.Option<{ message: string; actions: ToastAction[] }>>(
@@ -159,6 +161,11 @@ export class NotificationModeService extends Effect.Service<NotificationModeServ
           });
         })
       );
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          commandDisposable.dispose();
+        })
+      );
       item.command = commandId;
 
       const showTransient = Effect.fn('NotificationModeService.showTransient')(function* (
@@ -178,7 +185,7 @@ export class NotificationModeService extends Effect.Service<NotificationModeServ
           Effect.andThen(Effect.sync(() => item.hide())),
           Effect.andThen(Ref.set(hideTimerRef, Option.none())),
           Effect.interruptible,
-          Effect.forkDaemon
+          Effect.forkIn(scope)
         );
         yield* Ref.set(hideTimerRef, Option.some(newFiber));
       });
@@ -202,21 +209,7 @@ export class NotificationModeService extends Effect.Service<NotificationModeServ
           return mode === 'progressToastSuccessToast' || mode === 'progressToastSuccessOff'
             ? vscode.ProgressLocation.Notification
             : vscode.ProgressLocation.Window;
-        }),
-        runDispose: (): void => {
-          hideTimerRef.pipe(
-            Ref.get,
-            Effect.flatMap(
-              Option.match({
-                onNone: () => Effect.void,
-                onSome: Fiber.interrupt
-              })
-            ),
-            Runtime.runFork(runtime)
-          );
-          commandDisposable.dispose();
-          item.dispose();
-        }
+        })
       };
     })
 }) {}

--- a/packages/salesforcedx-vscode-services/test/jest/notificationModeService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/notificationModeService.test.ts
@@ -112,12 +112,8 @@ describe('NotificationModeService.Default', () => {
 
   afterEach(() => jest.restoreAllMocks());
 
-  const makeService = () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        return yield* NotificationModeService;
-      }).pipe(Effect.provide(NotificationModeService.Default('ext', 'status-id', 'Status Name')))
-    );
+  const runWithService = <A>(effect: Effect.Effect<A, never, NotificationModeService>) =>
+    Effect.runPromise(effect.pipe(Effect.provide(NotificationModeService.Default('ext', 'status-id', 'Status Name'))));
 
   it.each([
     ['progressToastSuccessOff', vscode.ProgressLocation.Notification],
@@ -125,21 +121,18 @@ describe('NotificationModeService.Default', () => {
   ] as const)('configures the status item and maps %s progress', async (mode, expectedLocation) => {
     makeConfig({ extGlobal: mode });
 
-    const service = await makeService();
-
+    await expect(NotificationModeService.getProgressLocation('Command').pipe(runWithService)).resolves.toBe(
+      expectedLocation
+    );
     expect(vscode.window.createStatusBarItem).toHaveBeenCalledWith('status-id', vscode.StatusBarAlignment.Left, 44);
     expect(item.name).toBe('Status Name');
     expect(item.command).toBe('status-id.showToast');
     expect(vscode.commands.registerCommand).toHaveBeenCalledWith('status-id.showToast', expect.any(Function));
-    await expect(Effect.runPromise(service.getProgressLocation('Command'))).resolves.toBe(expectedLocation);
-    service.runDispose();
   });
 
-  it('disposes the registered command and status item', async () => {
+  it('disposes the registered command and status item when the service scope closes', async () => {
     makeConfig({ extGlobal: 'progressToastSuccessOff' });
-    const service = await makeService();
-
-    service.runDispose();
+    await runWithService(NotificationModeService);
 
     expect(commandDisposable.dispose).toHaveBeenCalledTimes(1);
     expect(item.dispose).toHaveBeenCalledTimes(1);

--- a/packages/salesforcedx-vscode-soql/src/index.ts
+++ b/packages/salesforcedx-vscode-soql/src/index.ts
@@ -17,7 +17,12 @@ import { soqlOpenNewBuilder, soqlOpenNewTextEditor } from './commands/soqlFileCr
 import { SOQLEditorProvider } from './editor/soqlEditorProvider';
 import { startLanguageClient, stopLanguageClient } from './lspClient/client';
 import { QueryDataViewService } from './queryDataView/queryDataViewService';
-import { buildAllServicesLayer, getSoqlRuntime, setAllServicesLayer } from './services/extensionProvider';
+import {
+  buildAllServicesLayer,
+  disposeSoqlRuntime,
+  getSoqlRuntime,
+  setAllServicesLayer
+} from './services/extensionProvider';
 
 const EXTENSION_NAME = 'salesforcedx-vscode-soql';
 
@@ -27,16 +32,17 @@ export const activate = async (extensionContext: vscode.ExtensionContext): Promi
   await getSoqlRuntime().runPromise(activateEffect(extensionContext).pipe(Scope.extend(extensionScope)));
 };
 
-export const deactivate = async (): Promise<void> => getSoqlRuntime().runPromise(deactivateEffect());
+export const deactivate = async (): Promise<void> => {
+  await getSoqlRuntime().runPromise(deactivateEffect()).finally(disposeSoqlRuntime);
+};
 
 export const activateEffect = Effect.fn(`activation:${EXTENSION_NAME}`)(function* (context: vscode.ExtensionContext) {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const svc = yield* api.services.ChannelService;
   yield* svc.appendToChannel(`SOQL Extension Initializing in mode ${context.extensionMode}`);
 
-  const notificationMode = yield* api.services.NotificationModeService;
   yield* Effect.sync(() => {
-    context.subscriptions.push(SOQLEditorProvider.register(context), { dispose: () => notificationMode.runDispose() });
+    context.subscriptions.push(SOQLEditorProvider.register(context));
     QueryDataViewService.register(context);
     registerSoqlCodeLensProvider(context);
   });

--- a/packages/salesforcedx-vscode-soql/src/services/extensionProvider.ts
+++ b/packages/salesforcedx-vscode-soql/src/services/extensionProvider.ts
@@ -74,3 +74,10 @@ type SoqlRuntime = ManagedRuntime.ManagedRuntime<
 >;
 let _soqlRuntime: SoqlRuntime | undefined;
 export const getSoqlRuntime = () => (_soqlRuntime ??= ManagedRuntime.make(AllServicesLayer));
+
+export const disposeSoqlRuntime = async (): Promise<void> => {
+  if (_soqlRuntime) {
+    await _soqlRuntime.dispose();
+    _soqlRuntime = undefined;
+  }
+};

--- a/packages/salesforcedx-vscode-soql/test/jest/commands/dataQuery.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/commands/dataQuery.test.ts
@@ -45,8 +45,7 @@ import {
 
 const notificationMode = {
   getProgressLocation: () => Effect.succeed(vscode.ProgressLocation.Notification),
-  showSuccessNotification: () => Effect.void,
-  runDispose: jest.fn()
+  showSuccessNotification: () => Effect.void
 } as unknown as NotificationModeService;
 import { formatErrorMessage } from '../../../src/commands/queryUtils';
 import { nls } from '../../../src/messages';


### PR DESCRIPTION
### What does this PR do?
Moves `NotificationModeService` resource cleanup into its Effect scope. Status-bar items, commands, and timer fibers now close with the owning managed runtime instead of requiring consumers to register a VS Code disposable.

Adds managed-runtime disposal to each consuming extension and documents the Effect-owned lifecycle pattern in the Effect skills.

### What issues does this PR fix or reference?
@W-23549971@