### PR TITLE
fix: prevent Apex language server startup outside Salesforce projects

### DIFF
--- a/packages/salesforcedx-vscode-apex/src/index.ts
+++ b/packages/salesforcedx-vscode-apex/src/index.ts
@@ -44,6 +44,12 @@ export const activateEffect = Effect.fn('activation:salesforcedx-vscode-apex')(f
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   yield* (yield* api.services.WorkspaceService).getWorkspaceInfoOrThrow();
 
+  const isSalesforceProject = yield* api.services.ProjectService.isSalesforceProject();
+
+  if (!isSalesforceProject) {
+    return;
+  }
+
   // start the language server and client
   const languageServerStatusBarItem = new ApexLSPStatusBarItem();
   languageClientManager.setStatusBarInstance(languageServerStatusBarItem);

--- a/packages/salesforcedx-vscode-apex/test/jest/index.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/index.test.ts
@@ -4,6 +4,9 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+
+import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
+import * as Effect from 'effect/Effect';
 import * as vscode from 'vscode';
 
 // Mock vscode.extensions.getExtension before any imports that trigger src/index.ts
@@ -151,6 +154,38 @@ describe('index tests', () => {
     let mockContext: vscode.ExtensionContext;
     let originalWorkspaceFolders: any;
     let originalExtensions: any;
+    const runActivateEffect = (isSalesforceProject: boolean) => {
+      const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+
+      const getWorkspaceInfoOrThrow = () =>
+        workspaceFolder
+          ? Effect.succeed({
+              uri: workspaceFolder.uri,
+              path: workspaceFolder.uri.toString(),
+              fsPath: workspaceFolder.uri.fsPath,
+              isEmpty: false,
+              isVirtualFs: workspaceFolder.uri.scheme !== 'file',
+              cwd: process.cwd()
+            })
+          : Effect.fail(new Error('No workspace is currently open'));
+
+      const effect = index.activateEffect(mockContext).pipe(
+        Effect.provideService(ExtensionProviderService, {
+          getServicesApi: Effect.succeed({
+            services: {
+              WorkspaceService: Effect.succeed({
+                getWorkspaceInfoOrThrow
+              }),
+              ProjectService: {
+                isSalesforceProject: () => Effect.succeed(isSalesforceProject)
+              }
+            }
+          })
+        } as any)
+      );
+
+      return Effect.runPromise(effect as Effect.Effect<void, unknown, never>);
+    };
 
     beforeEach(() => {
       // Store original extensions
@@ -220,6 +255,52 @@ describe('index tests', () => {
         configurable: true
       });
       await expect(index.activate(mockContext)).rejects.toThrow(''); //should be "Unable to determine workspace folders for workspace"
+    });
+
+    it('should not start the Apex language server in a non-Salesforce workspace', async () => {
+      Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+        value: [
+          {
+            uri: URI.file('/mock/non-sfdx-workspace'),
+            name: 'non-sfdx-workspace',
+            index: 0
+          }
+        ],
+        configurable: true
+      });
+
+      const unexpectedStart = new Error('unexpected Apex language server start');
+
+      const createLanguageClientSpy = jest
+        .spyOn(languageClientManager, 'createLanguageClient')
+        .mockRejectedValue(unexpectedStart);
+
+      await runActivateEffect(false);
+
+      expect(createLanguageClientSpy).not.toHaveBeenCalled();
+    });
+
+    it('should start the Apex language server in a Salesforce workspace', async () => {
+      Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+        value: [
+          {
+            uri: URI.file('/mock/sfdx-workspace'),
+            name: 'sfdx-workspace',
+            index: 0
+          }
+        ],
+        configurable: true
+      });
+
+      const expectedStart = new Error('expected Apex language server start');
+
+      const createLanguageClientSpy = jest
+        .spyOn(languageClientManager, 'createLanguageClient')
+        .mockRejectedValue(expectedStart);
+
+      await expect(runActivateEffect(true)).rejects.toThrow('expected Apex language server start');
+
+      expect(createLanguageClientSpy).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## What does this PR do?

Prevents the Apex language server from starting when the current workspace is not a Salesforce project.

Opening a `.cls` file can activate the Apex extension because `.cls` is statically associated with the Apex language contribution. In a non-SFDX workspace, this could previously start the Apex language server and generate Salesforce tooling/cache files under `.sfdx/tools/*`.

This change adds a `ProjectService.isSalesforceProject()` check before the Apex language client is started.

## Why is this necessary?

In a non-SFDX workspace, opening a `.cls` file such as a LaTeX class file can currently cause Salesforce tooling to start and create `.sfdx/tools/*`, even though the folder is not a Salesforce project.

This addresses the language-server startup and `.sfdx/tools` side effect described in #7886.

## How was this implemented?

- Keep the existing workspace-open check.
- Use the existing `ProjectService.isSalesforceProject()` service to determine whether the workspace is a Salesforce project.
- Return before starting the Apex language server when the check is false.
- Add regression tests for both non-Salesforce and Salesforce workspaces.

## Scope

This PR does not change VS Code's static `.cls` language association, so a `.cls` file may still display `Apex` as its language mode in a non-SFDX workspace.

The change specifically prevents the Apex language server from starting and avoids creation of `.sfdx/tools/*` in that case.

## Test plan

- `npm test -w salesforcedx-vscode-apex`
  - 12 test suites passed
  - 115 tests passed
- `npm run lint -w salesforcedx-vscode-apex`
  - 0 errors
- `git diff --check`
  - clean
- Manual Extension Development Host validation:
  - Non-SFDX workspace + opened `.cls` file → `.sfdx` was not created.
  - Valid SFDX workspace + opened Apex class → normal Apex tooling startup was preserved.

Discussion: #7972

Fixes #7886