### PR TITLE
fix(lwc): correctly extract file path from Jest stack traces with parens - W-23731926

### DIFF
--- a/packages/salesforcedx-vscode-lwc/src/testSupport/testExplorer/lwcTestController.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/testExplorer/lwcTestController.ts
@@ -24,7 +24,7 @@ import {
   TestResultStatus,
   isTestCaseInfo
 } from '../types';
-import { LWC_TEST_RUN_LOG_NAME, JEST_STACK_TRACE_PATTERN } from '../types/constants';
+import { LWC_TEST_RUN_LOG_NAME, matchJestStackTraceLocation } from '../types/constants';
 import { isLwcJestTest } from '../utils/isLwcJestTest';
 import { normalizeJestFsPath } from '../utils/normalizeJestFsPath';
 import { workspace, workspaceService } from '../workspace';
@@ -576,14 +576,10 @@ class LwcTestController {
             message.actualOutput = errorMessage;
 
             // Extract error location from stack trace for editor highlighting
-            const match = errorDetail.match(JEST_STACK_TRACE_PATTERN);
-            if (match) {
-              const [, file, lineStr, columnStr] = match;
-              const errorUri = URI.file(file);
-              const position = new vscode.Position(
-                Math.max(0, parseInt(lineStr, 10) - 1),
-                Math.max(0, parseInt(columnStr, 10) - 1)
-              );
+            const location = matchJestStackTraceLocation(errorDetail);
+            if (location) {
+              const errorUri = URI.file(location.file);
+              const position = new vscode.Position(Math.max(0, location.line - 1), Math.max(0, location.column - 1));
               message.location = new vscode.Location(errorUri, position);
             }
 
@@ -654,14 +650,10 @@ class LwcTestController {
         const errorMessage = new vscode.TestMessage(cleanMessage);
 
         // Extract error location from stack trace in message for red highlight
-        const match = cleanMessage.match(JEST_STACK_TRACE_PATTERN);
-        if (match && fileItem.uri) {
-          const [, file, lineStr, columnStr] = match;
-          const errorUri = URI.file(file);
-          const position = new vscode.Position(
-            Math.max(0, parseInt(lineStr, 10) - 1),
-            Math.max(0, parseInt(columnStr, 10) - 1)
-          );
+        const location = matchJestStackTraceLocation(cleanMessage);
+        if (location && fileItem.uri) {
+          const errorUri = URI.file(location.file);
+          const position = new vscode.Position(Math.max(0, location.line - 1), Math.max(0, location.column - 1));
           errorMessage.location = new vscode.Location(errorUri, position);
         }
 

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/types/constants.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/types/constants.ts
@@ -45,7 +45,27 @@ export const LWC_JEST_RUNNER_DUPLICATE_LENS_NOTICE_DISMISSED = 'lwc.jestRunnerDu
 
 /**
  * Pattern to extract file location from Jest stack traces.
- * Matches lines like "at SomeFunction (/path/to/file.js:123:45)" or "at /path/to/file.js:123:45"
- * Uses .+? (non-greedy) to capture the file path, stopping at the first :line:col pattern
+ * Matches "at SomeFunction (/path/to/file.js:123:45)" (groups 1-3) or the unparenthesized
+ * "at /path/to/file.js:123:45" (groups 4-6) as mutually exclusive alternatives, anchored to
+ * end-of-line ($/m). This lets the path itself contain literal parentheses (e.g. a "Program
+ * Files (x86)" directory) without being confused for the function-name delimiter — a single
+ * optional non-capturing group can't disambiguate that case. Use matchJestStackTraceLocation
+ * rather than matching against this directly.
  */
-export const JEST_STACK_TRACE_PATTERN = /at (?:.*?\()?(.+?):(\d+):(\d+)\)?/;
+const JEST_STACK_TRACE_PATTERN = /at (?:.*?\((.+):(\d+):(\d+)\)|(.+):(\d+):(\d+))$/m;
+
+/**
+ * Extracts a file/line/column location from the first Jest stack trace line found in `text`.
+ */
+export const matchJestStackTraceLocation = (
+  text: string
+): { file: string; line: number; column: number } | undefined => {
+  const match = text.match(JEST_STACK_TRACE_PATTERN);
+  if (!match) {
+    return undefined;
+  }
+  const file = match[1] ?? match[4];
+  const line = match[2] ?? match[5];
+  const column = match[3] ?? match[6];
+  return { file, line: parseInt(line, 10), column: parseInt(column, 10) };
+};

--- a/packages/salesforcedx-vscode-lwc/test/jest/testSupport/types/constants.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/jest/testSupport/types/constants.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { matchJestStackTraceLocation } from '../../../../src/testSupport/types/constants';
+
+describe('matchJestStackTraceLocation', () => {
+  it('extracts location from a frame with a function name', () => {
+    const location = matchJestStackTraceLocation('at Object.<anonymous> (/path/to/file.js:10:5)');
+
+    expect(location).toEqual({ file: '/path/to/file.js', line: 10, column: 5 });
+  });
+
+  it('extracts location from a bare frame with no function name', () => {
+    const location = matchJestStackTraceLocation('at /path/to/file.js:10:5');
+
+    expect(location).toEqual({ file: '/path/to/file.js', line: 10, column: 5 });
+  });
+
+  it('captures the full path when a bare frame contains literal parentheses', () => {
+    const location = matchJestStackTraceLocation('at /path/foo(bar)/file.js:10:5');
+
+    expect(location).toEqual({ file: '/path/foo(bar)/file.js', line: 10, column: 5 });
+  });
+
+  it('captures the full path when a named frame contains literal parentheses', () => {
+    const location = matchJestStackTraceLocation('at new Foo (/path/Program Files (x86)/file.js:10:5)');
+
+    expect(location).toEqual({ file: '/path/Program Files (x86)/file.js', line: 10, column: 5 });
+  });
+
+  it('picks the first stack frame out of a multi-line message', () => {
+    const location = matchJestStackTraceLocation(
+      'TypeError: Cannot read properties of undefined\n' +
+        '    at Object.<anonymous> (/project/foo.test.js:42:7)\n' +
+        '    at Module._compile (node:internal/modules/cjs/loader:1000:1)'
+    );
+
+    expect(location).toEqual({ file: '/project/foo.test.js', line: 42, column: 7 });
+  });
+
+  it('returns undefined when there is no stack frame', () => {
+    const location = matchJestStackTraceLocation('TypeError: Cannot read properties of undefined');
+
+    expect(location).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes a regex bug in `JEST_STACK_TRACE_PATTERN` (used to extract file/line/column for inline error highlighting on Jest crashes) that mis-captured the file path whenever it contained a literal `(` — e.g. a `Program Files (x86)` directory — and had no function-name prefix. A single optional non-capturing group couldn't disambiguate the two stack-frame forms (`at name (path:line:col)` vs `at path:line:col`), so the group would greedily consume up through the first `(` in the path itself.

Replaces it with two mutually exclusive alternatives anchored to end-of-line, and adds a shared `matchJestStackTraceLocation` helper so both call sites in `lwcTestController.ts` parse consistently. Adds unit tests covering both stack-frame forms, paths with literal parentheses in each form, multi-line messages, and the no-match case.

### What issues does this PR fix or reference?
@W-23731926@

### Functionality Before
N/A — internal fix found during code review of #7940, no user-visible behavior change under normal paths.

### Functionality After
N/A