### PR TITLE
fix(org-browser): remove Org Browser extension commands from command palette - W-23830629

### DIFF
--- a/packages/salesforcedx-vscode-org-browser/package.json
+++ b/packages/salesforcedx-vscode-org-browser/package.json
@@ -496,6 +496,18 @@
         {
           "command": "sfdxOrgBrowser.filterText.active",
           "when": "false"
+        },
+        {
+          "command": "sfdxOrgBrowser.retrieveMetadata",
+          "when": "false"
+        },
+        {
+          "command": "sfdxOrgBrowser.refreshType",
+          "when": "false"
+        },
+        {
+          "command": "sfdxOrgBrowser.collapseAll",
+          "when": "false"
         }
       ],
       "view/item/context": [


### PR DESCRIPTION
### What does this PR do?
The following Org Browser extension commands were inadvertently surfaced in the command palette:
1. Retrieve Metadata
2. Org Browser: Refresh Type
3. Org Browser: Collapse All

This was happening because they were just omitted from the **commandPalette** section in **packages/salesforcedx-vscode-org-browser/package.json** rather than listed and tagged with `"when": "false"`. This was causing the 3 commands to always appear in the command palette whenever the Org Browser extension is installed, even outside a Salesforce project when the extension is not activated.

### What issues does this PR fix or reference?
@W-23830629@
