### PR TITLE
chore(salesforcedx-utils): enforce consistent-type-imports eslint rule - W-23371027

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -828,6 +828,16 @@ export default [
     }
   },
   {
+    // consistent-type-imports for salesforcedx-utils (inline to avoid no-duplicate-imports; W-23371027)
+    files: ['packages/salesforcedx-utils/**/*.ts'],
+    rules: {
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        { prefer: 'type-imports', fixStyle: 'inline-type-imports' }
+      ]
+    }
+  },
+  {
     // class-methods-use-this for packages not yet using Effect
     // (apex-oas + apex-testing omitted: covered by the Effect-services block above, which sets both rules)
     files: ['packages/salesforcedx-vscode-soql/**/*.ts', 'packages/soql-common/**/*.ts', 'packages/soql-model/**/*.ts'],

--- a/packages/salesforcedx-utils/src/cli/commandBuilder.ts
+++ b/packages/salesforcedx-utils/src/cli/commandBuilder.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { CommandFields } from '../types/command';
+import { type CommandFields } from '../types/command';
 import { Command } from './command';
 
 export const JSON_FLAG = '--json';

--- a/packages/salesforcedx-utils/src/cli/commandOutput.ts
+++ b/packages/salesforcedx-utils/src/cli/commandOutput.ts
@@ -6,7 +6,7 @@
  */
 
 import { stripAnsiInJson } from '../helpers/utils';
-import { CommandExecution } from '../types/commandExecution';
+import { type CommandExecution } from '../types/commandExecution';
 import { JSON_FLAG } from './commandBuilder';
 
 export class CommandOutput {


### PR DESCRIPTION
Adds a package-scoped ESLint override enabling `@typescript-eslint/consistent-type-imports` for `packages/salesforcedx-utils/**/*.ts`, matching the pattern already used for `packages/effect-ext-utils`. Uses `fixStyle: inline-type-imports` since the repo's `no-duplicate-imports` rule has no `allowSeparateTypeImports` option.

Ran `eslint --fix` scoped to the package; two type-only imports were converted to `import { type X } from ...`.

Split from closed W-23354585 / PR #7702 (repo-wide diff was too large to review/merge safely).

### What issues does this PR fix or reference?
@W-23371027@