### PR TITLE
chore(templates): bump @salesforce/templates to ^66.13.6 to pull in new UIBundle changes - W-23817526

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9757,9 +9757,9 @@
       }
     },
     "node_modules/@salesforce/templates": {
-      "version": "66.13.5",
-      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-66.13.5.tgz",
-      "integrity": "sha512-KooKEUjAYhzX6F9kWyV6eB81Nw9UaIYV0rYHitgdqSJ1JZN/vnqCuryuEM47Hss8d3xuE7cF2IFTrF9YLVS+DA==",
+      "version": "66.13.6",
+      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-66.13.6.tgz",
+      "integrity": "sha512-X6kM74bfZ5Zm5YM13LRuqt1cc+LvIn1ltXtG/P8J0ocebIMK4miyZwAQtAtQyIQF/VtGOXIPlgbyFPnZ7xl9MA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/kit": "^3.2.6",
@@ -45668,7 +45668,7 @@
         "@types/eslint": "^9.0.0",
         "@types/estree": "^1.0.0",
         "@types/semver": "7.5.8",
-        "@typescript-eslint/rule-tester": "8.66.0",
+        "@typescript-eslint/rule-tester": "^8.66.0",
         "semver": "^7.5.4"
       },
       "peerDependencies": {
@@ -46573,7 +46573,7 @@
         "@salesforce/o11y-reporter": "^1.8.5",
         "@salesforce/salesforcedx-utils-vscode": "*",
         "@salesforce/source-deploy-retrieve": "^13.0.0",
-        "@salesforce/templates": "^66.13.5",
+        "@salesforce/templates": "^66.13.6",
         "@salesforce/ts-types": "^3.0.0",
         "@salesforce/vscode-i18n": "*",
         "@salesforce/vscode-service-provider": "^1.5.0",
@@ -46764,7 +46764,7 @@
         "@salesforce/salesforcedx-utils": "*",
         "@salesforce/source-deploy-retrieve": "^13.0.0",
         "@salesforce/source-tracking": "^8.0.0",
-        "@salesforce/templates": "^66.13.5",
+        "@salesforce/templates": "^66.13.6",
         "@salesforce/vscode-i18n": "*",
         "@vscode/extension-telemetry": "^1.0.0",
         "effect": "^3.21.2",
@@ -46871,23 +46871,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "packages/salesforcedx-vscode-services-types/node_modules/shx": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
-      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.3",
-        "shelljs": "^0.8.5"
-      },
-      "bin": {
-        "shx": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "packages/salesforcedx-vscode-services/node_modules/@opentelemetry/sdk-trace-base": {

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -33,7 +33,7 @@
     "@salesforce/o11y-reporter": "^1.8.5",
     "@salesforce/salesforcedx-utils-vscode": "*",
     "@salesforce/source-deploy-retrieve": "^13.0.0",
-    "@salesforce/templates": "^66.13.5",
+    "@salesforce/templates": "^66.13.6",
     "@salesforce/ts-types": "^3.0.0",
     "@salesforce/vscode-i18n": "*",
     "@salesforce/vscode-service-provider": "^1.5.0",

--- a/packages/salesforcedx-vscode-services-types/package.json
+++ b/packages/salesforcedx-vscode-services-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/vscode-services",
-  "version": "67.10.0",
+  "version": "67.11.1",
   "description": "TypeScript type definitions for Salesforce VS Code Services extension API",
   "author": "Salesforce",
   "license": "BSD-3-Clause",

--- a/packages/salesforcedx-vscode-services/package.json
+++ b/packages/salesforcedx-vscode-services/package.json
@@ -45,7 +45,7 @@
     "@salesforce/salesforcedx-utils": "*",
     "@salesforce/source-deploy-retrieve": "^13.0.0",
     "@salesforce/source-tracking": "^8.0.0",
-    "@salesforce/templates": "^66.13.5",
+    "@salesforce/templates": "^66.13.6",
     "@salesforce/vscode-i18n": "*",
     "@vscode/extension-telemetry": "^1.0.0",
     "effect": "^3.21.2",


### PR DESCRIPTION
### What does this PR do?
Bumps @salesforce/templates to pull in the UIBundle change made in https://github.com/forcedotcom/salesforcedx-templates/pull/886.

### What issues does this PR fix or reference?
@W-23817526@

### Testing
Using the new version of @salesforce/templates, I created new projects using both the React Internal App and React External App templates with no errors.
