### PR TITLE
feat: enforce notification-mode key wiring + new eslint rule - W-23546519

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -180,6 +180,7 @@ export default [
       'local/no-vscode-quickpick-description-literals': 'error',
       'local/no-vscode-validateinput-literals': 'error',
       'local/no-self-barrel-import': 'error',
+      'local/notification-slot-matches-package-json': 'error',
       'barrel-files/avoid-barrel-files': 'error',
       'barrel-files/avoid-re-export-all': 'error',
       'workspaces/no-relative-imports': 'error',

--- a/packages/eslint-local-rules/README.md
+++ b/packages/eslint-local-rules/README.md
@@ -76,6 +76,37 @@ const findById = Effect.fn('UserService.findById')(function* (id: UserId) {
 
 Note: Immediately-invoked `Effect.fn` calls (e.g. `Effect.fn('x')(function* (){})()`) are flagged by the Effect Language Service rule `effectFnIife` (config-enforced in `config/effect-diagnostics.json`), not this rule. Use `Effect.gen(...).pipe(Effect.withSpan(...))` for one-shot effects.
 
+### notification-slot-matches-package-json
+
+Enforces that `SuccessOnlyCommandKey` and `ProgressOnlyCommandKey` type alias literals in notificationMode.ts files match their slot's enum shape defined in package.json commandLevelNotifications. The rule validates that:
+
+- Each key exists in the package.json commandLevelNotifications properties
+- The key's enum values match the expected notification slot type:
+  - `SuccessOnlyCommandKey`: must have enum `['successToast', 'successStatusBar', 'successOff']`
+  - `ProgressOnlyCommandKey`: must have enum `['progressToast', 'progressStatusBar']`
+
+**Bad:**
+
+```typescript
+// SuccessOnlyCommandKey lists a ProgressOnly command
+export type SuccessOnlyCommandKey = 'My Progress Command';
+
+// ProgressOnlyCommandKey lists a SuccessOnly command
+export type ProgressOnlyCommandKey = 'My Success Command';
+
+// Key doesn't exist in package.json
+export type SuccessOnlyCommandKey = 'Nonexistent Command';
+```
+
+**Good:**
+
+```typescript
+export type SuccessOnlyCommandKey = 'My Success Command';
+export type ProgressOnlyCommandKey = 'My Progress Command';
+```
+
+This rule requires files using these type aliases to be near a package.json that defines the commandLevelNotifications configuration.
+
 ### no-successive-annotate-current-span
 
 Enforces that back-to-back `Effect.annotateCurrentSpan` calls are merged into a single call. Each call opens and annotates the current span independently, so two or more adjacent calls do redundant work that a single object-argument call expresses more cheaply. The rule detects two forms: consecutive `yield* Effect.annotateCurrentSpan(...)` statements inside a generator, and consecutive `Effect.tap(x => Effect.annotateCurrentSpan(...))` arguments inside one `.pipe(...)` chain. Any intervening statement or non-annotate `.tap` breaks the run, so only genuinely successive calls are flagged. Array forms (`Effect.all`/`forEach`) and `andThen` chains are out of scope.
@@ -173,6 +204,16 @@ export default [
       'local/package-json-icon-paths': 'error',
       'local/package-json-command-refs': 'error',
       'local/package-json-view-refs': 'error'
+    }
+  },
+  // Enable TypeScript linting for notificationMode.ts files
+  {
+    files: ['**/notificationMode.ts'],
+    plugins: {
+      local: localRulesPlugin
+    },
+    rules: {
+      'local/notification-slot-matches-package-json': 'error'
     }
   },
   // Enable .vscodeignore linting for extension package folders

--- a/packages/eslint-local-rules/src/commandMustBeInPackageJson.ts
+++ b/packages/eslint-local-rules/src/commandMustBeInPackageJson.ts
@@ -7,43 +7,11 @@
 
 import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
 import { RuleCreator } from '@typescript-eslint/utils/eslint-utils';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
+import { getNearestPackageJson } from './packageJsonUtils';
 
-type PackageJson = {
-  contributes?: {
-    commands?: { command: string }[];
-  };
-};
-
-/** Cache package.json contents per directory to avoid repeated reads */
-const packageJsonCache = new Map<string, PackageJson | undefined>();
-
-/** Find and read the nearest package.json, returning contributes.commands */
 const getPackageCommands = (filePath: string): Set<string> => {
-  const dir = path.dirname(filePath);
-
-  if (packageJsonCache.has(dir)) {
-    const cached = packageJsonCache.get(dir);
-    return new Set(cached?.contributes?.commands?.map(c => c.command));
-  }
-
-  // Walk up directories to find package.json
-  const parts = dir.split(path.sep);
-  for (let i = parts.length; i > 0; i--) {
-    const candidate = path.join(parts.slice(0, i).join(path.sep), 'package.json');
-    try {
-      const content = fs.readFileSync(candidate, 'utf8');
-      const parsed = JSON.parse(content) as PackageJson;
-      packageJsonCache.set(dir, parsed);
-      return new Set(parsed?.contributes?.commands?.map(c => c.command));
-    } catch {
-      // Continue searching up
-    }
-  }
-
-  packageJsonCache.set(dir, undefined);
-  return new Set();
+  const pkg = getNearestPackageJson(filePath);
+  return new Set(pkg?.contributes?.commands?.map(c => c.command));
 };
 
 type RuleOptions = [{ ignorePatterns?: string[] }];

--- a/packages/eslint-local-rules/src/index.ts
+++ b/packages/eslint-local-rules/src/index.ts
@@ -18,6 +18,7 @@ import { noInlineEsbuildPlatform } from './noInlineEsbuildPlatform';
 import { noRuntimeVscodeImport } from './noRuntimeVscodeImport';
 import { noSelfBarrelImport } from './noSelfBarrelImport';
 import { noSuccessiveAnnotateCurrentSpan } from './noSuccessiveAnnotateCurrentSpan';
+import { notificationSlotMatchesPackageJson } from './notificationSlotMatchesPackageJson';
 import { noUnusedI18nMessages } from './noUnusedI18nMessages';
 import { noVscodeMessageLiterals } from './noVscodeMessageLiterals';
 import { noVscodeProgressTitleLiterals } from './noVscodeProgressTitleLiterals';
@@ -48,6 +49,7 @@ const plugin: TSESLint.FlatConfig.Plugin = {
     'no-duplicate-i18n-values': noDuplicateI18nValues,
     'no-duplicate-playwright-locators': noDuplicatePlaywrightLocators,
     'no-direct-services-imports': noDirectServicesImports,
+    'notification-slot-matches-package-json': notificationSlotMatchesPackageJson,
     'no-self-barrel-import': noSelfBarrelImport,
     'no-effect-fn-wrapper': noEffectFnWrapper,
     'no-successive-annotate-current-span': noSuccessiveAnnotateCurrentSpan,

--- a/packages/eslint-local-rules/src/notificationSlotMatchesPackageJson.ts
+++ b/packages/eslint-local-rules/src/notificationSlotMatchesPackageJson.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
+import { RuleCreator } from '@typescript-eslint/utils/eslint-utils';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+type PackageJson = {
+  contributes?: {
+    configuration?: {
+      properties?: Record<string, { properties?: Record<string, { enum?: string[] }> }>;
+    };
+  };
+};
+
+const SUCCESS_ONLY_ENUM = new Set(['successToast', 'successStatusBar', 'successOff']);
+const PROGRESS_ONLY_ENUM = new Set(['progressToast', 'progressStatusBar']);
+
+const packageJsonCache = new Map<string, PackageJson | undefined>();
+
+const getPackageJson = (filePath: string): PackageJson | undefined => {
+  const dir = path.dirname(filePath);
+  if (packageJsonCache.has(dir)) return packageJsonCache.get(dir);
+
+  const parts = dir.split(path.sep);
+  for (let i = parts.length; i > 0; i--) {
+    const candidate = path.join(parts.slice(0, i).join(path.sep), 'package.json');
+    try {
+      const parsed = JSON.parse(fs.readFileSync(candidate, 'utf8')) as PackageJson;
+      packageJsonCache.set(dir, parsed);
+      return parsed;
+    } catch {
+      // continue walking up
+    }
+  }
+
+  packageJsonCache.set(dir, undefined);
+  return undefined;
+};
+
+/** Read commandLevelNotifications properties from nearest package.json */
+const getCommandLevelProps = (filePath: string): Record<string, { enum?: string[] }> => {
+  const pkg = getPackageJson(filePath);
+  if (!pkg) return {};
+  const configProps = pkg.contributes?.configuration?.properties ?? {};
+  const sectionKey = Object.keys(configProps).find(k => k.endsWith('.commandLevelNotifications'));
+  if (!sectionKey) return {};
+  return configProps[sectionKey]?.properties ?? {};
+};
+
+/** Collect string literal members from a type alias body (union or single literal). */
+const collectLiterals = (node: TSESTree.TSTypeAnnotation['typeAnnotation']): string[] => {
+  if (node.type === AST_NODE_TYPES.TSUnionType) {
+    return node.types.flatMap(t =>
+      t.type === AST_NODE_TYPES.TSLiteralType &&
+      t.literal.type === AST_NODE_TYPES.Literal &&
+      typeof t.literal.value === 'string'
+        ? [t.literal.value]
+        : []
+    );
+  }
+  if (
+    node.type === AST_NODE_TYPES.TSLiteralType &&
+    node.literal.type === AST_NODE_TYPES.Literal &&
+    typeof node.literal.value === 'string'
+  ) {
+    return [node.literal.value];
+  }
+  return [];
+};
+
+const setsEqual = (a: Set<string>, b: Set<string>): boolean => a.size === b.size && [...a].every(v => b.has(v));
+
+export const notificationSlotMatchesPackageJson = RuleCreator.withoutDocs<
+  [],
+  'unknownKey' | 'slotMismatch' | 'unknownEnumShape'
+>({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        "Require SuccessOnlyCommandKey / ProgressOnlyCommandKey literals to match their slot's enum shape in package.json commandLevelNotifications"
+    },
+    schema: [],
+    messages: {
+      unknownKey: "'{{key}}' is not a key in package.json commandLevelNotifications.properties.",
+      slotMismatch:
+        "'{{key}}' has enum shape {{actual}} in package.json but is declared in {{alias}} (expected {{expected}}).",
+      unknownEnumShape: "'{{key}}' has an unrecognized enum shape in package.json: [{{enum}}]."
+    }
+  },
+  defaultOptions: [],
+  create: context => ({
+    TSTypeAliasDeclaration: (node: TSESTree.TSTypeAliasDeclaration): void => {
+      const aliasName = node.id.name;
+      if (aliasName !== 'SuccessOnlyCommandKey' && aliasName !== 'ProgressOnlyCommandKey') return;
+
+      // Ignore `never` bodies
+      if (node.typeAnnotation.type === AST_NODE_TYPES.TSNeverKeyword) return;
+
+      const keys = collectLiterals(node.typeAnnotation);
+      if (keys.length === 0) return;
+
+      const props = getCommandLevelProps(context.filename);
+
+      for (const key of keys) {
+        const entry = props[key];
+        if (!entry) {
+          context.report({ node: node.id, messageId: 'unknownKey', data: { key } });
+          continue;
+        }
+
+        const enumValues = entry.enum;
+        if (!enumValues || enumValues.length === 0) continue;
+
+        const enumSet = new Set(enumValues);
+        const isSuccess = setsEqual(enumSet, SUCCESS_ONLY_ENUM);
+        const isProgress = setsEqual(enumSet, PROGRESS_ONLY_ENUM);
+
+        if (!isSuccess && !isProgress) {
+          context.report({
+            node: node.id,
+            messageId: 'unknownEnumShape',
+            data: { key, enum: enumValues.join(', ') }
+          });
+          continue;
+        }
+
+        if (aliasName === 'SuccessOnlyCommandKey' && !isSuccess) {
+          context.report({
+            node: node.id,
+            messageId: 'slotMismatch',
+            data: {
+              key,
+              alias: 'SuccessOnlyCommandKey',
+              actual: isProgress ? 'ProgressOnly' : 'unknown',
+              expected: 'SuccessOnly'
+            }
+          });
+        }
+
+        if (aliasName === 'ProgressOnlyCommandKey' && !isProgress) {
+          context.report({
+            node: node.id,
+            messageId: 'slotMismatch',
+            data: {
+              key,
+              alias: 'ProgressOnlyCommandKey',
+              actual: isSuccess ? 'SuccessOnly' : 'unknown',
+              expected: 'ProgressOnly'
+            }
+          });
+        }
+      }
+    }
+  })
+});

--- a/packages/eslint-local-rules/src/notificationSlotMatchesPackageJson.ts
+++ b/packages/eslint-local-rules/src/notificationSlotMatchesPackageJson.ts
@@ -7,45 +7,14 @@
 
 import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
 import { RuleCreator } from '@typescript-eslint/utils/eslint-utils';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-
-type PackageJson = {
-  contributes?: {
-    configuration?: {
-      properties?: Record<string, { properties?: Record<string, { enum?: string[] }> }>;
-    };
-  };
-};
+import { getNearestPackageJson } from './packageJsonUtils';
 
 const SUCCESS_ONLY_ENUM = new Set(['successToast', 'successStatusBar', 'successOff']);
 const PROGRESS_ONLY_ENUM = new Set(['progressToast', 'progressStatusBar']);
 
-const packageJsonCache = new Map<string, PackageJson | undefined>();
-
-const getPackageJson = (filePath: string): PackageJson | undefined => {
-  const dir = path.dirname(filePath);
-  if (packageJsonCache.has(dir)) return packageJsonCache.get(dir);
-
-  const parts = dir.split(path.sep);
-  for (let i = parts.length; i > 0; i--) {
-    const candidate = path.join(parts.slice(0, i).join(path.sep), 'package.json');
-    try {
-      const parsed = JSON.parse(fs.readFileSync(candidate, 'utf8')) as PackageJson;
-      packageJsonCache.set(dir, parsed);
-      return parsed;
-    } catch {
-      // continue walking up
-    }
-  }
-
-  packageJsonCache.set(dir, undefined);
-  return undefined;
-};
-
 /** Read commandLevelNotifications properties from nearest package.json */
 const getCommandLevelProps = (filePath: string): Record<string, { enum?: string[] }> => {
-  const pkg = getPackageJson(filePath);
+  const pkg = getNearestPackageJson(filePath);
   if (!pkg) return {};
   const configProps = pkg.contributes?.configuration?.properties ?? {};
   const sectionKey = Object.keys(configProps).find(k => k.endsWith('.commandLevelNotifications'));

--- a/packages/eslint-local-rules/src/packageJsonUtils.ts
+++ b/packages/eslint-local-rules/src/packageJsonUtils.ts
@@ -17,6 +17,20 @@ export type PackageJson = {
   };
 };
 
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== undefined && value !== null;
+
+/** Read and parse a JSON file at a known path, returning it as a plain record. */
+export const readJsonRecord = (filePath: string): Record<string, unknown> | undefined => {
+  if (!fs.existsSync(filePath)) return undefined;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
 const packageJsonCache = new Map<string, PackageJson | undefined>();
 
 /** Find and parse the nearest package.json by walking up from the given file path. Result is cached per directory. */

--- a/packages/eslint-local-rules/src/packageJsonUtils.ts
+++ b/packages/eslint-local-rules/src/packageJsonUtils.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+export type PackageJson = {
+  contributes?: {
+    commands?: { command: string }[];
+    configuration?: {
+      properties?: Record<string, { properties?: Record<string, { enum?: string[] }> }>;
+    };
+  };
+};
+
+const packageJsonCache = new Map<string, PackageJson | undefined>();
+
+/** Find and parse the nearest package.json by walking up from the given file path. Result is cached per directory. */
+export const getNearestPackageJson = (filePath: string): PackageJson | undefined => {
+  const dir = path.dirname(filePath);
+  if (packageJsonCache.has(dir)) return packageJsonCache.get(dir);
+
+  const parts = dir.split(path.sep);
+  for (let i = parts.length; i > 0; i--) {
+    const candidate = path.join(parts.slice(0, i).join(path.sep), 'package.json');
+    try {
+      const parsed = JSON.parse(fs.readFileSync(candidate, 'utf8')) as PackageJson;
+      packageJsonCache.set(dir, parsed);
+      return parsed;
+    } catch {
+      // continue walking up
+    }
+  }
+
+  packageJsonCache.set(dir, undefined);
+  return undefined;
+};

--- a/packages/eslint-local-rules/src/vscodeignoreContributesConflict.ts
+++ b/packages/eslint-local-rules/src/vscodeignoreContributesConflict.ts
@@ -7,25 +7,12 @@
 
 import type { Rule } from 'eslint';
 import { minimatch } from 'minimatch';
-import * as fs from 'node:fs';
 import * as pathModule from 'node:path';
+import { isRecord, readJsonRecord } from './packageJsonUtils';
 
 type ParsedLine = {
   readonly line: number;
   readonly pattern: string;
-};
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== undefined && value !== null;
-
-const readJsonRecord = (filePath: string): Record<string, unknown> | undefined => {
-  if (!fs.existsSync(filePath)) return undefined;
-  try {
-    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-    return isRecord(parsed) ? parsed : undefined;
-  } catch {
-    return undefined;
-  }
 };
 
 /**

--- a/packages/eslint-local-rules/src/vscodeignoreRequiredPatterns.ts
+++ b/packages/eslint-local-rules/src/vscodeignoreRequiredPatterns.ts
@@ -8,6 +8,7 @@
 import type { Rule } from 'eslint';
 import * as fs from 'node:fs';
 import * as pathModule from 'node:path';
+import { readJsonRecord } from './packageJsonUtils';
 
 const REQUIRED_STATIC_ENTRIES = [
   '**/*.map',
@@ -39,22 +40,6 @@ const EXISTENCE_CHECKED_DIRS = ['scripts/**', 'docs/**'];
 type VscodeignoreLine = {
   readonly line: number;
   readonly value: string;
-};
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== undefined && value !== null;
-
-const readJsonRecord = (filePath: string): Record<string, unknown> | undefined => {
-  if (!fs.existsSync(filePath)) {
-    return undefined;
-  }
-
-  try {
-    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-    return isRecord(parsed) ? parsed : undefined;
-  } catch {
-    return undefined;
-  }
 };
 
 const parseVscodeignoreLine = (lineText: string): string | undefined => {

--- a/packages/eslint-local-rules/test/fixtures/notification-slot/package.json
+++ b/packages/eslint-local-rules/test/fixtures/notification-slot/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "test-notification-slot-fixture",
+  "contributes": {
+    "configuration": {
+      "properties": {
+        "test-ext.commandLevelNotifications": {
+          "properties": {
+            "My Success Command": {
+              "enum": ["successToast", "successStatusBar", "successOff"]
+            },
+            "My Progress Command": {
+              "enum": ["progressToast", "progressStatusBar"]
+            },
+            "My PAS Command": {
+              "enum": [
+                "progressToastSuccessToast",
+                "progressToastSuccessOff",
+                "progressStatusBarSuccessStatusBar",
+                "progressStatusBarSuccessOff"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/eslint-local-rules/test/notification-slot-matches-package-json.test.ts
+++ b/packages/eslint-local-rules/test/notification-slot-matches-package-json.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as path from 'node:path';
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { notificationSlotMatchesPackageJson } from '../src/notificationSlotMatchesPackageJson';
+
+const ruleTester = new RuleTester();
+
+const fixtureDir = path.join(__dirname, 'fixtures', 'notification-slot');
+
+ruleTester.run('notification-slot-matches-package-json', notificationSlotMatchesPackageJson, {
+  valid: [
+    {
+      // SuccessOnly key with correct success enum shape
+      code: `export type SuccessOnlyCommandKey = 'My Success Command';`,
+      filename: path.join(fixtureDir, 'notificationMode.ts')
+    },
+    {
+      // ProgressOnly key with correct progress enum shape
+      code: `export type ProgressOnlyCommandKey = 'My Progress Command';`,
+      filename: path.join(fixtureDir, 'notificationMode.ts')
+    },
+    {
+      // Multiple keys all with correct shape
+      code: `export type SuccessOnlyCommandKey = 'My Success Command';
+export type ProgressOnlyCommandKey = 'My Progress Command';`,
+      filename: path.join(fixtureDir, 'notificationMode.ts')
+    },
+    {
+      // never body is ignored
+      code: `export type SuccessOnlyCommandKey = never;`,
+      filename: path.join(fixtureDir, 'notificationMode.ts')
+    },
+    {
+      // ProgressAndSuccessCommandKey is ignored because it is not a hand-written slot
+      code: `export type ProgressAndSuccessCommandKey = 'My PAS Command';`,
+      filename: path.join(fixtureDir, 'notificationMode.ts')
+    }
+  ],
+  invalid: [
+    {
+      // SuccessOnly alias listing a ProgressOnly key
+      code: `export type SuccessOnlyCommandKey = 'My Progress Command';`,
+      filename: path.join(fixtureDir, 'notificationMode.ts'),
+      errors: [
+        {
+          messageId: 'slotMismatch',
+          data: {
+            key: 'My Progress Command',
+            alias: 'SuccessOnlyCommandKey',
+            actual: 'ProgressOnly',
+            expected: 'SuccessOnly'
+          }
+        }
+      ]
+    },
+    {
+      // ProgressOnly alias listing a SuccessOnly key
+      code: `export type ProgressOnlyCommandKey = 'My Success Command';`,
+      filename: path.join(fixtureDir, 'notificationMode.ts'),
+      errors: [
+        {
+          messageId: 'slotMismatch',
+          data: {
+            key: 'My Success Command',
+            alias: 'ProgressOnlyCommandKey',
+            actual: 'SuccessOnly',
+            expected: 'ProgressOnly'
+          }
+        }
+      ]
+    },
+    {
+      // SuccessOnly alias listing a PAS key (unknown enum shape)
+      code: `export type SuccessOnlyCommandKey = 'My PAS Command';`,
+      filename: path.join(fixtureDir, 'notificationMode.ts'),
+      errors: [
+        {
+          messageId: 'unknownEnumShape',
+          data: {
+            key: 'My PAS Command',
+            enum: 'progressToastSuccessToast, progressToastSuccessOff, progressStatusBarSuccessStatusBar, progressStatusBarSuccessOff'
+          }
+        }
+      ]
+    },
+    {
+      // Key not present in package.json at all
+      code: `export type SuccessOnlyCommandKey = 'Nonexistent Command';`,
+      filename: path.join(fixtureDir, 'notificationMode.ts'),
+      errors: [{ messageId: 'unknownKey', data: { key: 'Nonexistent Command' } }]
+    },
+    {
+      // Union with one valid and one wrong key
+      code: `export type SuccessOnlyCommandKey = 'My Success Command' | 'My Progress Command';`,
+      filename: path.join(fixtureDir, 'notificationMode.ts'),
+      errors: [
+        {
+          messageId: 'slotMismatch',
+          data: {
+            key: 'My Progress Command',
+            alias: 'SuccessOnlyCommandKey',
+            actual: 'ProgressOnly',
+            expected: 'SuccessOnly'
+          }
+        }
+      ]
+    }
+  ]
+});

--- a/packages/salesforcedx-vscode-apex-debugger/src/utils/notificationMode.ts
+++ b/packages/salesforcedx-vscode-apex-debugger/src/utils/notificationMode.ts
@@ -5,6 +5,11 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export type ProgressAndSuccessCommandKey = 'SFDX: Stop Apex Debugger Session';
+import type pkg from '../../package.json';
+
+type CommandNotificationKey =
+  keyof (typeof pkg)['contributes']['configuration']['properties']['salesforcedx-vscode-apex-debugger.commandLevelNotifications']['properties'];
 
 export type ProgressOnlyCommandKey = 'SFDX: Create and Set Up Project for ISV Debugging';
+
+export type ProgressAndSuccessCommandKey = Exclude<CommandNotificationKey, ProgressOnlyCommandKey>;

--- a/packages/salesforcedx-vscode-apex-log/src/utils/notificationMode.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/utils/notificationMode.ts
@@ -5,11 +5,14 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export type ProgressAndSuccessCommandKey =
-  | 'SFDX: Execute Anonymous Apex with Currently Open Editor'
-  | "SFDX: Execute Anonymous Apex with Editor's Selected Text";
+import type pkg from '../../package.json';
+
+type CommandNotificationKey =
+  keyof (typeof pkg)['contributes']['configuration']['properties']['salesforcedx-vscode-apex-log.commandLevelNotifications']['properties'];
 
 export type SuccessOnlyCommandKey =
   | 'SFDX: Remove Trace Flag for Current User'
   | 'SFDX: Remove Trace Flag'
   | 'SFDX: Remove Debug Level';
+
+export type ProgressAndSuccessCommandKey = Exclude<CommandNotificationKey, SuccessOnlyCommandKey>;

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/utils/notificationMode.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/utils/notificationMode.ts
@@ -5,6 +5,11 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export type ProgressAndSuccessCommandKey = 'Debug Apex Test Class' | 'Debug Anonymous Apex';
+import type pkg from '../../package.json';
+
+type CommandNotificationKey =
+  keyof (typeof pkg)['contributes']['configuration']['properties']['salesforcedx-vscode-apex-replay-debugger.commandLevelNotifications']['properties'];
 
 export type ProgressOnlyCommandKey = 'Update Checkpoints in Org';
+
+export type ProgressAndSuccessCommandKey = Exclude<CommandNotificationKey, ProgressOnlyCommandKey>;

--- a/packages/salesforcedx-vscode-metadata/src/utils/notificationMode.ts
+++ b/packages/salesforcedx-vscode-metadata/src/utils/notificationMode.ts
@@ -5,17 +5,13 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export type ProgressAndSuccessCommandKey =
-  | 'SFDX: Deploy This Source to Org'
-  | 'SFDX: Retrieve This Source from Org'
-  | 'SFDX: Push Source to Default Org'
-  | 'SFDX: Pull Source from Default Org'
-  | 'SFDX: Deploy Source in Manifest to Org'
-  | 'SFDX: Retrieve Source in Manifest from Org'
-  | 'SFDX: Delete from Project and Org'
-  | 'SFDX: Install Package'
-  | 'Deploy on Save';
+import type pkg from '../../package.json';
+
+type CommandNotificationKey =
+  keyof (typeof pkg)['contributes']['configuration']['properties']['salesforcedx-vscode-metadata.commandLevelNotifications']['properties'];
 
 export type ProgressOnlyCommandKey = 'SFDX: Diff Source Against Org';
+
+export type ProgressAndSuccessCommandKey = Exclude<CommandNotificationKey, ProgressOnlyCommandKey>;
 
 export type CommandKey = ProgressAndSuccessCommandKey | ProgressOnlyCommandKey;

--- a/packages/salesforcedx-vscode-org-browser/src/utils/notificationMode.ts
+++ b/packages/salesforcedx-vscode-org-browser/src/utils/notificationMode.ts
@@ -5,4 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export type ProgressAndSuccessCommandKey = 'Retrieve Metadata';
+import type pkg from '../../package.json';
+
+/** Derive command keys from package.json schema at compile time */
+type CommandNotificationKey =
+  keyof (typeof pkg)['contributes']['configuration']['properties']['salesforcedx-vscode-org-browser.commandLevelNotifications']['properties'];
+
+export type ProgressAndSuccessCommandKey = CommandNotificationKey;

--- a/packages/salesforcedx-vscode-org-browser/src/utils/notificationMode.ts
+++ b/packages/salesforcedx-vscode-org-browser/src/utils/notificationMode.ts
@@ -8,7 +8,5 @@
 import type pkg from '../../package.json';
 
 /** Derive command keys from package.json schema at compile time */
-type CommandNotificationKey =
+export type ProgressAndSuccessCommandKey =
   keyof (typeof pkg)['contributes']['configuration']['properties']['salesforcedx-vscode-org-browser.commandLevelNotifications']['properties'];
-
-export type ProgressAndSuccessCommandKey = CommandNotificationKey;

--- a/packages/salesforcedx-vscode-soql/src/utils/notificationMode.ts
+++ b/packages/salesforcedx-vscode-soql/src/utils/notificationMode.ts
@@ -5,6 +5,15 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export type ProgressAndSuccessCommandKey = 'SOQL Text Editor Run Query';
-export type ProgressOnlyCommandKey = 'SOQL Builder Run Query';
+import type pkg from '../../package.json';
+
+type CommandNotificationKey =
+  keyof (typeof pkg)['contributes']['configuration']['properties']['salesforcedx-vscode-soql.commandLevelNotifications']['properties'];
+
 export type SuccessOnlyCommandKey = 'Save Query Results';
+export type ProgressOnlyCommandKey = 'SOQL Builder Run Query';
+
+export type ProgressAndSuccessCommandKey = Exclude<
+  CommandNotificationKey,
+  SuccessOnlyCommandKey | ProgressOnlyCommandKey
+>;


### PR DESCRIPTION
<!--- PR title: <type>(optional scope): <description> - W-XXXXXXXX — append GUS work item at the end (space, hyphen, space, W-). Conventional commits: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
1. Layer A (types): derive valid-key SET from package.json at compile time so stale/typo keys fail tsc.
2. Layer B (lint): new eslint-local-rules rule reading notificationMode.ts DECLARATIONS, asserting each hand-written key's package.json enum SHAPE matches its slot — the invariant tsc cannot check.

Result of Layer B:
1. Key defined as ProgressOnly but contains SuccessOnly enums
<img width="2032" height="1162" alt="Screenshot 2026-08-13 at 12 22 22 PM" src="https://github.com/user-attachments/assets/bced13dd-5923-484f-acf9-b12f41cf14ec" />
<br><br>
2. Key listed in **notificationMode.ts** but not in the **package.json** key list for the setting
<img width="2032" height="1162" alt="Screenshot 2026-08-13 at 1 16 19 PM" src="https://github.com/user-attachments/assets/5f9c9ed4-e4bb-4482-a5f1-396863917ad1" />

### What issues does this PR fix or reference?
@W-23546519@
