### PR TITLE
fix(ci): explicitly set nightly: false in publishVSCode workflow

### DIFF
--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -180,6 +180,7 @@ jobs:
       extensions: ${{ needs.build-extension-list.outputs.extensions }}
       registries: 'all'
       pre-release: 'false'  # Stable releases (even minor versions)
+      nightly: 'false'
       version-bump: 'none'  # Version already set in release
       dry-run: false  # Publish to marketplace
       git-user-name: ${{ needs.get-git-identity.outputs.username }}


### PR DESCRIPTION
The shared workflow vscode-publish-extensions.yml defaults nightly to true, causing stable releases to skip marketplace publishing. This resulted in v67.10.0 only creating GitHub releases without publishing to VS Code Marketplace or Open VSX.

Explicitly pass nightly: false to ensure stable releases are published to all configured registries.

<!--- PR title: <type>(optional scope): <description> - W-XXXXXXXX — append GUS work item at the end (space, hyphen, space, W-). Conventional commits: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?

### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @<Insert GUS WI>@

### Functionality Before
<insert gif and/or summary>

### Functionality After
<insert gif and/or summary>
