### PR TITLE
fix(ci): pass nightly as boolean in publishVSCode workflow

### DIFF
--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -180,6 +180,7 @@ jobs:
       extensions: ${{ needs.build-extension-list.outputs.extensions }}
       registries: 'all'
       pre-release: 'false'  # Stable releases (even minor versions)
+      nightly: false  # Ensure marketplace publishing (shared workflow defaults to true)
       version-bump: 'none'  # Version already set in release
       dry-run: false  # Publish to marketplace
       git-user-name: ${{ needs.get-git-identity.outputs.username }}

--- a/contributing/publishing.md
+++ b/contributing/publishing.md
@@ -80,7 +80,10 @@ Then triggers `publishVSCode.yml`:
 - Download VSIX files; validate ≥1 present, exit if missing
 - Upload as artifact for validation
 - Validate VSIX OPC Part URIs (via artifact)
+- Call shared workflow [`vscode-publish-extensions`](https://github.com/salesforcecli/github-workflows/blob/main/.github/workflows/vscode-publish-extensions.yml) with `nightly: false` (boolean) to publish to VS Code Marketplace, Open VSX, and other configured registries
 - Send approval notification
+
+**Note:** Shared workflow defaults `nightly: true` (skips marketplace publishing). Pass `nightly: false` as boolean (not string) for proper YAML type handling.
 
 **Manual workflow_dispatch triggers:** If manually triggering `publishVSCode.yml`, ensure `testBuildAndRelease.yml` has already created the GitHub release with VSIX artifacts. The workflow validates the release exists before attempting downloads and will fail early with a clear error if the release is missing.
 


### PR DESCRIPTION
The shared workflow vscode-publish-extensions.yml expects nightly as a

boolean type, but 8ab4e99ac passed it as string 'false', causing

workflow startup failures. Pass nightly: false (boolean, no quotes)

to ensure stable releases publish to marketplace while avoiding

type errors.

<!--- PR title: <type>(optional scope): <description> - W-XXXXXXXX — append GUS work item at the end (space, hyphen, space, W-). Conventional commits: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?

### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @<Insert GUS WI>@

### Functionality Before
<insert gif and/or summary>

### Functionality After
<insert gif and/or summary>
