### PR TITLE
ci(vscode): publish release VSIX assets

### DIFF
--- a/.github/workflows/publishOpenVSX.yml
+++ b/.github/workflows/publishOpenVSX.yml
@@ -47,7 +47,7 @@ jobs:
   publish:
     needs: ['ctc-open', 'prepare-release-metadata']
     if: always() && needs.prepare-release-metadata.result == 'success' && (inputs.dry-run || needs.ctc-open.result == 'success')
-    uses: salesforcecli/github-workflows/.github/workflows/openvsx-publish-release-vsix.yml@sm/publish-release-vsix
+    uses: salesforcecli/github-workflows/.github/workflows/vscode-publish-release-vsix.yml@main
     with:
       release-tag: ${{ needs.prepare-release-metadata.outputs.RELEASE_TAG }}
       dry-run: ${{ inputs.dry-run }}

--- a/.github/workflows/publishOpenVSX.yml
+++ b/.github/workflows/publishOpenVSX.yml
@@ -4,88 +4,82 @@ on:
     # This limits the workflow to releases that are not pre-releases
     # From the docs: A release was published, or a pre-release was changed to a release.
     types: [released]
-  #  Button for publishing main branch in case there is a failure on the release.
+  # Button for retrying a specific release if automatic publishing fails.
   workflow_dispatch:
     inputs:
-      verify_only:
-        description: 'Skip re-publish; only download release + poll OpenVSX for the main version'
+      release-tag:
+        description: 'Release tag to publish (for example, v67.10.0)'
+        required: true
+        type: string
+      dry-run:
+        description: 'Download and inspect VSIXs without publishing or polling Open VSX'
         type: boolean
         default: false
 
 jobs:
-  prepare-environment-from-main:
-    name: 'Get Release Version'
+  prepare-release-metadata:
+    name: 'Prepare Release Metadata'
     # Only run for extension releases (e.g. v66.7.0), not npm package releases
     # which use a <name>-v prefix (e.g. soql-common-v1.0.4, vscode-i18n-v66.7.0).
-    if: github.event_name != 'release' || !contains(github.event.release.tag_name, '-v')
+    # Also exclude nightly releases (e.g. v67.11.0-nightly.20260812).
+    if: github.event_name != 'release' || (!contains(github.event.release.tag_name, '-v') && !contains(github.event.release.tag_name, '-nightly'))
     runs-on: ubuntu-latest
     environment: publish
     outputs:
-      RELEASE_VERSION: ${{ steps.getMainVersion.outputs.version }}
-      GUS_BUILD: ${{ steps.getGusBuild.outputs.gusBuild}}
-      SF_CHANGE_CASE_SCHEDULE_BUILD: ${{ steps.getScheduledBuild.outputs.sfChangeCaseScheduleBuild }}
+      RELEASE_TAG: ${{ steps.getReleaseTag.outputs.tag }}
+      RELEASE_VERSION: ${{ steps.getReleaseTag.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: 'main'
-      - id: getMainVersion
+      - id: getReleaseTag
+        env:
+          INPUT_RELEASE_TAG: ${{ github.event.inputs.release-tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          echo "version="$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")"" >> $GITHUB_OUTPUT
-      - run: echo "Main Version is ${{ steps.getMainVersion.outputs.version }}"
-      - id: getGusBuild
-        run: |
-          echo "gusBuild=${{ steps.getMainVersion.outputs.version }}" >> $GITHUB_OUTPUT
-      - run: echo "GUS BUILD is ${{ steps.getGusBuild.outputs.gusBuild }}"
-      - id: getScheduledBuild
-        run: |
-          echo "sfChangeCaseScheduleBuild=offcore.tooling.${{ steps.getMainVersion.outputs.version }}" >> $GITHUB_OUTPUT
-      - run: echo "SF_CHANGE_CASE_SCHEDULE_BUILD is ${{ steps.getScheduledBuild.outputs.sfChangeCaseScheduleBuild }}"\
+          TAG="${INPUT_RELEASE_TAG:-$RELEASE_TAG}"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
 
   ctc-open:
-    needs: [prepare-environment-from-main]
+    needs: [prepare-release-metadata]
+    if: inputs.dry-run != true
     uses: salesforcecli/github-workflows/.github/workflows/ctcOpen.yml@main
     secrets: inherit
 
   publish:
-    needs: ['ctc-open', 'prepare-environment-from-main']
+    needs: ['ctc-open', 'prepare-release-metadata']
+    if: always() && needs.prepare-release-metadata.result == 'success' && (inputs.dry-run || needs.ctc-open.result == 'success')
+    uses: salesforcecli/github-workflows/.github/workflows/openvsx-publish-release-vsix.yml@sm/publish-release-vsix
+    with:
+      release-tag: ${{ needs.prepare-release-metadata.outputs.RELEASE_TAG }}
+      dry-run: ${{ inputs.dry-run }}
+    secrets: inherit
+
+  verify-published:
+    needs: ['prepare-release-metadata', 'publish']
+    if: inputs.dry-run != true
     runs-on: ubuntu-latest
     env:
-      OVSX_PAT: ${{ secrets.IDEE_OVSX_PAT }}
-      PUBLISH_VERSION: ${{ needs.prepare-environment-from-main.outputs.RELEASE_VERSION }}
-      GITHUB_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
+      GH_TOKEN: ${{ github.token }}
+      PUBLISH_VERSION: ${{ needs.prepare-release-metadata.outputs.RELEASE_VERSION }}
+      RELEASE_TAG: ${{ needs.prepare-release-metadata.outputs.RELEASE_TAG }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: 'main'
-          token: ${{ secrets.IDEE_GH_TOKEN }}
       - uses: actions/setup-node@v7
         with:
           node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
-      - uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
-      - name: downloadExtensionsFromRelease
+      - name: Download VSIXs from release
         run: |
           mkdir ./extensions
-          gh release download v${{ env.PUBLISH_VERSION }} -D ./extensions
-      - name: Display downloaded vsix files
-        run: ls -R ./extensions
-      - if: ${{ !inputs.verify_only }}
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          command: |
-            cmd=$(find ./extensions -type f -name "*.vsix" -print0 | xargs -0 -I {} printf 'npx ovsx publish --skip-duplicate "%s" -p "%s" && ' '{}' "${OVSX_PAT}" | sed 's/ && $//') && [ -n "$cmd" ] && eval "$cmd" && echo "SUCCESSFULLY published"
+          gh release download "$RELEASE_TAG" -D ./extensions
       - name: Verify published versions landed on OpenVSX
         run: |
           TIMEOUT="${POLL_TIMEOUT:-600}"
           INTERVAL="${POLL_INTERVAL:-30}"
           deadline=$(( $(date +%s) + TIMEOUT ))
-          shopt -s nullglob
           pending=()
-          for f in ./extensions/*.vsix; do
+          while IFS= read -r -d '' f; do
             pending+=("salesforce.$(basename "$f" "-$PUBLISH_VERSION.vsix")")
-          done
+          done < <(find ./extensions -type f -name '*.vsix' -print0)
           if [ "${#pending[@]}" -eq 0 ]; then
-            echo "::error::no vsix files found in ./extensions — nothing to verify"
+            echo "::error::No VSIX files found in release $RELEASE_TAG"
             exit 1
           fi
           while :; do
@@ -111,16 +105,16 @@ jobs:
           echo "All published versions landed on OpenVSX"
 
   ctcCloseSuccess:
-    needs: [ctc-open, publish]
-    if: needs.ctc-open.result == 'success' && needs.publish.result == 'success' && needs.ctc-open.outputs.changeCaseId
+    needs: [ctc-open, verify-published]
+    if: needs.ctc-open.result == 'success' && needs.verify-published.result == 'success' && needs.ctc-open.outputs.changeCaseId
     uses: salesforcecli/github-workflows/.github/workflows/ctcClose.yml@main
     secrets: inherit
     with:
       changeCaseId: ${{needs.ctc-open.outputs.changeCaseId}}
 
   ctcCloseFail:
-    needs: [ctc-open, publish]
-    if: always() && needs.ctc-open.result == 'success' && needs.ctc-open.outputs.changeCaseId && needs.publish.result != 'success'
+    needs: [ctc-open, verify-published]
+    if: always() && needs.ctc-open.result == 'success' && needs.ctc-open.outputs.changeCaseId && needs.verify-published.result != 'success'
     uses: salesforcecli/github-workflows/.github/workflows/ctcClose.yml@main
     secrets: inherit
     with:

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -1,24 +1,28 @@
 name: Publish in Microsoft Marketplace
 
-# Publishing uses shared vscode-publish-extensions workflow for consistency.
+# Publishing uses the shared release-asset publisher workflow.
 
 on:
   release:
     # This limits the workflow to releases that are not pre-releases
     # From the docs: A release was published, or a pre-release was changed to a release.
     types: [released]
-  #  Button for publishing main branch in case there is a failure on the release.
+  # Button for retrying a specific release if automatic publishing fails.
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to publish (leave empty to read from main branch)'
-        required: false
-        default: ''
+        description: 'Release tag to publish (for example, v67.10.0)'
+        required: true
         type: string
+      dry-run:
+        description: 'Download and inspect VSIXs without publishing or triggering downstream releases'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
-  prepare-environment-from-main:
-    name: 'Get Release Version'
+  prepare-release-metadata:
+    name: 'Prepare Release Metadata'
     # Only run for extension releases (e.g. v66.7.0), not npm package releases
     # which use a <name>-v prefix (e.g. soql-common-v1.0.4, vscode-i18n-v66.7.0).
     # Also exclude nightly releases (e.g. v67.11.0-nightly.20260812).
@@ -26,29 +30,27 @@ jobs:
     runs-on: ubuntu-latest
     environment: publish
     outputs:
-      RELEASE_VERSION: ${{ steps.getMainVersion.outputs.version }}
+      RELEASE_TAG: ${{ steps.getReleaseTag.outputs.tag }}
+      CBW_RELEASE_VERSION: ${{ steps.cbwReleaseType.outputs.version }}
       CBW_RELEASE_TYPE: ${{ steps.cbwReleaseType.outputs.type }}
-      GUS_BUILD: ${{ steps.getGusBuild.outputs.gusBuild}}
+      GUS_BUILD: ${{ steps.getGusBuild.outputs.gusBuild }}
       SF_CHANGE_CASE_SCHEDULE_BUILD: ${{ steps.getScheduledBuild.outputs.sfChangeCaseScheduleBuild }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: 'main'
       - run: git fetch --tags --quiet
-      - id: getMainVersion
+      - id: getReleaseTag
         env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
           INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [ -n "$INPUT_VERSION" ]; then
-            VERSION="$INPUT_VERSION"
-          else
-            VERSION=$(node -pe "require('./packages/salesforcedx-vscode/package.json').version")
-          fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-      - run: echo "Main Version is ${{ steps.getMainVersion.outputs.version }}"
+          echo "tag=${INPUT_VERSION:-$RELEASE_TAG}" >> $GITHUB_OUTPUT
+      - run: echo "Release tag is ${{ steps.getReleaseTag.outputs.tag }}"
       - id: cbwReleaseType
         run: |
-          VERSION="${{ steps.getMainVersion.outputs.version }}"
+          VERSION="${{ steps.getReleaseTag.outputs.tag }}"
+          VERSION="${VERSION#v}"
           PREV_TAG=$(git tag -l 'v[0-9]*' --sort=-v:refname | grep -v "^v${VERSION}$" | head -1)
           PREV_VERSION="${PREV_TAG#v}"
 
@@ -61,20 +63,21 @@ jobs:
             TYPE="minor"
           fi
 
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "type=$TYPE" >> $GITHUB_OUTPUT
           echo "CBW release type: $TYPE (current=$VERSION, previous=$PREV_VERSION)"
       - id: getGusBuild
         run: |
-          echo "gusBuild=${{ steps.getMainVersion.outputs.version }}" >> $GITHUB_OUTPUT
+          echo "gusBuild=${{ steps.cbwReleaseType.outputs.version }}" >> $GITHUB_OUTPUT
       - run: echo "GUS BUILD is ${{ steps.getGusBuild.outputs.gusBuild }}"
       - id: getScheduledBuild
         run: |
-          echo "sfChangeCaseScheduleBuild=offcore.tooling.${{ steps.getMainVersion.outputs.version }}" >> $GITHUB_OUTPUT
+          echo "sfChangeCaseScheduleBuild=offcore.tooling.${{ steps.cbwReleaseType.outputs.version }}" >> $GITHUB_OUTPUT
       - run: echo "SF_CHANGE_CASE_SCHEDULE_BUILD is ${{ steps.getScheduledBuild.outputs.sfChangeCaseScheduleBuild }}"
 
   # Build list of extensions from release
   build-extension-list:
-    needs: [prepare-environment-from-main]
+    needs: [prepare-release-metadata]
     runs-on: ubuntu-latest
     outputs:
       extensions: ${{ steps.list.outputs.extensions }}
@@ -88,29 +91,29 @@ jobs:
           node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
       - name: Verify release exists
         env:
-          RELEASE_VERSION: ${{ needs.prepare-environment-from-main.outputs.RELEASE_VERSION }}
+          RELEASE_TAG: ${{ needs.prepare-release-metadata.outputs.RELEASE_TAG }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if ! gh release view v$RELEASE_VERSION &> /dev/null; then
-            echo "::error::Release v$RELEASE_VERSION does not exist. Cannot proceed with publish."
+          if ! gh release view "$RELEASE_TAG" &> /dev/null; then
+            echo "::error::Release $RELEASE_TAG does not exist. Cannot proceed with publish."
             echo "::notice::If triggered manually via workflow_dispatch, ensure the release has been created by testBuildAndRelease.yml first."
             exit 1
           fi
-          echo "Release v$RELEASE_VERSION exists, proceeding with download..."
+          echo "Release $RELEASE_TAG exists, proceeding with download..."
       - name: Download VSIXs from release
         env:
-          RELEASE_VERSION: ${{ needs.prepare-environment-from-main.outputs.RELEASE_VERSION }}
+          RELEASE_TAG: ${{ needs.prepare-release-metadata.outputs.RELEASE_TAG }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir ./extensions
-          gh release download v$RELEASE_VERSION -D ./extensions || {
-            echo "::error::Failed to download release v$RELEASE_VERSION"
+          gh release download "$RELEASE_TAG" -D ./extensions || {
+            echo "::error::Failed to download release $RELEASE_TAG"
             exit 1
           }
 
           # Validate: ≥1 VSIX file present
           if ! ls ./extensions/*.vsix 1> /dev/null 2>&1; then
-            echo "::error::No VSIX files found in release v$RELEASE_VERSION"
+            echo "::error::No VSIX files found in release $RELEASE_TAG"
             exit 1
           fi
 
@@ -123,69 +126,20 @@ jobs:
           EXTENSIONS=$(node scripts/parse-extension-names.js ./extensions)
           echo "extensions=$EXTENSIONS" >> $GITHUB_OUTPUT
           echo "Publishing extensions: $EXTENSIONS"
-      - name: Upload VSIXs for validation
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-vsix-files
-          path: ./extensions/*.vsix
-          retention-days: 1
 
   ctc-open:
-    needs: [prepare-environment-from-main]
+    needs: [prepare-release-metadata]
+    if: inputs.dry-run != true
     uses: salesforcecli/github-workflows/.github/workflows/ctcOpen.yml@main
     secrets: inherit
 
-  # Validate VSIX files before publishing
-  validate-vsix:
-    needs: [prepare-environment-from-main, build-extension-list]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: 'main'
-      - uses: actions/setup-node@v7
-        with:
-          node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
-      - name: Install dependencies
-        uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
-      - name: Download VSIXs from artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: release-vsix-files
-          path: ./extensions
-      - name: Display VSIX files
-        run: |
-          echo "VSIX files for validation:"
-          ls -lh ./extensions/*.vsix
-      - name: Validate VSIX OPC Part URIs
-        run: node scripts/validate-vsix-opc.mjs ./extensions
-
-  get-git-identity:
-    runs-on: ubuntu-latest
-    outputs:
-      username: ${{ steps.github-user-info.outputs.username }}
-      email: ${{ steps.github-user-info.outputs.email }}
-    steps:
-      - name: Get Github user info
-        id: github-user-info
-        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@main
-        with:
-          SVC_CLI_BOT_GITHUB_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
-
   publish:
-    needs: ['ctc-open', 'prepare-environment-from-main', 'build-extension-list', 'validate-vsix', 'get-git-identity']
-    uses: salesforcecli/github-workflows/.github/workflows/vscode-publish-extensions.yml@main
+    needs: ['ctc-open', 'prepare-release-metadata']
+    if: always() && needs.prepare-release-metadata.result == 'success' && (inputs.dry-run || needs.ctc-open.result == 'success')
+    uses: salesforcecli/github-workflows/.github/workflows/vscode-publish-release-vsix.yml@sm/publish-release-vsix
     with:
-      branch: 'main'
-      extensions: ${{ needs.build-extension-list.outputs.extensions }}
-      registries: 'all'
-      pre-release: 'false'  # Stable releases (even minor versions)
-      nightly: false  # Ensure marketplace publishing (shared workflow defaults to true)
-      version-bump: 'none'  # Version already set in release
-      dry-run: false  # Publish to marketplace
-      git-user-name: ${{ needs.get-git-identity.outputs.username }}
-      git-user-email: ${{ needs.get-git-identity.outputs.email }}
+      release-tag: ${{ needs.prepare-release-metadata.outputs.RELEASE_TAG }}
+      dry-run: ${{ inputs.dry-run }}
     secrets: inherit
 
   ctcCloseSuccess:
@@ -210,8 +164,8 @@ jobs:
   # Uses repository_dispatch (not workflow_call) because GitHub Actions blocks
   # public repos from calling reusable workflows in private repos.
   trigger-cbw-release:
-    needs: [publish, prepare-environment-from-main, build-extension-list]
-    if: needs.publish.result == 'success' && vars.CBW_TRIGGER_ENABLED != 'false'
+    needs: [publish, prepare-release-metadata, build-extension-list]
+    if: needs.publish.result == 'success' && !inputs.dry-run && vars.CBW_TRIGGER_ENABLED != 'false'
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:
@@ -226,8 +180,8 @@ jobs:
       - name: Trigger Code Builder Web release
         env:
           GH_TOKEN: ${{ steps.dispatch-token.outputs.token }}
-          VERSION: ${{ needs.prepare-environment-from-main.outputs.RELEASE_VERSION }}
-          RELEASE_TYPE: ${{ needs.prepare-environment-from-main.outputs.CBW_RELEASE_TYPE }}
+          VERSION: ${{ needs.prepare-release-metadata.outputs.CBW_RELEASE_VERSION }}
+          RELEASE_TYPE: ${{ needs.prepare-release-metadata.outputs.CBW_RELEASE_TYPE }}
           EXTENSIONS: ${{ needs.build-extension-list.outputs.extensions }}
         run: |
           echo "Dispatching extension-publish event to code-builder-web with version $VERSION (release-type: $RELEASE_TYPE, extensions: $EXTENSIONS)"

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -136,7 +136,7 @@ jobs:
   publish:
     needs: ['ctc-open', 'prepare-release-metadata']
     if: always() && needs.prepare-release-metadata.result == 'success' && (inputs.dry-run || needs.ctc-open.result == 'success')
-    uses: salesforcecli/github-workflows/.github/workflows/vscode-publish-release-vsix.yml@sm/publish-release-vsix
+    uses: salesforcecli/github-workflows/.github/workflows/vscode-publish-release-vsix.yml@main
     with:
       release-tag: ${{ needs.prepare-release-metadata.outputs.RELEASE_TAG }}
       dry-run: ${{ inputs.dry-run }}

--- a/contributing/publishing.md
+++ b/contributing/publishing.md
@@ -78,14 +78,10 @@ Merge to `main` triggers [testBuildAndRelease](https://github.com/forcedotcom/sa
 Then triggers `publishVSCode.yml`:
 - Verify release exists (required for manual workflow_dispatch triggers)
 - Download VSIX files; validate ≥1 present, exit if missing
-- Upload as artifact for validation
-- Validate VSIX OPC Part URIs (via artifact)
-- Call shared workflow [`vscode-publish-extensions`](https://github.com/salesforcecli/github-workflows/blob/main/.github/workflows/vscode-publish-extensions.yml) with `nightly: false` (boolean) to publish to VS Code Marketplace, Open VSX, and other configured registries
+- Call the shared release-asset publisher to publish every VSIX in the GitHub release to VS Code Marketplace
 - Send approval notification
 
-**Note:** Shared workflow defaults `nightly: true` (skips marketplace publishing). Pass `nightly: false` as boolean (not string) for proper YAML type handling.
-
-**Manual workflow_dispatch triggers:** If manually triggering `publishVSCode.yml`, ensure `testBuildAndRelease.yml` has already created the GitHub release with VSIX artifacts. The workflow validates the release exists before attempting downloads and will fail early with a clear error if the release is missing.
+**Manual workflow_dispatch triggers:** Specify the release tag (for example, `v67.10.0`) and ensure `testBuildAndRelease.yml` has already created that GitHub release with VSIX artifacts. The workflow validates the release exists before attempting downloads and will fail early with a clear error if the release is missing.
 
 Before approving marketplace publish, download VSIX files, install locally, verify functionality.
 

--- a/packages/salesforcedx-vscode-services-types/package.json
+++ b/packages/salesforcedx-vscode-services-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/vscode-services",
-  "version": "67.11.1",
+  "version": "67.11.2",
   "description": "TypeScript type definitions for Salesforce VS Code Services extension API",
   "author": "Salesforce",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
## Summary
- Publish stable VSIX assets directly from the selected GitHub release through the shared VS Code Marketplace and Open VSX workflows.
- Add dispatch dry runs that pass through to the shared workflows and suppress CTC, Open VSX polling, and Code Builder Web side effects.
- Update the services types package version to `67.11.2`.

## Dependency
Do not merge this PR until https://github.com/salesforcecli/github-workflows/pull/171 merges. Before merging this PR, update both shared-workflow references from `@sm/publish-release-vsix` to `@main`.

## Verification
- `npm run check:actions`
- `actionlint .github/workflows/publishVSCode.yml .github/workflows/publishOpenVSX.yml`
- Pre-commit and pre-push hooks

### What issues does this PR fix or reference?
No related issues or discussions.

[skip-validate-pr]