### PR TITLE
fix(lwc): refine jsconfig writes and package watchers

### DIFF
--- a/packages/salesforcedx-lightning-lsp-common/src/baseContext.ts
+++ b/packages/salesforcedx-lightning-lsp-common/src/baseContext.ts
@@ -42,51 +42,7 @@ const isSfdxPackageDirectoryConfig = (value: unknown): value is SfdxPackageDirec
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null;
-
-/**
- * Debounced file writer using Effect to prevent rapid successive writes to the same file.
- * Uses a Ref to track pending writes and Effect.sleep for debouncing.
- */
-const createDebouncedWriter = (debounceMs = 500) => {
-  const pendingWrites = new Map<string, { content: string; timer: NodeJS.Timeout }>();
-
-  return {
-    /**
-     * Schedule a debounced write. If called multiple times for the same path,
-     * only the last write will execute after the debounce period.
-     */
-    write: (
-      filePath: string,
-      content: string,
-      writeImpl: (targetPath: string, data: string) => Promise<void>
-    ): Promise<void> => {
-      // Clear any pending write for this path
-      const existing = pendingWrites.get(filePath);
-      if (existing) {
-        clearTimeout(existing.timer);
-      }
-
-      // Schedule new write after debounce period
-      return new Promise((resolve, reject) => {
-        const timer = setTimeout(() => {
-          pendingWrites.delete(filePath);
-          writeImpl(filePath, content)
-            .then(() => resolve())
-            .catch(error => reject(error));
-        }, debounceMs);
-
-        pendingWrites.set(filePath, { content, timer });
-      });
-    },
-
-    /** Flush all pending writes immediately */
-    flush: (): void => {
-      const timers = Array.from(pendingWrites.values());
-      pendingWrites.clear();
-      timers.forEach(({ timer }) => clearTimeout(timer));
-    }
-  };
-};
+const JSON_INDENT = 2;
 
 /**
  * Schema for JSON-serializable values (primitives, arrays, nested objects).
@@ -121,6 +77,7 @@ type JsonValue =
  * Effect Schema's equivalence automatically handles recursive structures.
  */
 const jsonValueEquivalence = Schema.equivalence(JsonValueSchema);
+const decodeJsonValue = Schema.decodeUnknownSync(JsonValueSchema);
 
 /**
  * Compares two JSON-serializable values for deep structural equality using Effect Schema.
@@ -140,8 +97,8 @@ export const areJsonValuesEqual = (a: unknown, b: unknown): boolean => {
   try {
     // Decode both values through the schema to validate they're valid JSON
     // Then use the schema-derived equivalence to compare them
-    const decodedA = Schema.decodeUnknownSync(JsonValueSchema)(a);
-    const decodedB = Schema.decodeUnknownSync(JsonValueSchema)(b);
+    const decodedA = decodeJsonValue(a);
+    const decodedB = decodeJsonValue(b);
 
     return jsonValueEquivalence(decodedA, decodedB);
   } catch {
@@ -324,7 +281,6 @@ export abstract class BaseWorkspaceContext {
   public fileSystemAccessor: LspFileSystemAccessor;
   private readonly sfdxTypingsDir?: string;
   private _connection?: Connection;
-  private readonly debouncedWriter = createDebouncedWriter(500);
 
   /** The LSP connection. Setting this also propagates to the fileSystemAccessor. */
   public get connection(): Connection | undefined {
@@ -537,7 +493,7 @@ export abstract class BaseWorkspaceContext {
             continue;
           }
 
-          jsconfigContent = JSON.stringify(mergedConfig, null, 4);
+          jsconfigContent = JSON.stringify(mergedConfig, null, JSON_INDENT);
         } else {
           // Create new jsconfig from template
           if (this.workspaceRoots?.length === 0 || !this.workspaceRoots[0]) {
@@ -560,13 +516,10 @@ export abstract class BaseWorkspaceContext {
             ...jsconfigSfdx,
             include: [...jsconfigSfdx.include, typingsInclude]
           };
-          jsconfigContent = JSON.stringify(config, null, 2);
+          jsconfigContent = JSON.stringify(config, null, JSON_INDENT);
         }
 
-        // Use debounced writer to prevent rapid successive writes during git operations
-        await this.debouncedWriter.write(jsconfigPath, jsconfigContent, (filePath, fileContent) =>
-          this.fileSystemAccessor.updateFileContent(filePath, fileContent)
-        );
+        await this.fileSystemAccessor.updateFileContent(jsconfigPath, jsconfigContent);
       } catch (error) {
         console.error(
           `writeSfdxJsconfig: Error reading/writing jsconfig: ${isError(error) ? error.message : String(error)}`
@@ -605,11 +558,21 @@ export abstract class BaseWorkspaceContext {
             ...jsconfigCore,
             include: [...jsconfigCore.include, typingsInclude]
           };
-          const jsconfigContent = JSON.stringify(config, null, 2);
-          // Use debounced writer to prevent rapid successive writes
-          await this.debouncedWriter.write(jsconfigPath, jsconfigContent, (filePath, fileContent) =>
-            this.fileSystemAccessor.updateFileContent(filePath, fileContent)
-          );
+
+          const existingConfigContent = await this.fileSystemAccessor.getFileContent(jsconfigPath);
+          if (existingConfigContent) {
+            try {
+              const existingConfig: unknown = JSON.parse(existingConfigContent);
+              if (areJsonValuesEqual(config, existingConfig)) {
+                continue;
+              }
+            } catch {
+              // Invalid existing JSON should be replaced with the generated configuration.
+            }
+          }
+
+          const jsconfigContent = JSON.stringify(config, null, JSON_INDENT);
+          await this.fileSystemAccessor.updateFileContent(jsconfigPath, jsconfigContent);
         } catch (error) {
           console.error('writeCoreJsconfig: Error reading/writing jsconfig:', error);
           throw error;

--- a/packages/salesforcedx-lightning-lsp-common/test/context.test.ts
+++ b/packages/salesforcedx-lightning-lsp-common/test/context.test.ts
@@ -350,8 +350,8 @@ describe('WorkspaceContext', () => {
     const afterFirstContent = (await freshAccessor.getFileContent(jsconfigPath)) ?? '';
     const afterFirst = JSON.parse(Buffer.from(afterFirstContent).toString('utf8')) as JsconfigContent;
 
-    // Manually reformat the file with different spacing (2 spaces instead of 4) to simulate external formatting
-    const reformattedContent = JSON.stringify(afterFirst, null, 2);
+    // Manually reformat the file with different spacing to simulate external formatting
+    const reformattedContent = JSON.stringify(afterFirst, null, 4);
     await freshAccessor.updateFileContent(jsconfigPath, reformattedContent);
 
     // Track writes by spying on updateFileContent
@@ -365,7 +365,7 @@ describe('WorkspaceContext', () => {
     const writesToJsconfig = writeSpy.mock.calls.filter(call => call[0] === jsconfigPath);
     expect(writesToJsconfig).toHaveLength(0);
 
-    // Verify content remained reformatted (2-space indent)
+    // Verify content remained reformatted
     const finalContent = (await freshAccessor.getFileContent(jsconfigPath)) ?? '';
     expect(finalContent).toBe(reformattedContent);
 
@@ -391,6 +391,38 @@ describe('WorkspaceContext', () => {
       Buffer.from((await coreProjectFileSystemAccessor.getFileContent(settingsPath)) ?? '').toString('utf8')
     );
     verifyCoreSettings(settings);
+  });
+
+  it('configureProject() does not rewrite a semantically unchanged core jsconfig', async () => {
+    const freshAccessor = new LspFileSystemAccessor();
+    const freshMap = buildContentMap(CORE_PROJECT_ROOT, CORE_PARTIAL_WORKSPACE_STRUCTURE as Record<string, string>);
+    for (const [rel, content] of Object.entries(CORE_WORKSPACE_STRUCTURE as Record<string, string>)) {
+      if (rel.startsWith('.vscode/typings/')) {
+        freshMap.set(normalizePath(path.join(CORE_ALL_ROOT, rel)), content);
+      }
+    }
+    mockAccessorWithVirtualFs(freshAccessor, freshMap);
+
+    const context = new WorkspaceContext(CORE_PROJECT_ROOT, freshAccessor);
+    context.initialize('CORE_PARTIAL');
+    const jsconfigPath = path.join(CORE_PROJECT_ROOT, 'modules', 'jsconfig.json');
+
+    await context.configureProject();
+    const generatedContent = (await freshAccessor.getFileContent(jsconfigPath)) ?? '';
+    const generatedConfig: unknown = JSON.parse(generatedContent);
+    const reformattedContent = JSON.stringify(generatedConfig, null, 4);
+    await freshAccessor.updateFileContent(jsconfigPath, reformattedContent);
+
+    const writeSpy = jest.spyOn(freshAccessor, 'updateFileContent');
+    writeSpy.mockClear();
+
+    await context.configureProject();
+
+    const writesToJsconfig = writeSpy.mock.calls.filter(call => call[0] === jsconfigPath);
+    expect(writesToJsconfig).toHaveLength(0);
+    expect(await freshAccessor.getFileContent(jsconfigPath)).toBe(reformattedContent);
+
+    writeSpy.mockRestore();
   });
 
   it('configureCoreMulti()', async () => {

--- a/packages/salesforcedx-vscode-lwc/src/languageClient/clientOptions.ts
+++ b/packages/salesforcedx-vscode-lwc/src/languageClient/clientOptions.ts
@@ -7,9 +7,9 @@
 
 import { code2ProtocolConverter } from '@salesforce/effect-ext-utils';
 import type { WorkspaceType } from '@salesforce/salesforcedx-lightning-lsp-common';
-import { workspace } from 'vscode';
+import { RelativePattern, workspace } from 'vscode';
 import type { DocumentSelector } from 'vscode-languageclient';
-import { URI } from 'vscode-uri';
+import { URI, Utils } from 'vscode-uri';
 
 /** Languages supported by the LWC language server. */
 const LWC_DOCUMENT_SELECTOR_LANGUAGES = ['html', 'javascript', 'typescript', 'json', 'xml'] as const;
@@ -30,19 +30,28 @@ export const buildDocumentSelector = (schemes: string[]): DocumentSelector =>
  * @param packageDirectories - Array of package directory paths from sfdx-project.json (e.g., ['force-app', 'utils'])
  */
 const getSynchronizeFileEvents = (packageDirectories?: string[]) => {
+  const workspaceRoot = workspace.workspaceFolders?.[0];
+
   // If we have package directories, scope watchers to only those paths for better performance
-  if (packageDirectories && packageDirectories.length > 0) {
-    return packageDirectories.flatMap(pkgDir => [
-      workspace.createFileSystemWatcher(`${pkgDir}/**/*.resource`),
-      workspace.createFileSystemWatcher(`${pkgDir}/**/labels/CustomLabels.labels-meta.xml`),
-      workspace.createFileSystemWatcher(`${pkgDir}/**/staticresources/*.resource-meta.xml`),
-      workspace.createFileSystemWatcher(`${pkgDir}/**/contentassets/*.asset-meta.xml`),
-      workspace.createFileSystemWatcher(`${pkgDir}/**/lwc/*/*.js`),
-      workspace.createFileSystemWatcher(`${pkgDir}/**/modules/*/*/*.js`),
-      workspace.createFileSystemWatcher(`${pkgDir}/**/modules/*/*/*.ts`),
-      // need to watch for directory deletions as no events are created for contents or deleted directories
-      workspace.createFileSystemWatcher(`${pkgDir}/`, false, true, false)
-    ]);
+  if (packageDirectories && packageDirectories.length > 0 && workspaceRoot) {
+    return packageDirectories.flatMap(pkgDir => {
+      const workspaceRootUri = URI.parse(workspaceRoot.uri.toString());
+      const computedPackageUri = Utils.joinPath(workspaceRootUri, ...pkgDir.split(/[\\/]+/));
+      const packageUri = workspaceRoot.uri.with({ path: computedPackageUri.path });
+      const relativePattern = (pattern: string): RelativePattern => new RelativePattern(packageUri, pattern);
+
+      return [
+        workspace.createFileSystemWatcher(relativePattern('**/*.resource')),
+        workspace.createFileSystemWatcher(relativePattern('**/labels/CustomLabels.labels-meta.xml')),
+        workspace.createFileSystemWatcher(relativePattern('**/staticresources/*.resource-meta.xml')),
+        workspace.createFileSystemWatcher(relativePattern('**/contentassets/*.asset-meta.xml')),
+        workspace.createFileSystemWatcher(relativePattern('**/lwc/*/*.js')),
+        workspace.createFileSystemWatcher(relativePattern('**/modules/*/*/*.js')),
+        workspace.createFileSystemWatcher(relativePattern('**/modules/*/*/*.ts')),
+        // need to watch for directory deletions as no events are created for contents or deleted directories
+        workspace.createFileSystemWatcher(relativePattern('**/'), false, true, false)
+      ];
+    });
   }
 
   // Fallback to workspace-wide patterns if no package directories available

--- a/packages/salesforcedx-vscode-lwc/test/jest/languageClient/clientOptions.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/jest/languageClient/clientOptions.test.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import * as vscode from 'vscode';
+import { URI } from 'vscode-uri';
 import { getBaseClientOptions } from '../../../src/languageClient/clientOptions';
 
 jest.mock('vscode');
@@ -80,6 +81,62 @@ describe('clientOptions', () => {
       expect(patterns).toContain('**/'); // Directory watcher
 
       createFileSystemWatcherSpy.mockRestore();
+    });
+
+    it('should scope watchers to package directory URIs with relative patterns', () => {
+      const mockWatcher = {
+        onDidCreate: jest.fn(),
+        onDidChange: jest.fn(),
+        onDidDelete: jest.fn(),
+        dispose: jest.fn()
+      } as unknown as vscode.FileSystemWatcher;
+      const workspaceUri = URI.file('/workspace');
+      const packageUri = URI.file('/workspace/packages/force-app');
+      const originalWorkspaceFolders = vscode.workspace.workspaceFolders;
+
+      Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+        configurable: true,
+        value: [{ uri: workspaceUri, name: 'workspace', index: 0 }]
+      });
+      const relativePatternMock = jest.fn((baseUri: URI, pattern: string) => ({ baseUri, pattern }));
+      Object.defineProperty(vscode, 'RelativePattern', {
+        configurable: true,
+        value: relativePatternMock
+      });
+      const createFileSystemWatcherSpy = jest
+        .spyOn(vscode.workspace, 'createFileSystemWatcher')
+        .mockReturnValue(mockWatcher);
+
+      try {
+        const options = getBaseClientOptions(
+          {
+            workspaceType: 'SFDX',
+            sfdxTypingsDir: '/path/to/typings'
+          },
+          ['packages\\force-app']
+        );
+
+        expect(options.synchronize?.fileEvents).toHaveLength(8);
+        expect(relativePatternMock).toHaveBeenCalledWith(packageUri, '**/lwc/*/*.js');
+        expect(relativePatternMock).toHaveBeenCalledWith(packageUri, '**/');
+
+        const directoryCall = createFileSystemWatcherSpy.mock.calls.find(
+          ([pattern]) => typeof pattern !== 'string' && pattern.pattern === '**/'
+        );
+        expect(directoryCall).toEqual([
+          expect.objectContaining({ baseUri: packageUri, pattern: '**/' }),
+          false,
+          true,
+          false
+        ]);
+      } finally {
+        createFileSystemWatcherSpy.mockRestore();
+        Reflect.deleteProperty(vscode, 'RelativePattern');
+        Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+          configurable: true,
+          value: originalWorkspaceFolders
+        });
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

- replace timer-based jsconfig write debouncing with semantic update-if-changed behavior
- apply the same semantic comparison to CORE jsconfig generation
- standardize generated jsconfig indentation and reuse the schema decoder
- scope LWC file watchers with package-rooted `RelativePattern` instances
- watch directory creation and deletion recursively without overlapping the specialized file patterns
- add regression coverage for CORE jsconfig rewrites and scoped watcher construction

## Why

This is a suggestion follow-up to #7979. The previous debouncer still guaranteed an eventual write, could leave superseded callers unresolved, and did not prevent unchanged CORE jsconfig files from being rewritten. The package-directory watcher also needed recursive directory coverage while remaining safe across desktop and browser-backed workspace URI schemes.

## Impact

Unchanged SFDX and CORE jsconfig files are no longer rewritten, avoiding unnecessary filesystem activity and watcher churn. Watchers remain restricted to configured package directories while correctly observing nested directory creation and deletion.

This does not modify `sfdx-project.json`; it is only read to discover package directories.

## Validation

- repository pre-commit workflow: passed (94 tasks)
- repository pre-push workflow: passed (173 tasks)
- Lightning LSP common tests: 117 passed
- LWC extension tests: 52 passed
- `git diff --check`: passed
