### PR TITLE
chore(templates): bump @salesforce/templates to ^66.13.7 to pull in new UIBundle changes - W-23817526

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9757,9 +9757,9 @@
       }
     },
     "node_modules/@salesforce/templates": {
-      "version": "66.13.6",
-      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-66.13.6.tgz",
-      "integrity": "sha512-X6kM74bfZ5Zm5YM13LRuqt1cc+LvIn1ltXtG/P8J0ocebIMK4miyZwAQtAtQyIQF/VtGOXIPlgbyFPnZ7xl9MA==",
+      "version": "66.13.7",
+      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-66.13.7.tgz",
+      "integrity": "sha512-JGmZ0qXNCbc99bIGgwkmAey1MQ/w2rC22gY1yLj2ajDQpYN8FpwqtyhJrDbQtWbRpFMXhK5Bp7krpyBqotY+tQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/kit": "^3.2.6",
@@ -46573,7 +46573,7 @@
         "@salesforce/o11y-reporter": "^1.8.5",
         "@salesforce/salesforcedx-utils-vscode": "*",
         "@salesforce/source-deploy-retrieve": "^13.0.0",
-        "@salesforce/templates": "^66.13.6",
+        "@salesforce/templates": "^66.13.7",
         "@salesforce/ts-types": "^3.0.0",
         "@salesforce/vscode-i18n": "*",
         "@salesforce/vscode-service-provider": "^1.5.0",
@@ -46764,7 +46764,7 @@
         "@salesforce/salesforcedx-utils": "*",
         "@salesforce/source-deploy-retrieve": "^13.0.0",
         "@salesforce/source-tracking": "^8.0.0",
-        "@salesforce/templates": "^66.13.6",
+        "@salesforce/templates": "^66.13.7",
         "@salesforce/vscode-i18n": "*",
         "@vscode/extension-telemetry": "^1.0.0",
         "effect": "^3.21.2",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -33,7 +33,7 @@
     "@salesforce/o11y-reporter": "^1.8.5",
     "@salesforce/salesforcedx-utils-vscode": "*",
     "@salesforce/source-deploy-retrieve": "^13.0.0",
-    "@salesforce/templates": "^66.13.6",
+    "@salesforce/templates": "^66.13.7",
     "@salesforce/ts-types": "^3.0.0",
     "@salesforce/vscode-i18n": "*",
     "@salesforce/vscode-service-provider": "^1.5.0",

--- a/packages/salesforcedx-vscode-services/package.json
+++ b/packages/salesforcedx-vscode-services/package.json
@@ -45,7 +45,7 @@
     "@salesforce/salesforcedx-utils": "*",
     "@salesforce/source-deploy-retrieve": "^13.0.0",
     "@salesforce/source-tracking": "^8.0.0",
-    "@salesforce/templates": "^66.13.6",
+    "@salesforce/templates": "^66.13.7",
     "@salesforce/vscode-i18n": "*",
     "@vscode/extension-telemetry": "^1.0.0",
     "effect": "^3.21.2",


### PR DESCRIPTION
### What does this PR do?
Bumps @salesforce/templates to pull in the UIBundle change made in https://github.com/forcedotcom/salesforcedx-templates/pull/889.

### What issues does this PR fix or reference?
@W-23817526@

### Testing
Using the new version of @salesforce/templates, I created new projects using both the React Internal App and React External App templates with no errors.