### PR TITLE
fix(apex-testing): preserve web filesystem URIs - W-23861350

### DIFF
--- a/packages/salesforcedx-vscode-apex-testing/src/commands/apexTestRunCodeAction.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/commands/apexTestRunCodeAction.ts
@@ -12,7 +12,7 @@ import * as Option from 'effect/Option';
 import { isUndefined } from 'effect/Predicate';
 import * as Schema from 'effect/Schema';
 import * as vscode from 'vscode';
-import { URI, Utils } from 'vscode-uri';
+import { Utils } from 'vscode-uri';
 import { nls } from '../messages';
 import { ApexTestRunCacheService } from '../testRunCache/apexTestRunCacheService';
 import { apexTestingDiagnostics } from '../utils/diagnostics';
@@ -91,64 +91,56 @@ const handleDiagnostics = Effect.fn('apexTestRunCodeAction.handleDiagnostics')(f
   }
 
   const packageDirectories = maybeProject.value.getUniquePackageDirectories();
-  const correlatedArtifacts = yield* Effect.promise(() =>
-    mapApexArtifactToFilesystem(testsWithDiagnostics, packageDirectories)
-  );
+  const correlatedArtifacts = yield* mapApexArtifactToFilesystem(testsWithDiagnostics, packageDirectories);
 
-  testsWithDiagnostics.forEach(test => {
-    const diagnostic = test.diagnostic;
-    const componentPath = correlatedArtifacts.get(test.apexClass.fullName ?? test.apexClass.name);
-
-    if (componentPath) {
+  yield* Effect.forEach(
+    testsWithDiagnostics,
+    test => {
+      const diagnostic = test.diagnostic;
+      const componentUri = correlatedArtifacts.get(test.apexClass.fullName ?? test.apexClass.name);
+      if (!componentUri) {
+        return Effect.void;
+      }
       const vscDiagnostic: vscode.Diagnostic = {
         message: `${diagnostic.exceptionMessage}\n${diagnostic.exceptionStackTrace}`,
         severity: vscode.DiagnosticSeverity.Error,
-        source: componentPath,
+        source: componentUri.toString(),
         range: getZeroBasedRange(diagnostic.lineNumber ?? 1, diagnostic.columnNumber ?? 1)
       };
-
-      apexTestingDiagnostics.set(URI.file(componentPath), [vscDiagnostic]);
-    }
-  });
+      return Effect.sync(() => apexTestingDiagnostics.set(componentUri, [vscDiagnostic]));
+    },
+    { concurrency: 1, discard: true }
+  );
 });
 
-const mapApexArtifactToFilesystem = async (
+const mapApexArtifactToFilesystem = Effect.fn('apexTestRunCodeAction.mapApexArtifactToFilesystem')(function* (
   tests: ApexTestResultData[],
   packageDirectories: NamedPackageDir[]
-): Promise<Map<string, string>> => {
-  const correlatedArtifacts: Map<string, string> = new Map(
-    tests.map(test => [test.apexClass.fullName ?? test.apexClass.name, 'unknown'])
-  );
-
-  const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-  if (!workspaceFolder) {
-    return correlatedArtifacts;
-  }
-
-  Array.from(
-    new Set(
-      (
-        await Promise.all(
-          packageDirectories
-            .map(pkgDir => new vscode.RelativePattern(URI.file(pkgDir.fullPath), '**/*.cls'))
-            .flatMap(pattern => vscode.workspace.findFiles(pattern, '**/node_modules/**'))
+) {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const classNames = new Set(tests.map(test => test.apexClass.fullName ?? test.apexClass.name));
+  return yield* Effect.forEach(
+    packageDirectories,
+    pkgDir =>
+      api.services.FsService.toUri(pkgDir.fullPath).pipe(
+        Effect.map(packageDirUri => new vscode.RelativePattern(packageDirUri, '**/*.cls')),
+        Effect.flatMap(pattern => api.services.FsService.findFiles(pattern, '**/node_modules/**'))
+      ),
+    { concurrency: 'unbounded' }
+  ).pipe(
+    Effect.map(matches => matches.flat()),
+    Effect.map(matches => [...new Map(matches.map(uri => [uri.toString(), uri])).values()]),
+    Effect.map(
+      matches =>
+        new Map(
+          matches.flatMap(uri => {
+            const fileName = Utils.basename(uri).slice(0, -'.cls'.length);
+            return classNames.has(fileName) ? [[fileName, uri] as const] : [];
+          })
         )
-      )
-        .flat()
-        // parsing to string for set to dedupe, then back to URI
-        .map(uri => uri.toString())
     )
-  )
-    .map(filePath => URI.parse(filePath))
-    .map(file => {
-      const fileName = Utils.basename(file).slice(0, -'.cls'.length);
-      if (correlatedArtifacts.has(fileName)) {
-        correlatedArtifacts.set(fileName, file.fsPath);
-      }
-    });
-
-  return correlatedArtifacts;
-};
+  );
+});
 
 const getTempFolder = Effect.fn('apexTestRunCodeAction.getTempFolder')(function* () {
   return yield* getTestResultsFolder().pipe(

--- a/packages/salesforcedx-vscode-apex-testing/src/utils/testUtils.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/utils/testUtils.ts
@@ -11,7 +11,7 @@ import * as Array from 'effect/Array';
 import * as Effect from 'effect/Effect';
 import { isNotUndefined } from 'effect/Predicate';
 import * as vscode from 'vscode';
-import { URI, Utils } from 'vscode-uri';
+import { type URI, Utils } from 'vscode-uri';
 import { getApexTestingRuntime } from '../services/extensionProvider';
 
 /**
@@ -89,49 +89,56 @@ export const buildClassToUriIndex = async (classNames: string[]): Promise<Map<st
     return new Map<string, URI>();
   }
 
-  return getApexTestingRuntime().runPromise(
-    Effect.gen(function* () {
-      const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  return Effect.gen(function* () {
+    const api = yield* (yield* ExtensionProviderService).getServicesApi;
 
-      // Get package directories from the project
-      const sfProject = yield* api.services.ProjectService.getSfProject();
-      const packageDirs = sfProject.getPackageDirectories().map(dir => dir.fullPath);
+    // Build index from component name to file URI
+    const classNameSet = new Set(classNames);
+    const index = new Map<string, URI>();
 
-      // Build ComponentSet for all ApexClass files in the project
-      const componentSet = yield* api.services.MetadataRetrieveService.buildComponentSetFromSource(packageDirs, [
-        { type: 'ApexClass', fullName: '*' }
-      ]);
-
-      // Build index from component name to file URI
-      const classNameSet = new Set(classNames);
-      const index = new Map<string, URI>();
-
-      yield* Effect.forEach(
-        Array.fromIterable(componentSet.getSourceComponents()),
-        component =>
-          Effect.gen(function* () {
-            // component.content is the .cls file path
-            if (component.content && classNameSet.has(component.name)) {
-              // Prefer shorter paths (files closer to workspace root)
+    yield* api.services.ProjectService.getSfProject().pipe(
+      Effect.map(project => project.getPackageDirectories()),
+      Effect.map(Array.map(dir => dir.fullPath)),
+      Effect.flatMap(packageDirs =>
+        api.services.MetadataRetrieveService.buildComponentSetFromSource(packageDirs, [
+          { type: 'ApexClass', fullName: '*' }
+        ])
+      ),
+      Effect.map(componentSet => componentSet.getSourceComponents()),
+      Effect.map(Array.fromIterable),
+      Effect.map(
+        Array.filter(
+          (component): component is typeof component & { content: string } =>
+            isNotUndefined(component.content) && component.content.length > 0 && classNameSet.has(component.name)
+        )
+      ),
+      Effect.flatMap(
+        Effect.forEach(
+          component =>
+            Effect.gen(function* () {
               const existingUri = index.get(component.name);
               if (
-                !existingUri ||
-                component.content.length < (yield* api.services.FsService.uriToPath(existingUri)).length
+                existingUri &&
+                component.content.length >= (yield* api.services.FsService.uriToPath(existingUri)).length
               ) {
-                index.set(component.name, URI.file(component.content));
+                return;
               }
-            }
-          }),
-        { concurrency: 1, discard: true }
-      );
-
-      return index;
-    }).pipe(
-      Effect.withSpan('buildClassToUriIndex', { attributes: { classCount: classNames.length } }),
-      Effect.catchAll(error =>
-        Effect.logError('Error building class to URI index', { error }).pipe(Effect.as(new Map<string, URI>()))
+              yield* api.services.FsService.toUri(component.content).pipe(
+                Effect.tap(uri => Effect.sync(() => index.set(component.name, uri)))
+              );
+            }),
+          { concurrency: 1, discard: true }
+        )
       )
-    )
+    );
+
+    return index;
+  }).pipe(
+    Effect.withSpan('buildClassToUriIndex', { attributes: { classCount: classNames.length } }),
+    Effect.catchAll(error =>
+      Effect.logError('Error building class to URI index', { error }).pipe(Effect.as(new Map<string, URI>()))
+    ),
+    getApexTestingRuntime().runPromise
   );
 };
 

--- a/packages/salesforcedx-vscode-apex-testing/src/views/testController.ts
+++ b/packages/salesforcedx-vscode-apex-testing/src/views/testController.ts
@@ -377,7 +377,7 @@ const retrieveOrgOnlyClass = Effect.fn('ApexTestController.retrieveOrgOnlyClassF
   yield* api.services.MetadataRetrieveService.retrieve([{ type: 'ApexClass', fullName: className }], {
     ignoreConflicts: true
   }).pipe(
-    Effect.map(getRetrievedFileUri),
+    Effect.flatMap(getRetrievedFileUri),
     Effect.flatMap(
       Effect.transposeMapOption(retrievedFileUri =>
         api.services.FsService.showTextDocument(retrievedFileUri, {
@@ -434,10 +434,12 @@ const getClassNameFromApexTestingUri = (uri: URI): string | undefined => {
   return classPath.slice(0, -4).replaceAll('/', '.');
 };
 
-const getRetrievedFileUri = (result: RetrieveResult): Option.Option<URI> =>
-  Option.fromNullable(
+const getRetrievedFileUri = Effect.fn('ApexTesting.getRetrievedFileUri')(function* (result: RetrieveResult) {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  return yield* Option.fromNullable(
     result.getFileResponses().find(r => isString(r.filePath) && r.filePath.length > 0)?.filePath
-  ).pipe(Option.map(URI.file));
+  ).pipe(Effect.transposeMapOption(filePath => api.services.FsService.toUri(filePath)));
+});
 
 // Batch-close text-input tabs matching predicate. No-op on web (tabGroups absent).
 const closeMatchingTabs = Effect.fn('ApexTesting.closeMatchingTabs')(function* (predicate: (uri: URI) => boolean) {

--- a/packages/salesforcedx-vscode-apex-testing/test/jest/discoveryVfs/apexTestingDiscoveryFs.test.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/jest/discoveryVfs/apexTestingDiscoveryFs.test.ts
@@ -8,6 +8,20 @@
 import { URI } from 'vscode-uri';
 import { getApexTestingClassUri, isForeignOrgClassUri } from '../../../src/discoveryVfs/apexTestingDiscoveryFs';
 
+describe('getApexTestingClassUri', () => {
+  it('maps a fully qualified class name to nested path segments', () => {
+    expect(getApexTestingClassUri('00DAAA', 'namespace.MyTest').toString()).toBe(
+      'apex-testing:/orgs/00daaa/classes/namespace/MyTest.cls'
+    );
+  });
+
+  it('maps every dot-separated name segment to a directory', () => {
+    expect(getApexTestingClassUri('00DAAA', 'my.domain.com').toString()).toBe(
+      'apex-testing:/orgs/00daaa/classes/my/domain/com.cls'
+    );
+  });
+});
+
 describe('isForeignOrgClassUri', () => {
   // org keys are sanitized (trim + lower-case + encodeURIComponent) into the path segment.
   const orgAUri = getApexTestingClassUri('00DAAA', 'MyTest');

--- a/packages/salesforcedx-vscode-apex-testing/test/jest/views/testController.test.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/jest/views/testController.test.ts
@@ -29,6 +29,7 @@ jest.mock('../../../src/services/extensionProvider', () => {
     safeDelete: () => EffectLib.void,
     safeWriteFile: () => EffectLib.void,
     writeFile: () => EffectLib.void,
+    toUri: (filePath: string) => EffectLib.succeed(UriClass.parse(`memfs:${filePath}`)),
     // accessor form: `yield* api.services.FsService.HashableUri` resolves the value namespace.
     HashableUri: EffectLib.succeed(HashableUri),
     showTextDocument: (uri: unknown, options?: unknown) =>
@@ -770,7 +771,7 @@ describe('ApexTestController', () => {
 
   describe('retrieveOrgOnlyClass', () => {
     it('retrieves org-only class for apex-testing class items', async () => {
-      const orgOnlyClassFileUri = URI.file('/workspace/force-app/main/default/classes/OrgOnlyClass.cls');
+      const orgOnlyClassFileUri = URI.parse('memfs:/workspace/force-app/main/default/classes/OrgOnlyClass.cls');
       const classTestItem = {
         id: 'class:OrgOnlyClass',
         label: 'OrgOnlyClass',
@@ -799,7 +800,7 @@ describe('ApexTestController', () => {
         (extensionProvider as unknown as { __mockMetadataRetrieve: jest.Mock }).__mockMetadataRetrieve
       ).toHaveBeenCalledWith([{ type: 'ApexClass', fullName: 'OrgOnlyClass' }], { ignoreConflicts: true });
       expect(vscode.window.showTextDocument).toHaveBeenCalledWith(
-        expect.objectContaining({ fsPath: orgOnlyClassFileUri.fsPath }),
+        expect.objectContaining({ scheme: 'memfs', path: orgOnlyClassFileUri.path }),
         expect.anything()
       );
       expect(refreshSpy).toHaveBeenCalled();


### PR DESCRIPTION
### What does this PR do?

Preserves workspace URI schemes when Apex Testing indexes local classes, publishes diagnostics, and opens retrieved classes. Filesystem path conversion and discovery now go through `FsService`, allowing Web Console `memfs:` resources to work without changing desktop behavior.

Adds regression coverage for virtual Apex class URIs and retrieved files.

### What issues does this PR fix or reference?
@W-23861350@

### Functionality Before
Apex Test Explorer created `file:` URIs for local classes. Opening a local class or method failed in Web Console because the workspace uses `memfs:`.

<img width="1917" height="1451" alt="Screenshot 2026-08-14 at 5 24 14 PM" src="https://github.com/user-attachments/assets/2835e431-6adb-42a3-ac41-701ee2e6e86e" />

### Functionality After
org-only
<img width="1071" height="524" alt="Screenshot 2026-08-14 at 6 08 00 PM" src="https://github.com/user-attachments/assets/0f3f7929-3a8b-4568-9ce8-57f223270751" />

local
<img width="1506" height="678" alt="Screenshot 2026-08-14 at 7 33 40 PM" src="https://github.com/user-attachments/assets/4c3bc311-f58d-47d9-b786-131f497020df" />

Apex Test Explorer preserves the workspace URI scheme. Local classes and methods open from Test Explorer in Web Console, while org-only class navigation and desktop behavior remain unchanged.