### PR TITLE
fix: order project config notifications after cache invalidation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46783,7 +46783,7 @@
     },
     "packages/salesforcedx-vscode-services-types": {
       "name": "@salesforce/vscode-services",
-      "version": "67.10.0",
+      "version": "67.11.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.43",

--- a/packages/salesforcedx-vscode-lwc/src/index.ts
+++ b/packages/salesforcedx-vscode-lwc/src/index.ts
@@ -192,11 +192,10 @@ export const activateEffect = Effect.fn('activation:salesforcedx-vscode-lwc')(fu
  */
 const watchSfProjectForLwcClient = Effect.fn('watchSfProjectForLwcClient')(function* () {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
-  const fileChangePubSub = yield* api.services.FileChangePubSub;
+  const projectService = yield* api.services.ProjectService;
   const channelSvc = yield* api.services.ChannelService;
 
-  yield* Stream.fromPubSub(fileChangePubSub).pipe(
-    Stream.filter(event => Utils.basename(event.uri) === 'sfdx-project.json'),
+  yield* projectService.projectConfigChanges.pipe(
     Stream.debounce(Duration.millis(500)),
     Stream.runForEach(() =>
       Effect.gen(function* () {
@@ -207,7 +206,7 @@ const watchSfProjectForLwcClient = Effect.fn('watchSfProjectForLwcClient')(funct
         yield* channelSvc.appendToChannel(nls.localize('lwc_restarting_language_server'));
 
         // Fetch updated package directories
-        const packageDirectories: string[] | undefined = yield* api.services.ProjectService.getSfProject().pipe(
+        const packageDirectories: string[] | undefined = yield* projectService.getSfProject().pipe(
           Effect.map(project => project.getPackageDirectories().map(dir => dir.path)),
           Effect.orElseSucceed(() => undefined)
         );

--- a/packages/salesforcedx-vscode-services-types/package.json
+++ b/packages/salesforcedx-vscode-services-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/vscode-services",
-  "version": "67.10.0",
+  "version": "67.11.1",
   "description": "TypeScript type definitions for Salesforce VS Code Services extension API",
   "author": "Salesforce",
   "license": "BSD-3-Clause",

--- a/packages/salesforcedx-vscode-services/src/core/projectService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/projectService.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import type { FileChangeEvent } from '../vscode/fileChangePubSub';
 import { Global, SfProject } from '@salesforce/core';
 import * as Cache from 'effect/Cache';
 import * as Chunk from 'effect/Chunk';
@@ -13,6 +14,7 @@ import * as Duration from 'effect/Duration';
 import * as Effect from 'effect/Effect';
 import * as Exit from 'effect/Exit';
 import { isNotUndefined, isUndefined } from 'effect/Predicate';
+import * as PubSub from 'effect/PubSub';
 import * as Schema from 'effect/Schema';
 import * as Stream from 'effect/Stream';
 import { normalize } from 'node:path';
@@ -61,6 +63,16 @@ const globalSfProjectCache = Effect.runSync(
     lookup: resolveSfProject
   }).pipe(Effect.withSpan('sfProjectCache'))
 );
+
+// Project cache state and its notifications share module-level lifetime so every services API consumer
+// observes the same ordered stream, just as every ProjectService instance uses the same project cache.
+const projectConfigChangePubSub = Effect.runSync(PubSub.sliding<FileChangeEvent>(100));
+
+/** Read-only stream of root sfdx-project.json events published after project cache invalidation. */
+export const projectConfigChanges = Stream.fromPubSub(projectConfigChangePubSub);
+
+/** Internal publisher used by sfProjectFileWatcher after it has invalidated all project caches. */
+export const publishProjectConfigChange = (event: FileChangeEvent) => PubSub.publish(projectConfigChangePubSub, event);
 
 /**
  * Invalidate the SfProject cache so the next `getSfProject` re-reads sfdx-project.json from disk.
@@ -261,6 +273,7 @@ export class ProjectService extends Effect.Service<ProjectService>()('ProjectSer
     return {
       isSalesforceProject,
       getSfProject,
+      projectConfigChanges,
       isInPackageDirectories,
       ensureInPackageDirectories,
       getSoqlMetadataPath,

--- a/packages/salesforcedx-vscode-services/src/core/sfProjectFileWatcher.ts
+++ b/packages/salesforcedx-vscode-services/src/core/sfProjectFileWatcher.ts
@@ -11,7 +11,7 @@ import * as Stream from 'effect/Stream';
 import { Utils } from 'vscode-uri';
 import { FileChangePubSub } from '../vscode/fileChangePubSub';
 import { WorkspaceService } from '../vscode/workspaceService';
-import { invalidateSfProjectCache, sfProjectCacheKey } from './projectService';
+import { invalidateSfProjectCache, publishProjectConfigChange, sfProjectCacheKey } from './projectService';
 
 const SFDX_PROJECT_FILE_NAME = 'sfdx-project.json';
 
@@ -24,17 +24,27 @@ export const watchSfProjectFile = Effect.fn('watchSfProjectFile')(function* () {
   const [fileChangePubSub, workspaceService] = yield* Effect.all([FileChangePubSub, WorkspaceService]);
 
   yield* Stream.fromPubSub(fileChangePubSub).pipe(
-    Stream.filter(event => Utils.basename(event.uri) === SFDX_PROJECT_FILE_NAME),
+    Stream.mapEffect(event =>
+      workspaceService.getWorkspaceInfo().pipe(Effect.map(workspace => ({ event, workspace })))
+    ),
+    // Only the supported workspace root owns ProjectService state. A basename check also matched nested
+    // sfdx-project.json files and could invalidate and notify consumers for an unrelated project.
+    Stream.filter(
+      ({ event, workspace }) =>
+        !workspace.isEmpty && event.uri.toString() === Utils.joinPath(workspace.uri, SFDX_PROJECT_FILE_NAME).toString()
+    ),
     Stream.debounce(Duration.millis(5)),
-    Stream.runForEach(() =>
+    Stream.runForEach(({ event, workspace }) =>
       // Derive the cache key from WorkspaceService (the same source `getSfProject` uses), NOT from the
       // event URI's dirname. On web the runner user-agent contains "Windows", so `vscode-uri` renders
       // `uri.fsPath` with backslashes (e.g. `\dx-project`) while WorkspaceService normalizes them to `/`
       // for virtual filesystems — keying off the event URI produced `\dx-project` and never matched the
       // `/dx-project` cache entry, so mid-session edits stayed stale on web.
-      workspaceService.getWorkspaceInfo().pipe(
-        Effect.flatMap(({ fsPath }) => sfProjectCacheKey(fsPath)),
-        Effect.flatMap(invalidateSfProjectCache)
+      sfProjectCacheKey(workspace.fsPath).pipe(
+        Effect.flatMap(invalidateSfProjectCache),
+        // This is the ordering guarantee for ProjectService consumers: observing the event means both
+        // the Effect cache and @salesforce/core's static SfProject instances have already been cleared.
+        Effect.andThen(publishProjectConfigChange(event))
       )
     )
   );

--- a/packages/salesforcedx-vscode-services/test/jest/core/sfProjectFileWatcher.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/sfProjectFileWatcher.test.ts
@@ -10,6 +10,7 @@ import * as Effect from 'effect/Effect';
 import * as Fiber from 'effect/Fiber';
 import * as Layer from 'effect/Layer';
 import * as PubSub from 'effect/PubSub';
+import * as Stream from 'effect/Stream';
 import { normalize } from 'node:path';
 import { URI } from 'vscode-uri';
 import * as projectService from '../../../src/core/projectService';
@@ -19,6 +20,7 @@ import { WorkspaceService } from '../../../src/vscode/workspaceService';
 
 const WORKSPACE_DIR = '/Users/testuser/project';
 const PROJECT_FILE_PATH = `${WORKSPACE_DIR}/sfdx-project.json`;
+const NESTED_PROJECT_FILE_PATH = `${WORKSPACE_DIR}/nested/sfdx-project.json`;
 const OTHER_FILE_PATH = `${WORKSPACE_DIR}/.sf/config.json`;
 
 const makeFileChangePubSubLayer = (pubsub: PubSub.PubSub<FileChangeEvent>) =>
@@ -29,12 +31,15 @@ const makeFileChangePubSubLayer = (pubsub: PubSub.PubSub<FileChangeEvent>) =>
 // keying off WorkspaceService guarantees the key equals the one `getSfProject` used to populate the cache.
 const makeWorkspaceServiceLayer = (fsPath: string) =>
   Layer.succeed(WorkspaceService, {
-    getWorkspaceInfo: () => Effect.succeed({ fsPath } as never),
-    getWorkspaceInfoOrThrow: () => Effect.succeed({ fsPath } as never)
+    getWorkspaceInfo: () => Effect.succeed({ fsPath, uri: URI.file(fsPath), isEmpty: false } as never),
+    getWorkspaceInfoOrThrow: () => Effect.succeed({ fsPath, uri: URI.file(fsPath), isEmpty: false } as never)
   } as unknown as WorkspaceService);
 
 const runWatcherTest = (publishUri: string, workspaceFsPath = WORKSPACE_DIR) => {
-  const invalidateSpy = jest.spyOn(projectService, 'invalidateSfProjectCache').mockImplementation(() => Effect.void);
+  const ordering: string[] = [];
+  const invalidateSpy = jest
+    .spyOn(projectService, 'invalidateSfProjectCache')
+    .mockImplementation(() => Effect.sync(() => ordering.push('invalidate')));
 
   return Effect.runPromise(
     Effect.gen(function* () {
@@ -45,6 +50,10 @@ const runWatcherTest = (publishUri: string, workspaceFsPath = WORKSPACE_DIR) => 
       );
 
       const fiber = yield* Effect.provide(Effect.scoped(watchSfProjectFile()), layer).pipe(Effect.fork);
+      const notificationFiber = yield* projectService.projectConfigChanges.pipe(
+        Stream.runForEach(() => Effect.sync(() => ordering.push('publish'))),
+        Effect.fork
+      );
 
       // Yield to allow the forked fiber to subscribe before we publish
       yield* Effect.sleep(0);
@@ -53,8 +62,9 @@ const runWatcherTest = (publishUri: string, workspaceFsPath = WORKSPACE_DIR) => 
       yield* Effect.sleep(200);
 
       yield* Fiber.interrupt(fiber);
+      yield* Fiber.interrupt(notificationFiber);
 
-      return invalidateSpy;
+      return { invalidateSpy, ordering };
     })
   );
 };
@@ -63,20 +73,32 @@ describe('watchSfProjectFile', () => {
   afterEach(() => jest.restoreAllMocks());
 
   it('invalidates the SfProject cache when sfdx-project.json changes', async () => {
-    const spy = await runWatcherTest(PROJECT_FILE_PATH);
-    expect(spy).toHaveBeenCalledTimes(1);
+    const { invalidateSpy } = await runWatcherTest(PROJECT_FILE_PATH);
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
   });
 
   it('invalidates with the cacheKey getSfProject would compute (the WorkspaceService fsPath)', async () => {
-    const spy = await runWatcherTest(PROJECT_FILE_PATH);
+    const { invalidateSpy } = await runWatcherTest(PROJECT_FILE_PATH);
     // parity guard: key must equal the workspace dir from WorkspaceService so invalidation targets the
     // live entry — NOT the event URI's dirname, which is backslashed on web and would never match.
-    expect(spy).toHaveBeenCalledWith(normalize(WORKSPACE_DIR));
+    expect(invalidateSpy).toHaveBeenCalledWith(normalize(WORKSPACE_DIR));
+  });
+
+  it('publishes the project config event after invalidating the cache', async () => {
+    const { ordering } = await runWatcherTest(PROJECT_FILE_PATH);
+    expect(ordering).toEqual(['invalidate', 'publish']);
   });
 
   it('does not invalidate when a non-project file changes', async () => {
-    const spy = await runWatcherTest(OTHER_FILE_PATH);
-    expect(spy).not.toHaveBeenCalled();
+    const { invalidateSpy, ordering } = await runWatcherTest(OTHER_FILE_PATH);
+    expect(invalidateSpy).not.toHaveBeenCalled();
+    expect(ordering).toEqual([]);
+  });
+
+  it('does not invalidate when a nested sfdx-project.json changes', async () => {
+    const { invalidateSpy, ordering } = await runWatcherTest(NESTED_PROJECT_FILE_PATH);
+    expect(invalidateSpy).not.toHaveBeenCalled();
+    expect(ordering).toEqual([]);
   });
 });
 

--- a/packages/salesforcedx-vscode-services/test/jest/core/templateService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/templateService.test.ts
@@ -10,6 +10,7 @@ import type { ConfigAggregator } from '@salesforce/core/configAggregator';
 import * as SfTemplates from '@salesforce/templates';
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
+import * as Stream from 'effect/Stream';
 import { URI } from 'vscode-uri';
 import { ConfigService } from '../../../src/core/configService';
 import { ConnectionService } from '../../../src/core/connectionService';
@@ -80,6 +81,7 @@ const createMockProjectService = (): Layer.Layer<ProjectService> => {
     ProjectService.make({
       isSalesforceProject: () => Effect.succeed(true),
       getSfProject: () => Effect.succeed(mockSfProject),
+      projectConfigChanges: Stream.empty,
       isInPackageDirectories: () => Effect.succeed(true),
       ensureInPackageDirectories: () => Effect.void,
       getSoqlMetadataPath: () => Effect.succeed(URI.file('/test/soql')),


### PR DESCRIPTION
## Summary

- expose a read-only `ProjectService.projectConfigChanges` stream
- publish root `sfdx-project.json` events only after the project caches are invalidated
- migrate the LWC mid-session configuration watcher introduced by #7979 to that ordered event
- restrict the event to the single supported workspace's root project configuration
- synchronize the generated services-types package version with the services package so the repository lock-sync gate passes

## Why

The implementation in #7979 subscribes directly to `FileChangePubSub`, while the services package independently subscribes to invalidate `ProjectService` caches. The different debounce periods reduce the likelihood of a race but do not guarantee that a consumer calling `getSfProject()` observes the refreshed configuration.

This suggestion keeps ownership in the existing `ProjectService` rather than introducing a new project-specific service. Consumers receive a discrete create, change, or delete event after invalidation completes.

## Validation

- normal pre-commit workflow passed all 93 scripts
- normal pre-push workflow passed all 173 tasks
- focused services watcher tests passed (6 tests)
- focused LWC client-options tests passed (3 tests)
- services and LWC TypeScript checks passed
- services and LWC lint checks passed
- formatting checks passed

