### PR TITLE
feat(codebuilder-e2e): verify gate + digest/Manifest utilities - W-23898517

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45829,7 +45829,8 @@
       "dependencies": {
         "@playwright/test": "^1.60.0",
         "@vscode/test-electron": "3.1.0",
-        "@vscode/test-web": "^0.0.81"
+        "@vscode/test-web": "^0.0.81",
+        "effect": "^3.21.2"
       },
       "devDependencies": {
         "@salesforce/core": "^9.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -45939,7 +45939,8 @@
       "dependencies": {
         "@playwright/test": "^1.60.0",
         "@vscode/test-electron": "3.1.0",
-        "@vscode/test-web": "^0.0.81"
+        "@vscode/test-web": "^0.0.81",
+        "effect": "^3.21.2"
       },
       "devDependencies": {
         "@salesforce/core": "^9.1.9"

--- a/packages/playwright-vscode-ext/jest.config.js
+++ b/packages/playwright-vscode-ext/jest.config.js
@@ -1,0 +1,4 @@
+// eslint:disable-next-line:no-var-requires
+const baseConfig = require('../../config/jest.base.config');
+
+module.exports = Object.assign({}, baseConfig);

--- a/packages/playwright-vscode-ext/jest.config.js
+++ b/packages/playwright-vscode-ext/jest.config.js
@@ -1,4 +1,3 @@
-// eslint:disable-next-line:no-var-requires
 const baseConfig = require('../../config/jest.base.config');
 
 module.exports = Object.assign({}, baseConfig);

--- a/packages/playwright-vscode-ext/package.json
+++ b/packages/playwright-vscode-ext/package.json
@@ -51,7 +51,7 @@
     "test:web:debug": "npm run test:web -- --debug",
     "test:desktop": "wireit",
     "test:desktop:debug": "npm run test:desktop -- --debug",
-    "test:unit": "wireit"
+    "test": "wireit"
   },
   "wireit": {
     "check:circular-deps": {
@@ -136,7 +136,7 @@
       ],
       "output": []
     },
-    "test:unit": {
+    "test": {
       "command": "jest",
       "files": [
         "src/**/*.ts",

--- a/packages/playwright-vscode-ext/package.json
+++ b/packages/playwright-vscode-ext/package.json
@@ -35,7 +35,8 @@
   "dependencies": {
     "@playwright/test": "^1.60.0",
     "@vscode/test-electron": "3.1.0",
-    "@vscode/test-web": "^0.0.81"
+    "@vscode/test-web": "^0.0.81",
+    "effect": "^3.21.2"
   },
   "devDependencies": {
     "@salesforce/core": "^9.0.0"
@@ -49,7 +50,8 @@
     "test:web:ui": "DEBUG_MODE=1 npm run test:web -- --headed",
     "test:web:debug": "npm run test:web -- --debug",
     "test:desktop": "wireit",
-    "test:desktop:debug": "npm run test:desktop -- --debug"
+    "test:desktop:debug": "npm run test:desktop -- --debug",
+    "test:unit": "wireit"
   },
   "wireit": {
     "check:circular-deps": {
@@ -133,6 +135,18 @@
         "../../.github/**"
       ],
       "output": []
+    },
+    "test:unit": {
+      "command": "jest",
+      "files": [
+        "src/**/*.ts",
+        "test/jest/**/*.ts",
+        "jest.config.js",
+        "../../config/jest.base.config.js"
+      ],
+      "output": [
+        "coverage"
+      ]
     }
   }
 }

--- a/packages/playwright-vscode-ext/package.json
+++ b/packages/playwright-vscode-ext/package.json
@@ -35,7 +35,8 @@
   "dependencies": {
     "@playwright/test": "^1.60.0",
     "@vscode/test-electron": "3.1.0",
-    "@vscode/test-web": "^0.0.81"
+    "@vscode/test-web": "^0.0.81",
+    "effect": "^3.21.2"
   },
   "devDependencies": {
     "@salesforce/core": "^9.1.9"
@@ -49,7 +50,8 @@
     "test:web:ui": "DEBUG_MODE=1 npm run test:web -- --headed",
     "test:web:debug": "npm run test:web -- --debug",
     "test:desktop": "wireit",
-    "test:desktop:debug": "npm run test:desktop -- --debug"
+    "test:desktop:debug": "npm run test:desktop -- --debug",
+    "test:unit": "wireit"
   },
   "wireit": {
     "check:circular-deps": {
@@ -133,6 +135,18 @@
         "../../.github/**"
       ],
       "output": []
+    },
+    "test:unit": {
+      "command": "jest",
+      "files": [
+        "src/**/*.ts",
+        "test/jest/**/*.ts",
+        "jest.config.js",
+        "../../config/jest.base.config.js"
+      ],
+      "output": [
+        "coverage"
+      ]
     }
   }
 }

--- a/packages/playwright-vscode-ext/src/codeBuilder/digest.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/digest.ts
@@ -21,7 +21,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import { existsSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
 import { join, resolve, sep } from 'node:path';
 
 /** The two-part content digest of one extension. `bundleDigest` is null for a declarative extension (no `main`). */
@@ -43,7 +43,35 @@ export class UnresolvableEntrypointError extends Error {
   }
 }
 
-const sha256 = (bytes: Buffer): string => createHash('sha256').update(bytes).digest('hex');
+const sha256 = (bytes: Buffer | string): string => createHash('sha256').update(bytes).digest('hex');
+
+/*
+ * Digest package.json by its CANONICAL content, not raw bytes. The swap side hashes bytes unzipped
+ * from the .vsix; the verify side hashes bytes docker-cp'd from the installed override dir — and the
+ * CB install path can legitimately rewrite the file (re-serialize JSON, normalize EOLs, inject a
+ * `__metadata` block). Hashing raw bytes would then mismatch on every run (permanent false-RED). So
+ * parse → drop install-injected keys → stably re-stringify, giving a byte-identical digest across
+ * both sides whenever the *meaningful* content is the same. A genuine version/content change still
+ * changes the canonical form, so the gate keeps its teeth.
+ */
+const INSTALL_INJECTED_KEYS = new Set(['__metadata']);
+const canonicalPackageJson = (raw: string): string => {
+  const parsed = JSON.parse(raw) as Record<string, unknown>;
+  const stableStringify = (value: unknown): string => {
+    if (value === null || typeof value !== 'object') {
+      return JSON.stringify(value);
+    }
+    if (Array.isArray(value)) {
+      return `[${value.map(stableStringify).join(',')}]`;
+    }
+    const entries = Object.keys(value as Record<string, unknown>)
+      .filter(k => !INSTALL_INJECTED_KEYS.has(k))
+      .toSorted()
+      .map(k => `${JSON.stringify(k)}:${stableStringify((value as Record<string, unknown>)[k])}`);
+    return `{${entries.join(',')}}`;
+  };
+  return stableStringify(parsed);
+};
 
 /*
  * Locate the directory that holds package.json directly. A raw .vsix unzip nests everything under
@@ -88,6 +116,14 @@ export const resolveEntrypoint = (extensionRoot: string): string | null => {
   if (!existsSync(entry) || !statSync(entry).isFile()) {
     throw new UnresolvableEntrypointError(extensionRoot, pkg.main);
   }
+  // Re-check containment on the REAL path: an in-root symlink pointing outside the extension would
+  // pass the string check above but hash foreign bytes. realpath resolves the link, then we assert
+  // the resolved target is still inside the (real) root.
+  const realRoot = realpathSync(rootAbs);
+  const realEntry = realpathSync(entry);
+  if (realEntry !== realRoot && !realEntry.startsWith(realRoot + sep)) {
+    throw new UnresolvableEntrypointError(extensionRoot, pkg.main);
+  }
   return entry;
 };
 
@@ -98,7 +134,7 @@ export const resolveEntrypoint = (extensionRoot: string): string | null => {
  */
 export const computeExtensionDigest = (dir: string): ExtensionDigest => {
   const root = resolveExtensionRoot(dir);
-  const pkgJsonDigest = sha256(readFileSync(join(root, 'package.json')));
+  const pkgJsonDigest = sha256(canonicalPackageJson(readFileSync(join(root, 'package.json'), 'utf-8')));
   const entry = resolveEntrypoint(root);
   const bundleDigest = entry === null ? null : sha256(readFileSync(entry));
   return { pkgJsonDigest, bundleDigest };

--- a/packages/playwright-vscode-ext/src/codeBuilder/digest.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/digest.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Composite content digest for a Code Builder extension override.
+ *
+ * The false-green problem (ADR 0022): the version gate compared installed *semver*, not bytes, so a
+ * swap that silently no-ops still passed when an unreleased build shared a version with the baked
+ * copy. The fix is a content digest computed identically on both sides of the unpack:
+ *   - swap side  — extracts the .vsix host-side, digests it, records it in the Manifest
+ *   - verify side — docker-cp's the installed override dir back out, recomputes, compares
+ * Because a .vsix is a zip but the installed override is a loose tree, the digest is defined over
+ * content that *survives unpacking*: the extension's package.json and its `main` bundle file.
+ *
+ * Composite = cheap gate (package.json) + byte-level catch (the shipped bundle). package.json alone
+ * misses a bundle-only change; the bundle digest catches it.
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** The two-part content digest of one extension. `bundleDigest` is null for a declarative extension (no `main`). */
+export type ExtensionDigest = {
+  /** sha256 of the extension's package.json bytes. */
+  pkgJsonDigest: string;
+  /** sha256 of the `main` bundle file bytes, or null when the extension declares no `main`. */
+  bundleDigest: string | null;
+};
+
+/** Thrown when an extension declares a `main` that does not resolve to a file — a real broken build/swap. */
+export class UnresolvableEntrypointError extends Error {
+  constructor(
+    public readonly extensionRoot: string,
+    public readonly main: string
+  ) {
+    super(`package.json "main" (${main}) does not resolve to a file under ${extensionRoot}`);
+    this.name = 'UnresolvableEntrypointError';
+  }
+}
+
+const sha256 = (bytes: Buffer): string => createHash('sha256').update(bytes).digest('hex');
+
+/*
+ * Locate the directory that holds package.json directly. A raw .vsix unzip nests everything under
+ * `extension/`; the CB image's installed override dir (`/base/extension-overrides/<id>-<ver>/`) has
+ * package.json at its root. Accept either so the same digest runs on both sides of the swap.
+ */
+export const resolveExtensionRoot = (dir: string): string => {
+  if (existsSync(join(dir, 'package.json'))) {
+    return dir;
+  }
+  const nested = join(dir, 'extension');
+  if (existsSync(join(nested, 'package.json'))) {
+    return nested;
+  }
+  throw new Error(`no package.json found in ${dir} or ${nested} — not an extracted extension`);
+};
+
+/*
+ * Resolve the shipped bundle entry file from package.json `main`.
+ *
+ * Policy (ADR 0022, plan §4.3):
+ *   - missing `main`            → valid: declarative extension, no bundle to digest → null
+ *   - `main` present, resolves  → absolute path to the bundle file
+ *   - `main` present, missing   → throw (strict): a declared entrypoint that isn't there is a real
+ *                                  broken build/swap, never a silent pass
+ * `browser` is ignored on purpose — CB runs the desktop/node build (ADR 0022, plan C2).
+ */
+export const resolveEntrypoint = (extensionRoot: string): string | null => {
+  const pkg = JSON.parse(readFileSync(join(extensionRoot, 'package.json'), 'utf-8')) as { main?: string };
+  if (pkg.main === undefined || pkg.main === '') {
+    return null;
+  }
+  const entry = join(extensionRoot, pkg.main);
+  if (!existsSync(entry) || !statSync(entry).isFile()) {
+    throw new UnresolvableEntrypointError(extensionRoot, pkg.main);
+  }
+  return entry;
+};
+
+/*
+ * Compute the composite digest of an extracted extension. `dir` may be the extension root or a
+ * parent that contains it (a raw .vsix unzip); resolveExtensionRoot handles both. Sync + host-side:
+ * the caller has already extracted (swap) or docker-cp'd (verify) the tree to the host.
+ */
+export const computeExtensionDigest = (dir: string): ExtensionDigest => {
+  const root = resolveExtensionRoot(dir);
+  const pkgJsonDigest = sha256(readFileSync(join(root, 'package.json')));
+  const entry = resolveEntrypoint(root);
+  const bundleDigest = entry === null ? null : sha256(readFileSync(entry));
+  return { pkgJsonDigest, bundleDigest };
+};

--- a/packages/playwright-vscode-ext/src/codeBuilder/digest.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/digest.ts
@@ -22,7 +22,7 @@
 
 import { createHash } from 'node:crypto';
 import { existsSync, readFileSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve, sep } from 'node:path';
 
 /** The two-part content digest of one extension. `bundleDigest` is null for a declarative extension (no `main`). */
 export type ExtensionDigest = {
@@ -66,9 +66,12 @@ export const resolveExtensionRoot = (dir: string): string => {
  *
  * Policy (ADR 0022, plan §4.3):
  *   - missing `main`            → valid: declarative extension, no bundle to digest → null
- *   - `main` present, resolves  → absolute path to the bundle file
+ *   - `main` present, resolves  → absolute path to the bundle file, inside the extension root
  *   - `main` present, missing   → throw (strict): a declared entrypoint that isn't there is a real
  *                                  broken build/swap, never a silent pass
+ *   - `main` escapes the root    → throw: an absolute path or one with `..` that resolves outside the
+ *                                  extension would hash unrelated bytes and could reconcile
+ *                                  differently on the swap vs verify side (different parent temp dirs)
  * `browser` is ignored on purpose — CB runs the desktop/node build (ADR 0022, plan C2).
  */
 export const resolveEntrypoint = (extensionRoot: string): string | null => {
@@ -76,7 +79,12 @@ export const resolveEntrypoint = (extensionRoot: string): string | null => {
   if (pkg.main === undefined || pkg.main === '') {
     return null;
   }
-  const entry = join(extensionRoot, pkg.main);
+  const rootAbs = resolve(extensionRoot);
+  const entry = resolve(rootAbs, pkg.main);
+  // Must stay within the extension root (guards `..` traversal and absolute-path `main`).
+  if (entry !== rootAbs && !entry.startsWith(rootAbs + sep)) {
+    throw new UnresolvableEntrypointError(extensionRoot, pkg.main);
+  }
   if (!existsSync(entry) || !statSync(entry).isFile()) {
     throw new UnresolvableEntrypointError(extensionRoot, pkg.main);
   }

--- a/packages/playwright-vscode-ext/src/codeBuilder/digest.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/digest.ts
@@ -102,19 +102,22 @@ export const resolveExtensionRoot = (dir: string): string => {
  *                                  differently on the swap vs verify side (different parent temp dirs)
  * `browser` is ignored on purpose — CB runs the desktop/node build (ADR 0022, plan C2).
  */
-export const resolveEntrypoint = (extensionRoot: string): string | null => {
-  const pkg = JSON.parse(readFileSync(join(extensionRoot, 'package.json'), 'utf-8')) as { main?: string };
-  if (pkg.main === undefined || pkg.main === '') {
+/*
+ * Resolve + validate the entrypoint from an already-parsed `main`. Split out so callers that have
+ * already read package.json (computeExtensionDigest, swap) don't re-read it just to get `main`.
+ */
+const resolveEntrypointFromMain = (extensionRoot: string, main: string | undefined): string | null => {
+  if (main === undefined || main === '') {
     return null;
   }
   const rootAbs = resolve(extensionRoot);
-  const entry = resolve(rootAbs, pkg.main);
+  const entry = resolve(rootAbs, main);
   // Must stay within the extension root (guards `..` traversal and absolute-path `main`).
   if (entry !== rootAbs && !entry.startsWith(rootAbs + sep)) {
-    throw new UnresolvableEntrypointError(extensionRoot, pkg.main);
+    throw new UnresolvableEntrypointError(extensionRoot, main);
   }
   if (!existsSync(entry) || !statSync(entry).isFile()) {
-    throw new UnresolvableEntrypointError(extensionRoot, pkg.main);
+    throw new UnresolvableEntrypointError(extensionRoot, main);
   }
   // Re-check containment on the REAL path: an in-root symlink pointing outside the extension would
   // pass the string check above but hash foreign bytes. realpath resolves the link, then we assert
@@ -122,9 +125,14 @@ export const resolveEntrypoint = (extensionRoot: string): string | null => {
   const realRoot = realpathSync(rootAbs);
   const realEntry = realpathSync(entry);
   if (realEntry !== realRoot && !realEntry.startsWith(realRoot + sep)) {
-    throw new UnresolvableEntrypointError(extensionRoot, pkg.main);
+    throw new UnresolvableEntrypointError(extensionRoot, main);
   }
   return entry;
+};
+
+export const resolveEntrypoint = (extensionRoot: string): string | null => {
+  const pkg = JSON.parse(readFileSync(join(extensionRoot, 'package.json'), 'utf-8')) as { main?: string };
+  return resolveEntrypointFromMain(extensionRoot, pkg.main);
 };
 
 /*
@@ -132,10 +140,15 @@ export const resolveEntrypoint = (extensionRoot: string): string | null => {
  * parent that contains it (a raw .vsix unzip); resolveExtensionRoot handles both. Sync + host-side:
  * the caller has already extracted (swap) or docker-cp'd (verify) the tree to the host.
  */
-export const computeExtensionDigest = (dir: string): ExtensionDigest => {
+export const computeExtensionDigest = (dir: string, rawPkgJson?: string): ExtensionDigest => {
   const root = resolveExtensionRoot(dir);
-  const pkgJsonDigest = sha256(canonicalPackageJson(readFileSync(join(root, 'package.json'), 'utf-8')));
-  const entry = resolveEntrypoint(root);
+  // Read package.json ONCE and derive everything from it: the digest (canonical bytes) and the
+  // entrypoint (`main`). Callers that already read it (swap, for name/version validation) pass it
+  // in so the file isn't read a second/third time per extension.
+  const raw = rawPkgJson ?? readFileSync(join(root, 'package.json'), 'utf-8');
+  const pkgJsonDigest = sha256(canonicalPackageJson(raw));
+  const { main } = JSON.parse(raw) as { main?: string };
+  const entry = resolveEntrypointFromMain(root, main);
   const bundleDigest = entry === null ? null : sha256(readFileSync(entry));
   return { pkgJsonDigest, bundleDigest };
 };

--- a/packages/playwright-vscode-ext/src/codeBuilder/digest.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/digest.ts
@@ -55,22 +55,28 @@ const sha256 = (bytes: Buffer | string): string => createHash('sha256').update(b
  * changes the canonical form, so the gate keeps its teeth.
  */
 const INSTALL_INJECTED_KEYS = new Set(['__metadata']);
+// Stable, key-sorted stringify. Does NOT filter keys — filtering happens ONCE at the top level
+// (below), because install-injected keys like `__metadata` are added to the package.json ROOT; a
+// legitimately-named nested key (e.g. `{ contributes: { __metadata: … } }`) must be preserved or the
+// swap-side and verify-side digests would still agree but over the wrong content.
+const stableStringify = (value: unknown): string => {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+  const obj = value as Record<string, unknown>;
+  const entries = Object.keys(obj)
+    .toSorted()
+    .map(k => `${JSON.stringify(k)}:${stableStringify(obj[k])}`);
+  return `{${entries.join(',')}}`;
+};
 const canonicalPackageJson = (raw: string): string => {
   const parsed = JSON.parse(raw) as Record<string, unknown>;
-  const stableStringify = (value: unknown): string => {
-    if (value === null || typeof value !== 'object') {
-      return JSON.stringify(value);
-    }
-    if (Array.isArray(value)) {
-      return `[${value.map(stableStringify).join(',')}]`;
-    }
-    const entries = Object.keys(value as Record<string, unknown>)
-      .filter(k => !INSTALL_INJECTED_KEYS.has(k))
-      .toSorted()
-      .map(k => `${JSON.stringify(k)}:${stableStringify((value as Record<string, unknown>)[k])}`);
-    return `{${entries.join(',')}}`;
-  };
-  return stableStringify(parsed);
+  // Drop install-injected keys at the ROOT only, then stably stringify the rest.
+  const rootFiltered = Object.fromEntries(Object.entries(parsed).filter(([k]) => !INSTALL_INJECTED_KEYS.has(k)));
+  return stableStringify(rootFiltered);
 };
 
 /*

--- a/packages/playwright-vscode-ext/src/codeBuilder/manifest.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/manifest.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * The Manifest is the contract object linking swap → verify, and doubles as the persisted provenance
+ * record (what bytes were installed, by version+digest). Swap emits it; verify consumes it as the
+ * "expected" side and holds no state of its own.
+ *
+ * It is an Effect Schema so it is validated at every boundary — read back from disk in a later CI
+ * step, handed to verify — rather than trusted as an untyped blob. Persisted to a manifest.json a
+ * human can diff to see exactly what was under test.
+ */
+
+import type { ExtensionDigest } from './digest';
+import * as Either from 'effect/Either';
+import * as Schema from 'effect/Schema';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+
+/** One manifest entry: the extension id, its version, and its composite content digest. */
+export const ManifestEntrySchema = Schema.Struct({
+  /** Full publisher-qualified id, e.g. "salesforce.salesforcedx-vscode-core". */
+  id: Schema.String,
+  /** The version under test, e.g. "67.4.0". */
+  version: Schema.String,
+  /** sha256 of package.json bytes. */
+  pkgJsonDigest: Schema.String,
+  /** sha256 of the `main` bundle bytes, or null for a declarative extension (no `main`). */
+  bundleDigest: Schema.NullOr(Schema.String)
+});
+
+export type ManifestEntry = Schema.Schema.Type<typeof ManifestEntrySchema>;
+
+/** The full manifest: every extension swapped in, keyed for lookup by verify. */
+export const ManifestSchema = Schema.Struct({
+  /** Schema version of the manifest file itself, so a reader can detect format drift. */
+  schemaVersion: Schema.Literal(1),
+  entries: Schema.Array(ManifestEntrySchema)
+});
+
+export type Manifest = Schema.Schema.Type<typeof ManifestSchema>;
+
+/** Build a Manifest from swap results: id → version + the digest computed at install time. */
+export const makeManifest = (entries: readonly ({ id: string; version: string } & ExtensionDigest)[]): Manifest => ({
+  schemaVersion: 1,
+  entries: entries.map(e => ({
+    id: e.id,
+    version: e.version,
+    pkgJsonDigest: e.pkgJsonDigest,
+    bundleDigest: e.bundleDigest
+  }))
+});
+
+const encode = Schema.encodeSync(ManifestSchema);
+const decodeEither = Schema.decodeUnknownEither(ManifestSchema);
+
+/** Serialize + write the manifest to disk (the provenance artifact CI uploads). */
+export const writeManifest = (path: string, manifest: Manifest): void => {
+  writeFileSync(path, `${JSON.stringify(encode(manifest), null, 2)}\n`, 'utf-8');
+};
+
+/** Read + validate a manifest from disk. Throws with the schema error if the file is malformed. */
+export const readManifest = (path: string): Manifest => {
+  if (!existsSync(path)) {
+    throw new Error(`manifest not found: ${path}`);
+  }
+  const parsed: unknown = JSON.parse(readFileSync(path, 'utf-8'));
+  const result = decodeEither(parsed);
+  if (Either.isLeft(result)) {
+    throw new Error(`invalid manifest at ${path}: ${String(result.left)}`);
+  }
+  return result.right;
+};

--- a/packages/playwright-vscode-ext/src/codeBuilder/manifest.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/manifest.ts
@@ -17,6 +17,7 @@
 
 import type { ExtensionDigest } from './digest';
 import * as Either from 'effect/Either';
+import * as ParseResult from 'effect/ParseResult';
 import * as Schema from 'effect/Schema';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 
@@ -70,7 +71,9 @@ export const readManifest = (path: string): Manifest => {
   const parsed: unknown = JSON.parse(readFileSync(path, 'utf-8'));
   const result = decodeEither(parsed);
   if (Either.isLeft(result)) {
-    throw new Error(`invalid manifest at ${path}: ${String(result.left)}`);
+    // TreeFormatter renders the schema ParseError as a readable field-by-field tree; String(...)
+    // would just print "[object Object]".
+    throw new Error(`invalid manifest at ${path}: ${ParseResult.TreeFormatter.formatErrorSync(result.left)}`);
   }
   return result.right;
 };

--- a/packages/playwright-vscode-ext/src/codeBuilder/manifest.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/manifest.ts
@@ -20,8 +20,8 @@ import * as Either from 'effect/Either';
 import * as Schema from 'effect/Schema';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 
-/** One manifest entry: the extension id, its version, and its composite content digest. */
-export const ManifestEntrySchema = Schema.Struct({
+/** One manifest entry: the extension id, its version, and its composite content digest. (Internal — the public surface is the Manifest type + the read/write/make functions.) */
+const ManifestEntrySchema = Schema.Struct({
   /** Full publisher-qualified id, e.g. "salesforce.salesforcedx-vscode-core". */
   id: Schema.String,
   /** The version under test, e.g. "67.4.0". */
@@ -35,7 +35,7 @@ export const ManifestEntrySchema = Schema.Struct({
 export type ManifestEntry = Schema.Schema.Type<typeof ManifestEntrySchema>;
 
 /** The full manifest: every extension swapped in, keyed for lookup by verify. */
-export const ManifestSchema = Schema.Struct({
+const ManifestSchema = Schema.Struct({
   /** Schema version of the manifest file itself, so a reader can detect format drift. */
   schemaVersion: Schema.Literal(1),
   entries: Schema.Array(ManifestEntrySchema)

--- a/packages/playwright-vscode-ext/src/codeBuilder/runner.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/runner.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * The command-runner seam. Every container-facing utility shells out through this instead of calling
+ * execFileSync directly, so unit tests inject a fake that records argv (asserting the exact
+ * `docker cp …` a utility builds) with no real docker. The default is the real execFileSync, using
+ * arg arrays — never a shell string — so no argument is shell-interpreted (#7718 idiom).
+ *
+ * Plain function, not an Effect service: a team not on Effect can still use every utility. This repo
+ * may wrap it as a layer, but the seam itself imposes no Effect dependency.
+ */
+
+import { execFileSync } from 'node:child_process';
+
+/** Runs a command with an argv array and returns stdout as a string. Throws on non-zero exit. */
+export type CommandRunner = (file: string, args: readonly string[]) => string;
+
+/** Default runner: real process execution, arg-array form (no shell interpolation). */
+export const defaultRunner: CommandRunner = (file, args) => execFileSync(file, args as string[], { encoding: 'utf-8' });

--- a/packages/playwright-vscode-ext/src/codeBuilder/runner.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/runner.ts
@@ -29,7 +29,16 @@ const DEFAULT_TIMEOUT_MS = 600_000; // 10 min per attempt
 const DEFAULT_MAX_ATTEMPTS = 5;
 
 /** Per-attempt timeout (ms) for a shelled command. Env-overridable via CB_RUNNER_TIMEOUT_MS. */
-export const runnerTimeoutMs = (): number => Number(process.env.CB_RUNNER_TIMEOUT_MS) || DEFAULT_TIMEOUT_MS;
+export const runnerTimeoutMs = (): number => {
+  const raw = process.env.CB_RUNNER_TIMEOUT_MS;
+  if (raw === undefined) {
+    return DEFAULT_TIMEOUT_MS;
+  }
+  // `0` is a VALID explicit "no timeout" (execFileSync treats 0/undefined as unbounded), so honor it
+  // rather than `|| DEFAULT`-ing it back to 10 min. Only an unset/NaN/negative value falls back.
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : DEFAULT_TIMEOUT_MS;
+};
 
 // execFileSync throws `code: 'ETIMEDOUT'` when its `timeout` fires (it SIGTERMs the child); a genuine
 // non-zero exit has a numeric `status` and no such code. Only the former is a hang worth retrying.
@@ -43,7 +52,9 @@ const isTimeout = (err: unknown): boolean =>
  * extractor so extraction gets the same hang protection.
  */
 export const withTimeoutRetry = <T>(attempt: () => T): T => {
-  const maxAttempts = Number(process.env.CB_RUNNER_MAX_ATTEMPTS) || DEFAULT_MAX_ATTEMPTS;
+  // Always run at least once, even if the env var is 0/negative/garbage — otherwise the loop would
+  // be skipped and we'd fall through to `throw lastError` with nothing set.
+  const maxAttempts = Math.max(1, Number(process.env.CB_RUNNER_MAX_ATTEMPTS) || DEFAULT_MAX_ATTEMPTS);
   let lastError: unknown;
   for (let i = 1; i <= maxAttempts; i++) {
     try {
@@ -55,7 +66,9 @@ export const withTimeoutRetry = <T>(attempt: () => T): T => {
       lastError = err;
     }
   }
-  throw lastError; // exhausted retries on repeated timeouts
+  // maxAttempts >= 1 guarantees lastError is set here; the ?? guard just makes `throw undefined`
+  // impossible if that ever changes.
+  throw lastError ?? new Error('withTimeoutRetry: exhausted with no attempt executed');
 };
 
 /** Default runner: real process execution, arg-array form (no shell interpolation), with timeout + retry. */

--- a/packages/playwright-vscode-ext/src/codeBuilder/runner.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/runner.ts
@@ -20,5 +20,44 @@ import { execFileSync } from 'node:child_process';
 /** Runs a command with an argv array and returns stdout as a string. Throws on non-zero exit. */
 export type CommandRunner = (file: string, args: readonly string[]) => string;
 
-/** Default runner: real process execution, arg-array form (no shell interpolation). */
-export const defaultRunner: CommandRunner = (file, args) => execFileSync(file, args as string[], { encoding: 'utf-8' });
+// A bare execFileSync blocks FOREVER if the child never returns — a hung docker daemon or a wedged
+// container would deadlock the whole run with no way to abort. So every shelled command is given a
+// per-attempt timeout and retried on TIMEOUT only; the timeout is the hang backstop, the retry
+// rides out a transient wedge. Defaults are generous + env-overridable so a legitimately slow op
+// (a multi-GB `docker pull`) is not killed mid-progress, and tests can dial them down.
+const DEFAULT_TIMEOUT_MS = 600_000; // 10 min per attempt
+const DEFAULT_MAX_ATTEMPTS = 5;
+
+/** Per-attempt timeout (ms) for a shelled command. Env-overridable via CB_RUNNER_TIMEOUT_MS. */
+export const runnerTimeoutMs = (): number => Number(process.env.CB_RUNNER_TIMEOUT_MS) || DEFAULT_TIMEOUT_MS;
+
+// execFileSync throws `code: 'ETIMEDOUT'` when its `timeout` fires (it SIGTERMs the child); a genuine
+// non-zero exit has a numeric `status` and no such code. Only the former is a hang worth retrying.
+const isTimeout = (err: unknown): boolean =>
+  typeof err === 'object' && err !== null && 'code' in err && err.code === 'ETIMEDOUT';
+
+/*
+ * Run `attempt`, retrying ONLY on timeout up to CB_RUNNER_MAX_ATTEMPTS times, then bubble the last
+ * timeout error. A non-timeout failure (a real non-zero exit) is thrown immediately — retrying a
+ * command that legitimately failed would just repeat the failure. Shared with swap's host-side
+ * extractor so extraction gets the same hang protection.
+ */
+export const withTimeoutRetry = <T>(attempt: () => T): T => {
+  const maxAttempts = Number(process.env.CB_RUNNER_MAX_ATTEMPTS) || DEFAULT_MAX_ATTEMPTS;
+  let lastError: unknown;
+  for (let i = 1; i <= maxAttempts; i++) {
+    try {
+      return attempt();
+    } catch (err) {
+      if (!isTimeout(err)) {
+        throw err; // real failure, not a hang — do not retry
+      }
+      lastError = err;
+    }
+  }
+  throw lastError; // exhausted retries on repeated timeouts
+};
+
+/** Default runner: real process execution, arg-array form (no shell interpolation), with timeout + retry. */
+export const defaultRunner: CommandRunner = (file, args) =>
+  withTimeoutRetry(() => execFileSync(file, args as string[], { encoding: 'utf-8', timeout: runnerTimeoutMs() }));

--- a/packages/playwright-vscode-ext/src/codeBuilder/verify.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/verify.ts
@@ -70,7 +70,9 @@ const assertSafeId = (id: string): void => {
  */
 const listOverrideDirs = (runner: CommandRunner, container: string, id: string): string[] => {
   assertSafeId(id);
-  return runner('docker', ['exec', container, 'bash', '-lc', `ls -d ${OVERRIDES_DIR}/${id}-[0-9]* 2>/dev/null || true`])
+  // `bash -c`, NOT `-lc`: a login shell sources profiles that may print a banner/MOTD to stdout,
+  // which would be parsed as an extra "dir" and turn 1 real match into a spurious "found 2".
+  return runner('docker', ['exec', container, 'bash', '-c', `ls -d ${OVERRIDES_DIR}/${id}-[0-9]* 2>/dev/null || true`])
     .split('\n')
     .map(l => l.trim())
     .filter(Boolean);
@@ -130,6 +132,24 @@ export const verifyExtensions = (container: string, manifest: Manifest, options:
           version,
           ok: false,
           reason: `expected exactly 1 override dir, found ${dirs.length}${dirs.length > 0 ? `: ${dirs.join(' ')}` : ''}`
+        });
+        continue;
+      }
+
+      /*
+       * Enforce the version explicitly. The glob `<id>-[0-9]*` is version-agnostic, so the single
+       * matched dir could be a different version than the manifest expects (e.g. the swap left a
+       * 67.0.0 dir but the manifest wants 67.4.0). The dir name is "<id>-<version>"; require its
+       * version segment to equal the expected one, so this is a true version gate — not merely
+       * transitive through the package.json digest.
+       */
+      const dirBasename = dirs[0].slice(dirs[0].lastIndexOf('/') + 1);
+      if (dirBasename !== `${id}-${version}`) {
+        entries.push({
+          id,
+          version,
+          ok: false,
+          reason: `installed dir "${dirBasename}" does not match expected version — wanted ${id}-${version}`
         });
         continue;
       }

--- a/packages/playwright-vscode-ext/src/codeBuilder/verify.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/verify.ts
@@ -49,15 +49,32 @@ export type VerifyResult = {
 };
 
 /*
+ * An extension id is "<publisher>.<name>": publisher and name are npm-style, so only letters,
+ * digits, dots, underscores and dashes are legitimate. `id` is interpolated into the `bash -lc`
+ * glob below, so reject anything outside that charset up front — a stray shell/glob metacharacter
+ * (`;`, `$`, backtick, `*`, `?`, `[`, whitespace) would otherwise be interpreted by the shell or
+ * silently widen the match. Fail loud rather than build an unsafe command.
+ */
+const VALID_ID = /^[A-Za-z0-9._-]+$/;
+const assertSafeId = (id: string): void => {
+  if (!VALID_ID.test(id)) {
+    throw new Error(`unsafe extension id ${JSON.stringify(id)}: expected only [A-Za-z0-9._-]`);
+  }
+};
+
+/*
  * List the override dirs for an id. The dir is "<id>-<version>"; versions start with a digit, so
  * anchoring on "-[0-9]" stops a shorter id (…-org) prefix-matching a longer sibling (…-org-browser).
  * More or fewer than one match is itself a failure (a leftover dir is the false-green we guard).
+ * `id` is charset-validated (assertSafeId) before it reaches the shell string.
  */
-const listOverrideDirs = (runner: CommandRunner, container: string, id: string): string[] =>
-  runner('docker', ['exec', container, 'bash', '-lc', `ls -d ${OVERRIDES_DIR}/${id}-[0-9]* 2>/dev/null || true`])
+const listOverrideDirs = (runner: CommandRunner, container: string, id: string): string[] => {
+  assertSafeId(id);
+  return runner('docker', ['exec', container, 'bash', '-lc', `ls -d ${OVERRIDES_DIR}/${id}-[0-9]* 2>/dev/null || true`])
     .split('\n')
     .map(l => l.trim())
     .filter(Boolean);
+};
 
 const digestsMatch = (
   expected: { pkgJsonDigest: string; bundleDigest: string | null },
@@ -71,6 +88,26 @@ const digestsMatch = (
  */
 export const verifyExtensions = (container: string, manifest: Manifest, options: VerifyOptions = {}): VerifyResult => {
   const runner = options.runner ?? defaultRunner;
+
+  /*
+   * An empty manifest must NOT pass. `entries.every(...)` is vacuously true on [], so without this
+   * guard a gate over zero extensions would report "all present" — exactly the swap-silently-no-ops
+   * false-green this utility exists to close (a bug in swap that emits no entries would go green).
+   */
+  if (manifest.entries.length === 0) {
+    return {
+      ok: false,
+      entries: [
+        {
+          id: '(none)',
+          version: '',
+          ok: false,
+          reason: 'manifest has no entries — nothing to verify (swap likely emitted an empty manifest)'
+        }
+      ]
+    };
+  }
+
   const workDir = options.workDir ?? mkdtempSync(join(tmpdir(), 'cb-verify-'));
   const ownWorkDir = options.workDir === undefined;
 
@@ -78,7 +115,15 @@ export const verifyExtensions = (container: string, manifest: Manifest, options:
   try {
     for (const entry of manifest.entries) {
       const { id, version } = entry;
-      const dirs = listOverrideDirs(runner, container, id);
+      let dirs: string[];
+      try {
+        dirs = listOverrideDirs(runner, container, id);
+      } catch (err) {
+        // Unsafe id (assertSafeId) or a listing failure — a structured per-entry failure, consistent
+        // with the other modes, rather than an exception that skips the remaining entries.
+        entries.push({ id, version, ok: false, reason: (err as Error).message });
+        continue;
+      }
       if (dirs.length !== 1) {
         entries.push({
           id,
@@ -89,15 +134,21 @@ export const verifyExtensions = (container: string, manifest: Manifest, options:
         continue;
       }
 
-      // Copy the installed override tree out to the host and recompute the digest there.
+      // Copy the installed override tree out to the host and recompute the digest there. The cp is
+      // inside the try so a mid-run failure (dir vanished after the ls — TOCTOU — or the container
+      // died) becomes a structured per-entry failure, not an exception that skips the rest.
       const dest = join(workDir, `${id}-${version}`);
-      runner('docker', ['cp', `${container}:${dirs[0]}/.`, dest]);
-
       let actual;
       try {
+        runner('docker', ['cp', `${container}:${dirs[0]}/.`, dest]);
         actual = computeExtensionDigest(dest);
       } catch (err) {
-        entries.push({ id, version, ok: false, reason: `digest failed: ${(err as Error).message}` });
+        entries.push({
+          id,
+          version,
+          ok: false,
+          reason: `could not read installed extension: ${(err as Error).message}`
+        });
         continue;
       }
 

--- a/packages/playwright-vscode-ext/src/codeBuilder/verify.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/verify.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Verify: the content + version gate. PURE assertion — no mutation, no memory, no `sf`. Given a
+ * running container and the Manifest swap emitted, it proves each extension is installed exactly
+ * once at the expected version AND that its bytes match (composite digest), closing the false-green
+ * (ADR 0022): a swap that silently no-ops leaves a stale dir whose digest won't match, so it fails
+ * loud instead of passing on a coincidental version match.
+ *
+ * Post-install content lives in a loose override tree in the container; we `docker cp` each dir out
+ * to the host and recompute with the SAME digest core swap used pre-install (portability over speed —
+ * no dependency on in-container hashing tools).
+ */
+
+import type { Manifest } from './manifest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { computeExtensionDigest } from './digest';
+import { defaultRunner, type CommandRunner } from './runner';
+
+/** Where the CB image loads extension overrides from. */
+export const OVERRIDES_DIR = '/base/extension-overrides';
+
+export type VerifyOptions = {
+  /** Command runner (injectable for tests). Defaults to real docker via execFileSync. */
+  runner?: CommandRunner;
+  /** Host dir to copy override trees into for hashing. Defaults to an OS temp dir. */
+  workDir?: string;
+};
+
+/** One extension's gate result — pass, or a specific loud reason. */
+export type VerifyEntryResult = {
+  id: string;
+  version: string;
+  ok: boolean;
+  /** Human-readable failure reason when `ok` is false; undefined when it passed. */
+  reason?: string;
+};
+
+export type VerifyResult = {
+  ok: boolean;
+  entries: VerifyEntryResult[];
+};
+
+/*
+ * List the override dirs for an id. The dir is "<id>-<version>"; versions start with a digit, so
+ * anchoring on "-[0-9]" stops a shorter id (…-org) prefix-matching a longer sibling (…-org-browser).
+ * More or fewer than one match is itself a failure (a leftover dir is the false-green we guard).
+ */
+const listOverrideDirs = (runner: CommandRunner, container: string, id: string): string[] =>
+  runner('docker', ['exec', container, 'bash', '-lc', `ls -d ${OVERRIDES_DIR}/${id}-[0-9]* 2>/dev/null || true`])
+    .split('\n')
+    .map(l => l.trim())
+    .filter(Boolean);
+
+const digestsMatch = (
+  expected: { pkgJsonDigest: string; bundleDigest: string | null },
+  actual: { pkgJsonDigest: string; bundleDigest: string | null }
+): boolean => expected.pkgJsonDigest === actual.pkgJsonDigest && expected.bundleDigest === actual.bundleDigest;
+
+/*
+ * Verify the container against the manifest. Copies each override dir out to a host work dir, recomputes
+ * the composite digest, and asserts exactly-one-dir + version + digest per entry. Returns a structured
+ * result; callers decide how loud to be (assertVerified below throws for the CI gate).
+ */
+export const verifyExtensions = (container: string, manifest: Manifest, options: VerifyOptions = {}): VerifyResult => {
+  const runner = options.runner ?? defaultRunner;
+  const workDir = options.workDir ?? mkdtempSync(join(tmpdir(), 'cb-verify-'));
+  const ownWorkDir = options.workDir === undefined;
+
+  const entries: VerifyEntryResult[] = [];
+  try {
+    for (const entry of manifest.entries) {
+      const { id, version } = entry;
+      const dirs = listOverrideDirs(runner, container, id);
+      if (dirs.length !== 1) {
+        entries.push({
+          id,
+          version,
+          ok: false,
+          reason: `expected exactly 1 override dir, found ${dirs.length}${dirs.length > 0 ? `: ${dirs.join(' ')}` : ''}`
+        });
+        continue;
+      }
+
+      // Copy the installed override tree out to the host and recompute the digest there.
+      const dest = join(workDir, `${id}-${version}`);
+      runner('docker', ['cp', `${container}:${dirs[0]}/.`, dest]);
+
+      let actual;
+      try {
+        actual = computeExtensionDigest(dest);
+      } catch (err) {
+        entries.push({ id, version, ok: false, reason: `digest failed: ${(err as Error).message}` });
+        continue;
+      }
+
+      if (!digestsMatch(entry, actual)) {
+        entries.push({
+          id,
+          version,
+          ok: false,
+          reason:
+            'content digest mismatch — the swap did not take (stale/wrong bytes installed). ' +
+            `expected pkgJson=${entry.pkgJsonDigest.slice(0, 12)} bundle=${entry.bundleDigest?.slice(0, 12) ?? 'null'}; ` +
+            `got pkgJson=${actual.pkgJsonDigest.slice(0, 12)} bundle=${actual.bundleDigest?.slice(0, 12) ?? 'null'}`
+        });
+        continue;
+      }
+
+      entries.push({ id, version, ok: true });
+    }
+  } finally {
+    if (ownWorkDir) {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  }
+
+  return { ok: entries.every(e => e.ok), entries };
+};
+
+/*
+ * CI gate wrapper: run verifyExtensions and throw loud on any failure. A mismatch means the swap
+ * didn't take, not a test bug — the message says so, so it isn't misread as a spec failure.
+ */
+export const assertVerified = (container: string, manifest: Manifest, options: VerifyOptions = {}): void => {
+  const result = verifyExtensions(container, manifest, options);
+  for (const e of result.entries) {
+    console.log(e.ok ? `OK   ${e.id}@${e.version}` : `FAIL ${e.id}@${e.version}: ${e.reason}`);
+  }
+  if (!result.ok) {
+    throw new Error(
+      'Code Builder extension gate failed — container is running wrong/mixed/stale versions (the swap did not take).'
+    );
+  }
+
+  console.log('==> Gate passed: all extensions present exactly once at the expected version and bytes.');
+};

--- a/packages/playwright-vscode-ext/src/codeBuilder/verify.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/verify.ts
@@ -24,8 +24,18 @@ import { join } from 'node:path';
 import { computeExtensionDigest } from './digest';
 import { defaultRunner, type CommandRunner } from './runner';
 
-/** Where the CB image loads extension overrides from. */
+/** Where the CB image stores extension override sources (swap writes here). */
 export const OVERRIDES_DIR = '/base/extension-overrides';
+
+/*
+ * The runtime extensions dir code-server actually LOADS from. start.sh re-links each override here
+ * on restart. Verify checks this too: swap writing correct bytes into OVERRIDES_DIR is necessary but
+ * not sufficient — if the restart-time re-link fails (the equal/lower-version case swap's symlink
+ * wipe exists to enable), the override dir is pristine yet the host loads stale/no code. Asserting
+ * the runtime entry exists closes that loop, so the gate proves the LOADED extension, not just the
+ * on-disk source. Kept in sync with swap's wipe target.
+ */
+export const RUNTIME_EXT_DIR = '/home/codebuilder/.local/share/code-server/extensions';
 
 export type VerifyOptions = {
   /** Command runner (injectable for tests). Defaults to real docker via execFileSync. */
@@ -50,29 +60,29 @@ export type VerifyResult = {
 
 /*
  * An extension id is "<publisher>.<name>": publisher and name are npm-style, so only letters,
- * digits, dots, underscores and dashes are legitimate. `id` is interpolated into the `bash -lc`
+ * digits, dots, underscores and dashes are legitimate. `id` is interpolated into the `bash -c`
  * glob below, so reject anything outside that charset up front — a stray shell/glob metacharacter
  * (`;`, `$`, backtick, `*`, `?`, `[`, whitespace) would otherwise be interpreted by the shell or
- * silently widen the match. Fail loud rather than build an unsafe command.
+ * silently widen the match. Fail loud rather than build an unsafe command. Also require an
+ * alphanumeric (reject dot-only `.`/`..`), matching swap's guard so the two agree on a legal id.
  */
 const VALID_ID = /^[A-Za-z0-9._-]+$/;
 const assertSafeId = (id: string): void => {
-  if (!VALID_ID.test(id)) {
-    throw new Error(`unsafe extension id ${JSON.stringify(id)}: expected only [A-Za-z0-9._-]`);
+  if (!VALID_ID.test(id) || !/[A-Za-z0-9]/.test(id)) {
+    throw new Error(`unsafe extension id ${JSON.stringify(id)}: expected only [A-Za-z0-9._-] with an alphanumeric`);
   }
 };
 
 /*
- * List the override dirs for an id. The dir is "<id>-<version>"; versions start with a digit, so
+ * List entries matching "<baseDir>/<id>-<version>" for an id. Versions start with a digit, so
  * anchoring on "-[0-9]" stops a shorter id (…-org) prefix-matching a longer sibling (…-org-browser).
- * More or fewer than one match is itself a failure (a leftover dir is the false-green we guard).
- * `id` is charset-validated (assertSafeId) before it reaches the shell string.
+ * `id` is charset-validated (assertSafeId) before it reaches the shell string. Used for BOTH the
+ * override source dir and the runtime symlink dir. `bash -c`, NOT `-lc`: a login shell sources
+ * profiles that may print a banner to stdout, which would be parsed as an extra match.
  */
-const listOverrideDirs = (runner: CommandRunner, container: string, id: string): string[] => {
+const listExtensionEntries = (runner: CommandRunner, container: string, baseDir: string, id: string): string[] => {
   assertSafeId(id);
-  // `bash -c`, NOT `-lc`: a login shell sources profiles that may print a banner/MOTD to stdout,
-  // which would be parsed as an extra "dir" and turn 1 real match into a spurious "found 2".
-  return runner('docker', ['exec', container, 'bash', '-c', `ls -d ${OVERRIDES_DIR}/${id}-[0-9]* 2>/dev/null || true`])
+  return runner('docker', ['exec', container, 'bash', '-c', `ls -d ${baseDir}/${id}-[0-9]* 2>/dev/null || true`])
     .split('\n')
     .map(l => l.trim())
     .filter(Boolean);
@@ -119,7 +129,7 @@ export const verifyExtensions = (container: string, manifest: Manifest, options:
       const { id, version } = entry;
       let dirs: string[];
       try {
-        dirs = listOverrideDirs(runner, container, id);
+        dirs = listExtensionEntries(runner, container, OVERRIDES_DIR, id);
       } catch (err) {
         // Unsafe id (assertSafeId) or a listing failure — a structured per-entry failure, consistent
         // with the other modes, rather than an exception that skips the remaining entries.
@@ -181,6 +191,31 @@ export const verifyExtensions = (container: string, manifest: Manifest, options:
             'content digest mismatch — the swap did not take (stale/wrong bytes installed). ' +
             `expected pkgJson=${entry.pkgJsonDigest.slice(0, 12)} bundle=${entry.bundleDigest?.slice(0, 12) ?? 'null'}; ` +
             `got pkgJson=${actual.pkgJsonDigest.slice(0, 12)} bundle=${actual.bundleDigest?.slice(0, 12) ?? 'null'}`
+        });
+        continue;
+      }
+
+      /*
+       * Correct bytes are in the override SOURCE dir — but the host loads from the RUNTIME dir, which
+       * start.sh re-links on restart only when the override is strictly-newer than the wiped symlink.
+       * Assert the runtime entry for this exact id-version exists, so a re-link failure (or a missing
+       * restart) fails loud instead of passing green on a container serving stale/no code.
+       */
+      let runtime: string[];
+      try {
+        runtime = listExtensionEntries(runner, container, RUNTIME_EXT_DIR, id);
+      } catch (err) {
+        entries.push({ id, version, ok: false, reason: (err as Error).message });
+        continue;
+      }
+      const runtimeMatch = runtime.some(p => p.slice(p.lastIndexOf('/') + 1) === `${id}-${version}`);
+      if (!runtimeMatch) {
+        const found = runtime.length > 0 ? ` (found: ${runtime.join(' ')})` : '';
+        entries.push({
+          id,
+          version,
+          ok: false,
+          reason: `override bytes are correct but no runtime entry ${id}-${version} under ${RUNTIME_EXT_DIR} — the restart re-link did not take (or verify ran before restart), so the host is not loading this version${found}`
         });
         continue;
       }

--- a/packages/playwright-vscode-ext/src/index.ts
+++ b/packages/playwright-vscode-ext/src/index.ts
@@ -192,3 +192,18 @@ export { createAndOpenApexScript } from './utils/apexScript';
 // Config factories
 export { createWebConfig } from './config/createWebConfig';
 export { createDesktopConfig } from './config/createDesktopConfig';
+
+// Code Builder e2e — content/version gate + Manifest (see docs/plans/code-builder-e2e-toolkit.md)
+export {
+  computeExtensionDigest,
+  resolveEntrypoint,
+  resolveExtensionRoot,
+  UnresolvableEntrypointError
+} from './codeBuilder/digest';
+export type { ExtensionDigest } from './codeBuilder/digest';
+export { ManifestSchema, ManifestEntrySchema, makeManifest, readManifest, writeManifest } from './codeBuilder/manifest';
+export type { Manifest, ManifestEntry } from './codeBuilder/manifest';
+export { verifyExtensions, assertVerified, OVERRIDES_DIR } from './codeBuilder/verify';
+export type { VerifyOptions, VerifyResult, VerifyEntryResult } from './codeBuilder/verify';
+export { defaultRunner } from './codeBuilder/runner';
+export type { CommandRunner } from './codeBuilder/runner';

--- a/packages/playwright-vscode-ext/src/index.ts
+++ b/packages/playwright-vscode-ext/src/index.ts
@@ -193,3 +193,18 @@ export { createAndOpenApexScript } from './utils/apexScript';
 // Config factories
 export { createWebConfig } from './config/createWebConfig';
 export { createDesktopConfig } from './config/createDesktopConfig';
+
+// Code Builder e2e — content/version gate + Manifest (see docs/plans/code-builder-e2e-toolkit.md)
+export {
+  computeExtensionDigest,
+  resolveEntrypoint,
+  resolveExtensionRoot,
+  UnresolvableEntrypointError
+} from './codeBuilder/digest';
+export type { ExtensionDigest } from './codeBuilder/digest';
+export { ManifestSchema, ManifestEntrySchema, makeManifest, readManifest, writeManifest } from './codeBuilder/manifest';
+export type { Manifest, ManifestEntry } from './codeBuilder/manifest';
+export { verifyExtensions, assertVerified, OVERRIDES_DIR } from './codeBuilder/verify';
+export type { VerifyOptions, VerifyResult, VerifyEntryResult } from './codeBuilder/verify';
+export { defaultRunner } from './codeBuilder/runner';
+export type { CommandRunner } from './codeBuilder/runner';

--- a/packages/playwright-vscode-ext/src/index.ts
+++ b/packages/playwright-vscode-ext/src/index.ts
@@ -202,9 +202,9 @@ export {
   UnresolvableEntrypointError
 } from './codeBuilder/digest';
 export type { ExtensionDigest } from './codeBuilder/digest';
-export { ManifestSchema, ManifestEntrySchema, makeManifest, readManifest, writeManifest } from './codeBuilder/manifest';
+export { makeManifest, readManifest, writeManifest } from './codeBuilder/manifest';
 export type { Manifest, ManifestEntry } from './codeBuilder/manifest';
-export { verifyExtensions, assertVerified, OVERRIDES_DIR } from './codeBuilder/verify';
+export { verifyExtensions, assertVerified, OVERRIDES_DIR, RUNTIME_EXT_DIR } from './codeBuilder/verify';
 export type { VerifyOptions, VerifyResult, VerifyEntryResult } from './codeBuilder/verify';
 export { defaultRunner } from './codeBuilder/runner';
 export type { CommandRunner } from './codeBuilder/runner';

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/digest.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/digest.test.ts
@@ -93,6 +93,18 @@ describe('digest', () => {
       );
       expect(resolveEntrypoint(d)).toBe(join(d, 'dist/node.js'));
     });
+
+    it('throws when main uses `..` to escape the extension root', () => {
+      // A traversing main would hash bytes outside the extension and could reconcile differently
+      // across the swap/verify temp dirs — reject it rather than silently hash the wrong file.
+      const d = track(makeExtension({ pkg: { name: 'x', version: '1.0.0', main: '../../../etc/hosts' } }));
+      expect(() => resolveEntrypoint(d)).toThrow(UnresolvableEntrypointError);
+    });
+
+    it('throws when main is an absolute path outside the root', () => {
+      const d = track(makeExtension({ pkg: { name: 'x', version: '1.0.0', main: '/etc/hosts' } }));
+      expect(() => resolveEntrypoint(d)).toThrow(UnresolvableEntrypointError);
+    });
   });
 
   describe('computeExtensionDigest', () => {

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/digest.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/digest.test.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  computeExtensionDigest,
+  resolveEntrypoint,
+  resolveExtensionRoot,
+  UnresolvableEntrypointError
+} from '../../../src/codeBuilder/digest';
+
+/** Build an extension dir on disk. `layout: 'nested'` puts files under extension/ (raw .vsix shape). */
+const makeExtension = (opts: {
+  pkg: Record<string, unknown>;
+  bundle?: { path: string; content: string };
+  layout?: 'flat' | 'nested';
+}): string => {
+  const dir = mkdtempSync(join(tmpdir(), 'cb-digest-test-'));
+  const root = opts.layout === 'nested' ? join(dir, 'extension') : dir;
+  mkdirSync(root, { recursive: true });
+  writeFileSync(join(root, 'package.json'), JSON.stringify(opts.pkg));
+  if (opts.bundle) {
+    const bundlePath = join(root, opts.bundle.path);
+    mkdirSync(join(bundlePath, '..'), { recursive: true });
+    writeFileSync(bundlePath, opts.bundle.content);
+  }
+  return dir;
+};
+
+describe('digest', () => {
+  const dirs: string[] = [];
+  const track = (d: string): string => {
+    dirs.push(d);
+    return d;
+  };
+  afterAll(() => dirs.forEach(d => rmSync(d, { recursive: true, force: true })));
+
+  describe('resolveExtensionRoot', () => {
+    it('returns the dir itself when package.json is at the root (installed override shape)', () => {
+      const d = track(makeExtension({ pkg: { name: 'x', version: '1.0.0' } }));
+      expect(resolveExtensionRoot(d)).toBe(d);
+    });
+
+    it('descends into extension/ when package.json is nested (raw .vsix shape)', () => {
+      const d = track(makeExtension({ pkg: { name: 'x', version: '1.0.0' }, layout: 'nested' }));
+      expect(resolveExtensionRoot(d)).toBe(join(d, 'extension'));
+    });
+
+    it('throws when no package.json is found', () => {
+      const d = track(mkdtempSync(join(tmpdir(), 'cb-empty-')));
+      expect(() => resolveExtensionRoot(d)).toThrow(/no package.json/);
+    });
+  });
+
+  describe('resolveEntrypoint strictness', () => {
+    it('returns null when main is absent (declarative extension)', () => {
+      const d = track(makeExtension({ pkg: { name: 'x', version: '1.0.0' } }));
+      expect(resolveEntrypoint(d)).toBeNull();
+    });
+
+    it('returns null when main is empty string', () => {
+      const d = track(makeExtension({ pkg: { name: 'x', version: '1.0.0', main: '' } }));
+      expect(resolveEntrypoint(d)).toBeNull();
+    });
+
+    it('resolves main to an absolute file path when it exists', () => {
+      const d = track(
+        makeExtension({
+          pkg: { name: 'x', version: '1.0.0', main: './dist/index.js' },
+          bundle: { path: 'dist/index.js', content: 'code' }
+        })
+      );
+      expect(resolveEntrypoint(d)).toBe(join(d, 'dist/index.js'));
+    });
+
+    it('throws UnresolvableEntrypointError when main is declared but missing (broken build/swap)', () => {
+      const d = track(makeExtension({ pkg: { name: 'x', version: '1.0.0', main: './dist/index.js' } }));
+      expect(() => resolveEntrypoint(d)).toThrow(UnresolvableEntrypointError);
+    });
+
+    it('ignores browser and keys off main only (CB runs the desktop build)', () => {
+      const d = track(
+        makeExtension({
+          pkg: { name: 'x', version: '1.0.0', main: './dist/node.js', browser: './dist/web.js' },
+          bundle: { path: 'dist/node.js', content: 'node-code' }
+        })
+      );
+      expect(resolveEntrypoint(d)).toBe(join(d, 'dist/node.js'));
+    });
+  });
+
+  describe('computeExtensionDigest', () => {
+    it('produces both digests when a bundle exists', () => {
+      const d = track(
+        makeExtension({
+          pkg: { name: 'x', version: '1.0.0', main: 'main.js' },
+          bundle: { path: 'main.js', content: 'abc' }
+        })
+      );
+      const digest = computeExtensionDigest(d);
+      expect(digest.pkgJsonDigest).toMatch(/^[0-9a-f]{64}$/);
+      expect(digest.bundleDigest).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('produces a null bundleDigest for a declarative extension', () => {
+      const d = track(makeExtension({ pkg: { name: 'x', version: '1.0.0' } }));
+      expect(computeExtensionDigest(d).bundleDigest).toBeNull();
+    });
+
+    it('changes bundleDigest when only the bundle bytes change (the false-green catch)', () => {
+      const a = track(
+        makeExtension({ pkg: { name: 'x', version: '1.0.0', main: 'm.js' }, bundle: { path: 'm.js', content: 'v1' } })
+      );
+      const b = track(
+        makeExtension({ pkg: { name: 'x', version: '1.0.0', main: 'm.js' }, bundle: { path: 'm.js', content: 'v2' } })
+      );
+      const da = computeExtensionDigest(a);
+      const db = computeExtensionDigest(b);
+      expect(da.pkgJsonDigest).toBe(db.pkgJsonDigest); // identical package.json
+      expect(da.bundleDigest).not.toBe(db.bundleDigest); // different bundle → caught
+    });
+
+    it('is stable across the nested (.vsix) and flat (installed) layouts', () => {
+      const flat = track(
+        makeExtension({ pkg: { name: 'x', version: '1.0.0', main: 'm.js' }, bundle: { path: 'm.js', content: 'same' } })
+      );
+      const nested = track(
+        makeExtension({
+          pkg: { name: 'x', version: '1.0.0', main: 'm.js' },
+          bundle: { path: 'm.js', content: 'same' },
+          layout: 'nested'
+        })
+      );
+      expect(computeExtensionDigest(flat)).toEqual(computeExtensionDigest(nested));
+    });
+  });
+});

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/digest.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/digest.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -150,6 +150,46 @@ describe('digest', () => {
         })
       );
       expect(computeExtensionDigest(flat)).toEqual(computeExtensionDigest(nested));
+    });
+  });
+
+  /** Write raw package.json bytes verbatim (bypasses makeExtension's JSON.stringify) to model install-time rewrites. */
+  const makeExtensionRaw = (packageJsonRaw: string): string => {
+    const dir = mkdtempSync(join(tmpdir(), 'cb-digest-raw-'));
+    writeFileSync(join(dir, 'package.json'), packageJsonRaw);
+    return dir;
+  };
+
+  describe('canonical package.json digest (install-invariance)', () => {
+    it('is identical despite key reordering + whitespace/indentation differences', () => {
+      const swapSide = track(makeExtensionRaw('{"name":"x","version":"1.0.0"}'));
+      const verifySide = track(makeExtensionRaw('{\n  "version": "1.0.0",\n  "name": "x"\n}\n'));
+      expect(computeExtensionDigest(swapSide).pkgJsonDigest).toBe(computeExtensionDigest(verifySide).pkgJsonDigest);
+    });
+
+    it('ignores an install-injected __metadata block', () => {
+      const swapSide = track(makeExtensionRaw('{"name":"x","version":"1.0.0"}'));
+      const installed = track(
+        makeExtensionRaw('{"name":"x","version":"1.0.0","__metadata":{"installedTimestamp":123,"id":"abc"}}')
+      );
+      expect(computeExtensionDigest(swapSide).pkgJsonDigest).toBe(computeExtensionDigest(installed).pkgJsonDigest);
+    });
+
+    it('still differs when the meaningful content (version) changes', () => {
+      const a = track(makeExtensionRaw('{"name":"x","version":"1.0.0"}'));
+      const b = track(makeExtensionRaw('{"name":"x","version":"1.0.1"}'));
+      expect(computeExtensionDigest(a).pkgJsonDigest).not.toBe(computeExtensionDigest(b).pkgJsonDigest);
+    });
+  });
+
+  describe('symlink escape', () => {
+    it('throws when main is an in-root symlink pointing outside the extension root', () => {
+      const outside = track(mkdtempSync(join(tmpdir(), 'cb-outside-')));
+      writeFileSync(join(outside, 'secret.js'), 'foreign-bytes');
+      const d = track(makeExtension({ pkg: { name: 'x', version: '1.0.0', main: 'link.js' } }));
+      // link.js lives inside the root (passes the string containment check) but resolves outside it.
+      symlinkSync(join(outside, 'secret.js'), join(d, 'link.js'));
+      expect(() => resolveEntrypoint(d)).toThrow(UnresolvableEntrypointError);
     });
   });
 });

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/digest.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/digest.test.ts
@@ -175,6 +175,17 @@ describe('digest', () => {
       expect(computeExtensionDigest(swapSide).pkgJsonDigest).toBe(computeExtensionDigest(installed).pkgJsonDigest);
     });
 
+    it('strips __metadata only at the ROOT — a nested key named __metadata is meaningful content', () => {
+      const withoutNested = track(makeExtensionRaw('{"name":"x","version":"1.0.0","contributes":{"foo":1}}'));
+      const withNested = track(
+        makeExtensionRaw('{"name":"x","version":"1.0.0","contributes":{"foo":1,"__metadata":"user-data"}}')
+      );
+      // A legitimately-named nested __metadata must NOT be filtered, so it changes the digest.
+      expect(computeExtensionDigest(withoutNested).pkgJsonDigest).not.toBe(
+        computeExtensionDigest(withNested).pkgJsonDigest
+      );
+    });
+
     it('still differs when the meaningful content (version) changes', () => {
       const a = track(makeExtensionRaw('{"name":"x","version":"1.0.0"}'));
       const b = track(makeExtensionRaw('{"name":"x","version":"1.0.1"}'));

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/manifest.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/manifest.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { makeManifest, readManifest, writeManifest } from '../../../src/codeBuilder/manifest';
+
+describe('manifest', () => {
+  const dirs: string[] = [];
+  const tmp = (): string => {
+    const d = mkdtempSync(join(tmpdir(), 'cb-manifest-test-'));
+    dirs.push(d);
+    return d;
+  };
+  afterAll(() => dirs.forEach(d => rmSync(d, { recursive: true, force: true })));
+
+  it('makeManifest maps swap results into schema-shaped entries', () => {
+    const m = makeManifest([
+      { id: 'salesforce.core', version: '67.4.0', pkgJsonDigest: 'a', bundleDigest: 'b' },
+      { id: 'salesforce.decl', version: '67.4.0', pkgJsonDigest: 'c', bundleDigest: null }
+    ]);
+    expect(m.schemaVersion).toBe(1);
+    expect(m.entries).toHaveLength(2);
+    expect(m.entries[1].bundleDigest).toBeNull();
+  });
+
+  it('round-trips through disk (write → read) preserving null bundleDigest', () => {
+    const m = makeManifest([
+      { id: 'salesforce.core', version: '67.4.0', pkgJsonDigest: 'aa', bundleDigest: 'bb' },
+      { id: 'salesforce.decl', version: '67.4.0', pkgJsonDigest: 'cc', bundleDigest: null }
+    ]);
+    const path = join(tmp(), 'manifest.json');
+    writeManifest(path, m);
+    expect(readManifest(path)).toEqual(m);
+  });
+
+  it('throws on a missing manifest file', () => {
+    expect(() => readManifest(join(tmp(), 'nope.json'))).toThrow(/manifest not found/);
+  });
+
+  it('throws (validation) on a malformed manifest', () => {
+    const path = join(tmp(), 'bad.json');
+    writeFileSync(path, JSON.stringify({ schemaVersion: 2, entries: 'not-an-array' }));
+    expect(() => readManifest(path)).toThrow(/invalid manifest/);
+  });
+});

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/manifest.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/manifest.test.ts
@@ -43,9 +43,18 @@ describe('manifest', () => {
     expect(() => readManifest(join(tmp(), 'nope.json'))).toThrow(/manifest not found/);
   });
 
-  it('throws (validation) on a malformed manifest', () => {
+  it('throws (validation) on a malformed manifest with a readable (formatted) schema error', () => {
     const path = join(tmp(), 'bad.json');
     writeFileSync(path, JSON.stringify({ schemaVersion: 2, entries: 'not-an-array' }));
     expect(() => readManifest(path)).toThrow(/invalid manifest/);
+    // The message must be the TreeFormatter output, not a useless "[object Object]".
+    let message = '';
+    try {
+      readManifest(path);
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).not.toContain('[object Object]');
+    expect(message).toMatch(/schemaVersion|entries/);
   });
 });

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/runner.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/runner.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { defaultRunner, runnerTimeoutMs, withTimeoutRetry } from '../../../src/codeBuilder/runner';
+
+const timeoutError = (): Error => Object.assign(new Error('timed out'), { code: 'ETIMEDOUT' });
+
+describe('runnerTimeoutMs', () => {
+  const saved = process.env.CB_RUNNER_TIMEOUT_MS;
+  afterEach(() => {
+    if (saved === undefined) {
+      delete process.env.CB_RUNNER_TIMEOUT_MS;
+    } else {
+      process.env.CB_RUNNER_TIMEOUT_MS = saved;
+    }
+  });
+
+  it('defaults to a generous 10 minutes so a slow docker pull is not killed mid-progress', () => {
+    delete process.env.CB_RUNNER_TIMEOUT_MS;
+    expect(runnerTimeoutMs()).toBe(600_000);
+  });
+
+  it('honors CB_RUNNER_TIMEOUT_MS', () => {
+    process.env.CB_RUNNER_TIMEOUT_MS = '1234';
+    expect(runnerTimeoutMs()).toBe(1234);
+  });
+});
+
+describe('withTimeoutRetry', () => {
+  const savedAttempts = process.env.CB_RUNNER_MAX_ATTEMPTS;
+  afterEach(() => {
+    if (savedAttempts === undefined) {
+      delete process.env.CB_RUNNER_MAX_ATTEMPTS;
+    } else {
+      process.env.CB_RUNNER_MAX_ATTEMPTS = savedAttempts;
+    }
+  });
+
+  it('returns the value on first success, no retry', () => {
+    let calls = 0;
+    const out = withTimeoutRetry(() => {
+      calls++;
+      return 'ok';
+    });
+    expect(out).toBe('ok');
+    expect(calls).toBe(1);
+  });
+
+  it('retries ONLY on ETIMEDOUT, up to CB_RUNNER_MAX_ATTEMPTS, then bubbles the timeout', () => {
+    process.env.CB_RUNNER_MAX_ATTEMPTS = '3';
+    let calls = 0;
+    expect(() =>
+      withTimeoutRetry(() => {
+        calls++;
+        throw timeoutError();
+      })
+    ).toThrow('timed out');
+    expect(calls).toBe(3);
+  });
+
+  it('does NOT retry a non-timeout failure (real non-zero exit) — throws immediately', () => {
+    process.env.CB_RUNNER_MAX_ATTEMPTS = '5';
+    let calls = 0;
+    expect(() =>
+      withTimeoutRetry(() => {
+        calls++;
+        throw new Error('command exited 1');
+      })
+    ).toThrow('command exited 1');
+    expect(calls).toBe(1);
+  });
+
+  it('recovers if a later attempt succeeds after a transient timeout', () => {
+    process.env.CB_RUNNER_MAX_ATTEMPTS = '3';
+    let calls = 0;
+    const out = withTimeoutRetry(() => {
+      calls++;
+      if (calls < 2) {
+        throw timeoutError();
+      }
+      return 'recovered';
+    });
+    expect(out).toBe('recovered');
+    expect(calls).toBe(2);
+  });
+});
+
+describe('defaultRunner', () => {
+  const savedTimeout = process.env.CB_RUNNER_TIMEOUT_MS;
+  const savedAttempts = process.env.CB_RUNNER_MAX_ATTEMPTS;
+  const restore = (key: string, saved: string | undefined): void => {
+    if (saved === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = saved;
+    }
+  };
+  afterEach(() => {
+    restore('CB_RUNNER_TIMEOUT_MS', savedTimeout);
+    restore('CB_RUNNER_MAX_ATTEMPTS', savedAttempts);
+  });
+
+  it('returns stdout for a normal command', () => {
+    expect(defaultRunner('echo', ['hello']).trim()).toBe('hello');
+  });
+
+  it('times out a hanging command and bubbles after the retries are exhausted', () => {
+    process.env.CB_RUNNER_TIMEOUT_MS = '150';
+    process.env.CB_RUNNER_MAX_ATTEMPTS = '2';
+    expect(() => defaultRunner('sleep', ['5'])).toThrow();
+  }, 10_000);
+});

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/runner.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/runner.test.ts
@@ -28,6 +28,18 @@ describe('runnerTimeoutMs', () => {
     process.env.CB_RUNNER_TIMEOUT_MS = '1234';
     expect(runnerTimeoutMs()).toBe(1234);
   });
+
+  it('treats 0 as an explicit "no timeout", not a fallback to the default', () => {
+    process.env.CB_RUNNER_TIMEOUT_MS = '0';
+    expect(runnerTimeoutMs()).toBe(0);
+  });
+
+  it('falls back to the default for a negative or non-numeric value', () => {
+    process.env.CB_RUNNER_TIMEOUT_MS = '-5';
+    expect(runnerTimeoutMs()).toBe(600_000);
+    process.env.CB_RUNNER_TIMEOUT_MS = 'not-a-number';
+    expect(runnerTimeoutMs()).toBe(600_000);
+  });
 });
 
 describe('withTimeoutRetry', () => {
@@ -86,6 +98,17 @@ describe('withTimeoutRetry', () => {
     });
     expect(out).toBe('recovered');
     expect(calls).toBe(2);
+  });
+
+  it('runs at least once even if CB_RUNNER_MAX_ATTEMPTS is 0/negative (never throws undefined)', () => {
+    process.env.CB_RUNNER_MAX_ATTEMPTS = '0';
+    let calls = 0;
+    const out = withTimeoutRetry(() => {
+      calls++;
+      return 'ran';
+    });
+    expect(out).toBe('ran');
+    expect(calls).toBe(1);
   });
 });
 

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/verify.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/verify.test.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { computeExtensionDigest } from '../../../src/codeBuilder/digest';
+import { makeManifest } from '../../../src/codeBuilder/manifest';
+import type { CommandRunner } from '../../../src/codeBuilder/runner';
+import { OVERRIDES_DIR, verifyExtensions } from '../../../src/codeBuilder/verify';
+
+/** Make a real extension tree on disk (the "installed" bytes the fake `docker cp` will hand back). */
+const makeExtensionTree = (pkg: Record<string, unknown>, bundle?: { path: string; content: string }): string => {
+  const dir = mkdtempSync(join(tmpdir(), 'cb-verify-src-'));
+  writeFileSync(join(dir, 'package.json'), JSON.stringify(pkg));
+  if (bundle) {
+    writeFileSync(join(dir, bundle.path), bundle.content);
+  }
+  return dir;
+};
+
+/*
+ * Fake runner: answers `ls -d …` with the configured override dirs for each id, and on `docker cp
+ * <c>:<src>/. <dest>` copies the mapped source tree into <dest> so computeExtensionDigest has real
+ * bytes. Records every argv for assertions.
+ */
+const makeFakeRunner = (opts: {
+  dirsById: Record<string, string[]>; // id → container override dir paths the ls returns
+  treeByContainerDir: Record<string, string>; // container dir path → host source tree to copy out
+}): { runner: CommandRunner; calls: string[][] } => {
+  const calls: string[][] = [];
+  const runner: CommandRunner = (file, args) => {
+    calls.push([file, ...args]);
+    const script = args.at(-1);
+    if (args[0] === 'exec' && typeof script === 'string' && script.includes('ls -d')) {
+      const id = Object.keys(opts.dirsById).find(k => script.includes(`${OVERRIDES_DIR}/${k}-[0-9]`));
+      return id ? opts.dirsById[id].join('\n') : '';
+    }
+    if (args[0] === 'cp') {
+      const srcSpec = args[1]; // "<container>:<dir>/."
+      const dest = args[2];
+      const containerDir = srcSpec.slice(srcSpec.indexOf(':') + 1).replace(/\/\.$/, '');
+      const srcTree = opts.treeByContainerDir[containerDir];
+      mkdirSync(dest, { recursive: true });
+      cpSync(srcTree, dest, { recursive: true });
+      return '';
+    }
+    return '';
+  };
+  return { runner, calls };
+};
+
+describe('verifyExtensions', () => {
+  const cleanup: string[] = [];
+  const track = (d: string): string => {
+    cleanup.push(d);
+    return d;
+  };
+  afterAll(() => cleanup.forEach(d => rmSync(d, { recursive: true, force: true })));
+
+  const CONTAINER = 'cb-test';
+  const CORE_ID = 'salesforce.salesforcedx-vscode-core';
+  const CORE_DIR = `${OVERRIDES_DIR}/${CORE_ID}-67.4.0`;
+
+  it('passes when the installed bytes match the manifest digest', () => {
+    const tree = track(
+      makeExtensionTree(
+        { name: 'salesforcedx-vscode-core', version: '67.4.0', main: 'm.js' },
+        { path: 'm.js', content: 'v1' }
+      )
+    );
+    const digest = computeExtensionDigest(tree);
+    const manifest = makeManifest([{ id: CORE_ID, version: '67.4.0', ...digest }]);
+    const { runner } = makeFakeRunner({
+      dirsById: { [CORE_ID]: [CORE_DIR] },
+      treeByContainerDir: { [CORE_DIR]: tree }
+    });
+
+    const result = verifyExtensions(CONTAINER, manifest, { runner });
+    expect(result.ok).toBe(true);
+    expect(result.entries[0]).toMatchObject({ id: CORE_ID, ok: true });
+  });
+
+  it('issues the correct docker cp argv (seam correctness)', () => {
+    const tree = track(makeExtensionTree({ name: 'c', version: '67.4.0' }));
+    const manifest = makeManifest([{ id: CORE_ID, version: '67.4.0', ...computeExtensionDigest(tree) }]);
+    const { runner, calls } = makeFakeRunner({
+      dirsById: { [CORE_ID]: [CORE_DIR] },
+      treeByContainerDir: { [CORE_DIR]: tree }
+    });
+
+    verifyExtensions(CONTAINER, manifest, { runner });
+    const cp = calls.find(c => c[1] === 'cp');
+    expect(cp?.slice(0, 3)).toEqual(['docker', 'cp', `${CONTAINER}:${CORE_DIR}/.`]);
+  });
+
+  it('fails loud when a stale dir yields a digest mismatch (the false-green)', () => {
+    const installed = track(
+      makeExtensionTree({ name: 'c', version: '67.4.0', main: 'm.js' }, { path: 'm.js', content: 'STALE' })
+    );
+    const intended = track(
+      makeExtensionTree({ name: 'c', version: '67.4.0', main: 'm.js' }, { path: 'm.js', content: 'FRESH' })
+    );
+    // Manifest carries the intended (fresh) digest; the container hands back stale bytes.
+    const manifest = makeManifest([{ id: CORE_ID, version: '67.4.0', ...computeExtensionDigest(intended) }]);
+    const { runner } = makeFakeRunner({
+      dirsById: { [CORE_ID]: [CORE_DIR] },
+      treeByContainerDir: { [CORE_DIR]: installed }
+    });
+
+    const result = verifyExtensions(CONTAINER, manifest, { runner });
+    expect(result.ok).toBe(false);
+    expect(result.entries[0].reason).toMatch(/digest mismatch/);
+  });
+
+  it('fails when there is no override dir (swap did not install)', () => {
+    const manifest = makeManifest([{ id: CORE_ID, version: '67.4.0', pkgJsonDigest: 'x', bundleDigest: null }]);
+    const { runner } = makeFakeRunner({ dirsById: { [CORE_ID]: [] }, treeByContainerDir: {} });
+
+    const result = verifyExtensions(CONTAINER, manifest, { runner });
+    expect(result.ok).toBe(false);
+    expect(result.entries[0].reason).toMatch(/expected exactly 1 override dir, found 0/);
+  });
+
+  it('fails when a leftover second dir is present (duplicate)', () => {
+    const manifest = makeManifest([{ id: CORE_ID, version: '67.4.0', pkgJsonDigest: 'x', bundleDigest: null }]);
+    const { runner } = makeFakeRunner({
+      dirsById: { [CORE_ID]: [CORE_DIR, `${OVERRIDES_DIR}/${CORE_ID}-67.0.0`] },
+      treeByContainerDir: {}
+    });
+
+    const result = verifyExtensions(CONTAINER, manifest, { runner });
+    expect(result.ok).toBe(false);
+    expect(result.entries[0].reason).toMatch(/found 2/);
+  });
+});

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/verify.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/verify.test.ts
@@ -54,6 +54,26 @@ const makeFakeRunner = (opts: {
   return { runner, calls };
 };
 
+/*
+ * A runner that actually models the container filesystem + the `ls -d <prefix>-[0-9]*` glob, so the
+ * "-[0-9] anchor stops a prefix id matching a longer sibling" claim is exercised for real (not just a
+ * preconfigured dir list). Parses the glob out of the bash script instead of trusting the caller.
+ */
+const makeGlobRunner =
+  (fsDirs: string[]): CommandRunner =>
+  (file, args) => {
+    const script = args.at(-1);
+    if (args[0] === 'exec' && typeof script === 'string' && script.includes('ls -d')) {
+      // Extract "<OVERRIDES_DIR>/<id>-[0-9]*" and translate the shell glob to a regex.
+      const m = script.match(/ls -d (\S+)-\[0-9\]\*/);
+      if (!m) return '';
+      const prefix = m[1]; // e.g. /base/extension-overrides/salesforce.foo
+      const re = new RegExp(`^${prefix.replaceAll('.', '\\.')}-[0-9].*$`);
+      return fsDirs.filter(d => re.test(d)).join('\n');
+    }
+    return '';
+  };
+
 describe('verifyExtensions', () => {
   const cleanup: string[] = [];
   const track = (d: string): string => {
@@ -136,5 +156,78 @@ describe('verifyExtensions', () => {
     const result = verifyExtensions(CONTAINER, manifest, { runner });
     expect(result.ok).toBe(false);
     expect(result.entries[0].reason).toMatch(/found 2/);
+  });
+
+  // An EMPTY manifest must not pass — every([]) is vacuously true, which would be the false-green.
+  it('fails loud on an empty manifest (does not pass vacuously)', () => {
+    const manifest = makeManifest([]);
+    const { runner } = makeFakeRunner({ dirsById: {}, treeByContainerDir: {} });
+
+    const result = verifyExtensions(CONTAINER, manifest, { runner });
+    expect(result.ok).toBe(false);
+    expect(result.entries[0].reason).toMatch(/no entries/);
+  });
+
+  // The container hands back a docker-cp failure (dir vanished / container died) mid-run.
+  it('records a structured failure (not a throw) when docker cp fails', () => {
+    const manifest = makeManifest([{ id: CORE_ID, version: '67.4.0', pkgJsonDigest: 'x', bundleDigest: null }]);
+    const runner: CommandRunner = (file, args) => {
+      if (args[0] === 'exec') return CORE_DIR;
+      if (args[0] === 'cp') throw new Error('No such container:path');
+      return '';
+    };
+
+    const result = verifyExtensions(CONTAINER, manifest, { runner });
+    expect(result.ok).toBe(false);
+    expect(result.entries[0].reason).toMatch(/could not read installed extension/);
+  });
+
+  // An id with shell/glob metacharacters must be rejected before it reaches the bash -lc string.
+  it('rejects an unsafe extension id before building the shell command', () => {
+    const manifest = makeManifest([
+      { id: 'salesforce.foo; rm -rf /', version: '1.0.0', pkgJsonDigest: 'x', bundleDigest: null }
+    ]);
+    const seen: string[][] = [];
+    const runner: CommandRunner = (file, args) => {
+      seen.push([file, ...args]);
+      return '';
+    };
+
+    const result = verifyExtensions(CONTAINER, manifest, { runner });
+    expect(result.ok).toBe(false);
+    expect(result.entries[0].reason).toMatch(/unsafe extension id/);
+    // Never reached the runner (no command was built from the tainted id).
+    expect(seen).toHaveLength(0);
+  });
+
+  /*
+   * The core anti-substring-match claim, exercised against a REAL glob (makeGlobRunner), not a
+   * preconfigured list: `<id>-[0-9]*` for a shorter id must not match a longer sibling. A regression
+   * that widened the glob to `<id>-*` would make this fail.
+   */
+  describe('glob match isolation (-[0-9] anchor)', () => {
+    const ORG = 'salesforce.salesforcedx-vscode-org';
+    const BROWSER = 'salesforce.salesforcedx-vscode-org-browser';
+    // Both installed, in one container fs.
+    const fsDirs = [`${OVERRIDES_DIR}/${ORG}-67.4.0`, `${OVERRIDES_DIR}/${BROWSER}-67.4.0`];
+
+    it('does not match a longer sibling id (org vs org-browser)', () => {
+      // org-browser's char after "org-" is "b", not a digit, so org-[0-9]* must see exactly its own dir.
+      const manifest = makeManifest([{ id: ORG, version: '67.4.0', pkgJsonDigest: 'x', bundleDigest: null }]);
+      const result = verifyExtensions(CONTAINER, manifest, { runner: makeGlobRunner(fsDirs) });
+      // It finds exactly one dir (not two), so it proceeds to the digest step — the failure here is the
+      // stub digest 'x', NOT a "found 2" duplicate. That distinction is the whole point.
+      expect(result.entries[0].reason).not.toMatch(/found 2/);
+    });
+
+    it('DOES flag a genuine duplicate where a digit follows the boundary', () => {
+      // foo vs foo-2 both start "foo-<digit>", so foo-[0-9]* legitimately matches both → duplicate.
+      const dirs = [`${OVERRIDES_DIR}/salesforce.foo-1.0.0`, `${OVERRIDES_DIR}/salesforce.foo-2-1.0.0`];
+      const manifest = makeManifest([
+        { id: 'salesforce.foo', version: '1.0.0', pkgJsonDigest: 'x', bundleDigest: null }
+      ]);
+      const result = verifyExtensions(CONTAINER, manifest, { runner: makeGlobRunner(dirs) });
+      expect(result.entries[0].reason).toMatch(/found 2/);
+    });
   });
 });

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/verify.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/verify.test.ts
@@ -158,6 +158,23 @@ describe('verifyExtensions', () => {
     expect(result.entries[0].reason).toMatch(/found 2/);
   });
 
+  // A single dir of the WRONG version must fail — the glob is version-agnostic, so version is gated explicitly.
+  it('fails when the only installed dir is a different version than the manifest', () => {
+    const tree = track(
+      makeExtensionTree({ name: 'c', version: '67.0.0', main: 'm.js' }, { path: 'm.js', content: 'old' })
+    );
+    const WRONG_DIR = `${OVERRIDES_DIR}/${CORE_ID}-67.0.0`; // installed 67.0.0…
+    const manifest = makeManifest([{ id: CORE_ID, version: '67.4.0', ...computeExtensionDigest(tree) }]); // …manifest wants 67.4.0
+    const { runner } = makeFakeRunner({
+      dirsById: { [CORE_ID]: [WRONG_DIR] },
+      treeByContainerDir: { [WRONG_DIR]: tree }
+    });
+
+    const result = verifyExtensions(CONTAINER, manifest, { runner });
+    expect(result.ok).toBe(false);
+    expect(result.entries[0].reason).toMatch(/does not match expected version/);
+  });
+
   // An EMPTY manifest must not pass — every([]) is vacuously true, which would be the false-green.
   it('fails loud on an empty manifest (does not pass vacuously)', () => {
     const manifest = makeManifest([]);

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/verify.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/verify.test.ts
@@ -11,7 +11,7 @@ import { join } from 'node:path';
 import { computeExtensionDigest } from '../../../src/codeBuilder/digest';
 import { makeManifest } from '../../../src/codeBuilder/manifest';
 import type { CommandRunner } from '../../../src/codeBuilder/runner';
-import { OVERRIDES_DIR, verifyExtensions } from '../../../src/codeBuilder/verify';
+import { OVERRIDES_DIR, RUNTIME_EXT_DIR, verifyExtensions } from '../../../src/codeBuilder/verify';
 
 /** Make a real extension tree on disk (the "installed" bytes the fake `docker cp` will hand back). */
 const makeExtensionTree = (pkg: Record<string, unknown>, bundle?: { path: string; content: string }): string => {
@@ -28,15 +28,27 @@ const makeExtensionTree = (pkg: Record<string, unknown>, bundle?: { path: string
  * <c>:<src>/. <dest>` copies the mapped source tree into <dest> so computeExtensionDigest has real
  * bytes. Records every argv for assertions.
  */
+const basename = (p: string): string => p.slice(p.lastIndexOf('/') + 1);
+
 const makeFakeRunner = (opts: {
-  dirsById: Record<string, string[]>; // id → container override dir paths the ls returns
+  dirsById: Record<string, string[]>; // id → container OVERRIDE dir paths the ls returns
   treeByContainerDir: Record<string, string>; // container dir path → host source tree to copy out
+  // id → RUNTIME symlink entries the ls returns. Omit for the healthy default: the same basenames
+  // as the override dirs, rebased under RUNTIME_EXT_DIR (i.e. start.sh re-linked them successfully).
+  runtimeById?: Record<string, string[]>;
 }): { runner: CommandRunner; calls: string[][] } => {
   const calls: string[][] = [];
   const runner: CommandRunner = (file, args) => {
     calls.push([file, ...args]);
     const script = args.at(-1);
     if (args[0] === 'exec' && typeof script === 'string' && script.includes('ls -d')) {
+      const runtimeId = Object.keys(opts.dirsById).find(k => script.includes(`${RUNTIME_EXT_DIR}/${k}-[0-9]`));
+      if (runtimeId) {
+        const explicit = opts.runtimeById?.[runtimeId];
+        if (explicit) return explicit.join('\n');
+        // healthy default: relink succeeded → runtime entry per override dir
+        return opts.dirsById[runtimeId].map(d => `${RUNTIME_EXT_DIR}/${basename(d)}`).join('\n');
+      }
       const id = Object.keys(opts.dirsById).find(k => script.includes(`${OVERRIDES_DIR}/${k}-[0-9]`));
       return id ? opts.dirsById[id].join('\n') : '';
     }
@@ -135,6 +147,45 @@ describe('verifyExtensions', () => {
     const result = verifyExtensions(CONTAINER, manifest, { runner });
     expect(result.ok).toBe(false);
     expect(result.entries[0].reason).toMatch(/digest mismatch/);
+  });
+
+  it('fails when the override bytes are correct but the runtime relink is missing (restart did not take)', () => {
+    const tree = track(
+      makeExtensionTree(
+        { name: 'salesforcedx-vscode-core', version: '67.4.0', main: 'm.js' },
+        { path: 'm.js', content: 'v1' }
+      )
+    );
+    const manifest = makeManifest([{ id: CORE_ID, version: '67.4.0', ...computeExtensionDigest(tree) }]);
+    // Override dir is pristine + digest matches, but start.sh never re-linked the runtime symlink.
+    const { runner } = makeFakeRunner({
+      dirsById: { [CORE_ID]: [CORE_DIR] },
+      treeByContainerDir: { [CORE_DIR]: tree },
+      runtimeById: { [CORE_ID]: [] }
+    });
+
+    const result = verifyExtensions(CONTAINER, manifest, { runner });
+    expect(result.ok).toBe(false);
+    expect(result.entries[0].reason).toMatch(/no runtime entry .* the restart re-link did not take/);
+  });
+
+  it('passes when both the override bytes AND the runtime relink are present', () => {
+    const tree = track(
+      makeExtensionTree(
+        { name: 'salesforcedx-vscode-core', version: '67.4.0', main: 'm.js' },
+        { path: 'm.js', content: 'v1' }
+      )
+    );
+    const manifest = makeManifest([{ id: CORE_ID, version: '67.4.0', ...computeExtensionDigest(tree) }]);
+    const { runner, calls } = makeFakeRunner({
+      dirsById: { [CORE_ID]: [CORE_DIR] },
+      treeByContainerDir: { [CORE_DIR]: tree }
+    });
+
+    const result = verifyExtensions(CONTAINER, manifest, { runner });
+    expect(result.ok).toBe(true);
+    // It actually queried the runtime dir (not just the override dir).
+    expect(calls.some(c => (c.at(-1) as string)?.includes(RUNTIME_EXT_DIR))).toBe(true);
   });
 
   it('fails when there is no override dir (swap did not install)', () => {


### PR DESCRIPTION
### What does this PR do?

First implementation story of the reusable Code Builder e2e toolkit (epic: Code Builder E2E Testing Framework). Adds the **content + version gate** and its supporting digest/Manifest utilities to `playwright-vscode-ext`.

New utilities under `packages/playwright-vscode-ext/src/codeBuilder/`:

- **`digest.ts`** — composite content digest: `package.json` digest **+** `main`-bundle digest. Strict on an unresolvable `main` (declared-but-missing throws); `main`-absent → package.json-only; `browser` ignored (CB runs the desktop build). `resolveExtensionRoot` handles both the nested `.vsix` layout and the flat installed-override layout so the same digest reconciles on both sides of a swap.
- **`manifest.ts`** — Effect-Schema `Manifest` (`name → version → { pkgJsonDigest, bundleDigest | null }`) with `makeManifest` / `readManifest` / `writeManifest`. Validated at every boundary; persisted as the provenance record.
- **`verify.ts`** — the **pure** gate: `docker cp` each override dir out, recompute the digest, assert exactly-one-dir-per-extension **and** digest match. `assertVerified` throws loud for CI. No mutation, no memory, no `sf`.
- **`runner.ts`** — injectable `CommandRunner` seam (plain function, default `execFileSync` with arg arrays) so the utilities unit-test with no real docker.


### What issues does this PR fix or reference?

@W-23898517@

### Functionality Before

No importable Code Builder verify/digest/manifest utilities; #7718's verify was a standalone script comparing semver only.

### Functionality After

Importable, unit-tested `verifyExtensions` / `computeExtensionDigest` / `Manifest` in `playwright-vscode-ext` that prove installed **bytes** match the intended VSIX, not just the version.
