### PR TITLE
fix(lwc): prevent task completion and run-all crash races

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ graphify-out/
 .claude/scheduled_tasks.lock
 .claude/auto-build-wi.lock
 .claude/backlog-grooming-*.md
+/.fastcontext

--- a/docs/superpowers/specs/2026-06-24-lwc-codelens-coexistence-and-terminal-design.md
+++ b/docs/superpowers/specs/2026-06-24-lwc-codelens-coexistence-and-terminal-design.md
@@ -111,7 +111,7 @@ Watch mode behavior and its terminal; any change to Jest Runner; the watch -> Co
    - Exit check: `> 0` (skips signals like SIGTERM=143)
 
 5. **Crash error tracking via `capturedCrashError` flag** (`lwcTestController.ts`)
-   - Set `true` post-`run.failed()` on crash
+   - Set `true` post-`run.errored()` on crash
    - Flows to `waitForResultFile()` & `applyResults()` for timeout/result coordination
 
 6. **Optimized `waitForResultFile` timeout** (`lwcTestController.ts`)
@@ -138,7 +138,7 @@ Watch mode behavior and its terminal; any change to Jest Runner; the watch -> Co
 8. **Crash error extraction & formatting** (`lwcTestController.ts`)
    - On `exitCode > 0`/undefined: call `extractErrorSummary()`
    - Strip ANSI via `replaceAll(/\x1b\[[0-9;]*m/g, '')`
-   - Use `run.failed()` for consistency
+   - Use `run.errored()` for crashed tests (couldn't execute, not failed assertions)
    - Build `TestMessage` w/ `actualOutput` (exit code) + `location` from stack
    - Handle multi-line via split/append
 
@@ -165,7 +165,7 @@ Watch mode behavior and its terminal; any change to Jest Runner; the watch -> Co
 
 **Crash error handling flow:**
 1. Task completion, `exitCode > 0` or undefined: extract via `sfTask.pseudoterminal.extractErrorSummary()`
-2. Strip ANSI, mark source + children `failed` w/ message + location
+2. Strip ANSI, mark source `errored` w/ message + location; mark children `skipped()` (never ran)
 3. Set `capturedCrashError = true`
 4. `expectNoResults = true` to `waitForResultFile()` → 2s timeout (avoid 5m hang)
 5. `applyResults(run, results, sourceItem)` → skip re-mark via `skipItem` check

--- a/package-lock.json
+++ b/package-lock.json
@@ -46783,7 +46783,7 @@
     },
     "packages/salesforcedx-vscode-services-types": {
       "name": "@salesforce/vscode-services",
-      "version": "67.10.0",
+      "version": "67.11.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.43",

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/testExplorer/lwcTestController.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/testExplorer/lwcTestController.ts
@@ -525,9 +525,9 @@ class LwcTestController {
 
       const { command, args, workspaceFolder, testResultFsPath } = shellInfo;
 
-      // Track whether we've marked items as failed due to a crash error.
-      // This prevents applyResults from overwriting the crash-extracted error with generic messages.
-      let capturedCrashError = false;
+      // Track task failure independently of whether this run has a selected source item.
+      // This also prevents partial results from overwriting a crash-extracted error.
+      let taskCrashed = false;
       let exitCode: number | undefined;
 
       if (isDebug) {
@@ -556,9 +556,10 @@ class LwcTestController {
           command,
           args
         );
-        // execute() sets taskExecution synchronously, returns promise for completion
+        // Subscribe before starting the task so a fast task cannot finish before its completion listeners exist.
+        const taskEndPromise = awaitTaskEnd(sfTask, token);
         void sfTask.execute();
-        const taskEnd = await awaitTaskEnd(sfTask, token);
+        const taskEnd = await taskEndPromise;
         exitCode = taskEnd.exitCode;
 
         // Capture error details if Jest crashed, but don't return early.
@@ -566,9 +567,11 @@ class LwcTestController {
         // of a multi-file run). We'll attempt to read results and show both captured error and
         // any partial test results Jest produced.
         if (exitCode === undefined || exitCode > 0) {
+          taskCrashed = true;
           let errorMessage = `Jest test suite failed to run (exit code ${exitCode})`;
           let errorDetail = 'The test suite crashed before producing results.';
 
+          // Prefer the captured Jest error over the generic crash message when task output is available.
           if (sfTask.pseudoterminal) {
             const capturedError = sfTask.pseudoterminal.extractErrorSummary();
             if (capturedError) {
@@ -578,6 +581,7 @@ class LwcTestController {
             }
           }
 
+          // If this execution targets a specific test item, attach the error to it.
           if (sourceItem) {
             const message = new vscode.TestMessage(errorDetail);
             message.actualOutput = errorMessage;
@@ -594,13 +598,13 @@ class LwcTestController {
             sourceItem.children.forEach(child => {
               run.failed(child, message);
             });
-            appendLine(run, errorMessage);
-            appendLine(run, '');
-            // Split multi-line error detail into individual lines for proper formatting
-            const errorLines = errorDetail.split('\n');
-            errorLines.forEach(line => appendLine(run, line));
-            capturedCrashError = true;
           }
+
+          appendLine(run, errorMessage);
+          appendLine(run, '');
+          // Split multi-line error detail into individual lines for proper formatting
+          const errorLines = errorDetail.split('\n');
+          errorLines.forEach(line => appendLine(run, line));
         }
       }
 
@@ -612,8 +616,7 @@ class LwcTestController {
       // Poll for the file's existence with a short timeout before attempting to read.
       // If we captured a crash error and the exit code suggests no results file will exist,
       // use a shorter timeout to avoid hanging for 5 minutes.
-      const expectNoResults = capturedCrashError && (exitCode === undefined || exitCode > 0);
-      await waitForResultFile(testResultFsPath, token, expectNoResults);
+      await waitForResultFile(testResultFsPath, token, taskCrashed);
 
       if (token.isCancellationRequested) {
         return;
@@ -623,9 +626,9 @@ class LwcTestController {
       if (results) {
         // Don't let applyResults overwrite crash-extracted errors.
         // Pass the crash state so it can skip items already marked as failed.
-        this.applyResults(run, results, capturedCrashError ? sourceItem : undefined);
+        this.applyResults(run, results, taskCrashed ? sourceItem : undefined);
         appendTestResultsOutput(run, results, this.testItemLookup);
-      } else if (sourceItem && !capturedCrashError) {
+      } else if (sourceItem && !taskCrashed) {
         // Only show generic "no results" error if we didn't already capture a specific crash error
         run.failed(sourceItem, new vscode.TestMessage(nls.localize('no_test_results_produced_message')));
         appendLine(run, nls.localize('no_test_results_produced_message'));
@@ -802,7 +805,7 @@ const awaitTaskEnd = (sfTask: SfTask, token: vscode.CancellationToken): Promise<
     };
 
     const endHandler = vscode.tasks.onDidEndTaskProcess(e => {
-      if (e.execution === sfTask.taskExecution) {
+      if (sfTask.matchesExecution(e.execution)) {
         safeResolve({ exitCode: e.exitCode });
       }
     });

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/testExplorer/lwcTestController.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/testExplorer/lwcTestController.ts
@@ -594,9 +594,9 @@ class LwcTestController {
               message.location = new vscode.Location(errorUri, position);
             }
 
-            run.failed(sourceItem, message);
+            run.errored(sourceItem, message);
             sourceItem.children.forEach(child => {
-              run.failed(child, message);
+              run.skipped(child);
             });
           }
 
@@ -625,7 +625,7 @@ class LwcTestController {
       const results = await readJestResults(testResultFsPath);
       if (results) {
         // Don't let applyResults overwrite crash-extracted errors.
-        // Pass the crash state so it can skip items already marked as failed.
+        // Pass the crash state so it can skip items already marked as errored.
         this.applyResults(run, results, taskCrashed ? sourceItem : undefined);
         appendTestResultsOutput(run, results, this.testItemLookup);
       } else if (sourceItem && !taskCrashed) {
@@ -689,8 +689,8 @@ class LwcTestController {
    * Walk the Jest JSON output and attribute results to matching TestItems.
    *
    * This method processes Jest test results and updates the VS Code Test Explorer with pass/fail/skip states.
-   * It includes logic to prevent overwriting crash-extracted errors that were already set when Jest failed
-   * before producing complete results.
+   * It includes logic to prevent overwriting crash-extracted errors that were already marked as errored
+   * when Jest crashed before producing complete results.
    *
    * @param run The test run to apply results to
    * @param results Jest JSON results to process

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/testRunner/taskService.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/testRunner/taskService.ts
@@ -19,6 +19,7 @@ type SfTaskDefinition = vscode.TaskDefinition & {
  */
 export class SfTask {
   private task: vscode.Task;
+  private taskId: string;
   /**
    * The vscode.TaskExecution for this task, set after execute() resolves.
    * Use to correlate with task process events (e.g., onDidEndTaskProcess).
@@ -34,8 +35,9 @@ export class SfTask {
 
   private onDidStartEventEmitter: vscode.EventEmitter<SfTask>;
   private onDidEndEventEmitter: vscode.EventEmitter<SfTask>;
-  constructor(task: vscode.Task, pseudoterminal?: JestPseudoterminal) {
+  constructor(task: vscode.Task, taskId: string, pseudoterminal?: JestPseudoterminal) {
     this.task = task;
+    this.taskId = taskId;
     this.pseudoterminal = pseudoterminal;
     this.onDidStartEventEmitter = new vscode.EventEmitter<SfTask>();
     this.onDidEndEventEmitter = new vscode.EventEmitter<SfTask>();
@@ -54,6 +56,15 @@ export class SfTask {
   public async execute() {
     this.taskExecution = await vscode.tasks.executeTask(this.task);
     return this;
+  }
+
+  /**
+   * Correlates a VS Code task execution without relying on execute() having resolved.
+   */
+  public matchesExecution(execution: vscode.TaskExecution): boolean {
+    const { definition } = execution.task;
+    const executionTaskId = isString(definition.sfTaskId) ? definition.sfTaskId : undefined;
+    return this.taskId === executionTaskId;
   }
 
   public terminate() {
@@ -179,7 +190,7 @@ class TaskService {
       showReuseMessage: false
     };
 
-    const sfTask = new SfTask(task, pseudoterminal);
+    const sfTask = new SfTask(task, taskId, pseudoterminal);
     this.createdTasks.set(taskId, sfTask);
     return sfTask;
   }

--- a/packages/salesforcedx-vscode-lwc/test/jest/testSupport/testExplorer/lwcTestController.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/jest/testSupport/testExplorer/lwcTestController.test.ts
@@ -930,8 +930,8 @@ describe('LwcTestController public run API', () => {
 
     await ctrl.runByExecutionInfo({ kind: 'testFile' as const, testUri }, false);
 
-    expect(mockRun.failed).toHaveBeenCalled();
-    const [, message] = (mockRun.failed as jest.Mock).mock.calls[0];
+    expect(mockRun.errored).toHaveBeenCalled();
+    const [, message] = (mockRun.errored as jest.Mock).mock.calls[0];
     expect(message.location).toBeDefined();
     // Compare URIs rather than fsPath to avoid platform-specific path separators
     expect(message.location.uri.toString()).toBe(testUri.toString());
@@ -1079,12 +1079,12 @@ describe('LwcTestController public run API', () => {
     await ctrl.runByExecutionInfo({ kind: 'testFile' as const, testUri }, false);
 
     // The crash-extracted error should be preserved, not overwritten by Jest's generic message
-    expect(mockRun.failed).toHaveBeenCalled();
-    const failedCalls = (mockRun.failed as jest.Mock).mock.calls;
+    expect(mockRun.errored).toHaveBeenCalled();
+    const erroredCalls = (mockRun.errored as jest.Mock).mock.calls;
 
     // Find the call with the crash-extracted error (should contain "SyntaxError" in the message field)
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const crashErrorCall = failedCalls.find((call: any[]) => {
+    const crashErrorCall = erroredCalls.find((call: any[]) => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const testMessage = call[1];
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
@@ -1258,20 +1258,20 @@ describe('LwcTestController public run API', () => {
     // Run a file-level test that crashes
     await ctrl.runByExecutionInfo({ kind: 'testFile' as const, testUri }, false);
 
-    // The file should have been marked as failed with the crash error
-    expect(mockRun.failed).toHaveBeenCalled();
+    // The file should have been marked as errored with the crash error
+    expect(mockRun.errored).toHaveBeenCalled();
 
     // Verify that the crash error message is preserved (contains "ReferenceError")
     // and NOT overwritten by the generic Jest message from the results file
-    const failedCalls = (mockRun.failed as jest.Mock).mock.calls;
+    const erroredCalls = (mockRun.errored as jest.Mock).mock.calls;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const fileFailedCall = failedCalls.find((call: any[]) => call[1]?.message?.includes('ReferenceError'));
+    const fileErroredCall = erroredCalls.find((call: any[]) => call[1]?.message?.includes('ReferenceError'));
 
-    expect(fileFailedCall).toBeDefined();
+    expect(fileErroredCall).toBeDefined();
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(fileFailedCall[1].message).toContain('ReferenceError: foo is not defined');
+    expect(fileErroredCall[1].message).toContain('ReferenceError: foo is not defined');
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(fileFailedCall[1].message).not.toContain('Generic Jest error');
+    expect(fileErroredCall[1].message).not.toContain('Generic Jest error');
   });
 
   it('runByExecutionInfo reveals Test Results panel when starting a run', async () => {

--- a/packages/salesforcedx-vscode-lwc/test/jest/testSupport/testExplorer/lwcTestController.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/jest/testSupport/testExplorer/lwcTestController.test.ts
@@ -627,10 +627,8 @@ describe('LwcTestController public run API', () => {
         testResultFsPath: '/c/Users/RUNNER~1/work/proj/.sfdx/tools/testresults/lwc/test-result-1.json'
       });
 
-    // Fake task that ends right after execute resolves, so awaitTaskEnd resolves. The real SfTask fires onDidEnd
-    // asynchronously via the task-end event; fire on the next tick here too, otherwise awaitTaskEnd's
-    // endDisposable isn't assigned yet when the handler runs (its .dispose() would throw).
-    // Also mock onDidEndTaskProcess to fire the callback with the task execution info.
+    // Fire the process-end event before execute() assigns taskExecution. Completion must be correlated by the
+    // stable sfTaskId, and the listener must already exist before execution starts.
     let taskEndProcessCallback: ((e: vscode.TaskProcessEndEvent) => void) | undefined;
     const mockOnDidEndTaskProcess = jest.fn((cb: (e: vscode.TaskProcessEndEvent) => void) => {
       taskEndProcessCallback = cb;
@@ -638,29 +636,27 @@ describe('LwcTestController public run API', () => {
     });
     const vscodeMock = require('vscode');
     vscodeMock.tasks.onDidEndTaskProcess = mockOnDidEndTaskProcess;
+    vscodeMock.workspace.getWorkspaceFolder = jest.fn().mockReturnValue({
+      uri: URI.file('/c/Users/RUNNER~1/work/proj'),
+      name: 'project',
+      index: 0
+    });
 
     const taskServiceModule = require('../../../../src/testSupport/testRunner/taskService');
     jest.spyOn(taskServiceModule.taskService, 'createTask').mockImplementation(() => {
-      let endCb: (() => void) | undefined;
       const mockTaskExecution: vscode.TaskExecution = {
         task: {} as vscode.Task,
         terminate: jest.fn()
       } as vscode.TaskExecution;
       return {
-        onDidEnd: (cb: () => void) => {
-          endCb = cb;
-          return { dispose: jest.fn() };
-        },
+        onDidEnd: jest.fn(() => ({ dispose: jest.fn() })),
         execute: jest.fn().mockImplementation(function (this: any) {
+          taskEndProcessCallback?.({ execution: mockTaskExecution, exitCode: 0 });
           this.taskExecution = mockTaskExecution;
-          // Fire onDidEndTaskProcess with exit code 0 (success)
-          setImmediate(() => {
-            taskEndProcessCallback?.({ execution: mockTaskExecution, exitCode: 0 });
-            endCb?.();
-          });
           return Promise.resolve();
         }),
         terminate: jest.fn(),
+        matchesExecution: jest.fn((execution: vscode.TaskExecution) => execution === mockTaskExecution),
         taskExecution: undefined,
         pseudoterminal: undefined
       };
@@ -703,6 +699,115 @@ describe('LwcTestController public run API', () => {
     // ...and applyResults must mark that SAME discovery item passed despite the aliased jest path.
     expect(mockRun.passed).toHaveBeenCalledWith(treeItem);
     expect(mockRun.skipped).not.toHaveBeenCalledWith(treeItem);
+  });
+
+  it('reports a run-all crash and bounds result polling when no source item exists', async () => {
+    const mockRun = {
+      started: jest.fn(),
+      passed: jest.fn(),
+      failed: jest.fn(),
+      skipped: jest.fn(),
+      errored: jest.fn(),
+      appendOutput: jest.fn(),
+      end: jest.fn()
+    };
+    const controller = {
+      resolveHandler: undefined,
+      refreshHandler: undefined,
+      items: { replace: jest.fn(), forEach: jest.fn() },
+      createTestItem: jest.fn(),
+      createRunProfile: jest.fn(() => ({ dispose: jest.fn() })),
+      createTestRun: jest.fn(() => mockRun),
+      dispose: jest.fn()
+    };
+    (vscode.tests.createTestController as jest.Mock).mockReturnValue(controller);
+
+    jest
+      .spyOn(require('../../../../src/testSupport/testRunner/testRunner').TestRunner.prototype, 'getShellExecutionInfo')
+      .mockResolvedValue({
+        command: 'node',
+        args: [],
+        workspaceFolder: { uri: URI.file('/project') },
+        testResultFsPath: '/project/.sfdx/tools/testresults/lwc/test-result-1.json'
+      });
+
+    const vscodeMock = require('vscode');
+    const statSpy = jest.spyOn(vscodeMock.workspace.fs, 'stat').mockRejectedValue(new Error('no result file'));
+    const warningSpy = jest.spyOn(vscodeMock.window, 'showWarningMessage');
+    const EffectLib = jest.requireActual('effect/Effect');
+    mockFsReadFile.mockImplementation(() => EffectLib.fail(new Error('no result file')));
+
+    let taskEndProcessCallback: ((e: vscode.TaskProcessEndEvent) => void) | undefined;
+    vscodeMock.tasks.onDidEndTaskProcess = jest.fn((cb: (e: vscode.TaskProcessEndEvent) => void) => {
+      taskEndProcessCallback = cb;
+      return { dispose: jest.fn() };
+    });
+
+    const capturedStackTrace =
+      'SyntaxError: Unexpected token\n    at Object.<anonymous> (/project/force-app/lwc/foo/__tests__/foo.test.js:15:3)';
+    const taskServiceModule = require('../../../../src/testSupport/testRunner/taskService');
+    jest.spyOn(taskServiceModule.taskService, 'createTask').mockImplementation(() => {
+      const mockTaskExecution: vscode.TaskExecution = {
+        task: {} as vscode.Task,
+        terminate: jest.fn()
+      } as vscode.TaskExecution;
+      return {
+        onDidEnd: jest.fn(() => ({ dispose: jest.fn() })),
+        execute: jest.fn().mockImplementation(function (this: any) {
+          taskEndProcessCallback?.({ execution: mockTaskExecution, exitCode: 1 });
+          this.taskExecution = mockTaskExecution;
+          return Promise.resolve();
+        }),
+        terminate: jest.fn(),
+        matchesExecution: jest.fn((execution: vscode.TaskExecution) => execution === mockTaskExecution),
+        taskExecution: undefined,
+        pseudoterminal: { extractErrorSummary: jest.fn(() => capturedStackTrace) }
+      };
+    });
+
+    const timeoutSpy = jest.spyOn(globalThis, 'setTimeout').mockImplementation((callback: TimerHandler) => {
+      if (typeof callback === 'function') {
+        callback();
+      }
+      return undefined as unknown as ReturnType<typeof setTimeout>;
+    });
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const { getLwcTestController } = require('../../../../src/testSupport/testExplorer/lwcTestController');
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const ctrl = getLwcTestController();
+      const controllerWithExecuteOne = ctrl as unknown as {
+        executeOne: (
+          run: typeof mockRun,
+          executionInfo: { kind: 'testDirectory'; testUri: URI },
+          sourceItem: vscode.TestItem | undefined,
+          isDebug: boolean,
+          token: vscode.CancellationToken
+        ) => Promise<void>;
+      };
+      const token = {
+        isCancellationRequested: false,
+        onCancellationRequested: jest.fn(() => ({ dispose: jest.fn() }))
+      } as unknown as vscode.CancellationToken;
+
+      // Exercise executeOne directly with no source item, matching the implicit run-all path.
+      await controllerWithExecuteOne.executeOne(
+        mockRun,
+        { kind: 'testDirectory', testUri: URI.file('/project') },
+        undefined,
+        false,
+        token
+      );
+
+      expect(statSpy).toHaveBeenCalledTimes(4);
+      expect(warningSpy).not.toHaveBeenCalled();
+      const output = mockRun.appendOutput.mock.calls.flat().join('');
+      expect(output).toContain('Jest test suite failed to run');
+      expect(output).toContain('SyntaxError: Unexpected token');
+    } finally {
+      timeoutSpy.mockRestore();
+    }
   });
 
   it('runByExecutionInfo sets error location on crash message when pseudoterminal captures a stack trace', async () => {
@@ -809,6 +914,7 @@ describe('LwcTestController public run API', () => {
           return Promise.resolve();
         }),
         terminate: jest.fn(),
+        matchesExecution: jest.fn((execution: vscode.TaskExecution) => execution === mockTaskExecution),
         taskExecution: undefined,
         pseudoterminal: {
           extractErrorSummary: jest.fn(() => capturedStackTrace)
@@ -956,6 +1062,7 @@ describe('LwcTestController public run API', () => {
           return Promise.resolve();
         }),
         terminate: jest.fn(),
+        matchesExecution: jest.fn((execution: vscode.TaskExecution) => execution === mockTaskExecution),
         taskExecution: undefined,
         pseudoterminal: {
           extractErrorSummary: jest.fn(() => capturedStackTrace)
@@ -1134,6 +1241,7 @@ describe('LwcTestController public run API', () => {
           return Promise.resolve();
         }),
         terminate: jest.fn(),
+        matchesExecution: jest.fn((execution: vscode.TaskExecution) => execution === mockTaskExecution),
         taskExecution: undefined,
         pseudoterminal: {
           extractErrorSummary: jest.fn(() => capturedStackTrace)

--- a/packages/salesforcedx-vscode-lwc/test/jest/testSupport/testRunner/taskService.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/jest/testSupport/testRunner/taskService.test.ts
@@ -24,6 +24,18 @@ describe('TaskService', () => {
         clear: true,
         showReuseMessage: false
       });
+
+      const matchingExecution = { task: internalTask } as vscode.TaskExecution;
+      const otherExecution = {
+        task: new vscode.Task(
+          { type: 'sfLwcTest', sfTaskId: 'other-task-id' },
+          vscode.TaskScope.Workspace,
+          'Other Task',
+          'SFDX'
+        )
+      } as vscode.TaskExecution;
+      expect(task.matchesExecution(matchingExecution)).toBe(true);
+      expect(task.matchesExecution(otherExecution)).toBe(false);
     });
   });
 });

--- a/packages/salesforcedx-vscode-services-types/package.json
+++ b/packages/salesforcedx-vscode-services-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/vscode-services",
-  "version": "67.10.0",
+  "version": "67.11.1",
   "description": "TypeScript type definitions for Salesforce VS Code Services extension API",
   "author": "Salesforce",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
## Summary

- register task completion listeners before starting the VS Code task
- correlate process completion through the stable `sfTaskId` rather than waiting for `taskExecution` assignment
- track and report Jest crashes independently of a selected `TestItem`
- keep implicit run-all crashes on the bounded four-attempt result-file polling path
- add regression coverage for completion before `execute()` resolves, execution identity, and run-all crash reporting
- ignore the local `.fastcontext` directory
- synchronize the generated services-types package version and lockfile required by the branch's quality gate

## Why

PR #7940 starts task execution before registering its completion listeners and compares process events with `taskExecution`, which is assigned only after `vscode.tasks.executeTask()` resolves. A sufficiently fast task can therefore finish before the listener or correlation value is available.

Crash tracking was also set only when a selected source item existed. Implicit run-all has no source item, so a crash could enter the normal 600-attempt result-file polling path and fail to append the captured Jest error.

## Impact

Fast task completions are captured reliably using the task's generated identity. A run-all crash now retains its diagnostic output and uses the existing short crash timeout without displaying the result-file warning.

## Validation

- full LWC Jest suite: 14 suites, 82 tests, and 3 snapshots passed
- LWC source and test TypeScript checks passed
- changed source files passed ESLint; changed tests have no lint errors
- Prettier and `git diff --check` passed
- normal pre-commit workflow passed all 94 tasks
- normal pre-push workflow passed all 173 tasks

