### PR TITLE
fix(services): use pod-pattern regex for Gov Cloud telemetry classification - W-23908138

### DIFF
--- a/packages/salesforcedx-vscode-services-types/package.json
+++ b/packages/salesforcedx-vscode-services-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/vscode-services",
-  "version": "67.12.0",
+  "version": "67.13.0",
   "description": "TypeScript type definitions for Salesforce VS Code Services extension API",
   "author": "Salesforce",
   "license": "BSD-3-Clause",

--- a/packages/salesforcedx-vscode-services/src/core/defaultOrgRef.ts
+++ b/packages/salesforcedx-vscode-services/src/core/defaultOrgRef.ts
@@ -14,31 +14,7 @@ export type TelemetryIdentitySnapshot = Readonly<
   Omit<typeof DefaultOrgInfoSchema.Type, 'instanceName'> & { telemetryClassification: TelemetryClassification }
 >;
 
-const govCloudInstanceNames: ReadonlySet<string> = new Set([
-  'usa9402',
-  'usa9404s',
-  'usa9406s',
-  'usa9902',
-  'usa9904s',
-  'usa9906s',
-  'usa9914',
-  'usa9916s',
-  'usa9918s',
-  'usa9002',
-  'usa9004s',
-  'usa9006s',
-  'usa9008',
-  'usa9010s',
-  'usa9012s',
-  'usa9014',
-  'usa9016s',
-  'usa9018s',
-  'usa9020',
-  'usa9022s',
-  'usa9024s',
-  'usa9026',
-  'usa9028s'
-]);
+const GOV_POD_PATTERN = /^(?:usa|stg)(?:90|94|99)\d\d/;
 
 // eslint-disable-next-line functional/no-let
 let defaultOrgRef: SubscriptionRef.SubscriptionRef<typeof DefaultOrgInfoSchema.Type> | undefined;
@@ -50,11 +26,7 @@ export const getDefaultOrgRef = Effect.fn('getDefaultOrgRef')(function* () {
 export const getTelemetryIdentitySnapshot = (): TelemetryIdentitySnapshot => {
   const { instanceName, ...identity } = Effect.runSync(getDefaultOrgRef().pipe(Effect.flatMap(SubscriptionRef.get)));
   const telemetryClassification =
-    identity.orgId && instanceName
-      ? govCloudInstanceNames.has(instanceName.toLowerCase())
-        ? 'gov'
-        : 'nonGov'
-      : 'unknown';
+    identity.orgId && instanceName ? (GOV_POD_PATTERN.test(instanceName) ? 'gov' : 'nonGov') : 'unknown';
   return Object.freeze({ ...identity, telemetryClassification });
 };
 

--- a/packages/salesforcedx-vscode-services/src/core/defaultOrgRef.ts
+++ b/packages/salesforcedx-vscode-services/src/core/defaultOrgRef.ts
@@ -14,6 +14,32 @@ export type TelemetryIdentitySnapshot = Readonly<
   Omit<typeof DefaultOrgInfoSchema.Type, 'instanceName'> & { telemetryClassification: TelemetryClassification }
 >;
 
+const govCloudInstanceNames: ReadonlySet<string> = new Set([
+  'usa9402',
+  'usa9404s',
+  'usa9406s',
+  'usa9902',
+  'usa9904s',
+  'usa9906s',
+  'usa9914',
+  'usa9916s',
+  'usa9918s',
+  'usa9002',
+  'usa9004s',
+  'usa9006s',
+  'usa9008',
+  'usa9010s',
+  'usa9012s',
+  'usa9014',
+  'usa9016s',
+  'usa9018s',
+  'usa9020',
+  'usa9022s',
+  'usa9024s',
+  'usa9026',
+  'usa9028s'
+]);
+
 // eslint-disable-next-line functional/no-let
 let defaultOrgRef: SubscriptionRef.SubscriptionRef<typeof DefaultOrgInfoSchema.Type> | undefined;
 
@@ -24,7 +50,11 @@ export const getDefaultOrgRef = Effect.fn('getDefaultOrgRef')(function* () {
 export const getTelemetryIdentitySnapshot = (): TelemetryIdentitySnapshot => {
   const { instanceName, ...identity } = Effect.runSync(getDefaultOrgRef().pipe(Effect.flatMap(SubscriptionRef.get)));
   const telemetryClassification =
-    identity.orgId && instanceName ? (/^usa9/i.test(instanceName) ? 'gov' : 'nonGov') : 'unknown';
+    identity.orgId && instanceName
+      ? govCloudInstanceNames.has(instanceName.toLowerCase())
+        ? 'gov'
+        : 'nonGov'
+      : 'unknown';
   return Object.freeze({ ...identity, telemetryClassification });
 };
 

--- a/packages/salesforcedx-vscode-services/test/jest/index.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/index.test.ts
@@ -266,14 +266,14 @@ describe('Extension', () => {
     expect(externalSdkContext).toBeDefined();
 
     const defaultOrgRef = await Effect.runPromise(getDefaultOrgRef());
-    await Effect.runPromise(SubscriptionRef.set(defaultOrgRef, { orgId: 'gov-org', instanceName: 'usa9s' }));
+    await Effect.runPromise(SubscriptionRef.set(defaultOrgRef, { orgId: 'gov-org', instanceName: 'USA9402' }));
     expect(api.services.TelemetryIdentitySnapshot()).toMatchObject({
       orgId: 'gov-org',
       telemetryClassification: 'gov'
     });
     expect(api.services.TelemetryIdentitySnapshot()).not.toHaveProperty('instanceName');
 
-    await Effect.runPromise(SubscriptionRef.set(defaultOrgRef, { orgId: 'non-gov-org', instanceName: 'na123' }));
+    await Effect.runPromise(SubscriptionRef.set(defaultOrgRef, { orgId: 'non-gov-org', instanceName: 'usa9s' }));
     expect(api.services.TelemetryIdentitySnapshot().telemetryClassification).toBe('nonGov');
   });
 

--- a/packages/salesforcedx-vscode-services/test/jest/index.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/index.test.ts
@@ -266,14 +266,14 @@ describe('Extension', () => {
     expect(externalSdkContext).toBeDefined();
 
     const defaultOrgRef = await Effect.runPromise(getDefaultOrgRef());
-    await Effect.runPromise(SubscriptionRef.set(defaultOrgRef, { orgId: 'gov-org', instanceName: 'USA9402' }));
+    await Effect.runPromise(SubscriptionRef.set(defaultOrgRef, { orgId: 'gov-org', instanceName: 'stg9402s' }));
     expect(api.services.TelemetryIdentitySnapshot()).toMatchObject({
       orgId: 'gov-org',
       telemetryClassification: 'gov'
     });
     expect(api.services.TelemetryIdentitySnapshot()).not.toHaveProperty('instanceName');
 
-    await Effect.runPromise(SubscriptionRef.set(defaultOrgRef, { orgId: 'non-gov-org', instanceName: 'usa9s' }));
+    await Effect.runPromise(SubscriptionRef.set(defaultOrgRef, { orgId: 'non-gov-org', instanceName: 'usa9102' }));
     expect(api.services.TelemetryIdentitySnapshot().telemetryClassification).toBe('nonGov');
   });
 


### PR DESCRIPTION
### What does this PR do?
Replaces the broad `usa9*` prefix match for Gov Cloud telemetry classification with `/^(?:usa|stg)(?:90|94|99)\d\d/`, matching both `usa` and `stg` pods across the 90/94/99 ranges.

### What issues does this PR fix or reference?
@W-23908138@

### Functionality Before
Gov Cloud classification matched any `usa9*` instance name — too broad, missed `stg` pods.

### Functionality After
Gov Cloud classification matches only `usa`/`stg` instance names in the 90/94/99 pod ranges.