### PR TITLE
fix(lwc): close Jest crash review gaps

### DIFF
--- a/packages/salesforcedx-vscode-lwc/src/testSupport/testExplorer/lwcTestController.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/testExplorer/lwcTestController.ts
@@ -474,7 +474,14 @@ class LwcTestController {
         for (const target of targets) {
           this.markRunning(run, target.item);
         }
-        await this.executeOne(run, dirInfo, undefined, isDebug, token);
+        await this.executeOne(
+          run,
+          dirInfo,
+          undefined,
+          isDebug,
+          token,
+          targets.map(target => target.item)
+        );
         return;
       }
 
@@ -506,12 +513,20 @@ class LwcTestController {
     item.children.forEach(child => this.markRunning(run, child));
   };
 
+  private markDescendantsSkipped = (run: vscode.TestRun, item: vscode.TestItem): void => {
+    item.children.forEach(child => {
+      run.skipped(child);
+      this.markDescendantsSkipped(run, child);
+    });
+  };
+
   private executeOne = async (
     run: vscode.TestRun,
     exec: TestExecutionInfo,
     sourceItem: vscode.TestItem | undefined,
     isDebug: boolean,
-    token: vscode.CancellationToken
+    token: vscode.CancellationToken,
+    runAllItems: readonly vscode.TestItem[] = []
   ): Promise<void> => {
     const testRunner = new TestRunner(exec, isDebug ? 'debug' : 'run');
     try {
@@ -581,8 +596,7 @@ class LwcTestController {
             }
           }
 
-          // If this execution targets a specific test item, attach the error to it.
-          if (sourceItem) {
+          const createCrashMessage = (): vscode.TestMessage => {
             const message = new vscode.TestMessage(errorDetail);
             message.actualOutput = errorMessage;
 
@@ -594,9 +608,19 @@ class LwcTestController {
               message.location = new vscode.Location(errorUri, position);
             }
 
-            run.errored(sourceItem, message);
-            sourceItem.children.forEach(child => {
-              run.skipped(child);
+            return message;
+          };
+
+          // If this execution targets a specific test item, attach the error to it. For an implicit run-all,
+          // give every item that was marked running a terminal state; partial Jest results can still replace
+          // these provisional crash states below.
+          if (sourceItem) {
+            run.errored(sourceItem, createCrashMessage());
+            this.markDescendantsSkipped(run, sourceItem);
+          } else {
+            runAllItems.forEach(item => {
+              run.errored(item, createCrashMessage());
+              this.markDescendantsSkipped(run, item);
             });
           }
 

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/testRunner/jestPseudoterminal.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/testRunner/jestPseudoterminal.ts
@@ -11,6 +11,7 @@ import * as vscode from 'vscode';
 const MAX_ERROR_STACK_LINES = 30; // Typical stack traces are 10-20 lines
 const MAX_FAIL_CONTEXT_LINES = 50; // FAIL blocks can include test output
 const MAX_CAPTURED_OUTPUT_KB = 100; // Prevent unbounded memory growth on verbose tests
+const CAPTURE_TRUNCATION_MARKER = '\n... Jest output truncated ...\n';
 
 /**
  * Pseudoterminal that spawns Jest, displays output, and captures it for error extraction.
@@ -89,19 +90,48 @@ export class JestPseudoterminal implements vscode.Pseudoterminal {
     return this.capturedOutput;
   }
 
-  /**
-   * Append text to captured output with memory limit. Keeps most recent output if limit exceeded.
-   */
+  /** Append text while retaining both the beginning and end of oversized output. */
   private appendWithLimit(current: string, text: string): string {
     const combined = current + text;
     const maxBytes = MAX_CAPTURED_OUTPUT_KB * 1024;
-    const byteLength = Buffer.byteLength(combined, 'utf8');
-    if (byteLength > maxBytes) {
-      // Slice by chars (~1.5 bytes/char avg, /2 for safety margin)
-      const targetChars = Math.floor(maxBytes / 2);
-      return combined.slice(-targetChars);
+    if (Buffer.byteLength(combined, 'utf8') <= maxBytes) {
+      return combined;
     }
-    return combined;
+
+    const markerBytes = Buffer.byteLength(CAPTURE_TRUNCATION_MARKER, 'utf8');
+    const availableBytes = maxBytes - markerBytes;
+    const headBytes = Math.floor(availableBytes / 2);
+    const tailBytes = availableBytes - headBytes;
+    const markerIndex = current.indexOf(CAPTURE_TRUNCATION_MARKER);
+    const headSource = markerIndex >= 0 ? current.slice(0, markerIndex) : combined;
+    const tailSource =
+      markerIndex >= 0 ? current.slice(markerIndex + CAPTURE_TRUNCATION_MARKER.length) + text : combined;
+
+    return this.utf8Prefix(headSource, headBytes) + CAPTURE_TRUNCATION_MARKER + this.utf8Suffix(tailSource, tailBytes);
+  }
+
+  private utf8Prefix(value: string, maxBytes: number): string {
+    const buffer = Buffer.from(value, 'utf8');
+    if (buffer.length <= maxBytes) {
+      return value;
+    }
+    let end = maxBytes;
+    while (end > 0 && end < buffer.length && (buffer[end] & 0xc0) === 0x80) {
+      end--;
+    }
+    return buffer.subarray(0, end).toString('utf8');
+  }
+
+  private utf8Suffix(value: string, maxBytes: number): string {
+    const buffer = Buffer.from(value, 'utf8');
+    if (buffer.length <= maxBytes) {
+      return value;
+    }
+    let start = buffer.length - maxBytes;
+    while (start < buffer.length && (buffer[start] & 0xc0) === 0x80) {
+      start++;
+    }
+    return buffer.subarray(start).toString('utf8');
   }
 
   /**

--- a/packages/salesforcedx-vscode-lwc/test/jest/testSupport/testExplorer/lwcTestController.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/jest/testSupport/testExplorer/lwcTestController.test.ts
@@ -783,13 +783,22 @@ describe('LwcTestController public run API', () => {
           executionInfo: { kind: 'testDirectory'; testUri: URI },
           sourceItem: vscode.TestItem | undefined,
           isDebug: boolean,
-          token: vscode.CancellationToken
+          token: vscode.CancellationToken,
+          runAllItems: readonly vscode.TestItem[]
         ) => Promise<void>;
       };
       const token = {
         isCancellationRequested: false,
         onCancellationRequested: jest.fn(() => ({ dispose: jest.fn() }))
       } as unknown as vscode.CancellationToken;
+      const runAllChild = {
+        id: 'case:child',
+        children: { forEach: jest.fn() }
+      } as unknown as vscode.TestItem;
+      const runAllItem = {
+        id: 'file:run-all',
+        children: { forEach: (callback: (item: vscode.TestItem) => void) => callback(runAllChild) }
+      } as unknown as vscode.TestItem;
 
       // Exercise executeOne directly with no source item, matching the implicit run-all path.
       await controllerWithExecuteOne.executeOne(
@@ -797,11 +806,17 @@ describe('LwcTestController public run API', () => {
         { kind: 'testDirectory', testUri: URI.file('/project') },
         undefined,
         false,
-        token
+        token,
+        [runAllItem]
       );
 
       expect(statSpy).toHaveBeenCalledTimes(4);
       expect(warningSpy).not.toHaveBeenCalled();
+      expect(mockRun.errored).toHaveBeenCalledWith(
+        runAllItem,
+        expect.objectContaining({ message: expect.stringContaining('SyntaxError: Unexpected token') })
+      );
+      expect(mockRun.skipped).toHaveBeenCalledWith(runAllChild);
       const output = mockRun.appendOutput.mock.calls.flat().join('');
       expect(output).toContain('Jest test suite failed to run');
       expect(output).toContain('SyntaxError: Unexpected token');
@@ -1116,12 +1131,13 @@ describe('LwcTestController public run API', () => {
     // (the file item should still have the crash-extracted error, not "Generic Jest error message from results file")
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(item.id).toBe('file:file:///project/force-app/lwc/foo/__tests__/foo.test.js');
+    expect(mockRun.failed).not.toHaveBeenCalledWith(item, expect.anything());
+    expect(mockRun.passed).not.toHaveBeenCalledWith(item);
   });
 
-  it('applyResults skips files when crash-extracted error exists in deeply nested descendant', async () => {
-    // This test verifies the ancestor chain walking works for deeply nested items
-    // Simulates a case where a deeply nested test case (e.g., inside multiple describe blocks) crashes
+  it('preserves a case-level crash error when the fallback resolves without an exit code and partial results exist', async () => {
     const testUri = URI.file('/project/force-app/lwc/foo/__tests__/foo.test.js');
+    const testName = 'does not overwrite the crash error';
 
     const mockRun = {
       started: jest.fn(),
@@ -1133,6 +1149,43 @@ describe('LwcTestController public run API', () => {
       end: jest.fn()
     };
 
+    const createTestItem = (id: string, label: string, uri?: URI): vscode.TestItem => {
+      const childItems = new Map<string, vscode.TestItem>();
+      const children: vscode.TestItemCollection = {
+        get size() {
+          return childItems.size;
+        },
+        replace: items => {
+          childItems.clear();
+          items.forEach(child => {
+            Object.defineProperty(child, 'parent', { value: item, configurable: true });
+            childItems.set(child.id, child);
+          });
+        },
+        forEach: (callback, thisArg) => {
+          childItems.forEach(child => callback.call(thisArg, child, children));
+        },
+        add: child => {
+          Object.defineProperty(child, 'parent', { value: item, configurable: true });
+          childItems.set(child.id, child);
+        },
+        delete: idToDelete => {
+          childItems.delete(idToDelete);
+        },
+        get: idToGet => childItems.get(idToGet),
+        [Symbol.iterator]: () => childItems[Symbol.iterator]()
+      };
+      const item = {
+        id,
+        label,
+        uri,
+        canResolveChildren: false,
+        tags: [],
+        children
+      } as unknown as vscode.TestItem;
+      return item;
+    };
+
     const controller = {
       resolveHandler: undefined,
       refreshHandler: undefined,
@@ -1140,14 +1193,7 @@ describe('LwcTestController public run API', () => {
         replace: jest.fn(),
         forEach: jest.fn()
       },
-      createTestItem: (id: string, label: string, uri?: URI) => ({
-        id,
-        label,
-        uri,
-        canResolveChildren: false,
-        tags: [],
-        children: { replace: jest.fn(), forEach: jest.fn() }
-      }),
+      createTestItem,
       createRunProfile: jest.fn(() => ({ dispose: jest.fn() })),
       createTestRun: jest.fn(() => mockRun),
       dispose: jest.fn()
@@ -1175,7 +1221,9 @@ describe('LwcTestController public run API', () => {
 
     (vscode.tests.createTestController as jest.Mock).mockReturnValue(controller);
     (lwcTestIndexer.findAllTestFileInfo as jest.Mock).mockResolvedValue([{ kind: 'testFile' as const, testUri }]);
-    (lwcTestIndexer.findTestInfoFromLwcJestTestFile as jest.Mock).mockResolvedValue([]);
+    (lwcTestIndexer.findTestInfoFromLwcJestTestFile as jest.Mock).mockResolvedValue([
+      { kind: 'testCase' as const, testUri, testName, ancestorTitles: ['outer', 'inner'] }
+    ]);
 
     jest
       .spyOn(require('../../../../src/testSupport/testRunner/testRunner').TestRunner.prototype, 'getShellExecutionInfo')
@@ -1194,7 +1242,7 @@ describe('LwcTestController public run API', () => {
       index: 0
     });
 
-    // Mock that a results file exists with generic error
+    // Jest wrote a partial results file that would overwrite the case-level crash without the ancestor guard.
     const EffectLib = jest.requireActual('effect/Effect');
     mockFsReadFile.mockImplementation(() =>
       EffectLib.succeed(
@@ -1203,19 +1251,21 @@ describe('LwcTestController public run API', () => {
             {
               name: '/project/force-app/lwc/foo/__tests__/foo.test.js',
               status: 'failed',
-              assertionResults: [],
-              message: 'Generic Jest error that should NOT overwrite crash error'
+              assertionResults: [
+                {
+                  title: testName,
+                  ancestorTitles: ['outer', 'inner'],
+                  status: 'failed',
+                  failureMessages: ['Generic Jest error that should NOT overwrite crash error']
+                }
+              ]
             }
           ]
         })
       )
     );
 
-    let taskEndProcessCallback: ((e: vscode.TaskProcessEndEvent) => void) | undefined;
-    vscodeMock.tasks.onDidEndTaskProcess = jest.fn((cb: (e: vscode.TaskProcessEndEvent) => void) => {
-      taskEndProcessCallback = cb;
-      return { dispose: jest.fn() };
-    });
+    vscodeMock.tasks.onDidEndTaskProcess = jest.fn(() => ({ dispose: jest.fn() }));
 
     const capturedStackTrace =
       'ReferenceError: foo is not defined\n    at Object.<anonymous> (/project/force-app/lwc/foo/__tests__/foo.test.js:20:5)';
@@ -1234,10 +1284,7 @@ describe('LwcTestController public run API', () => {
         },
         execute: jest.fn().mockImplementation(function (this: any) {
           this.taskExecution = mockTaskExecution;
-          setImmediate(() => {
-            taskEndProcessCallback?.({ execution: mockTaskExecution, exitCode: 1 });
-            endCb?.();
-          });
+          setImmediate(() => endCb?.());
           return Promise.resolve();
         }),
         terminate: jest.fn(),
@@ -1249,29 +1296,36 @@ describe('LwcTestController public run API', () => {
       };
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const { getLwcTestController } = require('../../../../src/testSupport/testExplorer/lwcTestController');
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const ctrl = getLwcTestController();
-    await ctrl.refresh();
+    const timeoutSpy = jest.spyOn(globalThis, 'setTimeout').mockImplementation((callback: TimerHandler) => {
+      if (typeof callback === 'function') {
+        callback();
+      }
+      return undefined as unknown as ReturnType<typeof setTimeout>;
+    });
 
-    // Run a file-level test that crashes
-    await ctrl.runByExecutionInfo({ kind: 'testFile' as const, testUri }, false);
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const { getLwcTestController } = require('../../../../src/testSupport/testExplorer/lwcTestController');
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const ctrl = getLwcTestController();
+      await ctrl.refresh();
 
-    // The file should have been marked as errored with the crash error
-    expect(mockRun.errored).toHaveBeenCalled();
+      await ctrl.runByExecutionInfo(
+        { kind: 'testCase' as const, testUri, testName, ancestorTitles: ['outer', 'inner'] },
+        false
+      );
 
-    // Verify that the crash error message is preserved (contains "ReferenceError")
-    // and NOT overwritten by the generic Jest message from the results file
-    const erroredCalls = (mockRun.errored as jest.Mock).mock.calls;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    const fileErroredCall = erroredCalls.find((call: any[]) => call[1]?.message?.includes('ReferenceError'));
-
-    expect(fileErroredCall).toBeDefined();
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(fileErroredCall[1].message).toContain('ReferenceError: foo is not defined');
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(fileErroredCall[1].message).not.toContain('Generic Jest error');
+      expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 250);
+      const caseItem = expect.objectContaining({ id: expect.stringContaining(`::outer > inner > ${testName}`) });
+      expect(mockRun.errored).toHaveBeenCalledWith(
+        caseItem,
+        expect.objectContaining({ message: expect.stringContaining('ReferenceError: foo is not defined') })
+      );
+      expect(mockRun.failed).not.toHaveBeenCalledWith(caseItem, expect.anything());
+      expect(mockRun.passed).not.toHaveBeenCalledWith(caseItem);
+    } finally {
+      timeoutSpy.mockRestore();
+    }
   });
 
   it('runByExecutionInfo reveals Test Results panel when starting a run', async () => {

--- a/packages/salesforcedx-vscode-lwc/test/jest/testSupport/testRunner/jestPseudoterminal.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/jest/testSupport/testRunner/jestPseudoterminal.test.ts
@@ -369,5 +369,23 @@ Error: Module not found
       const pty = new JestPseudoterminal('npm', ['test'], { cwd: '/test' });
       expect(pty.getCapturedOutput()).toBe('');
     });
+
+    it('bounds multibyte output while preserving error context at both ends', () => {
+      const pty = new JestPseudoterminal('npm', ['test'], { cwd: '/test' });
+      pty.open();
+
+      const earlyError = 'SyntaxError: early failure\n    at /project/early.test.js:2:3\n';
+      const lateError = 'ReferenceError: late failure\n    at /project/late.test.js:4:5\n';
+      mockStdout.emit('data', Buffer.from(earlyError + '界'.repeat(80_000)));
+      mockStdout.emit('data', Buffer.from(lateError));
+
+      const captured = pty.getCapturedOutput();
+      expect(Buffer.byteLength(captured, 'utf8')).toBeLessThanOrEqual(100 * 1024);
+      expect(captured).toContain(earlyError);
+      expect(captured).toContain('... Jest output truncated ...');
+      expect(captured).toContain(lateError);
+      expect(captured).not.toContain('\uFFFD');
+      expect(pty.extractErrorSummary()).toContain('SyntaxError: early failure');
+    });
   });
 });

--- a/packages/salesforcedx-vscode-lwc/test/jest/testSupport/types/constants.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/jest/testSupport/types/constants.test.ts
@@ -32,6 +32,12 @@ describe('matchJestStackTraceLocation', () => {
     expect(location).toEqual({ file: '/path/Program Files (x86)/file.js', line: 10, column: 5 });
   });
 
+  it('extracts a Windows drive-letter path containing literal parentheses', () => {
+    const location = matchJestStackTraceLocation('at new Foo (C:\\Program Files (x86)\\project\\foo.test.js:10:5)');
+
+    expect(location).toEqual({ file: 'C:\\Program Files (x86)\\project\\foo.test.js', line: 10, column: 5 });
+  });
+
   it('picks the first stack frame out of a multi-line message', () => {
     const location = matchJestStackTraceLocation(
       'TypeError: Cannot read properties of undefined\n' +


### PR DESCRIPTION
## Summary

- give every test item started by an implicit run-all a terminal crash state, while allowing partial Jest results to replace provisional states
- keep both the beginning and end of oversized pseudoterminal output within the exact 100 KB UTF-8 byte limit
- replace the file-level "descendant" regression with a real case-level crash test that covers the missing process-end event, `exitCode === undefined`, and a partial results file
- strengthen overwrite assertions and add Windows drive-letter and multibyte output coverage

## Why

This is a follow-up suggestion for #7940. The remaining gaps came from three places: run-all execution has no single `sourceItem`, tail-only output retention can discard an early error header, and the existing descendant test did not establish a case-to-file parent relationship or execute a case-level run.

The changes ensure crashed run-all items do not finish without a terminal state, preserve useful error context at both ends of verbose output, and verify that a case-level crash message survives later partial Jest results.

## Validation

- `npm test --workspace packages/salesforcedx-vscode-lwc` — 84 tests passed
- `npm run compile --workspace packages/salesforcedx-vscode-lwc`
- `npm run lint --workspace packages/salesforcedx-vscode-lwc` — 0 errors; existing warnings remain
- repository pre-commit workflow — 82 scripts passed
- repository pre-push workflow — 80 scripts passed
